### PR TITLE
[orchestration] retract last applied field as well

### DIFF
--- a/pkg/orchestrator/pod.go
+++ b/pkg/orchestrator/pod.go
@@ -42,6 +42,8 @@ func ProcessPodList(podList []*v1.Pod, groupID int32, hostName string, clusterID
 	podMsgs := make([]*model.Pod, 0, len(podList))
 
 	for _, p := range podList {
+		redact.RemoveLastAppliedConfigurationAnnotation(p.Annotations)
+
 		// extract pod info
 		podModel := extractPodMessage(p)
 

--- a/pkg/orchestrator/redact/data_scrubber.go
+++ b/pkg/orchestrator/redact/data_scrubber.go
@@ -80,7 +80,7 @@ func (ds *DataScrubber) ScrubSimpleCommand(cmdline []string) ([]string, bool) {
 
 	// preprocess, without the preprocessing we would need to strip until whitespaces.
 	// the first index can be skipped because it should be the program name.
-	for index := 1; index < len(newCmdline); index++ {
+	for index := 0; index < len(newCmdline); index++ {
 		cmd := newCmdline[index]
 		for _, pattern := range ds.LiteralSensitivePatterns {
 			// if we found a word from the list,

--- a/pkg/orchestrator/redact/data_scrubber.go
+++ b/pkg/orchestrator/redact/data_scrubber.go
@@ -80,7 +80,7 @@ func (ds *DataScrubber) ScrubSimpleCommand(cmdline []string) ([]string, bool) {
 
 	// preprocess, without the preprocessing we would need to strip until whitespaces.
 	// the first index can be skipped because it should be the program name.
-	for index := 0; index < len(newCmdline); index++ {
+	for index := 1; index < len(newCmdline); index++ {
 		cmd := newCmdline[index]
 		for _, pattern := range ds.LiteralSensitivePatterns {
 			// if we found a word from the list,

--- a/pkg/orchestrator/redact/pod.go
+++ b/pkg/orchestrator/redact/pod.go
@@ -15,6 +15,7 @@ import (
 
 const (
 	redactedValue = "********"
+	replacedValue = "-"
 )
 
 // ScrubContainer scrubs sensitive information in the command line & env vars
@@ -59,6 +60,6 @@ func ScrubContainer(c *v1.Container, scrubber *DataScrubber) {
 func RemoveLastAppliedConfigurationAnnotation(annotations map[string]string) {
 	a := annotations["kubectl.kubernetes.io/last-applied-configuration"]
 	if a != "" {
-		annotations["kubectl.kubernetes.io/last-applied-configuration"] = redactedValue
+		annotations["kubectl.kubernetes.io/last-applied-configuration"] = replacedValue
 	}
 }

--- a/pkg/orchestrator/redact/pod.go
+++ b/pkg/orchestrator/redact/pod.go
@@ -58,8 +58,7 @@ func ScrubContainer(c *v1.Container, scrubber *DataScrubber) {
 
 // RemoveLastAppliedConfigurationAnnotation redacts the whole "kubectl.kubernetes.io/last-applied-configuration" annotation. As it may contain duplicate information and secrets.
 func RemoveLastAppliedConfigurationAnnotation(annotations map[string]string) {
-	a := annotations["kubectl.kubernetes.io/last-applied-configuration"]
-	if a != "" {
+	if _, found := annotations["kubectl.kubernetes.io/last-applied-configuration"]; found {
 		annotations["kubectl.kubernetes.io/last-applied-configuration"] = replacedValue
 	}
 }

--- a/pkg/orchestrator/redact/pod.go
+++ b/pkg/orchestrator/redact/pod.go
@@ -6,10 +6,10 @@
 package redact
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -55,15 +55,10 @@ func ScrubContainer(c *v1.Container, scrubber *DataScrubber) {
 	}
 }
 
-// TODO: we need to access the env for this
-// Alternative idea: unmarshal to pod spec
-// lets try the log scrubber
-func ScrubAnnotations(o *metav1.ObjectMeta, scrubber *DataScrubber) {
-	annotations := o.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
-	msgScrubbed, err := log.CredentialsCleanerBytes([]byte(annotations))
-	if err == nil {
-		log.Errorf("%v", string(msgScrubbed))
-	} else {
-		log.Errorf("failure: %v", err)
+// RemoveLastAppliedConfigurationAnnotation redacts the whole "kubectl.kubernetes.io/last-applied-configuration" annotation. As it may contain duplicate information and secrets.
+func RemoveLastAppliedConfigurationAnnotation(annotations map[string]string) {
+	a := annotations["kubectl.kubernetes.io/last-applied-configuration"]
+	if a != "" {
+		annotations["kubectl.kubernetes.io/last-applied-configuration"] = redactedValue
 	}
 }

--- a/pkg/orchestrator/redact/pod.go
+++ b/pkg/orchestrator/redact/pod.go
@@ -6,6 +6,7 @@
 package redact
 
 import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -51,5 +52,18 @@ func ScrubContainer(c *v1.Container, scrubber *DataScrubber) {
 	}
 	if len(c.Args) > 0 {
 		c.Args = scrubbedMergedCommand[words:]
+	}
+}
+
+// TODO: we need to access the env for this
+// Alternative idea: unmarshal to pod spec
+// lets try the log scrubber
+func ScrubAnnotations(o *metav1.ObjectMeta, scrubber *DataScrubber) {
+	annotations := o.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
+	msgScrubbed, err := log.CredentialsCleanerBytes([]byte(annotations))
+	if err == nil {
+		log.Errorf("%v", string(msgScrubbed))
+	} else {
+		log.Errorf("failure: %v", err)
 	}
 }

--- a/pkg/orchestrator/redact/pod_test.go
+++ b/pkg/orchestrator/redact/pod_test.go
@@ -77,7 +77,7 @@ func TestScrubAnnotations(t *testing.T) {
 	}}
 	RemoveLastAppliedConfigurationAnnotation(objectMeta.Annotations)
 	actual := objectMeta.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
-	expected := redactedValue
+	expected := replacedValue
 	assert.Equal(t, expected, actual)
 }
 

--- a/pkg/orchestrator/redact/pod_test.go
+++ b/pkg/orchestrator/redact/pod_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func TestScrubAnnotations(t *testing.T) {
-	scrubber := NewDefaultDataScrubber()
-	old := `{
+	lastAppliedConfiguration := `{
   "apiVersion": "apps/v1",
   "kind": "ReplicaSet",
   "metadata": {
@@ -74,12 +73,12 @@ func TestScrubAnnotations(t *testing.T) {
   }
 }`
 	objectMeta := metav1.ObjectMeta{Annotations: map[string]string{
-		"kubectl.kubernetes.io/last-applied-configuration": old,
+		"kubectl.kubernetes.io/last-applied-configuration": lastAppliedConfiguration,
 	}}
-	//// TODO: best if we could only parse the spec container part (PodTemplateSpec) (by parsing object.spec.spec)
-	//var a apps.ReplicaSet // if replica
-	//json.Unmarshal([]byte(old), &a)
-	ScrubAnnotations(&objectMeta, scrubber)
+	RemoveLastAppliedConfigurationAnnotation(objectMeta.Annotations)
+	actual := objectMeta.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
+	expected := redactedValue
+	assert.Equal(t, expected, actual)
 }
 
 func TestScrubContainer(t *testing.T) {
@@ -92,11 +91,6 @@ func TestScrubContainer(t *testing.T) {
 		})
 	}
 }
-
-// TODO: add a test for this
-//   annotations:
-//    kubectl.kubernetes.io/last-applied-configuration: |
-//      {"apiVersion":"apps/v1","kind":"ReplicaSet","metadata":{"annotations":{},"name":"gitlab-password-all","namespace":"datadog-agent"},"spec":{"replicas":1,"selector":{"matchLabels":{"tier":"frontend"}},"template":{"metadata":{"labels":{"tier":"frontend"}},"spec":{"containers":[{"env":[{"name":"GITLAB_TOKEN","value":"test"},{"name":"TOKEN","value":"test"},{"name":"password","value":"test"},{"name":"secret","value":"test"},{"name":"pwd","value":"test"},{"name":"consul","value":"test"}],"image":"gcr.io/google_samples/gb-frontend:v3","name":"php-redis"}]}}}}
 
 func getScrubCases() map[string]struct {
 	input    v1.Container

--- a/pkg/orchestrator/redact/pod_test.go
+++ b/pkg/orchestrator/redact/pod_test.go
@@ -79,6 +79,18 @@ func TestScrubAnnotations(t *testing.T) {
 	actual := objectMeta.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
 	expected := replacedValue
 	assert.Equal(t, expected, actual)
+
+}
+
+func TestScrubAnnotationsValueDoesNotExist(t *testing.T) {
+	objectMeta := metav1.ObjectMeta{Annotations: map[string]string{
+		"something/else": "some pseudo yaml",
+	}}
+
+	RemoveLastAppliedConfigurationAnnotation(objectMeta.Annotations)
+	actual := objectMeta.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
+	expected := ""
+	assert.Equal(t, expected, actual)
 }
 
 func TestScrubContainer(t *testing.T) {

--- a/pkg/orchestrator/redact/pod_test.go
+++ b/pkg/orchestrator/redact/pod_test.go
@@ -6,11 +6,11 @@
 package redact
 
 import (
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestScrubAnnotations(t *testing.T) {

--- a/pkg/orchestrator/redact/pod_test.go
+++ b/pkg/orchestrator/redact/pod_test.go
@@ -93,6 +93,17 @@ func TestScrubAnnotationsValueDoesNotExist(t *testing.T) {
 	assert.Equal(t, expected, actual)
 }
 
+func TestScrubAnnotationsValueIsEmpty(t *testing.T) {
+	objectMeta := metav1.ObjectMeta{Annotations: map[string]string{
+		"kubectl.kubernetes.io/last-applied-configuration": "",
+	}}
+
+	RemoveLastAppliedConfigurationAnnotation(objectMeta.Annotations)
+	actual := objectMeta.Annotations["kubectl.kubernetes.io/last-applied-configuration"]
+	expected := replacedValue
+	assert.Equal(t, expected, actual)
+}
+
 func TestScrubContainer(t *testing.T) {
 	scrubber := NewDefaultDataScrubber()
 	tests := getScrubCases()

--- a/releasenotes/notes/remove-last-applied-ebd665efe472e1e7.yaml
+++ b/releasenotes/notes/remove-last-applied-ebd665efe472e1e7.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+security:
+  - |
+    Redact the whole annotation "kubectl.kubernetes.io/last-applied-configuration" to ensure we don't expose secrets.


### PR DESCRIPTION
### What does this PR do?

Redact the `last-applied-configuration` annotation for every resource we collect for orchestration

### Motivation

the `last-applied-configuration` can contain sensitive information. It is difficult to ensure that this field is scrubbed correctly in an easy and performant matter. 


### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Collect the data and make sure that the annotation is empty in the collected resource
