### PR TITLE
Add wrapper for fmemopen to target older GLIBC

### DIFF
--- a/.gitlab/deps_build.yml
+++ b/.gitlab/deps_build.yml
@@ -16,8 +16,8 @@
     - cd /tmp/bcc/build
     - cmake .. -DENABLE_EXAMPLES=OFF -DENABLE_TESTS=OFF -DENABLE_MAN=OFF -DCMAKE_INSTALL_PREFIX=/opt/libbcc -DCMAKE_EXE_LINKER_FLAGS="-Wl,-rpath,$DATADOG_AGENT_EMBEDDED_PATH/lib" -DCMAKE_SHARED_LINKER_FLAGS="-Wl,-rpath,$DATADOG_AGENT_EMBEDDED_PATH/lib"
     - make -j 4 # "$(nproc)"
-    # Check that libbcc has no references to glibc >= 2.23
-    - objdump -p src/cc/libbcc.so | egrep 'GLIBC_2\.(2[3-9]|[3-9][0-9])' && exit 1
+    # Check that libbcc has no references to glibc >= 2.18
+    - objdump -p src/cc/libbcc.so | egrep 'GLIBC_2\.(1[8-9]|[2-9][0-9])' && exit 1
     - make install
     - cd /opt/libbcc
     - chmod go-rwx lib/libbcc*

--- a/omnibus/config/software/libbcc_compat.patch
+++ b/omnibus/config/software/libbcc_compat.patch
@@ -64,7 +64,7 @@ index 931de2d9..1cd1212f 100644
  
  # Link against LLVM libraries
 -target_link_libraries(bcc-shared ${bcc_common_libs_for_s})
-+target_link_libraries(bcc-shared ${bcc_common_libs_for_s} -Wl,--wrap=exp -Wl,--wrap=log -Wl,--wrap=pow -Wl,--wrap=exp2 -Wl,--wrap=log2 -Wl,--wrap=log2f)
++target_link_libraries(bcc-shared ${bcc_common_libs_for_s} -Wl,--wrap=exp -Wl,--wrap=log -Wl,--wrap=pow -Wl,--wrap=exp2 -Wl,--wrap=log2 -Wl,--wrap=log2f -Wl,--wrap=fmemopen)
  target_link_libraries(bcc-static ${bcc_common_libs_for_a} bcc-loader-static)
  set(bcc-lua-static ${bcc-lua-static} ${bcc_common_libs_for_lua})
  
@@ -73,7 +73,7 @@ new file mode 100644
 index 0000000..c01fbe2
 --- /dev/null
 +++ b/src/cc/wrapper.c
-@@ -0,0 +1,41 @@
+@@ -0,0 +1,51 @@
 +#ifdef __x86_64__
 +#define GLIBC_VERS "GLIBC_2.2.5"
 +#elif defined(__aarch64__)
@@ -109,9 +109,19 @@ index 0000000..c01fbe2
 +  return __ ## func ## _prior_glibc(x);                         \
 +}
 +
++#define define_fmemopen_wrapper_for(func)                                      \
++FILE *__ ## func ## _prior_glibc(void *buf, size_t size, const char *mode);    \
++                                                                               \
++asm(".symver __" #func "_prior_glibc, " #func "@" GLIBC_VERS);                 \
++                                                                               \
++FILE *__wrap_## func ## (void *buf, size_t size, const char *mode) {           \
++ return __ ## func ## _prior_glibc(buf, size, mode);                           \
++}                                                                              \
++
 +define_wrapper1_for(exp)
 +define_wrapper1_for(log)
 +define_wrapper2_for(pow)
 +define_wrapper1_for(exp2)
 +define_wrapper1_for(log2)
 +define_wrapper3_for(log2f)
++define_fmemopen_wrapper_for(fmemopen)

--- a/omnibus/config/software/libbcc_compat.patch
+++ b/omnibus/config/software/libbcc_compat.patch
@@ -73,7 +73,7 @@ new file mode 100644
 index 0000000..c01fbe2
 --- /dev/null
 +++ b/src/cc/wrapper.c
-@@ -0,0 +1,53 @@
+@@ -0,0 +1,54 @@
 +#ifdef __x86_64__
 +#define GLIBC_VERS "GLIBC_2.2.5"
 +#elif defined(__aarch64__)
@@ -83,6 +83,7 @@ index 0000000..c01fbe2
 +#endif
 +
 +#include <stddef.h>
++#include <stdio.h>
 +
 +#define define_wrapper1_for(func)                               \
 +double __ ## func ## _prior_glibc(double x);                    \

--- a/omnibus/config/software/libbcc_compat.patch
+++ b/omnibus/config/software/libbcc_compat.patch
@@ -73,7 +73,7 @@ new file mode 100644
 index 0000000..c01fbe2
 --- /dev/null
 +++ b/src/cc/wrapper.c
-@@ -0,0 +1,51 @@
+@@ -0,0 +1,53 @@
 +#ifdef __x86_64__
 +#define GLIBC_VERS "GLIBC_2.2.5"
 +#elif defined(__aarch64__)
@@ -81,6 +81,8 @@ index 0000000..c01fbe2
 +#else
 +#error Unknown architecture
 +#endif
++
++#include <stddef.h>
 +
 +#define define_wrapper1_for(func)                               \
 +double __ ## func ## _prior_glibc(double x);                    \
@@ -114,7 +116,7 @@ index 0000000..c01fbe2
 +                                                                               \
 +asm(".symver __" #func "_prior_glibc, " #func "@" GLIBC_VERS);                 \
 +                                                                               \
-+FILE *__wrap_## func ## (void *buf, size_t size, const char *mode) {           \
++FILE *__wrap_## func (void *buf, size_t size, const char *mode) {           \
 + return __ ## func ## _prior_glibc(buf, size, mode);                           \
 +}                                                                              \
 +


### PR DESCRIPTION
### What does this PR do?

Wraps `fmemopen` in the same way we wrap other functions to target a older glibc version of the function. Changes grep pattern to ensure this doesn't happen again.

### Motivation

system-probe failing to load on older distros with glibc < 2.22:
```
/opt/datadog-agent/embedded/bin/system-probe: /lib64/libc.so.6: version `GLIBC_2.22' not found (required by /opt/datadog-agent/embedded/lib/libbcc.so.0)
```
