### PR TITLE
[DCA][Fix] Configure server-side timeouts

### DIFF
--- a/cmd/cluster-agent/api/server.go
+++ b/cmd/cluster-agent/api/server.go
@@ -19,6 +19,7 @@ import (
 	"net"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/gorilla/mux"
 
@@ -95,7 +96,10 @@ func StartServer() error {
 		ErrorLog: stdLog.New(&config.ErrorLogWriter{
 			AdditionalDepth: 4, // Use a stack depth of 4 on top of the default one to get a relevant filename in the stdlib
 		}, "Error from the agent http API server: ", 0), // log errors to seelog,
-		TLSConfig: &tlsConfig,
+		TLSConfig:    &tlsConfig,
+		ReadTimeout:  config.Datadog.GetDuration("cluster_agent.server.read_timeout_seconds") * time.Second,
+		WriteTimeout: config.Datadog.GetDuration("cluster_agent.server.write_timeout_seconds") * time.Second,
+		IdleTimeout:  config.Datadog.GetDuration("cluster_agent.server.idle_timeout_seconds") * time.Second,
 	}
 
 	tlsListener := tls.NewListener(listener, &tlsConfig)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -506,6 +506,9 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("cluster_agent.url", "")
 	config.BindEnvAndSetDefault("cluster_agent.kubernetes_service_name", "datadog-cluster-agent")
 	config.BindEnvAndSetDefault("cluster_agent.tagging_fallback", false)
+	config.BindEnvAndSetDefault("cluster_agent.server.read_timeout_seconds", 2)
+	config.BindEnvAndSetDefault("cluster_agent.server.write_timeout_seconds", 2)
+	config.BindEnvAndSetDefault("cluster_agent.server.idle_timeout_seconds", 60)
 	config.BindEnvAndSetDefault("metrics_port", "5000")
 
 	// Metadata endpoints

--- a/releasenotes-dca/notes/dca-server-to-f7c62e1f71c1b3e7.yaml
+++ b/releasenotes-dca/notes/dca-server-to-f7c62e1f71c1b3e7.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a potential file descriptors leak.


### PR DESCRIPTION
### What does this PR do?

Define timeout values in the DCA's http server configuration.

### Motivation

- Make sure the DCA closes its connections.
- It's a best practice to set the timeout on both server and client side.

### Describe your test plan

Running `lsof -p 1 -a -d 0-256` inside the DCA container multiple times should show how the file descriptors related to the node agent connections are being cleaned and recreated.
