### PR TITLE
[corechecks/snmp] Fix ip_address validation

### DIFF
--- a/pkg/collector/corechecks/snmp/config.go
+++ b/pkg/collector/corechecks/snmp/config.go
@@ -149,6 +149,10 @@ func buildConfig(rawInstance integration.Data, rawInitConfig integration.Data) (
 		c.extraTags = strings.Split(instance.ExtraTags, ",")
 	}
 
+	if c.ipAddress == "" {
+		return snmpConfig{}, fmt.Errorf("ip_address config must be provided")
+	}
+
 	if c.port == 0 {
 		c.port = defaultPort
 	}

--- a/pkg/collector/corechecks/snmp/config_test.go
+++ b/pkg/collector/corechecks/snmp/config_test.go
@@ -230,6 +230,18 @@ community_string: abc
 	assert.Equal(t, mockProfilesDefinitions()["f5-big-ip"].Metrics, check.config.profiles["f5-big-ip"].Metrics)
 }
 
+func TestIPAddressConfiguration(t *testing.T) {
+	setConfdPathAndCleanProfiles()
+	// TEST Default port
+	check := Check{session: &snmpSession{}}
+	// language=yaml
+	rawInstanceConfig := []byte(`
+ip_address:
+`)
+	err := check.Configure(rawInstanceConfig, []byte(``), "test")
+	assert.EqualError(t, err, "build config failed: ip_address config must be provided")
+}
+
 func TestPortConfiguration(t *testing.T) {
 	setConfdPathAndCleanProfiles()
 	// TEST Default port


### PR DESCRIPTION
### What does this PR do?

Fix ip_address validation

### Motivation

- `ip_address` should be mandatory
- if `ip_address`, metrics won't have `ip_address` tag

Unlike Python SNMP integration, in core we don’t check if ip_address is empty.

Currently if `ip_address` is not set, its value will be an empty string, it will lead `gosnmp` (library used) to request `localhost` and report metrics with `ip_address:` tags (empty ip_address).

### Additional Notes

### Describe your test plan

Check that missing `ip_address` is a invalid config.