### PR TITLE
[networks] Fix HTTP stats lookup during encoding

### DIFF
--- a/pkg/network/encoding/encoding.go
+++ b/pkg/network/encoding/encoding.go
@@ -5,7 +5,6 @@ import (
 
 	model "github.com/DataDog/agent-payload/process"
 	"github.com/DataDog/datadog-agent/pkg/network"
-	"github.com/DataDog/datadog-agent/pkg/network/http"
 	"github.com/gogo/protobuf/jsonpb"
 )
 
@@ -54,7 +53,7 @@ func modelConnections(conns *network.Connections) *model.Connections {
 	httpIndex := FormatHTTPStats(conns.HTTP)
 
 	for i, conn := range conns.Conns {
-		httpKey := http.NewKey(conn.Source, conn.Dest, conn.SPort, conn.DPort, "")
+		httpKey := httpKeyFromConn(conn)
 		agentConns[i] = FormatConnection(conn, domainSet, routeIndex, httpIndex[httpKey])
 		delete(httpIndex, httpKey)
 	}

--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -39,7 +39,7 @@ func TestSerialization(t *testing.T) {
 					ReplSrcIP:   util.AddressFromString("20.1.1.1"),
 					ReplDstIP:   util.AddressFromString("20.1.1.1"),
 					ReplSrcPort: 40,
-					ReplDstPort: 70,
+					ReplDstPort: 80,
 				},
 
 				Type:      network.UDP,
@@ -67,10 +67,10 @@ func TestSerialization(t *testing.T) {
 		},
 		HTTP: map[http.Key]http.RequestStats{
 			http.NewKey(
-				util.AddressFromString("10.1.1.1"),
-				util.AddressFromString("10.2.2.2"),
-				1000,
-				9000,
+				util.AddressFromString("20.1.1.1"),
+				util.AddressFromString("20.1.1.1"),
+				40,
+				80,
 				"/testpath",
 			): httpReqStats,
 		},
@@ -124,7 +124,7 @@ func TestSerialization(t *testing.T) {
 					ReplSrcIP:   "20.1.1.1",
 					ReplDstIP:   "20.1.1.1",
 					ReplSrcPort: int32(40),
-					ReplDstPort: int32(70),
+					ReplDstPort: int32(80),
 				},
 
 				Type:      model.ConnectionType_udp,

--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -177,6 +177,7 @@ func FormatHTTPStats(httpData map[http.Key]http.RequestStats) map[http.Key]model
 	return aggregationsByKey
 }
 
+// Build the key for the http map based on whether the local or remote side is http.
 func httpKeyFromConn(c network.ConnectionStats) http.Key {
 	// Retrieve translated addresses
 	laddr, lport := nat.GetLocalAddress(c)

--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -7,6 +7,7 @@ import (
 	model "github.com/DataDog/agent-payload/process"
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/http"
+	"github.com/DataDog/datadog-agent/pkg/network/nat"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/gogo/protobuf/proto"
 )
@@ -174,6 +175,23 @@ func FormatHTTPStats(httpData map[http.Key]http.RequestStats) map[http.Key]model
 	}
 
 	return aggregationsByKey
+}
+
+func httpKeyFromConn(c network.ConnectionStats) http.Key {
+	// Retrieve translated addresses
+	laddr, lport := nat.GetLocalAddress(c)
+	raddr, rport := nat.GetRemoteAddress(c)
+
+	if http.IsHTTP(int(rport)) {
+		return http.NewKey(laddr, raddr, lport, rport, "")
+	}
+
+	if http.IsHTTP(int(lport)) {
+		// Since HTTP data is always indexed as (client, server), we flip the lookup key
+		return http.NewKey(raddr, laddr, rport, lport, "")
+	}
+
+	return http.Key{}
 }
 
 func returnToPool(c *model.Connections) {

--- a/pkg/network/http/http_stats.go
+++ b/pkg/network/http/http_stats.go
@@ -34,6 +34,11 @@ func NewKey(saddr, daddr util.Address, sport, dport uint16, path string) Key {
 	}
 }
 
+// IsHTTP determines whether the port number corresponds to a HTTP port
+func IsHTTP(port int) bool {
+	return port == 80 || port == 8080
+}
+
 // RelativeAccuracy defines the acceptable error in quantile values calculated by DDSketch.
 // For example, if the actual value at p50 is 100, with a relative accuracy of 0.01 the value calculated
 // will be between 99 and 101

--- a/pkg/network/nat/nat.go
+++ b/pkg/network/nat/nat.go
@@ -1,0 +1,32 @@
+package nat
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+)
+
+// GetLocalAddress returns the translated (local ip, local port) pair
+func GetLocalAddress(c network.ConnectionStats) (util.Address, uint16) {
+	localIP := c.Source
+	localPort := c.SPort
+
+	if c.IPTranslation != nil && c.IPTranslation.ReplDstIP != nil {
+		// Fields are flipped
+		localIP = c.IPTranslation.ReplDstIP
+		localPort = c.IPTranslation.ReplDstPort
+	}
+	return localIP, localPort
+}
+
+// GetRemoteAddress returns the translated (remote ip, remote port) pair
+func GetRemoteAddress(c network.ConnectionStats) (util.Address, uint16) {
+	remoteIP := c.Dest
+	remotePort := c.DPort
+
+	if c.IPTranslation != nil && c.IPTranslation.ReplSrcIP != nil {
+		// Fields are flipped
+		remoteIP = c.IPTranslation.ReplSrcIP
+		remotePort = c.IPTranslation.ReplSrcPort
+	}
+	return remoteIP, remotePort
+}


### PR DESCRIPTION
### What does this PR do?

Fix HTTP stats lookup during serialization. Two issues were causing HTTP stats to be dropped:
* NAT translations were not being accounted for;
* Server-side lookups were being done using the wrong (inverted) keys;

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
