### PR TITLE
Support and add deprecation warning for old system-probe flags

### DIFF
--- a/cmd/system-probe/main.go
+++ b/cmd/system-probe/main.go
@@ -10,6 +10,7 @@ import (
 
 func main() {
 	setDefaultCommandIfNonePresent()
+	checkForDeprecatedFlags()
 	if err := app.SysprobeCmd.Execute(); err != nil {
 		os.Exit(1)
 	}

--- a/cmd/system-probe/main_common.go
+++ b/cmd/system-probe/main_common.go
@@ -3,7 +3,9 @@
 package main
 
 import (
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/app"
 )
@@ -31,4 +33,16 @@ func setDefaultCommandIfNonePresent() {
 		args = append(args, os.Args[1:]...)
 	}
 	os.Args = args
+}
+
+func checkForDeprecatedFlags() {
+	for i, a := range os.Args {
+		if strings.HasPrefix(a, "-config") {
+			fmt.Println("WARNING: `-config` argument is deprecated and will be removed in a future version. Please use `--config` instead.")
+			os.Args[i] = "-" + os.Args[i]
+		} else if strings.HasPrefix(a, "-pid") {
+			fmt.Println("WARNING: `-pid` argument is deprecated and will be removed in a future version. Please use `--pid` instead.")
+			os.Args[i] = "-" + os.Args[i]
+		}
+	}
 }

--- a/cmd/system-probe/main_windows.go
+++ b/cmd/system-probe/main_windows.go
@@ -40,6 +40,7 @@ func main() {
 	}
 
 	setDefaultCommandIfNonePresent()
+	checkForDeprecatedFlags()
 	if err := app.SysprobeCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/releasenotes/notes/system-probe-flags-deprecated-0f3baa3e8de565b1.yaml
+++ b/releasenotes/notes/system-probe-flags-deprecated-0f3baa3e8de565b1.yaml
@@ -1,0 +1,4 @@
+---
+deprecations:
+  - |
+    The single dash variants of the system-probe flags are now deprecated. Please use ``--config`` and ``--pid`` instead.


### PR DESCRIPTION
### What does this PR do?

Allows users to still use `-config` and `-pid` flags for system-probe, while displaying a deprecation warning.

### Motivation

The change from `flag` to `cobra` in 7.28 for parsing flags inadvertently caused the single dash flags to stop working.

### Describe your test plan

Run system-probe with `-config` and/or `-pid`. You should receive a warning, but everything continues to function properly.
