### PR TITLE
Use DNS record TTL and whether a record is in-use to determine expiration

### DIFF
--- a/pkg/network/dns_cache.go
+++ b/pkg/network/dns_cache.go
@@ -222,6 +222,7 @@ func (v *dnsCacheVal) merge(name string, deadline time.Time, maxSize int) (rejec
 	if exp, ok := v.names[name]; ok {
 		if deadline.After(exp) {
 			v.names[name] = deadline
+			v.inUse = true
 		}
 		return false
 	}
@@ -230,6 +231,7 @@ func (v *dnsCacheVal) merge(name string, deadline time.Time, maxSize int) (rejec
 	}
 
 	v.names[name] = deadline
+	v.inUse = true
 	return false
 }
 

--- a/pkg/network/dns_cache.go
+++ b/pkg/network/dns_cache.go
@@ -215,7 +215,10 @@ type dnsCacheVal struct {
 }
 
 func (v *dnsCacheVal) merge(name string, deadline time.Time, maxSize int) (rejected bool) {
-	if _, ok := v.names[name]; ok {
+	if exp, ok := v.names[name]; ok {
+		if deadline.After(exp) {
+			v.names[name] = deadline
+		}
 		return false
 	}
 	if len(v.names) == maxSize {

--- a/pkg/network/dns_cache.go
+++ b/pkg/network/dns_cache.go
@@ -211,6 +211,10 @@ func (c *reverseDNSCache) getNamesForIP(ip util.Address) []string {
 
 type dnsCacheVal struct {
 	names map[string]time.Time
+	// inUse keeps track of whether this dns cache record is currently in use by a connection.
+	// This flag is reset to false every time reverseDnsCache.Get is called.
+	// This flag is only set to true if reverseDNSCache.getNamesForIP returns this struct.
+	// If inUse is set, then this record will not be expired out.
 	inUse bool
 }
 

--- a/pkg/network/dns_snooper_test.go
+++ b/pkg/network/dns_snooper_test.go
@@ -109,19 +109,9 @@ func checkSnooping(t *testing.T, destIP string, reverseDNS *SocketFilterSnooper)
 	destAddr := util.AddressFromString(destIP)
 	srcAddr := util.AddressFromString("127.0.0.1")
 
-	timeout := time.After(1 * time.Second)
-Loop:
-	// Wait until DNS entry becomes available (with a timeout)
-	for {
-		select {
-		case <-timeout:
-			break Loop
-		default:
-			if reverseDNS.cache.Len() >= 1 {
-				break Loop
-			}
-		}
-	}
+	require.Eventually(t, func() bool {
+		return reverseDNS.cache.Len() >= 1
+	}, 1*time.Second, 10*time.Millisecond)
 
 	// Verify that the IP from the connections above maps to the right name
 	payload := []ConnectionStats{{Source: srcAddr, Dest: destAddr}}

--- a/pkg/network/dns_snooper_test.go
+++ b/pkg/network/dns_snooper_test.go
@@ -127,10 +127,6 @@ func checkSnooping(t *testing.T, destIP string, reverseDNS *SocketFilterSnooper)
 }
 
 func TestDNSOverUDPSnooping(t *testing.T) {
-	//
-	// skipping for now as test seems to be flaky.  Should be reinserted when cause
-	// is discovered
-	t.Skip()
 	m, reverseDNS := initDNSTestsWithDomainCollection(t, false)
 	defer m.Stop(manager.CleanAll)
 	defer reverseDNS.Close()

--- a/pkg/network/dns_snooper_test.go
+++ b/pkg/network/dns_snooper_test.go
@@ -131,25 +131,23 @@ func TestDNSOverUDPSnooping(t *testing.T) {
 	// skipping for now as test seems to be flaky.  Should be reinserted when cause
 	// is discovered
 	t.Skip()
-	cfg := testConfig()
-	buf, err := netebpf.ReadBPFModule(cfg.BPFDir, false)
-	require.NoError(t, err)
-	defer buf.Close()
-
-	m, reverseDNS := getSnooper(t, buf, false, false, 15*time.Second, false)
+	m, reverseDNS := initDNSTestsWithDomainCollection(t, false)
 	defer m.Stop(manager.CleanAll)
 	defer reverseDNS.Close()
 
 	// Connect to golang.org. This will result in a DNS lookup which will be captured by SocketFilterSnooper
-	conn, err := net.DialTimeout("tcp", "golang.org:80", 1*time.Second)
-	require.NoError(t, err)
+	_, _, reps := sendDNSQueries(t, []string{"golang.org"}, validDNSServerIP, UDP)
+	rep := reps[0]
+	require.NotNil(t, rep)
+	require.Equal(t, rep.Rcode, mdns.RcodeSuccess)
 
-	// Get destination IP to compare against snooped DNS
-	destIP, _, err := net.SplitHostPort(conn.RemoteAddr().String())
-	conn.Close()
-	require.NoError(t, err)
-
-	checkSnooping(t, destIP, reverseDNS)
+	for _, r := range rep.Answer {
+		aRecord, ok := r.(*mdns.A)
+		require.True(t, ok)
+		require.True(t, mdns.NumField(aRecord) >= 1)
+		destIP := mdns.Field(aRecord, 1)
+		checkSnooping(t, destIP, reverseDNS)
+	}
 }
 
 func TestDNSOverTCPSnooping(t *testing.T) {

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -140,7 +140,7 @@ func (ns *networkState) getClients() []string {
 	return clients
 }
 
-// Connections returns the connections for the given client
+// GetDelta returns the connections for the given client
 // If the client is not registered yet, we register it and return the connections we have in the global state
 // Otherwise we return both the connections with last stats and the closed connections for this client
 func (ns *networkState) GetDelta(


### PR DESCRIPTION
### What does this PR do?

The reverse DNS cache inside system-probe was previously caching for 3 minutes, and extending that duration every time a record was used. This uses the actual TTL from the record and keeps track of values in-use.

### Motivation

More accurate DNS caching behavior.

### Additional Notes

This does not handle the following case:
1. DNS is resolved for `myhost` to `1.1.1.1` with a TTL of 30s
1. A connection is opened to `1.1.1.1` and kept open
1. \>30s elapses
1. Another connection is opened to `1.1.1.1`

The connection from step 4 will use the same domain mapping from step 1, even though the record has expired, and the new connection did not resolve any DNS.

To fix this scenario would require more sophisticated tracking of connections to DNS records. 

Multiple clients also disrupt the record expiration by potentially causing an early expiration before the other client has had a chance to use the value. Fixing this would require per-client tracking with some sort of inactivity limit to prevent a single client request (often from debugging) from keeping records around forever.