### PR TITLE
Increase the spot price for the e2e tests EC2 instance

### DIFF
--- a/test/e2e/scripts/setup-instance/02-ec2.sh
+++ b/test/e2e/scripts/setup-instance/02-ec2.sh
@@ -18,7 +18,7 @@ COMMIT_USER=$(git log -1 --pretty=format:'%ae' | tr -d '[:space:]')
 REGION="${REGION:-us-east-1}"
 
 SPOT_REQUEST_ID=$(aws ec2 request-spot-instances \
-                      --spot-price "0.070" \
+                      --spot-price "0.150" \
                       --instance-count 1 \
                       --type "one-time" \
                       --valid-until $(($(date +%s) + 3300)) \


### PR DESCRIPTION
### What does this PR do?

Increase the offered spot price for the e2e tests EC2 instance.

### Motivation

The e2e tests GitLab job are timing out after 2 hours because it cannot get a spot instance.

### Additional Notes


### Describe your test plan

Check that the e2e pupernetes test job are running fine.
