### PR TITLE
logs/sender: fix batch strategy flush timer

### DIFF
--- a/pkg/logs/sender/batch_strategy.go
+++ b/pkg/logs/sender/batch_strategy.go
@@ -84,7 +84,7 @@ func (s *batchStrategy) syncFlush(inputChan chan *message.Message, outputChan ch
 
 // Send accumulates messages to a buffer and sends them when the buffer is full or outdated.
 func (s *batchStrategy) Send(inputChan chan *message.Message, outputChan chan *message.Message, send func([]byte) error) {
-	flushTimer := time.NewTimer(s.batchWait)
+	flushTimer := time.NewTicker(s.batchWait)
 	defer func() {
 		s.flushBuffer(outputChan, send)
 		flushTimer.Stop()

--- a/pkg/logs/sender/batch_strategy.go
+++ b/pkg/logs/sender/batch_strategy.go
@@ -84,10 +84,10 @@ func (s *batchStrategy) syncFlush(inputChan chan *message.Message, outputChan ch
 
 // Send accumulates messages to a buffer and sends them when the buffer is full or outdated.
 func (s *batchStrategy) Send(inputChan chan *message.Message, outputChan chan *message.Message, send func([]byte) error) {
-	flushTimer := time.NewTicker(s.batchWait)
+	flushTicker := time.NewTicker(s.batchWait)
 	defer func() {
 		s.flushBuffer(outputChan, send)
-		flushTimer.Stop()
+		flushTicker.Stop()
 		s.pendingSends.Wait()
 	}()
 	for {
@@ -98,7 +98,7 @@ func (s *batchStrategy) Send(inputChan chan *message.Message, outputChan chan *m
 				return
 			}
 			s.processMessage(m, outputChan, send)
-		case <-flushTimer.C:
+		case <-flushTicker.C:
 			// the first message that was added to the buffer has been here for too long, send the payload now
 			s.flushBuffer(outputChan, send)
 		case <-s.syncFlushTrigger:


### PR DESCRIPTION
### What does this PR do?

Fix a regression that was added in https://github.com/DataDog/datadog-agent/pull/7828

The code was refactored with the intention of using a long-lived ticker instead of recreating a timer on each flush, but the timer was never changed to a ticker, meaning it would cause only one flush at the beginning and be silent thereafter.

### Motivation

Fix the timer. 

### Describe your test plan

Improved the unit test to test multiple flushes. 
