### PR TITLE
[process-agent] Fix default path for datadog.yaml file on macOS

### DIFF
--- a/cmd/process-agent/flags/flags.go
+++ b/cmd/process-agent/flags/flags.go
@@ -1,0 +1,10 @@
+// +build !windows,!darwin
+
+package flags
+
+const (
+	// DefaultConfPath points to the location of datadog.yaml
+	DefaultConfPath = "/etc/datadog-agent/datadog.yaml"
+	// DefaultSysProbeConfPath points to the location of system-probe.yaml
+	DefaultSysProbeConfPath = "/etc/datadog-agent/system-probe.yaml"
+)

--- a/cmd/process-agent/flags/flags_darwin.go
+++ b/cmd/process-agent/flags/flags_darwin.go
@@ -1,0 +1,10 @@
+// +build darwin
+
+package flags
+
+const (
+	// DefaultConfPath points to the location of datadog.yaml
+	DefaultConfPath = "/opt/datadog-agent/etc/datadog.yaml"
+	// system-probe is not yet supported on darwin
+	DefaultSysProbeConfPath = ""
+)

--- a/cmd/process-agent/flags/flags_darwin.go
+++ b/cmd/process-agent/flags/flags_darwin.go
@@ -5,6 +5,6 @@ package flags
 const (
 	// DefaultConfPath points to the location of datadog.yaml
 	DefaultConfPath = "/opt/datadog-agent/etc/datadog.yaml"
-	// system-probe is not yet supported on darwin
+	// DefaultSysProbeConfPath is set to empty since system-probe is not yet supported on darwin
 	DefaultSysProbeConfPath = ""
 )

--- a/cmd/process-agent/flags/flags_windows.go
+++ b/cmd/process-agent/flags/flags_windows.go
@@ -1,0 +1,14 @@
+// +build windows
+
+package flags
+
+const (
+	// DefaultConfPath points to the location of datadog.yaml
+	DefaultConfPath = "c:\\programdata\\datadog\\datadog.yaml"
+	// DefaultSysProbeConfPath points to the location of system-probe.yaml
+	DefaultSysProbeConfPath = "c:\\programdata\\datadog\\system-probe.yaml"
+	// DefaultConfdPath points to the location of conf.d
+	DefaultConfdPath = "c:\\programdata\\datadog\\conf.d"
+	// DefaultLogFilePath points to the location of process-agent.log
+	DefaultLogFilePath = "c:\\programdata\\datadog\\logs\\process-agent.log"
+)

--- a/cmd/process-agent/main.go
+++ b/cmd/process-agent/main.go
@@ -4,8 +4,9 @@ package main
 
 import (
 	"flag"
-	"github.com/DataDog/datadog-agent/cmd/process-agent/flags"
 	_ "net/http/pprof"
+
+	"github.com/DataDog/datadog-agent/cmd/process-agent/flags"
 )
 
 func main() {

--- a/cmd/process-agent/main.go
+++ b/cmd/process-agent/main.go
@@ -4,15 +4,19 @@ package main
 
 import (
 	"flag"
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/cmd/process-agent/flags"
 	_ "net/http/pprof"
 )
 
 func main() {
 	ignore := ""
-	flag.StringVar(&opts.configPath, "config", common.DefaultConfPath, "Path to datadog.yaml config")
+	flag.StringVar(&opts.configPath, "config", flags.DefaultConfPath, "Path to datadog.yaml config")
 	flag.StringVar(&ignore, "ddconfig", "", "[deprecated] Path to dd-agent config")
-	flag.StringVar(&opts.sysProbeConfigPath, "sysprobe-config", "/etc/datadog-agent/system-probe.yaml", "Path to system-probe.yaml config")
+
+	if flags.DefaultSysProbeConfPath != "" {
+		flag.StringVar(&opts.sysProbeConfigPath, "sysprobe-config", flags.DefaultSysProbeConfPath, "Path to system-probe.yaml config")
+	}
+
 	flag.StringVar(&opts.pidfilePath, "pid", "", "Path to set pidfile for process")
 	flag.BoolVar(&opts.info, "info", false, "Show info about running process agent and exit")
 	flag.BoolVar(&opts.version, "version", false, "Print the version and exit")

--- a/cmd/process-agent/main.go
+++ b/cmd/process-agent/main.go
@@ -4,12 +4,13 @@ package main
 
 import (
 	"flag"
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	_ "net/http/pprof"
 )
 
 func main() {
 	ignore := ""
-	flag.StringVar(&opts.configPath, "config", "/etc/datadog-agent/datadog.yaml", "Path to datadog.yaml config")
+	flag.StringVar(&opts.configPath, "config", common.DefaultConfPath, "Path to datadog.yaml config")
 	flag.StringVar(&ignore, "ddconfig", "", "[deprecated] Path to dd-agent config")
 	flag.StringVar(&opts.sysProbeConfigPath, "sysprobe-config", "/etc/datadog-agent/system-probe.yaml", "Path to system-probe.yaml config")
 	flag.StringVar(&opts.pidfilePath, "pid", "", "Path to set pidfile for process")

--- a/cmd/process-agent/main_windows.go
+++ b/cmd/process-agent/main_windows.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/DataDog/datadog-agent/cmd/process-agent/flags"
 	_ "github.com/DataDog/datadog-agent/pkg/util/containers/providers/windows"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 
@@ -25,10 +26,10 @@ var elog debug.Log
 const ServiceName = "datadog-process-agent"
 
 // opts are the command-line options
-var defaultConfigPath = "c:\\programdata\\datadog\\datadog.yaml"
-var defaultSysProbeConfigPath = "c:\\programdata\\datadog\\system-probe.yaml"
-var defaultConfdPath = "c:\\programdata\\datadog\\conf.d"
-var defaultLogFilePath = "c:\\programdata\\datadog\\logs\\process-agent.log"
+var defaultConfigPath = flags.DefaultConfPath
+var defaultSysProbeConfigPath = flags.DefaultSysProbeConfPath
+var defaultConfdPath = flags.DefaultConfdPath
+var defaultLogFilePath = flags.DefaultLogFilePath
 
 var winopts struct {
 	installService   bool


### PR DESCRIPTION
### What does this PR do?

When installing the agent on macOS, the `datadog.yaml` file is created under `/opt/datadog-agent/etc`. This path is different from the Linux's one (`/etc/datadog-agent`).

As a consequence, this might lead to some confusion when manually running the agent. For example, executing `./process-agent --check=process` will not read the values from the default config file and overrides like `hostname` won't be taken into account.

This PR creates a `flags` package where default values for `process-agent` arguments are defined. By doing so, we're able to redefine these values according to the platform the agent is compiled for. We're also able to hide arguments that don't apply for a given OS (e.g. `sysprobe-config` in macOS since it doesn't have support for `system-probe` yet).

### Motivation


### Additional Notes


### Describe your test plan

Run `./process-agent --help` on different platforms (linux, macOS and windows) and verify that the default values for `config` and `sysprobe-config` are correctly populated.

