### PR TITLE
Discard warning logs from client-go when using ComponentStatus on K8S >= 1.19

### DIFF
--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-
 	"strings"
 	"sync"
 	"time"
@@ -171,6 +170,8 @@ func getClientConfig() (*rest.Config, error) {
 }
 
 func getKubeClient(timeout time.Duration) (kubernetes.Interface, error) {
+	// TODO: Remove custom warning logger when we remove usage of ComponentStatus
+	rest.SetDefaultWarningHandler(CustomWarningLogger{})
 	clientConfig, err := getClientConfig()
 	if err != nil {
 		return nil, err

--- a/pkg/util/kubernetes/apiserver/warning_handler.go
+++ b/pkg/util/kubernetes/apiserver/warning_handler.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build kubeapiserver
+
+package apiserver
+
+import klog "k8s.io/klog"
+
+var supressedWarning = "v1 ComponentStatus is deprecated in v1.19+"
+
+type CustomWarningLogger struct{}
+
+// TODO: Remove custom warning logger when we remove usage of ComponentStatus
+func (CustomWarningLogger) HandleWarningHeader(code int, agent string, message string) {
+	if code != 299 || len(message) == 0 || message == supressedWarning {
+		return
+	}
+
+	klog.Warning(message)
+}


### PR DESCRIPTION
### What does this PR do?

`ComponentStatus` is currently in Cluster Agent `apiserver` check. Using custom warning logger to discard spammy log in `client-go`.

See https://github.com/kubernetes/kubernetes/pull/93570

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Run Cluster Agent on K8S >= 1.19, you should not see any log with `v1 ComponentStatus is deprecated in v1.19+`
