### PR TITLE
[kitchen] Increase retry limit for Windows tests

### DIFF
--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -22,6 +22,10 @@
     - export KITCHEN_OSVERS="win2008r2,win2012,win2012r2,win2016,win2019"
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
+  # Windows kitchen tests are slower and more fragile (lots of WinRM::WinRMAuthorizationError and/or execution expired errors)
+  # Give them one more chance before failing.
+  # TODO: understand why they fail more often than Linux jobs on network errors.
+  retry: 2
 
 # Kitchen: tests
 # --------------


### PR DESCRIPTION
### What does this PR do?

Increases the number of retries for Windows kitchen jobs from 1 to 2.

### Motivation

Windows kitchen jobs fail more on network errors compared to their Linux counterparts.
