### PR TITLE
Remove duplicated allowHostNetwork param in scc.yaml

### DIFF
--- a/Dockerfiles/manifests/openshift/scc.yaml
+++ b/Dockerfiles/manifests/openshift/scc.yaml
@@ -47,7 +47,6 @@ allowedCapabilities:
 #
 allowHostDirVolumePlugin: true
 allowHostIPC: false
-allowHostNetwork: false
 allowPrivilegedContainer: false
 allowedFlexVolumes: []
 defaultAddCapabilities: []


### PR DESCRIPTION
### What does this PR do?

`allowHostNetwork` option in the `scc.yaml` example file was duplicated.
This PR remove the duplication.

### Motivation

The `SecurityContextConstraints` example should be valid

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
