### PR TITLE
[system-probe] Fix appending idle conns

### DIFF
--- a/pkg/network/tracer/perf_batching.go
+++ b/pkg/network/tracer/perf_batching.go
@@ -106,7 +106,7 @@ func (p *PerfBatchManager) GetIdleConns() []network.ConnectionStats {
 			start = bState.offset
 		}
 
-		idle = p.extractBatchInto(idle, b, start, batchLen)
+		idle = append(idle, p.extractBatchInto(idle, b, start, batchLen)...)
 		// update timestamp regardless since this partial batch still exists
 		cpuState.processed[batchId] = batchState{offset: batchLen, updated: time.Now()}
 	}


### PR DESCRIPTION
### What does this PR do?

We were not collecting all the idle connections during a connection check. This mainly impacts connection closes (udp and tcp), and would lead to connections missing from the connections check.

### Motivation

Test failures like https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/62766416
