### PR TITLE
[internal_profiling] fix runtime settings setup

### DIFF
--- a/cmd/agent/app/config.go
+++ b/cmd/agent/app/config.go
@@ -168,7 +168,7 @@ func initRuntimeSettings() error {
 	if err := commonsettings.RegisterRuntimeSetting(settings.DsdCaptureDurationRuntimeSetting("dogstatsd_capture_duration")); err != nil {
 		return err
 	}
-	if err := commonsettings.RegisterRuntimeSetting(commonsettings.ProfilingRuntimeSetting("profiling")); err != nil {
+	if err := commonsettings.RegisterRuntimeSetting(commonsettings.ProfilingRuntimeSetting("internal_profiling")); err != nil {
 		return err
 	}
 

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -252,9 +252,9 @@ func StartAgent() error {
 		log.Warnf("Can't initiliaze the runtime settings: %v", err)
 	}
 
-	// Setup Profiling
-	if config.Datadog.GetBool("profiling.enabled") {
-		err := settings.SetRuntimeSetting("profiling", true)
+	// Setup Internal Profiling
+	if config.Datadog.GetBool("internal_profiling.enabled") {
+		err := settings.SetRuntimeSetting("internal_profiling", true)
 		if err != nil {
 			log.Errorf("Error starting profiler: %v", err)
 		}

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -137,11 +137,11 @@ func load(configPath string) (*Config, error) {
 		StatsdHost: aconfig.GetBindHost(),
 		StatsdPort: cfg.GetInt("dogstatsd_port"),
 
-		ProfilingEnabled:     cfg.GetBool(key(spNS, "profiling.enabled")),
-		ProfilingSite:        cfg.GetString(key(spNS, "profiling.site")),
+		ProfilingEnabled:     cfg.GetBool(key(spNS, "internal_profiling.enabled")),
+		ProfilingSite:        cfg.GetString(key(spNS, "internal_profiling.site")),
 		ProfilingURL:         cfg.GetString(key(spNS, "profiling.profile_dd_url")),
-		ProfilingAPIKey:      aconfig.SanitizeAPIKey(cfg.GetString(key(spNS, "profiling.api_key"))),
-		ProfilingEnvironment: cfg.GetString(key(spNS, "profiling.env")),
+		ProfilingAPIKey:      aconfig.SanitizeAPIKey(cfg.GetString(key(spNS, "internal_profiling.api_key"))),
+		ProfilingEnvironment: cfg.GetString(key(spNS, "internal_profiling.env")),
 	}
 
 	if err := ValidateSocketAddress(c.SocketAddress); err != nil {

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -618,7 +618,7 @@ api_key:
     #
     # loader: core
 
-{{- if .Profiling -}}
+{{- if .InternalProfiling -}}
 ## @param profiling - custom object - optional
 ## Enter specific configurations for internal profiling.
 ## Uncomment this parameter and the one below to enable profiling.
@@ -926,7 +926,7 @@ api_key:
   #   - 'sql*'
   #   - '*pass*d*'
 
-{{- if .Profiling -}}
+{{- if .InternalProfiling -}}
   ## @param profiling - custom object - optional
   ## Enter specific configurations for internal profiling.
   ## Uncomment this parameter and the one below to enable profiling.
@@ -995,7 +995,7 @@ api_key:
   #
   # log_file: /var/log/datadog/system-probe.log
 
-{{- if .Profiling -}}
+{{- if .InternalProfiling -}}
   ## @param profiling - custom object - optional
   ## Enter specific configurations for internal profiling.
   ## Uncomment this parameter and the one below to enable profiling.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -621,12 +621,17 @@ api_key:
 {{- if .InternalProfiling -}}
 ## @param profiling - custom object - optional
 ## Enter specific configurations for internal profiling.
+##
+## Please note that:
+##   1. This does *not* enable profiling for user applications.
+##   2. This only enables internal profiling of the agent go runtime.
+##   3. To enable profiling for user apps please refer to
+##      https://docs.datadoghq.com/tracing/profiling/
+##   4. Enabling this feature will incur in billing charges and other
+##      unexpected side-effects (ie. agent profiles showing with your
+##      services).
+##
 ## Uncomment this parameter and the one below to enable profiling.
-## See https://docs.datadoghq.com/tracing/profiling/
-#
-## NOTE: If enabled this option may incur in billing charges or other
-##       unexpected side-effects (ie. agent profiles showing with your
-##       services).
 #
 # internal_profiling:
 #
@@ -929,12 +934,17 @@ api_key:
 {{- if .InternalProfiling -}}
   ## @param profiling - custom object - optional
   ## Enter specific configurations for internal profiling.
+  ##
+  ## Please note that:
+  ##   1. This does *not* enable profiling for user applications.
+  ##   2. This only enables internal profiling of the agent go runtime.
+  ##   3. To enable profiling for user apps please refer to
+  ##      https://docs.datadoghq.com/tracing/profiling/
+  ##   4. Enabling this feature will incur in billing charges and other
+  ##      unexpected side-effects (ie. agent profiles showing with your
+  ##      services).
+  ##
   ## Uncomment this parameter and the one below to enable profiling.
-  ## See https://docs.datadoghq.com/tracing/profiling/
-  #
-  ## NOTE: If you enable this option, it may impact your billing or
-  ##       other features (e.g. process-agent profiles showing with your
-  ##       services).
   #
   # internal_profiling:
   #
@@ -998,12 +1008,17 @@ api_key:
 {{- if .InternalProfiling -}}
   ## @param profiling - custom object - optional
   ## Enter specific configurations for internal profiling.
+  ##
+  ## Please note that:
+  ##   1. This does *not* enable profiling for user applications.
+  ##   2. This only enables internal profiling of the agent go runtime.
+  ##   3. To enable profiling for user apps please refer to
+  ##      https://docs.datadoghq.com/tracing/profiling/
+  ##   4. Enabling this feature will incur in billing charges and other
+  ##      unexpected side-effects (ie. agent profiles showing with your
+  ##      services).
+  ##
   ## Uncomment this parameter and the one below to enable profiling.
-  ## See https://docs.datadoghq.com/tracing/profiling/
-  #
-  ## NOTE: If enabled this option may incur billing charges or other
-  ##       unexpected side-effects (ie. system probe profiles showing with your
-  ##       services).
   #
   # internal_profiling:
   #

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -24,7 +24,7 @@ type context struct {
 	Python            bool // Sub-option of Agent
 	BothPythonPresent bool // Sub-option of Agent - Python
 	Metadata          bool
-	Profiling         bool
+	InternalProfiling bool
 	Dogstatsd         bool
 	LogsAgent         bool
 	JMX               bool
@@ -60,7 +60,7 @@ func mkContext(buildType string) context {
 		Agent:             true,
 		Python:            true,
 		Metadata:          true,
-		Profiling:         false, // NOTE: hidden for now
+		InternalProfiling: false, // NOTE: hidden for now
 		Dogstatsd:         true,
 		LogsAgent:         true,
 		JMX:               true,

--- a/pkg/config/settings/runtime_setting_profiling.go
+++ b/pkg/config/settings/runtime_setting_profiling.go
@@ -33,7 +33,7 @@ func (l ProfilingRuntimeSetting) Name() string {
 
 // Get returns the current value of the runtime setting
 func (l ProfilingRuntimeSetting) Get() (interface{}, error) {
-	return config.Datadog.GetBool("profiling.enabled"), nil
+	return config.Datadog.GetBool("internal_profiling.enabled"), nil
 }
 
 // Set changes the value of the runtime setting
@@ -56,8 +56,8 @@ func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 
 		// allow full url override for development use
 		site := fmt.Sprintf(profiling.ProfileURLTemplate, s)
-		if config.Datadog.IsSet("profiling.profile_dd_url") {
-			site = config.Datadog.GetString("profiling.profile_dd_url")
+		if config.Datadog.IsSet("internal_profiling.profile_dd_url") {
+			site = config.Datadog.GetString("internal_profiling.profile_dd_url")
 		}
 
 		v, _ := version.Agent()
@@ -69,11 +69,11 @@ func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 			fmt.Sprintf("version:%v", v),
 		)
 		if err == nil {
-			config.Datadog.Set("profiling.enabled", true)
+			config.Datadog.Set("internal_profiling.enabled", true)
 		}
 	} else {
 		profiling.Stop()
-		config.Datadog.Set("profiling.enabled", false)
+		config.Datadog.Set("internal_profiling.enabled", false)
 	}
 
 	return nil

--- a/pkg/config/settings/runtime_settings_test.go
+++ b/pkg/config/settings/runtime_settings_test.go
@@ -107,8 +107,8 @@ func TestProfiling(t *testing.T) {
 	cleanRuntimeSetting()
 	setupConf()
 
-	ll := ProfilingRuntimeSetting("profiling")
-	assert.Equal(t, "profiling", ll.Name())
+	ll := ProfilingRuntimeSetting("internal_profiling")
+	assert.Equal(t, "internal_profiling", ll.Name())
 
 	err := ll.Set("false")
 	assert.Nil(t, err)


### PR DESCRIPTION
### What does this PR do?

Addresses the runtime setting config management for `internal_profiling`.

### Motivation

This is a bugfix to PR #7916 where we did not properly address the renaming of the  `profiling` to `internal_profiling` in the context of the runtime settings. This PR should address that problem.

### Additional Notes

- Any internal use of the environment variables in our deployments should be updated in helm charts, etc if we wish to enable this on production.

### Describe your test plan

Make sure that:
- You can set the configuration using the appropriate `internal_profiling` config subsection, the deprecated `profiling` option should now be mostly meaningless.
- You should be able to also change it as a runtime setting as follows:
```
sudo -u dd-agent -- datadog-agent config set internal_profiling true
sudo -u dd-agent -- datadog-agent config set internal_profiling false
```
(please note that this particular config options is hidden, by design, so it will not show up when issuing a `sudo -u dd-agent -- datadog-agent config set profiling true
sudo -u dd-agent -- datadog-agent config list-runtime`.
- This should also be evaluated by the #process-agent and #networks team as the changes affect the process agent and the system probe.
 