### PR TITLE
[system-probe] Fix: don't return nil when no items in batch

### DIFF
--- a/pkg/network/tracer/perf_batching.go
+++ b/pkg/network/tracer/perf_batching.go
@@ -129,7 +129,7 @@ type batchState struct {
 // The `start` (inclusive) and `end` (exclusive) arguments represent the offsets of the connections we're interested in.
 func (p *PerfBatchManager) extractBatchInto(buffer []network.ConnectionStats, b *batch, start, end uint16) []network.ConnectionStats {
 	if start >= end || end > ConnCloseBatchSize {
-		return nil
+		return buffer
 	}
 
 	current := uintptr(unsafe.Pointer(b)) + uintptr(start)*C.sizeof_conn_t


### PR DESCRIPTION
### What does this PR do?

Returning `nil` from `PerfBatchManager.extractBatchInfo` causes idle connections accumulated so far to be lost, leading to some closed connections not showing up in the connections check.

### Motivation

CI failures like https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/63126382

