### PR TITLE
[Windows Installer] Make NPM feature depend on main app

### DIFF
--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -484,23 +484,23 @@
           <ComponentRef Id="system_probe.yaml.example" />
       <?endif ?>
       <Condition Level="1"><![CDATA[1]]></Condition>
+
+      <?if $(var.IncludeSysprobe) = true ?>
+        <!-- don't install by default (indicated by level 100)  Only things with level
+        <= INSTALLLEVEL (1 by default) will be installed.  Can be changed via gui or command line params to optionally install -->
+        <Feature  Id="NPM" 
+                  Level="100"  
+                  Title="Network Performance Monitoring" 
+                  ConfigurableDirectory="APPLICATIONROOTDIRECTORY"
+                  Absent="allow"
+                  AllowAdvertise="no"
+        >
+          <MergeRef Id="ddnpminstall"/>
+          <Condition Level="1"><![CDATA[NPM OR (DD_FILTER_INSTALLED and (not WixUI_InstallMode = "Change"))]]></Condition>
+        </Feature>
+      <?endif ?>
     </Feature>
-     <?if $(var.IncludeSysprobe) = true ?>
-      <!-- don't install by default (indicated by level 100)  Only things with level
-           <= INSTALLLEVEL (1 by default) will be installed.  Can be changed via gui or command line params to optionally install -->
-      <Feature Id="NPM" 
-               Level="100"  
-               Title="Network Performance Monitoring" 
-               ConfigurableDirectory="APPLICATIONROOTDIRECTORY"
-               Absent="allow"
-               AllowAdvertise="no"
-               >
-        <MergeRef Id="ddnpminstall"/>
-        
-        <Condition Level="1"><![CDATA[NPM OR (DD_FILTER_INSTALLED and (not WixUI_InstallMode = "Change"))]]></Condition>
-        
-      </Feature>
-    <?endif ?>
+  
     <!-- UI Stuff: 100% Omnibus Generated -->
     <Icon Id="project.ico" SourceFile="Resources\assets\project_16x16.ico"/>
     <Property Id="ARPPRODUCTICON" Value="project.ico" />


### PR DESCRIPTION
### What does this PR do?

This PR introduces a dependency between the NPM feature and the main app.

![image](https://user-images.githubusercontent.com/63521/115623911-1d2dda00-a2fa-11eb-8b23-dbdb76fccb55.png)

### Motivation

It should not be possible to install NPM without having the Datadog Agent installed.

### Describe your test plan

Run the installer with the following parameters and verify that:
- `ADDLOCAL=ALL`: the Datadog Agent & NPM are highlighted in the feature selection window. Check in the logs that `ADDLOCAL is (MainApplication,NPM)` is present.
- `ADDLOCAL=NPM`: the Datadog Agent & NPM are highlighted in the feature selection window. Check in the logs that `ADDLOCAL is (MainApplication,NPM)` is present.
- `ADDLOCAL=MainApplication`: only the Datadog Agent is highlighted in the feature selection window. Check in the logs that `ADDLOCAL is (MainApplication)` is present.
-`NPM=TRUE`: the Datadog Agent & NPM are highlighted in the feature selection window.Check in the logs that `ADDLOCAL is (MainApplication,NPM)` is present.
-`ADDLOCAL=MainApplication NPM=TRUE`: only the Datadog Agent is highlighted in the feature selection window. Check in the logs that `ADDLOCAL is (MainApplication)` is present.

Test an install without NPM, then do change setup and add NPM. It should add the feature.
