### PR TITLE
Only declare system-probe config just before use

### DIFF
--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -67,6 +67,7 @@ type Config struct {
 
 // New creates a config object for system-probe. It assumes no configuration has been loaded as this point.
 func New(configPath string) (*Config, error) {
+	aconfig.InitSystemProbeConfig(aconfig.Datadog)
 	aconfig.Datadog.SetConfigName("system-probe")
 	// set the paths where a config file is expected
 	if len(configPath) != 0 {
@@ -94,6 +95,7 @@ func New(configPath string) (*Config, error) {
 
 // Merge will merge the system-probe configuration into the existing datadog configuration
 func Merge(configPath string) (*Config, error) {
+	aconfig.InitSystemProbeConfig(aconfig.Datadog)
 	if configPath != "" {
 		if !strings.HasSuffix(configPath, ".yaml") {
 			configPath = path.Join(configPath, defaultConfigFileName)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -783,8 +783,6 @@ func InitConfig(config Config) {
 	config.SetKnown("process_config.internal_profiling.enabled")
 	config.SetKnown("process_config.remote_tagger")
 
-	setupSystemProbe(config)
-
 	// Network
 	config.BindEnv("network.id") //nolint:errcheck
 

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -19,7 +19,11 @@ const (
 	defaultOffsetThreshold = 400
 )
 
-func setupSystemProbe(cfg Config) {
+// InitSystemProbeConfig declares all the configuration values normally read from system-probe.yaml.
+// This function should not be called before ResolveSecrets,
+// unless you call `cmd/system-probe/config.New` or `cmd/system-probe/config.Merge` in-between.
+// This is to prevent the in-memory values from being fixed before the file-based values have had a chance to be read.
+func InitSystemProbeConfig(cfg Config) {
 	// settings for system-probe in general
 	cfg.BindEnvAndSetDefault(join(spNS, "enabled"), false, "DD_SYSTEM_PROBE_ENABLED")
 	cfg.BindEnvAndSetDefault(join(spNS, "external"), false, "DD_SYSTEM_PROBE_EXTERNAL")

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -245,17 +245,19 @@ func NewDefaultAgentConfig(canAccessContainers bool) *AgentConfig {
 }
 
 func loadConfigIfExists(path string) error {
-	if util.PathExists(path) {
-		config.Datadog.AddConfigPath(path)
-		if strings.HasSuffix(path, ".yaml") { // If they set a config file directly, let's try to honor that
-			config.Datadog.SetConfigFile(path)
-		}
+	if path != "" {
+		if util.PathExists(path) {
+			config.Datadog.AddConfigPath(path)
+			if strings.HasSuffix(path, ".yaml") { // If they set a config file directly, let's try to honor that
+				config.Datadog.SetConfigFile(path)
+			}
 
-		if _, err := config.LoadWithoutSecret(); err != nil {
-			return err
+			if _, err := config.LoadWithoutSecret(); err != nil {
+				return err
+			}
+		} else {
+			log.Infof("no config exists at %s, ignoring...", path)
 		}
-	} else {
-		log.Infof("no config exists at %s, ignoring...", path)
 	}
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

This changes the system-probe configuration values to only be declared just before use. 

This should not affect code using the system-probe config values, because it should be calling either `New` or `Merge` to ensure that the `system-probe.yaml` config values are read, if present.

### Motivation

This fixes a problem observed in our staging environment where the core agent wasn't communicating with the system-probe over the correct unix socket.

The reason for this is that after `config.ResolveSecrets` is called, all keys will become fixed in value. This is because `ResolveSecrets` essentially does the following:

1. Render current config to YAML
2. Walks YAML structure replacing secrets as it goes
3. Merges result back into config as an **override**

The override takes precedence over any other type of config (file, environment, defaults, etc.). Thus it is not possible to change a key's value once the override is set.

Ideally, `ResolveSecrets` would only override those keys that it replaced secrets for, but I didn't see a straightforward way to accomplish that.

*By not declaring the system-probe configuration values until just before they are needed, it prevents them from being overridden before `system-probe.yaml` has been read.* 

### Additional Notes

The override behavior is only apparent when [secrets management](https://docs.datadoghq.com/agent/guide/secrets-management/) is in use. 
