### PR TITLE
[gitlab] Move docker_trigger_internal_amd64 to a later stage and make it automatic

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -63,7 +63,9 @@
 
 /.gitlab/image_scan.yml                              @DataDog/container-integrations @DataDog/agent-platform
 
-/.gitlab/internal_deploy.yml                         @DataDog/container-integrations @DataDog/agent-platform
+/.gitlab/internal_deploy.yml                         @DataDog/processes @DataDog/networks @DataDog/agent-platform
+
+/.gitlab/internal_image_deploy.yml                   @DataDog/container-integrations @DataDog/agent-platform
 
 /.gitlab/maintenance_jobs/docker.yml                 @DataDog/container-integrations @DataDog/agent-platform
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,6 +20,7 @@ include:
   - /.gitlab/choco_build.yml
   - /.gitlab/choco_deploy.yml
   - /.gitlab/deploy_invalidate.yml
+  - /.gitlab/internal_image_deploy.yml
   - /.gitlab/trigger_release.yml
   - /.gitlab/e2e.yml
   - /.gitlab/kitchen_cleanup.yml
@@ -67,6 +68,7 @@ stages:
   - choco_build
   - choco_deploy
   - deploy_invalidate
+  - internal_image_deploy
   - trigger_release
   - e2e
   - kitchen_cleanup

--- a/.gitlab/image_deploy.yml
+++ b/.gitlab/image_deploy.yml
@@ -6,5 +6,4 @@
 include:
   - /.gitlab/image_deploy/docker_linux.yml
   - /.gitlab/image_deploy/docker_windows.yml
-  - /.gitlab/image_deploy/internal_trigger.yml
   - /.gitlab/image_deploy/twistlock.yml

--- a/.gitlab/internal_image_deploy.yml
+++ b/.gitlab/internal_image_deploy.yml
@@ -1,13 +1,15 @@
 ---
+# internal_image_deploy stage
+# Contains jobs to trigger a pipeline in the images repo to create internal Agent images.
+
 .if_deploy_on_tag_7: &if_deploy_on_tag_7
   # no RELEASE_VERSION means a nightly build for omnibus
   if: $DEPLOY_AGENT == "true" && $RELEASE_VERSION_7 != "nightly-a7" && $RELEASE_VERSION_7 != ""
 
 docker_trigger_internal_amd64:
-  stage: image_deploy
+  stage: internal_image_deploy
   rules:
     - <<: *if_deploy_on_tag_7
-      when: manual
   needs:
     - job: docker_build_agent7_jmx
       artifacts: false


### PR DESCRIPTION
### What does this PR do?

Moves `docker_trigger_internal_amd64` to a new stage (`internal_image_deploy`) and makes it automatic.

### Motivation

Do not block release pipelines until this job is run. Do not skip the deploy jobs if this job fails.
