### PR TITLE
[gce] add hostname as the host alias

### DIFF
--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -122,6 +122,12 @@ func getHostAliases() []string {
 		aliases = append(aliases, azureAlias)
 	}
 
+	if gceHostname, err := gce.GetHostname(); err != nil {
+		log.Debugf("no GCE hostname to use as Host Alias: %s", err)
+	} else {
+		aliases = append(aliases, gceHostname)
+	}
+
 	gceAlias, err := gce.GetHostAlias()
 	if err != nil {
 		log.Debugf("no GCE Host Alias: %s", err)

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -122,17 +122,11 @@ func getHostAliases() []string {
 		aliases = append(aliases, azureAlias)
 	}
 
-	if gceHostname, err := gce.GetHostname(); err != nil {
-		log.Debugf("no GCE hostname to use as Host Alias: %s", err)
-	} else {
-		aliases = append(aliases, gceHostname)
-	}
-
-	gceAlias, err := gce.GetHostAlias()
+	gceAliases, err := gce.GetHostAliases()
 	if err != nil {
 		log.Debugf("no GCE Host Alias: %s", err)
 	} else {
-		aliases = append(aliases, gceAlias)
+		aliases = append(aliases, gceAliases...)
 	}
 
 	cfAliases, err := cloudfoundry.GetHostAliases()

--- a/pkg/util/gce/gce_test.go
+++ b/pkg/util/gce/gce_test.go
@@ -68,9 +68,9 @@ func TestGetHostAliases(t *testing.T) {
 	defer ts.Close()
 	metadataURL = ts.URL
 
-	val, err := GetHostAlias()
+	val, err := GetHostAliases()
 	assert.Nil(t, err)
-	assert.Equal(t, "gce-instance-name.gce-project", val)
+	assert.Equal(t, []string{"gce-custom-hostname.custom-domain.gce-project", "gce-instance-name.gce-project"}, val)
 }
 
 func TestGetHostAliasesInstanceNameError(t *testing.T) {
@@ -92,9 +92,9 @@ func TestGetHostAliasesInstanceNameError(t *testing.T) {
 	defer ts.Close()
 	metadataURL = ts.URL
 
-	val, err := GetHostAlias()
+	val, err := GetHostAliases()
 	assert.Nil(t, err)
-	assert.Equal(t, "gce-custom-hostname.gce-project", val)
+	assert.Equal(t, []string{"gce-custom-hostname.custom-domain.gce-project", "gce-custom-hostname.gce-project"}, val)
 }
 
 func TestGetClusterName(t *testing.T) {

--- a/releasenotes/notes/gce-fqdn-alias-fa9760945da094a7.yaml
+++ b/releasenotes/notes/gce-fqdn-alias-fa9760945da094a7.yaml
@@ -1,3 +1,3 @@
 enhancements:
   - |
-    Always send GCE hostname as a host alias
+    Adding the hostname to the host aliases when running on GCE

--- a/releasenotes/notes/gce-fqdn-alias-fa9760945da094a7.yaml
+++ b/releasenotes/notes/gce-fqdn-alias-fa9760945da094a7.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    Always send GCE hostname as a host alias


### PR DESCRIPTION
### What does this PR do?

Ensure that the full GCE/GKE hostname is visible in the app even when a custom hostname is specified by the user.

### Additional Notes

It would be nicer if `gce.GetHostAlias` returned a set of GCE aliases to use, but it is tricky given that we don't log inside `gce` package, and we probably want detailed debug logs about individual aliases.

### Describe your test plan

Run agent on a GCE node with a custom hostname set via `DD_HOSTNAME`. Verify that the GCE hostname (by default looks something like `name.zone.projecty-id.internal`) is visible as a host alias in the web app.