### PR TITLE
[orchestrator] fix wrong usage of bindenv + tests

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -749,11 +749,12 @@ func InitConfig(config Config) {
 	// this option will potentially impact the CPU usage of the agent
 	config.BindEnvAndSetDefault("orchestrator_explorer.container_scrubbing.enabled", true)
 	config.BindEnvAndSetDefault("orchestrator_explorer.custom_sensitive_words", []string{})
+	config.BindEnv("orchestrator_explorer.max_per_message")     //nolint:errcheck
+	config.BindEnv("orchestrator_explorer.orchestrator_dd_url") //nolint:errcheck
 
 	// Orchestrator Explorer - process agent
-	config.BindEnv("orchestrator_explorer.orchestrator_dd_url", "") //nolint:errcheck
 	// DEPRECATED in favor of `orchestrator_explorer.orchestrator_dd_url` setting. If both are set `orchestrator_explorer.orchestrator_dd_url` will take precedence.
-	config.BindEnv("process_config.orchestrator_dd_url", "") //nolint:errcheck
+	config.BindEnv("process_config.orchestrator_dd_url") //nolint:errcheck
 	// DEPRECATED in favor of `orchestrator_explorer.orchestrator_additional_endpoints` setting. If both are set `orchestrator_explorer.orchestrator_additional_endpoints` will take precedence.
 	config.SetKnown("process_config.orchestrator_additional_endpoints.*")
 	config.SetKnown("orchestrator_explorer.orchestrator_additional_endpoints.*")

--- a/pkg/orchestrator/config/config_test.go
+++ b/pkg/orchestrator/config/config_test.go
@@ -121,10 +121,10 @@ func (suite *YamlConfigTestSuite) TestExtractOrchestratorEndpointsPrecedence() {
 }
 
 func (suite *YamlConfigTestSuite) TestEnvConfigDDURL() {
-	ddOrchestratorUrl := "DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_DD_URL"
+	ddOrchestratorURL := "DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_DD_URL"
 	expectedValue := "123.datadoghq.com"
-	os.Setenv(ddOrchestratorUrl, expectedValue)
-	defer os.Unsetenv(ddOrchestratorUrl)
+	os.Setenv(ddOrchestratorURL, expectedValue)
+	defer os.Unsetenv(ddOrchestratorURL)
 
 	orchestratorCfg := NewDefaultOrchestratorConfig()
 	err := orchestratorCfg.Load()

--- a/pkg/orchestrator/config/config_test.go
+++ b/pkg/orchestrator/config/config_test.go
@@ -151,15 +151,16 @@ func (suite *YamlConfigTestSuite) TestEnvConfigMessageSize() {
 
 func (suite *YamlConfigTestSuite) TestEnvConfigMessageSizeTooHigh() {
 	ddMaxMessage := "DD_ORCHESTRATOR_EXPLORER_MAX_PER_MESSAGE"
-	expectedValue := "150"
-	os.Setenv(ddMaxMessage, expectedValue)
+	expectedDefaultValue := 100
+
+	os.Setenv(ddMaxMessage, "150")
 	defer os.Unsetenv(ddMaxMessage)
 
 	orchestratorCfg := NewDefaultOrchestratorConfig()
 	err := orchestratorCfg.Load()
 	suite.NoError(err)
 
-	suite.Equal(100, orchestratorCfg.MaxPerMessage)
+	suite.Equal(expectedDefaultValue, orchestratorCfg.MaxPerMessage)
 }
 
 func (suite *YamlConfigTestSuite) TestEnvConfigSensitiveWords() {

--- a/releasenotes/notes/fix-orchestrator-env-5fd123a19577b8b5.yaml
+++ b/releasenotes/notes/fix-orchestrator-env-5fd123a19577b8b5.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    Makes "DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_DD_URL" and "DD_ORCHESTRATOR_EXPLORER_MAX_PER_MESSAGE" usable in an env configuration.
+    Fix the usage of  "DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_DD_URL" and "DD_ORCHESTRATOR_EXPLORER_MAX_PER_MESSAGE" environment variables.

--- a/releasenotes/notes/fix-orchestrator-env-5fd123a19577b8b5.yaml
+++ b/releasenotes/notes/fix-orchestrator-env-5fd123a19577b8b5.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Makes "DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_DD_URL" and "DD_ORCHESTRATOR_EXPLORER_MAX_PER_MESSAGE" usable in an env configuration.


### PR DESCRIPTION
### What does this PR do?

Fixes wrong usage of `BindEnv` which made that `DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_DD_URL` did not work for our DCA. `orchestrator_explorer.max_per_message` was not registered at all. 
Now the following env registering works:
- `DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_DD_URL`
- `DD_ORCHESTRATOR_EXPLORER_MAX_PER_MESSAGE`


This fixes it for the `DCA` and `Process-agent`

### Motivation

Fix linkage for adding own links e.g. for private link

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

- Look at the unit tests
- Use the respective envs defined above and try to run the DCA with these envs and see whether they are used e.g as seen here:

```
export DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_DD_URL=https://SomeURL.com
```
you fill eventually find the error messages for above wrongly used DD_URL. This shows that the env is working again.
```
2021-04-22 12:57:11 UTC | CLUSTER | ERROR | (pkg/forwarder/worker.go:179 in process) | Too many errors for endpoint 'https://SomeURL.com/api/v1/orchestrator': retrying later
```