### PR TITLE
Fix dogstatsd telemetry not being correctly configured

### DIFF
--- a/pkg/telemetry/histogram.go
+++ b/pkg/telemetry/histogram.go
@@ -19,6 +19,16 @@ type Histogram interface {
 	Delete(tagsValue ...string)
 }
 
+type histogramNoOp struct{}
+
+func (h histogramNoOp) Observe(_ float64, _ ...string) {}
+func (h histogramNoOp) Delete(_ ...string)             {}
+
+// NewHistogramNoOp creates a dummy Histogram
+func NewHistogramNoOp() Histogram {
+	return histogramNoOp{}
+}
+
 // NewHistogram creates a Histogram with default options for telemetry purpose.
 // Current implementation used: Prometheus Histogram
 func NewHistogram(subsystem, name string, tags []string, help string, buckets []float64) Histogram {

--- a/pkg/telemetry/summaries.go
+++ b/pkg/telemetry/summaries.go
@@ -19,6 +19,16 @@ type Summary interface {
 	Delete(tagsValue ...string)
 }
 
+type summaryNoOp struct{}
+
+func (h summaryNoOp) Observe(_ float64, _ ...string) {}
+func (h summaryNoOp) Delete(_ ...string)             {}
+
+// NewSummaryNoOp creates a dummy Summary
+func NewSummaryNoOp() Summary {
+	return summaryNoOp{}
+}
+
 // NewSummary creates a Summary with default options for telemetry purpose.
 // Current implementation used: Prometheus Summary
 func NewSummary(subsystem, name string, tags []string, help string) Summary {


### PR DESCRIPTION
### What does this PR do?

When configured through the datadog.yaml the configuration was loaded
after the init module functions where ran.
