### PR TITLE
Fix [Windows installer] Only warn once if a property cannot be replaced

### DIFF
--- a/tools/windows/install-help/cal/PropertyReplacer.cpp
+++ b/tools/windows/install-help/cal/PropertyReplacer.cpp
@@ -233,14 +233,14 @@ std::wstring replace_yaml_properties(
         {
             input.append(L"\nec2_use_windows_prefix_detection: " + *ec2UseWindowsPrefixDetection + L"\n");
         }
+    }
 
-        // Remove duplicated entries
-        if (failedToReplace != nullptr)
-        {
-            std::sort(failedToReplace->begin(), failedToReplace->end());
-            auto last = std::unique(failedToReplace->begin(), failedToReplace->end());
-            failedToReplace->erase(last, failedToReplace->end());
-        }
+    // Remove duplicated entries
+    if (failedToReplace != nullptr)
+    {
+        std::sort(failedToReplace->begin(), failedToReplace->end());
+        auto last = std::unique(failedToReplace->begin(), failedToReplace->end());
+        failedToReplace->erase(last, failedToReplace->end());
     }
 
     return input;


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug in https://github.com/DataDog/datadog-agent/pull/7720 that was introduced [here](https://github.com/DataDog/datadog-agent/pull/7598/files#diff-addb01f5a2a0aa26f64f3a2599bba235a6f8cf3c90681ee2e8b94f82cff05665R237-R243) where the code that checks for duplicate properties was included in a if by accident.

The unit tests weren't catching this case because a non-duplicated property was used for the test. This PR addresses that as well.

### Motivation

No duplicated warnings during installation.

### Describe your test plan

See original https://github.com/DataDog/datadog-agent/pull/7720.
