### PR TITLE
avoid running the check if cluster name is empty

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -147,8 +147,9 @@ func (o *OrchestratorCheck) Configure(config, initConfig integration.Data, sourc
 
 	// check if cluster name is set
 	hostname, _ := coreutil.GetHostname()
-	if clusterName := clustername.GetClusterName(hostname); clusterName != "" {
-		o.orchestratorConfig.KubeClusterName = clusterName
+	o.orchestratorConfig.KubeClusterName = clustername.GetClusterName(hostname)
+	if o.orchestratorConfig.KubeClusterName == "" {
+		return errors.New("orchestrator check is configured but the cluster name is empty")
 	}
 
 	// load instance level config


### PR DESCRIPTION
### What does this PR do?

Oversight of the cluster check migration, the orchestrator check should not run if the cluster name is empty

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
