### PR TITLE
[runtime-security] Do not crash when loading an empty policy

### DIFF
--- a/pkg/security/rules/policy.go
+++ b/pkg/security/rules/policy.go
@@ -85,7 +85,7 @@ func LoadPolicy(r io.Reader, name string) (*Policy, error) {
 	policy := &Policy{Name: name}
 
 	decoder := yaml.NewDecoder(r)
-	if err := decoder.Decode(&policy); err != nil {
+	if err := decoder.Decode(policy); err != nil {
 		return nil, &ErrPolicyLoad{Name: name, Err: err}
 	}
 


### PR DESCRIPTION
### What does this PR do?

Fix crash when loading an empty policy