### PR TITLE
[metadata] add `host_aliases` setting

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/common/types"
 	"github.com/DataDog/datadog-agent/pkg/collector/check/defaults"
+	"github.com/DataDog/datadog-agent/pkg/util/hostname/validate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/secrets"
@@ -1328,4 +1329,23 @@ func GetBindHost() string {
 	}
 
 	return "localhost"
+}
+
+// GetValidHostAliases validates host aliases set in `host_aliases` variable and returns
+// only valid ones.
+func GetValidHostAliases() []string {
+	return getValidHostAliasesWithConfig(Datadog)
+}
+
+func getValidHostAliasesWithConfig(config Config) []string {
+	aliases := []string{}
+	for _, alias := range config.GetStringSlice("host_aliases") {
+		if err := validate.ValidHostname(alias); err == nil {
+			aliases = append(aliases, alias)
+		} else {
+			log.Warnf("skipping invalid host alias '%s': %s", alias, err)
+		}
+	}
+
+	return aliases
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -199,6 +199,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("allow_arbitrary_tags", false)
 	config.BindEnvAndSetDefault("use_proxy_for_cloud_metadata", false)
 	config.BindEnvAndSetDefault("check_sampler_bucket_expiry", 60) // in seconds
+	config.BindEnvAndSetDefault("host_aliases", []string{})
 
 	// overridden in IoT Agent main
 	config.BindEnvAndSetDefault("iot_host", false)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -58,6 +58,16 @@ api_key:
 #
 # hostname_fqdn: false
 
+## @param host_aliases - list of strings - optional
+## List of host aliases to report in addition to any aliases collected
+## automatically from cloud providers.
+## More information at
+## https://docs.datadoghq.com/agent/faq/how-datadog-agent-determines-the-hostname/?tab=agentv6v7#host-aliases
+#
+# host_aliases:
+#   - <ALIAS-1>
+#   - <ALIAS-2>
+
 ## @param tags  - list of key:value elements - optional
 ## List of host tags. Attached in-app to every metric, event, log, trace, and service check emitted by this Agent.
 ##

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -939,3 +939,8 @@ func TestPrometheusScrapeChecksEnv(t *testing.T) {
 	assert.NoError(t, Datadog.UnmarshalKey("prometheus_scrape.checks", &checks))
 	assert.EqualValues(t, checks, expected)
 }
+
+func TestGetValidHostAliasesWithConfig(t *testing.T) {
+	config := setupConfFromYAML(`host_aliases: ["foo", "-bar"]`)
+	assert.EqualValues(t, getValidHostAliasesWithConfig(config), []string{"foo"})
+}

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -106,7 +106,7 @@ func GetPythonVersion() string {
 // getHostAliases returns the hostname aliases from different provider
 // This should include GCE, Azure, Cloud foundry, kubernetes
 func getHostAliases() []string {
-	aliases := []string{}
+	aliases := config.Datadog.GetStringSlice("host_aliases")
 
 	alibabaAlias, err := alibaba.GetHostAlias()
 	if err != nil {

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -28,7 +28,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/ec2"
 	"github.com/DataDog/datadog-agent/pkg/util/gce"
 	kubelet "github.com/DataDog/datadog-agent/pkg/util/hostname/kubelet"
-	"github.com/DataDog/datadog-agent/pkg/util/hostname/validate"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 
 	"io/ioutil"
@@ -107,7 +106,7 @@ func GetPythonVersion() string {
 // getHostAliases returns the hostname aliases from different provider
 // This should include GCE, Azure, Cloud foundry, kubernetes
 func getHostAliases() []string {
-	aliases := config.Datadog.GetStringSlice("host_aliases")
+	aliases := config.GetValidHostAliases()
 
 	alibabaAlias, err := alibaba.GetHostAlias()
 	if err != nil {
@@ -151,16 +150,7 @@ func getHostAliases() []string {
 		aliases = append(aliases, tencentAlias)
 	}
 
-	validatedAliases := []string{}
-	for _, alias := range util.SortUniqInPlace(aliases) {
-		if err := validate.ValidHostname(alias); err == nil {
-			validatedAliases = append(validatedAliases, alias)
-		} else {
-			log.Warnf("skipping invalid host alias '%s': %s", alias, err)
-		}
-	}
-
-	return validatedAliases
+	return util.SortUniqInPlace(aliases)
 }
 
 func getPublicIPv4() (string, error) {

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -150,7 +150,7 @@ func getHostAliases() []string {
 		aliases = append(aliases, tencentAlias)
 	}
 
-	return aliases
+	return util.SortUniqInPlace(aliases)
 }
 
 func getPublicIPv4() (string, error) {

--- a/releasenotes/notes/host-aliases-97fab806e1f849f3.yaml
+++ b/releasenotes/notes/host-aliases-97fab806e1f849f3.yaml
@@ -1,0 +1,4 @@
+features:
+  - |
+    New `host_aliases` setting can be used to add custom host aliases in
+    addition to aliases obtained from cloud providers automatically.


### PR DESCRIPTION
### What does this PR do?

This setting can be used to add custom host aliases in addition to aliases obtained from cloud providers automatically.

### Describe your test plan

Run the agent with `host_aliases` enabled in the config file (or `DD_HOST_ALIASES` env var) and verify that the configured aliases appear on the host panel in the app.