### PR TITLE
Fix spammy log

### DIFF
--- a/pkg/tagger/collectors/common.go
+++ b/pkg/tagger/collectors/common.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	// OrchestratorScopeEntityID defines the orchestrator scope entity ID
-	OrchestratorScopeEntityID = "internal:orchestrator-scope-entity-id"
+	OrchestratorScopeEntityID = "internal://orchestrator-scope-entity-id"
 
 	autodiscoveryLabelTagsKey = "com.datadoghq.ad.tags"
 )


### PR DESCRIPTION
### What does this PR do?

Fix a very spammy log introduced in `7.28.0-rc.1`:

```
2021-04-23 06:07:28 UTC | CORE | WARN | (cmd/agent/api/grpc.go:109 in TaggerStreamEntities) | can't convert tagger entity to protobuf: invalid entity id "internal:orchestrator-scope-entity-id"
```

### Motivation

Since the load of `7.28.0-rc.1`, this warning is generated several times per second.

### Additional Notes

Here is where the error is raised: [cmd/agent/api/grpc.go#L156](https://github.com/DataDog/datadog-agent/blob/7.28.0-rc.2/cmd/agent/api/grpc.go#L156-L158).

### Describe your test plan

Load the fixed version on a test cluster and check that the amount of logs generated by the agent is back to normal and, in particular, that this specific warning log doesn’t appear anymore.