### PR TITLE
[runtime-security] use tracepoint for syscall on kernel < 4.12

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "d12a830d38037144d120bf740087eaa3ce8b4750a91d6586f824175dbd50bc4b")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "2bb77819f9a874c638467f9aa9499a34a96ef9e8533c4b8a60a4d93febfa0d11")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "2bb77819f9a874c638467f9aa9499a34a96ef9e8533c4b8a60a4d93febfa0d11")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "7f1c9c77b6746d2bf6ea5f44201a2cfdcfb915564b2c53e77ebb50bc5abd2546")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "7f1c9c77b6746d2bf6ea5f44201a2cfdcfb915564b2c53e77ebb50bc5abd2546")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "ced83393da6990bd432f8b127d7f57cf2f61e511c63f9b33ed6836a5117934da")

--- a/pkg/security/ebpf/c/chown.h
+++ b/pkg/security/ebpf/c/chown.h
@@ -24,7 +24,7 @@ int __attribute__((always_inline)) trace__sys_chown(uid_t user, gid_t group) {
     }
 
     struct syscall_cache_t syscall = {
-        .type = SYSCALL_CHOWN,
+        .type = EVENT_CHOWN,
         .policy = policy,
         .setattr = {
             .user = user,
@@ -65,17 +65,12 @@ SYSCALL_KPROBE4(fchownat, int, dirfd, const char*, filename, uid_t, user, gid_t,
     return trace__sys_chown(user, group);
 }
 
-int __attribute__((always_inline)) trace__sys_chown_ret(struct pt_regs *ctx) {
-    struct syscall_cache_t *syscall = pop_syscall(SYSCALL_CHOWN);
-    if (!syscall)
-        return 0;
-
-    int retval = PT_REGS_RC(ctx);
-    if (IS_UNHANDLED_ERROR(retval))
+int __attribute__((always_inline)) do_sys_chown_ret(void *ctx, struct syscall_cache_t *syscall) {
+    if (IS_UNHANDLED_ERROR(syscall->retval))
         return 0;
 
     struct chown_event_t event = {
-        .syscall.retval = retval,
+        .syscall.retval = syscall->retval,
         .file = syscall->setattr.file,
         .user = syscall->setattr.user,
         .group = syscall->setattr.group,
@@ -89,6 +84,24 @@ int __attribute__((always_inline)) trace__sys_chown_ret(struct pt_regs *ctx) {
     send_event(ctx, EVENT_CHOWN, event);
 
     return 0;
+}
+
+SEC("tracepoint/handle_sys_chown_exit")
+int handle_sys_chown_exit(void *ctx) {
+    struct syscall_cache_t *syscall = pop_syscall(EVENT_CHOWN);
+    if (!syscall)
+        return 0;
+
+    return do_sys_chown_ret(ctx, syscall);
+}
+
+int __attribute__((always_inline)) trace__sys_chown_ret(struct pt_regs *ctx) {
+    struct syscall_cache_t *syscall = pop_syscall(EVENT_CHOWN);
+    if (!syscall)
+        return 0;
+
+    syscall->retval = PT_REGS_RC(ctx);
+    return do_sys_chown_ret(ctx, syscall);
 }
 
 SYSCALL_KRETPROBE(lchown) {

--- a/pkg/security/ebpf/c/commit_creds.h
+++ b/pkg/security/ebpf/c/commit_creds.h
@@ -34,12 +34,16 @@ int __attribute__((always_inline)) trace__credentials_update(u64 type) {
     return 0;
 }
 
+int __attribute__((always_inline)) credentials_predicate(u64 type) {
+    return type == EVENT_SETUID || type == EVENT_SETGID || type == EVENT_CAPSET;
+}
+
 int __attribute__((always_inline)) trace__credentials_update_ret(struct pt_regs *ctx) {
     int retval = PT_REGS_RC(ctx);
     if (retval < 0)
         return 0;
 
-    struct syscall_cache_t *syscall = pop_syscall(SYSCALL_SETUID | SYSCALL_SETGID | SYSCALL_CAPSET);
+    struct syscall_cache_t *syscall = pop_syscall_with(credentials_predicate);
     if (!syscall)
         return 0;
 
@@ -55,19 +59,19 @@ int __attribute__((always_inline)) trace__credentials_update_ret(struct pt_regs 
     fill_container_context(entry, &event.container);
 
     switch (syscall->type) {
-        case SYSCALL_SETUID:
+        case EVENT_SETUID:
             event_type = EVENT_SETUID;
             event.setuid.uid = pid_entry->credentials.uid;
             event.setuid.euid = pid_entry->credentials.euid;
             event.setuid.fsuid = pid_entry->credentials.fsuid;
             break;
-        case SYSCALL_SETGID:
+        case EVENT_SETGID:
             event_type = EVENT_SETGID;
             event.setgid.gid = pid_entry->credentials.gid;
             event.setgid.egid = pid_entry->credentials.egid;
             event.setgid.fsgid = pid_entry->credentials.fsgid;
             break;
-        case SYSCALL_CAPSET:
+        case EVENT_CAPSET:
             event_type = EVENT_CAPSET;
             event.capset.cap_effective = pid_entry->credentials.cap_effective;
             event.capset.cap_permitted = pid_entry->credentials.cap_permitted;
@@ -79,7 +83,7 @@ int __attribute__((always_inline)) trace__credentials_update_ret(struct pt_regs 
 }
 
 SYSCALL_KPROBE0(setuid) {
-    return trace__credentials_update(SYSCALL_SETUID);
+    return trace__credentials_update(EVENT_SETUID);
 }
 
 SYSCALL_KRETPROBE(setuid) {
@@ -87,7 +91,7 @@ SYSCALL_KRETPROBE(setuid) {
 }
 
 SYSCALL_KPROBE0(seteuid) {
-    return trace__credentials_update(SYSCALL_SETUID);
+    return trace__credentials_update(EVENT_SETUID);
 }
 
 SYSCALL_KRETPROBE(seteuid) {
@@ -95,7 +99,7 @@ SYSCALL_KRETPROBE(seteuid) {
 }
 
 SYSCALL_KPROBE0(setfsuid) {
-    return trace__credentials_update(SYSCALL_SETUID);
+    return trace__credentials_update(EVENT_SETUID);
 }
 
 SYSCALL_KRETPROBE(setfsuid) {
@@ -103,7 +107,7 @@ SYSCALL_KRETPROBE(setfsuid) {
 }
 
 SYSCALL_KPROBE0(setreuid) {
-    return trace__credentials_update(SYSCALL_SETUID);
+    return trace__credentials_update(EVENT_SETUID);
 }
 
 SYSCALL_KRETPROBE(setreuid) {
@@ -111,7 +115,7 @@ SYSCALL_KRETPROBE(setreuid) {
 }
 
 SYSCALL_KPROBE0(setresuid) {
-    return trace__credentials_update(SYSCALL_SETUID);
+    return trace__credentials_update(EVENT_SETUID);
 }
 
 SYSCALL_KRETPROBE(setresuid) {
@@ -119,7 +123,7 @@ SYSCALL_KRETPROBE(setresuid) {
 }
 
 SYSCALL_KPROBE0(setuid16) {
-    return trace__credentials_update(SYSCALL_SETUID);
+    return trace__credentials_update(EVENT_SETUID);
 }
 
 SYSCALL_KRETPROBE(setuid16) {
@@ -127,7 +131,7 @@ SYSCALL_KRETPROBE(setuid16) {
 }
 
 SYSCALL_KPROBE0(seteuid16) {
-    return trace__credentials_update(SYSCALL_SETUID);
+    return trace__credentials_update(EVENT_SETUID);
 }
 
 SYSCALL_KRETPROBE(seteuid16) {
@@ -135,7 +139,7 @@ SYSCALL_KRETPROBE(seteuid16) {
 }
 
 SYSCALL_KPROBE0(setfsuid16) {
-    return trace__credentials_update(SYSCALL_SETUID);
+    return trace__credentials_update(EVENT_SETUID);
 }
 
 SYSCALL_KRETPROBE(setfsuid16) {
@@ -143,7 +147,7 @@ SYSCALL_KRETPROBE(setfsuid16) {
 }
 
 SYSCALL_KPROBE0(setreuid16) {
-    return trace__credentials_update(SYSCALL_SETUID);
+    return trace__credentials_update(EVENT_SETUID);
 }
 
 SYSCALL_KRETPROBE(setreuid16) {
@@ -151,7 +155,7 @@ SYSCALL_KRETPROBE(setreuid16) {
 }
 
 SYSCALL_KPROBE0(setresuid16) {
-    return trace__credentials_update(SYSCALL_SETUID);
+    return trace__credentials_update(EVENT_SETUID);
 }
 
 SYSCALL_KRETPROBE(setresuid16) {
@@ -161,7 +165,7 @@ SYSCALL_KRETPROBE(setresuid16) {
 
 
 SYSCALL_KPROBE0(setgid) {
-    return trace__credentials_update(SYSCALL_SETGID);
+    return trace__credentials_update(EVENT_SETGID);
 }
 
 SYSCALL_KRETPROBE(setgid) {
@@ -169,7 +173,7 @@ SYSCALL_KRETPROBE(setgid) {
 }
 
 SYSCALL_KPROBE0(setegid) {
-    return trace__credentials_update(SYSCALL_SETGID);
+    return trace__credentials_update(EVENT_SETGID);
 }
 
 SYSCALL_KRETPROBE(setegid) {
@@ -177,7 +181,7 @@ SYSCALL_KRETPROBE(setegid) {
 }
 
 SYSCALL_KPROBE0(setfsgid) {
-    return trace__credentials_update(SYSCALL_SETGID);
+    return trace__credentials_update(EVENT_SETGID);
 }
 
 SYSCALL_KRETPROBE(setfsgid) {
@@ -185,7 +189,7 @@ SYSCALL_KRETPROBE(setfsgid) {
 }
 
 SYSCALL_KPROBE0(setregid) {
-    return trace__credentials_update(SYSCALL_SETGID);
+    return trace__credentials_update(EVENT_SETGID);
 }
 
 SYSCALL_KRETPROBE(setregid) {
@@ -193,7 +197,7 @@ SYSCALL_KRETPROBE(setregid) {
 }
 
 SYSCALL_KPROBE0(setresgid) {
-    return trace__credentials_update(SYSCALL_SETGID);
+    return trace__credentials_update(EVENT_SETGID);
 }
 
 SYSCALL_KRETPROBE(setresgid) {
@@ -201,7 +205,7 @@ SYSCALL_KRETPROBE(setresgid) {
 }
 
 SYSCALL_KPROBE0(setgid16) {
-    return trace__credentials_update(SYSCALL_SETGID);
+    return trace__credentials_update(EVENT_SETGID);
 }
 
 SYSCALL_KRETPROBE(setgid16) {
@@ -209,7 +213,7 @@ SYSCALL_KRETPROBE(setgid16) {
 }
 
 SYSCALL_KPROBE0(setegid16) {
-    return trace__credentials_update(SYSCALL_SETGID);
+    return trace__credentials_update(EVENT_SETGID);
 }
 
 SYSCALL_KRETPROBE(setegid16) {
@@ -217,7 +221,7 @@ SYSCALL_KRETPROBE(setegid16) {
 }
 
 SYSCALL_KPROBE0(setfsgid16) {
-    return trace__credentials_update(SYSCALL_SETGID);
+    return trace__credentials_update(EVENT_SETGID);
 }
 
 SYSCALL_KRETPROBE(setfsgid16) {
@@ -225,7 +229,7 @@ SYSCALL_KRETPROBE(setfsgid16) {
 }
 
 SYSCALL_KPROBE0(setregid16) {
-    return trace__credentials_update(SYSCALL_SETGID);
+    return trace__credentials_update(EVENT_SETGID);
 }
 
 SYSCALL_KRETPROBE(setregid16) {
@@ -233,7 +237,7 @@ SYSCALL_KRETPROBE(setregid16) {
 }
 
 SYSCALL_KPROBE0(setresgid16) {
-    return trace__credentials_update(SYSCALL_SETGID);
+    return trace__credentials_update(EVENT_SETGID);
 }
 
 SYSCALL_KRETPROBE(setresgid16) {
@@ -243,7 +247,7 @@ SYSCALL_KRETPROBE(setresgid16) {
 
 
 SYSCALL_KPROBE0(capset) {
-    return trace__credentials_update(SYSCALL_CAPSET);
+    return trace__credentials_update(EVENT_CAPSET);
 }
 
 SYSCALL_KRETPROBE(capset) {

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -266,6 +266,17 @@ struct file_t {
     struct file_metadata_t metadata;
 };
 
+struct tracepoint_raw_syscalls_sys_exit_t
+{
+    unsigned short common_type;
+    unsigned char common_flags;
+    unsigned char common_preempt_count;
+    int common_pid;
+
+    long id;
+    long ret;
+};
+
 struct bpf_map_def SEC("maps/path_id") path_id = {
     .type = BPF_MAP_TYPE_ARRAY,
     .key_size = sizeof(u32),

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -185,6 +185,7 @@
 
 enum event_type
 {
+    EVENT_ANY = 0,
     EVENT_FIRST_DISCARDER = 1,
     EVENT_OPEN = EVENT_FIRST_DISCARDER,
     EVENT_MKDIR,
@@ -211,28 +212,6 @@ enum event_type
     EVENT_ARGS_ENVS,
     EVENT_MOUNT_RELEASED,
     EVENT_MAX, // has to be the last one
-};
-
-enum syscall_type
-{
-    SYSCALL_OPEN        = 1 << EVENT_OPEN,
-    SYSCALL_MKDIR       = 1 << EVENT_MKDIR,
-    SYSCALL_LINK        = 1 << EVENT_LINK,
-    SYSCALL_RENAME      = 1 << EVENT_RENAME,
-    SYSCALL_UNLINK      = 1 << EVENT_UNLINK,
-    SYSCALL_RMDIR       = 1 << EVENT_RMDIR,
-    SYSCALL_CHMOD       = 1 << EVENT_CHMOD,
-    SYSCALL_CHOWN       = 1 << EVENT_CHOWN,
-    SYSCALL_UTIME       = 1 << EVENT_UTIME,
-    SYSCALL_MOUNT       = 1 << EVENT_MOUNT,
-    SYSCALL_UMOUNT      = 1 << EVENT_UMOUNT,
-    SYSCALL_SETXATTR    = 1 << EVENT_SETXATTR,
-    SYSCALL_REMOVEXATTR = 1 << EVENT_REMOVEXATTR,
-    SYSCALL_EXEC        = 1 << EVENT_EXEC,
-    SYSCALL_FORK        = 1 << EVENT_FORK,
-    SYSCALL_SETUID      = 1 << EVENT_SETUID,
-    SYSCALL_SETGID      = 1 << EVENT_SETGID,
-    SYSCALL_CAPSET      = 1 << EVENT_CAPSET,
 };
 
 struct kevent_t {

--- a/pkg/security/ebpf/c/exec.h
+++ b/pkg/security/ebpf/c/exec.h
@@ -11,7 +11,7 @@
 #define MAX_STR_BUFF_LEN (1 << 15)
 #define MAX_ARRAY_ELEMENT_PER_TAIL 28
 #define MAX_ARRAY_ELEMENT_SIZE 4096
-#define MAX_ARGS_ELEMENTS 160
+#define MAX_ARGS_ELEMENTS 140
 
 struct args_envs_event_t {
     struct kevent_t event;

--- a/pkg/security/ebpf/c/exec.h
+++ b/pkg/security/ebpf/c/exec.h
@@ -147,7 +147,7 @@ void __attribute__((always_inline)) parse_str_array(struct pt_regs *ctx, struct 
 
 SEC("kprobe/parse_args_envs")
 int parse_args_envs(struct pt_regs *ctx) {
-    struct syscall_cache_t *syscall = peek_syscall(SYSCALL_EXEC);
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_EXEC);
     if (!syscall) {
         return 0;
     }
@@ -167,7 +167,7 @@ int parse_args_envs(struct pt_regs *ctx) {
 
 int __attribute__((always_inline)) trace__sys_execveat(struct pt_regs *ctx, const char **argv, const char **env) {
     struct syscall_cache_t syscall = {
-        .type = SYSCALL_EXEC,
+        .type = EVENT_EXEC,
         .exec = {
             .args = {
                 .id = bpf_get_prandom_u32(),
@@ -280,7 +280,7 @@ int __attribute__((always_inline)) handle_do_fork(struct pt_regs *ctx) {
     }
 
     struct syscall_cache_t syscall = {
-        .type = SYSCALL_FORK,
+        .type = EVENT_FORK,
         .clone = {
             .is_thread = 1,
         }
@@ -308,7 +308,7 @@ int kprobe__do_fork(struct pt_regs *ctx) {
 SEC("tracepoint/sched/sched_process_fork")
 int sched_process_fork(struct _tracepoint_sched_process_fork *args) {
     // check if this is a thread first
-    struct syscall_cache_t *syscall = pop_syscall(SYSCALL_FORK);
+    struct syscall_cache_t *syscall = pop_syscall(EVENT_FORK);
     if (syscall) {
         return 0;
     }
@@ -408,7 +408,7 @@ int kprobe_exit_itimers(struct pt_regs *ctx) {
 }
 
 int __attribute__((always_inline)) parse_args_and_env(struct pt_regs *ctx) {
-    struct syscall_cache_t *syscall = peek_syscall(SYSCALL_EXEC);
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_EXEC);
     if (!syscall) {
         return 0;
     }
@@ -436,7 +436,7 @@ void __attribute__((always_inline)) fill_args_envs(struct exec_event_t *event, s
 
 SEC("kprobe/security_bprm_committed_creds")
 int kprobe_security_bprm_committed_creds(struct pt_regs *ctx) {
-    struct syscall_cache_t *syscall = pop_syscall(SYSCALL_EXEC);
+    struct syscall_cache_t *syscall = pop_syscall(EVENT_EXEC);
     if (!syscall) {
         return 0;
     }

--- a/pkg/security/ebpf/c/filename.h
+++ b/pkg/security/ebpf/c/filename.h
@@ -5,15 +5,15 @@
 
 SEC("kprobe/filename_create")
 int kprobe__filename_create(struct pt_regs *ctx) {
-    struct syscall_cache_t *syscall = peek_syscall(SYSCALL_MKDIR | SYSCALL_LINK);
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_ANY);
     if (!syscall)
         return 0;
 
     switch (syscall->type) {
-        case SYSCALL_MKDIR:
+        case EVENT_MKDIR:
             syscall->mkdir.path = (struct path *)PT_REGS_PARM3(ctx);
             break;
-       case SYSCALL_LINK:
+       case EVENT_LINK:
             syscall->link.target_path = (struct path *)PT_REGS_PARM3(ctx);
             break;
     }

--- a/pkg/security/ebpf/c/mkdir.h
+++ b/pkg/security/ebpf/c/mkdir.h
@@ -66,8 +66,8 @@ int kprobe__vfs_mkdir(struct pt_regs *ctx) {
     return 0;
 }
 
-int __attribute__((always_inline)) do_sys_mkdir_ret(void *ctx, struct syscall_cache_t *syscall) {
-    if (IS_UNHANDLED_ERROR(syscall->retval))
+int __attribute__((always_inline)) do_sys_mkdir_ret(void *ctx, struct syscall_cache_t *syscall, int retval) {
+    if (IS_UNHANDLED_ERROR(retval))
         return 0;
 
     // the inode of the dentry was not properly set when kprobe/security_path_mkdir was called, make sure we grab it now
@@ -79,7 +79,7 @@ int __attribute__((always_inline)) do_sys_mkdir_ret(void *ctx, struct syscall_ca
     }
 
     struct mkdir_event_t event = {
-        .syscall.retval = syscall->retval,
+        .syscall.retval = retval,
         .file = syscall->mkdir.file,
         .mode = syscall->mkdir.mode,
     };
@@ -94,12 +94,12 @@ int __attribute__((always_inline)) do_sys_mkdir_ret(void *ctx, struct syscall_ca
 }
 
 SEC("tracepoint/handle_sys_mkdir_exit")
-int handle_sys_mkdir_exit(void *ctx) {
+int handle_sys_mkdir_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_MKDIR);
     if (!syscall)
         return 0;
 
-    return do_sys_mkdir_ret(ctx, syscall);
+    return do_sys_mkdir_ret(args, syscall, args->ret);
 }
 
 int __attribute__((always_inline)) trace__sys_mkdir_ret(struct pt_regs *ctx) {
@@ -107,8 +107,8 @@ int __attribute__((always_inline)) trace__sys_mkdir_ret(struct pt_regs *ctx) {
     if (!syscall)
         return 0;
 
-    syscall->retval = PT_REGS_RC(ctx);
-    return do_sys_mkdir_ret(ctx, syscall);
+    int retval = PT_REGS_RC(ctx);
+    return do_sys_mkdir_ret(ctx, syscall, retval);
 }
 
 SYSCALL_KRETPROBE(mkdir)

--- a/pkg/security/ebpf/c/mount.h
+++ b/pkg/security/ebpf/c/mount.h
@@ -23,7 +23,7 @@ struct mount_event_t {
 
 SYSCALL_COMPAT_KPROBE3(mount, const char*, source, const char*, target, const char*, fstype) {
     struct syscall_cache_t syscall = {
-        .type = SYSCALL_MOUNT,
+        .type = EVENT_MOUNT,
     };
 
     cache_syscall(&syscall);
@@ -32,7 +32,7 @@ SYSCALL_COMPAT_KPROBE3(mount, const char*, source, const char*, target, const ch
 
 SEC("kprobe/attach_recursive_mnt")
 int kprobe__attach_recursive_mnt(struct pt_regs *ctx) {
-    struct syscall_cache_t *syscall = peek_syscall(SYSCALL_MOUNT);
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_MOUNT);
     if (!syscall)
         return 0;
 
@@ -55,7 +55,7 @@ int kprobe__attach_recursive_mnt(struct pt_regs *ctx) {
 
 SEC("kprobe/propagate_mnt")
 int kprobe__propagate_mnt(struct pt_regs *ctx) {
-    struct syscall_cache_t *syscall = peek_syscall(SYSCALL_MOUNT);
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_MOUNT);
     if (!syscall)
         return 0;
 
@@ -76,13 +76,8 @@ int kprobe__propagate_mnt(struct pt_regs *ctx) {
     return 0;
 }
 
-SYSCALL_COMPAT_KRETPROBE(mount) {
-    struct syscall_cache_t *syscall = pop_syscall(SYSCALL_MOUNT);
-    if (!syscall)
-        return 0;
-
-    int retval = PT_REGS_RC(ctx);
-    if (retval)
+int __attribute__((always_inline)) do_sys_mount_ret(void *ctx, struct syscall_cache_t *syscall) {
+    if (syscall->retval)
         return 0;
 
     struct dentry *dentry = get_mountpoint_dentry(syscall->mount.dest_mountpoint);
@@ -92,7 +87,7 @@ SYSCALL_COMPAT_KRETPROBE(mount) {
     };
 
     struct mount_event_t event = {
-        .syscall.retval = retval,
+        .syscall.retval = syscall->retval,
         .mount_id = get_mount_mount_id(syscall->mount.src_mnt),
         .group_id = get_mount_peer_group_id(syscall->mount.src_mnt),
         .device = get_mount_dev(syscall->mount.src_mnt),
@@ -115,6 +110,24 @@ SYSCALL_COMPAT_KRETPROBE(mount) {
     send_event(ctx, EVENT_MOUNT, event);
 
     return 0;
+}
+
+SEC("tracepoint/handle_sys_mount_exit")
+int handle_sys_mount_exit(void *ctx) {
+    struct syscall_cache_t *syscall = pop_syscall(EVENT_MOUNT);
+    if (!syscall)
+        return 0;
+
+    return do_sys_mount_ret(ctx, syscall);
+}
+
+SYSCALL_COMPAT_KRETPROBE(mount) {
+    struct syscall_cache_t *syscall = pop_syscall(EVENT_MOUNT);
+    if (!syscall)
+        return 0;
+
+    syscall->retval = PT_REGS_RC(ctx);
+    return do_sys_mount_ret(ctx, syscall);
 }
 
 #endif

--- a/pkg/security/ebpf/c/open.h
+++ b/pkg/security/ebpf/c/open.h
@@ -32,7 +32,7 @@ int __attribute__((always_inline)) trace__sys_openat(int flags, umode_t mode) {
     }
 
     struct syscall_cache_t syscall = {
-        .type = SYSCALL_OPEN,
+        .type = EVENT_OPEN,
         .policy = policy,
         .open = {
             .flags = flags,
@@ -128,7 +128,7 @@ int __attribute__((always_inline)) handle_open_event(struct syscall_cache_t *sys
 
 SEC("kprobe/vfs_truncate")
 int kprobe__vfs_truncate(struct pt_regs *ctx) {
-    struct syscall_cache_t *syscall = peek_syscall(SYSCALL_OPEN);
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_OPEN);
     if (!syscall)
         return 0;
 
@@ -153,7 +153,7 @@ int kprobe__vfs_truncate(struct pt_regs *ctx) {
 
 SEC("kprobe/vfs_open")
 int kprobe__vfs_open(struct pt_regs *ctx) {
-    struct syscall_cache_t *syscall = peek_syscall(SYSCALL_OPEN);
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_OPEN);
     if (!syscall)
         return 0;
 
@@ -167,7 +167,7 @@ int kprobe__vfs_open(struct pt_regs *ctx) {
 
 SEC("kprobe/do_dentry_open")
 int kprobe__do_dentry_open(struct pt_regs *ctx) {
-    struct syscall_cache_t *syscall = peek_syscall(SYSCALL_EXEC);
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_EXEC);
     if (!syscall)
         return 0;
 
@@ -197,7 +197,7 @@ int kprobe__io_openat2(struct pt_regs *ctx) {
         return 0;
     }
 
-    struct syscall_cache_t *syscall = peek_syscall(SYSCALL_OPEN);
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_OPEN);
     if (!syscall) {
         unsigned int flags = req.how.flags & VALID_OPEN_FLAGS;
         umode_t mode = req.how.mode & S_IALLUGO;
@@ -206,14 +206,17 @@ int kprobe__io_openat2(struct pt_regs *ctx) {
     return 0;
 }
 
-int __attribute__((always_inline)) _do_sys_open_ret(struct syscall_cache_t *syscall, void *ctx, int retval) {
+int __attribute__((always_inline)) do_sys_open_ret(void *ctx, struct syscall_cache_t *syscall) {
+    if (IS_UNHANDLED_ERROR(syscall->retval))
+        return 0;
+
     // increase mount ref
     inc_mount_ref(syscall->open.file.path_key.mount_id);
     if (syscall->discarded)
         return 0;
 
     struct open_event_t event = {
-        .syscall.retval = retval,
+        .syscall.retval = syscall->retval,
         .file = syscall->open.file,
         .flags = syscall->open.flags,
         .mode = syscall->open.mode,
@@ -222,7 +225,7 @@ int __attribute__((always_inline)) _do_sys_open_ret(struct syscall_cache_t *sysc
     fill_file_metadata(syscall->open.dentry, &event.file.metadata);
 
     int ret = resolve_dentry(syscall->open.dentry, syscall->open.file.path_key, syscall->policy.mode != NO_FILTER ? EVENT_OPEN : 0);
-    if (ret == DENTRY_DISCARDED || (ret == DENTRY_INVALID && !(IS_UNHANDLED_ERROR(retval)))) {
+    if (ret == DENTRY_DISCARDED || (ret == DENTRY_INVALID && !(IS_UNHANDLED_ERROR(syscall->retval)))) {
        return 0;
     }
 
@@ -234,20 +237,22 @@ int __attribute__((always_inline)) _do_sys_open_ret(struct syscall_cache_t *sysc
     return 0;
 }
 
-int __attribute__((always_inline)) do_sys_open_ret(struct pt_regs *ctx, int retval) {
-    struct syscall_cache_t *syscall = pop_syscall(SYSCALL_OPEN);
+SEC("tracepoint/handle_sys_open_exit")
+int handle_sys_open_exit(void *ctx) {
+    struct syscall_cache_t *syscall = pop_syscall(EVENT_OPEN);
     if (!syscall)
         return 0;
 
-    return _do_sys_open_ret(syscall, ctx, retval);
+    return do_sys_open_ret(ctx, syscall);
 }
 
 int __attribute__((always_inline)) trace__sys_open_ret(struct pt_regs *ctx) {
-    int retval = PT_REGS_RC(ctx);
-    if (IS_UNHANDLED_ERROR(retval))
+    struct syscall_cache_t *syscall = pop_syscall(EVENT_OPEN);
+    if (!syscall)
         return 0;
 
-    return do_sys_open_ret(ctx, retval);
+    syscall->retval = PT_REGS_RC(ctx);
+    return do_sys_open_ret(ctx, syscall);
 }
 
 SYSCALL_KRETPROBE(creat) {
@@ -280,7 +285,11 @@ int kretprobe__io_openat2(struct pt_regs *ctx) {
     if (IS_ERR(f))
         return 0;
 
-    return do_sys_open_ret(ctx, 0);
+    struct syscall_cache_t *syscall = pop_syscall(EVENT_OPEN);
+    if (!syscall)
+        return 0;
+
+    return do_sys_open_ret(ctx, syscall);
 }
 
 SEC("kprobe/filp_close")

--- a/pkg/security/ebpf/c/prebuilt/probe.c
+++ b/pkg/security/ebpf/c/prebuilt/probe.c
@@ -51,8 +51,7 @@ void __attribute__((always_inline)) invalidate_inode(struct pt_regs *ctx, u32 mo
 
     if (!is_flushing_discarders()) {
         // remove both regular and parent discarders
-        remove_inode_discarder(mount_id, inode, 1);
-        remove_inode_discarder(mount_id, inode, 0);
+        remove_inode_discarders(mount_id, inode);
     }
 
     if (send_invalidate_event) {

--- a/pkg/security/ebpf/c/prebuilt/probe.c
+++ b/pkg/security/ebpf/c/prebuilt/probe.c
@@ -32,11 +32,11 @@
 #include "mount.h"
 #include "umount.h"
 #include "link.h"
-#include "raw_syscalls.h"
 #include "procfs.h"
 #include "setxattr.h"
 #include "erpc.h"
 #include "ioctl.h"
+#include "raw_syscalls.h"
 
 struct invalidate_dentry_event_t {
     struct kevent_t event;

--- a/pkg/security/ebpf/c/raw_syscalls.h
+++ b/pkg/security/ebpf/c/raw_syscalls.h
@@ -22,6 +22,13 @@ struct bpf_map_def SEC("maps/concurrent_syscalls") concurrent_syscalls = {
     .namespace = "",
 };
 
+struct bpf_map_def SEC("maps/sys_exit_progs") sys_exit_progs = {
+    .type = BPF_MAP_TYPE_PROG_ARRAY,
+    .key_size = sizeof(u32),
+    .value_size = sizeof(u32),
+    .max_entries = 64,
+};
+
 #define CONCURRENT_SYSCALLS_COUNTER 0
 
 struct _tracepoint_raw_syscalls_sys_exit
@@ -88,16 +95,14 @@ int sys_enter(struct _tracepoint_raw_syscalls_sys_enter *args) {
     return 0;
 }
 
+// used as fallback for kernel < 4.12
 int __attribute__((always_inline)) handle_sys_exit(struct _tracepoint_raw_syscalls_sys_exit *args) {
-    struct syscall_cache_t *syscall = pop_syscall(0);
-    if (!syscall) {
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_ANY);
+    if (!syscall)
         return 0;
-    }
 
-    switch(syscall->type) {
-        case SYSCALL_OPEN:
-            return _do_sys_open_ret(syscall, args, args->ret);
-    }
+    syscall->retval = args->ret;
+    bpf_tail_call(args, &sys_exit_progs, syscall->type);
 
     return 0;
 }

--- a/pkg/security/ebpf/c/rmdir.h
+++ b/pkg/security/ebpf/c/rmdir.h
@@ -20,7 +20,7 @@ int __attribute__((always_inline)) unlink_approvers(struct syscall_cache_t *sysc
 
 SYSCALL_KPROBE0(rmdir) {
     struct syscall_cache_t syscall = {
-        .type = SYSCALL_RMDIR,
+        .type = EVENT_RMDIR,
         .policy = fetch_policy(EVENT_RMDIR),
     };
 
@@ -32,18 +32,15 @@ SYSCALL_KPROBE0(rmdir) {
 // security_inode_rmdir is shared between rmdir and unlink syscalls
 SEC("kprobe/security_inode_rmdir")
 int kprobe__security_inode_rmdir(struct pt_regs *ctx) {
-    struct syscall_cache_t *syscall = peek_syscall(SYSCALL_RMDIR | SYSCALL_UNLINK);
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_ANY);
     if (!syscall)
         return 0;
 
-    u64 event_type = 0;
     struct path_key_t key = {};
     struct dentry *dentry = NULL;
 
     switch (syscall->type) {
-        case SYSCALL_RMDIR:
-            event_type = EVENT_RMDIR;
-
+        case EVENT_RMDIR:
             if (syscall->rmdir.file.path_key.ino) {
                 return 0;
             }
@@ -62,9 +59,7 @@ int kprobe__security_inode_rmdir(struct pt_regs *ctx) {
             }
 
             break;
-        case SYSCALL_UNLINK:
-            event_type = EVENT_UNLINK;
-
+        case EVENT_UNLINK:
             if (syscall->unlink.file.path_key.ino) {
                 return 0;
             }
@@ -84,14 +79,16 @@ int kprobe__security_inode_rmdir(struct pt_regs *ctx) {
             }
 
             break;
+        default:
+            return 0;
     }
 
-    if (is_discarded_by_process(syscall->policy.mode, event_type)) {
+    if (is_discarded_by_process(syscall->policy.mode, syscall->type)) {
         return mark_as_discarded(syscall);
     }
 
     if (dentry != NULL) {
-        int ret = resolve_dentry(dentry, key, syscall->policy.mode != NO_FILTER ? event_type : 0);
+        int ret = resolve_dentry(dentry, key, syscall->policy.mode != NO_FILTER ? syscall->type : 0);
         if (ret == DENTRY_DISCARDED) {
             return mark_as_discarded(syscall);
         }
@@ -100,20 +97,15 @@ int kprobe__security_inode_rmdir(struct pt_regs *ctx) {
     return 0;
 }
 
-SYSCALL_KRETPROBE(rmdir) {
-    struct syscall_cache_t *syscall = pop_syscall(SYSCALL_RMDIR | SYSCALL_UNLINK);
-    if (!syscall)
-        return 0;
-
-    int retval = PT_REGS_RC(ctx);
-    if (IS_UNHANDLED_ERROR(retval)) {
+int __attribute__((always_inline)) do_sys_rmdir_ret(void *ctx, struct syscall_cache_t *syscall) {
+    if (IS_UNHANDLED_ERROR(syscall->retval)) {
         return 0;
     }
 
     int pass_to_userspace = !syscall->discarded && is_event_enabled(EVENT_RMDIR);
     if (pass_to_userspace) {
         struct rmdir_event_t event = {
-            .syscall.retval = retval,
+            .syscall.retval = syscall->retval,
             .file = syscall->rmdir.file,
             .discarder_revision = bump_discarder_revision(syscall->rmdir.file.path_key.mount_id),
         };
@@ -127,6 +119,28 @@ SYSCALL_KRETPROBE(rmdir) {
     invalidate_inode(ctx, syscall->rmdir.file.path_key.mount_id, syscall->rmdir.file.path_key.ino, !pass_to_userspace);
 
     return 0;
+}
+
+SEC("tracepoint/handle_sys_rmdir_exit")
+int handle_sys_rmdir_exit(void *ctx) {
+    struct syscall_cache_t *syscall = pop_syscall(EVENT_RMDIR);
+    if (!syscall)
+        return 0;
+
+    return do_sys_rmdir_ret(ctx, syscall);
+}
+
+int __attribute__((always_inline)) rmdir_predicate(u64 type) {
+    return type == EVENT_RMDIR || type == EVENT_UNLINK;
+}
+
+SYSCALL_KRETPROBE(rmdir) {
+    struct syscall_cache_t *syscall = pop_syscall_with(rmdir_predicate);
+    if (!syscall)
+        return 0;
+
+    syscall->retval = PT_REGS_RC(ctx);
+    return do_sys_rmdir_ret(ctx, syscall);
 }
 
 #endif

--- a/pkg/security/ebpf/c/setxattr.h
+++ b/pkg/security/ebpf/c/setxattr.h
@@ -19,7 +19,7 @@ int __attribute__((always_inline)) trace__sys_setxattr(const char *xattr_name) {
     }
 
     struct syscall_cache_t syscall = {
-        .type = SYSCALL_SETXATTR,
+        .type = EVENT_SETXATTR,
         .policy = policy,
         .xattr = {
             .name = xattr_name,
@@ -50,7 +50,7 @@ int __attribute__((always_inline)) trace__sys_removexattr(const char *xattr_name
     }
 
     struct syscall_cache_t syscall = {
-        .type = SYSCALL_REMOVEXATTR,
+        .type = EVENT_REMOVEXATTR,
         .policy = policy,
         .xattr = {
             .name = xattr_name,
@@ -75,7 +75,7 @@ SYSCALL_KPROBE2(fremovexattr, int, fd, const char *, name) {
 }
 
 int __attribute__((always_inline)) trace__vfs_setxattr(struct pt_regs *ctx, u64 event_type) {
-    struct syscall_cache_t *syscall = peek_syscall(1 << event_type);
+    struct syscall_cache_t *syscall = peek_syscall(event_type);
     if (!syscall)
         return 0;
 
@@ -107,17 +107,12 @@ int kprobe__vfs_removexattr(struct pt_regs *ctx) {
     return trace__vfs_setxattr(ctx, EVENT_REMOVEXATTR);
 }
 
-int __attribute__((always_inline)) trace__sys_setxattr_ret(struct pt_regs *ctx, u64 event_type) {
-    struct syscall_cache_t *syscall = pop_syscall(1 << event_type);
-    if (!syscall)
-        return 0;
-
-    int retval = PT_REGS_RC(ctx);
-    if (IS_UNHANDLED_ERROR(retval))
+int __attribute__((always_inline)) _do_sys_setxattr_ret(void *ctx, struct syscall_cache_t *syscall, u64 event_type) {
+    if (IS_UNHANDLED_ERROR(syscall->retval))
         return 0;
 
     struct setxattr_event_t event = {
-        .syscall.retval = retval,
+        .syscall.retval = syscall->retval,
         .file = syscall->xattr.file,
     };
 
@@ -133,28 +128,72 @@ int __attribute__((always_inline)) trace__sys_setxattr_ret(struct pt_regs *ctx, 
     return 0;
 }
 
+int __attribute__((always_inline)) do_sys_setxattr_ret(void *ctx, struct syscall_cache_t *syscall) {
+    return _do_sys_setxattr_ret(ctx, syscall, EVENT_SETXATTR);
+}
+
+SEC("tracepoint/handle_sys_setxattr_exit")
+int handle_sys_setxattr_exit(void *ctx) {
+    struct syscall_cache_t *syscall = pop_syscall(EVENT_SETXATTR);
+    if (!syscall)
+        return 0;
+
+    return do_sys_setxattr_ret(ctx, syscall);
+}
+
+int __attribute__((always_inline)) do_sys_removexattr_ret(void *ctx, struct syscall_cache_t *syscall) {
+    return _do_sys_setxattr_ret(ctx, syscall, EVENT_REMOVEXATTR);
+}
+
+SEC("tracepoint/handle_sys_removexattr_exit")
+int handle_sys_removexattr_exit(void *ctx) {
+    struct syscall_cache_t *syscall = pop_syscall(EVENT_REMOVEXATTR);
+    if (!syscall)
+        return 0;
+
+    return do_sys_removexattr_ret(ctx, syscall);
+}
+
+int __attribute__((always_inline)) trace__sys_setxattr_ret(struct pt_regs *ctx) {
+    struct syscall_cache_t *syscall = pop_syscall(EVENT_SETXATTR);
+    if (!syscall)
+        return 0;
+
+    syscall->retval = PT_REGS_RC(ctx);
+    return do_sys_setxattr_ret(ctx, syscall);
+}
+
+int __attribute__((always_inline)) trace__sys_removexattr_ret(struct pt_regs *ctx) {
+    struct syscall_cache_t *syscall = pop_syscall(EVENT_REMOVEXATTR);
+    if (!syscall)
+        return 0;
+
+    syscall->retval = PT_REGS_RC(ctx);
+    return do_sys_setxattr_ret(ctx, syscall);
+}
+
 SYSCALL_KRETPROBE(setxattr) {
-    return trace__sys_setxattr_ret(ctx, EVENT_SETXATTR);
+    return trace__sys_setxattr_ret(ctx);
 }
 
 SYSCALL_KRETPROBE(fsetxattr) {
-    return trace__sys_setxattr_ret(ctx, EVENT_SETXATTR);
+    return trace__sys_setxattr_ret(ctx);
 }
 
 SYSCALL_KRETPROBE(lsetxattr) {
-    return trace__sys_setxattr_ret(ctx, EVENT_SETXATTR);
+    return trace__sys_setxattr_ret(ctx);
 }
 
 SYSCALL_KRETPROBE(removexattr) {
-    return trace__sys_setxattr_ret(ctx, EVENT_REMOVEXATTR);
+    return trace__sys_removexattr_ret(ctx);
 }
 
 SYSCALL_KRETPROBE(lremovexattr) {
-    return trace__sys_setxattr_ret(ctx, EVENT_REMOVEXATTR);
+    return trace__sys_removexattr_ret(ctx);
 }
 
 SYSCALL_KRETPROBE(fremovexattr) {
-    return trace__sys_setxattr_ret(ctx, EVENT_REMOVEXATTR);
+    return trace__sys_removexattr_ret(ctx);
 }
 
 #endif

--- a/pkg/security/ebpf/c/syscalls.h
+++ b/pkg/security/ebpf/c/syscalls.h
@@ -17,7 +17,6 @@ struct syscall_cache_t {
     struct policy_t policy;
     u64 type;
     u32 discarded;
-    u64 retval;
 
     union {
         struct {

--- a/pkg/security/ebpf/c/syscalls.h
+++ b/pkg/security/ebpf/c/syscalls.h
@@ -17,6 +17,7 @@ struct syscall_cache_t {
     struct policy_t policy;
     u64 type;
     u32 discarded;
+    u64 retval;
 
     union {
         struct {
@@ -137,8 +138,37 @@ void __attribute__((always_inline)) cache_syscall(struct syscall_cache_t *syscal
 struct syscall_cache_t * __attribute__((always_inline)) peek_syscall(u64 type) {
     u64 key = bpf_get_current_pid_tgid();
     struct syscall_cache_t *syscall = (struct syscall_cache_t *) bpf_map_lookup_elem(&syscalls, &key);
-    if (syscall && (syscall->type & type) > 0)
+    if (!syscall) {
+        return NULL;
+    }
+    if (!type || syscall->type == type) {
         return syscall;
+    }
+    return NULL;
+}
+
+struct syscall_cache_t * __attribute__((always_inline)) peek_syscall_with(int (*predicate)(u64 type)) {
+    u64 key = bpf_get_current_pid_tgid();
+    struct syscall_cache_t *syscall = (struct syscall_cache_t *) bpf_map_lookup_elem(&syscalls, &key);
+    if (!syscall) {
+        return NULL;
+    }
+    if (predicate(syscall->type)) {
+        return syscall;
+    }
+    return NULL;
+}
+
+struct syscall_cache_t * __attribute__((always_inline)) pop_syscall_with(int (*predicate)(u64 type)) {
+    u64 key = bpf_get_current_pid_tgid();
+    struct syscall_cache_t *syscall = (struct syscall_cache_t *) bpf_map_lookup_elem(&syscalls, &key);
+    if (!syscall) {
+        return NULL;
+    }
+    if (predicate(syscall->type)) {
+        bpf_map_delete_elem(&syscalls, &key);
+        return syscall;
+    }
     return NULL;
 }
 
@@ -148,7 +178,7 @@ struct syscall_cache_t * __attribute__((always_inline)) pop_syscall(u64 type) {
     if (!syscall) {
         return NULL;
     }
-    if (!type || (syscall->type & type) > 0) {
+    if (!type || syscall->type == type) {
         bpf_map_delete_elem(&syscalls, &key);
         return syscall;
     }

--- a/pkg/security/ebpf/c/syscalls.h
+++ b/pkg/security/ebpf/c/syscalls.h
@@ -145,7 +145,10 @@ struct syscall_cache_t * __attribute__((always_inline)) peek_syscall(u64 type) {
 struct syscall_cache_t * __attribute__((always_inline)) pop_syscall(u64 type) {
     u64 key = bpf_get_current_pid_tgid();
     struct syscall_cache_t *syscall = (struct syscall_cache_t *) bpf_map_lookup_elem(&syscalls, &key);
-    if (syscall && (syscall->type & type) > 0) {
+    if (!syscall) {
+        return NULL;
+    }
+    if (!type || (syscall->type & type) > 0) {
         bpf_map_delete_elem(&syscalls, &key);
         return syscall;
     }

--- a/pkg/security/ebpf/c/umount.h
+++ b/pkg/security/ebpf/c/umount.h
@@ -18,7 +18,7 @@ SYSCALL_KPROBE0(umount) {
 SEC("kprobe/security_sb_umount")
 int kprobe__security_sb_umount(struct pt_regs *ctx) {
     struct syscall_cache_t syscall = {
-        .type = SYSCALL_UMOUNT,
+        .type = EVENT_UMOUNT,
         .umount = {
             .vfs = (struct vfsmount *)PT_REGS_PARM1(ctx),
         }
@@ -28,19 +28,14 @@ int kprobe__security_sb_umount(struct pt_regs *ctx) {
     return 0;
 }
 
-SYSCALL_KRETPROBE(umount) {
-    struct syscall_cache_t *syscall = pop_syscall(SYSCALL_UMOUNT);
-    if (!syscall)
-        return 0;
-
-    int retval = PT_REGS_RC(ctx);
-    if (retval)
+int __attribute__((always_inline)) do_sys_umount_ret(void *ctx, struct syscall_cache_t *syscall) {
+    if (syscall->retval)
         return 0;
 
     int mount_id = get_vfsmount_mount_id(syscall->umount.vfs);
 
     struct umount_event_t event = {
-        .syscall .retval = retval,
+        .syscall .retval = syscall->retval,
         .mount_id = mount_id
     };
 
@@ -52,6 +47,24 @@ SYSCALL_KRETPROBE(umount) {
     umounted(ctx, mount_id);
 
     return 0;
+}
+
+SEC("tracepoint/handle_sys_umount_exit")
+int handle_sys_umount_exit(void *ctx) {
+    struct syscall_cache_t *syscall = pop_syscall(EVENT_UMOUNT);
+    if (!syscall)
+        return 0;
+
+    return do_sys_umount_ret(ctx, syscall);
+}
+
+SYSCALL_KRETPROBE(umount) {
+    struct syscall_cache_t *syscall = pop_syscall(EVENT_UMOUNT);
+    if (!syscall)
+        return 0;
+
+    syscall->retval = PT_REGS_RC(ctx);
+    return do_sys_umount_ret(ctx, syscall);
 }
 
 #endif

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -7,7 +7,10 @@
 
 package probes
 
-import "github.com/DataDog/ebpf/manager"
+import (
+	"github.com/DataDog/datadog-agent/pkg/security/model"
+	"github.com/DataDog/ebpf/manager"
+)
 
 // allProbes contain the list of all the probes of the runtime security module
 var allProbes []*manager.Probe
@@ -94,10 +97,107 @@ func AllPerfMaps() []*manager.PerfMap {
 	}
 }
 
+func getSysExitTailCallRoutes() []manager.TailCallRoute {
+	return []manager.TailCallRoute{
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileChmodEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_chmod_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileChownEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_chown_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileLinkEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_link_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileMkdirEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_mkdir_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileMountEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_mount_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileOpenEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_open_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileRenameEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_rename_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileRmdirEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_rmdir_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileSetXAttrEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_setxattr_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileRemoveXAttrEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_removexattr_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileUmountEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_umount_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileUnlinkEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_unlink_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileUtimeEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_utimes_exit",
+			},
+		},
+	}
+}
+
 // AllTailRoutes returns the list of all the tail call routes
 func AllTailRoutes() []manager.TailCallRoute {
 	var routes []manager.TailCallRoute
 
+	routes = append(routes, getSysExitTailCallRoutes()...)
 	routes = append(routes, getExecTailCallRoutes()...)
 
 	return routes

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -16,7 +16,6 @@ import (
 // SyscallMonitorSelectors is the list of probes that should be activated for the syscall monitor feature
 var SyscallMonitorSelectors = []manager.ProbesSelector{
 	&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "tracepoint/raw_syscalls/sys_enter"}},
-	&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "tracepoint/raw_syscalls/sys_exit"}},
 	&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "tracepoint/sched/sched_process_exec"}},
 }
 
@@ -27,6 +26,7 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 	"*": {
 		// Exec probes
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "tracepoint/raw_syscalls/sys_exit"}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "tracepoint/sched/sched_process_fork"}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/do_exit"}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/security_bprm_committed_creds"}},

--- a/pkg/security/ebpf/probes/exec.go
+++ b/pkg/security/ebpf/probes/exec.go
@@ -8,8 +8,6 @@
 package probes
 
 import (
-	"fmt"
-
 	"github.com/DataDog/ebpf/manager"
 )
 
@@ -123,7 +121,7 @@ func getExecTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "args_envs_progs",
 			Key:           i,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: fmt.Sprintf("kprobe/parse_args_envs"),
+				Section: "kprobe/parse_args_envs",
 			},
 		}
 		routes = append(routes, route)

--- a/pkg/security/model/model.go
+++ b/pkg/security/model/model.go
@@ -153,6 +153,8 @@ func (e *Event) GetEventType() EventType {
 // GetTags returns the list of tags specific to this event
 func (e *Event) GetTags() []string {
 	tags := []string{"type:" + e.GetType()}
+
+	// should already be resolved at this stage
 	if len(e.ContainerContext.Tags) > 0 {
 		tags = append(tags, e.ContainerContext.Tags...)
 	}

--- a/pkg/security/model/strings.go
+++ b/pkg/security/model/strings.go
@@ -16,10 +16,20 @@ func IsAlphaNumeric(r rune) bool {
 	return unicode.IsOneOf(alphaNumericRange, r)
 }
 
-// IsPrintable returns whether the string does contain only ascii
+// IsPrintable returns whether the string does contain only unicode printable
 func IsPrintable(s string) bool {
 	for _, c := range s {
 		if !unicode.IsOneOf(unicode.PrintRanges, c) {
+			return false
+		}
+	}
+	return true
+}
+
+// IsPrintableASCII returns whether the string does contain only ASCII char
+func IsPrintableASCII(s string) bool {
+	for _, c := range s {
+		if (c < 'A' || c > 'B') && (c < 'a' || c > 'z') && c != '/' && c != ':' && c != '-' && (c < '0' || c > '9') {
 			return false
 		}
 	}

--- a/pkg/security/model/strings_test.go
+++ b/pkg/security/model/strings_test.go
@@ -17,3 +17,11 @@ func TestIsPrintable(t *testing.T) {
 	assert.Equal(t, false, IsPrintable("\n"))
 	assert.Equal(t, false, IsPrintable("\u001d"))
 }
+
+func TestIsPrintableASCII(t *testing.T) {
+	assert.Equal(t, true, IsPrintableASCII("A-B"))
+	assert.Equal(t, true, IsPrintableASCII("A/B"))
+	assert.Equal(t, true, IsPrintableASCII("/dev/pts2"))
+	assert.Equal(t, false, IsPrintableASCII("\n"))
+	assert.Equal(t, false, IsPrintableASCII("\u001d"))
+}

--- a/pkg/security/model/unmarshallers.go
+++ b/pkg/security/model/unmarshallers.go
@@ -141,7 +141,7 @@ func (e *Process) UnmarshalBinary(data []byte) (int, error) {
 	var ttyRaw [64]byte
 	SliceToArray(data[read:read+64], unsafe.Pointer(&ttyRaw))
 	ttyName := string(bytes.Trim(ttyRaw[:], "\x00"))
-	if IsPrintable(ttyName) {
+	if IsPrintableASCII(ttyName) {
 		e.TTYName = ttyName
 	}
 	read += 64

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -255,6 +255,9 @@ func (m *Module) HandleCustomEvent(rule *rules.Rule, event *sprobe.CustomEvent) 
 
 // RuleMatch is called by the ruleset when a rule matches
 func (m *Module) RuleMatch(rule *rules.Rule, event eval.Event) {
+	// prepare the event
+	m.probe.OnRuleMatch(rule, event.(*probe.Event))
+
 	m.SendEvent(rule, event)
 }
 

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -185,6 +185,9 @@ func (m *Module) Reload() error {
 		return err
 	}
 
+	atomic.StoreUint64(&m.currentRuleSet, 1-m.currentRuleSet)
+	m.ruleSets[m.currentRuleSet] = ruleSet
+
 	// analyze the ruleset, push default policies in the kernel and generate the policy report
 	report, err := rsa.Apply(ruleSet, approvers)
 	if err != nil {
@@ -200,9 +203,6 @@ func (m *Module) Reload() error {
 
 	m.apiServer.Apply(ruleIDs)
 	m.rateLimiter.Apply(ruleIDs)
-
-	atomic.StoreUint64(&m.currentRuleSet, 1-m.currentRuleSet)
-	m.ruleSets[m.currentRuleSet] = ruleSet
 
 	m.displayReport(report)
 

--- a/pkg/security/probe/applier.go
+++ b/pkg/security/probe/applier.go
@@ -93,13 +93,13 @@ func (rsa *RuleSetApplier) setupFilters(rs *rules.RuleSet, eventType eval.EventT
 // Apply setup the filters for the provided set of rules and returns the policy report.
 func (rsa *RuleSetApplier) Apply(rs *rules.RuleSet, approvers map[eval.EventType]rules.Approvers) (*Report, error) {
 	if rsa.probe != nil {
-		if err := rsa.probe.FlushDiscarders(); err != nil {
-			return nil, errors.Wrap(err, "failed to flush discarders")
-		}
-
 		// based on the ruleset and the requested rules, select the probes that need to be activated
 		if err := rsa.probe.SelectProbes(rs); err != nil {
 			return nil, errors.Wrap(err, "failed to select probes")
+		}
+
+		if err := rsa.probe.FlushDiscarders(); err != nil {
+			return nil, errors.Wrap(err, "failed to flush discarders")
 		}
 	}
 

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -206,6 +206,10 @@ func (id *inodeDiscarders) initRevision(mountEvent *model.MountEvent) {
 	}
 }
 
+var (
+	discarderEvent = NewEvent(nil, nil)
+)
+
 // Important should always be called after having checked that the file is not a discarder itself otherwise it can report incorrect
 // parent discarder
 func isParentPathDiscarder(rs *rules.RuleSet, regexCache *simplelru.LRU, eventType model.EventType, filenameField eval.Field, filename string) (bool, error) {
@@ -218,7 +222,11 @@ func isParentPathDiscarder(rs *rules.RuleSet, regexCache *simplelru.LRU, eventTy
 
 	basenameField := strings.Replace(filenameField, ".path", ".name", 1)
 
-	event := NewEvent(nil, nil)
+	event := discarderEvent
+	defer func() {
+		*discarderEvent = eventZero
+	}()
+
 	if _, err := event.GetFieldType(filenameField); err != nil {
 		return false, nil
 	}

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -342,13 +342,13 @@ func filenameDiscarderWrapper(eventType model.EventType, handler onDiscarderHand
 			isDiscarded, _, parentInode, err := probe.inodeDiscarders.discardParentInode(rs, eventType, field, filename, mountID, inode, pathID)
 			if !isDiscarded && !isDeleted {
 				if _, ok := err.(*ErrInvalidKeyPath); !ok {
-					log.Tracef("Apply `%s.file.path` inode discarder for event `%s`, inode: %d", eventType, eventType, inode)
+					log.Tracef("Apply `%s.file.path` inode discarder for event `%s`, inode: %d(%s)", eventType, eventType, inode, filename)
 
 					// not able to discard the parent then only discard the filename
 					err = probe.inodeDiscarders.discardInode(eventType, mountID, inode, true)
 				}
 			} else {
-				log.Tracef("Apply `%s.file.path` parent inode discarder for event `%s` with value `%s`", eventType, eventType, filename)
+				log.Tracef("Apply `%s.file.path` parent inode discarder for event `%s`, inode: %d(%s)", eventType, eventType, parentInode, filename)
 			}
 
 			if err != nil {

--- a/pkg/security/probe/kernel.go
+++ b/pkg/security/probe/kernel.go
@@ -21,6 +21,7 @@ import (
 
 var (
 	// KERNEL_VERSION(a,b,c) = (a << 16) + (b << 8) + (c)
+	kernel4_12 = kernel.VersionCode(4, 12, 0) //nolint:deadcode,unused
 	kernel4_13 = kernel.VersionCode(4, 13, 0) //nolint:deadcode,unused
 	kernel4_16 = kernel.VersionCode(4, 16, 0) //nolint:deadcode,unused
 	kernel5_3  = kernel.VersionCode(5, 3, 0)  //nolint:deadcode,unused

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -20,6 +20,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/eval"
 )
 
+var eventZero Event
+
 // Model describes the data model for the runtime security agent probe events
 type Model struct {
 	model.Model

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -820,6 +820,22 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, erpc.GetConstants()...)
 	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, DiscarderConstants...)
 
+	// kretprobe fallback for kernel < 4.12
+	if p.kernelVersion < kernel4_12 {
+		p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, manager.ConstantEditor{
+			Name:  "kretprobe_fallback",
+			Value: uint64(1),
+		})
+	}
+
+	// constants syscall monitor
+	if p.config.SyscallMonitor {
+		p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, manager.ConstantEditor{
+			Name:  "syscall_monitor",
+			Value: uint64(1),
+		})
+	}
+
 	// tail calls
 	p.managerOptions.TailCallRouter = probes.AllTailRoutes()
 

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -506,6 +506,12 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 	p.DispatchEvent(event, dataLen, int(CPU), p.perfMap)
 }
 
+// OnRuleMatch is called when a rule matches just before sending
+func (p *Probe) OnRuleMatch(rule *rules.Rule, event *Event) {
+	// ensure that all the fields are resolved before sending
+	event.ResolveContainerTags(&event.ContainerContext)
+}
+
 // OnNewDiscarder is called when a new discarder is found
 func (p *Probe) OnNewDiscarder(rs *rules.RuleSet, event *Event, field eval.Field, eventType eval.EventType) error {
 	// discarders disabled

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -651,7 +651,7 @@ func (p *Probe) SelectProbes(rs *rules.RuleSet) error {
 
 // FlushDiscarders removes all the discarders
 func (p *Probe) FlushDiscarders() error {
-	log.Debugf("Freezing discarders")
+	log.Debug("Freezing discarders")
 
 	flushingMap, err := p.Map("flushing_discarders")
 	if err != nil {

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -256,8 +256,6 @@ func (p *Probe) handleLostEvents(CPU int, count uint64, perfMap *manager.PerfMap
 	p.monitor.perfBufferMonitor.CountLostEvent(count, perfMap, CPU)
 }
 
-var eventZero Event
-
 func (p *Probe) zeroEvent() *Event {
 	*p.event = eventZero
 	return p.event

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -95,6 +95,9 @@ func TestOpenLeafDiscarderFilter(t *testing.T) {
 	}
 	defer test.Close()
 
+	// ensure that all the previous discarder are removed or the retention periode is over
+	time.Sleep(probe.DiscardRetention * 2)
+
 	fd1, testFile1, err := openTestFile(test, "test-obc-2", syscall.O_CREAT|syscall.O_SYNC)
 	if err != nil {
 		t.Fatal(err)
@@ -124,7 +127,7 @@ func TestOpenLeafDiscarderFilter(t *testing.T) {
 func TestOpenParentDiscarderFilter(t *testing.T) {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
-		Expression: `open.file.path =~ "/usr/test-obd-2" && open.flags & (O_CREAT | O_SYNC) > 0`,
+		Expression: `open.file.path =~ "/usr/local/test-obd-2" && open.flags & (O_CREAT | O_SYNC) > 0`,
 	}
 
 	test, err := newTestModule(nil, []*rules.RuleDefinition{rule}, testOpts{wantProbeEvents: true})
@@ -132,6 +135,10 @@ func TestOpenParentDiscarderFilter(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer test.Close()
+
+	// ensure that all the previous discarder are removed or the retention periode is over
+	time.Sleep(probe.DiscardRetention * 2)
+	test.probe.FlushDiscarders()
 
 	fd1, testFile1, err := openTestFile(test, "test-obd-2", syscall.O_CREAT|syscall.O_SYNC)
 	if err != nil {
@@ -215,6 +222,10 @@ func TestOpenProcessPidDiscarder(t *testing.T) {
 	}
 	defer test.Close()
 
+	// ensure that all the previous discarder are removed or the retention periode is over
+	time.Sleep(probe.DiscardRetention * 2)
+	test.probe.FlushDiscarders()
+
 	fd1, testFile1, err := openTestFile(test, "test-oba-1", syscall.O_CREAT)
 	if err != nil {
 		t.Fatal(err)
@@ -255,6 +266,10 @@ func TestDiscarderRetentionFilter(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer test.Close()
+
+	// ensure that all the previous discarder are removed or the retention periode is over
+	time.Sleep(probe.DiscardRetention * 2)
+	test.probe.FlushDiscarders()
 
 	fd1, testFile1, err := openTestFile(test, "test-obc-2", syscall.O_CREAT|syscall.O_SYNC)
 	if err != nil {

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -95,8 +95,8 @@ func TestOpenLeafDiscarderFilter(t *testing.T) {
 	}
 	defer test.Close()
 
-	// ensure that all the previous discarder are removed or the retention periode is over
-	time.Sleep(probe.DiscardRetention * 2)
+	// ensure that all the previous discarder are removed
+	test.probe.FlushDiscarders()
 
 	fd1, testFile1, err := openTestFile(test, "test-obc-2", syscall.O_CREAT|syscall.O_SYNC)
 	if err != nil {
@@ -136,8 +136,7 @@ func TestOpenParentDiscarderFilter(t *testing.T) {
 	}
 	defer test.Close()
 
-	// ensure that all the previous discarder are removed or the retention periode is over
-	time.Sleep(probe.DiscardRetention * 2)
+	// ensure that all the previous discarder are removed
 	test.probe.FlushDiscarders()
 
 	fd1, testFile1, err := openTestFile(test, "test-obd-2", syscall.O_CREAT|syscall.O_SYNC)
@@ -222,8 +221,7 @@ func TestOpenProcessPidDiscarder(t *testing.T) {
 	}
 	defer test.Close()
 
-	// ensure that all the previous discarder are removed or the retention periode is over
-	time.Sleep(probe.DiscardRetention * 2)
+	// ensure that all the previous discarder are removed
 	test.probe.FlushDiscarders()
 
 	fd1, testFile1, err := openTestFile(test, "test-oba-1", syscall.O_CREAT)
@@ -267,8 +265,7 @@ func TestDiscarderRetentionFilter(t *testing.T) {
 	}
 	defer test.Close()
 
-	// ensure that all the previous discarder are removed or the retention periode is over
-	time.Sleep(probe.DiscardRetention * 2)
+	// ensure that all the previous discarder are removed
 	test.probe.FlushDiscarders()
 
 	fd1, testFile1, err := openTestFile(test, "test-obc-2", syscall.O_CREAT|syscall.O_SYNC)

--- a/pkg/security/tests/overlayfs_test.go
+++ b/pkg/security/tests/overlayfs_test.go
@@ -621,6 +621,9 @@ func TestOverlayFS(t *testing.T) {
 	})
 
 	t.Run("invalidate-discarder", func(t *testing.T) {
+		// ensure that all the previous discarder are removed
+		test.probe.FlushDiscarders()
+
 		testFile, _, err := test.Path("bind/discarded.txt")
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -395,10 +395,6 @@ func TestProcessContext(t *testing.T) {
 	})
 
 	test.Run(t, "ancestors", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
-		if rhel7 {
-			t.Skip()
-		}
-
 		testFile, _, err := test.Path("test-process-ancestors")
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -434,10 +434,6 @@ func TestProcessContext(t *testing.T) {
 	})
 
 	test.Run(t, "pid1", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
-		if rhel7 {
-			t.Skip()
-		}
-
 		testFile, _, err := test.Path("test-process-pid1")
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -391,6 +391,12 @@ func TestProcessContext(t *testing.T) {
 			if testEnvironment == DockerEnvironment {
 				testContainerPath(t, event, "process.file.container_path")
 			}
+
+			str := event.String()
+
+			if !strings.Contains(str, "pts") {
+				t.Error("tty not serialized")
+			}
 		}
 	})
 

--- a/pkg/security/tests/setup_test.go
+++ b/pkg/security/tests/setup_test.go
@@ -352,16 +352,20 @@ func newTestModule(macros []*rules.MacroDefinition, rules []*rules.RuleDefinitio
 		return nil, err
 	}
 
-	sysprobeConfig, err := setTestConfig(st.root, opts)
+	confDir, err := ioutil.TempDir(st.root, "conf")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(confDir)
+
+	sysprobeConfig, err := setTestConfig(confDir, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	cfgFilename, err := setTestPolicy(st.root, macros, rules)
-	if err != nil {
+	if _, err := setTestPolicy(confDir, macros, rules); err != nil {
 		return nil, err
 	}
-	defer os.Remove(cfgFilename)
 
 	var cmdWrapper cmdWrapper
 	if testEnvironment == DockerEnvironment {

--- a/pkg/security/tests/setup_test.go
+++ b/pkg/security/tests/setup_test.go
@@ -352,20 +352,16 @@ func newTestModule(macros []*rules.MacroDefinition, rules []*rules.RuleDefinitio
 		return nil, err
 	}
 
-	confDir, err := ioutil.TempDir(st.root, "conf")
-	if err != nil {
-		return nil, err
-	}
-	defer os.RemoveAll(confDir)
-
-	sysprobeConfig, err := setTestConfig(confDir, opts)
+	sysprobeConfig, err := setTestConfig(st.root, opts)
 	if err != nil {
 		return nil, err
 	}
 
-	if _, err := setTestPolicy(confDir, macros, rules); err != nil {
+	cfgFilename, err := setTestPolicy(st.root, macros, rules)
+	if err != nil {
 		return nil, err
 	}
+	defer os.Remove(cfgFilename)
 
 	var cmdWrapper cmdWrapper
 	if testEnvironment == DockerEnvironment {


### PR DESCRIPTION
### What does this PR do?

This PR adds a fallback mechanism that uses tracepoint for kernel < 4.12 for `ret` as due to the kretprobe limitation on these kernel generates a lot of event misses.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Re-enabled functionals docker test on centos7 which were failing before the fix. 
