### PR TITLE
Ensure system-probe config is initialized, even for subconfigs

### DIFF
--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -19,11 +19,21 @@ const (
 	defaultOffsetThreshold = 400
 )
 
+func isSystemProbeConfigInit(cfg Config) bool {
+	keys := cfg.GetKnownKeys()
+	_, ok := keys[join(spNS, "enabled")]
+	return ok
+}
+
 // InitSystemProbeConfig declares all the configuration values normally read from system-probe.yaml.
 // This function should not be called before ResolveSecrets,
 // unless you call `cmd/system-probe/config.New` or `cmd/system-probe/config.Merge` in-between.
 // This is to prevent the in-memory values from being fixed before the file-based values have had a chance to be read.
 func InitSystemProbeConfig(cfg Config) {
+	if isSystemProbeConfigInit(cfg) {
+		return
+	}
+
 	// settings for system-probe in general
 	cfg.BindEnvAndSetDefault(join(spNS, "enabled"), false, "DD_SYSTEM_PROBE_ENABLED")
 	cfg.BindEnvAndSetDefault(join(spNS, "external"), false, "DD_SYSTEM_PROBE_EXTERNAL")

--- a/pkg/ebpf/config.go
+++ b/pkg/ebpf/config.go
@@ -48,6 +48,7 @@ func key(pieces ...string) string {
 // NewConfig creates a config with ebpf-related settings
 func NewConfig() *Config {
 	cfg := aconfig.Datadog
+	aconfig.InitSystemProbeConfig(cfg)
 
 	return &Config{
 		BPFDebug:                 cfg.GetBool(key(spNS, "bpf_debug")),

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -148,6 +148,8 @@ func join(pieces ...string) string {
 // New creates a config for the network tracer
 func New() *Config {
 	cfg := ddconfig.Datadog
+	ddconfig.InitSystemProbeConfig(cfg)
+
 	c := &Config{
 		Config: *ebpf.NewConfig(),
 


### PR DESCRIPTION
### What does this PR do?

Fixes tests by ensuring that even sub-configs (`pkg/network` and `pkg/ebpf`) initialize the system-probe config.

### Motivation

Broken kitchen tests. 😢 
