### PR TITLE
[Windows] Remove debug binaries from shipped package

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -88,12 +88,14 @@ build do
     debug_customaction = ""
     if ENV['DEBUG_CUSTOMACTION'] and not ENV['DEBUG_CUSTOMACTION'].empty?
       debug_customaction = "--debug"
+
+      ## Don't build test executables on 32bit Windows & in release builds
+      unless windows_arch_i386?
+        command "invoke installcmd.build --major-version #{major_version_arg} --arch=" + platform
+        command "invoke uninstallcmd.build --major-version #{major_version_arg} --arch=" + platform
+      end
     end
     command "invoke customaction.build --major-version #{major_version_arg} #{debug_customaction} --arch=" + platform
-    unless windows_arch_i386?
-      command "invoke installcmd.build --major-version #{major_version_arg} --arch=" + platform
-      command "invoke uninstallcmd.build --major-version #{major_version_arg} --arch=" + platform
-    end
   end
 
   # move around bin and config files
@@ -102,7 +104,13 @@ build do
       move 'bin/agent/dist/system-probe.yaml', "#{conf_dir}/system-probe.yaml.example"
   end
   move 'bin/agent/dist/conf.d', "#{conf_dir}/"
-  copy 'bin/agent', "#{install_dir}/bin/"
+
+  unless windows?
+    copy 'bin/agent', "#{install_dir}/bin/"
+  else
+    copy 'bin/agent/ddtray.exe', "#{install_dir}/bin/agent"
+    copy 'bin/agent/dist', "#{install_dir}/bin/agent"
+  end
 
   block do
     # defer compilation step in a block to allow getting the project's build version, which is populated

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -88,14 +88,12 @@ build do
     debug_customaction = ""
     if ENV['DEBUG_CUSTOMACTION'] and not ENV['DEBUG_CUSTOMACTION'].empty?
       debug_customaction = "--debug"
-
-      ## Don't build test executables on 32bit Windows & in release builds
-      unless windows_arch_i386?
-        command "invoke installcmd.build --major-version #{major_version_arg} --arch=" + platform
-        command "invoke uninstallcmd.build --major-version #{major_version_arg} --arch=" + platform
-      end
     end
     command "invoke customaction.build --major-version #{major_version_arg} #{debug_customaction} --arch=" + platform
+    unless windows_arch_i386?
+      command "invoke installcmd.build --major-version #{major_version_arg} --arch=" + platform
+      command "invoke uninstallcmd.build --major-version #{major_version_arg} --arch=" + platform
+    end
   end
 
   # move around bin and config files

--- a/omnibus/config/software/datadog-cf-finalize.rb
+++ b/omnibus/config/software/datadog-cf-finalize.rb
@@ -30,11 +30,6 @@ build do
             copy "#{cf_source_root}/agent/agent.exe", "#{cf_bin_root_bin}"
             copy "#{cf_source_root}/agent/libdatadog-agent-three.dll", "#{cf_bin_root_bin}"
 
-            unless windows_arch_i386?
-              copy "#{cf_source_root}/agent/install-cmd.exe", "#{cf_bin_root_bin}/agent"
-              copy "#{cf_source_root}/agent/uninstall-cmd.exe", "#{cf_bin_root_bin}/agent"
-            end
-
             copy "#{cf_source_root}/agent/process-agent.exe", "#{cf_bin_root_bin}/agent"
             copy "#{cf_source_root}/agent/trace-agent.exe", "#{cf_bin_root_bin}/agent"
             copy "#{cf_source_root}/agent/security-agent.exe", "#{cf_bin_root_bin}/agent"

--- a/omnibus/config/software/datadog-cf-finalize.rb
+++ b/omnibus/config/software/datadog-cf-finalize.rb
@@ -30,6 +30,11 @@ build do
             copy "#{cf_source_root}/agent/agent.exe", "#{cf_bin_root_bin}"
             copy "#{cf_source_root}/agent/libdatadog-agent-three.dll", "#{cf_bin_root_bin}"
 
+            unless windows_arch_i386?
+              copy "#{cf_source_root}/agent/install-cmd.exe", "#{cf_bin_root_bin}/agent"
+              copy "#{cf_source_root}/agent/uninstall-cmd.exe", "#{cf_bin_root_bin}/agent"
+            end
+
             copy "#{cf_source_root}/agent/process-agent.exe", "#{cf_bin_root_bin}/agent"
             copy "#{cf_source_root}/agent/trace-agent.exe", "#{cf_bin_root_bin}/agent"
             copy "#{cf_source_root}/agent/security-agent.exe", "#{cf_bin_root_bin}/agent"


### PR DESCRIPTION
### What does this PR do?

This PR removes debug binaries from the shipped package.

### Motivation

Don't ship debug binaries & smaller package.

### Additional notes

The `dd-agent` file is a bash script, which is not used on Windows.
A side-effect of this fix is that this file will not be included in the installer anymore.

### Describe your test plan

Run the following command on a previous build (in this case 7.20.0):
```
(gci "C:\Program Files\Datadog\Datadog Agent\bin\" *.* -rec).FullName
```
and save the output to a file.
Run the same command on a version containing this fix, and check the difference.
Only the debug binary and `dd-agent` should be missing.
```
PS C:\Users\doguser\Desktop> compare-object (get-content .\files_before.txt) (get-content .\files_after.txt)

InputObject                                                        SideIndicator
-----------                                                        -------------
C:\Program Files\Datadog\Datadog Agent\bin\agent\customaction.pdb  <=
C:\Program Files\Datadog\Datadog Agent\bin\agent\dd-agent          <=
C:\Program Files\Datadog\Datadog Agent\bin\agent\install-cmd.exe   <=
C:\Program Files\Datadog\Datadog Agent\bin\agent\uninstall-cmd.exe <=
```
