### PR TITLE
[runtime-security] do not resolve zero pid

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "eaa93a41577a76465e71cea02bb6cf4f04df541e598e59367e36027696ea5479")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "d12a830d38037144d120bf740087eaa3ce8b4750a91d6586f824175dbd50bc4b")

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -457,7 +457,7 @@ func (p *ProcessResolver) resolveWithKernelMaps(pid, tid uint32) *model.ProcessC
 }
 
 func (p *ProcessResolver) resolveWithProcfs(pid uint32, maxDepth int) *model.ProcessCacheEntry {
-	if maxDepth < 1 {
+	if maxDepth < 1 || pid == 0 {
 		return nil
 	}
 

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -457,7 +457,7 @@ func (p *ProcessResolver) resolveWithKernelMaps(pid, tid uint32) *model.ProcessC
 }
 
 func (p *ProcessResolver) resolveWithProcfs(pid uint32, maxDepth int) *model.ProcessCacheEntry {
-	if maxDepth < 1 || pid == 0 {
+	if maxDepth < 1 {
 		return nil
 	}
 

--- a/pkg/security/probe/tags_resolver.go
+++ b/pkg/security/probe/tags_resolver.go
@@ -46,7 +46,7 @@ type TagsResolver struct {
 func (t *TagsResolver) Start(ctx context.Context) error {
 	go func() {
 		if err := t.tagger.Init(); err != nil {
-			log.Debugf("failed to init Tagger: %s", err)
+			log.Errorf("failed to init tagger: %s", err)
 		}
 	}()
 


### PR DESCRIPTION
### What does this PR do?

Do not resolve PID with value 0

### Motivation

Resolving zero pid causes useless access to file in /proc