### PR TITLE
[runtime-security] Fix cgroup_procs_write and cgroup_tasks_write on Centos7

### DIFF
--- a/pkg/security/ebpf/c/cgroup.h
+++ b/pkg/security/ebpf/c/cgroup.h
@@ -1,9 +1,34 @@
 #ifndef _CGROUP_H_
 #define _CGROUP_H_
 
+#define CGROUP_DEFAULT  1
+#define CGROUP_CENTOS_7 2
+
+u32 __attribute__((always_inline)) get_cgroup_write_type(void) {
+    u64 type;
+    LOAD_CONSTANT("cgroup_write_type", type);
+    return type;
+}
+
 static __attribute__((always_inline)) int trace__cgroup_write(struct pt_regs *ctx) {
-    char *pid_buff = (char *) PT_REGS_PARM2(ctx);
-    u32 pid = atoi(pid_buff);
+    u32 cgroup_write_type = get_cgroup_write_type();
+    u32 pid;
+
+    switch (cgroup_write_type) {
+        case CGROUP_DEFAULT: {
+            char *pid_buff = (char *) PT_REGS_PARM2(ctx);
+            pid = atoi(pid_buff);
+            break;
+        }
+        case CGROUP_CENTOS_7: {
+            pid = (u32) PT_REGS_PARM3(ctx);
+            break;
+        }
+        default:
+            // ignore
+            return 0;
+    }
+
     struct proc_cache_t new_entry = {};
     struct proc_cache_t *old_entry;
     u8 new_cookie = 0;
@@ -24,18 +49,43 @@ static __attribute__((always_inline)) int trace__cgroup_write(struct pt_regs *ct
         cookie = bpf_get_prandom_u32();
     }
 
-    // Retrieve the container ID from the cgroup path.
-    struct kernfs_open_file *kern_f = (struct kernfs_open_file *) PT_REGS_PARM1(ctx);
-    struct file *f;
-    bpf_probe_read(&f, sizeof(f), &kern_f->file);
-    struct dentry *dentry = get_file_dentry(f);
-
-    // The last dentry in the cgroup path should be `cgroup.procs`, thus the container ID should be its parent.
     struct dentry *container_d;
     struct qstr container_qstr;
-    bpf_probe_read(&container_d, sizeof(container_d), &dentry->d_parent);
-    bpf_probe_read(&container_qstr, sizeof(container_qstr), &container_d->d_name);
-    bpf_probe_read(&new_entry.container.container_id, sizeof(new_entry.container.container_id), (void*) container_qstr.name);
+    char *container_id;
+
+    switch (cgroup_write_type) {
+        case CGROUP_DEFAULT: {
+            // Retrieve the container ID from the cgroup path.
+            struct kernfs_open_file *kern_f = (struct kernfs_open_file *) PT_REGS_PARM1(ctx);
+            struct file *f;
+            bpf_probe_read(&f, sizeof(f), &kern_f->file);
+            struct dentry *dentry = get_file_dentry(f);
+
+            // The last dentry in the cgroup path should be `cgroup.procs`, thus the container ID should be its parent.
+            bpf_probe_read(&container_d, sizeof(container_d), &dentry->d_parent);
+            bpf_probe_read(&container_qstr, sizeof(container_qstr), &dentry->d_name);
+            bpf_probe_read(&container_qstr, sizeof(container_qstr), &container_d->d_name);
+            container_id = (void*) container_qstr.name;
+            break;
+        }
+        case CGROUP_CENTOS_7: {
+            void *cgroup = (void *) PT_REGS_PARM1(ctx);
+            bpf_probe_read(&container_d, sizeof(container_d), cgroup + 72); // offsetof(struct cgroup, dentry)
+            bpf_probe_read(&container_qstr, sizeof(container_qstr), &container_d->d_name);
+            container_id = (void*) container_qstr.name;
+            char prefix[4];
+            bpf_probe_read(&prefix, sizeof(prefix), container_id);
+            if (prefix[0] == 'd' && prefix[1] == 'o' && prefix[2] == 'c' && prefix[3] == 'k') {
+                container_id += 7; // skip "docker-"
+            }
+            break;
+        }
+        default:
+            // ignore
+            return 0;
+    }
+
+    bpf_probe_read(&new_entry.container.container_id, sizeof(new_entry.container.container_id), container_id);
     bpf_map_update_elem(&proc_cache, &cookie, &new_entry, BPF_ANY);
 
     if (new_cookie) {

--- a/pkg/security/ebpf/c/container.h
+++ b/pkg/security/ebpf/c/container.h
@@ -9,6 +9,9 @@ static __attribute__((always_inline)) u32 copy_container_id(char src[CONTAINER_I
 #pragma unroll
     for (int i = 0; i < CONTAINER_ID_LEN; i++)
     {
+        if (src[i] == 0)
+            break;
+
         dst[i] = src[i];
     }
     return CONTAINER_ID_LEN;

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -819,6 +819,7 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, TTYConstants(p)...)
 	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, erpc.GetConstants()...)
 	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, DiscarderConstants...)
+	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, getCGroupWriteConstants())
 
 	// tail calls
 	p.managerOptions.TailCallRouter = probes.AllTailRoutes()

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -60,6 +60,23 @@ func getDoForkInput(probe *Probe) uint64 {
 	return doForkListInput
 }
 
+// getCGroupWriteConstants returns the value of the constant used to determine how cgroups should be captured in kernel
+// space
+func getCGroupWriteConstants() manager.ConstantEditor {
+	cgroupWriteConst := uint64(1)
+	kv, err := NewKernelVersion()
+	if err == nil {
+		if kv.IsRH7Kernel() {
+			cgroupWriteConst = 2
+		}
+	}
+
+	return manager.ConstantEditor{
+		Name:  "cgroup_write_type",
+		Value: cgroupWriteConst,
+	}
+}
+
 // TTYConstants returns the tty constants
 func TTYConstants(probe *Probe) []manager.ConstantEditor {
 	ttyOffset, nameOffset := uint64(400), uint64(368)

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -460,7 +460,7 @@ func TestProcessContext(t *testing.T) {
 		} else {
 			assert.Equal(t, rule.ID, "test_rule_pid1", "wrong rule triggered")
 
-			if !rhel7 && !validateExecSchema(t, event) {
+			if !validateExecSchema(t, event) {
 				t.Fatal(event.String())
 			}
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug that prevented the runtime security module from properly tracking cgroups on Centos 7.

### Motivation

We track container IDs by tracking the cgroups in which the processes of a container live. In the current state, container ID tracking doesn't work on Centos 7 because the input parameters of `cgroup_procs_write` and `cgroup_tasks_write` are incorrectly handled.

### Describe your test plan

The schema validation feature of the functional tests ensure that a container ID is properly set at runtime.