### PR TITLE
[CI] Allow INTEGRATIONS_CORE var override

### DIFF
--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -24,7 +24,7 @@
     - if (Test-Path .omnibus) { remove-item -recurse -force .omnibus }
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - mkdir .omnibus\pkg
-    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e OMNIBUS_TARGET=${OMNIBUS_TARGET} -e WINDOWS_BUILDER=true -e RELEASE_VERSION="$RELEASE_VERSION" -e MAJOR_VERSION="$AGENT_MAJOR_VERSION" -e PY_RUNTIMES="$PYTHON_RUNTIMES" -e GOMODCACHE="/gomodcache" -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -e TARGET_ARCH="$ARCH" -e DEBUG_CUSTOMACTION="$DEBUG_CUSTOMACTION" -e DEB_RPM_BUCKET_BRANCH="$DEB_RPM_BUCKET_BRANCH" 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_${ARCH}:${Env:DATADOG_AGENT_WINBUILDIMAGES} c:\mnt\tasks\winbuildscripts\buildwin.bat
+    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e CI_JOB_ID=${CI_JOB_ID} -e OMNIBUS_TARGET=${OMNIBUS_TARGET} -e WINDOWS_BUILDER=true -e RELEASE_VERSION="$RELEASE_VERSION" -e MAJOR_VERSION="$AGENT_MAJOR_VERSION" -e PY_RUNTIMES="$PYTHON_RUNTIMES" -e INTEGRATIONS_CORE_VERSION="$INTEGRATIONS_CORE_VERSION" -e GOMODCACHE="/gomodcache" -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -e TARGET_ARCH="$ARCH" -e DEBUG_CUSTOMACTION="$DEBUG_CUSTOMACTION" -e DEB_RPM_BUCKET_BRANCH="$DEB_RPM_BUCKET_BRANCH" 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_${ARCH}:${Env:DATADOG_AGENT_WINBUILDIMAGES} c:\mnt\tasks\winbuildscripts\buildwin.bat
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - copy build-out\${CI_JOB_ID}\*.msi .omnibus\pkg
     - if (Test-Path build-out\${CI_JOB_ID}\*.zip) { copy build-out\${CI_JOB_ID}\*.zip .omnibus\pkg }
@@ -130,7 +130,7 @@ windows_zip_agent_binaries_x64-a7:
     - if (Test-Path .omnibus) { remove-item -recurse -force .omnibus }
     - if (Test-Path build-out) { remove-item -recurse -force build-out }
     - mkdir .omnibus\pkg
-    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e OMNIBUS_TARGET=${OMNIBUS_TARGET} -e WINDOWS_BUILDER=true -e RELEASE_VERSION="$RELEASE_VERSION" -e MAJOR_VERSION="$AGENT_MAJOR_VERSION" -e PY_RUNTIMES="$PYTHON_RUNTIMES" -e GOMODCACHE="/gomodcache" -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -e DEB_RPM_BUCKET_BRANCH="$DEB_RPM_BUCKET_BRANCH" 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_${ARCH}:${Env:DATADOG_AGENT_WINBUILDIMAGES} c:\mnt\tasks\winbuildscripts\buildwin.bat
+    - docker run --rm -m 4096M -v "$(Get-Location):c:\mnt" -e OMNIBUS_TARGET=${OMNIBUS_TARGET} -e WINDOWS_BUILDER=true -e RELEASE_VERSION="$RELEASE_VERSION" -e MAJOR_VERSION="$AGENT_MAJOR_VERSION" -e INTEGRATIONS_CORE_VERSION="$INTEGRATIONS_CORE_VERSION" -e PY_RUNTIMES="$PYTHON_RUNTIMES" -e GOMODCACHE="/gomodcache" -e AWS_NETWORKING=true -e SIGN_WINDOWS=true -e DEB_RPM_BUCKET_BRANCH="$DEB_RPM_BUCKET_BRANCH" 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/windows_1809_${ARCH}:${Env:DATADOG_AGENT_WINBUILDIMAGES} c:\mnt\tasks\winbuildscripts\buildwin.bat
     - If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
     - copy build-out\*.zip .omnibus\pkg
   artifacts:

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -362,6 +362,9 @@ def get_omnibus_env(
     if go_mod_cache:
         env['OMNIBUS_GOMODCACHE'] = go_mod_cache
 
+    if 'INTEGRATIONS_CORE_VERSION' in os.environ:
+        env['INTEGRATIONS_CORE_VERSION'] = os.environ.get('INTEGRATIONS_CORE_VERSION')
+
     if sys.platform == 'win32' and os.environ.get('SIGN_WINDOWS'):
         # get certificate and password from ssm
         pfxfile = get_signing_cert(ctx)

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -239,6 +239,9 @@ def omnibus_build(
         )
         env['MAJOR_VERSION'] = major_version
 
+        if 'INTEGRATIONS_CORE_VERSION' in os.environ:
+            env['INTEGRATIONS_CORE_VERSION'] = os.environ.get('INTEGRATIONS_CORE_VERSION')
+
         # If the host has a GOMODCACHE set, try to reuse it
         if not go_mod_cache and os.environ.get('GOMODCACHE'):
             go_mod_cache = os.environ.get('GOMODCACHE')


### PR DESCRIPTION
Overrides the `INTEGRATIONS_CORE_VERSION` value defined in the release.json by the one provided as an environment variable if one is specified.

### Motivation
Our integrations-core repo sometimes update the python dependencies which sometimes lead to breaking the gitlab CI on master. We plan to trigger a test build of the agent automatically when a PR is bumping dependencies, this way we can tell before merging if the agent still build correctly or not.

To trigger a build of the agent based on a specific branch of `integrations-core`, the only option currently is to update the release.json file. With this PR, we'll be able to trigger the build without having to update this file.

### Example
1. I created a new branch based on this one. The branch is called `florian/test_builds`
2. I updated the release.json file to use a non-existing version of integrations-core (i.e the CI should fail).
3. I triggered a manual run of the gitlab CI by passing the INTEGRATIONS_CORE_VERSION=master env var.
4. The build is passing