### PR TITLE
Ensure we ignore error if a system-probe config file doesn't exist

### DIFF
--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -84,7 +84,7 @@ func New(configPath string) (*Config, error) {
 	_, err := aconfig.LoadWithoutSecret()
 	var e viper.ConfigFileNotFoundError
 	if err != nil {
-		if errors.As(err, &e) {
+		if errors.As(err, &e) || errors.Is(err, os.ErrNotExist) {
 			log.Infof("no config exists at %s, ignoring...", configPath)
 		} else {
 			return nil, err


### PR DESCRIPTION
### What does this PR do?

Ignores `os.ErrNotExist` when attempting to load the system-probe config file.

### Motivation

We need to support environments where config is only done through environment variables.


