### PR TITLE
Fix DatadogMetric creation

### DIFF
--- a/pkg/clusteragent/externalmetrics/datadogmetric_controller.go
+++ b/pkg/clusteragent/externalmetrics/datadogmetric_controller.go
@@ -36,7 +36,7 @@ const (
 var (
 	gvrDDM  = datadoghq.GroupVersion.WithResource("datadogmetrics")
 	metaDDM = metav1.TypeMeta{
-		Kind:       "datadogmetric",
+		Kind:       "DatadogMetric",
 		APIVersion: "datadoghq.com/v1alpha1",
 	}
 )


### PR DESCRIPTION
### What does this PR do?

Fix autogeneration of `DatadogMetrics`.

### Motivation



### Additional Notes



### Describe your test plan

Start a DCA with the metrics provider and the datadog metrics enabled and create an HPA with a custom DD metric.

With the `1.12.0-rc1`, no `DatadogMetric` is created and the DCA logs the following error:
```
2021-04-26 15:23:32 UTC | CLUSTER | ERROR | (pkg/clusteragent/externalmetrics/datadogmetric_controller.go:170 in process) | Impossible to synchronize DatadogMetric (attempt #3): datadog-agent-helm/dcaautogen-afda243730e31f83713b52b84d9d2bac9b6d1f, err: Unable to create DatadogMetric: datadog-agent-helm/dcaautogen-afda243730e31f83713b52b84d9d2bac9b6d1f, err: datadogmetric.datadoghq.com "dcaautogen-afda243730e31f83713b52b84d9d2bac9b6d1f" is invalid: kind: Invalid value: "datadogmetric": must be DatadogMetric
```

With this fix, a `DatadogMetric` should be autogenerated.
