### PR TITLE
[gitlab] Fix docker_trigger_internal dependencies

### DIFF
--- a/.gitlab/internal_image_deploy.yml
+++ b/.gitlab/internal_image_deploy.yml
@@ -13,6 +13,8 @@ docker_trigger_internal:
   needs:
     - job: docker_build_agent7_jmx
       artifacts: false
+    - job: docker_build_agent7_jmx_arm64
+      artifacts: false
   trigger:
     project: DataDog/images
     branch: master


### PR DESCRIPTION
### What does this PR do?

Adds `docker_build_agent7_jmx_arm64` as a dependency of `docker_trigger_internal`.

### Motivation

#7617 made the pipeline triggered by `docker_trigger_internal` multiarch, but it now needs the `arm64` images to be built before being triggered.
