### PR TITLE
[jmx] fix crash when jmx_max_restarts < 1

### DIFF
--- a/pkg/jmxfetch/limiter.go
+++ b/pkg/jmxfetch/limiter.go
@@ -11,15 +11,23 @@ type restartLimiter struct {
 }
 
 func newRestartLimiter(maxRestarts int, interval float64) restartLimiter {
+	var stopTimes []time.Time
+	if maxRestarts > 0 {
+		stopTimes = make([]time.Time, maxRestarts)
+	}
 	return restartLimiter{
 		maxRestarts: maxRestarts,
 		interval:    interval,
-		stopTimes:   make([]time.Time, maxRestarts),
+		stopTimes:   stopTimes,
 		idx:         0,
 	}
 }
 
 func (r *restartLimiter) canRestart(now time.Time) bool {
+	if r.maxRestarts < 1 {
+		return false
+	}
+
 	r.stopTimes[r.idx] = now
 	oldestIdx := (r.idx + r.maxRestarts + 1) % r.maxRestarts
 

--- a/pkg/jmxfetch/limiter.go
+++ b/pkg/jmxfetch/limiter.go
@@ -1,0 +1,36 @@
+package jmxfetch
+
+import "time"
+
+// restartLimiter checks if too many restarts happened within a time period
+type restartLimiter struct {
+	maxRestarts int
+	interval    float64
+	stopTimes   []time.Time
+	idx         int
+}
+
+func newRestartLimiter(maxRestarts int, interval float64) restartLimiter {
+	return restartLimiter{
+		maxRestarts: maxRestarts,
+		interval:    interval,
+		stopTimes:   make([]time.Time, maxRestarts),
+		idx:         0,
+	}
+}
+
+func (r *restartLimiter) canRestart(now time.Time) bool {
+	r.stopTimes[r.idx] = now
+	oldestIdx := (r.idx + r.maxRestarts + 1) % r.maxRestarts
+
+	// Please note that the zero value for `time.Time` is `0001-01-01 00:00:00 +0000 UTC`
+	// therefore for the first iteration (the initial launch attempt), the interval will
+	// always be biger than ival (jmx_restart_interval). In fact, this sub operation with
+	// stopTimes here will only start yielding values potentially <= ival _after_ the first
+	// maxRestarts attempts, which is fine and consistent.
+	restartTooSoon := r.stopTimes[r.idx].Sub(r.stopTimes[oldestIdx]).Seconds() <= r.interval
+
+	r.idx = (r.idx + 1) % r.maxRestarts
+
+	return !restartTooSoon
+}

--- a/pkg/jmxfetch/limiter.go
+++ b/pkg/jmxfetch/limiter.go
@@ -5,7 +5,7 @@ import "time"
 // restartLimiter checks if too many restarts happened within a time period
 type restartLimiter struct {
 	maxRestarts int
-	interval    float64
+	interval    float64 // in seconds
 	stopTimes   []time.Time
 	idx         int
 }

--- a/pkg/jmxfetch/limiter.go
+++ b/pkg/jmxfetch/limiter.go
@@ -36,7 +36,7 @@ func (r *restartLimiter) canRestart(now time.Time) bool {
 	// <= ival _after_ the first maxRestarts-1 attempts.
 	canRestart := r.stopTimes[r.idx].Sub(r.stopTimes[oldestIdx]).Seconds() > r.interval
 
-	r.idx = (r.idx + 1) % r.maxRestarts
+	r.idx = oldestIdx
 
 	return canRestart
 }

--- a/pkg/jmxfetch/limiter.go
+++ b/pkg/jmxfetch/limiter.go
@@ -31,11 +31,9 @@ func (r *restartLimiter) canRestart(now time.Time) bool {
 	r.stopTimes[r.idx] = now
 	oldestIdx := (r.idx + r.maxRestarts + 1) % r.maxRestarts
 
-	// Please note that the zero value for `time.Time` is `0001-01-01 00:00:00 +0000 UTC`
-	// therefore for the first iteration (the initial launch attempt), the interval will
-	// always be biger than ival (jmx_restart_interval). In fact, this sub operation with
-	// stopTimes here will only start yielding values potentially <= ival _after_ the first
-	// maxRestarts attempts, which is fine and consistent.
+	// Please note that the zero value for `time.Time` is `0001-01-01 00:00:00+0000 UTC`
+	// The sub operation with stopTimes here will only start yielding values potentially
+	// <= ival _after_ the first maxRestarts-1 attempts.
 	restartTooSoon := r.stopTimes[r.idx].Sub(r.stopTimes[oldestIdx]).Seconds() <= r.interval
 
 	r.idx = (r.idx + 1) % r.maxRestarts

--- a/pkg/jmxfetch/limiter.go
+++ b/pkg/jmxfetch/limiter.go
@@ -29,14 +29,14 @@ func (r *restartLimiter) canRestart(now time.Time) bool {
 	}
 
 	r.stopTimes[r.idx] = now
-	oldestIdx := (r.idx + r.maxRestarts + 1) % r.maxRestarts
+	oldestIdx := (r.idx + 1) % r.maxRestarts
 
 	// Please note that the zero value for `time.Time` is `0001-01-01 00:00:00+0000 UTC`
 	// The sub operation with stopTimes here will only start yielding values potentially
 	// <= ival _after_ the first maxRestarts-1 attempts.
-	restartTooSoon := r.stopTimes[r.idx].Sub(r.stopTimes[oldestIdx]).Seconds() <= r.interval
+	canRestart := r.stopTimes[r.idx].Sub(r.stopTimes[oldestIdx]).Seconds() > r.interval
 
 	r.idx = (r.idx + 1) % r.maxRestarts
 
-	return !restartTooSoon
+	return canRestart
 }

--- a/pkg/jmxfetch/limiter_test.go
+++ b/pkg/jmxfetch/limiter_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestCanRestart(t *testing.T) {
@@ -30,9 +32,7 @@ func TestCanRestart(t *testing.T) {
 		for cidx, check := range tt.checks {
 			name := fmt.Sprintf("%d/%d", tidx, cidx)
 			t.Run(name, func(t *testing.T) {
-				if got := r.canRestart(tref.Add(check.now)); got != check.result {
-					t.Errorf("restartLimiter.canRestart() = %v, want %v", got, check.result)
-				}
+				require.Equal(t, check.result, r.canRestart(tref.Add(check.now)))
 			})
 		}
 	}

--- a/pkg/jmxfetch/limiter_test.go
+++ b/pkg/jmxfetch/limiter_test.go
@@ -16,6 +16,8 @@ func TestCanRestart(t *testing.T) {
 		interval    float64
 		checks      []check
 	}{
+		{-1, 10.0, []check{{0 * time.Second, false}}},
+		{0, 10.0, []check{{0 * time.Second, false}}},
 		{1, 10.0, []check{{0 * time.Second, false}}},
 		{2, 10.0, []check{{0 * time.Second, true}, {1 * time.Second, false}}},
 		{3, 10.0, []check{{0 * time.Second, true}, {1 * time.Second, true},

--- a/pkg/jmxfetch/limiter_test.go
+++ b/pkg/jmxfetch/limiter_test.go
@@ -1,0 +1,37 @@
+package jmxfetch
+
+import (
+	"fmt"
+	"testing"
+	"time"
+)
+
+func TestCanRestart(t *testing.T) {
+	type check struct {
+		now    time.Duration
+		result bool
+	}
+	tests := []struct {
+		maxRestarts int
+		interval    float64
+		checks      []check
+	}{
+		{1, 10.0, []check{{0 * time.Second, false}}},
+		{2, 10.0, []check{{0 * time.Second, true}, {1 * time.Second, false}}},
+		{3, 10.0, []check{{0 * time.Second, true}, {1 * time.Second, true},
+			{13 * time.Second, true}, {14 * time.Second, true}, {15 * time.Second, false}}},
+	}
+
+	tref := time.Now()
+	for tidx, tt := range tests {
+		r := newRestartLimiter(tt.maxRestarts, tt.interval)
+		for cidx, check := range tt.checks {
+			name := fmt.Sprintf("%d/%d", tidx, cidx)
+			t.Run(name, func(t *testing.T) {
+				if got := r.canRestart(tref.Add(check.now)); got != check.result {
+					t.Errorf("restartLimiter.canRestart() = %v, want %v", got, check.result)
+				}
+			})
+		}
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Fix a crash in the agent when jmxfetch is enabled and `jmx_max_restarts` setting is set to value less than 1.

### Describe your test plan

Enable JMX collection (`cp bin/agent/dist/conf.d/jmx.d/conf.yaml{.example,}`) and set `jmx_max_restarts: 0` in `datadog.yaml`