### PR TITLE
Fix windows string conversions.

### DIFF
--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -61,6 +61,10 @@ func zipCounterStrings(tempDir, hostname string) error {
 			bufferSize += bufferIncrement
 			continue
 		}
+		// must set the length of the slice to the actual amount of data
+		// sz is in bytes, but it's a slice of uint16s, so divide the returned
+		// buffer size by two.
+		counterlist = counterlist[:(sz / 2)]
 		break
 	}
 	clist := winutil.ConvertWindowsStringList(counterlist)

--- a/pkg/logs/input/windowsevent/launcher_windows.go
+++ b/pkg/logs/input/windowsevent/launcher_windows.go
@@ -18,6 +18,7 @@ import (
 	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 	"golang.org/x/sys/windows"
 )
 
@@ -81,6 +82,9 @@ func evtNextChannel(h evtEnumHandle) (ch string, err error) {
 	}
 	err = nil
 	// Call will set error anyway.  Clear it so we don't return an error
-	ch = ConvertWindowsString(buf)
+
+	// make sure size of buffer is set
+	buf = buf[:(bufUsed * 2)]
+	ch = winutil.ConvertWindowsString(buf)
 	return
 }

--- a/pkg/logs/input/windowsevent/tailer_windows.go
+++ b/pkg/logs/input/windowsevent/tailer_windows.go
@@ -19,6 +19,7 @@ import (
 	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 	"golang.org/x/sys/windows"
 )
 
@@ -136,10 +137,11 @@ func EvtRender(h C.ULONGLONG) (richEvt *richEvent, err error) {
 	if ret == 0 {
 		return
 	}
+	buf = buf[:bufUsed]
 	// Call will set error anyway.  Clear it so we don't return an error
 	err = nil
 
-	xml := ConvertWindowsString(buf)
+	xml := winutil.ConvertWindowsString(buf)
 
 	richEvt = enrichEvent(h, xml)
 
@@ -219,22 +221,6 @@ const (
 	EvtSubscribeStartAtOldestRecord
 	EvtSubscribeStartAfterBookmark
 )
-
-// ConvertWindowsString converts a windows c-string
-// into a go string.  Even though the input is array
-// of uint8, the underlying data is expected to be
-// uint16 (unicode)
-func ConvertWindowsString(winput []uint8) string {
-	var retstring string
-	for i := 0; i < len(winput); i += 2 {
-		dbyte := (uint16(winput[i+1]) << 8) + uint16(winput[i])
-		if dbyte == 0 {
-			break
-		}
-		retstring += string(rune(dbyte))
-	}
-	return retstring
-}
 
 // LPWSTRToString converts a C.LPWSTR to a string. It also truncates the
 // strings to 128kB as a basic protection mechanism to avoid allocating an

--- a/pkg/process/checks/allprocesses_windows.go
+++ b/pkg/process/checks/allprocesses_windows.go
@@ -224,17 +224,6 @@ func getUsernameForProcess(h windows.Handle) (name string, err error) {
 	return domain + "\\" + user, err
 }
 
-func convertWindowsString(winput []uint16) string {
-	var buf bytes.Buffer
-	for _, r := range winput {
-		if r == 0 {
-			break
-		}
-		buf.WriteRune(rune(r))
-	}
-	return buf.String()
-}
-
 func parseCmdLineArgs(cmdline string) (res []string) {
 	blocks := strings.Split(cmdline, " ")
 	findCloseQuote := false
@@ -305,7 +294,7 @@ func (cp *cachedProcess) fillFromProcEntry(pe32 *w32.PROCESSENTRY32) (err error)
 		log.Debugf("Couldn't get process username %v %v", pe32.Th32ProcessID, err)
 	}
 	var cmderr error
-	cp.executablePath = convertWindowsString(pe32.SzExeFile[:])
+	cp.executablePath = winutil.ConvertWindowsString16(pe32.SzExeFile[:])
 	cp.commandLine, cmderr = winutil.GetCommandLineForProcess(cp.procHandle)
 	if cmderr != nil {
 		log.Debugf("Error retrieving full command line %v", cmderr)

--- a/pkg/process/checks/allprocesses_windows_test.go
+++ b/pkg/process/checks/allprocesses_windows_test.go
@@ -5,6 +5,7 @@ package checks
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -74,7 +75,7 @@ func TestWindowsStringConversion(t *testing.T) {
 			expected: ".NET CLR-säkerhet ! Microsoft.Exchange.UM.CallRouter ! Tid för körningskontroller i procent",
 		},
 	} {
-		assert.Equal(t, tc.expected, convertWindowsString(tc.input))
+		assert.Equal(t, tc.expected, winutil.ConvertWindowsString16(tc.input))
 	}
 
 }

--- a/pkg/util/winutil/pdhutil/pdhhelper.go
+++ b/pkg/util/winutil/pdhutil/pdhhelper.go
@@ -247,6 +247,11 @@ func makeCounterSetIndexes() error {
 		} else if regerr != nil {
 			return regerr
 		}
+		// must set the length of the slice to the actual amount of data
+		// sz is in bytes, but it's a slice of uint16s, so divide the returned
+		// buffer size by two.
+
+		counterlist = counterlist[:(sz / 2)]
 		break
 	}
 	clist := winutil.ConvertWindowsStringList(counterlist)

--- a/pkg/util/winutil/winstrings.go
+++ b/pkg/util/winutil/winstrings.go
@@ -19,14 +19,19 @@ import (
 func ConvertWindowsStringList(winput []uint16) []string {
 
 	if len(winput) < 2 {
-		return []string{}
+		return nil
 	}
 	val := make([]string, 0, 5)
 	from := 0
-	for i, c := range winput {
-		if c == 0 {
+
+	for i := 0; i < (len(winput) - 1); i++ {
+		if winput[i] == 0 {
 			val = append(val, windows.UTF16ToString(winput[from:i]))
 			from = i + 1
+
+			if winput[i+1] == 0 {
+				return val
+			}
 		}
 	}
 	return val
@@ -50,11 +55,4 @@ func ConvertWindowsString(winput []uint8) string {
 // uint16 (unicode)
 func ConvertWindowsString16(winput []uint16) string {
 	return windows.UTF16ToString(winput)
-}
-
-// ConvertASCIIString converts a c-string into
-// a go string
-func ConvertASCIIString(input []byte) string {
-
-	return string(input)
 }

--- a/pkg/util/winutil/winstrings.go
+++ b/pkg/util/winutil/winstrings.go
@@ -44,6 +44,10 @@ func ConvertWindowsString(winput []uint8) string {
 	if len(winput) < 2 {
 		return ""
 	}
+	if winput[len(winput)-1] == 0 {
+		winput = winput[:len(winput)-1] // remove terminating null
+	}
+
 	p := (*[1 << 29]uint16)(unsafe.Pointer(&winput[0]))[: len(winput)/2 : len(winput)/2]
 	return string(utf16.Decode(p))
 
@@ -57,6 +61,10 @@ func ConvertWindowsString16(winput []uint16) string {
 	if len(winput) < 2 {
 		return ""
 	}
+	if winput[len(winput)-1] == 0 {
+		winput = winput[:len(winput)-1] // remove terminating null
+	}
+
 	return string(utf16.Decode(winput))
 }
 

--- a/pkg/util/winutil/winstrings.go
+++ b/pkg/util/winutil/winstrings.go
@@ -8,8 +8,9 @@
 package winutil
 
 import (
-	"unicode/utf16"
 	"unsafe"
+
+	"golang.org/x/sys/windows"
 )
 
 // ConvertWindowsStringList Converts a windows-style C list of strings
@@ -20,14 +21,11 @@ func ConvertWindowsStringList(winput []uint16) []string {
 	if len(winput) < 2 {
 		return []string{}
 	}
-	if winput[len(winput)-1] == 0 {
-		winput = winput[:len(winput)-1] // remove terminating null
-	}
 	val := make([]string, 0, 5)
 	from := 0
 	for i, c := range winput {
 		if c == 0 {
-			val = append(val, string(utf16.Decode(winput[from:i])))
+			val = append(val, windows.UTF16ToString(winput[from:i]))
 			from = i + 1
 		}
 	}
@@ -41,15 +39,8 @@ func ConvertWindowsStringList(winput []uint16) []string {
 // uint16 (unicode)
 func ConvertWindowsString(winput []uint8) string {
 
-	if len(winput) < 2 {
-		return ""
-	}
-	if winput[len(winput)-1] == 0 {
-		winput = winput[:len(winput)-1] // remove terminating null
-	}
-
 	p := (*[1 << 29]uint16)(unsafe.Pointer(&winput[0]))[: len(winput)/2 : len(winput)/2]
-	return string(utf16.Decode(p))
+	return windows.UTF16ToString(p)
 
 }
 
@@ -58,14 +49,7 @@ func ConvertWindowsString(winput []uint8) string {
 // of uint8, the underlying data is expected to be
 // uint16 (unicode)
 func ConvertWindowsString16(winput []uint16) string {
-	if len(winput) < 2 {
-		return ""
-	}
-	if winput[len(winput)-1] == 0 {
-		winput = winput[:len(winput)-1] // remove terminating null
-	}
-
-	return string(utf16.Decode(winput))
+	return windows.UTF16ToString(winput)
 }
 
 // ConvertASCIIString converts a c-string into

--- a/releasenotes/notes/fixconversions-c7a6d6522ed745d2.yaml
+++ b/releasenotes/notes/fixconversions-c7a6d6522ed745d2.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On Windows, fixes inefficient string conversion


### PR DESCRIPTION
String conversions were done with manual, inefficient loops rather than
built in primitives

### What does this PR do?

Fixes very poor implementation of string conversions from windows APIs.

### Motivation

it is possible that these conversions are triggering a deadlock in the go runtime.

