### PR TITLE
[runtime-security] Filter container ID from cgroup

### DIFF
--- a/pkg/security/model/unmarshallers.go
+++ b/pkg/security/model/unmarshallers.go
@@ -11,6 +11,8 @@ import (
 	"bytes"
 	"time"
 	"unsafe"
+
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 // BinaryUnmarshaler interface implemented by every event type
@@ -24,7 +26,7 @@ func (e *ContainerContext) UnmarshalBinary(data []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	e.ID = id
+	e.ID = utils.FindContainerID(id)
 
 	return 64, nil
 }


### PR DESCRIPTION
### What does this PR do?

This PR filters the container ID retrieved from kernel space so that incorrect cgroup patterns don't generate invalid container IDs.

### Motivation

Cgroups can be used by the host operating system for other things than containers.

### Describe your test plan

Container IDs are tested in multiple kitchen tests.
