### PR TITLE
[DDM][DCA] Add logging on query resolution success

### DIFF
--- a/pkg/clusteragent/externalmetrics/model/datadogmetricinternal.go
+++ b/pkg/clusteragent/externalmetrics/model/datadogmetricinternal.go
@@ -242,6 +242,7 @@ func (d *DatadogMetricInternal) resolveQuery(query string) {
 		return
 	}
 	if resolvedQuery != "" {
+		log.Infof("DatadogMetric query %q was resolved successfully, new query: %q", query, resolvedQuery)
 		d.resolvedQuery = &resolvedQuery
 		return
 	}


### PR DESCRIPTION
### What does this PR do?

Log the resolved DDM query when the resolution succeed 

### Motivation

Better observability

### Describe your test plan

Same as https://github.com/DataDog/datadog-agent/pull/7682 + check DCA's logs
