### PR TITLE
[runtime-security] Cleanup load_controller entries on process death and purge counters

### DIFF
--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -22,7 +22,7 @@ var (
 	// Load controller metrics
 
 	// MetricLoadControllerPidDiscarder is the name of the metric used to count the number of pid discarders
-	// Tags: event_type
+	// Tags: -
 	MetricLoadControllerPidDiscarder = newRuntimeMetric(".load_controller.pids_discarder")
 
 	// Rate limiter metrics

--- a/pkg/security/model/unmarshallers.go
+++ b/pkg/security/model/unmarshallers.go
@@ -11,6 +11,8 @@ import (
 	"bytes"
 	"time"
 	"unsafe"
+
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 // BinaryUnmarshaler interface implemented by every event type
@@ -24,7 +26,7 @@ func (e *ContainerContext) UnmarshalBinary(data []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	e.ID = id
+	e.ID = utils.FindContainerID(id)
 
 	return 64, nil
 }

--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -266,7 +266,6 @@ func NewRuleSetLoadedEvent(rs *rules.RuleSet, err *multierror.Error) (*rules.Rul
 // easyjson:json
 type NoisyProcessEvent struct {
 	Timestamp      time.Time                 `json:"date"`
-	Event          string                    `json:"event_type"`
 	Count          uint64                    `json:"pid_count"`
 	Threshold      int64                     `json:"threshold"`
 	ControlPeriod  time.Duration             `json:"control_period"`
@@ -275,8 +274,7 @@ type NoisyProcessEvent struct {
 }
 
 // NewNoisyProcessEvent returns the rule and a populated custom event for a noisy_process event
-func NewNoisyProcessEvent(eventType model.EventType,
-	count uint64,
+func NewNoisyProcessEvent(count uint64,
 	threshold int64,
 	controlPeriod time.Duration,
 	discardedUntil time.Time,
@@ -287,7 +285,6 @@ func NewNoisyProcessEvent(eventType model.EventType,
 			ID: NoisyProcessRuleID,
 		}), newCustomEvent(model.CustomNoisyProcessEventType, NoisyProcessEvent{
 			Timestamp:      timestamp,
-			Event:          eventType.String(),
 			Count:          count,
 			Threshold:      threshold,
 			ControlPeriod:  controlPeriod,

--- a/pkg/security/probe/custom_events_easyjson.go
+++ b/pkg/security/probe/custom_events_easyjson.go
@@ -551,8 +551,6 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(in *jle
 			if data := in.Raw(); in.Ok() {
 				in.AddError((out.Timestamp).UnmarshalJSON(data))
 			}
-		case "event_type":
-			out.Event = string(in.String())
 		case "pid_count":
 			out.Count = uint64(in.Uint64())
 		case "threshold":
@@ -591,11 +589,6 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(out *jw
 		const prefix string = ",\"date\":"
 		out.RawString(prefix[1:])
 		out.Raw((in.Timestamp).MarshalJSON())
-	}
-	{
-		const prefix string = ",\"event_type\":"
-		out.RawString(prefix)
-		out.String(string(in.Event))
 	}
 	{
 		const prefix string = ",\"pid_count\":"


### PR DESCRIPTION
### What does this PR do?

The PR introduces 2 changes to improve the load controller:
- remove cache entries on process exit
- purge the entire cache on cleanup, instead of resetting the counters to 0

### Motivation

The load controller is making too many allocations du to how `hashicorp/golang-lru` works. We need to make sure that unused entries are properly removed so that the iterations over the entire cache are faster.

### Describe your test plan

This changes has an effect on CPU and memory usage. We'll double check at runtime that they have improved.
