### PR TITLE
[CI] Do not make `inv deps` verbose

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ jobs:
       - run:
           name: grab go deps
           command: |
-            inv deps --verbose
+            inv -e deps
       - run:
           name: build rtloader
           command: |

--- a/.gitlab/binary_build/system_probe.yml
+++ b/.gitlab/binary_build/system_probe.yml
@@ -10,7 +10,7 @@
     # TODO: remove this once we switch to k8s runners, they won't have this problem
     - find "$CI_BUILDS_DIR" ! -path '*DataDog/datadog-agent*' -depth  # -delete implies -depth
     - find "$CI_BUILDS_DIR" ! -path '*DataDog/datadog-agent*' -delete || true  # Allow failure, we can't remove parent folders of datadog-agent
-    - inv -e deps --verbose
+    - inv -e deps
     # Retrieve libbcc from S3
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/libbcc-$ARCH-$BCC_VERSION.tar.xz /tmp/libbcc.tar.xz
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/clang-$ARCH-11.0.1.tar.xz /tmp/clang.tar.xz

--- a/.gitlab/deps_fetch.yml
+++ b/.gitlab/deps_fetch.yml
@@ -7,7 +7,7 @@
   stage: deps_fetch
   needs: []
   script:
-    - inv -e deps --verbose
+    - inv -e deps
     - cd $GOPATH/pkg/mod/ && tar czf $CI_PROJECT_DIR/modcache.tar.gz .
   artifacts:
     expire_in: 1 day

--- a/tasks/winbuildscripts/dobuild.bat
+++ b/tasks/winbuildscripts/dobuild.bat
@@ -46,7 +46,7 @@ cd \dev\go\src\github.com\DataDog\datadog-agent || exit /b 101
 
 pip3 install -r requirements.txt || exit /b 102
 
-inv -e deps --verbose || exit /b 103
+inv -e deps || exit /b 103
 
 @echo "inv -e %OMNIBUS_BUILD% %OMNIBUS_ARGS% --skip-deps --major-version %MAJOR_VERSION% --release-version %RELEASE_VERSION%"
 inv -e %OMNIBUS_BUILD% %OMNIBUS_ARGS% --skip-deps --major-version %MAJOR_VERSION% --release-version %RELEASE_VERSION% || exit /b 104

--- a/tasks/winbuildscripts/unittests.ps1
+++ b/tasks/winbuildscripts/unittests.ps1
@@ -30,7 +30,7 @@ if($err -ne 0){
     [Environment]::Exit($err)
 }
 
-& inv -e deps --verbose
+& inv -e deps
 
 & inv -e rtloader.make --python-runtimes="$Env:PY_RUNTIMES" --install-prefix=$Env:BUILD_ROOT\dev --cmake-options='-G \"Unix Makefiles\"' --arch $archflag
 $err = $LASTEXITCODE


### PR DESCRIPTION
### What does this PR do?

- Remove `--verbose` flag from `inv deps` calls.

### Motivation

- Output is too verbose and not very useful anyway.

### Additional Notes

- Errors will still show up.
