### PR TITLE
[runtime-security] introduce more delay for tags resolution

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -825,6 +825,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.events_stats.polling_interval", 20)
 	config.BindEnvAndSetDefault("runtime_security_config.run_path", defaultRunPath)
 	config.BindEnvAndSetDefault("runtime_security_config.event_server.burst", 40)
+	config.BindEnvAndSetDefault("runtime_security_config.event_server.retention", 6)
 	config.BindEnvAndSetDefault("runtime_security_config.event_server.rate", 10)
 	config.BindEnvAndSetDefault("runtime_security_config.load_controller.events_count_threshold", 20000)
 	config.BindEnvAndSetDefault("runtime_security_config.load_controller.discarder_timeout", 10)

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -46,6 +46,8 @@ type Config struct {
 	EventServerBurst int
 	// EventServerRate defines the grpc server rate at which events can be sent
 	EventServerRate int
+	// EventServerRetention defines an event retention period so that some fields can be resolved
+	EventServerRetention int
 	// PIDCacheSize is the size of the user space PID caches
 	PIDCacheSize int
 	// CookieCacheSize is the size of the cookie cache used to cache process context
@@ -91,6 +93,7 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 		PoliciesDir:                        aconfig.Datadog.GetString("runtime_security_config.policies.dir"),
 		EventServerBurst:                   aconfig.Datadog.GetInt("runtime_security_config.event_server.burst"),
 		EventServerRate:                    aconfig.Datadog.GetInt("runtime_security_config.event_server.rate"),
+		EventServerRetention:               aconfig.Datadog.GetInt("runtime_security_config.event_server.retention"),
 		PIDCacheSize:                       aconfig.Datadog.GetInt("runtime_security_config.pid_cache_size"),
 		CookieCacheSize:                    aconfig.Datadog.GetInt("runtime_security_config.cookie_cache_size"),
 		LoadControllerEventsCountThreshold: int64(aconfig.Datadog.GetInt("runtime_security_config.load_controller.events_count_threshold")),

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -27,6 +27,18 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+const (
+	defaultSendEventDelay = 5 * time.Second
+)
+
+type pendingMsg struct {
+	ruleID    string
+	data      []byte
+	tags      map[string]bool
+	extTagsCb func() []string
+	sendAfter time.Time
+}
+
 // APIServer represents a gRPC server in charge of receiving events sent by
 // the runtime security system-probe module and forwards them to Datadog
 type APIServer struct {
@@ -36,6 +48,7 @@ type APIServer struct {
 	rate          *Limiter
 	statsdClient  *statsd.Client
 	probe         *sprobe.Probe
+	queue         []*pendingMsg
 }
 
 // GetEvents waits for security events
@@ -95,8 +108,91 @@ func (a *APIServer) DumpProcessCache(ctx context.Context, params *api.DumpProces
 	}, nil
 }
 
+func (a *APIServer) enqueue(msg *pendingMsg) {
+	a.Lock()
+	a.queue = append(a.queue, msg)
+	a.Unlock()
+}
+
+func (a *APIServer) dequeue(now time.Time, cb func(msg *pendingMsg)) {
+	a.Lock()
+	defer a.Unlock()
+
+	var i int
+	var msg *pendingMsg
+
+	for i != len(a.queue) {
+		msg = a.queue[i]
+		if msg.sendAfter.After(now) {
+			break
+		}
+		cb(msg)
+
+		i++
+	}
+
+	if i > len(a.queue) {
+		a.queue = a.queue[0:0]
+	} else if i > 0 {
+		a.queue = a.queue[i:]
+	}
+}
+
+func (a *APIServer) start(ctx context.Context) {
+	ticker := time.NewTicker(200 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case now := <-ticker.C:
+			a.dequeue(now, func(msg *pendingMsg) {
+				for _, tag := range msg.extTagsCb() {
+					msg.tags[tag] = true
+				}
+
+				var tags []string
+				for tag := range msg.tags {
+					tags = append(tags, tag)
+				}
+
+				m := &api.SecurityEventMessage{
+					RuleID: msg.ruleID,
+					Data:   msg.data,
+					Tags:   tags,
+				}
+
+				select {
+				case a.msgs <- m:
+					break
+				default:
+					// The channel is full, consume the oldest event
+					oldestMsg := <-a.msgs
+					// Try to send the event again
+					select {
+					case a.msgs <- m:
+						break
+					default:
+						// Looks like the channel is full again, expire the current message too
+						a.expireEvent(m)
+						break
+					}
+					a.expireEvent(oldestMsg)
+					break
+				}
+			})
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// Start the api server, starts to consume the msg queue
+func (a *APIServer) Start(ctx context.Context) {
+	go a.start(ctx)
+}
+
 // SendEvent forwards events sent by the runtime security module to Datadog
-func (a *APIServer) SendEvent(rule *rules.Rule, event Event) {
+func (a *APIServer) SendEvent(rule *rules.Rule, event Event, extTagsCb func() []string) {
 	agentContext := &AgentContext{
 		RuleID:      rule.Definition.ID,
 		RuleVersion: rule.Definition.Version,
@@ -128,30 +224,25 @@ func (a *APIServer) SendEvent(rule *rules.Rule, event Event) {
 	data = append(data, ruleEventJSON[1:]...)
 	log.Tracef("Sending event message for rule `%s` to security-agent `%s`", rule.ID, string(data))
 
-	msg := &api.SecurityEventMessage{
-		RuleID: rule.Definition.ID,
-		Data:   data,
-		Tags:   append(rule.Tags, append(event.GetTags(), "rule_id:"+rule.Definition.ID)...),
+	msg := &pendingMsg{
+		ruleID:    rule.Definition.ID,
+		data:      data,
+		extTagsCb: extTagsCb,
+		tags:      make(map[string]bool),
+		sendAfter: time.Now().Add(defaultSendEventDelay),
 	}
 
-	select {
-	case a.msgs <- msg:
-		break
-	default:
-		// The channel is full, consume the oldest event
-		oldestMsg := <-a.msgs
-		// Try to send the event again
-		select {
-		case a.msgs <- msg:
-			break
-		default:
-			// Looks like the channel is full again, expire the current message too
-			a.expireEvent(msg)
-			break
-		}
-		a.expireEvent(oldestMsg)
-		break
+	msg.tags["rule_id:"+rule.Definition.ID] = true
+
+	for _, tag := range rule.Tags {
+		msg.tags[tag] = true
 	}
+
+	for _, tag := range event.GetTags() {
+		msg.tags[tag] = true
+	}
+
+	a.enqueue(msg)
 }
 
 // expireEvent updates the count of expired messages for the appropriate rule

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -509,6 +509,7 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 // OnRuleMatch is called when a rule matches just before sending
 func (p *Probe) OnRuleMatch(rule *rules.Rule, event *Event) {
 	// ensure that all the fields are resolved before sending
+	event.ResolveContainerID(&event.ContainerContext)
 	event.ResolveContainerTags(&event.ContainerContext)
 }
 


### PR DESCRIPTION
### What does this PR do?

Introduce a queue to delay tags resolution just before sending event.

### Motivation

Try to resolve tags just before sending event add a queue to delay a bit more to let the remote tagger retrieve the tags.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
