### PR TITLE
[serverless] hotfix for serverless traces being sent with hostname

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -363,6 +363,7 @@ func runAgent(ctx context.Context, stopCh chan struct{}) (err error) {
 	var ta *traceAgent.Agent
 	if config.Datadog.GetBool("apm_config.enabled") {
 		tc, confErr := traceConfig.Load(datadogConfigPath)
+		tc.Hostname = ""
 		tc.GlobalTags[traceOriginMetadataKey] = traceOriginMetadataValue
 		tc.SynchronousFlushing = true
 		if confErr != nil {


### PR DESCRIPTION
### What does this PR do?

Hotfix for an issue where hostname was non-empty for serverless traces. The hostname was being set to the IP address of the serverless environment.

### Motivation
Excess host names were causing billing implications for a small segment of customers.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Performed a manual test of built extension.
