### PR TITLE
If process-agent doesn't query for 20 mins, exit network tracer / system-probe

### DIFF
--- a/cmd/system-probe/modules/all_linux.go
+++ b/cmd/system-probe/modules/all_linux.go
@@ -2,7 +2,11 @@
 
 package modules
 
-import "github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
+import (
+	"time"
+
+	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
+)
 
 // All System Probe modules should register their factories here
 var All = []module.Factory{
@@ -11,4 +15,8 @@ var All = []module.Factory{
 	OOMKillProbe,
 	SecurityRuntime,
 	Process,
+}
+
+func inactivityEventLog(duration time.Duration) {
+
 }

--- a/cmd/system-probe/modules/all_windows.go
+++ b/cmd/system-probe/modules/all_windows.go
@@ -2,9 +2,28 @@
 
 package modules
 
-import "github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
+import (
+	"time"
+
+	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
+	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	"golang.org/x/sys/windows/svc/eventlog"
+)
 
 // All System Probe modules should register their factories here
 var All = []module.Factory{
 	NetworkTracer,
+}
+
+const (
+	msgSysprobeRestartInactivity = 0x8000000f
+)
+
+func inactivityEventLog(duration time.Duration) {
+	elog, err := eventlog.Open(config.ServiceName)
+	if err != nil {
+		return
+	}
+	defer elog.Close()
+	elog.Warning(msgSysprobeRestartInactivity, duration.String())
 }

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync/atomic"
 	"time"
 
@@ -113,11 +114,13 @@ func (nt *networkTracer) Register(httpMux *http.ServeMux) error {
 		}
 	})
 
-	nt.restartTimer = time.AfterFunc(inactivityRestartDuration, func() {
-		log.Criticalf("%v since the process-agent last queried for data. It may not be configured correctly and/or running. Exiting system-probe to save system resources.", inactivityRestartDuration)
-		nt.Close()
-		os.Exit(1)
-	})
+	if runtime.GOOS == "windows" {
+		nt.restartTimer = time.AfterFunc(inactivityRestartDuration, func() {
+			log.Criticalf("%v since the process-agent last queried for data. It may not be configured correctly and/or running. Exiting system-probe to save system resources.", inactivityRestartDuration)
+			nt.Close()
+			os.Exit(1)
+		})
+	}
 
 	return nil
 }

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -24,7 +24,8 @@ import (
 // ErrSysprobeUnsupported is the unsupported error prefix, for error-class matching from callers
 var ErrSysprobeUnsupported = errors.New("system-probe unsupported")
 
-var inactivityLogDuration = 10 * time.Minute
+const inactivityLogDuration = 10 * time.Minute
+const inactivityRestartDuration = 20 * time.Minute
 
 // NetworkTracer is a factory for NPM's tracer
 var NetworkTracer = module.Factory{
@@ -47,7 +48,8 @@ var NetworkTracer = module.Factory{
 var _ module.Module = &networkTracer{}
 
 type networkTracer struct {
-	tracer *tracer.Tracer
+	tracer       *tracer.Tracer
+	restartTimer *time.Timer
 }
 
 func (nt *networkTracer) GetStats() map[string]interface{} {
@@ -72,6 +74,9 @@ func (nt *networkTracer) Register(httpMux *http.ServeMux) error {
 		marshaler := encoding.GetMarshaler(contentType)
 		writeConnections(w, marshaler, cs)
 
+		if nt.restartTimer != nil {
+			nt.restartTimer.Reset(inactivityRestartDuration)
+		}
 		count := atomic.AddUint64(&runCounter, 1)
 		logRequests(id, count, len(cs.Conns), start)
 	})
@@ -106,6 +111,12 @@ func (nt *networkTracer) Register(httpMux *http.ServeMux) error {
 		if run := atomic.LoadUint64(&runCounter); run == 0 {
 			log.Warnf("%v since the agent started without activity, the process-agent may not be configured correctly and/or running", inactivityLogDuration)
 		}
+	})
+
+	nt.restartTimer = time.AfterFunc(inactivityRestartDuration, func() {
+		log.Criticalf("%v since the process-agent last queried for data. It may not be configured correctly and/or running. Exiting system-probe to save system resources.", inactivityRestartDuration)
+		nt.Close()
+		os.Exit(1)
 	})
 
 	return nil

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -117,6 +117,7 @@ func (nt *networkTracer) Register(httpMux *http.ServeMux) error {
 	if runtime.GOOS == "windows" {
 		nt.restartTimer = time.AfterFunc(inactivityRestartDuration, func() {
 			log.Criticalf("%v since the process-agent last queried for data. It may not be configured correctly and/or running. Exiting system-probe to save system resources.", inactivityRestartDuration)
+      inactivityEventLog(inactivityRestartDuration)
 			nt.Close()
 			os.Exit(1)
 		})

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -117,7 +117,7 @@ func (nt *networkTracer) Register(httpMux *http.ServeMux) error {
 	if runtime.GOOS == "windows" {
 		nt.restartTimer = time.AfterFunc(inactivityRestartDuration, func() {
 			log.Criticalf("%v since the process-agent last queried for data. It may not be configured correctly and/or running. Exiting system-probe to save system resources.", inactivityRestartDuration)
-      inactivityEventLog(inactivityRestartDuration)
+			inactivityEventLog(inactivityRestartDuration)
 			nt.Close()
 			os.Exit(1)
 		})

--- a/cmd/system-probe/windows_resources/system-probe-msg.mc
+++ b/cmd/system-probe/windows_resources/system-probe-msg.mc
@@ -104,3 +104,11 @@ Severity=Error
 Language=English
 The service failed to start. Error %1
 .
+
+MessageId=15
+SymbolicName=MSG_SYSPROBE_RESTART_INACTIVITY
+Severity=Warning
+Language=English
+System probe restarting after %1.  The process agent has not queried for data.  It may not be configured correctly and/or running.
+.
+

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -317,6 +317,12 @@
                     KeyPath="yes"
                     DiskId="1"
                     Source="$(var.BinFiles)/system-probe.exe" />
+                <!-- The "Name" field must match the argument to eventlog.Open() -->
+                <util:EventSource Log="Application" Name="datadog-system-probe"
+                      EventMessageFile="[AGENT]system-probe.exe"
+                      SupportsErrors="yes"
+                      SupportsInformationals="yes"
+                      SupportsWarnings="yes"/>
                 </Component>
             <?endif ?> <!-- include sysprobe -->
           <?endif ?>


### PR DESCRIPTION
### What does this PR do?

Exits network-tracer/system-probe after a period of inactivity from process-agent. 

### Motivation

This is to save system resources from the driver/ebpf code that just accumulate when they are not being queried/polled. Specifically non-paged memory on Windows.

### Additional Notes

This will exit other system-probe modules if they are enabled alongside network tracer. We don't have a way to restart system-probe modules at the moment, but that is being worked on for 7.29. When that is added, we can change this code to restart only the network module (at least on Linux).