### PR TITLE
Fix incessant deprecation warnings relating to no_proxy_nonexact_match

### DIFF
--- a/pkg/util/http/transport.go
+++ b/pkg/util/http/transport.go
@@ -128,11 +128,10 @@ func GetProxyTransportFunc(p *config.Proxy) func(*http.Request) (*url.URL, error
 		// Print a warning if the proxy behavior would change if the new no_proxy behavior would be enabled
 		newURL, _ := proxyConfig.ProxyFunc()(r.URL)
 		if url != newURL && url != nil {
-			urlString := r.URL.String()
+			logSafeURL := r.URL.Scheme + "://" + r.URL.Host
 			NoProxyWarningMapMutex.Lock()
-			if _, ok := NoProxyWarningMap[urlString]; !ok {
-				NoProxyWarningMap[log.SanitizeURL(r.URL.String())] = true
-				logSafeURL := r.URL.Scheme + "://" + r.URL.Host
+			if _, ok := NoProxyWarningMap[logSafeURL]; !ok {
+				NoProxyWarningMap[logSafeURL] = true
 				log.Warnf("Deprecation warning: the HTTP request to %s uses proxy %s but will ignore the proxy when the Agent configuration option no_proxy_nonexact_match defaults to true in a future agent version. Please adapt the Agent’s proxy configuration accordingly", logSafeURL, url.String())
 			}
 			NoProxyWarningMapMutex.Unlock()

--- a/releasenotes/notes/Clean-Transport-Proxy-Warnings-73960284f00c3e17.yaml
+++ b/releasenotes/notes/Clean-Transport-Proxy-Warnings-73960284f00c3e17.yaml
@@ -1,0 +1,5 @@
+fixes:
+  - |
+    Fix incessant deprecation warnings relating to no_proxy_nonexact_match.
+    Transport Proxy Warnings will now only list the affected HTTP scheme and
+    host necessary to adjust the agent's proxy settings.


### PR DESCRIPTION
### What does this PR do?

Fix incessant deprecation warnings and clean the NoProxyWarningMap.

`urlString` is never added to `NoProxyWarningMap` which causes the deprecation warning to be logged every time payload is sent out. We check for the existence of raw URL `urlString` (`if _, ok := NoProxyWarningMap[urlString]`) but stores the scrubbed URL  (`NoProxyWarningMap[log.SanitizeURL(r.URL.String())] = true`).

There is no sense to keep logging these since affected URLs will show up in `agent status`.

I've decided to check/store only the `logSafeURL` (containing only the scheme+host) which has enough information to adjust the agent's proxy settings.

Before this PR:

```
  Transport Proxy Warnings
  ========================
    The following URLs used a proxy - but will ignore the proxy in future Agent versions with the no_proxy setting.
    Enable the new behavior now with no_proxy_nonexact_match: true
      https://7-29-0-app.agent.datadoghq.com/api/v1/check_run?api_key=*************************12345
      https://7-29-0-app.agent.datadoghq.com/api/v1/series?api_key=*************************12345
      https://7-29-0-app.agent.datadoghq.com/intake/?api_key=*************************12345
      https://api.datadoghq.com/api/v1/validate?api_key=*************************12345
```

After this PR:

```
  Transport Proxy Warnings
  ========================
    The following URLs used a proxy - but will ignore the proxy in future Agent versions with the no_proxy setting.
    Enable the new behavior now with no_proxy_nonexact_match: true
      https://7-29-0-app.agent.datadoghq.com
      https://api.datadoghq.com
```


### Motivation

Worked on this block of code + dev day

### Additional Notes


### Describe your test plan

Test with a proxy config similar to:

```
no_proxy_nonexact_match: false
proxy:
  https: http://localhost:8888/
  http: http://localhost:8888/
  no_proxy:
    - datadoghq.com  
```

