### PR TITLE
Add an event viewer notification when we restart due to inactivity

### DIFF
--- a/cmd/system-probe/modules/all_linux.go
+++ b/cmd/system-probe/modules/all_linux.go
@@ -12,3 +12,7 @@ var All = []module.Factory{
 	SecurityRuntime,
 	Process,
 }
+
+func inactivityEventLog(duration string) {
+
+}

--- a/cmd/system-probe/modules/all_linux.go
+++ b/cmd/system-probe/modules/all_linux.go
@@ -2,7 +2,11 @@
 
 package modules
 
-import "github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
+import (
+	"time"
+
+	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
+)
 
 // All System Probe modules should register their factories here
 var All = []module.Factory{
@@ -13,6 +17,6 @@ var All = []module.Factory{
 	Process,
 }
 
-func inactivityEventLog(duration string) {
+func inactivityEventLog(duration time.Duration) {
 
 }

--- a/cmd/system-probe/modules/all_unsupported.go
+++ b/cmd/system-probe/modules/all_unsupported.go
@@ -6,7 +6,3 @@ import "github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 
 // All System Probe modules should register their factories here
 var All = []module.Factory{}
-
-func inactivityEventLog(duration string) {
-
-}

--- a/cmd/system-probe/modules/all_unsupported.go
+++ b/cmd/system-probe/modules/all_unsupported.go
@@ -6,3 +6,7 @@ import "github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 
 // All System Probe modules should register their factories here
 var All = []module.Factory{}
+
+func inactivityEventLog(duration string) {
+
+}

--- a/cmd/system-probe/modules/all_windows.go
+++ b/cmd/system-probe/modules/all_windows.go
@@ -3,6 +3,8 @@
 package modules
 
 import (
+	"time"
+
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	"golang.org/x/sys/windows/svc/eventlog"
@@ -17,12 +19,11 @@ const (
 	msgSysprobeRestartInactivity = 0x8000000f
 )
 
-func inactivityEventLog(duration string) {
+func inactivityEventLog(duration time.Duration) {
 	elog, err := eventlog.Open(config.ServiceName)
 	if err != nil {
 		return
 	}
 	defer elog.Close()
-	elog.Warning(msgSysprobeRestartInactivity, duration)
-	return
+	elog.Warning(msgSysprobeRestartInactivity, duration.String())
 }

--- a/cmd/system-probe/modules/all_windows.go
+++ b/cmd/system-probe/modules/all_windows.go
@@ -2,9 +2,27 @@
 
 package modules
 
-import "github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
+import (
+	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
+	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	"golang.org/x/sys/windows/svc/eventlog"
+)
 
 // All System Probe modules should register their factories here
 var All = []module.Factory{
 	NetworkTracer,
+}
+
+const (
+	msgSysprobeRestartInactivity = 0x8000000f
+)
+
+func inactivityEventLog(duration string) {
+	elog, err := eventlog.Open(config.ServiceName)
+	if err != nil {
+		return
+	}
+	defer elog.Close()
+	elog.Warning(msgSysprobeRestartInactivity, duration)
+	return
 }

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -115,6 +115,7 @@ func (nt *networkTracer) Register(httpMux *http.ServeMux) error {
 
 	nt.restartTimer = time.AfterFunc(inactivityRestartDuration, func() {
 		log.Criticalf("%v since the process-agent last queried for data. It may not be configured correctly and/or running. Exiting system-probe to save system resources.", inactivityRestartDuration)
+		inactivityEventLog(inactivityRestartDuration.String())
 		nt.Close()
 		os.Exit(1)
 	})

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -115,7 +115,7 @@ func (nt *networkTracer) Register(httpMux *http.ServeMux) error {
 
 	nt.restartTimer = time.AfterFunc(inactivityRestartDuration, func() {
 		log.Criticalf("%v since the process-agent last queried for data. It may not be configured correctly and/or running. Exiting system-probe to save system resources.", inactivityRestartDuration)
-		inactivityEventLog(inactivityRestartDuration.String())
+		inactivityEventLog(inactivityRestartDuration)
 		nt.Close()
 		os.Exit(1)
 	})

--- a/cmd/system-probe/windows_resources/system-probe-msg.mc
+++ b/cmd/system-probe/windows_resources/system-probe-msg.mc
@@ -109,6 +109,6 @@ MessageId=15
 SymbolicName=MSG_SYSPROBE_RESTART_INACTIVITY
 Severity=Warning
 Language=English
-System probe restarting afer %1.  The process agent has not queried for data.  It may not be configured correctly and/or running.
+System probe restarting after %1.  The process agent has not queried for data.  It may not be configured correctly and/or running.
 .
 

--- a/cmd/system-probe/windows_resources/system-probe-msg.mc
+++ b/cmd/system-probe/windows_resources/system-probe-msg.mc
@@ -104,3 +104,11 @@ Severity=Error
 Language=English
 The service failed to start. Error %1
 .
+
+MessageId=15
+SymbolicName=MSG_SYSPROBE_RESTART_INACTIVITY
+Severity=Warning
+Language=English
+System probe restarting afer %1.  The process agent has not queried for data.  It may not be configured correctly and/or running.
+.
+

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -317,6 +317,12 @@
                     KeyPath="yes"
                     DiskId="1"
                     Source="$(var.BinFiles)/system-probe.exe" />
+                <!-- The "Name" field must match the argument to eventlog.Open() -->
+                <util:EventSource Log="Application" Name="datadog-system-probe"
+                      EventMessageFile="[AGENT]system-probe.exe"
+                      SupportsErrors="yes"
+                      SupportsInformationals="yes"
+                      SupportsWarnings="yes"/>
                 </Component>
             <?endif ?> <!-- include sysprobe -->
           <?endif ?>


### PR DESCRIPTION
timeout.

Fix the fact that the event logs for the system probe were never
properly set up; otherwise the log that's generated is not helpful


### Motivation

Add additional information if/when we hit this case.

### Additional Notes

Need to add change to setup, otherwise the only message that's logged is that the message file isn't present.

### Describe your test plan

Write there any instructions and details that should be tested during the QA.
