### PR TITLE
Separate hinted API and APP key replacers

### DIFF
--- a/pkg/util/log/strip.go
+++ b/pkg/util/log/strip.go
@@ -28,11 +28,17 @@ var blankRegex = regexp.MustCompile(`^\s*$`)
 var singleLineReplacers, multiLineReplacers []Replacer
 
 func init() {
-	hintedKeyReplacer := Replacer{
-		// If hinted, mask the value regardless if it doesn't match 32/40-char hexadecimal string
-		Regex: regexp.MustCompile(`(ap[ip]_key=)\b[a-zA-Z0-9]+([a-zA-Z0-9]{5})\b`),
-		Hints: []string{"api_key", "app_key"},
+	hintedAPIKeyReplacer := Replacer{
+		// If hinted, mask the value regardless if it doesn't match 32-char hexadecimal string
+		Regex: regexp.MustCompile(`(api_?key=)\b[a-zA-Z0-9]+([a-zA-Z0-9]{5})\b`),
+		Hints: []string{"api_key", "apikey"},
 		Repl:  []byte(`$1***************************$2`),
+	}
+	hintedAPPKeyReplacer := Replacer{
+		// If hinted, mask the value regardless if it doesn't match 40-char hexadecimal string
+		Regex: regexp.MustCompile(`(ap(?:p|plication)_?key=)\b[a-zA-Z0-9]+([a-zA-Z0-9]{5})\b`),
+		Hints: []string{"app_key", "appkey", "application_key"},
+		Repl:  []byte(`$1***********************************$2`),
 	}
 	apiKeyReplacer := Replacer{
 		Regex: regexp.MustCompile(`\b[a-fA-F0-9]{27}([a-fA-F0-9]{5})\b`),
@@ -68,7 +74,7 @@ func init() {
 		Hints: []string{"BEGIN"},
 		Repl:  []byte(`********`),
 	}
-	singleLineReplacers = []Replacer{hintedKeyReplacer, apiKeyReplacer, appKeyReplacer, uriPasswordReplacer, passwordReplacer, tokenReplacer, snmpReplacer}
+	singleLineReplacers = []Replacer{hintedAPIKeyReplacer, hintedAPPKeyReplacer, apiKeyReplacer, appKeyReplacer, uriPasswordReplacer, passwordReplacer, tokenReplacer, snmpReplacer}
 	multiLineReplacers = []Replacer{certReplacer}
 }
 

--- a/pkg/util/log/strip_test.go
+++ b/pkg/util/log/strip_test.go
@@ -147,6 +147,30 @@ func TestTextStripApiKey(t *testing.T) {
 	assertClean(t,
 		`Error status code 500 : http://dog.tld/api?key=3290abeefc68e1bbe852a25252bad88c`,
 		`Error status code 500 : http://dog.tld/api?key=***************************ad88c`)
+	assertClean(t,
+		`hintedAPIKeyReplacer : http://dog.tld/api_key=InvalidLength12345abbbb`,
+		`hintedAPIKeyReplacer : http://dog.tld/api_key=***************************abbbb`)
+	assertClean(t,
+		`hintedAPIKeyReplacer : http://dog.tld/apikey=InvalidLength12345abbbb`,
+		`hintedAPIKeyReplacer : http://dog.tld/apikey=***************************abbbb`)
+	assertClean(t,
+		`apiKeyReplacer: https://agent-http-intake.logs.datadoghq.com/v1/input/aaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb`,
+		`apiKeyReplacer: https://agent-http-intake.logs.datadoghq.com/v1/input/***************************abbbb`)
+}
+
+func TestTextStripAppKey(t *testing.T) {
+	assertClean(t,
+		`hintedAPPKeyReplacer : http://dog.tld/app_key=InvalidLength12345abbbb`,
+		`hintedAPPKeyReplacer : http://dog.tld/app_key=***********************************abbbb`)
+	assertClean(t,
+		`hintedAPPKeyReplacer : http://dog.tld/appkey=InvalidLength12345abbbb`,
+		`hintedAPPKeyReplacer : http://dog.tld/appkey=***********************************abbbb`)
+	assertClean(t,
+		`hintedAPPKeyReplacer : http://dog.tld/application_key=InvalidLength12345abbbb`,
+		`hintedAPPKeyReplacer : http://dog.tld/application_key=***********************************abbbb`)
+	assertClean(t,
+		`appKeyReplacer: http://dog.tld/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbb`,
+		`appKeyReplacer: http://dog.tld/***********************************abbbb`)
 }
 
 func TestTextStripURLPassword(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Separates `hintedKeyReplacer` so that masked application keys return 40 characters

### Motivation

Wanted to add tests for https://github.com/DataDog/datadog-agent/pull/7330

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

Run the agent with an invalid API key (less than or more than 32 characters in length)

Or configure an http_check with `url: http://some.url.example.com/?application_key=aaaaaa12345` and run `agent check http_check -l debug | grep LogMessage | grep application_key`

Resulting log should be masked and 40 characters long for an app key, 32 for an api key. E.g.

```
 CORE | INFO | (pkg/collector/python/datadog_agent.go:124 in LogMessage) | http_check:My first service:49372ed38a10f44f | (http_check.py:133) | http://some.url.example.com/?application_key=***********************************12345 is DOWN
```
