### PR TITLE
Imports Agent5 value for `dogstatsd_non_local_traffic`

### DIFF
--- a/pkg/config/legacy/converter.go
+++ b/pkg/config/legacy/converter.go
@@ -147,6 +147,7 @@ func FromAgentConfig(agentConfig Config, converter *config.LegacyConfigConverter
 
 	if agentConfig["non_local_traffic"] != "" {
 		if enabled, err := isAffirmative(agentConfig["non_local_traffic"]); err == nil {
+			converter.Set("dogstatsd_non_local_traffic", enabled)
 			// trace-agent listen locally by default, convert the config only if configured to listen to more
 			converter.Set("apm_config.apm_non_local_traffic", enabled)
 		}

--- a/pkg/config/legacy/converter_test.go
+++ b/pkg/config/legacy/converter_test.go
@@ -267,7 +267,8 @@ func TestConverter(t *testing.T) {
 	for k, v := range map[string]bool{
 		"hostname_fqdn":                    true,
 		"apm_config.enabled":               false,
-		"apm_config.apm_non_local_traffic": false,
+		"apm_config.apm_non_local_traffic": true,
+		"dogstatsd_non_local_traffic":      true,
 		"skip_ssl_validation":              false,
 		"apm_config.log_throttling":        true, // trace.config.log_throttling
 	} {

--- a/pkg/config/legacy/importer.go
+++ b/pkg/config/legacy/importer.go
@@ -53,8 +53,8 @@ var (
 		"syslog_port",
 		"collect_instance_metadata",
 		"listen_port",          // not for 6.0, ignore for now
-		"non_local_traffic",    // not for 6.0, converted for the trace-agent
 		"create_dd_check_tags", // not for 6.0, ignore for now
+		"non_local_traffic",    // converted for the trace-agent and dogstatsd
 		"bind_host",
 		"proxy_forbid_method_switch", // deprecated
 		"collect_orchestrator_tags",  // deprecated

--- a/pkg/config/legacy/tests/config.json
+++ b/pkg/config/legacy/tests/config.json
@@ -25,7 +25,7 @@
   "listen_port": "17123",
   "log_level": "INFO",
   "log_to_syslog": "True",
-  "non_local_traffic": "False",
+  "non_local_traffic": "True",
   "proxy_forbid_method_switch": "False",
   "proxy_host": "my-proxy.com",
   "proxy_password": "password",

--- a/pkg/config/legacy/tests/datadog.conf
+++ b/pkg/config/legacy/tests/datadog.conf
@@ -84,7 +84,7 @@ additional_checksd: /etc/dd-agent/checks.d/
 # that might not have an internet connection
 # For more information, please see
 # https://github.com/DataDog/dd-agent/wiki/Network-Traffic-and-Proxy-Configuration
-non_local_traffic: False
+non_local_traffic: True
 
 # Select the Tornado HTTP Client to be used in the Forwarder,
 # between curl client and simple http client (default: simple http client)

--- a/releasenotes/notes/Import-dogstatsd-non-local-traffic-f86c6f2174f96d55.yaml
+++ b/releasenotes/notes/Import-dogstatsd-non-local-traffic-f86c6f2174f96d55.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Imports the value of `non_local_traffic` to `dogstatsd_non_local_traffic`
+    (in addition to `apm_config.non_local_traffic`) when upgrading from
+    Datadog Agent v5.


### PR DESCRIPTION
### What does this PR do?

Imports the value of `non_local_traffic` for `dogstatsd_non_local_traffic` (in addition to `apm_config.non_local_traffic`) when upgrading from Datadog Agent v5.

### Motivation

AGENT-6101
Customer upgraded from v5 and suddenly lost Dogstatsd metrics being sent from external host.

### Additional Notes

Anything else we should know when reviewing?

### Describe your test plan

- Create an old conf with `non_local_traffic` set to non-default

```
mkdir /tmp/dd{5,6}

cat <<-EOF > /tmp/dd5/datadog.conf
[Main]
non_local_traffic: yes
EOF
```

- Run the import command: `agent import /tmp/dd5/ /tmp/dd6`
- Check if set accordingly: `grep non_local_traffic /tmp/dd6/datadog.yaml`
   expected result:
```
  apm_non_local_traffic: true
dogstatsd_non_local_traffic: true
```
