### PR TITLE
Fix DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_ADDITIONAL_ENDPOINTS env variable

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -749,8 +749,8 @@ func InitConfig(config Config) {
 	// this option will potentially impact the CPU usage of the agent
 	config.BindEnvAndSetDefault("orchestrator_explorer.container_scrubbing.enabled", true)
 	config.BindEnvAndSetDefault("orchestrator_explorer.custom_sensitive_words", []string{})
-	config.BindEnv("orchestrator_explorer.max_per_message")     //nolint:errcheck
-	config.BindEnv("orchestrator_explorer.orchestrator_dd_url") //nolint:errcheck
+	config.BindEnv("orchestrator_explorer.max_per_message")                   //nolint:errcheck
+	config.BindEnv("orchestrator_explorer.orchestrator_dd_url")               //nolint:errcheck
 	config.BindEnv("orchestrator_explorer.orchestrator_additional_endpoints") //nolint:errcheck
 
 	// Orchestrator Explorer - process agent

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -751,6 +751,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("orchestrator_explorer.custom_sensitive_words", []string{})
 	config.BindEnv("orchestrator_explorer.max_per_message")     //nolint:errcheck
 	config.BindEnv("orchestrator_explorer.orchestrator_dd_url") //nolint:errcheck
+	config.BindEnv("orchestrator_explorer.orchestrator_additional_endpoints") //nolint:errcheck
 
 	// Orchestrator Explorer - process agent
 	// DEPRECATED in favor of `orchestrator_explorer.orchestrator_dd_url` setting. If both are set `orchestrator_explorer.orchestrator_dd_url` will take precedence.

--- a/releasenotes-dca/notes/orchestrator-endpoints-20ad5a633c8ccc29.yaml
+++ b/releasenotes-dca/notes/orchestrator-endpoints-20ad5a633c8ccc29.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix a bug preventing the
+    "DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_ADDITIONAL_ENDPOINTS" environment
+    variable to be read.


### PR DESCRIPTION
### What does this PR do?

Fix a bug preventing `DD_ORCHESTRATOR_EXPLORER_ORCHESTRATOR_ADDITIONAL_ENDPOINTS` to be read in order to set additional endpoints for the orchestrator explorer.

This is

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
