### PR TITLE
[backport][Windows] Remove debug binaries from shipped package

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -102,7 +102,13 @@ build do
       move 'bin/agent/dist/system-probe.yaml', "#{conf_dir}/system-probe.yaml.example"
   end
   move 'bin/agent/dist/conf.d', "#{conf_dir}/"
-  copy 'bin/agent', "#{install_dir}/bin/"
+
+  unless windows?
+    copy 'bin/agent', "#{install_dir}/bin/"
+  else
+    copy 'bin/agent/ddtray.exe', "#{install_dir}/bin/agent"
+    copy 'bin/agent/dist', "#{install_dir}/bin/agent"
+  end
 
   block do
     # defer compilation step in a block to allow getting the project's build version, which is populated


### PR DESCRIPTION
### What does this PR do?

Backport https://github.com/DataDog/datadog-agent/pull/7974