### PR TITLE
[system-probe] Fix system-probe profiler

### DIFF
--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -141,7 +141,7 @@ func load(configPath string) (*Config, error) {
 
 		ProfilingEnabled:     cfg.GetBool(key(spNS, "internal_profiling.enabled")),
 		ProfilingSite:        cfg.GetString(key(spNS, "internal_profiling.site")),
-		ProfilingURL:         cfg.GetString(key(spNS, "profiling.profile_dd_url")),
+		ProfilingURL:         cfg.GetString(key(spNS, "internal_profiling.profile_dd_url")),
 		ProfilingAPIKey:      aconfig.SanitizeAPIKey(cfg.GetString(key(spNS, "internal_profiling.api_key"))),
 		ProfilingEnvironment: cfg.GetString(key(spNS, "internal_profiling.env")),
 	}


### PR DESCRIPTION
### What does this PR do?

This PR fixes a typo in the system-probe profiler configuration and a typo that would stop the profiler on startup, even if activated. 

### Motivation

Make sure we can activate the profiler on system-probe.

### Describe how to test your changes

The profiler is only used for debugging purposes. The Runtime security agent team is considering activating it in the CI while running stress tests & functional tests. For now, no real testing is required.