### PR TITLE
Windows installer: Do not compare netbios and fqdn

### DIFF
--- a/tools/windows/install-help/cal/TargetMachine.cpp
+++ b/tools/windows/install-help/cal/TargetMachine.cpp
@@ -191,19 +191,14 @@ DWORD TargetMachine::DetectDomainInformation()
         WcaLog(LOGMSG_STANDARD, "Computer is joined to a workgroup");
         break;
     case NetSetupDomainName:
-        WcaLog(LOGMSG_STANDARD, "Computer is joined to domain \"%S\"", _joinedDomain.c_str());
+        // Print both domain names: NETBIOS and FQDN
+        WcaLog(LOGMSG_STANDARD, "Computer is joined to domain \"%S\" (\"%S\")", _joinedDomain.c_str(), _dnsDomainName.c_str());
         _isDomainJoined = true;
         break;
     }
 
     if (_isDomainJoined)
     {
-        if (_wcsicmp(_dnsDomainName.c_str(), _joinedDomain.c_str()) != 0)
-        {
-            WcaLog(LOGMSG_STANDARD, "DNS domain name \"%S\" doesn't match the joined domain \"%S\"",
-                   _dnsDomainName.c_str(), _joinedDomain.c_str());
-        }
-
         // Detect if we are on a read-only domain controller
         if (IsDomainController())
         {


### PR DESCRIPTION
### What does this PR do?

Remove string compare and always log both fields.

### Motivation

It doesn't make any difference if the fields are equal or not, the two
names can be different and that's okay (and they could match and that's
also okay). Still print them both so they appear in the logs.
