### PR TITLE
[DCA][Entrypoint] Allow configuring default check config

### DIFF
--- a/Dockerfiles/cluster-agent/entrypoint.sh
+++ b/Dockerfiles/cluster-agent/entrypoint.sh
@@ -14,7 +14,7 @@ if [[ -z "$DD_API_KEY" ]]; then
 fi
 
 ##### Copy the custom confs removing any ".." folder in the paths #####
-find /conf.d -name '*.yaml' | sed -E "s#/\.\.[^/]+##" | xargs -I{} cp --parents -fv {} /etc/datadog-agent/
+find /conf.d -name '*.yaml' -o -name '*.yaml.default' | sed -E "s#/\.\.[^/]+##" | xargs -I{} cp --parents -fv {} /etc/datadog-agent/
 
 ##### Starting up #####
 export PATH="/opt/datadog-agent/bin/datadog-cluster-agent/:/opt/datadog-agent/embedded/bin/":$PATH


### PR DESCRIPTION
### What does this PR do?

`*.yaml.default` check configuration files can now be passed via confd

### Motivation

Allow users to change a default check configurations via confd.
Example: https://github.com/DataDog/helm-charts/pull/219 adds a default ksm core configuration and names it `kubernetes_state_core.yaml.default`, customers would be allowed to override it by configuring `confd`.  The Cluster Agent will ignore `*.yaml.default` and run the new config in this case.

### Describe how to test your changes

Should be tested with https://github.com/DataDog/helm-charts/pull/219
- Enable `datadog.kubeStateMetricsCore.enabled` 
- Configure another `kubernetes_state_core.yaml` via `confd` and make sure the DCA schedules the custom check not the default
