### PR TITLE
[CI] Report exceptions during message creation

### DIFF
--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import io
 import os
 import re

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -1,5 +1,7 @@
+import io
 import os
 import re
+import traceback
 from collections import defaultdict
 
 from invoke import task
@@ -173,24 +175,10 @@ Please check for typos in the JOBOWNERS file and/or add them to the Github <-> S
 """
 
 
-@task
-def notify_failure(_, notification_type="merge", print_to_stdout=False):
-    """
-    Send failure notifications for the current pipeline. CI-only task.
-    Use the --print-to-stdout option to test this locally, without sending
-    real slack messages.
-    """
-    header = ""
-    if notification_type == "merge":
-        header = ":host-red: :merged: datadog-agent merge"
-    elif notification_type == "deploy":
-        header = ":host-red: :rocket: datadog-agent deploy"
-
+def generate_failure_messages(base):
     project_name = "DataDog/datadog-agent"
     all_teams = "@DataDog/agent-all"
     failed_jobs = get_failed_jobs(project_name, os.getenv("CI_PIPELINE_ID"))
-    base = base_message(header)
-
     # Generate messages for each team
     messages_to_send = defaultdict(lambda: TeamMessage(base))
     messages_to_send[all_teams] = SlackMessage(base, jobs=failed_jobs)
@@ -214,6 +202,39 @@ def notify_failure(_, notification_type="merge", print_to_stdout=False):
             pass
             # TODO: enable also jobs
             # messages_to_send[owner].failed_jobs = jobs
+
+    return messages_to_send
+
+
+@task
+def notify_failure(_, notification_type="merge", print_to_stdout=False):
+    """
+    Send failure notifications for the current pipeline. CI-only task.
+    Use the --print-to-stdout option to test this locally, without sending
+    real slack messages.
+    """
+
+    header = ""
+    if notification_type == "merge":
+        header = ":host-red: :merged: datadog-agent merge"
+    elif notification_type == "deploy":
+        header = ":host-red: :rocket: datadog-agent deploy"
+    base = base_message(header)
+
+    try:
+        messages_to_send = generate_failure_messages(base)
+    except Exception as e:
+        buffer = io.StringIO()
+        print(base, file=buffer)
+        print("Found exception when generating notification:", file=buffer)
+        traceback.print_exc(limit=-1, file=buffer)
+        print("See the job log for the full exception traceback.", file=buffer)
+        messages_to_send = {
+            "@DataDog/agent-all": SlackMessage(buffer.getvalue()),
+        }
+        # Print traceback on job log
+        print(e)
+        traceback.print_exc()
 
     # Send messages
     for owner, message in messages_to_send.items():


### PR DESCRIPTION
### What does this PR do?

- Report any exception that happened during message creation on Slack.

### Motivation

- Have Slack notifications when things fail

### Describe how to test your changes

Check that doing
```
CI_PIPELINE_ID=4332986 inv -e pipeline.notify-failure --print-to-stdout
```
works properly.

Add an exception on the Python code and do
```
CI_PIPELINE_ID=4332986 inv -e pipeline.notify-failure --print-to-stdout
```
Check that it would send a failure message.
