### PR TITLE
fix apiserver cache timeout config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -506,7 +506,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("leader_lease_duration", "60")
 	config.BindEnvAndSetDefault("leader_election", false)
 	config.BindEnvAndSetDefault("kube_resources_namespace", "")
-	config.BindEnvAndSetDefault("cache_sync_timeout", 2) // in seconds
+	config.BindEnvAndSetDefault("kube_cache_sync_timeout_seconds", 2)
 
 	// Datadog cluster agent
 	config.BindEnvAndSetDefault("cluster_agent.enabled", false)

--- a/pkg/util/kubernetes/apiserver/util.go
+++ b/pkg/util/kubernetes/apiserver/util.go
@@ -22,13 +22,13 @@ import (
 	"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1"
 )
 
-// syncTimeout can be used to wait for the kubernetes client-go cache to sync.
-var syncTimeout = config.Datadog.GetDuration("cache_sync_timeout") * time.Second
-
 // SyncInformers should be called after the instantiation of new informers.
 // It's blocking until the informers are synced or the timeout exceeded.
 func SyncInformers(informers map[InformerName]cache.SharedInformer) error {
 	var g errgroup.Group
+	// syncTimeout can be used to wait for the kubernetes client-go cache to sync.
+	// It cannot be retrieved at the package-level due to the package being imported before configs are loaded.
+	syncTimeout := config.Datadog.GetDuration("kube_cache_sync_timeout_seconds") * time.Second
 	for name := range informers {
 		name := name // https://golang.org/doc/faq#closures_and_goroutines
 		g.Go(func() error {

--- a/releasenotes/notes/fix-kubeapiserver-cache-timeout-d92d7f08e00c2900.yaml
+++ b/releasenotes/notes/fix-kubeapiserver-cache-timeout-d92d7f08e00c2900.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix issue where Kube Apiserver cache sync timeout configuration is not used.


### PR DESCRIPTION
### What does this PR do?

The apiserver cache sync timeout configuration was not working because the package is imported before the config is loaded. https://github.com/DataDog/datadog-agent/blob/140a4ee164261ef2245340c50371ba989fbeb038/cmd/cluster-agent/app/app.go#L46

Moving the reading of the config to inside the function where it's used.


### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

In DEBUG mode, set the configuration in the agent to something other than `2` and make sure the `couldn't sync informer` log line outputs the time expected.