### PR TITLE
[dogstatsd][capture] add missing config option defaults for captures (#7985)

### DIFF
--- a/cmd/agent/app/dogstatsd_capture.go
+++ b/cmd/agent/app/dogstatsd_capture.go
@@ -111,7 +111,7 @@ func dogstatsdCapture() error {
 		return err
 	}
 
-	fmt.Printf("Capture started, capture file being written to: %s", resp.Path)
+	fmt.Printf("Capture started, capture file being written to: %s\n", resp.Path)
 
 	return nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -390,6 +390,11 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("dogstatsd_entity_id_precedence", false)
 	// Sends Dogstatsd parse errors to the Debug level instead of the Error level
 	config.BindEnvAndSetDefault("dogstatsd_disable_verbose_logs", false)
+	// Location to store dogstatsd captures by default
+	config.BindEnvAndSetDefault("dogstatsd_capture_path", "")
+	// Depth of the channel the capture writer reads before persisting to disk.
+	// Default is 0 - blocking channel
+	config.BindEnvAndSetDefault("dogstatsd_capture_depth", 0)
 
 	_ = config.BindEnv("dogstatsd_mapper_profiles")
 	config.SetEnvKeyTransformer("dogstatsd_mapper_profiles", func(in string) interface{} {

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1209,7 +1209,7 @@ api_key:
 #
 # dogstatsd_tags:
 #   - <TAG_KEY>:<TAG_VALUE>
-
+#
 ## @param dogstatsd_mapper_profiles - list of custom object - optional
 ## The profiles will be used to convert parts of metrics names into tags.
 ## If a profile prefix is matched, other profiles won't be tried even if that profile matching rules doesn't match.

--- a/pkg/dogstatsd/replay/capture.go
+++ b/pkg/dogstatsd/replay/capture.go
@@ -7,6 +7,7 @@ package replay
 
 import (
 	"fmt"
+	"path"
 	"sync"
 	"time"
 
@@ -22,8 +23,11 @@ type TrafficCapture struct {
 
 // NewTrafficCapture creates a TrafficCapture instance.
 func NewTrafficCapture() (*TrafficCapture, error) {
-	location := config.Datadog.GetString("dogstatsd_uds_capture_path")
-	writer := NewTrafficCaptureWriter(location, config.Datadog.GetInt("dogstatsd_uds_capture_depth"))
+	location := config.Datadog.GetString("dogstatsd_capture_path")
+	if location == "" {
+		location = path.Join(config.Datadog.GetString("run_path"), "dsd_capture")
+	}
+	writer := NewTrafficCaptureWriter(location, config.Datadog.GetInt("dogstatsd_capture_depth"))
 	if writer == nil {
 		return nil, fmt.Errorf("unable to instantiate capture writer")
 	}

--- a/pkg/dogstatsd/replay/reader.go
+++ b/pkg/dogstatsd/replay/reader.go
@@ -49,12 +49,12 @@ func NewTrafficCaptureReader(path string, depth int) (*TrafficCaptureReader, err
 	return &TrafficCaptureReader{
 		Contents: c,
 		Traffic:  make(chan *pb.UnixDogstatsdMsg, depth),
+		Shutdown: make(chan struct{}),
 	}, nil
 }
 
 // Read reads the contents of the traffic capture and writes each packet to a channel
 func (tc *TrafficCaptureReader) Read() {
-	tc.Shutdown = make(chan struct{})
 	defer close(tc.Shutdown)
 
 	log.Debugf("About to begin processing file of size: %d\n", len(tc.Contents))

--- a/pkg/dogstatsd/replay/writer.go
+++ b/pkg/dogstatsd/replay/writer.go
@@ -84,8 +84,15 @@ func (tc *TrafficCaptureWriter) Capture(d time.Duration) {
 	log.Debug("Starting capture...")
 
 	tc.Lock()
+	p := path.Join(tc.Location, fmt.Sprintf(fileTemplate, time.Now().Unix()))
+	if err := os.MkdirAll(filepath.Dir(p), 0770); err != nil {
+		log.Errorf("There was an issue writing the expected location: %v ", err)
 
-	fp, err := os.Create(path.Join(tc.Location, fmt.Sprintf(fileTemplate, time.Now().Unix())))
+		tc.Unlock()
+		return
+	}
+
+	fp, err := os.Create(p)
 	if err != nil {
 		log.Errorf("There was an issue starting the capture: %v ", err)
 


### PR DESCRIPTION

### What does this PR do?

Cherry-picks #7985 into the `7.28.x` branch.

### Motivation

Fix is relevant for the active release. Addresses missing config and small race.

### Additional Notes

-

### Describe how to test your changes

- Make sure the captures are correctly written to the correct location (`/opt/datadog-agent/run/dsd_captures` with an installed agent artifact on linux).
