### PR TITLE
[release] Add `WINDOWS_*` fields to `release.json` in release scripts

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -414,6 +414,16 @@ def _create_version_dict_from_match(match):
     return version
 
 
+def _is_dict_version_field(key):
+    """
+    Returns a bool to indicate if the field should be stringified from a dictionary or not.
+
+    Generally all `*_VERSION` fields are parsed with regex but `WINDOWS_DDNPM_VERSION`
+    should be used as-is.
+    """
+    return "VERSION" in key and key != "WINDOWS_DDNPM_VERSION"
+
+
 def _stringify_config(config_dict):
     """
     Takes a config dict of the following form:
@@ -425,7 +435,9 @@ def _stringify_config(config_dict):
 
     and transforms all VERSIONs into their string representation.
     """
-    return {key: _stringify_version(value) if "VERSION" in key else value for key, value in config_dict.items()}
+    return {
+        key: _stringify_version(value) if _is_dict_version_field(key) else value for key, value in config_dict.items()
+    }
 
 
 def _stringify_version(version_dict):
@@ -498,6 +510,31 @@ def _get_highest_version_from_release_json(release_json, highest_major, version_
     return highest_version
 
 
+def _get_windows_ddnpm_release_json_info(
+    release_json, highest_major, version_re, is_first_rc=False,
+):
+
+    highest_release_json_version = _get_highest_version_from_release_json(release_json, highest_major, version_re)
+
+    # First RC should use the data from nightly section otherwise reuse the last RC info
+    if is_first_rc:
+        print("Using 'nightly' DDNPM values")
+        release_json_version_data = release_json['nightly']
+    else:
+        highest_release = _stringify_version(highest_release_json_version)
+        print("Using '{}' DDNPM values".format(highest_release))
+        release_json_version_data = release_json[highest_release]
+
+    win_ddnpm_driver = release_json_version_data['WINDOWS_DDNPM_DRIVER']
+    win_ddnpm_version = release_json_version_data['WINDOWS_DDNPM_VERSION']
+    win_ddnpm_shasum = release_json_version_data['WINDOWS_DDNPM_SHASUM']
+
+    if win_ddnpm_driver not in ['release-signed', 'attestation-signed']:
+        print("WARN: WINDOWS_DDNPM_DRIVER value '{}' is not valid".format(win_ddnpm_driver))
+
+    return win_ddnpm_driver, win_ddnpm_version, win_ddnpm_shasum
+
+
 def _save_release_json(
     release_json,
     list_major_versions,
@@ -508,6 +545,9 @@ def _save_release_json(
     jmxfetch_version,
     security_agent_policies_version,
     macos_build_version,
+    windows_ddnpm_driver,
+    windows_ddnpm_version,
+    windows_ddnpm_shasum,
 ):
     import requests
 
@@ -519,6 +559,7 @@ def _save_release_json(
     jmxfetch_sha256 = hashlib.sha256(jmxfetch).hexdigest()
 
     print("Jmxfetch's SHA256 is {}".format(jmxfetch_sha256))
+    print("Windows DDNPM's SHA256 is {}".format(windows_ddnpm_shasum))
 
     new_version_config = OrderedDict()
     new_version_config["INTEGRATIONS_CORE_VERSION"] = integration_version
@@ -528,6 +569,9 @@ def _save_release_json(
     new_version_config["JMXFETCH_HASH"] = jmxfetch_sha256
     new_version_config["SECURITY_AGENT_POLICIES_VERSION"] = security_agent_policies_version
     new_version_config["MACOS_BUILD_VERSION"] = macos_build_version
+    new_version_config["WINDOWS_DDNPM_DRIVER"] = windows_ddnpm_driver
+    new_version_config["WINDOWS_DDNPM_VERSION"] = windows_ddnpm_version
+    new_version_config["WINDOWS_DDNPM_SHASUM"] = windows_ddnpm_shasum
 
     # Necessary if we want to maintain the JSON order, so that humans don't get confused
     new_release_json = OrderedDict()
@@ -567,6 +611,9 @@ def finish(
     omnibus_ruby_version=None,
     security_agent_policies_version=None,
     macos_build_version=None,
+    windows_ddnpm_driver=None,
+    windows_ddnpm_version=None,
+    windows_ddnpm_shasum=None,
     ignore_rc_tag=False,
 ):
 
@@ -713,6 +760,14 @@ def finish(
                 return Exit(code=1)
     print("datadog-agent-macos-build' tag is {}".format(_stringify_version(macos_build_version)))
 
+    if not windows_ddnpm_version:
+        # Get info on DDNPM
+        windows_ddnpm_driver, windows_ddnpm_version, windows_ddnpm_shasum = _get_windows_ddnpm_release_json_info(
+            release_json, highest_major, version_re
+        )
+
+    print("windows ddnpm version is {}".format(windows_ddnpm_version))
+
     _save_release_json(
         release_json,
         list_major_versions,
@@ -723,6 +778,9 @@ def finish(
         jmxfetch_version,
         security_agent_policies_version,
         macos_build_version,
+        windows_ddnpm_driver,
+        windows_ddnpm_version,
+        windows_ddnpm_shasum,
     )
 
     # Update internal module dependencies
@@ -739,6 +797,9 @@ def create_rc(
     omnibus_ruby_version=None,
     security_agent_policies_version=None,
     macos_build_version=None,
+    windows_ddnpm_driver=None,
+    windows_ddnpm_version=None,
+    windows_ddnpm_shasum=None,
 ):
 
     """
@@ -829,6 +890,15 @@ def create_rc(
         )
     print("datadog-agent-macos-build's tag is {}".format(_stringify_version(macos_build_version)))
 
+    if not windows_ddnpm_version:
+        is_first_rc = highest_version["rc"] == 1
+        # Get info on DDNPM
+        windows_ddnpm_driver, windows_ddnpm_version, windows_ddnpm_shasum = _get_windows_ddnpm_release_json_info(
+            release_json, highest_major, version_re, is_first_rc
+        )
+
+    print("windows ddnpm version is {}".format(windows_ddnpm_version))
+
     _save_release_json(
         release_json,
         list_major_versions,
@@ -839,6 +909,9 @@ def create_rc(
         jmxfetch_version,
         security_agent_policies_version,
         macos_build_version,
+        windows_ddnpm_driver,
+        windows_ddnpm_version,
+        windows_ddnpm_shasum,
     )
 
     # Update internal module dependencies
@@ -859,7 +932,7 @@ def update_modules(ctx, agent_version, verify=True):
     * --verify checks for correctness on the Agent Version (on by default).
 
     Examples:
-    inv -e release.update-modules 7.27.0 
+    inv -e release.update-modules 7.27.0
     """
     if verify:
         check_version(agent_version)

--- a/tasks/release_tests.py
+++ b/tasks/release_tests.py
@@ -1,4 +1,5 @@
 import random
+import re
 import unittest
 
 from . import release
@@ -138,6 +139,63 @@ class TestIsHigherMethod(unittest.TestCase):
                 self._get_version(version["major"], version["minor"], None, None),
             )
         )
+
+
+class TestIsDictVersionField(unittest.TestCase):
+    def test_non_version_fields_return_false(self):
+        for key in ['FOO', 'BAR', 'WINDOWS_DDNPM_DRIVER', 'JMXFETCH_HASH']:
+            self.assertFalse(release._is_dict_version_field(key))
+
+    def test_version_fields_return_true(self):
+        for key in ['FOO_VERSION', 'BAR_VERSION', 'JMXFETCH_VERSION']:
+            self.assertTrue(release._is_dict_version_field(key))
+
+    def test_version_fields_return_false_for_win_ddnpm_version(self):
+        self.assertFalse(release._is_dict_version_field('WINDOWS_DDNPM_VERSION'))
+
+
+class TestGetWindowsDDNPMReleaseJsonInfo(unittest.TestCase):
+    test_version_re = re.compile(r'(v)?(\d+)[.](\d+)([.](\d+))?(-rc\.(\d+))?')
+    test_release_json = {
+        "nightly": {
+            "WINDOWS_DDNPM_DRIVER": "attestation-signed",
+            "WINDOWS_DDNPM_VERSION": "nightly-ddnpm-version",
+            "WINDOWS_DDNPM_SHASUM": "nightly-ddnpm-sha",
+        },
+        "nightly-a7": {
+            "WINDOWS_DDNPM_DRIVER": "attestation-signed",
+            "WINDOWS_DDNPM_VERSION": "nightly-ddnpm-version",
+            "WINDOWS_DDNPM_SHASUM": "nightly-ddnpm-sha",
+        },
+        "6.28.0-rc.3": {
+            "WINDOWS_DDNPM_DRIVER": "release-signed",
+            "WINDOWS_DDNPM_VERSION": "rc3-ddnpm-version",
+            "WINDOWS_DDNPM_SHASUM": "rc3-ddnpm-sha",
+        },
+        "7.28.0-rc.3": {
+            "WINDOWS_DDNPM_DRIVER": "release-signed",
+            "WINDOWS_DDNPM_VERSION": "rc3-ddnpm-version",
+            "WINDOWS_DDNPM_SHASUM": "rc3-ddnpm-sha",
+        },
+    }
+
+    def test_ddnpm_info_is_taken_from_nightly_on_first_rc(self):
+        driver, version, shasum = release._get_windows_ddnpm_release_json_info(
+            self.test_release_json, 7, self.test_version_re, True
+        )
+
+        self.assertEqual(driver, 'attestation-signed')
+        self.assertEqual(version, 'nightly-ddnpm-version')
+        self.assertEqual(shasum, 'nightly-ddnpm-sha')
+
+    def test_ddnpm_info_is_taken_from_previous_rc_on_subsequent_rcs(self):
+        driver, version, shasum = release._get_windows_ddnpm_release_json_info(
+            self.test_release_json, 7, self.test_version_re, False
+        )
+
+        self.assertEqual(driver, 'release-signed')
+        self.assertEqual(version, 'rc3-ddnpm-version')
+        self.assertEqual(shasum, 'rc3-ddnpm-sha')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
`inv release.*` scripts did not support automatic adding of
`WINDOWS_DDNPM_*` when creating new releases or closing the release
which made the process likely to be error prone. This change ensures
that those fields are correctly added per #networks guidance.

### Motivation

Missing fields when doing `inv release.create-rc`

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

- Run `inv release.create-rc`
- Ensure that proper `WINDOWS_DDNPM_*` are present in the generated values.
