### PR TITLE
Set empty no_proxy to type interface{} to avoid viper merge errors (PRMS-2733)

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -918,7 +918,14 @@ func loadProxyFromEnv(config Config) {
 	if isSet {
 		config.Set("proxy.http", p.HTTP)
 		config.Set("proxy.https", p.HTTPS)
-		config.Set("proxy.no_proxy", p.NoProxy)
+		if len(p.NoProxy) > 0 {
+			config.Set("proxy.no_proxy", p.NoProxy)
+		} else {
+			// If this is set to an empty []string, viper will have a type conflict when merging
+			// this config during secrets resolution. It unmarshals empty yaml lists to type
+			// []interface{}, which will then conflict with type []string and fail to merge.
+			config.Set("proxy.no_proxy", []interface{}{})
+		}
 		proxies = p
 	}
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -719,6 +719,28 @@ func TestLoadProxyEmptyValuePrecedence(t *testing.T) {
 	os.Unsetenv("DD_PROXY_NO_PROXY")
 }
 
+func TestLoadProxyWithoutNoProxy(t *testing.T) {
+	config := setupConf()
+
+	os.Setenv("DD_PROXY_HTTP", "http_url")
+	os.Setenv("DD_PROXY_HTTPS", "https_url")
+
+	loadProxyFromEnv(config)
+
+	proxies := GetProxies()
+	assert.Equal(t,
+		&Proxy{
+			HTTP:  "http_url",
+			HTTPS: "https_url",
+		},
+		proxies)
+
+	assert.Equal(t, []interface{}{}, config.Get("proxy.no_proxy"))
+
+	os.Unsetenv("DD_PROXY_HTTP")
+	os.Unsetenv("DD_PROXY_HTTPS")
+}
+
 func TestSanitizeAPIKeyConfig(t *testing.T) {
 	config := setupConf()
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -123,9 +123,9 @@ unknown_key.unknown_subkey: true
 }
 
 func TestSiteEnvVar(t *testing.T) {
-	resetApiKey := setEnvForTest("DD_API_KEY", "fakeapikey")
+	resetAPIKey := setEnvForTest("DD_API_KEY", "fakeapikey")
 	resetSite := setEnvForTest("DD_SITE", "datadoghq.eu")
-	defer resetApiKey()
+	defer resetAPIKey()
 	defer resetSite()
 	testConfig := setupConfFromYAML("")
 
@@ -144,12 +144,12 @@ func TestSiteEnvVar(t *testing.T) {
 }
 
 func TestDDURLEnvVar(t *testing.T) {
-	resetApiKey := setEnvForTest("DD_API_KEY", "fakeapikey")
-	resetUrl := setEnvForTest("DD_DD_URL", "https://app.datadoghq.eu")
-	resetExternalUrl := setEnvForTest("DD_EXTERNAL_CONFIG_EXTERNAL_AGENT_DD_URL", "https://custom.external-agent.datadoghq.com")
-	defer resetApiKey()
-	defer resetUrl()
-	defer resetExternalUrl()
+	resetAPIKey := setEnvForTest("DD_API_KEY", "fakeapikey")
+	resetURL := setEnvForTest("DD_DD_URL", "https://app.datadoghq.eu")
+	resetExternalURL := setEnvForTest("DD_EXTERNAL_CONFIG_EXTERNAL_AGENT_DD_URL", "https://custom.external-agent.datadoghq.com")
+	defer resetAPIKey()
+	defer resetURL()
+	defer resetExternalURL()
 	testConfig := setupConfFromYAML("")
 	testConfig.BindEnv("external_config.external_agent_dd_url")
 
@@ -248,9 +248,9 @@ additional_endpoints:
 }
 
 func TestGetMultipleEndpointsEnvVar(t *testing.T) {
-	resetApiKey := setEnvForTest("DD_API_KEY", "fakeapikey")
+	resetAPIKey := setEnvForTest("DD_API_KEY", "fakeapikey")
 	resetAdditionalEndpoints := setEnvForTest("DD_ADDITIONAL_ENDPOINTS", "{\"https://foo.datadoghq.com\": [\"someapikey\"]}")
-	defer resetApiKey()
+	defer resetAPIKey()
 	defer resetAdditionalEndpoints()
 
 	testConfig := setupConf()
@@ -571,11 +571,11 @@ func TestLoadProxyStdEnvOnly(t *testing.T) {
 	config.Set("use_proxy_for_cloud_metadata", true)
 
 	// uppercase
-	resetHttpProxyUpper := setEnvForTest("HTTP_PROXY", "http_url")
-	resetHttpsProxyUpper := setEnvForTest("HTTPS_PROXY", "https_url")
+	resetHTTPProxyUpper := setEnvForTest("HTTP_PROXY", "http_url")
+	resetHTTPSProxyUpper := setEnvForTest("HTTPS_PROXY", "https_url")
 	resetNoProxyUpper := setEnvForTest("NO_PROXY", "a,b,c") // comma-separated list
-	defer resetHttpProxyUpper()
-	defer resetHttpsProxyUpper()
+	defer resetHTTPProxyUpper()
+	defer resetHTTPSProxyUpper()
 	defer resetNoProxyUpper()
 
 	loadProxyFromEnv(config)
@@ -594,11 +594,11 @@ func TestLoadProxyStdEnvOnly(t *testing.T) {
 	config.Set("proxy", nil)
 
 	// lowercase
-	resetHttpProxyLower := setEnvForTest("http_proxy", "http_url2")
-	resetHttpsProxyLower := setEnvForTest("https_proxy", "https_url2")
+	resetHTTPProxyLower := setEnvForTest("http_proxy", "http_url2")
+	resetHTTPSProxyLower := setEnvForTest("https_proxy", "https_url2")
 	resetNoProxyLower := setEnvForTest("no_proxy", "1,2,3") // comma-separated list
-	defer resetHttpProxyLower()
-	defer resetHttpsProxyLower()
+	defer resetHTTPProxyLower()
+	defer resetHTTPSProxyLower()
 	defer resetNoProxyLower()
 
 	loadProxyFromEnv(config)
@@ -616,11 +616,11 @@ func TestLoadProxyDDSpecificEnvOnly(t *testing.T) {
 	// Don't include cloud metadata URL's in no_proxy
 	config.Set("use_proxy_for_cloud_metadata", true)
 
-	resetHttpProxy := setEnvForTest("DD_PROXY_HTTP", "http_url")
-	resetHttpsProxy := setEnvForTest("DD_PROXY_HTTPS", "https_url")
+	resetHTTPProxy := setEnvForTest("DD_PROXY_HTTP", "http_url")
+	resetHTTPSProxy := setEnvForTest("DD_PROXY_HTTPS", "https_url")
 	resetNoProxy := setEnvForTest("DD_PROXY_NO_PROXY", "a b c") // space-separated list
-	defer resetHttpProxy()
-	defer resetHttpsProxy()
+	defer resetHTTPProxy()
+	defer resetHTTPSProxy()
 	defer resetNoProxy()
 
 	loadProxyFromEnv(config)
@@ -639,17 +639,17 @@ func TestLoadProxyDDSpecificEnvPrecedenceOverStdEnv(t *testing.T) {
 	// Don't include cloud metadata URL's in no_proxy
 	config.Set("use_proxy_for_cloud_metadata", true)
 
-	resetDdHttpProxy := setEnvForTest("DD_PROXY_HTTP", "dd_http_url")
-	resetDdHttpsProxy := setEnvForTest("DD_PROXY_HTTPS", "dd_https_url")
+	resetDdHTTPProxy := setEnvForTest("DD_PROXY_HTTP", "dd_http_url")
+	resetDdHTTPSProxy := setEnvForTest("DD_PROXY_HTTPS", "dd_https_url")
 	resetDdNoProxy := setEnvForTest("DD_PROXY_NO_PROXY", "a b c")
-	resetHttpProxy := setEnvForTest("HTTP_PROXY", "env_http_url")
-	resetHttpsProxy := setEnvForTest("HTTPS_PROXY", "env_https_url")
+	resetHTTPProxy := setEnvForTest("HTTP_PROXY", "env_http_url")
+	resetHTTPSProxy := setEnvForTest("HTTPS_PROXY", "env_https_url")
 	resetNoProxy := setEnvForTest("NO_PROXY", "d,e,f")
-	defer resetDdHttpProxy()
-	defer resetDdHttpsProxy()
+	defer resetDdHTTPProxy()
+	defer resetDdHTTPSProxy()
 	defer resetDdNoProxy()
-	defer resetHttpProxy()
-	defer resetHttpsProxy()
+	defer resetHTTPProxy()
+	defer resetHTTPSProxy()
 	defer resetNoProxy()
 
 	loadProxyFromEnv(config)
@@ -668,10 +668,10 @@ func TestLoadProxyStdEnvAndConf(t *testing.T) {
 	// Don't include cloud metadata URL's in no_proxy
 	config.Set("use_proxy_for_cloud_metadata", true)
 
-	resetHttpProxy := setEnvForTest("HTTP_PROXY", "http_env")
+	resetHTTPProxy := setEnvForTest("HTTP_PROXY", "http_env")
 	config.Set("proxy.no_proxy", []string{"d", "e", "f"})
 	config.Set("proxy.http", "http_conf")
-	defer resetHttpProxy()
+	defer resetHTTPProxy()
 
 	loadProxyFromEnv(config)
 	proxies := GetProxies()
@@ -688,10 +688,10 @@ func TestLoadProxyDDSpecificEnvAndConf(t *testing.T) {
 	// Don't include cloud metadata URL's in no_proxy
 	config.Set("use_proxy_for_cloud_metadata", true)
 
-	resetHttpProxy := setEnvForTest("DD_PROXY_HTTP", "http_env")
+	resetHTTPProxy := setEnvForTest("DD_PROXY_HTTP", "http_env")
 	config.Set("proxy.no_proxy", []string{"d", "e", "f"})
 	config.Set("proxy.http", "http_conf")
-	defer resetHttpProxy()
+	defer resetHTTPProxy()
 
 	loadProxyFromEnv(config)
 	proxies := GetProxies()
@@ -708,16 +708,16 @@ func TestLoadProxyEmptyValuePrecedence(t *testing.T) {
 	// Don't include cloud metadata URL's in no_proxy
 	config.Set("use_proxy_for_cloud_metadata", true)
 
-	resetDdHttpProxy := setEnvForTest("DD_PROXY_HTTP", "")
+	resetDdHTTPProxy := setEnvForTest("DD_PROXY_HTTP", "")
 	resetDdNoProxy := setEnvForTest("DD_PROXY_NO_PROXY", "a b c")
-	resetHttpProxy := setEnvForTest("HTTP_PROXY", "env_http_url")
-	resetHttpsProxy := setEnvForTest("HTTPS_PROXY", "")
+	resetHTTPProxy := setEnvForTest("HTTP_PROXY", "env_http_url")
+	resetHTTPSProxy := setEnvForTest("HTTPS_PROXY", "")
 	resetNoProxy := setEnvForTest("NO_PROXY", "")
 	config.Set("proxy.https", "https_conf")
-	defer resetDdHttpProxy()
+	defer resetDdHTTPProxy()
 	defer resetDdNoProxy()
-	defer resetHttpProxy()
-	defer resetHttpsProxy()
+	defer resetHTTPProxy()
+	defer resetHTTPSProxy()
 	defer resetNoProxy()
 
 	loadProxyFromEnv(config)
@@ -737,11 +737,11 @@ func TestLoadProxyWithoutNoProxy(t *testing.T) {
 	// Don't include cloud metadata URL's in no_proxy
 	config.Set("use_proxy_for_cloud_metadata", true)
 
-	resetHttpProxy := setEnvForTest("DD_PROXY_HTTP", "http_url")
-	resetHttpsProxy := setEnvForTest("DD_PROXY_HTTPS", "https_url")
+	resetHTTPProxy := setEnvForTest("DD_PROXY_HTTP", "http_url")
+	resetHTTPSProxy := setEnvForTest("DD_PROXY_HTTPS", "https_url")
 	resetNoProxy := setEnvForTest("NO_PROXY", "")
-	defer resetHttpProxy()
-	defer resetHttpsProxy()
+	defer resetHTTPProxy()
+	defer resetHTTPSProxy()
 	defer resetNoProxy()
 
 	loadProxyFromEnv(config)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -545,7 +545,7 @@ func TestEnvNestedConfig(t *testing.T) {
 func TestLoadProxyFromStdEnvNoValue(t *testing.T) {
 	config := setupConf()
 
-	resetEnv := unsetEnvForTest("NO_PROXY")
+	resetEnv := unsetEnvForTest("NO_PROXY") // CircleCI sets NO_PROXY, so unset it for this test
 	defer resetEnv()
 
 	loadProxyFromEnv(config)
@@ -564,7 +564,7 @@ func TestLoadProxyConfOnly(t *testing.T) {
 	// Don't include cloud metadata URL's in no_proxy
 	config.Set("use_proxy_for_cloud_metadata", true)
 
-	resetEnv := unsetEnvForTest("NO_PROXY")
+	resetEnv := unsetEnvForTest("NO_PROXY") // CircleCI sets NO_PROXY, so unset it for this test
 	defer resetEnv()
 
 	loadProxyFromEnv(config)
@@ -677,9 +677,11 @@ func TestLoadProxyStdEnvAndConf(t *testing.T) {
 	config.Set("use_proxy_for_cloud_metadata", true)
 
 	resetHTTPProxy := setEnvForTest("HTTP_PROXY", "http_env")
+	resetNoProxy := unsetEnvForTest("NO_PROXY") // CircleCI sets NO_PROXY, so unset it for this test
 	config.Set("proxy.no_proxy", []string{"d", "e", "f"})
 	config.Set("proxy.http", "http_conf")
 	defer resetHTTPProxy()
+	defer resetNoProxy()
 
 	loadProxyFromEnv(config)
 	proxies := GetProxies()
@@ -697,9 +699,11 @@ func TestLoadProxyDDSpecificEnvAndConf(t *testing.T) {
 	config.Set("use_proxy_for_cloud_metadata", true)
 
 	resetHTTPProxy := setEnvForTest("DD_PROXY_HTTP", "http_env")
+	resetNoProxy := unsetEnvForTest("NO_PROXY") // CircleCI sets NO_PROXY, so unset it for this test
 	config.Set("proxy.no_proxy", []string{"d", "e", "f"})
 	config.Set("proxy.http", "http_conf")
 	defer resetHTTPProxy()
+	defer resetNoProxy()
 
 	loadProxyFromEnv(config)
 	proxies := GetProxies()
@@ -747,7 +751,7 @@ func TestLoadProxyWithoutNoProxy(t *testing.T) {
 
 	resetHTTPProxy := setEnvForTest("DD_PROXY_HTTP", "http_url")
 	resetHTTPSProxy := setEnvForTest("DD_PROXY_HTTPS", "https_url")
-	resetNoProxy := unsetEnvForTest("NO_PROXY")
+	resetNoProxy := unsetEnvForTest("NO_PROXY") // CircleCI sets NO_PROXY, so unset it for this test
 	defer resetHTTPProxy()
 	defer resetHTTPSProxy()
 	defer resetNoProxy()

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -722,6 +722,11 @@ func TestLoadProxyEmptyValuePrecedence(t *testing.T) {
 func TestLoadProxyWithoutNoProxy(t *testing.T) {
 	config := setupConf()
 
+	// circleCI set some proxy setting
+	ciValue := os.Getenv("NO_PROXY")
+	os.Unsetenv("NO_PROXY")
+	defer os.Setenv("NO_PROXY", ciValue)
+
 	os.Setenv("DD_PROXY_HTTP", "http_url")
 	os.Setenv("DD_PROXY_HTTPS", "https_url")
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -722,6 +722,9 @@ func TestLoadProxyEmptyValuePrecedence(t *testing.T) {
 func TestLoadProxyWithoutNoProxy(t *testing.T) {
 	config := setupConf()
 
+	// Don't include cloud metadata URL's in no_proxy
+	config.Set("use_proxy_for_cloud_metadata", true)
+
 	// circleCI set some proxy setting
 	ciValue := os.Getenv("NO_PROXY")
 	os.Unsetenv("NO_PROXY")

--- a/releasenotes/notes/viper-no-proxy-conflict-8412a62836ef57f3.yaml
+++ b/releasenotes/notes/viper-no-proxy-conflict-8412a62836ef57f3.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix noisy configuration error when specifying a proxy config and using secrets management.


### PR DESCRIPTION
### What does this PR do?

Customer reports seeing the following error messages from the process-agent:
```
ERROR 2021/04/07 11:39:34 svType != tvType; key=no_proxy, st=[]interface{}, tt=[]string, sv=[], tv=[]
```

This error comes from the config library [spf13/viper](https://github.com/spf13/viper) and occurs when we resolve the secrets in the config and merge them into the existing config (ref. [config.ResolveSecrets()](https://github.com/DataDog/datadog-agent/blob/9ca9e76/pkg/config/config.go#L1012), [viper.mergeMaps()](https://github.com/spf13/viper/blob/36be6bf/viper.go#L1830)).

In order to resolve the conflict, this PR sets the type of `no_proxy` to `[]interface{}` when it is empty. When it is populated, viper has the correct type of `[]string` so there is no conflict.

@DataDog/processes 

### Motivation

https://datadoghq.atlassian.net/browse/PRMS-2733

### Describe how to test your changes

In datadog.yaml, set some secret config value, such as an encrypted API key, as well as the `secret_backend_command`. Also, via datadog.yaml or environment variable, set a proxy config, but *not* `no_proxy`.

Start the process-agent binary manually, and verify that the error above no longer appears.