### PR TITLE
Change default profiling period from 1 minute to 5 minutes

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -38,6 +38,8 @@ core,"github.com/DataDog/gopsutil/internal/common",BSD-3-Clause
 core,"github.com/DataDog/gopsutil/mem",BSD-3-Clause
 core,"github.com/DataDog/gopsutil/net",BSD-3-Clause
 core,"github.com/DataDog/gopsutil/process",BSD-3-Clause
+core,"github.com/DataDog/gostackparse",Apache-2.0
+core,"github.com/google/pprof/profile",Apache-2.0
 core,"github.com/DataDog/mmh3",UNKNOWN
 core,"github.com/DataDog/sketches-go/ddsketch",Apache-2.0
 core,"github.com/DataDog/sketches-go/ddsketch/mapping",Apache-2.0
@@ -712,6 +714,8 @@ core,"google.golang.org/protobuf/types/known/timestamppb",BSD-3-Clause
 core,"google.golang.org/protobuf/types/known/wrapperspb",BSD-3-Clause
 core,"google.golang.org/protobuf/types/pluginpb",BSD-3-Clause
 core,"gopkg.in/DataDog/dd-trace-go.v1/ddtrace",Apache-2.0
+core,"gopkg.in/DataDog/dd-trace-go.v1/internal",Apache-2.0
+core,"gopkg.in/DataDog/dd-trace-go.v1/internal/globalconfig",Apache-2.0
 core,"gopkg.in/DataDog/dd-trace-go.v1/internal/log",Apache-2.0
 core,"gopkg.in/DataDog/dd-trace-go.v1/internal/version",Apache-2.0
 core,"gopkg.in/DataDog/dd-trace-go.v1/profiler",Apache-2.0

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -310,5 +310,5 @@ func enableProfiling(cfg *config.AgentConfig) error {
 
 	v, _ := version.Agent()
 
-	return profiling.Start(cfg.ProfilingAPIKey, site, cfg.ProfilingEnvironment, "process-agent", profiling.DefaultProfilingPeriod, fmt.Sprintf("version:%v", v))
+	return profiling.Start(cfg.ProfilingAPIKey, site, cfg.ProfilingEnvironment, "process-agent", time.Duration(cfg.ProfilingPeriod)*time.Minute, fmt.Sprintf("version:%v", v))
 }

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -310,5 +310,5 @@ func enableProfiling(cfg *config.AgentConfig) error {
 
 	v, _ := version.Agent()
 
-	return profiling.Start(cfg.ProfilingAPIKey, site, cfg.ProfilingEnvironment, "process-agent", time.Duration(cfg.ProfilingPeriod)*time.Minute, fmt.Sprintf("version:%v", v))
+	return profiling.Start(cfg.ProfilingAPIKey, site, cfg.ProfilingEnvironment, "process-agent", cfg.ProfilingPeriod, cfg.ProfilingCPUDuration, fmt.Sprintf("version:%v", v))
 }

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -310,5 +310,5 @@ func enableProfiling(cfg *config.AgentConfig) error {
 
 	v, _ := version.Agent()
 
-	return profiling.Start(cfg.ProfilingAPIKey, site, cfg.ProfilingEnvironment, "process-agent", 5 * time.Minute, fmt.Sprintf("version:%v", v))
+	return profiling.Start(cfg.ProfilingAPIKey, site, cfg.ProfilingEnvironment, "process-agent", profiling.DefaultProfilingPeriod, fmt.Sprintf("version:%v", v))
 }

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -310,5 +310,5 @@ func enableProfiling(cfg *config.AgentConfig) error {
 
 	v, _ := version.Agent()
 
-	return profiling.Start(cfg.ProfilingAPIKey, site, cfg.ProfilingEnvironment, "process-agent", fmt.Sprintf("version:%v", v))
+	return profiling.Start(cfg.ProfilingAPIKey, site, cfg.ProfilingEnvironment, "process-agent", 5 * time.Minute, fmt.Sprintf("version:%v", v))
 }

--- a/cmd/system-probe/app/run.go
+++ b/cmd/system-probe/app/run.go
@@ -196,12 +196,17 @@ func enableProfiling(cfg *config.Config) error {
 		}
 	}
 
+	period := profiling.DefaultProfilingPeriod
+	if cfg.ProfilingPeriod > 0 {
+		period = time.Duration(cfg.ProfilingPeriod)*time.Minute
+	}
+
 	return profiling.Start(
 		cfg.ProfilingAPIKey,
 		site,
 		cfg.ProfilingEnvironment,
 		"system-probe",
-		5 * time.Minute,
+		period,
 		fmt.Sprintf("version:%v", v),
 	)
 }

--- a/cmd/system-probe/app/run.go
+++ b/cmd/system-probe/app/run.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -200,6 +201,7 @@ func enableProfiling(cfg *config.Config) error {
 		site,
 		cfg.ProfilingEnvironment,
 		"system-probe",
+		5 * time.Minute,
 		fmt.Sprintf("version:%v", v),
 	)
 }

--- a/cmd/system-probe/app/run.go
+++ b/cmd/system-probe/app/run.go
@@ -196,17 +196,12 @@ func enableProfiling(cfg *config.Config) error {
 		}
 	}
 
-	period := profiling.DefaultProfilingPeriod
-	if cfg.ProfilingPeriod > 0 {
-		period = time.Duration(cfg.ProfilingPeriod)*time.Minute
-	}
-
 	return profiling.Start(
 		cfg.ProfilingAPIKey,
 		site,
 		cfg.ProfilingEnvironment,
 		"system-probe",
-		period,
+		time.Duration(cfg.ProfilingPeriod)*time.Minute,
 		fmt.Sprintf("version:%v", v),
 	)
 }

--- a/cmd/system-probe/app/run.go
+++ b/cmd/system-probe/app/run.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -185,10 +184,6 @@ func enableProfiling(cfg *config.Config) error {
 	// check if TRACE_AGENT_URL is set, in which case, forward the profiles to the trace agent
 	if traceAgentURL := os.Getenv("TRACE_AGENT_URL"); len(traceAgentURL) > 0 {
 		site = fmt.Sprintf(profiling.ProfilingLocalURLTemplate, traceAgentURL)
-		if cfg.ProfilingAPIKey == "" {
-			// when forwarding to the trace agent, its api key will be used. ProfilingAPIKey cannot be empty.
-			cfg.ProfilingAPIKey = "<none>"
-		}
 	} else {
 		site = fmt.Sprintf(profiling.ProfileURLTemplate, cfg.ProfilingSite)
 		if cfg.ProfilingURL != "" {
@@ -201,7 +196,8 @@ func enableProfiling(cfg *config.Config) error {
 		site,
 		cfg.ProfilingEnvironment,
 		"system-probe",
-		time.Duration(cfg.ProfilingPeriod)*time.Minute,
+		cfg.ProfilingPeriod,
+		cfg.ProfilingCPUDuration,
 		fmt.Sprintf("version:%v", v),
 	)
 }

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"time"
 
 	aconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -63,7 +64,8 @@ type Config struct {
 	ProfilingURL         string
 	ProfilingAPIKey      string
 	ProfilingEnvironment string
-	ProfilingPeriod      int
+	ProfilingPeriod      time.Duration
+	ProfilingCPUDuration time.Duration
 }
 
 // New creates a config object for system-probe. It assumes no configuration has been loaded as this point.
@@ -145,7 +147,8 @@ func load(configPath string) (*Config, error) {
 		ProfilingURL:         cfg.GetString(key(spNS, "internal_profiling.profile_dd_url")),
 		ProfilingAPIKey:      aconfig.SanitizeAPIKey(cfg.GetString(key(spNS, "internal_profiling.api_key"))),
 		ProfilingEnvironment: cfg.GetString(key(spNS, "internal_profiling.env")),
-		ProfilingPeriod:      cfg.GetInt(key(spNS, "internal_profiling.period")),
+		ProfilingPeriod:      cfg.GetDuration(key(spNS, "internal_profiling.period")),
+		ProfilingCPUDuration: cfg.GetDuration(key(spNS, "internal_profiling.cpu_duration")),
 	}
 
 	if err := ValidateSocketAddress(c.SocketAddress); err != nil {

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -63,6 +63,7 @@ type Config struct {
 	ProfilingURL         string
 	ProfilingAPIKey      string
 	ProfilingEnvironment string
+	ProfilingPeriod      int
 }
 
 // New creates a config object for system-probe. It assumes no configuration has been loaded as this point.
@@ -144,6 +145,7 @@ func load(configPath string) (*Config, error) {
 		ProfilingURL:         cfg.GetString(key(spNS, "internal_profiling.profile_dd_url")),
 		ProfilingAPIKey:      aconfig.SanitizeAPIKey(cfg.GetString(key(spNS, "internal_profiling.api_key"))),
 		ProfilingEnvironment: cfg.GetString(key(spNS, "internal_profiling.env")),
+		ProfilingPeriod:      cfg.GetInt(key(spNS, "internal_profiling.period")),
 	}
 
 	if err := ValidateSocketAddress(c.SocketAddress); err != nil {

--- a/go.mod
+++ b/go.mod
@@ -231,4 +231,4 @@ replace (
 	k8s.io/sample-controller => k8s.io/sample-controller v0.20.5
 )
 
-replace gopkg.in/DataDog/dd-trace-go.v1 => gopkg.in/DataDog/dd-trace-go.v1 v1.23.1
+replace gopkg.in/DataDog/dd-trace-go.v1 => gopkg.in/DataDog/dd-trace-go.v1 v1.30.0

--- a/go.sum
+++ b/go.sum
@@ -91,6 +91,7 @@ github.com/DataDog/agent-payload v4.70.0+incompatible/go.mod h1:/2RW4IC/2z54jtB6
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/DataDog/datadog-api-client-go v1.0.0-beta.18/go.mod h1:Gn0fZwIOBbSidO0OaPEh9nO5EmIPsxJrHfHvfVXEaoU=
+github.com/DataDog/datadog-go v4.4.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-go v4.5.0+incompatible h1:MyyuIz5LVAI3Im+0F/tfo64ETyH4sNVynZ29yOiHm50=
 github.com/DataDog/datadog-go v4.5.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a h1:vqz6k806rvz01tIzOA2UHE3j1IEAMcDxw8O+nA3H+Mk=
@@ -105,6 +106,8 @@ github.com/DataDog/gohai v0.0.0-20210303102637-6b668acb50dd h1:tvXbvgbfV9OkVQPwd
 github.com/DataDog/gohai v0.0.0-20210303102637-6b668acb50dd/go.mod h1:sMLDxV2xjWr4YWY5DH/N7udDsLVhJ9xKinFTAIcgSyI=
 github.com/DataDog/gopsutil v0.0.0-20200624212600-1b53412ef321 h1:OPAXA+r6yznoxWR5jQ2iTh5CvzIMrdw8AU0uFN2RwEw=
 github.com/DataDog/gopsutil v0.0.0-20200624212600-1b53412ef321/go.mod h1:tGQp6XG4XpOyy67WG/YWXVxzOY6LejK35e8KcQhtRIQ=
+github.com/DataDog/gostackparse v0.5.0 h1:jb72P6GFHPHz2W0onsN51cS3FkaMDcjb0QzgxxA4gDk=
+github.com/DataDog/gostackparse v0.5.0/go.mod h1:lTfqcJKqS9KnXQGnyQMCugq3u1FP6UZMfWR0aitKFMM=
 github.com/DataDog/mmh3 v0.0.0-20200316233529-f5b682d8c981 h1:UcKqIrOowv2PjTkOC27Xm9TMZlPbRi3CK1OCoawdvl0=
 github.com/DataDog/mmh3 v0.0.0-20200316233529-f5b682d8c981/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
 github.com/DataDog/sketches-go v1.0.0 h1:chm5KSXO7kO+ywGWJ0Zs6tdmWU8PBXSbywFVciL6BG4=
@@ -1205,6 +1208,7 @@ github.com/tedsuo/rata v1.0.0 h1:Sf9aZrYy6ElSTncjnGkyC2yuVvz5YJetBIUKJ4CmeKE=
 github.com/tedsuo/rata v1.0.0/go.mod h1:X47ELzhOoLbfFIY0Cql9P6yo3Cdwf2CMX3FVZxRzJPc=
 github.com/thecodeteam/goscaleio v0.1.0/go.mod h1:68sdkZAsK8bvEwBlbQnlLS+xU+hvLYM/iQ8KXej1AwM=
 github.com/tidwall/pretty v1.0.0/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhVysOjyk=
+github.com/tinylib/msgp v1.1.2/go.mod h1:+d+yLhGm8mzTaHzB+wgMYrodPfmZrzkirds8fDWklFE=
 github.com/tinylib/msgp v1.1.5 h1:2gXmtWueD2HefZHQe1QOy9HVzmFrLOVvsXwXBQ0ayy0=
 github.com/tinylib/msgp v1.1.5/go.mod h1:eQsjooMTnV42mHu917E26IogZ2930nFyBQdofk10Udg=
 github.com/tklauser/go-sysconf v0.3.4 h1:HT8SVixZd3IzLdfs/xlpq0jeSfTX57g1v6wB1EuzV7M=
@@ -1734,8 +1738,8 @@ google.golang.org/protobuf v1.23.1-0.20200526195155-81db48ad09cc/go.mod h1:EGpAD
 google.golang.org/protobuf v1.24.0/go.mod h1:r/3tXBNzIEhYS9I1OUVjXDlt8tc493IdKGjtUeSXeh4=
 google.golang.org/protobuf v1.25.0 h1:Ejskq+SyPohKW+1uil0JJMtmHCgJPJ/qWTxr8qp+R4c=
 google.golang.org/protobuf v1.25.0/go.mod h1:9JNX74DMeImyA3h4bdi1ymwjUzf21/xIlbajtzgsN7c=
-gopkg.in/DataDog/dd-trace-go.v1 v1.23.1 h1:WwxQG9Sk+kcW/vepd1zFrRZUTzJHoYL/Cl0ArmMlVXo=
-gopkg.in/DataDog/dd-trace-go.v1 v1.23.1/go.mod h1:DVp8HmDh8PuTu2Z0fVVlBsyWaC++fzwVCaGWylTe3tg=
+gopkg.in/DataDog/dd-trace-go.v1 v1.30.0 h1:yJJrDYzAlUsDPpAVBjv4VFnXKTbgvaJFTX0646xDPi4=
+gopkg.in/DataDog/dd-trace-go.v1 v1.30.0/go.mod h1:SnKViq44dv/0gjl9RpkP0Y2G3BJSRkp6eYdCSu39iI8=
 gopkg.in/Knetic/govaluate.v3 v3.0.0 h1:18mUyIt4ZlRlFZAAfVetz4/rzlJs9yhN+U02F4u1AOc=
 gopkg.in/Knetic/govaluate.v3 v3.0.0/go.mod h1:csKLBORsPbafmSCGTEh3U7Ozmsuq8ZSIlKk1bcqph0E=
 gopkg.in/airbrake/gobrake.v2 v2.0.9/go.mod h1:/h5ZAUhDkGaJfjzjKLSjv6zCL6O0LLBxU4K+aSYdM/U=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -595,6 +595,7 @@ func InitConfig(config Config) {
 	// internal profiling
 	config.BindEnvAndSetDefault("internal_profiling.enabled", false)
 	config.BindEnv("internal_profiling.profile_dd_url", "") //nolint:errcheck
+	config.BindEnvAndSetDefault("internal_profiling.period", 5)
 
 	// Process agent
 	config.SetDefault("process_config.enabled", "false")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -595,7 +595,8 @@ func InitConfig(config Config) {
 	// internal profiling
 	config.BindEnvAndSetDefault("internal_profiling.enabled", false)
 	config.BindEnv("internal_profiling.profile_dd_url", "") //nolint:errcheck
-	config.BindEnvAndSetDefault("internal_profiling.period", 5)
+	config.BindEnvAndSetDefault("internal_profiling.period", 5*time.Minute)
+	config.BindEnvAndSetDefault("internal_profiling.cpu_duration", 1*time.Minute)
 
 	// Process agent
 	config.SetDefault("process_config.enabled", "false")

--- a/pkg/config/settings/runtime_setting_profiling.go
+++ b/pkg/config/settings/runtime_setting_profiling.go
@@ -7,6 +7,7 @@ package settings
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/profiling"
@@ -67,6 +68,7 @@ func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 			config.Datadog.GetString("env"),
 			profiling.ProfileCoreService,
 			profiling.DefaultProfilingPeriod,
+			15*time.Second,
 			fmt.Sprintf("version:%v", v),
 		)
 		if err == nil {

--- a/pkg/config/settings/runtime_setting_profiling.go
+++ b/pkg/config/settings/runtime_setting_profiling.go
@@ -7,6 +7,7 @@ package settings
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/profiling"
@@ -66,6 +67,7 @@ func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 			site,
 			config.Datadog.GetString("env"),
 			profiling.ProfileCoreService,
+			5 * time.Minute,
 			fmt.Sprintf("version:%v", v),
 		)
 		if err == nil {

--- a/pkg/config/settings/runtime_setting_profiling.go
+++ b/pkg/config/settings/runtime_setting_profiling.go
@@ -7,7 +7,6 @@ package settings
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/profiling"
@@ -67,7 +66,7 @@ func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 			site,
 			config.Datadog.GetString("env"),
 			profiling.ProfileCoreService,
-			5 * time.Minute,
+			profiling.DefaultProfilingPeriod,
 			fmt.Sprintf("version:%v", v),
 		)
 		if err == nil {

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"strings"
+	"time"
 )
 
 const (
@@ -53,7 +54,8 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.profile_dd_url"), "", "DD_SYSTEM_PROBE_INTERNAL_PROFILING_DD_URL", "DD_APM_INTERNAL_PROFILING_DD_URL")
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.api_key"), "", "DD_SYSTEM_PROBE_INTERNAL_PROFILING_API_KEY", "DD_API_KEY")
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.env"), "", "DD_SYSTEM_PROBE_INTERNAL_PROFILING_ENV", "DD_ENV")
-	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.period"), 5, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_PERIOD")
+	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.period"), 5*time.Minute, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_PERIOD")
+	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.cpu_duration"), 1*time.Minute, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_CPU_DURATION")
 
 	// ebpf general settings
 	cfg.BindEnvAndSetDefault(join(spNS, "bpf_debug"), false)

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -53,6 +53,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.profile_dd_url"), "", "DD_SYSTEM_PROBE_INTERNAL_PROFILING_DD_URL", "DD_APM_INTERNAL_PROFILING_DD_URL")
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.api_key"), "", "DD_SYSTEM_PROBE_INTERNAL_PROFILING_API_KEY", "DD_API_KEY")
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.env"), "", "DD_SYSTEM_PROBE_INTERNAL_PROFILING_ENV", "DD_ENV")
+	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.period"), 5, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_PERIOD")
 
 	// ebpf general settings
 	cfg.BindEnvAndSetDefault(join(spNS, "bpf_debug"), false)

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "ced83393da6990bd432f8b127d7f57cf2f61e511c63f9b33ed6836a5117934da")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "99ab8667f42ec990f6b30b13096d196b1b7d3d0557662c0f47652bba0e7b968d")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "99ab8667f42ec990f6b30b13096d196b1b7d3d0557662c0f47652bba0e7b968d")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "ced83393da6990bd432f8b127d7f57cf2f61e511c63f9b33ed6836a5117934da")

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -103,6 +103,7 @@ type AgentConfig struct {
 	ProfilingURL              string
 	ProfilingAPIKey           string
 	ProfilingEnvironment      string
+	ProfilingPeriod      int
 	// host type of the agent, used to populate container payload with additional host information
 	ContainerHostType model.ContainerHostType
 

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -103,7 +103,8 @@ type AgentConfig struct {
 	ProfilingURL              string
 	ProfilingAPIKey           string
 	ProfilingEnvironment      string
-	ProfilingPeriod      int
+	ProfilingPeriod           time.Duration
+	ProfilingCPUDuration      time.Duration
 	// host type of the agent, used to populate container payload with additional host information
 	ContainerHostType model.ContainerHostType
 

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -211,6 +211,7 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 		a.ProfilingURL = config.Datadog.GetString("internal_profiling.profile_dd_url")
 		a.ProfilingAPIKey = config.SanitizeAPIKey(config.Datadog.GetString("api_key"))
 		a.ProfilingEnvironment = config.Datadog.GetString("env")
+		a.ProfilingPeriod = config.Datadog.GetInt("internal_profiling.period")
 	}
 
 	// Used to override container source auto-detection

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -211,7 +211,8 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 		a.ProfilingURL = config.Datadog.GetString("internal_profiling.profile_dd_url")
 		a.ProfilingAPIKey = config.SanitizeAPIKey(config.Datadog.GetString("api_key"))
 		a.ProfilingEnvironment = config.Datadog.GetString("env")
-		a.ProfilingPeriod = config.Datadog.GetInt("internal_profiling.period")
+		a.ProfilingPeriod = config.Datadog.GetDuration("internal_profiling.period")
+		a.ProfilingCPUDuration = config.Datadog.GetDuration("internal_profiling.cpu_duration")
 	}
 
 	// Used to override container source auto-detection

--- a/pkg/util/profiling/profiling.go
+++ b/pkg/util/profiling/profiling.go
@@ -26,6 +26,8 @@ const (
 	ProfileCoreService = "datadog-agent"
 	// ProfilingLocalURLTemplate is the constant used to compute the URL of the local trace agent
 	ProfilingLocalURLTemplate = "http://%v/profiling/v1/input"
+	// DefaultProfilingPeriod defines the default profiling period
+	DefaultProfilingPeriod = 5 * time.Minute
 )
 
 // Active returns a boolean indicating whether profiling is active or not;

--- a/pkg/util/profiling/profiling.go
+++ b/pkg/util/profiling/profiling.go
@@ -41,7 +41,7 @@ func Active() bool {
 
 // Start initiates profiling with the supplied parameters;
 // this function is thread-safe.
-func Start(apiKey, site, env, service string, period time.Duration, tags ...string) error {
+func Start(apiKey, site, env, service string, period time.Duration, cpuDuration time.Duration, tags ...string) error {
 	if Active() {
 		return nil
 	}
@@ -52,6 +52,8 @@ func Start(apiKey, site, env, service string, period time.Duration, tags ...stri
 		profiler.WithService(service),
 		profiler.WithURL(site),
 		profiler.WithPeriod(period),
+		profiler.WithProfileTypes(profiler.CPUProfile, profiler.HeapProfile, profiler.MutexProfile),
+		profiler.CPUDuration(cpuDuration),
 		profiler.WithTags(tags...),
 	)
 	if err == nil {

--- a/pkg/util/profiling/profiling.go
+++ b/pkg/util/profiling/profiling.go
@@ -7,6 +7,7 @@ package profiling
 
 import (
 	"sync"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -38,7 +39,7 @@ func Active() bool {
 
 // Start initiates profiling with the supplied parameters;
 // this function is thread-safe.
-func Start(apiKey, site, env, service string, tags ...string) error {
+func Start(apiKey, site, env, service string, period time.Duration, tags ...string) error {
 	if Active() {
 		return nil
 	}
@@ -48,6 +49,7 @@ func Start(apiKey, site, env, service string, tags ...string) error {
 		profiler.WithEnv(env),
 		profiler.WithService(service),
 		profiler.WithURL(site),
+		profiler.WithPeriod(period),
 		profiler.WithTags(tags...),
 	)
 	if err == nil {

--- a/pkg/util/profiling/profiling_test.go
+++ b/pkg/util/profiling/profiling_test.go
@@ -19,6 +19,7 @@ func TestProfiling(t *testing.T) {
 		"testing",
 		ProfileCoreService,
 		time.Minute,
+		15*time.Second,
 		"1.0.0",
 	)
 	assert.Nil(t, err)

--- a/pkg/util/profiling/profiling_test.go
+++ b/pkg/util/profiling/profiling_test.go
@@ -7,6 +7,7 @@ package profiling
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -17,6 +18,7 @@ func TestProfiling(t *testing.T) {
 		"https://nowhere.testing.dev",
 		"testing",
 		ProfileCoreService,
+		time.Minute,
 		"1.0.0",
 	)
 	assert.Nil(t, err)


### PR DESCRIPTION
### What does this PR do?

This PR changes the default agent profiling period from 1 minute to 5 minutes.

### Motivation

For now, we do not need to have a profile every minute, 5 minutes should be enough to understand how our fleet of agents behave.

### Describe how to test your changes

There is a unit test for the profiling helper that was changed.