### PR TITLE
[status] list one logs input per line

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -318,7 +318,10 @@
             {{- end }}
             {{- end }}
             {{- if .inputs }}
-            Inputs: {{ range $input := .inputs }}{{$input}} {{ end }}</br>
+            Inputs:
+            {{- range $input := .inputs }}
+              {{$input}}<br>
+            {{- end }}</br>
             {{- end }}
             BytesRead: {{ .bytes_read }}</br>
             Average Latency (ms): {{ .all_time_avg_latency }}</br>

--- a/pkg/status/templates/logsagent.tmpl
+++ b/pkg/status/templates/logsagent.tmpl
@@ -61,7 +61,10 @@ Logs Agent
         {{ $message }}
       {{- end }}
       {{- if .inputs }}
-      Inputs: {{ range $input := .inputs }}{{$input}} {{ end }}
+      Inputs:
+      {{- range $input := .inputs }}
+        {{$input}}
+      {{- end }}
       {{- end }}
       BytesRead: {{ .bytes_read }}
       Average Latency (ms): {{ .all_time_avg_latency }}


### PR DESCRIPTION
### What does this PR do?

When a directory is tailed using a wildcard pattern, list each tailed file on a separate line in the status report. This prevents problems when scrubbing the report for a flare, and is easier to read and grep in general.

### Describe how to test your changes

Create a large number of log files with long path names, so that their total length is >64k, for example 
```shell
perl -e '$a="/"."a"x250; $p="/tmp"; mkdir $p.=$a for 0..4; open X,">$p$a$_" for 0..100; print "path: $p/*\n"'
```

Create [wildcard logs config](https://docs.datadoghq.com/agent/logs/advanced_log_collection/?tab=configurationfile#tail-directories-by-using-wildcards) for the directory with the logs.

Enable logs agent: `logs_enabled: true` in `datadog.yaml`

Collect a flare from the running agent, don't send.

Unzip the flare archive and verify that `status.log` is populated.