### PR TITLE
[networks] Make IPv6 offset guessing more permissive

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -163,6 +163,7 @@
 /pkg/util/containers/collectors/cloudfoundry.go              @DataDog/integrations-tools-and-libraries
 /pkg/util/docker/                       @DataDog/container-integrations
 /pkg/util/ecs/                          @DataDog/container-integrations
+/pkg/util/kernel/                       @DataDog/networks
 /pkg/util/kubernetes/                   @DataDog/container-integrations @DataDog/container-app
 /pkg/util/retry/                        @DataDog/container-integrations
 /pkg/logs/                              @DataDog/agent-core

--- a/pkg/network/ebpf/c/prebuilt/tracer.c
+++ b/pkg/network/ebpf/c/prebuilt/tracer.c
@@ -214,7 +214,11 @@ static __always_inline int read_conn_tuple_partial(conn_tuple_t * t, struct sock
             log_debug("ERR(read_conn_tuple.v4): src or dst addr not set src=%d, dst=%d\n", t->saddr_l, t->daddr_l);
             return 0;
         }
-    } else if (is_ipv6_enabled() && check_family(skp, AF_INET6)) {
+    } else if (check_family(skp, AF_INET6)) {
+        if (!is_ipv6_enabled()) {
+            return 0;
+        }
+
         if (t->saddr_h == 0) {
             bpf_probe_read(&t->saddr_h, sizeof(t->saddr_h), ((char*)skp) + offset_daddr_ipv6() + 2 * sizeof(u64));
         }

--- a/pkg/network/tracer/offsetguess.go
+++ b/pkg/network/tracer/offsetguess.go
@@ -752,7 +752,7 @@ func getUDP6Conn(ipv6 bool) (*net.UDPConn, error) {
 	linkLocal, err := getIPv6LinkLocalAddress()
 	if err != nil {
 		// TODO: Find a offset guessing method that doesn't need an available IPv6 interface
-		log.Debug("unable to find ipv6 device for udp6 flow offset guessing. unconnected udp6 flows won't be traced.")
+		log.Debugf("unable to find ipv6 device for udp6 flow offset guessing. unconnected udp6 flows won't be traced: %s", err)
 		return nil, nil
 	}
 

--- a/pkg/util/kernel/ip.go
+++ b/pkg/util/kernel/ip.go
@@ -5,13 +5,12 @@ package kernel
 import (
 	"io/ioutil"
 	"path/filepath"
-	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 )
 
 // IsIPv6Enabled returns whether or not IPv6 has been enabled on the host
 func IsIPv6Enabled() bool {
-	ints, err := ioutil.ReadFile(filepath.Join(util.GetProcRoot(), "net/if_inet6"))
-	return err == nil && strings.TrimSpace(string(ints)) != ""
+	_, err := ioutil.ReadFile(filepath.Join(util.GetProcRoot(), "net/if_inet6"))
+	return err == nil
 }


### PR DESCRIPTION
### What does this PR do?

Ensures that IPv6 field offsets are guessed even when a link-local IPv6 interface is not available.
That was the behavior up to 7.27 when [support for UDP on IPv6 "unconnected" sends](https://github.com/DataDog/datadog-agent/pull/7198) was added.

We're now checking for an IPv6 interface only when UDP6 fields are being guessed, and we allow these fields to be skipped instead of disabling IPv6 tracing altogether.

This fixes some resolution scenarios on ECS where traffic from containers running on VPC mode was happening through IPv4-mapped IPv6 addresses, but were not being resolved because system-probe container (running in bridge mode) had IPv6 tracing disabled as no IPv6 interface could be detected.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
