### PR TITLE
[gitlab] Add servercore image build jobs as dependencies of Windows image deploy jobs

### DIFF
--- a/.gitlab/image_deploy/docker_windows.yml
+++ b/.gitlab/image_deploy/docker_windows.yml
@@ -30,10 +30,16 @@ dev_branch_docker_hub-a7-windows:
   needs:
     - docker_build_agent7_windows1809
     - docker_build_agent7_windows1809_jmx
+    - docker_build_agent7_windows1809_core
+    - docker_build_agent7_windows1809_core_jmx
     - docker_build_agent7_windows1909
     - docker_build_agent7_windows1909_jmx
+    - docker_build_agent7_windows1909_core
+    - docker_build_agent7_windows1909_core_jmx
     - docker_build_agent7_windows2004
     - docker_build_agent7_windows2004_jmx
+    - docker_build_agent7_windows2004_core
+    - docker_build_agent7_windows2004_core_jmx
   variables:
     VARIANT: 2004
   script:
@@ -91,10 +97,16 @@ dev_master_docker_hub-a7-windows:
   needs:
     - docker_build_agent7_windows1809
     - docker_build_agent7_windows1809_jmx
+    - docker_build_agent7_windows1809_core
+    - docker_build_agent7_windows1809_core_jmx
     - docker_build_agent7_windows1909
     - docker_build_agent7_windows1909_jmx
+    - docker_build_agent7_windows1909_core
+    - docker_build_agent7_windows1909_core_jmx
     - docker_build_agent7_windows2004
     - docker_build_agent7_windows2004_jmx
+    - docker_build_agent7_windows2004_core
+    - docker_build_agent7_windows2004_core_jmx
   variables:
     VARIANT: 2004
   script:


### PR DESCRIPTION
### What does this PR do?

Adds the server core image build jobs as dependencies of all Windows image deploy jobs.

### Motivation

Follow-up of #7836.

The `dev_branch_docker_hub-a7-windows` and `dev_master_docker_hub-a7-windows` jobs also use the Server Core images, so they need to depend on the jobs which build them.
