### PR TITLE
[kitchen] Fix scenario extend order

### DIFF
--- a/.gitlab/kitchen_testing/centos.yml
+++ b/.gitlab/kitchen_testing/centos.yml
@@ -49,14 +49,14 @@
 
 .kitchen_scenario_centos_all_non_fips_a6:
   extends:
-    - .kitchen_os_centos_all_non_fips
     - .kitchen_agent_a6
+    - .kitchen_os_centos_all_non_fips
   needs: ["deploy_rpm_testing-a6"]
 
 .kitchen_scenario_centos_all_non_fips_a7:
   extends:
-    - .kitchen_os_centos_all_non_fips
     - .kitchen_agent_a7
+    - .kitchen_os_centos_all_non_fips
   needs: ["deploy_rpm_testing-a7"]
 
 .kitchen_scenario_centos_6_7_non_fips_a6:
@@ -67,20 +67,20 @@
 
 .kitchen_scenario_centos_6_7_non_fips_a7:
   extends:
-    - .kitchen_os_centos_6_7_non_fips
     - .kitchen_agent_a7
+    - .kitchen_os_centos_6_7_non_fips
   needs: ["deploy_rpm_testing-a7"]
 
 .kitchen_scenario_centos_8_fips_a6:
   extends:
-    - .kitchen_os_centos_8_fips
     - .kitchen_agent_a6
+    - .kitchen_os_centos_8_fips
   needs: ["deploy_rpm_testing-a6"]
 
 .kitchen_scenario_centos_8_fips_a7:
   extends:
-    - .kitchen_os_centos_8_fips
     - .kitchen_agent_a7
+    - .kitchen_os_centos_8_fips
   needs: ["deploy_rpm_testing-a7"]
 
 # Kitchen: final test matrix (tests * scenarios)

--- a/.gitlab/kitchen_testing/debian.yml
+++ b/.gitlab/kitchen_testing/debian.yml
@@ -27,14 +27,14 @@
 
 .kitchen_scenario_debian_a6:
   extends:
-    - .kitchen_os_debian
     - .kitchen_agent_a6
+    - .kitchen_os_debian
   needs: ["deploy_deb_testing-a6"]
 
 .kitchen_scenario_debian_a7:
   extends:
-    - .kitchen_os_debian
     - .kitchen_agent_a7
+    - .kitchen_os_debian
   needs: ["deploy_deb_testing-a7"]
 
 # Kitchen: final test matrix (tests * scenarios)

--- a/.gitlab/kitchen_testing/suse.yml
+++ b/.gitlab/kitchen_testing/suse.yml
@@ -27,14 +27,14 @@
 
 .kitchen_scenario_suse_a6:
   extends:
-    - .kitchen_os_suse
     - .kitchen_agent_a6
+    - .kitchen_os_suse
   needs: ["deploy_suse_rpm_testing-a6"]
 
 .kitchen_scenario_suse_a7:
   extends:
-    - .kitchen_os_suse
     - .kitchen_agent_a7
+    - .kitchen_os_suse
   needs: ["deploy_suse_rpm_testing-a7"]
 
 # Kitchen: final test matrix (tests * scenarios)

--- a/.gitlab/kitchen_testing/ubuntu.yml
+++ b/.gitlab/kitchen_testing/ubuntu.yml
@@ -27,14 +27,14 @@
 
 .kitchen_scenario_ubuntu_a6:
   extends:
-    - .kitchen_os_ubuntu
     - .kitchen_agent_a6
+    - .kitchen_os_ubuntu
   needs: ["deploy_deb_testing-a6"]
 
 .kitchen_scenario_ubuntu_a7:
   extends:
-    - .kitchen_os_ubuntu
     - .kitchen_agent_a7
+    - .kitchen_os_ubuntu
   needs: ["deploy_deb_testing-a7"]
 
 # Kitchen: final test matrix (tests * scenarios)

--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -89,14 +89,14 @@
 
 .kitchen_scenario_windows_a6:
   extends:
-    - .kitchen_os_windows
     - .kitchen_agent_a6
+    - .kitchen_os_windows
   needs: ["deploy_windows_testing-a6"]
 
 .kitchen_scenario_windows_a7:
   extends:
-    - .kitchen_os_windows
     - .kitchen_agent_a7
+    - .kitchen_os_windows
   needs: ["deploy_windows_testing-a7"]
 
 # Kitchen: final test matrix (test types * scenarios)

--- a/test/kitchen/docs/README.md
+++ b/test/kitchen/docs/README.md
@@ -43,6 +43,8 @@ From these base blocks, we define:
 - test types: `kitchen_test_<test_suite>_<flavor>` which is a combination of a chosen test suite, Agent flavor and Azure location.
 - scenarios: `kitchen_scenario_<OS>_aX` which is a combination of a chosen OS and major Agent version.
 
+**Note:** When jobs use combinations of other jobs with the `extends` keyword (eg. test types, scenarios), the `extends` list is processed in order. Duplicate keys are overridden (ie. the latest job in the list which contains the key wins). Therefore, `extends` lists need to be ordered from the most generic to the most specific extension.
+
 **Note:** To avoid having too many different test types, we bind each test suite with a specific Azure location. Eg. all install script tests are run in the same Azure location.
 
 The real jobs that are run in the Gitlab pipelines are thus a combination of test types and scenarios, named `kitchen_<OS>_<test_suite>_<flavor>-aX`.


### PR DESCRIPTION
### What does this PR do?

Changes the order of extends in `.kitchen_scenario_*` job definitions.

### Motivation

The `extends` list is applied in order. Duplicates keys are overridden (ie. the latter extended job wins). Therefore, the more specific extensions should go after the more generic ones (here, OS-specific extensions should go after the more generic Agent version extension).

The previous order made #7947 do nothing, as the kitchen scenario jobs were defined as:
```
.kitchen_scenario_windows_a6:
  extends:
    - .kitchen_os_windows
    - .kitchen_agent_a6
  needs: ["deploy_windows_testing-a6"]

.kitchen_scenario_windows_a7:
  extends:
    - .kitchen_os_windows
    - .kitchen_agent_a7
  needs: ["deploy_windows_testing-a7"]
```
 
`.kitchen_os_windows` was changed to have `retry: 2`, but `.kitchen_agent_a6` and `.kitchen_agent_a7` define `retry: 1`, so the jobs still ended up with only one retry.

### Describe how to test your changes

Run a pipeline with kitchen tests, make sure it passes (in progress).
