### PR TITLE
[compliance] do not override logs endpoints with default ones (#8026)

### DIFF
--- a/cmd/cluster-agent/app/compliance.go
+++ b/cmd/cluster-agent/app/compliance.go
@@ -39,12 +39,15 @@ func runCompliance(ctx context.Context, apiCl *apiserver.APIClient, isLeader fun
 }
 
 func newLogContext(logsConfig config.LogsConfigKeys, endpointPrefix string) (*config.Endpoints, *client.DestinationsContext, error) {
-	httpConnectivity := config.HTTPConnectivityFailure
-	if endpoints, err := config.BuildHTTPEndpointsWithConfig(logsConfig, endpointPrefix); err == nil {
-		httpConnectivity = logshttp.CheckConnectivity(endpoints.Main)
+	endpoints, err := config.BuildHTTPEndpointsWithConfig(logsConfig, endpointPrefix)
+	if err != nil {
+		endpoints, err = config.BuildHTTPEndpoints()
+		if err == nil {
+			httpConnectivity := logshttp.CheckConnectivity(endpoints.Main)
+			endpoints, err = config.BuildEndpoints(httpConnectivity)
+		}
 	}
 
-	endpoints, err := config.BuildEndpoints(httpConnectivity)
 	if err != nil {
 		return nil, nil, log.Errorf("Invalid endpoints: %v", err)
 	}

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -115,12 +115,15 @@ func init() {
 }
 
 func newLogContext(logsConfig config.LogsConfigKeys, endpointPrefix string) (*config.Endpoints, *client.DestinationsContext, error) {
-	httpConnectivity := config.HTTPConnectivityFailure
-	if endpoints, err := config.BuildHTTPEndpointsWithConfig(logsConfig, endpointPrefix); err == nil {
-		httpConnectivity = logshttp.CheckConnectivity(endpoints.Main)
+	endpoints, err := config.BuildHTTPEndpointsWithConfig(logsConfig, endpointPrefix)
+	if err != nil {
+		endpoints, err = config.BuildHTTPEndpoints()
+		if err == nil {
+			httpConnectivity := logshttp.CheckConnectivity(endpoints.Main)
+			endpoints, err = config.BuildEndpoints(httpConnectivity)
+		}
 	}
 
-	endpoints, err := config.BuildEndpoints(httpConnectivity)
 	if err != nil {
 		return nil, nil, log.Errorf("Invalid endpoints: %v", err)
 	}


### PR DESCRIPTION
(cherry picked from commit 977366177e29f87f2fb9a68764318fdf4096aa27)

### What does this PR do?

Use logs endpoints specified in the proper section of the configuration

### Motivation

Endpoints specified in the configuration were not used and the endpoints specified
in the default section `logs_config` were used instead