### PR TITLE
[runtime-security] disable all perf_buffer metrics backport

### DIFF
--- a/pkg/security/probe/perf_buffer_monitor.go
+++ b/pkg/security/probe/perf_buffer_monitor.go
@@ -296,12 +296,14 @@ func (pbm *PerfBufferMonitor) CountLostEvent(count uint64, m *manager.PerfMap, c
 func (pbm *PerfBufferMonitor) CountEvent(eventType model.EventType, timestamp uint64, count uint64, size uint64, m *manager.PerfMap, cpu int) {
 	// check event order
 	if timestamp < pbm.lastTimestamp && pbm.lastTimestamp != 0 {
-		tags := []string{
-			fmt.Sprintf("map:%s", m.Name),
-			fmt.Sprintf("cpu:%d", cpu),
-			fmt.Sprintf("event_type:%s", eventType),
-		}
-		_ = pbm.statsdClient.Count(metrics.MetricPerfBufferSortingError, 1, tags, 1.0)
+		// Comment this out for now, until we fix the cardinality of the perf_buffer.* metrics.
+		//
+		// tags := []string{
+		// 	fmt.Sprintf("map:%s", m.Name),
+		// 	fmt.Sprintf("cpu:%d", cpu),
+		// 	fmt.Sprintf("event_type:%s", eventType),
+		// }
+		// _ = pbm.statsdClient.Count(metrics.MetricPerfBufferSortingError, 1, tags, 1.0)
 	} else {
 		pbm.lastTimestamp = timestamp
 	}

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -92,9 +92,11 @@ func (m *Monitor) SendStats() error {
 		}
 	}
 
-	if err := m.perfBufferMonitor.SendStats(); err != nil {
-		return errors.Wrap(err, "failed to send events stats")
-	}
+	// Comment this out for now, until we fix the cardinality of the perf_buffer.* metrics.
+	//
+	//if err := m.perfBufferMonitor.SendStats(); err != nil {
+	//	return errors.Wrap(err, "failed to send events stats")
+	//}
 
 	return nil
 }

--- a/pkg/security/probe/reorderer.go
+++ b/pkg/security/probe/reorderer.go
@@ -217,10 +217,10 @@ func (r *ReOrderer) Start(ctx context.Context) {
 		case <-metricTicker.C:
 			r.metric.QueueSize = r.heap.len()
 
-			select {
-			case r.Metrics <- r.metric:
-			default:
-			}
+			//select {
+			//case r.Metrics <- r.metric:
+			//default:
+			//}
 
 			r.metric.zero()
 		case <-ctx.Done():


### PR DESCRIPTION
### What does this PR do?

This is a backport of https://github.com/DataDog/datadog-agent/commit/f3723b6ed33d3e9ef6a8a8ecf9cff322d2223ffb

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

`perf_buffer.*` metrics shouldn't be sent anymore.
