### PR TITLE
Vickenty/azure hostname

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -573,6 +573,9 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("cloud_foundry_garden.listen_network", "unix")
 	config.BindEnvAndSetDefault("cloud_foundry_garden.listen_address", "/var/vcap/data/garden/garden.sock")
 
+	// Azure
+	config.BindEnvAndSetDefault("azure_hostname_style", "os")
+
 	// JMXFetch
 	config.BindEnvAndSetDefault("jmx_custom_jars", []string{})
 	config.BindEnvAndSetDefault("jmx_use_cgroup_memory_limit", false)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -308,7 +308,7 @@ api_key:
 #
 # gce_metadata_timeout: 1000
 
-## @param azure_hostname_style - string - optional
+## @param azure_hostname_style - string - optional - default: "os"
 ## Changes how agent hostname is set on Azure virtual machines.
 ##
 ## Possible values:

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -308,6 +308,18 @@ api_key:
 #
 # gce_metadata_timeout: 1000
 
+## @param azure_hostname_style - string - optional
+## Changes how agent hostname is set on Azure virtual machines.
+##
+## Possible values:
+##   "os" - use the hostname reported by the operating system (default)
+##   "name" - use the instance name
+##   "name_and_resource_group" - use a combination of the instance name and resource group name
+##   "full" - use a combination of the instance name, resource group name and subscription id
+##   "vmid" - use the instance id
+#
+# azure_hostname_style: "os"
+
 ## @param flare_stripped_keys - list of strings - optional
 ## By default, the Agent removes known sensitive keys from Agent and Integrations yaml configs before
 ## including them in the flare.

--- a/pkg/util/azure/azure_test.go
+++ b/pkg/util/azure/azure_test.go
@@ -6,6 +6,7 @@
 package azure
 
 import (
+	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -16,7 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
-func TestGetHostname(t *testing.T) {
+func TestGetAlias(t *testing.T) {
 	expected := "5d33a910-a7a0-4443-9f01-6a807801b29b"
 	var lastRequest *http.Request
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -93,4 +94,69 @@ func TestGetNTPHosts(t *testing.T) {
 	actualHosts := GetNTPHosts()
 
 	assert.Equal(t, expectedHosts, actualHosts)
+}
+
+func TestGetHostname(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		io.WriteString(w, `{
+			"name": "vm-name",
+			"resourceGroupName": "my-resource-group",
+			"subscriptionId": "2370ac56-5683-45f8-a2d4-d1054292facb",
+			"vmId": "b33fa46-6aff-4dfa-be0a-9e922ca3ac6d"
+		}`)
+	}))
+	defer ts.Close()
+	metadataURL = ts.URL
+
+	cases := []struct {
+		style, value string
+		err          bool
+	}{
+		{"os", "", true},
+		{"vmid", "b33fa46-6aff-4dfa-be0a-9e922ca3ac6d", false},
+		{"name", "vm-name", false},
+		{"name_and_resource_group", "vm-name.my-resource-group", false},
+		{"full", "vm-name.my-resource-group.2370ac56-5683-45f8-a2d4-d1054292facb", false},
+		{"invalid", "", true},
+	}
+
+	mockConfig := config.Mock()
+
+	for _, tt := range cases {
+		mockConfig.Set(hostnameStyleSetting, tt.style)
+		hostname, err := getHostnameWithConfig(mockConfig)
+		assert.Equal(t, tt.value, hostname)
+		assert.Equal(t, tt.err, (err != nil))
+	}
+}
+
+func TestGetHostnameWithInvalidMetadata(t *testing.T) {
+	mockConfig := config.Mock()
+
+	styles := []string{"vmid", "name", "name_and_resource_group", "full"}
+
+	for _, response := range []string{"", "!"} {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			io.WriteString(w, fmt.Sprintf(`{
+				"name": "%s",
+				"resourceGroupName": "%s",
+				"subscriptionId": "%s",
+				"vmId": "%s"
+			}`, response, response, response, response))
+		}))
+		metadataURL = ts.URL
+
+		t.Run(fmt.Sprintf("with response '%s'", response), func(t *testing.T) {
+			for _, style := range styles {
+				mockConfig.Set(hostnameStyleSetting, style)
+				hostname, err := getHostnameWithConfig(mockConfig)
+				assert.Empty(t, hostname)
+				assert.NotNil(t, err)
+			}
+		})
+
+		ts.Close()
+	}
 }

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -268,6 +268,21 @@ func GetHostnameData() (HostnameData, error) {
 		}
 	}
 
+	if getAzureHostname, found := hostname.ProviderCatalog["azure"]; found {
+		log.Debug("GetHostname trying Azure metadata...")
+
+		azureHostname, err := getAzureHostname()
+		if err == nil {
+			hostName = azureHostname
+			provider = "azure"
+		} else {
+			expErr := new(expvar.String)
+			expErr.Set(err.Error())
+			hostnameErrors.Set("azure", expErr)
+			log.Debugf("unable to get hostname from Azure: %s", err)
+		}
+	}
+
 	h, err := os.Hostname()
 	// We have a FQDN not equals to the resolved hostname, and the configuration
 	// field `hostname_fqdn` isn't set -> we display a warning message about

--- a/pkg/util/hostname/azure.go
+++ b/pkg/util/hostname/azure.go
@@ -1,0 +1,7 @@
+package hostname
+
+import "github.com/DataDog/datadog-agent/pkg/util/azure"
+
+func init() {
+	RegisterHostnameProvider("azure", azure.GetHostname)
+}

--- a/releasenotes/notes/azure-hostname-e079a207d85d5094.yaml
+++ b/releasenotes/notes/azure-hostname-e079a207d85d5094.yaml
@@ -1,0 +1,6 @@
+enhancements:
+  - |
+    Agent can now set hostname based on Azure instance metadata. See the new
+    ``azure_hostname_style`` configuration option.
+
+


### PR DESCRIPTION
### What does this PR do?

Add a configuration setting to set hostname from the Azure instance metadata. Several options are provided, that generate host names with varying length and uniqueness.

### Describe how to test your changes

Install the agent on an Azure vm.
Change hostname to be different from vm name (`sudo hostname different`).
Run `agent hostname` with different values of `azure_hostname_style` and verify that output matches documentation.