### PR TITLE
[runtime-security] remove kretprobe for process snapshot

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "164eb69bf352c9b1a9cd5ca0ff346ef47cb2f70969103aacea526c32f68558b5")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "dbb004ad20a8f192b4e6e38882f6a18df8e733d3542762dc90e7c96e30113fbb")

--- a/pkg/security/ebpf/c/erpc.h
+++ b/pkg/security/ebpf/c/erpc.h
@@ -60,7 +60,7 @@ int __attribute__((always_inline)) is_eprc_request(struct pt_regs *ctx) {
     u64 fd, pid;
 
     LOAD_CONSTANT("erpc_fd", fd);
-    LOAD_CONSTANT("erpc_pid", pid);
+    LOAD_CONSTANT("runtime_pid", pid);
 
     u32 vfs_fd = PT_REGS_PARM2(ctx);
     if (!vfs_fd || (u64)vfs_fd != fd) {

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -50,7 +50,7 @@ func AllProbes() []*manager.Probe {
 		// Snapshot probe
 		&manager.Probe{
 			UID:     SecurityAgentUID,
-			Section: "kretprobe/get_task_exe_file",
+			Section: "kprobe/security_inode_getattr",
 		},
 	)
 
@@ -69,7 +69,7 @@ func AllMaps() []*manager.Map {
 		// Dentry resolver table
 		{Name: "pathnames"},
 		// Snapshot table
-		{Name: "inode_info_cache"},
+		{Name: "exec_file_cache"},
 		// Open tables
 		{Name: "open_flags_approvers"},
 		// Exec tables

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -35,7 +35,6 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/prepare_binprm"}},
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/bprm_execve"}},
 			}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kretprobe/get_task_exe_file"}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/vfs_open"}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/do_dentry_open"}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/commit_creds"}},
@@ -208,6 +207,11 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 		// ioctl probes
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/do_vfs_ioctl"}},
+		}},
+
+		// snapshot
+		&manager.AllOf{Selectors: []manager.ProbesSelector{
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/security_inode_getattr"}},
 		}},
 	},
 

--- a/pkg/security/probe/dentry_resolver.go
+++ b/pkg/security/probe/dentry_resolver.go
@@ -18,8 +18,9 @@ import (
 	lib "github.com/DataDog/ebpf"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/pkg/errors"
+
+	"github.com/DataDog/datadog-agent/pkg/security/model"
 )
-import "github.com/DataDog/datadog-agent/pkg/security/model"
 
 const (
 	dentryPathKeyNotFound = "error: dentry path key not found"
@@ -80,7 +81,10 @@ func (p *PathKey) MarshalBinary() ([]byte, error) {
 		return nil, &ErrInvalidKeyPath{Inode: p.Inode, MountID: p.MountID}
 	}
 
-	return make([]byte, 16), nil
+	buff := make([]byte, 16)
+	p.Write(buff)
+
+	return buff, nil
 }
 
 // PathValue describes a value of an entry of the cache

--- a/pkg/security/probe/erpc.go
+++ b/pkg/security/probe/erpc.go
@@ -11,7 +11,6 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/ebpf/manager"
 )
 
@@ -39,10 +38,6 @@ func (k *ERPC) GetConstants() []manager.ConstantEditor {
 		{
 			Name:  "erpc_fd",
 			Value: uint64(k.fd),
-		},
-		{
-			Name:  "erpc_pid",
-			Value: uint64(utils.Getpid()),
 		},
 	}
 }

--- a/pkg/security/probe/mount_resolver.go
+++ b/pkg/security/probe/mount_resolver.go
@@ -9,7 +9,6 @@ package probe
 
 import (
 	"context"
-	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"os"
 	"path"
 	"strconv"
@@ -23,6 +22,7 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -32,6 +32,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/model"
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/eval"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -808,6 +809,10 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 
 	// Add global constant editors
 	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors,
+		manager.ConstantEditor{
+			Name:  "runtime_pid",
+			Value: uint64(utils.Getpid()),
+		},
 		manager.ConstantEditor{
 			Name:  "do_fork_input",
 			Value: getDoForkInput(p),


### PR DESCRIPTION
### What does this PR do?

Remove use of kretprobe for process snapshot because of kernel < 4.12 limitation.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes
