### PR TITLE
[KSMCore] Add reason tag to pod metrics

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -118,14 +118,13 @@ var (
 
 	// metadata metrics are useful for label joins
 	// but shouldn't be submitted to Datadog
-	metadataMetricsRegex = regexp.MustCompile(".*_(info|labels)")
+	metadataMetricsRegex = regexp.MustCompile(".*_(info|labels|status_reason)")
 
 	// defaultDeniedMetrics used to configure the KSM store to ignore these metrics by KSM engine
 	defaultDeniedMetrics = options.MetricSet{
 		".*_generation":                                    {},
 		".*_metadata_resource_version":                     {},
 		"kube_pod_owner":                                   {},
-		"kube_pod_status_reason":                           {},
 		"kube_pod_restart_policy":                          {},
 		"kube_pod_completion_time":                         {},
 		"kube_pod_status_scheduled_time":                   {},
@@ -173,6 +172,10 @@ var (
 		"kube_pod_labels": {
 			LabelsToMatch: []string{"pod", "namespace"},
 			LabelsToGet:   defaultStandardLabels,
+		},
+		"kube_pod_status_reason": {
+			LabelsToMatch: []string{"pod", "namespace"},
+			LabelsToGet:   []string{"reason"},
 		},
 		"kube_deployment_labels": {
 			LabelsToMatch: []string{"deployment", "namespace"},

--- a/releasenotes/notes/ksm-core-pod-status-reason-1207938b2f084c55.yaml
+++ b/releasenotes/notes/ksm-core-pod-status-reason-1207938b2f084c55.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    The kube state metrics core check now tags pod metrics with a ``reason`` tag.
+    It can be ``NodeLost``, ``Evicted`` or ``UnexpectedAdmissionError``.


### PR DESCRIPTION
### What does this PR do?

Define a default label join on `kube_pod_status_reason` to get the `reason` tag.

### Motivation

FR

### Additional Notes

The supported values for the tag are `NodeLost`, `Evicted`, `UnexpectedAdmissionError` see [why](https://github.com/kubernetes/kube-state-metrics/blob/v2.0.0/internal/store/pod.go#L37) 

### Describe how to test your changes

Force the eviction of a pod (e.g high disk pressure), make sure the ksm core check adds the `reason` tag
![image](https://user-images.githubusercontent.com/38987709/116875371-187ef500-ac1b-11eb-8663-123b5f3a7db7.png)
