### PR TITLE
[install_script] Activate repo_gpgcheck for RPM repos by default

### DIFF
--- a/releasenotes-installscript/notes/rpm-repo-gpgcheck-95d08d1aaa1f5abb.yaml
+++ b/releasenotes-installscript/notes/rpm-repo-gpgcheck-95d08d1aaa1f5abb.yaml
@@ -1,0 +1,15 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG-INSTALLSCRIPT.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Activate `repo_gpgcheck` on RPM repositories by default. `repo_gpgcheck`
+    is still set to `0` when using a custom `REPO_URL` or when running on
+    RHEL/CentOS 8.1 because of a [bug in dnf](https://bugzilla.redhat.com/show_bug.cgi?id=1792506).
+    The default value can be overriden by specifying `DD_RPM_REPO_GPGCHECK`
+    variable. The allowed values are `0` (to disable) and `1` (to enable).


### PR DESCRIPTION
### What does this PR do?

Activates `repo_gpgcheck` by default for RPM repos. This doesn't apply when user provides custom `REPO_URL` and when running on RHEL/CentOS 8.1, which have a [bug in dnf](https://bugzilla.redhat.com/show_bug.cgi?id=1792506).

### Motivation

Improving security of our users when installing RPM packages.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Test on:
* A SUSE platform, verify that `repo_gpgcheck=1`
* A Fedora/Amazon Linux platform, verify that `repo_gpgcheck=1`
* CentOS 8.1, verify that `repo_gpgcheck=0`
* CentOS != 8.1, verify that `repo_gpgcheck=1`
* CentOS != 8.1 with custom `REPO_URL`, verify that `repo_gpgcheck=0`
* CentOS != 8.1 with custom `REPO_URL` and `DD_RPM_REPO_GPGCHECK=1`, verify that `repo_gpgcheck=1`