### PR TITLE
Save customaction PDB in omnibus package dir

### DIFF
--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -108,6 +108,7 @@ build do
   else
     copy 'bin/agent/ddtray.exe', "#{install_dir}/bin/agent"
     copy 'bin/agent/dist', "#{install_dir}/bin/agent"
+    copy 'bin/agent/customaction.pdb', "#{Omnibus::Config.package_dir()}"
   end
 
   block do

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -108,7 +108,7 @@ build do
   else
     copy 'bin/agent/ddtray.exe', "#{install_dir}/bin/agent"
     copy 'bin/agent/dist', "#{install_dir}/bin/agent"
-    mkdir Omnibus::Config.package_dir() unless File.exists?(Omnibus::Config.package_dir())
+    mkdir Omnibus::Config.package_dir() unless Dir.exists?(Omnibus::Config.package_dir())
     copy 'bin/agent/customaction.pdb', "#{Omnibus::Config.package_dir()}/"
   end
 

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -108,7 +108,8 @@ build do
   else
     copy 'bin/agent/ddtray.exe', "#{install_dir}/bin/agent"
     copy 'bin/agent/dist', "#{install_dir}/bin/agent"
-    copy 'bin/agent/customaction.pdb', "#{Omnibus::Config.package_dir()}"
+    mkdir Omnibus::Config.package_dir() unless File.exists?(Omnibus::Config.package_dir())
+    copy 'bin/agent/customaction.pdb', "#{Omnibus::Config.package_dir()}/"
   end
 
   block do

--- a/tasks/winbuildscripts/buildwin.bat
+++ b/tasks/winbuildscripts/buildwin.bat
@@ -26,11 +26,11 @@ copy \dev\go\src\github.com\DataDog\datadog-agent\omnibus\pkg\* c:\mnt\omnibus\p
 REM copy wixpdb file for debugging purposes
 if exist \omnibus-ruby\pkg\*.wixpdb copy \omnibus-ruby\pkg\*.wixpdb c:\mnt\omnibus\pkg\ || exit /b 7
 
+REM copy customaction pdb file for debugging purposes
+if exist \omnibus-ruby\pkg\*.pdb copy \omnibus-ruby\pkg\*.pdb c:\mnt\omnibus\pkg\ || exit /b 8
+
 REM show output binary directories (for debugging)
 dir C:\opt\datadog-agent\bin\agent\
-
-REM copy customaction pdb file for debugging purposes
-if exist C:\opt\datadog-agent\bin\agent\*.pdb copy C:\opt\datadog-agent\bin\agent\*.pdb c:\mnt\omnibus\pkg\ || exit /b 8
 
 goto :EOF
 


### PR DESCRIPTION
### What does this PR do?

This PR saves the customaction PDB in the omnibus package directory so that it can be uploaded as a gitlab artefact.

### Motivation

https://github.com/DataDog/datadog-agent/pull/7974 removed the PDB from the binary directory so it was longer saved as a gitlab artefact.
