### PR TITLE
[gitlab] Refactor py2 tests

### DIFF
--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -6,7 +6,7 @@
   mkdir -p $GOPATH/pkg/mod && tar xzf modcache.tar.gz -C $GOPATH/pkg/mod
   rm -f modcache.tar.gz
 
-.linux_tests:
+.rtloader_tests:
   stage: source_test
   before_script:
     - *retrieve_linux_go_deps
@@ -18,6 +18,11 @@
     - inv -e rtloader.install
     - inv -e rtloader.format --raise-if-changed
     - inv -e rtloader.test
+  # Placeholder script, overridden by .linux_tests when running all go tests
+  script: [ "# Skipping go tests" ]
+
+.linux_tests:
+  stage: source_test
   script:
     - inv -e test --race --profile --rerun-fails=2 --python-runtimes "$PYTHON_RUNTIMES" --cpus 4 $EXTRA_OPTS --save-result-json test_output.json
   artifacts:
@@ -27,7 +32,7 @@
       - test_output.json
 
 tests_deb-x64-py2:
-  extends: .linux_tests
+  extends: .rtloader_tests
   needs: ["linux_x64_go_deps"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main", "size:2xlarge"]
@@ -36,7 +41,9 @@ tests_deb-x64-py2:
     CONDA_ENV: ddpy2
 
 tests_deb-x64-py3:
-  extends: .linux_tests
+  extends:
+    - .rtloader_tests
+    - .linux_tests
   needs: ["linux_x64_go_deps"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main", "size:2xlarge"]
@@ -44,34 +51,33 @@ tests_deb-x64-py3:
     PYTHON_RUNTIMES: '3'
     CONDA_ENV: ddpy3
 
+# Exclude systemd because it cannot succeed on Centos 6: the image doesn't have the shared object required by
+# https://github.com/coreos/go-systemd/blob/c8cc474ba8655dfbdb0ac7fcc09b7faf5b643caf/sdjournal/functions.go#L46
+# This is OK because the test on systemd still runs on the debian image above
 tests_rpm-x64-py2:
-  extends: .linux_tests
+  extends: .rtloader_tests
   needs: ["linux_x64_go_deps"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main", "size:2xlarge"]
   variables:
     PYTHON_RUNTIMES: '2'
     CONDA_ENV: ddpy2
-    # Exclude systemd because it cannot succeed on Centos 6: the image doesn't have the shared object required by
-    # https://github.com/coreos/go-systemd/blob/c8cc474ba8655dfbdb0ac7fcc09b7faf5b643caf/sdjournal/functions.go#L46
-    # This is OK because the test on systemd still runs on the debian image above
     EXTRA_OPTS: '--build-exclude=systemd'
 
 tests_rpm-x64-py3:
-  extends: .linux_tests
+  extends:
+    - .rtloader_tests
+    - .linux_tests
   needs: ["linux_x64_go_deps"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main", "size:2xlarge"]
   variables:
     PYTHON_RUNTIMES: '3'
     CONDA_ENV: ddpy3
-    # Exclude systemd because it cannot succeed on Centos 6: the image doesn't have the shared object required by
-    # https://github.com/coreos/go-systemd/blob/c8cc474ba8655dfbdb0ac7fcc09b7faf5b643caf/sdjournal/functions.go#L46
-    # This is OK because the test on systemd still runs on the debian image above
     EXTRA_OPTS: '--build-exclude=systemd'
 
 tests_deb-arm64-py2:
-  extends: .linux_tests
+  extends: .rtloader_tests
   needs: ["linux_arm64_go_deps"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
@@ -80,7 +86,9 @@ tests_deb-arm64-py2:
     CONDA_ENV: ddpy2
 
 tests_deb-arm64-py3:
-  extends: .linux_tests
+  extends:
+    - .rtloader_tests
+    - .linux_tests
   needs: ["linux_arm64_go_deps"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
@@ -89,7 +97,7 @@ tests_deb-arm64-py3:
     CONDA_ENV: ddpy3
 
 tests_rpm-arm64-py2:
-  extends: .linux_tests
+  extends: .rtloader_tests
   needs: ["linux_arm64_go_deps"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
@@ -98,7 +106,9 @@ tests_rpm-arm64-py2:
     CONDA_ENV: ddpy2
 
 tests_rpm-arm64-py3:
-  extends: .linux_tests
+  extends:
+    - .rtloader_tests
+    - .linux_tests
   needs: ["linux_arm64_go_deps"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -13,7 +13,6 @@
     - source /root/.bashrc && conda activate $CONDA_ENV
     - python3 -m pip install wheel
     - python3 -m pip install -r requirements.txt
-    - inv -e install-tools
     - inv -e rtloader.make --install-prefix=$SRC_PATH/dev --python-runtimes "$PYTHON_RUNTIMES"
     - inv -e rtloader.install
     - inv -e rtloader.format --raise-if-changed
@@ -24,6 +23,7 @@
 .linux_tests:
   stage: source_test
   script:
+    - inv -e install-tools
     - inv -e test --race --profile --rerun-fails=2 --python-runtimes "$PYTHON_RUNTIMES" --cpus 4 $EXTRA_OPTS --save-result-json test_output.json
   artifacts:
     expire_in: 2 weeks


### PR DESCRIPTION
### What does this PR do?

Changes py2 tests to only test rtloader.

### Motivation

Only the rtloader tests are tied to specific Python versions. The other go tests do not care about which Python version is used (though they do need the rtloader libraries to be installed). Therefore we don't need to run all go tests on each job, as this makes us run the same tests twice.

This reduces the time taken by py2 tests from ~10 minutes to ~1 minute, therefore reducing the CI resources consumption.
