### PR TITLE
Fix Lambda Extension logs shutdown

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -107,7 +107,7 @@ func init() {
 func run(cmd *cobra.Command, args []string) error {
 	// Main context passed to components
 	ctx, cancel := context.WithCancel(context.Background())
-	defer stopCallback(cancel)
+	defer shutDownGracefully(cancel)
 
 	stopCh := make(chan struct{})
 
@@ -481,15 +481,14 @@ func readAPIKeyFromSSM() (string, error) {
 	return "", nil
 }
 
-func stopCallback(cancel context.CancelFunc) {
-	// gracefully shut down any component
+func shutDownGracefully(cancel context.CancelFunc) {
 	cancel()
 
+	log.Debug("Stopping statsdServer...")
 	if statsdServer != nil {
 		statsdServer.Stop()
 	}
 
-	log.Info("See ya!")
 	log.Flush()
 	return
 }

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -358,12 +358,12 @@ func runAgent(stopCh chan struct{}) (daemon *serverless.Daemon, err error) {
 		tc.SynchronousFlushing = true
 		if confErr != nil {
 			log.Errorf("Unable to load trace agent config: %s", confErr)
-			return
+		} else {
+			ta = traceAgent.NewAgent(traceAgentCtx, tc)
+			go func() {
+				ta.Run()
+			}()
 		}
-		ta = traceAgent.NewAgent(traceAgentCtx, tc)
-		go func() {
-			ta.Run()
-		}()
 	}
 
 	// run the invocation loop in a routine

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -105,20 +105,16 @@ func init() {
 }
 
 func run(cmd *cobra.Command, args []string) error {
-	// Main context passed to components
-	ctx, cancel := context.WithCancel(context.Background())
-	defer shutDownGracefully(cancel)
-
 	stopCh := make(chan struct{})
 
-	// handle SIGTERM
-	go handleSignals(stopCh)
-
 	// run the agent
-	err := runAgent(ctx, stopCh)
+	daemon, err := runAgent(stopCh)
 	if err != nil {
 		return err
 	}
+
+	// handle SIGTERM
+	go handleSignals(daemon, stopCh)
 
 	// block here until we receive a stop signal
 	<-stopCh
@@ -139,9 +135,11 @@ func main() {
 	}
 }
 
-func runAgent(ctx context.Context, stopCh chan struct{}) (err error) {
+func runAgent(stopCh chan struct{}) (daemon serverless.Daemon, err error) {
 
 	startTime := time.Now()
+
+	traceAgentCtx, stopTraceAgent := context.WithCancel(context.Background())
 
 	// setup logger
 	// -----------
@@ -166,7 +164,7 @@ func runAgent(ctx context.Context, stopCh chan struct{}) (err error) {
 	}
 
 	// immediately starts the communication server
-	daemon := serverless.StartDaemon(stopCh)
+	daemon := serverless.StartDaemon(stopTraceAgent, stopCh)
 
 	// serverless parts
 	// ----------------
@@ -362,7 +360,7 @@ func runAgent(ctx context.Context, stopCh chan struct{}) (err error) {
 			log.Errorf("Unable to load trace agent config: %s", confErr)
 			return
 		}
-		ta = traceAgent.NewAgent(ctx, tc)
+		ta = traceAgent.NewAgent(traceAgentCtx, tc)
 		go func() {
 			ta.Run()
 		}()
@@ -391,7 +389,7 @@ func runAgent(ctx context.Context, stopCh chan struct{}) (err error) {
 
 // handleSignals handles OS signals, if a SIGTERM is received,
 // the serverless agent stops.
-func handleSignals(stopCh chan struct{}) {
+func handleSignals(daemon serverless.Daemon, stopCh chan struct{}) {
 	// setup a channel to catch OS signals
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
@@ -402,6 +400,7 @@ func handleSignals(stopCh chan struct{}) {
 		switch signo {
 		default:
 			log.Infof("Received signal '%s', shutting down...", signo)
+			daemon.Stop()
 			stopCh <- struct{}{}
 			return
 		}
@@ -479,16 +478,4 @@ func readAPIKeyFromSSM() (string, error) {
 	// should not happen but let's handle this gracefully
 	log.Warn("SSM returned something but there seems to be no data available;")
 	return "", nil
-}
-
-func shutDownGracefully(cancel context.CancelFunc) {
-	cancel()
-
-	log.Debug("Stopping statsdServer...")
-	if statsdServer != nil {
-		statsdServer.Stop()
-	}
-
-	log.Flush()
-	return
 }

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -135,7 +135,7 @@ func main() {
 	}
 }
 
-func runAgent(stopCh chan struct{}) (daemon serverless.Daemon, err error) {
+func runAgent(stopCh chan struct{}) (daemon *serverless.Daemon, err error) {
 
 	startTime := time.Now()
 
@@ -164,7 +164,7 @@ func runAgent(stopCh chan struct{}) (daemon serverless.Daemon, err error) {
 	}
 
 	// immediately starts the communication server
-	daemon := serverless.StartDaemon(stopTraceAgent, stopCh)
+	daemon = serverless.StartDaemon(stopTraceAgent, stopCh)
 
 	// serverless parts
 	// ----------------
@@ -389,7 +389,7 @@ func runAgent(stopCh chan struct{}) (daemon serverless.Daemon, err error) {
 
 // handleSignals handles OS signals, if a SIGTERM is received,
 // the serverless agent stops.
-func handleSignals(daemon serverless.Daemon, stopCh chan struct{}) {
+func handleSignals(daemon *serverless.Daemon, stopCh chan struct{}) {
 	// setup a channel to catch OS signals
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)

--- a/pkg/serverless/protocol.go
+++ b/pkg/serverless/protocol.go
@@ -164,9 +164,12 @@ func (d *Daemon) Stop() {
 	log.Debug("Waiting to shut down HTTP server")
 	time.Sleep(shutdownDelay)
 	log.Debug("Shutting down HTTP server")
-	d.httpServer.Shutdown(context.Background())
+	err := d.httpServer.Shutdown(context.Background())
+	if err != nil {
+		log.Error("Error shutting down HTTP server")
+	}
 
-	err := aws.PersistCurrentStateToFile()
+	err = aws.PersistCurrentStateToFile()
 	if err != nil {
 		log.Error("Unable to persist current state to file while shutting down")
 	}
@@ -179,6 +182,7 @@ func (d *Daemon) Stop() {
 	d.stopTraceAgent()
 	d.statsdServer.Stop()
 	logs.Stop()
+	log.Debug("Serverless agent shutdown complete")
 }
 
 // StartDaemon starts an HTTP server to receive messages from the runtime.

--- a/pkg/serverless/protocol.go
+++ b/pkg/serverless/protocol.go
@@ -31,8 +31,8 @@ const httpServerPort int = 8124
 
 const httpLogsCollectionRoute string = "/lambda/logs"
 
-// shutdownDelay is the amount of time we wait before shutting down the logs agent
-// after we begin our final flush before shutting down. This allows for the final log messages
+// shutdownDelay is the amount of time we wait before shutting down the HTTP server
+// after we receive a Shutdown event. This allows time for the final log messages
 // to arrive from the Logs API.
 const shutdownDelay time.Duration = 1 * time.Second
 

--- a/pkg/serverless/serverless.go
+++ b/pkg/serverless/serverless.go
@@ -37,8 +37,7 @@ const (
 	headerExtErrType  string = "Lambda-Extension-Function-Error-Type"
 	headerContentType string = "Content-Type"
 
-	requestTimeout      time.Duration = 5 * time.Second
-	arbitraryShortDelay time.Duration = 10 * time.Millisecond
+	requestTimeout time.Duration = 5 * time.Second
 
 	// FatalNoAPIKey is the error reported to the AWS Extension environment when
 	// no API key has been set. Unused until we can report error
@@ -288,22 +287,12 @@ func WaitForNextInvocation(stopCh chan struct{}, daemon *Daemon, metricsChan cha
 	if payload.EventType == "SHUTDOWN" {
 		log.Debug("Received shutdown event. Reason: " + payload.ShutdownReason)
 
-		err := aws.PersistCurrentStateToFile()
-		if err != nil {
-			log.Error("Unable to persist current state to file while shutting down")
-		}
-
 		if strings.ToLower(payload.ShutdownReason) == "timeout" {
 			metricTags := getTagsForEnhancedMetrics()
 			sendTimeoutEnhancedMetric(metricTags, metricsChan)
-			// Ensure that timeout metric has been received by the statsdServer before flushing
-			time.Sleep(arbitraryShortDelay)
 		}
 
-		// Always flush when shutting down, regardless of flushing strategy
-		daemon.TriggerFlush(context.Background(), true)
-
-		// shutdown the serverless agent
+		daemon.Stop()
 		stopCh <- struct{}{}
 	}
 


### PR DESCRIPTION
### What does this PR do?

There is a race condition that causes panics and prevents us from receiving logs when shutting down the Lambda Extension. When the extension receives a shutdown event from the API, it stops the logs agent. However, the extension may continue to receive log messages from the logs API after receiving the shutdown event. Currently, when these messages are received, we try to send them to the logs agent. Since the logs agent has been stopped, this results in a panic.

To fix this issue:
- Consolidate the shutdown logic in a new `Daemon.Stop()` function.
- Add a 1-second delay after we receive the shutdown signal before shutting down. This should allow for final log messages to be delivered from the logs API.
- After the 1-second delay, shut down the HTTP server first before shutting down the agents. This will prevent us from sending messages to the agents after they have already shut down.
- Do some refactoring so that we also call `Daemon.Stop()` after receiving a `SIGINT` signal. This shouldn't really happen in practice because during a shutdown, we receive a shutdown message over the Lambda API, and then `SIGKILL` two seconds later.

### Motivation

The current behavior causes panics and lost log messages.

### Describe how to test your changes

I have been manually testing these changes with functions running periodically in the sandbox account that frequently encounter the race condition. I used debug log messages to confirm the behavior is as expected.
