### PR TITLE
pkg/trace/obfuscate: add keep_sql_alias and dollar_quoted_func features

### DIFF
--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -69,16 +69,22 @@ func (f *discardFilter) Filter(token, lastToken TokenKind, buffer []byte) (Token
 			// closing bracket counter-part. See GitHub issue DataDog/datadog-trace-agent#475.
 			return FilteredBracketedIdentifier, nil, nil
 		}
+		if config.HasFeature("keep_sql_alias") {
+			return token, buffer, nil
+		}
 		return Filtered, nil, nil
 	}
 
 	// filters based on the current token; if the next token should be ignored,
 	// return the same token value (not FilteredGroupable) and nil
 	switch token {
-	case As:
-		return As, nil, nil
 	case Comment, ';':
 		return markFilteredGroupable(token), nil, nil
+	case As:
+		if !config.HasFeature("keep_sql_alias") {
+			return As, nil, nil
+		}
+		fallthrough
 	default:
 		return token, buffer, nil
 	}

--- a/releasenotes/notes/apm-dollar-quoted-func-keep-sql-alias-80f624a2b9409b47.yaml
+++ b/releasenotes/notes/apm-dollar-quoted-func-keep-sql-alias-80f624a2b9409b47.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: The obfuscator adds two new features (`dollar_quoted_func` and `keep_sql_alias`). They are off by default. For more details see PR 8071.
+    We do not recommend using these features unless you have a good reason or have been recommended by support for your specific use-case.


### PR DESCRIPTION
This change adds two feature flags which enable custom obfuscation
behaviour. They work in the following way:

* `keep_sql_alias` will determine SQL aliases ("AS <alias>") to not be
  discarded.
* `dollar_quoted_func` will determine dollar-quoted strings delimited by
  the tag "$func$" to be considered an embedded SQL query and to be obfuscated.

If obfuscation of $func$ embedded queries fails, as a safety mechanism,
the entire query will fall back to being treated as a string and be
completely obscured.