### PR TITLE
Fix integrations-core version on windows

### DIFF
--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -363,6 +363,7 @@ def get_omnibus_env(
         env['OMNIBUS_GOMODCACHE'] = go_mod_cache
 
     integrations_core_version = os.environ.get('INTEGRATIONS_CORE_VERSION')
+    # Only overrides the env var if the value is a non-empty string.
     if integrations_core_version:
         env['INTEGRATIONS_CORE_VERSION'] = integrations_core_version
 

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -362,8 +362,9 @@ def get_omnibus_env(
     if go_mod_cache:
         env['OMNIBUS_GOMODCACHE'] = go_mod_cache
 
-    if 'INTEGRATIONS_CORE_VERSION' in os.environ:
-        env['INTEGRATIONS_CORE_VERSION'] = os.environ.get('INTEGRATIONS_CORE_VERSION')
+    integrations_core_version = os.environ.get('INTEGRATIONS_CORE_VERSION')
+    if integrations_core_version:
+        env['INTEGRATIONS_CORE_VERSION'] = integrations_core_version
 
     if sys.platform == 'win32' and os.environ.get('SIGN_WINDOWS'):
         # get certificate and password from ssm

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -239,8 +239,9 @@ def omnibus_build(
         )
         env['MAJOR_VERSION'] = major_version
 
-        if 'INTEGRATIONS_CORE_VERSION' in os.environ:
-            env['INTEGRATIONS_CORE_VERSION'] = os.environ.get('INTEGRATIONS_CORE_VERSION')
+        integrations_core_version = os.environ.get('INTEGRATIONS_CORE_VERSION')
+        if integrations_core_version:
+            env['INTEGRATIONS_CORE_VERSION'] = integrations_core_version
 
         # If the host has a GOMODCACHE set, try to reuse it
         if not go_mod_cache and os.environ.get('GOMODCACHE'):

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -240,6 +240,7 @@ def omnibus_build(
         env['MAJOR_VERSION'] = major_version
 
         integrations_core_version = os.environ.get('INTEGRATIONS_CORE_VERSION')
+        # Only overrides the env var if the value is a non-empty string.
         if integrations_core_version:
             env['INTEGRATIONS_CORE_VERSION'] = integrations_core_version
 


### PR DESCRIPTION
Since https://github.com/DataDog/datadog-agent/pull/7977/ an INTEGRATIONS_CORE_VERSION environment variable is able to override what's set in the release.json

Because we pass it to windows builders here: https://github.com/DataDog/datadog-agent/blob/070e4cb47d32d53c8cb7fdf2604d1e4ea977f6c4/.gitlab/package_build/windows.yml#L133
Even if this env var is initially unset in the gitlab pipeline, the windows builder will always have the env var (even though its value is an empty string) because of this `docker run` command.

In the end, we end up with a windows image using the "master" branch of integrations-core.

Example: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/64873660/raw
This job was triggered without any `INTEGRATIONS_CORE_VERSION` env var, but should be targeting `7.28.0-rc.1` of integrations-core.
In the logs we can see:

```
=[Software: datadog-agent-integrations-py2] I | 2021-05-04T09:05:07+00:00 | Resolving manifest entry for datadog-agent-integrations-py2

==[Software: datadog-agent-integrations-py3] I | 2021-05-04T09:05:07+00:00 | Resolving manifest entry for datadog-agent-integrations-py3

[Software: datadog-agent-integrations-py2] W | 2021-05-04T09:05:07+00:00 | Version master for software datadog-agent-integrations-py2 was not parseable. Comparison methods such as #satisfies? will not be available for this version.

[Software: datadog-agent-integrations-py3] W | 2021-05-04T09:05:07+00:00 | Version master for software datadog-agent-integrations-py3 was not parseable. Comparison methods such as #satisfies? will not be available for this version.

[Software: datadog-agent-integrations-py2] W | 2021-05-04T09:05:07+00:00 | Version master for software datadog-agent-integrations-py2 was not parseable. Comparison methods such as #satisfies? will not be available for this version.

[Software: datadog-agent-integrations-py3] W | 2021-05-04T09:05:07+00:00 | Version master for software datadog-agent-integrations-py3 was not parseable. Comparison methods such as #satisfies? will not be available for this version.
```