### PR TITLE
[system-probe] Ignore ENOENT when getting namespace for pid

### DIFF
--- a/pkg/network/tracer/cached_conntrack_test.go
+++ b/pkg/network/tracer/cached_conntrack_test.go
@@ -59,6 +59,18 @@ func TestEnsureConntrack(t *testing.T) {
 	require.Equal(t, 2, n)
 }
 
+func TestCachedConntrackIgnoreErrExists(t *testing.T) {
+	cache := newCachedConntrack("/proc", func(_ int) (netlink.Conntrack, error) {
+		require.FailNow(t, "unexpected call to conntrack creator")
+		return nil, nil
+	}, 1)
+	defer cache.Close()
+
+	ctrk, err := cache.ensureConntrack(0, 0)
+	require.Nil(t, ctrk)
+	require.NoError(t, err)
+}
+
 func TestCachedConntrackExists(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()


### PR DESCRIPTION
### What does this PR do?

Ignores `ENOENT` error when we try to get the namespace for a process. This error is caused by the pid not being there anymore, and can be safely ignored. On some customer environments this was causing excessive logs of the error.

### Motivation

Excessive logging on some customer environments.

