### PR TITLE
[invoke] Reintroduce Python 2 compatibility code

### DIFF
--- a/tasks/libs/types.py
+++ b/tasks/libs/types.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import io
 import subprocess
 from collections import defaultdict

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import os
 import sys
 

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import io
 import os
 import re


### PR DESCRIPTION
### What does this PR do?

Partially reverts #8072.

### Motivation

Some of our builders still use Python 2. We should revert this PR once they're migrated to Python 3.
