### PR TITLE
[cmd/agent] give some rest to the CPU while streaming logs on stdout.

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -250,9 +250,9 @@ func streamLogs(w http.ResponseWriter, r *http.Request) {
 		} else {
 			// The buffer will flush on its own most of the time, but when we run out of logs flush so the client is up to date.
 			flusher.Flush()
+			// don't hog the CPU when we're not receiving log
+			time.Sleep(1 * time.Millisecond)
 		}
-		// don't hog the CPU
-		time.Sleep(1 * time.Millisecond)
 	}
 }
 

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -251,6 +251,8 @@ func streamLogs(w http.ResponseWriter, r *http.Request) {
 			// The buffer will flush on its own most of the time, but when we run out of logs flush so the client is up to date.
 			flusher.Flush()
 		}
+		// don't hog the CPU
+		time.Sleep(1 * time.Millisecond)
 	}
 }
 

--- a/releasenotes/notes/stream-logs-sleep-ea37183f290f5a73.yaml
+++ b/releasenotes/notes/stream-logs-sleep-ea37183f290f5a73.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The `agent stream-logs` command will use less CPU while idle.


### PR DESCRIPTION
### What does this PR do?

Add a short sleep in the infinite `for` loop streaming logs to the caller of the
feature `stream-logs` in order to let the scheduler use that core for something else.
It may introduce some latency but as it is a debug feature, I think it's better
that way.

### Motivation

To not hog a core while streaming logs to the caller.

### Describe how to test your changes

* Validate that the command `agent stream-logs` is still properly streaming logs
* Validate that the main process of the Agent is not heavily increasing while using this command