### PR TITLE
Fix CPU utilization being underreported on Windows

### DIFF
--- a/pkg/collector/corechecks/system/cpu/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows.go
@@ -37,6 +37,7 @@ const cpuCheckName = "cpu"
 
 // For testing purpose
 var times = Times
+var cpuInfo = cpu.GetCpuInfo
 
 // TimesStat contains the amounts of time the CPU has spent performing different
 // kinds of work. Time units are in USER_HZ or Jiffies (typically hundredths of
@@ -44,7 +45,8 @@ var times = Times
 type TimesStat struct {
 	CPU    string
 	User   float64
-	System float64
+	Kernel float64
+	System float64 // kernel - idle
 	Idle   float64
 }
 
@@ -59,7 +61,7 @@ type Check struct {
 
 // Total returns the total number of seconds in a CPUTimesStat
 func (c TimesStat) Total() float64 {
-	total := c.User + c.System + c.Idle
+	total := c.User + c.Kernel + c.Idle
 	return total
 }
 
@@ -123,7 +125,7 @@ func (c *Check) Configure(data integration.Data, initConfig integration.Data, so
 	}
 
 	// do nothing
-	info, err := cpu.GetCpuInfo()
+	info, err := cpuInfo()
 	if err != nil {
 		return fmt.Errorf("cpu.Check: could not query CPU info")
 	}
@@ -176,6 +178,7 @@ func Times() ([]TimesStat, error) {
 		CPU:    "cpu-total",
 		Idle:   float64(idle),
 		User:   float64(user),
+		Kernel: float64(kernel),
 		System: float64(system),
 	})
 	return ret, nil

--- a/pkg/collector/corechecks/system/cpu/cpu_windows_test.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows_test.go
@@ -22,6 +22,7 @@ var (
 			User:   1229386,
 			System: 263584,
 			Idle:   25496761,
+			Kernel: 25496761 + 263584,
 		},
 	}
 	secondSample = []TimesStat{
@@ -30,6 +31,7 @@ var (
 			User:   1229586,
 			System: 268584,
 			Idle:   25596761,
+			Kernel: 25596761 + 268584,
 		},
 	}
 )
@@ -66,10 +68,10 @@ func TestCPUCheckWindows(t *testing.T) {
 	m.AssertNumberOfCalls(t, "Commit", 1)
 
 	sample = secondSample
-	m.On(metrics.GaugeType.String(), "system.cpu.user", 0.19960079840319359, "", []string(nil)).Return().Times(1)
-	m.On(metrics.GaugeType.String(), "system.cpu.system", 4.99001996007984, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.user", 0.09746588693957114, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.system", 2.4366471734892787, "", []string(nil)).Return().Times(1)
 	m.On(metrics.GaugeType.String(), "system.cpu.iowait", 0.0, "", []string(nil)).Return().Times(1)
-	m.On(metrics.GaugeType.String(), "system.cpu.idle", 99.8003992015968, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.idle", 48.732943469785575, "", []string(nil)).Return().Times(1)
 	m.On(metrics.GaugeType.String(), "system.cpu.stolen", 0.0, "", []string(nil)).Return().Times(1)
 	m.On(metrics.GaugeType.String(), "system.cpu.guest", 0.0, "", []string(nil)).Return().Times(1)
 	m.On(metrics.GaugeType.String(), "system.cpu.num_cores", 1.0, "", []string(nil)).Return().Times(1)

--- a/pkg/collector/corechecks/system/cpu/cpu_windows_test.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows_test.go
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build windows
+
+package cpu
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/stretchr/testify/mock"
+)
+
+var (
+	firstSample = []TimesStat{
+		{
+			CPU:    "cpu-total",
+			User:   1229386,
+			System: 263584,
+			Idle:   25496761,
+		},
+	}
+	secondSample = []TimesStat{
+		{
+			CPU:    "cpu-total",
+			User:   1229586,
+			System: 268584,
+			Idle:   25596761,
+		},
+	}
+)
+
+var sample = firstSample
+
+func CPUTimes() ([]TimesStat, error) {
+	return sample, nil
+}
+
+func CPUInfo() (map[string]string, error) {
+	return map[string]string{
+		"cpu_logical_processors": "1",
+	}, nil
+}
+
+func TestCPUCheckWindows(t *testing.T) {
+	times = CPUTimes
+	cpuInfo = CPUInfo
+	cpuCheck := new(Check)
+	cpuCheck.Configure(nil, nil, "test")
+
+	m := mocksender.NewMockSender(cpuCheck.ID())
+	m.On(metrics.GaugeType.String(), "system.cpu.num_cores", 1.0, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.interrupt", mock.AnythingOfType("float64"), "", []string(nil)).Return().Times(1)
+
+	m.On("Commit").Return().Times(1)
+
+	sample = firstSample
+	cpuCheck.Run()
+
+	m.AssertExpectations(t)
+	m.AssertNumberOfCalls(t, metrics.GaugeType.String(), 2)
+	m.AssertNumberOfCalls(t, "Commit", 1)
+
+	sample = secondSample
+	m.On(metrics.GaugeType.String(), "system.cpu.user", 0.19960079840319359, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.system", 4.99001996007984, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.iowait", 0.0, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.idle", 99.8003992015968, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.stolen", 0.0, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.guest", 0.0, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.num_cores", 1.0, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.interrupt", mock.AnythingOfType("float64"), "", []string(nil)).Return().Times(1)
+	m.On("Commit").Return().Times(1)
+	cpuCheck.Run()
+
+	m.AssertExpectations(t)
+	m.AssertNumberOfCalls(t, metrics.GaugeType.String(), 10)
+	m.AssertNumberOfCalls(t, "Commit", 2)
+}

--- a/releasenotes/notes/fix-cpu-usage-windows-27be22682a4c7d9d.yaml
+++ b/releasenotes/notes/fix-cpu-usage-windows-27be22682a4c7d9d.yaml
@@ -1,0 +1,7 @@
+---
+upgrade:
+  - |
+    Fixes CPU utilization being underreported on Windows, expect an increase in the reported percentages under system.cpu.* after upgrading.
+fixes:
+  - |
+    Fixes CPU utilization being underreported on Windows.


### PR DESCRIPTION
### What does this PR do?

To calculate the CPU usage percentage we divided the used cycles by the
total cycles since the last check run. However, the calculation of the total
was off by `c.Idle` since we were adding `c.User + c.System + c.Idle`
where `c.System` is calculated [1] by doing `c.Kernel - c.Idle`, resulting
in `c.User + c.Kernel - c.Idle + c.Idle` which is wrong.

Also adds a simple test for Windows since we were only testing Linux.

[1] https://github.com/DataDog/datadog-agent/blob/98527df/pkg/collector/corechecks/system/cpu/cpu_windows.go#L173

### Motivation

A customer reported this.
