### PR TITLE
Use C-string for WcaLog

### DIFF
--- a/tools/windows/install-help/cal/TargetMachine.cpp
+++ b/tools/windows/install-help/cal/TargetMachine.cpp
@@ -86,7 +86,7 @@ DWORD TargetMachine::DetectMachineType()
         {
             // NetServerGetInfo will fail if the Server service isn't running,
             // but in that case it's safe to assume we are a workstation.
-            WcaLog(LOGMSG_STANDARD, "Failed to get server info: %S", FormatErrorMessage(status));
+            WcaLog(LOGMSG_STANDARD, "Failed to get server info: %S", FormatErrorMessage(status).c_str());
             WcaLog(LOGMSG_STANDARD, "Continuing assuming machine type is SV_TYPE_WORKSTATION.");
             _serverType = SV_TYPE_WORKSTATION;
             return ERROR_SUCCESS;


### PR DESCRIPTION
### What does this PR do?

Use C-string for WcaLog

### Motivation

Correct logs

### Describe how to test your changes

Test installing the Agent in a docker container and check that the `Failed to get server info` log is showing correctly.
