### PR TITLE
Remove `kube-state-metrics` replace, no longer needed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -235,7 +235,4 @@ replace (
 
 replace github.com/vishvananda/netlink => github.com/DataDog/netlink v1.0.1-0.20210423142224-2a6feccc042d
 
-// Remove once the PR kubernetes/kube-state-metrics#1455 is merged
-replace k8s.io/kube-state-metrics/v2 => github.com/L3n41c/kube-state-metrics/v2 v2.0.0-rc.1.0.20210409121934-c22976b826b2
-
 replace gopkg.in/DataDog/dd-trace-go.v1 => gopkg.in/DataDog/dd-trace-go.v1 v1.23.1


### PR DESCRIPTION
### What does this PR do?

Remove `k8s.io/kube-state-metrics/v2` replace since kubernetes/kube-state-metrics#1455 was merged

### Motivation

We are pinning a commit that does not belong to any branch, L3n41c/kube-state-metrics@c22976b826b2

### Additional Notes

Found with Dependabot

### Describe how to test your changes

Should be a no-op