### PR TITLE
Fallback to logs_config section when key is not present

### DIFF
--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -151,8 +151,8 @@ func newRuntimeReporter(stopper restart.Stopper, sourceName, sourceType string, 
 
 // This function will only be used on Linux. The only platforms where the runtime agent runs
 func newLogContextRuntime() (*config.Endpoints, *client.DestinationsContext, error) { // nolint: deadcode, unused
-	logsConfigComplianceKeys := config.NewLogsConfigKeys("runtime_security_config.endpoints.")
-	return newLogContext(logsConfigComplianceKeys, "runtime-security-http-intake.logs.")
+	logsConfigRuntimeKeys := config.NewLogsConfigKeys("runtime_security_config.endpoints.")
+	return newLogContext(logsConfigRuntimeKeys, "runtime-security-http-intake.logs.")
 }
 
 func startRuntimeSecurity(hostname string, stopper restart.Stopper, statsdClient *ddgostatsd.Client) (*secagent.RuntimeSecurityAgent, error) {

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -205,18 +205,32 @@ var logsConfigDefaultKeys = NewLogsConfigKeys("logs_config.")
 
 // NewLogsConfigKeys returns a new logs configuration keys set
 func NewLogsConfigKeys(configPrefix string) LogsConfigKeys {
-	return LogsConfigKeys{
+	logsConfigKeys := LogsConfigKeys{
 		UseCompression:          configPrefix + "use_compression",
 		CompressionLevel:        configPrefix + "compression_level",
 		ConnectionResetInterval: configPrefix + "connection_reset_interval",
-		LogsDDURL:               configPrefix + "logs_dd_url",
 		LogsNoSSL:               configPrefix + "logs_no_ssl",
+		LogsDDURL:               configPrefix + "logs_dd_url",
+		AdditionalEndpoints:     configPrefix + "additional_endpoints",
 		DDURL:                   configPrefix + "dd_url",
 		DevModeNoSSL:            configPrefix + "dev_mode_no_ssl",
-		AdditionalEndpoints:     configPrefix + "additional_endpoints",
 		BatchWait:               configPrefix + "batch_wait",
 		BatchMaxConcurrentSend:  configPrefix + "batch_max_concurrent_send",
 	}
+
+	if !coreConfig.Datadog.IsSet(logsConfigKeys.LogsDDURL) {
+		logsConfigKeys.LogsDDURL = "logs_config.logs_dd_url"
+	}
+
+	if !coreConfig.Datadog.IsSet(logsConfigKeys.DDURL) {
+		logsConfigKeys.DDURL = "logs_config.dd_url"
+	}
+
+	if !coreConfig.Datadog.IsSet(logsConfigKeys.AdditionalEndpoints) {
+		logsConfigKeys.AdditionalEndpoints = "logs_config.additional_endpoints"
+	}
+
+	return logsConfigKeys
 }
 
 // BuildHTTPEndpoints returns the HTTP endpoints to send logs to.

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -336,6 +336,32 @@ func (suite *ConfigTestSuite) TestEndpointsSetLogsDDUrl() {
 	suite.Equal(expectedEndpoints, endpoints)
 }
 
+func (suite *ConfigTestSuite) TestEndpointsFallbackLogsDDUrl() {
+	suite.config.Set("api_key", "123")
+	suite.config.Set("logs_config.logs_dd_url", "my-proxy:443")
+
+	logsConfig := NewLogsConfigKeys("compliance_config.endpoints.")
+	endpoints, err := BuildHTTPEndpointsWithConfig(logsConfig, "default-intake.mydomain.")
+
+	suite.Nil(err)
+
+	expectedEndpoints := &Endpoints{
+		UseHTTP:   true,
+		BatchWait: coreConfig.DefaultBatchWait * time.Second,
+		Main: Endpoint{
+			APIKey:           "123",
+			Host:             "my-proxy",
+			Port:             443,
+			UseSSL:           true,
+			UseCompression:   true,
+			CompressionLevel: 6,
+		},
+	}
+
+	suite.Nil(err)
+	suite.Equal(expectedEndpoints, endpoints)
+}
+
 func (suite *ConfigTestSuite) TestEndpointsSetDDSite() {
 	suite.config.Set("api_key", "123")
 


### PR DESCRIPTION
### What does this PR do?

Fallback to `logs_config` section when no url is specified in the dedicated section.

### Motivation

Specific logs endpoints can now be specified for both compliance and runtime in the
security agent. Existing configuration may exist in `logs_config` so we fallback to using this section
if no dedicated parameters exist.