### PR TITLE
Windows CPU check: Use Processor Information PDH

### DIFF
--- a/pkg/collector/corechecks/system/cpu/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows.go
@@ -14,7 +14,6 @@ package cpu
 import (
 	"fmt"
 	"strconv"
-	"unsafe"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -35,32 +34,17 @@ var (
 
 const cpuCheckName = "cpu"
 
-// For testing purpose
-var times = Times
-
-// TimesStat contains the amounts of time the CPU has spent performing different
-// kinds of work. Time units are in USER_HZ or Jiffies (typically hundredths of
-// a second). It is based on linux /proc/stat file.
-type TimesStat struct {
-	CPU    string
-	User   float64
-	System float64
-	Idle   float64
-}
+// For testing purposes
+var cpuInfo = cpu.GetCpuInfo
 
 // Check doesn't need additional fields
 type Check struct {
 	core.CheckBase
-	nbCPU       float64
-	lastNbCycle float64
-	lastTimes   TimesStat
-	counter     *pdhutil.PdhMultiInstanceCounterSet
-}
-
-// Total returns the total number of seconds in a CPUTimesStat
-func (c TimesStat) Total() float64 {
-	total := c.User + c.System + c.Idle
-	return total
+	nbCPU             float64
+	interruptsCounter *pdhutil.PdhMultiInstanceCounterSet
+	idleCounter       *pdhutil.PdhMultiInstanceCounterSet
+	userCounter       *pdhutil.PdhMultiInstanceCounterSet
+	privilegedCounter *pdhutil.PdhMultiInstanceCounterSet
 }
 
 // Run executes the check
@@ -70,49 +54,45 @@ func (c *Check) Run() error {
 		return err
 	}
 
-	cpuTimes, err := times()
-	if err != nil {
-		log.Errorf("cpu.Check: could not retrieve cpu stats: %s", err)
-		return err
-	} else if len(cpuTimes) < 1 {
-		errEmpty := fmt.Errorf("no cpu stats retrieve (empty results)")
-		log.Errorf("cpu.Check: %s", errEmpty)
-		return errEmpty
-	}
-	t := cpuTimes[0]
-
-	nbCycle := t.Total() / c.nbCPU
-
 	sender.Gauge("system.cpu.num_cores", c.nbCPU, "", nil)
-	if c.lastNbCycle != 0 {
-		// gopsutil return the sum of every CPU
-		toPercent := 100 / (nbCycle - c.lastNbCycle)
 
-		user := ((t.User) - (c.lastTimes.User)) / c.nbCPU
-		system := ((t.System) - (c.lastTimes.System)) / c.nbCPU
-		iowait := float64(0)
-		idle := (t.Idle - c.lastTimes.Idle) / c.nbCPU
-		stolen := float64(0)
-		guest := float64(0)
-
-		sender.Gauge("system.cpu.user", user*toPercent, "", nil)
-		sender.Gauge("system.cpu.system", system*toPercent, "", nil)
-		sender.Gauge("system.cpu.iowait", iowait*toPercent, "", nil)
-		sender.Gauge("system.cpu.idle", idle*toPercent, "", nil)
-		sender.Gauge("system.cpu.stolen", stolen*toPercent, "", nil)
-		sender.Gauge("system.cpu.guest", guest*toPercent, "", nil)
-	}
-	vals, err := c.counter.GetAllValues()
+	vals, err := c.interruptsCounter.GetAllValues()
 	if err != nil {
 		log.Warnf("Error getting handle value %v", err)
 	} else {
 		val := vals["_Total"]
-		sender.Gauge("system.cpu.interrupt", float64(val), "", nil)
+		sender.Gauge("system.cpu.interrupt", float64(val), "", nil) //FIXME(Agent8): should be multiplied by 100 like the other metrics
 	}
+
+	vals, err = c.idleCounter.GetAllValues()
+	if err != nil {
+		log.Warnf("Error getting handle value %v", err)
+	} else {
+		val := vals["_Total"]
+		sender.Gauge("system.cpu.idle", float64(val*100), "", nil)
+	}
+
+	vals, err = c.userCounter.GetAllValues()
+	if err != nil {
+		log.Warnf("Error getting handle value %v", err)
+	} else {
+		val := vals["_Total"]
+		sender.Gauge("system.cpu.user", float64(val*100), "", nil)
+	}
+
+	vals, err = c.privilegedCounter.GetAllValues()
+	if err != nil {
+		log.Warnf("Error getting handle value %v", err)
+	} else {
+		val := vals["_Total"]
+		sender.Gauge("system.cpu.system", float64(val*100), "", nil)
+	}
+
+	sender.Gauge("system.cpu.iowait", 0.0, "", nil)
+	sender.Gauge("system.cpu.stolen", 0.0, "", nil)
+	sender.Gauge("system.cpu.guest", 0.0, "", nil)
 	sender.Commit()
 
-	c.lastNbCycle = nbCycle
-	c.lastTimes = t
 	return nil
 }
 
@@ -123,16 +103,30 @@ func (c *Check) Configure(data integration.Data, initConfig integration.Data, so
 	}
 
 	// do nothing
-	info, err := cpu.GetCpuInfo()
+	info, err := cpuInfo()
 	if err != nil {
 		return fmt.Errorf("cpu.Check: could not query CPU info")
 	}
 	cpucount, _ := strconv.ParseFloat(info["cpu_logical_processors"], 64)
 	c.nbCPU = cpucount
 
-	c.counter, err = pdhutil.GetMultiInstanceCounter("Processor", "% Interrupt Time", &[]string{"_Total"}, nil)
+	// Note we use "processor information" instead of "processor" because on multi-processor machines the later only gives
+	// you visibility about other applications running on the same processor as you
+	c.interruptsCounter, err = pdhutil.GetMultiInstanceCounter("Processor Information", "% Interrupt Time", &[]string{"_Total"}, nil)
 	if err != nil {
 		return fmt.Errorf("cpu.Check could not establish interrupt time counter %v", err)
+	}
+	c.idleCounter, err = pdhutil.GetMultiInstanceCounter("Processor Information", "% Idle Time", &[]string{"_Total"}, nil)
+	if err != nil {
+		return fmt.Errorf("cpu.Check could not establish idle time counter %v", err)
+	}
+	c.userCounter, err = pdhutil.GetMultiInstanceCounter("Processor Information", "% User Time", &[]string{"_Total"}, nil)
+	if err != nil {
+		return fmt.Errorf("cpu.Check could not establish idle time counter %v", err)
+	}
+	c.privilegedCounter, err = pdhutil.GetMultiInstanceCounter("Processor Information", "% Privileged Time", &[]string{"_Total"}, nil)
+	if err != nil {
+		return fmt.Errorf("cpu.Check could not establish system time counter %v", err)
 	}
 	return nil
 }
@@ -145,38 +139,4 @@ func cpuFactory() check.Check {
 
 func init() {
 	core.RegisterCheck(cpuCheckName, cpuFactory)
-}
-
-// FILETIME is a copy of the Windows FILETIME structure
-type FILETIME struct {
-	DwLowDateTime  uint32
-	DwHighDateTime uint32
-}
-
-// Times returns times stat per cpu and combined for all CPUs
-func Times() ([]TimesStat, error) {
-	var ret []TimesStat
-	var lpIdleTime FILETIME
-	var lpKernelTime FILETIME
-	var lpUserTime FILETIME
-	r, _, _ := procGetSystemTimes.Call(
-		uintptr(unsafe.Pointer(&lpIdleTime)),
-		uintptr(unsafe.Pointer(&lpKernelTime)),
-		uintptr(unsafe.Pointer(&lpUserTime)))
-	if r == 0 {
-		return ret, windows.GetLastError()
-	}
-
-	idle := uint64(uint64(lpIdleTime.DwHighDateTime)<<32) + uint64(lpIdleTime.DwLowDateTime)
-	user := uint64(uint64(lpUserTime.DwHighDateTime)<<32) + uint64(lpUserTime.DwLowDateTime)
-	kernel := uint64(uint64(lpKernelTime.DwHighDateTime)<<32) + uint64(lpKernelTime.DwLowDateTime)
-	system := (kernel - idle)
-
-	ret = append(ret, TimesStat{
-		CPU:    "cpu-total",
-		Idle:   float64(idle),
-		User:   float64(user),
-		System: float64(system),
-	})
-	return ret, nil
 }

--- a/pkg/collector/corechecks/system/cpu/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows.go
@@ -122,7 +122,7 @@ func (c *Check) Configure(data integration.Data, initConfig integration.Data, so
 	}
 	c.userCounter, err = pdhutil.GetMultiInstanceCounter("Processor Information", "% User Time", &[]string{"_Total"}, nil)
 	if err != nil {
-		return fmt.Errorf("cpu.Check could not establish idle time counter %v", err)
+		return fmt.Errorf("cpu.Check could not establish user time counter %v", err)
 	}
 	c.privilegedCounter, err = pdhutil.GetMultiInstanceCounter("Processor Information", "% Privileged Time", &[]string{"_Total"}, nil)
 	if err != nil {

--- a/pkg/collector/corechecks/system/cpu/cpu_windows_test.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows_test.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build windows
+
+package cpu
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	pdhtest "github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
+)
+
+func CPUInfo() (map[string]string, error) {
+	return map[string]string{
+		"cpu_logical_processors": "1",
+	}, nil
+}
+
+func TestCPUCheckWindows(t *testing.T) {
+	cpuInfo = CPUInfo
+	pdhtest.SetupTesting("..\\testfiles\\counter_indexes_en-us.txt", "..\\testfiles\\allcounters_en-us.txt")
+	pdhtest.SetQueryReturnValue("\\\\.\\Processor Information(_Total)\\% Interrupt Time", 0.1)
+	pdhtest.SetQueryReturnValue("\\\\.\\Processor Information(_Total)\\% Idle Time", 0.5)
+	pdhtest.SetQueryReturnValue("\\\\.\\Processor Information(_Total)\\% User Time", 0.3)
+	pdhtest.SetQueryReturnValue("\\\\.\\Processor Information(_Total)\\% Privileged Time", 0.2)
+
+	cpuCheck := new(Check)
+	cpuCheck.Configure(nil, nil, "test")
+
+	m := mocksender.NewMockSender(cpuCheck.ID())
+	m.On(metrics.GaugeType.String(), "system.cpu.num_cores", 1.0, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.interrupt", 0.1, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.idle", 50.0, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.user", 30.0, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.system", 20.0, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.iowait", 0.0, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.stolen", 0.0, "", []string(nil)).Return().Times(1)
+	m.On(metrics.GaugeType.String(), "system.cpu.guest", 0.0, "", []string(nil)).Return().Times(1)
+	m.On("Commit").Return().Times(1)
+
+	cpuCheck.Run()
+
+	m.AssertExpectations(t)
+	m.AssertNumberOfCalls(t, metrics.GaugeType.String(), 8)
+	m.AssertNumberOfCalls(t, "Commit", 1)
+}

--- a/releasenotes/notes/fix-cpu-usage-windows-27be22682a4c7d9d.yaml
+++ b/releasenotes/notes/fix-cpu-usage-windows-27be22682a4c7d9d.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes CPU utilization being underreported on Windows hosts with more than one physical CPU.


### PR DESCRIPTION
### What does this PR do?

The previous implementation using `GetSystemTimes` would only return the
CPU usage of applications running on the same physical processor as the
Agent. By using the `Processor Information` PDH counters we get visibility
on all processors. Note that the `Processor` PDH counters have the same
problem as `GetSystemTimes`, so the choice of `Processor Information` is
not arbitrary.

Also adds a test for the CPU check on Windows.

### Motivation

A customer reported seeing lower-than-real CPU usage on their multi-processor hosts.

###  Test plan

- Spin up a multi-processor bare metal instance on AWS (or some other cloud).
- Run a load generator and watch the CPU usage with the task manager.
- Observe that the Agent before this fix will at random either report or not the CPU load (depending on which processor runs the Agent, should change after Agent restarts).
- After the fix, the Agent should always report the same CPU usage as the task manager.
