### PR TITLE
Add network config warning

### DIFF
--- a/pkg/collector/corechecks/snmp/config.go
+++ b/pkg/collector/corechecks/snmp/config.go
@@ -154,7 +154,7 @@ func buildConfig(rawInstance integration.Data, rawInitConfig integration.Data) (
 	}
 
 	if instance.Network != "" {
-		log.Warnf("`network` is not available for corecheck SNMP integration to use autodiscovery. Agent `snmp_listener` config can be used instead: https://docs.datadoghq.com/network_monitoring/devices/setup?tab=snmpv2#autodiscovery")
+		log.Warnf("`network` config is not available for corecheck SNMP integration to use autodiscovery. Agent `snmp_listener` config can be used instead: https://docs.datadoghq.com/network_monitoring/devices/setup?tab=snmpv2#autodiscovery")
 	}
 
 	if c.ipAddress == "" {

--- a/pkg/collector/corechecks/snmp/config.go
+++ b/pkg/collector/corechecks/snmp/config.go
@@ -41,6 +41,10 @@ type snmpInstanceConfig struct {
 	Profile          string            `yaml:"profile"`
 	UseGlobalMetrics bool              `yaml:"use_global_metrics"`
 	ExtraTags        string            `yaml:"extra_tags"` // comma separated tags
+
+	// `network` config is only available in Python SNMP integration
+	// it's added here to raise warning if used with corecheck SNMP integration
+	Network string `yaml:"network"`
 }
 
 type snmpConfig struct {
@@ -147,6 +151,10 @@ func buildConfig(rawInstance integration.Data, rawInitConfig integration.Data) (
 	c.port = uint16(instance.Port)
 	if instance.ExtraTags != "" {
 		c.extraTags = strings.Split(instance.ExtraTags, ",")
+	}
+
+	if instance.Network != "" {
+		log.Warnf("`network` is not available for corecheck SNMP integration to use autodiscovery. Agent `snmp_listener` config can be used instead: https://docs.datadoghq.com/network_monitoring/devices/setup?tab=snmpv2#autodiscovery")
 	}
 
 	if c.ipAddress == "" {


### PR DESCRIPTION
### What does this PR do?

Add network config warning

### Motivation

Might be helpful to some users migrating from Python SNMP AD to Agent SNMP AD (snmp_listener).

### Describe how to test your changes


II-273