### PR TITLE
Send logs by default from Lambda Extension 

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -829,7 +829,7 @@ func InitConfig(config Config) {
 	bindEnvAndSetLogsConfigKeys(config, "runtime_security_config.endpoints.")
 
 	// Serverless Agent
-	config.BindEnvAndSetDefault("serverless_logs_enabled", true)
+	config.BindEnvAndSetDefault("serverless.logs_enabled", true)
 
 	// command line options
 	config.SetKnown("cmd.check.fullsketches")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -828,6 +828,9 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.remote_tagger", true)
 	bindEnvAndSetLogsConfigKeys(config, "runtime_security_config.endpoints.")
 
+	// Serverless Agent
+	config.BindEnvAndSetDefault("send_logs", true)
+
 	// command line options
 	config.SetKnown("cmd.check.fullsketches")
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -829,7 +829,7 @@ func InitConfig(config Config) {
 	bindEnvAndSetLogsConfigKeys(config, "runtime_security_config.endpoints.")
 
 	// Serverless Agent
-	config.BindEnvAndSetDefault("lambda_logs_enabled", true)
+	config.BindEnvAndSetDefault("serverless_logs_enabled", true)
 
 	// command line options
 	config.SetKnown("cmd.check.fullsketches")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -829,7 +829,7 @@ func InitConfig(config Config) {
 	bindEnvAndSetLogsConfigKeys(config, "runtime_security_config.endpoints.")
 
 	// Serverless Agent
-	config.BindEnvAndSetDefault("send_logs", true)
+	config.BindEnvAndSetDefault("lambda_logs_enabled", true)
 
 	// command line options
 	config.SetKnown("cmd.check.fullsketches")

--- a/pkg/serverless/protocol.go
+++ b/pkg/serverless/protocol.go
@@ -212,7 +212,7 @@ func (l *LogsCollection) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	} else {
 		metricsChan := l.daemon.aggregator.GetBufferedMetricsWithTsChannel()
 		metricTags := getTagsForEnhancedMetrics()
-		sendLogsToIntake := config.Datadog.GetBool("send_logs")
+		sendLogsToIntake := config.Datadog.GetBool("lambda_logs_enabled")
 		arn := aws.GetARN()
 		lastRequestID := aws.GetRequestID()
 		functionName := aws.FunctionNameFromARN()

--- a/pkg/serverless/protocol.go
+++ b/pkg/serverless/protocol.go
@@ -212,7 +212,7 @@ func (l *LogsCollection) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	} else {
 		metricsChan := l.daemon.aggregator.GetBufferedMetricsWithTsChannel()
 		metricTags := getTagsForEnhancedMetrics()
-		sendLogsToIntake := config.Datadog.GetBool("lambda_logs_enabled")
+		sendLogsToIntake := config.Datadog.GetBool("serverless_logs_enabled")
 		arn := aws.GetARN()
 		lastRequestID := aws.GetRequestID()
 		functionName := aws.FunctionNameFromARN()

--- a/pkg/serverless/protocol.go
+++ b/pkg/serverless/protocol.go
@@ -212,7 +212,8 @@ func (l *LogsCollection) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	} else {
 		metricsChan := l.daemon.aggregator.GetBufferedMetricsWithTsChannel()
 		metricTags := getTagsForEnhancedMetrics()
-		sendLogsToIntake := config.Datadog.GetBool("logs_enabled")
+		sendLogsToIntake := config.Datadog.GetBool("send_logs")
+
 		arn := aws.GetARN()
 		lastRequestID := aws.GetRequestID()
 		functionName := aws.FunctionNameFromARN()

--- a/pkg/serverless/protocol.go
+++ b/pkg/serverless/protocol.go
@@ -213,7 +213,6 @@ func (l *LogsCollection) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		metricsChan := l.daemon.aggregator.GetBufferedMetricsWithTsChannel()
 		metricTags := getTagsForEnhancedMetrics()
 		sendLogsToIntake := config.Datadog.GetBool("send_logs")
-
 		arn := aws.GetARN()
 		lastRequestID := aws.GetRequestID()
 		functionName := aws.FunctionNameFromARN()

--- a/pkg/serverless/protocol.go
+++ b/pkg/serverless/protocol.go
@@ -212,7 +212,7 @@ func (l *LogsCollection) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	} else {
 		metricsChan := l.daemon.aggregator.GetBufferedMetricsWithTsChannel()
 		metricTags := getTagsForEnhancedMetrics()
-		sendLogsToIntake := config.Datadog.GetBool("serverless_logs_enabled")
+		sendLogsToIntake := config.Datadog.GetBool("serverless.logs_enabled")
 		arn := aws.GetARN()
 		lastRequestID := aws.GetRequestID()
 		functionName := aws.FunctionNameFromARN()


### PR DESCRIPTION
### What does this PR do?

Current behavior:
- In the regular Datadog agent, the `logs_enabled` config key defaults to `false`. Setting it to `true` enables the logs agent.
- In the Lambda extension, the logs agent is always enabled. However, by default we only use the logs to calculate metrics. If the user wants to send the logs to Datadog, they must set `logs_enabled` to `true`.

New behavior:
- Create a new config key called `serverless.logs_enabled` which defaults to `true`. This is used by the Lambda extension to decide whether or not to send logs to Datadog. 

### Motivation

The vast majority of Lambda extension users will want to send logs to Datadog. We would like this to be the default behavior so that customers can avoid configuring the extension. Because the `logs_enabled` config key is used by the regular agent and defaults to `false`, the only way to change the default behavior without affecting the regular agent is to create a separate config key for the Lambda extension.

As a bonus, this removes confusion that may arise because the `logs_enabled` key previously had a different meaning in the Lambda extension compared to the regular agent.

### Additional Notes

**This is a breaking change for the Lambda extension:**
- Customers that previously were not sending logs to Datadog will now send logs to Datadog unless they explicitly disable it using the new `serverless.logs_enabled` config value (which corresponds to the `DD_SERVERLESS_LOGS_ENABLED` environment variable).
- The value set by `logs_enabled` will now be ignored going forward.

I also looked into using `IsSet()` to override the normal default so that we could continue using the same `logs_enabled` environment variable. That is, if `logs_enabled` was not **explicitly set** to false, we could override the default to true in the Lambda Extension. This did not work because `isSet()` returns true even when the value is not explicitly set -- a default counts as being "set".

### Describe how to test your changes

I manually tested this change in the sandbox environment.
