### PR TITLE
[Extension] Fix ssm env var name

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -76,7 +76,7 @@ where they can be graphed on dashboards. The Datadog Serverless Agent implements
 	// KSM > SSM > Apikey in environment var
 	// If one is set but failing, the next will be tried
 	kmsAPIKeyEnvVar = "DD_KMS_API_KEY"
-	ssmAPIKeyEnvVar = "DD_API_KEY_SECRET_ARN"
+	ssmAPIKeyEnvVar = "DD_API_KEY_SSM_NAME"
 	apiKeyEnvVar    = "DD_API_KEY"
 
 	logLevelEnvVar = "DD_LOG_LEVEL"
@@ -446,7 +446,7 @@ func readAPIKeyFromKMS() (string, error) {
 	return rv, nil
 }
 
-// readAPIKeyFromSSM reads an API Key in SSM if the env var DD_API_KEY_SECRET_ARN
+// readAPIKeyFromSSM reads an API Key in SSM if the env var DD_API_KEY_SSM_NAME
 // has been set.
 // If none has been set, it is returning an empty string and a nil error.
 func readAPIKeyFromSSM() (string, error) {
@@ -454,7 +454,7 @@ func readAPIKeyFromSSM() (string, error) {
 	if arn == "" {
 		return "", nil
 	}
-	log.Debug("Found DD_API_KEY_SECRET_ARN value, trying to use it.")
+	log.Debug("Found DD_API_KEY_SSM_NAME value, trying to use it.")
 	ssmClient := secretsmanager.New(session.New(nil))
 	secret := &secretsmanager.GetSecretValueInput{}
 	secret.SetSecretId(arn)


### PR DESCRIPTION
### What does this PR do?

Changes name of env var for SSM DD_API_KEY support to be consistent with the forwarder. In the forwarder 'DD_API_KEY_SECRET_ARN' is used for a secrets manager ARN, not a SSM key, which is what the code was reading.

### Motivation

Noticed this logic was incompatible. This is a breaking change, but the env var is currently undocumented.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
