### PR TITLE
[process-agent/system-probe] Fix local resolution for incoming connections

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "ced83393da6990bd432f8b127d7f57cf2f61e511c63f9b33ed6836a5117934da")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "99ab8667f42ec990f6b30b13096d196b1b7d3d0557662c0f47652bba0e7b968d")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "99ab8667f42ec990f6b30b13096d196b1b7d3d0557662c0f47652bba0e7b968d")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "ced83393da6990bd432f8b127d7f57cf2f61e511c63f9b33ed6836a5117934da")

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -680,7 +680,16 @@ func (ns *networkState) determineConnectionIntraHost(connections []ConnectionSta
 		}
 
 		if conn.IntraHost && conn.Direction == INCOMING {
-			// remove ip translation from incoming local connections
+			// Remove ip translation from incoming local connections
+			// this is necessary for local connections because of
+			// the way we store conntrack entries in the conntrack
+			// cache in the system-probe. For local connections
+			// that are DNAT'ed, system-probe will tack on the
+			// translation on the incoming source side as well,
+			// even though there is no SNAT on the incoming side.
+			// This is because we store both the origin and reply
+			// (and map them to each other) in the conntrack cache
+			// in system-probe.
 			conn.IPTranslation = nil
 		}
 	}

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -642,11 +642,10 @@ func (ns *networkState) determineConnectionIntraHost(connections []ConnectionSta
 		Address util.Address
 		Port    uint16
 		Type    ConnectionType
-		NetNS   uint32
 	}
 
 	newConnKey := func(connStat *ConnectionStats, useRAddrAsKey bool) connKey {
-		key := connKey{Type: connStat.Type, NetNS: connStat.NetNS}
+		key := connKey{Type: connStat.Type}
 		if useRAddrAsKey {
 			if connStat.IPTranslation == nil {
 				key.Address = connStat.Dest
@@ -666,10 +665,6 @@ func (ns *networkState) determineConnectionIntraHost(connections []ConnectionSta
 	for _, conn := range connections {
 		k := newConnKey(&conn, false)
 		lAddrs[k] = struct{}{}
-		if !k.Address.IsLoopback() {
-			k.NetNS = 0
-			lAddrs[k] = struct{}{}
-		}
 	}
 
 	// do not use range value here since it will create a copy of the ConnectionStats object
@@ -682,10 +677,6 @@ func (ns *networkState) determineConnectionIntraHost(connections []ConnectionSta
 		} else {
 			keyWithRAddr := newConnKey(conn, true)
 			_, conn.IntraHost = lAddrs[keyWithRAddr]
-			if !conn.IntraHost && !keyWithRAddr.Address.IsLoopback() {
-				keyWithRAddr.NetNS = 0
-				_, conn.IntraHost = lAddrs[keyWithRAddr]
-			}
 		}
 
 		if conn.IntraHost && conn.Direction == INCOMING {

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -1368,6 +1368,180 @@ func TestHTTPStatsWithMultipleClients(t *testing.T) {
 	assert.Len(t, delta.HTTP, 2)
 }
 
+func TestDetermineConnectionIntraHost(t *testing.T) {
+	tests := []struct {
+		name      string
+		conn      ConnectionStats
+		intraHost bool
+	}{
+		{
+			name: "equal source/dest",
+			conn: ConnectionStats{
+				Source: util.AddressFromString("1.1.1.1"),
+				Dest:   util.AddressFromString("1.1.1.1"),
+				SPort:  123,
+				DPort:  456,
+			},
+			intraHost: true,
+		},
+		{
+			name: "source/dest loopback",
+			conn: ConnectionStats{
+				Source: util.AddressFromString("127.0.0.1"),
+				Dest:   util.AddressFromString("127.0.0.1"),
+				SPort:  123,
+				DPort:  456,
+			},
+			intraHost: true,
+		},
+		{
+			name: "dest nat'ed to loopback",
+			conn: ConnectionStats{
+				Source: util.AddressFromString("1.1.1.1"),
+				Dest:   util.AddressFromString("2.2.2.2"),
+				SPort:  123,
+				DPort:  456,
+				IPTranslation: &IPTranslation{
+					ReplSrcIP:   util.AddressFromString("127.0.0.1"),
+					ReplDstIP:   util.AddressFromString("1.1.1.1"),
+					ReplSrcPort: 456,
+					ReplDstPort: 123,
+				},
+			},
+			intraHost: true,
+		},
+		{
+			name: "local connection with nat on both sides",
+			conn: ConnectionStats{
+				Source:    util.AddressFromString("1.1.1.1"),
+				Dest:      util.AddressFromString("169.254.169.254"),
+				SPort:     12345,
+				DPort:     80,
+				Direction: OUTGOING,
+				IPTranslation: &IPTranslation{
+					ReplSrcIP:   util.AddressFromString("127.0.0.1"),
+					ReplDstIP:   util.AddressFromString("1.1.1.1"),
+					ReplSrcPort: 8181,
+					ReplDstPort: 12345,
+				},
+			},
+			intraHost: true,
+		},
+		{
+			name: "local connection with nat on both sides",
+			conn: ConnectionStats{
+				Source:    util.AddressFromString("127.0.0.1"),
+				Dest:      util.AddressFromString("1.1.1.1"),
+				SPort:     8181,
+				DPort:     12345,
+				Direction: INCOMING,
+				IPTranslation: &IPTranslation{
+					ReplSrcIP:   util.AddressFromString("1.1.1.1"),
+					ReplDstIP:   util.AddressFromString("169.254.169.254"),
+					ReplSrcPort: 12345,
+					ReplDstPort: 80,
+				},
+			},
+			intraHost: true,
+		},
+		{
+			name: "remote connection with source translation (redirect)",
+			conn: ConnectionStats{
+				Source:    util.AddressFromString("4.4.4.4"),
+				Dest:      util.AddressFromString("2.2.2.2"),
+				SPort:     12345,
+				DPort:     80,
+				Direction: INCOMING,
+				NetNS:     2,
+				IPTranslation: &IPTranslation{
+					ReplSrcIP:   util.AddressFromString("2.2.2.2"),
+					ReplDstIP:   util.AddressFromString("127.0.0.1"),
+					ReplSrcPort: 12345,
+					ReplDstPort: 15006,
+				},
+			},
+			intraHost: false,
+		},
+		{
+			name: "local connection, same network ns",
+			conn: ConnectionStats{
+				Source:    util.AddressFromString("1.1.1.1"),
+				Dest:      util.AddressFromString("2.2.2.2"),
+				SPort:     12345,
+				DPort:     80,
+				Direction: OUTGOING,
+				NetNS:     1,
+			},
+			intraHost: true,
+		},
+		{
+			name: "local connection, same network ns",
+			conn: ConnectionStats{
+				Source:    util.AddressFromString("2.2.2.2"),
+				Dest:      util.AddressFromString("1.1.1.1"),
+				SPort:     80,
+				DPort:     12345,
+				Direction: INCOMING,
+				NetNS:     1,
+			},
+			intraHost: true,
+		},
+		{
+			name: "local connection, different network ns",
+			conn: ConnectionStats{
+				Source:    util.AddressFromString("1.1.1.1"),
+				Dest:      util.AddressFromString("2.2.2.2"),
+				SPort:     12345,
+				DPort:     80,
+				Direction: OUTGOING,
+				NetNS:     1,
+			},
+			intraHost: true,
+		},
+		{
+			name: "local connection, different network ns",
+			conn: ConnectionStats{
+				Source:    util.AddressFromString("2.2.2.2"),
+				Dest:      util.AddressFromString("1.1.1.1"),
+				SPort:     80,
+				DPort:     12345,
+				Direction: INCOMING,
+				NetNS:     2,
+			},
+			intraHost: true,
+		},
+		{
+			name: "remote connection",
+			conn: ConnectionStats{
+				Source:    util.AddressFromString("1.1.1.1"),
+				Dest:      util.AddressFromString("3.3.3.3"),
+				SPort:     12345,
+				DPort:     80,
+				Direction: OUTGOING,
+				NetNS:     1,
+			},
+			intraHost: false,
+		},
+	}
+
+	var conns []ConnectionStats
+	for _, te := range tests {
+		conns = append(conns, te.conn)
+	}
+	state := newDefaultState().(*networkState)
+	state.determineConnectionIntraHost(conns)
+	for i, te := range tests {
+		assert.Equal(t, te.intraHost, conns[i].IntraHost, "name: %s, conn: %+v", te.name, conns[i])
+		if conns[i].Direction == INCOMING {
+			if conns[i].IntraHost {
+				assert.Nil(t, conns[i].IPTranslation, "name: %s, conn: %+v", te.name, conns[i])
+			} else {
+				assert.NotNil(t, conns[i].IPTranslation, "name: %s, conn: %+v", te.name, conns[i])
+			}
+		}
+	}
+}
+
 func generateRandConnections(n int) []ConnectionStats {
 	cs := make([]ConnectionStats, 0, n)
 	for i := 0; i < n; i++ {

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -1418,6 +1418,7 @@ func TestDetermineConnectionIntraHost(t *testing.T) {
 				SPort:     12345,
 				DPort:     80,
 				Direction: OUTGOING,
+				NetNS:     1212,
 				IPTranslation: &IPTranslation{
 					ReplSrcIP:   util.AddressFromString("127.0.0.1"),
 					ReplDstIP:   util.AddressFromString("1.1.1.1"),
@@ -1435,6 +1436,7 @@ func TestDetermineConnectionIntraHost(t *testing.T) {
 				SPort:     8181,
 				DPort:     12345,
 				Direction: INCOMING,
+				NetNS:     1233,
 				IPTranslation: &IPTranslation{
 					ReplSrcIP:   util.AddressFromString("1.1.1.1"),
 					ReplDstIP:   util.AddressFromString("169.254.169.254"),

--- a/pkg/process/net/resolver/resolver.go
+++ b/pkg/process/net/resolver/resolver.go
@@ -143,16 +143,14 @@ func (l *LocalResolver) Resolve(c *model.Connections) {
 
 		if conn.Raddr.ContainerId == "" {
 			log.Tracef("could not resolve raddr %v", conn.Raddr)
-			continue
 		}
 
 		// make sure we do not have a translation for an incoming
 		// connection that is local
-		if conn.Direction == model.ConnectionDirection_incoming {
+		if conn.IntraHost && conn.Direction == model.ConnectionDirection_incoming {
 			log.Tracef("clearing nat translation for connection %+v", conn)
 			conn.IpTranslation = nil
 		}
-
 	}
 }
 

--- a/pkg/process/net/resolver/resolver.go
+++ b/pkg/process/net/resolver/resolver.go
@@ -136,11 +136,11 @@ func (l *LocalResolver) Resolve(c *model.Connections) {
 			if ok {
 				// done
 			} else if !ip.IsLoopback() {
-				cid, ok = ctrsByLaddr[addrWithNS{raddr, 0}]
+				cid, _ = ctrsByLaddr[addrWithNS{raddr, 0}]
 			} else {
 				// raddr is loopback, try the root NS (already tried the local
 				// NS above)
-				cid, ok = ctrsByLaddr[addrWithNS{raddr, rootNs}]
+				cid, _ = ctrsByLaddr[addrWithNS{raddr, rootNs}]
 			}
 
 			conn.Raddr.ContainerId = cid

--- a/pkg/process/net/resolver/resolver.go
+++ b/pkg/process/net/resolver/resolver.go
@@ -144,13 +144,6 @@ func (l *LocalResolver) Resolve(c *model.Connections) {
 		if conn.Raddr.ContainerId == "" {
 			log.Tracef("could not resolve raddr %v", conn.Raddr)
 		}
-
-		// make sure we do not have a translation for an incoming
-		// connection that is local
-		if conn.IntraHost && conn.Direction == model.ConnectionDirection_incoming {
-			log.Tracef("clearing nat translation for connection %+v", conn)
-			conn.IpTranslation = nil
-		}
 	}
 }
 

--- a/pkg/process/net/resolver/resolver.go
+++ b/pkg/process/net/resolver/resolver.go
@@ -38,6 +38,10 @@ func (l *LocalResolver) LoadAddrs(containers []*containers.Container) {
 	l.addrToCtrID = make(map[model.ContainerAddr]string)
 	l.ctrForPid = make(map[int32]string)
 	for _, ctr := range containers {
+		for _, pid := range ctr.Pids {
+			l.ctrForPid[pid] = ctr.ID
+		}
+
 		for _, networkAddr := range ctr.AddressList {
 			if networkAddr.IP.IsLoopback() {
 				continue
@@ -50,9 +54,6 @@ func (l *LocalResolver) LoadAddrs(containers []*containers.Container) {
 			l.addrToCtrID[addr] = ctr.ID
 		}
 
-		for _, pid := range ctr.Pids {
-			l.ctrForPid[pid] = ctr.ID
-		}
 	}
 }
 

--- a/pkg/process/net/resolver/resolver_test.go
+++ b/pkg/process/net/resolver/resolver_test.go
@@ -119,7 +119,7 @@ func TestResolveLoopbackConnections(t *testing.T) {
 					Port: 1234,
 				},
 				IpTranslation: &model.IPTranslation{
-					ReplDstIP:   "10.1.1.1",
+					ReplDstIP:   "127.0.0.1",
 					ReplDstPort: 1234,
 					ReplSrcIP:   "10.1.1.2",
 					ReplSrcPort: 1234,
@@ -133,7 +133,7 @@ func TestResolveLoopbackConnections(t *testing.T) {
 			name: "raddr resolution with nat to localhost",
 			conn: &model.Connection{
 				Pid:   2,
-				NetNS: 2,
+				NetNS: 1,
 				Laddr: &model.Addr{
 					Ip:   "10.1.1.2",
 					Port: 1234,
@@ -318,9 +318,9 @@ func TestResolveLoopbackConnections(t *testing.T) {
 	resolver.Resolve(conns)
 
 	for _, te := range tests {
-		t.Run(te.name, func(_t *testing.T) {
-			assert.Equal(_t, te.expectedLaddrID, te.conn.Laddr.ContainerId, "laddr container id does not match expected value")
-			assert.Equal(_t, te.expectedRaddrID, te.conn.Raddr.ContainerId, "raddr container id does not match expected value")
+		t.Run(te.name, func(t *testing.T) {
+			assert.Equal(t, te.expectedLaddrID, te.conn.Laddr.ContainerId, "laddr container id does not match expected value")
+			assert.Equal(t, te.expectedRaddrID, te.conn.Raddr.ContainerId, "raddr container id does not match expected value")
 		})
 	}
 }

--- a/pkg/process/net/resolver/resolver_test.go
+++ b/pkg/process/net/resolver/resolver_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	model "github.com/DataDog/agent-payload/process"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLocalResolver(t *testing.T) {
@@ -99,6 +101,9 @@ func TestLocalResolver(t *testing.T) {
 }
 
 func TestResolveLoopbackConnections(t *testing.T) {
+
+	rootNs, err := util.GetNetNsInoFromPid("/proc", 1)
+	require.NoError(t, err)
 
 	tests := []struct {
 		name            string
@@ -282,6 +287,54 @@ func TestResolveLoopbackConnections(t *testing.T) {
 			expectedLaddrID: "foo7",
 			expectedRaddrID: "foo6",
 		},
+		{
+			name: "cross namespace with dnat to loopback",
+			conn: &model.Connection{
+				Pid:   20,
+				NetNS: 20,
+				Laddr: &model.Addr{
+					Ip:   "10.10.10.10",
+					Port: 22222,
+				},
+				Raddr: &model.Addr{
+					Ip:   "169.254.169.254.169",
+					Port: 80,
+				},
+				Direction: model.ConnectionDirection_outgoing,
+				IpTranslation: &model.IPTranslation{
+					ReplDstIP:   "10.10.10.10",
+					ReplDstPort: 22222,
+					ReplSrcIP:   "127.0.0.1",
+					ReplSrcPort: 8181,
+				},
+			},
+			expectedLaddrID: "foo20",
+			expectedRaddrID: "foo21",
+		},
+		{
+			name: "cross namespace with dnat to loopback",
+			conn: &model.Connection{
+				Pid:   21,
+				NetNS: rootNs,
+				Laddr: &model.Addr{
+					Ip:   "127.0.0.1",
+					Port: 8181,
+				},
+				Raddr: &model.Addr{
+					Ip:   "10.10.10.10",
+					Port: 22222,
+				},
+				Direction: model.ConnectionDirection_outgoing,
+				IpTranslation: &model.IPTranslation{
+					ReplDstIP:   "169.254.169.254",
+					ReplDstPort: 80,
+					ReplSrcIP:   "10.10.10.10",
+					ReplSrcPort: 22222,
+				},
+			},
+			expectedLaddrID: "foo21",
+			expectedRaddrID: "foo20",
+		},
 	}
 
 	resolver := &LocalResolver{}
@@ -318,6 +371,14 @@ func TestResolveLoopbackConnections(t *testing.T) {
 			{
 				ID:   "bar",
 				Pids: []int32{20},
+			},
+			{
+				ID:   "foo20",
+				Pids: []int32{20},
+			},
+			{
+				ID:   "foo21",
+				Pids: []int32{21},
 			},
 		},
 	)

--- a/pkg/process/net/resolver/resolver_test.go
+++ b/pkg/process/net/resolver/resolver_test.go
@@ -101,11 +101,10 @@ func TestLocalResolver(t *testing.T) {
 func TestResolveLoopbackConnections(t *testing.T) {
 
 	tests := []struct {
-		name                string
-		conn                *model.Connection
-		expectedLaddrID     string
-		expectedRaddrID     string
-		translationExpected bool
+		name            string
+		conn            *model.Connection
+		expectedLaddrID string
+		expectedRaddrID string
 	}{
 		{
 			name: "raddr resolution with nat",
@@ -129,9 +128,8 @@ func TestResolveLoopbackConnections(t *testing.T) {
 				Direction: model.ConnectionDirection_incoming,
 				IntraHost: true,
 			},
-			expectedLaddrID:     "foo1",
-			expectedRaddrID:     "foo2",
-			translationExpected: false,
+			expectedLaddrID: "foo1",
+			expectedRaddrID: "foo2",
 		},
 		{
 			name: "raddr resolution with nat to localhost",
@@ -155,9 +153,8 @@ func TestResolveLoopbackConnections(t *testing.T) {
 				Direction: model.ConnectionDirection_outgoing,
 				IntraHost: true,
 			},
-			expectedLaddrID:     "foo2",
-			expectedRaddrID:     "foo1",
-			translationExpected: true,
+			expectedLaddrID: "foo2",
+			expectedRaddrID: "foo1",
 		},
 		{
 			name: "raddr failed localhost resolution",
@@ -335,7 +332,6 @@ func TestResolveLoopbackConnections(t *testing.T) {
 		t.Run(te.name, func(t *testing.T) {
 			assert.Equal(t, te.expectedLaddrID, te.conn.Laddr.ContainerId, "laddr container id does not match expected value")
 			assert.Equal(t, te.expectedRaddrID, te.conn.Raddr.ContainerId, "raddr container id does not match expected value")
-			assert.Equal(t, te.translationExpected, te.conn.IpTranslation != nil, "%+v", te.conn.IpTranslation)
 		})
 	}
 }

--- a/pkg/process/util/netns_darwin.go
+++ b/pkg/process/util/netns_darwin.go
@@ -1,0 +1,9 @@
+package util
+
+import "fmt"
+
+// GetNetNsInoFromPid gets the network namespace inode number for the given
+// `pid`
+func GetNetNsInoFromPid(procRoot string, pid int) (uint32, error) {
+	return 0, fmt.Errorf("not supported")
+}

--- a/pkg/process/util/netns_windows.go
+++ b/pkg/process/util/netns_windows.go
@@ -1,0 +1,9 @@
+package util
+
+import "fmt"
+
+// GetNetNsInoFromPid gets the network namespace inode number for the given
+// `pid`
+func GetNetNsInoFromPid(procRoot string, pid int) (uint32, error) {
+	return 0, fmt.Errorf("not supported")
+}


### PR DESCRIPTION
### What does this PR do?

This fixes a problem with local resolution when both ends of the connection are on the same host. Currently we end up with a network translation tacked on to both ends, even if one end is actually no getting translated. 

This PR:
* removes ip translation from a local incoming connection
* modifies the local resolution lookup to do a lookup in the network namespace first, and then a lookup without namespace
* modifies the local resolver code in process-agent to use the nat'ed raddr instead of the nat'ed laddr

### Motivation

Problems in the UI with matching both ends of a connection (i.e. by flipping source and dest, e.g.)

### Additional Notes

### Describe how to test your changes

* Run `system-probe` binary
* Run `sudo iptables -I OUTPUT -t nat -p tcp --dport 8080 -j DNAT --to-destination 127.0.0.1:8081`
* Run `nc -l -k 127.0.0.1 8081`
* In a new console/terminal, run `nc 127.0.0.1 8080 -v`. This should connect to the server that was run in the previous step. Type in something to send some data to the server. Leave this running
* For the following command you may need to replace `/var/run/sysprobe/sysprobe.sock` with the sysprobe socket path on your setup
* In another console, run `curl --unix-socket /var/run/sysprobe/sysprobe.sock http://unix/connections?client_id=3 | jq '.conns[] | select(.raddr.port==8080 and .direction=="outgoing" and .ipTranslation!=null)'`. You should see one connection
* `curl --unix-socket /var/run/sysprobe/sysprobe.sock http://unix/connections?client_id=3 | jq '.conns[] | select(.laddr.port==8081 and .direction=="incoming" and .ipTranslation==null)'`. You should see one connection again.