### PR TITLE
Json payload builder benchmarks

### DIFF
--- a/pkg/serializer/json_payload_builder_benchmark_test.go
+++ b/pkg/serializer/json_payload_builder_benchmark_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serializer/stream"
 )
 
-func benchmarkJSONPayloadBuilderThroughput(points int, items int, tags int, runs int) {
+func benchmarkJSONPayloadBuilderThroughput(points int, items int, tags int, runs int) { //nolint:unuse
 	series := metrics.Series{}
 	for i := 0; i < items; i++ {
 		series = append(series, &metrics.Serie{

--- a/pkg/serializer/json_payload_builder_benchmark_test.go
+++ b/pkg/serializer/json_payload_builder_benchmark_test.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
 //+build zlib
 
 package serializer
@@ -5,7 +10,6 @@ package serializer
 import (
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/serializer/stream"
@@ -49,62 +53,6 @@ func benchmarkJSONPayloadBuilderUsage(b *testing.B, points int, items int, tags 
 		payloadBuilder.Build(series)
 	}
 }
-
-func benchmarkJSONPayloadBuilderThroughput(points int, items int, tags int, runs int) { //nolint:unuse
-	series := generateData(points, items, tags)
-	json, _ := series.MarshalJSON()
-	initialSize := len(json)
-	metricsCount := len(series)
-
-	payloadBuilder := stream.NewJSONPayloadBuilder(true)
-	var totalTime time.Duration
-
-	for i := 0; i < runs; i++ {
-		start := time.Now()
-		payloadBuilder.Build(series)
-		totalTime += time.Since(start)
-	}
-	avgTime := int64(totalTime) / int64(runs)
-	speed := float64(initialSize) / (float64(avgTime) / float64(time.Second))
-	metricRate := int(float64(metricsCount) / (float64(avgTime) / float64(time.Second)))
-	megabyte := float64(1024 * 1024)
-	fmt.Printf("inputSize: %d bytes \t # of metrics: %d \t tags: %d \t points: %d \t avg duration: %s \t throughput: %f MB/sec \t metrics/sec: %d\n", initialSize, metricsCount, tags, points, fmt.Sprint(time.Duration(avgTime)), speed/megabyte, metricRate)
-}
-
-// Uncomment to run these benchmarks. These are non-standard benchmarks to collect custom metrics
-// so they should not be run as part of normal CI.
-
-// func TestJSONPayloadBuilderThroughputPoints(t *testing.T) {
-// 	// # of points and items chosen to be approximately the same # of bytes per payload between tests
-// 	benchmarkJSONPayloadBuilderThroughput(0, 21000, 1, 10)
-// 	benchmarkJSONPayloadBuilderThroughput(1, 20000, 1, 10)
-// 	benchmarkJSONPayloadBuilderThroughput(2, 20000, 1, 10)
-// 	benchmarkJSONPayloadBuilderThroughput(5, 15000, 1, 10)
-// 	benchmarkJSONPayloadBuilderThroughput(10, 10000, 1, 10)
-// 	benchmarkJSONPayloadBuilderThroughput(100, 2000, 1, 10)
-// 	benchmarkJSONPayloadBuilderThroughput(200, 1000, 1, 10)
-// }
-
-// func TestJSONPayloadBuilderThroughputTags(t *testing.T) {
-// 	// # of points and items chosen to be approximately the same # of bytes per payload between tests
-// 	benchmarkJSONPayloadBuilderThroughput(1, 21000, 1, 10)
-// 	benchmarkJSONPayloadBuilderThroughput(1, 21000, 2, 10)
-// 	benchmarkJSONPayloadBuilderThroughput(1, 19000, 5, 10)
-// 	benchmarkJSONPayloadBuilderThroughput(1, 15000, 10, 10)
-// 	benchmarkJSONPayloadBuilderThroughput(1, 2000, 100, 10)
-// 	benchmarkJSONPayloadBuilderThroughput(1, 200, 1000, 10)
-// 	benchmarkJSONPayloadBuilderThroughput(1, 20, 10000, 10)
-// }
-
-// func TestJSONPayloadBuilderThroughputHighRate(t *testing.T) {
-// 	// warning - These tests are very slow
-// 	benchmarkJSONPayloadBuilderThroughput(1, 1000000, 1, 1)
-// 	benchmarkJSONPayloadBuilderThroughput(1, 1000000, 10, 1)
-// 	benchmarkJSONPayloadBuilderThroughput(2, 1000000, 1, 1)
-// 	benchmarkJSONPayloadBuilderThroughput(2, 1000000, 10, 1)
-// 	benchmarkJSONPayloadBuilderThroughput(4, 500000, 1, 1)
-// 	benchmarkJSONPayloadBuilderThroughput(4, 500000, 10, 1)
-// }
 
 func BenchmarkJSONPayloadBuilderThroughputPoints0(b *testing.B) {
 	benchmarkJSONPayloadBuilderUsage(b, 0, 100, 1)

--- a/pkg/serializer/json_payload_builder_benchmark_test.go
+++ b/pkg/serializer/json_payload_builder_benchmark_test.go
@@ -4,7 +4,6 @@ package serializer
 
 import (
 	"fmt"
-	"testing"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/metrics"
@@ -54,34 +53,37 @@ func benchmarkJSONPayloadBuilderThroughput(points int, items int, tags int, runs
 	fmt.Printf("inputSize: %d bytes \t # of metrics: %d \t tags: %d \t points: %d \t avg duration: %s \t throughput: %f MB/sec \t metrics/sec: %d\n", initialSize, metricsCount, tags, points, fmt.Sprint(time.Duration(avgTime)), speed/megabyte, metricRate)
 }
 
-func TestJSONPayloadBuilderThroughputPoints(t *testing.T) {
-	// # of points and items chosen to be approximately the same # of bytes per payload between tests
-	benchmarkJSONPayloadBuilderThroughput(0, 21000, 1, 10)
-	benchmarkJSONPayloadBuilderThroughput(1, 20000, 1, 10)
-	benchmarkJSONPayloadBuilderThroughput(2, 20000, 1, 10)
-	benchmarkJSONPayloadBuilderThroughput(5, 15000, 1, 10)
-	benchmarkJSONPayloadBuilderThroughput(10, 10000, 1, 10)
-	benchmarkJSONPayloadBuilderThroughput(100, 2000, 1, 10)
-	benchmarkJSONPayloadBuilderThroughput(200, 1000, 1, 10)
-}
+// Uncomment to run these benchmarks. These are non-standard benchmarks to collect custom metrics
+// so they should not be run as part of normal CI.
 
-func TestJSONPayloadBuilderThroughputTags(t *testing.T) {
-	// # of points and items chosen to be approximately the same # of bytes per payload between tests
-	benchmarkJSONPayloadBuilderThroughput(1, 21000, 1, 10)
-	benchmarkJSONPayloadBuilderThroughput(1, 21000, 2, 10)
-	benchmarkJSONPayloadBuilderThroughput(1, 19000, 5, 10)
-	benchmarkJSONPayloadBuilderThroughput(1, 15000, 10, 10)
-	benchmarkJSONPayloadBuilderThroughput(1, 2000, 100, 10)
-	benchmarkJSONPayloadBuilderThroughput(1, 200, 1000, 10)
-	benchmarkJSONPayloadBuilderThroughput(1, 20, 10000, 10)
-}
+// func TestJSONPayloadBuilderThroughputPoints(t *testing.T) {
+// 	// # of points and items chosen to be approximately the same # of bytes per payload between tests
+// 	benchmarkJSONPayloadBuilderThroughput(0, 21000, 1, 10)
+// 	benchmarkJSONPayloadBuilderThroughput(1, 20000, 1, 10)
+// 	benchmarkJSONPayloadBuilderThroughput(2, 20000, 1, 10)
+// 	benchmarkJSONPayloadBuilderThroughput(5, 15000, 1, 10)
+// 	benchmarkJSONPayloadBuilderThroughput(10, 10000, 1, 10)
+// 	benchmarkJSONPayloadBuilderThroughput(100, 2000, 1, 10)
+// 	benchmarkJSONPayloadBuilderThroughput(200, 1000, 1, 10)
+// }
 
-func TestJSONPayloadBuilderThroughputHighRate(t *testing.T) {
-	// warning - These tests are very slow
-	benchmarkJSONPayloadBuilderThroughput(1, 1000000, 1, 1)
-	benchmarkJSONPayloadBuilderThroughput(1, 1000000, 10, 1)
-	benchmarkJSONPayloadBuilderThroughput(2, 1000000, 1, 1)
-	benchmarkJSONPayloadBuilderThroughput(2, 1000000, 10, 1)
-	benchmarkJSONPayloadBuilderThroughput(4, 500000, 1, 1)
-	benchmarkJSONPayloadBuilderThroughput(4, 500000, 10, 1)
-}
+// func TestJSONPayloadBuilderThroughputTags(t *testing.T) {
+// 	// # of points and items chosen to be approximately the same # of bytes per payload between tests
+// 	benchmarkJSONPayloadBuilderThroughput(1, 21000, 1, 10)
+// 	benchmarkJSONPayloadBuilderThroughput(1, 21000, 2, 10)
+// 	benchmarkJSONPayloadBuilderThroughput(1, 19000, 5, 10)
+// 	benchmarkJSONPayloadBuilderThroughput(1, 15000, 10, 10)
+// 	benchmarkJSONPayloadBuilderThroughput(1, 2000, 100, 10)
+// 	benchmarkJSONPayloadBuilderThroughput(1, 200, 1000, 10)
+// 	benchmarkJSONPayloadBuilderThroughput(1, 20, 10000, 10)
+// }
+
+// func TestJSONPayloadBuilderThroughputHighRate(t *testing.T) {
+// 	// warning - These tests are very slow
+// 	benchmarkJSONPayloadBuilderThroughput(1, 1000000, 1, 1)
+// 	benchmarkJSONPayloadBuilderThroughput(1, 1000000, 10, 1)
+// 	benchmarkJSONPayloadBuilderThroughput(2, 1000000, 1, 1)
+// 	benchmarkJSONPayloadBuilderThroughput(2, 1000000, 10, 1)
+// 	benchmarkJSONPayloadBuilderThroughput(4, 500000, 1, 1)
+// 	benchmarkJSONPayloadBuilderThroughput(4, 500000, 10, 1)
+// }

--- a/pkg/serializer/json_payload_builder_benchmark_test.go
+++ b/pkg/serializer/json_payload_builder_benchmark_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serializer/stream"
 )
 
-func benchmarkJSONPayloadBuilderThroughput(points int, items int, runs int) {
+func benchmarkJSONPayloadBuilderThroughput(points int, items int, tags int, runs int) {
 	series := metrics.Series{}
 	for i := 0; i < items; i++ {
 		series = append(series, &metrics.Serie{
@@ -26,11 +26,18 @@ func benchmarkJSONPayloadBuilderThroughput(points int, items int, runs int) {
 			Name:     "test.metrics",
 			Interval: 15,
 			Host:     "localHost",
-			Tags:     []string{"tag1", "tag2:yes"},
+			Tags: func() []string {
+				ts := make([]string, tags)
+				for t := 0; t < tags; t++ {
+					ts[t] = fmt.Sprintf("tag%d:foobar", t)
+				}
+				return ts
+			}(),
 		})
 	}
 	json, _ := series.MarshalJSON()
 	initialSize := len(json)
+	metricsCount := len(series)
 
 	payloadBuilder := stream.NewJSONPayloadBuilder(true)
 	var totalTime time.Duration
@@ -42,17 +49,39 @@ func benchmarkJSONPayloadBuilderThroughput(points int, items int, runs int) {
 	}
 	avgTime := int64(totalTime) / int64(runs)
 	speed := float64(initialSize) / (float64(avgTime) / float64(time.Second))
+	metricRate := int(float64(metricsCount) / (float64(avgTime) / float64(time.Second)))
 	megabyte := float64(1024 * 1024)
-	fmt.Printf("inputSize: %d bytes \t avg duration: %s \t throughput: %f MB/sec\n", initialSize, fmt.Sprint(time.Duration(avgTime)), speed/megabyte)
+	fmt.Printf("inputSize: %d bytes \t # of metrics: %d \t tags: %d \t points: %d \t avg duration: %s \t throughput: %f MB/sec \t metrics/sec: %d\n", initialSize, metricsCount, tags, points, fmt.Sprint(time.Duration(avgTime)), speed/megabyte, metricRate)
 }
 
-func TestJSONPayloadBuilderThroughput(t *testing.T) {
+func TestJSONPayloadBuilderThroughputPoints(t *testing.T) {
 	// # of points and items chosen to be approximately the same # of bytes per payload between tests
-	benchmarkJSONPayloadBuilderThroughput(0, 21000, 10)
-	benchmarkJSONPayloadBuilderThroughput(1, 20000, 10)
-	benchmarkJSONPayloadBuilderThroughput(2, 20000, 10)
-	benchmarkJSONPayloadBuilderThroughput(5, 15000, 10)
-	benchmarkJSONPayloadBuilderThroughput(10, 10000, 10)
-	benchmarkJSONPayloadBuilderThroughput(100, 2000, 10)
-	benchmarkJSONPayloadBuilderThroughput(200, 1000, 10)
+	benchmarkJSONPayloadBuilderThroughput(0, 21000, 1, 10)
+	benchmarkJSONPayloadBuilderThroughput(1, 20000, 1, 10)
+	benchmarkJSONPayloadBuilderThroughput(2, 20000, 1, 10)
+	benchmarkJSONPayloadBuilderThroughput(5, 15000, 1, 10)
+	benchmarkJSONPayloadBuilderThroughput(10, 10000, 1, 10)
+	benchmarkJSONPayloadBuilderThroughput(100, 2000, 1, 10)
+	benchmarkJSONPayloadBuilderThroughput(200, 1000, 1, 10)
+}
+
+func TestJSONPayloadBuilderThroughputTags(t *testing.T) {
+	// # of points and items chosen to be approximately the same # of bytes per payload between tests
+	benchmarkJSONPayloadBuilderThroughput(1, 21000, 1, 10)
+	benchmarkJSONPayloadBuilderThroughput(1, 21000, 2, 10)
+	benchmarkJSONPayloadBuilderThroughput(1, 19000, 5, 10)
+	benchmarkJSONPayloadBuilderThroughput(1, 15000, 10, 10)
+	benchmarkJSONPayloadBuilderThroughput(1, 2000, 100, 10)
+	benchmarkJSONPayloadBuilderThroughput(1, 200, 1000, 10)
+	benchmarkJSONPayloadBuilderThroughput(1, 20, 10000, 10)
+}
+
+func TestJSONPayloadBuilderThroughputHighRate(t *testing.T) {
+	// warning - These tests are very slow
+	benchmarkJSONPayloadBuilderThroughput(1, 1000000, 1, 1)
+	benchmarkJSONPayloadBuilderThroughput(1, 1000000, 10, 1)
+	benchmarkJSONPayloadBuilderThroughput(2, 1000000, 1, 1)
+	benchmarkJSONPayloadBuilderThroughput(2, 1000000, 10, 1)
+	benchmarkJSONPayloadBuilderThroughput(4, 500000, 1, 1)
+	benchmarkJSONPayloadBuilderThroughput(4, 500000, 10, 1)
 }

--- a/pkg/serializer/json_payload_builder_benchmark_test.go
+++ b/pkg/serializer/json_payload_builder_benchmark_test.go
@@ -1,0 +1,58 @@
+//+build zlib
+
+package serializer
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/serializer/stream"
+)
+
+func benchmarkJSONPayloadBuilderThroughput(points int, items int, runs int) {
+	series := metrics.Series{}
+	for i := 0; i < items; i++ {
+		series = append(series, &metrics.Serie{
+			Points: func() []metrics.Point {
+				ps := make([]metrics.Point, points)
+				for p := 0; p < points; p++ {
+					ps[p] = metrics.Point{Ts: float64(p * i), Value: float64(p + i)}
+				}
+				return ps
+			}(),
+			MType:    metrics.APIGaugeType,
+			Name:     "test.metrics",
+			Interval: 15,
+			Host:     "localHost",
+			Tags:     []string{"tag1", "tag2:yes"},
+		})
+	}
+	json, _ := series.MarshalJSON()
+	initialSize := len(json)
+
+	payloadBuilder := stream.NewJSONPayloadBuilder(true)
+	var totalTime time.Duration
+
+	for i := 0; i < runs; i++ {
+		start := time.Now()
+		payloadBuilder.Build(series)
+		totalTime += time.Since(start)
+	}
+	avgTime := int64(totalTime) / int64(runs)
+	speed := float64(initialSize) / (float64(avgTime) / float64(time.Second))
+	megabyte := float64(1024 * 1024)
+	fmt.Printf("inputSize: %d bytes \t avg duration: %s \t throughput: %f MB/sec\n", initialSize, fmt.Sprint(time.Duration(avgTime)), speed/megabyte)
+}
+
+func TestJSONPayloadBuilderThroughput(t *testing.T) {
+	// # of points and items chosen to be approximately the same # of bytes per payload between tests
+	benchmarkJSONPayloadBuilderThroughput(0, 21000, 10)
+	benchmarkJSONPayloadBuilderThroughput(1, 20000, 10)
+	benchmarkJSONPayloadBuilderThroughput(2, 20000, 10)
+	benchmarkJSONPayloadBuilderThroughput(5, 15000, 10)
+	benchmarkJSONPayloadBuilderThroughput(10, 10000, 10)
+	benchmarkJSONPayloadBuilderThroughput(100, 2000, 10)
+	benchmarkJSONPayloadBuilderThroughput(200, 1000, 10)
+}

--- a/pkg/serializer/json_payload_builder_benchmark_test.go
+++ b/pkg/serializer/json_payload_builder_benchmark_test.go
@@ -4,13 +4,14 @@ package serializer
 
 import (
 	"fmt"
+	"testing"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/serializer/stream"
 )
 
-func benchmarkJSONPayloadBuilderThroughput(points int, items int, tags int, runs int) { //nolint:unuse
+func generateData(points int, items int, tags int) metrics.Series {
 	series := metrics.Series{}
 	for i := 0; i < items; i++ {
 		series = append(series, &metrics.Serie{
@@ -34,6 +35,23 @@ func benchmarkJSONPayloadBuilderThroughput(points int, items int, tags int, runs
 			}(),
 		})
 	}
+	return series
+}
+
+func benchmarkJSONPayloadBuilderUsage(b *testing.B, points int, items int, tags int) {
+
+	series := generateData(points, items, tags)
+	payloadBuilder := stream.NewJSONPayloadBuilder(true)
+
+	b.ResetTimer()
+
+	for n := 0; n < b.N; n++ {
+		payloadBuilder.Build(series)
+	}
+}
+
+func benchmarkJSONPayloadBuilderThroughput(points int, items int, tags int, runs int) { //nolint:unuse
+	series := generateData(points, items, tags)
 	json, _ := series.MarshalJSON()
 	initialSize := len(json)
 	metricsCount := len(series)
@@ -87,3 +105,60 @@ func benchmarkJSONPayloadBuilderThroughput(points int, items int, tags int, runs
 // 	benchmarkJSONPayloadBuilderThroughput(4, 500000, 1, 1)
 // 	benchmarkJSONPayloadBuilderThroughput(4, 500000, 10, 1)
 // }
+
+func BenchmarkJSONPayloadBuilderThroughputPoints0(b *testing.B) {
+	benchmarkJSONPayloadBuilderUsage(b, 0, 100, 1)
+}
+func BenchmarkJSONPayloadBuilderThroughputPoints1(b *testing.B) {
+	benchmarkJSONPayloadBuilderUsage(b, 1, 100, 1)
+}
+func BenchmarkJSONPayloadBuilderThroughputPoints2(b *testing.B) {
+	benchmarkJSONPayloadBuilderUsage(b, 2, 100, 1)
+}
+func BenchmarkJSONPayloadBuilderThroughputPoints5(b *testing.B) {
+	benchmarkJSONPayloadBuilderUsage(b, 5, 100, 1)
+}
+func BenchmarkJSONPayloadBuilderThroughputPoints10(b *testing.B) {
+	benchmarkJSONPayloadBuilderUsage(b, 10, 100, 1)
+}
+func BenchmarkJSONPayloadBuilderThroughputPoints100(b *testing.B) {
+	benchmarkJSONPayloadBuilderUsage(b, 100, 100, 1)
+}
+
+func BenchmarkJSONPayloadBuilderTags0(b *testing.B) {
+	benchmarkJSONPayloadBuilderUsage(b, 1, 100, 0)
+}
+func BenchmarkJSONPayloadBuilderTags1(b *testing.B) {
+	benchmarkJSONPayloadBuilderUsage(b, 1, 100, 1)
+}
+func BenchmarkJSONPayloadBuilderTags2(b *testing.B) {
+	benchmarkJSONPayloadBuilderUsage(b, 1, 100, 2)
+}
+func BenchmarkJSONPayloadBuilderTags5(b *testing.B) {
+	benchmarkJSONPayloadBuilderUsage(b, 1, 100, 5)
+}
+func BenchmarkJSONPayloadBuilderTags10(b *testing.B) {
+	benchmarkJSONPayloadBuilderUsage(b, 1, 100, 10)
+}
+func BenchmarkJSONPayloadBuilderTags100(b *testing.B) {
+	benchmarkJSONPayloadBuilderUsage(b, 1, 100, 100)
+}
+
+func BenchmarkJSONPayloadBuilderItems1(b *testing.B) {
+	benchmarkJSONPayloadBuilderUsage(b, 1, 1, 1)
+}
+func BenchmarkJSONPayloadBuilderItems10(b *testing.B) {
+	benchmarkJSONPayloadBuilderUsage(b, 1, 10, 1)
+}
+func BenchmarkJSONPayloadBuilderItems100(b *testing.B) {
+	benchmarkJSONPayloadBuilderUsage(b, 1, 100, 1)
+}
+func BenchmarkJSONPayloadBuilderItems1000(b *testing.B) {
+	benchmarkJSONPayloadBuilderUsage(b, 1, 1000, 1)
+}
+func BenchmarkJSONPayloadBuilderItems10000(b *testing.B) {
+	benchmarkJSONPayloadBuilderUsage(b, 1, 10000, 1)
+}
+func BenchmarkJSONPayloadBuilderItems100000(b *testing.B) {
+	benchmarkJSONPayloadBuilderUsage(b, 1, 100000, 1)
+}

--- a/pkg/serializer/json_payload_builder_throughput_benchmark_test.go
+++ b/pkg/serializer/json_payload_builder_throughput_benchmark_test.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//+build zlib,optional_benchmarks
+
+package serializer
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/serializer/stream"
+)
+
+func benchmarkJSONPayloadBuilderThroughput(points int, items int, tags int, runs int) { //nolint:unuse
+	series := generateData(points, items, tags)
+	json, _ := series.MarshalJSON()
+	initialSize := len(json)
+	metricsCount := len(series)
+
+	payloadBuilder := stream.NewJSONPayloadBuilder(true)
+	var totalTime time.Duration
+
+	for i := 0; i < runs; i++ {
+		start := time.Now()
+		payloadBuilder.Build(series)
+		totalTime += time.Since(start)
+	}
+	avgTime := int64(totalTime) / int64(runs)
+	speed := float64(initialSize) / (float64(avgTime) / float64(time.Second))
+	metricRate := int(float64(metricsCount) / (float64(avgTime) / float64(time.Second)))
+	megabyte := float64(1024 * 1024)
+	fmt.Printf("inputSize: %d bytes \t # of metrics: %d \t tags: %d \t points: %d \t avg duration: %s \t throughput: %f MB/sec \t metrics/sec: %d\n", initialSize, metricsCount, tags, points, fmt.Sprint(time.Duration(avgTime)), speed/megabyte, metricRate)
+}
+
+func TestJSONPayloadBuilderThroughputPoints(t *testing.T) {
+	// # of points and items chosen to be approximately the same # of bytes per payload between tests
+	benchmarkJSONPayloadBuilderThroughput(0, 21000, 1, 10)
+	benchmarkJSONPayloadBuilderThroughput(1, 20000, 1, 10)
+	benchmarkJSONPayloadBuilderThroughput(2, 20000, 1, 10)
+	benchmarkJSONPayloadBuilderThroughput(5, 15000, 1, 10)
+	benchmarkJSONPayloadBuilderThroughput(10, 10000, 1, 10)
+	benchmarkJSONPayloadBuilderThroughput(100, 2000, 1, 10)
+	benchmarkJSONPayloadBuilderThroughput(200, 1000, 1, 10)
+}
+
+func TestJSONPayloadBuilderThroughputTags(t *testing.T) {
+	// # of points and items chosen to be approximately the same # of bytes per payload between tests
+	benchmarkJSONPayloadBuilderThroughput(1, 21000, 1, 10)
+	benchmarkJSONPayloadBuilderThroughput(1, 21000, 2, 10)
+	benchmarkJSONPayloadBuilderThroughput(1, 19000, 5, 10)
+	benchmarkJSONPayloadBuilderThroughput(1, 15000, 10, 10)
+	benchmarkJSONPayloadBuilderThroughput(1, 2000, 100, 10)
+	benchmarkJSONPayloadBuilderThroughput(1, 200, 1000, 10)
+	benchmarkJSONPayloadBuilderThroughput(1, 20, 10000, 10)
+}
+
+func TestJSONPayloadBuilderThroughputHighRate(t *testing.T) {
+	// warning - These tests are very slow
+	benchmarkJSONPayloadBuilderThroughput(1, 1000000, 1, 1)
+	benchmarkJSONPayloadBuilderThroughput(1, 1000000, 10, 1)
+	benchmarkJSONPayloadBuilderThroughput(2, 1000000, 1, 1)
+	benchmarkJSONPayloadBuilderThroughput(2, 1000000, 10, 1)
+	benchmarkJSONPayloadBuilderThroughput(4, 500000, 1, 1)
+	benchmarkJSONPayloadBuilderThroughput(4, 500000, 10, 1)
+}


### PR DESCRIPTION
### What does this PR do?

Add some custom benchmarks to measure json_payload_builder's performance. 
These are non-standard benchmarks and implemented as Unit tests since they collect custom throughput metrics. These tests should not run with CI and are commented out. 

These tests are added to collect data and help justify future improvements to the serializer design and concurrency. 

### Results
## Stress test
This is the same test as presented earlier in this thread with more info columns
```
inputSize: 2289013 bytes 	 # of metrics: 21000 	 tags: 1 	 points: 0 	 avg duration: 12.83904ms 	 throughput: 170.026179 MB/sec 	 metrics/sec: 1635636
inputSize: 2348903 bytes 	 # of metrics: 20000 	 tags: 1 	 points: 1 	 avg duration: 16.8538ms 	 throughput: 132.912961 MB/sec 	 metrics/sec: 1186676
inputSize: 2606687 bytes 	 # of metrics: 20000 	 tags: 1 	 points: 2 	 avg duration: 27.907953ms 	 throughput: 89.076058 MB/sec 	 metrics/sec: 716641
inputSize: 2531354 bytes 	 # of metrics: 15000 	 tags: 1 	 points: 5 	 avg duration: 74.119697ms 	 throughput: 32.570118 MB/sec 	 metrics/sec: 202375
inputSize: 2297652 bytes 	 # of metrics: 10000 	 tags: 1 	 points: 10 	 avg duration: 110.955155ms 	 throughput: 19.748625 MB/sec 	 metrics/sec: 90126
inputSize: 2693117 bytes 	 # of metrics: 2000 	 tags: 1 	 points: 100 	 avg duration: 229.921676ms 	 throughput: 11.170571 MB/sec 	 metrics/sec: 8698
inputSize: 2502796 bytes 	 # of metrics: 1000 	 tags: 1 	 points: 200 	 avg duration: 193.559202ms 	 throughput: 12.331381 MB/sec 	 metrics/sec: 5166
```

## Many tags test
This test is to measure impact of # of tags
```
inputSize: 2466903 bytes 	 # of metrics: 21000 	 tags: 1 	 points: 1 	 avg duration: 17.929777ms 	 throughput: 131.213123 MB/sec 	 metrics/sec: 1171235
inputSize: 2760903 bytes 	 # of metrics: 21000 	 tags: 2 	 points: 1 	 avg duration: 19.694097ms 	 throughput: 133.694999 MB/sec 	 metrics/sec: 1066309
inputSize: 3294903 bytes 	 # of metrics: 19000 	 tags: 5 	 points: 1 	 avg duration: 21.552ms 	 throughput: 145.799200 MB/sec 	 metrics/sec: 881588
inputSize: 3648903 bytes 	 # of metrics: 15000 	 tags: 10 	 points: 1 	 avg duration: 28.144545ms 	 throughput: 123.642613 MB/sec 	 metrics/sec: 532962
inputSize: 3184903 bytes 	 # of metrics: 2000 	 tags: 100 	 points: 1 	 avg duration: 21.867934ms 	 throughput: 138.895617 MB/sec 	 metrics/sec: 91458
inputSize: 3198303 bytes 	 # of metrics: 200 	 tags: 1000 	 points: 1 	 avg duration: 36.700545ms 	 throughput: 83.108832 MB/sec 	 metrics/sec: 5449
inputSize: 3379823 bytes 	 # of metrics: 20 	 tags: 10000 	 points: 1 	 avg duration: 32.010252ms 	 throughput: 100.694315 MB/sec 	 metrics/sec: 62
```

## high volume test
This test is to measure somewhat realistic metrics per second
```
inputSize: 118888903 bytes 	 # of metrics: 1000000 	 tags: 1 	 points: 1 	 avg duration: 810.806764ms 	 throughput: 139.837626 MB/sec 	 metrics/sec: 1233339
inputSize: 244888903 bytes 	 # of metrics: 1000000 	 tags: 10 	 points: 1 	 avg duration: 1.491732863s 	 throughput: 156.559035 MB/sec 	 metrics/sec: 670361
inputSize: 134666687 bytes 	 # of metrics: 1000000 	 tags: 1 	 points: 2 	 avg duration: 1.478266603s 	 throughput: 86.877536 MB/sec 	 metrics/sec: 676467
inputSize: 260666687 bytes 	 # of metrics: 1000000 	 tags: 10 	 points: 2 	 avg duration: 2.277351481s 	 throughput: 109.157996 MB/sec 	 metrics/sec: 439106
inputSize: 83018564 bytes 	 # of metrics: 500000 	 tags: 1 	 points: 4 	 avg duration: 2.487680808s 	 throughput: 31.825897 MB/sec 	 metrics/sec: 200990
inputSize: 146018564 bytes 	 # of metrics: 500000 	 tags: 10 	 points: 4 	 avg duration: 2.547097683s 	 throughput: 54.671698 MB/sec 	 metrics/sec: 196301
```

### Describe how to test your changes
N/A
