### PR TITLE
[gitlab] Fix Azure cleanup jobs on new image

### DIFF
--- a/.gitlab/maintenance_jobs/kitchen.yml
+++ b/.gitlab/maintenance_jobs/kitchen.yml
@@ -30,14 +30,14 @@ periodic_kitchen_cleanup_azure:
     # Remove kitchen resources for all existing test suite prefixes
     # Legacy resource group prefixes
     # TODO: remove them once we're not using them at all anymore
-    - RESOURCE_GROUP_PREFIX=kitchen-dd-agent python3.6 ~/deploy_scripts/cleanup_azure.py
-    - RESOURCE_GROUP_PREFIX=kitchen-dd-security-agent python3.6 ~/deploy_scripts/cleanup_azure.py
-    - RESOURCE_GROUP_PREFIX=kitchen-dd-system-probe python3.6 ~/deploy_scripts/cleanup_azure.py
+    - RESOURCE_GROUP_PREFIX=kitchen-dd-agent python3.6 /deploy_scripts/cleanup_azure.py
+    - RESOURCE_GROUP_PREFIX=kitchen-dd-security-agent python3.6 /deploy_scripts/cleanup_azure.py
+    - RESOURCE_GROUP_PREFIX=kitchen-dd-system-probe python3.6 /deploy_scripts/cleanup_azure.py
     # New resource group prefixes
-    - RESOURCE_GROUP_PREFIX=kitchen-chef python3.6 ~/deploy_scripts/cleanup_azure.py
-    - RESOURCE_GROUP_PREFIX=kitchen-install-script python3.6 ~/deploy_scripts/cleanup_azure.py
-    - RESOURCE_GROUP_PREFIX=kitchen-upgrade python3.6 ~/deploy_scripts/cleanup_azure.py
-    - RESOURCE_GROUP_PREFIX=kitchen-step-by-step python3.6 ~/deploy_scripts/cleanup_azure.py
-    - RESOURCE_GROUP_PREFIX=kitchen-win python3.6 ~/deploy_scripts/cleanup_azure.py
-    - RESOURCE_GROUP_PREFIX=kitchen-security-agent python3.6 ~/deploy_scripts/cleanup_azure.py
-    - RESOURCE_GROUP_PREFIX=kitchen-system-probe python3.6 ~/deploy_scripts/cleanup_azure.py
+    - RESOURCE_GROUP_PREFIX=kitchen-chef python3.6 /deploy_scripts/cleanup_azure.py
+    - RESOURCE_GROUP_PREFIX=kitchen-install-script python3.6 /deploy_scripts/cleanup_azure.py
+    - RESOURCE_GROUP_PREFIX=kitchen-upgrade python3.6 /deploy_scripts/cleanup_azure.py
+    - RESOURCE_GROUP_PREFIX=kitchen-step-by-step python3.6 /deploy_scripts/cleanup_azure.py
+    - RESOURCE_GROUP_PREFIX=kitchen-win python3.6 /deploy_scripts/cleanup_azure.py
+    - RESOURCE_GROUP_PREFIX=kitchen-security-agent python3.6 /deploy_scripts/cleanup_azure.py
+    - RESOURCE_GROUP_PREFIX=kitchen-system-probe python3.6 /deploy_scripts/cleanup_azure.py

--- a/test/kitchen/docs/README.md
+++ b/test/kitchen/docs/README.md
@@ -229,7 +229,7 @@ When kitchen tests are run, VMs are created in dedicated resource groups in Azur
 
 The periodic cleanup jobs runs the `cleanup_azure.py` script on a given list of Azure resource group prefixes. Eg.:
 ```
-RESOURCE_GROUP_PREFIX=kitchen-dd-agent python3.6 ~/deploy_scripts/cleanup_azure.py
+RESOURCE_GROUP_PREFIX=kitchen-dd-agent python3.6 /deploy_scripts/cleanup_azure.py
 ```
 cleans up all resources created by test suites that start with `dd-agent`.
 


### PR DESCRIPTION
### What does this PR do?

Fixes the Azure cleanup maintenance job by setting the new correct location for the cleanup script.

### Motivation

Follow-up of #8104. The Azure cleanup maintenance jobs were missed because they don't run as part of any regular pipeline, they only run on scheduled pipelines (which have `TESTING_CLEANUP` set to `true`.
