### PR TITLE
[DCA][Admission] Support namespace selector fallback

### DIFF
--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -277,6 +277,7 @@ func start(cmd *cobra.Command, args []string) error {
 			SecretInformers:  apiCl.CertificateSecretInformerFactory,
 			WebhookInformers: apiCl.WebhookConfigInformerFactory,
 			Client:           apiCl.Cl,
+			DiscoveryClient:  apiCl.DiscoveryCl,
 			StopCh:           stopCh,
 		}
 		err = admissionpkg.StartControllers(admissionCtx)

--- a/pkg/clusteragent/admission/util_test.go
+++ b/pkg/clusteragent/admission/util_test.go
@@ -8,14 +8,17 @@
 package admission
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
 
 	"github.com/stretchr/testify/assert"
 	admiv1beta1 "k8s.io/api/admissionregistration/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/version"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
 )
 
 func Test_getWebhookSkeleton(t *testing.T) {
@@ -93,11 +96,17 @@ func Test_getWebhookSkeleton(t *testing.T) {
 }
 
 func Test_generateWebhooks(t *testing.T) {
+	client := fakeclientset.NewSimpleClientset()
+	fakeDiscovery, ok := client.Discovery().(*fakediscovery.FakeDiscovery)
+	assert.True(t, ok)
+
 	mockConfig := config.Mock()
 	tests := []struct {
-		name        string
-		setupConfig func()
-		want        func() []admiv1beta1.MutatingWebhook
+		name          string
+		setupConfig   func()
+		serverVersion *version.Info
+		want          func() []admiv1beta1.MutatingWebhook
+		wantErr       bool
 	}{
 		{
 			name: "config injection, mutate all",
@@ -119,6 +128,7 @@ func Test_generateWebhooks(t *testing.T) {
 				}
 				return []admiv1beta1.MutatingWebhook{webhook}
 			},
+			wantErr: false,
 		},
 		{
 			name: "config injection, mutate labelled",
@@ -136,6 +146,7 @@ func Test_generateWebhooks(t *testing.T) {
 				}
 				return []admiv1beta1.MutatingWebhook{webhook}
 			},
+			wantErr: false,
 		},
 		{
 			name: "tags injection, mutate all",
@@ -157,6 +168,7 @@ func Test_generateWebhooks(t *testing.T) {
 				}
 				return []admiv1beta1.MutatingWebhook{webhook}
 			},
+			wantErr: false,
 		},
 		{
 			name: "tags injection, mutate labelled",
@@ -174,6 +186,7 @@ func Test_generateWebhooks(t *testing.T) {
 				}
 				return []admiv1beta1.MutatingWebhook{webhook}
 			},
+			wantErr: false,
 		},
 		{
 			name: "config and tags injection, mutate labelled",
@@ -196,6 +209,7 @@ func Test_generateWebhooks(t *testing.T) {
 				}
 				return []admiv1beta1.MutatingWebhook{webhookConfig, webhookTags}
 			},
+			wantErr: false,
 		},
 		{
 			name: "config and tags injection, mutate all",
@@ -227,14 +241,164 @@ func Test_generateWebhooks(t *testing.T) {
 				}
 				return []admiv1beta1.MutatingWebhook{webhookConfig, webhookTags}
 			},
+			wantErr: false,
+		},
+		{
+			name: "namespace selector enabled, old cluster version",
+			setupConfig: func() {
+				mockConfig.Set("admission_controller.mutate_unlabelled", false)
+				mockConfig.Set("admission_controller.inject_config.enabled", true)
+				mockConfig.Set("admission_controller.inject_tags.enabled", true)
+				mockConfig.Set("admission_controller.namespace_selector_fallback", true)
+			},
+			serverVersion: &version.Info{Major: "1", Minor: "14+"},
+			want: func() []admiv1beta1.MutatingWebhook {
+				webhookConfig := getWebhookSkeleton("config", "/injectconfig")
+				webhookConfig.NamespaceSelector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"admission.datadoghq.com/enabled": "true",
+					},
+				}
+				webhookTags := getWebhookSkeleton("tags", "/injecttags")
+				webhookTags.NamespaceSelector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"admission.datadoghq.com/enabled": "true",
+					},
+				}
+				return []admiv1beta1.MutatingWebhook{webhookConfig, webhookTags}
+			},
+			wantErr: false,
+		},
+		{
+			name: "namespace selector enabled, new cluster version",
+			setupConfig: func() {
+				mockConfig.Set("admission_controller.mutate_unlabelled", false)
+				mockConfig.Set("admission_controller.inject_config.enabled", true)
+				mockConfig.Set("admission_controller.inject_tags.enabled", true)
+				mockConfig.Set("admission_controller.namespace_selector_fallback", true)
+			},
+			serverVersion: &version.Info{Major: "1", Minor: "19+"},
+			want: func() []admiv1beta1.MutatingWebhook {
+				webhookConfig := getWebhookSkeleton("config", "/injectconfig")
+				webhookConfig.ObjectSelector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"admission.datadoghq.com/enabled": "true",
+					},
+				}
+				webhookTags := getWebhookSkeleton("tags", "/injecttags")
+				webhookTags.ObjectSelector = &metav1.LabelSelector{
+					MatchLabels: map[string]string{
+						"admission.datadoghq.com/enabled": "true",
+					},
+				}
+				return []admiv1beta1.MutatingWebhook{webhookConfig, webhookTags}
+			},
+			wantErr: false,
+		},
+		{
+			name: "namespace selector enabled, invalid version",
+			setupConfig: func() {
+				mockConfig.Set("admission_controller.mutate_unlabelled", false)
+				mockConfig.Set("admission_controller.inject_config.enabled", true)
+				mockConfig.Set("admission_controller.inject_tags.enabled", true)
+				mockConfig.Set("admission_controller.namespace_selector_fallback", true)
+			},
+			serverVersion: &version.Info{Major: "1", Minor: "foo"},
+			want:          func() []admiv1beta1.MutatingWebhook { return []admiv1beta1.MutatingWebhook{} },
+			wantErr:       true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			tt.setupConfig()
-			if got := generateWebhooks(); !reflect.DeepEqual(got, tt.want()) {
-				t.Errorf("generateWebhooks() = %v, want %v", got, tt.want())
-			}
+			fakeDiscovery.FakedServerVersion = tt.serverVersion
+			cache.Cache.Flush()
+			got, err := generateWebhooks(fakeDiscovery)
+			assert.Equal(t, tt.wantErr, err != nil)
+			assert.EqualValues(t, tt.want(), got)
+		})
+	}
+}
+
+func Test_shouldFallback(t *testing.T) {
+	tests := []struct {
+		name    string
+		v       *version.Info
+		want    bool
+		wantErr bool
+	}{
+		{
+			name:    "v1.10 => fallback",
+			v:       &version.Info{Major: "1", Minor: "10"},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "v1.11 => fallback",
+			v:       &version.Info{Major: "1", Minor: "11"},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "v1.12 => fallback",
+			v:       &version.Info{Major: "1", Minor: "12"},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "v1.13 => fallback",
+			v:       &version.Info{Major: "1", Minor: "13"},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "v1.14 => fallback",
+			v:       &version.Info{Major: "1", Minor: "14"},
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "v1.15 => no fallback",
+			v:       &version.Info{Major: "1", Minor: "15+"},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "v1.9 => no fallback",
+			v:       &version.Info{Major: "1", Minor: "9"},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "unsupported major #1",
+			v:       &version.Info{Major: "0", Minor: "14"},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "unsupported major #2",
+			v:       &version.Info{Major: "2", Minor: "14"},
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:    "invalid minor",
+			v:       &version.Info{Major: "1", Minor: "foo"},
+			want:    false,
+			wantErr: true,
+		},
+		{
+			name:    "custom minor",
+			v:       &version.Info{Major: "1", Minor: "10+"},
+			want:    true,
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := shouldFallback(tt.v)
+			assert.Equal(t, tt.wantErr, err != nil)
+			assert.Equal(t, tt.want, got)
 		})
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -726,6 +726,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.enabled", true)
 	config.BindEnvAndSetDefault("admission_controller.inject_tags.endpoint", "/injecttags")
 	config.BindEnvAndSetDefault("admission_controller.pod_owners_cache_validity", 10) // in minutes
+	config.BindEnvAndSetDefault("admission_controller.namespace_selector_fallback", false)
 
 	// Telemetry
 	// Enable telemetry metrics on the internals of the Agent.

--- a/pkg/util/kubernetes/apiserver/common/version.go
+++ b/pkg/util/kubernetes/apiserver/common/version.go
@@ -1,0 +1,85 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build kubeapiserver
+
+package common
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/retry"
+
+	"k8s.io/apimachinery/pkg/version"
+	"k8s.io/client-go/discovery"
+)
+
+const serverVersionCacheKey = "kubeServerVersion"
+
+// kubeServerVersion is a local struct adapted to the agent retry package.
+// It allow retrieving the kubernetes server version with a retry.
+type kubeServerVersion struct {
+	retrier    retry.Retrier
+	clientFunc func() (*version.Info, error)
+	info       *version.Info
+}
+
+func newKubeServerVersion(retryTimeout time.Duration, discoveryFunc func() (*version.Info, error)) (*kubeServerVersion, error) {
+	serverVersion := &kubeServerVersion{clientFunc: discoveryFunc}
+	return serverVersion, serverVersion.retrier.SetupRetrier(&retry.Config{
+		Name:              "kubeServerVersion",
+		AttemptMethod:     serverVersion.set,
+		Strategy:          retry.Backoff,
+		InitialRetryDelay: 1 * time.Second,
+		MaxRetryDelay:     retryTimeout,
+	})
+}
+
+// set is a retriable method to retrieve the kubernetes server version.
+func (k *kubeServerVersion) set() error {
+	var err error
+	k.info, err = k.clientFunc()
+	return err
+}
+
+// KubeServerVersion returns the version of the kubernetes server using a Discovery Client.
+// It retries with an exponential backoff until timeout.
+// It caches the result in memory for 1 hour.
+func KubeServerVersion(discoveryCl discovery.DiscoveryInterface, retryTimeout time.Duration) (*version.Info, error) {
+	if serverVersion, found := cache.Cache.Get(serverVersionCacheKey); found {
+		return serverVersion.(*version.Info), nil
+	}
+
+	serverVersion, err := newKubeServerVersion(retryTimeout, discoveryCl.ServerVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), retryTimeout)
+	defer cancel()
+
+	for {
+		err := serverVersion.retrier.TriggerRetry()
+		switch serverVersion.retrier.RetryStatus() {
+		case retry.OK:
+			cache.Cache.Set(serverVersionCacheKey, serverVersion.info, time.Hour)
+			return serverVersion.info, nil
+		case retry.PermaFail:
+			return nil, err
+		default:
+			sleepFor := serverVersion.retrier.NextRetry().UTC().Sub(time.Now().UTC()) + time.Second
+			log.Debugf("Waiting for getting Kubernetes server version, next retry: %v", sleepFor)
+			select {
+			case <-ctx.Done():
+				return nil, fmt.Errorf("timeout reached while waiting for Kubernetes server version, last error: %w", err)
+			case <-time.After(sleepFor):
+			}
+		}
+	}
+}

--- a/pkg/util/kubernetes/apiserver/common/version_test.go
+++ b/pkg/util/kubernetes/apiserver/common/version_test.go
@@ -1,0 +1,74 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build kubeapiserver
+
+package common
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+
+	"github.com/stretchr/testify/assert"
+	"k8s.io/apimachinery/pkg/version"
+	fakediscovery "k8s.io/client-go/discovery/fake"
+	fakeclientset "k8s.io/client-go/kubernetes/fake"
+)
+
+func TestKubeServerVersion(t *testing.T) {
+	tests := []struct {
+		name        string
+		loadFunc    func()
+		fakeVersion *version.Info
+		want        *version.Info
+		wantErr     bool
+		wantFunc    func(t *testing.T, f *fakediscovery.FakeDiscovery)
+	}{
+
+		{
+			name:        "nominal case",
+			loadFunc:    func() { cache.Cache.Flush() },
+			fakeVersion: &version.Info{Major: "1", Minor: "17+"},
+			want:        &version.Info{Major: "1", Minor: "17+"},
+			wantErr:     false,
+			wantFunc: func(t *testing.T, f *fakediscovery.FakeDiscovery) {
+				_, found := cache.Cache.Get(serverVersionCacheKey)
+				assert.True(t, found)
+				assert.NotEmpty(t, f.Actions())
+			},
+		},
+		{
+			name: "get from cache",
+			loadFunc: func() {
+				cache.Cache.Flush()
+				cache.Cache.Set(serverVersionCacheKey, &version.Info{Major: "1", Minor: "17+"}, time.Hour)
+			},
+			fakeVersion: &version.Info{Major: "1", Minor: "17+"},
+			want:        &version.Info{Major: "1", Minor: "17+"},
+			wantErr:     false,
+			wantFunc: func(t *testing.T, f *fakediscovery.FakeDiscovery) {
+				_, found := cache.Cache.Get(serverVersionCacheKey)
+				assert.True(t, found)
+				assert.Empty(t, f.Actions())
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := fakeclientset.NewSimpleClientset()
+			fakeDiscovery, ok := client.Discovery().(*fakediscovery.FakeDiscovery)
+			assert.True(t, ok)
+			fakeDiscovery.FakedServerVersion = tt.fakeVersion
+
+			tt.loadFunc()
+			got, err := KubeServerVersion(fakeDiscovery, 2*time.Second)
+			assert.Equal(t, tt.wantErr, err != nil)
+			assert.Equal(t, tt.want, got)
+			tt.wantFunc(t, fakeDiscovery)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

- Introduce a a discovery client and the corresponding utils to get the Kubernetes server version
- Support a new parameter `admission_controller.namespace_selector_fallback` (disabled by default) to allow using `NamespaceSelector` instead of `ObjectSelector` in the `MutatingWebhookConfigurations` Spec, this happens only in k8s versions between v1.10 and v1.14 included.

### Motivation

Better Admission Controller support for older k8s versions (< 1.15+) that didn't support `ObjectSelector`

### Additional Notes

The utils around the kube server version retrieval are meant to be used in future features if needed.

### Describe how to test your changes

- Enable `admission_controller.namespace_selector_fallback` in a k8s cluster between v1.10 and v1.14, the `MutatingWebhookConfigurations` object `datadog-webhook` should contain a `NamespaceSelector` defined accordingly.

- Try the case where `admission_controller.namespace_selector_fallback` is enabled in newer k8s version 1.15+, make sure the `ObjectSelector` is preferred in this case.
