### PR TITLE
Change of the Fargate v2 date extraction error log logic

### DIFF
--- a/pkg/util/ecs/common.go
+++ b/pkg/util/ecs/common.go
@@ -55,7 +55,7 @@ func ListContainersInCurrentTask() ([]*containers.Container, error) {
 		if filter == nil || !filter.IsExcluded(c.Name, c.Image, "") {
 			c, e := convertMetaV2Container(c, task.Limits)
 			cList = append(cList, c)
-			if e != "" {
+			if e != nil {
 				log.Error(e)
 			}
 		}
@@ -98,7 +98,7 @@ func UpdateContainerMetrics(cList []*containers.Container) error {
 
 // convertMetaV2Container returns an internal container representation from an
 // ECS metadata v2 container object.
-func convertMetaV2Container(c v2.Container, taskLimits map[string]float64) (*containers.Container, string) {
+func convertMetaV2Container(c v2.Container, taskLimits map[string]float64) (*containers.Container, error) {
 	container := &containers.Container{
 		Type:        "ECS",
 		ID:          c.DockerID,
@@ -116,7 +116,7 @@ func convertMetaV2Container(c v2.Container, taskLimits map[string]float64) (*con
 	if c.KnownStatus != "PULLED" {
 		createdAt, err := time.Parse(time.RFC3339, c.CreatedAt)
 		if err != nil {
-			dateError = dateError = fmt.Errorf("Unable to determine creation time for container %s - %w", c.DockerID, err)
+			dateError = fmt.Errorf("Unable to determine creation time for container %s - %w", c.DockerID, err)
 		} else {
 			container.Created = createdAt.Unix()
 		}

--- a/pkg/util/ecs/common_test.go
+++ b/pkg/util/ecs/common_test.go
@@ -109,10 +109,64 @@ func TestConvertMetaV2Container(t *testing.T) {
 				Limits:      metrics.ContainerLimits{CPULimit: 50, MemLimit: 1024000000},
 			},
 		},
+		{
+			name: "no dates",
+			c: v2.Container{
+				DockerID:   "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
+				DockerName: "ecs-nginx-5-nginx-curl-ccccb9f49db0dfe0d901",
+				Image:      "nrdlngr/nginx-curl",
+				ImageID:    "sha256:2e00ae64383cfc865ba0a2ba37f61b50a120d2d9378559dcd458dc0de47bc165",
+				Limits: map[string]uint64{
+					"CPU":    0,
+					"Memory": 0,
+				},
+				KnownStatus: "PULLED",
+			},
+			taskLimits: map[string]float64{},
+			want: &containers.Container{
+				EntityID:    "container_id://43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
+				ID:          "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
+				Image:       "nrdlngr/nginx-curl",
+				ImageID:     "sha256:2e00ae64383cfc865ba0a2ba37f61b50a120d2d9378559dcd458dc0de47bc165",
+				Name:        "ecs-nginx-5-nginx-curl-ccccb9f49db0dfe0d901",
+				Type:        "ECS",
+				AddressList: []containers.NetworkAddress{},
+				Limits:      metrics.ContainerLimits{CPULimit: 100},
+			},
+		},
+		{
+			name: "no started date",
+			c: v2.Container{
+				CreatedAt:  "2018-02-01T20:55:10.554941919Z",
+				DockerID:   "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
+				DockerName: "ecs-nginx-5-nginx-curl-ccccb9f49db0dfe0d901",
+				Image:      "nrdlngr/nginx-curl",
+				ImageID:    "sha256:2e00ae64383cfc865ba0a2ba37f61b50a120d2d9378559dcd458dc0de47bc165",
+				Limits: map[string]uint64{
+					"CPU":    512,
+					"Memory": 1024,
+				},
+				KnownStatus: "CREATED",
+			},
+			taskLimits: map[string]float64{"CPU": 1, "Memory": 2048},
+			want: &containers.Container{
+				Created:     1517518510,
+				EntityID:    "container_id://43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
+				ID:          "43481a6ce4842eec8fe72fc28500c6b52edcc0917f105b83379f88cac1ff3946",
+				Image:       "nrdlngr/nginx-curl",
+				ImageID:     "sha256:2e00ae64383cfc865ba0a2ba37f61b50a120d2d9378559dcd458dc0de47bc165",
+				Name:        "ecs-nginx-5-nginx-curl-ccccb9f49db0dfe0d901",
+				Type:        "ECS",
+				AddressList: []containers.NetworkAddress{},
+				Limits:      metrics.ContainerLimits{CPULimit: 50, MemLimit: 1024000000},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			assert.Equal(t, tt.want, convertMetaV2Container(tt.c, tt.taskLimits))
+			data, dateError := convertMetaV2Container(tt.c, tt.taskLimits)
+			assert.Equal(t, tt.want, data)
+			assert.Equal(t, "", dateError)
 		})
 	}
 }

--- a/pkg/util/ecs/common_test.go
+++ b/pkg/util/ecs/common_test.go
@@ -166,7 +166,7 @@ func TestConvertMetaV2Container(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			data, dateError := convertMetaV2Container(tt.c, tt.taskLimits)
 			assert.Equal(t, tt.want, data)
-			assert.Equal(t, "", dateError)
+			assert.Equal(t, nil, dateError)
 		})
 	}
 }

--- a/releasenotes/notes/fix-fargate-container-dates-errors-acb43bcbb856d37a.yaml
+++ b/releasenotes/notes/fix-fargate-container-dates-errors-acb43bcbb856d37a.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    An error log was printed when the creation date or the started date 
+    of a fargate container was not found in the fargate API payload. 
+    This would happen even though it was expected to not have these dates
+    because of the container being in a given state. 
+    This is now fixed and the error is only printed when it should be.


### PR DESCRIPTION
### What does this PR do?

This PR changes the error log logic in the parsing of a container in fargate api v2.
Before, we were sending an error whenever dates couldn't be parsed which didn't account for the fact that dates are not present when the containers are in the state PULLED and CREATED.
This can happen if the container starts after the datadog agent for example.
The code will now only send an error if a created date and start date cannot be parsed and if the container is not in a PULLED or CREATED state.


### Motivation

Customer reported error logs like:
`Unable to determine creation time for container ***************************0d744-2858448025 - parsing time "" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "2006"` when running the agent on Fargate.

This is a harmless log in specific cases so I wanted to make sure that these logs are displayed only when something is wrong.

### Additional Notes



### Describe how to test your changes

I replicated the issue by adding a health check command to the agent:

```
"healthCheck": {
      "retries": 2,
      "command": [
        "CMD-SHELL",
        "/probe.sh"
      ],
}
```

and by having another container depend on the HEALTHY condition of the datadog agent container:

```
"dependsOn": [
  {
    "containerName": "datadog-agent-fargate",
    "condition": "HEALTHY"
  }]
  ```
  
  This will start this container after a few minutes the agent is started.