### PR TITLE
[backport] Update rhel-81 image for 7.28.x branch

### DIFF
--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -5,7 +5,7 @@
                 "centos-69": "urn,OpenLogic:CentOS:6.9:6.9.20180530",
                 "centos-76": "urn,OpenLogic:CentOS:7.6:7.6.201909120",
                 "centos-77": "urn,OpenLogic:CentOS:7.7:7.7.201912090",
-                "rhel-81": "urn,RedHat:RHEL:8.1:8.1.2020020415"
+                "rhel-81": "urn,RedHat:RHEL:8.1:8.1.2021040910"
             }
         },
         "ec2": {


### PR DESCRIPTION
### What does this PR do?

This PR backports a pipeline fix from https://github.com/DataDog/datadog-agent/pull/8124 to `7.28.x` branch

### Motivation

Pipeline for 7.28 is failing

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
