### PR TITLE
[ec2] use aws provided credentials to fetch tags

### DIFF
--- a/pkg/util/ec2/ec2_tags.go
+++ b/pkg/util/ec2/ec2_tags.go
@@ -34,6 +34,18 @@ func fetchEc2Tags() ([]string, error) {
 		return nil, err
 	}
 
+	// First, try automatic credentials detection. This works in most scenarios,
+	// except when a more specific role (e.g. task role in ECS) does not have
+	// EC2:DescribeTags permission, but a more general role (e.g. instance role)
+	// does have it.
+	tags, err := getTagsWithCreds(instanceIdentity, nil)
+	if err == nil {
+		return tags, nil
+	}
+	log.Warnf("unable to get tags using default credentials (falling back to instance role): %s", err)
+
+	// If the above fails, for backward compatibility, fall back to our legacy
+	// behavior, where we explicitly query instance role to get credentials.
 	iamParams, err := getSecurityCreds()
 	if err != nil {
 		return nil, err
@@ -43,6 +55,10 @@ func fetchEc2Tags() ([]string, error) {
 		iamParams.SecretAccessKey,
 		iamParams.Token)
 
+	return getTagsWithCreds(instanceIdentity, awsCreds)
+}
+
+func getTagsWithCreds(instanceIdentity *ec2Identity, awsCreds *credentials.Credentials) ([]string, error) {
 	awsSess, err := session.NewSession(&aws.Config{
 		Region:      aws.String(instanceIdentity.Region),
 		Credentials: awsCreds,

--- a/releasenotes/notes/ec2-tags-b88f992e36ca4120.yaml
+++ b/releasenotes/notes/ec2-tags-b88f992e36ca4120.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    Support fetching host tags using ECS task and EKS IAM roles.


### PR DESCRIPTION
### What does this PR do?

ECS task role and EKS service account can be used to provide required
permissions to the agent without exposing them to other processes.

This PR changes agent behavior to fetch tags using these task or pod
specific credentials first. For compatibility with the current
version, we fall back to instance role credentials if we fail fetching
tags using task- or pod-specific credentials.

### Describe how to test your changes

Test following configurations and check that agent is able to retrieve instance tags in all cases:

1. as a ECS task
   - with no task role assigned
   - with task role assigned that does not have `EC2:DescribeTags` permission
   - with task role assigned that has `EC2:DescribeTags` permissions
2. as a pod on EKS backed by EC2 instances
   1. when instance role has `EC2:DescribeTags` permission (usually via `AmazonEKS_CNI_Policy`)
	  - without a service account
	  - with a service account that does not have `EC2:DescribeTags` permission
	  - with a service account that has `EC2:DescribeTags` permission
   2. when instance role does not have `EC2:DescribeTags` permission
	  - with a service account that has `EC2:DescribeTags` permission
