### PR TITLE
[Tagger] Update container_name after Docker container rename

### DIFF
--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -103,7 +103,7 @@ func (c *DockerCollector) processEvent(e *docker.ContainerEvent) {
 	switch e.Action {
 	case "die":
 		info = &TagInfo{Entity: e.ContainerEntityName(), Source: dockerCollectorName, DeleteEntity: true}
-	case "start":
+	case "start", "rename":
 		low, orchestrator, high, standard, err := c.fetchForDockerID(e.ContainerID)
 		if err != nil {
 			log.Debugf("Error fetching tags for container '%s': %v", e.ContainerName, err)

--- a/releasenotes/notes/docker-rename-container-tags-4de31f200132a6ab.yaml
+++ b/releasenotes/notes/docker-rename-container-tags-4de31f200132a6ab.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixes the container_name tag not being updated after Docker containers were
+    renamed.


### PR DESCRIPTION
### What does this PR do?

Before, we only looked at the `start` and `die` events coming from the
Docker daemon. That is ok for most tags, since most of the data is
immutable. That is not the case for the `container_name` tag though,
since Docker containers can be renamed after they are start. Now, we
re-calculate all of the Docker container tags also on `rename` events,
fixing the `container_name` tag.

### Describe how to test your changes

* [Run the agent as a standalone container](https://docs.datadoghq.com/agent/docker/?tab=standard#setup).
* Start a long-running container:

```
$ docker run busybox sleep infinity &
```

* Run `agent tagger-list`, and check that the `container_name` tag matches the container name from `docker ps`.
* Rename the container with `docker container rename <current name> <new name>`
* Run `agent tagger-list`, and check that the `container_name` tag matches the new name.