### PR TITLE
[networks] Add module-restart command

### DIFF
--- a/cmd/system-probe/api/config.go
+++ b/cmd/system-probe/api/config.go
@@ -7,11 +7,9 @@ import (
 )
 
 // setupConfigHandlers adds the specific handlers for /config endpoints
-func setupConfigHandlers(r *mux.Router) *mux.Router {
-	r.HandleFunc("/", settingshttp.Server.GetFull(config.Namespace)).Methods("GET")
-	r.HandleFunc("/list-runtime", settingshttp.Server.ListConfigurable).Methods("GET")
-	r.HandleFunc("/{setting}", settingshttp.Server.GetValue).Methods("GET")
-	r.HandleFunc("/{setting}", settingshttp.Server.SetValue).Methods("POST")
-
-	return r
+func setupConfigHandlers(r *mux.Router) {
+	r.HandleFunc("/config/", settingshttp.Server.GetFull(config.Namespace)).Methods("GET")
+	r.HandleFunc("/config/list-runtime", settingshttp.Server.ListConfigurable).Methods("GET")
+	r.HandleFunc("/config/{setting}", settingshttp.Server.GetValue).Methods("GET")
+	r.HandleFunc("/config/{setting}", settingshttp.Server.SetValue).Methods("POST")
 }

--- a/cmd/system-probe/api/config.go
+++ b/cmd/system-probe/api/config.go
@@ -8,7 +8,7 @@ import (
 
 // setupConfigHandlers adds the specific handlers for /config endpoints
 func setupConfigHandlers(r *mux.Router) {
-	r.HandleFunc("/config/", settingshttp.Server.GetFull(config.Namespace)).Methods("GET")
+	r.HandleFunc("/config", settingshttp.Server.GetFull(config.Namespace)).Methods("GET")
 	r.HandleFunc("/config/list-runtime", settingshttp.Server.ListConfigurable).Methods("GET")
 	r.HandleFunc("/config/{setting}", settingshttp.Server.GetValue).Methods("GET")
 	r.HandleFunc("/config/{setting}", settingshttp.Server.SetValue).Methods("POST")

--- a/cmd/system-probe/api/module/common.go
+++ b/cmd/system-probe/api/module/common.go
@@ -2,9 +2,9 @@ package module
 
 import (
 	"errors"
-	"net/http"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	"github.com/gorilla/mux"
 )
 
 // ErrNotEnabled is a special error type that should be returned by a Factory
@@ -20,6 +20,6 @@ type Factory struct {
 // Module defines the common API implemented by every System Probe Module
 type Module interface {
 	GetStats() map[string]interface{}
-	Register(*http.ServeMux) error
+	Register(*mux.Router) error
 	Close()
 }

--- a/cmd/system-probe/api/module/loader.go
+++ b/cmd/system-probe/api/module/loader.go
@@ -94,7 +94,11 @@ func RestartModule(factory Factory) error {
 		return err
 	}
 
-	moduleInstance.Register(l.httpMux)
+	err = moduleInstance.Register(l.httpMux)
+	if err != nil {
+		return err
+	}
+
 	l.modules[factory.Name] = moduleInstance
 	return nil
 }

--- a/cmd/system-probe/api/module/loader.go
+++ b/cmd/system-probe/api/module/loader.go
@@ -85,6 +85,10 @@ func RestartModule(factory Factory) error {
 	l.Lock()
 	defer l.Unlock()
 
+	if l.closed == true {
+		return fmt.Errorf("can't restart module because system-probe is shutting down")
+	}
+
 	currentModule := l.modules[factory.Name]
 	if currentModule == nil {
 		return fmt.Errorf("module %s is not running", factory.Name)

--- a/cmd/system-probe/api/module/loader.go
+++ b/cmd/system-probe/api/module/loader.go
@@ -1,6 +1,7 @@
 package module
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
@@ -86,13 +87,15 @@ func RestartModule(factory Factory) error {
 
 	_, ok := l.modules[factory.Name]
 	if !ok {
-		return errors.New("module not started")
+		return fmt.Errorf("module %s not started", factory.Name)
 	}
 
 	moduleInstance, err := factory.Fn(l.cfg)
 	if err != nil {
 		return err
 	}
+
+	log.Infof("module: %s restarted", factory.Name)
 
 	err = moduleInstance.Register(l.httpMux)
 	if err != nil {

--- a/cmd/system-probe/api/restart.go
+++ b/cmd/system-probe/api/restart.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
+	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	"github.com/DataDog/datadog-agent/cmd/system-probe/modules"
+	"github.com/gorilla/mux"
+)
+
+func restartModuleHandler(w http.ResponseWriter, r *http.Request) {
+	vars := mux.Vars(r)
+	moduleName := config.ModuleName(vars["module-name"])
+
+	var target module.Factory
+	for _, f := range modules.All {
+		if f.Name == moduleName {
+			target = f
+		}
+	}
+
+	if target.Name != moduleName {
+		http.Error(w, fmt.Sprintf("invalid module: %s", moduleName), http.StatusBadRequest)
+		return
+	}
+
+	err := module.RestartModule(target)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+}

--- a/cmd/system-probe/api/server.go
+++ b/cmd/system-probe/api/server.go
@@ -20,7 +20,7 @@ func StartServer(cfg *config.Config) error {
 		return fmt.Errorf("error creating IPC socket: %s", err)
 	}
 
-	mux := http.NewServeMux()
+	mux := gorilla.NewRouter()
 	err = module.Register(cfg, mux, modules.All)
 	if err != nil {
 		return fmt.Errorf("failed to create system probe: %s", err)
@@ -32,8 +32,10 @@ func StartServer(cfg *config.Config) error {
 		utils.WriteAsJSON(w, stats)
 	})
 
-	configMux := gorilla.NewRouter()
-	mux.Handle("/config/", http.StripPrefix("/config", setupConfigHandlers(configMux)))
+	setupConfigHandlers(mux)
+
+	// Module-restart handler
+	mux.HandleFunc("/module-restart/{module-name}", restartModuleHandler).Methods("POST")
 
 	go func() {
 		err = http.Serve(conn.GetListener(), mux)

--- a/cmd/system-probe/app/restart.go
+++ b/cmd/system-probe/app/restart.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package app
+
+import (
+	"fmt"
+	"io/ioutil"
+
+	"github.com/DataDog/datadog-agent/cmd/system-probe/api"
+	"github.com/spf13/cobra"
+)
+
+func init() {
+	SysprobeCmd.AddCommand(moduleRestartCommand)
+}
+
+var moduleRestartCommand = &cobra.Command{
+	Use:   "module-restart [module]",
+	Short: "Restart a given system-probe module",
+	Long:  ``,
+	RunE:  moduleRestart,
+}
+
+func moduleRestart(_ *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("module-restart: wrong number of arguments")
+	}
+
+	cfg, err := setupConfig()
+	if err != nil {
+		return err
+	}
+	client := api.GetClient(cfg.SocketAddress)
+	url := fmt.Sprintf("http://localhost/module-restart/%s", args[0])
+	resp, err := client.Post(url, "", nil)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		body, _ := ioutil.ReadAll(resp.Body)
+		err := fmt.Errorf("error restarting module: %s", body)
+		return err
+	}
+
+	return nil
+}

--- a/cmd/system-probe/app/restart.go
+++ b/cmd/system-probe/app/restart.go
@@ -22,13 +22,10 @@ var moduleRestartCommand = &cobra.Command{
 	Short: "Restart a given system-probe module",
 	Long:  ``,
 	RunE:  moduleRestart,
+	Args:  cobra.ExactArgs(1),
 }
 
 func moduleRestart(_ *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return fmt.Errorf("module-restart: wrong number of arguments")
-	}
-
 	cfg, err := setupConfig()
 	if err != nil {
 		return err

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/encoding"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/gorilla/mux"
 )
 
 // ErrSysprobeUnsupported is the unsupported error prefix, for error-class matching from callers
@@ -59,7 +60,7 @@ func (nt *networkTracer) GetStats() map[string]interface{} {
 }
 
 // Register all networkTracer endpoints
-func (nt *networkTracer) Register(httpMux *http.ServeMux) error {
+func (nt *networkTracer) Register(httpMux *mux.Router) error {
 	var runCounter uint64
 
 	httpMux.HandleFunc("/connections", func(w http.ResponseWriter, req *http.Request) {

--- a/cmd/system-probe/modules/oom_kill_probe.go
+++ b/cmd/system-probe/modules/oom_kill_probe.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 )
 
@@ -33,7 +34,7 @@ type oomKillModule struct {
 	*probe.OOMKillProbe
 }
 
-func (o *oomKillModule) Register(httpMux *http.ServeMux) error {
+func (o *oomKillModule) Register(httpMux *mux.Router) error {
 	httpMux.HandleFunc("/check/oom_kill", func(w http.ResponseWriter, req *http.Request) {
 		stats := o.OOMKillProbe.GetAndFlush()
 		utils.WriteAsJSON(w, stats)

--- a/cmd/system-probe/modules/process.go
+++ b/cmd/system-probe/modules/process.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/encoding"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/gorilla/mux"
 )
 
 // ErrProcessUnsupported is an error type indicating that the process module is not support in the running environment
@@ -45,7 +46,7 @@ func (t *process) GetStats() map[string]interface{} {
 }
 
 // Register registers endpoints for the module to expose data
-func (t *process) Register(httpMux *http.ServeMux) error {
+func (t *process) Register(httpMux *mux.Router) error {
 	var runCounter uint64
 	httpMux.HandleFunc("/proc/stats", func(w http.ResponseWriter, req *http.Request) {
 		start := time.Now()

--- a/cmd/system-probe/modules/tcp_queue_tracer.go
+++ b/cmd/system-probe/modules/tcp_queue_tracer.go
@@ -10,6 +10,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/system-probe/utils"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
+	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 )
 
@@ -32,7 +33,7 @@ type tcpQueueLengthModule struct {
 	*probe.TCPQueueLengthTracer
 }
 
-func (t *tcpQueueLengthModule) Register(httpMux *http.ServeMux) error {
+func (t *tcpQueueLengthModule) Register(httpMux *mux.Router) error {
 	httpMux.HandleFunc("/check/tcp_queue_length", func(w http.ResponseWriter, req *http.Request) {
 		stats := t.TCPQueueLengthTracer.GetAndFlush()
 		utils.WriteAsJSON(w, stats)

--- a/pkg/network/netlink/decoding.go
+++ b/pkg/network/netlink/decoding.go
@@ -47,22 +47,30 @@ func (c Con) String() string {
 	return fmt.Sprintf("netns=%d src=%s dst=%s sport=%d dport=%d src=%s dst=%s sport=%d dport=%d proto=%d", c.NetNS, c.Origin.Src, c.Origin.Dst, *c.Origin.Proto.SrcPort, *c.Origin.Proto.DstPort, c.Reply.Src, c.Reply.Dst, *c.Reply.Proto.SrcPort, *c.Reply.Proto.DstPort, *c.Con.Origin.Proto.Number)
 }
 
-var scanner = NewAttributeScanner()
+type Decoder struct {
+	scanner *AttributeScanner
+}
+
+func NewDecoder() *Decoder {
+	return &Decoder{
+		scanner: NewAttributeScanner(),
+	}
+}
 
 // DecodeAndReleaseEvent decodes a single Event into a slice of []ct.Con objects and
 // releases the underlying buffer.
 // TODO: Replace the intermediate ct.Con object by the same format we use in the cache
-func DecodeAndReleaseEvent(e Event) []Con {
+func (d *Decoder) DecodeAndReleaseEvent(e Event) []Con {
 	msgs := e.Messages()
 	conns := make([]Con, 0, len(msgs))
 
 	for _, msg := range msgs {
 		c := &Con{NetNS: e.netns}
-		if err := scanner.ResetTo(msg.Data); err != nil {
+		if err := d.scanner.ResetTo(msg.Data); err != nil {
 			log.Debugf("error decoding netlink message: %s", err)
 			continue
 		}
-		err := unmarshalCon(scanner, c)
+		err := d.unmarshalCon(c)
 		if err != nil {
 			log.Debugf("error decoding netlink message: %s", err)
 			continue
@@ -76,87 +84,87 @@ func DecodeAndReleaseEvent(e Event) []Con {
 	return conns
 }
 
-func unmarshalCon(s *AttributeScanner, c *Con) error {
+func (d *Decoder) unmarshalCon(c *Con) error {
 	c.Origin = &ct.IPTuple{}
 	c.Reply = &ct.IPTuple{}
 
-	for toDecode := 2; toDecode > 0 && s.Next(); {
-		switch s.Type() {
+	for toDecode := 2; toDecode > 0 && d.scanner.Next(); {
+		switch d.scanner.Type() {
 		case ctaTupleOrig:
 			toDecode--
-			s.Nested(func() error {
-				return unmarshalTuple(s, c.Origin)
+			d.scanner.Nested(func() error {
+				return d.unmarshalTuple(c.Origin)
 			})
 		case ctaTupleReply:
 			toDecode--
-			s.Nested(func() error {
-				return unmarshalTuple(s, c.Reply)
+			d.scanner.Nested(func() error {
+				return d.unmarshalTuple(c.Reply)
 			})
 		}
 	}
 
-	return s.Err()
+	return d.scanner.Err()
 }
 
-func unmarshalTuple(s *AttributeScanner, t *ct.IPTuple) error {
-	for toDecode := 2; toDecode > 0 && s.Next(); {
-		switch s.Type() {
+func (d *Decoder) unmarshalTuple(t *ct.IPTuple) error {
+	for toDecode := 2; toDecode > 0 && d.scanner.Next(); {
+		switch d.scanner.Type() {
 		case ctaTupleIP:
 			toDecode--
-			s.Nested(func() error {
-				return unmarshalTupleIP(s, t)
+			d.scanner.Nested(func() error {
+				return d.unmarshalTupleIP(t)
 			})
 		case ctaTupleProto:
 			toDecode--
-			s.Nested(func() error {
-				return unmarshalProto(s, t)
+			d.scanner.Nested(func() error {
+				return d.unmarshalProto(t)
 			})
 		}
 	}
-	return s.Err()
+	return d.scanner.Err()
 }
 
 // We might also want to consider deferring the allocation of the IP byte slice
-func unmarshalTupleIP(s *AttributeScanner, t *ct.IPTuple) error {
-	for toDecode := 2; toDecode > 0 && s.Next(); {
-		switch s.Type() {
+func (d *Decoder) unmarshalTupleIP(t *ct.IPTuple) error {
+	for toDecode := 2; toDecode > 0 && d.scanner.Next(); {
+		switch d.scanner.Type() {
 		case ctaIPv4Src, ctaIPv6Src:
 			toDecode--
-			data := copySlice(s.Bytes())
+			data := copySlice(d.scanner.Bytes())
 			ip := net.IP(data)
 			t.Src = &ip
 		case ctaIPv4Dst, ctaIPv6Dst:
 			toDecode--
-			data := copySlice(s.Bytes())
+			data := copySlice(d.scanner.Bytes())
 			ip := net.IP(data)
 			t.Dst = &ip
 		}
 	}
 
-	return s.Err()
+	return d.scanner.Err()
 }
 
-func unmarshalProto(s *AttributeScanner, t *ct.IPTuple) error {
+func (d *Decoder) unmarshalProto(t *ct.IPTuple) error {
 	t.Proto = &ct.ProtoTuple{}
 
-	for toDecode := 3; toDecode > 0 && s.Next(); {
-		switch s.Type() {
+	for toDecode := 3; toDecode > 0 && d.scanner.Next(); {
+		switch d.scanner.Type() {
 		case ctaProtoNum:
 			toDecode--
-			protoNum := s.Bytes()[0]
+			protoNum := d.scanner.Bytes()[0]
 			t.Proto.Number = &protoNum
 		case ctaProtoSrcPort:
 			toDecode--
-			port := binary.BigEndian.Uint16(s.Bytes())
+			port := binary.BigEndian.Uint16(d.scanner.Bytes())
 			t.Proto.SrcPort = &port
 		case ctaProtoDstPort:
 			toDecode--
-			port := binary.BigEndian.Uint16(s.Bytes())
+			port := binary.BigEndian.Uint16(d.scanner.Bytes())
 			t.Proto.DstPort = &port
 		}
 	}
 
-	return s.Err()
+	return d.scanner.Err()
 }
 
 func copySlice(src []byte) []byte {

--- a/pkg/network/netlink/decoding.go
+++ b/pkg/network/netlink/decoding.go
@@ -47,10 +47,12 @@ func (c Con) String() string {
 	return fmt.Sprintf("netns=%d src=%s dst=%s sport=%d dport=%d src=%s dst=%s sport=%d dport=%d proto=%d", c.NetNS, c.Origin.Src, c.Origin.Dst, *c.Origin.Proto.SrcPort, *c.Origin.Proto.DstPort, c.Reply.Src, c.Reply.Dst, *c.Reply.Proto.SrcPort, *c.Reply.Proto.DstPort, *c.Con.Origin.Proto.Number)
 }
 
+// Decoder is responsible for decoding netlink messages
 type Decoder struct {
 	scanner *AttributeScanner
 }
 
+// NewDecoder returns a new netlink message Decoder
 func NewDecoder() *Decoder {
 	return &Decoder{
 		scanner: NewAttributeScanner(),

--- a/pkg/network/netlink/decoding_test.go
+++ b/pkg/network/netlink/decoding_test.go
@@ -25,7 +25,9 @@ func TestDecodeAndReleaseEvent(t *testing.T) {
 			},
 		},
 	}
-	connections := DecodeAndReleaseEvent(e)
+
+	decoder := NewDecoder()
+	connections := decoder.DecodeAndReleaseEvent(e)
 	assert.Len(t, connections, 1)
 	c := connections[0]
 
@@ -52,10 +54,11 @@ func BenchmarkDecodeSingleMessage(b *testing.B) {
 	}
 
 	e := Event{msgs: messages[:1]}
+	decoder := NewDecoder()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		DecodeAndReleaseEvent(e)
+		decoder.DecodeAndReleaseEvent(e)
 	}
 }
 
@@ -67,10 +70,11 @@ func BenchmarkDecodeMultipleMessages(b *testing.B) {
 	}
 
 	e := Event{msgs: messages}
+	decoder := NewDecoder()
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		DecodeAndReleaseEvent(e)
+		decoder.DecodeAndReleaseEvent(e)
 	}
 }
 

--- a/pkg/network/netlink/encoding_test.go
+++ b/pkg/network/netlink/encoding_test.go
@@ -43,7 +43,8 @@ func TestEncodeConn(t *testing.T) {
 	require.NoError(t, err)
 	require.NotEmpty(t, data)
 
-	connections := DecodeAndReleaseEvent(Event{
+	decoder := NewDecoder()
+	connections := decoder.DecodeAndReleaseEvent(Event{
 		msgs: []netlink.Message{
 			{
 				Data: data,

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -12,7 +12,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"net/http"
 	"os"
 	"os/signal"
 	"sync"
@@ -20,6 +19,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
@@ -57,7 +57,7 @@ type Module struct {
 }
 
 // Register the runtime security agent module
-func (m *Module) Register(httpMux *http.ServeMux) error {
+func (m *Module) Register(_ *mux.Router) error {
 	// force socket cleanup of previous socket not cleanup
 	os.Remove(m.config.SocketPath)
 


### PR DESCRIPTION
### What does this PR do?

Add ability to restart system-probe modules during runtime.

#### TODOs:
- [x] Figure out how we want to do error handling on Cobra;
- [x] Investigate netlink panics after module-restart;

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Run `system-probe module-restart network_tracer` and verify that the network_tracer module restarts without affecting other modules.
