### PR TITLE
Do not add init duration of 0.00 ms to REPORT log lines

### DIFF
--- a/pkg/serverless/aws/logs.go
+++ b/pkg/serverless/aws/logs.go
@@ -111,37 +111,27 @@ func (l *LogMessage) UnmarshalJSON(data []byte) error {
 					l.ObjectRecord.RequestID,
 				)
 			case LogTypePlatformReport:
-				// only logTypePlatformReport has what we call "enhanced metrics"
-				if typ == LogTypePlatformReport {
-					if metrics, ok := objectRecord["metrics"].(map[string]interface{}); ok {
-						if v, ok := metrics["durationMs"].(float64); ok {
-							l.ObjectRecord.Metrics.DurationMs = v
-						}
-						if v, ok := metrics["billedDurationMs"].(float64); ok {
-							l.ObjectRecord.Metrics.BilledDurationMs = int(v)
-						}
-						if v, ok := metrics["memorySizeMB"].(float64); ok {
-							l.ObjectRecord.Metrics.MemorySizeMB = int(v)
-						}
-						if v, ok := metrics["maxMemoryUsedMB"].(float64); ok {
-							l.ObjectRecord.Metrics.MaxMemoryUsedMB = int(v)
-						}
-						if v, ok := metrics["initDurationMs"].(float64); ok {
-							l.ObjectRecord.Metrics.InitDurationMs = v
-						}
-						log.Debugf("Enhanced metrics: %+v\n", l.ObjectRecord.Metrics)
-					} else {
-						log.Error("LogMessage.UnmarshalJSON: can't read the metrics object")
+				if metrics, ok := objectRecord["metrics"].(map[string]interface{}); ok {
+					if v, ok := metrics["durationMs"].(float64); ok {
+						l.ObjectRecord.Metrics.DurationMs = v
 					}
-					l.StringRecord = fmt.Sprintf("REPORT RequestId: %s	Duration: %.2f ms    	Billed Duration: %d ms	Memory Size: %d MB	Max Memory Used: %d MB	Init Duration: %.2f ms",
-						l.ObjectRecord.RequestID,
-						l.ObjectRecord.Metrics.DurationMs,
-						l.ObjectRecord.Metrics.BilledDurationMs,
-						l.ObjectRecord.Metrics.MemorySizeMB,
-						l.ObjectRecord.Metrics.MaxMemoryUsedMB,
-						l.ObjectRecord.Metrics.InitDurationMs,
-					)
+					if v, ok := metrics["billedDurationMs"].(float64); ok {
+						l.ObjectRecord.Metrics.BilledDurationMs = int(v)
+					}
+					if v, ok := metrics["memorySizeMB"].(float64); ok {
+						l.ObjectRecord.Metrics.MemorySizeMB = int(v)
+					}
+					if v, ok := metrics["maxMemoryUsedMB"].(float64); ok {
+						l.ObjectRecord.Metrics.MaxMemoryUsedMB = int(v)
+					}
+					if v, ok := metrics["initDurationMs"].(float64); ok {
+						l.ObjectRecord.Metrics.InitDurationMs = v
+					}
+					log.Debugf("Enhanced metrics: %+v\n", l.ObjectRecord.Metrics)
+				} else {
+					log.Error("LogMessage.UnmarshalJSON: can't read the metrics object")
 				}
+				l.StringRecord = createStringRecordForReportLog(l)
 			}
 		} else {
 			log.Error("LogMessage.UnmarshalJSON: can't read the record object")
@@ -151,4 +141,19 @@ func (l *LogMessage) UnmarshalJSON(data []byte) error {
 	}
 
 	return nil
+}
+
+func createStringRecordForReportLog(l *LogMessage) string {
+	stringRecord := fmt.Sprintf("REPORT RequestId: %s\tDuration: %.2f ms\tBilled Duration: %d ms\tMemory Size: %d MB\tMax Memory Used: %d MB",
+		l.ObjectRecord.RequestID,
+		l.ObjectRecord.Metrics.DurationMs,
+		l.ObjectRecord.Metrics.BilledDurationMs,
+		l.ObjectRecord.Metrics.MemorySizeMB,
+		l.ObjectRecord.Metrics.MaxMemoryUsedMB,
+	)
+	if l.ObjectRecord.Metrics.InitDurationMs > 0 {
+		stringRecord = stringRecord + fmt.Sprintf("\tInit Duration: %.2f ms", l.ObjectRecord.Metrics.InitDurationMs)
+	}
+
+	return stringRecord
 }

--- a/pkg/serverless/aws/logs_test.go
+++ b/pkg/serverless/aws/logs_test.go
@@ -1,0 +1,47 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateStringRecordForReportLogWithInitDuration(t *testing.T) {
+	var sampleLogMessage = LogMessage{
+		ObjectRecord: PlatformObjectRecord{
+			RequestID: "cf84ebaf-606a-4b0f-b99b-3685bfe973d7",
+			Metrics: ReportLogMetrics{
+				DurationMs:       100.00,
+				BilledDurationMs: 100,
+				MemorySizeMB:     128,
+				MaxMemoryUsedMB:  128,
+				InitDurationMs:   50.00,
+			},
+		},
+	}
+	output := createStringRecordForReportLog(&sampleLogMessage)
+	expectedOutput := "REPORT RequestId: cf84ebaf-606a-4b0f-b99b-3685bfe973d7\tDuration: 100.00 ms\tBilled Duration: 100 ms\tMemory Size: 128 MB\tMax Memory Used: 128 MB\tInit Duration: 50.00 ms"
+	assert.Equal(t, expectedOutput, output)
+}
+
+func TestCreateStringRecordForReportLogWithoutInitDuration(t *testing.T) {
+	var sampleLogMessage = LogMessage{
+		ObjectRecord: PlatformObjectRecord{
+			RequestID: "cf84ebaf-606a-4b0f-b99b-3685bfe973d7",
+			Metrics: ReportLogMetrics{
+				DurationMs:       100.00,
+				BilledDurationMs: 100,
+				MemorySizeMB:     128,
+				MaxMemoryUsedMB:  128,
+			},
+		},
+	}
+	output := createStringRecordForReportLog(&sampleLogMessage)
+	expectedOutput := "REPORT RequestId: cf84ebaf-606a-4b0f-b99b-3685bfe973d7\tDuration: 100.00 ms\tBilled Duration: 100 ms\tMemory Size: 128 MB\tMax Memory Used: 128 MB"
+	assert.Equal(t, expectedOutput, output)
+}

--- a/pkg/serverless/aws/logs_test.go
+++ b/pkg/serverless/aws/logs_test.go
@@ -38,6 +38,7 @@ func TestCreateStringRecordForReportLogWithoutInitDuration(t *testing.T) {
 				BilledDurationMs: 100,
 				MemorySizeMB:     128,
 				MaxMemoryUsedMB:  128,
+				InitDurationMs:   0.00,
 			},
 		},
 	}


### PR DESCRIPTION
### What does this PR do?

We receive REPORT log lines from the Lambda Logs API as JSON objects. We then construct a log string based on the values in the JSON. Previously, we would add an `InitDuration` to the string even if the value of this metric was `0.00 ms`. This does not match the behavior of CloudWatch logs, which exclude the value if there is no init duration.

We rely on the presence or absence of the init duration metric to mark invocations as cold starts; if there is an init duration present, we consider that invocation a cold start. Because we were erroneously adding `InitDuration` to all REPORT log lines, we were also erroneously marking all invocations as cold starts.

### Motivation

- Match behavior of CloudWatch logs
- Stop erroneously marking all invocations as cold starts

### Describe how to test your changes

- Unit tests
- Manual testing
