### PR TITLE
[kitchen] Update SLES images

### DIFF
--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -39,8 +39,8 @@
     "suse" : {
         "azure": {
             "x86_64": {
-                "sles-12": "urn,SUSE:sles-12-sp5-byos:gen1:2020.09.21",
-                "sles-15": "urn,SUSE:sles-15-sp2-byos:gen1:2020.09.21"
+                "sles-12": "urn,SUSE:sles-12-sp5-byos:gen1:2021.03.03",
+                "sles-15": "urn,SUSE:sles-15-sp2-byos:gen1:2021.03.03"
             }
         },
         "ec2": {


### PR DESCRIPTION
### What does this PR do?

Updates the VM images used in SLES kitchen tests.

### Motivation

The previous images got removed from Azure.

