### PR TITLE
Add /pkg/serverless/ to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -129,6 +129,7 @@
 /pkg/metadata/                          @DataDog/agent-core
 /pkg/metrics/                           @DataDog/agent-core
 /pkg/serializer/                        @DataDog/agent-core
+/pkg/serverless/                        @DataDog/serverless
 /pkg/status/                            @DataDog/agent-core
 /pkg/telemetry/                         @DataDog/agent-core
 /pkg/version/                           @DataDog/agent-core

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -238,6 +238,7 @@ GITHUB_SLACK_MAP = {
     "@DataDog/agent-core": "#agent-core",
     "@DataDog/container-app": "#container-app",
     "@Datadog/metrics-aggregation": "#metrics-aggregation",
+    "@Datadog/serverless": "#serverless-agent",
     "@DataDog/agent-all": "#datadog-agent-pipelines",
 }
 


### PR DESCRIPTION
### Motivation

I think this is the right assignment, instead of agent-core which was the previous default.
