### PR TITLE
Remove docker configuration from macOS build

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -202,6 +202,9 @@ build do
 
             # remove windows specific configs
             delete "#{install_dir}/etc/conf.d/winproc.d"
+            
+            # remove docker configuration
+            delete "#{install_dir}/etc/conf.d/docker.d"
 
             if ENV['HARDENED_RUNTIME_MAC'] == 'true'
                 hardened_runtime = "-o runtime --entitlements #{entitlements_file} "


### PR DESCRIPTION
### What does this PR do?

Remove `docker` check configuration folder from macOS build.

### Motivation

Since the integration is enabled by default it caused a bunch of warnings when running commands on Mac:

```
  Loading Errors
  ==============
    docker
    ------
      Core Check Loader:
        Check docker not found in Catalog      JMX Check Loader:
        check is not a jmx check, or unable to determine if it's so      Python Check Loader:
        unable to import module 'docker': No module named 'docker'
```

### Additional Notes

Follow up to #7234.

Created pipeline with macOS build with `inv -e pipeline.run -a -g mx-psi/remove-docker.d --no-kitchen-tests`, see https://github.com/DataDog/datadog-agent-macos-build/runs/2583214743?check_suite_focus=true#step:8:4338:
```
[Builder: datadog-agent-finalize] I | 2021-05-14T11:45:24+00:00 | delete `/opt/datadog-agent/etc/conf.d/docker.d': 0.0005s
```

### Describe how to test your changes

0. (if needed) Remove any existing configuration for the Datadog Agent on the `/opt/datadog-agent` folder.
1. Do a fresh install of the macOS Datadog Agent.
2. Run the `status` and `check` subcommands and check that the output no longer has the `Loading Errors` error.
3. Check that the `docker.d` folder is no longer present (e.g. by running `find /opt/datadog-agent/etc/conf.d -name docker.d`)