### PR TITLE
Add Agent Platform as CODEOWNERS of `internal/tools`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -219,3 +219,5 @@
 /tools/gdb/                             @DataDog/agent-core
 /tools/retry_file_dump/                 @DataDog/agent-core
 /tools/windows/                         @DataDog/agent-platform
+
+/internal/tools/                        @DataDog/agent-platform


### PR DESCRIPTION
### What does this PR do?

Add Agent Platform as CODEOWNERS of `internal/tools` folder.

### Motivation

No one owns it right now.

### Additional Notes

This folder includes the Go tooling versions.
