### PR TITLE
Increase payload size limit for event platform `dbm-metrics` forwarder 

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -660,6 +660,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("logs_config.use_tcp", false)
 
 	bindEnvAndSetLogsConfigKeys(config, "logs_config.")
+	bindEnvAndSetLogsConfigKeys(config, "database_monitoring.samples.")
+	bindEnvAndSetLogsConfigKeys(config, "database_monitoring.metrics.")
 
 	config.BindEnvAndSetDefault("logs_config.dd_port", 10516)
 	config.BindEnvAndSetDefault("logs_config.dev_mode_use_proto", true)
@@ -1090,6 +1092,7 @@ func bindEnvAndSetLogsConfigKeys(config Config, prefix string) {
 	config.BindEnvAndSetDefault(prefix+"connection_reset_interval", 0) // in seconds, 0 means disabled
 	config.BindEnvAndSetDefault(prefix+"logs_no_ssl", false)
 	config.BindEnvAndSetDefault(prefix+"batch_max_concurrent_send", DefaultBatchMaxConcurrentSend)
+	config.BindEnvAndSetDefault(prefix+"batch_max_content_size", DefaultBatchMaxContentSize)
 }
 
 // getDomainPrefix provides the right prefix for agent X.Y.Z

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1093,6 +1093,7 @@ func bindEnvAndSetLogsConfigKeys(config Config, prefix string) {
 	config.BindEnvAndSetDefault(prefix+"logs_no_ssl", false)
 	config.BindEnvAndSetDefault(prefix+"batch_max_concurrent_send", DefaultBatchMaxConcurrentSend)
 	config.BindEnvAndSetDefault(prefix+"batch_max_content_size", DefaultBatchMaxContentSize)
+	config.BindEnvAndSetDefault(prefix+"batch_max_size", DefaultBatchMaxSize)
 }
 
 // getDomainPrefix provides the right prefix for agent X.Y.Z

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,6 +55,13 @@ const (
 	// DefaultBatchMaxConcurrentSend is the default HTTP batch max concurrent send for logs
 	DefaultBatchMaxConcurrentSend = 0
 
+	// DefaultBatchMaxSize is the default HTTP batch max size (maximum number of events in a single batch) for logs
+	DefaultBatchMaxSize = 100
+
+	// DefaultBatchMaxContentSize is the default HTTP batch max content size (before compression) for logs
+	// It is also the maximum possible size of a single event. Events exceeding this limit are dropped.
+	DefaultBatchMaxContentSize = 1000000
+
 	// DefaultAuditorTTL is the default logs auditor TTL in hours
 	DefaultAuditorTTL = 23
 

--- a/pkg/epforwarder/epforwarder.go
+++ b/pkg/epforwarder/epforwarder.go
@@ -26,16 +26,19 @@ var passthroughPipelineDescs = []passthroughPipelineDesc{
 		eventType:              eventTypeDBMSamples,
 		endpointsConfigPrefix:  "database_monitoring.samples.",
 		hostnameEndpointPrefix: "dbquery-http-intake.logs.",
-		// ensures pipelines can support 1000s of events per second
+		// raise the default batch_max_concurrent_send from 0 to 10 to ensure this pipeline is able to handle 4k events/s
 		defaultBatchMaxConcurrentSend: 10,
 		defaultBatchMaxContentSize:    pkgconfig.DefaultBatchMaxContentSize,
+		defaultBatchMaxSize:           pkgconfig.DefaultBatchMaxSize,
 	},
 	{
-		eventType:                     eventTypeDBMMetrics,
-		endpointsConfigPrefix:         "database_monitoring.metrics.",
-		hostnameEndpointPrefix:        "dbm-metrics-intake.",
+		eventType:              eventTypeDBMMetrics,
+		endpointsConfigPrefix:  "database_monitoring.metrics.",
+		hostnameEndpointPrefix: "dbm-metrics-intake.",
+		// raise the default batch_max_concurrent_send from 0 to 10 to ensure this pipeline is able to handle 4k events/s
 		defaultBatchMaxConcurrentSend: 10,
 		defaultBatchMaxContentSize:    20e6,
+		defaultBatchMaxSize:           pkgconfig.DefaultBatchMaxSize,
 	},
 }
 
@@ -122,6 +125,7 @@ type passthroughPipelineDesc struct {
 	hostnameEndpointPrefix        string
 	defaultBatchMaxConcurrentSend int
 	defaultBatchMaxContentSize    int
+	defaultBatchMaxSize           int
 }
 
 // newHTTPPassthroughPipeline creates a new HTTP-only event platform pipeline that sends messages directly to intake

--- a/pkg/epforwarder/epforwarder.go
+++ b/pkg/epforwarder/epforwarder.go
@@ -145,6 +145,9 @@ func newHTTPPassthroughPipeline(desc passthroughPipelineDesc, destinationsContex
 	if endpoints.BatchMaxContentSize <= pkgconfig.DefaultBatchMaxContentSize {
 		endpoints.BatchMaxContentSize = desc.defaultBatchMaxContentSize
 	}
+	if endpoints.BatchMaxSize <= pkgconfig.DefaultBatchMaxSize {
+		endpoints.BatchMaxSize = desc.defaultBatchMaxSize
+	}
 	main := http.NewDestination(endpoints.Main, http.JSONContentType, destinationsContext, endpoints.BatchMaxConcurrentSend)
 	additionals := []client.Destination{}
 	for _, endpoint := range endpoints.Additionals {

--- a/pkg/epforwarder/epforwarder.go
+++ b/pkg/epforwarder/epforwarder.go
@@ -154,8 +154,8 @@ func newHTTPPassthroughPipeline(desc passthroughPipelineDesc, destinationsContex
 	inputChan := make(chan *message.Message, 100)
 	strategy := sender.NewBatchStrategy(sender.ArraySerializer, endpoints.BatchWait, endpoints.BatchMaxConcurrentSend, pkgconfig.DefaultBatchMaxSize, endpoints.BatchMaxContentSize, desc.eventType)
 	a := auditor.NewNullAuditor()
-	log.Debugf("Initialized event platform forwarder pipeline. eventType=%s mainHost=%s additionalHosts=%s batch_max_concurrent_send=%d batch_max_content_size=%d",
-		desc.eventType, endpoints.Main.Host, joinHosts(endpoints.Additionals), endpoints.BatchMaxConcurrentSend, endpoints.BatchMaxContentSize)
+	log.Debugf("Initialized event platform forwarder pipeline. eventType=%s mainHost=%s additionalHosts=%s batch_max_concurrent_send=%d batch_max_content_size=%d batch_max_size=%d",
+		desc.eventType, endpoints.Main.Host, joinHosts(endpoints.Additionals), endpoints.BatchMaxConcurrentSend, endpoints.BatchMaxContentSize, endpoints.BatchMaxSize)
 	return &passthroughPipeline{
 		sender:  sender.NewSender(inputChan, a.Channel(), destinations, strategy),
 		in:      inputChan,

--- a/pkg/logs/agent_test.go
+++ b/pkg/logs/agent_test.go
@@ -89,7 +89,7 @@ func (suite *AgentTestSuite) TestAgent() {
 	defer l.Close()
 
 	endpoint := tcp.AddrToEndPoint(l.Addr())
-	endpoints := config.NewEndpoints(endpoint, nil, true, false, 0, 0)
+	endpoints := config.NewEndpoints(endpoint, nil, true, false)
 
 	agent, sources, _ := createAgent(endpoints)
 
@@ -120,7 +120,7 @@ func (suite *AgentTestSuite) TestAgent() {
 
 func (suite *AgentTestSuite) TestAgentStopsWithWrongBackend() {
 	endpoint := config.Endpoint{Host: "fake:", Port: 0}
-	endpoints := config.NewEndpoints(endpoint, nil, true, false, 0, 0)
+	endpoints := config.NewEndpoints(endpoint, nil, true, false)
 
 	agent, sources, _ := createAgent(endpoints)
 
@@ -146,7 +146,7 @@ func (suite *AgentTestSuite) TestAgentStopsWithWrongAdditionalBackend() {
 	endpoint := tcp.AddrToEndPoint(l.Addr())
 	additionalEndpoint := config.Endpoint{Host: "still_fake", Port: 0}
 
-	endpoints := config.NewEndpoints(endpoint, []config.Endpoint{additionalEndpoint}, true, false, 0, 0)
+	endpoints := config.NewEndpoints(endpoint, []config.Endpoint{additionalEndpoint}, true, false)
 
 	agent, sources, _ := createAgent(endpoints)
 

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -332,10 +332,10 @@ func batchWaitFromKey(config coreConfig.Config, batchWaitKey string) time.Durati
 	return (time.Duration(batchWait) * time.Second)
 }
 
-func batchMaxConcurrentSendFromKey(batchMaxConcurrentSendKey string) int {
-	batchMaxConcurrentSend := coreConfig.Datadog.GetInt(batchMaxConcurrentSendKey)
+func batchMaxConcurrentSendFromKey(key string) int {
+	batchMaxConcurrentSend := coreConfig.Datadog.GetInt(key)
 	if batchMaxConcurrentSend < 0 {
-		log.Warnf("Invalid batch_max_concurrent_send: %v should be >= 0, fallback on %v", batchMaxConcurrentSend, coreConfig.DefaultBatchMaxConcurrentSend)
+		log.Warnf("Invalid %s: %v should be >= 0, fallback on %v", key, batchMaxConcurrentSend, coreConfig.DefaultBatchMaxConcurrentSend)
 		return coreConfig.DefaultBatchMaxConcurrentSend
 	}
 	return batchMaxConcurrentSend
@@ -344,7 +344,10 @@ func batchMaxConcurrentSendFromKey(batchMaxConcurrentSendKey string) int {
 func batchMaxSizeFromKey(key string) int {
 	batchMaxSize := coreConfig.Datadog.GetInt(key)
 	if batchMaxSize <= 0 {
-		log.Warnf("Invalid %s: %v should be > 0, fallback on %v", key, batchMaxSize, coreConfig.DefaultBatchMaxSize)
+		// since zero is the default initialized value we don't want to log a warning for it
+		if batchMaxSize < 0 {
+			log.Warnf("Invalid %s: %v should be > 0, fallback on %v", key, batchMaxSize, coreConfig.DefaultBatchMaxSize)
+		}
 		return coreConfig.DefaultBatchMaxSize
 	}
 	return batchMaxSize
@@ -353,7 +356,10 @@ func batchMaxSizeFromKey(key string) int {
 func batchMaxContentSizeFromKey(key string) int {
 	batchMaxContentSize := coreConfig.Datadog.GetInt(key)
 	if batchMaxContentSize <= 0 {
-		log.Warnf("Invalid %s: %v should be > 0, fallback on %v", key, batchMaxContentSize, coreConfig.DefaultBatchMaxContentSize)
+		// since zero is the default initialized value we don't want to log a warning for it
+		if batchMaxContentSize < 0 {
+			log.Warnf("Invalid %s: %v should be > 0, fallback on %v", key, batchMaxContentSize, coreConfig.DefaultBatchMaxContentSize)
+		}
 		return coreConfig.DefaultBatchMaxContentSize
 	}
 	return batchMaxContentSize

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -183,7 +183,7 @@ func buildTCPEndpoints() (*Endpoints, error) {
 		additionals[i].ProxyAddress = proxyAddress
 		additionals[i].APIKey = coreConfig.SanitizeAPIKey(additionals[i].APIKey)
 	}
-	return NewEndpoints(main, additionals, useProto, false, 0, 0), nil
+	return NewEndpoints(main, additionals, useProto, false), nil
 }
 
 // LogsConfigKeys stores logs configuration keys stored in YAML configuration files
@@ -198,6 +198,8 @@ type LogsConfigKeys struct {
 	AdditionalEndpoints     string
 	BatchWait               string
 	BatchMaxConcurrentSend  string
+	BatchMaxSize            string
+	BatchMaxContentSize     string
 }
 
 // logsConfigDefaultKeys defines the default YAML keys used to retrieve logs configuration
@@ -216,6 +218,8 @@ func NewLogsConfigKeys(configPrefix string) LogsConfigKeys {
 		AdditionalEndpoints:     configPrefix + "additional_endpoints",
 		BatchWait:               configPrefix + "batch_wait",
 		BatchMaxConcurrentSend:  configPrefix + "batch_max_concurrent_send",
+		BatchMaxSize:            configPrefix + "batch_max_size",
+		BatchMaxContentSize:     configPrefix + "batch_max_content_size",
 	}
 }
 
@@ -266,8 +270,10 @@ func BuildHTTPEndpointsWithConfig(logsConfig LogsConfigKeys, endpointPrefix stri
 
 	batchWait := batchWaitFromKey(coreConfig.Datadog, logsConfig.BatchWait)
 	batchMaxConcurrentSend := batchMaxConcurrentSendFromKey(logsConfig.BatchMaxConcurrentSend)
+	batchMaxSize := batchMaxSizeFromKey(logsConfig.BatchMaxConcurrentSend)
+	batchMaxContentSize := batchMaxContentSizeFromKey(logsConfig.BatchMaxContentSize)
 
-	return NewEndpoints(main, additionals, false, true, batchWait, batchMaxConcurrentSend), nil
+	return NewEndpointsWithBatchSettings(main, additionals, false, true, batchWait, batchMaxConcurrentSend, batchMaxSize, batchMaxContentSize), nil
 }
 
 func getAdditionalEndpoints() []Endpoint {
@@ -333,6 +339,24 @@ func batchMaxConcurrentSendFromKey(batchMaxConcurrentSendKey string) int {
 		return coreConfig.DefaultBatchMaxConcurrentSend
 	}
 	return batchMaxConcurrentSend
+}
+
+func batchMaxSizeFromKey(key string) int {
+	batchMaxSize := coreConfig.Datadog.GetInt(key)
+	if batchMaxSize <= 0 {
+		log.Warnf("Invalid %s: %v should be > 0, fallback on %v", key, batchMaxSize, coreConfig.DefaultBatchMaxSize)
+		return coreConfig.DefaultBatchMaxSize
+	}
+	return batchMaxSize
+}
+
+func batchMaxContentSizeFromKey(key string) int {
+	batchMaxContentSize := coreConfig.Datadog.GetInt(key)
+	if batchMaxContentSize <= 0 {
+		log.Warnf("Invalid %s: %v should be > 0, fallback on %v", key, batchMaxContentSize, coreConfig.DefaultBatchMaxContentSize)
+		return coreConfig.DefaultBatchMaxContentSize
+	}
+	return batchMaxContentSize
 }
 
 // TaggerWarmupDuration is used to configure the tag providers

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -270,7 +270,7 @@ func BuildHTTPEndpointsWithConfig(logsConfig LogsConfigKeys, endpointPrefix stri
 
 	batchWait := batchWaitFromKey(coreConfig.Datadog, logsConfig.BatchWait)
 	batchMaxConcurrentSend := batchMaxConcurrentSendFromKey(logsConfig.BatchMaxConcurrentSend)
-	batchMaxSize := batchMaxSizeFromKey(logsConfig.BatchMaxConcurrentSend)
+	batchMaxSize := batchMaxSizeFromKey(logsConfig.BatchMaxSize)
 	batchMaxContentSize := batchMaxContentSizeFromKey(logsConfig.BatchMaxContentSize)
 
 	return NewEndpointsWithBatchSettings(main, additionals, false, true, batchWait, batchMaxConcurrentSend, batchMaxSize, batchMaxContentSize), nil
@@ -344,10 +344,7 @@ func batchMaxConcurrentSendFromKey(key string) int {
 func batchMaxSizeFromKey(key string) int {
 	batchMaxSize := coreConfig.Datadog.GetInt(key)
 	if batchMaxSize <= 0 {
-		// since zero is the default initialized value we don't want to log a warning for it
-		if batchMaxSize < 0 {
-			log.Warnf("Invalid %s: %v should be > 0, fallback on %v", key, batchMaxSize, coreConfig.DefaultBatchMaxSize)
-		}
+		log.Warnf("Invalid %s: %v should be > 0, fallback on %v", key, batchMaxSize, coreConfig.DefaultBatchMaxSize)
 		return coreConfig.DefaultBatchMaxSize
 	}
 	return batchMaxSize
@@ -356,10 +353,7 @@ func batchMaxSizeFromKey(key string) int {
 func batchMaxContentSizeFromKey(key string) int {
 	batchMaxContentSize := coreConfig.Datadog.GetInt(key)
 	if batchMaxContentSize <= 0 {
-		// since zero is the default initialized value we don't want to log a warning for it
-		if batchMaxContentSize < 0 {
-			log.Warnf("Invalid %s: %v should be > 0, fallback on %v", key, batchMaxContentSize, coreConfig.DefaultBatchMaxContentSize)
-		}
+		log.Warnf("Invalid %s: %v should be > 0, fallback on %v", key, batchMaxContentSize, coreConfig.DefaultBatchMaxContentSize)
 		return coreConfig.DefaultBatchMaxContentSize
 	}
 	return batchMaxContentSize

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -178,7 +178,8 @@ func (suite *ConfigTestSuite) TestMultipleHttpEndpointsEnvVar() {
 		UseCompression:   true,
 		CompressionLevel: 2}
 
-	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint1, expectedAdditionalEndpoint2}, false, true)
+	expectedEndpoints := NewEndpointsWithBatchSettings(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint1, expectedAdditionalEndpoint2}, false, true,
+		1*time.Second, coreConfig.DefaultBatchMaxConcurrentSend, coreConfig.DefaultBatchMaxSize, coreConfig.DefaultBatchMaxContentSize)
 	endpoints, err := BuildHTTPEndpoints()
 
 	suite.Nil(err)
@@ -264,7 +265,8 @@ func (suite *ConfigTestSuite) TestMultipleHttpEndpointsInConfig() {
 		UseCompression:   true,
 		CompressionLevel: 2}
 
-	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint1, expectedAdditionalEndpoint2}, false, true)
+	expectedEndpoints := NewEndpointsWithBatchSettings(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint1, expectedAdditionalEndpoint2}, false, true,
+		1*time.Second, coreConfig.DefaultBatchMaxConcurrentSend, coreConfig.DefaultBatchMaxSize, coreConfig.DefaultBatchMaxContentSize)
 	endpoints, err := BuildHTTPEndpoints()
 
 	suite.Nil(err)
@@ -330,6 +332,9 @@ func (suite *ConfigTestSuite) TestEndpointsSetLogsDDUrl() {
 			UseCompression:   true,
 			CompressionLevel: 6,
 		},
+		BatchMaxSize:           coreConfig.DefaultBatchMaxSize,
+		BatchMaxContentSize:    coreConfig.DefaultBatchMaxContentSize,
+		BatchMaxConcurrentSend: coreConfig.DefaultBatchMaxConcurrentSend,
 	}
 
 	suite.Nil(err)
@@ -361,6 +366,9 @@ func (suite *ConfigTestSuite) TestEndpointsSetDDSite() {
 			UseCompression:   true,
 			CompressionLevel: 6,
 		},
+		BatchMaxSize:           coreConfig.DefaultBatchMaxSize,
+		BatchMaxContentSize:    coreConfig.DefaultBatchMaxContentSize,
+		BatchMaxConcurrentSend: coreConfig.DefaultBatchMaxConcurrentSend,
 	}
 
 	suite.Nil(err)

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -178,7 +178,7 @@ func (suite *ConfigTestSuite) TestMultipleHttpEndpointsEnvVar() {
 		UseCompression:   true,
 		CompressionLevel: 2}
 
-	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint1, expectedAdditionalEndpoint2}, false, true, time.Second, 0)
+	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint1, expectedAdditionalEndpoint2}, false, true)
 	endpoints, err := BuildHTTPEndpoints()
 
 	suite.Nil(err)
@@ -212,7 +212,7 @@ func (suite *ConfigTestSuite) TestMultipleTCPEndpointsEnvVar() {
 		CompressionLevel: 0,
 		ProxyAddress:     "proxy.test:3128"}
 
-	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint}, true, false, 0, 0)
+	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint}, true, false)
 	endpoints, err := buildTCPEndpoints()
 
 	suite.Nil(err)
@@ -264,7 +264,7 @@ func (suite *ConfigTestSuite) TestMultipleHttpEndpointsInConfig() {
 		UseCompression:   true,
 		CompressionLevel: 2}
 
-	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint1, expectedAdditionalEndpoint2}, false, true, time.Second, 0)
+	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint1, expectedAdditionalEndpoint2}, false, true)
 	endpoints, err := BuildHTTPEndpoints()
 
 	suite.Nil(err)
@@ -303,7 +303,7 @@ func (suite *ConfigTestSuite) TestMultipleTCPEndpointsInConf() {
 		CompressionLevel: 0,
 		ProxyAddress:     "proxy.test:3128"}
 
-	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint}, true, false, 0, 0)
+	expectedEndpoints := NewEndpoints(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint}, true, false)
 	endpoints, err := buildTCPEndpoints()
 
 	suite.Nil(err)

--- a/pkg/logs/config/endpoints.go
+++ b/pkg/logs/config/endpoints.go
@@ -6,6 +6,7 @@
 package config
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"time"
 )
 
@@ -29,10 +30,26 @@ type Endpoints struct {
 	UseHTTP                bool
 	BatchWait              time.Duration
 	BatchMaxConcurrentSend int
+	BatchMaxSize           int
+	BatchMaxContentSize    int
 }
 
-// NewEndpoints returns a new endpoints composite.
-func NewEndpoints(main Endpoint, additionals []Endpoint, useProto bool, useHTTP bool, batchWait time.Duration, batchMaxConcurrentSend int) *Endpoints {
+// NewEndpoints returns a new endpoints composite with default batching settings
+func NewEndpoints(main Endpoint, additionals []Endpoint, useProto bool, useHTTP bool) *Endpoints {
+	return &Endpoints{
+		Main:                   main,
+		Additionals:            additionals,
+		UseProto:               useProto,
+		UseHTTP:                useHTTP,
+		BatchWait:              config.DefaultBatchWait,
+		BatchMaxConcurrentSend: config.DefaultBatchMaxConcurrentSend,
+		BatchMaxSize:           config.DefaultBatchMaxSize,
+		BatchMaxContentSize:    config.DefaultBatchMaxContentSize,
+	}
+}
+
+// NewEndpointsWithBatchSettings returns a new endpoints composite with non-default batching settings specified
+func NewEndpointsWithBatchSettings(main Endpoint, additionals []Endpoint, useProto bool, useHTTP bool, batchWait time.Duration, batchMaxConcurrentSend int, batchMaxSize int, batchMaxContentSize int) *Endpoints {
 	return &Endpoints{
 		Main:                   main,
 		Additionals:            additionals,
@@ -40,5 +57,7 @@ func NewEndpoints(main Endpoint, additionals []Endpoint, useProto bool, useHTTP 
 		UseHTTP:                useHTTP,
 		BatchWait:              batchWait,
 		BatchMaxConcurrentSend: batchMaxConcurrentSend,
+		BatchMaxSize:           batchMaxSize,
+		BatchMaxContentSize:    batchMaxContentSize,
 	}
 }

--- a/pkg/logs/pipeline/pipeline.go
+++ b/pkg/logs/pipeline/pipeline.go
@@ -48,7 +48,7 @@ func NewPipeline(outputChan chan *message.Message, processingRules []*config.Pro
 
 	var strategy sender.Strategy
 	if endpoints.UseHTTP || serverless {
-		strategy = sender.NewBatchStrategy(sender.ArraySerializer, endpoints.BatchWait, endpoints.BatchMaxConcurrentSend)
+		strategy = sender.NewBatchStrategy(sender.ArraySerializer, endpoints.BatchWait, endpoints.BatchMaxConcurrentSend, endpoints.BatchMaxSize, endpoints.BatchMaxContentSize)
 	} else {
 		strategy = sender.StreamStrategy
 	}

--- a/pkg/logs/pipeline/pipeline.go
+++ b/pkg/logs/pipeline/pipeline.go
@@ -48,7 +48,7 @@ func NewPipeline(outputChan chan *message.Message, processingRules []*config.Pro
 
 	var strategy sender.Strategy
 	if endpoints.UseHTTP || serverless {
-		strategy = sender.NewBatchStrategy(sender.ArraySerializer, endpoints.BatchWait, endpoints.BatchMaxConcurrentSend, endpoints.BatchMaxSize, endpoints.BatchMaxContentSize)
+		strategy = sender.NewBatchStrategy(sender.ArraySerializer, endpoints.BatchWait, endpoints.BatchMaxConcurrentSend, endpoints.BatchMaxSize, endpoints.BatchMaxContentSize, "logs")
 	} else {
 		strategy = sender.StreamStrategy
 	}

--- a/pkg/logs/pipeline/provider_test.go
+++ b/pkg/logs/pipeline/provider_test.go
@@ -30,7 +30,7 @@ func (suite *ProviderTestSuite) SetupTest() {
 		numberOfPipelines: 3,
 		auditor:           suite.a,
 		pipelines:         []*Pipeline{},
-		endpoints:         config.NewEndpoints(config.Endpoint{}, nil, true, false, 0, 0),
+		endpoints:         config.NewEndpoints(config.Endpoint{}, nil, true, false),
 	}
 }
 

--- a/pkg/logs/sender/batch_strategy_test.go
+++ b/pkg/logs/sender/batch_strategy_test.go
@@ -27,7 +27,7 @@ func TestBatchStrategySendsPayloadWhenBufferIsFull(t *testing.T) {
 
 	done := make(chan bool)
 	go func() {
-		newBatchStrategyWithSize(LineSerializer, 100*time.Millisecond, 0, 2, 2).Send(input, output, success)
+		NewBatchStrategy(LineSerializer, 100*time.Millisecond, 0, 2, 2).Send(input, output, success)
 		close(done)
 	}()
 
@@ -56,7 +56,7 @@ func TestBatchStrategySendsPayloadWhenBufferIsOutdated(t *testing.T) {
 		return nil
 	}
 
-	strategy := newBatchStrategyWithSize(LineSerializer, timerInterval, 0, 100, 100)
+	strategy := NewBatchStrategy(LineSerializer, timerInterval, 0, 100, 100)
 	done := make(chan bool)
 	go func() {
 		strategy.Send(input, output, send)
@@ -94,7 +94,7 @@ func TestBatchStrategySendsPayloadWhenClosingInput(t *testing.T) {
 
 	done := make(chan bool)
 	go func() {
-		newBatchStrategyWithSize(LineSerializer, 100*time.Millisecond, 0, 2, 2).Send(input, output, success)
+		NewBatchStrategy(LineSerializer, 100*time.Millisecond, 0, 2, 2).Send(input, output, success)
 		close(done)
 	}()
 
@@ -129,7 +129,7 @@ func TestBatchStrategyShouldNotBlockWhenForceStopping(t *testing.T) {
 		close(input)
 	}()
 
-	newBatchStrategyWithSize(LineSerializer, 100*time.Millisecond, 0, 2, 2).Send(input, output, success)
+	NewBatchStrategy(LineSerializer, 100*time.Millisecond, 0, 2, 2).Send(input, output, success)
 }
 
 func TestBatchStrategyShouldNotBlockWhenStoppingGracefully(t *testing.T) {
@@ -148,7 +148,7 @@ func TestBatchStrategyShouldNotBlockWhenStoppingGracefully(t *testing.T) {
 		assert.Equal(t, message, <-output)
 	}()
 
-	newBatchStrategyWithSize(LineSerializer, 100*time.Millisecond, 0, 2, 2).Send(input, output, success)
+	NewBatchStrategy(LineSerializer, 100*time.Millisecond, 0, 2, 2).Send(input, output, success)
 }
 
 func TestBatchStrategyConcurrentSends(t *testing.T) {
@@ -162,7 +162,7 @@ func TestBatchStrategyConcurrentSends(t *testing.T) {
 		return nil
 	}
 
-	strategy := newBatchStrategyWithSize(LineSerializer, 100*time.Millisecond, 2, 1, 100)
+	strategy := NewBatchStrategy(LineSerializer, 100*time.Millisecond, 2, 1, 100)
 	done := make(chan bool)
 	go func() {
 		strategy.Send(input, output, stuckSend)
@@ -212,7 +212,7 @@ func TestBatchStrategySynchronousFlush(t *testing.T) {
 
 	// batch size is large so it will not flush until we trigger it manually
 	// flush time is large so it won't automatically trigger during this test
-	strategy := newBatchStrategyWithSize(LineSerializer, time.Hour, 0, 100, 100)
+	strategy := NewBatchStrategy(LineSerializer, time.Hour, 0, 100, 100)
 	done := make(chan bool)
 	go func() {
 		strategy.Send(input, output, send)

--- a/pkg/logs/sender/batch_strategy_test.go
+++ b/pkg/logs/sender/batch_strategy_test.go
@@ -27,7 +27,7 @@ func TestBatchStrategySendsPayloadWhenBufferIsFull(t *testing.T) {
 
 	done := make(chan bool)
 	go func() {
-		NewBatchStrategy(LineSerializer, 100*time.Millisecond, 0, 2, 2).Send(input, output, success)
+		NewBatchStrategy(LineSerializer, 100*time.Millisecond, 0, 2, 2, "test").Send(input, output, success)
 		close(done)
 	}()
 
@@ -56,7 +56,7 @@ func TestBatchStrategySendsPayloadWhenBufferIsOutdated(t *testing.T) {
 		return nil
 	}
 
-	strategy := NewBatchStrategy(LineSerializer, timerInterval, 0, 100, 100)
+	strategy := NewBatchStrategy(LineSerializer, timerInterval, 0, 100, 100, "test")
 	done := make(chan bool)
 	go func() {
 		strategy.Send(input, output, send)
@@ -94,7 +94,7 @@ func TestBatchStrategySendsPayloadWhenClosingInput(t *testing.T) {
 
 	done := make(chan bool)
 	go func() {
-		NewBatchStrategy(LineSerializer, 100*time.Millisecond, 0, 2, 2).Send(input, output, success)
+		NewBatchStrategy(LineSerializer, 100*time.Millisecond, 0, 2, 2, "test").Send(input, output, success)
 		close(done)
 	}()
 
@@ -129,7 +129,7 @@ func TestBatchStrategyShouldNotBlockWhenForceStopping(t *testing.T) {
 		close(input)
 	}()
 
-	NewBatchStrategy(LineSerializer, 100*time.Millisecond, 0, 2, 2).Send(input, output, success)
+	NewBatchStrategy(LineSerializer, 100*time.Millisecond, 0, 2, 2, "test").Send(input, output, success)
 }
 
 func TestBatchStrategyShouldNotBlockWhenStoppingGracefully(t *testing.T) {
@@ -148,7 +148,7 @@ func TestBatchStrategyShouldNotBlockWhenStoppingGracefully(t *testing.T) {
 		assert.Equal(t, message, <-output)
 	}()
 
-	NewBatchStrategy(LineSerializer, 100*time.Millisecond, 0, 2, 2).Send(input, output, success)
+	NewBatchStrategy(LineSerializer, 100*time.Millisecond, 0, 2, 2, "test").Send(input, output, success)
 }
 
 func TestBatchStrategyConcurrentSends(t *testing.T) {
@@ -162,7 +162,7 @@ func TestBatchStrategyConcurrentSends(t *testing.T) {
 		return nil
 	}
 
-	strategy := NewBatchStrategy(LineSerializer, 100*time.Millisecond, 2, 1, 100)
+	strategy := NewBatchStrategy(LineSerializer, 100*time.Millisecond, 2, 1, 100, "")
 	done := make(chan bool)
 	go func() {
 		strategy.Send(input, output, stuckSend)
@@ -212,7 +212,7 @@ func TestBatchStrategySynchronousFlush(t *testing.T) {
 
 	// batch size is large so it will not flush until we trigger it manually
 	// flush time is large so it won't automatically trigger during this test
-	strategy := NewBatchStrategy(LineSerializer, time.Hour, 0, 100, 100)
+	strategy := NewBatchStrategy(LineSerializer, time.Hour, 0, 100, 100, "test")
 	done := make(chan bool)
 	go func() {
 		strategy.Send(input, output, send)

--- a/pkg/logs/sender/batch_strategy_test.go
+++ b/pkg/logs/sender/batch_strategy_test.go
@@ -162,7 +162,7 @@ func TestBatchStrategyConcurrentSends(t *testing.T) {
 		return nil
 	}
 
-	strategy := NewBatchStrategy(LineSerializer, 100*time.Millisecond, 2, 1, 100, "")
+	strategy := NewBatchStrategy(LineSerializer, 100*time.Millisecond, 2, 1, 100, "test")
 	done := make(chan bool)
 	go func() {
 		strategy.Send(input, output, stuckSend)

--- a/pkg/logs/sender/message_buffer.go
+++ b/pkg/logs/sender/message_buffer.go
@@ -57,3 +57,8 @@ func (p *MessageBuffer) IsFull() bool {
 func (p *MessageBuffer) IsEmpty() bool {
 	return len(p.messageBuffer) == 0
 }
+
+// ContentSizeLimit returns the configured content size limit. Messages above this limit are not accepted.
+func (p *MessageBuffer) ContentSizeLimit() int {
+	return p.contentSizeLimit
+}

--- a/releasenotes/notes/dbm-metrics-increase-payload-size-limit-fa4cfa556054cd9e.yaml
+++ b/releasenotes/notes/dbm-metrics-increase-payload-size-limit-fa4cfa556054cd9e.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Increase payload size limit for `dbm-metrics` from `1 MB` to `20 MB`.
+  - |
+    Expose new `batch_max_size` and `batch_max_content_size` config settings for all logs endpoints.
+fixes:
+  - |
+    Declare `database_monitoring.{samples,metrics}` as known keys in order to remove "unknown key" warnings on startup.


### PR DESCRIPTION
### What does this PR do?

Increase payload size limit for `dbm-metrics` from default `1 MB` to `20 MB` to support the rare edge case where we sometimes get very large payloads. These payloads must be sent as-is and cannot be split. 

Other changes:
* `logs/sender`: expose `batch_max_size` and `batch_max_content_size` as a config options for all logs endpoints (these still default to the same defaults as before) 
* declare `database_monitoring.{samples,metrics}` as known keys in order to remove "unknown key" warnings on startup. 
* added more telemetry to make for easier troubleshooting of dropped payloads 

#### Telemetry Updates

New log warning:

```
2021-05-17 16:56:11 EDT | CORE | WARN | (pkg/logs/sender/batch_strategy.go:122 in processMessage) | Dropped message in pipeline=dbm-metrics reason=too-large ContentLength=45118037 ContentSizeLimit=20000000
```

New telemetry:

```
$ curl http://localhost:5000/telemetry | grep logs_sender_batch_strategy
logs_sender_batch_strategy__dropped_too_large{pipeline="dbm-metrics"} 6
```

### Motivation

Support large `dbm-metrics` payloads and improve troubleshooting of dropped payloads. 

### Describe how to test your changes

1. Run an agent build locally with https://github.com/DataDog/integrations-core/pull/9223 included
    1. Set `deep_database_monitoring: true` in the mysql instance config and configure it to talk to a test database
    1. Enable agent telemetry `telemetry.enabled: true`
1. Confirm that statement metrics are being ingested and appear on the database queries page 
1. Hack the check locally to send an unusually large `dbm-metrics` payload (30+ MB)
1. Confirm that the new "Dropped message in pipeline" warning log message appears
1. Adjust the payload so it's just below 20 MB.
1. Confirm that there are no warnings in the logs indicating that the payload is being dropped or that there are intake HTTP errors
1. Confirm from the telemetry that dbm-metrics are being sent `curl http://localhost:5000/telemetry | grep dbm-metrics`