### PR TITLE
[DCA] Expose `external_metrics.datadog_metrics` metric

### DIFF
--- a/pkg/clusteragent/externalmetrics/datadogmetric_controller.go
+++ b/pkg/clusteragent/externalmetrics/datadogmetric_controller.go
@@ -208,8 +208,10 @@ func (c *DatadogMetricController) processDatadogMetric(key interface{}) error {
 		if datadogMetricCached != nil {
 			// Feeding local cache with DatadogMetric information
 			c.store.Set(datadogMetricKey, model.NewDatadogMetricInternal(datadogMetricKey, *datadogMetricCached), ddmControllerStoreID)
+			setDatadogMetricTelemetry(datadogMetricCached)
 		} else {
 			c.store.Delete(datadogMetricKey, ddmControllerStoreID)
+			unsetDatadogMetricTelemetry(ns, name)
 		}
 	}
 
@@ -307,6 +309,8 @@ func (c *DatadogMetricController) createDatadogMetric(ns, name string, datadogMe
 		return fmt.Errorf("Unable to create DatadogMetric: %s/%s, err: %v", ns, name, err)
 	}
 
+	setDatadogMetricTelemetry(datadogMetric)
+
 	return nil
 }
 
@@ -331,6 +335,7 @@ func (c *DatadogMetricController) updateDatadogMetric(ns, name string, datadogMe
 		if err != nil {
 			return fmt.Errorf("Unable to update DatadogMetric: %s/%s, err: %v", ns, name, err)
 		}
+		setDatadogMetricTelemetry(datadogMetric)
 	} else {
 		return fmt.Errorf("Impossible to build new status for DatadogMetric: %s", datadogMetricInternal.ID)
 	}
@@ -344,5 +349,6 @@ func (c *DatadogMetricController) deleteDatadogMetric(ns, name string) error {
 	if err != nil {
 		return fmt.Errorf("Unable to delete DatadogMetric: %s/%s, err: %v", ns, name, err)
 	}
+	unsetDatadogMetricTelemetry(ns, name)
 	return nil
 }

--- a/pkg/clusteragent/externalmetrics/telemetry.go
+++ b/pkg/clusteragent/externalmetrics/telemetry.go
@@ -1,0 +1,56 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build kubeapiserver
+
+package externalmetrics
+
+import (
+	corev1 "k8s.io/api/core/v1"
+
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	le "github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/leaderelection/metrics"
+	datadoghq "github.com/DataDog/datadog-operator/api/v1alpha1"
+)
+
+const (
+	ddmTelemetryValid   = "true"
+	ddmTelemetryInvalid = "false"
+)
+
+var (
+	ddmTelemetry = telemetry.NewGaugeWithOpts("external_metrics", "datadog_metrics",
+		[]string{"namespace", "name", "valid", le.JoinLeaderLabel}, "The label valid is true if the DatadogMetric CR is valid, false otherwise",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+)
+
+func setDatadogMetricTelemetry(ddm *datadoghq.DatadogMetric) {
+	unsetDatadogMetricTelemetry(ddm.Namespace, ddm.Name)
+
+	var validValue string
+	switch isDatadogMetricValid(ddm) {
+	case true:
+		validValue = ddmTelemetryValid
+	case false:
+		validValue = ddmTelemetryInvalid
+	}
+
+	ddmTelemetry.Set(1.0, ddm.Namespace, ddm.Name, validValue, le.JoinLeaderValue)
+}
+
+func unsetDatadogMetricTelemetry(ns, name string) {
+	ddmTelemetry.Delete(ns, name, ddmTelemetryValid, le.JoinLeaderValue)
+	ddmTelemetry.Delete(ns, name, ddmTelemetryInvalid, le.JoinLeaderValue)
+}
+
+func isDatadogMetricValid(ddm *datadoghq.DatadogMetric) bool {
+	for _, condition := range ddm.Status.Conditions {
+		if condition.Type == datadoghq.DatadogMetricConditionTypeValid {
+			return condition.Status == corev1.ConditionTrue
+		}
+	}
+
+	return false
+}

--- a/releasenotes-dca/notes/dca-ddm-telemetry-370c17035c9097b8.yaml
+++ b/releasenotes-dca/notes/dca-ddm-telemetry-370c17035c9097b8.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    The Cluster Agent exposes a new metric `external_metrics.datadog_metrics`
+    to track the validity of DatadogMetric objects.


### PR DESCRIPTION
### What does this PR do?

The Cluster Agent now exposes a new metric
`external_metrics.datadog_metrics` to track the validity of
DatadogMetric objects.

### Motivation

For many reason, the DatadogMetric CR can be invalidated. Especially with the new tags injection feature team will be interested in monitoring their DDM status and be alerted if anything goes wrong.

This is quite important to improve the stability of the whole autoscaling solution we provide to internal teams and to customers.

### Describe how to test your changes

* [Set up the DCA to use the DatadogMetric CRD](https://docs.datadoghq.com/agent/cluster_agent/external_metrics/#set-up-datadog-cluster-agent-to-use-datadogmetric).
* [Create a DatadogMetric object](https://docs.datadoghq.com/agent/cluster_agent/external_metrics/#set-up-an-hpa-to-use-a-datadogmetric-object).
* Check that `datadog.cluster_agent.external_metrics.datadog_metrics` is reported correctly. It should labels for the namespace and name of the created object, plus a `valid` label that reflects the `Valid` condition in the `DatadogMetric` object.