### PR TITLE
Add internal/tools to module list

### DIFF
--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -7,11 +7,12 @@ from invoke import task
 class GoModule:
     """A Go module abstraction."""
 
-    def __init__(self, path, targets=None, condition=lambda: True, dependencies=None):
+    def __init__(self, path, targets=None, condition=lambda: True, dependencies=None, should_tag=True):
         self.path = path
         self.targets = targets if targets else ["."]
         self.dependencies = dependencies if dependencies else []
         self.condition = condition
+        self.should_tag = should_tag
 
     def __version(self, agent_version):
         """Return the module version for a given Agent version.

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -69,6 +69,7 @@ class GoModule:
 DEFAULT_MODULES = {
     ".": GoModule(".", targets=["./pkg", "./cmd"], dependencies=["pkg/util/log", "pkg/util/winutil"]),
     "pkg/util/log": GoModule("pkg/util/log"),
+    "internal/tools": GoModule("internal/tools", condition=lambda: False, should_tag=False),
     "pkg/util/winutil": GoModule(
         "pkg/util/winutil", condition=lambda: sys.platform == 'win32', dependencies=["pkg/util/log"]
     ),

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -965,9 +965,10 @@ def tag_version(ctx, agent_version, commit="HEAD", verify=True, push=True):
         check_version(agent_version)
 
     for module in DEFAULT_MODULES.values():
-        for tag in module.tag(agent_version):
-            ctx.run("git tag -m {tag} {tag} {commit}".format(tag=tag, commit=commit))
-            if push:
-                ctx.run("git push origin {}".format(tag))
+        if module.should_tag:
+            for tag in module.tag(agent_version):
+                ctx.run("git tag -m {tag} {tag} {commit}".format(tag=tag, commit=commit))
+                if push:
+                    ctx.run("git push origin {}".format(tag))
 
     print("Created all tags for version {}".format(agent_version))


### PR DESCRIPTION
### What does this PR do?

- Add `should_tag` field to `GoModule`.
- Add `internal/tools` to module list (with `should_tag` set to `False`).

### Motivation

- Ensure that `internal/tools` is checked in the go mod tidy check.

### Additional Notes

This was found on #8160 and is a follow up to #7750.
The module will be ignored for unit tests and in the build.
