### PR TITLE
Check for connections in root ns conntrack table before expiry

### DIFF
--- a/pkg/network/netlink/conntrack_integration_test.go
+++ b/pkg/network/netlink/conntrack_integration_test.go
@@ -5,8 +5,11 @@ package netlink
 
 import (
 	"fmt"
+	"io"
 	"net"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/network/netlink/testutil"
 	nettestutil "github.com/DataDog/datadog-agent/pkg/network/testutil"
@@ -49,6 +52,64 @@ func TestConntrackExists(t *testing.T) {
 	// test a combination of (tcp, udp) x (root ns, test ns)
 	testConntrackExists(t, tcpLaddr.IP.String(), tcpLaddr.Port, "tcp", testNs, ctrks)
 	testConntrackExists(t, udpLaddr.IP.String(), udpLaddr.Port, "udp", testNs, ctrks)
+}
+
+func TestConntrackExistsRootDNAT(t *testing.T) {
+	defer testutil.TeardownCrossNsDNAT(t)
+	testutil.SetupCrossNsDNAT(t)
+	defer nettestutil.RunCommands(t, []string{
+		"iptables --table nat --delete CLUSTERIPS --destination 10.10.1.1 --protocol tcp --match tcp --dport 80 --jump DNAT --to-destination 2.2.2.4:80",
+		"iptables --table nat --delete PREROUTING --jump CLUSTERIPS",
+		"iptables --table nat --delete OUTPUT --jump CLUSTERIPS",
+		"iptables --table nat --delete-chain CLUSTERIPS",
+	}, true)
+	nettestutil.RunCommands(t, []string{
+		"iptables --table nat --new-chain CLUSTERIPS",
+		"iptables --table nat --append PREROUTING --jump CLUSTERIPS",
+		"iptables --table nat --append OUTPUT --jump CLUSTERIPS",
+		"iptables --table nat --append CLUSTERIPS --destination 10.10.1.1 --protocol tcp --match tcp --dport 80 --jump DNAT --to-destination 2.2.2.4:80",
+	}, false)
+
+	testNs, err := netns.GetFromName("test")
+	require.NoError(t, err)
+	defer testNs.Close()
+
+	rootNs, err := util.GetRootNetNamespace("/proc")
+	require.NoError(t, err)
+	defer rootNs.Close()
+
+	destIP := "10.10.1.1"
+	destPort := 80
+	var tcpCloser io.Closer
+	_ = util.WithNS("/proc", testNs, func() error {
+		tcpCloser = nettestutil.StartServerTCP(t, net.ParseIP("2.2.2.4"), 8080)
+		return nil
+	})
+	defer tcpCloser.Close()
+
+	tcpConn := nettestutil.PingTCP(t, net.ParseIP(destIP), destPort)
+	defer tcpConn.Close()
+
+	rootck, err := NewConntrack(int(rootNs))
+	require.NoError(t, err)
+
+	testck, err := NewConntrack(int(testNs))
+	require.NoError(t, err)
+
+	tcpLaddr := tcpConn.LocalAddr().(*net.TCPAddr)
+	c := &Con{
+		Con: ct.Con{
+			Origin: newIPTuple(tcpLaddr.IP.String(), destIP, uint16(tcpLaddr.Port), uint16(destPort), unix.IPPROTO_TCP),
+		},
+	}
+
+	exists, err := rootck.Exists(c)
+	require.NoError(t, err)
+	assert.True(t, exists)
+
+	exists, err = testck.Exists(c)
+	require.NoError(t, err)
+	assert.False(t, exists)
 }
 
 func testConntrackExists(t *testing.T, laddrIP string, laddrPort int, proto string, testNs netns.NsHandle, ctrks map[int]Conntrack) {

--- a/pkg/network/netlink/testutil/conntrack.go
+++ b/pkg/network/netlink/testutil/conntrack.go
@@ -85,6 +85,7 @@ func SetupCrossNsDNAT(t *testing.T) {
 		"ip -n test address add 2.2.2.4/24 dev veth2",
 		"ip link set veth1 up",
 		"ip -n test link set veth2 up",
+		"ip netns exec test ip route add default dev veth2",
 
 		//this is required to enable conntrack in the root net namespace
 		//conntrack won't be enabled unless there is at least one iptables

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -995,12 +995,18 @@ func (t *Tracer) connectionExpired(conn *ConnTuple, latestTime uint64, stats *Co
 		return true
 	}
 
-	ok, err := ctr.Exists(conn)
+	exists, err := ctr.Exists(conn)
 	if err != nil {
-		log.Warnf("error checking conntrack for connection %s: %s", *conn, err)
+		log.Warnf("error checking conntrack for connection %s: %s", conn, err)
+	}
+	if !exists {
+		exists, err = ctr.ExistsInRootNS(conn)
+		if err != nil {
+			log.Warnf("error checking conntrack for connection in root ns %s: %s", conn, err)
+		}
 	}
 
-	return !ok
+	return !exists
 }
 
 func (t *Tracer) connVia(cs *network.ConnectionStats) {


### PR DESCRIPTION
### What does this PR do?

Checks to see if a connection exists in either its network namespace `conntrack` table, or the root network namespace `conntrack` table. 

### Motivation

We were prematurely expiring connections (and their NAT translation entries) using k8s cluster IPs, when the connection was idle long enough to trigger this check. This would cause host resolution problems on the backend, and the flows would end up without a destination host.

This was happening because the connections were created within a network namespace, but the cluster IP `iptables` rules and `conntrack` entries were in the root network namespace.

### Describe how to test your changes

I've added an automated test that covers this scenario.