### PR TITLE
Do not include MSG_PEEK receives in total count

### DIFF
--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "f58a28c466c4eff5740331390f7bf8c48df3dd9afdbfee704abc8d99ca755a88")
+var Tracer = NewRuntimeAsset("tracer.c", "21616a7c62146a4976ef79f00ebbfad1d38a2762750992ef9df77ff644d87e30")

--- a/pkg/network/config/config_linux.go
+++ b/pkg/network/config/config_linux.go
@@ -57,7 +57,7 @@ func (c *Config) EnabledProbes(runtimeTracer bool) (map[probes.ProbeName]struct{
 			enabled[probes.Inet6BindRet] = struct{}{}
 		}
 
-		if pre410Kernel {
+		if !runtimeTracer && pre410Kernel {
 			enabled[probes.UDPRecvMsgPre410] = struct{}{}
 		} else {
 			enabled[probes.UDPRecvMsg] = struct{}{}

--- a/pkg/network/ebpf/c/prebuilt/tracer.c
+++ b/pkg/network/ebpf/c/prebuilt/tracer.c
@@ -518,7 +518,13 @@ int kprobe__ip_make_skb(struct pt_regs* ctx) {
 SEC("kprobe/udp_recvmsg")
 int kprobe__udp_recvmsg(struct pt_regs* ctx) {
     struct sock* sk = (struct sock*)PT_REGS_PARM1(ctx);
-    struct msghdr* msg = (struct msghdr*) PT_REGS_PARM2(ctx);
+    struct msghdr* msg = (struct msghdr*)PT_REGS_PARM2(ctx);
+    int flags = (int)PT_REGS_PARM5(ctx);
+    log_debug("kprobe/udp_recvmsg: flags: %x\n", flags);
+    if (flags & MSG_PEEK) {
+        return 0;
+    }
+
     u64 pid_tgid = bpf_get_current_pid_tgid();
     udp_recv_sock_t t = { .sk = NULL, .msg = NULL };
     if (sk) {
@@ -528,17 +534,20 @@ int kprobe__udp_recvmsg(struct pt_regs* ctx) {
         bpf_probe_read(&t.msg, sizeof(t.msg), &msg);
     }
 
-    // Store pointer to the socket using the pid/tgid
     bpf_map_update_elem(&udp_recv_sock, &pid_tgid, &t, BPF_ANY);
-    log_debug("kprobe/udp_recvmsg: pid_tgid: %d\n", pid_tgid);
-
     return 0;
 }
 
 SEC("kprobe/udp_recvmsg/pre_4_1_0")
 int kprobe__udp_recvmsg_pre_4_1_0(struct pt_regs* ctx) {
     struct sock* sk = (struct sock*)PT_REGS_PARM2(ctx);
-    struct msghdr* msg = (struct msghdr*) PT_REGS_PARM3(ctx);
+    struct msghdr* msg = (struct msghdr*)PT_REGS_PARM3(ctx);
+    int flags = (int)PT_REGS_PARM6(ctx);
+    log_debug("kprobe/udp_recvmsg: flags: %x\n", flags);
+    if (flags & MSG_PEEK) {
+        return 0;
+    }
+
     u64 pid_tgid = bpf_get_current_pid_tgid();
     udp_recv_sock_t t = { .sk = NULL, .msg = NULL };
     if (sk) {
@@ -548,10 +557,7 @@ int kprobe__udp_recvmsg_pre_4_1_0(struct pt_regs* ctx) {
         bpf_probe_read(&t.msg, sizeof(t.msg), &msg);
     }
 
-    // Store pointer to the socket using the pid/tgid
     bpf_map_update_elem(&udp_recv_sock, &pid_tgid, &t, BPF_ANY);
-    log_debug("kprobe/udp_recvmsg/pre_4_1_0: pid_tgid: %d\n", pid_tgid);
-
     return 0;
 }
 

--- a/pkg/network/ebpf/c/runtime/tracer.c
+++ b/pkg/network/ebpf/c/runtime/tracer.c
@@ -355,28 +355,20 @@ int kprobe__ip_make_skb(struct pt_regs* ctx) {
 // skb_consume_udp (v4.10+, https://elixir.bootlin.com/linux/v4.10/source/net/ipv4/udp.c#L1500)
 SEC("kprobe/udp_recvmsg")
 int kprobe__udp_recvmsg(struct pt_regs* ctx) {
-    struct sock* sk = (struct sock*)PT_REGS_PARM1(ctx);
-    struct msghdr* msg = (struct msghdr*) PT_REGS_PARM2(ctx);
-    u64 pid_tgid = bpf_get_current_pid_tgid();
-    udp_recv_sock_t t = { .sk = NULL, .msg = NULL };
-    if (sk) {
-        bpf_probe_read(&t.sk, sizeof(t.sk), &sk);
-    }
-    if (msg) {
-        bpf_probe_read(&t.msg, sizeof(t.msg), &msg);
-    }
-
-    // Store pointer to the socket using the pid/tgid
-    bpf_map_update_elem(&udp_recv_sock, &pid_tgid, &t, BPF_ANY);
-    log_debug("kprobe/udp_recvmsg: pid_tgid: %d\n", pid_tgid);
-
-    return 0;
-}
-
-SEC("kprobe/udp_recvmsg/pre_4_1_0")
-int kprobe__udp_recvmsg_pre_4_1_0(struct pt_regs* ctx) {
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4, 1, 0)
     struct sock* sk = (struct sock*)PT_REGS_PARM2(ctx);
-    struct msghdr* msg = (struct msghdr*) PT_REGS_PARM3(ctx);
+    struct msghdr* msg = (struct msghdr*)PT_REGS_PARM3(ctx);
+    int flags = (int)PT_REGS_PARM6(ctx);
+#else
+    struct sock* sk = (struct sock*)PT_REGS_PARM1(ctx);
+    struct msghdr* msg = (struct msghdr*)PT_REGS_PARM2(ctx);
+    int flags = (int)PT_REGS_PARM5(ctx);
+#endif
+    log_debug("kprobe/udp_recvmsg: flags: %x\n", flags);
+    if (flags & MSG_PEEK) {
+        return 0;
+    }
+
     u64 pid_tgid = bpf_get_current_pid_tgid();
     udp_recv_sock_t t = { .sk = NULL, .msg = NULL };
     if (sk) {
@@ -386,10 +378,7 @@ int kprobe__udp_recvmsg_pre_4_1_0(struct pt_regs* ctx) {
         bpf_probe_read(&t.msg, sizeof(t.msg), &msg);
     }
 
-    // Store pointer to the socket using the pid/tgid
     bpf_map_update_elem(&udp_recv_sock, &pid_tgid, &t, BPF_ANY);
-    log_debug("kprobe/udp_recvmsg/pre_4_1_0: pid_tgid: %d\n", pid_tgid);
-
     return 0;
 }
 

--- a/pkg/network/tracer/testdata/peek.py
+++ b/pkg/network/tracer/testdata/peek.py
@@ -1,0 +1,9 @@
+#!/usr/bin/env python3
+
+import socket
+
+s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+s.bind(("127.0.0.1", 34568))
+s.recvfrom(1024, socket.MSG_PEEK)
+s.recvfrom(1024)
+s.close()


### PR DESCRIPTION
### What does this PR do?

Excludes `udp_recvmsg` calls from receive byte totals if `flags` includes `MSG_PEEK`.

### Motivation

Peeks do not remove data from the queue, so that data will be received later and thus shouldn't be double counted.

### Describe how to test your changes

Automated test added.
