### PR TITLE
Add basic retry logic to SyncForwarder

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -323,8 +323,6 @@ func runAgent(stopCh chan struct{}) (daemon *serverless.Daemon, err error) {
 		// of reporting non-critical init errors.
 		log.Errorf("Misconfiguration of agent endpoints: %s", err)
 	}
-	forwarderTimeout := config.Datadog.GetDuration("forwarder_timeout") * time.Second
-	log.Debugf("Using a SyncForwarder with a %v timeout", forwarderTimeout)
 	f := forwarder.NewSyncForwarder(keysPerDomain)
 	f.Start() //nolint:errcheck
 	serializer := serializer.NewSerializer(f, nil)

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -325,7 +325,7 @@ func runAgent(stopCh chan struct{}) (daemon *serverless.Daemon, err error) {
 	}
 	forwarderTimeout := config.Datadog.GetDuration("forwarder_timeout") * time.Second
 	log.Debugf("Using a SyncForwarder with a %v timeout", forwarderTimeout)
-	f := forwarder.NewSyncForwarder(keysPerDomain, forwarderTimeout)
+	f := forwarder.NewSyncForwarder(keysPerDomain)
 	f.Start() //nolint:errcheck
 	serializer := serializer.NewSerializer(f, nil)
 

--- a/pkg/forwarder/sync_forwarder.go
+++ b/pkg/forwarder/sync_forwarder.go
@@ -23,6 +23,7 @@ var forwarderTimeout = config.Datadog.GetDuration("forwarder_timeout") * time.Se
 
 // NewSyncForwarder returns a new synchronous forwarder.
 func NewSyncForwarder(keysPerDomains map[string][]string) *SyncForwarder {
+	log.Debugf("Using a SyncForwarder with a %v timeout", forwarderTimeout)
 	return &SyncForwarder{
 		defaultForwarder: NewDefaultForwarder(NewOptions(keysPerDomains)),
 		client: &http.Client{

--- a/pkg/forwarder/sync_forwarder.go
+++ b/pkg/forwarder/sync_forwarder.go
@@ -45,7 +45,7 @@ func (f *SyncForwarder) Stop() {
 func (f *SyncForwarder) sendHTTPTransactions(transactions []*transaction.HTTPTransaction) error {
 	for _, t := range transactions {
 		if err := t.Process(context.Background(), f.client); err != nil {
-			log.Errorf("SyncForwarder.sendHTTPTransactions: %s", err)
+			log.Errorf("SyncForwarder.sendHTTPTransactions first attempt: %s", err)
 
 			// If there is an error, instantiate a new HTTP client and retry one time
 			// The new HTTP client is instantiated in case the connection has been closed
@@ -54,7 +54,9 @@ func (f *SyncForwarder) sendHTTPTransactions(transactions []*transaction.HTTPTra
 				Timeout:   forwarderTimeout,
 				Transport: utilhttp.CreateHTTPTransport(),
 			}
-			t.Process(context.Background(), f.client)
+			if err:= t.Process(context.Background(), f.client); err != nil {
+				log.("SyncForwarder.sendHTTPTransactions second attempt: %s", err)
+			}
 		}
 	}
 	log.Debugf("SyncForwarder has flushed %d transactions", len(transactions))

--- a/pkg/forwarder/sync_forwarder.go
+++ b/pkg/forwarder/sync_forwarder.go
@@ -49,7 +49,6 @@ func (f *SyncForwarder) sendHTTPTransactions(transactions []*transaction.HTTPTra
 			// If there is an error, instantiate a new HTTP client and retry one time
 			// The new HTTP client is instantiated in case the connection has been closed
 			log.Debug("Retrying transaction")
-			forwarderTimeout := config.Datadog.GetDuration("forwarder_timeout") * time.Second
 			f.client = &http.Client{
 				Timeout:   forwarderTimeout,
 				Transport: utilhttp.CreateHTTPTransport(),

--- a/pkg/forwarder/sync_forwarder.go
+++ b/pkg/forwarder/sync_forwarder.go
@@ -50,7 +50,7 @@ func (f *SyncForwarder) sendHTTPTransactions(transactions []*transaction.HTTPTra
 				Timeout:   forwarderTimeout,
 				Transport: utilhttp.CreateHTTPTransport(),
 			}
-			log.Debug("Retrying")
+			log.Debug("Retrying transaction")
 			t.Process(context.Background(), f.client)
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

Adds basic retry logic to the SyncForwarder, which is used by the Lambda Extension to send metrics to Datadog.

### Motivation

We are encountering periodic errors when sending metrics to Datadog from the Lambda Extension. Without retry logic, these errors result in lost data. As a first step towards mitigating this issue, add basic retry logic that should establish a new connection and retry one time. Later, we could do a deeper exploration of why we are encountering these API errors to more fully resolve the issue.

### Describe how to test your changes

I compared the rate of missing `enhanced.invocations` using this logic versus the current release branch. I invoked a "Hello World" function once per minute.

Over the same four hour period (5/17/21 4 PM - 8 PM ET), the release branch showed 11 missing invocations, while this branch showed 0. I also tried a third solution: retrying the request without instantiating a new HTTP client. That solution resulted in 2 missing invocations.
