### PR TITLE
[orchestrator] [dca] additional status information

### DIFF
--- a/pkg/clusteragent/orchestrator/status.go
+++ b/pkg/clusteragent/orchestrator/status.go
@@ -102,17 +102,16 @@ func GetStatus(apiCl kubernetes.Interface) map[string]interface{} {
 }
 
 func setClusterName(status map[string]interface{}) {
-	message := "No cluster name was detected. This means resource collection will not work."
+	errorMsg := "No cluster name was detected. This means resource collection will not work."
 
 	hostname, err := util.GetHostname()
 	if err != nil {
-		status["ClusterNameError"] = fmt.Sprintf("Error detecting cluster name: %s.\n%s", err.Error(), message)
+		status["ClusterNameError"] = fmt.Sprintf("Error detecting cluster name: %s.\n%s", err.Error(), errorMsg)
 	} else {
-		cName := clustername.GetClusterName(hostname)
-		if cName == "" {
-			status["ClusterName"] = message
-		} else {
+		if cName := clustername.GetClusterName(hostname); cName != "" {
 			status["ClusterName"] = cName
+		} else {
+			status["ClusterName"] = errorMsg
 		}
 	}
 }
@@ -121,8 +120,8 @@ func setClusterName(status map[string]interface{}) {
 func setCollectionIsWorking(status map[string]interface{}) {
 	c := orchestrator.KubernetesResourceCache.ItemCount()
 	if c > 0 {
-		status["CollectionWorking"] = "The collection should work because we have resources in the cache"
+		status["CollectionWorking"] = "The collection is at least partially running since the cache has been populated."
 	} else {
-		status["CollectionWorking"] = "The collection should not to work as there are no elements in the cache. Care the cache may still be priming."
+		status["CollectionWorking"] = "The collection has not run successfully yet since the cache is empty."
 	}
 }

--- a/pkg/clusteragent/orchestrator/status.go
+++ b/pkg/clusteragent/orchestrator/status.go
@@ -121,8 +121,8 @@ func setClusterName(status map[string]interface{}) {
 func setCollectionIsWorking(status map[string]interface{}) {
 	c := orchestrator.KubernetesResourceCache.ItemCount()
 	if c > 0 {
-		status["CollectionWorking"] = "The collection seems to work as we have resources in the cache"
+		status["CollectionWorking"] = "The collection should work because we have resources in the cache"
 	} else {
-		status["CollectionWorking"] = "The collection seems not to work as there are not elements in the cache. Care the cache may still be priming."
+		status["CollectionWorking"] = "The collection should not to work as there are no elements in the cache. Care the cache may still be priming."
 	}
 }

--- a/pkg/status/templates/orchestrator.tmpl
+++ b/pkg/status/templates/orchestrator.tmpl
@@ -12,7 +12,9 @@ Orchestrator Explorer
 {{- if .ClusterIDError }}
   Cluster ID error: {{.ClusterIDError}}
 {{- end }}
-
+{{- if .ClusterName }}
+  Cluster Name: {{.ClusterName}}
+{{- end }}
 {{- if .ClusterID }}
   Cluster ID: {{.ClusterID}}
 {{- end }}
@@ -20,9 +22,6 @@ Orchestrator Explorer
   Cluster ID error: {{.ClusterNameError}}
 {{- end }}
 
-{{- if .ClusterName }}
-  Cluster Name: {{.ClusterName}}
-{{- end }}
 {{- if .ContainerScrubbing }}
   {{.ContainerScrubbing}}
 {{- end}}

--- a/pkg/status/templates/orchestrator.tmpl
+++ b/pkg/status/templates/orchestrator.tmpl
@@ -2,7 +2,7 @@
 */}}=====================
 Orchestrator Explorer
 =====================
-
+  Collection Status: {{ .CollectionWorking }}
 {{- if .Error }}
   Error: {{ .Error }}
 {{- end }}
@@ -21,7 +21,7 @@ Orchestrator Explorer
 {{- end }}
 
 {{- if .ClusterName }}
-  Cluster name: {{.ClusterName}}
+  Cluster Name: {{.ClusterName}}
 {{- end }}
 {{- if .ContainerScrubbing }}
   {{.ContainerScrubbing}}

--- a/releasenotes-dca/notes/orchestrator-status-new-bc580d884555eea8.yaml
+++ b/releasenotes-dca/notes/orchestrator-status-new-bc580d884555eea8.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add additional status information in orchestrator section output.
+    Whether collection works and whether cluster name is set.


### PR DESCRIPTION
### What does this PR do?

Add additional information about orchestrator resource collection to make clear whether things are working and why not by adding the following information as messages in the status:
- if the clusterName is "" the collection will not work
- if the cache is empty the collection the collection is most probably not working or at least it might still be priming the cache

### Motivation

More information for the users and support

### Additional Notes

Error Case:
```
=====================
Orchestrator Explorer
=====================
  Collection Status: The collection has not run successfully yet since the cache is empty.
  Cluster Name: No cluster name was detected. This means resource collection will not work.
  Cluster ID: 9e99cefc-06cb-44a7-a0d5-69aaf0ff5a47
  Container scrubbing: enabled
```

Good Case:
```
=====================
Orchestrator Explorer
=====================
  Collection Status: The collection is at least partially running since the cache has been populated.
  Cluster Name: nammn
  Cluster ID: 9e99cefc-06cb-44a7-a0d5-69aaf0ff5a47
```

### Describe how to test your changes

try to run collection on a cluster with either:
- no cluster name set | cluster name set to `""`
- orch explorer not working for other reasons (no access to cluster name, RBAC problems ...)
