### PR TITLE
Add basic retry logic to SyncForwarder

### DIFF
--- a/pkg/forwarder/sync_forwarder.go
+++ b/pkg/forwarder/sync_forwarder.go
@@ -12,7 +12,6 @@ import (
 
 // SyncForwarder is a very simple Forwarder synchronously sending
 // the data to the intake.
-// It doesn't ship any retry mechanism for now.
 type SyncForwarder struct {
 	defaultForwarder *DefaultForwarder
 	client           *http.Client

--- a/pkg/forwarder/sync_forwarder.go
+++ b/pkg/forwarder/sync_forwarder.go
@@ -42,6 +42,9 @@ func (f *SyncForwarder) sendHTTPTransactions(transactions []*transaction.HTTPTra
 	for _, t := range transactions {
 		if err := t.Process(context.Background(), f.client); err != nil {
 			log.Errorf("SyncForwarder.sendHTTPTransactions: %s", err)
+			// Retry once after error
+			log.Debug("Retrying transaction")
+			t.Process(context.Background(), f.client)
 		}
 	}
 	log.Debugf("SyncForwarder has flushed %d transactions", len(transactions))

--- a/pkg/forwarder/sync_forwarder.go
+++ b/pkg/forwarder/sync_forwarder.go
@@ -41,10 +41,12 @@ func (f *SyncForwarder) Stop() {
 func (f *SyncForwarder) sendHTTPTransactions(transactions []*transaction.HTTPTransaction) error {
 	for _, t := range transactions {
 		if err := t.Process(context.Background(), f.client); err != nil {
-			log.Errorf("SyncForwarder.sendHTTPTransactions: %s", err)
+			log.Debugf("SyncForwarder.sendHTTPTransactions first attempt: %s", err)
 			// Retry once after error
 			log.Debug("Retrying transaction")
-			t.Process(context.Background(), f.client)
+			if err := t.Process(context.Background(), f.client); err != nil {
+				log.Errorf("SyncForwarder.sendHTTPTransactions final attempt: %s", err)
+			}
 		}
 	}
 	log.Debugf("SyncForwarder has flushed %d transactions", len(transactions))


### PR DESCRIPTION
### What does this PR do?

Adds basic retry logic to the SyncForwarder, which is used by the Lambda Extension to send metrics to Datadog.

### Motivation

We are encountering periodic errors when sending metrics to Datadog from the Lambda Extension. Without retry logic, these errors result in lost data. As a first step towards mitigating this issue, add basic retry logic that should retry once after an error. Later, we could do a deeper exploration of why we are encountering these API errors to more fully resolve the issue.

### Describe how to test your changes

I compared the rate of missing `enhanced.invocations` using this logic versus the current release branch. I invoked a "Hello World" function once per minute.

Over the same twelve hour period, the release branch showed about 40 missing invocations, while this branch showed 0. Previously, a [different solution](https://github.com/DataDog/datadog-agent/pull/8176) seemed more promising, but in the end it seemed like it added complexity without necessarily providing any benefit.
