### PR TITLE
Darcy.rayner/fix compute stats

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -91,6 +91,8 @@ where they can be graphed on dashboards. The Datadog Serverless Agent implements
 
 	traceOriginMetadataKey   = "_dd.origin"
 	traceOriginMetadataValue = "lambda"
+	computeStatsKey          = "_dd.compute_stats"
+	computeStatsValue        = "1"
 )
 
 const (
@@ -352,6 +354,7 @@ func runAgent(stopCh chan struct{}) (daemon *serverless.Daemon, err error) {
 		tc, confErr := traceConfig.Load(datadogConfigPath)
 		tc.Hostname = ""
 		tc.GlobalTags[traceOriginMetadataKey] = traceOriginMetadataValue
+		tc.GlobalTags[computeStatsKey] = computeStatsValue
 		tc.SynchronousFlushing = true
 		if confErr != nil {
 			log.Errorf("Unable to load trace agent config: %s", confErr)

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -93,6 +93,7 @@ where they can be graphed on dashboards. The Datadog Serverless Agent implements
 	traceOriginMetadataValue = "lambda"
 	computeStatsKey          = "_dd.compute_stats"
 	computeStatsValue        = "1"
+	functionARNKey           = "function_arn"
 )
 
 const (
@@ -355,6 +356,7 @@ func runAgent(stopCh chan struct{}) (daemon *serverless.Daemon, err error) {
 		tc.Hostname = ""
 		tc.GlobalTags[traceOriginMetadataKey] = traceOriginMetadataValue
 		tc.GlobalTags[computeStatsKey] = computeStatsValue
+		tc.GlobalTags[functionARNKey] = functionARN
 		tc.SynchronousFlushing = true
 		if confErr != nil {
 			log.Errorf("Unable to load trace agent config: %s", confErr)


### PR DESCRIPTION
### What does this PR do?

Adds the __dd.compute_stats=1 metadata field to lambda trace payloads. This allows backend based stats aggregation to occur.
<img width="1260" alt="Screen Shot 2021-05-18 at 4 18 31 PM" src="https://user-images.githubusercontent.com/50632605/118718067-d4801880-b7f4-11eb-83a6-cefac0af55f6.png">


### Motivation

Lambda traces weren't appearing in the APM services list, because stats weren't be aggregated on the backend.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
