### PR TITLE
Simplify tcp_sendmsg probe for runtime compilation

### DIFF
--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "21616a7c62146a4976ef79f00ebbfad1d38a2762750992ef9df77ff644d87e30")
+var Tracer = NewRuntimeAsset("tracer.c", "9a28d5974f99213966a7985e608d70bd5a8a0115d9bef8822864bb689e768466")

--- a/pkg/network/config/config_linux.go
+++ b/pkg/network/config/config_linux.go
@@ -19,7 +19,7 @@ func (c *Config) EnabledProbes(runtimeTracer bool) (map[probes.ProbeName]struct{
 	pre410Kernel := kv < kernel.VersionCode(4, 1, 0)
 
 	if c.CollectTCPConns {
-		if pre410Kernel {
+		if !runtimeTracer && pre410Kernel {
 			enabled[probes.TCPSendMsgPre410] = struct{}{}
 		} else {
 			enabled[probes.TCPSendMsg] = struct{}{}

--- a/pkg/network/ebpf/manager.go
+++ b/pkg/network/ebpf/manager.go
@@ -59,7 +59,6 @@ func NewManager(closedHandler *ebpf.PerfHandler, runtimeTracer bool) *manager.Ma
 		},
 		Probes: []*manager.Probe{
 			{Section: string(probes.TCPSendMsg)},
-			{Section: string(probes.TCPSendMsgPre410), MatchFuncName: "^tcp_sendmsg$"},
 			{Section: string(probes.TCPCleanupRBuf)},
 			{Section: string(probes.TCPClose)},
 			{Section: string(probes.TCPCloseReturn), KProbeMaxActive: maxActive},
@@ -67,7 +66,6 @@ func NewManager(closedHandler *ebpf.PerfHandler, runtimeTracer bool) *manager.Ma
 			{Section: string(probes.IPMakeSkb)},
 			{Section: string(probes.IP6MakeSkb)},
 			{Section: string(probes.UDPRecvMsg)},
-			{Section: string(probes.UDPRecvMsgPre410), MatchFuncName: "^udp_recvmsg$"},
 			{Section: string(probes.UDPRecvMsgReturn), KProbeMaxActive: maxActive},
 			{Section: string(probes.TCPRetransmit)},
 			{Section: string(probes.InetCskAcceptReturn), KProbeMaxActive: maxActive},
@@ -91,6 +89,8 @@ func NewManager(closedHandler *ebpf.PerfHandler, runtimeTracer bool) *manager.Ma
 		mgr.Probes = append(mgr.Probes,
 			&manager.Probe{Section: string(probes.TCPRetransmitPre470), MatchFuncName: "^tcp_retransmit_skb$"},
 			&manager.Probe{Section: string(probes.IP6MakeSkbPre470), MatchFuncName: "^ip6_make_skb$"},
+			&manager.Probe{Section: string(probes.UDPRecvMsgPre410), MatchFuncName: "^udp_recvmsg$"},
+			&manager.Probe{Section: string(probes.TCPSendMsgPre410), MatchFuncName: "^tcp_sendmsg$"},
 		)
 	}
 


### PR DESCRIPTION
### What does this PR do?

Removes the pre-4.1.0 probe for the runtime-compiled network tracer, and uses an `#if / else` to handle the version differences.

### Motivation

Simplify and reduce the amount of code we need to maintain.