### PR TITLE
[invoke, gitlab] Add option to cancel redundant pipelines to pipeline commands

### DIFF
--- a/tasks/libs/common/gitlab.py
+++ b/tasks/libs/common/gitlab.py
@@ -158,6 +158,8 @@ class Gitlab(object):
         headers = dict(headers or [])
         headers["PRIVATE-TOKEN"] = self.api_token
 
+        # TODO: Use the param argument of requests instead of handling URL params
+        # manually
         try:
             if data or method == "POST":
                 r = requests.post(url, headers=headers, data=data, stream=stream)

--- a/tasks/libs/common/gitlab.py
+++ b/tasks/libs/common/gitlab.py
@@ -4,6 +4,7 @@ import os
 import platform
 import re
 import subprocess
+from urllib.parse import quote
 
 from invoke.exceptions import Exit
 
@@ -36,8 +37,6 @@ class Gitlab(object):
         """
         Gets the project info.
         """
-        from urllib.parse import quote
-
         path = "/projects/{}".format(quote(project_name, safe=""))
         return self.make_request(path, json=True)
 
@@ -46,8 +45,6 @@ class Gitlab(object):
         Create a pipeline targeting a given reference of a project.
         ref must be a branch or a tag.
         """
-        from urllib.parse import quote
-
         if variables is None:
             variables = {}
 
@@ -60,24 +57,19 @@ class Gitlab(object):
         """
         Gets all pipelines for a given reference (+ optionally git sha).
         """
-        pipelines = []
         page = 1
 
         # Go through all pages
         results = self.pipelines_for_ref(project_name, ref, sha=sha, page=page)
         while results:
-            pipelines.extend(results)
+            yield from results
             page += 1
             results = self.pipelines_for_ref(project_name, ref, sha=sha, page=page)
-
-        return pipelines
 
     def pipelines_for_ref(self, project_name, ref, sha=None, page=1, per_page=100):
         """
         Gets one page of pipelines for a given reference (+ optionally git sha).
         """
-        from urllib.parse import quote
-
         path = "/projects/{}/pipelines?ref={}&per_page={}&page={}".format(
             quote(project_name, safe=""), quote(ref, safe=""), per_page, page
         )
@@ -101,8 +93,6 @@ class Gitlab(object):
         """
         Gets info for a given pipeline.
         """
-        from urllib.parse import quote
-
         path = "/projects/{}/pipelines/{}".format(quote(project_name, safe=""), pipeline_id)
         return self.make_request(path, json=True)
 
@@ -110,8 +100,6 @@ class Gitlab(object):
         """
         Cancels a given pipeline.
         """
-        from urllib.parse import quote
-
         path = "/projects/{}/pipelines/{}/cancel".format(quote(project_name, safe=""), pipeline_id)
         return self.make_request(path, json=True, method="POST")
 
@@ -119,14 +107,10 @@ class Gitlab(object):
         """
         Gets info for a given commit sha.
         """
-        from urllib.parse import quote
-
         path = "/projects/{}/repository/commits/{}".format(quote(project_name, safe=""), commit_sha)
         return self.make_request(path, json=True)
 
     def artifact(self, project_name, job_id, artifact_name):
-        from urllib.parse import quote
-
         path = "/projects/{}/jobs/{}/artifacts/{}".format(quote(project_name, safe=""), job_id, artifact_name)
         response = self.make_request(path, stream=True)
         if response.status_code != 200:
@@ -137,25 +121,20 @@ class Gitlab(object):
         """
         Gets all the jobs for a pipeline.
         """
-        jobs = []
         page = 1
 
         # Go through all pages
         results = self.jobs(project_name, pipeline_id, page)
         while results:
-            jobs.extend(results)
+            yield from results
             page += 1
             results = self.jobs(project_name, pipeline_id, page)
-
-        return jobs
 
     def jobs(self, project_name, pipeline_id, page=1, per_page=100):
         """
         Gets one page of the jobs for a pipeline.
         per_page cannot exceed 100.
         """
-        from urllib.parse import quote
-
         path = "/projects/{}/pipelines/{}/jobs?per_page={}&page={}".format(
             quote(project_name, safe=""), pipeline_id, per_page, page
         )
@@ -165,8 +144,6 @@ class Gitlab(object):
         """
         Look up a tag by its name.
         """
-        from urllib.parse import quote
-
         path = "/projects/{}/repository/tags/{}".format(quote(project_name, safe=""), tag_name)
         return self.make_request(path, json=True)
 

--- a/tasks/libs/common/user_interactions.py
+++ b/tasks/libs/common/user_interactions.py
@@ -1,0 +1,19 @@
+from .color import color_message
+
+
+def yes_no_question(input_message, color="white", default=None):
+    choice = None
+    valid_answers = {'yes': True, 'y': True, 'no': False, 'n': False, '': default}
+
+    if default is None:
+        default_answer_prompt = "[y/n]"
+    elif default:
+        default_answer_prompt = "[Y/n]"
+    else:
+        default_answer_prompt = "[y/N]"
+
+    while choice not in valid_answers or valid_answers[choice] is None:
+        print(color_message("{} {} ".format(input_message, default_answer_prompt), color), end='')
+        choice = input().strip().lower()
+
+    return valid_answers[choice]

--- a/tasks/libs/pipeline_tools.py
+++ b/tasks/libs/pipeline_tools.py
@@ -8,6 +8,50 @@ from .common.gitlab import Gitlab
 PIPELINE_FINISH_TIMEOUT_SEC = 3600 * 5
 
 
+def get_running_pipelines_on_same_ref(
+    gitlab, project, ref, sha=None,
+):
+    pipelines = gitlab.all_pipelines_for_ref(project, ref, sha=sha)
+
+    RUNNING_STATUSES = ["created", "pending", "running"]
+    running_pipelines = [pipeline for pipeline in pipelines if pipeline["status"] in RUNNING_STATUSES]
+
+    return running_pipelines
+
+
+def cancel_pipelines_with_confirmation(gitlab, project, pipelines):
+    for pipeline in pipelines:
+        commit_author, commit_short_sha, commit_title = get_commit_for_pipeline(gitlab, project, pipeline['id'])
+
+        print(
+            color_message("Pipeline", "blue"),
+            color_message(pipeline['id'], "bold"),
+            color_message("(https://gitlab.ddbuild.io/{}/pipelines/{})".format(project, pipeline['id']), "green"),
+        )
+
+        print(color_message("Started at", "blue"), pipeline['created_at'])
+
+        print(
+            color_message("Commit:", "blue"),
+            color_message(commit_title, "green"),
+            color_message("({})".format(commit_short_sha), "grey"),
+            color_message("by", "blue"),
+            color_message(commit_author, "bold"),
+        )
+
+        choice = None
+        valid_answers = {'yes': True, 'y': True, '': True, 'no': False, 'n': False}
+        while choice not in valid_answers:
+            print(color_message("Do you want to cancel this pipeline? [Y/n] ", "orange"), end='')
+            choice = input().strip().lower()
+
+        if valid_answers[choice]:
+            gitlab.cancel_pipeline(project, pipeline['id'])
+            print("Pipeline {} has been cancelled.\n".format(color_message(pipeline['id'], "bold")))
+        else:
+            print("Pipeline {} will keep running.\n".format(color_message(pipeline['id'], "bold")))
+
+
 def trigger_agent_pipeline(
     gitlab,
     project,

--- a/tasks/libs/pipeline_tools.py
+++ b/tasks/libs/pipeline_tools.py
@@ -4,6 +4,7 @@ from time import sleep, time
 
 from .common.color import color_message
 from .common.gitlab import Gitlab
+from .common.user_interactions import yes_no_question
 
 PIPELINE_FINISH_TIMEOUT_SEC = 3600 * 5
 
@@ -39,13 +40,7 @@ def cancel_pipelines_with_confirmation(gitlab, project, pipelines):
             color_message(commit_author, "bold"),
         )
 
-        choice = None
-        valid_answers = {'yes': True, 'y': True, '': True, 'no': False, 'n': False}
-        while choice not in valid_answers:
-            print(color_message("Do you want to cancel this pipeline? [Y/n] ", "orange"), end='')
-            choice = input().strip().lower()
-
-        if valid_answers[choice]:
+        if yes_no_question("Do you want to cancel this pipeline?", color="orange", default=True):
             gitlab.cancel_pipeline(project, pipeline['id'])
             print("Pipeline {} has been cancelled.\n".format(color_message(pipeline['id'], "bold")))
         else:

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -16,7 +16,12 @@ from .libs.pipeline_notifications import (
     get_failed_tests,
     send_slack_message,
 )
-from .libs.pipeline_tools import trigger_agent_pipeline, wait_for_pipeline
+from .libs.pipeline_tools import (
+    cancel_pipelines_with_confirmation,
+    get_running_pipelines_on_same_ref,
+    trigger_agent_pipeline,
+    wait_for_pipeline,
+)
 from .libs.types import SlackMessage, TeamMessage
 
 # Tasks to trigger pipelines
@@ -76,6 +81,35 @@ def check_deploy_pipeline(gitlab, project_name, git_ref, release_version_6, rele
 
 
 @task
+def clean_running_pipelines(ctx, git_ref="master", here=False, use_latest_sha=False, sha=None):
+    """
+    Fetch running pipelines on a target ref (+ optionally a git sha), and ask the user if they
+    should be cancelled.
+    """
+
+    project_name = "DataDog/datadog-agent"
+    gitlab = Gitlab()
+    gitlab.test_project_found(project_name)
+
+    if here:
+        git_ref = ctx.run("git rev-parse --abbrev-ref HEAD", hide=True).stdout.strip()
+
+    print("Fetching running pipelines on {}".format(git_ref))
+
+    if not sha and use_latest_sha:
+        sha = ctx.run("git rev-parse {}".format(git_ref), hide=True).stdout.strip()
+        print("Git sha not provided, using the one {} currently points to: {}".format(git_ref, sha))
+    elif not sha:
+        print("Git sha not provided, fetching all running pipelines on {}".format(git_ref))
+
+    pipelines = get_running_pipelines_on_same_ref(gitlab, project_name, git_ref, sha)
+
+    print("Found {} running pipeline(s) matching the request.".format(len(pipelines)))
+    print("They are ordered from the newest one to the oldest one.\n")
+    cancel_pipelines_with_confirmation(gitlab, project_name, pipelines)
+
+
+@task
 def trigger(ctx, git_ref="master", release_version_6="nightly", release_version_7="nightly-a7", repo_branch="nightly"):
     """
     DEPRECATED: Trigger a deploy pipeline on the given git ref. Use pipeline.run with the --deploy option instead.
@@ -130,6 +164,9 @@ def run(
     To not build Agent 6, set --release-version-6 "". To not build Agent 7, set --release-version-7 "".
     The --repo-branch option indicates which branch of the staging repository the packages will be deployed to (useful only on deploy pipelines).
 
+    If other pipelines are already running on the git ref, the script will prompt the user to confirm if these previous
+    pipelines should be cancelled.
+
     Examples
     Run a pipeline on my-branch:
       inv pipeline.run --git-ref my-branch
@@ -173,6 +210,19 @@ def run(
 
     if here:
         git_ref = ctx.run("git rev-parse --abbrev-ref HEAD", hide=True).stdout.strip()
+
+    pipelines = get_running_pipelines_on_same_ref(gitlab, project_name, git_ref)
+
+    if len(pipelines) != 0:
+        print(
+            (
+                "There are already {} pipeline(s) running on the target git ref.\n"
+                "For each of them, you'll be asked whether you want to cancel them or not.\n"
+                "If you don't need these pipelines, please cancel them to save CI resources.\n"
+                "They are ordered from the newest one to the oldest one.\n"
+            ).format(len(pipelines))
+        )
+        cancel_pipelines_with_confirmation(gitlab, project_name, pipelines)
 
     pipeline_id = trigger_agent_pipeline(
         gitlab,

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -104,8 +104,11 @@ def clean_running_pipelines(ctx, git_ref="master", here=False, use_latest_sha=Fa
 
     pipelines = get_running_pipelines_on_same_ref(gitlab, project_name, git_ref, sha)
 
-    print("Found {} running pipeline(s) matching the request.".format(len(pipelines)))
-    print("They are ordered from the newest one to the oldest one.\n")
+    print(
+        "Found {} running pipeline(s) matching the request.".format(len(pipelines)),
+        "They are ordered from the newest one to the oldest one.\n",
+        sep='\n',
+    )
     cancel_pipelines_with_confirmation(gitlab, project_name, pipelines)
 
 
@@ -213,14 +216,13 @@ def run(
 
     pipelines = get_running_pipelines_on_same_ref(gitlab, project_name, git_ref)
 
-    if len(pipelines) != 0:
+    if pipelines:
         print(
-            (
-                "There are already {} pipeline(s) running on the target git ref.\n"
-                "For each of them, you'll be asked whether you want to cancel them or not.\n"
-                "If you don't need these pipelines, please cancel them to save CI resources.\n"
-                "They are ordered from the newest one to the oldest one.\n"
-            ).format(len(pipelines))
+            "There are already {} pipeline(s) running on the target git ref.".format(len(pipelines)),
+            "For each of them, you'll be asked whether you want to cancel them or not.",
+            "If you don't need these pipelines, please cancel them to save CI resources.",
+            "They are ordered from the newest one to the oldest one.\n",
+            sep='\n',
         )
         cancel_pipelines_with_confirmation(gitlab, project_name, pipelines)
 


### PR DESCRIPTION
### What does this PR do?

Adds a new invoke command, `invoke pipeline.clean-running-pipelines` to cancel running pipelines on a git ref.
When `invoke pipeline.run` is used, the same logic is run, and the user is asked whether they want to cancel existing running pipelines on the same git ref or not.

### Motivation

Limit the number of pipelines running by removing redundant pipelines.
Try to prevent conflicts in kitchen tests (they can happen if two pipelines with kitchen tests run at the same time on the same commit).