### PR TITLE
Send logs API key requests in the header instead of path

### DIFF
--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -10,14 +10,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/telemetry"
-
-	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // ContentType options,

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -60,7 +60,7 @@ func TestBuildURLShouldReturnHTTPSWithUseSSL(t *testing.T) {
 		Host:   "foo",
 		UseSSL: true,
 	})
-	assert.Equal(t, "https://foo/v1/input/bar", url)
+	assert.Equal(t, "https://foo/v1/input", url)
 }
 
 func TestBuildURLShouldReturnHTTPWithoutUseSSL(t *testing.T) {
@@ -69,7 +69,7 @@ func TestBuildURLShouldReturnHTTPWithoutUseSSL(t *testing.T) {
 		Host:   "foo",
 		UseSSL: false,
 	})
-	assert.Equal(t, "http://foo/v1/input/bar", url)
+	assert.Equal(t, "http://foo/v1/input", url)
 }
 
 func TestBuildURLShouldReturnAddressWithPortWhenDefined(t *testing.T) {
@@ -79,7 +79,7 @@ func TestBuildURLShouldReturnAddressWithPortWhenDefined(t *testing.T) {
 		Port:   1234,
 		UseSSL: false,
 	})
-	assert.Equal(t, "http://foo:1234/v1/input/bar", url)
+	assert.Equal(t, "http://foo:1234/v1/input", url)
 }
 
 func TestDestinationSend200(t *testing.T) {

--- a/releasenotes/notes/logs-send-api-key-in-header-ee99f702687fc6bb.yaml
+++ b/releasenotes/notes/logs-send-api-key-in-header-ee99f702687fc6bb.yaml
@@ -1,0 +1,4 @@
+---
+security:
+  - |
+    Authenticate logs http input requests using the API key header rather than the URL path.

--- a/releasenotes/notes/logs-send-api-key-in-header-ee99f702687fc6bb.yaml
+++ b/releasenotes/notes/logs-send-api-key-in-header-ee99f702687fc6bb.yaml
@@ -1,4 +1,4 @@
 ---
-security:
+enhancements:
   - |
     Authenticate logs http input requests using the API key header rather than the URL path.


### PR DESCRIPTION
### What does this PR do?

This PR changes the logs sender authentication method from the URL path to the request headers for HTTP destinations.

So rather than sending logs to URL `/v1/input/apikey1234567890`, we will simply send to `/v1/input`

### Motivation



### Additional Notes

### Describe how to test your changes
