### PR TITLE
Fix parsing of Extension logs in Lambda Extension

### DIFF
--- a/pkg/serverless/aws/logs.go
+++ b/pkg/serverless/aws/logs.go
@@ -142,8 +142,6 @@ func (l *LogMessage) UnmarshalJSON(data []byte) error {
 					log.Error("LogMessage.UnmarshalJSON: can't read the metrics object")
 				}
 				l.StringRecord = createStringRecordForReportLog(l)
-				log.Debug("Unmarshalled REPORT log")
-				log.Debug("String record: " + l.StringRecord)
 			}
 		} else {
 			log.Error("LogMessage.UnmarshalJSON: can't read the record object")
@@ -158,14 +156,7 @@ func (l *LogMessage) UnmarshalJSON(data []byte) error {
 // ShouldProcessLog returns whether or not the log should be further processed.
 func ShouldProcessLog(arn string, lastRequestID string, message LogMessage) bool {
 	// If the global request ID or ARN variable isn't set at this point, do not process further
-	if arn == "" {
-		log.Debug("Skipped processing log message because of missing arn")
-		log.Debug("Message type: " + message.Type)
-		return false
-	}
-	if lastRequestID == "" {
-		log.Debug("Skipped processing log message because of missing lastRequestId")
-		log.Debug("Message type: " + message.Type)
+	if lastRequestID == "" || arn == "" {
 		return false
 	}
 	// Making sure that we do not process these types of logs since they are not tied to specific invovations

--- a/pkg/serverless/aws/logs.go
+++ b/pkg/serverless/aws/logs.go
@@ -92,10 +92,7 @@ func (l *LogMessage) UnmarshalJSON(data []byte) error {
 	switch typ {
 	case LogTypePlatformLogsSubscription, LogTypePlatformExtension:
 		l.Type = typ
-	case LogTypeFunction:
-		l.Type = typ
-		l.StringRecord = j["record"].(string)
-	case LogTypeExtension:
+	case LogTypeFunction, LogTypeExtension:
 		l.Type = typ
 		l.StringRecord = j["record"].(string)
 	case LogTypePlatformStart, LogTypePlatformEnd, LogTypePlatformReport:

--- a/pkg/serverless/aws/logs.go
+++ b/pkg/serverless/aws/logs.go
@@ -156,7 +156,7 @@ func (l *LogMessage) UnmarshalJSON(data []byte) error {
 // ShouldProcessLog returns whether or not the log should be further processed.
 func ShouldProcessLog(arn string, lastRequestID string, message LogMessage) bool {
 	// If the global request ID or ARN variable isn't set at this point, do not process further
-	if lastRequestID == "" || arn == "" {
+	if arn == "" || lastRequestID == "" {
 		return false
 	}
 	// Making sure that we do not process these types of logs since they are not tied to specific invovations

--- a/pkg/serverless/aws/logs_test.go
+++ b/pkg/serverless/aws/logs_test.go
@@ -6,10 +6,30 @@
 package aws
 
 import (
+	"encoding/json"
+	"io/ioutil"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
+
+func TestUnmarshalExtensionLog(t *testing.T) {
+	raw, err := ioutil.ReadFile("./testdata/extension_log.json")
+	require.NoError(t, err)
+	var messages []LogMessage
+	err = json.Unmarshal(raw, &messages)
+	require.NoError(t, err)
+
+	expectedTime, _ := time.Parse(logMessageTimeLayout, "2020-08-20T12:31:32.123Z")
+	expectedLogMessage := LogMessage{
+		Type:         LogTypeExtension,
+		Time:         expectedTime,
+		StringRecord: "sample extension log",
+	}
+	assert.Equal(t, expectedLogMessage, messages[0])
+}
 
 func TestShouldProcessLog(t *testing.T) {
 

--- a/pkg/serverless/aws/testdata/extension_log.json
+++ b/pkg/serverless/aws/testdata/extension_log.json
@@ -1,0 +1,7 @@
+[
+    {
+        "time": "2020-08-20T12:31:32.123Z",
+        "type": "extension",
+        "record": "sample extension log"
+    }
+]

--- a/pkg/serverless/protocol.go
+++ b/pkg/serverless/protocol.go
@@ -319,8 +319,15 @@ func (l *LogsCollection) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func processMessage(message aws.LogMessage, arn string, lastRequestID string, functionName string, computeEnhancedMetrics bool, metricTags []string, metricsChan chan []metrics.MetricSample) {
 	// Do not send logs or metrics if we can't associate them with an ARN or Request ID
 	// First, if the log has a Request ID, set the global Request ID variable
+	log.Debug("processMessage called with lastRequestId: " + lastRequestID)
+
+	if message.Type == aws.LogTypePlatformReport {
+		log.Debug("Called processMessage for a REPORT log")
+		log.Debug("String record of message: " + message.StringRecord)
+	}
 	if message.Type == aws.LogTypePlatformStart {
 		if len(message.ObjectRecord.RequestID) > 0 {
+			log.Debug("Setting Request ID to: " + message.ObjectRecord.RequestID)
 			aws.SetRequestID(message.ObjectRecord.RequestID)
 			lastRequestID = message.ObjectRecord.RequestID
 		}

--- a/pkg/serverless/protocol.go
+++ b/pkg/serverless/protocol.go
@@ -319,15 +319,8 @@ func (l *LogsCollection) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 func processMessage(message aws.LogMessage, arn string, lastRequestID string, functionName string, computeEnhancedMetrics bool, metricTags []string, metricsChan chan []metrics.MetricSample) {
 	// Do not send logs or metrics if we can't associate them with an ARN or Request ID
 	// First, if the log has a Request ID, set the global Request ID variable
-	log.Debug("processMessage called with lastRequestId: " + lastRequestID)
-
-	if message.Type == aws.LogTypePlatformReport {
-		log.Debug("Called processMessage for a REPORT log")
-		log.Debug("String record of message: " + message.StringRecord)
-	}
 	if message.Type == aws.LogTypePlatformStart {
 		if len(message.ObjectRecord.RequestID) > 0 {
-			log.Debug("Setting Request ID to: " + message.ObjectRecord.RequestID)
 			aws.SetRequestID(message.ObjectRecord.RequestID)
 			lastRequestID = message.ObjectRecord.RequestID
 		}


### PR DESCRIPTION
### What does this PR do?

Fixes a bug that caused `EXTENSION` logs (i.e. not `FUNCTION` or `PLATFORM` logs) to not be parsed correctly.

### Describe how to test your changes

Added unit test coverage. Later we can extend this pattern to cover other types of log messages as well.
