### PR TITLE
[KSMCore] Implement cronjob, ep, hpa and vpa count metrics

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
@@ -58,6 +58,9 @@
 `kubernetes_state.deployment.condition`
 : The current status conditions of a deployment. Tags:`kube_deployment` `kube_namespace` (`env` `service` `version` from standard labels).
 
+`kubernetes_state.endpoint.count`
+: Number of endpoints. Tags:`kube_namespace` `endpoint`.
+
 `kubernetes_state.endpoint.address_available`
 : Number of addresses available in endpoint. Tags:`endpoint` `kube_namespace`.
 
@@ -235,6 +238,9 @@
 `kubernetes_state.statefulset.replicas_updated`
 : The number of updated replicas per StatefulSet. Tags:`kube_namespace` `kube_stateful_set` (`env` `service` `version` from standard labels).
 
+`kubernetes_state.hpa.count`
+: Number of horizontal pod autoscaler. Tags: `kube_namespace` `horizontalpodautoscaler`
+
 `kubernetes_state.hpa.min_replicas`
 : Lower limit for the number of pods that can be set by the autoscaler, default 1. Tags:`kube_namespace` `horizontalpodautoscaler`.
 
@@ -252,6 +258,9 @@
 
 `kubernetes_state.hpa.spec_target_metric`
 : The metric specifications used by this autoscaler when calculating the desired replica count. Tags:`kube_namespace` `horizontalpodautoscaler` `metric_name` `metric_target_type`.
+
+`kubernetes_state.vpa.count`
+: Number of vertical pod autoscaler. Tags: `kube_namespace` `verticalpodautoscaler`
 
 `kubernetes_state.vpa.lower_bound`
 : Minimum resources the container can use before the VerticalPodAutoscaler updater evicts it. Tags:`kube_namespace` `verticalpodautoscaler` `kube_container_name` `resource` `target_api_version` `target_kind` `target_name` `unit`.
@@ -273,6 +282,9 @@
 
 `kubernetes_state.vpa.spec_container_maxallowed`
 : Maximum resources the VerticalPodAutoscaler can set for containers matching the name. Tags:`kube_namespace` `verticalpodautoscaler` `kube_container_name` `resource` `target_api_version` `target_kind` `target_name` `unit`.
+
+`kubernetes_state.cronjob.count`
+: Number of cronjobs. Tags:`kube_namespace`.
 
 `kubernetes_state.cronjob.spec_suspend`
 : Suspend flag tells the controller to suspend subsequent executions. Tags:`kube_namespace` `kube_cronjob` (`env` `service` `version` from standard labels).

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
@@ -59,7 +59,7 @@
 : The current status conditions of a deployment. Tags:`kube_deployment` `kube_namespace` (`env` `service` `version` from standard labels).
 
 `kubernetes_state.endpoint.count`
-: Number of endpoints. Tags:`kube_namespace` `endpoint`.
+: Number of endpoints. Tags:`kube_namespace`.
 
 `kubernetes_state.endpoint.address_available`
 : Number of addresses available in endpoint. Tags:`endpoint` `kube_namespace`.
@@ -239,7 +239,7 @@
 : The number of updated replicas per StatefulSet. Tags:`kube_namespace` `kube_stateful_set` (`env` `service` `version` from standard labels).
 
 `kubernetes_state.hpa.count`
-: Number of horizontal pod autoscaler. Tags: `kube_namespace` `horizontalpodautoscaler`
+: Number of horizontal pod autoscaler. Tags: `kube_namespace`.
 
 `kubernetes_state.hpa.min_replicas`
 : Lower limit for the number of pods that can be set by the autoscaler, default 1. Tags:`kube_namespace` `horizontalpodautoscaler`.
@@ -260,7 +260,7 @@
 : The metric specifications used by this autoscaler when calculating the desired replica count. Tags:`kube_namespace` `horizontalpodautoscaler` `metric_name` `metric_target_type`.
 
 `kubernetes_state.vpa.count`
-: Number of vertical pod autoscaler. Tags: `kube_namespace` `verticalpodautoscaler`
+: Number of vertical pod autoscaler. Tags: `kube_namespace`.
 
 `kubernetes_state.vpa.lower_bound`
 : Minimum resources the container can use before the VerticalPodAutoscaler updater evicts it. Tags:`kube_namespace` `verticalpodautoscaler` `kube_container_name` `resource` `target_api_version` `target_kind` `target_name` `unit`.

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
@@ -162,15 +162,15 @@ var (
 		),
 		"kube_endpoint_labels": newCountObjectsAggregator(
 			"endpoint.count",
-			[]string{"namespace", "endpoint"},
+			[]string{"namespace"},
 		),
 		"kube_horizontalpodautoscaler_labels": newCountObjectsAggregator(
 			"hpa.count",
-			[]string{"namespace", "horizontalpodautoscaler"},
+			[]string{"namespace"},
 		),
 		"kube_verticalpodautoscaler_labels": newCountObjectsAggregator(
 			"vpa.count",
-			[]string{"namespace", "verticalpodautoscaler"},
+			[]string{"namespace"},
 		),
 	}
 )

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
@@ -156,5 +156,21 @@ var (
 			"statefulset.count",
 			[]string{"namespace"},
 		),
+		"kube_cronjob_labels": newCountObjectsAggregator(
+			"cronjob.count",
+			[]string{"namespace"},
+		),
+		"kube_endpoint_labels": newCountObjectsAggregator(
+			"endpoint.count",
+			[]string{"namespace", "endpoint"},
+		),
+		"kube_horizontalpodautoscaler_labels": newCountObjectsAggregator(
+			"hpa.count",
+			[]string{"namespace", "horizontalpodautoscaler"},
+		),
+		"kube_verticalpodautoscaler_labels": newCountObjectsAggregator(
+			"vpa.count",
+			[]string{"namespace", "verticalpodautoscaler"},
+		),
 	}
 )

--- a/releasenotes/notes/releasenotes/notes/ksmcore-add-new-count-metrics-67c9c158783846c6.yaml
+++ b/releasenotes/notes/releasenotes/notes/ksmcore-add-new-count-metrics-67c9c158783846c6.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+
+---
+enhancements:
+  - |
+    Implement the following synthetic metrics in the ``kubernetes_state_core`` check to mimic the legacy ``kubernetes_state`` one.
+    * ``cronjob.count``
+    * ``endpoint.count``
+    * ``hpa.count``
+    * ``vpa.count`

--- a/releasenotes/notes/releasenotes/notes/ksmcore-add-new-count-metrics-67c9c158783846c6.yaml
+++ b/releasenotes/notes/releasenotes/notes/ksmcore-add-new-count-metrics-67c9c158783846c6.yaml
@@ -9,7 +9,7 @@
 ---
 enhancements:
   - |
-    Implement the following synthetic metrics in the ``kubernetes_state_core`` check to mimic the legacy ``kubernetes_state`` one.
+    Implement the following synthetic metrics in the ``kubernetes_state_core``.
     * ``cronjob.count``
     * ``endpoint.count``
     * ``hpa.count``


### PR DESCRIPTION
### What does this PR do?

Implements in the KSMCore check the following metrics: 

- `cronjob.count`
- `endpoint.count`
- `hpa.count`
- `vpa.count`

### Motivation

Update the kubernetes_state_core so users can graph the count following missing Kubernetes resource types. 

### Describe how to test your changes

Deploy the agent and enable the kubernetes_state_core check and validate that the above mentioned metrics are correctly generated. 

<img width="701" alt="Image 2021-05-18 at 1 22 19 PM" src="https://user-images.githubusercontent.com/3012422/118884922-0fea1800-b8c5-11eb-918d-f9b05211535e.png">

