### PR TITLE
[runtime-security] Export in_upper_layer field for exec events

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "c8d0964288f045acdca15154af069fd1f08cf0edb5cc4a02976189cc5953268b")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "164eb69bf352c9b1a9cd5ca0ff346ef47cb2f70969103aacea526c32f68558b5")

--- a/pkg/security/ebpf/c/exec.h
+++ b/pkg/security/ebpf/c/exec.h
@@ -220,6 +220,7 @@ int __attribute__((always_inline)) handle_exec_event(struct pt_regs *ctx, struct
         .exec_timestamp = bpf_ktime_get_ns(),
     };
     fill_file_metadata(exec_dentry, &entry.executable.metadata);
+    set_file_inode(exec_dentry, &entry.executable, 0);
     bpf_get_current_comm(&entry.comm, sizeof(entry.comm));
 
     // select the previous cookie entry in cache of the current process

--- a/pkg/security/model/accessors.go
+++ b/pkg/security/model/accessors.go
@@ -149,7 +149,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).Chmod.File.InUpperLayer
+				return (*Event)(ctx.Object).Chmod.File.FileFields.InUpperLayer
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -329,7 +329,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).Chown.File.InUpperLayer
+				return (*Event)(ctx.Object).Chown.File.FileFields.InUpperLayer
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -650,6 +650,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "exec.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).Exec.Process.FileFields.InUpperLayer
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "exec.file.inode":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -904,7 +914,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).Link.Target.InUpperLayer
+				return (*Event)(ctx.Object).Link.Target.FileFields.InUpperLayer
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1024,7 +1034,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).Link.Source.InUpperLayer
+				return (*Event)(ctx.Object).Link.Source.FileFields.InUpperLayer
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1184,7 +1194,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).Mkdir.File.InUpperLayer
+				return (*Event)(ctx.Object).Mkdir.File.FileFields.InUpperLayer
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1334,7 +1344,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).Open.File.InUpperLayer
+				return (*Event)(ctx.Object).Open.File.FileFields.InUpperLayer
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1754,6 +1764,31 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					element := (*ProcessCacheEntry)(value)
 
 					result = element.ProcessContext.Process.FileFields.Group
+
+					results = append(results, result)
+
+					value = iterator.Next()
+				}
+
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.in_upper_layer":
+		return &eval.BoolArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []bool {
+				var results []bool
+
+				iterator := &ProcessAncestorsIterator{}
+
+				value := iterator.Front(ctx)
+				for value != nil {
+					var result bool
+
+					element := (*ProcessCacheEntry)(value)
+
+					result = element.ProcessContext.Process.FileFields.InUpperLayer
 
 					results = append(results, result)
 
@@ -2395,6 +2430,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "process.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).ProcessContext.Process.FileFields.InUpperLayer
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "process.file.inode":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -2659,7 +2704,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).RemoveXAttr.File.InUpperLayer
+				return (*Event)(ctx.Object).RemoveXAttr.File.FileFields.InUpperLayer
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -2809,7 +2854,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).Rename.New.InUpperLayer
+				return (*Event)(ctx.Object).Rename.New.FileFields.InUpperLayer
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -2929,7 +2974,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).Rename.Old.InUpperLayer
+				return (*Event)(ctx.Object).Rename.Old.FileFields.InUpperLayer
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -3069,7 +3114,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).Rmdir.File.InUpperLayer
+				return (*Event)(ctx.Object).Rmdir.File.FileFields.InUpperLayer
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -3349,7 +3394,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).SetXAttr.File.InUpperLayer
+				return (*Event)(ctx.Object).SetXAttr.File.FileFields.InUpperLayer
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -3489,7 +3534,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).Unlink.File.InUpperLayer
+				return (*Event)(ctx.Object).Unlink.File.FileFields.InUpperLayer
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -3629,7 +3674,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).Utimes.File.InUpperLayer
+				return (*Event)(ctx.Object).Utimes.File.FileFields.InUpperLayer
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -3849,6 +3894,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"exec.file.group",
 
+		"exec.file.in_upper_layer",
+
 		"exec.file.inode",
 
 		"exec.file.mode",
@@ -4033,6 +4080,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"process.ancestors.file.group",
 
+		"process.ancestors.file.in_upper_layer",
+
 		"process.ancestors.file.inode",
 
 		"process.ancestors.file.mode",
@@ -4098,6 +4147,8 @@ func (e *Event) GetFields() []eval.Field {
 		"process.file.gid",
 
 		"process.file.group",
+
+		"process.file.in_upper_layer",
 
 		"process.file.inode",
 
@@ -4404,7 +4455,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "chmod.file.in_upper_layer":
 
-		return e.Chmod.File.InUpperLayer, nil
+		return e.Chmod.File.FileFields.InUpperLayer, nil
 
 	case "chmod.file.inode":
 
@@ -4476,7 +4527,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "chown.file.in_upper_layer":
 
-		return e.Chown.File.InUpperLayer, nil
+		return e.Chown.File.FileFields.InUpperLayer, nil
 
 	case "chown.file.inode":
 
@@ -4602,6 +4653,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Exec.Process.FileFields.Group, nil
 
+	case "exec.file.in_upper_layer":
+
+		return e.Exec.Process.FileFields.InUpperLayer, nil
+
 	case "exec.file.inode":
 
 		return int(e.Exec.Process.FileFields.Inode), nil
@@ -4704,7 +4759,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "link.file.destination.in_upper_layer":
 
-		return e.Link.Target.InUpperLayer, nil
+		return e.Link.Target.FileFields.InUpperLayer, nil
 
 	case "link.file.destination.inode":
 
@@ -4752,7 +4807,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "link.file.in_upper_layer":
 
-		return e.Link.Source.InUpperLayer, nil
+		return e.Link.Source.FileFields.InUpperLayer, nil
 
 	case "link.file.inode":
 
@@ -4816,7 +4871,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "mkdir.file.in_upper_layer":
 
-		return e.Mkdir.File.InUpperLayer, nil
+		return e.Mkdir.File.FileFields.InUpperLayer, nil
 
 	case "mkdir.file.inode":
 
@@ -4876,7 +4931,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "open.file.in_upper_layer":
 
-		return e.Open.File.InUpperLayer, nil
+		return e.Open.File.FileFields.InUpperLayer, nil
 
 	case "open.file.inode":
 
@@ -5196,6 +5251,28 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 			element := (*ProcessCacheEntry)(ptr)
 
 			result := element.ProcessContext.Process.FileFields.Group
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.in_upper_layer":
+
+		var values []bool
+
+		ctx := eval.NewContext(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := element.ProcessContext.Process.FileFields.InUpperLayer
 
 			values = append(values, result)
 
@@ -5696,6 +5773,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ProcessContext.Process.FileFields.Group, nil
 
+	case "process.file.in_upper_layer":
+
+		return e.ProcessContext.Process.FileFields.InUpperLayer, nil
+
 	case "process.file.inode":
 
 		return int(e.ProcessContext.Process.FileFields.Inode), nil
@@ -5802,7 +5883,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "removexattr.file.in_upper_layer":
 
-		return e.RemoveXAttr.File.InUpperLayer, nil
+		return e.RemoveXAttr.File.FileFields.InUpperLayer, nil
 
 	case "removexattr.file.inode":
 
@@ -5862,7 +5943,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "rename.file.destination.in_upper_layer":
 
-		return e.Rename.New.InUpperLayer, nil
+		return e.Rename.New.FileFields.InUpperLayer, nil
 
 	case "rename.file.destination.inode":
 
@@ -5910,7 +5991,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "rename.file.in_upper_layer":
 
-		return e.Rename.Old.InUpperLayer, nil
+		return e.Rename.Old.FileFields.InUpperLayer, nil
 
 	case "rename.file.inode":
 
@@ -5966,7 +6047,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "rmdir.file.in_upper_layer":
 
-		return e.Rmdir.File.InUpperLayer, nil
+		return e.Rmdir.File.FileFields.InUpperLayer, nil
 
 	case "rmdir.file.inode":
 
@@ -6078,7 +6159,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "setxattr.file.in_upper_layer":
 
-		return e.SetXAttr.File.InUpperLayer, nil
+		return e.SetXAttr.File.FileFields.InUpperLayer, nil
 
 	case "setxattr.file.inode":
 
@@ -6134,7 +6215,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "unlink.file.in_upper_layer":
 
-		return e.Unlink.File.InUpperLayer, nil
+		return e.Unlink.File.FileFields.InUpperLayer, nil
 
 	case "unlink.file.inode":
 
@@ -6190,7 +6271,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "utimes.file.in_upper_layer":
 
-		return e.Utimes.File.InUpperLayer, nil
+		return e.Utimes.File.FileFields.InUpperLayer, nil
 
 	case "utimes.file.inode":
 
@@ -6408,6 +6489,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "exec", nil
 
 	case "exec.file.group":
+		return "exec", nil
+
+	case "exec.file.in_upper_layer":
 		return "exec", nil
 
 	case "exec.file.inode":
@@ -6686,6 +6770,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "process.ancestors.file.group":
 		return "*", nil
 
+	case "process.ancestors.file.in_upper_layer":
+		return "*", nil
+
 	case "process.ancestors.file.inode":
 		return "*", nil
 
@@ -6783,6 +6870,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 
 	case "process.file.group":
+		return "*", nil
+
+	case "process.file.in_upper_layer":
 		return "*", nil
 
 	case "process.file.inode":
@@ -7424,6 +7514,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "exec.file.in_upper_layer":
+
+		return reflect.Bool, nil
+
 	case "exec.file.inode":
 
 		return reflect.Int, nil
@@ -7792,6 +7886,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "process.ancestors.file.in_upper_layer":
+
+		return reflect.Bool, nil
+
 	case "process.ancestors.file.inode":
 
 		return reflect.Int, nil
@@ -7923,6 +8021,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "process.file.group":
 
 		return reflect.String, nil
+
+	case "process.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "process.file.inode":
 
@@ -8550,8 +8652,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "chmod.file.in_upper_layer":
 
 		var ok bool
-		if e.Chmod.File.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.InUpperLayer"}
+		if e.Chmod.File.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -8736,8 +8838,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "chown.file.in_upper_layer":
 
 		var ok bool
-		if e.Chown.File.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chown.File.InUpperLayer"}
+		if e.Chown.File.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -9064,6 +9166,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "exec.file.in_upper_layer":
+
+		var ok bool
+		if e.Exec.Process.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.InUpperLayer"}
+		}
+		return nil
+
 	case "exec.file.inode":
 
 		var ok bool
@@ -9329,8 +9439,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "link.file.destination.in_upper_layer":
 
 		var ok bool
-		if e.Link.Target.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Target.InUpperLayer"}
+		if e.Link.Target.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -9452,8 +9562,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "link.file.in_upper_layer":
 
 		var ok bool
-		if e.Link.Source.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Source.InUpperLayer"}
+		if e.Link.Source.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -9616,8 +9726,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "mkdir.file.in_upper_layer":
 
 		var ok bool
-		if e.Mkdir.File.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.InUpperLayer"}
+		if e.Mkdir.File.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -9770,8 +9880,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "open.file.in_upper_layer":
 
 		var ok bool
-		if e.Open.File.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Open.File.InUpperLayer"}
+		if e.Open.File.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -10065,6 +10175,18 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.Group = str
 
+		return nil
+
+	case "process.ancestors.file.in_upper_layer":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+
+		var ok bool
+		if e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.InUpperLayer"}
+		}
 		return nil
 
 	case "process.ancestors.file.inode":
@@ -10492,6 +10614,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "process.file.in_upper_layer":
+
+		var ok bool
+		if e.ProcessContext.Process.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.InUpperLayer"}
+		}
+		return nil
+
 	case "process.file.inode":
 
 		var ok bool
@@ -10768,8 +10898,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "removexattr.file.in_upper_layer":
 
 		var ok bool
-		if e.RemoveXAttr.File.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.InUpperLayer"}
+		if e.RemoveXAttr.File.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -10923,8 +11053,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "rename.file.destination.in_upper_layer":
 
 		var ok bool
-		if e.Rename.New.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.New.InUpperLayer"}
+		if e.Rename.New.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -11046,8 +11176,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "rename.file.in_upper_layer":
 
 		var ok bool
-		if e.Rename.Old.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.InUpperLayer"}
+		if e.Rename.Old.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -11190,8 +11320,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "rmdir.file.in_upper_layer":
 
 		var ok bool
-		if e.Rmdir.File.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.InUpperLayer"}
+		if e.Rmdir.File.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -11482,8 +11612,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "setxattr.file.in_upper_layer":
 
 		var ok bool
-		if e.SetXAttr.File.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.InUpperLayer"}
+		if e.SetXAttr.File.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -11626,8 +11756,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "unlink.file.in_upper_layer":
 
 		var ok bool
-		if e.Unlink.File.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.InUpperLayer"}
+		if e.Unlink.File.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -11770,8 +11900,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "utimes.file.in_upper_layer":
 
 		var ok bool
-		if e.Utimes.File.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.InUpperLayer"}
+		if e.Utimes.File.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.InUpperLayer"}
 		}
 		return nil
 

--- a/pkg/security/model/model.go
+++ b/pkg/security/model/model.go
@@ -286,10 +286,11 @@ type FileFields struct {
 	CTime time.Time `field:"-"`
 	MTime time.Time `field:"-"`
 
-	MountID uint32 `field:"mount_id"`
-	Inode   uint64 `field:"inode"`
-	PathID  uint32 `field:"-"`
-	Flags   int32  `field:"-"`
+	MountID      uint32 `field:"mount_id"`
+	Inode        uint64 `field:"inode"`
+	PathID       uint32 `field:"-"`
+	Flags        int32  `field:"-"`
+	InUpperLayer bool   `field:"in_upper_layer,ResolveFileFieldsInUpperLayer"`
 }
 
 // GetInLowerLayer returns whether a file is in a lower layer
@@ -309,7 +310,6 @@ type FileEvent struct {
 	ContainerPath string `field:"container_path,ResolveFileContainerPath"`
 	BasenameStr   string `field:"name,ResolveFileBasename"`
 	Filesytem     string `field:"filesystem,ResolveFileFilesystem"`
-	InUpperLayer  bool   `field:"in_upper_layer,ResolveFileInUpperLayer"`
 
 	PathResolutionError error `field:"-"`
 }

--- a/pkg/security/probe/accessors.go
+++ b/pkg/security/probe/accessors.go
@@ -150,7 +150,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).Chmod.File)
+				return (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&(*Event)(ctx.Object).Chmod.File.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -330,7 +330,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).Chown.File)
+				return (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&(*Event)(ctx.Object).Chown.File.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -651,6 +651,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "exec.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&(*Event)(ctx.Object).Exec.Process.FileFields)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "exec.file.inode":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -905,7 +915,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).Link.Target)
+				return (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&(*Event)(ctx.Object).Link.Target.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1025,7 +1035,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).Link.Source)
+				return (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&(*Event)(ctx.Object).Link.Source.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1185,7 +1195,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).Mkdir.File)
+				return (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&(*Event)(ctx.Object).Mkdir.File.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1335,7 +1345,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).Open.File)
+				return (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&(*Event)(ctx.Object).Open.File.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1832,6 +1842,37 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					element := (*model.ProcessCacheEntry)(value)
 
 					result = (*Event)(ctx.Object).ResolveFileFieldsGroup(&element.FileFields)
+
+					results = append(results, result)
+
+					value = iterator.Next()
+				}
+				ctx.Cache[field] = unsafe.Pointer(&results)
+
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.in_upper_layer":
+		return &eval.BoolArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []bool {
+				if ptr := ctx.Cache[field]; ptr != nil {
+					if result := (*[]bool)(ptr); result != nil {
+						return *result
+					}
+				}
+				var results []bool
+
+				iterator := &model.ProcessAncestorsIterator{}
+
+				value := iterator.Front(ctx)
+				for value != nil {
+					var result bool
+
+					element := (*model.ProcessCacheEntry)(value)
+
+					result = (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&element.FileFields)
 
 					results = append(results, result)
 
@@ -2594,6 +2635,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "process.file.in_upper_layer":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&(*Event)(ctx.Object).ProcessContext.Process.FileFields)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "process.file.inode":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -2858,7 +2909,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).RemoveXAttr.File)
+				return (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&(*Event)(ctx.Object).RemoveXAttr.File.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -3008,7 +3059,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).Rename.New)
+				return (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&(*Event)(ctx.Object).Rename.New.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -3128,7 +3179,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).Rename.Old)
+				return (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&(*Event)(ctx.Object).Rename.Old.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -3268,7 +3319,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).Rmdir.File)
+				return (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&(*Event)(ctx.Object).Rmdir.File.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -3548,7 +3599,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).SetXAttr.File)
+				return (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&(*Event)(ctx.Object).SetXAttr.File.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -3688,7 +3739,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).Unlink.File)
+				return (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&(*Event)(ctx.Object).Unlink.File.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -3828,7 +3879,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).ResolveFileInUpperLayer(&(*Event)(ctx.Object).Utimes.File)
+				return (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&(*Event)(ctx.Object).Utimes.File.FileFields)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -4048,6 +4099,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"exec.file.group",
 
+		"exec.file.in_upper_layer",
+
 		"exec.file.inode",
 
 		"exec.file.mode",
@@ -4232,6 +4285,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"process.ancestors.file.group",
 
+		"process.ancestors.file.in_upper_layer",
+
 		"process.ancestors.file.inode",
 
 		"process.ancestors.file.mode",
@@ -4297,6 +4352,8 @@ func (e *Event) GetFields() []eval.Field {
 		"process.file.gid",
 
 		"process.file.group",
+
+		"process.file.in_upper_layer",
 
 		"process.file.inode",
 
@@ -4603,7 +4660,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "chmod.file.in_upper_layer":
 
-		return e.ResolveFileInUpperLayer(&e.Chmod.File), nil
+		return e.ResolveFileFieldsInUpperLayer(&e.Chmod.File.FileFields), nil
 
 	case "chmod.file.inode":
 
@@ -4675,7 +4732,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "chown.file.in_upper_layer":
 
-		return e.ResolveFileInUpperLayer(&e.Chown.File), nil
+		return e.ResolveFileFieldsInUpperLayer(&e.Chown.File.FileFields), nil
 
 	case "chown.file.inode":
 
@@ -4801,6 +4858,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveFileFieldsGroup(&e.Exec.Process.FileFields), nil
 
+	case "exec.file.in_upper_layer":
+
+		return e.ResolveFileFieldsInUpperLayer(&e.Exec.Process.FileFields), nil
+
 	case "exec.file.inode":
 
 		return int(e.Exec.Process.FileFields.Inode), nil
@@ -4903,7 +4964,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "link.file.destination.in_upper_layer":
 
-		return e.ResolveFileInUpperLayer(&e.Link.Target), nil
+		return e.ResolveFileFieldsInUpperLayer(&e.Link.Target.FileFields), nil
 
 	case "link.file.destination.inode":
 
@@ -4951,7 +5012,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "link.file.in_upper_layer":
 
-		return e.ResolveFileInUpperLayer(&e.Link.Source), nil
+		return e.ResolveFileFieldsInUpperLayer(&e.Link.Source.FileFields), nil
 
 	case "link.file.inode":
 
@@ -5015,7 +5076,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "mkdir.file.in_upper_layer":
 
-		return e.ResolveFileInUpperLayer(&e.Mkdir.File), nil
+		return e.ResolveFileFieldsInUpperLayer(&e.Mkdir.File.FileFields), nil
 
 	case "mkdir.file.inode":
 
@@ -5075,7 +5136,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "open.file.in_upper_layer":
 
-		return e.ResolveFileInUpperLayer(&e.Open.File), nil
+		return e.ResolveFileFieldsInUpperLayer(&e.Open.File.FileFields), nil
 
 	case "open.file.inode":
 
@@ -5395,6 +5456,28 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 			element := (*model.ProcessCacheEntry)(ptr)
 
 			result := (*Event)(ctx.Object).ResolveFileFieldsGroup(&element.FileFields)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.in_upper_layer":
+
+		var values []bool
+
+		ctx := eval.NewContext(unsafe.Pointer(e))
+
+		iterator := &model.ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*model.ProcessCacheEntry)(ptr)
+
+			result := (*Event)(ctx.Object).ResolveFileFieldsInUpperLayer(&element.FileFields)
 
 			values = append(values, result)
 
@@ -5895,6 +5978,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveFileFieldsGroup(&e.ProcessContext.Process.FileFields), nil
 
+	case "process.file.in_upper_layer":
+
+		return e.ResolveFileFieldsInUpperLayer(&e.ProcessContext.Process.FileFields), nil
+
 	case "process.file.inode":
 
 		return int(e.ProcessContext.Process.FileFields.Inode), nil
@@ -6001,7 +6088,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "removexattr.file.in_upper_layer":
 
-		return e.ResolveFileInUpperLayer(&e.RemoveXAttr.File), nil
+		return e.ResolveFileFieldsInUpperLayer(&e.RemoveXAttr.File.FileFields), nil
 
 	case "removexattr.file.inode":
 
@@ -6061,7 +6148,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "rename.file.destination.in_upper_layer":
 
-		return e.ResolveFileInUpperLayer(&e.Rename.New), nil
+		return e.ResolveFileFieldsInUpperLayer(&e.Rename.New.FileFields), nil
 
 	case "rename.file.destination.inode":
 
@@ -6109,7 +6196,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "rename.file.in_upper_layer":
 
-		return e.ResolveFileInUpperLayer(&e.Rename.Old), nil
+		return e.ResolveFileFieldsInUpperLayer(&e.Rename.Old.FileFields), nil
 
 	case "rename.file.inode":
 
@@ -6165,7 +6252,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "rmdir.file.in_upper_layer":
 
-		return e.ResolveFileInUpperLayer(&e.Rmdir.File), nil
+		return e.ResolveFileFieldsInUpperLayer(&e.Rmdir.File.FileFields), nil
 
 	case "rmdir.file.inode":
 
@@ -6277,7 +6364,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "setxattr.file.in_upper_layer":
 
-		return e.ResolveFileInUpperLayer(&e.SetXAttr.File), nil
+		return e.ResolveFileFieldsInUpperLayer(&e.SetXAttr.File.FileFields), nil
 
 	case "setxattr.file.inode":
 
@@ -6333,7 +6420,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "unlink.file.in_upper_layer":
 
-		return e.ResolveFileInUpperLayer(&e.Unlink.File), nil
+		return e.ResolveFileFieldsInUpperLayer(&e.Unlink.File.FileFields), nil
 
 	case "unlink.file.inode":
 
@@ -6389,7 +6476,7 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "utimes.file.in_upper_layer":
 
-		return e.ResolveFileInUpperLayer(&e.Utimes.File), nil
+		return e.ResolveFileFieldsInUpperLayer(&e.Utimes.File.FileFields), nil
 
 	case "utimes.file.inode":
 
@@ -6607,6 +6694,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "exec", nil
 
 	case "exec.file.group":
+		return "exec", nil
+
+	case "exec.file.in_upper_layer":
 		return "exec", nil
 
 	case "exec.file.inode":
@@ -6885,6 +6975,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "process.ancestors.file.group":
 		return "*", nil
 
+	case "process.ancestors.file.in_upper_layer":
+		return "*", nil
+
 	case "process.ancestors.file.inode":
 		return "*", nil
 
@@ -6982,6 +7075,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 
 	case "process.file.group":
+		return "*", nil
+
+	case "process.file.in_upper_layer":
 		return "*", nil
 
 	case "process.file.inode":
@@ -7623,6 +7719,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "exec.file.in_upper_layer":
+
+		return reflect.Bool, nil
+
 	case "exec.file.inode":
 
 		return reflect.Int, nil
@@ -7991,6 +8091,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "process.ancestors.file.in_upper_layer":
+
+		return reflect.Bool, nil
+
 	case "process.ancestors.file.inode":
 
 		return reflect.Int, nil
@@ -8122,6 +8226,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "process.file.group":
 
 		return reflect.String, nil
+
+	case "process.file.in_upper_layer":
+
+		return reflect.Bool, nil
 
 	case "process.file.inode":
 
@@ -8749,8 +8857,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "chmod.file.in_upper_layer":
 
 		var ok bool
-		if e.Chmod.File.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.InUpperLayer"}
+		if e.Chmod.File.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -8935,8 +9043,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "chown.file.in_upper_layer":
 
 		var ok bool
-		if e.Chown.File.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Chown.File.InUpperLayer"}
+		if e.Chown.File.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -9263,6 +9371,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "exec.file.in_upper_layer":
+
+		var ok bool
+		if e.Exec.Process.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.InUpperLayer"}
+		}
+		return nil
+
 	case "exec.file.inode":
 
 		var ok bool
@@ -9528,8 +9644,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "link.file.destination.in_upper_layer":
 
 		var ok bool
-		if e.Link.Target.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Target.InUpperLayer"}
+		if e.Link.Target.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -9651,8 +9767,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "link.file.in_upper_layer":
 
 		var ok bool
-		if e.Link.Source.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Link.Source.InUpperLayer"}
+		if e.Link.Source.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -9815,8 +9931,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "mkdir.file.in_upper_layer":
 
 		var ok bool
-		if e.Mkdir.File.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.InUpperLayer"}
+		if e.Mkdir.File.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -9969,8 +10085,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "open.file.in_upper_layer":
 
 		var ok bool
-		if e.Open.File.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Open.File.InUpperLayer"}
+		if e.Open.File.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -10264,6 +10380,18 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.Group = str
 
+		return nil
+
+	case "process.ancestors.file.in_upper_layer":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &model.ProcessCacheEntry{}
+		}
+
+		var ok bool
+		if e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.InUpperLayer"}
+		}
 		return nil
 
 	case "process.ancestors.file.inode":
@@ -10691,6 +10819,14 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "process.file.in_upper_layer":
+
+		var ok bool
+		if e.ProcessContext.Process.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.InUpperLayer"}
+		}
+		return nil
+
 	case "process.file.inode":
 
 		var ok bool
@@ -10967,8 +11103,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "removexattr.file.in_upper_layer":
 
 		var ok bool
-		if e.RemoveXAttr.File.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.InUpperLayer"}
+		if e.RemoveXAttr.File.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -11122,8 +11258,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "rename.file.destination.in_upper_layer":
 
 		var ok bool
-		if e.Rename.New.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.New.InUpperLayer"}
+		if e.Rename.New.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -11245,8 +11381,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "rename.file.in_upper_layer":
 
 		var ok bool
-		if e.Rename.Old.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.InUpperLayer"}
+		if e.Rename.Old.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -11389,8 +11525,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "rmdir.file.in_upper_layer":
 
 		var ok bool
-		if e.Rmdir.File.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.InUpperLayer"}
+		if e.Rmdir.File.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -11681,8 +11817,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "setxattr.file.in_upper_layer":
 
 		var ok bool
-		if e.SetXAttr.File.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.InUpperLayer"}
+		if e.SetXAttr.File.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -11825,8 +11961,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "unlink.file.in_upper_layer":
 
 		var ok bool
-		if e.Unlink.File.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.InUpperLayer"}
+		if e.Unlink.File.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.InUpperLayer"}
 		}
 		return nil
 
@@ -11969,8 +12105,8 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 	case "utimes.file.in_upper_layer":
 
 		var ok bool
-		if e.Utimes.File.InUpperLayer, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.InUpperLayer"}
+		if e.Utimes.File.FileFields.InUpperLayer, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.InUpperLayer"}
 		}
 		return nil
 

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -87,9 +87,9 @@ func (ev *Event) ResolveFileFilesystem(f *model.FileEvent) string {
 	return ev.resolvers.MountResolver.GetFilesystem(f.FileFields.MountID)
 }
 
-// ResolveFileInUpperLayer resolves whether the file is in an upper layer
-func (ev *Event) ResolveFileInUpperLayer(f *model.FileEvent) bool {
-	return f.FileFields.GetInUpperLayer()
+// ResolveFileFieldsInUpperLayer resolves whether the file is in an upper layer
+func (ev *Event) ResolveFileFieldsInUpperLayer(f *model.FileFields) bool {
+	return f.GetInUpperLayer()
 }
 
 // ResolveXAttrName returns the string representation of the extended attribute name

--- a/pkg/security/tests/probe_monitor_test.go
+++ b/pkg/security/tests/probe_monitor_test.go
@@ -106,8 +106,6 @@ func truncatedParents(t *testing.T, opts testOpts) {
 					// count the "a"s.
 					splittedFilepath = splittedFilepath[1:]
 				}
-				t.Logf("%s", filepath.(string))
-				t.Logf("%v", splittedFilepath)
 				assert.Equal(t, splittedFilepath[0], "a", "invalid path resolution at the left edge")
 				assert.Equal(t, splittedFilepath[len(splittedFilepath)-1], "a", "invalid path resolution at the right edge")
 				assert.Equal(t, len(splittedFilepath), model.MaxPathDepth, "invalid path depth")


### PR DESCRIPTION
### What does this PR do?

This PR exports `in_upper_layer` for `exec` events. This field can now be used to write rules and the context provided with `exec` events is now correct.

### Motivation

The value of `in_upper_layer` context for `exec` events is currently incorrect.

### Describe how to test your changes

Make sure that a rule can be written with a condition on `exec.file.in_upper_layer`. Check that the exported context for that field is correct.