### PR TITLE
[logs] exponential backoff for logs http sender

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -70,6 +70,18 @@ const (
 
 	// DefaultRuntimePoliciesDir is the default policies directory used by the runtime security module
 	DefaultRuntimePoliciesDir = "/etc/datadog-agent/runtime-security.d"
+
+	// DefaultLogsSenderBackoffFactor is the default logs sender backoff randomness factor
+	DefaultLogsSenderBackoffFactor = 2.0
+
+	// DefaultLogsSenderBackoffBase is the default logs sender base backoff time, seconds
+	DefaultLogsSenderBackoffBase = 0.05
+
+	// DefaultLogsSenderBackoffMax is the default logs sender maximum backoff time, seconds
+	DefaultLogsSenderBackoffMax = 1.0
+
+	// DefaultLogsSenderBackoffRecoveryInterval is the default logs sender backoff recovery interval
+	DefaultLogsSenderBackoffRecoveryInterval = 2
 )
 
 // Datadog is the global configuration object
@@ -1104,6 +1116,11 @@ func bindEnvAndSetLogsConfigKeys(config Config, prefix string) {
 	config.BindEnvAndSetDefault(prefix+"batch_max_concurrent_send", DefaultBatchMaxConcurrentSend)
 	config.BindEnvAndSetDefault(prefix+"batch_max_content_size", DefaultBatchMaxContentSize)
 	config.BindEnvAndSetDefault(prefix+"batch_max_size", DefaultBatchMaxSize)
+	config.BindEnvAndSetDefault(prefix+"sender_backoff_factor", DefaultLogsSenderBackoffFactor)
+	config.BindEnvAndSetDefault(prefix+"sender_backoff_base", DefaultLogsSenderBackoffBase)
+	config.BindEnvAndSetDefault(prefix+"sender_backoff_max", DefaultLogsSenderBackoffMax)
+	config.BindEnvAndSetDefault(prefix+"sender_recovery_interval", DefaultForwarderRecoveryInterval)
+	config.BindEnvAndSetDefault(prefix+"sender_recovery_reset", false)
 }
 
 // getDomainPrefix provides the right prefix for agent X.Y.Z

--- a/pkg/forwarder/blocked_endpoints.go
+++ b/pkg/forwarder/blocked_endpoints.go
@@ -6,20 +6,13 @@
 package forwarder
 
 import (
-	"math"
-	"math/rand"
 	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/backoff"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
-
-const secondsFloat = float64(time.Second)
-
-func randomBetween(min, max float64) float64 {
-	return rand.Float64()*(max-min) + min
-}
 
 type block struct {
 	nbError int
@@ -28,28 +21,8 @@ type block struct {
 
 type blockedEndpoints struct {
 	errorPerEndpoint map[string]*block
+	backoffPolicy    backoff.BackoffPolicy
 	m                sync.RWMutex
-
-	// This controls the overlap between consecutive retry interval ranges. When
-	// set to `2`, there is a guarantee that there will be no overlap. The overlap
-	// will asymptotically approach 50% the higher the value is set.
-	minBackoffFactor float64
-
-	// This controls the rate of exponential growth. Also, you can calculate the start
-	// of the very first retry interval range by evaluating the following expression:
-	// baseBackoffTime / minBackoffFactor * 2
-	baseBackoffTime float64
-
-	// This is the maximum number of seconds to wait for a retry.
-	maxBackoffTime float64
-
-	// This controls how many retry interval ranges to step down for an endpoint
-	// upon success. Increasing this should only be considered when maxBackoffTime
-	// is particularly high or if our intake team is particularly confident.
-	recoveryInterval int
-
-	// This derived value is the number of errors it will take to reach the maxBackoffTime.
-	maxErrors int
 }
 
 func newBlockedEndpoints() *blockedEndpoints {
@@ -71,8 +44,6 @@ func newBlockedEndpoints() *blockedEndpoints {
 		backoffMax = 64
 	}
 
-	errorsMax := int(math.Floor(math.Log2(backoffMax/backoffBase))) + 1
-
 	recInterval := config.Datadog.GetInt("forwarder_recovery_interval")
 	if recInterval <= 0 {
 		log.Warnf("Configured forwarder_recovery_interval (%v) is not positive; %v will be used", recInterval, config.DefaultForwarderRecoveryInterval)
@@ -80,17 +51,10 @@ func newBlockedEndpoints() *blockedEndpoints {
 	}
 
 	recoveryReset := config.Datadog.GetBool("forwarder_recovery_reset")
-	if recoveryReset {
-		recInterval = errorsMax
-	}
 
 	return &blockedEndpoints{
 		errorPerEndpoint: make(map[string]*block),
-		minBackoffFactor: backoffFactor,
-		baseBackoffTime:  backoffBase,
-		maxBackoffTime:   backoffMax,
-		recoveryInterval: recInterval,
-		maxErrors:        errorsMax,
+		backoffPolicy:    backoff.NewBackoffPolicy(backoffFactor, backoffBase, backoffMax, recInterval, recoveryReset),
 	}
 }
 
@@ -105,10 +69,7 @@ func (e *blockedEndpoints) close(endpoint string) {
 		b = &block{}
 	}
 
-	b.nbError++
-	if b.nbError > e.maxErrors {
-		b.nbError = e.maxErrors
-	}
+	b.nbError = e.backoffPolicy.IncError(b.nbError)
 	b.until = time.Now().Add(e.getBackoffDuration(b.nbError))
 
 	e.errorPerEndpoint[endpoint] = b
@@ -125,10 +86,7 @@ func (e *blockedEndpoints) recover(endpoint string) {
 		b = &block{}
 	}
 
-	b.nbError -= e.recoveryInterval
-	if b.nbError < 0 {
-		b.nbError = 0
-	}
+	b.nbError = e.backoffPolicy.DecError(b.nbError)
 	b.until = time.Now().Add(e.getBackoffDuration(b.nbError))
 
 	e.errorPerEndpoint[endpoint] = b
@@ -145,19 +103,5 @@ func (e *blockedEndpoints) isBlock(endpoint string) bool {
 }
 
 func (e *blockedEndpoints) getBackoffDuration(numErrors int) time.Duration {
-	var backoffTime float64
-
-	if numErrors > 0 {
-		backoffTime = e.baseBackoffTime * math.Pow(2, float64(numErrors))
-
-		if backoffTime > e.maxBackoffTime {
-			backoffTime = e.maxBackoffTime
-		} else {
-			min := backoffTime / e.minBackoffFactor
-			max := math.Min(e.maxBackoffTime, backoffTime)
-			backoffTime = randomBetween(min, max)
-		}
-	}
-
-	return time.Duration(backoffTime * secondsFloat)
+	return e.backoffPolicy.GetBackoffDuration(numErrors)
 }

--- a/pkg/forwarder/blocked_endpoints.go
+++ b/pkg/forwarder/blocked_endpoints.go
@@ -21,7 +21,7 @@ type block struct {
 
 type blockedEndpoints struct {
 	errorPerEndpoint map[string]*block
-	backoffPolicy    backoff.BackoffPolicy
+	backoffPolicy    backoff.Policy
 	m                sync.RWMutex
 }
 
@@ -54,7 +54,7 @@ func newBlockedEndpoints() *blockedEndpoints {
 
 	return &blockedEndpoints{
 		errorPerEndpoint: make(map[string]*block),
-		backoffPolicy:    backoff.NewBackoffPolicy(backoffFactor, backoffBase, backoffMax, recInterval, recoveryReset),
+		backoffPolicy:    backoff.NewPolicy(backoffFactor, backoffBase, backoffMax, recInterval, recoveryReset),
 	}
 }
 

--- a/pkg/forwarder/blocked_endpoints_test.go
+++ b/pkg/forwarder/blocked_endpoints_test.go
@@ -21,30 +21,12 @@ func init() {
 	rand.Seed(10)
 }
 
-func TestRandomBetween(t *testing.T) {
-	getRandomMinMax := func() (float64, float64) {
-		a := float64(rand.Intn(10))
-		b := float64(rand.Intn(10))
-		min := math.Min(a, b)
-		max := math.Max(a, b)
-		return min, max
-	}
-
-	for i := 1; i < 100; i++ {
-		min, max := getRandomMinMax()
-		between := randomBetween(min, max)
-
-		assert.True(t, min <= between)
-		assert.True(t, max >= between)
-	}
-}
-
 func TestMinBackoffFactorValid(t *testing.T) {
 	mockConfig := config.Mock()
 	e := newBlockedEndpoints()
 
 	// Verify default
-	defaultValue := e.minBackoffFactor
+	defaultValue := e.backoffPolicy.MinBackoffFactor
 	assert.Equal(t, float64(2), defaultValue)
 
 	// Reset original value when finished
@@ -53,12 +35,12 @@ func TestMinBackoffFactorValid(t *testing.T) {
 	// Verify configuration updates global var
 	mockConfig.Set("forwarder_backoff_factor", 4)
 	e = newBlockedEndpoints()
-	assert.Equal(t, float64(4), e.minBackoffFactor)
+	assert.Equal(t, float64(4), e.backoffPolicy.MinBackoffFactor)
 
 	// Verify invalid values recover gracefully
 	mockConfig.Set("forwarder_backoff_factor", 1.5)
 	e = newBlockedEndpoints()
-	assert.Equal(t, defaultValue, e.minBackoffFactor)
+	assert.Equal(t, defaultValue, e.backoffPolicy.MinBackoffFactor)
 }
 
 func TestBaseBackoffTimeValid(t *testing.T) {
@@ -66,7 +48,7 @@ func TestBaseBackoffTimeValid(t *testing.T) {
 	e := newBlockedEndpoints()
 
 	// Verify default
-	defaultValue := e.baseBackoffTime
+	defaultValue := e.backoffPolicy.BaseBackoffTime
 	assert.Equal(t, float64(2), defaultValue)
 
 	// Reset original value when finished
@@ -75,12 +57,12 @@ func TestBaseBackoffTimeValid(t *testing.T) {
 	// Verify configuration updates global var
 	mockConfig.Set("forwarder_backoff_base", 4)
 	e = newBlockedEndpoints()
-	assert.Equal(t, float64(4), e.baseBackoffTime)
+	assert.Equal(t, float64(4), e.backoffPolicy.BaseBackoffTime)
 
 	// Verify invalid values recover gracefully
 	mockConfig.Set("forwarder_backoff_base", 0)
 	e = newBlockedEndpoints()
-	assert.Equal(t, defaultValue, e.baseBackoffTime)
+	assert.Equal(t, defaultValue, e.backoffPolicy.BaseBackoffTime)
 }
 
 func TestMaxBackoffTimeValid(t *testing.T) {
@@ -88,7 +70,7 @@ func TestMaxBackoffTimeValid(t *testing.T) {
 	e := newBlockedEndpoints()
 
 	// Verify default
-	defaultValue := e.maxBackoffTime
+	defaultValue := e.backoffPolicy.MaxBackoffTime
 	assert.Equal(t, float64(64), defaultValue)
 
 	// Reset original value when finished
@@ -97,12 +79,12 @@ func TestMaxBackoffTimeValid(t *testing.T) {
 	// Verify configuration updates global var
 	mockConfig.Set("forwarder_backoff_max", 128)
 	e = newBlockedEndpoints()
-	assert.Equal(t, float64(128), e.maxBackoffTime)
+	assert.Equal(t, float64(128), e.backoffPolicy.MaxBackoffTime)
 
 	// Verify invalid values recover gracefully
 	mockConfig.Set("forwarder_backoff_max", 0)
 	e = newBlockedEndpoints()
-	assert.Equal(t, defaultValue, e.maxBackoffTime)
+	assert.Equal(t, defaultValue, e.backoffPolicy.MaxBackoffTime)
 }
 
 func TestRecoveryIntervalValid(t *testing.T) {
@@ -110,7 +92,7 @@ func TestRecoveryIntervalValid(t *testing.T) {
 	e := newBlockedEndpoints()
 
 	// Verify default
-	defaultValue := e.recoveryInterval
+	defaultValue := e.backoffPolicy.RecoveryInterval
 	recoveryReset := config.Datadog.GetBool("forwarder_recovery_reset")
 	assert.Equal(t, 2, defaultValue)
 	assert.Equal(t, false, recoveryReset)
@@ -122,17 +104,17 @@ func TestRecoveryIntervalValid(t *testing.T) {
 	// Verify configuration updates global var
 	mockConfig.Set("forwarder_recovery_interval", 1)
 	e = newBlockedEndpoints()
-	assert.Equal(t, 1, e.recoveryInterval)
+	assert.Equal(t, 1, e.backoffPolicy.RecoveryInterval)
 
 	// Verify invalid values recover gracefully
 	mockConfig.Set("forwarder_recovery_interval", 0)
 	e = newBlockedEndpoints()
-	assert.Equal(t, defaultValue, e.recoveryInterval)
+	assert.Equal(t, defaultValue, e.backoffPolicy.RecoveryInterval)
 
 	// Verify reset error count
 	mockConfig.Set("forwarder_recovery_reset", true)
 	e = newBlockedEndpoints()
-	assert.Equal(t, e.maxErrors, e.recoveryInterval)
+	assert.Equal(t, e.backoffPolicy.MaxErrors, e.backoffPolicy.RecoveryInterval)
 }
 
 // Test we increase delay on average
@@ -166,7 +148,7 @@ func TestMaxGetBackoffDuration(t *testing.T) {
 	e := newBlockedEndpoints()
 	backoffDuration := e.getBackoffDuration(100)
 
-	assert.Equal(t, time.Duration(e.maxBackoffTime)*time.Second, backoffDuration)
+	assert.Equal(t, time.Duration(e.backoffPolicy.MaxBackoffTime)*time.Second, backoffDuration)
 }
 
 func TestMaxErrors(t *testing.T) {
@@ -187,7 +169,7 @@ func TestMaxErrors(t *testing.T) {
 		previousBackoffDuration = backoffDuration
 	}
 
-	assert.Equal(t, e.maxErrors, attempts)
+	assert.Equal(t, e.backoffPolicy.MaxErrors, attempts)
 }
 
 func TestBlock(t *testing.T) {
@@ -208,10 +190,10 @@ func TestMaxBlock(t *testing.T) {
 	e.close("test")
 	now := time.Now()
 
-	maxBackoffDuration := time.Duration(e.maxBackoffTime) * time.Second
+	maxBackoffDuration := time.Duration(e.backoffPolicy.MaxBackoffTime) * time.Second
 
 	assert.Contains(t, e.errorPerEndpoint, "test")
-	assert.Equal(t, e.maxErrors, e.errorPerEndpoint["test"].nbError)
+	assert.Equal(t, e.backoffPolicy.MaxErrors, e.errorPerEndpoint["test"].nbError)
 	assert.True(t, now.Add(maxBackoffDuration).After(e.errorPerEndpoint["test"].until) ||
 		now.Add(maxBackoffDuration).Equal(e.errorPerEndpoint["test"].until))
 }
@@ -227,7 +209,7 @@ func TestUnblock(t *testing.T) {
 	e.close("test")
 
 	e.recover("test")
-	assert.True(t, e.errorPerEndpoint["test"].nbError == int(math.Max(0, float64(5-e.recoveryInterval))))
+	assert.True(t, e.errorPerEndpoint["test"].nbError == int(math.Max(0, float64(5-e.backoffPolicy.RecoveryInterval))))
 }
 
 func TestMaxUnblock(t *testing.T) {

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -47,7 +47,7 @@ type Destination struct {
 	once                sync.Once
 	payloadChan         chan []byte
 	climit              chan struct{} // semaphore for limiting concurrent background sends
-	backoff             backoff.BackoffPolicy
+	backoff             backoff.Policy
 	nbErrors            int
 	blockedUntil        time.Time
 }
@@ -65,7 +65,7 @@ func newDestination(endpoint config.Endpoint, contentType string, destinationsCo
 		maxConcurrentBackgroundSends = 0
 	}
 
-	policy := backoff.NewBackoffPolicy(
+	policy := backoff.NewPolicy(
 		endpoint.BackoffFactor,
 		endpoint.BackoffBase,
 		endpoint.BackoffMax,

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
+	"github.com/DataDog/datadog-agent/pkg/util/backoff"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -46,6 +47,9 @@ type Destination struct {
 	once                sync.Once
 	payloadChan         chan []byte
 	climit              chan struct{} // semaphore for limiting concurrent background sends
+	backoff             backoff.BackoffPolicy
+	nbErrors            int
+	blockedUntil        time.Time
 }
 
 // NewDestination returns a new Destination.
@@ -60,6 +64,15 @@ func newDestination(endpoint config.Endpoint, contentType string, destinationsCo
 	if maxConcurrentBackgroundSends < 0 {
 		maxConcurrentBackgroundSends = 0
 	}
+
+	policy := backoff.NewBackoffPolicy(
+		endpoint.BackoffFactor,
+		endpoint.BackoffBase,
+		endpoint.BackoffMax,
+		endpoint.RecoveryInterval,
+		endpoint.RecoveryReset,
+	)
+
 	return &Destination{
 		host:                endpoint.Host,
 		url:                 buildURL(endpoint),
@@ -69,6 +82,7 @@ func newDestination(endpoint config.Endpoint, contentType string, destinationsCo
 		client:              httputils.NewResetClient(endpoint.ConnectionResetInterval, httpClientFactory(timeout)),
 		destinationsContext: destinationsContext,
 		climit:              make(chan struct{}, maxConcurrentBackgroundSends),
+		backoff:             policy,
 	}
 }
 
@@ -84,7 +98,26 @@ func errorToTag(err error) string {
 
 // Send sends a payload over HTTP,
 // the error returned can be retryable and it is the responsibility of the callee to retry.
-func (d *Destination) Send(payload []byte) (err error) {
+func (d *Destination) Send(payload []byte) error {
+	if d.blockedUntil.After(time.Now()) {
+		log.Debugf("%s: sleeping until %v before retrying", d.url, d.blockedUntil)
+		d.waitForBackoff()
+	}
+
+	err := d.send(payload)
+
+	if _, ok := err.(*client.RetryableError); ok {
+		d.nbErrors = d.backoff.IncError(d.nbErrors)
+	} else {
+		d.nbErrors = d.backoff.DecError(d.nbErrors)
+	}
+
+	d.blockedUntil = time.Now().Add(d.backoff.GetBackoffDuration(d.nbErrors))
+
+	return err
+}
+
+func (d *Destination) send(payload []byte) (err error) {
 	defer func() {
 		tlmSend.Inc(d.host, errorToTag(err))
 	}()
@@ -160,12 +193,12 @@ func (d *Destination) sendInBackground(payloadChan chan []byte) {
 			case payload := <-payloadChan:
 				// if the channel is non-buffered then there is no concurrency and we block on sending each payload
 				if cap(d.climit) == 0 {
-					d.Send(payload) //nolint:errcheck
+					d.send(payload) //nolint:errcheck
 					break
 				}
 				d.climit <- struct{}{}
 				go func() {
-					d.Send(payload) //nolint:errcheck
+					d.send(payload) //nolint:errcheck
 					<-d.climit
 				}()
 			case <-ctx.Done():
@@ -218,11 +251,17 @@ func CheckConnectivity(endpoint config.Endpoint) config.HTTPConnectivity {
 	// Lower the timeout to 5s because HTTP connectivity test is done synchronously during the agent bootstrap sequence
 	destination := newDestination(endpoint, JSONContentType, ctx, time.Second*5, 0)
 	log.Infof("Sending HTTP connectivity request to %s...", destination.url)
-	err := destination.Send(emptyPayload)
+	err := destination.send(emptyPayload)
 	if err != nil {
 		log.Warnf("HTTP connectivity failure: %v", err)
 	} else {
 		log.Info("HTTP connectivity successful")
 	}
 	return err == nil
+}
+
+func (d *Destination) waitForBackoff() {
+	ctx, cancel := context.WithDeadline(d.destinationsContext.Context(), d.blockedUntil)
+	defer cancel()
+	<-ctx.Done()
 }

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -10,9 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/stretchr/testify/suite"
-
 	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/stretchr/testify/suite"
 )
 
 type ConfigTestSuite struct {
@@ -150,6 +149,11 @@ func (suite *ConfigTestSuite) TestMultipleHttpEndpointsEnvVar() {
 	suite.config.Set("logs_config.use_compression", true)
 	suite.config.Set("logs_config.compression_level", 6)
 	suite.config.Set("logs_config.logs_no_ssl", false)
+	suite.config.Set("logs_config.sender_backoff_factor", 3.0)
+	suite.config.Set("logs_config.sender_backoff_base", 1.0)
+	suite.config.Set("logs_config.sender_backoff_max", 2.0)
+	suite.config.Set("logs_config.sender_recovery_interval", 10)
+	suite.config.Set("logs_config.sender_recovery_reset", true)
 
 	os.Setenv("DD_LOGS_CONFIG_ADDITIONAL_ENDPOINTS", `[
 	{"api_key": "456", "host": "additional.endpoint.1", "port": 1234, "use_compression": true, "compression_level": 2},
@@ -162,7 +166,13 @@ func (suite *ConfigTestSuite) TestMultipleHttpEndpointsEnvVar() {
 		Port:             443,
 		UseSSL:           true,
 		UseCompression:   true,
-		CompressionLevel: 6}
+		CompressionLevel: 6,
+		BackoffFactor:    3,
+		BackoffBase:      1.0,
+		BackoffMax:       2.0,
+		RecoveryInterval: 10,
+		RecoveryReset:    true,
+	}
 	expectedAdditionalEndpoint1 := Endpoint{
 		APIKey:           "456",
 		Host:             "additional.endpoint.1",
@@ -249,7 +259,12 @@ func (suite *ConfigTestSuite) TestMultipleHttpEndpointsInConfig() {
 		Port:             443,
 		UseSSL:           true,
 		UseCompression:   true,
-		CompressionLevel: 6}
+		CompressionLevel: 6,
+		BackoffFactor:    coreConfig.DefaultLogsSenderBackoffFactor,
+		BackoffBase:      coreConfig.DefaultLogsSenderBackoffBase,
+		BackoffMax:       coreConfig.DefaultLogsSenderBackoffMax,
+		RecoveryInterval: coreConfig.DefaultLogsSenderBackoffRecoveryInterval,
+	}
 	expectedAdditionalEndpoint1 := Endpoint{
 		APIKey:           "456",
 		Host:             "additional.endpoint.1",
@@ -331,6 +346,10 @@ func (suite *ConfigTestSuite) TestEndpointsSetLogsDDUrl() {
 			UseSSL:           true,
 			UseCompression:   true,
 			CompressionLevel: 6,
+			BackoffFactor:    coreConfig.DefaultLogsSenderBackoffFactor,
+			BackoffBase:      coreConfig.DefaultLogsSenderBackoffBase,
+			BackoffMax:       coreConfig.DefaultLogsSenderBackoffMax,
+			RecoveryInterval: coreConfig.DefaultLogsSenderBackoffRecoveryInterval,
 		},
 		BatchMaxSize:           coreConfig.DefaultBatchMaxSize,
 		BatchMaxContentSize:    coreConfig.DefaultBatchMaxContentSize,
@@ -365,6 +384,10 @@ func (suite *ConfigTestSuite) TestEndpointsSetDDSite() {
 			UseSSL:           true,
 			UseCompression:   true,
 			CompressionLevel: 6,
+			BackoffFactor:    coreConfig.DefaultLogsSenderBackoffFactor,
+			BackoffBase:      coreConfig.DefaultLogsSenderBackoffBase,
+			BackoffMax:       coreConfig.DefaultLogsSenderBackoffMax,
+			RecoveryInterval: coreConfig.DefaultLogsSenderBackoffRecoveryInterval,
 		},
 		BatchMaxSize:           coreConfig.DefaultBatchMaxSize,
 		BatchMaxContentSize:    coreConfig.DefaultBatchMaxContentSize,

--- a/pkg/logs/config/endpoints.go
+++ b/pkg/logs/config/endpoints.go
@@ -20,6 +20,12 @@ type Endpoint struct {
 	CompressionLevel        int  `mapstructure:"compression_level" json:"compression_level"`
 	ProxyAddress            string
 	ConnectionResetInterval time.Duration
+
+	BackoffFactor    float64
+	BackoffBase      float64
+	BackoffMax       float64
+	RecoveryInterval int
+	RecoveryReset    bool
 }
 
 // Endpoints holds the main endpoint and additional ones to dualship logs.

--- a/pkg/util/backoff/backoff.go
+++ b/pkg/util/backoff/backoff.go
@@ -1,0 +1,93 @@
+package backoff
+
+import (
+	"math"
+	"math/rand"
+	"time"
+)
+
+// BackoffPolicy contains parameters and logic necessary to implement an exponential backoff
+// strategy when handling errors.
+type BackoffPolicy struct {
+	// MinBackoffFactor controls the overlap between consecutive retry interval ranges. When
+	// set to `2`, there is a guarantee that there will be no overlap. The overlap
+	// will asymptotically approach 50% the higher the value is set.
+	MinBackoffFactor float64
+
+	// BaseBackoffTime controls the rate of exponential growth. Also, you can calculate the start
+	// of the very first retry interval range by evaluating the following expression:
+	// baseBackoffTime / minBackoffFactor * 2
+	BaseBackoffTime float64
+
+	// MaxBackoffTime is the maximum number of seconds to wait for a retry.
+	MaxBackoffTime float64
+
+	// RecoveryInterval controls how many retry interval ranges to step down for an endpoint
+	// upon success. Increasing this should only be considered when maxBackoffTime
+	// is particularly high or if our intake team is particularly confident.
+	RecoveryInterval int
+
+	// MaxErrors derived value is the number of errors it will take to reach the maxBackoffTime.
+	MaxErrors int
+}
+
+const secondsFloat = float64(time.Second)
+
+func randomBetween(min, max float64) float64 {
+	return rand.Float64()*(max-min) + min
+}
+
+// NewBackoffPolicy constructs new Backoff object with given parameters
+func NewBackoffPolicy(minBackoffFactor, baseBackoffTime, maxBackoffTime float64, recoveryInterval int, recoveryReset bool) BackoffPolicy {
+	maxErrors := int(math.Floor(math.Log2(maxBackoffTime/baseBackoffTime))) + 1
+
+	if recoveryReset {
+		recoveryInterval = maxErrors
+	}
+
+	return BackoffPolicy{
+		MinBackoffFactor: minBackoffFactor,
+		BaseBackoffTime:  baseBackoffTime,
+		MaxBackoffTime:   maxBackoffTime,
+		RecoveryInterval: recoveryInterval,
+		MaxErrors:        maxErrors,
+	}
+}
+
+// GetBackoffDuration returns amount of time to sleep after numErrors error
+func (b *BackoffPolicy) GetBackoffDuration(numErrors int) time.Duration {
+	var backoffTime float64
+
+	if numErrors > 0 {
+		backoffTime = b.BaseBackoffTime * math.Pow(2, float64(numErrors))
+
+		if backoffTime > b.MaxBackoffTime {
+			backoffTime = b.MaxBackoffTime
+		} else {
+			min := backoffTime / b.MinBackoffFactor
+			max := math.Min(b.MaxBackoffTime, backoffTime)
+			backoffTime = randomBetween(min, max)
+		}
+	}
+
+	return time.Duration(backoffTime * secondsFloat)
+
+}
+
+// IncError increments the error counter up to MaxErrors
+func (b *BackoffPolicy) IncError(numErrors int) int {
+	numErrors++
+	if numErrors > b.MaxErrors {
+		return b.MaxErrors
+	}
+	return numErrors
+}
+
+// DecError decrements the error counter down to zero at RecoveryInterval rate
+func (b *BackoffPolicy) DecError(numErrors int) int {
+	numErrors -= b.RecoveryInterval
+	if numErrors < 0 {
+		return 0
+	}
+	return numErrors
+}

--- a/pkg/util/backoff/backoff.go
+++ b/pkg/util/backoff/backoff.go
@@ -6,9 +6,9 @@ import (
 	"time"
 )
 
-// BackoffPolicy contains parameters and logic necessary to implement an exponential backoff
+// Policy contains parameters and logic necessary to implement an exponential backoff
 // strategy when handling errors.
-type BackoffPolicy struct {
+type Policy struct {
 	// MinBackoffFactor controls the overlap between consecutive retry interval ranges. When
 	// set to `2`, there is a guarantee that there will be no overlap. The overlap
 	// will asymptotically approach 50% the higher the value is set.
@@ -37,15 +37,15 @@ func randomBetween(min, max float64) float64 {
 	return rand.Float64()*(max-min) + min
 }
 
-// NewBackoffPolicy constructs new Backoff object with given parameters
-func NewBackoffPolicy(minBackoffFactor, baseBackoffTime, maxBackoffTime float64, recoveryInterval int, recoveryReset bool) BackoffPolicy {
+// NewPolicy constructs new Backoff object with given parameters
+func NewPolicy(minBackoffFactor, baseBackoffTime, maxBackoffTime float64, recoveryInterval int, recoveryReset bool) Policy {
 	maxErrors := int(math.Floor(math.Log2(maxBackoffTime/baseBackoffTime))) + 1
 
 	if recoveryReset {
 		recoveryInterval = maxErrors
 	}
 
-	return BackoffPolicy{
+	return Policy{
 		MinBackoffFactor: minBackoffFactor,
 		BaseBackoffTime:  baseBackoffTime,
 		MaxBackoffTime:   maxBackoffTime,
@@ -55,7 +55,7 @@ func NewBackoffPolicy(minBackoffFactor, baseBackoffTime, maxBackoffTime float64,
 }
 
 // GetBackoffDuration returns amount of time to sleep after numErrors error
-func (b *BackoffPolicy) GetBackoffDuration(numErrors int) time.Duration {
+func (b *Policy) GetBackoffDuration(numErrors int) time.Duration {
 	var backoffTime float64
 
 	if numErrors > 0 {
@@ -75,7 +75,7 @@ func (b *BackoffPolicy) GetBackoffDuration(numErrors int) time.Duration {
 }
 
 // IncError increments the error counter up to MaxErrors
-func (b *BackoffPolicy) IncError(numErrors int) int {
+func (b *Policy) IncError(numErrors int) int {
 	numErrors++
 	if numErrors > b.MaxErrors {
 		return b.MaxErrors
@@ -84,7 +84,7 @@ func (b *BackoffPolicy) IncError(numErrors int) int {
 }
 
 // DecError decrements the error counter down to zero at RecoveryInterval rate
-func (b *BackoffPolicy) DecError(numErrors int) int {
+func (b *Policy) DecError(numErrors int) int {
 	numErrors -= b.RecoveryInterval
 	if numErrors < 0 {
 		return 0

--- a/pkg/util/backoff/backoff_test.go
+++ b/pkg/util/backoff/backoff_test.go
@@ -32,14 +32,14 @@ func TestRandomBetween(t *testing.T) {
 }
 
 func TestEmpty(t *testing.T) {
-	b := BackoffPolicy{}
+	b := Policy{}
 	assert.Equal(t, 0, b.IncError(0))
 	assert.Equal(t, 0, b.DecError(0))
 	assert.Equal(t, time.Duration(0), b.GetBackoffDuration(0))
 }
 
 func TestBackoff(t *testing.T) {
-	b := NewBackoffPolicy(1, 1, 9, 2, false)
+	b := NewPolicy(1, 1, 9, 2, false)
 
 	assert.Equal(t, 1, b.IncError(0))
 	assert.Equal(t, 2, b.IncError(1))

--- a/pkg/util/backoff/backoff_test.go
+++ b/pkg/util/backoff/backoff_test.go
@@ -1,0 +1,61 @@
+package backoff
+
+import (
+	"math"
+	"math/rand"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func init() {
+	rand.Seed(10)
+}
+
+func TestRandomBetween(t *testing.T) {
+	getRandomMinMax := func() (float64, float64) {
+		a := float64(rand.Intn(10))
+		b := float64(rand.Intn(10))
+		min := math.Min(a, b)
+		max := math.Max(a, b)
+		return min, max
+	}
+
+	for i := 1; i < 100; i++ {
+		min, max := getRandomMinMax()
+		between := randomBetween(min, max)
+
+		assert.True(t, min <= between)
+		assert.True(t, max >= between)
+	}
+}
+
+func TestEmpty(t *testing.T) {
+	b := BackoffPolicy{}
+	assert.Equal(t, 0, b.IncError(0))
+	assert.Equal(t, 0, b.DecError(0))
+	assert.Equal(t, time.Duration(0), b.GetBackoffDuration(0))
+}
+
+func TestBackoff(t *testing.T) {
+	b := NewBackoffPolicy(1, 1, 9, 2, false)
+
+	assert.Equal(t, 1, b.IncError(0))
+	assert.Equal(t, 2, b.IncError(1))
+	assert.Equal(t, 3, b.IncError(2))
+	assert.Equal(t, 4, b.IncError(3))
+	assert.Equal(t, 4, b.IncError(4))
+
+	assert.Equal(t, 0, b.DecError(0))
+	assert.Equal(t, 0, b.DecError(1))
+	assert.Equal(t, 0, b.DecError(2))
+	assert.Equal(t, 1, b.DecError(3))
+	assert.Equal(t, 2, b.DecError(4))
+
+	assert.Equal(t, 0*time.Second, b.GetBackoffDuration(0))
+	assert.Equal(t, 2*time.Second, b.GetBackoffDuration(1))
+	assert.Equal(t, 4*time.Second, b.GetBackoffDuration(2))
+	assert.Equal(t, 8*time.Second, b.GetBackoffDuration(3))
+	assert.Equal(t, 9*time.Second, b.GetBackoffDuration(4))
+}

--- a/releasenotes/notes/logs-backoff-1e129cce3ba7aa68.yaml
+++ b/releasenotes/notes/logs-backoff-1e129cce3ba7aa68.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Reduce CPU usage when logs agent is unable to reach an http endpoint.


### PR DESCRIPTION
### What does this PR do?

Add delay in the logs sender before retrying payloads sent to http destinations. Specific implementation was extracted from the metrics forwarder for re-use, using a different set of defaults.

### Motivation

Reduce CPU usage when agent is unable to reach logs endpoint.

### Additional Notes

Retry policy was chosen to be fairly aggressive: it minimizes effect of transient errors, while still achieves our goal of reducing CPU usage.

Exponential backoff only applies to main logs endpoint, because additional endpoints do not retry failed payloads.

### Describe how to test your changes

Configure a logs check.
Run the agent against a mock http server.
Stop the mock http server and verify that agent CPU usage remains stable.
Debug log should contain information about the retry delay.