### PR TITLE
[dogstatsd] replay: enable nanosecond resolution for correct cadence in replay

### DIFF
--- a/pkg/dogstatsd/listeners/uds_common.go
+++ b/pkg/dogstatsd/listeners/uds_common.go
@@ -173,7 +173,7 @@ func (l *UDSListener) Listen() {
 			pid, container, taggingErr := processUDSOrigin(oobS[:oobn])
 
 			if capBuff != nil {
-				capBuff.Pb.Timestamp = time.Now().Unix()
+				capBuff.Pb.Timestamp = time.Now().UnixNano()
 				capBuff.Pid = int32(pid)
 				capBuff.Oob = oob
 				capBuff.Buff = packet
@@ -206,7 +206,7 @@ func (l *UDSListener) Listen() {
 			t1 = time.Now()
 
 			if capBuff != nil {
-				capBuff.Pb.Timestamp = time.Now().Unix()
+				capBuff.Pb.Timestamp = time.Now().UnixNano()
 				capBuff.Buff = packet
 				capBuff.Pb.Pid = 0
 				capBuff.Pb.AncillarySize = int32(0)

--- a/pkg/dogstatsd/replay/file.go
+++ b/pkg/dogstatsd/replay/file.go
@@ -20,9 +20,12 @@ var (
 )
 
 const (
-	datadogFileVersion uint8 = 2
+	// Version 3+ adds support for nanosecond cadence.
+	// Version 2+ adds support for storing state.
+	datadogFileVersion uint8 = 3
 	versionIndex             = 4
 	minStateVersion          = 2
+	minNanoVersion           = 3
 )
 
 func init() {

--- a/pkg/dogstatsd/replay/reader.go
+++ b/pkg/dogstatsd/replay/reader.go
@@ -94,7 +94,6 @@ func (tc *TrafficCaptureReader) Read() {
 			break
 		}
 
-		// TODO: ensure proper cadence
 		if tc.last != 0 {
 			if msg.Timestamp > tc.last {
 				util.Wait(tsResolution * time.Duration(msg.Timestamp-tc.last))

--- a/pkg/dogstatsd/replay/reader.go
+++ b/pkg/dogstatsd/replay/reader.go
@@ -74,6 +74,13 @@ func (tc *TrafficCaptureReader) Read() {
 	tc.offset = uint32(len(datadogHeader))
 	tc.Unlock()
 
+	var tsResolution time.Duration
+	if tc.Version < minNanoVersion {
+		tsResolution = time.Second
+	} else {
+		tsResolution = time.Nanosecond
+	}
+
 	// The state must be read out of band, it makes zero sense in the context
 	// of the replaying process, it must be pushed to the agent. We just read
 	// and submit the packets here.
@@ -90,7 +97,7 @@ func (tc *TrafficCaptureReader) Read() {
 		// TODO: ensure proper cadence
 		if tc.last != 0 {
 			if msg.Timestamp > tc.last {
-				util.Wait(time.Second * time.Duration(msg.Timestamp-tc.last))
+				util.Wait(tsResolution * time.Duration(msg.Timestamp-tc.last))
 			}
 		}
 

--- a/releasenotes/notes/dogstatsd-capture-improved-cadence-50baeeaa53338d6f.yaml
+++ b/releasenotes/notes/dogstatsd-capture-improved-cadence-50baeeaa53338d6f.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Adds improved cadence/resolution captures/replay to dogstatsd traffic
+    captures. The new file format will store payloads with nanosecond
+    resolution. The replay feature remains backward-compatible.


### PR DESCRIPTION
### What does this PR do?

Adds nano-second resolution timestamps to captures and thus allowing replayed traffic to closer mimic the incoming traffic flow.

### Motivation

This PR addresses an issue with the current replay code, which relied on seconds resolution when time-stamping captured payloads. Unfortunately in high-throughput scenarios this would result in bursts of traffic that would lead to filling and then blocking the UDS socket buffer. The goal of this PR, via an improved replay resolution, is to address this issue and allow a replay cadence which will hopefully be a lot closer to the real deal.   

### Additional Notes

- Stacked over #8193 and #8199 ; merge *after* those. 

### Describe how to test your changes

This is inherently hard to test because by nature the replay cannot be perfectly replayed to match the original traffic, however this should can likely be easily verified by replaying a high-throughput capture and having the UDS socket *not* block.  

So, as a best-effort for QA I would suggest the following:
- generate UDS traffic (with or without origin detection, that should be a non-factor for this test) at a relatively high rate. Something around 1000 pps should already cause the socket buffer to lock if the time-stamping were to have the old second granularity.
- capture 60s seconds worth of traffic with the `/opt/datadog-agent/bin/datadog-agent dogstatsd-capture -d 60s`
- replay back the traffic captured with `/opt/datadog-agent/bin/datadog-agent dogstatsd-replay -f <capture_file_here>`
- there should be no lock/buffer full errors.