### PR TITLE
Improve `streamLogs` function

### DIFF
--- a/pkg/logs/diagnostic/message_receiver.go
+++ b/pkg/logs/diagnostic/message_receiver.go
@@ -97,7 +97,7 @@ func (b *BufferedMessageReceiver) HandleMessage(m message.Message, redactedMsg [
 
 // Filter writes the buffered events from the input channel formatted as a string to the output channel
 func (b *BufferedMessageReceiver) Filter(filters *Filters, done <-chan struct{}) <-chan string {
-	out := make(chan string, 100)
+	out := make(chan string, config.ChanSize)
 	go func() {
 		defer close(out)
 		for {

--- a/pkg/logs/diagnostic/message_receiver.go
+++ b/pkg/logs/diagnostic/message_receiver.go
@@ -95,7 +95,7 @@ func (b *BufferedMessageReceiver) HandleMessage(m message.Message, redactedMsg [
 	b.inputChan <- messagePair{&m, redactedMsg}
 }
 
-// Next pops the next buffered event off the input channel formatted as a string
+// Filter writes the buffered events from the input channel formatted as a string to the output channel
 func (b *BufferedMessageReceiver) Filter(filters *Filters, done <-chan struct{}) <-chan string {
 	out := make(chan string, 100)
 	go func() {


### PR DESCRIPTION
### What does this PR do?

In the stream-logs command, current code is relying on a for loop to get messages to write on stdout.

Now messages are pushed in a channel, received by this select to display them. We would benefit from the internal locking/waiting of the channel/select and would improve the overall CPU usage when the command is used, also avoiding to rely on this trick to avoid a 100% core usage in some situations. 

### Motivation

https://github.com/DataDog/datadog-agent/pull/8080#discussion_r626400740

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Check `stream-logs` still works as expected.
