### PR TITLE
Fix `forwarder_storage_path` when `run_path` is set.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -13,7 +13,6 @@ import (
 	"net"
 	"net/url"
 	"os"
-	"path"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -353,8 +352,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("forwarder_recovery_reset", false)
 
 	// Forwarder storage on disk
-	defaultForwarderStoragePath := path.Join(config.GetString("run_path"), "transactions_to_retry")
-	config.BindEnvAndSetDefault("forwarder_storage_path", defaultForwarderStoragePath)
+	config.BindEnvAndSetDefault("forwarder_storage_path", "")
 	config.BindEnvAndSetDefault("forwarder_outdated_file_in_days", 10)
 	config.BindEnvAndSetDefault("forwarder_flush_to_disk_mem_ratio", 0.5)
 	config.BindEnvAndSetDefault("forwarder_storage_max_size_in_bytes", 0) // 0 means disabled. This is a BETA feature.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -214,12 +214,6 @@ api_key:
 #
 # forwarder_storage_max_disk_ratio: 0.95
 
-## @param forwarder_storage_path - string - optional - default: /opt/datadog-agent/run/transactions_to_retry (c:\ProgramData\Datadog\run\transactions_to_retry on Windows)
-## `forwarder_storage_path` defines the root folder where the transactions of the forwarder are stored when
-## the retry queue is full.
-#
-# forwarder_storage_path: /opt/datadog-agent/run/transactions_to_retry
-
 ## @param forwarder_outdated_file_in_days - int - optional - default: 10
 ## This value specifies how many days the overflow transactions will remain valid before
 ## being discarded. During the Agent restart, if a retry file contains transactions that were

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -224,6 +224,9 @@ func NewDefaultForwarder(options *Options) *DefaultForwarder {
 		log.Infof("Retry queue storage on disk is disabled")
 	} else if agentFolder := getAgentFolder(options); agentFolder != "" {
 		storagePath := config.Datadog.GetString("forwarder_storage_path")
+		if storagePath == "" {
+			storagePath = path.Join(config.Datadog.GetString("run_path"), "transactions_to_retry")
+		}
 		outdatedFileInDays := config.Datadog.GetInt("forwarder_outdated_file_in_days")
 		var err error
 

--- a/releasenotes/notes/fix-forwarder_storage_path-b67620acf35a815f.yaml
+++ b/releasenotes/notes/fix-forwarder_storage_path-b67620acf35a815f.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix the default value of the configuration option ``forwarder_storage_path`` when ``run_path`` is set.
+    The default value is ``RUN_PATH/transactions_to_retry`` where RUN_PATH is defined by the configuration option ``run_path``.
+


### PR DESCRIPTION
### What does this PR do?

Fix `forwarder_storage_path` when `run_path` is set.
Same fix as https://github.com/DataDog/datadog-agent/pull/7985/commits/c68ad274c454d823300f7ec73493c70d2fc527a5.

### Motivation

https://github.com/DataDog/datadog-agent/pull/7985#discussion_r621036006

### Describe how to test your changes
- Check the default value `forwarder_storage_path` is the same as before
- Check `forwarder_storage_path` can be override
- Check  when `run_path` is set, the default value of `forwarder_storage_path` is updated.
