### PR TITLE
[notify] Fix notification jobs failing due to generator use

### DIFF
--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -10,7 +10,9 @@ from .types import Test
 def get_failed_jobs(project_name, pipeline_id):
     gitlab = Gitlab()
 
-    jobs = gitlab.all_jobs(project_name, pipeline_id)
+    # gitlab.all_jobs yields a generator, it needs to be converted to a list to be able to
+    # go through it twice
+    jobs = list(gitlab.all_jobs(project_name, pipeline_id))
 
     # Get instances of failed jobs
     failed_jobs = {job["name"]: [] for job in jobs if job["status"] == "failed"}


### PR DESCRIPTION
### What does this PR do?

When fetching the job list of a pipeline, cast the resulting generator to a list to be able to use it twice.

### Motivation

#8186 modified the `Gitlab.all_pipelines_for_ref` and `Gitlab.all_jobs` methods to return generator. This works well except if the resulting generator needs to be used more than once.
