### PR TITLE
Revert "[Extension] Fix ssm env var name"

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -76,7 +76,7 @@ where they can be graphed on dashboards. The Datadog Serverless Agent implements
 	// KSM > SSM > Apikey in environment var
 	// If one is set but failing, the next will be tried
 	kmsAPIKeyEnvVar = "DD_KMS_API_KEY"
-	ssmAPIKeyEnvVar = "DD_API_KEY_SSM_NAME"
+	ssmAPIKeyEnvVar = "DD_API_KEY_SECRET_ARN"
 	apiKeyEnvVar    = "DD_API_KEY"
 
 	logLevelEnvVar = "DD_LOG_LEVEL"
@@ -445,7 +445,7 @@ func readAPIKeyFromKMS() (string, error) {
 	return rv, nil
 }
 
-// readAPIKeyFromSSM reads an API Key in SSM if the env var DD_API_KEY_SSM_NAME
+// readAPIKeyFromSSM reads an API Key in SSM if the env var DD_API_KEY_SECRET_ARN
 // has been set.
 // If none has been set, it is returning an empty string and a nil error.
 func readAPIKeyFromSSM() (string, error) {
@@ -453,7 +453,7 @@ func readAPIKeyFromSSM() (string, error) {
 	if arn == "" {
 		return "", nil
 	}
-	log.Debug("Found DD_API_KEY_SSM_NAME value, trying to use it.")
+	log.Debug("Found DD_API_KEY_SECRET_ARN value, trying to use it.")
 	ssmClient := secretsmanager.New(session.New(nil))
 	secret := &secretsmanager.GetSecretValueInput{}
 	secret.SetSecretId(arn)


### PR DESCRIPTION
We incorrectly changed the environment variable name `DD_API_KEY_SECRET_ARN` to `DD_API_KEY_SSM_NAME`. This changes it back to `DD_API_KEY_SECRET_ARN`.

This part of the codebase still confuses confuses the AWS Systems Manager (SSM) Parameter Store and the AWS Secrets Manager. The code uses the secrets manager but refers to it as SSM. We will follow up in a subsequent PR to address this.