### PR TITLE
[Serverless] do not report aws.enhanced.init_duration for non cold start invocations

### DIFF
--- a/pkg/serverless/enhanced_metrics.go
+++ b/pkg/serverless/enhanced_metrics.go
@@ -56,7 +56,7 @@ func generateEnhancedMetricsFromReportLog(message aws.LogMessage, tags []string,
 	memorySizeMb := float64(message.ObjectRecord.Metrics.MemorySizeMB)
 	billedDurationMs := float64(message.ObjectRecord.Metrics.BilledDurationMs)
 
-	metricsChan <- []metrics.MetricSample{{
+	enhancedMetrics := []metrics.MetricSample{{
 		Name:       "aws.lambda.enhanced.max_memory_used",
 		Value:      float64(message.ObjectRecord.Metrics.MaxMemoryUsedMB),
 		Mtype:      metrics.DistributionType,
@@ -85,13 +85,6 @@ func generateEnhancedMetricsFromReportLog(message aws.LogMessage, tags []string,
 		SampleRate: 1,
 		Timestamp:  float64(message.Time.UnixNano()),
 	}, {
-		Name:       "aws.lambda.enhanced.init_duration",
-		Value:      message.ObjectRecord.Metrics.InitDurationMs * msToSec,
-		Mtype:      metrics.DistributionType,
-		Tags:       tags,
-		SampleRate: 1,
-		Timestamp:  float64(message.Time.UnixNano()),
-	}, {
 		Name:       "aws.lambda.enhanced.estimated_cost",
 		Value:      calculateEstimatedCost(billedDurationMs, memorySizeMb),
 		Mtype:      metrics.DistributionType,
@@ -99,6 +92,18 @@ func generateEnhancedMetricsFromReportLog(message aws.LogMessage, tags []string,
 		SampleRate: 1,
 		Timestamp:  float64(message.Time.UnixNano()),
 	}}
+	if message.ObjectRecord.Metrics.InitDurationMs > 0 {
+		initDurationMetric := metrics.MetricSample{
+			Name:       "aws.lambda.enhanced.init_duration",
+			Value:      message.ObjectRecord.Metrics.InitDurationMs * msToSec,
+			Mtype:      metrics.DistributionType,
+			Tags:       tags,
+			SampleRate: 1,
+			Timestamp:  float64(message.Time.UnixNano()),
+		}
+		enhancedMetrics = append(enhancedMetrics, initDurationMetric)
+	}
+	metricsChan <- enhancedMetrics
 }
 
 // sendTimeoutEnhancedMetric sends an enhanced metric representing a timeout

--- a/pkg/serverless/enhanced_metrics_test.go
+++ b/pkg/serverless/enhanced_metrics_test.go
@@ -51,7 +51,7 @@ func TestGenerateEnhancedMetricsFromFunctionLogNoMetric(t *testing.T) {
 	assert.Equal(t, len(metricsChan), 0)
 }
 
-func TestGenerateEnhancedMetricsFromReportLog(t *testing.T) {
+func TestGenerateEnhancedMetricsFromReportLogColdStart(t *testing.T) {
 	reportLog := aws.LogMessage{
 		Type: aws.LogTypePlatformReport,
 		Time: time.Now(),
@@ -101,8 +101,67 @@ func TestGenerateEnhancedMetricsFromReportLog(t *testing.T) {
 		SampleRate: 1,
 		Timestamp:  float64(reportLog.Time.UnixNano()),
 	}, {
+		Name:       "aws.lambda.enhanced.estimated_cost",
+		Value:      calculateEstimatedCost(800.0, 1024.0),
+		Mtype:      metrics.DistributionType,
+		Tags:       tags,
+		SampleRate: 1,
+		Timestamp:  float64(reportLog.Time.UnixNano()),
+	}, {
 		Name:       "aws.lambda.enhanced.init_duration",
 		Value:      0.1,
+		Mtype:      metrics.DistributionType,
+		Tags:       tags,
+		SampleRate: 1,
+		Timestamp:  float64(reportLog.Time.UnixNano()),
+	}})
+}
+
+func TestGenerateEnhancedMetricsFromReportLogNoColdStart(t *testing.T) {
+	reportLog := aws.LogMessage{
+		Type: aws.LogTypePlatformReport,
+		Time: time.Now(),
+		ObjectRecord: aws.PlatformObjectRecord{
+			Metrics: aws.ReportLogMetrics{
+				DurationMs:       1000.0,
+				BilledDurationMs: 800.0,
+				MemorySizeMB:     1024.0,
+				MaxMemoryUsedMB:  256.0,
+				InitDurationMs:   0,
+			},
+		},
+	}
+	metricsChan := make(chan []metrics.MetricSample)
+	tags := []string{"functionname:test-function"}
+
+	go generateEnhancedMetricsFromReportLog(reportLog, tags, metricsChan)
+
+	generatedMetrics := <-metricsChan
+
+	assert.Equal(t, generatedMetrics, []metrics.MetricSample{{
+		Name:       "aws.lambda.enhanced.max_memory_used",
+		Value:      256.0,
+		Mtype:      metrics.DistributionType,
+		Tags:       tags,
+		SampleRate: 1,
+		Timestamp:  float64(reportLog.Time.UnixNano()),
+	}, {
+		Name:       "aws.lambda.enhanced.memorysize",
+		Value:      1024.0,
+		Mtype:      metrics.DistributionType,
+		Tags:       tags,
+		SampleRate: 1,
+		Timestamp:  float64(reportLog.Time.UnixNano()),
+	}, {
+		Name:       "aws.lambda.enhanced.billed_duration",
+		Value:      0.80,
+		Mtype:      metrics.DistributionType,
+		Tags:       tags,
+		SampleRate: 1,
+		Timestamp:  float64(reportLog.Time.UnixNano()),
+	}, {
+		Name:       "aws.lambda.enhanced.duration",
+		Value:      1.0,
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,
 		SampleRate: 1,


### PR DESCRIPTION
### What does this PR do?

Do not send aws.enhanced.init_duration metrics for non cold start invocations 

### Motivation

Average on this metric are biased

### Describe how to test your changes

Using extension 57 on us-east-1, you should no be able to see this metrics for non cold starts
![noMoreZero](https://user-images.githubusercontent.com/864493/119207441-3d24fa80-ba6c-11eb-9302-9aedfc4d394a.png)

