### PR TITLE
[networks] Extend HTTP monitoring to all ports

### DIFF
--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -5,6 +5,16 @@
 #include "ipv6.h"
 #include "http.h"
 
+// TODO: Replace those by injected constants based on system configuration
+// once we have port range detection merged into the codebase.
+#define EPHEMERAL_RANGE_BEG 32768
+#define EPHEMERAL_RANGE_END 60999
+#define HTTPS_PORT 443
+
+static __always_inline int is_ephemeral_port(u16 port) {
+    return port >= EPHEMERAL_RANGE_BEG && port <= EPHEMERAL_RANGE_END;
+}
+
 SEC("socket/http_filter")
 int socket__http_filter(struct __sk_buff* skb) {
     skb_info_t skb_info;
@@ -13,15 +23,19 @@ int socket__http_filter(struct __sk_buff* skb) {
         return 0;
     }
 
-    // src_port represents the source port number *before* normalization
-    // for more context please refer to http-types.h comment on `owned_by_src_port` field
-    u16 src_port = skb_info.tup.sport;
-    if (skb_info.tup.sport != 80 && skb_info.tup.sport != 8080 && skb_info.tup.dport != 80 && skb_info.tup.dport != 8080) {
+    // don't bother to inspect packet contents when there is no chance we're dealing with plain HTTP
+    if (!(skb_info.tup.metadata&CONN_TYPE_TCP) || skb_info.tup.sport == HTTPS_PORT || skb_info.tup.dport == HTTPS_PORT) {
         return 0;
     }
 
-    if (skb_info.tup.sport == 80 || skb_info.tup.sport == 8080) {
-        // Normalize tuple
+
+    // src_port represents the source port number *before* normalization
+    // for more context please refer to http-types.h comment on `owned_by_src_port` field
+    u16 src_port = skb_info.tup.sport;
+
+    // we normalize the tuple to always be (client, server),
+    // so if sport is not in ephemeral port range we flip it
+    if (!is_ephemeral_port(skb_info.tup.sport)) {
         flip_tuple(&skb_info.tup);
     }
 

--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -186,16 +186,11 @@ func httpKeyFromConn(c network.ConnectionStats) http.Key {
 	laddr, lport := nat.GetLocalAddress(c)
 	raddr, rport := nat.GetRemoteAddress(c)
 
-	if http.IsHTTP(int(rport)) {
+	if network.IsEphemeralPort(int(lport)) {
 		return http.NewKey(laddr, raddr, lport, rport, "")
 	}
 
-	if http.IsHTTP(int(lport)) {
-		// Since HTTP data is always indexed as (client, server), we flip the lookup key
-		return http.NewKey(raddr, laddr, rport, lport, "")
-	}
-
-	return http.Key{}
+	return http.NewKey(raddr, laddr, rport, lport, "")
 }
 
 func returnToPool(c *model.Connections) {

--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -186,6 +186,8 @@ func httpKeyFromConn(c network.ConnectionStats) http.Key {
 	laddr, lport := nat.GetLocalAddress(c)
 	raddr, rport := nat.GetRemoteAddress(c)
 
+	// HTTP data is always indexed as (client, server), so we flip
+	// the lookup key if necessary using the port range heuristic
 	if network.IsEphemeralPort(int(lport)) {
 		return http.NewKey(laddr, raddr, lport, rport, "")
 	}

--- a/pkg/network/http/http_stats.go
+++ b/pkg/network/http/http_stats.go
@@ -34,11 +34,6 @@ func NewKey(saddr, daddr util.Address, sport, dport uint16, path string) Key {
 	}
 }
 
-// IsHTTP determines whether the port number corresponds to a HTTP port
-func IsHTTP(port int) bool {
-	return port == 80 || port == 8080
-}
-
 // RelativeAccuracy defines the acceptable error in quantile values calculated by DDSketch.
 // For example, if the actual value at p50 is 100, with a relative accuracy of 0.01 the value calculated
 // will be between 99 and 101

--- a/pkg/network/port_range.go
+++ b/pkg/network/port_range.go
@@ -1,0 +1,14 @@
+package network
+
+const (
+	ephemeralRangeStart = 32768
+	ephemeralRangeEnd   = 60999
+)
+
+// IsEphemeralPort returns true if a port belongs to the ephemeral range
+// This is mostly a placeholder for now as we have work planned for a
+// platform-agnostic solution that will, among other things, source these values
+// from procfs for Linux hosts
+func IsEphemeralPort(port int) bool {
+	return port >= ephemeralRangeStart && port <= ephemeralRangeEnd
+}


### PR DESCRIPTION
### What does this PR do?

Extend HTTP monitoring to all ports. The additional cost incurred per TCP segment is essentially one eBPF map lookup.
I tested this change against a mix of different workloads and didn't notice any perfomance impact.
As to the ephemeral port range detection I'll refactor part of the code after https://github.com/DataDog/datadog-agent/pull/7864 gets merged, so we can account for environments where a custom port range is used.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

1. Spin up an HTTP server and bind it to port `8081`: `python3 -m http.server --bind 127.0.0.1 8081`
2. Send a request to it: `curl http://localhost:8081`
3. Verify that the `httpAggregations` field is populated by inspecting the output of `curl -s localhost/connections --unix-socket /opt/datadog-agent/run/sysprobe.sock | jq '.conns[] | select(.raddr.port==8081 and .type == "tcp")'`
