### PR TITLE
pkg/trace/obfuscate: update test case

### DIFF
--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -333,7 +333,7 @@ func TestSQLTableFinderAndQuantizeTableNames(t *testing.T) {
 				"SELECT * FROM ( SELECT * FROM nested_table )",
 			},
 			{
-				"-- get user \n--\n select * \n   from users \n    where\n       id = 214325346",
+				"   -- get user \n--\n select * \n   from users \n    where\n       id = 214325346    ",
 				"users",
 				"select * from users where id = ?",
 			},


### PR DESCRIPTION
### What does this PR do?

Update a test case to make it clear that whitespace is trimmed from the start & end of the query.

### Motivation

Clarify expected SQL obfuscator behavior. 
