### PR TITLE
[snmp_listener] Add loader as snmp_listener.loader config

### DIFF
--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -33,6 +33,7 @@ type ListenerConfig struct {
 	Workers               int      `mapstructure:"workers"`
 	DiscoveryInterval     int      `mapstructure:"discovery_interval"`
 	AllowedFailures       int      `mapstructure:"allowed_failures"`
+	Loader                string   `mapstructure:"loader"`
 	CollectDeviceMetadata bool     `mapstructure:"collect_device_metadata"`
 	Configs               []Config `mapstructure:"configs"`
 }
@@ -102,6 +103,9 @@ func NewListenerConfig() (ListenerConfig, error) {
 			config.CollectDeviceMetadata = *config.CollectDeviceMetadataConfig
 		} else {
 			config.CollectDeviceMetadata = snmpConfig.CollectDeviceMetadata
+		}
+		if config.Loader == "" {
+			config.Loader = snmpConfig.Loader
 		}
 	}
 	return snmpConfig, nil

--- a/pkg/snmp/snmp_test.go
+++ b/pkg/snmp/snmp_test.go
@@ -87,3 +87,44 @@ snmp_listener:
 	assert.Equal(t, "127.0.0.3/30", conf.Configs[2].Network)
 	assert.Equal(t, false, conf.Configs[2].CollectDeviceMetadata)
 }
+
+func Test_LoaderConfig(t *testing.T) {
+	config.Datadog.SetConfigType("yaml")
+	err := config.Datadog.ReadConfig(strings.NewReader(`
+snmp_listener:
+  configs:
+   - network: 127.1.0.0/30
+   - network: 127.2.0.0/30
+     loader: core
+   - network: 127.3.0.0/30
+     loader: python
+`))
+	assert.NoError(t, err)
+
+	conf, err := NewListenerConfig()
+	assert.NoError(t, err)
+
+	assert.Equal(t, "", conf.Configs[0].Loader)
+	assert.Equal(t, "core", conf.Configs[1].Loader)
+	assert.Equal(t, "python", conf.Configs[2].Loader)
+
+	err = config.Datadog.ReadConfig(strings.NewReader(`
+snmp_listener:
+  loader: core
+  configs:
+   - network: 127.1.0.0/30
+   - network: 127.2.0.0/30
+     loader: core
+   - network: 127.3.0.0/30
+     loader: python
+`))
+	assert.NoError(t, err)
+
+	conf, err = NewListenerConfig()
+	assert.NoError(t, err)
+
+	assert.Equal(t, "core", conf.Configs[0].Loader)
+	assert.Equal(t, "core", conf.Configs[1].Loader)
+	assert.Equal(t, "python", conf.Configs[2].Loader)
+
+}

--- a/releasenotes/notes/snmp_listener_add_loader_as_global_config-34dbab5a7e7a3fbc.yaml
+++ b/releasenotes/notes/snmp_listener_add_loader_as_global_config-34dbab5a7e7a3fbc.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add loader as ``snmp_listener.loader`` config


### PR DESCRIPTION
Depend/Rebase onto https://github.com/DataDog/datadog-agent/pull/8140

### What does this PR do?

[snmp_listener] Add loader as snmp_listener.loader config

### Motivation

User request

### Additional Notes

### Describe how to test your changes

- Check that `snmp_listener.loader` is working as expected


II-299