### PR TITLE
Fix scheduling of default checks on ECS Fargate

### DIFF
--- a/Dockerfiles/agent/entrypoint/50-ecs.sh
+++ b/Dockerfiles/agent/entrypoint/50-ecs.sh
@@ -12,6 +12,4 @@ if [[ ! -e /etc/datadog-agent/datadog.yaml ]]; then
 fi
 
 # Remove all default checks, AD will automatically enable fargate check
-if [[ ! -e /etc/datadog-agent/conf.d/ecs_fargate.d/conf.yaml.default ]]; then
-    find /etc/datadog-agent/conf.d/ -iname "*.yaml.default" -delete
-fi
+find /etc/datadog-agent/conf.d/ -iname "*.yaml.default" | xargs grep -L 'ad_identifiers' | xargs rm -f

--- a/releasenotes/notes/fix-ecs-fargate-init-4420bf6bf92760af.yaml
+++ b/releasenotes/notes/fix-ecs-fargate-init-4420bf6bf92760af.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix bug introduced in 7.26 where default checks were schedueld on ECS Fargate due to changes in entrypoint scripts.


### PR DESCRIPTION
### What does this PR do?

Since 7.26 we do not remove `.default` files anymore as the `ecs_fargate` with environment autodiscovery relies on `.default` files.
Changing the logic to remove all default files without `ad_identifiers`.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Deploy the Agent on ECS Fargate, default checks (CPU, network, etc.) should not be scheduled.
