### PR TITLE
[dca] [fix] auto detect ec2 cluster name

### DIFF
--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -67,49 +67,46 @@ func getClusterName(data *clusterNameData, hostname string) string {
 	data.mutex.Lock()
 	defer data.mutex.Unlock()
 
-	if !data.initDone {
-		data.clusterName = config.Datadog.GetString("cluster_name")
-		if data.clusterName != "" {
-			log.Infof("Got cluster name %s from config", data.clusterName)
-			// the host alias "hostname-clustername" must not exceed 255 chars
-			hostAlias := hostname + "-" + data.clusterName
-			if !validClusterName.MatchString(data.clusterName) || len(hostAlias) > 255 {
-				log.Errorf("\"%s\" isn’t a valid cluster name. It must be dot-separated tokens where tokens "+
-					"start with a lowercase letter followed by lowercase letters, numbers, or "+
-					"hyphens, and cannot end with a hyphen nor have a dot adjacent to a hyphen and \"%s\" must not "+
-					"exceed 255 chars", data.clusterName, hostAlias)
-				log.Errorf("As a consequence, the cluster name provided by the config will be ignored")
-				data.clusterName = ""
-			}
+	data.clusterName = config.Datadog.GetString("cluster_name")
+	if data.clusterName != "" {
+		log.Infof("Got cluster name %s from config", data.clusterName)
+		// the host alias "hostname-clustername" must not exceed 255 chars
+		hostAlias := hostname + "-" + data.clusterName
+		if !validClusterName.MatchString(data.clusterName) || len(hostAlias) > 255 {
+			log.Errorf("\"%s\" isn’t a valid cluster name. It must be dot-separated tokens where tokens "+
+				"start with a lowercase letter followed by lowercase letters, numbers, or "+
+				"hyphens, and cannot end with a hyphen nor have a dot adjacent to a hyphen and \"%s\" must not "+
+				"exceed 255 chars", data.clusterName, hostAlias)
+			log.Errorf("As a consequence, the cluster name provided by the config will be ignored")
+			data.clusterName = ""
 		}
+	}
 
-		// autodiscover clustername through k8s providers' API
-		if data.clusterName == "" {
-			for cloudProvider, getClusterNameFunc := range ProviderCatalog {
-				log.Debugf("Trying to auto discover the cluster name from the %s API...", cloudProvider)
-				clusterName, err := getClusterNameFunc()
-				if err != nil {
-					log.Debugf("Unable to auto discover the cluster name from the %s API: %s", cloudProvider, err)
-					// try the next cloud provider
-					continue
-				}
-				if clusterName != "" {
-					log.Infof("Using cluster name %s auto discovered from the %s API", clusterName, cloudProvider)
-					data.clusterName = clusterName
-					break
-				}
-			}
-		}
-
-		if data.clusterName == "" {
-			clusterName, err := hostinfo.GetNodeClusterNameLabel()
+	// autodiscover clustername through k8s providers' API
+	if data.clusterName == "" {
+		for cloudProvider, getClusterNameFunc := range ProviderCatalog {
+			log.Debugf("Trying to auto discover the cluster name from the %s API...", cloudProvider)
+			clusterName, err := getClusterNameFunc()
 			if err != nil {
-				log.Debugf("Unable to auto discover the cluster name from node label : %s", err)
-			} else {
+				log.Debugf("Unable to auto discover the cluster name from the %s API: %s", cloudProvider, err)
+				// try the next cloud provider
+				continue
+			}
+			if clusterName != "" {
+				log.Infof("Using cluster name %s auto discovered from the %s API", clusterName, cloudProvider)
 				data.clusterName = clusterName
+				break
 			}
 		}
-		data.initDone = true
+	}
+
+	if data.clusterName == "" {
+		clusterName, err := hostinfo.GetNodeClusterNameLabel()
+		if err != nil {
+			log.Debugf("Unable to auto discover the cluster name from node label : %s", err)
+		} else {
+			data.clusterName = clusterName
+		}
 	}
 	return data.clusterName
 }

--- a/releasenotes-dca/notes/ec2-cluster-name-ecf4abee3c435e92.yaml
+++ b/releasenotes-dca/notes/ec2-cluster-name-ecf4abee3c435e92.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Autodetect EC2 cluster name

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -68,7 +68,7 @@ AGENT_TAGS = set(
 ANDROID_TAGS = set(["android", "zlib",])
 
 # CLUSTER_AGENT_TAGS lists the tags needed when building the cluster-agent
-CLUSTER_AGENT_TAGS = set(["clusterchecks", "kubeapiserver", "orchestrator", "secrets", "zlib", "ec2",])
+CLUSTER_AGENT_TAGS = set(["clusterchecks", "kubeapiserver", "orchestrator", "secrets", "zlib", "ec2", "gce",])
 
 # CLUSTER_AGENT_CLOUDFOUNDRY_TAGS lists the tags needed when building the cloudfoundry cluster-agent
 CLUSTER_AGENT_CLOUDFOUNDRY_TAGS = set(["clusterchecks", "secrets",])

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -65,45 +65,45 @@ AGENT_TAGS = set(
 )
 
 # ANDROID_TAGS lists the tags needed when building the android agent
-ANDROID_TAGS = set(["android", "zlib", ])
+ANDROID_TAGS = set(["android", "zlib",])
 
 # CLUSTER_AGENT_TAGS lists the tags needed when building the cluster-agent
-CLUSTER_AGENT_TAGS = set(["clusterchecks", "kubeapiserver", "orchestrator", "secrets", "zlib", "ec2"])
+CLUSTER_AGENT_TAGS = set(["clusterchecks", "kubeapiserver", "orchestrator", "secrets", "zlib", "ec2",])
 
 # CLUSTER_AGENT_CLOUDFOUNDRY_TAGS lists the tags needed when building the cloudfoundry cluster-agent
-CLUSTER_AGENT_CLOUDFOUNDRY_TAGS = set(["clusterchecks", "secrets", ])
+CLUSTER_AGENT_CLOUDFOUNDRY_TAGS = set(["clusterchecks", "secrets",])
 
 # DOGSTATSD_TAGS lists the tags needed when building dogstatsd
-DOGSTATSD_TAGS = set(["docker", "kubelet", "secrets", "zlib", ])
+DOGSTATSD_TAGS = set(["docker", "kubelet", "secrets", "zlib",])
 
 # IOT_AGENT_TAGS lists the tags needed when building the IoT agent
-IOT_AGENT_TAGS = set(["jetson", "systemd", "zlib", ])
+IOT_AGENT_TAGS = set(["jetson", "systemd", "zlib",])
 
 # PROCESS_AGENT_TAGS lists the tags necessary to build the process-agent
-PROCESS_AGENT_TAGS = AGENT_TAGS.union(set(["clusterchecks", "fargateprocess", "orchestrator", ]))
+PROCESS_AGENT_TAGS = AGENT_TAGS.union(set(["clusterchecks", "fargateprocess", "orchestrator",]))
 
 # SECURITY_AGENT_TAGS lists the tags necessary to build the security agent
-SECURITY_AGENT_TAGS = set(["netcgo", "secrets", "docker", "kubeapiserver", "kubelet", ])
+SECURITY_AGENT_TAGS = set(["netcgo", "secrets", "docker", "kubeapiserver", "kubelet",])
 
 # PROCESS_AGENT_TAGS lists the tags necessary to build system-probe
-SYSTEM_PROBE_TAGS = AGENT_TAGS.union(set(["clusterchecks", "linux_bpf", ]))
+SYSTEM_PROBE_TAGS = AGENT_TAGS.union(set(["clusterchecks", "linux_bpf",]))
 
 # TRACE_AGENT_TAGS lists the tags that have to be added when the trace-agent
-TRACE_AGENT_TAGS = set(["docker", "kubeapiserver", "kubelet", "netcgo", "secrets", ])
+TRACE_AGENT_TAGS = set(["docker", "kubeapiserver", "kubelet", "netcgo", "secrets",])
 
 # TEST_TAGS lists the tags that have to be added to run tests
-TEST_TAGS = AGENT_TAGS.union(set(["clusterchecks", ]))
+TEST_TAGS = AGENT_TAGS.union(set(["clusterchecks",]))
 
 ### Tag exclusion lists
 
 # List of tags to always remove when not building on Linux
-LINUX_ONLY_TAGS = set(["containerd", "cri", "netcgo", "systemd", "jetson", ])
+LINUX_ONLY_TAGS = set(["containerd", "cri", "netcgo", "systemd", "jetson",])
 
 # List of tags to always remove when building on Windows
 WINDOWS_EXCLUDE_TAGS = set(["linux_bpf"])
 
 # List of tags to always remove when building on Windows 32-bits
-WINDOWS_32BIT_EXCLUDE_TAGS = set(["docker", "kubeapiserver", "kubelet", "orchestrator", ])
+WINDOWS_32BIT_EXCLUDE_TAGS = set(["docker", "kubeapiserver", "kubelet", "orchestrator",])
 
 # Build type: build tags map
 build_tags = {

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -65,45 +65,45 @@ AGENT_TAGS = set(
 )
 
 # ANDROID_TAGS lists the tags needed when building the android agent
-ANDROID_TAGS = set(["android", "zlib",])
+ANDROID_TAGS = set(["android", "zlib", ])
 
 # CLUSTER_AGENT_TAGS lists the tags needed when building the cluster-agent
-CLUSTER_AGENT_TAGS = set(["clusterchecks", "kubeapiserver", "orchestrator", "secrets", "zlib",])
+CLUSTER_AGENT_TAGS = set(["clusterchecks", "kubeapiserver", "orchestrator", "secrets", "zlib", "ec2"])
 
 # CLUSTER_AGENT_CLOUDFOUNDRY_TAGS lists the tags needed when building the cloudfoundry cluster-agent
-CLUSTER_AGENT_CLOUDFOUNDRY_TAGS = set(["clusterchecks", "secrets",])
+CLUSTER_AGENT_CLOUDFOUNDRY_TAGS = set(["clusterchecks", "secrets", ])
 
 # DOGSTATSD_TAGS lists the tags needed when building dogstatsd
-DOGSTATSD_TAGS = set(["docker", "kubelet", "secrets", "zlib",])
+DOGSTATSD_TAGS = set(["docker", "kubelet", "secrets", "zlib", ])
 
 # IOT_AGENT_TAGS lists the tags needed when building the IoT agent
-IOT_AGENT_TAGS = set(["jetson", "systemd", "zlib",])
+IOT_AGENT_TAGS = set(["jetson", "systemd", "zlib", ])
 
 # PROCESS_AGENT_TAGS lists the tags necessary to build the process-agent
-PROCESS_AGENT_TAGS = AGENT_TAGS.union(set(["clusterchecks", "fargateprocess", "orchestrator",]))
+PROCESS_AGENT_TAGS = AGENT_TAGS.union(set(["clusterchecks", "fargateprocess", "orchestrator", ]))
 
 # SECURITY_AGENT_TAGS lists the tags necessary to build the security agent
-SECURITY_AGENT_TAGS = set(["netcgo", "secrets", "docker", "kubeapiserver", "kubelet",])
+SECURITY_AGENT_TAGS = set(["netcgo", "secrets", "docker", "kubeapiserver", "kubelet", ])
 
 # PROCESS_AGENT_TAGS lists the tags necessary to build system-probe
-SYSTEM_PROBE_TAGS = AGENT_TAGS.union(set(["clusterchecks", "linux_bpf",]))
+SYSTEM_PROBE_TAGS = AGENT_TAGS.union(set(["clusterchecks", "linux_bpf", ]))
 
 # TRACE_AGENT_TAGS lists the tags that have to be added when the trace-agent
-TRACE_AGENT_TAGS = set(["docker", "kubeapiserver", "kubelet", "netcgo", "secrets",])
+TRACE_AGENT_TAGS = set(["docker", "kubeapiserver", "kubelet", "netcgo", "secrets", ])
 
 # TEST_TAGS lists the tags that have to be added to run tests
-TEST_TAGS = AGENT_TAGS.union(set(["clusterchecks",]))
+TEST_TAGS = AGENT_TAGS.union(set(["clusterchecks", ]))
 
 ### Tag exclusion lists
 
 # List of tags to always remove when not building on Linux
-LINUX_ONLY_TAGS = set(["containerd", "cri", "netcgo", "systemd", "jetson",])
+LINUX_ONLY_TAGS = set(["containerd", "cri", "netcgo", "systemd", "jetson", ])
 
 # List of tags to always remove when building on Windows
 WINDOWS_EXCLUDE_TAGS = set(["linux_bpf"])
 
 # List of tags to always remove when building on Windows 32-bits
-WINDOWS_32BIT_EXCLUDE_TAGS = set(["docker", "kubeapiserver", "kubelet", "orchestrator",])
+WINDOWS_32BIT_EXCLUDE_TAGS = set(["docker", "kubeapiserver", "kubelet", "orchestrator", ])
 
 # Build type: build tags map
 build_tags = {


### PR DESCRIPTION
### What does this PR do?

Make the cluster-agent compile files marked as `ec2` and `gce` as well.
The related image building job uses the same command which uses python `invoke` command: https://github.com/DataDog/datadog-agent/blob/717d1cc52ad4f6a606d050d6e6cb07d994f7eaa0/.gitlab/binary_build/cluster_agent.yml#L18

**NOTE**:
GCE build tag is not added in the `DCA`, the cluster name detection code for the specific cloud providers do not use the tag. So I did not add this to the PR. 

**Binary Size**
Tested on my mac:

With EC2 and GCE Tags 
```
.rwxr-xr-x 94M nam.nguyen 25 May 16:58 datadog-cluster-agent
```

Current, based on Master/Main
```
.rwxr-xr-x 91M nam.nguyen 25 May 16:59 datadog-cluster-agent
```

Note: we have one file with the `// +build ec2` tag and one file with `// +build gce`

Size diff: 3MB

### Motivation

Our agents are able to auto discover the cluster name in `ec2` while our `cluster-agent` was unable to do so.
This fix should makes it possible. 

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

- deploy an image based on master to an `ec2` cluster
- verify that it does not work for the DCA: `kubectl exec -it deployment/datadog-cluster-agent -- agent status`
```
=====================
Orchestrator Explorer
=====================
  Collection Status: The collection has not run successfully yet since the cache is empty.
  Cluster Name: No cluster name was detected. This means resource collection will not work.
  Cluster ID: 1ca220d2-4ff3-498c-8119-adc25e90346e
  Container scrubbing: enabled
```


- verify that it works for the agent: `kubectl exec -it daemonset/datadog -- agent status`
```
    host tags:
      kube_cluster_name:nam-nguyen
      cluster_name:nam-nguyen
```
- deploy the image based on this fix on an `ec2` cluster
- verify that it works now `kubectl exec -it deployment/datadog-cluster-agent -- agent status`
```
=====================
Orchestrator Explorer
=====================
  Collection Status: The collection is at least partially running since the cache has been populated.
  Cluster Name: nam-nguyen
  Cluster ID: 1ca220d2-4ff3-498c-8119-adc25e90346e
  Container scrubbing: enabled
```