### PR TITLE
[snmp_listener] Make SNMP Listener configs compatible with SNMP Integration configs

### DIFF
--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -396,7 +396,7 @@ func (s *SNMPService) GetExtraConfig(key []byte) ([]byte, error) {
 	case "oid_batch_size":
 		return []byte(fmt.Sprintf("%d", s.config.OidBatchSize)), nil
 	case "community":
-		return []byte(s.config.Community), nil
+		return []byte(s.config.CommunityString), nil
 	case "user":
 		return []byte(s.config.User), nil
 	case "auth_key":

--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -23,9 +23,9 @@ func TestSNMPListener(t *testing.T) {
 	testChan := make(chan snmpJob, 10)
 
 	snmpConfig := snmp.Config{
-		Network:   "192.168.0.0/24",
-		Community: "public",
-		Loader:    "core",
+		Network:         "192.168.0.0/24",
+		CommunityString: "public",
+		Loader:          "core",
 	}
 	listenerConfig := snmp.ListenerConfig{
 		Configs: []snmp.Config{snmpConfig},
@@ -53,7 +53,7 @@ func TestSNMPListener(t *testing.T) {
 	assert.Equal(t, "192.168.0.0", job.currentIP.String())
 	assert.Equal(t, "192.168.0.0", job.subnet.startingIP.String())
 	assert.Equal(t, "192.168.0.0/24", job.subnet.network.String())
-	assert.Equal(t, "public", job.subnet.config.Community)
+	assert.Equal(t, "public", job.subnet.config.CommunityString)
 
 	job = <-testChan
 	assert.Equal(t, "192.168.0.1", job.currentIP.String())
@@ -72,10 +72,10 @@ func TestSNMPListenerSubnets(t *testing.T) {
 
 	for i := 0; i < 100; i++ {
 		snmpConfig := snmp.Config{
-			Network:     "172.18.0.0/30",
-			Community:   "f5-big-ip",
-			Port:        1161,
-			ContextName: "context" + strconv.Itoa(i),
+			Network:         "172.18.0.0/30",
+			CommunityString: "f5-big-ip",
+			Port:            1161,
+			ContextName:     "context" + strconv.Itoa(i),
 		}
 		listenerConfig.Configs = append(listenerConfig.Configs, snmpConfig)
 	}
@@ -123,7 +123,7 @@ func TestSNMPListenerIgnoredAdresses(t *testing.T) {
 
 	snmpConfig := snmp.Config{
 		Network:            "192.168.0.0/24",
-		Community:          "public",
+		CommunityString:    "public",
 		IgnoredIPAddresses: map[string]bool{"192.168.0.0": true},
 	}
 	listenerConfig := snmp.ListenerConfig{
@@ -158,11 +158,11 @@ func TestSNMPListenerIgnoredAdresses(t *testing.T) {
 
 func TestExtraConfig(t *testing.T) {
 	snmpConfig := snmp.Config{
-		Network:      "192.168.0.0/24",
-		Community:    "public",
-		Timeout:      5,
-		Retries:      2,
-		OidBatchSize: 10,
+		Network:         "192.168.0.0/24",
+		CommunityString: "public",
+		Timeout:         5,
+		Retries:         2,
+		OidBatchSize:    10,
 	}
 
 	svc := SNMPService{
@@ -214,10 +214,10 @@ func TestExtraConfig(t *testing.T) {
 
 func TestExtraConfigExtraTags(t *testing.T) {
 	snmpConfig := snmp.Config{
-		Network:   "192.168.0.0/24",
-		Community: "public",
-		Timeout:   5,
-		Retries:   2,
+		Network:         "192.168.0.0/24",
+		CommunityString: "public",
+		Timeout:         5,
+		Retries:         2,
 		Tags: []string{
 			"tag1:val,1,2",
 			"tag2:val_2",

--- a/pkg/collector/corechecks/snmp/gosnmp_log.go
+++ b/pkg/collector/corechecks/snmp/gosnmp_log.go
@@ -32,7 +32,7 @@ var replacers = []Replacer{
 		Repl:  []byte(`$1 ********`),
 	},
 	{
-		Regex: regexp.MustCompile(`(\s*(?:Community|ContextEngineID):).+?(\s[\w]+:)`),
+		Regex: regexp.MustCompile(`(\s*(?:CommunityString|ContextEngineID):).+?(\s[\w]+:)`),
 		Repl:  []byte(`${1}********${2}`),
 	},
 }

--- a/pkg/collector/corechecks/snmp/gosnmp_log_test.go
+++ b/pkg/collector/corechecks/snmp/gosnmp_log_test.go
@@ -62,13 +62,13 @@ func TestTraceLevelLogWriter_Write(t *testing.T) {
 		},
 		{
 			name:         "scrub community no quote",
-			logLine:      []byte(`TEST: ContextName:cisco-nexus Community:abcd PDUType:162`),
-			expectedLogs: "[TRACE] Write: TEST: ContextName:cisco-nexus Community:******** PDUType:162",
+			logLine:      []byte(`TEST: ContextName:cisco-nexus CommunityString:abcd PDUType:162`),
+			expectedLogs: "[TRACE] Write: TEST: ContextName:cisco-nexus CommunityString:******** PDUType:162",
 		},
 		{
 			name:         "scrub community quote",
-			logLine:      []byte(`TEST: ContextName:"cisco-nexus", Community:"abcd", PDUType:0xa5`),
-			expectedLogs: "[TRACE] Write: TEST: ContextName:\"cisco-nexus\", Community:******** PDUType:0xa5",
+			logLine:      []byte(`TEST: ContextName:"cisco-nexus", CommunityString:"abcd", PDUType:0xa5`),
+			expectedLogs: "[TRACE] Write: TEST: ContextName:\"cisco-nexus\", CommunityString:******** PDUType:0xa5",
 		},
 		{
 			name:         "scrub ContextEngineID no quote",

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -524,12 +524,12 @@ api_key:
   #
   # discovery_interval: 3600
 
-  ## @param allowed_failures - integer - optional - default: 3
+  ## @param discovery_allowed_failures - integer - optional - default: 3
   ## The number of failed requests to a given SNMP device before removing it from the list of monitored
   ## devices.
-  ## If a device shuts down, the Agent stops monitoring it after `discovery_interval * allowed_failures` seconds.
+  ## If a device shuts down, the Agent stops monitoring it after `discovery_interval * discovery_allowed_failures` seconds.
   #
-  # allowed_failures: 3
+  # discovery_allowed_failures: 3
 
   ## @param configs - list - required
   ## The actual list of configurations used to discover SNMP devices in various subnets.
@@ -545,14 +545,14 @@ api_key:
   ##      - 10.0.1.1
   #
   # configs:
-    ## @param network - string - required
+    ## @param network_address - string - required
     ## The subnet in CIDR format to scan for SNMP devices.
     ## All unignored IP addresses in the CIDR range are scanned.
     ## For optimal discovery time, be sure to use the smallest network mask
     ## possible as is appropriate for your network topology.
     ## Ex: 10.0.1.0/24
     #
-    # - network: <NETWORK>
+    # - network_address: <NETWORK>
 
     ## @param ignored_ip_addresses - list of strings - optional
     ## A list of IP addresses to ignore when scanning the network.
@@ -566,12 +566,12 @@ api_key:
     #
     # port: 161
 
-    ## @param version - integer - optional - default: <BEST_GUESS>
+    ## @param snmp_version - integer - optional - default: <BEST_GUESS>
     ## Set the version of the SNMP protocol. Available options are: `1`, `2` or `3`.
     ## If unset, the Agent tries to guess the correct version based on other configuration
     ## parameters, for example: if `user` is set, the Agent uses SNMP v3.
     #
-    # version: <VERSION>
+    # snmp_version: <VERSION>
 
     ## @param timeout - integer - optional - default: 5
     ## The number of seconds before timing out.
@@ -583,11 +583,11 @@ api_key:
     #
     # retries: 3
 
-    ## @param community - string - optional
+    ## @param community_string - string - optional
     ## Required for SNMP v1 & v2.
     ## Ex: 'public'
     #
-    # community: <COMMUNITY>
+    # community_string: <COMMUNITY>
 
     ## @param user - string - optional
     ## The username to connect to your SNMP devices.
@@ -595,33 +595,33 @@ api_key:
     #
     # user: <USERNAME>
 
-    ## @param authentication_key - string - optional
+    ## @param authKey - string - optional
     ## The passphrase to use with your Authentication type.
     ## SNMPv3 only.
     #
-    # authentication_key: <AUTHENTICATION_KEY>
+    # authKey: <AUTHENTICATION_KEY>
 
-    ## @param authentication_protocol - string - optional
+    ## @param authProtocol - string - optional
     ## The authentication protocol to use when connecting to your SNMP devices.
     ## Available options are: MD5, SHA.
     ## Defaults to MD5 when `authentication_key` is specified.
     ## SNMPv3 only.
     #
-    # authentication_protocol: <AUTHENTICATION_PROTOCOL>
+    # authProtocol: <AUTHENTICATION_PROTOCOL>
 
-    ## @param privacy_key - string - optional
+    ## @param privKey - string - optional
     ## The passphrase to use with your privacy protocol.
     ## SNMPv3 only.
     #
-    # privacy_key: <PRIVACY_KEY>
+    # privKey: <PRIVACY_KEY>
 
-    ## @param privacy_protocol - string - optional
+    ## @param privProtocol - string - optional
     ## The privacy protocol to use when connecting to your SNMP devices.
     ## Available options are: DES, 3DES, AES, AES192, AES256, AES192C, AES256C.
     ## Defaults to DES when `privacy_key` is specified.
     ## SNMPv3 only.
     #
-    # privacy_protocol: <PRIVACY_PROTOCOL>
+    # privProtocol: <PRIVACY_PROTOCOL>
 
     ## @param context_name - string - optional
     ## The name of your context (optional SNMP v3-only parameter).

--- a/pkg/snmp/snmp_test.go
+++ b/pkg/snmp/snmp_test.go
@@ -30,8 +30,8 @@ func TestBuildSNMPParams(t *testing.T) {
 	assert.Equal(t, "SNMP version not supported: 4", err.Error())
 
 	config = Config{
-		Network:   "192.168.0.0/24",
-		Community: "public",
+		Network:         "192.168.0.0/24",
+		CommunityString: "public",
 	}
 	params, _ := config.BuildSNMPParams("192.168.0.1")
 	assert.Equal(t, gosnmp.Version2c, params.Version)
@@ -88,43 +88,69 @@ snmp_listener:
 	assert.Equal(t, false, conf.Configs[2].CollectDeviceMetadata)
 }
 
-func Test_LoaderConfig(t *testing.T) {
+func Test_Configs(t *testing.T) {
 	config.Datadog.SetConfigType("yaml")
 	err := config.Datadog.ReadConfig(strings.NewReader(`
 snmp_listener:
+  workers: 10
+  discovery_interval: 11
+  discovery_allowed_failures: 5
+  loader: core
+  collect_device_metadata: true
   configs:
-   - network: 127.1.0.0/30
-   - network: 127.2.0.0/30
-     loader: core
-   - network: 127.3.0.0/30
-     loader: python
+   - authProtocol: someAuthProtocol
+     authKey: someAuthKey
+     privProtocol: somePrivProtocol
+     privKey: somePrivKey
+     community_string: someCommunityString
+     snmp_version: someSnmpVersion
+     network_address: 127.1.0.0/30
 `))
 	assert.NoError(t, err)
 
 	conf, err := NewListenerConfig()
 	assert.NoError(t, err)
 
-	assert.Equal(t, "", conf.Configs[0].Loader)
-	assert.Equal(t, "core", conf.Configs[1].Loader)
-	assert.Equal(t, "python", conf.Configs[2].Loader)
+	networkConf := conf.Configs[0]
+	assert.Equal(t, 10, conf.Workers)
+	assert.Equal(t, 11, conf.DiscoveryInterval)
+	assert.Equal(t, 5, conf.AllowedFailures)
+	assert.Equal(t, true, conf.CollectDeviceMetadata)
+	assert.Equal(t, "core", conf.Loader)
+	assert.Equal(t, "someAuthProtocol", networkConf.AuthProtocol)
+	assert.Equal(t, "someAuthKey", networkConf.AuthKey)
+	assert.Equal(t, "somePrivProtocol", networkConf.PrivProtocol)
+	assert.Equal(t, "somePrivKey", networkConf.PrivKey)
+	assert.Equal(t, "someCommunityString", networkConf.CommunityString)
+	assert.Equal(t, "someSnmpVersion", networkConf.Version)
+	assert.Equal(t, "127.1.0.0/30", networkConf.Network)
 
+	/////////////////
+	// legacy configs
+	/////////////////
 	err = config.Datadog.ReadConfig(strings.NewReader(`
 snmp_listener:
-  loader: core
+  allowed_failures: 15
   configs:
-   - network: 127.1.0.0/30
-   - network: 127.2.0.0/30
-     loader: core
-   - network: 127.3.0.0/30
-     loader: python
+   - authentication_protocol: legacyAuthProtocol
+     authentication_key: legacyAuthKey
+     privacy_protocol: legacyPrivProtocol
+     privacy_key: legacyPrivKey
+     community: legacyCommunityString
+     version: legacySnmpVersion
+     network: 127.2.0.0/30
 `))
 	assert.NoError(t, err)
-
 	conf, err = NewListenerConfig()
 	assert.NoError(t, err)
+	legacyConfig := conf.Configs[0]
 
-	assert.Equal(t, "core", conf.Configs[0].Loader)
-	assert.Equal(t, "core", conf.Configs[1].Loader)
-	assert.Equal(t, "python", conf.Configs[2].Loader)
-
+	assert.Equal(t, 15, conf.AllowedFailures)
+	assert.Equal(t, "legacyAuthProtocol", legacyConfig.AuthProtocol)
+	assert.Equal(t, "legacyAuthKey", legacyConfig.AuthKey)
+	assert.Equal(t, "legacyPrivProtocol", legacyConfig.PrivProtocol)
+	assert.Equal(t, "legacyPrivKey", legacyConfig.PrivKey)
+	assert.Equal(t, "legacyCommunityString", legacyConfig.CommunityString)
+	assert.Equal(t, "legacySnmpVersion", legacyConfig.Version)
+	assert.Equal(t, "127.2.0.0/30", legacyConfig.Network)
 }


### PR DESCRIPTION
### What does this PR do?

[snmp_listener] Make SNMP Listener configs compatible with SNMP Integration configs

### Motivation

Make it easier to migration from SNMP python autodiscovery to snmp listener (SNMP agent autodiscovery)

### Additional Notes

### Describe how to test your changes

- Check the legacy configs work
- Check the new configs work