### PR TITLE
[release] Fix 7.28.0 JMXFetch changelog entries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -95,7 +95,8 @@ Enhancement Notes
 
 - Add ``jvm.gc.old_gen_size`` as an alias for ``Tenured Gen``.
   Prevent double signing of release artifacts.
-  JMXFetch upgraded to ``0.43.0 <https://github.com/DataDog/jmxfetch/releases/0.43.0>``
+
+- JMXFetch upgraded to `v0.44.0 <https://github.com/DataDog/jmxfetch/releases/0.44.0>`_.
 
 - The ``kubernetes_state_core`` check now collects two new metrics ``kubernetes_state.pod.age`` and ``kubernetes_state.pod.uptime``.
 
@@ -172,9 +173,6 @@ Other Notes
 -----------
 
 - The Agent, Logs Agent and the system-probe are now compiled with Go ``1.15.11``
-
-- JMXFetch upgraded from ``0.42.0`` to ``0.42.1`` as a part of the move to
-  a new release pipeline for this component.
 
 - Bump embedded Python 3 to ``3.8.8``
 


### PR DESCRIPTION
Since the JMXFetch version got auto-upgraded by the release scripts in
the 7.28.x branch, we needed to fix up the changelog to indicate the
upgrade properly and correctly identify the version included.

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
