### PR TITLE
[KSMCore] Add node ephemeral-storage metrics

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
@@ -79,6 +79,9 @@
 `kubernetes_state.node.pods_allocatable`
 : The allocatable memory of a node that is available for scheduling. Tags:`node` `resource` `unit`.
 
+`kubernetes_state.node.ephemeral_storage_allocatable`
+: The allocatable ephemeral-storage of a node that is available for scheduling. Tags:`node` `resource` `unit`.
+
 `kubernetes_state.node.cpu_capacity`
 : The CPU capacity of a node. Tags:`node` `resource` `unit`.
 
@@ -87,6 +90,9 @@
 
 `kubernetes_state.node.pods_capacity`
 : The pods capacity of a node. Tags:`node` `resource` `unit`.
+
+`kubernetes_state.node.ephemeral_storage_capacity`
+: The ephemeral-storage capacity of a node. Tags:`node` `resource` `unit`.
 
 `kubernetes_state.node.by_condition`
 : The condition of a cluster node. Tags:`condition` `node` `status`.

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
@@ -270,7 +270,7 @@ func submitNodeResourceMetric(s aggregator.Sender, name string, metric ksmstore.
 		s.Gauge(ksmMetricPrefix+"node.pods_"+metricSuffix, metric.Val, hostname, tags)
 		return
 	case "ephemeral_storage":
-		s.Gauge(ksmMetricPrefix+"node.ephemeral_storage"+metricSuffix, metric.Val, hostname, tags)
+		s.Gauge(ksmMetricPrefix+"node.ephemeral_storage_"+metricSuffix, metric.Val, hostname, tags)
 		return
 	default:
 		log.Tracef("Ignoring node resource metric '%s': resource '%s' is not supported", name, resource)

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers.go
@@ -269,6 +269,9 @@ func submitNodeResourceMetric(s aggregator.Sender, name string, metric ksmstore.
 	case "pods":
 		s.Gauge(ksmMetricPrefix+"node.pods_"+metricSuffix, metric.Val, hostname, tags)
 		return
+	case "ephemeral_storage":
+		s.Gauge(ksmMetricPrefix+"node.ephemeral_storage"+metricSuffix, metric.Val, hostname, tags)
+		return
 	default:
 		log.Tracef("Ignoring node resource metric '%s': resource '%s' is not supported", name, resource)
 	}

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers_test.go
@@ -1681,6 +1681,27 @@ func Test_nodeAllocatableTransformer(t *testing.T) {
 			},
 		},
 		{
+			name: "ephemeral_storage",
+			args: args{
+				name: "kube_node_status_allocatable",
+				metric: ksmstore.DDMetric{
+					Val: 64,
+					Labels: map[string]string{
+						"resource": "ephemeral_storage",
+						"unit":     "byte",
+					},
+				},
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+			expected: &metricsExpected{
+				name:     "kubernetes_state.node.ephemeral_storage_allocatable",
+				val:      64,
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+		},
+		{
 			name: "no resource label",
 			args: args{
 				name: "kube_node_status_allocatable",
@@ -1776,6 +1797,27 @@ func Test_nodeCapacityTransformer(t *testing.T) {
 			expected: &metricsExpected{
 				name:     "kubernetes_state.node.pods_capacity",
 				val:      100,
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+		},
+		{
+			name: "ephemeral_storage",
+			args: args{
+				name: "kube_node_status_capacity",
+				metric: ksmstore.DDMetric{
+					Val: 129,
+					Labels: map[string]string{
+						"resource": "ephemeral_storage",
+						"unit":     "byte",
+					},
+				},
+				tags:     []string{"foo:bar"},
+				hostname: "foo",
+			},
+			expected: &metricsExpected{
+				name:     "kubernetes_state.node.ephemeral_storage_capacity",
+				val:      129,
 				tags:     []string{"foo:bar"},
 				hostname: "foo",
 			},

--- a/releasenotes/notes/add-ephemeral-storage-metric-6ef30c2f30db0dbd.yaml
+++ b/releasenotes/notes/add-ephemeral-storage-metric-6ef30c2f30db0dbd.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add the following new metrics to the ``kubernetes_state_core``.
+    * ``node.ephemeral_storage_allocatable```
+    * ``node.ephemeral_storage_capacity``


### PR DESCRIPTION
### What does this PR do?

Implements in the KSMCore check "ephemeral-storage" metrics from node. 
Metrics added: 
   * ``node.ephemeral_storage_allocatable``
   * ``node.ephemeral_storage_capacity``

### Motivation

Update the ``kubernetes_state_core`` so users can get 'ephemeral-storage' metrics for ``capacity``, and ``allocatable`` from nodes. 

### Describe how to test your changes

Deploy the agent and enable the ``kubernetes_state_core`` check and validate that the above mentioned metrics are correctly generated.

![ephemeral-storage](https://user-images.githubusercontent.com/3012422/119534645-24ab2d80-bd55-11eb-8819-45111096879c.png)

