### PR TITLE
[log] avoid feedback loop in windows tailer

### DIFF
--- a/pkg/logs/input/file/tailer_windows.go
+++ b/pkg/logs/input/file/tailer_windows.go
@@ -56,7 +56,6 @@ func (t *Tailer) readAvailable() (int, error) {
 
 	sz := st.Size()
 	offset := t.GetReadOffset()
-	log.Debugf("Size is %d, offset is %d", sz, offset)
 	if sz == 0 {
 		log.Debug("File size now zero, resetting offset")
 		t.SetReadOffset(0)
@@ -74,10 +73,8 @@ func (t *Tailer) readAvailable() (int, error) {
 		n, err := f.Read(inBuf)
 		bytes += n
 		if n == 0 || err != nil {
-			log.Debugf("Done reading")
 			return bytes, err
 		}
-		log.Debugf("Sending %d bytes to input channel", n)
 		t.decoder.InputChan <- decoder.NewInput(inBuf[:n])
 		t.incrementReadOffset(n)
 	}

--- a/releasenotes/notes/windows-tailer-54ca0b6ac01525b0.yaml
+++ b/releasenotes/notes/windows-tailer-54ca0b6ac01525b0.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Reduce amount of log messages on windows when tailing log files.


### PR DESCRIPTION
### What does this PR do?

Remove debug messages that would generate additional messages when the agent is tailing
its own log file, causing endless loop.

### Describe how to test your changes

On **Windows**:
1. Configure the agent to tail its own log file and set log level to `debug`. 
2. Check that full agent log is visible in datadog app.
3. Check that the agent does not produce new debug entries every second.