### PR TITLE
[process-agent] Ignore empty CollectorStatus from orchestrator-intake

### DIFF
--- a/cmd/process-agent/collector_test.go
+++ b/cmd/process-agent/collector_test.go
@@ -24,7 +24,7 @@ func TestUpdateRTStatus(t *testing.T) {
 		{ActiveClients: 3, Interval: 2},
 		{ActiveClients: 0, Interval: 2},
 	}
-	c.updateStatus(statuses)
+	c.updateRTStatus(statuses)
 	assert.Equal(int32(1), atomic.LoadInt32(&c.realTimeEnabled))
 
 	// Validate that we stay that way
@@ -33,7 +33,7 @@ func TestUpdateRTStatus(t *testing.T) {
 		{ActiveClients: 3, Interval: 2},
 		{ActiveClients: 0, Interval: 2},
 	}
-	c.updateStatus(statuses)
+	c.updateRTStatus(statuses)
 	assert.Equal(int32(1), atomic.LoadInt32(&c.realTimeEnabled))
 
 	// And that it can turn back off
@@ -42,7 +42,7 @@ func TestUpdateRTStatus(t *testing.T) {
 		{ActiveClients: 0, Interval: 2},
 		{ActiveClients: 0, Interval: 2},
 	}
-	c.updateStatus(statuses)
+	c.updateRTStatus(statuses)
 	assert.Equal(int32(0), atomic.LoadInt32(&c.realTimeEnabled))
 }
 
@@ -60,7 +60,7 @@ func TestUpdateRTInterval(t *testing.T) {
 		{ActiveClients: 3, Interval: 2},
 		{ActiveClients: 0, Interval: 10},
 	}
-	c.updateStatus(statuses)
+	c.updateRTStatus(statuses)
 	assert.Equal(int32(1), atomic.LoadInt32(&c.realTimeEnabled))
 	assert.Equal(10*time.Second, c.realTimeInterval)
 }

--- a/releasenotes/notes/process-agent-ignore-orch-intake-collectorstatus-441fd8046fc24c96.yaml
+++ b/releasenotes/notes/process-agent-ignore-orch-intake-collectorstatus-441fd8046fc24c96.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Ignore CollectorStatus response from orchestrator-intake in the process-agent to prevent changing realtime mode interval to default 2s.
+


### PR DESCRIPTION
### What does this PR do?

Since the pod check is also handled by the process agent we process the empty CollectorStatus payload from the orchestrator-intake and that can potentially reset the RT interval to the default 2s.

### Motivation

Only handle RT interval changes from process intake endpoint.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Deploy process-agent with orchestrator explorer enabled. Make sure that the RT interval is not flipping between the one configured on the intake and the default 2s.
