### PR TITLE
[compliance-agent] return multiple reports for failed or success resources

### DIFF
--- a/pkg/compliance/checks/checkable_test.go
+++ b/pkg/compliance/checks/checkable_test.go
@@ -28,7 +28,7 @@ func TestCheckableList(t *testing.T) {
 		expected outcome
 	}{
 		{
-			name: "first=passed, second=passed => result=[all passed]",
+			name: "first=passed, second=passed, third=pass => result=[all passed]",
 			list: []outcome{
 				{
 					reports: []*compliance.Report{
@@ -50,70 +50,10 @@ func TestCheckableList(t *testing.T) {
 						},
 					},
 				},
-			},
-			expected: outcome{
-				reports: []*compliance.Report{
-					{
-						Passed: true,
-						Data: event.Data{
-							"something else": "passed",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "first=passed, second=failed => result=[failed from second]",
-			list: []outcome{
 				{
 					reports: []*compliance.Report{
 						{
 							Passed: true,
-							Data: event.Data{
-								"something": "passed",
-							},
-						},
-					},
-				},
-				{
-					reports: []*compliance.Report{
-						{
-							Passed: false,
-							Data: event.Data{
-								"something": "failed",
-							},
-						},
-					},
-				},
-			},
-			expected: outcome{
-				reports: []*compliance.Report{
-					{
-						Passed: false,
-						Data: event.Data{
-							"something": "failed",
-						},
-					},
-				},
-			},
-		},
-		{
-			name: "first=failed, second=failed => result=[all failed]",
-			list: []outcome{
-				{
-					reports: []*compliance.Report{
-						{
-							Passed: false,
-							Data: event.Data{
-								"something": "failed",
-							},
-						},
-					},
-				},
-				{
-					reports: []*compliance.Report{
-						{
-							Passed: false,
 							Data: event.Data{
 								"something else": "failed",
 							},
@@ -124,109 +64,23 @@ func TestCheckableList(t *testing.T) {
 			expected: outcome{
 				reports: []*compliance.Report{
 					{
-						Passed: false,
+						Passed: true,
 						Data: event.Data{
-							"something": "failed",
+							"something": "passed",
 						},
 					},
-				},
-			},
-		},
-		{
-			name: "first=error, second=passed => result[error from first]",
-			list: []outcome{
-				{
-					reports: []*compliance.Report{
-						{
-							Passed: false,
-							Error:  errors.New("some error"),
-						},
-					},
-				},
-				{
-					reports: []*compliance.Report{
-						{
-							Passed: true,
-							Data: event.Data{
-								"something else": "passed",
-							},
-						},
-					},
-				},
-			},
-			expected: outcome{
-				reports: []*compliance.Report{
 					{
-						Passed: false,
-						Error:  errors.New("some error"),
-					},
-				},
-			},
-		},
-		{
-			name: "first=failed, second=passed => result[failed from first]",
-			list: []outcome{
-				{
-					reports: []*compliance.Report{
-						{
-							Passed: false,
-							Data: event.Data{
-								"something": "failed",
-							},
+						Passed: true,
+						Data: event.Data{
+							"something else": "passed",
 						},
 					},
-				},
-				{
-					reports: []*compliance.Report{
-						{
-							Passed: true,
-							Data: event.Data{
-								"something else": "passed",
-							},
-						},
-					},
-				},
-			},
-			expected: outcome{
-				reports: []*compliance.Report{
 					{
 						Passed: false,
 						Data: event.Data{
-							"something": "failed",
+							"truncated": 1,
 						},
-					},
-				},
-			},
-		},
-		{
-			name: "first=failed, second=error => result[failed from first]",
-			list: []outcome{
-				{
-					reports: []*compliance.Report{
-						{
-							Passed: false,
-							Data: event.Data{
-								"something": "failed",
-							},
-						},
-					},
-				},
-				{
-					reports: []*compliance.Report{
-						{
-							Passed: false,
-							Error:  errors.New("some other error"),
-						},
-					},
-				},
-			},
-			expected: outcome{
-				reports: []*compliance.Report{
-					{
-						Passed: false,
-						Data: event.Data{
-							"something": "failed",
-						},
+						Error: errors.New("truncated result"),
 					},
 				},
 			},
@@ -236,7 +90,7 @@ func TestCheckableList(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			env := &mocks.Env{}
-			env.On("MaxEventsPerRun").Return(1)
+			env.On("MaxEventsPerRun").Return(2)
 
 			var list checkableList
 

--- a/pkg/compliance/checks/helpers.go
+++ b/pkg/compliance/checks/helpers.go
@@ -135,21 +135,6 @@ func instanceToReport(instance *eval.Instance, passed bool, allowedFields []stri
 
 // instanceToReports converts an evaluated instanceResult to reports
 // filtering out fields not on the allowedFields list
-func instanceResultToReports(result *eval.InstanceResult, allowedFields []string) []*compliance.Report {
-	var reports []*compliance.Report
-
-	if len(result.Instances) > 0 {
-		for _, instance := range result.Instances {
-			reports = append(reports, instanceToReport(instance, result.Passed, allowedFields))
-
-			// report only one success instance
-			if result.Passed {
-				break
-			}
-		}
-	} else {
-		reports = append(reports, &compliance.Report{Passed: false})
-	}
-
-	return reports
+func instanceResultToReport(result *eval.InstanceResult, allowedFields []string) *compliance.Report {
+	return instanceToReport(result.Instance, result.Passed, allowedFields)
 }

--- a/pkg/compliance/checks/resource_check.go
+++ b/pkg/compliance/checks/resource_check.go
@@ -92,11 +92,17 @@ func (c *resourceCheck) evaluate(env env.Env, resolved interface{}) []*complianc
 			return []*compliance.Report{compliance.BuildReportForError(ErrResourceCannotUseFallback)}
 		}
 
-		result, err := conditionExpression.EvaluateIterator(resolved, globalInstance, env.MaxEventsPerRun())
+		results, err := conditionExpression.EvaluateIterator(resolved, globalInstance)
 		if err != nil {
 			return []*compliance.Report{compliance.BuildReportForError(err)}
 		}
-		reports := instanceResultToReports(result, c.reportedFields)
+
+		var reports []*compliance.Report
+		for _, result := range results {
+			report := instanceResultToReport(result, c.reportedFields)
+			reports = append(reports, report)
+		}
+
 		return reports
 	default:
 		return []*compliance.Report{compliance.BuildReportForError(ErrResourceFailedToResolve)}

--- a/pkg/compliance/checks/resource_check_test.go
+++ b/pkg/compliance/checks/resource_check_test.go
@@ -158,11 +158,17 @@ func TestResourceCheck(t *testing.T) {
 			expectErr: ErrResourceFallbackMissing,
 		},
 		{
-			name:              "iterator not passing",
+			name:              "iterator partially passed",
 			resourceCondition: "a > 10",
 			resourceResolved:  iterator,
 			reportedFields:    []string{"a"},
 			expectReports: []*compliance.Report{
+				{
+					Passed: true,
+					Data: event.Data{
+						"a": 14,
+					},
+				},
 				{
 					Passed: false,
 					Data: event.Data{
@@ -173,20 +179,6 @@ func TestResourceCheck(t *testing.T) {
 					Passed: false,
 					Data: event.Data{
 						"a": 4,
-					},
-				},
-			},
-		},
-		{
-			name:              "iterator passed",
-			resourceCondition: "a > 2",
-			resourceResolved:  iterator,
-			reportedFields:    []string{"a"},
-			expectReports: []*compliance.Report{
-				{
-					Passed: true,
-					Data: event.Data{
-						"a": 14,
 					},
 				},
 			},
@@ -201,18 +193,6 @@ func TestResourceCheck(t *testing.T) {
 					Passed: false,
 					Data: event.Data{
 						"a": 14,
-					},
-				},
-				{
-					Passed: false,
-					Data: event.Data{
-						"a": 6,
-					},
-				},
-				{
-					Passed: false,
-					Data: event.Data{
-						"a": 4,
 					},
 				},
 			},


### PR DESCRIPTION
### What does this PR do?

Previously only one report was sent for successful check. With the patch multiple reports are sent for both success and fails.
In case of an iterable comparison, namely none, all, count function only one report is sent.
In case of 'max event per run' an extra report is sent with a error and the remaining reports as part of the data field. 

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
