### PR TITLE
[dogstatsd/server] add the `origin` tag on the telemetry of processed metrics when available

### DIFF
--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -664,12 +664,12 @@ func (s *Server) parseEventMessage(parser *parser, message []byte, origin string
 	sample, err := parser.parseEvent(message)
 	if err != nil {
 		dogstatsdEventParseErrors.Add(1)
-		tlmProcessed.Inc("events", "error")
+		tlmProcessed.Inc("events", "error", "")
 		return nil, err
 	}
 	event := enrichEvent(sample, s.defaultHostname, origin, s.entityIDPrecedenceEnabled)
 	event.Tags = append(event.Tags, s.extraTags...)
-	tlmProcessed.Inc("events", "ok")
+	tlmProcessed.Inc("events", "ok", "")
 	dogstatsdEventPackets.Add(1)
 	return event, nil
 }
@@ -678,13 +678,13 @@ func (s *Server) parseServiceCheckMessage(parser *parser, message []byte, origin
 	sample, err := parser.parseServiceCheck(message)
 	if err != nil {
 		dogstatsdServiceCheckParseErrors.Add(1)
-		tlmProcessed.Inc("service_checks", "error")
+		tlmProcessed.Inc("service_checks", "error", "")
 		return nil, err
 	}
 	serviceCheck := enrichServiceCheck(sample, s.defaultHostname, origin, s.entityIDPrecedenceEnabled)
 	serviceCheck.Tags = append(serviceCheck.Tags, s.extraTags...)
 	dogstatsdServiceCheckPackets.Add(1)
-	tlmProcessed.Inc("service_checks", "ok")
+	tlmProcessed.Inc("service_checks", "ok", "")
 	return serviceCheck, nil
 }
 

--- a/pkg/dogstatsd/server_bench_test.go
+++ b/pkg/dogstatsd/server_bench_test.go
@@ -120,7 +120,7 @@ func BenchmarkParseMetricMessage(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		samplesBench = make([]metrics.MetricSample, 0, 512)
 		for pb.Next() {
-			s.parseMetricMessage(samplesBench, parser, message, "")
+			s.parseMetricMessage(samplesBench, parser, message, "", false)
 			samplesBench = samplesBench[0:0]
 		}
 	})

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -682,7 +682,7 @@ func TestNoMappingsConfig(t *testing.T) {
 	assert.Nil(t, s.mapper)
 
 	parser := newParser(newFloat64ListPool())
-	samples, err = s.parseMetricMessage(samples, parser, []byte("test.metric:666|g"), "")
+	samples, err = s.parseMetricMessage(samples, parser, []byte("test.metric:666|g"), "", false)
 	assert.NoError(t, err)
 	assert.Len(t, samples, 1)
 }
@@ -796,7 +796,7 @@ dogstatsd_mapper_profiles:
 			var actualSamples []MetricSample
 			for _, p := range scenario.packets {
 				parser := newParser(newFloat64ListPool())
-				samples, err := s.parseMetricMessage(samples, parser, []byte(p), "")
+				samples, err := s.parseMetricMessage(samples, parser, []byte(p), "", false)
 				assert.NoError(t, err, "Case `%s` failed. parseMetricMessage should not return error %v", err)
 				for _, sample := range samples {
 					actualSamples = append(actualSamples, MetricSample{Name: sample.Name, Tags: sample.Tags, Mtype: sample.Mtype, Value: sample.Value})

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -851,3 +851,79 @@ func TestNewServerExtraTags(t *testing.T) {
 	require.Equal(s.extraTags[1], "new:constructor", "the tag new:constructor should be set")
 	s.Stop()
 }
+
+func TestProcessedMetricsOrigin(t *testing.T) {
+	assert := assert.New(t)
+
+	s, err := NewServer(mockAggregator(), nil)
+	assert.NoError(err, "starting the DogStatsD server shouldn't fail")
+	s.Stop()
+
+	assert.Len(s.cachedTlmOriginIds, 0, "this cache must be empty")
+	assert.Len(s.cachedOrder, 0, "this cache list must be empty")
+
+	parser := newParser(newFloat64ListPool())
+	samples := []metrics.MetricSample{}
+	samples, err = s.parseMetricMessage(samples, parser, []byte("test.metric:666|g"), "container_id://test_container", false)
+	assert.NoError(err)
+	assert.Len(samples, 1)
+
+	// one thing should have been stored when we parse a metric
+	samples, err = s.parseMetricMessage(samples, parser, []byte("test.metric:555|g"), "container_id://test_container", true)
+	assert.NoError(err)
+	assert.Len(samples, 2)
+	assert.Len(s.cachedTlmOriginIds, 1, "one entry should have been cached")
+	assert.Len(s.cachedOrder, 1, "one entry should have been cached")
+	assert.Equal(s.cachedOrder[0].origin, "container_id://test_container")
+
+	// when we parse another metric (different value) with same origin, cache should contain only one entry
+	samples, err = s.parseMetricMessage(samples, parser, []byte("test.second_metric:525|g"), "container_id://test_container", true)
+	assert.NoError(err)
+	assert.Len(samples, 3)
+	assert.Len(s.cachedTlmOriginIds, 1, "one entry should have been cached")
+	assert.Len(s.cachedOrder, 1, "one entry should have been cached")
+	assert.Equal(s.cachedOrder[0].origin, "container_id://test_container")
+	assert.Equal(s.cachedOrder[0].ok, map[string]string{"message_type": "metrics", "state": "ok", "origin": "container_id://test_container"})
+	assert.Equal(s.cachedOrder[0].err, map[string]string{"message_type": "metrics", "state": "error", "origin": "container_id://test_container"})
+
+	// when we parse another metric (different value) but with a different origin, we should store a new entry
+	samples, err = s.parseMetricMessage(samples, parser, []byte("test.second_metric:525|g"), "container_id://another_container", true)
+	assert.NoError(err)
+	assert.Len(samples, 4)
+	assert.Len(s.cachedTlmOriginIds, 2, "two entries should have been cached")
+	assert.Len(s.cachedOrder, 2, "two entries should have been cached")
+	assert.Equal(s.cachedOrder[0].origin, "container_id://test_container")
+	assert.Equal(s.cachedOrder[0].ok, map[string]string{"message_type": "metrics", "state": "ok", "origin": "container_id://test_container"})
+	assert.Equal(s.cachedOrder[0].err, map[string]string{"message_type": "metrics", "state": "error", "origin": "container_id://test_container"})
+	assert.Equal(s.cachedOrder[1].origin, "container_id://another_container")
+	assert.Equal(s.cachedOrder[1].ok, map[string]string{"message_type": "metrics", "state": "ok", "origin": "container_id://another_container"})
+	assert.Equal(s.cachedOrder[1].err, map[string]string{"message_type": "metrics", "state": "error", "origin": "container_id://another_container"})
+
+	// oldest one should be removed once we reach the limit of the cache
+	maxOriginTagsCached = 2
+	samples, err = s.parseMetricMessage(samples, parser, []byte("yetanothermetric:525|g"), "third_origin", true)
+	assert.NoError(err)
+	assert.Len(samples, 5)
+	assert.Len(s.cachedTlmOriginIds, 2, "two entries should have been cached, one has been evicted already")
+	assert.Len(s.cachedOrder, 2, "two entries should have been cached, one has been evicted already")
+	assert.Equal(s.cachedOrder[0].origin, "container_id://another_container")
+	assert.Equal(s.cachedOrder[0].ok, map[string]string{"message_type": "metrics", "state": "ok", "origin": "container_id://another_container"})
+	assert.Equal(s.cachedOrder[0].err, map[string]string{"message_type": "metrics", "state": "error", "origin": "container_id://another_container"})
+	assert.Equal(s.cachedOrder[1].origin, "third_origin")
+	assert.Equal(s.cachedOrder[1].ok, map[string]string{"message_type": "metrics", "state": "ok", "origin": "third_origin"})
+	assert.Equal(s.cachedOrder[1].err, map[string]string{"message_type": "metrics", "state": "error", "origin": "third_origin"})
+
+	// oldest one should be removed once we reach the limit of the cache
+	maxOriginTagsCached = 2
+	samples, err = s.parseMetricMessage(samples, parser, []byte("blablabla:555|g"), "fourth_origin", true)
+	assert.NoError(err)
+	assert.Len(samples, 6)
+	assert.Len(s.cachedTlmOriginIds, 2, "two entries should have been cached, two have been evicted already")
+	assert.Len(s.cachedOrder, 2, "two entries should have been cached, two have been evicted already")
+	assert.Equal(s.cachedOrder[0].origin, "third_origin")
+	assert.Equal(s.cachedOrder[0].ok, map[string]string{"message_type": "metrics", "state": "ok", "origin": "third_origin"})
+	assert.Equal(s.cachedOrder[0].err, map[string]string{"message_type": "metrics", "state": "error", "origin": "third_origin"})
+	assert.Equal(s.cachedOrder[1].origin, "fourth_origin")
+	assert.Equal(s.cachedOrder[1].ok, map[string]string{"message_type": "metrics", "state": "ok", "origin": "fourth_origin"})
+	assert.Equal(s.cachedOrder[1].err, map[string]string{"message_type": "metrics", "state": "error", "origin": "fourth_origin"})
+}


### PR DESCRIPTION
### What does this PR do?

Add the `origin` tag on the telemetry of processed metrics when available.

### Motivation

Better troubleshooting when a node is having issue, helping us identify which service is actually having issue sending data to DogStatsD or this kind of scenario.

### Additional Notes

Since it is a hot path of the DogStatsD server, we have to make sure that these
tags are not escaped on the heap, hence maintaining this cache map (for which I've
added a cache eviction mechanism to avoid having an ever-growing cache).

The DogStatsD-stats debug mode has to be enabled for this to be enabled.
We observed a ~6% CPU usage increase with this debug mode enabled with this feature.

### Describe how to test your changes

Run the Datadog Agent with DogStatsD server, origin detection, telemetry and dogstatsd_metrics_stats enabled, send a metric through UDS to this DogStatsD server, validate that the telemetry ships the origin of the processed metric.