### PR TITLE
Fix Windows CPU check not working on non-English Windows since #8097

### DIFF
--- a/pkg/collector/corechecks/system/cpu/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows.go
@@ -41,10 +41,10 @@ var cpuInfo = cpu.GetCpuInfo
 type Check struct {
 	core.CheckBase
 	nbCPU             float64
-	interruptsCounter *pdhutil.PdhMultiInstanceCounterSet
-	idleCounter       *pdhutil.PdhMultiInstanceCounterSet
-	userCounter       *pdhutil.PdhMultiInstanceCounterSet
-	privilegedCounter *pdhutil.PdhMultiInstanceCounterSet
+	interruptsCounter pdhutil.PdhSingleInstanceCounterSet
+	idleCounter       pdhutil.PdhSingleInstanceCounterSet
+	userCounter       pdhutil.PdhSingleInstanceCounterSet
+	privilegedCounter pdhutil.PdhSingleInstanceCounterSet
 }
 
 // Run executes the check
@@ -56,35 +56,31 @@ func (c *Check) Run() error {
 
 	sender.Gauge("system.cpu.num_cores", c.nbCPU, "", nil)
 
-	vals, err := c.interruptsCounter.GetAllValues()
+	val, err := c.interruptsCounter.GetValue()
 	if err != nil {
 		log.Warnf("Error getting handle value %v", err)
 	} else {
-		val := vals["_Total"]
 		sender.Gauge("system.cpu.interrupt", float64(val), "", nil)
 	}
 
-	vals, err = c.idleCounter.GetAllValues()
+	val, err = c.idleCounter.GetValue()
 	if err != nil {
 		log.Warnf("Error getting handle value %v", err)
 	} else {
-		val := vals["_Total"]
 		sender.Gauge("system.cpu.idle", float64(val), "", nil)
 	}
 
-	vals, err = c.userCounter.GetAllValues()
+	val, err = c.userCounter.GetValue()
 	if err != nil {
 		log.Warnf("Error getting handle value %v", err)
 	} else {
-		val := vals["_Total"]
 		sender.Gauge("system.cpu.user", float64(val), "", nil)
 	}
 
-	vals, err = c.privilegedCounter.GetAllValues()
+	val, err = c.privilegedCounter.GetValue()
 	if err != nil {
 		log.Warnf("Error getting handle value %v", err)
 	} else {
-		val := vals["_Total"]
 		sender.Gauge("system.cpu.system", float64(val), "", nil)
 	}
 
@@ -112,19 +108,19 @@ func (c *Check) Configure(data integration.Data, initConfig integration.Data, so
 
 	// Note we use "processor information" instead of "processor" because on multi-processor machines the later only gives
 	// you visibility about other applications running on the same processor as you
-	c.interruptsCounter, err = pdhutil.GetMultiInstanceCounter("Processor Information", "% Interrupt Time", &[]string{"_Total"}, nil)
+	c.interruptsCounter, err = pdhutil.GetEnglishCounter("Processor Information", "% Interrupt Time", "_Total")
 	if err != nil {
 		return fmt.Errorf("cpu.Check could not establish interrupt time counter %v", err)
 	}
-	c.idleCounter, err = pdhutil.GetMultiInstanceCounter("Processor Information", "% Idle Time", &[]string{"_Total"}, nil)
+	c.idleCounter, err = pdhutil.GetEnglishCounter("Processor Information", "% Idle Time", "_Total")
 	if err != nil {
 		return fmt.Errorf("cpu.Check could not establish idle time counter %v", err)
 	}
-	c.userCounter, err = pdhutil.GetMultiInstanceCounter("Processor Information", "% User Time", &[]string{"_Total"}, nil)
+	c.userCounter, err = pdhutil.GetEnglishCounter("Processor Information", "% User Time", "_Total")
 	if err != nil {
 		return fmt.Errorf("cpu.Check could not establish user time counter %v", err)
 	}
-	c.privilegedCounter, err = pdhutil.GetMultiInstanceCounter("Processor Information", "% Privileged Time", &[]string{"_Total"}, nil)
+	c.privilegedCounter, err = pdhutil.GetEnglishCounter("Processor Information", "% Privileged Time", "_Total")
 	if err != nil {
 		return fmt.Errorf("cpu.Check could not establish system time counter %v", err)
 	}

--- a/pkg/collector/corechecks/system/cpu/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows.go
@@ -108,19 +108,19 @@ func (c *Check) Configure(data integration.Data, initConfig integration.Data, so
 
 	// Note we use "processor information" instead of "processor" because on multi-processor machines the later only gives
 	// you visibility about other applications running on the same processor as you
-	c.interruptsCounter, err = pdhutil.GetEnglishCounter("Processor Information", "% Interrupt Time", "_Total")
+	c.interruptsCounter, err = pdhutil.GetUnlocalizedCounter("Processor Information", "% Interrupt Time", "_Total")
 	if err != nil {
 		return fmt.Errorf("cpu.Check could not establish interrupt time counter %v", err)
 	}
-	c.idleCounter, err = pdhutil.GetEnglishCounter("Processor Information", "% Idle Time", "_Total")
+	c.idleCounter, err = pdhutil.GetUnlocalizedCounter("Processor Information", "% Idle Time", "_Total")
 	if err != nil {
 		return fmt.Errorf("cpu.Check could not establish idle time counter %v", err)
 	}
-	c.userCounter, err = pdhutil.GetEnglishCounter("Processor Information", "% User Time", "_Total")
+	c.userCounter, err = pdhutil.GetUnlocalizedCounter("Processor Information", "% User Time", "_Total")
 	if err != nil {
 		return fmt.Errorf("cpu.Check could not establish user time counter %v", err)
 	}
-	c.privilegedCounter, err = pdhutil.GetEnglishCounter("Processor Information", "% Privileged Time", "_Total")
+	c.privilegedCounter, err = pdhutil.GetUnlocalizedCounter("Processor Information", "% Privileged Time", "_Total")
 	if err != nil {
 		return fmt.Errorf("cpu.Check could not establish system time counter %v", err)
 	}

--- a/pkg/util/winutil/pdhutil/pdh.go
+++ b/pkg/util/winutil/pdhutil/pdh.go
@@ -179,6 +179,29 @@ func PdhAddCounter(hQuery PDH_HQUERY, szFullCounterPath string, dwUserData uintp
 	return uint32(ret)
 }
 
+// PdhAddEnglishCounter adds the specified counter to the query
+/*
+Parameters
+hQuery [in]
+Handle to the query to which you want to add the counter. This handle is returned by the PdhOpenQuery function.
+szFullCounterPath [in]
+Null-terminated string that contains the counter path. For details on the format of a counter path, see Specifying a Counter Path. The maximum length of a counter path is PDH_MAX_COUNTER_PATH.
+dwUserData [in]
+User-defined value. This value becomes part of the counter information. To retrieve this value later, call the PdhGetCounterInfo function and access the dwUserData member of the PDH_COUNTER_INFO structure.
+phCounter [out]
+Handle to the counter that was added to the query. You may need to reference this handle in subsequent calls.
+*/
+func PdhAddEnglishCounter(hQuery PDH_HQUERY, szFullCounterPath string, dwUserData uintptr, phCounter *PDH_HCOUNTER) uint32 {
+	ptxt, _ := windows.UTF16PtrFromString(szFullCounterPath)
+	ret, _, _ := procPdhAddEnglishCounterW.Call(
+		uintptr(hQuery),
+		uintptr(unsafe.Pointer(ptxt)),
+		dwUserData,
+		uintptr(unsafe.Pointer(phCounter)))
+
+	return uint32(ret)
+}
+
 /* PdhCollectQueryData
    Collects the current raw data value for all counters in the specified query and updates the status code of each counter.
 Parameters

--- a/pkg/util/winutil/pdhutil/pdhcounter.go
+++ b/pkg/util/winutil/pdhutil/pdhcounter.go
@@ -87,8 +87,8 @@ func (p *PdhCounterSet) Initialize(className string) error {
 	return nil
 }
 
-// GetEnglishCounter wraps the PdhAddEnglishCounter call that takes unlocalized counter names (as opposed to the other functions which use PdhAddCounter)
-func GetEnglishCounter(className, counterName, instance string) (PdhSingleInstanceCounterSet, error) {
+// GetUnlocalizedCounter wraps the PdhAddEnglishCounter call that takes unlocalized counter names (as opposed to the other functions which use PdhAddCounter)
+func GetUnlocalizedCounter(className, counterName, instance string) (PdhSingleInstanceCounterSet, error) {
 	var p PdhSingleInstanceCounterSet
 	winerror := pfnPdhOpenQuery(uintptr(0), uintptr(0), &p.query)
 	if ERROR_SUCCESS != winerror {
@@ -110,6 +110,7 @@ func GetEnglishCounter(className, counterName, instance string) (PdhSingleInstan
 }
 
 // GetSingleInstanceCounter returns a single instance counter object for the given counter class
+// TODO: Replace usages of this with GetUnlocalizedCounter using an empty string as instance
 func GetSingleInstanceCounter(className, counterName string) (*PdhSingleInstanceCounterSet, error) {
 	var p PdhSingleInstanceCounterSet
 	if err := p.Initialize(className); err != nil {
@@ -136,6 +137,7 @@ func GetSingleInstanceCounter(className, counterName string) (*PdhSingleInstance
 }
 
 // GetMultiInstanceCounter returns a multi-instance counter object for the given counter class
+// TODO: Replace usages of this with a function similar to GetUnlocalizedCounter for multi-instance counters, that uses PdhAddEnglishCounter
 func GetMultiInstanceCounter(className, counterName string, requestedInstances *[]string, verifyfn CounterInstanceVerify) (*PdhMultiInstanceCounterSet, error) {
 	var p PdhMultiInstanceCounterSet
 	if err := p.Initialize(className); err != nil {

--- a/pkg/util/winutil/pdhutil/pdhhelper.go
+++ b/pkg/util/winutil/pdhutil/pdhhelper.go
@@ -24,6 +24,7 @@ var (
 	procPdhMakeCounterPath          = modPdhDll.NewProc("PdhMakeCounterPathW")
 	procPdhGetFormattedCounterValue = modPdhDll.NewProc("PdhGetFormattedCounterValue")
 	procPdhAddCounterW              = modPdhDll.NewProc("PdhAddCounterW")
+	procPdhAddEnglishCounterW       = modPdhDll.NewProc("PdhAddEnglishCounterW")
 	procPdhCollectQueryData         = modPdhDll.NewProc("PdhCollectQueryData")
 	procPdhCloseQuery               = modPdhDll.NewProc("PdhCloseQuery")
 	procPdhOpenQuery                = modPdhDll.NewProc("PdhOpenQuery")

--- a/pkg/util/winutil/pdhutil/pdhmocks_windows.go
+++ b/pkg/util/winutil/pdhutil/pdhmocks_windows.go
@@ -46,6 +46,21 @@ func mockPdhOpenQuery(szDataSource uintptr, dwUserData uintptr, phQuery *PDH_HQU
 	return 0
 }
 
+func mockPdhAddEnglishCounter(hQuery PDH_HQUERY, szFullCounterPath string, dwUserData uintptr, phCounter *PDH_HCOUNTER) uint32 {
+	ndx := int(hQuery)
+	var thisQuery mockQuery
+	var ok bool
+	if thisQuery, ok = openQueries[ndx]; ok == false {
+		return uint32(PDH_INVALID_PATH)
+	}
+	counterIndex++
+
+	thisQuery.counters[counterIndex] = mockCounter{name: szFullCounterPath}
+	*phCounter = PDH_HCOUNTER(uintptr(counterIndex))
+
+	return 0
+}
+
 func mockPdhAddCounter(hQuery PDH_HQUERY, szFullCounterPath string, dwUserData uintptr, phCounter *PDH_HCOUNTER) uint32 {
 	ndx := int(hQuery)
 	var thisQuery mockQuery
@@ -143,6 +158,7 @@ func SetupTesting(counterstringsfile, countersfile string) {
 	pfnMakeCounterSetInstances = mockmakeCounterSetIndexes
 	pfnPdhOpenQuery = mockPdhOpenQuery
 	pfnPdhAddCounter = mockPdhAddCounter
+	pfnPdhAddEnglishCounter = mockPdhAddEnglishCounter
 	pfnPdhCollectQueryData = mockPdhCollectQueryData
 	pfnPdhEnumObjectItems = mockpdhEnumObjectItems
 	pfnPdhRemoveCounter = mockPdhRemoveCounter


### PR DESCRIPTION
### What does this PR do?

- Adds a new `GetUnlocalizedCounter` function to `pdhutil` which wraps the system call `PdhAddEnglishCounter`. In contrast, the existing `pdhutil` functions `GetSingleInstanceCounter` and `GetMultiInstanceCounter` use `PdhAddCounter` which is different from `PdhAddEnglishCounter` in that it takes localized counter names on non-English Windows. `GetSingleInstanceCounter` and `GetMultiInstanceCounter` have some logic to try to find the localized name from the English name so they would still work, but that logic wasn't working for the CPU check when tested on a Windows in Spanish.
- Makes the CPU check on Windows use `GetUnlocalizedCounter` instead of `GetMultiInstanceCounter`. Note the new `GetMultiInstanceCounter` doesn't implement the full functionality of `GetMultiInstanceCounter`, but we actually weren't using most of it for the CPU check. We only care about a single instance from the counters used in the CPU check.

The rest of the checks that use PDH counters continue to use the existing `GetSingleInstanceCounter` and `GetMultiInstanceCounter` functions, to minimize the scope of this change. Once this is proven to work well we can start replacing them with the new, simpler function and get rid of the logic to map English to non-English counter names.

### Motivation

Fix the current way to query the CPU usage on Windows which was introduced in #8097 and #8135 (still unreleased).

```
core.loader: could not configure check cpu: cpu.Check could not establish interrupt time counter Class name not found: Processor Information
```

### Describe how to test your changes

- Before this change: The CPU check wasn't reporting values on non-English Windows using an Agent that includes #8097 (note such build was never released).
- After: The CPU check should report values again on non-English Windows (like it did before merging #8097, eg: in the last stable release).
