### PR TITLE
[process][ecs fargate] Fix CPU limit used

### DIFF
--- a/pkg/process/checks/container_common.go
+++ b/pkg/process/checks/container_common.go
@@ -15,8 +15,8 @@ func calculateCtrPct(cur, prev, sys2, sys1 uint64, numCPU int, before time.Time)
 	}
 
 	// If we have system usage values then we need to calculate against those.
-	// XXX: Right now this only applies to ECS collection. Note that the inclusion of CPUs
-	// are accounted for on the frontend when normalized against the CPU limit
+	// XXX: Right now this only applies to ECS collection. Note that the inclusion of CPUs is
+	// necessary because the value gets normalized against the CPU limit, which also accounts for CPUs.
 	if sys1 >= 0 && sys2 > 0 && sys2 != sys1 {
 		cpuDelta := float32(cur - prev)
 		sysDelta := float32(sys2 - sys1)

--- a/pkg/process/checks/container_common.go
+++ b/pkg/process/checks/container_common.go
@@ -15,7 +15,8 @@ func calculateCtrPct(cur, prev, sys2, sys1 uint64, numCPU int, before time.Time)
 	}
 
 	// If we have system usage values then we need to calculate against those.
-	// XXX: Right now this only applies to ECS collection
+	// XXX: Right now this only applies to ECS collection. Note that the inclusion of CPUs
+	// are accounted for on the frontend when normalized against the CPU limit
 	if sys1 >= 0 && sys2 > 0 && sys2 != sys1 {
 		cpuDelta := float32(cur - prev)
 		sysDelta := float32(sys2 - sys1)

--- a/pkg/util/ecs/common.go
+++ b/pkg/util/ecs/common.go
@@ -150,7 +150,6 @@ func convertMetaV2Container(c v2.Container, taskLimits map[string]float64) (*con
 
 func formatTaskCPULimit(val float64) float64 {
 	// The ECS API exposes the task CPU limit with the format: 0.25, 0.5, 1, 2, 4
-	// Value is reported in Hz
 	return val * 100
 }
 

--- a/pkg/util/ecs/common.go
+++ b/pkg/util/ecs/common.go
@@ -131,9 +131,9 @@ func convertMetaV2Container(c v2.Container, taskLimits map[string]float64) (*con
 		}
 	}
 
-	if l, found := c.Limits[cpuKey]; found && l > 0 {
-		container.Limits.CPULimit = formatContainerCPULimit(float64(l))
-	} else if l, found := taskLimits[cpuKey]; found && l > 0 {
+	// The task limit is required in Fargate (so this should always exist). Use this as the basis for the CPU limit
+	// because the container limits configured are treated as CPU shares, rather than a fixed limit to adhere to.
+	if l, found := taskLimits[cpuKey]; found && l > 0 {
 		container.Limits.CPULimit = formatTaskCPULimit(l)
 	} else {
 		container.Limits.CPULimit = 100
@@ -146,12 +146,6 @@ func convertMetaV2Container(c v2.Container, taskLimits map[string]float64) (*con
 	}
 
 	return container, dateError
-}
-
-func formatContainerCPULimit(val float64) float64 {
-	// The ECS API exposes the container CPU limit in CPU units
-	// Value is reported in Hz
-	return val / 1024 * 100
 }
 
 func formatTaskCPULimit(val float64) float64 {

--- a/pkg/util/ecs/common_test.go
+++ b/pkg/util/ecs/common_test.go
@@ -78,7 +78,7 @@ func TestConvertMetaV2Container(t *testing.T) {
 				StartedAt:   1517518511,
 				Type:        "ECS",
 				AddressList: []containers.NetworkAddress{},
-				Limits:      metrics.ContainerLimits{CPULimit: 50, MemLimit: 1024000000},
+				Limits:      metrics.ContainerLimits{CPULimit: 100, MemLimit: 1024000000},
 			},
 		},
 		{
@@ -158,7 +158,7 @@ func TestConvertMetaV2Container(t *testing.T) {
 				Name:        "ecs-nginx-5-nginx-curl-ccccb9f49db0dfe0d901",
 				Type:        "ECS",
 				AddressList: []containers.NetworkAddress{},
-				Limits:      metrics.ContainerLimits{CPULimit: 50, MemLimit: 1024000000},
+				Limits:      metrics.ContainerLimits{CPULimit: 100, MemLimit: 1024000000},
 			},
 		},
 	}

--- a/releasenotes/notes/fix-ecs-fargate-cpu-limit-93bd4656ee607c08.yaml
+++ b/releasenotes/notes/fix-ecs-fargate-cpu-limit-93bd4656ee607c08.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix CPU limit used for Live Containers page in ECS Fargate environments.


### PR DESCRIPTION
### What does this PR do?

- Fix CPU limit used in ECS Fargate tasks. Previously the task limit was used in the case where container limit wasn't set; however in Fargate, container limits are handled as CPU shares, whereas the task limit is the actual cap ([ref](https://aws.amazon.com/blogs/containers/how-amazon-ecs-manages-cpu-and-memory-resources/)):

> CPU units assigned to containers are implemented using Linux CPU shares within the task (which is more of a weighted mechanism to determine CPU access priority)

- Add comments to clarify logic used in CPU computations

### Motivation

More sensical normalized CPU values shown on the Live Containers page for ECS Fargate

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Create an ECS task that includes the Datadog Agent with the Process Agent enabled. Make sure the Live Container page for any monitored containers does not show dramatic spikes in CPU metrics (e.g. tens of thousands of percentages). 

Test different values of task and container limits.

Test for both Fargate 1.3 and 1.4, as the metadata API seems to behave slightly differently.