### PR TITLE
[runtime-security] fix rhel 8 kitchen test

### DIFF
--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -79,7 +79,7 @@ if node['platform_family'] != 'windows'
     end
   end
 
-  if not platform_family?('suse')
+  if not platform_family?('suse', 'rhel')
     package 'Install i386 libc' do
       case node[:platform]
       when 'redhat', 'centos', 'fedora'


### PR DESCRIPTION
### What does this PR do?

This PR prevents the steps in `Install i386 libc` from being executed on RHEL 8. We don't need it for that distribution, and when the installation fails, the entire job fails.

### Motivation

Fix the CI.
