### PR TITLE
[install script] Add missing `$sudo_cmd`

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -360,7 +360,7 @@ elif [ "$OS" = "Debian" ]; then
 
     for key in "${APT_GPG_KEYS[@]}"; do
         $sudo_cmd curl --retry 5 -o "/tmp/${key}" "https://${keys_url}/${key}"
-        cat "/tmp/${key}" | $sudo_cmd gpg --import --batch --no-default-keyring --keyring "$apt_usr_share_keyring"
+        $sudo_cmd cat "/tmp/${key}" | $sudo_cmd gpg --import --batch --no-default-keyring --keyring "$apt_usr_share_keyring"
     done
 
     release_version="$(grep VERSION_ID /etc/os-release | cut -d = -f 2 | xargs echo | cut -d "." -f 1)"


### PR DESCRIPTION
### What does this PR do?

Adds missing `$sudo_cmd`, follow up to #8222.

### Motivation

Fixes #8250.

### Additional Notes

I don't see any other problems on #8222 but please check it. 

### Describe how to test your changes

Run the install script as a non-root user on Debian
