### PR TITLE
[AD] Fix env discovery incompatible listeners

### DIFF
--- a/cmd/agent/common/autodiscovery.go
+++ b/cmd/agent/common/autodiscovery.go
@@ -130,6 +130,7 @@ func setupAutoDiscovery(confSearchPaths []string, metaScheduler *scheduler.MetaS
 
 				if _, found := incomp[existingListener.Name]; found {
 					log.Debugf("Discarding discovered listener: %s as incompatible with listener from config: %s", listener.Name, existingListener.Name)
+					skipListener = true
 					break
 				}
 			}

--- a/releasenotes/notes/fix-env-discovery-845c58305a74112c.yaml
+++ b/releasenotes/notes/fix-env-discovery-845c58305a74112c.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a bug that can make the agent enable incompatible Autodiscovery listeners.


### PR DESCRIPTION
### What does this PR do?

Fix a bug that can enable incompatible Autodiscovery listeners.

### Motivation

Docker and Kubelet Autodiscovery listeners shouldn't start together.

### Describe how to test your changes

Enable the Docker AD listener explicitly in a k8s environment, make sure the env discovery doesn't enable the Kubelet AD listener.
