### PR TITLE
When using ECS, prevent pinging non-AWS cloud metadata endpoints

### DIFF
--- a/Dockerfiles/agent/datadog-ecs.yaml
+++ b/Dockerfiles/agent/datadog-ecs.yaml
@@ -7,3 +7,7 @@ apm_config:
 
 # Use java container support
 jmx_use_container_support: true
+
+# Set Cloud Provider to AWS
+cloud_provider_metadata:
+  - "aws"

--- a/releasenotes/notes/ecs-aws-cloud-provider-46a963205110a195.yaml
+++ b/releasenotes/notes/ecs-aws-cloud-provider-46a963205110a195.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    When running in ECS, agent will now only ping AWS Metadata Endpoints,
+    rather than all Cloud Providers.


### PR DESCRIPTION
### What does this PR do?

When configured to run in ECS, for example, by using the `ECS_FARGATE` environment variable with the container, the Agent will only reach out to AWS Metadata endpoints, rather than all default Cloud Providers.

### Motivation

Attempted traffic to non-AWS Metadata Endpoints results in dropped packets that triggered network alerts.

### Describe how to test your changes

Starting up the container with the ECS_FARGATE environment variable set to true should no longer call out to IP addresses like 100.100.100.200, which is Alibaba Cloud's metadata endpoint.
