### PR TITLE
[Serverless] fix inconsistent metric timestamp

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -334,6 +334,10 @@ func runAgent(stopCh chan struct{}) (daemon *serverless.Daemon, err error) {
 	aggregatorInstance := aggregator.InitAggregator(serializer, nil, "serverless")
 	metricsChan := aggregatorInstance.GetBufferedMetricsWithTsChannel()
 
+	// prevents any UDP packets from being stuck in the buffer and not parsed during the current invocation
+	// by setting this option to 1ms, all packets received will directly be sent to the parser
+	config.Datadog.Set("dogstatsd_packet_buffer_flush_timeout", 1*time.Millisecond)
+
 	// initializes the DogStatsD server
 	// --------------------------------
 


### PR DESCRIPTION
### What does this PR do?

Override the default 100ms value of `dogstatsd_packet_buffer_flush_timeout` to prevent received UDP packets from being stuck in the buffer for the current invocation.
By setting a lower value, it allows to automatically send the packet to the parser (during the same invocation)

### Motivation

Inconsistent timestamp value for metrics generated in datadog-lambda-*

### Describe how to test your changes

Use extension version 84 and deploy a function in us-east-1, you should not see any incorrect timestamp values 

![Screen Shot 2021-05-27 at 4 49 53 PM](https://user-images.githubusercontent.com/864493/119895620-fcb1fa80-bf0b-11eb-939c-280f58b45e52.png)

