### PR TITLE
[containers] fix CPU metric reporting when cgroup file is missing

### DIFF
--- a/pkg/util/containers/providers/cgroup/cgroup_metrics.go
+++ b/pkg/util/containers/providers/cgroup/cgroup_metrics.go
@@ -182,17 +182,19 @@ func (c ContainerCgroup) SoftMemLimit() (uint64, error) {
 }
 
 // CPU returns the CPU status for this cgroup instance
-// If the cgroup file does not exist then we just log debug return nothing.
+// If the cgroup file does not exist then we return an error; otherwise
+// the metrics struct will be defaulted and set CPU values to 0.
 func (c ContainerCgroup) CPU() (*metrics.ContainerCPUStats, error) {
-	ret := &metrics.ContainerCPUStats{}
 	statfile := c.cgroupFilePath("cpuacct", "cpuacct.stat")
 	f, err := os.Open(statfile)
 	if os.IsNotExist(err) {
-		log.Debugf("Missing cgroup file: %s", statfile)
-		return ret, nil
+		log.Warnf("Missing cgroup file: %s", statfile)
+		return nil, fmt.Errorf("cgroup file does not exist")
 	} else if err != nil {
 		return nil, err
 	}
+
+	ret := &metrics.ContainerCPUStats{}
 	defer f.Close()
 	scanner := bufio.NewScanner(f)
 	for scanner.Scan() {

--- a/pkg/util/containers/providers/cgroup/cgroup_metrics.go
+++ b/pkg/util/containers/providers/cgroup/cgroup_metrics.go
@@ -182,8 +182,9 @@ func (c ContainerCgroup) SoftMemLimit() (uint64, error) {
 }
 
 // CPU returns the CPU status for this cgroup instance
-// If the cgroup file does not exist then we return an error; otherwise
-// the metrics struct will be defaulted and set CPU values to 0.
+// If the cgroup file does not exist then we return an error; otherwise the metrics
+// struct will be defaulted and set CPU values to 0, leading to misleading results
+// (since CPU is reported cumulatively).
 func (c ContainerCgroup) CPU() (*metrics.ContainerCPUStats, error) {
 	statfile := c.cgroupFilePath("cpuacct", "cpuacct.stat")
 	f, err := os.Open(statfile)

--- a/pkg/util/containers/providers/cgroup/cgroup_metrics.go
+++ b/pkg/util/containers/providers/cgroup/cgroup_metrics.go
@@ -189,7 +189,7 @@ func (c ContainerCgroup) CPU() (*metrics.ContainerCPUStats, error) {
 	statfile := c.cgroupFilePath("cpuacct", "cpuacct.stat")
 	f, err := os.Open(statfile)
 	if os.IsNotExist(err) {
-		log.Warnf("Missing cgroup file: %s", statfile)
+		log.Debugf("Missing cgroup file: %s", statfile)
 		return nil, fmt.Errorf("cgroup file does not exist")
 	} else if err != nil {
 		return nil, err

--- a/pkg/util/containers/providers/cgroup/cgroup_metrics.go
+++ b/pkg/util/containers/providers/cgroup/cgroup_metrics.go
@@ -190,7 +190,7 @@ func (c ContainerCgroup) CPU() (*metrics.ContainerCPUStats, error) {
 	f, err := os.Open(statfile)
 	if os.IsNotExist(err) {
 		log.Debugf("Missing cgroup file: %s", statfile)
-		return nil, fmt.Errorf("cgroup file does not exist")
+		return nil, fmt.Errorf("cgroup file does not exist: %s", statfile)
 	} else if err != nil {
 		return nil, err
 	}

--- a/pkg/util/containers/providers/cgroup/cgroup_metrics_test.go
+++ b/pkg/util/containers/providers/cgroup/cgroup_metrics_test.go
@@ -25,13 +25,21 @@ func TestCPU(t *testing.T) {
 		"user":   64140,
 		"system": 18327,
 	}
+
+	// First run returns an error because cgroup file doesn't exist
+	cgroupEmpty := newDummyContainerCgroup(tempFolder.RootPath, "")
+	timeStat, err := cgroupEmpty.CPU()
+	assert.NotNil(t, err)
+	assert.Nil(t, timeStat)
+
+	// Second run, add files
 	tempFolder.add("cpuacct/cpuacct.stat", cpuacctStats.String())
 	tempFolder.add("cpuacct/cpuacct.usage", "915266418275")
 	tempFolder.add("cpu/cpu.shares", "1024")
 
 	cgroup := newDummyContainerCgroup(tempFolder.RootPath, "cpuacct", "cpu")
 
-	timeStat, err := cgroup.CPU()
+	timeStat, err = cgroup.CPU()
 	assert.Nil(t, err)
 	assert.Equal(t, timeStat.User, uint64(64140))
 	assert.Equal(t, timeStat.System, uint64(18327))

--- a/releasenotes/notes/fix-cgroup-cpu-ce66252bbd495daa.yaml
+++ b/releasenotes/notes/fix-cgroup-cpu-ce66252bbd495daa.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix handling of CPU metric collected from cgroups when the cgroup file is missing.


### PR DESCRIPTION
### What does this PR do?

Thanks to the detailed investigation in https://github.com/DataDog/datadog-agent/issues/7370, it seems that cgroup files can occasionally and briefly be missing when gathering resource data. For CPU in particular it leads to grossly misleading metrics since the data are reported cumulatively. This PR changes how we handle the case of a missing cgroup file when gathering CPU data - instead of returning an empty struct or `nil` (which would eventually be replaced with an empty struct), which results in reporting 0 values, we return an error and don't report anything.

### Motivation

Better user experience (and reduced false positives)

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Ideally, run the agent in a Docker container for a few days and make sure `docker.cpu.usage` metric does not spike (e.g. over 1k%)