### PR TITLE
[CMD] Make the check cmd resilient to Autodiscovery-related  latency

### DIFF
--- a/releasenotes/notes/fix-check-cmd-ad-f2d4d951d200483e.yaml
+++ b/releasenotes/notes/fix-check-cmd-ad-f2d4d951d200483e.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Improve the resiliency of the ``datadog-agent check`` command when running Autodiscovered checks.


### PR DESCRIPTION
### What does this PR do?

Get AD configs with a retrier in the `check` command.

### Motivation

Autodiscovery listeners run asynchronously, `AC.GetAllConfigs()` can fail at the beginning to resolve templated configs depending on non-deterministic factors (system load, network latency, active Autodiscovery listeners and their configurations).

### Describe how to test your changes

Run AD configurations using the check command in different containerized environments with different AD listeners (docker only, k8s) using file autodisovery, annotations, labels - make sure the check command is able to resolve the config and run the check.
