### PR TITLE
[networks] Improve debugging experience for HTTP monitoring

### DIFF
--- a/pkg/network/encoding/format_test.go
+++ b/pkg/network/encoding/format_test.go
@@ -5,6 +5,9 @@ import (
 
 	model "github.com/DataDog/agent-payload/process"
 	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/network/http"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -72,4 +75,72 @@ func TestFormatRouteIdx(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestFormatHTTPStats(t *testing.T) {
+	var (
+		clientPort = uint16(52800)
+		serverPort = uint16(8080)
+		localhost  = util.AddressFromString("127.0.0.1")
+	)
+
+	httpKey1 := http.NewKey(
+		localhost,
+		localhost,
+		clientPort,
+		serverPort,
+		"/testpath-1",
+		http.MethodGet,
+	)
+	var httpStats1 http.RequestStats
+	for i := range httpStats1 {
+		httpStats1[i].Count = 1
+		httpStats1[i].FirstLatencySample = 10
+	}
+
+	httpKey2 := httpKey1
+	httpKey2.Path = "/testpath-2"
+	var httpStats2 http.RequestStats
+	for i := range httpStats2 {
+		httpStats2[i].Count = 1
+		httpStats2[i].FirstLatencySample = 20
+	}
+
+	in := map[http.Key]http.RequestStats{
+		httpKey1: httpStats1,
+		httpKey2: httpStats2,
+	}
+	out := &model.HTTPAggregations{
+		EndpointAggregations: []*model.HTTPStats{
+			{
+				Path:   "/testpath-1",
+				Method: model.HTTPMethod_Get,
+				StatsByResponseStatus: []*model.HTTPStats_Data{
+					{Count: 1, FirstLatencySample: 10, Latencies: nil},
+					{Count: 1, FirstLatencySample: 10, Latencies: nil},
+					{Count: 1, FirstLatencySample: 10, Latencies: nil},
+					{Count: 1, FirstLatencySample: 10, Latencies: nil},
+					{Count: 1, FirstLatencySample: 10, Latencies: nil},
+				},
+			},
+			{
+				Path:   "/testpath-2",
+				Method: model.HTTPMethod_Get,
+				StatsByResponseStatus: []*model.HTTPStats_Data{
+					{Count: 1, FirstLatencySample: 20, Latencies: nil},
+					{Count: 1, FirstLatencySample: 20, Latencies: nil},
+					{Count: 1, FirstLatencySample: 20, Latencies: nil},
+					{Count: 1, FirstLatencySample: 20, Latencies: nil},
+					{Count: 1, FirstLatencySample: 20, Latencies: nil},
+				},
+			},
+		},
+	}
+
+	result := FormatHTTPStats(in)
+
+	aggregationKey := httpKey1
+	aggregationKey.Path = ""
+	aggregationKey.Method = http.MethodUnknown
+	assert.Equal(t, out, result[aggregationKey])
 }

--- a/pkg/network/encoding/format_test.go
+++ b/pkg/network/encoding/format_test.go
@@ -142,5 +142,6 @@ func TestFormatHTTPStats(t *testing.T) {
 	aggregationKey := httpKey1
 	aggregationKey.Path = ""
 	aggregationKey.Method = http.MethodUnknown
-	assert.Equal(t, out, result[aggregationKey])
+	aggregations := result[aggregationKey].EndpointAggregations
+	assert.ElementsMatch(t, out.EndpointAggregations, aggregations)
 }

--- a/pkg/network/http/debugging/debugging.go
+++ b/pkg/network/http/debugging/debugging.go
@@ -1,0 +1,100 @@
+package debugging
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/network/http"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/DataDog/sketches-go/ddsketch"
+)
+
+// RequestSummary represents a (debug-friendly) aggregated view of requests
+// matching a (client, server, path, method) tuple
+type RequestSummary struct {
+	Client   Address
+	Server   Address
+	DNS      string
+	Path     string
+	Method   string
+	ByStatus map[int]Stats
+}
+
+// Address represents represents a IP:Port
+type Address struct {
+	IP   string
+	Port uint16
+}
+
+// Stats consolidates request count and latency information for a certain status code
+type Stats struct {
+	Count              int
+	FirstLatencySample float64
+	LatencyP50         float64
+}
+
+// HTTP returns a debug-friendly representation of map[http.Key]http.RequestStats
+func HTTP(stats map[http.Key]http.RequestStats, dns map[util.Address][]string) []RequestSummary {
+	all := make([]RequestSummary, 0, len(stats))
+	for k, v := range stats {
+		clientAddr := formatIP(k.SrcIPLow, k.SrcIPHigh)
+		serverAddr := formatIP(k.DstIPLow, k.DstIPHigh)
+
+		debug := RequestSummary{
+			Client: Address{
+				IP:   clientAddr.String(),
+				Port: k.SrcPort,
+			},
+			Server: Address{
+				IP:   serverAddr.String(),
+				Port: k.DstPort,
+			},
+			DNS:      getDNS(dns, serverAddr),
+			Path:     k.Path,
+			Method:   k.Method.String(),
+			ByStatus: make(map[int]Stats),
+		}
+
+		for i, stat := range v {
+			if stat.Count == 0 {
+				continue
+			}
+
+			status := (i + 1) * 100
+			debug.ByStatus[status] = Stats{
+				Count:              stat.Count,
+				FirstLatencySample: stat.FirstLatencySample,
+				LatencyP50:         getSketchQuantile(stat.Latencies, 0.5),
+			}
+		}
+
+		all = append(all, debug)
+	}
+
+	return all
+}
+
+func formatIP(low, high uint64) util.Address {
+	// TODO: this is  not correct, but we don't have socket family information
+	// for HTTP at the moment, so given this is purely debugging code I think it's fine
+	// to assume for now that it's only IPv6 if higher order bits are set.
+	if high > 0 || (low>>32) > 0 {
+		return util.V6Address(low, high)
+	}
+
+	return util.V4Address(uint32(low))
+}
+
+func getDNS(dns map[util.Address][]string, addr util.Address) string {
+	if names := dns[addr]; len(names) > 0 {
+		return names[0]
+	}
+
+	return ""
+}
+
+func getSketchQuantile(sketch *ddsketch.DDSketch, percentile float64) float64 {
+	if sketch == nil {
+		return 0.0
+	}
+
+	val, _ := sketch.GetValueAtQuantile(0.5)
+	return val
+}

--- a/pkg/network/http/http_stats.go
+++ b/pkg/network/http/http_stats.go
@@ -28,6 +28,28 @@ const (
 	MethodPatch
 )
 
+// Method returns a string representing the HTTP method of the request
+func (m Method) String() string {
+	switch m {
+	case MethodGet:
+		return "GET"
+	case MethodPost:
+		return "POST"
+	case MethodPut:
+		return "PUT"
+	case MethodHead:
+		return "HEAD"
+	case MethodDelete:
+		return "DELETE"
+	case MethodOptions:
+		return "OPTIONS"
+	case MethodPatch:
+		return "PATCH"
+	default:
+		return "UNKNOWN"
+	}
+}
+
 // Key is an identifier for a group of HTTP transactions
 type Key struct {
 	SrcIPHigh uint64

--- a/pkg/network/http/model.go
+++ b/pkg/network/http/model.go
@@ -62,28 +62,6 @@ func (tx *httpTX) StatusClass() int {
 	return (int(tx.response_status_code) / 100) * 100
 }
 
-// Method returns a string representing the HTTP method of the request
-func (tx *httpTX) Method() string {
-	switch tx.request_method {
-	case C.HTTP_GET:
-		return "GET"
-	case C.HTTP_POST:
-		return "POST"
-	case C.HTTP_PUT:
-		return "PUT"
-	case C.HTTP_HEAD:
-		return "HEAD"
-	case C.HTTP_DELETE:
-		return "DELETE"
-	case C.HTTP_OPTIONS:
-		return "OPTIONS"
-	case C.HTTP_PATCH:
-		return "PATCH"
-	default:
-		return ""
-	}
-}
-
 // RequestLatency returns the latency of the request in ms
 func (tx *httpTX) RequestLatency() float64 {
 	return float64((tx.response_last_seen - tx.request_started) / (1000000))


### PR DESCRIPTION
### What does this PR do?

This PR adds a debug endpoint to `network_tracer` for the purpose of debugging data generated from the HTTP monitoring feature.

For example, given the following curl command which generate 2 requests using the same TCP socket:
```
curl -XGET http://httpbin.org/status/200 --next -XGET http://httpbin.org/status/200
```
The following debug data will be available in the `/debug/http_monitoring` endpoint:
```
curl -s --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/debug/http_monitoring | jq
[
  {
    "Client": {
      "IP": "10.0.2.15",
      "Port": 44144
    },
    "Server": {
      "IP": "54.166.163.67",
      "Port": 80
    },
    "DNS": "httpbin.org",
    "Path": "/status/200",
    "Method": "GET",
    "ByStatus": {
      "200": {
        "Count": 2,
        "FirstLatencySample": 0,
        "P50": 19.10687726994728
      }
    }
  }
]
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
