### PR TITLE
[windows] add go check for windows kernel memory pool allocations

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -72,6 +72,7 @@ import (
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/filehandles"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/memory"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/uptime"
+	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/winkmem"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/system/winproc"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/systemd"
 

--- a/cmd/agent/dist/conf.d/winkmem.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/winkmem.d/conf.yaml.example
@@ -3,33 +3,33 @@ init_config:
   ## For each of the four metrics, configure the top N results to be reported.  The
   ## default for all is 10.
 
-  ## @param topPagedBytes: - integer - optional - default: 10
-  ## report the top N pool tag consumers by size of paged memory
-  # topPagedBytes: 8
+  ## @param top_paged_bytes: - integer - optional - default: 10
+  ## Report the top N pool tag consumers by size of paged memory.
+  # top_paged_bytes: 8
 
-  ## @param topNonPagedBytes: - integer - optional - default: 10
-  ## report the top N pool tag consumers by size of non-paged memory
-  # topNonPagedBytes: 5
+  ## @param top_non_paged_bytes: - integer - optional - default: 10
+  ## Report the top N pool tag consumers by size of non-paged memory.
+  # top_non_paged_bytes: 5
 
-  ## @topPagedAllocsOutstanding: - integer - optional - default: 10
-  ## report the pool tag with the top number of allocations outstanding 
-  ## (allocations minus frees).  This can be different from the topPagedBytes
-  ## if there are many small allocations (vs. a few large)
-  # topPagedAllocsOutstanding: 5
+  ## @top_paged_allocs_outstanding: - integer - optional - default: 10
+  ## Report the pool tag with the top number of allocations outstanding
+  ## (allocations minus frees).  This can be different from the top_paged_bytes
+  ## if there are many small allocations (vs. a few large allocations).
+  # top_paged_allocs_outstanding: 5
 
-  ## @topNonPagedAllocsOutstanding: - integer - optional - default: 10
-  ## report the pool tag with the top number of non-paged allocations outstanding
-  ## (allocations minus frees).  This can be different from the topNonPagedBytes
-  ## if there are many small allocations (vs. a few large)
-  # topNonPagedAllocsOutstanding: 5
+  ## @top_non_paged_allocs_outstanding: - integer - optional - default: 10
+  ## Report the pool tag with the top number of non-paged allocations outstanding
+  ## (allocations minus frees).  This can be different from the top_non_paged_bytes
+  ## if there are many small allocations (vs. a few large allocations)
+  # top_non_paged_allocs_outstanding: 5
 
-  ## @alloctags: - list - optional - default: None
-  ## list of specific pool tags that should be reported regardless of whether
-  ## that tag is a top consumer
-  # alloctags:
+  ## @extra_tags: - list - optional - default: None
+  ## List of specific pool tags that should be reported, regardless of whether
+  ## that tag is a top consumer.
+  # extra_tags:
   # - Tag1
   # - Tag2
 
-# There is only one instance of the check; there is no instance configuration
+# There is only one instance of the check; there is no instance configuration.
 instances:
   - {}

--- a/cmd/agent/dist/conf.d/winkmem.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/winkmem.d/conf.yaml.example
@@ -1,6 +1,6 @@
 init_config:
   ## The Windows kernel memory check lists the top users of kernel memory by pool tag.
-  ## for each of the four metrics, configure the top N results to be reported.  The
+  ## For each of the four metrics, configure the top N results to be reported.  The
   ## default for all is 10.
 
   ## @param topPagedBytes: - integer - optional - default: 10

--- a/cmd/agent/dist/conf.d/winkmem.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/winkmem.d/conf.yaml.example
@@ -26,3 +26,4 @@ init_config:
 
 # There is only one instance of the check; there is no instance configuration
 instances:
+  - {}

--- a/cmd/agent/dist/conf.d/winkmem.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/winkmem.d/conf.yaml.example
@@ -1,0 +1,28 @@
+init_config:
+  ## The Windows kernel memory check lists the top users of kernel memory by pool tag.
+  ## for each of the four metrics, configure the top N results to be reported.  The
+  ## default for all is 10.
+
+  ## topPagedBytes: N report the top N pool tag consumers of paged memory
+  # topPagedBytes: 8
+
+  ## topNonPagedBytes: N report the top N pool tag consumers of non-paged memory
+  # topNonPagedBytes: 5
+
+  ## topPagedAllocsOutstanding: N report the pool tag with the top number of allocations
+  ## outstanding (allocations minus frees).  This can be different from the topPagedBytes
+  ## if there are many small allocations (vs. a few large)
+  # topPagedAllocsOutstanding: 5
+
+  ## topNonPagedAllocsOutstanding: N  report the pool tag with the top number of non-paged
+  ## allocations outstanding
+  # topNonPagedAllocsOutstanding: 5
+
+  ## alloctags is a list of specific pool tags that should be reported regardless of whether
+  ## that tag is a top consumer
+  # alloctags:
+  # - Tag1
+  # - Tag2
+
+# There is only one instance of the check; there is no instance configuration
+instances:

--- a/cmd/agent/dist/conf.d/winkmem.d/conf.yaml.example
+++ b/cmd/agent/dist/conf.d/winkmem.d/conf.yaml.example
@@ -3,22 +3,28 @@ init_config:
   ## for each of the four metrics, configure the top N results to be reported.  The
   ## default for all is 10.
 
-  ## topPagedBytes: N report the top N pool tag consumers of paged memory
+  ## @param topPagedBytes: - integer - optional - default: 10
+  ## report the top N pool tag consumers by size of paged memory
   # topPagedBytes: 8
 
-  ## topNonPagedBytes: N report the top N pool tag consumers of non-paged memory
+  ## @param topNonPagedBytes: - integer - optional - default: 10
+  ## report the top N pool tag consumers by size of non-paged memory
   # topNonPagedBytes: 5
 
-  ## topPagedAllocsOutstanding: N report the pool tag with the top number of allocations
-  ## outstanding (allocations minus frees).  This can be different from the topPagedBytes
+  ## @topPagedAllocsOutstanding: - integer - optional - default: 10
+  ## report the pool tag with the top number of allocations outstanding 
+  ## (allocations minus frees).  This can be different from the topPagedBytes
   ## if there are many small allocations (vs. a few large)
   # topPagedAllocsOutstanding: 5
 
-  ## topNonPagedAllocsOutstanding: N  report the pool tag with the top number of non-paged
-  ## allocations outstanding
+  ## @topNonPagedAllocsOutstanding: - integer - optional - default: 10
+  ## report the pool tag with the top number of non-paged allocations outstanding
+  ## (allocations minus frees).  This can be different from the topNonPagedBytes
+  ## if there are many small allocations (vs. a few large)
   # topNonPagedAllocsOutstanding: 5
 
-  ## alloctags is a list of specific pool tags that should be reported regardless of whether
+  ## @alloctags: - list - optional - default: None
+  ## list of specific pool tags that should be reported regardless of whether
   ## that tag is a top consumer
   # alloctags:
   # - Tag1

--- a/pkg/collector/corechecks/system/winkmem/empty.go
+++ b/pkg/collector/corechecks/system/winkmem/empty.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+// +build !windows
+
+package winkmem
+
+// Avoid the following error on non-supported platforms:
+// "build constraints exclude all Go files in github.com\DataDog\datadog-agent\pkg\collector\corechecks\ebpf"
+func init() {
+}

--- a/pkg/collector/corechecks/system/winkmem/winkmem.go
+++ b/pkg/collector/corechecks/system/winkmem/winkmem.go
@@ -153,7 +153,7 @@ func (w *KMemCheck) Run() error {
 		}
 	}
 	sender.Commit()
-	log.Infof("Logged %v entries", len(tagmap))
+	log.Debugf("Logged %v entries", len(tagmap))
 	return nil
 
 }

--- a/pkg/collector/corechecks/system/winkmem/winkmem.go
+++ b/pkg/collector/corechecks/system/winkmem/winkmem.go
@@ -1,0 +1,239 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+// +build windows
+
+package winkmem
+
+import (
+	"encoding/binary"
+	"fmt"
+	"sort"
+	"unsafe"
+
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	"golang.org/x/sys/windows"
+)
+
+const (
+	kmemCheckName = "winkmem"
+
+	// KMemDefaultTopNum is the default number of kernel memory tags to return
+	KMemDefaultTopNum = 10
+)
+
+var (
+	modntdll                     = windows.NewLazyDLL("ntdll.dll")
+	procNtQuerySystemInformation = modntdll.NewProc("NtQuerySystemInformation")
+)
+
+// Config is the configuration options for this check
+// it is exported so that the yaml parser can read it.
+type Config struct {
+	TopPagedBytes                int      `yaml:"topPagedBytes"`
+	TopNonPagedBytes             int      `yaml:"topNonPagedBytes"`
+	TopPagedAllocsOutstanding    int      `yaml:"topPagedAllocsOutstanding"`
+	TopNonPagedAllocsOutstanding int      `yaml:"topNonPagedAllocsOutstanding"`
+	SpecificTags                 []string `yaml:"alloctags"`
+}
+
+// KMemCheck is the agent object for this check.
+type KMemCheck struct {
+	core.CheckBase
+	config Config
+}
+
+func init() {
+	core.RegisterCheck(kmemCheckName, winkmemFactory)
+}
+
+func winkmemFactory() check.Check {
+	return &KMemCheck{
+		CheckBase: core.NewCheckBase(kmemCheckName),
+	}
+}
+
+/*
+configuration:
+
+init_config:
+  topPagedBytes: 10  // indicates record the top 10 paged-pool byte users
+  topNonPagedBytes: 9 // indicates record the top 9 non-paged pool byte users
+  topPagedAllocsOutstanding: 8 // indicates record the top 8 by number of non-freed allocs
+  topNonPagedAllocsOutstanding: 7 // indicates record the top 7 by number of non freed allocs
+  allocTags:
+    - HTab      // indicates record the allocs with memtag `HTab` regardless of whether it's in the top N above
+*/
+
+// Configure is called to configure the object prior to the first run
+func (w *KMemCheck) Configure(data integration.Data, initConfig integration.Data, source string) error {
+
+	// check to make sure the function is actually there, so we can fail gracefully
+	// if it's not
+	if err := modntdll.Load(); err != nil {
+		return err
+	}
+	if err := procNtQuerySystemInformation.Find(); err != nil {
+		return err
+	}
+
+	if err := w.CommonConfigure(data, source); err != nil {
+		return err
+	}
+	cf := Config{
+		TopNonPagedBytes:             KMemDefaultTopNum,
+		TopPagedBytes:                KMemDefaultTopNum,
+		TopPagedAllocsOutstanding:    KMemDefaultTopNum,
+		TopNonPagedAllocsOutstanding: KMemDefaultTopNum,
+	}
+	err := yaml.Unmarshal(initConfig, &cf)
+	if err != nil {
+		return err
+	}
+
+	w.config = cf
+	log.Infof("Winkmem config %v", w.config)
+	return nil
+}
+
+// Run executes the check
+func (w *KMemCheck) Run() error {
+	sender, err := aggregator.GetSender(w.ID())
+	if err != nil {
+		return err
+	}
+	spi, err := getpoolinfo()
+	if err != nil {
+		return err
+	}
+	// make a map to keep track of the indexes we actually want
+	// to send up (so we don't double count them)
+	tagmap := make(map[int]bool)
+	for i := 0; i < w.config.TopPagedBytes; i++ {
+		tagmap[spi.pagedPoolBytes[i].Value] = true
+	}
+	for i := 0; i < w.config.TopNonPagedBytes; i++ {
+		tagmap[spi.nonPagedPoolBytes[i].Value] = true
+	}
+	for i := 0; i < w.config.TopPagedAllocsOutstanding; i++ {
+		tagmap[spi.pagedPoolAllocsOutstanding[i].Value] = true
+	}
+	for i := 0; i < w.config.TopNonPagedAllocsOutstanding; i++ {
+		tagmap[spi.nonPagedPoolAllocsOutstanding[i].Value] = true
+	}
+	if len(w.config.SpecificTags) > 0 {
+		for _, ktag := range w.config.SpecificTags {
+			tagmap[spi.byKey[ktag]] = true
+		}
+	}
+
+	// now we have a list of indexes we actually want to store.  Walk them,
+	// and do it
+	for k, v := range tagmap {
+		// double sanity check, but should always be true
+		if v {
+			var tags = []string{}
+			pti := spi.spti.poolTags[k]
+
+			tags = append(tags, "kmemtag:"+string(pti.tag[:]))
+			log.Debugf("Logging mem tag %v", tags)
+
+			sender.Gauge("winkmem.paged_pool_bytes", float64(pti.pagedUsed), "", tags)
+			sender.Gauge("winkmem.nonpaged_pool_bytes", float64(pti.nonPagedUsed), "", tags)
+			sender.Gauge("winkmem.paged_allocs_outstanding", float64(pti.pagedAllocs-pti.pagedFrees), "", tags)
+			sender.Gauge("winkmem.nonpaged_allocs_outstanding", float64(pti.nonPagedAllocs-pti.nonPagedFrees), "", tags)
+		}
+	}
+	sender.Commit()
+	log.Infof("Logged %v entries", len(tagmap))
+	return nil
+
+}
+
+type systemPooltag struct {
+	tag            [4]uint8
+	pagedAllocs    uint32
+	pagedFrees     uint32
+	pagedUsed      uint64
+	nonPagedAllocs uint32
+	nonPagedFrees  uint32
+	nonPagedUsed   uint64
+}
+type systemPooltagInformation struct {
+	count    uint32
+	padding  uint32
+	poolTags []systemPooltag
+}
+
+type systemPoolInformation struct {
+	spti                          systemPooltagInformation
+	byKey                         map[string]int
+	pagedPoolBytes                sortKeyList
+	nonPagedPoolBytes             sortKeyList
+	pagedPoolAllocsOutstanding    sortKeyList
+	nonPagedPoolAllocsOutstanding sortKeyList
+}
+type sortKey struct {
+	Key   uint64 // numerical value (i.e. allocs, frees, etc)
+	Value int    // index into pooltags array
+}
+type sortKeyList []sortKey
+
+func (p sortKeyList) Len() int { return len(p) }
+func (p sortKeyList) Swap(i, j int) {
+	l1, l2 := p[j], p[i]
+	p[j], p[i] = p[i], p[j]
+	p[i], p[j] = l1, l2
+}
+func (p sortKeyList) Less(i, j int) bool { return p[i].Key < p[j].Key }
+
+func getpoolinfo() (*systemPoolInformation, error) {
+	firstbuffer := make([]uint8, 48) // magic size of empty structure in C land
+	var returnlen uint32
+	r, _, _ := procNtQuerySystemInformation.Call(uintptr(0x16),
+		uintptr(unsafe.Pointer(&firstbuffer[0])),
+		48,
+		uintptr(unsafe.Pointer(&returnlen)))
+	if r != 0xC0000004 {
+		return nil, fmt.Errorf("Expected STATUS_INFO_LENGTH_MISMATCH, got %v", r)
+	}
+
+	fullbuffer := make([]uint8, returnlen)
+	r, _, _ = procNtQuerySystemInformation.Call(uintptr(0x16),
+		uintptr(unsafe.Pointer(&fullbuffer[0])),
+		uintptr(returnlen),
+		uintptr(unsafe.Pointer(&returnlen)))
+	if r != 0 {
+		return nil, fmt.Errorf("Unexpected error getting system info %v", r)
+	}
+	spi := &systemPoolInformation{
+		byKey: make(map[string]int),
+	}
+	spi.spti.count = binary.LittleEndian.Uint32(fullbuffer[:4])
+
+	for i := 0; i < int(spi.spti.count); i++ {
+		pt := (*systemPooltag)(unsafe.Pointer(&fullbuffer[8+(40*i)]))
+
+		tagstr := string(pt.tag[:])
+		spi.byKey[tagstr] = i
+		spi.pagedPoolBytes = append(spi.pagedPoolBytes, sortKey{pt.pagedUsed, i})
+		spi.nonPagedPoolBytes = append(spi.nonPagedPoolBytes, sortKey{pt.nonPagedUsed, i})
+		spi.pagedPoolAllocsOutstanding = append(spi.pagedPoolAllocsOutstanding, sortKey{uint64(pt.pagedAllocs) - uint64(pt.pagedFrees), i})
+		spi.nonPagedPoolAllocsOutstanding = append(spi.nonPagedPoolAllocsOutstanding, sortKey{uint64(pt.nonPagedAllocs) - uint64(pt.nonPagedFrees), i})
+		spi.spti.poolTags = append(spi.spti.poolTags, *pt)
+	}
+	sort.Sort(sort.Reverse(spi.pagedPoolBytes))
+	sort.Sort(sort.Reverse(spi.nonPagedPoolBytes))
+	sort.Sort(sort.Reverse(spi.pagedPoolAllocsOutstanding))
+	sort.Sort(sort.Reverse(spi.nonPagedPoolAllocsOutstanding))
+
+	return spi, nil
+}

--- a/pkg/collector/corechecks/system/winkmem/winkmem.go
+++ b/pkg/collector/corechecks/system/winkmem/winkmem.go
@@ -38,11 +38,11 @@ var (
 // Config is the configuration options for this check
 // it is exported so that the yaml parser can read it.
 type Config struct {
-	TopPagedBytes                int      `yaml:"topPagedBytes"`
-	TopNonPagedBytes             int      `yaml:"topNonPagedBytes"`
-	TopPagedAllocsOutstanding    int      `yaml:"topPagedAllocsOutstanding"`
-	TopNonPagedAllocsOutstanding int      `yaml:"topNonPagedAllocsOutstanding"`
-	SpecificTags                 []string `yaml:"alloctags"`
+	TopPagedBytes                int      `yaml:"top_paged_bytes"`
+	TopNonPagedBytes             int      `yaml:"top_non_paged_bytes"`
+	TopPagedAllocsOutstanding    int      `yaml:"top_paged_allocs_outstanding"`
+	TopNonPagedAllocsOutstanding int      `yaml:"top_non_paged_allocs_outstanding"`
+	SpecificTags                 []string `yaml:"extra_tags"`
 }
 
 // KMemCheck is the agent object for this check.
@@ -189,9 +189,7 @@ type sortKeyList []sortKey
 
 func (p sortKeyList) Len() int { return len(p) }
 func (p sortKeyList) Swap(i, j int) {
-	l1, l2 := p[j], p[i]
 	p[j], p[i] = p[i], p[j]
-	p[i], p[j] = l1, l2
 }
 func (p sortKeyList) Less(i, j int) bool { return p[i].Key < p[j].Key }
 

--- a/pkg/collector/corechecks/system/winkmem/winkmem_test.go
+++ b/pkg/collector/corechecks/system/winkmem/winkmem_test.go
@@ -1,0 +1,34 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+// +build windows
+
+package winkmem
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/stretchr/testify/mock"
+)
+
+func TestWinKMem(t *testing.T) {
+
+	kcheck := new(KMemCheck)
+	kcheck.Configure(nil, nil, "test")
+
+	m := mocksender.NewMockSender(kcheck.ID())
+
+	// since we're using the default config, there should
+	// be the default number
+	m.On("Gauge", "winkmem.paged_pool_bytes", mock.AnythingOfType("float64"), "", mock.AnythingOfType("[]string"))
+	m.On("Gauge", "winkmem.nonpaged_pool_bytes", mock.AnythingOfType("float64"), "", mock.AnythingOfType("[]string"))
+	m.On("Gauge", "winkmem.paged_allocs_outstanding", mock.AnythingOfType("float64"), "", mock.AnythingOfType("[]string"))
+	m.On("Gauge", "winkmem.nonpaged_allocs_outstanding", mock.AnythingOfType("float64"), "", mock.AnythingOfType("[]string"))
+	m.On("Commit").Return().Times(1)
+
+	kcheck.Run()
+	m.AssertExpectations(t)
+	m.AssertNumberOfCalls(t, "Commit", 1)
+}

--- a/releasenotes/notes/winkmemtag-214adad243bd79c6.yaml
+++ b/releasenotes/notes/winkmemtag-214adad243bd79c6.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Adds new Windows system check, winkmem.  This check reports the top users
+    of paged and non-paged memory in the windows kernel.

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -59,6 +59,7 @@ AGENT_CORECHECKS = [
     "systemd",
     "tcp_queue_length",
     "uptime",
+    "winkmem",
     "winproc",
     "jetson",
 ]


### PR DESCRIPTION
Go check for windows kernel memory pool allocations

### What does this PR do?

Adds a `go` check which reports windows kernel pool allocations.
Would be useful for tracking leaks in kernel drivers

### Motivation

looking for insight into leaks in build-stable

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Install windows agent.
Edit the sample config, rename to `conf.yaml`, and restart agent.
device should start reporting metrics of type 
`winkmem.paged_pool_bytes`
`winkmem.nonpaged_pool_bytes`
`winkmem.paged_allocs_outstanding`
`winkmem.nonpaged_allocs_outstanding`

with various tags.  The tags will vary based on environment, because they're derived at runtime from the kernel memory tags used by various drivers.

In addition, configure one or more specific memory tags in the `init_config:` section
```
alloctags:
  - ExTg
  ```
  
 all four metrics should report with that tag regardless of whether they're in the top N consumers.