### PR TITLE
[omnibus] Update snowflake-connector-python patch

### DIFF
--- a/omnibus/config/patches/snowflake-connector-python-py2/dependencies.patch
+++ b/omnibus/config/patches/snowflake-connector-python-py2/dependencies.patch
@@ -1,9 +1,13 @@
 diff --git a/setup.py b/setup.py
-index 0da6a8a..761de39 100644
+index 0da6a8a..509e3a1 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -185,13 +185,13 @@ setup(
-         'certifi<2021.0.0',
+@@ -182,16 +182,16 @@ setup(
+         'botocore>=1.5.0,<1.14.0',
+         'requests<2.23.0',
+         'urllib3>=1.20,<1.26.0',
+-        'certifi<2021.0.0',
++        'certifi',
          'future<1.0.0',
          'six<2.0.0',
 -        'pytz<2021.0',

--- a/omnibus/config/patches/snowflake-connector-python-py3/dependencies.patch
+++ b/omnibus/config/patches/snowflake-connector-python-py3/dependencies.patch
@@ -1,9 +1,13 @@
 diff --git a/setup.py b/setup.py
-index 0da6a8a..761de39 100644
+index 0da6a8a..509e3a1 100644
 --- a/setup.py
 +++ b/setup.py
-@@ -185,13 +185,13 @@ setup(
-         'certifi<2021.0.0',
+@@ -182,16 +182,16 @@ setup(
+         'botocore>=1.5.0,<1.14.0',
+         'requests<2.23.0',
+         'urllib3>=1.20,<1.26.0',
+-        'certifi<2021.0.0',
++        'certifi',
          'future<1.0.0',
          'six<2.0.0',
 -        'pytz<2021.0',

--- a/omnibus/config/software/snowflake-connector-python-py2.rb
+++ b/omnibus/config/software/snowflake-connector-python-py2.rb
@@ -26,6 +26,6 @@ build do
   end
 
   ship_license "https://raw.githubusercontent.com/snowflakedb/snowflake-connector-python/v#{version}/LICENSE.txt"
-  patch :source => "cryptography-dependency.patch", :target => "setup.py"
+  patch :source => "dependencies.patch", :target => "setup.py"
   command "#{pip} install ."
 end

--- a/omnibus/config/software/snowflake-connector-python-py3.rb
+++ b/omnibus/config/software/snowflake-connector-python-py3.rb
@@ -25,6 +25,6 @@ build do
   end
 
   ship_license "https://raw.githubusercontent.com/snowflakedb/snowflake-connector-python/v#{version}/LICENSE.txt"
-  patch :source => "cryptography-dependency.patch", :target => "setup.py"
+  patch :source => "dependencies.patch", :target => "setup.py"
   command "#{pip} install ."
 end


### PR DESCRIPTION
### What does this PR do?

Updates the `snowflake-connector-python` dependencies: there's no need to pin `certifi` (it only bundles certificates), and the current pin makes the builds fail (because a new version of certifi got released yesterday: https://pypi.org/project/certifi/#history).

Changes the patch filename to better match its contents.

### Motivation

Fix Agent builds.