### PR TITLE
[runtime-security] De-duplicate policy load errors

### DIFF
--- a/pkg/security/utils/multierror.go
+++ b/pkg/security/utils/multierror.go
@@ -7,7 +7,7 @@ package utils
 
 import "github.com/hashicorp/go-multierror"
 
-/// FilterMultiError creates a new *multierror.Error filtering an existing one with a list of error
+// FilterMultiError creates a new *multierror.Error filtering an existing one with a list of error
 func FilterMultiError(multi *multierror.Error, filter []error) *multierror.Error {
 	if multi == nil {
 		return nil

--- a/pkg/security/utils/multierror.go
+++ b/pkg/security/utils/multierror.go
@@ -9,6 +9,10 @@ import "github.com/hashicorp/go-multierror"
 
 /// FilterMultiError creates a new *multierror.Error filtering an existing one with a list of error
 func FilterMultiError(multi *multierror.Error, filter []error) *multierror.Error {
+	if multi == nil {
+		return nil
+	}
+
 	var res *multierror.Error
 
 	filterMsgs := make([]string, 0, len(filter))

--- a/pkg/security/utils/multierror.go
+++ b/pkg/security/utils/multierror.go
@@ -1,0 +1,39 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package utils
+
+import "github.com/hashicorp/go-multierror"
+
+/// FilterMultiError creates a new *multierror.Error filtering an existing one with a list of error
+func FilterMultiError(multi *multierror.Error, filter []error) *multierror.Error {
+	var res *multierror.Error
+
+	filterMsgs := make([]string, 0, len(filter))
+	for _, ferr := range filter {
+		if ferr != nil {
+			filterMsgs = append(filterMsgs, ferr.Error())
+		}
+	}
+
+	for _, current := range multi.Errors {
+		if current == nil {
+			continue
+		}
+
+		isFiltered := false
+		for _, errMsg := range filterMsgs {
+			if current.Error() == errMsg {
+				isFiltered = true
+			}
+		}
+
+		if !isFiltered {
+			res = multierror.Append(res, current)
+		}
+	}
+
+	return res
+}

--- a/pkg/security/utils/multierror_test.go
+++ b/pkg/security/utils/multierror_test.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package utils
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/hashicorp/go-multierror"
+	"gotest.tools/assert"
+)
+
+func TestBasic(t *testing.T) {
+	var multi *multierror.Error
+
+	multi = multierror.Append(multi, errors.New("A"))
+	multi = multierror.Append(multi, errors.New("B"))
+
+	filter := []error{errors.New("B"), errors.New("C")}
+
+	res := FilterMultiError(multi, filter)
+
+	assert.Assert(t, res != nil, "should return a non-nil error")
+	assert.Equal(t, len(res.Errors), 1, "should return the correct count of errors")
+}
+
+func TestEmptyFilter(t *testing.T) {
+	var multi *multierror.Error
+
+	multi = multierror.Append(multi, errors.New("A"))
+	multi = multierror.Append(multi, errors.New("B"))
+
+	filter := []error{}
+
+	res := FilterMultiError(multi, filter)
+
+	assert.Assert(t, res != nil, "should return a non-nil error")
+	assert.Equal(t, len(res.Errors), 2, "should return the correct count of errors")
+}
+
+func TestNilMulti(t *testing.T) {
+	var multi *multierror.Error
+
+	filter := []error{errors.New("B"), errors.New("C")}
+
+	res := FilterMultiError(multi, filter)
+
+	assert.Assert(t, res == nil, "should return a nil multierror")
+}


### PR DESCRIPTION
### What does this PR do?

When loading policies, load errors (syntax/semantic errors) are currently reported twice. This PR fixes this problem by filtering the second display with the errors displayed during the first display.

### Motivation

This is a bug-fix.

### Additional Notes

--

### Describe how to test your changes

Some tests to the filter function are added to this PR 