### PR TITLE
[runtime-security] re-enable sorting error metric

### DIFF
--- a/pkg/security/probe/reorderer.go
+++ b/pkg/security/probe/reorderer.go
@@ -217,10 +217,10 @@ func (r *ReOrderer) Start(ctx context.Context) {
 		case <-metricTicker.C:
 			r.metric.QueueSize = r.heap.len()
 
-			//select {
-			//case r.Metrics <- r.metric:
-			//default:
-			//}
+			select {
+			case r.Metrics <- r.metric:
+			default:
+			}
 
 			r.metric.zero()
 		case <-ctx.Done():


### PR DESCRIPTION
### What does this PR do?

This PR re-enables the sorting error metric.

### Motivation

While re-activating the perf buffer metrics, we forgot to re-enable the sorting error metric.
