### PR TITLE
[runtime-security] Fix inode size on ubuntu bionic

### DIFF
--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -55,10 +55,10 @@ var (
 	// Dentry Resolver metrics
 
 	// MetricDentryResolverHits is the counter of successful dentry resolution
-	// Tags: cache, kernel_maps
+	// Tags: type, resolution
 	MetricDentryResolverHits = newRuntimeMetric(".dentry_resolver.hits")
 	// MetricDentryResolverMiss is the counter of unsuccessful dentry resolution
-	// Tags: cache, kernel_maps
+	// Tags: type, resolution
 	MetricDentryResolverMiss = newRuntimeMetric(".dentry_resolver.miss")
 
 	// Perf buffer metrics

--- a/pkg/security/probe/mount_resolver.go
+++ b/pkg/security/probe/mount_resolver.go
@@ -386,8 +386,6 @@ func getSizeOfStructInode(probe *Probe) uint64 {
 		sizeOf = 560
 	case probe.kernelVersion.IsSLES15Kernel():
 		sizeOf = 592
-	case probe.kernelVersion.Code != 0 && probe.kernelVersion.Code < kernel.Kernel4_16:
-		sizeOf = 608
 	}
 
 	return sizeOf


### PR DESCRIPTION
### What does this PR do?

This PR fixes the inode size on Ubuntu Bionic (kernel 4.15).

### Motivation

Currently, overlayfs tests on Ubuntu Bionic (kernel 4.15) fail.

### Describe how to test your changes

Run the tests suit on a Ubuntu Bionic (kernel 4.15).