### PR TITLE
[collector] Log error when a check can't be loaded for an instance 

### DIFF
--- a/pkg/collector/scheduler.go
+++ b/pkg/collector/scheduler.go
@@ -198,7 +198,7 @@ func (s *CheckScheduler) getChecks(config integration.Config) ([]check.Check, er
 		}
 
 		if len(errors) == numLoaders {
-			log.Warnf("Unable to load a check from instance of config '%s': %s", config.Name, strings.Join(errors, "; "))
+			log.Errorf("Unable to load a check from instance of config '%s': %s", config.Name, strings.Join(errors, "; "))
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

Follow up to https://github.com/DataDog/datadog-agent/pull/8276, error-level is actually better since this should never happen on a well-configured Agent.

### Describe how to test your changes

If https://github.com/DataDog/datadog-agent/pull/8276 works fine, then there's nothing to QA here
