### PR TITLE
[AD][Kubelet] Delete old services when an update is detected

### DIFF
--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -309,10 +309,15 @@ func (l *KubeletListener) createService(entity string, pod *kubelet.Pod, firstRu
 	l.m.Lock()
 	defer l.m.Unlock()
 	old, found := l.services[entity]
-	if found && kubeletSvcEqual(old, &svc) {
-		log.Tracef("Received a duplicated kubelet service '%s'", svc.entity)
-		return
+	if found {
+		if kubeletSvcEqual(old, &svc) {
+			log.Tracef("Received a duplicated kubelet service '%s'", svc.entity)
+			return
+		}
+		log.Tracef("Kubelet service '%s' has been updated, removing the old one", svc.entity)
+		l.delService <- old
 	}
+
 	l.services[entity] = &svc
 
 	l.newService <- &svc


### PR DESCRIPTION
### What does this PR do?

Delete the old AD service when an update is detected for the same entity in the kubelet listener

### Motivation

Bug fix

### Additional Notes

Related to https://github.com/DataDog/datadog-agent/pull/6692

### Describe how to test your changes

- Multi containers pod, with one container in CLB
- One AD check targeting the healthy container
=> Correct check scheduling + no duplicated check instances should be added

(The fix has been validated on a prod env already where the issue was easily reproducible)