### PR TITLE
[Serverless - WIP] Remove STS call ans refactor tags

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -316,7 +316,6 @@ func runAgent(stopCh chan struct{}) (daemon *serverless.Daemon, err error) {
 	aggregatorInstance := aggregator.InitAggregator(serializer, nil, "serverless")
 	metricsChan := aggregatorInstance.GetBufferedMetricsWithTsChannel()
 
-	config.Datadog.Set("dogstatsd_packet_buffer_flush_timeout", 1*time.Millisecond)
 	// initializes the DogStatsD server
 	// --------------------------------
 

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -21,7 +21,6 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/kms"
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
-	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/spf13/cobra"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
@@ -221,29 +220,13 @@ func runAgent(stopCh chan struct{}) (daemon *serverless.Daemon, err error) {
 	// read configuration from both the environment vars and the config file
 	// if one is provided
 	// --------------------------
-	svc := sts.New(session.New())
-	ctx, cancel := context.WithTimeout(context.Background(), fetchAccountIDTimeout)
-	defer cancel()
 
-	accountID, _ := aws.FetchAccountID(ctx, svc)
-	functionARN, err := aws.FetchFunctionARNFromEnv(accountID)
-	if err == nil {
-		log.Debugf("Extension found function ARN: %s", functionARN)
-		aws.SetARN(functionARN)
-	} else {
-		log.Debugf("Extension couldn't find function ARN")
-	}
 	aws.SetColdStart(true)
 
 	config.Datadog.SetConfigFile(datadogConfigPath)
 	if _, confErr := config.LoadWithoutSecret(); confErr == nil {
 		log.Info("A configuration file has been found and read.")
 	}
-
-	// extra tags to append to all logs / metrics
-	extraTags := config.GetConfiguredTags(true)
-	extraTags = append(extraTags, aws.GetARNTags()...)
-	log.Debugf("Adding tags to telemetry: %s", extraTags)
 
 	// adaptive flush configuration
 	if v, exists := os.LookupEnv(flushStrategyEnvVar); exists {
@@ -308,7 +291,7 @@ func runAgent(stopCh chan struct{}) (daemon *serverless.Daemon, err error) {
 			// a logs agent to collect/process/flush the logs.
 			if err := logs.StartServerless(
 				func() *autodiscovery.AutoConfig { return common.AC },
-				logsChan, extraTags,
+				logsChan, nil,
 			); err != nil {
 				log.Error("Could not start an instance of the Logs Agent:", err)
 			}
@@ -334,10 +317,11 @@ func runAgent(stopCh chan struct{}) (daemon *serverless.Daemon, err error) {
 	aggregatorInstance := aggregator.InitAggregator(serializer, nil, "serverless")
 	metricsChan := aggregatorInstance.GetBufferedMetricsWithTsChannel()
 
+	config.Datadog.Set("dogstatsd_packet_buffer_flush_timeout", 1*time.Millisecond)
 	// initializes the DogStatsD server
 	// --------------------------------
 
-	statsdServer, err = dogstatsd.NewServer(aggregatorInstance, extraTags)
+	statsdServer, err = dogstatsd.NewServer(aggregatorInstance, nil)
 	if err != nil {
 		// we're not reporting the error to AWS because we don't want the function
 		// execution to be stopped. TODO(remy): discuss with AWS if there is way
@@ -353,10 +337,6 @@ func runAgent(stopCh chan struct{}) (daemon *serverless.Daemon, err error) {
 	if config.Datadog.GetBool("apm_config.enabled") {
 		tc, confErr := traceConfig.Load(datadogConfigPath)
 		tc.Hostname = ""
-		globalTags := aws.BuildGlobalTagsMap(functionARN, aws.FunctionNameFromARN(), os.Getenv(aws.RegionEnvVar), accountID)
-		for key, value := range globalTags {
-			tc.GlobalTags[key] = value
-		}
 		tc.SynchronousFlushing = true
 		if confErr != nil {
 			log.Errorf("Unable to load trace agent config: %s", confErr)

--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -64,8 +64,8 @@ where they can be graphed on dashboards. The Datadog Serverless Agent implements
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
 			av, _ := version.Agent()
-			fmt.Println(fmt.Sprintf("Serverless Datadog Agent %s - Codename: %s - Commit: %s - Serialization version: %s - Go version: %s",
-				av.GetNumber(), av.Meta, av.Commit, serializer.AgentPayloadVersion, runtime.Version()))
+			fmt.Printf("Serverless Datadog Agent %s - Codename: %s - Commit: %s - Serialization version: %s - Go version: %s\n",
+				av.GetNumber(), av.Meta, av.Commit, serializer.AgentPayloadVersion, runtime.Version())
 		},
 	}
 
@@ -86,8 +86,7 @@ where they can be graphed on dashboards. The Datadog Serverless Agent implements
 
 	// AWS Lambda is writing the Lambda function files in /var/task, we want the
 	// configuration file to be at the root of this directory.
-	datadogConfigPath     = "/var/task/datadog.yaml"
-	fetchAccountIDTimeout = 500.0 * time.Millisecond
+	datadogConfigPath = "/var/task/datadog.yaml"
 )
 
 const (

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -834,6 +834,7 @@ func FormatDebugStats(stats []byte) (string, error) {
 	return buf.String(), nil
 }
 
+// SetExtraTags sets extra tags to the server
 func (s *Server) SetExtraTags(tags []string) {
 	s.extraTags = tags
 }

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -833,3 +833,7 @@ func FormatDebugStats(stats []byte) (string, error) {
 
 	return buf.String(), nil
 }
+
+func (s *Server) SetExtraTags(tags []string) {
+	s.extraTags = tags
+}

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -834,7 +834,7 @@ func FormatDebugStats(stats []byte) (string, error) {
 	return buf.String(), nil
 }
 
-// SetExtraTags sets extra tags to the server
+// SetExtraTags sets extra tags. All metrics sent to the DogstatsD will be tagged with them.
 func (s *Server) SetExtraTags(tags []string) {
 	s.extraTags = tags
 }

--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -272,7 +272,7 @@ func GetScheduler() *Scheduler {
 	return adScheduler
 }
 
-//
+// GetSourceFromName returns the LogSource from the source name if it exists.
 func (s *Scheduler) GetSourceFromName(name string) *logsConfig.LogSource {
 	for _, source := range s.sources.GetSources() {
 		if name == source.Config.Source {

--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -271,3 +271,13 @@ func (s *Scheduler) getCreationTime(config integration.Config) service.CreationT
 func GetScheduler() *Scheduler {
 	return adScheduler
 }
+
+//
+func (s *Scheduler) GetSourceFromName(name string) *logsConfig.LogSource {
+	for _, source := range s.sources.GetSources() {
+		if name == source.Config.Source {
+			return source
+		}
+	}
+	return nil
+}

--- a/pkg/serverless/aws/arn.go
+++ b/pkg/serverless/aws/arn.go
@@ -6,37 +6,14 @@
 package aws
 
 import (
-	"context"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
-	"os"
-	"strconv"
 	"strings"
 	"sync"
-
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-
-	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 )
 
 const (
 	persistedStateFilePath = "/tmp/dd-lambda-extension-cache.json"
-	// RegionEnvVar is used to represent the AWS region environment variable name
-	RegionEnvVar       = "AWS_REGION"
-	functionNameEnvVar = "AWS_LAMBDA_FUNCTION_NAME"
-	qualifierEnvVar    = "AWS_LAMBDA_FUNCTION_VERSION"
-
-	traceOriginMetadataKey   = "_dd.origin"
-	traceOriginMetadataValue = "lambda"
-	computeStatsKey          = "_dd.compute_stats"
-	computeStatsValue        = "1"
-	functionARNKey           = "function_arn"
-	functionNameKey          = "functionname"
-	regionKey                = "region"
-	awsAccountKey            = "aws_account"
 )
 
 type persistedState struct {
@@ -104,14 +81,6 @@ func SetARN(arn string) {
 	currentARN.qualifier = qualifier
 }
 
-// FunctionNameFromARN returns the function name from the currently set ARN.
-// Thread-safe.
-func FunctionNameFromARN() string {
-	arn := GetARN()
-	parts := strings.Split(arn, ":")
-	return parts[len(parts)-1]
-}
-
 // GetRequestID returns the currently running function request ID.
 func GetRequestID() string {
 	currentReqID.Lock()
@@ -171,104 +140,4 @@ func RestoreCurrentStateFromFile() error {
 	SetARN(restoredState.CurrentARN)
 	SetRequestID(restoredState.CurrentReqID)
 	return nil
-}
-
-// FetchFunctionARNFromEnv reconstructs the function arn from what's available
-// in the environment.
-func FetchFunctionARNFromEnv(accountID string) (string, error) {
-	partition := "aws"
-	region := os.Getenv(RegionEnvVar)
-	functionName := os.Getenv(functionNameEnvVar)
-	qualifier := os.Getenv(qualifierEnvVar)
-
-	if len(accountID) == 0 || len(region) == 0 || len(functionName) == 0 {
-		return "", log.Errorf("Couldn't construct function arn with accountID:%s, region:%s, functionName:%s", accountID, region, functionName)
-	}
-
-	if strings.HasPrefix(region, "us-gov") {
-		partition = "aws-us-gov"
-	}
-	if strings.HasPrefix(region, "cn-") {
-		partition = "aws-cn"
-	}
-
-	baseARN := fmt.Sprintf("arn:%s:lambda:%s:%s:function:%s", partition, region, accountID, functionName)
-	if len(qualifier) > 0 && qualifier != "$LATEST" {
-		return fmt.Sprintf("%s:%s", baseARN, qualifier), nil
-	}
-	return baseARN, nil
-}
-
-// GetARNTags returns tags associated with the current ARN
-func GetARNTags() []string {
-	functionARN := GetARN()
-	qualifier := GetQualifier()
-
-	parts := strings.Split(functionARN, ":")
-	if len(parts) < 6 {
-		return []string{
-			fmt.Sprintf("function_arn:%s", strings.ToLower(functionARN)),
-		}
-	}
-	region := parts[3]
-	accountID := parts[4]
-	functionName := strings.ToLower(parts[6])
-
-	tags := []string{
-		fmt.Sprintf("region:%s", region),
-		fmt.Sprintf("aws_account:%s", accountID),
-		fmt.Sprintf("account_id:%s", accountID),
-		fmt.Sprintf("functionname:%s", functionName),
-		fmt.Sprintf("function_arn:%s", strings.ToLower(functionARN)),
-	}
-	resource := functionName
-	if len(qualifier) > 0 {
-		_, err := strconv.ParseUint(qualifier, 10, 64)
-		if err == nil {
-			tags = append(tags, fmt.Sprintf("executedversion:%s", qualifier))
-		}
-		resource = fmt.Sprintf("%s:%s", resource, qualifier)
-	}
-	tags = append(tags, fmt.Sprintf("resource:%s", resource))
-
-	return tags
-}
-
-// BuildGlobalTagsMap returns tags associated with the given ARN
-func BuildGlobalTagsMap(functionARN string, functionName string, region string, awsAccountID string) map[string]string {
-	tags := make(map[string]string)
-	tags[traceOriginMetadataKey] = traceOriginMetadataValue
-	tags[computeStatsKey] = computeStatsValue
-	if functionARN != "" {
-		tags[functionARNKey] = functionARN
-	}
-	tags[functionNameKey] = functionName
-	if region != "" {
-		tags[regionKey] = region
-	}
-	if awsAccountID != "" {
-		tags[awsAccountKey] = awsAccountID
-	}
-	return tags
-}
-
-// FetchAccountID retrieves the AWS Lambda's account id by calling STS
-func FetchAccountID(ctx context.Context, svc stsiface.STSAPI) (string, error) {
-	// sts.GetCallerIdentity returns information about the current AWS credentials,
-	// (including account ID), and is one of the only AWS API methods that can't be
-	// denied via IAM.
-
-	input := &sts.GetCallerIdentityInput{}
-
-	result, err := svc.GetCallerIdentityWithContext(ctx, input)
-	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok {
-			switch aerr.Code() {
-			default:
-				return "", log.Errorf("Couldn't get account ID: %s", aerr.Error())
-			}
-		}
-		return "", log.Errorf("Couldn't get account ID: %s", err.Error())
-	}
-	return *result.Account, nil
 }

--- a/pkg/serverless/aws/arn_test.go
+++ b/pkg/serverless/aws/arn_test.go
@@ -7,14 +7,8 @@
 package aws
 
 import (
-	"context"
-	"os"
 	"testing"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/aws/aws-sdk-go/service/sts/stsiface"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -31,9 +25,6 @@ func TestGetAndSetARN(t *testing.T) {
 
 	output := GetARN()
 	assert.Equal(t, exampleArnWithoutVersion, output)
-
-	functionName := FunctionNameFromARN()
-	assert.Equal(t, exampleFunctionName, functionName)
 }
 
 func TestGetAndSetColdstart(t *testing.T) {
@@ -73,7 +64,7 @@ func TestPersistAndRestoreCurrentState(t *testing.T) {
 	assert.Equal(t, exampleRequestID, output)
 }
 
-func TestGetTagsForEnhancedMetrics(t *testing.T) {
+/*func TestGetTagsForEnhancedMetrics(t *testing.T) {
 	SetARN("arn:aws:lambda:us-east-1:123456789012:function:my-Function:7")
 	defer SetARN("")
 
@@ -88,82 +79,10 @@ func TestGetTagsForEnhancedMetrics(t *testing.T) {
 		"executedversion:7",
 		"resource:my-function:7",
 	})
-}
-
-type mockedSTSAPI struct {
-	stsiface.STSAPI
-	Resp sts.GetCallerIdentityOutput
-}
-
-func (m mockedSTSAPI) GetCallerIdentityWithContext(ctx context.Context, in *sts.GetCallerIdentityInput, options ...request.Option) (*sts.GetCallerIdentityOutput, error) {
-	// Only need to return mocked response output
-	return &m.Resp, nil
-}
-
-func TestFetchFunctionARNFromEnv(t *testing.T) {
-	t.Cleanup(resetState)
-	os.Setenv(RegionEnvVar, "us-east-1")
-	os.Setenv(functionNameEnvVar, "my-Function")
-	os.Setenv(qualifierEnvVar, "7")
-	arn, err := FetchFunctionARNFromEnv("123456789012")
-	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-Function:7", arn)
-	assert.Nil(t, err)
-}
-
-func TestFetchFunctionARNFromEnvGovcloud(t *testing.T) {
-	t.Cleanup(resetState)
-	os.Setenv(RegionEnvVar, "us-gov-west-1")
-	os.Setenv(functionNameEnvVar, "my-Function")
-	os.Setenv(qualifierEnvVar, "7")
-	arn, err := FetchFunctionARNFromEnv("123456789012")
-	assert.Equal(t, "arn:aws-us-gov:lambda:us-gov-west-1:123456789012:function:my-Function:7", arn)
-	assert.Nil(t, err)
-}
-
-func TestFetchFunctionARNFromEnvChina(t *testing.T) {
-	t.Cleanup(resetState)
-	os.Setenv(RegionEnvVar, "cn-east-1")
-	os.Setenv(functionNameEnvVar, "my-Function")
-	os.Setenv(qualifierEnvVar, "7")
-	arn, err := FetchFunctionARNFromEnv("123456789012")
-	assert.Equal(t, "arn:aws-cn:lambda:cn-east-1:123456789012:function:my-Function:7", arn)
-	assert.Nil(t, err)
-}
-
-func TestFetchAccountID(t *testing.T) {
-	svc := mockedSTSAPI{
-		Resp: sts.GetCallerIdentityOutput{
-			Account: aws.String("123456789012"),
-			Arn:     aws.String(""),
-			UserId:  aws.String(""),
-		},
-	}
-	ctx := context.Background()
-	result, err := FetchAccountID(ctx, svc)
-	assert.Equal(t, "123456789012", result)
-	assert.Nil(t, err)
-}
+}*/
 
 func resetState() {
 	SetARN("")
 	SetRequestID("")
 	SetColdStart(false)
-	os.Setenv(RegionEnvVar, "")
-	os.Setenv(functionNameEnvVar, "")
-	os.Setenv(qualifierEnvVar, "")
-}
-
-func TestBuildGlobalTagsMap(t *testing.T) {
-	arn := "arn:aws:lambda:us-east-1:123456789012:function:my-function"
-	awsAccount := "123456789012"
-	functionName := "my-function"
-	region := "us-east-1"
-	m := BuildGlobalTagsMap(arn, functionName, region, awsAccount)
-	assert.Equal(t, len(m), 6)
-	assert.Equal(t, region, m["region"])
-	assert.Equal(t, functionName, m["functionname"])
-	assert.Equal(t, awsAccount, m["aws_account"])
-	assert.Equal(t, arn, m["function_arn"])
-	assert.Equal(t, "lambda", m["_dd.origin"])
-	assert.Equal(t, "1", m["_dd.compute_stats"])
 }

--- a/pkg/serverless/aws/arn_test.go
+++ b/pkg/serverless/aws/arn_test.go
@@ -15,7 +15,6 @@ import (
 const (
 	exampleArn               = "arn:aws:lambda:us-east-1:123456789012:function:my-function:7"
 	exampleArnWithoutVersion = "arn:aws:lambda:us-east-1:123456789012:function:my-function"
-	exampleFunctionName      = "my-function"
 	exampleRequestID         = "123"
 )
 

--- a/pkg/serverless/aws/arn_test.go
+++ b/pkg/serverless/aws/arn_test.go
@@ -64,23 +64,6 @@ func TestPersistAndRestoreCurrentState(t *testing.T) {
 	assert.Equal(t, exampleRequestID, output)
 }
 
-/*func TestGetTagsForEnhancedMetrics(t *testing.T) {
-	SetARN("arn:aws:lambda:us-east-1:123456789012:function:my-Function:7")
-	defer SetARN("")
-
-	generatedTags := GetARNTags()
-
-	assert.Equal(t, generatedTags, []string{
-		"region:us-east-1",
-		"aws_account:123456789012",
-		"account_id:123456789012",
-		"functionname:my-function",
-		"function_arn:arn:aws:lambda:us-east-1:123456789012:function:my-function",
-		"executedversion:7",
-		"resource:my-function:7",
-	})
-}*/
-
 func resetState() {
 	SetARN("")
 	SetRequestID("")

--- a/pkg/serverless/enhanced_metrics.go
+++ b/pkg/serverless/enhanced_metrics.go
@@ -118,8 +118,8 @@ func sendTimeoutEnhancedMetric(tags []string, metricsChan chan []metrics.MetricS
 	}}
 }
 
-// getTagsForEnhancedMetrics returns the tags that should be included with enhanced metrics
-func getTagsForEnhancedMetrics(tags []string) []string {
+// addColdStartTag appends the cold_start tag to existing tags
+func addColdStartTag(tags []string) []string {
 	coldStart := aws.GetColdStart()
 	tags = append(tags, fmt.Sprintf("cold_start:%v", coldStart))
 	return tags

--- a/pkg/serverless/enhanced_metrics.go
+++ b/pkg/serverless/enhanced_metrics.go
@@ -119,8 +119,7 @@ func sendTimeoutEnhancedMetric(tags []string, metricsChan chan []metrics.MetricS
 }
 
 // getTagsForEnhancedMetrics returns the tags that should be included with enhanced metrics
-func getTagsForEnhancedMetrics() []string {
-	tags := aws.GetARNTags()
+func getTagsForEnhancedMetrics(tags []string) []string {
 	coldStart := aws.GetColdStart()
 	tags = append(tags, fmt.Sprintf("cold_start:%v", coldStart))
 	return tags

--- a/pkg/serverless/enhanced_metrics_test.go
+++ b/pkg/serverless/enhanced_metrics_test.go
@@ -195,21 +195,36 @@ func TestSendTimeoutEnhancedMetric(t *testing.T) {
 	}})
 }
 
-func TestGetTagsForEnhancedMetrics(t *testing.T) {
+func TestGetTagsForEnhancedMetricsWithoutColdStart(t *testing.T) {
 	aws.SetARN("arn:aws:lambda:us-east-1:123456789012:function:my-function:7")
 	defer aws.SetARN("")
 
-	generatedTags := getTagsForEnhancedMetrics()
+	generatedTags := getTagsForEnhancedMetrics([]string{
+		"myTagName0:myTagValue0",
+		"myTagName1:myTagValue1",
+	})
 
 	assert.Equal(t, generatedTags, []string{
-		"region:us-east-1",
-		"aws_account:123456789012",
-		"account_id:123456789012",
-		"functionname:my-function",
-		"function_arn:arn:aws:lambda:us-east-1:123456789012:function:my-function",
-		"executedversion:7",
-		"resource:my-function:7",
+		"myTagName0:myTagValue0",
+		"myTagName1:myTagValue1",
 		"cold_start:false",
+	})
+}
+
+func TestGetTagsForEnhancedMetricsWithColdStart(t *testing.T) {
+	aws.SetARN("arn:aws:lambda:us-east-1:123456789012:function:my-function:7")
+	aws.SetColdStart(true)
+	defer aws.SetARN("")
+
+	generatedTags := getTagsForEnhancedMetrics([]string{
+		"myTagName0:myTagValue0",
+		"myTagName1:myTagValue1",
+	})
+
+	assert.Equal(t, generatedTags, []string{
+		"myTagName0:myTagValue0",
+		"myTagName1:myTagValue1",
+		"cold_start:true",
 	})
 }
 

--- a/pkg/serverless/enhanced_metrics_test.go
+++ b/pkg/serverless/enhanced_metrics_test.go
@@ -195,11 +195,11 @@ func TestSendTimeoutEnhancedMetric(t *testing.T) {
 	}})
 }
 
-func TestGetTagsForEnhancedMetricsWithoutColdStart(t *testing.T) {
+func TestAddColdStartTagWithoutColdStart(t *testing.T) {
 	aws.SetARN("arn:aws:lambda:us-east-1:123456789012:function:my-function:7")
 	defer aws.SetARN("")
 
-	generatedTags := getTagsForEnhancedMetrics([]string{
+	generatedTags := addColdStartTag([]string{
 		"myTagName0:myTagValue0",
 		"myTagName1:myTagValue1",
 	})
@@ -211,12 +211,12 @@ func TestGetTagsForEnhancedMetricsWithoutColdStart(t *testing.T) {
 	})
 }
 
-func TestGetTagsForEnhancedMetricsWithColdStart(t *testing.T) {
+func TestAddColdStartTagWithColdStart(t *testing.T) {
 	aws.SetARN("arn:aws:lambda:us-east-1:123456789012:function:my-function:7")
 	aws.SetColdStart(true)
 	defer aws.SetARN("")
 
-	generatedTags := getTagsForEnhancedMetrics([]string{
+	generatedTags := addColdStartTag([]string{
 		"myTagName0:myTagValue0",
 		"myTagName1:myTagValue1",
 	})

--- a/pkg/serverless/protocol.go
+++ b/pkg/serverless/protocol.go
@@ -282,10 +282,10 @@ func (d *Daemon) WaitUntilClientReady(timeout time.Duration) bool {
 }
 
 // ComputeGlobalTags extracts tags from the ARN, merge them use any user-predefined tags and set them to traces, logs and metrics
-func (d *Daemon) ComputeGlobalTags(arn string, tags []string) {
+func (d *Daemon) ComputeGlobalTags(arn string, configTags []string) {
 	if len(d.extraTags) == 0 {
 		tagMap := buildTagMapFromArn(arn)
-		tagArray := buildTagsFromMap(tagMap, blackListTagForMetricsAndLogs())
+		tagArray := buildTagsFromMap(configTags, tagMap, blackListTagForMetricsAndLogs())
 		d.statsdServer.SetExtraTags(tagArray)
 		d.traceAgent.SetGlobalTags(buildTracerTags(tagMap, blackListTagForTraces()))
 		d.extraTags = tagArray

--- a/pkg/serverless/protocol.go
+++ b/pkg/serverless/protocol.go
@@ -281,7 +281,7 @@ func (d *Daemon) WaitUntilClientReady(timeout time.Duration) bool {
 	return d.clientLibReady
 }
 
-// ComputeGlobalTags extracts tags from the ARN, merge them use any user-predefined tags and set them to traces, logs and metrics
+// ComputeGlobalTags extracts tags from the ARN, merges them with any user-defined tags and adds them to traces, logs and metrics
 func (d *Daemon) ComputeGlobalTags(arn string, configTags []string) {
 	if len(d.extraTags) == 0 {
 		tagMap := buildTagMapFromArn(arn)

--- a/pkg/serverless/protocol.go
+++ b/pkg/serverless/protocol.go
@@ -295,10 +295,10 @@ func (d *Daemon) ComputeGlobalTags(arn string, tags []string) {
 		tagArray := buildTagsFromMap(tagMap, blackListTagForMetricsAndLogs())
 		d.statsdServer.SetExtraTags(tagArray)
 		d.traceAgent.SetGlobalTags(buildTracerTags(tagMap, blackListTagForTraces()))
+		d.extraTags = tagArray
 		source := scheduler.GetScheduler().GetSourceFromName("lambda")
 		if source != nil {
 			source.Config.Tags = tagArray
-			d.extraTags = tagArray
 		} else {
 			log.Debug("Impossible to retrieve the lambda LogSource")
 		}

--- a/pkg/serverless/protocol.go
+++ b/pkg/serverless/protocol.go
@@ -285,12 +285,12 @@ func (d *Daemon) WaitUntilClientReady(timeout time.Duration) bool {
 func (d *Daemon) ComputeGlobalTags(arn string, configTags []string) {
 	if len(d.extraTags) == 0 {
 		tagMap := buildTagMapFromArn(arn)
-		tagArray := buildTagsFromMap(configTags, tagMap, blackListTagForMetricsAndLogs())
+		tagArray := buildTagsFromMap(configTags, tagMap)
 		if d.statsdServer != nil {
 			d.statsdServer.SetExtraTags(tagArray)
 		}
 		if d.traceAgent != nil {
-			d.traceAgent.SetGlobalTags(buildTracerTags(tagMap, blackListTagForTraces()))
+			d.traceAgent.SetGlobalTags(buildTracerTags(tagMap))
 		}
 		d.extraTags = tagArray
 		source := scheduler.GetScheduler().GetSourceFromName("lambda")

--- a/pkg/serverless/protocol.go
+++ b/pkg/serverless/protocol.go
@@ -330,7 +330,7 @@ func (l *LogsCollection) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 func processLogMessages(l *LogsCollection, messages []aws.LogMessage, functionName string) {
 	metricsChan := l.daemon.aggregator.GetBufferedMetricsWithTsChannel()
-	metricTags := getTagsForEnhancedMetrics(l.daemon.extraTags)
+	metricTags := addColdStartTag(l.daemon.extraTags)
 	logsEnabled := config.Datadog.GetBool("serverless.logs_enabled")
 	enhancedMetricsEnabled := config.Datadog.GetBool("enhanced_metrics")
 	functionName = strings.ToLower(functionName)

--- a/pkg/serverless/protocol.go
+++ b/pkg/serverless/protocol.go
@@ -286,8 +286,12 @@ func (d *Daemon) ComputeGlobalTags(arn string, configTags []string) {
 	if len(d.extraTags) == 0 {
 		tagMap := buildTagMapFromArn(arn)
 		tagArray := buildTagsFromMap(configTags, tagMap, blackListTagForMetricsAndLogs())
-		d.statsdServer.SetExtraTags(tagArray)
-		d.traceAgent.SetGlobalTags(buildTracerTags(tagMap, blackListTagForTraces()))
+		if d.statsdServer != nil {
+			d.statsdServer.SetExtraTags(tagArray)
+		}
+		if d.traceAgent != nil {
+			d.traceAgent.SetGlobalTags(buildTracerTags(tagMap, blackListTagForTraces()))
+		}
 		d.extraTags = tagArray
 		source := scheduler.GetScheduler().GetSourceFromName("lambda")
 		if source != nil {

--- a/pkg/serverless/protocol_test.go
+++ b/pkg/serverless/protocol_test.go
@@ -20,6 +20,7 @@ func TestWaitForDaemonBlocking(t *testing.T) {
 	_, cancel := context.WithCancel(context.Background())
 	d := StartDaemon(cancel)
 	d.ReadyWg.Done()
+	d.ReadyWg.Done()
 	defer d.Stop()
 
 	// WaitForDaemon doesn't block if the client library hasn't
@@ -46,6 +47,7 @@ func TestWaitUntilReady(t *testing.T) {
 	assert := assert.New(t)
 	_, cancel := context.WithCancel(context.Background())
 	d := StartDaemon(cancel)
+	d.ReadyWg.Done()
 	d.ReadyWg.Done()
 	defer d.Stop()
 

--- a/pkg/serverless/serverless.go
+++ b/pkg/serverless/serverless.go
@@ -300,7 +300,7 @@ func WaitForNextInvocation(stopCh chan struct{}, daemon *Daemon, metricsChan cha
 		log.Debug("Received shutdown event. Reason: " + payload.ShutdownReason)
 
 		if strings.ToLower(payload.ShutdownReason) == "timeout" {
-			metricTags := getTagsForEnhancedMetrics(daemon.extraTags)
+			metricTags := addColdStartTag(daemon.extraTags)
 			sendTimeoutEnhancedMetric(metricTags, metricsChan)
 		}
 

--- a/pkg/serverless/serverless.go
+++ b/pkg/serverless/serverless.go
@@ -249,7 +249,6 @@ func WaitForNextInvocation(stopCh chan struct{}, daemon *Daemon, metricsChan cha
 	if response, err = client.Do(request); err != nil {
 		return fmt.Errorf("WaitForNextInvocation: while GET next route: %v", err)
 	}
-
 	// we received an INVOKE or SHUTDOWN event
 	daemon.StoreInvocationTime(time.Now())
 

--- a/pkg/serverless/serverless.go
+++ b/pkg/serverless/serverless.go
@@ -266,6 +266,7 @@ func WaitForNextInvocation(stopCh chan struct{}, daemon *Daemon, metricsChan cha
 
 	if payload.EventType == "INVOKE" {
 		log.Debug("Received invocation event")
+		daemon.ComputeGlobalTags(payload.InvokedFunctionArn, config.GetConfiguredTags(true))
 		aws.SetARN(payload.InvokedFunctionArn)
 		daemon.StartInvocation()
 		if coldstart {
@@ -300,7 +301,7 @@ func WaitForNextInvocation(stopCh chan struct{}, daemon *Daemon, metricsChan cha
 		log.Debug("Received shutdown event. Reason: " + payload.ShutdownReason)
 
 		if strings.ToLower(payload.ShutdownReason) == "timeout" {
-			metricTags := getTagsForEnhancedMetrics()
+			metricTags := getTagsForEnhancedMetrics(daemon.extraTags)
 			sendTimeoutEnhancedMetric(metricTags, metricsChan)
 		}
 

--- a/pkg/serverless/tags.go
+++ b/pkg/serverless/tags.go
@@ -54,7 +54,7 @@ func buildTagMapFromArn(arn string) map[string]string {
 	return tags
 }
 
-func buildTagsFromMap(tags map[string]string, tagBlackList []string) []string {
+func buildTagsFromMap(configTags []string, tags map[string]string, tagBlackList []string) []string {
 	tagsMap := make(map[string]string)
 	for k, v := range tags {
 		tagsMap[k] = v
@@ -62,7 +62,8 @@ func buildTagsFromMap(tags map[string]string, tagBlackList []string) []string {
 	for _, blackListKey := range tagBlackList {
 		delete(tagsMap, blackListKey)
 	}
-	tagsArray := make([]string, 0, len(tagsMap))
+	tagsArray := make([]string, 0, len(configTags)+len(tagsMap))
+	tagsArray = append(tagsArray, configTags...)
 	for key, value := range tagsMap {
 		tagsArray = append(tagsArray, fmt.Sprintf("%s:%s", key, value))
 	}

--- a/pkg/serverless/tags.go
+++ b/pkg/serverless/tags.go
@@ -1,0 +1,96 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package serverless
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+const (
+	qualifierEnvVar = "AWS_LAMBDA_FUNCTION_VERSION"
+
+	traceOriginMetadataKey   = "_dd.origin"
+	traceOriginMetadataValue = "lambda"
+	computeStatsKey          = "_dd.compute_stats"
+	computeStatsValue        = "1"
+	functionARNKey           = "function_arn"
+	functionNameKey          = "functionname"
+	regionKey                = "region"
+	awsAccountKey            = "aws_account"
+	resourceKey              = "resource"
+	executedVersionKey       = "executedversion"
+)
+
+func buildTagMapFromArn(arn string) map[string]string {
+	tags := make(map[string]string)
+
+	tags = setIfNotEmpty(tags, traceOriginMetadataKey, traceOriginMetadataValue)
+	tags = setIfNotEmpty(tags, computeStatsKey, computeStatsValue)
+	tags = setIfNotEmpty(tags, functionARNKey, arn)
+
+	parts := strings.Split(arn, ":")
+	if len(parts) < 6 {
+		return tags
+	}
+
+	tags = setIfNotEmpty(tags, regionKey, parts[3])
+	tags = setIfNotEmpty(tags, awsAccountKey, parts[4])
+	tags = setIfNotEmpty(tags, functionNameKey, parts[6])
+	tags = setIfNotEmpty(tags, resourceKey, parts[6])
+
+	qualifier := os.Getenv(qualifierEnvVar)
+	if len(qualifier) > 0 {
+		if qualifier != "$LATEST" {
+			tags = setIfNotEmpty(tags, resourceKey, fmt.Sprintf("%s:%s", parts[6], qualifier))
+			tags = setIfNotEmpty(tags, executedVersionKey, qualifier)
+		}
+	}
+
+	return tags
+}
+
+func buildTagsFromMap(tags map[string]string, tagBlackList []string) []string {
+	tagsMap := make(map[string]string)
+	for k, v := range tags {
+		tagsMap[k] = v
+	}
+	for _, blackListKey := range tagBlackList {
+		delete(tagsMap, blackListKey)
+	}
+	tagsArray := make([]string, 0, len(tagsMap))
+	for key, value := range tagsMap {
+		tagsArray = append(tagsArray, fmt.Sprintf("%s:%s", key, value))
+	}
+	return tagsArray
+}
+
+func buildTracerTags(tags map[string]string, tagBlackList []string) map[string]string {
+	tagsMap := make(map[string]string)
+	for k, v := range tags {
+		tagsMap[k] = v
+	}
+	for _, blackListKey := range tagBlackList {
+		delete(tagsMap, blackListKey)
+	}
+	return tagsMap
+}
+
+func setIfNotEmpty(tagMap map[string]string, key string, value string) map[string]string {
+	if key != "" {
+		tagMap[key] = strings.ToLower(value)
+	}
+	return tagMap
+}
+
+func blackListTagForMetricsAndLogs() []string {
+	return []string{traceOriginMetadataKey, computeStatsKey}
+}
+
+func blackListTagForTraces() []string {
+	return []string{resourceKey}
+}

--- a/pkg/serverless/tags.go
+++ b/pkg/serverless/tags.go
@@ -54,8 +54,9 @@ func buildTagMapFromArn(arn string) map[string]string {
 	return tags
 }
 
-func buildTagsFromMap(configTags []string, tags map[string]string, tagBlackList []string) []string {
+func buildTagsFromMap(configTags []string, tags map[string]string) []string {
 	tagsMap := make(map[string]string)
+	tagBlackList := []string{traceOriginMetadataKey, computeStatsKey}
 	for k, v := range tags {
 		tagsMap[k] = v
 	}
@@ -70,8 +71,9 @@ func buildTagsFromMap(configTags []string, tags map[string]string, tagBlackList 
 	return tagsArray
 }
 
-func buildTracerTags(tags map[string]string, tagBlackList []string) map[string]string {
+func buildTracerTags(tags map[string]string) map[string]string {
 	tagsMap := make(map[string]string)
+	tagBlackList := []string{resourceKey}
 	for k, v := range tags {
 		tagsMap[k] = v
 	}
@@ -86,12 +88,4 @@ func setIfNotEmpty(tagMap map[string]string, key string, value string) map[strin
 		tagMap[key] = strings.ToLower(value)
 	}
 	return tagMap
-}
-
-func blackListTagForMetricsAndLogs() []string {
-	return []string{traceOriginMetadataKey, computeStatsKey}
-}
-
-func blackListTagForTraces() []string {
-	return []string{resourceKey}
 }

--- a/pkg/serverless/tags_test.go
+++ b/pkg/serverless/tags_test.go
@@ -81,6 +81,19 @@ func TestBuildTagMapFromArnComplete(t *testing.T) {
 	assert.Equal(t, "my-function", tagMap["resource"])
 }
 
+func TestBuildTagMapFromArnCompleteWithUperCase(t *testing.T) {
+	arn := "arn:aws:lambda:us-east-1:123456789012:function:My-Function"
+	tagMap := buildTagMapFromArn(arn)
+	assert.Equal(t, 7, len(tagMap))
+	assert.Equal(t, "lambda", tagMap["_dd.origin"])
+	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
+	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
+	assert.Equal(t, "us-east-1", tagMap["region"])
+	assert.Equal(t, "123456789012", tagMap["aws_account"])
+	assert.Equal(t, "my-function", tagMap["functionname"])
+	assert.Equal(t, "my-function", tagMap["resource"])
+}
+
 func TestBuildTagMapFromArnCompleteWithLatest(t *testing.T) {
 	os.Setenv("AWS_LAMBDA_FUNCTION_VERSION", "$LATEST")
 	arn := "arn:aws:lambda:us-east-1:123456789012:function:my-function"

--- a/pkg/serverless/tags_test.go
+++ b/pkg/serverless/tags_test.go
@@ -81,7 +81,7 @@ func TestBuildTagMapFromArnComplete(t *testing.T) {
 	assert.Equal(t, "my-function", tagMap["resource"])
 }
 
-func TestBuildTagMapFromArnCompleteWithUperCase(t *testing.T) {
+func TestBuildTagMapFromArnCompleteWithUpperCase(t *testing.T) {
 	arn := "arn:aws:lambda:us-east-1:123456789012:function:My-Function"
 	tagMap := buildTagMapFromArn(arn)
 	assert.Equal(t, 7, len(tagMap))

--- a/pkg/serverless/tags_test.go
+++ b/pkg/serverless/tags_test.go
@@ -1,0 +1,108 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package serverless
+
+import (
+	"os"
+	"sort"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSetIfNotEmptyWithNonEmptyKey(t *testing.T) {
+	testMap := make(map[string]string)
+	testMap = setIfNotEmpty(testMap, "nonEmptyKey", "VALUE")
+	assert.Equal(t, 1, len(testMap))
+	assert.Equal(t, "value", testMap["nonEmptyKey"])
+}
+
+func TestSetIfNotEmptyWithEmptyKey(t *testing.T) {
+	testMap := make(map[string]string)
+	testMap = setIfNotEmpty(testMap, "", "VALUE")
+	assert.Equal(t, 0, len(testMap))
+}
+
+func TestBuildTracerTags(t *testing.T) {
+	tagsMap := map[string]string{
+		"key0": "value0",
+		"key1": "value1",
+		"key2": "value2",
+		"key3": "value3",
+	}
+	blackList := []string{"key2", "key1"}
+	resultTagsMap := buildTracerTags(tagsMap, blackList)
+	assert.Equal(t, 2, len(resultTagsMap))
+	assert.Equal(t, "value0", resultTagsMap["key0"])
+	assert.Equal(t, "value3", resultTagsMap["key3"])
+}
+
+func TestBuildTagsFromMap(t *testing.T) {
+	tagsMap := map[string]string{
+		"key0": "value0",
+		"key1": "value1",
+		"key2": "value2",
+		"key3": "value3",
+	}
+	blackList := []string{"key1", "key2"}
+	resultTagsArray := buildTagsFromMap(tagsMap, blackList)
+	sort.Strings(resultTagsArray)
+	assert.Equal(t, []string{
+		"key0:value0",
+		"key3:value3",
+	}, resultTagsArray)
+}
+
+func TestBuildTagMapFromArnIncomplete(t *testing.T) {
+	arn := "function:my-function"
+	tagMap := buildTagMapFromArn(arn)
+	assert.Equal(t, 3, len(tagMap))
+	assert.Equal(t, "lambda", tagMap["_dd.origin"])
+	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
+	assert.Equal(t, "function:my-function", tagMap["function_arn"])
+}
+
+func TestBuildTagMapFromArnComplete(t *testing.T) {
+	arn := "arn:aws:lambda:us-east-1:123456789012:function:my-function"
+	tagMap := buildTagMapFromArn(arn)
+	assert.Equal(t, 7, len(tagMap))
+	assert.Equal(t, "lambda", tagMap["_dd.origin"])
+	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
+	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
+	assert.Equal(t, "us-east-1", tagMap["region"])
+	assert.Equal(t, "123456789012", tagMap["aws_account"])
+	assert.Equal(t, "my-function", tagMap["functionname"])
+	assert.Equal(t, "my-function", tagMap["resource"])
+}
+
+func TestBuildTagMapFromArnCompleteWithLatest(t *testing.T) {
+	os.Setenv("AWS_LAMBDA_FUNCTION_VERSION", "$LATEST")
+	arn := "arn:aws:lambda:us-east-1:123456789012:function:my-function"
+	tagMap := buildTagMapFromArn(arn)
+	assert.Equal(t, 7, len(tagMap))
+	assert.Equal(t, "lambda", tagMap["_dd.origin"])
+	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
+	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
+	assert.Equal(t, "us-east-1", tagMap["region"])
+	assert.Equal(t, "123456789012", tagMap["aws_account"])
+	assert.Equal(t, "my-function", tagMap["functionname"])
+	assert.Equal(t, "my-function", tagMap["resource"])
+}
+
+func TestBuildTagMapFromArnCompleteWithVersionNumber(t *testing.T) {
+	os.Setenv("AWS_LAMBDA_FUNCTION_VERSION", "888")
+	arn := "arn:aws:lambda:us-east-1:123456789012:function:my-function"
+	tagMap := buildTagMapFromArn(arn)
+	assert.Equal(t, 8, len(tagMap))
+	assert.Equal(t, "lambda", tagMap["_dd.origin"])
+	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
+	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
+	assert.Equal(t, "us-east-1", tagMap["region"])
+	assert.Equal(t, "123456789012", tagMap["aws_account"])
+	assert.Equal(t, "my-function", tagMap["functionname"])
+	assert.Equal(t, "my-function:888", tagMap["resource"])
+	assert.Equal(t, "888", tagMap["executedversion"])
+}

--- a/pkg/serverless/tags_test.go
+++ b/pkg/serverless/tags_test.go
@@ -28,33 +28,34 @@ func TestSetIfNotEmptyWithEmptyKey(t *testing.T) {
 
 func TestBuildTracerTags(t *testing.T) {
 	tagsMap := map[string]string{
-		"key0": "value0",
-		"key1": "value1",
-		"key2": "value2",
-		"key3": "value3",
+		"key0":     "value0",
+		"resource": "value1",
+		"key1":     "value1",
 	}
-	blackList := []string{"key2", "key1"}
-	resultTagsMap := buildTracerTags(tagsMap, blackList)
+	resultTagsMap := buildTracerTags(tagsMap)
 	assert.Equal(t, 2, len(resultTagsMap))
 	assert.Equal(t, "value0", resultTagsMap["key0"])
-	assert.Equal(t, "value3", resultTagsMap["key3"])
+	assert.Equal(t, "value1", resultTagsMap["key1"])
 }
 
 func TestBuildTagsFromMap(t *testing.T) {
 	tagsMap := map[string]string{
-		"key0": "value0",
-		"key1": "value1",
-		"key2": "value2",
-		"key3": "value3",
+		"key0":              "value0",
+		"key1":              "value1",
+		"key2":              "value2",
+		"key3":              "value3",
+		"_dd.origin":        "xxx",
+		"_dd.compute_stats": "xxx",
 	}
 	configTags := []string{"configTagKey0:configTagValue0", "configTagKey1:configTagValue1"}
-	blackList := []string{"key1", "key2"}
-	resultTagsArray := buildTagsFromMap(configTags, tagsMap, blackList)
+	resultTagsArray := buildTagsFromMap(configTags, tagsMap)
 	sort.Strings(resultTagsArray)
 	assert.Equal(t, []string{
 		"configTagKey0:configTagValue0",
 		"configTagKey1:configTagValue1",
 		"key0:value0",
+		"key1:value1",
+		"key2:value2",
 		"key3:value3",
 	}, resultTagsArray)
 }

--- a/pkg/serverless/tags_test.go
+++ b/pkg/serverless/tags_test.go
@@ -47,10 +47,13 @@ func TestBuildTagsFromMap(t *testing.T) {
 		"key2": "value2",
 		"key3": "value3",
 	}
+	configTags := []string{"configTagKey0:configTagValue0", "configTagKey1:configTagValue1"}
 	blackList := []string{"key1", "key2"}
-	resultTagsArray := buildTagsFromMap(tagsMap, blackList)
+	resultTagsArray := buildTagsFromMap(configTags, tagsMap, blackList)
 	sort.Strings(resultTagsArray)
 	assert.Equal(t, []string{
+		"configTagKey0:configTagValue0",
+		"configTagKey1:configTagValue1",
 		"key0:value0",
 		"key3:value3",
 	}, resultTagsArray)

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -440,7 +440,7 @@ func newEventProcessor(conf *config.AgentConfig) *event.Processor {
 	return event.NewProcessor(extractors, conf.MaxEPS)
 }
 
-// SetGlobalTags sets global tags to the current configuration
+// SetGlobalTags sets global tags to the agent configuration
 func (a *Agent) SetGlobalTags(tags map[string]string) {
 	a.conf.GlobalTags = tags
 }

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -439,3 +439,7 @@ func newEventProcessor(conf *config.AgentConfig) *event.Processor {
 
 	return event.NewProcessor(extractors, conf.MaxEPS)
 }
+
+func (a *Agent) SetExtraTags(tags map[string]string) {
+	a.conf.GlobalTags = tags
+}

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -440,6 +440,7 @@ func newEventProcessor(conf *config.AgentConfig) *event.Processor {
 	return event.NewProcessor(extractors, conf.MaxEPS)
 }
 
-func (a *Agent) SetExtraTags(tags map[string]string) {
+// SetGlobalTags sets global tags to the current configuration
+func (a *Agent) SetGlobalTags(tags map[string]string) {
 	a.conf.GlobalTags = tags
 }


### PR DESCRIPTION
[work in progress]

### What does this PR do?

 - Remove the STS call which was used to compute tags before the first invocation. Now tags are computed during the first invocation thanks to the extension API payload field  `InvokedFunctionArn`
 - Refactor tag management

Need to verify :
🟠    behaviour on us-gov
✅    behaviour with VPC
✅    thread safety of tag computing during the first invocations

### Motivation

Increase performance of extension startup + code cleaning

### Describe how to test your changes

Need to document + summarize performance improvements




