### PR TITLE
[tasks] Change all references to datadog-agent's master branch to `DEFAULT_BRANCH`

### DIFF
--- a/tasks/github.py
+++ b/tasks/github.py
@@ -1,13 +1,13 @@
 from invoke import task
 
 from .libs.github_actions_tools import download_artifacts, follow_workflow_run, trigger_macos_workflow
-from .utils import load_release_versions
+from .utils import DEFAULT_BRANCH, load_release_versions
 
 
 @task
 def trigger_macos_build(
     ctx,
-    datadog_agent_ref="master",
+    datadog_agent_ref=DEFAULT_BRANCH,
     release_version="nightly-a7",
     major_version="7",
     python_runtimes="3",

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -6,13 +6,15 @@ from time import sleep
 
 from invoke.exceptions import Exit
 
+from tasks.utils import DEFAULT_BRANCH
+
 from .common.color import color_message
 from .common.github import Github, GithubException
 
 
 def trigger_macos_workflow(
     github_action_ref="master",
-    datadog_agent_ref="master",
+    datadog_agent_ref=DEFAULT_BRANCH,
     release_version="nightly-a7",
     major_version="7",
     python_runtimes="3",

--- a/tasks/libs/pipeline_tools.py
+++ b/tasks/libs/pipeline_tools.py
@@ -2,6 +2,8 @@ import functools
 import platform
 from time import sleep, time
 
+from tasks.utils import DEFAULT_BRANCH
+
 from .common.color import color_message
 from .common.gitlab import Gitlab
 from .common.user_interactions import yes_no_question
@@ -50,7 +52,7 @@ def cancel_pipelines_with_confirmation(gitlab, project, pipelines):
 def trigger_agent_pipeline(
     gitlab,
     project,
-    ref="master",
+    ref=DEFAULT_BRANCH,
     release_version_6="nightly",
     release_version_7="nightly-a7",
     branch="nightly",
@@ -74,14 +76,14 @@ def trigger_agent_pipeline(
         args["DEPLOY_AGENT"] = "true"
 
     # The RUN_ALL_BUILDS option can be selectively enabled. However, it cannot be explicitly
-    # disabled on pipelines where they're activated by default (master & deploy pipelines)
-    # as that would make the pipeline fail (some jobs on master and deploy pipelines depend
+    # disabled on pipelines where they're activated by default (default branch & deploy pipelines)
+    # as that would make the pipeline fail (some jobs on the default branch and deploy pipelines depend
     # on jobs that are only run if RUN_ALL_BUILDS is true).
     if all_builds:
         args["RUN_ALL_BUILDS"] = "true"
 
     # Kitchen tests can be selectively enabled, or disabled on pipelines where they're
-    # enabled by default (master and deploy pipelines).
+    # enabled by default (default branch and deploy pipelines).
     if kitchen_tests:
         args["RUN_KITCHEN_TESTS"] = "true"
     else:

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -7,6 +7,8 @@ from collections import defaultdict
 from invoke import task
 from invoke.exceptions import Exit
 
+from tasks.utils import DEFAULT_BRANCH
+
 from .libs.common.color import color_message
 from .libs.common.gitlab import Gitlab
 from .libs.pipeline_notifications import (
@@ -81,7 +83,7 @@ def check_deploy_pipeline(gitlab, project_name, git_ref, release_version_6, rele
 
 
 @task
-def clean_running_pipelines(ctx, git_ref="master", here=False, use_latest_sha=False, sha=None):
+def clean_running_pipelines(ctx, git_ref=DEFAULT_BRANCH, here=False, use_latest_sha=False, sha=None):
     """
     Fetch running pipelines on a target ref (+ optionally a git sha), and ask the user if they
     should be cancelled.
@@ -113,7 +115,9 @@ def clean_running_pipelines(ctx, git_ref="master", here=False, use_latest_sha=Fa
 
 
 @task
-def trigger(ctx, git_ref="master", release_version_6="nightly", release_version_7="nightly-a7", repo_branch="nightly"):
+def trigger(
+    ctx, git_ref=DEFAULT_BRANCH, release_version_6="nightly", release_version_7="nightly-a7", repo_branch="nightly"
+):
     """
     DEPRECATED: Trigger a deploy pipeline on the given git ref. Use pipeline.run with the --deploy option instead.
 
@@ -147,7 +151,7 @@ def trigger(ctx, git_ref="master", release_version_6="nightly", release_version_
 @task
 def run(
     ctx,
-    git_ref="master",
+    git_ref=DEFAULT_BRANCH,
     here=False,
     release_version_6="nightly",
     release_version_7="nightly-a7",
@@ -160,7 +164,7 @@ def run(
     Run a pipeline on the given git ref, or on the current branch if --here is given.
     By default, this pipeline will run all builds & tests, including all kitchen tests, but is not a deploy pipeline.
     Use --deploy to make this pipeline a deploy pipeline, which will upload artifacts to the staging repositories.
-    Use --no-all-builds to not run builds for all architectures (only a subset of jobs will run. No effect on master pipelines).
+    Use --no-all-builds to not run builds for all architectures (only a subset of jobs will run. No effect on pipelines on the default branch).
     Use --no-kitchen-tests to not run all kitchen tests on the pipeline.
 
     The --release-version-6 and --release-version-7 options indicate which release.json entries are used.

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -14,6 +14,8 @@ from datetime import date
 from invoke import Failure, task
 from invoke.exceptions import Exit
 
+from tasks.utils import DEFAULT_BRANCH
+
 from .modules import DEFAULT_MODULES
 
 
@@ -56,8 +58,8 @@ def add_dca_prelude(ctx, version, agent7_version, agent6_version=""):
             """prelude:
     |
     Released on: {1}
-    Pinned to datadog-agent v{0}: `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#{2}{3}>`_.""".format(
-                agent7_version, date.today(), agent7_version.replace('.', ''), agent6_version,
+    Pinned to datadog-agent v{0}: `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/{4}/CHANGELOG.rst#{2}{3}>`_.""".format(
+                agent7_version, date.today(), agent7_version.replace('.', ''), agent6_version, DEFAULT_BRANCH,
             )
         )
 

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -21,10 +21,9 @@ from .dogstatsd import integration_tests as dsd_integration_tests
 from .go import fmt, generate, golangci_lint, ineffassign, lint, misspell, staticcheck, vet
 from .modules import DEFAULT_MODULES, GoModule
 from .trace_agent import integration_tests as trace_integration_tests
-from .utils import get_build_flags
+from .utils import DEFAULT_BRANCH, get_build_flags
 
 PROFILE_COV = "profile.cov"
-DEFAULT_GIT_BRANCH = 'master'
 
 
 def ensure_bytes(s):
@@ -314,8 +313,8 @@ def lint_teamassignment(_):
     branch = os.environ.get("CIRCLE_BRANCH")
     pr_url = os.environ.get("CIRCLE_PULL_REQUEST")
 
-    if branch == DEFAULT_GIT_BRANCH:
-        print("Running on {}, skipping check for team assignment.".format(DEFAULT_GIT_BRANCH))
+    if branch == DEFAULT_BRANCH:
+        print("Running on {}, skipping check for team assignment.".format(DEFAULT_BRANCH))
     elif pr_url:
         import requests
 
@@ -346,8 +345,8 @@ def lint_milestone(_):
     branch = os.environ.get("CIRCLE_BRANCH")
     pr_url = os.environ.get("CIRCLE_PULL_REQUEST")
 
-    if branch == DEFAULT_GIT_BRANCH:
-        print("Running on {}, skipping check for milestone.".format(DEFAULT_GIT_BRANCH))
+    if branch == DEFAULT_BRANCH:
+        print("Running on {}, skipping check for milestone.".format(DEFAULT_BRANCH))
     elif pr_url:
         import requests
 
@@ -377,8 +376,8 @@ def lint_releasenote(ctx):
     branch = os.environ.get("CIRCLE_BRANCH")
     pr_url = os.environ.get("CIRCLE_PULL_REQUEST")
 
-    if branch == DEFAULT_GIT_BRANCH:
-        print("Running on {}, skipping release note check.".format(DEFAULT_GIT_BRANCH))
+    if branch == DEFAULT_BRANCH:
+        print("Running on {}, skipping release note check.".format(DEFAULT_BRANCH))
     # Check if a releasenote has been added/changed
     elif pr_url:
         import requests
@@ -673,7 +672,7 @@ def lint_python(ctx):
     print(
         """Remember to set up pre-commit to lint your files before committing:
     https://github.com/DataDog/datadog-agent/blob/{}/docs/dev/agent_dev_env.md#pre-commit-hooks""".format(
-            DEFAULT_GIT_BRANCH
+            DEFAULT_BRANCH
         )
     )
 

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -13,6 +13,7 @@ from invoke import task
 
 # constants
 ORG_PATH = "github.com/DataDog"
+DEFAULT_BRANCH = "master"
 REPO_PATH = "{}/datadog-agent".format(ORG_PATH)
 
 


### PR DESCRIPTION
### What does this PR do?

- Refactor tasks code so that we have a single reference for the default branch of the `datadog-agent` repository. 
- Reword some comments so that they apply to any default branch name.

### Motivation

Make it easier to rename `master` to `main`

### Additional Notes

Reviews should double check that I am not missing any reference on `tasks`.
