### PR TITLE
[runtime-security] fix discarder retention with revision

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "6de1f96cc6be087a6c8271543923caec159d0b80b777737498315f2051496971")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "7909dd8d845fa28b82c1781ad7648d7ea32adb30adb9e71e0221ed043eb654c1")

--- a/pkg/security/ebpf/c/rename.h
+++ b/pkg/security/ebpf/c/rename.h
@@ -179,7 +179,7 @@ int __attribute__((always_inline)) dr_rename_callback(void *ctx, int retval) {
         .syscall.retval = retval,
         .old = syscall->rename.src_file,
         .new = syscall->rename.target_file,
-        .discarder_revision = bump_discarder_revision(syscall->rename.target_file.path_key.mount_id),
+        .discarder_revision = get_discarder_revision(syscall->rename.target_file.path_key.mount_id),
     };
 
     struct proc_cache_t *entry = fill_process_context(&event.process);

--- a/pkg/security/ebpf/c/rmdir.h
+++ b/pkg/security/ebpf/c/rmdir.h
@@ -130,7 +130,7 @@ int __attribute__((always_inline)) sys_rmdir_ret(void *ctx, int retval) {
         struct rmdir_event_t event = {
             .syscall.retval = retval,
             .file = syscall->rmdir.file,
-            .discarder_revision = bump_discarder_revision(syscall->rmdir.file.path_key.mount_id),
+            .discarder_revision = get_discarder_revision(syscall->rmdir.file.path_key.mount_id),
         };
 
         struct proc_cache_t *entry = fill_process_context(&event.process);

--- a/pkg/security/ebpf/c/unlink.h
+++ b/pkg/security/ebpf/c/unlink.h
@@ -111,7 +111,7 @@ int __attribute__((always_inline)) sys_unlink_ret(void *ctx, int retval) {
             .syscall.retval = retval,
             .file = syscall->unlink.file,
             .flags = syscall->unlink.flags,
-            .discarder_revision = bump_discarder_revision(syscall->unlink.file.path_key.mount_id),
+            .discarder_revision = get_discarder_revision(syscall->unlink.file.path_key.mount_id),
         };
 
         struct proc_cache_t *entry = fill_process_context(&event.process);

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -143,9 +143,9 @@ func newPidDiscarders(m *lib.Map, erpc *ERPC) *pidDiscarders {
 }
 
 type inodeDiscarder struct {
-	PathKey  PathKey
-	Revision uint32
-	Padding  uint32
+	PathKey PathKey
+	IsLeaf  uint32
+	Padding uint32
 }
 
 type inodeDiscarders struct {

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -269,6 +269,11 @@ func (p *Probe) unmarshalProcessContainer(data []byte, event *Event) (int, error
 }
 
 func (p *Probe) invalidateDentry(mountID uint32, inode uint64, revision uint32) {
+	// sanity check
+	if mountID == 0 || inode == 0 {
+		log.Errorf("invalid mount_id/inode tuple %d:%d", mountID, inode)
+	}
+
 	if p.resolvers.MountResolver.IsOverlayFS(mountID) {
 		log.Tracef("remove all dentry entries for mount id %d", mountID)
 		p.resolvers.DentryResolver.DelCacheEntries(mountID)

--- a/pkg/security/secl/eval/eval_operators.go
+++ b/pkg/security/secl/eval/eval_operators.go
@@ -881,7 +881,7 @@ func DurationLesserThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *sta
 		// optimize the evaluation if needed, moving the evaluation with more weight at the right
 
 		evalFnc := func(ctx *Context) bool {
-			return int64(ea(ctx)+eb(ctx)) > ctx.Now().UnixNano()
+			return ctx.Now().UnixNano()-int64(ea(ctx)) < int64(eb(ctx))
 		}
 
 		return &BoolEvaluator{
@@ -898,7 +898,7 @@ func DurationLesserThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *sta
 		_ = ctx
 
 		return &BoolEvaluator{
-			Value:     int64(ea+eb) > ctx.Now().UnixNano(),
+			Value:     ctx.Now().UnixNano()-int64(ea) < int64(eb),
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -913,7 +913,7 @@ func DurationLesserThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *sta
 		}
 
 		evalFnc := func(ctx *Context) bool {
-			return int64(ea(ctx)+eb) > ctx.Now().UnixNano()
+			return ctx.Now().UnixNano()-int64(ea(ctx)) < int64(eb)
 		}
 
 		return &BoolEvaluator{
@@ -932,7 +932,7 @@ func DurationLesserThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *sta
 	}
 
 	evalFnc := func(ctx *Context) bool {
-		return int64(ea+eb(ctx)) > ctx.Now().UnixNano()
+		return ctx.Now().UnixNano()-int64(ea) < int64(eb(ctx))
 	}
 
 	return &BoolEvaluator{
@@ -951,7 +951,7 @@ func DurationLesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, sta
 		// optimize the evaluation if needed, moving the evaluation with more weight at the right
 
 		evalFnc := func(ctx *Context) bool {
-			return int64(ea(ctx)+eb(ctx)) >= ctx.Now().UnixNano()
+			return ctx.Now().UnixNano()-int64(ea(ctx)) <= int64(eb(ctx))
 		}
 
 		return &BoolEvaluator{
@@ -968,7 +968,7 @@ func DurationLesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, sta
 		_ = ctx
 
 		return &BoolEvaluator{
-			Value:     int64(ea+eb) >= ctx.Now().UnixNano(),
+			Value:     ctx.Now().UnixNano()-int64(ea) <= int64(eb),
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -983,7 +983,7 @@ func DurationLesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, sta
 		}
 
 		evalFnc := func(ctx *Context) bool {
-			return int64(ea(ctx)+eb) >= ctx.Now().UnixNano()
+			return ctx.Now().UnixNano()-int64(ea(ctx)) <= int64(eb)
 		}
 
 		return &BoolEvaluator{
@@ -1002,7 +1002,7 @@ func DurationLesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, sta
 	}
 
 	evalFnc := func(ctx *Context) bool {
-		return int64(ea+eb(ctx)) >= ctx.Now().UnixNano()
+		return ctx.Now().UnixNano()-int64(ea) <= int64(eb(ctx))
 	}
 
 	return &BoolEvaluator{
@@ -1021,7 +1021,7 @@ func DurationGreaterThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *st
 		// optimize the evaluation if needed, moving the evaluation with more weight at the right
 
 		evalFnc := func(ctx *Context) bool {
-			return int64(ea(ctx)+eb(ctx)) < ctx.Now().UnixNano()
+			return ctx.Now().UnixNano()-int64(ea(ctx)) > int64(eb(ctx))
 		}
 
 		return &BoolEvaluator{
@@ -1038,7 +1038,7 @@ func DurationGreaterThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *st
 		_ = ctx
 
 		return &BoolEvaluator{
-			Value:     int64(ea+eb) < ctx.Now().UnixNano(),
+			Value:     ctx.Now().UnixNano()-int64(ea) > int64(eb),
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -1053,7 +1053,7 @@ func DurationGreaterThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *st
 		}
 
 		evalFnc := func(ctx *Context) bool {
-			return int64(ea(ctx)+eb) < ctx.Now().UnixNano()
+			return ctx.Now().UnixNano()-int64(ea(ctx)) > int64(eb)
 		}
 
 		return &BoolEvaluator{
@@ -1072,7 +1072,7 @@ func DurationGreaterThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *st
 	}
 
 	evalFnc := func(ctx *Context) bool {
-		return int64(ea+eb(ctx)) < ctx.Now().UnixNano()
+		return ctx.Now().UnixNano()-int64(ea) > int64(eb(ctx))
 	}
 
 	return &BoolEvaluator{
@@ -1091,7 +1091,7 @@ func DurationGreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, st
 		// optimize the evaluation if needed, moving the evaluation with more weight at the right
 
 		evalFnc := func(ctx *Context) bool {
-			return int64(ea(ctx)+eb(ctx)) <= ctx.Now().UnixNano()
+			return ctx.Now().UnixNano()-int64(ea(ctx)) >= int64(eb(ctx))
 		}
 
 		return &BoolEvaluator{
@@ -1108,7 +1108,7 @@ func DurationGreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, st
 		_ = ctx
 
 		return &BoolEvaluator{
-			Value:     int64(ea+eb) <= ctx.Now().UnixNano(),
+			Value:     ctx.Now().UnixNano()-int64(ea) >= int64(eb),
 			isPartial: isPartialLeaf,
 		}, nil
 	}
@@ -1123,7 +1123,7 @@ func DurationGreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, st
 		}
 
 		evalFnc := func(ctx *Context) bool {
-			return int64(ea(ctx)+eb) <= ctx.Now().UnixNano()
+			return ctx.Now().UnixNano()-int64(ea(ctx)) >= int64(eb)
 		}
 
 		return &BoolEvaluator{
@@ -1142,7 +1142,7 @@ func DurationGreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, st
 	}
 
 	evalFnc := func(ctx *Context) bool {
-		return int64(ea+eb(ctx)) <= ctx.Now().UnixNano()
+		return ctx.Now().UnixNano()-int64(ea) >= int64(eb(ctx))
 	}
 
 	return &BoolEvaluator{

--- a/pkg/security/secl/generators/operators/operators.go
+++ b/pkg/security/secl/generators/operators/operators.go
@@ -263,7 +263,7 @@ func Array{{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, opts *Opts, st
 
 	durationCompare := func(op string) func(a string, b string) string {
 		return func(a string, b string) string {
-			return fmt.Sprintf("int64(%s + %s) %s ctx.Now().UnixNano()", a, b, op)
+			return fmt.Sprintf("ctx.Now().UnixNano() - int64(%s) %s int64(%s)", a, op, b)
 		}
 	}
 
@@ -379,7 +379,7 @@ func Array{{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, opts *Opts, st
 				Arg2Type:       "IntEvaluator",
 				FuncReturnType: "BoolEvaluator",
 				EvalReturnType: "bool",
-				Op:             durationCompare(">"),
+				Op:             durationCompare("<"),
 				ValueType:      "ScalarValueType",
 			},
 			{
@@ -388,7 +388,7 @@ func Array{{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, opts *Opts, st
 				Arg2Type:       "IntEvaluator",
 				FuncReturnType: "BoolEvaluator",
 				EvalReturnType: "bool",
-				Op:             durationCompare(">="),
+				Op:             durationCompare("<="),
 				ValueType:      "ScalarValueType",
 			},
 			{
@@ -397,7 +397,7 @@ func Array{{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, opts *Opts, st
 				Arg2Type:       "IntEvaluator",
 				FuncReturnType: "BoolEvaluator",
 				EvalReturnType: "bool",
-				Op:             durationCompare("<"),
+				Op:             durationCompare(">"),
 				ValueType:      "ScalarValueType",
 			},
 			{
@@ -406,7 +406,7 @@ func Array{{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, opts *Opts, st
 				Arg2Type:       "IntEvaluator",
 				FuncReturnType: "BoolEvaluator",
 				EvalReturnType: "bool",
-				Op:             durationCompare("<="),
+				Op:             durationCompare(">="),
 				ValueType:      "ScalarValueType",
 			},
 		},

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -74,7 +74,7 @@ func TestProcessContext(t *testing.T) {
 		t.Fatal("unable to find proc entry")
 	}
 	execSince := time.Now().Sub(time.Unix(0, filledProc.CreateTime*int64(time.Millisecond)))
-	waitUntil := execSince + getEventTimeout + 2*time.Second
+	waitUntil := execSince + getEventTimeout + time.Second
 
 	ruleDefs := []*rules.RuleDefinition{
 		{
@@ -155,7 +155,7 @@ func TestProcessContext(t *testing.T) {
 		}
 
 		// ensure to exceed the delay
-		time.Sleep(4 * time.Second)
+		time.Sleep(2 * time.Second)
 
 		f, err = os.OpenFile(testFile, os.O_RDONLY, 0)
 		if err != nil {

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -74,7 +74,7 @@ func TestProcessContext(t *testing.T) {
 		t.Fatal("unable to find proc entry")
 	}
 	execSince := time.Now().Sub(time.Unix(0, filledProc.CreateTime*int64(time.Millisecond)))
-	waitUntil := execSince + getEventTimeout + time.Second
+	waitUntil := execSince + getEventTimeout + 2*time.Second
 
 	ruleDefs := []*rules.RuleDefinition{
 		{
@@ -153,6 +153,9 @@ func TestProcessContext(t *testing.T) {
 		if err == nil {
 			t.Error("shouldn't get an event")
 		}
+
+		// ensure to exceed the delay
+		time.Sleep(4 * time.Second)
 
 		f, err = os.OpenFile(testFile, os.O_RDONLY, 0)
 		if err != nil {

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -322,7 +322,7 @@ def docker_functional_tests(
     container_name = 'security-agent-tests'
     capabilities = ['SYS_ADMIN', 'SYS_RESOURCE', 'SYS_PTRACE', 'NET_ADMIN', 'IPC_LOCK', 'ALL']
 
-    cmd = 'docker run --name {container_name} {caps} --privileged -d '
+    cmd = 'docker run --name {container_name} {caps} --privileged -d --pid=host '
     cmd += '-v /proc:/host/proc -e HOST_PROC=/host/proc '
     cmd += '-v {GOPATH}/src/{REPO_PATH}/pkg/security/tests:/tests debian:bullseye sleep 3600'
 

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -59,6 +59,7 @@ if node['platform_family'] != 'windows'
       volumes ['/tmp/security-agent:/tmp/security-agent', '/proc:/host/proc', '/etc/os-release:/host/etc/os-release']
       env ['HOST_PROC=/host/proc', 'DOCKER_DD_AGENT=yes']
       privileged true
+      pid_mode 'host'
     end
 
     docker_exec 'debug_fs' do


### PR DESCRIPTION
### What does this PR do?

This PR fix the discarder retention logic removing the revision for the discarder key to place it in the params so that the retention still work even in case of an umount.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
