### PR TITLE
[runtime-security] Export eRPC debug metrics

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "7909dd8d845fa28b82c1781ad7648d7ea32adb30adb9e71e0221ed043eb654c1")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "cff4824aed66190218299b256b730cbd3aa7a2f6e799f5c0d2faf811c4c144b6")

--- a/pkg/security/ebpf/c/buffer_selector.h
+++ b/pkg/security/ebpf/c/buffer_selector.h
@@ -2,12 +2,13 @@
 #define _BUFFER_SELECTOR_H
 
 #define SYSCALL_MONITOR_KEY 0
+#define ERPC_MONITOR_KEY    1
 
 struct bpf_map_def SEC("maps/buffer_selector") buffer_selector = {
     .type = BPF_MAP_TYPE_ARRAY,
     .key_size = sizeof(u32),
     .value_size = sizeof(u32),
-    .max_entries = 1,
+    .max_entries = 2,
     .pinning = 0,
     .namespace = "",
 };

--- a/pkg/security/ebpf/map.go
+++ b/pkg/security/ebpf/map.go
@@ -10,6 +10,7 @@ package ebpf
 import (
 	"bytes"
 	"encoding/binary"
+
 	"github.com/DataDog/datadog-agent/pkg/security/model"
 )
 
@@ -86,4 +87,6 @@ var (
 var (
 	// BufferSelectorSyscallMonitorKey is the key used to select the active syscall monitor buffer key
 	BufferSelectorSyscallMonitorKey = ZeroUint32MapItem
+	// BufferSelectorERPCMonitorKey is the key used to select the active eRPC monitor buffer key
+	BufferSelectorERPCMonitorKey = Uint32MapItem(1)
 )

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -60,6 +60,9 @@ var (
 	// MetricDentryResolverMiss is the counter of unsuccessful dentry resolution
 	// Tags: cache, kernel_maps
 	MetricDentryResolverMiss = newRuntimeMetric(".dentry_resolver.miss")
+	// MetricDentryERPC is the counter of eRPC dentry resolution errors by error type
+	// Tags: ret
+	MetricDentryERPC = newRuntimeMetric(".dentry_resolver.erpc")
 
 	// Perf buffer metrics
 

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -95,11 +95,9 @@ func (m *Monitor) SendStats() error {
 		}
 	}
 
-	// Comment this out for now, until we fix the cardinality of the perf_buffer.* metrics.
-	//
-	//if err := m.perfBufferMonitor.SendStats(); err != nil {
-	//	return errors.Wrap(err, "failed to send events stats")
-	//}
+	if err := m.perfBufferMonitor.SendStats(); err != nil {
+		return errors.Wrap(err, "failed to send events stats")
+	}
 
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

This PR exports a new metric ( `datadog.runtime_security.dentry_resolver.erpc` ) to help understand eRPC errors. This metric is tagged with one of the following values:
- `ret:cache_miss`: the eRPC resolution failed because of a kernel map cache miss
- `ret:buffer_size`: the eRPC resolution failed because of a limited kernel space eRPC buffer
- `ret:major_page_fault`: the eRPC resolution failed because of a major page fault
- `ret:tail_call_error`: the eRPC resolution failed because of a tail call error
- `ret:unknown`: the eRPC resolution failed because of an unexpected return value of the `bpf_probe_write_user` helper

### Motivation

Provides visibility in the `dentry_resolver` metrics.
