### PR TITLE
remove IsContainerized check from logs agent launcher

### DIFF
--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -99,7 +99,7 @@ func NewAgent(sources *config.LogSources, services *service.Services, processing
 		traps.NewLauncher(sources, pipelineProvider),
 	}
 
-	// Only try to start the container launchers if we are in a container environment or docker is available
+	// Only try to start the container launchers if Docker or Kubernetes is available
 	if coreConfig.IsFeaturePresent(coreConfig.Docker) || coreConfig.IsFeaturePresent(coreConfig.Kubernetes) {
 		inputs = append(inputs, container.NewLauncher(containerLaunchables))
 	}

--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -100,7 +100,7 @@ func NewAgent(sources *config.LogSources, services *service.Services, processing
 	}
 
 	// Only try to start the container launchers if we are in a container environment or docker is available
-	if coreConfig.IsContainerized() || coreConfig.IsFeaturePresent(coreConfig.Docker) || coreConfig.IsFeaturePresent(coreConfig.Kubernetes) {
+	if coreConfig.IsFeaturePresent(coreConfig.Docker) || coreConfig.IsFeaturePresent(coreConfig.Kubernetes) {
 		inputs = append(inputs, container.NewLauncher(containerLaunchables))
 	}
 


### PR DESCRIPTION
### What does this PR do?

Remove `IsContainerized` check when trying to start K8s or docker launchers.
In testing we found that environments that are containerized but neither docker nor K8s will retry forever. We should instead rely only on feature detection. 

### Motivation

QA


### Describe how to test your changes

Run the agent in a containerized - non docker or K8s environment and make sure the launchers are not retried in the logs. 
