### PR TITLE
[log] increase default backoff delay

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -74,10 +74,10 @@ const (
 	DefaultLogsSenderBackoffFactor = 2.0
 
 	// DefaultLogsSenderBackoffBase is the default logs sender base backoff time, seconds
-	DefaultLogsSenderBackoffBase = 0.05
+	DefaultLogsSenderBackoffBase = 1.0
 
 	// DefaultLogsSenderBackoffMax is the default logs sender maximum backoff time, seconds
-	DefaultLogsSenderBackoffMax = 1.0
+	DefaultLogsSenderBackoffMax = 120.0
 
 	// DefaultLogsSenderBackoffRecoveryInterval is the default logs sender backoff recovery interval
 	DefaultLogsSenderBackoffRecoveryInterval = 2


### PR DESCRIPTION
### What does this PR do?

Increase default backoff delay to match that of TCP destinations. Followup to #8198.

### Describe how to test your changes

Configure a logs check.
Run the agent against a mock http server.
Stop the mock http server and verify that agent CPU usage remains stable.
Debug log should contain information about the retry delay, going up to around 2 minutes.