### PR TITLE
Remove cryptodome exclusion

### DIFF
--- a/Dockerfiles/agent/amd64/Dockerfile
+++ b/Dockerfiles/agent/amd64/Dockerfile
@@ -39,7 +39,6 @@ RUN find / -maxdepth 1 -type f -name 'datadog-agent*_amd64.deb' ! -name "$DD_AGE
     # ditto for this older libsystemd
     usr/lib/x86_64-linux-gnu/libsystemd.so.0.21.0 \
     # self-test certificates that are detected (false positive) as private keys
-    opt/datadog-agent/embedded/lib/python*/site-packages/Cryptodome/SelfTest \
     opt/datadog-agent/embedded/lib/python*/site-packages/future/backports/test \
  && if [ "$PYTHON_VERSION" = "2" ]; then \
         rm -rf \

--- a/Dockerfiles/agent/arm64/Dockerfile
+++ b/Dockerfiles/agent/arm64/Dockerfile
@@ -39,7 +39,6 @@ RUN find / -maxdepth 1 -type f -name 'datadog-agent*_arm64.deb' ! -name "$DD_AGE
     # ditto for this older libsystemd
     usr/lib/x86_64-linux-gnu/libsystemd.so.0.21.0 \
     # self-test certificates that are detected (false positive) as private keys
-    opt/datadog-agent/embedded/lib/python*/site-packages/Cryptodome/SelfTest \
     opt/datadog-agent/embedded/lib/python*/site-packages/future/backports/test \
  && if [ "$PYTHON_VERSION" = "2" ]; then \
         rm -rf \


### PR DESCRIPTION
### What does this PR do?

Remove cryptodome exclusion

### Motivation

The exclusion is not needed anymore since upgrade of pycryptodomex to 3.10+ :
https://github.com/DataDog/integrations-core/pull/9352

- https://github.com/Legrandin/pycryptodome/issues/431

> The bulk of the test vectors have been moved to the separate package pycryptodome-test-vectors. As result, packages pycryptodome and pycryptodomex become significantly smaller (from 14MB to 3MB).

https://github.com/Legrandin/pycryptodome/blob/master/Changelog.rst#other-changes-1

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
