### PR TITLE
Fix container_name tag after Docker container rename

### DIFF
--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -204,9 +204,9 @@ func (l *DockerListener) processEvent(e *docker.ContainerEvent) {
 
 	if found {
 		switch e.Action {
-		case "die":
+		case docker.ContainerEventActionDie:
 			l.removeService(cID)
-		case "start":
+		case docker.ContainerEventActionStart:
 			// Container restarted with the same ID within 5 seconds.
 			time.AfterFunc(5*time.Second, func() {
 				l.createService(cID)

--- a/pkg/autodiscovery/providers/docker.go
+++ b/pkg/autodiscovery/providers/docker.go
@@ -118,7 +118,7 @@ CONNECT:
 				// only these two event types will change what containers appear.
 				// Container labels cannot change once they are created, so we don't need to react on
 				// other lifecycle events.
-				if ev.Action == "start" {
+				if ev.Action == docker.ContainerEventActionStart {
 					container, err := d.dockerUtil.Inspect(ev.ContainerID, false)
 					if err != nil {
 						log.Warnf("Error inspecting container: %s", err)
@@ -135,7 +135,7 @@ CONNECT:
 							d.addLabels(ev.ContainerID, container.Config.Labels)
 						}
 					}
-				} else if ev.Action == "die" {
+				} else if ev.Action == docker.ContainerEventActionDie {
 					// delay for short lived detection
 					time.AfterFunc(delayDuration, func() {
 						d.Lock()

--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -102,10 +102,12 @@ func (c *DockerCollector) processEvent(e *docker.ContainerEvent) {
 	var info *TagInfo
 
 	switch e.Action {
-	case "die":
+	case docker.ContainerEventActionDie:
 		info = &TagInfo{Entity: e.ContainerEntityName(), Source: dockerCollectorName, DeleteEntity: true}
-	case "start", "rename":
-		low, orchestrator, high, standard, err := c.fetchForDockerID(e.ContainerID, e.Action == "start")
+	case docker.ContainerEventActionStart, docker.ContainerEventActionRename:
+		inspectCached := e.Action == docker.ContainerEventActionStart
+		low, orchestrator, high, standard, err := c.fetchForDockerID(e.ContainerID, inspectCached)
+
 		if err != nil {
 			log.Debugf("Error fetching tags for container '%s': %v", e.ContainerName, err)
 		}

--- a/pkg/util/docker/docker_util.go
+++ b/pkg/util/docker/docker_util.go
@@ -235,8 +235,25 @@ func (d *DockerUtil) Inspect(id string, withSize bool) (types.ContainerJSON, err
 			return container, nil
 		}
 	}
+
+	container, err := d.InspectNoCache(id, withSize)
+	if err != nil {
+		return container, err
+	}
+
+	// cache the inspect for 10 seconds to reduce pressure on the daemon
+	cache.Cache.Set(cacheKey, container, 10*time.Second)
+
+	return container, nil
+}
+
+// InspectNoCache returns a docker inspect object for a given container ID. It
+// ignores the inspect cache, always collecting fresh data from the docker
+// daemon.
+func (d *DockerUtil) InspectNoCache(id string, withSize bool) (types.ContainerJSON, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), d.queryTimeout)
 	defer cancel()
+
 	container, _, err := d.cli.ContainerInspectWithRaw(ctx, id, withSize)
 	if client.IsErrNotFound(err) {
 		return container, dderrors.NewNotFound(fmt.Sprintf("docker container %s", id))
@@ -244,12 +261,11 @@ func (d *DockerUtil) Inspect(id string, withSize bool) (types.ContainerJSON, err
 	if err != nil {
 		return container, err
 	}
+
 	// ContainerJSONBase is a pointer embed, so it might be nil and cause segfaults
 	if container.ContainerJSONBase == nil {
 		return container, errors.New("invalid inspect data")
 	}
-	// cache the inspect for 10 seconds to reduce pressure on the daemon
-	cache.Cache.Set(cacheKey, container, 10*time.Second)
 
 	return container, nil
 }

--- a/pkg/util/docker/event_pull.go
+++ b/pkg/util/docker/event_pull.go
@@ -83,19 +83,20 @@ func (d *DockerUtil) processContainerEvent(msg events.Message) (*ContainerEvent,
 		ns = ns - msg.Time*1e9
 	}
 
-	// Not filtered, return event
+	action := msg.Action
+
+	// Fix the "exec_start: /bin/sh -c true" case
+	if strings.Contains(action, ":") {
+		action = strings.SplitN(action, ":", 2)[0]
+	}
+
 	event := &ContainerEvent{
 		ContainerID:   msg.Actor.ID,
 		ContainerName: containerName,
 		ImageName:     imageName,
-		Action:        msg.Action,
+		Action:        action,
 		Timestamp:     time.Unix(msg.Time, ns),
 		Attributes:    msg.Actor.Attributes,
-	}
-
-	// Fix the "exec_start: /bin/sh -c true" case
-	if strings.Contains(event.Action, ":") {
-		event.Action = strings.SplitN(event.Action, ":", 2)[0]
 	}
 
 	return event, nil

--- a/pkg/util/docker/event_stream.go
+++ b/pkg/util/docker/event_stream.go
@@ -81,6 +81,7 @@ func (d *DockerUtil) dispatchEvents(sub *eventSubscriber) {
 	fltrs.Add("type", "container")
 	fltrs.Add("event", "start")
 	fltrs.Add("event", "die")
+	fltrs.Add("event", "rename")
 
 	// On initial subscribe, don't go back in time. On reconnect, we'll
 	// resume at the latest timestamp we got.

--- a/pkg/util/docker/event_types.go
+++ b/pkg/util/docker/event_types.go
@@ -13,6 +13,15 @@ import (
 	"time"
 )
 
+const (
+	// ContainerEventActionStart is the action of starting a docker container
+	ContainerEventActionStart = "start"
+	// ContainerEventActionDie is the action of stopping a docker container
+	ContainerEventActionDie = "die"
+	// ContainerEventActionRename is the action of renaming a docker container
+	ContainerEventActionRename = "rename"
+)
+
 // ContainerEvent describes an event from the docker daemon
 type ContainerEvent struct {
 	ContainerID   string


### PR DESCRIPTION
### What does this PR do?

This is a follow up to the changes introduced in #842. It includes `rename` events in the filter, and bypasses the inspect cache when a `rename` event is received.

### Describe how to test your changes

Same as #8142 