### PR TITLE
Update config.md

### DIFF
--- a/docs/agent/config.md
+++ b/docs/agent/config.md
@@ -1,6 +1,5 @@
 # Configuration Options
 
-This information is available in the Datadog documentation:<br>
-[docs.datadoghq.com/agent/versions][1]
+See the [config_template.yaml][1] file for a list of configuration options and examples.
 
-[1]: https://docs.datadoghq.com/agent/versions
+[1]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml


### PR DESCRIPTION
### What does this PR do?

Links to the `config_template.yaml` file as we are incorrectly linking to versions, which does not have reference to configuration options.

### Motivation

We're currently in the process of updating documentation to make it easier for users to reference the config template examples. However, in the interim, updating to the config template link so user have access to examples.
