### PR TITLE
[process-agent] Remove getting root network namespace from process-agent

### DIFF
--- a/pkg/process/net/resolver/resolver.go
+++ b/pkg/process/net/resolver/resolver.go
@@ -118,10 +118,6 @@ func (l *LocalResolver) Resolve(c *model.Connections) {
 
 	log.Tracef("ctrsByLaddr = %v", ctrsByLaddr)
 
-	rootNs, err := procutil.GetNetNsInoFromPid(procutil.HostProc(), 1)
-	if err != nil {
-		log.Errorf("failed to get root network namespace, some loopback resolution will not be possible: %s", err)
-	}
 	// go over connections again using hashtable computed earlier to resolver raddr
 	for _, conn := range c.Conns {
 		if conn.Raddr.ContainerId == "" {
@@ -133,14 +129,8 @@ func (l *LocalResolver) Resolve(c *model.Connections) {
 
 			// first match within net namespace
 			cid, ok := ctrsByLaddr[addrWithNS{raddr, conn.NetNS}]
-			if ok {
-				// done
-			} else if !ip.IsLoopback() {
+			if !ok && !ip.IsLoopback() {
 				cid, _ = ctrsByLaddr[addrWithNS{raddr, 0}]
-			} else {
-				// raddr is loopback, try the root NS (already tried the local
-				// NS above)
-				cid, _ = ctrsByLaddr[addrWithNS{raddr, rootNs}]
 			}
 
 			conn.Raddr.ContainerId = cid

--- a/pkg/process/net/resolver/resolver_linux_test.go
+++ b/pkg/process/net/resolver/resolver_linux_test.go
@@ -308,7 +308,7 @@ func TestResolveLoopbackConnections(t *testing.T) {
 				},
 			},
 			expectedLaddrID: "foo20",
-			expectedRaddrID: "foo21",
+			expectedRaddrID: "",
 		},
 		{
 			name: "cross namespace with dnat to loopback",


### PR DESCRIPTION
### What does this PR do?

`process-agent` does not have the elevated permissions needed for this, so it always fails

### Motivation

Excessive logging of messages like this:

```2021-06-02 17:41:05 UTC | PROCESS | ERROR | (pkg/process/net/resolver/resolver.go:123 in Resolve) | failed to get root network namespace, some loopback resolution will not be possible: permission denied```

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
