### PR TITLE
[process-agent] Small improvements for chunking config and log trace

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -802,6 +802,7 @@ func InitConfig(config Config) {
 	config.SetKnown("process_config.intervals.process_realtime")
 	config.SetKnown("process_config.queue_size")
 	config.SetKnown("process_config.max_per_message")
+	config.SetKnown("process_config.max_ctr_procs_per_message")
 	config.SetKnown("process_config.intervals.process")
 	config.SetKnown("process_config.blacklist_patterns")
 	config.SetKnown("process_config.intervals.container")

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -260,7 +260,7 @@ func packProcCtrMessages(
 		msgs = append(msgs, msgFn(ctrProcs, ctrs...))
 	}
 
-	log.Debugf("Created %d container process messages", len(msgs))
+	log.Tracef("Created %d container process messages", len(msgs))
 
 	return msgs
 }

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -387,6 +387,8 @@ func loadEnvVariables() {
 		{"DD_PROCESS_AGENT_URL", "process_config.process_dd_url"},
 		{"DD_PROCESS_AGENT_INTERNAL_PROFILING_ENABLED", "process_config.internal_profiling.enabled"},
 		{"DD_PROCESS_AGENT_REMOTE_TAGGER", "process_config.remote_tagger"},
+		{"DD_PROCESS_AGENT_MAX_PER_MESSAGE", "process_config.max_per_message"},
+		{"DD_PROCESS_AGENT_MAX_CTR_PROCS_PER_MESSAGE", "process_config.max_ctr_procs_per_message"},
 		{"DD_ORCHESTRATOR_URL", "orchestrator_explorer.orchestrator_dd_url"},
 		{"DD_HOSTNAME", "hostname"},
 		{"DD_DOGSTATSD_PORT", "dogstatsd_port"},

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -108,6 +108,14 @@ func TestOnlyEnvConfig(t *testing.T) {
 	agentConfig, _ = NewAgentConfig("test", "", "")
 	assert.Equal(t, "apikey_from_env", agentConfig.APIEndpoints[0].APIKey)
 	assert.False(t, agentConfig.Enabled)
+
+	os.Setenv("DD_PROCESS_AGENT_MAX_PER_MESSAGE", "99")
+	agentConfig, _ = NewAgentConfig("test", "", "")
+	assert.Equal(t, 99, agentConfig.MaxPerMessage)
+
+	os.Setenv("DD_PROCESS_AGENT_MAX_CTR_PROCS_PER_MESSAGE", "1234")
+	agentConfig, _ = NewAgentConfig("test", "", "")
+	assert.Equal(t, 1234, agentConfig.MaxCtrProcessesPerMessage)
 }
 
 func TestOnlyEnvConfigArgsScrubbingEnabled(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Follow-up for https://github.com/DataDog/datadog-agent/pull/7902.

- Allow env var config for `max_per_message` and `max_ctr_procs_per_message`.
- Lower log on chunked messages to Trace level.

### Motivation

Allow configuration via env vars in K8s and other envs where config file could be cumbersome.

### Describe how to test your changes

Make sure that these env vars can be set and take effect when set via helm chart.
