### PR TITLE
[runtime-security] allow more granularity for trace log

### DIFF
--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -99,7 +99,7 @@ func checkPolicies(cmd *cobra.Command, args []string) error {
 	// enabled all the rules
 	enabled := map[eval.EventType]bool{"*": true}
 
-	opts := rules.NewOptsWithParams(model.SECLConstants, sprobe.SupportedDiscarders, enabled, sprobe.AllCustomRuleIDs(), model.SECLLegacyAttributes, securityLogger.DatadogAgentLogger{})
+	opts := rules.NewOptsWithParams(model.SECLConstants, sprobe.SupportedDiscarders, enabled, sprobe.AllCustomRuleIDs(), model.SECLLegacyAttributes, &securityLogger.PatternLogger{})
 	model := &model.Model{}
 	ruleSet := rules.NewRuleSet(model, model.NewEvent, opts)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -892,6 +892,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.agent_monitoring_events", true)
 	config.BindEnvAndSetDefault("runtime_security_config.custom_sensitive_words", []string{})
 	config.BindEnvAndSetDefault("runtime_security_config.remote_tagger", true)
+	config.BindEnvAndSetDefault("runtime_security_config.log_patterns", []string{})
 	bindEnvAndSetLogsConfigKeys(config, "runtime_security_config.endpoints.")
 
 	// Serverless Agent

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -80,6 +80,8 @@ type Config struct {
 	RemoteTaggerEnabled bool
 	// HostServiceName string
 	HostServiceName string
+	// LogTags tags to be used by the logger for trace level
+	LogPatterns []string
 }
 
 // IsEnabled returns true if any feature is enabled. Has to be applied in config package too
@@ -116,6 +118,7 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 		ERPCDentryResolutionEnabled:        aconfig.Datadog.GetBool("runtime_security_config.erpc_dentry_resolution_enabled"),
 		MapDentryResolutionEnabled:         aconfig.Datadog.GetBool("runtime_security_config.map_dentry_resolution_enabled"),
 		RemoteTaggerEnabled:                aconfig.Datadog.GetBool("runtime_security_config.remote_tagger"),
+		LogPatterns:                        aconfig.Datadog.GetStringSlice("runtime_security_config.log_patterns"),
 	}
 
 	// if runtime is enabled then we force fim

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -80,7 +80,7 @@ type Config struct {
 	RemoteTaggerEnabled bool
 	// HostServiceName string
 	HostServiceName string
-	// LogTags tags to be used by the logger for trace level
+	// LogPatterns pattern to be used by the logger for trace level
 	LogPatterns []string
 }
 

--- a/pkg/security/log/logger.go
+++ b/pkg/security/log/logger.go
@@ -5,28 +5,166 @@
 
 package log
 
-import "github.com/DataDog/datadog-agent/pkg/util/log"
+import (
+	"fmt"
+	"regexp"
+	"runtime"
+	"strings"
+	"sync"
 
-// DatadogAgentLogger is a wrapper for the agent logger that we use to prevent a dependency on packages that we cannot
-// import outside of the agent repository
-type DatadogAgentLogger struct{}
+	"github.com/cihub/seelog"
 
-// Tracef is used to print a trace level log
-func (l DatadogAgentLogger) Tracef(format string, params ...interface{}) {
-	log.Tracef(format, params...)
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	Wildcard = "*"
+	depth    = 4
+)
+
+// used to extract package.struct.func from the caller
+var re = regexp.MustCompile(`[^\.]*\/([^\.]*)\.\(?\*?([^\.\)]*)\)?\.(.*)$`)
+
+// PatternLogger is a wrapper for the agent logger that add a level of filtering to trace log level
+type PatternLogger struct {
+	sync.RWMutex
+
+	re       *regexp.Regexp
+	patterns [][]string
+}
+
+func (l *PatternLogger) match(els []string) bool {
+LOOP:
+	for _, pattern := range l.patterns {
+		for i, node := range pattern {
+			if node == Wildcard {
+				continue
+			}
+
+			if i >= len(els) {
+				break
+			}
+
+			if node != els[i] {
+				continue LOOP
+			}
+		}
+
+		return true
+	}
+
+	return false
+}
+
+func (l *PatternLogger) trace(format string, params ...interface{}) {
+	pc, _, _, ok := runtime.Caller(3)
+	if !ok {
+		return
+	}
+	details := runtime.FuncForPC(pc)
+	if details == nil {
+		return
+	}
+
+	els := re.FindStringSubmatch(details.Name())
+	if len(els) != 4 {
+		return
+	}
+
+	l.RLock()
+	active := l.match(els[1:])
+	l.RUnlock()
+
+	if active {
+		log.TraceStackDepth(depth, fmt.Sprintf(format, params...))
+	}
+}
+
+// TraceTag is used to print a trace level log
+func (l *PatternLogger) Trace(v interface{}) {
+	if logLevel, err := log.GetLogLevel(); err != nil || logLevel != seelog.TraceLvl {
+		return
+	}
+
+	l.trace("%v", v)
+}
+
+// TraceTagf is used to print a trace level log
+func (l *PatternLogger) Tracef(format string, params ...interface{}) {
+	if logLevel, err := log.GetLogLevel(); err != nil || logLevel != seelog.TraceLvl {
+		return
+	}
+
+	l.trace(format, params...)
 }
 
 // Debugf is used to print a trace level log
-func (l DatadogAgentLogger) Debugf(format string, params ...interface{}) {
+func (l *PatternLogger) Debugf(format string, params ...interface{}) {
 	log.Debugf(format, params...)
 }
 
 // Errorf is used to print an error
-func (l DatadogAgentLogger) Errorf(format string, params ...interface{}) {
+func (l *PatternLogger) Errorf(format string, params ...interface{}) {
 	_ = log.Errorf(format, params...)
 }
 
+// Warnf is used to print a warn
+func (l *PatternLogger) Warnf(format string, params ...interface{}) {
+	log.Warnf(format, params...)
+}
+
 // Infof is used to print an error
-func (l DatadogAgentLogger) Infof(format string, params ...interface{}) {
+func (l *PatternLogger) Infof(format string, params ...interface{}) {
 	log.Infof(format, params...)
+}
+
+// SetPatterns set pattern
+func (l *PatternLogger) SetPatterns(patterns []string) {
+	l.Lock()
+	for _, pattern := range patterns {
+		l.patterns = append(l.patterns, strings.Split(pattern, "."))
+	}
+	l.Unlock()
+}
+
+// DefaultLogger default logger of this package
+var DefaultLogger *PatternLogger
+
+// Debugf is used to print a trace level log
+func Debugf(format string, params ...interface{}) {
+	DefaultLogger.Debugf(format, params...)
+}
+
+// Errorf is used to print an error
+func Errorf(format string, params ...interface{}) {
+	DefaultLogger.Errorf(format, params...)
+}
+
+// Warnf is used to print a warn
+func Warnf(format string, params ...interface{}) {
+	DefaultLogger.Warnf(format, params...)
+}
+
+// Infof is used to print an error
+func Infof(format string, params ...interface{}) {
+	DefaultLogger.Infof(format, params...)
+}
+
+// Tracef is used to print an trace
+func Tracef(format string, params ...interface{}) {
+	DefaultLogger.Tracef(format, params...)
+}
+
+// Trace is used to print an trace
+func Trace(v interface{}) {
+	DefaultLogger.Trace(v)
+}
+
+// SetPatterns set patterns
+func SetPatterns(patterns []string) {
+	DefaultLogger.SetPatterns(patterns)
+}
+
+func init() {
+	DefaultLogger = &PatternLogger{}
 }

--- a/pkg/security/log/logger.go
+++ b/pkg/security/log/logger.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	Wildcard = "*"
+	wildcard = "*"
 	depth    = 4
 )
 
@@ -29,7 +29,6 @@ var re = regexp.MustCompile(`[^\.]*\/([^\.]*)\.\(?\*?([^\.\)]*)\)?\.(.*)$`)
 type PatternLogger struct {
 	sync.RWMutex
 
-	re       *regexp.Regexp
 	patterns [][]string
 }
 
@@ -37,7 +36,7 @@ func (l *PatternLogger) match(els []string) bool {
 LOOP:
 	for _, pattern := range l.patterns {
 		for i, node := range pattern {
-			if node == Wildcard {
+			if node == wildcard {
 				continue
 			}
 
@@ -80,7 +79,7 @@ func (l *PatternLogger) trace(format string, params ...interface{}) {
 	}
 }
 
-// TraceTag is used to print a trace level log
+// Trace is used to print a trace level log
 func (l *PatternLogger) Trace(v interface{}) {
 	if logLevel, err := log.GetLogLevel(); err != nil || logLevel != seelog.TraceLvl {
 		return
@@ -89,7 +88,7 @@ func (l *PatternLogger) Trace(v interface{}) {
 	l.trace("%v", v)
 }
 
-// TraceTagf is used to print a trace level log
+// Tracef is used to print a trace level log
 func (l *PatternLogger) Tracef(format string, params ...interface{}) {
 	if logLevel, err := log.GetLogLevel(); err != nil || logLevel != seelog.TraceLvl {
 		return

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/security/api"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
+	seclog "github.com/DataDog/datadog-agent/pkg/security/log"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
@@ -233,7 +234,7 @@ func (a *APIServer) SendEvent(rule *rules.Rule, event Event, extTagsCb func() []
 
 	data := append(probeJSON[:len(probeJSON)-1], ',')
 	data = append(data, ruleEventJSON[1:]...)
-	log.Tracef("Sending event message for rule `%s` to security-agent `%s`", rule.ID, string(data))
+	seclog.Tracef("Sending event message for rule `%s` to security-agent `%s`", rule.ID, string(data))
 
 	msg := &pendingMsg{
 		ruleID:    rule.Definition.ID,
@@ -266,7 +267,7 @@ func (a *APIServer) expireEvent(msg *api.SecurityEventMessage) {
 	if ok {
 		atomic.AddInt64(count, 1)
 	}
-	log.Tracef("the event server channel is full, an event of ID %v was dropped", msg.RuleID)
+	seclog.Tracef("the event server channel is full, an event of ID %v was dropped", msg.RuleID)
 }
 
 // GetStats returns a map indexed by ruleIDs that describes the amount of events

--- a/pkg/security/probe/kfilters_test.go
+++ b/pkg/security/probe/kfilters_test.go
@@ -44,49 +44,49 @@ func TestIsParentDiscarder(t *testing.T) {
 
 	enabled := map[eval.EventType]bool{"*": true}
 
-	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
+	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/var/log/datadog/system-probe.log"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/datadog/system-probe.sock"); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path == "/var/log/datadog/system-probe.log"`, `unlink.file.name == "datadog"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/var/log/datadog/datadog-agent.log"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.name =~ ".*"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/.runc/1234"); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path == "/etc/conf.d/httpd.conf" || unlink.file.name == "conf.d"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/nginx.conf"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path == "/etc/conf.d/httpd.conf" || unlink.file.name == "sys.d"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/sys.d/nginx.conf"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.name == "conf.d"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/nginx.conf"); is {
@@ -94,56 +94,56 @@ func TestIsParentDiscarder(t *testing.T) {
 	}
 
 	// field that doesn't exists shouldn't return any discarders
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `rename.file.path == "/etc/conf.d/abc"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileRenameEventType, "rename.file.path", "/etc/conf.d/nginx.conf"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `rename.file.path == "/etc/conf.d/abc"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileRenameEventType, "rename.file.path", "/etc/nginx/nginx.conf"); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/conf.d/*"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/sys.d/nginx.conf"); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.*"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/conf.d/ab*"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.d/ab*"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.d"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/*"`)
 
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/cron.d/log"); is {
@@ -154,7 +154,7 @@ func TestIsParentDiscarder(t *testing.T) {
 func TestApproverAncestors1(t *testing.T) {
 	enabled := map[eval.EventType]bool{"*": true}
 	m := &model.Model{}
-	rs := rules.NewRuleSet(m, m.NewEvent, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
+	rs := rules.NewRuleSet(m, m.NewEvent, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `open.file.path == "/etc/passwd" && process.ancestors.file.name == "vipw"`, `open.file.path == "/etc/shadow" && process.ancestors.file.name == "vipw"`)
 
 	capabilities, exists := allCapabilities["open"]
@@ -175,7 +175,7 @@ func TestApproverAncestors1(t *testing.T) {
 func TestApproverAncestors2(t *testing.T) {
 	enabled := map[eval.EventType]bool{"*": true}
 	m := &model.Model{}
-	rs := rules.NewRuleSet(m, m.NewEvent, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, log.DatadogAgentLogger{}))
+	rs := rules.NewRuleSet(m, m.NewEvent, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `(open.file.path == "/etc/shadow" || open.file.path == "/etc/gshadow") && process.ancestors.file.path not in ["/usr/bin/dpkg"]`)
 	capabilities, exists := allCapabilities["open"]
 	if !exists {

--- a/pkg/security/probe/load_controller.go
+++ b/pkg/security/probe/load_controller.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-go/statsd"
 	"github.com/hashicorp/golang-lru/simplelru"
 
+	seclog "github.com/DataDog/datadog-agent/pkg/security/log"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/model"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -116,7 +117,7 @@ func (lc *LoadController) discardNoisiestProcess() {
 	}
 
 	// push a temporary discarder on the noisiest process & event type tuple
-	log.Tracef("discarding events from pid %d for %s seconds", maxKey.Pid, lc.DiscarderTimeout)
+	seclog.Tracef("discarding events from pid %d for %s seconds", maxKey.Pid, lc.DiscarderTimeout)
 	if err := lc.probe.pidDiscarders.discardWithTimeout(0xffffffffffffffff, maxKey.Pid, lc.DiscarderTimeout.Nanoseconds()); err != nil {
 		log.Warnf("couldn't insert temporary discarder: %v", err)
 		return

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/hashicorp/go-multierror"
 
+	seclog "github.com/DataDog/datadog-agent/pkg/security/log"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -134,7 +135,7 @@ func (m *Monitor) ProcessEvent(event *Event, size uint64, CPU int, perfMap *mana
 
 // ProcessLostEvent processes a lost event through the various monitors and controllers of the probe
 func (m *Monitor) ProcessLostEvent(count uint64, cpu int, perfMap *manager.PerfMap) {
-	log.Tracef("lost %d events\n", count)
+	seclog.Tracef("lost %d events\n", count)
 	m.perfBufferMonitor.CountLostEvent(count, perfMap, cpu)
 }
 

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -27,10 +27,10 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
+	seclog "github.com/DataDog/datadog-agent/pkg/security/log"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/model"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -819,7 +819,7 @@ func (p *ProcessResolver) syncCache(proc *process.Process) (*model.ProcessCacheE
 
 	// update the cache entry
 	if err := p.enrichEventFromProc(entry, proc); err != nil {
-		log.Trace(err)
+		seclog.Trace(err)
 		return nil, false
 	}
 
@@ -832,7 +832,7 @@ func (p *ProcessResolver) syncCache(proc *process.Process) (*model.ProcessCacheE
 		return nil, false
 	}
 
-	log.Tracef("New process cache entry added: %s %s %d/%d", entry.Comm, entry.PathnameStr, pid, entry.FileFields.Inode)
+	seclog.Tracef("New process cache entry added: %s %s %d/%d", entry.Comm, entry.PathnameStr, pid, entry.FileFields.Inode)
 
 	return entry, true
 }


### PR DESCRIPTION
### What does this PR do?

Add a way to filter trace level log based on config parameter where you can specify <package>.<obj>.<func> that will actually log.

### Motivation

Due the high number of event generated it is almost impossible to use only the log level to determine what log to activate. This add more granularity.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
