### PR TITLE
[diagnostic] fix infinite loop

### DIFF
--- a/pkg/logs/diagnostic/message_receiver.go
+++ b/pkg/logs/diagnostic/message_receiver.go
@@ -107,7 +107,7 @@ func (b *BufferedMessageReceiver) Filter(filters *Filters, done <-chan struct{})
 					out <- formatMessage(msgPair.msg, msgPair.redactedMsg)
 				}
 			case <-done:
-				break
+				return
 			}
 		}
 	}()


### PR DESCRIPTION
### What does this PR do?

Fix busy loop when `stream-logs` client is disconnected. Stop the filter goroutine instead of spinning inside the for loop forever.

### Describe how to test your changes

Enable logs agent and add some logs.
Check that stream-logs works as intended.
Stop with ^C and check that `agent run` cpu usage does not increase.