### PR TITLE
[runtime-security] add group_id to rule definition

### DIFF
--- a/pkg/security/rules/ruleset.go
+++ b/pkg/security/rules/ruleset.go
@@ -37,6 +37,7 @@ type RuleID = string
 // RuleDefinition holds the definition of a rule
 type RuleDefinition struct {
 	ID          RuleID            `yaml:"id"`
+	GroupID     RuleID            `yaml:"group_id"`
 	Version     string            `yaml:"version"`
 	Expression  string            `yaml:"expression"`
 	Description string            `yaml:"description"`

--- a/releasenotes/notes/runtime-security-group-id-717907b020fcdef7.yaml
+++ b/releasenotes/notes/runtime-security-group-id-717907b020fcdef7.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Runtime Security introduces a new field in the rule definition `group_id`
+    that will be used as `rule_id` for event sent if present. This add the
+    ability to group rules.


### PR DESCRIPTION
### What does this PR do?

Add an extra `group_id` field to rule definition which if present will be used as `rule_id` for the events sent to the backend. 

### Motivation

Be able to group rules having the same goal, namely monitoring all the possible access of a file.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
