### PR TITLE
[pipeline notifications] Enable notifications for individual jobs

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -14,6 +14,10 @@ build_system-probe*                  @DataDog/agent-network
 cluster_agent_cloudfoundry-build*    @Datadog/integrations-tools-and-libs
 cluster_agent-build*                 @DataDog/container-integrations
 
+# Kitchen testing
+# Don't notify on kitchen Windows tests since they are too flaky
+kitchen_windows_*                    @DataDog/do-not-notify
+
 # Image build
 docker_build*                        @DataDog/container-integrations
 

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -323,9 +323,7 @@ def generate_failure_messages(base):
             # message, do not overwrite the failed jobs list
             pass
         else:
-            pass
-            # TODO: enable also jobs
-            # messages_to_send[owner].failed_jobs = jobs
+            messages_to_send[owner].failed_jobs = jobs
 
     return messages_to_send
 


### PR DESCRIPTION
### What does this PR do?

- Enable pipeline notifications for jobs
- Ignore notifications for Kitchen Windows tests since they are currently too flaky

### Motivation

- Keep pipeline green
