### PR TITLE
[gui] cleanup style for logs input list

### DIFF
--- a/cmd/agent/gui/views/private/css/stylesheet.css
+++ b/cmd/agent/gui/views/private/css/stylesheet.css
@@ -319,6 +319,11 @@ a {
   padding-left: 20px;
   padding-bottom: 20px;
 }
+#main #general_status .stat .stat_subdata ul, #main #collector_status .stat .stat_subdata ul {
+  display: block;
+  margin: 0;
+  padding: 0 0 0 20px;
+}
 #main #general_status .stat .error, #main #collector_status .stat .error {
   color: red;
   font-weight: bold;

--- a/cmd/agent/gui/views/private/css/stylesheet.scss
+++ b/cmd/agent/gui/views/private/css/stylesheet.scss
@@ -381,6 +381,12 @@ a {
         padding-bottom: 20px;
       }
 
+      .stat_subdata ul {
+        display: block;
+        margin: 0;
+        padding: 0 0 0 20px;
+      }
+
       .error {
         color: red;
         font-weight: bold;

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -343,9 +343,11 @@
             {{- end }}
             {{- if .inputs }}
             Inputs:
-            {{- range $input := .inputs }}
-              {{$input}}<br>
-            {{- end }}</br>
+            <ul>
+              {{- range $input := .inputs }}
+                <li>{{$input}}
+              {{- end }}
+            </ul>
             {{- end }}
             BytesRead: {{ .bytes_read }}</br>
             Average Latency (ms): {{ .all_time_avg_latency }}</br>


### PR DESCRIPTION

### What does this PR do?

- put first item on a line of its own
- remove margin after the list
- add indentation for list items

### Describe how to test your changes

Enable logs and add some log files.
Run the agent.
Open the status page, check that the files are displayed one per line, with no unnecessary space around.