### PR TITLE
[dogstatsd] capture: fix deadlock on shallow channels and shutdown

### DIFF
--- a/pkg/dogstatsd/replay/writer.go
+++ b/pkg/dogstatsd/replay/writer.go
@@ -205,6 +205,10 @@ process:
 			}
 		case <-tc.shutdown:
 			log.Debug("Capture shutting down")
+			tc.Lock()
+			tc.shutdown = nil
+			tc.Unlock()
+
 			break process
 		}
 	}
@@ -231,12 +235,16 @@ cleanup:
 		log.Warnf("Wrote %d bytes for capture tagger state", n)
 	}
 
+	tc.Lock()
+	defer tc.Unlock()
 	err = tc.writer.Flush()
 	if err != nil {
 		log.Errorf("There was an error flushing the underlying writer while stopping the capture: %v", err)
 	}
 
 	tc.File.Close()
+	tc.ongoing = false
+
 }
 
 // StopCapture stops the ongoing capture if in process.
@@ -255,8 +263,9 @@ func (tc *TrafficCaptureWriter) StopCapture() {
 		tc.oobPacketPoolManager.SetPassthru(true)
 	}
 
-	close(tc.shutdown)
-	tc.ongoing = false
+	if tc.shutdown != nil {
+		close(tc.shutdown)
+	}
 
 	log.Debug("Capture was stopped")
 }

--- a/pkg/dogstatsd/replay/writer.go
+++ b/pkg/dogstatsd/replay/writer.go
@@ -265,12 +265,10 @@ func (tc *TrafficCaptureWriter) StopCapture() {
 func (tc *TrafficCaptureWriter) Enqueue(msg *CaptureBuffer) bool {
 	qd := false
 
-	tc.RLock()
-	if tc.ongoing {
+	if tc.IsOngoing() {
 		tc.Traffic <- msg
 		qd = true
 	}
-	tc.RUnlock()
 
 	return qd
 }


### PR DESCRIPTION
### What does this PR do?

There was previously a deadlock situation while holding an `RLock()` over a write operation to a channel. Because the main loop needed to read from that channel, and the `StopCapture()` method needs to hold a `Lock()`, we ended up in a situation where no more traffic could be processed.

This also improves the shutdown a little bit, just to make sure we don't launch new captures before we're actually done flushing and closing the file descriptor, as well as making `StopCapture()` idempotent.

### Motivation

Fix deadlock situation.

### Additional Notes

The races appear to be gone as evidenced by a `-race` build.

### Describe how to test your changes

This should be easy to test; to reproduce with a buggy version a channel depth of zero for the capture on a machine with GOMAXPROCS>1 could easily lead to a deadlock when throughput is relatively high (just launch a few captures and you should eventually hit the problem). With this fix, captures should wrap up cleanly and avoid any kind of deadlock.
