### PR TITLE
[networks] Allow routes to be registered multiple times

### DIFF
--- a/cmd/system-probe/api/module/common.go
+++ b/cmd/system-probe/api/module/common.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
-	"github.com/gorilla/mux"
 )
 
 // ErrNotEnabled is a special error type that should be returned by a Factory
@@ -20,6 +19,6 @@ type Factory struct {
 // Module defines the common API implemented by every System Probe Module
 type Module interface {
 	GetStats() map[string]interface{}
-	Register(*mux.Router) error
+	Register(*Router) error
 	Close()
 }

--- a/cmd/system-probe/api/module/router.go
+++ b/cmd/system-probe/api/module/router.go
@@ -1,0 +1,46 @@
+package module
+
+import (
+	"net/http"
+	"sync"
+
+	"github.com/gorilla/mux"
+)
+
+// Router provides a wrapper around mux.Router so routes can be re-registered
+// This is needed to support the module-restart feature
+type Router struct {
+	mux            sync.Mutex
+	handlerByRoute map[string]func(http.ResponseWriter, *http.Request)
+	router         *mux.Router
+}
+
+// NewRouter returns a new Router
+func NewRouter(mux *mux.Router) *Router {
+	return &Router{
+		handlerByRoute: make(map[string]func(http.ResponseWriter, *http.Request)),
+		router:         mux,
+	}
+}
+
+// HandleFunc registers a HandleFunc in such a way that routes can be registered multiple times
+func (r *Router) HandleFunc(path string, responseWriter func(http.ResponseWriter, *http.Request)) *mux.Route {
+	r.mux.Lock()
+	_, registered := r.handlerByRoute[path]
+	r.handlerByRoute[path] = responseWriter
+	r.mux.Unlock()
+
+	if registered {
+		// If this route was previously registered there is nothing left to do.
+		// The return value serves as a stub to support modules that are (re)registering routes
+		// chaining calls like HandleFunc(path, handler).Method("POST")
+		return new(mux.Route)
+	}
+
+	return r.router.HandleFunc(path, func(w http.ResponseWriter, req *http.Request) {
+		r.mux.Lock()
+		handlerFn := r.handlerByRoute[path]
+		r.mux.Unlock()
+		handlerFn(w, req)
+	})
+}

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -21,7 +21,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/http/debugging"
 	"github.com/DataDog/datadog-agent/pkg/network/tracer"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/gorilla/mux"
 )
 
 // ErrSysprobeUnsupported is the unsupported error prefix, for error-class matching from callers
@@ -61,7 +60,7 @@ func (nt *networkTracer) GetStats() map[string]interface{} {
 }
 
 // Register all networkTracer endpoints
-func (nt *networkTracer) Register(httpMux *mux.Router) error {
+func (nt *networkTracer) Register(httpMux *module.Router) error {
 	var runCounter uint64
 
 	httpMux.HandleFunc("/connections", func(w http.ResponseWriter, req *http.Request) {

--- a/cmd/system-probe/modules/oom_kill_probe.go
+++ b/cmd/system-probe/modules/oom_kill_probe.go
@@ -11,7 +11,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 )
 
@@ -34,7 +33,7 @@ type oomKillModule struct {
 	*probe.OOMKillProbe
 }
 
-func (o *oomKillModule) Register(httpMux *mux.Router) error {
+func (o *oomKillModule) Register(httpMux *module.Router) error {
 	httpMux.HandleFunc("/check/oom_kill", func(w http.ResponseWriter, req *http.Request) {
 		stats := o.OOMKillProbe.GetAndFlush()
 		utils.WriteAsJSON(w, stats)

--- a/cmd/system-probe/modules/process.go
+++ b/cmd/system-probe/modules/process.go
@@ -17,7 +17,6 @@ import (
 	reqEncoding "github.com/DataDog/datadog-agent/pkg/process/encoding/request"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/gorilla/mux"
 )
 
 // ErrProcessUnsupported is an error type indicating that the process module is not support in the running environment
@@ -48,7 +47,7 @@ func (t *process) GetStats() map[string]interface{} {
 }
 
 // Register registers endpoints for the module to expose data
-func (t *process) Register(httpMux *mux.Router) error {
+func (t *process) Register(httpMux *module.Router) error {
 	var runCounter uint64
 	httpMux.HandleFunc("/proc/stats", func(w http.ResponseWriter, req *http.Request) {
 		start := time.Now()

--- a/cmd/system-probe/modules/tcp_queue_tracer.go
+++ b/cmd/system-probe/modules/tcp_queue_tracer.go
@@ -10,7 +10,6 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/system-probe/utils"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf/probe"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
-	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 )
 
@@ -33,7 +32,7 @@ type tcpQueueLengthModule struct {
 	*probe.TCPQueueLengthTracer
 }
 
-func (t *tcpQueueLengthModule) Register(httpMux *mux.Router) error {
+func (t *tcpQueueLengthModule) Register(httpMux *module.Router) error {
 	httpMux.HandleFunc("/check/tcp_queue_length", func(w http.ResponseWriter, req *http.Request) {
 		stats := t.TCPQueueLengthTracer.GetAndFlush()
 		utils.WriteAsJSON(w, stats)

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -19,7 +19,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/gorilla/mux"
 	"github.com/pkg/errors"
 	"google.golang.org/grpc"
 
@@ -57,7 +56,7 @@ type Module struct {
 }
 
 // Register the runtime security agent module
-func (m *Module) Register(_ *mux.Router) error {
+func (m *Module) Register(_ *module.Router) error {
 	// force socket cleanup of previous socket not cleanup
 	os.Remove(m.config.SocketPath)
 


### PR DESCRIPTION
### What does this PR do?

Add a `module.Router` "wrapper" around `mux.Router` in order to support re-registering routes. 
This fixes the `module-restart` command which is currently broken.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

1. Start system-probe
2. Restart network_tracer via `system-probe module-restart network_tracer`
3. Verify that connection check works via `curl --unix-socket <SYSTEM_PROBE_SOCK> http://unix/connections`
