### PR TITLE
[DCA][CMD] Support changing the log level at runtime

### DIFF
--- a/cmd/agent/app/config.go
+++ b/cmd/agent/app/config.go
@@ -10,47 +10,18 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/app/settings"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/cmd/agent/common/commands"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	commonsettings "github.com/DataDog/datadog-agent/pkg/config/settings"
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
+
 	"github.com/fatih/color"
-	"github.com/spf13/cobra"
 )
 
 func init() {
-	AgentCmd.AddCommand(configCommand)
-	configCommand.AddCommand(listRuntimeCommand)
-	configCommand.AddCommand(setCommand)
-	configCommand.AddCommand(getCommand)
+	AgentCmd.AddCommand(commands.Config(getSettingsClient))
 }
-
-var (
-	configCommand = &cobra.Command{
-		Use:   "config",
-		Short: "Print the runtime configuration of a running agent",
-		Long:  ``,
-		RunE:  showRuntimeConfiguration,
-	}
-	listRuntimeCommand = &cobra.Command{
-		Use:   "list-runtime",
-		Short: "List settings that can be changed at runtime",
-		Long:  ``,
-		RunE:  listRuntimeConfigurableValue,
-	}
-	setCommand = &cobra.Command{
-		Use:   "set [setting] [value]",
-		Short: "Set, for the current runtime, the value of a given configuration setting",
-		Long:  ``,
-		RunE:  setConfigValue,
-	}
-	getCommand = &cobra.Command{
-		Use:   "get [setting]",
-		Short: "Get, for the current runtime, the value of a given configuration setting",
-		Long:  ``,
-		RunE:  getConfigValue,
-	}
-)
 
 func setupConfig() error {
 	if flagNoColor {
@@ -82,78 +53,6 @@ func getSettingsClient() (commonsettings.Client, error) {
 	}
 	hc := util.GetClient(false)
 	return settingshttp.NewClient(hc, fmt.Sprintf("https://%v:%v/agent/config", ipcAddress, config.Datadog.GetInt("cmd_port")), "datadog-agent"), nil
-}
-
-func showRuntimeConfiguration(_ *cobra.Command, _ []string) error {
-	c, err := getSettingsClient()
-	if err != nil {
-		return err
-	}
-	runtimeConfig, err := c.FullConfig()
-	if err != nil {
-		return err
-	}
-
-	fmt.Println(runtimeConfig)
-	return nil
-}
-
-func listRuntimeConfigurableValue(_ *cobra.Command, _ []string) error {
-	c, err := getSettingsClient()
-	if err != nil {
-		return err
-	}
-
-	settingsList, err := c.List()
-	if err != nil {
-		return err
-	}
-
-	fmt.Println("=== Settings that can be changed at runtime ===")
-	for setting, details := range settingsList {
-		if !details.Hidden {
-			fmt.Printf("%-30s %s\n", setting, details.Description)
-		}
-	}
-	return nil
-}
-
-func setConfigValue(_ *cobra.Command, args []string) error {
-	if len(args) != 2 {
-		return fmt.Errorf("Exactly two parameters are required: the setting name and its value")
-	}
-	c, err := getSettingsClient()
-	if err != nil {
-		return err
-	}
-
-	hidden, err := c.Set(args[0], args[1])
-	if err != nil {
-		return err
-	}
-	if hidden {
-		fmt.Printf("IMPORTANT: you have modified a hidden option, this may incur billing charges or have other unexpected side-effects.\n")
-	}
-	fmt.Printf("Configuration setting %s is now set to: %s\n", args[0], args[1])
-	return nil
-}
-
-func getConfigValue(_ *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return fmt.Errorf("A single setting name must be specified")
-	}
-
-	c, err := getSettingsClient()
-	if err != nil {
-		return err
-	}
-	value, err := c.Get(args[0])
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("%s is set to: %v\n", args[0], value)
-	return nil
 }
 
 // initRuntimeSettings builds the map of runtime settings configurable at runtime.

--- a/cmd/agent/common/commands/config.go
+++ b/cmd/agent/common/commands/config.go
@@ -1,0 +1,141 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package commands
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/config/settings"
+
+	"github.com/spf13/cobra"
+)
+
+// Config returns the main cobra config command.
+func Config(getClient settings.ClientBuilder) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Print the runtime configuration of a running agent",
+		Long:  ``,
+		RunE:  func(_ *cobra.Command, _ []string) error { return showRuntimeConfiguration(getClient) },
+	}
+
+	cmd.AddCommand(listRuntime(getClient))
+	cmd.AddCommand(set(getClient))
+	cmd.AddCommand(get(getClient))
+
+	return cmd
+}
+
+// listRuntime returns a cobra command to list the settings that can be changed at runtime.
+func listRuntime(getClient settings.ClientBuilder) *cobra.Command {
+	return &cobra.Command{
+		Use:   "list-runtime",
+		Short: "List settings that can be changed at runtime",
+		Long:  ``,
+		RunE:  func(_ *cobra.Command, _ []string) error { return listRuntimeConfigurableValue(getClient) },
+	}
+}
+
+// set returns a cobra command to set a config value at runtime.
+func set(getClient settings.ClientBuilder) *cobra.Command {
+	return &cobra.Command{
+		Use:   "set [setting] [value]",
+		Short: "Set, for the current runtime, the value of a given configuration setting",
+		Long:  ``,
+		RunE:  func(_ *cobra.Command, args []string) error { return setConfigValue(getClient, args) },
+	}
+}
+
+// get returns a cobra command to get a runtime config value.
+func get(getClient settings.ClientBuilder) *cobra.Command {
+	return &cobra.Command{
+		Use:   "get [setting]",
+		Short: "Get, for the current runtime, the value of a given configuration setting",
+		Long:  ``,
+		RunE:  func(_ *cobra.Command, args []string) error { return getConfigValue(getClient, args) },
+	}
+}
+
+func showRuntimeConfiguration(getClient settings.ClientBuilder) error {
+	c, err := getClient()
+	if err != nil {
+		return err
+	}
+
+	runtimeConfig, err := c.FullConfig()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println(runtimeConfig)
+
+	return nil
+}
+
+func listRuntimeConfigurableValue(getClient settings.ClientBuilder) error {
+	c, err := getClient()
+	if err != nil {
+		return err
+	}
+
+	settingsList, err := c.List()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("=== Settings that can be changed at runtime ===")
+	for setting, details := range settingsList {
+		if !details.Hidden {
+			fmt.Printf("%-30s %s\n", setting, details.Description)
+		}
+	}
+
+	return nil
+}
+
+func setConfigValue(getClient settings.ClientBuilder, args []string) error {
+	if len(args) != 2 {
+		return fmt.Errorf("exactly two parameters are required: the setting name and its value")
+	}
+
+	c, err := getClient()
+	if err != nil {
+		return err
+	}
+
+	hidden, err := c.Set(args[0], args[1])
+	if err != nil {
+		return err
+	}
+
+	if hidden {
+		fmt.Printf("IMPORTANT: you have modified a hidden option, this may incur billing charges or have other unexpected side-effects.\n")
+	}
+
+	fmt.Printf("Configuration setting %s is now set to: %s\n", args[0], args[1])
+
+	return nil
+}
+
+func getConfigValue(getClient settings.ClientBuilder, args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("a single setting name must be specified")
+	}
+
+	c, err := getClient()
+	if err != nil {
+		return err
+	}
+
+	value, err := c.Get(args[0])
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("%s is set to: %v\n", args[0], value)
+
+	return nil
+}

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -15,7 +15,6 @@ import (
 	"sort"
 
 	"github.com/gorilla/mux"
-	yaml "gopkg.in/yaml.v2"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
@@ -23,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
 	"github.com/DataDog/datadog-agent/pkg/flare"
 	"github.com/DataDog/datadog-agent/pkg/status"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
@@ -40,7 +40,10 @@ func SetupHandlers(r *mux.Router) {
 	r.HandleFunc("/status", getStatus).Methods("GET")
 	r.HandleFunc("/status/health", getHealth).Methods("GET")
 	r.HandleFunc("/config-check", getConfigCheck).Methods("GET")
-	r.HandleFunc("/config", getRuntimeConfig).Methods("GET")
+	r.HandleFunc("/config", settingshttp.Server.GetFull("")).Methods("GET")
+	r.HandleFunc("/config/list-runtime", settingshttp.Server.ListConfigurable).Methods("GET")
+	r.HandleFunc("/config/{setting}", settingshttp.Server.GetValue).Methods("GET")
+	r.HandleFunc("/config/{setting}", settingshttp.Server.SetValue).Methods("POST")
 }
 
 func getStatus(w http.ResponseWriter, r *http.Request) {
@@ -167,24 +170,4 @@ func getConfigCheck(w http.ResponseWriter, r *http.Request) {
 	}
 
 	w.Write(jsonConfig)
-}
-
-func getRuntimeConfig(w http.ResponseWriter, r *http.Request) {
-	runtimeConfig, err := yaml.Marshal(config.Datadog.AllSettings())
-	if err != nil {
-		log.Errorf("Unable to marshal runtime config response: %s", err)
-		body, _ := json.Marshal(map[string]string{"error": err.Error()})
-		http.Error(w, string(body), 500)
-		return
-	}
-
-	scrubbed, err := log.CredentialsCleanerBytes(runtimeConfig)
-	if err != nil {
-		log.Errorf("Unable to scrub sensitive data from runtime config: %s", err)
-		body, _ := json.Marshal(map[string]string{"error": err.Error()})
-		http.Error(w, string(body), 500)
-		return
-	}
-
-	w.Write(scrubbed)
 }

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -152,6 +152,11 @@ func start(cmd *cobra.Command, args []string) error {
 		log.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)
 	}
 
+	// Init settings that can be changed at runtime
+	if err := initRuntimeSettings(); err != nil {
+		log.Warnf("Can't initiliaze the runtime settings: %v", err)
+	}
+
 	if !config.Datadog.IsSet("api_key") {
 		log.Critical("no API key configured, exiting")
 		return nil

--- a/pkg/config/settings/api.go
+++ b/pkg/config/settings/api.go
@@ -7,3 +7,6 @@ type Client interface {
 	List() (map[string]RuntimeSettingResponse, error)
 	FullConfig() (string, error)
 }
+
+// ClientBuilder represents a function returning a runtime settings API client
+type ClientBuilder func() (Client, error)

--- a/releasenotes-dca/notes/support-dca-loglevel-at-runtime-70cbde2ba2544152.yaml
+++ b/releasenotes-dca/notes/support-dca-loglevel-at-runtime-70cbde2ba2544152.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Add the ability to change log_level at runtime.
+    To set the log_level to ``debug`` the following command should be used: ``agent config set log_level debug``.


### PR DESCRIPTION
### What does this PR do?

Support changing the DCA's  log level at runtime.

### Motivation

Useful for debugging without having to restart / redeploy.

### Additional Notes

Can be easily extended to support changing configs at runtime other the log level.

### Describe how to test your changes

```
agent config --help
...
Available Commands:
  get          Get, for the current runtime, the value of a given configuration setting
  list-runtime List settings that can be changed at runtime
  set          Set, for the current runtime, the value of a given configuration setting
```

Run `agent config list-runtime`, `agent config set log_level <level>`, `agent config get log_level` on both the Agent and the Cluster Agent.
