### PR TITLE
[DCA] Update CLC status and flare

### DIFF
--- a/pkg/flare/cluster_checks.go
+++ b/pkg/flare/cluster_checks.go
@@ -79,13 +79,13 @@ func GetClusterChecks(w io.Writer) error {
 		fmt.Fprintln(w, "")
 	}
 
-	// Print summary of node-agents
+	// Print summary of agents
 	if len(cr.Nodes) == 0 {
-		fmt.Fprintln(w, fmt.Sprintf("=== %s node-agent reporting ===", color.RedString("Zero")))
-		fmt.Fprintln(w, "No check will be dispatched until node-agents report to the cluster-agent")
+		fmt.Fprintln(w, fmt.Sprintf("=== %s agent reporting ===", color.RedString("Zero")))
+		fmt.Fprintln(w, "No check will be dispatched until agents report to the cluster-agent")
 		return nil
 	}
-	fmt.Fprintln(w, fmt.Sprintf("=== %d node-agents reporting ===", len(cr.Nodes)))
+	fmt.Fprintln(w, fmt.Sprintf("=== %d agents reporting ===", len(cr.Nodes)))
 	sort.Slice(cr.Nodes, func(i, j int) bool { return cr.Nodes[i].Name < cr.Nodes[j].Name })
 	table := tabwriter.NewWriter(w, 0, 0, 3, ' ', 0)
 	fmt.Fprintln(table, "\nName\tRunning checks")

--- a/pkg/status/templates/header.tmpl
+++ b/pkg/status/templates/header.tmpl
@@ -178,7 +178,7 @@ Cluster Checks Dispatching
 {{- if .clusterchecks.Leader }}
   {{- if .clusterchecks.Active }}
   Status: Leader, serving requests
-  Active nodes: {{ .clusterchecks.NodeCount }}
+  Active agents: {{ .clusterchecks.NodeCount }}
   Check Configurations: {{ .clusterchecks.TotalConfigs }}
     - Dispatched: {{ .clusterchecks.ActiveConfigs }}
     - Unassigned: {{ .clusterchecks.DanglingConfigs }}


### PR DESCRIPTION
### What does this PR do?

Update the output of `agent status` and `agent clusterchecks` commands: Avoid confusion when dedicated clustercheck runners are used instead of node agents.

### Motivation

Better UX

### Describe how to test your changes

Run `agent status` and `agent clusterchecks`
