### PR TITLE
[runtime-security] Fix hosts with high cpu count

### DIFF
--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -87,6 +87,20 @@ func AllMaps() []*manager.Map {
 	}
 }
 
+// AllMapSpecEditors returns the list of map editors
+func AllMapSpecEditors(numCPU int) map[string]manager.MapSpecEditor {
+	return map[string]manager.MapSpecEditor{
+		"proc_cache": {
+			MaxEntries: uint32(4096 * numCPU),
+			EditorFlag: manager.EditMaxEntries,
+		},
+		"pid_cache": {
+			MaxEntries: uint32(4096 * numCPU),
+			EditorFlag: manager.EditMaxEntries,
+		},
+	}
+}
+
 // AllPerfMaps returns the list of perf maps of the runtime security module
 func AllPerfMaps() []*manager.PerfMap {
 	return []*manager.PerfMap{

--- a/pkg/security/probe/dentry_resolver.go
+++ b/pkg/security/probe/dentry_resolver.go
@@ -11,11 +11,8 @@ import (
 	"C"
 	"fmt"
 	"os"
-	"runtime"
 	"sync/atomic"
 	"unsafe"
-
-	"github.com/DataDog/datadog-agent/pkg/security/ebpf"
 
 	"github.com/DataDog/datadog-go/statsd"
 	lib "github.com/DataDog/ebpf"
@@ -23,8 +20,10 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/model"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
 const (
@@ -45,6 +44,8 @@ type DentryResolver struct {
 	erpcSegmentSize       int
 	erpcRequest           ERPCRequest
 	erpcEnabled           bool
+	erpcStatsZero         []eRPCStats
+	numCPU                int
 	mapEnabled            bool
 
 	hitsCounters map[string]map[string]*int64
@@ -171,12 +172,10 @@ func (dr *DentryResolver) SendStats() error {
 	return dr.sendERPCStats()
 }
 
-var eRPCStatsZero = make([]eRPCStats, runtime.NumCPU())
-
 func (dr *DentryResolver) sendERPCStats() error {
 	buffer := dr.erpcStats[1-dr.activeERPCStatsBuffer]
 	iterator := buffer.Iterate()
-	stats := make([]eRPCStats, runtime.NumCPU())
+	stats := make([]eRPCStats, dr.numCPU)
 	counters := map[eRPCRet]int64{}
 	var ret eRPCRet
 
@@ -197,7 +196,7 @@ func (dr *DentryResolver) sendERPCStats() error {
 		}
 	}
 	for _, r := range allERPCRet() {
-		_ = buffer.Put(r, eRPCStatsZero)
+		_ = buffer.Put(r, dr.erpcStatsZero)
 	}
 
 	dr.activeERPCStatsBuffer = 1 - dr.activeERPCStatsBuffer
@@ -685,6 +684,11 @@ func NewDentryResolver(probe *Probe) (*DentryResolver, error) {
 		}
 	}
 
+	numCPU, err := utils.NumCPU()
+	if err != nil {
+		return nil, errors.Wrapf(err, "couldn't fetch the host CPU count")
+	}
+
 	return &DentryResolver{
 		client:          probe.statsdClient,
 		cache:           make(map[uint32]*lru.Cache),
@@ -693,8 +697,10 @@ func NewDentryResolver(probe *Probe) (*DentryResolver, error) {
 		erpcSegmentSize: len(segment),
 		erpcRequest:     ERPCRequest{},
 		erpcEnabled:     probe.config.ERPCDentryResolutionEnabled,
+		erpcStatsZero:   make([]eRPCStats, numCPU),
 		mapEnabled:      probe.config.MapDentryResolutionEnabled,
 		hitsCounters:    hitsCounters,
 		missCounters:    missCounters,
+		numCPU:          numCPU,
 	}, nil
 }

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -803,9 +803,16 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 		statsdClient:   client,
 		erpc:           erpc,
 	}
+
 	if err = p.detectKernelVersion(); err != nil {
 		return nil, err
 	}
+
+	numCPU, err := utils.NumCPU()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse CPU count")
+	}
+	p.managerOptions.MapSpecEditors = probes.AllMapSpecEditors(numCPU)
 
 	if !p.config.EnableKernelFilters {
 		log.Warn("Forcing in-kernel filter policy to `pass`: filtering not enabled")

--- a/pkg/security/utils/numcpu.go
+++ b/pkg/security/utils/numcpu.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build linux
+
+package utils
+
+import "github.com/DataDog/gopsutil/cpu"
+
+// NumCPU returns the count of CPUs in the CPU affinity mask of the pid 1 process
+func NumCPU() (int, error) {
+	cpuInfos, err := cpu.Info()
+	if err != nil {
+		return 0, err
+	}
+	var count int32
+	for _, inf := range cpuInfos {
+		count += inf.Cores
+	}
+	return int(count), nil
+}


### PR DESCRIPTION
### What does this PR do?

This PR helps prevent a few bugs on hosts with a high CPU count:
- Instead of relying on `runtime.NumCPU()` to get the host CPU count, use `gopsutil` and parse `/proc/cpuinfo`. When system-probe has a CPU affinity mask that doesn't allow it to be scheduled on all CPUs, the answer of `runtime.NumCPU()` won't be the total count of CPUs on the host (which is an issue for various PERCPU kernel space hashmaps).
- When hosts (with high CPU counts) are under pressure, the amount of `fork` events skyrockets and may eventually overflows the kernel space process context caches. This PR increases the size of the kernel space caches based on the CPU count.

### Motivation

- We're missing kernel space telemetry on the perf buffer as well as the dentry resolver.
- When we lose our kernel space caches and lose `fork` events on the perf maps, we lose the container context of a process.

### Describe how to test your changes

Double check that we collect kernel space telemetry about the dentry resolver & perf buffer on huge hosts (96+ virtual cores).