### PR TITLE
fix: Allow admission control webhook to be reinvoked if further hooks change things

### DIFF
--- a/pkg/clusteragent/admission/util.go
+++ b/pkg/clusteragent/admission/util.go
@@ -117,6 +117,7 @@ func buildLabelSelector() *metav1.LabelSelector {
 
 func getWebhookSkeleton(nameSuffix, path string) admiv1beta1.MutatingWebhook {
 	failurePolicy := admiv1beta1.Ignore
+	reinvocationPolicy := admiv1beta1.IfNeededReinvocationPolicy
 	sideEffects := admiv1beta1.SideEffectClassNone
 	servicePort := int32(443)
 	timeout := config.Datadog.GetInt32("admission_controller.timeout_seconds")
@@ -143,6 +144,7 @@ func getWebhookSkeleton(nameSuffix, path string) admiv1beta1.MutatingWebhook {
 			},
 		},
 		FailurePolicy:  &failurePolicy,
+		ReinvocationPolicy: &reinvocationPolicy,
 		SideEffects:    &sideEffects,
 		TimeoutSeconds: &timeout,
 	}


### PR DESCRIPTION
### What does this PR do?

Allow the hooks to be invoked again if another hook makes changes to the same object

### Motivation

I wanted to use a different hook to set the datadog labels

### Describe how to test your changes

Create a Kyverno policy as in #8350 and make sure it reliably creates the `DD_SERVICE` environment variable
