### PR TITLE
[dogstatsd] capture: only track relevant bytes used in buffer

### DIFF
--- a/pkg/dogstatsd/listeners/uds_common.go
+++ b/pkg/dogstatsd/listeners/uds_common.go
@@ -178,9 +178,9 @@ func (l *UDSListener) Listen() {
 				capBuff.Oob = oob
 				capBuff.Buff = packet
 				capBuff.Pb.AncillarySize = int32(oobn)
-				capBuff.Pb.Ancillary = oobS[:oobn] // or oob[:oobn] ?
+				capBuff.Pb.Ancillary = oobS[:oobn]
 				capBuff.Pb.PayloadSize = int32(n)
-				capBuff.Pb.Payload = packet.Buffer // or packet.Buffer[:n] ?
+				capBuff.Pb.Payload = packet.Buffer[:n]
 				capBuff.Pb.Pid = int32(pid)
 			}
 
@@ -211,7 +211,7 @@ func (l *UDSListener) Listen() {
 				capBuff.Pb.Pid = 0
 				capBuff.Pb.AncillarySize = int32(0)
 				capBuff.Pb.PayloadSize = int32(n)
-				capBuff.Pb.Payload = packet.Buffer // or packet.Buffer[:n] ?
+				capBuff.Pb.Payload = packet.Buffer[:n]
 			}
 		}
 

--- a/releasenotes/notes/dogstatsd-capture-optimize-buffer-serialization-606f0fedaa4bd9fe.yaml
+++ b/releasenotes/notes/dogstatsd-capture-optimize-buffer-serialization-606f0fedaa4bd9fe.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    For dogstatsd captures, Only serialize to disk the portion of buffers
+    actually used by the payloads ingested, not the full buffer.


### PR DESCRIPTION
### What does this PR do?

This PR makes sure we only track the bytes actually used within the buffer, and not the entire buffer's slice. This is important because when we serialize the buffer to disk we only want to store the actual payload on the wire, not the full buffer.

### Motivation

Capture files could get unnecessarily massive when payloads did not use the full buffer.  

### Additional Notes

-

### Describe how to test your changes

- Make sure new captures still replay correctly.
- Verify the files (you can do this with `hexdump -c <use_capture_file_here>`.
