### PR TITLE
[compliance-agent] Fix compliance check resource type

### DIFF
--- a/pkg/compliance/checks/builder.go
+++ b/pkg/compliance/checks/builder.go
@@ -382,7 +382,7 @@ func (b *builder) checkFromRule(meta *compliance.SuiteMeta, rule *compliance.Rul
 		return nil, ErrRuleDoesNotApply
 	}
 
-	resourceReporter := b.getRuleResourceReporter(ruleScope, rule)
+	resourceReporter := b.getRuleResourceReporter(ruleScope, *rule)
 	return b.newCheck(meta, ruleScope, rule, resourceReporter)
 }
 
@@ -399,7 +399,7 @@ func getRuleScope(meta *compliance.SuiteMeta, rule *compliance.Rule) (compliance
 	}
 }
 
-func (b *builder) kubeResourceReporter(rule *compliance.Rule, resourceType string) resourceReporter {
+func (b *builder) kubeResourceReporter(rule compliance.Rule, resourceType string) resourceReporter {
 	return func(report *compliance.Report) compliance.ReportResource {
 		var clusterID string
 		var err error
@@ -433,7 +433,7 @@ func (b *builder) kubeResourceReporter(rule *compliance.Rule, resourceType strin
 	}
 }
 
-func (b *builder) getRuleResourceReporter(scope compliance.RuleScope, rule *compliance.Rule) resourceReporter {
+func (b *builder) getRuleResourceReporter(scope compliance.RuleScope, rule compliance.Rule) resourceReporter {
 	switch scope {
 	case compliance.DockerScope:
 		return func(report *compliance.Report) compliance.ReportResource {
@@ -459,7 +459,7 @@ func (b *builder) getRuleResourceReporter(scope compliance.RuleScope, rule *comp
 		return b.kubeResourceReporter(rule, "kubernetes_node")
 
 	case compliance.KubernetesClusterScope:
-		return b.kubeResourceReporter(rule, "kubernetes_controller")
+		return b.kubeResourceReporter(rule, "kubernetes_cluster")
 
 	default:
 		return func(report *compliance.Report) compliance.ReportResource {

--- a/pkg/compliance/checks/check.go
+++ b/pkg/compliance/checks/check.go
@@ -119,7 +119,7 @@ func (c *complianceCheck) Run() error {
 			Data:             data,
 		}
 
-		log.Debugf("%s: reporting [%s]", c.ruleID, e.Result)
+		log.Debugf("%s: reporting [%s] [%s] [%s]", c.ruleID, e.Result, e.ResourceID, e.ResourceType)
 
 		c.Reporter().Report(e)
 		if c.eventNotify != nil {


### PR DESCRIPTION
### What does this PR do?

Use the resource type of a rule, when one is specified

### Motivation

The reported resource type was incorrect for some rules