### PR TITLE
[runtime-security] Generate a warning log for unsupported kernel

### DIFF
--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -8,6 +8,7 @@
 package kernel
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -26,6 +27,8 @@ var (
 	Kernel4_12 = kernel.VersionCode(4, 12, 0) //nolint:deadcode,unused
 	// Kernel4_13 is the KernelVersion representation of kernel version 4.13
 	Kernel4_13 = kernel.VersionCode(4, 13, 0) //nolint:deadcode,unused
+	// Kernel4_15 is the KernelVersion representation of kernel version 4.15
+	Kernel4_15 = kernel.VersionCode(4, 15, 0) //nolint:deadcode,unused
 	// Kernel4_16 is the KernelVersion representation of kernel version 4.16
 	Kernel4_16 = kernel.VersionCode(4, 16, 0) //nolint:deadcode,unused
 	// Kernel5_3 is the KernelVersion representation of kernel version 5.3
@@ -36,6 +39,10 @@ var (
 type Version struct {
 	osRelease map[string]string
 	Code      kernel.Version
+}
+
+func (k *Version) String() string {
+	return fmt.Sprintf("kernel %s - %v", k.Code, k.osRelease)
 }
 
 // NewKernelVersion returns a new kernel version helper

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -100,6 +100,14 @@ func (p *Probe) detectKernelVersion() error {
 	return nil
 }
 
+// VerifyOSVersion returns an error if the current kernel version is not supported
+func (p *Probe) VerifyOSVersion() error {
+	if !p.kernelVersion.IsRH7Kernel() && !p.kernelVersion.IsRH8Kernel() && p.kernelVersion.Code < kernel.Kernel4_15 {
+		return errors.Errorf("the following kernel is not supported: %s", p.kernelVersion)
+	}
+	return nil
+}
+
 // Init initializes the probe
 func (p *Probe) Init(client *statsd.Client) error {
 	p.startTime = time.Now()
@@ -804,7 +812,11 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 		erpc:           erpc,
 	}
 	if err = p.detectKernelVersion(); err != nil {
+		// we need the kernel version to start, fail if we can't get it
 		return nil, err
+	}
+	if err = p.VerifyOSVersion(); err != nil {
+		log.Warnf("the current kernel isn't officially supported, some features might not work properly: %v", err)
 	}
 
 	if !p.config.EnableKernelFilters {


### PR DESCRIPTION
### What does this PR do?

This PR introduces a warning log when the runtime security module is activated on an unsupported kernel.

### Motivation

Help debug unsupported kernels.

### Describe how to test your changes

Start the runtime security agent on an unsupported kernel.