### PR TITLE
Only include cgosymbolizer on Linux

### DIFF
--- a/pkg/collector/python/memory.go
+++ b/pkg/collector/python/memory.go
@@ -17,7 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	_ "github.com/benesch/cgosymbolizer"
 	"github.com/cihub/seelog"
 )
 

--- a/pkg/collector/python/memory_linux.go
+++ b/pkg/collector/python/memory_linux.go
@@ -8,5 +8,6 @@
 package python
 
 import (
+	// Makes backtraces include Cgo frames. Linux-only due to https://github.com/golang/go/issues/45558
 	_ "github.com/benesch/cgosymbolizer"
 )

--- a/pkg/collector/python/memory_linux.go
+++ b/pkg/collector/python/memory_linux.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build python
+
+package python
+
+import (
+	_ "github.com/benesch/cgosymbolizer"
+)

--- a/releasenotes/notes/cgosymbolizer-linux-only-174fcb4672dd81f8.yaml
+++ b/releasenotes/notes/cgosymbolizer-linux-only-174fcb4672dd81f8.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes the Agent using 100% CPU on MacOS Big Sur.


### PR DESCRIPTION
### Motivation

Windows is not supported and it seems it can trigger 100% CPU usage on MacOS Big Sur [1].

[1] https://github.com/golang/go/issues/45558

