### PR TITLE
[Serverless] add account_id tag

### DIFF
--- a/pkg/serverless/tags.go
+++ b/pkg/serverless/tags.go
@@ -21,6 +21,7 @@ const (
 	functionARNKey           = "function_arn"
 	functionNameKey          = "functionname"
 	regionKey                = "region"
+	accountIdKey             = "account_id"
 	awsAccountKey            = "aws_account"
 	resourceKey              = "resource"
 	executedVersionKey       = "executedversion"
@@ -40,6 +41,7 @@ func buildTagMapFromArn(arn string) map[string]string {
 
 	tags = setIfNotEmpty(tags, regionKey, parts[3])
 	tags = setIfNotEmpty(tags, awsAccountKey, parts[4])
+	tags = setIfNotEmpty(tags, accountIdKey, parts[4])
 	tags = setIfNotEmpty(tags, functionNameKey, parts[6])
 	tags = setIfNotEmpty(tags, resourceKey, parts[6])
 

--- a/pkg/serverless/tags.go
+++ b/pkg/serverless/tags.go
@@ -21,7 +21,7 @@ const (
 	functionARNKey           = "function_arn"
 	functionNameKey          = "functionname"
 	regionKey                = "region"
-	accountIdKey             = "account_id"
+	accountIDKey             = "account_id"
 	awsAccountKey            = "aws_account"
 	resourceKey              = "resource"
 	executedVersionKey       = "executedversion"
@@ -41,7 +41,7 @@ func buildTagMapFromArn(arn string) map[string]string {
 
 	tags = setIfNotEmpty(tags, regionKey, parts[3])
 	tags = setIfNotEmpty(tags, awsAccountKey, parts[4])
-	tags = setIfNotEmpty(tags, accountIdKey, parts[4])
+	tags = setIfNotEmpty(tags, accountIDKey, parts[4])
 	tags = setIfNotEmpty(tags, functionNameKey, parts[6])
 	tags = setIfNotEmpty(tags, resourceKey, parts[6])
 

--- a/pkg/serverless/tags_test.go
+++ b/pkg/serverless/tags_test.go
@@ -72,12 +72,13 @@ func TestBuildTagMapFromArnIncomplete(t *testing.T) {
 func TestBuildTagMapFromArnComplete(t *testing.T) {
 	arn := "arn:aws:lambda:us-east-1:123456789012:function:my-function"
 	tagMap := buildTagMapFromArn(arn)
-	assert.Equal(t, 7, len(tagMap))
+	assert.Equal(t, 8, len(tagMap))
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
 	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
 	assert.Equal(t, "us-east-1", tagMap["region"])
 	assert.Equal(t, "123456789012", tagMap["aws_account"])
+	assert.Equal(t, "123456789012", tagMap["account_id"])
 	assert.Equal(t, "my-function", tagMap["functionname"])
 	assert.Equal(t, "my-function", tagMap["resource"])
 }
@@ -85,12 +86,13 @@ func TestBuildTagMapFromArnComplete(t *testing.T) {
 func TestBuildTagMapFromArnCompleteWithUpperCase(t *testing.T) {
 	arn := "arn:aws:lambda:us-east-1:123456789012:function:My-Function"
 	tagMap := buildTagMapFromArn(arn)
-	assert.Equal(t, 7, len(tagMap))
+	assert.Equal(t, 8, len(tagMap))
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
 	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
 	assert.Equal(t, "us-east-1", tagMap["region"])
 	assert.Equal(t, "123456789012", tagMap["aws_account"])
+	assert.Equal(t, "123456789012", tagMap["account_id"])
 	assert.Equal(t, "my-function", tagMap["functionname"])
 	assert.Equal(t, "my-function", tagMap["resource"])
 }
@@ -99,12 +101,13 @@ func TestBuildTagMapFromArnCompleteWithLatest(t *testing.T) {
 	os.Setenv("AWS_LAMBDA_FUNCTION_VERSION", "$LATEST")
 	arn := "arn:aws:lambda:us-east-1:123456789012:function:my-function"
 	tagMap := buildTagMapFromArn(arn)
-	assert.Equal(t, 7, len(tagMap))
+	assert.Equal(t, 8, len(tagMap))
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
 	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
 	assert.Equal(t, "us-east-1", tagMap["region"])
 	assert.Equal(t, "123456789012", tagMap["aws_account"])
+	assert.Equal(t, "123456789012", tagMap["account_id"])
 	assert.Equal(t, "my-function", tagMap["functionname"])
 	assert.Equal(t, "my-function", tagMap["resource"])
 }
@@ -113,12 +116,13 @@ func TestBuildTagMapFromArnCompleteWithVersionNumber(t *testing.T) {
 	os.Setenv("AWS_LAMBDA_FUNCTION_VERSION", "888")
 	arn := "arn:aws:lambda:us-east-1:123456789012:function:my-function"
 	tagMap := buildTagMapFromArn(arn)
-	assert.Equal(t, 8, len(tagMap))
+	assert.Equal(t, 9, len(tagMap))
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
 	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
 	assert.Equal(t, "us-east-1", tagMap["region"])
 	assert.Equal(t, "123456789012", tagMap["aws_account"])
+	assert.Equal(t, "123456789012", tagMap["account_id"])
 	assert.Equal(t, "my-function", tagMap["functionname"])
 	assert.Equal(t, "my-function:888", tagMap["resource"])
 	assert.Equal(t, "888", tagMap["executedversion"])


### PR DESCRIPTION
### What does this PR do?

Add account_id tags to logs metrics and spans

### Motivation

Consistency with previous versions

### Describe how to test your changes

New extension version deployed + check on Datadog UI

![Screen Shot 2021-06-08 at 1 35 24 PM](https://user-images.githubusercontent.com/864493/121231674-ac695f80-c85e-11eb-93d7-6671250376f7.png)
-
![Screen Shot 2021-06-08 at 1 38 12 PM](https://user-images.githubusercontent.com/864493/121231829-e33f7580-c85e-11eb-9818-19374ec367aa.png)


