### PR TITLE
[rtloader] Enable dynamic interpreter binary path resolution

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,8 @@ skip_branch_with_pr: true
 
 clone_folder: C:\gopath\src\github.com\DataDog\datadog-agent
 
+image: "Visual Studio 2017"
+
 # environment must be set for python 64 bit
 environment:
   GOPATH: C:\gopath
@@ -12,7 +14,7 @@ environment:
   GOROOT: C:\go_1.15.11
   # Give hints to CMake to find Pythons
   Python2_ROOT_DIR: C:\Python27-x64
-  Python3_ROOT_DIR: C:\Python37-x64
+  Python3_ROOT_DIR: C:\Python38-x64
   PIP3: pip3 -q
   MSYS_ROOT: C:\msys64
   # GLIB-URL: http://ftp.gnome.org/pub/gnome/binaries/win64/glib/2.26/glib_2.26.1-1_win64.zip

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -266,7 +266,7 @@ func pathToBinary(name string, ignoreErrors bool) (string, error) {
 		log.Error(resolutionError)
 
 		if ignoreErrors {
-			return "", nil
+			return name, nil
 		}
 
 		return "", resolutionError

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -248,6 +248,12 @@ func InitConfig(config Config) {
 	// Whether to honour the value of PYTHONPATH, if set, on Windows. On other OSes we always do.
 	config.BindEnvAndSetDefault("windows_use_pythonpath", false)
 
+	// When the Python full interpreter path cannot be deduced via heuristics, the agent
+	// is expected to prevent rtloader from initializing. When set to true, this override
+	// allows us to proceed but with some capabilities unavailable (e.g. `multiprocessing`
+	// library support will not work reliably in those environments)
+	config.BindEnvAndSetDefault("allow_python_path_heuristics_failure", false)
+
 	// if/when the default is changed to true, make the default platform
 	// dependent; default should remain false on Windows to maintain backward
 	// compatibility with Agent5 behavior/win

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo"
 	mocks "github.com/DataDog/datadog-agent/pkg/proto/pbgo/mocks"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/providers"
+	providerMocks "github.com/DataDog/datadog-agent/pkg/util/containers/providers/mock"
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -29,10 +31,14 @@ import (
 var originalConfig = config.Datadog
 
 func restoreGlobalConfig() {
+	providers.Deregister()
+
 	config.Datadog = originalConfig
 }
 
 func newConfig() {
+	providers.Register(providerMocks.FakeContainerImpl{})
+
 	config.Datadog = config.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
 	config.InitConfig(config.Datadog)
 	// force timeout to 0s, otherwise each test waits 60s
@@ -578,6 +584,9 @@ func TestGetHostnameFromCmd(t *testing.T) {
 }
 
 func TestInvalidHostname(t *testing.T) {
+	providers.Register(providerMocks.FakeContainerImpl{})
+	defer providers.Deregister()
+
 	// Input yaml file has an invalid hostname (localhost) so we expect to configure via environment
 	agentConfig, err := NewAgentConfig(
 		"test",

--- a/pkg/util/cloudfoundry/garden_test.go
+++ b/pkg/util/cloudfoundry/garden_test.go
@@ -1,15 +1,16 @@
 package cloudfoundry
 
 import (
-	"code.cloudfoundry.org/garden/gardenfakes"
-	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
-	"github.com/DataDog/datadog-agent/pkg/util/containers/providers"
 	"net"
 	"testing"
 
 	"code.cloudfoundry.org/garden"
-	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"code.cloudfoundry.org/garden/gardenfakes"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/providers"
+	providerMocks "github.com/DataDog/datadog-agent/pkg/util/containers/providers/mock"
 )
 
 func TestParseContainerPorts(t *testing.T) {
@@ -42,60 +43,9 @@ func TestParseContainerPorts(t *testing.T) {
 	assert.Equal(t, expected, addresses)
 }
 
-type fakeContainerImpl struct {
-}
-
-func (f fakeContainerImpl) Prefetch() error {
-	return nil
-}
-
-func (f fakeContainerImpl) ContainerExists(containerID string) bool {
-	return true
-}
-
-func (f fakeContainerImpl) GetContainerStartTime(containerID string) (int64, error) {
-	panic("implement me")
-}
-
-func (f fakeContainerImpl) DetectNetworkDestinations(pid int) ([]containers.NetworkDestination, error) {
-	panic("implement me")
-}
-
-func (f fakeContainerImpl) GetAgentCID() (string, error) {
-	panic("implement me")
-}
-
-func (f fakeContainerImpl) GetPIDs(containerID string) ([]int32, error) {
-	return []int32{123}, nil
-}
-
-func (f fakeContainerImpl) ContainerIDForPID(pid int) (string, error) {
-	panic("implement me")
-}
-
-func (f fakeContainerImpl) GetDefaultGateway() (net.IP, error) {
-	panic("implement me")
-}
-
-func (f fakeContainerImpl) GetDefaultHostIPs() ([]string, error) {
-	panic("implement me")
-}
-
-func (f fakeContainerImpl) GetContainerMetrics(containerID string) (*metrics.ContainerMetrics, error) {
-	return nil, nil
-}
-
-func (f fakeContainerImpl) GetContainerLimits(containerID string) (*metrics.ContainerLimits, error) {
-	return nil, nil
-}
-
-func (f fakeContainerImpl) GetNetworkMetrics(containerID string, networks map[string]string) (metrics.ContainerNetStats, error) {
-	return nil, nil
-}
-
 func TestListContainers(t *testing.T) {
 	defer providers.Deregister()
-	providers.Register(fakeContainerImpl{})
+	providers.Register(providerMocks.FakeContainerImpl{})
 	cli := gardenfakes.FakeClient{}
 	bulkContainers := map[string]garden.ContainerInfoEntry{
 		"ok": {

--- a/pkg/util/containers/providers/mock/mock.go
+++ b/pkg/util/containers/providers/mock/mock.go
@@ -1,0 +1,77 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
+package providers
+
+import (
+	"net"
+
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/metrics"
+)
+
+// FakeContainerImpl is a fake implementation of a container provider
+type FakeContainerImpl struct {
+}
+
+// Prefetch mocks the prefetch interface method
+func (f FakeContainerImpl) Prefetch() error {
+	return nil
+}
+
+// ContainerExists mocks the ContainerExists interface method
+func (f FakeContainerImpl) ContainerExists(containerID string) bool {
+	return true
+}
+
+// GetContainerStartTime mocks the GetContainerStartTime interface method
+func (f FakeContainerImpl) GetContainerStartTime(containerID string) (int64, error) {
+	panic("implement me")
+}
+
+// DetectNetworkDestinations mocks the DetectNetworkDestinations interface method
+func (f FakeContainerImpl) DetectNetworkDestinations(pid int) ([]containers.NetworkDestination, error) {
+	panic("implement me")
+}
+
+// GetAgentCID mocks the GetAgentCID interface method
+func (f FakeContainerImpl) GetAgentCID() (string, error) {
+	panic("implement me")
+}
+
+// GetPIDs mocks the GetPIDs interface method
+func (f FakeContainerImpl) GetPIDs(containerID string) ([]int32, error) {
+	return []int32{123}, nil
+}
+
+// ContainerIDForPID mocks the ContainerIDForPID interface method
+func (f FakeContainerImpl) ContainerIDForPID(pid int) (string, error) {
+	panic("implement me")
+}
+
+// GetDefaultGateway the GetDefaultGateway interface method
+func (f FakeContainerImpl) GetDefaultGateway() (net.IP, error) {
+	panic("implement me")
+}
+
+// GetDefaultHostIPs mocks the GetDefaultHostIPs interface method
+func (f FakeContainerImpl) GetDefaultHostIPs() ([]string, error) {
+	panic("implement me")
+}
+
+// GetContainerMetrics mocks the GetContainerMetrics interface method
+func (f FakeContainerImpl) GetContainerMetrics(containerID string) (*metrics.ContainerMetrics, error) {
+	return nil, nil
+}
+
+// GetContainerLimits mocks the GetContainerLimits interface method
+func (f FakeContainerImpl) GetContainerLimits(containerID string) (*metrics.ContainerLimits, error) {
+	return nil, nil
+}
+
+// GetNetworkMetrics mocks the GetNetworkMetrics interface method
+func (f FakeContainerImpl) GetNetworkMetrics(containerID string, networks map[string]string) (metrics.ContainerNetStats, error) {
+	return nil, nil
+}

--- a/pkg/util/executable/executable.go
+++ b/pkg/util/executable/executable.go
@@ -4,9 +4,11 @@
 // Copyright 2016-present Datadog, Inc.
 
 // Package executable provides information on the executable that started the process
+// and utils to find other executables on the system
 package executable
 
 import (
+	"os/exec"
 	"path/filepath"
 
 	// TODO: Use the built-in "os" package as soon as it implements `Executable()`
@@ -52,4 +54,21 @@ func FolderAllowSymlinkFailure() (string, error) {
 	}
 
 	return filepath.Dir(p), nil
+}
+
+// ResolvePath resolves the absolute path to the executable program
+// with the given name in the argument. Returns error if the program's
+// path cannot be resolved.
+func ResolvePath(execName string) (string, error) {
+	execPath, err := exec.LookPath(execName)
+	if err != nil {
+		return "", err
+	}
+
+	execAbsPath, err := filepath.Abs(execPath)
+	if err != nil {
+		return "", err
+	}
+
+	return execAbsPath, nil
 }

--- a/pkg/util/executable/executable_test.go
+++ b/pkg/util/executable/executable_test.go
@@ -1,0 +1,64 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build windows darwin linux
+
+package executable
+
+import (
+	"github.com/stretchr/testify/assert"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestResolvePath(t *testing.T) {
+	testProgram := "ls"
+	if runtime.GOOS == "windows" {
+		testProgram = "dir"
+	}
+
+	actualPath, err := ResolvePath(testProgram)
+	if !assert.Nil(t, err) {
+		return
+	}
+
+	if !assert.NotEmpty(t, actualPath) {
+		return
+	}
+
+	if _, err := os.Stat(actualPath); os.IsNotExist(err) {
+		assert.FailNowf(t, "Resolved path '%s' does not exist!", actualPath)
+	}
+}
+
+func TestResolvePathIsAbsolute(t *testing.T) {
+	testProgram := "ls"
+	if runtime.GOOS == "windows" {
+		testProgram = "dir"
+	}
+
+	actualPath, err := ResolvePath(testProgram)
+	if !assert.Nil(t, err) {
+		return
+	}
+
+	absPath, err := filepath.Abs(actualPath)
+	if !assert.Nil(t, err) {
+		return
+	}
+
+	assert.Equal(t, absPath, actualPath)
+}
+
+func TestResolvePathFailure(t *testing.T) {
+	testProgram := "badprogramname"
+
+	_, err := ResolvePath(testProgram)
+	if !assert.NotNil(t, err) {
+		return
+	}
+}

--- a/releasenotes/notes/set-rtloader-python-interpreter-bin-path-da017336fd301733.yaml
+++ b/releasenotes/notes/set-rtloader-python-interpreter-bin-path-da017336fd301733.yaml
@@ -1,0 +1,9 @@
+---
+enhancements:
+  - |
+    Python interpreter ``sys.executable`` is now set to the appropriate interpreter's
+    executable path. This should allow ``multiprocessing`` to be able to spawn new
+    processes since it will try to invoke the Python interpreter instead of the Agent
+    itself. It should be noted though that the ``datadog_agent`` import should be
+    guarded with ``try``/``except`` clauses and only used from within the main process
+    as the ``rtloader``-injected helpers are not available in the child processes.

--- a/releasenotes/notes/set-rtloader-python-interpreter-bin-path-da017336fd301733.yaml
+++ b/releasenotes/notes/set-rtloader-python-interpreter-bin-path-da017336fd301733.yaml
@@ -4,6 +4,5 @@ enhancements:
     Python interpreter ``sys.executable`` is now set to the appropriate interpreter's
     executable path. This should allow ``multiprocessing`` to be able to spawn new
     processes since it will try to invoke the Python interpreter instead of the Agent
-    itself. It should be noted though that the ``datadog_agent`` import should be
-    guarded with ``try``/``except`` clauses and only used from within the main process
-    as the ``rtloader``-injected helpers are not available in the child processes.
+    itself. It should be noted though that the Pyton packages injected at runtime by
+    the Agent are only available from the main process, not from any sub-processes.

--- a/rtloader/demo/CMakeLists.txt
+++ b/rtloader/demo/CMakeLists.txt
@@ -1,11 +1,36 @@
+cmake_minimum_required(VERSION 3.19)
+
+project("RTLoader Demo")
+
+option(USE_AGENT_RTLOADER_LIB "Use RTLoader implementation from the agent build" OFF)
+
 ## Use compiler debugging flags per default
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${CMAKE_C_FLAGS_DEBUG}")
 
 add_executable(demo main.c)
-include_directories(${CMAKE_SOURCE_DIR}/include)
-if(NOT WIN32)
-    target_link_libraries(demo LINK_PUBLIC datadog-agent-rtloader dl)
+
+## Add our paths for includes. Note that these may be different depending on
+## where you have rtloader built and/or checked out
+include_directories("${CMAKE_SOURCE_DIR}/../include" "${CMAKE_SOURCE_DIR}/../common")
+
+
+if(WIN32)
+  set_target_properties(demo PROPERTIES LINK_FLAGS -static)
+  target_link_libraries(demo PUBLIC datadog-agent-rtloader)
 else()
-    set_target_properties(demo PROPERTIES LINK_FLAGS -static)
-    target_link_libraries(demo LINK_PUBLIC datadog-agent-rtloader)
+  if (APPLE)
+    set(LIB_SUFFIX "dylib")
+  else()
+    set(LIB_SUFFIX "so")
+  endif()
+
+
+  if (USE_AGENT_RTLOADER_LIB)
+    set(RTLOADER_LIB_PREFIX "${CMAKE_SOURCE_DIR}/../build/rtloader/")
+  else()
+    set(RTLOADER_LIB_PREFIX "")
+  endif()
+
+  set(RTLOADER_LIB "${RTLOADER_LIB_PREFIX}libdatadog-agent-rtloader.${LIB_SUFFIX}")
+  target_link_libraries(demo PUBLIC "${RTLOADER_LIB}" dl)
 endif()

--- a/rtloader/demo/main.c
+++ b/rtloader/demo/main.c
@@ -78,7 +78,7 @@ int main(int argc, char *argv[])
     char *init_error = NULL;
     // Embed Python2
     if (strcmp(argv[1], "2") == 0) {
-        rtloader = make2(python_home, &init_error);
+        rtloader = make2(python_home, "", &init_error);
         if (!rtloader) {
             printf("Unable to init Python2: %s\n", init_error);
             return 1;
@@ -86,7 +86,7 @@ int main(int argc, char *argv[])
     }
     // Embed Python3
     else if (strcmp(argv[1], "3") == 0) {
-        rtloader = make3(python_home, &init_error);
+        rtloader = make3(python_home, "", &init_error);
         if (!rtloader) {
             printf("Unable to init Python3: %s\n", init_error);
             return 1;

--- a/rtloader/demo/main.c
+++ b/rtloader/demo/main.c
@@ -2,6 +2,8 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2019-present Datadog, Inc.
+
+// These headers can be found in rtloader/include and rtloader/common directories
 #include "datadog_agent_rtloader.h"
 #include "rtloader_mem.h"
 
@@ -26,7 +28,7 @@ char **get_tags(char *id, int highCard)
     return data;
 }
 
-void submitMetric(char *id, metric_type_t mt, char *name, double val, char **tags,  char *hostname)
+void submitMetric(char *id, metric_type_t mt, char *name, double val, char **tags,  char *hostname, bool flush_first_val)
 {
     printf("I'm extending Python providing aggregator.submit_metric:\n");
     printf("Check id: %s\n", id);

--- a/rtloader/demo/main.py
+++ b/rtloader/demo/main.py
@@ -8,5 +8,5 @@ import aggregator
 import tagger
 
 if __name__ == "__main__":
-    aggregator.submit_metric(None, 'id', aggregator.GAUGE, 'name', -99.0, ['foo', 'bar'], 'myhost')
+    aggregator.submit_metric(None, 'id', aggregator.GAUGE, 'name', -99.0, ['foo', 'bar'], 'myhost', False)
     print("tags returned by tagger: %s\n" % tagger.get_tags("21", True))

--- a/rtloader/include/datadog_agent_rtloader.h
+++ b/rtloader/include/datadog_agent_rtloader.h
@@ -29,24 +29,26 @@ struct rtloader_pyobject_s;
 typedef struct rtloader_pyobject_s rtloader_pyobject_t;
 
 // FACTORIES
-/*! \fn rtloader_t *make2(const char *python_home, char **error)
+/*! \fn rtloader_t *make2(const char *python_home, const char *python_exe, char **error)
     \brief Factory function to load the python2 backend DLL and create its relevant RtLoader
     instance.
     \param python_home A C-string with the path to the PYTHONHOME for said DLL.
+    \param python_exe A C-string with the path to the python interpreter.
     \param error A C-string pointer output parameter to return error messages.
     \return A rtloader_t * pointer to the RtLoader instance.
     \sa rtloader_t
 */
-DATADOG_AGENT_RTLOADER_API rtloader_t *make2(const char *pythonhome, char **error);
-/*! \fn rtloader_t *make3(const char *python_home, char **error)
+DATADOG_AGENT_RTLOADER_API rtloader_t *make2(const char *python_home, const char *python_exe, char **error);
+/*! \fn rtloader_t *make3(const char *python_home, const char *python_exe, char **error)
     \brief Factory function to load the python3 backend DLL and create its relevant RtLoader
     instance.
     \param python_home A C-string with the path to the PYTHONHOME for said DLL.
+    \param python_exe A C-string with the path to the python interpreter.
     \param error A C-string pointer output parameter to return error messages.
     \return A rtloader_t * pointer to the RtLoader instance.
     \sa rtloader_t
 */
-DATADOG_AGENT_RTLOADER_API rtloader_t *make3(const char *pythonhome, char **error);
+DATADOG_AGENT_RTLOADER_API rtloader_t *make3(const char *python_home, const char *python_exe, char **error);
 
 // HELPERS
 /*! \fn void set_memory_tracker_cb(cb_memory_tracker_t)

--- a/rtloader/include/rtloader.h
+++ b/rtloader/include/rtloader.h
@@ -450,9 +450,10 @@ private:
   \typedef create_t defines the factory function prototype to create RtLoader instances for
   the underlying python runtimes.
   \param python_home A C-string path to the python home for the target python runtime.
+  \param python_exe A C-string path to the python interpreter.
   \return A pointer to the RtLoader instance created by the implementing function.
 */
-typedef RtLoader *(create_t)(const char *python_home, cb_memory_tracker_t memtrack_cb);
+typedef RtLoader *(create_t)(const char *python_home, const char *python_exe, cb_memory_tracker_t memtrack_cb);
 
 /*! destroy_t function prototype
   \typedef destroy_t defines the destructor function prototype to destroy existing RtLoader instances.

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -100,7 +100,7 @@ create_t *loadAndCreate(const char *dll, const char *python_home, char **error)
     return create;
 }
 
-rtloader_t *make2(const char *python_home, char **error)
+rtloader_t *make2(const char *python_home, const char *python_exe, char **error)
 {
 
     if (rtloader_backend != NULL) {
@@ -112,10 +112,10 @@ rtloader_t *make2(const char *python_home, char **error)
     if (!create) {
         return NULL;
     }
-    return AS_TYPE(rtloader_t, create(python_home, _get_memory_tracker_cb()));
+    return AS_TYPE(rtloader_t, create(python_home, python_exe, _get_memory_tracker_cb()));
 }
 
-rtloader_t *make3(const char *python_home, char **error)
+rtloader_t *make3(const char *python_home, const char *python_exe, char **error)
 {
     if (rtloader_backend != NULL) {
         *error = strdupe("RtLoader already initialized!");
@@ -126,7 +126,7 @@ rtloader_t *make3(const char *python_home, char **error)
     if (!create_three) {
         return NULL;
     }
-    return AS_TYPE(rtloader_t, create_three(python_home, _get_memory_tracker_cb()));
+    return AS_TYPE(rtloader_t, create_three(python_home, python_exe, _get_memory_tracker_cb()));
 }
 
 /*! \fn void destroy(rtloader_t *rtloader)
@@ -150,7 +150,7 @@ void destroy(rtloader_t *rtloader)
 }
 
 #else
-rtloader_t *make2(const char *python_home, char **error)
+rtloader_t *make2(const char *python_home, const char *python_exe, char **error)
 {
     if (rtloader_backend != NULL) {
         std::string err_msg = "RtLoader already initialized!";
@@ -179,10 +179,10 @@ rtloader_t *make2(const char *python_home, char **error)
         return NULL;
     }
 
-    return AS_TYPE(rtloader_t, create(python_home, _get_memory_tracker_cb()));
+    return AS_TYPE(rtloader_t, create(python_home, python_exe, _get_memory_tracker_cb()));
 }
 
-rtloader_t *make3(const char *python_home, char **error)
+rtloader_t *make3(const char *python_home, const char *python_exe, char **error)
 {
     if (rtloader_backend != NULL) {
         std::string err_msg = "RtLoader already initialized!";
@@ -212,7 +212,7 @@ rtloader_t *make3(const char *python_home, char **error)
         return NULL;
     }
 
-    return AS_TYPE(rtloader_t, create_three(python_home, _get_memory_tracker_cb()));
+    return AS_TYPE(rtloader_t, create_three(python_home, python_exe, _get_memory_tracker_cb()));
 }
 
 void destroy(rtloader_t *rtloader)

--- a/rtloader/test/common/common_three.go
+++ b/rtloader/test/common/common_three.go
@@ -6,11 +6,17 @@ package testcommon
 //
 import "C"
 
+import "unsafe"
+
 // UsingTwo states whether we're using Two as backend
 const UsingTwo bool = false
 
 // GetRtLoader returns a RtLoader instance using Three
 func GetRtLoader() *C.rtloader_t {
 	var err *C.char = nil
-	return C.make3(nil, &err)
+
+	executablePath := C.CString("/folder/mock_python_interpeter_bin_path")
+	defer C.free(unsafe.Pointer(executablePath))
+
+	return C.make3(nil, executablePath, &err)
 }

--- a/rtloader/test/common/common_two.go
+++ b/rtloader/test/common/common_two.go
@@ -6,11 +6,17 @@ package testcommon
 //
 import "C"
 
+import "unsafe"
+
 // UsingTwo states whether we're using Two as backend
 const UsingTwo bool = true
 
 // GetRtLoader returns a RtLoader instance using Two
 func GetRtLoader() *C.rtloader_t {
 	var err *C.char = nil
-	return C.make2(nil, &err)
+
+	executablePath := C.CString("/folder/mock_python_interpeter_bin_path")
+	defer C.free(unsafe.Pointer(executablePath))
+
+	return C.make2(nil, executablePath, &err)
 }

--- a/rtloader/test/init/init_two.go
+++ b/rtloader/test/init/init_two.go
@@ -3,5 +3,5 @@
 package testinit
 
 const (
-	initAllocations = 1
+	initAllocations = 2
 )

--- a/rtloader/test/rtloader/rtloader.go
+++ b/rtloader/test/rtloader/rtloader.go
@@ -161,14 +161,14 @@ func getFakeCheck() (string, error) {
 	// check instance
 	emptyStr := (*C.char)(helpers.TrackedCString(""))
 	defer C._free(unsafe.Pointer(emptyStr))
-	checkIdStr := (*C.char)(helpers.TrackedCString("checkID"))
-	defer C._free(unsafe.Pointer(checkIdStr))
+	checkIDStr := (*C.char)(helpers.TrackedCString("checkID"))
+	defer C._free(unsafe.Pointer(checkIDStr))
 	configStr := (*C.char)(helpers.TrackedCString("{\"fake_check\": \"/\"}"))
 	defer C._free(unsafe.Pointer(configStr))
 	classStr = (*C.char)(helpers.TrackedCString("fake_check"))
 	defer C._free(unsafe.Pointer(classStr))
 
-	ret = C.get_check(rtloader, class, emptyStr, configStr, checkIdStr, classStr, &check)
+	ret = C.get_check(rtloader, class, emptyStr, configStr, checkIDStr, classStr, &check)
 	if ret != 1 || check == nil {
 		return "", fmt.Errorf(C.GoString(C.get_error(rtloader)))
 	}
@@ -200,14 +200,14 @@ func runFakeCheck() (string, error) {
 
 	emptyStr := (*C.char)(helpers.TrackedCString(""))
 	defer C._free(unsafe.Pointer(emptyStr))
-	checkIdStr := (*C.char)(helpers.TrackedCString("checkID"))
-	defer C._free(unsafe.Pointer(checkIdStr))
+	checkIDStr := (*C.char)(helpers.TrackedCString("checkID"))
+	defer C._free(unsafe.Pointer(checkIDStr))
 	configStr := (*C.char)(helpers.TrackedCString("{\"fake_check\": \"/\"}"))
 	defer C._free(unsafe.Pointer(configStr))
 	classStr = (*C.char)(helpers.TrackedCString("fake_check"))
 	defer C._free(unsafe.Pointer(classStr))
 
-	C.get_check(rtloader, class, emptyStr, configStr, checkIdStr, classStr, &check)
+	C.get_check(rtloader, class, emptyStr, configStr, checkIDStr, classStr, &check)
 
 	checkResultStr := C.run_check(rtloader, check)
 	defer C._free(unsafe.Pointer(checkResultStr))
@@ -233,14 +233,14 @@ func cancelFakeCheck() error {
 
 	emptyStr := (*C.char)(helpers.TrackedCString(""))
 	defer C._free(unsafe.Pointer(emptyStr))
-	checkIdStr := (*C.char)(helpers.TrackedCString("checkID"))
-	defer C._free(unsafe.Pointer(checkIdStr))
+	checkIDStr := (*C.char)(helpers.TrackedCString("checkID"))
+	defer C._free(unsafe.Pointer(checkIDStr))
 	configStr := (*C.char)(helpers.TrackedCString("{\"fake_check\": \"/\"}"))
 	defer C._free(unsafe.Pointer(configStr))
 	classStr = (*C.char)(helpers.TrackedCString("fake_check"))
 	defer C._free(unsafe.Pointer(classStr))
 
-	C.get_check(rtloader, class, emptyStr, configStr, checkIdStr, classStr, &check)
+	C.get_check(rtloader, class, emptyStr, configStr, checkIDStr, classStr, &check)
 
 	C.cancel_check(rtloader, check)
 
@@ -265,14 +265,14 @@ func runFakeGetWarnings() ([]string, error) {
 
 	emptyStr := (*C.char)(helpers.TrackedCString(""))
 	defer C._free(unsafe.Pointer(emptyStr))
-	checkIdStr := (*C.char)(helpers.TrackedCString("checkID"))
-	defer C._free(unsafe.Pointer(checkIdStr))
+	checkIDStr := (*C.char)(helpers.TrackedCString("checkID"))
+	defer C._free(unsafe.Pointer(checkIDStr))
 	configStr := (*C.char)(helpers.TrackedCString("{\"fake_check\": \"/\"}"))
 	defer C._free(unsafe.Pointer(configStr))
 	classStr = (*C.char)(helpers.TrackedCString("fake_check"))
 	defer C._free(unsafe.Pointer(classStr))
 
-	C.get_check(rtloader, class, emptyStr, configStr, checkIdStr, classStr, &check)
+	C.get_check(rtloader, class, emptyStr, configStr, checkIDStr, classStr, &check)
 
 	warns := C.get_checks_warnings(rtloader, check)
 

--- a/rtloader/test/rtloader/rtloader_test.go
+++ b/rtloader/test/rtloader/rtloader_test.go
@@ -69,6 +69,28 @@ with open(r'%s', 'w') as f:
 	helpers.AssertMemoryUsage(t)
 }
 
+func TestSysExecutableValue(t *testing.T) {
+	// Reset memory counters
+	helpers.ResetMemoryStats()
+
+	code := fmt.Sprintf(`
+import sys
+with open(r'%s', 'w') as f:
+ f.write(sys.executable)`, tmpfile.Name())
+
+	output, err := runString(code)
+	if err != nil {
+		t.Fatalf("`test_sys_executable` error: %v", err)
+	}
+
+	if output != "/folder/mock_python_interpeter_bin_path" {
+		t.Errorf("Unexpected sys.executable value: '%s'", output)
+	}
+
+	// Check for leaks
+	helpers.AssertMemoryUsage(t)
+}
+
 func TestGetError(t *testing.T) {
 	// Reset memory counters
 	helpers.ResetMemoryStats()

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -21,9 +21,10 @@
 #include <algorithm>
 #include <sstream>
 
-extern "C" DATADOG_AGENT_RTLOADER_API RtLoader *create(const char *pythonHome, cb_memory_tracker_t memtrack_cb)
+extern "C" DATADOG_AGENT_RTLOADER_API RtLoader *create(const char *python_home, const char *python_exe,
+                                                       cb_memory_tracker_t memtrack_cb)
 {
-    return new Three(pythonHome, memtrack_cb);
+    return new Three(python_home, python_exe, memtrack_cb);
 }
 
 extern "C" DATADOG_AGENT_RTLOADER_API void destroy(RtLoader *p)
@@ -31,13 +32,19 @@ extern "C" DATADOG_AGENT_RTLOADER_API void destroy(RtLoader *p)
     delete p;
 }
 
-Three::Three(const char *python_home, cb_memory_tracker_t memtrack_cb)
+Three::Three(const char *python_home, const char *python_exe, cb_memory_tracker_t memtrack_cb)
     : RtLoader(memtrack_cb)
     , _pythonHome(NULL)
+    , _pythonExe(NULL)
     , _baseClass(NULL)
     , _pythonPaths()
 {
     initPythonHome(python_home);
+
+    // If not empty, set our Python interpreter path
+    if (python_exe && strlen(python_exe) > 0) {
+        initPythonExe(python_exe);
+    }
 }
 
 Three::~Three()
@@ -50,6 +57,7 @@ Three::~Three()
 
 void Three::initPythonHome(const char *pythonHome)
 {
+    // Py_SetPythonHome stores a pointer to the string we pass to it, so we must keep it in memory
     wchar_t *oldPythonHome = _pythonHome;
     if (pythonHome == NULL || strlen(pythonHome) == 0) {
         _pythonHome = Py_DecodeLocale(_defaultPythonHome, NULL);
@@ -57,9 +65,18 @@ void Three::initPythonHome(const char *pythonHome)
         _pythonHome = Py_DecodeLocale(pythonHome, NULL);
     }
 
-    // Py_SetPythonHome stores a pointer to the string we pass to it, so we must keep it in memory
     Py_SetPythonHome(_pythonHome);
     PyMem_RawFree((void *)oldPythonHome);
+}
+
+void Three::initPythonExe(const char *python_exe)
+{
+    // Py_SetProgramName stores a pointer to the string we pass to it, so we must keep it in memory
+    wchar_t *oldPythonExe = _pythonExe;
+    _pythonExe = Py_DecodeLocale(python_exe, NULL);
+
+    Py_SetProgramName(_pythonExe);
+    PyMem_RawFree((void *)oldPythonExe);
 }
 
 bool Three::init()

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -76,6 +76,14 @@ void Three::initPythonExe(const char *python_exe)
     _pythonExe = Py_DecodeLocale(python_exe, NULL);
 
     Py_SetProgramName(_pythonExe);
+
+    // HACK: This extra internal API invocation is due to the workaround for an upstream bug on
+    // Windows (https://bugs.python.org/issue34725) where just using `Py_SetProgramName` is
+    // ineffective. The workaround API call will be removed at some point in the future (Python
+    // 3.12+) so we should convert this initialization to the new`PyConfig API`
+    // (https://docs.python.org/3.11/c-api/init_config.html#c.PyConfig) before then.
+    _Py_SetProgramFullPath(_pythonExe);
+
     PyMem_RawFree((void *)oldPythonExe);
 }
 

--- a/rtloader/three/three.h
+++ b/rtloader/three/three.h
@@ -28,11 +28,12 @@ public:
     /*!
       \param python_home A C-string with the path to the python home for the
       python interpreter.
+      \param python_exe A C-string with the path to the python interpreter.
 
       Basic constructor, initializes the _error string to an empty string and
-      errorFlag to false and set the supplied PYTHONHOME.
+      errorFlag to false and set the supplied PYTHONHOME and ProgramName.
     */
-    Three(const char *python_home, cb_memory_tracker_t memtrack_cb);
+    Three(const char *python_home, const char *python_exe, cb_memory_tracker_t memtrack_cb);
 
     //! Destructor.
     /*!
@@ -131,6 +132,13 @@ private:
     */
     void initPythonHome(const char *pythonHome = NULL);
 
+    //! initPythonExe member.
+    /*!
+      \brief This member function sets the path to the underlying python3 interpreter.
+      \param python_exe A C-string to the target python executable.
+    */
+    void initPythonExe(const char *python_exe = NULL);
+
     //! _importFrom member.
     /*!
       \brief This member function imports a Python object by name from the specified
@@ -172,6 +180,7 @@ private:
     typedef std::vector<std::string> PyPaths;
 
     wchar_t *_pythonHome; /*!< unicode string with the PYTHONHOME for the underlying interpreter */
+    wchar_t *_pythonExe; /*!< unicode string with the path to the executable of the underlying interpreter */
     PyObject *_baseClass; /*!< PyObject * pointer to the base Agent check class */
     PyPaths _pythonPaths; /*!< string vector containing paths in the PYTHONPATH */
     PyThreadState *_threadState; /*!< PyThreadState * pointer to the saved Python interpreter thread state */

--- a/rtloader/two/two.h
+++ b/rtloader/two/two.h
@@ -27,11 +27,12 @@ public:
     /*!
       \param python_home A C-string with the path to the python home for the
       python interpreter.
+      \param python_exe A C-string with the path to the python interpreter.
 
       Basic constructor, initializes the _error string to an empty string and
       errorFlag to false and set the supplied PYTHONHOME.
     */
-    Two(const char *python_home, cb_memory_tracker_t memtrack_cb);
+    Two(const char *python_home, const char *python_exe, cb_memory_tracker_t memtrack_cb);
 
     //! Destructor.
     /*!
@@ -130,6 +131,13 @@ private:
     */
     void initPythonHome(const char *pythonHome = NULL);
 
+    //! initPythonExe member.
+    /*!
+      \brief This member function sets the path to the underlying python2 interpreter.
+      \param python_exe A C-string to the target python executable.
+    */
+    void initPythonExe(const char *python_exe = NULL);
+
     //! _importFrom member.
     /*!
       \brief This member function imports a Python object by name from the specified
@@ -171,6 +179,7 @@ private:
     typedef std::vector<std::string> PyPaths;
 
     char *_pythonHome; /*!< string with the PYTHONHOME for the underlying interpreter */
+    char *_pythonExe; /*!< string with the path to the executable of the underlying interpreter */
     PyObject *_baseClass; /*!< PyObject * pointer to the base Agent check class */
     PyPaths _pythonPaths; /*!< string vector containing paths in the PYTHONPATH */
     PyThreadState *_threadState; /*!< PyThreadState * pointer to the saved Python interpreter thread state */

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -100,7 +100,7 @@ def test(
     cpus=0,
     major_version='7',
     python_runtimes='3',
-    timeout=120,
+    timeout=180,
     arch="x64",
     cache=True,
     skip_linters=False,


### PR DESCRIPTION
### What does this PR do?

Previously, our RTLoader was unable to have a custom program name (via
`Py_SetProgramName`) which made use of libraries like `multiprocessing`
not work since they would try to spawn new processes via the rtloader's
parent process path (in this case the agent binary).

**Caveats: Processes spawned from the main one are not injected with the Golang helpers from
the Agent (eg. `from datadog_agent import ...`). Due to this, all interactions with said helpers
must be done from the main process and subprocesses must use `try`/`catch` guards around
Golang helper imports.**

### Motivation

This change adds an ability to configure this value so that when
a library like `multiprocessing` it can point to the correct interpreter
path and work as intended.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

- Ensure that Python integrations work as normal
- Ensure that `sys.executable` within a check shows an absolute path to the python interpreter binary and not the agent binary
- Alternatively, you can ensure that checks using libraries like `multiprocessing` with `spawn` do not error out on the main 3 platforms (example check can be found [here](https://gist.github.com/sgnn7/8e3a64f27e0770ae580ebc8b3cf13c02).