### PR TITLE
[corechecks/snmp] Simplify autodetect logic

### DIFF
--- a/pkg/collector/corechecks/snmp/config.go
+++ b/pkg/collector/corechecks/snmp/config.go
@@ -273,17 +273,17 @@ func buildConfig(rawInstance integration.Data, rawInitConfig integration.Data) (
 		return snmpConfig{}, fmt.Errorf("validation errors: %s", strings.Join(errors, "\n"))
 	}
 
+	if profile != "" || len(c.metrics) > 0 {
+		c.autodetectProfile = false
+	} else {
+		c.autodetectProfile = true
+	}
+
 	if profile != "" {
 		err = c.refreshWithProfile(profile)
 		if err != nil {
 			return snmpConfig{}, fmt.Errorf("failed to refresh with profile `%s`: %s", profile, err)
 		}
-	}
-
-	if len(c.metrics) > 0 {
-		c.autodetectProfile = false
-	} else {
-		c.autodetectProfile = true
 	}
 
 	c.deviceID, c.deviceIDTags = buildDeviceID(c.getDeviceIDTags())

--- a/pkg/collector/corechecks/snmp/config.go
+++ b/pkg/collector/corechecks/snmp/config.go
@@ -74,13 +74,13 @@ type snmpConfig struct {
 	profileTags           []string
 	profile               string
 	profileDef            *profileDefinition
-	uptimeMetricAdded     bool
 	extraTags             []string
 	instanceTags          []string
 	collectDeviceMetadata bool
 	deviceID              string
 	deviceIDTags          []string
 	subnet                string
+	autodetectProfile     bool
 }
 
 func (c *snmpConfig) refreshWithProfile(profile string) error {
@@ -111,13 +111,9 @@ func (c *snmpConfig) refreshWithProfile(profile string) error {
 }
 
 func (c *snmpConfig) addUptimeMetric() {
-	if c.uptimeMetricAdded {
-		return
-	}
 	metricConfig := getUptimeMetricConfig()
 	c.metrics = append(c.metrics, metricConfig)
 	c.oidConfig.addScalarOids([]string{metricConfig.Symbol.OID})
-	c.uptimeMetricAdded = true
 }
 
 // getStaticTags return static tags built from configuration
@@ -142,7 +138,7 @@ func (c *snmpConfig) getDeviceIDTags() []string {
 func (c *snmpConfig) toString() string {
 	return fmt.Sprintf("snmpConfig: ipAddress=`%s`, port=`%d`, snmpVersion=`%s`, timeout=`%d`, retries=`%d`, "+
 		"user=`%s`, authProtocol=`%s`, privProtocol=`%s`, contextName=`%s`, oidConfig=`%#v`, "+
-		"oidBatchSize=`%d`, profileTags=`%#v`, uptimeMetricAdded=`%t`",
+		"oidBatchSize=`%d`, profileTags=`%#v`",
 		c.ipAddress,
 		c.port,
 		c.snmpVersion,
@@ -155,7 +151,6 @@ func (c *snmpConfig) toString() string {
 		c.oidConfig,
 		c.oidBatchSize,
 		c.profileTags,
-		c.uptimeMetricAdded,
 	)
 }
 
@@ -285,6 +280,12 @@ func buildConfig(rawInstance integration.Data, rawInitConfig integration.Data) (
 		}
 	}
 
+	if len(c.metrics) > 0 {
+		c.autodetectProfile = false
+	} else {
+		c.autodetectProfile = true
+	}
+
 	c.deviceID, c.deviceIDTags = buildDeviceID(c.getDeviceIDTags())
 
 	subnet, err := getSubnetFromTags(c.instanceTags)
@@ -292,6 +293,8 @@ func buildConfig(rawInstance integration.Data, rawInitConfig integration.Data) (
 		log.Debugf("subnet not found: %s", err)
 	}
 	c.subnet = subnet
+
+	c.addUptimeMetric()
 	return c, nil
 }
 

--- a/pkg/collector/corechecks/snmp/config_test.go
+++ b/pkg/collector/corechecks/snmp/config_test.go
@@ -177,6 +177,7 @@ oid_batch_size: 10
 		{Symbol: symbolConfig{OID: "1.2.3.4", Name: "aGlobalMetric"}},
 	}
 	metrics = append(metrics, mockProfilesDefinitions()["f5-big-ip"].Metrics...)
+	metrics = append(metrics, metricsConfig{Symbol: symbolConfig{OID: "1.3.6.1.2.1.1.3.0", Name: "sysUpTimeInstance"}})
 
 	metricsTags := []metricTagConfig{
 		{Tag: "my_symbol", OID: "1.2.3", Name: "mySymbol"},
@@ -210,6 +211,7 @@ oid_batch_size: 10
 	assert.Equal(t, "780a58c96c908df8", check.config.deviceID)
 	assert.Equal(t, []string{"snmp_device:1.2.3.4", "tag1", "tag2:val2"}, check.config.deviceIDTags)
 	assert.Equal(t, "127.0.0.0/30", check.config.subnet)
+	assert.Equal(t, false, check.config.autodetectProfile)
 }
 
 func TestDefaultConfigurations(t *testing.T) {
@@ -230,7 +232,7 @@ community_string: abc
 	assert.Equal(t, uint16(161), check.config.port)
 	assert.Equal(t, 2, check.config.timeout)
 	assert.Equal(t, 3, check.config.retries)
-	var metrics []metricsConfig
+	metrics := []metricsConfig{{Symbol: symbolConfig{OID: "1.3.6.1.2.1.1.3.0", Name: "sysUpTimeInstance"}}}
 
 	var metricsTags []metricTagConfig
 
@@ -361,6 +363,7 @@ global_metrics:
 	metrics := []metricsConfig{
 		{Symbol: symbolConfig{OID: "1.3.6.1.2.1.2.1", Name: "ifNumber"}},
 		{Symbol: symbolConfig{OID: "1.2.3.4", Name: "aGlobalMetric"}},
+		{Symbol: symbolConfig{OID: "1.3.6.1.2.1.1.3.0", Name: "sysUpTimeInstance"}},
 	}
 	assert.Equal(t, metrics, check.config.metrics)
 }
@@ -391,6 +394,7 @@ global_metrics:
 
 	metrics := []metricsConfig{
 		{Symbol: symbolConfig{OID: "1.3.6.1.2.1.2.1", Name: "aInstanceMetric"}},
+		{Symbol: symbolConfig{OID: "1.3.6.1.2.1.1.3.0", Name: "sysUpTimeInstance"}},
 	}
 	assert.Equal(t, metrics, check.config.metrics)
 }

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -75,6 +75,8 @@ func (c *Check) processMetricsAndMetadata(staticTags []string) ([]string, error)
 		if err != nil {
 			return tags, fmt.Errorf("failed to fetching sysobjectid: %s", err)
 		}
+		c.config.autodetectProfile = false // do not try to auto detect profile next time
+
 		profile, err := getProfileForSysObjectID(c.config.profiles, sysObjectID)
 		if err != nil {
 			return tags, fmt.Errorf("failed to get profile sys object id for `%s`: %s", sysObjectID, err)

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -69,8 +69,8 @@ func (c *Check) processMetricsAndMetadata(staticTags []string) ([]string, error)
 		}
 	}()
 
-	// If no OIDs, try to detect profile using device sysobjectid
-	if !c.config.oidConfig.hasOids() {
+	// Try to detect profile using device sysobjectid
+	if c.config.autodetectProfile {
 		sysObjectID, err := fetchSysObjectID(c.session)
 		if err != nil {
 			return tags, fmt.Errorf("failed to fetching sysobjectid: %s", err)
@@ -89,8 +89,6 @@ func (c *Check) processMetricsAndMetadata(staticTags []string) ([]string, error)
 
 	// Fetch and report metrics
 	if c.config.oidConfig.hasOids() {
-		c.config.addUptimeMetric()
-
 		collectionTime := timeNow()
 		valuesStore, err := fetchValues(c.session, c.config)
 		if err != nil {

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -733,6 +733,17 @@ profiles:
 	sender.AssertMetric(t, "MonotonicCount", "snmp.ifInDiscards", float64(131), "", row1Tags)
 	sender.AssertMetric(t, "MonotonicCount", "snmp.ifInDiscards", float64(132), "", row2Tags)
 	sender.AssertMetric(t, "Gauge", "snmp.sysStatMemoryTotal", float64(30), "", snmpTags)
+
+	assert.Equal(t, false, check.config.autodetectProfile)
+
+	// Make sure we don't auto detect and add metrics twice if we also did that previously
+	firstRunMetrics := check.config.metrics
+	firstRunMetricsTags := check.config.metricTags
+	err = check.Run()
+	assert.Nil(t, err)
+
+	assert.Len(t, check.config.metrics, len(firstRunMetrics))
+	assert.Len(t, check.config.metricTags, len(firstRunMetricsTags))
 }
 
 func TestServiceCheckFailures(t *testing.T) {

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -715,7 +715,7 @@ profiles:
 	}
 
 	session.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&sysObjectIDPacket, nil)
-	session.On("Get", []string{"1.3.6.1.4.1.3375.2.1.1.2.1.44.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.999", "1.2.3.4.5", "1.3.6.1.2.1.1.5.0", "1.3.6.1.2.1.1.3.0"}).Return(&packet, nil)
+	session.On("Get", []string{"1.3.6.1.2.1.1.3.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.999", "1.2.3.4.5", "1.3.6.1.2.1.1.5.0"}).Return(&packet, nil)
 	session.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.13", "1.3.6.1.2.1.2.2.1.14", "1.3.6.1.2.1.31.1.1.1.1", "1.3.6.1.2.1.31.1.1.1.18"}).Return(&bulkPacket, nil)
 
 	err = check.Run()
@@ -902,7 +902,7 @@ func TestCheck_Run(t *testing.T) {
 			sysObjectIDPacket: sysObjectIDPacketOkMock,
 			valuesPacket:      valuesPacketErrMock,
 			valuesError:       fmt.Errorf("no value"),
-			expectedErr:       "failed to fetch values: failed to fetch scalar oids with batching: failed to fetch scalar oids: fetch scalar: error getting oids `[1.3.6.1.4.1.3375.2.1.1.2.1.44.0 1.3.6.1.4.1.3375.2.1.1.2.1.44.999 1.2.3.4.5 1.3.6.1.2.1.1.5.0 1.3.6.1.2.1.1.3.0]`: no value",
+			expectedErr:       "failed to fetch values: failed to fetch scalar oids with batching: failed to fetch scalar oids: fetch scalar: error getting oids `[1.3.6.1.2.1.1.3.0 1.3.6.1.4.1.3375.2.1.1.2.1.44.0 1.3.6.1.4.1.3375.2.1.1.2.1.44.999 1.2.3.4.5 1.3.6.1.2.1.1.5.0]`: no value",
 		},
 	}
 	for _, tt := range tests {
@@ -929,7 +929,7 @@ ip_address: 1.2.3.4
 			mocksender.SetSender(sender, check.ID())
 
 			session.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&tt.sysObjectIDPacket, tt.sysObjectIDError)
-			session.On("Get", []string{"1.3.6.1.4.1.3375.2.1.1.2.1.44.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.999", "1.2.3.4.5", "1.3.6.1.2.1.1.5.0", "1.3.6.1.2.1.1.3.0"}).Return(&tt.valuesPacket, tt.valuesError)
+			session.On("Get", []string{"1.3.6.1.2.1.1.3.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.999", "1.2.3.4.5", "1.3.6.1.2.1.1.5.0"}).Return(&tt.valuesPacket, tt.valuesError)
 
 			sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 			sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -736,7 +736,7 @@ profiles:
 
 	assert.Equal(t, false, check.config.autodetectProfile)
 
-	// Make sure we don't auto detect and add metrics twice if we also did that previously
+	// Make sure we don't auto detect and add metrics twice if we already did that previously
 	firstRunMetrics := check.config.metrics
 	firstRunMetricsTags := check.config.metricTags
 	err = check.Run()


### PR DESCRIPTION
### What does this PR do?

Simplify autodetect logic 

### Motivation

Use specific flag `autodetectProfile` instead of relying on `oidConfig.hasOids()`

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.
