### PR TITLE
[runtime-security] Fix system-probe deadlock

### DIFF
--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -757,11 +757,12 @@ func (p *Probe) Snapshot() error {
 
 // Close the probe
 func (p *Probe) Close() error {
-	p.cancelFnc()
-
+	// We need to stop the manager first, otherwise there can be a dead lock between the eBPF perf map reader and the
+	// reorderer (at the channel level)
 	if err := p.manager.Stop(manager.CleanAll); err != nil {
 		return err
 	}
+	p.cancelFnc()
 	return p.resolvers.Close()
 }
 


### PR DESCRIPTION
### What does this PR do?

In some cases, the goroutine of the eBPF manager can enter in a deadlock with the reorderer. This PR ensures that we stop the manager before we stop the reorderer to prevent the deadlock from happening.

### Motivation

Fix a deadlock in system-probe.