### PR TITLE
pkg/trace/stats: de-duplicate aggregation keys

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -319,7 +319,7 @@ func (a *Agent) processStats(in pb.ClientStatsPayload, lang, tracerVersion strin
 func mergeDuplicates(s pb.ClientStatsBucket) {
 	indexes := make(map[stats.Aggregation]int, len(s.Stats))
 	for i, g := range s.Stats {
-		a := stats.NewAggregationFromGroup("", "", "", g)
+		a := stats.NewAggregationFromGroup(g)
 		if j, ok := indexes[a]; ok {
 			s.Stats[j].Hits += g.Hits
 			s.Stats[j].Errors += g.Errors

--- a/pkg/trace/stats/aggregation.go
+++ b/pkg/trace/stats/aggregation.go
@@ -23,6 +23,7 @@ type Aggregation struct {
 	PayloadAggregationKey
 }
 
+// BucketsAggregationKey specifies the key by which a bucket is aggregated.
 type BucketsAggregationKey struct {
 	Service    string
 	Name       string
@@ -32,6 +33,7 @@ type BucketsAggregationKey struct {
 	Synthetics bool
 }
 
+// PayloadAggregationKey specifies the key by which a payload is aggregated.
 type PayloadAggregationKey struct {
 	Env      string
 	Hostname string

--- a/pkg/trace/stats/aggregation.go
+++ b/pkg/trace/stats/aggregation.go
@@ -17,20 +17,25 @@ const (
 	tagSynthetics = "synthetics"
 )
 
-// Aggregation contains all the dimension on which we aggregate statistics
-// when adding or removing fields to Aggregation the methods ToTagSet, KeyLen,
-// WriteKey and the structs payloadAggregationKey, bucketAggregationKey in the ClientStatsAggregator
-// should always be updated accordingly.
+// Aggregation contains all the dimension on which we aggregate statistics.
 type Aggregation struct {
-	Env        string
-	Resource   string
+	BucketsAggregationKey
+	PayloadAggregationKey
+}
+
+type BucketsAggregationKey struct {
 	Service    string
 	Name       string
+	Resource   string
 	Type       string
-	Hostname   string
 	StatusCode uint32
-	Version    string
 	Synthetics bool
+}
+
+type PayloadAggregationKey struct {
+	Env      string
+	Hostname string
+	Version  string
 }
 
 func getStatusCode(s *pb.Span) uint32 {
@@ -54,28 +59,31 @@ func NewAggregationFromSpan(s *pb.Span, env string, agentHostname string) Aggreg
 		hostname = agentHostname
 	}
 	return Aggregation{
-		Env:        env,
-		Resource:   s.Resource,
-		Service:    s.Service,
-		Name:       s.Name,
-		Type:       s.Type,
-		Hostname:   hostname,
-		StatusCode: getStatusCode(s),
-		Version:    traceutil.GetMetaDefault(s, tagVersion, ""),
-		Synthetics: synthetics,
+		PayloadAggregationKey: PayloadAggregationKey{
+			Env:      env,
+			Hostname: hostname,
+			Version:  traceutil.GetMetaDefault(s, tagVersion, ""),
+		},
+		BucketsAggregationKey: BucketsAggregationKey{
+			Resource:   s.Resource,
+			Service:    s.Service,
+			Name:       s.Name,
+			Type:       s.Type,
+			StatusCode: getStatusCode(s),
+			Synthetics: synthetics,
+		},
 	}
 }
 
 // NewAggregationFromGroup gets the Aggregation key of grouped stats.
-func NewAggregationFromGroup(env, hostname, version string, g pb.ClientGroupedStats) Aggregation {
+func NewAggregationFromGroup(g pb.ClientGroupedStats) Aggregation {
 	return Aggregation{
-		Env:        env,
-		Hostname:   hostname,
-		Version:    version,
-		Resource:   g.Resource,
-		Service:    g.Service,
-		Name:       g.Name,
-		StatusCode: g.HTTPStatusCode,
-		Synthetics: g.Synthetics,
+		BucketsAggregationKey: BucketsAggregationKey{
+			Resource:   g.Resource,
+			Service:    g.Service,
+			Name:       g.Name,
+			StatusCode: g.HTTPStatusCode,
+			Synthetics: g.Synthetics,
+		},
 	}
 }

--- a/pkg/trace/stats/client_stats_aggregator_test.go
+++ b/pkg/trace/stats/client_stats_aggregator_test.go
@@ -36,7 +36,7 @@ func wrapPayloads(p []pb.ClientStatsPayload) pb.StatsPayload {
 	}
 }
 
-func payloadWithCounts(ts time.Time, k bucketAggregationKey, hits, errors, duration uint64) pb.ClientStatsPayload {
+func payloadWithCounts(ts time.Time, k BucketsAggregationKey, hits, errors, duration uint64) pb.ClientStatsPayload {
 	return pb.ClientStatsPayload{
 		Env:     "test-env",
 		Version: "test-version",
@@ -45,12 +45,12 @@ func payloadWithCounts(ts time.Time, k bucketAggregationKey, hits, errors, durat
 				Start: uint64(ts.UnixNano()),
 				Stats: []pb.ClientGroupedStats{
 					{
-						Service:        k.service,
-						Name:           k.name,
-						Resource:       k.resource,
-						HTTPStatusCode: k.statusCode,
-						Type:           k.typ,
-						Synthetics:     k.synthetics,
+						Service:        k.Service,
+						Name:           k.Name,
+						Resource:       k.Resource,
+						HTTPStatusCode: k.StatusCode,
+						Type:           k.Type,
+						Synthetics:     k.Synthetics,
 						Hits:           hits,
 						Errors:         errors,
 						Duration:       duration,
@@ -247,38 +247,38 @@ func TestFuzzCountFields(t *testing.T) {
 func TestCountAggregation(t *testing.T) {
 	assert := assert.New(t)
 	type tt struct {
-		k    bucketAggregationKey
+		k    BucketsAggregationKey
 		res  pb.ClientGroupedStats
 		name string
 	}
 	tts := []tt{
 		{
-			bucketAggregationKey{service: "s"},
+			BucketsAggregationKey{Service: "s"},
 			pb.ClientGroupedStats{Service: "s"},
 			"service",
 		},
 		{
-			bucketAggregationKey{name: "n"},
+			BucketsAggregationKey{Name: "n"},
 			pb.ClientGroupedStats{Name: "n"},
 			"name",
 		},
 		{
-			bucketAggregationKey{resource: "r"},
+			BucketsAggregationKey{Resource: "r"},
 			pb.ClientGroupedStats{Resource: "r"},
 			"resource",
 		},
 		{
-			bucketAggregationKey{typ: "t"},
+			BucketsAggregationKey{Type: "t"},
 			pb.ClientGroupedStats{Type: "t"},
 			"resource",
 		},
 		{
-			bucketAggregationKey{synthetics: true},
+			BucketsAggregationKey{Synthetics: true},
 			pb.ClientGroupedStats{Synthetics: true},
 			"synthetics",
 		},
 		{
-			bucketAggregationKey{statusCode: 10},
+			BucketsAggregationKey{StatusCode: 10},
 			pb.ClientGroupedStats{HTTPStatusCode: 10},
 			"status",
 		},
@@ -291,7 +291,7 @@ func TestCountAggregation(t *testing.T) {
 			c1 := payloadWithCounts(testTime, tc.k, 11, 7, 100)
 			c2 := payloadWithCounts(testTime, tc.k, 27, 2, 300)
 			c3 := payloadWithCounts(testTime, tc.k, 5, 10, 3)
-			keyDefault := bucketAggregationKey{}
+			keyDefault := BucketsAggregationKey{}
 			cDefault := payloadWithCounts(testTime, keyDefault, 0, 2, 4)
 
 			assert.Len(a.out, 0)

--- a/pkg/trace/stats/concentrator.go
+++ b/pkg/trace/stats/concentrator.go
@@ -161,7 +161,7 @@ func (c *Concentrator) Flush() pb.StatsPayload {
 }
 
 func (c *Concentrator) flushNow(now int64) pb.StatsPayload {
-	m := make(map[PayloadKey][]pb.ClientStatsBucket)
+	m := make(map[PayloadAggregationKey][]pb.ClientStatsBucket)
 
 	c.mu.Lock()
 	for ts, srb := range c.buckets {
@@ -188,9 +188,9 @@ func (c *Concentrator) flushNow(now int64) pb.StatsPayload {
 	sb := make([]pb.ClientStatsPayload, 0, len(m))
 	for k, s := range m {
 		sb = append(sb, pb.ClientStatsPayload{
-			Env:      k.env,
-			Hostname: k.hostname,
-			Version:  k.version,
+			Env:      k.Env,
+			Hostname: k.Hostname,
+			Version:  k.Version,
 			Stats:    s,
 		})
 	}

--- a/pkg/trace/stats/statsraw.go
+++ b/pkg/trace/stats/statsraw.go
@@ -107,13 +107,6 @@ type RawBucket struct {
 	keyBuf strings.Builder
 }
 
-// PayloadKey uniquely identifies a ClientStatsPayload inside a StatsPayload
-type PayloadKey struct {
-	hostname string
-	version  string
-	env      string
-}
-
 // NewRawBucket opens a new calculation bucket for time ts and initializes it properly
 func NewRawBucket(ts, d uint64) *RawBucket {
 	// The only non-initialized value is the Duration which should be set by whoever closes that bucket
@@ -127,18 +120,18 @@ func NewRawBucket(ts, d uint64) *RawBucket {
 // Export transforms a RawBucket into a ClientStatsBucket, typically used
 // before communicating data to the API, as RawBucket is the internal
 // type while ClientStatsBucket is the public, shared one.
-func (sb *RawBucket) Export() map[PayloadKey]pb.ClientStatsBucket {
-	m := make(map[PayloadKey]pb.ClientStatsBucket)
+func (sb *RawBucket) Export() map[PayloadAggregationKey]pb.ClientStatsBucket {
+	m := make(map[PayloadAggregationKey]pb.ClientStatsBucket)
 	for k, v := range sb.data {
 		b, err := v.export(k)
 		if err != nil {
 			log.Errorf("Dropping stats bucket due to encoding error: %v.", err)
 			continue
 		}
-		key := PayloadKey{
-			hostname: k.Hostname,
-			version:  k.Version,
-			env:      k.Env,
+		key := PayloadAggregationKey{
+			Hostname: k.Hostname,
+			Version:  k.Version,
+			Env:      k.Env,
 		}
 		s, ok := m[key]
 		if !ok {

--- a/pkg/trace/stats/statsraw_test.go
+++ b/pkg/trace/stats/statsraw_test.go
@@ -19,11 +19,15 @@ func TestGrain(t *testing.T) {
 	s := pb.Span{Service: "thing", Name: "other", Resource: "yo"}
 	aggr := NewAggregationFromSpan(&s, "default", "default")
 	assert.Equal(Aggregation{
-		Env:      "default",
-		Hostname: "default",
-		Service:  "thing",
-		Name:     "other",
-		Resource: "yo",
+		PayloadAggregationKey: PayloadAggregationKey{
+			Env:      "default",
+			Hostname: "default",
+		},
+		BucketsAggregationKey: BucketsAggregationKey{
+			Service:  "thing",
+			Name:     "other",
+			Resource: "yo",
+		},
 	}, aggr)
 }
 
@@ -32,14 +36,18 @@ func TestGrainWithExtraTags(t *testing.T) {
 	s := pb.Span{Service: "thing", Name: "other", Resource: "yo", Meta: map[string]string{tagHostname: "host-id", tagVersion: "v0", tagStatusCode: "418", tagOrigin: "synthetics-browser"}}
 	aggr := NewAggregationFromSpan(&s, "default", "default")
 	assert.Equal(Aggregation{
-		Env:        "default",
-		Service:    "thing",
-		Resource:   "yo",
-		Name:       "other",
-		Hostname:   "host-id",
-		StatusCode: 418,
-		Version:    "v0",
-		Synthetics: true,
+		PayloadAggregationKey: PayloadAggregationKey{
+			Hostname: "host-id",
+			Version:  "v0",
+			Env:      "default",
+		},
+		BucketsAggregationKey: BucketsAggregationKey{
+			Service:    "thing",
+			Resource:   "yo",
+			Name:       "other",
+			StatusCode: 418,
+			Synthetics: true,
+		},
 	}, aggr)
 }
 

--- a/pkg/trace/writer/stats_test.go
+++ b/pkg/trace/writer/stats_test.go
@@ -292,11 +292,13 @@ func getKey(b pb.ClientGroupedStats, start, duration uint64) key {
 		start:    start,
 		duration: duration,
 		Aggregation: stats.Aggregation{
-			Resource:   b.Resource,
-			Service:    b.Service,
-			Type:       b.Type,
-			StatusCode: b.HTTPStatusCode,
-			Synthetics: b.Synthetics,
+			BucketsAggregationKey: stats.BucketsAggregationKey{
+				Resource:   b.Resource,
+				Service:    b.Service,
+				Type:       b.Type,
+				StatusCode: b.HTTPStatusCode,
+				Synthetics: b.Synthetics,
+			},
 		},
 	}
 }


### PR DESCRIPTION
This change ensures that any keys that are expected to be shared as
aggregators between the ClientStatsAggregator and the Concentrator are
part of shared structures to reduce the probability of bugs due to lack
of attention.