### PR TITLE
[runtime-security] add pool for processes (#8364)

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "cff4824aed66190218299b256b730cbd3aa7a2f6e799f5c0d2faf811c4c144b6")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "8e51b9e593325a44f18682cbb70eea203fb204b4b65b826bc2bdca66c1da1743")

--- a/pkg/security/ebpf/c/exec.h
+++ b/pkg/security/ebpf/c/exec.h
@@ -7,7 +7,7 @@
 #include "syscalls.h"
 #include "container.h"
 
-#define MAX_PERF_STR_BUFF_LEN 128
+#define MAX_PERF_STR_BUFF_LEN 256
 #define MAX_STR_BUFF_LEN (1 << 15)
 #define MAX_ARRAY_ELEMENT_PER_TAIL 28
 #define MAX_ARRAY_ELEMENT_SIZE 4096

--- a/pkg/security/module/rate_limiter.go
+++ b/pkg/security/module/rate_limiter.go
@@ -122,8 +122,8 @@ type RateLimiterStat struct {
 // GetStats returns a map indexed by ruleIDs that describes the amount of events
 // that were dropped because of the rate limiter
 func (rl *RateLimiter) GetStats() map[rules.RuleID]RateLimiterStat {
-	rl.RLock()
-	defer rl.RUnlock()
+	rl.Lock()
+	defer rl.Unlock()
 
 	stats := make(map[rules.RuleID]RateLimiterStat)
 	for ruleID, ruleLimiter := range rl.limiters {

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -47,6 +47,21 @@ type Event struct {
 	scrubber            *pconfig.DataScrubber
 }
 
+// Retain the event
+func (ev *Event) Retain() Event {
+	if ev.processCacheEntry != nil {
+		ev.processCacheEntry.Retain()
+	}
+	return *ev
+}
+
+// Release the event
+func (ev *Event) Release() {
+	if ev.processCacheEntry != nil {
+		ev.processCacheEntry.Release()
+	}
+}
+
 // GetPathResolutionError returns the path resolution error as a string if there is one
 func (ev *Event) GetPathResolutionError() error {
 	return ev.pathResolutionError
@@ -163,7 +178,7 @@ func (ev *Event) ResolveContainerTags(e *model.ContainerContext) []string {
 // UnmarshalProcess unmarshal a Process
 func (ev *Event) UnmarshalProcess(data []byte) (int, error) {
 	// reset the process cache entry of the current event
-	entry := NewProcessCacheEntry()
+	entry := ev.resolvers.ProcessResolver.NewProcessCacheEntry()
 	entry.Pid = ev.ProcessContext.Pid
 	entry.Tid = ev.ProcessContext.Tid
 
@@ -368,11 +383,6 @@ func (ev *Event) ResolveSetgidFSGroup(e *model.SetgidEvent) string {
 	return e.FSGroup
 }
 
-// NewProcessCacheEntry returns an empty instance of ProcessCacheEntry
-func NewProcessCacheEntry() *model.ProcessCacheEntry {
-	return &model.ProcessCacheEntry{}
-}
-
 func (ev *Event) String() string {
 	d, err := json.Marshal(ev)
 	if err != nil {
@@ -454,11 +464,6 @@ func (ev *Event) GetProcessServiceTag() string {
 	}
 
 	return ""
-}
-
-// Clone returns a copy on the event
-func (ev *Event) Clone() Event {
-	return *ev
 }
 
 // NewEvent returns a new event

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -152,7 +152,7 @@ func (p *Probe) Init(client *statsd.Client) error {
 	if os.Getenv("RUNTIME_SECURITY_TESTSUITE") != "true" {
 		p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, manager.ConstantEditor{
 			Name:  "system_probe_pid",
-			Value: uint64(os.Getpid()),
+			Value: uint64(utils.Getpid()),
 		})
 	}
 
@@ -512,6 +512,9 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 	}
 
 	p.DispatchEvent(event, dataLen, int(CPU), p.perfMap)
+
+	// flush exited process
+	p.resolvers.ProcessResolver.DequeueExited()
 }
 
 // OnRuleMatch is called when a rule matches just before sending

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -14,7 +14,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
-	"runtime"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -126,12 +125,15 @@ type ProcessResolver struct {
 	entryCache    map[uint32]*model.ProcessCacheEntry
 	argsEnvsCache *simplelru.LRU
 
-	argsEnvsPool *ArgsEnvsPool
+	argsEnvsPool          *ArgsEnvsPool
+	processCacheEntryPool *ProcessCacheEntryPool
+
+	exitedQueue []uint32
 }
 
 // ArgsEnvsPool defines a pool for args/envs allocations
 type ArgsEnvsPool struct {
-	pool sync.Pool
+	pool *sync.Pool
 }
 
 // Get returns a cache entry
@@ -142,30 +144,100 @@ func (a *ArgsEnvsPool) Get() *model.ArgsEnvsCacheEntry {
 // GetFrom returns a new entry with value from the given entry
 func (a *ArgsEnvsPool) GetFrom(event *model.ArgsEnvsEvent) *model.ArgsEnvsCacheEntry {
 	entry := a.Get()
-	*entry = event.ArgsEnvsCacheEntry
+	entry.ArgsEnvs = event.ArgsEnvs
 	return entry
 }
 
 // Put returns a cache entry to the pool
 func (a *ArgsEnvsPool) Put(entry *model.ArgsEnvsCacheEntry) {
-	for entry != nil {
-		// be sure to reset the entry here
-		next := entry.Next
-		entry.Next = nil
-		entry.Last = nil
-
-		a.pool.Put(entry)
-		entry = next
-	}
+	a.pool.Put(entry)
 }
 
 // NewArgsEnvsPool returns a new ArgsEnvEntry pool
 func NewArgsEnvsPool() *ArgsEnvsPool {
-	return &ArgsEnvsPool{
-		pool: sync.Pool{
-			New: func() interface{} { return &model.ArgsEnvsCacheEntry{} },
-		},
+	ap := ArgsEnvsPool{pool: &sync.Pool{}}
+
+	ap.pool.New = func() interface{} {
+		return model.NewArgsEnvsCacheEntry(ap.Put)
 	}
+
+	return &ap
+}
+
+// ProcessCacheEntryPool defines a pool for process entry allocations
+type ProcessCacheEntryPool struct {
+	pool *sync.Pool
+}
+
+// Get returns a cache entry
+func (p *ProcessCacheEntryPool) Get() *model.ProcessCacheEntry {
+	return p.pool.Get().(*model.ProcessCacheEntry)
+}
+
+// Put returns a cache entry
+func (p *ProcessCacheEntryPool) Put(pce *model.ProcessCacheEntry) {
+	pce.Reset()
+	p.pool.Put(pce)
+}
+
+// NewProcessCacheEntryPool returns a new ProcessCacheEntryPool pool
+func NewProcessCacheEntryPool(p *ProcessResolver) *ProcessCacheEntryPool {
+	pcep := ProcessCacheEntryPool{pool: &sync.Pool{}}
+
+	pcep.pool.New = func() interface{} {
+		return model.NewProcessCacheEntry(func(pce *model.ProcessCacheEntry) {
+			if pce.Ancestor != nil {
+				pce.Ancestor.Release()
+			}
+
+			if pce.ArgsEntry != nil && pce.ArgsEntry.ArgsEnvsCacheEntry != nil {
+				pce.ArgsEntry.ArgsEnvsCacheEntry.Release()
+			}
+			if pce.EnvsEntry != nil && pce.EnvsEntry.ArgsEnvsCacheEntry != nil {
+				pce.EnvsEntry.ArgsEnvsCacheEntry.Release()
+			}
+
+			atomic.AddInt64(&p.cacheSize, -1)
+
+			pcep.Put(pce)
+		})
+	}
+
+	return &pcep
+}
+
+// DequeueExited dequeue exited process
+func (p *ProcessResolver) DequeueExited() {
+	p.Lock()
+	defer p.Unlock()
+
+	delEntry := func(pid uint32, exitTime time.Time) {
+		p.deleteEntry(pid, exitTime)
+		_ = p.client.Count(metrics.MetricProcessResolverFlushed, 1, []string{}, 1.0)
+	}
+
+	now := time.Now()
+	for _, pid := range p.exitedQueue {
+		entry := p.entryCache[pid]
+		if entry == nil {
+			continue
+		}
+
+		if tm := entry.ExecTime; !tm.IsZero() && tm.Add(time.Minute).Before(now) {
+			delEntry(pid, now)
+		} else if tm := entry.ForkTime; !tm.IsZero() && tm.Add(time.Minute).Before(now) {
+			delEntry(pid, now)
+		} else if entry.ForkTime.IsZero() && entry.ExecTime.IsZero() {
+			delEntry(pid, now)
+		}
+	}
+
+	p.exitedQueue = p.exitedQueue[0:0]
+}
+
+// NewProcessCacheEntry returns a new process cache entry
+func (p *ProcessResolver) NewProcessCacheEntry() *model.ProcessCacheEntry {
+	return p.processCacheEntryPool.Get()
 }
 
 // SendStats sends process resolver metrics
@@ -186,14 +258,8 @@ func (p *ProcessResolver) UpdateArgsEnvs(event *model.ArgsEnvsEvent) {
 	entry := p.argsEnvsPool.GetFrom(event)
 	if e, found := p.argsEnvsCache.Get(event.ID); found {
 		list := e.(*model.ArgsEnvsCacheEntry)
-		if list.Last == nil {
-			list.Last = entry
-		} else {
-			list.Last.Next = entry
-			list.Last = entry
-		}
+		list.Append(entry)
 	} else {
-		entry.Last = entry
 		p.argsEnvsCache.Add(event.ID, entry)
 	}
 }
@@ -202,6 +268,7 @@ func (p *ProcessResolver) UpdateArgsEnvs(event *model.ArgsEnvsEvent) {
 func (p *ProcessResolver) AddForkEntry(pid uint32, entry *model.ProcessCacheEntry) *model.ProcessCacheEntry {
 	p.Lock()
 	defer p.Unlock()
+
 	return p.insertForkEntry(pid, entry)
 }
 
@@ -328,38 +395,23 @@ func (p *ProcessResolver) retrieveExecFileFields(procExecPath string) (*model.Fi
 	return &fileFields, nil
 }
 
-func (p *ProcessResolver) insertEntry(pid uint32, entry *model.ProcessCacheEntry) *model.ProcessCacheEntry {
+func (p *ProcessResolver) insertEntry(pid uint32, entry, prev *model.ProcessCacheEntry) *model.ProcessCacheEntry {
 	p.entryCache[pid] = entry
+	entry.Retain()
+
+	if prev != nil {
+		prev.Release()
+	}
 
 	_ = p.client.Count(metrics.MetricProcessResolverAdded, 1, []string{}, 1.0)
 	atomic.AddInt64(&p.cacheSize, 1)
-
-	var args *model.ArgsEnvsCacheEntry
-	if entry.ArgsEntry != nil {
-		args = entry.ArgsEntry.ArgsEnvsCacheEntry
-	}
-
-	var envs *model.ArgsEnvsCacheEntry
-	if entry.EnvsEntry != nil {
-		envs = entry.EnvsEntry.ArgsEnvsCacheEntry
-	}
-
-	runtime.SetFinalizer(entry, func(obj interface{}) {
-		if args != nil {
-			p.argsEnvsPool.Put(args)
-		}
-		if envs != nil {
-			p.argsEnvsPool.Put(envs)
-		}
-
-		atomic.AddInt64(&p.cacheSize, -1)
-	})
 
 	return entry
 }
 
 func (p *ProcessResolver) insertForkEntry(pid uint32, entry *model.ProcessCacheEntry) *model.ProcessCacheEntry {
-	if prev := p.entryCache[pid]; prev != nil {
+	prev := p.entryCache[pid]
+	if prev != nil {
 		// this shouldn't happen but it is better to exit the prev and let the new one replace it
 		prev.Exit(entry.ForkTime)
 	}
@@ -369,15 +421,16 @@ func (p *ProcessResolver) insertForkEntry(pid uint32, entry *model.ProcessCacheE
 		parent.Fork(entry)
 	}
 
-	return p.insertEntry(pid, entry)
+	return p.insertEntry(pid, entry, prev)
 }
 
 func (p *ProcessResolver) insertExecEntry(pid uint32, entry *model.ProcessCacheEntry) *model.ProcessCacheEntry {
-	if prev := p.entryCache[pid]; prev != nil {
+	prev := p.entryCache[pid]
+	if prev != nil {
 		prev.Exec(entry)
 	}
 
-	return p.insertEntry(pid, entry)
+	return p.insertEntry(pid, entry, prev)
 }
 
 func (p *ProcessResolver) deleteEntry(pid uint32, exitTime time.Time) {
@@ -387,7 +440,9 @@ func (p *ProcessResolver) deleteEntry(pid uint32, exitTime time.Time) {
 		return
 	}
 	entry.Exit(exitTime)
+
 	delete(p.entryCache, entry.Pid)
+	entry.Release()
 }
 
 // DeleteEntry tries to delete an entry in the process cache
@@ -499,7 +554,7 @@ func (p *ProcessResolver) resolveWithKernelMaps(pid, tid uint32) *model.ProcessC
 		return nil
 	}
 
-	entry := NewProcessCacheEntry()
+	entry := p.NewProcessCacheEntry()
 	data := append(entryb, cookieb...)
 
 	if _, err = p.unmarshalFromKernelMaps(entry, data); err != nil {
@@ -545,7 +600,7 @@ func (p *ProcessResolver) resolveWithProcfs(pid uint32, maxDepth int) *model.Pro
 	parent := p.resolveWithProcfs(uint32(filledProc.Ppid), maxDepth-1)
 	entry, inserted := p.syncCache(proc)
 	if inserted && entry != nil {
-		entry.Ancestor = parent
+		entry.SetAncestor(parent)
 	}
 
 	return entry
@@ -558,6 +613,12 @@ func (p *ProcessResolver) SetProcessArgs(pce *model.ProcessCacheEntry) {
 			ArgsEnvsCacheEntry: e.(*model.ArgsEnvsCacheEntry),
 		}
 
+		// attach to a process thus retain the head of the chain
+		// note: only the head of the list is retained and when released
+		// the whole list will be released
+		pce.ArgsEntry.ArgsEnvsCacheEntry.Retain()
+
+		// no need to keep it in LRU now as attached to a process
 		p.argsEnvsCache.Remove(pce.ArgsID)
 	}
 }
@@ -580,6 +641,12 @@ func (p *ProcessResolver) SetProcessEnvs(pce *model.ProcessCacheEntry) {
 			ArgsEnvsCacheEntry: e.(*model.ArgsEnvsCacheEntry),
 		}
 
+		// attach to a process thus retain the head of the chain
+		// note: only the head of the list is retained and when released
+		// the whole list will be released
+		pce.EnvsEntry.ArgsEnvsCacheEntry.Retain()
+
+		// no need to keep it in LRU now as attached to a process
 		p.argsEnvsCache.Remove(pce.ArgsID)
 	}
 }
@@ -696,12 +763,12 @@ func (p *ProcessResolver) Start(ctx context.Context) error {
 }
 
 func (p *ProcessResolver) cacheFlush(ctx context.Context) {
-	ticker := time.NewTicker(10 * time.Minute)
+	ticker := time.NewTicker(2 * time.Minute)
 	defer ticker.Stop()
 
 	for {
 		select {
-		case now := <-ticker.C:
+		case _ = <-ticker.C:
 			var pids []uint32
 
 			p.RLock()
@@ -710,24 +777,13 @@ func (p *ProcessResolver) cacheFlush(ctx context.Context) {
 			}
 			p.RUnlock()
 
-			delEntry := func(pid uint32, exitTime time.Time) {
-				p.deleteEntry(pid, exitTime)
-				_ = p.client.Count(metrics.MetricProcessResolverFlushed, 1, []string{}, 1.0)
-			}
-
-			// flush slowly
+			// iterating slowly
 			for _, pid := range pids {
 				if _, err := process.NewProcess(int32(pid)); err != nil {
 					// check start time to ensure to not delete a recent pid
 					p.Lock()
 					if entry := p.entryCache[pid]; entry != nil {
-						if tm := entry.ExecTime; !tm.IsZero() && tm.Add(time.Minute).Before(now) {
-							delEntry(pid, now)
-						} else if tm := entry.ForkTime; !tm.IsZero() && tm.Add(time.Minute).Before(now) {
-							delEntry(pid, now)
-						} else if entry.ForkTime.IsZero() && entry.ExecTime.IsZero() {
-							delEntry(pid, now)
-						}
+						p.exitedQueue = append(p.exitedQueue, pid)
 					}
 					p.Unlock()
 				}
@@ -759,7 +815,7 @@ func (p *ProcessResolver) syncCache(proc *process.Process) (*model.ProcessCacheE
 		return nil, false
 	}
 
-	entry = NewProcessCacheEntry()
+	entry = p.NewProcessCacheEntry()
 
 	// update the cache entry
 	if err := p.enrichEventFromProc(entry, proc); err != nil {
@@ -769,10 +825,10 @@ func (p *ProcessResolver) syncCache(proc *process.Process) (*model.ProcessCacheE
 
 	parent := p.entryCache[entry.PPid]
 	if parent != nil {
-		entry.Ancestor = parent
+		entry.SetAncestor(parent)
 	}
 
-	if entry = p.insertEntry(pid, entry); entry == nil {
+	if entry = p.insertEntry(pid, entry, p.entryCache[pid]); entry == nil {
 		return nil, false
 	}
 
@@ -859,7 +915,7 @@ func NewProcessResolver(probe *Probe, resolvers *Resolvers, client *statsd.Clien
 		return nil, err
 	}
 
-	return &ProcessResolver{
+	p := &ProcessResolver{
 		probe:         probe,
 		resolvers:     resolvers,
 		client:        client,
@@ -868,7 +924,10 @@ func NewProcessResolver(probe *Probe, resolvers *Resolvers, client *statsd.Clien
 		argsEnvsCache: argsEnvsCache,
 		state:         snapshotting,
 		argsEnvsPool:  NewArgsEnvsPool(),
-	}, nil
+	}
+	p.processCacheEntryPool = NewProcessCacheEntryPool(p)
+
+	return p, nil
 }
 
 // NewProcessResolverOpts returns a new set of process resolver options

--- a/pkg/security/probe/process_resolver_test.go
+++ b/pkg/security/probe/process_resolver_test.go
@@ -8,44 +8,42 @@
 package probe
 
 import (
-	"runtime"
+	"fmt"
 	"sync/atomic"
 	"testing"
 	"time"
 
 	"github.com/avast/retry-go"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 )
 
 func testCacheSize(t *testing.T, resolver *ProcessResolver) {
 	err := retry.Do(
 		func() error {
-			runtime.GC()
 			if atomic.LoadInt64(&resolver.cacheSize) == 0 {
 				return nil
 			}
 
-			return errors.New("cache size error")
+			return fmt.Errorf("cache size error: %d", atomic.LoadInt64(&resolver.cacheSize))
 		},
 	)
 	assert.Nil(t, err)
 }
 
 func TestFork1st(t *testing.T) {
-	parent := NewProcessCacheEntry()
-	parent.Pid = 1
-	parent.ForkTime = time.Now()
-
-	child := NewProcessCacheEntry()
-	child.Pid = 2
-	child.PPid = parent.Pid
-	child.ForkTime = time.Now()
-
 	resolver, err := NewProcessResolver(nil, nil, nil, NewProcessResolverOpts(10000))
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	parent := resolver.NewProcessCacheEntry()
+	parent.Pid = 1
+	parent.ForkTime = time.Now()
+
+	child := resolver.NewProcessCacheEntry()
+	child.Pid = 2
+	child.PPid = parent.Pid
+	child.ForkTime = time.Now()
 
 	// parent
 	resolver.AddForkEntry(parent.Pid, parent)
@@ -74,19 +72,19 @@ func TestFork1st(t *testing.T) {
 }
 
 func TestFork2nd(t *testing.T) {
-	parent := NewProcessCacheEntry()
-	parent.Pid = 1
-	parent.ForkTime = time.Now()
-
-	child := NewProcessCacheEntry()
-	child.Pid = 2
-	child.PPid = parent.Pid
-	child.ForkTime = time.Now()
-
 	resolver, err := NewProcessResolver(nil, nil, nil, NewProcessResolverOpts(10000))
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	parent := resolver.NewProcessCacheEntry()
+	parent.Pid = 1
+	parent.ForkTime = time.Now()
+
+	child := resolver.NewProcessCacheEntry()
+	child.Pid = 2
+	child.PPid = parent.Pid
+	child.ForkTime = time.Now()
 
 	// parent
 	resolver.AddForkEntry(parent.Pid, parent)
@@ -117,24 +115,24 @@ func TestFork2nd(t *testing.T) {
 }
 
 func TestForkExec(t *testing.T) {
-	parent := NewProcessCacheEntry()
-	parent.Pid = 1
-	parent.ForkTime = time.Now()
-
-	child := NewProcessCacheEntry()
-	child.Pid = 2
-	child.PPid = parent.Pid
-	child.ForkTime = time.Now()
-
-	exec := NewProcessCacheEntry()
-	exec.Pid = child.Pid
-	exec.PPid = child.PPid
-	exec.ExecTime = time.Now()
-
 	resolver, err := NewProcessResolver(nil, nil, nil, NewProcessResolverOpts(10000))
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	parent := resolver.NewProcessCacheEntry()
+	parent.Pid = 1
+	parent.ForkTime = time.Now()
+
+	child := resolver.NewProcessCacheEntry()
+	child.Pid = 2
+	child.PPid = parent.Pid
+	child.ForkTime = time.Now()
+
+	exec := resolver.NewProcessCacheEntry()
+	exec.Pid = child.Pid
+	exec.PPid = child.PPid
+	exec.ExecTime = time.Now()
 
 	// parent
 	resolver.AddForkEntry(parent.Pid, parent)
@@ -175,24 +173,24 @@ func TestForkExec(t *testing.T) {
 }
 
 func TestOrphanExec(t *testing.T) {
-	parent := NewProcessCacheEntry()
-	parent.Pid = 1
-	parent.ForkTime = time.Now()
-
-	child := NewProcessCacheEntry()
-	child.Pid = 2
-	child.PPid = parent.Pid
-	child.ForkTime = time.Now()
-
-	exec := NewProcessCacheEntry()
-	exec.Pid = child.Pid
-	exec.PPid = child.PPid
-	exec.ExecTime = time.Now()
-
 	resolver, err := NewProcessResolver(nil, nil, nil, NewProcessResolverOpts(10000))
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	parent := resolver.NewProcessCacheEntry()
+	parent.Pid = 1
+	parent.ForkTime = time.Now()
+
+	child := resolver.NewProcessCacheEntry()
+	child.Pid = 2
+	child.PPid = parent.Pid
+	child.ForkTime = time.Now()
+
+	exec := resolver.NewProcessCacheEntry()
+	exec.Pid = child.Pid
+	exec.PPid = child.PPid
+	exec.ExecTime = time.Now()
 
 	// parent
 	resolver.AddForkEntry(parent.Pid, parent)
@@ -232,29 +230,29 @@ func TestOrphanExec(t *testing.T) {
 }
 
 func TestForkExecExec(t *testing.T) {
-	parent := NewProcessCacheEntry()
-	parent.Pid = 1
-	parent.ForkTime = time.Now()
-
-	child := NewProcessCacheEntry()
-	child.Pid = 2
-	child.PPid = parent.Pid
-	child.ForkTime = time.Now()
-
-	exec1 := NewProcessCacheEntry()
-	exec1.Pid = child.Pid
-	exec1.PPid = child.PPid
-	exec1.ExecTime = time.Now()
-
-	exec2 := NewProcessCacheEntry()
-	exec2.Pid = child.Pid
-	exec2.PPid = child.PPid
-	exec2.ExecTime = time.Now()
-
 	resolver, err := NewProcessResolver(nil, nil, nil, NewProcessResolverOpts(10000))
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	parent := resolver.NewProcessCacheEntry()
+	parent.Pid = 1
+	parent.ForkTime = time.Now()
+
+	child := resolver.NewProcessCacheEntry()
+	child.Pid = 2
+	child.PPid = parent.Pid
+	child.ForkTime = time.Now()
+
+	exec1 := resolver.NewProcessCacheEntry()
+	exec1.Pid = child.Pid
+	exec1.PPid = child.PPid
+	exec1.ExecTime = time.Now()
+
+	exec2 := resolver.NewProcessCacheEntry()
+	exec2.Pid = child.Pid
+	exec2.PPid = child.PPid
+	exec2.ExecTime = time.Now()
 
 	// parent
 	resolver.AddForkEntry(parent.Pid, parent)
@@ -304,33 +302,33 @@ func TestForkExecExec(t *testing.T) {
 }
 
 func TestForkReuse(t *testing.T) {
-	parent1 := NewProcessCacheEntry()
-	parent1.Pid = 1
-	parent1.ForkTime = time.Now()
-
-	child1 := NewProcessCacheEntry()
-	child1.Pid = 2
-	child1.PPid = parent1.Pid
-	child1.ForkTime = time.Now()
-
-	exec1 := NewProcessCacheEntry()
-	exec1.Pid = child1.Pid
-	exec1.PPid = child1.PPid
-	exec1.ExecTime = time.Now()
-
-	parent2 := NewProcessCacheEntry()
-	parent2.Pid = 1
-	parent2.ForkTime = time.Now()
-
-	child2 := NewProcessCacheEntry()
-	child2.Pid = 3
-	child2.PPid = parent2.Pid
-	child2.ForkTime = time.Now()
-
 	resolver, err := NewProcessResolver(nil, nil, nil, NewProcessResolverOpts(10000))
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	parent1 := resolver.NewProcessCacheEntry()
+	parent1.Pid = 1
+	parent1.ForkTime = time.Now()
+
+	child1 := resolver.NewProcessCacheEntry()
+	child1.Pid = 2
+	child1.PPid = parent1.Pid
+	child1.ForkTime = time.Now()
+
+	exec1 := resolver.NewProcessCacheEntry()
+	exec1.Pid = child1.Pid
+	exec1.PPid = child1.PPid
+	exec1.ExecTime = time.Now()
+
+	parent2 := resolver.NewProcessCacheEntry()
+	parent2.Pid = 1
+	parent2.ForkTime = time.Now()
+
+	child2 := resolver.NewProcessCacheEntry()
+	child2.Pid = 3
+	child2.PPid = parent2.Pid
+	child2.ForkTime = time.Now()
 
 	// parent1
 	resolver.AddForkEntry(parent1.Pid, parent1)
@@ -403,29 +401,29 @@ func TestForkReuse(t *testing.T) {
 }
 
 func TestForkForkExec(t *testing.T) {
-	parent := NewProcessCacheEntry()
-	parent.Pid = 1
-	parent.ForkTime = time.Now()
-
-	child := NewProcessCacheEntry()
-	child.Pid = 2
-	child.PPid = parent.Pid
-	child.ForkTime = time.Now()
-
-	grandChild := NewProcessCacheEntry()
-	grandChild.Pid = 3
-	grandChild.PPid = child.Pid
-	grandChild.ForkTime = time.Now()
-
-	childExec := NewProcessCacheEntry()
-	childExec.Pid = child.Pid
-	childExec.PPid = child.PPid
-	childExec.ExecTime = time.Now()
-
 	resolver, err := NewProcessResolver(nil, nil, nil, NewProcessResolverOpts(10000))
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	parent := resolver.NewProcessCacheEntry()
+	parent.Pid = 1
+	parent.ForkTime = time.Now()
+
+	child := resolver.NewProcessCacheEntry()
+	child.Pid = 2
+	child.PPid = parent.Pid
+	child.ForkTime = time.Now()
+
+	grandChild := resolver.NewProcessCacheEntry()
+	grandChild.Pid = 3
+	grandChild.PPid = child.Pid
+	grandChild.ForkTime = time.Now()
+
+	childExec := resolver.NewProcessCacheEntry()
+	childExec.Pid = child.Pid
+	childExec.PPid = child.PPid
+	childExec.ExecTime = time.Now()
 
 	// parent
 	resolver.AddForkEntry(parent.Pid, parent)

--- a/pkg/security/probe/user_resolver.go
+++ b/pkg/security/probe/user_resolver.go
@@ -11,13 +11,13 @@ import (
 	"os/user"
 	"strconv"
 
-	"github.com/hashicorp/golang-lru/simplelru"
+	lru "github.com/hashicorp/golang-lru"
 )
 
 // UserGroupResolver resolves user and group ids to names
 type UserGroupResolver struct {
-	userCache  *simplelru.LRU
-	groupCache *simplelru.LRU
+	userCache  *lru.Cache
+	groupCache *lru.Cache
 }
 
 // ResolveUser resolves a user id to a username
@@ -54,12 +54,12 @@ func (r *UserGroupResolver) ResolveGroup(gid int) (string, error) {
 
 // NewUserGroupResolver instantiates a new user and group resolver
 func NewUserGroupResolver() (*UserGroupResolver, error) {
-	userCache, err := simplelru.NewLRU(64, nil)
+	userCache, err := lru.New(64)
 	if err != nil {
 		return nil, err
 	}
 
-	groupCache, err := simplelru.NewLRU(64, nil)
+	groupCache, err := lru.New(64)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/tests/setup_test.go
+++ b/pkg/security/tests/setup_test.go
@@ -196,7 +196,8 @@ func (h *testEventHandler) ClearEventsChannels() {
 
 func (h *testEventHandler) HandleEvent(event *sprobe.Event) {
 	testMod.module.HandleEvent(event)
-	e := event.Clone()
+
+	e := event.Retain()
 	select {
 	case h.GetActiveEventsChan() <- &e:
 		break
@@ -491,7 +492,8 @@ func (tm *testModule) SwapLogLevel(logLevel seelog.LogLevel) (seelog.LogLevel, e
 }
 
 func (tm *testModule) RuleMatch(rule *rules.Rule, event eval.Event) {
-	e := event.(*sprobe.Event).Clone()
+	e := event.(*sprobe.Event).Retain()
+
 	te := testEvent{Event: &e, rule: rule.Rule}
 	select {
 	case tm.events <- te:
@@ -501,7 +503,8 @@ func (tm *testModule) RuleMatch(rule *rules.Rule, event eval.Event) {
 }
 
 func (tm *testModule) EventDiscarderFound(rs *rules.RuleSet, event eval.Event, field eval.Field, eventType eval.EventType) {
-	e := event.(*sprobe.Event).Clone()
+	e := event.(*sprobe.Event).Retain()
+
 	discarder := &testDiscarder{event: &e, field: field, eventType: eventType}
 	select {
 	case tm.discarders <- discarder:


### PR DESCRIPTION
### What does this PR do?

Introduces pool allocator to reduce memory allocations for args and process entry. It also discards the system-probe open event during the snapshot in order to reduce the CPU pressure.

### Motivation

Reduce memory allocations so that it reduces memory spikes between two GC. 

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

We should see less memory spike on staging environment.
