### PR TITLE
[Gitlab] Make jobs that run on master also run on main

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -150,10 +150,10 @@ variables:
 # Condition mixins for simplification of rules
 #
 .if_master_branch: &if_master_branch
-  if: $CI_COMMIT_BRANCH == "master"
+  if: $CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "main"
 
 .if_not_master_branch: &if_not_master_branch
-  if: $CI_COMMIT_BRANCH != "master"
+  if: $CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "main"
 
 .if_release_branch: &if_release_branch
   if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+\.x$/
@@ -202,7 +202,7 @@ variables:
 # RUN_KITCHEN_TESTS can be set to true to force kitchen tests to be run on a branch pipeline.
 # RUN_KITCHEN_TESTS can be set to false to force kithcen tests to not run on master/deploy pipelines.
 .if_kitchen: &if_kitchen
-  if: ($CI_COMMIT_BRANCH == "master" || $DEPLOY_AGENT == "true" || $RUN_KITCHEN_TESTS == "true") && $RUN_KITCHEN_TESTS != "false"
+  if: ($CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "main"  || $DEPLOY_AGENT == "true" || $RUN_KITCHEN_TESTS == "true") && $RUN_KITCHEN_TESTS != "false"
 
 # Rules to trigger default kitchen tests.
 # Some of the kitchen tests are run on all pipelines by default. They can only be disabled

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -48,7 +48,7 @@ tests_ebpf_x64:
     # Compile runtime security stress tests to be executed in kitchen tests
     - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
     # Compile master version for comparison, uncomment following lines when merged
-    - git checkout -f master
+    - git checkout -f main || git checkout -f master
     - git pull
     - inv -e deps
     - inv -e system-probe.build --bundle-ebpf --incremental-build


### PR DESCRIPTION
### What does this PR do?

- Make Gitlab rules that apply to `master` also apply to `main`.
- Make ebpf test try to checkout from both master and main.

### Motivation

Upcoming rename from `master` to `main`.

### Additional Notes

Should we change the name of rules on this PR too?
