### PR TITLE
[tasks] Change default branch from `master` to `main`

### DIFF
--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -13,7 +13,7 @@ from invoke import task
 
 # constants
 ORG_PATH = "github.com/DataDog"
-DEFAULT_BRANCH = "master"
+DEFAULT_BRANCH = "main"
 REPO_PATH = "{}/datadog-agent".format(ORG_PATH)
 
 


### PR DESCRIPTION
### What does this PR do?

Change default branch from `master` to `main` on `tasks` code. Follow up to #8303.

### Motivation

Renaming `master` to `main`

### Additional Notes

**This should be merged only after the renaming is complete.**
