### PR TITLE
Improve support for slow to load secret backend and troubleshooting them

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -263,7 +263,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("secret_backend_command", "")
 	config.BindEnvAndSetDefault("secret_backend_arguments", []string{})
 	config.BindEnvAndSetDefault("secret_backend_output_max_size", secrets.SecretBackendOutputMaxSize)
-	config.BindEnvAndSetDefault("secret_backend_timeout", 5)
+	config.BindEnvAndSetDefault("secret_backend_timeout", 30)
 	config.BindEnvAndSetDefault("secret_backend_command_allow_group_exec_perm", false)
 
 	// Use to output logs in JSON format

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -495,10 +495,10 @@ api_key:
 #
 # secret_backend_output_max_size: 1048576
 
-## @param secret_backend_timeout - integer - optional - default: 5
+## @param secret_backend_timeout - integer - optional - default: 30
 ## The timeout to execute the command in second
 #
-# secret_backend_timeout: 5
+# secret_backend_timeout: 30
 
 ## @param snmp_listener - custom object - optional
 ## Creates and schedules a listener to automatically discover your SNMP devices.

--- a/releasenotes/notes/improve-secret-backend-troubleshooting-47488d46bf6227e4.yaml
+++ b/releasenotes/notes/improve-secret-backend-troubleshooting-47488d46bf6227e4.yaml
@@ -4,6 +4,6 @@ enhancements:
     When using a `secret_backend_command` STDERR is always logged with a debug log level. This eases troubleshooting a
     user's `secret_backend_command` in a containerized environment.
   - |
-    `secret_backend_timeout` has been increased from 5s to 30s. This will help better support, for example, slow to load
+    `secret_backend_timeout` has been increased from 5s to 30s. This increases support for the slow to load
     Python script used for `secret_backend_command`. This could have been an issue when importing large librairies in a
     containerized environment.

--- a/releasenotes/notes/improve-secret-backend-troubleshooting-47488d46bf6227e4.yaml
+++ b/releasenotes/notes/improve-secret-backend-troubleshooting-47488d46bf6227e4.yaml
@@ -5,5 +5,5 @@ enhancements:
     user's `secret_backend_command` in a containerized environment.
   - |
     `secret_backend_timeout` has been increased from 5s to 30s. This increases support for the slow to load
-    Python script used for `secret_backend_command`. This could have been an issue when importing large librairies in a
+    Python script used for `secret_backend_command`. This was an issue when importing large libraries in a
     containerized environment.

--- a/releasenotes/notes/improve-secret-backend-troubleshooting-47488d46bf6227e4.yaml
+++ b/releasenotes/notes/improve-secret-backend-troubleshooting-47488d46bf6227e4.yaml
@@ -1,0 +1,9 @@
+---
+enhancements:
+  - |
+    When using a `secret_backend_command` STDERR will always be logged with a debug log level. This ease troubleshooting
+    user's `secret_backend_command` in a containerized environment.
+  - |
+    `secret_backend_timeout` has been increased from 5s to 30s. This will help better support, for example, slow to load
+    Python script used for `secret_backend_command`. This could have been an issue when importing large librairies in a
+    containerized environment.

--- a/releasenotes/notes/improve-secret-backend-troubleshooting-47488d46bf6227e4.yaml
+++ b/releasenotes/notes/improve-secret-backend-troubleshooting-47488d46bf6227e4.yaml
@@ -1,7 +1,7 @@
 ---
 enhancements:
   - |
-    When using a `secret_backend_command` STDERR will always be logged with a debug log level. This ease troubleshooting
+    When using a `secret_backend_command` STDERR is always logged with a debug log level. This eases troubleshooting a
     user's `secret_backend_command` in a containerized environment.
   - |
     `secret_backend_timeout` has been increased from 5s to 30s. This will help better support, for example, slow to load


### PR DESCRIPTION
### What does this PR do?

When using a `secret_backend_command` STDERR will always be logged with a debug log level. This ease troubleshooting user's `secret_backend_command` in a containerized environment.

`secret_backend_timeout` has been increased from 5s to 30s. This will help better support, for example, slow to load Python script used for `secret_backend_command`. This could have been an issue when importing large librairies in a containerized environment.

### Motivation

Users Python script could timeout when using secret in a daemonset (especially when not using the official Helm chart).

### Describe how to test your changes

- Setup a EKS/GKE cluster
- Deploy the Agent as a `daemonset` **NOT** using the official Helm but simply using the official docker image.

  Don't forget the base role definition:
  ```
  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/rbac/clusterrole.yaml"
  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/rbac/serviceaccount.yaml" 
  kubectl apply -f "https://raw.githubusercontent.com/DataDog/datadog-agent/master/Dockerfiles/manifests/rbac/clusterrolebinding.yaml"
  ```

  Here is a example daemonset:

  ```
  ---
  apiVersion: v1
  kind: Secret
  metadata:
    name: dd-secret
  data:
    api-key: <YOUR API KEY b64 encoded>
  ---
  apiVersion: apps/v1
  kind: DaemonSet
  metadata:
    name: datadog-agent
    namespace: default
  spec:
    selector:
      matchLabels:
        app: datadog-agent
    template:
      metadata:
        labels:
          app: datadog-agent
        name: datadog-agent
      spec:
        serviceAccountName: datadog-agent
        containers:
        - image: datadog/agent:7
          imagePullPolicy: Always
          name: datadog-agent
          env:
            - name: DD_LOG_LEVEL
              value: DEBUG
            - name: DD_API_KEY
              value: ENC[api-key]
            - name: DD_SECRET_BACKEND_COMMAND
              value: "<you secret_backend_command script>"
            - name: DD_COLLECT_KUBERNETES_EVENTS
              value: "true"
            - name: DD_LEADER_ELECTION
              value: "true"
            - name: KUBERNETES
              value: "true"
            - name: DD_HEALTH_PORT
              value: "5555"
            - name: DD_KUBERNETES_KUBELET_HOST
              valueFrom:
                fieldRef:
                  fieldPath: status.hostIP
          resources:
            requests:
              memory: "256Mi"
              cpu: "200m"
            limits:
              memory: "256Mi"
              cpu: "200m"
          livenessProbe:
            httpGet:
              path: /health
              port: 5555
            initialDelaySeconds: 15
            periodSeconds: 15
            timeoutSeconds: 5
            successThreshold: 1
            failureThreshold: 3
          volumeMounts:
            - name: secret-volume
              mountPath: /etc/secret-volume
        volumes:
          - name: secret-volume
            secret:
              secretName: dd-secret
  ```
- Setup a Python script as `secret_backend_command`. You need to import large python libraries (`boto3` is a good example and will  slow down python startup but a lot). You can use the official secret helper as a base https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/agent/secrets-helper (This will soon be replace by a Go equivalent). Also update the script to log something on STDERR.
- Deploy your daemonset and make sure the pod don't restart and check that what was logged by the script on STDERR was logged by the agent even if the `secret_backend_script` did not exit with and error code.