### PR TITLE
[Serverless] support for DD_TAGS and DD_EXTRA_TAGS

### DIFF
--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -68,7 +68,7 @@ func start(getAC func() *autodiscovery.AutoConfig, serverless bool, logsChan cha
 
 	// setup the server config
 	httpConnectivity := config.HTTPConnectivityFailure
-	if endpoints, err := config.BuildHTTPEndpoints(); err == nil && !serverless {
+	if endpoints, err := config.BuildHTTPEndpoints(); err == nil {
 		httpConnectivity = http.CheckConnectivity(endpoints.Main)
 	}
 	endpoints, err := config.BuildEndpoints(httpConnectivity)

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -68,7 +68,7 @@ func start(getAC func() *autodiscovery.AutoConfig, serverless bool, logsChan cha
 
 	// setup the server config
 	httpConnectivity := config.HTTPConnectivityFailure
-	if endpoints, err := config.BuildHTTPEndpoints(); err == nil {
+	if endpoints, err := config.BuildHTTPEndpoints(); err == nil && !serverless {
 		httpConnectivity = http.CheckConnectivity(endpoints.Main)
 	}
 	endpoints, err := config.BuildEndpoints(httpConnectivity)

--- a/pkg/serverless/aws/logs.go
+++ b/pkg/serverless/aws/logs.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"time"
 
+	logConfig "github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/scheduler"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -198,4 +200,17 @@ func ParseLogsAPIPayload(data []byte) ([]LogMessage, error) {
 // removeInvalidTracingItem is a temporary fix to handle malformed JSON tracing object
 func removeInvalidTracingItem(data []byte) []byte {
 	return []byte(strings.ReplaceAll(string(data), ",\"tracing\":}", ""))
+}
+
+// GetLambdaSource returns the LogSource used by the extension
+func GetLambdaSource() *logConfig.LogSource {
+	currentScheduler := scheduler.GetScheduler()
+	if currentScheduler != nil {
+		source := currentScheduler.GetSourceFromName("lambda")
+		if source != nil {
+			return source
+		}
+	}
+	log.Debug("Impossible to retrieve the lambda LogSource")
+	return nil
 }

--- a/pkg/serverless/aws/logs_test.go
+++ b/pkg/serverless/aws/logs_test.go
@@ -11,6 +11,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/scheduler"
+	"github.com/DataDog/datadog-agent/pkg/logs/service"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -141,4 +144,29 @@ func TestParseLogsAPIPayloadNotWellFormatedButNotRecoverable(t *testing.T) {
 	require.NoError(t, err)
 	_, err = ParseLogsAPIPayload(raw)
 	assert.NotNil(t, err)
+}
+
+func TestGetLambdaSourceNilScheduler(t *testing.T) {
+	assert.Nil(t, GetLambdaSource())
+}
+
+func TestGetLambdaSourceNilSource(t *testing.T) {
+	logSources := config.NewLogSources()
+	services := service.NewServices()
+	scheduler.CreateScheduler(logSources, services)
+	assert.Nil(t, GetLambdaSource())
+}
+
+func TestGetLambdaSourceValidSource(t *testing.T) {
+	logSources := config.NewLogSources()
+	chanSource := config.NewLogSource("TestLog", &config.LogsConfig{
+		Type:    config.StringChannelType,
+		Source:  "lambda",
+		Tags:    nil,
+		Channel: nil,
+	})
+	logSources.AddSource(chanSource)
+	services := service.NewServices()
+	scheduler.CreateScheduler(logSources, services)
+	assert.NotNil(t, GetLambdaSource())
 }

--- a/pkg/serverless/protocol.go
+++ b/pkg/serverless/protocol.go
@@ -20,7 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
 	"github.com/DataDog/datadog-agent/pkg/logs"
 	logConfig "github.com/DataDog/datadog-agent/pkg/logs/config"
-	"github.com/DataDog/datadog-agent/pkg/logs/scheduler"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/serverless/aws"
 	"github.com/DataDog/datadog-agent/pkg/serverless/flush"
@@ -285,8 +284,8 @@ func (d *Daemon) WaitUntilClientReady(timeout time.Duration) bool {
 // ComputeGlobalTags extracts tags from the ARN, merges them with any user-defined tags and adds them to traces, logs and metrics
 func (d *Daemon) ComputeGlobalTags(arn string, configTags []string) {
 	if len(d.extraTags) == 0 {
-		tagMap := buildTagMapFromArn(arn)
-		tagArray := buildTagsFromMap(configTags, tagMap)
+		tagMap := buildTagMap(arn, configTags)
+		tagArray := buildTagsFromMap(tagMap)
 		if d.statsdServer != nil {
 			d.statsdServer.SetExtraTags(tagArray)
 		}
@@ -294,7 +293,7 @@ func (d *Daemon) ComputeGlobalTags(arn string, configTags []string) {
 			d.traceAgent.SetGlobalTags(buildTracerTags(tagMap))
 		}
 		d.extraTags = tagArray
-		source := scheduler.GetScheduler().GetSourceFromName("lambda")
+		source := aws.GetLambdaSource()
 		if source != nil {
 			source.Config.Tags = tagArray
 		} else {

--- a/pkg/serverless/tags.go
+++ b/pkg/serverless/tags.go
@@ -26,8 +26,12 @@ const (
 	executedVersionKey       = "executedversion"
 )
 
-func buildTagMapFromArn(arn string) map[string]string {
+func buildTagMap(arn string, configTags []string) map[string]string {
 	tags := make(map[string]string)
+
+	for _, tag := range configTags {
+		tags = addTag(tags, tag)
+	}
 
 	tags = setIfNotEmpty(tags, traceOriginMetadataKey, traceOriginMetadataValue)
 	tags = setIfNotEmpty(tags, computeStatsKey, computeStatsValue)
@@ -54,7 +58,7 @@ func buildTagMapFromArn(arn string) map[string]string {
 	return tags
 }
 
-func buildTagsFromMap(configTags []string, tags map[string]string) []string {
+func buildTagsFromMap(tags map[string]string) []string {
 	tagsMap := make(map[string]string)
 	tagBlackList := []string{traceOriginMetadataKey, computeStatsKey}
 	for k, v := range tags {
@@ -63,8 +67,7 @@ func buildTagsFromMap(configTags []string, tags map[string]string) []string {
 	for _, blackListKey := range tagBlackList {
 		delete(tagsMap, blackListKey)
 	}
-	tagsArray := make([]string, 0, len(configTags)+len(tagsMap))
-	tagsArray = append(tagsArray, configTags...)
+	tagsArray := make([]string, 0, len(tagsMap))
 	for key, value := range tagsMap {
 		tagsArray = append(tagsArray, fmt.Sprintf("%s:%s", key, value))
 	}
@@ -86,6 +89,14 @@ func buildTracerTags(tags map[string]string) map[string]string {
 func setIfNotEmpty(tagMap map[string]string, key string, value string) map[string]string {
 	if key != "" {
 		tagMap[key] = strings.ToLower(value)
+	}
+	return tagMap
+}
+
+func addTag(tagMap map[string]string, tag string) map[string]string {
+	extract := strings.Split(tag, ":")
+	if len(extract) == 2 {
+		tagMap[strings.ToLower(extract[0])] = strings.ToLower(extract[1])
 	}
 	return tagMap
 }

--- a/pkg/serverless/tags_test.go
+++ b/pkg/serverless/tags_test.go
@@ -47,12 +47,9 @@ func TestBuildTagsFromMap(t *testing.T) {
 		"_dd.origin":        "xxx",
 		"_dd.compute_stats": "xxx",
 	}
-	configTags := []string{"configTagKey0:configTagValue0", "configTagKey1:configTagValue1"}
-	resultTagsArray := buildTagsFromMap(configTags, tagsMap)
+	resultTagsArray := buildTagsFromMap(tagsMap)
 	sort.Strings(resultTagsArray)
 	assert.Equal(t, []string{
-		"configTagKey0:configTagValue0",
-		"configTagKey1:configTagValue1",
 		"key0:value0",
 		"key1:value1",
 		"key2:value2",
@@ -62,17 +59,19 @@ func TestBuildTagsFromMap(t *testing.T) {
 
 func TestBuildTagMapFromArnIncomplete(t *testing.T) {
 	arn := "function:my-function"
-	tagMap := buildTagMapFromArn(arn)
-	assert.Equal(t, 3, len(tagMap))
+	tagMap := buildTagMap(arn, []string{"tag0:value0", "TAG1:VALUE1"})
+	assert.Equal(t, 5, len(tagMap))
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
 	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "function:my-function", tagMap["function_arn"])
+	assert.Equal(t, "value0", tagMap["tag0"])
+	assert.Equal(t, "value1", tagMap["tag1"])
 }
 
 func TestBuildTagMapFromArnComplete(t *testing.T) {
 	arn := "arn:aws:lambda:us-east-1:123456789012:function:my-function"
-	tagMap := buildTagMapFromArn(arn)
-	assert.Equal(t, 7, len(tagMap))
+	tagMap := buildTagMap(arn, []string{"tag0:value0", "TAG1:VALUE1"})
+	assert.Equal(t, 9, len(tagMap))
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
 	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
@@ -80,12 +79,14 @@ func TestBuildTagMapFromArnComplete(t *testing.T) {
 	assert.Equal(t, "123456789012", tagMap["aws_account"])
 	assert.Equal(t, "my-function", tagMap["functionname"])
 	assert.Equal(t, "my-function", tagMap["resource"])
+	assert.Equal(t, "value0", tagMap["tag0"])
+	assert.Equal(t, "value1", tagMap["tag1"])
 }
 
 func TestBuildTagMapFromArnCompleteWithUpperCase(t *testing.T) {
 	arn := "arn:aws:lambda:us-east-1:123456789012:function:My-Function"
-	tagMap := buildTagMapFromArn(arn)
-	assert.Equal(t, 7, len(tagMap))
+	tagMap := buildTagMap(arn, []string{"tag0:value0", "TAG1:VALUE1"})
+	assert.Equal(t, 9, len(tagMap))
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
 	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
@@ -93,13 +94,15 @@ func TestBuildTagMapFromArnCompleteWithUpperCase(t *testing.T) {
 	assert.Equal(t, "123456789012", tagMap["aws_account"])
 	assert.Equal(t, "my-function", tagMap["functionname"])
 	assert.Equal(t, "my-function", tagMap["resource"])
+	assert.Equal(t, "value0", tagMap["tag0"])
+	assert.Equal(t, "value1", tagMap["tag1"])
 }
 
 func TestBuildTagMapFromArnCompleteWithLatest(t *testing.T) {
 	os.Setenv("AWS_LAMBDA_FUNCTION_VERSION", "$LATEST")
 	arn := "arn:aws:lambda:us-east-1:123456789012:function:my-function"
-	tagMap := buildTagMapFromArn(arn)
-	assert.Equal(t, 7, len(tagMap))
+	tagMap := buildTagMap(arn, []string{"tag0:value0", "TAG1:VALUE1"})
+	assert.Equal(t, 9, len(tagMap))
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
 	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
@@ -107,13 +110,15 @@ func TestBuildTagMapFromArnCompleteWithLatest(t *testing.T) {
 	assert.Equal(t, "123456789012", tagMap["aws_account"])
 	assert.Equal(t, "my-function", tagMap["functionname"])
 	assert.Equal(t, "my-function", tagMap["resource"])
+	assert.Equal(t, "value0", tagMap["tag0"])
+	assert.Equal(t, "value1", tagMap["tag1"])
 }
 
 func TestBuildTagMapFromArnCompleteWithVersionNumber(t *testing.T) {
 	os.Setenv("AWS_LAMBDA_FUNCTION_VERSION", "888")
 	arn := "arn:aws:lambda:us-east-1:123456789012:function:my-function"
-	tagMap := buildTagMapFromArn(arn)
-	assert.Equal(t, 8, len(tagMap))
+	tagMap := buildTagMap(arn, []string{"tag0:value0", "TAG1:VALUE1"})
+	assert.Equal(t, 10, len(tagMap))
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
 	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
@@ -122,4 +127,6 @@ func TestBuildTagMapFromArnCompleteWithVersionNumber(t *testing.T) {
 	assert.Equal(t, "my-function", tagMap["functionname"])
 	assert.Equal(t, "my-function:888", tagMap["resource"])
 	assert.Equal(t, "888", tagMap["executedversion"])
+	assert.Equal(t, "value0", tagMap["tag0"])
+	assert.Equal(t, "value1", tagMap["tag1"])
 }

--- a/pkg/serverless/tags_test.go
+++ b/pkg/serverless/tags_test.go
@@ -130,3 +130,47 @@ func TestBuildTagMapFromArnCompleteWithVersionNumber(t *testing.T) {
 	assert.Equal(t, "value0", tagMap["tag0"])
 	assert.Equal(t, "value1", tagMap["tag1"])
 }
+
+func TestAddTagInvalid(t *testing.T) {
+	tagMap := map[string]string{
+		"key_a": "value_a",
+		"key_b": "value_b",
+	}
+	addTag(tagMap, "invalidTag")
+	assert.Equal(t, 2, len(tagMap))
+	assert.Equal(t, "value_a", tagMap["key_a"])
+	assert.Equal(t, "value_b", tagMap["key_b"])
+}
+
+func TestAddTagInvalid2(t *testing.T) {
+	tagMap := map[string]string{
+		"key_a": "value_a",
+		"key_b": "value_b",
+	}
+	addTag(tagMap, "invalidTag:invalid:invalid")
+	assert.Equal(t, 2, len(tagMap))
+	assert.Equal(t, "value_a", tagMap["key_a"])
+	assert.Equal(t, "value_b", tagMap["key_b"])
+}
+func TestAddTagInvalid3(t *testing.T) {
+	tagMap := map[string]string{
+		"key_a": "value_a",
+		"key_b": "value_b",
+	}
+	addTag(tagMap, "")
+	assert.Equal(t, 2, len(tagMap))
+	assert.Equal(t, "value_a", tagMap["key_a"])
+	assert.Equal(t, "value_b", tagMap["key_b"])
+}
+
+func TestAddTag(t *testing.T) {
+	tagMap := map[string]string{
+		"key_a": "value_a",
+		"key_b": "value_b",
+	}
+	addTag(tagMap, "VaLiD:TaG")
+	assert.Equal(t, 3, len(tagMap))
+	assert.Equal(t, "value_a", tagMap["key_a"])
+	assert.Equal(t, "value_b", tagMap["key_b"])
+	assert.Equal(t, "tag", tagMap["valid"])
+}


### PR DESCRIPTION
### What does this PR do?

Handle correctly DD_TAGS and DD_EXTRA_TAGS

### Motivation

Consistency

### Additional Notes

The method `GetConfiguredTags` in pkg/config/config.go already does the merging logic for us

### Describe how to test your changes

Deploy a lambda with DD_TAGS or DD_EXTRA_TAGS or both and you should see the tags in logs metrics and traces
