### PR TITLE
Fix check sampler

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -357,7 +357,7 @@ func (agg *BufferedAggregator) registerSender(id check.ID) error {
 	if _, ok := agg.checkSamplers[id]; ok {
 		return fmt.Errorf("Sender with ID '%s' has already been registered, will use existing sampler", id)
 	}
-	agg.checkSamplers[id] = newCheckSampler(time.Duration(config.Datadog.GetInt("check_sampler_bucket_expiry")) * time.Second)
+	agg.checkSamplers[id] = newCheckSampler(config.Datadog.GetInt("check_sampler_bucket_commits_count_expiry"))
 	return nil
 }
 

--- a/pkg/aggregator/check_sampler_bench_test.go
+++ b/pkg/aggregator/check_sampler_bench_test.go
@@ -7,7 +7,6 @@ package aggregator
 
 import (
 	"testing"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
@@ -24,7 +23,7 @@ func benchmarkAddBucket(bucketValue int64, b *testing.B) {
 		forwarder.NewOptions(map[string][]string{"hello": {"world"}})),
 		nil,
 	)
-	checkSampler := newCheckSampler(60 * time.Second)
+	checkSampler := newCheckSampler(1)
 
 	bucket := &metrics.HistogramBucket{
 		Name:       "my.histogram",
@@ -39,12 +38,11 @@ func benchmarkAddBucket(bucketValue int64, b *testing.B) {
 		checkSampler.addBucket(bucket)
 		// reset bucket cache
 		checkSampler.lastBucketValue = make(map[ckey.ContextKey]int64)
-		checkSampler.lastSeenBucket = make(map[ckey.ContextKey]time.Time)
 	}
 }
 
 func benchmarkAddBucketWideBounds(bucketValue int64, b *testing.B) {
-	checkSampler := newCheckSampler(60 * time.Second)
+	checkSampler := newCheckSampler(1)
 
 	bounds := []float64{0, .0005, .001, .003, .005, .007, .01, .015, .02, .025, .03, .04, .05, .06, .07, .08, .09, .1, .5, 1, 5, 10}
 	bucket := &metrics.HistogramBucket{
@@ -65,7 +63,6 @@ func benchmarkAddBucketWideBounds(bucketValue int64, b *testing.B) {
 		}
 		// reset bucket cache
 		checkSampler.lastBucketValue = make(map[ckey.ContextKey]int64)
-		checkSampler.lastSeenBucket = make(map[ckey.ContextKey]time.Time)
 	}
 }
 

--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -32,7 +32,7 @@ func generateContextKey(sample metrics.MetricSampleContext) ckey.ContextKey {
 }
 
 func TestCheckGaugeSampling(t *testing.T) {
-	checkSampler := newCheckSampler(60 * time.Second)
+	checkSampler := newCheckSampler(1)
 
 	mSample1 := metrics.MetricSample{
 		Name:       "my.metric.name",
@@ -91,7 +91,7 @@ func TestCheckGaugeSampling(t *testing.T) {
 }
 
 func TestCheckRateSampling(t *testing.T) {
-	checkSampler := newCheckSampler(60 * time.Second)
+	checkSampler := newCheckSampler(1)
 
 	mSample1 := metrics.MetricSample{
 		Name:       "my.metric.name",
@@ -139,8 +139,8 @@ func TestCheckRateSampling(t *testing.T) {
 	}
 }
 
-func TestHistogramIntervalSampling(t *testing.T) {
-	checkSampler := newCheckSampler(60 * time.Second)
+func TestHistogramCountSampling(t *testing.T) {
+	checkSampler := newCheckSampler(1)
 
 	mSample1 := metrics.MetricSample{
 		Name:       "my.metric.name",
@@ -172,6 +172,7 @@ func TestHistogramIntervalSampling(t *testing.T) {
 	checkSampler.addSample(&mSample3)
 
 	checkSampler.commit(12349.0)
+	require.Len(t, checkSampler.contextResolver.expireCountByKey, 1)
 	series, _ := checkSampler.flush()
 
 	// Check that the `.count` metric returns a raw count of the samples, with no interval normalization
@@ -195,10 +196,12 @@ func TestHistogramIntervalSampling(t *testing.T) {
 	}
 
 	assert.True(t, foundCount)
+	checkSampler.commit(12349.0)
+	require.Len(t, checkSampler.contextResolver.expireCountByKey, 0)
 }
 
 func TestCheckHistogramBucketSampling(t *testing.T) {
-	checkSampler := newCheckSampler(10 * time.Millisecond)
+	checkSampler := newCheckSampler(1)
 
 	bucket1 := &metrics.HistogramBucket{
 		Name:            "my.histogram",
@@ -212,7 +215,6 @@ func TestCheckHistogramBucketSampling(t *testing.T) {
 	}
 	checkSampler.addBucket(bucket1)
 	assert.Equal(t, len(checkSampler.lastBucketValue), 1)
-	assert.Equal(t, len(checkSampler.lastSeenBucket), 1)
 
 	checkSampler.commit(12349.0)
 	_, flushed := checkSampler.flush()
@@ -243,9 +245,11 @@ func TestCheckHistogramBucketSampling(t *testing.T) {
 	}
 	checkSampler.addBucket(bucket2)
 	assert.Equal(t, len(checkSampler.lastBucketValue), 1)
-	assert.Equal(t, len(checkSampler.lastSeenBucket), 1)
 
 	checkSampler.commit(12401.0)
+	assert.Len(t, checkSampler.lastBucketValue, 1)
+	checkSampler.commit(12401.0)
+	assert.Len(t, checkSampler.lastBucketValue, 0)
 	_, flushed = checkSampler.flush()
 
 	expSketch = &quantile.Sketch{}
@@ -267,11 +271,10 @@ func TestCheckHistogramBucketSampling(t *testing.T) {
 	time.Sleep(11 * time.Millisecond)
 	checkSampler.flush()
 	assert.Equal(t, len(checkSampler.lastBucketValue), 0)
-	assert.Equal(t, len(checkSampler.lastSeenBucket), 0)
 }
 
 func TestCheckHistogramBucketDontFlushFirstValue(t *testing.T) {
-	checkSampler := newCheckSampler(60 * time.Second)
+	checkSampler := newCheckSampler(1)
 
 	bucket1 := &metrics.HistogramBucket{
 		Name:            "my.histogram",
@@ -323,7 +326,7 @@ func TestCheckHistogramBucketDontFlushFirstValue(t *testing.T) {
 }
 
 func TestCheckHistogramBucketInfinityBucket(t *testing.T) {
-	checkSampler := newCheckSampler(10 * time.Millisecond)
+	checkSampler := newCheckSampler(1)
 
 	bucket1 := &metrics.HistogramBucket{
 		Name:       "my.histogram",

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -23,7 +23,7 @@ type SerieSignature struct {
 // TimeSampler aggregates metrics by buckets of 'interval' seconds
 type TimeSampler struct {
 	interval                    int64
-	contextResolver             *ContextResolver
+	contextResolver             *timestampContextResolver
 	metricsByTimestamp          map[int64]metrics.ContextMetrics
 	counterLastSampledByContext map[ckey.ContextKey]float64
 	lastCutOffTime              int64
@@ -37,7 +37,7 @@ func NewTimeSampler(interval int64) *TimeSampler {
 	}
 	return &TimeSampler{
 		interval:                    interval,
-		contextResolver:             newContextResolver(),
+		contextResolver:             newTimestampContextResolver(),
 		metricsByTimestamp:          map[int64]metrics.ContextMetrics{},
 		counterLastSampledByContext: map[ckey.ContextKey]float64{},
 		sketchMap:                   make(sketchMap),

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -251,13 +251,13 @@ func TestCounterExpirySeconds(t *testing.T) {
 	// Counter2 should still report
 	assert.Equal(t, 1, len(series))
 	assert.Equal(t, 1, len(sampler.counterLastSampledByContext))
-	assert.Equal(t, 2, len(sampler.contextResolver.contextsByKey))
+	assert.Equal(t, 2, len(sampler.contextResolver.resolver.contextsByKey))
 
 	series, _ = sampler.flush(1800.0)
 	// Everything stopped reporting and is expired
 	assert.Equal(t, 0, len(series))
 	assert.Equal(t, 0, len(sampler.counterLastSampledByContext))
-	assert.Equal(t, 0, len(sampler.contextResolver.contextsByKey))
+	assert.Equal(t, 0, len(sampler.contextResolver.resolver.contextsByKey))
 }
 
 func TestSketch(t *testing.T) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -218,7 +218,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("python_version", DefaultPython)
 	config.BindEnvAndSetDefault("allow_arbitrary_tags", false)
 	config.BindEnvAndSetDefault("use_proxy_for_cloud_metadata", false)
-	config.BindEnvAndSetDefault("check_sampler_bucket_expiry", 60) // in seconds
+	config.BindEnvAndSetDefault("check_sampler_bucket_commits_count_expiry", 1) // The number of commits before expiring a context
 	config.BindEnvAndSetDefault("host_aliases", []string{})
 
 	// overridden in IoT Agent main

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -218,7 +218,10 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("python_version", DefaultPython)
 	config.BindEnvAndSetDefault("allow_arbitrary_tags", false)
 	config.BindEnvAndSetDefault("use_proxy_for_cloud_metadata", false)
-	config.BindEnvAndSetDefault("check_sampler_bucket_commits_count_expiry", 1) // The number of commits before expiring a context
+
+	// The number of commits before expiring a context. The value is 2 to handle
+	// the case where a check miss to send a metric.
+	config.BindEnvAndSetDefault("check_sampler_bucket_commits_count_expiry", 2)
 	config.BindEnvAndSetDefault("host_aliases", []string{})
 
 	// overridden in IoT Agent main

--- a/releasenotes/notes/check_sampler_bucket_commits_count_expiry-952ce2d59407efaa.yaml
+++ b/releasenotes/notes/check_sampler_bucket_commits_count_expiry-952ce2d59407efaa.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Make the check_sampler bucket expiry configurable based on the number of `CheckSampler` commits.


### PR DESCRIPTION
### What does this PR do?

Revert https://github.com/DataDog/datadog-agent/pull/8335 and fix the issue.

### Additional Notes

When a histogram check sends a value, the code run `case checkHistogramBucket := <-agg.checkHistogramBucketIn`
https://github.com/DataDog/datadog-agent/blob/7.29.0-rc.1/pkg/aggregator/aggregator.go#L734-L737.

When a histogram check sends the commit, the code run `case checkMetric := <-agg.checkMetricIn` https://github.com/DataDog/datadog-agent/blob/7.29.0-rc.1/pkg/aggregator/aggregator.go#L730-L733.

Even if the value is sent before the commit, the branch `case checkMetric ` can be executed before `case checkHistogramBucket`, as a result, the commit is handled before the value which creates a spike in the web app.

This issue will be address in AC-1010

### Describe how to test your changes

- QA again #7903: The bug is random so make sure to wait several hours (I checked during a period of ~3 hours).
- QA again #8017
