### PR TITLE
[compliance-agent] Bump default reported resources count to 100

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -841,7 +841,7 @@ func InitConfig(config Config) {
 	// Datadog security agent (compliance)
 	config.BindEnvAndSetDefault("compliance_config.enabled", false)
 	config.BindEnvAndSetDefault("compliance_config.check_interval", 20*time.Minute)
-	config.BindEnvAndSetDefault("compliance_config.check_max_events_per_run", 30)
+	config.BindEnvAndSetDefault("compliance_config.check_max_events_per_run", 100)
 	config.BindEnvAndSetDefault("compliance_config.dir", "/etc/datadog-agent/compliance.d")
 	config.BindEnvAndSetDefault("compliance_config.run_path", defaultRunPath)
 	bindEnvAndSetLogsConfigKeys(config, "compliance_config.endpoints.")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -999,8 +999,8 @@ api_key:
   # check_interval: 20m
 
   ## @param check_max_events_per_run - integer
-  ## - optional - default: 30
-  # check_max_events_per_run: 30
+  ## - optional - default: 100
+  # check_max_events_per_run: 100
 {{ end -}}
 {{- if .SystemProbe }}
 


### PR DESCRIPTION
### What does this PR do?

Bump default reported resources count to 100

### Motivation

Previously, only 30 results could be sent for a compliance rule. For containers and images, this number is too low