### PR TITLE
Add comment explaining retry behavior in SyncForwarder

### DIFF
--- a/pkg/forwarder/sync_forwarder.go
+++ b/pkg/forwarder/sync_forwarder.go
@@ -42,6 +42,8 @@ func (f *SyncForwarder) sendHTTPTransactions(transactions []*transaction.HTTPTra
 		if err := t.Process(context.Background(), f.client); err != nil {
 			log.Debugf("SyncForwarder.sendHTTPTransactions first attempt: %s", err)
 			// Retry once after error
+			// The intake may have closed the connection between invocations.
+			// If so, the first attempt will fail because the closed connection will still be cached.
 			log.Debug("Retrying transaction")
 			if err := t.Process(context.Background(), f.client); err != nil {
 				log.Errorf("SyncForwarder.sendHTTPTransactions final attempt: %s", err)

--- a/pkg/forwarder/sync_forwarder.go
+++ b/pkg/forwarder/sync_forwarder.go
@@ -42,7 +42,7 @@ func (f *SyncForwarder) sendHTTPTransactions(transactions []*transaction.HTTPTra
 		if err := t.Process(context.Background(), f.client); err != nil {
 			log.Debugf("SyncForwarder.sendHTTPTransactions first attempt: %s", err)
 			// Retry once after error
-			// The intake may have closed the connection between invocations.
+			// The intake may have closed the connection between Lambda invocations.
 			// If so, the first attempt will fail because the closed connection will still be cached.
 			log.Debug("Retrying transaction")
 			if err := t.Process(context.Background(), f.client); err != nil {


### PR DESCRIPTION
### What does this PR do?

Add a comment clarifying why we need to retry once in the `SyncForwarder`.

### Motivation

After investigation, we have a better understanding of why we need to retry once here. While we might be able to fix or mitigate this issue by working with the metrics intake team, for now we should document why this retry behavior is needed.
