### PR TITLE
Update master links to point to main

### DIFF
--- a/.circleci/README.md
+++ b/.circleci/README.md
@@ -22,7 +22,7 @@ docker push datadog/datadog-agent-runner-circle:go1147
 ```
 
 Once your image is pushed, update this file:
-https://github.com/DataDog/datadog-agent/blob/master/.circleci/config.yml.
+https://github.com/DataDog/datadog-agent/blob/main/.circleci/config.yml.
 Change `image: datadog/datadog-agent-runner-circle:goXXXX` for the tag you
 just pushed.
 

--- a/CHANGELOG-DCA.rst
+++ b/CHANGELOG-DCA.rst
@@ -86,7 +86,7 @@ Prelude
 -------
 
 Released on: 2021-03-02
-Pinned to datadog-agent v7.26.0: `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#7260--6260>`_.
+Pinned to datadog-agent v7.26.0: `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst#7260--6260>`_.
 
 
 .. _Release Notes_dca-1.11.0_dca-1.11.X_New Features:
@@ -131,7 +131,7 @@ Prelude
 -------
 
 Released on: 2021-03-02
-    Pinned to datadog-agent v7.24.0: `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#7240--6240>`_..
+    Pinned to datadog-agent v7.24.0: `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst#7240--6240>`_..
 
 .. _Release Notes_dca-1.10.0_dca-1.10.X_New Features:
 
@@ -189,7 +189,7 @@ Prelude
 -------
 
 Released on: 2020-10-21
-Pinned to datadog-agent v7.23.1: `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#7231>`_..
+Pinned to datadog-agent v7.23.1: `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst#7231>`_..
 
 .. _Release Notes_dca-1.9.1_dca-1.9.x_Bug Fixes:
 
@@ -212,7 +212,7 @@ Prelude
 -------
 
 Released on: 2020-10-13
-Pinned to datadog-agent v7.23.0: `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#7230--6230>`_..
+Pinned to datadog-agent v7.23.0: `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst#7230--6230>`_..
 
 New Features
 ------------
@@ -275,7 +275,7 @@ Prelude
 Released on: 2020-07-20
 
 This version contains the changes released with version 7.21.0 of the core agent.
-Please refer to the `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#7210--6210>`_.
+Please refer to the `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst#7210--6210>`_.
 
 New Features
 ------------
@@ -302,7 +302,7 @@ Prelude
 Released on: 2020-06-11
 
 This version contains the changes released with version 7.20.0 of the core agent.
-Please refer to the `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#7200--6200>`_.
+Please refer to the `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst#7200--6200>`_.
 
 Bug Fixes
 ---------
@@ -374,7 +374,7 @@ Prelude
 Released on: 2020-01-28
 
 This version contains the changes released with version 7.17.0 of the core agent.
-Please refer to the `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#7170>`_.
+Please refer to the `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst#7170>`_.
 
 New Features
 ------------
@@ -411,7 +411,7 @@ Prelude
 Released on: 2019-11-06
 
 This version contains the changes released with version 6.15.0 of the core agent.
-Please refer to the `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#6150>`_.
+Please refer to the `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst#6150>`_.
 
 New Features
 ------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4701,7 +4701,7 @@ Upgrade Notes
 
   For more details please read the technical note in the `datadog.yaml`_.
 
-  .. _datadog.yaml: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml#L130-L140
+  .. _datadog.yaml: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml#L130-L140
 
 - Prometheus custom checks are now limited to 2000 metrics by default
   to provide users control over the maximum number of custom metrics
@@ -5192,7 +5192,7 @@ Deprecation Notes
   pulled from integrations-core. The code now resides in the `datadog_checks`
   namespace, though the old `checks`, `utils`, etc. paths are still supported.
   Please update your custom checks accordingly. For more information, see
-  https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md#python-modules
+  https://github.com/DataDog/datadog-agent/blob/main/docs/agent/changes.md#python-modules
 
 
 .. _Release Notes_6.3.0_Bug Fixes:
@@ -5364,7 +5364,7 @@ Enhancements
 - Add agent5-like JMXFetch helper commands to help with JMXFetch troubleshooting.
 
 - The agent has been tested on Kubernetes 1.4 & OpenShift 3.4. Refer to
-  https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/README.md
+  https://github.com/DataDog/datadog-agent/blob/main/Dockerfiles/agent/README.md
   for installation instructions
 
 - Extract creator tags from kubernetes legacy `created-by` annotation if

--- a/Dockerfiles/agent/DOCKERHUB.md
+++ b/Dockerfiles/agent/DOCKERHUB.md
@@ -54,7 +54,7 @@ For issues and help troubleshooting, please [contact our support team](https://w
 
 ## License
 
-View [license information](https://github.com/DataDog/datadog-agent/blob/master/LICENSE) for the software contained in this image.
+View [license information](https://github.com/DataDog/datadog-agent/blob/main/LICENSE) for the software contained in this image.
 
 As with all Docker images, these likely also contain other software which may be under other licenses (such as Bash, etc from the base distribution, along with any direct or indirect dependencies of the primary software being contained).
 

--- a/Dockerfiles/agent/DOCKERHUB.md
+++ b/Dockerfiles/agent/DOCKERHUB.md
@@ -45,8 +45,8 @@ slimmer.
 Please refer to:
 
 - [https://docs.datadoghq.com/](https://docs.datadoghq.com/)
-- [usage instructions](https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/agent) for this image
-- [general agent documentation](https://github.com/DataDog/datadog-agent/tree/master/docs) in our repo
+- [usage instructions](https://github.com/DataDog/datadog-agent/tree/main/Dockerfiles/agent) for this image
+- [general agent documentation](https://github.com/DataDog/datadog-agent/tree/main/docs) in our repo
 
 ## Support
 

--- a/Dockerfiles/dogstatsd/DOCKERHUB.md
+++ b/Dockerfiles/dogstatsd/DOCKERHUB.md
@@ -13,8 +13,8 @@ datadog Agent major version.
 Please refer to:
 
 - [https://docs.datadoghq.com/](https://docs.datadoghq.com/)
-- [usage instructions](https://github.com/DataDog/datadog-agent/tree/master/Dockerfiles/dogstatsd/alpine) for this image
-- [general agent documentation](https://github.com/DataDog/datadog-agent/tree/master/docs) in our repo
+- [usage instructions](https://github.com/DataDog/datadog-agent/tree/main/Dockerfiles/dogstatsd/alpine) for this image
+- [general agent documentation](https://github.com/DataDog/datadog-agent/tree/main/docs) in our repo
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ To start working on the Agent, you can build the `master` branch:
 
      * Discards any changes done in `bin/agent/dist`.
      * Builds the Agent and writes the binary to `bin/agent/agent`.
-     * Copies files from `dev/dist` to `bin/agent/dist`. See `https://github.com/DataDog/datadog-agent/blob/master/dev/dist/README.md` for more information.
+     * Copies files from `dev/dist` to `bin/agent/dist`. See `https://github.com/DataDog/datadog-agent/blob/main/dev/dist/README.md` for more information.
 
      If you built an older version of the agent, you may have the error `make: *** No targets specified and no makefile found.  Stop.`. To solve the issue, you should remove `CMakeCache.txt` from `rtloader` folder with `rm rtloader/CMakeCache.txt`.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Datadog Agent
 
-[![CircleCI](https://circleci.com/gh/DataDog/datadog-agent/tree/master.svg?style=svg&circle-token=dbcee3f02b9c3fe5f142bfc5ecb735fdec34b643)](https://circleci.com/gh/DataDog/datadog-agent/tree/master)
+[![CircleCI](https://circleci.com/gh/DataDog/datadog-agent/tree/main.svg?style=svg&circle-token=dbcee3f02b9c3fe5f142bfc5ecb735fdec34b643)](https://circleci.com/gh/DataDog/datadog-agent/tree/main)
 [![Build status](https://ci.appveyor.com/api/projects/status/kcwhmlsc0oq3m49p/branch/master?svg=true)](https://ci.appveyor.com/project/Datadog/datadog-agent/branch/master)
 [![Coverage status](https://codecov.io/github/DataDog/datadog-agent/coverage.svg?branch=master)](https://codecov.io/github/DataDog/datadog-agent?branch=master)
 [![GoDoc](https://godoc.org/github.com/DataDog/datadog-agent?status.svg)](https://godoc.org/github.com/DataDog/datadog-agent)

--- a/chocolatey/datadog-agent-offline.nuspec
+++ b/chocolatey/datadog-agent-offline.nuspec
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/DataDog/datadog-agent</projectUrl>
     <iconUrl>https://datadog-prod.imgix.net/img/dd_logo_70x75.png</iconUrl>
     <copyright>$copyright$</copyright>
-    <licenseUrl>https://raw.githubusercontent.com/DataDog/datadog-agent/master/LICENSE</licenseUrl>
+    <licenseUrl>https://raw.githubusercontent.com/DataDog/datadog-agent/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <docsUrl>https://docs.datadoghq.com</docsUrl>
     <tags>datadog agent monitoring admin</tags>

--- a/chocolatey/datadog-agent-offline.nuspec
+++ b/chocolatey/datadog-agent-offline.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>datadog-agent-offline</id>
     <version>$package_version$</version>
-    <packageSourceUrl>https://github.com/DataDog/datadog-agent/tree/master/chocolatey</packageSourceUrl>
+    <packageSourceUrl>https://github.com/DataDog/datadog-agent/tree/main/chocolatey</packageSourceUrl>
     <owners>package@datadoghq.com</owners>
     <title>Datadog Agent Offline Install</title>
     <authors>Datadog</authors>

--- a/chocolatey/datadog-agent-online.nuspec
+++ b/chocolatey/datadog-agent-online.nuspec
@@ -10,7 +10,7 @@
     <projectUrl>https://github.com/DataDog/datadog-agent</projectUrl>
     <iconUrl>https://datadog-prod.imgix.net/img/dd_logo_70x75.png</iconUrl>
     <copyright>$copyright$</copyright>
-    <licenseUrl>https://raw.githubusercontent.com/DataDog/datadog-agent/master/LICENSE</licenseUrl>
+    <licenseUrl>https://raw.githubusercontent.com/DataDog/datadog-agent/main/LICENSE</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <docsUrl>https://docs.datadoghq.com</docsUrl>
     <tags>datadog agent monitoring admin</tags>

--- a/chocolatey/datadog-agent-online.nuspec
+++ b/chocolatey/datadog-agent-online.nuspec
@@ -3,7 +3,7 @@
   <metadata>
     <id>datadog-agent</id>
     <version>$package_version$</version>
-    <packageSourceUrl>https://github.com/DataDog/datadog-agent/tree/master/chocolatey</packageSourceUrl>
+    <packageSourceUrl>https://github.com/DataDog/datadog-agent/tree/main/chocolatey</packageSourceUrl>
     <owners>package@datadoghq.com</owners>
     <title>Datadog Agent</title>
     <authors>Datadog</authors>

--- a/cmd/agent/doc.go
+++ b/cmd/agent/doc.go
@@ -11,7 +11,7 @@ Datadog on your behalf.
 To install the agent, please refer the official documentation at https://docs.datadoghq.com/.
 
 If you want to build the agent by yourself or contribute to the project, please
-refer to the Agent Developer Guide at https://github.com/DataDog/datadog-agent/tree/master/docs/dev
+refer to the Agent Developer Guide at https://github.com/DataDog/datadog-agent/tree/main/docs/dev
 for more details.
 
 */

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -126,7 +126,7 @@ function verify_agent_version(){
     if [ -z "$agent_version_custom" ]; then
         echo -e "
   \033[33mWarning: Specified version not found: $agent_major_version.$agent_minor_version
-  Check available versions at: https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst\033[0m"
+  Check available versions at: https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst\033[0m"
         fallback_msg
         exit 1;
     else

--- a/docs/agent/config.md
+++ b/docs/agent/config.md
@@ -2,4 +2,4 @@
 
 See the [config_template.yaml][1] file for a list of configuration options and examples.
 
-[1]: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml
+[1]: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml

--- a/docs/dev/agent_api.md
+++ b/docs/dev/agent_api.md
@@ -11,7 +11,7 @@ The token is written to a file that's only readable by the user that the Agent r
 
 ## Endpoints
 
-Please refer to the [`cmd/agent/api`](https://github.com/DataDog/datadog-agent/tree/master/cmd/agent/api)
+Please refer to the [`cmd/agent/api`](https://github.com/DataDog/datadog-agent/tree/main/cmd/agent/api)
 package for a list of endpoints implemented so far.
 
 TODO: generate a list of endpoints with [swagger](http://swagger.io/)

--- a/docs/dev/agent_dev_env.md
+++ b/docs/dev/agent_dev_env.md
@@ -99,7 +99,7 @@ additional tool it might need.
 
 **Please note that versions of Golang that aren't an exact match to the version
 specified in our build images (see e.g. [here](https://github.com/DataDog/datadog-agent/blob/main/.circleci/images/builder/Dockerfile#L1))
-may not be able to build the agent and/or the [rtloader](https://github.com/DataDog/datadog-agent/tree/master/rtloader)
+may not be able to build the agent and/or the [rtloader](https://github.com/DataDog/datadog-agent/tree/main/rtloader)
 binary properly.**
 
 ## Installing dependencies

--- a/docs/dev/agent_dev_env.md
+++ b/docs/dev/agent_dev_env.md
@@ -74,7 +74,7 @@ runs. Our invoke tasks are only compatible with Python 3, thus you will
 need to use Python 3 to run them.
 
 Though you may install invoke in a variety of way we suggest you use
-the provided [requirements](https://github.com/DataDog/datadog-agent/blob/master/requirements.txt)
+the provided [requirements](https://github.com/DataDog/datadog-agent/blob/main/requirements.txt)
 file and `pip`:
 
 ```bash
@@ -98,7 +98,7 @@ sure that `$GOPATH/bin` is in your `$PATH` otherwise `invoke` cannot use any
 additional tool it might need.
 
 **Please note that versions of Golang that aren't an exact match to the version
-specified in our build images (see e.g. [here](https://github.com/DataDog/datadog-agent/blob/master/.circleci/images/builder/Dockerfile#L1))
+specified in our build images (see e.g. [here](https://github.com/DataDog/datadog-agent/blob/main/.circleci/images/builder/Dockerfile#L1))
 may not be able to build the agent and/or the [rtloader](https://github.com/DataDog/datadog-agent/tree/master/rtloader)
 binary properly.**
 
@@ -225,4 +225,4 @@ See `pre-commit run --help` for further options.
 
 [Microsoft Visual Studio Code](https://code.visualstudio.com/download) is recommended as it's lightweight and versatile.
 
-Building on Windows would require multiple 3rd-party softwares to be installed. To avoid the complexity, it is recommended to make the code change in VS Code then do the build in Docker image. For complete information, see [Build the Agent packages](https://github.com/DataDog/datadog-agent/blob/master/docs/dev/agent_omnibus.md)
+Building on Windows would require multiple 3rd-party softwares to be installed. To avoid the complexity, it is recommended to make the code change in VS Code then do the build in Docker image. For complete information, see [Build the Agent packages](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/agent_omnibus.md)

--- a/docs/dev/agent_memory.md
+++ b/docs/dev/agent_memory.md
@@ -329,4 +329,4 @@ the [provided wrappers]() to reserve memory:
 
 [1] https://jvns.ca/blog/2017/09/24/profiling-go-with-pprof/
 [2] https://blog.detectify.com/2019/09/05/how-we-tracked-down-a-memory-leak-in-one-of-our-go-microservices/
-[3] https://github.com/DataDog/datadog-agent/blob/master/rtloader/common/rtloader_mem.h
+[3] https://github.com/DataDog/datadog-agent/blob/main/rtloader/common/rtloader_mem.h

--- a/docs/dev/caveats.md
+++ b/docs/dev/caveats.md
@@ -15,7 +15,7 @@ The COM concurrency model may be set in different ways, it also has to be called
 
 To support Python checks which use COM, we call  `CoInitializeEx(0)` in the python loader while checks are loading, and run `CoUninitialize()` immediately after loading. By doing so, `pythoncom` is imported during the loading of checks and the concurrency model is already set.
 ### WMI
-WMI is implemented via COM. Therefore, all of the above apply to any code that directly or indirectly uses WMI.  _All_ use of WMI in the core agent is removed, along with the [removal](https://github.com/DataDog/datadog-agent/blob/master/tasks/go.py#L295-L299) of the `gopsutil` dependency to ensure that this dependency is not reintroduced.
+WMI is implemented via COM. Therefore, all of the above apply to any code that directly or indirectly uses WMI.  _All_ use of WMI in the core agent is removed, along with the [removal](https://github.com/DataDog/datadog-agent/blob/main/tasks/go.py#L295-L299) of the `gopsutil` dependency to ensure that this dependency is not reintroduced.
 
 
 However, Python checks do continue to make these calls. Python checks will set/use the concurrency model as they please (typically the single-threaded model). This has a few implications:

--- a/docs/serverless/README.md
+++ b/docs/serverless/README.md
@@ -49,4 +49,4 @@ startup process).
 
 ### Build
 
-For more information about building a Serverless Agent, see [this README](https://github.com/DataDog/datadog-agent/tree/master/cmd/serverless/README.md).
+For more information about building a Serverless Agent, see [this README](https://github.com/DataDog/datadog-agent/tree/main/cmd/serverless/README.md).

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/DataDog/datadog-agent
 go 1.15
 
 // NOTE: Prefer using simple `require` directives instead of using `replace` if possible.
-// See https://github.com/DataDog/datadog-agent/blob/master/docs/dev/gomodreplace.md
+// See https://github.com/DataDog/datadog-agent/blob/main/docs/dev/gomodreplace.md
 // for more details.
 
 // Internal deps fix version

--- a/pkg/autodiscovery/README.md
+++ b/pkg/autodiscovery/README.md
@@ -1,6 +1,6 @@
 # package `autodiscovery`
 
-This package is a core piece of the agent. It is responsible for collecting check configurations from different sources (see package [config providers](https://github.com/DataDog/datadog-agent/tree/master/pkg/autodiscovery/providers)) and then schedule or unschedule integration configurations with the help of the schedulers.
+This package is a core piece of the agent. It is responsible for collecting check configurations from different sources (see package [config providers](https://github.com/DataDog/datadog-agent/tree/main/pkg/autodiscovery/providers)) and then schedule or unschedule integration configurations with the help of the schedulers.
 
 It is also responsible for listening to container-related events and resolve template configurations that would match them.
 

--- a/pkg/autodiscovery/README.md
+++ b/pkg/autodiscovery/README.md
@@ -8,8 +8,8 @@ It is also responsible for listening to container-related events and resolve tem
 
 As a central component, `AutoConfig` owns and orchestrates several key modules:
 
-- it owns a reference to a [`MetaScheduler`](https://github.com/DataDog/datadog-agent/blob/master/pkg/autodiscovery/scheduler) that dispatches integrations configs for scheduling or unscheduling to all registered schedulers. There are 3 scheduler implementations: checks scheduler and logs scheduler in the agent, and cluster checks dispatcher in the cluster agent.
-- it stores a list of [`ConfigProviders`](https://github.com/DataDog/datadog-agent/blob/master/pkg/autodiscovery/providers) and poll them according to their poll policy via [`configPollers`](https://github.com/DataDog/datadog-agent/blob/master/pkg/autodiscovery/config_poller.go)
-- it owns [`ServiceListener`](https://github.com/DataDog/datadog-agent/blob/master/pkg/autodiscovery/listeners) used to listen to lifecycle events of containers and other kind of services like network devices, kubernetes Endpoints and Service objects
+- it owns a reference to a [`MetaScheduler`](https://github.com/DataDog/datadog-agent/blob/main/pkg/autodiscovery/scheduler) that dispatches integrations configs for scheduling or unscheduling to all registered schedulers. There are 3 scheduler implementations: checks scheduler and logs scheduler in the agent, and cluster checks dispatcher in the cluster agent.
+- it stores a list of [`ConfigProviders`](https://github.com/DataDog/datadog-agent/blob/main/pkg/autodiscovery/providers) and poll them according to their poll policy via [`configPollers`](https://github.com/DataDog/datadog-agent/blob/main/pkg/autodiscovery/config_poller.go)
+- it owns [`ServiceListener`](https://github.com/DataDog/datadog-agent/blob/main/pkg/autodiscovery/listeners) used to listen to lifecycle events of containers and other kind of services like network devices, kubernetes Endpoints and Service objects
 - it uses the `ConfigResolver` that resolves a configuration template to an actual configuration based on a service matching the template. A template matches a service if they have in common at least one AD identifier element
 - it uses a `store` component to safely store and retrieve all data and mappings needed for the autodiscovery lifecycle

--- a/pkg/clusteragent/README.md
+++ b/pkg/clusteragent/README.md
@@ -1,6 +1,6 @@
 # Datadog Cluster Agent - DCA
 
-[![CircleCI](https://circleci.com/gh/DataDog/datadog-agent/tree/master.svg?style=svg&circle-token=dbcee3f02b9c3fe5f142bfc5ecb735fdec34b643)](https://circleci.com/gh/DataDog/datadog-agent/tree/master)
+[![CircleCI](https://circleci.com/gh/DataDog/datadog-agent/tree/main.svg?style=svg&circle-token=dbcee3f02b9c3fe5f142bfc5ecb735fdec34b643)](https://circleci.com/gh/DataDog/datadog-agent/tree/main)
 [![Build status](https://ci.appveyor.com/api/projects/status/kcwhmlsc0oq3m49p/branch/master?svg=true)](https://ci.appveyor.com/project/Datadog/datadog-agent/branch/master)
 [![GoDoc](https://godoc.org/github.com/DataDog/datadog-agent?status.svg)](https://godoc.org/github.com/DataDog/datadog-agent)
 
@@ -67,7 +67,7 @@ Secondly, it will start serving the `DD_CLUSTER_AGENT.CMD_PORT` if set or 5005 b
 ## Documentation
 
 The general documentation of the project (including instructions on the Beta builds,
-Agent installation, development, etc) is located under the [docs](https://github.com/DataDog/datadog-agent/tree/master/docs) directory
+Agent installation, development, etc) is located under the [docs](https://github.com/DataDog/datadog-agent/tree/main/docs) directory
 of the present repo.
 
 ## Contributing code

--- a/pkg/clusteragent/README.md
+++ b/pkg/clusteragent/README.md
@@ -23,7 +23,7 @@ currently in Alpha.
 
 ## Getting started
 
-For pre-requisite, refer to the Agent's Getting Started section in the [README](https://github.com/DataDog/datadog-agent/blob/master/README.md)
+For pre-requisite, refer to the Agent's Getting Started section in the [README](https://github.com/DataDog/datadog-agent/blob/main/README.md)
 
 To start working on the Cluster Agent, you can build the `master` branch:
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1061,7 +1061,7 @@ func load(config Config, origin string, loadSecret bool) (*Warnings, error) {
 
 // ResolveSecrets merges all the secret values from origin into config. Secret values
 // are identified by a value of the form "ENC[key]" where key is the secret key.
-// See: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/secrets.md
+// See: https://github.com/DataDog/datadog-agent/blob/main/docs/agent/secrets.md
 func ResolveSecrets(config Config, origin string) error {
 	// We have to init the secrets package before we can use it to decrypt
 	// anything.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -479,7 +479,7 @@ api_key:
 ## `secret_backend_command` is the path to the script to execute to fetch secrets.
 ## The executable must have specific rights that differ on Windows and Linux.
 ##
-## For more information see: https://github.com/DataDog/datadog-agent/blob/master/docs/agent/secrets.md
+## For more information see: https://github.com/DataDog/datadog-agent/blob/main/docs/agent/secrets.md
 #
 # secret_backend_command: <COMMAND_PATH>
 
@@ -1933,7 +1933,7 @@ api_key:
 ## @param kubernetes_collect_metadata_tags - boolean - optional - default: true
 ## Set this to false to disable tag collection for the Agent.
 ## Note: In order to collect Kubernetes service names, the Agent needs certain rights.
-## See https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/README.md#kubernetes
+## See https://github.com/DataDog/datadog-agent/blob/main/Dockerfiles/agent/README.md#kubernetes
 #
 # kubernetes_collect_metadata_tags: true
 
@@ -1951,7 +1951,7 @@ api_key:
 ## Set `collect_kubernetes_events` to true to enable log collection.
 ## Note: leader election must be enabled must be enabled  bellow to to collect events.
 ##       Only the leader Agent collects events.
-## See https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/README.md#event-collection
+## See https://github.com/DataDog/datadog-agent/blob/main/Dockerfiles/agent/README.md#event-collection
 #
 # collect_kubernetes_events: false
 
@@ -1962,7 +1962,7 @@ api_key:
 
 ## @param leader_election - boolean - optional - default: false
 ## Set the parameter to true to enable leader election on this node.
-## See https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/README.md#leader-election
+## See https://github.com/DataDog/datadog-agent/blob/main/Dockerfiles/agent/README.md#leader-election
 #
 # leader_election: false
 

--- a/pkg/config/legacy/kubernetes.go
+++ b/pkg/config/legacy/kubernetes.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	warningNewKubeCheck       string = "Warning: The Kubernetes integration has been overhauled, please see https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md#kubernetes-support"
+	warningNewKubeCheck       string = "Warning: The Kubernetes integration has been overhauled, please see https://github.com/DataDog/datadog-agent/blob/main/docs/agent/changes.md#kubernetes-support"
 	deprecationAPIServerCreds string = "please use kubernetes_kubeconfig_path instead"
 	deprecationHisto          string = "please contact support to determine the best alternative for you"
 	deprecationFiltering      string = "Agent6 now collects metrics from all available namespaces"

--- a/pkg/forwarder/internal/retry/README.md
+++ b/pkg/forwarder/internal/retry/README.md
@@ -39,4 +39,4 @@ Finally, `File 1` is read and removed, sending the `tr2` and `tr1` to the intake
 * There is a single retry queue for all the endpoints.
 * The files are read and written as a whole which is efficient as few reads and writes on disk are performed.
 * At agent startup, previous files are reloaded. Unknown domains and old files are removed.
-* Protobuf is used to serialize on disk. See [Retry file dump](https://github.com/DataDog/datadog-agent/blob/master/tools/retry_file_dump/README.md) to dump the content of a `.retry` file.
+* Protobuf is used to serialize on disk. See [Retry file dump](https://github.com/DataDog/datadog-agent/blob/main/tools/retry_file_dump/README.md) to dump the content of a `.retry` file.

--- a/pkg/proto/datadog/README.md
+++ b/pkg/proto/datadog/README.md
@@ -42,7 +42,7 @@ the agent by running:
 inv -e deps
 ```
 
-The grpc deps are defined [here](https://github.com/DataDog/datadog-agent/blob/master/cmd/agent/api/tools.go)
+The grpc deps are defined [here](https://github.com/DataDog/datadog-agent/blob/main/cmd/agent/api/tools.go)
 and are tracked by gomod.
 
 

--- a/pkg/proto/datadog/api/README.md
+++ b/pkg/proto/datadog/api/README.md
@@ -40,7 +40,7 @@ the agent by running:
 inv -e deps
 ```
 
-The grpc deps are defined [here](https://github.com/DataDog/datadog-agent/blob/master/cmd/agent/api/tools.go)
+The grpc deps are defined [here](https://github.com/DataDog/datadog-agent/blob/main/cmd/agent/api/tools.go)
 and are tracked by gomod.
 
 

--- a/pkg/status/templates/forwarder.tmpl
+++ b/pkg/status/templates/forwarder.tmpl
@@ -15,7 +15,7 @@ Forwarder
   {{- if .Transactions.DroppedOnInput }}
 
     Warning: the forwarder dropped transactions, there is probably an issue with your network
-    More info at https://github.com/DataDog/datadog-agent/tree/master/docs/agent/status.md
+    More info at https://github.com/DataDog/datadog-agent/tree/main/docs/agent/status.md
   {{- end}}
   {{- if .Transactions.Success}}
 

--- a/releasenotes-dca/notes/prelude-release-1.10.0-e6239bd8aa16c90d.yaml
+++ b/releasenotes-dca/notes/prelude-release-1.10.0-e6239bd8aa16c90d.yaml
@@ -1,4 +1,4 @@
 prelude:
     |
     Released on: 2020-12-10
-    Pinned to datadog-agent v7.24.0: `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#7240--6240>`_.
+    Pinned to datadog-agent v7.24.0: `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst#7240--6240>`_.

--- a/releasenotes-dca/notes/prelude-release-1.11.0-07dbb2dd2b6000bd.yaml
+++ b/releasenotes-dca/notes/prelude-release-1.11.0-07dbb2dd2b6000bd.yaml
@@ -1,4 +1,4 @@
 prelude:
     |
     Released on: 2021-03-01
-    Pinned to datadog-agent v7.26.0: `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#7260--6260>`_.
+    Pinned to datadog-agent v7.26.0: `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/main/CHANGELOG.rst#7260--6260>`_.

--- a/releasenotes/notes/bump-check-runners-4-4ec46f9d8a2cae3e.yaml
+++ b/releasenotes/notes/bump-check-runners-4-4ec46f9d8a2cae3e.yaml
@@ -24,7 +24,7 @@ upgrade:
 
     For more details please read the technical note in the `datadog.yaml`_. 
 
-    .. _datadog.yaml: https://github.com/DataDog/datadog-agent/blob/master/pkg/config/config_template.yaml#L130-L140
+    .. _datadog.yaml: https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml#L130-L140
 features:
   - |
     Bump the default number of check runners to 4. This has some

--- a/releasenotes/notes/kubernetes-14-support-e8e0893b32fa960d.yaml
+++ b/releasenotes/notes/kubernetes-14-support-e8e0893b32fa960d.yaml
@@ -2,7 +2,7 @@
 features:
   - |
     The agent has been tested on Kubernetes 1.4 & OpenShift 3.4. Refer to
-    https://github.com/DataDog/datadog-agent/blob/master/Dockerfiles/agent/README.md
+    https://github.com/DataDog/datadog-agent/blob/main/Dockerfiles/agent/README.md
     for installation instructions    
 issues:
   - |

--- a/releasenotes/notes/remove-duplicated-python-code-d4e1e29f420206cd.yaml
+++ b/releasenotes/notes/remove-duplicated-python-code-d4e1e29f420206cd.yaml
@@ -5,4 +5,4 @@ deprecations:
     pulled from integrations-core. The code now resides in the `datadog_checks`
     namespace, though the old `checks`, `utils`, etc. paths are still supported.
     Please update your custom checks accordingly. For more information, see
-    https://github.com/DataDog/datadog-agent/blob/master/docs/agent/changes.md#python-modules
+    https://github.com/DataDog/datadog-agent/blob/main/docs/agent/changes.md#python-modules

--- a/rtloader/common/builtins/datadog_agent.c
+++ b/rtloader/common/builtins/datadog_agent.c
@@ -233,7 +233,7 @@ PyObject *get_config(PyObject *self, PyObject *args)
     different places:
 
      1. github.com/DataDog/integrations-core/blob/master/datadog_checks_base/datadog_checks/base/utils/headers.py
-     2. github.com/DataDog/datadog-agent/blob/master/pkg/util/common.go
+     2. github.com/DataDog/datadog-agent/blob/main/pkg/util/common.go
 */
 PyObject *headers(PyObject *self, PyObject *args, PyObject *kwargs)
 {

--- a/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
+++ b/tasks/winbuildscripts/Generate-Chocolatey-Package.ps1
@@ -57,7 +57,7 @@ if ($rawAgentVersion -match $releaseCandidatePattern) {
     exit 3
 }
 
-Invoke-WebRequest -Uri "https://raw.githubusercontent.com/DataDog/datadog-agent/master/LICENSE" -OutFile $licensePath
+Invoke-WebRequest -Uri "https://raw.githubusercontent.com/DataDog/datadog-agent/main/LICENSE" -OutFile $licensePath
 
 Write-Host "Generating Chocolatey $installMethod package version $agentVersion in $outputDirectory"
 

--- a/test/kitchen/site-cookbooks/dd-agent-install-script/attributes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install-script/attributes/default.rb
@@ -1,6 +1,6 @@
 default['dd-agent-install-script']['api_key'] = nil
 default['dd-agent-install-script']['install_script_dir'] = '/tmp/install-script/'
-default['dd-agent-install-script']['install_script_url'] = 'https://raw.githubusercontent.com/DataDog/datadog-agent/master/cmd/agent/install_script.sh'
+default['dd-agent-install-script']['install_script_url'] = 'https://raw.githubusercontent.com/DataDog/datadog-agent/main/cmd/agent/install_script.sh'
 default['dd-agent-install-script']['install_candidate'] = true
 
 default['dd-agent-install-script']['repo_url'] = 'datad0g.com'

--- a/test/kitchen/tasks/kitchen.py
+++ b/test/kitchen/tasks/kitchen.py
@@ -48,7 +48,7 @@ def genconfig(
                 "Fetching the latest kitchen platforms.json from Github. Use --platformfile=platforms.json to override with a local file."
             )
             r = requests.get(
-                'https://raw.githubusercontent.com/DataDog/datadog-agent/master/test/kitchen/platforms.json',
+                'https://raw.githubusercontent.com/DataDog/datadog-agent/main/test/kitchen/platforms.json',
                 allow_redirects=True,
             )
             r.raise_for_status()

--- a/tools/dep_tree_resolver/README.md
+++ b/tools/dep_tree_resolver/README.md
@@ -9,12 +9,12 @@ dependency tree.
 _Note that this program only calculates the output based on the content of the main
 `go.mod` and its dependencies and it does not handle depndencies declared in a
 other isolated modules (e.g.
-[`tools.go`](https://github.com/DataDog/datadog-agent/blob/master/internal/tools/tools.go)._
+[`tools.go`](https://github.com/DataDog/datadog-agent/blob/main/internal/tools/tools.go)._
 
 ## Usage
 
 1. Ensure that you have a version of Golang that can handle modules (though having
-   the exact version from [go.mod](https://github.com/DataDog/datadog-agent/blob/master/go.mod#L3)
+   the exact version from [go.mod](https://github.com/DataDog/datadog-agent/blob/main/go.mod#L3)
    is preferrable).
 2. Ensure that you are in the root of the desired project
 3. Run the script:


### PR DESCRIPTION
### What does this PR do?

Updates `master` links to point to `main`.

### Motivation

Renaming this makes it slightly easier to grep for `master` and find outdated references and we avoid relying on Github redirects.

### Additional Notes

I did this using `ripgrep` and [`sd`](https://github.com/chmln/sd) (see each commit for command).
