### PR TITLE
[kitchen] Fix unicode error in kitchen.should-rerun-failed task

### DIFF
--- a/test/kitchen/tasks/kitchen.py
+++ b/test/kitchen/tasks/kitchen.py
@@ -168,7 +168,7 @@ def should_rerun_failed(_, runlog):
     Parse a log from kitchen run and see if we should rerun it (e.g. because of a network issue).
     """
     test_result_re = re.compile(r'\d+\s+examples?,\s+(?P<failures>\d+)\s+failures?')
-    with open(runlog, 'r') as f:
+    with open(runlog, 'r', encoding='utf-8') as f:
         text = f.read()
         result = set(test_result_re.findall(text))
         if result == {'0'} or result == set():


### PR DESCRIPTION
### What does this PR do?

Fixes unicode decode error in `kitchen.should-rerun-failed` task

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
