### PR TITLE
[runtime-security] remove service tag and add kernel related flare

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -633,51 +633,15 @@ func zipFile(originalPath, zippedPath string) error {
 }
 
 func zipRegistryJSON(tempDir, hostname string) error {
-	originalPath := filepath.Join(config.Datadog.GetString("logs_config.run_path"), "registry.json")
-	original, err := os.Open(originalPath)
-	if err != nil {
-		return err
-	}
-	defer original.Close()
-
+	originalPath := filepath.Join(config.Datadog.GetString("logs_config.run_path"))
 	zippedPath := filepath.Join(tempDir, hostname, "registry.json")
-	err = ensureParentDirsExist(zippedPath)
-	if err != nil {
-		return err
-	}
-
-	zipped, err := os.OpenFile(zippedPath, os.O_RDWR|os.O_CREATE, os.ModePerm)
-	if err != nil {
-		return err
-	}
-	defer zipped.Close()
-
-	_, err = io.Copy(zipped, original)
-	return err
+	return zipFile(originalPath, zippedPath)
 }
 
 func zipVersionHistory(tempDir, hostname string) error {
 	originalPath := filepath.Join(config.Datadog.GetString("run_path"), "version-history.json")
-	original, err := os.Open(originalPath)
-	if err != nil {
-		return err
-	}
-	defer original.Close()
-
 	zippedPath := filepath.Join(tempDir, hostname, "version-history.json")
-	err = ensureParentDirsExist(zippedPath)
-	if err != nil {
-		return err
-	}
-
-	zipped, err := os.OpenFile(zippedPath, os.O_RDWR|os.O_CREATE, os.ModePerm)
-	if err != nil {
-		return err
-	}
-	defer zipped.Close()
-
-	_, err = io.Copy(zipped, original)
-	return err
+	return zipFile(originalPath, zippedPath)
 }
 
 func zipConfigCheck(tempDir, hostname string) error {
@@ -781,26 +745,8 @@ func zipHealth(tempDir, hostname string) error {
 
 func zipInstallInfo(tempDir, hostname string) error {
 	originalPath := filepath.Join(config.FileUsedDir(), "install_info")
-	original, err := os.Open(originalPath)
-	if err != nil {
-		return err
-	}
-	defer original.Close()
-
 	zippedPath := filepath.Join(tempDir, hostname, "install_info")
-	err = ensureParentDirsExist(zippedPath)
-	if err != nil {
-		return err
-	}
-
-	zipped, err := os.OpenFile(zippedPath, os.O_RDWR|os.O_CREATE, os.ModePerm)
-	if err != nil {
-		return err
-	}
-	defer zipped.Close()
-
-	_, err = io.Copy(zipped, original)
-	return err
+	return zipFile(originalPath, zippedPath)
 }
 
 func zipTelemetry(tempDir, hostname string) error {

--- a/pkg/flare/archive_linux.go
+++ b/pkg/flare/archive_linux.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build linux
+
+package flare
+
+import (
+	"path/filepath"
+)
+
+func zipLinuxKernelSymbols(tempDir, hostname string) error {
+	return zipFile("/proc/kallsyms", filepath.Join(tempDir, hostname, "kallsyms"))
+}
+
+func zipLinuxKrobeEvents(tempDir, hostname string) error {
+	return zipFile("/sys/kernel/debug/tracing/kprobe_events", filepath.Join(tempDir, hostname, "kprobe_events"))
+}
+
+func zipLinuxPid1MountInfo(tempDir, hostname string) error {
+	return zipFile("/proc/1/mountinfo", filepath.Join(tempDir, hostname, "mountinfo"))
+}

--- a/pkg/flare/archive_linux.go
+++ b/pkg/flare/archive_linux.go
@@ -22,3 +22,11 @@ func zipLinuxKrobeEvents(tempDir, hostname string) error {
 func zipLinuxPid1MountInfo(tempDir, hostname string) error {
 	return zipFile("/proc/1/mountinfo", filepath.Join(tempDir, hostname, "mountinfo"))
 }
+
+func zipLinuxTracingAvailableEvents(tempDir, hostname string) error {
+	return zipFile("/sys/kernel/debug/tracing/available_events", filepath.Join(tempDir, hostname, "available_events"))
+}
+
+func zipLinuxTracingAvailableFilterFunctions(tempDir, hostname string) error {
+	return zipFile("/sys/kernel/debug/tracing/available_filter_functions", filepath.Join(tempDir, hostname, "available_filter_functions"))
+}

--- a/pkg/flare/archive_nolinux.go
+++ b/pkg/flare/archive_nolinux.go
@@ -1,0 +1,20 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build !linux
+
+package flare
+
+func zipLinuxKernelSymbols(tempDir, hostname string) error {
+	return nil
+}
+
+func zipLinuxKrobeEvents(tempDir, hostname string) error {
+	return nil
+}
+
+func zipLinuxPid1MountInfo(tempDir, hostname string) error {
+	return nil
+}

--- a/pkg/flare/archive_nolinux.go
+++ b/pkg/flare/archive_nolinux.go
@@ -18,3 +18,11 @@ func zipLinuxKrobeEvents(tempDir, hostname string) error {
 func zipLinuxPid1MountInfo(tempDir, hostname string) error {
 	return nil
 }
+
+func zipLinuxTracingAvailableEvents(tempDir, hostname string) error {
+	return nil
+}
+
+func zipLinuxTracingAvailableFilterFunctions(tempDir, hostname string) error {
+	return nil
+}

--- a/pkg/flare/archive_security.go
+++ b/pkg/flare/archive_security.go
@@ -83,6 +83,21 @@ func CreateSecurityAgentArchive(local bool, logFilePath string, runtimeStatus ma
 		return "", err
 	}
 
+	err = zipLinuxKernelSymbols(tempDir, hostname)
+	if err != nil {
+		return "", err
+	}
+
+	err = zipLinuxPid1MountInfo(tempDir, hostname)
+	if err != nil {
+		return "", err
+	}
+
+	err = zipLinuxKrobeEvents(tempDir, hostname)
+	if err != nil {
+		log.Infof("Error while getting kprobe_events: %s", err)
+	}
+
 	err = permsInfos.commit(tempDir, hostname, os.ModePerm)
 	if err != nil {
 		log.Infof("Error while creating permissions.log infos file: %s", err)

--- a/pkg/flare/archive_security.go
+++ b/pkg/flare/archive_security.go
@@ -98,6 +98,16 @@ func CreateSecurityAgentArchive(local bool, logFilePath string, runtimeStatus ma
 		log.Infof("Error while getting kprobe_events: %s", err)
 	}
 
+	err = zipLinuxTracingAvailableEvents(tempDir, hostname)
+	if err != nil {
+		log.Infof("Error while getting kprobe_events: %s", err)
+	}
+
+	err = zipLinuxTracingAvailableFilterFunctions(tempDir, hostname)
+	if err != nil {
+		log.Infof("Error while getting kprobe_events: %s", err)
+	}
+
 	err = permsInfos.commit(tempDir, hostname, os.ModePerm)
 	if err != nil {
 		log.Infof("Error while creating permissions.log infos file: %s", err)

--- a/releasenotes/notes/runtime-security-service-tag-03a269ce6cd63e73.yaml
+++ b/releasenotes/notes/runtime-security-service-tag-03a269ce6cd63e73.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Runtime Security now provide kernel related information
+    as part of the flare.
+other:
+  - |
+    Runtime Security doesn't set the service tag with the
+    `runtime-security-agent` value by default.


### PR DESCRIPTION
### What does this PR do?

Do not send anymore the service tag with the default value `runtime-security-agent`.
Add kernel related information to security-agent flare, like probe_events, pid1 mountinfo, kallsyms.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
- [x ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.

Note: Adding GitHub labels is only possible for contributors with write access.
