### PR TITLE
[backport] Make Gitlab work with `main` branch

### DIFF
--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -52,7 +52,7 @@ tests_ebpf_x64:
     # Compile runtime security stress tests to be executed in kitchen tests
     - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
     # Compile master version for comparison, uncomment following lines when merged
-    - git checkout -f master
+    - git checkout -f main || git checkout -f master
     - git pull
     - inv -e deps
     - inv -e system-probe.build --bundle-ebpf --incremental-build


### PR DESCRIPTION
### What does this PR do?

Partial backport of #8385 to make ebpf tests work.

### Motivation

Fix broken pipeline

### Additional Notes

Keeping `master` option in case we need to revert the change.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
