### PR TITLE
[runtime-security] do not set 'service' tag with 'runtime-security-agent'

### DIFF
--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -141,9 +141,8 @@ func newRuntimeReporter(stopper restart.Stopper, sourceName, sourceType string, 
 	logSource := config.NewLogSource(
 		sourceName,
 		&config.LogsConfig{
-			Type:    sourceType,
-			Service: sourceName,
-			Source:  sourceName,
+			Type:   sourceType,
+			Source: sourceName,
 		},
 	)
 	return event.NewReporter(logSource, pipelineProvider.NextPipelineChan()), nil


### PR DESCRIPTION
### What does this PR do?

Do not set 'service' tag for all logs

### Motivation

When a service was detected, logs could have twice the 'service' tag