### PR TITLE
[runtime-security] fix missing field tags and fix accessors generator script

### DIFF
--- a/pkg/security/model/model.go
+++ b/pkg/security/model/model.go
@@ -414,8 +414,8 @@ var zeroProcessContext ProcessContext
 type ProcessCacheEntry struct {
 	ProcessContext
 
-	refCount  uint64
-	onRelease func(_ *ProcessCacheEntry)
+	refCount  uint64                     `field:"-"`
+	onRelease func(_ *ProcessCacheEntry) `field:"-"`
 }
 
 // Reset the entry

--- a/pkg/security/secl/generators/accessors/accessors.go
+++ b/pkg/security/secl/generators/accessors/accessors.go
@@ -17,7 +17,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -288,7 +287,7 @@ func handleSpec(astFile *ast.File, spec interface{}, prefix, aliasPrefix, event 
 						dejavu[fieldName] = true
 
 						if fieldType != nil {
-							if err := handleField(astFile, fieldName, fieldAlias, prefix, aliasPrefix, filepath.Base(pkgname), fieldType, event, fieldIterator, dejavu, false); err != nil {
+							if err := handleField(astFile, fieldName, fieldAlias, prefix, aliasPrefix, pkgname, fieldType, event, fieldIterator, dejavu, false); err != nil {
 								log.Print(err)
 							}
 
@@ -359,7 +358,7 @@ func parseFile(filename string, pkgName string) (*Module, error) {
 
 	packages = make(map[string]*types.Package, len(program.AllPackages))
 	for typePackage := range program.AllPackages {
-		packages[typePackage.Name()] = typePackage
+		packages[typePackage.Path()] = typePackage
 	}
 
 	var buildTags []string


### PR DESCRIPTION
### What does this PR do?

This PR:
- adds missing field tags to `ProcessCacheEntry` struct
- fix module name collision in accessors generator script by using whole module path in map

### Describe how to test your changes

Try running the generator command on the accessors file. It should run without errors.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
