### PR TITLE
[logs/config] enable additional endpoints regardless of underlying transport

### DIFF
--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -113,7 +113,7 @@ func BuildEndpointsWithConfig(logsConfig *LogsConfigKeys, endpointPrefix string,
 		log.Warnf("Use of illegal configuration parameter, if you need to send your logs to a proxy, "+
 			"please use '%s' and '%s' instead", logsConfig.getConfigKey("logs_dd_url"), logsConfig.getConfigKey("logs_no_ssl"))
 	}
-	if logsConfig.isForceHTTPUse() || (bool(httpConnectivity) && !(logsConfig.isForceTCPUse() || logsConfig.isSocks5ProxySet() || logsConfig.hasAdditionalEndpoints())) {
+	if logsConfig.isForceHTTPUse() || (bool(httpConnectivity) && !(logsConfig.isForceTCPUse() || logsConfig.isSocks5ProxySet())) {
 		return BuildHTTPEndpointsWithConfig(logsConfig, endpointPrefix)
 	}
 	log.Warnf("You are currently sending Logs to Datadog through TCP (either because %s or %s is set or the HTTP connectivity test has failed) "+

--- a/pkg/logs/config/config_keys.go
+++ b/pkg/logs/config/config_keys.go
@@ -101,10 +101,6 @@ func (l *LogsConfigKeys) useCompression() bool {
 	return l.getConfig().GetBool(l.getConfigKey("use_compression"))
 }
 
-func (l *LogsConfigKeys) hasAdditionalEndpoints() bool {
-	return len(l.getAdditionalEndpoints()) > 0
-}
-
 // getLogsAPIKey provides the dd api key used by the main logs agent sender.
 func (l *LogsConfigKeys) getLogsAPIKey() string {
 	if configKey := l.getConfigKey("api_key"); l.isSetAndNotEmpty(configKey) {


### PR DESCRIPTION
### What does this PR do?
Allow `additional_endpoints` for logs over both TCP and HTTP instead of just TCP.

### Motivation
Compare logs flowing through different paths.

### Additional Notes
Additional endpoint were already supported for http in `BuildHTTPEndpointsWithConfig` and subsequently accounted for while sending (did a few test).

I'm not exactly sure why it was disabled in the first place, but it would be very convenient for upcoming test case involving vector and the agent.


### Describe how to test your changes
Standard QA + UT should be enough.
I did local test using vector as an alternate endpoint.
