### PR TITLE
[runtime-security] make sure to use golang zero time when unmarshalling

### DIFF
--- a/pkg/security/model/process_cache_entry.go
+++ b/pkg/security/model/process_cache_entry.go
@@ -40,8 +40,8 @@ func copyProcessContext(parent, child *ProcessCacheEntry) {
 func (pc *ProcessCacheEntry) Exec(entry *ProcessCacheEntry) {
 	entry.SetAncestor(pc)
 
-	// empty and mark as exit previous entry
-	pc.ExitTime = entry.ExecTime
+	// use exec time a exit time
+	pc.Exit(entry.ExecTime)
 
 	// keep some context
 	copyProcessContext(pc, entry)

--- a/pkg/security/model/unmarshallers.go
+++ b/pkg/security/model/unmarshallers.go
@@ -125,6 +125,13 @@ func (e *Credentials) UnmarshalBinary(data []byte) (int, error) {
 	return 40, nil
 }
 
+func unmarshalTime(data []byte) time.Time {
+	if t := int64(ByteOrder.Uint64(data)); t != 0 {
+		return time.Unix(0, t)
+	}
+	return time.Time{}
+}
+
 // UnmarshalBinary unmarshals a binary representation of itself
 func (e *Process) UnmarshalBinary(data []byte) (int, error) {
 	// Unmarshal proc_cache_t
@@ -157,8 +164,8 @@ func (e *Process) UnmarshalBinary(data []byte) (int, error) {
 	e.Cookie = ByteOrder.Uint32(data[read : read+4])
 	e.PPid = ByteOrder.Uint32(data[read+4 : read+8])
 
-	e.ForkTime = time.Unix(0, int64(ByteOrder.Uint64(data[read+8:read+16])))
-	e.ExitTime = time.Unix(0, int64(ByteOrder.Uint64(data[read+16:read+24])))
+	e.ForkTime = unmarshalTime(data[read+8 : read+16])
+	e.ExitTime = unmarshalTime(data[read+16 : read+24])
 	read += 24
 
 	// Unmarshal the credentials contained in pid_cache_t


### PR DESCRIPTION
### What does this PR do?

Make sure that unmarshal zero kernel time value to zero golang time.

### Motivation

Avoid having incorrect exit time.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
