### PR TITLE
Do not duplicate datadog.agent.up

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -594,7 +594,7 @@ func (agg *BufferedAggregator) sendServiceChecks(start time.Time, serviceChecks 
 func (agg *BufferedAggregator) flushServiceChecks(start time.Time, waitForSerializer bool) {
 	// Add a simple service check for the Agent status
 	agg.addServiceCheck(metrics.ServiceCheck{
-		CheckName: "datadog.agent.up",
+		CheckName: fmt.Sprintf("datadog.%s.up", agg.agentName),
 		Status:    metrics.ServiceCheckOK,
 		Tags:      agg.tags(false),
 		Host:      agg.hostname,

--- a/releasenotes/notes/fix-default-service-check-b785cefd35c196f1.yaml
+++ b/releasenotes/notes/fix-default-service-check-b785cefd35c196f1.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Avoid sending duplicated ``datadog.agent.up`` service checks.


### PR DESCRIPTION
### What does this PR do?

Avoid sending duplicated `datadog.agent.up` service checks by multiple agents.

### Motivation

Can cause false negatives.

### Describe how to test your changes

Write here in detail how you have tested your changes

Enable the agent and the security agent, make sure both service checks `datadog.agent.up` and `datadog.security_agent.up` are sent.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.

