### PR TITLE
[DCA][Admission] Update secret on service change

### DIFF
--- a/pkg/clusteragent/admission/status.go
+++ b/pkg/clusteragent/admission/status.go
@@ -100,10 +100,11 @@ func getSecretStatus(ns, name string, apiCl kubernetes.Interface) (map[string]in
 	secretStatus["Namespace"] = secret.GetNamespace()
 	secretStatus["CreatedAt"] = secret.GetCreationTimestamp()
 	secretStatus["CABundleDigest"] = getDigest(secret.Data["cert.pem"])
-	t, err := certificate.GetDurationBeforeExpiration(secret.Data)
+	cert, err := certificate.GetCertFromSecret(secret.Data)
 	if err != nil {
-		log.Errorf("Cannot get certificate validity duration: %v", err)
+		log.Errorf("Cannot get certificate from secret: %v", err)
 	}
+	t := certificate.GetDurationBeforeExpiration(cert)
 	secretStatus["CertValidDuration"] = t.String()
 	return secretStatus, nil
 }

--- a/pkg/util/kubernetes/certificate/certificate_test.go
+++ b/pkg/util/kubernetes/certificate/certificate_test.go
@@ -17,14 +17,18 @@ func TestCreateSecretData(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Failed to create the Secret: %v", err)
 	}
+
 	_, err = ParseSecretData(data)
 	if err != nil {
 		t.Fatalf("Failed to parse the Secret: %v", err)
 	}
-	expiration, err := GetDurationBeforeExpiration(data)
+
+	cert, err := GetCertFromSecret(data)
 	if err != nil {
 		t.Fatalf("Failed to parse the Secret: %v", err)
 	}
+
+	expiration := GetDurationBeforeExpiration(cert)
 	if expiration < 1*time.Hour {
 		t.Fatalf("The Secret expires too soon: %v", expiration)
 	}

--- a/releasenotes-dca/notes/dca-admission-update-secret-0fdf2e79d1abd2b0.yaml
+++ b/releasenotes-dca/notes/dca-admission-update-secret-0fdf2e79d1abd2b0.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix an edge case where the Admission Controller doesn't update
+    the certificate according to the Cluster Agent configuration.


### PR DESCRIPTION
### What does this PR do?

Make the Admission's secret controller detect service name changes.

### Motivation

Bug fix.

### Additional Notes

Improved the controller's logging as well.

### Describe how to test your changes

- Enable the Admission controller and set a custom service name.
```
  env:
  - name: DD_ADMISSION_CONTROLLER_SERVICE_NAME
    value: "svc1"
```
- Verify that the certificate's `Subject Alternative Name` corresponds to the service name
```
kg secrets webhook-certificate -ojson | jq -r '.data | ."cert.pem"' | base64 --decode | openssl x509 -text -noout | grep "Subject Alternative Name" -A1 | tail -n 1 | xargs
DNS:svc1, DNS:svc1.default, DNS:svc1.default.svc, DNS:svc1.default.svc.cluster.local
```

- Change the config and make sure the new service name is applied
```
  env:
  - name: DD_ADMISSION_CONTROLLER_SERVICE_NAME
    value: "svc2"
```
```
kg secrets webhook-certificate -ojson | jq -r '.data | ."cert.pem"' | base64 --decode | openssl x509 -text -noout | grep "Subject Alternative Name" -A1 | tail -n 1 | xargs
DNS:svc2, DNS:svc2.default, DNS:svc2.default.svc, DNS:svc2.default.svc.cluster.local
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
