### PR TITLE
[corechecks/snmp] Add interface.id_tags field

### DIFF
--- a/pkg/collector/corechecks/snmp/metadata/payload.go
+++ b/pkg/collector/corechecks/snmp/metadata/payload.go
@@ -25,7 +25,7 @@ type NetworkDevicesMetadata struct {
 // DeviceMetadata contains device metadata
 type DeviceMetadata struct {
 	ID          string       `json:"id"`
-	IDTags      []string     `json:"id_tags"`
+	IDTags      []string     `json:"id_tags"` // id_tags is the input to produce device.id, it's also used to correlated with device metrics.
 	Name        string       `json:"name"`
 	Description string       `json:"description"`
 	IPAddress   string       `json:"ip_address"`
@@ -40,8 +40,8 @@ type DeviceMetadata struct {
 // InterfaceMetadata contains interface metadata
 type InterfaceMetadata struct {
 	DeviceID    string   `json:"device_id"`
-	IDTags      []string `json:"id_tags"`
-	Index       int32    `json:"index"` // IF-MIB ifIndex type is InterfaceIndex (Integer32 (1..2147483647))
+	IDTags      []string `json:"id_tags"` // used to correlate with interface metrics
+	Index       int32    `json:"index"`   // IF-MIB ifIndex type is InterfaceIndex (Integer32 (1..2147483647))
 	Name        string   `json:"name"`
 	Alias       string   `json:"alias"`
 	Description string   `json:"description"`

--- a/pkg/collector/corechecks/snmp/metadata/payload.go
+++ b/pkg/collector/corechecks/snmp/metadata/payload.go
@@ -39,12 +39,13 @@ type DeviceMetadata struct {
 
 // InterfaceMetadata contains interface metadata
 type InterfaceMetadata struct {
-	DeviceID    string `json:"device_id"`
-	Index       int32  `json:"index"` // IF-MIB ifIndex type is InterfaceIndex (Integer32 (1..2147483647))
-	Name        string `json:"name"`
-	Alias       string `json:"alias"`
-	Description string `json:"description"`
-	MacAddress  string `json:"mac_address"`
-	AdminStatus int32  `json:"admin_status"` // IF-MIB ifAdminStatus type is INTEGER
-	OperStatus  int32  `json:"oper_status"`  // IF-MIB ifOperStatus type is INTEGER
+	DeviceID    string   `json:"device_id"`
+	IDTags      []string `json:"id_tags"`
+	Index       int32    `json:"index"` // IF-MIB ifIndex type is InterfaceIndex (Integer32 (1..2147483647))
+	Name        string   `json:"name"`
+	Alias       string   `json:"alias"`
+	Description string   `json:"description"`
+	MacAddress  string   `json:"mac_address"`
+	AdminStatus int32    `json:"admin_status"` // IF-MIB ifAdminStatus type is INTEGER
+	OperStatus  int32    `json:"oper_status"`  // IF-MIB ifOperStatus type is INTEGER
 }

--- a/pkg/collector/corechecks/snmp/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/report_device_metadata.go
@@ -12,6 +12,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/metadata"
 )
 
+// interfaceNameTagKey matches the `interface` tag used in `_generic-if.yaml` for ifName
+var interfaceNameTagKey = "interface"
+
 func (ms *metricSender) reportNetworkDeviceMetadata(config snmpConfig, store *resultValueStore, origTags []string, collectTime time.Time, deviceStatus metadata.DeviceStatus) {
 	tags := copyStrings(origTags)
 	tags = util.SortUniqInPlace(tags)
@@ -81,15 +84,17 @@ func buildNetworkInterfacesMetadata(deviceID string, store *resultValueStore) ([
 			continue
 		}
 
+		name := store.getColumnValueAsString(metadata.IfNameOID, strIndex)
 		networkInterface := metadata.InterfaceMetadata{
 			DeviceID:    deviceID,
 			Index:       int32(index),
-			Name:        store.getColumnValueAsString(metadata.IfNameOID, strIndex),
+			Name:        name,
 			Alias:       store.getColumnValueAsString(metadata.IfAliasOID, strIndex),
 			Description: store.getColumnValueAsString(metadata.IfDescrOID, strIndex),
 			MacAddress:  store.getColumnValueAsString(metadata.IfPhysAddressOID, strIndex),
 			AdminStatus: int32(store.getColumnValueAsFloat(metadata.IfAdminStatusOID, strIndex)),
 			OperStatus:  int32(store.getColumnValueAsFloat(metadata.IfOperStatusOID, strIndex)),
+			IDTags:      []string{interfaceNameTagKey + ":" + name},
 		}
 		interfaces = append(interfaces, networkInterface)
 	}

--- a/pkg/collector/corechecks/snmp/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/report_device_metadata_test.go
@@ -138,6 +138,9 @@ func Test_metricSender_reportNetworkDeviceMetadata_withInterfaces(t *testing.T) 
     "interfaces": [
         {
             "device_id": "1234",
+            "id_tags": [
+                "interface:21"
+            ],
             "index": 1,
             "name": "21",
             "alias": "",
@@ -148,6 +151,9 @@ func Test_metricSender_reportNetworkDeviceMetadata_withInterfaces(t *testing.T) 
         },
         {
             "device_id": "1234",
+            "id_tags": [
+                "interface:22"
+            ],
             "index": 2,
             "name": "22",
             "alias": "",

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -565,6 +565,7 @@ profiles:
   "interfaces": [
     {
       "device_id": "173b2077d0770b8",
+      "id_tags": ["interface:nameRow1"],
       "index": 1,
       "name": "nameRow1",
       "alias": "descRow1",
@@ -575,6 +576,7 @@ profiles:
     },
     {
       "device_id": "173b2077d0770b8",
+	  "id_tags": ["interface:nameRow2"],
       "index": 2,
       "name": "nameRow2",
       "alias": "descRow2",
@@ -1240,6 +1242,7 @@ tags:
   "interfaces": [
     {
       "device_id": "173b2077d0770b8",
+      "id_tags": ["interface:nameRow1"],
       "index": 1,
       "name": "nameRow1",
       "alias": "descRow1",
@@ -1250,6 +1253,7 @@ tags:
     },
     {
       "device_id": "173b2077d0770b8",
+      "id_tags": ["interface:nameRow2"],
       "index": 2,
       "name": "nameRow2",
       "alias": "descRow2",

--- a/releasenotes/notes/snmp_add_interface_id_tags-6c56d07157ff47d6.yaml
+++ b/releasenotes/notes/snmp_add_interface_id_tags-6c56d07157ff47d6.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    [snmp/corecheck] Add interface.id_tags needed to correlated metadata interfaces with interface metrics


### PR DESCRIPTION
### What does this PR do?

[corechecks/snmp] Add interface.id_tags field

### Motivation

Needed for correlation with interface metrics

### Additional Notes

### Describe how to test your changes

- [ ] Check that interface id_tags is present in `agent check snmp` output, with `init_config.collect_device_metadata: true`


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
