### PR TITLE
[gitlab] Improve `agent_release_management` trigger behavior

### DIFF
--- a/.gitlab/trigger_release.yml
+++ b/.gitlab/trigger_release.yml
@@ -12,7 +12,7 @@ trigger_release_6:
     !reference [.on_deploy_stable_or_beta_repo_branch_a6_always]
   stage: trigger_release
   script:
-    - export RELEASE_VERSION=$(inv -e agent.version --major-version 6 --url-safe)-1
+    - export RELEASE_VERSION=$(inv -e agent.version --major-version 6 --url-safe --omnibus-format)-1
     - python3 -m pip install -r requirements.txt
     - inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-release-management" --git-ref "master" --variables "RELEASE_VERSION"
 
@@ -23,6 +23,6 @@ trigger_release_7:
     !reference [.on_deploy_stable_or_beta_repo_branch_a7_always]
   stage: trigger_release
   script:
-    - export RELEASE_VERSION=$(inv -e agent.version --major-version 7 --url-safe)-1
+    - export RELEASE_VERSION=$(inv -e agent.version --major-version 7 --url-safe --omnibus-format)-1
     - python3 -m pip install -r requirements.txt
     - inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-release-management" --git-ref "master" --variables "RELEASE_VERSION"

--- a/.gitlab/trigger_release.yml
+++ b/.gitlab/trigger_release.yml
@@ -6,21 +6,23 @@
 # because there's no way to retry a trigger job once it gets skipped
 # because of a pipeline failure, even when retrying the pipeline.
 trigger_release_6:
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["runner:main", "size:2xlarge"]
   rules:
     !reference [.on_deploy_stable_or_beta_repo_branch_a6_always]
   stage: trigger_release
-  variables:
-    RELEASE_VERSION: $RELEASE_VERSION_6-1
-  trigger:
-    project: DataDog/agent-release-management
-    branch: master
+  script:
+    - RELEASE_VERSION=$(inv -e agent.version --major-version 6 --url-safe)
+    - python3 -m pip install -r requirements.txt
+    - inv pipeline.trigger-child-pipeline --repo-name "agent-release-management" --ref "master" --variables "RELEASE_VERSION"
 
 trigger_release_7:
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["runner:main", "size:2xlarge"]
   rules:
     !reference [.on_deploy_stable_or_beta_repo_branch_a7_always]
   stage: trigger_release
-  variables:
-    RELEASE_VERSION: $RELEASE_VERSION_7-1
-  trigger:
-    project: DataDog/agent-release-management
-    branch: master
+  script:
+    - RELEASE_VERSION=$(inv -e agent.version --major-version 7 --url-safe)
+    - python3 -m pip install -r requirements.txt
+    - inv pipeline.trigger-child-pipeline --repo-name "agent-release-management" --ref "master" --variables "RELEASE_VERSION"

--- a/.gitlab/trigger_release.yml
+++ b/.gitlab/trigger_release.yml
@@ -12,7 +12,7 @@ trigger_release_6:
     !reference [.on_deploy_stable_or_beta_repo_branch_a6_always]
   stage: trigger_release
   script:
-    - RELEASE_VERSION=$(inv -e agent.version --major-version 6 --url-safe)
+    - export RELEASE_VERSION=$(inv -e agent.version --major-version 6 --url-safe)
     - python3 -m pip install -r requirements.txt
     - inv pipeline.trigger-child-pipeline --repo-name "DataDog/agent-release-management" --ref "master" --variables "RELEASE_VERSION"
 
@@ -23,6 +23,6 @@ trigger_release_7:
     !reference [.on_deploy_stable_or_beta_repo_branch_a7_always]
   stage: trigger_release
   script:
-    - RELEASE_VERSION=$(inv -e agent.version --major-version 7 --url-safe)
+    - export RELEASE_VERSION=$(inv -e agent.version --major-version 7 --url-safe)
     - python3 -m pip install -r requirements.txt
     - inv pipeline.trigger-child-pipeline --repo-name "DataDog/agent-release-management" --ref "master" --variables "RELEASE_VERSION"

--- a/.gitlab/trigger_release.yml
+++ b/.gitlab/trigger_release.yml
@@ -12,9 +12,9 @@ trigger_release_6:
     !reference [.on_deploy_stable_or_beta_repo_branch_a6_always]
   stage: trigger_release
   script:
-    - export RELEASE_VERSION=$(inv -e agent.version --major-version 6 --url-safe)
+    - export RELEASE_VERSION=$(inv -e agent.version --major-version 6 --url-safe)-1
     - python3 -m pip install -r requirements.txt
-    - inv pipeline.trigger-child-pipeline --repo-name "DataDog/agent-release-management" --ref "master" --variables "RELEASE_VERSION"
+    - inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-release-management" --git-ref "master" --variables "RELEASE_VERSION"
 
 trigger_release_7:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
@@ -23,6 +23,6 @@ trigger_release_7:
     !reference [.on_deploy_stable_or_beta_repo_branch_a7_always]
   stage: trigger_release
   script:
-    - export RELEASE_VERSION=$(inv -e agent.version --major-version 7 --url-safe)
+    - export RELEASE_VERSION=$(inv -e agent.version --major-version 7 --url-safe)-1
     - python3 -m pip install -r requirements.txt
-    - inv pipeline.trigger-child-pipeline --repo-name "DataDog/agent-release-management" --ref "master" --variables "RELEASE_VERSION"
+    - inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-release-management" --git-ref "master" --variables "RELEASE_VERSION"

--- a/.gitlab/trigger_release.yml
+++ b/.gitlab/trigger_release.yml
@@ -2,27 +2,27 @@
 # trigger_release stage
 # Contains jobs which trigger release pipelines in the datadog/agent-release-management repository.
 
+.agent_release_management_trigger:
+  stage: trigger_release
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["runner:main", "size:2xlarge"]
+  script:
+    - python3 -m pip install -r requirements.txt
+    - inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-release-management" --git-ref "master" --variables "RELEASE_VERSION"
+
 # The trigger jobs are always run (even on failing pipelines)
 # because there's no way to retry a trigger job once it gets skipped
 # because of a pipeline failure, even when retrying the pipeline.
 trigger_release_6:
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  extends: .agent_release_management_trigger
   rules:
     !reference [.on_deploy_stable_or_beta_repo_branch_a6_always]
-  stage: trigger_release
-  script:
+  before_script:
     - export RELEASE_VERSION=$(inv -e agent.version --major-version 6 --url-safe --omnibus-format)-1
-    - python3 -m pip install -r requirements.txt
-    - inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-release-management" --git-ref "master" --variables "RELEASE_VERSION"
 
 trigger_release_7:
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  extends: .agent_release_management_trigger
   rules:
     !reference [.on_deploy_stable_or_beta_repo_branch_a7_always]
-  stage: trigger_release
-  script:
+  before_script:
     - export RELEASE_VERSION=$(inv -e agent.version --major-version 7 --url-safe --omnibus-format)-1
-    - python3 -m pip install -r requirements.txt
-    - inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-release-management" --git-ref "master" --variables "RELEASE_VERSION"

--- a/.gitlab/trigger_release.yml
+++ b/.gitlab/trigger_release.yml
@@ -14,7 +14,7 @@ trigger_release_6:
   script:
     - RELEASE_VERSION=$(inv -e agent.version --major-version 6 --url-safe)
     - python3 -m pip install -r requirements.txt
-    - inv pipeline.trigger-child-pipeline --repo-name "agent-release-management" --ref "master" --variables "RELEASE_VERSION"
+    - inv pipeline.trigger-child-pipeline --repo-name "DataDog/agent-release-management" --ref "master" --variables "RELEASE_VERSION"
 
 trigger_release_7:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
@@ -25,4 +25,4 @@ trigger_release_7:
   script:
     - RELEASE_VERSION=$(inv -e agent.version --major-version 7 --url-safe)
     - python3 -m pip install -r requirements.txt
-    - inv pipeline.trigger-child-pipeline --repo-name "agent-release-management" --ref "master" --variables "RELEASE_VERSION"
+    - inv pipeline.trigger-child-pipeline --repo-name "DataDog/agent-release-management" --ref "master" --variables "RELEASE_VERSION"

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -6,6 +6,7 @@ Agent namespaced tasks
 import datetime
 import glob
 import os
+import re
 import shutil
 import sys
 from distutils.dir_util import copy_tree
@@ -640,16 +641,21 @@ def clean(ctx):
 
 
 @task
-def version(ctx, url_safe=False, git_sha_length=7, major_version='7'):
+def version(ctx, url_safe=False, omnibus_format=False, git_sha_length=7, major_version='7'):
     """
     Get the agent version.
     url_safe: get the version that is able to be addressed as a url
+    omnibus_format: performs the same transformations omnibus does on version names to
+                    get the exact same string that's used in package names
     git_sha_length: different versions of git have a different short sha length,
                     use this to explicitly set the version
                     (the windows builder and the default ubuntu version have such an incompatibility)
     """
-    print(
-        get_version(
-            ctx, include_git=True, url_safe=url_safe, git_sha_length=git_sha_length, major_version=major_version
-        )
+    version = get_version(
+        ctx, include_git=True, url_safe=url_safe, git_sha_length=git_sha_length, major_version=major_version
     )
+    if omnibus_format:
+        # See: https://github.com/DataDog/omnibus-ruby/blob/datadog-5.5.0/lib/omnibus/packagers/deb.rb#L599
+        version = re.sub('-', '~', version)
+        version = re.sub(r'[^a-zA-Z0-9\.\+\:\~]+', '_', version)
+    print(version)

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -656,6 +656,17 @@ def version(ctx, url_safe=False, omnibus_format=False, git_sha_length=7, major_v
     )
     if omnibus_format:
         # See: https://github.com/DataDog/omnibus-ruby/blob/datadog-5.5.0/lib/omnibus/packagers/deb.rb#L599
+        # In theory we'd need to have one format for each package type (deb, rpm, msi, pkg).
+        # However, there are a few things that allow us in practice to have only one variable for everything:
+        # - the deb and rpm safe version formats are identical (the only difference is an additional rule on Wind River Linux, which doesn't apply to us).
+        #   Moreover, of the two rules, we actually really only use the first one (because we always use inv agent.version --url-safe).
+        # - the msi version name uses the raw version string. The only difference with the deb / rpm versions
+        #   is therefore that dashes are replaced by tildes. We're already doing the reverse operation in agent-release-management
+        #   to get the correct msi name.
+        # - the pkg version name uses the raw version + a variation of the second rule (where a dash is used in place of an underscore).
+        #   Once again, replacing tildes by dashes (+ replacing underscore by dashes if we ever end up using the second rule for some reason)
+        #   in agent-release-management is enough. We're already replacing tildes by dashes in agent-release-management.
+        # TODO: investigate if having one format per package type in the agent.version method makes more sense.
         version = re.sub('-', '~', version)
         version = re.sub(r'[^a-zA-Z0-9\.\+\:\~]+', '_', version)
     print(version)

--- a/tasks/libs/common/gitlab.py
+++ b/tasks/libs/common/gitlab.py
@@ -89,6 +89,15 @@ class Gitlab(object):
 
         return sorted(pipelines, key=lambda pipeline: pipeline['created_at'], reverse=True)[0]
 
+    def trigger_pipeline(self, project_name, data):
+        """
+        Gets one page of the jobs for a pipeline.
+        per_page cannot exceed 100.
+        """
+        path = "/projects/{}/trigger/pipeline".format(quote(project_name, safe=""))
+
+        return self.make_request(path, data=data, json=True)
+
     def pipeline(self, project_name, pipeline_id):
         """
         Gets info for a given pipeline.

--- a/tasks/libs/common/gitlab.py
+++ b/tasks/libs/common/gitlab.py
@@ -92,9 +92,12 @@ class Gitlab(object):
     def trigger_pipeline(self, project_name, data):
         """
         Trigger a pipeline on a project using the trigger endpoint.
-        Requires a trigger token in the data object.
+        Requires a trigger token in the data object, in the 'token' field.
         """
         path = "/projects/{}/trigger/pipeline".format(quote(project_name, safe=""))
+
+        if 'token' not in data:
+            raise Exit("Missing 'token' field in data object to trigger child pipelines", 1)
 
         return self.make_request(path, data=data, json_input=True, json_output=True)
 
@@ -161,6 +164,17 @@ class Gitlab(object):
     ):
         """
         Utility to make a request to the Gitlab API.
+
+        headers: A hash of headers to pass to the request.
+        data: A hash containing the body of the request.
+        json_input: If set to true, data is passed with the json parameter of requests.post instead of the data parameter.
+
+        By default, the request method is GET, or POST if data is not empty.
+        method: Can be set to "POST" to force a POST request even when data is empty.
+
+        By default, we return the text field of the response object. The following fields can alter this behavior:
+        json_output: the json field of the response object is returned.
+        stream_output: the request asks for a stream response, and the raw response object is returned.
         """
         import requests
 

--- a/tasks/libs/common/gitlab.py
+++ b/tasks/libs/common/gitlab.py
@@ -38,7 +38,7 @@ class Gitlab(object):
         Gets the project info.
         """
         path = "/projects/{}".format(quote(project_name, safe=""))
-        return self.make_request(path, json=True)
+        return self.make_request(path, json_output=True)
 
     def create_pipeline(self, project_name, ref, variables=None):
         """
@@ -51,7 +51,7 @@ class Gitlab(object):
         path = "/projects/{}/pipeline".format(quote(project_name, safe=""))
         headers = {"Content-Type": "application/json"}
         data = json.dumps({"ref": ref, "variables": [{"key": k, "value": v} for (k, v) in variables.items()],})
-        return self.make_request(path, headers=headers, data=data, json=True)
+        return self.make_request(path, headers=headers, data=data, json_output=True)
 
     def all_pipelines_for_ref(self, project_name, ref, sha=None):
         """
@@ -75,7 +75,7 @@ class Gitlab(object):
         )
         if sha:
             path = "{}&sha={}".format(path, sha)
-        return self.make_request(path, json=True)
+        return self.make_request(path, json_output=True)
 
     def last_pipeline_for_ref(self, project_name, ref, per_page=100):
         """
@@ -91,37 +91,37 @@ class Gitlab(object):
 
     def trigger_pipeline(self, project_name, data):
         """
-        Gets one page of the jobs for a pipeline.
-        per_page cannot exceed 100.
+        Trigger a pipeline on a project using the trigger endpoint.
+        Requires a trigger token in the data object.
         """
         path = "/projects/{}/trigger/pipeline".format(quote(project_name, safe=""))
 
-        return self.make_request(path, data=data, json=True)
+        return self.make_request(path, data=data, json_input=True, json_output=True)
 
     def pipeline(self, project_name, pipeline_id):
         """
         Gets info for a given pipeline.
         """
         path = "/projects/{}/pipelines/{}".format(quote(project_name, safe=""), pipeline_id)
-        return self.make_request(path, json=True)
+        return self.make_request(path, json_output=True)
 
     def cancel_pipeline(self, project_name, pipeline_id):
         """
         Cancels a given pipeline.
         """
         path = "/projects/{}/pipelines/{}/cancel".format(quote(project_name, safe=""), pipeline_id)
-        return self.make_request(path, json=True, method="POST")
+        return self.make_request(path, json_output=True, method="POST")
 
     def commit(self, project_name, commit_sha):
         """
         Gets info for a given commit sha.
         """
         path = "/projects/{}/repository/commits/{}".format(quote(project_name, safe=""), commit_sha)
-        return self.make_request(path, json=True)
+        return self.make_request(path, json_output=True)
 
     def artifact(self, project_name, job_id, artifact_name):
         path = "/projects/{}/jobs/{}/artifacts/{}".format(quote(project_name, safe=""), job_id, artifact_name)
-        response = self.make_request(path, stream=True)
+        response = self.make_request(path, stream_output=True)
         if response.status_code != 200:
             return None
         return response
@@ -147,16 +147,18 @@ class Gitlab(object):
         path = "/projects/{}/pipelines/{}/jobs?per_page={}&page={}".format(
             quote(project_name, safe=""), pipeline_id, per_page, page
         )
-        return self.make_request(path, json=True)
+        return self.make_request(path, json_output=True)
 
     def find_tag(self, project_name, tag_name):
         """
         Look up a tag by its name.
         """
         path = "/projects/{}/repository/tags/{}".format(quote(project_name, safe=""), tag_name)
-        return self.make_request(path, json=True)
+        return self.make_request(path, json_output=True)
 
-    def make_request(self, path, headers=None, data=None, json=False, stream=False, method=None):
+    def make_request(
+        self, path, headers=None, data=None, json_input=False, json_output=False, stream_output=False, method=None
+    ):
         """
         Utility to make a request to the Gitlab API.
         """
@@ -170,10 +172,14 @@ class Gitlab(object):
         # TODO: Use the param argument of requests instead of handling URL params
         # manually
         try:
-            if data or method == "POST":
-                r = requests.post(url, headers=headers, data=data, stream=stream)
+            # If json_input is true, we specifically want to send data using the json
+            # parameter of requests.post
+            if data and json_input:
+                r = requests.post(url, headers=headers, json=data, stream=stream_output)
+            elif data or method == "POST":
+                r = requests.post(url, headers=headers, data=data, stream=stream_output)
             else:
-                r = requests.get(url, headers=headers, stream=stream)
+                r = requests.get(url, headers=headers, stream=stream_output)
             if r.status_code == 401:
                 print(
                     "HTTP 401: Your GITLAB_TOKEN may have expired. You can "
@@ -203,9 +209,9 @@ class Gitlab(object):
             else:
                 print("Error while connecting to {}: {}".format(url, str(e)))
             raise Exit(code=1)
-        if json:
+        if json_output:
             return r.json()
-        if stream:
+        if stream_output:
             return r
         return r.text
 

--- a/tasks/libs/common/gitlab.py
+++ b/tasks/libs/common/gitlab.py
@@ -166,7 +166,7 @@ class Gitlab(object):
         Utility to make a request to the Gitlab API.
 
         headers: A hash of headers to pass to the request.
-        data: A hash containing the body of the request.
+        data: An object containing the body of the request.
         json_input: If set to true, data is passed with the json parameter of requests.post instead of the data parameter.
 
         By default, the request method is GET, or POST if data is not empty.

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -333,15 +333,17 @@ def generate_failure_messages(base):
 
 
 @task
-def trigger_child_pipeline(_, git_ref, project_name, variables):
+def trigger_child_pipeline(_, git_ref, project_name, variables=""):
     """
-    Trigger a child pipeline on a target repository and ref.
+    Trigger a child pipeline on a target repository and git ref.
     Used in CI jobs only (requires CI_JOB_TOKEN).
 
-    Use --variables to specify the environment variables that should be passed to the child pipeline.
+    Use --variables to specify the environment variables that should be passed to the child pipeline, as a comma-spearated list.
 
     Examples:
     inv pipeline.trigger-child-pipeline --git-ref "master" --project-name "DataDog/agent-release-management" --variables "RELEASE_VERSION"
+
+    inv pipeline.trigger-child-pipeline --git-ref "master" --project-name "DataDog/agent-release-management" --variables "VAR1,VAR2,VAR3"
     """
 
     if not os.environ.get('CI_JOB_TOKEN'):
@@ -367,7 +369,7 @@ def trigger_child_pipeline(_, git_ref, project_name, variables):
 
     res = gitlab.trigger_pipeline(project_name, data)
 
-    if not res.get('id'):
+    if 'id' not in res:
         raise Exit("Failed to create child pipeline: {}".format(res), 1)
 
     print("Created a child pipeline with id={}, url={}".format(res['id'], res['web_url']))

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -334,10 +334,12 @@ def generate_failure_messages(base):
 
 @task
 def trigger_child_pipeline(_, git_ref, project_name, variables):
-    # The Gitlab utility requires `GITLAB_TOKEN` to be set, even though
+    if not os.environ.get('CI_JOB_TOKEN'):
+        raise Exit("CI_JOB_TOKEN variable needed to create child pipelines.", 1)
+
+    # The Gitlab lib requires `GITLAB_TOKEN` to be set, even though
     # we won't use it here
-    if os.environ.get('CI_JOB_TOKEN'):
-        os.environ["GITLAB_TOKEN"] = os.environ['CI_JOB_TOKEN']
+    os.environ["GITLAB_TOKEN"] = os.environ['CI_JOB_TOKEN']
 
     gitlab = Gitlab()
 

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -4,7 +4,6 @@ import re
 import traceback
 from collections import defaultdict
 
-import requests
 from invoke import task
 from invoke.exceptions import Exit
 
@@ -335,6 +334,8 @@ def generate_failure_messages(base):
 
 @task
 def trigger_child_pipeline(_, ref, repo_name, variables):
+    import requests
+
     data = {"token": os.environ['CI_JOB_TOKEN'], "ref": ref, "variables": {}}
 
     for v in variables.split(','):

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -338,7 +338,7 @@ def trigger_child_pipeline(_, git_ref, project_name, variables=""):
     Trigger a child pipeline on a target repository and git ref.
     Used in CI jobs only (requires CI_JOB_TOKEN).
 
-    Use --variables to specify the environment variables that should be passed to the child pipeline, as a comma-spearated list.
+    Use --variables to specify the environment variables that should be passed to the child pipeline, as a comma-separated list.
 
     Examples:
     inv pipeline.trigger-child-pipeline --git-ref "master" --project-name "DataDog/agent-release-management" --variables "RELEASE_VERSION"

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -334,6 +334,8 @@ def generate_failure_messages(base):
 
 @task
 def trigger_child_pipeline(_, ref, repo_name, variables):
+    from urllib.parse import quote
+
     import requests
 
     data = {"token": os.environ['CI_JOB_TOKEN'], "ref": ref, "variables": {}}
@@ -343,7 +345,7 @@ def trigger_child_pipeline(_, ref, repo_name, variables):
 
     print("Creating child pipeline in repo {}, on ref {} with params: {}".format(repo_name, ref, data['variables']))
     res = requests.post(
-        "https://gitlab.ddbuild.io/api/v4/projects/DataDog/{}/trigger/pipeline".format(repo_name), json=data
+        "https://gitlab.ddbuild.io/api/v4/projects/{}/trigger/pipeline".format(quote(repo_name, safe="")), json=data
     )
     res.raise_for_status()
     child_pipeline = res.json()


### PR DESCRIPTION
### What does this PR do?

Introduces a new invoke task, `pipeline.trigger-child-pipeline`, to create child pipelines from the CI in another repository.
Adds a new option to the `agent.version` task to make the version match the format omnibus uses to name packages.
Uses both above changes to trigger child pipelines on the `agent-release-management` using the correct package version (instead of the `RELEASE_VERSION` variable).

### Motivation

We can't use the `trigger` keyword to create `agent-release-management` pipelines, because we need to pass it the package name as omnibus computes it (otherwise the `agent-release-management` pipeline fails as soon as the version contains dashes or special characters), therefore we need to compute it with `agent.version`.

### Additional Notes

For now, the `pipeline.trigger-child-pipeline` task doesn't follow the child pipeline's status. This is fine because we don't need that for the `agent-release-management` child pipelines (we don't need to depend on the child pipeline), but we'll need to add this feature later for other child pipelines.

Noop for release pipelines (as `RELEASE_VERSION`, `agent.version`, and `agent.version --omnibus-format` are identical for versions in the form of `X.Y.Z`).

### Describe how to test your changes

Tested deploy pipelines targeting the `beta` release branch.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
