### PR TITLE
Remove noisy logs when collecting cloudfoundry containers

### DIFF
--- a/pkg/util/cloudfoundry/types.go
+++ b/pkg/util/cloudfoundry/types.go
@@ -228,7 +228,7 @@ func DesiredLRPFromBBSModel(bbsLRP *models.DesiredLRP, includeList, excludeList 
 		var ok bool
 		extractVA[key], ok = envVA[key]
 		if !ok || extractVA[key] == "" {
-			_ = log.Errorf("Couldn't extract %s from LRP %s", key, bbsLRP.ProcessGuid)
+			log.Tracef("Couldn't extract %s from LRP %s", key, bbsLRP.ProcessGuid)
 		}
 	}
 	appName := extractVA[ApplicationNameKey]
@@ -362,15 +362,17 @@ func getVcapApplicationMap(vcap string) (map[string]string, error) {
 		return res, err
 	}
 
-	// Keep only needed keys
+	// Keep only needed keys, if they are present
 	for _, key := range envVcapApplicationKeys {
 		val, ok := vcMap[key]
 		if !ok {
-			return res, fmt.Errorf("could not find key %s in VCAP_APPLICATION env var", key)
+			log.Tracef("Could not find key %s in VCAP_APPLICATION env var", key)
+			continue
 		}
 		valString, ok := val.(string)
 		if !ok {
-			return res, fmt.Errorf("could not parse the value of %s as a string", key)
+			log.Debugf("Could not parse the value of %s as a string", key)
+			continue
 		}
 		res[key] = valString
 	}

--- a/releasenotes/notes/cfnoisylogs-7cc594f3cecfecaa.yaml
+++ b/releasenotes/notes/cfnoisylogs-7cc594f3cecfecaa.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Removes noisy error logs when collecting Cloud Foundry application containers


### PR DESCRIPTION
In actual environments, there are many cases where some LRPs don't have a organisation, so the parsing could fail trying to get it from the VCAP_APPLICATION env var.
This solves it, and reduce the level of the log, as it can be very noisy in large environments