### PR TITLE
[Tagger] Improve caching and pruning

### DIFF
--- a/pkg/tagger/collectors/kubernetes_main.go
+++ b/pkg/tagger/collectors/kubernetes_main.go
@@ -178,8 +178,8 @@ func (c *KubeMetadataCollector) Fetch(ctx context.Context, entity string) ([]str
 		return lowCards, orchestratorCards, highCards, err
 	}
 
-	if kubelet.IsPodReady(pod) == false {
-		return lowCards, orchestratorCards, highCards, errors.NewNotFound(entity)
+	if !kubelet.IsPodReady(pod) {
+		return lowCards, orchestratorCards, highCards, nil
 	}
 
 	pods := []*kubelet.Pod{pod}
@@ -198,6 +198,7 @@ func (c *KubeMetadataCollector) Fetch(ctx context.Context, entity string) ([]str
 			return info.LowCardTags, info.OrchestratorCardTags, info.HighCardTags, nil
 		}
 	}
+
 	return lowCards, orchestratorCards, highCards, errors.NewNotFound(entity)
 }
 

--- a/pkg/tagger/collectors/kubernetes_metadata_mapper.go
+++ b/pkg/tagger/collectors/kubernetes_metadata_mapper.go
@@ -50,28 +50,30 @@ func (c *KubeMetadataCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 	}
 
 	for _, po := range pods {
-		if kubelet.IsPodReady(po) == false {
-			log.Debugf("pod %q is not ready, skipping", po.Metadata.Name)
-			continue
-		}
-
-		// We cannot define if a hostNetwork Pod is a member of a service
-		if po.Spec.HostNetwork == true {
+		// Generate empty tagInfos for pods and their containers if pod
+		// uses hostNetwork (we cannot define if a hostNetwork Pod is a
+		// member of a service) or is not ready (it would not be an
+		// endpoint of a service). This allows the tagger to cache the
+		// result and avoid repeated calls to the DCA.
+		if po.Spec.HostNetwork == true || !kubelet.IsPodReady(po) {
 			for _, container := range po.Status.Containers {
 				entityID, err := kubelet.KubeContainerIDToTaggerEntityID(container.ID)
 				if err != nil {
 					log.Warnf("Unable to parse container: %s", err)
 					continue
 				}
-				info := &TagInfo{
-					Source:               kubeMetadataCollectorName,
-					Entity:               entityID,
-					HighCardTags:         []string{},
-					OrchestratorCardTags: []string{},
-					LowCardTags:          []string{},
-				}
-				tagInfo = append(tagInfo, info)
+
+				tagInfo = append(tagInfo, &TagInfo{
+					Source: kubeMetadataCollectorName,
+					Entity: entityID,
+				})
 			}
+
+			tagInfo = append(tagInfo, &TagInfo{
+				Source: kubeMetadataCollectorName,
+				Entity: kubelet.PodUIDToTaggerEntityName(po.Metadata.UID),
+			})
+
 			continue
 		}
 

--- a/pkg/tagger/local/clock.go
+++ b/pkg/tagger/local/clock.go
@@ -1,0 +1,21 @@
+package local
+
+import "time"
+
+type clock interface {
+	Now() time.Time
+}
+
+type realClock struct{}
+
+func (realClock) Now() time.Time {
+	return time.Now()
+}
+
+type fakeClock struct {
+	now time.Time
+}
+
+func (f fakeClock) Now() time.Time {
+	return f.now
+}

--- a/pkg/tagger/local/clock.go
+++ b/pkg/tagger/local/clock.go
@@ -11,11 +11,3 @@ type realClock struct{}
 func (realClock) Now() time.Time {
 	return time.Now()
 }
-
-type fakeClock struct {
-	now time.Time
-}
-
-func (f fakeClock) Now() time.Time {
-	return f.now
-}

--- a/pkg/tagger/local/tagstore_test.go
+++ b/pkg/tagger/local/tagstore_test.go
@@ -123,6 +123,8 @@ func (s *StoreTestSuite) TestLookupNotPresent() {
 }
 
 func (s *StoreTestSuite) TestPrune__deletedEntities() {
+	clock := &fakeClock{now: time.Now()}
+	s.store.clock = clock
 	s.store.processTagInfo([]*collectors.TagInfo{
 		// Adds
 		{
@@ -163,6 +165,7 @@ func (s *StoreTestSuite) TestPrune__deletedEntities() {
 	assert.Len(s.T(), tagsHigh, 2)
 	assert.Len(s.T(), sourcesHigh, 1)
 
+	clock.now = clock.now.Add(10 * time.Minute)
 	s.store.prune()
 
 	// test1 should only have tags from source2, source1 should be removed
@@ -193,6 +196,7 @@ func (s *StoreTestSuite) TestPrune__deletedEntities() {
 		},
 	})
 
+	clock.now = clock.now.Add(10 * time.Minute)
 	s.store.prune()
 
 	tagsHigh, sourcesHigh = s.store.lookup("test1", collectors.HighCardinality)
@@ -386,7 +390,9 @@ type entityEventExpectation struct {
 }
 
 func TestSubscribe(t *testing.T) {
+	clock := &fakeClock{now: time.Now()}
 	store := newTagStore()
+	store.clock = clock
 
 	collectors.CollectorPriorities["source2"] = collectors.ClusterOrchestrator
 
@@ -434,6 +440,7 @@ func TestSubscribe(t *testing.T) {
 		},
 	})
 
+	clock.now = clock.now.Add(10 * time.Minute)
 	store.prune()
 
 	store.processTagInfo([]*collectors.TagInfo{
@@ -444,6 +451,7 @@ func TestSubscribe(t *testing.T) {
 		},
 	})
 
+	clock.now = clock.now.Add(10 * time.Minute)
 	store.prune()
 
 	var wg sync.WaitGroup

--- a/pkg/tagger/local/tagstore_test.go
+++ b/pkg/tagger/local/tagstore_test.go
@@ -17,6 +17,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagger/types"
 )
 
+type fakeClock struct {
+	now time.Time
+}
+
+func (f fakeClock) Now() time.Time {
+	return f.now
+}
+
 type StoreTestSuite struct {
 	suite.Suite
 	store *tagStore


### PR DESCRIPTION
### What does this PR do?

This improves pruning as a follow up of #8420, and caching of entities from the kube-metadata-collector to avoid too many network calls on cache misses.

### Motivation

We started to see timeouts when connecting to the DCA from certain nodes on a 5 minutes interval. Our assumption is that too many connections are being opened at once, and those can be avoided with these changes.

### Describe how to test your changes

* Testing entity deletion: create a pod, check that `agent tagger-list` has tags for the pod and container. Delete the pod, wait ~5 minutes, ensure that entities for pod and container no longer appear in the output.
* Testing kube-metadata-collector caching: set log level to debug with `agent config set log_level debug`, ensure that shortly after a pod not targeted by a service is created, there are no log lines like `entity $id not found in kube-metadata-collector, skipping`.