### PR TITLE
Whitelist installation path for newer versions of `aerospike` dependency

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -41,6 +41,7 @@ end
 
 relative_path 'integrations-core'
 whitelist_file "embedded/lib/python3.8/site-packages/.libsaerospike"
+whitelist_file "embedded/lib/python3.8/site-packages/aerospike.libs"
 whitelist_file "embedded/lib/python3.8/site-packages/psycopg2"
 whitelist_file "embedded/lib/python3.8/site-packages/pymqi"
 


### PR DESCRIPTION
### Motivation

- https://github.com/DataDog/integrations-core/pull/9552
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/71741658

```
            [HealthCheck] I | 2021-06-17T20:37:36+00:00 | Running health on agent
            [HealthCheck] E | 2021-06-17T20:37:41+00:00 | Failed!
            [HealthCheck] E | 2021-06-17T20:37:41+00:00 | The following libraries have unsafe or unmet dependencies:
    --> /opt/datadog-agent/embedded/lib/python3.8/site-packages/aerospike.libs/libssl-c3e65f62.so.1.1
            [HealthCheck] E | 2021-06-17T20:37:41+00:00 | The following binaries have unsafe or unmet dependencies:
            [HealthCheck] E | 2021-06-17T20:37:41+00:00 | The following requirements could not be resolved:
    --> libcrypto-3cd8319f.so.1.1
            [HealthCheck] E | 2021-06-17T20:37:41+00:00 | The precise failures were:
    --> /opt/datadog-agent/embedded/lib/python3.8/site-packages/aerospike.libs/libssl-c3e65f62.so.1.1
    DEPENDS ON: libcrypto-3cd8319f.so.1.1
      COUNT: 1
      PROVIDED BY: not found
      FAILED BECAUSE: Unresolved dependency
            [HealthCheck] I | 2021-06-17T20:37:41+00:00 | Health check time: 5.7772s
The health check failed! Please see above for important information.
```