### PR TITLE
pkg/trace/writer: do not warn on first retry

### DIFF
--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -256,7 +256,7 @@ func (s *sender) sendPayload(p *payload) {
 
 		if r := atomic.AddInt32(&p.retries, 1); (r&(r-1)) == 0 && r > 3 {
 			// Only log a warning if the retry attempt is a power of 2
-			// and larger than 3, to avoid alerting the user unnecesarily.
+			// and larger than 3, to avoid alerting the user unnecessarily.
 			// e.g. attempts 4, 8, 16, etc.
 			log.Warnf("Retried payload %d times: %s", r, err.Error())
 		}

--- a/pkg/trace/writer/sender.go
+++ b/pkg/trace/writer/sender.go
@@ -254,7 +254,10 @@ func (s *sender) sendPayload(p *payload) {
 		}
 		atomic.AddInt32(&s.attempt, 1)
 
-		if r := atomic.AddInt32(&p.retries, 1); shouldWarnRetry(r) {
+		if r := atomic.AddInt32(&p.retries, 1); (r&(r-1)) == 0 && r > 3 {
+			// Only log a warning if the retry attempt is a power of 2
+			// and larger than 3, to avoid alerting the user unnecesarily.
+			// e.g. attempts 4, 8, 16, etc.
 			log.Warnf("Retried payload %d times: %s", r, err.Error())
 		}
 		select {
@@ -293,15 +296,6 @@ func waitForSenders(senders []*sender) {
 		}(s)
 	}
 	wg.Wait()
-}
-
-// shouldWarnRetry determines whether a warning should be emitted
-// after it has been retried n times.
-func shouldWarnRetry(n int32) bool {
-	if (n != 0) && (n != 2) && ((n & (n - 1)) == 0) {
-		return true
-	}
-	return false
 }
 
 // releasePayload releases the payload p and records the specified event. The payload

--- a/pkg/trace/writer/sender_test.go
+++ b/pkg/trace/writer/sender_test.go
@@ -348,23 +348,3 @@ func (r *mockRecorder) recordEvent(t eventType, data *eventData) {
 		r.rejected = append(r.rejected, data)
 	}
 }
-
-func TestShouldWarnRetry(t *testing.T) {
-	for _, test := range []struct {
-		retries    int32
-		shouldWarn bool
-	}{{0, false},
-		{1, true},
-		{2, false},
-		{3, false},
-		{4, true},
-		{5, false},
-		{6, false},
-		{8, true},
-	} {
-		actual := shouldWarnRetry(test.retries)
-		if actual != test.shouldWarn {
-			t.Fatalf("expected: %t, actual: %t", test.shouldWarn, actual)
-		}
-	}
-}

--- a/releasenotes/notes/apm-skip-warn-retry-1st-c246cfc44da14c88.yaml
+++ b/releasenotes/notes/apm-skip-warn-retry-1st-c246cfc44da14c88.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    APM: The trace-agent no longer warns on the first outgoing request retry,
+    only starting from the 4th.


### PR DESCRIPTION
Removes warning on first retry which could alarm users for nothing and wasn't really helpful...