### PR TITLE
[corechecks/snmp] Add bulk_max_repetitions config

### DIFF
--- a/pkg/collector/corechecks/snmp/config.go
+++ b/pkg/collector/corechecks/snmp/config.go
@@ -22,7 +22,7 @@ var subnetTagPrefix = "autodiscovery_subnet"
 // Using too high max repetitions might lead to tooBig SNMP error messages.
 // - Java SNMP and gosnmp (gosnmp.defaultMaxRepetitions) uses 50
 // - snmp-net uses 10
-const defaultBulkMaxRepetitions = 10
+const defaultBulkMaxRepetitions = uint32(10)
 
 type snmpInitConfig struct {
 	Profiles              profileConfigMap `yaml:"profiles"`
@@ -77,7 +77,7 @@ type snmpConfig struct {
 	metrics               []metricsConfig
 	metricTags            []metricTagConfig
 	oidBatchSize          int
-	bulkMaxRepetitions    int
+	bulkMaxRepetitions    uint32
 	profiles              profileDefinitionMap
 	profileTags           []string
 	profile               string
@@ -233,16 +233,18 @@ func buildConfig(rawInstance integration.Data, rawInitConfig integration.Data) (
 		c.oidBatchSize = defaultOidBatchSize
 	}
 
+	var bulkMaxRepetitions int
 	if instance.BulkMaxRepetitions != 0 {
-		c.bulkMaxRepetitions = int(instance.BulkMaxRepetitions)
+		bulkMaxRepetitions = int(instance.BulkMaxRepetitions)
 	} else if initConfig.BulkMaxRepetitions != 0 {
-		c.bulkMaxRepetitions = int(initConfig.BulkMaxRepetitions)
+		bulkMaxRepetitions = int(initConfig.BulkMaxRepetitions)
 	} else {
-		c.bulkMaxRepetitions = defaultBulkMaxRepetitions
+		bulkMaxRepetitions = int(defaultBulkMaxRepetitions)
 	}
-	if c.bulkMaxRepetitions <= 0 {
-		return snmpConfig{}, fmt.Errorf("bulk max repetition must be a positive integer. Invalid value: %d", c.bulkMaxRepetitions)
+	if bulkMaxRepetitions <= 0 {
+		return snmpConfig{}, fmt.Errorf("bulk max repetition must be a positive integer. Invalid value: %d", bulkMaxRepetitions)
 	}
+	c.bulkMaxRepetitions = uint32(bulkMaxRepetitions)
 
 	// metrics Configs
 	if instance.UseGlobalMetrics {

--- a/pkg/collector/corechecks/snmp/config.go
+++ b/pkg/collector/corechecks/snmp/config.go
@@ -240,6 +240,9 @@ func buildConfig(rawInstance integration.Data, rawInitConfig integration.Data) (
 	} else {
 		c.bulkMaxRepetitions = defaultBulkMaxRepetitions
 	}
+	if c.bulkMaxRepetitions <= 0 {
+		return snmpConfig{}, fmt.Errorf("bulk max repetition must be a positive integer. Invalid value: %d", c.bulkMaxRepetitions)
+	}
 
 	// metrics Configs
 	if instance.UseGlobalMetrics {

--- a/pkg/collector/corechecks/snmp/config_test.go
+++ b/pkg/collector/corechecks/snmp/config_test.go
@@ -116,7 +116,7 @@ bulk_max_repetitions: 20
 
 	assert.Nil(t, err)
 	assert.Equal(t, 10, check.config.oidBatchSize)
-	assert.Equal(t, 20, check.config.bulkMaxRepetitions)
+	assert.Equal(t, uint32(20), check.config.bulkMaxRepetitions)
 	assert.Equal(t, "1.2.3.4", check.config.ipAddress)
 	assert.Equal(t, uint16(1161), check.config.port)
 	assert.Equal(t, 7, check.config.timeout)
@@ -350,7 +350,7 @@ community_string: abc
 `)
 	err := check.Configure(rawInstanceConfig, []byte(``), "test")
 	assert.Nil(t, err)
-	assert.Equal(t, 10, check.config.bulkMaxRepetitions)
+	assert.Equal(t, uint32(10), check.config.bulkMaxRepetitions)
 
 	// TEST Instance config batch size
 	check = Check{session: &snmpSession{}}
@@ -362,7 +362,7 @@ bulk_max_repetitions: 10
 `)
 	err = check.Configure(rawInstanceConfig, []byte(``), "test")
 	assert.Nil(t, err)
-	assert.Equal(t, 10, check.config.bulkMaxRepetitions)
+	assert.Equal(t, uint32(10), check.config.bulkMaxRepetitions)
 
 	// TEST Init config batch size
 	check = Check{session: &snmpSession{}}
@@ -377,7 +377,7 @@ bulk_max_repetitions: 15
 `)
 	err = check.Configure(rawInstanceConfig, rawInitConfig, "test")
 	assert.Nil(t, err)
-	assert.Equal(t, 15, check.config.bulkMaxRepetitions)
+	assert.Equal(t, uint32(15), check.config.bulkMaxRepetitions)
 
 	// TEST Instance & Init config batch size
 	check = Check{session: &snmpSession{}}
@@ -393,7 +393,7 @@ bulk_max_repetitions: 15
 `)
 	err = check.Configure(rawInstanceConfig, rawInitConfig, "test")
 	assert.Nil(t, err)
-	assert.Equal(t, 20, check.config.bulkMaxRepetitions)
+	assert.Equal(t, uint32(20), check.config.bulkMaxRepetitions)
 
 	// TEST invalid value
 	check = Check{session: &snmpSession{}}

--- a/pkg/collector/corechecks/snmp/config_test.go
+++ b/pkg/collector/corechecks/snmp/config_test.go
@@ -110,11 +110,13 @@ global_metrics:
     OID: 1.2.3.4
     name: aGlobalMetric
 oid_batch_size: 10
+bulk_max_repetitions: 20
 `)
 	err := check.Configure(rawInstanceConfig, rawInitConfig, "test")
 
 	assert.Nil(t, err)
 	assert.Equal(t, 10, check.config.oidBatchSize)
+	assert.Equal(t, 20, check.config.bulkMaxRepetitions)
 	assert.Equal(t, "1.2.3.4", check.config.ipAddress)
 	assert.Equal(t, uint16(1161), check.config.port)
 	assert.Equal(t, 7, check.config.timeout)
@@ -335,6 +337,76 @@ oid_batch_size: 15
 	err = check.Configure(rawInstanceConfig, rawInitConfig, "test")
 	assert.Nil(t, err)
 	assert.Equal(t, 20, check.config.oidBatchSize)
+}
+
+func TestBulkMaxRepetitionConfiguration(t *testing.T) {
+	setConfdPathAndCleanProfiles()
+	// TEST Default batch size
+	check := Check{session: &snmpSession{}}
+	// language=yaml
+	rawInstanceConfig := []byte(`
+ip_address: 1.2.3.4
+community_string: abc
+`)
+	err := check.Configure(rawInstanceConfig, []byte(``), "test")
+	assert.Nil(t, err)
+	assert.Equal(t, 10, check.config.bulkMaxRepetitions)
+
+	// TEST Instance config batch size
+	check = Check{session: &snmpSession{}}
+	// language=yaml
+	rawInstanceConfig = []byte(`
+ip_address: 1.2.3.4
+community_string: abc
+bulk_max_repetitions: 10
+`)
+	err = check.Configure(rawInstanceConfig, []byte(``), "test")
+	assert.Nil(t, err)
+	assert.Equal(t, 10, check.config.bulkMaxRepetitions)
+
+	// TEST Init config batch size
+	check = Check{session: &snmpSession{}}
+	// language=yaml
+	rawInstanceConfig = []byte(`
+ip_address: 1.2.3.4
+community_string: abc
+`)
+	// language=yaml
+	rawInitConfig := []byte(`
+bulk_max_repetitions: 15
+`)
+	err = check.Configure(rawInstanceConfig, rawInitConfig, "test")
+	assert.Nil(t, err)
+	assert.Equal(t, 15, check.config.bulkMaxRepetitions)
+
+	// TEST Instance & Init config batch size
+	check = Check{session: &snmpSession{}}
+	// language=yaml
+	rawInstanceConfig = []byte(`
+ip_address: 1.2.3.4
+community_string: abc
+bulk_max_repetitions: 20
+`)
+	// language=yaml
+	rawInitConfig = []byte(`
+bulk_max_repetitions: 15
+`)
+	err = check.Configure(rawInstanceConfig, rawInitConfig, "test")
+	assert.Nil(t, err)
+	assert.Equal(t, 20, check.config.bulkMaxRepetitions)
+
+	// TEST invalid value
+	check = Check{session: &snmpSession{}}
+	// language=yaml
+	rawInstanceConfig = []byte(`
+ip_address: 1.2.3.4
+community_string: abc
+bulk_max_repetitions: -5
+`)
+	// language=yaml
+	rawInitConfig = []byte(``)
+	err = check.Configure(rawInstanceConfig, rawInitConfig, "test")
+	assert.EqualError(t, err, "build config failed: bulk max repetition must be a positive integer. Invalid value: -5")
 }
 
 func TestGlobalMetricsConfigurations(t *testing.T) {

--- a/pkg/collector/corechecks/snmp/fetch.go
+++ b/pkg/collector/corechecks/snmp/fetch.go
@@ -27,7 +27,7 @@ func fetchValues(session sessionAPI, config snmpConfig) (*resultValueStore, erro
 	for _, value := range config.oidConfig.columnOids {
 		oids[value] = value
 	}
-	columnResults, err := fetchColumnOidsWithBatching(session, oids, config.oidBatchSize)
+	columnResults, err := fetchColumnOidsWithBatching(session, oids, config.oidBatchSize, config.bulkMaxRepetitions)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch oids with batching: %v", err)
 	}

--- a/pkg/collector/corechecks/snmp/fetch_column.go
+++ b/pkg/collector/corechecks/snmp/fetch_column.go
@@ -9,7 +9,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func fetchColumnOidsWithBatching(session sessionAPI, oids map[string]string, oidBatchSize int, bulkMaxRepetitions int) (columnResultValuesType, error) {
+func fetchColumnOidsWithBatching(session sessionAPI, oids map[string]string, oidBatchSize int, bulkMaxRepetitions uint32) (columnResultValuesType, error) {
 	retValues := make(columnResultValuesType, len(oids))
 
 	columnOids := getOidsMapKeys(oids)
@@ -46,7 +46,7 @@ func fetchColumnOidsWithBatching(session sessionAPI, oids map[string]string, oid
 // fetchColumnOids has an `oids` argument representing a `map[string]string`,
 // the key of the map is the column oid, and the value is the oid used to fetch the next value for the column.
 // The value oid might be equal to column oid or a row oid of the same column.
-func fetchColumnOids(session sessionAPI, oids map[string]string, bulkMaxRepetitions int) (columnResultValuesType, error) {
+func fetchColumnOids(session sessionAPI, oids map[string]string, bulkMaxRepetitions uint32) (columnResultValuesType, error) {
 	returnValues := make(columnResultValuesType, len(oids))
 	curOids := oids
 	for {
@@ -74,7 +74,7 @@ func fetchColumnOids(session sessionAPI, oids map[string]string, bulkMaxRepetiti
 	return returnValues, nil
 }
 
-func getResults(session sessionAPI, requestOids []string, bulkMaxRepetitions int) (*gosnmp.SnmpPacket, error) {
+func getResults(session sessionAPI, requestOids []string, bulkMaxRepetitions uint32) (*gosnmp.SnmpPacket, error) {
 	var results *gosnmp.SnmpPacket
 	if session.GetVersion() == gosnmp.Version1 {
 		// snmp v1 doesn't support GetBulk

--- a/pkg/collector/corechecks/snmp/fetch_column.go
+++ b/pkg/collector/corechecks/snmp/fetch_column.go
@@ -9,7 +9,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func fetchColumnOidsWithBatching(session sessionAPI, oids map[string]string, oidBatchSize int) (columnResultValuesType, error) {
+func fetchColumnOidsWithBatching(session sessionAPI, oids map[string]string, oidBatchSize int, bulkMaxRepetitions int) (columnResultValuesType, error) {
 	retValues := make(columnResultValuesType, len(oids))
 
 	columnOids := getOidsMapKeys(oids)
@@ -25,7 +25,7 @@ func fetchColumnOidsWithBatching(session sessionAPI, oids map[string]string, oid
 			oidsToFetch[oid] = oids[oid]
 		}
 
-		results, err := fetchColumnOids(session, oidsToFetch)
+		results, err := fetchColumnOids(session, oidsToFetch, bulkMaxRepetitions)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch column oids: %s", err)
 		}
@@ -46,7 +46,7 @@ func fetchColumnOidsWithBatching(session sessionAPI, oids map[string]string, oid
 // fetchColumnOids has an `oids` argument representing a `map[string]string`,
 // the key of the map is the column oid, and the value is the oid used to fetch the next value for the column.
 // The value oid might be equal to column oid or a row oid of the same column.
-func fetchColumnOids(session sessionAPI, oids map[string]string) (columnResultValuesType, error) {
+func fetchColumnOids(session sessionAPI, oids map[string]string, bulkMaxRepetitions int) (columnResultValuesType, error) {
 	returnValues := make(columnResultValuesType, len(oids))
 	curOids := oids
 	for {
@@ -63,7 +63,7 @@ func fetchColumnOids(session sessionAPI, oids map[string]string) (columnResultVa
 		sort.Strings(columnOids)
 		sort.Strings(requestOids)
 
-		results, err := getResults(session, requestOids)
+		results, err := getResults(session, requestOids, bulkMaxRepetitions)
 		if err != nil {
 			return nil, err
 		}
@@ -74,7 +74,7 @@ func fetchColumnOids(session sessionAPI, oids map[string]string) (columnResultVa
 	return returnValues, nil
 }
 
-func getResults(session sessionAPI, requestOids []string) (*gosnmp.SnmpPacket, error) {
+func getResults(session sessionAPI, requestOids []string, bulkMaxRepetitions int) (*gosnmp.SnmpPacket, error) {
 	var results *gosnmp.SnmpPacket
 	if session.GetVersion() == gosnmp.Version1 {
 		// snmp v1 doesn't support GetBulk
@@ -86,7 +86,7 @@ func getResults(session sessionAPI, requestOids []string) (*gosnmp.SnmpPacket, e
 		results = getNextResults
 		log.Debugf("fetch column: GetNext results Variables: %v", results.Variables)
 	} else {
-		getBulkResults, err := session.GetBulk(requestOids)
+		getBulkResults, err := session.GetBulk(requestOids, bulkMaxRepetitions)
 		if err != nil {
 			log.Debugf("fetch column: failed getting oids `%v` using GetBulk: %s", requestOids, err)
 			return nil, fmt.Errorf("fetch column: failed getting oids `%v` using GetBulk: %s", requestOids, err)

--- a/pkg/collector/corechecks/snmp/fetch_test.go
+++ b/pkg/collector/corechecks/snmp/fetch_test.go
@@ -75,7 +75,7 @@ func Test_fetchColumnOids(t *testing.T) {
 
 	oids := map[string]string{"1.1.1": "1.1.1", "1.1.2": "1.1.2"}
 
-	columnValues, err := fetchColumnOidsWithBatching(session, oids, 100, 10)
+	columnValues, err := fetchColumnOidsWithBatching(session, oids, 100, defaultBulkMaxRepetitions)
 	assert.Nil(t, err)
 
 	expectedColumnValues := columnResultValuesType{

--- a/pkg/collector/corechecks/snmp/fetch_test.go
+++ b/pkg/collector/corechecks/snmp/fetch_test.go
@@ -69,13 +69,13 @@ func Test_fetchColumnOids(t *testing.T) {
 			},
 		},
 	}
-	session.On("GetBulk", []string{"1.1.1", "1.1.2"}).Return(&bulkPacket, nil)
-	session.On("GetBulk", []string{"1.1.1.3"}).Return(&bulkPacket2, nil)
-	session.On("GetBulk", []string{"1.1.1.5"}).Return(&bulkPacket3, nil)
+	session.On("GetBulk", []string{"1.1.1", "1.1.2"}, defaultBulkMaxRepetitions).Return(&bulkPacket, nil)
+	session.On("GetBulk", []string{"1.1.1.3"}, defaultBulkMaxRepetitions).Return(&bulkPacket2, nil)
+	session.On("GetBulk", []string{"1.1.1.5"}, defaultBulkMaxRepetitions).Return(&bulkPacket3, nil)
 
 	oids := map[string]string{"1.1.1": "1.1.1", "1.1.2": "1.1.2"}
 
-	columnValues, err := fetchColumnOidsWithBatching(session, oids, 100)
+	columnValues, err := fetchColumnOidsWithBatching(session, oids, 100, 10)
 	assert.Nil(t, err)
 
 	expectedColumnValues := columnResultValuesType{
@@ -156,17 +156,17 @@ func Test_fetchColumnOidsBatch_usingGetBulk(t *testing.T) {
 		},
 	}
 	// First bulk iteration with two batches with batch size 2
-	session.On("GetBulk", []string{"1.1.1", "1.1.2"}).Return(&bulkPacket, nil)
+	session.On("GetBulk", []string{"1.1.1", "1.1.2"}, defaultBulkMaxRepetitions).Return(&bulkPacket, nil)
 
 	// Second bulk iteration
-	session.On("GetBulk", []string{"1.1.1.3"}).Return(&bulkPacket2, nil)
+	session.On("GetBulk", []string{"1.1.1.3"}, defaultBulkMaxRepetitions).Return(&bulkPacket2, nil)
 
 	// Third bulk iteration
-	session.On("GetBulk", []string{"1.1.1.5"}).Return(&bulkPacket3, nil)
+	session.On("GetBulk", []string{"1.1.1.5"}, defaultBulkMaxRepetitions).Return(&bulkPacket3, nil)
 
 	oids := map[string]string{"1.1.1": "1.1.1", "1.1.2": "1.1.2"}
 
-	columnValues, err := fetchColumnOidsWithBatching(session, oids, 2)
+	columnValues, err := fetchColumnOidsWithBatching(session, oids, 2, 10)
 	assert.Nil(t, err)
 
 	expectedColumnValues := columnResultValuesType{
@@ -263,7 +263,7 @@ func Test_fetchColumnOidsBatch_usingGetNext(t *testing.T) {
 
 	oids := map[string]string{"1.1.1": "1.1.1", "1.1.2": "1.1.2", "1.1.3": "1.1.3"}
 
-	columnValues, err := fetchColumnOidsWithBatching(session, oids, 2)
+	columnValues, err := fetchColumnOidsWithBatching(session, oids, 2, 10)
 	assert.Nil(t, err)
 
 	expectedColumnValues := columnResultValuesType{
@@ -572,6 +572,7 @@ func Test_fetchValues_errors(t *testing.T) {
 		{
 			name: "invalid batch size",
 			config: snmpConfig{
+				bulkMaxRepetitions: defaultBulkMaxRepetitions,
 				oidConfig: oidConfig{
 					scalarOids: []string{"1.1", "1.2"},
 				},
@@ -581,7 +582,8 @@ func Test_fetchValues_errors(t *testing.T) {
 		{
 			name: "get fetch error",
 			config: snmpConfig{
-				oidBatchSize: 10,
+				bulkMaxRepetitions: defaultBulkMaxRepetitions,
+				oidBatchSize:       10,
 				oidConfig: oidConfig{
 					scalarOids: []string{"1.1", "2.2"},
 				},
@@ -591,7 +593,8 @@ func Test_fetchValues_errors(t *testing.T) {
 		{
 			name: "bulk fetch error",
 			config: snmpConfig{
-				oidBatchSize: 10,
+				bulkMaxRepetitions: defaultBulkMaxRepetitions,
+				oidBatchSize:       10,
 				oidConfig: oidConfig{
 					scalarOids: []string{},
 					columnOids: []string{"1.1", "2.2"},
@@ -604,7 +607,7 @@ func Test_fetchValues_errors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			session := createMockSession()
 			session.On("Get", []string{"1.1", "2.2"}).Return(&gosnmp.SnmpPacket{}, fmt.Errorf("get error"))
-			session.On("GetBulk", []string{"1.1", "2.2"}).Return(&gosnmp.SnmpPacket{}, fmt.Errorf("bulk error"))
+			session.On("GetBulk", []string{"1.1", "2.2"}, defaultBulkMaxRepetitions).Return(&gosnmp.SnmpPacket{}, fmt.Errorf("bulk error"))
 
 			_, err := fetchValues(session, tt.config)
 

--- a/pkg/collector/corechecks/snmp/session.go
+++ b/pkg/collector/corechecks/snmp/session.go
@@ -17,7 +17,7 @@ type sessionAPI interface {
 	Connect() error
 	Close() error
 	Get(oids []string) (result *gosnmp.SnmpPacket, err error)
-	GetBulk(oids []string, bulkMaxRepetitions int) (result *gosnmp.SnmpPacket, err error)
+	GetBulk(oids []string, bulkMaxRepetitions uint32) (result *gosnmp.SnmpPacket, err error)
 	GetNext(oids []string) (result *gosnmp.SnmpPacket, err error)
 	GetVersion() gosnmp.SnmpVersion
 }
@@ -110,8 +110,8 @@ func (s *snmpSession) Get(oids []string) (result *gosnmp.SnmpPacket, err error) 
 	return s.gosnmpInst.Get(oids)
 }
 
-func (s *snmpSession) GetBulk(oids []string, bulkMaxRepetitions int) (result *gosnmp.SnmpPacket, err error) {
-	return s.gosnmpInst.GetBulk(oids, 0, uint32(bulkMaxRepetitions))
+func (s *snmpSession) GetBulk(oids []string, bulkMaxRepetitions uint32) (result *gosnmp.SnmpPacket, err error) {
+	return s.gosnmpInst.GetBulk(oids, 0, bulkMaxRepetitions)
 }
 
 func (s *snmpSession) GetNext(oids []string) (result *gosnmp.SnmpPacket, err error) {

--- a/pkg/collector/corechecks/snmp/session.go
+++ b/pkg/collector/corechecks/snmp/session.go
@@ -12,17 +12,12 @@ import (
 
 const sysObjectIDOid = "1.3.6.1.2.1.1.2.0"
 
-// Using too high max repetitions might lead to tooBig SNMP error messages.
-// - Java SNMP and gosnmp (gosnmp.defaultMaxRepetitions) uses 50
-// - snmp-net uses 10
-const bulkMaxRepetition = 10
-
 type sessionAPI interface {
 	Configure(config snmpConfig) error
 	Connect() error
 	Close() error
 	Get(oids []string) (result *gosnmp.SnmpPacket, err error)
-	GetBulk(oids []string) (result *gosnmp.SnmpPacket, err error)
+	GetBulk(oids []string, bulkMaxRepetitions int) (result *gosnmp.SnmpPacket, err error)
 	GetNext(oids []string) (result *gosnmp.SnmpPacket, err error)
 	GetVersion() gosnmp.SnmpVersion
 }
@@ -115,8 +110,8 @@ func (s *snmpSession) Get(oids []string) (result *gosnmp.SnmpPacket, err error) 
 	return s.gosnmpInst.Get(oids)
 }
 
-func (s *snmpSession) GetBulk(oids []string) (result *gosnmp.SnmpPacket, err error) {
-	return s.gosnmpInst.GetBulk(oids, 0, bulkMaxRepetition)
+func (s *snmpSession) GetBulk(oids []string, bulkMaxRepetitions int) (result *gosnmp.SnmpPacket, err error) {
+	return s.gosnmpInst.GetBulk(oids, 0, uint32(bulkMaxRepetitions))
 }
 
 func (s *snmpSession) GetNext(oids []string) (result *gosnmp.SnmpPacket, err error) {

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -25,7 +26,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type mockSession struct {
@@ -52,8 +52,8 @@ func (s *mockSession) Get(oids []string) (result *gosnmp.SnmpPacket, err error) 
 	return args.Get(0).(*gosnmp.SnmpPacket), args.Error(1)
 }
 
-func (s *mockSession) GetBulk(oids []string) (result *gosnmp.SnmpPacket, err error) {
-	args := s.Mock.Called(oids)
+func (s *mockSession) GetBulk(oids []string, bulkMaxRepetitions int) (result *gosnmp.SnmpPacket, err error) {
+	args := s.Mock.Called(oids, bulkMaxRepetitions)
 	return args.Get(0).(*gosnmp.SnmpPacket), args.Error(1)
 }
 
@@ -212,8 +212,8 @@ tags:
 	}
 
 	session.On("Get", mock.Anything).Return(&packet, nil)
-	session.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.14", "1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.20"}).Return(&bulkPacket, nil)
-	session.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.14.2", "1.3.6.1.2.1.2.2.1.2.2", "1.3.6.1.2.1.2.2.1.20.2"}).Return(&bulkPacket2, nil)
+	session.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.14", "1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.20"}, defaultBulkMaxRepetitions).Return(&bulkPacket, nil)
+	session.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.14.2", "1.3.6.1.2.1.2.2.1.2.2", "1.3.6.1.2.1.2.2.1.20.2"}, defaultBulkMaxRepetitions).Return(&bulkPacket2, nil)
 
 	err = check.Run()
 	assert.Nil(t, err)
@@ -513,7 +513,7 @@ profiles:
 		"1.3.6.1.2.1.2.2.1.8",
 		"1.3.6.1.2.1.31.1.1.1.1",
 		"1.3.6.1.2.1.31.1.1.1.18",
-	}).Return(&bulkPacket, nil)
+	}, defaultBulkMaxRepetitions).Return(&bulkPacket, nil)
 
 	err = check.Run()
 	assert.Nil(t, err)
@@ -719,7 +719,7 @@ profiles:
 
 	session.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&sysObjectIDPacket, nil)
 	session.On("Get", []string{"1.3.6.1.2.1.1.3.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.999", "1.2.3.4.5", "1.3.6.1.2.1.1.5.0"}).Return(&packet, nil)
-	session.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.13", "1.3.6.1.2.1.2.2.1.14", "1.3.6.1.2.1.31.1.1.1.1", "1.3.6.1.2.1.31.1.1.1.18"}).Return(&bulkPacket, nil)
+	session.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.13", "1.3.6.1.2.1.2.2.1.14", "1.3.6.1.2.1.31.1.1.1.1", "1.3.6.1.2.1.31.1.1.1.18"}, defaultBulkMaxRepetitions).Return(&bulkPacket, nil)
 
 	err = check.Run()
 	assert.Nil(t, err)
@@ -1203,7 +1203,7 @@ tags:
 		"1.3.6.1.2.1.2.2.1.8",
 		"1.3.6.1.2.1.31.1.1.1.1",
 		"1.3.6.1.2.1.31.1.1.1.18",
-	}).Return(&bulkPacket, nil)
+	}, defaultBulkMaxRepetitions).Return(&bulkPacket, nil)
 
 	err = check.Run()
 	assert.EqualError(t, err, "failed to autodetect profile: failed to fetching sysobjectid: cannot get sysobjectid: no value")

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -52,7 +52,7 @@ func (s *mockSession) Get(oids []string) (result *gosnmp.SnmpPacket, err error) 
 	return args.Get(0).(*gosnmp.SnmpPacket), args.Error(1)
 }
 
-func (s *mockSession) GetBulk(oids []string, bulkMaxRepetitions int) (result *gosnmp.SnmpPacket, err error) {
+func (s *mockSession) GetBulk(oids []string, bulkMaxRepetitions uint32) (result *gosnmp.SnmpPacket, err error) {
 	args := s.Mock.Called(oids, bulkMaxRepetitions)
 	return args.Get(0).(*gosnmp.SnmpPacket), args.Error(1)
 }

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -10,7 +10,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -26,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 type mockSession struct {

--- a/releasenotes/notes/snmp_add_bulk_max_rep_config-6ee08dc2c8290f64.yaml
+++ b/releasenotes/notes/snmp_add_bulk_max_rep_config-6ee08dc2c8290f64.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    [corechecks/snmp] Add bulk_max_repetitions config


### PR DESCRIPTION
### What does this PR do?

Add bulk_max_repetitions config

### Motivation

User can configure higher bulk_max_repetitions to reduce the number of calls needed to query OID values.

It's useful when there are very high number of **column rows** to collect and if the device support high number of OIDs being requested.

example `oid_batch_size` of 60 and `bulk_max_repetitions` of 100 will lead to a max of 6000 (60 * 100) OID values being called for one single SNMP GETBULK call.


### Describe how to test your changes

- check `bulk_max_repetitions` works as init_config
- check `bulk_max_repetitions` works as instance config

Suggestions for testing:
- change `init_config.bulk_max_repetitions`, then  `instances[].bulk_max_repetitions`
- run `agent check snmp --log-leve debug` command 
- You can look for `fetch column: GetBulk results Variables` log and check if for each column we are fetching the right amount of "rows" (matching the bulk_max_repetitions config)

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
