### PR TITLE
[runtime-security] fix ia32 syscall tracepoints on old kernels, fix multiple bugs around syscall event peek/pop

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "278ade3e6433b43deb49981a27e2635ae5abf2a63ae87507896f4b50ce99829b")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "878f687b3f2f0222cf1144bebc9f672008eae9c54e2ef49978086b5a435a0c3e")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "878f687b3f2f0222cf1144bebc9f672008eae9c54e2ef49978086b5a435a0c3e")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "879a263ca51596b3aa448510db29fad783eaf29cb9c4871ec4504caee83eb2e6")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "879a263ca51596b3aa448510db29fad783eaf29cb9c4871ec4504caee83eb2e6")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "304eade7292d8c6ecdb1749b9df6cb7db84914b3122ce5d79475633f5298e0de")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "df174f60b799590882d5bf85051b8f9fd1df3313a360d8988c3cf2b6a3933d5b")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "11eb1e243e6aac5c5960907acc9efb07e8b76fee500fc76d3e888b38442495e3")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "4b524bc3a0abeddbd18146b22dbb6a2c39e87eb1ee2ccc955b1e2a06e49f94c9")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "278ade3e6433b43deb49981a27e2635ae5abf2a63ae87507896f4b50ce99829b")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "304eade7292d8c6ecdb1749b9df6cb7db84914b3122ce5d79475633f5298e0de")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "e703b082ce3bbfb382462df1f0fea600622b4e7562c8c9f65be20bb553d20d88")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "8e51b9e593325a44f18682cbb70eea203fb204b4b65b826bc2bdca66c1da1743")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "df174f60b799590882d5bf85051b8f9fd1df3313a360d8988c3cf2b6a3933d5b")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "11eb1e243e6aac5c5960907acc9efb07e8b76fee500fc76d3e888b38442495e3")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "4b524bc3a0abeddbd18146b22dbb6a2c39e87eb1ee2ccc955b1e2a06e49f94c9")

--- a/pkg/security/ebpf/c/chmod.h
+++ b/pkg/security/ebpf/c/chmod.h
@@ -105,4 +105,9 @@ SYSCALL_KRETPROBE(fchmodat) {
     return kprobe_sys_chmod_ret(ctx);
 }
 
+SEC("tracepoint/handle_sys_chmod_exit")
+int tracepoint_handle_sys_chmod_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    return sys_chmod_ret(args, args->ret);
+}
+
 #endif

--- a/pkg/security/ebpf/c/chmod.h
+++ b/pkg/security/ebpf/c/chmod.h
@@ -49,11 +49,11 @@ SYSCALL_KPROBE3(fchmodat, int, dirfd, const char*, filename, umode_t, mode) {
 }
 
 int __attribute__((always_inline)) sys_chmod_ret(void *ctx, int retval) {
-    if (IS_UNHANDLED_ERROR(retval))
-        return 0;
-
     struct syscall_cache_t *syscall = pop_syscall(EVENT_CHMOD);
     if (!syscall)
+        return 0;
+
+    if (IS_UNHANDLED_ERROR(retval))
         return 0;
 
     struct chmod_event_t event = {

--- a/pkg/security/ebpf/c/chown.h
+++ b/pkg/security/ebpf/c/chown.h
@@ -158,4 +158,9 @@ SYSCALL_KRETPROBE(fchownat) {
     return kprobe_sys_chown_ret(ctx);
 }
 
+SEC("tracepoint/handle_sys_chown_exit")
+int tracepoint_handle_sys_chown_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    return sys_chown_ret(args, args->ret);
+}
+
 #endif

--- a/pkg/security/ebpf/c/chown.h
+++ b/pkg/security/ebpf/c/chown.h
@@ -66,11 +66,11 @@ SYSCALL_KPROBE4(fchownat, int, dirfd, const char*, filename, uid_t, user, gid_t,
 }
 
 int __attribute__((always_inline)) sys_chown_ret(void *ctx, int retval) {
-    if (IS_UNHANDLED_ERROR(retval))
-        return 0;
-
     struct syscall_cache_t *syscall = pop_syscall(EVENT_CHOWN);
     if (!syscall)
+        return 0;
+
+    if (IS_UNHANDLED_ERROR(retval))
         return 0;
 
     struct chown_event_t event = {

--- a/pkg/security/ebpf/c/commit_creds.h
+++ b/pkg/security/ebpf/c/commit_creds.h
@@ -363,6 +363,11 @@ int tracepoint_syscalls_sys_exit_capset(struct tracepoint_syscalls_sys_exit_t *a
     return credentials_update_ret(args, args->ret);
 }
 
+SEC("tracepoint/handle_sys_commit_creds_exit")
+int tracepoint_handle_sys_commit_creds_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    return credentials_update_ret(args, args->ret);
+}
+
 SEC("kprobe/commit_creds")
 int kprobe__commit_creds(struct pt_regs *ctx) {
     struct cred *credentials = (struct cred *)PT_REGS_PARM1(ctx);

--- a/pkg/security/ebpf/c/commit_creds.h
+++ b/pkg/security/ebpf/c/commit_creds.h
@@ -39,11 +39,11 @@ int __attribute__((always_inline)) credentials_predicate(u64 type) {
 }
 
 int __attribute__((always_inline)) credentials_update_ret(void *ctx, int retval) {
-    if (retval < 0)
-        return 0;
-
     struct syscall_cache_t *syscall = pop_syscall_with(credentials_predicate);
     if (!syscall)
+        return 0;
+
+    if (retval < 0)
         return 0;
 
     u32 pid = bpf_get_current_pid_tgid() >> 32;

--- a/pkg/security/ebpf/c/link.h
+++ b/pkg/security/ebpf/c/link.h
@@ -142,6 +142,11 @@ SYSCALL_KRETPROBE(linkat) {
     return kprobe_sys_link_ret(ctx);
 }
 
+SEC("tracepoint/handle_sys_link_exit")
+int tracepoint_handle_sys_link_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    return sys_link_ret(args, args->ret, DR_TRACEPOINT);
+}
+
 int __attribute__((always_inline)) dr_link_dst_callback(void *ctx, int retval) {
     if (IS_UNHANDLED_ERROR(retval))
         return 0;

--- a/pkg/security/ebpf/c/link.h
+++ b/pkg/security/ebpf/c/link.h
@@ -148,11 +148,11 @@ int tracepoint_handle_sys_link_exit(struct tracepoint_raw_syscalls_sys_exit_t *a
 }
 
 int __attribute__((always_inline)) dr_link_dst_callback(void *ctx, int retval) {
-    if (IS_UNHANDLED_ERROR(retval))
-        return 0;
-
     struct syscall_cache_t *syscall = pop_syscall(EVENT_LINK);
     if (!syscall)
+        return 0;
+
+    if (IS_UNHANDLED_ERROR(retval))
         return 0;
 
     struct link_event_t event = {

--- a/pkg/security/ebpf/c/mkdir.h
+++ b/pkg/security/ebpf/c/mkdir.h
@@ -121,11 +121,11 @@ int tracepoint_handle_sys_mkdir_exit(struct tracepoint_raw_syscalls_sys_exit_t *
 }
 
 int __attribute__((always_inline)) dr_mkdir_callback(void *ctx, int retval) {
-    if (IS_UNHANDLED_ERROR(retval))
-        return 0;
-
     struct syscall_cache_t *syscall = pop_syscall(EVENT_MKDIR);
     if (!syscall)
+        return 0;
+
+    if (IS_UNHANDLED_ERROR(retval))
         return 0;
 
     if (syscall->resolver.ret == DENTRY_DISCARDED) {

--- a/pkg/security/ebpf/c/mkdir.h
+++ b/pkg/security/ebpf/c/mkdir.h
@@ -115,6 +115,11 @@ SYSCALL_KRETPROBE(mkdirat) {
     return kprobe_sys_mkdir_ret(ctx);
 }
 
+SEC("tracepoint/handle_sys_mkdir_exit")
+int tracepoint_handle_sys_mkdir_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    return sys_mkdir_ret(args, args->ret, DR_TRACEPOINT);
+}
+
 int __attribute__((always_inline)) dr_mkdir_callback(void *ctx, int retval) {
     if (IS_UNHANDLED_ERROR(retval))
         return 0;

--- a/pkg/security/ebpf/c/mount.h
+++ b/pkg/security/ebpf/c/mount.h
@@ -129,6 +129,11 @@ SYSCALL_COMPAT_KRETPROBE(mount) {
     return sys_mount_ret(ctx, retval, DR_KPROBE);
 }
 
+SEC("tracepoint/handle_sys_mount_exit")
+int tracepoint_handle_sys_mount_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    return sys_mount_ret(args, args->ret, DR_TRACEPOINT);
+}
+
 int __attribute__((always_inline)) dr_mount_callback(void *ctx, int retval) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_MOUNT);
     if (!syscall)

--- a/pkg/security/ebpf/c/open.h
+++ b/pkg/security/ebpf/c/open.h
@@ -319,11 +319,11 @@ int kprobe__filp_close(struct pt_regs *ctx) {
 }
 
 int __attribute__((always_inline)) dr_open_callback(void *ctx, int retval) {
-    if (IS_UNHANDLED_ERROR(retval))
-        return 0;
-
     struct syscall_cache_t *syscall = pop_syscall(EVENT_OPEN);
     if (!syscall)
+        return 0;
+
+    if (IS_UNHANDLED_ERROR(retval))
         return 0;
 
     if (syscall->resolver.ret == DENTRY_DISCARDED || syscall->resolver.ret == DENTRY_INVALID) {

--- a/pkg/security/ebpf/c/open.h
+++ b/pkg/security/ebpf/c/open.h
@@ -293,6 +293,11 @@ SYSCALL_KRETPROBE(openat2) {
     return kprobe_sys_open_ret(ctx);
 }
 
+SEC("tracepoint/handle_sys_open_exit")
+int tracepoint_handle_sys_open_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    return sys_open_ret(args, args->ret, DR_TRACEPOINT);
+}
+
 SEC("kretprobe/io_openat2")
 int kretprobe__io_openat2(struct pt_regs *ctx) {
     struct file *f = (struct file *) PT_REGS_RC(ctx);

--- a/pkg/security/ebpf/c/raw_syscalls.h
+++ b/pkg/security/ebpf/c/raw_syscalls.h
@@ -83,19 +83,6 @@ int sys_enter(struct _tracepoint_raw_syscalls_sys_enter *args) {
     return 0;
 }
 
-// are we running an ia32 syscall (32 bits sycall on 64 bits kernel)
-bool __attribute__((always_inline)) is_running_ia32_syscall() {
-    struct task_struct *cur_task = (struct task_struct *)bpf_get_current_task();
-    struct thread_info *cur_thread_info = (struct thread_info *)cur_task;
-
-    u64 flags_offset;
-    LOAD_CONSTANT("thread_info_flags_offset", flags_offset);
-
-    u64 flags;
-    bpf_probe_read(&flags, sizeof(flags), (char *)cur_thread_info + flags_offset);
-    return flags & TIF_IA32;
-}
-
 // used as a fallback, because tracepoints are not enable when using a ia32 userspace application with a x64 kernel
 // cf. https://elixir.bootlin.com/linux/latest/source/arch/x86/include/asm/ftrace.h#L106
 int __attribute__((always_inline)) handle_sys_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
@@ -111,7 +98,7 @@ SEC("tracepoint/raw_syscalls/sys_exit")
 int sys_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
     u64 fallback;
     LOAD_CONSTANT("tracepoint_raw_syscall_fallback", fallback);
-    if (fallback && is_running_ia32_syscall()) {
+    if (fallback) {
         handle_sys_exit(args);
     }
 

--- a/pkg/security/ebpf/c/raw_syscalls.h
+++ b/pkg/security/ebpf/c/raw_syscalls.h
@@ -22,6 +22,13 @@ struct bpf_map_def SEC("maps/concurrent_syscalls") concurrent_syscalls = {
     .namespace = "",
 };
 
+struct bpf_map_def SEC("maps/sys_exit_progs") sys_exit_progs = {
+    .type = BPF_MAP_TYPE_PROG_ARRAY,
+    .key_size = sizeof(u32),
+    .value_size = sizeof(u32),
+    .max_entries = 64,
+};
+
 #define CONCURRENT_SYSCALLS_COUNTER 0
 
 struct process_syscall_t {
@@ -77,8 +84,25 @@ int sys_enter(struct _tracepoint_raw_syscalls_sys_enter *args) {
     return 0;
 }
 
+// used as a fallback, because tracepoints are not enable when using a ia32 userspace application with a x64 kernel
+// cf. https://elixir.bootlin.com/linux/latest/source/arch/x86/include/asm/ftrace.h#L106
+int __attribute__((always_inline)) handle_sys_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    struct syscall_cache_t *syscall = peek_syscall(EVENT_ANY);
+    if (!syscall)
+        return 0;
+
+    bpf_tail_call(args, &sys_exit_progs, syscall->type);
+    return 0;
+}
+
 SEC("tracepoint/raw_syscalls/sys_exit")
 int sys_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    u64 fallback;
+    LOAD_CONSTANT("tracepoint_raw_syscall_fallback", fallback);
+    if (fallback) {
+        handle_sys_exit(args);
+    }
+
     u64 enabled;
     LOAD_CONSTANT("syscall_monitor", enabled);
     if (enabled) {

--- a/pkg/security/ebpf/c/rename.h
+++ b/pkg/security/ebpf/c/rename.h
@@ -173,11 +173,11 @@ int tracepoint_handle_sys_rename_exit(struct tracepoint_raw_syscalls_sys_exit_t 
 }
 
 int __attribute__((always_inline)) dr_rename_callback(void *ctx, int retval) {
-    if (IS_UNHANDLED_ERROR(retval))
-        return 0;
-
     struct syscall_cache_t *syscall = pop_syscall(EVENT_RENAME);
     if (!syscall)
+        return 0;
+
+    if (IS_UNHANDLED_ERROR(retval))
         return 0;
 
     struct rename_event_t event = {

--- a/pkg/security/ebpf/c/rename.h
+++ b/pkg/security/ebpf/c/rename.h
@@ -167,6 +167,11 @@ SYSCALL_KRETPROBE(renameat2) {
     return kprobe_sys_rename_ret(ctx);
 }
 
+SEC("tracepoint/handle_sys_rename_exit")
+int tracepoint_handle_sys_rename_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    return sys_rename_ret(args, args->ret, DR_TRACEPOINT);
+}
+
 int __attribute__((always_inline)) dr_rename_callback(void *ctx, int retval) {
     if (IS_UNHANDLED_ERROR(retval))
         return 0;

--- a/pkg/security/ebpf/c/rmdir.h
+++ b/pkg/security/ebpf/c/rmdir.h
@@ -117,13 +117,13 @@ int __attribute__((always_inline)) dr_security_inode_rmdir_callback(struct pt_re
 }
 
 int __attribute__((always_inline)) sys_rmdir_ret(void *ctx, int retval) {
-    if (IS_UNHANDLED_ERROR(retval)) {
-        return 0;
-    }
-
     struct syscall_cache_t *syscall = pop_syscall_with(rmdir_predicate);
     if (!syscall)
         return 0;
+
+    if (IS_UNHANDLED_ERROR(retval)) {
+        return 0;
+    }
 
     int pass_to_userspace = !syscall->discarded && is_event_enabled(EVENT_RMDIR);
     if (pass_to_userspace) {

--- a/pkg/security/ebpf/c/rmdir.h
+++ b/pkg/security/ebpf/c/rmdir.h
@@ -154,4 +154,9 @@ SYSCALL_KRETPROBE(rmdir) {
     return sys_rmdir_ret(ctx, retval);
 }
 
+SEC("tracepoint/handle_sys_rmdir_exit")
+int tracepoint_handle_sys_rmdir_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    return sys_rmdir_ret(args, args->ret);
+}
+
 #endif

--- a/pkg/security/ebpf/c/setxattr.h
+++ b/pkg/security/ebpf/c/setxattr.h
@@ -128,11 +128,11 @@ int kprobe__vfs_removexattr(struct pt_regs *ctx) {
 }
 
 int __attribute__((always_inline)) sys_xattr_ret(void *ctx, int retval, u64 event_type) {
-    if (IS_UNHANDLED_ERROR(retval))
-        return 0;
-
     struct syscall_cache_t *syscall = pop_syscall(event_type);
     if (!syscall)
+        return 0;
+
+    if (IS_UNHANDLED_ERROR(retval))
         return 0;
 
     struct setxattr_event_t event = {

--- a/pkg/security/ebpf/c/setxattr.h
+++ b/pkg/security/ebpf/c/setxattr.h
@@ -184,6 +184,11 @@ SYSCALL_KRETPROBE(lsetxattr) {
     return kprobe_sys_setxattr_ret(ctx);
 }
 
+SEC("tracepoint/handle_sys_setxattr_exit")
+int tracepoint_handle_sys_setxattr_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    return sys_xattr_ret(args, args->ret, EVENT_SETXATTR);
+}
+
 int __attribute__((always_inline)) kprobe_sys_removexattr_ret(struct pt_regs *ctx) {
     int retval = PT_REGS_RC(ctx);
     return sys_xattr_ret(ctx, retval, EVENT_REMOVEXATTR);
@@ -214,6 +219,11 @@ int tracepoint_syscalls_sys_exit_fremovexattr(struct tracepoint_syscalls_sys_exi
 
 SYSCALL_KRETPROBE(fremovexattr) {
     return kprobe_sys_removexattr_ret(ctx);
+}
+
+SEC("tracepoint/handle_sys_removexattr_exit")
+int tracepoint_handle_sys_removexattr_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    return sys_xattr_ret(args, args->ret, EVENT_REMOVEXATTR);
 }
 
 #endif

--- a/pkg/security/ebpf/c/umount.h
+++ b/pkg/security/ebpf/c/umount.h
@@ -29,11 +29,11 @@ int kprobe__security_sb_umount(struct pt_regs *ctx) {
 }
 
 int __attribute__((always_inline)) sys_umount_ret(void *ctx, int retval) {
-    if (retval)
-        return 0;
-
     struct syscall_cache_t *syscall = pop_syscall(EVENT_UMOUNT);
     if (!syscall)
+        return 0;
+
+    if (retval)
         return 0;
 
     int mount_id = get_vfsmount_mount_id(syscall->umount.vfs);

--- a/pkg/security/ebpf/c/umount.h
+++ b/pkg/security/ebpf/c/umount.h
@@ -63,4 +63,9 @@ SYSCALL_KRETPROBE(umount) {
     return sys_umount_ret(ctx, retval);
 }
 
+SEC("tracepoint/handle_sys_umount_exit")
+int tracepoint_handle_sys_umount_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    return sys_umount_ret(args, args->ret);
+}
+
 #endif

--- a/pkg/security/ebpf/c/unlink.h
+++ b/pkg/security/ebpf/c/unlink.h
@@ -90,13 +90,13 @@ int __attribute__((always_inline)) dr_unlink_callback(struct pt_regs *ctx) {
 }
 
 int __attribute__((always_inline)) sys_unlink_ret(void *ctx, int retval) {
-    if (IS_UNHANDLED_ERROR(retval)) {
-        return 0;
-    }
-
     struct syscall_cache_t *syscall = pop_syscall(EVENT_UNLINK);
     if (!syscall)
         return 0;
+
+    if (IS_UNHANDLED_ERROR(retval)) {
+        return 0;
+    }
 
     // ensure that we invalidate all the layers
     u64 inode = syscall->unlink.file.path_key.ino;

--- a/pkg/security/ebpf/c/unlink.h
+++ b/pkg/security/ebpf/c/unlink.h
@@ -107,17 +107,30 @@ int __attribute__((always_inline)) sys_unlink_ret(void *ctx, int retval) {
                             (mask_has_event(enabled_events, EVENT_UNLINK) ||
                              mask_has_event(enabled_events, EVENT_RMDIR));
     if (pass_to_userspace) {
-        struct unlink_event_t event = {
-            .syscall.retval = retval,
-            .file = syscall->unlink.file,
-            .flags = syscall->unlink.flags,
-            .discarder_revision = get_discarder_revision(syscall->unlink.file.path_key.mount_id),
-        };
+        if (syscall->unlink.flags & AT_REMOVEDIR) {
+            struct rmdir_event_t event = {
+                .syscall.retval = retval,
+                .file = syscall->unlink.file,
+                .discarder_revision = get_discarder_revision(syscall->unlink.file.path_key.mount_id),
+            };
 
-        struct proc_cache_t *entry = fill_process_context(&event.process);
-        fill_container_context(entry, &event.container);
+            struct proc_cache_t *entry = fill_process_context(&event.process);
+            fill_container_context(entry, &event.container);
 
-        send_event(ctx, syscall->unlink.flags&AT_REMOVEDIR ? EVENT_RMDIR : EVENT_UNLINK, event);
+            send_event(ctx, EVENT_RMDIR, event);
+        } else {
+            struct unlink_event_t event = {
+                .syscall.retval = retval,
+                .file = syscall->unlink.file,
+                .flags = syscall->unlink.flags,
+                .discarder_revision = get_discarder_revision(syscall->unlink.file.path_key.mount_id),
+            };
+
+            struct proc_cache_t *entry = fill_process_context(&event.process);
+            fill_container_context(entry, &event.container);
+
+            send_event(ctx, EVENT_UNLINK, event);
+        }
     }
 
     invalidate_inode(ctx, syscall->unlink.file.path_key.mount_id, syscall->unlink.file.path_key.ino, !pass_to_userspace);

--- a/pkg/security/ebpf/c/unlink.h
+++ b/pkg/security/ebpf/c/unlink.h
@@ -148,4 +148,9 @@ SYSCALL_KRETPROBE(unlinkat) {
     return kprobe_sys_unlink_ret(ctx);
 }
 
+SEC("tracepoint/handle_sys_unlink_exit")
+int tracepoint_handle_sys_unlink_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    return sys_unlink_ret(args, args->ret);
+}
+
 #endif

--- a/pkg/security/ebpf/c/unlink.h
+++ b/pkg/security/ebpf/c/unlink.h
@@ -107,30 +107,17 @@ int __attribute__((always_inline)) sys_unlink_ret(void *ctx, int retval) {
                             (mask_has_event(enabled_events, EVENT_UNLINK) ||
                              mask_has_event(enabled_events, EVENT_RMDIR));
     if (pass_to_userspace) {
-        if (syscall->unlink.flags & AT_REMOVEDIR) {
-            struct rmdir_event_t event = {
-                .syscall.retval = retval,
-                .file = syscall->unlink.file,
-                .discarder_revision = get_discarder_revision(syscall->unlink.file.path_key.mount_id),
-            };
+        struct unlink_event_t event = {
+            .syscall.retval = retval,
+            .file = syscall->unlink.file,
+            .flags = syscall->unlink.flags,
+            .discarder_revision = get_discarder_revision(syscall->unlink.file.path_key.mount_id),
+        };
 
-            struct proc_cache_t *entry = fill_process_context(&event.process);
-            fill_container_context(entry, &event.container);
+        struct proc_cache_t *entry = fill_process_context(&event.process);
+        fill_container_context(entry, &event.container);
 
-            send_event(ctx, EVENT_RMDIR, event);
-        } else {
-            struct unlink_event_t event = {
-                .syscall.retval = retval,
-                .file = syscall->unlink.file,
-                .flags = syscall->unlink.flags,
-                .discarder_revision = get_discarder_revision(syscall->unlink.file.path_key.mount_id),
-            };
-
-            struct proc_cache_t *entry = fill_process_context(&event.process);
-            fill_container_context(entry, &event.container);
-
-            send_event(ctx, EVENT_UNLINK, event);
-        }
+        send_event(ctx, syscall->unlink.flags&AT_REMOVEDIR ? EVENT_RMDIR : EVENT_UNLINK, event);
     }
 
     invalidate_inode(ctx, syscall->unlink.file.path_key.mount_id, syscall->unlink.file.path_key.ino, !pass_to_userspace);

--- a/pkg/security/ebpf/c/utimes.h
+++ b/pkg/security/ebpf/c/utimes.h
@@ -64,11 +64,11 @@ SYSCALL_COMPAT_TIME_KPROBE0(futimesat) {
 }
 
 int __attribute__((always_inline)) sys_utimes_ret(void *ctx, int retval) {
-    if (IS_UNHANDLED_ERROR(retval))
-        return 0;
-
     struct syscall_cache_t *syscall = pop_syscall(EVENT_UTIME);
     if (!syscall)
+        return 0;
+
+    if (IS_UNHANDLED_ERROR(retval))
         return 0;
 
     struct utime_event_t event = {

--- a/pkg/security/ebpf/c/utimes.h
+++ b/pkg/security/ebpf/c/utimes.h
@@ -144,4 +144,9 @@ SYSCALL_COMPAT_TIME_KRETPROBE(futimesat) {
     return kprobe_sys_utimes_ret(ctx);
 }
 
+SEC("tracepoint/handle_sys_utimes_exit")
+int tracepoint_handle_sys_utimes_exit(struct tracepoint_raw_syscalls_sys_exit_t *args) {
+    return sys_utimes_ret(args, args->ret);
+}
+
 #endif

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -116,6 +116,7 @@ func AllTailRoutes() []manager.TailCallRoute {
 
 	routes = append(routes, getExecTailCallRoutes()...)
 	routes = append(routes, getDentryResolverTailCallRoutes()...)
+	routes = append(routes, getSysExitTailCallRoutes()...)
 
 	return routes
 }

--- a/pkg/security/ebpf/probes/raw_sys_exit.go
+++ b/pkg/security/ebpf/probes/raw_sys_exit.go
@@ -1,0 +1,109 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build linux
+
+package probes
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/security/model"
+	"github.com/DataDog/ebpf/manager"
+)
+
+func getSysExitTailCallRoutes() []manager.TailCallRoute {
+	return []manager.TailCallRoute{
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileChmodEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_chmod_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileChownEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_chown_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileLinkEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_link_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileMkdirEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_mkdir_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileMountEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_mount_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileOpenEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_open_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileRenameEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_rename_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileRmdirEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_rmdir_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileSetXAttrEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_setxattr_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileRemoveXAttrEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_removexattr_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileUmountEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_umount_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileUnlinkEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_unlink_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.FileUtimeEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_utimes_exit",
+			},
+		},
+	}
+}

--- a/pkg/security/ebpf/probes/raw_sys_exit.go
+++ b/pkg/security/ebpf/probes/raw_sys_exit.go
@@ -105,5 +105,26 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 				Section: "tracepoint/handle_sys_utimes_exit",
 			},
 		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.SetuidEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_commit_creds_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.SetgidEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_commit_creds_exit",
+			},
+		},
+		{
+			ProgArrayName: "sys_exit_progs",
+			Key:           uint32(model.CapsetEventType),
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "tracepoint/handle_sys_commit_creds_exit",
+			},
+		},
 	}
 }

--- a/pkg/security/ebpf/probes/syscall_helpers.go
+++ b/pkg/security/ebpf/probes/syscall_helpers.go
@@ -84,6 +84,8 @@ func getCompatSyscallFnName(name string) string {
 	return ia32SyscallPrefix + "compat_sys_" + name
 }
 
+// ShouldUseSyscallExitTracepoints returns true if the kernel version is old and we need to use tracepoints to handle syscall exits
+// instead of kretprobes
 func ShouldUseSyscallExitTracepoints() bool {
 	return currentKernelVersion != nil && (currentKernelVersion.Code < kernel.Kernel4_12 || currentKernelVersion.IsRH7Kernel())
 }

--- a/pkg/security/ebpf/probes/syscall_helpers.go
+++ b/pkg/security/ebpf/probes/syscall_helpers.go
@@ -84,13 +84,17 @@ func getCompatSyscallFnName(name string) string {
 	return ia32SyscallPrefix + "compat_sys_" + name
 }
 
+func ShouldUseSyscallExitTracepoints() bool {
+	return currentKernelVersion != nil && (currentKernelVersion.Code < kernel.Kernel4_12 || currentKernelVersion.IsRH7Kernel())
+}
+
 func expandKprobe(hookpoint string, syscallName string, flag int) []string {
 	var sections []string
 	if flag&Entry == Entry {
 		sections = append(sections, "kprobe/"+hookpoint)
 	}
 	if flag&Exit == Exit {
-		if len(syscallName) > 0 && currentKernelVersion != nil && (currentKernelVersion.Code < kernel.Kernel4_12 || currentKernelVersion.IsRH7Kernel()) {
+		if len(syscallName) > 0 && ShouldUseSyscallExitTracepoints() {
 			sections = append(sections, "tracepoint/syscalls/sys_exit_"+syscallName)
 		} else {
 			sections = append(sections, "kretprobe/"+hookpoint)

--- a/pkg/security/probe/dentry_resolver.go
+++ b/pkg/security/probe/dentry_resolver.go
@@ -662,9 +662,13 @@ func NewDentryResolver(probe *Probe) (*DentryResolver, error) {
 	// For each segment of a path, we write 16 bytes to store (inode, mount_id, path_id), and then at least 2 bytes to
 	// store the smallest possible path (segment of size 1 + trailing 0). 18 * 1500 = 27 000.
 	// Then, 27k + 256 / page_size < 7.
-	segment, err := unix.Mmap(0, 0, 7*os.Getpagesize(), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED|unix.MAP_ANON)
+	segment, err := unix.Mmap(0, 0, 7*os.Getpagesize(), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED|unix.MAP_ANON|unix.MAP_POPULATE)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to mmap memory segment")
+	}
+
+	if err := unix.Mlock(segment); err != nil {
+		return nil, errors.Wrap(err, "failed to lock memory segment")
 	}
 
 	hitsCounters := make(map[string]map[string]*int64)

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -859,6 +859,16 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, DiscarderConstants...)
 	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, getCGroupWriteConstants())
 
+	// if we are using tracepoints to probe syscall exits, i.e. if we are using an old kernel version (< 4.12)
+	// we need to use raw_syscall tracepoints for exits, as syscall are not trace when running an ia32 userspace
+	// process
+	if probes.ShouldUseSyscallExitTracepoints() {
+		p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, manager.ConstantEditor{
+			Name:  "tracepoint_raw_syscall_fallback",
+			Value: uint64(1),
+		})
+	}
+
 	// constants syscall monitor
 	if p.config.SyscallMonitor {
 		p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, manager.ConstantEditor{

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -868,10 +868,6 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 				Name:  "tracepoint_raw_syscall_fallback",
 				Value: uint64(1),
 			},
-			manager.ConstantEditor{
-				Name:  "thread_info_flags_offset",
-				Value: getThreadInfoFlagsOffset(p),
-			},
 		)
 	}
 

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -863,10 +863,16 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 	// we need to use raw_syscall tracepoints for exits, as syscall are not trace when running an ia32 userspace
 	// process
 	if probes.ShouldUseSyscallExitTracepoints() {
-		p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, manager.ConstantEditor{
-			Name:  "tracepoint_raw_syscall_fallback",
-			Value: uint64(1),
-		})
+		p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors,
+			manager.ConstantEditor{
+				Name:  "tracepoint_raw_syscall_fallback",
+				Value: uint64(1),
+			},
+			manager.ConstantEditor{
+				Name:  "thread_info_flags_offset",
+				Value: getThreadInfoFlagsOffset(p),
+			},
+		)
 	}
 
 	// constants syscall monitor

--- a/pkg/security/probe/syscalls.go
+++ b/pkg/security/probe/syscalls.go
@@ -327,13 +327,3 @@ const (
 func (s Syscall) MarshalText() ([]byte, error) {
 	return []byte(strings.ToLower(strings.TrimPrefix(s.String(), "Sys"))), nil
 }
-
-func getThreadInfoFlagsOffset(probe *Probe) uint64 {
-	offset := uint64(0)
-
-	if probe.kernelVersion.IsRH7Kernel() {
-		offset = 16
-	}
-
-	return offset
-}

--- a/pkg/security/probe/syscalls.go
+++ b/pkg/security/probe/syscalls.go
@@ -327,3 +327,13 @@ const (
 func (s Syscall) MarshalText() ([]byte, error) {
 	return []byte(strings.ToLower(strings.TrimPrefix(s.String(), "Sys"))), nil
 }
+
+func getThreadInfoFlagsOffset(probe *Probe) uint64 {
+	offset := uint64(0)
+
+	if probe.kernelVersion.IsRH7Kernel() {
+		offset = 16
+	}
+
+	return offset
+}


### PR DESCRIPTION
### What does this PR do?

- Handle ia32 syscalls using `raw_syscall` tracepoint
- Fix a bug around not popping an errored syscall in the syscall event queue

### Describe how to test your changes

Run the test suite on Centos 7.
Try handling a syscall from a x86 application running on Centos 7 x64.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
