### PR TITLE
Implement statefulset collection

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator_transformer.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator_transformer.go
@@ -138,6 +138,39 @@ func extractCronJob(cj *batchv1beta1.CronJob) *model.CronJob {
 	return &cronJob
 }
 
+func extractStatefulSet(sts *v1.StatefulSet) *model.StatefulSet {
+	statefulSet := model.StatefulSet{
+		Metadata: orchestrator.ExtractMetadata(&sts.ObjectMeta),
+		Spec: &model.StatefulSetSpec{
+			ServiceName:         sts.Spec.ServiceName,
+			PodManagementPolicy: string(sts.Spec.PodManagementPolicy),
+			UpdateStrategy:      string(sts.Spec.UpdateStrategy.Type),
+		},
+		Status: &model.StatefulSetStatus{
+			Replicas:        sts.Status.Replicas,
+			ReadyReplicas:   sts.Status.ReadyReplicas,
+			CurrentReplicas: sts.Status.CurrentReplicas,
+			UpdatedReplicas: sts.Status.UpdatedReplicas,
+		},
+	}
+
+	if sts.Spec.UpdateStrategy.Type == "RollingUpdate" && sts.Spec.UpdateStrategy.RollingUpdate != nil {
+		if sts.Spec.UpdateStrategy.RollingUpdate.Partition != nil {
+			statefulSet.Spec.Partition = *sts.Spec.UpdateStrategy.RollingUpdate.Partition
+		}
+	}
+
+	if sts.Spec.Replicas != nil {
+		statefulSet.Spec.Replicas = *sts.Spec.Replicas
+	}
+
+	if sts.Spec.Selector != nil {
+		statefulSet.Spec.Selectors = extractLabelSelector(sts.Spec.Selector)
+	}
+
+	return &statefulSet
+}
+
 func extractDaemonSet(ds *v1.DaemonSet) *model.DaemonSet {
 	daemonSet := model.DaemonSet{
 		Metadata: orchestrator.ExtractMetadata(&ds.ObjectMeta),

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator_transformer.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator_transformer.go
@@ -161,7 +161,7 @@ func extractStatefulSet(sts *v1.StatefulSet) *model.StatefulSet {
 	}
 
 	if sts.Spec.Replicas != nil {
-		statefulSet.Spec.Replicas = *sts.Spec.Replicas
+		statefulSet.Spec.DesiredReplicas = *sts.Spec.Replicas
 	}
 
 	if sts.Spec.Selector != nil {

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator_transformer_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator_transformer_test.go
@@ -91,9 +91,9 @@ func TestExtractStatefulSet(t *testing.T) {
 					ResourceVersion:   "1234",
 				},
 				Spec: &model.StatefulSetSpec{
-					Replicas:       2,
-					UpdateStrategy: "RollingUpdate",
-					Partition:      2,
+					DesiredReplicas: 2,
+					UpdateStrategy:  "RollingUpdate",
+					Partition:       2,
 					Selectors: []*model.LabelSelectorRequirement{
 						{
 							Key:      "app",

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -39,8 +39,10 @@ const (
 	PayloadTypeJob = "job"
 	// PayloadTypeCronJob is the name of the cronjob payload type
 	PayloadTypeCronJob = "cronjob"
-	// PayloadTypeDaemonset is the name of the daemonset payload type
-	PayloadTypeDaemonset = "daemonset"
+	// PayloadTypeDaemonSet is the name of the daemonset payload type
+	PayloadTypeDaemonSet = "daemonset"
+	// PayloadTypeStatefulSet is the name of the statefulset payload type
+	PayloadTypeStatefulSet = "statefulset"
 )
 
 const (
@@ -573,8 +575,10 @@ func (f *DefaultForwarder) SubmitOrchestratorChecks(payload Payloads, extra http
 		transactionsIntakeCronJob.Add(1)
 	case PayloadTypeCluster:
 		transactionsIntakeCluster.Add(1)
-	case PayloadTypeDaemonset:
+	case PayloadTypeDaemonSet:
 		transactionsIntakeDaemonSet.Add(1)
+	case PayloadTypeStatefulSet:
+		transactionsIntakeStatefulSet.Add(1)
 	}
 
 	return f.submitProcessLikePayload(orchestratorEndpoint, payload, extra, true)

--- a/pkg/forwarder/telemetry.go
+++ b/pkg/forwarder/telemetry.go
@@ -13,15 +13,16 @@ import (
 )
 
 var (
-	transactionsIntakePod        = expvar.Int{}
-	transactionsIntakeDeployment = expvar.Int{}
-	transactionsIntakeReplicaSet = expvar.Int{}
-	transactionsIntakeService    = expvar.Int{}
-	transactionsIntakeNode       = expvar.Int{}
-	transactionsIntakeJob        = expvar.Int{}
-	transactionsIntakeCronJob    = expvar.Int{}
-	transactionsIntakeCluster    = expvar.Int{}
-	transactionsIntakeDaemonSet  = expvar.Int{}
+	transactionsIntakePod         = expvar.Int{}
+	transactionsIntakeDeployment  = expvar.Int{}
+	transactionsIntakeReplicaSet  = expvar.Int{}
+	transactionsIntakeService     = expvar.Int{}
+	transactionsIntakeNode        = expvar.Int{}
+	transactionsIntakeJob         = expvar.Int{}
+	transactionsIntakeCronJob     = expvar.Int{}
+	transactionsIntakeCluster     = expvar.Int{}
+	transactionsIntakeDaemonSet   = expvar.Int{}
+	transactionsIntakeStatefulSet = expvar.Int{}
 
 	v1SeriesEndpoint       = transaction.Endpoint{Route: "/api/v1/series", Name: "series_v1"}
 	v1CheckRunsEndpoint    = transaction.Endpoint{Route: "/api/v1/check_run", Name: "check_run_v1"}
@@ -109,6 +110,7 @@ func initOrchestratorExpVars() {
 	transaction.TransactionsExpvars.Set("CronJobs", &transactionsIntakeCronJob)
 	transaction.TransactionsExpvars.Set("Clusters", &transactionsIntakeCluster)
 	transaction.TransactionsExpvars.Set("DaemonSets", &transactionsIntakeDaemonSet)
+	transaction.TransactionsExpvars.Set("StatefulSets", &transactionsIntakeStatefulSet)
 }
 
 func initTransactionsExpvars() {

--- a/pkg/orchestrator/cache.go
+++ b/pkg/orchestrator/cache.go
@@ -27,27 +27,29 @@ const (
 )
 
 var (
-	cacheExpVars        = expvar.NewMap("orchestrator-cache")
-	deploymentCacheHits = expvar.Int{}
-	replicaSetCacheHits = expvar.Int{}
-	nodeCacheHits       = expvar.Int{}
-	serviceCacheHits    = expvar.Int{}
-	podCacheHits        = expvar.Int{}
-	clusterCacheHits    = expvar.Int{}
-	jobCacheHits        = expvar.Int{}
-	cronJobCacheHits    = expvar.Int{}
-	daemonSetCacheHits  = expvar.Int{}
+	cacheExpVars         = expvar.NewMap("orchestrator-cache")
+	deploymentCacheHits  = expvar.Int{}
+	replicaSetCacheHits  = expvar.Int{}
+	nodeCacheHits        = expvar.Int{}
+	serviceCacheHits     = expvar.Int{}
+	podCacheHits         = expvar.Int{}
+	clusterCacheHits     = expvar.Int{}
+	jobCacheHits         = expvar.Int{}
+	cronJobCacheHits     = expvar.Int{}
+	daemonSetCacheHits   = expvar.Int{}
+	statefulSetCacheHits = expvar.Int{}
 
-	sendExpVars    = expvar.NewMap("orchestrator-sends")
-	deploymentHits = expvar.Int{}
-	replicaSetHits = expvar.Int{}
-	nodeHits       = expvar.Int{}
-	serviceHits    = expvar.Int{}
-	podHits        = expvar.Int{}
-	clusterHits    = expvar.Int{}
-	jobHits        = expvar.Int{}
-	cronJobHits    = expvar.Int{}
-	daemonSetHits  = expvar.Int{}
+	sendExpVars     = expvar.NewMap("orchestrator-sends")
+	deploymentHits  = expvar.Int{}
+	replicaSetHits  = expvar.Int{}
+	nodeHits        = expvar.Int{}
+	serviceHits     = expvar.Int{}
+	podHits         = expvar.Int{}
+	clusterHits     = expvar.Int{}
+	jobHits         = expvar.Int{}
+	cronJobHits     = expvar.Int{}
+	daemonSetHits   = expvar.Int{}
+	statefulSetHits = expvar.Int{}
 
 	// KubernetesResourceCache provides an in-memory key:value store similar to memcached for kubernetes resources.
 	KubernetesResourceCache = cache.New(defaultExpire, defaultPurge)
@@ -67,6 +69,7 @@ func init() {
 	cacheExpVars.Set("Jobs", &jobCacheHits)
 	cacheExpVars.Set("CronJobs", &cronJobCacheHits)
 	cacheExpVars.Set("DaemonSets", &daemonSetCacheHits)
+	cacheExpVars.Set("StatefulSets", &statefulSetCacheHits)
 
 	sendExpVars.Set("Pods", &podHits)
 	sendExpVars.Set("Deployments", &deploymentHits)
@@ -77,6 +80,7 @@ func init() {
 	sendExpVars.Set("Jobs", &jobHits)
 	sendExpVars.Set("CronJobs", &cronJobHits)
 	sendExpVars.Set("DaemonSets", &daemonSetHits)
+	sendExpVars.Set("StatefulSets", &statefulSetHits)
 }
 
 // SkipKubernetesResource checks with a global kubernetes cache whether the resource was already reported.
@@ -121,6 +125,8 @@ func incCacheHit(nodeType NodeType) {
 		cronJobCacheHits.Add(1)
 	case K8sDaemonSet:
 		daemonSetCacheHits.Add(1)
+	case K8sStatefulSet:
+		statefulSetCacheHits.Add(1)
 	default:
 		log.Errorf("Cannot increment unknown nodeType, iota: %v", nodeType)
 		return
@@ -148,6 +154,8 @@ func incCacheMiss(nodeType NodeType) {
 		cronJobHits.Add(1)
 	case K8sDaemonSet:
 		daemonSetHits.Add(1)
+	case K8sStatefulSet:
+		statefulSetHits.Add(1)
 	default:
 		log.Errorf("Cannot increment unknown nodeType, iota: %v", nodeType)
 		return

--- a/pkg/orchestrator/util.go
+++ b/pkg/orchestrator/util.go
@@ -33,6 +33,8 @@ const (
 	K8sCronJob
 	// K8sDaemonSet represents a Kubernetes DaemonSet
 	K8sDaemonSet
+	// K8sStatefulSet represents a Kubernetes StatefulSet
+	K8sStatefulSet
 )
 
 var (
@@ -84,9 +86,11 @@ func (n NodeType) String() string {
 		return "ReplicaSet"
 	case K8sService:
 		return "Service"
+	case K8sStatefulSet:
+		return "StatefulSet"
 	default:
-		log.Errorf("Trying to convert unknown NodeType iota: %v", n)
-		return ""
+		log.Errorf("Trying to convert unknown NodeType iota: %d", n)
+		return "Unknown"
 	}
 }
 

--- a/pkg/orchestrator/util.go
+++ b/pkg/orchestrator/util.go
@@ -39,15 +39,16 @@ const (
 
 var (
 	telemetryTags = map[NodeType][]string{
-		K8sCluster:    getTelemetryTags(K8sCluster),
-		K8sCronJob:    getTelemetryTags(K8sCronJob),
-		K8sDeployment: getTelemetryTags(K8sDeployment),
-		K8sJob:        getTelemetryTags(K8sJob),
-		K8sNode:       getTelemetryTags(K8sNode),
-		K8sPod:        getTelemetryTags(K8sPod),
-		K8sReplicaSet: getTelemetryTags(K8sReplicaSet),
-		K8sService:    getTelemetryTags(K8sService),
-		K8sDaemonSet:  getTelemetryTags(K8sDaemonSet),
+		K8sCluster:     getTelemetryTags(K8sCluster),
+		K8sCronJob:     getTelemetryTags(K8sCronJob),
+		K8sDeployment:  getTelemetryTags(K8sDeployment),
+		K8sJob:         getTelemetryTags(K8sJob),
+		K8sNode:        getTelemetryTags(K8sNode),
+		K8sPod:         getTelemetryTags(K8sPod),
+		K8sReplicaSet:  getTelemetryTags(K8sReplicaSet),
+		K8sService:     getTelemetryTags(K8sService),
+		K8sDaemonSet:   getTelemetryTags(K8sDaemonSet),
+		K8sStatefulSet: getTelemetryTags(K8sStatefulSet),
 	}
 )
 
@@ -63,6 +64,7 @@ func NodeTypes() []NodeType {
 		K8sPod,
 		K8sReplicaSet,
 		K8sService,
+		K8sStatefulSet,
 	}
 }
 
@@ -98,7 +100,7 @@ func (n NodeType) String() string {
 func (n NodeType) Orchestrator() string {
 	switch n {
 	case K8sCluster, K8sCronJob, K8sDeployment, K8sDaemonSet, K8sJob,
-		K8sNode, K8sPod, K8sReplicaSet, K8sService:
+		K8sNode, K8sPod, K8sReplicaSet, K8sService, K8sStatefulSet:
 		return "k8s"
 	default:
 		log.Errorf("Unknown NodeType %v", n)

--- a/pkg/status/templates/orchestrator.tmpl
+++ b/pkg/status/templates/orchestrator.tmpl
@@ -66,8 +66,10 @@ Orchestrator Explorer
       Last Run: (Hits: {{.JobsStats.CacheHits}} Miss: {{.JobsStats.CacheMiss}}) | Total: (Hits: {{.CacheHits.Jobs}} Miss: {{.CacheMiss.Jobs}})
     CronJob:
       Last Run: (Hits: {{.CronJobsStats.CacheHits}} Miss: {{.CronJobsStats.CacheMiss}}) | Total: (Hits: {{.CacheHits.CronJobs}} Miss: {{.CacheMiss.CronJobs}})
-    Daemonset:
+    DaemonSets:
       Last Run: (Hits: {{.DaemonSetsStats.CacheHits}} Miss: {{.DaemonSetsStats.CacheMiss}}) | Total: (Hits: {{.CacheHits.DaemonSets}} Miss: {{.CacheMiss.DaemonSets}})
+    StatefulSets:
+      Last Run: (Hits: {{.StatefulSetsStats.CacheHits}} Miss: {{.StatefulSetsStats.CacheMiss}}) | Total: (Hits: {{.CacheHits.StatefulSets}} Miss: {{.CacheMiss.StatefulSets}})
 {{else}}
 {{- if .LeaderName }}
   Status: Follower, cluster agent leader is: {{ .LeaderName }}

--- a/pkg/util/kubernetes/apiserver/types.go
+++ b/pkg/util/kubernetes/apiserver/types.go
@@ -46,4 +46,6 @@ const (
 	CronJobsInformer InformerName = "cronJobs"
 	// DaemonSetsInformer holds the name of the informer
 	DaemonSetsInformer InformerName = "daemonSets"
+	// StatefulSetsInformer holds the name of the informer
+	StatefulSetsInformer InformerName = "statefulSets"
 )

--- a/releasenotes-dca/notes/collect-sts-c6554614c1d40dce.yaml
+++ b/releasenotes-dca/notes/collect-sts-c6554614c1d40dce.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Enable ``DaemonSet`` collection by default in the orchestrator check.
+    Add ``StatefulSet`` collection in the orchestrator check.


### PR DESCRIPTION
### What does this PR do?

Add `StatefulSet` collection in the orchestrator check.
Enable `DaemonSet` collection by default in the orchestrator check.

### Motivation

Add statefulset collection capabilities to the cluster-agent

### Additional Notes

Requires https://github.com/DataDog/agent-payload/pull/109

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
