### PR TITLE
[omnibus] Exclude aerospike libs from stripping process

### DIFF
--- a/omnibus/config/software/datadog-agent-finalize.rb
+++ b/omnibus/config/software/datadog-agent-finalize.rb
@@ -189,6 +189,10 @@ build do
             strip_exclude("*psycopg2*")
             strip_exclude("*cffi_backend*")
 
+            # We get the following error when the aerospike lib is stripped:
+            # The `aerospike` client is not installed: /opt/datadog-agent/embedded/lib/python2.7/site-packages/aerospike.so: ELF load command address/offset not properly aligned
+            strip_exclude("*aerospike*")
+
             # Do not strip eBPF programs
             strip_exclude("*tracer*")
             strip_exclude("*offset-guess*")


### PR DESCRIPTION
### What does this PR do?

Prevent aerospike libraries from being stripped during omnibus builds.

### Motivation

Integrations-core CI started failing after the update to `aerospike` `4.0.0` with this error:
```
The `aerospike` client is not installed: /opt/datadog-agent/embedded/lib/python2.7/site-packages/aerospike.so: ELF load command address/offset not properly aligned
```

Not stripping the mentioned library fixes the problem.

### Describe how to test your changes

Run integrations-core CI on the resulting build: https://github.com/DataDog/integrations-core/pull/9560

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
