### PR TITLE
[runtime-security] fix small bugs

### DIFF
--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -301,7 +301,7 @@ func (ev *Event) ResolveExecArgsOptions(e *model.ExecEvent) (options []string) {
 			}
 			if len(name) > 0 && model.IsAlphaNumeric(rune(name[0])) {
 				if index := strings.IndexRune(name, '='); index == -1 {
-					if i < len(args)-1 && args[i+1][0] != '-' {
+					if i < len(args)-1 && (len(args[i+1]) == 0 || args[i+1][0] != '-') {
 						options = append(options, name+"="+args[i+1])
 						i++
 					}

--- a/pkg/security/probe/model_test.go
+++ b/pkg/security/probe/model_test.go
@@ -154,7 +154,7 @@ func TestExecArgsOptions(t *testing.T) {
 					ArgsEntry: &model.ArgsEntry{
 						Values: []string{
 							"--config", "/etc/myfile", "--host=myhost", "--verbose",
-							"-c", "/etc/myfile", "-h=myhost", "-v",
+							"-c", "/etc/myfile", "-e", "", "-h=myhost", "-v",
 							"--", "---", "-9",
 						},
 					},
@@ -169,7 +169,7 @@ func TestExecArgsOptions(t *testing.T) {
 	}
 
 	options := e.ResolveExecArgsOptions(&e.Exec)
-	sort.Sort(sort.StringSlice(options))
+	sort.Strings(options)
 
 	hasOption := func(options []string, option string) bool {
 		i := sort.SearchStrings(options, option)
@@ -184,6 +184,10 @@ func TestExecArgsOptions(t *testing.T) {
 		t.Error("option 'c=/etc/myfile' not found")
 	}
 
+	if !hasOption(options, "e=") {
+		t.Error("option 'e=' not found")
+	}
+
 	if !hasOption(options, "host=myhost") {
 		t.Error("option 'host=myhost' not found")
 	}
@@ -196,7 +200,7 @@ func TestExecArgsOptions(t *testing.T) {
 		t.Error("option 'verbose=' found")
 	}
 
-	if len(options) != 4 {
-		t.Errorf("expected 4 options, got %d", len(options))
+	if len(options) != 5 {
+		t.Errorf("expected 5 options, got %d", len(options))
 	}
 }

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -599,7 +599,7 @@ func (p *ProcessResolver) resolveWithProcfs(pid uint32, maxDepth int) *model.Pro
 
 	parent := p.resolveWithProcfs(uint32(filledProc.Ppid), maxDepth-1)
 	entry, inserted := p.syncCache(proc)
-	if inserted && entry != nil {
+	if inserted && entry != nil && parent != nil {
 		entry.SetAncestor(parent)
 	}
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes:
- a bug where a nil pointer was dereferenced
- a bug where the first element of an empty string was accessed

### Motivation

Bug fix

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
