### PR TITLE
Adding a variable to customize expvar server bind address

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -8,15 +8,15 @@ package app
 import (
 	"context"
 	"fmt"
+	"net/http"
+	"os"
+	"os/signal"
 	"runtime"
 	"syscall"
 
 	_ "expvar" // Blank import used because this isn't directly used in this file
-	"net/http"
-	_ "net/http/pprof" // Blank import used because this isn't directly used in this file
 
-	"os"
-	"os/signal"
+	_ "net/http/pprof" // Blank import used because this isn't directly used in this file
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api"
 	"github.com/DataDog/datadog-agent/cmd/agent/clcrunnerapi"
@@ -194,7 +194,7 @@ func StartAgent() error {
 			config.Datadog.GetBool("log_format_json"),
 		)
 
-		//Setup JMX logger
+		// Setup JMX logger
 		if loggerSetupErr == nil {
 			loggerSetupErr = config.SetupJMXLogger(
 				jmxLoggerName,
@@ -218,7 +218,7 @@ func StartAgent() error {
 			false, // not in json
 		)
 
-		//Setup JMX logger
+		// Setup JMX logger
 		if loggerSetupErr == nil {
 			loggerSetupErr = config.SetupJMXLogger(
 				jmxLoggerName,
@@ -271,19 +271,20 @@ func StartAgent() error {
 	}
 
 	// Setup expvar server
-	var port = config.Datadog.GetString("expvar_port")
+	expvarPort := config.Datadog.GetString("expvar_port")
+	expvarHost := config.Datadog.GetString("expvar_host")
 	if config.Datadog.GetBool("telemetry.enabled") {
 		http.Handle("/telemetry", telemetry.Handler())
 	}
 	go func() {
-		err := http.ListenAndServe("127.0.0.1:"+port, http.DefaultServeMux)
+		err := http.ListenAndServe(fmt.Sprintf("%s:%s", expvarHost, expvarPort), http.DefaultServeMux)
 		if err != nil && err != http.ErrServerClosed {
-			log.Errorf("Error creating expvar server on port %v: %v", port, err)
+			log.Errorf("Error creating expvar server on port %v: %v", expvarPort, err)
 		}
 	}()
 
 	// Setup healthcheck port
-	var healthPort = config.Datadog.GetInt("health_port")
+	healthPort := config.Datadog.GetInt("health_port")
 	if healthPort > 0 {
 		err := healthprobe.Serve(common.MainCtx, healthPort)
 		if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -566,10 +566,12 @@ func InitConfig(config Config) {
 
 	// GCE
 	config.BindEnvAndSetDefault("collect_gce_tags", true)
-	config.BindEnvAndSetDefault("exclude_gce_tags", []string{"kube-env", "kubelet-config", "containerd-configure-sh", "startup-script", "shutdown-script",
+	config.BindEnvAndSetDefault("exclude_gce_tags", []string{
+		"kube-env", "kubelet-config", "containerd-configure-sh", "startup-script", "shutdown-script",
 		"configure-sh", "sshKeys", "ssh-keys", "user-data", "cli-cert", "ipsec-cert", "ssl-cert", "google-container-manifest",
 		"bosh_settings", "windows-startup-script-ps1", "common-psm1", "k8s-node-setup-psm1", "serial-port-logging-enable",
-		"enable-oslogin", "disable-address-manager", "disable-legacy-endpoints", "windows-keys", "kubeconfig"})
+		"enable-oslogin", "disable-address-manager", "disable-legacy-endpoints", "windows-keys", "kubeconfig",
+	})
 	config.BindEnvAndSetDefault("gce_send_project_id_tag", false)
 	config.BindEnvAndSetDefault("gce_metadata_timeout", 1000) // value in milliseconds
 
@@ -615,6 +617,7 @@ func InitConfig(config Config) {
 
 	// Go_expvar server port
 	config.BindEnvAndSetDefault("expvar_port", "5000")
+	config.BindEnvAndSetDefault("expvar_host", "127.0.0.1")
 
 	// internal profiling
 	config.BindEnvAndSetDefault("internal_profiling.enabled", false)
@@ -893,9 +896,7 @@ func InitConfig(config Config) {
 	setupAPM(config)
 }
 
-var (
-	ddURLRegexp = regexp.MustCompile(`^app(\.(us|eu)\d)?\.datad(oghq|0g)\.(com|eu)$`)
-)
+var ddURLRegexp = regexp.MustCompile(`^app(\.(us|eu)\d)?\.datad(oghq|0g)\.(com|eu)$`)
 
 // GetProxies returns the proxy settings from the configuration
 func GetProxies() *Proxy {


### PR DESCRIPTION
### What does this PR do?

Adding a variable to customize expvar server bind address

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Set `expvar_host` to `0.0.0.0` (for instance) and check that `expvar_port` is accessible from another host.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
