### PR TITLE
[Serverless] Remove http connectivity check when serverless mode is on

### DIFF
--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -54,7 +54,7 @@ func StartServerless(getAC func() *autodiscovery.AutoConfig, logsChan chan *conf
 	return start(getAC, true, logsChan, extraTags)
 }
 
-// buildEndpoint builds endpoints regarding the agent is in serverless mode or not
+// buildEndpoints builds endpoints for the logs agent
 func buildEndpoints(serverless bool) (*config.Endpoints, error) {
 	if serverless {
 		return config.BuildServerlessEndpoints()

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -14,11 +14,11 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
 	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/client/http"
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
-	"github.com/DataDog/datadog-agent/pkg/logs/client/http"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/diagnostic"
 	"github.com/DataDog/datadog-agent/pkg/logs/scheduler"
@@ -54,6 +54,18 @@ func StartServerless(getAC func() *autodiscovery.AutoConfig, logsChan chan *conf
 	return start(getAC, true, logsChan, extraTags)
 }
 
+// buildEndpoint builds endpoints regarding the agent is in serverless mode or not
+func buildEndpoints(serverless bool) (*config.Endpoints, error) {
+	if serverless {
+		return config.BuildServerlessEndpoints()
+	}
+	httpConnectivity := config.HTTPConnectivityFailure
+	if endpoints, err := config.BuildHTTPEndpoints(); err == nil {
+		httpConnectivity = http.CheckConnectivity(endpoints.Main)
+	}
+	return config.BuildEndpoints(httpConnectivity)
+}
+
 func start(getAC func() *autodiscovery.AutoConfig, serverless bool, logsChan chan *config.ChannelMessage, extraTags []string) error {
 	if IsAgentRunning() {
 		return nil
@@ -67,14 +79,8 @@ func start(getAC func() *autodiscovery.AutoConfig, serverless bool, logsChan cha
 	scheduler.CreateScheduler(sources, services)
 
 	// setup the server config
-	httpConnectivity := config.HTTPConnectivityFailure
-	if endpoints, err := config.BuildHTTPEndpoints(); err == nil {
-		httpConnectivity = http.CheckConnectivity(endpoints.Main)
-	}
-	endpoints, err := config.BuildEndpoints(httpConnectivity)
-	if serverless {
-		endpoints, err = config.BuildServerlessEndpoints()
-	}
+	endpoints, err := buildEndpoints(serverless)
+
 	if err != nil {
 		message := fmt.Sprintf("Invalid endpoints: %v", err)
 		status.AddGlobalError(invalidEndpoints, message)

--- a/pkg/logs/logs_test.go
+++ b/pkg/logs/logs_test.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package logs
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildServerlessEndpoints(t *testing.T) {
+	endpoints, err := buildEndpoints(true)
+	assert.Nil(t, err)
+	assert.Equal(t, "lambda-http-intake.logs.datadoghq.com", endpoints.Main.Host)
+}
+
+func TestBuildEndpoints(t *testing.T) {
+	endpoints, err := buildEndpoints(false)
+	assert.Nil(t, err)
+	assert.Equal(t, "agent-intake.logs.datadoghq.com", endpoints.Main.Host)
+}

--- a/pkg/serverless/serverless_test.go
+++ b/pkg/serverless/serverless_test.go
@@ -41,6 +41,7 @@ func TestHandleInvocationShouldSetExtraTags(t *testing.T) {
 		"a3:valuea3",
 		"a4:valuea4",
 		"a_maj:valueamaj",
+		"account_id:123456789012",
 		"aws_account:123456789012",
 		"function_arn:arn:aws:lambda:us-east-1:123456789012:function:my-function",
 		"functionname:my-function",


### PR DESCRIPTION
### What does this PR do?

Remove an extra http call which was made to check whether or not we can reach the log intake

### Motivation

Make the serverless agent starts way faster.

While starting the agent is doing a HTTP connectivity check to ensure that we are able to reach the log api intake and while this is great for a serverfull environment, it should be skipped in a serverless one not to slow down the extension startup.
 

### Describe how to test your changes

Manual testing + Unit testing

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.

