### PR TITLE
[Serverless] support comma in DD_TAGS and DD_EXTRA_TAGS

### DIFF
--- a/pkg/serverless/serverless_test.go
+++ b/pkg/serverless/serverless_test.go
@@ -30,7 +30,7 @@ func TestHandleInvocationShouldSetExtraTags(t *testing.T) {
 	deadlineMs := (time.Now().UnixNano())/1000000 + 20
 
 	//setting DD_TAGS and DD_EXTRA_TAGS
-	os.Setenv("DD_TAGS", "a1:valueA1 a2:valueA2 A_MAJ:valueAMaj")
+	os.Setenv("DD_TAGS", "a1:valueA1,a2:valueA2,A_MAJ:valueAMaj")
 	os.Setenv("DD_EXTRA_TAGS", "a3:valueA3 a4:valueA4")
 
 	callInvocationHandler(d, "arn:aws:lambda:us-east-1:123456789012:function:my-function", deadlineMs, 0, true, handleInvocation)
@@ -41,6 +41,7 @@ func TestHandleInvocationShouldSetExtraTags(t *testing.T) {
 		"a3:valuea3",
 		"a4:valuea4",
 		"a_maj:valueamaj",
+		"account_id:123456789012",
 		"aws_account:123456789012",
 		"function_arn:arn:aws:lambda:us-east-1:123456789012:function:my-function",
 		"functionname:my-function",

--- a/pkg/serverless/tags.go
+++ b/pkg/serverless/tags.go
@@ -31,7 +31,10 @@ func buildTagMap(arn string, configTags []string) map[string]string {
 	tags := make(map[string]string)
 
 	for _, tag := range configTags {
-		tags = addTag(tags, tag)
+		splitTags := strings.Split(tag, ",")
+		for _, singleTag := range splitTags {
+			tags = addTag(tags, singleTag)
+		}
 	}
 
 	tags = setIfNotEmpty(tags, traceOriginMetadataKey, traceOriginMetadataValue)

--- a/pkg/serverless/tags_test.go
+++ b/pkg/serverless/tags_test.go
@@ -68,7 +68,7 @@ func TestBuildTagMapFromArnIncomplete(t *testing.T) {
 	assert.Equal(t, "value1", tagMap["tag1"])
 }
 
-func TestBuildTagMapFromArnIncompleteWithComaAndSpaceTags(t *testing.T) {
+func TestBuildTagMapFromArnIncompleteWithCommaAndSpaceTags(t *testing.T) {
 	arn := "function:my-function"
 	tagMap := buildTagMap(arn, []string{"tag0:value0", "tag1:value1,tag2:VALUE2", "TAG3:VALUE3"})
 	assert.Equal(t, 7, len(tagMap))

--- a/pkg/serverless/tags_test.go
+++ b/pkg/serverless/tags_test.go
@@ -68,6 +68,19 @@ func TestBuildTagMapFromArnIncomplete(t *testing.T) {
 	assert.Equal(t, "value1", tagMap["tag1"])
 }
 
+func TestBuildTagMapFromArnIncompleteWithComaAndSpaceTags(t *testing.T) {
+	arn := "function:my-function"
+	tagMap := buildTagMap(arn, []string{"tag0:value0", "tag1:value1,tag2:VALUE2", "TAG3:VALUE3"})
+	assert.Equal(t, 7, len(tagMap))
+	assert.Equal(t, "lambda", tagMap["_dd.origin"])
+	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
+	assert.Equal(t, "function:my-function", tagMap["function_arn"])
+	assert.Equal(t, "value0", tagMap["tag0"])
+	assert.Equal(t, "value1", tagMap["tag1"])
+	assert.Equal(t, "value2", tagMap["tag2"])
+	assert.Equal(t, "value3", tagMap["tag3"])
+}
+
 func TestBuildTagMapFromArnComplete(t *testing.T) {
 	arn := "arn:aws:lambda:us-east-1:123456789012:function:my-function"
 	tagMap := buildTagMap(arn, []string{"tag0:value0", "TAG1:VALUE1"})


### PR DESCRIPTION
### What does this PR do?

Support comma separated tags in DD_EXTRA_TAGS and DD_TAGS (only on the Serverless agent)

### Motivation

Consistency with dd-trace-py (space+comma supported) and dd-trace-js (only comma supported)

### Describe how to test your changes

Integration, unit and manual testing

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.