### PR TITLE
[Podman][Docker] Subscribe to `died` events

### DIFF
--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -204,7 +204,7 @@ func (l *DockerListener) processEvent(e *docker.ContainerEvent) {
 
 	if found {
 		switch e.Action {
-		case docker.ContainerEventActionDie:
+		case docker.ContainerEventActionDie, docker.ContainerEventActionDied:
 			l.removeService(cID)
 		case docker.ContainerEventActionStart:
 			// Container restarted with the same ID within 5 seconds.

--- a/pkg/autodiscovery/providers/docker.go
+++ b/pkg/autodiscovery/providers/docker.go
@@ -135,7 +135,7 @@ CONNECT:
 							d.addLabels(ev.ContainerID, container.Config.Labels)
 						}
 					}
-				} else if ev.Action == docker.ContainerEventActionDie {
+				} else if ev.Action == docker.ContainerEventActionDie || ev.Action == docker.ContainerEventActionDied {
 					// delay for short lived detection
 					time.AfterFunc(delayDuration, func() {
 						d.Lock()

--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -102,7 +102,7 @@ func (c *DockerCollector) processEvent(e *docker.ContainerEvent) {
 	var info *TagInfo
 
 	switch e.Action {
-	case docker.ContainerEventActionDie:
+	case docker.ContainerEventActionDie, docker.ContainerEventActionDied:
 		info = &TagInfo{Entity: e.ContainerEntityName(), Source: dockerCollectorName, DeleteEntity: true}
 	case docker.ContainerEventActionStart, docker.ContainerEventActionRename:
 		inspectCached := e.Action == docker.ContainerEventActionStart

--- a/pkg/util/docker/event_stream.go
+++ b/pkg/util/docker/event_stream.go
@@ -81,6 +81,7 @@ func (d *DockerUtil) dispatchEvents(sub *eventSubscriber) {
 	fltrs.Add("type", "container")
 	fltrs.Add("event", "start")
 	fltrs.Add("event", "die")
+	fltrs.Add("event", "died")
 	fltrs.Add("event", "rename")
 
 	// On initial subscribe, don't go back in time. On reconnect, we'll

--- a/pkg/util/docker/event_types.go
+++ b/pkg/util/docker/event_types.go
@@ -18,6 +18,8 @@ const (
 	ContainerEventActionStart = "start"
 	// ContainerEventActionDie is the action of stopping a docker container
 	ContainerEventActionDie = "die"
+	// ContainerEventActionDied is the action of stopping a podman container
+	ContainerEventActionDied = "died"
 	// ContainerEventActionRename is the action of renaming a docker container
 	ContainerEventActionRename = "rename"
 )


### PR DESCRIPTION
### What does this PR do?

Subscribe to container `died` events. As Podman uses `died` instead of `die`. (as opposed to Docker)

### Motivation

Monitor Podman containers.

### Describe how to test your changes

```
$ sudo podman run -d --name dd-agent \
    -v /run/podman/podman.sock:/run/podman/podman.sock:ro \
    -v /proc/:/host/proc/:ro \
    -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
    -e DD_API_KEY=<API_KEY> \
    -e DOCKER_HOST=unix:///run/podman/podman.sock \
    datadog/agent:latest
```

Make sure Autodiscovery and the tagger works as expected, more importantly, when a container dies make sure the corresponding AD check is unscheduled.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
