### PR TITLE
Add to the flare the DatadogAgent events from Application.

### DIFF
--- a/pkg/flare/archive_win.go
+++ b/pkg/flare/archive_win.go
@@ -28,7 +28,7 @@ var (
 
 	eventLogChannelsToExport = map[string]string{
 		"System":      "Event/System/Provider[@Name=\"Service Control Manager\"]",
-		"Application": "Event/System/Provider[@Name=\"datadog-trace-agent\"]",
+		"Application": "Event/System/Provider[@Name=\"datadog-trace-agent\" or @Name=\"DatadogAgent\"]",
 		"Microsoft-Windows-WMI-Activity/Operational": "*",
 	}
 	execTimeout = 30 * time.Second


### PR DESCRIPTION
### What does this PR do?

Add to the flare, the Agent core events from `Application` Event Viewer (Windows).

### Motivation

Provide more information for support cases.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

When creating a flare check that `Application.evtx` contains all the events from `Event Viewer` for both the trace agent and the core agent.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
