### PR TITLE
[release] Do not automatically bump external repo versions in release tasks

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -14,8 +14,10 @@ from datetime import date
 from invoke import Failure, task
 from invoke.exceptions import Exit
 
+from tasks.libs.common.color import color_message
 from tasks.utils import DEFAULT_BRANCH
 
+from .libs.common.user_interactions import yes_no_question
 from .modules import DEFAULT_MODULES
 
 
@@ -460,6 +462,25 @@ def _query_github_api(auth_token, url):
     return response
 
 
+def _confirm_external_repo_version(repo, latest_version, highest_release_json_version):
+    confirmed_version = highest_release_json_version
+    if latest_version != highest_release_json_version:
+        print(
+            color_message(
+                "The latest version of {} ({}) does not match the latest version found in the release.json file ({}).".format(
+                    repo, _stringify_version(latest_version), _stringify_version(highest_release_json_version)
+                ),
+                "orange",
+            )
+        )
+        if yes_no_question(
+            "Do you want to update {} to {}?".format(repo, _stringify_version(latest_version)), "orange", False
+        ):
+            confirmed_version = latest_version
+
+    return confirmed_version
+
+
 def _get_highest_repo_version(auth, repo, new_rc_version, version_re):
     if new_rc_version is not None:
         url = "https://api.github.com/repos/DataDog/{}/git/matching-refs/tags/{}{}".format(
@@ -874,6 +895,7 @@ def create_rc(
 
     if not jmxfetch_version:
         jmxfetch_version = _get_highest_repo_version(github_token, "jmxfetch", highest_jmxfetch_version, version_re)
+        jmxfetch_version = _confirm_external_repo_version("jmxfetch", jmxfetch_version, highest_jmxfetch_version)
     print("jmxfetch's tag is {}".format(_stringify_version(jmxfetch_version)))
 
     if not omnibus_ruby_version:
@@ -883,6 +905,9 @@ def create_rc(
     if not security_agent_policies_version:
         security_agent_policies_version = _get_highest_repo_version(
             github_token, "security-agent-policies", highest_security_agent_policies_version, version_re
+        )
+        security_agent_policies_version = _confirm_external_repo_version(
+            "security-agent-policies", security_agent_policies_version, highest_security_agent_policies_version
         )
     print("security-agent-policies' tag is {}".format(_stringify_version(security_agent_policies_version)))
 

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -741,6 +741,7 @@ def finish(
 
     if not jmxfetch_version:
         jmxfetch_version = _get_highest_repo_version(github_token, "jmxfetch", highest_jmxfetch_version, version_re)
+        jmxfetch_version = _confirm_external_repo_version("jmxfetch", jmxfetch_version, highest_jmxfetch_version)
     print("jmxfetch's tag is {}".format(_stringify_version(jmxfetch_version)))
 
     if not omnibus_ruby_version:
@@ -762,6 +763,9 @@ def finish(
     if not security_agent_policies_version:
         security_agent_policies_version = _get_highest_repo_version(
             github_token, "security-agent-policies", highest_security_agent_policies_version, version_re
+        )
+        security_agent_policies_version = _confirm_external_repo_version(
+            "security-agent-policies", security_agent_policies_version, highest_security_agent_policies_version
         )
     print("security-agent-policies' tag is {}".format(_stringify_version(security_agent_policies_version)))
 


### PR DESCRIPTION
### What does this PR do?

When `inv release.create-rc` or `inv release.finish` would change the version of an external repository (which doesn't follow the Agent's version scheme) in a new RC / release's entry, asks for user confirmation before proceeding.

### Motivation

Prevent silent (and sometimes unwanted) bumps of external dependencies.

### Describe how to test your changes

Run `inv release.create-rc` and `inv release.finish` with mock `release.json` entries that exhibit this behavior.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
