### PR TITLE
pkg/trace: fix obfuscation of Postgres queries using tilde operator

### DIFF
--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -805,19 +805,19 @@ LIMIT 1
 			`INSERT INTO table ( field1 ) VALUES ( ? )`,
 		},
 		{
-			query: `SELECT nspname FROM pg_class where nspname !~ '.*toIgnore.*'`,
+			query:    `SELECT nspname FROM pg_class where nspname !~ '.*toIgnore.*'`,
 			expected: `SELECT nspname FROM pg_class where nspname !~ ?`,
 		},
 		{
-			query: `SELECT nspname FROM pg_class where nspname !~* '.*toIgnoreInsensitive.*'`,
+			query:    `SELECT nspname FROM pg_class where nspname !~* '.*toIgnoreInsensitive.*'`,
 			expected: `SELECT nspname FROM pg_class where nspname !~* ?`,
 		},
 		{
-			query: `SELECT nspname FROM pg_class where nspname ~ '.*matching.*'`,
+			query:    `SELECT nspname FROM pg_class where nspname ~ '.*matching.*'`,
 			expected: `SELECT nspname FROM pg_class where nspname ~ ?`,
 		},
 		{
-			query: `SELECT nspname FROM pg_class where nspname ~* '.*matchingInsensitive.*'`,
+			query:    `SELECT nspname FROM pg_class where nspname ~* '.*matchingInsensitive.*'`,
 			expected: `SELECT nspname FROM pg_class where nspname ~* ?`,
 		},
 	}

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -804,10 +804,26 @@ LIMIT 1
 			`INSERT INTO table (field1) VALUES ($tag$random \wqejks "sadads' text$tag$)`,
 			`INSERT INTO table ( field1 ) VALUES ( ? )`,
 		},
+		{
+			query: `SELECT nspname FROM pg_class where nspname !~ '.*toIgnore.*'`,
+			expected: `SELECT nspname FROM pg_class where nspname !~ ?`,
+		},
+		{
+			query: `SELECT nspname FROM pg_class where nspname !~* '.*toIgnoreInsensitive.*'`,
+			expected: `SELECT nspname FROM pg_class where nspname !~* ?`,
+		},
+		{
+			query: `SELECT nspname FROM pg_class where nspname ~ '.*matching.*'`,
+			expected: `SELECT nspname FROM pg_class where nspname ~ ?`,
+		},
+		{
+			query: `SELECT nspname FROM pg_class where nspname ~* '.*matchingInsensitive.*'`,
+			expected: `SELECT nspname FROM pg_class where nspname ~* ?`,
+		},
 	}
 
 	for _, c := range cases {
-		t.Run("", func(t *testing.T) {
+		t.Run(c.query, func(t *testing.T) {
 			s := SQLSpan(c.query)
 			NewObfuscator(nil).Obfuscate(s)
 			assert.Equal(t, c.expected, s.Resource)

--- a/releasenotes/notes/apm-fix-sql-obfuscation-of-tilde-operator-8dd0109d436f211a.yaml
+++ b/releasenotes/notes/apm-fix-sql-obfuscation-of-tilde-operator-8dd0109d436f211a.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fix SQL obfuscation on postgres queries using the tilde operator.


### PR DESCRIPTION
### What does this PR do?

This fixes obfuscation failures happening on Postgres queries using the tilde operator ([POSIX regular expressions](https://www.postgresql.org/docs/current/functions-matching.html#FUNCTIONS-POSIX-REGEXP)). 

### Motivation

User reports of obfuscation failures. 

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Added simplified test queries inspired by more real world examples. 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
