### PR TITLE
Fix incorrect log source name when tailing docker containers from file 

### DIFF
--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -262,6 +262,9 @@ func (l *Launcher) getFileSource(container *Container, source *config.LogSource)
 	// Update parent source with additional information
 	sourceInfo.SetMessage(containerID, fmt.Sprintf("Container ID: %s, Image: %s, Created: %s, Tailing from file: %s", ShortContainerID(containerID), shortName, container.container.Created, l.getPath(containerID)))
 
+	// When ContainerCollectAll is not enabled, we try to derive the service and source names from container labels
+	// provided by AD (in this case, the parent source config). Otherwise we use the standard service or short image
+	// name for the service name and always use the short image name for the source name.
 	var serviceName string
 	if source.Name != config.ContainerCollectAll && source.Config.Service != "" {
 		serviceName = source.Config.Service

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -321,11 +321,11 @@ func newOverridenSource(standardService, shortName string, status *config.LogSta
 
 // startTailer starts a new tailer for the container matching with the source.
 func (l *Launcher) startTailer(container *Container, source *config.LogSource) {
-	// if l.shouldTailFromFile(container) {
-	l.scheduleFileSource(container, source)
-	// } else {
-	// 	l.startSocketTailer(container, source)
-	// }
+	if l.shouldTailFromFile(container) {
+		l.scheduleFileSource(container, source)
+	} else {
+		l.startSocketTailer(container, source)
+	}
 }
 
 func (l *Launcher) shouldTailFromFile(container *Container) bool {

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -271,11 +271,9 @@ func (l *Launcher) getFileSource(container *Container, source *config.LogSource)
 		serviceName = shortName
 	}
 
-	var sourceName string
+	sourceName := shortName
 	if source.Name != config.ContainerCollectAll && source.Config.Source != "" {
 		sourceName = source.Config.Source
-	} else {
-		sourceName = shortName
 	}
 
 	// New file source that inherit most of its parent properties

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -271,13 +271,20 @@ func (l *Launcher) getFileSource(container *Container, source *config.LogSource)
 		serviceName = shortName
 	}
 
+	var sourceName string
+	if source.Name != config.ContainerCollectAll && source.Config.Source != "" {
+		sourceName = source.Config.Source
+	} else {
+		sourceName = shortName
+	}
+
 	// New file source that inherit most of its parent properties
 	fileSource := config.NewLogSource(source.Name, &config.LogsConfig{
 		Type:            config.FileType,
 		Identifier:      containerID,
 		Path:            l.getPath(containerID),
 		Service:         serviceName,
-		Source:          shortName,
+		Source:          sourceName,
 		Tags:            source.Config.Tags,
 		ProcessingRules: source.Config.ProcessingRules,
 	})
@@ -314,11 +321,11 @@ func newOverridenSource(standardService, shortName string, status *config.LogSta
 
 // startTailer starts a new tailer for the container matching with the source.
 func (l *Launcher) startTailer(container *Container, source *config.LogSource) {
-	if l.shouldTailFromFile(container) {
-		l.scheduleFileSource(container, source)
-	} else {
-		l.startSocketTailer(container, source)
-	}
+	// if l.shouldTailFromFile(container) {
+	l.scheduleFileSource(container, source)
+	// } else {
+	// 	l.startSocketTailer(container, source)
+	// }
 }
 
 func (l *Launcher) shouldTailFromFile(container *Container) bool {

--- a/pkg/logs/input/docker/launcher_test.go
+++ b/pkg/logs/input/docker/launcher_test.go
@@ -120,6 +120,7 @@ func TestGetFileSource(t *testing.T) {
 		container       *Container
 		source          *config.LogSource
 		wantServiceName string
+		wantSourceName  string
 		wantPath        string
 		wantTags        []string
 		wantRules       []*config.ProcessingRule
@@ -136,8 +137,9 @@ func TestGetFileSource(t *testing.T) {
 				},
 				service: &service.Service{Identifier: "123456"},
 			},
-			source:          config.NewLogSource("from container", &config.LogsConfig{Service: "configServiceName", Tags: []string{"foo:bar", "foo:baz"}}),
+			source:          config.NewLogSource("from container", &config.LogsConfig{Service: "configServiceName", Source: "configSourceName", Tags: []string{"foo:bar", "foo:baz"}}),
 			wantServiceName: "configServiceName",
+			wantSourceName:  "configSourceName",
 			wantPath:        "/var/lib/docker/containers/123456/123456-json.log",
 			wantTags:        []string{"foo:bar", "foo:baz"},
 		},
@@ -153,8 +155,9 @@ func TestGetFileSource(t *testing.T) {
 				},
 				service: &service.Service{Identifier: "123456"},
 			},
-			source:          config.NewLogSource("from container", &config.LogsConfig{ProcessingRules: testRules}),
+			source:          config.NewLogSource("from container", &config.LogsConfig{ProcessingRules: testRules, Source: "stdSourceName"}),
 			wantServiceName: "stdServiceName",
+			wantSourceName:  "stdSourceName",
 			wantPath:        "/var/lib/docker/containers/123456/123456-json.log",
 			wantRules:       testRules,
 			wantTags:        nil,
@@ -169,6 +172,7 @@ func TestGetFileSource(t *testing.T) {
 			assert.Equal(t, config.FileType, fileSource.source.Config.Type)
 			assert.Equal(t, tt.container.service.Identifier, fileSource.source.Config.Identifier)
 			assert.Equal(t, tt.wantServiceName, fileSource.source.Config.Service)
+			assert.Equal(t, tt.wantSourceName, fileSource.source.Config.Source)
 			assert.Equal(t, tt.wantTags, fileSource.source.Config.Tags)
 			assert.Equal(t, tt.wantRules, fileSource.source.Config.ProcessingRules)
 		})

--- a/pkg/logs/input/docker/launcher_test.go
+++ b/pkg/logs/input/docker/launcher_test.go
@@ -120,6 +120,7 @@ func TestGetFileSource(t *testing.T) {
 		container       *Container
 		source          *config.LogSource
 		wantServiceName string
+		wantSourceName  string
 		wantPath        string
 		wantTags        []string
 		wantRules       []*config.ProcessingRule
@@ -136,8 +137,9 @@ func TestGetFileSource(t *testing.T) {
 				},
 				service: &service.Service{Identifier: "123456"},
 			},
-			source:          config.NewLogSource("from container", &config.LogsConfig{Service: "configServiceName", Tags: []string{"foo:bar", "foo:baz"}}),
+			source:          config.NewLogSource("from container", &config.LogsConfig{Service: "configServiceName", Source: "configSourceName", Tags: []string{"foo:bar", "foo:baz"}}),
 			wantServiceName: "configServiceName",
+			wantSourceName:  "configSourceName",
 			wantPath:        "/var/lib/docker/containers/123456/123456-json.log",
 			wantTags:        []string{"foo:bar", "foo:baz"},
 		},
@@ -153,8 +155,28 @@ func TestGetFileSource(t *testing.T) {
 				},
 				service: &service.Service{Identifier: "123456"},
 			},
-			source:          config.NewLogSource("from container", &config.LogsConfig{ProcessingRules: testRules}),
+			source:          config.NewLogSource("from container", &config.LogsConfig{ProcessingRules: testRules, Source: "stdSourceName"}),
 			wantServiceName: "stdServiceName",
+			wantSourceName:  "stdSourceName",
+			wantPath:        "/var/lib/docker/containers/123456/123456-json.log",
+			wantRules:       testRules,
+			wantTags:        nil,
+		},
+		{
+			name:  "Source and service name overide when container collec tall",
+			sFunc: func(n, e string) string { return "" },
+			container: &Container{
+				container: types.ContainerJSON{
+					ContainerJSONBase: &types.ContainerJSONBase{
+						Name:  "fooName",
+						Image: "fooImage",
+					},
+				},
+				service: &service.Service{Identifier: "123456"},
+			},
+			source:          config.NewLogSource(config.ContainerCollectAll, &config.LogsConfig{ProcessingRules: testRules, Source: "stdSourceName"}),
+			wantServiceName: "fooImage",
+			wantSourceName:  "fooImage",
 			wantPath:        "/var/lib/docker/containers/123456/123456-json.log",
 			wantRules:       testRules,
 			wantTags:        nil,
@@ -164,11 +186,13 @@ func TestGetFileSource(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			l := &Launcher{
 				serviceNameFunc: tt.sFunc,
+				collectAllInfo:  config.NewMappedInfo("Container Info"),
 			}
 			fileSource := l.getFileSource(tt.container, tt.source)
 			assert.Equal(t, config.FileType, fileSource.source.Config.Type)
 			assert.Equal(t, tt.container.service.Identifier, fileSource.source.Config.Identifier)
 			assert.Equal(t, tt.wantServiceName, fileSource.source.Config.Service)
+			assert.Equal(t, tt.wantSourceName, fileSource.source.Config.Source)
 			assert.Equal(t, tt.wantTags, fileSource.source.Config.Tags)
 			assert.Equal(t, tt.wantRules, fileSource.source.Config.ProcessingRules)
 		})

--- a/pkg/logs/input/docker/launcher_test.go
+++ b/pkg/logs/input/docker/launcher_test.go
@@ -163,7 +163,7 @@ func TestGetFileSource(t *testing.T) {
 			wantTags:        nil,
 		},
 		{
-			name:  "Source and service name overide when container collec tall",
+			name:  "Source and service name overide when container collect all",
 			sFunc: func(n, e string) string { return "" },
 			container: &Container{
 				container: types.ContainerJSON{

--- a/releasenotes/notes/fix-docker-log-source-when-tailing-from-file-086646718c05f2bb.yaml
+++ b/releasenotes/notes/fix-docker-log-source-when-tailing-from-file-086646718c05f2bb.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    When tailing logs from docker with `DD_LOGS_CONFIG_DOCKER_CONTAINER_USE_FILE=true` and a 
+    source container label is set the agent will now respect that label and use it as the source. 
+    This aligns the behavior with tailing from the docker socket. 


### PR DESCRIPTION
### What does this PR do?

When running a container (with AD labels) with`DD_LOGS_CONFIG_DOCKER_CONTAINER_USE_FILE=true` the `source` from the container label is not taken into account. 

This was because when tailing as a file we were using the container short image name and not looking at the parent (docker derived) source for the container label. 

This change ensure the labels are respected in file tailing mode.

## QA

Run the agent: 
```
docker run --rm -ti --net=host \
-e DD_API_KEY=<API_KEY> \
-e DD_LOGS_ENABLED=true \
-e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=false \
-e DD_LOGS_CONFIG_DOCKER_CONTAINER_USE_FILE=true \
-e DD_CONTAINER_EXCLUDE="image:agent" \
-v /var/run/docker.sock:/var/run/docker.sock:ro \
-v /proc/:/host/proc/:ro \
-v /opt/datadog-agent/run:/opt/datadog-agent/run:rw \
-v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
-v /var/lib/docker/containers:/var/lib/docker/containers:ro \
datadog/agent:<RC tag>
```

Also test with

```
-e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true
```

Start a logging container:

```
docker run -it --label com.datadoghq.ad.logs='[{"source": "customLogger", "service": "mylogger"}]' debian  /bin/bash -c 'i=0; while true; do echo "$i this is a log line"; sleep 1; i=$(($i+1)); done'
```

Ensure in app that the source of the log is `customLogger` and NOT `debian`. 

Also probably worth spot checking container_collect_all to ensure nothing changed. 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
