### PR TITLE
[gitlab] Don't ignore Windows kitchen test failures

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -15,8 +15,7 @@ cluster_agent_cloudfoundry-build*    @Datadog/integrations-tools-and-libs
 cluster_agent-build*                 @DataDog/container-integrations
 
 # Kitchen testing
-# Don't notify on kitchen Windows tests since they are too flaky
-kitchen_windows_*                    @DataDog/do-not-notify
+kitchen_windows_*                    @DataDog/agent-platform
 
 # Image build
 docker_build*                        @DataDog/container-integrations

--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -14,9 +14,6 @@ build_system-probe*                  @DataDog/agent-network
 cluster_agent_cloudfoundry-build*    @Datadog/integrations-tools-and-libs
 cluster_agent-build*                 @DataDog/container-integrations
 
-# Kitchen testing
-kitchen_windows_*                    @DataDog/agent-platform
-
 # Image build
 docker_build*                        @DataDog/container-integrations
 


### PR DESCRIPTION
### What does this PR do?

Since https://github.com/DataDog/datadog-agent/pull/8344 has been merged, we haven't seen any failures due to flaky infrastructure/network. Therefore let's enable notifications for Windows kitchen test failures to the agent-platform channel.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
