### PR TITLE
[backport] [kitchen] Update system file check exclusion list with catroot2 folder

### DIFF
--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -782,6 +782,7 @@ shared_examples_for 'an Agent that is removed' do
             'C:/Windows/WinSxS/',
             'C:/Windows/Logs/',
             'C:/Windows/servicing/',
+            'c:/Windows/System32/catroot2/',
             'c:/windows/System32/config/',
             'C:/Windows/ServiceProfiles/NetworkService/AppData/Local/Microsoft/Windows/DeliveryOptimization/Logs/',
             'C:/Windows/ServiceProfiles/NetworkService/AppData/Local/Microsoft/Windows/DeliveryOptimization/Cache/',


### PR DESCRIPTION

### What does this PR do?

Backport of #8456.
Adds c:/Windows/System32/catroot2/ folder to the exclusion list when checking system files.

### Motivation

Fix 7.29.0 release.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
