### PR TITLE
[Tagger] Stop re-collecting of exited docker containers

### DIFF
--- a/releasenotes/notes/tagger-docker-memory-growth-16d28a326903c72f.yaml
+++ b/releasenotes/notes/tagger-docker-memory-growth-16d28a326903c72f.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Agent collecting Docker containers on hosts with a lot of container churn
+    now uses less memory by properly purging the respective tags after the
+    containers exit. Other container runtimes were not affected by the issue.


### PR DESCRIPTION
### What does this PR do?

A customer has complained that some agent containers were getting
OOM-killed due to memory growth that looked like a memory leak.
Investigating a flare from one of these agents, we noticed that it had
entities with tags only from the docker collector, but not from the
kubelet or kube-metadata-collector.

After investigation, it turned out that tags from the docker collector
were being deleted properly, but they were collected again shortly
after, caused by a `tagger.Tag` cache miss. The `Fetch` method did not
make any distinctions between started and exited containers, and would
return tags for exited containers when it actually shouldn't. Since the
container had already exited, no `died` events were received for it
anymore, and the entity would live forever.

This change adds an option to `fetchForDockerID` to allow exited
containers to be skipped, and `Fetch` uses that to prevent
re-introducing entities that no longer exist.

### Describe how to test your changes

This needs to be tested on a k8s cluster running docker (you can get one by enabling it in Docker Desktop). The easiest way is to create a minutely cronjob, and ensure with `agent tagger-list` that the entities for completed jobs get cleaned up after ~5 minutes.

Also, you can check that after ~10 minutes the number of entities has stopped growing. I've used this command:

```
while true; do kubectl exec $AGENT_POD -c agent -- agent tagger-list | grep Entity | wc -l; sleep 60; done
```