### PR TITLE
Lower log level of trace info stats to debug

### DIFF
--- a/pkg/trace/info/stats.go
+++ b/pkg/trace/info/stats.go
@@ -98,14 +98,14 @@ func (rs *ReceiverStats) LogStats() {
 	defer rs.RUnlock()
 
 	if len(rs.Stats) == 0 {
-		log.Info("No data received")
+		log.Debug("No data received")
 		return
 	}
 
 	for _, ts := range rs.Stats {
 		if !ts.isEmpty() {
 			tags := ts.Tags.toArray()
-			log.Infof("%v -> %s", tags, ts.infoString())
+			log.Debugf("%v -> %s", tags, ts.infoString())
 			warnString := ts.WarnString()
 			if len(warnString) > 0 {
 				log.Warnf("%v -> %s. Enable debug logging for more details.", tags, warnString)

--- a/releasenotes/notes/apm-lower-log-level-of-trace-info-stats-fd1d405c815b3a8d.yaml
+++ b/releasenotes/notes/apm-lower-log-level-of-trace-info-stats-fd1d405c815b3a8d.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    APM: Trace info stats now have the 'debug' log level instead of the 'info' log level.


### PR DESCRIPTION
### What does this PR do?

Lowers the log level of trace info stats from `info` to `debug`.

### Motivation

Around two out of three of the info logs from the Datadog agents are these trace info stats. They are handy for debugging, but are not always needed. Also the ingestion of these logs is not free.

### Additional Notes

These changes still allow for debugging trace stats by putting the agent in [debug mode](https://docs.datadoghq.com/agent/troubleshooting/debug_mode/).

### Describe how to test your changes

Running the Datadog agent in [debug mode](https://docs.datadoghq.com/agent/troubleshooting/debug_mode/) shows the logs. They are not shown when running the agent with a log level of `info` or higher.