### PR TITLE
[cgroups] incorporate cpuset in cpu limit

### DIFF
--- a/pkg/util/containers/providers/cgroup/cgroup_metrics.go
+++ b/pkg/util/containers/providers/cgroup/cgroup_metrics.go
@@ -266,7 +266,8 @@ func (c ContainerCgroup) CPUPeriods() (throttledNr uint64, throttledTime float64
 
 // CPULimit would show CPU limit for this cgroup.
 // It does so by checking the cpu period and cpu quota config
-// if a user does this:
+// or cpuset if CPUs are pinned.
+// If a user does this:
 //
 //	docker run --cpus='0.5' ubuntu:latest
 //
@@ -274,28 +275,49 @@ func (c ContainerCgroup) CPUPeriods() (throttledNr uint64, throttledTime float64
 //
 // However cfs_period_us is per CPU, which means that
 //
-// docker run --cpu='2' ubuntu:latest
+// docker run --cpus='2' ubuntu:latest
 //
 // Will yield 200% (cfs_period_us = 100000, cfs_quota_us = 200000)
+//
+// If a user does:
+//
+// docker run --cpuset-cpus='1,3' ubuntu:latest
+//
+// we should return 200%
+//
+// In the case that both CFS quota and CPU sets are defined, we take the minimum.
 //
 // If the limits files aren't available (on older version) then
 // we'll return the default value of numCPU * 100.
 func (c ContainerCgroup) CPULimit() (float64, error) {
-	limit := float64(system.HostCPUCount()) * 100.0
+	defaultLimit := float64(system.HostCPUCount()) * 100.0
+	limitFromCPUSet := float64(-1)
+	limitFromQuota := float64(-1)
+
+	cpusetFile := c.cgroupFilePath("cpuset", "cpuset.cpus")
+	cpuLines, err := readLines(cpusetFile)
+	if os.IsNotExist(err) {
+		log.Debugf("Missing cgroup file: %s", cpusetFile)
+	} else {
+		numCPUs := parseCPUSetFile(cpuLines)
+		if numCPUs > 0 {
+			limitFromCPUSet = float64(numCPUs) * 100.0
+		}
+	}
 
 	periodFile := c.cgroupFilePath("cpu", "cpu.cfs_period_us")
 	quotaFile := c.cgroupFilePath("cpu", "cpu.cfs_quota_us")
 	plines, err := readLines(periodFile)
 	if os.IsNotExist(err) {
 		log.Debugf("Missing cgroup file: %s", periodFile)
-		return limit, nil
+		return defaultLimit, nil
 	} else if err != nil {
 		return 0, err
 	}
 	qlines, err := readLines(quotaFile)
 	if os.IsNotExist(err) {
 		log.Debugf("Missing cgroup file: %s", quotaFile)
-		return limit, nil
+		return defaultLimit, nil
 	} else if err != nil {
 		return 0, err
 	}
@@ -334,9 +356,23 @@ func (c ContainerCgroup) CPULimit() (float64, error) {
 
 	// default cpu limit is 100%
 	if (period > 0) && (quota > 0) {
-		limit = quota / period * 100.0
+		limitFromQuota = quota / period * 100.0
 	}
-	return limit, nil
+
+	// Return min of limitFromCPUSet and limitFromQuota. If they are both -1, return default
+	if limitFromCPUSet == -1 && limitFromQuota == -1 {
+		return defaultLimit, nil
+	}
+
+	if limitFromCPUSet == -1 {
+		return limitFromQuota, nil
+	}
+
+	if limitFromQuota == -1 {
+		return limitFromCPUSet, nil
+	}
+
+	return math.Min(limitFromQuota, limitFromCPUSet), nil
 }
 
 // IO returns the disk read and write bytes stats for this cgroup.

--- a/pkg/util/containers/providers/cgroup/cgroup_metrics.go
+++ b/pkg/util/containers/providers/cgroup/cgroup_metrics.go
@@ -296,10 +296,12 @@ func (c ContainerCgroup) CPULimit() (float64, error) {
 
 	cpusetFile := c.cgroupFilePath("cpuset", "cpuset.cpus")
 	cpuLines, err := readLines(cpusetFile)
-	if os.IsNotExist(err) {
-		log.Debugf("Missing cgroup file: %s", cpusetFile)
-	} else if err != nil {
-		return 0, err
+	if err != nil {
+		if os.IsNotExist(err) {
+			log.Debugf("Missing cgroup file: %s", cpusetFile)
+		} else {
+			return 0, err
+		}
 	} else {
 		numCPUs := parseCPUSetFile(cpuLines)
 		if numCPUs > 0 {

--- a/pkg/util/containers/providers/cgroup/cgroup_metrics.go
+++ b/pkg/util/containers/providers/cgroup/cgroup_metrics.go
@@ -298,6 +298,8 @@ func (c ContainerCgroup) CPULimit() (float64, error) {
 	cpuLines, err := readLines(cpusetFile)
 	if os.IsNotExist(err) {
 		log.Debugf("Missing cgroup file: %s", cpusetFile)
+	} else if err != nil {
+		return 0, err
 	} else {
 		numCPUs := parseCPUSetFile(cpuLines)
 		if numCPUs > 0 {

--- a/pkg/util/containers/providers/cgroup/cgroup_metrics_test.go
+++ b/pkg/util/containers/providers/cgroup/cgroup_metrics_test.go
@@ -39,6 +39,31 @@ func TestCPU(t *testing.T) {
 	assert.InDelta(t, timeStat.UsageTotal, 91526.6418275, 0.0000001)
 }
 
+func TestCPULimit(t *testing.T) {
+	tempFolder, err := newTempFolder("cpu-limit")
+	assert.Nil(t, err)
+	defer tempFolder.removeAll()
+
+	// CFS period and quota
+	tempFolder.add("cpu/cpu.cfs_period_us", "100000")
+	tempFolder.add("cpu/cpu.cfs_quota_us", "600000")
+
+	cgroup := newDummyContainerCgroup(tempFolder.RootPath, "cpu")
+	cpuLimit, err := cgroup.CPULimit()
+
+	assert.Nil(t, err)
+	assert.Equal(t, cpuLimit, float64(600))
+
+	// CPU set
+	tempFolder.add("cpuset/cpuset.cpus", "0-4")
+
+	cgroup = newDummyContainerCgroup(tempFolder.RootPath, "cpu", "cpuset")
+	cpuLimit, err = cgroup.CPULimit()
+
+	assert.Nil(t, err)
+	assert.Equal(t, cpuLimit, float64(500))
+}
+
 func TestCPUNrThrottled(t *testing.T) {
 	tempFolder, err := newTempFolder("cpu-throttled")
 	assert.Nil(t, err)

--- a/pkg/util/containers/providers/cgroup/common.go
+++ b/pkg/util/containers/providers/cgroup/common.go
@@ -78,7 +78,7 @@ func parseCPUSetFile(lines []string) int {
 			p1, _ := strconv.Atoi(lineParts[1])
 			numCPUs += p1 - p0 + 1
 		} else if len(lineParts) == 1 {
-			numCPUs += 1
+			numCPUs++
 		}
 	}
 

--- a/pkg/util/containers/providers/cgroup/common.go
+++ b/pkg/util/containers/providers/cgroup/common.go
@@ -11,6 +11,8 @@ import (
 	"bufio"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
@@ -54,4 +56,31 @@ func pathExists(filename string) bool {
 		return true
 	}
 	return false
+}
+
+func parseCPUSetFile(lines []string) int {
+	numCPUs := 0
+	if len(lines) == 0 {
+		return numCPUs
+	}
+	// File contents should be only one line so assume this is the case.
+	line := lines[0]
+
+	// Examples of List Format:
+	//		0-5
+	//		0-4,9
+	//		0-2,7,12-14
+	lineSlice := strings.Split(line, ",")
+	for _, l := range lineSlice {
+		lineParts := strings.Split(l, "-")
+		if len(lineParts) == 2 {
+			p0, _ := strconv.Atoi(lineParts[0])
+			p1, _ := strconv.Atoi(lineParts[1])
+			numCPUs += p1 - p0 + 1
+		} else if len(lineParts) == 1 {
+			numCPUs += 1
+		}
+	}
+
+	return numCPUs
 }

--- a/pkg/util/containers/providers/cgroup/common_test.go
+++ b/pkg/util/containers/providers/cgroup/common_test.go
@@ -13,6 +13,9 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type tempFolder struct {
@@ -104,4 +107,31 @@ func detab(str string) string {
 		}
 	}
 	return strings.Join(detabbed, "\n")
+}
+
+// Unit tests
+
+func Test_parseCPUSetFile(t *testing.T) {
+	for _, tc := range []struct {
+		input []string
+		want  int
+	}{
+		{
+			input: []string{"0-5"},
+			want:  6,
+		},
+		{
+			input: []string{"0-4,9"},
+			want:  6,
+		},
+		{
+			input: []string{"0-2,7,12-14"},
+			want:  7,
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			numCPUs := parseCPUSetFile(tc.input)
+			assert.Equal(t, tc.want, numCPUs)
+		})
+	}
 }

--- a/releasenotes/notes/use-cpuset-in-cgroups-cpu-limit-de684c90d829a42e.yaml
+++ b/releasenotes/notes/use-cpuset-in-cgroups-cpu-limit-de684c90d829a42e.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Consider pinned CPUs (cpusets) when calculating CPU limit from cgroups.


### PR DESCRIPTION
### What does this PR do?

Update CPU limit calculation from cgroups to include cpuset information. Previously we computed CPU limit from CFS Quota and CFS Period. Now we also take into consideration pinned CPUs (cpusets) and return the minimum between the two calculations.

### Motivation

More accurate information for improved user experience

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

1. Run minikube with the static CPU manager policy: ```minikube start --extra-config=kubelet.cpu-manager-policy=static --extra-config=kubelet.reserved-cpus=2```
1. Run agent daemonset with process agent enabled
1. Run an application pod in Guaranteed QoS by setting the CPU requests and limits and memory requests and limits to the same values. A suggestion is to use an image with a process that can be run with a configurable cpu:
```
  containers:
      - image: vboulineau/stress-ng
        args: ["-t", "0", "--cpu", "1"]
```
1. On Live Containers page, make sure CPU percentage reports as expected

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
