### PR TITLE
[config] Fix default of logs_config.expected_tags_duration

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -662,7 +662,7 @@ func InitConfig(config Config) {
 	config.BindEnv("logs_config.api_key") //nolint:errcheck
 
 	// Duration during which the host tags will be submitted with log events.
-	config.BindEnvAndSetDefault("logs_config.expected_tags_duration", 0) // duration-formatted string (parsed by `time.ParseDuration`)
+	config.BindEnvAndSetDefault("logs_config.expected_tags_duration", time.Duration(0)) // duration-formatted string (parsed by `time.ParseDuration`)
 	// send the logs to the port 443 of the logs-backend via TCP:
 	config.BindEnvAndSetDefault("logs_config.use_port_443", false)
 	// increase the read buffer size of the UDP sockets:


### PR DESCRIPTION
### What does this PR do?

Fixes `logs_config.expected_tags_duration` option in `config.AllSettings()`'s output, by settings its default value to the correct `time.Duration` type.

### Motivation

Actually allows the setting to be set as a duration-formatted string when:

- the secret resolution feature is used, or
- more generally, when the value is displayed in `agent config`'s output

The reason for this behavior is that `AllSettings()` relies on the type of the default
value of the config option to cast the option's value. If the default is an int, and the option
is set to a duration-formatted string, then `AllSettings()` casts the string
to an int which results in a resolved int value of `0` whatever string value
was set in config.

Since secret resolution relies on this default casting behavior of `AllSettings()` (for example to transform space-separated env var string values into actual lists), we need to ensure that all default values define the expected type for their respective config options, instead of trying to change `AllSettings()`' behavior.

### Additional Notes

No changelog, this is an undocumented option.

### Describe how to test your changes

Difficult change to unit test meaningfully.

QA:

1. set `logs_config.expected_tags_duration` to `10m` in agent config, and restart agent
2. run `agent config` command, and confirm that `logs_config.expected_tags_duration` is set to `10m` (or a duration-formatted string with the same semantic value, such as `10m0s`)

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.