### PR TITLE
Report container inclusion/exclusion errors in agent status

### DIFF
--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -49,7 +49,8 @@ func FormatStatus(data []byte) (string, error) {
 	inventoriesStats := stats["inventories"]
 	systemProbeStats := stats["systemProbeStats"]
 	snmpTrapsStats := stats["snmpTrapsStats"]
-	autodiscoveryErrors := stats["autodiscoveryErrors"]
+	adConfigErrors := stats["adConfigErrors"]
+	filterErrors := stats["filterErrors"]
 	title := fmt.Sprintf("Agent (v%s)", stats["version"])
 	stats["title"] = title
 	renderStatusTemplate(b, "/header.tmpl", stats)
@@ -71,7 +72,7 @@ func FormatStatus(data []byte) (string, error) {
 		renderStatusTemplate(b, "/snmp-traps.tmpl", snmpTrapsStats)
 	}
 	if config.IsContainerized() {
-		renderStatusTemplate(b, "/autodiscovery.tmpl", autodiscoveryErrors)
+		renderAutodiscoveryStats(b, adConfigErrors, filterErrors)
 	}
 
 	return b.String(), nil
@@ -185,6 +186,13 @@ func renderRuntimeSecurityStats(w io.Writer, runtimeSecurityStatus interface{}) 
 	status := make(map[string]interface{})
 	status["RuntimeSecurityStatus"] = runtimeSecurityStatus
 	renderStatusTemplate(w, "/runtimesecurity.tmpl", status)
+}
+
+func renderAutodiscoveryStats(w io.Writer, adConfigErrors interface{}, filterErrors interface{}) {
+	autodiscoveryStats := make(map[string]interface{})
+	autodiscoveryStats["adConfigErrors"] = adConfigErrors
+	autodiscoveryStats["FilterErrors"] = filterErrors
+	renderStatusTemplate(w, "/autodiscovery.tmpl", autodiscoveryStats)
 }
 
 func renderStatusTemplate(w io.Writer, templateName string, stats interface{}) {

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -49,8 +49,6 @@ func FormatStatus(data []byte) (string, error) {
 	inventoriesStats := stats["inventories"]
 	systemProbeStats := stats["systemProbeStats"]
 	snmpTrapsStats := stats["snmpTrapsStats"]
-	adConfigErrors := stats["adConfigErrors"]
-	filterErrors := stats["filterErrors"]
 	title := fmt.Sprintf("Agent (v%s)", stats["version"])
 	stats["title"] = title
 	renderStatusTemplate(b, "/header.tmpl", stats)
@@ -72,7 +70,7 @@ func FormatStatus(data []byte) (string, error) {
 		renderStatusTemplate(b, "/snmp-traps.tmpl", snmpTrapsStats)
 	}
 	if config.IsContainerized() {
-		renderAutodiscoveryStats(b, adConfigErrors, filterErrors)
+		renderAutodiscoveryStats(b, stats["adConfigErrors"], stats["filterErrors"])
 	}
 
 	return b.String(), nil
@@ -191,7 +189,7 @@ func renderRuntimeSecurityStats(w io.Writer, runtimeSecurityStatus interface{}) 
 func renderAutodiscoveryStats(w io.Writer, adConfigErrors interface{}, filterErrors interface{}) {
 	autodiscoveryStats := make(map[string]interface{})
 	autodiscoveryStats["adConfigErrors"] = adConfigErrors
-	autodiscoveryStats["FilterErrors"] = filterErrors
+	autodiscoveryStats["filterErrors"] = filterErrors
 	renderStatusTemplate(w, "/autodiscovery.tmpl", autodiscoveryStats)
 }
 

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -25,6 +25,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/snmp/traps"
 	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -83,7 +84,8 @@ func GetStatus() (map[string]interface{}, error) {
 	}
 
 	if config.IsContainerized() {
-		stats["autodiscoveryErrors"] = common.AC.GetAutodiscoveryErrors()
+		stats["adConfigErrors"] = common.AC.GetAutodiscoveryErrors()
+		stats["filterErrors"] = containers.GetFilterErrors()
 	}
 
 	return stats, nil

--- a/pkg/status/templates/autodiscovery.tmpl
+++ b/pkg/status/templates/autodiscovery.tmpl
@@ -3,7 +3,7 @@ NOTE: Changes made to this template should be reflected on the following templat
 * cmd/agent/gui/views/templates/generalStatus.tmpl
 */}}
 
-{{- if or .adConfigErrors .FilterErrors}}
+{{- if or .adConfigErrors .filterErrors}}
 =============
 Autodiscovery
 =============
@@ -23,9 +23,9 @@ Autodiscovery
   {{- end }}
 {{- end }}
 
-{{- with .FilterErrors }}
-  Inclusion/Exclusion Errors
-  ==========================
+{{- with .filterErrors }}
+  Container Inclusion/Exclusion Errors
+  ====================================
   {{ range $filtererror, $empty := . }}
     {{ $filtererror }}
   {{- end }}

--- a/pkg/status/templates/autodiscovery.tmpl
+++ b/pkg/status/templates/autodiscovery.tmpl
@@ -3,13 +3,13 @@ NOTE: Changes made to this template should be reflected on the following templat
 * cmd/agent/gui/views/templates/generalStatus.tmpl
 */}}
 
-{{- with . }}
+{{- if or .adConfigErrors .FilterErrors}}
 =============
 Autodiscovery
 =============
-
-  Errors
-  ======
+{{ with .adConfigErrors}}
+  Configuration Errors
+  ====================
   {{- range $configprovider, $configerrors := . }}
   {{ if $configerrors }}
     {{- range $identifier, $errmap := $configerrors }}
@@ -21,4 +21,13 @@ Autodiscovery
     {{ end }}
   {{- end }}
   {{- end }}
+{{- end }}
+
+{{- with .FilterErrors }}
+  Inclusion/Exclusion Errors
+  ==========================
+  {{ range $filtererror, $empty := . }}
+    {{ $filtererror }}
+  {{- end }}
+{{- end }}
 {{- end }}

--- a/pkg/util/containers/filter.go
+++ b/pkg/util/containers/filter.go
@@ -154,7 +154,7 @@ func ResetSharedFilter() {
 func GetFilterErrors() map[string]struct{} {
 	filter, _ := newMetricFilterFromConfig()
 	logFilter, _ := NewAutodiscoveryFilter(LogsFilter)
-	for err, _ := range logFilter.Errors {
+	for err := range logFilter.Errors {
 		filter.Errors[err] = struct{}{}
 	}
 	return filter.Errors

--- a/pkg/util/containers/filter_test.go
+++ b/pkg/util/containers/filter_test.go
@@ -6,6 +6,9 @@
 package containers
 
 import (
+	"errors"
+	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -401,6 +404,158 @@ func TestNewAutodiscoveryFilter(t *testing.T) {
 	assert.False(t, f.IsExcluded("dummy", "k8s.gcr.io/pause-amd64:3.1", ""))
 	assert.False(t, f.IsExcluded("dummy", "rancher/pause-amd64:3.1", ""))
 	resetConfig()
+
+	// Filter errors - non-duplicate error messages
+	config.Datadog.SetDefault("container_include", []string{"image:apache.*", "invalid"})
+	config.Datadog.SetDefault("container_exclude", []string{"name:dd-.*", "invalid"})
+
+	f, err = NewAutodiscoveryFilter(GlobalFilter)
+	require.NoError(t, err)
+
+	assert.True(t, f.IsExcluded("dd-152462", "dummy:latest", ""))
+	assert.False(t, f.IsExcluded("dd-152462", "apache:latest", ""))
+	assert.False(t, f.IsExcluded("dummy", "dummy", ""))
+	assert.False(t, f.IsExcluded("dummy", "k8s.gcr.io/pause-amd64:3.1", ""))
+	assert.False(t, f.IsExcluded("dummy", "rancher/pause-amd64:3.1", ""))
+	fe := map[string]struct{}{
+		"Container filter \"invalid\" is unknown, ignoring it. The supported filters are 'image', 'name' and 'kube_namespace'": {},
+	}
+	assert.Equal(t, fe, GetFilterErrors())
+	resetFilterErrors()
+	resetConfig()
+
+	// Filter errors - invalid regex
+	config.Datadog.SetDefault("container_include", []string{"image:apache.*", "kube_namespace:?"})
+	config.Datadog.SetDefault("container_exclude", []string{"name:dd-.*", "invalid"})
+
+	f, err = NewAutodiscoveryFilter(GlobalFilter)
+	assert.Error(t, err, errors.New("invalid regex '?': error parsing regexp: missing argument to repetition operator: `?`"))
+	assert.Nil(t, f)
+	fe = map[string]struct{}{
+		"invalid regex '?': error parsing regexp: missing argument to repetition operator: `?`":                                {},
+		"Container filter \"invalid\" is unknown, ignoring it. The supported filters are 'image', 'name' and 'kube_namespace'": {},
+	}
+	assert.Equal(t, fe, GetFilterErrors())
+	resetFilterErrors()
+	resetConfig()
+}
+
+func TestValidateFilter(t *testing.T) {
+	for filters, tc := range []struct {
+		desc           string
+		filter         string
+		prefix         string
+		expectedRegexp *regexp.Regexp
+		expectedErr    error
+	}{
+		{
+			desc:           "image filter",
+			filter:         "image:apache.*",
+			prefix:         imageFilterPrefix,
+			expectedRegexp: regexp.MustCompile("apache.*"),
+			expectedErr:    nil,
+		},
+		{
+			desc:           "name filter",
+			filter:         "name:dd-.*",
+			prefix:         nameFilterPrefix,
+			expectedRegexp: regexp.MustCompile("dd-.*"),
+			expectedErr:    nil,
+		},
+		{
+			desc:           "kube_namespace filter",
+			filter:         "kube_namespace:monitoring",
+			prefix:         kubeNamespaceFilterPrefix,
+			expectedRegexp: regexp.MustCompile("monitoring"),
+			expectedErr:    nil,
+		},
+		{
+			desc:           "empty filter regex",
+			filter:         "image:",
+			prefix:         imageFilterPrefix,
+			expectedRegexp: regexp.MustCompile(""),
+			expectedErr:    nil,
+		},
+		{
+			desc:           "invalid golang regex",
+			filter:         "image:?",
+			prefix:         imageFilterPrefix,
+			expectedRegexp: nil,
+			expectedErr:    errors.New("invalid regex '?': error parsing regexp: missing argument to repetition operator: `?`"),
+		},
+	} {
+		t.Run(fmt.Sprintf("case %d: %s", filters, tc.desc), func(t *testing.T) {
+			r, err := validateFilter(tc.filter, tc.prefix)
+			assert.Equal(t, tc.expectedRegexp, r)
+			assert.Equal(t, tc.expectedErr, err)
+		})
+	}
+}
+
+func TestParseFilters(t *testing.T) {
+	for filters, tc := range []struct {
+		desc             string
+		filters          []string
+		imageFilters     []*regexp.Regexp
+		nameFilters      []*regexp.Regexp
+		namespaceFilters []*regexp.Regexp
+		expectedErrMsg   error
+		filterErrors     []string
+	}{
+		{
+			desc:             "valid filters",
+			filters:          []string{"image:nginx.*", "name:xyz-.*", "kube_namespace:sandbox.*", "name:abc"},
+			imageFilters:     []*regexp.Regexp{regexp.MustCompile("nginx.*")},
+			nameFilters:      []*regexp.Regexp{regexp.MustCompile("xyz-.*"), regexp.MustCompile("abc")},
+			namespaceFilters: []*regexp.Regexp{regexp.MustCompile("sandbox.*")},
+			expectedErrMsg:   nil,
+			filterErrors:     nil,
+		},
+		{
+			desc:             "invalid regex",
+			filters:          []string{"image:apache.*", "name:a(?=b)", "kube_namespace:sandbox.*", "name:abc"},
+			imageFilters:     nil,
+			nameFilters:      nil,
+			namespaceFilters: nil,
+			expectedErrMsg:   errors.New("invalid regex 'a(?=b)': error parsing regexp: invalid or unsupported Perl syntax: `(?=`"),
+			filterErrors:     []string{"invalid regex 'a(?=b)': error parsing regexp: invalid or unsupported Perl syntax: `(?=`"},
+		},
+		{
+			desc:             "invalid filter prefix, valid regex",
+			filters:          []string{"image:redis.*", "invalid", "name:dd-.*", "kube_namespace:dev-.*", "name:abc", "also invalid"},
+			imageFilters:     []*regexp.Regexp{regexp.MustCompile("redis.*")},
+			nameFilters:      []*regexp.Regexp{regexp.MustCompile("dd-.*"), regexp.MustCompile("abc")},
+			namespaceFilters: []*regexp.Regexp{regexp.MustCompile("dev-.*")},
+			expectedErrMsg:   nil,
+			filterErrors: []string{
+				"Container filter \"invalid\" is unknown, ignoring it. The supported filters are 'image', 'name' and 'kube_namespace'",
+				"Container filter \"also invalid\" is unknown, ignoring it. The supported filters are 'image', 'name' and 'kube_namespace'",
+			},
+		},
+		{
+			desc:             "invalid regex and invalid filter prefix",
+			filters:          []string{"invalid", "name:a(?=b)", "image:apache.*", "kube_namespace:?", "also invalid", "name:abc"},
+			imageFilters:     nil,
+			nameFilters:      nil,
+			namespaceFilters: nil,
+			expectedErrMsg:   errors.New("invalid regex 'a(?=b)': error parsing regexp: invalid or unsupported Perl syntax: `(?=`"),
+			filterErrors: []string{
+				"invalid regex 'a(?=b)': error parsing regexp: invalid or unsupported Perl syntax: `(?=`",
+				"invalid regex '?': error parsing regexp: missing argument to repetition operator: `?`",
+				"Container filter \"invalid\" is unknown, ignoring it. The supported filters are 'image', 'name' and 'kube_namespace'",
+				"Container filter \"also invalid\" is unknown, ignoring it. The supported filters are 'image', 'name' and 'kube_namespace'",
+			},
+		},
+	} {
+		t.Run(fmt.Sprintf("case %d: %s", filters, tc.desc), func(t *testing.T) {
+			imageFilters, nameFilters, namespaceFilters, filterErrors, err := parseFilters(tc.filters)
+			assert.Equal(t, tc.imageFilters, imageFilters)
+			assert.Equal(t, tc.nameFilters, nameFilters)
+			assert.Equal(t, tc.namespaceFilters, namespaceFilters)
+			assert.Equal(t, tc.filterErrors, filterErrors)
+			assert.Equal(t, tc.expectedErrMsg, err)
+		})
+	}
 }
 
 func resetConfig() {

--- a/pkg/util/containers/filter_test.go
+++ b/pkg/util/containers/filter_test.go
@@ -421,7 +421,7 @@ func TestNewAutodiscoveryFilter(t *testing.T) {
 		"Container filter \"invalid\" is unknown, ignoring it. The supported filters are 'image', 'name' and 'kube_namespace'": {},
 	}
 	assert.Equal(t, fe, GetFilterErrors())
-	resetFilterErrors()
+	ResetSharedFilter()
 	resetConfig()
 
 	// Filter errors - invalid regex
@@ -430,13 +430,13 @@ func TestNewAutodiscoveryFilter(t *testing.T) {
 
 	f, err = NewAutodiscoveryFilter(GlobalFilter)
 	assert.Error(t, err, errors.New("invalid regex '?': error parsing regexp: missing argument to repetition operator: `?`"))
-	assert.Nil(t, f)
+	assert.NotNil(t, f)
 	fe = map[string]struct{}{
 		"invalid regex '?': error parsing regexp: missing argument to repetition operator: `?`":                                {},
 		"Container filter \"invalid\" is unknown, ignoring it. The supported filters are 'image', 'name' and 'kube_namespace'": {},
 	}
 	assert.Equal(t, fe, GetFilterErrors())
-	resetFilterErrors()
+	ResetSharedFilter()
 	resetConfig()
 }
 
@@ -485,7 +485,7 @@ func TestValidateFilter(t *testing.T) {
 		},
 	} {
 		t.Run(fmt.Sprintf("case %d: %s", filters, tc.desc), func(t *testing.T) {
-			r, err := validateFilter(tc.filter, tc.prefix)
+			r, err := filterToRegex(tc.filter, tc.prefix)
 			assert.Equal(t, tc.expectedRegexp, r)
 			assert.Equal(t, tc.expectedErr, err)
 		})

--- a/releasenotes/notes/report-container-filter-errors-in-agent-status-c91b07d6649e16a8.yaml
+++ b/releasenotes/notes/report-container-filter-errors-in-agent-status-c91b07d6649e16a8.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add a section about container inclusion/exclusion errors
+    to the agent status command.


### PR DESCRIPTION
### What does this PR do?

Add container inclusion/exclusion errors to the agent status: https://a.cl.ly/04u2LX17

```
=============
Autodiscovery
=============

  Container Inclusion/Exclusion Errors
  ====================================
  
    Container filter "notvalid" is unknown, ignoring it. The supported filters are 'image', 'name' and 'kube_namespace'
```

* [Agent status with autodiscovery config errors and inclusion/exclusion errors](https://a.cl.ly/p9uAXDpP)
* [Agent status with only autodiscovery config errors](https://a.cl.ly/YEuZB9oW)
* [Agent status with no autodiscovery config or inclusion/exclusion errors](https://a.cl.ly/QwuA264n)

### Motivation

FR

### Additional Notes

### Describe how to test your changes

* Use the env vars listed in [this doc](https://docs.datadoghq.com/agent/guide/autodiscovery-management/?tab=containerizedagent) to add any combination of valid and invalid values. Example invalid values:
  * `DD_CONTAINER_EXCLUDE=.*`
  * `DD_CONTAINER_INCLUDE_LOGS=a(?=b)`
* Check the agent status: `kubectl exec -it <agent_pod> -c agent -- agent status`
* Compare the errors and warnings in the agent status with those listed in the agent logs: `kubectl logs <agent_pod> -c agent | grep "pkg/util/containers/filter.go"`
* Check that metrics and logs are being included/excluded as normally expected for relevant pods

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
