### PR TITLE
[secrets] get SID for user dynamically as opposed to hard-coded ddagentuser

### DIFF
--- a/pkg/api/security/platform_windows.go
+++ b/pkg/api/security/platform_windows.go
@@ -49,25 +49,9 @@ func lookupUsernameAndDomain(usid *syscall.SID) (username, domain string, e erro
 func saveAuthToken(token, tokenPath string) error {
 	// get the current user
 	var sidString string
-	log.Infof("Getting sidstring from user")
-	tok, e := syscall.OpenCurrentProcessToken()
-	if e != nil {
-		log.Warnf("Couldn't get process token %v", e)
-		return e
-	}
-	defer tok.Close()
-	user, e := tok.GetTokenUser()
-	if e != nil {
-		log.Warnf("Couldn't get  token user %v", e)
-		return e
-	}
-	sidString, e = user.User.Sid.String()
-	if e != nil {
-		log.Warnf("Couldn't get  user sid string %v", e)
-		return e
-	}
+
 	log.Infof("Getting sidstring from current user")
-	currUserSid, err := windows.StringToSid(sidString)
+	currUserSid, err := GetSidFromUser()
 	if err != nil {
 		log.Warnf("Unable to get current user sid %v", err)
 		return err
@@ -84,4 +68,28 @@ func saveAuthToken(token, tokenPath string) error {
 		log.Infof("Wrote auth token acl %v", err)
 	}
 	return err
+}
+
+// GetSidFromUser grabs and returns the windows SID for the current user or an error
+func GetSidFromUser() (*windows.SID, error) {
+	log.Infof("Getting sidstring from user")
+	tok, e := syscall.OpenCurrentProcessToken()
+	if e != nil {
+		log.Warnf("Couldn't get process token %v", e)
+		return e
+	}
+	defer tok.Close()
+	user, e := tok.GetTokenUser()
+	if e != nil {
+		log.Warnf("Couldn't get  token user %v", e)
+		return e
+	}
+
+	sidString, e := user.User.Sid.String()
+	if e != nil {
+		log.Warnf("Couldn't get  user sid string %v", e)
+		return e
+	}
+
+	return windows.StringToSid(sidString)
 }

--- a/pkg/api/security/platform_windows.go
+++ b/pkg/api/security/platform_windows.go
@@ -11,6 +11,7 @@ import (
 	"syscall"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 	acl "github.com/hectane/go-acl"
 	"golang.org/x/sys/windows"
 )
@@ -48,10 +49,9 @@ func lookupUsernameAndDomain(usid *syscall.SID) (username, domain string, e erro
 // writes auth token(s) to a file with the same permissions as datadog.yaml
 func saveAuthToken(token, tokenPath string) error {
 	// get the current user
-	var sidString string
 
 	log.Infof("Getting sidstring from current user")
-	currUserSid, err := GetSidFromUser()
+	currUserSid, err := winutil.GetSidFromUser()
 	if err != nil {
 		log.Warnf("Unable to get current user sid %v", err)
 		return err
@@ -68,28 +68,4 @@ func saveAuthToken(token, tokenPath string) error {
 		log.Infof("Wrote auth token acl %v", err)
 	}
 	return err
-}
-
-// GetSidFromUser grabs and returns the windows SID for the current user or an error
-func GetSidFromUser() (*windows.SID, error) {
-	log.Infof("Getting sidstring from user")
-	tok, e := syscall.OpenCurrentProcessToken()
-	if e != nil {
-		log.Warnf("Couldn't get process token %v", e)
-		return e
-	}
-	defer tok.Close()
-	user, e := tok.GetTokenUser()
-	if e != nil {
-		log.Warnf("Couldn't get  token user %v", e)
-		return e
-	}
-
-	sidString, e := user.User.Sid.String()
-	if e != nil {
-		log.Warnf("Couldn't get  user sid string %v", e)
-		return e
-	}
-
-	return windows.StringToSid(sidString)
 }

--- a/pkg/secrets/check_rights_windows.go
+++ b/pkg/secrets/check_rights_windows.go
@@ -14,7 +14,6 @@ import (
 
 	"golang.org/x/sys/windows"
 
-	"github.com/DataDog/datadog-agent/pkg/api/security"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 )
 
@@ -80,7 +79,7 @@ func checkRights(filename string, allowGroupExec bool) error {
 	}
 	defer windows.FreeSid(administrators)
 
-	secretuser, err := security.GetSidFromUser()
+	secretuser, err := winutil.GetSidFromUser()
 	defer windows.FreeSid(secretuser)
 
 	bSecretUserExplicitlyAllowed := false

--- a/pkg/secrets/check_rights_windows_test.go
+++ b/pkg/secrets/check_rights_windows_test.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -39,7 +40,7 @@ func TestCheckRights(t *testing.T) {
 	// file does not exist
 	require.NotNil(t, checkRights("/does not exists", allowGroupExec))
 
-	// missing ddagentuser
+	// missing current user
 	tmpfile, err = ioutil.TempFile("", "agent-collector-test")
 	require.Nil(t, err)
 	defer os.Remove(tmpfile.Name())
@@ -50,7 +51,8 @@ func TestCheckRights(t *testing.T) {
 		"-removeAdmin", "0",
 		"-removeLocalSystem", "0",
 		"-addDDuser", "0").Run()
-	require.NotNil(t, checkRights(tmpfile.Name(), allowGroupExec))
+	err = checkRights(tmpfile.Name(), allowGroupExec)
+	assert.NotNil(t, checkRights(tmpfile.Name(), allowGroupExec))
 
 	// missing localSystem
 	tmpfile, err = ioutil.TempFile("", "agent-collector-test")
@@ -62,7 +64,7 @@ func TestCheckRights(t *testing.T) {
 		"-removeAdmin", "0",
 		"-removeLocalSystem", "1",
 		"-addDDuser", "0").Run()
-	require.NotNil(t, checkRights(tmpfile.Name(), allowGroupExec))
+	assert.NotNil(t, checkRights(tmpfile.Name(), allowGroupExec))
 
 	// missing Administrator
 	tmpfile, err = ioutil.TempFile("", "agent-collector-test")
@@ -74,7 +76,7 @@ func TestCheckRights(t *testing.T) {
 		"-removeAdmin", "1",
 		"-removeLocalSystem", "0",
 		"-addDDuser", "0").Run()
-	require.NotNil(t, checkRights(tmpfile.Name(), allowGroupExec))
+	assert.NotNil(t, checkRights(tmpfile.Name(), allowGroupExec))
 
 	// extra rights for someone else
 	tmpfile, err = ioutil.TempFile("", "agent-collector-test")
@@ -86,7 +88,7 @@ func TestCheckRights(t *testing.T) {
 		"-removeAdmin", "0",
 		"-removeLocalSystem", "0",
 		"-addDDuser", "1").Run()
-	require.NotNil(t, checkRights(tmpfile.Name(), allowGroupExec))
+	assert.Nil(t, checkRights(tmpfile.Name(), allowGroupExec))
 
 	// missing localSystem or Administrator
 	tmpfile, err = ioutil.TempFile("", "agent-collector-test")
@@ -98,5 +100,5 @@ func TestCheckRights(t *testing.T) {
 		"-removeAdmin", "0",
 		"-removeLocalSystem", "0",
 		"-addDDuser", "1").Run()
-	require.Nil(t, checkRights(tmpfile.Name(), allowGroupExec))
+	assert.Nil(t, checkRights(tmpfile.Name(), allowGroupExec))
 }

--- a/pkg/secrets/test/setAcl.ps1
+++ b/pkg/secrets/test/setAcl.ps1
@@ -41,9 +41,11 @@ if ($removeLocalSystem -eq $True) {
     }
 }
 
-# adding ACL for ddagentuser
+# adding ACL for current user
 if ($addDDUser -eq $True) {
-    $ddAcl = New-Object  system.security.accesscontrol.filesystemaccessrule("ddagentuser", "FullControl","Allow")
+    $ddCurrentUser =  [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+    # $ddCurrentUser = "ddtestuser"
+    $ddAcl = New-Object  system.security.accesscontrol.filesystemaccessrule($ddCurrentUser, "FullControl","Allow")
     $acl.SetAccessRule($ddAcl)
 }
 

--- a/pkg/secrets/test/setAcl.ps1
+++ b/pkg/secrets/test/setAcl.ps1
@@ -43,8 +43,7 @@ if ($removeLocalSystem -eq $True) {
 
 # adding ACL for current user
 if ($addDDUser -eq $True) {
-    $ddCurrentUser =  [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
-    # $ddCurrentUser = "ddtestuser"
+    $ddCurrentUser = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
     $ddAcl = New-Object  system.security.accesscontrol.filesystemaccessrule($ddCurrentUser, "FullControl","Allow")
     $acl.SetAccessRule($ddAcl)
 }

--- a/pkg/util/winutil/go.mod
+++ b/pkg/util/winutil/go.mod
@@ -6,5 +6,6 @@ replace github.com/DataDog/datadog-agent/pkg/util/log => ../log
 
 require (
 	github.com/DataDog/datadog-agent/pkg/util/log v0.30.0-rc.7
+	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f
 )

--- a/pkg/util/winutil/users.go
+++ b/pkg/util/winutil/users.go
@@ -1,0 +1,38 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018-present Datadog, Inc.
+// +build windows
+
+package winutil
+
+import (
+	"syscall"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"golang.org/x/sys/windows"
+)
+
+// GetSidFromUser grabs and returns the windows SID for the current user or an error
+func GetSidFromUser() (*windows.SID, error) {
+	log.Infof("Getting sidstring from user")
+	tok, e := syscall.OpenCurrentProcessToken()
+	if e != nil {
+		log.Warnf("Couldn't get process token %v", e)
+		return nil, e
+	}
+	defer tok.Close()
+	user, e := tok.GetTokenUser()
+	if e != nil {
+		log.Warnf("Couldn't get  token user %v", e)
+		return nil, e
+	}
+
+	sidString, e := user.User.Sid.String()
+	if e != nil {
+		log.Warnf("Couldn't get  user sid string %v", e)
+		return nil, e
+	}
+
+	return windows.StringToSid(sidString)
+}

--- a/pkg/util/winutil/users.go
+++ b/pkg/util/winutil/users.go
@@ -24,15 +24,27 @@ func GetSidFromUser() (*windows.SID, error) {
 	defer tok.Close()
 	user, e := tok.GetTokenUser()
 	if e != nil {
-		log.Warnf("Couldn't get  token user %v", e)
+		log.Warnf("Couldn't get token user %v", e)
 		return nil, e
 	}
 
 	sidString, e := user.User.Sid.String()
 	if e != nil {
-		log.Warnf("Couldn't get  user sid string %v", e)
+		log.Warnf("Couldn't get user sid string %v", e)
 		return nil, e
 	}
 
 	return windows.StringToSid(sidString)
+}
+
+// GetUserFromSid returns the user and domain for a given windows SID, or an
+// error if any.
+func GetUserFromSid(sid *windows.SID) (string, string, error) {
+	username, domain, _, err := sid.LookupAccount("")
+	if err != nil {
+		log.Warnf("Couldn't get username and/or domain from sid: %v", err)
+		return "", "", err
+	}
+
+	return username, domain, nil
 }

--- a/pkg/util/winutil/users.go
+++ b/pkg/util/winutil/users.go
@@ -23,6 +23,7 @@ func GetSidFromUser() (*windows.SID, error) {
 		return nil, e
 	}
 	defer tok.Close()
+
 	user, e := tok.GetTokenUser()
 	if e != nil {
 		log.Warnf("Couldn't get token user %v", e)

--- a/pkg/util/winutil/users.go
+++ b/pkg/util/winutil/users.go
@@ -13,7 +13,8 @@ import (
 	"golang.org/x/sys/windows"
 )
 
-// GetSidFromUser grabs and returns the windows SID for the current user or an error
+// GetSidFromUser grabs and returns the windows SID for the current user or an error.
+// The *SID returned does not need to be freed by the caller.
 func GetSidFromUser() (*windows.SID, error) {
 	log.Infof("Getting sidstring from user")
 	tok, e := syscall.OpenCurrentProcessToken()

--- a/pkg/util/winutil/users_test.go
+++ b/pkg/util/winutil/users_test.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2018-present Datadog, Inc.
+
+// +build windows
+
+package winutil
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetSidFromUser(t *testing.T) {
+	sid, err := GetSidFromUser()
+	t.Logf("The SID found was: %v", sid)
+	assert.Nil(t, err)
+}
+
+func TestGetUserFromSid(t *testing.T) {
+	sid, err := GetSidFromUser()
+	assert.Nil(t, err)
+
+	username, domain, err := GetUserFromSid(sid)
+	assert.Nil(t, err)
+	t.Logf("username: %v\tdomain: %v", username, domain)
+}

--- a/pkg/util/winutil/users_test.go
+++ b/pkg/util/winutil/users_test.go
@@ -17,13 +17,20 @@ func TestGetSidFromUser(t *testing.T) {
 	sid, err := GetSidFromUser()
 	t.Logf("The SID found was: %v", sid)
 	assert.Nil(t, err)
+	assert.NotNil(t, sid)
 }
 
 func TestGetUserFromSid(t *testing.T) {
 	sid, err := GetSidFromUser()
 	assert.Nil(t, err)
+	assert.NotNil(t, sid)
 
 	username, domain, err := GetUserFromSid(sid)
 	assert.Nil(t, err)
+
 	t.Logf("username: %v\tdomain: %v", username, domain)
+	assert.NotNil(t, username)
+	assert.NotNil(t, domain)
+	assert.NotEqual(t, "", username)
+	assert.NotEqual(t, "", domain)
 }

--- a/releasenotes/notes/windows-secrets-support-any-user-844cb3e5e7a1a173.yaml
+++ b/releasenotes/notes/windows-secrets-support-any-user-844cb3e5e7a1a173.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Enhances the secrets feature to support arbitrarily named user
+    accounts running the datadog-agent service. Previously the
+    feature was hardcoded to `ddagentuser` or Administrator accounts
+    only.


### PR DESCRIPTION
### What does this PR do?

Instead of collecting the SID for the hard-coded `ddagentuser` we instead run the verification against the current user, which is the correct way to approach this.

### Motivation

This PR improves the secrets feature to support any arbitrary name for the service account running the datadog-agent. Previously, rights were verified against a hardcoded `ddagentuser`. This could cause issues for users trying to use a secrets backend with another user account.

### Additional Notes

(none)

### Describe how to test your changes

Testing this is a little convoluted:

1. install an agent using an arbitrary user account (not `ddagentuser`):
```
Start-Process -Wait msiexec -ArgumentList '/qn /i datadog-agent-7-latest.amd64.msi /l*v "install.log" APIKEY="<api_key>" SITE="datadoghq.com" DDAGENTUSER_NAME="<arbitrary_agent_username>" DDAGENTUSER_PASSWORD="<password>"'
```
2. Add a secrets backend (you can use the dummy backend exe for testing purposes in the example section [here](https://docs.datadoghq.com/agent/guide/secrets-management/?tab=windows#the-executable-api)).
3. Set some `ENC[key]` secret in the datadog.yaml config
4. Set the correct rights to the the executable backend. You can use a powershell script like this:
```
$acl = Get-Acl <executable_backend_exe_path>
$ddAcl = New-Object  system.security.accesscontrol.filesystemaccessrule("<arbitrary_agent_username>", "FullControl","Allow")
$acl.SetAccessRule($ddAcl)
$acl | Set-Acl <executable _backend_exe_path> 
```

You can verify the current rights with:
```
 Get-Acl <executable_backend_exe_path> | fl
```

If the file is inheriting rights or some other user other than an `Administrator` or `<arbitrary_agent_username>` has rights to it, the agent will likely fail to start. Make sure only `Administrator` or `<arbitrary_agent_username>` accounts have access to the file. 

5. Restart the agent and make sure the agent comes up correctly and resolves the secrets.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
