### PR TITLE
[AD] Allow skipping secret backend for check configs

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -428,6 +428,11 @@ func (ac *AutoConfig) RemoveScheduler(name string) {
 }
 
 func decryptConfig(conf integration.Config) (integration.Config, error) {
+	if config.Datadog.GetBool("secret_backend_skip_checks") {
+		log.Debugf("'secret_backend_skip_checks' is enabled, not decrypting configuration %q", conf.Name)
+		return conf, nil
+	}
+
 	var err error
 
 	// init_config

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -429,7 +429,7 @@ func (ac *AutoConfig) RemoveScheduler(name string) {
 
 func decryptConfig(conf integration.Config) (integration.Config, error) {
 	if config.Datadog.GetBool("secret_backend_skip_checks") {
-		log.Debugf("'secret_backend_skip_checks' is enabled, not decrypting configuration %q", conf.Name)
+		log.Tracef("'secret_backend_skip_checks' is enabled, not decrypting configuration %q", conf.Name)
 		return conf, nil
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -275,6 +275,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("secret_backend_output_max_size", secrets.SecretBackendOutputMaxSize)
 	config.BindEnvAndSetDefault("secret_backend_timeout", 30)
 	config.BindEnvAndSetDefault("secret_backend_command_allow_group_exec_perm", false)
+	config.BindEnvAndSetDefault("secret_backend_skip_checks", false)
 
 	// Use to output logs in JSON format
 	config.BindEnvAndSetDefault("log_format_json", false)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -500,6 +500,11 @@ api_key:
 #
 # secret_backend_timeout: 30
 
+## @param secret_backend_skip_checks - boolean - optional - default: false
+## Disable fetching secrets for check configurations
+#
+# secret_backend_skip_checks: false
+
 ## @param snmp_listener - custom object - optional
 ## Creates and schedules a listener to automatically discover your SNMP devices.
 ## Discovered devices can then be monitored with the SNMP integration by using

--- a/releasenotes-dca/notes/support-skipping-sb-for-configs-9b4b589b8ba09638.yaml
+++ b/releasenotes-dca/notes/support-skipping-sb-for-configs-9b4b589b8ba09638.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    The Cluster Agent can be instructed to dispatch cluster checks without decrypting secrets.
+    The node Agent or the cluster check runner will fetch the secrets after receiving the configurations from the Cluster Agent.
+    This can be enabled by setting ``DD_SECRET_BACKEND_SKIP_CHECKS`` to ``true`` in the Cluster Agent config.


### PR DESCRIPTION
### What does this PR do?

Support skipping secret backend calls when discovering checks.

### Motivation

Avoid decrypting cluster checks at the Cluster Agent level.

### Describe how to test your changes

- Configure secret backend on both the Cluster Agent and the CLC Runner as per [this documentation](https://docs.datadoghq.com/agent/guide/secrets-management/?tab=linux#kubernetes-secrets).
- Enable `DD_SECRET_BACKEND_SKIP_CHECKS` in the Cluster Agent config
```
  env:
  - name: DD_SECRET_BACKEND_SKIP_CHECKS
    value: "true"
```
- Configure a cluster check with `ENC[<key>]` in its config
- Cluster Agent should log this debug line `'secret_backend_skip_checks' is enabled, not decrypting configuration <check name>`
- `agent clusterchecks` should show the field encrypted (`ENC[<key>]`)
- The CLC Runner should decrypt the secret and run the check

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
