### PR TITLE
[runtime-security] fast array lookup in SECL

### DIFF
--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -256,7 +256,7 @@ func isParentPathDiscarder(rs *rules.RuleSet, regexCache *simplelru.LRU, eventTy
 		if values := rule.GetFieldValues(filenameField); len(values) > 0 {
 			for _, value := range values {
 				if value.Type == eval.PatternValueType {
-					if value.Regex.MatchString(dirname) {
+					if value.Regexp.MatchString(dirname) {
 						return false, nil
 					}
 

--- a/pkg/security/secl/eval/pattern.go
+++ b/pkg/security/secl/eval/pattern.go
@@ -29,7 +29,7 @@ func patternToRegexp(pattern string) (*regexp.Regexp, error) {
 }
 
 func toPattern(se *StringEvaluator) error {
-	if se.isRegexp {
+	if se.regexp != nil {
 		return nil
 	}
 
@@ -38,7 +38,6 @@ func toPattern(se *StringEvaluator) error {
 		return fmt.Errorf("invalid pattern '%s': %s", se.Value, err)
 	}
 	se.valueType = PatternValueType
-	se.isRegexp = true
 	se.regexp = reg
 
 	return nil


### PR DESCRIPTION
### What does this PR do?

Improve map lookups adding a mechanism to process regex and scalar separately. Scalar value lookups now use a map instead of an array.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Unit test cover this change.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
