### PR TITLE
[Serverless] Refactoring logs and extension registration

### DIFF
--- a/cmd/serverless/main.go
+++ b/cmd/serverless/main.go
@@ -85,7 +85,7 @@ const (
 	// loggerName is the name of the serverless agent logger
 	loggerName config.LoggerName = "SAGENT"
 
-	runtimeApiEnvVar = "AWS_LAMBDA_RUNTIME_API"
+	runtimeAPIEnvVar = "AWS_LAMBDA_RUNTIME_API"
 
 	extensionRegistrationRoute   = "/2020-01-01/extension/register"
 	extensionRegistrationTimeout = 5 * time.Second
@@ -171,8 +171,8 @@ func runAgent(stopCh chan struct{}) (daemon *serverless.Daemon, err error) {
 	// ----------------
 
 	// extension registration
-	extesionRegistrationUrl := registration.BuildURL(os.Getenv(runtimeApiEnvVar), extensionRegistrationRoute)
-	serverlessID, err := registration.RegisterExtension(extesionRegistrationUrl, extensionRegistrationTimeout)
+	extesionRegistrationURL := registration.BuildURL(os.Getenv(runtimeAPIEnvVar), extensionRegistrationRoute)
+	serverlessID, err := registration.RegisterExtension(extesionRegistrationURL, extensionRegistrationTimeout)
 	if err != nil {
 		// at this point, we were not even able to register, thus, we don't have
 		// any ID assigned, thus, we can't report an error to the init error route
@@ -264,10 +264,10 @@ func runAgent(stopCh chan struct{}) (daemon *serverless.Daemon, err error) {
 	// ----------------------
 	log.Debug("Enabling logs collection HTTP route")
 
-	logRegistrationUrl := registration.BuildURL(os.Getenv(runtimeApiEnvVar), logsAPIRegistrationRoute)
+	logRegistrationURL := registration.BuildURL(os.Getenv(runtimeAPIEnvVar), logsAPIRegistrationRoute)
 	logRegistrationError := registration.EnableLogsCollection(
 		serverlessID,
-		logRegistrationUrl,
+		logRegistrationURL,
 		logsAPIRegistrationTimeout,
 		os.Getenv(logsLogsTypeSubscribed),
 		logsAPIHttpServerPort,

--- a/pkg/serverless/protocol.go
+++ b/pkg/serverless/protocol.go
@@ -28,7 +28,6 @@ import (
 // httpServerPort will be the default port used to run the HTTP server listening
 // to calls from the client libraries and to logs from the AWS environment.
 const httpServerPort int = 8124
-const httpLogsCollectionRoute string = "/lambda/logs"
 
 // shutdownDelay is the amount of time we wait before shutting down the HTTP server
 // after we receive a Shutdown event. This allows time for the final log messages

--- a/pkg/serverless/protocol.go
+++ b/pkg/serverless/protocol.go
@@ -28,7 +28,6 @@ import (
 // httpServerPort will be the default port used to run the HTTP server listening
 // to calls from the client libraries and to logs from the AWS environment.
 const httpServerPort int = 8124
-
 const httpLogsCollectionRoute string = "/lambda/logs"
 
 // shutdownDelay is the amount of time we wait before shutting down the HTTP server
@@ -81,6 +80,11 @@ type Daemon struct {
 	// finishInvocationOnce assert that FinishedInvocation will be called only once (at the end of the function OR after a timeout)
 	// this should be reset before each invocation
 	finishInvocationOnce sync.Once
+}
+
+//SetMuxHandle configures the log collection route handler
+func (d *Daemon) SetMuxHandle(route string, logsChan chan *logConfig.ChannelMessage) {
+	d.mux.Handle(route, &LogsCollection{daemon: d, ch: logsChan})
 }
 
 // SetStatsdServer sets the DogStatsD server instance running when it is ready.

--- a/pkg/serverless/protocol.go
+++ b/pkg/serverless/protocol.go
@@ -245,17 +245,6 @@ func StartDaemon(stopTraceAgent context.CancelFunc) *Daemon {
 	return daemon
 }
 
-// EnableLogsCollection is adding the HTTP route on which the HTTP server will receive
-// logs from AWS.
-// Returns the HTTP URL on which AWS should send the logs.
-func (d *Daemon) EnableLogsCollection() (string, chan *logConfig.ChannelMessage, error) {
-	httpAddr := fmt.Sprintf("http://sandbox:%d%s", httpServerPort, httpLogsCollectionRoute)
-	logsChan := make(chan *logConfig.ChannelMessage)
-	d.mux.Handle(httpLogsCollectionRoute, &LogsCollection{daemon: d, ch: logsChan})
-	log.Debugf("Logs collection route has been initialized. Logs must be sent to %s", httpAddr)
-	return httpAddr, logsChan, nil
-}
-
 // StartInvocation tells the daemon the invocation began
 func (d *Daemon) StartInvocation() {
 	d.InvcWg.Add(1)

--- a/pkg/serverless/registration/extension_api.go
+++ b/pkg/serverless/registration/extension_api.go
@@ -1,0 +1,74 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package registration
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+const (
+	extensionName = "datadog-agent"
+	headerExtName = "Lambda-Extension-Name"
+	HeaderExtID   = "Lambda-Extension-Identifier"
+)
+
+// RegisterExtension registers the serverless daemon and subscribe to INVOKE and SHUTDOWN messages.
+// Returns either (the serverless ID assigned by the serverless daemon + the api key as read from
+// the environment) or an error.
+func RegisterExtension(url string, timeout time.Duration) (ID, error) {
+	payload := createRegistrationPayload()
+
+	request, err := buildRegisterRequest(headerExtName, extensionName, url, payload)
+	if err != nil {
+		return "", fmt.Errorf("registerExtension: can't create the POST register request: %v", err)
+	}
+
+	response, err := sendRequest(&http.Client{Timeout: timeout}, request)
+	if err != nil {
+		return "", fmt.Errorf("registerExtension: error while POST register route: %v", err)
+	}
+
+	if !isAValidResponse(response) {
+		return "", fmt.Errorf("registerExtension: didn't receive an HTTP 200")
+	}
+
+	id := extractId(response)
+	if len(id) == 0 {
+		return "", fmt.Errorf("registerExtension: didn't receive an identifier")
+	}
+
+	return ID(id), nil
+}
+
+func createRegistrationPayload() *bytes.Buffer {
+	payload := bytes.NewBuffer(nil)
+	payload.Write([]byte(`{"events":["INVOKE", "SHUTDOWN"]}`))
+	return payload
+}
+
+func extractId(response *http.Response) string {
+	return response.Header.Get(HeaderExtID)
+}
+
+func isAValidResponse(response *http.Response) bool {
+	return response.StatusCode == 200
+}
+
+func buildRegisterRequest(headerExtensionName string, extensionName string, url string, payload *bytes.Buffer) (*http.Request, error) {
+	request, err := http.NewRequest(http.MethodPost, url, payload)
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set(headerExtensionName, extensionName)
+	return request, nil
+}
+
+func sendRequest(httpClient HttpClient, request *http.Request) (*http.Response, error) {
+	return httpClient.Do(request)
+}

--- a/pkg/serverless/registration/extension_api.go
+++ b/pkg/serverless/registration/extension_api.go
@@ -16,7 +16,7 @@ const (
 	extensionName = "datadog-agent"
 	headerExtName = "Lambda-Extension-Name"
 
-	//HeaderExtID is the header name for the extension identifer
+	//HeaderExtID is the header name for the extension identifier
 	HeaderExtID = "Lambda-Extension-Identifier"
 )
 

--- a/pkg/serverless/registration/extension_api.go
+++ b/pkg/serverless/registration/extension_api.go
@@ -15,7 +15,9 @@ import (
 const (
 	extensionName = "datadog-agent"
 	headerExtName = "Lambda-Extension-Name"
-	HeaderExtID   = "Lambda-Extension-Identifier"
+
+	//HeaderExtID is the header name for the extension identifer
+	HeaderExtID = "Lambda-Extension-Identifier"
 )
 
 // RegisterExtension registers the serverless daemon and subscribe to INVOKE and SHUTDOWN messages.
@@ -38,7 +40,7 @@ func RegisterExtension(url string, timeout time.Duration) (ID, error) {
 		return "", fmt.Errorf("registerExtension: didn't receive an HTTP 200")
 	}
 
-	id := extractId(response)
+	id := extractID(response)
 	if len(id) == 0 {
 		return "", fmt.Errorf("registerExtension: didn't receive an identifier")
 	}
@@ -52,7 +54,7 @@ func createRegistrationPayload() *bytes.Buffer {
 	return payload
 }
 
-func extractId(response *http.Response) string {
+func extractID(response *http.Response) string {
 	return response.Header.Get(HeaderExtID)
 }
 
@@ -69,6 +71,6 @@ func buildRegisterRequest(headerExtensionName string, extensionName string, url 
 	return request, nil
 }
 
-func sendRequest(httpClient HttpClient, request *http.Request) (*http.Response, error) {
-	return httpClient.Do(request)
+func sendRequest(client HTTPClient, request *http.Request) (*http.Response, error) {
+	return client.Do(request)
 }

--- a/pkg/serverless/registration/extension_api_test.go
+++ b/pkg/serverless/registration/extension_api_test.go
@@ -22,14 +22,14 @@ func TestCreateRegistrationPayload(t *testing.T) {
 	assert.Equal(t, "{\"events\":[\"INVOKE\", \"SHUTDOWN\"]}", payload.String())
 }
 
-func TestExtractId(t *testing.T) {
-	expectedId := "blablabla"
+func TestExtractID(t *testing.T) {
+	expectedID := "blablabla"
 	response := &http.Response{
 		Header: map[string][]string{
-			HeaderExtID: {expectedId},
+			HeaderExtID: {expectedID},
 		},
 	}
-	assert.Equal(t, expectedId, extractId(response))
+	assert.Equal(t, expectedID, extractID(response))
 }
 
 func TestIsValidResponseTrue(t *testing.T) {

--- a/pkg/serverless/registration/extension_api_test.go
+++ b/pkg/serverless/registration/extension_api_test.go
@@ -1,0 +1,137 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package registration
+
+import (
+	"bytes"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const registerExtensionTimeout = 10 * time.Millisecond
+
+func TestCreateRegistrationPayload(t *testing.T) {
+	payload := createRegistrationPayload()
+	assert.Equal(t, "{\"events\":[\"INVOKE\", \"SHUTDOWN\"]}", payload.String())
+}
+
+func TestExtractId(t *testing.T) {
+	expectedId := "blablabla"
+	response := &http.Response{
+		Header: map[string][]string{
+			HeaderExtID: []string{expectedId},
+		},
+	}
+	assert.Equal(t, expectedId, extractId(response))
+}
+
+func TestIsValidResponseTrue(t *testing.T) {
+	response := &http.Response{
+		StatusCode: 200,
+	}
+	assert.True(t, isAValidResponse(response))
+}
+
+func TestIsValidResponseFalse(t *testing.T) {
+	response := &http.Response{
+		StatusCode: 404,
+	}
+	assert.False(t, isAValidResponse(response))
+}
+
+func TestBuildRegisterRequestSuccess(t *testing.T) {
+	request, err := buildRegisterRequest("X-Header", "extensionName", "myUrl", bytes.NewBuffer([]byte("blablabla")))
+	assert.Nil(t, err)
+	assert.Equal(t, http.MethodPost, request.Method)
+	assert.Equal(t, "myUrl", request.URL.Path)
+	assert.NotNil(t, request.Body)
+	assert.Equal(t, "extensionName", request.Header["X-Header"][0])
+}
+
+func TestBuildRegisterRequestFailure(t *testing.T) {
+	request, err := buildRegisterRequest("X-Header", "extensionName", ":invalid:", bytes.NewBuffer([]byte("blablabla")))
+	assert.Nil(t, request)
+	assert.NotNil(t, err)
+}
+
+func TestSendRequestFailure(t *testing.T) {
+	response, err := sendRequest(&http.Client{}, &http.Request{})
+	assert.Nil(t, response)
+	assert.NotNil(t, err)
+}
+
+func TestSendRequestSuccess(t *testing.T) {
+	response, err := sendRequest(&ClientMock{}, &http.Request{})
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+}
+
+func TestRegisterSuccess(t *testing.T) {
+	//fake the register route
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		//add the extension id
+		w.Header().Add(HeaderExtID, "myGeneratedId")
+		w.WriteHeader(200)
+	}))
+	defer ts.Close()
+
+	id, err := RegisterExtension(ts.URL, registerExtensionTimeout)
+
+	assert.Equal(t, "myGeneratedId", id.String())
+	assert.Nil(t, err)
+}
+
+func TestRegisterErrorNoExtensionId(t *testing.T) {
+	//fake the register route
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		//no the extension id
+		w.WriteHeader(200)
+	}))
+	defer ts.Close()
+
+	id, err := RegisterExtension(ts.URL, registerExtensionTimeout)
+
+	assert.Empty(t, id.String())
+	assert.NotNil(t, err)
+}
+
+func TestRegisterErrorHttp(t *testing.T) {
+	//fake the register route
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// non 200 http code
+		w.WriteHeader(500)
+	}))
+	defer ts.Close()
+
+	id, err := RegisterExtension(ts.URL, registerExtensionTimeout)
+
+	assert.Empty(t, id.String())
+	assert.NotNil(t, err)
+}
+
+func TestRegisterErrorTimeout(t *testing.T) {
+	id, err := RegisterExtension(":invalidURL:", registerExtensionTimeout)
+	assert.Empty(t, id.String())
+	assert.NotNil(t, err)
+}
+
+func TestRegisterErrorBuildRequest(t *testing.T) {
+	//fake the register route
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(registerExtensionTimeout + 10*time.Millisecond)
+		w.WriteHeader(200)
+	}))
+	defer ts.Close()
+
+	id, err := RegisterExtension(ts.URL, registerExtensionTimeout)
+
+	assert.Empty(t, id.String())
+	assert.NotNil(t, err)
+}

--- a/pkg/serverless/registration/extension_api_test.go
+++ b/pkg/serverless/registration/extension_api_test.go
@@ -26,7 +26,7 @@ func TestExtractId(t *testing.T) {
 	expectedId := "blablabla"
 	response := &http.Response{
 		Header: map[string][]string{
-			HeaderExtID: []string{expectedId},
+			HeaderExtID: {expectedId},
 		},
 	}
 	assert.Equal(t, expectedId, extractId(response))

--- a/pkg/serverless/registration/logs_api.go
+++ b/pkg/serverless/registration/logs_api.go
@@ -20,9 +20,10 @@ const (
 	headerContentType string = "Content-Type"
 )
 
+// EnableLogsCollection enables logs collections via AWS Logs API
 func EnableLogsCollection(
 	id ID,
-	registrationUrl string,
+	registrationURL string,
 	registrationTimeout time.Duration,
 	logsType string,
 	port int,
@@ -34,7 +35,7 @@ func EnableLogsCollection(
 	callBackURI := buildCallbackURI(port, collectionRoute)
 	payload := buildLogRegistrationPayload(callBackURI, logsType, timeout, maxBytes, maxItems)
 
-	return subscribeLogs(id, registrationUrl, registrationTimeout, payload)
+	return subscribeLogs(id, registrationURL, registrationTimeout, payload)
 }
 
 // subscribeLogs subscribes to the logs collection on the platform.
@@ -66,7 +67,7 @@ func subscribeLogs(id ID, url string, timeout time.Duration, payload json.Marsha
 		return fmt.Errorf("SubscribeLogs: while PUT subscribe request: %s", err)
 	}
 
-	if !isValidHttpCode(response.StatusCode) {
+	if !isValidHTTPCode(response.StatusCode) {
 		return fmt.Errorf("SubscribeLogs: received an HTTP %s", response.Status)
 	}
 
@@ -76,11 +77,11 @@ func subscribeLogs(id ID, url string, timeout time.Duration, payload json.Marsha
 func buildLogRegistrationPayload(callBackURI string, logsType string, timeoutMs int, maxBytes int, maxItems int) *LogSubscriptionPayload {
 	logsTypeArray := getLogTypesToSubscribe(logsType)
 	log.Debug("Subscribing to Logs for types:", logsTypeArray)
-	destination := &Destination{
+	destination := &destination{
 		URI:      callBackURI,
 		Protocol: "HTTP",
 	}
-	buffering := &Buffering{
+	buffering := &buffering{
 		TimeoutMs: timeoutMs,
 		MaxBytes:  maxBytes,
 		MaxItems:  maxItems,
@@ -107,11 +108,11 @@ func buildLogRegistrationRequest(url string, headerExtID string, headerContentTy
 	return request, nil
 }
 
-func sendLogRegistrationRequest(httpClient HttpClient, request *http.Request) (*http.Response, error) {
-	return httpClient.Do(request)
+func sendLogRegistrationRequest(client HTTPClient, request *http.Request) (*http.Response, error) {
+	return client.Do(request)
 }
 
-func isValidHttpCode(statusCode int) bool {
+func isValidHTTPCode(statusCode int) bool {
 	return statusCode < 300
 }
 
@@ -129,7 +130,6 @@ func getLogTypesToSubscribe(envLogsType string) []string {
 			}
 		}
 		return logsType
-	} else {
-		return []string{"platform", "function", "extension"}
 	}
+	return []string{"platform", "function", "extension"}
 }

--- a/pkg/serverless/registration/logs_api.go
+++ b/pkg/serverless/registration/logs_api.go
@@ -1,0 +1,135 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package registration
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	headerContentType string = "Content-Type"
+)
+
+func EnableLogsCollection(
+	id ID,
+	registrationUrl string,
+	registrationTimeout time.Duration,
+	logsType string,
+	port int,
+	collectionRoute string,
+	timeout int,
+	maxBytes int,
+	maxItems int) error {
+
+	callBackURI := buildCallbackURI(port, collectionRoute)
+	payload := buildLogRegistrationPayload(callBackURI, logsType, timeout, maxBytes, maxItems)
+
+	return subscribeLogs(id, registrationUrl, registrationTimeout, payload)
+}
+
+// subscribeLogs subscribes to the logs collection on the platform.
+// We send a request to AWS to subscribe for logs, indicating on which port we
+// are opening an HTTP server, to receive logs from AWS.
+// When we are receiving logs on this HTTP server, we're pushing them in a channel
+// tailed by the Logs Agent pipeline, these logs then go through the regular
+// Logs Agent pipeline to finally be sent on the intake when we receive a FLUSH
+// call from the Lambda function / client.
+// logsType contains the type of logs for which we are subscribing, possible
+// value: platform, extension and function.
+func subscribeLogs(id ID, url string, timeout time.Duration, payload json.Marshaler) error {
+
+	jsonBytes, err := payload.MarshalJSON()
+	if err != nil {
+		return fmt.Errorf("SubscribeLogs: can't marshal subscribe JSON %v", err)
+	}
+
+	request, err := buildLogRegistrationRequest(url, HeaderExtID, headerContentType, id, jsonBytes)
+	if err != nil {
+		return fmt.Errorf("SubscribeLogs: can't create the PUT request: %v", err)
+	}
+
+	response, err := sendLogRegistrationRequest(&http.Client{
+		Transport: &http.Transport{IdleConnTimeout: timeout},
+		Timeout:   timeout,
+	}, request)
+	if err != nil {
+		return fmt.Errorf("SubscribeLogs: while PUT subscribe request: %s", err)
+	}
+
+	if !isValidHttpCode(response.StatusCode) {
+		return fmt.Errorf("SubscribeLogs: received an HTTP %s", response.Status)
+	}
+
+	return nil
+}
+
+func buildLogRegistrationPayload(callBackURI string, logsType string, timeoutMs int, maxBytes int, maxItems int) *LogSubscriptionPayload {
+	logsTypeArray := getLogTypesToSubscribe(logsType)
+	log.Debug("Subscribing to Logs for types:", logsTypeArray)
+	destination := &Destination{
+		URI:      callBackURI,
+		Protocol: "HTTP",
+	}
+	buffering := &Buffering{
+		TimeoutMs: timeoutMs,
+		MaxBytes:  maxBytes,
+		MaxItems:  maxItems,
+	}
+	payload := &LogSubscriptionPayload{
+		Destination: *destination,
+		Types:       logsTypeArray,
+		Buffering:   *buffering,
+	}
+	return payload
+}
+
+func buildCallbackURI(httpServerPort int, httpLogsCollectionRoute string) string {
+	return fmt.Sprintf("http://sandbox:%d%s", httpServerPort, httpLogsCollectionRoute)
+}
+
+func buildLogRegistrationRequest(url string, headerExtID string, headerContentType string, id ID, payload []byte) (*http.Request, error) {
+	request, err := http.NewRequest(http.MethodPut, url, bytes.NewBuffer(payload))
+	if err != nil {
+		return nil, err
+	}
+	request.Header.Set(headerExtID, id.String())
+	request.Header.Set(headerContentType, "application/json")
+	return request, nil
+}
+
+func sendLogRegistrationRequest(httpClient HttpClient, request *http.Request) (*http.Response, error) {
+	return httpClient.Do(request)
+}
+
+func isValidHttpCode(statusCode int) bool {
+	return statusCode < 300
+}
+
+func getLogTypesToSubscribe(envLogsType string) []string {
+	if len(envLogsType) > 0 {
+		var logsType []string
+		parts := strings.Split(strings.TrimSpace(envLogsType), " ")
+		for _, part := range parts {
+			part = strings.ToLower(strings.TrimSpace(part))
+			switch part {
+			case "function", "platform", "extension":
+				logsType = append(logsType, part)
+			default:
+				log.Warn("While subscribing to logs, unknown log type", part)
+			}
+		}
+		return logsType
+	} else {
+		return []string{"platform", "function", "extension"}
+	}
+}

--- a/pkg/serverless/registration/logs_api_payload.go
+++ b/pkg/serverless/registration/logs_api_payload.go
@@ -9,21 +9,24 @@ import (
 	"encoding/json"
 )
 
-type Destination struct {
+type destination struct {
 	URI      string `json:"URI"`
 	Protocol string `json:"protocol"`
 }
-type Buffering struct {
+type buffering struct {
 	MaxBytes  int `json:"maxBytes"`
 	MaxItems  int `json:"maxItems"`
 	TimeoutMs int `json:"timeoutMs"`
 }
+
+// LogSubscriptionPayload is the payload we send while subscribing to the AWS Logs API
 type LogSubscriptionPayload struct {
-	Buffering   Buffering   `json:"buffering"`
-	Destination Destination `json:"destination"`
+	Buffering   buffering   `json:"buffering"`
+	Destination destination `json:"destination"`
 	Types       []string    `json:"types"`
 }
 
+// MarshalJSON marshals the given LogSubscriptionPayload object
 func (p *LogSubscriptionPayload) MarshalJSON() ([]byte, error) {
 	// use an alias to avoid infinite recursion while serializing
 	type LogSubscriptionPayloadAlias LogSubscriptionPayload

--- a/pkg/serverless/registration/logs_api_payload.go
+++ b/pkg/serverless/registration/logs_api_payload.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package registration
+
+import (
+	"encoding/json"
+)
+
+type Destination struct {
+	URI      string `json:"URI"`
+	Protocol string `json:"protocol"`
+}
+type Buffering struct {
+	MaxBytes  int `json:"maxBytes"`
+	MaxItems  int `json:"maxItems"`
+	TimeoutMs int `json:"timeoutMs"`
+}
+type LogSubscriptionPayload struct {
+	Buffering   Buffering   `json:"buffering"`
+	Destination Destination `json:"destination"`
+	Types       []string    `json:"types"`
+}
+
+func (p *LogSubscriptionPayload) MarshalJSON() ([]byte, error) {
+	// use an alias to avoid infinite recursion while serializing
+	type LogSubscriptionPayloadAlias LogSubscriptionPayload
+	return json.Marshal((*LogSubscriptionPayloadAlias)(p))
+}

--- a/pkg/serverless/registration/logs_api_test.go
+++ b/pkg/serverless/registration/logs_api_test.go
@@ -43,16 +43,16 @@ func TestBuildLogRegistrationRequestError(t *testing.T) {
 	assert.Nil(t, request)
 }
 
-func TestIsValidHttpCodeSuccess(t *testing.T) {
-	assert.True(t, isValidHttpCode(200))
-	assert.True(t, isValidHttpCode(202))
-	assert.True(t, isValidHttpCode(204))
+func TestIsValidHTTPCodeSuccess(t *testing.T) {
+	assert.True(t, isValidHTTPCode(200))
+	assert.True(t, isValidHTTPCode(202))
+	assert.True(t, isValidHTTPCode(204))
 }
 
-func TestIsValidHttpCodeError(t *testing.T) {
-	assert.False(t, isValidHttpCode(300))
-	assert.False(t, isValidHttpCode(404))
-	assert.False(t, isValidHttpCode(400))
+func TestIsValidHTTPCodeError(t *testing.T) {
+	assert.False(t, isValidHTTPCode(300))
+	assert.False(t, isValidHTTPCode(404))
+	assert.False(t, isValidHTTPCode(400))
 }
 
 func TestSendLogRegistrationRequestFailure(t *testing.T) {

--- a/pkg/serverless/registration/logs_api_test.go
+++ b/pkg/serverless/registration/logs_api_test.go
@@ -1,0 +1,159 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package registration
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const registerLogsTimeout = 10 * time.Millisecond
+
+func TestBuildLogRegistrationPayload(t *testing.T) {
+	payload := buildLogRegistrationPayload("myUri", "platform function", 10, 100, 1000)
+	assert.Equal(t, "HTTP", payload.Destination.Protocol)
+	assert.Equal(t, "myUri", payload.Destination.URI)
+	assert.Equal(t, 10, payload.Buffering.TimeoutMs)
+	assert.Equal(t, 100, payload.Buffering.MaxBytes)
+	assert.Equal(t, 1000, payload.Buffering.MaxItems)
+	assert.Equal(t, []string{"platform", "function"}, payload.Types)
+}
+
+func TestBuildLogRegistrationRequestSuccess(t *testing.T) {
+	request, err := buildLogRegistrationRequest("myUrl", "X-Extension", "Content-Type", "myId", []byte("test"))
+	assert.Nil(t, err)
+	assert.Equal(t, http.MethodPut, request.Method)
+	assert.Equal(t, "myUrl", request.URL.Path)
+	assert.NotNil(t, request.Body)
+	assert.Equal(t, "myId", request.Header["X-Extension"][0])
+	assert.Equal(t, "application/json", request.Header["Content-Type"][0])
+}
+
+func TestBuildLogRegistrationRequestError(t *testing.T) {
+	request, err := buildLogRegistrationRequest(":invalid:", "X-Extension", "Content-Type", "myId", []byte("test"))
+	assert.NotNil(t, err)
+	assert.Nil(t, request)
+}
+
+func TestIsValidHttpCodeSuccess(t *testing.T) {
+	assert.True(t, isValidHttpCode(200))
+	assert.True(t, isValidHttpCode(202))
+	assert.True(t, isValidHttpCode(204))
+}
+
+func TestIsValidHttpCodeError(t *testing.T) {
+	assert.False(t, isValidHttpCode(300))
+	assert.False(t, isValidHttpCode(404))
+	assert.False(t, isValidHttpCode(400))
+}
+
+func TestSendLogRegistrationRequestFailure(t *testing.T) {
+	response, err := sendLogRegistrationRequest(&http.Client{}, &http.Request{})
+	assert.Nil(t, response)
+	assert.NotNil(t, err)
+}
+
+func TestSendLogRegistrationRequestSuccess(t *testing.T) {
+	response, err := sendLogRegistrationRequest(&ClientMock{}, &http.Request{})
+	assert.Nil(t, err)
+	assert.NotNil(t, response)
+}
+
+func TestSubscribeLogsSuccess(t *testing.T) {
+	payload := buildLogRegistrationPayload("myUri", "platform function", 10, 100, 1000)
+	//fake the register route
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer ts.Close()
+
+	err := subscribeLogs("myId", ts.URL, registerLogsTimeout, payload)
+	assert.Nil(t, err)
+}
+
+func TestSubscribeLogsTimeout(t *testing.T) {
+	payload := buildLogRegistrationPayload("myUri", "platform function", 10, 100, 1000)
+	//fake the register route
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// timeout
+		time.Sleep(registerLogsTimeout + 10*time.Millisecond)
+		w.WriteHeader(200)
+	}))
+	defer ts.Close()
+
+	err := subscribeLogs("myId", ts.URL, registerLogsTimeout, payload)
+	assert.NotNil(t, err)
+}
+
+func TestSubscribeLogsInvalidHttpCode(t *testing.T) {
+	payload := buildLogRegistrationPayload("myUri", "platform function", 10, 100, 1000)
+	//fake the register route
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// invalid code
+		w.WriteHeader(500)
+	}))
+	defer ts.Close()
+
+	err := subscribeLogs("myId", ts.URL, registerLogsTimeout, payload)
+	assert.NotNil(t, err)
+}
+
+func TestSubscribeLogsInvalidUrl(t *testing.T) {
+	payload := buildLogRegistrationPayload("myUri", "platform function", 10, 100, 1000)
+	err := subscribeLogs("myId", ":invalid:", registerLogsTimeout, payload)
+	assert.NotNil(t, err)
+}
+
+type ImpossibleToMarshall struct{}
+
+func (p *ImpossibleToMarshall) MarshalJSON() ([]byte, error) {
+	return nil, fmt.Errorf("should fail")
+}
+
+func TestSubscribeLogsInvalidPayloadObject(t *testing.T) {
+	payload := &ImpossibleToMarshall{}
+	err := subscribeLogs("myId", ":invalid:", registerLogsTimeout, payload)
+	assert.NotNil(t, err)
+}
+
+func TestGetLogTypesToSubscribeEmpty(t *testing.T) {
+	result := getLogTypesToSubscribe("")
+	assert.Equal(t, 3, len(result))
+	assert.Equal(t, "platform", result[0])
+	assert.Equal(t, "function", result[1])
+	assert.Equal(t, "extension", result[2])
+}
+
+func TestGetLogTypesToSubscribeInvalid(t *testing.T) {
+	result := getLogTypesToSubscribe("invalid log type")
+	assert.Empty(t, result)
+}
+
+func TestGetLogTypesToSubscribeValid(t *testing.T) {
+	result := getLogTypesToSubscribe("function blabla extension")
+	assert.Equal(t, 2, len(result))
+	assert.Equal(t, "function", result[0])
+}
+
+func TestBuildCallbackURI(t *testing.T) {
+	assert.Equal(t, "http://sandbox:1234/myPath", buildCallbackURI(1234, "/myPath"))
+}
+
+func TestEnableLogsCollection(t *testing.T) {
+	//fake the register route
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(200)
+	}))
+	defer ts.Close()
+
+	err := EnableLogsCollection("myId", ts.URL, registerLogsTimeout, "platform function", 1234, "/route", 10, 100, 1000)
+	assert.Nil(t, err)
+}

--- a/pkg/serverless/registration/utils.go
+++ b/pkg/serverless/registration/utils.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package registration
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// ID is the extension ID within the AWS Extension environment.
+type ID string
+
+// String returns the string value for this ID.
+func (i ID) String() string {
+	return string(i)
+}
+
+// HttpClient represents an Http Client
+type HttpClient interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+func BuildURL(prefix string, route string) string {
+	if len(prefix) == 0 {
+		return fmt.Sprintf("http://localhost:9001%s", route)
+	}
+	return fmt.Sprintf("http://%s%s", prefix, route)
+}

--- a/pkg/serverless/registration/utils.go
+++ b/pkg/serverless/registration/utils.go
@@ -18,11 +18,12 @@ func (i ID) String() string {
 	return string(i)
 }
 
-// HttpClient represents an Http Client
-type HttpClient interface {
+// HTTPClient represents an Http Client
+type HTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
+// BuildURL builds and URL with a prefix and a route
 func BuildURL(prefix string, route string) string {
 	if len(prefix) == 0 {
 		return fmt.Sprintf("http://localhost:9001%s", route)

--- a/pkg/serverless/registration/utils_test.go
+++ b/pkg/serverless/registration/utils_test.go
@@ -1,0 +1,30 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package registration
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type ClientMock struct {
+}
+
+func (c *ClientMock) Do(req *http.Request) (*http.Response, error) {
+	return &http.Response{}, nil
+}
+
+func TestBuildUrlPrefixEmpty(t *testing.T) {
+	builtUrl := BuildURL("", "/myPath")
+	assert.Equal(t, "http://localhost:9001/myPath", builtUrl)
+}
+
+func TestBuildUrlWithPrefix(t *testing.T) {
+	builtUrl := BuildURL("myPrefix:3000", "/myPath")
+	assert.Equal(t, "http://myPrefix:3000/myPath", builtUrl)
+}

--- a/pkg/serverless/registration/utils_test.go
+++ b/pkg/serverless/registration/utils_test.go
@@ -20,11 +20,11 @@ func (c *ClientMock) Do(req *http.Request) (*http.Response, error) {
 }
 
 func TestBuildUrlPrefixEmpty(t *testing.T) {
-	builtUrl := BuildURL("", "/myPath")
-	assert.Equal(t, "http://localhost:9001/myPath", builtUrl)
+	builtURL := BuildURL("", "/myPath")
+	assert.Equal(t, "http://localhost:9001/myPath", builtURL)
 }
 
 func TestBuildUrlWithPrefix(t *testing.T) {
-	builtUrl := BuildURL("myPrefix:3000", "/myPath")
-	assert.Equal(t, "http://myPrefix:3000/myPath", builtUrl)
+	builtURL := BuildURL("myPrefix:3000", "/myPath")
+	assert.Equal(t, "http://myPrefix:3000/myPath", builtURL)
 }

--- a/pkg/serverless/serverless.go
+++ b/pkg/serverless/serverless.go
@@ -26,15 +26,11 @@ import (
 )
 
 const (
-	routeRegister      string = "/2020-01-01/extension/register"
-	routeEventNext     string = "/2020-01-01/extension/event/next"
-	routeInitError     string = "/2020-01-01/extension/init/error"
-	routeSubscribeLogs string = "/2020-08-15/logs"
+	routeEventNext string = "/2020-01-01/extension/event/next"
+	routeInitError string = "/2020-01-01/extension/init/error"
 
-	headerExtName     string = "Lambda-Extension-Name"
-	headerExtID       string = "Lambda-Extension-Identifier"
-	headerExtErrType  string = "Lambda-Extension-Function-Error-Type"
-	headerContentType string = "Content-Type"
+	headerExtID      string = "Lambda-Extension-Identifier"
+	headerExtErrType string = "Lambda-Extension-Function-Error-Type"
 
 	requestTimeout     time.Duration = 5 * time.Second
 	clientReadyTimeout time.Duration = 2 * time.Second


### PR DESCRIPTION
### What does this PR do?

- create the registration package
- refactor Extension Registering + Log Registering with 100% pure function, easier to test
- add 100% unit-test coverage to this package

### Motivation

Engineering sprint

### Describe how to test your changes

Integration tests + unit tests

### Checklist
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
