### PR TITLE
[install_script] Fix SUSE version detection mechanism

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -470,7 +470,7 @@ elif [ "$OS" = "SUSE" ]; then
   SUSE_VER=$(cat /etc/os-release 2>/dev/null | grep VERSION_ID | tr -d '"' | tr . = | cut -d = -f 2 | xargs echo)
   if [ -z "$SUSE_VER" ]; then
     # if there's no /etc/os-release, set version to 0, because we don't really care about the exact version
-    $SUSE_VER="0"
+    SUSE_VER="0"
   fi
   if [ "$SUSE_VER" -ge 15 ]; then
     gpgkeys=''

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -434,6 +434,7 @@ elif [ "$OS" = "SUSE" ]; then
   fi
 
   # Try to guess if we're installing on SUSE 11, as it needs a different flow to work
+  # Note that SUSE11 doesn't have /etc/os-release file, so we have to use /etc/SuSE-release
   if cat /etc/SuSE-release 2>/dev/null | grep VERSION | grep 11; then
     SUSE11="yes"
   fi
@@ -462,8 +463,15 @@ elif [ "$OS" = "SUSE" ]; then
     fi
   fi
 
-  # parse the major version number out of the distro release info file. xargs is used to trim whitespace.
-  SUSE_VER=$( (cat /etc/SuSE-release 2>/dev/null; cat /etc/SUSE-brand 2>/dev/null) | grep VERSION | tr . = | cut -d = -f 2 | xargs echo)
+  # Parse the major version number out of the distro release info file. xargs is used to trim whitespace.
+  # NOTE: We use this to find out whether or not release version is >= 15, so we have to use /etc/os-release,
+  # as /etc/SuSE-release has been deprecated and is no longer present everywhere, e.g. in AWS AMI.
+  # See https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15/#fate-324409
+  SUSE_VER=$(cat /etc/os-release 2>/dev/null | grep VERSION_ID | tr -d '"' | tr . = | cut -d = -f 2 | xargs echo)
+  if [ -z "$SUSE_VER" ]; then
+    # if there's no /etc/os-release, set version to 0, because we don't really care about the exact version
+    $SUSE_VER="0"
+  fi
   if [ "$SUSE_VER" -ge 15 ]; then
     gpgkeys=''
     separator='\n       '

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -468,11 +468,8 @@ elif [ "$OS" = "SUSE" ]; then
   # as /etc/SuSE-release has been deprecated and is no longer present everywhere, e.g. in AWS AMI.
   # See https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15/#fate-324409
   SUSE_VER=$(cat /etc/os-release 2>/dev/null | grep VERSION_ID | tr -d '"' | tr . = | cut -d = -f 2 | xargs echo)
-  if [ -z "$SUSE_VER" ]; then
-    # if there's no /etc/os-release, set version to 0, because we don't really care about the exact version
-    SUSE_VER="0"
-  fi
-  if [ "$SUSE_VER" -ge 15 ]; then
+  gpgkeys="https://${keys_url}/DATADOG_RPM_KEY_CURRENT.public"
+  if [ -n "$SUSE_VER" ] && [ "$SUSE_VER" -ge 15 ]; then
     gpgkeys=''
     separator='\n       '
     for key_path in "${RPM_GPG_KEYS[@]}"; do
@@ -483,8 +480,6 @@ elif [ "$OS" = "SUSE" ]; then
         gpgkeys="${gpgkeys:+"${gpgkeys}${separator}"}https://${keys_url}/${key_path}"
       done
     fi
-  else
-    gpgkeys="https://${keys_url}/DATADOG_RPM_KEY_CURRENT.public"
   fi
 
   echo -e "\033[34m\n* Installing YUM Repository for Datadog\n\033[0m"

--- a/releasenotes-installscript/notes/fix-suse-version-detection-2274efb2f13ef9a1.yaml
+++ b/releasenotes-installscript/notes/fix-suse-version-detection-2274efb2f13ef9a1.yaml
@@ -1,0 +1,11 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG-INSTALLSCRIPT.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix SUSE version detection algorithm to work without deprecated /etc/SuSE-release file.


### PR DESCRIPTION
### What does this PR do?

Fixes detection of version on SUSE >= 15 where /etc/SuSE-release is deprecated and not guaranteed to be present (it's missing e.g. on AWS AMIs). See https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15/#fate-324409 for more details.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Ensure that no such warning is emitted when running on SUSE 15 (with neither `/etc/SuSE-release` nor `/etc/SUSE-brand` present): `bash: line 444: [: : integer expression expected` (the line number may vary) and that all these keys are present in the repofile `/etc/zypp/repos.d/datadog.repo` under the `gpgkey` section:

* DATADOG_RPM_KEY_CURRENT.public
* DATADOG_RPM_KEY_E09422B3.public
* DATADOG_RPM_KEY_FD4BF915.public

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
