### PR TITLE
[CWS] fix errors with docker functional tests

### DIFF
--- a/pkg/security/tests/chown32_test.go
+++ b/pkg/security/tests/chown32_test.go
@@ -318,7 +318,7 @@ func checkSyscallTester(t *testing.T, path string) {
 	t.Helper()
 	sideTester := exec.Command(path, "check")
 	if _, err := sideTester.CombinedOutput(); err != nil {
-		t.Skip("cannot run syscall tester check")
+		t.Error("cannot run syscall tester check")
 	}
 }
 

--- a/pkg/security/tests/chown32_test.go
+++ b/pkg/security/tests/chown32_test.go
@@ -18,11 +18,6 @@ import (
 )
 
 func TestChown32(t *testing.T) {
-	// The docker container used in functional tests is not able to run a x86 executable by default so we skip those tests
-	if testEnvironment == DockerEnvironment {
-		t.Skip("running in docker env, skipping x86 syscall tests")
-	}
-
 	ruleDef := &rules.RuleDefinition{
 		ID:         "test_rule",
 		Expression: `chown.file.path == "{{.Root}}/test-chown" && chown.file.destination.uid in [100, 101, 102, 103, 104, 105, 106] && chown.file.destination.gid in [200, 201, 202, 203, 204, 205, 206]`,
@@ -323,7 +318,7 @@ func checkSyscallTester(t *testing.T, path string) {
 	t.Helper()
 	sideTester := exec.Command(path, "check")
 	if _, err := sideTester.CombinedOutput(); err != nil {
-		t.Skip()
+		t.Skip("cannot run syscall tester check")
 	}
 }
 

--- a/pkg/security/tests/chown32_test.go
+++ b/pkg/security/tests/chown32_test.go
@@ -12,12 +12,25 @@ import (
 	"os/exec"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/tests/syscall_tester"
 	"gotest.tools/assert"
 )
 
 func TestChown32(t *testing.T) {
+	isSuseKernel := func() bool {
+		kv, err := kernel.NewKernelVersion()
+		if err != nil {
+			return false
+		}
+		return kv.IsSuseKernel()
+	}()
+
+	if isSuseKernel {
+		t.Skip("SUSE kernel: skipping chown32 tests")
+	}
+
 	ruleDef := &rules.RuleDefinition{
 		ID:         "test_rule",
 		Expression: `chown.file.path == "{{.Root}}/test-chown" && chown.file.destination.uid in [100, 101, 102, 103, 104, 105, 106] && chown.file.destination.gid in [200, 201, 202, 203, 204, 205, 206]`,

--- a/pkg/security/tests/chown32_test.go
+++ b/pkg/security/tests/chown32_test.go
@@ -326,7 +326,10 @@ func runSyscallTesterFunc(t *testing.T, path string, args ...string) {
 	t.Helper()
 	sideTester := exec.Command(path, args...)
 	if output, err := sideTester.CombinedOutput(); err != nil {
-		t.Error(string(output))
 		t.Error(err)
+		output := string(output)
+		if output != "" {
+			t.Error(output)
+		}
 	}
 }

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -363,12 +363,7 @@ RUN apt-get update -y \
             f.write(dockerfile)
 
         cmd = 'docker build {docker_file_ctx} --tag {image_tag}'
-        ctx.run(
-            cmd.format(**{
-                "docker_file_ctx": temp_dir,
-                "image_tag": docker_image_tag_name,
-            })
-        )
+        ctx.run(cmd.format(**{"docker_file_ctx": temp_dir, "image_tag": docker_image_tag_name,}))
 
     container_name = 'security-agent-tests'
     capabilities = ['SYS_ADMIN', 'SYS_RESOURCE', 'SYS_PTRACE', 'NET_ADMIN', 'IPC_LOCK', 'ALL']

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -347,8 +347,10 @@ def docker_functional_tests(
     dockerfile = """
 FROM debian:bullseye
 
+RUN dpkg --add-architecture i386
+
 RUN apt-get update -y \
-    && apt-get install -y --no-install-recommends xfsprogs \
+    && apt-get install -y --no-install-recommends xfsprogs libc6:i386 \
     && rm -rf /var/lib/apt/lists/*
     """
 

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -374,6 +374,7 @@ RUN apt-get update -y \
     capabilities = ['SYS_ADMIN', 'SYS_RESOURCE', 'SYS_PTRACE', 'NET_ADMIN', 'IPC_LOCK', 'ALL']
 
     cmd = 'docker run --name {container_name} {caps} --privileged -d --pid=host '
+    cmd += '-v /dev:/dev '
     cmd += '-v /proc:/host/proc -e HOST_PROC=/host/proc '
     cmd += '-v {GOPATH}/src/{REPO_PATH}/pkg/security/tests:/tests {image_tag} sleep 3600'
 

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -80,7 +80,7 @@ if node['platform_family'] != 'windows'
     end
   end
 
-  if not platform_family?('suse', 'rhel')
+  if not platform_family?('suse')
     package 'Install i386 libc' do
       case node[:platform]
       when 'redhat', 'centos', 'fedora'

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -69,7 +69,7 @@ if node['platform_family'] != 'windows'
 
     docker_exec 'install_xfs' do
       container 'docker-testsuite'
-      command ['yum', '-y', 'install', 'xfsprogs', 'e2fsprogs']
+      command ['yum', '-y', 'install', 'xfsprogs', 'e2fsprogs', 'glibc.i686']
     end
 
     for i in 0..7 do


### PR DESCRIPTION
### What does this PR do?

This PR fixes some problems we had with the `docker-functional-tests` task:
- the rename tests were not working because `xfsprogs` was not installed
- the chown32 tests were skipped because `libc6:i386` was not installed
- the rename tests were failing randomly because of a bug in how `/dev` is represented inside a privileged container

### Motivation

The goal of this PR is to be able to run docker functional tests locally in an easier way.

### Additional Notes

1) The solution chosen to fix the `/dev` problem, i.e. mounting the `/dev` volume, is only one of the potential solutions. One other possible solution would be to mount a `devtmpfs` in `/dev`. This works but breaks the TTYs (the TestProcessContext/tty test and `docker exec -it CONTAINER_NAME bash`) and would need quite a lot of work.

2) We are currently building the docker image in the task. This is OK because the image is cached correctly but is not the cleanest solution.
 
### Describe how to test your changes

The docker functional tests should pass
```
inv -e security-agent.docker-functional-tests --testflags "-loglevel debug -test.v"
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
