### PR TITLE
[networks] Fix HTTP serialization bug due to object pooling

### DIFF
--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -2,6 +2,7 @@ package encoding
 
 import (
 	"encoding/json"
+	"fmt"
 	"testing"
 
 	model "github.com/DataDog/agent-payload/process"
@@ -385,6 +386,68 @@ func TestHTTPSerializationWithLocalhostTraffic(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.Equal(t, out, result)
+}
+
+func TestPooledObjectGarbageRegression(t *testing.T) {
+	// This test ensures that no garbage data is accidentally
+	// left on pooled Connection objects used during serialization
+	httpKey := http.NewKey(
+		util.AddressFromString("10.0.15.1"),
+		util.AddressFromString("172.217.10.45"),
+		60000,
+		8080,
+		"",
+		http.MethodGet,
+	)
+
+	in := &network.Connections{
+		Conns: []network.ConnectionStats{
+			{
+				Source: util.AddressFromString("10.0.15.1"),
+				SPort:  uint16(60000),
+				Dest:   util.AddressFromString("172.217.10.45"),
+				DPort:  uint16(8080),
+			},
+		},
+	}
+
+	encodeAndDecodeHTTP := func(c *network.Connections) *model.HTTPAggregations {
+		marshaler := GetMarshaler("application/protobuf")
+		blob, err := marshaler.Marshal(c)
+		require.NoError(t, err)
+
+		unmarshaler := GetUnmarshaler("application/protobuf")
+		result, err := unmarshaler.Unmarshal(blob)
+		require.NoError(t, err)
+
+		httpBlob := result.Conns[0].HttpAggregations
+		if httpBlob == nil {
+			return nil
+		}
+
+		httpOut := new(model.HTTPAggregations)
+		err = proto.Unmarshal(httpBlob, httpOut)
+		require.NoError(t, err)
+		return httpOut
+	}
+
+	// Let's alternate between payloads with and without HTTP data
+	for i := 0; i < 1000; i++ {
+		if (i % 2) == 0 {
+			httpKey.Path = fmt.Sprintf("/path-%d", i)
+			in.HTTP = map[http.Key]http.RequestStats{httpKey: {}}
+			out := encodeAndDecodeHTTP(in)
+
+			require.NotNil(t, out)
+			require.Len(t, out.EndpointAggregations, 1)
+			require.Equal(t, httpKey.Path, out.EndpointAggregations[0].Path)
+		} else {
+			// No HTTP data in this payload, so we should never get HTTP data back after the serialization
+			in.HTTP = nil
+			out := encodeAndDecodeHTTP(in)
+			require.Nil(t, out, "expected a nil object, but got garbage")
+		}
+	}
 }
 
 func unmarshalSketch(t *testing.T, bytes []byte) *ddsketch.DDSketch {

--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -207,6 +207,7 @@ func httpKeyFromConn(c network.ConnectionStats) http.Key {
 func returnToPool(c *model.Connections) {
 	if c.Conns != nil {
 		for _, c := range c.Conns {
+			c.Reset()
 			connPool.Put(c)
 		}
 	}

--- a/pkg/network/encoding/format_test.go
+++ b/pkg/network/encoding/format_test.go
@@ -1,6 +1,7 @@
 package encoding
 
 import (
+	"runtime"
 	"testing"
 
 	model "github.com/DataDog/agent-payload/process"
@@ -144,4 +145,14 @@ func TestFormatHTTPStats(t *testing.T) {
 	aggregationKey.Method = http.MethodUnknown
 	aggregations := result[aggregationKey].EndpointAggregations
 	assert.ElementsMatch(t, out.EndpointAggregations, aggregations)
+}
+
+func BenchmarkConnectionReset(b *testing.B) {
+	c := new(model.Connection)
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		c.Reset()
+	}
+	runtime.KeepAlive(c)
 }


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where HTTP "garbage" data may be accidentally sent to the backend due to a serialization bug.
Please note that this feature is still in test stage, so there is no customer impact.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
