### PR TITLE
Do not spawn tagger pull in a background goroutine

### DIFF
--- a/pkg/tagger/local/tagger.go
+++ b/pkg/tagger/local/tagger.go
@@ -124,9 +124,9 @@ func (t *Tagger) run() error {
 		case msg := <-t.infoIn:
 			t.store.processTagInfo(msg)
 		case <-t.retryTicker.C:
-			go t.startCollectors(ctx)
+			t.startCollectors(ctx)
 		case <-t.pullTicker.C:
-			go t.pull(ctx)
+			t.pull(ctx)
 		case <-t.pruneTicker.C:
 			t.store.prune()
 		case <-t.telemetryTicker.C:

--- a/releasenotes/notes/no_async_for_tagger-0e1f1c582f8fd61b.yaml
+++ b/releasenotes/notes/no_async_for_tagger-0e1f1c582f8fd61b.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    In case of internal problem to the tagger, flag the `tagger` component as unhealthy (in the output of `agent health`) instead of leaking goroutines.


### PR DESCRIPTION
### What does this PR do?

Do not spawn tag puller in a background goroutine.

### Motivation

Spawning `t.pull(…)` or `t.startCollectors(…)` in a background goroutine instead of directly from the `(t *Tagger) run()` goroutine defeats the purpose of the health checker:
If `t.pull(…)` falls into an infinite loop or a deadlock or whatever that makes the function never return, it will not make the tagger component unhealthy.
So, the issue will remain unnoticed. We would “just” leak goroutines.

### Additional Notes

This PR should also fix this issue: https://github.com/DataDog/datadog-agent/pull/8383#issuecomment-868512299.

### Describe how to test your changes

* Check that the tagger is still working and its content is still dynamically updated by adding and removing monitored workload.
* Check that the `trace-agent` isn’t logging `… | TRACE | WARN | (pkg/tagger/local/tagger.go:224 in pull) | Error pulling from …: …: context canceled` in loop as described in https://github.com/DataDog/datadog-agent/pull/8383#issuecomment-868512299 anymore.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [X] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [X] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
