### PR TITLE
Handle nested CNAME records in DNS packet capture

### DIFF
--- a/pkg/network/dns_parser.go
+++ b/pkg/network/dns_parser.go
@@ -2,7 +2,6 @@ package network
 
 import (
 	"bytes"
-	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/process/util"
@@ -163,7 +162,7 @@ func (p *dnsParser) parseAnswerInto(
 	pktInfo.queryType = QueryType(question.Type)
 	alias := p.extractCNAME(question.Name, dns.Answers)
 	p.extractIPsInto(alias, dns.Answers, t)
-	t.dns = strings.ToLower(string(question.Name))
+	t.dns = string(bytes.ToLower(question.Name))
 
 	pktInfo.pktType = SuccessfulResponse
 	return nil


### PR DESCRIPTION
### What does this PR do?

If DNS answers contain more than 1 CNAME answer before reaching the A record, we would not capture the 
IP -> domain association.

Example:
```
example.com CNAME www.example.com
www.example.com CNAME www.us1.example.com
www.us1.example.com A 1.1.1.1
```

### Motivation

Problem with DNS in demo environment surfaced this issue.

### Additional Notes

This removes the processing of the `additional` DNS answer section, which was unnecessary.

### Describe how to test your changes

Automated tests were added.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.

Note: Adding GitHub labels is only possible for contributors with write access.
