### PR TITLE
Fix race in TestBootTimeRefresh test

### DIFF
--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -26,8 +26,9 @@ var (
 	skipLocalTest = true
 )
 
-func getProbeWithPermission() *Probe {
-	return NewProcessProbe(WithPermission(true))
+func getProbeWithPermission(options ...Option) *Probe {
+	options = append(options, WithPermission(true))
+	return NewProcessProbe(options...)
 }
 
 func TestGetActivePIDs(t *testing.T) {
@@ -757,8 +758,7 @@ func TestBootTimeLocalFS(t *testing.T) {
 
 func TestBootTimeRefresh(t *testing.T) {
 	os.Setenv("HOST_PROC", "resources/test_procfs/proc/")
-	bootTimeRefreshInterval = 500 * time.Millisecond
-	probe := getProbeWithPermission()
+	probe := getProbeWithPermission(WithBootTimeRefreshInterval(500 * time.Millisecond))
 	defer probe.Close()
 
 	assert.Equal(t, uint64(1606127264), atomic.LoadUint64(&probe.bootTime))


### PR DESCRIPTION
### What does this PR do?

Do not set bootTimeRefreshInterval as a global variable

### Motivation

Fix race in TestBootTimeRefresh test

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
