### PR TITLE
pkg/trace/config: attempt to acquire hostname via gRPC

### DIFF
--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -21,8 +21,10 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/proto/pbgo"
 	"github.com/DataDog/datadog-agent/pkg/trace/config/features"
 	"github.com/DataDog/datadog-agent/pkg/util/fargate"
+	"github.com/DataDog/datadog-agent/pkg/util/grpc"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -203,8 +205,12 @@ func (c *AgentConfig) validate() error {
 		return errors.New("agent binary path not set")
 	}
 	if c.Hostname == "" {
+		// no user-set hostname, try to acquire
 		if err := c.acquireHostname(); err != nil {
-			return err
+			log.Debugf("Could not get hostname via gRPC: %v. Falling back to other methods.", err)
+			if err := c.acquireHostnameFallback(); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -214,18 +220,40 @@ func (c *AgentConfig) validate() error {
 // when it can not be obtained by any other means. It is replaced in tests.
 var fallbackHostnameFunc = os.Hostname
 
-// acquireHostname attempts to acquire a hostname for this configuration. It
+// acquireHostname attempts to acquire a hostname for the trace-agent by connecting to the core agent's
+// gRPC endpoints. If it fails, it will return an error.
+func (c *AgentConfig) acquireHostname() error {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	client, err := grpc.GetDDAgentClient(ctx)
+	if err != nil {
+		return err
+	}
+	reply, err := client.GetHostname(ctx, &pbgo.HostnameRequest{})
+	if err != nil {
+		return err
+	}
+	if features.Has("disable_empty_hostname") && reply.Hostname == "" {
+		log.Debugf("Acquired empty hostname from gRPC but it's disallowed.")
+		return errors.New("empty hostname disallowed")
+	}
+	c.Hostname = reply.Hostname
+	log.Infof("Acquired hostname from gRPC: %s", c.Hostname)
+	return nil
+}
+
+// acquireHostnameFallback attempts to acquire a hostname for this configuration. It
 // tries to shell out to the infrastructure agent for this, if DD_AGENT_BIN is
 // set, otherwise falling back to os.Hostname.
-func (c *AgentConfig) acquireHostname() error {
+func (c *AgentConfig) acquireHostnameFallback() error {
 	var out bytes.Buffer
 	cmd := exec.Command(c.DDAgentBin, "hostname")
 	cmd.Env = append(os.Environ(), cmd.Env...) // needed for Windows
 	cmd.Stdout = &out
 	err := cmd.Run()
 	c.Hostname = strings.TrimSpace(out.String())
-	if hostnameDisallowed := features.Has("disable_empty_hostname") && c.Hostname == ""; err != nil || hostnameDisallowed {
-		if hostnameDisallowed {
+	if emptyDisallowed := features.Has("disable_empty_hostname") && c.Hostname == ""; err != nil || emptyDisallowed {
+		if emptyDisallowed {
 			log.Debugf("Core agent returned empty hostname but is disallowed by disable_empty_hostname feature flag. Falling back to os.Hostname.")
 		}
 		// There was either an error retrieving the hostname from the core agent, or
@@ -233,6 +261,9 @@ func (c *AgentConfig) acquireHostname() error {
 		host, err2 := fallbackHostnameFunc()
 		if err2 != nil {
 			return fmt.Errorf("couldn't get hostname from agent (%q), nor from OS (%q). Try specifying it by means of config or the DD_HOSTNAME env var", err, err2)
+		}
+		if emptyDisallowed && host == "" {
+			return errors.New("empty hostname disallowed")
 		}
 		c.Hostname = host
 		log.Infof("Acquired hostname from OS: %q. Core agent was unreachable at %q: %v.", c.Hostname, c.DDAgentBin, err)

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -238,7 +238,7 @@ func (c *AgentConfig) acquireHostname() error {
 		return errors.New("empty hostname disallowed")
 	}
 	c.Hostname = reply.Hostname
-	log.Infof("Acquired hostname from gRPC: %s", c.Hostname)
+	log.Debugf("Acquired hostname from gRPC: %s", c.Hostname)
 	return nil
 }
 
@@ -266,10 +266,10 @@ func (c *AgentConfig) acquireHostnameFallback() error {
 			return errors.New("empty hostname disallowed")
 		}
 		c.Hostname = host
-		log.Infof("Acquired hostname from OS: %q. Core agent was unreachable at %q: %v.", c.Hostname, c.DDAgentBin, err)
+		log.Debugf("Acquired hostname from OS: %q. Core agent was unreachable at %q: %v.", c.Hostname, c.DDAgentBin, err)
 		return nil
 	}
-	log.Infof("Acquired hostname from core agent (%s): %q.", c.DDAgentBin, c.Hostname)
+	log.Debugf("Acquired hostname from core agent (%s): %q.", c.DDAgentBin, c.Hostname)
 	return nil
 }
 

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -130,14 +130,14 @@ func TestConfigHostname(t *testing.T) {
 		t.Run("good", func(t *testing.T) {
 			cfg := AgentConfig{DDAgentBin: makeProgram("host.name", 0)}
 			defer os.Remove(cfg.DDAgentBin)
-			assert.NoError(t, cfg.acquireHostname())
+			assert.NoError(t, cfg.acquireHostnameFallback())
 			assert.Equal(t, cfg.Hostname, "host.name")
 		})
 
 		t.Run("empty", func(t *testing.T) {
 			cfg := AgentConfig{DDAgentBin: makeProgram("", 0)}
 			defer os.Remove(cfg.DDAgentBin)
-			assert.NoError(t, cfg.acquireHostname())
+			assert.NoError(t, cfg.acquireHostnameFallback())
 			assert.Empty(t, cfg.Hostname)
 		})
 
@@ -147,21 +147,21 @@ func TestConfigHostname(t *testing.T) {
 
 			cfg := AgentConfig{DDAgentBin: makeProgram("", 0)}
 			defer os.Remove(cfg.DDAgentBin)
-			assert.NoError(t, cfg.acquireHostname())
+			assert.NoError(t, cfg.acquireHostnameFallback())
 			assert.Equal(t, "fallback.host", cfg.Hostname)
 		})
 
 		t.Run("fallback1", func(t *testing.T) {
 			cfg := AgentConfig{DDAgentBin: makeProgram("", 1)}
 			defer os.Remove(cfg.DDAgentBin)
-			assert.NoError(t, cfg.acquireHostname())
+			assert.NoError(t, cfg.acquireHostnameFallback())
 			assert.Equal(t, cfg.Hostname, "fallback.host")
 		})
 
 		t.Run("fallback2", func(t *testing.T) {
 			cfg := AgentConfig{DDAgentBin: makeProgram("some text", 1)}
 			defer os.Remove(cfg.DDAgentBin)
-			assert.NoError(t, cfg.acquireHostname())
+			assert.NoError(t, cfg.acquireHostnameFallback())
 			assert.Equal(t, cfg.Hostname, "fallback.host")
 		})
 	})
@@ -351,9 +351,9 @@ func TestUndocumentedYamlConfig(t *testing.T) {
 	assert.Equal(0.05, c.AnalyzedSpansByService["db"]["intake"])
 }
 
-func TestAcquireHostname(t *testing.T) {
+func TestAcquireHostnameFallback(t *testing.T) {
 	c := New()
-	err := c.acquireHostname()
+	err := c.acquireHostnameFallback()
 	assert.Nil(t, err)
 	host, _ := os.Hostname()
 	assert.Equal(t, host, c.Hostname)

--- a/releasenotes/notes/apm-obtain-hostname-via-grpc-e3c1e6f961a86aa7.yaml
+++ b/releasenotes/notes/apm-obtain-hostname-via-grpc-e3c1e6f961a86aa7.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: Main hostname acquisition now happens via gRPC to the Datadog Agent.


### PR DESCRIPTION
This change sets the running core agent's gRPC endpoints as the main
source for obtaining the hostname. The old code is now used as fallback
only.
