### PR TITLE
[install_script] Changelog for 1.5.0 + bump version to 1.5.0.post

### DIFF
--- a/CHANGELOG-INSTALLSCRIPT.rst
+++ b/CHANGELOG-INSTALLSCRIPT.rst
@@ -2,6 +2,44 @@
 Release Notes
 =============
 
+.. _Release Notes_installscript-1.5.0:
+
+installscript-1.5.0
+===================
+
+.. _Release Notes_installscript-1.5.0_New Features:
+
+New Features
+------------
+
+- Adds capability to specify a minor (and optional patch) version by setting
+  the ``DD_AGENT_MINOR_VERSION`` variable.
+
+
+.. _Release Notes_installscript-1.5.0_Enhancement Notes:
+
+Enhancement Notes
+-----------------
+
+- Adds email validation before sending a report.
+
+- Improvements for APT keys management
+
+  - By default, get keys from keys.datadoghq.com, not Ubuntu keyserver
+  - Always add the ``DATADOG_APT_KEY_CURRENT.public`` key (contains key used to sign current repodata)
+  - Add ``signed-by`` option to all sources list lines
+  - On Debian >= 9 and Ubuntu >= 16, only add keys to ``/usr/share/keyrings/datadog-archive-keyring.gpg``
+  - On older systems, also add the same keyring to ``/etc/apt/trusted.gpg.d``
+
+
+.. _Release Notes_installscript-1.5.0_Bug Fixes:
+
+Bug Fixes
+---------
+
+- Fix SUSE version detection algorithm to work without deprecated ``/etc/SuSE-release`` file.
+
+
 .. _Release Notes_installscript-1.4.0:
 
 installscript-1.4.0

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -6,7 +6,7 @@
 # using the package manager and Datadog repositories.
 
 set -e
-install_script_version=1.5.0
+install_script_version=1.5.0.post
 logfile="ddagent-install.log"
 support_email=support@datadoghq.com
 

--- a/test/kitchen/test/integration/install-script/rspec/install-script_spec.rb
+++ b/test/kitchen/test/integration/install-script/rspec/install-script_spec.rb
@@ -26,7 +26,7 @@ shared_examples_for 'Agent installed by the install script' do
       expect(install_info['install_method']).to match(
         'tool' => 'install_script',
         'tool_version' => 'install_script',
-        'installer_version' => /^install_script-\d+\.\d+\.\d+$/
+        'installer_version' => /^install_script-\d+\.\d+\.\d+(.post)?$/
       )
     end
   end


### PR DESCRIPTION
### What does this PR do?

Adds changelog for installscript 1.5.0, bumps version to 1.5.0.post.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
