### PR TITLE
Align behavior of containerd and cri checks

### DIFF
--- a/pkg/collector/corechecks/containers/containerd/containerd.go
+++ b/pkg/collector/corechecks/containers/containerd/containerd.go
@@ -187,18 +187,6 @@ func computeMetrics(sender aggregator.Sender, cu cutil.ContainerdItf, fil *ddCon
 			continue
 		}
 
-		tags, err := collectTags(info)
-		if err != nil {
-			log.Errorf("Could not collect tags for container %s: %s", ctn.ID()[:12], err)
-		}
-		// Tagger tags
-		taggerTags, err := tagger.Tag(ddContainers.ContainerEntityPrefix+ctn.ID(), collectors.HighCardinality)
-		if err != nil {
-			log.Errorf(err.Error())
-			continue
-		}
-		tags = append(tags, taggerTags...)
-
 		metricTask, errTask := cu.TaskMetrics(ctn)
 		if errTask != nil {
 			log.Tracef("Could not retrieve metrics from task %s: %s", ctn.ID()[:12], errTask.Error())
@@ -210,6 +198,19 @@ func computeMetrics(sender aggregator.Sender, cu cutil.ContainerdItf, fil *ddCon
 			log.Errorf("Could not process the metrics from %s: %v", ctn.ID(), err.Error())
 			continue
 		}
+
+		tags, err := collectTags(info)
+		if err != nil {
+			log.Errorf("Could not collect tags for container %s: %s", ctn.ID()[:12], err)
+		}
+
+		// Tagger tags
+		taggerTags, err := tagger.Tag(ddContainers.ContainerEntityPrefix+ctn.ID(), collectors.HighCardinality)
+		if err != nil {
+			log.Errorf(err.Error())
+			continue
+		}
+		tags = append(tags, taggerTags...)
 
 		currentTime := time.Now()
 		computeUptime(sender, info, currentTime, tags)

--- a/pkg/collector/corechecks/containers/cri/cri.go
+++ b/pkg/collector/corechecks/containers/cri/cri.go
@@ -114,7 +114,7 @@ func (c *CRICheck) generateMetrics(sender aggregator.Sender, containerStats map[
 			continue
 		}
 
-		if ctnStatus == nil || c.isExcluded(ctnStatus) {
+		if ctnStatus == nil || ctnStatus.State != pb.ContainerState_CONTAINER_RUNNING || c.isExcluded(ctnStatus) {
 			continue
 		}
 

--- a/pkg/collector/corechecks/containers/cri/cri.go
+++ b/pkg/collector/corechecks/containers/cri/cri.go
@@ -108,6 +108,16 @@ func (c *CRICheck) generateMetrics(sender aggregator.Sender, containerStats map[
 			continue
 		}
 
+		ctnStatus, err := criUtil.GetContainerStatus(cid)
+		if err != nil {
+			log.Debugf("Could not retrieve the status of container %q: %s", cid, err)
+			continue
+		}
+
+		if ctnStatus == nil || c.isExcluded(ctnStatus) {
+			continue
+		}
+
 		entityID := containers.BuildTaggerEntityName(cid)
 		tags, err := tagger.Tag(entityID, collectors.HighCardinality)
 		if err != nil {
@@ -115,15 +125,8 @@ func (c *CRICheck) generateMetrics(sender aggregator.Sender, containerStats map[
 		}
 		tags = append(tags, "runtime:"+criUtil.GetRuntime())
 
-		ctnStatus, err := criUtil.GetContainerStatus(cid)
-		if err == nil && ctnStatus != nil {
-			if c.isExcluded(ctnStatus) {
-				continue
-			}
-
-			currentUnixTime := time.Now().UnixNano()
-			c.computeContainerUptime(sender, currentUnixTime, *ctnStatus, tags)
-		}
+		currentUnixTime := time.Now().UnixNano()
+		c.computeContainerUptime(sender, currentUnixTime, *ctnStatus, tags)
 
 		c.processContainerStats(sender, *stats, tags)
 	}

--- a/releasenotes/notes/cri-ignore-stopped-containers-5be41aeaafcf8e22.yaml
+++ b/releasenotes/notes/cri-ignore-stopped-containers-5be41aeaafcf8e22.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    The cri check no longer sends metrics for stopped containers, in line with
+    containerd and docker checks. These metrics were all zeros in the first
+    place, so no impact is expected.


### PR DESCRIPTION
### What does this PR do?

* cri/containerd: prevent calls to the tagger for stopped containers. This matches the behavior of the docker check, and reduces memory usage by preventing empty entities from being cached in the tagger
* cri: do not generate metrics for stopped containers. This matches the behavior of both the docker and containerd checks. Previously, the agent generated metrics with zero values for stopped containers.

### Describe how to test your changes

On a k8s cluster with containerd as the container runtime, check that stopped containers (such as from Cronjobs, Jobs, or init containers on any pod) don't generate any metrics by going to the DD app and looking at `cri.cpu.usage` (or other cri metrics). Stopped containers should stop reporting metrics at all, instead of reporting them as zeroes. Also check that other tags are still applied to the metrics.