### PR TITLE
Use Env AD to choose which providers to trigger in different components (tagger, hostname, host tags...)

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -251,6 +251,7 @@ github.com/cihub/seelog v0.0.0-20151216151435-d2c6e5aa9fbf h1:XI2tOTCBqEnMyN2j1y
 github.com/cihub/seelog v0.0.0-20151216151435-d2c6e5aa9fbf/go.mod h1:9d6lWj8KzO/fd/NrVaLscBKmPigpZpn5YawRPw+e3Yo=
 github.com/cilium/ebpf v0.0.0-20200110133405-4032b1d8aae3/go.mod h1:MA5e5Lr8slmEg9bt0VpxxWqJlO4iwu3FBdHUzV7wQVg=
 github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775/go.mod h1:7cR51M8ViRLIdUjrmSXlK9pkrsDlLHbO8jiB8X8JnOc=
+github.com/cilium/ebpf v0.2.0 h1:Fv93L3KKckEcEHR3oApXVzyBTDA8WAm6VXhPE00N3f8=
 github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX2Qs=
 github.com/cilium/ebpf v0.5.0 h1:E1KshmrMEtkMP2UjlWzfmUV1owWY+BnbL5FxxuatnrU=
 github.com/cilium/ebpf v0.5.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
@@ -763,14 +764,28 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
+<<<<<<< HEAD
+=======
+github.com/itchyny/go-flags v1.5.0 h1:Z5q2ist2sfDjDlExVPBrMqlsEDxDR2h4zuOElB0OEYI=
+<<<<<<< HEAD
+>>>>>>> 2b1c5b0dd (Use Env AD to choose which providers to trigger in different components (tagger, hostname, host tags...))
 github.com/itchyny/go-flags v1.5.0/go.mod h1:lenkYuCobuxLBAd/HGFE4LRoW8D3B6iXRQfWYJ+MNbA=
+=======
+>>>>>>> 081273f20 (Use Env AD to choose which providers to trigger in different components (tagger, hostname, host tags...))
 github.com/itchyny/go-flags v1.5.0/go.mod h1:lenkYuCobuxLBAd/HGFE4LRoW8D3B6iXRQfWYJ+MNbA=
 github.com/itchyny/gojq v0.12.4 h1:8zgOZWMejEWCLjbF/1mWY7hY7QEARm7dtuhC6Bp4R8o=
 github.com/itchyny/gojq v0.12.4/go.mod h1:EQUSKgW/YaOxmXpAwGiowFDO4i2Rmtk5+9dFyeiymAg=
 github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921iRkU=
 github.com/itchyny/timefmt-go v0.1.3/go.mod h1:0osSSCQSASBJMsIZnhAaF1C2fCBTJZXrnj37mG8/c+A=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
+<<<<<<< HEAD
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
+<<<<<<< HEAD
+=======
+=======
+>>>>>>> 081273f20 (Use Env AD to choose which providers to trigger in different components (tagger, hostname, host tags...))
+github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a h1:BcF8coBl0QFVhe8vAMMlD+CV8EISiu9MGKLoj6ZEyJA=
+>>>>>>> 2b1c5b0dd (Use Env AD to choose which providers to trigger in different components (tagger, hostname, host tags...))
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
@@ -832,6 +847,7 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxv
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
+github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/go.sum
+++ b/go.sum
@@ -251,7 +251,6 @@ github.com/cihub/seelog v0.0.0-20151216151435-d2c6e5aa9fbf h1:XI2tOTCBqEnMyN2j1y
 github.com/cihub/seelog v0.0.0-20151216151435-d2c6e5aa9fbf/go.mod h1:9d6lWj8KzO/fd/NrVaLscBKmPigpZpn5YawRPw+e3Yo=
 github.com/cilium/ebpf v0.0.0-20200110133405-4032b1d8aae3/go.mod h1:MA5e5Lr8slmEg9bt0VpxxWqJlO4iwu3FBdHUzV7wQVg=
 github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775/go.mod h1:7cR51M8ViRLIdUjrmSXlK9pkrsDlLHbO8jiB8X8JnOc=
-github.com/cilium/ebpf v0.2.0 h1:Fv93L3KKckEcEHR3oApXVzyBTDA8WAm6VXhPE00N3f8=
 github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX2Qs=
 github.com/cilium/ebpf v0.5.0 h1:E1KshmrMEtkMP2UjlWzfmUV1owWY+BnbL5FxxuatnrU=
 github.com/cilium/ebpf v0.5.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
@@ -764,28 +763,12 @@ github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NH
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb1-client v0.0.0-20191209144304-8bf82d3c094d/go.mod h1:qj24IKcXYK6Iy9ceXlo3Tc+vtHo9lIhSX5JddghvEPo=
 github.com/ishidawataru/sctp v0.0.0-20190723014705-7c296d48a2b5/go.mod h1:DM4VvS+hD/kDi1U1QsX2fnZowwBhqD0Dk3bRPKF/Oc8=
-<<<<<<< HEAD
-=======
-github.com/itchyny/go-flags v1.5.0 h1:Z5q2ist2sfDjDlExVPBrMqlsEDxDR2h4zuOElB0OEYI=
-<<<<<<< HEAD
->>>>>>> 2b1c5b0dd (Use Env AD to choose which providers to trigger in different components (tagger, hostname, host tags...))
-github.com/itchyny/go-flags v1.5.0/go.mod h1:lenkYuCobuxLBAd/HGFE4LRoW8D3B6iXRQfWYJ+MNbA=
-=======
->>>>>>> 081273f20 (Use Env AD to choose which providers to trigger in different components (tagger, hostname, host tags...))
 github.com/itchyny/go-flags v1.5.0/go.mod h1:lenkYuCobuxLBAd/HGFE4LRoW8D3B6iXRQfWYJ+MNbA=
 github.com/itchyny/gojq v0.12.4 h1:8zgOZWMejEWCLjbF/1mWY7hY7QEARm7dtuhC6Bp4R8o=
 github.com/itchyny/gojq v0.12.4/go.mod h1:EQUSKgW/YaOxmXpAwGiowFDO4i2Rmtk5+9dFyeiymAg=
 github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921iRkU=
 github.com/itchyny/timefmt-go v0.1.3/go.mod h1:0osSSCQSASBJMsIZnhAaF1C2fCBTJZXrnj37mG8/c+A=
 github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
-<<<<<<< HEAD
-github.com/j-keck/arping v0.0.0-20160618110441-2cf9dc699c56/go.mod h1:ymszkNOg6tORTn+6F6j+Jc8TOr5osrynvN6ivFWZ2GA=
-<<<<<<< HEAD
-=======
-=======
->>>>>>> 081273f20 (Use Env AD to choose which providers to trigger in different components (tagger, hostname, host tags...))
-github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a h1:BcF8coBl0QFVhe8vAMMlD+CV8EISiu9MGKLoj6ZEyJA=
->>>>>>> 2b1c5b0dd (Use Env AD to choose which providers to trigger in different components (tagger, hostname, host tags...))
 github.com/jimstudt/http-authentication v0.0.0-20140401203705-3eca13d6893a/go.mod h1:wK6yTYYcgjHE1Z1QtXACPDjcFJyBskHEdagmnq3vsP8=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
@@ -847,7 +830,6 @@ github.com/konsorten/go-windows-terminal-sequences v1.0.3/go.mod h1:T0+1ngSBFLxv
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
-github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -467,6 +467,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("ignore_autoconf", []string{})
 	config.BindEnvAndSetDefault("autoconfig_from_environment", true)
 	config.BindEnvAndSetDefault("autoconfig_exclude_features", []string{})
+	config.BindEnvAndSetDefault("autoconfig_include_features", []string{})
 
 	// Docker
 	config.BindEnvAndSetDefault("docker_query_timeout", int64(5))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1069,7 +1069,7 @@ func load(config Config, origin string, loadSecret bool) (*Warnings, error) {
 	SanitizeAPIKeyConfig(config, "api_key")
 	// Environment feature detection needs to run before applying override funcs
 	// as it may provide such overrides
-	detectFeatures()
+	DetectFeatures()
 	applyOverrideFuncs(config)
 	// setTracemallocEnabled *must* be called before setNumWorkers
 	warnings.TraceMallocEnabledWithPy2 = setTracemallocEnabled(config)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1579,6 +1579,34 @@ api_key:
 # extra_config_providers:
 #   - clusterchecks
 
+## @param autoconfig_exclude_features - list of comma separated strings - optional
+## Exclude features automatically detected and enabled by environment autodiscovery.
+## Supported syntax is a list of `(<attribute>:)<regexp>`. Currently only the `name` attribute is supported.
+## When no attribute is present, it defaults to `name:` attribute.
+#
+# autoconfig_exclude_features:
+#  - cloudfoundry
+#  - containerd
+#  - cri
+#  - docker
+#  - ecsfargate
+#  - eksfargate
+#  - kubernetes
+#  - orchestratorexplorer
+
+## @param autoconfig_include_features - list of comma separated strings - optional
+## Force activation of features (as if they were discovered by environment autodiscovery).
+#
+# autoconfig_include_features:
+#  - cloudfoundry
+#  - containerd
+#  - cri
+#  - docker
+#  - ecsfargate
+#  - eksfargate
+#  - kubernetes
+#  - orchestratorexplorer
+
 {{ end -}}
 {{- if .Autodiscovery }}
 

--- a/pkg/config/environment.go
+++ b/pkg/config/environment.go
@@ -28,11 +28,7 @@ func IsContainerized() bool {
 // which is typically only set by Docker
 func IsDockerRuntime() bool {
 	_, err := os.Stat("/.dockerenv")
-	if err == nil {
-		return true
-	}
-
-	return false
+	return err == nil
 }
 
 // IsKubernetes returns whether the Agent is running on a kubernetes cluster

--- a/pkg/config/environment_containers.go
+++ b/pkg/config/environment_containers.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/system"
 )
 
+// Remember to also register feature in init()
 const (
 	// Docker socket present
 	Docker Feature = "docker"
@@ -31,9 +32,9 @@ const (
 	// EKSFargate environment
 	EKSFargate Feature = "eksfargate"
 	// KubeOrchestratorExplorer can be enabled
-	KubeOrchestratorExplorer Feature = "orchestratorExplorer"
+	KubeOrchestratorExplorer Feature = "orchestratorexplorer"
 	// CloudFoundry socket present
-	CloudFoundry Feature = "cloudFoundry"
+	CloudFoundry Feature = "cloudfoundry"
 
 	defaultLinuxDockerSocket       = "/var/run/docker.sock"
 	defaultWindowsDockerSocketPath = "//./pipe/docker_engine"
@@ -46,6 +47,17 @@ const (
 	socketTimeout     = 500 * time.Millisecond
 	connectionTimeout = 1 * time.Second
 )
+
+func init() {
+	registerFeature(Docker)
+	registerFeature(Containerd)
+	registerFeature(Cri)
+	registerFeature(Kubernetes)
+	registerFeature(ECSFargate)
+	registerFeature(EKSFargate)
+	registerFeature(KubeOrchestratorExplorer)
+	registerFeature(CloudFoundry)
+}
 
 func detectContainerFeatures(features FeatureMap) {
 	detectKubernetes(features)

--- a/pkg/config/environment_containers.go
+++ b/pkg/config/environment_containers.go
@@ -6,6 +6,7 @@
 package config
 
 import (
+	"net"
 	"os"
 	"path"
 	"runtime"
@@ -31,6 +32,8 @@ const (
 	EKSFargate Feature = "eksfargate"
 	// KubeOrchestratorExplorer can be enabled
 	KubeOrchestratorExplorer Feature = "orchestratorExplorer"
+	// CloudFoundry socket present
+	CloudFoundry Feature = "cloudFoundry"
 
 	defaultLinuxDockerSocket       = "/var/run/docker.sock"
 	defaultWindowsDockerSocketPath = "//./pipe/docker_engine"
@@ -40,7 +43,8 @@ const (
 	unixSocketPrefix               = "unix://"
 	winNamedPipePrefix             = "npipe://"
 
-	socketTimeout = 500 * time.Millisecond
+	socketTimeout     = 500 * time.Millisecond
+	connectionTimeout = 1 * time.Second
 )
 
 func detectContainerFeatures(features FeatureMap) {
@@ -48,6 +52,7 @@ func detectContainerFeatures(features FeatureMap) {
 	detectDocker(features)
 	detectContainerd(features)
 	detectFargate(features)
+	detectCloudFoundry(features)
 }
 
 func detectKubernetes(features FeatureMap) {
@@ -127,6 +132,33 @@ func detectFargate(features FeatureMap) {
 	if Datadog.GetBool("eks_fargate") {
 		features[EKSFargate] = struct{}{}
 		features[Kubernetes] = struct{}{}
+	}
+}
+
+func detectCloudFoundry(features FeatureMap) {
+	network := Datadog.GetString("cloud_foundry_garden.listen_network")
+	addr := Datadog.GetString("cloud_foundry_garden.listen_address")
+
+	if strings.HasPrefix(network, "unix") {
+		prefixes := getHostMountPrefixes()
+
+		for _, p := range prefixes {
+			fullAddr := path.Join(p, addr)
+			exists, reachable := system.CheckSocketAvailable(fullAddr, socketTimeout)
+			if exists && reachable {
+				features[CloudFoundry] = struct{}{}
+				break
+			}
+
+			if exists && !reachable {
+				log.Infof("Agent found cloud foundry socket at: %s but socket not reachable (permissions?)", fullAddr)
+			}
+		}
+	} else {
+		_, err := net.DialTimeout(network, addr, connectionTimeout)
+		if err == nil {
+			features[CloudFoundry] = struct{}{}
+		}
 	}
 }
 

--- a/pkg/config/environment_detection.go
+++ b/pkg/config/environment_detection.go
@@ -99,11 +99,18 @@ func detectFeatures() {
 	if IsAutoconfigEnabled() {
 		detectContainerFeatures(newFeatures)
 		excludedFeatures := Datadog.GetStringSlice("autoconfig_exclude_features")
-		for _, ef := range excludedFeatures {
-			delete(newFeatures, Feature(ef))
+		for _, f := range excludedFeatures {
+			delete(newFeatures, Feature(f))
+		}
+
+		includedFeatures := Datadog.GetStringSlice("autoconfig_include_features")
+		for _, f := range includedFeatures {
+			newFeatures[Feature(f)] = struct{}{}
 		}
 
 		log.Infof("Features detected from environment: %v", newFeatures)
+	} else {
+		log.Warnf("Deactivating Autoconfig will disable most components. It's recommended to use autoconfig_exclude_features and autoconfig_include_features to activate/deactivate features selectively")
 	}
 	detectedFeatures = newFeatures
 }

--- a/pkg/config/environment_detection_test.go
+++ b/pkg/config/environment_detection_test.go
@@ -1,0 +1,42 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestExcludeFeatures(t *testing.T) {
+	assert := assert.New(t)
+
+	features := FeatureMap{
+		CloudFoundry:             struct{}{},
+		Containerd:               struct{}{},
+		Cri:                      struct{}{},
+		Docker:                   struct{}{},
+		KubeOrchestratorExplorer: struct{}{},
+		Kubernetes:               struct{}{},
+		ECSFargate:               struct{}{},
+		EKSFargate:               struct{}{},
+	}
+
+	excludedFeatures := []string{
+		"cri",
+		"name:cri",
+		"name:docker",
+		"name:^.*fargate",
+	}
+
+	excludeFeatures(features, excludedFeatures)
+	assert.Equal(features, FeatureMap{
+		CloudFoundry:             struct{}{},
+		Containerd:               struct{}{},
+		KubeOrchestratorExplorer: struct{}{},
+		Kubernetes:               struct{}{},
+	})
+}

--- a/pkg/config/environment_testing.go
+++ b/pkg/config/environment_testing.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build test
+
+package config
+
+// Setting a default list of features with what is widely used in unit tests.
+func init() {
+	detectedFeatures = FeatureMap{Docker: struct{}{}}
+}
+
+func SetFeature(feature Feature) {
+	featureLock.Lock()
+	defer featureLock.Unlock()
+
+	detectedFeatures[feature] = struct{}{}
+}
+
+func ClearFeatures() {
+	featureLock.Lock()
+	defer featureLock.Unlock()
+
+	detectedFeatures = make(FeatureMap)
+}

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -63,14 +63,16 @@ type Launcher struct {
 
 // IsAvailable retrues true if the launcher is available and a retrier otherwise
 func IsAvailable() (bool, *retry.Retrier) {
+	if !coreConfig.IsFeaturePresent(coreConfig.Docker) {
+		return false, nil
+	}
+
 	util, retrier := dockerutil.GetDockerUtilWithRetrier()
 	if util != nil {
 		log.Info("Docker launcher is available")
 		return true, nil
 	}
-	if coreConfig.IsFeaturePresent(coreConfig.Docker) {
-		log.Warnf("Docker launcher is not available: %v", retrier.LastError())
-	}
+
 	return false, retrier
 }
 
@@ -255,7 +257,6 @@ func (l *Launcher) getFileSource(container *Container, source *config.LogSource)
 
 	standardService := l.serviceNameFunc(container.container.Name, dockerutil.ContainerIDToTaggerEntityName(containerID))
 	shortName, err := container.getShortImageName(context.TODO())
-
 	if err != nil {
 		log.Warnf("Could not get short image name for container %v: %v", ShortContainerID(containerID), err)
 	}

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -275,16 +275,17 @@ func loadConfigIfExists(path string) error {
 func NewAgentConfig(loggerName config.LoggerName, yamlPath, netYamlPath string) (*AgentConfig, error) {
 	var err error
 
+	// For Agent 6 we will have a YAML config file to use.
+	if err := loadConfigIfExists(yamlPath); err != nil {
+		return nil, err
+	}
+
 	// Note: This only considers container sources that are already setup. It's possible that container sources may
 	//       need a few minutes to be ready on newly provisioned hosts.
 	_, err = util.GetContainers()
 	canAccessContainers := err == nil
 
 	cfg := NewDefaultAgentConfig(canAccessContainers)
-	// For Agent 6 we will have a YAML config file to use.
-	if err := loadConfigIfExists(yamlPath); err != nil {
-		return nil, err
-	}
 
 	if err := cfg.LoadProcessYamlConfig(yamlPath); err != nil {
 		return nil, err
@@ -527,7 +528,6 @@ func getHostnameFromGRPC(ctx context.Context, grpcClientFn func(ctx context.Cont
 		return "", fmt.Errorf("cannot connect to datadog agent via grpc: %w", err)
 	}
 	reply, err := ddAgentClient.GetHostname(ctx, &pb.HostnameRequest{})
-
 	if err != nil {
 		return "", fmt.Errorf("cannot get hostname from datadog agent via grpc: %w", err)
 	}

--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/docker/docker/api/types"
@@ -37,6 +38,10 @@ type DockerCollector struct {
 
 // Detect tries to connect to the docker socket and returns success
 func (c *DockerCollector) Detect(_ context.Context, out chan<- []*TagInfo) (CollectionMode, error) {
+	if !config.IsFeaturePresent(config.Docker) {
+		return NoCollection, nil
+	}
+
 	du, err := docker.GetDockerUtil()
 	if err != nil {
 		return NoCollection, err
@@ -125,7 +130,6 @@ func (c *DockerCollector) processEvent(ctx context.Context, e *docker.ContainerE
 		low, orchestrator, high, standard, err := c.fetchForDockerID(ctx, e.ContainerID, fetchOptions{
 			inspectCached: e.Action == docker.ContainerEventActionStart,
 		})
-
 		if err != nil {
 			log.Debugf("Error fetching tags for container '%s': %v", e.ContainerName, err)
 		}

--- a/pkg/tagger/collectors/ecs_fargate_main.go
+++ b/pkg/tagger/collectors/ecs_fargate_main.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	taggerutil "github.com/DataDog/datadog-agent/pkg/tagger/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
@@ -39,6 +40,10 @@ type ECSFargateCollector struct {
 // Detect tries to connect to the ECS metadata API
 func (c *ECSFargateCollector) Detect(ctx context.Context, out chan<- []*TagInfo) (CollectionMode, error) {
 	var err error
+
+	if !config.IsFeaturePresent(config.ECSFargate) {
+		return NoCollection, nil
+	}
 
 	if !ecsutil.IsFargateInstance(ctx) {
 		return NoCollection, fmt.Errorf("Failed to connect to task metadata API, ECS tagging will not work")

--- a/pkg/tagger/collectors/ecs_main.go
+++ b/pkg/tagger/collectors/ecs_main.go
@@ -43,6 +43,10 @@ type ECSCollector struct {
 
 // Detect tries to connect to the ECS agent
 func (c *ECSCollector) Detect(ctx context.Context, out chan<- []*TagInfo) (CollectionMode, error) {
+	if !config.IsFeaturePresent(config.Docker) {
+		return NoCollection, nil
+	}
+
 	if ecsutil.IsFargateInstance(ctx) {
 		return NoCollection, fmt.Errorf("ECS collector is disabled on Fargate")
 	}

--- a/pkg/tagger/collectors/garden_main.go
+++ b/pkg/tagger/collectors/garden_main.go
@@ -31,6 +31,9 @@ type GardenCollector struct {
 
 // Detect tries to connect to the Garden API and the cluster agent
 func (c *GardenCollector) Detect(ctx context.Context, out chan<- []*TagInfo) (CollectionMode, error) {
+	if !config.IsFeaturePresent(config.CloudFoundry) {
+		return NoCollection, nil
+	}
 
 	// Detect if we're on a compute VM by trying to connect to the local garden API
 	var err error

--- a/pkg/tagger/collectors/kubernetes_main.go
+++ b/pkg/tagger/collectors/kubernetes_main.go
@@ -51,6 +51,10 @@ type KubeMetadataCollector struct {
 
 // Detect tries to connect to the kubelet and the API Server if the DCA is not used or the DCA.
 func (c *KubeMetadataCollector) Detect(_ context.Context, out chan<- []*TagInfo) (CollectionMode, error) {
+	if !config.IsFeaturePresent(config.Kubernetes) {
+		return NoCollection, nil
+	}
+
 	if config.Datadog.GetBool("kubernetes_collect_metadata_tags") == false {
 		log.Infof("The metadata mapper was configured to be disabled, not collecting metadata for the pods from the API Server")
 		return NoCollection, fmt.Errorf("collection disabled by the configuration")

--- a/pkg/tagger/local/tagger.go
+++ b/pkg/tagger/local/tagger.go
@@ -161,6 +161,10 @@ func (t *Tagger) tryCollectors(ctx context.Context) []collectorReply {
 	for name, factory := range t.candidates {
 		collector := factory()
 		mode, err := collector.Detect(ctx, t.infoIn)
+		if mode == collectors.NoCollection && err == nil {
+			log.Debugf("collector %s skipped as feature not activated", name)
+			continue
+		}
 		if retry.IsErrWillRetry(err) {
 			log.Debugf("will retry %s later: %s", name, err)
 			continue // don't add it to the modes map as we want to retry later
@@ -347,7 +351,6 @@ func (t *Tagger) Standard(entity string) ([]string, error) {
 
 // GetEntity returns the entity corresponding to the specified id and an error
 func (t *Tagger) GetEntity(entityID string) (*types.Entity, error) {
-
 	tags, err := t.store.getEntityTags(entityID)
 	if err != nil {
 		return nil, err

--- a/pkg/tagger/local/tagger.go
+++ b/pkg/tagger/local/tagger.go
@@ -162,7 +162,7 @@ func (t *Tagger) tryCollectors(ctx context.Context) []collectorReply {
 		collector := factory()
 		mode, err := collector.Detect(ctx, t.infoIn)
 		if mode == collectors.NoCollection && err == nil {
-			log.Debugf("collector %s skipped as feature not activated", name)
+			log.Infof("collector %s skipped as feature not activated", name)
 			continue
 		}
 		if retry.IsErrWillRetry(err) {

--- a/pkg/util/containers/collectors/docker.go
+++ b/pkg/util/containers/collectors/docker.go
@@ -11,9 +11,9 @@ import (
 	"context"
 	"errors"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
-	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 const (

--- a/pkg/util/containers/collectors/docker.go
+++ b/pkg/util/containers/collectors/docker.go
@@ -9,9 +9,11 @@ package collectors
 
 import (
 	"context"
+	"errors"
 
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/docker"
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 const (
@@ -27,6 +29,10 @@ type DockerCollector struct {
 
 // Detect tries to connect to the docker socket and returns success
 func (c *DockerCollector) Detect() error {
+	if !config.IsFeaturePresent(config.Docker) {
+		return errors.New("Docker feature is deactivated")
+	}
+
 	du, err := docker.GetDockerUtil()
 	if err != nil {
 		return err

--- a/pkg/util/containers/collectors/kubelet.go
+++ b/pkg/util/containers/collectors/kubelet.go
@@ -9,7 +9,9 @@ package collectors
 
 import (
 	"context"
+	"errors"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
@@ -26,6 +28,10 @@ type KubeletCollector struct {
 
 // Detect tries to connect to the kubelet
 func (c *KubeletCollector) Detect() error {
+	if !config.IsFeaturePresent(config.Kubernetes) {
+		return errors.New("Kubernetes feature is deactivated")
+	}
+
 	util, err := kubelet.GetKubeUtil()
 	if err != nil {
 		return err

--- a/pkg/util/docker/host_metadata.go
+++ b/pkg/util/docker/host_metadata.go
@@ -9,10 +9,12 @@ package docker
 
 import (
 	"context"
+	"errors"
 	"time"
 
 	"github.com/docker/docker/api/types/swarm"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host/container"
 )
 
@@ -21,6 +23,10 @@ func init() {
 }
 
 func getMetadata() (map[string]string, error) {
+	if !config.IsFeaturePresent(config.Docker) {
+		return nil, errors.New("Docker feature deactivated")
+	}
+
 	metadata := make(map[string]string)
 	du, err := GetDockerUtil()
 	if err != nil {

--- a/pkg/util/ecs/metadata/detection.go
+++ b/pkg/util/ecs/metadata/detection.go
@@ -70,7 +70,7 @@ func getAgentV1ContainerURLs(ctx context.Context) ([]string, error) {
 	var urls []string
 
 	if !config.IsFeaturePresent(config.Docker) {
-		return nil, errors.New("docker feature not activated")
+		return nil, errors.New("Docker feature not activated")
 	}
 
 	du, err := docker.GetDockerUtil()

--- a/pkg/util/ecs/metadata/detection.go
+++ b/pkg/util/ecs/metadata/detection.go
@@ -10,6 +10,7 @@ package metadata
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -67,6 +68,10 @@ func detectAgentV1URL() (string, error) {
 
 func getAgentV1ContainerURLs(ctx context.Context) ([]string, error) {
 	var urls []string
+
+	if !config.IsFeaturePresent(config.Docker) {
+		return nil, errors.New("docker feature not activated")
+	}
 
 	du, err := docker.GetDockerUtil()
 	if err != nil {

--- a/pkg/util/hostname/kubelet/hostname.go
+++ b/pkg/util/hostname/kubelet/hostname.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	k "github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -22,6 +23,10 @@ var kubeUtilGet kubeUtilGetter = k.GetKubeUtil
 
 // HostnameProvider builds a hostname from the kubernetes nodename and an optional cluster-name
 func HostnameProvider(ctx context.Context) (string, error) {
+	if config.IsFeaturePresent(config.Kubernetes) {
+		return "", nil
+	}
+
 	ku, err := kubeUtilGet()
 	if err != nil {
 		return "", err

--- a/pkg/util/hostname_docker.go
+++ b/pkg/util/hostname_docker.go
@@ -21,40 +21,37 @@ import (
 func getContainerHostname(ctx context.Context) (bool, string) {
 	var name string
 
-	// Cluster-agent logic: Kube apiserver
-	if getKubeHostname, found := hostname.ProviderCatalog["kube_apiserver"]; found {
-		log.Debug("GetHostname trying Kubernetes trough API server...")
-		name, err := getKubeHostname(ctx)
-		if err == nil && validate.ValidHostname(name) == nil {
-			return true, name
+	if config.IsFeaturePresent(config.Kubernetes) {
+		// Cluster-agent logic: Kube apiserver
+		if getKubeHostname, found := hostname.ProviderCatalog["kube_apiserver"]; found {
+			log.Debug("GetHostname trying Kubernetes trough API server...")
+			name, err := getKubeHostname(ctx)
+			if err == nil && validate.ValidHostname(name) == nil {
+				return true, name
+			}
 		}
-	}
-
-	if config.IsContainerized() == false {
-		return false, name
 	}
 
 	// Node-agent logic: docker or kubelet
-
-	// Docker
-	log.Debug("GetHostname trying Docker API...")
-	if getDockerHostname, found := hostname.ProviderCatalog["docker"]; found {
-		name, err := getDockerHostname(ctx)
-		if err == nil && validate.ValidHostname(name) == nil {
-			return true, name
+	if config.IsFeaturePresent(config.Docker) {
+		log.Debug("GetHostname trying Docker API...")
+		if getDockerHostname, found := hostname.ProviderCatalog["docker"]; found {
+			name, err := getDockerHostname(ctx)
+			if err == nil && validate.ValidHostname(name) == nil {
+				return true, name
+			}
 		}
 	}
 
-	if config.IsKubernetes() == false {
-		return false, name
-	}
-	// Kubelet
-	if getKubeletHostname, found := hostname.ProviderCatalog["kubelet"]; found {
-		log.Debug("GetHostname trying Kubernetes trough kubelet API...")
-		name, err := getKubeletHostname(ctx)
-		if err == nil && validate.ValidHostname(name) == nil {
-			return true, name
+	if config.IsFeaturePresent(config.Kubernetes) {
+		if getKubeletHostname, found := hostname.ProviderCatalog["kubelet"]; found {
+			log.Debug("GetHostname trying Kubernetes trough kubelet API...")
+			name, err := getKubeletHostname(ctx)
+			if err == nil && validate.ValidHostname(name) == nil {
+				return true, name
+			}
 		}
 	}
+
 	return false, name
 }

--- a/pkg/util/kubernetes/kubelet/host_metadata.go
+++ b/pkg/util/kubernetes/kubelet/host_metadata.go
@@ -12,6 +12,7 @@ import (
 	"fmt"
 	"regexp"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host/container"
 )
 
@@ -21,6 +22,10 @@ func init() {
 
 func getMetadata() (map[string]string, error) {
 	metadata := make(map[string]string)
+	if !config.IsFeaturePresent(config.Kubernetes) {
+		return metadata, nil
+	}
+
 	ku, err := GetKubeUtil()
 	if err != nil {
 		return metadata, err

--- a/releasenotes/notes/env-ad-components-e9b43e96cf901a9b.yaml
+++ b/releasenotes/notes/env-ad-components-e9b43e96cf901a9b.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Environment autodiscovery is now used to selectively activate providers (kubernetes, docker, etc.) inside each component (tagger, host tags, hostname).

--- a/test/integration/corechecks/docker/main_test.go
+++ b/test/integration/corechecks/docker/main_test.go
@@ -24,9 +24,11 @@ import (
 	"github.com/DataDog/datadog-agent/test/integration/utils"
 )
 
-var retryDelay = flag.Int("retry-delay", 1, "time to wait between retries (default 1 second)")
-var retryTimeout = flag.Int("retry-timeout", 30, "maximum time before failure (default 30 seconds)")
-var skipCleanup = flag.Bool("skip-cleanup", false, "skip cleanup of the docker containers (for debugging)")
+var (
+	retryDelay   = flag.Int("retry-delay", 1, "time to wait between retries (default 1 second)")
+	retryTimeout = flag.Int("retry-timeout", 30, "maximum time before failure (default 30 seconds)")
+	skipCleanup  = flag.Bool("skip-cleanup", false, "skip cleanup of the docker containers (for debugging)")
+)
 
 var dockerCfgString = `
 collect_events: true
@@ -46,8 +48,10 @@ docker_env_as_tags:
     "low_card_env": lowcardenvtag
 `
 
-var sender *mocksender.MockSender
-var dockerCheck check.Check
+var (
+	sender      *mocksender.MockSender
+	dockerCheck check.Check
+)
 
 func TestMain(m *testing.M) {
 	flag.Parse()
@@ -97,6 +101,7 @@ func setup() error {
 	if err != nil {
 		return err
 	}
+	config.DetectFeatures()
 
 	// Setup tagger
 	tagger.SetDefaultTagger(local.NewTagger(collectors.DefaultCatalog))
@@ -120,8 +125,8 @@ func setup() error {
 // Reset the state and trigger a new run
 func doRun(m *testing.M) int {
 	// Setup docker check
-	var dockerCfg = []byte(dockerCfgString)
-	var dockerInitCfg = []byte("")
+	dockerCfg := []byte(dockerCfgString)
+	dockerInitCfg := []byte("")
 	dockerCheck = docker.DockerFactory()
 	dockerCheck.Configure(dockerCfg, dockerInitCfg, "test")
 

--- a/test/integration/listeners/docker/docker_listener_test.go
+++ b/test/integration/listeners/docker/docker_listener_test.go
@@ -42,6 +42,7 @@ type DockerListenerTestSuite struct {
 func (suite *DockerListenerTestSuite) SetupSuite() {
 	config.Datadog.SetDefault("ac_include", []string{"name:.*redis.*"})
 	config.Datadog.SetDefault("ac_exclude", []string{"image:datadog/docker-library:redis.*"})
+	config.DetectFeatures()
 	containers.ResetSharedFilter()
 
 	tagger.SetDefaultTagger(local.NewTagger(collectors.DefaultCatalog))
@@ -193,7 +194,8 @@ func (suite *DockerListenerTestSuite) commonSection(containerIDs []string) {
 			expectedADIDs[entity] = []string{
 				entity,
 				"datadog/docker-library",
-				"docker-library"}
+				"docker-library",
+			}
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

Environment autodiscovery is now used to selectively activate providers (kubernetes, docker, etc.) inside each component (tagger, host tags, hostname).

Useful to avoid unnecessary accesses and easily activate/deactivate everything linked to a feature.
Features can be force activated/deactivated based on `autoconfig_exclude_features` and `autoconfig_include_features`.

From this PR, it's not recommended to deactivate environment autodiscovery anymore as it **will** impact normal execution of the Agent.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
