### PR TITLE
pkg/trace/api: add orchestrator tags to profiles in Fargate environments

### DIFF
--- a/pkg/trace/api/profiles.go
+++ b/pkg/trace/api/profiles.go
@@ -74,10 +74,10 @@ func (r *HTTPReceiver) profileProxyHandler() http.Handler {
 	tags := fmt.Sprintf("host:%s,default_env:%s,agent_version:%s", r.conf.Hostname, r.conf.DefaultEnv, info.Version)
 	if r.conf.IsFargate {
 		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
-		orch := fargate.GetOrchestrator(context.Background())
+		orch := fargate.GetOrchestrator(ctx)
 		cancel()
 		if err := ctx.Err(); err != nil && err != context.Canceled {
-			log.Warnf("Failed to detect if running in AWS Fargate. If you are in a Fargate instance, this may cause issues with your profiles: %v", err)
+			log.Warnf("Failed to get Fargate orchestrator. This may cause issues with your profiles: %v", err)
 		}
 		tag := fmt.Sprintf("orchestrator:fargate_%s", strings.ToLower(string(orch)))
 		tags = tags + "," + tag

--- a/pkg/trace/api/profiles.go
+++ b/pkg/trace/api/profiles.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -9,12 +10,14 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
 	"github.com/DataDog/datadog-agent/pkg/trace/logutil"
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/fargate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -68,7 +71,17 @@ func (r *HTTPReceiver) profileProxyHandler() http.Handler {
 	if err != nil {
 		return errorHandler(err)
 	}
-	tags := fmt.Sprintf("host:%s,default_env:%s", r.conf.Hostname, r.conf.DefaultEnv)
+	tags := fmt.Sprintf("host:%s,default_env:%s,agent_version:%s", r.conf.Hostname, r.conf.DefaultEnv, info.Version)
+	if r.conf.IsFargate {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		orch := fargate.GetOrchestrator(context.Background())
+		cancel()
+		if err := ctx.Err(); err != nil && err != context.Canceled {
+			log.Warnf("Failed to detect if running in AWS Fargate. If you are in a Fargate instance, this may cause issues with your profiles: %v", err)
+		}
+		tag := fmt.Sprintf("orchestrator:fargate_%s", strings.ToLower(string(orch)))
+		tags = tags + "," + tag
+	}
 	return newProfileProxy(r.conf.NewHTTPTransport(), targets, keys, tags)
 }
 

--- a/releasenotes/notes/apm-add-orchestrator-tag-f16b9cc1d55ac082.yaml
+++ b/releasenotes/notes/apm-add-orchestrator-tag-f16b9cc1d55ac082.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: Added additional tags to profiles in AWS Fargate environments.
+


### PR DESCRIPTION
### What does this PR do?

Adds `agent_version` tag to profiles to determine old/new profile tagging and`orchestrator` tag to track whether profile is sent from ECS/EKS Fargate.

[PROF-3455]

### Motivation

Fargate clusters schedule on a pool of many hosts, making it difficult to tell how many hosts are actually being used. We are trying to improve how we track hosts in Fargate, especially how to differentiate data sent from regular ECS/EKS and ECS/EKS Fargate.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Tested changes by running a test environment in ECS Fargate. Used the dockerhub image of the agent from CI with the branch tag `peterg17-profiling-fargate-tags-py3-jmx`. Confirmed that the changes didn't cause any errors and properly tagged profiles in staging.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.


[PROF-3455]: https://datadoghq.atlassian.net/browse/PROF-3455