### PR TITLE
[networks] Add support for sendfile(2) traffic

### DIFF
--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Conntrack = NewRuntimeAsset("conntrack.c", "47c460f375ea33e41e78346784f8701583a43dfe170b1a7faaaeeb7ef6e12f24")
+var Conntrack = NewRuntimeAsset("conntrack.c", "246d6c2a6b78e1a1e99a5135b96f4be104e5dc4521b321e4ab2dadba5a22c97a")

--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Conntrack = NewRuntimeAsset("conntrack.c", "246d6c2a6b78e1a1e99a5135b96f4be104e5dc4521b321e4ab2dadba5a22c97a")
+var Conntrack = NewRuntimeAsset("conntrack.c", "47c460f375ea33e41e78346784f8701583a43dfe170b1a7faaaeeb7ef6e12f24")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "e0e509f5a8a560239d15e9320fe2823db485075e40ba7d7e195b8253272d49c6")
+var Tracer = NewRuntimeAsset("tracer.c", "0b6e717b7212d8c59810fc5ce220ce0d1de968e875b42aee08eead42d345f082")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "d920cd16af440a66efd9001459a48bbbb69c3109d1df5a978116c02975fd8cc4")
+var Tracer = NewRuntimeAsset("tracer.c", "e0e509f5a8a560239d15e9320fe2823db485075e40ba7d7e195b8253272d49c6")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "ee26ac010ffa41b1b3927bb5cfb5724ac0c0459cc6cb7e195833f0c06c4d24da")
+var Tracer = NewRuntimeAsset("tracer.c", "e7bfb30b8421210793999e60d6f6ec2bd5bed9733d46134a488ed7436c143439")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "e7bfb30b8421210793999e60d6f6ec2bd5bed9733d46134a488ed7436c143439")
+var Tracer = NewRuntimeAsset("tracer.c", "d920cd16af440a66efd9001459a48bbbb69c3109d1df5a978116c02975fd8cc4")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "9a28d5974f99213966a7985e608d70bd5a8a0115d9bef8822864bb689e768466")
+var Tracer = NewRuntimeAsset("tracer.c", "ee26ac010ffa41b1b3927bb5cfb5724ac0c0459cc6cb7e195833f0c06c4d24da")

--- a/pkg/network/config/config_linux.go
+++ b/pkg/network/config/config_linux.go
@@ -36,6 +36,11 @@ func (c *Config) EnabledProbes(runtimeTracer bool) (map[probes.ProbeName]struct{
 		} else {
 			enabled[probes.TCPRetransmit] = struct{}{}
 		}
+
+		enabled[probes.SockFDLookup] = struct{}{}
+		enabled[probes.SockFDLookupRet] = struct{}{}
+		enabled[probes.DoSendfile] = struct{}{}
+		enabled[probes.DoSendfileRet] = struct{}{}
 	}
 
 	if c.CollectUDPConns {

--- a/pkg/network/config/config_linux.go
+++ b/pkg/network/config/config_linux.go
@@ -41,6 +41,7 @@ func (c *Config) EnabledProbes(runtimeTracer bool) (map[probes.ProbeName]struct{
 		enabled[probes.SockFDLookupRet] = struct{}{}
 		enabled[probes.DoSendfile] = struct{}{}
 		enabled[probes.DoSendfileRet] = struct{}{}
+		enabled[probes.TCPRelease] = struct{}{}
 	}
 
 	if c.CollectUDPConns {

--- a/pkg/network/config/config_linux.go
+++ b/pkg/network/config/config_linux.go
@@ -41,7 +41,7 @@ func (c *Config) EnabledProbes(runtimeTracer bool) (map[probes.ProbeName]struct{
 		enabled[probes.SockFDLookupRet] = struct{}{}
 		enabled[probes.DoSendfile] = struct{}{}
 		enabled[probes.DoSendfileRet] = struct{}{}
-		enabled[probes.TCPRelease] = struct{}{}
+		enabled[probes.TCPV4Destroy] = struct{}{}
 	}
 
 	if c.CollectUDPConns {

--- a/pkg/network/config/config_linux.go
+++ b/pkg/network/config/config_linux.go
@@ -41,7 +41,6 @@ func (c *Config) EnabledProbes(runtimeTracer bool) (map[probes.ProbeName]struct{
 		enabled[probes.SockFDLookupRet] = struct{}{}
 		enabled[probes.DoSendfile] = struct{}{}
 		enabled[probes.DoSendfileRet] = struct{}{}
-		enabled[probes.TCPV4Destroy] = struct{}{}
 	}
 
 	if c.CollectUDPConns {

--- a/pkg/network/ebpf/c/prebuilt/offset-guess.c
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.c
@@ -48,7 +48,7 @@ static __always_inline bool check_family(struct sock* sk, tracer_status_t* statu
     return family == expected_family;
 }
 
-static __always_inline int guess_offsets(tracer_status_t* status, struct sock* skp, struct flowi4 *fl4, struct flowi6 *fl6) {
+static __always_inline int guess_offsets(tracer_status_t* status, char* subject, caller caller) {
     u64 zero = 0;
 
     if (status->state != TRACER_STATE_CHECKING) {
@@ -78,46 +78,46 @@ static __always_inline int guess_offsets(tracer_status_t* status, struct sock* s
 
     switch (status->what) {
     case GUESS_SADDR:
-        bpf_probe_read(&new_status.saddr, sizeof(new_status.saddr), ((char*)skp) + status->offset_saddr);
+        bpf_probe_read(&new_status.saddr, sizeof(new_status.saddr), subject + status->offset_saddr);
         break;
     case GUESS_DADDR:
-        bpf_probe_read(&new_status.daddr, sizeof(new_status.daddr), ((char*)skp) + status->offset_daddr);
+        bpf_probe_read(&new_status.daddr, sizeof(new_status.daddr), subject + status->offset_daddr);
         break;
     case GUESS_FAMILY:
-        bpf_probe_read(&new_status.family, sizeof(new_status.family), ((char*)skp) + status->offset_family);
+        bpf_probe_read(&new_status.family, sizeof(new_status.family), subject + status->offset_family);
         break;
     case GUESS_SPORT:
-        bpf_probe_read(&new_status.sport, sizeof(new_status.sport), ((char*)skp) + status->offset_sport);
+        bpf_probe_read(&new_status.sport, sizeof(new_status.sport), subject + status->offset_sport);
         break;
     case GUESS_DPORT:
-        bpf_probe_read(&new_status.dport, sizeof(new_status.dport), ((char*)skp) + status->offset_dport);
+        bpf_probe_read(&new_status.dport, sizeof(new_status.dport), subject + status->offset_dport);
         break;
     case GUESS_SADDR_FL4:
-        bpf_probe_read(&new_status.saddr_fl4, sizeof(new_status.saddr_fl4), ((char*)fl4) + status->offset_saddr_fl4);
+        bpf_probe_read(&new_status.saddr_fl4, sizeof(new_status.saddr_fl4), subject + status->offset_saddr_fl4);
         break;
     case GUESS_DADDR_FL4:
-        bpf_probe_read(&new_status.daddr_fl4, sizeof(new_status.daddr_fl4), ((char*)fl4) + status->offset_daddr_fl4);
+        bpf_probe_read(&new_status.daddr_fl4, sizeof(new_status.daddr_fl4), subject + status->offset_daddr_fl4);
         break;
     case GUESS_SPORT_FL4:
-        bpf_probe_read(&new_status.sport_fl4, sizeof(new_status.sport_fl4), ((char*)fl4) + status->offset_sport_fl4);
+        bpf_probe_read(&new_status.sport_fl4, sizeof(new_status.sport_fl4), subject + status->offset_sport_fl4);
         break;
     case GUESS_DPORT_FL4:
-        bpf_probe_read(&new_status.dport_fl4, sizeof(new_status.dport_fl4), ((char*)fl4) + status->offset_dport_fl4);
+        bpf_probe_read(&new_status.dport_fl4, sizeof(new_status.dport_fl4), subject + status->offset_dport_fl4);
         break;
     case GUESS_SADDR_FL6:
-        bpf_probe_read(&new_status.saddr_fl6, sizeof(u32) * 4, ((char*)fl6) + status->offset_saddr_fl6);
+        bpf_probe_read(&new_status.saddr_fl6, sizeof(u32) * 4, subject + status->offset_saddr_fl6);
         break;
     case GUESS_DADDR_FL6:
-        bpf_probe_read(&new_status.daddr_fl6, sizeof(u32) * 4, ((char*)fl6) + status->offset_daddr_fl6);
+        bpf_probe_read(&new_status.daddr_fl6, sizeof(u32) * 4, subject + status->offset_daddr_fl6);
         break;
     case GUESS_SPORT_FL6:
-        bpf_probe_read(&new_status.sport_fl6, sizeof(new_status.sport_fl6), ((char*)fl6) + status->offset_sport_fl6);
+        bpf_probe_read(&new_status.sport_fl6, sizeof(new_status.sport_fl6), subject + status->offset_sport_fl6);
         break;
     case GUESS_DPORT_FL6:
-        bpf_probe_read(&new_status.dport_fl6, sizeof(new_status.dport_fl6), ((char*)fl6) + status->offset_dport_fl6);
+        bpf_probe_read(&new_status.dport_fl6, sizeof(new_status.dport_fl6), subject + status->offset_dport_fl6);
         break;
     case GUESS_NETNS:
-        bpf_probe_read(&possible_skc_net, sizeof(possible_net_t*), ((char*)skp) + status->offset_netns);
+        bpf_probe_read(&possible_skc_net, sizeof(possible_net_t*), subject + status->offset_netns);
         // if we get a kernel fault, it means possible_skc_net
         // is an invalid pointer, signal an error so we can go
         // to the next offset_netns
@@ -129,15 +129,25 @@ static __always_inline int guess_offsets(tracer_status_t* status, struct sock* s
         new_status.netns = possible_netns;
         break;
     case GUESS_RTT:
-        bpf_probe_read(&new_status.rtt, sizeof(new_status.rtt), ((char*)skp) + status->offset_rtt);
-        bpf_probe_read(&new_status.rtt_var, sizeof(new_status.rtt_var), ((char*)skp) + status->offset_rtt_var);
+        bpf_probe_read(&new_status.rtt, sizeof(new_status.rtt), subject + status->offset_rtt);
+        bpf_probe_read(&new_status.rtt_var, sizeof(new_status.rtt_var), subject + status->offset_rtt_var);
         break;
     case GUESS_DADDR_IPV6:
-        if (!check_family(skp, status, AF_INET6)) {
+        if (!check_family((struct sock*)subject, status, AF_INET6)) {
             break;
         }
 
-        bpf_probe_read(new_status.daddr_ipv6, sizeof(u32) * 4, ((char*)skp) + status->offset_daddr_ipv6);
+        bpf_probe_read(new_status.daddr_ipv6, sizeof(u32) * 4, subject + status->offset_daddr_ipv6);
+        break;
+    case GUESS_SOCKET_SK:
+        if (caller != kprobe_sock_getsockopt) {
+            return 0;
+        }
+
+        struct sock *skp;
+        bpf_probe_read(&skp, sizeof(skp), subject + status->offset_socket_sk);
+        bpf_probe_read(&new_status.sport_via_sk, sizeof(new_status.sport_via_sk), (char *)skp + status->offset_sport);
+        bpf_probe_read(&new_status.dport_via_sk, sizeof(new_status.dport_via_sk), (char *)skp + status->offset_dport);
         break;
     default:
         // not for us
@@ -159,7 +169,7 @@ int kprobe__ip_make_skb(struct pt_regs* ctx) {
     }
 
     struct flowi4* fl4 = (struct flowi4*)PT_REGS_PARM2(ctx);
-    guess_offsets(status, NULL, fl4, NULL);
+    guess_offsets(status, (char*)fl4, any);
     return 0;
 }
 
@@ -171,7 +181,7 @@ int kprobe__ip6_make_skb(struct pt_regs* ctx) {
         return 0;
     }
     struct flowi6* fl6 = (struct flowi6*)PT_REGS_PARM7(ctx);
-    guess_offsets(status, NULL, NULL, fl6);
+    guess_offsets(status, (char*)fl6, any);
     return 0;
 }
 
@@ -183,7 +193,7 @@ int kprobe__ip6_make_skb__pre_4_7_0(struct pt_regs* ctx) {
         return 0;
     }
     struct flowi6* fl6 = (struct flowi6*)PT_REGS_PARM9(ctx);
-    guess_offsets(status, NULL, NULL, fl6);
+    guess_offsets(status, (char*)fl6, any);
     return 0;
 }
 
@@ -204,8 +214,22 @@ int kprobe__tcp_getsockopt(struct pt_regs* ctx) {
 
     struct sock* sk = (struct sock*)PT_REGS_PARM1(ctx);
     status->tcp_info_kprobe_status = 1;
-    guess_offsets(status, sk, NULL, NULL);
+    guess_offsets(status, (char*)sk, any);
 
+    return 0;
+}
+
+/* Used for offset guessing the struct socket->sk field */
+SEC("kprobe/sock_common_getsockopt")
+int kprobe__sock_common_getsockopt(struct pt_regs* ctx) {
+    u64 zero = 0;
+    tracer_status_t* status = bpf_map_lookup_elem(&tracer_status, &zero);
+    if (status == NULL || status->what != GUESS_SOCKET_SK) {
+        return 0;
+    }
+
+    struct socket* socket = (struct socket*)PT_REGS_PARM1(ctx);
+    guess_offsets(status, (char*)socket, kprobe_sock_getsockopt);
     return 0;
 }
 
@@ -244,7 +268,7 @@ int kretprobe__tcp_v6_connect(struct pt_regs* __attribute__((unused)) ctx) {
     }
 
     // We should figure out offsets if they're not already figured out
-    guess_offsets(status, skp, NULL, NULL);
+    guess_offsets(status, (char*)skp, any);
 
     return 0;
 }

--- a/pkg/network/ebpf/c/prebuilt/offset-guess.h
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.h
@@ -34,13 +34,6 @@ static const __u8 TRACER_STATE_CHECKING = 1;
 static const __u8 TRACER_STATE_CHECKED = 2;
 static const __u8 TRACER_STATE_READY = 3;
 
-// used to disambiguate the source of guess_offsets call
-// useful when guess_offsets is called "simultaneously" from different places
-typedef enum{
-    any,
-    kprobe_sock_getsockopt,
-} caller;
-
 typedef struct {
     __u64 state;
     // tcp_info_kprobe_status records if the tcp_info kprobe has been triggered.

--- a/pkg/network/ebpf/c/prebuilt/offset-guess.h
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.h
@@ -27,11 +27,19 @@ static const __u8 GUESS_SADDR_FL6 = 12;
 static const __u8 GUESS_DADDR_FL6 = 13;
 static const __u8 GUESS_SPORT_FL6 = 14;
 static const __u8 GUESS_DPORT_FL6 = 15;
+static const __u8 GUESS_SOCKET_SK = 16;
 
 static const __u8 TRACER_STATE_UNINITIALIZED = 0;
 static const __u8 TRACER_STATE_CHECKING = 1;
 static const __u8 TRACER_STATE_CHECKED = 2;
 static const __u8 TRACER_STATE_READY = 3;
+
+// used to disambiguate the source of guess_offsets call
+// useful when guess_offsets is called "simultaneously" from different places
+typedef enum{
+    any,
+    kprobe_sock_getsockopt,
+} caller;
 
 typedef struct {
     __u64 state;
@@ -60,6 +68,7 @@ typedef struct {
     __u64 offset_daddr_fl6;
     __u64 offset_sport_fl6;
     __u64 offset_dport_fl6;
+    __u64 offset_socket_sk;
 
     __u64 err;
 
@@ -71,6 +80,8 @@ typedef struct {
     __u32 daddr;
     __u16 sport;
     __u16 dport;
+    __u16 sport_via_sk;
+    __u16 dport_via_sk;
     __u16 family;
     __u32 saddr_fl4;
     __u32 daddr_fl4;

--- a/pkg/network/ebpf/c/prebuilt/tracer.c
+++ b/pkg/network/ebpf/c/prebuilt/tracer.c
@@ -163,6 +163,12 @@ static __always_inline __u64 offset_dport_fl6() {
      return val;
 }
 
+static __always_inline __u64 offset_socket_sk() {
+     __u64 val = 0;
+     LOAD_CONSTANT("offset_socket_sk", val);
+     return val;
+}
+
 static __always_inline __u32 get_netns_from_sock(struct sock* sk) {
     possible_net_t* skc_net = NULL;
     __u32 net_ns_inum = 0;
@@ -853,7 +859,7 @@ int kretprobe__sockfd_lookup_light(struct pt_regs* ctx) {
 
     struct socket *socket = (struct socket*)PT_REGS_RC(ctx);
     struct sock *skp;
-    bpf_probe_read(&skp, sizeof(skp), &socket->sk);
+    bpf_probe_read(&skp, sizeof(skp), (char*)socket + offset_socket_sk());
 
     conn_tuple_t t = {};
     if (!read_conn_tuple(&t, skp, pid_tgid, CONN_TYPE_TCP)) {

--- a/pkg/network/ebpf/c/prebuilt/tracer.c
+++ b/pkg/network/ebpf/c/prebuilt/tracer.c
@@ -876,7 +876,7 @@ int kretprobe__sockfd_lookup_light(struct pt_regs* ctx) {
     // For now let's only store information for TCP sockets
     struct socket* socket = (struct socket*)PT_REGS_RC(ctx);
     enum sock_type sock_type = 0;
-    bpf_probe_read(&sock_type, sizeof(short), (char*)socket + offsetof(struct socket, type));
+    bpf_probe_read(&sock_type, sizeof(short), &socket->type);
     if (sock_type != SOCK_STREAM) {
         goto cleanup;
     }
@@ -929,7 +929,7 @@ int kretprobe__do_sendfile(struct pt_regs* ctx) {
 
     conn_tuple_t t = {};
     if (!read_conn_tuple(&t, *sock, pid_tgid, CONN_TYPE_TCP)) {
-        return 0;
+        goto cleanup;
     }
 
     handle_message(&t, sent, 0, CONN_DIRECTION_UNKNOWN, 0, 0, PACKET_COUNT_NONE);

--- a/pkg/network/ebpf/c/prebuilt/tracer.c
+++ b/pkg/network/ebpf/c/prebuilt/tracer.c
@@ -861,8 +861,8 @@ int kprobe__sockfd_lookup_light(struct pt_regs* ctx) {
 }
 
 // this kretprobe is essentially creating:
-// * an index of pid_fd_t to conn_tuple_t;
-// * an index of conn_tuple_t to pid_fd_t;
+// * an index of pid_fd_t to a struct sock*;
+// * an index of struct sock* to pid_fd_t;
 SEC("kretprobe/sockfd_lookup_light")
 int kretprobe__sockfd_lookup_light(struct pt_regs* ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();

--- a/pkg/network/ebpf/c/prebuilt/tracer.c
+++ b/pkg/network/ebpf/c/prebuilt/tracer.c
@@ -890,11 +890,7 @@ int kretprobe__sockfd_lookup_light(struct pt_regs* ctx) {
 
     // These entries are cleaned up by tcp_{v4,v6}_destroy_sock kprobes
     bpf_map_update_elem(&pid_fd_by_sock, &sock, &pid_fd, BPF_ANY);
-
-    // At this point older kernel verifiers will complain that pid_fd is a map value
-    // so we make a copy of it
-    pid_fd_t pid_fd_copy = pid_fd;
-    bpf_map_update_elem(&sock_by_pid_fd, &pid_fd_copy, &sock, BPF_ANY);
+    bpf_map_update_elem(&sock_by_pid_fd, &pid_fd, &sock, BPF_ANY);
 cleanup:
     bpf_map_delete_elem(&sockfd_lookup_args, &pid_tgid);
     return 0;

--- a/pkg/network/ebpf/c/runtime/tracer.c
+++ b/pkg/network/ebpf/c/runtime/tracer.c
@@ -9,6 +9,7 @@
 #include "syscalls.h"
 #include "ip.h"
 #include "netns.h"
+#include "sockfd.h"
 
 #ifdef FEATURE_IPV6_ENABLED
 #include "ipv6.h"
@@ -150,7 +151,7 @@ static __always_inline void handle_tcp_stats(conn_tuple_t* t, struct sock* skp) 
     bpf_probe_read(&rtt, sizeof(rtt), &tcp_sk(skp)->srtt_us);
     bpf_probe_read(&rtt_var, sizeof(rtt_var), &tcp_sk(skp)->mdev_us);
 
- 
+
     tcp_stats_t stats = { .retransmits = 0, .rtt = rtt, .rtt_var = rtt_var };
     update_tcp_stats(t, stats);
 }
@@ -212,6 +213,8 @@ int kprobe__tcp_close(struct pt_regs* ctx) {
     conn_tuple_t t = {};
     u64 pid_tgid = bpf_get_current_pid_tgid();
     sk = (struct sock*)PT_REGS_PARM1(ctx);
+
+    clear_sockfd_maps(sk);
 
     // Get network namespace id
     log_debug("kprobe/tcp_close: tgid: %u, pid: %u\n", pid_tgid >> 32, pid_tgid & 0xFFFFFFFF);
@@ -633,6 +636,105 @@ int kretprobe__inet6_bind(struct pt_regs* ctx) {
     __s64 ret = PT_REGS_RC(ctx);
     log_debug("kretprobe/inet6_bind: ret=%d\n", ret);
     return sys_exit_bind(ret);
+}
+
+SEC("kprobe/sockfd_lookup_light")
+int kprobe__sockfd_lookup_light(struct pt_regs* ctx) {
+    int sockfd = (int)PT_REGS_PARM1(ctx);
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+
+    // Check if have already a map entry for this pid_fd_t
+    pid_fd_t key = {
+        .pid = pid_tgid >> 32,
+        .fd = sockfd,
+    };
+    struct sock** sock = bpf_map_lookup_elem(&sock_by_pid_fd, &key);
+    if (sock != NULL) {
+        return 0;
+    }
+
+    bpf_map_update_elem(&sockfd_lookup_args, &pid_tgid, &sockfd, BPF_ANY);
+    return 0;
+}
+
+// this kretprobe is essentially creating:
+// * an index of pid_fd_t to a struct sock*;
+// * an index of struct sock* to pid_fd_t;
+SEC("kretprobe/sockfd_lookup_light")
+int kretprobe__sockfd_lookup_light(struct pt_regs* ctx) {
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    int *sockfd = bpf_map_lookup_elem(&sockfd_lookup_args, &pid_tgid);
+    if (sockfd == NULL) {
+        return 0;
+    }
+
+    // For now let's only store information for TCP sockets
+    struct socket* socket = (struct socket*)PT_REGS_RC(ctx);
+    enum sock_type sock_type = 0;
+    bpf_probe_read(&sock_type, sizeof(short), &socket->type);
+    if (sock_type != SOCK_STREAM) {
+        goto cleanup;
+    }
+
+    // Retrieve struct sock* pointer from struct socket*
+    struct sock *sock = NULL;
+    bpf_probe_read(&sock, sizeof(sock), &socket->sk);
+
+    pid_fd_t pid_fd = {
+        .pid = pid_tgid >> 32,
+        .fd = (*sockfd),
+    };
+
+    // These entries are cleaned up by tcp_{v4,v6}_destroy_sock kprobes
+    bpf_map_update_elem(&pid_fd_by_sock, &sock, &pid_fd, BPF_ANY);
+    bpf_map_update_elem(&sock_by_pid_fd, &pid_fd, &sock, BPF_ANY);
+cleanup:
+    bpf_map_delete_elem(&sockfd_lookup_args, &pid_tgid);
+    return 0;
+}
+
+SEC("kprobe/do_sendfile")
+int kprobe__do_sendfile(struct pt_regs* ctx) {
+    u64 fd_out = (int)PT_REGS_PARM1(ctx);
+    u64 fd_in = (int)PT_REGS_PARM2(ctx);
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u64 val = (fd_in << 32) | fd_out;
+    bpf_map_update_elem(&do_sendfile_args, &pid_tgid, &val, BPF_ANY);
+    return 0;
+}
+
+SEC("kretprobe/do_sendfile")
+int kretprobe__do_sendfile(struct pt_regs* ctx) {
+    __u32 packets_in = 0;
+    __u32 packets_out = 0;
+
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    u64 *fd_in_out = bpf_map_lookup_elem(&do_sendfile_args, &pid_tgid);
+    if (fd_in_out == NULL) {
+        return 0;
+    }
+
+    pid_fd_t key = {
+        .pid = pid_tgid >> 32,
+        .fd = *fd_in_out & 0xFFFFFFFF,
+    };
+
+    size_t sent = (size_t)PT_REGS_RC(ctx);
+    struct sock** sock = bpf_map_lookup_elem(&sock_by_pid_fd, &key);
+    if (sock == NULL) {
+        goto cleanup;
+    }
+
+    conn_tuple_t t = {};
+    if (!read_conn_tuple(&t, *sock, pid_tgid, CONN_TYPE_TCP)) {
+        goto cleanup;
+    }
+
+    get_tcp_segment_counts(*sock, &packets_in, &packets_out);
+    handle_message(&t, sent, 0, CONN_DIRECTION_UNKNOWN, packets_out, packets_in, PACKET_COUNT_ABSOLUTE);
+cleanup:
+    bpf_map_delete_elem(&do_sendfile_args, &pid_tgid);
+    return 0;
 }
 
 //endregion

--- a/pkg/network/ebpf/c/runtime/tracer.c
+++ b/pkg/network/ebpf/c/runtime/tracer.c
@@ -695,29 +695,29 @@ cleanup:
 
 SEC("kprobe/do_sendfile")
 int kprobe__do_sendfile(struct pt_regs* ctx) {
-    u64 fd_out = (int)PT_REGS_PARM1(ctx);
-    u64 fd_in = (int)PT_REGS_PARM2(ctx);
+    u32 fd_out = (int)PT_REGS_PARM1(ctx);
     u64 pid_tgid = bpf_get_current_pid_tgid();
-    u64 val = (fd_in << 32) | fd_out;
-    bpf_map_update_elem(&do_sendfile_args, &pid_tgid, &val, BPF_ANY);
+    pid_fd_t key = {
+        .pid = pid_tgid >> 32,
+        .fd = fd_out,
+    };
+    struct sock** sock = bpf_map_lookup_elem(&sock_by_pid_fd, &key);
+    if (sock == NULL) {
+        return 0;
+    }
+
+    // bring map value to eBPF stack to satisfy Kernel 4.4 verifier
+    struct sock* skp = *sock;
+    bpf_map_update_elem(&do_sendfile_args, &pid_tgid, &skp, BPF_ANY);
     return 0;
 }
 
 SEC("kretprobe/do_sendfile")
 int kretprobe__do_sendfile(struct pt_regs* ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
-    u64 *fd_in_out = bpf_map_lookup_elem(&do_sendfile_args, &pid_tgid);
-    if (fd_in_out == NULL) {
-        return 0;
-    }
-
-    pid_fd_t key = {
-        .pid = pid_tgid >> 32,
-        .fd = *fd_in_out & 0xFFFFFFFF,
-    };
-    struct sock** sock = bpf_map_lookup_elem(&sock_by_pid_fd, &key);
+    struct sock** sock = bpf_map_lookup_elem(&do_sendfile_args, &pid_tgid);
     if (sock == NULL) {
-        goto cleanup;
+        return 0;
     }
 
     conn_tuple_t t = {};

--- a/pkg/network/ebpf/c/sockfd.h
+++ b/pkg/network/ebpf/c/sockfd.h
@@ -1,0 +1,65 @@
+#ifndef __SOCKFD_H
+#define __SOCKFD_H
+
+#include "tracer.h"
+#include <linux/types.h>
+
+typedef struct {
+    __u32 pid;
+    __u32 fd;
+} pid_fd_t;
+
+// This map is used to to temporarily store function arguments (sockfd) for
+// sockfd_lookup_light function calls, so they can be acessed by the corresponding kretprobe.
+// * Key is the pid_tgid;
+// * Value the socket FD;
+struct bpf_map_def SEC("maps/sockfd_lookup_args") sockfd_lookup_args = {
+    .type = BPF_MAP_TYPE_HASH,
+    .key_size = sizeof(__u64),
+    .value_size = sizeof(__u32),
+    .max_entries = 1024,
+    .pinning = 0,
+    .namespace = "",
+};
+
+struct bpf_map_def SEC("maps/tup_by_pid_fd") tup_by_pid_fd = {
+    .type = BPF_MAP_TYPE_HASH,
+    .key_size = sizeof(pid_fd_t),
+    .value_size = sizeof(conn_tuple_t),
+    .max_entries = 1024,
+    .pinning = 0,
+    .namespace = "",
+};
+
+struct bpf_map_def SEC("maps/pid_fd_by_tup") pid_fd_by_tup = {
+    .type = BPF_MAP_TYPE_HASH,
+    .key_size = sizeof(conn_tuple_t),
+    .value_size = sizeof(pid_fd_t),
+    .max_entries = 1024,
+    .pinning = 0,
+    .namespace = "",
+};
+
+static __always_inline int socket_to_tuple(struct socket* socket, conn_tuple_t* tuple, u64 pid_tgid, u64 offset_sk, u64 offset_type) {
+    struct sock *sock = NULL;
+    bpf_probe_read(&sock, sizeof(sock), (char*)socket + offset_sk);
+
+    enum sock_type sock_type = 0;
+    bpf_probe_read(&sock_type, sizeof(short), (char*)socket + offset_type);
+
+    metadata_mask_t metadata = 0;
+    switch(sock_type) {
+    case SOCK_STREAM:
+        metadata |= CONN_TYPE_TCP;
+        break;
+    case SOCK_DGRAM:
+        metadata |= CONN_TYPE_UDP;
+        break;
+    default:
+        return 0;
+    }
+
+    return read_conn_tuple(tuple, sock, pid_tgid, metadata);
+}
+
+#endif

--- a/pkg/network/ebpf/c/tracer-maps.h
+++ b/pkg/network/ebpf/c/tracer-maps.h
@@ -155,19 +155,6 @@ struct bpf_map_def SEC("maps/ip_route_dest_gateways") ip_route_dest_gateways = {
     .namespace = "",
 };
 
-// This map is used to to temporarily store function arguments (sockfd) for
-// sockfd_lookup_light function calls, so they can be acessed by the corresponding kretprobe.
-// * Key is the pid_tgid;
-// * Value the socket FD;
-struct bpf_map_def SEC("maps/sockfd_lookup_args") sockfd_lookup_args = {
-    .type = BPF_MAP_TYPE_HASH,
-    .key_size = sizeof(__u64),
-    .value_size = sizeof(int),
-    .max_entries = 1024,
-    .pinning = 0,
-    .namespace = "",
-};
-
 // This map is used to to temporarily store function arguments (fd_in and fd_out) for
 // do_sendfile function calls, so they can be acessed by the corresponding kretprobe.
 // * Key is pid_tgid (u64)
@@ -176,18 +163,6 @@ struct bpf_map_def SEC("maps/do_sendfile_args") do_sendfile_args = {
     .type = BPF_MAP_TYPE_HASH,
     .key_size = sizeof(__u64),
     .value_size = sizeof(__u64),
-    .max_entries = 1024,
-    .pinning = 0,
-    .namespace = "",
-};
-
-// This map indexes conn_tuple_t structs by (PID|SOCKET_FD);
-// It's currently being used by SENDFILE(2) tracing but we also plan to
-// use it for other applications such as HTTPS/OpenSSL monitoring
-struct bpf_map_def SEC("maps/tup_by_pid_sockfd") tup_by_pid_sockfd = {
-    .type = BPF_MAP_TYPE_HASH,
-    .key_size = sizeof(__u64),
-    .value_size = sizeof(conn_tuple_t),
     .max_entries = 1024,
     .pinning = 0,
     .namespace = "",

--- a/pkg/network/ebpf/c/tracer-maps.h
+++ b/pkg/network/ebpf/c/tracer-maps.h
@@ -155,4 +155,42 @@ struct bpf_map_def SEC("maps/ip_route_dest_gateways") ip_route_dest_gateways = {
     .namespace = "",
 };
 
+// This map is used to to temporarily store function arguments (sockfd) for
+// sockfd_lookup_light function calls, so they can be acessed by the corresponding kretprobe.
+// * Key is the pid_tgid;
+// * Value the socket FD;
+struct bpf_map_def SEC("maps/sockfd_lookup_args") sockfd_lookup_args = {
+    .type = BPF_MAP_TYPE_HASH,
+    .key_size = sizeof(__u64),
+    .value_size = sizeof(int),
+    .max_entries = 1024,
+    .pinning = 0,
+    .namespace = "",
+};
+
+// This map is used to to temporarily store function arguments (fd_in and fd_out) for
+// do_sendfile function calls, so they can be acessed by the corresponding kretprobe.
+// * Key is pid_tgid (u64)
+// * Value is (fd_in|fd_out) (u64)
+struct bpf_map_def SEC("maps/do_sendfile_args") do_sendfile_args = {
+    .type = BPF_MAP_TYPE_HASH,
+    .key_size = sizeof(__u64),
+    .value_size = sizeof(__u64),
+    .max_entries = 1024,
+    .pinning = 0,
+    .namespace = "",
+};
+
+// This map indexes conn_tuple_t structs by (PID|SOCKET_FD);
+// It's currently being used by SENDFILE(2) tracing but we also plan to
+// use it for other applications such as HTTPS/OpenSSL monitoring
+struct bpf_map_def SEC("maps/tup_by_pid_sockfd") tup_by_pid_sockfd = {
+    .type = BPF_MAP_TYPE_HASH,
+    .key_size = sizeof(__u64),
+    .value_size = sizeof(conn_tuple_t),
+    .max_entries = 1024,
+    .pinning = 0,
+    .namespace = "",
+};
+
 #endif

--- a/pkg/network/ebpf/c/tracer-maps.h
+++ b/pkg/network/ebpf/c/tracer-maps.h
@@ -155,14 +155,15 @@ struct bpf_map_def SEC("maps/ip_route_dest_gateways") ip_route_dest_gateways = {
     .namespace = "",
 };
 
-// This map is used to to temporarily store function arguments (fd_in and fd_out) for
-// do_sendfile function calls, so they can be acessed by the corresponding kretprobe.
+// This map is used to to temporarily store function arguments (the struct sock*
+// mapped to the given fd_out) for do_sendfile function calls, so they can be
+// acessed by the corresponding kretprobe.
 // * Key is pid_tgid (u64)
-// * Value is (fd_in|fd_out) (u64)
+// * Value is (struct sock*)
 struct bpf_map_def SEC("maps/do_sendfile_args") do_sendfile_args = {
     .type = BPF_MAP_TYPE_HASH,
     .key_size = sizeof(__u64),
-    .value_size = sizeof(__u64),
+    .value_size = sizeof(struct sock*),
     .max_entries = 1024,
     .pinning = 0,
     .namespace = "",

--- a/pkg/network/ebpf/manager.go
+++ b/pkg/network/ebpf/manager.go
@@ -46,8 +46,8 @@ func NewManager(closedHandler *ebpf.PerfHandler, runtimeTracer bool) *manager.Ma
 			{Name: string(probes.UdpPortBindingsMap)},
 			{Name: "pending_bind"},
 			{Name: string(probes.TelemetryMap)},
-			{Name: string(probes.TupByPidFDMap)},
-			{Name: string(probes.PidFDByTupMap)},
+			{Name: string(probes.SockByPidFDMap)},
+			{Name: string(probes.PidFDBySockMap)},
 			{Name: string(probes.SockFDLookupArgsMap)},
 			{Name: string(probes.DoSendfileArgsMap)},
 		},
@@ -88,7 +88,7 @@ func NewManager(closedHandler *ebpf.PerfHandler, runtimeTracer bool) *manager.Ma
 			{Section: string(probes.SockFDLookupRet), KProbeMaxActive: maxActive},
 			{Section: string(probes.DoSendfile), KProbeMaxActive: maxActive},
 			{Section: string(probes.DoSendfileRet), KProbeMaxActive: maxActive},
-			{Section: string(probes.TCPRelease), KProbeMaxActive: maxActive},
+			{Section: string(probes.TCPV4Destroy), KProbeMaxActive: maxActive},
 		},
 	}
 

--- a/pkg/network/ebpf/manager.go
+++ b/pkg/network/ebpf/manager.go
@@ -46,7 +46,8 @@ func NewManager(closedHandler *ebpf.PerfHandler, runtimeTracer bool) *manager.Ma
 			{Name: string(probes.UdpPortBindingsMap)},
 			{Name: "pending_bind"},
 			{Name: string(probes.TelemetryMap)},
-			{Name: string(probes.TupByPidSockFDMap)},
+			{Name: string(probes.TupByPidFDMap)},
+			{Name: string(probes.PidFDByTupMap)},
 			{Name: string(probes.SockFDLookupArgsMap)},
 			{Name: string(probes.DoSendfileArgsMap)},
 		},
@@ -87,6 +88,7 @@ func NewManager(closedHandler *ebpf.PerfHandler, runtimeTracer bool) *manager.Ma
 			{Section: string(probes.SockFDLookupRet), KProbeMaxActive: maxActive},
 			{Section: string(probes.DoSendfile), KProbeMaxActive: maxActive},
 			{Section: string(probes.DoSendfileRet), KProbeMaxActive: maxActive},
+			{Section: string(probes.TCPRelease), KProbeMaxActive: maxActive},
 		},
 	}
 

--- a/pkg/network/ebpf/manager.go
+++ b/pkg/network/ebpf/manager.go
@@ -88,7 +88,6 @@ func NewManager(closedHandler *ebpf.PerfHandler, runtimeTracer bool) *manager.Ma
 			{Section: string(probes.SockFDLookupRet), KProbeMaxActive: maxActive},
 			{Section: string(probes.DoSendfile), KProbeMaxActive: maxActive},
 			{Section: string(probes.DoSendfileRet), KProbeMaxActive: maxActive},
-			{Section: string(probes.TCPV4Destroy), KProbeMaxActive: maxActive},
 		},
 	}
 

--- a/pkg/network/ebpf/manager.go
+++ b/pkg/network/ebpf/manager.go
@@ -45,6 +45,9 @@ func NewManager(closedHandler *ebpf.PerfHandler, runtimeTracer bool) *manager.Ma
 			{Name: string(probes.UdpPortBindingsMap)},
 			{Name: "pending_bind"},
 			{Name: string(probes.TelemetryMap)},
+			{Name: string(probes.TupByPidSockFDMap)},
+			{Name: string(probes.SockFDLookupArgsMap)},
+			{Name: string(probes.DoSendfileArgsMap)},
 		},
 		PerfMaps: []*manager.PerfMap{
 			{
@@ -79,6 +82,10 @@ func NewManager(closedHandler *ebpf.PerfHandler, runtimeTracer bool) *manager.Ma
 			{Section: string(probes.SocketDnsFilter)},
 			{Section: string(probes.IPRouteOutputFlow)},
 			{Section: string(probes.IPRouteOutputFlowReturn), KProbeMaxActive: maxActive},
+			{Section: string(probes.SockFDLookup), KProbeMaxActive: maxActive},
+			{Section: string(probes.SockFDLookupRet), KProbeMaxActive: maxActive},
+			{Section: string(probes.DoSendfile), KProbeMaxActive: maxActive},
+			{Section: string(probes.DoSendfileRet), KProbeMaxActive: maxActive},
 		},
 	}
 

--- a/pkg/network/ebpf/manager.go
+++ b/pkg/network/ebpf/manager.go
@@ -25,6 +25,7 @@ func NewOffsetManager() *manager.Manager {
 		PerfMaps: []*manager.PerfMap{},
 		Probes: []*manager.Probe{
 			{Section: string(probes.TCPGetSockOpt)},
+			{Section: string(probes.SockGetSockOpt)},
 			{Section: string(probes.TCPv6Connect)},
 			{Section: string(probes.IPMakeSkb)},
 			{Section: string(probes.IP6MakeSkb)},

--- a/pkg/network/ebpf/probes/probes.go
+++ b/pkg/network/ebpf/probes/probes.go
@@ -105,9 +105,6 @@ const (
 
 	// DoSendfileRet is the kretprobe used used to trace traffic via SENDFILE(2) syscall
 	DoSendfileRet ProbeName = "kretprobe/do_sendfile"
-
-	// TCPV4Destroy is the kprobe used for cleaning up the socket file descriptor maps
-	TCPV4Destroy ProbeName = "kprobe/tcp_v4_destroy_sock"
 )
 
 // BPFMapName stores the name of the BPF maps storing statistics and other info

--- a/pkg/network/ebpf/probes/probes.go
+++ b/pkg/network/ebpf/probes/probes.go
@@ -32,6 +32,10 @@ const (
 	// This probe is used for offset guessing only
 	TCPGetSockOpt ProbeName = "kprobe/tcp_getsockopt"
 
+	// SockGetSockOpt traces the sock_common_getsockopt() kernel function
+	// This probe is used for offset guessing only
+	SockGetSockOpt ProbeName = "kprobe/sock_common_getsockopt"
+
 	// TCPSetState traces the tcp_set_state() kernel function
 	TCPSetState ProbeName = "kprobe/tcp_set_state"
 

--- a/pkg/network/ebpf/probes/probes.go
+++ b/pkg/network/ebpf/probes/probes.go
@@ -89,6 +89,18 @@ const (
 
 	// ConntrackHashInsert is the probe for new conntrack entries
 	ConntrackHashInsert ProbeName = "kprobe/__nf_conntrack_hash_insert"
+
+	// SockFDLookup is the kprobe used for mapping socket FDs to kernel sock structs
+	SockFDLookup ProbeName = "kprobe/sockfd_lookup_light"
+
+	// SockFDLookupRet is the kretprobe used for mapping socket FDs to kernel sock structs
+	SockFDLookupRet ProbeName = "kretprobe/sockfd_lookup_light"
+
+	// DoSendfile is the kprobe used used to trace traffic via SENDFILE(2) syscall
+	DoSendfile ProbeName = "kprobe/do_sendfile"
+
+	// DoSendfileRet is the kretprobe used used to trace traffic via SENDFILE(2) syscall
+	DoSendfileRet ProbeName = "kretprobe/do_sendfile"
 )
 
 // BPFMapName stores the name of the BPF maps storing statistics and other info
@@ -110,6 +122,9 @@ const (
 	GatewayMap            BPFMapName = "ip_route_dest_gateways"
 	ConntrackMap          BPFMapName = "conntrack"
 	ConntrackTelemetryMap BPFMapName = "conntrack_telemetry"
+	SockFDLookupArgsMap   BPFMapName = "sockfd_lookup_args"
+	DoSendfileArgsMap     BPFMapName = "do_sendfile_args"
+	TupByPidSockFDMap     BPFMapName = "tup_by_pid_sockfd"
 )
 
 // SectionName returns the SectionName for the given BPF map

--- a/pkg/network/ebpf/probes/probes.go
+++ b/pkg/network/ebpf/probes/probes.go
@@ -106,8 +106,8 @@ const (
 	// DoSendfileRet is the kretprobe used used to trace traffic via SENDFILE(2) syscall
 	DoSendfileRet ProbeName = "kretprobe/do_sendfile"
 
-	// TCPRelease is the kprobe used for cleaning up the (PID|FD) => tuple map
-	TCPRelease ProbeName = "kprobe/tcp_v4_destroy_sock"
+	// TCPV4Destroy is the kprobe used for cleaning up the socket file descriptor maps
+	TCPV4Destroy ProbeName = "kprobe/tcp_v4_destroy_sock"
 )
 
 // BPFMapName stores the name of the BPF maps storing statistics and other info
@@ -131,8 +131,8 @@ const (
 	ConntrackTelemetryMap BPFMapName = "conntrack_telemetry"
 	SockFDLookupArgsMap   BPFMapName = "sockfd_lookup_args"
 	DoSendfileArgsMap     BPFMapName = "do_sendfile_args"
-	TupByPidFDMap         BPFMapName = "tup_by_pid_fd"
-	PidFDByTupMap         BPFMapName = "pid_fd_by_tup"
+	SockByPidFDMap        BPFMapName = "sock_by_pid_fd"
+	PidFDBySockMap        BPFMapName = "pid_fd_by_sock"
 )
 
 // SectionName returns the SectionName for the given BPF map

--- a/pkg/network/ebpf/probes/probes.go
+++ b/pkg/network/ebpf/probes/probes.go
@@ -105,6 +105,9 @@ const (
 
 	// DoSendfileRet is the kretprobe used used to trace traffic via SENDFILE(2) syscall
 	DoSendfileRet ProbeName = "kretprobe/do_sendfile"
+
+	// TCPRelease is the kprobe used for cleaning up the (PID|FD) => tuple map
+	TCPRelease ProbeName = "kprobe/tcp_v4_destroy_sock"
 )
 
 // BPFMapName stores the name of the BPF maps storing statistics and other info
@@ -128,7 +131,8 @@ const (
 	ConntrackTelemetryMap BPFMapName = "conntrack_telemetry"
 	SockFDLookupArgsMap   BPFMapName = "sockfd_lookup_args"
 	DoSendfileArgsMap     BPFMapName = "do_sendfile_args"
-	TupByPidSockFDMap     BPFMapName = "tup_by_pid_sockfd"
+	TupByPidFDMap         BPFMapName = "tup_by_pid_fd"
+	PidFDByTupMap         BPFMapName = "pid_fd_by_tup"
 )
 
 // SectionName returns the SectionName for the given BPF map

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -160,8 +160,8 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 			string(probes.TcpStatsMap):        {Type: ebpf.Hash, MaxEntries: uint32(config.MaxTrackedConnections), EditorFlag: manager.EditMaxEntries},
 			string(probes.PortBindingsMap):    {Type: ebpf.Hash, MaxEntries: uint32(config.MaxTrackedConnections), EditorFlag: manager.EditMaxEntries},
 			string(probes.UdpPortBindingsMap): {Type: ebpf.Hash, MaxEntries: uint32(config.MaxTrackedConnections), EditorFlag: manager.EditMaxEntries},
-			string(probes.TupByPidFDMap):      {Type: ebpf.Hash, MaxEntries: uint32(config.MaxTrackedConnections), EditorFlag: manager.EditMaxEntries},
-			string(probes.PidFDByTupMap):      {Type: ebpf.Hash, MaxEntries: uint32(config.MaxTrackedConnections), EditorFlag: manager.EditMaxEntries},
+			string(probes.SockByPidFDMap):     {Type: ebpf.Hash, MaxEntries: uint32(config.MaxTrackedConnections), EditorFlag: manager.EditMaxEntries},
+			string(probes.PidFDBySockMap):     {Type: ebpf.Hash, MaxEntries: uint32(config.MaxTrackedConnections), EditorFlag: manager.EditMaxEntries},
 		},
 	}
 

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -160,7 +160,8 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 			string(probes.TcpStatsMap):        {Type: ebpf.Hash, MaxEntries: uint32(config.MaxTrackedConnections), EditorFlag: manager.EditMaxEntries},
 			string(probes.PortBindingsMap):    {Type: ebpf.Hash, MaxEntries: uint32(config.MaxTrackedConnections), EditorFlag: manager.EditMaxEntries},
 			string(probes.UdpPortBindingsMap): {Type: ebpf.Hash, MaxEntries: uint32(config.MaxTrackedConnections), EditorFlag: manager.EditMaxEntries},
-			string(probes.TupByPidSockFDMap):  {Type: ebpf.Hash, MaxEntries: uint32(config.MaxTrackedConnections), EditorFlag: manager.EditMaxEntries},
+			string(probes.TupByPidFDMap):      {Type: ebpf.Hash, MaxEntries: uint32(config.MaxTrackedConnections), EditorFlag: manager.EditMaxEntries},
+			string(probes.PidFDByTupMap):      {Type: ebpf.Hash, MaxEntries: uint32(config.MaxTrackedConnections), EditorFlag: manager.EditMaxEntries},
 		},
 	}
 

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -160,6 +160,7 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 			string(probes.TcpStatsMap):        {Type: ebpf.Hash, MaxEntries: uint32(config.MaxTrackedConnections), EditorFlag: manager.EditMaxEntries},
 			string(probes.PortBindingsMap):    {Type: ebpf.Hash, MaxEntries: uint32(config.MaxTrackedConnections), EditorFlag: manager.EditMaxEntries},
 			string(probes.UdpPortBindingsMap): {Type: ebpf.Hash, MaxEntries: uint32(config.MaxTrackedConnections), EditorFlag: manager.EditMaxEntries},
+			string(probes.TupByPidSockFDMap):  {Type: ebpf.Hash, MaxEntries: uint32(config.MaxTrackedConnections), EditorFlag: manager.EditMaxEntries},
 		},
 	}
 

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -2567,7 +2567,6 @@ func TestConnectionAssured(t *testing.T) {
 }
 
 func TestConnectionNotAssured(t *testing.T) {
-
 	cfg := testConfig()
 	cfg.BPFDebug = true
 	tr, err := NewTracer(cfg)
@@ -2741,6 +2740,16 @@ func TestSendfileRegression(t *testing.T) {
 	require.NoError(t, err)
 	defer tr.Stop()
 
+	// Create temporary file
+	tmpfile, err := ioutil.TempFile("", "sendfile_source")
+	require.NoError(t, err)
+	defer os.Remove(tmpfile.Name())
+	n, err := tmpfile.Write(genPayload(clientMessageSize))
+	require.NoError(t, err)
+	require.Equal(t, clientMessageSize, n)
+	_, err = tmpfile.Seek(0, 0)
+	require.NoError(t, err)
+
 	// Start TCP server
 	var rcvd int64
 	server := NewTCPServer(func(c net.Conn) {
@@ -2752,16 +2761,6 @@ func TestSendfileRegression(t *testing.T) {
 	require.NoError(t, err)
 	defer close(doneChan)
 
-	// Create temporary file
-	tmpfile, err := ioutil.TempFile("", "sendfile_source")
-	require.NoError(t, err)
-	defer os.Remove(tmpfile.Name())
-	n, err := tmpfile.Write(genPayload(clientMessageSize))
-	require.NoError(t, err)
-	require.Equal(t, clientMessageSize, n)
-	_, err = tmpfile.Seek(0, 0)
-	require.NoError(t, err)
-
 	// Connect to TCP server
 	c, err := net.DialTimeout("tcp", server.address, time.Second)
 	require.NoError(t, err)
@@ -2769,13 +2768,8 @@ func TestSendfileRegression(t *testing.T) {
 	// Warm up state
 	_ = getConnections(t, tr)
 
-	// Send payload using SENDFILE(2) syscall
-	rawConn, err := c.(*net.TCPConn).SyscallConn()
-	require.NoError(t, err)
-	rawConn.Control(func(fd uintptr) {
-		n, _ = syscall.Sendfile(int(fd), int(tmpfile.Fd()), nil, clientMessageSize)
-	})
-	require.Equal(t, clientMessageSize, n)
+	// Send file contents via SENDFILE(2)
+	sendFile(t, c, tmpfile)
 
 	// Verify that our TCP server received the contents of the file
 	c.Close()
@@ -2789,8 +2783,24 @@ func TestSendfileRegression(t *testing.T) {
 		conns := getConnections(t, tr)
 		var ok bool
 		conn, ok = findConnection(c.LocalAddr(), c.RemoteAddr(), conns)
-		return ok
+		return ok && conn.MonotonicSentBytes > 0
 	}, 3*time.Second, 500*time.Millisecond, "couldn't find connection used by sendfile(2)")
 
-	assert.Equalf(t, int64(clientMessageSize), conn.MonotonicSentBytes, "sendfile data wasn't traced")
+	assert.Equalf(t, int64(clientMessageSize), int64(conn.MonotonicSentBytes), "sendfile data wasn't properly traced")
+}
+
+func sendFile(t *testing.T, c net.Conn, f *os.File) {
+	// Grab file size
+	stat, err := f.Stat()
+	require.NoError(t, err)
+	fsize := int(stat.Size())
+
+	// Send payload using SENDFILE(2) syscall
+	rawConn, err := c.(*net.TCPConn).SyscallConn()
+	require.NoError(t, err)
+	var n int
+	rawConn.Control(func(fd uintptr) {
+		n, _ = syscall.Sendfile(int(fd), int(f.Fd()), nil, fsize)
+	})
+	require.Equal(t, fsize, n)
 }

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -2777,7 +2777,7 @@ func TestSendfileRegression(t *testing.T) {
 		return int64(clientMessageSize) == rcvd
 	}, 3*time.Second, 500*time.Millisecond, "TCP server didn't receive data")
 
-	// Finaly retrieve connection and assert that the sendfile was accounted for
+	// Finally, retrieve connection and assert that the sendfile was accounted for
 	var conn *network.ConnectionStats
 	require.Eventually(t, func() bool {
 		conns := getConnections(t, tr)


### PR DESCRIPTION
### What does this PR do?

Add support for tracing network traffic originated from sendfile(2) calls.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Change is being unit tested.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
