### PR TITLE
[aggregator/ckey] implement a faster hash to reduce CPU and RAM usage

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -411,6 +411,8 @@ func (agg *BufferedAggregator) addServiceCheck(sc metrics.ServiceCheck) {
 	}
 	tb := util.NewTagsBuilderFromSlice(sc.Tags)
 	metrics.EnrichTags(tb, sc.OriginID, sc.K8sOriginID, sc.Cardinality)
+
+	tb.SortUniq()
 	sc.Tags = tb.Get()
 
 	agg.serviceChecks = append(agg.serviceChecks, &sc)
@@ -423,6 +425,8 @@ func (agg *BufferedAggregator) addEvent(e metrics.Event) {
 	}
 	tb := util.NewTagsBuilderFromSlice(e.Tags)
 	metrics.EnrichTags(tb, e.OriginID, e.K8sOriginID, e.Cardinality)
+
+	tb.SortUniq()
 	e.Tags = tb.Get()
 
 	agg.events = append(agg.events, &e)

--- a/pkg/aggregator/ckey/key.go
+++ b/pkg/aggregator/ckey/key.go
@@ -88,6 +88,10 @@ func (g *KeyGenerator) Generate(name, hostname string, tags []string) ContextKey
 			for {
 				if g.seen[j] == 0 {
 					// not seen, we will add it to the hash
+					// TODO(remy): we may want to store the original bytes instead
+					// of the hash, even if the comparison would be slower, we would
+					// be able to avoid collisions here.
+					// See https://github.com/DataDog/datadog-agent/pull/8529#discussion_r661493647
 					g.seen[j] = h
 					g.intb = g.intb ^ h // add this tag into the hash
 					break

--- a/pkg/aggregator/ckey/key.go
+++ b/pkg/aggregator/ckey/key.go
@@ -6,9 +6,6 @@
 package ckey
 
 import (
-	"sort"
-
-	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/twmb/murmur3"
 )
 
@@ -16,8 +13,7 @@ import (
 // aggregate metrics from a same context together.
 //
 // This implementation has been designed to remove all heap
-// allocations from the intake to reduce GC pressure on high
-// volumes.
+// allocations from the intake in order to reduce GC pressure on high volumes.
 //
 // Having int64/uint64 context keys mean that we will get better performances
 // from the Go runtime while using them as map keys. This is thanks to the fast-path
@@ -27,49 +23,93 @@ import (
 // Note that Agent <= 6.19.0 were using a 128 bits hash, we've switched
 // to 64 bits for better performances (map access) and because 128 bits were overkill
 // in the first place.
-// Note that we've benchmarked against xxhash64 which should be slightly faster,
-// but the Go compiler is not inlining xxhash sum methods whereas it is inlining
-// the murmur3 implementation, providing better performances overall.
-// Note that benchmarks against fnv1a did not provide better performances (no inlining).
+// Note that benchmarks against fnv1a did not provide better performances (no inlining)
+// nor did benchmarks with xxhash (slightly slower).
 type ContextKey uint64
-
-// KeyGenerator generates key
-// Not safe for concurrent usage
-type KeyGenerator struct {
-	buf []byte
-}
 
 // NewKeyGenerator creates a new key generator
 func NewKeyGenerator() *KeyGenerator {
 	return &KeyGenerator{
-		buf: make([]byte, 0, 1024),
+		seen:  make([]uint64, 512, 512),
+		empty: make([]uint64, 512, 512),
 	}
+}
+
+// KeyGenerator generates hash for the given name, hostname and tags.
+// The tags don't have to be sorted and duplicated tags will be ignored while
+// generating the hash.
+// Not safe for concurrent usage.
+type KeyGenerator struct {
+	// reused buffer to not create a uint64 on the stack every key generation
+	intb uint64
+
+	// seen is used as a hashset to deduplicate the tags when there is more than
+	// 16 and less than 512 tags.
+	seen []uint64
+	// empty is an empty hashset with all values set to 0, to reset `seen`
+	empty []uint64
+
+	// idx is used to deduplicate tags when there is less than 16 tags (faster than the
+	// hashset) or more than 512 tags (hashset has been allocated with 512 values max)
+	idx int
 }
 
 // Generate returns the ContextKey hash for the given parameters.
 // The tags array is sorted in place to avoid heap allocations.
 func (g *KeyGenerator) Generate(name, hostname string, tags []string) ContextKey {
-	g.buf = g.buf[:0]
+	g.intb = 0xc6a4a7935bd1e995
+	g.intb = g.intb ^ murmur3.StringSum64(name)
+	g.intb = g.intb ^ murmur3.StringSum64(hostname)
 
-	// Sort the tags in place. For typical tag slices, we use
-	// the in-place insertion sort to avoid heap allocations.
-	// We default to stdlib's sort package for longer slices.
-	// See `pkg/util/sort.go` for info on the threshold.
-	if len(tags) < util.InsertionSortThreshold {
-		util.InsertionSort(tags)
+	// there is two implementations used here to deduplicate the tags depending on how
+	// many tags we have to process:
+	//   -  16 < n < 512: 		we use a hashset of 512 values. This size has been
+	// 							selected to have space for approximately 500 tags
+	// 							since it nos impacting much the performances,
+	// 							even if the backend is truncating after 100.
+	//   -  n < 16 or n > 512: 	we use a simple for loops, which is faster than
+	//                         	the hashset when there is less than 16 tags, and
+	//                         	we use it as fallback when there is more than 512
+	//                         	because it is the maximum size the allocated
+	//                         	hashset can handle.
+	if len(tags) > 16 && len(tags) < 512 {
+		copy(g.seen, g.empty) // reset the `seen` hashset
+	OUTER:
+		for i := range tags {
+			h := murmur3.StringSum64(tags[i])
+			j := h & 511 // address this hash into the hashset
+			for {
+				if g.seen[j] == 0 { // not seen, we will add it to the hash
+					g.seen[j] = h
+					break
+				} else if g.seen[j] == h {
+					continue OUTER // already seen, we do not want to xor multiple times the same tag
+				} else {
+					// move 'right' in the hashset because there is already a value,
+					// in this bucket, which is not the one we're dealing with right now,
+					// we may have already seen this tag
+					j = (j + 1) & 511
+				}
+			}
+			g.intb = g.intb ^ h // add this tag into the hash
+		}
 	} else {
-		sort.Strings(tags)
+		g.idx = 0
+	OUTER2:
+		for i := range tags {
+			h := murmur3.StringSum64(tags[i])
+			for j := 0; j < g.idx; j++ {
+				if g.seen[j] == h {
+					continue OUTER2 // we do not want to xor multiple times the same tag
+				}
+			}
+			g.intb = g.intb ^ h
+			g.seen[g.idx] = h
+			g.idx++
+		}
 	}
 
-	g.buf = append(g.buf, name...)
-	g.buf = append(g.buf, ',')
-	for i := 0; i < len(tags); i++ {
-		g.buf = append(g.buf, tags[i]...)
-		g.buf = append(g.buf, ',')
-	}
-	g.buf = append(g.buf, hostname...)
-
-	return ContextKey(murmur3.Sum64(g.buf))
+	return ContextKey(g.intb)
 }
 
 // Equals returns whether the two context keys are equal or not.

--- a/pkg/aggregator/ckey/key.go
+++ b/pkg/aggregator/ckey/key.go
@@ -65,7 +65,7 @@ func (g *KeyGenerator) Generate(name, hostname string, tags []string) ContextKey
 	// many tags we have to process:
 	//   -  16 < n < 512: 		we use a hashset of 512 values. This size has been
 	// 							selected to have space for approximately 500 tags
-	// 							since it nos impacting much the performances,
+	// 							since it's not impacting the performance much,
 	// 							even if the backend is truncating after 100.
 	//   -  n < 16 or n > 512: 	we use a simple for loops, which is faster than
 	//                         	the hashset when there is less than 16 tags, and

--- a/pkg/aggregator/ckey/key_test.go
+++ b/pkg/aggregator/ckey/key_test.go
@@ -25,7 +25,7 @@ func TestGenerateReproductible(t *testing.T) {
 	generator := NewKeyGenerator()
 
 	firstKey := generator.Generate(name, hostname, tags)
-	assert.Equal(t, ContextKey(0x5a2b4635eb90c410), firstKey)
+	assert.Equal(t, ContextKey(0x558b3fdbeb2ae197), firstKey)
 
 	for n := 0; n < 10; n++ {
 		t.Run(fmt.Sprintf("iteration %d:", n), func(t *testing.T) {
@@ -36,7 +36,7 @@ func TestGenerateReproductible(t *testing.T) {
 
 	otherKey := generator.Generate("othername", hostname, tags)
 	assert.NotEqual(t, firstKey, otherKey)
-	assert.Equal(t, ContextKey(0x90352c032ca3bcd), otherKey)
+	assert.Equal(t, ContextKey(0x76fd4f64609a9375), otherKey)
 }
 
 func TestCompare(t *testing.T) {
@@ -47,6 +47,32 @@ func TestCompare(t *testing.T) {
 	assert.True(t, Equals(base, base))
 	assert.True(t, Equals(base, same))
 	assert.False(t, Equals(base, diff))
+}
+
+func TestTagsOrderAndDupsDontMatter(t *testing.T) {
+	assert := assert.New(t)
+
+	name := "metrics.to.test.hashing"
+	hostname := "hostname.localhost"
+	tags := []string{"bar", "foo", "key:value", "key:value2"}
+
+	generator := NewKeyGenerator()
+	key := generator.Generate(name, hostname, tags)
+
+	// change tags order, the generated key should be the same
+	tags[0], tags[1], tags[2], tags[3] = tags[3], tags[0], tags[1], tags[2]
+	key2 := generator.Generate(name, hostname, tags)
+	assert.Equal(key, key2, "order of tags should not matter")
+
+	// add a duplicated tag
+	tags = append(tags, "key:value", "foo")
+	key3 := generator.Generate(name, hostname, tags)
+	assert.Equal(key, key3, "duplicated tags should not matter")
+
+	// and now, completely change of the tag, the generated key should NOT be the same
+	tags[2] = "another:tag"
+	key4 := generator.Generate(name, hostname, tags)
+	assert.NotEqual(key, key4, "tags content should matter")
 }
 
 func genTags(count int) []string {

--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -44,8 +44,8 @@ func newContextResolver() *contextResolver {
 
 // trackContext returns the contextKey associated with the context of the metricSample and tracks that context
 func (cr *contextResolver) trackContext(metricSampleContext metrics.MetricSampleContext) ckey.ContextKey {
-	metricSampleContext.GetTags(cr.tagsBuffer)
-	contextKey := cr.generateContextKey(metricSampleContext, cr.tagsBuffer)
+	metricSampleContext.GetTags(cr.tagsBuffer)                              // tags here are not sorted and can contain duplicates
+	contextKey := cr.generateContextKey(metricSampleContext, cr.tagsBuffer) // the generator is ignoring duplicates (and doesn't mind the order)
 
 	if _, ok := cr.contextsByKey[contextKey]; !ok {
 		// making a copy of tags for the context since tagsBuffer

--- a/pkg/aggregator/context_resolver_test.go
+++ b/pkg/aggregator/context_resolver_test.go
@@ -9,7 +9,7 @@ package aggregator
 
 import (
 	// stdlib
-	"sort"
+
 	"testing"
 
 	// 3p
@@ -31,7 +31,7 @@ func TestGenerateContextKey(t *testing.T) {
 	}
 
 	contextKey := generateContextKey(&mSample)
-	assert.Equal(t, ckey.ContextKey(0xdd892472f57d5cf1), contextKey)
+	assert.Equal(t, ckey.ContextKey(0xd28d2867c6dd822c), contextKey)
 }
 
 func TestTrackContext(t *testing.T) {
@@ -79,15 +79,12 @@ func TestTrackContext(t *testing.T) {
 
 	// When we look up the 2 keys, they return the correct contexts
 	context1 := contextResolver.contextsByKey[contextKey1]
-	sort.Strings(expectedContext1.Tags) // context tags are sorted
 	assert.Equal(t, expectedContext1, *context1)
 
 	context2 := contextResolver.contextsByKey[contextKey2]
-	sort.Strings(expectedContext2.Tags) // context tags are sorted
 	assert.Equal(t, expectedContext2, *context2)
 
 	context3 := contextResolver.contextsByKey[contextKey3]
-	sort.Strings(expectedContext3.Tags) // context tags are sorted
 	assert.Equal(t, expectedContext3, *context3)
 
 	unknownContextKey := ckey.ContextKey(0xffffffffffffffff)

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -691,13 +691,18 @@ func (s *Server) Stop() {
 	s.Started = false
 }
 
+// storeMetricStats stores stats on the given metric sample.
+// It is storing the stats of the sample as they are received: it means that if
+// a metric is received with duplicated tags, it will be stored this way here.
+// It can help troubleshooting clients with bad behaviors but it is different that
+// what will be outputted by the aggregator, which takes care of deduping the tags
+// to aggregate the metrics.
 func (s *Server) storeMetricStats(sample metrics.MetricSample) {
 	now := time.Now()
 	s.Debug.Lock()
 	defer s.Debug.Unlock()
 
 	// key
-	util.SortUniqInPlace(sample.Tags)
 	key := s.Debug.keyGen.Generate(sample.Name, "", sample.Tags)
 
 	// store

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -659,8 +659,8 @@ func TestDebugStats(t *testing.T) {
 	require.Equal(t, metric3.Count, uint64(1))
 
 	// test context correctness
-	require.Equal(t, metric4.Tags, "b c")
-	require.Equal(t, metric5.Tags, "b c")
+	require.Equal(t, metric4.Tags, "c b")
+	require.Equal(t, metric5.Tags, "c b")
 	require.Equal(t, hash4, hash5)
 }
 

--- a/pkg/metrics/metric_sample.go
+++ b/pkg/metrics/metric_sample.go
@@ -123,6 +123,9 @@ func addOrchestratorTags(cardinality collectors.TagCardinality, tb *util.TagsBui
 }
 
 // EnrichTags expend a tag list with origin detection tags
+// NOTE(remy): it is not needed to sort/dedup the tags anymore since after the
+// enrichment, the metric and its tags is sent to the context key generator, which
+// is taking care of deduping the tags while generating the context key.
 func EnrichTags(tb *util.TagsBuilder, originID string, k8sOriginID string, cardinality string) {
 	taggerCard := taggerCardinality(cardinality)
 
@@ -135,8 +138,6 @@ func EnrichTags(tb *util.TagsBuilder, originID string, k8sOriginID string, cardi
 			log.Tracef("Cannot get tags for entity %s: %s", k8sOriginID, err)
 		}
 	}
-
-	tb.SortUniq()
 }
 
 // GetTags returns the metric sample tags

--- a/releasenotes/notes/faster-ckey-hash-8f30ad530cce348a.yaml
+++ b/releasenotes/notes/faster-ckey-hash-8f30ad530cce348a.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Implemented a faster context key/hash generator: it should result in a reduced CPU
+    usage and a smaller RAM footprint for DogStatsD servers receiving a lot of metrics.


### PR DESCRIPTION
### What does this PR do?

The highest CPU usage in the CPU profiles of highly loaded DogStatsD server was
the sorting of the metric tags in order to generate reproducible context keys.

This commit implements a hash which does not need to sort the tags to generate
reproducible context keys: it relies on XORing parts of the hash together instead
of building a bytes buffer containing all parts before hashing this whole buffer.
In order for this to work, a fast deduplication algorithm had to be written since
duplicated tags would make the hash computation wrong because of the XOR usage.

Using this implementation, the DogStatsD server will use less CPU to process more
metrics, and thus, it will use less RAM since it won't have to buffer as much as
before.

Micro-benchmarks of the KeyGenerator, `7.30.0-dev` against this branch:

```
KeyGeneration/1-tags-8    25.1ns ± 4%  21.6ns ± 0%  -14.08%  (p=0.016 n=5+4)
KeyGeneration/2-tags-8    34.7ns ± 3%  30.6ns ± 7%  -11.99%  (p=0.008 n=5+5)
KeyGeneration/4-tags-8    59.9ns ±12%  50.0ns ± 3%  -16.59%  (p=0.008 n=5+5)
KeyGeneration/8-tags-8     119ns ±10%    86ns ± 6%  -27.67%  (p=0.008 n=5+5)
KeyGeneration/16-tags-8    212ns ± 1%   206ns ± 3%     ~     (p=0.095 n=5+5)
KeyGeneration/32-tags-8    423ns ± 4%   312ns ± 2%  -26.29%  (p=0.008 n=5+5)
KeyGeneration/64-tags-8   2.72µs ± 3%  0.60µs ± 2%  -78.07%  (p=0.008 n=5+5)
KeyGeneration/128-tags-8  6.15µs ± 3%  1.14µs ± 3%  -81.44%  (p=0.008 n=5+5)
```

Here are different benchmarks results, where DogStatsD servers are hit with
300k metrics/second, with 10, 15 and 20 client tags added to the metrics
(the benchmarks are configured with "High cardinality" discovery tags, meaning
that the metrics end up with more than 50 tags approximately).

PR results are in red/orange in those graphs, purple lines are `7.29.0`: 

![image](https://user-images.githubusercontent.com/1798689/123966337-a0804180-d9b5-11eb-8707-4b405922b5f3.png)
![image](https://user-images.githubusercontent.com/1798689/123966701-f2c16280-d9b5-11eb-9522-e50e186c42bb.png)
![image](https://user-images.githubusercontent.com/1798689/123966873-184e6c00-d9b6-11eb-9de4-cd191744f28e.png)

### Motivation

Improve performances of the DogStatsD server to lower its CPU and RAM usage.

### Additional Notes

I've decided to continue to sort+unique the tags for Service Checks and (old) Events since their throughput isn't as high as DogStatsD samples.

AFAIK, mathematically, nothing has changed about the amount of collisions possible with this context key implementation, still, I've created a tool to naively / practically verify this in https://github.com/DataDog/datadog-agent/pull/8526 and this implementation has been through it multiple times successfully (i.e. tested with more than 50 millions different generated metrics).

### Describe how to test your changes

Validate that custom metrics received by DogStatsD are still available and display sane values.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [N/A] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [N/A] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
