### PR TITLE
[CWS] fix inconsistencies between C and Go structs, for unmarshallers

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "57e058baddb56382e35cf19091f4635646461e6a6e3f69401983fcc21737f8a9")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "2762cd66cf18ec7a929f4708ca3e60d4af653f7bd886e07c140d6aef392bcba6")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "4525f98aeb4dd273e672d9d2471c3746fe031b1afcf9d8d5a6d9b3bc800aac37")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "57e058baddb56382e35cf19091f4635646461e6a6e3f69401983fcc21737f8a9")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "1c93ead9c93591c46191e3a03f67ae863ec26329f32fa8a430edf3044165369f")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "4525f98aeb4dd273e672d9d2471c3746fe031b1afcf9d8d5a6d9b3bc800aac37")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "2561ecf9465a32a7c4005119f87ac13952ba2b5a5ed89192dda1726fd72c66ed")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "1c93ead9c93591c46191e3a03f67ae863ec26329f32fa8a430edf3044165369f")

--- a/pkg/security/ebpf/c/chown.h
+++ b/pkg/security/ebpf/c/chown.h
@@ -9,8 +9,8 @@ struct chown_event_t {
     struct container_context_t container;
     struct syscall_t syscall;
     struct file_t file;
-    uid_t user;
-    gid_t group;
+    uid_t uid;
+    gid_t gid;
 };
 
 int __attribute__((always_inline)) chown_approvers(struct syscall_cache_t *syscall) {
@@ -76,8 +76,8 @@ int __attribute__((always_inline)) sys_chown_ret(void *ctx, int retval) {
     struct chown_event_t event = {
         .syscall.retval = retval,
         .file = syscall->setattr.file,
-        .user = syscall->setattr.user,
-        .group = syscall->setattr.group,
+        .uid = syscall->setattr.user,
+        .gid = syscall->setattr.group,
     };
 
     struct proc_cache_t *entry = fill_process_context(&event.process);

--- a/pkg/security/ebpf/c/mount.h
+++ b/pkg/security/ebpf/c/mount.h
@@ -14,8 +14,8 @@ struct mount_event_t {
     u32 group_id;
     dev_t device;
     u32 parent_mount_id;
-    unsigned long parent_ino;
-    unsigned long root_ino;
+    unsigned long parent_inode;
+    unsigned long root_inode;
     u32 root_mount_id;
     u32 padding;
     char fstype[FSTYPE_LEN];
@@ -145,8 +145,8 @@ int __attribute__((always_inline)) dr_mount_callback(void *ctx, int retval) {
         .group_id = get_mount_peer_group_id(syscall->mount.src_mnt),
         .device = get_mount_dev(syscall->mount.src_mnt),
         .parent_mount_id = syscall->mount.path_key.mount_id,
-        .parent_ino = syscall->mount.path_key.ino,
-        .root_ino = syscall->mount.root_key.ino,
+        .parent_inode = syscall->mount.path_key.ino,
+        .root_inode = syscall->mount.root_key.ino,
         .root_mount_id = syscall->mount.root_key.mount_id,
     };
     bpf_probe_read_str(&event.fstype, FSTYPE_LEN, (void*) syscall->mount.fstype);

--- a/pkg/security/ebpf/c/utimes.h
+++ b/pkg/security/ebpf/c/utimes.h
@@ -9,7 +9,7 @@
   utime syscalls call utimes_common
 */
 
-struct utime_event_t {
+struct utimes_event_t {
     struct kevent_t event;
     struct process_context_t process;
     struct container_context_t container;
@@ -68,7 +68,7 @@ int __attribute__((always_inline)) sys_utimes_ret(void *ctx, int retval) {
     if (IS_UNHANDLED_ERROR(retval))
         return 0;
 
-    struct utime_event_t event = {
+    struct utimes_event_t event = {
         .syscall.retval = retval,
         .atime = syscall->setattr.atime,
         .mtime = syscall->setattr.mtime,

--- a/pkg/security/model/unmarshallers.go
+++ b/pkg/security/model/unmarshallers.go
@@ -246,7 +246,7 @@ func (e *FileFields) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshals a binary representation of itself
 func (e *FileEvent) UnmarshalBinary(data []byte) (int, error) {
-	return e.FileFields.UnmarshalBinary(data)
+	return UnmarshalBinary(data, &e.FileFields)
 }
 
 // UnmarshalBinary unmarshals a binary representation of itself

--- a/pkg/security/tests/utimes_test.go
+++ b/pkg/security/tests/utimes_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
 )
 
-func TestUtime(t *testing.T) {
+func TestUtimes(t *testing.T) {
 	ruleDef := &rules.RuleDefinition{
 		ID:         "test_rule",
 		Expression: `utimes.file.path == "{{.Root}}/test-utime" && utimes.file.uid == 98 && utimes.file.gid == 99`,


### PR DESCRIPTION
### What does this PR do?

This PR fixes some inconsistencies for field and struct names between C and Go.

### Motivation

While exploring the possibility to generate most of the unmarshallers from Dwarf debuginfo on the C side and the Go AST on the Go side, we realised that some field names or struct names are inconsistent between the two languages. The goal of this PR is to fix those inconsistencies.

### Describe how to test your changes

Those must should not break anything.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
