### PR TITLE
[runtime-security] install glibc.i686 on Oracle (fix kitchen tests on Oracle)

### DIFF
--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -96,7 +96,7 @@ if node['platform_family'] != 'windows'
   if not platform_family?('suse')
     package 'Install i386 libc' do
       case node[:platform]
-      when 'redhat', 'centos', 'fedora'
+      when 'redhat', 'centos', 'fedora', 'oracle'
         package_name 'glibc.i686'
       when 'ubuntu', 'debian'
         package_name 'libc6-i386'


### PR DESCRIPTION
### What does this PR do?

This PR fixes kitchen tests on Oracle, by fixing the `glibc.i686` install step in the kitchen cookbook.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
