### PR TITLE
Increase default timeout to sync informers from 2 to 5 seconds

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -541,7 +541,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("leader_lease_duration", "60")
 	config.BindEnvAndSetDefault("leader_election", false)
 	config.BindEnvAndSetDefault("kube_resources_namespace", "")
-	config.BindEnvAndSetDefault("kube_cache_sync_timeout_seconds", 2)
+	config.BindEnvAndSetDefault("kube_cache_sync_timeout_seconds", 5)
 
 	// Datadog cluster agent
 	config.BindEnvAndSetDefault("cluster_agent.enabled", false)

--- a/releasenotes/notes/increase-kube-sync-timeout-54bd44a2b6238470.yaml
+++ b/releasenotes/notes/increase-kube-sync-timeout-54bd44a2b6238470.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Increase default timeout to sync Kubernetes Informers from 2 to 5 seconds.


### PR DESCRIPTION
### What does this PR do?

Increase default timeout to sync Kubernetes Informers from 2 to 5 seconds.

### Motivation

Internal configuration and some support cases around this.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

`agent config` should display the new default

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
