### PR TITLE
[runtime-security] use ktimeval directly in utimes event

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "28ee3bb3d08aef8227fccdac8bc3af2127c8cfaf75658aabdbce65907db21019")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "0d0681bf0a4a1adef71d02807bb73aadf052a23450c4c2e54b4971cd744ee00a")

--- a/pkg/security/ebpf/c/utimes.h
+++ b/pkg/security/ebpf/c/utimes.h
@@ -15,10 +15,7 @@ struct utime_event_t {
     struct container_context_t container;
     struct syscall_t syscall;
     struct file_t file;
-    struct {
-        long tv_sec;
-        long tv_usec;
-    } atime, mtime;
+    struct ktimeval atime, mtime;
 };
 
 int __attribute__((always_inline)) trace__sys_utimes() {
@@ -73,14 +70,8 @@ int __attribute__((always_inline)) sys_utimes_ret(void *ctx, int retval) {
 
     struct utime_event_t event = {
         .syscall.retval = retval,
-        .atime = {
-            .tv_sec = syscall->setattr.atime.tv_sec,
-            .tv_usec = syscall->setattr.atime.tv_nsec,
-        },
-        .mtime = {
-            .tv_sec = syscall->setattr.mtime.tv_sec,
-            .tv_usec = syscall->setattr.mtime.tv_nsec,
-        },
+        .atime = syscall->setattr.atime,
+        .mtime = syscall->setattr.mtime,
         .file = syscall->setattr.file,
     };
 


### PR DESCRIPTION
### What does this PR do?

This PR uses `struct ktimeval` directly instead of defining an ad-hoc struct in `utime_event_t`. It also fixes some inconsistencies in the nano/microsecond part of the time.

To collect the time we hook the `security_inode_setattr` function and collect the fields `ia_atime` and `ia_mtime`. Those fields are of the `struct timespec(64)` type:
```
struct timespec64 {
	time64_t	tv_sec;			/* seconds */
	long		tv_nsec;		/* nanoseconds */
};
```
We can then see that we are collecting seconds, and nanoseconds. This corresponds to what is expected by `ktimeval`:
```
struct ktimeval {
    long tv_sec;
    long tv_nsec;
};
```
but not to the ad-hoc structure:
```
struct {
    long tv_sec;
    long tv_usec;
} atime, mtime;
```

On the other side, when unmarshalling the event we use:
```
timeSec := ByteOrder.Uint64(data[0:8])
timeNsec := ByteOrder.Uint64(data[8:16])
e.Atime = time.Unix(int64(timeSec), int64(timeNsec))
```
(c.f https://golang.org/pkg/time/#Unix) and unmarshall the second fields as nanoseconds.

It is thus clear that we do the correct thing but we can directly use `struct ktimeval`.

### Motivation

Fix the described problem.

### Describe how to test your changes

The tests, and kitchen tests should continue to pass.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
