### PR TITLE
Remove orchestrator-explorer clusterID retrieval when feature is disabled

### DIFF
--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -128,8 +128,10 @@ func (l *Collector) runCheck(c checks.Check, results *api.WeightedQueue) {
 		extraHeaders.Set(headers.ProcessVersionHeader, Version)
 		extraHeaders.Set(headers.ContainerCountHeader, strconv.Itoa(getContainerCount(m)))
 
-		if cid, err := clustername.GetClusterID(); err == nil && cid != "" {
-			extraHeaders.Set(headers.ClusterIDHeader, cid)
+		if l.cfg.Orchestrator.OrchestrationCollectionEnabled {
+			if cid, err := clustername.GetClusterID(); err == nil && cid != "" {
+				extraHeaders.Set(headers.ClusterIDHeader, cid)
+			}
 		}
 
 		payloads = append(payloads, checkPayload{

--- a/cmd/process-agent/collector_api_test.go
+++ b/cmd/process-agent/collector_api_test.go
@@ -190,6 +190,9 @@ func TestRTProcMessageNotRetried(t *testing.T) {
 func TestSendPodMessage(t *testing.T) {
 	clusterID := "d801b2b1-4811-11ea-8618-121d4d0938a3"
 
+	cfg := config.NewDefaultAgentConfig(false)
+	cfg.Orchestrator.OrchestrationCollectionEnabled = true
+
 	orig := os.Getenv("DD_ORCHESTRATOR_CLUSTER_ID")
 	_ = os.Setenv("DD_ORCHESTRATOR_CLUSTER_ID", clusterID)
 	defer func() { _ = os.Setenv("DD_ORCHESTRATOR_CLUSTER_ID", orig) }()
@@ -204,7 +207,7 @@ func TestSendPodMessage(t *testing.T) {
 		data: [][]process.MessageBody{{m}},
 	}
 
-	runCollectorTest(t, check, config.NewDefaultAgentConfig(false), &endpointConfig{}, func(cfg *config.AgentConfig, ep *mockEndpoint) {
+	runCollectorTest(t, check, cfg, &endpointConfig{}, func(cfg *config.AgentConfig, ep *mockEndpoint) {
 		req := <-ep.Requests
 
 		assert.Equal(t, "/api/v1/orchestrator", req.uri)

--- a/releasenotes/notes/orchestrator-explorer-dca-call-bug-3175bbf12f757106.yaml
+++ b/releasenotes/notes/orchestrator-explorer-dca-call-bug-3175bbf12f757106.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Remove unplanned call between the process-agent and the the DCA when the
+    orchestratorExplorer feature is disabled.


### PR DESCRIPTION
### What does this PR do?

A code section was overlooked in the process-agent leading to unexpected cluster-agent calls in the collector in order to fetch the clusterID even though the feature is being explicitly disabled.

The following errors would be printed in the DCA logs:

```
2021-06-29 20:09:13 UTC | CLUSTER | ERROR | (pkg/util/kubernetes/apiserver/common/common.go:75 in GetOrCreateClusterID) | Cannot retrieve ConfigMap default/datadog-cluster-id: configmaps "datadog-cluster-id" is forbidden: User "system:serviceaccount:default:datadog-cluster-agent" cannot get resource "configmaps" in API group "" in the namespace "default"
2021-06-29 20:09:13 UTC | CLUSTER | ERROR | (api/v1/kubernetes_metadata.go:342 in getClusterID) | Failed to generate or retrieve the cluster ID: configmaps "datadog-cluster-id" is forbidden: User "system:serviceaccount:default:datadog-cluster-agent" cannot get resource "configmaps" in API group "" in the namespace "default"
2021-06-29 20:09:13 UTC | CLUSTER | ERROR | (pkg/util/kubernetes/apiserver/common/common.go:75 in GetOrCreateClusterID) | Cannot retrieve ConfigMap default/datadog-cluster-id: configmaps "datadog-cluster-id" is forbidden: User "system:serviceaccount:default:datadog-cluster-agent" cannot get resource "configmaps" in API group "" in the namespace "default"
2021-06-29 20:09:13 UTC | CLUSTER | ERROR | (api/v1/kubernetes_metadata.go:342 in getClusterID) | Failed to generate or retrieve the cluster ID: configmaps "datadog-cluster-id" is forbidden: User "system:serviceaccount:default:datadog-cluster-agent" cannot get resource "configmaps" in API group "" in the namespace "default"
2021-06-29 20:09:15 UTC | CLUSTER | ERROR | (pkg/util/kubernetes/apiserver/common/common.go:75 in GetOrCreateClusterID) | Cannot retrieve ConfigMap default/datadog-cluster-id: configmaps "datadog-cluster-id" is forbidden: User "system:serviceaccount:default:datadog-cluster-agent" cannot get resource "configmaps" in API group "" in the namespace "default"
2021-06-29 20:09:15 UTC | CLUSTER | ERROR | (api/v1/kubernetes_metadata.go:342 in getClusterID) | Failed to generate or retrieve the cluster ID: configmaps "datadog-cluster-id" is forbidden: User "system:serviceaccount:default:datadog-cluster-agent" cannot get resource "configmaps" in API group "" in the namespace "default"
2021-06-29 20:09:15 UTC | CLUSTER | ERROR | (pkg/util/kubernetes/apiserver/common/common.go:75 in GetOrCreateClusterID) | Cannot retrieve ConfigMap default/datadog-cluster-id: configmaps "datadog-cluster-id" is forbidden: User "system:serviceaccount:default:datadog-cluster-agent" cannot get resource "configmaps" in API group "" in the namespace "default"
2021-06-29 20:09:15 UTC | CLUSTER | ERROR | (api/v1/kubernetes_metadata.go:342 in getClusterID) | Failed to generate or retrieve the cluster ID: configmaps "datadog-cluster-id" is forbidden: User "system:serviceaccount:default:datadog-cluster-agent" cannot get resource "configmaps" in API group "" in the namespace "default"
2021-06-29 20:09:18 UTC | CLUSTER | ERROR | (pkg/util/kubernetes/apiserver/common/common.go:75 in GetOrCreateClusterID) | Cannot retrieve ConfigMap default/datadog-cluster-id: configmaps "datadog-cluster-id" is forbidden: User "system:serviceaccount:default:datadog-cluster-agent" cannot get resource "configmaps" in API group "" in the namespace "default"
2021-06-29 20:09:18 UTC | CLUSTER | ERROR | (api/v1/kubernetes_metadata.go:342 in getClusterID) | Failed to generate or retrieve the cluster ID: configmaps "datadog-cluster-id" is forbidden: User "system:serviceaccount:default:datadog-cluster-agent" cannot get resource "configmaps" in API group "" in the namespace "default"
2021-06-29 20:09:18 UTC | CLUSTER | ERROR | (pkg/util/kubernetes/apiserver/common/common.go:75 in GetOrCreateClusterID) | Cannot retrieve ConfigMap default/datadog-cluster-id: configmaps "datadog-cluster-id" is forbidden: User "system:serviceaccount:default:datadog-cluster-agent" cannot get resource "configmaps" in API group "" in the namespace "default"
2021-06-29 20:09:18 UTC | CLUSTER | ERROR | (api/v1/kubernetes_metadata.go:342 in getClusterID) | Failed to generate or retrieve the cluster ID: configmaps "datadog-cluster-id" is forbidden: User "system:serviceaccount:default:datadog-cluster-agent" cannot get resource "configmaps" in API group "" in the namespace "default"
```