### PR TITLE
[runtime-security] add policies version to metric and send regularly policies events

### DIFF
--- a/pkg/security/model/events.go
+++ b/pkg/security/model/events.go
@@ -78,6 +78,8 @@ const (
 	CustomForkBombEventType
 	// CustomTruncatedParentsEventType is the custom event used to report that the parents of a path were truncated
 	CustomTruncatedParentsEventType
+	// CustomActiveRulesetEventType is the custom event used to report the current active ruleset
+	CustomActiveRulesetEventType
 )
 
 func (t EventType) String() string {

--- a/pkg/security/module/event.go
+++ b/pkg/security/module/event.go
@@ -13,6 +13,7 @@ type AgentContext struct {
 	RuleID        string `json:"rule_id"`
 	PolicyName    string `json:"policy_name,omitempty"`
 	PolicyVersion string `json:"policy_version,omitempty"`
+	Version       string `json:"version,omitempty"`
 }
 
 // Signal - Rule event wrapper used to send an event to the backend

--- a/pkg/security/module/event.go
+++ b/pkg/security/module/event.go
@@ -11,7 +11,6 @@ package module
 // easyjson:json
 type AgentContext struct {
 	RuleID        string `json:"rule_id"`
-	RuleVersion   string `json:"rule_version,omitempty"`
 	PolicyName    string `json:"policy_name,omitempty"`
 	PolicyVersion string `json:"policy_version,omitempty"`
 }

--- a/pkg/security/module/event_easyjson.go
+++ b/pkg/security/module/event_easyjson.go
@@ -128,6 +128,8 @@ func easyjsonF642ad3eDecodeGithubComDataDogDatadogAgentPkgSecurityModule1(in *jl
 			out.PolicyName = string(in.String())
 		case "policy_version":
 			out.PolicyVersion = string(in.String())
+		case "version":
+			out.Version = string(in.String())
 		default:
 			in.SkipRecursive()
 		}
@@ -156,6 +158,11 @@ func easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgSecurityModule1(out *j
 		const prefix string = ",\"policy_version\":"
 		out.RawString(prefix)
 		out.String(string(in.PolicyVersion))
+	}
+	if in.Version != "" {
+		const prefix string = ",\"version\":"
+		out.RawString(prefix)
+		out.String(string(in.Version))
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/module/event_easyjson.go
+++ b/pkg/security/module/event_easyjson.go
@@ -124,8 +124,6 @@ func easyjsonF642ad3eDecodeGithubComDataDogDatadogAgentPkgSecurityModule1(in *jl
 		switch key {
 		case "rule_id":
 			out.RuleID = string(in.String())
-		case "rule_version":
-			out.RuleVersion = string(in.String())
 		case "policy_name":
 			out.PolicyName = string(in.String())
 		case "policy_version":
@@ -148,11 +146,6 @@ func easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgSecurityModule1(out *j
 		const prefix string = ",\"rule_id\":"
 		out.RawString(prefix[1:])
 		out.String(string(in.RuleID))
-	}
-	if in.RuleVersion != "" {
-		const prefix string = ",\"rule_version\":"
-		out.RawString(prefix)
-		out.String(string(in.RuleVersion))
 	}
 	if in.PolicyName != "" {
 		const prefix string = ",\"policy_name\":"

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -206,8 +206,7 @@ func (a *APIServer) GetConfig(ctx context.Context, params *api.GetConfigParams) 
 // SendEvent forwards events sent by the runtime security module to Datadog
 func (a *APIServer) SendEvent(rule *rules.Rule, event Event, extTagsCb func() []string) {
 	agentContext := &AgentContext{
-		RuleID:      rule.Definition.ID,
-		RuleVersion: rule.Definition.Version,
+		RuleID: rule.Definition.ID,
 	}
 
 	ruleEvent := &Signal{

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -26,6 +26,7 @@ import (
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 type pendingMsg struct {
@@ -206,7 +207,8 @@ func (a *APIServer) GetConfig(ctx context.Context, params *api.GetConfigParams) 
 // SendEvent forwards events sent by the runtime security module to Datadog
 func (a *APIServer) SendEvent(rule *rules.Rule, event Event, extTagsCb func() []string) {
 	agentContext := &AgentContext{
-		RuleID: rule.Definition.ID,
+		RuleID:  rule.Definition.ID,
+		Version: version.AgentVersion,
 	}
 
 	ruleEvent := &Signal{

--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -144,7 +144,6 @@ func NewEventLostWriteEvent(mapName string, perEventPerCPU map[string]uint64) (*
 // easyjson:json
 type RuleIgnored struct {
 	ID         string `json:"id"`
-	Version    string `json:"version,omitempty"`
 	Expression string `json:"expression"`
 	Reason     string `json:"reason"`
 }
@@ -186,8 +185,8 @@ func (r *PoliciesIgnored) UnmarshalJSON(data []byte) error {
 // RuleLoaded defines a loaded rule
 // easyjson:json
 type RuleLoaded struct {
-	ID         string `json:"id"`
-	Version    string `json:"version,omitempty"`
+	ID string `json:"id"`
+
 	Expression string `json:"expression"`
 }
 
@@ -225,7 +224,6 @@ func NewRuleSetEvent(rs *rules.RuleSet, err *multierror.Error) *RuleSetEvent {
 		}
 		policy.RulesLoaded = append(policy.RulesLoaded, &RuleLoaded{
 			ID:         rule.ID,
-			Version:    rule.Definition.Version,
 			Expression: rule.Definition.Expression,
 		})
 	}
@@ -242,7 +240,6 @@ func NewRuleSetEvent(rs *rules.RuleSet, err *multierror.Error) *RuleSetEvent {
 				}
 				policy.RulesIgnored = append(policy.RulesIgnored, &RuleIgnored{
 					ID:         rerr.Definition.ID,
-					Version:    rerr.Definition.Version,
 					Expression: rerr.Definition.Expression,
 					Reason:     rerr.Err.Error(),
 				})

--- a/pkg/security/probe/custom_events_easyjson.go
+++ b/pkg/security/probe/custom_events_easyjson.go
@@ -20,7 +20,7 @@ var (
 	_ easyjson.Marshaler
 )
 
-func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(in *jlexer.Lexer, out *RulesetLoadedEvent) {
+func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(in *jlexer.Lexer, out *RuleSetEvent) {
 	isTopLevel := in.IsStart()
 	if in.IsNull() {
 		if isTopLevel {
@@ -119,7 +119,7 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(in *jlex
 		in.Consumed()
 	}
 }
-func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(out *jwriter.Writer, in RulesetLoadedEvent) {
+func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(out *jwriter.Writer, in RuleSetEvent) {
 	out.RawByte('{')
 	first := true
 	_ = first
@@ -173,26 +173,26 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(out *jwr
 }
 
 // MarshalJSON supports json.Marshaler interface
-func (v RulesetLoadedEvent) MarshalJSON() ([]byte, error) {
+func (v RuleSetEvent) MarshalJSON() ([]byte, error) {
 	w := jwriter.Writer{}
 	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(&w, v)
 	return w.Buffer.BuildBytes(), w.Error
 }
 
 // MarshalEasyJSON supports easyjson.Marshaler interface
-func (v RulesetLoadedEvent) MarshalEasyJSON(w *jwriter.Writer) {
+func (v RuleSetEvent) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(w, v)
 }
 
 // UnmarshalJSON supports json.Unmarshaler interface
-func (v *RulesetLoadedEvent) UnmarshalJSON(data []byte) error {
+func (v *RuleSetEvent) UnmarshalJSON(data []byte) error {
 	r := jlexer.Lexer{Data: data}
 	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(&r, v)
 	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
-func (v *RulesetLoadedEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
+func (v *RuleSetEvent) UnmarshalEasyJSON(l *jlexer.Lexer) {
 	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(l, v)
 }
 func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(in *jlexer.Lexer, out *RuleLoaded) {

--- a/pkg/security/probe/custom_events_easyjson.go
+++ b/pkg/security/probe/custom_events_easyjson.go
@@ -216,8 +216,6 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(in *jle
 		switch key {
 		case "id":
 			out.ID = string(in.String())
-		case "version":
-			out.Version = string(in.String())
 		case "expression":
 			out.Expression = string(in.String())
 		default:
@@ -238,11 +236,6 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(out *jw
 		const prefix string = ",\"id\":"
 		out.RawString(prefix[1:])
 		out.String(string(in.ID))
-	}
-	if in.Version != "" {
-		const prefix string = ",\"version\":"
-		out.RawString(prefix)
-		out.String(string(in.Version))
 	}
 	{
 		const prefix string = ",\"expression\":"
@@ -296,8 +289,6 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(in *jle
 		switch key {
 		case "id":
 			out.ID = string(in.String())
-		case "version":
-			out.Version = string(in.String())
 		case "expression":
 			out.Expression = string(in.String())
 		case "reason":
@@ -320,11 +311,6 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(out *jw
 		const prefix string = ",\"id\":"
 		out.RawString(prefix[1:])
 		out.String(string(in.ID))
-	}
-	if in.Version != "" {
-		const prefix string = ",\"version\":"
-		out.RawString(prefix)
-		out.String(string(in.Version))
 	}
 	{
 		const prefix string = ",\"expression\":"

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -152,7 +152,7 @@ func (m *Monitor) ProcessLostEvent(count uint64, cpu int, perfMap *manager.PerfM
 func (m *Monitor) reportActiveRuleset(ctx context.Context, wg *sync.WaitGroup) {
 	defer wg.Done()
 
-	ticker := time.NewTicker(10 * time.Second)
+	ticker := time.NewTicker(5 * time.Minute)
 	defer ticker.Stop()
 
 	for {

--- a/pkg/security/rules/ruleset.go
+++ b/pkg/security/rules/ruleset.go
@@ -21,7 +21,6 @@ type MacroID = string
 // MacroDefinition holds the definition of a macro
 type MacroDefinition struct {
 	ID         MacroID `yaml:"id"`
-	Version    string  `yaml:"version"`
 	Expression string  `yaml:"expression"`
 }
 
@@ -37,7 +36,6 @@ type RuleID = string
 // RuleDefinition holds the definition of a rule
 type RuleDefinition struct {
 	ID          RuleID            `yaml:"id"`
-	Version     string            `yaml:"version"`
 	Expression  string            `yaml:"expression"`
 	Description string            `yaml:"description"`
 	Tags        map[string]string `yaml:"tags"`


### PR DESCRIPTION
### What does this PR do?

This PR add `policies_version` tag to the `running` metric and send regularly event reporting the current policies loaded.

It also add the agent version to the event logs.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
