### PR TITLE
Remove Agent Platform ownership of .github/*

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,7 +29,8 @@
 /setup.cfg                              @DataDog/agent-platform
 
 /.circleci/                             @DataDog/agent-platform
-/.github/                               @DataDog/agent-platform
+/.github/*                              @DataDog/do-not-notify
+/.github/dependabot.yaml                @DataDog/agent-platform
 
 # Gitlab files
 # Files containing job contents are owned by teams in charge of the jobs + agent-platform

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,7 +29,9 @@
 /setup.cfg                              @DataDog/agent-platform
 
 /.circleci/                             @DataDog/agent-platform
-/.github/*                              @DataDog/do-not-notify
+
+/.github/CODEOWNERS                     @DataDog/do-not-notify
+/.github/*_TEMPLATE.md                  @DataDog/agent-all
 /.github/dependabot.yaml                @DataDog/agent-platform
 
 # Gitlab files


### PR DESCRIPTION
### What does this PR do?

Sets ownership of files in `.github/*`:

- `dependabot.yaml`: Agent Platform
- Github issue/PR templates: all Agent teams
- `CODEOWNERS`: don't ping any specific team
