### PR TITLE
[CWS] run kitchen functional tests of security agent on arm64

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -9,7 +9,6 @@
   extends:
     - .kitchen_common
     - .kitchen_datadog_agent_flavor
-    - .kitchen_azure_location_north_central_us
   rules:
     !reference [.manual]
   stage: functional_test
@@ -22,9 +21,20 @@
 .kitchen_test_security_agent_x64:
   extends:
     - .kitchen_test_security_agent
+    - .kitchen_azure_location_north_central_us
   needs: ["tests_ebpf_x64"]
   variables:
     KITCHEN_ARCH: x86_64
+
+.kitchen_test_security_agent_arm64:
+  extends:
+    - .kitchen_test_security_agent
+    - .kitchen_ec2_location_us_east_1
+    - .kitchen_ec2_spot_instances
+  needs: [ "tests_ebpf_arm64" ]
+  variables:
+    KITCHEN_ARCH: arm64
+    KITCHEN_EC2_INSTANCE_TYPE: "t4g.large"
 
 .kitchen_stress_security_agent:
   extends:
@@ -56,6 +66,15 @@ kitchen_ubuntu_security_agent_x64:
     - rsync -azr --delete ./ $SRC_PATH
     - export KITCHEN_PLATFORM=ubuntu
     - export KITCHEN_OSVERS="ubuntu-18-04,ubuntu-20-04"
+    - cd $DD_AGENT_TESTING_DIR
+    - bash -l tasks/kitchen_setup.sh
+
+kitchen_ubuntu_security_agent_arm64:
+  extends: .kitchen_test_security_agent_arm64
+  before_script:
+    - rsync -azr --delete ./ $SRC_PATH
+    - export KITCHEN_PLATFORM=ubuntu
+    - export KITCHEN_OSVERS="ubuntu-20-04"
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -15,6 +15,8 @@
   variables:
     AGENT_MAJOR_VERSION: 7
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
+    # we need chef >= 15 for arm64
+    CHEF_VERSION: 15.16.4
   script:
     - bash -l tasks/run-test-kitchen.sh security-agent-test $AGENT_MAJOR_VERSION
 

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -13,12 +13,18 @@
   rules:
     !reference [.manual]
   stage: functional_test
-  needs: ["tests_ebpf_x64"]
   variables:
     AGENT_MAJOR_VERSION: 7
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
   script:
     - bash -l tasks/run-test-kitchen.sh security-agent-test $AGENT_MAJOR_VERSION
+
+.kitchen_test_security_agent_x64:
+  extends:
+    - .kitchen_test_security_agent
+  needs: ["tests_ebpf_x64"]
+  variables:
+    KITCHEN_ARCH: x86_64
 
 .kitchen_stress_security_agent:
   extends:
@@ -35,8 +41,8 @@
   script:
     - bash -l tasks/run-test-kitchen.sh security-agent-stress $AGENT_MAJOR_VERSION
 
-kitchen_centos_security_agent:
-  extends: .kitchen_test_security_agent
+kitchen_centos_security_agent_x64:
+  extends: .kitchen_test_security_agent_x64
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export KITCHEN_PLATFORM="centos"
@@ -44,8 +50,8 @@ kitchen_centos_security_agent:
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 
-kitchen_ubuntu_security_agent:
-  extends: .kitchen_test_security_agent
+kitchen_ubuntu_security_agent_x64:
+  extends: .kitchen_test_security_agent_x64
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export KITCHEN_PLATFORM=ubuntu
@@ -62,8 +68,8 @@ kitchen_ubuntu_security_agent_stress:
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 
-kitchen_suse_security_agent:
-  extends: .kitchen_test_security_agent
+kitchen_suse_security_agent_x64:
+  extends: .kitchen_test_security_agent_x64
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export KITCHEN_PLATFORM="suse"
@@ -71,8 +77,8 @@ kitchen_suse_security_agent:
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 
-kitchen_debian_security_agent:
-  extends: .kitchen_test_security_agent
+kitchen_debian_security_agent_x64:
+  extends: .kitchen_test_security_agent_x64
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export KITCHEN_PLATFORM="debian"
@@ -80,8 +86,8 @@ kitchen_debian_security_agent:
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 
-kitchen_oracle_security_agent:
-  extends: .kitchen_test_security_agent
+kitchen_oracle_security_agent_x64:
+  extends: .kitchen_test_security_agent_x64
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export KITCHEN_PLATFORM="oracle"

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -83,6 +83,6 @@ tests_ebpf_arm64:
     - git pull
     - inv -e deps
     - inv -e system-probe.build --bundle-ebpf --incremental-build
-    - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite-master
+    # - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite-master
     - git reset --hard
     - git checkout -

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -75,7 +75,7 @@ tests_ebpf_arm64:
   script:
     - !reference [.build_sysprobe_artifacts]
     # Compile runtime security functional tests to be executed in kitchen tests
-    - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite
+    - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --build-flags "-race"
     # Compile runtime security stress tests to be executed in kitchen tests
     - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
     # Compile main version for comparison, uncomment following lines when merged

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -74,3 +74,15 @@ tests_ebpf_arm64:
     - !reference [.retrieve_sysprobe_deps]
   script:
     - !reference [.build_sysprobe_artifacts]
+    # Compile runtime security functional tests to be executed in kitchen tests
+    - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite
+    # Compile runtime security stress tests to be executed in kitchen tests
+    - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
+    # Compile main version for comparison, uncomment following lines when merged
+    - git checkout -f main || git checkout -f master
+    - git pull
+    - inv -e deps
+    - inv -e system-probe.build --bundle-ebpf --incremental-build
+    - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite-master
+    - git reset --hard
+    - git checkout -

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "42e8a7cca9b8f3b4460f03f1954554edd661b0f96e8422687c5eb12090a02518")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "292dd2538d7a9b7b6459092b96d98d1b0541608b618e2bd1bb14cf43e8fff27f")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "cd31f1bd8a0741d69d61505ae1efc24cdafdd36430be8aa5946d3b764451dc95")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "9f6c3e991d7ea36d70592b21f2141eb6162a5066bd920bf6ac37d20e50ded530")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "292dd2538d7a9b7b6459092b96d98d1b0541608b618e2bd1bb14cf43e8fff27f")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "cd31f1bd8a0741d69d61505ae1efc24cdafdd36430be8aa5946d3b764451dc95")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "e1847a9dd7bd04fbf575ec140ab5fa6d8e5db9706ebe280f8c516c0d6a4ed49e")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "cda28c4a4a868b22058c4fe5a7f50de19345c8956fdf268b681ad8fa8b1ea403")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "9f6c3e991d7ea36d70592b21f2141eb6162a5066bd920bf6ac37d20e50ded530")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "565cea36a10b4c466b6f9ed74eba93d93700cb229c187266caa6fe8ca1e16031")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "565cea36a10b4c466b6f9ed74eba93d93700cb229c187266caa6fe8ca1e16031")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "a5cbe95af9fe2c5f5f8b06a6cb76eba2c02a4cd37c716fe42b0a9375bdabd646")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "cda28c4a4a868b22058c4fe5a7f50de19345c8956fdf268b681ad8fa8b1ea403")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "42e8a7cca9b8f3b4460f03f1954554edd661b0f96e8422687c5eb12090a02518")

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -12,6 +12,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	aconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
@@ -140,6 +141,10 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 
 	if !c.EnableApprovers && !c.EnableDiscarders {
 		c.EnableKernelFilters = false
+	}
+
+	if probes.GetRuntimeArch() == "arm64" {
+		c.ERPCDentryResolutionEnabled = false
 	}
 
 	if c.ERPCDentryResolutionEnabled == false && c.MapDentryResolutionEnabled == false {

--- a/pkg/security/ebpf/c/erpc.h
+++ b/pkg/security/ebpf/c/erpc.h
@@ -56,7 +56,7 @@ int __attribute__((always_inline)) handle_discard_pid(void *data) {
     return discard_pid(discarder.req.event_type, discarder.pid, discarder.req.timeout);
 }
 
-int __attribute__((always_inline)) is_eprc_request(struct pt_regs *ctx) {
+int __attribute__((always_inline)) is_erpc_request(struct pt_regs *ctx) {
     u64 fd, pid;
 
     LOAD_CONSTANT("erpc_fd", fd);

--- a/pkg/security/ebpf/c/erpc.h
+++ b/pkg/security/ebpf/c/erpc.h
@@ -86,11 +86,11 @@ int __attribute__((always_inline)) handle_erpc_request(struct pt_regs *ctx) {
     void *req = (void *)PT_REGS_PARM4(ctx);
 
     u8 op;
-    bpf_probe_read(&op, sizeof(op), req);
+    int read_res = bpf_probe_read(&op, sizeof(op), req);
 
     void *data = req + sizeof(op);
 
-    bpf_printk("ERPC request: op = %d\n", op);
+    bpf_printk("ERPC request: op = %d, addr = %lx, read_res = %d\n", op, (long long)req, read_res);
 
     if (!is_flushing_discarders()) {
         switch (op) {

--- a/pkg/security/ebpf/c/erpc.h
+++ b/pkg/security/ebpf/c/erpc.h
@@ -90,6 +90,8 @@ int __attribute__((always_inline)) handle_erpc_request(struct pt_regs *ctx) {
 
     void *data = req + sizeof(op);
 
+    bpf_printk("ERPC request: op = %d\n", op);
+
     if (!is_flushing_discarders()) {
         switch (op) {
             case DISCARD_INODE_OP:

--- a/pkg/security/ebpf/c/erpc.h
+++ b/pkg/security/ebpf/c/erpc.h
@@ -46,6 +46,8 @@ int __attribute__((always_inline)) handle_discard_inode(void *data) {
     struct discard_inode_t discarder;
     bpf_probe_read(&discarder, sizeof(discarder), data);
 
+    bpf_printk("req disc ino: et = %llx, mi = %x, ino = %llx", discarder.req.event_type, discarder.mount_id, discarder.inode);
+    bpf_printk("tmout = %llx, isleaf = %x\n", discarder.req.timeout, discarder.is_leaf);
     return discard_inode(discarder.req.event_type, discarder.mount_id, discarder.inode, discarder.req.timeout, discarder.is_leaf);
 }
 
@@ -83,8 +85,6 @@ int __attribute__((always_inline)) is_erpc_request(u64 vfs_fd, u32 cmd, u8 *op) 
 }
 
 int __attribute__((always_inline)) handle_erpc_request(struct pt_regs *ctx, u8 op, void *data) {
-    bpf_printk("ERPC request: op = %d, addr = %lx\n", op, (long long)data);
-
     if (!is_flushing_discarders()) {
         switch (op) {
             case DISCARD_INODE_OP:
@@ -105,8 +105,6 @@ int __attribute__((always_inline)) handle_erpc_request(struct pt_regs *ctx, u8 o
 }
 
 int __attribute__((always_inline)) handle_erpc_request_arch_non_overlapping(struct pt_regs *ctx, u8 op, void *data) {
-    bpf_printk("ERPC request ANO: op = %d\n", op);
-
     if (!is_flushing_discarders()) {
         switch (op) {
             case DISCARD_INODE_OP:

--- a/pkg/security/ebpf/c/erpc.h
+++ b/pkg/security/ebpf/c/erpc.h
@@ -56,14 +56,13 @@ int __attribute__((always_inline)) handle_discard_pid(void *data) {
     return discard_pid(discarder.req.event_type, discarder.pid, discarder.req.timeout);
 }
 
-int __attribute__((always_inline)) is_erpc_request(struct pt_regs *ctx) {
+int __attribute__((always_inline)) is_erpc_request(u64 vfs_fd, u32 cmd) {
     u64 fd, pid;
 
     LOAD_CONSTANT("erpc_fd", fd);
     LOAD_CONSTANT("runtime_pid", pid);
 
-    u32 vfs_fd = PT_REGS_PARM2(ctx);
-    if (!vfs_fd || (u64)vfs_fd != fd) {
+    if (!vfs_fd || vfs_fd != fd) {
         return 0;
     }
 
@@ -74,7 +73,6 @@ int __attribute__((always_inline)) is_erpc_request(struct pt_regs *ctx) {
         return 0;
     }
 
-    u32 cmd = PT_REGS_PARM3(ctx);
     if (cmd != RPC_CMD) {
         return 0;
     }
@@ -82,9 +80,7 @@ int __attribute__((always_inline)) is_erpc_request(struct pt_regs *ctx) {
     return 1;
 }
 
-int __attribute__((always_inline)) handle_erpc_request(struct pt_regs *ctx) {
-    void *req = (void *)PT_REGS_PARM4(ctx);
-
+int __attribute__((always_inline)) handle_erpc_request(struct pt_regs *ctx, void *req) {
     u8 op;
     int read_res = bpf_probe_read(&op, sizeof(op), req);
 

--- a/pkg/security/ebpf/c/erpc.h
+++ b/pkg/security/ebpf/c/erpc.h
@@ -46,8 +46,6 @@ int __attribute__((always_inline)) handle_discard_inode(void *data) {
     struct discard_inode_t discarder;
     bpf_probe_read(&discarder, sizeof(discarder), data);
 
-    bpf_printk("req disc ino: et = %llx, mi = %x, ino = %llx", discarder.req.event_type, discarder.mount_id, discarder.inode);
-    bpf_printk("tmout = %llx, isleaf = %x\n", discarder.req.timeout, discarder.is_leaf);
     return discard_inode(discarder.req.event_type, discarder.mount_id, discarder.inode, discarder.req.timeout, discarder.is_leaf);
 }
 

--- a/pkg/security/ebpf/c/ioctl.h
+++ b/pkg/security/ebpf/c/ioctl.h
@@ -5,7 +5,7 @@
 
 SEC("kprobe/do_vfs_ioctl")
 int kprobe__do_vfs_ioctl(struct pt_regs *ctx) {
-    if (is_eprc_request(ctx)) {
+    if (is_erpc_request(ctx)) {
         return handle_erpc_request(ctx);
     }
 

--- a/pkg/security/ebpf/c/ioctl.h
+++ b/pkg/security/ebpf/c/ioctl.h
@@ -6,49 +6,54 @@
 // the default SYSCALL_KPROBE macros don't allow to probe a syscall with more than 4 parameters
 // this hack is a "solution" to this problem
 
-#define IOCTL_ABI_HOOKx(x,word_size,type,TYPE,prefix,syscall,suffix,body,...) \
-    int __attribute__((always_inline)) type##__##sys##syscall(struct pt_regs *ctx __JOIN(x,__SC_DECL,__VA_ARGS__)); \
-    SEC(#type "/" SYSCALL##word_size##_PREFIX #prefix SYSCALL_PREFIX #syscall #suffix) \
-    int type##__ ##word_size##_##prefix ##sys##syscall##suffix(struct pt_regs *ctx) { \
-        SYSCALL_##TYPE##_PROLOG(x,__SC_##word_size##_PARAM,syscall,__VA_ARGS__) \
-        body \
+#define IOCTL_ABI_HOOKx(x, word_size, type, TYPE, prefix, syscall, suffix, body, ...)                                 \
+    int __attribute__((always_inline)) type##__##sys##syscall(struct pt_regs *ctx __JOIN(x, __SC_DECL, __VA_ARGS__)); \
+    SEC(#type "/" SYSCALL##word_size##_PREFIX #prefix SYSCALL_PREFIX #syscall #suffix)                                \
+    int type##__##word_size##_##prefix##sys##syscall##suffix(struct pt_regs *ctx) {                                   \
+        SYSCALL_##TYPE##_PROLOG(x, __SC_##word_size##_PARAM, syscall, __VA_ARGS__)                                    \
+            body                                                                                                      \
     }
 
 #if USE_SYSCALL_WRAPPER == 1
-  #define IOCTL_HOOKx(x,type,TYPE,prefix,name,body,...) \
-    IOCTL_ABI_HOOKx(x,32,type,TYPE,prefix,name,,body,__VA_ARGS__) \
-    IOCTL_ABI_HOOKx(x,64,type,TYPE,,name,,body,__VA_ARGS__)
+#define IOCTL_HOOKx(x, type, TYPE, prefix, name, body, ...)               \
+    IOCTL_ABI_HOOKx(x, 32, type, TYPE, prefix, name, , body, __VA_ARGS__) \
+        IOCTL_ABI_HOOKx(x, 64, type, TYPE, , name, , body, __VA_ARGS__)
 #else
-  #define IOCTL_HOOKx(x,type,TYPE,prefix,name,body,...) \
-    IOCTL_ABI_HOOKx(x,64,type,TYPE,compat_,name,,body,__VA_ARGS__) \
-    IOCTL_ABI_HOOKx(x,64,type,TYPE,,name,,body,__VA_ARGS__)
+#define IOCTL_HOOKx(x, type, TYPE, prefix, name, body, ...)                \
+    IOCTL_ABI_HOOKx(x, 64, type, TYPE, compat_, name, , body, __VA_ARGS__) \
+        IOCTL_ABI_HOOKx(x, 64, type, TYPE, , name, , body, __VA_ARGS__)
 #endif
 
-#define IOCTL_KPROBE6(name, body, ...) IOCTL_HOOKx(6,kprobe,KPROBE,,_##name,body,__VA_ARGS__)
-
-
-IOCTL_KPROBE6(ioctl, {
-    u8 op = UNKNOWN_OP;
-    if (is_erpc_request(fd, cmd, &op)) {
-        bpf_printk("a4 = %llx, a5 = %llx, a6 = %llx\n", a4, a5, a6);
+#define IOCTL_KPROBE6(name, body, ...) IOCTL_HOOKx(6, kprobe, KPROBE, , _##name, body, __VA_ARGS__)
 
 #if defined(__x86_64__)
+SYSCALL_KPROBE3(ioctl, int, fd, unsigned int, cmd, unsigned long, arg) {
+    u8 op = UNKNOWN_OP;
+    if (is_erpc_request(fd, cmd, &op)) {
         return handle_erpc_request(ctx, op, (void *)arg);
-#elif defined(__aarch64__)
-        u64 data[4];
-        data[0] = (u64)arg;
-        data[1] = a4;
-        data[2] = a5;
-        data[3] = a6;
-        return handle_erpc_request_arch_non_overlapping(ctx, op, (void *)data);
-#else
-  #error "Unsupported platform"
-#endif
     }
 
     return 0;
-}, int, fd, unsigned int, cmd, unsigned long, arg, u64, a4, u64, a5, u64, a6)
+}
 
+#elif defined(__aarch64__)
+IOCTL_KPROBE6(
+    ioctl, {
+        u8 op = UNKNOWN_OP;
+        if (is_erpc_request(fd, cmd, &op)) {
+            u64 data[4];
+            data[0] = (u64)arg;
+            data[1] = a4;
+            data[2] = a5;
+            data[3] = a6;
+            return handle_erpc_request_arch_non_overlapping(ctx, op, (void *)data);
+        }
+
+        return 0;
+    },
+    int, fd, unsigned int, cmd, unsigned long, arg, u64, a4, u64, a5, u64, a6)
+#else
+#error "Unsupported platform"
 #endif
 
-
+#endif

--- a/pkg/security/ebpf/c/ioctl.h
+++ b/pkg/security/ebpf/c/ioctl.h
@@ -3,10 +3,9 @@
 
 #include "erpc.h"
 
-SEC("kprobe/do_vfs_ioctl")
-int kprobe__do_vfs_ioctl(struct pt_regs *ctx) {
-    if (is_erpc_request(ctx)) {
-        return handle_erpc_request(ctx);
+SYSCALL_KPROBE3(ioctl, int, fd, unsigned int, cmd, unsigned long, arg) {
+    if (is_erpc_request(fd, cmd)) {
+        return handle_erpc_request(ctx, (void *)arg);
     }
 
     return 0;

--- a/pkg/security/ebpf/c/ioctl.h
+++ b/pkg/security/ebpf/c/ioctl.h
@@ -3,12 +3,52 @@
 
 #include "erpc.h"
 
-SYSCALL_KPROBE3(ioctl, int, fd, unsigned int, cmd, unsigned long, arg) {
-    if (is_erpc_request(fd, cmd)) {
-        return handle_erpc_request(ctx, (void *)arg);
+// the default SYSCALL_KPROBE macros don't allow to probe a syscall with more than 4 parameters
+// this hack is a "solution" to this problem
+
+#define IOCTL_ABI_HOOKx(x,word_size,type,TYPE,prefix,syscall,suffix,body,...) \
+    int __attribute__((always_inline)) type##__##sys##syscall(struct pt_regs *ctx __JOIN(x,__SC_DECL,__VA_ARGS__)); \
+    SEC(#type "/" SYSCALL##word_size##_PREFIX #prefix SYSCALL_PREFIX #syscall #suffix) \
+    int type##__ ##word_size##_##prefix ##sys##syscall##suffix(struct pt_regs *ctx) { \
+        SYSCALL_##TYPE##_PROLOG(x,__SC_##word_size##_PARAM,syscall,__VA_ARGS__) \
+        body \
+    }
+
+#if USE_SYSCALL_WRAPPER == 1
+  #define IOCTL_HOOKx(x,type,TYPE,prefix,name,body,...) \
+    IOCTL_ABI_HOOKx(x,32,type,TYPE,prefix,name,,body,__VA_ARGS__) \
+    IOCTL_ABI_HOOKx(x,64,type,TYPE,,name,,body,__VA_ARGS__)
+#else
+  #define IOCTL_HOOKx(x,type,TYPE,prefix,name,body,...) \
+    IOCTL_ABI_HOOKx(x,64,type,TYPE,compat_,name,,body,__VA_ARGS__) \
+    IOCTL_ABI_HOOKx(x,64,type,TYPE,,name,,body,__VA_ARGS__)
+#endif
+
+#define IOCTL_KPROBE6(name, body, ...) IOCTL_HOOKx(6,kprobe,KPROBE,,_##name,body,__VA_ARGS__)
+
+
+IOCTL_KPROBE6(ioctl, {
+    u8 op = UNKNOWN_OP;
+    if (is_erpc_request(fd, cmd, &op)) {
+        bpf_printk("a4 = %llx, a5 = %llx, a6 = %llx\n", a4, a5, a6);
+
+#if defined(__x86_64__)
+        return handle_erpc_request(ctx, op, (void *)arg);
+#elif defined(__aarch64__)
+        u64 data[4];
+        data[0] = (u64)arg;
+        data[1] = a4;
+        data[2] = a5;
+        data[3] = a6;
+        return handle_erpc_request_arch_non_overlapping(ctx, op, (void *)data);
+#else
+  #error "Unsupported platform"
+#endif
     }
 
     return 0;
-}
+}, int, fd, unsigned int, cmd, unsigned long, arg, u64, a4, u64, a5, u64, a6)
 
 #endif
+
+

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -205,9 +205,9 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 		},
 
 		// ioctl probes
-		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/do_vfs_ioctl"}},
-		}},
+		&manager.AllOf{Selectors: ExpandSyscallProbesSelector(
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "ioctl"}, Entry),
+		},
 
 		// snapshot
 		&manager.AllOf{Selectors: []manager.ProbesSelector{

--- a/pkg/security/ebpf/probes/ioctl.go
+++ b/pkg/security/ebpf/probes/ioctl.go
@@ -9,14 +9,9 @@ package probes
 
 import "github.com/DataDog/ebpf/manager"
 
-// ioctlProbes holds the list of probes used to track ioctl events
-var ioctlProbes = []*manager.Probe{
-	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/do_vfs_ioctl",
-	},
-}
-
 func getIoctlProbes() []*manager.Probe {
-	return ioctlProbes
+	return ExpandSyscallProbes(&manager.Probe{
+		UID:             SecurityAgentUID,
+		SyscallFuncName: "ioctl",
+	}, Entry)
 }

--- a/pkg/security/ebpf/probes/syscall_helpers.go
+++ b/pkg/security/ebpf/probes/syscall_helpers.go
@@ -38,6 +38,15 @@ func resolveRuntimeArch() {
 	}
 }
 
+// GetRuntimeArch returns the current runtime arch (one of `x64`, `arm64` or `ia32`)
+func GetRuntimeArch() string {
+	if len(runtimeArch) == 0 {
+		resolveRuntimeArch()
+	}
+
+	return runtimeArch
+}
+
 // currentKernelVersion is the current kernel version
 var currentKernelVersion *kernel.Version
 

--- a/pkg/security/probe/erpc.go
+++ b/pkg/security/probe/erpc.go
@@ -54,7 +54,7 @@ func (k *ERPC) Request(req *ERPCRequest) error {
 	var errno syscall.Errno
 	if runtimeArch == "arm64" {
 		if req.OP != DiscardInodeOp && req.OP != DiscardPidOp {
-			return fmt.Errorf("eRPC op (%v) is not supported", req.OP)
+			return fmt.Errorf("eRPC op (%v) is not supported on this platform", req.OP)
 		}
 
 		var args [4]uintptr

--- a/pkg/security/probe/erpc.go
+++ b/pkg/security/probe/erpc.go
@@ -8,6 +8,7 @@
 package probe
 
 import (
+	"runtime"
 	"syscall"
 	"unsafe"
 
@@ -44,10 +45,11 @@ func (k *ERPC) GetConstants() []manager.ConstantEditor {
 
 // Request generates an ioctl syscall with the required request
 func (k *ERPC) Request(req *ERPCRequest) error {
-	if _, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(k.fd), rpcCmd, uintptr(unsafe.Pointer(req))); errno != 0 {
-		if errno != syscall.ENOTTY {
-			return errno
-		}
+	_, _, errno := syscall.Syscall(syscall.SYS_IOCTL, uintptr(k.fd), rpcCmd, uintptr(unsafe.Pointer(req)))
+	runtime.KeepAlive(req)
+
+	if errno != 0 && errno != syscall.ENOTTY {
+		return errno
 	}
 
 	return nil

--- a/pkg/security/tests/chown32_test.go
+++ b/pkg/security/tests/chown32_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// +build functionaltests,!386
+// +build functionaltests,amd64
 
 package tests
 

--- a/pkg/security/tests/chown_test.go
+++ b/pkg/security/tests/chown_test.go
@@ -115,7 +115,7 @@ func TestChown(t *testing.T) {
 		}
 	})
 
-	t.Run("lchown", func(t *testing.T) {
+	t.Run("lchown", ifSyscallSupported("SYS_LCHOWN", func(t *testing.T, syscallNB uintptr) {
 		testSymlink, testSymlinkPtr, err := test.Path("test-symlink")
 		if err != nil {
 			t.Fatal(err)
@@ -128,7 +128,7 @@ func TestChown(t *testing.T) {
 		defer os.Remove(testSymlink)
 
 		err = test.GetSignal(t, func() error {
-			if _, _, errno := syscall.Syscall(syscall.SYS_LCHOWN, uintptr(testSymlinkPtr), uintptr(102), uintptr(202)); errno != 0 {
+			if _, _, errno := syscall.Syscall(syscallNB, uintptr(testSymlinkPtr), uintptr(102), uintptr(202)); errno != 0 {
 				if errno == unix.ENOSYS {
 					t.Skip("lchown is not supported")
 				}
@@ -155,7 +155,7 @@ func TestChown(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-	})
+	}))
 
 	t.Run("chown", ifSyscallSupported("SYS_CHOWN", func(t *testing.T, syscallNB uintptr) {
 		defer func() {

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -61,12 +61,6 @@ func TestOpenBasenameApproverFilterERPCDentryResolution(t *testing.T) {
 	}
 	defer test.Close()
 
-	tracePipe, err := test.startTracing()
-	if err != nil {
-		t.Error(err)
-	}
-	defer tracePipe.Close()
-
 	var fd1, fd2 int
 	var testFile1, testFile2 string
 

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -61,6 +61,12 @@ func TestOpenBasenameApproverFilterERPCDentryResolution(t *testing.T) {
 	}
 	defer test.Close()
 
+	tracePipe, err := test.startTracing()
+	if err != nil {
+		t.Error(err)
+	}
+	defer tracePipe.Close()
+
 	var fd1, fd2 int
 	var testFile1, testFile2 string
 

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -45,6 +45,8 @@ func openTestFile(test *testModule, testFile string, flags int) (int, error) {
 }
 
 func TestOpenBasenameApproverFilterERPCDentryResolution(t *testing.T) {
+	SkipIfERPCDentryIsNotSupportedT(t)
+
 	// generate a basename up to the current limit of the agent
 	var basename string
 	for i := 0; i < model.MaxSegmentLength; i++ {

--- a/pkg/security/tests/probe_monitor_test.go
+++ b/pkg/security/tests/probe_monitor_test.go
@@ -122,6 +122,7 @@ func TestTruncatedParentsMap(t *testing.T) {
 }
 
 func TestTruncatedParentsERPC(t *testing.T) {
+	SkipIfERPCDentryIsNotSupportedT(t)
 	truncatedParents(t, testOpts{disableMapDentryResolution: true})
 }
 

--- a/pkg/security/tests/setup_test.go
+++ b/pkg/security/tests/setup_test.go
@@ -36,6 +36,7 @@ import (
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/security/model"
 	"github.com/DataDog/datadog-agent/pkg/security/module"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
@@ -982,6 +983,20 @@ func waitForOpenProbeEvent(test *testModule, action func() error, filename strin
 func TestEnv(t *testing.T) {
 	if testEnvironment != "" && testEnvironment != HostEnvironment && testEnvironment != DockerEnvironment {
 		t.Fatal("invalid environment")
+	}
+}
+
+func SkipIfERPCDentryIsNotSupportedT(t *testing.T) {
+	t.Helper()
+	if probes.GetRuntimeArch() == "arm64" {
+		t.Skip("ERPC DEntry Resolution is not supported on this platform (arm64)")
+	}
+}
+
+func SkipIfERPCDentryIsNotSupportedB(b *testing.B) {
+	b.Helper()
+	if probes.GetRuntimeArch() == "arm64" {
+		b.Skip("ERPC DEntry Resolution is not supported on this platform (arm64)")
 	}
 }
 

--- a/pkg/security/tests/setup_test.go
+++ b/pkg/security/tests/setup_test.go
@@ -258,7 +258,7 @@ func assertMode(t *testing.T, actualMode, expectedMode uint32, msgAndArgs ...int
 	if len(msgAndArgs) == 0 {
 		msgAndArgs = append(msgAndArgs, "wrong mode")
 	}
-	assert.Equal(t, strconv.FormatUint(uint64(actualMode), 8), strconv.FormatUint(uint64(expectedMode), 8), msgAndArgs...)
+	assert.Equal(t, strconv.FormatUint(uint64(expectedMode), 8), strconv.FormatUint(uint64(actualMode), 8), msgAndArgs...)
 }
 
 func assertRights(t *testing.T, actualMode, expectedMode uint16, msgAndArgs ...interface{}) {
@@ -276,12 +276,12 @@ func assertNearTime(t *testing.T, event time.Time) {
 
 func assertTriggeredRule(t *testing.T, r *rules.Rule, id string) {
 	t.Helper()
-	assert.Equal(t, r.ID, id, "wrong triggered rule")
+	assert.Equal(t, id, r.ID, "wrong triggered rule")
 }
 
 func assertReturnValue(t *testing.T, retval, expected int64) {
 	t.Helper()
-	assert.Equal(t, retval, expected, "wrong return value")
+	assert.Equal(t, expected, retval, "wrong return value")
 }
 
 func assertFieldEqual(t *testing.T, e *sprobe.Event, field string, value interface{}, msgAndArgs ...interface{}) {
@@ -290,7 +290,7 @@ func assertFieldEqual(t *testing.T, e *sprobe.Event, field string, value interfa
 	if err != nil {
 		t.Errorf("failed to get field '%s': %s", field, err)
 	} else {
-		assert.Equal(t, fieldValue, value, msgAndArgs...)
+		assert.Equal(t, value, fieldValue, msgAndArgs...)
 	}
 }
 

--- a/pkg/security/tests/stress_test.go
+++ b/pkg/security/tests/stress_test.go
@@ -302,7 +302,7 @@ func BenchmarkERPCDentryResolutionSegment(b *testing.B) {
 	}
 	defer test.Close()
 
-	testFile, testFilePtr, err := test.Path("aa/bb/cc/dd/ee")
+	testFile, _, err := test.Path("aa/bb/cc/dd/ee")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -316,9 +316,9 @@ func BenchmarkERPCDentryResolutionSegment(b *testing.B) {
 		pathID  uint32
 	)
 	err = test.GetSignal(b, func() error {
-		fd, _, errno := syscall.Syscall(syscall.SYS_OPEN, uintptr(testFilePtr), syscall.O_CREAT, 0755)
-		if errno != 0 {
-			b.Fatal(error(errno))
+		fd, err := syscall.Open(testFile, syscall.O_CREAT, 0755)
+		if err != nil {
+			b.Fatal(err)
 		}
 		return syscall.Close(int(fd))
 	}, func(event *sprobe.Event, _ *rules.Rule) {
@@ -371,7 +371,7 @@ func BenchmarkERPCDentryResolutionPath(b *testing.B) {
 	}
 	defer test.Close()
 
-	testFile, testFilePtr, err := test.Path("aa/bb/cc/dd/ee")
+	testFile, _, err := test.Path("aa/bb/cc/dd/ee")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -385,9 +385,9 @@ func BenchmarkERPCDentryResolutionPath(b *testing.B) {
 		pathID  uint32
 	)
 	err = test.GetSignal(b, func() error {
-		fd, _, errno := syscall.Syscall(syscall.SYS_OPEN, uintptr(testFilePtr), syscall.O_CREAT, 0755)
-		if errno != 0 {
-			b.Fatal(error(errno))
+		fd, err := syscall.Open(testFile, syscall.O_CREAT, 0755)
+		if err != nil {
+			b.Fatal(err)
 		}
 		return syscall.Close(int(fd))
 	}, func(event *sprobe.Event, _ *rules.Rule) {
@@ -437,7 +437,7 @@ func BenchmarkMapDentryResolutionSegment(b *testing.B) {
 	}
 	defer test.Close()
 
-	testFile, testFilePtr, err := test.Path("aa/bb/cc/dd/ee")
+	testFile, _, err := test.Path("aa/bb/cc/dd/ee")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -451,9 +451,9 @@ func BenchmarkMapDentryResolutionSegment(b *testing.B) {
 		pathID  uint32
 	)
 	err = test.GetSignal(b, func() error {
-		fd, _, errno := syscall.Syscall(syscall.SYS_OPEN, uintptr(testFilePtr), syscall.O_CREAT, 0755)
-		if errno != 0 {
-			b.Fatal(error(errno))
+		fd, err := syscall.Open(testFile, syscall.O_CREAT, 0755)
+		if err != nil {
+			b.Fatal(err)
 		}
 		return syscall.Close(int(fd))
 	}, func(event *sprobe.Event, _ *rules.Rule) {
@@ -503,7 +503,7 @@ func BenchmarkMapDentryResolutionPath(b *testing.B) {
 	}
 	defer test.Close()
 
-	testFile, testFilePtr, err := test.Path("aa/bb/cc/dd/ee")
+	testFile, _, err := test.Path("aa/bb/cc/dd/ee")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -517,9 +517,9 @@ func BenchmarkMapDentryResolutionPath(b *testing.B) {
 		pathID  uint32
 	)
 	err = test.GetSignal(b, func() error {
-		fd, _, errno := syscall.Syscall(syscall.SYS_OPEN, uintptr(testFilePtr), syscall.O_CREAT, 0755)
-		if errno != 0 {
-			b.Fatal(error(errno))
+		fd, err := syscall.Open(testFile, syscall.O_CREAT, 0755)
+		if err != nil {
+			b.Fatal(err)
 		}
 		return syscall.Close(int(fd))
 	}, func(event *sprobe.Event, _ *rules.Rule) {

--- a/pkg/security/tests/stress_test.go
+++ b/pkg/security/tests/stress_test.go
@@ -291,6 +291,7 @@ func TestStress_E2EExecEvent(t *testing.T) {
 }
 
 func BenchmarkERPCDentryResolutionSegment(b *testing.B) {
+	SkipIfERPCDentryIsNotSupportedB(b)
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
 		Expression: `open.file.path == "{{.Root}}/aa/bb/cc/dd/ee" && open.flags & O_CREAT != 0`,

--- a/pkg/security/tests/syscalls_amd64_test.go
+++ b/pkg/security/tests/syscalls_amd64_test.go
@@ -7,6 +7,7 @@ import "syscall"
 var supportedSyscalls = map[string]uintptr{
 	"SYS_CHMOD":  syscall.SYS_CHMOD,
 	"SYS_CHOWN":  syscall.SYS_CHOWN,
+	"SYS_LCHOWN": syscall.SYS_LCHOWN,
 	"SYS_LINK":   syscall.SYS_LINK,
 	"SYS_MKDIR":  syscall.SYS_MKDIR,
 	"SYS_OPEN":   syscall.SYS_OPEN,

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -211,19 +211,8 @@ def build_functional_tests(
     env.update(goenv)
 
     env["CGO_ENABLED"] = "1"
-    arch_mapping = {
-        "x86": "386",
-        "x64": "amd64",
-        "arm64": "arm64",
-    }
-    if arch in arch_mapping:
-        env["GOARCH"] = arch_mapping[arch]
-        if arch == "arm64":
-            env["CC"] = "aarch64-linux-gnu-gcc"
-    else:
-        print("Error: unknown arch")
-        return Exit(code=1)
-
+    if arch == "x86":
+        env["GOARCH"] = "386"
 
     build_tags = "linux_bpf," + build_tags
     if bundle_ebpf:

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -211,8 +211,19 @@ def build_functional_tests(
     env.update(goenv)
 
     env["CGO_ENABLED"] = "1"
-    if arch == "x86":
-        env["GOARCH"] = "386"
+    arch_mapping = {
+        "x86": "386",
+        "x64": "amd64",
+        "arm64": "arm64",
+    }
+    if arch in arch_mapping:
+        env["GOARCH"] = arch_mapping[arch]
+        if arch == "arm64":
+            env["CC"] = "aarch64-linux-gnu-gcc"
+    else:
+        print("Error: unknown arch")
+        return Exit(code=1)
+
 
     build_tags = "linux_bpf," + build_tags
     if bundle_ebpf:

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -93,7 +93,7 @@ if node['platform_family'] != 'windows'
     end
   end
 
-  if not platform_family?('suse')
+  if not platform_family?('suse') and intel? and _64_bit?
     package 'Install i386 libc' do
       case node[:platform]
       when 'redhat', 'centos', 'fedora', 'oracle'

--- a/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
@@ -5,7 +5,7 @@ print `uname -a`
 
 describe 'successfully run functional test' do
   it 'displays PASS and returns 0' do
-    output = `sudo /tmp/security-agent/testsuite -test.v 1>&2`
+    output = `sudo /tmp/security-agent/testsuite -loglevel debug -test.v 1>&2`
     retval = $?
     expect(retval).to eq(0)
   end


### PR DESCRIPTION
### What does this PR do?

This PR adds some jobs, executing on arm64, running the functional testsuite in order to test more regularly the arm64 arch support.
This PR also includes the fixes needed to compile and run the testsuite on amd64:
- syscall support

### Motivation

The arm64 architecture is an important architecture to support and will only be more important in the future.

### Describe how to test your changes

Please run the testsuite on arm64 to confirm that the security agent tests are passing.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
