### PR TITLE
[DCA] Implement apiserver/scheduler/controller-manager liveness checks

### DIFF
--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -202,8 +202,7 @@ func (k *KubeASCheck) Run() error {
 	}
 
 	// Running the Control Plane status check.
-	useComponentStatus := config.Datadog.GetBool("kube_controlplane_")
-	if useComponentStatus {
+	if k.instance.UseComponentStatus {
 		err = k.componentStatusCheck(sender)
 		if err != nil {
 			k.Warnf("Could not collect control plane status from ComponentStatus: %s", err.Error()) //nolint:errcheck
@@ -401,12 +400,13 @@ func sendControlPlaneServiceCheck(sender aggregator.Sender, component string, re
 	if ready {
 		msg = "ok"
 		status = metrics.ServiceCheckOK
-	} else if err != nil {
-		msg = err.Error()
-		status = metrics.ServiceCheckCritical
 	} else {
-		msg = "unknown error"
 		status = metrics.ServiceCheckCritical
+		if err != nil {
+			msg = err.Error()
+		} else {
+			msg = "unknown error"
+		}
 	}
 
 	tags := []string{fmt.Sprintf("component:%s", component)}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -543,6 +543,20 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("kube_resources_namespace", "")
 	config.BindEnvAndSetDefault("kube_cache_sync_timeout_seconds", 5)
 
+	// Kubernetes Control Plane -- controller manager
+	config.BindEnvAndSetDefault("kube_controller_manager_addr", "")
+	config.BindEnvAndSetDefault("kube_controller_manager_tls_verify", true)
+	config.BindEnvAndSetDefault("kube_controller_manager_client_ca", "")
+	config.BindEnvAndSetDefault("kube_controller_manager_client_crt", "")
+	config.BindEnvAndSetDefault("kube_controller_manager_client_key", "")
+
+	// Kubernetes Control Plane -- scheduler
+	config.BindEnvAndSetDefault("kube_scheduler_addr", "")
+	config.BindEnvAndSetDefault("kube_scheduler_tls_verify", true)
+	config.BindEnvAndSetDefault("kube_scheduler_client_ca", "")
+	config.BindEnvAndSetDefault("kube_scheduler_client_crt", "")
+	config.BindEnvAndSetDefault("kube_scheduler_client_key", "")
+
 	// Datadog cluster agent
 	config.BindEnvAndSetDefault("cluster_agent.enabled", false)
 	config.BindEnvAndSetDefault("cluster_agent.auth_token", "")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -543,20 +543,6 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("kube_resources_namespace", "")
 	config.BindEnvAndSetDefault("kube_cache_sync_timeout_seconds", 5)
 
-	// Kubernetes Control Plane -- controller manager
-	config.BindEnvAndSetDefault("kube_controller_manager_addr", "")
-	config.BindEnvAndSetDefault("kube_controller_manager_tls_verify", true)
-	config.BindEnvAndSetDefault("kube_controller_manager_client_ca", "")
-	config.BindEnvAndSetDefault("kube_controller_manager_client_crt", "")
-	config.BindEnvAndSetDefault("kube_controller_manager_client_key", "")
-
-	// Kubernetes Control Plane -- scheduler
-	config.BindEnvAndSetDefault("kube_scheduler_addr", "")
-	config.BindEnvAndSetDefault("kube_scheduler_tls_verify", true)
-	config.BindEnvAndSetDefault("kube_scheduler_client_ca", "")
-	config.BindEnvAndSetDefault("kube_scheduler_client_crt", "")
-	config.BindEnvAndSetDefault("kube_scheduler_client_key", "")
-
 	// Datadog cluster agent
 	config.BindEnvAndSetDefault("cluster_agent.enabled", false)
 	config.BindEnvAndSetDefault("cluster_agent.auth_token", "")

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -608,6 +608,17 @@ func (c *APIClient) GetRESTObject(path string, output runtime.Object) error {
 	return result.Into(output)
 }
 
+// GetReadiness retrieves the API Server readiness status
+func (c *APIClient) GetReadiness(ctx context.Context) (string, error) {
+	path := "/readyz"
+	content, err := c.Cl.Discovery().RESTClient().Get().AbsPath(path).DoRaw(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	return string(content), nil
+}
+
 func convertmetadataMapperBundleToAPI(input *metadataMapperBundle) *apiv1.MetadataResponseBundle {
 	output := apiv1.NewMetadataResponseBundle()
 	if input == nil {

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -608,15 +608,12 @@ func (c *APIClient) GetRESTObject(path string, output runtime.Object) error {
 	return result.Into(output)
 }
 
-// GetReadiness retrieves the API Server readiness status
-func (c *APIClient) GetReadiness(ctx context.Context) (string, error) {
+// IsAPIServerReady retrieves the API Server readiness status
+func (c *APIClient) IsAPIServerReady(ctx context.Context) (bool, error) {
 	path := "/readyz"
-	content, err := c.Cl.Discovery().RESTClient().Get().AbsPath(path).DoRaw(ctx)
-	if err != nil {
-		return "", err
-	}
+	_, err := c.Cl.Discovery().RESTClient().Get().AbsPath(path).DoRaw(ctx)
 
-	return string(content), nil
+	return err == nil, err
 }
 
 func convertmetadataMapperBundleToAPI(input *metadataMapperBundle) *apiv1.MetadataResponseBundle {

--- a/releasenotes-dca/notes/kube-apiserver-controlplane-check-dbc4322c05d65dcf.yaml
+++ b/releasenotes-dca/notes/kube-apiserver-controlplane-check-dbc4322c05d65dcf.yaml
@@ -1,0 +1,25 @@
+---
+features:
+  - |
+    Introduce a `use_component_status` config option to the
+    kubernetes_apiserver check. When set to false, it no longer uses the
+    `ComponentStatus` object (deprecated since Kubernetes 1.19) for the
+    Kubernetes API Server Control Plane health checks, and instead uses each
+    component's health endpoints. It also introduces extra config options for each
+    component::
+
+      cluster_check: false
+      instances:
+        - use_component_status: false
+          kube_controller_manager:
+            url: "https://localhost:10257"
+            tls_verify: true
+            client_ca:
+            client_crt:
+            client_key:
+          kube_scheduler:
+            url: "https://localhost:10259"
+            tls_verify: true
+            client_ca:
+            client_crt:
+            client_key:


### PR DESCRIPTION
### What does this PR do?

Previously, the kube_apiserver_controlplane used ComponentStatus to
report control plane components' liveness. This has been deprecated in
[Kubernetes 1.19](https://github.com/DataDog/datadog-agent/pull/8134)
and will be removed at some point in the future.

To remediate that, we're following the recommendation in the deprecation
notice to use the components' own health check endpoints.

### Describe how to test your changes

This can be tested more easily on kind, but similar instructions work on any distribution where you have access to the control plane. Without that access, this check just doesn't work.

Create a kind cluster (`kind create cluster --config kind.yaml`) with the following `kind.yaml`. This is necessary because by default kind binds the control plane components to `127.0.0.1`.

```
kind: Cluster
apiVersion: kind.x-k8s.io/v1alpha4
nodes:
  - role: control-plane
    kubeadmConfigPatches:
    - |
      apiVersion: kubeadm.k8s.io/v1beta2
      kind: ClusterConfiguration
      scheduler:
        extraArgs:
          bind-address: 0.0.0.0
      controllerManager:
        extraArgs:
          bind-address: 0.0.0.0
```

Get the IP of the control plane pods:

```
$ kubectl get pods -o wide -n kube-system
NAME                                         READY   STATUS    RESTARTS   AGE   IP           NODE                 NOMINATED NODE   READINESS GATES
coredns-74ff55c5b-5lrnc                      1/1     Running   0          43h   10.244.0.2   kind-control-plane   <none>           <none>
coredns-74ff55c5b-bvw45                      1/1     Running   0          43h   10.244.0.3   kind-control-plane   <none>           <none>
etcd-kind-control-plane                      1/1     Running   0          43h   172.18.0.2   kind-control-plane   <none>           <none>
kindnet-6f2n6                                1/1     Running   1          43h   172.18.0.2   kind-control-plane   <none>           <none>
kube-apiserver-kind-control-plane            1/1     Running   0          43h   172.18.0.2   kind-control-plane   <none>           <none>
kube-controller-manager-kind-control-plane   1/1     Running   17         43h   172.18.0.2   kind-control-plane   <none>           <none>
kube-proxy-d9snk                             1/1     Running   0          43h   172.18.0.2   kind-control-plane   <none>           <none>
kube-scheduler-kind-control-plane            1/1     Running   18         43h   172.18.0.2   kind-control-plane   <none>           <none>
```

Configure the check with a `kubernetes_apiserver.yaml` as below. `tls_verify` needs to be false because of the way kind generates certs (otherwise, we get an error: ` x509: certificate is valid for 127.0.0.1, not 172.18.0.2`).

```
init_config:
instances:
  - use_component_status: false
    kube_controller_manager:
      url: "https://172.18.0.2:10257"
      tls_verify: false
    kube_scheduler:
      url: "https://172.18.0.2:10259"
      tls_verify: false
```

Running `agent check kubernetes_apiserver`, you should see output similar to this:

```
=== Service Checks ===
[
  {
    "check": "kube_apiserver_controlplane.up",
    "host_name": "kind-control-plane-juliogreff-kind",
    "timestamp": 1625582387,
    "status": 0,
    "message": "ok",
    "tags": [
      "component:kube-controller-manager"
    ]
  },
  {
    "check": "kube_apiserver_controlplane.up",
    "host_name": "kind-control-plane-juliogreff-kind",
    "timestamp": 1625582387,
    "status": 0,
    "message": "ok",
    "tags": [
      "component:kube-scheduler"
    ]
  },
  {
    "check": "kube_apiserver_controlplane.up",
    "host_name": "kind-control-plane-juliogreff-kind",
    "timestamp": 1625582387,
    "status": 0,
    "message": "ok",
    "tags": [
      "component:apiserver"
    ]
  }
]
```

You can also test that the check still works without the config, which should default to using ComponentStatus.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
