### PR TITLE
[logs] Add support for new intake api

### DIFF
--- a/cmd/cluster-agent/app/compliance.go
+++ b/cmd/cluster-agent/app/compliance.go
@@ -26,6 +26,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+const (
+	intakeTrackType = "compliance"
+)
+
 func runCompliance(ctx context.Context, apiCl *apiserver.APIClient, isLeader func() bool) error {
 	stopper := restart.NewSerialStopper()
 	if err := startCompliance(stopper, apiCl, isLeader); err != nil {
@@ -39,12 +43,12 @@ func runCompliance(ctx context.Context, apiCl *apiserver.APIClient, isLeader fun
 }
 
 func newLogContext(logsConfig *config.LogsConfigKeys, endpointPrefix string) (*config.Endpoints, *client.DestinationsContext, error) {
-	endpoints, err := config.BuildHTTPEndpointsWithConfig(logsConfig, endpointPrefix)
+	endpoints, err := config.BuildHTTPEndpointsWithConfig(logsConfig, endpointPrefix, intakeTrackType, config.DefaultIntakeProtocol)
 	if err != nil {
-		endpoints, err = config.BuildHTTPEndpoints()
+		endpoints, err = config.BuildHTTPEndpoints(intakeTrackType, config.DefaultIntakeProtocol)
 		if err == nil {
 			httpConnectivity := logshttp.CheckConnectivity(endpoints.Main)
-			endpoints, err = config.BuildEndpoints(httpConnectivity)
+			endpoints, err = config.BuildEndpoints(httpConnectivity, intakeTrackType, config.DefaultIntakeProtocol)
 		}
 	}
 

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -47,8 +47,6 @@ import (
 const (
 	// loggerName is the name of the security agent logger
 	loggerName coreconfig.LoggerName = "SECURITY"
-	// No intake track type is defined for the security agent (yet), we use v1 intake only.
-	intakeTrackType = ""
 )
 
 var (
@@ -118,7 +116,7 @@ func init() {
 	SecurityAgentCmd.AddCommand(startCmd)
 }
 
-func newLogContext(logsConfig *config.LogsConfigKeys, endpointPrefix string) (*config.Endpoints, *client.DestinationsContext, error) {
+func newLogContext(logsConfig *config.LogsConfigKeys, intakeTrackType, endpointPrefix string) (*config.Endpoints, *client.DestinationsContext, error) {
 	endpoints, err := config.BuildHTTPEndpointsWithConfig(logsConfig, endpointPrefix, intakeTrackType, config.DefaultIntakeProtocol)
 	if err != nil {
 		endpoints, err = config.BuildHTTPEndpoints(intakeTrackType, config.DefaultIntakeProtocol)

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -44,8 +44,12 @@ import (
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 )
 
-// loggerName is the name of the security agent logger
-const loggerName coreconfig.LoggerName = "SECURITY"
+const (
+	// loggerName is the name of the security agent logger
+	loggerName coreconfig.LoggerName = "SECURITY"
+	// No intake track type is defined for the security agent (yet), we use v1 intake only.
+	intakeTrackType = ""
+)
 
 var (
 	// SecurityAgentCmd is the entry point for security agent CLI commands
@@ -115,12 +119,12 @@ func init() {
 }
 
 func newLogContext(logsConfig *config.LogsConfigKeys, endpointPrefix string) (*config.Endpoints, *client.DestinationsContext, error) {
-	endpoints, err := config.BuildHTTPEndpointsWithConfig(logsConfig, endpointPrefix)
+	endpoints, err := config.BuildHTTPEndpointsWithConfig(logsConfig, endpointPrefix, intakeTrackType, config.DefaultIntakeProtocol)
 	if err != nil {
-		endpoints, err = config.BuildHTTPEndpoints()
+		endpoints, err = config.BuildHTTPEndpoints(intakeTrackType, config.DefaultIntakeProtocol)
 		if err == nil {
 			httpConnectivity := logshttp.CheckConnectivity(endpoints.Main)
-			endpoints, err = config.BuildEndpoints(httpConnectivity)
+			endpoints, err = config.BuildEndpoints(httpConnectivity, intakeTrackType, config.DefaultIntakeProtocol)
 		}
 	}
 

--- a/cmd/security-agent/app/compliance.go
+++ b/cmd/security-agent/app/compliance.go
@@ -59,7 +59,7 @@ func init() {
 
 func newLogContextCompliance() (*config.Endpoints, *client.DestinationsContext, error) {
 	logsConfigComplianceKeys := config.NewLogsConfigKeys("compliance_config.endpoints.", coreconfig.Datadog)
-	return newLogContext(logsConfigComplianceKeys, "compliance-http-intake.logs.")
+	return newLogContext(logsConfigComplianceKeys, "compliance-http-intake.logs.", "compliance")
 }
 
 func eventRun(cmd *cobra.Command, args []string) error {

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -151,7 +151,7 @@ func newRuntimeReporter(stopper restart.Stopper, sourceName, sourceType string, 
 // This function will only be used on Linux. The only platforms where the runtime agent runs
 func newLogContextRuntime() (*config.Endpoints, *client.DestinationsContext, error) { // nolint: deadcode, unused
 	logsConfigComplianceKeys := config.NewLogsConfigKeys("runtime_security_config.endpoints.", coreconfig.Datadog)
-	return newLogContext(logsConfigComplianceKeys, "runtime-security-http-intake.logs.")
+	return newLogContext(logsConfigComplianceKeys, "runtime-security-http-intake.logs.", "logs")
 }
 
 func startRuntimeSecurity(hostname string, stopper restart.Stopper, statsdClient *ddgostatsd.Client) (*secagent.RuntimeSecurityAgent, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1153,6 +1153,7 @@ func bindEnvAndSetLogsConfigKeys(config Config, prefix string) {
 	config.BindEnvAndSetDefault(prefix+"sender_backoff_max", DefaultLogsSenderBackoffMax)
 	config.BindEnvAndSetDefault(prefix+"sender_recovery_interval", DefaultForwarderRecoveryInterval)
 	config.BindEnvAndSetDefault(prefix+"sender_recovery_reset", false)
+	config.BindEnvAndSetDefault(prefix+"use_v2_api", false)
 }
 
 // getDomainPrefix provides the right prefix for agent X.Y.Z

--- a/pkg/epforwarder/epforwarder.go
+++ b/pkg/epforwarder/epforwarder.go
@@ -30,6 +30,7 @@ var passthroughPipelineDescs = []passthroughPipelineDesc{
 		eventType:              eventTypeDBMSamples,
 		endpointsConfigPrefix:  "database_monitoring.samples.",
 		hostnameEndpointPrefix: "dbquery-http-intake.logs.",
+		intakeTrackType:        "databasequery",
 		// raise the default batch_max_concurrent_send from 0 to 10 to ensure this pipeline is able to handle 4k events/s
 		defaultBatchMaxConcurrentSend: 10,
 		defaultBatchMaxContentSize:    pkgconfig.DefaultBatchMaxContentSize,
@@ -39,6 +40,7 @@ var passthroughPipelineDescs = []passthroughPipelineDesc{
 		eventType:              eventTypeDBMMetrics,
 		endpointsConfigPrefix:  "database_monitoring.metrics.",
 		hostnameEndpointPrefix: "dbm-metrics-intake.",
+		intakeTrackType:        "dbmetrics",
 		// raise the default batch_max_concurrent_send from 0 to 10 to ensure this pipeline is able to handle 4k events/s
 		defaultBatchMaxConcurrentSend: 10,
 		defaultBatchMaxContentSize:    20e6,
@@ -133,6 +135,7 @@ type passthroughPipeline struct {
 
 type passthroughPipelineDesc struct {
 	eventType                     string
+	intakeTrackType               string
 	endpointsConfigPrefix         string
 	hostnameEndpointPrefix        string
 	defaultBatchMaxConcurrentSend int
@@ -144,7 +147,7 @@ type passthroughPipelineDesc struct {
 // without any of the processing that exists in regular logs pipelines.
 func newHTTPPassthroughPipeline(desc passthroughPipelineDesc, destinationsContext *client.DestinationsContext) (p *passthroughPipeline, err error) {
 	configKeys := config.NewLogsConfigKeys(desc.endpointsConfigPrefix, coreConfig.Datadog)
-	endpoints, err := config.BuildHTTPEndpointsWithConfig(configKeys, desc.hostnameEndpointPrefix)
+	endpoints, err := config.BuildHTTPEndpointsWithConfig(configKeys, desc.hostnameEndpointPrefix, desc.intakeTrackType, config.DefaultIntakeProtocol)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/epforwarder/epforwarder.go
+++ b/pkg/epforwarder/epforwarder.go
@@ -40,7 +40,7 @@ var passthroughPipelineDescs = []passthroughPipelineDesc{
 		eventType:              eventTypeDBMMetrics,
 		endpointsConfigPrefix:  "database_monitoring.metrics.",
 		hostnameEndpointPrefix: "dbm-metrics-intake.",
-		intakeTrackType:        "dbmetrics",
+		intakeTrackType:        "dbmmetrics",
 		// raise the default batch_max_concurrent_send from 0 to 10 to ensure this pipeline is able to handle 4k events/s
 		defaultBatchMaxConcurrentSend: 10,
 		defaultBatchMaxContentSize:    20e6,

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
+	"net/url"
 	"sync"
 	"time"
 
@@ -237,13 +238,16 @@ func buildURL(endpoint config.Endpoint) string {
 	} else {
 		address = endpoint.Host
 	}
-	uri := ""
-	if endpoint.Version == config.EPIntakeVersion2 && endpoint.TrackType != "" {
-		uri = fmt.Sprintf("api/v2/%s", endpoint.TrackType)
-	} else {
-		uri = "v1/input"
+	url := url.URL{
+		Scheme: scheme,
+		Host:   address,
 	}
-	return fmt.Sprintf("%v://%v/%v", scheme, address, uri)
+	if endpoint.Version == config.EPIntakeVersion2 && endpoint.TrackType != "" {
+		url.Path = fmt.Sprintf("/api/v2/%s", endpoint.TrackType)
+	} else {
+		url.Path = "/v1/input"
+	}
+	return url.String()
 }
 
 func buildContentEncoding(endpoint config.Endpoint) ContentEncoding {

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -24,11 +24,14 @@ type HTTPServerTest struct {
 	destCtx     *client.DestinationsContext
 	destination *Destination
 	endpoint    config.Endpoint
+	request     *http.Request
 }
 
 func NewHTTPServerTest(statusCode int) *HTTPServerTest {
+	var request http.Request
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(statusCode)
+		request = *r
 	}))
 	url := strings.Split(ts.URL, ":")
 	port, _ := strconv.Atoi(url[2])
@@ -46,6 +49,7 @@ func NewHTTPServerTest(statusCode int) *HTTPServerTest {
 		destCtx:     destCtx,
 		destination: dest,
 		endpoint:    endpoint,
+		request:     &request,
 	}
 }
 
@@ -80,6 +84,17 @@ func TestBuildURLShouldReturnAddressWithPortWhenDefined(t *testing.T) {
 		UseSSL: false,
 	})
 	assert.Equal(t, "http://foo:1234/v1/input", url)
+}
+
+func TestBuildURLShouldReturnAddressForVersion2(t *testing.T) {
+	url := buildURL(config.Endpoint{
+		APIKey:    "bar",
+		Host:      "foo",
+		UseSSL:    false,
+		Version:   config.EPIntakeVersion2,
+		TrackType: "test-track",
+	})
+	assert.Equal(t, "http://foo/api/v2/test-track", url)
 }
 
 func TestDestinationSend200(t *testing.T) {
@@ -127,4 +142,23 @@ func TestErrorToTag(t *testing.T) {
 	assert.Equal(t, errorToTag(nil), "none")
 	assert.Equal(t, errorToTag(errors.New("fail")), "non-retryable")
 	assert.Equal(t, errorToTag(client.NewRetryableError(errors.New("fail"))), "retryable")
+}
+
+func TestDestinationSendsV2Protocol(t *testing.T) {
+	server := NewHTTPServerTest(200)
+	defer server.httpServer.Close()
+
+	server.destination.protocol = "test-proto"
+	err := server.destination.unconditionalSend([]byte("payload"))
+	assert.Nil(t, err)
+	assert.Equal(t, server.request.Header.Get("dd-protocol"), "test-proto")
+}
+
+func TestDestinationDoesntSendEmptyV2Protocol(t *testing.T) {
+	server := NewHTTPServerTest(200)
+	defer server.httpServer.Close()
+
+	err := server.destination.unconditionalSend([]byte("payload"))
+	assert.Nil(t, err)
+	assert.Empty(t, server.request.Header.Values("dd-protocol"))
 }

--- a/pkg/logs/config/config_keys.go
+++ b/pkg/logs/config/config_keys.go
@@ -233,3 +233,7 @@ func (l *LogsConfigKeys) senderRecoveryReset() bool {
 func (l *LogsConfigKeys) aggregationTimeout() time.Duration {
 	return l.getConfig().GetDuration(l.getConfigKey("aggregation_timeout")) * time.Millisecond
 }
+
+func (l *LogsConfigKeys) useV2API() bool {
+	return l.getConfig().GetBool(l.getConfigKey("use_v2_api"))
+}

--- a/pkg/logs/config/endpoints.go
+++ b/pkg/logs/config/endpoints.go
@@ -6,8 +6,20 @@
 package config
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+// EPIntakeVersion is the events platform intake API version
+type EPIntakeVersion uint8
+
+const (
+	_ EPIntakeVersion = iota
+	// EPIntakeVersion1 is version 1 of the envets platform intake API
+	EPIntakeVersion1
+	// EPIntakeVersion2 is version 2 of the envets platform intake API
+	EPIntakeVersion2
 )
 
 // Endpoint holds all the organization and network parameters to send logs to Datadog.
@@ -26,6 +38,10 @@ type Endpoint struct {
 	BackoffMax       float64
 	RecoveryInterval int
 	RecoveryReset    bool
+
+	Version   EPIntakeVersion
+	TrackType string
+	Protocol  string
 }
 
 // Endpoints holds the main endpoint and additional ones to dualship logs.

--- a/pkg/logs/config/endpoints_test.go
+++ b/pkg/logs/config/endpoints_test.go
@@ -25,35 +25,35 @@ func (suite *EndpointsTestSuite) SetupTest() {
 
 func (suite *EndpointsTestSuite) TestLogsEndpointConfig() {
 	suite.Equal("agent-intake.logs.datadoghq.com", coreConfig.GetMainEndpoint(tcpEndpointPrefix, "logs_config.dd_url"))
-	endpoints, err := BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err := BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.Equal("agent-intake.logs.datadoghq.com", endpoints.Main.Host)
 	suite.Equal(10516, endpoints.Main.Port)
 
 	suite.config.Set("site", "datadoghq.com")
 	suite.Equal("agent-intake.logs.datadoghq.com", coreConfig.GetMainEndpoint(tcpEndpointPrefix, "logs_config.dd_url"))
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.Equal("agent-intake.logs.datadoghq.com", endpoints.Main.Host)
 	suite.Equal(10516, endpoints.Main.Port)
 
 	suite.config.Set("site", "datadoghq.eu")
 	suite.Equal("agent-intake.logs.datadoghq.eu", coreConfig.GetMainEndpoint(tcpEndpointPrefix, "logs_config.dd_url"))
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.Equal("agent-intake.logs.datadoghq.eu", endpoints.Main.Host)
 	suite.Equal(443, endpoints.Main.Port)
 
 	suite.config.Set("logs_config.dd_url", "lambda.logs.datadoghq.co.jp")
 	suite.Equal("lambda.logs.datadoghq.co.jp", coreConfig.GetMainEndpoint(tcpEndpointPrefix, "logs_config.dd_url"))
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.Equal("lambda.logs.datadoghq.co.jp", endpoints.Main.Host)
 	suite.Equal(10516, endpoints.Main.Port)
 
 	suite.config.Set("logs_config.logs_dd_url", "azure.logs.datadoghq.co.uk:1234")
 	suite.Equal("azure.logs.datadoghq.co.uk:1234", coreConfig.GetMainEndpoint(tcpEndpointPrefix, "logs_config.logs_dd_url"))
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.Equal("azure.logs.datadoghq.co.uk", endpoints.Main.Host)
 	suite.Equal(1234, endpoints.Main.Port)
@@ -68,7 +68,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithDefaultAndVa
 	suite.config.Set("api_key", "azerty")
 	suite.config.Set("logs_config.socks5_proxy_address", "boz:1234")
 
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	endpoint = endpoints.Main
 	suite.Equal("azerty", endpoint.APIKey)
@@ -79,7 +79,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithDefaultAndVa
 	suite.Equal(0, len(endpoints.Additionals))
 
 	suite.config.Set("logs_config.use_port_443", true)
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	endpoint = endpoints.Main
 	suite.Equal("azerty", endpoint.APIKey)
@@ -91,7 +91,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithDefaultAndVa
 
 	suite.config.Set("logs_config.logs_dd_url", "host:1234")
 	suite.config.Set("logs_config.logs_no_ssl", true)
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	endpoint = endpoints.Main
 	suite.Equal("azerty", endpoint.APIKey)
@@ -103,7 +103,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithDefaultAndVa
 
 	suite.config.Set("logs_config.logs_dd_url", ":1234")
 	suite.config.Set("logs_config.logs_no_ssl", false)
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	endpoint = endpoints.Main
 	suite.Equal("azerty", endpoint.APIKey)
@@ -121,7 +121,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPCon
 
 	suite.config.Set("logs_config.use_http", true)
 
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.True(endpoints.UseHTTP)
 	suite.Equal(endpoints.BatchWait, 5*time.Second)
@@ -139,7 +139,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPCon
 	suite.config.Set("logs_config.use_http", true)
 	suite.config.Set("logs_config.use_compression", true)
 
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.True(endpoints.UseHTTP)
 
@@ -157,7 +157,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPCon
 	suite.config.Set("logs_config.use_compression", true)
 	suite.config.Set("logs_config.compression_level", 1)
 
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.True(endpoints.UseHTTP)
 
@@ -175,7 +175,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPCon
 	suite.config.Set("logs_config.dd_url", "foo")
 	suite.config.Set("logs_config.batch_wait", 9)
 
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.True(endpoints.UseHTTP)
 	suite.Equal(endpoints.BatchWait, 9*time.Second)
@@ -193,7 +193,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidProxyCo
 	suite.config.Set("logs_config.use_http", true)
 	suite.config.Set("logs_config.logs_dd_url", "foo:1234")
 
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.True(endpoints.UseHTTP)
 
@@ -209,7 +209,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldFailWithInvalidProxyCon
 	suite.config.Set("logs_config.use_http", true)
 	suite.config.Set("logs_config.logs_dd_url", "foo")
 
-	_, err = BuildEndpoints(HTTPConnectivityFailure)
+	_, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.NotNil(err)
 }
 
@@ -220,7 +220,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldFailWithInvalidOverride
 	}
 	for _, url := range invalidURLs {
 		suite.config.Set("logs_config.logs_dd_url", url)
-		_, err := BuildEndpoints(HTTPConnectivityFailure)
+		_, err := BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 		suite.NotNil(err)
 	}
 }
@@ -231,7 +231,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldFallbackOnDefaultWithIn
 	invalidBatchWaits := []int{-1, 0, 11}
 	for _, batchWait := range invalidBatchWaits {
 		suite.config.Set("logs_config.batch_wait", batchWait)
-		endpoints, err := BuildEndpoints(HTTPConnectivityFailure)
+		endpoints, err := BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 		suite.Nil(err)
 		suite.Equal(endpoints.BatchWait, coreConfig.DefaultBatchWait*time.Second)
 	}
@@ -240,7 +240,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldFallbackOnDefaultWithIn
 //When migrating the agent v5 to v6, logs_dd_url is set to empty. Default to the dd_url/site already set instead.
 func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWhenMigratingToAgentV6() {
 	suite.config.Set("logs_config.logs_dd_url", "")
-	endpoints, err := BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err := BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.Equal("agent-intake.logs.datadoghq.com", endpoints.Main.Host)
 	suite.Equal(10516, endpoints.Main.Port)
@@ -250,30 +250,30 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldTakeIntoAccountHTTPConn
 	// When use_http is true always create HTTP endpoints
 	suite.config.Set("logs_config.use_http", "true")
 	suite.config.Set("logs_config.use_tcp", "false")
-	endpoints, err := BuildEndpoints(HTTPConnectivitySuccess)
+	endpoints, err := BuildEndpoints(HTTPConnectivitySuccess, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.True(endpoints.UseHTTP)
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.True(endpoints.UseHTTP)
 
 	// When use_tcp is true always create TCP endpoints
 	suite.config.Set("logs_config.use_http", "false")
 	suite.config.Set("logs_config.use_tcp", "true")
-	endpoints, err = BuildEndpoints(HTTPConnectivitySuccess)
+	endpoints, err = BuildEndpoints(HTTPConnectivitySuccess, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.False(endpoints.UseHTTP)
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.False(endpoints.UseHTTP)
 
 	// When use_http & use_tcp are false create HTTP endpoints if HTTP connectivity is successful
 	suite.config.Set("logs_config.use_http", "false")
 	suite.config.Set("logs_config.use_tcp", "false")
-	endpoints, err = BuildEndpoints(HTTPConnectivitySuccess)
+	endpoints, err = BuildEndpoints(HTTPConnectivitySuccess, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.True(endpoints.UseHTTP)
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.False(endpoints.UseHTTP)
 
@@ -281,10 +281,10 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldTakeIntoAccountHTTPConn
 	suite.config.Set("logs_config.use_http", "false")
 	suite.config.Set("logs_config.use_tcp", "false")
 	suite.config.Set("logs_config.socks5_proxy_address", "my-address")
-	endpoints, err = BuildEndpoints(HTTPConnectivitySuccess)
+	endpoints, err = BuildEndpoints(HTTPConnectivitySuccess, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.False(endpoints.UseHTTP)
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.False(endpoints.UseHTTP)
 	suite.config.Set("logs_config.socks5_proxy_address", "")
@@ -300,10 +300,10 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldTakeIntoAccountHTTPConn
 			"compression_level": 1,
 		},
 	})
-	endpoints, err = BuildEndpoints(HTTPConnectivitySuccess)
+	endpoints, err = BuildEndpoints(HTTPConnectivitySuccess, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.False(endpoints.UseHTTP)
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.False(endpoints.UseHTTP)
 }
@@ -319,7 +319,7 @@ func (suite *EndpointsTestSuite) TestIsSetAndNotEmpty() {
 func (suite *EndpointsTestSuite) TestDefaultApiKey() {
 	suite.config.Set("api_key", "wassupkey")
 	suite.Equal("wassupkey", defaultLogsConfigKeys().getLogsAPIKey())
-	endpoints, err := BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err := BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.Equal("wassupkey", endpoints.Main.APIKey)
 }
@@ -328,7 +328,7 @@ func (suite *EndpointsTestSuite) TestOverrideApiKey() {
 	suite.config.Set("api_key", "wassupkey")
 	suite.config.Set("logs_config.api_key", "wassuplogskey")
 	suite.Equal("wassuplogskey", defaultLogsConfigKeys().getLogsAPIKey())
-	endpoints, err := BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err := BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.Equal("wassuplogskey", endpoints.Main.APIKey)
 }
@@ -349,7 +349,7 @@ func (suite *EndpointsTestSuite) TestAdditionalEndpoints() {
 		},
 	})
 
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.Len(endpoints.Additionals, 1)
 
@@ -359,7 +359,7 @@ func (suite *EndpointsTestSuite) TestAdditionalEndpoints() {
 	suite.True(endpoint.UseSSL)
 
 	suite.config.Set("logs_config.use_http", true)
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure)
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
 	suite.Nil(err)
 	suite.Len(endpoints.Additionals, 1)
 

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -30,6 +30,8 @@ const (
 	// key used to display a warning message on the agent status
 	invalidProcessingRules = "invalid_global_processing_rules"
 	invalidEndpoints       = "invalid_endpoints"
+	intakeTrackType        = "logs"
+	intakeProtocol         = "agent-json"
 )
 
 var (
@@ -68,12 +70,12 @@ func start(getAC func() *autodiscovery.AutoConfig, serverless bool, logsChan cha
 
 	// setup the server config
 	httpConnectivity := config.HTTPConnectivityFailure
-	if endpoints, err := config.BuildHTTPEndpoints(); err == nil {
+	if endpoints, err := config.BuildHTTPEndpoints(intakeTrackType, intakeProtocol); err == nil {
 		httpConnectivity = http.CheckConnectivity(endpoints.Main)
 	}
-	endpoints, err := config.BuildEndpoints(httpConnectivity)
+	endpoints, err := config.BuildEndpoints(httpConnectivity, intakeTrackType, intakeProtocol)
 	if serverless {
-		endpoints, err = config.BuildServerlessEndpoints()
+		endpoints, err = config.BuildServerlessEndpoints(intakeTrackType, intakeProtocol)
 	}
 	if err != nil {
 		message := fmt.Sprintf("Invalid endpoints: %v", err)

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -75,7 +75,7 @@ func start(getAC func() *autodiscovery.AutoConfig, serverless bool, logsChan cha
 	}
 	endpoints, err := config.BuildEndpoints(httpConnectivity, intakeTrackType, intakeProtocol)
 	if serverless {
-		endpoints, err = config.BuildServerlessEndpoints(intakeTrackType, intakeProtocol)
+		endpoints, err = config.BuildServerlessEndpoints(intakeTrackType, config.DefaultIntakeProtocol)
 	}
 	if err != nil {
 		message := fmt.Sprintf("Invalid endpoints: %v", err)

--- a/pkg/logs/status/test_utils.go
+++ b/pkg/logs/status/test_utils.go
@@ -13,6 +13,6 @@ import (
 // InitStatus initialize a status builder
 func InitStatus(sources *config.LogSources) {
 	var isRunning int32 = 1
-	endpoints, _ := config.BuildEndpoints(config.HTTPConnectivityFailure)
+	endpoints, _ := config.BuildEndpoints(config.HTTPConnectivityFailure, "test-track", "test-proto")
 	Init(&isRunning, endpoints, sources, metrics.LogsExpvars)
 }


### PR DESCRIPTION
### What does this PR do?

Add support for new version 2 intake API used for logs and events. New API supports additional parameters to differentiate requests: a track type, which is part of a url, and an optional `dd-protocol`
header.

Each component that interacts that interacts with the intake, was assigned an individual type; this is passed via various routes into the endpoint construction.

Whether new API is used or not is controlled by a new hidden `use_v2_api` configuratio option (available, like other options, for each agent component separately).

Additional endpoints inherit the api version setting from the parent endpoint, but it can be overridden if necessary.

### Describe how to test your changes

Agent Core to test the logs agent (instructions below). Other teams please use a variation of this plan as applicable to your part of the agent.

Configure a logs check and enable logs agent:

- Configure a logs check and enable logs agent (using default v1 api).
  ```yaml
  logs_config:
    enabled: true
  ```
- Check in the agent log that the logs connectivity check is done to `/v1/input` and succeeds.
  ```
  [...] Sending HTTP connectivity request to https://agent-http-intake.logs.datadoghq.com/v1/input
  [...] HTTP connectivity successful
  ```
- Add some log entries to the log file and check that they appear in the app.
- Enable v2 api and restart the agent.
  ```yaml
  logs_config:
    enabled: true
    use_v2_api: true
  ```
- Check in the agent log that the logs connectivity check is done to `/api/v2/logs` and succeeds.
  ```
  [...] Sending HTTP connectivity request to https://agent-http-intake.logs.datadoghq.com/api/v2/logs
  [...] HTTP connectivity successful
  ```
- Add some log entries to the log file and check that they appear in the app.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
