### PR TITLE
[profiling] expose more profiling options, take 2

### DIFF
--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -310,5 +310,5 @@ func enableProfiling(cfg *config.AgentConfig) error {
 
 	v, _ := version.Agent()
 
-	return profiling.Start(site, cfg.ProfilingEnvironment, "process-agent", cfg.ProfilingPeriod, cfg.ProfilingCPUDuration, cfg.ProfilingWithGoroutines, fmt.Sprintf("version:%v", v))
+	return profiling.Start(site, cfg.ProfilingEnvironment, "process-agent", cfg.ProfilingPeriod, cfg.ProfilingCPUDuration, cfg.ProfilingMutexFraction, cfg.ProfilingBlockRate, cfg.ProfilingWithGoroutines, fmt.Sprintf("version:%v", v))
 }

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -310,5 +310,5 @@ func enableProfiling(cfg *config.AgentConfig) error {
 
 	v, _ := version.Agent()
 
-	return profiling.Start(cfg.ProfilingAPIKey, site, cfg.ProfilingEnvironment, "process-agent", cfg.ProfilingPeriod, cfg.ProfilingCPUDuration, cfg.ProfilingWithGoroutines, fmt.Sprintf("version:%v", v))
+	return profiling.Start(site, cfg.ProfilingEnvironment, "process-agent", cfg.ProfilingPeriod, cfg.ProfilingCPUDuration, cfg.ProfilingWithGoroutines, fmt.Sprintf("version:%v", v))
 }

--- a/cmd/system-probe/app/run.go
+++ b/cmd/system-probe/app/run.go
@@ -197,7 +197,9 @@ func enableProfiling(cfg *config.Config) error {
 		"system-probe",
 		cfg.ProfilingPeriod,
 		cfg.ProfilingCPUDuration,
-		false,
+		cfg.ProfilingMutexFraction,
+		cfg.ProfilingBlockRate,
+		cfg.ProfilingWithGoroutines,
 		fmt.Sprintf("version:%v", v),
 	)
 }

--- a/cmd/system-probe/app/run.go
+++ b/cmd/system-probe/app/run.go
@@ -192,7 +192,6 @@ func enableProfiling(cfg *config.Config) error {
 	}
 
 	return profiling.Start(
-		cfg.ProfilingAPIKey,
 		site,
 		cfg.ProfilingEnvironment,
 		"system-probe",

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -59,12 +59,15 @@ type Config struct {
 	StatsdHost string
 	StatsdPort int
 
-	ProfilingEnabled     bool
-	ProfilingSite        string
-	ProfilingURL         string
-	ProfilingEnvironment string
-	ProfilingPeriod      time.Duration
-	ProfilingCPUDuration time.Duration
+	ProfilingEnabled        bool
+	ProfilingSite           string
+	ProfilingURL            string
+	ProfilingEnvironment    string
+	ProfilingPeriod         time.Duration
+	ProfilingCPUDuration    time.Duration
+	ProfilingMutexFraction  int
+	ProfilingBlockRate      int
+	ProfilingWithGoroutines bool
 }
 
 // New creates a config object for system-probe. It assumes no configuration has been loaded as this point.
@@ -141,12 +144,15 @@ func load(configPath string) (*Config, error) {
 		StatsdHost: aconfig.GetBindHost(),
 		StatsdPort: cfg.GetInt("dogstatsd_port"),
 
-		ProfilingEnabled:     cfg.GetBool(key(spNS, "internal_profiling.enabled")),
-		ProfilingSite:        cfg.GetString(key(spNS, "internal_profiling.site")),
-		ProfilingURL:         cfg.GetString(key(spNS, "internal_profiling.profile_dd_url")),
-		ProfilingEnvironment: cfg.GetString(key(spNS, "internal_profiling.env")),
-		ProfilingPeriod:      cfg.GetDuration(key(spNS, "internal_profiling.period")),
-		ProfilingCPUDuration: cfg.GetDuration(key(spNS, "internal_profiling.cpu_duration")),
+		ProfilingEnabled:        cfg.GetBool(key(spNS, "internal_profiling.enabled")),
+		ProfilingSite:           cfg.GetString(key(spNS, "internal_profiling.site")),
+		ProfilingURL:            cfg.GetString(key(spNS, "internal_profiling.profile_dd_url")),
+		ProfilingEnvironment:    cfg.GetString(key(spNS, "internal_profiling.env")),
+		ProfilingPeriod:         cfg.GetDuration(key(spNS, "internal_profiling.period")),
+		ProfilingCPUDuration:    cfg.GetDuration(key(spNS, "internal_profiling.cpu_duration")),
+		ProfilingMutexFraction:  cfg.GetInt(key(spNS, "internal_profiling.mutex_profile_fraction")),
+		ProfilingBlockRate:      cfg.GetInt(key(spNS, "internal_profiling.block_profile_rate")),
+		ProfilingWithGoroutines: cfg.GetBool(key(spNS, "internal_profiling.enable_goroutine_stacktraces")),
 	}
 
 	if err := ValidateSocketAddress(c.SocketAddress); err != nil {

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -62,7 +62,6 @@ type Config struct {
 	ProfilingEnabled     bool
 	ProfilingSite        string
 	ProfilingURL         string
-	ProfilingAPIKey      string
 	ProfilingEnvironment string
 	ProfilingPeriod      time.Duration
 	ProfilingCPUDuration time.Duration
@@ -145,7 +144,6 @@ func load(configPath string) (*Config, error) {
 		ProfilingEnabled:     cfg.GetBool(key(spNS, "internal_profiling.enabled")),
 		ProfilingSite:        cfg.GetString(key(spNS, "internal_profiling.site")),
 		ProfilingURL:         cfg.GetString(key(spNS, "internal_profiling.profile_dd_url")),
-		ProfilingAPIKey:      aconfig.SanitizeAPIKey(cfg.GetString(key(spNS, "internal_profiling.api_key"))),
 		ProfilingEnvironment: cfg.GetString(key(spNS, "internal_profiling.env")),
 		ProfilingPeriod:      cfg.GetDuration(key(spNS, "internal_profiling.period")),
 		ProfilingCPUDuration: cfg.GetDuration(key(spNS, "internal_profiling.cpu_duration")),

--- a/pkg/config/settings/runtime_setting_profiling.go
+++ b/pkg/config/settings/runtime_setting_profiling.go
@@ -68,6 +68,8 @@ func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 			profiling.ProfileCoreService,
 			profiling.DefaultProfilingPeriod,
 			15*time.Second,
+			profiling.GetMutexProfileFraction(),
+			profiling.GetBlockProfileRate(),
 			config.Datadog.GetBool("internal_profiling.enable_goroutine_stacktraces"),
 			fmt.Sprintf("version:%v", v),
 		)

--- a/pkg/config/settings/runtime_setting_profiling.go
+++ b/pkg/config/settings/runtime_setting_profiling.go
@@ -63,7 +63,6 @@ func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 
 		v, _ := version.Agent()
 		err := profiling.Start(
-			config.SanitizeAPIKey(config.Datadog.GetString("api_key")),
 			site,
 			config.Datadog.GetString("env"),
 			profiling.ProfileCoreService,

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -56,6 +56,9 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.env"), "", "DD_SYSTEM_PROBE_INTERNAL_PROFILING_ENV", "DD_ENV")
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.period"), 5*time.Minute, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_PERIOD")
 	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.cpu_duration"), 1*time.Minute, "DD_SYSTEM_PROBE_INTERNAL_PROFILING_CPU_DURATION")
+	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.mutex_profile_fraction"), 0)
+	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.block_profile_rate"), 0)
+	cfg.BindEnvAndSetDefault(join(spNS, "internal_profiling.enable_goroutine_stacktraces"), false)
 
 	// ebpf general settings
 	cfg.BindEnvAndSetDefault(join(spNS, "bpf_debug"), false)

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -104,6 +104,8 @@ type AgentConfig struct {
 	ProfilingEnvironment      string
 	ProfilingPeriod           time.Duration
 	ProfilingCPUDuration      time.Duration
+	ProfilingMutexFraction    int
+	ProfilingBlockRate        int
 	ProfilingWithGoroutines   bool
 	// host type of the agent, used to populate container payload with additional host information
 	ContainerHostType model.ContainerHostType

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -101,7 +101,6 @@ type AgentConfig struct {
 	ProfilingEnabled          bool
 	ProfilingSite             string
 	ProfilingURL              string
-	ProfilingAPIKey           string
 	ProfilingEnvironment      string
 	ProfilingPeriod           time.Duration
 	ProfilingCPUDuration      time.Duration

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -209,7 +209,6 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 		a.ProfilingEnabled = config.Datadog.GetBool(key(ns, "internal_profiling.enabled"))
 		a.ProfilingSite = config.Datadog.GetString("site")
 		a.ProfilingURL = config.Datadog.GetString("internal_profiling.profile_dd_url")
-		a.ProfilingAPIKey = config.SanitizeAPIKey(config.Datadog.GetString("api_key"))
 		a.ProfilingEnvironment = config.Datadog.GetString("env")
 		a.ProfilingPeriod = config.Datadog.GetDuration("internal_profiling.period")
 		a.ProfilingCPUDuration = config.Datadog.GetDuration("internal_profiling.cpu_duration")

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -212,6 +212,8 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 		a.ProfilingEnvironment = config.Datadog.GetString("env")
 		a.ProfilingPeriod = config.Datadog.GetDuration("internal_profiling.period")
 		a.ProfilingCPUDuration = config.Datadog.GetDuration("internal_profiling.cpu_duration")
+		a.ProfilingMutexFraction = config.Datadog.GetInt("internal_profiling.mutex_profile_fraction")
+		a.ProfilingBlockRate = config.Datadog.GetInt("internal_profiling.block_profile_rate")
 		a.ProfilingWithGoroutines = config.Datadog.GetBool("internal_profiling.enable_goroutine_stacktraces")
 	}
 

--- a/pkg/trace/agent/run.go
+++ b/pkg/trace/agent/run.go
@@ -197,7 +197,9 @@ func runProfiling(cfg *config.AgentConfig) {
 	if v := coreconfig.Datadog.GetDuration("internal_profiling.cpu_duration"); v != 0 {
 		cpudur = v
 	}
+	mutexFraction := coreconfig.Datadog.GetInt("internal_profiling.mutex_profile_fraction")
+	blockRate := coreconfig.Datadog.GetInt("internal_profiling.block_profile_rate")
 	routines := coreconfig.Datadog.GetBool("internal_profiling.enable_goroutine_stacktraces")
-	profiling.Start(cfg.APIKey(), addr, cfg.DefaultEnv, "trace-agent", period, cpudur, routines, fmt.Sprintf("version:%s", info.Version))
-	log.Infof("Internal profiling enabled: [Target:%q][Env:%q][Period:%s][CPU:%s][Routines:%v].", addr, cfg.DefaultEnv, period, cpudur, routines)
+	profiling.Start(addr, cfg.DefaultEnv, "trace-agent", period, cpudur, mutexFraction, blockRate, routines, fmt.Sprintf("version:%s", info.Version))
+	log.Infof("Internal profiling enabled: [Target:%q][Env:%q][Period:%s][CPU:%s][Mutex:%d][Block:%d][Routines:%v].", addr, cfg.DefaultEnv, period, cpudur, mutexFraction, blockRate, routines)
 }

--- a/pkg/util/profiling/profiling.go
+++ b/pkg/util/profiling/profiling.go
@@ -6,7 +6,6 @@
 package profiling
 
 import (
-	"runtime"
 	"sync"
 	"time"
 
@@ -33,14 +32,14 @@ const (
 
 // Start initiates profiling with the supplied parameters;
 // this function is thread-safe.
-func Start(site, env, service string, period time.Duration, cpuDuration time.Duration, withGoroutine bool, tags ...string) error {
+func Start(site, env, service string, period time.Duration, cpuDuration time.Duration, mutexFraction, blockRate int, withGoroutine bool, tags ...string) error {
 	mu.Lock()
 	defer mu.Unlock()
 	if running {
 		return nil
 	}
 
-	types := []profiler.ProfileType{profiler.CPUProfile, profiler.HeapProfile, profiler.MutexProfile}
+	types := []profiler.ProfileType{profiler.CPUProfile, profiler.HeapProfile}
 	if withGoroutine {
 		types = append(types, profiler.GoroutineProfile)
 	}
@@ -58,11 +57,11 @@ func Start(site, env, service string, period time.Duration, cpuDuration time.Dur
 	// If block or mutex profiling was configured via runtime configuration, pass current
 	// values to profiler. This prevents profiler from resetting mutex profile rate to the
 	// default value; and enables collection of blocking profile data if it is enabled.
-	if frac := runtime.SetMutexProfileFraction(-1); frac > 0 {
-		options = append(options, profiler.MutexProfileFraction(frac))
+	if mutexFraction > 0 {
+		options = append(options, profiler.MutexProfileFraction(mutexFraction))
 	}
-	if blockProfileRate > 0 {
-		options = append(options, profiler.BlockProfileRate(blockProfileRate))
+	if blockRate > 0 {
+		options = append(options, profiler.BlockProfileRate(blockRate))
 	}
 
 	err := profiler.Start(options...)

--- a/pkg/util/profiling/profiling.go
+++ b/pkg/util/profiling/profiling.go
@@ -33,7 +33,7 @@ const (
 
 // Start initiates profiling with the supplied parameters;
 // this function is thread-safe.
-func Start(apiKey, site, env, service string, period time.Duration, cpuDuration time.Duration, withGoroutine bool, tags ...string) error {
+func Start(site, env, service string, period time.Duration, cpuDuration time.Duration, withGoroutine bool, tags ...string) error {
 	mu.Lock()
 	defer mu.Unlock()
 	if running {

--- a/pkg/util/profiling/profiling_test.go
+++ b/pkg/util/profiling/profiling_test.go
@@ -14,7 +14,6 @@ import (
 
 func TestProfiling(t *testing.T) {
 	err := Start(
-		"fake-api",
 		"https://nowhere.testing.dev",
 		"testing",
 		ProfileCoreService,

--- a/pkg/util/profiling/profiling_test.go
+++ b/pkg/util/profiling/profiling_test.go
@@ -19,6 +19,8 @@ func TestProfiling(t *testing.T) {
 		ProfileCoreService,
 		time.Minute,
 		15*time.Second,
+		0,
+		0,
 		false,
 		"1.0.0",
 	)


### PR DESCRIPTION
### What does this PR do?

Disable mutex profiler by default.
Allows agents to configure additional profile types (mutex, blocking, goroutine stack).

### Motivation

Mutex profiler has non-negligible cost, especially when left running for longer periods of time. We want it to be opt-in, rather than being enabled by default.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Run the agent with internal profiling enabled in `datadog.yml`:

```yaml
internal_profiling:
  enabled: true
  mutex_profile_fraction: 1
  block_profile_rate: 1
  enable_goroutine_stacktraces: true
process_config:
  internal_profiling:
    enabled: true
```

Check that profiles for core and process agents are available, and include all profile types.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
