### PR TITLE
pkg/trace/sampler: add an LRU for the service catalog

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -156,6 +156,7 @@
 /pkg/collector/corechecks/systemd/      @DataDog/agent-integrations
 /pkg/collector/corechecks/nvidia/       @DataDog/agent-platform
 /pkg/config/config_template.yaml        @DataDog/agent-all @DataDog/documentation
+/pkg/config/apm.go                      @DataDog/agent-apm
 /pkg/tagger/                            @DataDog/container-integrations
 /pkg/tagger/collectors/garden*.go       @DataDog/integrations-tools-and-libraries
 /pkg/util/cloudfoundry/                 @DataDog/integrations-tools-and-libraries

--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -58,6 +58,7 @@ func setupAPM(config Config) {
 	config.BindEnvAndSetDefault("apm_config.windows_pipe_security_descriptor", "D:AI(A;;GA;;;WD)", "DD_APM_WINDOWS_PIPE_SECURITY_DESCRIPTOR") //nolint:errcheck
 	config.BindEnvAndSetDefault("apm_config.remote_tagger", false, "DD_APM_REMOTE_TAGGER")                                                    //nolint:errcheck
 
+	config.BindEnv("apm_config.max_catalog_services", "DD_APM_MAX_CATALOG_SERVICES")                     //nolint:errcheck
 	config.BindEnv("apm_config.receiver_timeout", "DD_APM_RECEIVER_TIMEOUT")                             //nolint:errcheck
 	config.BindEnv("apm_config.max_payload_size", "DD_APM_MAX_PAYLOAD_SIZE")                             //nolint:errcheck
 	config.BindEnv("apm_config.log_file", "DD_APM_LOG_FILE")                                             //nolint:errcheck

--- a/pkg/trace/sampler/catalog.go
+++ b/pkg/trace/sampler/catalog.go
@@ -9,6 +9,7 @@ import (
 	"container/list"
 	"sync"
 
+	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -35,10 +36,14 @@ type catalogEntry struct {
 
 // newServiceLookup returns a new serviceKeyCatalog.
 func newServiceLookup() *serviceKeyCatalog {
+	entries := maxCatalogEntries
+	if v := coreconfig.Datadog.GetInt("apm_config.max_catalog_entries"); v > 0 {
+		entries = v
+	}
 	return &serviceKeyCatalog{
 		items:      make(map[ServiceSignature]*list.Element),
 		ll:         list.New(),
-		maxEntries: maxCatalogEntries,
+		maxEntries: entries,
 	}
 }
 

--- a/pkg/trace/sampler/catalog.go
+++ b/pkg/trace/sampler/catalog.go
@@ -9,7 +9,7 @@ import (
 	"container/list"
 	"sync"
 
-	"github.com/DataDog/datadog-agent/pkg/security/log"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // defaultServiceRateKey specifies the key for the default rate to be used by any service that

--- a/pkg/trace/sampler/catalog.go
+++ b/pkg/trace/sampler/catalog.go
@@ -5,29 +5,58 @@
 
 package sampler
 
-import "sync"
+import (
+	"container/list"
+	"sync"
 
+	"github.com/DataDog/datadog-agent/pkg/security/log"
+)
+
+// defaultServiceRateKey specifies the key for the default rate to be used by any service that
+// doesn't have a rate specified.
 const defaultServiceRateKey = "service:,env:"
+
+// maxCatalogEntries specifies the maximum number of entries allowed in the catalog.
+const maxCatalogEntries = 5000 // 5000 is the maximum (service,env) combination in the backend.
 
 // serviceKeyCatalog reverse-maps service signatures to their generated hashes for
 // easy look up.
 type serviceKeyCatalog struct {
-	mu     sync.Mutex
-	lookup map[ServiceSignature]Signature
+	mu         sync.Mutex
+	items      map[ServiceSignature]*list.Element
+	ll         *list.List
+	maxEntries int
+}
+
+type catalogEntry struct {
+	key ServiceSignature
+	sig Signature
 }
 
 // newServiceLookup returns a new serviceKeyCatalog.
 func newServiceLookup() *serviceKeyCatalog {
 	return &serviceKeyCatalog{
-		lookup: make(map[ServiceSignature]Signature),
+		items:      make(map[ServiceSignature]*list.Element),
+		ll:         list.New(),
+		maxEntries: maxCatalogEntries,
 	}
 }
 
 func (cat *serviceKeyCatalog) register(svcSig ServiceSignature) Signature {
-	hash := svcSig.Hash()
 	cat.mu.Lock()
-	cat.lookup[svcSig] = hash
-	cat.mu.Unlock()
+	defer cat.mu.Unlock()
+	if el, ok := cat.items[svcSig]; ok {
+		cat.ll.MoveToFront(el)
+		return el.Value.(catalogEntry).sig
+	}
+	hash := svcSig.Hash()
+	el := cat.ll.PushFront(catalogEntry{key: svcSig, sig: hash})
+	cat.items[svcSig] = el
+	if cat.ll.Len() > cat.maxEntries {
+		del := cat.ll.Remove(cat.ll.Back()).(catalogEntry)
+		delete(cat.items, del.key)
+		log.Warnf("More than %d services in service-rates catalog. Dropping %v.", cat.maxEntries, del.key)
+	}
 	return hash
 }
 
@@ -37,11 +66,13 @@ func (cat *serviceKeyCatalog) ratesByService(rates map[Signature]float64, totalS
 	rbs := make(map[ServiceSignature]float64, len(rates)+1)
 	cat.mu.Lock()
 	defer cat.mu.Unlock()
-	for key, sig := range cat.lookup {
+	for key, el := range cat.items {
+		sig := el.Value.(catalogEntry).sig
 		if rate, ok := rates[sig]; ok {
 			rbs[key] = rate
 		} else {
-			delete(cat.lookup, key)
+			cat.ll.Remove(el)
+			delete(cat.items, key)
 		}
 	}
 	rbs[ServiceSignature{}] = totalScore

--- a/pkg/trace/sampler/catalog_test.go
+++ b/pkg/trace/sampler/catalog_test.go
@@ -6,6 +6,8 @@
 package sampler
 
 import (
+	"math"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -166,4 +168,30 @@ func TestServiceKeyCatalogRatesByService(t *testing.T) {
 	assert.Equal(map[ServiceSignature]float64{
 		{}: 0.2,
 	}, rateByService)
+}
+
+func BenchmarkServiceKeyCatalog(b *testing.B) {
+	b.ReportAllocs()
+
+	b.Run("new", func(b *testing.B) {
+		x := 1
+		cat := newServiceLookup()
+		cat.maxEntries = math.MaxInt16
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			x *= 2
+			ss := ServiceSignature{Name: strconv.Itoa(x), Env: strconv.Itoa(x)}
+			cat.register(ss)
+		}
+	})
+
+	b.Run("same", func(b *testing.B) {
+		cat := newServiceLookup()
+		cat.maxEntries = math.MaxInt16
+		ss := ServiceSignature{Name: "sql-db", Env: "staging"}
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			cat.register(ss)
+		}
+	})
 }

--- a/pkg/trace/sampler/catalog_test.go
+++ b/pkg/trace/sampler/catalog_test.go
@@ -52,33 +52,80 @@ func TestServiceSignatureString(t *testing.T) {
 
 func TestNewServiceLookup(t *testing.T) {
 	cat := newServiceLookup()
-	assert.NotNil(t, cat.lookup)
+	assert.NotNil(t, cat.items)
+	assert.NotNil(t, cat.ll)
 }
 
 func TestServiceKeyCatalogRegister(t *testing.T) {
-	assert := assert.New(t)
-
 	cat := newServiceLookup()
 	s := getTestPrioritySampler()
 
 	_, root1 := getTestTraceWithService(t, "service1", s)
 	sig1 := cat.register(ServiceSignature{root1.Service, defaultEnv})
-	assert.Equal(
-		map[ServiceSignature]Signature{
-			{"service1", "none"}: sig1,
-		},
-		cat.lookup,
-	)
+	catalogContains(t, cat, map[ServiceSignature]Signature{
+		{"service1", "none"}: sig1,
+	})
 
 	_, root2 := getTestTraceWithService(t, "service2", s)
 	sig2 := cat.register(ServiceSignature{root2.Service, defaultEnv})
-	assert.Equal(
-		map[ServiceSignature]Signature{
-			{"service1", "none"}: sig1,
-			{"service2", "none"}: sig2,
-		},
-		cat.lookup,
-	)
+	catalogContains(t, cat, map[ServiceSignature]Signature{
+		{"service1", "none"}: sig1,
+		{"service2", "none"}: sig2,
+	})
+}
+
+func TestServiceKeyCatalogLRU(t *testing.T) {
+	t.Run("size", func(t *testing.T) {
+		cat := newServiceLookup()
+		cat.maxEntries = 3
+		_ = cat.register(ServiceSignature{"service1", "env1"})
+		sig2 := cat.register(ServiceSignature{"service2", "env2"})
+		sig3 := cat.register(ServiceSignature{"service3", "env3"})
+		sig4 := cat.register(ServiceSignature{"service4", "env4"})
+		catalogContains(t, cat, map[ServiceSignature]Signature{
+			{"service2", "env2"}: sig2,
+			{"service3", "env3"}: sig3,
+			{"service4", "env4"}: sig4,
+		})
+		sig5 := cat.register(ServiceSignature{"service5", "env5"})
+		catalogContains(t, cat, map[ServiceSignature]Signature{
+			{"service3", "env3"}: sig3,
+			{"service4", "env4"}: sig4,
+			{"service5", "env5"}: sig5,
+		})
+	})
+
+	t.Run("move", func(t *testing.T) {
+		cat := newServiceLookup()
+		cat.maxEntries = 3
+		sig1 := cat.register(ServiceSignature{"service1", "env1"})
+		_ = cat.register(ServiceSignature{"service2", "env2"})
+		sig3 := cat.register(ServiceSignature{"service3", "env3"})
+		cat.register(ServiceSignature{"service1", "env1"}) // sig1 is moved, so 2 will be out
+		sig4 := cat.register(ServiceSignature{"service4", "env4"})
+		catalogContains(t, cat, map[ServiceSignature]Signature{
+			{"service1", "env1"}: sig1,
+			{"service3", "env3"}: sig3,
+			{"service4", "env4"}: sig4,
+		})
+	})
+}
+
+func catalogContains(t *testing.T, cat *serviceKeyCatalog, has map[ServiceSignature]Signature) {
+	assert := assert.New(t)
+	assert.Len(cat.items, len(has), "too many items in map")
+	assert.Equal(len(has), cat.ll.Len(), "too many elements in list")
+	for el := cat.ll.Back(); el != nil; el = el.Prev() {
+		key := el.Value.(catalogEntry).key
+		if _, ok := has[key]; !ok {
+			t.Fatalf("Foreign item in list: %s", key)
+			return
+		}
+		if _, ok := cat.items[key]; !ok {
+			t.Fatalf("Foreign item in map: %s", key)
+			return
+		}
+	}
 }
 
 func TestServiceKeyCatalogRatesByService(t *testing.T) {

--- a/releasenotes/notes/apm-service-catalog-limit-5000-fed8029e69a96db5.yaml
+++ b/releasenotes/notes/apm-service-catalog-limit-5000-fed8029e69a96db5.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: The priority sampler service catalog is no longer unbounded. It is now limited to 5000 service & env combinations.


### PR DESCRIPTION
This change makes the service catalog an LRU cache with a maximum
entries of 5000.  Configurable via `"apm_config.max_catalog_services", "DD_APM_MAX_CATALOG_SERVICES"`