### PR TITLE
Store HTTP latencies as nanoseconds represented by float64

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	code.cloudfoundry.org/rep v0.0.0-20200325195957-1404b978e31e // indirect
 	code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a // indirect
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
-	github.com/DataDog/agent-payload v4.76.0+incompatible
+	github.com/DataDog/agent-payload v4.77.0+incompatible
 	github.com/DataDog/datadog-agent/pkg/util/log v0.29.0-rc.6
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.29.0-rc.6
 	github.com/DataDog/datadog-go v4.8.0+incompatible

--- a/go.sum
+++ b/go.sum
@@ -108,6 +108,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802 h1:1BDTz0u9nC3//pOC
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DataDog/agent-payload v4.76.0+incompatible h1:fcejmqcFJW2A9lbiX8haOOpUI7IiHhaEL7Hna/uU2Dw=
 github.com/DataDog/agent-payload v4.76.0+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
+github.com/DataDog/agent-payload v4.77.0+incompatible h1:APKtqRHGNGVeDmnRadvO7z0cB6zbc5vxkGh5iRDBDc0=
+github.com/DataDog/agent-payload v4.77.0+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/DataDog/datadog-api-client-go v1.0.0-beta.18 h1:4i51yRTWm8SEuc9iRxxFicm59jQcAo70v+3ddZhEq8Q=

--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -479,7 +479,7 @@ func verifyQuantile(t *testing.T, sketch *ddsketch.DDSketch, q float64, expected
 	val, err := sketch.GetValueAtQuantile(q)
 	assert.Nil(t, err)
 
-	acceptableError := expectedValue * http.RelativeAccuracy
+	acceptableError := expectedValue * sketch.IndexMapping.RelativeAccuracy()
 	assert.True(t, val >= expectedValue-acceptableError)
 	assert.True(t, val <= expectedValue+acceptableError)
 }

--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -180,7 +180,7 @@ func FormatHTTPStats(httpData map[http.Key]http.RequestStats) map[http.Key]*mode
 				blob, _ := proto.Marshal(latencies.ToProto())
 				data.Latencies = blob
 			} else {
-				data.FirstLatencySample = uint64(stats[i].FirstLatencySample)
+				data.FirstLatencySample = stats[i].FirstLatencySample
 			}
 		}
 

--- a/pkg/network/http/http_statkeeper_test.go
+++ b/pkg/network/http/http_statkeeper_test.go
@@ -28,7 +28,7 @@ func TestProcessHTTPTransactions(t *testing.T) {
 
 		for j := 0; j < 10; j++ {
 			statusCode := (j%5 + 1) * 100
-			latency := time.Duration(j%5) * time.Second
+			latency := time.Duration(j%5) * time.Millisecond
 			txs[i*10+j] = generateIPv4HTTPTransaction(sourceIP, destIP, sourcePort, destPort, path, statusCode, latency)
 		}
 	}
@@ -47,7 +47,7 @@ func TestProcessHTTPTransactions(t *testing.T) {
 			p50, err := stats[i].Latencies.GetValueAtQuantile(0.5)
 			assert.Nil(t, err)
 
-			expectedLatency := float64(i)
+			expectedLatency := float64(time.Duration(i) * time.Millisecond)
 			acceptableError := expectedLatency * stats[i].Latencies.IndexMapping.RelativeAccuracy()
 			assert.True(t, p50 >= expectedLatency-acceptableError)
 			assert.True(t, p50 <= expectedLatency+acceptableError)

--- a/pkg/network/http/http_statkeeper_test.go
+++ b/pkg/network/http/http_statkeeper_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/stretchr/testify/assert"
@@ -27,7 +28,7 @@ func TestProcessHTTPTransactions(t *testing.T) {
 
 		for j := 0; j < 10; j++ {
 			statusCode := (j%5 + 1) * 100
-			latency := float64(j % 5)
+			latency := time.Duration(j%5) * time.Second
 			txs[i*10+j] = generateIPv4HTTPTransaction(sourceIP, destIP, sourcePort, destPort, path, statusCode, latency)
 		}
 	}
@@ -47,18 +48,18 @@ func TestProcessHTTPTransactions(t *testing.T) {
 			assert.Nil(t, err)
 
 			expectedLatency := float64(i)
-			acceptableError := expectedLatency * RelativeAccuracy
+			acceptableError := expectedLatency * stats[i].Latencies.IndexMapping.RelativeAccuracy()
 			assert.True(t, p50 >= expectedLatency-acceptableError)
 			assert.True(t, p50 <= expectedLatency+acceptableError)
 		}
 	}
 }
 
-func generateIPv4HTTPTransaction(source util.Address, dest util.Address, sourcePort int, destPort int, path string, code int, latency float64) httpTX {
+func generateIPv4HTTPTransaction(source util.Address, dest util.Address, sourcePort int, destPort int, path string, code int, latency time.Duration) httpTX {
 	var tx httpTX
 
 	reqFragment := fmt.Sprintf("GET %s HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0", path)
-	latencyNS := _Ctype_ulonglong(latency * 1000.0) // microseconds to ns
+	latencyNS := _Ctype_ulonglong(uint64(latency))
 	tx.request_started = 1
 	tx.response_last_seen = tx.request_started + latencyNS
 	tx.response_status_code = _Ctype_ushort(code)
@@ -81,7 +82,7 @@ func BenchmarkProcessSameConn(b *testing.B) {
 		8080,
 		"foobar",
 		404,
-		float64(30000),
+		30*time.Millisecond,
 	)
 	transactions := []httpTX{tx}
 

--- a/pkg/network/http/http_stats.go
+++ b/pkg/network/http/http_stats.go
@@ -4,22 +4,15 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/sketches-go/ddsketch"
-	"github.com/DataDog/sketches-go/ddsketch/mapping"
-	"github.com/DataDog/sketches-go/ddsketch/store"
 )
 
 // Method is the type used to represent HTTP request methods
 type Method int
 
-const (
-	// maxNumBins is the maximum number of bins of the ddSketch we use to store percentiles.
-	// It can affect relative accuracy, but in practice, 2048 bins is enough to have 1% relative accuracy from
-	// 80 micro second to 1 year: http://www.vldb.org/pvldb/vol12/p2195-masson.pdf
-	maxNumBins = 2048
-	// bias and gamma are DDSketch parameters. We should use the same as in the backend to avoid conversions that affect accuracy.
-	bias  = 1338.5
-	gamma = 1.015625
-)
+// RelativeAccuracy defines the acceptable error in quantile values calculated by DDSketch.
+// For example, if the actual value at p50 is 100, with a relative accuracy of 0.01 the value calculated
+// will be between 99 and 101
+const RelativeAccuracy = 0.01
 
 const (
 	// MethodUnknown represents an unknown request method
@@ -104,7 +97,7 @@ type RequestStats [NumStatusClasses]struct {
 	Count     int
 	Latencies *ddsketch.DDSketch
 
-	// This field holds the value (in seconds) of the first HTTP request
+	// This field holds the value (in nanoseconds) of the first HTTP request
 	// in this bucket. We do this as optimization to avoid creating sketches with
 	// a single value. This is quite common in the context of HTTP requests without
 	// keep-alives where a short-lived TCP connection is used for a single request.
@@ -187,11 +180,7 @@ func (r *RequestStats) AddRequest(statusClass int, latency float64) {
 }
 
 func (r *RequestStats) initSketch(i int) (err error) {
-	m, err := mapping.NewLogarithmicMappingWithGamma(gamma, bias)
-	if err != nil {
-		log.Errorf("Error when creating ddsketch: %v", err)
-	}
-	r[i].Latencies = ddsketch.NewDDSketch(m, store.NewCollapsingLowestDenseStore(maxNumBins), store.NewCollapsingLowestDenseStore(maxNumBins))
+	r[i].Latencies, err = ddsketch.NewDefaultDDSketch(RelativeAccuracy)
 	if err != nil {
 		log.Debugf("error recording http transaction latency: could not create new ddsketch: %v", err)
 	}

--- a/pkg/network/http/http_stats_test.go
+++ b/pkg/network/http/http_stats_test.go
@@ -63,7 +63,7 @@ func verifyQuantile(t *testing.T, sketch *ddsketch.DDSketch, q float64, expected
 	val, err := sketch.GetValueAtQuantile(q)
 	assert.Nil(t, err)
 
-	acceptableError := expectedValue * RelativeAccuracy
+	acceptableError := expectedValue * sketch.IndexMapping.RelativeAccuracy()
 	assert.True(t, val >= expectedValue-acceptableError)
 	assert.True(t, val <= expectedValue+acceptableError)
 }

--- a/pkg/network/http/model.go
+++ b/pkg/network/http/model.go
@@ -3,7 +3,6 @@
 package http
 
 import (
-	"time"
 	"unsafe"
 )
 
@@ -63,9 +62,9 @@ func (tx *httpTX) StatusClass() int {
 	return (int(tx.response_status_code) / 100) * 100
 }
 
-// RequestLatency returns the latency of the request in seconds
+// RequestLatency returns the latency of the request in nanoseconds
 func (tx *httpTX) RequestLatency() float64 {
-	return float64(tx.response_last_seen-tx.request_started) / float64(time.Second)
+	return nsTimestampToFloat(uint64(tx.response_last_seen - tx.request_started))
 }
 
 // Incomplete returns true if the transaction contains only the request or response information
@@ -85,4 +84,18 @@ func (batch *httpBatch) IsDirty(notification httpNotification) bool {
 // Transactions returns the slice of HTTP transactions embedded in the batch
 func (batch *httpBatch) Transactions() []httpTX {
 	return (*(*[HTTPBatchSize]httpTX)(unsafe.Pointer(&batch.txs)))[:]
+}
+
+// below is copied from pkg/trace/stats/statsraw.go
+// 10 bits precision (any value will be +/- 1/1024)
+const roundMask uint64 = 1 << 10
+
+// nsTimestampToFloat converts a nanosec timestamp into a float nanosecond timestamp truncated to a fixed precision
+func nsTimestampToFloat(ns uint64) float64 {
+	var shift uint
+	for ns > roundMask {
+		ns = ns >> 1
+		shift++
+	}
+	return float64(ns << shift)
 }

--- a/pkg/network/http/model.go
+++ b/pkg/network/http/model.go
@@ -3,6 +3,7 @@
 package http
 
 import (
+	"time"
 	"unsafe"
 )
 
@@ -62,9 +63,9 @@ func (tx *httpTX) StatusClass() int {
 	return (int(tx.response_status_code) / 100) * 100
 }
 
-// RequestLatency returns the latency of the request in microseconds
+// RequestLatency returns the latency of the request in seconds
 func (tx *httpTX) RequestLatency() float64 {
-	return float64((tx.response_last_seen - tx.request_started) / (1000))
+	return float64(uint64(tx.response_last_seen-tx.request_started) / uint64(time.Second))
 }
 
 // Incomplete returns true if the transaction contains only the request or response information

--- a/pkg/network/http/model.go
+++ b/pkg/network/http/model.go
@@ -65,7 +65,7 @@ func (tx *httpTX) StatusClass() int {
 
 // RequestLatency returns the latency of the request in seconds
 func (tx *httpTX) RequestLatency() float64 {
-	return float64(uint64(tx.response_last_seen-tx.request_started) / uint64(time.Second))
+	return float64(tx.response_last_seen-tx.request_started) / float64(time.Second)
 }
 
 // Incomplete returns true if the transaction contains only the request or response information

--- a/pkg/network/http/model_test.go
+++ b/pkg/network/http/model_test.go
@@ -20,6 +20,14 @@ func TestPath(t *testing.T) {
 	assert.Equal(t, "/foo/bar", string(tx.Path(b)))
 }
 
+func TestLatency(t *testing.T) {
+	tx := httpTX{
+		response_last_seen: 2e6,
+		request_started:    1e6,
+	}
+	assert.Equal(t, 0.001, tx.RequestLatency())
+}
+
 func BenchmarkPath(b *testing.B) {
 	tx := httpTX{
 		request_fragment: requestFragment(

--- a/pkg/network/http/model_test.go
+++ b/pkg/network/http/model_test.go
@@ -25,7 +25,8 @@ func TestLatency(t *testing.T) {
 		response_last_seen: 2e6,
 		request_started:    1e6,
 	}
-	assert.Equal(t, 0.001, tx.RequestLatency())
+	// quantization brings it down
+	assert.Equal(t, 999424.0, tx.RequestLatency())
 }
 
 func BenchmarkPath(b *testing.B) {


### PR DESCRIPTION
### What does this PR do?

APM requested we store the HTTP latencies in the sketches as nanoseconds. We are also using the same quantization code to prevent excess bucketing.

### Motivation

Reduce conversion error when converting sketch latencies.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.

