### PR TITLE
[SB] Add `readsecret.sh` to core Agent

### DIFF
--- a/Dockerfiles/agent/amd64/Dockerfile
+++ b/Dockerfiles/agent/amd64/Dockerfile
@@ -131,7 +131,7 @@ COPY --from=extract /output/ /
 # S6 entrypoint, service definitions, healthcheck probe
 COPY s6-services /etc/services.d/
 COPY cont-init.d /etc/cont-init.d/
-COPY probe.sh initlog.sh secrets-helper/readsecret.py /
+COPY probe.sh initlog.sh secrets-helper/readsecret.py secrets-helper/readsecret.sh /
 
 # Extract s6-overlay
 #
@@ -154,7 +154,9 @@ RUN tar xzf s6.tgz -C / --exclude="./bin" \
  && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ \
  && chmod 755 /probe.sh /initlog.sh \
  && chown root:root /readsecret.py \
- && chmod 500 /readsecret.py
+ && chmod 500 /readsecret.py \
+ && chown root:root /readsecret.sh \
+ && chmod 500 /readsecret.sh
 
 # Update links to python binaries
 

--- a/Dockerfiles/agent/arm64/Dockerfile
+++ b/Dockerfiles/agent/arm64/Dockerfile
@@ -131,7 +131,7 @@ COPY --from=extract /output/ /
 # S6 entrypoint, service definitions, healthcheck probe
 COPY s6-services /etc/services.d/
 COPY cont-init.d /etc/cont-init.d/
-COPY probe.sh initlog.sh secrets-helper/readsecret.py /
+COPY probe.sh initlog.sh secrets-helper/readsecret.py secrets-helper/readsecret.sh /
 
 # Extract s6-overlay
 #
@@ -154,7 +154,9 @@ RUN tar xzf s6.tgz -C / --exclude="./bin" \
  && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ \
  && chmod 755 /probe.sh /initlog.sh \
  && chown root:root /readsecret.py \
- && chmod 500 /readsecret.py
+ && chmod 500 /readsecret.py \
+ && chown root:root /readsecret.sh \
+ && chmod 500 /readsecret.sh
 
 # Update links to python binaries
 

--- a/Dockerfiles/agent/secrets-helper/README.md
+++ b/Dockerfiles/agent/secrets-helper/README.md
@@ -5,6 +5,8 @@ Many of our integrations require credentials to retrieve metrics. To avoid hardc
 This script is available in the docker image as `/readsecret.py` and is intended
 to be used with [the agent's external secret feature](https://github.com/DataDog/datadog-agent/blob/6.4.x/docs/agent/secrets.md). Please refer to this feature's documentation for usage examples.
 
+**Note:** Starting with Agent version 7.30.0, another script `/readsecret.sh` written in `Go` is also available and can be used instead of `/readsecret.py`. We recommend using `/readsecret.sh` as it's faster.
+
 ## Script usage
 
 - The script requires a folder passed as argument. Secret handles will be interpreted as file names, relative to this folder. The script will refuse to access any file out of this root folder (including symbolic link targets), in order to avoid leaking sensitive information.
@@ -19,7 +21,7 @@ to be used with [the agent's external secret feature](https://github.com/DataDog
 
 [Docker secrets](https://docs.docker.com/engine/swarm/secrets/) are mounted in the `/run/secrets` folder. You need to pass the following environment variables to your agent container:
 
-- `DD_SECRET_BACKEND_COMMAND=/readsecret.py`
+- `DD_SECRET_BACKEND_COMMAND=/readsecret.py` (or `DD_SECRET_BACKEND_COMMAND=/readsecret.sh`)
 - `DD_SECRET_BACKEND_ARGUMENTS=/run/secrets`
 
 To use the `db_prod_password` secret value, exposed in the `/run/secrets/db_prod_password` file, just insert `ENC[db_prod_password]` in your template.
@@ -30,7 +32,7 @@ Kubernetes supports [exposing secrets as files](https://kubernetes.io/docs/tasks
 
 If your secrets are mounted in `/etc/secret-volume`, just use the following environment variables:
 
-- `DD_SECRET_BACKEND_COMMAND=/readsecret.py`
+- `DD_SECRET_BACKEND_COMMAND=/readsecret.py` (or `DD_SECRET_BACKEND_COMMAND=/readsecret.sh`)
 - `DD_SECRET_BACKEND_ARGUMENTS=/etc/secret-volume`
 
 Following the linked example, the password field will be stored in the `/etc/secret-volume/password` file, and accessible via the `ENC[password]` token.

--- a/Dockerfiles/agent/secrets-helper/readsecret.sh
+++ b/Dockerfiles/agent/secrets-helper/readsecret.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2016-present Datadog, Inc.
+
+/opt/datadog-agent/bin/agent/agent secret-helper read $@

--- a/cmd/agent/app/secret_helper.go
+++ b/cmd/agent/app/secret_helper.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build secrets
+
+package app
+
+import (
+	"github.com/DataDog/datadog-agent/cmd/secrets"
+)
+
+func init() {
+	AgentCmd.AddCommand(secrets.SecretHelperCmd)
+}

--- a/releasenotes/notes/support-readsecret-sh-75bddd76f73e950d.yaml
+++ b/releasenotes/notes/support-readsecret-sh-75bddd76f73e950d.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    In addition to the existing ``/readsecret.py`` script, the Agent container image
+    contains another secret helper script ``/readsecret.sh``, faster and more reliable.


### PR DESCRIPTION
### What does this PR do?

Support `readsecret.sh` in the core agent. (Previously only supported by the cluster agent)

### Motivation

The python script is very slow at startup and the secret backend timeout can be hit in some cases. `readsecret.sh` is more reliable.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Follow the same instructions documented [here](https://docs.datadoghq.com/agent/guide/secrets-management/?tab=linux#kubernetes-secrets), just replace `DD_SECRET_BACKEND_COMMAND=/readsecret.py` by `DD_SECRET_BACKEND_COMMAND=/readsecret.sh`

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
