### PR TITLE
Move Linux kitchen tests from US North to other regions

### DIFF
--- a/.gitlab/kitchen_common/testing.yml
+++ b/.gitlab/kitchen_common/testing.yml
@@ -174,10 +174,10 @@
   extends:
     - .kitchen_test_upgrade7
     - .kitchen_datadog_agent_flavor
-    - .kitchen_azure_location_north_central_us
+    - .kitchen_azure_location_west_central_us
 
 .kitchen_test_upgrade7_iot_agent:
   extends:
     - .kitchen_test_upgrade7
     - .kitchen_datadog_iot_agent_flavor
-    - .kitchen_azure_location_north_central_us
+    - .kitchen_azure_location_south_central_us


### PR DESCRIPTION
### Motivation

This is a workaround. In US North Azure VMs, `sudo` complains with:

```
sudo: unable to resolve host dd-agent-testing-debian-10-azure: Name or service not known
```

Which breaks our parsing of the agent status because we call `sudo datadog-agent status -j 2>&1`

The better fix would be to not redirect stderr to stdout on that command.

