### PR TITLE
[runtime-security] add agent version to event log

### DIFF
--- a/pkg/security/module/event.go
+++ b/pkg/security/module/event.go
@@ -11,9 +11,9 @@ package module
 // easyjson:json
 type AgentContext struct {
 	RuleID        string `json:"rule_id"`
-	RuleVersion   string `json:"rule_version,omitempty"`
 	PolicyName    string `json:"policy_name,omitempty"`
 	PolicyVersion string `json:"policy_version,omitempty"`
+	Version       string `json:"version,omitempty"`
 }
 
 // Signal - Rule event wrapper used to send an event to the backend

--- a/pkg/security/module/event_easyjson.go
+++ b/pkg/security/module/event_easyjson.go
@@ -124,12 +124,12 @@ func easyjsonF642ad3eDecodeGithubComDataDogDatadogAgentPkgSecurityModule1(in *jl
 		switch key {
 		case "rule_id":
 			out.RuleID = string(in.String())
-		case "rule_version":
-			out.RuleVersion = string(in.String())
 		case "policy_name":
 			out.PolicyName = string(in.String())
 		case "policy_version":
 			out.PolicyVersion = string(in.String())
+		case "version":
+			out.Version = string(in.String())
 		default:
 			in.SkipRecursive()
 		}
@@ -149,11 +149,6 @@ func easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgSecurityModule1(out *j
 		out.RawString(prefix[1:])
 		out.String(string(in.RuleID))
 	}
-	if in.RuleVersion != "" {
-		const prefix string = ",\"rule_version\":"
-		out.RawString(prefix)
-		out.String(string(in.RuleVersion))
-	}
 	if in.PolicyName != "" {
 		const prefix string = ",\"policy_name\":"
 		out.RawString(prefix)
@@ -163,6 +158,11 @@ func easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgSecurityModule1(out *j
 		const prefix string = ",\"policy_version\":"
 		out.RawString(prefix)
 		out.String(string(in.PolicyVersion))
+	}
+	if in.Version != "" {
+		const prefix string = ",\"version\":"
+		out.RawString(prefix)
+		out.String(string(in.Version))
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -26,6 +26,7 @@ import (
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 type pendingMsg struct {
@@ -206,8 +207,8 @@ func (a *APIServer) GetConfig(ctx context.Context, params *api.GetConfigParams) 
 // SendEvent forwards events sent by the runtime security module to Datadog
 func (a *APIServer) SendEvent(rule *rules.Rule, event Event, extTagsCb func() []string) {
 	agentContext := &AgentContext{
-		RuleID:      rule.Definition.ID,
-		RuleVersion: rule.Definition.Version,
+		RuleID:  rule.Definition.ID,
+		Version: version.AgentVersion,
 	}
 
 	ruleEvent := &Signal{

--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -222,7 +222,6 @@ func NewRuleSetLoadedEvent(rs *rules.RuleSet, err *multierror.Error) (*rules.Rul
 		}
 		policy.RulesLoaded = append(policy.RulesLoaded, &RuleLoaded{
 			ID:         rule.ID,
-			Version:    rule.Definition.Version,
 			Expression: rule.Definition.Expression,
 		})
 	}
@@ -239,7 +238,6 @@ func NewRuleSetLoadedEvent(rs *rules.RuleSet, err *multierror.Error) (*rules.Rul
 				}
 				policy.RulesIgnored = append(policy.RulesIgnored, &RuleIgnored{
 					ID:         rerr.Definition.ID,
-					Version:    rerr.Definition.Version,
 					Expression: rerr.Definition.Expression,
 					Reason:     rerr.Err.Error(),
 				})

--- a/pkg/security/rules/ruleset.go
+++ b/pkg/security/rules/ruleset.go
@@ -21,7 +21,6 @@ type MacroID = string
 // MacroDefinition holds the definition of a macro
 type MacroDefinition struct {
 	ID         MacroID `yaml:"id"`
-	Version    string  `yaml:"version"`
 	Expression string  `yaml:"expression"`
 }
 
@@ -37,7 +36,6 @@ type RuleID = string
 // RuleDefinition holds the definition of a rule
 type RuleDefinition struct {
 	ID          RuleID            `yaml:"id"`
-	Version     string            `yaml:"version"`
 	Expression  string            `yaml:"expression"`
 	Description string            `yaml:"description"`
 	Tags        map[string]string `yaml:"tags"`


### PR DESCRIPTION
### What does this PR do?

Add agent as part of the agent context attached to logs.

### Motivation

This will ease the identification of what agent triggered which rules.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
