### PR TITLE
[circleci] address python linting issue adding env vars

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -189,6 +189,11 @@ jobs:
       - restore_cache: *restore_source
       - restore_cache: *restore_deps
       - run:
+          name: setting env vars for click
+          command: |
+              echo 'export LC_ALL="C.UTF-8"' >> $BASH_ENV
+              echo 'export LANG="C.UTF-8"' >> $BASH_ENV
+      - run:
           name: lint python files
           command: inv -e lint-python
 
@@ -320,7 +325,7 @@ workflows:
       - release_note:
           filters:
             branches:
-              ignore: 
+              ignore:
                 - master
                 - main
           requires:
@@ -328,7 +333,7 @@ workflows:
       - team_label:
           filters:
             branches:
-              ignore: 
+              ignore:
                 - master
                 - main
           requires:
@@ -336,7 +341,7 @@ workflows:
       - milestone:
           filters:
             branches:
-              ignore: 
+              ignore:
                 - master
                 - main
           requires:


### PR DESCRIPTION
### What does this PR do?

Python linting is failing due to a change on CircleCI builders now requiring env vars to be set for click to properly operate (that or click was unpinned), after SSH'ing into the box, setting the env vars indeed fixes the problem, so let's do that. Either way, if we bump to click in the future, or if the change is permanent in the builders this appears to be a change that makes sense to make permanent.

### Motivation

Broken CI builds.

### Additional Notes

(nothing)

### Describe how to test your changes

Green python-lint stage in CircleCI should validate the fix.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
