### PR TITLE
[backport] Move Linux kitchen tests from US North to other regions

### DIFF
--- a/.gitlab/kitchen_common/testing.yml
+++ b/.gitlab/kitchen_common/testing.yml
@@ -187,10 +187,10 @@
   extends:
     - .kitchen_test_upgrade7
     - .kitchen_datadog_agent_flavor
-    - .kitchen_azure_location_north_central_us
+    - .kitchen_azure_location_west_central_us
 
 .kitchen_test_upgrade7_iot_agent:
   extends:
     - .kitchen_test_upgrade7
     - .kitchen_datadog_iot_agent_flavor
-    - .kitchen_azure_location_north_central_us
+    - .kitchen_azure_location_south_central_us


### PR DESCRIPTION

### What does this PR do?

Backport of #8567.

This is a workaround. In US North Azure VMs, sudo complains with:

`sudo: unable to resolve host <hostname>: Name or service not known`

Which breaks our parsing of the agent status because we call `sudo datadog-agent status -j 2>&1`

The better fix would be to not redirect stderr to stdout.

### Motivation

Fix 7.29.1 release pipelines.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
