### PR TITLE
[corechecks/snmp] Set default oid_batch_size to 5

### DIFF
--- a/pkg/collector/corechecks/snmp/config.go
+++ b/pkg/collector/corechecks/snmp/config.go
@@ -13,7 +13,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-var defaultOidBatchSize = 60
+// Python snmp integration is using oid_batch_size=10 as default.
+// Using high oid batch size might lead to snmp calls timing out.
+// For some devices, the default oid_batch_size of 10 might be high (leads to timeouts),
+// and require manual setting oid_batch_size to a lower value e.g. 1 or 5
+var defaultOidBatchSize = 10
+
 var defaultPort = uint16(161)
 var defaultRetries = 3
 var defaultTimeout = 2

--- a/pkg/collector/corechecks/snmp/config.go
+++ b/pkg/collector/corechecks/snmp/config.go
@@ -13,11 +13,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// Python snmp integration is using oid_batch_size=10 as default.
 // Using high oid batch size might lead to snmp calls timing out.
-// For some devices, the default oid_batch_size of 10 might be high (leads to timeouts),
-// and require manual setting oid_batch_size to a lower value e.g. 1 or 5
-var defaultOidBatchSize = 10
+// For some devices, the default oid_batch_size of 5 might be high (leads to timeouts),
+// and require manual setting oid_batch_size to a lower value.
+var defaultOidBatchSize = 5
 
 var defaultPort = uint16(161)
 var defaultRetries = 3

--- a/pkg/collector/corechecks/snmp/config_test.go
+++ b/pkg/collector/corechecks/snmp/config_test.go
@@ -293,7 +293,7 @@ community_string: abc
 `)
 	err := check.Configure(rawInstanceConfig, []byte(``), "test")
 	assert.Nil(t, err)
-	assert.Equal(t, 60, check.config.oidBatchSize)
+	assert.Equal(t, 5, check.config.oidBatchSize)
 
 	// TEST Instance config batch size
 	check = Check{session: &snmpSession{}}

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -318,6 +318,7 @@ func TestProfile(t *testing.T) {
 ip_address: 1.2.3.4
 profile: f5-big-ip
 collect_device_metadata: true
+oid_batch_size: 10
 tags:
   - "mytag:val1"
   - "mytag:val1" # add duplicate tag for testing deduplication
@@ -1049,6 +1050,7 @@ func TestReportDeviceMetadataEvenOnProfileError(t *testing.T) {
 	rawInstanceConfig := []byte(`
 ip_address: 1.2.3.4
 collect_device_metadata: true
+oid_batch_size: 10
 tags:
   - "mytag:val1"
   - "autodiscovery_subnet:127.0.0.0/30"

--- a/releasenotes/notes/snmp_corecheck_update_default_oid_batch_size-7ec7a91efe7f4bfa.yaml
+++ b/releasenotes/notes/snmp_corecheck_update_default_oid_batch_size-7ec7a91efe7f4bfa.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    [corechecks/snmp] Set default oid_batch_size to 5. High oid batch size can lead to timeouts.


### PR DESCRIPTION
### What does this PR do?

Set default oid_batch_size to 5

With this change, GET BULK requests will retrieve at most 50 (5 oid batch size * 10 max rep) OID values per call.
Before this change, GET BULK requests is retrieving at most 600 (60 oid batch size * 10 max rep) OID values per call.

### Motivation

Many users are experiencing timeouts due to snmp calls requesting too many OIDs at time.

### Additional Notes

Lower OID batch size can have some impact on performance, but the impact should be limited since in most cases the devices have some default limit of 64 or 100 OID values per request.

![image](https://user-images.githubusercontent.com/49917914/124885787-ea7baf80-dfd3-11eb-99ef-3b2fe49a682d.png)

Next Step: Investigate about auto adjusting the oid batch size (and bulk max rep)

### Describe how to test your changes

- Run `agent check snmp` with debug log level
- Check that the logs `fetch column: request oids` and `fetch scalar: request oids` have the correct batch size (number of OIDs requested)

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
