### PR TITLE
[system-probe] Terminate gracefully when system-probe is not enabled

### DIFF
--- a/cmd/system-probe/windows/service/service.go
+++ b/cmd/system-probe/windows/service/service.go
@@ -37,6 +37,9 @@ type sysprobeWindowService struct{}
 func (m *sysprobeWindowService) Execute(args []string, r <-chan svc.ChangeRequest, changes chan<- svc.Status) (ssec bool, errno uint32) {
 	const cmdsAccepted = svc.AcceptStop | svc.AcceptShutdown
 	changes <- svc.Status{State: svc.StartPending}
+	defer func() {
+		changes <- svc.Status{State: svc.Stopped}
+	}()
 
 	if err := app.StartSystemProbe(); err != nil {
 		if err == app.ErrNotEnabled {
@@ -47,7 +50,6 @@ func (m *sysprobeWindowService) Execute(args []string, r <-chan svc.ChangeReques
 		log.Errorf("Failed to start system-probe %v", err)
 		elog.Error(agentStartFailure, err.Error())
 		errno = 1 // indicates non-successful return from handler.
-		changes <- svc.Status{State: svc.Stopped}
 		return
 	}
 
@@ -88,7 +90,6 @@ loop:
 	log.Infof("Initiating service shutdown")
 	changes <- svc.Status{State: svc.StopPending}
 	app.StopSystemProbe()
-	changes <- svc.Status{State: svc.Stopped}
 	return
 }
 

--- a/cmd/system-probe/windows/service/service.go
+++ b/cmd/system-probe/windows/service/service.go
@@ -39,6 +39,11 @@ func (m *sysprobeWindowService) Execute(args []string, r <-chan svc.ChangeReques
 	changes <- svc.Status{State: svc.StartPending}
 
 	if err := app.StartSystemProbe(); err != nil {
+		if err == ErrNotEnabled {
+			changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
+			return
+		}
+
 		log.Errorf("Failed to start system-probe %v", err)
 		elog.Error(agentStartFailure, err.Error())
 		errno = 1 // indicates non-successful return from handler.

--- a/cmd/system-probe/windows/service/service.go
+++ b/cmd/system-probe/windows/service/service.go
@@ -39,7 +39,7 @@ func (m *sysprobeWindowService) Execute(args []string, r <-chan svc.ChangeReques
 	changes <- svc.Status{State: svc.StartPending}
 
 	if err := app.StartSystemProbe(); err != nil {
-		if err == ErrNotEnabled {
+		if err == app.ErrNotEnabled {
 			changes <- svc.Status{State: svc.Running, Accepts: cmdsAccepted}
 			return
 		}


### PR DESCRIPTION
### What does this PR do?

Properly handle the scenario where system-probe is not enabled. Currently we're doing the following:
* On the Linux version system-probe is currently logging `system probe successfully started` and then hanging (waiting for an OS signal);
* On Windows we're doing a similar thing and waiting from signals from SCM;

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Please perform the following test in both platforms:
1. Install the latest agent
2. Disable all modules from system-probe by editing `sytem-probe.yaml` like the following:
```
system_probe_config:
  enabled: false
network_config:
  enabled: false
```
3. Start system-probe "service", by either doing `sudo service datadog-agent-sysprobe start` or using the Windows Service Panel
4. Validate that system-probe starts, log a message saying it's disabled, and then gracefully terminates.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
