### PR TITLE
Fix missing .node.count metric in KSM Core

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -316,11 +316,6 @@ func (k *KSMCheck) processMetrics(sender aggregator.Sender, metrics map[string][
 				// Some metrics can be aggregated and consumed as-is or by a transformer.
 				// So, let’s continue the processing.
 			}
-			if metadataMetricsRegex.MatchString(metricFamily.Name) {
-				// metadata metrics are only used by the check for label joins
-				// they shouldn't be forwarded to Datadog
-				continue
-			}
 			if transform, found := metricTransformers[metricFamily.Name]; found {
 				for _, m := range metricFamily.ListMetrics {
 					hostname, tags := k.hostnameAndTags(m.Labels, labelJoiner)
@@ -336,6 +331,11 @@ func (k *KSMCheck) processMetrics(sender aggregator.Sender, metrics map[string][
 				continue
 			}
 			if _, found := metricAggregators[metricFamily.Name]; found {
+				continue
+			}
+			if metadataMetricsRegex.MatchString(metricFamily.Name) {
+				// metadata metrics are only used by the check for label joins
+				// they shouldn't be forwarded to Datadog
 				continue
 			}
 			// ignore the metric if it doesn't have a transformer

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
@@ -71,7 +71,7 @@
 : Number of namespaces. Tags:`phase`.
 
 `kubernetes_state.node.count`
-: Information about a cluster node. Tags:`node` `kernel_version` `os_image` `container_runtime_version` `kubelet_version` `kubeproxy_version` `provider_id` `pod_cidr`.
+: Number of nodes. Tags:`kernel_version` `os_image` `container_runtime_version` `kubelet_version`.
 
 `kubernetes_state.node.cpu_allocatable`
 : The allocatable CPU of a node that is available for scheduling. Tags:`node` `resource` `unit`.

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
@@ -23,7 +23,7 @@ type metricAggregator interface {
 // and GO accepts arrays as valid map key type, but not slices.
 // This hard coded limit is fine because the metrics to aggregate and the label list to use are hardcoded
 // in the code and cannot be arbitrarily set by the end-user.
-const maxNumberOfAllowedLabels = 3
+const maxNumberOfAllowedLabels = 4
 
 type counterAggregator struct {
 	metricName    string
@@ -122,55 +122,57 @@ func (a *counterAggregator) flush(sender aggregator.Sender, k *KSMCheck, labelJo
 	a.accumulator = make(map[[maxNumberOfAllowedLabels]string]float64)
 }
 
-var (
-	metricAggregators = map[string]metricAggregator{
-		"kube_persistentvolume_status_phase": newSumValuesAggregator(
-			"persistentvolumes.by_phase",
-			[]string{"storageclass", "phase"},
-		),
-		"kube_service_spec_type": newCountObjectsAggregator(
-			"service.count",
-			[]string{"namespace", "type"},
-		),
-		"kube_namespace_status_phase": newSumValuesAggregator(
-			"namespace.count",
-			[]string{"phase"},
-		),
-		"kube_replicaset_owner": newCountObjectsAggregator(
-			"replicaset.count",
-			[]string{"namespace", "owner_name", "owner_kind"},
-		),
-		"kube_job_owner": newCountObjectsAggregator(
-			"job.count",
-			[]string{"namespace", "owner_name", "owner_kind"},
-		),
-		"kube_deployment_labels": newCountObjectsAggregator(
-			"deployment.count",
-			[]string{"namespace"},
-		),
-		"kube_daemonset_labels": newCountObjectsAggregator(
-			"daemonset.count",
-			[]string{"namespace"},
-		),
-		"kube_statefulset_labels": newCountObjectsAggregator(
-			"statefulset.count",
-			[]string{"namespace"},
-		),
-		"kube_cronjob_labels": newCountObjectsAggregator(
-			"cronjob.count",
-			[]string{"namespace"},
-		),
-		"kube_endpoint_labels": newCountObjectsAggregator(
-			"endpoint.count",
-			[]string{"namespace"},
-		),
-		"kube_horizontalpodautoscaler_labels": newCountObjectsAggregator(
-			"hpa.count",
-			[]string{"namespace"},
-		),
-		"kube_verticalpodautoscaler_labels": newCountObjectsAggregator(
-			"vpa.count",
-			[]string{"namespace"},
-		),
-	}
-)
+var metricAggregators = map[string]metricAggregator{
+	"kube_persistentvolume_status_phase": newSumValuesAggregator(
+		"persistentvolumes.by_phase",
+		[]string{"storageclass", "phase"},
+	),
+	"kube_service_spec_type": newCountObjectsAggregator(
+		"service.count",
+		[]string{"namespace", "type"},
+	),
+	"kube_namespace_status_phase": newSumValuesAggregator(
+		"namespace.count",
+		[]string{"phase"},
+	),
+	"kube_replicaset_owner": newCountObjectsAggregator(
+		"replicaset.count",
+		[]string{"namespace", "owner_name", "owner_kind"},
+	),
+	"kube_job_owner": newCountObjectsAggregator(
+		"job.count",
+		[]string{"namespace", "owner_name", "owner_kind"},
+	),
+	"kube_deployment_labels": newCountObjectsAggregator(
+		"deployment.count",
+		[]string{"namespace"},
+	),
+	"kube_daemonset_labels": newCountObjectsAggregator(
+		"daemonset.count",
+		[]string{"namespace"},
+	),
+	"kube_statefulset_labels": newCountObjectsAggregator(
+		"statefulset.count",
+		[]string{"namespace"},
+	),
+	"kube_cronjob_labels": newCountObjectsAggregator(
+		"cronjob.count",
+		[]string{"namespace"},
+	),
+	"kube_endpoint_labels": newCountObjectsAggregator(
+		"endpoint.count",
+		[]string{"namespace"},
+	),
+	"kube_horizontalpodautoscaler_labels": newCountObjectsAggregator(
+		"hpa.count",
+		[]string{"namespace"},
+	),
+	"kube_verticalpodautoscaler_labels": newCountObjectsAggregator(
+		"vpa.count",
+		[]string{"namespace"},
+	),
+	"kube_node_info": newCountObjectsAggregator(
+		"node.count",
+		[]string{"kubelet_version", "container_runtime_version", "kernel_version", "os_image"},
+	),
+}

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -63,7 +63,6 @@ var (
 		"kube_daemonset_status_number_available":                                                   "daemonset.daemons_available",
 		"kube_endpoint_address_available":                                                          "endpoint.address_available",
 		"kube_endpoint_address_not_ready":                                                          "endpoint.address_not_ready",
-		"kube_node_info":                                                                           "node.count",
 		"kube_pod_container_status_terminated":                                                     "container.terminated",
 		"kube_pod_container_status_waiting":                                                        "container.waiting",
 		"kube_pod_container_resource_requests_cpu_cores":                                           "container.cpu_requested",


### PR DESCRIPTION
### What does this PR do?

We exclude metadata metrics but if the metric is explicitly set in the mapper, we do send it.

### Motivation

Bugfix

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Deploy Cluster Agent with KSM Core activated (see Helm chart), check that the metric `kubernetes_state.node.count` is reported.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
