### PR TITLE
[KSMCore] Add global user-defined tags

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -71,6 +71,9 @@ type KSMConfig struct {
 	//   - zone:eu
 	Tags []string `yaml:"tags"`
 
+	// DisableGlobalTags disables adding the global host tags defined via tags/DD_TAG in the Agent config, default false.
+	DisableGlobalTags bool `yaml:"disable_global_tags"`
+
 	// Namespaces contains the namespaces from which we collect metrics
 	// Example: Enable metric collection for objects in prod and kube-system namespaces.
 	// namespaces:
@@ -450,13 +453,19 @@ func (k *KSMCheck) getClusterName() {
 }
 
 // initTags avoids keeping a nil Tags field in the check instance
-// and sets the kube_cluster_name tag for all metrics
+// Sets the kube_cluster_name tag for all metrics.
+// Adds the global user-defined tags from the Agent config.
 func (k *KSMCheck) initTags() {
 	if k.instance.Tags == nil {
 		k.instance.Tags = []string{}
 	}
+
 	if k.clusterName != "" {
 		k.instance.Tags = append(k.instance.Tags, "kube_cluster_name:"+k.clusterName)
+	}
+
+	if !k.instance.DisableGlobalTags {
+		k.instance.Tags = append(k.instance.Tags, config.GetConfiguredTags(false)...)
 	}
 }
 

--- a/releasenotes/notes/ksm-core-global-tags-7392c80979a25d01.yaml
+++ b/releasenotes/notes/ksm-core-global-tags-7392c80979a25d01.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    The Kube State Metrics Core checks adds the global user-defined tags (``DD_TAGS``) by the default.


### PR DESCRIPTION
### What does this PR do?

The Kube State Metrics Core checks adds the global user-defined tags (`DD_TAGS`) by the default.

### Motivation

FR

### Additional Notes

Can be disabled by `disable_global_tags`

### Describe how to test your changes

- Set `DD_TAGS` and make sure the ksm core checks adds the tags.
- Set `DD_TAGS` and `disable_global_tags=true` make sure the ksm core checks doesn't add the tags.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
