### PR TITLE
Update tested python package version

### DIFF
--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -700,14 +700,14 @@ shared_examples_for 'an Agent with integrations' do
 
   before do
     freeze_content = File.read(integrations_freeze_file)
-    freeze_content.gsub!(/datadog-cilium==.*/, 'datadog-cilium==1.0.1')
+    freeze_content.gsub!(/datadog-cilium==.*/, 'datadog-cilium==1.5.3')
     File.write(integrations_freeze_file, freeze_content)
 
     integration_remove('datadog-cilium')
   end
 
   it 'can uninstall an installed package' do
-    integration_install('datadog-cilium==1.0.1')
+    integration_install('datadog-cilium==1.5.3')
 
     expect do
       integration_remove('datadog-cilium')
@@ -718,32 +718,32 @@ shared_examples_for 'an Agent with integrations' do
     integration_remove('datadog-cilium')
 
     expect do
-      integration_install('datadog-cilium==1.0.1')
-    end.to change { integration_freeze.match?(%r{datadog-cilium==1\.0\.1}) }.from(false).to(true)
+      integration_install('datadog-cilium==1.5.3')
+    end.to change { integration_freeze.match?(%r{datadog-cilium==1\.5\.3}) }.from(false).to(true)
   end
 
   it 'can upgrade an installed package' do
     expect do
-      integration_install('datadog-cilium==1.0.2')
-    end.to change { integration_freeze.match?(%r{datadog-cilium==1\.0\.2}) }.from(false).to(true)
+      integration_install('datadog-cilium==1.6.0')
+    end.to change { integration_freeze.match?(%r{datadog-cilium==1\.6\.0}) }.from(false).to(true)
   end
 
   it 'can downgrade an installed package' do
     integration_remove('datadog-cilium')
-    integration_install('datadog-cilium==1.0.2')
+    integration_install('datadog-cilium==1.6.0')
 
     expect do
-      integration_install('datadog-cilium==1.0.1')
-    end.to change { integration_freeze.match?(%r{datadog-cilium==1\.0\.1}) }.from(false).to(true)
+      integration_install('datadog-cilium==1.5.3')
+    end.to change { integration_freeze.match?(%r{datadog-cilium==1\.5\.3}) }.from(false).to(true)
   end
 
   it 'cannot downgrade an installed package to a version older than the one shipped with the agent' do
     integration_remove('datadog-cilium')
-    integration_install('datadog-cilium==1.0.1')
+    integration_install('datadog-cilium==1.5.3')
 
     expect do
-      integration_install('datadog-cilium==1.0.0')
-    end.to raise_error(/Failed to install integrations package 'datadog-cilium==1\.0\.0'/)
+      integration_install('datadog-cilium==1.5.2')
+    end.to raise_error(/Failed to install integrations package 'datadog-cilium==1\.5\.2'/)
   end
 end
 


### PR DESCRIPTION
### What does this PR do?

Use more recent python package for integration install/uninstall tests

### Motivation

We updated the root layout in https://github.com/DataDog/integrations-core/pull/9556 and removed some developer keys.
It means that some old python packages can't be installed in new agent, so let's have a more up to date test.

### Additional Notes

### Describe how to test your changes

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
