### PR TITLE
Add libdatadog-agent-two docker image

### DIFF
--- a/omnibus/config/software/datadog-cf-finalize.rb
+++ b/omnibus/config/software/datadog-cf-finalize.rb
@@ -29,6 +29,9 @@ build do
 
             copy "#{cf_source_root}/agent/agent.exe", "#{cf_bin_root_bin}"
             copy "#{cf_source_root}/agent/libdatadog-agent-three.dll", "#{cf_bin_root_bin}"
+            if with_python_runtime? "2"
+                copy "#{cf_source_root}/agent/libdatadog-agent-two.dll", "#{cf_bin_root_bin}"
+            end
 
             unless windows_arch_i386?
               copy "#{cf_source_root}/agent/install-cmd.exe", "#{cf_bin_root_bin}/agent"


### PR DESCRIPTION
### What does this PR do?

Add missing `libdatadog-agent-two` to docker image.

### Motivation

Let E2E tests run.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.