### PR TITLE
Suggest installing the IoT Agent on armv7l

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -261,6 +261,11 @@ if [ ! "$apikey" ]; then
   fi
 fi
 
+if [[ `uname -m` == "armv7l" ]] && [[ $agent_flavor == "datadog-agent" ]]; then
+    printf "\033[31mThe full Datadog Agent isn't available for your architecture (armv7l).\nInstall the Datadog IoT Agent by setting DD_AGENT_FLAVOR='datadog-iot'agent'.\033[0m\n"
+    exit 1;
+fi
+
 # OS/Distro Detection
 # Try lsb_release, fallback with /etc/issue then uname command
 KNOWN_DISTRIBUTION="(Debian|Ubuntu|RedHat|CentOS|openSUSE|Amazon|Arista|SUSE)"

--- a/releasenotes-installscript/notes/install-script-detect-raspberrypi-a55cbc9bb0307cf8.yaml
+++ b/releasenotes-installscript/notes/install-script-detect-raspberrypi-a55cbc9bb0307cf8.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Suggest installing the IoT Agent on armv7l.


### PR DESCRIPTION
### What does this PR do?

Suggest installing the IoT Agent on armv7l (arm 32 bit).

### Motivation

The install script would fail to install the regular Agent with a not-user-friendly error.

### Additional Notes

The skip-qa label is there because this is to be QAd as part of the install script release, not the Agent release.
### Describe how to test your changes

Tested on a Raspberry PI running 32 bit Raspbian.
