### PR TITLE
Revert "Use custom Python 2 interpreter for Windows"

### DIFF
--- a/omnibus/config/software/python2.rb
+++ b/omnibus/config/software/python2.rb
@@ -82,20 +82,21 @@ if ohai["platform"] != "windows"
   end
 
 else
-  default_version "2.7.18-fc7d4ab"
-  dependency "vc_redist_14"
+  default_version "2.7.18"
+  dependency "vc_redist"
 
   if windows_arch_i386?
-    dependency "vc_ucrt_redist"
     source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-x86.zip",
-           :sha256 => "310A4E7DCDA84B086D325C6C54C90DBD48ABF6366534706FBEEAAEFF274F91D3".downcase
+           :sha256 => "c8309b3351610a7159e91e55f09f7341bc3bbdd67d2a5e3049a9d1157e5a9110",
+           :extract => :seven_zip
   else
-    source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-x64.zip",
-           :sha256 => "F94C925BC08DBF215EAA0C398507E928634EEA98A9FFF77489C4EE0FF148DC47".downcase
+    source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-amd64.zip",
+         :sha256 => "7989b2efe6106a3df82c47d403dbb166db6d4040f3654871323df7e724a9fdd2",
+         :extract => :seven_zip
   end
-  vcrt140_root = "#{Omnibus::Config.source_dir()}/vc_redist_140/expanded"
   build do
+    #
+    # expand python zip into the embedded directory
     command "XCOPY /YEHIR *.* \"#{windows_safe_path(python_2_embedded)}\""
-    command "copy /y \"#{windows_safe_path(vcrt140_root)}\\*.dll\" \"#{windows_safe_path(python_2_embedded)}\""
   end
 end

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -70,12 +70,12 @@ else
     dependency "vc_ucrt_redist"
 
     source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-x86.zip",
-           :sha256 => "ac6acfa3d1f6a73e0e0580debdd5a813961d4054a7da6038780bf5d47e4ae647"
+            :sha256 => "ac6acfa3d1f6a73e0e0580debdd5a813961d4054a7da6038780bf5d47e4ae647"
   else
 
     # note that startring with 3.7.3 on Windows, the zip should be created without the built-in pip
     source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-amd64.zip",
-           :sha256 => "3f1533fb5d3944c57f554c9e80f4d77d953eb64e9eca68bb055642f9a8fe5a23"
+         :sha256 => "3f1533fb5d3944c57f554c9e80f4d77d953eb64e9eca68bb055642f9a8fe5a23"
 
   end
   vcrt140_root = "#{Omnibus::Config.source_dir()}/vc_redist_140/expanded"

--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -243,6 +243,35 @@
             <?endif ?>
         </Component>
 
+        <?if $(var.IncludePython2) = true ?>
+        <Component Id="MSVCRUNTIME" Guid="30ce4f57-47ce-47c0-8564-e510d69787a9">
+
+            <Condition> <![CDATA[VersionNT <= 601]]> </Condition>
+            <File Id="msvcm90.dll"
+                Name="msvcm90.dll"
+                Vital="yes"
+                KeyPath="yes"
+                DiskId="1"
+                Source="$(var.BinFiles)/msvcm90.dll"/>
+            <File Id="msvcp90.dll"
+                Name="msvcp90.dll"
+                Vital="yes"
+                DiskId="1"
+                Source="$(var.BinFiles)/msvcp90.dll"/>
+            <File Id="msvcr90.dll"
+                Name="msvcr90.dll"
+                Vital="yes"
+                DiskId="1"
+                Source="$(var.BinFiles)/msvcr90.dll"/>
+            <File Id="Microsoft.VC90.CRT.manifest"
+                Name="Microsoft.VC90.CRT.manifest"
+                Vital="yes"
+                DiskId="1"
+                Source="$(var.BinFiles)/Microsoft.VC90.CRT.manifest"/>
+
+        </Component>
+        <?endif ?>
+
         <Directory Id="AGENT" Name="agent">
           <?if $(var.Platform) = x64 ?>
             <!-- Windows service declaration for APM agent -->
@@ -453,6 +482,9 @@
         <?endif ?>
         <ComponentGroupRef Id="ExtraEXAMPLECONFSLOCATION" />
         <ComponentRef Id="CleanupMainApplicationFolder" />
+        <?if $(var.IncludePython2) = true ?>
+          <ComponentRef Id="MSVCRUNTIME" />
+        <?endif ?>
       <?if $(var.IncludeSysprobe) = true ?>
           <ComponentRef Id="DATADOGSYSPROBESERVICE" />
           <ComponentRef Id="system_probe.yaml.example" />


### PR DESCRIPTION
Reverts DataDog/datadog-agent#8566 since it broke the "integration install" command.