### PR TITLE
Bugfixes to windows npm

### DIFF
--- a/pkg/network/dns.go
+++ b/pkg/network/dns.go
@@ -67,6 +67,7 @@ func (nullReverseDNS) GetStats() map[string]int64 {
 		"packets_dropped":   0,
 		"socket_polls":      0,
 		"decoding_errors":   0,
+		"errors":            0,
 	}
 }
 

--- a/pkg/network/driver_interface.go
+++ b/pkg/network/driver_interface.go
@@ -160,6 +160,9 @@ func (di *DriverInterface) Close() error {
 	if err := windows.CancelIoEx(di.driverDNSHandle.handle, nil); err != nil {
 		return errors.Wrap(err, "error cancelling DNS io completion")
 	}
+	if err := windows.CloseHandle(di.dnsIOCP); err != nil {
+		return errors.Wrap(err, "error closing DNS io completion handle")
+	}
 	if err := windows.CloseHandle(di.driverDNSHandle.handle); err != nil {
 		return errors.Wrap(err, "error closing driver DNS handle")
 	}
@@ -324,8 +327,11 @@ func (di *DriverInterface) GetConnectionStats(activeBuf *DriverBuffer, closedBuf
 	for err := error(windows.ERROR_MORE_DATA); err == windows.ERROR_MORE_DATA; {
 		err = windows.ReadFile(di.driverFlowHandle.handle, di.readBuffer, &bytesRead, nil)
 		if err != nil {
+			if err == windows.ERROR_NO_MORE_ITEMS {
+				break
+			}
 			if err != windows.ERROR_MORE_DATA {
-				return 0, 0, err
+				return 0, 0, fmt.Errorf("ReadFile: %w", err)
 			}
 			atomic.AddInt64(&di.moreDataErrors, 1)
 		}

--- a/pkg/network/event_windows.go
+++ b/pkg/network/event_windows.go
@@ -183,7 +183,7 @@ func connDirection(flags C.uint32_t) ConnectionDirection {
 	if (direction & C.FLOW_DIRECTION_OUTBOUND) == C.FLOW_DIRECTION_OUTBOUND {
 		return OUTGOING
 	}
-	return NONE
+	return OUTGOING
 }
 
 func isFlowClosed(flags C.uint32_t) bool {

--- a/pkg/network/network_filter.go
+++ b/pkg/network/network_filter.go
@@ -10,7 +10,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// ConnectionFilter holds a user-defined blacklisted IP/CIDR, and ports
+// ConnectionFilter holds a user-defined excluded IP/CIDR, and ports
 type ConnectionFilter struct {
 	IP       *net.IPNet // If nil, then all IPs will be considered matching.
 	AllPorts ConnTypeFilter
@@ -24,8 +24,8 @@ type ConnTypeFilter struct {
 	UDP bool
 }
 
-// ParseConnectionFilters takes the user defined blacklist and returns a slice of ConnectionFilters
-func ParseConnectionFilters(filters map[string][]string) (blacklist []*ConnectionFilter) {
+// ParseConnectionFilters takes the user defined excludelist and returns a slice of ConnectionFilters
+func ParseConnectionFilters(filters map[string][]string) (excludelist []*ConnectionFilter) {
 	for ip, portFilters := range filters {
 		filter := &ConnectionFilter{Ports: map[uint16]ConnTypeFilter{}}
 		var subnet *net.IPNet
@@ -83,10 +83,10 @@ func ParseConnectionFilters(filters map[string][]string) (blacklist []*Connectio
 
 		// If there were any errors in parsing the port filters above, we'll skip this entry.
 		if err == nil {
-			blacklist = append(blacklist, filter)
+			excludelist = append(excludelist, filter)
 		}
 	}
-	return blacklist
+	return excludelist
 }
 
 // parsePortFilter checks for valid port(s) and protocol filters

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -84,7 +84,7 @@ type Tracer struct {
 	// Internal buffer used to compute bytekeys
 	buf []byte
 
-	// Connections for the tracer to blacklist
+	// Connections for the tracer to exclude
 	sourceExcludes []*network.ConnectionFilter
 	destExcludes   []*network.ConnectionFilter
 


### PR DESCRIPTION
### What does this PR do?

Fixes some bugs in windows NPM:
- Closes DNS handles properly
- Fixes default connection direction
- Include DNS stats for Windows in expvars

### Motivation

Found during dev of https://github.com/DataDog/datadog-agent/pull/8585

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.