### PR TITLE
Final release entries + add prelude for 7.29.1 release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,8 +50,8 @@ require (
 	code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a // indirect
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
 	github.com/DataDog/agent-payload v4.72.0+incompatible
-	github.com/DataDog/datadog-agent/pkg/util/log v0.29.0
-	github.com/DataDog/datadog-agent/pkg/util/winutil v0.29.0
+	github.com/DataDog/datadog-agent/pkg/util/log v0.29.1
+	github.com/DataDog/datadog-agent/pkg/util/winutil v0.29.1
 	github.com/DataDog/datadog-go v4.5.0+incompatible
 	github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a
 	github.com/DataDog/ebpf v0.0.0-20210419131141-ea64821c9793

--- a/pkg/util/winutil/go.mod
+++ b/pkg/util/winutil/go.mod
@@ -5,6 +5,6 @@ go 1.15
 replace github.com/DataDog/datadog-agent/pkg/util/log => ../log
 
 require (
-	github.com/DataDog/datadog-agent/pkg/util/log v0.29.0
+	github.com/DataDog/datadog-agent/pkg/util/log v0.29.1
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f
 )

--- a/release.json
+++ b/release.json
@@ -22,7 +22,7 @@
         "WINDOWS_DDNPM_SHASUM": "5d31cbf7aea921edd5ba34baf074e496749265a80468b65a034d3796558a909e",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
-    "6.29.1-rc.1": {
+    "6.29.1": {
         "INTEGRATIONS_CORE_VERSION": "7.29.0",
         "OMNIBUS_SOFTWARE_VERSION": "7.29.0",
         "OMNIBUS_RUBY_VERSION": "7.29.0",
@@ -34,7 +34,7 @@
         "WINDOWS_DDNPM_VERSION": "0.98.2.git.86.53d1ee4",
         "WINDOWS_DDNPM_SHASUM": "5d31cbf7aea921edd5ba34baf074e496749265a80468b65a034d3796558a909e"
     },
-    "7.29.1-rc.1": {
+    "7.29.1": {
         "INTEGRATIONS_CORE_VERSION": "7.29.0",
         "OMNIBUS_SOFTWARE_VERSION": "7.29.0",
         "OMNIBUS_RUBY_VERSION": "7.29.0",

--- a/releasenotes/notes/prelude-release-7.29.1-e9b9de0131baaad3.yaml
+++ b/releasenotes/notes/prelude-release-7.29.1-e9b9de0131baaad3.yaml
@@ -1,0 +1,5 @@
+prelude:
+    |
+    Release on: 2021-07-11
+
+    - Please refer to the `7.29.1 tag on integrations-core <https://github.com/DataDog/integrations-core/blob/master/AGENT_CHANGELOG.md#datadog-agent-version-7291>`_ for the list of changes on the Core Checks


### PR DESCRIPTION
### What does this PR do?

Final entries and prelude for 7.29.1.

### Motivation

7.29.1 final artifacts.

### Additional Notes

(none)

### Describe how to test your changes

Regular QA

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
