### PR TITLE
Fix docker image deployment

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -306,6 +306,7 @@ variables:
     allow_failure: true
     variables:
       AGENT_REPOSITORY: agent
+      IMG_REGISTRIES: public
 
 .on_deploy_a7:
   - <<: *if_not_version_7
@@ -329,6 +330,7 @@ variables:
     variables:
       AGENT_REPOSITORY: agent
       DSD_REPOSITORY: dogstatsd
+      IMG_REGISTRIES: public
 
 .on_deploy_nightly_repo_branch_a6:
   - <<: *if_not_version_6


### PR DESCRIPTION
### What does this PR do?

Fix the following error when trying to deploy `rc.1` image:
```
$ export VERSION="$(inv -e agent.version --major-version 6 --url-safe)"
$ export IMG_SOURCES="${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6${JMX}-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6${JMX}-arm64"
$ export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}${JMX}"
$ inv pipeline.trigger-child-pipeline --project-name "DataDog/public-images" --git-ref "main" --variables "IMG_REGISTRIES,IMG_SOURCES,IMG_DESTINATIONS"
Traceback (most recent call last):
  File "/root/miniconda3/envs/ddpy3/bin/inv", line 10, in <module>
    sys.exit(program.run())
  File "/root/miniconda3/envs/ddpy3/lib/python3.8/site-packages/invoke/program.py", line 384, in run
    self.execute()
  File "/root/miniconda3/envs/ddpy3/lib/python3.8/site-packages/invoke/program.py", line 566, in execute
    executor.execute(*self.tasks)
  File "/root/miniconda3/envs/ddpy3/lib/python3.8/site-packages/invoke/executor.py", line 129, in execute
    result = call.task(*args, **call.kwargs)
  File "/root/miniconda3/envs/ddpy3/lib/python3.8/site-packages/invoke/tasks.py", line 127, in __call__
    result = self.body(*args, **kwargs)
  File "/go/src/github.com/DataDog/datadog-agent/tasks/pipeline.py", line 362, in trigger_child_pipeline
    data['variables'][v] = os.environ[v]
  File "/root/miniconda3/envs/ddpy3/lib/python3.8/os.py", line 675, in __getitem__
    raise KeyError(key) from None
KeyError: 'IMG_REGISTRIES'
ERROR: Job failed: exit code 1
```

### Motivation

We should be able to deploy.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Try to deploy the agent docker images of an `rc`.
It should deploy on `docker.io/datadog/agent`, `gcr.io/datadoghq/agent` and `public.ecr.aws/datadog/agent`
and it shoudn’t produce the above-mentioned error.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
