### PR TITLE
Reduce flakiness of some system-probe tests

### DIFF
--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -279,13 +279,25 @@ func BeautifyKey(key string) string {
 // ConnectionSummary returns a string summarizing a connection
 func ConnectionSummary(c *ConnectionStats, names map[util.Address][]string) string {
 	str := fmt.Sprintf(
-		"[%s] [PID: %d] [%v:%d ⇄ %v:%d] (%s) %s sent (+%s), %s received (+%s)",
+		"[%s] [PID: %d] [%v:%d ⇄ %v:%d] ",
 		c.Type,
 		c.Pid,
 		printAddress(c.Source, names[c.Source]),
 		c.SPort,
 		printAddress(c.Dest, names[c.Dest]),
 		c.DPort,
+	)
+	if c.IPTranslation != nil {
+		str += fmt.Sprintf(
+			"xlated [%v:%d ⇄ %v:%d] ",
+			c.IPTranslation.ReplSrcIP,
+			c.IPTranslation.ReplSrcPort,
+			c.IPTranslation.ReplDstIP,
+			c.IPTranslation.ReplDstPort,
+		)
+	}
+
+	str += fmt.Sprintf("(%s) %s sent (+%s), %s received (+%s)",
 		c.Direction,
 		humanize.Bytes(c.MonotonicSentBytes), humanize.Bytes(c.LastSentBytes),
 		humanize.Bytes(c.MonotonicRecvBytes), humanize.Bytes(c.LastRecvBytes),

--- a/pkg/network/tracer/testdata/peek.py
+++ b/pkg/network/tracer/testdata/peek.py
@@ -1,9 +1,0 @@
-#!/usr/bin/env python3
-
-import socket
-
-s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-s.bind(("127.0.0.1", 34568))
-s.recvfrom(1024, socket.MSG_PEEK)
-s.recvfrom(1024)
-s.close()

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -2272,18 +2272,18 @@ func TestGatewayLookupEnabled(t *testing.T) {
 	m.EXPECT().IsAWS().Return(true)
 	cloud = m
 
+	ifi := ipRouteGet(t, "", "8.8.8.8", nil)
+	ifs, err := net.Interfaces()
+	require.NoError(t, err)
+
 	cfg := testConfig()
 	cfg.EnableGatewayLookup = true
 	tr, err := NewTracer(cfg)
 	require.NoError(t, err)
 	require.NotNil(t, tr)
 	defer tr.Stop()
-
 	require.NotNil(t, tr.gwLookup)
 
-	ifi := ipRouteGet(t, "", "8.8.8.8", nil)
-	ifs, err := net.Interfaces()
-	require.NoError(t, err)
 	tr.gwLookup.subnetForHwAddrFunc = func(hwAddr net.HardwareAddr) (network.Subnet, error) {
 		t.Logf("subnet lookup: %s", hwAddr)
 		for _, i := range ifs {

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -2251,7 +2251,7 @@ func ipRouteGet(t *testing.T, from, dest string, iif *net.Interface) *net.Interf
 	out, err := cmd.CombinedOutput()
 	require.NoError(t, err, "ip command returned error, output: %s", out)
 	t.Log(strings.Join(cmd.Args, " "))
-	t.Log(out)
+	t.Log(string(out))
 
 	matches := ipRouteGetOut.FindSubmatch(out)
 	require.Len(t, matches, 2, string(out))


### PR DESCRIPTION
### What does this PR do?

Try to reduce the flakiness of the following tests that fail semi-regularly in CI:
- TestUDPPeekCount
- TestGatewayLookupEnabled

### Motivation

CI failures that delay/annoy everyone.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
