### PR TITLE
[install_script] Fix APT keyring permissions

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -379,6 +379,9 @@ elif [ "$OS" = "Debian" ]; then
     if [ ! -f $apt_usr_share_keyring ]; then
         $sudo_cmd touch $apt_usr_share_keyring
     fi
+    # ensure that the _apt user used on Ubuntu/Debian systems to read GPG keyrings
+    # can read our keyring
+    $sudo_cmd chmod a+r $apt_usr_share_keyring
 
     for key in "${APT_GPG_KEYS[@]}"; do
         $sudo_cmd curl --retry 5 -o "/tmp/${key}" "https://${keys_url}/${key}"
@@ -388,7 +391,8 @@ elif [ "$OS" = "Debian" ]; then
     release_version="$(grep VERSION_ID /etc/os-release | cut -d = -f 2 | xargs echo | cut -d "." -f 1)"
     if { [ "$DISTRIBUTION" == "Debian" ] && [ "$release_version" -lt 9 ]; } || \
        { [ "$DISTRIBUTION" == "Ubuntu" ] && [ "$release_version" -lt 16 ]; }; then
-        $sudo_cmd cp $apt_usr_share_keyring $apt_trusted_d_keyring
+        # copy with -a to preserve file permissions
+        $sudo_cmd cp -a $apt_usr_share_keyring $apt_trusted_d_keyring
     fi
 
     printf "\033[34m\n* Installing the Datadog Agent package\n\033[0m\n"

--- a/releasenotes-installscript/notes/fix-debian-keyring-permissions-0ef75b553c321082.yaml
+++ b/releasenotes-installscript/notes/fix-debian-keyring-permissions-0ef75b553c321082.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG-INSTALLSCRIPT.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Ensure that Debian/Ubuntu APT keyrings get created world-readable, so that
+    the ``_apt`` user can read them.


### PR DESCRIPTION
### What does this PR do?

On Ubuntu/Debian systems, there is an `_apt` user which reads the APT keyrings to verify signatures. Our APT keyrings are owned by root and so if they're not world-readable, the `_apt` user fails to read them and thus can't verify the signatures.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

With `umask 007` (or the permissions on `/usr/share/keyrings/datadog-archive-keyring.gpg` set to e.g. `-rw-r-----` prior to executing the script), install_script version 1.5.0 should fail with something like:

```
W: GPG error: https://apt.datadoghq.com stable Release: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 4B4593018387EEAF
E: The repository 'https://apt.datadoghq.com stable Release' is not signed.
```

However, with the same umask (or the permissions on `/usr/share/keyrings/datadog-archive-keyring.gpg` set to e.g. `-rw-r-----` prior to executing the script), the version of install_script containing this patch should pass.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
