### PR TITLE
[corechecks/snmp] Handle snmp v1 no valid oids

### DIFF
--- a/pkg/collector/corechecks/snmp/fetch_scalar.go
+++ b/pkg/collector/corechecks/snmp/fetch_scalar.go
@@ -89,6 +89,10 @@ func doFetchScalarOids(session sessionAPI, oids []string) (*gosnmp.SnmpPacket, e
 					return nil, fmt.Errorf("invalid ErrorIndex `%d` when fetching oids `%v`", scalarOids.ErrorIndex, oids)
 				}
 				oids = append(oids[:zeroBaseIndex], oids[zeroBaseIndex+1:]...)
+				if len(oids) == 0 {
+					// If all oids are not found, return an empty packet with no variable and no error
+					return &gosnmp.SnmpPacket{}, nil
+				}
 				continue
 			}
 			results = scalarOids

--- a/pkg/collector/corechecks/snmp/fetch_test.go
+++ b/pkg/collector/corechecks/snmp/fetch_test.go
@@ -506,6 +506,32 @@ func Test_fetchScalarOids_v1NoSuchName(t *testing.T) {
 	assert.Equal(t, expectedColumnValues, columnValues)
 }
 
+func Test_fetchScalarOids_v1NoSuchName_noValidOidsLeft(t *testing.T) {
+	session := createMockSession()
+	session.version = gosnmp.Version1
+
+	getPacket := gosnmp.SnmpPacket{
+		Error:      gosnmp.NoSuchName,
+		ErrorIndex: 1,
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name: "1.1.1.1.0",
+				Type: gosnmp.Null,
+			},
+		},
+	}
+
+	session.On("Get", []string{"1.1.1.1.0"}).Return(&getPacket, nil)
+
+	oids := []string{"1.1.1.1.0"}
+
+	columnValues, err := fetchScalarOids(session, oids)
+	assert.Nil(t, err)
+
+	expectedColumnValues := scalarResultValuesType{}
+	assert.Equal(t, expectedColumnValues, columnValues)
+}
+
 func Test_fetchScalarOids_v1NoSuchName_errorIndexTooHigh(t *testing.T) {
 	session := createMockSession()
 	session.version = gosnmp.Version1


### PR DESCRIPTION
Related PR: https://github.com/DataDog/integrations-core/pull/9687

### What does this PR do?

Handle snmp v1 no valid oids

### Motivation

If all oids are returning `gosnmp.NoSuchName`, this lead to oids list being empty and then leading to timeout.

```
E   Exception: Message: failed to fetch values: failed to fetch scalar oids with batching: failed to fetch scalar oids: fetch scalar: error getting oids `[]`: request timeout (after 3 retries)
```

https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=70284&view=logs&j=475ea3e3-a9fc-55a6-2e22-b5a67273560a&t=1a1f47dd-bcf6-5ffb-3d85-8c5dbec3db65

### Additional Notes



### Describe how to test your changes

Make sure the failing e2e test above is passing

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
