### PR TITLE
[runtime-security] Fix manager dead lock

### DIFF
--- a/pkg/security/probe/reorderer.go
+++ b/pkg/security/probe/reorderer.go
@@ -170,6 +170,7 @@ type ReOrdererMetric struct {
 
 // ReOrderer defines an event re-orderer
 type ReOrderer struct {
+	ctx         context.Context
 	queue       chan []byte
 	handler     func(cpu uint64, data []byte)
 	heap        *reOrdererHeap
@@ -181,7 +182,7 @@ type ReOrderer struct {
 }
 
 // Start event handler loop
-func (r *ReOrderer) Start(ctx context.Context, wg *sync.WaitGroup) {
+func (r *ReOrderer) Start(wg *sync.WaitGroup) {
 	defer wg.Done()
 
 	flushTicker := time.NewTicker(r.opts.Rate)
@@ -226,7 +227,7 @@ func (r *ReOrderer) Start(ctx context.Context, wg *sync.WaitGroup) {
 			}
 
 			r.metric.zero()
-		case <-ctx.Done():
+		case <-r.ctx.Done():
 			return
 		}
 	}
@@ -234,12 +235,18 @@ func (r *ReOrderer) Start(ctx context.Context, wg *sync.WaitGroup) {
 
 // HandleEvent handle event form perf ring
 func (r *ReOrderer) HandleEvent(CPU int, data []byte, perfMap *manager.PerfMap, manager *manager.Manager) {
-	r.queue <- data
+	select {
+	case r.queue <- data:
+		return
+	case <-r.ctx.Done():
+		return
+	}
 }
 
 // NewReOrderer returns a new ReOrderer
-func NewReOrderer(handler func(cpu uint64, data []byte), extractInfo func(data []byte) (uint64, uint64, error), opts ReOrdererOpts) *ReOrderer {
+func NewReOrderer(ctx context.Context, handler func(cpu uint64, data []byte), extractInfo func(data []byte) (uint64, uint64, error), opts ReOrdererOpts) *ReOrderer {
 	return &ReOrderer{
+		ctx:     ctx,
 		queue:   make(chan []byte, opts.QueueSize),
 		handler: handler,
 		heap: &reOrdererHeap{

--- a/pkg/security/probe/reorderer_test.go
+++ b/pkg/security/probe/reorderer_test.go
@@ -83,8 +83,9 @@ func TestOrderRate(t *testing.T) {
 	retention := 5
 
 	var lock sync.RWMutex
+	ctx, cancel := context.WithCancel(context.Background())
 
-	reOrderer := NewReOrderer(func(cpu uint64, data []byte) {
+	reOrderer := NewReOrderer(ctx, func(cpu uint64, data []byte) {
 		lock.Lock()
 		event = append(event, data[2])
 		lock.Unlock()
@@ -99,13 +100,11 @@ func TestOrderRate(t *testing.T) {
 			MetricRate: 200 * time.Millisecond,
 		})
 
-	ctx, cancel := context.WithCancel(context.Background())
-
 	var wg sync.WaitGroup
 	defer wg.Wait()
 
 	wg.Add(1)
-	go reOrderer.Start(ctx, &wg)
+	go reOrderer.Start(&wg)
 
 	var e uint8
 	for i := 0; i != 10; i++ {

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -386,11 +386,11 @@ func TestDiscarderRetentionFilter(t *testing.T) {
 	defer syscall.Close(fd)
 	defer os.Remove(testFile)
 
-	if err := waitForOpenDiscarder(test, testFile); err != nil {
+	if err = waitForOpenDiscarder(test, testFile); err != nil {
 		inode := getInode(t, testFile)
 		parentInode := getInode(t, path.Dir(testFile))
 
-		t.Fatalf("not able to get the expected event inode: %d, parent inode: %d", inode, parentInode)
+		t.Fatalf("event inode: %d, parent inode: %d, error: %v", inode, parentInode, err)
 	}
 
 	if err := waitForOpenProbeEvent(test, func() error {


### PR DESCRIPTION
### What does this PR do?

This PR ensures we stop the managers before any other component of the runtime security module in system-probe.

### Motivation

This PR fixes a dead lock in the eBPF manager.
