### PR TITLE
Fix Kubelet container ID matching in some scenarios

### DIFF
--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -293,10 +293,13 @@ func (ku *KubeUtil) searchPodForContainerID(podList []*Pod, containerID string) 
 
 	// We will match only on the id itself, without runtime identifier, it should be quite unlikely on a Kube node
 	// to have a container in the runtime used by Kube to match a container in another runtime...
-	strippedContainerID := containers.ContainerIDForEntity(containerID)
+	if containers.IsEntityName(containerID) {
+		containerID = containers.ContainerIDForEntity(containerID)
+	}
+
 	for _, pod := range podList {
 		for _, container := range pod.Status.GetAllContainers() {
-			if containers.ContainerIDForEntity(container.ID) == strippedContainerID {
+			if container.ID != "" && containers.ContainerIDForEntity(container.ID) == containerID {
 				return pod, nil
 			}
 		}


### PR DESCRIPTION
### What does this PR do?

Currently, when passing a raw container id (e.g. without `<runtime>://`), the matching could happen with a POD in `Pending` state (thus without container ID).

### Motivation

Bugfix

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

The use case is quite difficult to trigger. It would require:
- Configure the Agent to make sure the Kubelet connection does **not** work
- Do not use Docker
- Have a Pending POD on the node

Starting previous Agent version (<= 7.30) should fail with `Error while getting hostname, exiting: unable to reliably determine the host name`.
Using the Agent with this fix should fix it.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
