### PR TITLE
Fix condition to use Kubelet hostname provider

### DIFF
--- a/pkg/util/hostname/kubelet/hostname.go
+++ b/pkg/util/hostname/kubelet/hostname.go
@@ -23,7 +23,7 @@ var kubeUtilGet kubeUtilGetter = k.GetKubeUtil
 
 // HostnameProvider builds a hostname from the kubernetes nodename and an optional cluster-name
 func HostnameProvider(ctx context.Context) (string, error) {
-	if config.IsFeaturePresent(config.Kubernetes) {
+	if !config.IsFeaturePresent(config.Kubernetes) {
 		return "", nil
 	}
 

--- a/pkg/util/hostname/kubelet/hostname_test.go
+++ b/pkg/util/hostname/kubelet/hostname_test.go
@@ -30,6 +30,9 @@ func (m *kubeUtilMock) GetNodename(ctx context.Context) (string, error) {
 }
 
 func TestHostnameProvider(t *testing.T) {
+	config.SetDetectedFeatures(config.FeatureMap{config.Kubernetes: struct{}{}})
+	defer config.SetDetectedFeatures(nil)
+
 	ctx := context.Background()
 	mockConfig := config.Mock()
 
@@ -47,7 +50,7 @@ func TestHostnameProvider(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "node-name", hostName)
 
-	var testClusterName = "laika"
+	testClusterName := "laika"
 	mockConfig.Set("cluster_name", testClusterName)
 	clustername.ResetClusterName() // reset state as clustername was already read
 


### PR DESCRIPTION
### What does this PR do?

Missing `!` in the condition introduced in #8521.

### Motivation

Bugfix

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Deploy the Agent on Kubernetes without cloud provider integration (or cloud providers deactivated) so that the Kubelet and without Docker to make sure the Kubelet provider is used.
The hostname should be reported properly.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
