### PR TITLE
Allow setting DD_SOURCE header for new v2 logs intake

### DIFF
--- a/cmd/cluster-agent/app/compliance.go
+++ b/cmd/cluster-agent/app/compliance.go
@@ -43,12 +43,12 @@ func runCompliance(ctx context.Context, apiCl *apiserver.APIClient, isLeader fun
 }
 
 func newLogContext(logsConfig *config.LogsConfigKeys, endpointPrefix string) (*config.Endpoints, *client.DestinationsContext, error) {
-	endpoints, err := config.BuildHTTPEndpointsWithConfig(logsConfig, endpointPrefix, intakeTrackType, config.DefaultIntakeProtocol)
+	endpoints, err := config.BuildHTTPEndpointsWithConfig(logsConfig, endpointPrefix, intakeTrackType, config.DefaultIntakeProtocol, config.DefaultIntakeSource)
 	if err != nil {
-		endpoints, err = config.BuildHTTPEndpoints(intakeTrackType, config.DefaultIntakeProtocol)
+		endpoints, err = config.BuildHTTPEndpoints(intakeTrackType, config.DefaultIntakeProtocol, config.DefaultIntakeSource)
 		if err == nil {
 			httpConnectivity := logshttp.CheckConnectivity(endpoints.Main)
-			endpoints, err = config.BuildEndpoints(httpConnectivity, intakeTrackType, config.DefaultIntakeProtocol)
+			endpoints, err = config.BuildEndpoints(httpConnectivity, intakeTrackType, config.DefaultIntakeProtocol, config.DefaultIntakeSource)
 		}
 	}
 

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -116,13 +116,13 @@ func init() {
 	SecurityAgentCmd.AddCommand(startCmd)
 }
 
-func newLogContext(logsConfig *config.LogsConfigKeys, intakeTrackType, endpointPrefix string) (*config.Endpoints, *client.DestinationsContext, error) {
-	endpoints, err := config.BuildHTTPEndpointsWithConfig(logsConfig, endpointPrefix, intakeTrackType, config.DefaultIntakeProtocol)
+func newLogContext(logsConfig *config.LogsConfigKeys, endpointPrefix string, intakeTrackType config.IntakeTrackType, intakeSource config.IntakeSource) (*config.Endpoints, *client.DestinationsContext, error) {
+	endpoints, err := config.BuildHTTPEndpointsWithConfig(logsConfig, endpointPrefix, intakeTrackType, config.DefaultIntakeProtocol, intakeSource)
 	if err != nil {
-		endpoints, err = config.BuildHTTPEndpoints(intakeTrackType, config.DefaultIntakeProtocol)
+		endpoints, err = config.BuildHTTPEndpoints(intakeTrackType, config.DefaultIntakeProtocol, intakeSource)
 		if err == nil {
 			httpConnectivity := logshttp.CheckConnectivity(endpoints.Main)
-			endpoints, err = config.BuildEndpoints(httpConnectivity, intakeTrackType, config.DefaultIntakeProtocol)
+			endpoints, err = config.BuildEndpoints(httpConnectivity, intakeTrackType, config.DefaultIntakeProtocol, intakeSource)
 		}
 	}
 

--- a/cmd/security-agent/app/compliance.go
+++ b/cmd/security-agent/app/compliance.go
@@ -59,7 +59,7 @@ func init() {
 
 func newLogContextCompliance() (*config.Endpoints, *client.DestinationsContext, error) {
 	logsConfigComplianceKeys := config.NewLogsConfigKeys("compliance_config.endpoints.", coreconfig.Datadog)
-	return newLogContext(logsConfigComplianceKeys, "compliance-http-intake.logs.", "compliance")
+	return newLogContext(logsConfigComplianceKeys, "compliance-http-intake.logs.", "compliance", config.DefaultIntakeSource)
 }
 
 func eventRun(cmd *cobra.Command, args []string) error {

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -34,6 +34,10 @@ import (
 	ddgostatsd "github.com/DataDog/datadog-go/statsd"
 )
 
+const (
+	cwsIntakeSource config.IntakeSource = "cloud-workload-security"
+)
+
 var (
 	runtimeCmd = &cobra.Command{
 		Use:   "runtime",
@@ -151,7 +155,7 @@ func newRuntimeReporter(stopper restart.Stopper, sourceName, sourceType string, 
 // This function will only be used on Linux. The only platforms where the runtime agent runs
 func newLogContextRuntime() (*config.Endpoints, *client.DestinationsContext, error) { // nolint: deadcode, unused
 	logsConfigComplianceKeys := config.NewLogsConfigKeys("runtime_security_config.endpoints.", coreconfig.Datadog)
-	return newLogContext(logsConfigComplianceKeys, "runtime-security-http-intake.logs.", "logs")
+	return newLogContext(logsConfigComplianceKeys, "runtime-security-http-intake.logs.", "logs", cwsIntakeSource)
 }
 
 func startRuntimeSecurity(hostname string, stopper restart.Stopper, statsdClient *ddgostatsd.Client) (*secagent.RuntimeSecurityAgent, error) {

--- a/pkg/epforwarder/epforwarder.go
+++ b/pkg/epforwarder/epforwarder.go
@@ -2,9 +2,10 @@ package epforwarder
 
 import (
 	"fmt"
-	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"strings"
 	"sync"
+
+	pkgconfig "github.com/DataDog/datadog-agent/pkg/config"
 
 	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/auditor"
@@ -135,7 +136,7 @@ type passthroughPipeline struct {
 
 type passthroughPipelineDesc struct {
 	eventType                     string
-	intakeTrackType               string
+	intakeTrackType               config.IntakeTrackType
 	endpointsConfigPrefix         string
 	hostnameEndpointPrefix        string
 	defaultBatchMaxConcurrentSend int
@@ -147,7 +148,7 @@ type passthroughPipelineDesc struct {
 // without any of the processing that exists in regular logs pipelines.
 func newHTTPPassthroughPipeline(desc passthroughPipelineDesc, destinationsContext *client.DestinationsContext) (p *passthroughPipeline, err error) {
 	configKeys := config.NewLogsConfigKeys(desc.endpointsConfigPrefix, coreConfig.Datadog)
-	endpoints, err := config.BuildHTTPEndpointsWithConfig(configKeys, desc.hostnameEndpointPrefix, desc.intakeTrackType, config.DefaultIntakeProtocol)
+	endpoints, err := config.BuildHTTPEndpointsWithConfig(configKeys, desc.hostnameEndpointPrefix, desc.intakeTrackType, config.DefaultIntakeProtocol, config.DefaultIntakeSource)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -51,7 +51,8 @@ type Destination struct {
 	backoff             backoff.Policy
 	nbErrors            int
 	blockedUntil        time.Time
-	protocol            string
+	protocol            config.IntakeProtocol
+	source              config.IntakeSource
 }
 
 // NewDestination returns a new Destination.
@@ -86,6 +87,7 @@ func newDestination(endpoint config.Endpoint, contentType string, destinationsCo
 		climit:              make(chan struct{}, maxConcurrentBackgroundSends),
 		backoff:             policy,
 		protocol:            endpoint.Protocol,
+		source:              endpoint.Source,
 	}
 }
 
@@ -144,7 +146,10 @@ func (d *Destination) unconditionalSend(payload []byte) (err error) {
 	req.Header.Set("Content-Type", d.contentType)
 	req.Header.Set("Content-Encoding", d.contentEncoding.name())
 	if d.protocol != "" {
-		req.Header.Set("DD-PROTOCOL", d.protocol)
+		req.Header.Set("DD-PROTOCOL", string(d.protocol))
+	}
+	if d.source != "" {
+		req.Header.Set("DD-SOURCE", string(d.source))
 	}
 	req = req.WithContext(ctx)
 

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -31,7 +31,10 @@ const (
 )
 
 // DefaultIntakeProtocol indicates that no special protocol is in use for the endpoint intake track type.
-const DefaultIntakeProtocol = ""
+const DefaultIntakeProtocol IntakeProtocol = ""
+
+// DefaultIntakeSource indicates that no special DD_SOURCE header is in use for the endpoint intake track type.
+const DefaultIntakeSource IntakeSource = ""
 
 // logs-intake endpoints depending on the site and environment.
 var logsEndpoints = map[string]int{
@@ -105,19 +108,19 @@ func GlobalProcessingRules() ([]*ProcessingRule, error) {
 }
 
 // BuildEndpoints returns the endpoints to send logs.
-func BuildEndpoints(httpConnectivity HTTPConnectivity, intakeTrackType, intakeProtocol string) (*Endpoints, error) {
+func BuildEndpoints(httpConnectivity HTTPConnectivity, intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeSource IntakeSource) (*Endpoints, error) {
 	coreConfig.SanitizeAPIKeyConfig(coreConfig.Datadog, "logs_config.api_key")
-	return BuildEndpointsWithConfig(defaultLogsConfigKeys(), httpEndpointPrefix, httpConnectivity, intakeTrackType, intakeProtocol)
+	return BuildEndpointsWithConfig(defaultLogsConfigKeys(), httpEndpointPrefix, httpConnectivity, intakeTrackType, intakeProtocol, intakeSource)
 }
 
 // BuildEndpointsWithConfig returns the endpoints to send logs.
-func BuildEndpointsWithConfig(logsConfig *LogsConfigKeys, endpointPrefix string, httpConnectivity HTTPConnectivity, intakeTrackType, intakeProtocol string) (*Endpoints, error) {
+func BuildEndpointsWithConfig(logsConfig *LogsConfigKeys, endpointPrefix string, httpConnectivity HTTPConnectivity, intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeSource IntakeSource) (*Endpoints, error) {
 	if logsConfig.devModeNoSSL() {
 		log.Warnf("Use of illegal configuration parameter, if you need to send your logs to a proxy, "+
 			"please use '%s' and '%s' instead", logsConfig.getConfigKey("logs_dd_url"), logsConfig.getConfigKey("logs_no_ssl"))
 	}
 	if logsConfig.isForceHTTPUse() || (bool(httpConnectivity) && !(logsConfig.isForceTCPUse() || logsConfig.isSocks5ProxySet() || logsConfig.hasAdditionalEndpoints())) {
-		return BuildHTTPEndpointsWithConfig(logsConfig, endpointPrefix, intakeTrackType, intakeProtocol)
+		return BuildHTTPEndpointsWithConfig(logsConfig, endpointPrefix, intakeTrackType, intakeProtocol, intakeSource)
 	}
 	log.Warnf("You are currently sending Logs to Datadog through TCP (either because %s or %s is set or the HTTP connectivity test has failed) "+
 		"To benefit from increased reliability and better network performances, "+
@@ -127,9 +130,9 @@ func BuildEndpointsWithConfig(logsConfig *LogsConfigKeys, endpointPrefix string,
 }
 
 // BuildServerlessEndpoints returns the endpoints to send logs for the Serverless agent.
-func BuildServerlessEndpoints(intakeTrackType, intakeProtocol string) (*Endpoints, error) {
+func BuildServerlessEndpoints(intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeSource IntakeSource) (*Endpoints, error) {
 	coreConfig.SanitizeAPIKeyConfig(coreConfig.Datadog, "logs_config.api_key")
-	return BuildHTTPEndpointsWithConfig(defaultLogsConfigKeys(), serverlessHTTPEndpointPrefix, intakeTrackType, intakeProtocol)
+	return BuildHTTPEndpointsWithConfig(defaultLogsConfigKeys(), serverlessHTTPEndpointPrefix, intakeTrackType, intakeProtocol, intakeSource)
 }
 
 // ExpectedTagsDuration returns a duration of the time expected tags will be submitted for.
@@ -188,12 +191,12 @@ func buildTCPEndpoints(logsConfig *LogsConfigKeys) (*Endpoints, error) {
 }
 
 // BuildHTTPEndpoints returns the HTTP endpoints to send logs to.
-func BuildHTTPEndpoints(intakeTrackType, intakeProtocol string) (*Endpoints, error) {
-	return BuildHTTPEndpointsWithConfig(defaultLogsConfigKeys(), httpEndpointPrefix, intakeTrackType, intakeProtocol)
+func BuildHTTPEndpoints(intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeSource IntakeSource) (*Endpoints, error) {
+	return BuildHTTPEndpointsWithConfig(defaultLogsConfigKeys(), httpEndpointPrefix, intakeTrackType, intakeProtocol, intakeSource)
 }
 
 // BuildHTTPEndpointsWithConfig uses two arguments that instructs it how to access configuration parameters, then returns the HTTP endpoints to send logs to. This function is able to default to the 'classic' BuildHTTPEndpoints() w ldHTTPEndpointsWithConfigdefault variables logsConfigDefaultKeys and httpEndpointPrefix
-func BuildHTTPEndpointsWithConfig(logsConfig *LogsConfigKeys, endpointPrefix string, intakeTrackType, intakeProtocol string) (*Endpoints, error) {
+func BuildHTTPEndpointsWithConfig(logsConfig *LogsConfigKeys, endpointPrefix string, intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeSource IntakeSource) (*Endpoints, error) {
 	// Provide default values for legacy settings when the configuration key does not exist
 	defaultNoSSL := logsConfig.logsNoSSL()
 
@@ -213,6 +216,7 @@ func BuildHTTPEndpointsWithConfig(logsConfig *LogsConfigKeys, endpointPrefix str
 		main.Version = EPIntakeVersion2
 		main.TrackType = intakeTrackType
 		main.Protocol = intakeProtocol
+		main.Source = intakeSource
 	} else {
 		main.Version = EPIntakeVersion1
 	}
@@ -240,6 +244,7 @@ func BuildHTTPEndpointsWithConfig(logsConfig *LogsConfigKeys, endpointPrefix str
 		if additionals[i].Version == EPIntakeVersion2 {
 			additionals[i].TrackType = intakeTrackType
 			additionals[i].Protocol = intakeProtocol
+			additionals[i].Source = intakeSource
 		}
 	}
 

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -195,7 +195,7 @@ func (suite *ConfigTestSuite) TestMultipleHttpEndpointsEnvVar() {
 
 	expectedEndpoints := NewEndpointsWithBatchSettings(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint1, expectedAdditionalEndpoint2}, false, true,
 		1*time.Second, coreConfig.DefaultBatchMaxConcurrentSend, coreConfig.DefaultBatchMaxSize, coreConfig.DefaultBatchMaxContentSize)
-	endpoints, err := BuildHTTPEndpoints("test-track", "test-proto")
+	endpoints, err := BuildHTTPEndpoints("test-track", "test-proto", "test-source")
 
 	suite.Nil(err)
 	suite.Equal(expectedEndpoints, endpoints)
@@ -292,7 +292,7 @@ func (suite *ConfigTestSuite) TestMultipleHttpEndpointsInConfig() {
 
 	expectedEndpoints := NewEndpointsWithBatchSettings(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint1, expectedAdditionalEndpoint2}, false, true,
 		1*time.Second, coreConfig.DefaultBatchMaxConcurrentSend, coreConfig.DefaultBatchMaxSize, coreConfig.DefaultBatchMaxContentSize)
-	endpoints, err := BuildHTTPEndpoints("test-track", "test-proto")
+	endpoints, err := BuildHTTPEndpoints("test-track", "test-proto", "test-source")
 
 	suite.Nil(err)
 	suite.Equal(expectedEndpoints, endpoints)
@@ -338,6 +338,7 @@ func (suite *ConfigTestSuite) TestMultipleHttpEndpointsInConfig2() {
 		Version:          EPIntakeVersion2,
 		TrackType:        "test-track",
 		Protocol:         "test-proto",
+		Source:           "test-source",
 	}
 	expectedAdditionalEndpoint1 := Endpoint{
 		APIKey:           "456",
@@ -358,11 +359,12 @@ func (suite *ConfigTestSuite) TestMultipleHttpEndpointsInConfig2() {
 		Version:          EPIntakeVersion2,
 		TrackType:        "test-track",
 		Protocol:         "test-proto",
+		Source:           "test-source",
 	}
 
 	expectedEndpoints := NewEndpointsWithBatchSettings(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint1, expectedAdditionalEndpoint2}, false, true,
 		1*time.Second, coreConfig.DefaultBatchMaxConcurrentSend, coreConfig.DefaultBatchMaxSize, coreConfig.DefaultBatchMaxContentSize)
-	endpoints, err := BuildHTTPEndpoints("test-track", "test-proto")
+	endpoints, err := BuildHTTPEndpoints("test-track", "test-proto", "test-source")
 
 	suite.Nil(err)
 	suite.Equal(expectedEndpoints, endpoints)
@@ -412,7 +414,7 @@ func (suite *ConfigTestSuite) TestEndpointsSetLogsDDUrl() {
 	suite.config.Set("compliance_config.endpoints.logs_dd_url", "my-proxy:443")
 
 	logsConfig := NewLogsConfigKeys("compliance_config.endpoints.", suite.config)
-	endpoints, err := BuildHTTPEndpointsWithConfig(logsConfig, "default-intake.mydomain.", "test-track", "test-proto")
+	endpoints, err := BuildHTTPEndpointsWithConfig(logsConfig, "default-intake.mydomain.", "test-track", "test-proto", "test-source")
 
 	suite.Nil(err)
 
@@ -451,7 +453,7 @@ func (suite *ConfigTestSuite) TestEndpointsSetDDSite() {
 	defer os.Unsetenv("DD_COMPLIANCE_CONFIG_ENDPOINTS_BATCH_WAIT")
 
 	logsConfig := NewLogsConfigKeys("compliance_config.endpoints.", suite.config)
-	endpoints, err := BuildHTTPEndpointsWithConfig(logsConfig, "default-intake.logs.", "test-track", "test-proto")
+	endpoints, err := BuildHTTPEndpointsWithConfig(logsConfig, "default-intake.logs.", "test-track", "test-proto", "test-source")
 
 	suite.Nil(err)
 
@@ -505,7 +507,7 @@ func (suite *ConfigTestSuite) TestBuildServerlessEndpoints() {
 		BatchMaxConcurrentSend: coreConfig.DefaultBatchMaxConcurrentSend,
 	}
 
-	endpoints, err := BuildServerlessEndpoints("test-track", "test-proto")
+	endpoints, err := BuildServerlessEndpoints("test-track", "test-proto", "test-source")
 
 	suite.Nil(err)
 	suite.Equal(expectedEndpoints, endpoints)

--- a/pkg/logs/config/endpoints.go
+++ b/pkg/logs/config/endpoints.go
@@ -14,6 +14,15 @@ import (
 // EPIntakeVersion is the events platform intake API version
 type EPIntakeVersion uint8
 
+// IntakeTrackType indicates the type of an endpoint intake.
+type IntakeTrackType string
+
+// IntakeProtocol indicates the protocol to use for an endpoint intake.
+type IntakeProtocol string
+
+// IntakeSource indicates the log source to use for an endpoint intake.
+type IntakeSource string
+
 const (
 	_ EPIntakeVersion = iota
 	// EPIntakeVersion1 is version 1 of the envets platform intake API
@@ -40,8 +49,9 @@ type Endpoint struct {
 	RecoveryReset    bool
 
 	Version   EPIntakeVersion
-	TrackType string
-	Protocol  string
+	TrackType IntakeTrackType
+	Protocol  IntakeProtocol
+	Source    IntakeSource
 }
 
 // Endpoints holds the main endpoint and additional ones to dualship logs.

--- a/pkg/logs/config/endpoints_test.go
+++ b/pkg/logs/config/endpoints_test.go
@@ -25,35 +25,35 @@ func (suite *EndpointsTestSuite) SetupTest() {
 
 func (suite *EndpointsTestSuite) TestLogsEndpointConfig() {
 	suite.Equal("agent-intake.logs.datadoghq.com", coreConfig.GetMainEndpoint(tcpEndpointPrefix, "logs_config.dd_url"))
-	endpoints, err := BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err := BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.Equal("agent-intake.logs.datadoghq.com", endpoints.Main.Host)
 	suite.Equal(10516, endpoints.Main.Port)
 
 	suite.config.Set("site", "datadoghq.com")
 	suite.Equal("agent-intake.logs.datadoghq.com", coreConfig.GetMainEndpoint(tcpEndpointPrefix, "logs_config.dd_url"))
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.Equal("agent-intake.logs.datadoghq.com", endpoints.Main.Host)
 	suite.Equal(10516, endpoints.Main.Port)
 
 	suite.config.Set("site", "datadoghq.eu")
 	suite.Equal("agent-intake.logs.datadoghq.eu", coreConfig.GetMainEndpoint(tcpEndpointPrefix, "logs_config.dd_url"))
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.Equal("agent-intake.logs.datadoghq.eu", endpoints.Main.Host)
 	suite.Equal(443, endpoints.Main.Port)
 
 	suite.config.Set("logs_config.dd_url", "lambda.logs.datadoghq.co.jp")
 	suite.Equal("lambda.logs.datadoghq.co.jp", coreConfig.GetMainEndpoint(tcpEndpointPrefix, "logs_config.dd_url"))
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.Equal("lambda.logs.datadoghq.co.jp", endpoints.Main.Host)
 	suite.Equal(10516, endpoints.Main.Port)
 
 	suite.config.Set("logs_config.logs_dd_url", "azure.logs.datadoghq.co.uk:1234")
 	suite.Equal("azure.logs.datadoghq.co.uk:1234", coreConfig.GetMainEndpoint(tcpEndpointPrefix, "logs_config.logs_dd_url"))
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.Equal("azure.logs.datadoghq.co.uk", endpoints.Main.Host)
 	suite.Equal(1234, endpoints.Main.Port)
@@ -68,7 +68,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithDefaultAndVa
 	suite.config.Set("api_key", "azerty")
 	suite.config.Set("logs_config.socks5_proxy_address", "boz:1234")
 
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	endpoint = endpoints.Main
 	suite.Equal("azerty", endpoint.APIKey)
@@ -79,7 +79,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithDefaultAndVa
 	suite.Equal(0, len(endpoints.Additionals))
 
 	suite.config.Set("logs_config.use_port_443", true)
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	endpoint = endpoints.Main
 	suite.Equal("azerty", endpoint.APIKey)
@@ -91,7 +91,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithDefaultAndVa
 
 	suite.config.Set("logs_config.logs_dd_url", "host:1234")
 	suite.config.Set("logs_config.logs_no_ssl", true)
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	endpoint = endpoints.Main
 	suite.Equal("azerty", endpoint.APIKey)
@@ -103,7 +103,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithDefaultAndVa
 
 	suite.config.Set("logs_config.logs_dd_url", ":1234")
 	suite.config.Set("logs_config.logs_no_ssl", false)
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	endpoint = endpoints.Main
 	suite.Equal("azerty", endpoint.APIKey)
@@ -121,7 +121,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPCon
 
 	suite.config.Set("logs_config.use_http", true)
 
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.True(endpoints.UseHTTP)
 	suite.Equal(endpoints.BatchWait, 5*time.Second)
@@ -139,7 +139,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPCon
 	suite.config.Set("logs_config.use_http", true)
 	suite.config.Set("logs_config.use_compression", true)
 
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.True(endpoints.UseHTTP)
 
@@ -157,7 +157,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPCon
 	suite.config.Set("logs_config.use_compression", true)
 	suite.config.Set("logs_config.compression_level", 1)
 
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.True(endpoints.UseHTTP)
 
@@ -175,7 +175,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidHTTPCon
 	suite.config.Set("logs_config.dd_url", "foo")
 	suite.config.Set("logs_config.batch_wait", 9)
 
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.True(endpoints.UseHTTP)
 	suite.Equal(endpoints.BatchWait, 9*time.Second)
@@ -193,7 +193,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWithValidProxyCo
 	suite.config.Set("logs_config.use_http", true)
 	suite.config.Set("logs_config.logs_dd_url", "foo:1234")
 
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.True(endpoints.UseHTTP)
 
@@ -209,7 +209,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldFailWithInvalidProxyCon
 	suite.config.Set("logs_config.use_http", true)
 	suite.config.Set("logs_config.logs_dd_url", "foo")
 
-	_, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	_, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.NotNil(err)
 }
 
@@ -220,7 +220,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldFailWithInvalidOverride
 	}
 	for _, url := range invalidURLs {
 		suite.config.Set("logs_config.logs_dd_url", url)
-		_, err := BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+		_, err := BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 		suite.NotNil(err)
 	}
 }
@@ -231,7 +231,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldFallbackOnDefaultWithIn
 	invalidBatchWaits := []int{-1, 0, 11}
 	for _, batchWait := range invalidBatchWaits {
 		suite.config.Set("logs_config.batch_wait", batchWait)
-		endpoints, err := BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+		endpoints, err := BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 		suite.Nil(err)
 		suite.Equal(endpoints.BatchWait, coreConfig.DefaultBatchWait*time.Second)
 	}
@@ -240,7 +240,7 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldFallbackOnDefaultWithIn
 //When migrating the agent v5 to v6, logs_dd_url is set to empty. Default to the dd_url/site already set instead.
 func (suite *EndpointsTestSuite) TestBuildEndpointsShouldSucceedWhenMigratingToAgentV6() {
 	suite.config.Set("logs_config.logs_dd_url", "")
-	endpoints, err := BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err := BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.Equal("agent-intake.logs.datadoghq.com", endpoints.Main.Host)
 	suite.Equal(10516, endpoints.Main.Port)
@@ -250,30 +250,30 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldTakeIntoAccountHTTPConn
 	// When use_http is true always create HTTP endpoints
 	suite.config.Set("logs_config.use_http", "true")
 	suite.config.Set("logs_config.use_tcp", "false")
-	endpoints, err := BuildEndpoints(HTTPConnectivitySuccess, "test-track", "test-proto")
+	endpoints, err := BuildEndpoints(HTTPConnectivitySuccess, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.True(endpoints.UseHTTP)
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.True(endpoints.UseHTTP)
 
 	// When use_tcp is true always create TCP endpoints
 	suite.config.Set("logs_config.use_http", "false")
 	suite.config.Set("logs_config.use_tcp", "true")
-	endpoints, err = BuildEndpoints(HTTPConnectivitySuccess, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivitySuccess, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.False(endpoints.UseHTTP)
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.False(endpoints.UseHTTP)
 
 	// When use_http & use_tcp are false create HTTP endpoints if HTTP connectivity is successful
 	suite.config.Set("logs_config.use_http", "false")
 	suite.config.Set("logs_config.use_tcp", "false")
-	endpoints, err = BuildEndpoints(HTTPConnectivitySuccess, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivitySuccess, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.True(endpoints.UseHTTP)
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.False(endpoints.UseHTTP)
 
@@ -281,10 +281,10 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldTakeIntoAccountHTTPConn
 	suite.config.Set("logs_config.use_http", "false")
 	suite.config.Set("logs_config.use_tcp", "false")
 	suite.config.Set("logs_config.socks5_proxy_address", "my-address")
-	endpoints, err = BuildEndpoints(HTTPConnectivitySuccess, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivitySuccess, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.False(endpoints.UseHTTP)
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.False(endpoints.UseHTTP)
 	suite.config.Set("logs_config.socks5_proxy_address", "")
@@ -300,10 +300,10 @@ func (suite *EndpointsTestSuite) TestBuildEndpointsShouldTakeIntoAccountHTTPConn
 			"compression_level": 1,
 		},
 	})
-	endpoints, err = BuildEndpoints(HTTPConnectivitySuccess, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivitySuccess, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.False(endpoints.UseHTTP)
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.False(endpoints.UseHTTP)
 }
@@ -319,7 +319,7 @@ func (suite *EndpointsTestSuite) TestIsSetAndNotEmpty() {
 func (suite *EndpointsTestSuite) TestDefaultApiKey() {
 	suite.config.Set("api_key", "wassupkey")
 	suite.Equal("wassupkey", defaultLogsConfigKeys().getLogsAPIKey())
-	endpoints, err := BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err := BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.Equal("wassupkey", endpoints.Main.APIKey)
 }
@@ -328,7 +328,7 @@ func (suite *EndpointsTestSuite) TestOverrideApiKey() {
 	suite.config.Set("api_key", "wassupkey")
 	suite.config.Set("logs_config.api_key", "wassuplogskey")
 	suite.Equal("wassuplogskey", defaultLogsConfigKeys().getLogsAPIKey())
-	endpoints, err := BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err := BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.Equal("wassuplogskey", endpoints.Main.APIKey)
 }
@@ -349,7 +349,7 @@ func (suite *EndpointsTestSuite) TestAdditionalEndpoints() {
 		},
 	})
 
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.Len(endpoints.Additionals, 1)
 
@@ -359,7 +359,7 @@ func (suite *EndpointsTestSuite) TestAdditionalEndpoints() {
 	suite.True(endpoint.UseSSL)
 
 	suite.config.Set("logs_config.use_http", true)
-	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, err = BuildEndpoints(HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	suite.Nil(err)
 	suite.Len(endpoints.Additionals, 1)
 

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -59,13 +59,13 @@ func StartServerless(getAC func() *autodiscovery.AutoConfig, logsChan chan *conf
 // buildEndpoints builds endpoints for the logs agent
 func buildEndpoints(serverless bool) (*config.Endpoints, error) {
 	if serverless {
-		return config.BuildServerlessEndpoints(intakeTrackType, config.DefaultIntakeProtocol)
+		return config.BuildServerlessEndpoints(intakeTrackType, config.DefaultIntakeProtocol, config.DefaultIntakeSource)
 	}
 	httpConnectivity := config.HTTPConnectivityFailure
-	if endpoints, err := config.BuildHTTPEndpoints(intakeTrackType, intakeProtocol); err == nil {
+	if endpoints, err := config.BuildHTTPEndpoints(intakeTrackType, intakeProtocol, config.DefaultIntakeSource); err == nil {
 		httpConnectivity = http.CheckConnectivity(endpoints.Main)
 	}
-	return config.BuildEndpoints(httpConnectivity, intakeTrackType, intakeProtocol)
+	return config.BuildEndpoints(httpConnectivity, intakeTrackType, intakeProtocol, config.DefaultIntakeSource)
 }
 
 func start(getAC func() *autodiscovery.AutoConfig, serverless bool, logsChan chan *config.ChannelMessage, extraTags []string) error {

--- a/pkg/logs/status/test_utils.go
+++ b/pkg/logs/status/test_utils.go
@@ -13,6 +13,6 @@ import (
 // InitStatus initialize a status builder
 func InitStatus(sources *config.LogSources) {
 	var isRunning int32 = 1
-	endpoints, _ := config.BuildEndpoints(config.HTTPConnectivityFailure, "test-track", "test-proto")
+	endpoints, _ := config.BuildEndpoints(config.HTTPConnectivityFailure, "test-track", "test-proto", "test-source")
 	Init(&isRunning, endpoints, sources, metrics.LogsExpvars)
 }


### PR DESCRIPTION
### What does this PR do?

When using the new v2 logs intake, the 'DD-SOURCE' HTTP header can now be specified.
This PR also fixes a bug that caused a wrong URL to be used for compliance and runtime endpoints.

### Motivation

Using the DD-SOURCE header allows making the distinction between logs going to the same intake track.