### PR TITLE
Fix cgroup parsing with systemd cgroup manager and CRIO

### DIFF
--- a/pkg/util/containers/providers/cgroup/provider.go
+++ b/pkg/util/containers/providers/cgroup/provider.go
@@ -141,7 +141,7 @@ func (mp *provider) GetNetworkMetrics(containerID string, networks map[string]st
 		return nil, errors.New("no pid for this container")
 	}
 
-	metrics, err := collectNetworkStats(int(cg.Pids[0]), networks)
+	metrics, err := collectNetworkStats(int(cg.Pids[len(cg.Pids)-1]), networks)
 	if err != nil {
 		return nil, fmt.Errorf("Could not collect network stats for container %s: %s", containerID[:12], err)
 	}

--- a/releasenotes/notes/fix-crio-systemd-58f6343fb742c9d5.yaml
+++ b/releasenotes/notes/fix-crio-systemd-58f6343fb742c9d5.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a bug in cgroup parser preventing from getting proper metrics in Container Live View when using CRI-O and systemd cgroup manager.


### PR DESCRIPTION
### What does this PR do?

When the Agent is deployed on Kubernetes with CRI-O and using the `systemd` cgroup manager, the `cgroup` collector confuses the wrapping `crio/common` process as referencing PODs/containers cgroups, leading to wrong values in the `Live Container View`.

### Motivation

Bugfix.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Deploy a Kubernetes cluster with CRI-O using `systemd` as cgroup manager (can be achieved with `minikube`: `minikube start --force-systemd=true --container-runtime=cri-o --driver=hyperkit`).
Deploy the Agent, the statistics in Container Live View should be accurate for all containers.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
