### PR TITLE
logs-agent: retry on 429's from intake

### DIFF
--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -172,9 +172,9 @@ func (d *Destination) unconditionalSend(payload []byte) (err error) {
 	if resp.StatusCode >= 400 {
 		log.Warnf("failed to post http payload. code=%d host=%s response=%s", resp.StatusCode, d.host, string(response))
 	}
-	if resp.StatusCode >= 500 {
-		// the server could not serve the request,
-		// most likely because of an internal error
+	if resp.StatusCode == 429 || resp.StatusCode >= 500 {
+		// the server could not serve the request, most likely because of an
+		// internal error or, (429) because it is overwhelmed
 		return client.NewRetryableError(errServer)
 	} else if resp.StatusCode >= 400 {
 		// the logs-agent is likely to be misconfigured,

--- a/pkg/logs/client/http/destination_test.go
+++ b/pkg/logs/client/http/destination_test.go
@@ -108,8 +108,18 @@ func TestDestinationSend500(t *testing.T) {
 	server := NewHTTPServerTest(500)
 	err := server.destination.Send([]byte("yo"))
 	assert.NotNil(t, err)
-	_, ok := err.(*client.RetryableError)
-	assert.True(t, ok)
+	_, retriable := err.(*client.RetryableError)
+	assert.True(t, retriable)
+	assert.Equal(t, "server error", err.Error())
+	server.stop()
+}
+
+func TestDestinationSend429(t *testing.T) {
+	server := NewHTTPServerTest(429)
+	err := server.destination.Send([]byte("yo"))
+	assert.NotNil(t, err)
+	_, retriable := err.(*client.RetryableError)
+	assert.True(t, retriable)
 	assert.Equal(t, "server error", err.Error())
 	server.stop()
 }
@@ -118,8 +128,8 @@ func TestDestinationSend400(t *testing.T) {
 	server := NewHTTPServerTest(400)
 	err := server.destination.Send([]byte("yo"))
 	assert.NotNil(t, err)
-	_, ok := err.(*client.RetryableError)
-	assert.False(t, ok)
+	_, retriable := err.(*client.RetryableError)
+	assert.False(t, retriable)
 	assert.Equal(t, "client error", err.Error())
 	server.stop()
 }

--- a/releasenotes/notes/retry-log-send-on-429-ec0c5e071c44f5b9.yaml
+++ b/releasenotes/notes/retry-log-send-on-429-ec0c5e071c44f5b9.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    The logs-agent now retries on an HTTP 429 response, where this had been treated as a hard failure.
+    The v2 Event Intake will return 429 responses when it is overwhelmed.


### PR DESCRIPTION
### What does this PR do?

When the intake server responds with an HTTP 429, the logs-agent now
retries sending the event using its usual backoff.  The v2 Event Intake
API will use 429's to signal that the server is overwhelmed.

### Motivation

Prepare for the v2 Event Intake API.

### Describe how to test your changes

This PR includes a new unit test for an HTTP 429 response.

Since this should not change any current behavior, QA can consist of observing that log intake still works.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.

Note: Adding GitHub labels is only possible for contributors with write access.
