### PR TITLE
Rename master -> main in a few missed spots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Datadog Agent
 
 [![CircleCI](https://circleci.com/gh/DataDog/datadog-agent/tree/main.svg?style=svg&circle-token=dbcee3f02b9c3fe5f142bfc5ecb735fdec34b643)](https://circleci.com/gh/DataDog/datadog-agent/tree/main)
-[![Build status](https://ci.appveyor.com/api/projects/status/kcwhmlsc0oq3m49p/branch/master?svg=true)](https://ci.appveyor.com/project/Datadog/datadog-agent/branch/master)
-[![Coverage status](https://codecov.io/github/DataDog/datadog-agent/coverage.svg?branch=master)](https://codecov.io/github/DataDog/datadog-agent?branch=master)
+[![Build status](https://ci.appveyor.com/api/projects/status/kcwhmlsc0oq3m49p/branch/main?svg=true)](https://ci.appveyor.com/project/Datadog/datadog-agent/branch/main)
+[![Coverage status](https://codecov.io/github/DataDog/datadog-agent/coverage.svg?branch=main)](https://codecov.io/github/DataDog/datadog-agent?branch=main)
 [![GoDoc](https://godoc.org/github.com/DataDog/datadog-agent?status.svg)](https://godoc.org/github.com/DataDog/datadog-agent)
 [![Go Report Card](https://goreportcard.com/badge/github.com/DataDog/datadog-agent)](https://goreportcard.com/report/github.com/DataDog/datadog-agent)
 
@@ -40,7 +40,7 @@ To build the Agent you need:
 Builds and tests are orchestrated with `invoke`, type `invoke --list` on a shell
 to see the available tasks.
 
-To start working on the Agent, you can build the `master` branch:
+To start working on the Agent, you can build the `main` branch:
 
 1. Checkout the repo: `git clone https://github.com/DataDog/datadog-agent.git $GOPATH/src/github.com/DataDog/datadog-agent`.
 2. cd into the project folder: `cd $GOPATH/src/github.com/DataDog/datadog-agent`.

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -41,7 +41,7 @@ when submitting your PR:
   * summarize your PR with an explanatory title and a message describing your
     changes, cross-referencing any related bugs/PRs.
   * use [Reno](#reno) to create a releasenote.
-  * open your PR against the `master` branch.
+  * open your PR against the `main` branch.
   * for PRs from contributors with write access to the repository (for community PRs, will be done by Datadog employees):
     + set the relevant `team/` label
     + add a milestone to your PR (by default, use the highest milestone version available, ex: `6.8.0`)
@@ -91,7 +91,7 @@ body to skip the build and give that slot to someone else who does need it.
 
 ### Squash your commits
 
-Please rebase your changes on `master` and squash your commits whenever possible,
+Please rebase your changes on `main` and squash your commits whenever possible,
 it keeps history cleaner and it's easier to revert things. It also makes developers
 happier!
 

--- a/pkg/clusteragent/README.md
+++ b/pkg/clusteragent/README.md
@@ -1,7 +1,7 @@
 # Datadog Cluster Agent - DCA
 
 [![CircleCI](https://circleci.com/gh/DataDog/datadog-agent/tree/main.svg?style=svg&circle-token=dbcee3f02b9c3fe5f142bfc5ecb735fdec34b643)](https://circleci.com/gh/DataDog/datadog-agent/tree/main)
-[![Build status](https://ci.appveyor.com/api/projects/status/kcwhmlsc0oq3m49p/branch/master?svg=true)](https://ci.appveyor.com/project/Datadog/datadog-agent/branch/master)
+[![Build status](https://ci.appveyor.com/api/projects/status/kcwhmlsc0oq3m49p/branch/main?svg=true)](https://ci.appveyor.com/project/Datadog/datadog-agent/branch/main)
 [![GoDoc](https://godoc.org/github.com/DataDog/datadog-agent?status.svg)](https://godoc.org/github.com/DataDog/datadog-agent)
 
 The Datadog Cluster Agent (referred to as DCA) faithfully collects events and metrics and brings them to
@@ -25,7 +25,7 @@ currently in Alpha.
 
 For pre-requisite, refer to the Agent's Getting Started section in the [README](https://github.com/DataDog/datadog-agent/blob/main/README.md)
 
-To start working on the Cluster Agent, you can build the `master` branch:
+To start working on the Cluster Agent, you can build the `main` branch:
 
 1. Clone the repo: `git clone https://github.com/DataDog/datadog-agent.git $GOPATH/src/github.com/DataDog/datadog-agent`.
 2. cd into the project folder: `cd $GOPATH/src/github.com/DataDog/datadog-agent`.


### PR DESCRIPTION

### What does this PR do?

This fixes a few loose ends missed in 153d3e940cf77138d5a9ab821ed9351d534d14de.

### Motivation

Brief confusion at seeing "master" in the READMEs

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
