### PR TITLE
[runtime-security] do not use zero cookie

### DIFF
--- a/pkg/security/ebpf/c/cgroup.h
+++ b/pkg/security/ebpf/c/cgroup.h
@@ -39,7 +39,7 @@ static __attribute__((always_inline)) int trace__cgroup_write(struct pt_regs *ct
     if (pid_entry) {
         cookie = pid_entry->cookie;
         // Select the old cache entry
-        old_entry = bpf_map_lookup_elem(&proc_cache, &cookie);
+        old_entry = get_proc_from_cookie(cookie);
         if (old_entry) {
             // copy cache data
             copy_proc_cache(old_entry, &new_entry);

--- a/pkg/security/ebpf/c/process.h
+++ b/pkg/security/ebpf/c/process.h
@@ -95,6 +95,9 @@ struct bpf_map_def SEC("maps/pid_cache") pid_cache = {
     .namespace = "",
 };
 
+// defined in exec.h
+struct proc_cache_t *get_proc_from_cookie(u32 cookie);
+
 struct proc_cache_t * __attribute__((always_inline)) get_proc_cache(u32 tgid) {
     struct proc_cache_t *entry = NULL;
 
@@ -102,7 +105,7 @@ struct proc_cache_t * __attribute__((always_inline)) get_proc_cache(u32 tgid) {
     if (pid_entry) {
         // Select the cache entry
         u32 cookie = pid_entry->cookie;
-        entry = bpf_map_lookup_elem(&proc_cache, &cookie);
+        entry = get_proc_from_cookie(cookie);
     }
     return entry;
 }


### PR DESCRIPTION
### What does this PR do?

Ensure that we don't use zero cookie for proc_cache lookup.

### Motivation

Wrong container id inheritance from a bug introduced in
https://github.com/DataDog/datadog-agent/pull/7491

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
