### PR TITLE
Fix nettop invoke task path

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -296,7 +296,7 @@ def nettop(ctx, incremental_build=False, go_mod="mod"):
     # Build
     ctx.run(
         cmd.format(
-            path=os.path.join(REPO_PATH, "pkg", "ebpf", "nettop"),
+            path=os.path.join(REPO_PATH, "pkg", "network", "nettop"),
             bin_path=bin_path,
             go_mod=go_mod,
             build_type="" if incremental_build else "-a",


### PR DESCRIPTION
### What does this PR do?

The path to the `nettop` code in the invoke task was incorrect.

### Motivation

Fixes #7747

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
