### PR TITLE
Make conntrack initialization timeout a configurable value

### DIFF
--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -99,6 +99,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "conntrack_rate_limit"), 500)
 	cfg.BindEnvAndSetDefault(join(spNS, "enable_conntrack_all_namespaces"), true, "DD_SYSTEM_PROBE_ENABLE_CONNTRACK_ALL_NAMESPACES")
 	cfg.BindEnvAndSetDefault(join(netNS, "ignore_conntrack_init_failure"), false, "DD_SYSTEM_PROBE_NETWORK_IGNORE_CONNTRACK_INIT_FAILURE")
+	cfg.BindEnvAndSetDefault(join(netNS, "conntrack_init_timeout"), 10*time.Second)
 
 	cfg.BindEnvAndSetDefault(join(spNS, "source_excludes"), map[string][]string{})
 	cfg.BindEnvAndSetDefault(join(spNS, "dest_excludes"), map[string][]string{})

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -115,6 +115,9 @@ type Config struct {
 	// Setting it to -1 disables the limit and can result in a high CPU usage.
 	ConntrackRateLimit int
 
+	// ConntrackInitTimeout specifies how long we wait for conntrack to initialize before failing
+	ConntrackInitTimeout time.Duration
+
 	// EnableConntrackAllNamespaces enables network address translation via netlink for all namespaces that are peers of the root namespace.
 	// default is true
 	EnableConntrackAllNamespaces bool
@@ -191,6 +194,7 @@ func New() *Config {
 		ConntrackRateLimit:           cfg.GetInt(join(spNS, "conntrack_rate_limit")),
 		EnableConntrackAllNamespaces: cfg.GetBool(join(spNS, "enable_conntrack_all_namespaces")),
 		IgnoreConntrackInitFailure:   cfg.GetBool(join(netNS, "ignore_conntrack_init_failure")),
+		ConntrackInitTimeout:         cfg.GetDuration(join(netNS, "conntrack_init_timeout")),
 
 		EnableGatewayLookup: cfg.GetBool(join(netNS, "enable_gateway_lookup")),
 

--- a/pkg/network/netlink/conntracker.go
+++ b/pkg/network/netlink/conntracker.go
@@ -20,8 +20,6 @@ import (
 )
 
 const (
-	initializationTimeout = time.Second * 10
-
 	compactInterval      = time.Minute
 	defaultOrphanTimeout = 2 * time.Minute
 )
@@ -94,8 +92,8 @@ func NewConntracker(config *config.Config) (Conntracker, error) {
 	select {
 	case <-done:
 		return conntracker, err
-	case <-time.After(initializationTimeout):
-		return nil, fmt.Errorf("could not initialize conntrack after: %s", initializationTimeout)
+	case <-time.After(config.ConntrackInitTimeout):
+		return nil, fmt.Errorf("could not initialize conntrack after: %s", config.ConntrackInitTimeout)
 	}
 }
 

--- a/pkg/network/tracer/ebpf_conntracker.go
+++ b/pkg/network/tracer/ebpf_conntracker.go
@@ -31,10 +31,6 @@ import (
 */
 import "C"
 
-const (
-	initializationTimeout = time.Second * 10
-)
-
 var tuplePool = sync.Pool{
 	New: func() interface{} {
 		return new(ConnTuple)
@@ -95,13 +91,13 @@ func NewEBPFConntracker(cfg *config.Config) (netlink.Conntracker, error) {
 		telemetryMap: telemetryMap,
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), initializationTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.ConntrackInitTimeout)
 	defer cancel()
 
 	err = e.dumpInitialTables(ctx, cfg)
 	if err != nil {
 		if errors.Is(err, context.DeadlineExceeded) {
-			return nil, fmt.Errorf("could not initialize conntrack after %s", initializationTimeout)
+			return nil, fmt.Errorf("could not initialize conntrack after %s", cfg.ConntrackInitTimeout)
 		}
 		return nil, err
 	}


### PR DESCRIPTION
### What does this PR do?

Makes the `conntrack` initialization timeout configurable. Fixes #7781. Related to #8181

### Motivation

The default `conntrack` initialization timeout of 10s can be too aggressive for some hosts with a large number of processes. If `conntrack` fails to initialize, then system-probe exits.

### Describe how to test your changes

Set `network_config.conntrack_init_timeout = 5ms` and start system-probe. You should see a fast failure of the system-probe and a log line with `could not initialize conntrack after: 5ms`

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
