### PR TITLE
[AD] Ignore containers stopped too long ago

### DIFF
--- a/pkg/autodiscovery/listeners/docker.go
+++ b/pkg/autodiscovery/listeners/docker.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
@@ -135,9 +136,6 @@ func (l *DockerListener) Stop() {
 // creates services for them, and pass them to the AutoConfig.
 // It is typically called at start up.
 func (l *DockerListener) init() {
-	l.m.Lock()
-	defer l.m.Unlock()
-
 	ctx := context.TODO()
 
 	containersList, err := l.dockerUtil.RawContainerList(ctx, types.ContainerListOptions{})
@@ -146,58 +144,7 @@ func (l *DockerListener) init() {
 	}
 
 	for _, co := range containersList {
-		if l.isExcluded(ctx, co) {
-			continue // helper method already logs
-		}
-		var svc Service
-
-		checkNames, err := getCheckNamesFromLabels(co.Labels)
-		if err != nil {
-			log.Errorf("Error getting check names from docker labels on container %s: %v", co.ID, err)
-		}
-
-		containerImage, err := l.dockerUtil.ResolveImageName(ctx, co.Image)
-		if err != nil {
-			log.Warnf("Error while resolving image name: %s", err)
-			containerImage = ""
-		}
-		metricsExcluded := false
-		logsExcluded := false
-		for _, name := range co.Names {
-			if l.filters.IsExcluded(containers.MetricsFilter, name, containerImage, "") {
-				metricsExcluded = true
-			}
-			if l.filters.IsExcluded(containers.LogsFilter, name, containerImage, "") {
-				logsExcluded = true
-			}
-			if metricsExcluded && logsExcluded {
-				break
-			}
-		}
-
-		if findKubernetesInLabels(co.Labels) {
-			svc = &DockerKubeletService{
-				DockerService: DockerService{
-					cID:           co.ID,
-					adIdentifiers: l.getConfigIDFromPs(ctx, co),
-					checkNames:    checkNames,
-					// Host and Ports will be looked up when needed
-				},
-			}
-		} else {
-			svc = &DockerService{
-				cID:             co.ID,
-				adIdentifiers:   l.getConfigIDFromPs(ctx, co),
-				hosts:           l.getHostsFromPs(co),
-				ports:           l.getPortsFromPs(co),
-				creationTime:    integration.Before,
-				checkNames:      checkNames,
-				metricsExcluded: metricsExcluded,
-				logsExcluded:    logsExcluded,
-			}
-		}
-		l.newService <- svc
-		l.services[co.ID] = svc
+		l.createService(ctx, co.ID)
 	}
 }
 
@@ -227,7 +174,7 @@ func (l *DockerListener) processEvent(ctx context.Context, e *docker.ContainerEv
 	} else {
 		// we might receive a `die` event for an unrelated container we don't
 		// care about, let's ignore it.
-		if e.Action == "start" {
+		if e.Action == docker.ContainerEventActionStart {
 			l.createService(ctx, cID)
 		}
 	}
@@ -253,12 +200,28 @@ func (l *DockerListener) createService(ctx context.Context, cID string) {
 		log.Warnf("error while resolving image name: %s", err)
 		containerImage = ""
 	}
+
 	// Detect AD exclusion
 	containerName = cInspect.Name
 	if l.filters.IsExcluded(containers.GlobalFilter, containerName, containerImage, "") {
 		log.Debugf("container %s filtered out: name %q image %q", cID[:12], containerName, containerImage)
 		return
 	}
+
+	// Ignore containers that have been stopped for too long
+	if !cInspect.State.Running && cInspect.State.FinishedAt != "" {
+		finishedAt, err := time.Parse(time.RFC3339, cInspect.State.FinishedAt)
+		if err == nil {
+			excludeAge := time.Duration(config.Datadog.GetInt("container_exclude_stopped_age")) * time.Hour
+			if time.Now().Sub(finishedAt) > excludeAge {
+				log.Debugf("container %q not running for too long, skipping", cID[:12])
+				return
+			}
+		} else {
+			log.Debugf("container %q not running, but can't parse FinishedAt: %s", cID[:12])
+		}
+	}
+
 	if findKubernetesInLabels(cInspect.Config.Labels) {
 		isKube = true
 	}
@@ -399,21 +362,6 @@ func (s *DockerService) GetEntity() string {
 
 func (s *DockerService) GetTaggerEntity() string {
 	return docker.ContainerIDToTaggerEntityName(s.cID)
-}
-
-func (l *DockerListener) isExcluded(ctx context.Context, co types.Container) bool {
-	image, err := l.dockerUtil.ResolveImageName(ctx, co.Image)
-	if err != nil {
-		log.Warnf("error while resolving image name: %s", err)
-		image = ""
-	}
-	for _, name := range co.Names {
-		if l.filters.IsExcluded(containers.GlobalFilter, name, image, "") {
-			log.Debugf("container %s filtered out: name %q image %q", co.ID[:12], name, image)
-			return true
-		}
-	}
-	return false
 }
 
 // GetADIdentifiers returns a set of AD identifiers for a container.

--- a/pkg/autodiscovery/listeners/docker_test.go
+++ b/pkg/autodiscovery/listeners/docker_test.go
@@ -609,3 +609,106 @@ func TestGetCheckNames(t *testing.T) {
 	checkNames := s.GetCheckNames(ctx)
 	assert.Equal(t, []string{"redis"}, checkNames)
 }
+
+func TestCreateService(t *testing.T) {
+	d, err := docker.GetDockerUtil()
+	if err != nil {
+		t.Fatalf("cannot get docker util: %s", err)
+	}
+
+	filters, err := newContainerFilters()
+	if err != nil {
+		t.Fatalf("cannot create container filters: %s", err)
+	}
+
+	l := &DockerListener{
+		dockerUtil: d,
+		filters:    filters,
+		services:   make(map[string]Service),
+		newService: make(chan<- Service, 100),
+	}
+
+	imageName := "test"
+	cID := "12345678901234567890123456789012"
+	cacheKey := docker.GetInspectCacheKey(cID, false)
+
+	tests := []struct {
+		name      string
+		container types.ContainerJSON
+		service   Service
+	}{
+		{
+			name: "container running",
+			container: types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					ID:    cID,
+					Image: imageName,
+					State: &types.ContainerState{
+						Running: true,
+					},
+				},
+				Config: &container.Config{},
+			},
+			service: &DockerService{
+				cID:             cID,
+				adIdentifiers:   []string{fmt.Sprintf("docker://%s", cID), imageName},
+				creationTime:    1,
+				hosts:           map[string]string{},
+				ports:           []ContainerPort{},
+				metricsExcluded: false,
+				logsExcluded:    false,
+			},
+		},
+		{
+			name: "stopped container, not too old",
+			container: types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					ID:    cID,
+					Image: imageName,
+					State: &types.ContainerState{
+						Running:    false,
+						FinishedAt: time.Now().Add(-1 * time.Hour).Format(time.RFC3339),
+					},
+				},
+				Config: &container.Config{},
+			},
+			service: &DockerService{
+				cID:             cID,
+				adIdentifiers:   []string{fmt.Sprintf("docker://%s", cID), imageName},
+				creationTime:    1,
+				hosts:           map[string]string{},
+				ports:           []ContainerPort{},
+				metricsExcluded: false,
+				logsExcluded:    false,
+			},
+		},
+		{
+			name: "stopped container, too old",
+			container: types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					ID:    cID,
+					Image: imageName,
+					State: &types.ContainerState{
+						Running:    false,
+						FinishedAt: time.Now().Add(-24 * time.Hour).Format(time.RFC3339),
+					},
+				},
+				Config: &container.Config{},
+			},
+			service: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cache.Cache.Set(cacheKey, tt.container, time.Minute)
+			defer cache.Cache.Delete(cacheKey)
+
+			ctx := context.Background()
+			l.createService(ctx, cID)
+			defer delete(l.services, cID)
+
+			assert.Equal(t, tt.service, l.services[cID])
+		})
+	}
+}

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -150,13 +150,10 @@ func (l *KubeletListener) Stop() {
 
 func (l *KubeletListener) processNewPods(pods []*kubelet.Pod, firstRun bool) {
 	for _, pod := range pods {
-		// We ignore the state of the pod but only taking containers with ids
-		// into consideration (not pending)
 		for _, container := range pod.Status.GetAllContainers() {
-			if !container.IsPending() {
-				l.createService(container.ID, pod, firstRun)
-			}
+			l.createService(container, pod, firstRun)
 		}
+
 		l.createPodService(pod, firstRun)
 	}
 }
@@ -209,13 +206,48 @@ func (l *KubeletListener) createPodService(pod *kubelet.Pod, firstRun bool) {
 	l.newService <- &svc
 }
 
-func (l *KubeletListener) createService(entity string, pod *kubelet.Pod, firstRun bool) {
+func (l *KubeletListener) createService(container kubelet.ContainerStatus, pod *kubelet.Pod, firstRun bool) {
+	if container.IsPending() {
+		return
+	}
+
+	// Get the ImageName from the `spec` because the one in `status` isn’t reliable
+	containerImage := ""
+	for _, containerSpec := range pod.Spec.Containers {
+		if containerSpec.Name == container.Name {
+			containerImage = containerSpec.Image
+		}
+	}
+
+	if containerImage == "" {
+		log.Debugf("couldn't find the container %s (%s) in the spec of pod %s", container.Name, container.ID, pod.Metadata.Name)
+		containerImage = container.Image
+	}
+
+	// Detect AD exclusion
+	if l.filters.IsExcluded(containers.GlobalFilter, container.Name, containerImage, pod.Metadata.Namespace) {
+		log.Debugf("container %s filtered out: name %q image %q namespace %q", container.ID, container.Name, containerImage, pod.Metadata.Namespace)
+		return
+	}
+
+	// Ignore containers that have been stopped for too long
+	if terminated := container.State.Terminated; terminated != nil {
+		finishedAt := terminated.FinishedAt
+		excludeAge := time.Duration(config.Datadog.GetInt("container_exclude_stopped_age")) * time.Hour
+		if time.Now().Sub(finishedAt) > excludeAge {
+			log.Debugf("container %q not running for too long, skipping", container.ID)
+			return
+		}
+	}
+
 	var crTime integration.CreationTime
 	if firstRun {
 		crTime = integration.Before
 	} else {
 		crTime = integration.After
 	}
+
+	entity := container.ID
 	svc := KubeContainerService{
 		entity:       entity,
 		creationTime: crTime,
@@ -228,68 +260,42 @@ func (l *KubeletListener) createService(entity string, pod *kubelet.Pod, firstRu
 	}
 	podName := pod.Metadata.Name
 
+	// Detect metrics or logs exclusion
+	// Exclude terminated containers (including init containers) from metrics collection but keep them for collecting logs.
+	svc.metricsExcluded = l.filters.IsExcluded(containers.MetricsFilter, container.Name, containerImage, pod.Metadata.Namespace) || container.IsTerminated()
+	svc.logsExcluded = l.filters.IsExcluded(containers.LogsFilter, container.Name, containerImage, pod.Metadata.Namespace)
+
 	// AD Identifiers
-	var containerName string
-	for _, container := range pod.Status.GetAllContainers() {
-		if container.ID == svc.entity {
-			// Get the ImageName from the `spec` because the one in `status` isn’t reliable
-			containerImage := ""
-			for _, containerSpec := range pod.Spec.Containers {
-				if containerSpec.Name == container.Name {
-					containerImage = containerSpec.Image
-					break
-				}
-			}
-			if containerImage == "" {
-				log.Debugf("couldn't find the container %s (%s) in the spec of pod %s", container.Name, container.ID, pod.Metadata.Name)
-				containerImage = container.Image
-			}
+	containerName := container.Name
+	adIdentifier := containerName
 
-			// Detect AD exclusion
-			if l.filters.IsExcluded(containers.GlobalFilter, container.Name, containerImage, pod.Metadata.Namespace) {
-				log.Debugf("container %s filtered out: name %q image %q namespace %q", container.ID, container.Name, containerImage, pod.Metadata.Namespace)
-				return
-			}
+	// Check for custom AD identifiers
+	if customADIdentifier, customIDFound := utils.GetCustomCheckID(pod.Metadata.Annotations, containerName); customIDFound {
+		adIdentifier = customADIdentifier
+		// Add custom check ID as AD identifier
+		svc.adIdentifiers = append(svc.adIdentifiers, customADIdentifier)
+	}
 
-			// Detect metrics or logs exclusion
-			// Exclude terminated containers (including init containers) from metrics collection but keep them for collecting logs.
-			svc.metricsExcluded = l.filters.IsExcluded(containers.MetricsFilter, container.Name, containerImage, pod.Metadata.Namespace) || container.IsTerminated()
-			svc.logsExcluded = l.filters.IsExcluded(containers.LogsFilter, container.Name, containerImage, pod.Metadata.Namespace)
+	// Add container uid as ID
+	svc.adIdentifiers = append(svc.adIdentifiers, entity)
 
-			// Cache the container name to get the corresponding ports after breaking the for-loop
-			containerName = container.Name
-
-			// Check for custom AD identifiers
-			adIdentifier := containerName
-			if customADIdentifier, customIDFound := utils.GetCustomCheckID(pod.Metadata.Annotations, containerName); customIDFound {
-				adIdentifier = customADIdentifier
-				// Add custom check ID as AD identifier
-				svc.adIdentifiers = append(svc.adIdentifiers, customADIdentifier)
-			}
-
-			// Add container uid as ID
-			svc.adIdentifiers = append(svc.adIdentifiers, entity)
-
-			// Cache check names if the pod template is annotated
-			if podHasADTemplate(pod.Metadata.Annotations, adIdentifier) {
-				var err error
-				svc.checkNames, err = getCheckNamesFromAnnotations(pod.Metadata.Annotations, adIdentifier)
-				if err != nil {
-					log.Error(err.Error())
-				}
-			}
-
-			// Add other identifiers if no template found
-			svc.adIdentifiers = append(svc.adIdentifiers, containerImage)
-			_, short, _, err := containers.SplitImageName(containerImage)
-			if err != nil {
-				log.Warnf("Error while spliting image name: %s", err)
-			}
-			if len(short) > 0 && short != containerImage {
-				svc.adIdentifiers = append(svc.adIdentifiers, short)
-			}
-			break
+	// Cache check names if the pod template is annotated
+	if podHasADTemplate(pod.Metadata.Annotations, adIdentifier) {
+		var err error
+		svc.checkNames, err = getCheckNamesFromAnnotations(pod.Metadata.Annotations, adIdentifier)
+		if err != nil {
+			log.Error(err.Error())
 		}
+	}
+
+	// Add other identifiers if no template found
+	svc.adIdentifiers = append(svc.adIdentifiers, containerImage)
+	_, short, _, err := containers.SplitImageName(containerImage)
+	if err != nil {
+		log.Warnf("Error while spliting image name: %s", err)
+	}
+	if len(short) > 0 && short != containerImage {
+		svc.adIdentifiers = append(svc.adIdentifiers, short)
 	}
 
 	// Hosts

--- a/pkg/autodiscovery/listeners/kubelet_test.go
+++ b/pkg/autodiscovery/listeners/kubelet_test.go
@@ -10,6 +10,7 @@ package listeners
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
@@ -194,6 +195,26 @@ func getMockedPods() []*kubelet.Pod {
 			Image: "org/custom:latest",
 			ID:    "docker://custom-check-id",
 		},
+		{
+			Name:  "dead",
+			Image: "datadoghq.com/dead:beef",
+			ID:    "docker://dead",
+			State: kubelet.ContainerState{
+				Terminated: &kubelet.ContainerStateTerminated{
+					FinishedAt: time.Now().Add(-1 * time.Hour),
+				},
+			},
+		},
+		{
+			Name:  "dead-too-long",
+			Image: "datadoghq.com/dead:beef",
+			ID:    "docker://dead-too-long",
+			State: kubelet.ContainerState{
+				Terminated: &kubelet.ContainerStateTerminated{
+					FinishedAt: time.Now().Add(-24 * time.Hour),
+				},
+			},
+		},
 	}
 
 	initContainerStatuses := []kubelet.ContainerStatus{
@@ -201,7 +222,11 @@ func getMockedPods() []*kubelet.Pod {
 			Name:  "init",
 			Image: "org/init:latest",
 			ID:    "docker://init-container",
-			State: kubelet.ContainerState{Terminated: &kubelet.ContainerStateTerminated{ExitCode: 0}},
+			State: kubelet.ContainerState{
+				Terminated: &kubelet.ContainerStateTerminated{
+					FinishedAt: time.Now(),
+				},
+			},
 		},
 	}
 
@@ -249,7 +274,7 @@ func TestProcessNewPod(t *testing.T) {
 		config.Datadog.SetDefault("exclude_pause_container", true)
 	}()
 
-	services := make(chan Service, 10)
+	services := make(chan Service, 11)
 	listener := KubeletListener{
 		newService: services,
 		services:   make(map[string]Service),
@@ -508,6 +533,14 @@ func TestProcessNewPod(t *testing.T) {
 		assert.FailNow(t, "ninth service not in channel")
 	}
 
+	// Terminated container that's recent enough
+	select {
+	case service := <-services:
+		assert.Equal(t, "docker://dead", service.GetEntity())
+	default:
+		assert.FailNow(t, "pod service not in channel")
+	}
+
 	select {
 	case service := <-services:
 		assert.Equal(t, "docker://init-container", service.GetEntity())
@@ -564,7 +597,7 @@ func TestProcessNewPod(t *testing.T) {
 
 	select {
 	case <-services:
-		assert.FailNow(t, "10 services in channel, filtering is broken")
+		assert.FailNow(t, "11 services in channel, filtering is broken")
 	default:
 		// all good
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -461,7 +461,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("container_exclude_metrics", []string{})
 	config.BindEnvAndSetDefault("container_include_logs", []string{})
 	config.BindEnvAndSetDefault("container_exclude_logs", []string{})
-	config.BindEnvAndSetDefault("ad_config_poll_interval", int64(10)) // in seconds
+	config.BindEnvAndSetDefault("container_exclude_stopped_age", DefaultAuditorTTL-1) // in hours
+	config.BindEnvAndSetDefault("ad_config_poll_interval", int64(10))                 // in seconds
 	config.BindEnvAndSetDefault("extra_listeners", []string{})
 	config.BindEnvAndSetDefault("extra_config_providers", []string{})
 	config.BindEnvAndSetDefault("ignore_autoconf", []string{})

--- a/releasenotes/notes/ad-ignore-stopped-containers-ee856d1e3df0bf7d.yaml
+++ b/releasenotes/notes/ad-ignore-stopped-containers-ee856d1e3df0bf7d.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Introduce a `container_exclude_stopped_age` configuration option to allow
+    the Agent to not autodiscover containers that have been stopped for a
+    certain number of hours (by default 22). This makes restarts of the Agent
+    not re-send logs for these containers.


### PR DESCRIPTION
### What does this PR do?

The logs agent stores a "registry.json" file with pointers to positions
inside log files of known containers, in order for a restart of the
agent not to re-send all logs from the very beginning, and instead start
at the latest position. More relevant to the changes in this commit,
this registry is cleaned of entries older than 23 hours. Unfortunately,
this makes a freshly started agent to re-send longs for containers that
were stopped longer than 23 hours ago.

To prevent this, we're introducing a `container_exclude_stopped_age`
config option to make autodiscovery ignore containers that were stopped
a certain time ago (by default, DefaultAuditorTTL minus 1 hour).

### Describe how to test your changes

You'll need an agent running and collecting logs in a K8s cluster, and a workload that generates logs (I'm using the Job below):

```
apiVersion: batch/v1
kind: Job
metadata:
  name: hello
spec:
  template:
    spec:
      restartPolicy: OnFailure
      containers:
      - name: hello
        image: busybox
        args:
        - /bin/sh
        - -c
        - date; echo Hello from the Kubernetes cluster
```

First, try deleting the Agent pod. Checking in the DD UI, you should see the logs generated by the container specified above twice (once as the agent picks up the container while it's running, and again once it restarts). This shows we haven't broken anything and that the agent still picks up stopped containers that are newer than the cutoff age. If the container just restarts instead of the pod being deleted, we should have the logs just once.

Now, configure the agent to set `DD_CONTAINER_EXCLUDE_STOPPED_AGE=0`. This tells the agent to ignore any stopped containers entirely. As the agent starts again, it should not send any logs for the container that's stopped. All other logs for running containers should still continue to be sent.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
