### PR TITLE
[networks] Check for `sockfd_lookup_light` symbol

### DIFF
--- a/pkg/network/config/config_linux.go
+++ b/pkg/network/config/config_linux.go
@@ -3,6 +3,9 @@
 package config
 
 import (
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
@@ -37,10 +40,12 @@ func (c *Config) EnabledProbes(runtimeTracer bool) (map[probes.ProbeName]struct{
 			enabled[probes.TCPRetransmit] = struct{}{}
 		}
 
-		enabled[probes.SockFDLookup] = struct{}{}
-		enabled[probes.SockFDLookupRet] = struct{}{}
-		enabled[probes.DoSendfile] = struct{}{}
-		enabled[probes.DoSendfileRet] = struct{}{}
+		if matches, _ := ebpf.VerifyKernelFuncs(filepath.Join(c.ProcRoot, "kallsyms"), []string{"sockfd_lookup_light"}); len(matches) > 0 {
+			enabled[probes.SockFDLookup] = struct{}{}
+			enabled[probes.SockFDLookupRet] = struct{}{}
+			enabled[probes.DoSendfile] = struct{}{}
+			enabled[probes.DoSendfileRet] = struct{}{}
+		}
 	}
 
 	if c.CollectUDPConns {

--- a/pkg/network/config/config_linux.go
+++ b/pkg/network/config/config_linux.go
@@ -40,7 +40,8 @@ func (c *Config) EnabledProbes(runtimeTracer bool) (map[probes.ProbeName]struct{
 			enabled[probes.TCPRetransmit] = struct{}{}
 		}
 
-		if matches, _ := ebpf.VerifyKernelFuncs(filepath.Join(c.ProcRoot, "kallsyms"), []string{"sockfd_lookup_light"}); len(matches) > 0 {
+		missing, err := ebpf.VerifyKernelFuncs(filepath.Join(c.ProcRoot, "kallsyms"), []string{"sockfd_lookup_light"})
+		if err == nil && len(missing) == 0 {
 			enabled[probes.SockFDLookup] = struct{}{}
 			enabled[probes.SockFDLookupRet] = struct{}{}
 			enabled[probes.DoSendfile] = struct{}{}


### PR DESCRIPTION
### What does this PR do?

Check for `sockfd_lookup_light` symbol to prevent system-probe from crashing when the kprobe is not available. This is a static function that might be inlined in certain builds (so far we've seen this at least in GKE COS)

Related to https://github.com/DataDog/datadog-agent/pull/8524

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
