### PR TITLE
[CWS] small fixes (typos, test expected/actual order)

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "452b177a5ecf8b491a2e5e9d1417a38bb75b137bc04f71da1241001a9f58551d")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "868ba5412961b23252ac6a6accdc6ba61fe00092150168807a5664afa28d980a")

--- a/pkg/security/ebpf/c/erpc.h
+++ b/pkg/security/ebpf/c/erpc.h
@@ -56,7 +56,7 @@ int __attribute__((always_inline)) handle_discard_pid(void *data) {
     return discard_pid(discarder.req.event_type, discarder.pid, discarder.req.timeout);
 }
 
-int __attribute__((always_inline)) is_eprc_request(struct pt_regs *ctx) {
+int __attribute__((always_inline)) is_erpc_request(struct pt_regs *ctx) {
     u64 fd, pid;
 
     LOAD_CONSTANT("erpc_fd", fd);

--- a/pkg/security/ebpf/c/ioctl.h
+++ b/pkg/security/ebpf/c/ioctl.h
@@ -5,7 +5,7 @@
 
 SEC("kprobe/do_vfs_ioctl")
 int kprobe__do_vfs_ioctl(struct pt_regs *ctx) {
-    if (is_eprc_request(ctx)) {
+    if (is_erpc_request(ctx)) {
         return handle_erpc_request(ctx);
     }
 

--- a/pkg/security/probe/process_resolver_test.go
+++ b/pkg/security/probe/process_resolver_test.go
@@ -47,22 +47,22 @@ func TestFork1st(t *testing.T) {
 
 	// parent
 	resolver.AddForkEntry(parent.Pid, parent)
-	assert.Equal(t, resolver.entryCache[parent.Pid], parent)
-	assert.Equal(t, len(resolver.entryCache), 1)
-	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 1)
+	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
+	assert.Equal(t, 1, len(resolver.entryCache))
+	assert.EqualValues(t, 1, atomic.LoadInt64(&resolver.cacheSize))
 
 	// parent
 	//     \ child
 	resolver.AddForkEntry(child.Pid, child)
-	assert.Equal(t, resolver.entryCache[child.Pid], child)
-	assert.Equal(t, len(resolver.entryCache), 2)
-	assert.Equal(t, child.Ancestor, parent)
-	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 2)
+	assert.Equal(t, child, resolver.entryCache[child.Pid])
+	assert.Equal(t, 2, len(resolver.entryCache))
+	assert.Equal(t, parent, child.Ancestor)
+	assert.EqualValues(t, 2, atomic.LoadInt64(&resolver.cacheSize))
 
 	// parent
 	resolver.DeleteEntry(child.Pid, time.Now())
 	assert.Nil(t, resolver.entryCache[child.Pid])
-	assert.Equal(t, len(resolver.entryCache), 1)
+	assert.Equal(t, 1, len(resolver.entryCache))
 
 	// nothing
 	resolver.DeleteEntry(parent.Pid, time.Now())
@@ -88,24 +88,24 @@ func TestFork2nd(t *testing.T) {
 
 	// parent
 	resolver.AddForkEntry(parent.Pid, parent)
-	assert.Equal(t, resolver.entryCache[parent.Pid], parent)
-	assert.Equal(t, len(resolver.entryCache), 1)
-	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 1)
+	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
+	assert.Equal(t, 1, len(resolver.entryCache))
+	assert.EqualValues(t, 1, atomic.LoadInt64(&resolver.cacheSize))
 
 	// parent
 	//     \ child
 	resolver.AddForkEntry(child.Pid, child)
-	assert.Equal(t, resolver.entryCache[child.Pid], child)
-	assert.Equal(t, len(resolver.entryCache), 2)
-	assert.Equal(t, child.Ancestor, parent)
-	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 2)
+	assert.Equal(t, child, resolver.entryCache[child.Pid])
+	assert.Equal(t, 2, len(resolver.entryCache))
+	assert.Equal(t, parent, child.Ancestor)
+	assert.EqualValues(t, 2, atomic.LoadInt64(&resolver.cacheSize))
 
 	// [parent]
 	//     \ child
 	resolver.DeleteEntry(parent.Pid, time.Now())
 	assert.Nil(t, resolver.entryCache[parent.Pid])
-	assert.Equal(t, len(resolver.entryCache), 1)
-	assert.Equal(t, child.Ancestor, parent)
+	assert.Equal(t, 1, len(resolver.entryCache))
+	assert.Equal(t, parent, child.Ancestor)
 
 	// nothing
 	resolver.DeleteEntry(child.Pid, time.Now())
@@ -136,34 +136,34 @@ func TestForkExec(t *testing.T) {
 
 	// parent
 	resolver.AddForkEntry(parent.Pid, parent)
-	assert.Equal(t, resolver.entryCache[parent.Pid], parent)
-	assert.Equal(t, len(resolver.entryCache), 1)
-	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 1)
+	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
+	assert.Equal(t, 1, len(resolver.entryCache))
+	assert.EqualValues(t, 1, atomic.LoadInt64(&resolver.cacheSize))
 
 	// parent
 	//     \ child
 	resolver.AddForkEntry(child.Pid, child)
-	assert.Equal(t, resolver.entryCache[child.Pid], child)
-	assert.Equal(t, len(resolver.entryCache), 2)
-	assert.Equal(t, child.Ancestor, parent)
-	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 2)
+	assert.Equal(t, child, resolver.entryCache[child.Pid])
+	assert.Equal(t, 2, len(resolver.entryCache))
+	assert.Equal(t, parent, child.Ancestor)
+	assert.EqualValues(t, 2, atomic.LoadInt64(&resolver.cacheSize))
 
 	// parent
 	//     \ [child] -> exec
 	resolver.AddExecEntry(exec.Pid, exec)
-	assert.Equal(t, resolver.entryCache[exec.Pid], exec)
-	assert.Equal(t, len(resolver.entryCache), 2)
-	assert.Equal(t, exec.Ancestor, child)
-	assert.Equal(t, exec.Ancestor.Ancestor, parent)
-	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 3)
+	assert.Equal(t, exec, resolver.entryCache[exec.Pid])
+	assert.Equal(t, 2, len(resolver.entryCache))
+	assert.Equal(t, child, exec.Ancestor)
+	assert.Equal(t, parent, exec.Ancestor.Ancestor)
+	assert.EqualValues(t, 3, atomic.LoadInt64(&resolver.cacheSize))
 
 	// [parent]
 	//     \ [child] -> exec
 	resolver.DeleteEntry(parent.Pid, time.Now())
 	assert.Nil(t, resolver.entryCache[parent.Pid])
-	assert.Equal(t, len(resolver.entryCache), 1)
-	assert.Equal(t, exec.Ancestor, child)
-	assert.Equal(t, exec.Ancestor.Ancestor, parent)
+	assert.Equal(t, 1, len(resolver.entryCache))
+	assert.Equal(t, child, exec.Ancestor)
+	assert.Equal(t, parent, exec.Ancestor.Ancestor)
 
 	// nothing
 	resolver.DeleteEntry(exec.Pid, time.Now())
@@ -194,33 +194,33 @@ func TestOrphanExec(t *testing.T) {
 
 	// parent
 	resolver.AddForkEntry(parent.Pid, parent)
-	assert.Equal(t, resolver.entryCache[parent.Pid], parent)
-	assert.Equal(t, len(resolver.entryCache), 1)
-	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 1)
+	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
+	assert.Equal(t, 1, len(resolver.entryCache))
+	assert.EqualValues(t, 1, atomic.LoadInt64(&resolver.cacheSize))
 
 	// parent
 	//     \ child
 	resolver.AddForkEntry(child.Pid, child)
-	assert.Equal(t, resolver.entryCache[child.Pid], child)
-	assert.Equal(t, len(resolver.entryCache), 2)
-	assert.Equal(t, child.Ancestor, parent)
-	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 2)
+	assert.Equal(t, child, resolver.entryCache[child.Pid])
+	assert.Equal(t, 2, len(resolver.entryCache))
+	assert.Equal(t, parent, child.Ancestor)
+	assert.EqualValues(t, 2, atomic.LoadInt64(&resolver.cacheSize))
 
 	// [parent]
 	//     \ child
 	resolver.DeleteEntry(parent.Pid, time.Now())
 	assert.Nil(t, resolver.entryCache[parent.Pid])
-	assert.Equal(t, len(resolver.entryCache), 1)
-	assert.Equal(t, child.Ancestor, parent)
+	assert.Equal(t, 1, len(resolver.entryCache))
+	assert.Equal(t, parent, child.Ancestor)
 
 	// [parent]
 	//     \ [child] -> exec
 	resolver.AddExecEntry(exec.Pid, exec)
-	assert.Equal(t, resolver.entryCache[exec.Pid], exec)
-	assert.Equal(t, len(resolver.entryCache), 1)
-	assert.Equal(t, exec.Ancestor, child)
-	assert.Equal(t, exec.Ancestor.Ancestor, parent)
-	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 3)
+	assert.Equal(t, exec, resolver.entryCache[exec.Pid])
+	assert.Equal(t, 1, len(resolver.entryCache))
+	assert.Equal(t, child, exec.Ancestor)
+	assert.Equal(t, parent, exec.Ancestor.Ancestor)
+	assert.EqualValues(t, 3, atomic.LoadInt64(&resolver.cacheSize))
 
 	// nothing
 	resolver.DeleteEntry(exec.Pid, time.Now())
@@ -256,43 +256,43 @@ func TestForkExecExec(t *testing.T) {
 
 	// parent
 	resolver.AddForkEntry(parent.Pid, parent)
-	assert.Equal(t, resolver.entryCache[parent.Pid], parent)
-	assert.Equal(t, len(resolver.entryCache), 1)
-	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 1)
+	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
+	assert.Equal(t, 1, len(resolver.entryCache))
+	assert.EqualValues(t, 1, atomic.LoadInt64(&resolver.cacheSize))
 
 	// parent
 	//     \ child
 	resolver.AddForkEntry(child.Pid, child)
-	assert.Equal(t, resolver.entryCache[child.Pid], child)
-	assert.Equal(t, len(resolver.entryCache), 2)
-	assert.Equal(t, child.Ancestor, parent)
-	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 2)
+	assert.Equal(t, child, resolver.entryCache[child.Pid])
+	assert.Equal(t, 2, len(resolver.entryCache))
+	assert.Equal(t, parent, child.Ancestor)
+	assert.EqualValues(t, 2, atomic.LoadInt64(&resolver.cacheSize))
 
 	// [parent]
 	//     \ child
 	resolver.DeleteEntry(parent.Pid, time.Now())
 	assert.Nil(t, resolver.entryCache[parent.Pid])
-	assert.Equal(t, len(resolver.entryCache), 1)
-	assert.Equal(t, child.Ancestor, parent)
+	assert.Equal(t, 1, len(resolver.entryCache))
+	assert.Equal(t, parent, child.Ancestor)
 
 	// [parent]
 	//     \ [child] -> exec1
 	resolver.AddExecEntry(exec1.Pid, exec1)
-	assert.Equal(t, resolver.entryCache[exec1.Pid], exec1)
-	assert.Equal(t, len(resolver.entryCache), 1)
-	assert.Equal(t, exec1.Ancestor, child)
-	assert.Equal(t, exec1.Ancestor.Ancestor, parent)
-	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 3)
+	assert.Equal(t, exec1, resolver.entryCache[exec1.Pid])
+	assert.Equal(t, 1, len(resolver.entryCache))
+	assert.Equal(t, child, exec1.Ancestor)
+	assert.Equal(t, parent, exec1.Ancestor.Ancestor)
+	assert.EqualValues(t, 3, atomic.LoadInt64(&resolver.cacheSize))
 
 	// [parent]
 	//     \ [child] -> [exec1] -> exec2
 	resolver.AddExecEntry(exec2.Pid, exec2)
-	assert.Equal(t, resolver.entryCache[exec2.Pid], exec2)
-	assert.Equal(t, len(resolver.entryCache), 1)
-	assert.Equal(t, exec2.Ancestor, exec1)
-	assert.Equal(t, exec2.Ancestor.Ancestor, child)
-	assert.Equal(t, exec2.Ancestor.Ancestor.Ancestor, parent)
-	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 4)
+	assert.Equal(t, exec2, resolver.entryCache[exec2.Pid])
+	assert.Equal(t, 1, len(resolver.entryCache))
+	assert.Equal(t, exec1, exec2.Ancestor)
+	assert.Equal(t, child, exec2.Ancestor.Ancestor)
+	assert.Equal(t, parent, exec2.Ancestor.Ancestor.Ancestor)
+	assert.EqualValues(t, 4, atomic.LoadInt64(&resolver.cacheSize))
 
 	// nothing
 	resolver.DeleteEntry(exec2.Pid, time.Now())
@@ -332,42 +332,42 @@ func TestForkReuse(t *testing.T) {
 
 	// parent1
 	resolver.AddForkEntry(parent1.Pid, parent1)
-	assert.Equal(t, resolver.entryCache[parent1.Pid], parent1)
-	assert.Equal(t, len(resolver.entryCache), 1)
-	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 1)
+	assert.Equal(t, parent1, resolver.entryCache[parent1.Pid])
+	assert.Equal(t, 1, len(resolver.entryCache))
+	assert.EqualValues(t, 1, atomic.LoadInt64(&resolver.cacheSize))
 
 	// parent1
 	//     \ child1
 	resolver.AddForkEntry(child1.Pid, child1)
-	assert.Equal(t, resolver.entryCache[child1.Pid], child1)
-	assert.Equal(t, len(resolver.entryCache), 2)
-	assert.Equal(t, child1.Ancestor, parent1)
-	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 2)
+	assert.Equal(t, child1, resolver.entryCache[child1.Pid])
+	assert.Equal(t, 2, len(resolver.entryCache))
+	assert.Equal(t, parent1, child1.Ancestor)
+	assert.EqualValues(t, 2, atomic.LoadInt64(&resolver.cacheSize))
 
 	// [parent1]
 	//     \ child1
 	resolver.DeleteEntry(parent1.Pid, time.Now())
 	assert.Nil(t, resolver.entryCache[parent1.Pid])
-	assert.Equal(t, len(resolver.entryCache), 1)
-	assert.Equal(t, child1.Ancestor, parent1)
+	assert.Equal(t, 1, len(resolver.entryCache))
+	assert.Equal(t, parent1, child1.Ancestor)
 
 	// [parent1]
 	//     \ [child1] -> exec1
 	resolver.AddExecEntry(exec1.Pid, exec1)
-	assert.Equal(t, resolver.entryCache[exec1.Pid], exec1)
-	assert.Equal(t, len(resolver.entryCache), 1)
-	assert.Equal(t, exec1.Ancestor, child1)
-	assert.Equal(t, exec1.Ancestor.Ancestor, parent1)
-	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 3)
+	assert.Equal(t, exec1, resolver.entryCache[exec1.Pid])
+	assert.Equal(t, 1, len(resolver.entryCache))
+	assert.Equal(t, child1, exec1.Ancestor)
+	assert.Equal(t, parent1, exec1.Ancestor.Ancestor)
+	assert.EqualValues(t, 3, atomic.LoadInt64(&resolver.cacheSize))
 
 	// [parent1:pid1]
 	//     \ [child1] -> exec1
 	//
 	// parent2:pid1
 	resolver.AddForkEntry(parent2.Pid, parent2)
-	assert.Equal(t, resolver.entryCache[parent2.Pid], parent2)
-	assert.Equal(t, len(resolver.entryCache), 2)
-	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 4)
+	assert.Equal(t, parent2, resolver.entryCache[parent2.Pid])
+	assert.Equal(t, 2, len(resolver.entryCache))
+	assert.EqualValues(t, 4, atomic.LoadInt64(&resolver.cacheSize))
 
 	// [parent1:pid1]
 	//     \ [child1] -> exec1
@@ -375,23 +375,23 @@ func TestForkReuse(t *testing.T) {
 	// parent2:pid1
 	//     \ child2
 	resolver.AddForkEntry(child2.Pid, child2)
-	assert.Equal(t, resolver.entryCache[child2.Pid], child2)
-	assert.Equal(t, len(resolver.entryCache), 3)
-	assert.Equal(t, child2.Ancestor, parent2)
-	assert.EqualValues(t, atomic.LoadInt64(&resolver.cacheSize), 5)
+	assert.Equal(t, child2, resolver.entryCache[child2.Pid])
+	assert.Equal(t, 3, len(resolver.entryCache))
+	assert.Equal(t, parent2, child2.Ancestor)
+	assert.EqualValues(t, 5, atomic.LoadInt64(&resolver.cacheSize))
 
 	// parent2:pid1
 	//     \ child2
 	resolver.DeleteEntry(exec1.Pid, time.Now())
 	assert.Nil(t, resolver.entryCache[exec1.Pid])
-	assert.Equal(t, len(resolver.entryCache), 2)
+	assert.Equal(t, 2, len(resolver.entryCache))
 
 	// [parent2:pid1]
 	//     \ child2
 	resolver.DeleteEntry(parent2.Pid, time.Now())
 	assert.Nil(t, resolver.entryCache[parent2.Pid])
-	assert.Equal(t, len(resolver.entryCache), 1)
-	assert.Equal(t, child2.Ancestor, parent2)
+	assert.Equal(t, 1, len(resolver.entryCache))
+	assert.Equal(t, parent2, child2.Ancestor)
 
 	// nothing
 	resolver.DeleteEntry(child2.Pid, time.Now())
@@ -427,49 +427,49 @@ func TestForkForkExec(t *testing.T) {
 
 	// parent
 	resolver.AddForkEntry(parent.Pid, parent)
-	assert.Equal(t, resolver.entryCache[parent.Pid], parent)
-	assert.Equal(t, len(resolver.entryCache), 1)
+	assert.Equal(t, parent, resolver.entryCache[parent.Pid])
+	assert.Equal(t, 1, len(resolver.entryCache))
 
 	// parent
 	//     \ child
 	resolver.AddForkEntry(child.Pid, child)
-	assert.Equal(t, resolver.entryCache[child.Pid], child)
-	assert.Equal(t, len(resolver.entryCache), 2)
-	assert.Equal(t, child.Ancestor, parent)
+	assert.Equal(t, child, resolver.entryCache[child.Pid])
+	assert.Equal(t, 2, len(resolver.entryCache))
+	assert.Equal(t, parent, child.Ancestor)
 
 	// parent
 	//     \ child
 	//          \ grandChild
 	resolver.AddForkEntry(grandChild.Pid, grandChild)
-	assert.Equal(t, resolver.entryCache[grandChild.Pid], grandChild)
-	assert.Equal(t, len(resolver.entryCache), 3)
-	assert.Equal(t, grandChild.Ancestor, child)
-	assert.Equal(t, grandChild.Ancestor.Ancestor, parent)
+	assert.Equal(t, grandChild, resolver.entryCache[grandChild.Pid])
+	assert.Equal(t, 3, len(resolver.entryCache))
+	assert.Equal(t, child, grandChild.Ancestor)
+	assert.Equal(t, parent, grandChild.Ancestor.Ancestor)
 
 	// parent
 	//     \ [child] -> childExec
 	//          \ grandChild
 	resolver.AddExecEntry(childExec.Pid, childExec)
-	assert.Equal(t, resolver.entryCache[childExec.Pid], childExec)
-	assert.Equal(t, len(resolver.entryCache), 3)
-	assert.Equal(t, childExec.Ancestor, child)
-	assert.Equal(t, childExec.Ancestor.Ancestor, parent)
-	assert.Equal(t, grandChild.Ancestor, child)
-	assert.Equal(t, grandChild.Ancestor.Ancestor, parent)
+	assert.Equal(t, childExec, resolver.entryCache[childExec.Pid])
+	assert.Equal(t, 3, len(resolver.entryCache))
+	assert.Equal(t, child, childExec.Ancestor)
+	assert.Equal(t, parent, childExec.Ancestor.Ancestor)
+	assert.Equal(t, child, grandChild.Ancestor)
+	assert.Equal(t, parent, grandChild.Ancestor.Ancestor)
 
 	// [parent]
 	//     \ [child] -> childExec
 	//          \ grandChild
 	resolver.DeleteEntry(parent.Pid, time.Now())
 	assert.Nil(t, resolver.entryCache[parent.Pid])
-	assert.Equal(t, len(resolver.entryCache), 2)
+	assert.Equal(t, 2, len(resolver.entryCache))
 
 	// [parent]
 	//     \ [child]
 	//          \ grandChild
 	resolver.DeleteEntry(childExec.Pid, time.Now())
 	assert.Nil(t, resolver.entryCache[childExec.Pid])
-	assert.Equal(t, len(resolver.entryCache), 1)
+	assert.Equal(t, 1, len(resolver.entryCache))
 
 	// nothing
 	resolver.DeleteEntry(grandChild.Pid, time.Now())

--- a/pkg/security/probe/reorderer_test.go
+++ b/pkg/security/probe/reorderer_test.go
@@ -127,7 +127,7 @@ func TestOrderRate(t *testing.T) {
 
 	// should now get the elements
 	lock.RLock()
-	assert.Equal(t, event, []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9})
+	assert.Equal(t, []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9}, event)
 	lock.RUnlock()
 
 	cancel()

--- a/pkg/security/tests/chmod_test.go
+++ b/pkg/security/tests/chmod_test.go
@@ -54,9 +54,9 @@ func TestChmod(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "chmod", "wrong event type")
+			assert.Equal(t, "chmod", event.GetType(), "wrong event type")
 			assertRights(t, uint16(event.Chmod.Mode), 0o707)
-			assert.Equal(t, event.Chmod.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, getInode(t, testFile), event.Chmod.File.Inode, "wrong inode")
 			assertRights(t, event.Chmod.File.Mode, expectedMode, "wrong initial mode")
 
 			assertNearTime(t, event.Chmod.File.MTime)
@@ -80,9 +80,9 @@ func TestChmod(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "chmod", "wrong event type")
+			assert.Equal(t, "chmod", event.GetType(), "wrong event type")
 			assertRights(t, uint16(event.Chmod.Mode), 0o757)
-			assert.Equal(t, event.Chmod.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, getInode(t, testFile), event.Chmod.File.Inode, "wrong inode")
 			assertRights(t, event.Chmod.File.Mode, expectedMode)
 
 			assertNearTime(t, event.Chmod.File.MTime)
@@ -104,9 +104,9 @@ func TestChmod(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "chmod", "wrong event type")
+			assert.Equal(t, "chmod", event.GetType(), "wrong event type")
 			assertRights(t, uint16(event.Chmod.Mode), 0o717, "wrong mode")
-			assert.Equal(t, event.Chmod.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, getInode(t, testFile), event.Chmod.File.Inode, "wrong inode")
 			assertRights(t, event.Chmod.File.Mode, expectedMode, "wrong initial mode")
 
 			assertNearTime(t, event.Chmod.File.MTime)

--- a/pkg/security/tests/chown32_test.go
+++ b/pkg/security/tests/chown32_test.go
@@ -75,13 +75,13 @@ func TestChown32(t *testing.T) {
 			// fchown syscall
 			return runSyscallTesterFunc(t, syscallTester, "chown", testFile, "100", "200")
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "chown", "wrong event type")
-			assert.Equal(t, event.Chown.UID, uint32(100), "wrong user")
-			assert.Equal(t, event.Chown.GID, uint32(200), "wrong user")
-			assert.Equal(t, event.Chown.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, "chown", event.GetType(), "wrong event type")
+			assert.Equal(t, uint32(100), event.Chown.UID, "wrong user")
+			assert.Equal(t, uint32(200), event.Chown.GID, "wrong user")
+			assert.Equal(t, getInode(t, testFile), event.Chown.File.Inode, "wrong inode")
 			assertRights(t, event.Chown.File.Mode, uint16(expectedMode), "wrong initial mode")
-			assert.Equal(t, event.Chown.File.UID, uint32(prevUID), "wrong initial user")
-			assert.Equal(t, event.Chown.File.GID, uint32(prevGID), "wrong initial group")
+			assert.Equal(t, uint32(prevUID), event.Chown.File.UID, "wrong initial user")
+			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
@@ -106,13 +106,13 @@ func TestChown32(t *testing.T) {
 			// fchown syscall
 			return runSyscallTesterFunc(t, syscallTester, "fchown", testFile, "101", "201")
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "chown", "wrong event type")
-			assert.Equal(t, event.Chown.UID, uint32(101), "wrong user")
-			assert.Equal(t, event.Chown.GID, uint32(201), "wrong user")
-			assert.Equal(t, event.Chown.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, "chown", event.GetType(), "wrong event type")
+			assert.Equal(t, uint32(101), event.Chown.UID, "wrong user")
+			assert.Equal(t, uint32(201), event.Chown.GID, "wrong user")
+			assert.Equal(t, getInode(t, testFile), event.Chown.File.Inode, "wrong inode")
 			assertRights(t, event.Chown.File.Mode, uint16(expectedMode), "wrong initial mode")
-			assert.Equal(t, event.Chown.File.UID, uint32(prevUID), "wrong initial user")
-			assert.Equal(t, event.Chown.File.GID, uint32(prevGID), "wrong initial group")
+			assert.Equal(t, uint32(prevUID), event.Chown.File.UID, "wrong initial user")
+			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
@@ -137,13 +137,13 @@ func TestChown32(t *testing.T) {
 			// fchown syscall
 			return runSyscallTesterFunc(t, syscallTester, "fchownat", testFile, "102", "202")
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "chown", "wrong event type")
-			assert.Equal(t, event.Chown.UID, uint32(102), "wrong user")
-			assert.Equal(t, event.Chown.GID, uint32(202), "wrong user")
-			assert.Equal(t, event.Chown.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, "chown", event.GetType(), "wrong event type")
+			assert.Equal(t, uint32(102), event.Chown.UID, "wrong user")
+			assert.Equal(t, uint32(202), event.Chown.GID, "wrong user")
+			assert.Equal(t, getInode(t, testFile), event.Chown.File.Inode, "wrong inode")
 			assertRights(t, event.Chown.File.Mode, uint16(expectedMode), "wrong initial mode")
-			assert.Equal(t, event.Chown.File.UID, uint32(prevUID), "wrong initial user")
-			assert.Equal(t, event.Chown.File.GID, uint32(prevGID), "wrong initial group")
+			assert.Equal(t, uint32(prevUID), event.Chown.File.UID, "wrong initial user")
+			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
@@ -173,13 +173,13 @@ func TestChown32(t *testing.T) {
 			// fchown syscall
 			return runSyscallTesterFunc(t, syscallTester, "lchown", testSymlink, "103", "203")
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "chown", "wrong event type")
-			assert.Equal(t, event.Chown.UID, uint32(103), "wrong user")
-			assert.Equal(t, event.Chown.GID, uint32(203), "wrong user")
-			assert.Equal(t, event.Chown.File.Inode, getInode(t, testSymlink), "wrong inode")
+			assert.Equal(t, "chown", event.GetType(), "wrong event type")
+			assert.Equal(t, uint32(103), event.Chown.UID, "wrong user")
+			assert.Equal(t, uint32(203), event.Chown.GID, "wrong user")
+			assert.Equal(t, getInode(t, testSymlink), event.Chown.File.Inode, "wrong inode")
 			assertRights(t, event.Chown.File.Mode, uint16(0o777), "wrong initial mode")
-			assert.Equal(t, event.Chown.File.UID, uint32(0), "wrong initial user")
-			assert.Equal(t, event.Chown.File.GID, uint32(0), "wrong initial group")
+			assert.Equal(t, uint32(0), event.Chown.File.UID, "wrong initial user")
+			assert.Equal(t, uint32(0), event.Chown.File.GID, "wrong initial group")
 
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
@@ -209,13 +209,13 @@ func TestChown32(t *testing.T) {
 			// fchown syscall
 			return runSyscallTesterFunc(t, syscallTester, "lchown32", testSymlink, "104", "204")
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "chown", "wrong event type")
-			assert.Equal(t, event.Chown.UID, uint32(104), "wrong user")
-			assert.Equal(t, event.Chown.GID, uint32(204), "wrong user")
-			assert.Equal(t, event.Chown.File.Inode, getInode(t, testSymlink), "wrong inode")
+			assert.Equal(t, "chown", event.GetType(), "wrong event type")
+			assert.Equal(t, uint32(104), event.Chown.UID, "wrong user")
+			assert.Equal(t, uint32(204), event.Chown.GID, "wrong user")
+			assert.Equal(t, getInode(t, testSymlink), event.Chown.File.Inode, "wrong inode")
 			assertRights(t, event.Chown.File.Mode, uint16(0o777), "wrong initial mode")
-			assert.Equal(t, event.Chown.File.UID, uint32(0), "wrong initial user")
-			assert.Equal(t, event.Chown.File.GID, uint32(0), "wrong initial group")
+			assert.Equal(t, uint32(0), event.Chown.File.UID, "wrong initial user")
+			assert.Equal(t, uint32(0), event.Chown.File.GID, "wrong initial group")
 
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
@@ -241,13 +241,13 @@ func TestChown32(t *testing.T) {
 			// fchown syscall
 			return runSyscallTesterFunc(t, syscallTester, "fchown32", testFile, "105", "205")
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "chown", "wrong event type")
-			assert.Equal(t, event.Chown.UID, uint32(105), "wrong user")
-			assert.Equal(t, event.Chown.GID, uint32(205), "wrong user")
-			assert.Equal(t, event.Chown.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, "chown", event.GetType(), "wrong event type")
+			assert.Equal(t, uint32(105), event.Chown.UID, "wrong user")
+			assert.Equal(t, uint32(205), event.Chown.GID, "wrong user")
+			assert.Equal(t, getInode(t, testFile), event.Chown.File.Inode, "wrong inode")
 			assertRights(t, event.Chown.File.Mode, uint16(expectedMode), "wrong initial mode")
-			assert.Equal(t, event.Chown.File.UID, uint32(prevUID), "wrong initial user")
-			assert.Equal(t, event.Chown.File.GID, uint32(prevGID), "wrong initial group")
+			assert.Equal(t, uint32(prevUID), event.Chown.File.UID, "wrong initial user")
+			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
@@ -272,13 +272,13 @@ func TestChown32(t *testing.T) {
 			// fchown syscall
 			return runSyscallTesterFunc(t, syscallTester, "chown32", testFile, "106", "206")
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "chown", "wrong event type")
-			assert.Equal(t, event.Chown.UID, uint32(106), "wrong user")
-			assert.Equal(t, event.Chown.GID, uint32(206), "wrong user")
-			assert.Equal(t, event.Chown.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, "chown", event.GetType(), "wrong event type")
+			assert.Equal(t, uint32(106), event.Chown.UID, "wrong user")
+			assert.Equal(t, uint32(206), event.Chown.GID, "wrong user")
+			assert.Equal(t, getInode(t, testFile), event.Chown.File.Inode, "wrong inode")
 			assertRights(t, event.Chown.File.Mode, uint16(expectedMode), "wrong initial mode")
-			assert.Equal(t, event.Chown.File.UID, uint32(prevUID), "wrong initial user")
-			assert.Equal(t, event.Chown.File.GID, uint32(prevGID), "wrong initial group")
+			assert.Equal(t, uint32(prevUID), event.Chown.File.UID, "wrong initial user")
+			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)

--- a/pkg/security/tests/chown_test.go
+++ b/pkg/security/tests/chown_test.go
@@ -63,13 +63,13 @@ func TestChown(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "chown", "wrong event type")
-			assert.Equal(t, event.Chown.UID, uint32(100), "wrong user")
-			assert.Equal(t, event.Chown.GID, uint32(200), "wrong user")
-			assert.Equal(t, event.Chown.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, "chown", event.GetType(), "wrong event type")
+			assert.Equal(t, uint32(100), event.Chown.UID, "wrong user")
+			assert.Equal(t, uint32(200), event.Chown.GID, "wrong user")
+			assert.Equal(t, getInode(t, testFile), event.Chown.File.Inode, "wrong inode")
 			assertRights(t, event.Chown.File.Mode, uint16(expectedMode), "wrong initial mode")
-			assert.Equal(t, event.Chown.File.UID, uint32(prevUID), "wrong initial user")
-			assert.Equal(t, event.Chown.File.GID, uint32(prevGID), "wrong initial group")
+			assert.Equal(t, uint32(prevUID), event.Chown.File.UID, "wrong initial user")
+			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
@@ -95,13 +95,13 @@ func TestChown(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "chown", "wrong event type")
-			assert.Equal(t, event.Chown.UID, uint32(101), "wrong user")
-			assert.Equal(t, event.Chown.GID, uint32(201), "wrong user")
-			assert.Equal(t, event.Chown.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, "chown", event.GetType(), "wrong event type")
+			assert.Equal(t, uint32(101), event.Chown.UID, "wrong user")
+			assert.Equal(t, uint32(201), event.Chown.GID, "wrong user")
+			assert.Equal(t, getInode(t, testFile), event.Chown.File.Inode, "wrong inode")
 			assertRights(t, event.Chown.File.Mode, uint16(expectedMode), "wrong initial mode")
-			assert.Equal(t, event.Chown.File.UID, uint32(prevUID), "wrong initial user")
-			assert.Equal(t, event.Chown.File.GID, uint32(prevGID), "wrong initial group")
+			assert.Equal(t, uint32(prevUID), event.Chown.File.UID, "wrong initial user")
+			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
@@ -136,14 +136,14 @@ func TestChown(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "chown", "wrong event type")
+			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assertTriggeredRule(t, rule, "test_rule2")
-			assert.Equal(t, event.Chown.UID, uint32(102), "wrong user")
-			assert.Equal(t, event.Chown.GID, uint32(202), "wrong user")
-			assert.Equal(t, event.Chown.File.Inode, getInode(t, testSymlink), "wrong inode")
+			assert.Equal(t, uint32(102), event.Chown.UID, "wrong user")
+			assert.Equal(t, uint32(202), event.Chown.GID, "wrong user")
+			assert.Equal(t, getInode(t, testSymlink), event.Chown.File.Inode, "wrong inode")
 			assertRights(t, event.Chown.File.Mode, 0o777, "wrong initial mode")
-			assert.Equal(t, event.Chown.File.UID, uint32(0), "wrong initial user")
-			assert.Equal(t, event.Chown.File.GID, uint32(0), "wrong initial group")
+			assert.Equal(t, uint32(0), event.Chown.File.UID, "wrong initial user")
+			assert.Equal(t, uint32(0), event.Chown.File.GID, "wrong initial group")
 
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
@@ -169,13 +169,13 @@ func TestChown(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "chown", "wrong event type")
-			assert.Equal(t, event.Chown.UID, uint32(103), "wrong user")
-			assert.Equal(t, event.Chown.GID, uint32(203), "wrong user")
-			assert.Equal(t, event.Chown.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, "chown", event.GetType(), "wrong event type")
+			assert.Equal(t, uint32(103), event.Chown.UID, "wrong user")
+			assert.Equal(t, uint32(203), event.Chown.GID, "wrong user")
+			assert.Equal(t, getInode(t, testFile), event.Chown.File.Inode, "wrong inode")
 			assertRights(t, event.Chown.File.Mode, uint16(expectedMode), "wrong initial mode")
-			assert.Equal(t, event.Chown.File.UID, uint32(prevUID), "wrong initial user")
-			assert.Equal(t, event.Chown.File.GID, uint32(prevGID), "wrong initial group")
+			assert.Equal(t, uint32(prevUID), event.Chown.File.UID, "wrong initial user")
+			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
 
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)

--- a/pkg/security/tests/link_test.go
+++ b/pkg/security/tests/link_test.go
@@ -50,8 +50,8 @@ func TestLink(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "link", "wrong event type")
-			assert.Equal(t, event.Link.Source.Inode, getInode(t, testNewFile), "wrong inode")
+			assert.Equal(t, "link", event.GetType(), "wrong event type")
+			assert.Equal(t, getInode(t, testNewFile), event.Link.Source.Inode, "wrong inode")
 
 			assertRights(t, event.Link.Source.Mode, uint16(expectedMode))
 			assertRights(t, event.Link.Target.Mode, uint16(expectedMode))
@@ -78,8 +78,8 @@ func TestLink(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "link", "wrong event type")
-			assert.Equal(t, event.Link.Source.Inode, getInode(t, testNewFile), "wrong inode")
+			assert.Equal(t, "link", event.GetType(), "wrong event type")
+			assert.Equal(t, getInode(t, testNewFile), event.Link.Source.Inode, "wrong inode")
 
 			assertRights(t, event.Link.Source.Mode, uint16(expectedMode))
 			assertRights(t, event.Link.Target.Mode, uint16(expectedMode))

--- a/pkg/security/tests/macros_test.go
+++ b/pkg/security/tests/macros_test.go
@@ -53,7 +53,7 @@ func TestMacros(t *testing.T) {
 		}
 		return os.Remove(testFile)
 	}, func(event *sprobe.Event, rule *rules.Rule) {
-		assert.Equal(t, event.GetType(), "mkdir", "wrong event type")
+		assert.Equal(t, "mkdir", event.GetType(), "wrong event type")
 	})
 	if err != nil {
 		t.Error(err)

--- a/pkg/security/tests/mkdir_test.go
+++ b/pkg/security/tests/mkdir_test.go
@@ -56,7 +56,7 @@ func TestMkdir(t *testing.T) {
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_mkdir")
 			assertRights(t, uint16(event.Mkdir.Mode), mkdirMode)
-			assert.Equal(t, event.Mkdir.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, getInode(t, testFile), event.Mkdir.File.Inode, "wrong inode")
 			assertRights(t, event.Mkdir.File.Mode, expectedMode)
 
 			assertNearTime(t, event.Mkdir.File.MTime)
@@ -79,9 +79,9 @@ func TestMkdir(t *testing.T) {
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_mkdirat")
 
-			assert.Equal(t, event.Mkdir.File.Inode, getInode(t, testatFile), "wrong inode")
+			assert.Equal(t, getInode(t, testatFile), event.Mkdir.File.Inode, "wrong inode")
 			assertRights(t, uint16(event.Mkdir.Mode), 0777)
-			assert.Equal(t, event.Mkdir.File.Inode, getInode(t, testatFile), "wrong inode")
+			assert.Equal(t, getInode(t, testatFile), event.Mkdir.File.Inode, "wrong inode")
 			assertRights(t, event.Mkdir.File.Mode&expectedMode, expectedMode)
 
 			assertNearTime(t, event.Mkdir.File.MTime)

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -69,9 +69,9 @@ func TestMount(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event) bool {
-			assert.Equal(t, event.GetType(), "mount", "wrong event type")
-			assert.Equal(t, event.Mount.MountPointStr, "/"+dstMntBasename, "wrong mount point")
-			assert.Equal(t, event.Mount.GetFSType(), "xfs", "wrong mount fs type")
+			assert.Equal(t, "mount", event.GetType(), "wrong event type")
+			assert.Equal(t, "/"+dstMntBasename, event.Mount.MountPointStr, "wrong mount point")
+			assert.Equal(t, "xfs", event.Mount.GetFSType(), "wrong mount fs type")
 
 			mntID = event.Mount.MountID
 			return true
@@ -100,8 +100,8 @@ func TestMount(t *testing.T) {
 		err = test.GetSignal(t, func() error {
 			return os.Chmod(file, 0707)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "chmod", "wrong event type")
-			assert.Equal(t, event.Chmod.File.PathnameStr, file, "wrong path")
+			assert.Equal(t, "chmod", event.GetType(), "wrong event type")
+			assert.Equal(t, file, event.Chmod.File.PathnameStr, "wrong path")
 		})
 		if err != nil {
 			t.Error(err)
@@ -122,8 +122,8 @@ func TestMount(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event) bool {
-			assert.Equal(t, event.GetType(), "umount", "wrong event type")
-			assert.Equal(t, event.Umount.MountID, mntID, "wrong mount id")
+			assert.Equal(t, "umount", event.GetType(), "wrong event type")
+			assert.Equal(t, mntID, event.Umount.MountID, "wrong mount id")
 			return true
 		}, 3*time.Second, model.FileUmountEventType)
 		if err != nil {
@@ -135,7 +135,7 @@ func TestMount(t *testing.T) {
 		err = test.GetSignal(t, func() error {
 			return syscall.Fchownat(int(releaseFile.Fd()), "", 123, 123, unix.AT_EMPTY_PATH)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "chown", "wrong event type")
+			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assertTriggeredRule(t, rule, "test_rule_pending")
 		})
 		if err != nil {

--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -55,10 +55,10 @@ func TestOpen(t *testing.T) {
 			}
 			return syscall.Close(int(fd))
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "open", "wrong event type")
-			assert.Equal(t, int(event.Open.Flags), syscall.O_CREAT, "wrong flags")
+			assert.Equal(t, "open", event.GetType(), "wrong event type")
+			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0755)
-			assert.Equal(t, event.Open.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 
 			if !validateOpenSchema(t, event) {
 				t.Fatal(event.String())
@@ -76,10 +76,10 @@ func TestOpen(t *testing.T) {
 			}
 			return syscall.Close(int(fd))
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "open", "wrong event type")
-			assert.Equal(t, int(event.Open.Flags), syscall.O_CREAT, "wrong flags")
+			assert.Equal(t, "open", event.GetType(), "wrong event type")
+			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0711)
-			assert.Equal(t, event.Open.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 		})
 	})
 
@@ -101,10 +101,10 @@ func TestOpen(t *testing.T) {
 			}
 			return syscall.Close(int(fd))
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "open", "wrong event type")
-			assert.Equal(t, int(event.Open.Flags), syscall.O_CREAT, "wrong flags")
+			assert.Equal(t, "open", event.GetType(), "wrong event type")
+			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0711)
-			assert.Equal(t, event.Open.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 		})
 	})
 
@@ -118,10 +118,10 @@ func TestOpen(t *testing.T) {
 			}
 			return syscall.Close(int(fd))
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "open", "wrong event type")
-			assert.Equal(t, int(event.Open.Flags), syscall.O_CREAT|syscall.O_WRONLY|syscall.O_TRUNC, "wrong flags")
+			assert.Equal(t, "open", event.GetType(), "wrong event type")
+			assert.Equal(t, syscall.O_CREAT|syscall.O_WRONLY|syscall.O_TRUNC, int(event.Open.Flags), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0711)
-			assert.Equal(t, event.Open.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 		})
 	}))
 
@@ -149,9 +149,9 @@ func TestOpen(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "open", "wrong event type")
-			assert.Equal(t, int(event.Open.Flags), syscall.O_CREAT|syscall.O_WRONLY|syscall.O_TRUNC, "wrong flags")
-			assert.Equal(t, event.Open.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, "open", event.GetType(), "wrong event type")
+			assert.Equal(t, syscall.O_CREAT|syscall.O_WRONLY|syscall.O_TRUNC, int(event.Open.Flags), "wrong flags")
+			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 		})
 	})
 
@@ -166,7 +166,7 @@ func TestOpen(t *testing.T) {
 			}
 			return f.Close()
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "open", "wrong event type")
+			assert.Equal(t, "open", event.GetType(), "wrong event type")
 		})
 		if err != nil {
 			t.Error(err)
@@ -195,9 +195,9 @@ func TestOpen(t *testing.T) {
 			}
 			return unix.Close(fdInt)
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "open", "wrong event type")
-			assert.Equal(t, int(event.Open.Flags), syscall.O_CREAT, "wrong flags")
-			assert.Equal(t, event.Open.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, "open", event.GetType(), "wrong event type")
+			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
+			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 		})
 	})
 
@@ -212,7 +212,7 @@ func TestOpen(t *testing.T) {
 			f.Close()
 			return nil
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "open", "wrong event type")
+			assert.Equal(t, "open", event.GetType(), "wrong event type")
 		})
 		if err != nil {
 			t.Error(err)
@@ -253,11 +253,11 @@ func TestOpen(t *testing.T) {
 
 			return unix.Close(fd)
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "open", "wrong event type")
+			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			// O_LARGEFILE is added by io_uring during __io_openat_prep
-			assert.Equal(t, int(event.Open.Flags&0xfff), syscall.O_CREAT, "wrong flags")
+			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags&0xfff), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0747)
-			assert.Equal(t, event.Open.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 		})
 
 		prepRequest, err = iouring.Openat2(unix.AT_FDCWD, testFile, &openHow)
@@ -283,11 +283,11 @@ func TestOpen(t *testing.T) {
 
 			return unix.Close(fd)
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "open", "wrong event type")
+			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			// O_LARGEFILE is added by io_uring during __io_openat_prep
-			assert.Equal(t, int(event.Open.Flags&0xfff), syscall.O_CREAT, "wrong flags")
+			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags&0xfff), "wrong flags")
 			assertRights(t, uint16(event.Open.Mode), 0711)
-			assert.Equal(t, event.Open.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 		})
 	})
 
@@ -325,9 +325,9 @@ func TestOpenMetadata(t *testing.T) {
 			}
 			return f.Close()
 		}, func(event *sprobe.Event, r *rules.Rule) {
-			assert.Equal(t, event.GetType(), "open", "wrong event type")
+			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			assertRights(t, uint16(event.Open.File.Mode), expectedMode)
-			assert.Equal(t, event.Open.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 
 			assertNearTime(t, event.Open.File.MTime)
 			assertNearTime(t, event.Open.File.CTime)

--- a/pkg/security/tests/overlayfs_test.go
+++ b/pkg/security/tests/overlayfs_test.go
@@ -179,9 +179,9 @@ func TestOverlayFS(t *testing.T) {
 			return f.Close()
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			inode = getInode(t, testFile)
-			assert.Equal(t, event.Open.File.Inode, inode, "wrong open inode")
+			assert.Equal(t, inode, event.Open.File.Inode, "wrong open inode")
 			inUpperLayer, _ := event.GetFieldValue("open.file.in_upper_layer")
-			assert.Equal(t, inUpperLayer, false, "should be in base layer")
+			assert.Equal(t, false, inUpperLayer, "should be in base layer")
 		})
 		if err != nil {
 			t.Error(err)
@@ -190,9 +190,9 @@ func TestOverlayFS(t *testing.T) {
 		err = test.GetSignal(t, func() error {
 			return os.Remove(testFile)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong unlink inode")
+			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
 			inUpperLayer, _ := event.GetFieldValue("open.file.in_upper_layer")
-			assert.Equal(t, inUpperLayer, false, "should be in base layer")
+			assert.Equal(t, false, inUpperLayer, "should be in base layer")
 		})
 		if err != nil {
 			t.Error(err)
@@ -215,9 +215,9 @@ func TestOverlayFS(t *testing.T) {
 			return f.Close()
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			inode = getInode(t, testFile)
-			assert.Equal(t, inode, event.Open.File.Inode, "wrong open inode")
+			assert.Equal(t, event.Open.File.Inode, inode, "wrong open inode")
 			inUpperLayer, _ := event.GetFieldValue("open.file.in_upper_layer")
-			assert.Equal(t, inUpperLayer, false, "should be in base layer")
+			assert.Equal(t, false, inUpperLayer, "should be in base layer")
 		})
 		if err != nil {
 			t.Error(err)
@@ -226,9 +226,9 @@ func TestOverlayFS(t *testing.T) {
 		err = test.GetSignal(t, func() error {
 			return os.Remove(testFile)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong unlink inode")
+			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
-			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
+			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
 		if err != nil {
 			t.Error(err)
@@ -251,9 +251,9 @@ func TestOverlayFS(t *testing.T) {
 			return f.Close()
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			inode = getInode(t, testFile)
-			assert.Equal(t, event.Open.File.Inode, inode, "wrong open inode")
+			assert.Equal(t, inode, event.Open.File.Inode, "wrong open inode")
 			inUpperLayer, _ := event.GetFieldValue("open.file.in_upper_layer")
-			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
+			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
 		if err != nil {
 			t.Error(err)
@@ -262,9 +262,9 @@ func TestOverlayFS(t *testing.T) {
 		err = test.GetSignal(t, func() error {
 			return os.Remove(testFile)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong unlink inode")
+			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
-			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
+			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
 		if err != nil {
 			t.Error(err)
@@ -292,12 +292,12 @@ func TestOverlayFS(t *testing.T) {
 			}
 
 			inode = getInode(t, newFile)
-			assert.Equal(t, event.Rename.New.Inode, inode, "wrong rename inode")
+			assert.Equal(t, inode, event.Rename.New.Inode, "wrong rename inode")
 			inUpperLayer, _ := event.GetFieldValue("rename.file.in_upper_layer")
-			assert.Equal(t, inUpperLayer, false, "should be in base layer")
+			assert.Equal(t, false, inUpperLayer, "should be in base layer")
 
 			inUpperLayer, _ = event.GetFieldValue("rename.file.destination.in_upper_layer")
-			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
+			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
 		if err != nil {
 			t.Error(err)
@@ -306,9 +306,9 @@ func TestOverlayFS(t *testing.T) {
 		err = test.GetSignal(t, func() error {
 			return os.Remove(newFile)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong unlink inode")
+			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
-			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
+			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
 		if err != nil {
 			t.Error(err)
@@ -326,9 +326,9 @@ func TestOverlayFS(t *testing.T) {
 		err = test.GetSignal(t, func() error {
 			return os.Remove(testDir)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.Rmdir.File.Inode, inode, "wrong rmdir inode")
+			assert.Equal(t, inode, event.Rmdir.File.Inode, "wrong rmdir inode")
 			inUpperLayer, _ := event.GetFieldValue("rmdir.file.in_upper_layer")
-			assert.Equal(t, inUpperLayer, false, "should be in base layer")
+			assert.Equal(t, false, inUpperLayer, "should be in base layer")
 		})
 		if err != nil {
 			t.Error(err)
@@ -347,9 +347,9 @@ func TestOverlayFS(t *testing.T) {
 			return os.Chmod(testFile, 0777)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			inode = getInode(t, testFile)
-			assert.Equal(t, event.Chmod.File.Inode, inode, "wrong chmod inode")
+			assert.Equal(t, inode, event.Chmod.File.Inode, "wrong chmod inode")
 			inUpperLayer, _ := event.GetFieldValue("chmod.file.in_upper_layer")
-			assert.Equal(t, inUpperLayer, false, "should be in base layer")
+			assert.Equal(t, false, inUpperLayer, "should be in base layer")
 		})
 		if err != nil {
 			t.Error(err)
@@ -358,9 +358,9 @@ func TestOverlayFS(t *testing.T) {
 		err = test.GetSignal(t, func() error {
 			return os.Remove(testFile)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong unlink inode")
+			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
-			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
+			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
 		if err != nil {
 			t.Error(err)
@@ -377,9 +377,9 @@ func TestOverlayFS(t *testing.T) {
 			return syscall.Mkdir(testFile, 0777)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			inode := getInode(t, testFile)
-			assert.Equal(t, event.Mkdir.File.Inode, inode, "wrong mkdir inode")
+			assert.Equal(t, inode, event.Mkdir.File.Inode, "wrong mkdir inode")
 			inUpperLayer, _ := event.GetFieldValue("mkdir.file.in_upper_layer")
-			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
+			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
 		if err != nil {
 			t.Error(err)
@@ -398,9 +398,9 @@ func TestOverlayFS(t *testing.T) {
 			return os.Chtimes(testFile, time.Now(), time.Now())
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			inode = getInode(t, testFile)
-			assert.Equal(t, event.Utimes.File.Inode, inode, "wrong utimes inode")
+			assert.Equal(t, inode, event.Utimes.File.Inode, "wrong utimes inode")
 			inUpperLayer, _ := event.GetFieldValue("utimes.file.in_upper_layer")
-			assert.Equal(t, inUpperLayer, false, "should be in base layer")
+			assert.Equal(t, false, inUpperLayer, "should be in base layer")
 		})
 		if err != nil {
 			t.Error(err)
@@ -409,9 +409,9 @@ func TestOverlayFS(t *testing.T) {
 		err = test.GetSignal(t, func() error {
 			return os.Remove(testFile)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong unlink inode")
+			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
-			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
+			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
 		if err != nil {
 			t.Error(err)
@@ -430,9 +430,9 @@ func TestOverlayFS(t *testing.T) {
 			return os.Chown(testFile, os.Getuid(), os.Getgid())
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			inode = getInode(t, testFile)
-			assert.Equal(t, event.Chown.File.Inode, inode, "wrong chown inode")
+			assert.Equal(t, inode, event.Chown.File.Inode, "wrong chown inode")
 			inUpperLayer, _ := event.GetFieldValue("chown.file.in_upper_layer")
-			assert.Equal(t, inUpperLayer, false, "should be in base layer")
+			assert.Equal(t, false, inUpperLayer, "should be in base layer")
 		})
 		if err != nil {
 			t.Error(err)
@@ -441,9 +441,9 @@ func TestOverlayFS(t *testing.T) {
 		err = test.GetSignal(t, func() error {
 			return os.Remove(testFile)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong unlink inode")
+			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
-			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
+			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
 		if err != nil {
 			t.Error(err)
@@ -473,9 +473,9 @@ func TestOverlayFS(t *testing.T) {
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			inode = getInode(t, testFile)
-			assert.Equal(t, event.SetXAttr.File.Inode, inode, "wrong setxattr inode")
+			assert.Equal(t, inode, event.SetXAttr.File.Inode, "wrong setxattr inode")
 			inUpperLayer, _ := event.GetFieldValue("setxattr.file.in_upper_layer")
-			assert.Equal(t, inUpperLayer, false, "should be in base layer")
+			assert.Equal(t, false, inUpperLayer, "should be in base layer")
 		})
 		if err != nil {
 			t.Error(err)
@@ -484,9 +484,9 @@ func TestOverlayFS(t *testing.T) {
 		err = test.GetSignal(t, func() error {
 			return os.Remove(testFile)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong unlink inode")
+			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
-			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
+			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
 		if err != nil {
 			t.Error(err)
@@ -505,9 +505,9 @@ func TestOverlayFS(t *testing.T) {
 			return os.Truncate(testFile, 0)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			inode = getInode(t, testFile)
-			assert.Equal(t, event.Open.File.Inode, inode, "wrong open inode")
+			assert.Equal(t, inode, event.Open.File.Inode, "wrong open inode")
 			inUpperLayer, _ := event.GetFieldValue("open.file.in_upper_layer")
-			assert.Equal(t, inUpperLayer, false, "should be in base layer")
+			assert.Equal(t, false, inUpperLayer, "should be in base layer")
 		})
 		if err != nil {
 			t.Error(err)
@@ -516,9 +516,9 @@ func TestOverlayFS(t *testing.T) {
 		err = test.GetSignal(t, func() error {
 			return os.Remove(testFile)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong unlink inode")
+			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
-			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
+			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
 		if err != nil {
 			t.Error(err)
@@ -542,13 +542,13 @@ func TestOverlayFS(t *testing.T) {
 			return os.Link(testSrc, testTarget)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			inode = getInode(t, testSrc)
-			assert.Equal(t, event.Link.Source.Inode, inode, "wrong link source inode")
+			assert.Equal(t, inode, event.Link.Source.Inode, "wrong link source inode")
 
 			inUpperLayer, _ := event.GetFieldValue("link.file.in_upper_layer")
-			assert.Equal(t, inUpperLayer, false, "should be in base layer")
+			assert.Equal(t, false, inUpperLayer, "should be in base layer")
 
 			inUpperLayer, _ = event.GetFieldValue("link.file.destination.in_upper_layer")
-			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
+			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
 		if err != nil {
 			t.Error(err)
@@ -557,9 +557,9 @@ func TestOverlayFS(t *testing.T) {
 		err = test.GetSignal(t, func() error {
 			return os.Remove(testSrc)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong unlink inode")
+			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
-			assert.Equal(t, inUpperLayer, true, "should be in base layer")
+			assert.Equal(t, true, inUpperLayer, "should be in base layer")
 		})
 		if err != nil {
 			t.Error(err)
@@ -568,9 +568,9 @@ func TestOverlayFS(t *testing.T) {
 		err = test.GetSignal(t, func() error {
 			return os.Remove(testTarget)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong unlink inode")
+			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
-			assert.Equal(t, inUpperLayer, true, "should be in upper layer")
+			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
 		if err != nil {
 			t.Error(err)

--- a/pkg/security/tests/probe_monitor_test.go
+++ b/pkg/security/tests/probe_monitor_test.go
@@ -40,7 +40,7 @@ func TestRulesetLoaded(t *testing.T) {
 			test.reloadConfiguration()
 			return nil
 		}, func(rule *rules.Rule, customEvent *sprobe.CustomEvent) bool {
-			assert.Equal(t, rule.ID, probe.RulesetLoadedRuleID, "wrong rule")
+			assert.Equal(t, probe.RulesetLoadedRuleID, rule.ID, "wrong rule")
 			return true
 		}, 3*time.Second, model.CustomRulesetLoadedEventType); err != nil {
 			t.Error(err)
@@ -83,7 +83,7 @@ func truncatedParents(t *testing.T, opts testOpts) {
 			}
 			return f.Close()
 		}, func(rule *rules.Rule, customEvent *sprobe.CustomEvent) bool {
-			assert.Equal(t, rule.ID, probe.AbnormalPathRuleID, "wrong rule")
+			assert.Equal(t, probe.AbnormalPathRuleID, rule.ID, "wrong rule")
 			return true
 		}, 3*time.Second, model.CustomTruncatedParentsEventType)
 		if err != nil {
@@ -106,9 +106,9 @@ func truncatedParents(t *testing.T, opts testOpts) {
 					// count the "a"s.
 					splittedFilepath = splittedFilepath[1:]
 				}
-				assert.Equal(t, splittedFilepath[0], "a", "invalid path resolution at the left edge")
-				assert.Equal(t, splittedFilepath[len(splittedFilepath)-1], "a", "invalid path resolution at the right edge")
-				assert.Equal(t, len(splittedFilepath), model.MaxPathDepth, "invalid path depth")
+				assert.Equal(t, "a", splittedFilepath[0], "invalid path resolution at the left edge")
+				assert.Equal(t, "a", splittedFilepath[len(splittedFilepath)-1], "invalid path resolution at the right edge")
+				assert.Equal(t, model.MaxPathDepth, len(splittedFilepath), "invalid path depth")
 			}
 		})
 		if err != nil {
@@ -154,7 +154,7 @@ func TestNoisyProcess(t *testing.T) {
 			}
 			return nil
 		}, func(rule *rules.Rule, customEvent *sprobe.CustomEvent) bool {
-			assert.Equal(t, rule.ID, probe.NoisyProcessRuleID, "wrong rule")
+			assert.Equal(t, probe.NoisyProcessRuleID, rule.ID, "wrong rule")
 			return true
 		}, 3*time.Second, model.CustomNoisyProcessEventType)
 		if err != nil {

--- a/pkg/security/tests/rename_test.go
+++ b/pkg/security/tests/rename_test.go
@@ -57,8 +57,8 @@ func TestRename(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "rename", "wrong event type")
-			assert.Equal(t, event.Rename.New.Inode, getInode(t, testNewFile), "wrong inode")
+			assert.Equal(t, "rename", event.GetType(), "wrong event type")
+			assert.Equal(t, getInode(t, testNewFile), event.Rename.New.Inode, "wrong inode")
 			assertFieldEqual(t, event, "rename.file.destination.inode", int(getInode(t, testNewFile)), "wrong inode")
 
 			assertRights(t, event.Rename.Old.Mode, expectedMode)
@@ -90,8 +90,8 @@ func TestRename(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "rename", "wrong event type")
-			assert.Equal(t, event.Rename.New.Inode, getInode(t, testNewFile), "wrong inode")
+			assert.Equal(t, "rename", event.GetType(), "wrong event type")
+			assert.Equal(t, getInode(t, testNewFile), event.Rename.New.Inode, "wrong inode")
 			assertFieldEqual(t, event, "rename.file.destination.inode", int(getInode(t, testNewFile)), "wrong inode")
 
 			assertRights(t, event.Rename.Old.Mode, expectedMode)
@@ -126,8 +126,8 @@ func TestRename(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "rename", "wrong event type")
-			assert.Equal(t, event.Rename.New.Inode, getInode(t, testNewFile), "wrong inode")
+			assert.Equal(t, "rename", event.GetType(), "wrong event type")
+			assert.Equal(t, getInode(t, testNewFile), event.Rename.New.Inode, "wrong inode")
 			assertFieldEqual(t, event, "rename.file.destination.inode", int(getInode(t, testNewFile)), "wrong inode")
 
 			assertRights(t, event.Rename.Old.Mode, expectedMode)
@@ -186,7 +186,7 @@ func TestRenameInvalidate(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "rename", "wrong event type")
+			assert.Equal(t, "rename", event.GetType(), "wrong event type")
 			assertFieldEqual(t, event, "rename.file.destination.path", testNewFile)
 
 			if !validateRenameSchema(t, event) {
@@ -253,7 +253,7 @@ func TestRenameReuseInode(t *testing.T) {
 		}
 		return nil
 	}, func(event *sprobe.Event, rule *rules.Rule) {
-		assert.Equal(t, event.GetType(), "open", "wrong event type")
+		assert.Equal(t, "open", event.GetType(), "wrong event type")
 	})
 	if err != nil {
 		t.Error(err)
@@ -287,7 +287,7 @@ func TestRenameReuseInode(t *testing.T) {
 		}
 		return f.Close()
 	}, func(event *sprobe.Event, rule *rules.Rule) {
-		assert.Equal(t, event.GetType(), "open", "wrong event type")
+		assert.Equal(t, "open", event.GetType(), "wrong event type")
 		assertFieldEqual(t, event, "open.file.inode", int(testNewFileInode))
 		assertFieldEqual(t, event, "open.file.path", testReuseInodeFile)
 
@@ -336,7 +336,7 @@ func TestRenameFolder(t *testing.T) {
 			}
 			return testFile.Close()
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "open", "wrong event type")
+			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			assertFieldEqual(t, event, "open.file.path", filename.Load().(string))
 
 			if !validateRenameSchema(t, event) {

--- a/pkg/security/tests/rmdir_test.go
+++ b/pkg/security/tests/rmdir_test.go
@@ -53,8 +53,8 @@ func TestRmdir(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "rmdir", "wrong event type")
-			assert.Equal(t, event.Rmdir.File.Inode, inode, "wrong inode")
+			assert.Equal(t, "rmdir", event.GetType(), "wrong event type")
+			assert.Equal(t, inode, event.Rmdir.File.Inode, "wrong inode")
 			assertRights(t, event.Rmdir.File.Mode, expectedMode, "wrong initial mode")
 
 			assertNearTime(t, event.Rmdir.File.MTime)
@@ -81,8 +81,8 @@ func TestRmdir(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "rmdir", "wrong event type")
-			assert.Equal(t, event.Rmdir.File.Inode, inode, "wrong inode")
+			assert.Equal(t, "rmdir", event.GetType(), "wrong event type")
+			assert.Equal(t, inode, event.Rmdir.File.Inode, "wrong inode")
 			assertRights(t, event.Rmdir.File.Mode, expectedMode, "wrong initial mode")
 
 			assertNearTime(t, event.Rmdir.File.MTime)
@@ -119,7 +119,7 @@ func TestRmdirInvalidate(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "rmdir", "wrong event type")
+			assert.Equal(t, "rmdir", event.GetType(), "wrong event type")
 			assertFieldEqual(t, event, "rmdir.file.path", testFile)
 		})
 		if err != nil {

--- a/pkg/security/tests/selinux_test.go
+++ b/pkg/security/tests/selinux_test.go
@@ -72,7 +72,7 @@ func TestSELinux(t *testing.T) {
 			return nil
 		}, func(event *probe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_selinux_enforce")
-			assert.Equal(t, event.GetType(), "selinux", "wrong event type")
+			assert.Equal(t, "selinux", event.GetType(), "wrong event type")
 
 			if !validateSELinuxSchema(t, event) {
 				t.Fatal(event.String())
@@ -91,7 +91,7 @@ func TestSELinux(t *testing.T) {
 			return nil
 		}, func(event *probe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_selinux_enforce")
-			assert.Equal(t, event.GetType(), "selinux", "wrong event type")
+			assert.Equal(t, "selinux", event.GetType(), "wrong event type")
 
 			assertFieldEqual(t, event, "selinux.enforce.status", "permissive", "wrong enforce value")
 
@@ -112,7 +112,7 @@ func TestSELinux(t *testing.T) {
 			return nil
 		}, func(event *probe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_selinux_write_bool_true")
-			assert.Equal(t, event.GetType(), "selinux", "wrong event type")
+			assert.Equal(t, "selinux", event.GetType(), "wrong event type")
 
 			assertFieldEqual(t, event, "selinux.bool.name", TEST_BOOL_NAME, "wrong bool name")
 			assertFieldEqual(t, event, "selinux.bool.state", "on", "wrong bool value")
@@ -134,7 +134,7 @@ func TestSELinux(t *testing.T) {
 			return nil
 		}, func(event *probe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_selinux_write_bool_false")
-			assert.Equal(t, event.GetType(), "selinux", "wrong event type")
+			assert.Equal(t, "selinux", event.GetType(), "wrong event type")
 
 			assertFieldEqual(t, event, "selinux.bool.name", TEST_BOOL_NAME, "wrong bool name")
 			assertFieldEqual(t, event, "selinux.bool.state", "off", "wrong bool value")
@@ -161,7 +161,7 @@ func TestSELinux(t *testing.T) {
 		if err == nil {
 			t.Error("expected error")
 		} else {
-			assert.Equal(t, err.Error(), "timeout", "wrong error type, expected timeout")
+			assert.Equal(t, "timeout", err.Error(), "wrong error type, expected timeout")
 		}
 	})
 }
@@ -198,7 +198,7 @@ func TestSELinuxCommitBools(t *testing.T) {
 			return nil
 		}, func(event *probe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_selinux_commit_bools")
-			assert.Equal(t, event.GetType(), "selinux", "wrong event type")
+			assert.Equal(t, "selinux", event.GetType(), "wrong event type")
 
 			assertFieldEqual(t, event, "selinux.bool_commit.state", true, "wrong bool value")
 

--- a/pkg/security/tests/setup_test.go
+++ b/pkg/security/tests/setup_test.go
@@ -257,7 +257,7 @@ func assertMode(t *testing.T, actualMode, expectedMode uint32, msgAndArgs ...int
 	if len(msgAndArgs) == 0 {
 		msgAndArgs = append(msgAndArgs, "wrong mode")
 	}
-	assert.Equal(t, strconv.FormatUint(uint64(actualMode), 8), strconv.FormatUint(uint64(expectedMode), 8), msgAndArgs...)
+	assert.Equal(t, strconv.FormatUint(uint64(expectedMode), 8), strconv.FormatUint(uint64(actualMode), 8), msgAndArgs...)
 }
 
 func assertRights(t *testing.T, actualMode, expectedMode uint16, msgAndArgs ...interface{}) {
@@ -275,12 +275,12 @@ func assertNearTime(t *testing.T, event time.Time) {
 
 func assertTriggeredRule(t *testing.T, r *rules.Rule, id string) {
 	t.Helper()
-	assert.Equal(t, r.ID, id, "wrong triggered rule")
+	assert.Equal(t, id, r.ID, "wrong triggered rule")
 }
 
 func assertReturnValue(t *testing.T, retval, expected int64) {
 	t.Helper()
-	assert.Equal(t, retval, expected, "wrong return value")
+	assert.Equal(t, expected, retval, "wrong return value")
 }
 
 func assertFieldEqual(t *testing.T, e *sprobe.Event, field string, value interface{}, msgAndArgs ...interface{}) {
@@ -289,7 +289,7 @@ func assertFieldEqual(t *testing.T, e *sprobe.Event, field string, value interfa
 	if err != nil {
 		t.Errorf("failed to get field '%s': %s", field, err)
 	} else {
-		assert.Equal(t, fieldValue, value, msgAndArgs...)
+		assert.Equal(t, value, fieldValue, msgAndArgs...)
 	}
 }
 

--- a/pkg/security/tests/unlink_test.go
+++ b/pkg/security/tests/unlink_test.go
@@ -48,8 +48,8 @@ func TestUnlink(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "unlink", "wrong event type")
-			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong inode")
+			assert.Equal(t, "unlink", event.GetType(), "wrong event type")
+			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong inode")
 			assertRights(t, event.Unlink.File.Mode, expectedMode)
 
 			assertNearTime(t, event.Unlink.File.MTime)
@@ -72,8 +72,8 @@ func TestUnlink(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "unlink", "wrong event type")
-			assert.Equal(t, event.Unlink.File.Inode, inode, "wrong inode")
+			assert.Equal(t, "unlink", event.GetType(), "wrong event type")
+			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong inode")
 			assertRights(t, event.Unlink.File.Mode, expectedMode)
 
 			assertNearTime(t, event.Unlink.File.MTime)
@@ -112,7 +112,7 @@ func TestUnlinkInvalidate(t *testing.T) {
 			os.Remove(testFile)
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "unlink", "wrong event type")
+			assert.Equal(t, "unlink", event.GetType(), "wrong event type")
 			assertFieldEqual(t, event, "unlink.file.path", testFile)
 		})
 		if err != nil {

--- a/pkg/security/tests/utimes_test.go
+++ b/pkg/security/tests/utimes_test.go
@@ -52,10 +52,10 @@ func TestUtime(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "utimes", "wrong event type")
-			assert.Equal(t, event.Utimes.Atime.Unix(), int64(123))
-			assert.Equal(t, event.Utimes.Mtime.Unix(), int64(456))
-			assert.Equal(t, event.Utimes.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, "utimes", event.GetType(), "wrong event type")
+			assert.Equal(t, int64(123), event.Utimes.Atime.Unix())
+			assert.Equal(t, int64(456), event.Utimes.Mtime.Unix())
+			assert.Equal(t, getInode(t, testFile), event.Utimes.File.Inode, "wrong inode")
 
 			assertRights(t, uint16(event.Utimes.File.Mode), expectedMode)
 
@@ -90,11 +90,11 @@ func TestUtime(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "utimes", "wrong event type")
-			assert.Equal(t, event.Utimes.Atime.Unix(), int64(111))
+			assert.Equal(t, "utimes", event.GetType(), "wrong event type")
+			assert.Equal(t, int64(111), event.Utimes.Atime.Unix())
 
-			assert.Equal(t, event.Utimes.Atime.UnixNano()%int64(time.Second)/int64(time.Microsecond), int64(222))
-			assert.Equal(t, event.Utimes.File.Inode, getInode(t, testFile))
+			assert.Equal(t, int64(222), event.Utimes.Atime.UnixNano()%int64(time.Second)/int64(time.Microsecond))
+			assert.Equal(t, getInode(t, testFile), event.Utimes.File.Inode)
 			assertRights(t, uint16(event.Utimes.File.Mode), expectedMode)
 
 			assertNearTime(t, event.Utimes.File.MTime)
@@ -131,11 +131,11 @@ func TestUtime(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "utimes", "wrong event type")
-			assert.Equal(t, event.Utimes.Mtime.Unix(), int64(555))
+			assert.Equal(t, "utimes", event.GetType(), "wrong event type")
+			assert.Equal(t, int64(555), event.Utimes.Mtime.Unix())
 
-			assert.Equal(t, event.Utimes.Mtime.UnixNano()%int64(time.Second)/int64(time.Nanosecond), int64(666))
-			assert.Equal(t, event.Utimes.File.Inode, getInode(t, testFile))
+			assert.Equal(t, int64(666), event.Utimes.Mtime.UnixNano()%int64(time.Second)/int64(time.Nanosecond))
+			assert.Equal(t, getInode(t, testFile), event.Utimes.File.Inode)
 			assertRights(t, uint16(event.Utimes.File.Mode), expectedMode)
 
 			assertNearTime(t, event.Utimes.File.MTime)

--- a/pkg/security/tests/xattr_test.go
+++ b/pkg/security/tests/xattr_test.go
@@ -63,10 +63,10 @@ func TestSetXAttr(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "setxattr", "wrong event type")
-			assert.Equal(t, event.SetXAttr.Name, "user.test_xattr")
-			assert.Equal(t, event.SetXAttr.Namespace, "user")
-			assert.Equal(t, event.SetXAttr.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, "setxattr", event.GetType(), "wrong event type")
+			assert.Equal(t, "user.test_xattr", event.SetXAttr.Name)
+			assert.Equal(t, "user", event.SetXAttr.Namespace)
+			assert.Equal(t, getInode(t, testFile), event.SetXAttr.File.Inode, "wrong inode")
 			assertRights(t, event.SetXAttr.File.Mode, uint16(expectedMode))
 
 			assertNearTime(t, event.SetXAttr.File.MTime)
@@ -101,10 +101,10 @@ func TestSetXAttr(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "setxattr", "wrong event type")
-			assert.Equal(t, event.SetXAttr.Name, "user.test_xattr")
-			assert.Equal(t, event.SetXAttr.Namespace, "user")
-			assert.Equal(t, event.SetXAttr.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, "setxattr", event.GetType(), "wrong event type")
+			assert.Equal(t, "user.test_xattr", event.SetXAttr.Name)
+			assert.Equal(t, "user", event.SetXAttr.Namespace)
+			assert.Equal(t, getInode(t, testFile), event.SetXAttr.File.Inode, "wrong inode")
 			assertRights(t, event.SetXAttr.File.Mode, 0777)
 
 			assertNearTime(t, event.SetXAttr.File.MTime)
@@ -132,10 +132,10 @@ func TestSetXAttr(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "setxattr", "wrong event type")
-			assert.Equal(t, event.SetXAttr.Name, "user.test_xattr")
-			assert.Equal(t, event.SetXAttr.Namespace, "user")
-			assert.Equal(t, event.SetXAttr.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, "setxattr", event.GetType(), "wrong event type")
+			assert.Equal(t, "user.test_xattr", event.SetXAttr.Name)
+			assert.Equal(t, "user", event.SetXAttr.Namespace)
+			assert.Equal(t, getInode(t, testFile), event.SetXAttr.File.Inode, "wrong inode")
 			assertRights(t, event.SetXAttr.File.Mode, uint16(expectedMode))
 
 			assertNearTime(t, event.SetXAttr.File.MTime)
@@ -199,10 +199,10 @@ func TestRemoveXAttr(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "removexattr", "wrong event type")
-			assert.Equal(t, event.RemoveXAttr.Name, "user.test_xattr")
+			assert.Equal(t, "removexattr", event.GetType(), "wrong event type")
+			assert.Equal(t, "user.test_xattr", event.RemoveXAttr.Name)
 
-			assert.Equal(t, event.RemoveXAttr.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, getInode(t, testFile), event.RemoveXAttr.File.Inode, "wrong inode")
 			assertRights(t, event.RemoveXAttr.File.Mode, uint16(expectedMode))
 
 			assertNearTime(t, event.RemoveXAttr.File.MTime)
@@ -244,10 +244,10 @@ func TestRemoveXAttr(t *testing.T) {
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			assert.Equal(t, event.GetType(), "removexattr", "wrong event type")
-			assert.Equal(t, event.RemoveXAttr.Name, "user.test_xattr")
+			assert.Equal(t, "removexattr", event.GetType(), "wrong event type")
+			assert.Equal(t, "user.test_xattr", event.RemoveXAttr.Name)
 
-			assert.Equal(t, event.RemoveXAttr.File.Inode, getInode(t, testFile), "wrong inode")
+			assert.Equal(t, getInode(t, testFile), event.RemoveXAttr.File.Inode, "wrong inode")
 			assertRights(t, event.RemoveXAttr.File.Mode, 0777)
 
 			assertNearTime(t, event.RemoveXAttr.File.MTime)


### PR DESCRIPTION
### What does this PR do?

This PR fixes 2 small bugs with no actual impact in the execution of the agent.
- A small typo in `is_erpc_request` function name
- Use the correct expected/actual argument for `assert.Equal` function in tests. This is important because for example with strings, the library displays a diff so the expected and actual args have semantic meanings.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
