### PR TITLE
Fix CloudFoundry tagger collector

### DIFF
--- a/pkg/tagger/collectors/garden_main.go
+++ b/pkg/tagger/collectors/garden_main.go
@@ -31,10 +31,6 @@ type GardenCollector struct {
 
 // Detect tries to connect to the Garden API and the cluster agent
 func (c *GardenCollector) Detect(ctx context.Context, out chan<- []*TagInfo) (CollectionMode, error) {
-	if !config.IsFeaturePresent(config.CloudFoundry) {
-		return NoCollection, nil
-	}
-
 	// Detect if we're on a compute VM by trying to connect to the local garden API
 	var err error
 	c.gardenUtil, err = cloudfoundry.GetGardenUtil()
@@ -86,7 +82,7 @@ func (c *GardenCollector) Pull(ctx context.Context) error {
 }
 
 // Fetch gets the tags for a specific entity
-func (c *GardenCollector) Fetch(entity string) ([]string, []string, []string, error) {
+func (c *GardenCollector) Fetch(ctx context.Context, entity string) ([]string, []string, []string, error) {
 	_, cid := containers.SplitEntityName(entity)
 	tagsByInstanceGUID, err := c.extractTags(config.Datadog.GetString("bosh_id"))
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

Fixes container collection in cloud foundry

### Motivation

- https://github.com/DataDog/datadog-agent/pull/7605 changed the interface for a `Puller` but didn't change the signature in `garden_main.go`
- https://github.com/DataDog/datadog-agent/pull/8521 changed the collector detection mechanism that could introduce some flakiness depending on the order the process are started during a cloud foundry deployment. The retry is needed

