### PR TITLE
Comments for race-free handling of tag.Provider.GetTags()

### DIFF
--- a/pkg/logs/tag/local_provider.go
+++ b/pkg/logs/tag/local_provider.go
@@ -37,6 +37,9 @@ func NewLocalProvider(t []string) Provider {
 		go func() {
 			<-time.After(time.Until(p.expectedTagsDeadline))
 
+			// NOTE: this lock covers only the properties of this struct, and
+			// not the contents of the []string slices.  These slices must
+			// be treated as immutable.
 			p.Lock()
 			defer p.Unlock()
 			p.expectedTags = p.tags
@@ -46,7 +49,8 @@ func NewLocalProvider(t []string) Provider {
 	return p
 }
 
-// GetTags returns an empty list of tags.
+// GetTags returns the provider's tags.  The resulting slice is shared and
+// must not be mutated
 func (p *localProvider) GetTags() []string {
 
 	p.RLock()

--- a/pkg/logs/tag/provider.go
+++ b/pkg/logs/tag/provider.go
@@ -17,6 +17,10 @@ import (
 
 // Provider returns a list of up-to-date tags for a given entity.
 type Provider interface {
+	// Return the current list of tags for the provider's entity.
+	//
+	// Callers should consider the resulting slice read-only.  Implementers
+	// must be careful not to mutate the slice after returning it.
 	GetTags() []string
 }
 


### PR DESCRIPTION

### What does this PR do?
This interface method returns a mutable value.  Callers and implementers
must take care not to mutate that value.  This is already the case for
all uses of this method.

### Motivation

https://datadoghq.atlassian.net/browse/AGNTGLD-63

### Additional Notes

This only changes comments.  I'd love to hear ideas as to how to mechanically avoid this bug!
