### PR TITLE
Fix CC API polling interval configuration, and allow batch size configuration

### DIFF
--- a/cmd/cluster-agent-cloudfoundry/app/app.go
+++ b/cmd/cluster-agent-cloudfoundry/app/app.go
@@ -227,7 +227,7 @@ func run(cmd *cobra.Command, args []string) error {
 }
 
 func initializeCCCache(ctx context.Context) error {
-	pollInterval := time.Second * time.Duration(config.Datadog.GetInt("cloud_foundry_bbs.poll_interval"))
+	pollInterval := time.Second * time.Duration(config.Datadog.GetInt("cloud_foundry_cc.poll_interval"))
 	_, err := cloudfoundry.ConfigureGlobalCCCache(
 		ctx,
 		config.Datadog.GetString("cloud_foundry_cc.url"),
@@ -235,6 +235,7 @@ func initializeCCCache(ctx context.Context) error {
 		config.Datadog.GetString("cloud_foundry_cc.client_secret"),
 		config.Datadog.GetBool("cloud_foundry_cc.skip_ssl_validation"),
 		pollInterval,
+		config.Datadog.GetInt("cloud_foundry_cc.apps_batch_size"),
 		nil,
 	)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -606,6 +606,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("cloud_foundry_cc.client_secret", "")
 	config.BindEnvAndSetDefault("cloud_foundry_cc.poll_interval", 60)
 	config.BindEnvAndSetDefault("cloud_foundry_cc.skip_ssl_validation", false)
+	config.BindEnvAndSetDefault("cloud_foundry_cc.apps_batch_size", 5000)
 
 	// Cloud Foundry Garden
 	config.BindEnvAndSetDefault("cloud_foundry_garden.listen_network", "unix")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2177,6 +2177,11 @@ api_key:
   #
   # poll_interval: 60
 
+  ## @param apps_batch_size - integer - optional - default: 5000
+  ## Number of apps per page to collect when calling the list apps endpoint of the CC API. Max 5000.
+  #
+  # apps_batch_size: 5000
+
 {{ end -}}
 {{- if .SNMP }}
 

--- a/pkg/util/cloudfoundry/main_test.go
+++ b/pkg/util/cloudfoundry/main_test.go
@@ -30,7 +30,7 @@ func TestMain(m *testing.M) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	bc, _ = ConfigureGlobalBBSCache(ctx, "url", "", "", "", time.Second, []*regexp.Regexp{}, []*regexp.Regexp{}, &testBBSClient{})
-	cc, _ = ConfigureGlobalCCCache(ctx, "url", "", "", false, time.Second, &testCCClient{})
+	cc, _ = ConfigureGlobalCCCache(ctx, "url", "", "", false, time.Second, 1, &testCCClient{})
 	for i := 1; i <= 10; i++ {
 		if cc.GetPollSuccesses() == 0 || bc.GetPollSuccesses() == 0 {
 			time.Sleep(time.Second)


### PR DESCRIPTION
### What does this PR do?

Fix a copy paste error to use the correct configuration option for the CC API polling interval
Add a configuration option for the batch size to tweak performance impact on the CC API.

### Motivation

Tested by customer on large environment that surfaced the issues
