### PR TITLE
[CWS] run kitchen functional tests on arm64, and fix bugs

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -76,7 +76,7 @@ kitchen_ubuntu_security_agent_arm64:
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export KITCHEN_PLATFORM=ubuntu
-    - export KITCHEN_OSVERS="ubuntu-20-04"
+    - export KITCHEN_OSVERS="ubuntu-20-04-hwe,ubuntu-21-04"
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -15,6 +15,8 @@
   variables:
     AGENT_MAJOR_VERSION: 7
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
+    # we need chef >= 15 for arm64
+    CHEF_VERSION: 15.16.4
   script:
     - bash -l tasks/run-test-kitchen.sh security-agent-test $AGENT_MAJOR_VERSION
 

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -13,12 +13,18 @@
   rules:
     !reference [.manual]
   stage: functional_test
-  needs: ["tests_ebpf_x64"]
   variables:
     AGENT_MAJOR_VERSION: 7
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
   script:
     - bash -l tasks/run-test-kitchen.sh security-agent-test $AGENT_MAJOR_VERSION
+
+.kitchen_test_security_agent_x64:
+  extends:
+    - .kitchen_test_security_agent
+  needs: ["tests_ebpf_x64"]
+  variables:
+    KITCHEN_ARCH: x86_64
 
 .kitchen_stress_security_agent:
   extends:
@@ -35,8 +41,8 @@
   script:
     - bash -l tasks/run-test-kitchen.sh security-agent-stress $AGENT_MAJOR_VERSION
 
-kitchen_centos_security_agent:
-  extends: .kitchen_test_security_agent
+kitchen_centos_security_agent_x64:
+  extends: .kitchen_test_security_agent_x64
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export KITCHEN_PLATFORM="centos"
@@ -44,8 +50,8 @@ kitchen_centos_security_agent:
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 
-kitchen_ubuntu_security_agent:
-  extends: .kitchen_test_security_agent
+kitchen_ubuntu_security_agent_x64:
+  extends: .kitchen_test_security_agent_x64
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export KITCHEN_PLATFORM=ubuntu
@@ -62,8 +68,8 @@ kitchen_ubuntu_security_agent_stress:
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 
-kitchen_suse_security_agent:
-  extends: .kitchen_test_security_agent
+kitchen_suse_security_agent_x64:
+  extends: .kitchen_test_security_agent_x64
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export KITCHEN_PLATFORM="suse"
@@ -71,8 +77,8 @@ kitchen_suse_security_agent:
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 
-kitchen_debian_security_agent:
-  extends: .kitchen_test_security_agent
+kitchen_debian_security_agent_x64:
+  extends: .kitchen_test_security_agent_x64
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export KITCHEN_PLATFORM="debian"
@@ -80,8 +86,8 @@ kitchen_debian_security_agent:
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 
-kitchen_oracle_security_agent:
-  extends: .kitchen_test_security_agent
+kitchen_oracle_security_agent_x64:
+  extends: .kitchen_test_security_agent_x64
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export KITCHEN_PLATFORM="oracle"

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -9,7 +9,6 @@
   extends:
     - .kitchen_common
     - .kitchen_datadog_agent_flavor
-    - .kitchen_azure_location_north_central_us
   rules:
     !reference [.manual]
   stage: functional_test
@@ -22,9 +21,20 @@
 .kitchen_test_security_agent_x64:
   extends:
     - .kitchen_test_security_agent
+    - .kitchen_azure_location_north_central_us
   needs: ["tests_ebpf_x64"]
   variables:
     KITCHEN_ARCH: x86_64
+
+.kitchen_test_security_agent_arm64:
+  extends:
+    - .kitchen_test_security_agent
+    - .kitchen_ec2_location_us_east_1
+    - .kitchen_ec2_spot_instances
+  needs: [ "tests_ebpf_arm64" ]
+  variables:
+    KITCHEN_ARCH: arm64
+    KITCHEN_EC2_INSTANCE_TYPE: "t4g.large"
 
 .kitchen_stress_security_agent:
   extends:
@@ -56,6 +66,15 @@ kitchen_ubuntu_security_agent_x64:
     - rsync -azr --delete ./ $SRC_PATH
     - export KITCHEN_PLATFORM=ubuntu
     - export KITCHEN_OSVERS="ubuntu-18-04,ubuntu-20-04,ubuntu-21-04"
+    - cd $DD_AGENT_TESTING_DIR
+    - bash -l tasks/kitchen_setup.sh
+
+kitchen_ubuntu_security_agent_arm64:
+  extends: .kitchen_test_security_agent_arm64
+  before_script:
+    - rsync -azr --delete ./ $SRC_PATH
+    - export KITCHEN_PLATFORM=ubuntu
+    - export KITCHEN_OSVERS="ubuntu-20-04"
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -99,7 +99,7 @@ tests_ebpf_arm64:
     - git pull
     - inv -e deps
     - inv -e system-probe.build --bundle-ebpf --incremental-build
-    - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite-master
+    # - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite-master
     - git reset --hard
     - git checkout -
 

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -90,6 +90,18 @@ tests_ebpf_arm64:
     - !reference [.retrieve_sysprobe_deps]
   script:
     - !reference [.build_sysprobe_artifacts]
+    # Compile runtime security functional tests to be executed in kitchen tests
+    - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite
+    # Compile runtime security stress tests to be executed in kitchen tests
+    - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
+    # Compile main version for comparison, uncomment following lines when merged
+    - git checkout -f main || git checkout -f master
+    - git pull
+    - inv -e deps
+    - inv -e system-probe.build --bundle-ebpf --incremental-build
+    - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite-master
+    - git reset --hard
+    - git checkout -
 
 tests_windows_sysprobe_x64:
   extends: .tests_windows_sysprobe

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -91,7 +91,7 @@ tests_ebpf_arm64:
   script:
     - !reference [.build_sysprobe_artifacts]
     # Compile runtime security functional tests to be executed in kitchen tests
-    - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite
+    - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --build-flags "-race"
     # Compile runtime security stress tests to be executed in kitchen tests
     - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
     # Compile main version for comparison, uncomment following lines when merged

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -94,14 +94,6 @@ tests_ebpf_arm64:
     - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --build-flags "-race"
     # Compile runtime security stress tests to be executed in kitchen tests
     - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
-    # Compile main version for comparison, uncomment following lines when merged
-    - git checkout -f main || git checkout -f master
-    - git pull
-    - inv -e deps
-    - inv -e system-probe.build --bundle-ebpf --incremental-build
-    # - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite-master
-    - git reset --hard
-    - git checkout -
 
 tests_windows_sysprobe_x64:
   extends: .tests_windows_sysprobe

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "9dfe314aebb7ca21bc71b8dd33360755a3b9d1b1630164c596f9e048783c80f5")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "af462d15449357093c9da0e89525b02e08543b73336e5ce3f2f28b5d4b0a258c")

--- a/pkg/security/ebpf/c/exec.h
+++ b/pkg/security/ebpf/c/exec.h
@@ -442,6 +442,11 @@ int kprobe_bprm_execve(struct pt_regs *ctx) {
     return parse_args_and_env(ctx);
 }
 
+SEC("kprobe/security_bprm_check")
+int kprobe_security_bprm_check(struct pt_regs *ctx) {
+    return parse_args_and_env(ctx);
+}
+
 void __attribute__((always_inline)) fill_args_envs(struct exec_event_t *event, struct syscall_cache_t *syscall) {
     event->args_id = syscall->exec.args.id;
     event->args_truncated = syscall->exec.args.truncated;

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -34,6 +34,7 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 			&manager.BestEffort{Selectors: []manager.ProbesSelector{
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/prepare_binprm"}},
 				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/bprm_execve"}},
+				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/security_bprm_check"}},
 			}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/vfs_open"}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/do_dentry_open"}},

--- a/pkg/security/ebpf/probes/exec.go
+++ b/pkg/security/ebpf/probes/exec.go
@@ -63,6 +63,10 @@ var execProbes = []*manager.Probe{
 	},
 	{
 		UID:     SecurityAgentUID,
+		Section: "kprobe/security_bprm_check",
+	},
+	{
+		UID:     SecurityAgentUID,
 		Section: "kprobe/security_bprm_committed_creds",
 	},
 	{

--- a/pkg/security/tests/chown32_test.go
+++ b/pkg/security/tests/chown32_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// +build functionaltests,!386
+// +build functionaltests,amd64
 
 package tests
 

--- a/pkg/security/tests/chown_test.go
+++ b/pkg/security/tests/chown_test.go
@@ -115,7 +115,7 @@ func TestChown(t *testing.T) {
 		}
 	})
 
-	t.Run("lchown", func(t *testing.T) {
+	t.Run("lchown", ifSyscallSupported("SYS_LCHOWN", func(t *testing.T, syscallNB uintptr) {
 		testSymlink, testSymlinkPtr, err := test.Path("test-symlink")
 		if err != nil {
 			t.Fatal(err)
@@ -128,7 +128,7 @@ func TestChown(t *testing.T) {
 		defer os.Remove(testSymlink)
 
 		err = test.GetSignal(t, func() error {
-			if _, _, errno := syscall.Syscall(syscall.SYS_LCHOWN, uintptr(testSymlinkPtr), uintptr(102), uintptr(202)); errno != 0 {
+			if _, _, errno := syscall.Syscall(syscallNB, uintptr(testSymlinkPtr), uintptr(102), uintptr(202)); errno != 0 {
 				if errno == unix.ENOSYS {
 					t.Skip("lchown is not supported")
 				}
@@ -155,7 +155,7 @@ func TestChown(t *testing.T) {
 		if err != nil {
 			t.Error(err)
 		}
-	})
+	}))
 
 	t.Run("chown", ifSyscallSupported("SYS_CHOWN", func(t *testing.T, syscallNB uintptr) {
 		defer func() {

--- a/pkg/security/tests/stress_test.go
+++ b/pkg/security/tests/stress_test.go
@@ -302,7 +302,7 @@ func BenchmarkERPCDentryResolutionSegment(b *testing.B) {
 	}
 	defer test.Close()
 
-	testFile, testFilePtr, err := test.Path("aa/bb/cc/dd/ee")
+	testFile, _, err := test.Path("aa/bb/cc/dd/ee")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -316,9 +316,9 @@ func BenchmarkERPCDentryResolutionSegment(b *testing.B) {
 		pathID  uint32
 	)
 	err = test.GetSignal(b, func() error {
-		fd, _, errno := syscall.Syscall(syscall.SYS_OPEN, uintptr(testFilePtr), syscall.O_CREAT, 0755)
-		if errno != 0 {
-			b.Fatal(error(errno))
+		fd, err := syscall.Open(testFile, syscall.O_CREAT, 0755)
+		if err != nil {
+			b.Fatal(err)
 		}
 		return syscall.Close(int(fd))
 	}, func(event *sprobe.Event, _ *rules.Rule) {
@@ -371,7 +371,7 @@ func BenchmarkERPCDentryResolutionPath(b *testing.B) {
 	}
 	defer test.Close()
 
-	testFile, testFilePtr, err := test.Path("aa/bb/cc/dd/ee")
+	testFile, _, err := test.Path("aa/bb/cc/dd/ee")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -385,9 +385,9 @@ func BenchmarkERPCDentryResolutionPath(b *testing.B) {
 		pathID  uint32
 	)
 	err = test.GetSignal(b, func() error {
-		fd, _, errno := syscall.Syscall(syscall.SYS_OPEN, uintptr(testFilePtr), syscall.O_CREAT, 0755)
-		if errno != 0 {
-			b.Fatal(error(errno))
+		fd, err := syscall.Open(testFile, syscall.O_CREAT, 0755)
+		if err != nil {
+			b.Fatal(err)
 		}
 		return syscall.Close(int(fd))
 	}, func(event *sprobe.Event, _ *rules.Rule) {
@@ -437,7 +437,7 @@ func BenchmarkMapDentryResolutionSegment(b *testing.B) {
 	}
 	defer test.Close()
 
-	testFile, testFilePtr, err := test.Path("aa/bb/cc/dd/ee")
+	testFile, _, err := test.Path("aa/bb/cc/dd/ee")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -451,9 +451,9 @@ func BenchmarkMapDentryResolutionSegment(b *testing.B) {
 		pathID  uint32
 	)
 	err = test.GetSignal(b, func() error {
-		fd, _, errno := syscall.Syscall(syscall.SYS_OPEN, uintptr(testFilePtr), syscall.O_CREAT, 0755)
-		if errno != 0 {
-			b.Fatal(error(errno))
+		fd, err := syscall.Open(testFile, syscall.O_CREAT, 0755)
+		if err != nil {
+			b.Fatal(err)
 		}
 		return syscall.Close(int(fd))
 	}, func(event *sprobe.Event, _ *rules.Rule) {
@@ -503,7 +503,7 @@ func BenchmarkMapDentryResolutionPath(b *testing.B) {
 	}
 	defer test.Close()
 
-	testFile, testFilePtr, err := test.Path("aa/bb/cc/dd/ee")
+	testFile, _, err := test.Path("aa/bb/cc/dd/ee")
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -517,9 +517,9 @@ func BenchmarkMapDentryResolutionPath(b *testing.B) {
 		pathID  uint32
 	)
 	err = test.GetSignal(b, func() error {
-		fd, _, errno := syscall.Syscall(syscall.SYS_OPEN, uintptr(testFilePtr), syscall.O_CREAT, 0755)
-		if errno != 0 {
-			b.Fatal(error(errno))
+		fd, err := syscall.Open(testFile, syscall.O_CREAT, 0755)
+		if err != nil {
+			b.Fatal(err)
 		}
 		return syscall.Close(int(fd))
 	}, func(event *sprobe.Event, _ *rules.Rule) {

--- a/pkg/security/tests/syscalls_amd64_test.go
+++ b/pkg/security/tests/syscalls_amd64_test.go
@@ -7,6 +7,7 @@ import "syscall"
 var supportedSyscalls = map[string]uintptr{
 	"SYS_CHMOD":  syscall.SYS_CHMOD,
 	"SYS_CHOWN":  syscall.SYS_CHOWN,
+	"SYS_LCHOWN": syscall.SYS_LCHOWN,
 	"SYS_LINK":   syscall.SYS_LINK,
 	"SYS_MKDIR":  syscall.SYS_MKDIR,
 	"SYS_OPEN":   syscall.SYS_OPEN,

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -62,7 +62,9 @@
         "ec2": {
             "arm64": {
                 "ubuntu-18-04": "ami-02ed82f3a38303e6f",
-                "ubuntu-20-04": "ami-0b75998a97c952252"
+                "ubuntu-20-04": "ami-0b75998a97c952252",
+                "ubuntu-20-04-hwe": "ami-0a82127206c2824a1",
+                "ubuntu-21-04": "ami-074fb75106523f6ff"
             }
         },
         "vagrant" : {

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -93,7 +93,7 @@ if node['platform_family'] != 'windows'
     end
   end
 
-  if not platform_family?('suse')
+  if not platform_family?('suse') and intel? and _64_bit?
     package 'Install i386 libc' do
       case node[:platform]
       when 'redhat', 'centos', 'fedora', 'oracle'


### PR DESCRIPTION
### What does this PR do?

This PR adds some jobs, executing on arm64, running the functional test suite in order to test more regularly the arm64 arch support. It runs the test suite on ubuntu 20.04.2 LTS (with and 5.8 HWE Kernel) and on ubuntu 21.04

This PR also includes the fixes needed to compile and run the test suite on arm64:
- Syscall support

### Motivation

The arm64 architecture is an important architecture to support and will only be more important in the future.

### Describe how to test your changes

Please run the test suite on arm64 to confirm that the security agent tests are passing.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
