### PR TITLE
Set hostname to "none" by default for containerized CI Agent

### DIFF
--- a/Dockerfiles/agent/datadog-ci.yaml
+++ b/Dockerfiles/agent/datadog-ci.yaml
@@ -1,6 +1,8 @@
 ## Provides defaults for CI environments,
 ## please see datadog.yaml.example for all supported options
 
+hostname: "none"
+
 apm_config:
   enabled: true
   apm_non_local_traffic: true


### PR DESCRIPTION
### What does this PR do?

Sets the hostname to "none" by default for the containerized CI Agent.

### Motivation

So that users don't have to set `DD_HOSTNAME=none` on top of
`DD_INSIDE_CI=true`. See the current docs of the Agent in CI envs: https://docs.datadoghq.com/continuous_integration/setup_tests/agent/?tab=azurepipelines#installing-the-datadog-agent-as-a-service-container-on-each-build

### Describe how to test your changes

After following the [CI instructions in the docs](https://docs.datadoghq.com/continuous_integration/setup_tests/agent/?tab=azurepipelines#installing-the-datadog-agent-as-a-service-container-on-each-build), without setting `DD_HOSTNAME`, the hostname should not show up in the test stats reported to the CI DD product.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
~- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.~
~- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.~