### PR TITLE
[datadog-agent] Fix missing network metrics on ECS Fargate

### DIFF
--- a/pkg/util/ecs/common.go
+++ b/pkg/util/ecs/common.go
@@ -93,6 +93,11 @@ func UpdateContainerMetrics(cList []*containers.Container) error {
 		if ctr.Limits.MemLimit == 0 {
 			ctr.Limits.MemLimit = memLimit
 		}
+
+		netStats := convertMetaV2NetStats(stats.Networks)
+		if netStats != nil {
+			ctr.Network = netStats
+		}
 	}
 	return nil
 }
@@ -179,6 +184,26 @@ func convertMetaV2ContainerStats(s *v2.ContainerStats) (metrics.ContainerMetrics
 			WriteBytes: s.IO.WriteBytes,
 		},
 	}, s.Memory.Limit
+}
+
+// convertMetaV2NetStats returns interface network stats metrics representations from an ECS
+// metadata v2 container network stats object.
+func convertMetaV2NetStats(s v2.NetStatsMap) []*metrics.InterfaceNetStats {
+	if len(s) == 0 {
+		return nil
+	}
+
+	ifStats := make([]*metrics.InterfaceNetStats, 0, len(s))
+	for name, stats := range s {
+		ifStats = append(ifStats, &metrics.InterfaceNetStats{
+			NetworkName: name,
+			BytesRcvd:   stats.RxBytes,
+			PacketsRcvd: stats.RxPackets,
+			BytesSent:   stats.TxBytes,
+			PacketsSent: stats.TxPackets,
+		})
+	}
+	return ifStats
 }
 
 // parseContainerNetworkAddresses converts ECS container ports

--- a/pkg/util/ecs/common_test.go
+++ b/pkg/util/ecs/common_test.go
@@ -259,7 +259,14 @@ func TestConvertMetaV2ContainerStats(t *testing.T) {
 			ReadBytes:  1024,
 			WriteBytes: 256,
 		},
-		Network: v2.NetStats{},
+		Networks: v2.NetStatsMap{
+			"eth0": v2.NetStats{
+				RxBytes:   163710528,
+				RxPackets: 113457,
+				TxBytes:   1103607,
+				TxPackets: 16969,
+			},
+		},
 	}
 
 	expectedCPU := &metrics.ContainerCPUStats{
@@ -278,11 +285,25 @@ func TestConvertMetaV2ContainerStats(t *testing.T) {
 		WriteBytes: 256,
 	}
 
+	expectedNetStats := []*metrics.InterfaceNetStats{
+		{
+			NetworkName: "eth0",
+			BytesRcvd:   163710528,
+			PacketsRcvd: 113457,
+			BytesSent:   1103607,
+			PacketsSent: 16969,
+		},
+	}
+
 	containerMetrics, memLimit := convertMetaV2ContainerStats(stats)
 
 	assert.Equal(t, expectedCPU, containerMetrics.CPU)
 	assert.Equal(t, expectedMem, containerMetrics.Memory)
 	assert.Equal(t, expectedIO, containerMetrics.IO)
+
+	netStats := convertMetaV2NetStats(stats.Networks)
+
+	assert.Equal(t, expectedNetStats, netStats)
 	assert.Equal(t, uint64(268435456), memLimit)
 }
 

--- a/pkg/util/ecs/metadata/v2/client_test.go
+++ b/pkg/util/ecs/metadata/v2/client_test.go
@@ -328,7 +328,14 @@ func TestGetContainerStats(t *testing.T) {
 			ReadBytes:  0,
 			WriteBytes: 0,
 		},
-		Network: NetStats{},
+		Networks: NetStatsMap{
+			"eth0": NetStats{
+				RxBytes:   163710528,
+				RxPackets: 113457,
+				TxBytes:   1103607,
+				TxPackets: 16969,
+			},
+		},
 	}
 
 	metadata, err := NewClient(ts.URL).GetContainerStats(ctx, containerID)

--- a/pkg/util/ecs/metadata/v2/client_test.go
+++ b/pkg/util/ecs/metadata/v2/client_test.go
@@ -9,6 +9,7 @@ package v2
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -229,129 +230,240 @@ func TestGetContainerStats(t *testing.T) {
 	ctx := context.Background()
 	assert := assert.New(t)
 
-	containerID := "470f831ceac0479b8c6614a7232e707fb24760c350b13ee589dd1d6424315d98"
+	tests := []struct {
+		name          string
+		fixture       string
+		containerID   string
+		expectedStats *ContainerStats
+		expectedErr   error
+	}{
+		{
+			name:        "net-stats",
+			fixture:     "./testdata/container_stats.json",
+			containerID: "470f831ceac0479b8c6614a7232e707fb24760c350b13ee589dd1d6424315d98",
+			expectedStats: &ContainerStats{
+				CPU: CPUStats{
+					System: 3951680000000,
+					Usage: CPUUsage{
+						Kernelmode: 2260000000,
+						Total:      9743590394,
+						Usermode:   7450000000,
+					},
+				},
+				Memory: MemStats{
+					Details: DetailedMem{
+						RSS:     1564672,
+						Cache:   65499136,
+						PgFault: 430478,
+					},
+					Limit:    268435456,
+					MaxUsage: 139751424,
+					Usage:    77254656,
+				},
+				IO: IOStats{
+					BytesPerDeviceAndKind: []OPStat{
+						{
+							Kind:  "Read",
+							Major: 259,
+							Minor: 0,
+							Value: 12288,
+						},
+						{
+							Kind:  "Write",
+							Major: 259,
+							Minor: 0,
+							Value: 144908288,
+						},
+						{
+							Kind:  "Sync",
+							Major: 259,
+							Minor: 0,
+							Value: 8122368,
+						},
+						{
+							Kind:  "Async",
+							Major: 259,
+							Minor: 0,
+							Value: 136798208,
+						},
+						{
+							Kind:  "Total",
+							Major: 259,
+							Minor: 0,
+							Value: 144920576,
+						},
+					},
+					OPPerDeviceAndKind: []OPStat{
+						{
+							Kind:  "Read",
+							Major: 259,
+							Minor: 0,
+							Value: 3,
+						},
+						{
+							Kind:  "Write",
+							Major: 259,
+							Minor: 0,
+							Value: 1618,
+						},
+						{
+							Kind:  "Sync",
+							Major: 259,
+							Minor: 0,
+							Value: 514,
+						},
+						{
+							Kind:  "Async",
+							Major: 259,
+							Minor: 0,
+							Value: 1107,
+						},
+						{
+							Kind:  "Total",
+							Major: 259,
+							Minor: 0,
+							Value: 1621,
+						},
+					},
+					ReadBytes:  0,
+					WriteBytes: 0,
+				},
+				Networks: NetStatsMap{
+					"eth0": NetStats{
+						RxBytes:   163710528,
+						RxPackets: 113457,
+						TxBytes:   1103607,
+						TxPackets: 16969,
+					},
+				},
+			},
+		},
+		{
+			name:        "no-net-stats",
+			fixture:     "./testdata/container_stats_empty_net_stats.json",
+			containerID: "470f831ceac0479b8c6614a7232e707fb24760c350b13ee589dd1d6424315d98",
+			expectedStats: &ContainerStats{
+				CPU: CPUStats{
+					System: 3951680000000,
+					Usage: CPUUsage{
+						Kernelmode: 2260000000,
+						Total:      9743590394,
+						Usermode:   7450000000,
+					},
+				},
+				Memory: MemStats{
+					Details: DetailedMem{
+						RSS:     1564672,
+						Cache:   65499136,
+						PgFault: 430478,
+					},
+					Limit:    268435456,
+					MaxUsage: 139751424,
+					Usage:    77254656,
+				},
+				IO: IOStats{
+					BytesPerDeviceAndKind: []OPStat{
+						{
+							Kind:  "Read",
+							Major: 259,
+							Minor: 0,
+							Value: 12288,
+						},
+						{
+							Kind:  "Write",
+							Major: 259,
+							Minor: 0,
+							Value: 144908288,
+						},
+						{
+							Kind:  "Sync",
+							Major: 259,
+							Minor: 0,
+							Value: 8122368,
+						},
+						{
+							Kind:  "Async",
+							Major: 259,
+							Minor: 0,
+							Value: 136798208,
+						},
+						{
+							Kind:  "Total",
+							Major: 259,
+							Minor: 0,
+							Value: 144920576,
+						},
+					},
+					OPPerDeviceAndKind: []OPStat{
+						{
+							Kind:  "Read",
+							Major: 259,
+							Minor: 0,
+							Value: 3,
+						},
+						{
+							Kind:  "Write",
+							Major: 259,
+							Minor: 0,
+							Value: 1618,
+						},
+						{
+							Kind:  "Sync",
+							Major: 259,
+							Minor: 0,
+							Value: 514,
+						},
+						{
+							Kind:  "Async",
+							Major: 259,
+							Minor: 0,
+							Value: 1107,
+						},
+						{
+							Kind:  "Total",
+							Major: 259,
+							Minor: 0,
+							Value: 1621,
+						},
+					},
+					ReadBytes:  0,
+					WriteBytes: 0,
+				},
+			},
+		},
+		{
+			name:        "missing-container",
+			fixture:     "./testdata/container_stats.json",
+			containerID: "470f831ceac0479b8c6614a7232e707fb24760c350b13ee589dd1d6424315d42",
+			expectedErr: errors.New("Failed to retrieve container stats for id: 470f831ceac0479b8c6614a7232e707fb24760c350b13ee589dd1d6424315d42"),
+		},
+	}
+
 	handlerPath := "/v2/stats"
 
-	ecsinterface, err := testutil.NewDummyECS(
-		testutil.FileHandlerOption(handlerPath, "./testdata/container_stats.json"),
-	)
-	require.Nil(t, err)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ecsinterface, err := testutil.NewDummyECS(
+				testutil.FileHandlerOption(handlerPath, test.fixture),
+			)
+			require.Nil(t, err)
 
-	ts, _, err := ecsinterface.Start()
-	defer ts.Close()
-	require.Nil(t, err)
+			ts, _, err := ecsinterface.Start()
+			defer ts.Close()
+			require.Nil(t, err)
 
-	expected := &ContainerStats{
-		CPU: CPUStats{
-			System: 3951680000000,
-			Usage: CPUUsage{
-				Kernelmode: 2260000000,
-				Total:      9743590394,
-				Usermode:   7450000000,
-			},
-		},
-		Memory: MemStats{
-			Details: DetailedMem{
-				RSS:     1564672,
-				Cache:   65499136,
-				PgFault: 430478,
-			},
-			Limit:    268435456,
-			MaxUsage: 139751424,
-			Usage:    77254656,
-		},
-		IO: IOStats{
-			BytesPerDeviceAndKind: []OPStat{
-				{
-					Kind:  "Read",
-					Major: 259,
-					Minor: 0,
-					Value: 12288,
-				},
-				{
-					Kind:  "Write",
-					Major: 259,
-					Minor: 0,
-					Value: 144908288,
-				},
-				{
-					Kind:  "Sync",
-					Major: 259,
-					Minor: 0,
-					Value: 8122368,
-				},
-				{
-					Kind:  "Async",
-					Major: 259,
-					Minor: 0,
-					Value: 136798208,
-				},
-				{
-					Kind:  "Total",
-					Major: 259,
-					Minor: 0,
-					Value: 144920576,
-				},
-			},
-			OPPerDeviceAndKind: []OPStat{
-				{
-					Kind:  "Read",
-					Major: 259,
-					Minor: 0,
-					Value: 3,
-				},
-				{
-					Kind:  "Write",
-					Major: 259,
-					Minor: 0,
-					Value: 1618,
-				},
-				{
-					Kind:  "Sync",
-					Major: 259,
-					Minor: 0,
-					Value: 514,
-				},
-				{
-					Kind:  "Async",
-					Major: 259,
-					Minor: 0,
-					Value: 1107,
-				},
-				{
-					Kind:  "Total",
-					Major: 259,
-					Minor: 0,
-					Value: 1621,
-				},
-			},
-			ReadBytes:  0,
-			WriteBytes: 0,
-		},
-		Networks: NetStatsMap{
-			"eth0": NetStats{
-				RxBytes:   163710528,
-				RxPackets: 113457,
-				TxBytes:   1103607,
-				TxPackets: 16969,
-			},
-		},
+			metadata, err := NewClient(ts.URL).GetContainerStats(ctx, test.containerID)
+			assert.Equal(test.expectedStats, metadata)
+			assert.Equal(test.expectedErr, err)
+
+			select {
+			case r := <-ecsinterface.Requests:
+				assert.Equal("GET", r.Method)
+				assert.Equal(handlerPath, r.URL.Path)
+			case <-time.After(2 * time.Second):
+				assert.FailNow("Timeout on receive channel")
+			}
+		})
 	}
 
-	metadata, err := NewClient(ts.URL).GetContainerStats(ctx, containerID)
-	assert.Nil(err)
-	assert.Equal(expected, metadata)
-
-	// Container without stats
-	metadata, err = NewClient(ts.URL).GetContainerStats(ctx, "470f831ceac0479b8c6614a7232e707fb24760c350b13ee589dd1d6424315d42")
-	assert.NotNil(err)
-	assert.Nil(metadata)
-
-	select {
-	case r := <-ecsinterface.Requests:
-		assert.Equal("GET", r.Method)
-		assert.Equal(handlerPath, r.URL.Path)
-	case <-time.After(2 * time.Second):
-		assert.FailNow("Timeout on receive channel")
-	}
 }

--- a/pkg/util/ecs/metadata/v2/testdata/container_stats.json
+++ b/pkg/util/ecs/metadata/v2/testdata/container_stats.json
@@ -130,6 +130,18 @@
     },
     "name": "/ecs-xavierlucas-test_redis-awsvpc-12-redis-86fe99b5ffeabffeed01",
     "num_procs": 0,
+    "networks": {
+      "eth0": {
+        "rx_bytes": 163710528,
+        "rx_packets": 113457,
+        "rx_errors": 0,
+        "rx_dropped": 0,
+        "tx_bytes": 1103607,
+        "tx_packets": 16969,
+        "tx_errors": 0,
+        "tx_dropped": 0
+      }
+    },
     "pids_stats": {
       "current": 6
     },

--- a/pkg/util/ecs/metadata/v2/testdata/container_stats_empty_net_stats.json
+++ b/pkg/util/ecs/metadata/v2/testdata/container_stats_empty_net_stats.json
@@ -1,0 +1,155 @@
+{
+  "470f831ceac0479b8c6614a7232e707fb24760c350b13ee589dd1d6424315d42": null,
+  "470f831ceac0479b8c6614a7232e707fb24760c350b13ee589dd1d6424315d98": {
+    "blkio_stats": {
+      "io_merged_recursive": [],
+      "io_queue_recursive": [],
+      "io_service_bytes_recursive": [
+        {
+          "major": 259,
+          "minor": 0,
+          "op": "Read",
+          "value": 12288
+        },
+        {
+          "major": 259,
+          "minor": 0,
+          "op": "Write",
+          "value": 144908288
+        },
+        {
+          "major": 259,
+          "minor": 0,
+          "op": "Sync",
+          "value": 8122368
+        },
+        {
+          "major": 259,
+          "minor": 0,
+          "op": "Async",
+          "value": 136798208
+        },
+        {
+          "major": 259,
+          "minor": 0,
+          "op": "Total",
+          "value": 144920576
+        }
+      ],
+      "io_service_time_recursive": [],
+      "io_serviced_recursive": [
+        {
+          "major": 259,
+          "minor": 0,
+          "op": "Read",
+          "value": 3
+        },
+        {
+          "major": 259,
+          "minor": 0,
+          "op": "Write",
+          "value": 1618
+        },
+        {
+          "major": 259,
+          "minor": 0,
+          "op": "Sync",
+          "value": 514
+        },
+        {
+          "major": 259,
+          "minor": 0,
+          "op": "Async",
+          "value": 1107
+        },
+        {
+          "major": 259,
+          "minor": 0,
+          "op": "Total",
+          "value": 1621
+        }
+      ],
+      "io_time_recursive": [],
+      "io_wait_time_recursive": [],
+      "sectors_recursive": []
+    },
+    "cpu_stats": {
+      "cpu_usage": {
+        "percpu_usage": [5906703717, 3836886677],
+        "total_usage": 9743590394,
+        "usage_in_kernelmode": 2260000000,
+        "usage_in_usermode": 7450000000
+      },
+      "online_cpus": 2,
+      "system_cpu_usage": 3951680000000,
+      "throttling_data": {
+        "periods": 0,
+        "throttled_periods": 0,
+        "throttled_time": 0
+      }
+    },
+    "id": "470f831ceac0479b8c6614a7232e707fb24760c350b13ee589dd1d6424315d98",
+    "memory_stats": {
+      "limit": 268435456,
+      "max_usage": 139751424,
+      "stats": {
+        "active_anon": 1564672,
+        "active_file": 28020736,
+        "cache": 65499136,
+        "dirty": 0,
+        "hierarchical_memory_limit": 268435456,
+        "hierarchical_memsw_limit": 536870912,
+        "inactive_anon": 0,
+        "inactive_file": 37478400,
+        "mapped_file": 0,
+        "pgfault": 430478,
+        "pgmajfault": 0,
+        "pgpgin": 229452,
+        "pgpgout": 213079,
+        "rss": 1564672,
+        "rss_huge": 0,
+        "total_active_anon": 1564672,
+        "total_active_file": 28020736,
+        "total_cache": 65499136,
+        "total_dirty": 0,
+        "total_inactive_anon": 0,
+        "total_inactive_file": 37478400,
+        "total_mapped_file": 0,
+        "total_pgfault": 430478,
+        "total_pgmajfault": 0,
+        "total_pgpgin": 229452,
+        "total_pgpgout": 213079,
+        "total_rss": 1564672,
+        "total_rss_huge": 0,
+        "total_unevictable": 0,
+        "total_writeback": 0,
+        "unevictable": 0,
+        "writeback": 0
+      },
+      "usage": 77254656
+    },
+    "name": "/ecs-xavierlucas-test_redis-awsvpc-12-redis-86fe99b5ffeabffeed01",
+    "num_procs": 0,
+    "pids_stats": {
+      "current": 6
+    },
+    "precpu_stats": {
+      "cpu_usage": {
+        "percpu_usage": [5906299037, 3836449635],
+        "total_usage": 9742748672,
+        "usage_in_kernelmode": 2260000000,
+        "usage_in_usermode": 7450000000
+      },
+      "online_cpus": 2,
+      "system_cpu_usage": 3949670000000,
+      "throttling_data": {
+        "periods": 0,
+        "throttled_periods": 0,
+        "throttled_time": 0
+      }
+    },
+    "preread": "2019-10-25T10:07:00.001729463Z",
+    "read": "2019-10-25T10:07:01.006590487Z",
+    "storage_stats": {}
+  }
+}

--- a/pkg/util/ecs/metadata/v2/types.go
+++ b/pkg/util/ecs/metadata/v2/types.go
@@ -54,12 +54,15 @@ type Port struct {
 // ContainerStats represents the statistics of a container as returned by the
 // ECS metadata API v2.
 type ContainerStats struct {
-	CPU     CPUStats `json:"cpu_stats"`
-	Memory  MemStats `json:"memory_stats"`
-	IO      IOStats  `json:"blkio_stats"`
-	Network NetStats `json:"network"`
+	CPU      CPUStats    `json:"cpu_stats"`
+	Memory   MemStats    `json:"memory_stats"`
+	IO       IOStats     `json:"blkio_stats"`
+	Networks NetStatsMap `json:"networks"`
 	//Pids    []int32  `json:"pids_stats"` // seems to be always empty
 }
+
+// NetStatsMap represents a map of networks stats
+type NetStatsMap map[string]NetStats
 
 // CPUStats represents an ECS container CPU usage
 type CPUStats struct {

--- a/releasenotes/notes/ecs-fargate-collect-net-stat-metrics-22ec649320df16b4.yaml
+++ b/releasenotes/notes/ecs-fargate-collect-net-stat-metrics-22ec649320df16b4.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    Collect net stats metrics (RX/TX) for ECS Fargate containers.

--- a/releasenotes/notes/ecs-fargate-collect-net-stat-metrics-22ec649320df16b4.yaml
+++ b/releasenotes/notes/ecs-fargate-collect-net-stat-metrics-22ec649320df16b4.yaml
@@ -1,3 +1,3 @@
 enhancements:
   - |
-    Collect net stats metrics (RX/TX) for ECS Fargate containers.
+    Collect net stats metrics (RX/TX) for ECS Fargate in Live Containers.


### PR DESCRIPTION
### What does this PR do?

Adds translation of net stat metrics for ECS Fargate containers.

![image](https://user-images.githubusercontent.com/30147836/130123627-903c5919-6613-4d27-9c36-31666e4d31cb.png)

### Motivation

Missing net stat metrics on ECS Fargate.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Set up a Fargate task having some network activity, observe the RX/TX.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
