### PR TITLE
[runtime-security] enforce erpc read

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "e1847a9dd7bd04fbf575ec140ab5fa6d8e5db9706ebe280f8c516c0d6a4ed49e")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "0c995d90126b2dd2a80df73255ac99964acbaff0d2c9c14096589e032f8e7780")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "914da4e15bce516f74935f8ef8e75deb3aaf7258fcd7933fe2804f1ec99e5356")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "452b177a5ecf8b491a2e5e9d1417a38bb75b137bc04f71da1241001a9f58551d")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "0c995d90126b2dd2a80df73255ac99964acbaff0d2c9c14096589e032f8e7780")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "914da4e15bce516f74935f8ef8e75deb3aaf7258fcd7933fe2804f1ec99e5356")

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -302,13 +302,9 @@ static __attribute__((always_inline)) u32 get_path_id(int invalidate) {
 
     u32 *prev_id = bpf_map_lookup_elem(&path_id, &key);
     if (!prev_id) {
-        u32 first_id = 1;
-        bpf_map_update_elem(&path_id, &key, &first_id, BPF_ANY);
-
-        return first_id;
+        return 0;
     }
 
-    // return the current id so that the current event will use it. Increase the id for the next event only.
     u32 id = *prev_id;
 
     // need to invalidate the current path id for event which may change the association inode/name like

--- a/pkg/security/ebpf/c/dentry_resolver.h
+++ b/pkg/security/ebpf/c/dentry_resolver.h
@@ -331,9 +331,19 @@ int __attribute__((always_inline)) handle_resolve_path(struct pt_regs* ctx, void
     if (state == NULL)
         return 0;
 
-    bpf_probe_read(&state->key, sizeof(state->key), data);
-    bpf_probe_read(&state->userspace_buffer, sizeof(state->userspace_buffer), data + sizeof(state->key));
-    bpf_probe_read(&state->buffer_size, sizeof(state->buffer_size), data + sizeof(state->key) + sizeof(state->userspace_buffer));
+    int ret = bpf_probe_read(&state->key, sizeof(state->key), data);
+    if (ret < 0) {
+        return 0;
+    }
+    ret = bpf_probe_read(&state->userspace_buffer, sizeof(state->userspace_buffer), data + sizeof(state->key));
+    if (ret < 0) {
+        return 0;
+    }
+    ret = bpf_probe_read(&state->buffer_size, sizeof(state->buffer_size), data + sizeof(state->key) + sizeof(state->userspace_buffer));
+    if (ret < 0) {
+        return 0;
+    }
+
     state->iteration = 0;
     state->ret = 0;
     state->cursor = 0;

--- a/pkg/security/ebpf/c/erpc.h
+++ b/pkg/security/ebpf/c/erpc.h
@@ -85,7 +85,7 @@ int __attribute__((always_inline)) is_eprc_request(struct pt_regs *ctx) {
 int __attribute__((always_inline)) handle_erpc_request(struct pt_regs *ctx) {
     void *req = (void *)PT_REGS_PARM4(ctx);
 
-    u8 op;
+    u8 op = 0;
     int ret = bpf_probe_read(&op, sizeof(op), req);
     if (ret < 0) {
         return 0;

--- a/pkg/security/ebpf/c/erpc.h
+++ b/pkg/security/ebpf/c/erpc.h
@@ -86,7 +86,10 @@ int __attribute__((always_inline)) handle_erpc_request(struct pt_regs *ctx) {
     void *req = (void *)PT_REGS_PARM4(ctx);
 
     u8 op;
-    bpf_probe_read(&op, sizeof(op), req);
+    int ret = bpf_probe_read(&op, sizeof(op), req);
+    if (ret < 0) {
+        return 0;
+    }
 
     void *data = req + sizeof(op);
 

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -86,7 +86,7 @@ func (r *Resolvers) resolveFileFieldsPath(e *model.FileFields) (string, error) {
 
 	_, mountPath, rootPath, mountErr := r.MountResolver.GetMountPath(e.MountID)
 	if mountErr != nil {
-		return pathStr, mountErr
+		return "", mountErr
 	}
 
 	if strings.HasPrefix(pathStr, rootPath) && rootPath != "/" {


### PR DESCRIPTION
### What does this PR do?

This PR fix an path resolution issue introduced with the use of eRPC. The check of the eRPC in-kernel execution was incorrect causing the re-use of the previous resolution. These fixes enforce the return value of the eRPC call.

The eRPC was introduced by https://github.com/DataDog/datadog-agent/commit/6a2420b569a1355f25c394c3e7897368550844aa

### Motivation

Event with wrong path were sent.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
