### PR TITLE
[snmp] Suggest single quote for community string

### DIFF
--- a/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
+++ b/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
@@ -31,6 +31,7 @@ instances:
 
     ## @param community_string - string - optional
     ## Only useful for SNMP v1 & v2.
+    ## Enclose the community string with single quote like below (to avoid special characters being interpreted).
     #
     community_string: '%%extra_community%%'
 

--- a/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
+++ b/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
@@ -6,80 +6,80 @@ instances:
     ## @param ip_address - string - optional
     ## The IP address of the device to monitor.
     #
-    ip_address: "%%host%%"
+    ip_address: '%%host%%'
 
     ## @param port - integer - optional - default: 161
     ## Default SNMP port.
     #
-    port: "%%port%%"
+    port: '%%port%%'
 
     ## @param snmp_version - integer - optional - default: 2
     ## If you are using SNMP v1 set snmp_version to 1 (required)
     ## If you are using SNMP v3 set snmp_version to 3 (required)
     #
-    snmp_version: "%%extra_version%%"
+    snmp_version: '%%extra_version%%'
 
     ## @param timeout - integer - optional - default: 5
     ## Amount of second before timing out.
     #
-    timeout: "%%extra_timeout%%"
+    timeout: '%%extra_timeout%%'
 
     ## @param retries - integer - optional - default: 5
     ## Amount of retries before failure.
     #
-    retries: "%%extra_retries%%"
+    retries: '%%extra_retries%%'
 
     ## @param community_string - string - optional
     ## Only useful for SNMP v1 & v2.
     #
-    community_string: "%%extra_community%%"
+    community_string: '%%extra_community%%'
 
     ## @param user - string - optional
     ## USERNAME to connect to your SNMP devices.
     #
-    user: "%%extra_user%%"
+    user: '%%extra_user%%'
 
     ## @param authKey - string - optional
     ## Authentication key to use with your Authentication type.
     #
-    authKey: "%%extra_auth_key%%"
+    authKey: '%%extra_auth_key%%'
 
     ## @param authProtocol - string - optional
     ## Authentication type to use when connecting to your SNMP devices.
     ## It can be one of: MD5, SHA, SHA224, SHA256, SHA384, SHA512.
     ## Default to MD5 when `authKey` is specified.
     #
-    authProtocol: "%%extra_auth_protocol%%"
+    authProtocol: '%%extra_auth_protocol%%'
 
     ## @param privKey - string - optional
     ## Privacy type key to use with your Privacy type.
     #
-    privKey: "%%extra_priv_key%%"
+    privKey: '%%extra_priv_key%%'
 
     ## @param privProtocol - string - optional
     ## Privacy type to use when connecting to your SNMP devices.
     ## It can be one of: DES, 3DES, AES, AES192, AES256, AES192C, AES256C.
     ## Default to DES when `privKey` is specified.
     #
-    privProtocol: "%%extra_priv_protocol%%"
+    privProtocol: '%%extra_priv_protocol%%'
 
     ## @param context_engine_id - string - optional
     ## ID of your context engine; typically unneeded.
     ## (optional SNMP v3-only parameter)
     #
-    context_engine_id: "%%extra_context_engine_id%%"
+    context_engine_id: '%%extra_context_engine_id%%'
 
     ## @param context_name - string - optional
     ## Name of your context (optional SNMP v3-only parameter).
     #
-    context_name: "%%extra_context_name%%"
+    context_name: '%%extra_context_name%%'
 
     ## @param loader - string - optional
     ## Check loader to use. Available loaders for snmp:
     ## - core: will use corecheck SNMP integration
     ## - python: will use python SNMP integration
     #
-    loader: "%%extra_loader%%"
+    loader: '%%extra_loader%%'
 
     ## @param tags - list of key:value element - optional
     ## List of tags to attach to every metric, event and service check emitted by this integration.
@@ -89,22 +89,22 @@ instances:
     tags:
       # The autodiscovery subnet the device is part of.
       # Used by Agent autodiscovery to pass subnet name.
-      - "autodiscovery_subnet:%%extra_autodiscovery_subnet%%"
+      - 'autodiscovery_subnet:%%extra_autodiscovery_subnet%%'
 
     ## @param extra_tags - string - optional
     ## Comma separated tags to attach to every metric, event and service check emitted by this integration.
     ## Example:
     ##  extra_tags: "tag1:val1,tag2:val2"
     #
-    extra_tags: "%%extra_tags%%"
+    extra_tags: '%%extra_tags%%'
 
     ## @param oid_batch_size - integer - optional - default: 60
     ## The number of OIDs handled by each batch. Increasing this number improves performance but
     ## uses more resources.
     #
-    oid_batch_size: "%%extra_oid_batch_size%%"
+    oid_batch_size: '%%extra_oid_batch_size%%'
 
     ## @param collect_device_metadata - bool - optional - default: false
     ## Enable device metadata collection
     #
-    collect_device_metadata: "%%extra_collect_device_metadata%%"
+    collect_device_metadata: '%%extra_collect_device_metadata%%'

--- a/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
+++ b/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
@@ -6,81 +6,80 @@ instances:
     ## @param ip_address - string - optional
     ## The IP address of the device to monitor.
     #
-    ip_address: '%%host%%'
+    ip_address: "%%host%%"
 
     ## @param port - integer - optional - default: 161
     ## Default SNMP port.
     #
-    port: '%%port%%'
+    port: "%%port%%"
 
     ## @param snmp_version - integer - optional - default: 2
     ## If you are using SNMP v1 set snmp_version to 1 (required)
     ## If you are using SNMP v3 set snmp_version to 3 (required)
     #
-    snmp_version: '%%extra_version%%'
+    snmp_version: "%%extra_version%%"
 
     ## @param timeout - integer - optional - default: 5
     ## Amount of second before timing out.
     #
-    timeout: '%%extra_timeout%%'
+    timeout: "%%extra_timeout%%"
 
     ## @param retries - integer - optional - default: 5
     ## Amount of retries before failure.
     #
-    retries: '%%extra_retries%%'
+    retries: "%%extra_retries%%"
 
     ## @param community_string - string - optional
     ## Only useful for SNMP v1 & v2.
-    ## Enclose the community string with single quote like below (to avoid special characters being interpreted).
     #
-    community_string: '%%extra_community%%'
+    community_string: "%%extra_community%%"
 
     ## @param user - string - optional
     ## USERNAME to connect to your SNMP devices.
     #
-    user: '%%extra_user%%'
+    user: "%%extra_user%%"
 
     ## @param authKey - string - optional
     ## Authentication key to use with your Authentication type.
     #
-    authKey: '%%extra_auth_key%%'
+    authKey: "%%extra_auth_key%%"
 
     ## @param authProtocol - string - optional
     ## Authentication type to use when connecting to your SNMP devices.
     ## It can be one of: MD5, SHA, SHA224, SHA256, SHA384, SHA512.
     ## Default to MD5 when `authKey` is specified.
     #
-    authProtocol: '%%extra_auth_protocol%%'
+    authProtocol: "%%extra_auth_protocol%%"
 
     ## @param privKey - string - optional
     ## Privacy type key to use with your Privacy type.
     #
-    privKey: '%%extra_priv_key%%'
+    privKey: "%%extra_priv_key%%"
 
     ## @param privProtocol - string - optional
     ## Privacy type to use when connecting to your SNMP devices.
     ## It can be one of: DES, 3DES, AES, AES192, AES256, AES192C, AES256C.
     ## Default to DES when `privKey` is specified.
     #
-    privProtocol: '%%extra_priv_protocol%%'
+    privProtocol: "%%extra_priv_protocol%%"
 
     ## @param context_engine_id - string - optional
     ## ID of your context engine; typically unneeded.
     ## (optional SNMP v3-only parameter)
     #
-    context_engine_id: '%%extra_context_engine_id%%'
+    context_engine_id: "%%extra_context_engine_id%%"
 
     ## @param context_name - string - optional
     ## Name of your context (optional SNMP v3-only parameter).
     #
-    context_name: '%%extra_context_name%%'
+    context_name: "%%extra_context_name%%"
 
     ## @param loader - string - optional
     ## Check loader to use. Available loaders for snmp:
     ## - core: will use corecheck SNMP integration
     ## - python: will use python SNMP integration
     #
-    loader: '%%extra_loader%%'
+    loader: "%%extra_loader%%"
 
     ## @param tags - list of key:value element - optional
     ## List of tags to attach to every metric, event and service check emitted by this integration.
@@ -90,22 +89,22 @@ instances:
     tags:
       # The autodiscovery subnet the device is part of.
       # Used by Agent autodiscovery to pass subnet name.
-      - 'autodiscovery_subnet:%%extra_autodiscovery_subnet%%'
+      - "autodiscovery_subnet:%%extra_autodiscovery_subnet%%"
 
     ## @param extra_tags - string - optional
     ## Comma separated tags to attach to every metric, event and service check emitted by this integration.
     ## Example:
     ##  extra_tags: "tag1:val1,tag2:val2"
     #
-    extra_tags: '%%extra_tags%%'
+    extra_tags: "%%extra_tags%%"
 
     ## @param oid_batch_size - integer - optional - default: 60
     ## The number of OIDs handled by each batch. Increasing this number improves performance but
     ## uses more resources.
     #
-    oid_batch_size: '%%extra_oid_batch_size%%'
+    oid_batch_size: "%%extra_oid_batch_size%%"
 
     ## @param collect_device_metadata - bool - optional - default: false
     ## Enable device metadata collection
     #
-    collect_device_metadata: '%%extra_collect_device_metadata%%'
+    collect_device_metadata: "%%extra_collect_device_metadata%%"

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -586,9 +586,10 @@ api_key:
 
     ## @param community_string - string - optional
     ## Required for SNMP v1 & v2.
+    ## Enclose the community string with single quote like below (to avoid special characters being interpreted).
     ## Ex: 'public'
     #
-    # community_string: <COMMUNITY>
+    # community_string: '<COMMUNITY>'
 
     ## @param user - string - optional
     ## The username to connect to your SNMP devices.
@@ -742,7 +743,7 @@ api_key:
   ## The maximum time the Datadog Agent waits to fill each batch of logs before sending.
   #
   # batch_wait: 5
-  
+
 {{ end -}}
 {{- if .TraceAgent }}
 
@@ -2178,11 +2179,12 @@ api_key:
   ## @param community_strings - list of strings - required
   ## A list of known SNMPv2 community strings that devices can use to send traps to the Agent.
   ## Traps with an unknown community string are ignored.
+  ## Enclose the community string with single quote like below (to avoid special characters being interpreted).
   ## Must be non-empty.
   #
   # community_strings:
-  #   - <COMMUNITY_1>
-  #   - <COMMUNITY_2>
+  #   - '<COMMUNITY_1>'
+  #   - '<COMMUNITY_2>'
 
   ## @param bind_host - string - optional
   ## The hostname to listen on for incoming trap packets.


### PR DESCRIPTION
Related PR: https://github.com/DataDog/integrations-core/pull/9742

### What does this PR do?

- Use single quote in auto_conf.yaml
- Recommend using single quote for community_string

### Motivation

If community string contain special character the actual community string being use to reach the device might be wrong.

### Additional Notes


### Describe how to test your changes

- Check that `auto_conf.yaml` works as before (use snmp_listener config as described here https://docs.datadoghq.com/network_monitoring/devices/setup?tab=snmpv2)

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
