### PR TITLE
Use custom python 2 on Windows

### DIFF
--- a/omnibus/config/software/python2.rb
+++ b/omnibus/config/software/python2.rb
@@ -82,16 +82,16 @@ if ohai["platform"] != "windows"
   end
 
 else
-  default_version "2.7.18"
+  default_version "2.7.18-8829519"
   dependency "vc_redist"
 
   if windows_arch_i386?
     source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-x86.zip",
-           :sha256 => "c8309b3351610a7159e91e55f09f7341bc3bbdd67d2a5e3049a9d1157e5a9110",
+           :sha256 => "295F16FB166AC26624AE9CBA08666DB437E0B8DDBB8D8D987F0598B71E4B6B24".downcase,
            :extract => :seven_zip
   else
-    source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-amd64.zip",
-         :sha256 => "7989b2efe6106a3df82c47d403dbb166db6d4040f3654871323df7e724a9fdd2",
+    source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-x64.zip",
+         :sha256 => "58424EEB272E5678E732402CAF150124CD583B81F5DA442C911CE71A63ECD339".downcase,
          :extract => :seven_zip
   end
   build do


### PR DESCRIPTION
### What does this PR do?

This PR makes omnibus use our custom Python 2 interpreter for Windows.

### Additional notes

Original PR: https://github.com/DataDog/datadog-agent/pull/8566
Reverted in 7.30: https://github.com/DataDog/datadog-agent/pull/8593

### Describe how to test your changes

- Install Agent 6
- Uninstall an integration and reinstall it
- Run the Agent with a Python integration configured

### Checklist
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
