### PR TITLE
Add more prometheus scrape params and make default true bool params configurable

### DIFF
--- a/pkg/autodiscovery/common/types/prometheus.go
+++ b/pkg/autodiscovery/common/types/prometheus.go
@@ -50,14 +50,14 @@ type OpenmetricsInstance struct {
 	Namespace                     string                      `mapstructure:"namespace" yaml:"namespace,omitempty" json:"namespace"`
 	Metrics                       []string                    `mapstructure:"metrics" yaml:"metrics,omitempty" json:"metrics,omitempty"`
 	Prefix                        string                      `mapstructure:"prometheus_metrics_prefix" yaml:"prometheus_metrics_prefix,omitempty" json:"prometheus_metrics_prefix,omitempty"`
-	HealthCheck                   bool                        `mapstructure:"health_service_check" yaml:"health_service_check,omitempty" json:"health_service_check,omitempty"`
+	HealthCheck                   *bool                       `mapstructure:"health_service_check" yaml:"health_service_check,omitempty" json:"health_service_check,omitempty"`
 	LabelToHostname               bool                        `mapstructure:"label_to_hostname" yaml:"label_to_hostname,omitempty" json:"label_to_hostname,omitempty"`
 	LabelJoins                    map[string]LabelJoinsConfig `mapstructure:"label_joins" yaml:"label_joins,omitempty" json:"label_joins,omitempty"`
 	LabelsMapper                  map[string]string           `mapstructure:"labels_mapper" yaml:"labels_mapper,omitempty" json:"labels_mapper,omitempty"`
 	TypeOverride                  map[string]string           `mapstructure:"type_overrides" yaml:"type_overrides,omitempty" json:"type_overrides,omitempty"`
-	HistogramBuckets              bool                        `mapstructure:"send_histograms_buckets" yaml:"send_histograms_buckets,omitempty" json:"send_histograms_buckets,omitempty"`
+	HistogramBuckets              *bool                       `mapstructure:"send_histograms_buckets" yaml:"send_histograms_buckets,omitempty" json:"send_histograms_buckets,omitempty"`
 	DistributionBuckets           bool                        `mapstructure:"send_distribution_buckets" yaml:"send_distribution_buckets,omitempty" json:"send_distribution_buckets,omitempty"`
-	MonotonicCounter              bool                        `mapstructure:"send_monotonic_counter" yaml:"send_monotonic_counter,omitempty" json:"send_monotonic_counter,omitempty"`
+	MonotonicCounter              *bool                       `mapstructure:"send_monotonic_counter" yaml:"send_monotonic_counter,omitempty" json:"send_monotonic_counter,omitempty"`
 	MonotonicWithGauge            bool                        `mapstructure:"send_monotonic_with_gauge" yaml:"send_monotonic_with_gauge,omitempty" json:"send_monotonic_with_gauge,omitempty"`
 	DistributionCountsAsMonotonic bool                        `mapstructure:"send_distribution_counts_as_monotonic" yaml:"send_distribution_counts_as_monotonic,omitempty" json:"send_distribution_counts_as_monotonic,omitempty"`
 	DistributionSumsAsMonotonic   bool                        `mapstructure:"send_distribution_sums_as_monotonic" yaml:"send_distribution_sums_as_monotonic,omitempty" json:"send_distribution_sums_as_monotonic,omitempty"`

--- a/pkg/autodiscovery/common/types/prometheus.go
+++ b/pkg/autodiscovery/common/types/prometheus.go
@@ -58,12 +58,15 @@ type OpenmetricsInstance struct {
 	HistogramBuckets              bool                        `mapstructure:"send_histograms_buckets" yaml:"send_histograms_buckets,omitempty" json:"send_histograms_buckets,omitempty"`
 	DistributionBuckets           bool                        `mapstructure:"send_distribution_buckets" yaml:"send_distribution_buckets,omitempty" json:"send_distribution_buckets,omitempty"`
 	MonotonicCounter              bool                        `mapstructure:"send_monotonic_counter" yaml:"send_monotonic_counter,omitempty" json:"send_monotonic_counter,omitempty"`
+	MonotonicWithGauge            bool                        `mapstructure:"send_monotonic_with_gauge" yaml:"send_monotonic_with_gauge,omitempty" json:"send_monotonic_with_gauge,omitempty"`
 	DistributionCountsAsMonotonic bool                        `mapstructure:"send_distribution_counts_as_monotonic" yaml:"send_distribution_counts_as_monotonic,omitempty" json:"send_distribution_counts_as_monotonic,omitempty"`
 	DistributionSumsAsMonotonic   bool                        `mapstructure:"send_distribution_sums_as_monotonic" yaml:"send_distribution_sums_as_monotonic,omitempty" json:"send_distribution_sums_as_monotonic,omitempty"`
 	ExcludeLabels                 []string                    `mapstructure:"exclude_labels" yaml:"exclude_labels,omitempty" json:"exclude_labels,omitempty"`
 	BearerTokenAuth               bool                        `mapstructure:"bearer_token_auth" yaml:"bearer_token_auth,omitempty" json:"bearer_token_auth,omitempty"`
 	BearerTokenPath               string                      `mapstructure:"bearer_token_path" yaml:"bearer_token_path,omitempty" json:"bearer_token_path,omitempty"`
 	IgnoreMetrics                 []string                    `mapstructure:"ignore_metrics" yaml:"ignore_metrics,omitempty" json:"ignore_metrics,omitempty"`
+	IgnoreMetricsByLabels         map[string]interface{}      `mapstructure:"ignore_metrics_by_labels" yaml:"ignore_metrics_by_labels,omitempty" json:"ignore_metrics_by_labels,omitempty"`
+	IgnoreTags                    []string                    `mapstructure:"ignore_tags" yaml:"ignore_tags,omitempty" json:"ignore_tags,omitempty"`
 	Proxy                         map[string]string           `mapstructure:"proxy" yaml:"proxy,omitempty" json:"proxy,omitempty"`
 	SkipProxy                     bool                        `mapstructure:"skip_proxy" yaml:"skip_proxy,omitempty" json:"skip_proxy,omitempty"`
 	Username                      string                      `mapstructure:"username" yaml:"username,omitempty" json:"username,omitempty"`

--- a/releasenotes/notes/add-prometheus-scrape-params-11753f10b91b21f7.yaml
+++ b/releasenotes/notes/add-prometheus-scrape-params-11753f10b91b21f7.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Add `send_monotonic_with_gauge`, `ignore_metrics_by_labels`,
+    and `ignore_tags` params to prometheus scrape

--- a/releasenotes/notes/add-prometheus-scrape-params-11753f10b91b21f7.yaml
+++ b/releasenotes/notes/add-prometheus-scrape-params-11753f10b91b21f7.yaml
@@ -1,5 +1,6 @@
 ---
 fixes:
   - |
-    Add `send_monotonic_with_gauge`, `ignore_metrics_by_labels`,
-    and `ignore_tags` params to prometheus scrape
+    Add `send_monotonic_with_gauge`, `ignore_metrics_by_labels`, 
+    and `ignore_tags` params to prometheus scrape. Allow values 
+    defaulting to `true` to be set to `false`, if configured.


### PR DESCRIPTION
### What does this PR do?

Adds the following params to prometheus scrape:
* `send_monotonic_with_gauge`
* `ignore_metrics_by_labels`
* `ignore_tags`

Allows boolean parameters that default to `true` to be set to `false`. `json.Marshal` with `omitempty` tags considers `false` to be an empty value so some configurations like `health_service_check: false` weren't being set.

### Motivation

Support ticket

### Additional Notes

### Describe how to test your changes

* Set up an application pod with prometheus annotations and an agent pod with prometheus scrape enabled [following the docs](https://docs.datadoghq.com/agent/kubernetes/prometheus/#configuration-1)
* Using `agent configcheck`, check that `send_monotonic_with_gauge`, `ignore_metrics_by_labels`, and `ignore_tags` can be set, and that a param defaulting to `true` (e.g. `send_monotonic_counter`) can be set to `false`.
* Example helm configuration for prometheus scrape:
```yaml
  prometheusScrape:
    enabled: true
    additionalConfigs:
      - configurations:
          - send_monotonic_counter: false
            send_monotonic_with_gauge: true
            ignore_tags:
              - pod:.*
            ignore_metrics_by_labels:
              foo:
                - "2"
              bar: "*"
```
* `agent configcheck`:
```
=== openmetrics check ===
Configuration provider: prometheus-pods
Configuration source: prometheus_pods:docker://<cid>
Instance ID: openmetrics:default:<id>
ignore_metrics_by_labels:
  bar: '*'
  foo:
  - "2"
ignore_tags:
- pod:.*
metrics:
- '*'
send_monotonic_counter: false
send_monotonic_with_gauge: true
...
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
