### PR TITLE
[draft] Track agent binary sizes as well as package sizes

### DIFF
--- a/.gitlab/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics.yml
@@ -92,6 +92,25 @@ send_pkg_size-a7:
 
             post_body=$(echo $post_body | jq -c ".series += [{\"metric\":\"$metric\", \"points\":[[$currenttime, $value]],\"tags\":$tags}]")
         }
+    - |
+        add_metrics() {
+            local base="${1}"
+            local os="${2}"
+
+            # record a the total uncompressed size of each package
+            add_metric datadog.agent.package.size $(du -sB1 ${base}/agent | sed 's/\([0-9]\+\).\+/\1/') os:${os} package:agent agent:7
+            add_metric datadog.agent.package.size $(du -sB1 ${base}/dogstatsd | sed 's/\([0-9]\+\).\+/\1/') os:${os} package:dogstatsd agent:7
+            add_metric datadog.agent.package.size $(du -sB1 ${base}/iot-agent | sed 's/\([0-9]\+\).\+/\1/') os:${os} package:iot-agent agent:7
+
+            # record the size of each of the important binaries in each package
+            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/bin/agent/agent | sed 's/\([0-9]\+\).\+/\1/') bin:agent os:${os} package:agent agent:7
+            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/trace-agent | sed 's/\([0-9]\+\).\+/\1/') bin:trace-agent os:${os} package:agent agent:7
+            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/security-agent | sed 's/\([0-9]\+\).\+/\1/') bin:security-agent os:${os} package:agent agent:7
+            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/process-agent | sed 's/\([0-9]\+\).\+/\1/') bin:process-agent os:${os} package:agent agent:7
+            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/system-probe | sed 's/\([0-9]\+\).\+/\1/') bin:system-probe os:${os} package:agent agent:7
+            add_metric datadog.agent.binary.size $(du -sB1 ${base}/dogstatsd/opt/datadog-dogstatsd/bin/dogstatsd | sed 's/\([0-9]\+\).\+/\1/') bin:dogstatsd os:${os} package:dogstatsd agent:7
+            add_metric datadog.agent.binary.size $(du -sB1 ${base}/iot-agent/opt/datadog-agent/bin/agent/agent | sed 's/\([0-9]\+\).\+/\1/') bin:agent os:${os} package:iot-agent agent:7
+        }
     - currenttime=$(date +%s)
 
     # We silence dpkg and cpio output so we don't exceed gitlab log limit
@@ -100,25 +119,19 @@ send_pkg_size-a7:
     - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-agent_7*_amd64.deb /tmp/deb/agent > /dev/null
     - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-iot-agent_7*_amd64.deb /tmp/deb/iot-agent > /dev/null
     - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd_7*_amd64.deb /tmp/deb/dogstatsd > /dev/null
-    - add_metric datadog.agent.package.size $(du -sB1 /tmp/deb/agent | sed 's/\([0-9]\+\).\+/\1/') os:debian package:agent agent:7
-    - add_metric datadog.agent.package.size $(du -sB1 /tmp/deb/dogstatsd | sed 's/\([0-9]\+\).\+/\1/') os:debian package:dogstatsd agent:7
-    - add_metric datadog.agent.package.size $(du -sB1 /tmp/deb/iot-agent | sed 's/\([0-9]\+\).\+/\1/') os:debian package:iot-agent agent:7
+    - add_metrics /tmp/deb debian
 
     # centos
     - cd /tmp/rpm/agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
     - cd /tmp/rpm/dogstatsd && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd-7.*.x86_64.rpm | cpio -idm > /dev/null
     - cd /tmp/rpm/iot-agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-iot-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
-    - add_metric datadog.agent.package.size $(du -sB1 /tmp/rpm/agent | sed 's/\([0-9]\+\).\+/\1/') os:centos package:agent agent:7
-    - add_metric datadog.agent.package.size $(du -sB1 /tmp/rpm/dogstatsd | sed 's/\([0-9]\+\).\+/\1/') os:centos package:dogstatsd agent:7
-    - add_metric datadog.agent.package.size $(du -sB1 /tmp/rpm/iot-agent | sed 's/\([0-9]\+\).\+/\1/') os:centos package:iot-agent agent:7
+    - add_metrics /tmp/rpm centos
 
     # suse
     - cd /tmp/suse/agent && rpm2cpio $OMNIBUS_PACKAGE_DIR_SUSE/datadog-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
     - cd /tmp/suse/dogstatsd && rpm2cpio $OMNIBUS_PACKAGE_DIR_SUSE/datadog-dogstatsd-7.*.x86_64.rpm | cpio -idm > /dev/null
     - cd /tmp/suse/iot-agent && rpm2cpio $OMNIBUS_PACKAGE_DIR_SUSE/datadog-iot-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
-    - add_metric datadog.agent.package.size $(du -sB1 /tmp/suse/agent | sed 's/\([0-9]\+\).\+/\1/') os:suse package:agent agent:7
-    - add_metric datadog.agent.package.size $(du -sB1 /tmp/suse/dogstatsd | sed 's/\([0-9]\+\).\+/\1/') os:suse package:dogstatsd agent:7
-    - add_metric datadog.agent.package.size $(du -sB1 /tmp/suse/iot-agent | sed 's/\([0-9]\+\).\+/\1/') os:suse package:iot-agent agent:7
+    - add_metrics /tmp/suse suse
 
     - DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key --with-decryption --query "Parameter.Value" --out text)
     - 'curl --fail -X POST -H "Content-type: application/json" -d "$post_body" "https://api.datadoghq.com/api/v1/series?api_key=$DD_API_KEY"'

--- a/.gitlab/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics.yml
@@ -66,7 +66,7 @@ send_pkg_size-a7:
     - iot_agent_suse-x64
   before_script:
     # FIXME: tmp while we uppdate the base image
-    - apt-get install -y wget rpm2cpio cpio
+    - apt-get install -y wget rpm2cpio cpio jq
     - ls -l $OMNIBUS_PACKAGE_DIR
     - ls -l $OMNIBUS_PACKAGE_DIR_SUSE
   script:
@@ -75,43 +75,50 @@ send_pkg_size-a7:
     - mkdir -p /tmp/rpm/agent /tmp/rpm/dogstatsd /tmp/rpm/iot-agent
     - mkdir -p /tmp/suse/agent /tmp/suse/dogstatsd /tmp/suse/iot-agent
 
+    # we will build up a JSON body in `$metrics`, and then post it.
+    - 'post_body="{\"series\": []}"'
+    - |
+        add_metric() {
+            local metric="${1}"
+            shift
+            local value="${1}"
+            shift
+
+            local tags=[]
+            while [ -n "${1}" ]; do
+                tags=$(echo $tags | jq -c ". += [\"${1}\"]")
+                shift
+            done
+
+            post_body=$(echo $post_body | jq -c ".series += [{\"metric\":\"$metric\", \"points\":[[$currenttime, $value]],\"tags\":$tags}]")
+        }
+    - currenttime=$(date +%s)
+
     # We silence dpkg and cpio output so we don't exceed gitlab log limit
 
     # debian
     - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-agent_7*_amd64.deb /tmp/deb/agent > /dev/null
     - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-iot-agent_7*_amd64.deb /tmp/deb/iot-agent > /dev/null
     - dpkg -x $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd_7*_amd64.deb /tmp/deb/dogstatsd > /dev/null
-    - DEB_AGENT_SIZE=$(du -sB1 /tmp/deb/agent | sed 's/\([0-9]\+\).\+/\1/')
-    - DEB_DOGSTATSD_SIZE=$(du -sB1 /tmp/deb/dogstatsd | sed 's/\([0-9]\+\).\+/\1/')
-    - DEB_IOT_AGENT_SIZE=$(du -sB1 /tmp/deb/iot-agent | sed 's/\([0-9]\+\).\+/\1/')
+    - add_metric datadog.agent.package.size $(du -sB1 /tmp/deb/agent | sed 's/\([0-9]\+\).\+/\1/') os:debian package:agent agent:7
+    - add_metric datadog.agent.package.size $(du -sB1 /tmp/deb/dogstatsd | sed 's/\([0-9]\+\).\+/\1/') os:debian package:dogstatsd agent:7
+    - add_metric datadog.agent.package.size $(du -sB1 /tmp/deb/iot-agent | sed 's/\([0-9]\+\).\+/\1/') os:debian package:iot-agent agent:7
+
     # centos
     - cd /tmp/rpm/agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
     - cd /tmp/rpm/dogstatsd && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd-7.*.x86_64.rpm | cpio -idm > /dev/null
     - cd /tmp/rpm/iot-agent && rpm2cpio $OMNIBUS_PACKAGE_DIR/datadog-iot-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
-    - RPM_AGENT_SIZE=$(du -sB1 /tmp/rpm/agent | sed 's/\([0-9]\+\).\+/\1/')
-    - RPM_DOGSTATSD_SIZE=$(du -sB1 /tmp/rpm/dogstatsd | sed 's/\([0-9]\+\).\+/\1/')
-    - RPM_IOT_AGENT_SIZE=$(du -sB1 /tmp/rpm/iot-agent | sed 's/\([0-9]\+\).\+/\1/')
+    - add_metric datadog.agent.package.size $(du -sB1 /tmp/rpm/agent | sed 's/\([0-9]\+\).\+/\1/') os:centos package:agent agent:7
+    - add_metric datadog.agent.package.size $(du -sB1 /tmp/rpm/dogstatsd | sed 's/\([0-9]\+\).\+/\1/') os:centos package:dogstatsd agent:7
+    - add_metric datadog.agent.package.size $(du -sB1 /tmp/rpm/iot-agent | sed 's/\([0-9]\+\).\+/\1/') os:centos package:iot-agent agent:7
+
     # suse
     - cd /tmp/suse/agent && rpm2cpio $OMNIBUS_PACKAGE_DIR_SUSE/datadog-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
     - cd /tmp/suse/dogstatsd && rpm2cpio $OMNIBUS_PACKAGE_DIR_SUSE/datadog-dogstatsd-7.*.x86_64.rpm | cpio -idm > /dev/null
     - cd /tmp/suse/iot-agent && rpm2cpio $OMNIBUS_PACKAGE_DIR_SUSE/datadog-iot-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
-    - SUSE_AGENT_SIZE=$(du -sB1 /tmp/suse/agent | sed 's/\([0-9]\+\).\+/\1/')
-    - SUSE_DOGSTATSD_SIZE=$(du -sB1 /tmp/suse/dogstatsd | sed 's/\([0-9]\+\).\+/\1/')
-    - SUSE_IOT_AGENT_SIZE=$(du -sB1 /tmp/suse/iot-agent | sed 's/\([0-9]\+\).\+/\1/')
+    - add_metric datadog.agent.package.size $(du -sB1 /tmp/suse/agent | sed 's/\([0-9]\+\).\+/\1/') os:suse package:agent agent:7
+    - add_metric datadog.agent.package.size $(du -sB1 /tmp/suse/dogstatsd | sed 's/\([0-9]\+\).\+/\1/') os:suse package:dogstatsd agent:7
+    - add_metric datadog.agent.package.size $(du -sB1 /tmp/suse/iot-agent | sed 's/\([0-9]\+\).\+/\1/') os:suse package:iot-agent agent:7
 
-    - currenttime=$(date +%s)
     - DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key --with-decryption --query "Parameter.Value" --out text)
-    - |
-      curl --fail -X POST -H "Content-type: application/json" \
-      -d "{\"series\":[
-            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $DEB_AGENT_SIZE]], \"tags\":[\"os:debian\", \"package:agent\", \"agent:7\"]},
-            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $DEB_DOGSTATSD_SIZE]], \"tags\":[\"os:debian\", \"package:dogstatsd\", \"agent:7\"]},
-            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $DEB_IOT_AGENT_SIZE]], \"tags\":[\"os:debian\", \"package:iot-agent\", \"agent:7\"]},
-            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $RPM_AGENT_SIZE]], \"tags\":[\"os:centos\", \"package:agent\", \"agent:7\"]},
-            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $RPM_DOGSTATSD_SIZE]], \"tags\":[\"os:centos\", \"package:dogstatsd\", \"agent:7\"]},
-            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $RPM_IOT_AGENT_SIZE]], \"tags\":[\"os:centos\", \"package:iot-agent\", \"agent:7\"]},
-            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $SUSE_AGENT_SIZE]], \"tags\":[\"os:suse\", \"package:agent\", \"agent:7\"]},
-            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $SUSE_DOGSTATSD_SIZE]], \"tags\":[\"os:suse\", \"package:dogstatsd\", \"agent:7\"]},
-            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $SUSE_IOT_AGENT_SIZE]], \"tags\":[\"os:suse\", \"package:iot-agent\", \"agent:7\"]}
-          ]}" \
-      "https://api.datadoghq.com/api/v1/series?api_key=$DD_API_KEY"
+    - 'curl --fail -X POST -H "Content-type: application/json" -d "$post_body" "https://api.datadoghq.com/api/v1/series?api_key=$DD_API_KEY"'


### PR DESCRIPTION
### What does this PR do?

Tracks the size of various binaries within the agent, beyond the existing size of each package.

### Motivation

AC-746

### Describe how to test your changes

I temporarily adjusted the gitlab task to run on PRs, but have removed this testing.  See https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/76532166.

### Checklist
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
