### PR TITLE
Boyan env options in yaml

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -4,12 +4,14 @@
 #########################
 
 ## @param api_key - string - required
+## @env DD_API_KEY - Your Datadog API key (required)
 ## The Datadog API key to associate your Agent's data with your organization.
 ## Create a new API key here: https://app.datadoghq.com/account/settings
 #
 api_key:
 
 ## @param site - string - optional - default: datadoghq.com
+## @env DD_SITE - Destination site for your metrics, traces and logs.
 ## The site of the Datadog intake to send Agent data to.
 ## Set to 'datadoghq.eu' to send data to the EU site.
 ## Set to 'us3.datadoghq.com' to send data to the US3 site.
@@ -18,6 +20,7 @@ api_key:
 # site: datadoghq.com
 
 ## @param dd_url - string - optional - default: https://app.datadoghq.com
+## @env DD_URL - Optional setting to override the URL for metric submission.
 ## The host of the Datadog intake server to send metrics to, only set this option
 ## if you need the Agent to send metrics to a custom URL, it overrides the site
 ## setting defined in "site". It does not affect APM, Logs or Live Process intake which have their

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -4,14 +4,14 @@
 #########################
 
 ## @param api_key - string - required
-## @env DD_API_KEY - Your Datadog API key (required)
+## @env DD_API_KEY - string - required
 ## The Datadog API key to associate your Agent's data with your organization.
 ## Create a new API key here: https://app.datadoghq.com/account/settings
 #
 api_key:
 
 ## @param site - string - optional - default: datadoghq.com
-## @env DD_SITE - Destination site for your metrics, traces and logs.
+## @env DD_SITE - string - optional - default: datadoghq.com
 ## The site of the Datadog intake to send Agent data to.
 ## Set to 'datadoghq.eu' to send data to the EU site.
 ## Set to 'us3.datadoghq.com' to send data to the US3 site.
@@ -20,7 +20,7 @@ api_key:
 # site: datadoghq.com
 
 ## @param dd_url - string - optional - default: https://app.datadoghq.com
-## @env DD_URL - Optional setting to override the URL for metric submission.
+## @env DD_URL - string - optional - default: https://app.datadoghq.com
 ## The host of the Datadog intake server to send metrics to, only set this option
 ## if you need the Agent to send metrics to a custom URL, it overrides the site
 ## setting defined in "site". It does not affect APM, Logs or Live Process intake which have their


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

The idea would be to introduce a documentation option similar to the @param directive already used in the datadog-agent and integrations configurations. The new directive would be @env and would live side-by-side with the corresponding option (defined in the @param section). The directive will include the environment variable as well as a description for the expected format for the variable. [See RFC here for details](https://github.com/DataDog/architecture/blob/master/rfcs/agent-env-var-docs/rfc.md)

Note: Adding GitHub labels is only possible for contributors with write access.
