### PR TITLE
[runtime-security] Do not put path_id in userspace buffer

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "9dfe314aebb7ca21bc71b8dd33360755a3b9d1b1630164c596f9e048783c80f5")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "94921c4321cbc9538b2e684152dcc25799f3684880036b1fe34931192bd87025")

--- a/pkg/security/ebpf/c/dentry_resolver.h
+++ b/pkg/security/ebpf/c/dentry_resolver.h
@@ -371,11 +371,11 @@ int __attribute__((always_inline)) handle_resolve_segment(void *data) {
         return 0;
     }
 
-    int ret = bpf_probe_write_user((void *) userspace_buffer, &key, sizeof(key));
+    int ret = bpf_probe_write_user((void *) userspace_buffer, &key, offsetof(struct path_key_t, path_id));
     if (ret < 0)
         return ret;
 
-    return bpf_probe_write_user((void *) userspace_buffer + sizeof(key), map_value->name, DR_MAX_SEGMENT_LENGTH + 1);
+    return bpf_probe_write_user((void *) userspace_buffer + offsetof(struct path_key_t, path_id), map_value->name, DR_MAX_SEGMENT_LENGTH + 1);
 }
 
 int __attribute__((always_inline)) resolve_dentry(void *ctx, int dr_type) {

--- a/pkg/security/probe/dentry_resolver.go
+++ b/pkg/security/probe/dentry_resolver.go
@@ -514,8 +514,7 @@ func (dr *DentryResolver) ResolveFromERPC(mountID uint32, inode uint64, pathID u
 		// parse the path_key_t structure
 		key.Inode = model.ByteOrder.Uint64(dr.erpcSegment[i : i+8])
 		key.MountID = model.ByteOrder.Uint32(dr.erpcSegment[i+8 : i+12])
-		// skip PathID
-		i += 16
+		i += 12
 
 		if dr.erpcSegment[i] == 0 {
 			if depth >= model.MaxPathDepth {


### PR DESCRIPTION
### What does this PR do?

Do not put path_id in output

### Motivation

The path_id is only used in kernel so it's useless to pass it to userspace

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
