### PR TITLE
[runtime-security] expose ctime and mtime to SECL

### DIFF
--- a/pkg/security/model/accessors.go
+++ b/pkg/security/model/accessors.go
@@ -87,6 +87,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "chmod.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chmod.File.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "chmod.file.destination.mode":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -167,6 +177,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "chmod.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chmod.File.FileFields.MTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "chmod.file.mount_id":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -232,6 +252,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).Chmod.SyscallEvent.Retval)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chown.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chown.File.FileFields.CTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -332,6 +362,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).Chown.File.FileFields.Mode)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chown.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chown.File.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -602,6 +642,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "exec.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Exec.Process.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "exec.file.filesystem":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -657,6 +707,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).Exec.Process.FileFields.Mode)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "exec.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Exec.Process.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -842,6 +902,26 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "link.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Source.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.destination.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Target.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "link.file.destination.filesystem":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -897,6 +977,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).Link.Target.FileFields.Mode)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.destination.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Target.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -1022,6 +1112,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "link.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Source.FileFields.MTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "link.file.mount_id":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1087,6 +1187,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).Link.SyscallEvent.Retval)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "mkdir.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Mkdir.File.FileFields.CTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -1172,6 +1282,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "mkdir.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Mkdir.File.FileFields.MTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "mkdir.file.mount_id":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1242,6 +1362,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "open.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Open.File.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "open.file.destination.mode":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1307,6 +1437,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).Open.File.FileFields.Mode)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "open.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Open.File.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -1642,6 +1782,31 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.IteratorWeight,
 		}, nil
 
+	case "process.ancestors.file.change_time":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				var results []int
+
+				iterator := &ProcessAncestorsIterator{}
+
+				value := iterator.Front(ctx)
+				for value != nil {
+					var result int
+
+					element := (*ProcessCacheEntry)(value)
+
+					result = int(element.ProcessContext.Process.FileFields.CTime)
+
+					results = append(results, result)
+
+					value = iterator.Next()
+				}
+
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+
 	case "process.ancestors.file.filesystem":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -1781,6 +1946,31 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					element := (*ProcessCacheEntry)(value)
 
 					result = int(element.ProcessContext.Process.FileFields.Mode)
+
+					results = append(results, result)
+
+					value = iterator.Next()
+				}
+
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.modification_time":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				var results []int
+
+				iterator := &ProcessAncestorsIterator{}
+
+				value := iterator.Front(ctx)
+				for value != nil {
+					var result int
+
+					element := (*ProcessCacheEntry)(value)
+
+					result = int(element.ProcessContext.Process.FileFields.MTime)
 
 					results = append(results, result)
 
@@ -2342,6 +2532,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "process.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "process.file.filesystem":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -2397,6 +2597,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.Mode)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "process.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -2582,6 +2792,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "removexattr.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).RemoveXAttr.File.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "removexattr.file.destination.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -2662,6 +2882,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "removexattr.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).RemoveXAttr.File.FileFields.MTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "removexattr.file.mount_id":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -2732,6 +2962,26 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "rename.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.Old.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.destination.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.New.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "rename.file.destination.filesystem":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -2787,6 +3037,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).Rename.New.FileFields.Mode)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.destination.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.New.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -2912,6 +3172,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "rename.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.Old.FileFields.MTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "rename.file.mount_id":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -2982,6 +3252,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "rmdir.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rmdir.File.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "rmdir.file.filesystem":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -3037,6 +3317,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).Rmdir.File.FileFields.Mode)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rmdir.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rmdir.File.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3272,6 +3562,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "setxattr.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).SetXAttr.File.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "setxattr.file.destination.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -3352,6 +3652,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "setxattr.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).SetXAttr.File.FileFields.MTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "setxattr.file.mount_id":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -3422,6 +3732,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "unlink.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Unlink.File.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "unlink.file.filesystem":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -3477,6 +3797,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).Unlink.File.FileFields.Mode)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "unlink.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Unlink.File.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3552,6 +3882,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "utimes.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Utimes.File.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "utimes.file.filesystem":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -3607,6 +3947,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).Utimes.File.FileFields.Mode)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "utimes.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Utimes.File.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3694,6 +4044,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"capset.cap_permitted",
 
+		"chmod.file.change_time",
+
 		"chmod.file.destination.mode",
 
 		"chmod.file.destination.rights",
@@ -3710,6 +4062,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"chmod.file.mode",
 
+		"chmod.file.modification_time",
+
 		"chmod.file.mount_id",
 
 		"chmod.file.name",
@@ -3723,6 +4077,8 @@ func (e *Event) GetFields() []eval.Field {
 		"chmod.file.user",
 
 		"chmod.retval",
+
+		"chown.file.change_time",
 
 		"chown.file.destination.gid",
 
@@ -3743,6 +4099,8 @@ func (e *Event) GetFields() []eval.Field {
 		"chown.file.inode",
 
 		"chown.file.mode",
+
+		"chown.file.modification_time",
 
 		"chown.file.mount_id",
 
@@ -3796,6 +4154,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"exec.euser",
 
+		"exec.file.change_time",
+
 		"exec.file.filesystem",
 
 		"exec.file.gid",
@@ -3807,6 +4167,8 @@ func (e *Event) GetFields() []eval.Field {
 		"exec.file.inode",
 
 		"exec.file.mode",
+
+		"exec.file.modification_time",
 
 		"exec.file.mount_id",
 
@@ -3844,6 +4206,10 @@ func (e *Event) GetFields() []eval.Field {
 
 		"exec.user",
 
+		"link.file.change_time",
+
+		"link.file.destination.change_time",
+
 		"link.file.destination.filesystem",
 
 		"link.file.destination.gid",
@@ -3855,6 +4221,8 @@ func (e *Event) GetFields() []eval.Field {
 		"link.file.destination.inode",
 
 		"link.file.destination.mode",
+
+		"link.file.destination.modification_time",
 
 		"link.file.destination.mount_id",
 
@@ -3880,6 +4248,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"link.file.mode",
 
+		"link.file.modification_time",
+
 		"link.file.mount_id",
 
 		"link.file.name",
@@ -3893,6 +4263,8 @@ func (e *Event) GetFields() []eval.Field {
 		"link.file.user",
 
 		"link.retval",
+
+		"mkdir.file.change_time",
 
 		"mkdir.file.destination.mode",
 
@@ -3910,6 +4282,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"mkdir.file.mode",
 
+		"mkdir.file.modification_time",
+
 		"mkdir.file.mount_id",
 
 		"mkdir.file.name",
@@ -3924,6 +4298,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"mkdir.retval",
 
+		"open.file.change_time",
+
 		"open.file.destination.mode",
 
 		"open.file.filesystem",
@@ -3937,6 +4313,8 @@ func (e *Event) GetFields() []eval.Field {
 		"open.file.inode",
 
 		"open.file.mode",
+
+		"open.file.modification_time",
 
 		"open.file.mount_id",
 
@@ -3974,6 +4352,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"process.ancestors.euser",
 
+		"process.ancestors.file.change_time",
+
 		"process.ancestors.file.filesystem",
 
 		"process.ancestors.file.gid",
@@ -3985,6 +4365,8 @@ func (e *Event) GetFields() []eval.Field {
 		"process.ancestors.file.inode",
 
 		"process.ancestors.file.mode",
+
+		"process.ancestors.file.modification_time",
 
 		"process.ancestors.file.mount_id",
 
@@ -4042,6 +4424,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"process.euser",
 
+		"process.file.change_time",
+
 		"process.file.filesystem",
 
 		"process.file.gid",
@@ -4053,6 +4437,8 @@ func (e *Event) GetFields() []eval.Field {
 		"process.file.inode",
 
 		"process.file.mode",
+
+		"process.file.modification_time",
 
 		"process.file.mount_id",
 
@@ -4090,6 +4476,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"process.user",
 
+		"removexattr.file.change_time",
+
 		"removexattr.file.destination.name",
 
 		"removexattr.file.destination.namespace",
@@ -4106,6 +4494,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"removexattr.file.mode",
 
+		"removexattr.file.modification_time",
+
 		"removexattr.file.mount_id",
 
 		"removexattr.file.name",
@@ -4120,6 +4510,10 @@ func (e *Event) GetFields() []eval.Field {
 
 		"removexattr.retval",
 
+		"rename.file.change_time",
+
+		"rename.file.destination.change_time",
+
 		"rename.file.destination.filesystem",
 
 		"rename.file.destination.gid",
@@ -4131,6 +4525,8 @@ func (e *Event) GetFields() []eval.Field {
 		"rename.file.destination.inode",
 
 		"rename.file.destination.mode",
+
+		"rename.file.destination.modification_time",
 
 		"rename.file.destination.mount_id",
 
@@ -4156,6 +4552,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"rename.file.mode",
 
+		"rename.file.modification_time",
+
 		"rename.file.mount_id",
 
 		"rename.file.name",
@@ -4170,6 +4568,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"rename.retval",
 
+		"rmdir.file.change_time",
+
 		"rmdir.file.filesystem",
 
 		"rmdir.file.gid",
@@ -4181,6 +4581,8 @@ func (e *Event) GetFields() []eval.Field {
 		"rmdir.file.inode",
 
 		"rmdir.file.mode",
+
+		"rmdir.file.modification_time",
 
 		"rmdir.file.mount_id",
 
@@ -4228,6 +4630,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"setuid.user",
 
+		"setxattr.file.change_time",
+
 		"setxattr.file.destination.name",
 
 		"setxattr.file.destination.namespace",
@@ -4244,6 +4648,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"setxattr.file.mode",
 
+		"setxattr.file.modification_time",
+
 		"setxattr.file.mount_id",
 
 		"setxattr.file.name",
@@ -4258,6 +4664,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"setxattr.retval",
 
+		"unlink.file.change_time",
+
 		"unlink.file.filesystem",
 
 		"unlink.file.gid",
@@ -4269,6 +4677,8 @@ func (e *Event) GetFields() []eval.Field {
 		"unlink.file.inode",
 
 		"unlink.file.mode",
+
+		"unlink.file.modification_time",
 
 		"unlink.file.mount_id",
 
@@ -4284,6 +4694,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"unlink.retval",
 
+		"utimes.file.change_time",
+
 		"utimes.file.filesystem",
 
 		"utimes.file.gid",
@@ -4295,6 +4707,8 @@ func (e *Event) GetFields() []eval.Field {
 		"utimes.file.inode",
 
 		"utimes.file.mode",
+
+		"utimes.file.modification_time",
 
 		"utimes.file.mount_id",
 
@@ -4322,6 +4736,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "capset.cap_permitted":
 
 		return int(e.Capset.CapPermitted), nil
+
+	case "chmod.file.change_time":
+
+		return int(e.Chmod.File.FileFields.CTime), nil
 
 	case "chmod.file.destination.mode":
 
@@ -4355,6 +4773,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.Chmod.File.FileFields.Mode), nil
 
+	case "chmod.file.modification_time":
+
+		return int(e.Chmod.File.FileFields.MTime), nil
+
 	case "chmod.file.mount_id":
 
 		return int(e.Chmod.File.FileFields.MountID), nil
@@ -4382,6 +4804,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "chmod.retval":
 
 		return int(e.Chmod.SyscallEvent.Retval), nil
+
+	case "chown.file.change_time":
+
+		return int(e.Chown.File.FileFields.CTime), nil
 
 	case "chown.file.destination.gid":
 
@@ -4422,6 +4848,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "chown.file.mode":
 
 		return int(e.Chown.File.FileFields.Mode), nil
+
+	case "chown.file.modification_time":
+
+		return int(e.Chown.File.FileFields.MTime), nil
 
 	case "chown.file.mount_id":
 
@@ -4527,6 +4957,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Exec.Process.Credentials.EUser, nil
 
+	case "exec.file.change_time":
+
+		return int(e.Exec.Process.FileFields.CTime), nil
+
 	case "exec.file.filesystem":
 
 		return e.Exec.Process.Filesystem, nil
@@ -4550,6 +4984,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "exec.file.mode":
 
 		return int(e.Exec.Process.FileFields.Mode), nil
+
+	case "exec.file.modification_time":
+
+		return int(e.Exec.Process.FileFields.MTime), nil
 
 	case "exec.file.mount_id":
 
@@ -4623,6 +5061,14 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Exec.Process.Credentials.User, nil
 
+	case "link.file.change_time":
+
+		return int(e.Link.Source.FileFields.CTime), nil
+
+	case "link.file.destination.change_time":
+
+		return int(e.Link.Target.FileFields.CTime), nil
+
 	case "link.file.destination.filesystem":
 
 		return e.Link.Target.Filesytem, nil
@@ -4646,6 +5092,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "link.file.destination.mode":
 
 		return int(e.Link.Target.FileFields.Mode), nil
+
+	case "link.file.destination.modification_time":
+
+		return int(e.Link.Target.FileFields.MTime), nil
 
 	case "link.file.destination.mount_id":
 
@@ -4695,6 +5145,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.Link.Source.FileFields.Mode), nil
 
+	case "link.file.modification_time":
+
+		return int(e.Link.Source.FileFields.MTime), nil
+
 	case "link.file.mount_id":
 
 		return int(e.Link.Source.FileFields.MountID), nil
@@ -4722,6 +5176,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "link.retval":
 
 		return int(e.Link.SyscallEvent.Retval), nil
+
+	case "mkdir.file.change_time":
+
+		return int(e.Mkdir.File.FileFields.CTime), nil
 
 	case "mkdir.file.destination.mode":
 
@@ -4755,6 +5213,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.Mkdir.File.FileFields.Mode), nil
 
+	case "mkdir.file.modification_time":
+
+		return int(e.Mkdir.File.FileFields.MTime), nil
+
 	case "mkdir.file.mount_id":
 
 		return int(e.Mkdir.File.FileFields.MountID), nil
@@ -4783,6 +5245,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.Mkdir.SyscallEvent.Retval), nil
 
+	case "open.file.change_time":
+
+		return int(e.Open.File.FileFields.CTime), nil
+
 	case "open.file.destination.mode":
 
 		return int(e.Open.Mode), nil
@@ -4810,6 +5276,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "open.file.mode":
 
 		return int(e.Open.File.FileFields.Mode), nil
+
+	case "open.file.modification_time":
+
+		return int(e.Open.File.FileFields.MTime), nil
 
 	case "open.file.mount_id":
 
@@ -5063,6 +5533,28 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return values, nil
 
+	case "process.ancestors.file.change_time":
+
+		var values []int
+
+		ctx := eval.NewContext(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := int(element.ProcessContext.Process.FileFields.CTime)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
 	case "process.ancestors.file.filesystem":
 
 		var values []string
@@ -5187,6 +5679,28 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 			element := (*ProcessCacheEntry)(ptr)
 
 			result := int(element.ProcessContext.Process.FileFields.Mode)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.modification_time":
+
+		var values []int
+
+		ctx := eval.NewContext(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := int(element.ProcessContext.Process.FileFields.MTime)
 
 			values = append(values, result)
 
@@ -5631,6 +6145,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ProcessContext.Process.Credentials.EUser, nil
 
+	case "process.file.change_time":
+
+		return int(e.ProcessContext.Process.FileFields.CTime), nil
+
 	case "process.file.filesystem":
 
 		return e.ProcessContext.Process.Filesystem, nil
@@ -5654,6 +6172,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "process.file.mode":
 
 		return int(e.ProcessContext.Process.FileFields.Mode), nil
+
+	case "process.file.modification_time":
+
+		return int(e.ProcessContext.Process.FileFields.MTime), nil
 
 	case "process.file.mount_id":
 
@@ -5727,6 +6249,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ProcessContext.Process.Credentials.User, nil
 
+	case "removexattr.file.change_time":
+
+		return int(e.RemoveXAttr.File.FileFields.CTime), nil
+
 	case "removexattr.file.destination.name":
 
 		return e.RemoveXAttr.Name, nil
@@ -5759,6 +6285,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.RemoveXAttr.File.FileFields.Mode), nil
 
+	case "removexattr.file.modification_time":
+
+		return int(e.RemoveXAttr.File.FileFields.MTime), nil
+
 	case "removexattr.file.mount_id":
 
 		return int(e.RemoveXAttr.File.FileFields.MountID), nil
@@ -5787,6 +6317,14 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.RemoveXAttr.SyscallEvent.Retval), nil
 
+	case "rename.file.change_time":
+
+		return int(e.Rename.Old.FileFields.CTime), nil
+
+	case "rename.file.destination.change_time":
+
+		return int(e.Rename.New.FileFields.CTime), nil
+
 	case "rename.file.destination.filesystem":
 
 		return e.Rename.New.Filesytem, nil
@@ -5810,6 +6348,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "rename.file.destination.mode":
 
 		return int(e.Rename.New.FileFields.Mode), nil
+
+	case "rename.file.destination.modification_time":
+
+		return int(e.Rename.New.FileFields.MTime), nil
 
 	case "rename.file.destination.mount_id":
 
@@ -5859,6 +6401,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.Rename.Old.FileFields.Mode), nil
 
+	case "rename.file.modification_time":
+
+		return int(e.Rename.Old.FileFields.MTime), nil
+
 	case "rename.file.mount_id":
 
 		return int(e.Rename.Old.FileFields.MountID), nil
@@ -5887,6 +6433,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.Rename.SyscallEvent.Retval), nil
 
+	case "rmdir.file.change_time":
+
+		return int(e.Rmdir.File.FileFields.CTime), nil
+
 	case "rmdir.file.filesystem":
 
 		return e.Rmdir.File.Filesytem, nil
@@ -5910,6 +6460,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "rmdir.file.mode":
 
 		return int(e.Rmdir.File.FileFields.Mode), nil
+
+	case "rmdir.file.modification_time":
+
+		return int(e.Rmdir.File.FileFields.MTime), nil
 
 	case "rmdir.file.mount_id":
 
@@ -6003,6 +6557,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.SetUID.User, nil
 
+	case "setxattr.file.change_time":
+
+		return int(e.SetXAttr.File.FileFields.CTime), nil
+
 	case "setxattr.file.destination.name":
 
 		return e.SetXAttr.Name, nil
@@ -6035,6 +6593,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.SetXAttr.File.FileFields.Mode), nil
 
+	case "setxattr.file.modification_time":
+
+		return int(e.SetXAttr.File.FileFields.MTime), nil
+
 	case "setxattr.file.mount_id":
 
 		return int(e.SetXAttr.File.FileFields.MountID), nil
@@ -6063,6 +6625,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.SetXAttr.SyscallEvent.Retval), nil
 
+	case "unlink.file.change_time":
+
+		return int(e.Unlink.File.FileFields.CTime), nil
+
 	case "unlink.file.filesystem":
 
 		return e.Unlink.File.Filesytem, nil
@@ -6086,6 +6652,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "unlink.file.mode":
 
 		return int(e.Unlink.File.FileFields.Mode), nil
+
+	case "unlink.file.modification_time":
+
+		return int(e.Unlink.File.FileFields.MTime), nil
 
 	case "unlink.file.mount_id":
 
@@ -6115,6 +6685,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.Unlink.SyscallEvent.Retval), nil
 
+	case "utimes.file.change_time":
+
+		return int(e.Utimes.File.FileFields.CTime), nil
+
 	case "utimes.file.filesystem":
 
 		return e.Utimes.File.Filesytem, nil
@@ -6138,6 +6712,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "utimes.file.mode":
 
 		return int(e.Utimes.File.FileFields.Mode), nil
+
+	case "utimes.file.modification_time":
+
+		return int(e.Utimes.File.FileFields.MTime), nil
 
 	case "utimes.file.mount_id":
 
@@ -6181,6 +6759,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "capset.cap_permitted":
 		return "capset", nil
 
+	case "chmod.file.change_time":
+		return "chmod", nil
+
 	case "chmod.file.destination.mode":
 		return "chmod", nil
 
@@ -6205,6 +6786,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "chmod.file.mode":
 		return "chmod", nil
 
+	case "chmod.file.modification_time":
+		return "chmod", nil
+
 	case "chmod.file.mount_id":
 		return "chmod", nil
 
@@ -6225,6 +6809,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 
 	case "chmod.retval":
 		return "chmod", nil
+
+	case "chown.file.change_time":
+		return "chown", nil
 
 	case "chown.file.destination.gid":
 		return "chown", nil
@@ -6254,6 +6841,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "chown", nil
 
 	case "chown.file.mode":
+		return "chown", nil
+
+	case "chown.file.modification_time":
 		return "chown", nil
 
 	case "chown.file.mount_id":
@@ -6334,6 +6924,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "exec.euser":
 		return "exec", nil
 
+	case "exec.file.change_time":
+		return "exec", nil
+
 	case "exec.file.filesystem":
 		return "exec", nil
 
@@ -6350,6 +6943,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "exec", nil
 
 	case "exec.file.mode":
+		return "exec", nil
+
+	case "exec.file.modification_time":
 		return "exec", nil
 
 	case "exec.file.mount_id":
@@ -6406,6 +7002,12 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "exec.user":
 		return "exec", nil
 
+	case "link.file.change_time":
+		return "link", nil
+
+	case "link.file.destination.change_time":
+		return "link", nil
+
 	case "link.file.destination.filesystem":
 		return "link", nil
 
@@ -6422,6 +7024,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "link", nil
 
 	case "link.file.destination.mode":
+		return "link", nil
+
+	case "link.file.destination.modification_time":
 		return "link", nil
 
 	case "link.file.destination.mount_id":
@@ -6460,6 +7065,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "link.file.mode":
 		return "link", nil
 
+	case "link.file.modification_time":
+		return "link", nil
+
 	case "link.file.mount_id":
 		return "link", nil
 
@@ -6480,6 +7088,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 
 	case "link.retval":
 		return "link", nil
+
+	case "mkdir.file.change_time":
+		return "mkdir", nil
 
 	case "mkdir.file.destination.mode":
 		return "mkdir", nil
@@ -6505,6 +7116,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "mkdir.file.mode":
 		return "mkdir", nil
 
+	case "mkdir.file.modification_time":
+		return "mkdir", nil
+
 	case "mkdir.file.mount_id":
 		return "mkdir", nil
 
@@ -6526,6 +7140,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "mkdir.retval":
 		return "mkdir", nil
 
+	case "open.file.change_time":
+		return "open", nil
+
 	case "open.file.destination.mode":
 		return "open", nil
 
@@ -6545,6 +7162,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "open", nil
 
 	case "open.file.mode":
+		return "open", nil
+
+	case "open.file.modification_time":
 		return "open", nil
 
 	case "open.file.mount_id":
@@ -6601,6 +7221,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "process.ancestors.euser":
 		return "*", nil
 
+	case "process.ancestors.file.change_time":
+		return "*", nil
+
 	case "process.ancestors.file.filesystem":
 		return "*", nil
 
@@ -6617,6 +7240,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 
 	case "process.ancestors.file.mode":
+		return "*", nil
+
+	case "process.ancestors.file.modification_time":
 		return "*", nil
 
 	case "process.ancestors.file.mount_id":
@@ -6703,6 +7329,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "process.euser":
 		return "*", nil
 
+	case "process.file.change_time":
+		return "*", nil
+
 	case "process.file.filesystem":
 		return "*", nil
 
@@ -6719,6 +7348,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 
 	case "process.file.mode":
+		return "*", nil
+
+	case "process.file.modification_time":
 		return "*", nil
 
 	case "process.file.mount_id":
@@ -6775,6 +7407,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "process.user":
 		return "*", nil
 
+	case "removexattr.file.change_time":
+		return "removexattr", nil
+
 	case "removexattr.file.destination.name":
 		return "removexattr", nil
 
@@ -6799,6 +7434,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "removexattr.file.mode":
 		return "removexattr", nil
 
+	case "removexattr.file.modification_time":
+		return "removexattr", nil
+
 	case "removexattr.file.mount_id":
 		return "removexattr", nil
 
@@ -6820,6 +7458,12 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "removexattr.retval":
 		return "removexattr", nil
 
+	case "rename.file.change_time":
+		return "rename", nil
+
+	case "rename.file.destination.change_time":
+		return "rename", nil
+
 	case "rename.file.destination.filesystem":
 		return "rename", nil
 
@@ -6836,6 +7480,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "rename", nil
 
 	case "rename.file.destination.mode":
+		return "rename", nil
+
+	case "rename.file.destination.modification_time":
 		return "rename", nil
 
 	case "rename.file.destination.mount_id":
@@ -6874,6 +7521,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "rename.file.mode":
 		return "rename", nil
 
+	case "rename.file.modification_time":
+		return "rename", nil
+
 	case "rename.file.mount_id":
 		return "rename", nil
 
@@ -6895,6 +7545,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "rename.retval":
 		return "rename", nil
 
+	case "rmdir.file.change_time":
+		return "rmdir", nil
+
 	case "rmdir.file.filesystem":
 		return "rmdir", nil
 
@@ -6911,6 +7564,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "rmdir", nil
 
 	case "rmdir.file.mode":
+		return "rmdir", nil
+
+	case "rmdir.file.modification_time":
 		return "rmdir", nil
 
 	case "rmdir.file.mount_id":
@@ -6982,6 +7638,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "setuid.user":
 		return "setuid", nil
 
+	case "setxattr.file.change_time":
+		return "setxattr", nil
+
 	case "setxattr.file.destination.name":
 		return "setxattr", nil
 
@@ -7006,6 +7665,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "setxattr.file.mode":
 		return "setxattr", nil
 
+	case "setxattr.file.modification_time":
+		return "setxattr", nil
+
 	case "setxattr.file.mount_id":
 		return "setxattr", nil
 
@@ -7027,6 +7689,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "setxattr.retval":
 		return "setxattr", nil
 
+	case "unlink.file.change_time":
+		return "unlink", nil
+
 	case "unlink.file.filesystem":
 		return "unlink", nil
 
@@ -7043,6 +7708,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "unlink", nil
 
 	case "unlink.file.mode":
+		return "unlink", nil
+
+	case "unlink.file.modification_time":
 		return "unlink", nil
 
 	case "unlink.file.mount_id":
@@ -7066,6 +7734,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "unlink.retval":
 		return "unlink", nil
 
+	case "utimes.file.change_time":
+		return "utimes", nil
+
 	case "utimes.file.filesystem":
 		return "utimes", nil
 
@@ -7082,6 +7753,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "utimes", nil
 
 	case "utimes.file.mode":
+		return "utimes", nil
+
+	case "utimes.file.modification_time":
 		return "utimes", nil
 
 	case "utimes.file.mount_id":
@@ -7121,6 +7795,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "chmod.file.change_time":
+
+		return reflect.Int, nil
+
 	case "chmod.file.destination.mode":
 
 		return reflect.Int, nil
@@ -7153,6 +7831,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "chmod.file.modification_time":
+
+		return reflect.Int, nil
+
 	case "chmod.file.mount_id":
 
 		return reflect.Int, nil
@@ -7178,6 +7860,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 
 	case "chmod.retval":
+
+		return reflect.Int, nil
+
+	case "chown.file.change_time":
 
 		return reflect.Int, nil
 
@@ -7218,6 +7904,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 
 	case "chown.file.mode":
+
+		return reflect.Int, nil
+
+	case "chown.file.modification_time":
 
 		return reflect.Int, nil
 
@@ -7325,6 +8015,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "exec.file.change_time":
+
+		return reflect.Int, nil
+
 	case "exec.file.filesystem":
 
 		return reflect.String, nil
@@ -7346,6 +8040,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 
 	case "exec.file.mode":
+
+		return reflect.Int, nil
+
+	case "exec.file.modification_time":
 
 		return reflect.Int, nil
 
@@ -7421,6 +8119,14 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "link.file.change_time":
+
+		return reflect.Int, nil
+
+	case "link.file.destination.change_time":
+
+		return reflect.Int, nil
+
 	case "link.file.destination.filesystem":
 
 		return reflect.String, nil
@@ -7442,6 +8148,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 
 	case "link.file.destination.mode":
+
+		return reflect.Int, nil
+
+	case "link.file.destination.modification_time":
 
 		return reflect.Int, nil
 
@@ -7493,6 +8203,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "link.file.modification_time":
+
+		return reflect.Int, nil
+
 	case "link.file.mount_id":
 
 		return reflect.Int, nil
@@ -7518,6 +8232,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 
 	case "link.retval":
+
+		return reflect.Int, nil
+
+	case "mkdir.file.change_time":
 
 		return reflect.Int, nil
 
@@ -7553,6 +8271,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "mkdir.file.modification_time":
+
+		return reflect.Int, nil
+
 	case "mkdir.file.mount_id":
 
 		return reflect.Int, nil
@@ -7581,6 +8303,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "open.file.change_time":
+
+		return reflect.Int, nil
+
 	case "open.file.destination.mode":
 
 		return reflect.Int, nil
@@ -7606,6 +8332,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 
 	case "open.file.mode":
+
+		return reflect.Int, nil
+
+	case "open.file.modification_time":
 
 		return reflect.Int, nil
 
@@ -7681,6 +8411,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "process.ancestors.file.change_time":
+
+		return reflect.Int, nil
+
 	case "process.ancestors.file.filesystem":
 
 		return reflect.String, nil
@@ -7702,6 +8436,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 
 	case "process.ancestors.file.mode":
+
+		return reflect.Int, nil
+
+	case "process.ancestors.file.modification_time":
 
 		return reflect.Int, nil
 
@@ -7817,6 +8555,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "process.file.change_time":
+
+		return reflect.Int, nil
+
 	case "process.file.filesystem":
 
 		return reflect.String, nil
@@ -7838,6 +8580,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 
 	case "process.file.mode":
+
+		return reflect.Int, nil
+
+	case "process.file.modification_time":
 
 		return reflect.Int, nil
 
@@ -7913,6 +8659,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "removexattr.file.change_time":
+
+		return reflect.Int, nil
+
 	case "removexattr.file.destination.name":
 
 		return reflect.String, nil
@@ -7945,6 +8695,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "removexattr.file.modification_time":
+
+		return reflect.Int, nil
+
 	case "removexattr.file.mount_id":
 
 		return reflect.Int, nil
@@ -7973,6 +8727,14 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "rename.file.change_time":
+
+		return reflect.Int, nil
+
+	case "rename.file.destination.change_time":
+
+		return reflect.Int, nil
+
 	case "rename.file.destination.filesystem":
 
 		return reflect.String, nil
@@ -7994,6 +8756,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 
 	case "rename.file.destination.mode":
+
+		return reflect.Int, nil
+
+	case "rename.file.destination.modification_time":
 
 		return reflect.Int, nil
 
@@ -8045,6 +8811,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "rename.file.modification_time":
+
+		return reflect.Int, nil
+
 	case "rename.file.mount_id":
 
 		return reflect.Int, nil
@@ -8073,6 +8843,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "rmdir.file.change_time":
+
+		return reflect.Int, nil
+
 	case "rmdir.file.filesystem":
 
 		return reflect.String, nil
@@ -8094,6 +8868,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 
 	case "rmdir.file.mode":
+
+		return reflect.Int, nil
+
+	case "rmdir.file.modification_time":
 
 		return reflect.Int, nil
 
@@ -8189,6 +8967,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "setxattr.file.change_time":
+
+		return reflect.Int, nil
+
 	case "setxattr.file.destination.name":
 
 		return reflect.String, nil
@@ -8221,6 +9003,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "setxattr.file.modification_time":
+
+		return reflect.Int, nil
+
 	case "setxattr.file.mount_id":
 
 		return reflect.Int, nil
@@ -8249,6 +9035,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "unlink.file.change_time":
+
+		return reflect.Int, nil
+
 	case "unlink.file.filesystem":
 
 		return reflect.String, nil
@@ -8270,6 +9060,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 
 	case "unlink.file.mode":
+
+		return reflect.Int, nil
+
+	case "unlink.file.modification_time":
 
 		return reflect.Int, nil
 
@@ -8301,6 +9095,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "utimes.file.change_time":
+
+		return reflect.Int, nil
+
 	case "utimes.file.filesystem":
 
 		return reflect.String, nil
@@ -8322,6 +9120,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 
 	case "utimes.file.mode":
+
+		return reflect.Int, nil
+
+	case "utimes.file.modification_time":
 
 		return reflect.Int, nil
 
@@ -8379,6 +9181,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Capset.CapPermitted"}
 		}
 		e.Capset.CapPermitted = uint64(v)
+		return nil
+
+	case "chmod.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.CTime"}
+		}
+		e.Chmod.File.FileFields.CTime = uint64(v)
 		return nil
 
 	case "chmod.file.destination.mode":
@@ -8461,6 +9273,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Chmod.File.FileFields.Mode = uint16(v)
 		return nil
 
+	case "chmod.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.MTime"}
+		}
+		e.Chmod.File.FileFields.MTime = uint64(v)
+		return nil
+
 	case "chmod.file.mount_id":
 
 		var ok bool
@@ -8532,6 +9354,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Chmod.SyscallEvent.Retval"}
 		}
 		e.Chmod.SyscallEvent.Retval = int64(v)
+		return nil
+
+	case "chown.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.CTime"}
+		}
+		e.Chown.File.FileFields.CTime = uint64(v)
 		return nil
 
 	case "chown.file.destination.gid":
@@ -8634,6 +9466,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.Mode"}
 		}
 		e.Chown.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "chown.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.MTime"}
+		}
+		e.Chown.File.FileFields.MTime = uint64(v)
 		return nil
 
 	case "chown.file.mount_id":
@@ -8906,6 +9748,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "exec.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.CTime"}
+		}
+		e.Exec.Process.FileFields.CTime = uint64(v)
+		return nil
+
 	case "exec.file.filesystem":
 
 		var ok bool
@@ -8964,6 +9816,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.Mode"}
 		}
 		e.Exec.Process.FileFields.Mode = uint16(v)
+		return nil
+
+	case "exec.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.MTime"}
+		}
+		e.Exec.Process.FileFields.MTime = uint64(v)
 		return nil
 
 	case "exec.file.mount_id":
@@ -9154,6 +10016,26 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "link.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.CTime"}
+		}
+		e.Link.Source.FileFields.CTime = uint64(v)
+		return nil
+
+	case "link.file.destination.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.CTime"}
+		}
+		e.Link.Target.FileFields.CTime = uint64(v)
+		return nil
+
 	case "link.file.destination.filesystem":
 
 		var ok bool
@@ -9212,6 +10094,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.Mode"}
 		}
 		e.Link.Target.FileFields.Mode = uint16(v)
+		return nil
+
+	case "link.file.destination.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.MTime"}
+		}
+		e.Link.Target.FileFields.MTime = uint64(v)
 		return nil
 
 	case "link.file.destination.mount_id":
@@ -9337,6 +10229,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Link.Source.FileFields.Mode = uint16(v)
 		return nil
 
+	case "link.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.MTime"}
+		}
+		e.Link.Source.FileFields.MTime = uint64(v)
+		return nil
+
 	case "link.file.mount_id":
 
 		var ok bool
@@ -9408,6 +10310,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Link.SyscallEvent.Retval"}
 		}
 		e.Link.SyscallEvent.Retval = int64(v)
+		return nil
+
+	case "mkdir.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.CTime"}
+		}
+		e.Mkdir.File.FileFields.CTime = uint64(v)
 		return nil
 
 	case "mkdir.file.destination.mode":
@@ -9490,6 +10402,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Mkdir.File.FileFields.Mode = uint16(v)
 		return nil
 
+	case "mkdir.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.MTime"}
+		}
+		e.Mkdir.File.FileFields.MTime = uint64(v)
+		return nil
+
 	case "mkdir.file.mount_id":
 
 		var ok bool
@@ -9563,6 +10485,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Mkdir.SyscallEvent.Retval = int64(v)
 		return nil
 
+	case "open.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.CTime"}
+		}
+		e.Open.File.FileFields.CTime = uint64(v)
+		return nil
+
 	case "open.file.destination.mode":
 
 		var ok bool
@@ -9631,6 +10563,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.Mode"}
 		}
 		e.Open.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "open.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.MTime"}
+		}
+		e.Open.File.FileFields.MTime = uint64(v)
 		return nil
 
 	case "open.file.mount_id":
@@ -9860,6 +10802,20 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "process.ancestors.file.change_time":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.CTime"}
+		}
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.CTime = uint64(v)
+		return nil
+
 	case "process.ancestors.file.filesystem":
 
 		if e.ProcessContext.Ancestor == nil {
@@ -9942,6 +10898,20 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.Mode"}
 		}
 		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.Mode = uint16(v)
+		return nil
+
+	case "process.ancestors.file.modification_time":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.MTime"}
+		}
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.MTime = uint64(v)
 		return nil
 
 	case "process.ancestors.file.mount_id":
@@ -10308,6 +11278,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "process.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.CTime"}
+		}
+		e.ProcessContext.Process.FileFields.CTime = uint64(v)
+		return nil
+
 	case "process.file.filesystem":
 
 		var ok bool
@@ -10366,6 +11346,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.Mode"}
 		}
 		e.ProcessContext.Process.FileFields.Mode = uint16(v)
+		return nil
+
+	case "process.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.MTime"}
+		}
+		e.ProcessContext.Process.FileFields.MTime = uint64(v)
 		return nil
 
 	case "process.file.mount_id":
@@ -10556,6 +11546,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "removexattr.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.CTime"}
+		}
+		e.RemoveXAttr.File.FileFields.CTime = uint64(v)
+		return nil
+
 	case "removexattr.file.destination.name":
 
 		var ok bool
@@ -10638,6 +11638,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.RemoveXAttr.File.FileFields.Mode = uint16(v)
 		return nil
 
+	case "removexattr.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.MTime"}
+		}
+		e.RemoveXAttr.File.FileFields.MTime = uint64(v)
+		return nil
+
 	case "removexattr.file.mount_id":
 
 		var ok bool
@@ -10711,6 +11721,26 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.RemoveXAttr.SyscallEvent.Retval = int64(v)
 		return nil
 
+	case "rename.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.CTime"}
+		}
+		e.Rename.Old.FileFields.CTime = uint64(v)
+		return nil
+
+	case "rename.file.destination.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.CTime"}
+		}
+		e.Rename.New.FileFields.CTime = uint64(v)
+		return nil
+
 	case "rename.file.destination.filesystem":
 
 		var ok bool
@@ -10769,6 +11799,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.Mode"}
 		}
 		e.Rename.New.FileFields.Mode = uint16(v)
+		return nil
+
+	case "rename.file.destination.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.MTime"}
+		}
+		e.Rename.New.FileFields.MTime = uint64(v)
 		return nil
 
 	case "rename.file.destination.mount_id":
@@ -10894,6 +11934,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Rename.Old.FileFields.Mode = uint16(v)
 		return nil
 
+	case "rename.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.MTime"}
+		}
+		e.Rename.Old.FileFields.MTime = uint64(v)
+		return nil
+
 	case "rename.file.mount_id":
 
 		var ok bool
@@ -10967,6 +12017,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Rename.SyscallEvent.Retval = int64(v)
 		return nil
 
+	case "rmdir.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.CTime"}
+		}
+		e.Rmdir.File.FileFields.CTime = uint64(v)
+		return nil
+
 	case "rmdir.file.filesystem":
 
 		var ok bool
@@ -11025,6 +12085,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.Mode"}
 		}
 		e.Rmdir.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "rmdir.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.MTime"}
+		}
+		e.Rmdir.File.FileFields.MTime = uint64(v)
 		return nil
 
 	case "rmdir.file.mount_id":
@@ -11267,6 +12337,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "setxattr.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.CTime"}
+		}
+		e.SetXAttr.File.FileFields.CTime = uint64(v)
+		return nil
+
 	case "setxattr.file.destination.name":
 
 		var ok bool
@@ -11349,6 +12429,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.SetXAttr.File.FileFields.Mode = uint16(v)
 		return nil
 
+	case "setxattr.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.MTime"}
+		}
+		e.SetXAttr.File.FileFields.MTime = uint64(v)
+		return nil
+
 	case "setxattr.file.mount_id":
 
 		var ok bool
@@ -11422,6 +12512,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.SetXAttr.SyscallEvent.Retval = int64(v)
 		return nil
 
+	case "unlink.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.CTime"}
+		}
+		e.Unlink.File.FileFields.CTime = uint64(v)
+		return nil
+
 	case "unlink.file.filesystem":
 
 		var ok bool
@@ -11480,6 +12580,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.Mode"}
 		}
 		e.Unlink.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "unlink.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.MTime"}
+		}
+		e.Unlink.File.FileFields.MTime = uint64(v)
 		return nil
 
 	case "unlink.file.mount_id":
@@ -11555,6 +12665,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Unlink.SyscallEvent.Retval = int64(v)
 		return nil
 
+	case "utimes.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.CTime"}
+		}
+		e.Utimes.File.FileFields.CTime = uint64(v)
+		return nil
+
 	case "utimes.file.filesystem":
 
 		var ok bool
@@ -11613,6 +12733,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.Mode"}
 		}
 		e.Utimes.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "utimes.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.MTime"}
+		}
+		e.Utimes.File.FileFields.MTime = uint64(v)
 		return nil
 
 	case "utimes.file.mount_id":

--- a/pkg/security/model/model.go
+++ b/pkg/security/model/model.go
@@ -277,13 +277,13 @@ type ExecEvent struct {
 
 // FileFields holds the information required to identify a file
 type FileFields struct {
-	UID   uint32    `field:"uid"`
-	User  string    `field:"user,ResolveFileFieldsUser"`
-	GID   uint32    `field:"gid"`
-	Group string    `field:"group,ResolveFileFieldsGroup"`
-	Mode  uint16    `field:"mode" field:"rights,ResolveRights"`
-	CTime time.Time `field:"-"`
-	MTime time.Time `field:"-"`
+	UID   uint32 `field:"uid"`
+	User  string `field:"user,ResolveFileFieldsUser"`
+	GID   uint32 `field:"gid"`
+	Group string `field:"group,ResolveFileFieldsGroup"`
+	Mode  uint16 `field:"mode" field:"rights,ResolveRights"`
+	CTime uint64 `field:"change_time"`
+	MTime uint64 `field:"modification_time"`
 
 	MountID      uint32 `field:"mount_id"`
 	Inode        uint64 `field:"inode"`

--- a/pkg/security/model/unmarshallers.go
+++ b/pkg/security/model/unmarshallers.go
@@ -235,11 +235,12 @@ func (e *FileFields) UnmarshalBinary(data []byte) (int, error) {
 
 	timeSec := ByteOrder.Uint64(data[40:48])
 	timeNsec := ByteOrder.Uint64(data[48:56])
-	e.CTime = time.Unix(int64(timeSec), int64(timeNsec))
+	e.CTime = uint64(time.Unix(int64(timeSec), int64(timeNsec)).UnixNano())
 
 	timeSec = ByteOrder.Uint64(data[56:64])
 	timeNsec = ByteOrder.Uint64(data[64:72])
-	e.MTime = time.Unix(int64(timeSec), int64(timeNsec))
+	e.MTime = uint64(time.Unix(int64(timeSec), int64(timeNsec)).UnixNano())
+
 	return 72, nil
 }
 

--- a/pkg/security/probe/accessors.go
+++ b/pkg/security/probe/accessors.go
@@ -88,6 +88,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "chmod.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chmod.File.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "chmod.file.destination.mode":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -168,6 +178,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "chmod.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chmod.File.FileFields.MTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "chmod.file.mount_id":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -233,6 +253,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).Chmod.SyscallEvent.Retval)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chown.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chown.File.FileFields.CTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -333,6 +363,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).Chown.File.FileFields.Mode)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "chown.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Chown.File.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -603,6 +643,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "exec.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Exec.Process.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "exec.file.filesystem":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -658,6 +708,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).Exec.Process.FileFields.Mode)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "exec.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Exec.Process.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -843,6 +903,26 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "link.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Source.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.destination.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Target.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "link.file.destination.filesystem":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -898,6 +978,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).Link.Target.FileFields.Mode)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "link.file.destination.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Target.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -1023,6 +1113,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "link.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Link.Source.FileFields.MTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "link.file.mount_id":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1088,6 +1188,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).Link.SyscallEvent.Retval)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "mkdir.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Mkdir.File.FileFields.CTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -1173,6 +1283,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "mkdir.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Mkdir.File.FileFields.MTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "mkdir.file.mount_id":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1243,6 +1363,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "open.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Open.File.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "open.file.destination.mode":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -1308,6 +1438,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).Open.File.FileFields.Mode)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "open.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Open.File.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -1703,6 +1843,37 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.IteratorWeight,
 		}, nil
 
+	case "process.ancestors.file.change_time":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				if ptr := ctx.Cache[field]; ptr != nil {
+					if result := (*[]int)(ptr); result != nil {
+						return *result
+					}
+				}
+				var results []int
+
+				iterator := &model.ProcessAncestorsIterator{}
+
+				value := iterator.Front(ctx)
+				for value != nil {
+					var result int
+
+					element := (*model.ProcessCacheEntry)(value)
+
+					result = int(element.ProcessContext.Process.FileFields.CTime)
+
+					results = append(results, result)
+
+					value = iterator.Next()
+				}
+				ctx.Cache[field] = unsafe.Pointer(&results)
+
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+
 	case "process.ancestors.file.filesystem":
 		return &eval.StringArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []string {
@@ -1877,6 +2048,37 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					element := (*model.ProcessCacheEntry)(value)
 
 					result = int(element.ProcessContext.Process.FileFields.Mode)
+
+					results = append(results, result)
+
+					value = iterator.Next()
+				}
+				ctx.Cache[field] = unsafe.Pointer(&results)
+
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.file.modification_time":
+		return &eval.IntArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []int {
+				if ptr := ctx.Cache[field]; ptr != nil {
+					if result := (*[]int)(ptr); result != nil {
+						return *result
+					}
+				}
+				var results []int
+
+				iterator := &model.ProcessAncestorsIterator{}
+
+				value := iterator.Front(ctx)
+				for value != nil {
+					var result int
+
+					element := (*model.ProcessCacheEntry)(value)
+
+					result = int(element.ProcessContext.Process.FileFields.MTime)
 
 					results = append(results, result)
 
@@ -2547,6 +2749,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "process.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "process.file.filesystem":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -2602,6 +2814,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.Mode)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "process.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).ProcessContext.Process.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -2787,6 +3009,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "removexattr.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).RemoveXAttr.File.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "removexattr.file.destination.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -2867,6 +3099,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "removexattr.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).RemoveXAttr.File.FileFields.MTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "removexattr.file.mount_id":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -2937,6 +3179,26 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "rename.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.Old.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.destination.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.New.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "rename.file.destination.filesystem":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -2992,6 +3254,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).Rename.New.FileFields.Mode)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rename.file.destination.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.New.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3117,6 +3389,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "rename.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rename.Old.FileFields.MTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "rename.file.mount_id":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -3187,6 +3469,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "rmdir.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rmdir.File.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "rmdir.file.filesystem":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -3242,6 +3534,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).Rmdir.File.FileFields.Mode)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "rmdir.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Rmdir.File.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3477,6 +3779,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.HandlerWeight,
 		}, nil
 
+	case "setxattr.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).SetXAttr.File.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "setxattr.file.destination.name":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -3557,6 +3869,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "setxattr.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).SetXAttr.File.FileFields.MTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "setxattr.file.mount_id":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -3627,6 +3949,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "unlink.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Unlink.File.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "unlink.file.filesystem":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -3682,6 +4014,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).Unlink.File.FileFields.Mode)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "unlink.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Unlink.File.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3757,6 +4099,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "utimes.file.change_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Utimes.File.FileFields.CTime)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "utimes.file.filesystem":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
@@ -3812,6 +4164,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).Utimes.File.FileFields.Mode)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "utimes.file.modification_time":
+		return &eval.IntEvaluator{
+			EvalFnc: func(ctx *eval.Context) int {
+
+				return int((*Event)(ctx.Object).Utimes.File.FileFields.MTime)
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -3899,6 +4261,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"capset.cap_permitted",
 
+		"chmod.file.change_time",
+
 		"chmod.file.destination.mode",
 
 		"chmod.file.destination.rights",
@@ -3915,6 +4279,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"chmod.file.mode",
 
+		"chmod.file.modification_time",
+
 		"chmod.file.mount_id",
 
 		"chmod.file.name",
@@ -3928,6 +4294,8 @@ func (e *Event) GetFields() []eval.Field {
 		"chmod.file.user",
 
 		"chmod.retval",
+
+		"chown.file.change_time",
 
 		"chown.file.destination.gid",
 
@@ -3948,6 +4316,8 @@ func (e *Event) GetFields() []eval.Field {
 		"chown.file.inode",
 
 		"chown.file.mode",
+
+		"chown.file.modification_time",
 
 		"chown.file.mount_id",
 
@@ -4001,6 +4371,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"exec.euser",
 
+		"exec.file.change_time",
+
 		"exec.file.filesystem",
 
 		"exec.file.gid",
@@ -4012,6 +4384,8 @@ func (e *Event) GetFields() []eval.Field {
 		"exec.file.inode",
 
 		"exec.file.mode",
+
+		"exec.file.modification_time",
 
 		"exec.file.mount_id",
 
@@ -4049,6 +4423,10 @@ func (e *Event) GetFields() []eval.Field {
 
 		"exec.user",
 
+		"link.file.change_time",
+
+		"link.file.destination.change_time",
+
 		"link.file.destination.filesystem",
 
 		"link.file.destination.gid",
@@ -4060,6 +4438,8 @@ func (e *Event) GetFields() []eval.Field {
 		"link.file.destination.inode",
 
 		"link.file.destination.mode",
+
+		"link.file.destination.modification_time",
 
 		"link.file.destination.mount_id",
 
@@ -4085,6 +4465,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"link.file.mode",
 
+		"link.file.modification_time",
+
 		"link.file.mount_id",
 
 		"link.file.name",
@@ -4098,6 +4480,8 @@ func (e *Event) GetFields() []eval.Field {
 		"link.file.user",
 
 		"link.retval",
+
+		"mkdir.file.change_time",
 
 		"mkdir.file.destination.mode",
 
@@ -4115,6 +4499,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"mkdir.file.mode",
 
+		"mkdir.file.modification_time",
+
 		"mkdir.file.mount_id",
 
 		"mkdir.file.name",
@@ -4129,6 +4515,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"mkdir.retval",
 
+		"open.file.change_time",
+
 		"open.file.destination.mode",
 
 		"open.file.filesystem",
@@ -4142,6 +4530,8 @@ func (e *Event) GetFields() []eval.Field {
 		"open.file.inode",
 
 		"open.file.mode",
+
+		"open.file.modification_time",
 
 		"open.file.mount_id",
 
@@ -4179,6 +4569,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"process.ancestors.euser",
 
+		"process.ancestors.file.change_time",
+
 		"process.ancestors.file.filesystem",
 
 		"process.ancestors.file.gid",
@@ -4190,6 +4582,8 @@ func (e *Event) GetFields() []eval.Field {
 		"process.ancestors.file.inode",
 
 		"process.ancestors.file.mode",
+
+		"process.ancestors.file.modification_time",
 
 		"process.ancestors.file.mount_id",
 
@@ -4247,6 +4641,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"process.euser",
 
+		"process.file.change_time",
+
 		"process.file.filesystem",
 
 		"process.file.gid",
@@ -4258,6 +4654,8 @@ func (e *Event) GetFields() []eval.Field {
 		"process.file.inode",
 
 		"process.file.mode",
+
+		"process.file.modification_time",
 
 		"process.file.mount_id",
 
@@ -4295,6 +4693,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"process.user",
 
+		"removexattr.file.change_time",
+
 		"removexattr.file.destination.name",
 
 		"removexattr.file.destination.namespace",
@@ -4311,6 +4711,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"removexattr.file.mode",
 
+		"removexattr.file.modification_time",
+
 		"removexattr.file.mount_id",
 
 		"removexattr.file.name",
@@ -4325,6 +4727,10 @@ func (e *Event) GetFields() []eval.Field {
 
 		"removexattr.retval",
 
+		"rename.file.change_time",
+
+		"rename.file.destination.change_time",
+
 		"rename.file.destination.filesystem",
 
 		"rename.file.destination.gid",
@@ -4336,6 +4742,8 @@ func (e *Event) GetFields() []eval.Field {
 		"rename.file.destination.inode",
 
 		"rename.file.destination.mode",
+
+		"rename.file.destination.modification_time",
 
 		"rename.file.destination.mount_id",
 
@@ -4361,6 +4769,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"rename.file.mode",
 
+		"rename.file.modification_time",
+
 		"rename.file.mount_id",
 
 		"rename.file.name",
@@ -4375,6 +4785,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"rename.retval",
 
+		"rmdir.file.change_time",
+
 		"rmdir.file.filesystem",
 
 		"rmdir.file.gid",
@@ -4386,6 +4798,8 @@ func (e *Event) GetFields() []eval.Field {
 		"rmdir.file.inode",
 
 		"rmdir.file.mode",
+
+		"rmdir.file.modification_time",
 
 		"rmdir.file.mount_id",
 
@@ -4433,6 +4847,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"setuid.user",
 
+		"setxattr.file.change_time",
+
 		"setxattr.file.destination.name",
 
 		"setxattr.file.destination.namespace",
@@ -4449,6 +4865,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"setxattr.file.mode",
 
+		"setxattr.file.modification_time",
+
 		"setxattr.file.mount_id",
 
 		"setxattr.file.name",
@@ -4463,6 +4881,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"setxattr.retval",
 
+		"unlink.file.change_time",
+
 		"unlink.file.filesystem",
 
 		"unlink.file.gid",
@@ -4474,6 +4894,8 @@ func (e *Event) GetFields() []eval.Field {
 		"unlink.file.inode",
 
 		"unlink.file.mode",
+
+		"unlink.file.modification_time",
 
 		"unlink.file.mount_id",
 
@@ -4489,6 +4911,8 @@ func (e *Event) GetFields() []eval.Field {
 
 		"unlink.retval",
 
+		"utimes.file.change_time",
+
 		"utimes.file.filesystem",
 
 		"utimes.file.gid",
@@ -4500,6 +4924,8 @@ func (e *Event) GetFields() []eval.Field {
 		"utimes.file.inode",
 
 		"utimes.file.mode",
+
+		"utimes.file.modification_time",
 
 		"utimes.file.mount_id",
 
@@ -4527,6 +4953,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "capset.cap_permitted":
 
 		return int(e.Capset.CapPermitted), nil
+
+	case "chmod.file.change_time":
+
+		return int(e.Chmod.File.FileFields.CTime), nil
 
 	case "chmod.file.destination.mode":
 
@@ -4560,6 +4990,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.Chmod.File.FileFields.Mode), nil
 
+	case "chmod.file.modification_time":
+
+		return int(e.Chmod.File.FileFields.MTime), nil
+
 	case "chmod.file.mount_id":
 
 		return int(e.Chmod.File.FileFields.MountID), nil
@@ -4587,6 +5021,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "chmod.retval":
 
 		return int(e.Chmod.SyscallEvent.Retval), nil
+
+	case "chown.file.change_time":
+
+		return int(e.Chown.File.FileFields.CTime), nil
 
 	case "chown.file.destination.gid":
 
@@ -4627,6 +5065,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "chown.file.mode":
 
 		return int(e.Chown.File.FileFields.Mode), nil
+
+	case "chown.file.modification_time":
+
+		return int(e.Chown.File.FileFields.MTime), nil
 
 	case "chown.file.mount_id":
 
@@ -4732,6 +5174,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Exec.Process.Credentials.EUser, nil
 
+	case "exec.file.change_time":
+
+		return int(e.Exec.Process.FileFields.CTime), nil
+
 	case "exec.file.filesystem":
 
 		return e.Exec.Process.Filesystem, nil
@@ -4755,6 +5201,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "exec.file.mode":
 
 		return int(e.Exec.Process.FileFields.Mode), nil
+
+	case "exec.file.modification_time":
+
+		return int(e.Exec.Process.FileFields.MTime), nil
 
 	case "exec.file.mount_id":
 
@@ -4828,6 +5278,14 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.Exec.Process.Credentials.User, nil
 
+	case "link.file.change_time":
+
+		return int(e.Link.Source.FileFields.CTime), nil
+
+	case "link.file.destination.change_time":
+
+		return int(e.Link.Target.FileFields.CTime), nil
+
 	case "link.file.destination.filesystem":
 
 		return e.ResolveFileFilesystem(&e.Link.Target), nil
@@ -4851,6 +5309,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "link.file.destination.mode":
 
 		return int(e.Link.Target.FileFields.Mode), nil
+
+	case "link.file.destination.modification_time":
+
+		return int(e.Link.Target.FileFields.MTime), nil
 
 	case "link.file.destination.mount_id":
 
@@ -4900,6 +5362,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.Link.Source.FileFields.Mode), nil
 
+	case "link.file.modification_time":
+
+		return int(e.Link.Source.FileFields.MTime), nil
+
 	case "link.file.mount_id":
 
 		return int(e.Link.Source.FileFields.MountID), nil
@@ -4927,6 +5393,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "link.retval":
 
 		return int(e.Link.SyscallEvent.Retval), nil
+
+	case "mkdir.file.change_time":
+
+		return int(e.Mkdir.File.FileFields.CTime), nil
 
 	case "mkdir.file.destination.mode":
 
@@ -4960,6 +5430,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.Mkdir.File.FileFields.Mode), nil
 
+	case "mkdir.file.modification_time":
+
+		return int(e.Mkdir.File.FileFields.MTime), nil
+
 	case "mkdir.file.mount_id":
 
 		return int(e.Mkdir.File.FileFields.MountID), nil
@@ -4988,6 +5462,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.Mkdir.SyscallEvent.Retval), nil
 
+	case "open.file.change_time":
+
+		return int(e.Open.File.FileFields.CTime), nil
+
 	case "open.file.destination.mode":
 
 		return int(e.Open.Mode), nil
@@ -5015,6 +5493,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "open.file.mode":
 
 		return int(e.Open.File.FileFields.Mode), nil
+
+	case "open.file.modification_time":
+
+		return int(e.Open.File.FileFields.MTime), nil
 
 	case "open.file.mount_id":
 
@@ -5268,6 +5750,28 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return values, nil
 
+	case "process.ancestors.file.change_time":
+
+		var values []int
+
+		ctx := eval.NewContext(unsafe.Pointer(e))
+
+		iterator := &model.ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*model.ProcessCacheEntry)(ptr)
+
+			result := int(element.ProcessContext.Process.FileFields.CTime)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
 	case "process.ancestors.file.filesystem":
 
 		var values []string
@@ -5392,6 +5896,28 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 			element := (*model.ProcessCacheEntry)(ptr)
 
 			result := int(element.ProcessContext.Process.FileFields.Mode)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.file.modification_time":
+
+		var values []int
+
+		ctx := eval.NewContext(unsafe.Pointer(e))
+
+		iterator := &model.ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*model.ProcessCacheEntry)(ptr)
+
+			result := int(element.ProcessContext.Process.FileFields.MTime)
 
 			values = append(values, result)
 
@@ -5836,6 +6362,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ProcessContext.Process.Credentials.EUser, nil
 
+	case "process.file.change_time":
+
+		return int(e.ProcessContext.Process.FileFields.CTime), nil
+
 	case "process.file.filesystem":
 
 		return e.ProcessContext.Process.Filesystem, nil
@@ -5859,6 +6389,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "process.file.mode":
 
 		return int(e.ProcessContext.Process.FileFields.Mode), nil
+
+	case "process.file.modification_time":
+
+		return int(e.ProcessContext.Process.FileFields.MTime), nil
 
 	case "process.file.mount_id":
 
@@ -5932,6 +6466,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ProcessContext.Process.Credentials.User, nil
 
+	case "removexattr.file.change_time":
+
+		return int(e.RemoveXAttr.File.FileFields.CTime), nil
+
 	case "removexattr.file.destination.name":
 
 		return e.ResolveXAttrName(&e.RemoveXAttr), nil
@@ -5964,6 +6502,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.RemoveXAttr.File.FileFields.Mode), nil
 
+	case "removexattr.file.modification_time":
+
+		return int(e.RemoveXAttr.File.FileFields.MTime), nil
+
 	case "removexattr.file.mount_id":
 
 		return int(e.RemoveXAttr.File.FileFields.MountID), nil
@@ -5992,6 +6534,14 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.RemoveXAttr.SyscallEvent.Retval), nil
 
+	case "rename.file.change_time":
+
+		return int(e.Rename.Old.FileFields.CTime), nil
+
+	case "rename.file.destination.change_time":
+
+		return int(e.Rename.New.FileFields.CTime), nil
+
 	case "rename.file.destination.filesystem":
 
 		return e.ResolveFileFilesystem(&e.Rename.New), nil
@@ -6015,6 +6565,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "rename.file.destination.mode":
 
 		return int(e.Rename.New.FileFields.Mode), nil
+
+	case "rename.file.destination.modification_time":
+
+		return int(e.Rename.New.FileFields.MTime), nil
 
 	case "rename.file.destination.mount_id":
 
@@ -6064,6 +6618,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.Rename.Old.FileFields.Mode), nil
 
+	case "rename.file.modification_time":
+
+		return int(e.Rename.Old.FileFields.MTime), nil
+
 	case "rename.file.mount_id":
 
 		return int(e.Rename.Old.FileFields.MountID), nil
@@ -6092,6 +6650,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.Rename.SyscallEvent.Retval), nil
 
+	case "rmdir.file.change_time":
+
+		return int(e.Rmdir.File.FileFields.CTime), nil
+
 	case "rmdir.file.filesystem":
 
 		return e.ResolveFileFilesystem(&e.Rmdir.File), nil
@@ -6115,6 +6677,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "rmdir.file.mode":
 
 		return int(e.Rmdir.File.FileFields.Mode), nil
+
+	case "rmdir.file.modification_time":
+
+		return int(e.Rmdir.File.FileFields.MTime), nil
 
 	case "rmdir.file.mount_id":
 
@@ -6208,6 +6774,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return e.ResolveSetuidUser(&e.SetUID), nil
 
+	case "setxattr.file.change_time":
+
+		return int(e.SetXAttr.File.FileFields.CTime), nil
+
 	case "setxattr.file.destination.name":
 
 		return e.ResolveXAttrName(&e.SetXAttr), nil
@@ -6240,6 +6810,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.SetXAttr.File.FileFields.Mode), nil
 
+	case "setxattr.file.modification_time":
+
+		return int(e.SetXAttr.File.FileFields.MTime), nil
+
 	case "setxattr.file.mount_id":
 
 		return int(e.SetXAttr.File.FileFields.MountID), nil
@@ -6268,6 +6842,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.SetXAttr.SyscallEvent.Retval), nil
 
+	case "unlink.file.change_time":
+
+		return int(e.Unlink.File.FileFields.CTime), nil
+
 	case "unlink.file.filesystem":
 
 		return e.ResolveFileFilesystem(&e.Unlink.File), nil
@@ -6291,6 +6869,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "unlink.file.mode":
 
 		return int(e.Unlink.File.FileFields.Mode), nil
+
+	case "unlink.file.modification_time":
+
+		return int(e.Unlink.File.FileFields.MTime), nil
 
 	case "unlink.file.mount_id":
 
@@ -6320,6 +6902,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.Unlink.SyscallEvent.Retval), nil
 
+	case "utimes.file.change_time":
+
+		return int(e.Utimes.File.FileFields.CTime), nil
+
 	case "utimes.file.filesystem":
 
 		return e.ResolveFileFilesystem(&e.Utimes.File), nil
@@ -6343,6 +6929,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "utimes.file.mode":
 
 		return int(e.Utimes.File.FileFields.Mode), nil
+
+	case "utimes.file.modification_time":
+
+		return int(e.Utimes.File.FileFields.MTime), nil
 
 	case "utimes.file.mount_id":
 
@@ -6386,6 +6976,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "capset.cap_permitted":
 		return "capset", nil
 
+	case "chmod.file.change_time":
+		return "chmod", nil
+
 	case "chmod.file.destination.mode":
 		return "chmod", nil
 
@@ -6410,6 +7003,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "chmod.file.mode":
 		return "chmod", nil
 
+	case "chmod.file.modification_time":
+		return "chmod", nil
+
 	case "chmod.file.mount_id":
 		return "chmod", nil
 
@@ -6430,6 +7026,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 
 	case "chmod.retval":
 		return "chmod", nil
+
+	case "chown.file.change_time":
+		return "chown", nil
 
 	case "chown.file.destination.gid":
 		return "chown", nil
@@ -6459,6 +7058,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "chown", nil
 
 	case "chown.file.mode":
+		return "chown", nil
+
+	case "chown.file.modification_time":
 		return "chown", nil
 
 	case "chown.file.mount_id":
@@ -6539,6 +7141,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "exec.euser":
 		return "exec", nil
 
+	case "exec.file.change_time":
+		return "exec", nil
+
 	case "exec.file.filesystem":
 		return "exec", nil
 
@@ -6555,6 +7160,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "exec", nil
 
 	case "exec.file.mode":
+		return "exec", nil
+
+	case "exec.file.modification_time":
 		return "exec", nil
 
 	case "exec.file.mount_id":
@@ -6611,6 +7219,12 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "exec.user":
 		return "exec", nil
 
+	case "link.file.change_time":
+		return "link", nil
+
+	case "link.file.destination.change_time":
+		return "link", nil
+
 	case "link.file.destination.filesystem":
 		return "link", nil
 
@@ -6627,6 +7241,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "link", nil
 
 	case "link.file.destination.mode":
+		return "link", nil
+
+	case "link.file.destination.modification_time":
 		return "link", nil
 
 	case "link.file.destination.mount_id":
@@ -6665,6 +7282,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "link.file.mode":
 		return "link", nil
 
+	case "link.file.modification_time":
+		return "link", nil
+
 	case "link.file.mount_id":
 		return "link", nil
 
@@ -6685,6 +7305,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 
 	case "link.retval":
 		return "link", nil
+
+	case "mkdir.file.change_time":
+		return "mkdir", nil
 
 	case "mkdir.file.destination.mode":
 		return "mkdir", nil
@@ -6710,6 +7333,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "mkdir.file.mode":
 		return "mkdir", nil
 
+	case "mkdir.file.modification_time":
+		return "mkdir", nil
+
 	case "mkdir.file.mount_id":
 		return "mkdir", nil
 
@@ -6731,6 +7357,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "mkdir.retval":
 		return "mkdir", nil
 
+	case "open.file.change_time":
+		return "open", nil
+
 	case "open.file.destination.mode":
 		return "open", nil
 
@@ -6750,6 +7379,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "open", nil
 
 	case "open.file.mode":
+		return "open", nil
+
+	case "open.file.modification_time":
 		return "open", nil
 
 	case "open.file.mount_id":
@@ -6806,6 +7438,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "process.ancestors.euser":
 		return "*", nil
 
+	case "process.ancestors.file.change_time":
+		return "*", nil
+
 	case "process.ancestors.file.filesystem":
 		return "*", nil
 
@@ -6822,6 +7457,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 
 	case "process.ancestors.file.mode":
+		return "*", nil
+
+	case "process.ancestors.file.modification_time":
 		return "*", nil
 
 	case "process.ancestors.file.mount_id":
@@ -6908,6 +7546,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "process.euser":
 		return "*", nil
 
+	case "process.file.change_time":
+		return "*", nil
+
 	case "process.file.filesystem":
 		return "*", nil
 
@@ -6924,6 +7565,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 
 	case "process.file.mode":
+		return "*", nil
+
+	case "process.file.modification_time":
 		return "*", nil
 
 	case "process.file.mount_id":
@@ -6980,6 +7624,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "process.user":
 		return "*", nil
 
+	case "removexattr.file.change_time":
+		return "removexattr", nil
+
 	case "removexattr.file.destination.name":
 		return "removexattr", nil
 
@@ -7004,6 +7651,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "removexattr.file.mode":
 		return "removexattr", nil
 
+	case "removexattr.file.modification_time":
+		return "removexattr", nil
+
 	case "removexattr.file.mount_id":
 		return "removexattr", nil
 
@@ -7025,6 +7675,12 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "removexattr.retval":
 		return "removexattr", nil
 
+	case "rename.file.change_time":
+		return "rename", nil
+
+	case "rename.file.destination.change_time":
+		return "rename", nil
+
 	case "rename.file.destination.filesystem":
 		return "rename", nil
 
@@ -7041,6 +7697,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "rename", nil
 
 	case "rename.file.destination.mode":
+		return "rename", nil
+
+	case "rename.file.destination.modification_time":
 		return "rename", nil
 
 	case "rename.file.destination.mount_id":
@@ -7079,6 +7738,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "rename.file.mode":
 		return "rename", nil
 
+	case "rename.file.modification_time":
+		return "rename", nil
+
 	case "rename.file.mount_id":
 		return "rename", nil
 
@@ -7100,6 +7762,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "rename.retval":
 		return "rename", nil
 
+	case "rmdir.file.change_time":
+		return "rmdir", nil
+
 	case "rmdir.file.filesystem":
 		return "rmdir", nil
 
@@ -7116,6 +7781,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "rmdir", nil
 
 	case "rmdir.file.mode":
+		return "rmdir", nil
+
+	case "rmdir.file.modification_time":
 		return "rmdir", nil
 
 	case "rmdir.file.mount_id":
@@ -7187,6 +7855,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "setuid.user":
 		return "setuid", nil
 
+	case "setxattr.file.change_time":
+		return "setxattr", nil
+
 	case "setxattr.file.destination.name":
 		return "setxattr", nil
 
@@ -7211,6 +7882,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "setxattr.file.mode":
 		return "setxattr", nil
 
+	case "setxattr.file.modification_time":
+		return "setxattr", nil
+
 	case "setxattr.file.mount_id":
 		return "setxattr", nil
 
@@ -7232,6 +7906,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "setxattr.retval":
 		return "setxattr", nil
 
+	case "unlink.file.change_time":
+		return "unlink", nil
+
 	case "unlink.file.filesystem":
 		return "unlink", nil
 
@@ -7248,6 +7925,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "unlink", nil
 
 	case "unlink.file.mode":
+		return "unlink", nil
+
+	case "unlink.file.modification_time":
 		return "unlink", nil
 
 	case "unlink.file.mount_id":
@@ -7271,6 +7951,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "unlink.retval":
 		return "unlink", nil
 
+	case "utimes.file.change_time":
+		return "utimes", nil
+
 	case "utimes.file.filesystem":
 		return "utimes", nil
 
@@ -7287,6 +7970,9 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "utimes", nil
 
 	case "utimes.file.mode":
+		return "utimes", nil
+
+	case "utimes.file.modification_time":
 		return "utimes", nil
 
 	case "utimes.file.mount_id":
@@ -7326,6 +8012,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "chmod.file.change_time":
+
+		return reflect.Int, nil
+
 	case "chmod.file.destination.mode":
 
 		return reflect.Int, nil
@@ -7358,6 +8048,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "chmod.file.modification_time":
+
+		return reflect.Int, nil
+
 	case "chmod.file.mount_id":
 
 		return reflect.Int, nil
@@ -7383,6 +8077,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 
 	case "chmod.retval":
+
+		return reflect.Int, nil
+
+	case "chown.file.change_time":
 
 		return reflect.Int, nil
 
@@ -7423,6 +8121,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 
 	case "chown.file.mode":
+
+		return reflect.Int, nil
+
+	case "chown.file.modification_time":
 
 		return reflect.Int, nil
 
@@ -7530,6 +8232,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "exec.file.change_time":
+
+		return reflect.Int, nil
+
 	case "exec.file.filesystem":
 
 		return reflect.String, nil
@@ -7551,6 +8257,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 
 	case "exec.file.mode":
+
+		return reflect.Int, nil
+
+	case "exec.file.modification_time":
 
 		return reflect.Int, nil
 
@@ -7626,6 +8336,14 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "link.file.change_time":
+
+		return reflect.Int, nil
+
+	case "link.file.destination.change_time":
+
+		return reflect.Int, nil
+
 	case "link.file.destination.filesystem":
 
 		return reflect.String, nil
@@ -7647,6 +8365,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 
 	case "link.file.destination.mode":
+
+		return reflect.Int, nil
+
+	case "link.file.destination.modification_time":
 
 		return reflect.Int, nil
 
@@ -7698,6 +8420,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "link.file.modification_time":
+
+		return reflect.Int, nil
+
 	case "link.file.mount_id":
 
 		return reflect.Int, nil
@@ -7723,6 +8449,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.String, nil
 
 	case "link.retval":
+
+		return reflect.Int, nil
+
+	case "mkdir.file.change_time":
 
 		return reflect.Int, nil
 
@@ -7758,6 +8488,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "mkdir.file.modification_time":
+
+		return reflect.Int, nil
+
 	case "mkdir.file.mount_id":
 
 		return reflect.Int, nil
@@ -7786,6 +8520,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "open.file.change_time":
+
+		return reflect.Int, nil
+
 	case "open.file.destination.mode":
 
 		return reflect.Int, nil
@@ -7811,6 +8549,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 
 	case "open.file.mode":
+
+		return reflect.Int, nil
+
+	case "open.file.modification_time":
 
 		return reflect.Int, nil
 
@@ -7886,6 +8628,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "process.ancestors.file.change_time":
+
+		return reflect.Int, nil
+
 	case "process.ancestors.file.filesystem":
 
 		return reflect.String, nil
@@ -7907,6 +8653,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 
 	case "process.ancestors.file.mode":
+
+		return reflect.Int, nil
+
+	case "process.ancestors.file.modification_time":
 
 		return reflect.Int, nil
 
@@ -8022,6 +8772,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "process.file.change_time":
+
+		return reflect.Int, nil
+
 	case "process.file.filesystem":
 
 		return reflect.String, nil
@@ -8043,6 +8797,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 
 	case "process.file.mode":
+
+		return reflect.Int, nil
+
+	case "process.file.modification_time":
 
 		return reflect.Int, nil
 
@@ -8118,6 +8876,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "removexattr.file.change_time":
+
+		return reflect.Int, nil
+
 	case "removexattr.file.destination.name":
 
 		return reflect.String, nil
@@ -8150,6 +8912,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "removexattr.file.modification_time":
+
+		return reflect.Int, nil
+
 	case "removexattr.file.mount_id":
 
 		return reflect.Int, nil
@@ -8178,6 +8944,14 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "rename.file.change_time":
+
+		return reflect.Int, nil
+
+	case "rename.file.destination.change_time":
+
+		return reflect.Int, nil
+
 	case "rename.file.destination.filesystem":
 
 		return reflect.String, nil
@@ -8199,6 +8973,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 
 	case "rename.file.destination.mode":
+
+		return reflect.Int, nil
+
+	case "rename.file.destination.modification_time":
 
 		return reflect.Int, nil
 
@@ -8250,6 +9028,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "rename.file.modification_time":
+
+		return reflect.Int, nil
+
 	case "rename.file.mount_id":
 
 		return reflect.Int, nil
@@ -8278,6 +9060,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "rmdir.file.change_time":
+
+		return reflect.Int, nil
+
 	case "rmdir.file.filesystem":
 
 		return reflect.String, nil
@@ -8299,6 +9085,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 
 	case "rmdir.file.mode":
+
+		return reflect.Int, nil
+
+	case "rmdir.file.modification_time":
 
 		return reflect.Int, nil
 
@@ -8394,6 +9184,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "setxattr.file.change_time":
+
+		return reflect.Int, nil
+
 	case "setxattr.file.destination.name":
 
 		return reflect.String, nil
@@ -8426,6 +9220,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "setxattr.file.modification_time":
+
+		return reflect.Int, nil
+
 	case "setxattr.file.mount_id":
 
 		return reflect.Int, nil
@@ -8454,6 +9252,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "unlink.file.change_time":
+
+		return reflect.Int, nil
+
 	case "unlink.file.filesystem":
 
 		return reflect.String, nil
@@ -8475,6 +9277,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 
 	case "unlink.file.mode":
+
+		return reflect.Int, nil
+
+	case "unlink.file.modification_time":
 
 		return reflect.Int, nil
 
@@ -8506,6 +9312,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "utimes.file.change_time":
+
+		return reflect.Int, nil
+
 	case "utimes.file.filesystem":
 
 		return reflect.String, nil
@@ -8527,6 +9337,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 		return reflect.Int, nil
 
 	case "utimes.file.mode":
+
+		return reflect.Int, nil
+
+	case "utimes.file.modification_time":
 
 		return reflect.Int, nil
 
@@ -8584,6 +9398,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Capset.CapPermitted"}
 		}
 		e.Capset.CapPermitted = uint64(v)
+		return nil
+
+	case "chmod.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.CTime"}
+		}
+		e.Chmod.File.FileFields.CTime = uint64(v)
 		return nil
 
 	case "chmod.file.destination.mode":
@@ -8666,6 +9490,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Chmod.File.FileFields.Mode = uint16(v)
 		return nil
 
+	case "chmod.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chmod.File.FileFields.MTime"}
+		}
+		e.Chmod.File.FileFields.MTime = uint64(v)
+		return nil
+
 	case "chmod.file.mount_id":
 
 		var ok bool
@@ -8737,6 +9571,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Chmod.SyscallEvent.Retval"}
 		}
 		e.Chmod.SyscallEvent.Retval = int64(v)
+		return nil
+
+	case "chown.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.CTime"}
+		}
+		e.Chown.File.FileFields.CTime = uint64(v)
 		return nil
 
 	case "chown.file.destination.gid":
@@ -8839,6 +9683,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.Mode"}
 		}
 		e.Chown.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "chown.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Chown.File.FileFields.MTime"}
+		}
+		e.Chown.File.FileFields.MTime = uint64(v)
 		return nil
 
 	case "chown.file.mount_id":
@@ -9111,6 +9965,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "exec.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.CTime"}
+		}
+		e.Exec.Process.FileFields.CTime = uint64(v)
+		return nil
+
 	case "exec.file.filesystem":
 
 		var ok bool
@@ -9169,6 +10033,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.Mode"}
 		}
 		e.Exec.Process.FileFields.Mode = uint16(v)
+		return nil
+
+	case "exec.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.FileFields.MTime"}
+		}
+		e.Exec.Process.FileFields.MTime = uint64(v)
 		return nil
 
 	case "exec.file.mount_id":
@@ -9359,6 +10233,26 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "link.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.CTime"}
+		}
+		e.Link.Source.FileFields.CTime = uint64(v)
+		return nil
+
+	case "link.file.destination.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.CTime"}
+		}
+		e.Link.Target.FileFields.CTime = uint64(v)
+		return nil
+
 	case "link.file.destination.filesystem":
 
 		var ok bool
@@ -9417,6 +10311,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.Mode"}
 		}
 		e.Link.Target.FileFields.Mode = uint16(v)
+		return nil
+
+	case "link.file.destination.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Target.FileFields.MTime"}
+		}
+		e.Link.Target.FileFields.MTime = uint64(v)
 		return nil
 
 	case "link.file.destination.mount_id":
@@ -9542,6 +10446,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Link.Source.FileFields.Mode = uint16(v)
 		return nil
 
+	case "link.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Link.Source.FileFields.MTime"}
+		}
+		e.Link.Source.FileFields.MTime = uint64(v)
+		return nil
+
 	case "link.file.mount_id":
 
 		var ok bool
@@ -9613,6 +10527,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Link.SyscallEvent.Retval"}
 		}
 		e.Link.SyscallEvent.Retval = int64(v)
+		return nil
+
+	case "mkdir.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.CTime"}
+		}
+		e.Mkdir.File.FileFields.CTime = uint64(v)
 		return nil
 
 	case "mkdir.file.destination.mode":
@@ -9695,6 +10619,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Mkdir.File.FileFields.Mode = uint16(v)
 		return nil
 
+	case "mkdir.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Mkdir.File.FileFields.MTime"}
+		}
+		e.Mkdir.File.FileFields.MTime = uint64(v)
+		return nil
+
 	case "mkdir.file.mount_id":
 
 		var ok bool
@@ -9768,6 +10702,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Mkdir.SyscallEvent.Retval = int64(v)
 		return nil
 
+	case "open.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.CTime"}
+		}
+		e.Open.File.FileFields.CTime = uint64(v)
+		return nil
+
 	case "open.file.destination.mode":
 
 		var ok bool
@@ -9836,6 +10780,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.Mode"}
 		}
 		e.Open.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "open.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Open.File.FileFields.MTime"}
+		}
+		e.Open.File.FileFields.MTime = uint64(v)
 		return nil
 
 	case "open.file.mount_id":
@@ -10065,6 +11019,20 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "process.ancestors.file.change_time":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &model.ProcessCacheEntry{}
+		}
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.CTime"}
+		}
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.CTime = uint64(v)
+		return nil
+
 	case "process.ancestors.file.filesystem":
 
 		if e.ProcessContext.Ancestor == nil {
@@ -10147,6 +11115,20 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.Mode"}
 		}
 		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.Mode = uint16(v)
+		return nil
+
+	case "process.ancestors.file.modification_time":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &model.ProcessCacheEntry{}
+		}
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.FileFields.MTime"}
+		}
+		e.ProcessContext.Ancestor.ProcessContext.Process.FileFields.MTime = uint64(v)
 		return nil
 
 	case "process.ancestors.file.mount_id":
@@ -10513,6 +11495,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "process.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.CTime"}
+		}
+		e.ProcessContext.Process.FileFields.CTime = uint64(v)
+		return nil
+
 	case "process.file.filesystem":
 
 		var ok bool
@@ -10571,6 +11563,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.Mode"}
 		}
 		e.ProcessContext.Process.FileFields.Mode = uint16(v)
+		return nil
+
+	case "process.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.FileFields.MTime"}
+		}
+		e.ProcessContext.Process.FileFields.MTime = uint64(v)
 		return nil
 
 	case "process.file.mount_id":
@@ -10761,6 +11763,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "removexattr.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.CTime"}
+		}
+		e.RemoveXAttr.File.FileFields.CTime = uint64(v)
+		return nil
+
 	case "removexattr.file.destination.name":
 
 		var ok bool
@@ -10843,6 +11855,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.RemoveXAttr.File.FileFields.Mode = uint16(v)
 		return nil
 
+	case "removexattr.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "RemoveXAttr.File.FileFields.MTime"}
+		}
+		e.RemoveXAttr.File.FileFields.MTime = uint64(v)
+		return nil
+
 	case "removexattr.file.mount_id":
 
 		var ok bool
@@ -10916,6 +11938,26 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.RemoveXAttr.SyscallEvent.Retval = int64(v)
 		return nil
 
+	case "rename.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.CTime"}
+		}
+		e.Rename.Old.FileFields.CTime = uint64(v)
+		return nil
+
+	case "rename.file.destination.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.CTime"}
+		}
+		e.Rename.New.FileFields.CTime = uint64(v)
+		return nil
+
 	case "rename.file.destination.filesystem":
 
 		var ok bool
@@ -10974,6 +12016,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.Mode"}
 		}
 		e.Rename.New.FileFields.Mode = uint16(v)
+		return nil
+
+	case "rename.file.destination.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.New.FileFields.MTime"}
+		}
+		e.Rename.New.FileFields.MTime = uint64(v)
 		return nil
 
 	case "rename.file.destination.mount_id":
@@ -11099,6 +12151,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Rename.Old.FileFields.Mode = uint16(v)
 		return nil
 
+	case "rename.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rename.Old.FileFields.MTime"}
+		}
+		e.Rename.Old.FileFields.MTime = uint64(v)
+		return nil
+
 	case "rename.file.mount_id":
 
 		var ok bool
@@ -11172,6 +12234,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Rename.SyscallEvent.Retval = int64(v)
 		return nil
 
+	case "rmdir.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.CTime"}
+		}
+		e.Rmdir.File.FileFields.CTime = uint64(v)
+		return nil
+
 	case "rmdir.file.filesystem":
 
 		var ok bool
@@ -11230,6 +12302,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.Mode"}
 		}
 		e.Rmdir.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "rmdir.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Rmdir.File.FileFields.MTime"}
+		}
+		e.Rmdir.File.FileFields.MTime = uint64(v)
 		return nil
 
 	case "rmdir.file.mount_id":
@@ -11472,6 +12554,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "setxattr.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.CTime"}
+		}
+		e.SetXAttr.File.FileFields.CTime = uint64(v)
+		return nil
+
 	case "setxattr.file.destination.name":
 
 		var ok bool
@@ -11554,6 +12646,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.SetXAttr.File.FileFields.Mode = uint16(v)
 		return nil
 
+	case "setxattr.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "SetXAttr.File.FileFields.MTime"}
+		}
+		e.SetXAttr.File.FileFields.MTime = uint64(v)
+		return nil
+
 	case "setxattr.file.mount_id":
 
 		var ok bool
@@ -11627,6 +12729,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.SetXAttr.SyscallEvent.Retval = int64(v)
 		return nil
 
+	case "unlink.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.CTime"}
+		}
+		e.Unlink.File.FileFields.CTime = uint64(v)
+		return nil
+
 	case "unlink.file.filesystem":
 
 		var ok bool
@@ -11685,6 +12797,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.Mode"}
 		}
 		e.Unlink.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "unlink.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Unlink.File.FileFields.MTime"}
+		}
+		e.Unlink.File.FileFields.MTime = uint64(v)
 		return nil
 
 	case "unlink.file.mount_id":
@@ -11760,6 +12882,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		e.Unlink.SyscallEvent.Retval = int64(v)
 		return nil
 
+	case "utimes.file.change_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.CTime"}
+		}
+		e.Utimes.File.FileFields.CTime = uint64(v)
+		return nil
+
 	case "utimes.file.filesystem":
 
 		var ok bool
@@ -11818,6 +12950,16 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.Mode"}
 		}
 		e.Utimes.File.FileFields.Mode = uint16(v)
+		return nil
+
+	case "utimes.file.modification_time":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Utimes.File.FileFields.MTime"}
+		}
+		e.Utimes.File.FileFields.MTime = uint64(v)
 		return nil
 
 	case "utimes.file.mount_id":

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -244,8 +244,8 @@ func newFileSerializer(fe *model.FileEvent, e *Event) *FileSerializer {
 		GID:                 fe.GID,
 		User:                e.ResolveFileFieldsUser(&fe.FileFields),
 		Group:               e.ResolveFileFieldsGroup(&fe.FileFields),
-		Mtime:               &fe.MTime,
-		Ctime:               &fe.CTime,
+		Mtime:               getTimeIfNotZero(time.Unix(0, int64(fe.MTime))),
+		Ctime:               getTimeIfNotZero(time.Unix(0, int64(fe.CTime))),
 		InUpperLayer:        getInUpperLayer(e.resolvers, &fe.FileFields),
 	}
 }
@@ -265,8 +265,8 @@ func newProcessFileSerializerWithResolvers(process *model.Process, r *Resolvers)
 		GID:                 process.FileFields.GID,
 		User:                r.ResolveFileFieldsUser(&process.FileFields),
 		Group:               r.ResolveFileFieldsGroup(&process.FileFields),
-		Mtime:               &process.FileFields.MTime,
-		Ctime:               &process.FileFields.CTime,
+		Mtime:               getTimeIfNotZero(time.Unix(0, int64(process.FileFields.MTime))),
+		Ctime:               getTimeIfNotZero(time.Unix(0, int64(process.FileFields.CTime))),
 	}
 }
 

--- a/pkg/security/secl/generators/accessors/accessors.go
+++ b/pkg/security/secl/generators/accessors/accessors.go
@@ -21,6 +21,7 @@ import (
 	"strconv"
 	"strings"
 	"text/template"
+	"unicode"
 
 	"github.com/davecgh/go-spew/spew"
 	"github.com/fatih/structtag"
@@ -197,6 +198,10 @@ func handleSpec(astFile *ast.File, spec interface{}, prefix, aliasPrefix, event 
 
 				if isEmbedded := len(field.Names) == 0; !isEmbedded {
 					fieldName := field.Names[0].Name
+
+					if !unicode.IsUpper(rune(fieldName[0])) {
+						continue
+					}
 
 					if dejavu[fieldName] {
 						continue

--- a/pkg/security/tests/setup_test.go
+++ b/pkg/security/tests/setup_test.go
@@ -265,9 +265,9 @@ func assertRights(t *testing.T, actualMode, expectedMode uint16, msgAndArgs ...i
 	assertMode(t, uint32(actualMode)&01777, uint32(expectedMode), msgAndArgs...)
 }
 
-func assertNearTime(t *testing.T, event time.Time) {
+func assertNearTime(t *testing.T, ns uint64) {
 	t.Helper()
-	now := time.Now()
+	now, event := time.Now(), time.Unix(0, int64(ns))
 	if event.After(now) || event.Before(now.Add(-1*time.Hour)) {
 		t.Errorf("expected time close to %s, got %s", now, event)
 	}

--- a/pkg/security/tests/xattr_test.go
+++ b/pkg/security/tests/xattr_test.go
@@ -298,12 +298,14 @@ func TestRemoveXAttr(t *testing.T) {
 			}
 
 			now := time.Now()
-			if event.RemoveXAttr.File.MTime.After(now) || event.RemoveXAttr.File.MTime.Before(now.Add(-1*time.Hour)) {
-				t.Errorf("expected mtime close to %s, got %s", now, event.RemoveXAttr.File.MTime)
+			mtime := time.Unix(0, int64(event.RemoveXAttr.File.MTime))
+			if mtime.After(now) || mtime.Before(now.Add(-1*time.Hour)) {
+				t.Errorf("expected mtime close to %s, got %s", now, mtime)
 			}
 
-			if event.RemoveXAttr.File.CTime.After(now) || event.RemoveXAttr.File.CTime.Before(now.Add(-1*time.Hour)) {
-				t.Errorf("expected ctime close to %s, got %s", now, event.RemoveXAttr.File.CTime)
+			ctime := time.Unix(0, int64(event.RemoveXAttr.File.CTime))
+			if ctime.After(now) || ctime.Before(now.Add(-1*time.Hour)) {
+				t.Errorf("expected ctime close to %s, got %s", now, ctime)
 			}
 		})
 	})

--- a/releasenotes/notes/runtime-ctime-secl-4a165840be662f9e.yaml
+++ b/releasenotes/notes/runtime-ctime-secl-4a165840be662f9e.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Runtime security now exposes change_time and modification_time in SECL.


### PR DESCRIPTION
### What does this PR do?

This PR exposes change_time and modification_time to SECL so that we can now write rules like:

`exec.file.change_time < 5s' 

Which will trigger an event if a newly created file is executed.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
