### PR TITLE
[config] add a runtime setting for `log_payloads`.

### DIFF
--- a/cmd/agent/app/config.go
+++ b/cmd/agent/app/config.go
@@ -67,6 +67,9 @@ func initRuntimeSettings() error {
 	if err := commonsettings.RegisterRuntimeSetting(settings.DsdCaptureDurationRuntimeSetting("dogstatsd_capture_duration")); err != nil {
 		return err
 	}
+	if err := commonsettings.RegisterRuntimeSetting(commonsettings.LogPayloadsRuntimeSetting{}); err != nil {
+		return err
+	}
 	if err := commonsettings.RegisterRuntimeSetting(commonsettings.ProfilingGoroutines("internal_profiling_goroutines")); err != nil {
 		return err
 	}

--- a/pkg/config/settings/runtime_setting_log_payloads.go
+++ b/pkg/config/settings/runtime_setting_log_payloads.go
@@ -17,7 +17,7 @@ type LogPayloadsRuntimeSetting struct {
 
 // Description returns the runtime setting's description
 func (l LogPayloadsRuntimeSetting) Description() string {
-	return "Enable logging payload at runtime."
+	return "Enable logging payloads at runtime."
 }
 
 // Hidden returns whether or not this setting is hidden from the list of runtime settings

--- a/pkg/config/settings/runtime_setting_log_payloads.go
+++ b/pkg/config/settings/runtime_setting_log_payloads.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package settings
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+// LogPayloadsRuntimeSetting wraps operations to start logging aggregator payload at runtime.
+type LogPayloadsRuntimeSetting struct {
+}
+
+// Description returns the runtime setting's description
+func (l LogPayloadsRuntimeSetting) Description() string {
+	return "Enable logging payload at runtime."
+}
+
+// Hidden returns whether or not this setting is hidden from the list of runtime settings
+func (l LogPayloadsRuntimeSetting) Hidden() bool {
+	return true
+}
+
+// Name returns the name of the runtime setting
+func (l LogPayloadsRuntimeSetting) Name() string {
+	return "log_payloads"
+}
+
+// Get returns the current value of the runtime setting
+func (l LogPayloadsRuntimeSetting) Get() (interface{}, error) {
+	return config.Datadog.GetBool("log_payloads"), nil
+}
+
+// Set changes the value of the runtime setting
+func (l LogPayloadsRuntimeSetting) Set(v interface{}) error {
+	var newValue bool
+	var err error
+
+	if newValue, err = GetBool(v); err != nil {
+		return fmt.Errorf("LogPayloadsRuntimeSetting: %v", err)
+	}
+
+	config.Datadog.Set("log_payloads", newValue)
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?

To help troubleshooting, let's have a runtime settting for the `log_payloads` configuration field.

### Motivation

Be able to see what will send the Agent on a live running agent.

### Describe how to test your changes

  * Set the log level to `debug` and logs_payload to `false` in your configuration file / env var.
  * Validate that the aggregator payload isn't logged
  * Set the `log_payloads` runtime setting to `true`
  * Validate that the aggregator payload is logged
  * Set the `log_payloads` runtime setting to `false`
  * Validate that the aggregator payload isn't logged

### Checklist

- [n/a] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [n/a] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [n/a] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
