### PR TITLE
[kitchen tests] specify version of selinux cookbook dependency

### DIFF
--- a/test/kitchen/Berksfile
+++ b/test/kitchen/Berksfile
@@ -11,7 +11,8 @@ cookbook 'apt', '< 4.0'
 
 # Version 7.3.0 of the cookbook depends on chef version >= 15.0 but right now we are running 14.12.9
 cookbook 'docker', '< 7.3.0'
-cookbook 'selinux'
+# Version 4.0.0 of the cookbook depends on chef version >= 15.3 but right now we are running 14.12.9
+cookbook 'selinux', '< 4.0.0'
 
 cookbook 'dd-agent-disable-system-repos', path: './site-cookbooks/dd-agent-disable-system-repos'
 cookbook 'dd-agent-enable-fips', path: './site-cookbooks/dd-agent-enable-fips'


### PR DESCRIPTION
### What does this PR do?

The version 4.0.0 of the selinux cookbook was released on 07/21/2021 (https://supermarket.chef.io/cookbooks/selinux#changelog) and this broke some functional tests setup. This PR fixes this issue by being more precise in the dependency version requirement.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
