### PR TITLE
[runtime-security] fix mutex lock around expired events

### DIFF
--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -41,13 +41,13 @@ type pendingMsg struct {
 // APIServer represents a gRPC server in charge of receiving events sent by
 // the runtime security system-probe module and forwards them to Datadog
 type APIServer struct {
-	sync.RWMutex
 	msgs              chan *api.SecurityEventMessage
 	expiredEventsLock sync.RWMutex
 	expiredEvents     map[rules.RuleID]*int64
 	rate              *Limiter
 	statsdClient      *statsd.Client
 	probe             *sprobe.Probe
+	queueLock         sync.Mutex
 	queue             []*pendingMsg
 	retention         time.Duration
 	cfg               *config.Config
@@ -111,14 +111,14 @@ func (a *APIServer) DumpProcessCache(ctx context.Context, params *api.DumpProces
 }
 
 func (a *APIServer) enqueue(msg *pendingMsg) {
-	a.Lock()
+	a.queueLock.Lock()
 	a.queue = append(a.queue, msg)
-	a.Unlock()
+	a.queueLock.Unlock()
 }
 
 func (a *APIServer) dequeue(now time.Time, cb func(msg *pendingMsg)) {
-	a.Lock()
-	defer a.Unlock()
+	a.queueLock.Lock()
+	defer a.queueLock.Unlock()
 
 	var i int
 	var msg *pendingMsg
@@ -277,8 +277,8 @@ func (a *APIServer) expireEvent(msg *api.SecurityEventMessage) {
 // GetStats returns a map indexed by ruleIDs that describes the amount of events
 // that were expired or rate limited before reaching
 func (a *APIServer) GetStats() map[string]int64 {
-	a.expiredEventsLock.Lock()
-	defer a.expiredEventsLock.Unlock()
+	a.expiredEventsLock.RLock()
+	defer a.expiredEventsLock.RUnlock()
 
 	stats := make(map[string]int64)
 	for ruleID, val := range a.expiredEvents {

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -277,8 +277,8 @@ func (a *APIServer) expireEvent(msg *api.SecurityEventMessage) {
 // GetStats returns a map indexed by ruleIDs that describes the amount of events
 // that were expired or rate limited before reaching
 func (a *APIServer) GetStats() map[string]int64 {
-	a.RLock()
-	defer a.RUnlock()
+	a.expiredEventsLock.Lock()
+	defer a.expiredEventsLock.Unlock()
 
 	stats := make(map[string]int64)
 	for ruleID, val := range a.expiredEvents {


### PR DESCRIPTION
### What does this PR do?

In one functional test, the race detector detected:
```
WARNING: DATA RACE
       Write at 0x00c001a72938 by goroutine 132:
         github.com/DataDog/datadog-agent/pkg/security/module.(*APIServer).Apply()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/module/server.go:308 +0xcd
         github.com/DataDog/datadog-agent/pkg/security/module.(*Module).Reload()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/module/module.go:271 +0x969
         github.com/DataDog/datadog-agent/pkg/security/tests.(*testModule).reloadConfiguration()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/setup_test.go:501 +0x21b
         github.com/DataDog/datadog-agent/pkg/security/tests.newTestModule()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/setup_test.go:424 +0x11a9
         github.com/DataDog/datadog-agent/pkg/security/tests.TestProcessExec()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/process_test.go:541 +0x2bd
         testing.tRunner()
             /root/.gimme/versions/go1.15.13.linux.amd64/src/testing/testing.go:1123 +0x202
       
       Previous read at 0x00c001a72938 by goroutine 16:
         github.com/DataDog/datadog-agent/pkg/security/module.(*APIServer).GetStats()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/module/server.go:284 +0xc5
         github.com/DataDog/datadog-agent/pkg/security/module.(*APIServer).SendStats()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/module/server.go:292 +0x55
         github.com/DataDog/datadog-agent/pkg/security/module.(*Module).metricsSender()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/module/module.go:381 +0x9c7
       
       Goroutine 132 (running) created at:
         testing.(*T).Run()
             /root/.gimme/versions/go1.15.13.linux.amd64/src/testing/testing.go:1168 +0x5bb
         testing.runTests.func1()
             /root/.gimme/versions/go1.15.13.linux.amd64/src/testing/testing.go:1439 +0xa6
         testing.tRunner()
             /root/.gimme/versions/go1.15.13.linux.amd64/src/testing/testing.go:1123 +0x202
         testing.runTests()
             /root/.gimme/versions/go1.15.13.linux.amd64/src/testing/testing.go:1437 +0x612
         testing.(*M).Run()
             /root/.gimme/versions/go1.15.13.linux.amd64/src/testing/testing.go:1345 +0x3b3
         github.com/DataDog/datadog-agent/pkg/security/tests.TestMain()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/setup_test.go:990 +0xdb
         main.main()
             _testmain.go:137 +0x271
         runtime.main()
             /root/.gimme/versions/go1.15.13.linux.amd64/src/runtime/proc.go:204 +0x208
         github.com/DataDog/ebpf.init()
             /go/pkg/mod/github.com/!data!dog/ebpf@v0.0.0-20210419131141-ea64821c9793/prog.go:341 +0x498
         github.com/DataDog/ebpf.init()
             /go/pkg/mod/github.com/!data!dog/ebpf@v0.0.0-20210419131141-ea64821c9793/syscalls.go:436 +0x42b
         github.com/DataDog/ebpf.init()
             /go/pkg/mod/github.com/!data!dog/ebpf@v0.0.0-20210419131141-ea64821c9793/syscalls.go:223 +0x3bb
         github.com/DataDog/ebpf.init()
             /go/pkg/mod/github.com/!data!dog/ebpf@v0.0.0-20210419131141-ea64821c9793/syscalls.go:195 +0x34e
         runtime.doInit()
             /root/.gimme/versions/go1.15.13.linux.amd64/src/runtime/proc.go:5652 +0x89
       
       Goroutine 16 (running) created at:
         github.com/DataDog/datadog-agent/pkg/security/module.(*Module).Start()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/module/module.go:127 +0x189
         github.com/DataDog/datadog-agent/pkg/security/tests.newTestModule()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/setup_test.go:475 +0xa50
         github.com/DataDog/datadog-agent/pkg/security/tests.TestProcess()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/process_test.go:47 +0x386
         testing.tRunner()
             /root/.gimme/versions/go1.15.13.linux.amd64/src/testing/testing.go:1123 +0x202
       ==================
```

This PR fixes this issue, by being more strict around the mutex lock.

### Motivation

Fix a potential race in the runtime security server.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
