### PR TITLE
Update devenv script

### DIFF
--- a/devenv/gcloud.pkr.hcl
+++ b/devenv/gcloud.pkr.hcl
@@ -1,0 +1,45 @@
+# Packer script to build devenv image on GCP.
+# 
+# Usage:
+#   packer init gcloud.pkr.hcl
+#   packer build gcloud.pkr.hcl
+
+packer {
+  required_plugins {
+    googlecompute = {
+      version = ">= 0.0.1"
+      source = "github.com/hashicorp/googlecompute"
+    }
+  }
+}
+
+source "googlecompute" "datadog-agent-windows-dev" {
+  project_id = 
+  network = 
+  subnetwork = 
+
+  source_image_family = "windows-2019"
+  zone = "europe-west1-b"
+  disk_size = 50
+  machine_type = "e2-standard-4"
+  communicator = "winrm"
+  winrm_username = "packer_user"
+  winrm_insecure = true
+  winrm_use_ssl = true
+  image_name = "agent-windows-dev-{{timestamp}}"
+  image_family = "agent-windows-dev"
+  metadata = {
+    windows-startup-script-cmd = "winrm quickconfig -quiet & net user /add packer_user & net localgroup administrators packer_user /add & winrm set winrm/config/service/auth @{Basic=\"true\"}"
+  }
+}
+
+build {
+  sources = ["sources.googlecompute.datadog-agent-windows-dev"]
+  provisioner "powershell" {
+    scripts = [
+      "scripts/Install-DevEnv.ps1",
+      "scripts/Disable-WinRM.ps1"
+    ]
+  }
+}
+

--- a/devenv/scripts/Install-DevEnv.ps1
+++ b/devenv/scripts/Install-DevEnv.ps1
@@ -33,11 +33,8 @@ cinst -y visualstudio2017buildtools --params "--add Microsoft.VisualStudio.Compo
 Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing Visual C++ Workload'
 cinst -y visualstudio2017-workload-vctools
 
-Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installinc VC Tools for Python 2.7'l
-cinst -y vcpython27
-
 Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing Wix'
-cinst -y wixtoolset --version 3.11
+cinst -y wixtoolset --version 3.11.2
 [Environment]::SetEnvironmentVariable(
     "Path",
     [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::Machine) + ";${env:ProgramFiles}\WiX Toolset v3.11\bin",
@@ -83,14 +80,20 @@ $Env:Path="$Env:Path;c:\go\bin;"
 
 Write-Host -ForegroundColor Green "Installed go $ENV:GO_VERSION"
 
-Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing Python 2'
-cinst -y python2
+Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing Python 3'
+cinst -y python3
 
 Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing Ruby'
 cinst -y ruby --version 2.4.3.1
 
 Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing MSYS'
 cinst -y msys2 --params "/NoUpdate" # install msys2 without system update
+
+Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing MINGW'
+cinst -y mingw
+
+Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing Make'
+cinst -y make
 
 # Reload environment to get ruby in path
 Update-SessionEnvironment
@@ -100,5 +103,10 @@ ridk install 2 3 # use ruby's ridk to update the system and install development 
 
 Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing Bundler'
 gem install bundler
+
+Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Creating GOPATH'
+cd ~
+mkdir go\src\github.com\DataDog
+[Environment]::SetEnvironmentVariable("GOPATH", "${env:HOMEDRIVE}${env:HOMEPATH}\go", [EnvironmentVariableTarget]::User)
 
 Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen ' * DONE *'

--- a/devenv/scripts/Install-DevEnv.ps1
+++ b/devenv/scripts/Install-DevEnv.ps1
@@ -27,19 +27,6 @@ cinst -y git
 Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Getting 7zip'
 cinst -y 7zip
 
-Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing Visual Studio build tools'
-cinst -y visualstudio2017buildtools --params "--add Microsoft.VisualStudio.ComponentGroup.NativeDesktop.Win81"
-
-Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing Visual C++ Workload'
-cinst -y visualstudio2017-workload-vctools
-
-Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing Wix'
-cinst -y wixtoolset --version 3.11.2
-[Environment]::SetEnvironmentVariable(
-    "Path",
-    [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::Machine) + ";${env:ProgramFiles}\WiX Toolset v3.11\bin",
-    [System.EnvironmentVariableTarget]::Machine)
-
 Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing CMake'
 cinst -y cmake
 [Environment]::SetEnvironmentVariable(
@@ -83,12 +70,6 @@ Write-Host -ForegroundColor Green "Installed go $ENV:GO_VERSION"
 Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing Python 3'
 cinst -y python3
 
-Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing Ruby'
-cinst -y ruby --version 2.4.3.1
-
-Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing MSYS'
-cinst -y msys2 --params "/NoUpdate" # install msys2 without system update
-
 Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing MINGW'
 cinst -y mingw
 
@@ -98,11 +79,6 @@ cinst -y make
 # Reload environment to get ruby in path
 Update-SessionEnvironment
 
-Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing Toolchain'
-ridk install 2 3 # use ruby's ridk to update the system and install development toolchain
-
-Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing Bundler'
-gem install bundler
 
 Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Creating GOPATH'
 cd ~

--- a/devenv/scripts/Install-DevEnv.ps1
+++ b/devenv/scripts/Install-DevEnv.ps1
@@ -59,10 +59,12 @@ Start-Process "7z" -ArgumentList 'x -oc:\ c:\go.zip' -Wait
 Write-Host -ForegroundColor Green "Removing temporary file $out"
 Remove-Item 'c:\go.zip'
 
-setx GOROOT c:\go
-$Env:GOROOT="c:\go"
-setx PATH "$Env:Path;c:\go\bin;"
-$Env:Path="$Env:Path;c:\go\bin;"
+[Environment]::SetEnvironmentVariable(
+    "Path",
+    [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::Machine) + ";C:\go\bin",
+    [System.EnvironmentVariableTarget]::Machine)
+
+setx /m GOROOT c:\go
 # End Go workaround
 
 Write-Host -ForegroundColor Green "Installed go $ENV:GO_VERSION"
@@ -76,13 +78,15 @@ cinst -y mingw
 Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Installing Make'
 cinst -y make
 
-# Reload environment to get ruby in path
-Update-SessionEnvironment
+$GoPath="C:\gopath"
+$AgentPath="$GoPath\src\github.com\datadog\datadog-agent"
+mkdir -Force $AgentPath
 
+[Environment]::SetEnvironmentVariable(
+    "Path",
+    [Environment]::GetEnvironmentVariable("Path", [EnvironmentVariableTarget]::Machine) + ";$GoPath\bin;$AgentPath\rtloader\bin",
+    [System.EnvironmentVariableTarget]::Machine)
 
-Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen '- Creating GOPATH'
-cd ~
-mkdir go\src\github.com\DataDog
-[Environment]::SetEnvironmentVariable("GOPATH", "${env:HOMEDRIVE}${env:HOMEPATH}\go", [EnvironmentVariableTarget]::User)
+setx /m GOPATH "$GoPath"
 
 Write-Host -ForegroundColor Yellow -BackgroundColor DarkGreen ' * DONE *'


### PR DESCRIPTION
### What does this PR do?

Update `Install-DevEnv.ps1`:

- remove visual studio tools, as they are currently not required to build the agent;
- remove vcpython27, no longer available;
- remove wix, fails to install under packer (installation works when the script is run from a user session);
- install python3 instead of python2 (py3 is needed to run build tools; both packages ship just python.exe, and shadow each other on PATH);
- install mingw and cmake, so they are on PATH by default;
- remove msys (redundant when we have above);
- prepare and set up GOPATH.

### Motivation

Make it easier to set up development environment on Windows.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
