### PR TITLE
Use custom python 3 on Windows

### DIFF
--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -70,12 +70,12 @@ else
     dependency "vc_ucrt_redist"
 
     source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-x86.zip",
-            :sha256 => "ac6acfa3d1f6a73e0e0580debdd5a813961d4054a7da6038780bf5d47e4ae647"
+            :sha256 => "ADBCACE8F0CE380BC61A062327127A8608B819CE7E6EEC6CD39A1EBEBA817ACD".downcase
   else
 
     # note that startring with 3.7.3 on Windows, the zip should be created without the built-in pip
     source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-x64.zip",
-         :sha256 => "3f1533fb5d3944c57f554c9e80f4d77d953eb64e9eca68bb055642f9a8fe5a23"
+         :sha256 => "1B1EEF965F5DC0D71381D7DADEF438D249BC107639AA9086DC9DDBF85A92E5E8".downcase
 
   end
   vcrt140_root = "#{Omnibus::Config.source_dir()}/vc_redist_140/expanded"

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -63,19 +63,19 @@ if ohai["platform"] != "windows"
   end
 
 else
-  default_version "3.8.10-46f0d00"
+  default_version "3.8.10-c0e3646"
   dependency "vc_redist_14"
 
   if windows_arch_i386?
     dependency "vc_ucrt_redist"
 
     source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-x86.zip",
-            :sha256 => "ADBCACE8F0CE380BC61A062327127A8608B819CE7E6EEC6CD39A1EBEBA817ACD".downcase
+            :sha256 => "1EFD6CB17A9EEEB1DA2E79FCCA98078B35FA81DCA116265FC39DE0F01F4791F9".downcase
   else
 
     # note that startring with 3.7.3 on Windows, the zip should be created without the built-in pip
     source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-x64.zip",
-         :sha256 => "1B1EEF965F5DC0D71381D7DADEF438D249BC107639AA9086DC9DDBF85A92E5E8".downcase
+         :sha256 => "6123722512D61B42940E7906CBB6A3C765B74EBA5660A33C9981F5B6FF9C45E9".downcase
 
   end
   vcrt140_root = "#{Omnibus::Config.source_dir()}/vc_redist_140/expanded"

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -1,8 +1,7 @@
 name "python3"
 
-default_version "3.8.10"
-
 if ohai["platform"] != "windows"
+  default_version "3.8.10"
   dependency "libffi"
   dependency "ncurses"
   dependency "zlib"
@@ -64,6 +63,7 @@ if ohai["platform"] != "windows"
   end
 
 else
+  default_version "3.8.10-46f0d00"
   dependency "vc_redist_14"
 
   if windows_arch_i386?
@@ -74,7 +74,7 @@ else
   else
 
     # note that startring with 3.7.3 on Windows, the zip should be created without the built-in pip
-    source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-amd64.zip",
+    source :url => "https://dd-agent-omnibus.s3.amazonaws.com/python-windows-#{version}-x64.zip",
          :sha256 => "3f1533fb5d3944c57f554c9e80f4d77d953eb64e9eca68bb055642f9a8fe5a23"
 
   end


### PR DESCRIPTION
### What does this PR do?

This PR makes omnibus use our custom Python 3 interpreter for Windows.

Describe how to test your changes
Install Agent 7
Uninstall an integration and reinstall it
Run the Agent with a Python integration configured

### Checklist
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.


Note: Adding GitHub labels is only possible for contributors with write access.
