### PR TITLE
pkg/trace/stats: Update sketch parameters

### DIFF
--- a/pkg/trace/stats/statsraw.go
+++ b/pkg/trace/stats/statsraw.go
@@ -33,7 +33,11 @@ const (
 var indexMapping *mapping.LogarithmicMapping
 
 func init() {
-	indexMapping, _ = mapping.NewLogarithmicMappingWithGamma(sketchGamma, sketchOffset)
+	var err error
+	indexMapping, err = mapping.NewLogarithmicMappingWithGamma(sketchGamma, sketchOffset)
+	if err != nil {
+		log.Criticalf("Error when creating sketch mapping: %v", err)
+	}
 }
 
 // Most "algorithm" stuff here is tested with stats_test.go as what is important

--- a/pkg/trace/stats/statsraw.go
+++ b/pkg/trace/stats/statsraw.go
@@ -6,8 +6,6 @@
 package stats
 
 import (
-	"github.com/DataDog/sketches-go/ddsketch/mapping"
-	"github.com/DataDog/sketches-go/ddsketch/store"
 	"math/rand"
 	"strings"
 
@@ -15,6 +13,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/sketches-go/ddsketch"
+	"github.com/DataDog/sketches-go/ddsketch/mapping"
+	"github.com/DataDog/sketches-go/ddsketch/store"
 	"github.com/golang/protobuf/proto"
 )
 

--- a/pkg/trace/stats/statsraw.go
+++ b/pkg/trace/stats/statsraw.go
@@ -22,8 +22,8 @@ const (
 	// relativeAccuracy is the value accuracy we have on the percentiles. For example, we can
 	// say that p99 is 100ms +- 1ms
 	relativeAccuracy = 0.01
-	sketchGamma = 1.015625
-	sketchOffset = 1.8761281912861705
+	sketchGamma      = 1.015625
+	sketchOffset     = 1.8761281912861705
 	// maxNumBins is the maximum number of bins of the ddSketch we use to store percentiles.
 	// It can affect relative accuracy, but in practice, 2048 bins is enough to have 1% relative accuracy from
 	// 80 micro second to 1 year: http://www.vldb.org/pvldb/vol12/p2195-masson.pdf

--- a/releasenotes/notes/dd-sketch-parameters-5037893b469a6a6e.yaml
+++ b/releasenotes/notes/dd-sketch-parameters-5037893b469a6a6e.yaml
@@ -1,0 +1,3 @@
+enhancements:
+  - |
+    APM: Copy DDSketch parameters from the Datadog backend to avoid lossy conversion.


### PR DESCRIPTION
Switches parameters for sketches so that no lossy conversion is needed in the Datadog backend.
That will ensure the best possible relative accuracy.