### PR TITLE
Ensure namespaced resolution has a non-zero namespace

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -180,6 +180,7 @@
 /pkg/metadata/kubernetes/               @DataDog/agent-network
 /pkg/process/                           @DataDog/processes
 /pkg/process/checks/pod*.go             @DataDog/container-app
+/pkg/process/net/                       @DataDog/processes @DataDog/agent-network
 /pkg/orchestrator/                      @DataDog/container-app
 /pkg/network/                           @DataDog/agent-network
 /pkg/ebpf/                              @DataDog/agent-network

--- a/pkg/process/net/resolver/resolver_linux_test.go
+++ b/pkg/process/net/resolver/resolver_linux_test.go
@@ -334,6 +334,42 @@ func TestResolveLoopbackConnections(t *testing.T) {
 			expectedLaddrID: "foo21",
 			expectedRaddrID: "foo20",
 		},
+		{
+			name: "zero src netns failed resolution",
+			conn: &model.Connection{
+				Pid:   22,
+				NetNS: 0,
+				Laddr: &model.Addr{
+					Ip:   "127.0.0.1",
+					Port: 8282,
+				},
+				Raddr: &model.Addr{
+					Ip:   "127.0.0.1",
+					Port: 1250,
+				},
+				Direction: model.ConnectionDirection_outgoing,
+			},
+			expectedLaddrID: "foo22",
+			expectedRaddrID: "", // should NOT resolve to foo7
+		},
+		{
+			name: "zero src and dst netns failed resolution",
+			conn: &model.Connection{
+				Pid:   21,
+				NetNS: 0,
+				Laddr: &model.Addr{
+					Ip:   "127.0.0.1",
+					Port: 8181,
+				},
+				Raddr: &model.Addr{
+					Ip:   "127.0.0.1",
+					Port: 8282,
+				},
+				Direction: model.ConnectionDirection_outgoing,
+			},
+			expectedLaddrID: "foo21",
+			expectedRaddrID: "", // should NOT resolve to foo22
+		},
 	}
 
 	resolver := &LocalResolver{}
@@ -378,6 +414,10 @@ func TestResolveLoopbackConnections(t *testing.T) {
 			{
 				ID:   "foo21",
 				Pids: []int32{21},
+			},
+			{
+				ID:   "foo22",
+				Pids: []int32{22},
 			},
 		},
 	)


### PR DESCRIPTION
### What does this PR do?

When doing container resolution of addresses, we need to ensure the namespace is non-zero before allowing loopback address resolution.

### Motivation

Strange resolution results against loopback addresses in a large customer's account.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.