### PR TITLE
[pkg/util] Add `hostname_file` configuration option

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -180,6 +180,7 @@ func InitConfig(config Config) {
 	config.SetDefault("proxy", nil)
 	config.BindEnvAndSetDefault("skip_ssl_validation", false)
 	config.BindEnvAndSetDefault("hostname", "")
+	config.BindEnvAndSetDefault("hostname_file", "")
 	config.BindEnvAndSetDefault("tags", []string{})
 	config.BindEnvAndSetDefault("extra_tags", []string{})
 	config.BindEnv("env") //nolint:errcheck

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -53,6 +53,14 @@ api_key:
 #
 # hostname: <HOSTNAME_NAME>
 
+## @param hostname_file - string - optional
+## In some environments, auto-detection of the hostname is not adequate and
+## environment variables cannot be used to set the value. In such cases, the
+## file on the host can also be used provide an appropriate value. If
+## 'hostname' value has been set to a non-empty value, this option is ignored.
+#
+# hostname_file: /var/lib/cloud/data/instance-id
+
 ## @param hostname_fqdn - boolean - optional - default: false
 ## When the Agent relies on the OS to determine the hostname, make it use the
 ## FQDN instead of the short hostname. Recommended value: true

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -151,6 +151,16 @@ func TestSiteEnvVar(t *testing.T) {
 	assert.Equal(t, "https://external-agent.datadoghq.eu", externalAgentURL)
 }
 
+func TestDDHostnameFileEnvVar(t *testing.T) {
+	resetAPIKey := setEnvForTest("DD_API_KEY", "fakeapikey")
+	resetHostnameFile := setEnvForTest("DD_HOSTNAME_FILE", "somefile")
+	defer resetAPIKey()
+	defer resetHostnameFile()
+	testConfig := setupConfFromYAML("")
+
+	assert.Equal(t, "somefile", testConfig.Get("hostname_file"))
+}
+
 func TestDDURLEnvVar(t *testing.T) {
 	resetAPIKey := setEnvForTest("DD_API_KEY", "fakeapikey")
 	resetURL := setEnvForTest("DD_DD_URL", "https://app.datadoghq.eu")

--- a/pkg/util/azure/azure.go
+++ b/pkg/util/azure/azure.go
@@ -122,7 +122,7 @@ func getResponse(ctx context.Context, url string) (string, error) {
 }
 
 // GetHostname returns hostname based on Azure instance metadata.
-func GetHostname(ctx context.Context) (string, error) {
+func GetHostname(ctx context.Context, options map[string]interface{}) (string, error) {
 	if !config.IsCloudProviderEnabled(CloudProviderName) {
 		return "", fmt.Errorf("cloud provider is disabled by configuration")
 	}

--- a/pkg/util/docker/diagnosis.go
+++ b/pkg/util/docker/diagnosis.go
@@ -27,7 +27,7 @@ func diagnose() error {
 		log.Info("successfully connected to docker")
 	}
 
-	hostname, err := HostnameProvider(context.TODO())
+	hostname, err := HostnameProvider(context.TODO(), nil)
 	if err != nil {
 		log.Errorf("returned hostname %q with error: %s", hostname, err)
 	} else {

--- a/pkg/util/docker/global.go
+++ b/pkg/util/docker/global.go
@@ -68,7 +68,7 @@ func EnableTestingMode() {
 }
 
 // HostnameProvider docker implementation for the hostname provider
-func HostnameProvider(ctx context.Context) (string, error) {
+func HostnameProvider(ctx context.Context, options map[string]interface{}) (string, error) {
 	du, err := GetDockerUtil()
 	if err != nil {
 		return "", err

--- a/pkg/util/docker/global_nodocker.go
+++ b/pkg/util/docker/global_nodocker.go
@@ -10,7 +10,7 @@ package docker
 import "context"
 
 // HostnameProvider docker implementation for the hostname provider
-func HostnameProvider(ctx context.Context) (string, error) {
+func HostnameProvider(ctx context.Context, options map[string]interface{}) (string, error) {
 	return "", ErrDockerNotCompiled
 }
 

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -377,7 +377,7 @@ func isDefaultHostname(hostname string, useWindowsPrefix bool) bool {
 }
 
 // HostnameProvider gets the hostname
-func HostnameProvider(ctx context.Context) (string, error) {
+func HostnameProvider(ctx context.Context, options map[string]interface{}) (string, error) {
 	log.Debug("GetHostname trying EC2 metadata...")
 	return GetInstanceID(ctx)
 }

--- a/pkg/util/ecs/metadata/doc.go
+++ b/pkg/util/ecs/metadata/doc.go
@@ -4,7 +4,6 @@
 // Copyright 2020-present Datadog, Inc.
 
 /*
-
 Package metadata provides clients for Metadata APIs exposed by the ECS agent.
 There are three versions of these APIs:
 
@@ -17,6 +16,5 @@ There are three versions of these APIs:
 	platform version 1.3.0 with the Faragate launch type.
 
 Each of these versions sits in its own subpackage.
-
 */
 package metadata

--- a/pkg/util/gce/gce.go
+++ b/pkg/util/gce/gce.go
@@ -215,6 +215,6 @@ func getResponse(ctx context.Context, url string) (string, error) {
 }
 
 // HostnameProvider GCE implementation of the HostnameProvider
-func HostnameProvider(ctx context.Context) (string, error) {
+func HostnameProvider(ctx context.Context, options map[string]interface{}) (string, error) {
 	return GetHostname(ctx)
 }

--- a/pkg/util/hostname/apiserver/hostname.go
+++ b/pkg/util/hostname/apiserver/hostname.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func HostnameProvider(ctx context.Context) (string, error) {
+func HostnameProvider(ctx context.Context, options map[string]interface{}) (string, error) {
 	nodeName, err := a.HostNodeName(ctx)
 	if err != nil {
 		return "", err

--- a/pkg/util/hostname/file.go
+++ b/pkg/util/hostname/file.go
@@ -1,0 +1,12 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package hostname
+
+import "github.com/DataDog/datadog-agent/pkg/util/hostname/file"
+
+func init() {
+	RegisterHostnameProvider("file", file.HostnameProvider)
+}

--- a/pkg/util/hostname/file/hostname.go
+++ b/pkg/util/hostname/file/hostname.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package file
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/util/hostname/validate"
+)
+
+// HostnameProvider parses a file from the 'filename' option and returns the content
+// as the hostname
+func HostnameProvider(ctx context.Context, options map[string]interface{}) (string, error) {
+	if options == nil {
+		return "", fmt.Errorf("'file' hostname provider requires a 'filename' field in options")
+	}
+
+	filenameVal, ok := options["filename"]
+	if !ok {
+		return "", fmt.Errorf("'file' hostname provider requires a 'filename' field in options")
+	}
+
+	filename := fmt.Sprintf("%s", filenameVal)
+	fileContent, err := ioutil.ReadFile(filename)
+	if err != nil {
+		return "", fmt.Errorf("Could not read hostname from %s: %v", filename, err)
+	}
+
+	hostname := strings.TrimSpace(string(fileContent))
+
+	err = validate.ValidHostname(hostname)
+	if err != nil {
+		return "", err
+	}
+
+	return hostname, nil
+}

--- a/pkg/util/hostname/file/hostname_test.go
+++ b/pkg/util/hostname/file/hostname_test.go
@@ -1,0 +1,99 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package file
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetHostname(t *testing.T) {
+	hostnameFile, err := writeTempHostnameFile("expectedfilehostname")
+	if !assert.Nil(t, err) {
+		return
+	}
+	defer os.RemoveAll(hostnameFile)
+
+	options := map[string]interface{}{
+		"filename": hostnameFile,
+	}
+
+	hostname, err := HostnameProvider(context.TODO(), options)
+	if !assert.Nil(t, err) {
+		return
+	}
+
+	assert.Equal(t, "expectedfilehostname", hostname)
+}
+
+func TestGetHostnameWhitespaceTrim(t *testing.T) {
+	hostnameFile, err := writeTempHostnameFile("  \n\r expectedfilehostname  \r\n\n ")
+	if !assert.Nil(t, err) {
+		return
+	}
+	defer os.RemoveAll(hostnameFile)
+
+	options := map[string]interface{}{
+		"filename": hostnameFile,
+	}
+
+	hostname, err := HostnameProvider(context.TODO(), options)
+	if !assert.Nil(t, err) {
+		return
+	}
+
+	assert.Equal(t, "expectedfilehostname", hostname)
+}
+
+func TestGetHostnameNoOptions(t *testing.T) {
+	_, err := HostnameProvider(context.TODO(), nil)
+	assert.NotNil(t, err)
+}
+
+func TestGetHostnameNoFilenameOption(t *testing.T) {
+	options := map[string]interface{}{
+		"one": "one",
+		"two": "two",
+	}
+
+	_, err := HostnameProvider(context.TODO(), options)
+	assert.NotNil(t, err)
+}
+
+func TestGetHostnameInvalidHostname(t *testing.T) {
+	hostnameFile, err := writeTempHostnameFile(strings.Repeat("a", 256))
+	if !assert.Nil(t, err) {
+		return
+	}
+	defer os.RemoveAll(hostnameFile)
+
+	options := map[string]interface{}{
+		"filename": hostnameFile,
+	}
+
+	_, err = HostnameProvider(context.TODO(), options)
+	assert.NotNil(t, err)
+}
+
+func writeTempHostnameFile(content string) (string, error) {
+	destFile, err := ioutil.TempFile("", "test-hostname-file-config-")
+	if err != nil {
+		return "", err
+	}
+
+	err = ioutil.WriteFile(destFile.Name(), []byte(content), os.ModePerm)
+	if err != nil {
+		os.RemoveAll(destFile.Name())
+		return "", err
+	}
+
+	return destFile.Name(), nil
+}

--- a/pkg/util/hostname/kubelet/host_alias.go
+++ b/pkg/util/hostname/kubelet/host_alias.go
@@ -16,7 +16,7 @@ import (
 
 // GetHostAlias uses the "kubelet" hostname provider to fetch the kubernetes alias
 func GetHostAlias(ctx context.Context) (string, error) {
-	name, err := HostnameProvider(ctx)
+	name, err := HostnameProvider(ctx, nil)
 	if err == nil && validate.ValidHostname(name) == nil {
 		return name, nil
 	}

--- a/pkg/util/hostname/kubelet/hostname.go
+++ b/pkg/util/hostname/kubelet/hostname.go
@@ -22,7 +22,7 @@ type kubeUtilGetter func() (k.KubeUtilInterface, error)
 var kubeUtilGet kubeUtilGetter = k.GetKubeUtil
 
 // HostnameProvider builds a hostname from the kubernetes nodename and an optional cluster-name
-func HostnameProvider(ctx context.Context) (string, error) {
+func HostnameProvider(ctx context.Context, options map[string]interface{}) (string, error) {
 	if !config.IsFeaturePresent(config.Kubernetes) {
 		return "", nil
 	}

--- a/pkg/util/hostname/kubelet/hostname_test.go
+++ b/pkg/util/hostname/kubelet/hostname_test.go
@@ -46,7 +46,7 @@ func TestHostnameProvider(t *testing.T) {
 		return ku, nil
 	}
 
-	hostName, err := HostnameProvider(ctx)
+	hostName, err := HostnameProvider(ctx, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "node-name", hostName)
 
@@ -58,7 +58,7 @@ func TestHostnameProvider(t *testing.T) {
 	defer mockConfig.Set("cluster_name", "")
 	defer clustername.ResetClusterName()
 
-	hostName, err = HostnameProvider(ctx)
+	hostName, err = HostnameProvider(ctx, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, "node-name-laika", hostName)
 }

--- a/pkg/util/hostname/providers.go
+++ b/pkg/util/hostname/providers.go
@@ -8,7 +8,7 @@ package hostname
 import "context"
 
 // Provider is a generic function to grab the hostname and return it
-type Provider func(context.Context) (string, error)
+type Provider func(ctx context.Context, options map[string]interface{}) (string, error)
 
 // ProviderCatalog holds all the various kinds of hostname providers
 var ProviderCatalog = make(map[string]Provider)

--- a/pkg/util/hostname_docker.go
+++ b/pkg/util/hostname_docker.go
@@ -25,7 +25,7 @@ func getContainerHostname(ctx context.Context) (bool, string) {
 		// Cluster-agent logic: Kube apiserver
 		if getKubeHostname, found := hostname.ProviderCatalog["kube_apiserver"]; found {
 			log.Debug("GetHostname trying Kubernetes trough API server...")
-			name, err := getKubeHostname(ctx)
+			name, err := getKubeHostname(ctx, nil)
 			if err == nil && validate.ValidHostname(name) == nil {
 				return true, name
 			}
@@ -36,7 +36,7 @@ func getContainerHostname(ctx context.Context) (bool, string) {
 	if config.IsFeaturePresent(config.Docker) {
 		log.Debug("GetHostname trying Docker API...")
 		if getDockerHostname, found := hostname.ProviderCatalog["docker"]; found {
-			name, err := getDockerHostname(ctx)
+			name, err := getDockerHostname(ctx, nil)
 			if err == nil && validate.ValidHostname(name) == nil {
 				return true, name
 			}
@@ -46,7 +46,7 @@ func getContainerHostname(ctx context.Context) (bool, string) {
 	if config.IsFeaturePresent(config.Kubernetes) {
 		if getKubeletHostname, found := hostname.ProviderCatalog["kubelet"]; found {
 			log.Debug("GetHostname trying Kubernetes trough kubelet API...")
-			name, err := getKubeletHostname(ctx)
+			name, err := getKubeletHostname(ctx, nil)
 			if err == nil && validate.ValidHostname(name) == nil {
 				return true, name
 			}

--- a/pkg/util/hostname_test.go
+++ b/pkg/util/hostname_test.go
@@ -1,0 +1,98 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build !serverless
+
+package util
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+)
+
+func TestGetHostnameFromHostnameConfig(t *testing.T) {
+	clearCache()
+	config.Datadog.Set("hostname", "expectedhostname")
+	config.Datadog.Set("hostname_file", "")
+	defer cleanUpConfigValues()
+
+	hostname, err := GetHostname(context.TODO())
+	if !assert.Nil(t, err) {
+		return
+	}
+
+	assert.Equal(t, "expectedhostname", hostname)
+}
+
+func TestGetHostnameCaching(t *testing.T) {
+	clearCache()
+	config.Datadog.Set("hostname", "expectedhostname")
+	config.Datadog.Set("hostname_file", "badhostname")
+	defer cleanUpConfigValues()
+
+	hostname, err := GetHostname(context.TODO())
+	if !assert.Nil(t, err) {
+		return
+	}
+	assert.Equal(t, "expectedhostname", hostname)
+
+	config.Datadog.Set("hostname", "newhostname")
+	hostname, err = GetHostname(context.TODO())
+	if !assert.Nil(t, err) {
+		return
+	}
+	assert.Equal(t, "expectedhostname", hostname)
+}
+
+func TestGetHostnameFromHostnameFileConfig(t *testing.T) {
+	hostnameFile, err := writeTempHostnameFile("expectedfilehostname")
+	if !assert.Nil(t, err) {
+		return
+	}
+	defer os.RemoveAll(hostnameFile)
+
+	config.Datadog.Set("hostname", "")
+	config.Datadog.Set("hostname_file", hostnameFile)
+	defer cleanUpConfigValues()
+
+	hostname, err := GetHostname(context.TODO())
+	if !assert.Nil(t, err) {
+		return
+	}
+
+	assert.Equal(t, "expectedfilehostname", hostname)
+}
+
+func writeTempHostnameFile(content string) (string, error) {
+	destFile, err := ioutil.TempFile("", "test-hostname-file-config-")
+	if err != nil {
+		return "", err
+	}
+
+	err = ioutil.WriteFile(destFile.Name(), []byte(content), os.ModePerm)
+	if err != nil {
+		os.RemoveAll(destFile.Name())
+		return "", err
+	}
+
+	return destFile.Name(), nil
+}
+
+func cleanUpConfigValues() {
+	clearCache()
+	config.Datadog.Set("hostname", "")
+	config.Datadog.Set("hostname_file", "")
+}
+
+func clearCache() {
+	cache.Cache.Flush()
+}

--- a/pkg/util/kubernetes/kubelet/kubelet_hosts.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_hosts.go
@@ -86,7 +86,7 @@ func getKubeletHostFromConfig(ctx context.Context, kubeletHost string) ([]string
 func getKubeletHostFromDocker(ctx context.Context) ([]string, []string) {
 	var ips []string
 	var hostnames []string
-	dockerHost, err := docker.HostnameProvider(ctx)
+	dockerHost, err := docker.HostnameProvider(ctx, nil)
 	if err != nil {
 		log.Debugf("unable to get hostname from docker, make sure to set the kubernetes_kubelet_host option: %s", err)
 		return ips, hostnames

--- a/pkg/util/tencent/tencent.go
+++ b/pkg/util/tencent/tencent.go
@@ -54,7 +54,7 @@ func GetInstanceID(ctx context.Context) (string, error) {
 }
 
 // HostnameProvider gets the hostname
-func HostnameProvider(ctx context.Context) (string, error) {
+func HostnameProvider(ctx context.Context, options map[string]interface{}) (string, error) {
 	log.Debug("GetHostname trying Tencent metadata...")
 	return GetInstanceID(ctx)
 }

--- a/releasenotes/notes/add-hostname-file-config-option-fa039cfd5ae8bcc8.yaml
+++ b/releasenotes/notes/add-hostname-file-config-option-fa039cfd5ae8bcc8.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Added `hostname_file` as a configuration option that can be used to set
+    the Agent's hostname.

--- a/test/integration/util/kube_apiserver/apiserver_test.go
+++ b/test/integration/util/kube_apiserver/apiserver_test.go
@@ -186,7 +186,7 @@ func (suite *testSuite) TestHostnameProvider() {
 	defer core.Pods("default").Delete(ctx, myHostname, v1.DeleteOptions{})
 
 	// Hostname provider should return the expected value
-	foundHost, err := hostname_apiserver.HostnameProvider(ctx)
+	foundHost, err := hostname_apiserver.HostnameProvider(ctx, nil)
 	assert.Equal(suite.T(), "target.host", foundHost)
 
 	// Testing hostname when a cluster name is set
@@ -196,6 +196,6 @@ func (suite *testSuite) TestHostnameProvider() {
 	defer mockConfig.Set("cluster_name", "")
 	defer clustername.ResetClusterName()
 
-	foundHost, err = hostname_apiserver.HostnameProvider(ctx)
+	foundHost, err = hostname_apiserver.HostnameProvider(ctx, nil)
 	assert.Equal(suite.T(), "target.host-laika", foundHost)
 }


### PR DESCRIPTION

### What does this PR do?

- Adds `hostname_file` configuration option
- Adds `file` hostname provider

### Motivation

In some EC2-based EKS environments, getting the instance ID via metadata http endpoints
is not allowable due to security posture. This change will allow those users to mount the
`instance-id` file from the host and use that as the basis for their hostname.

#### Longer decription

In some environments, auto-detection of the hostname is not adequate and
environment variables cannot be used to set the value. In such cases, the
file on the host can also be used provide a file with the appropriate
value via `hostname_file` option.

Since getting the hostname via a file is pretty analogous to the rest of
the providers, it was made into a `HostnameProvider` and `options` were
added to the interface (and this provider may not be the only one that
could use parameterization). Ideally, we will expand this code in the
future to make the configuration file be a provider as well as there's no
need to treat the config as a bespoke provider.

Incidental to this PR some tests were added and minor formatting changes
made.

### Additional Notes

### Describe how to test your changes

1. Test that setting `hostname` results in the correct hostname being set for the agent in status
1. Unset `hostname` config field but set `hostname_file` to a file containing the desired hostname. Ensure in agent status that the file-based name is picked up correctly
1. Unset `hostname` and `hostname_file`. Ensure in agent status that the file-based name is picked up correctly from remaining hostname providers (ec2/docker/etc).
1. Set `DD_HOSTNAME_FILE` to a file containing the desired hostname in Linux/Darwin. Ensure in agent status that the file-based name is picked up correctly.

### Checklist
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
