### PR TITLE
[AD][Kubelet] AD checks should not target init containers

### DIFF
--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -252,7 +252,8 @@ func (l *KubeletListener) createService(entity string, pod *kubelet.Pod, firstRu
 			}
 
 			// Detect metrics or logs exclusion
-			svc.metricsExcluded = l.filters.IsExcluded(containers.MetricsFilter, container.Name, containerImage, pod.Metadata.Namespace)
+			// Exclude terminated containers (including init containers) from metrics collection but keep them for collecting logs.
+			svc.metricsExcluded = l.filters.IsExcluded(containers.MetricsFilter, container.Name, containerImage, pod.Metadata.Namespace) || container.IsTerminated()
 			svc.logsExcluded = l.filters.IsExcluded(containers.LogsFilter, container.Name, containerImage, pod.Metadata.Namespace)
 
 			// Cache the container name to get the corresponding ports after breaking the for-loop

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -129,6 +129,11 @@ func (c *ContainerStatus) IsPending() bool {
 	return c.ID == ""
 }
 
+// IsTerminated returns if the container is in a terminated state
+func (c *ContainerStatus) IsTerminated() bool {
+	return c.State.Terminated != nil
+}
+
 // ContainerState holds a possible state of container.
 // Only one of its members may be specified.
 // If none of them is specified, the default one is ContainerStateWaiting.

--- a/releasenotes/notes/do-not-target-init-containers-8453301cc6d5b378.yaml
+++ b/releasenotes/notes/do-not-target-init-containers-8453301cc6d5b378.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Auto-discovered checks will not target init containers anymore in Kubernetes.


### PR DESCRIPTION
### What does this PR do?

Auto-discovered checks will not target init containers anymore in Kubernetes.

### Motivation

- Init containers are always in a terminated, the agent is not supposed to run checks against them. 
- OOTB image-based AD checks could match init containers (e.g redisdb, cilium..). This fix prevents the agent from running a duplicated checks targeting both main and init containers in the pod. Instead, only the main container will be matched.

### Additional Notes

Noticed that `agent configcheck` doesn't take into consideration `DD_CONTAINER_EXCLUDE_METRICS` and shows the check even if it's excluded and ignored by the Scheduler. This will be addressed in a separate PR. 

### Describe how to test your changes

Deployed a redis pod with a dummy init container using the same redis image that the agent could match with `auto_conf.yaml`.
- Only one instance of the check should run

```
    redisdb (3.5.0)
    ---------------
      Instance ID: redisdb:94f4b617bb0c8b5b [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/redisdb.d/auto_conf.yaml
      Total Runs: 1
      Metric Samples: Last Run: 46, Total: 46
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 1, Total: 1
      Average Execution Time : 6ms
      Last Execution Date : 2021-07-23 13:03:35 UTC (1627045415000)
      Last Successful Execution Date : 2021-07-23 13:03:35 UTC (1627045415000)
      metadata:
        version.major: 6
        version.minor: 2
        version.patch: 5
        version.raw: 6.2.5
        version.scheme: semver
```

- The logs agent must be able to still collect logs from both containers

```
  default/redis/redis
  -------------------
    - Type: file
      Identifier: 7e37397be43de2287df838934a60f07bed1fa142f2cf3b4899dafa02595245ce
      Path: /var/log/pods/default_redis_3fc26ddb-a0c2-4ee5-a99e-ab7d45db4e4e/redis/*.log
      Status: OK
        1 files tailed out of 1 files matching
      Inputs:
        /var/log/pods/default_redis_3fc26ddb-a0c2-4ee5-a99e-ab7d45db4e4e/redis/0.log
      BytesRead: 1084
      Average Latency (ms): 7898
      24h Average Latency (ms): 7898
      Peak Latency (ms): 7899
      24h Peak Latency (ms): 7899
...
  default/redis/redis-init
  ------------------------
    - Type: file
      Identifier: f4162a00f680dd5c5893ae2a6a51d3a56f33c0a3497e3a2c2928e625578cea6f
      Path: /var/log/pods/default_redis_3fc26ddb-a0c2-4ee5-a99e-ab7d45db4e4e/redis-init/*.log
      Status: OK
        1 files tailed out of 1 files matching
      Inputs:
        /var/log/pods/default_redis_3fc26ddb-a0c2-4ee5-a99e-ab7d45db4e4e/redis-init/0.log
      BytesRead: 111
      Average Latency (ms): 8020
      24h Average Latency (ms): 8020
      Peak Latency (ms): 8020
      24h Peak Latency (ms): 8020
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.

