### PR TITLE
[runtime-security] Improve kernel and user space dentry resolvers

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -880,7 +880,7 @@ func InitConfig(config Config) {
 	config.SetKnown("runtime_security_config.fim_enabled")
 	config.BindEnvAndSetDefault("runtime_security_config.erpc_dentry_resolution_enabled", true)
 	config.BindEnvAndSetDefault("runtime_security_config.map_dentry_resolution_enabled", true)
-	config.BindEnvAndSetDefault("runtime_security_config.dentry_cache_size", 512)
+	config.BindEnvAndSetDefault("runtime_security_config.dentry_cache_size", 1024)
 	config.BindEnvAndSetDefault("runtime_security_config.policies.dir", DefaultRuntimePoliciesDir)
 	config.BindEnvAndSetDefault("runtime_security_config.socket", "/opt/datadog-agent/run/runtime-security.sock")
 	config.BindEnvAndSetDefault("runtime_security_config.enable_approvers", true)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -880,6 +880,7 @@ func InitConfig(config Config) {
 	config.SetKnown("runtime_security_config.fim_enabled")
 	config.BindEnvAndSetDefault("runtime_security_config.erpc_dentry_resolution_enabled", true)
 	config.BindEnvAndSetDefault("runtime_security_config.map_dentry_resolution_enabled", true)
+	config.BindEnvAndSetDefault("runtime_security_config.dentry_cache_size", 512)
 	config.BindEnvAndSetDefault("runtime_security_config.policies.dir", DefaultRuntimePoliciesDir)
 	config.BindEnvAndSetDefault("runtime_security_config.socket", "/opt/datadog-agent/run/runtime-security.sock")
 	config.BindEnvAndSetDefault("runtime_security_config.enable_approvers", true)

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "2762cd66cf18ec7a929f4708ca3e60d4af653f7bd886e07c140d6aef392bcba6")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "dc077dcaf4df5816ca715f02a719002ddea515c4c4216c48a417dff6a0ee63dd")

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -76,6 +76,8 @@ type Config struct {
 	ERPCDentryResolutionEnabled bool
 	// MapDentryResolutionEnabled determines if the map resolution is enabled
 	MapDentryResolutionEnabled bool
+	// DentryCacheSize is the size of the user space dentry cache
+	DentryCacheSize int
 	// RemoteTaggerEnabled defines whether the remote tagger is enabled
 	RemoteTaggerEnabled bool
 	// HostServiceName string
@@ -119,6 +121,7 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 		CustomSensitiveWords:               aconfig.Datadog.GetStringSlice("runtime_security_config.custom_sensitive_words"),
 		ERPCDentryResolutionEnabled:        aconfig.Datadog.GetBool("runtime_security_config.erpc_dentry_resolution_enabled"),
 		MapDentryResolutionEnabled:         aconfig.Datadog.GetBool("runtime_security_config.map_dentry_resolution_enabled"),
+		DentryCacheSize:                    aconfig.Datadog.GetInt("runtime_security_config.dentry_cache_size"),
 		RemoteTaggerEnabled:                aconfig.Datadog.GetBool("runtime_security_config.remote_tagger"),
 		LogPatterns:                        aconfig.Datadog.GetStringSlice("runtime_security_config.log_patterns"),
 		SelfTestEnabled:                    aconfig.Datadog.GetBool("runtime_security_config.self_test.enabled"),

--- a/pkg/security/ebpf/c/dentry_resolver.h
+++ b/pkg/security/ebpf/c/dentry_resolver.h
@@ -120,6 +120,9 @@ int __attribute__((always_inline)) resolve_dentry_tail_call(struct dentry_resolv
         if (dentry != d_parent) {
             write_dentry_inode(d_parent, &d_inode);
             write_inode_ino(d_inode, &next_key.ino);
+        } else {
+            next_key.ino = 0;
+            next_key.mount_id = 0;
         }
 
         // discard filename and its parent only in order to limit the number of lookup
@@ -139,8 +142,6 @@ int __attribute__((always_inline)) resolve_dentry_tail_call(struct dentry_resolv
 
         if (map_value.name[0] == '/' || map_value.name[0] == 0) {
             map_value.name[0] = '/';
-            next_key.ino = 0;
-            next_key.mount_id = 0;
         }
 
         map_value.parent = next_key;

--- a/pkg/security/ebpf/c/dentry_resolver.h
+++ b/pkg/security/ebpf/c/dentry_resolver.h
@@ -142,6 +142,8 @@ int __attribute__((always_inline)) resolve_dentry_tail_call(struct dentry_resolv
 
         if (map_value.name[0] == '/' || map_value.name[0] == 0) {
             map_value.name[0] = '/';
+            next_key.ino = 0;
+            next_key.mount_id = 0;
         }
 
         map_value.parent = next_key;

--- a/pkg/security/ebpf/c/erpc.h
+++ b/pkg/security/ebpf/c/erpc.h
@@ -10,7 +10,8 @@ enum erpc_op {
     DISCARD_INODE_OP,
     DISCARD_PID_OP,
     RESOLVE_SEGMENT_OP,
-    RESOLVE_PATH_OP
+    RESOLVE_PATH_OP,
+    RESOLVE_PARENT_OP
 };
 
 int __attribute__((always_inline)) handle_discard(void *data, u64 *event_type, u64 *timeout) {
@@ -88,6 +89,17 @@ int __attribute__((always_inline)) handle_erpc_request(struct pt_regs *ctx) {
     u8 op = 0;
     int ret = bpf_probe_read(&op, sizeof(op), req);
     if (ret < 0) {
+        ret = DR_ERPC_READ_PAGE_FAULT;
+        struct bpf_map_def *erpc_stats = select_buffer(&dr_erpc_stats_fb, &dr_erpc_stats_bb, ERPC_MONITOR_KEY);
+        if (erpc_stats == NULL) {
+            return 0;
+        }
+
+        struct dr_erpc_stats_t *stats = bpf_map_lookup_elem(erpc_stats, &ret);
+        if (stats == NULL) {
+            return 0;
+        }
+        __sync_fetch_and_add(&stats->count, 1);
         return 0;
     }
 
@@ -107,6 +119,8 @@ int __attribute__((always_inline)) handle_erpc_request(struct pt_regs *ctx) {
             return handle_resolve_segment(data);
         case RESOLVE_PATH_OP:
             return handle_resolve_path(ctx, data);
+        case RESOLVE_PARENT_OP:
+            return handle_resolve_parent(data);
     }
 
     return 0;

--- a/pkg/security/ebpf/c/link.h
+++ b/pkg/security/ebpf/c/link.h
@@ -65,7 +65,7 @@ int kprobe__vfs_link(struct pt_regs *ctx) {
     // this is a hard link, source and target dentries are on the same filesystem & mount point
     // target_path was set by kprobe/filename_create before we reach this point.
     syscall->link.src_file.path_key.mount_id = get_path_mount_id(syscall->link.target_path);
-    set_file_inode(src_dentry, &syscall->link.src_file, 1);
+    set_file_inode(src_dentry, &syscall->link.src_file, 0);
 
     // we generate a fake target key as the inode is the same
     syscall->link.target_file.path_key.ino = FAKE_INODE_MSW<<32 | bpf_get_prandom_u32();

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -8,6 +8,8 @@
 package probes
 
 import (
+	"math"
+
 	"github.com/DataDog/ebpf/manager"
 )
 
@@ -101,6 +103,10 @@ func AllMapSpecEditors(numCPU int) map[string]manager.MapSpecEditor {
 		"pid_cache": {
 			MaxEntries: uint32(4096 * numCPU),
 			EditorFlag: manager.EditMaxEntries,
+		},
+		"pathnames": {
+			// max 600,000 | min 64,000 entrie => max ~180 MB | min ~18 MB
+			MaxEntries: uint32(math.Max(math.Min(640000, float64(64000*numCPU/4)), 64000)),
 		},
 	}
 }

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -105,8 +105,8 @@ func AllMapSpecEditors(numCPU int) map[string]manager.MapSpecEditor {
 			EditorFlag: manager.EditMaxEntries,
 		},
 		"pathnames": {
-			// max 600,000 | min 64,000 entrie => max ~180 MB | min ~18 MB
-			MaxEntries: uint32(math.Max(math.Min(640000, float64(64000*numCPU/4)), 64000)),
+			// max 600,000 | min 64,000 entrie => max ~180 MB | min ~27 MB
+			MaxEntries: uint32(math.Max(math.Min(640000, float64(64000*numCPU/4)), 96000)),
 		},
 	}
 }

--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -293,7 +293,7 @@ func NewNoisyProcessEvent(count uint64,
 
 func resolutionErrorToEventType(err error) model.EventType {
 	switch err.(type) {
-	case ErrTruncatedParents:
+	case ErrTruncatedParents, ErrTruncatedParentsERPC:
 		return model.CustomTruncatedParentsEventType
 	default:
 		return model.UnknownEventType

--- a/pkg/security/probe/dentry_resolver.go
+++ b/pkg/security/probe/dentry_resolver.go
@@ -11,6 +11,7 @@ import (
 	"C"
 	"fmt"
 	"os"
+	"sync"
 	"sync/atomic"
 	"unsafe"
 
@@ -26,9 +27,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
-const (
-	dentryPathKeyNotFound = "error: dentry path key not found"
-	fakeInodeMSW          = 0xdeadc001
+var (
+	errDentryPathKeyNotFound = errors.New("error: dentry path key not found")
+	fakeInodeMSW             = uint64(0xdeadc001)
 )
 
 // DentryResolver resolves inode/mountID to full paths
@@ -38,7 +39,10 @@ type DentryResolver struct {
 	erpcStats             [2]*lib.Map
 	bufferSelector        *lib.Map
 	activeERPCStatsBuffer uint32
+	dentryCacheSize       int
 	cache                 map[uint32]*lru.Cache
+	cacheGenerations      map[uint32]int
+	cacheGenerationsLock  sync.Mutex
 	erpc                  *ERPC
 	erpcSegment           []byte
 	erpcSegmentSize       int
@@ -99,15 +103,22 @@ func (p *PathKey) MarshalBinary() ([]byte, error) {
 	return buff, nil
 }
 
-// PathValue describes a value of an entry of the cache
-type PathValue struct {
+// PathLeaf is the go representation of the eBPF path_leaf_t structure
+type PathLeaf struct {
 	Parent PathKey
 	Name   [model.MaxSegmentLength + 1]byte
 	Len    uint16
 }
 
+// PathEntry is the path structure saved in cache
+type PathEntry struct {
+	Parent     PathKey
+	Name       string
+	Generation int
+}
+
 // GetName returns the path value as a string
-func (pv *PathValue) GetName() string {
+func (pv *PathLeaf) GetName() string {
 	return C.GoString((*C.char)(unsafe.Pointer(&pv.Name)))
 }
 
@@ -216,7 +227,7 @@ func (dr *DentryResolver) DelCacheEntry(mountID uint32, inode uint64) {
 			}
 			entries.Remove(key.Inode)
 
-			parent := path.(PathValue).Parent
+			parent := path.(PathEntry).Parent
 			if parent.Inode == 0 {
 				break
 			}
@@ -232,33 +243,48 @@ func (dr *DentryResolver) DelCacheEntries(mountID uint32) {
 	delete(dr.cache, mountID)
 }
 
-func (dr *DentryResolver) lookupInodeFromCache(mountID uint32, inode uint64) (pathValue PathValue, err error) {
+func (dr *DentryResolver) lookupInodeFromCache(mountID uint32, inode uint64) (*PathEntry, error) {
 	entries, exists := dr.cache[mountID]
 	if !exists {
-		return pathValue, ErrEntryNotFound
+		return nil, ErrEntryNotFound
 	}
 
 	entry, exists := entries.Get(inode)
 	if !exists {
-		return pathValue, ErrEntryNotFound
+		return nil, ErrEntryNotFound
 	}
 
-	return entry.(PathValue), nil
+	cacheEntry := entry.(PathEntry)
+	dr.cacheGenerationsLock.Lock()
+	defer dr.cacheGenerationsLock.Unlock()
+	if cacheEntry.Generation < dr.cacheGenerations[mountID] {
+		return nil, ErrEntryNotFound
+	}
+
+	return &cacheEntry, nil
 }
 
-func (dr *DentryResolver) cacheInode(mountID uint32, inode uint64, pathValue PathValue) error {
-	entries, exists := dr.cache[mountID]
+func (dr *DentryResolver) cacheInode(key PathKey, path PathEntry) error {
+	dr.cacheGenerationsLock.Lock()
+	defer dr.cacheGenerationsLock.Unlock()
+
+	entries, exists := dr.cache[key.MountID]
 	if !exists {
 		var err error
 
-		entries, err = lru.New(128)
+		entries, err = lru.New(dr.dentryCacheSize)
 		if err != nil {
 			return err
 		}
-		dr.cache[mountID] = entries
+		dr.cache[key.MountID] = entries
+		dr.cacheGenerations[key.MountID] = 0
+		path.Generation = 0
+	} else {
+		// lookup mount_id generation
+		path.Generation = dr.cacheGenerations[key.MountID]
 	}
 
-	entries.Add(inode, pathValue)
+	entries.Add(key.Inode, path)
 
 	return nil
 }
@@ -271,27 +297,32 @@ func (dr *DentryResolver) getNameFromCache(mountID uint32, inode uint64) (string
 	}
 
 	atomic.AddInt64(dr.hitsCounters[metrics.SegmentResolutionTag][metrics.CacheTag], 1)
-	return path.GetName(), nil
+	return path.Name, nil
 }
 
-func (dr *DentryResolver) lookupInodeFromMap(mountID uint32, inode uint64, pathID uint32) (pathValue PathValue, err error) {
+func (dr *DentryResolver) lookupInodeFromMap(mountID uint32, inode uint64, pathID uint32) (PathLeaf, error) {
 	key := PathKey{MountID: mountID, Inode: inode, PathID: pathID}
-	if err = dr.pathnames.Lookup(key, &pathValue); err != nil {
-		return pathValue, errors.Wrapf(err, "unable to get filename for mountID `%d` and inode `%d`", mountID, inode)
+	var pathLeaf PathLeaf
+	if err := dr.pathnames.Lookup(key, &pathLeaf); err != nil {
+		return pathLeaf, errors.Wrapf(err, "unable to get filename for mountID `%d` and inode `%d`", mountID, inode)
 	}
-	return pathValue, nil
+	return pathLeaf, nil
 }
 
 // GetNameFromMap resolves the name of the provided inode
 func (dr *DentryResolver) GetNameFromMap(mountID uint32, inode uint64, pathID uint32) (string, error) {
-	pathValue, err := dr.lookupInodeFromMap(mountID, inode, pathID)
+	pathLeaf, err := dr.lookupInodeFromMap(mountID, inode, pathID)
 	if err != nil {
 		atomic.AddInt64(dr.missCounters[metrics.SegmentResolutionTag][metrics.KernelMapsTag], 1)
 		return "", errors.Wrapf(err, "unable to get filename for mountID `%d` and inode `%d`", mountID, inode)
 	}
 
 	atomic.AddInt64(dr.hitsCounters[metrics.SegmentResolutionTag][metrics.KernelMapsTag], 1)
-	return pathValue.GetName(), nil
+
+	cacheKey := PathKey{MountID: mountID, Inode: inode}
+	cacheEntry := PathEntry{Parent: pathLeaf.Parent, Name: pathLeaf.GetName()}
+	_ = dr.cacheInode(cacheKey, cacheEntry)
+	return cacheEntry.Name, nil
 }
 
 // GetName resolves a couple of mountID/inode to a path
@@ -311,8 +342,10 @@ func (dr *DentryResolver) GetName(mountID uint32, inode uint64, pathID uint32) s
 }
 
 // ResolveFromCache resolves path from the cache
-func (dr *DentryResolver) ResolveFromCache(mountID uint32, inode uint64) (filename string, err error) {
-	var path PathValue
+func (dr *DentryResolver) ResolveFromCache(mountID uint32, inode uint64) (string, error) {
+	var path *PathEntry
+	var filename string
+	var err error
 	depth := int64(0)
 	key := PathKey{MountID: mountID, Inode: inode}
 
@@ -327,7 +360,7 @@ func (dr *DentryResolver) ResolveFromCache(mountID uint32, inode uint64) (filena
 
 		// Don't append dentry name if this is the root dentry (i.d. name == '/')
 		if path.Name[0] != '\x00' && path.Name[0] != '/' {
-			filename = "/" + path.GetName() + filename
+			filename = "/" + path.Name + filename
 		}
 
 		if path.Parent.Inode == 0 {
@@ -345,15 +378,17 @@ func (dr *DentryResolver) ResolveFromCache(mountID uint32, inode uint64) (filena
 		atomic.AddInt64(dr.hitsCounters[metrics.PathResolutionTag][metrics.CacheTag], depth)
 	}
 
-	return
+	return filename, err
 }
 
 // ResolveFromMap resolves the path of the provided inode / mount id / path id
 func (dr *DentryResolver) ResolveFromMap(mountID uint32, inode uint64, pathID uint32) (string, error) {
-	key := PathKey{MountID: mountID, Inode: inode, PathID: pathID}
-	var path PathValue
-	var filename, segment string
+	var cacheKey PathKey
+	var cacheEntry PathEntry
 	var err, resolutionErr error
+	var filename string
+	var path PathLeaf
+	key := PathKey{MountID: mountID, Inode: inode, PathID: pathID}
 
 	keyBuffer, err := key.MarshalBinary()
 	if err != nil {
@@ -361,20 +396,21 @@ func (dr *DentryResolver) ResolveFromMap(mountID uint32, inode uint64, pathID ui
 	}
 
 	depth := int64(0)
-	toAdd := make(map[PathKey]PathValue)
+	toAdd := make(map[PathKey]PathEntry)
 
 	// Fetch path recursively
 	for i := 0; i <= model.MaxPathDepth; i++ {
 		key.Write(keyBuffer)
 		if err = dr.pathnames.Lookup(keyBuffer, &path); err != nil {
-			filename = dentryPathKeyNotFound
+			filename = ""
+			err = errDentryPathKeyNotFound
 			atomic.AddInt64(dr.missCounters[metrics.PathResolutionTag][metrics.KernelMapsTag], 1)
 			break
 		}
 		depth++
 
-		cacheKey := PathKey{MountID: key.MountID, Inode: key.Inode}
-		toAdd[cacheKey] = path
+		cacheKey = PathKey{MountID: key.MountID, Inode: key.Inode}
+		cacheEntry = PathEntry{Parent: path.Parent, Name: ""}
 
 		if path.Name[0] == '\x00' {
 			resolutionErr = errTruncatedParents
@@ -382,10 +418,14 @@ func (dr *DentryResolver) ResolveFromMap(mountID uint32, inode uint64, pathID ui
 		}
 
 		// Don't append dentry name if this is the root dentry (i.d. name == '/')
-		if path.Name[0] != '/' {
-			segment = C.GoString((*C.char)(unsafe.Pointer(&path.Name)))
-			filename = "/" + segment + filename
+		if path.Name[0] == '/' {
+			cacheEntry.Name = "/"
+		} else {
+			cacheEntry.Name = C.GoString((*C.char)(unsafe.Pointer(&path.Name)))
+			filename = "/" + cacheEntry.Name + filename
 		}
+
+		toAdd[cacheKey] = cacheEntry
 
 		if path.Parent.Inode == 0 {
 			break
@@ -412,7 +452,7 @@ func (dr *DentryResolver) ResolveFromMap(mountID uint32, inode uint64, pathID ui
 		for k, v := range toAdd {
 			// do not cache fake path keys in the case of rename events
 			if k.Inode>>32 != fakeInodeMSW {
-				_ = dr.cacheInode(k.MountID, k.Inode, v)
+				_ = dr.cacheInode(k, v)
 			}
 		}
 	}
@@ -436,7 +476,7 @@ func (dr *DentryResolver) markSegmentAsZero() {
 }
 
 // GetNameFromERPC resolves the name of the provided inode / mount id / path id
-func (dr *DentryResolver) GetNameFromERPC(mountID uint32, inode uint64, pathID uint32) (name string, err error) {
+func (dr *DentryResolver) GetNameFromERPC(mountID uint32, inode uint64, pathID uint32) (string, error) {
 	// create eRPC request
 	dr.erpcRequest.OP = ResolveSegmentOp
 	model.ByteOrder.PutUint64(dr.erpcRequest.Data[0:8], inode)
@@ -451,7 +491,7 @@ func (dr *DentryResolver) GetNameFromERPC(mountID uint32, inode uint64, pathID u
 	// ensure to zero the segments in order check the in-kernel execution
 	dr.markSegmentAsZero()
 
-	if err = dr.erpc.Request(&dr.erpcRequest); err != nil {
+	if err := dr.erpc.Request(&dr.erpcRequest); err != nil {
 		atomic.AddInt64(dr.missCounters[metrics.SegmentResolutionTag][metrics.ERPCTag], 1)
 		return "", errors.Wrapf(err, "unable to get filename for mountID `%d` and inode `%d` with eRPC", mountID, inode)
 	}
@@ -475,8 +515,8 @@ func (dr *DentryResolver) GetNameFromERPC(mountID uint32, inode uint64, pathID u
 func (dr *DentryResolver) ResolveFromERPC(mountID uint32, inode uint64, pathID uint32) (string, error) {
 	var filename, segment string
 	var err, resolutionErr error
-	var key PathKey
-	var val PathValue
+	var cacheKey PathKey
+	var cacheEntry PathEntry
 	depth := int64(0)
 
 	// create eRPC request
@@ -499,7 +539,7 @@ func (dr *DentryResolver) ResolveFromERPC(mountID uint32, inode uint64, pathID u
 	}
 
 	var keys []PathKey
-	var segments []string
+	var entries []PathEntry
 
 	if model.ByteOrder.Uint64(dr.erpcSegment[0:8]) == 0 {
 		atomic.AddInt64(dr.missCounters[metrics.PathResolutionTag][metrics.ERPCTag], 1)
@@ -512,8 +552,8 @@ func (dr *DentryResolver) ResolveFromERPC(mountID uint32, inode uint64, pathID u
 		depth++
 
 		// parse the path_key_t structure
-		key.Inode = model.ByteOrder.Uint64(dr.erpcSegment[i : i+8])
-		key.MountID = model.ByteOrder.Uint32(dr.erpcSegment[i+8 : i+12])
+		cacheKey.Inode = model.ByteOrder.Uint64(dr.erpcSegment[i : i+8])
+		cacheKey.MountID = model.ByteOrder.Uint32(dr.erpcSegment[i+8 : i+12])
 		// skip PathID
 		i += 16
 
@@ -534,8 +574,8 @@ func (dr *DentryResolver) ResolveFromERPC(mountID uint32, inode uint64, pathID u
 			break
 		}
 
-		keys = append(keys, key)
-		segments = append(segments, segment)
+		keys = append(keys, cacheKey)
+		entries = append(entries, PathEntry{Name: segment})
 	}
 
 	if len(filename) == 0 {
@@ -543,22 +583,22 @@ func (dr *DentryResolver) ResolveFromERPC(mountID uint32, inode uint64, pathID u
 	}
 
 	if resolutionErr == nil {
-		var seg string
 		for i, k := range keys {
 			if k.Inode>>32 == fakeInodeMSW {
 				continue
 			}
 
-			if len(keys) > i+1 {
-				val.Parent = keys[i+1]
+			if len(entries) > i {
+				cacheEntry = entries[i]
 			} else {
-				val.Parent = PathKey{}
+				continue
 			}
-			seg = segments[i]
-			copy(val.Name[:], seg[:])
-			val.Name[len(seg)] = 0
 
-			_ = dr.cacheInode(k.MountID, k.Inode, val)
+			if len(keys) > i+1 {
+				cacheEntry.Parent = keys[i+1]
+			}
+
+			_ = dr.cacheInode(k, cacheEntry)
 		}
 
 		if depth > 0 {
@@ -605,13 +645,22 @@ func (dr *DentryResolver) resolveParentFromMap(mountID uint32, inode uint64, pat
 	return path.Parent.MountID, path.Parent.Inode, nil
 }
 
-// GetParent - Return the parent mount_id/inode
+// GetParent returns the parent mount_id/inode
 func (dr *DentryResolver) GetParent(mountID uint32, inode uint64, pathID uint32) (uint32, uint64, error) {
 	parentMountID, parentInode, err := dr.resolveParentFromCache(mountID, inode)
 	if err != nil {
 		parentMountID, parentInode, err = dr.resolveParentFromMap(mountID, inode, pathID)
 	}
 	return parentMountID, parentInode, err
+}
+
+func (dr *DentryResolver) BumpCacheGenerations() {
+	dr.cacheGenerationsLock.Lock()
+	defer dr.cacheGenerationsLock.Unlock()
+
+	for genMountID := range dr.cacheGenerations {
+		dr.cacheGenerations[genMountID] += 1
+	}
 }
 
 // Start the dentry resolver
@@ -697,17 +746,19 @@ func NewDentryResolver(probe *Probe) (*DentryResolver, error) {
 	}
 
 	return &DentryResolver{
-		client:          probe.statsdClient,
-		cache:           make(map[uint32]*lru.Cache),
-		erpc:            probe.erpc,
-		erpcSegment:     segment,
-		erpcSegmentSize: len(segment),
-		erpcRequest:     ERPCRequest{},
-		erpcEnabled:     probe.config.ERPCDentryResolutionEnabled,
-		erpcStatsZero:   make([]eRPCStats, numCPU),
-		mapEnabled:      probe.config.MapDentryResolutionEnabled,
-		hitsCounters:    hitsCounters,
-		missCounters:    missCounters,
-		numCPU:          numCPU,
+		client:           probe.statsdClient,
+		cache:            make(map[uint32]*lru.Cache),
+		cacheGenerations: make(map[uint32]int),
+		dentryCacheSize:  probe.config.DentryCacheSize,
+		erpc:             probe.erpc,
+		erpcSegment:      segment,
+		erpcSegmentSize:  len(segment),
+		erpcRequest:      ERPCRequest{},
+		erpcEnabled:      probe.config.ERPCDentryResolutionEnabled,
+		erpcStatsZero:    make([]eRPCStats, numCPU),
+		mapEnabled:       probe.config.MapDentryResolutionEnabled,
+		hitsCounters:     hitsCounters,
+		missCounters:     missCounters,
+		numCPU:           numCPU,
 	}, nil
 }

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -84,7 +84,7 @@ var (
 )
 
 var (
-	dentryInvalidDiscarder = []interface{}{dentryPathKeyNotFound}
+	dentryInvalidDiscarder = []interface{}{""}
 )
 
 // InvalidDiscarders exposes list of values that are not discarders

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -39,6 +39,8 @@ const (
 	ResolveSegmentOp
 	// ResolvePathOp resolves the requested path
 	ResolvePathOp
+	// ResolveParentOp resolves the parent of the provide path key
+	ResolveParentOp
 )
 
 const (

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -72,7 +72,10 @@ func (ev *Event) ResolveFilePath(f *model.FileEvent) string {
 	if len(f.PathnameStr) == 0 {
 		path, err := ev.resolvers.resolveFileFieldsPath(&f.FileFields)
 		if err != nil {
-			if _, ok := err.(ErrTruncatedParents); ok {
+			switch err.(type) {
+			case ErrDentryPathKeyNotFound:
+				// this error is the only one we don't care about
+			default:
 				f.PathResolutionError = err
 				ev.SetPathResolutionError(err)
 			}

--- a/pkg/security/probe/mount_resolver.go
+++ b/pkg/security/probe/mount_resolver.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/DataDog/gopsutil/process"
-
 	"github.com/moby/sys/mountinfo"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
@@ -195,6 +194,11 @@ func (mr *MountResolver) IsOverlayFS(mountID uint32) bool {
 func (mr *MountResolver) Insert(e model.MountEvent) {
 	mr.lock.Lock()
 	defer mr.lock.Unlock()
+
+	if e.MountPointPathResolutionError != nil || e.RootPathResolutionError != nil {
+		// do not insert an invalid value
+		return
+	}
 
 	mr.insert(e)
 

--- a/pkg/security/probe/mount_resolver.go
+++ b/pkg/security/probe/mount_resolver.go
@@ -191,19 +191,20 @@ func (mr *MountResolver) IsOverlayFS(mountID uint32) bool {
 }
 
 // Insert a new mount point in the cache
-func (mr *MountResolver) Insert(e model.MountEvent) {
+func (mr *MountResolver) Insert(e model.MountEvent) error {
 	mr.lock.Lock()
 	defer mr.lock.Unlock()
 
 	if e.MountPointPathResolutionError != nil || e.RootPathResolutionError != nil {
 		// do not insert an invalid value
-		return
+		return errors.Errorf("couldn't insert mount_id %d: mount_point_error:%v root_error:%v", e.MountID, e.MountPointPathResolutionError, e.RootPathResolutionError)
 	}
 
 	mr.insert(e)
 
 	// init discarder revisions
 	mr.probe.inodeDiscarders.initRevision(&e)
+	return nil
 }
 
 func (mr *MountResolver) insert(e model.MountEvent) {
@@ -344,7 +345,7 @@ func (mr *MountResolver) Start(ctx context.Context) {
 }
 
 // GetMountPath returns the path of a mount identified by its mount ID. The first path is the container mount path if
-// it exists
+// it exists, the second parameter is the mount point path, and the third parameter is the root path.
 func (mr *MountResolver) GetMountPath(mountID uint32) (string, string, string, error) {
 	if mountID == 0 {
 		return "", "", "", nil

--- a/pkg/security/probe/perf_buffer_monitor.go
+++ b/pkg/security/probe/perf_buffer_monitor.go
@@ -71,6 +71,8 @@ type PerfBufferMonitor struct {
 
 	// lastTimestamp is used to track the timestamp of the last event retrieved from the perf map
 	lastTimestamp uint64
+	// shouldBumpGeneration is used to track if the dentry cache generations should be bumped
+	shouldBumpGeneration uint64
 }
 
 // NewPerfBufferMonitor instantiates a new event statistics counter
@@ -318,6 +320,7 @@ func (pbm *PerfBufferMonitor) CountEvent(eventType model.EventType, timestamp ui
 	// check event order
 	if timestamp < pbm.lastTimestamp && pbm.lastTimestamp != 0 {
 		atomic.AddInt64(pbm.sortingErrorStats[m.Name][eventType], 1)
+		atomic.SwapUint64(&pbm.shouldBumpGeneration, 1)
 	} else {
 		pbm.lastTimestamp = timestamp
 	}
@@ -445,6 +448,11 @@ func (pbm *PerfBufferMonitor) collectAndSendKernelStats(client *statsd.Client) e
 					stats.Lost -= tmpCount
 				}
 
+				// purge dentry resolver generation if needed
+				if evtType == model.FileRenameEventType || evtType == model.FileUnlinkEventType || evtType == model.FileRmdirEventType {
+					atomic.SwapUint64(&pbm.shouldBumpGeneration, 1)
+				}
+
 				if client != nil {
 					if err := pbm.sendKernelStats(client, stats, tags); err != nil {
 						return err
@@ -494,6 +502,10 @@ func (pbm *PerfBufferMonitor) sendKernelStats(client *statsd.Client, stats PerfM
 func (pbm *PerfBufferMonitor) SendStats() error {
 	if err := pbm.collectAndSendKernelStats(pbm.statsdClient); err != nil {
 		return err
+	}
+
+	if atomic.SwapUint64(&pbm.shouldBumpGeneration, 0) == 1 {
+		pbm.probe.resolvers.DentryResolver.BumpCacheGenerations()
 	}
 
 	if err := pbm.sendEventsAndBytesReadStats(pbm.statsdClient); err != nil {

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -308,7 +308,7 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 	// no need to dispatch events
 	switch eventType {
 	case model.MountReleasedEventType:
-		if _, err := event.MountReleased.UnmarshalBinary(data[offset:]); err != nil {
+		if _, err = event.MountReleased.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode mount released event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
@@ -321,12 +321,12 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 		}
 
 		// Delete new mount point from cache
-		if err := p.resolvers.MountResolver.Delete(event.MountReleased.MountID); err != nil {
+		if err = p.resolvers.MountResolver.Delete(event.MountReleased.MountID); err != nil {
 			log.Warnf("failed to delete mount point %d from cache: %s", event.MountReleased.MountID, err)
 		}
 		return
 	case model.InvalidateDentryEventType:
-		if _, err := event.InvalidateDentry.UnmarshalBinary(data[offset:]); err != nil {
+		if _, err = event.InvalidateDentry.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode invalidate dentry event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
@@ -335,7 +335,7 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 
 		return
 	case model.ArgsEnvsEventType:
-		if _, err := event.ArgsEnvs.UnmarshalBinary(data[offset:]); err != nil {
+		if _, err = event.ArgsEnvs.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode args envs event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
@@ -354,7 +354,7 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 
 	switch eventType {
 	case model.FileMountEventType:
-		if _, err := event.Mount.UnmarshalBinary(data[offset:]); err != nil {
+		if _, err = event.Mount.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode mount event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
@@ -364,7 +364,10 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 		// Resolve root
 		event.SetMountRoot(&event.Mount)
 		// Insert new mount point in cache
-		p.resolvers.MountResolver.Insert(event.Mount)
+		err = p.resolvers.MountResolver.Insert(event.Mount)
+		if err != nil {
+			log.Errorf("failed to insert mount event: %v", err)
+		}
 
 		// There could be entries of a previous mount_id in the cache for instance,
 		// runc does the following : it bind mounts itself (using /proc/exe/self),
@@ -374,22 +377,22 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 		// so we remove all dentry entries belonging to the mountID.
 		p.resolvers.DentryResolver.DelCacheEntries(event.Mount.MountID)
 	case model.FileUmountEventType:
-		if _, err := event.Umount.UnmarshalBinary(data[offset:]); err != nil {
+		if _, err = event.Umount.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode umount event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 	case model.FileOpenEventType:
-		if _, err := event.Open.UnmarshalBinary(data[offset:]); err != nil {
+		if _, err = event.Open.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode open event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 	case model.FileMkdirEventType:
-		if _, err := event.Mkdir.UnmarshalBinary(data[offset:]); err != nil {
+		if _, err = event.Mkdir.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode mkdir event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 	case model.FileRmdirEventType:
-		if _, err := event.Rmdir.UnmarshalBinary(data[offset:]); err != nil {
+		if _, err = event.Rmdir.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode rmdir event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
@@ -399,7 +402,7 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 			defer p.invalidateDentry(event.Rmdir.File.MountID, event.Rmdir.File.Inode)
 		}
 	case model.FileUnlinkEventType:
-		if _, err := event.Unlink.UnmarshalBinary(data[offset:]); err != nil {
+		if _, err = event.Unlink.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode unlink event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
@@ -409,7 +412,7 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 			defer p.invalidateDentry(event.Unlink.File.MountID, event.Unlink.File.Inode)
 		}
 	case model.FileRenameEventType:
-		if _, err := event.Rename.UnmarshalBinary(data[offset:]); err != nil {
+		if _, err = event.Rename.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode rename event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
@@ -419,37 +422,37 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 			defer p.invalidateDentry(event.Rename.New.MountID, event.Rename.New.Inode)
 		}
 	case model.FileChmodEventType:
-		if _, err := event.Chmod.UnmarshalBinary(data[offset:]); err != nil {
+		if _, err = event.Chmod.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode chmod event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 	case model.FileChownEventType:
-		if _, err := event.Chown.UnmarshalBinary(data[offset:]); err != nil {
+		if _, err = event.Chown.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode chown event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 	case model.FileUtimesEventType:
-		if _, err := event.Utimes.UnmarshalBinary(data[offset:]); err != nil {
+		if _, err = event.Utimes.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode utime event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 	case model.FileLinkEventType:
-		if _, err := event.Link.UnmarshalBinary(data[offset:]); err != nil {
+		if _, err = event.Link.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode link event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 	case model.FileSetXAttrEventType:
-		if _, err := event.SetXAttr.UnmarshalBinary(data[offset:]); err != nil {
+		if _, err = event.SetXAttr.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode setxattr event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 	case model.FileRemoveXAttrEventType:
-		if _, err := event.RemoveXAttr.UnmarshalBinary(data[offset:]); err != nil {
+		if _, err = event.RemoveXAttr.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode removexattr event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 	case model.ForkEventType:
-		if _, err := event.UnmarshalProcess(data[offset:]); err != nil {
+		if _, err = event.UnmarshalProcess(data[offset:]); err != nil {
 			log.Errorf("failed to decode fork event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
@@ -459,14 +462,14 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 		p.resolvers.ProcessResolver.AddForkEntry(event.ProcessContext.Pid, event.processCacheEntry)
 	case model.ExecEventType:
 		// unmarshal and fill event.processCacheEntry
-		if _, err := event.UnmarshalProcess(data[offset:]); err != nil {
+		if _, err = event.UnmarshalProcess(data[offset:]); err != nil {
 			log.Errorf("failed to decode exec event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
 		p.resolvers.ProcessResolver.SetProcessArgs(event.processCacheEntry)
 		p.resolvers.ProcessResolver.SetProcessEnvs(event.processCacheEntry)
 
-		if _, err := p.resolvers.ProcessResolver.SetProcessPath(event.processCacheEntry); err != nil {
+		if _, err = p.resolvers.ProcessResolver.SetProcessPath(event.processCacheEntry); err != nil {
 			log.Debugf("failed to resolve exec path: %s", err)
 		}
 		p.resolvers.ProcessResolver.SetProcessFilesystem(event.processCacheEntry)
@@ -485,25 +488,25 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 	case model.ExitEventType:
 		defer p.resolvers.ProcessResolver.DeleteEntry(event.ProcessContext.Pid, event.ResolveEventTimestamp())
 	case model.SetuidEventType:
-		if _, err := event.SetUID.UnmarshalBinary(data[offset:]); err != nil {
+		if _, err = event.SetUID.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode setuid event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
 		defer p.resolvers.ProcessResolver.UpdateUID(event.ProcessContext.Pid, event)
 	case model.SetgidEventType:
-		if _, err := event.SetGID.UnmarshalBinary(data[offset:]); err != nil {
+		if _, err = event.SetGID.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode setgid event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
 		defer p.resolvers.ProcessResolver.UpdateGID(event.ProcessContext.Pid, event)
 	case model.CapsetEventType:
-		if _, err := event.Capset.UnmarshalBinary(data[offset:]); err != nil {
+		if _, err = event.Capset.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode capset event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}
 		defer p.resolvers.ProcessResolver.UpdateCapset(event.ProcessContext.Pid, event)
 	case model.SELinuxEventType:
-		if _, err := event.SELinux.UnmarshalBinary(data[offset:]); err != nil {
+		if _, err = event.SELinux.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode selinux event: %s (offset %d, len %d)", err, offset, len(data))
 			return
 		}

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -77,10 +77,10 @@ func (r *Resolvers) resolveBasename(e *model.FileFields) string {
 	return r.DentryResolver.GetName(e.MountID, e.Inode, e.PathID)
 }
 
-// resolveFileFieldsPath resolves the inode to a full path. Returns the path and true if it was entirely resolved
+// resolveFileFieldsPath resolves the inode to a full path
 func (r *Resolvers) resolveFileFieldsPath(e *model.FileFields) (string, error) {
 	pathStr, err := r.DentryResolver.Resolve(e.MountID, e.Inode, e.PathID)
-	if pathStr == dentryPathKeyNotFound {
+	if err != nil {
 		return pathStr, err
 	}
 

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -97,12 +97,6 @@ func (r *Resolvers) resolveFileFieldsPath(e *model.FileFields) (string, error) {
 	return pathStr, err
 }
 
-// ResolveFilePath resolves the inode to a full path. Returns the path and true if it was entirely resolved
-func (r *Resolvers) ResolveFilePath(e *model.FileEvent) string {
-	path, _ := r.resolveFileFieldsPath(&e.FileFields)
-	return path
-}
-
 // ResolveFileFieldsUser resolves the user id of the file to a username
 func (r *Resolvers) ResolveFileFieldsUser(e *model.FileFields) string {
 	if len(e.User) == 0 {

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -86,7 +86,7 @@ func (r *Resolvers) resolveFileFieldsPath(e *model.FileFields) (string, error) {
 
 	_, mountPath, rootPath, mountErr := r.MountResolver.GetMountPath(e.MountID)
 	if mountErr != nil {
-		return "", mountErr
+		return pathStr, mountErr
 	}
 
 	if strings.HasPrefix(pathStr, rootPath) && rootPath != "/" {

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -55,7 +55,7 @@ func TestOpenBasenameApproverFilterERPCDentryResolution(t *testing.T) {
 		Expression: fmt.Sprintf(`open.file.path == "{{.Root}}/%s"`, basename),
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{wantProbeEvents: true, disableMapDentryResolution: true})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{disableMapDentryResolution: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +110,7 @@ func TestOpenBasenameApproverFilterMapDentryResolution(t *testing.T) {
 		Expression: fmt.Sprintf(`open.file.path == "{{.Root}}/%s"`, basename),
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{wantProbeEvents: true, disableERPCDentryResolution: true})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{disableERPCDentryResolution: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -160,7 +160,7 @@ func TestOpenLeafDiscarderFilter(t *testing.T) {
 		Expression: `open.filename =~ "{{.Root}}/test-obc-1" && open.flags & (O_CREAT | O_SYNC) > 0`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{wantProbeEvents: true})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -208,7 +208,7 @@ func TestOpenParentDiscarderFilter(t *testing.T) {
 		Expression: `open.file.path =~ "/usr/local/test-obd-2" && open.flags & (O_CREAT | O_SYNC) > 0`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{wantProbeEvents: true})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -336,7 +336,7 @@ func TestOpenFlagsApproverFilter(t *testing.T) {
 		Expression: `open.flags & (O_SYNC | O_NOCTTY) > 0`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{wantProbeEvents: true})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -389,7 +389,7 @@ func TestOpenProcessPidDiscarder(t *testing.T) {
 		Expression: `open.file.path =="{{.Root}}/test-oba-1" && process.file.path == "/bin/cat"`,
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{wantProbeEvents: true})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -442,7 +442,7 @@ func TestDiscarderRetentionFilter(t *testing.T) {
 	}
 	defer testDrive.Close()
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{testDir: testDrive.Root(), wantProbeEvents: true})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{testDir: testDrive.Root()})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -262,7 +262,7 @@ func TestDiscarderFilterMask(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{wantProbeEvents: true})
+	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -40,7 +40,7 @@ func TestMount(t *testing.T) {
 	}
 	defer testDrive.Close()
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{testDir: testDrive.Root(), wantProbeEvents: true})
+	test, err := newTestModule(t, nil, ruleDefs, testOpts{testDir: testDrive.Root()})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/overlayfs_test.go
+++ b/pkg/security/tests/overlayfs_test.go
@@ -101,7 +101,7 @@ func TestOverlayFS(t *testing.T) {
 	}
 	defer testDrive.Close()
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{testDir: testDrive.Root(), wantProbeEvents: true, disableApprovers: true})
+	test, err := newTestModule(t, nil, ruleDefs, testOpts{testDir: testDrive.Root(), disableApprovers: true})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/probe_monitor_test.go
+++ b/pkg/security/tests/probe_monitor_test.go
@@ -36,13 +36,13 @@ func TestRulesetLoaded(t *testing.T) {
 	}
 
 	t.Run("ruleset_loaded", func(t *testing.T) {
-		if err := test.GetProbeCustomEvent(func() error {
+		if err := test.GetProbeCustomEvent(t, func() error {
 			test.reloadConfiguration()
 			return nil
 		}, func(rule *rules.Rule, customEvent *sprobe.CustomEvent) bool {
 			assert.Equal(t, probe.RulesetLoadedRuleID, rule.ID, "wrong rule")
 			return true
-		}, 3*time.Second, model.CustomRulesetLoadedEventType); err != nil {
+		}, model.CustomRulesetLoadedEventType); err != nil {
 			t.Error(err)
 		}
 	})
@@ -76,7 +76,7 @@ func truncatedParents(t *testing.T, opts testOpts) {
 
 		defer os.Remove(truncatedParentsFile)
 
-		err = test.GetProbeCustomEvent(func() error {
+		err = test.GetProbeCustomEvent(t, func() error {
 			f, err := os.OpenFile(truncatedParentsFile, os.O_CREATE, 0755)
 			if err != nil {
 				t.Fatal(err)
@@ -85,7 +85,7 @@ func truncatedParents(t *testing.T, opts testOpts) {
 		}, func(rule *rules.Rule, customEvent *sprobe.CustomEvent) bool {
 			assert.Equal(t, probe.AbnormalPathRuleID, rule.ID, "wrong rule")
 			return true
-		}, 3*time.Second, model.CustomTruncatedParentsEventType)
+		}, model.CustomTruncatedParentsEventType)
 		if err != nil {
 			t.Error(err)
 		}
@@ -142,7 +142,7 @@ func TestNoisyProcess(t *testing.T) {
 	}
 
 	t.Run("noisy_process", func(t *testing.T) {
-		err = test.GetProbeCustomEvent(func() error {
+		err = test.GetProbeCustomEvent(t, func() error {
 			// generate load
 			for i := int64(0); i < testMod.config.LoadControllerEventsCountThreshold*2; i++ {
 				f, err := os.OpenFile(file, os.O_CREATE, 0755)
@@ -156,7 +156,7 @@ func TestNoisyProcess(t *testing.T) {
 		}, func(rule *rules.Rule, customEvent *sprobe.CustomEvent) bool {
 			assert.Equal(t, probe.NoisyProcessRuleID, rule.ID, "wrong rule")
 			return true
-		}, 3*time.Second, model.CustomNoisyProcessEventType)
+		}, model.CustomNoisyProcessEventType)
 		if err != nil {
 			t.Error(err)
 		}

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -713,7 +713,7 @@ func TestProcessExecExit(t *testing.T) {
 		Expression: fmt.Sprintf(`exec.file.path == "%s" && exec.args in [~"*01010101*"]`, executable),
 	}
 
-	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{wantProbeEvents: true})
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/schemas/schemas.go
+++ b/pkg/security/tests/schemas/schemas.go
@@ -16,6 +16,7 @@
 // pkg/security/tests/schemas/rename.schema.json
 // pkg/security/tests/schemas/selinux.schema.json
 // pkg/security/tests/schemas/usr.json
+//go:build functionaltests
 // +build functionaltests
 
 package schemas

--- a/pkg/security/tests/schemas/schemas.go
+++ b/pkg/security/tests/schemas/schemas.go
@@ -16,7 +16,6 @@
 // pkg/security/tests/schemas/rename.schema.json
 // pkg/security/tests/schemas/selinux.schema.json
 // pkg/security/tests/schemas/usr.json
-//go:build functionaltests
 // +build functionaltests
 
 package schemas

--- a/pkg/security/tests/setup_test.go
+++ b/pkg/security/tests/setup_test.go
@@ -53,7 +53,6 @@ var (
 )
 
 const (
-	grpcAddr        = "127.0.0.1:18787"
 	getEventTimeout = 3 * time.Second
 )
 
@@ -121,17 +120,11 @@ const (
 	DockerEnvironment = "docker"
 )
 
-type testEvent struct {
-	eval.Event
-	rule *eval.Rule
-}
-
 type testOpts struct {
 	testDir                     string
 	disableFilters              bool
 	disableApprovers            bool
 	disableDiscarders           bool
-	wantProbeEvents             bool
 	eventsCountThreshold        int
 	reuseProbeHandler           bool
 	disableERPCDentryResolution bool
@@ -568,7 +561,8 @@ func (tm *testModule) RegisterRuleEventHandler(cb ruleHandler) {
 	tm.ruleHandler.Unlock()
 }
 
-func (tm *testModule) GetProbeCustomEvent(action func() error, cb func(rule *rules.Rule, event *sprobe.CustomEvent) bool, timeout time.Duration, eventType ...model.EventType) error {
+func (tm *testModule) GetProbeCustomEvent(tb testing.TB, action func() error, cb func(rule *rules.Rule, event *sprobe.CustomEvent) bool, eventType ...model.EventType) error {
+	tb.Helper()
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/pkg/security/tests/setup_test.go
+++ b/pkg/security/tests/setup_test.go
@@ -53,7 +53,7 @@ var (
 )
 
 const (
-	getEventTimeout = 3 * time.Second
+	getEventTimeout = 10 * time.Second
 )
 
 type stringSlice []string


### PR DESCRIPTION
### What does this PR do?

This PR implements a few changes to improve our kernel space and user space dentry resolvers:
- prevent the insertion of a mount point if its resolution yielded and error
- remove "error: dentry path key not found" from the filename in the kernel maps resolver and use an error instead
- increase the kernel and user space dentry cache sizes with the CPU count
- differentiate the "read" page faults from the "write" page faults during an eRPC dentry resolution
- implement the parent resolution with eRPC
- implement a generation mechanism to clear the caches when events are lost or miss ordered
- prevent unnecessary copies in user space during the cache resolution
- fixes an infinite loop of the dentry resolver when a socket file descriptor is used 

### Motivation

These changes will improve the overall performances of the kernel space and user space dentry resolvers. 
