### PR TITLE
[runtime-security] fix iouring test

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -49,7 +49,7 @@ kitchen_ubuntu_security_agent:
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - export KITCHEN_PLATFORM=ubuntu
-    - export KITCHEN_OSVERS="ubuntu-18-04,ubuntu-20-04"
+    - export KITCHEN_OSVERS="ubuntu-18-04,ubuntu-20-04,ubuntu-21-04"
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 

--- a/go.mod
+++ b/go.mod
@@ -120,7 +120,7 @@ require (
 	github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/ianlancetaylor/cgosymbolizer v0.0.0-20201204192058-7acc97e53614 // indirect
-	github.com/iceber/iouring-go v0.0.0-20201110085921-73520a520aac
+	github.com/iceber/iouring-go v0.0.0-20210723144509-ddbccb61dc5b
 	github.com/iovisor/gobpf v0.0.0
 	github.com/itchyny/gojq v0.12.4
 	github.com/json-iterator/go v1.1.11

--- a/go.mod
+++ b/go.mod
@@ -120,7 +120,7 @@ require (
 	github.com/hectane/go-acl v0.0.0-20190604041725-da78bae5fc95
 	github.com/huandu/xstrings v1.3.2 // indirect
 	github.com/ianlancetaylor/cgosymbolizer v0.0.0-20201204192058-7acc97e53614 // indirect
-	github.com/iceber/iouring-go v0.0.0-20210723144509-ddbccb61dc5b
+	github.com/iceber/iouring-go v0.0.0-20210726032807-b073cc83b2b8
 	github.com/iovisor/gobpf v0.0.0
 	github.com/itchyny/gojq v0.12.4
 	github.com/json-iterator/go v1.1.11

--- a/go.sum
+++ b/go.sum
@@ -786,6 +786,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639 h1:mV02weK
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/iceber/iouring-go v0.0.0-20201110085921-73520a520aac h1:d3pC9bvboHtlFNHwKAer3qYHsIizhPavMffA0Buf13E=
 github.com/iceber/iouring-go v0.0.0-20201110085921-73520a520aac/go.mod h1:LEzdaZarZ5aqROlLIwJ4P7h3+4o71008fSy6wpaEB+s=
+github.com/iceber/iouring-go v0.0.0-20210723144509-ddbccb61dc5b h1:b9ZHLr2EenLVfZpnJLy5TQrtlelB0K9T/XrpBasT1ww=
+github.com/iceber/iouring-go v0.0.0-20210723144509-ddbccb61dc5b/go.mod h1:LEzdaZarZ5aqROlLIwJ4P7h3+4o71008fSy6wpaEB+s=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=

--- a/go.sum
+++ b/go.sum
@@ -784,10 +784,8 @@ github.com/ianlancetaylor/cgosymbolizer v0.0.0-20201204192058-7acc97e53614/go.mo
 github.com/ianlancetaylor/demangle v0.0.0-20181102032728-5e5cf60278f6/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639 h1:mV02weKRL81bEnm8A0HT1/CAelMQDBuQIfLw8n+d6xI=
 github.com/ianlancetaylor/demangle v0.0.0-20200824232613-28f6c0f3b639/go.mod h1:aSSvb/t6k1mPoxDqO4vJh6VOCGPwU4O0C2/Eqndh1Sc=
-github.com/iceber/iouring-go v0.0.0-20201110085921-73520a520aac h1:d3pC9bvboHtlFNHwKAer3qYHsIizhPavMffA0Buf13E=
-github.com/iceber/iouring-go v0.0.0-20201110085921-73520a520aac/go.mod h1:LEzdaZarZ5aqROlLIwJ4P7h3+4o71008fSy6wpaEB+s=
-github.com/iceber/iouring-go v0.0.0-20210723144509-ddbccb61dc5b h1:b9ZHLr2EenLVfZpnJLy5TQrtlelB0K9T/XrpBasT1ww=
-github.com/iceber/iouring-go v0.0.0-20210723144509-ddbccb61dc5b/go.mod h1:LEzdaZarZ5aqROlLIwJ4P7h3+4o71008fSy6wpaEB+s=
+github.com/iceber/iouring-go v0.0.0-20210726032807-b073cc83b2b8 h1:OwV7phffPbNO1q8WRkO0yIlwCJUE5uV8vIuWYP7iUJM=
+github.com/iceber/iouring-go v0.0.0-20210726032807-b073cc83b2b8/go.mod h1:LEzdaZarZ5aqROlLIwJ4P7h3+4o71008fSy6wpaEB+s=
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.10/go.mod h1:jmQim1M+e3UYxmgPu/WyfjB3N3VflVyUjjjwH0dnCYA=

--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -225,6 +225,7 @@ func TestOpen(t *testing.T) {
 			}
 			t.Skip("io_uring not supported")
 		}
+		defer iour.Close()
 
 		prepRequest, err := iouring.Openat(unix.AT_FDCWD, testFile, syscall.O_CREAT, 0747)
 		if err != nil {
@@ -245,7 +246,6 @@ func TestOpen(t *testing.T) {
 				}
 				t.Skip("openat not supported by io_uring")
 			}
-			defer iour.Close()
 
 			if fd < 0 {
 				t.Fatalf("failed to open file with io_uring: %d", fd)

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -55,7 +55,8 @@
                 "ubuntu-14-04": "urn,Canonical:UbuntuServer:14.04.5-LTS:14.04.201905140",
                 "ubuntu-16-04": "urn,Canonical:UbuntuServer:16.04.0-LTS:16.04.201604203",
                 "ubuntu-18-04": "urn,Canonical:UbuntuServer:18.04-LTS:18.04.201906040",
-                "ubuntu-20-04": "urn,Canonical:0001-com-ubuntu-server-focal:20_04-lts:20.04.202004230"
+                "ubuntu-20-04": "urn,Canonical:0001-com-ubuntu-server-focal:20_04-lts:20.04.202004230",
+                "ubuntu-21-04": "urn,Canonical:0001-com-ubuntu-server-hirsute:21_04:21.04.202107200"
             }
         },
         "ec2": {


### PR DESCRIPTION
### What does this PR do?

Since iouring gained the possibility to run `openat/openat2` operations, we added a test to check that even through iouring open events are correctly handled. This PR:
- fix the test that was broken since the refactor of #8292
- upgrade the iouring-go dependency (thus fixing a race detected by the race detector)
- add an Ubuntu 21.04 kernel to the gitlab pipelines to ensure that this iouring test is actually run

### Motivation

iouring is the future of the linux kernel, it is very important to ensure that this is not an easy way to bypass our probes

### Describe how to test your changes

The kitchen tests running in the Gitlab pipelines should run, and pass.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
