### PR TITLE
[WIP] String interning improvements

### DIFF
--- a/pkg/dogstatsd/intern.go
+++ b/pkg/dogstatsd/intern.go
@@ -21,6 +21,7 @@ var (
 type stringInterner struct {
 	strings map[string]string
 	maxSize int
+	calls uint64
 	// telemetry
 	tlmEnabled bool
 }
@@ -36,8 +37,24 @@ func newStringInterner(maxSize int) *stringInterner {
 // LoadOrStore always returns the string from the cache, adding it into the
 // cache if needed.
 // If we need to store a new entry and the cache is at its maximum capacity,
-// it is reset.
+// an existing entry is randomly dropped.
 func (i *stringInterner) LoadOrStore(key []byte) string {
+	// Drop one random entry every dropInterval calls to LoadOrStore. This
+	// aims at ensuring that entries are eventually dropped even if no new
+	// entries are added.
+	// TODO: Use a LRU/LFU policy (possibly approximated via sampling).
+	i.calls++
+	if i.calls % dropInterval == 0 {
+		for k := range i.strings {
+			delete(i.strings, k)
+			break
+		}
+	}
+	
+	if len(key) == 0 {
+		return ""
+	}
+		
 	// here is the string interner trick: the map lookup using
 	// string(key) doesn't actually allocate a string, but is
 	// returning the string value -> no new heap allocation
@@ -46,13 +63,17 @@ func (i *stringInterner) LoadOrStore(key []byte) string {
 	if s, found := i.strings[string(key)]; found {
 		return s
 	}
+	
+	// If adding a new entry would bring us over the maxSize limit, randomly drop one entry.
+	// TODO: Use a LRU/LFU policy (possibly approximated via sampling).
 	if len(i.strings) >= i.maxSize {
-		i.strings = make(map[string]string)
-		log.Debug("clearing the string interner cache")
-		if i.tlmEnabled {
-			tlmSIResets.Inc()
+		for k := range i.strings {
+			delete(i.strings, k)
+			break
 		}
 	}
+	
+	// Add the new entry.
 	s := string(key)
 	i.strings[s] = s
 	return s

--- a/pkg/dogstatsd/intern.go
+++ b/pkg/dogstatsd/intern.go
@@ -36,7 +36,7 @@ const (
 type stringInterner struct {
 	strings map[string]string
 	maxSize int
-	calls uint64
+	calls   uint64
 	// telemetry
 	tlmEnabled bool
 }
@@ -57,13 +57,13 @@ func (i *stringInterner) LoadOrStore(key []byte) string {
 	if i.tlmEnabled {
 		tlmSICalls.Inc()
 	}
-	
+
 	// Drop one random entry every dropInterval calls to LoadOrStore. This
 	// aims at ensuring that entries are eventually dropped even if no new
 	// entries are added.
 	// TODO: Use a LRU/LFU policy (possibly approximated via sampling).
 	i.calls++
-	if i.calls % dropInterval == 0 {
+	if i.calls%dropInterval == 0 {
 		for k := range i.strings {
 			if k == string(key) { // Temp string: should not allocate
 				// Avoid removing this entry in case it's exactly the one
@@ -77,7 +77,7 @@ func (i *stringInterner) LoadOrStore(key []byte) string {
 			break // Drop a single entry.
 		}
 	}
-	
+
 	// Silly case: it's pointless to use/lookup an entry for this.
 	if len(key) == 0 {
 		if i.tlmEnabled {
@@ -85,7 +85,7 @@ func (i *stringInterner) LoadOrStore(key []byte) string {
 		}
 		return ""
 	}
-		
+
 	// This is the string interner trick: the map lookup using
 	// string(key) does not actually allocate a string, but is
 	// returning the string value -> no new heap allocation
@@ -97,7 +97,7 @@ func (i *stringInterner) LoadOrStore(key []byte) string {
 		}
 		return s
 	}
-	
+
 	// If adding a new entry would bring us over the maxSize limit, randomly drop one entry.
 	// TODO: Use a LRU/LFU policy (possibly approximated via sampling).
 	if len(i.strings) >= i.maxSize {
@@ -109,7 +109,7 @@ func (i *stringInterner) LoadOrStore(key []byte) string {
 			break // Drop a single entry.
 		}
 	}
-	
+
 	// Add the new entry.
 	s := string(key)
 	i.strings[s] = s

--- a/pkg/dogstatsd/intern.go
+++ b/pkg/dogstatsd/intern.go
@@ -15,6 +15,13 @@ var (
 		nil, "Amount of resets of the string interner used in dogstatsd")
 )
 
+const (
+	// dropInterval controls how frequently an entry is dropped, regardless of map size.
+	// Specifically, an entry is dropped every dropInterval calls to LoadOrStore.
+	// It is recommended to use a power-of-2.
+	dropInterval = 256
+)
+
 // stringInterner is a string cache providing a longer life for strings,
 // helping to avoid GC runs because they're re-used many times instead of
 // created every time.

--- a/pkg/dogstatsd/intern.go
+++ b/pkg/dogstatsd/intern.go
@@ -7,10 +7,10 @@ import (
 )
 
 var (
-	// Amount of resets of the string interner used in dogstatsd
-	// Note that it's not ideal because there is many allocated string interner
-	// (one per worker) but it'll still give us an insight (and it's comparable
-	// as long as the amount of worker is stable).
+	// Amount of entries in the string interner used in dogstatsd.
+	// Note that it's not ideal because there are multiple string interners
+	// (one per worker) but this will still give us an insight (and it's
+	// comparable as long as the amount of worker is stable).
 	tlmSIEntries = telemetry.NewGauge("dogstatsd", "string_interner_entries",
 		nil, "Amount of entries in the string interner used in dogstatsd")
 )
@@ -18,7 +18,8 @@ var (
 const (
 	// dropInterval controls how frequently an entry is dropped, regardless of map size.
 	// Specifically, an entry is dropped every dropInterval calls to LoadOrStore.
-	// It is recommended to use a power-of-2.
+	// This ensures that eventually old entries are evicted.
+	// It is recommended, for performance, to use a number that is power-of-2.
 	dropInterval = 256
 )
 

--- a/pkg/dogstatsd/intern.go
+++ b/pkg/dogstatsd/intern.go
@@ -3,7 +3,6 @@ package dogstatsd
 import (
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	telemetry_utils "github.com/DataDog/datadog-agent/pkg/telemetry/utils"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 var (
@@ -11,7 +10,7 @@ var (
 	// Note that it's not ideal because there are multiple string interners
 	// (one per worker) but this will still give us an insight (and it's
 	// comparable as long as the amount of worker is stable).
-	tlmSIEntries = telemetry.NewCounter("dogstatsd", "string_interner_entries",
+	tlmSIEntries = telemetry.NewGauge("dogstatsd", "string_interner_entries",
 		nil, "Amount of entries in the dogstasts string interner")
 	// Number of calls to the interner.
 	// Together with tlmSIHits can be used to calculate the hit ratio.
@@ -66,7 +65,7 @@ func (i *stringInterner) LoadOrStore(key []byte) string {
 	i.calls++
 	if i.calls % dropInterval == 0 {
 		for k := range i.strings {
-			if k == s {
+			if k == string(key) { // Temp string: should not allocate
 				// Avoid removing this entry in case it's exactly the one
 				// that we need below.
 				continue


### PR DESCRIPTION
### What does this PR do?

Improve the string interner to more gracefully handle the following cases:

- When the cardinality of the strings to be interned is significantly higher than maxSize, avoid resetting the interner too frequently
- When the cardinality of the strings to be interned is strictly lower than maxSize, avoid wasting/leaking memory for strings that are seen infrequently

### Motivation

What inspired you to submit this pull request?

### Additional Notes

WIP - DO NOT REVIEW

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
