### PR TITLE
[WIP] Improvements to string interner

### DIFF
--- a/docs/dogstatsd/internals.md
+++ b/docs/dogstatsd/internals.md
@@ -53,7 +53,7 @@ Input: slice of Packets
 Output: MetricSample sent
 
 The Worker is the part of the Dogstatsd server responsible for parsing the metrics in the bytes array and turning them into MetricSamples. The server spawns multiple workers based on the amount of cores available on the host (the amount of workers created is equal to the number of cores on the machine minus 2. If this result is less than 2, 2 workers are spawned).
-The Worker is using a system called StringInterner to not allocate memory every time a string is needed. Note that this StringInterner is caching a finite number of strings and when it is full it is emptied to start caching strings again. Its size is configurable with `dogstatsd_string_interner_size`.
+The Worker is using a system called StringInterner to not allocate memory every time a string is needed. Note that this StringInterner is caching a finite number of strings and when it is full it drops old entries to make space for new ones. Its size is configurable with `dogstatsd_string_interner_size`.
 
 The MetricSamples created are not directly sent to the Agent aggregator but first to a part called the Batcher.
 

--- a/pkg/dogstatsd/intern.go
+++ b/pkg/dogstatsd/intern.go
@@ -28,22 +28,32 @@ const (
 	// This ensures that eventually old entries are evicted.
 	// It is recommended, for performance, to use a number that is power-of-2.
 	dropInterval = 256
+	// dropSample controls how many entries are sampled, at most, to pick the least
+	// recently used when an entry needs to be dropped.
+	// Higher numbers lower the chances of recently-accessed entries to be dropped,
+	// at the expense of higher CPU usage.
+	dropSample = 3
 )
 
 // stringInterner is a string cache providing a longer life for strings,
 // helping to avoid GC runs because they're re-used many times instead of
 // created every time.
 type stringInterner struct {
-	strings map[string]string
+	strings map[string]*stringEntry
 	maxSize int
-	calls   uint64
+	calls   uint
 	// telemetry
 	tlmEnabled bool
 }
 
+type stringEntry struct {
+	str        string
+	lastAccess uint
+}
+
 func newStringInterner(maxSize int) *stringInterner {
 	return &stringInterner{
-		strings:    make(map[string]string),
+		strings:    make(map[string]*stringEntry),
 		maxSize:    maxSize,
 		tlmEnabled: telemetry_utils.IsEnabled(),
 	}
@@ -61,21 +71,10 @@ func (i *stringInterner) LoadOrStore(key []byte) string {
 	// Drop one random entry every dropInterval calls to LoadOrStore. This
 	// aims at ensuring that entries are eventually dropped even if no new
 	// entries are added.
-	// TODO: Use a LRU/LFU policy (possibly approximated via sampling).
 	i.calls++
 	if i.calls%dropInterval == 0 {
-		for k := range i.strings {
-			if k == string(key) { // Temp string: should not allocate
-				// Avoid removing this entry in case it's exactly the one
-				// that we need below.
-				continue
-			}
-			delete(i.strings, k)
-			if i.tlmEnabled {
-				tlmSIEntries.Dec()
-			}
-			break // Drop a single entry.
-		}
+		// Drop a old entry, avoding the one we are going to need below.
+		i.dropOldEntry(key)
 	}
 
 	// Silly case: it's pointless to use/lookup an entry for this.
@@ -91,31 +90,51 @@ func (i *stringInterner) LoadOrStore(key []byte) string {
 	// returning the string value -> no new heap allocation
 	// for this string.
 	// See https://github.com/golang/go/commit/f5f5a8b6209f84961687d993b93ea0d397f5d5bf
-	if s, found := i.strings[string(key)]; found {
+	if entry, found := i.strings[string(key)]; found {
+		entry.lastAccess = i.calls
 		if i.tlmEnabled {
 			tlmSIHits.Inc()
 		}
-		return s
+		return entry.str
 	}
 
 	// If adding a new entry would bring us over the maxSize limit, randomly drop one entry.
-	// TODO: Use a LRU/LFU policy (possibly approximated via sampling).
 	if len(i.strings) >= i.maxSize {
-		for k := range i.strings {
-			delete(i.strings, k)
-			if i.tlmEnabled {
-				tlmSIEntries.Dec()
-			}
-			break // Drop a single entry.
-		}
+		i.dropOldEntry(nil)
 	}
 
 	// Add the new entry.
 	s := string(key)
-	i.strings[s] = s
+	i.strings[s] = &stringEntry{str: s, lastAccess: i.calls}
 	if i.tlmEnabled {
 		tlmSIEntries.Inc()
 	}
 
 	return s
+}
+
+func (i *stringInterner) dropOldEntry(excludedKey []byte) {
+	var victim *stringEntry
+	sample := dropSample
+	for _, entry := range i.strings {
+		if string(excludedKey) == entry.str { // Does not allocate.
+			// We do not consider this entry for deletion.
+			continue
+		}
+		if sample <= 0 {
+			break
+		}
+		sample--
+		if victim == nil || victim.lastAccess > entry.lastAccess {
+			// Either we have no victim yet, or the current victim has been
+			// accessed more recently than the current entry.
+			victim = entry
+		}
+	}
+	if victim != nil {
+		delete(i.strings, victim.str)
+		if i.tlmEnabled {
+			tlmSIEntries.Dec()
+		}
+	}
 }

--- a/pkg/dogstatsd/intern.go
+++ b/pkg/dogstatsd/intern.go
@@ -3,16 +3,31 @@ package dogstatsd
 import (
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	telemetry_utils "github.com/DataDog/datadog-agent/pkg/telemetry/utils"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 var (
-	// Amount of resets of the string interner used in dogstatsd
-	// Note that it's not ideal because there is many allocated string interner
-	// (one per worker) but it'll still give us an insight (and it's comparable
-	// as long as the amount of worker is stable).
-	tlmSIResets = telemetry.NewCounter("dogstatsd", "string_interner_resets",
-		nil, "Amount of resets of the string interner used in dogstatsd")
+	// Amount of entries in the string interner used in dogstatsd.
+	// Note that it's not ideal because there are multiple string interners
+	// (one per worker) but this will still give us an insight (and it's
+	// comparable as long as the amount of worker is stable).
+	tlmSIEntries = telemetry.NewGauge("dogstatsd", "string_interner_entries",
+		nil, "Amount of entries in the dogstasts string interner")
+	// Number of calls to the interner.
+	// Together with tlmSIHits can be used to calculate the hit ratio.
+	tlmSICalls = telemetry.NewCounter("dogstatsd", "string_interner_calls",
+		nil, "Number of calls to the dogstatsd string interner")
+	// Number of hits to strings already in the interner.
+	// Together with tlmSICalls can be used to calculate the hit ratio.
+	tlmSIHits = telemetry.NewCounter("dogstatsd", "string_interner_hits",
+		nil, "Number of hits in the dogstatsd string interner")
+)
+
+const (
+	// dropInterval controls how frequently an entry is dropped, regardless of map size.
+	// Specifically, an entry is dropped every dropInterval calls to LoadOrStore.
+	// This ensures that eventually old entries are evicted.
+	// It is recommended, for performance, to use a number that is power-of-2.
+	dropInterval = 256
 )
 
 // stringInterner is a string cache providing a longer life for strings,
@@ -21,6 +36,7 @@ var (
 type stringInterner struct {
 	strings map[string]string
 	maxSize int
+	calls   uint64
 	// telemetry
 	tlmEnabled bool
 }
@@ -36,24 +52,70 @@ func newStringInterner(maxSize int) *stringInterner {
 // LoadOrStore always returns the string from the cache, adding it into the
 // cache if needed.
 // If we need to store a new entry and the cache is at its maximum capacity,
-// it is reset.
+// an existing entry is randomly dropped.
 func (i *stringInterner) LoadOrStore(key []byte) string {
-	// here is the string interner trick: the map lookup using
-	// string(key) doesn't actually allocate a string, but is
+	if i.tlmEnabled {
+		tlmSICalls.Inc()
+	}
+
+	// Drop one random entry every dropInterval calls to LoadOrStore. This
+	// aims at ensuring that entries are eventually dropped even if no new
+	// entries are added.
+	// TODO: Use a LRU/LFU policy (possibly approximated via sampling).
+	i.calls++
+	if i.calls%dropInterval == 0 {
+		for k := range i.strings {
+			if k == string(key) { // Temp string: should not allocate
+				// Avoid removing this entry in case it's exactly the one
+				// that we need below.
+				continue
+			}
+			delete(i.strings, k)
+			if i.tlmEnabled {
+				tlmSIEntries.Dec()
+			}
+			break // Drop a single entry.
+		}
+	}
+
+	// Silly case: it's pointless to use/lookup an entry for this.
+	if len(key) == 0 {
+		if i.tlmEnabled {
+			tlmSIHits.Inc()
+		}
+		return ""
+	}
+
+	// This is the string interner trick: the map lookup using
+	// string(key) does not actually allocate a string, but is
 	// returning the string value -> no new heap allocation
 	// for this string.
 	// See https://github.com/golang/go/commit/f5f5a8b6209f84961687d993b93ea0d397f5d5bf
 	if s, found := i.strings[string(key)]; found {
+		if i.tlmEnabled {
+			tlmSIHits.Inc()
+		}
 		return s
 	}
+
+	// If adding a new entry would bring us over the maxSize limit, randomly drop one entry.
+	// TODO: Use a LRU/LFU policy (possibly approximated via sampling).
 	if len(i.strings) >= i.maxSize {
-		i.strings = make(map[string]string)
-		log.Debug("clearing the string interner cache")
-		if i.tlmEnabled {
-			tlmSIResets.Inc()
+		for k := range i.strings {
+			delete(i.strings, k)
+			if i.tlmEnabled {
+				tlmSIEntries.Dec()
+			}
+			break // Drop a single entry.
 		}
 	}
+
+	// Add the new entry.
 	s := string(key)
 	i.strings[s] = s
+	if i.tlmEnabled {
+		tlmSIEntries.Inc()
+	}
+
 	return s
 }


### PR DESCRIPTION
### What does this PR do?

Improve the interning logic to avoid the reset on overflow behavior: use instead a pseudo-LRU policy (like the one used for key expiration in redis) to respect the configured maxSize.

### Motivation

Improve the string interner to more gracefully handle the following cases:

- When the cardinality of the strings to be interned is significantly higher than maxSize, avoid resetting the interner too frequently
- When the cardinality of the strings to be interned is strictly lower than maxSize, avoid wasting/leaking memory for strings that are seen infrequently

### Additional Notes



### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
