### PR TITLE
[runtime-security] fix the `TestProcessLineage` test

### DIFF
--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -640,7 +640,7 @@ func TestProcessMetadata(t *testing.T) {
 	})
 }
 
-func TestProcessLineage(t *testing.T) {
+func TestProcessExecExit(t *testing.T) {
 	executable := "/usr/bin/touch"
 	if resolved, err := os.Readlink(executable); err == nil {
 		executable = resolved
@@ -662,7 +662,6 @@ func TestProcessLineage(t *testing.T) {
 	defer test.Close()
 
 	var execPid int // will be set by the first fork event
-	var lastEvent model.EventType
 
 	err = test.GetProbeEvent(func() error {
 		cmd := exec.Command(executable, "-t", "01010101", "/dev/null")
@@ -673,35 +672,48 @@ func TestProcessLineage(t *testing.T) {
 		}
 
 		switch event.GetEventType() {
-		case model.ForkEventType:
-			if filename, err := event.GetFieldValue("process.file.name"); err == nil && filename.(string) == "testsuite" {
-				testProcessLineageFork(t, event)
-				execPid = int(event.ProcessContext.Pid)
-			}
 		case model.ExecEventType:
-			if lastEvent != model.ForkEventType {
-				t.Error("exec event should follow a fork event")
-			}
-			if err := testProcessLineageExec(t, event); err != nil {
-				t.Error(err)
+			if isExpectedExecEvent(event) {
+				execPid = int(event.ProcessContext.Pid)
+				if err := testProcessEEExec(t, event); err != nil {
+					t.Error(err)
+				}
 			}
 		case model.ExitEventType:
-			if lastEvent != model.ExecEventType {
-				t.Error("exit event should follow an exec event")
-			}
 			return true
 		}
-		lastEvent = event.GetEventType()
 		return false
-	}, time.Second*3, model.ForkEventType, model.ExecEventType, model.ExitEventType)
+	}, time.Second*3, model.ExecEventType, model.ExitEventType)
 	if err != nil {
 		t.Error(err)
 	}
 
-	testProcessLineageExit(t, uint32(execPid), test)
+	testProcessEEExit(t, uint32(execPid), test)
 }
 
-func testProcessLineageExec(t *testing.T, event *probe.Event) error {
+func isExpectedExecEvent(event *sprobe.Event) bool {
+	if event.GetEventType() != model.ExecEventType {
+		return false
+	}
+
+	basename, err := event.GetFieldValue("exec.file.name")
+	if err != nil {
+		return false
+	}
+
+	if basename.(string) != "touch" {
+		return false
+	}
+
+	args, err := event.GetFieldValue("exec.args")
+	if err != nil {
+		return false
+	}
+
+	return strings.Contains(args.(string), "01010101")
+}
+
+func testProcessEEExec(t *testing.T, event *probe.Event) error {
 	// check for the new process context
 	cacheEntry := event.ResolveProcessCacheEntry()
 	if cacheEntry == nil {
@@ -718,32 +730,7 @@ func testProcessLineageExec(t *testing.T, event *probe.Event) error {
 	return nil
 }
 
-func testProcessLineageFork(t *testing.T, event *probe.Event) {
-	// we need to make sure that the child entry if properly populated with its parent metadata
-	newEntry := event.ResolveProcessCacheEntry()
-	if newEntry == nil {
-		t.Errorf("expected a new process cache entry, got nil")
-	} else {
-		// fetch the parent of the new entry, it should the test binary itself
-		parentEntry := newEntry.Ancestor
-
-		if parentEntry == nil {
-			t.Errorf("expected a parent cache entry, got nil")
-		} else {
-			// checking cookie and pathname str should be enough to make sure that the metadata were properly
-			// copied from kernel space (those 2 information are stored in 2 different maps)
-			assert.Equal(t, parentEntry.Cookie, newEntry.Cookie, "wrong cookie")
-			assert.Equal(t, parentEntry.Pid, newEntry.PPid, "wrong ppid")
-			assert.Equal(t, parentEntry.ContainerID, newEntry.ContainerID, "wrong container id")
-
-			// We can't check that the new entry is in the list of the children of its parent because the exit event
-			// has probably already been processed (thus the parent list of children has already been updated and the
-			// child entry deleted).
-		}
-	}
-}
-
-func testProcessLineageExit(t *testing.T, pid uint32, test *testModule) {
+func testProcessEEExit(t *testing.T, pid uint32, test *testModule) {
 	// make sure that the process cache entry of the process was properly deleted from the cache
 	err := retry.Do(func() error {
 		resolvers := test.probe.GetResolvers()

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -676,8 +676,8 @@ func TestProcessLineage(t *testing.T) {
 		case model.ForkEventType:
 			if filename, err := event.GetFieldValue("process.file.name"); err == nil && filename.(string) == "testsuite" {
 				testProcessLineageFork(t, event)
+				execPid = int(event.ProcessContext.Pid)
 			}
-			execPid = int(event.ProcessContext.Pid)
 		case model.ExecEventType:
 			if lastEvent != model.ForkEventType {
 				t.Error("exec event should follow a fork event")

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -667,20 +667,18 @@ func TestProcessExecExit(t *testing.T) {
 		cmd := exec.Command(executable, "-t", "01010101", "/dev/null")
 		return cmd.Run()
 	}, func(event *sprobe.Event) bool {
-		if execPid != 0 && int(event.ProcessContext.Pid) != execPid {
-			return false
-		}
-
 		switch event.GetEventType() {
 		case model.ExecEventType:
-			if isExpectedExecEvent(event) {
+			if testProcessEEIsExpectedExecEvent(event) {
 				execPid = int(event.ProcessContext.Pid)
 				if err := testProcessEEExec(t, event); err != nil {
 					t.Error(err)
 				}
 			}
 		case model.ExitEventType:
-			return true
+			if execPid != 0 && int(event.ProcessContext.Pid) == execPid {
+				return true
+			}
 		}
 		return false
 	}, time.Second*3, model.ExecEventType, model.ExitEventType)
@@ -691,7 +689,7 @@ func TestProcessExecExit(t *testing.T) {
 	testProcessEEExit(t, uint32(execPid), test)
 }
 
-func isExpectedExecEvent(event *sprobe.Event) bool {
+func testProcessEEIsExpectedExecEvent(event *sprobe.Event) bool {
 	if event.GetEventType() != model.ExecEventType {
 		return false
 	}


### PR DESCRIPTION
### What does this PR do?

This PR fixes the `TestProcessLineage` functional test that could fail if exit events interleaved themselves between steps.

### Motivation

Fix a flaky test.
Example of failing test runs (search for `FAIL: TestProcessLineage`):
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/76839249/raw
- https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/76842299/raw

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
