### PR TITLE
[KSMCore] Add `kube_<kind>:<owner name>` tags to pod metrics

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -9,6 +9,7 @@ package ksm
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
 
@@ -22,6 +23,7 @@ import (
 	kubestatemetrics "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/builder"
 	ksmstore "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/store"
 	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -35,6 +37,11 @@ import (
 const (
 	kubeStateMetricsCheckName = "kubernetes_state_core"
 	maximumWaitForAPIServer   = 10 * time.Second
+
+	// createdByKind represents the KSM label key created_by_kind
+	createdByKind = "created_by_kind"
+	// createdByName represents the KSM label key created_by_name
+	createdByName = "created_by_name"
 )
 
 // KSMConfig contains the check config parameters
@@ -371,16 +378,28 @@ func (k *KSMCheck) hostnameAndTags(labels map[string]string, labelJoiner *labelJ
 	}
 
 	// apply label joins
+	ownerKind, ownerName := "", ""
 	for _, label := range labelsToAdd {
-		tag, hostTag := k.buildTag(label.key, label.value)
-		tags = append(tags, tag)
-		if hostTag != "" {
-			if k.clusterName != "" {
-				hostname = hostTag + "-" + k.clusterName
-			} else {
-				hostname = hostTag
+		switch label.key {
+		case createdByKind:
+			ownerKind = label.value
+		case createdByName:
+			ownerName = label.value
+		default:
+			tag, hostTag := k.buildTag(label.key, label.value)
+			tags = append(tags, tag)
+			if hostTag != "" {
+				if k.clusterName != "" {
+					hostname = hostTag + "-" + k.clusterName
+				} else {
+					hostname = hostTag
+				}
 			}
 		}
+	}
+
+	if owners := ownerTags(ownerKind, ownerName); len(owners) != 0 {
+		tags = append(tags, owners...)
 	}
 
 	return hostname, append(tags, k.instance.Tags...)
@@ -587,4 +606,35 @@ func buildDeniedMetricsSet(collectors []string) options.MetricSet {
 	}
 
 	return deniedMetrics
+}
+
+// ownerTags returns kube_<kind> tags based on given kind and name.
+// If the owner is a replicaset, it tries to get the kube_deployment tag in addition to kube_replica_set.
+// If the owner is a job, it tries to get the kube_cronjob tag in addition to kube_job.
+func ownerTags(kind, name string) []string {
+	if kind == "" || name == "" {
+		log.Debugf("Empty kind: %q or name: %q", kind, name)
+		return nil
+	}
+
+	tagKey, found := kubernetes.KindToTagName[kind]
+	if !found {
+		log.Debugf("Unknown owner kind %q", kind)
+		return nil
+	}
+
+	tagFormat := "%s:%s"
+	tags := []string{fmt.Sprintf(tagFormat, tagKey, name)}
+	switch kind {
+	case kubernetes.JobKind:
+		if cronjob := kubernetes.ParseCronJobForJob(name); cronjob != "" {
+			return append(tags, fmt.Sprintf(tagFormat, kubernetes.CronJobTagName, cronjob))
+		}
+	case kubernetes.ReplicaSetKind:
+		if deployment := kubernetes.ParseDeploymentForReplicaSet(name); deployment != "" {
+			return append(tags, fmt.Sprintf(tagFormat, kubernetes.DeploymentTagName, deployment))
+		}
+	}
+
+	return tags
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -158,7 +158,7 @@ var (
 		},
 		"kube_pod_info": {
 			LabelsToMatch: []string{"pod", "namespace"},
-			LabelsToGet:   []string{"node"},
+			LabelsToGet:   []string{"node", "created_by_kind", "created_by_name"},
 		},
 		"kube_persistentvolume_info": {
 			LabelsToMatch: []string{"persistentvolume"}, // persistent volumes are not namespaced

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -1051,3 +1051,60 @@ func TestKSMCheckInitTags(t *testing.T) {
 		})
 	}
 }
+
+func TestOwnerTags(t *testing.T) {
+	tests := []struct {
+		tc   string
+		kind string
+		name string
+		want []string
+	}{
+		{
+			tc:   "rs + deploy",
+			kind: "ReplicaSet",
+			name: "foo-6768ddc4d",
+			want: []string{"kube_replica_set:foo-6768ddc4d", "kube_deployment:foo"},
+		},
+		{
+			tc:   "rs only",
+			kind: "ReplicaSet",
+			name: "foo",
+			want: []string{"kube_replica_set:foo"},
+		},
+		{
+			tc:   "job + cronjob",
+			kind: "Job",
+			name: "foo-1627309500",
+			want: []string{"kube_job:foo-1627309500", "kube_cronjob:foo"},
+		},
+		{
+			tc:   "job only",
+			kind: "Job",
+			name: "foo",
+			want: []string{"kube_job:foo"},
+		},
+		{
+			tc:   "sts",
+			kind: "StatefulSet",
+			name: "foo",
+			want: []string{"kube_stateful_set:foo"},
+		},
+		{
+			tc:   "ds",
+			kind: "DaemonSet",
+			name: "foo",
+			want: []string{"kube_daemon_set:foo"},
+		},
+		{
+			tc:   "replication",
+			kind: "ReplicationController",
+			name: "foo",
+			want: []string{"kube_replication_controller:foo"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.tc, func(t *testing.T) {
+			assert.EqualValues(t, tt.want, ownerTags(tt.kind, tt.name))
+		})
+	}
+}

--- a/pkg/tagger/collectors/kubelet_extract_test.go
+++ b/pkg/tagger/collectors/kubelet_extract_test.go
@@ -1300,52 +1300,6 @@ func TestParsePods(t *testing.T) {
 	}
 }
 
-func TestParseDeploymentForReplicaSet(t *testing.T) {
-	for in, out := range map[string]string{
-		// Nominal 1.6 cases
-		"frontend-2891696001":  "frontend",
-		"front-end-2891696001": "front-end",
-
-		// Non-deployment 1.6 cases
-		"frontend2891696001":  "",
-		"-frontend2891696001": "",
-		"manually-created":    "",
-
-		// 1.8+ nominal cases
-		"frontend-56c89cfff7":   "frontend",
-		"frontend-56c":          "frontend",
-		"frontend-56c89cff":     "frontend",
-		"frontend-56c89cfff7c2": "frontend",
-		"front-end-768dd754b7":  "front-end",
-
-		// 1.8+ non-deployment cases
-		"frontend-5f":         "", // too short
-		"frontend-56a89cfff7": "", // no vowels allowed
-	} {
-		t.Run(fmt.Sprintf("case: %s", in), func(t *testing.T) {
-			assert.Equal(t, out, parseDeploymentForReplicaSet(in))
-		})
-	}
-}
-
-func TestParseCronJobForJob(t *testing.T) {
-	for in, out := range map[string]string{
-		"hello-1562319360": "hello",
-		"hello-600":        "hello",
-		"hello-world":      "",
-		"hello":            "",
-		"-hello1562319360": "",
-		"hello1562319360":  "",
-		"hello60":          "",
-		"hello-60":         "",
-		"hello-1562319a60": "",
-	} {
-		t.Run(fmt.Sprintf("case: %s", in), func(t *testing.T) {
-			assert.Equal(t, out, parseCronJobForJob(in))
-		})
-	}
-}
-
 func Test_parseJSONValue(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/pkg/util/kubernetes/helpers.go
+++ b/pkg/util/kubernetes/helpers.go
@@ -1,0 +1,64 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package kubernetes
+
+import (
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
+)
+
+// KubeAllowedEncodeStringAlphaNums holds the charactes allowed in replicaset names from as parent deployment
+// Taken from https://github.com/kow3ns/kubernetes/blob/96067e6d7b24a05a6a68a0d94db622957448b5ab/staging/src/k8s.io/apimachinery/pkg/util/rand/rand.go#L76
+const KubeAllowedEncodeStringAlphaNums = "bcdfghjklmnpqrstvwxz2456789"
+
+// Digits holds the digits used for naming replicasets in kubenetes < 1.8
+const Digits = "1234567890"
+
+// ParseDeploymentForReplicaSet gets the deployment name from a replicaset,
+// or returns an empty string if no parent deployment is found.
+func ParseDeploymentForReplicaSet(name string) string {
+	lastDash := strings.LastIndexAny(name, "-")
+	if lastDash == -1 {
+		// No dash
+		return ""
+	}
+	suffix := name[lastDash+1:]
+	if len(suffix) < 3 {
+		// Suffix is variable length but we cutoff at 3+ characters
+		return ""
+	}
+
+	if !utils.StringInRuneset(suffix, Digits) && !utils.StringInRuneset(suffix, KubeAllowedEncodeStringAlphaNums) {
+		// Invalid suffix
+		return ""
+	}
+
+	return name[:lastDash]
+}
+
+// ParseCronJobForJob gets the cronjob name from a job,
+// or returns an empty string if no parent cronjob is found.
+// https://github.com/kubernetes/kubernetes/blob/b4e3bd381bd4d7c0db1959341b39558b45187345/pkg/controller/cronjob/utils.go#L156
+func ParseCronJobForJob(name string) string {
+	lastDash := strings.LastIndexAny(name, "-")
+	if lastDash == -1 {
+		// No dash
+		return ""
+	}
+	suffix := name[lastDash+1:]
+	if len(suffix) < 3 {
+		// Suffix is variable length but we cutoff at 3+ characters
+		return ""
+	}
+
+	if !utils.StringInRuneset(suffix, Digits) {
+		// Invalid suffix
+		return ""
+	}
+
+	return name[:lastDash]
+}

--- a/pkg/util/kubernetes/helpers_test.go
+++ b/pkg/util/kubernetes/helpers_test.go
@@ -1,0 +1,59 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package kubernetes
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseDeploymentForReplicaSet(t *testing.T) {
+	for in, out := range map[string]string{
+		// Nominal 1.6 cases
+		"frontend-2891696001":  "frontend",
+		"front-end-2891696001": "front-end",
+
+		// Non-deployment 1.6 cases
+		"frontend2891696001":  "",
+		"-frontend2891696001": "",
+		"manually-created":    "",
+
+		// 1.8+ nominal cases
+		"frontend-56c89cfff7":   "frontend",
+		"frontend-56c":          "frontend",
+		"frontend-56c89cff":     "frontend",
+		"frontend-56c89cfff7c2": "frontend",
+		"front-end-768dd754b7":  "front-end",
+
+		// 1.8+ non-deployment cases
+		"frontend-5f":         "", // too short
+		"frontend-56a89cfff7": "", // no vowels allowed
+	} {
+		t.Run(fmt.Sprintf("case: %s", in), func(t *testing.T) {
+			assert.Equal(t, out, ParseDeploymentForReplicaSet(in))
+		})
+	}
+}
+
+func TestParseCronJobForJob(t *testing.T) {
+	for in, out := range map[string]string{
+		"hello-1562319360": "hello",
+		"hello-600":        "hello",
+		"hello-world":      "",
+		"hello":            "",
+		"-hello1562319360": "",
+		"hello1562319360":  "",
+		"hello60":          "",
+		"hello-60":         "",
+		"hello-1562319a60": "",
+	} {
+		t.Run(fmt.Sprintf("case: %s", in), func(t *testing.T) {
+			assert.Equal(t, out, ParseCronJobForJob(in))
+		})
+	}
+}

--- a/releasenotes-dca/notes/ksm-core-owner-tags-950d8dca71c3652a.yaml
+++ b/releasenotes-dca/notes/ksm-core-owner-tags-950d8dca71c3652a.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    The Kube State Metrics Core check adds owner tags to pod metrics.
+    (e.g ``kube_deployment``, ``kube_replica_set``, ``kube_cronjob``, ``kube_job``)

--- a/releasenotes/notes/ksm-core-owner-tags-950d8dca71c3652a.yaml
+++ b/releasenotes/notes/ksm-core-owner-tags-950d8dca71c3652a.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    The Kube State Metrics Core check adds owner tags to pod metrics.
+    (e.g ``kube_deployment``, ``kube_replica_set``, ``kube_cronjob``, ``kube_job``)


### PR DESCRIPTION
### What does this PR do?

Add owner tags to ksm core pod metrics. (`kube_deployment`, `kube_replica_set`, `kube_cronjob`, `kube_job`, `kube_daemon_set`, `kube_stateful_set`)

### Motivation

FR

### Describe how to test your changes

`kubernetes_state.pod.*` and `kubernetes_state.container.*` metrics corresponding to pods that are attached to basic k8s objects should now have `kube_<kind>:<owner name>` tags.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
