### PR TITLE
Allow Windows containers entrypoint executable to take command from environment variable

### DIFF
--- a/Dockerfiles/agent/entrypoint.d.windows/_default.ps1
+++ b/Dockerfiles/agent/entrypoint.d.windows/_default.ps1
@@ -1,1 +1,0 @@
-C:\entrypoint.exe datadogagent

--- a/Dockerfiles/agent/entrypoint.d.windows/agent.ps1
+++ b/Dockerfiles/agent/entrypoint.d.windows/agent.ps1
@@ -1,1 +1,0 @@
-C:\Program` Files\Datadog\Datadog` Agent\bin\agent.exe run

--- a/Dockerfiles/agent/entrypoint.d.windows/process-agent.ps1
+++ b/Dockerfiles/agent/entrypoint.d.windows/process-agent.ps1
@@ -1,1 +1,0 @@
-C:\Program` Files\Datadog\Datadog` Agent\bin\agent\process-agent.exe -foreground -config=C:/ProgramData/Datadog/datadog.yaml

--- a/Dockerfiles/agent/entrypoint.d.windows/security-agent.ps1
+++ b/Dockerfiles/agent/entrypoint.d.windows/security-agent.ps1
@@ -1,1 +1,0 @@
-C:\Program` Files\Datadog\Datadog` Agent\bin\agent\security-agent.exe start -c=C:/ProgramData/Datadog/datadog.yaml

--- a/Dockerfiles/agent/entrypoint.d.windows/trace-agent.ps1
+++ b/Dockerfiles/agent/entrypoint.d.windows/trace-agent.ps1
@@ -1,1 +1,0 @@
-C:\Program` Files\Datadog\Datadog` Agent\bin\agent\trace-agent.exe -foreground -config=C:/ProgramData/Datadog/datadog.yaml

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -19,8 +19,5 @@ ADD entrypoint-ps1 ./entrypoint-ps1
 COPY datadog*.yaml C:/ProgramData/Datadog/
 COPY install_info C:/ProgramData/Datadog/
 
-# Single entrypoint
-COPY entrypoint.ps1 C:/entrypoint.ps1
-COPY entrypoint.d.windows C:/ProgramData/entrypoints
-
-CMD C:\entrypoint.ps1
+ENTRYPOINT ["C:/entrypoint.exe"]
+CMD ["datadogagent"]

--- a/Dockerfiles/agent/windows/entrypoint/entrypoint.cpp
+++ b/Dockerfiles/agent/windows/entrypoint/entrypoint.cpp
@@ -12,6 +12,7 @@
 #include <string>
 #include <tchar.h>
 #include <thread>
+#include <cstdlib>
 #include <Windows.h>
 #include "Process.h"
 #include "Service.h"
@@ -22,11 +23,15 @@ namespace
     // Synchronizes the reception of the CTRL signal
     HANDLE CtrlSignalReceivedEvent = INVALID_HANDLE_VALUE;
 
+    const std::wstring TRUE_STR = L"TRUE";
+
+    // The keys between service and entrypoints must be unique
     const std::map<std::wstring, std::filesystem::path> services =
     {
-        {L"datadogagent", "C:\\ProgramData\\Datadog\\logs\\agent.log"},
-        {L"datadog-process-agent", "C:\\ProgramData\\Datadog\\logs\\process-agent.log"},
-        {L"datadog-trace-agent", "C:\\ProgramData\\Datadog\\logs\\trace-agent.log"},
+        {L"datadogagent", L"C:\\ProgramData\\Datadog\\logs\\agent.log"},
+        {L"datadog-process-agent", L"C:\\ProgramData\\Datadog\\logs\\process-agent.log"},
+        {L"datadog-trace-agent", L"C:\\ProgramData\\Datadog\\logs\\trace-agent.log"},
+        {L"datadog-security-agent", L"C:\\ProgramData\\Datadog\\logs\\security-agent.log"},
     };
 
     std::string FormatErrorCode(DWORD errorCode)
@@ -35,6 +40,20 @@ namespace
         sstream << "[" << errorCode << " (0x" << std::hex << errorCode << ")]";
         return sstream.str();
     }
+}
+
+const std::wstring GetEnvVar(std::wstring const& name)
+{
+    _TCHAR* buf = nullptr;
+    size_t sz = 0;
+    std::wstring val;
+    if (_wdupenv_s(&buf, &sz, name.c_str()) == 0 && buf != nullptr)
+    {
+        val.assign(buf);
+        free(buf);
+    }
+
+    return val;
 }
 
 BOOL WINAPI CtrlHandle(DWORD dwCtrlType)
@@ -63,6 +82,7 @@ void ExecuteInitScripts()
     for (auto& script : directoryIt)
     {
         Process pwsh = Process::Create(L"pwsh " + script.path().wstring());
+        std::cout << "[ENTRYPOINT][INFO] Running init script: " << script.path().string() << std::endl;
         DWORD exitCode = pwsh.WaitForExit();
         if (exitCode != 0)
         {
@@ -181,7 +201,8 @@ int _tmain(int argc, _TCHAR** argv)
 {
     DWORD exitCode = -1;
 
-    if (argc <= 1)
+    auto command = GetEnvVar(L"ENTRYPOINT");
+    if (argc <= 1 && command.empty())
     {
         std::cout << "Usage: entrypoint.exe <service> | <executable> <args>" << std::endl;
         return -1;
@@ -209,8 +230,16 @@ int _tmain(int argc, _TCHAR** argv)
 
     try
     {
-        ExecuteInitScripts();
-        const std::wstring command = argv[1];
+        auto runInitScripts = GetEnvVar(L"ENTRYPOINT_INITSCRIPTS");
+        if (runInitScripts.empty() || runInitScripts.compare(TRUE_STR) == 0)
+        {
+            ExecuteInitScripts();
+        }
+
+        // We checked earlier that argc >= 2 if command is empty
+        if (command.empty()) {
+            command.assign(argv[1]);
+        }
 
         auto svcIt = services.find(command);
         if (svcIt != services.end())


### PR DESCRIPTION
### What does this PR do?

Fix #8490: reverting entrypoint to be `entrypoint.exe` and add support for env var to `entrypoint.exe` to still allow initial goal.

### Motivation

Bugfix.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
