### PR TITLE
pkg/trace/agent: increase maximum tag (meta & metric) size to 25k bytes.

### DIFF
--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -41,7 +41,7 @@ import (
 func TestFormatTrace(t *testing.T) {
 	assert := assert.New(t)
 	resource := "SELECT name FROM people WHERE age = 42"
-	rep := strings.Repeat(" AND age = 42", 5000)
+	rep := strings.Repeat(" AND age = 42", 25000)
 	resource = resource + rep
 	testTrace := pb.Trace{
 		&pb.Span{
@@ -56,7 +56,7 @@ func TestFormatTrace(t *testing.T) {
 	assert.NotContains(result.Resource, "42")
 	assert.Contains(result.Resource, "SELECT name FROM people WHERE age = ?")
 
-	assert.Equal(5003, len(result.Meta["sql.query"])) // Ellipsis added in quantizer
+	assert.Equal(25003, len(result.Meta["sql.query"])) // Ellipsis added in quantizer
 	assert.NotEqual("Non-parsable SQL query", result.Meta["sql.query"])
 	assert.NotContains(result.Meta["sql.query"], "42")
 	assert.Contains(result.Meta["sql.query"], "SELECT name FROM people WHERE age = ?")

--- a/pkg/trace/agent/truncator_test.go
+++ b/pkg/trace/agent/truncator_test.go
@@ -86,7 +86,7 @@ func TestTruncateMetaKeyTooLong(t *testing.T) {
 
 func TestTruncateMetaValueTooLong(t *testing.T) {
 	s := testSpan()
-	val := strings.Repeat("TOOLONG", 5000)
+	val := strings.Repeat("TOOLONG", 25000)
 	s.Meta["foo"] = val
 	Truncate(s)
 	for _, v := range s.Meta {

--- a/pkg/trace/traceutil/truncate.go
+++ b/pkg/trace/traceutil/truncate.go
@@ -22,7 +22,7 @@ const (
 	// MaxMetaKeyLen the maximum length of metadata key
 	MaxMetaKeyLen = 200
 	// MaxMetaValLen the maximum length of metadata value
-	MaxMetaValLen = 5000
+	MaxMetaValLen = 25000
 	// MaxMetricsKeyLen the maximum length of a metric name key
 	MaxMetricsKeyLen = MaxMetaKeyLen
 )

--- a/releasenotes/notes/apm-update-meta-and-metrics-maximum-length-edc779e32cc6dcfe.yaml
+++ b/releasenotes/notes/apm-update-meta-and-metrics-maximum-length-edc779e32cc6dcfe.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Move the maximum meta and metrics value length from 5k to 25k

--- a/releasenotes/notes/apm-update-meta-and-metrics-maximum-length-edc779e32cc6dcfe.yaml
+++ b/releasenotes/notes/apm-update-meta-and-metrics-maximum-length-edc779e32cc6dcfe.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Move the maximum meta and metrics value length from 5k to 25k
+    APM: The maximum allowed tag value length has been increased to 25,000 bytes.


### PR DESCRIPTION
### What does this PR do?

Update meta and metrics limit to 25k instead of 5k

### Motivation

For some attributes such as stacktraces, it will be helpful to increase that limit

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
