### PR TITLE
[runtime-security] use a bit mask when using event_type discarder

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "868ba5412961b23252ac6a6accdc6ba61fe00092150168807a5664afa28d980a")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "2546d4a08debcbb02547e5c558cda8d25aca218a3ed9d8a531e9bf2aa82aa774")

--- a/pkg/security/ebpf/c/discarders.h
+++ b/pkg/security/ebpf/c/discarders.h
@@ -151,14 +151,14 @@ int __attribute__((always_inline)) discard_inode(u64 event_type, u32 mount_id, u
 
     struct inode_discarder_params_t *inode_params = bpf_map_lookup_elem(&inode_discarders, &key);
     if (inode_params) {
-        inode_params->params.event_mask |= event_type;
+        inode_params->params.event_mask |= 1 << event_type;
 
         if ((discarder_timestamp = get_discarder_timestamp(&inode_params->params, event_type)) != NULL) {
             *discarder_timestamp = timestamp;
         }
     } else {
         struct inode_discarder_params_t new_inode_params = {
-            .params.event_mask = event_type,
+            .params.event_mask = 1 << event_type,
             .revision = get_discarder_revision(mount_id),
         };
 


### PR DESCRIPTION
### What does this PR do?

Make use of a bit mask when placing the event_type in the discarder mask, otherwise we can have conflict between event_types. Some file access could discarder some expected event.

### Motivation

Some event are discarder while they shouldn't.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
