### PR TITLE
Add comments about thread-safety of safeConfig

### DIFF
--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -56,6 +56,9 @@ func (c *safeConfig) SetKnown(key string) {
 func (c *safeConfig) GetKnownKeys() map[string]interface{} {
 	c.Lock()
 	defer c.Unlock()
+
+	// GetKnownKeys returns a fresh map, so the caller may do with it
+	// as they please without holding the lock.
 	return c.Viper.GetKnownKeys()
 }
 
@@ -340,6 +343,9 @@ func (c *safeConfig) MergeConfigOverride(in io.Reader) error {
 func (c *safeConfig) AllSettings() map[string]interface{} {
 	c.Lock()
 	defer c.Unlock()
+
+	// AllSettings returns a fresh map, so the caller may do with it
+	// as they please without holding the lock.
 	return c.Viper.AllSettings()
 }
 


### PR DESCRIPTION
AGNTGLD-63 raised the issue that these accesses *look* like they are returning data protected by a lock without holding that lock.  It turns out, they aren't, so this adds comments to that effect.  I've added similar comments to the Viper fork in https://github.com/DataDog/viper/pull/18.

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
