### PR TITLE
Lock loadedConfigs while in use

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -24,7 +24,6 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	"github.com/DataDog/datadog-agent/cmd/agent/gui"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
 	"github.com/DataDog/datadog-agent/pkg/flare"
@@ -349,12 +348,7 @@ func getConfigCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	configSlice := make([]integration.Config, 0)
-	common.AC.WithLoadedConfigs(func(loadedConfigs map[string]integration.Config) {
-		for _, config := range loadedConfigs {
-			configSlice = append(configSlice, config)
-		}
-	})
+	configSlice := common.AC.AllLoadedConfigs()
 	sort.Slice(configSlice, func(i, j int) bool {
 		return configSlice[i].Name < configSlice[j].Name
 	})

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -349,11 +349,12 @@ func getConfigCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	configs := common.AC.GetLoadedConfigs()
 	configSlice := make([]integration.Config, 0)
-	for _, config := range configs {
-		configSlice = append(configSlice, config)
-	}
+	common.AC.WithLoadedConfigs(func(loadedConfigs map[string]integration.Config) {
+		for _, config := range loadedConfigs {
+			configSlice = append(configSlice, config)
+		}
+	})
 	sort.Slice(configSlice, func(i, j int) bool {
 		return configSlice[i].Name < configSlice[j].Name
 	})

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -348,7 +348,7 @@ func getConfigCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	configSlice := common.AC.AllLoadedConfigs()
+	configSlice := common.AC.CurrentLoadedConfigs()
 	sort.Slice(configSlice, func(i, j int) bool {
 		return configSlice[i].Name < configSlice[j].Name
 	})

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -348,7 +348,7 @@ func getConfigCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	configSlice := common.AC.CurrentLoadedConfigs()
+	configSlice := common.AC.LoadedConfigs()
 	sort.Slice(configSlice, func(i, j int) bool {
 		return configSlice[i].Name < configSlice[j].Name
 	})

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -148,11 +148,12 @@ func getConfigCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	configs := common.AC.GetLoadedConfigs()
 	configSlice := make([]integration.Config, 0)
-	for _, config := range configs {
-		configSlice = append(configSlice, config)
-	}
+	common.AC.WithLoadedConfigs(func(loadedConfigs map[string]integration.Config) {
+		for _, config := range loadedConfigs {
+			configSlice = append(configSlice, config)
+		}
+	})
 	sort.Slice(configSlice, func(i, j int) bool {
 		return configSlice[i].Name < configSlice[j].Name
 	})

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -20,7 +20,6 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
 	"github.com/DataDog/datadog-agent/pkg/flare"
@@ -148,12 +147,7 @@ func getConfigCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	configSlice := make([]integration.Config, 0)
-	common.AC.WithLoadedConfigs(func(loadedConfigs map[string]integration.Config) {
-		for _, config := range loadedConfigs {
-			configSlice = append(configSlice, config)
-		}
-	})
+	configSlice := common.AC.AllLoadedConfigs()
 	sort.Slice(configSlice, func(i, j int) bool {
 		return configSlice[i].Name < configSlice[j].Name
 	})

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -147,7 +147,7 @@ func getConfigCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	configSlice := common.AC.CurrentLoadedConfigs()
+	configSlice := common.AC.LoadedConfigs()
 	sort.Slice(configSlice, func(i, j int) bool {
 		return configSlice[i].Name < configSlice[j].Name
 	})

--- a/cmd/cluster-agent/api/agent/agent.go
+++ b/cmd/cluster-agent/api/agent/agent.go
@@ -147,7 +147,7 @@ func getConfigCheck(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	configSlice := common.AC.AllLoadedConfigs()
+	configSlice := common.AC.CurrentLoadedConfigs()
 	sort.Slice(configSlice, func(i, j int) bool {
 		return configSlice[i].Name < configSlice[j].Name
 	})

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -415,12 +415,7 @@ func (ac *AutoConfig) AddScheduler(name string, s scheduler.Scheduler, replayCon
 		return
 	}
 
-	var configs []integration.Config
-	ac.store.withLoadedConfigs(func(loadedConfigs map[string]integration.Config) {
-		for _, c := range loadedConfigs {
-			configs = append(configs, c)
-		}
-	})
+	configs := ac.AllLoadedConfigs()
 	s.Schedule(configs)
 }
 
@@ -574,6 +569,20 @@ func (ac *AutoConfig) WithLoadedConfigs(f func(map[string]integration.Config)) {
 		return
 	}
 	ac.store.withLoadedConfigs(f)
+}
+
+// AllLoadedConfigs returns a slice of all loaded configs.  This slice
+// is freshly created and will not be modified after return.
+func (ac *AutoConfig) AllLoadedConfigs() []integration.Config {
+	var configs []integration.Config
+	ac.store.withLoadedConfigs(func(loadedConfigs map[string]integration.Config) {
+		configs = make([]integration.Config, 0, len(loadedConfigs))
+		for _, c := range loadedConfigs {
+			configs = append(configs, c)
+		}
+	})
+
+	return configs
 }
 
 // GetUnresolvedTemplates returns templates in cache yet to be resolved

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -478,9 +478,8 @@ func (ac *AutoConfig) removeConfigTemplates(configs []integration.Config) {
 		if c.IsTemplate() {
 			// Remove the resolved configurations
 			tplDigest := c.Digest()
-			configs := ac.store.getConfigsForTemplate(tplDigest)
-			ac.store.removeConfigsForTemplate(tplDigest)
-			ac.processRemovedConfigs(configs)
+			removedConfigs := ac.store.removeConfigsForTemplate(tplDigest)
+			ac.processRemovedConfigs(removedConfigs)
 
 			// Remove template from the cache
 			err := ac.store.templateCache.Del(c)

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -645,9 +645,8 @@ func (ac *AutoConfig) processNewService(ctx context.Context, svc listeners.Servi
 // processDelService takes a service, stops its associated checks, and updates the cache
 func (ac *AutoConfig) processDelService(svc listeners.Service) {
 	ac.store.removeServiceForEntity(svc.GetEntity())
-	configs := ac.store.getConfigsForService(svc.GetEntity())
-	ac.store.removeConfigsForService(svc.GetEntity())
-	ac.processRemovedConfigs(configs)
+	removedConfigs := ac.store.removeConfigsForService(svc.GetEntity())
+	ac.processRemovedConfigs(removedConfigs)
 	ac.store.removeTagsHashForService(svc.GetTaggerEntity())
 	// FIXME: unschedule remove services as well
 	ac.unschedule([]integration.Config{

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -415,7 +415,7 @@ func (ac *AutoConfig) AddScheduler(name string, s scheduler.Scheduler, replayCon
 		return
 	}
 
-	configs := ac.AllLoadedConfigs()
+	configs := ac.CurrentLoadedConfigs()
 	s.Schedule(configs)
 }
 
@@ -559,23 +559,23 @@ func (ac *AutoConfig) resolveTemplateForService(tpl integration.Config, svc list
 	return resolvedConfig, nil
 }
 
-// WithLoadedConfigs calls the given function with the map of all
+// MapOverLoadedConfigs calls the given function with the map of all
 // loaded configs.  This is done with the config store locked, so
 // callers should perform minimal work within f.
-func (ac *AutoConfig) WithLoadedConfigs(f func(map[string]integration.Config)) {
+func (ac *AutoConfig) MapOverLoadedConfigs(f func(map[string]integration.Config)) {
 	if ac == nil || ac.store == nil {
 		log.Error("Autoconfig store not initialized")
 		f(map[string]integration.Config{})
 		return
 	}
-	ac.store.withLoadedConfigs(f)
+	ac.store.mapOverLoadedConfigs(f)
 }
 
-// AllLoadedConfigs returns a slice of all loaded configs.  This slice
+// CurrentLoadedConfigs returns a slice of all loaded configs.  This slice
 // is freshly created and will not be modified after return.
-func (ac *AutoConfig) AllLoadedConfigs() []integration.Config {
+func (ac *AutoConfig) CurrentLoadedConfigs() []integration.Config {
 	var configs []integration.Config
-	ac.store.withLoadedConfigs(func(loadedConfigs map[string]integration.Config) {
+	ac.store.mapOverLoadedConfigs(func(loadedConfigs map[string]integration.Config) {
 		configs = make([]integration.Config, 0, len(loadedConfigs))
 		for _, c := range loadedConfigs {
 			configs = append(configs, c)

--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -415,7 +415,7 @@ func (ac *AutoConfig) AddScheduler(name string, s scheduler.Scheduler, replayCon
 		return
 	}
 
-	configs := ac.CurrentLoadedConfigs()
+	configs := ac.LoadedConfigs()
 	s.Schedule(configs)
 }
 
@@ -571,9 +571,9 @@ func (ac *AutoConfig) MapOverLoadedConfigs(f func(map[string]integration.Config)
 	ac.store.mapOverLoadedConfigs(f)
 }
 
-// CurrentLoadedConfigs returns a slice of all loaded configs.  This slice
+// LoadedConfigs returns a slice of all loaded configs.  This slice
 // is freshly created and will not be modified after return.
-func (ac *AutoConfig) CurrentLoadedConfigs() []integration.Config {
+func (ac *AutoConfig) LoadedConfigs() []integration.Config {
 	var configs []integration.Config
 	ac.store.mapOverLoadedConfigs(func(loadedConfigs map[string]integration.Config) {
 		configs = make([]integration.Config, 0, len(loadedConfigs))

--- a/pkg/autodiscovery/autoconfig_test.go
+++ b/pkg/autodiscovery/autoconfig_test.go
@@ -325,6 +325,14 @@ func TestResolveTemplate(t *testing.T) {
 	assert.Len(t, res, 1)
 }
 
+func countLoadedConfigs(ac *AutoConfig) int {
+	count := -1 // -1 would indicate f was not called
+	ac.WithLoadedConfigs(func(loadedConfigs map[string]integration.Config) {
+		count = len(loadedConfigs)
+	})
+	return count
+}
+
 func TestRemoveTemplate(t *testing.T) {
 	ctx := context.Background()
 
@@ -335,7 +343,7 @@ func TestRemoveTemplate(t *testing.T) {
 		Name: "memory",
 	}
 	ac.processNewConfig(c)
-	assert.Len(t, ac.GetLoadedConfigs(), 1)
+	assert.Equal(t, countLoadedConfigs(ac), 1)
 
 	// Add new service
 	service := dummyService{
@@ -351,17 +359,16 @@ func TestRemoveTemplate(t *testing.T) {
 	}
 	configs := ac.processNewConfig(tpl)
 	assert.Len(t, configs, 1)
-	assert.Len(t, ac.GetLoadedConfigs(), 2)
+	assert.Equal(t, countLoadedConfigs(ac), 2)
 
 	// Remove the template, config should be removed too
 	ac.removeConfigTemplates([]integration.Config{tpl})
-	assert.Len(t, ac.GetLoadedConfigs(), 1)
+	assert.Equal(t, countLoadedConfigs(ac), 1)
 }
 
 func TestGetLoadedConfigNotInitialized(t *testing.T) {
 	ac := AutoConfig{}
-	cfgs := ac.GetLoadedConfigs()
-	require.Len(t, cfgs, 0)
+	assert.Equal(t, countLoadedConfigs(&ac), 0)
 }
 
 func TestCheckOverride(t *testing.T) {

--- a/pkg/autodiscovery/autoconfig_test.go
+++ b/pkg/autodiscovery/autoconfig_test.go
@@ -327,7 +327,7 @@ func TestResolveTemplate(t *testing.T) {
 
 func countLoadedConfigs(ac *AutoConfig) int {
 	count := -1 // -1 would indicate f was not called
-	ac.WithLoadedConfigs(func(loadedConfigs map[string]integration.Config) {
+	ac.MapOverLoadedConfigs(func(loadedConfigs map[string]integration.Config) {
 		count = len(loadedConfigs)
 	})
 	return count

--- a/pkg/autodiscovery/store.go
+++ b/pkg/autodiscovery/store.go
@@ -67,18 +67,14 @@ func (s *store) addConfigForService(serviceEntity string, config integration.Con
 	}
 }
 
-// getConfigsForTemplate gets config for a specified template
-func (s *store) getConfigsForTemplate(templateDigest string) []integration.Config {
-	s.m.RLock()
-	defer s.m.RUnlock()
-	return s.templateToConfigs[templateDigest]
-}
-
-// removeConfigsForTemplate removes a config for a specified template
-func (s *store) removeConfigsForTemplate(templateDigest string) {
+// removeConfigsForTemplate removes all configs for a specified template, returning
+// those configs
+func (s *store) removeConfigsForTemplate(templateDigest string) []integration.Config {
 	s.m.Lock()
 	defer s.m.Unlock()
+	removed := s.templateToConfigs[templateDigest]
 	delete(s.templateToConfigs, templateDigest)
+	return removed
 }
 
 // addConfigForTemplate adds a config for a specified template

--- a/pkg/autodiscovery/store.go
+++ b/pkg/autodiscovery/store.go
@@ -41,18 +41,14 @@ func newStore() *store {
 	return &s
 }
 
-// getConfigsForService gets config for a specified service
-func (s *store) getConfigsForService(serviceEntity string) []integration.Config {
-	s.m.RLock()
-	defer s.m.RUnlock()
-	return s.serviceToConfigs[serviceEntity]
-}
-
-// removeConfigsForService removes a config for a specified service
-func (s *store) removeConfigsForService(serviceEntity string) {
+// removeConfigsForService removes a config for a specified service, returning
+// the configs that were removed
+func (s *store) removeConfigsForService(serviceEntity string) []integration.Config {
 	s.m.Lock()
 	defer s.m.Unlock()
+	removed := s.serviceToConfigs[serviceEntity]
 	delete(s.serviceToConfigs, serviceEntity)
+	return removed
 }
 
 // addConfigForService adds a config for a specified service

--- a/pkg/autodiscovery/store.go
+++ b/pkg/autodiscovery/store.go
@@ -123,11 +123,13 @@ func (s *store) removeLoadedConfig(config integration.Config) {
 	delete(s.loadedConfigs, config.Digest())
 }
 
-// getLoadedConfigs returns all loaded and resolved configs
-func (s *store) getLoadedConfigs() map[string]integration.Config {
+// withLoadedConfigs calls the given function with the map of all
+// loaded configs.  This is done with the config store locked, so
+// callers should perform minimal work within f.
+func (s *store) withLoadedConfigs(f func(map[string]integration.Config)) {
 	s.m.RLock()
 	defer s.m.RUnlock()
-	return s.loadedConfigs
+	f(s.loadedConfigs)
 }
 
 // setJMXMetricsForConfigName stores the jmx metrics config for a config name

--- a/pkg/autodiscovery/store.go
+++ b/pkg/autodiscovery/store.go
@@ -115,10 +115,10 @@ func (s *store) removeLoadedConfig(config integration.Config) {
 	delete(s.loadedConfigs, config.Digest())
 }
 
-// withLoadedConfigs calls the given function with the map of all
+// mapOverLoadedConfigs calls the given function with the map of all
 // loaded configs.  This is done with the config store locked, so
 // callers should perform minimal work within f.
-func (s *store) withLoadedConfigs(f func(map[string]integration.Config)) {
+func (s *store) mapOverLoadedConfigs(f func(map[string]integration.Config)) {
 	s.m.RLock()
 	defer s.m.RUnlock()
 	f(s.loadedConfigs)

--- a/pkg/autodiscovery/store_test.go
+++ b/pkg/autodiscovery/store_test.go
@@ -28,20 +28,24 @@ func TestServiceToConfig(t *testing.T) {
 	assert.Equal(t, len(s.getConfigsForService(service.GetEntity())), 1)
 }
 
+func countConfigsForTemplate(s *store, template string) int {
+	return len(s.templateToConfigs[template])
+}
+
 func TestTemplateToConfig(t *testing.T) {
 	s := newStore()
 	s.addConfigForTemplate("digest1", integration.Config{Name: "foo"})
 	s.addConfigForTemplate("digest1", integration.Config{Name: "bar"})
 	s.addConfigForTemplate("digest2", integration.Config{Name: "foo"})
 
-	assert.Len(t, s.getConfigsForTemplate("digest1"), 2)
-	assert.Len(t, s.getConfigsForTemplate("digest2"), 1)
+	assert.Equal(t, countConfigsForTemplate(s, "digest1"), 2)
+	assert.Equal(t, countConfigsForTemplate(s, "digest2"), 1)
 
 	s.removeConfigsForTemplate("digest1")
-	assert.Len(t, s.getConfigsForTemplate("digest1"), 0)
-	assert.Len(t, s.getConfigsForTemplate("digest2"), 1)
+	assert.Equal(t, countConfigsForTemplate(s, "digest1"), 0)
+	assert.Equal(t, countConfigsForTemplate(s, "digest2"), 1)
 
 	s.addConfigForTemplate("digest1", integration.Config{Name: "foo"})
-	assert.Len(t, s.getConfigsForTemplate("digest1"), 1)
-	assert.Len(t, s.getConfigsForTemplate("digest2"), 1)
+	assert.Equal(t, countConfigsForTemplate(s, "digest1"), 1)
+	assert.Equal(t, countConfigsForTemplate(s, "digest2"), 1)
 }

--- a/pkg/autodiscovery/store_test.go
+++ b/pkg/autodiscovery/store_test.go
@@ -13,6 +13,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 )
 
+func countConfigsForTemplate(s *store, template string) int {
+	return len(s.templateToConfigs[template])
+}
+
+func countConfigsForService(s *store, service string) int {
+	return len(s.serviceToConfigs[service])
+}
+
 func TestServiceToConfig(t *testing.T) {
 	s := newStore()
 	service := dummyService{
@@ -22,14 +30,10 @@ func TestServiceToConfig(t *testing.T) {
 	}
 	s.addConfigForService(service.GetEntity(), integration.Config{Name: "foo"})
 	s.addConfigForService(service.GetEntity(), integration.Config{Name: "bar"})
-	assert.Equal(t, len(s.getConfigsForService(service.GetEntity())), 2)
+	assert.Equal(t, countConfigsForService(s, service.GetEntity()), 2)
 	s.removeConfigsForService(service.GetEntity())
 	s.addConfigForService(service.GetEntity(), integration.Config{Name: "foo"})
-	assert.Equal(t, len(s.getConfigsForService(service.GetEntity())), 1)
-}
-
-func countConfigsForTemplate(s *store, template string) int {
-	return len(s.templateToConfigs[template])
+	assert.Equal(t, countConfigsForService(s, service.GetEntity()), 1)
 }
 
 func TestTemplateToConfig(t *testing.T) {

--- a/pkg/collector/corechecks/systemd/systemd_test.go
+++ b/pkg/collector/corechecks/systemd/systemd_test.go
@@ -969,8 +969,8 @@ func TestGetPropertyBool(t *testing.T) {
 
 type mockAutoConfig struct{}
 
-func (*mockAutoConfig) GetLoadedConfigs() map[string]integration.Config {
-	return make(map[string]integration.Config)
+func (*mockAutoConfig) WithLoadedConfigs(f func(map[string]integration.Config)) {
+	f(map[string]integration.Config{})
 }
 
 type mockCollector struct{}

--- a/pkg/collector/corechecks/systemd/systemd_test.go
+++ b/pkg/collector/corechecks/systemd/systemd_test.go
@@ -969,7 +969,7 @@ func TestGetPropertyBool(t *testing.T) {
 
 type mockAutoConfig struct{}
 
-func (*mockAutoConfig) WithLoadedConfigs(f func(map[string]integration.Config)) {
+func (*mockAutoConfig) MapOverLoadedConfigs(f func(map[string]integration.Config)) {
 	f(map[string]integration.Config{})
 }
 

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -19,9 +19,9 @@ type schedulerInterface interface {
 	TriggerAndResetCollectorTimer(name string, delay time.Duration)
 }
 
-// AutoConfigInterface is an interface for the WithLoadedConfigs method of autodiscovery
+// AutoConfigInterface is an interface for the MapOverLoadedConfigs method of autodiscovery
 type AutoConfigInterface interface {
-	WithLoadedConfigs(func(map[string]integration.Config))
+	MapOverLoadedConfigs(func(map[string]integration.Config))
 }
 
 // CollectorInterface is an interface for the GetAllInstanceIDs method of the collector
@@ -135,7 +135,7 @@ func CreatePayload(ctx context.Context, hostname string, ac AutoConfigInterface,
 
 	foundInCollector := map[string]struct{}{}
 	if ac != nil {
-		ac.WithLoadedConfigs(func(loadedConfigs map[string]integration.Config) {
+		ac.MapOverLoadedConfigs(func(loadedConfigs map[string]integration.Config) {
 			for _, config := range loadedConfigs {
 				checkMetadata[config.Name] = make([]*CheckInstanceMetadata, 0)
 				instanceIDs := coll.GetAllInstanceIDs(config.Name)

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -19,9 +19,9 @@ type schedulerInterface interface {
 	TriggerAndResetCollectorTimer(name string, delay time.Duration)
 }
 
-// AutoConfigInterface is an interface for the GetLoadedConfigs method of autodiscovery
+// AutoConfigInterface is an interface for the WithLoadedConfigs method of autodiscovery
 type AutoConfigInterface interface {
-	GetLoadedConfigs() map[string]integration.Config
+	WithLoadedConfigs(func(map[string]integration.Config))
 }
 
 // CollectorInterface is an interface for the GetAllInstanceIDs method of the collector
@@ -135,16 +135,17 @@ func CreatePayload(ctx context.Context, hostname string, ac AutoConfigInterface,
 
 	foundInCollector := map[string]struct{}{}
 	if ac != nil {
-		configs := ac.GetLoadedConfigs()
-		for _, config := range configs {
-			checkMetadata[config.Name] = make([]*CheckInstanceMetadata, 0)
-			instanceIDs := coll.GetAllInstanceIDs(config.Name)
-			for _, id := range instanceIDs {
-				checkInstanceMetadata := createCheckInstanceMetadata(string(id), config.Provider)
-				checkMetadata[config.Name] = append(checkMetadata[config.Name], checkInstanceMetadata)
-				foundInCollector[string(id)] = struct{}{}
+		ac.WithLoadedConfigs(func(loadedConfigs map[string]integration.Config) {
+			for _, config := range loadedConfigs {
+				checkMetadata[config.Name] = make([]*CheckInstanceMetadata, 0)
+				instanceIDs := coll.GetAllInstanceIDs(config.Name)
+				for _, id := range instanceIDs {
+					checkInstanceMetadata := createCheckInstanceMetadata(string(id), config.Provider)
+					checkMetadata[config.Name] = append(checkMetadata[config.Name], checkInstanceMetadata)
+					foundInCollector[string(id)] = struct{}{}
+				}
 			}
-		}
+		})
 	}
 	// if metadata where added for check not in the collector we still need
 	// to add them to the checkMetadata (this happens when using the

--- a/pkg/metadata/inventories/inventories_test.go
+++ b/pkg/metadata/inventories/inventories_test.go
@@ -39,17 +39,17 @@ L:
 
 type mockAutoConfig struct{}
 
-func (*mockAutoConfig) GetLoadedConfigs() map[string]integration.Config {
-	ret := make(map[string]integration.Config)
-	ret["check1_digest"] = integration.Config{
+func (*mockAutoConfig) WithLoadedConfigs(f func(map[string]integration.Config)) {
+	configs := make(map[string]integration.Config)
+	configs["check1_digest"] = integration.Config{
 		Name:     "check1",
 		Provider: "provider1",
 	}
-	ret["check2_digest"] = integration.Config{
+	configs["check2_digest"] = integration.Config{
 		Name:     "check2",
 		Provider: "provider2",
 	}
-	return ret
+	f(configs)
 }
 
 type mockCollector struct{}

--- a/pkg/metadata/inventories/inventories_test.go
+++ b/pkg/metadata/inventories/inventories_test.go
@@ -39,7 +39,7 @@ L:
 
 type mockAutoConfig struct{}
 
-func (*mockAutoConfig) WithLoadedConfigs(f func(map[string]integration.Config)) {
+func (*mockAutoConfig) MapOverLoadedConfigs(f func(map[string]integration.Config)) {
 	configs := make(map[string]integration.Config)
 	configs["check1_digest"] = integration.Config{
 		Name:     "check1",


### PR DESCRIPTION
Since AD could modify the map of loaded configs at any time, it's
important that callers examining that list do so while the lock is held.
This is more efficient than copying the list.

### Motivation

AGNTGLD-63

### Additional Notes

I omitted a changelog since this has no user-visible impact.

Aside from `go test`, testing for this change would involve running `agent configcheck`, which uses the new `WithLoadedConfig` function.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.