### PR TITLE
[runtime-security] check that the security-agent is initialized when handling a `/status` request

### DIFF
--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -85,7 +85,9 @@ func GetStatus() (map[string]interface{}, error) {
 	}
 
 	if config.IsContainerized() {
-		stats["adConfigErrors"] = common.AC.GetAutodiscoveryErrors()
+		if common.AC != nil {
+			stats["adConfigErrors"] = common.AC.GetAutodiscoveryErrors()
+		}
 		stats["filterErrors"] = containers.GetFilterErrors()
 	}
 

--- a/releasenotes/notes/fix-security-agent-status-autodiscovery-9d6796f71e86cf16.yaml
+++ b/releasenotes/notes/fix-security-agent-status-autodiscovery-9d6796f71e86cf16.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix a bug where the status command of the security agent
+    could crash if the agent is not fully initialized.


### PR DESCRIPTION
### What does this PR do?

A bug was reported with the following stacktrace:
```
2021-07-27 19:00:39 UTC | SECURITY | INFO | (pkg/config/config.go:1198 in getResolvedDDUrl) | 'site' and 'dd_url' are both set in config: setting main endpoint to 'dd_url': "https://agent.datadoghq.com."
2021-07-27 19:00:39 UTC | SECURITY | ERROR | (/root/.gimme/versions/go1.15.11.linux.amd64/src/net/http/server.go:3093 in logf) | Error from the agent http API server: http: panic serving 127.0.0.1:59264: runtime error: invalid memory address or nil pointer dereference
goroutine 1977 [running]:
net/http.(*conn).serve.func1(0xc000f69720)
	/root/.gimme/versions/go1.15.11.linux.amd64/src/net/http/server.go:1801 +0x147
panic(0x222e740, 0x398edb0)
	/root/.gimme/versions/go1.15.11.linux.amd64/src/runtime/panic.go:975 +0x47a
github.com/DataDog/datadog-agent/pkg/autodiscovery.(*AutoConfig).GetAutodiscoveryErrors(0x0, 0xf)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/autodiscovery/autoconfig.go:653 +0x34
github.com/DataDog/datadog-agent/pkg/status.GetStatus(0x238e980, 0xc0009a75c0, 0x2572272)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/status/status.go:86 +0x80a
github.com/DataDog/datadog-agent/cmd/security-agent/api/agent.(*Agent).getStatus(0xc000c81570, 0x28aa5a0, 0xc0008f0000, 0xc000df4d00)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/cmd/security-agent/api/agent/agent.go:82 +0x11c
net/http.HandlerFunc.ServeHTTP(0xc000a89c00, 0x28aa5a0, 0xc0008f0000, 0xc000df4d00)
	/root/.gimme/versions/go1.15.11.linux.amd64/src/net/http/server.go:2042 +0x44
github.com/DataDog/datadog-agent/cmd/security-agent/api.validateToken.func1(0x28aa5a0, 0xc0008f0000, 0xc000df4d00)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/cmd/security-agent/api/server.go:118 +0x99
net/http.HandlerFunc.ServeHTTP(0xc0009ad220, 0x28aa5a0, 0xc0008f0000, 0xc000df4d00)
	/root/.gimme/versions/go1.15.11.linux.amd64/src/net/http/server.go:2042 +0x44
github.com/gorilla/mux.(*Router).ServeHTTP(0xc000aa1980, 0x28aa5a0, 0xc0008f0000, 0xc000df4b00)
	/gomodcache/github.com/gorilla/mux@v1.8.0/mux.go:210 +0xd3
net/http.serverHandler.ServeHTTP(0xc000e92620, 0x28aa5a0, 0xc0008f0000, 0xc000df4b00)
	/root/.gimme/versions/go1.15.11.linux.amd64/src/net/http/server.go:2843 +0xa3
net/http.(*conn).serve(0xc000f69720, 0x28b13a0, 0xc001362540)
	/root/.gimme/versions/go1.15.11.linux.amd64/src/net/http/server.go:1925 +0x8ad
created by net/http.(*Server).Serve
	/root/.gimme/versions/go1.15.11.linux.amd64/src/net/http/server.go:2969 +0x36c
```

The function `GetAutodiscoveryErrors` is called on a nil `*AutoConfig`.
This PR fixes this bug by ensuring that `common.AC` is not nil before using it.


### Motivation

Bug fix

### Describe how to test your changes

--

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
