### PR TITLE
[runtime-security] Use a ticker to send process resolver hits and misses metrics

### DIFF
--- a/pkg/security/probe/perf_buffer_monitor.go
+++ b/pkg/security/probe/perf_buffer_monitor.go
@@ -66,6 +66,8 @@ type PerfBufferMonitor struct {
 	kernelStats map[string][][model.MaxEventType]PerfMapStats
 	// readLostEvents is the count of lost events, collected by reading the perf buffer
 	readLostEvents map[string][]uint64
+	// sortingErrorStats holds the count of events that indicate that at least 1 event is miss ordered
+	sortingErrorStats map[string][model.MaxEventType]*int64
 
 	// lastTimestamp is used to track the timestamp of the last event retrieved from the perf map
 	lastTimestamp uint64
@@ -73,7 +75,7 @@ type PerfBufferMonitor struct {
 
 // NewPerfBufferMonitor instantiates a new event statistics counter
 func NewPerfBufferMonitor(p *Probe, client *statsd.Client) (*PerfBufferMonitor, error) {
-	es := PerfBufferMonitor{
+	pbm := PerfBufferMonitor{
 		probe:               p,
 		statsdClient:        client,
 		perfBufferStatsMaps: make(map[string]*lib.Map),
@@ -82,23 +84,24 @@ func NewPerfBufferMonitor(p *Probe, client *statsd.Client) (*PerfBufferMonitor, 
 		perfBufferMapNameToStatsMapsName: probes.GetPerfBufferStatisticsMaps(),
 		statsMapsNameToPerfBufferMapName: make(map[string]string),
 
-		stats:          make(map[string][][model.MaxEventType]PerfMapStats),
-		kernelStats:    make(map[string][][model.MaxEventType]PerfMapStats),
-		readLostEvents: make(map[string][]uint64),
+		stats:             make(map[string][][model.MaxEventType]PerfMapStats),
+		kernelStats:       make(map[string][][model.MaxEventType]PerfMapStats),
+		readLostEvents:    make(map[string][]uint64),
+		sortingErrorStats: make(map[string][model.MaxEventType]*int64),
 	}
 	numCPU, err := utils.NumCPU()
 	if err != nil {
 		return nil, errors.Wrapf(err, "couldn't fetch the host CPU count")
 	}
-	es.numCPU = numCPU
+	pbm.numCPU = numCPU
 
 	// compute statsMapPerfMap
-	for perfMap, statsMap := range es.perfBufferMapNameToStatsMapsName {
-		es.statsMapsNameToPerfBufferMapName[statsMap] = perfMap
+	for perfMap, statsMap := range pbm.perfBufferMapNameToStatsMapsName {
+		pbm.statsMapsNameToPerfBufferMapName[statsMap] = perfMap
 	}
 
 	// Select perf buffer statistics maps
-	for perfMapName, statsMapName := range es.perfBufferMapNameToStatsMapsName {
+	for perfMapName, statsMapName := range pbm.perfBufferMapNameToStatsMapsName {
 		stats, ok, err := p.manager.GetMap(statsMapName)
 		if !ok {
 			return nil, errors.Errorf("map %s not found", statsMapName)
@@ -107,33 +110,40 @@ func NewPerfBufferMonitor(p *Probe, client *statsd.Client) (*PerfBufferMonitor, 
 			return nil, err
 		}
 
-		es.perfBufferStatsMaps[perfMapName] = stats
+		pbm.perfBufferStatsMaps[perfMapName] = stats
 		// set default perf buffer size, it will be readjusted in the next loop if needed
-		es.perfBufferSize[perfMapName] = float64(p.managerOptions.DefaultPerfRingBufferSize)
+		pbm.perfBufferSize[perfMapName] = float64(p.managerOptions.DefaultPerfRingBufferSize)
 	}
 
 	// Prepare user space counters
 	for _, m := range p.manager.PerfMaps {
 		var stats, kernelStats [][model.MaxEventType]PerfMapStats
 		var usrLostEvents []uint64
+		var sortingErrorStats [model.MaxEventType]*int64
 
-		for i := 0; i < es.numCPU; i++ {
+		for i := 0; i < pbm.numCPU; i++ {
 			stats = append(stats, [model.MaxEventType]PerfMapStats{})
 			kernelStats = append(kernelStats, [model.MaxEventType]PerfMapStats{})
 			usrLostEvents = append(usrLostEvents, 0)
 		}
 
-		es.stats[m.Name] = stats
-		es.kernelStats[m.Name] = kernelStats
-		es.readLostEvents[m.Name] = usrLostEvents
+		for i := 0; i < int(model.MaxEventType); i++ {
+			zero := int64(0)
+			sortingErrorStats[i] = &zero
+		}
+
+		pbm.stats[m.Name] = stats
+		pbm.kernelStats[m.Name] = kernelStats
+		pbm.readLostEvents[m.Name] = usrLostEvents
+		pbm.sortingErrorStats[m.Name] = sortingErrorStats
 
 		// update perf buffer size if needed
 		if m.PerfRingBufferSize != 0 {
-			es.perfBufferSize[m.Name] = float64(m.PerfRingBufferSize)
+			pbm.perfBufferSize[m.Name] = float64(m.PerfRingBufferSize)
 		}
 	}
-	log.Debugf("monitoring perf ring buffer on %d CPU, %d events", es.numCPU, model.MaxEventType)
-	return &es, nil
+	log.Debugf("monitoring perf ring buffer on %d CPU, %d events", pbm.numCPU, model.MaxEventType)
+	return &pbm, nil
 }
 
 // getLostCount is an internal function, it can segfault if its parameters are incorrect.
@@ -289,6 +299,11 @@ func (pbm *PerfBufferMonitor) getAndResetEventBytes(eventType model.EventType, p
 	return atomic.SwapUint64(&pbm.stats[perfMap][cpu][eventType].Bytes, 0)
 }
 
+// getAndResetSortingErrorCount is an internal function, it can segfault if its parameters are incorrect.
+func (pbm *PerfBufferMonitor) getAndResetSortingErrorCount(eventType model.EventType, perfMap string) int64 {
+	return atomic.SwapInt64(pbm.sortingErrorStats[perfMap][eventType], 0)
+}
+
 // CountLostEvent adds `count` to the counter of lost events
 func (pbm *PerfBufferMonitor) CountLostEvent(count uint64, m *manager.PerfMap, cpu int) {
 	// sanity check
@@ -302,12 +317,7 @@ func (pbm *PerfBufferMonitor) CountLostEvent(count uint64, m *manager.PerfMap, c
 func (pbm *PerfBufferMonitor) CountEvent(eventType model.EventType, timestamp uint64, count uint64, size uint64, m *manager.PerfMap, cpu int) {
 	// check event order
 	if timestamp < pbm.lastTimestamp && pbm.lastTimestamp != 0 {
-		tags := metrics.SetTagsWithCardinality(
-			pbm.probe.config.StatsTagsCardinality,
-			fmt.Sprintf("map:%s", m.Name),
-			fmt.Sprintf("event_type:%s", eventType),
-		)
-		_ = pbm.statsdClient.Count(metrics.MetricPerfBufferSortingError, 1, tags, 1.0)
+		atomic.AddInt64(pbm.sortingErrorStats[m.Name][eventType], 1)
 	} else {
 		pbm.lastTimestamp = timestamp
 	}
@@ -322,26 +332,31 @@ func (pbm *PerfBufferMonitor) CountEvent(eventType model.EventType, timestamp ui
 }
 
 func (pbm *PerfBufferMonitor) sendEventsAndBytesReadStats(client *statsd.Client) error {
+	var count int64
+	var err error
+	tags := []string{pbm.probe.config.StatsTagsCardinality, "", ""}
+
 	for m := range pbm.stats {
+		tags[1] = fmt.Sprintf("map:%s", m)
 		for cpu := range pbm.stats[m] {
 			for eventType := range pbm.stats[m][cpu] {
 				evtType := model.EventType(eventType)
-				tags := metrics.SetTagsWithCardinality(
-					pbm.probe.config.StatsTagsCardinality,
-					fmt.Sprintf("map:%s", m),
-					fmt.Sprintf("event_type:%s", evtType),
-				)
+				tags[2] = fmt.Sprintf("event_type:%s", evtType)
 
-				count := float64(pbm.getAndResetEventCount(evtType, m, cpu))
-				if count > 0 {
-					if err := client.Count(metrics.MetricPerfBufferEventsRead, int64(count), tags, 1.0); err != nil {
+				if count = int64(pbm.getAndResetEventCount(evtType, m, cpu)); count > 0 {
+					if err = client.Count(metrics.MetricPerfBufferEventsRead, count, tags, 1.0); err != nil {
 						return err
 					}
 				}
 
-				count = float64(pbm.getAndResetEventBytes(evtType, m, cpu))
-				if count > 0 {
-					if err := client.Count(metrics.MetricPerfBufferBytesRead, int64(count), tags, 1.0); err != nil {
+				if count = int64(pbm.getAndResetEventBytes(evtType, m, cpu)); count > 0 {
+					if err = client.Count(metrics.MetricPerfBufferBytesRead, count, tags, 1.0); err != nil {
+						return err
+					}
+				}
+
+				if count = pbm.getAndResetSortingErrorCount(evtType, m); count > 0 {
+					if err = pbm.statsdClient.Count(metrics.MetricPerfBufferSortingError, count, tags, 1.0); err != nil {
 						return err
 					}
 				}
@@ -352,14 +367,13 @@ func (pbm *PerfBufferMonitor) sendEventsAndBytesReadStats(client *statsd.Client)
 }
 
 func (pbm *PerfBufferMonitor) sendLostEventsReadStats(client *statsd.Client) error {
+	tags := []string{pbm.probe.config.StatsTagsCardinality, ""}
+
 	for m := range pbm.readLostEvents {
 		var total float64
+		tags[1] = fmt.Sprintf("map:%s", m)
 
 		for cpu := range pbm.readLostEvents[m] {
-			tags := metrics.SetTagsWithCardinality(
-				pbm.probe.config.StatsTagsCardinality,
-				fmt.Sprintf("map:%s", m),
-			)
 			if count := float64(pbm.getAndResetReadLostCount(m, cpu)); count > 0 {
 				if err := client.Count(metrics.MetricPerfBufferLostRead, int64(count), tags, 1.0); err != nil {
 					return err
@@ -381,16 +395,17 @@ func (pbm *PerfBufferMonitor) collectAndSendKernelStats(client *statsd.Client) e
 	var (
 		id       uint32
 		iterator *lib.MapIterator
-		tags     []string
 		tmpCount uint64
 	)
 	cpuStats := make([]PerfMapStats, pbm.numCPU)
+	tags := []string{pbm.probe.config.StatsTagsCardinality, "", ""}
 
 	// loop through the statistics buffers of each perf map
 	for perfMapName, statsMap := range pbm.perfBufferStatsMaps {
 		// total and perEvent are used for alerting
 		var total uint64
 		perEvent := map[string]uint64{}
+		tags[1] = fmt.Sprintf("map:%s", perfMapName)
 
 		// loop through all the values of the active buffer
 		iterator = statsMap.Iterate()
@@ -402,6 +417,7 @@ func (pbm *PerfBufferMonitor) collectAndSendKernelStats(client *statsd.Client) e
 
 			// retrieve event type from key
 			evtType := model.EventType(id % uint32(model.MaxEventType))
+			tags[2] = fmt.Sprintf("event_type:%s", evtType)
 
 			// loop over each cpu entry
 			for cpu, stats := range cpuStats {
@@ -417,13 +433,6 @@ func (pbm *PerfBufferMonitor) collectAndSendKernelStats(client *statsd.Client) e
 				if _, ok := perEvent[evtType.String()]; !ok {
 					perEvent[evtType.String()] = 0
 				}
-
-				// prepare metrics tags
-				tags = metrics.SetTagsWithCardinality(
-					pbm.probe.config.StatsTagsCardinality,
-					fmt.Sprintf("map:%s", perfMapName),
-					fmt.Sprintf("event_type:%s", evtType),
-				)
 
 				// Update stats to avoid sending twice the same data points
 				if tmpCount = pbm.swapKernelEventBytes(evtType, perfMapName, cpu, stats.Bytes); tmpCount <= stats.Bytes {

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -11,15 +11,15 @@ import (
 	"context"
 	"sync"
 
+	"github.com/DataDog/datadog-go/statsd"
+	"github.com/DataDog/ebpf/manager"
 	"github.com/hashicorp/go-multierror"
+	"github.com/pkg/errors"
 
 	seclog "github.com/DataDog/datadog-agent/pkg/security/log"
 	"github.com/DataDog/datadog-agent/pkg/security/metrics"
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-go/statsd"
-	"github.com/DataDog/ebpf/manager"
-	"github.com/pkg/errors"
 )
 
 // Monitor regroups all the work we want to do to monitor the probes we pushed in the kernel
@@ -101,6 +101,10 @@ func (m *Monitor) SendStats() error {
 
 	if err := m.perfBufferMonitor.SendStats(); err != nil {
 		return errors.Wrap(err, "failed to send events stats")
+	}
+
+	if err := m.loadController.SendStats(); err != nil {
+		return errors.Wrap(err, "failed to send load controller stats")
 	}
 
 	return nil

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -121,6 +121,8 @@ type ProcessResolver struct {
 	pidCacheMap      *lib.Map
 	cacheSize        int64
 	opts             ProcessResolverOpts
+	hitsStats        map[string]*int64
+	missStats        *int64
 
 	entryCache    map[uint32]*model.ProcessCacheEntry
 	argsEnvsCache *simplelru.LRU
@@ -242,12 +244,37 @@ func (p *ProcessResolver) NewProcessCacheEntry() *model.ProcessCacheEntry {
 
 // SendStats sends process resolver metrics
 func (p *ProcessResolver) SendStats() error {
-	if err := p.client.Gauge(metrics.MetricProcessResolverCacheSize, p.GetCacheSize(), []string{}, 1.0); err != nil {
+	var err error
+	var count int64
+
+	if err = p.client.Gauge(metrics.MetricProcessResolverCacheSize, p.GetCacheSize(), []string{}, 1.0); err != nil {
 		return errors.Wrap(err, "failed to send process_resolver cache_size metric")
 	}
 
-	if err := p.client.Gauge(metrics.MetricProcessResolverReferenceCount, p.GetEntryCacheSize(), []string{}, 1.0); err != nil {
+	if err = p.client.Gauge(metrics.MetricProcessResolverReferenceCount, p.GetEntryCacheSize(), []string{}, 1.0); err != nil {
 		return errors.Wrap(err, "failed to send process_resolver reference_count metric")
+	}
+
+	if count = atomic.SwapInt64(p.hitsStats[metrics.CacheTag], 0); count > 0 {
+		if err = p.client.Count(metrics.MetricProcessResolverCacheHits, count, []string{metrics.CacheTag}, 1.0); err != nil {
+			return errors.Wrap(err, "failed to send process_resolver cache hits metric")
+		}
+	}
+
+	if count = atomic.SwapInt64(p.hitsStats[metrics.KernelMapsTag], 0); count > 0 {
+		if err = p.client.Count(metrics.MetricProcessResolverCacheHits, count, []string{metrics.KernelMapsTag}, 1.0); err != nil {
+			return errors.Wrap(err, "failed to send process_resolver kernel maps hits metric")
+		}
+	}
+
+	if count = atomic.SwapInt64(p.hitsStats[metrics.ProcFSTag], 0); count > 0 {
+		if err = p.client.Count(metrics.MetricProcessResolverCacheHits, atomic.SwapInt64(p.hitsStats[metrics.ProcFSTag], 0), []string{metrics.ProcFSTag}, 1.0); err != nil {
+			return errors.Wrap(err, "failed to send process_resolver procfs hits metric")
+		}
+	}
+
+	if err = p.client.Count(metrics.MetricProcessResolverCacheMiss, atomic.SwapInt64(p.missStats, 0), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send process_resolver procfs hits metric")
 	}
 
 	return nil
@@ -459,7 +486,7 @@ func (p *ProcessResolver) Resolve(pid, tid uint32) *model.ProcessCacheEntry {
 
 	entry, exists := p.entryCache[pid]
 	if exists {
-		_ = p.client.Count(metrics.MetricProcessResolverCacheHits, 1, []string{metrics.CacheTag}, 1.0)
+		atomic.AddInt64(p.hitsStats[metrics.CacheTag], 1)
 		return entry
 	}
 
@@ -469,17 +496,17 @@ func (p *ProcessResolver) Resolve(pid, tid uint32) *model.ProcessCacheEntry {
 
 	// fallback to the kernel maps directly, the perf event may be delayed / may have been lost
 	if entry = p.resolveWithKernelMaps(pid, tid); entry != nil {
-		_ = p.client.Count(metrics.MetricProcessResolverCacheHits, 1, []string{metrics.KernelMapsTag}, 1.0)
+		atomic.AddInt64(p.hitsStats[metrics.KernelMapsTag], 1)
 		return entry
 	}
 
 	// fallback to /proc, the in-kernel LRU may have deleted the entry
 	if entry = p.resolveWithProcfs(pid, procResolveMaxDepth); entry != nil {
-		_ = p.client.Count(metrics.MetricProcessResolverCacheHits, 1, []string{metrics.ProcFSTag}, 1.0)
+		atomic.AddInt64(p.hitsStats[metrics.ProcFSTag], 1)
 		return entry
 	}
 
-	_ = p.client.Count(metrics.MetricProcessResolverCacheMiss, 1, []string{}, 1.0)
+	atomic.AddInt64(p.missStats, 1)
 	return nil
 }
 
@@ -906,6 +933,7 @@ func NewProcessResolver(probe *Probe, resolvers *Resolvers, client *statsd.Clien
 		return nil, err
 	}
 
+	zero := int64(0)
 	p := &ProcessResolver{
 		probe:         probe,
 		resolvers:     resolvers,
@@ -915,8 +943,14 @@ func NewProcessResolver(probe *Probe, resolvers *Resolvers, client *statsd.Clien
 		argsEnvsCache: argsEnvsCache,
 		state:         snapshotting,
 		argsEnvsPool:  NewArgsEnvsPool(),
+		hitsStats:     map[string]*int64{},
+		missStats:     &zero,
 	}
 	p.processCacheEntryPool = NewProcessCacheEntryPool(p)
+	for _, t := range metrics.AllTypesTags {
+		hits := int64(0)
+		p.hitsStats[t] = &hits
+	}
 
 	return p, nil
 }


### PR DESCRIPTION
### What does this PR do?

This PR ensures that we use a ticker to send process resolver hits and misses instead of interacting with a dogstatsd client directly.

### Motivation

If the process resolver is spammed at a very high rate, this will put a significant pressure on dogstatsd. This PR is here to make sure that whatever the rate at which the process resolver is hit, we emit the same amount of data points.

### Describe how to test your changes

Generate processes in a loop and make sure that the amount of queries to dogstatsd doesn't blow up (look at the `datadog.agent.dogstatsd.processed` metric).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
