### PR TITLE
Tag release candidate images when deploying the agent

### DIFF
--- a/.gitlab/deploy_6/docker.yml
+++ b/.gitlab/deploy_6/docker.yml
@@ -9,7 +9,7 @@
 # Image tagging & manifest publication
 #
 
-deploy-a6:
+.deploy-a6-base:
   extends: .docker_job_definition
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main"]
@@ -21,13 +21,23 @@ deploy-a6:
     - python3 -m pip install -r requirements.txt
     - export VERSION="$(inv -e agent.version --major-version 6 --url-safe)"
     - export IMG_SOURCES="${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6${JMX}-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6${JMX}-arm64"
-    - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}${JMX}"
+    - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}${IMG_TAG_SUFFIX}${JMX}"
     - inv pipeline.trigger-child-pipeline --project-name "DataDog/public-images" --git-ref "main" --variables "IMG_REGISTRIES,IMG_SOURCES,IMG_DESTINATIONS"
   parallel:
     matrix:
       - JMX:
           - ""
           - "-jmx"
+
+
+deploy-a6:
+  extends: .deploy-a6-base
+
+
+deploy-a6-rc:
+  extends: .deploy-a6-base
+  variables:
+    IMG_TAG_SUFFIX: -rc
 
 
 #

--- a/.gitlab/deploy_7/docker.yml
+++ b/.gitlab/deploy_7/docker.yml
@@ -9,7 +9,7 @@
 # Image tagging & manifest publication
 #
 
-deploy-a7:
+.deploy-a7-base:
   extends: .docker_job_definition
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main"]
@@ -23,7 +23,7 @@ deploy-a7:
     - export IMG_LINUX_SOURCES="${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7${JMX}-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7${JMX}-arm64"
     - export IMG_WINDOWS_SOURCES="${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7${JMX}-win1809${SERVERCORE}-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7${JMX}-win1909${SERVERCORE}-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7${JMX}-win2004${SERVERCORE}-amd64"
     - if [[ "$SERVERCORE" == "-servercore" ]]; then export IMG_SOURCES="${IMG_WINDOWS_SOURCES}"; else export IMG_SOURCES="${IMG_LINUX_SOURCES},${IMG_WINDOWS_SOURCES}"; fi
-    - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}${SERVERCORE}${JMX}"
+    - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}{$IMG_TAG_SUFFIX}${SERVERCORE}${JMX}"
     - inv pipeline.trigger-child-pipeline --project-name "DataDog/public-images" --git-ref "main" --variables "IMG_REGISTRIES,IMG_SOURCES,IMG_DESTINATIONS"
   parallel:
     matrix:
@@ -33,6 +33,16 @@ deploy-a7:
         SERVERCORE:
           - ""
           - "-servercore"
+
+
+deploy-a7:
+  extends: .deploy-a7-base
+
+
+deploy-a7-rc:
+  extends: .deploy-a7-base
+  variables:
+    IMG_TAG_SUFFIX: -rc
 
 
 deploy-dogstatsd:


### PR DESCRIPTION
### What does this PR do?

This creates two new pipeline jobs when $DEPLOY_AGENT == true:
deploy-a7-rc and deploy-a6-rc, both only manually triggered. These jobs
are meant to tag release candidate images with the `7-rc{-jmx}` and
`6-rc{-jmx}` tags, to make the ongoing security scan of images easier
during the process of a release.

### Describe how to test your changes

While releasing a release candidate of the agent, trigger the deploy-a7-rc and deploy-a6-rc jobs, and check on dockerhub that the `7-rc{-jmx}` and `6-rc{-jmx}` tags exist and point to the image that was just released.
