### PR TITLE
[runtime-security] Simplify serializers

### DIFF
--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -117,8 +117,8 @@ type CapsetSerializer struct {
 // ProcessCredentialsSerializer serializes the process credentials to JSON
 // easyjson:json
 type ProcessCredentialsSerializer struct {
-	*CredentialsSerializer `json:",omitempty"`
-	Destination            interface{} `json:"destination,omitempty"`
+	*CredentialsSerializer
+	Destination interface{} `json:"destination,omitempty"`
 }
 
 // ProcessCacheEntrySerializer serializes a process cache entry to JSON
@@ -159,8 +159,8 @@ type ContainerContextSerializer struct {
 // FileEventSerializer serializes a file event to JSON
 // easyjson:json
 type FileEventSerializer struct {
-	FileSerializer `json:",omitempty"`
-	Destination    *FileSerializer `json:"destination,omitempty"`
+	FileSerializer
+	Destination *FileSerializer `json:"destination,omitempty"`
 
 	// Specific to mount events
 	NewMountID uint32 `json:"new_mount_id,omitempty"`


### PR DESCRIPTION
### What does this PR do?

This PR removes useless json tags in the serializers. The presence of those tags was confusing for tools that try to generate json schema based on those tags (https://github.com/alecthomas/jsonschema for exemple).

Please note that `easy_json` was run on this file and resulted in no change in the generated file, thus confirming that removing those tags has no impact.

### Motivation

The final motivation is to generate documentation for those json fields automatically. Generating json schema is one of the first step of this journey.

### Describe how to test your changes

This change should result in no change.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
