### PR TITLE
Copy the list of source pointers in LogSources#GetSources

### DIFF
--- a/pkg/logs/config/sources.go
+++ b/pkg/logs/config/sources.go
@@ -88,7 +88,7 @@ func (s *LogSources) GetRemovedForType(sourceType string) chan *LogSource {
 
 // GetSources returns all the sources currently held.  The result is copied and
 // will not be modified after it is returned.  However, the copy in the LogSources
-// instane may change in that time (changing indexes or adding/removing entries).
+// instance may change in that time (changing indexes or adding/removing entries).
 func (s *LogSources) GetSources() []*LogSource {
 	s.mu.Lock()
 	defer s.mu.Unlock()

--- a/pkg/logs/config/sources.go
+++ b/pkg/logs/config/sources.go
@@ -86,10 +86,13 @@ func (s *LogSources) GetRemovedForType(sourceType string) chan *LogSource {
 	return stream
 }
 
-// GetSources returns all the sources currently held.
+// GetSources returns all the sources currently held.  The result is copied and
+// will not be modified after it is returned.  However, the copy in the LogSources
+// instane may change in that time (changing indexes or adding/removing entries).
 func (s *LogSources) GetSources() []*LogSource {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	return s.sources
+	clone := append([]*LogSource{}, s.sources...)
+	return clone
 }


### PR DESCRIPTION
This avoids the situation where the slice is modified while callers are
iterating over it, which may cause "missed" elements when removing
sources.

### Motivation

AGNTGLD-63 / AC-1106

### Additional Notes

This might have caused errors in `github.com/DataDog/datadog-agent/pkg/scheduler.Scheduler#Unschedule`, in the case where it attempted to remove two contiguous Sources from the LogSources object, as the elements would be shifted beneath the iteration, and the second Source would be missed.

### Describe how to test your changes

* `go test`
* Schedule / Unschedule multiple log sources

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
