### PR TITLE
Add a checklist item for team label

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@ and instructions on how this should be tested in QA.
 - [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
 - [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
 - [ ] The appropriate `team/..` label has been applied, if known.
-- [ ] An appropriate milestone has been selected, if known.
+- [ ]  if known, an appropriate milestone has been selected otherwise `Triage` milestone is set.
 - [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
 
 Note: Adding GitHub labels is only possible for contributors with write access.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,8 @@ and instructions on how this should be tested in QA.
 
 - [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
 - [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
+- [ ] The appropriate `team/..` label has been applied, if known.
+- [ ] An appropriate milestone has been selected, if known.
 - [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
 
 Note: Adding GitHub labels is only possible for contributors with write access.


### PR DESCRIPTION
### Motivation

I keep getting red X's for the `team_label` check, so this will remind me and hopefully everyone else to add the label.

### Additional Notes

If there's some way that this should be set automatically, that I have missed, please let me know!

