### PR TITLE
Make Serverless team owner of cmd/serverless directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -95,6 +95,7 @@
 /cmd/cluster-agent-cloudfoundry/        @DataDog/integrations-tools-and-libraries
 /cmd/cluster-agent/api/v1/cloudfoundry_metadata.go        @DataDog/integrations-tools-and-libraries
 /cmd/process-agent/                     @DataDog/processes
+/cmd/serverless/                        @DataDog/serverless
 /cmd/system-probe/                      @DataDog/agent-network
 /cmd/security-agent/                    @DataDog/agent-security
 


### PR DESCRIPTION
### What does this PR do?

Changes the CODEOWNER of the `cmd/serverless` directory from agent-core to serverless.

### Motivation

This code is only used by the Serverless agent and is maintained by the Serverless team.
