### PR TITLE
[runtime-security]go generate protection check

### DIFF
--- a/.gitlab/source_test.yml
+++ b/.gitlab/source_test.yml
@@ -8,3 +8,4 @@ include:
   - /.gitlab/source_test/linux.yml
   - /.gitlab/source_test/security_scan.yml
   - /.gitlab/source_test/windows.yml
+  - /.gitlab/source_test/go_generate_check.yml

--- a/.gitlab/source_test/go_generate_check.yml
+++ b/.gitlab/source_test/go_generate_check.yml
@@ -1,16 +1,12 @@
 ---
 # check that go generate has been run in the pkg/security directory
 security_go_generate_check:
-  extends: .tests_linux_ebpf
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   tags: [ "runner:main", "size:large" ]
   stage: source_test
   needs: [ "linux_x64_go_deps" ]
-  variables:
-    ARCH: amd64
   before_script:
     - !reference [.retrieve_linux_go_deps]
-    - cd $SRC_PATH
   script:
     - go generate ./pkg/security/...
     - git status --porcelain

--- a/.gitlab/source_test/go_generate_check.yml
+++ b/.gitlab/source_test/go_generate_check.yml
@@ -1,0 +1,17 @@
+---
+# check that go generate has been run in the pkg/security directory
+security_go_generate_check:
+  extends: .tests_linux_ebpf
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
+  tags: [ "runner:main", "size:large" ]
+  stage: source_test
+  needs: [ "linux_x64_go_deps" ]
+  variables:
+    ARCH: amd64
+  before_script:
+    - !reference [.retrieve_linux_go_deps]
+    - cd $SRC_PATH
+  script:
+    - go generate ./pkg/security/...
+    - git status --porcelain
+    - test -z "$(git status --porcelain)"


### PR DESCRIPTION
### What does this PR do?

This PR adds a check in the Gitlab pipeline ensuring that `go generate` has been run in the `pkg/security` subdirectory.
Here is an example of a failing run: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/77497893

### Motivation

It is easy to forget to run the go generate command, especially for the `easy_json` part of the event serializers.

### Describe how to test your changes

Changing a field name in `pkg/security/probe/serializers.go` or `pkg/security/model/model.go` should result in the `security_go_generate_check` test failing.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
