### PR TITLE
Allow 'telemetry.checks' to be set through env vars

### DIFF
--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -58,33 +58,33 @@ func setupAPM(config Config) {
 	config.BindEnvAndSetDefault("apm_config.windows_pipe_security_descriptor", "D:AI(A;;GA;;;WD)", "DD_APM_WINDOWS_PIPE_SECURITY_DESCRIPTOR") //nolint:errcheck
 	config.BindEnvAndSetDefault("apm_config.remote_tagger", false, "DD_APM_REMOTE_TAGGER")                                                    //nolint:errcheck
 
-	config.BindEnv("apm_config.max_catalog_services", "DD_APM_MAX_CATALOG_SERVICES")                     //nolint:errcheck
-	config.BindEnv("apm_config.receiver_timeout", "DD_APM_RECEIVER_TIMEOUT")                             //nolint:errcheck
-	config.BindEnv("apm_config.max_payload_size", "DD_APM_MAX_PAYLOAD_SIZE")                             //nolint:errcheck
-	config.BindEnv("apm_config.log_file", "DD_APM_LOG_FILE")                                             //nolint:errcheck
-	config.BindEnv("apm_config.max_events_per_second", "DD_APM_MAX_EPS", "DD_MAX_EPS")                   //nolint:errcheck
-	config.BindEnv("apm_config.max_traces_per_second", "DD_APM_MAX_TPS", "DD_MAX_TPS")                   //nolint:errcheck
-	config.BindEnv("apm_config.max_memory", "DD_APM_MAX_MEMORY")                                         //nolint:errcheck
-	config.BindEnv("apm_config.max_cpu_percent", "DD_APM_MAX_CPU_PERCENT")                               //nolint:errcheck
-	config.BindEnv("apm_config.env", "DD_APM_ENV")                                                       //nolint:errcheck
-	config.BindEnv("apm_config.apm_non_local_traffic", "DD_APM_NON_LOCAL_TRAFFIC")                       //nolint:errcheck
-	config.BindEnv("apm_config.apm_dd_url", "DD_APM_DD_URL")                                             //nolint:errcheck
-	config.BindEnv("apm_config.connection_limit", "DD_APM_CONNECTION_LIMIT", "DD_CONNECTION_LIMIT")      //nolint:errcheck
-	config.BindEnv("apm_config.connection_reset_interval", "DD_APM_CONNECTION_RESET_INTERVAL")           //nolint:errcheck
-	config.BindEnv("apm_config.profiling_dd_url", "DD_APM_PROFILING_DD_URL")                             //nolint:errcheck
-	config.BindEnv("apm_config.profiling_additional_endpoints", "DD_APM_PROFILING_ADDITIONAL_ENDPOINTS") //nolint:errcheck
-	config.BindEnv("apm_config.additional_endpoints", "DD_APM_ADDITIONAL_ENDPOINTS")                     //nolint:errcheck
-	config.BindEnv("apm_config.replace_tags", "DD_APM_REPLACE_TAGS")                                     //nolint:errcheck
-	config.BindEnv("apm_config.analyzed_spans", "DD_APM_ANALYZED_SPANS")                                 //nolint:errcheck
-	config.BindEnv("apm_config.ignore_resources", "DD_APM_IGNORE_RESOURCES", "DD_IGNORE_RESOURCE")       //nolint:errcheck
-	config.BindEnv("apm_config.receiver_socket", "DD_APM_RECEIVER_SOCKET")                               //nolint:errcheck
-	config.BindEnv("apm_config.windows_pipe_name", "DD_APM_WINDOWS_PIPE_NAME")                           //nolint:errcheck
-	config.BindEnv("apm_config.sync_flushing", "DD_APM_SYNC_FLUSHING")                                   //nolint:errcheck
-	config.BindEnv("apm_config.filter_tags.require", "DD_APM_FILTER_TAGS_REQUIRE")                       //nolint:errcheck
-	config.BindEnv("apm_config.filter_tags.reject", "DD_APM_FILTER_TAGS_REJECT")                         //nolint:errcheck
-	config.BindEnv("apm_config.internal_profiling.enabled", "DD_APM_INTERNAL_PROFILING_ENABLED")         //nolint:errcheck
-	config.BindEnv("experimental.otlp.http_port", "DD_OTLP_HTTP_PORT")                                   //nolint:errcheck
-	config.BindEnv("experimental.otlp.grpc_port", "DD_OTLP_GRPC_PORT")                                   //nolint:errcheck
+	config.BindEnv("apm_config.max_catalog_services", "DD_APM_MAX_CATALOG_SERVICES")
+	config.BindEnv("apm_config.receiver_timeout", "DD_APM_RECEIVER_TIMEOUT")
+	config.BindEnv("apm_config.max_payload_size", "DD_APM_MAX_PAYLOAD_SIZE")
+	config.BindEnv("apm_config.log_file", "DD_APM_LOG_FILE")
+	config.BindEnv("apm_config.max_events_per_second", "DD_APM_MAX_EPS", "DD_MAX_EPS")
+	config.BindEnv("apm_config.max_traces_per_second", "DD_APM_MAX_TPS", "DD_MAX_TPS")
+	config.BindEnv("apm_config.max_memory", "DD_APM_MAX_MEMORY")
+	config.BindEnv("apm_config.max_cpu_percent", "DD_APM_MAX_CPU_PERCENT")
+	config.BindEnv("apm_config.env", "DD_APM_ENV")
+	config.BindEnv("apm_config.apm_non_local_traffic", "DD_APM_NON_LOCAL_TRAFFIC")
+	config.BindEnv("apm_config.apm_dd_url", "DD_APM_DD_URL")
+	config.BindEnv("apm_config.connection_limit", "DD_APM_CONNECTION_LIMIT", "DD_CONNECTION_LIMIT")
+	config.BindEnv("apm_config.connection_reset_interval", "DD_APM_CONNECTION_RESET_INTERVAL")
+	config.BindEnv("apm_config.profiling_dd_url", "DD_APM_PROFILING_DD_URL")
+	config.BindEnv("apm_config.profiling_additional_endpoints", "DD_APM_PROFILING_ADDITIONAL_ENDPOINTS")
+	config.BindEnv("apm_config.additional_endpoints", "DD_APM_ADDITIONAL_ENDPOINTS")
+	config.BindEnv("apm_config.replace_tags", "DD_APM_REPLACE_TAGS")
+	config.BindEnv("apm_config.analyzed_spans", "DD_APM_ANALYZED_SPANS")
+	config.BindEnv("apm_config.ignore_resources", "DD_APM_IGNORE_RESOURCES", "DD_IGNORE_RESOURCE")
+	config.BindEnv("apm_config.receiver_socket", "DD_APM_RECEIVER_SOCKET")
+	config.BindEnv("apm_config.windows_pipe_name", "DD_APM_WINDOWS_PIPE_NAME")
+	config.BindEnv("apm_config.sync_flushing", "DD_APM_SYNC_FLUSHING")
+	config.BindEnv("apm_config.filter_tags.require", "DD_APM_FILTER_TAGS_REQUIRE")
+	config.BindEnv("apm_config.filter_tags.reject", "DD_APM_FILTER_TAGS_REJECT")
+	config.BindEnv("apm_config.internal_profiling.enabled", "DD_APM_INTERNAL_PROFILING_ENABLED")
+	config.BindEnv("experimental.otlp.http_port", "DD_OTLP_HTTP_PORT")
+	config.BindEnv("experimental.otlp.grpc_port", "DD_OTLP_GRPC_PORT")
 
 	config.SetEnvKeyTransformer("apm_config.ignore_resources", func(in string) interface{} {
 		r, err := splitCSVString(in, ',')

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -786,7 +786,7 @@ func InitConfig(config Config) {
 	// Enable telemetry metrics on the internals of the Agent.
 	// This create a lot of billable custom metrics.
 	config.BindEnvAndSetDefault("telemetry.enabled", false)
-	config.SetKnown("telemetry.checks")
+	config.BindEnv("telemetry.checks")
 	// We're using []string as a default instead of []float64 because viper can only parse list of string from the environment
 	//
 	// The histogram buckets use to track the time in nanoseconds DogStatsD listeners are not reading/waiting new data

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -173,8 +173,8 @@ func init() {
 func InitConfig(config Config) {
 	// Agent
 	// Don't set a default on 'site' to allow detecting with viper whether it's set in config
-	config.BindEnv("site")   //nolint:errcheck
-	config.BindEnv("dd_url") //nolint:errcheck
+	config.BindEnv("site")
+	config.BindEnv("dd_url")
 	config.BindEnvAndSetDefault("app_key", "")
 	config.BindEnvAndSetDefault("cloud_provider_metadata", []string{"aws", "gcp", "azure", "alibaba"})
 	config.SetDefault("proxy", nil)
@@ -182,7 +182,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("hostname", "")
 	config.BindEnvAndSetDefault("tags", []string{})
 	config.BindEnvAndSetDefault("extra_tags", []string{})
-	config.BindEnv("env") //nolint:errcheck
+	config.BindEnv("env")
 	config.BindEnvAndSetDefault("tag_value_split_separator", map[string]string{})
 	config.BindEnvAndSetDefault("conf_path", ".")
 	config.BindEnvAndSetDefault("confd_path", defaultConfdPath)
@@ -212,7 +212,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("enable_gohai", true)
 	config.BindEnvAndSetDefault("check_runners", int64(4))
 	config.BindEnvAndSetDefault("auth_token_file_path", "")
-	_ = config.BindEnv("bind_host")
+	config.BindEnv("bind_host")
 	config.BindEnvAndSetDefault("ipc_address", "localhost")
 	config.BindEnvAndSetDefault("health_port", int64(0))
 	config.BindEnvAndSetDefault("disable_py3_validation", false)
@@ -328,9 +328,9 @@ func InitConfig(config Config) {
 		}
 	}
 
-	config.BindEnv("procfs_path")           //nolint:errcheck
-	config.BindEnv("container_proc_root")   //nolint:errcheck
-	config.BindEnv("container_cgroup_root") //nolint:errcheck
+	config.BindEnv("procfs_path")
+	config.BindEnv("container_proc_root")
+	config.BindEnv("container_cgroup_root")
 
 	config.BindEnvAndSetDefault("proc_root", "/proc")
 	config.BindEnvAndSetDefault("histogram_aggregates", []string{"max", "median", "avg", "count"})
@@ -361,8 +361,8 @@ func InitConfig(config Config) {
 	// Forwarder
 	config.BindEnvAndSetDefault("additional_endpoints", map[string][]string{})
 	config.BindEnvAndSetDefault("forwarder_timeout", 20)
-	_ = config.BindEnv("forwarder_retry_queue_max_size")                                                 // Deprecated in favor of `forwarder_retry_queue_payloads_max_size`
-	_ = config.BindEnv("forwarder_retry_queue_payloads_max_size")                                        // Default value is defined inside `NewOptions` in pkg/forwarder/forwarder.go
+	config.BindEnv("forwarder_retry_queue_max_size")                                                     // Deprecated in favor of `forwarder_retry_queue_payloads_max_size`
+	config.BindEnv("forwarder_retry_queue_payloads_max_size")                                            // Default value is defined inside `NewOptions` in pkg/forwarder/forwarder.go
 	config.BindEnvAndSetDefault("forwarder_connection_reset_interval", 0)                                // in seconds, 0 means disabled
 	config.BindEnvAndSetDefault("forwarder_apikey_validation_interval", DefaultAPIKeyValidationInterval) // in minutes
 	config.BindEnvAndSetDefault("forwarder_num_workers", 1)
@@ -432,7 +432,7 @@ func InitConfig(config Config) {
 	// Default is 0 - blocking channel
 	config.BindEnvAndSetDefault("dogstatsd_capture_depth", 0)
 
-	_ = config.BindEnv("dogstatsd_mapper_profiles")
+	config.BindEnv("dogstatsd_mapper_profiles")
 	config.SetEnvKeyTransformer("dogstatsd_mapper_profiles", func(in string) interface{} {
 		var mappings []MappingProfile
 		if err := json.Unmarshal([]byte(in), &mappings); err != nil {
@@ -515,7 +515,7 @@ func InitConfig(config Config) {
 
 	config.BindEnvAndSetDefault("prometheus_scrape.enabled", false)           // Enables the prometheus config provider
 	config.BindEnvAndSetDefault("prometheus_scrape.service_endpoints", false) // Enables Service Endpoints checks in the prometheus config provider
-	_ = config.BindEnv("prometheus_scrape.checks")                            // Defines any extra prometheus/openmetrics check configurations to be handled by the prometheus config provider
+	config.BindEnv("prometheus_scrape.checks")                                // Defines any extra prometheus/openmetrics check configurations to be handled by the prometheus config provider
 	config.SetEnvKeyTransformer("prometheus_scrape.checks", func(in string) interface{} {
 		var promChecks []*types.PrometheusCheck
 		if err := json.Unmarshal([]byte(in), &promChecks); err != nil {
@@ -632,7 +632,7 @@ func InitConfig(config Config) {
 
 	// internal profiling
 	config.BindEnvAndSetDefault("internal_profiling.enabled", false)
-	config.BindEnv("internal_profiling.profile_dd_url", "") //nolint:errcheck
+	config.BindEnv("internal_profiling.profile_dd_url", "")
 	config.BindEnvAndSetDefault("internal_profiling.period", 5*time.Minute)
 	config.BindEnvAndSetDefault("internal_profiling.cpu_duration", 1*time.Minute)
 	config.BindEnvAndSetDefault("internal_profiling.block_profile_rate", 0)
@@ -648,7 +648,7 @@ func InitConfig(config Config) {
 		AddOverride("process_config.enabled", ddProcessAgentEnabled)
 	}
 
-	config.BindEnv("process_config.process_dd_url", "") //nolint:errcheck
+	config.BindEnv("process_config.process_dd_url", "")
 
 	// Logs Agent
 
@@ -661,7 +661,7 @@ func InitConfig(config Config) {
 	// add a socks5 proxy:
 	config.BindEnvAndSetDefault("logs_config.socks5_proxy_address", "")
 	// specific logs-agent api-key
-	config.BindEnv("logs_config.api_key") //nolint:errcheck
+	config.BindEnv("logs_config.api_key")
 
 	// Duration during which the host tags will be submitted with log events.
 	config.BindEnvAndSetDefault("logs_config.expected_tags_duration", time.Duration(0)) // duration-formatted string (parsed by `time.ParseDuration`)
@@ -672,7 +672,7 @@ func InitConfig(config Config) {
 	// increase the number of files that can be tailed in parallel:
 	config.BindEnvAndSetDefault("logs_config.open_files_limit", 100)
 	// add global processing rules that are applied on all logs
-	config.BindEnv("logs_config.processing_rules") //nolint:errcheck
+	config.BindEnv("logs_config.processing_rules")
 	// enforce the agent to use files to collect container logs on kubernetes environment
 	config.BindEnvAndSetDefault("logs_config.k8s_container_use_file", false)
 	// Enable the agent to use files to collect container logs on standalone docker environment, containers
@@ -728,7 +728,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("histogram_copy_to_distribution", false)
 	config.BindEnvAndSetDefault("histogram_copy_to_distribution_prefix", "")
 
-	config.BindEnv("api_key") //nolint:errcheck
+	config.BindEnv("api_key")
 
 	config.BindEnvAndSetDefault("hpa_watcher_polling_freq", 10)
 	config.BindEnvAndSetDefault("hpa_watcher_gc_period", 60*5) // 5 minutes
@@ -812,13 +812,13 @@ func InitConfig(config Config) {
 	// this option will potentially impact the CPU usage of the agent
 	config.BindEnvAndSetDefault("orchestrator_explorer.container_scrubbing.enabled", true)
 	config.BindEnvAndSetDefault("orchestrator_explorer.custom_sensitive_words", []string{})
-	config.BindEnv("orchestrator_explorer.max_per_message")                   //nolint:errcheck
-	config.BindEnv("orchestrator_explorer.orchestrator_dd_url")               //nolint:errcheck
-	config.BindEnv("orchestrator_explorer.orchestrator_additional_endpoints") //nolint:errcheck
+	config.BindEnv("orchestrator_explorer.max_per_message")
+	config.BindEnv("orchestrator_explorer.orchestrator_dd_url")
+	config.BindEnv("orchestrator_explorer.orchestrator_additional_endpoints")
 
 	// Orchestrator Explorer - process agent
 	// DEPRECATED in favor of `orchestrator_explorer.orchestrator_dd_url` setting. If both are set `orchestrator_explorer.orchestrator_dd_url` will take precedence.
-	config.BindEnv("process_config.orchestrator_dd_url") //nolint:errcheck
+	config.BindEnv("process_config.orchestrator_dd_url")
 	// DEPRECATED in favor of `orchestrator_explorer.orchestrator_additional_endpoints` setting. If both are set `orchestrator_explorer.orchestrator_additional_endpoints` will take precedence.
 	config.SetKnown("process_config.orchestrator_additional_endpoints.*")
 	config.SetKnown("orchestrator_explorer.orchestrator_additional_endpoints.*")
@@ -850,7 +850,7 @@ func InitConfig(config Config) {
 	config.SetKnown("process_config.remote_tagger")
 
 	// Network
-	config.BindEnv("network.id") //nolint:errcheck
+	config.BindEnv("network.id")
 
 	// inventories
 	config.BindEnvAndSetDefault("inventories_enabled", true)
@@ -1141,9 +1141,9 @@ func GetMultipleEndpoints() (map[string][]string, error) {
 }
 
 func bindEnvAndSetLogsConfigKeys(config Config, prefix string, v2Api bool) {
-	config.BindEnv(prefix + "logs_dd_url")          //nolint:errcheck // Send the logs to a proxy. Must respect format '<HOST>:<PORT>' and '<PORT>' to be an integer
-	config.BindEnv(prefix + "dd_url")               //nolint:errcheck
-	config.BindEnv(prefix + "additional_endpoints") //nolint:errcheck
+	config.BindEnv(prefix + "logs_dd_url") // Send the logs to a proxy. Must respect format '<HOST>:<PORT>' and '<PORT>' to be an integer
+	config.BindEnv(prefix + "dd_url")
+	config.BindEnv(prefix + "additional_endpoints")
 	config.BindEnvAndSetDefault(prefix+"use_compression", true)
 	config.BindEnvAndSetDefault(prefix+"compression_level", 6) // Default level for the gzip/deflate algorithm
 	config.BindEnvAndSetDefault(prefix+"batch_wait", DefaultBatchWait)

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -76,7 +76,7 @@ func InitSystemProbeConfig(cfg Config) {
 	// network_tracer settings
 	// we cannot use BindEnvAndSetDefault for network_config.enabled because we need to know if it was manually set.
 	cfg.SetKnown(join(netNS, "enabled"))
-	_ = cfg.BindEnv(join(netNS, "enabled"), "DD_SYSTEM_PROBE_NETWORK_ENABLED")
+	cfg.BindEnv(join(netNS, "enabled"), "DD_SYSTEM_PROBE_NETWORK_ENABLED") //nolint:errcheck
 	cfg.BindEnvAndSetDefault(join(spNS, "disable_tcp"), false, "DD_DISABLE_TCP_TRACING")
 	cfg.BindEnvAndSetDefault(join(spNS, "disable_udp"), false, "DD_DISABLE_UDP_TRACING")
 	cfg.BindEnvAndSetDefault(join(spNS, "disable_ipv6"), false, "DD_DISABLE_IPV6_TRACING")

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -47,7 +47,7 @@ type Config interface {
 	GetSizeInBytes(key string) uint
 
 	SetEnvPrefix(in string)
-	BindEnv(input ...string) error
+	BindEnv(input ...string)
 	SetEnvKeyReplacer(r *strings.Replacer)
 	SetEnvKeyTransformer(key string, fn func(string) interface{})
 

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -267,7 +267,7 @@ func (c *safeConfig) SetEnvPrefix(in string) {
 }
 
 // BindEnv wraps Viper for concurrent access, and adds tracking of the configurable env vars
-func (c *safeConfig) BindEnv(input ...string) error {
+func (c *safeConfig) BindEnv(input ...string) {
 	c.Lock()
 	defer c.Unlock()
 	if len(input) == 1 {
@@ -277,7 +277,7 @@ func (c *safeConfig) BindEnv(input ...string) error {
 		envVarName := strings.Join([]string{c.envPrefix, strings.ToUpper(key)}, "_")
 		c.configEnvVars = append(c.configEnvVars, envVarName)
 	}
-	return c.Viper.BindEnv(input...)
+	_ = c.Viper.BindEnv(input...)
 }
 
 // SetEnvKeyReplacer wraps Viper for concurrent access


### PR DESCRIPTION
### What does this PR do?

Allow `telemetry.checks` to be set through env vars.

This also ignore `config.BindEnv` error not being checked since it was ignore everywhere anyway.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
