### PR TITLE
[cluster_agent] Allow to use per-metric maxAge

### DIFF
--- a/pkg/clusteragent/externalmetrics/metrics_retriever.go
+++ b/pkg/clusteragent/externalmetrics/metrics_retriever.go
@@ -95,7 +95,12 @@ func (mr *MetricsRetriever) retrieveMetricsValues() {
 				datadogMetricFromStore.Value = queryResult.Value
 
 				// If we get a valid but old metric, flag it as invalid
-				if currentTime.Unix()-queryResult.Timestamp <= mr.metricsMaxAge {
+				maxAge := datadogMetric.MaxAge
+				if maxAge == 0 {
+					maxAge = time.Duration(mr.metricsMaxAge) * time.Second
+				}
+
+				if time.Duration(currentTime.Unix()-queryResult.Timestamp)*time.Second <= maxAge {
 					datadogMetricFromStore.Valid = true
 					datadogMetricFromStore.Error = nil
 					datadogMetricFromStore.UpdateTime = time.Unix(queryResult.Timestamp, 0).UTC()

--- a/pkg/clusteragent/externalmetrics/metrics_retriever_test.go
+++ b/pkg/clusteragent/externalmetrics/metrics_retriever_test.go
@@ -237,6 +237,73 @@ func TestRetrieveMetricsErrorCases(t *testing.T) {
 			},
 		},
 		{
+			maxAge: 15,
+			desc:   "Test expired data from backend defining per-metric maxAge (overrides global maxAge)",
+			storeContent: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric0",
+						Active:     true,
+						UpdateTime: defaultPreviousUpdateTime,
+						Valid:      true,
+						Error:      nil,
+						MaxAge:     20 * time.Second,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric1",
+						Active:     true,
+						UpdateTime: defaultPreviousUpdateTime,
+						Valid:      false,
+						Error:      nil,
+						MaxAge:     5 * time.Second,
+					},
+					query: "query-metric1",
+				},
+			},
+			queryResults: map[string]autoscalers.Point{
+				"query-metric0": {
+					Value:     10.0,
+					Timestamp: defaultTestTime.Unix(),
+					Valid:     true,
+				},
+				"query-metric1": {
+					Value:     11.0,
+					Timestamp: defaultPreviousUpdateTime.Unix(),
+					Valid:     true,
+				},
+			},
+			queryError: nil,
+			expected: []ddmWithQuery{
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:         "metric0",
+						Active:     true,
+						Value:      10.0,
+						UpdateTime: defaultTestTime,
+						Valid:      true,
+						Error:      nil,
+						MaxAge:     20 * time.Second,
+					},
+					query: "query-metric0",
+				},
+				{
+					ddm: model.DatadogMetricInternal{
+						ID:     "metric1",
+						Active: true,
+						Value:  11.0,
+						Valid:  false,
+						Error:  fmt.Errorf(invalidMetricOutdatedErrorMessage, "query-metric1"),
+						MaxAge: 5 * time.Second,
+						// UpdateTime not set as it will not be compared directly
+					},
+					query: "query-metric1",
+				},
+			},
+		},
+		{
 			maxAge: 30,
 			desc:   "Test backend error (single metric)",
 			storeContent: []ddmWithQuery{

--- a/pkg/clusteragent/externalmetrics/model/datadogmetricinternal.go
+++ b/pkg/clusteragent/externalmetrics/model/datadogmetricinternal.go
@@ -40,6 +40,7 @@ type DatadogMetricInternal struct {
 	AutoscalerReferences string
 	UpdateTime           time.Time
 	Error                error
+	MaxAge               time.Duration
 }
 
 // NewDatadogMetricInternal returns a `DatadogMetricInternal` object from a `DatadogMetric` CRD Object
@@ -53,6 +54,7 @@ func NewDatadogMetricInternal(id string, datadogMetric datadoghq.DatadogMetric) 
 		Deleted:              false,
 		Autogen:              false,
 		AutoscalerReferences: datadogMetric.Status.AutoscalerReferences,
+		MaxAge:               datadogMetric.Spec.MaxAge.Duration,
 	}
 
 	if len(datadogMetric.Spec.ExternalMetricName) > 0 {

--- a/releasenotes-dca/notes/use-datadogmetric-max-age-77a566a0db2cb4d7.yaml
+++ b/releasenotes-dca/notes/use-datadogmetric-max-age-77a566a0db2cb4d7.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Added possibility to use the `maxAge` attribute defined in the datadogMetric CRD overriding the global `maxAge`.


### PR DESCRIPTION
### What does this PR do?

Allows to use the `maxAge` defined in the DatadogMetric CRD that overrides the global `maxAge`.

Note: the `external_metrics_provider.bucket_size` should probably be adapted if `maxAge` is greater than it. I think we can leave that for a different PR.

### Describe how to test your changes

To test this, you’ll need to deploy an HPA that references a datadogmetric so it's active. I used a local kind cluster to deploy the `cyclic-cpu-burner` example in the `k8s-testing-resources` repo and adapted the query of the metric to something I know my cluster was reporting (`kube_apiserver.go_threads`), but any metric works for this test:

```YAML
apiVersion: datadoghq.com/v1alpha1
kind: DatadogMetric
metadata:
  name: cyclic-cpu-burner-server
spec:
  query: "100*(avg:kube_apiserver.go_threads{kube_cluster_name:your-cluster-name}.rollup(avg,30)/max:kube_apiserver.go_threads{kube_cluster_name:your-cluster-name}.rollup(avg,30))"
```

Remember to replace `your-cluster-name` above.

The config options `clusterAgent.metricsProvider.enabled` and `clusterAgent.metricsProvider.useDatadogMetrics` need to be set to true.

We need to test 2 things:

1) Set a maxAge lower than the default one (2 minutes) and see that it’s correctly applied. The easiest way to test this is to set a very low maxAge to make sure that the backend cannot give us updated data. We can set maxAge to 5 seconds, for example:

```YAML
apiVersion: datadoghq.com/v1alpha1
kind: DatadogMetric
metadata:
  name: cyclic-cpu-burner-server
spec:
  maxAge: "5s"
  query: "100*(avg:kube_apiserver.go_threads{kube_cluster_name:david-ortiz-test}.rollup(avg,30)/max:kube_apiserver.go_threads{kube_cluster_name:david-ortiz-test}.rollup(avg,30))"
```

After deploying that, you should see that the metric is not valid and an “Outdated result from backend” error in `kubectl get datadogmetrics cyclic-cpu-burner-server -n default -o yaml`.

2) Set a maxAge higher than the default one (2 minutes) and see that we don’t get the “Outdated result from backend” error until 3 minutes pass without data instead of 2.

Define a maxAge of 3 minutes:

```
apiVersion: datadoghq.com/v1alpha1
kind: DatadogMetric
metadata:
  name: cyclic-cpu-burner-server
spec:
  maxAge: "3m"
  query: "100*(avg:kube_apiserver.go_threads{kube_cluster_name:david-ortiz-test}.rollup(avg,30)/max:kube_apiserver.go_threads{kube_cluster_name:david-ortiz-test}.rollup(avg,30))"
```

Wait until you see that the metric is active and valid in `kubectl get datadogmetrics cyclic-cpu-burner-server -n default`.

Now, we need to stop reporting data for at least 3 minutes. The easiest way I found to do this is top patch the daemon set so it’s not applied in any node. Make sure it's not a problem in the cluster where you're testing this ([Ref](https://stackoverflow.com/questions/53929693/how-to-scale-kubernetes-daemonset-to-0/57533340)):
`kubectl -n default patch daemonset datadog-agent -p '{"spec": {"template": {"spec": {"nodeSelector": {"non-existing": "true"}}}}}'`

After that, you should start seeing the “Outdated result from backend” error when the update time reported by `kubectl get datadogmetrics cyclic-cpu-burner-server -n default` is a little bit more than 3 minutes.

To restore the daemonset run: `kubectl -n default patch daemonset datadog-agent --type json -p='[{"op": "remove", "path": "/spec/template/spec/nodeSelector/non-existing"}]'`.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
