### PR TITLE
[tasks] Add tasks for manipulating pipeline schedules

### DIFF
--- a/tasks/libs/common/gitlab.py
+++ b/tasks/libs/common/gitlab.py
@@ -152,6 +152,109 @@ class Gitlab(object):
         )
         return self.make_request(path, json_output=True)
 
+    def all_pipeline_schedules(self, project_name):
+        """
+        Gets all pipelines schedules for the given project.
+        """
+        page = 1
+
+        # Go through all pages
+        results = self.pipeline_schedules(project_name, page)
+        while results:
+            yield from results
+            page += 1
+            results = self.pipeline_schedules(project_name, page)
+
+    def pipeline_schedules(self, project_name, page=1, per_page=100):
+        """
+        Gets one page of the pipeline schedules for the given project.
+        per_page cannot exceed 100
+        """
+        path = "/projects/{}/pipeline_schedules?per_page={}&page={}".format(
+            quote(project_name, safe=""), per_page, page
+        )
+        return self.make_request(path, json_output=True)
+
+    def pipeline_schedule(self, project_name, schedule_id):
+        """
+        Gets a single pipeline schedule.
+        """
+        path = "/projects/{}/pipeline_schedules/{}".format(quote(project_name, safe=""), schedule_id)
+        return self.make_request(path, json_output=True)
+
+    def create_pipeline_schedule(self, project_name, description, ref, cron, cron_timezone=None, active=None):
+        """
+        Create a new pipeline schedule with given attributes.
+        """
+        path = "/projects/{}/pipeline_schedules".format(quote(project_name, safe=""))
+        headers = {"Content-Type": "application/json"}
+        data = {
+            "description": description,
+            "ref": ref,
+            "cron": cron,
+            "cron_timezone": cron_timezone,
+            "active": active,
+        }
+        no_none_data = {k: v for k, v in data.items() if v is not None}
+        return self.make_request(path, headers=headers, data=json.dumps(no_none_data), json_output=True)
+
+    def edit_pipeline_schedule(
+        self, project_name, schedule_id, description=None, ref=None, cron=None, cron_timezone=None, active=None
+    ):
+        """
+        Edit an existing pipeline schedule with given attributes.
+        """
+        path = "/projects/{}/pipeline_schedules/{}".format(quote(project_name, safe=""), schedule_id)
+        data = {
+            "description": description,
+            "ref": ref,
+            "cron": cron,
+            "cron_timezone": cron_timezone,
+            "active": active,
+        }
+        no_none_data = {k: v for k, v in data.items() if v is not None}
+        headers = {"Content-Type": "application/json"}
+        return self.make_request(path, headers=headers, json_output=True, data=json.dumps(no_none_data), method="PUT")
+
+    def delete_pipeline_schedule(self, project_name, schedule_id):
+        """
+        Delete an existing pipeline schedule.
+        """
+        path = "/projects/{}/pipeline_schedules/{}".format(quote(project_name, safe=""), schedule_id)
+        # Gitlab API docs claim that this returns the JSON representation of the deleted schedule,
+        # but it actually returns an empty string
+        result = self.make_request(path, json_output=False, method="DELETE")
+        return "Pipeline schedule deleted; result: {}".format(result if result else "(empty)")
+
+    def create_pipeline_schedule_variable(self, project_name, schedule_id, key, value):
+        """
+        Create a variable for an existing pipeline schedule.
+        """
+        path = "/projects/{}/pipeline_schedules/{}/variables".format(quote(project_name, safe=""), schedule_id)
+        headers = {"Content-Type": "application/json"}
+        data = {
+            "key": key,
+            "value": value,
+        }
+        return self.make_request(path, headers=headers, data=json.dumps(data), json_output=True)
+
+    def edit_pipeline_schedule_variable(self, project_name, schedule_id, key, value):
+        """
+        Edit an existing variable for a pipeline schedule.
+        """
+        path = "/projects/{}/pipeline_schedules/{}/variables/{}".format(quote(project_name, safe=""), schedule_id, key)
+        headers = {"Content-Type": "application/json"}
+        return self.make_request(
+            path, headers=headers, data=json.dumps({"value": value}), json_output=True, method="PUT"
+        )
+
+    def delete_pipeline_schedule_variable(self, project_name, schedule_id, key):
+        """
+        Delete an existing variable for a pipeline schedule.
+        """
+        path = "/projects/{}/pipeline_schedules/{}/variables/{}".format(quote(project_name, safe=""), schedule_id, key)
+        return self.make_request(path, json_output=True, method="DELETE")
+
     def find_tag(self, project_name, tag_name):
         """
         Look up a tag by its name.
@@ -190,6 +293,10 @@ class Gitlab(object):
             # parameter of requests.post
             if data and json_input:
                 r = requests.post(url, headers=headers, json=data, stream=stream_output)
+            elif method == "PUT":
+                r = requests.put(url, headers=headers, data=data, stream=stream_output)
+            elif method == "DELETE":
+                r = requests.delete(url, headers=headers, stream=stream_output)
             elif data or method == "POST":
                 r = requests.post(url, headers=headers, data=data, stream=stream_output)
             else:

--- a/tasks/libs/common/gitlab.py
+++ b/tasks/libs/common/gitlab.py
@@ -187,7 +187,6 @@ class Gitlab(object):
         Create a new pipeline schedule with given attributes.
         """
         path = "/projects/{}/pipeline_schedules".format(quote(project_name, safe=""))
-        headers = {"Content-Type": "application/json"}
         data = {
             "description": description,
             "ref": ref,
@@ -196,7 +195,7 @@ class Gitlab(object):
             "active": active,
         }
         no_none_data = {k: v for k, v in data.items() if v is not None}
-        return self.make_request(path, headers=headers, data=json.dumps(no_none_data), json_output=True)
+        return self.make_request(path, data=no_none_data, json_output=True, json_input=True)
 
     def edit_pipeline_schedule(
         self, project_name, schedule_id, description=None, ref=None, cron=None, cron_timezone=None, active=None
@@ -213,8 +212,7 @@ class Gitlab(object):
             "active": active,
         }
         no_none_data = {k: v for k, v in data.items() if v is not None}
-        headers = {"Content-Type": "application/json"}
-        return self.make_request(path, headers=headers, json_output=True, data=json.dumps(no_none_data), method="PUT")
+        return self.make_request(path, json_output=True, data=no_none_data, method="PUT")
 
     def delete_pipeline_schedule(self, project_name, schedule_id):
         """
@@ -231,22 +229,18 @@ class Gitlab(object):
         Create a variable for an existing pipeline schedule.
         """
         path = "/projects/{}/pipeline_schedules/{}/variables".format(quote(project_name, safe=""), schedule_id)
-        headers = {"Content-Type": "application/json"}
         data = {
             "key": key,
             "value": value,
         }
-        return self.make_request(path, headers=headers, data=json.dumps(data), json_output=True)
+        return self.make_request(path, data=data, json_output=True, json_input=True)
 
     def edit_pipeline_schedule_variable(self, project_name, schedule_id, key, value):
         """
         Edit an existing variable for a pipeline schedule.
         """
         path = "/projects/{}/pipeline_schedules/{}/variables/{}".format(quote(project_name, safe=""), schedule_id, key)
-        headers = {"Content-Type": "application/json"}
-        return self.make_request(
-            path, headers=headers, data=json.dumps({"value": value}), json_output=True, method="PUT"
-        )
+        return self.make_request(path, data={"value": value}, json_output=True, method="PUT")
 
     def delete_pipeline_schedule_variable(self, project_name, schedule_id, key):
         """
@@ -294,7 +288,7 @@ class Gitlab(object):
             if data and json_input:
                 r = requests.post(url, headers=headers, json=data, stream=stream_output)
             elif method == "PUT":
-                r = requests.put(url, headers=headers, data=data, stream=stream_output)
+                r = requests.put(url, headers=headers, json=data, stream=stream_output)
             elif method == "DELETE":
                 r = requests.delete(url, headers=headers, stream=stream_output)
             elif data or method == "POST":

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -425,8 +425,7 @@ def _get_gitlab_with_project_access_token():
     try:
         project_access_token = os.environ['GITLAB_PROJECT_ACCESS_TOKEN']
     except KeyError:
-        print("You must specify GITLAB_PROJECT_ACCESS_TOKEN environment variable")
-        raise Exit(code=1)
+        raise Exit(message="You must specify GITLAB_PROJECT_ACCESS_TOKEN environment variable", code=1)
     return Gitlab(api_token=project_access_token)
 
 

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -1,5 +1,6 @@
 import io
 import os
+import pprint
 import re
 import traceback
 from collections import defaultdict
@@ -418,3 +419,144 @@ def notify_failure(_, notification_type="merge", print_to_stdout=False):
             print("Would send to {channel}:\n{message}".format(channel=channel, message=str(message)))
         else:
             send_slack_message(channel, str(message))  # TODO: use channel variable
+
+
+def _get_gitlab_with_project_access_token():
+    try:
+        project_access_token = os.environ['GITLAB_PROJECT_ACCESS_TOKEN']
+    except KeyError:
+        print("You must specify GITLAB_PROJECT_ACCESS_TOKEN environment variable")
+        raise Exit(code=1)
+    return Gitlab(api_token=project_access_token)
+
+
+@task
+def get_schedules(_):
+    """
+    Pretty-print all pipeline schedules on the repository.
+    """
+
+    project_name = "DataDog/datadog-agent"
+    gitlab = _get_gitlab_with_project_access_token()
+    gitlab.test_project_found(project_name)
+    for ps in gitlab.all_pipeline_schedules(project_name):
+        pprint.pprint(ps)
+
+
+@task
+def get_schedule(_, schedule_id):
+    """
+    Pretty-print a single pipeline schedule on the repository.
+    """
+
+    project_name = "DataDog/datadog-agent"
+    gitlab = _get_gitlab_with_project_access_token()
+    gitlab.test_project_found(project_name)
+    result = gitlab.pipeline_schedule(project_name, schedule_id)
+    pprint.pprint(result)
+
+
+@task
+def create_schedule(_, description, ref, cron, cron_timezone=None, active=False):
+    """
+    Create a new pipeline schedule on the repository.
+
+    Note that unless you explicitly specify the --active flag, the schedule will be created as inactive.
+    """
+
+    project_name = "DataDog/datadog-agent"
+    gitlab = _get_gitlab_with_project_access_token()
+    gitlab.test_project_found(project_name)
+    result = gitlab.create_pipeline_schedule(project_name, description, ref, cron, cron_timezone, active)
+    pprint.pprint(result)
+
+
+@task
+def edit_schedule(_, schedule_id, description=None, ref=None, cron=None, cron_timezone=None):
+    """
+    Edit an existing pipeline schedule on the repository.
+    """
+
+    project_name = "DataDog/datadog-agent"
+    gitlab = _get_gitlab_with_project_access_token()
+    gitlab.test_project_found(project_name)
+    result = gitlab.edit_pipeline_schedule(project_name, schedule_id, description, ref, cron, cron_timezone)
+    pprint.pprint(result)
+
+
+@task
+def activate_schedule(_, schedule_id):
+    """
+    Activate an existing pipeline schedule on the repository.
+    """
+
+    project_name = "DataDog/datadog-agent"
+    gitlab = _get_gitlab_with_project_access_token()
+    gitlab.test_project_found(project_name)
+    result = gitlab.edit_pipeline_schedule(project_name, schedule_id, active=True)
+    pprint.pprint(result)
+
+
+@task
+def deactivate_schedule(_, schedule_id):
+    """
+    Deactivate an existing pipeline schedule on the repository.
+    """
+
+    project_name = "DataDog/datadog-agent"
+    gitlab = _get_gitlab_with_project_access_token()
+    gitlab.test_project_found(project_name)
+    result = gitlab.edit_pipeline_schedule(project_name, schedule_id, active=False)
+    pprint.pprint(result)
+
+
+@task
+def delete_schedule(_, schedule_id):
+    """
+    Delete an existing pipeline schedule on the repository.
+    """
+
+    project_name = "DataDog/datadog-agent"
+    gitlab = _get_gitlab_with_project_access_token()
+    gitlab.test_project_found(project_name)
+    result = gitlab.delete_pipeline_schedule(project_name, schedule_id)
+    pprint.pprint(result)
+
+
+@task
+def create_schedule_variable(_, schedule_id, key, value):
+    """
+    Create a variable for an existing schedule on the repository.
+    """
+
+    project_name = "DataDog/datadog-agent"
+    gitlab = _get_gitlab_with_project_access_token()
+    gitlab.test_project_found(project_name)
+    result = gitlab.create_pipeline_schedule_variable(project_name, schedule_id, key, value)
+    pprint.pprint(result)
+
+
+@task
+def edit_schedule_variable(_, schedule_id, key, value):
+    """
+    Edit an existing variable for a schedule on the repository.
+    """
+
+    project_name = "DataDog/datadog-agent"
+    gitlab = _get_gitlab_with_project_access_token()
+    gitlab.test_project_found(project_name)
+    result = gitlab.edit_pipeline_schedule_variable(project_name, schedule_id, key, value)
+    pprint.pprint(result)
+
+
+@task
+def delete_schedule_variable(_, schedule_id, key):
+    """
+    Delete an existing variable for a schedule on the repository.
+    """
+
+    project_name = "DataDog/datadog-agent"
+    gitlab = _get_gitlab_with_project_access_token()
+    gitlab.test_project_found(project_name)
+    result = gitlab.delete_pipeline_schedule_variable(project_name, schedule_id, key)
+    pprint.pprint(result)

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -421,12 +421,15 @@ def notify_failure(_, notification_type="merge", print_to_stdout=False):
             send_slack_message(channel, str(message))  # TODO: use channel variable
 
 
-def _get_gitlab_with_project_access_token():
+def _init_pipeline_schedule_task():
+    project_name = "DataDog/datadog-agent"
     try:
         project_access_token = os.environ['GITLAB_PROJECT_ACCESS_TOKEN']
     except KeyError:
         raise Exit(message="You must specify GITLAB_PROJECT_ACCESS_TOKEN environment variable", code=1)
-    return Gitlab(api_token=project_access_token)
+    gitlab = Gitlab(api_token=project_access_token)
+    gitlab.test_project_found(project_name)
+    return project_name, gitlab
 
 
 @task
@@ -435,9 +438,7 @@ def get_schedules(_):
     Pretty-print all pipeline schedules on the repository.
     """
 
-    project_name = "DataDog/datadog-agent"
-    gitlab = _get_gitlab_with_project_access_token()
-    gitlab.test_project_found(project_name)
+    project_name, gitlab = _init_pipeline_schedule_task()
     for ps in gitlab.all_pipeline_schedules(project_name):
         pprint.pprint(ps)
 
@@ -448,9 +449,7 @@ def get_schedule(_, schedule_id):
     Pretty-print a single pipeline schedule on the repository.
     """
 
-    project_name = "DataDog/datadog-agent"
-    gitlab = _get_gitlab_with_project_access_token()
-    gitlab.test_project_found(project_name)
+    project_name, gitlab = _init_pipeline_schedule_task()
     result = gitlab.pipeline_schedule(project_name, schedule_id)
     pprint.pprint(result)
 
@@ -463,9 +462,7 @@ def create_schedule(_, description, ref, cron, cron_timezone=None, active=False)
     Note that unless you explicitly specify the --active flag, the schedule will be created as inactive.
     """
 
-    project_name = "DataDog/datadog-agent"
-    gitlab = _get_gitlab_with_project_access_token()
-    gitlab.test_project_found(project_name)
+    project_name, gitlab = _init_pipeline_schedule_task()
     result = gitlab.create_pipeline_schedule(project_name, description, ref, cron, cron_timezone, active)
     pprint.pprint(result)
 
@@ -476,9 +473,7 @@ def edit_schedule(_, schedule_id, description=None, ref=None, cron=None, cron_ti
     Edit an existing pipeline schedule on the repository.
     """
 
-    project_name = "DataDog/datadog-agent"
-    gitlab = _get_gitlab_with_project_access_token()
-    gitlab.test_project_found(project_name)
+    project_name, gitlab = _init_pipeline_schedule_task()
     result = gitlab.edit_pipeline_schedule(project_name, schedule_id, description, ref, cron, cron_timezone)
     pprint.pprint(result)
 
@@ -489,9 +484,7 @@ def activate_schedule(_, schedule_id):
     Activate an existing pipeline schedule on the repository.
     """
 
-    project_name = "DataDog/datadog-agent"
-    gitlab = _get_gitlab_with_project_access_token()
-    gitlab.test_project_found(project_name)
+    project_name, gitlab = _init_pipeline_schedule_task()
     result = gitlab.edit_pipeline_schedule(project_name, schedule_id, active=True)
     pprint.pprint(result)
 
@@ -502,9 +495,7 @@ def deactivate_schedule(_, schedule_id):
     Deactivate an existing pipeline schedule on the repository.
     """
 
-    project_name = "DataDog/datadog-agent"
-    gitlab = _get_gitlab_with_project_access_token()
-    gitlab.test_project_found(project_name)
+    project_name, gitlab = _init_pipeline_schedule_task()
     result = gitlab.edit_pipeline_schedule(project_name, schedule_id, active=False)
     pprint.pprint(result)
 
@@ -515,9 +506,7 @@ def delete_schedule(_, schedule_id):
     Delete an existing pipeline schedule on the repository.
     """
 
-    project_name = "DataDog/datadog-agent"
-    gitlab = _get_gitlab_with_project_access_token()
-    gitlab.test_project_found(project_name)
+    project_name, gitlab = _init_pipeline_schedule_task()
     result = gitlab.delete_pipeline_schedule(project_name, schedule_id)
     pprint.pprint(result)
 
@@ -528,9 +517,7 @@ def create_schedule_variable(_, schedule_id, key, value):
     Create a variable for an existing schedule on the repository.
     """
 
-    project_name = "DataDog/datadog-agent"
-    gitlab = _get_gitlab_with_project_access_token()
-    gitlab.test_project_found(project_name)
+    project_name, gitlab = _init_pipeline_schedule_task()
     result = gitlab.create_pipeline_schedule_variable(project_name, schedule_id, key, value)
     pprint.pprint(result)
 
@@ -541,9 +528,7 @@ def edit_schedule_variable(_, schedule_id, key, value):
     Edit an existing variable for a schedule on the repository.
     """
 
-    project_name = "DataDog/datadog-agent"
-    gitlab = _get_gitlab_with_project_access_token()
-    gitlab.test_project_found(project_name)
+    project_name, gitlab = _init_pipeline_schedule_task()
     result = gitlab.edit_pipeline_schedule_variable(project_name, schedule_id, key, value)
     pprint.pprint(result)
 
@@ -554,8 +539,6 @@ def delete_schedule_variable(_, schedule_id, key):
     Delete an existing variable for a schedule on the repository.
     """
 
-    project_name = "DataDog/datadog-agent"
-    gitlab = _get_gitlab_with_project_access_token()
-    gitlab.test_project_found(project_name)
+    project_name, gitlab = _init_pipeline_schedule_task()
     result = gitlab.delete_pipeline_schedule_variable(project_name, schedule_id, key)
     pprint.pprint(result)


### PR DESCRIPTION
### What does this PR do?

Adds inv tasks to handle pipeline schedules and pipeline schedule variables using a Gitlab Project Access Token.
The output of all the tasks is a simple pprint-formatted JSON returned by the API, which I believe is fine since these tasks will be used rarely and I don't think they need more human-friendly output.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
