### PR TITLE
Add Windows kernel VARIANT to install_info

### DIFF
--- a/.gitlab/image_build/docker_windows.yml
+++ b/.gitlab/image_build/docker_windows.yml
@@ -65,7 +65,7 @@
   needs: ["windows_msi_and_bosh_zip_x64-a7", "build_windows_container_entrypoint"]
   variables:
     AGENT_ZIP: "datadog-agent-7*-x86_64.zip"
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT}"
     TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-amd64"
 
 .docker_build_agent6_windows_common:
@@ -77,21 +77,21 @@
   needs: ["windows_msi_x64-a6", "build_windows_container_entrypoint"]
   variables:
     AGENT_ZIP: "datadog-agent-6*-x86_64.zip"
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT}"
     TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-amd64"
 
 .docker_build_agent6_windows_servercore_common:
   extends:
     - .docker_build_agent6_windows_common
   variables:
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT}"
     TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-servercore-amd64"
 
 .docker_build_agent7_windows_servercore_common:
   extends:
     - .docker_build_agent7_windows_common
   variables:
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT}"
     TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-servercore-amd64"
 
 include:

--- a/.gitlab/image_build/docker_windows.yml
+++ b/.gitlab/image_build/docker_windows.yml
@@ -39,8 +39,6 @@
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
     BUILD_CONTEXT: Dockerfiles/agent
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
-    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-amd64"
   script:
     - $ErrorActionPreference = "Stop"
     - '$_instance_id = (iwr  -UseBasicParsing http://169.254.169.254/latest/meta-data/instance-id).content ; Write-Host "Running on instance $($_instance_id)"'
@@ -67,6 +65,8 @@
   needs: ["windows_msi_and_bosh_zip_x64-a7", "build_windows_container_entrypoint"]
   variables:
     AGENT_ZIP: "datadog-agent-7*-x86_64.zip"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
+    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-amd64"
 
 .docker_build_agent6_windows_common:
   extends:
@@ -77,6 +77,22 @@
   needs: ["windows_msi_x64-a6", "build_windows_container_entrypoint"]
   variables:
     AGENT_ZIP: "datadog-agent-6*-x86_64.zip"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
+    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-amd64"
+
+.docker_build_agent6_windows_servercore_common:
+  extends:
+    - .docker_build_agent6_windows_common
+  variables:
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
+    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-servercore-amd64"
+
+.docker_build_agent7_windows_servercore_common:
+  extends:
+    - .docker_build_agent7_windows_common
+  variables:
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
+    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-servercore-amd64"
 
 include:
   - /.gitlab/image_build/docker_windows_agent6.yml

--- a/.gitlab/image_build/docker_windows_agent6.yml
+++ b/.gitlab/image_build/docker_windows_agent6.yml
@@ -2,33 +2,27 @@
 # Python 2 does not run on nanoserver
 docker_build_agent6_windows1809_core:
   extends:
-    - .docker_build_agent6_windows_common
+    - .docker_build_agent6_windows_servercore_common
   tags: ["runner:windows-docker", "windowsversion:1809"]
   variables:
     VARIANT: 1809
     TAG_SUFFIX: -6
     WITH_JMX: "false"
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
-    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-servercore-amd64"
 
 docker_build_agent6_windows1909_core:
   extends:
-    - .docker_build_agent6_windows_common
+    - .docker_build_agent6_windows_servercore_common
   tags: ["runner:windows-docker", "windowsversion:1909"]
   variables:
     VARIANT: 1909
     TAG_SUFFIX: -6
     WITH_JMX: "false"
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
-    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-servercore-amd64"
 
 docker_build_agent6_windows2004_core:
   extends:
-    - .docker_build_agent6_windows_common
+    - .docker_build_agent6_windows_servercore_common
   tags: ["runner:windows-docker", "windowsversion:2004"]
   variables:
     VARIANT: 2004
     TAG_SUFFIX: -6
     WITH_JMX: "false"
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
-    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-servercore-amd64"

--- a/.gitlab/image_build/docker_windows_agent7.yml
+++ b/.gitlab/image_build/docker_windows_agent7.yml
@@ -56,68 +56,55 @@ docker_build_agent7_windows2004_jmx:
 
 docker_build_agent7_windows1809_core:
   extends:
-    - .docker_build_agent7_windows_common
+    - .docker_build_agent7_windows_servercore_common
   tags: ["runner:windows-docker", "windowsversion:1809"]
   variables:
     VARIANT: 1809
     TAG_SUFFIX: -7
     WITH_JMX: "false"
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
-    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-servercore-amd64"
 
 docker_build_agent7_windows1809_core_jmx:
   extends:
-    - .docker_build_agent7_windows_common
+    - .docker_build_agent7_windows_servercore_common
   tags: ["runner:windows-docker", "windowsversion:1809"]
   variables:
     VARIANT: 1809
     TAG_SUFFIX: -7-jmx
     WITH_JMX: "true"
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
-    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-servercore-amd64"
 
 docker_build_agent7_windows1909_core:
   extends:
-    - .docker_build_agent7_windows_common
+    - .docker_build_agent7_windows_servercore_common
   tags: ["runner:windows-docker", "windowsversion:1909"]
   variables:
     VARIANT: 1909
     TAG_SUFFIX: -7
     WITH_JMX: "false"
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
-    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-servercore-amd64"
 
 docker_build_agent7_windows1909_core_jmx:
   extends:
-    - .docker_build_agent7_windows_common
+    - .docker_build_agent7_windows_servercore_common
   tags: ["runner:windows-docker", "windowsversion:1909"]
   variables:
     VARIANT: 1909
     TAG_SUFFIX: -7-jmx
     WITH_JMX: "true"
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
-    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-servercore-amd64"
 
 docker_build_agent7_windows2004_core:
   extends:
-    - .docker_build_agent7_windows_common
+    - .docker_build_agent7_windows_servercore_common
   tags: ["runner:windows-docker", "windowsversion:2004"]
   variables:
     VARIANT: 2004
     TAG_SUFFIX: "-7"
     WITH_JMX: "false"
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
-    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-servercore-amd64"
 
 docker_build_agent7_windows2004_core_jmx:
   extends:
-    - .docker_build_agent7_windows_common
+    - .docker_build_agent7_windows_servercore_common
   tags: ["runner:windows-docker", "windowsversion:2004"]
   needs: ["windows_msi_and_bosh_zip_x64-a7", "build_windows_container_entrypoint"]
   variables:
     VARIANT: 2004
     TAG_SUFFIX: -7-jmx
     WITH_JMX: "true"
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX}"
-    TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-servercore-amd64"
-

--- a/Dockerfiles/agent/install.ps1
+++ b/Dockerfiles/agent/install.ps1
@@ -34,3 +34,12 @@ $Env:Path="$Env:Path;C:/Program Files/Datadog/Datadog Agent/bin;C:/Program Files
 # Set variable indicating we are running in a container
 setx /m DOCKER_DD_AGENT "true"
 $Env:DOCKER_DD_AGENT="true"
+
+# Create install_info
+Write-Output @"
+---
+install_method:
+  tool: docker
+  tool_version: docker-win-$env:VARIANT
+  installer_version: docker
+"@ > C:/ProgramData/Datadog/install_info

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -2,6 +2,7 @@ ARG BASE_IMAGE=mcr.microsoft.com/powershell:lts-windowsservercore-1809
 FROM ${BASE_IMAGE}
 
 ARG WITH_JMX="false"
+ARG VARIANT="unknown"
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 
@@ -17,7 +18,6 @@ EXPOSE 8125/udp 8126/tcp
 COPY entrypoint.exe C:/entrypoint.exe
 ADD entrypoint-ps1 ./entrypoint-ps1
 COPY datadog*.yaml C:/ProgramData/Datadog/
-COPY install_info C:/ProgramData/Datadog/
 
 ENTRYPOINT ["C:/entrypoint.exe"]
 CMD ["datadogagent"]


### PR DESCRIPTION
### What does this PR do?

- Dedupe `BUILD_ARG` and `TARGET_TAG` vars from `docker_windows` jobs
- Add Windows kernel `VARIANT` to `install_info` dynamically, instead of using a static file in the Docker build.

### Motivation

Report the Docker image variant in use.

### Describe how to test your changes

```
> docker run -ti --entrypoint cmd <image>
> type install_info
---
install_method:
  tool: docker
  tool_version: docker-win-2004
  installer_version: docker
```
