### PR TITLE
Add possibility to automatically shutdown the Agent based on running processes

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -24,6 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/agent/common/misconfig"
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
 	"github.com/DataDog/datadog-agent/cmd/agent/gui"
+	"github.com/DataDog/datadog-agent/cmd/manager"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/api/healthprobe"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
@@ -299,6 +300,11 @@ func StartAgent() error {
 			return log.Errorf("Error while writing PID file, exiting: %v", err)
 		}
 		log.Infof("pid '%d' written to pid file '%s'", os.Getpid(), pidfilePath)
+	}
+
+	err = manager.ConfigureAutoExit(common.MainCtx)
+	if err != nil {
+		return log.Errorf("Unable to configure auto-exit, err: %w", err)
 	}
 
 	hostname, err := util.GetHostname(context.TODO())

--- a/cmd/manager/auto_exit.go
+++ b/cmd/manager/auto_exit.go
@@ -1,0 +1,87 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package manager
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	"golang.org/x/net/context"
+)
+
+const (
+	defaultExitTicker = 30 * time.Second
+)
+
+// ExitDetector is common interface for shutdown mechanisms
+type ExitDetector interface {
+	check() bool
+}
+
+// ConfigureAutoExit starts automatic shutdown mechanism if necessary
+func ConfigureAutoExit(ctx context.Context) error {
+	var sd ExitDetector
+	var err error
+
+	if config.Datadog.GetBool("auto_exit.noprocess.enabled") {
+		sd, err = DefaultNoProcessExit()
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if sd == nil {
+		return nil
+	}
+
+	validationPeriod := time.Duration(config.Datadog.GetInt("auto_exit.validation_period")) * time.Second
+	return startAutoExit(ctx, sd, defaultExitTicker, validationPeriod)
+}
+
+func startAutoExit(ctx context.Context, sd ExitDetector, tickerPeriod, validationPeriod time.Duration) error {
+	if sd == nil {
+		return fmt.Errorf("a shutdown detector must be provided")
+	}
+
+	selfProcess, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		return fmt.Errorf("cannot find own process, err: %w", err)
+	}
+
+	log.Info("Starting auto-exit watcher")
+	lastConditionNotMet := time.Now()
+	ticker := time.NewTicker(tickerPeriod)
+	go func() {
+		for {
+			select {
+			case <-ctx.Done():
+				return
+
+			case <-ticker.C:
+				shutdownConditionFound := sd.check()
+				if shutdownConditionFound {
+					if lastConditionNotMet.Add(validationPeriod).Before(time.Now()) {
+						log.Info("Conditions met for automatic exit: triggering stop sequence")
+						if err := selfProcess.Signal(os.Interrupt); err != nil {
+							log.Errorf("Unable to send termination signal - will use os.exit, err: %v", err)
+							os.Exit(1)
+						}
+						return
+					}
+				} else {
+					lastConditionNotMet = time.Now()
+				}
+			}
+		}
+	}()
+
+	return nil
+}

--- a/cmd/manager/auto_exit_noprocess.go
+++ b/cmd/manager/auto_exit_noprocess.go
@@ -1,0 +1,79 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package manager
+
+import (
+	"regexp"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/gopsutil/process"
+)
+
+type processes map[int32]*process.FilledProcess
+
+var (
+	defaultRegexps = []*regexp.Regexp{
+		regexp.MustCompile("pause|s6-svscan|s6-supervise"),
+		regexp.MustCompile("agent|process-agent|trace-agent|security-agent|system-probe"),
+	}
+	processFetcher = fetchProcesses
+)
+
+func fetchProcesses() (processes, error) {
+	return process.AllProcesses()
+}
+
+type noProcessExit struct {
+	excludedProcesses []*regexp.Regexp
+}
+
+// NoProcessExit creates a shutdown detector based on running processes
+func NoProcessExit(r []*regexp.Regexp) ExitDetector {
+	return &noProcessExit{excludedProcesses: r}
+}
+
+// DefaultNoProcessExit creates the default NoProcess shutdown detector
+func DefaultNoProcessExit() (ExitDetector, error) {
+	mergedRegexps := make([]*regexp.Regexp, len(defaultRegexps))
+	copy(mergedRegexps, defaultRegexps)
+
+	extraRegexps := config.Datadog.GetStringSlice("auto_exit.noprocess.excluded_processes")
+	for _, strRegexp := range extraRegexps {
+		r, err := regexp.Compile(strRegexp)
+		if err != nil {
+			return nil, err
+		}
+
+		mergedRegexps = append(mergedRegexps, r)
+	}
+
+	return NoProcessExit(mergedRegexps), nil
+}
+
+func (s *noProcessExit) check() bool {
+	processes, err := processFetcher()
+	if err != nil {
+		log.Debugf("Unable to get processes list to trigger autoshutdown, err: %w", err)
+		return false
+	}
+
+	for _, p := range processes {
+		isExcluded := false
+		for _, r := range s.excludedProcesses {
+			if isExcluded = r.MatchString(p.Name); isExcluded {
+				break
+			}
+		}
+
+		if !isExcluded {
+			log.Debugf("Processe preventing shutdown: p: %d - %s", p.Pid, p.Name)
+			return false
+		}
+	}
+
+	return true
+}

--- a/cmd/manager/auto_exit_noprocess.go
+++ b/cmd/manager/auto_exit_noprocess.go
@@ -57,7 +57,7 @@ func DefaultNoProcessExit() (ExitDetector, error) {
 func (s *noProcessExit) check() bool {
 	processes, err := processFetcher()
 	if err != nil {
-		log.Debugf("Unable to get processes list to trigger autoshutdown, err: %w", err)
+		log.Debugf("Unable to get processes list to trigger autoexit, err: %w", err)
 		return false
 	}
 
@@ -70,7 +70,7 @@ func (s *noProcessExit) check() bool {
 		}
 
 		if !isExcluded {
-			log.Debugf("Processe preventing shutdown: p: %d - %s", p.Pid, p.Name)
+			log.Debugf("Processes preventing autoexit: p: %d - %s", p.Pid, p.Name)
 			return false
 		}
 	}

--- a/cmd/manager/auto_exit_noprocess_test.go
+++ b/cmd/manager/auto_exit_noprocess_test.go
@@ -1,0 +1,80 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package manager
+
+import (
+	"regexp"
+	"testing"
+
+	assert "github.com/stretchr/testify/require"
+)
+
+type processFixture struct {
+	name string
+
+	processes  processes
+	regexps    []*regexp.Regexp
+	shouldExit bool
+}
+
+func (f *processFixture) run(t *testing.T) {
+	t.Helper()
+
+	processFetcher = func() (processes, error) {
+		for pid, p := range f.processes {
+			p.Pid = pid
+		}
+		return f.processes, nil
+	}
+
+	c := NoProcessExit(f.regexps)
+	assert.Equal(t, f.shouldExit, c.check())
+}
+
+func TestExitDetection(t *testing.T) {
+	tests := []processFixture{
+		{
+			name: "existing process",
+			processes: processes{
+				42: {
+					Name: "agent",
+				},
+				100: {
+					Name: "foo",
+				},
+				101: {
+					Name: "pause",
+				},
+				102: {
+					Name: "security-agent",
+				},
+			},
+			regexps:    defaultRegexps,
+			shouldExit: false,
+		},
+		{
+			name: "no other case",
+			processes: processes{
+				42: {
+					Name: "agent",
+				},
+				101: {
+					Name: "pause",
+				},
+				102: {
+					Name: "security-agent",
+				},
+			},
+			regexps:    defaultRegexps,
+			shouldExit: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.run(t)
+		})
+	}
+}

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -8,6 +8,7 @@ package app
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"os"
 	"os/signal"
 	"path"
@@ -15,13 +16,14 @@ import (
 	"time"
 
 	_ "expvar" // Blank import used because this isn't directly used in this file
-	"net/http"
+
 	_ "net/http/pprof" // Blank import used because this isn't directly used in this file
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
 	commonagent "github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/cmd/manager"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/api"
 	"github.com/DataDog/datadog-agent/cmd/security-agent/common"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
@@ -100,8 +102,10 @@ Datadog Security Agent takes care of running compliance and security checks.`,
 )
 
 func init() {
-	var defaultConfPathArray = []string{path.Join(commonagent.DefaultConfPath, "datadog.yaml"),
-		path.Join(commonagent.DefaultConfPath, "security-agent.yaml")}
+	defaultConfPathArray := []string{
+		path.Join(commonagent.DefaultConfPath, "datadog.yaml"),
+		path.Join(commonagent.DefaultConfPath, "security-agent.yaml"),
+	}
 	SecurityAgentCmd.PersistentFlags().StringArrayVarP(&confPathArray, "cfgpath", "c", defaultConfPathArray, "path to a yaml configuration file")
 	SecurityAgentCmd.PersistentFlags().BoolVarP(&flagNoColor, "no-color", "n", false, "disable color output")
 
@@ -213,8 +217,14 @@ func RunAgent(ctx context.Context) (err error) {
 		return nil
 	}
 
+	err = manager.ConfigureAutoExit(ctx)
+	if err != nil {
+		log.Criticalf("Unable to configure auto-exit, err: %w", err)
+		return nil
+	}
+
 	// Setup expvar server
-	var port = coreconfig.Datadog.GetString("security_agent.expvar_port")
+	port := coreconfig.Datadog.GetString("security_agent.expvar_port")
 	coreconfig.Datadog.Set("expvar_port", port)
 	if coreconfig.Datadog.GetBool("telemetry.enabled") {
 		http.Handle("/telemetry", telemetry.Handler())

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -220,6 +220,11 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("allow_arbitrary_tags", false)
 	config.BindEnvAndSetDefault("use_proxy_for_cloud_metadata", false)
 
+	// Auto exit configuration
+	config.BindEnvAndSetDefault("auto_exit.validation_period", 60)
+	config.BindEnvAndSetDefault("auto_exit.noprocess.enabled", false)
+	config.BindEnvAndSetDefault("auto_exit.noprocess.excluded_processes", []string{})
+
 	// The number of commits before expiring a context. The value is 2 to handle
 	// the case where a check miss to send a metric.
 	config.BindEnvAndSetDefault("check_sampler_bucket_commits_count_expiry", 2)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -340,6 +340,33 @@ api_key:
 #
 # use_proxy_for_cloud_metadata: false
 
+## @param auto_exit - custom object - optional
+## Configuration for the automatic exit mechanism: the Agent stops when some conditions are met.
+#
+# auto_exit:
+
+  ## @param noprocess - custom object - optional
+  ## Configure the `noprocess` automatic exit method.
+  ## Detect when no other processes (non-agent) are running to trigger automatic exit. `HOST_PROC` is taken into account when gathering processes.
+  ## Feature is only supported on POSIX systems.
+  #
+  # noprocess:
+    ## @param enabled - boolean - optional - default: false
+    ## Enable the `noprocess` method
+    #
+    # enabled: false
+
+    ## @param enabled - list of strings - optional
+    ## List of regular expressions to exclude extra processes (on top of built-in list).
+    #
+    # excluded_processes: []
+
+  ## @param validation_period - int - optional - default: 60
+  ## Time (in seconds) during which the auto shutdown validates that the selected shutdown mechanism returns true.
+  ## The value is verified every 30s. By default, three consecutive checks need to return true to trigger an automatic exit.
+  #
+  # validation_period: 60
+
 {{ end }}
 {{- if .Agent }}
 {{- if .Python }}

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -362,7 +362,7 @@ api_key:
     # excluded_processes: []
 
   ## @param validation_period - int - optional - default: 60
-  ## Time (in seconds) during which the auto shutdown validates that the selected shutdown mechanism returns true.
+  ## Time (in seconds) delay during which the auto exit validates that the selected method continuously detects an exit condition, before exiting.
   ## The value is verified every 30s. By default, three consecutive checks need to return true to trigger an automatic exit.
   #
   # validation_period: 60

--- a/pkg/trace/agent/run.go
+++ b/pkg/trace/agent/run.go
@@ -14,6 +14,7 @@ import (
 	"runtime/pprof"
 	"time"
 
+	"github.com/DataDog/datadog-agent/cmd/manager"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/pidfile"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
@@ -121,6 +122,12 @@ func Run(ctx context.Context) {
 
 	if err := util.SetupCoreDump(); err != nil {
 		log.Warnf("Can't setup core dumps: %v, core dumps might not be available after a crash", err)
+	}
+
+	err = manager.ConfigureAutoExit(ctx)
+	if err != nil {
+		osutil.Exitf("Unable to configure auto-exit, err: %v", err)
+		return
 	}
 
 	err = metrics.Configure(cfg, []string{"version:" + info.Version})

--- a/releasenotes/notes/auto-shutdown-process-17515db7a3a55f5a.yaml
+++ b/releasenotes/notes/auto-shutdown-process-17515db7a3a55f5a.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add a new parameter (auto_exit) to allow the Agent to exit automatically based on some condition. Currently, the only supported method "noprocess", triggers an exit if no other processes are visible to the Agent (taking into account HOST_PROC). Only available on POSIX systems.


### PR DESCRIPTION
### What does this PR do?

Add a new option (`auto_exit`) to allow the Agent to shutdown itself based on some condition. Currently the only supported method "noprocess", which will trigger Agent shutdown if no other processes are visible to the Agent (take into account HOST_PROC). Only available on POSIX systems.

### Motivation

Support monitoring EKS Fargate Jobs.

### Additional Notes


### Describe how to test your changes

Deploy the Agent as a side car in an EKS Fargate Job, setting `auto_exit.noprocess.enabled` or `DD_AUTO_EXIT_NOPROCESS_ENABLED` to `true`. The main container must exit after some time (e.g. applicative job is finished). When this happens, the Agent container should gracefully terminate ~60s after.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
