### PR TITLE
[Gitlab] Check also for go.sum diff when doing `go mod tidy`

### DIFF
--- a/internal/tools/go.sum
+++ b/internal/tools/go.sum
@@ -179,6 +179,7 @@ github.com/fatih/color v1.12.0 h1:mRhaKNwANqRgUBGKmnI5ZxEk7QXmjQeCcuYFMX2bfcc=
 github.com/fatih/color v1.12.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/fatih/structtag v1.2.0 h1:/OdNE99OxoI/PqaW/SuSK9uxxT3f/tcSZgon/ssNSx4=
 github.com/fatih/structtag v1.2.0/go.mod h1:mBJUNpUnHmRKrKlQQlmCrh5PuhftFbNv8Ys4/aAZl94=
+github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568 h1:BHsljHzVlRcyQhjrss6TZTdY2VfCqZPbv5k3iBFa2ZQ=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -524,9 +524,9 @@ def check_mod_tidy(ctx, test_folder="testmodule"):
     for mod in DEFAULT_MODULES.values():
         with ctx.cd(mod.full_path()):
             ctx.run("go mod tidy")
-            res = ctx.run("git diff-files --exit-code go.mod", warn=True)
+            res = ctx.run("git diff-files --exit-code go.mod go.sum", warn=True)
             if res.exited is None or res.exited > 0:
-                errors_found.append("go.mod for {} module is out of sync".format(mod.import_path))
+                errors_found.append("go.mod or go.sum for {} module is out of sync".format(mod.import_path))
 
     generate_dummy_package(ctx, test_folder)
     with ctx.cd(test_folder):

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -103,7 +103,7 @@ def generate_dummy_package(ctx, folder):
             )
         print("Done")
 
-        ctx.run("go mod init")
+        ctx.run("go mod init example.com/testmodule")
         for mod in DEFAULT_MODULES.values():
             if mod.path != ".":
                 ctx.run("go mod edit -require={}".format(mod.dependency_path("0.0.0")))


### PR DESCRIPTION
### What does this PR do?

Check `go.sum` diff when doing `check-mod-tidy`.

Update `internal/tools/go.sum` to make the test pass.

Give a name to `testmodule` to avoid failure on recent versions of Go.

### Motivation

Fix broken CI on `main` branch.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
