### PR TITLE
Add security_go_generate_check to JOBOWNERS

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -8,6 +8,7 @@ build_clang*                         @DataDog/agent-network
 # Notifications are handled separately for more fine-grained control on go tests
 tests_*                              @DataDog/multiple
 tests_ebpf                           @DataDog/agent-network
+security_go_generate_check           @DataDog/agent-security
 
 # Binary build
 build_system-probe*                  @DataDog/agent-network


### PR DESCRIPTION
### What does this PR do?

Add `security_go_generate_check` to JOBOWNERS.

### Motivation

Notify security agent team when the test breaks on the `main` branch.

### Additional Notes

Follow up to #8732.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
