### PR TITLE
Fix dependabot for main `go.mod` file

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -237,4 +237,4 @@ replace gopkg.in/DataDog/dd-trace-go.v1 => gopkg.in/DataDog/dd-trace-go.v1 v1.30
 // Remove once the PR kubernetes/kube-state-metrics#1516 is merged and released.
 replace k8s.io/kube-state-metrics/v2 => github.com/ahmed-mez/kube-state-metrics/v2 v2.1.0-rc.0.0.20210629115837-e46f17606d22
 
-replace github.com/aptly-dev/aptly => github.com/lebauce/aptly v0.7.2-0.20201005164315-09522984a976
+replace github.com/aptly-dev/aptly => github.com/lebauce/aptly v0.7.2-0.20210723103859-345a32860f4d

--- a/go.sum
+++ b/go.sum
@@ -880,8 +880,8 @@ github.com/kubernetes-sigs/custom-metrics-apiserver v0.0.0-20210311094424-0ca2b1
 github.com/kubernetes-sigs/custom-metrics-apiserver v0.0.0-20210311094424-0ca2b1909cdc/go.mod h1:o4psv/D+LJC+NGyL66BoKWXLkzlJeUqhL6/3rjFKXw0=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
-github.com/lebauce/aptly v0.7.2-0.20201005164315-09522984a976 h1:AqaR29P5INgl7Uqwmu7kdbB7GYZIv/NsgUXUdnFXECg=
-github.com/lebauce/aptly v0.7.2-0.20201005164315-09522984a976/go.mod h1:+3II479yQc6qORocqKTXZQupY2SVnKPWDC2VMA7Zk9s=
+github.com/lebauce/aptly v0.7.2-0.20210723103859-345a32860f4d h1:6k4uyp3yRFzEmzQZjnneNYhIvNvvcu9XIvFyalzuBAE=
+github.com/lebauce/aptly v0.7.2-0.20210723103859-345a32860f4d/go.mod h1:Uot/EzgnIw6okZTyEZ/Q8+er5ZXy2Bqrrabr/M6OxUE=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lib/pq v1.10.0 h1:Zx5DJFEYQXio93kgXnQ09fXNiUKsqv4OUEu2UtGcB1E=
 github.com/lib/pq v1.10.0/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=


### PR DESCRIPTION
### What does this PR do?

Update `replace` directive from lebauce/aptly@09522984a976 (which was removed from the repo) to lebauce/aptly@345a32860f4d.

### Motivation

Fix dependabot for main `go.mod` file. See error [here](https://github.com/DataDog/datadog-agent/network/updates/174999308)

### Additional Notes

A follow up PR should be done to add context to this replace directive in accordance with the [guidelines](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/gomodreplace.md).

### Describe how to test your changes

Should be a no-op.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
