### PR TITLE
[runtime-security] use the first event type as index for the discarder mask

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "2546d4a08debcbb02547e5c558cda8d25aca218a3ed9d8a531e9bf2aa82aa774")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "9dfe314aebb7ca21bc71b8dd33360755a3b9d1b1630164c596f9e048783c80f5")

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -507,7 +507,7 @@ static __attribute__((always_inline)) u64 get_enabled_events(void) {
 }
 
 static __attribute__((always_inline)) int mask_has_event(u64 mask, enum event_type event) {
-    return mask & (1 << (event-1));
+    return mask & (1 << (event-EVENT_FIRST_DISCARDER));
 }
 
 static __attribute__((always_inline)) int is_event_enabled(enum event_type event) {

--- a/pkg/security/ebpf/c/discarders.h
+++ b/pkg/security/ebpf/c/discarders.h
@@ -151,14 +151,14 @@ int __attribute__((always_inline)) discard_inode(u64 event_type, u32 mount_id, u
 
     struct inode_discarder_params_t *inode_params = bpf_map_lookup_elem(&inode_discarders, &key);
     if (inode_params) {
-        inode_params->params.event_mask |= 1 << event_type;
+        inode_params->params.event_mask |= 1 << (event_type - EVENT_FIRST_DISCARDER);
 
         if ((discarder_timestamp = get_discarder_timestamp(&inode_params->params, event_type)) != NULL) {
             *discarder_timestamp = timestamp;
         }
     } else {
         struct inode_discarder_params_t new_inode_params = {
-            .params.event_mask = 1 << event_type,
+            .params.event_mask = 1 << (event_type - EVENT_FIRST_DISCARDER),
             .revision = get_discarder_revision(mount_id),
         };
 


### PR DESCRIPTION
### What does this PR do?

The value of the first event type is not equal to zero so we need to subtract the first event value from the given value before using it as a mask.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
