### PR TITLE
[runtime-security] add context for aptly replace in `go.mod`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -238,4 +238,5 @@ replace gopkg.in/DataDog/dd-trace-go.v1 => gopkg.in/DataDog/dd-trace-go.v1 v1.30
 // Remove once the PR kubernetes/kube-state-metrics#1516 is merged and released.
 replace k8s.io/kube-state-metrics/v2 => github.com/ahmed-mez/kube-state-metrics/v2 v2.1.0-rc.0.0.20210629115837-e46f17606d22
 
+// Remove once the PR aptly-dev/aptly#967 is merged and released.
 replace github.com/aptly-dev/aptly => github.com/lebauce/aptly v0.7.2-0.20210723103859-345a32860f4d


### PR DESCRIPTION
### What does this PR do?

This PR adds context around the replace directive of `aptly` in `go.mod`

### Motivation

Requested by #8744

### Describe how to test your changes

Just a comment. Should be a no-op.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
