### PR TITLE
[Docs] Update k8s manifests

### DIFF
--- a/Dockerfiles/manifests/agent-only/README.md
+++ b/Dockerfiles/manifests/agent-only/README.md
@@ -1,6 +1,6 @@
 The kubernetes manifests found in this directory have been automatically generated
 from the [helm chart `datadog/datadog`](https://github.com/DataDog/helm-charts/tree/master/charts/datadog)
-version 2.19.4 with the following `values.yaml`:
+version 2.19.8 with the following `values.yaml`:
 
 ```yaml
 datadog:

--- a/Dockerfiles/manifests/agent-only/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/agent-only/cluster-agent-rbac.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.19.4"
+    chart: "datadog-2.19.8"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent

--- a/Dockerfiles/manifests/agent-only/daemonset.yaml
+++ b/Dockerfiles/manifests/agent-only/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -122,7 +122,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -132,7 +132,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:

--- a/Dockerfiles/manifests/all-containers/README.md
+++ b/Dockerfiles/manifests/all-containers/README.md
@@ -1,6 +1,6 @@
 The kubernetes manifests found in this directory have been automatically generated
 from the [helm chart `datadog/datadog`](https://github.com/DataDog/helm-charts/tree/master/charts/datadog)
-version 2.19.4 with the following `values.yaml`:
+version 2.19.8 with the following `values.yaml`:
 
 ```yaml
 datadog:

--- a/Dockerfiles/manifests/all-containers/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/all-containers/cluster-agent-rbac.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.19.4"
+    chart: "datadog-2.19.8"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent

--- a/Dockerfiles/manifests/all-containers/daemonset.yaml
+++ b/Dockerfiles/manifests/all-containers/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
       hostPID: true
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -139,7 +139,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: trace-agent
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["trace-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -203,7 +203,7 @@ spec:
               port: 8126
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -274,7 +274,7 @@ spec:
               mountPath: /etc/datadog-agent/system-probe.yaml
               subPath: system-probe.yaml
         - name: system-probe
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -327,7 +327,7 @@ spec:
               mountPropagation: None
               readOnly: true
         - name: security-agent
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -416,7 +416,7 @@ spec:
               subPath: system-probe.yaml
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -426,7 +426,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -464,7 +464,7 @@ spec:
               value: "yes"
           resources: {}
         - name: seccomp-setup
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           command:
             - cp
             - /etc/config/system-probe-seccomp.json

--- a/Dockerfiles/manifests/cluster-agent-datadogmetrics/README.md
+++ b/Dockerfiles/manifests/cluster-agent-datadogmetrics/README.md
@@ -1,6 +1,6 @@
 The kubernetes manifests found in this directory have been automatically generated
 from the [helm chart `datadog/datadog`](https://github.com/DataDog/helm-charts/tree/master/charts/datadog)
-version 2.19.4 with the following `values.yaml`:
+version 2.19.8 with the following `values.yaml`:
 
 ```yaml
 datadog:

--- a/Dockerfiles/manifests/cluster-agent-datadogmetrics/agent-services.yaml
+++ b/Dockerfiles/manifests/cluster-agent-datadogmetrics/agent-services.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog"
-    chart: "datadog-2.19.4"
+    chart: "datadog-2.19.8"
     release: "datadog"
     heritage: "Helm"
 spec:

--- a/Dockerfiles/manifests/cluster-agent-datadogmetrics/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/cluster-agent-datadogmetrics/cluster-agent-rbac.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.19.4"
+    chart: "datadog-2.19.8"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent
@@ -184,7 +184,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.19.4"
+    chart: "datadog-2.19.8"
     release: "datadog"
     heritage: "Helm"
   name: datadog-cluster-agent-system-auth-delegator

--- a/Dockerfiles/manifests/cluster-agent-datadogmetrics/daemonset.yaml
+++ b/Dockerfiles/manifests/cluster-agent-datadogmetrics/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -122,7 +122,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -132,7 +132,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:

--- a/Dockerfiles/manifests/cluster-agent/README.md
+++ b/Dockerfiles/manifests/cluster-agent/README.md
@@ -1,6 +1,6 @@
 The kubernetes manifests found in this directory have been automatically generated
 from the [helm chart `datadog/datadog`](https://github.com/DataDog/helm-charts/tree/master/charts/datadog)
-version 2.19.4 with the following `values.yaml`:
+version 2.19.8 with the following `values.yaml`:
 
 ```yaml
 datadog:

--- a/Dockerfiles/manifests/cluster-agent/agent-services.yaml
+++ b/Dockerfiles/manifests/cluster-agent/agent-services.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog"
-    chart: "datadog-2.19.4"
+    chart: "datadog-2.19.8"
     release: "datadog"
     heritage: "Helm"
 spec:

--- a/Dockerfiles/manifests/cluster-agent/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/cluster-agent/cluster-agent-rbac.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.19.4"
+    chart: "datadog-2.19.8"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent
@@ -169,7 +169,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.19.4"
+    chart: "datadog-2.19.8"
     release: "datadog"
     heritage: "Helm"
   name: datadog-cluster-agent-system-auth-delegator

--- a/Dockerfiles/manifests/cluster-agent/daemonset.yaml
+++ b/Dockerfiles/manifests/cluster-agent/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -122,7 +122,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -132,7 +132,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:

--- a/Dockerfiles/manifests/cluster-checks-runners/README.md
+++ b/Dockerfiles/manifests/cluster-checks-runners/README.md
@@ -1,6 +1,6 @@
 The kubernetes manifests found in this directory have been automatically generated
 from the [helm chart `datadog/datadog`](https://github.com/DataDog/helm-charts/tree/master/charts/datadog)
-version 2.19.4 with the following `values.yaml`:
+version 2.19.8 with the following `values.yaml`:
 
 ```yaml
 datadog:

--- a/Dockerfiles/manifests/cluster-checks-runners/agent-clusterchecks-deployment.yaml
+++ b/Dockerfiles/manifests/cluster-checks-runners/agent-clusterchecks-deployment.yaml
@@ -30,7 +30,7 @@ spec:
       imagePullSecrets: []
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -40,7 +40,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -51,7 +51,7 @@ spec:
           resources: {}
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           command: ["bash", "-c"]
           args:
             - rm -rf /etc/datadog-agent/conf.d && touch /etc/datadog-agent/datadog.yaml && exec agent run

--- a/Dockerfiles/manifests/cluster-checks-runners/agent-services.yaml
+++ b/Dockerfiles/manifests/cluster-checks-runners/agent-services.yaml
@@ -22,7 +22,7 @@ metadata:
   namespace: default
   labels:
     app: "datadog"
-    chart: "datadog-2.19.4"
+    chart: "datadog-2.19.8"
     release: "datadog"
     heritage: "Helm"
 spec:

--- a/Dockerfiles/manifests/cluster-checks-runners/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/cluster-checks-runners/cluster-agent-rbac.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.19.4"
+    chart: "datadog-2.19.8"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent
@@ -169,7 +169,7 @@ kind: ClusterRoleBinding
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.19.4"
+    chart: "datadog-2.19.8"
     release: "datadog"
     heritage: "Helm"
   name: datadog-cluster-agent-system-auth-delegator

--- a/Dockerfiles/manifests/cluster-checks-runners/daemonset.yaml
+++ b/Dockerfiles/manifests/cluster-checks-runners/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -122,7 +122,7 @@ spec:
             timeoutSeconds: 5
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -132,7 +132,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:

--- a/Dockerfiles/manifests/kubernetes_state_core/README.md
+++ b/Dockerfiles/manifests/kubernetes_state_core/README.md
@@ -1,6 +1,6 @@
 The kubernetes manifests found in this directory have been automatically generated
 from the [helm chart `datadog/datadog`](https://github.com/DataDog/helm-charts/tree/master/charts/datadog)
-version 2.19.4 with the following `values.yaml`:
+version 2.19.8 with the following `values.yaml`:
 
 ```yaml
 datadog:

--- a/Dockerfiles/manifests/kubernetes_state_core/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/kubernetes_state_core/cluster-agent-rbac.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.19.4"
+    chart: "datadog-2.19.8"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent

--- a/Dockerfiles/manifests/kubernetes_state_core/daemonset.yaml
+++ b/Dockerfiles/manifests/kubernetes_state_core/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -123,7 +123,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -187,7 +187,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -197,7 +197,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:

--- a/Dockerfiles/manifests/orchestrator-explorer/README.md
+++ b/Dockerfiles/manifests/orchestrator-explorer/README.md
@@ -1,6 +1,6 @@
 The kubernetes manifests found in this directory have been automatically generated
 from the [helm chart `datadog/datadog`](https://github.com/DataDog/helm-charts/tree/master/charts/datadog)
-version 2.19.4 with the following `values.yaml`:
+version 2.19.8 with the following `values.yaml`:
 
 ```yaml
 datadog:

--- a/Dockerfiles/manifests/orchestrator-explorer/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/orchestrator-explorer/cluster-agent-rbac.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.19.4"
+    chart: "datadog-2.19.8"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent

--- a/Dockerfiles/manifests/orchestrator-explorer/daemonset.yaml
+++ b/Dockerfiles/manifests/orchestrator-explorer/daemonset.yaml
@@ -22,7 +22,7 @@ spec:
     spec:
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -121,7 +121,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -185,7 +185,7 @@ spec:
               readOnly: true
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -195,7 +195,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:

--- a/Dockerfiles/manifests/security-agent/README.md
+++ b/Dockerfiles/manifests/security-agent/README.md
@@ -1,6 +1,6 @@
 The kubernetes manifests found in this directory have been automatically generated
 from the [helm chart `datadog/datadog`](https://github.com/DataDog/helm-charts/tree/master/charts/datadog)
-version 2.19.4 with the following `values.yaml`:
+version 2.19.8 with the following `values.yaml`:
 
 ```yaml
 datadog:

--- a/Dockerfiles/manifests/security-agent/cluster-agent-rbac.yaml
+++ b/Dockerfiles/manifests/security-agent/cluster-agent-rbac.yaml
@@ -4,7 +4,7 @@ kind: ServiceAccount
 metadata:
   labels:
     app: "datadog"
-    chart: "datadog-2.19.4"
+    chart: "datadog-2.19.8"
     heritage: "Helm"
     release: "datadog"
   name: datadog-cluster-agent

--- a/Dockerfiles/manifests/security-agent/daemonset.yaml
+++ b/Dockerfiles/manifests/security-agent/daemonset.yaml
@@ -25,7 +25,7 @@ spec:
       hostPID: true
       containers:
         - name: agent
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["agent", "run"]
           resources: {}
@@ -124,7 +124,7 @@ spec:
             successThreshold: 1
             timeoutSeconds: 5
         - name: process-agent
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["process-agent", "-config=/etc/datadog-agent/datadog.yaml"]
           resources: {}
@@ -193,7 +193,7 @@ spec:
               mountPath: /etc/datadog-agent/system-probe.yaml
               subPath: system-probe.yaml
         - name: system-probe
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -246,7 +246,7 @@ spec:
               mountPropagation: None
               readOnly: true
         - name: security-agent
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           securityContext:
             capabilities:
@@ -335,7 +335,7 @@ spec:
               subPath: system-probe.yaml
       initContainers:
         - name: init-volume
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -345,7 +345,7 @@ spec:
               mountPath: /opt/datadog-agent
           resources: {}
         - name: init-config
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           imagePullPolicy: IfNotPresent
           command: ["bash", "-c"]
           args:
@@ -383,7 +383,7 @@ spec:
               value: "yes"
           resources: {}
         - name: seccomp-setup
-          image: "gcr.io/datadoghq/agent:7.29.0"
+          image: "gcr.io/datadoghq/agent:7.29.1"
           command:
             - cp
             - /etc/config/system-probe-seccomp.json


### PR DESCRIPTION
### What does this PR do?

Update k8s manifests

### Motivation

Keep documentation up to date

### Describe how to test your changes

The manifests were already validated in `datadog/helm-charts`

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
