### PR TITLE
Nudge to use `generate-licenses` if lint fails

### DIFF
--- a/tasks/go.py
+++ b/tasks/go.py
@@ -331,16 +331,15 @@ def lint_licenses(ctx):
         print("- {}".format(license))
 
     if len(removed_licenses) + len(added_licenses) > 0:
-        print("licenses are not up-to-date")
-        raise Exit(code=1)
+        raise Exit(message="Licenses are not up-to-date.\n\nPlease run 'inv generate-licenses' to update licenses file.", code=1)
 
-    print("licenses ok")
+    print("Licenses are ok.")
 
 
 @task
 def generate_licenses(ctx, filename='LICENSE-3rdparty.csv', verbose=False):
     """
-    Generates that the LICENSE-3rdparty.csv file is up-to-date with contents of go.sum
+    Generates the LICENSE-3rdparty.csv file. Run this if `inv lint-licenses` fails.
     """
     with open(filename, 'w') as f:
         f.write("Component,Origin,License\n")

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -331,7 +331,10 @@ def lint_licenses(ctx):
         print("- {}".format(license))
 
     if len(removed_licenses) + len(added_licenses) > 0:
-        raise Exit(message="Licenses are not up-to-date.\n\nPlease run 'inv generate-licenses' to update licenses file.", code=1)
+        raise Exit(
+            message="Licenses are not up-to-date.\n\nPlease run 'inv generate-licenses' to update licenses file.",
+            code=1,
+        )
 
     print("Licenses are ok.")
 


### PR DESCRIPTION
### What does this PR do?

- Add hint to use the `generate-licenses` task when `lint-licenses` fails.
- Update `generate-licenses` description

### Motivation

License linting can be confusing (original idea stemmed from conversation in #8733).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
