### PR TITLE
[collector healthcheck] More accurate and less aggressive collector queue healthcheck

### DIFF
--- a/pkg/collector/scheduler/job.go
+++ b/pkg/collector/scheduler/job.go
@@ -207,6 +207,12 @@ func (jq *jobQueue) process(s *Scheduler) bool {
 				jq.health.Deregister() //nolint:errcheck
 				return false
 			}
+
+			select {
+			// we were able to schedule a check so we're not stuck, therefore poll the health chan
+			case <-jq.health.C:
+			default:
+			}
 		}
 		jq.mu.Lock()
 		jq.currentBucketIdx = (jq.currentBucketIdx + 1) % uint(len(jq.buckets))

--- a/pkg/collector/scheduler/job.go
+++ b/pkg/collector/scheduler/job.go
@@ -77,7 +77,7 @@ func newJobQueue(interval time.Duration) *jobQueue {
 		interval:     interval,
 		stop:         make(chan bool),
 		stopped:      make(chan bool),
-		health:       health.RegisterLiveness("collector-queue"),
+		health:       health.RegisterLiveness(fmt.Sprintf("collector-queue-%vs", interval.Seconds())),
 		bucketTicker: time.NewTicker(time.Second),
 	}
 

--- a/releasenotes/notes/less-aggressive-collector-queue-health-82822ea0a9da7850.yaml
+++ b/releasenotes/notes/less-aggressive-collector-queue-health-82822ea0a9da7850.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Improve accuracy and reduce false positives on the collector-queue health
+    check


### PR DESCRIPTION
### What does this PR do?

2 changes to improve the accuracy and reduce false positives of the collector-queue health check:

* ~Register one health check per job queue: to have a more consistent and predictable behavior on the health check,
each job queue should have its own health chan, otherwise only the last job queue that gets instantiated will actually have a working health check.~ _Update_: Use more unique names for each `collector-queue` health check to be able to differentiate them. This has no functional direct impact except allowing to actually differentiate the health checks in `health` command output/logs.
* Poll the health chan whenever a check is enqueued: So that its health check becomes unhealthy only when the job queue is unable to schedule any check for a period of time, which is the correct sign that the collector is completely stuck. Before this change, the health check would become unhealthy when all the checks scheduled at a given "tick" (i.e. for a given second) can't be scheduled for a period of time, which can lead to incorrect unhealthy states when a very high number of instances are configured.

### Motivation

Avoid false positives on the liveness probe, in scenarios where a very high number of check instances are configured (ex: SNMP check), and potentially with different `min_collection_interval`s.

### Describe how to test your changes

This code doesn't have existing unit tests unfortunately, and I didn't add any here...

QA:
* Check that the `agent health` command has one health check per job queue, and that they're healthy. By default: `collector-queue-15s` and `collector-queue-900s`.
* Check that the `collector-queue-15s` still becomes unhealthy (after ~30 seconds to 1min) when 4 custom check insrtances are scheduled, each doing nothing but blocking its check runner (for example with a `time.sleep(600)` in `check()`).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
~- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.~
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
~- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.~
