### PR TITLE
[telemetry] optimize tagger telemetry

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -786,7 +786,7 @@ func InitConfig(config Config) {
 	// Enable telemetry metrics on the internals of the Agent.
 	// This create a lot of billable custom metrics.
 	config.BindEnvAndSetDefault("telemetry.enabled", false)
-	config.SetKnown("telemetry.checks")
+	config.BindEnvAndSetDefault("telemetry.checks", []string{})
 	// We're using []string as a default instead of []float64 because viper can only parse list of string from the environment
 	//
 	// The histogram buckets use to track the time in nanoseconds DogStatsD listeners are not reading/waiting new data

--- a/pkg/tagger/local/tagger.go
+++ b/pkg/tagger/local/tagger.go
@@ -241,7 +241,7 @@ func (t *Tagger) Stop() error {
 
 // getTags returns a read only list of tags for a given entity.
 func (t *Tagger) getTags(entity string, cardinality collectors.TagCardinality) ([]string, error) {
-	telemetry.Queries.Inc(collectors.TagCardinalityToString(cardinality))
+	telemetry.IncQueriesForCardinality(cardinality)
 
 	if entity == "" {
 		return nil, fmt.Errorf("empty entity ID")

--- a/pkg/tagger/remote/tagger.go
+++ b/pkg/tagger/remote/tagger.go
@@ -136,7 +136,7 @@ func (t *Tagger) Stop() error {
 
 // Tag returns tags for a given entity at the desired cardinality.
 func (t *Tagger) Tag(entityID string, cardinality collectors.TagCardinality) ([]string, error) {
-	telemetry.Queries.Inc(collectors.TagCardinalityToString(cardinality))
+	telemetry.IncQueriesForCardinality(cardinality)
 
 	entity := t.store.getEntity(entityID)
 	if entity != nil {

--- a/pkg/tagger/replay/tagger.go
+++ b/pkg/tagger/replay/tagger.go
@@ -68,7 +68,7 @@ func (t *Tagger) Stop() error {
 
 // Tag returns tags for a given entity at the desired cardinality.
 func (t *Tagger) Tag(entityID string, cardinality collectors.TagCardinality) ([]string, error) {
-	telemetry.Queries.Inc(collectors.TagCardinalityToString(cardinality))
+	telemetry.IncQueriesForCardinality(cardinality)
 
 	entity, ok := t.store.getEntity(entityID)
 	if ok {

--- a/pkg/telemetry/counter.go
+++ b/pkg/telemetry/counter.go
@@ -6,8 +6,6 @@
 package telemetry
 
 import (
-	"fmt"
-
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -46,13 +44,7 @@ func NewCounter(subsystem, name string, tags []string, help string) Counter {
 // NewCounterWithOpts creates a Counter with the given options for telemetry purpose.
 // See NewCounter()
 func NewCounterWithOpts(subsystem, name string, tags []string, help string, opts Options) Counter {
-	// subsystem is optional
-	if subsystem != "" && !opts.NoDoubleUnderscoreSep {
-		// Prefix metrics with a _, prometheus will add a second _
-		// It will create metrics with a custom separator and
-		// will let us replace it to a dot later in the process.
-		name = fmt.Sprintf("_%s", name)
-	}
+	name = opts.NameWithSeparator(subsystem, name)
 
 	c := &promCounter{
 		pc: prometheus.NewCounterVec(

--- a/pkg/telemetry/counter.go
+++ b/pkg/telemetry/counter.go
@@ -33,6 +33,10 @@ type Counter interface {
 	// Even if less convenient, this signature could be used in hot path
 	// instead of Delete(...string) to avoid escaping the parameters on the heap.
 	DeleteWithTags(tags map[string]string)
+	// WithValues returns SimpleCounter for this metric with the given tag values.
+	WithValues(tagsValue ...string) SimpleCounter
+	// WithTags returns SimpleCounter for this metric with the given tqg values.
+	WithTags(tags map[string]string) SimpleCounter
 }
 
 // NewCounter creates a Counter with default options for telemetry purpose.

--- a/pkg/telemetry/gauge.go
+++ b/pkg/telemetry/gauge.go
@@ -6,8 +6,6 @@
 package telemetry
 
 import (
-	"fmt"
-
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -36,13 +34,7 @@ func NewGauge(subsystem, name string, tags []string, help string) Gauge {
 // NewGaugeWithOpts creates a Gauge with the given options for telemetry purpose.
 // See NewGauge()
 func NewGaugeWithOpts(subsystem, name string, tags []string, help string, opts Options) Gauge {
-	// subsystem is optional
-	if subsystem != "" && !opts.NoDoubleUnderscoreSep {
-		// Prefix metrics with a _, prometheus will add a second _
-		// It will create metrics with a custom separator and
-		// will let us replace it to a dot later in the process.
-		name = fmt.Sprintf("_%s", name)
-	}
+	name = opts.NameWithSeparator(subsystem, name)
 
 	g := &promGauge{
 		pg: prometheus.NewGaugeVec(

--- a/pkg/telemetry/histogram.go
+++ b/pkg/telemetry/histogram.go
@@ -6,8 +6,6 @@
 package telemetry
 
 import (
-	"fmt"
-
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -38,13 +36,7 @@ func NewHistogram(subsystem, name string, tags []string, help string, buckets []
 // NewHistogramWithOpts creates a Histogram with the given options for telemetry purpose.
 // See NewHistogram()
 func NewHistogramWithOpts(subsystem, name string, tags []string, help string, buckets []float64, opts Options) Histogram {
-	// subsystem is optional
-	if subsystem != "" && !opts.NoDoubleUnderscoreSep {
-		// Prefix metrics with a _, prometheus will add a second _
-		// It will create metrics with a custom separator and
-		// will let us replace it to a dot later in the process.
-		name = fmt.Sprintf("_%s", name)
-	}
+	name = opts.NameWithSeparator(subsystem, name)
 
 	h := &promHistogram{
 		ph: prometheus.NewHistogramVec(

--- a/pkg/telemetry/options.go
+++ b/pkg/telemetry/options.go
@@ -1,5 +1,7 @@
 package telemetry
 
+import "fmt"
+
 // Options for telemetry metrics.
 // Creating an Options struct without specifying any of its fields should be the
 // equivalent of using the DefaultOptions var.
@@ -14,4 +16,17 @@ var DefaultOptions = Options{
 	// By default, we want to separate the subsystem and the metric name with a
 	// double underscore to be able to replace it later in the process.
 	NoDoubleUnderscoreSep: false,
+}
+
+// NameWithSeparator returns name prefixed according to NoDoubleUnderscoreOption.
+func (opts *Options) NameWithSeparator(subsystem, name string) string {
+	// subsystem is optional
+	if subsystem != "" && !opts.NoDoubleUnderscoreSep {
+		// Prefix metrics with a _, prometheus will add a second _
+		// It will create metrics with a custom separator and
+		// will let us replace it to a dot later in the process.
+		return fmt.Sprintf("_%s", name)
+	}
+
+	return name
 }

--- a/pkg/telemetry/prom_counter.go
+++ b/pkg/telemetry/prom_counter.go
@@ -59,3 +59,13 @@ func (c *promCounter) Delete(tagsValue ...string) {
 func (c *promCounter) DeleteWithTags(tags map[string]string) {
 	c.pc.Delete(tags)
 }
+
+// WithValues returns SimpleCounter for this metric with the given tag values.
+func (c *promCounter) WithValues(tagsValue ...string) SimpleCounter {
+	return c.pc.WithLabelValues(tagsValue...)
+}
+
+// Withtags returns SimpleCounter for this metric with the given tag values.
+func (c *promCounter) WithTags(tags map[string]string) SimpleCounter {
+	return c.pc.With(tags)
+}

--- a/pkg/telemetry/simple_counter.go
+++ b/pkg/telemetry/simple_counter.go
@@ -1,0 +1,33 @@
+package telemetry
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// SimpleCounter tracks how many times something is happening.
+type SimpleCounter interface {
+	// Inc increments the counter.
+	Inc()
+	// Add increments the counter by given amount.
+	Add(float64)
+}
+
+// NewSimpleCounter creates a new SimpleCounter with default options.
+func NewSimpleCounter(subsystem, name, help string) SimpleCounter {
+	return NewSimpleCounterWithOpts(subsystem, name, help, DefaultOptions)
+}
+
+// NewSimpleCounterWithOpts creates a new SimpleCounter.
+func NewSimpleCounterWithOpts(subsystem, name, help string, opts Options) SimpleCounter {
+	name = opts.NameWithSeparator(subsystem, name)
+
+	pc := prometheus.NewCounter(prometheus.CounterOpts{
+		Subsystem: subsystem,
+		Name:      name,
+		Help:      help,
+	})
+
+	telemetryRegistry.MustRegister(pc)
+
+	return pc
+}


### PR DESCRIPTION
### What does this PR do?

Avoid re-hashing cardinality tag over and over (relatively slow), by exposing and caching basic counters for each cardinality tag value (relatively fast).

### Motivation

Tag hashing inside `Counter.Inc()` implementation is visible in the profiles and takes a noticeable amount of time.

### Describe how to test your changes

Run agent with telemetry enabled and configure telemetry check in `conf.d/agent_telemetry.d/conf.yaml`:

```
init_config:
instances:
  - prometheus_url: http://localhost:5000/telemetry
    namespace: "datadog.agent"
    metrics:
      - "*"
```

Check that `datadog.agent.tagger_queries` metrics are populated.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
