### PR TITLE
Add parameters to customize InCluster config used to reach APIServer

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -540,6 +540,8 @@ func InitConfig(config Config) {
 
 	// Kube ApiServer
 	config.BindEnvAndSetDefault("kubernetes_kubeconfig_path", "")
+	config.BindEnvAndSetDefault("kubernetes_apiserver_ca_path", "")
+	config.BindEnvAndSetDefault("kubernetes_apiserver_tls_verify", true)
 	config.BindEnvAndSetDefault("leader_lease_duration", "60")
 	config.BindEnvAndSetDefault("leader_election", false)
 	config.BindEnvAndSetDefault("kube_resources_namespace", "")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2030,6 +2030,20 @@ api_key:
 #
 # kubernetes_kubeconfig_path: ""
 
+## @param kubernetes_apiserver_ca_path - string - optional - default: ""
+## When running in a pod, the Agent automatically uses the pod's service account CA.
+## Use this option to keep using the InCluster config but overriding the default CA Path.
+## This parameter has no effect if `kubernetes_kubeconfig_path` is set.
+#
+# kubernetes_apiserver_ca_path: ""
+
+## @param kubernetes_apiserver_tls_verify - boolean - optional - default: true
+## When running in a pod, the Agent automatically uses the pod's service account CA.
+## Use this option to keep using the InCluster config but deactivating TLS verification (in case APIServer CA is not ServiceAccount CA)
+## This parameter has no effect if `kubernetes_kubeconfig_path` is set.
+#
+# kubernetes_apiserver_tls_verify: true
+
 ## @param kubernetes_apiserver_use_protobuf - boolean - optional - default: false
 ## By default, communication with the apiserver is in json format. Setting the following
 ## option to true allows communication in the binary protobuf format.

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -160,6 +160,15 @@ func getClientConfig(timeout time.Duration) (*rest.Config, error) {
 	cfgPath := config.Datadog.GetString("kubernetes_kubeconfig_path")
 	if cfgPath == "" {
 		clientConfig, err = rest.InClusterConfig()
+
+		if !config.Datadog.GetBool("kubernetes_apiserver_tls_verify") {
+			clientConfig.TLSClientConfig.Insecure = true
+		}
+
+		if customCAPath := config.Datadog.GetString("kubernetes_apiserver_ca_path"); customCAPath != "" {
+			clientConfig.TLSClientConfig.CAFile = customCAPath
+		}
+
 		if err != nil {
 			log.Debugf("Can't create a config for the official client from the service account's token: %v", err)
 			return nil, err

--- a/releasenotes/notes/apiserver-ca-4f3bc0f6d7f99a2f.yaml
+++ b/releasenotes/notes/apiserver-ca-4f3bc0f6d7f99a2f.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add two new parameters to allow customizing APIServer connection parameters (CAPath, TLSVerify) without requiring to use a fully custom kubeconfig.


### PR DESCRIPTION
### What does this PR do?

Add two new parameters to allow customizing APIServer connection parameters (CAPath, TLSVerify) without requiring to use a fully custom kubeconfig.

### Motivation

Support ticket.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
