### PR TITLE
Stop dropping TCP connections on log collection after 60s

### DIFF
--- a/pkg/logs/input/listener/tcp.go
+++ b/pkg/logs/input/listener/tcp.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"net"
 	"sync"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -17,9 +16,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/restart"
 )
-
-// defaultTimeout represents the time after which a connection is closed when no data is read
-const defaultTimeout = time.Minute
 
 // A TCPListener listens and accepts TCP connections and delegates the read operations to a tailer.
 type TCPListener struct {
@@ -115,7 +111,6 @@ func (l *TCPListener) startListener() error {
 
 // read reads data from connection, returns an error if it failed and stop the tailer.
 func (l *TCPListener) read(tailer *Tailer) ([]byte, error) {
-	tailer.conn.SetReadDeadline(time.Now().Add(defaultTimeout)) //nolint:errcheck
 	frame := make([]byte, l.frameSize)
 	n, err := tailer.conn.Read(frame)
 	if err != nil {

--- a/releasenotes/notes/tcp-logs-remove-timeout-bedd771596893d8d.yaml
+++ b/releasenotes/notes/tcp-logs-remove-timeout-bedd771596893d8d.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    TCP log collectors have historically closed sockets that are idle for more
+    than 60 seconds.  This is no longer the case.  The agent relies on TCP
+    keepalives to detect failed connections, and will otherwise wait indefinitely
+    for logs to arrive on a TCP connection.


### PR DESCRIPTION
### What does this PR do?

The TCP-socket log source has historically closed sockets that were idle for 60s, which caused data loss for log senders that just didn't have logs to send for that length of time.  This removes the unnecessary timeout.

### Motivation

Users were seeing data loss due to connections being closed.

### Additional Notes

In general, data loss on connection failure is just an inherent downside to using raw TCP connections with no framing or application-level acks.  The best thing we can do is to minimize the probability of connection termination, and the easiest way to do that is to stop deliberately terminating them at 60s!

Having done that, though, we run the risk of the agent never noticing that a sender has gone away, such as having been powered off – the receiving socket will just sit in the “waiting for data” state forever.  This can eventually cause resource exhaustion, and is (I suspect) what the 60s timeout was intended to solve.

TCP keepalives  are designed to avoid this situation, by periodically sending an empty PSH+ACK segment, expecting an ACK from the remote end.  If this ACK does not occur within a timeout, then the connection is marked as failed and any pending read calls return with an error.  Unfortunately, keepalives default to off, and when enabled default to a very long time, so we will need to enable and configure these on a per-socket basis.

Also, keepalives are configured separately on each end of a TCP connection, so senders (plugins) should enable keepalives on their end as well, which will help their TCP stack return an error on the first send after the connection fails, rather than the second.

As it turns out, keepalives are such a good idea that Go enables them by default (https://pkg.go.dev/net#ListenConfig), so we've been using them all this time.

### Describe how to test your changes

Set up a TCP-based log source and feed it a log line every 90s or so.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
