### PR TITLE
Add note about describing QA setup

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,6 +15,10 @@ Anything else we should know when reviewing?
 Write here in detail how you have tested your changes
 and instructions on how this should be tested in QA.
 
+Describe or link instructions to set up environment 
+for testing, if the process requires more than just
+running the agent on one of the supported platforms.
+
 ### Checklist
 <!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
 


### PR DESCRIPTION
### What does this PR do?

Add note to the PR template about describing setup required to QA changes.

### Motivation

Make it easier for people doing release testing to reproduce the environment for testing.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
