### PR TITLE
[KSMCore] Add pod.count and improve owner tagging

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
@@ -166,6 +166,9 @@
 `kubernetes_state.pod.uptime`
 : The time in seconds since the pod has been scheduled and acknowledged by the Kubelet. Tags:`kube_namespace` `pod_name` `phase` (`env` `service` `version` from standard labels).
 
+`kubernetes_state.pod.count`
+: Number of Pods. Tags:`kube_namespace` `kube_<owner kind>`.
+
 `kubernetes_state.persistentvolumeclaim.status`
 : The phase the persistent volume claim is currently in. Tags:`kube_namespace` `persistentvolumeclaim` `phase` `storageclass`.
 
@@ -197,7 +200,7 @@
 : Type about secret. Tags:`kube_namespace` `secret` `type`.
 
 `kubernetes_state.replicaset.count`
-: Number of ReplicaSets Tags:`kube_namespace` `owner_name` `owner_kind`.
+: Number of ReplicaSets Tags:`kube_namespace` `kube_deployment`.
 
 `kubernetes_state.replicaset.replicas_desired`
 : Number of desired pods for a ReplicaSet. Tags:`kube_namespace` `kube_replica_set` (`env` `service` `version` from standard labels).
@@ -299,7 +302,7 @@
 : The duration since the last time the cronjob was scheduled. Tags:`kube_cronjob` `kube_namespace` (`env` `service` `version` from standard labels).
 
 `kubernetes_state.job.count`
-: Number of jobs. Tags:`kube_namespace` `owner_name` `owner_kind`.
+: Number of jobs. Tags:`kube_namespace` `owner_cronjob`.
 
 `kubernetes_state.job.failed`
 : The number of pods which reached Phase Failed. Tags:`kube_job` or `kube_cronjob` `kube_namespace` (`env` `service` `version` from standard labels).

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
@@ -175,4 +175,8 @@ var metricAggregators = map[string]metricAggregator{
 		"node.count",
 		[]string{"kubelet_version", "container_runtime_version", "kernel_version", "os_image"},
 	),
+	"kube_pod_info": newCountObjectsAggregator(
+		"pod.count",
+		[]string{"namespace", "created_by_kind", "created_by_name"},
+	),
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -803,6 +803,50 @@ func TestKSMCheck_hostnameAndTags(t *testing.T) {
 			wantTags:     []string{"foo_label:foo_value", "bar_label:bar_value", "node:foo"},
 			wantHostname: "foo-bar",
 		},
+		{
+			name: "created_by_kind/created_by_name",
+			config: &KSMConfig{
+				LabelJoins: map[string]*JoinsConfig{
+					"foo": {
+						LabelsToMatch: []string{"foo_label"},
+						LabelsToGet:   []string{"created_by_kind", "created_by_name"},
+					},
+				},
+			},
+			args: args{
+				labels: map[string]string{"foo_label": "foo_value"},
+				metricsToGet: []ksmstore.DDMetricsFam{
+					{
+						Name:        "foo",
+						ListMetrics: []ksmstore.DDMetric{{Labels: map[string]string{"foo_label": "foo_value", "created_by_kind": "DaemonSet", "created_by_name": "foo_name"}}},
+					},
+				},
+			},
+			wantTags:     []string{"foo_label:foo_value", "kube_daemon_set:foo_name"},
+			wantHostname: "",
+		},
+		{
+			name: "owner_kind/owner_name",
+			config: &KSMConfig{
+				LabelJoins: map[string]*JoinsConfig{
+					"foo": {
+						LabelsToMatch: []string{"foo_label"},
+						LabelsToGet:   []string{"owner_kind", "owner_name"},
+					},
+				},
+			},
+			args: args{
+				labels: map[string]string{"foo_label": "foo_value"},
+				metricsToGet: []ksmstore.DDMetricsFam{
+					{
+						Name:        "foo",
+						ListMetrics: []ksmstore.DDMetric{{Labels: map[string]string{"foo_label": "foo_value", "owner_kind": "DaemonSet", "owner_name": "foo_name"}}},
+					},
+				},
+			},
+			wantTags:     []string{"foo_label:foo_value", "kube_daemon_set:foo_name"},
+			wantHostname: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/releasenotes-dca/notes/ksm-core-count-metrics-ebb99a5dd69df324.yaml
+++ b/releasenotes-dca/notes/ksm-core-count-metrics-ebb99a5dd69df324.yaml
@@ -1,0 +1,9 @@
+---
+enhancements:
+  - |
+    The Kube State Metrics Core check sends a new metric ``kubernetes_state.pod.count``
+    tagged with owner tags (e.g ``kube_deployment``, ``kube_replica_set``, ``kube_cronjob``, ``kube_job``).
+  - |
+    The Kube State Metrics Core check tags ``kubernetes_state.replicaset.count`` with a ``kube_deployment`` tag.
+  - |
+    The Kube State Metrics Core check tags ``kubernetes_state.job.count`` with a ``kube_cronjob`` tag.

--- a/releasenotes/notes/ksm-core-count-metrics-ebb99a5dd69df324.yaml
+++ b/releasenotes/notes/ksm-core-count-metrics-ebb99a5dd69df324.yaml
@@ -1,0 +1,9 @@
+---
+enhancements:
+  - |
+    The Kube State Metrics Core check sends a new metric ``kubernetes_state.pod.count``
+    tagged with owner tags (e.g ``kube_deployment``, ``kube_replica_set``, ``kube_cronjob``, ``kube_job``).
+  - |
+    The Kube State Metrics Core check tags ``kubernetes_state.replicaset.count`` with a ``kube_deployment`` tag.
+  - |
+    The Kube State Metrics Core check tags ``kubernetes_state.job.count`` with a ``kube_cronjob`` tag.


### PR DESCRIPTION
### What does this PR do?

- The Kube State Metrics Core check sends a new metric `kubernetes_state.pod.count` tagged with owner tags (e.g `kube_deployment`, `kube_replica_set`, `kube_cronjob`, `kube_job`).
- The Kube State Metrics Core check tags `kubernetes_state.replicaset.count` with a `kube_deployment` tag.
- The Kube State Metrics Core check tags `kubernetes_state.job.count` with a `kube_cronjob` tag.

### Motivation

- `kubernetes_state.pod.count` is needed for OOTB dashboards
- Align the tag keys with what's used in the kubelet check

### Describe how to test your changes

Enable the check and make sure enough workload is running to generate the metrics
- `kubernetes_state.pod.count` should be tagged with its owners. Example:
```
      "metric": "kubernetes_state.pod.count",
...
      "tags": [
        "kube_cluster_name:xx,
        "kube_deployment:kube-dns-autoscaler",
        "kube_namespace:kube-system",
        "kube_replica_set:kube-dns-autoscaler-7f89fb6b79"
      ],
```
- `kubernetes_state.replicaset.count` should be tagged with its owner. Example:
```
      "metric": "kubernetes_state.replicaset.count",
...
      "tags": [
        "kube_cluster_name:xx",
        "kube_deployment:kube-dns-autoscaler",
        "kube_namespace:kube-system"
```
- `kubernetes_state.job.count` should be tagged with its owner. Example:
```
      "metric": "kubernetes_state.job.count",
...
      "tags": [
        "kube_cluster_name:xx",
        "kube_cronjob:logger",
        "kube_namespace:default"
      ],
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
