### PR TITLE
Parse /proc/<pid>(/task/<pid>)?/maps entries

### DIFF
--- a/pkg/network/so/finder.go
+++ b/pkg/network/so/finder.go
@@ -28,7 +28,11 @@ func (f *finder) Find(filter *regexp.Regexp) []string {
 	seen := make(map[key]struct{})
 	result := common.NewStringSet()
 	iteratePIDS(f.procRoot, func(pidPath string, info os.FileInfo, mntNS ns) {
-		libs := getSharedLibraries(pidPath, f.buffer, filter)
+		pidMaps, err := ParseProcPidMaps(pidPath, f.buffer)
+		if err != nil {
+			return
+		}
+		libs := pidMaps.GetSharedLibraries(filter)
 
 		// If we have already seen (mntNS, lib) we skip the path resolution process
 		libs = excludeAlreadySeen(seen, mntNS, libs)

--- a/pkg/network/so/maps_test.go
+++ b/pkg/network/so/maps_test.go
@@ -11,7 +11,33 @@ import (
 
 func TestLibsFromMaps(t *testing.T) {
 	r := strings.NewReader(mapsFile)
-	libs := parseMaps(bufio.NewReader(r), AllLibraries)
+	maps, err := parseMaps("1234", bufio.NewReader(r))
+	if err != nil {
+		t.Fatal(err)
+	}
+	libs := maps.GetSharedLibraries()
+	expected := []string{
+		"/usr/lib/x86_64-linux-gnu/libc-2.31.so",
+		"/usr/lib/x86_64-linux-gnu/ld-2.31.so",
+		"[stack]",
+		"[vvar]",
+		"[vdso]",
+		"[vsyscall]",
+		"/usr/lib/locale/C.UTF-8/LC_TELEPHONE",
+		"/usr/lib/locale/C.UTF-8/LC_IDENTIFICATION",
+		"/usr/lib/locale/C.UTF-8/LC_MEASUREMENT",
+		"/usr/lib/x86_64-linux-gnu/gconv/gconv-modules.cache",
+	}
+	assert.ElementsMatch(t, expected, libs)
+}
+
+func TestLibsFromMapsAllSo(t *testing.T) {
+	r := strings.NewReader(mapsFile)
+	maps, err := parseMaps("1234", bufio.NewReader(r))
+	if err != nil {
+		t.Fatal(err)
+	}
+	libs := maps.GetSharedLibraries(AllLibraries)
 	expected := []string{
 		"/usr/lib/x86_64-linux-gnu/libc-2.31.so",
 		"/usr/lib/x86_64-linux-gnu/ld-2.31.so",
@@ -22,13 +48,16 @@ func TestLibsFromMaps(t *testing.T) {
 func TestLibsFromMapsWithFilter(t *testing.T) {
 	filter := regexp.MustCompile("libc")
 	r := strings.NewReader(mapsFile)
-	libs := parseMaps(bufio.NewReader(r), filter)
+	maps, err := parseMaps("1234", bufio.NewReader(r))
+	if err != nil {
+		t.Fatal(err)
+	}
+	libs := maps.GetSharedLibraries(filter)
 	expected := []string{"/usr/lib/x86_64-linux-gnu/libc-2.31.so"}
 	assert.ElementsMatch(t, expected, libs)
 }
 
-var mapsFile = `
-7f178d0a6000-7f178d0cb000 r--p 00000000 fd:00 268741                     /usr/lib/x86_64-linux-gnu/libc-2.31.so
+var mapsFile = `7f178d0a6000-7f178d0cb000 r--p 00000000 fd:00 268741                     /usr/lib/x86_64-linux-gnu/libc-2.31.so
 7f178d0cb000-7f178d243000 r-xp 00025000 fd:00 268741                     /usr/lib/x86_64-linux-gnu/libc-2.31.so
 7f178d243000-7f178d28d000 r--p 0019d000 fd:00 268741                     /usr/lib/x86_64-linux-gnu/libc-2.31.so
 7f178d28d000-7f178d28e000 ---p 001e7000 fd:00 268741                     /usr/lib/x86_64-linux-gnu/libc-2.31.so

--- a/pkg/network/so/so.go
+++ b/pkg/network/so/so.go
@@ -22,8 +22,13 @@ func Find(procRoot string, filter *regexp.Regexp) []string {
 // FromPID returns all shared libraries matching the given filter that are mapped into memory by a given PID
 func FromPID(procRoot string, pid int32, filter *regexp.Regexp) []string {
 	pidPath := filepath.Join(procRoot, strconv.Itoa(int(pid)))
+
 	buffer := bufio.NewReader(nil)
-	libs := getSharedLibraries(pidPath, buffer, filter)
+	pidMaps, err := ParseProcPidMaps(pidPath, buffer)
+	if err != nil {
+		return nil
+	}
+	libs := pidMaps.GetSharedLibraries(filter)
 	if len(libs) == 0 {
 		return nil
 	}


### PR DESCRIPTION
### What does this PR do?

Parse all fields form /proc/pid/maps entries and unmarshal them

### Motivation

I need to have access to virtual address mem space of each libraries of a specific process
aim to resolve dynamic symbol as an eBPF uprobe helper.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
