### PR TITLE
[Docker] Consistently report tags for stopped containers

### DIFF
--- a/pkg/collector/corechecks/containers/docker/docker.go
+++ b/pkg/collector/corechecks/containers/docker/docker.go
@@ -51,7 +51,12 @@ func updateContainerRunningCount(images map[string]*containerPerImage, c *contai
 	var containerTags []string
 	var err error
 
-	if c.Excluded {
+	// Containers that are not running (either pending or stopped) are not
+	// collected by the tagger, so they won't have any tags and will cause
+	// an expensive tagger fetch.  To have *some* tags for stopped
+	// containers, we treat them as excluded containers and make a
+	// synthetic list of tags from basic container information.
+	if c.Excluded || c.State != containers.ContainerRunningState {
 		// TODO we can do SplitImageName because we are in the docker corecheck and the image name is not a sha[...]
 		// We should resolve the image tags in the tagger as a real entity.
 		long, short, tag, err := containers.SplitImageName(c.Image)

--- a/releasenotes/notes/docker-stopped-containers-tags-c3850944f4d196f6.yaml
+++ b/releasenotes/notes/docker-stopped-containers-tags-c3850944f4d196f6.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fixes an issue where the `docker.containers.stopped` metric would have
+    unpredictable tags. Now all stopped containers will always be reported with
+    the correct tags.


### PR DESCRIPTION
### What does this PR do?

As stopped containers are purged from the tagger, after some 5 minutes
stopped containers will move from having all of their tags to having
none, probably messing with people's dashboards. Since a stopped
containers is guaranteed to eventually have no tags in the tagger, it is
better to treat them as we would excluded containers, and report a
synthetic set of tags that we can construct from basic container
information.

### Describe how to test your changes

This needs an Agent running with docker (k8s or standalone, although standalone is probably easier to test). Create any container that eventually stops (a simple `docker run busybox` should do), and look for it in the output of `agent tagger-list`. Both before and after it disappears from the tagger list, you should have the corresponding `docker.containers.stopped` metric show the correct count in the DD app with the `docker_image`, `image_name`, `image_tag`, and `short_image` tags.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
