### PR TITLE
[Tagger] Better telemetry for queries and fetches

### DIFF
--- a/pkg/tagger/telemetry/telemetry.go
+++ b/pkg/tagger/telemetry/telemetry.go
@@ -2,14 +2,20 @@ package telemetry
 
 import "github.com/DataDog/datadog-agent/pkg/telemetry"
 
-// PruneType represents the `prune_type` tag for the pruned_entities metric
-type PruneType string
-
 const (
-	// DeletedEntity refers to deleting entities due to a deletion event
-	DeletedEntity PruneType = "deletion_event"
-	// EmptyEntry refers to deleting entities with empty entries
-	EmptyEntry PruneType = "empty_entries"
+	// QueryEmptyEntityID refers to a query made with an empty entity id
+	QueryEmptyEntityID = "empty_entity_id"
+	// QueryEmptyTags refers to a query that returned no tags
+	QueryEmptyTags = "empty_tags"
+	// QuerySuccess refers to a successful query
+	QuerySuccess = "success"
+
+	// FetchNotFound refers to a tagger fetch that did not find an entity
+	FetchNotFound = "not_found"
+	// FetchError refers to a tagger fetch that returned an error
+	FetchError = "error"
+	// FetchSuccess refers to a tagger fetch that was successful
+	FetchSuccess = "success"
 )
 
 var (
@@ -30,7 +36,12 @@ var (
 
 	// Queries tracks the number of queries made against the tagger.
 	Queries = telemetry.NewCounterWithOpts("tagger", "queries",
-		[]string{"cardinality"}, "Queries made against the tagger.",
+		[]string{"cardinality", "status"}, "Queries made against the tagger.",
+		telemetry.Options{NoDoubleUnderscoreSep: true})
+
+	// Fetches tracks the number of fetches from the underlying collectors.
+	Fetches = telemetry.NewCounterWithOpts("tagger", "fetches",
+		[]string{"collector", "status"}, "Fetches from collectors.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 
 	// ClientStreamErrors tracks how many errors were received when streaming


### PR DESCRIPTION
### What does this PR do?

* Add a `status` tag to the `tagger.queries` metric showing whether the
query succeeded, found no tags, or was called with an empty ID.

* Add a `tagger.fetches` metric that counts the number of fetches caused
by queries. This gives us better visibility into the amount of cache
misses in the tagger, when they error out, and when they find no tags.

### Describe how to test your changes

* With an agent with telemetry enabled (`DD_TELEMETRY_ENABLED=true`), check that the new metrics appear in the output of `curl http://localhost:5000/telemetry`
* In the process agent, with telemetry (see above) and the remote tagger enabled (`DD_PROCESS_AGENT_REMOTE_TAGGER=true`), check that the new metrics appear in the output of `curl http://localhost:7650/telemetry`

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
