### PR TITLE
Correctly clear DockerUtil caches after listing containers

### DIFF
--- a/pkg/util/docker/containers.go
+++ b/pkg/util/docker/containers.go
@@ -259,7 +259,7 @@ func (d *DockerUtil) dockerContainers(ctx context.Context, cfg *ContainerListCon
 		d.Unlock()
 	}
 
-	if d.lastInvalidate.Add(invalidationInterval).After(time.Now()) {
+	if time.Now().Sub(d.lastInvalidate) > invalidationInterval {
 		d.cleanupCaches(cList)
 	}
 
@@ -375,6 +375,7 @@ func (d *DockerUtil) cleanupCaches(containers []types.Container) {
 			delete(d.imageNameBySha, image)
 		}
 	}
+	d.lastInvalidate = time.Now()
 	d.Unlock()
 }
 

--- a/releasenotes/notes/docker-memory-leak-dd5a121782d0506b.yaml
+++ b/releasenotes/notes/docker-memory-leak-dd5a121782d0506b.yaml
@@ -1,0 +1,8 @@
+---
+fixes:
+  - |
+    Fixes a memory leak when the Agent is running in Docker environments. This
+    leak resulted in memory usage growing linearly, corresponding with the
+    amount of containers ever ran while the current Agent process was also
+    running. Long-lived Agent processes on nodes with a lot of container churn
+    would cause the Agent to eventually run out of memory.


### PR DESCRIPTION
### What does this PR do?

The cache invalidation was wrong in two levels: it was clearing the
cache on every call to `dockerContainers` for the first 5 minutes (the
value of `invalidationInterval`) and then never again. It also never
updated `lastInvalidate`, so this has been very broken for a long time.

### Motivation

This ever-growing cache eventually exhausts memory, the agent gets OOM-killed, and customers are upset because we have memory leaks.

### Describe how to test your changes

Besides running a custom image showing you the size of the cache in every call, this is hard to test. Setting up a k8s cluster with docker, or an ECS EC2 cluster, and spamming it with scheduled tasks for a long, long time, should not result in memory increase. This is easier to verify in the process-agent, since there might be other leaks in the core agent that are not related to this.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
