### PR TITLE
[runtime-security] fix oracle centos test crashs

### DIFF
--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -76,7 +76,7 @@
     "oracle" : {
         "azure": {
             "x86_64": {
-                "oracle-7-9": "urn,Oracle:Oracle-Linux:ol79:7.9.4"
+                "oracle-7-9": "urn,Oracle:Oracle-Linux:ol79:7.9.6"
             }
         }
     },

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -76,7 +76,7 @@ if node['platform_family'] != 'windows'
       repo 'centos'
       tag '7'
       cap_add ['SYS_ADMIN', 'SYS_RESOURCE', 'SYS_PTRACE', 'NET_ADMIN', 'IPC_LOCK', 'ALL']
-      command "sleep 3600"
+      command "sleep 7200"
       volumes ['/tmp/security-agent:/tmp/security-agent', '/proc:/host/proc', '/etc/os-release:/host/etc/os-release']
       env ['HOST_PROC=/host/proc', 'DOCKER_DD_AGENT=yes']
       privileged true

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -17,12 +17,9 @@ if node['platform_family'] != 'windows'
     mode '755'
   end
 
-  # This cookbook doesn't work on Oracle Linux
-  # for reasons that could be related to https://github.com/chef/chef/issues/7072
-  if not platform?('oracle')
-    swap_file '/swapfile' do
-      size 1024
-    end
+  # `/swapfile` doesn't work on Oracle Linux, so we use `/mnt/swapfile`
+  swap_file '/mnt/swapfile' do
+    size 1024
   end
 
   # To uncomment when gitlab runner are able to build with GOARCH=386

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -17,6 +17,14 @@ if node['platform_family'] != 'windows'
     mode '755'
   end
 
+  # This cookbook doesn't work on Oracle Linux
+  # for reasons that could be related to https://github.com/chef/chef/issues/7072
+  if not platform?('oracle')
+    swap_file '/swapfile' do
+      size 1024
+    end
+  end
+
   # To uncomment when gitlab runner are able to build with GOARCH=386
   # cookbook_file "#{wrk_dir}/testsuite32" do
   #   source "testsuite32"

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -19,7 +19,7 @@ if node['platform_family'] != 'windows'
 
   # `/swapfile` doesn't work on Oracle Linux, so we use `/mnt/swapfile`
   swap_file '/mnt/swapfile' do
-    size 1024
+    size 2048
   end
 
   # To uncomment when gitlab runner are able to build with GOARCH=386


### PR DESCRIPTION
### What does this PR do?

The functional tests of security agent running on the Gitlab CI were sometimes crashing because:
- the host is running low on memory, and the testsuite is oom-killed
- the testsuite is running in a docker container (with `sleep 3600` as main process) and the process of pid=1 terminates
  - 3600s = 1h

To fix this issues, this PR:
- sets up some swap on CentOS (the `swap_file` chef cookbook doesn't work on Oracle Linux) to alleviate memory issues
- increase the sleep time to 2h for docker tests

### Motivation

Reduce the flakiness of functional tests

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
