### PR TITLE
[Tagger] Update telemetry for remote and replay tagger

### DIFF
--- a/pkg/tagger/remote/tagger.go
+++ b/pkg/tagger/remote/tagger.go
@@ -136,12 +136,13 @@ func (t *Tagger) Stop() error {
 
 // Tag returns tags for a given entity at the desired cardinality.
 func (t *Tagger) Tag(entityID string, cardinality collectors.TagCardinality) ([]string, error) {
-	telemetry.Queries.Inc(collectors.TagCardinalityToString(cardinality))
-
 	entity := t.store.getEntity(entityID)
 	if entity != nil {
+		telemetry.Queries.Inc(collectors.TagCardinalityToString(cardinality), telemetry.QuerySuccess)
 		return entity.GetTags(cardinality), nil
 	}
+
+	telemetry.Queries.Inc(collectors.TagCardinalityToString(cardinality), telemetry.QueryEmptyTags)
 
 	return []string{}, nil
 }

--- a/pkg/tagger/replay/tagger.go
+++ b/pkg/tagger/replay/tagger.go
@@ -68,12 +68,13 @@ func (t *Tagger) Stop() error {
 
 // Tag returns tags for a given entity at the desired cardinality.
 func (t *Tagger) Tag(entityID string, cardinality collectors.TagCardinality) ([]string, error) {
-	telemetry.Queries.Inc(collectors.TagCardinalityToString(cardinality))
-
 	entity, ok := t.store.getEntity(entityID)
 	if ok {
+		telemetry.Queries.Inc(collectors.TagCardinalityToString(cardinality), telemetry.QuerySuccess)
 		return entity.GetTags(cardinality), nil
 	}
+
+	telemetry.Queries.Inc(collectors.TagCardinalityToString(cardinality), telemetry.QueryEmptyTags)
 
 	return []string{}, nil
 }


### PR DESCRIPTION
### What does this PR do?

Fixes the following error:

```
panic: inconsistent label cardinality: expected 2 label values but got 1 in []string{"low"}
goroutine 280 [running]:
github.com/prometheus/client_golang/prometheus.(*CounterVec).WithLabelValues(0xc00028a660, 0xc000be8870, 0x1, 0x1, 0xc0003ed101, 0xc000be8870)
        /go/pkg/mod/github.com/prometheus/client_golang@v1.10.0/prometheus/counter.go:248 +0xda
github.com/DataDog/datadog-agent/pkg/telemetry.(*promCounter).Inc(0xc00028a668, 0xc000be8870, 0x1, 0x1)
        /workspaces/datadog-agent/pkg/telemetry/prom_counter.go:41 +0x4c
github.com/DataDog/datadog-agent/pkg/tagger/replay.(*Tagger).Tag(0xc0010d8db0, 0xc000da0d70, 0x4f, 0x0, 0x1, 0x1, 0xc000be8860, 0x1, 0x1)
        /workspaces/datadog-agent/pkg/tagger/replay/tagger.go:71 +0xcd
```

### Describe how to test your changes

This is a regression introduced by #8777. That PR had its description updated to cover these changes as well to simplify QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
