### PR TITLE
Include error in non-forced local flares

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -115,7 +115,7 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 		jmxLogFile = common.DefaultJmxLogFile
 	}
 	log.Infof("Making a flare")
-	filePath, err := flare.CreateArchive(false, common.GetDistPath(), common.PyChecksPath, []string{logFile, jmxLogFile}, profile)
+	filePath, err := flare.CreateArchive(false, common.GetDistPath(), common.PyChecksPath, []string{logFile, jmxLogFile}, profile, nil)
 	if err != nil || filePath == "" {
 		if err != nil {
 			log.Errorf("The flare failed to be created: %s", err)

--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -143,7 +143,7 @@ func makeFlare(caseID string) error {
 
 	var filePath string
 	if forceLocal {
-		filePath, err = createArchive(logFiles, profile)
+		filePath, err = createArchive(logFiles, profile, nil)
 	} else {
 		filePath, err = requestArchive(logFiles, profile)
 	}
@@ -182,7 +182,7 @@ func requestArchive(logFiles []string, pdata flare.ProfileData) (string, error) 
 	ipcAddress, err := config.GetIPCAddress()
 	if err != nil {
 		fmt.Fprintln(color.Output, color.RedString(fmt.Sprintf("Error getting IPC address for the agent: %s", err)))
-		return createArchive(logFiles, pdata)
+		return createArchive(logFiles, pdata, err)
 	}
 
 	urlstr := fmt.Sprintf("https://%v:%v/agent/flare", ipcAddress, config.Datadog.GetInt("cmd_port"))
@@ -191,7 +191,7 @@ func requestArchive(logFiles []string, pdata flare.ProfileData) (string, error) 
 	e = util.SetAuthToken()
 	if e != nil {
 		fmt.Fprintln(color.Output, color.RedString(fmt.Sprintf("Error: %s", e)))
-		return createArchive(logFiles, pdata)
+		return createArchive(logFiles, pdata, e)
 	}
 
 	p, err := json.Marshal(pdata)
@@ -204,17 +204,19 @@ func requestArchive(logFiles []string, pdata flare.ProfileData) (string, error) 
 	if e != nil {
 		if r != nil && string(r) != "" {
 			fmt.Fprintln(color.Output, fmt.Sprintf("The agent ran into an error while making the flare: %s", color.RedString(string(r))))
+			e = fmt.Errorf("Error getting flare from running agent: %s", string(r))
 		} else {
 			fmt.Fprintln(color.Output, color.RedString("The agent was unable to make the flare. (is it running?)"))
+			e = fmt.Errorf("Error getting flare from running agent: %w", e)
 		}
-		return createArchive(logFiles, pdata)
+		return createArchive(logFiles, pdata, e)
 	}
 	return string(r), nil
 }
 
-func createArchive(logFiles []string, pdata flare.ProfileData) (string, error) {
+func createArchive(logFiles []string, pdata flare.ProfileData, ipcError error) (string, error) {
 	fmt.Fprintln(color.Output, color.YellowString("Initiating flare locally."))
-	filePath, e := flare.CreateArchive(true, common.GetDistPath(), common.PyChecksPath, logFiles, pdata)
+	filePath, e := flare.CreateArchive(true, common.GetDistPath(), common.PyChecksPath, logFiles, pdata, ipcError)
 	if e != nil {
 		fmt.Printf("The flare zipfile failed to be created: %s\n", e)
 		return "", e

--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -204,7 +204,7 @@ func requestArchive(logFiles []string, pdata flare.ProfileData) (string, error) 
 	if e != nil {
 		if r != nil && string(r) != "" {
 			fmt.Fprintln(color.Output, fmt.Sprintf("The agent ran into an error while making the flare: %s", color.RedString(string(r))))
-			e = fmt.Errorf("Error getting flare from running agent: %s", string(r))
+			e = fmt.Errorf("Error getting flare from running agent: %s", r)
 		} else {
 			fmt.Fprintln(color.Output, color.RedString("The agent was unable to make the flare. (is it running?)"))
 			e = fmt.Errorf("Error getting flare from running agent: %w", e)

--- a/cmd/agent/gui/agent.go
+++ b/cmd/agent/gui/agent.go
@@ -140,7 +140,7 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 		jmxLogFile = common.DefaultJmxLogFile
 	}
 
-	filePath, e := flare.CreateArchive(false, common.GetDistPath(), common.PyChecksPath, []string{logFile, jmxLogFile}, nil)
+	filePath, e := flare.CreateArchive(false, common.GetDistPath(), common.PyChecksPath, []string{logFile, jmxLogFile}, nil, nil)
 	if e != nil {
 		w.Write([]byte("Error creating flare zipfile: " + e.Error()))
 		log.Errorf("Error creating flare zipfile: " + e.Error())

--- a/cmd/systray/doflare.go
+++ b/cmd/systray/doflare.go
@@ -206,12 +206,14 @@ func requestFlare(caseID, customerEmail string) (response string, e error) {
 	if e != nil {
 		if r != nil && string(r) != "" {
 			log.Warnf("The agent ran into an error while making the flare: %s\n", string(r))
+			e = fmt.Errorf("Error getting flare from running agent: %s", string(r))
 		} else {
 			log.Debug("The agent was unable to make the flare.")
+			e = fmt.Errorf("Error getting flare from running agent: %w", e)
 		}
 		log.Debug("Initiating flare locally.")
 
-		filePath, e = flare.CreateArchive(true, common.GetDistPath(), common.PyChecksPath, []string{logFile, jmxLogFile}, nil)
+		filePath, e = flare.CreateArchive(true, common.GetDistPath(), common.PyChecksPath, []string{logFile, jmxLogFile}, nil, e)
 		if e != nil {
 			log.Errorf("The flare zipfile failed to be created: %s\n", e)
 			return

--- a/cmd/systray/doflare.go
+++ b/cmd/systray/doflare.go
@@ -205,8 +205,8 @@ func requestFlare(caseID, customerEmail string) (response string, e error) {
 	var filePath string
 	if e != nil {
 		if r != nil && string(r) != "" {
-			log.Warnf("The agent ran into an error while making the flare: %s\n", string(r))
-			e = fmt.Errorf("Error getting flare from running agent: %s", string(r))
+			log.Warnf("The agent ran into an error while making the flare: %s\n", r)
+			e = fmt.Errorf("Error getting flare from running agent: %s", r)
 		} else {
 			log.Debug("The agent was unable to make the flare.")
 			e = fmt.Errorf("Error getting flare from running agent: %w", e)

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -134,17 +134,17 @@ func CreatePerformanceProfile(prefix, debugURL string, cpusec int, target *Profi
 }
 
 // CreateArchive packages up the files
-func CreateArchive(local bool, distPath, pyChecksPath string, logFilePaths []string, pdata ProfileData) (string, error) {
+func CreateArchive(local bool, distPath, pyChecksPath string, logFilePaths []string, pdata ProfileData, ipcError error) (string, error) {
 	zipFilePath := getArchivePath()
 	confSearchPaths := SearchPaths{
 		"":        config.Datadog.GetString("confd_path"),
 		"dist":    filepath.Join(distPath, "conf.d"),
 		"checksd": pyChecksPath,
 	}
-	return createArchive(confSearchPaths, local, zipFilePath, logFilePaths, pdata)
+	return createArchive(confSearchPaths, local, zipFilePath, logFilePaths, pdata, ipcError)
 }
 
-func createArchive(confSearchPaths SearchPaths, local bool, zipFilePath string, logFilePaths []string, pdata ProfileData) (string, error) {
+func createArchive(confSearchPaths SearchPaths, local bool, zipFilePath string, logFilePaths []string, pdata ProfileData, ipcError error) (string, error) {
 	tempDir, err := createTempDir()
 	if err != nil {
 		return "", err
@@ -167,14 +167,28 @@ func createArchive(confSearchPaths SearchPaths, local bool, zipFilePath string, 
 		if err != nil {
 			return "", err
 		}
-		// Can't reach the agent, mention it in those two files
-		err = writeStatusFile(tempDir, hostname, []byte("unable to get the status of the agent, is it running?"))
-		if err != nil {
-			return "", err
-		}
-		err = writeConfigCheck(tempDir, hostname, []byte("unable to get loaded checks config, is the agent running?"))
-		if err != nil {
-			return "", err
+
+		if ipcError != nil {
+			msg := []byte(fmt.Sprintf("unable to contact the agent to retrieve flare: %s", ipcError))
+			// Can't reach the agent, mention it in those two files
+			err = writeStatusFile(tempDir, hostname, msg)
+			if err != nil {
+				return "", err
+			}
+			err = writeConfigCheck(tempDir, hostname, msg)
+			if err != nil {
+				return "", err
+			}
+		} else {
+			// Can't reach the agent, mention it in those two files
+			err = writeStatusFile(tempDir, hostname, []byte("unable to get the status of the agent, is it running?"))
+			if err != nil {
+				return "", err
+			}
+			err = writeConfigCheck(tempDir, hostname, []byte("unable to get loaded checks config, is the agent running?"))
+			if err != nil {
+				return "", err
+			}
 		}
 	} else {
 		// Status informations are available, zip them up as the agent is running.

--- a/pkg/flare/archive_nix_test.go
+++ b/pkg/flare/archive_nix_test.go
@@ -29,7 +29,7 @@ func TestPermsFile(t *testing.T) {
 	mockConfig.Set("confd_path", "./test/confd")
 	mockConfig.Set("log_file", "./test/logs/agent.log")
 	zipFilePath := getArchivePath()
-	filePath, err := createArchive(SearchPaths{}, true, zipFilePath, []string{""}, nil)
+	filePath, err := createArchive(SearchPaths{}, true, zipFilePath, []string{""}, nil, nil)
 	defer os.Remove(zipFilePath)
 
 	assert.Nil(err)

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -32,7 +32,7 @@ func TestCreateArchive(t *testing.T) {
 	mockConfig.Set("confd_path", "./test/confd")
 	mockConfig.Set("log_file", "./test/logs/agent.log")
 	zipFilePath := getArchivePath()
-	filePath, err := createArchive(SearchPaths{}, true, zipFilePath, []string{""}, nil)
+	filePath, err := createArchive(SearchPaths{}, true, zipFilePath, []string{""}, nil, nil)
 
 	assert.Nil(t, err)
 	assert.Equal(t, zipFilePath, filePath)
@@ -56,7 +56,7 @@ func TestCreateArchiveAndGoRoutines(t *testing.T) {
 	pprofURL = ts.URL
 
 	zipFilePath := getArchivePath()
-	filePath, err := createArchive(SearchPaths{}, true, zipFilePath, []string{""}, nil)
+	filePath, err := createArchive(SearchPaths{}, true, zipFilePath, []string{""}, nil, nil)
 
 	assert.Nil(t, err)
 	assert.Equal(t, zipFilePath, filePath)
@@ -100,7 +100,7 @@ func TestCreateArchiveAndGoRoutines(t *testing.T) {
 func TestCreateArchiveBadConfig(t *testing.T) {
 	common.SetupConfig("")
 	zipFilePath := getArchivePath()
-	filePath, err := createArchive(SearchPaths{}, true, zipFilePath, []string{""}, nil)
+	filePath, err := createArchive(SearchPaths{}, true, zipFilePath, []string{""}, nil, nil)
 
 	assert.Nil(t, err)
 	assert.Equal(t, zipFilePath, filePath)
@@ -154,7 +154,7 @@ func TestIncludeSystemProbeConfig(t *testing.T) {
 	defer os.Remove("./test/system-probe.yaml")
 
 	zipFilePath := getArchivePath()
-	filePath, err := createArchive(SearchPaths{"": "./test/confd"}, true, zipFilePath, []string{""}, nil)
+	filePath, err := createArchive(SearchPaths{"": "./test/confd"}, true, zipFilePath, []string{""}, nil, nil)
 	assert.NoError(err)
 	assert.Equal(zipFilePath, filePath)
 
@@ -182,7 +182,7 @@ func TestIncludeConfigFiles(t *testing.T) {
 
 	common.SetupConfig("./test")
 	zipFilePath := getArchivePath()
-	filePath, err := createArchive(SearchPaths{"": "./test/confd"}, true, zipFilePath, []string{""}, nil)
+	filePath, err := createArchive(SearchPaths{"": "./test/confd"}, true, zipFilePath, []string{""}, nil, nil)
 
 	assert.NoError(err)
 	assert.Equal(zipFilePath, filePath)
@@ -290,7 +290,7 @@ func TestPerformanceProfile(t *testing.T) {
 		"third":  []byte{},
 	}
 	zipFilePath := getArchivePath()
-	filePath, err := createArchive(SearchPaths{}, true, zipFilePath, []string{""}, testProfile)
+	filePath, err := createArchive(SearchPaths{}, true, zipFilePath, []string{""}, testProfile, nil)
 
 	assert.NoError(t, err)
 	assert.Equal(t, zipFilePath, filePath)

--- a/releasenotes/notes/flare-local-include-error-bdacf400f6ad841a.yaml
+++ b/releasenotes/notes/flare-local-include-error-bdacf400f6ad841a.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    The `agent flare` command will now include an error message in the
+    resulting "local" flare if it cannot contact a running agent.


### PR DESCRIPTION
When `agent flare` cannot contact the running agent, it falls back to a
local flare.  In this situation, it should include the error contacting
the agent in that local flare.

### Motivation

AGENT-6665 - a customer unexpectedly getting local flares despite a running agent.

### Describe how to test your changes

Run `agent flare` in a situation where there is no local agent

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
