### PR TITLE
[fix] Lower the log level for tagger pulling errors

### DIFF
--- a/pkg/tagger/local/tagger.go
+++ b/pkg/tagger/local/tagger.go
@@ -227,7 +227,7 @@ func (t *Tagger) pull(ctx context.Context) {
 	for name, puller := range t.pullers {
 		err := puller.Pull(ctx)
 		if err != nil {
-			log.Warnf("Error pulling from %s: %s", name, err.Error())
+			log.Debugf("Error pulling from %s: %s", name, err.Error())
 		}
 	}
 	t.RUnlock()


### PR DESCRIPTION
### What does this PR do?

Follow up on https://github.com/DataDog/datadog-agent/pull/8736

### Motivation

Same as https://github.com/DataDog/datadog-agent/pull/8736

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

No more `WARN | (pkg/tagger/local/tagger.go:224 in pull) | Error pulling from …: …: context canceled`

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
