### PR TITLE
[ksm core] fix statefulset label mapping

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -27,7 +27,7 @@ var (
 		"daemonset":                           "kube_daemon_set",
 		"replicationcontroller":               "kube_replication_controller",
 		"replicaset":                          "kube_replica_set",
-		"statefulset ":                        "kube_stateful_set",
+		"statefulset":                         "kube_stateful_set",
 		"deployment":                          "kube_deployment",
 		"service":                             "kube_service",
 		"endpoint":                            "kube_endpoint",

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -134,7 +134,7 @@ func TestProcessMetrics(t *testing.T) {
 			expected:           []metricsExpected{},
 		},
 		{
-			name:   "datadog standard tags via label join, default label mapper, default label joins",
+			name:   "datadog standard tags via label join, default label mapper, default label joins (deployment)",
 			config: &KSMConfig{LabelsMapper: defaultLabelsMapper, LabelJoins: defaultLabelJoins},
 			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
 				"kube_deployment_status_replicas": {
@@ -162,6 +162,39 @@ func TestProcessMetrics(t *testing.T) {
 					name:     "kubernetes_state.deployment.replicas",
 					val:      1,
 					tags:     []string{"kube_namespace:default", "kube_deployment:redis", "env:dev", "service:redis", "version:v1"},
+					hostname: "",
+				},
+			},
+		},
+		{
+			name:   "datadog standard tags via label join, default label mapper, default label joins (statefulset)",
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper, LabelJoins: defaultLabelJoins},
+			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
+				"kube_statefulset_replicas": {
+					{
+						Type: "*v1.Statefulset",
+						Name: "kube_statefulset_replicas",
+						ListMetrics: []ksmstore.DDMetric{
+							{
+								Labels: map[string]string{"namespace": "default", "statefulset": "redis"},
+								Val:    1,
+							},
+						},
+					},
+				},
+			},
+			metricsToGet: []ksmstore.DDMetricsFam{
+				{
+					Name:        "kube_statefulset_labels",
+					ListMetrics: []ksmstore.DDMetric{{Labels: map[string]string{"namespace": "default", "statefulset": "redis", "label_tags_datadoghq_com_env": "dev", "label_tags_datadoghq_com_service": "redis", "label_tags_datadoghq_com_version": "v1"}}},
+				},
+			},
+			metricTransformers: metricTransformers,
+			expected: []metricsExpected{
+				{
+					name:     "kubernetes_state.statefulset.replicas_desired",
+					val:      1,
+					tags:     []string{"kube_namespace:default", "kube_stateful_set:redis", "env:dev", "service:redis", "version:v1"},
 					hostname: "",
 				},
 			},

--- a/releasenotes/notes/fix-ksm-check-statefulset-tag-293627a2b7c00d3e.yaml
+++ b/releasenotes/notes/fix-ksm-check-statefulset-tag-293627a2b7c00d3e.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix default mapping for statefulset label in Kubernetes State Metric Core check.


### PR DESCRIPTION
### What does this PR do?

Fix tag reporting for statefulset metrics

### Motivation

Better user experience with standardized tags

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [X] The appropriate `team/..` label has been applied, if known.
- [X] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
