### PR TITLE
Create new dbm event type for Active queries

### DIFF
--- a/pkg/collector/check/stats.go
+++ b/pkg/collector/check/stats.go
@@ -24,6 +24,7 @@ const (
 var EventPlatformNameTranslations = map[string]string{
 	"dbm-samples":              "Database Monitoring Query Samples",
 	"dbm-metrics":              "Database Monitoring Query Metrics",
+	"dbm-activity":             "Database Monitoring Activity Samples",
 	"network-devices-metadata": "Network Devices Metadata",
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -702,6 +702,7 @@ func InitConfig(config Config) {
 	bindEnvAndSetLogsConfigKeys(config, "logs_config.", false)
 	bindEnvAndSetLogsConfigKeys(config, "database_monitoring.samples.", false)
 	bindEnvAndSetLogsConfigKeys(config, "database_monitoring.metrics.", false)
+	bindEnvAndSetLogsConfigKeys(config, "database_monitoring.activity.", true)
 	bindEnvAndSetLogsConfigKeys(config, "network_devices.metadata.", false)
 
 	config.BindEnvAndSetDefault("logs_config.dd_port", 10516)

--- a/pkg/epforwarder/epforwarder.go
+++ b/pkg/epforwarder/epforwarder.go
@@ -19,8 +19,8 @@ import (
 )
 
 const (
-	eventTypeDBMSamples = "dbm-samples"
-	eventTypeDBMMetrics = "dbm-metrics"
+	eventTypeDBMSamples  = "dbm-samples"
+	eventTypeDBMMetrics  = "dbm-metrics"
 	eventTypeDBMActivity = "dbm-activity"
 
 	// EventTypeNetworkDevicesMetadata is the event type for network devices metadata

--- a/pkg/epforwarder/epforwarder.go
+++ b/pkg/epforwarder/epforwarder.go
@@ -21,6 +21,7 @@ import (
 const (
 	eventTypeDBMSamples = "dbm-samples"
 	eventTypeDBMMetrics = "dbm-metrics"
+	eventTypeDBMActivity = "dbm-activity"
 
 	// EventTypeNetworkDevicesMetadata is the event type for network devices metadata
 	EventTypeNetworkDevicesMetadata = "network-devices-metadata"
@@ -42,6 +43,16 @@ var passthroughPipelineDescs = []passthroughPipelineDesc{
 		endpointsConfigPrefix:  "database_monitoring.metrics.",
 		hostnameEndpointPrefix: "dbm-metrics-intake.",
 		intakeTrackType:        "dbmmetrics",
+		// raise the default batch_max_concurrent_send from 0 to 10 to ensure this pipeline is able to handle 4k events/s
+		defaultBatchMaxConcurrentSend: 10,
+		defaultBatchMaxContentSize:    20e6,
+		defaultBatchMaxSize:           pkgconfig.DefaultBatchMaxSize,
+	},
+	{
+		eventType:              eventTypeDBMActivity,
+		endpointsConfigPrefix:  "database_monitoring.activity.",
+		hostnameEndpointPrefix: "dbm-metrics-intake.",
+		intakeTrackType:        "dbmactivity",
 		// raise the default batch_max_concurrent_send from 0 to 10 to ensure this pipeline is able to handle 4k events/s
 		defaultBatchMaxConcurrentSend: 10,
 		defaultBatchMaxContentSize:    20e6,


### PR DESCRIPTION
### What does this PR do?

Adds new event type `dbm-activity`, which is configured to use the logs v2 API by default and will forward events to our intake. By using the logs v2 api we can distinguish between metrics and query activity events because all requests will come in on the path `/api/v2/{trackType}`.
 
### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
