### PR TITLE
[Backport][fix] Lower the log level for tagger pulling errors (#8787)

### DIFF
--- a/pkg/tagger/local/tagger.go
+++ b/pkg/tagger/local/tagger.go
@@ -227,7 +227,7 @@ func (t *Tagger) pull(ctx context.Context) {
 	for name, puller := range t.pullers {
 		err := puller.Pull(ctx)
 		if err != nil {
-			log.Warnf("Error pulling from %s: %s", name, err.Error())
+			log.Debugf("Error pulling from %s: %s", name, err.Error())
 		}
 	}
 	t.RUnlock()


### PR DESCRIPTION
### What does this PR do?

Backport https://github.com/DataDog/datadog-agent/pull/8787
