### PR TITLE
[runtime-security] do not invalidate on syscall error

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "af462d15449357093c9da0e89525b02e08543b73336e5ce3f2f28b5d4b0a258c")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "0a9957659ee22404f355163c5091439d4eb39c1dfc409ba80ca5dbb1204b9136")

--- a/pkg/security/ebpf/c/rename.h
+++ b/pkg/security/ebpf/c/rename.h
@@ -109,12 +109,14 @@ int __attribute__((always_inline)) sys_rename_ret(void *ctx, int retval, int dr_
     u64 inode = get_dentry_ino(syscall->rename.src_dentry);
 
     // invalidate inode from src dentry to handle ovl folder
-    if (syscall->rename.target_file.path_key.ino != inode) {
+    if (syscall->rename.target_file.path_key.ino != inode && retval >= 0) {
         invalidate_inode(ctx, syscall->rename.target_file.path_key.mount_id, inode, 1);
     }
 
     // invalidate user face inode, so no need to bump the discarder revision in the event
-    invalidate_inode(ctx, syscall->rename.target_file.path_key.mount_id, syscall->rename.target_file.path_key.ino, 1);
+    if (retval >= 0) {
+        invalidate_inode(ctx, syscall->rename.target_file.path_key.mount_id, syscall->rename.target_file.path_key.ino, 1);
+    }
 
     if (!syscall->discarded && is_event_enabled(EVENT_RENAME)) {
         // for centos7, use src dentry for target resolution as the pointers have been swapped

--- a/pkg/security/ebpf/c/rmdir.h
+++ b/pkg/security/ebpf/c/rmdir.h
@@ -136,7 +136,9 @@ int __attribute__((always_inline)) sys_rmdir_ret(void *ctx, int retval) {
         send_event(ctx, EVENT_RMDIR, event);
     }
 
-    invalidate_inode(ctx, syscall->rmdir.file.path_key.mount_id, syscall->rmdir.file.path_key.ino, !pass_to_userspace);
+    if (retval >= 0) {
+        invalidate_inode(ctx, syscall->rmdir.file.path_key.mount_id, syscall->rmdir.file.path_key.ino, !pass_to_userspace);
+    }
 
     return 0;
 }

--- a/pkg/security/ebpf/c/unlink.h
+++ b/pkg/security/ebpf/c/unlink.h
@@ -98,10 +98,6 @@ int __attribute__((always_inline)) sys_unlink_ret(void *ctx, int retval) {
         return 0;
     }
 
-    // ensure that we invalidate all the layers
-    u64 inode = syscall->unlink.file.path_key.ino;
-    invalidate_inode(ctx, syscall->unlink.file.path_key.mount_id, inode, 1);
-
     u64 enabled_events = get_enabled_events();
     int pass_to_userspace = !syscall->discarded &&
                             (mask_has_event(enabled_events, EVENT_UNLINK) ||
@@ -131,7 +127,9 @@ int __attribute__((always_inline)) sys_unlink_ret(void *ctx, int retval) {
         }
     }
 
-    invalidate_inode(ctx, syscall->unlink.file.path_key.mount_id, syscall->unlink.file.path_key.ino, !pass_to_userspace);
+    if (retval >= 0) {
+        invalidate_inode(ctx, syscall->unlink.file.path_key.mount_id, syscall->unlink.file.path_key.ino, !pass_to_userspace);
+    }
 
     return 0;
 }

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -394,23 +394,30 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 			return
 		}
 
-		// defer it do ensure that it will be done after the dispatch that could re-add it
-		defer p.invalidateDentry(event.Rmdir.File.MountID, event.Rmdir.File.Inode)
+		if event.Rmdir.Retval >= 0 {
+			// defer it do ensure that it will be done after the dispatch that could re-add it
+			defer p.invalidateDentry(event.Rmdir.File.MountID, event.Rmdir.File.Inode)
+		}
 	case model.FileUnlinkEventType:
 		if _, err := event.Unlink.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode unlink event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 
-		// defer it do ensure that it will be done after the dispatch that could re-add it
-		defer p.invalidateDentry(event.Unlink.File.MountID, event.Unlink.File.Inode)
+		if event.Unlink.Retval >= 0 {
+			// defer it do ensure that it will be done after the dispatch that could re-add it
+			defer p.invalidateDentry(event.Unlink.File.MountID, event.Unlink.File.Inode)
+		}
 	case model.FileRenameEventType:
 		if _, err := event.Rename.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode rename event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
 
-		defer p.invalidateDentry(event.Rename.New.MountID, event.Rename.New.Inode)
+		if event.Rename.Retval >= 0 {
+			// defer it do ensure that it will be done after the dispatch that could re-add it
+			defer p.invalidateDentry(event.Rename.New.MountID, event.Rename.New.Inode)
+		}
 	case model.FileChmodEventType:
 		if _, err := event.Chmod.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode chmod event: %s (offset %d, len %d)", err, offset, dataLen)


### PR DESCRIPTION
### What does this PR do?

- Stop sending invalidateDentry events on syscall error which invalidate the cache while the file didn't change. 
- Do not handle invalidateDentry on unlink/rmdir/rename events if the syscall failed. 

An unlink/rmdir/rename event can be emitted if the retval is EPREM for example. In that case the event can have an inode equal to 0.

### Motivation

stop generated this kind of error log
`invalid mount_id/inode tuple 1225:0`

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
