### PR TITLE
[runtime-security] split functional test jobs into 2 groups

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -73,7 +73,8 @@ stages:
   - trigger_release
   - e2e
   - kitchen_cleanup
-  - functional_test
+  - functional_test_security_agent
+  - functional_test_system_probe
   - functional_test_cleanup
   - notify
 

--- a/.gitlab/functional_test.yml
+++ b/.gitlab/functional_test.yml
@@ -1,5 +1,5 @@
 ---
-# functional_test stage
+# functional_test_{security_agent, system_probe} stages
 # Contains jobs which run kitchen tests on the security-agent and on system-probe
 
 include:

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -11,7 +11,7 @@
     - .kitchen_datadog_agent_flavor
   rules:
     !reference [.manual]
-  stage: functional_test
+  stage: functional_test_security_agent
   variables:
     AGENT_MAJOR_VERSION: 7
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
@@ -45,7 +45,7 @@
     - .kitchen_azure_location_north_central_us
   rules:
     !reference [.manual]
-  stage: functional_test
+  stage: functional_test_security_agent
   needs: ["tests_ebpf_x64"]
   variables:
     AGENT_MAJOR_VERSION: 7

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -11,7 +11,7 @@
     - .kitchen_datadog_agent_flavor
   rules:
     !reference [.on_system_probe_changes_or_manual]
-  stage: functional_test
+  stage: functional_test_system_probe
   variables:
     AGENT_MAJOR_VERSION: 7
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7


### PR DESCRIPTION
### What does this PR do?

Currently the functional test jobs of the security agent and the system probe are mixed in one column. This PR splits this column into one for each team.

### Motivation

More clarity in the pipeline view.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
