### PR TITLE
[runtime-security] add security-agent.yaml to flare

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -535,9 +535,15 @@ func zipConfigFiles(tempDir, hostname string, confSearchPaths SearchPaths, perms
 		}
 		// figure out system-probe file path based on main config path,
 		// and use best effort to include system-probe.yaml to the flare
-		systemProbePath := getSystemProbePath(filePath)
+		systemProbePath := getConfigPath(filePath, "system-probe.yaml")
 		if systemErr := createConfigFiles(systemProbePath, tempDir, hostname, permsInfos); systemErr != nil {
 			log.Warnf("could not zip system-probe.yaml, system-probe might not be configured, or is in a different directory with datadog.yaml: %s", systemErr)
+		}
+
+		// use best effort to include security-agent.yaml to the flare
+		securityAgentPath := getConfigPath(filePath, "security-agent.yaml")
+		if secErr := createConfigFiles(securityAgentPath, tempDir, hostname, permsInfos); secErr != nil {
+			log.Warnf("could not zip security-agent.yaml, security-agent might not be configured, or is in a different directory with datadog.yaml: %s", secErr)
 		}
 	}
 
@@ -939,8 +945,8 @@ func createConfigFiles(filePath, tempDir, hostname string, permsInfos permission
 	return err
 }
 
-// getSystemProbePath would take the path to datadog.yaml and replace the file name with system-probe.yaml
-func getSystemProbePath(ddCfgFilePath string) string {
+// getConfigPath would take the path to datadog.yaml and replace the file name with the given agent file name
+func getConfigPath(ddCfgFilePath string, agentFileName string) string {
 	path := filepath.Dir(ddCfgFilePath)
-	return filepath.Join(path, "system-probe.yaml")
+	return filepath.Join(path, agentFileName)
 }

--- a/releasenotes/notes/runtime-security-flare-317b08786582f7cd.yaml
+++ b/releasenotes/notes/runtime-security-flare-317b08786582f7cd.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add security-agent config file to flare


### PR DESCRIPTION
### What does this PR do?

This PR add the security-agent config file to flare.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
