### PR TITLE
Specify core loader for core checks

### DIFF
--- a/cmd/agent/dist/conf.d/containerd.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/containerd.d/conf.yaml.default
@@ -1,6 +1,7 @@
 ad_identifiers:
   - _containerd
 init_config:
+loader: core
 instances:
   -
     ## @param filters - list of strings - optional

--- a/cmd/agent/dist/conf.d/cpu.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/cpu.d/conf.yaml.default
@@ -1,2 +1,3 @@
+loader: core
 instances:
   - {}

--- a/cmd/agent/dist/conf.d/cri.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/cri.d/conf.yaml.default
@@ -2,6 +2,7 @@ ad_identifiers:
   - _cri
 init_config:
 
+loader: core
 instances:
 
     -

--- a/cmd/agent/dist/conf.d/disk.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/disk.d/conf.yaml.default
@@ -4,6 +4,7 @@
 
 init_config:
 
+loader: core
 instances:
 
     ## @param use_mount - boolean - required

--- a/cmd/agent/dist/conf.d/docker.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/docker.d/conf.yaml.default
@@ -7,6 +7,7 @@ ad_identifiers:
 
 init_config:
 
+loader: core
 instances:
 
   -

--- a/cmd/agent/dist/conf.d/file_handle.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/file_handle.d/conf.yaml.default
@@ -1,2 +1,3 @@
+loader: core
 instances:
 - {}

--- a/cmd/agent/dist/conf.d/io.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/io.d/conf.yaml.default
@@ -19,5 +19,6 @@ init_config:
   #
   # lowercase_device_tag: false
 
+loader: core
 instances:
 - {}

--- a/cmd/agent/dist/conf.d/load.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/load.d/conf.yaml.default
@@ -1,2 +1,3 @@
+loader: core
 instances:
 - {}

--- a/cmd/agent/dist/conf.d/memory.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/memory.d/conf.yaml.default
@@ -1,2 +1,3 @@
+loader: core
 instances:
   - {}

--- a/cmd/agent/dist/conf.d/network.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/network.d/conf.yaml.default
@@ -6,6 +6,7 @@ init_config:
 
 ## The Network check only supports one configured instance.
 
+loader: core
 instances:
 
     ## @param collect_connection_state - boolean - required

--- a/cmd/agent/dist/conf.d/ntp.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/ntp.d/conf.yaml.default
@@ -4,6 +4,7 @@
 
 init_config:
 
+loader: core
 instances:
 
   -

--- a/cmd/agent/dist/conf.d/uptime.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/uptime.d/conf.yaml.default
@@ -1,2 +1,3 @@
+loader: core
 instances:
 - {}

--- a/cmd/agent/dist/conf.d/winproc.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/winproc.d/conf.yaml.default
@@ -1,2 +1,3 @@
+loader: core
 instances:
   - {}

--- a/releasenotes/notes/core-checks-core-loader-8ef9c8199601e655.yaml
+++ b/releasenotes/notes/core-checks-core-loader-8ef9c8199601e655.yaml
@@ -1,0 +1,10 @@
+---
+enhancements:
+  - |
+    Checks defined in the agent core no longer log messages about not finding a
+    subclass of the base check.  This error occurred because the agent looked
+    first for a Python module and only then fell back to a core module.  The
+    default configurations (`<checkname>.yaml.default`) for core modules now
+    contain `loader: core`, causing the core loader to be used without first trying
+    Python.  Customers with custom configuration for these checks can add a
+    similar setting to their configuration files.


### PR DESCRIPTION
This will cause the agent to load these checks directly with the "core"
loader, rather than first trying Python.

In cases where these checks are also implemented in Python, as defined
the DataDog/integrations-core repo, the configuration from that
repository will overwrite this configuration.

### Motivation

Avoid unnecessary errors from the Python loader when trying to load these checks

### Describe how to test your changes

* Check an agent package to ensure that the `loader: core` is present for checks defined in the core, and _not_ present for checks also defined in integrations-core (disk, network).
* Check that logs from running affected checks do not show an error trying to load Python modules
* Check that running affected checks (both core and those redefined in integrations-core) run the correct version (e.g., by introducing an error into the Python check and verifying that the error is raised when running the check)

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.