### PR TITLE
[gitlab] Remove size tag in job definitions

### DIFF
--- a/.gitlab/binary_build/cluster_agent.yml
+++ b/.gitlab/binary_build/cluster_agent.yml
@@ -15,7 +15,7 @@ cluster_agent-build_amd64:
   rules:
     !reference [.on_tag_or_a7]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   needs: ["go_mod_tidy_check", "linux_x64_go_deps"]
   variables:
     ARCH: amd64

--- a/.gitlab/binary_build/cluster_agent_cloudfoundry.yml
+++ b/.gitlab/binary_build/cluster_agent_cloudfoundry.yml
@@ -4,7 +4,7 @@ cluster_agent_cloudfoundry-build_amd64:
     !reference [.on_a7]
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   needs: ["go_mod_tidy_check", "linux_x64_go_deps"]
   artifacts:
     expire_in: 2 weeks

--- a/.gitlab/binary_build/linux.yml
+++ b/.gitlab/binary_build/linux.yml
@@ -5,7 +5,7 @@ build_dogstatsd_static-deb_x64:
   rules:
     !reference [.on_a7]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   needs: ["tests_deb-x64-py3", "linux_x64_go_deps"]
   before_script:
     - !reference [.retrieve_linux_go_deps]
@@ -19,7 +19,7 @@ build_dogstatsd-deb_x64:
   rules:
     !reference [.on_a7]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   needs: ["tests_deb-x64-py3", "linux_x64_go_deps"]
   before_script:
     - !reference [.retrieve_linux_go_deps]
@@ -54,7 +54,7 @@ build_iot_agent-deb_x64:
   rules:
     !reference [.on_a7]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   needs: ["tests_deb-x64-py3", "linux_x64_go_deps"]
   before_script:
     - !reference [.retrieve_linux_go_deps]

--- a/.gitlab/binary_build/serverless.yml
+++ b/.gitlab/binary_build/serverless.yml
@@ -2,7 +2,7 @@
 build_serverless-deb_x64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   needs: ["linux_x64_go_deps"]
   before_script:
     - !reference [.retrieve_linux_go_deps]

--- a/.gitlab/binary_build/system_probe.yml
+++ b/.gitlab/binary_build/system_probe.yml
@@ -39,7 +39,7 @@
 build_system-probe-x64:
   stage: binary_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   needs: ["go_mod_tidy_check"]
   extends: .system-probe_build_common
   variables:

--- a/.gitlab/check_deploy.yml
+++ b/.gitlab/check_deploy.yml
@@ -12,7 +12,7 @@ check_already_deployed_version_6:
     !reference [.on_deploy_a6]
   stage: check_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies: ["agent_deb-x64-a6", "agent_deb-arm64-a6"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -25,7 +25,7 @@ check_already_deployed_version_7:
     !reference [.on_deploy_a7]
   stage: check_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies: ["agent_deb-x64-a7", "agent_deb-arm64-a7"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -39,7 +39,7 @@ check_if_build_only:
     !reference [.on_deploy]
   stage: check_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies: []
   script:
     - if [ "$DEB_RPM_BUCKET_BRANCH" == "none" ]; then echo "Stopping pipeline"; exit 1; fi

--- a/.gitlab/deploy_6/docker.yml
+++ b/.gitlab/deploy_6/docker.yml
@@ -12,7 +12,7 @@
 deploy-a6:
   extends: .docker_job_definition
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   stage: deploy6
   rules:
     !reference [.on_deploy_a6_manual]
@@ -37,7 +37,7 @@ deploy-a6:
 deploy_latest-a6:
   extends: .docker_job_definition
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   stage: deploy6
   rules:
     !reference [.on_deploy_a6_manual]

--- a/.gitlab/deploy_6/nix.yml
+++ b/.gitlab/deploy_6/nix.yml
@@ -12,7 +12,7 @@ deploy_staging_deb-6:
   stage: deploy6
   resource_group: deb_bucket
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies: ["agent_deb-x64-a6", "agent_deb-arm64-a6"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -42,7 +42,7 @@ deploy_staging_rpm-6:
   stage: deploy6
   resource_group: rpm_bucket
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies: ["agent_rpm-x64-a6", "agent_rpm-arm64-a6"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -59,7 +59,7 @@ deploy_staging_suse_rpm-6:
   stage: deploy6
   resource_group: suse_bucket
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies: ["agent_suse-x64-a6"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR_SUSE
@@ -75,7 +75,7 @@ deploy_staging_dmg-a6:
     !reference [.on_deploy_a6]
   stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies: ["agent_dmg-x64-a6"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR

--- a/.gitlab/deploy_6/windows.yml
+++ b/.gitlab/deploy_6/windows.yml
@@ -4,7 +4,7 @@ deploy_staging_windows_master-a6:
     !reference [.on_deploy_nightly_repo_branch_a6]
   stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies: ["windows_msi_x64-a6"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -17,7 +17,7 @@ deploy_staging_windows_master-latest-a6:
     !reference [.on_deploy_nightly_repo_branch_a6]
   stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies: ["windows_msi_x64-a6"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -29,7 +29,7 @@ deploy_staging_windows_tags-a6:
     !reference [.on_deploy_stable_or_beta_repo_branch_a6]
   stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies: ["windows_msi_x64-a6"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR

--- a/.gitlab/deploy_7/cluster_agent_cloudfoundry.yml
+++ b/.gitlab/deploy_7/cluster_agent_cloudfoundry.yml
@@ -4,7 +4,7 @@ deploy_cluster_agent_cloudfoundry:
     !reference [.on_deploy_a7]
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies: ["cluster_agent_cloudfoundry-build_amd64"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR

--- a/.gitlab/deploy_7/docker.yml
+++ b/.gitlab/deploy_7/docker.yml
@@ -12,7 +12,7 @@
 deploy-a7:
   extends: .docker_job_definition
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   stage: deploy7
   rules:
     !reference [.on_deploy_a7_manual]
@@ -38,7 +38,7 @@ deploy-a7:
 deploy-dogstatsd:
   extends: .docker_job_definition
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   stage: deploy7
   rules:
     !reference [.on_deploy_a7_manual]
@@ -58,7 +58,7 @@ deploy-dogstatsd:
 deploy_latest-a7:
   extends: .docker_job_definition
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   stage: deploy7
   rules:
     !reference [.on_deploy_a7_manual]
@@ -80,7 +80,7 @@ deploy_latest-a7:
 deploy_latest-dogstatsd:
   extends: .docker_job_definition
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   stage: deploy7
   rules:
     !reference [.on_deploy_a7_manual]

--- a/.gitlab/deploy_7/install_script.yml
+++ b/.gitlab/deploy_7/install_script.yml
@@ -4,7 +4,7 @@ promote_install_script:
     !reference [.on_install_script_release_manual]
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   needs:
     - kitchen_centos_install_script_agent-a6
     - kitchen_centos_install_script_agent-a7

--- a/.gitlab/deploy_7/nix.yml
+++ b/.gitlab/deploy_7/nix.yml
@@ -11,7 +11,7 @@ deploy_staging_deb-7:
   stage: deploy7
   resource_group: deb_bucket
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies:
     - agent_deb-x64-a7
     - agent_deb-arm64-a7
@@ -48,7 +48,7 @@ deploy_staging_rpm-7:
   stage: deploy7
   resource_group: rpm_bucket
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies:
     - agent_rpm-x64-a7
     - agent_rpm-arm64-a7
@@ -71,7 +71,7 @@ deploy_staging_suse_rpm-7:
   stage: deploy7
   resource_group: suse_bucket
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies:
     - agent_suse-x64-a7
     - dogstatsd_suse-x64
@@ -89,7 +89,7 @@ deploy_staging_dmg-a7:
     !reference [.on_deploy_a7]
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies: ["agent_dmg-x64-a7"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -102,7 +102,7 @@ deploy_staging_dsd:
     !reference [.on_deploy_a7]
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies: []
   script:
     - python3.6 -m pip install --user -r requirements.txt
@@ -116,7 +116,7 @@ deploy_staging_iot_agent:
     !reference [.on_deploy_a7]
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies: []
   script:
     - python3.6 -m pip install --user -r requirements.txt
@@ -131,7 +131,7 @@ deploy_staging_android_tags:
     - when: never
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies: ["agent_android_apk"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR

--- a/.gitlab/deploy_7/windows.yml
+++ b/.gitlab/deploy_7/windows.yml
@@ -4,7 +4,7 @@ deploy_staging_windows_master-a7:
     !reference [.on_deploy_nightly_repo_branch_a7]
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies: ["windows_msi_and_bosh_zip_x64-a7"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -18,7 +18,7 @@ deploy_staging_windows_tags-a7:
     !reference [.on_deploy_stable_or_beta_repo_branch_a7]
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies: ["windows_msi_and_bosh_zip_x64-a7", "windows_zip_agent_binaries_x64-a7"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR

--- a/.gitlab/deploy_invalidate.yml
+++ b/.gitlab/deploy_invalidate.yml
@@ -12,7 +12,7 @@
 .deploy_cloudfront_invalidate:
   stage: deploy_invalidate
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies: []
   script:
     - cd /deploy_scripts/cloudfront-invalidation

--- a/.gitlab/deps_build.yml
+++ b/.gitlab/deps_build.yml
@@ -33,7 +33,7 @@
 build_libbcc_x64:
   extends: .build_libbcc_common
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   variables:
     ARCH: amd64
 
@@ -87,7 +87,7 @@ build_libbcc_arm64:
 build_clang_x64:
   extends: .build_clang_common
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   variables:
     ARCH: amd64
 

--- a/.gitlab/deps_fetch.yml
+++ b/.gitlab/deps_fetch.yml
@@ -21,7 +21,7 @@
 linux_x64_go_deps:
   extends: .go_deps
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
 
 linux_arm64_go_deps:
   extends: .go_deps

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -5,7 +5,7 @@
 .k8s_e2e_template:
   stage: e2e
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies: []
   variables:
     LANG: C.UTF-8

--- a/.gitlab/image_build/docker_linux.yml
+++ b/.gitlab/image_build/docker_linux.yml
@@ -23,7 +23,7 @@
 .docker_build_job_definition_amd64:
   extends: .docker_build_job_definition
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:v2718644-9ce6565-18.09.6-py3
-  tags: ["runner:docker", "size:large"]
+  tags: ["runner:docker"]
   variables:
     ARCH: amd64
 

--- a/.gitlab/image_deploy/docker_linux.yml
+++ b/.gitlab/image_deploy/docker_linux.yml
@@ -15,7 +15,7 @@ dev_branch-a6:
     - docker_build_agent6_jmx
     - docker_build_agent6_py2py3_jmx
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   script: # We can't use the 'trigger' keyword on manual jobs, otherwise they can't be run if the pipeline fails and is retried
     - python3 -m pip install -r requirements.txt
     - inv pipeline.trigger-child-pipeline --project-name "DataDog/public-images" --git-ref "main" --variables "IMG_REGISTRIES,IMG_SOURCES,IMG_DESTINATIONS"
@@ -38,7 +38,7 @@ dev_branch-dogstatsd:
   needs:
     - docker_build_dogstatsd_amd64
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   script: # We can't use the 'trigger' keyword on manual jobs, otherwise they can't be run if the pipeline fails and is retried
     - python3 -m pip install -r requirements.txt
     - inv pipeline.trigger-child-pipeline --project-name "DataDog/public-images" --git-ref "main" --variables "IMG_REGISTRIES,IMG_SOURCES,IMG_DESTINATIONS"
@@ -56,7 +56,7 @@ dev_branch-a7:
     - docker_build_agent7
     - docker_build_agent7_jmx
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   script: # We can't use the 'trigger' keyword on manual jobs, otherwise they can't be run if the pipeline fails and is retried
     - python3 -m pip install -r requirements.txt
     - inv pipeline.trigger-child-pipeline --project-name "DataDog/public-images" --git-ref "main" --variables "IMG_REGISTRIES,IMG_SOURCES,IMG_DESTINATIONS"
@@ -81,7 +81,7 @@ dev_branch_multiarch-a6:
     - docker_build_agent6_jmx_arm64
     - docker_build_agent6_py2py3_jmx
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   script: # We can't use the 'trigger' keyword on manual jobs, otherwise they can't be run if the pipeline fails and is retried
     - python3 -m pip install -r requirements.txt
     - inv pipeline.trigger-child-pipeline --project-name "DataDog/public-images" --git-ref "main" --variables "IMG_REGISTRIES,IMG_SOURCES,IMG_DESTINATIONS"
@@ -107,7 +107,7 @@ dev_branch_multiarch-a7:
     - docker_build_agent7_jmx
     - docker_build_agent7_jmx_arm64
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   script: # We can't use the 'trigger' keyword on manual jobs, otherwise they can't be run if the pipeline fails and is retried
     - python3 -m pip install -r requirements.txt
     - inv pipeline.trigger-child-pipeline --project-name "DataDog/public-images" --git-ref "main" --variables "IMG_REGISTRIES,IMG_SOURCES,IMG_DESTINATIONS"
@@ -128,7 +128,7 @@ dev_branch_multiarch-dogstatsd:
   needs:
     - docker_build_dogstatsd_amd64
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   script: # We can't use the 'trigger' keyword on manual jobs, otherwise they can't be run if the pipeline fails and is retried
     - python3 -m pip install -r requirements.txt
     - inv pipeline.trigger-child-pipeline --project-name "DataDog/public-images" --git-ref "main" --variables "IMG_REGISTRIES,IMG_SOURCES,IMG_DESTINATIONS"
@@ -204,7 +204,7 @@ dca_dev_branch:
   needs:
     - docker_build_cluster_agent_amd64
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   script: # We can't use the 'trigger' keyword on manual jobs, otherwise they can't be run if the pipeline fails and is retried
     - python3 -m pip install -r requirements.txt
     - inv pipeline.trigger-child-pipeline --project-name "DataDog/public-images" --git-ref "main" --variables "IMG_REGISTRIES,IMG_SOURCES,IMG_DESTINATIONS"
@@ -222,7 +222,7 @@ dca_dev_branch_multiarch:
     - docker_build_cluster_agent_amd64
     - docker_build_cluster_agent_arm64
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   script: # We can't use the 'trigger' keyword on manual jobs, otherwise they can't be run if the pipeline fails and is retried
     - python3 -m pip install -r requirements.txt
     - inv pipeline.trigger-child-pipeline --project-name "DataDog/public-images" --git-ref "main" --variables "IMG_REGISTRIES,IMG_SOURCES,IMG_DESTINATIONS"

--- a/.gitlab/image_deploy/twistlock.yml
+++ b/.gitlab/image_deploy/twistlock.yml
@@ -5,7 +5,7 @@ twistlock_scan-6:
     !reference [.on_a6]
   stage: image_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/twistlock-cli:2.5.121
-  tags: ["runner:docker", "size:large"]
+  tags: ["runner:docker"]
   dependencies: []
   variables:
     SRC_AGENT: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent
@@ -24,7 +24,7 @@ twistlock_scan-7:
     !reference [.on_a7]
   stage: image_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/twistlock-cli:2.5.121
-  tags: ["runner:docker", "size:large"]
+  tags: ["runner:docker"]
   dependencies: []
   variables:
     SRC_AGENT: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent

--- a/.gitlab/integration_test.yml
+++ b/.gitlab/integration_test.yml
@@ -7,7 +7,7 @@ dogstatsd_x64_size_test:
   rules:
     !reference [.on_a7]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   needs: ["build_dogstatsd_static-deb_x64"]
   before_script:
     - source /root/.bashrc && conda activate ddpy3
@@ -21,7 +21,7 @@ dogstatsd_x64_size_test:
 #   stage: integration_test
 #   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
 #   allow_failure: true  # FIXME: this was set to true to temporarily unblock the pipeline
-#   tags: ["runner:main", "size:large"]
+#   tags: ["runner:main"]
 #   script:
 #     - inv -e bench.aggregator
 #     # FIXME: in our docker image, non ascii characters printed by the benchmark

--- a/.gitlab/internal_deploy.yml
+++ b/.gitlab/internal_deploy.yml
@@ -7,7 +7,7 @@ deploy_staging_process_and_sysprobe:
     !reference [.manual]
   stage: internal_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies: ["agent_deb-x64-a7"]
   before_script:
     - cd $OMNIBUS_PACKAGE_DIR

--- a/.gitlab/kitchen_common/cleanup.yml
+++ b/.gitlab/kitchen_common/cleanup.yml
@@ -3,7 +3,7 @@
   allow_failure: true
   stage: kitchen_cleanup
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   script:
     - aws s3 rm s3://$DEB_TESTING_S3_BUCKET/dists/pipeline-$DD_PIPELINE_ID --recursive
     - aws s3 rm s3://$RPM_TESTING_S3_BUCKET/testing/pipeline-$DD_PIPELINE_ID --recursive
@@ -17,7 +17,7 @@
   allow_failure: true
   stage: kitchen_cleanup
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies: []
   before_script:
     - rsync -azr --delete ./ $SRC_PATH

--- a/.gitlab/kitchen_common/testing.yml
+++ b/.gitlab/kitchen_common/testing.yml
@@ -2,7 +2,7 @@
 .kitchen_common:
   stage: kitchen_testing
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/dd-agent-testing:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   artifacts:
     expire_in: 2 weeks
     when: always

--- a/.gitlab/kitchen_deploy.yml
+++ b/.gitlab/kitchen_deploy.yml
@@ -21,7 +21,7 @@ deploy_deb_testing-a6:
     !reference [.on_kitchen_tests_a6]
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   needs: ["agent_deb-x64-a6"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
@@ -39,7 +39,7 @@ deploy_deb_testing-a7:
     !reference [.on_default_kitchen_tests_a7]
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   needs: ["agent_deb-x64-a7", "iot_agent_deb-x64", "dogstatsd_deb-x64"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
@@ -57,7 +57,7 @@ deploy_rpm_testing-a6:
     !reference [.on_kitchen_tests_a6]
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   needs: ["agent_rpm-x64-a6"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
@@ -73,7 +73,7 @@ deploy_rpm_testing-a7:
     !reference [.on_default_kitchen_tests_a7]
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   needs: ["agent_rpm-x64-a7", "iot_agent_rpm-x64", "dogstatsd_rpm-x64"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
@@ -89,7 +89,7 @@ deploy_suse_rpm_testing-a6:
     !reference [.on_kitchen_tests_a6]
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   needs: ["agent_suse-x64-a6"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
@@ -105,7 +105,7 @@ deploy_suse_rpm_testing-a7:
     !reference [.on_default_kitchen_tests_a7]
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   needs: ["agent_suse-x64-a7", "iot_agent_suse-x64", "dogstatsd_suse-x64"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
@@ -121,7 +121,7 @@ deploy_windows_testing-a6:
     !reference [.on_kitchen_tests_a6]
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   needs: ["windows_msi_x64-a6"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -133,7 +133,7 @@ deploy_windows_testing-a7:
     !reference [.on_default_kitchen_tests_a7]
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   needs: ["windows_msi_and_bosh_zip_x64-a7"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR

--- a/.gitlab/maintenance_jobs/docker.yml
+++ b/.gitlab/maintenance_jobs/docker.yml
@@ -64,7 +64,7 @@ delete_docker_tag:
     !reference [.on_main_manual]
   stage: maintenance_jobs
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker-notary:v2718650-9ce6565-0.6.1-py3
-  tags: ["runner:docker", "size:large"]
+  tags: ["runner:docker"]
   dependencies: []
   variables:
     IMAGE: ""  # image name, for example "agent"

--- a/.gitlab/maintenance_jobs/kitchen.yml
+++ b/.gitlab/maintenance_jobs/kitchen.yml
@@ -4,7 +4,7 @@
 periodic_kitchen_cleanup_s3:
   stage: maintenance_jobs
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   rules:
     !reference [.on_testing_cleanup]
   script:
@@ -19,7 +19,7 @@ periodic_kitchen_cleanup_s3:
 periodic_kitchen_cleanup_azure:
   stage: maintenance_jobs
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   rules:
     !reference [.on_testing_cleanup]
   script:

--- a/.gitlab/package_build/apk.yml
+++ b/.gitlab/package_build/apk.yml
@@ -4,7 +4,7 @@ agent_android_apk:
     !reference [.on_a7_except_deploy]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/android_builder:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   before_script:

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -47,7 +47,7 @@ agent_deb-x64-a6:
     !reference [.on_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   needs: ["tests_deb-x64-py2", "tests_deb-x64-py3", "build_system-probe-x64", "linux_x64_go_deps"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
@@ -66,7 +66,7 @@ agent_deb-x64-a7:
     !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   needs: ["tests_deb-x64-py3", "build_system-probe-x64", "linux_x64_go_deps"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
@@ -142,7 +142,7 @@ iot_agent_deb-x64:
     !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   needs: ["linux_x64_go_deps"]
   variables:
     PACKAGE_ARCH: amd64
@@ -178,7 +178,7 @@ dogstatsd_deb-x64:
     !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   needs: ["build_dogstatsd-deb_x64", "linux_x64_go_deps"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -24,7 +24,7 @@ agent_dmg-x64-a6:
   allow_failure: true
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   needs: ["go_mod_tidy_check"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
@@ -40,7 +40,7 @@ agent_dmg-x64-a7:
   allow_failure: true
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   needs: ["go_mod_tidy_check"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -44,7 +44,7 @@ agent_rpm-x64-a6:
     !reference [.on_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   needs: ["tests_rpm-x64-py2", "tests_rpm-x64-py3", "build_system-probe-x64", "linux_x64_go_deps"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
@@ -62,7 +62,7 @@ agent_rpm-x64-a7:
     !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   needs: ["tests_rpm-x64-py3", "build_system-probe-x64", "linux_x64_go_deps"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
@@ -137,7 +137,7 @@ iot_agent_rpm-x64:
     !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   needs: ["linux_x64_go_deps"]
 
 iot_agent_rpm-arm64:
@@ -167,7 +167,7 @@ dogstatsd_rpm-x64:
     !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   needs: ["build_dogstatsd-deb_x64", "linux_x64_go_deps"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -46,7 +46,7 @@ agent_suse-x64-a6:
     !reference [.on_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/suse_x64:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   needs: ["tests_rpm-x64-py2", "tests_rpm-x64-py3", "build_system-probe-x64", "linux_x64_go_deps"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
@@ -64,7 +64,7 @@ agent_suse-x64-a7:
     !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/suse_x64:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   needs: ["tests_rpm-x64-py3", "build_system-probe-x64", "linux_x64_go_deps"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
@@ -80,7 +80,7 @@ iot_agent_suse-x64:
     !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/suse_x64:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   needs: ["linux_x64_go_deps"]
   before_script:
     - source /root/.bashrc && conda activate ddpy3
@@ -114,7 +114,7 @@ dogstatsd_suse-x64:
     !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/suse_x64:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   needs: ["build_dogstatsd-deb_x64", "linux_x64_go_deps"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials

--- a/.gitlab/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics.yml
@@ -8,7 +8,7 @@ send_pkg_size-a6:
     !reference [.on_deploy_a6]
   stage: pkg_metrics
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies:
     - agent_deb-x64-a6
     - agent_rpm-x64-a6
@@ -53,7 +53,7 @@ send_pkg_size-a7:
     !reference [.on_deploy_a7]
   stage: pkg_metrics
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   dependencies:
     - agent_deb-x64-a7
     - iot_agent_deb-x64

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -48,7 +48,7 @@
 tests_ebpf_x64:
   extends: .tests_linux_ebpf
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
-  tags: [ "runner:main", "size:large" ]
+  tags: [ "runner:main" ]
   needs: [ "linux_x64_go_deps" ]
   variables:
     ARCH: amd64

--- a/.gitlab/source_test/go_generate_check.yml
+++ b/.gitlab/source_test/go_generate_check.yml
@@ -2,7 +2,7 @@
 # check that go generate has been run in the pkg/security directory
 security_go_generate_check:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
-  tags: [ "runner:main", "size:large" ]
+  tags: [ "runner:main" ]
   stage: source_test
   needs: [ "linux_x64_go_deps" ]
   before_script:

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -29,7 +29,7 @@ tests_deb-x64-py2:
   rules:
     !reference [.on_a6]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   needs: ["linux_x64_go_deps"]
   variables:
     PYTHON_RUNTIMES: '2'
@@ -40,7 +40,7 @@ tests_deb-x64-py3:
     - .rtloader_tests
     - .linux_tests
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   needs: ["linux_x64_go_deps"]
   variables:
     PYTHON_RUNTIMES: '3'
@@ -54,7 +54,7 @@ tests_rpm-x64-py2:
   rules:
     !reference [.on_a6]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   needs: ["linux_x64_go_deps"]
   variables:
     PYTHON_RUNTIMES: '2'
@@ -66,7 +66,7 @@ tests_rpm-x64-py3:
     - .rtloader_tests
     - .linux_tests
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   needs: ["linux_x64_go_deps"]
   variables:
     PYTHON_RUNTIMES: '3'
@@ -121,7 +121,7 @@ tests_rpm-arm64-py3:
 go_mod_tidy_check:
   stage: source_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   needs: ["linux_x64_go_deps"]
   before_script:
     - !reference [.retrieve_linux_go_deps]

--- a/.gitlab/source_test/security_scan.yml
+++ b/.gitlab/source_test/security_scan.yml
@@ -5,7 +5,7 @@ security_scan_test:
     !reference [.on_main_or_release_branch]
   stage: source_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/snyk:v3523070-7400854-next
-  tags: ["runner:main", "size:large"]
+  tags: ["runner:main"]
   needs: ["linux_x64_go_deps"]
   before_script:
     - !reference [.retrieve_linux_go_deps]

--- a/.gitlab/trigger_release.yml
+++ b/.gitlab/trigger_release.yml
@@ -5,7 +5,7 @@
 .agent_release_management_trigger:
   stage: trigger_release
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
-  tags: ["runner:main", "size:2xlarge"]
+  tags: ["runner:main"]
   script:
     - python3 -m pip install -r requirements.txt
     - inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-release-management" --git-ref "master" --variables "RELEASE_VERSION"


### PR DESCRIPTION
### What does this PR do?

Removes the `size:` tag used in Gitlab job definitions.

### Motivation

These tags don't do anything, and they're going to be removed from our Gitlab infra soon.
This should be a noop.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
