### PR TITLE
[system-probe] Add config flags for package management repository paths

### DIFF
--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -72,6 +72,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "runtime_compiler_output_dir"), defaultRuntimeCompilerOutputDir, "DD_RUNTIME_COMPILER_OUTPUT_DIR")
 	cfg.BindEnvAndSetDefault(join(spNS, "kernel_header_dirs"), []string{}, "DD_KERNEL_HEADER_DIRS")
 	cfg.BindEnvAndSetDefault(join(spNS, "kernel_header_download_dir"), DefaultKernelHeadersDownloadDir, "DD_KERNEL_HEADER_DOWNLOAD_DIR")
+	cfg.BindEnvAndSetDefault(join(spNS, "containerized_environment"), false)
 
 	// network_tracer settings
 	// we cannot use BindEnvAndSetDefault for network_config.enabled because we need to know if it was manually set.

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -20,6 +20,15 @@ const (
 	// defaultKernelHeadersDownloadDir is the default path for downloading kernel headers for runtime compilation
 	defaultKernelHeadersDownloadDir = "/var/tmp/datadog-agent/system-probe/kernel-headers"
 
+	// defaultAptConfigDir is the default path to the apt config directory
+	defaultAptConfigDir = "/etc/apt"
+
+	// defaultYumReposDir is the default path to the yum repository directory
+	defaultYumReposDir = "/etc/yum.repos.d"
+
+	// defaultZypperReposDir is the default path to the zypper repository directory
+	defaultZypperReposDir = "/etc/zypp/repos.d"
+
 	defaultOffsetThreshold = 400
 )
 
@@ -72,7 +81,9 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "runtime_compiler_output_dir"), defaultRuntimeCompilerOutputDir, "DD_RUNTIME_COMPILER_OUTPUT_DIR")
 	cfg.BindEnvAndSetDefault(join(spNS, "kernel_header_dirs"), []string{}, "DD_KERNEL_HEADER_DIRS")
 	cfg.BindEnvAndSetDefault(join(spNS, "kernel_header_download_dir"), defaultKernelHeadersDownloadDir, "DD_KERNEL_HEADER_DOWNLOAD_DIR")
-	cfg.BindEnvAndSetDefault(join(spNS, "containerized_environment"), false)
+	cfg.BindEnvAndSetDefault(join(spNS, "apt_config_dir"), defaultAptConfigDir, "DD_APT_CONFIG_DIR")
+	cfg.BindEnvAndSetDefault(join(spNS, "yum_repos_dir"), defaultYumReposDir, "DD_YUM_REPOS_DIR")
+	cfg.BindEnvAndSetDefault(join(spNS, "zypper_repos_dir"), defaultZypperReposDir, "DD_ZYPPER_REPOS_DIR")
 
 	// network_tracer settings
 	// we cannot use BindEnvAndSetDefault for network_config.enabled because we need to know if it was manually set.

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -17,8 +17,8 @@ const (
 	// defaultRuntimeCompilerOutputDir is the default path for output from the system-probe runtime compiler
 	defaultRuntimeCompilerOutputDir = "/var/tmp/datadog-agent/system-probe/build"
 
-	// DefaultKernelHeadersDownloadDir is the default path for downloading kernel headers for runtime compilation
-	DefaultKernelHeadersDownloadDir = "/var/tmp/datadog-agent/system-probe/kernel-headers"
+	// defaultKernelHeadersDownloadDir is the default path for downloading kernel headers for runtime compilation
+	defaultKernelHeadersDownloadDir = "/var/tmp/datadog-agent/system-probe/kernel-headers"
 
 	defaultOffsetThreshold = 400
 )
@@ -71,7 +71,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "enable_runtime_compiler"), false, "DD_ENABLE_RUNTIME_COMPILER")
 	cfg.BindEnvAndSetDefault(join(spNS, "runtime_compiler_output_dir"), defaultRuntimeCompilerOutputDir, "DD_RUNTIME_COMPILER_OUTPUT_DIR")
 	cfg.BindEnvAndSetDefault(join(spNS, "kernel_header_dirs"), []string{}, "DD_KERNEL_HEADER_DIRS")
-	cfg.BindEnvAndSetDefault(join(spNS, "kernel_header_download_dir"), DefaultKernelHeadersDownloadDir, "DD_KERNEL_HEADER_DOWNLOAD_DIR")
+	cfg.BindEnvAndSetDefault(join(spNS, "kernel_header_download_dir"), defaultKernelHeadersDownloadDir, "DD_KERNEL_HEADER_DOWNLOAD_DIR")
 	cfg.BindEnvAndSetDefault(join(spNS, "containerized_environment"), false)
 
 	// network_tracer settings

--- a/pkg/ebpf/bytecode/runtime/runtime_asset.go
+++ b/pkg/ebpf/bytecode/runtime/runtime_asset.go
@@ -138,7 +138,7 @@ func (a *RuntimeAsset) Compile(config *ebpf.Config, cflags []string) (CompiledOu
 			a.compilationResult = outputFileErr
 			return nil, fmt.Errorf("error stat-ing output file %s: %w", outputFile, err)
 		}
-		dirs, res, err := kernel.GetKernelHeaders(config.KernelHeadersDirs, config.KernelHeadersDownloadDir, config.ContainerizedEnvironment)
+		dirs, res, err := kernel.GetKernelHeaders(config.KernelHeadersDirs, config.KernelHeadersDownloadDir, config.AptConfigDir, config.YumReposDir, config.ZypperReposDir)
 		a.headerFetchResult = res
 		if err != nil {
 			a.compilationResult = headerFetchErr

--- a/pkg/ebpf/bytecode/runtime/runtime_asset.go
+++ b/pkg/ebpf/bytecode/runtime/runtime_asset.go
@@ -138,7 +138,7 @@ func (a *RuntimeAsset) Compile(config *ebpf.Config, cflags []string) (CompiledOu
 			a.compilationResult = outputFileErr
 			return nil, fmt.Errorf("error stat-ing output file %s: %w", outputFile, err)
 		}
-		dirs, res, err := kernel.GetKernelHeaders(config.KernelHeadersDirs, config.KernelHeadersDownloadDir)
+		dirs, res, err := kernel.GetKernelHeaders(config.KernelHeadersDirs, config.KernelHeadersDownloadDir, config.ContainerizedEnvironment)
 		a.headerFetchResult = res
 		if err != nil {
 			a.compilationResult = headerFetchErr

--- a/pkg/ebpf/config.go
+++ b/pkg/ebpf/config.go
@@ -40,6 +40,9 @@ type Config struct {
 	// RuntimeCompilerOutputDir is the directory where the runtime compiler will store compiled programs
 	RuntimeCompilerOutputDir string
 
+	// ContainerizedEnvironment indicates whether the system-probe is operating within a containerized environment
+	ContainerizedEnvironment bool
+
 	// AllowPrecompiledFallback indicates whether we are allowed to fallback to the prebuilt probes if runtime compilation fails.
 	AllowPrecompiledFallback bool
 }
@@ -64,6 +67,7 @@ func NewConfig() *Config {
 		RuntimeCompilerOutputDir: cfg.GetString(key(spNS, "runtime_compiler_output_dir")),
 		KernelHeadersDirs:        cfg.GetStringSlice(key(spNS, "kernel_header_dirs")),
 		KernelHeadersDownloadDir: cfg.GetString(key(spNS, "kernel_header_download_dir")),
+		ContainerizedEnvironment: cfg.GetBool(key(spNS, "containerized_environment")),
 		AllowPrecompiledFallback: true,
 	}
 }

--- a/pkg/ebpf/config.go
+++ b/pkg/ebpf/config.go
@@ -40,8 +40,14 @@ type Config struct {
 	// RuntimeCompilerOutputDir is the directory where the runtime compiler will store compiled programs
 	RuntimeCompilerOutputDir string
 
-	// ContainerizedEnvironment indicates whether the system-probe is operating within a containerized environment
-	ContainerizedEnvironment bool
+	// AptConfigDir is the path to the apt config directory
+	AptConfigDir string
+
+	// YumReposDir is the path to the yum repository directory
+	YumReposDir string
+
+	// ZypperReposDir is the path to the zypper repository directory
+	ZypperReposDir string
 
 	// AllowPrecompiledFallback indicates whether we are allowed to fallback to the prebuilt probes if runtime compilation fails.
 	AllowPrecompiledFallback bool
@@ -67,7 +73,9 @@ func NewConfig() *Config {
 		RuntimeCompilerOutputDir: cfg.GetString(key(spNS, "runtime_compiler_output_dir")),
 		KernelHeadersDirs:        cfg.GetStringSlice(key(spNS, "kernel_header_dirs")),
 		KernelHeadersDownloadDir: cfg.GetString(key(spNS, "kernel_header_download_dir")),
-		ContainerizedEnvironment: cfg.GetBool(key(spNS, "containerized_environment")),
+		AptConfigDir:             cfg.GetString(key(spNS, "apt_config_dir")),
+		YumReposDir:              cfg.GetString(key(spNS, "yum_repos_dir")),
+		ZypperReposDir:           cfg.GetString(key(spNS, "zypper_repos_dir")),
 		AllowPrecompiledFallback: true,
 	}
 }

--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -43,7 +43,7 @@ const (
 
 // GetKernelHeaders attempts to find kernel headers on the host, and if they cannot be found it will attempt
 // to  download them to headerDownloadDir
-func GetKernelHeaders(headerDirs []string, headerDownloadDir string) ([]string, HeaderFetchResult, error) {
+func GetKernelHeaders(headerDirs []string, headerDownloadDir string, containerizedEnv bool) ([]string, HeaderFetchResult, error) {
 	hv, hvErr := HostVersion()
 	if hvErr != nil {
 		return nil, hostVersionErr, fmt.Errorf("unable to determine host kernel version: %w", hvErr)
@@ -78,7 +78,7 @@ func GetKernelHeaders(headerDirs []string, headerDownloadDir string) ([]string, 
 	}
 	log.Debugf("unable to find downloaded kernel headers: %s", err)
 
-	if err = downloadHeaders(headerDownloadDir); err == nil {
+	if err = downloadHeaders(headerDownloadDir, containerizedEnv); err == nil {
 		log.Infof("successfully downloaded kernel headers to %s", dirs)
 		if err = validateHeaderDirs(hv, dirs); err == nil {
 			return dirs, downloadSuccess, nil

--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -78,7 +78,8 @@ func GetKernelHeaders(headerDirs []string, headerDownloadDir, aptConfigDir, yumR
 	}
 	log.Debugf("unable to find downloaded kernel headers: %s", err)
 
-	if err = downloadHeaders(headerDownloadDir, aptConfigDir, yumReposDir, zypperReposDir); err == nil {
+	d := headerDownloader{aptConfigDir, yumReposDir, zypperReposDir}
+	if err = d.downloadHeaders(headerDownloadDir); err == nil {
 		log.Infof("successfully downloaded kernel headers to %s", dirs)
 		if err = validateHeaderDirs(hv, dirs); err == nil {
 			return dirs, downloadSuccess, nil

--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -43,7 +43,7 @@ const (
 
 // GetKernelHeaders attempts to find kernel headers on the host, and if they cannot be found it will attempt
 // to  download them to headerDownloadDir
-func GetKernelHeaders(headerDirs []string, headerDownloadDir string, containerizedEnv bool) ([]string, HeaderFetchResult, error) {
+func GetKernelHeaders(headerDirs []string, headerDownloadDir, aptConfigDir, yumReposDir, zypperReposDir string) ([]string, HeaderFetchResult, error) {
 	hv, hvErr := HostVersion()
 	if hvErr != nil {
 		return nil, hostVersionErr, fmt.Errorf("unable to determine host kernel version: %w", hvErr)
@@ -78,7 +78,7 @@ func GetKernelHeaders(headerDirs []string, headerDownloadDir string, containeriz
 	}
 	log.Debugf("unable to find downloaded kernel headers: %s", err)
 
-	if err = downloadHeaders(headerDownloadDir, containerizedEnv); err == nil {
+	if err = downloadHeaders(headerDownloadDir, aptConfigDir, yumReposDir, zypperReposDir); err == nil {
 		log.Infof("successfully downloaded kernel headers to %s", dirs)
 		if err = validateHeaderDirs(hv, dirs); err == nil {
 			return dirs, downloadSuccess, nil

--- a/pkg/util/kernel/find_headers_test.go
+++ b/pkg/util/kernel/find_headers_test.go
@@ -15,7 +15,7 @@ func TestGetKernelHeaders(t *testing.T) {
 	if _, ok := os.LookupEnv("INTEGRATION"); !ok {
 		t.Skip("set INTEGRATION environment variable to run")
 	}
-	dirs, _, err := GetKernelHeaders(nil, "")
+	dirs, _, err := GetKernelHeaders(nil, "", "", "", "")
 	require.NoError(t, err)
 	assert.NotZero(t, len(dirs), "expected to find header directories")
 	t.Log(dirs)


### PR DESCRIPTION
### What does this PR do?

Adds the `AptConfigDir`, `YumReposDir` and `ZypperReposDir` configuration flags to the system-probe config. These allow us to specify where the system-probe should look for the appropriate package management repository directory (if it's not in the default location).

### Motivation

Kernel header downloading requires access to the host's package management repository directories (ie `/etc/yum.repos.d` on fedora). In a containerized environment, we want to mount those directories under `/host/etc` instead of `/etc` in order to prevent corrupting the host's system. Thus, the path checked by the system-probe needs to be configurable.

### Additional Notes

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.

Note: Adding GitHub labels is only possible for contributors with write access.
