### PR TITLE
DOCS-2215 Add @env variables to datadog.yaml

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -29,6 +29,9 @@ api_key:
 # dd_url: https://app.datadoghq.com
 
 ## @param proxy - custom object - optional
+## @env DD_PROXY_HTTP - string - optional
+## @env DD_PROXY_HTTPS - string - optional
+## @env DD_PROXY_NO_PROXY - space separated list of strings - optional
 ## If you need a proxy to connect to the Internet, provide it here (default:
 ## disabled). Refer to https://docs.datadoghq.com/agent/proxy/ to understand how to use these settings.
 ## For Logs proxy information, refer to https://docs.datadoghq.com/agent/proxy/#proxy-for-logs
@@ -41,17 +44,20 @@ api_key:
 #     - <HOSTNAME-2>
 
 ## @param skip_ssl_validation - boolean - optional - default: false
+## @env DD_SKIP_SSL_VALIDATION - boolean - optional - default: false
 ## Setting this option to "true" tells the Agent to skip validation of SSL/TLS certificates.
 #
 # skip_ssl_validation: false
 
 ## @param force_tls_12 - boolean - optional - default: false
+## @env DD_FORCE_TLS_12 - boolean - optional - default: false
 ## Setting this option to "true" forces the Agent to only use TLS 1.2 when
 ## pushing data to the Datadog intake specified in "site" or "dd_url".
 #
 # force_tls_12: false
 
 ## @param hostname - string - optional - default: auto-detected
+## @env DD_HOSTNAME - string - optional - default: auto-detected
 ## Force the hostname name.
 #
 # hostname: <HOSTNAME_NAME>
@@ -65,6 +71,7 @@ api_key:
 # hostname_file: /var/lib/cloud/data/instance-id
 
 ## @param hostname_fqdn - boolean - optional - default: false
+## @param DD_HOSTNAME_FQDN - boolean - optional - default: false
 ## When the Agent relies on the OS to determine the hostname, make it use the
 ## FQDN instead of the short hostname. Recommended value: true
 ## More information at https://dtdg.co/flag-hostname-fqdn
@@ -82,6 +89,7 @@ api_key:
 #   - <ALIAS-2>
 
 ## @param tags  - list of key:value elements - optional
+## @env DD_TAGS - space separated list of strings - optional
 ## List of host tags. Attached in-app to every metric, event, log, trace, and service check emitted by this Agent.
 ##
 ## Additional tags can be supplied using the `DD_EXTRA_TAGS` environment variable.
@@ -93,12 +101,14 @@ api_key:
 #   - <TAG_KEY>:<TAG_VALUE>
 
 ## @param env - string - optional
+## @param DD_ENV - string - optional
 ## The environment name where the agent is running. Attached in-app to every
 ## metric, event, log, trace, and service check emitted by this Agent.
 #
 # env: <environment name>
 
 ## @param tag_value_split_separator - map - optional
+## @env DD_TAG_VALUE_SPLIT_SEPARATOR - list of key:value strings - optional
 ## Split tag values according to a given separator. Only applies to host tags,
 ## and tags coming from container integrations. It does not apply to tags on dogstatsd metrics,
 ## and tags collected by other integrations.


### PR DESCRIPTION
### What does this PR do?

Add @env variables to datadog.yaml:

```
DD_ENV
DD_FORCE_TLS_12
DD_HOSTNAME
DD_HOSTNAME_FQDN
DD_PROXY_HTTP
DD_PROXY_HTTPS
DD_PROXY_NO_PROXY
DD_SKIP_SSL_VALIDATION
DD_TAG_VALUE_SPLIT_SEPARATOR
DD_TAGS
```

### Motivation

- Documentation OKR
- [RFC](https://github.com/DataDog/architecture/blob/master/rfcs/agent-env-var-docs/rfc.md)

### Additional Notes

Variables will be added in small batches.

### Describe how to test your changes

N/A

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
