### PR TITLE
[so/walker;so/namespace] /proc walk fixup and namespace fd close()

### DIFF
--- a/pkg/network/so/ns.go
+++ b/pkg/network/so/ns.go
@@ -24,6 +24,7 @@ func fstat(path string) (stat unix.Stat_t, err error) {
 	if err != nil {
 		return
 	}
+	defer unix.Close(fd)
 
 	err = unix.Fstat(fd, &stat)
 	return

--- a/pkg/network/so/walker.go
+++ b/pkg/network/so/walker.go
@@ -23,7 +23,7 @@ func newWalker(procRoot string, callbackFn callback) *walker {
 
 func (w *walker) walk(path string, info os.FileInfo, err error) error {
 	if err != nil {
-		return err
+		return filepath.SkipDir
 	}
 
 	// We're only interested in /proc subdirectories


### PR DESCRIPTION
 o fixup walker to not stop walking if a path is not accessible
 o NameSpace : close() the descriptor

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
