### PR TITLE
Exclude avi_vantage from py2 build

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -76,6 +76,9 @@ blacklist_packages = Array.new
 # We build these manually
 blacklist_packages.push(/^snowflake-connector-python==/)
 
+# Avi Vantage is py3 only
+blacklist_folders.push('avi_vantage')
+
 if suse?
   # Temporarily blacklist Aerospike until builder supports new dependency
   blacklist_packages.push(/^aerospike==/)


### PR DESCRIPTION
Avi Vantage is py3 only