### PR TITLE
[kitchen] Update Ubuntu 16.04 image

### DIFF
--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -53,7 +53,7 @@
         "azure": {
             "x86_64": {
                 "ubuntu-14-04": "urn,Canonical:UbuntuServer:14.04.5-LTS:14.04.201905140",
-                "ubuntu-16-04": "urn,Canonical:UbuntuServer:16.04.0-LTS:16.04.201604203",
+                "ubuntu-16-04": "urn,Canonical:UbuntuServer:16.04.0-LTS:16.04.202106110",
                 "ubuntu-18-04": "urn,Canonical:UbuntuServer:18.04-LTS:18.04.201906040",
                 "ubuntu-20-04": "urn,Canonical:0001-com-ubuntu-server-focal:20_04-lts:20.04.202004230",
                 "ubuntu-21-04": "urn,Canonical:0001-com-ubuntu-server-hirsute:21_04:21.04.202107200"


### PR DESCRIPTION
### What does this PR do?

Updates the Ubuntu 16.04 VM image used in kitchen tests.

### Motivation

The previous image disappeared.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
