### PR TITLE
[ckey] re-introduce context key optimization

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -411,6 +411,8 @@ func (agg *BufferedAggregator) addServiceCheck(sc metrics.ServiceCheck) {
 	}
 	tb := util.NewTagsBuilderFromSlice(sc.Tags)
 	metrics.EnrichTags(tb, sc.OriginID, sc.K8sOriginID, sc.Cardinality)
+
+	tb.SortUniq()
 	sc.Tags = tb.Get()
 
 	agg.serviceChecks = append(agg.serviceChecks, &sc)
@@ -423,6 +425,8 @@ func (agg *BufferedAggregator) addEvent(e metrics.Event) {
 	}
 	tb := util.NewTagsBuilderFromSlice(e.Tags)
 	metrics.EnrichTags(tb, e.OriginID, e.K8sOriginID, e.Cardinality)
+
+	tb.SortUniq()
 	e.Tags = tb.Get()
 
 	agg.events = append(agg.events, &e)

--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -28,7 +28,7 @@ func generateContextKey(sample metrics.MetricSampleContext) ckey.ContextKey {
 	k := ckey.NewKeyGenerator()
 	tb := util.NewTagsBuilder()
 	sample.GetTags(tb)
-	return k.Generate(sample.GetName(), sample.GetHost(), tb.Get())
+	return k.Generate(sample.GetName(), sample.GetHost(), tb)
 }
 
 func TestCheckGaugeSampling(t *testing.T) {

--- a/pkg/aggregator/ckey/key.go
+++ b/pkg/aggregator/ckey/key.go
@@ -6,9 +6,6 @@
 package ckey
 
 import (
-	"sort"
-
-	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/twmb/murmur3"
 )
 
@@ -16,8 +13,7 @@ import (
 // aggregate metrics from a same context together.
 //
 // This implementation has been designed to remove all heap
-// allocations from the intake to reduce GC pressure on high
-// volumes.
+// allocations from the intake in order to reduce GC pressure on high volumes.
 //
 // Having int64/uint64 context keys mean that we will get better performances
 // from the Go runtime while using them as map keys. This is thanks to the fast-path
@@ -27,49 +23,106 @@ import (
 // Note that Agent <= 6.19.0 were using a 128 bits hash, we've switched
 // to 64 bits for better performances (map access) and because 128 bits were overkill
 // in the first place.
-// Note that we've benchmarked against xxhash64 which should be slightly faster,
-// but the Go compiler is not inlining xxhash sum methods whereas it is inlining
-// the murmur3 implementation, providing better performances overall.
-// Note that benchmarks against fnv1a did not provide better performances (no inlining).
+// Note that benchmarks against fnv1a did not provide better performances (no inlining)
+// nor did benchmarks with xxhash (slightly slower).
 type ContextKey uint64
 
-// KeyGenerator generates key
-// Not safe for concurrent usage
-type KeyGenerator struct {
-	buf []byte
-}
+// hashSetSize is the size selected for hashset used to deduplicate the tags
+// while generating the hash. This size has been selected to have space for
+// approximately 500 tags since it's not impacting much the performances,
+// even if the backend is truncating after 100 tags.
+const hashSetSize = 512
 
 // NewKeyGenerator creates a new key generator
 func NewKeyGenerator() *KeyGenerator {
 	return &KeyGenerator{
-		buf: make([]byte, 0, 1024),
+		seen:  make([]uint64, 512, 512),
+		empty: make([]uint64, 512, 512),
 	}
+}
+
+// KeyGenerator generates hash for the given name, hostname and tags.
+// The tags don't have to be sorted and duplicated tags will be ignored while
+// generating the hash.
+// Not safe for concurrent usage.
+type KeyGenerator struct {
+	// reused buffer to not create a uint64 on the stack every key generation
+	intb uint64
+
+	// seen is used as a hashset to deduplicate the tags when there is more than
+	// 16 and less than 512 tags.
+	seen []uint64
+	// empty is an empty hashset with all values set to 0, to reset `seen`
+	empty []uint64
+
+	// idx is used to deduplicate tags when there is less than 16 tags (faster than the
+	// hashset) or more than 512 tags (hashset has been allocated with 512 values max)
+	idx int
 }
 
 // Generate returns the ContextKey hash for the given parameters.
 // The tags array is sorted in place to avoid heap allocations.
 func (g *KeyGenerator) Generate(name, hostname string, tags []string) ContextKey {
-	g.buf = g.buf[:0]
+	// between two generations, we have to set the hash to something neutral, let's
+	// use this big value seed from the murmur3 implementations
+	g.intb = 0xc6a4a7935bd1e995
 
-	// Sort the tags in place. For typical tag slices, we use
-	// the in-place insertion sort to avoid heap allocations.
-	// We default to stdlib's sort package for longer slices.
-	// See `pkg/util/sort.go` for info on the threshold.
-	if len(tags) < util.InsertionSortThreshold {
-		util.InsertionSort(tags)
+	g.intb = g.intb ^ murmur3.StringSum64(name)
+	g.intb = g.intb ^ murmur3.StringSum64(hostname)
+
+	// there is two implementations used here to deduplicate the tags depending on how
+	// many tags we have to process:
+	//   -  16 < n < hashSetSize:	we use a hashset of `hashSetSize` values.
+	//   -  n < 16 or n > hashSetSize: we use a simple for loops, which is faster than
+	//                         	the hashset when there is less than 16 tags, and
+	//                         	we use it as fallback when there is more than `hashSetSize`
+	//                         	because it is the maximum size the allocated
+	//                         	hashset can handle.
+	if len(tags) > 16 && len(tags) < hashSetSize {
+		// reset the `seen` hashset.
+		// it copies `g.empty` instead of using make because it's faster
+		copy(g.seen, g.empty)
+		for i := range tags {
+			h := murmur3.StringSum64(tags[i])
+			j := h & (hashSetSize - 1) // address this hash into the hashset
+			for {
+				if g.seen[j] == 0 {
+					// not seen, we will add it to the hash
+					// TODO(remy): we may want to store the original bytes instead
+					// of the hash, even if the comparison would be slower, we would
+					// be able to avoid collisions here.
+					// See https://github.com/DataDog/datadog-agent/pull/8529#discussion_r661493647
+					g.seen[j] = h
+					g.intb = g.intb ^ h // add this tag into the hash
+					break
+				} else if g.seen[j] == h {
+					// already seen, we do not want to xor multiple times the same tag
+					break
+				} else {
+					// move 'right' in the hashset because there is already a value,
+					// in this bucket, which is not the one we're dealing with right now,
+					// we may have already seen this tag
+					j = (j + 1) & (hashSetSize - 1)
+				}
+			}
+		}
 	} else {
-		sort.Strings(tags)
+		g.idx = 0
+	OUTER:
+		for i := range tags {
+			h := murmur3.StringSum64(tags[i])
+			for j := 0; j < g.idx; j++ {
+				if g.seen[j] == h {
+					continue OUTER // we do not want to xor multiple times the same tag
+				}
+			}
+			g.intb = g.intb ^ h
+			g.seen[g.idx] = h
+			g.idx++
+		}
 	}
 
-	g.buf = append(g.buf, name...)
-	g.buf = append(g.buf, ',')
-	for i := 0; i < len(tags); i++ {
-		g.buf = append(g.buf, tags[i]...)
-		g.buf = append(g.buf, ',')
-	}
-	g.buf = append(g.buf, hostname...)
-
-	return ContextKey(murmur3.Sum64(g.buf))
+	return ContextKey(g.intb)
 }
 
 // Equals returns whether the two context keys are equal or not.

--- a/pkg/aggregator/ckey/key.go
+++ b/pkg/aggregator/ckey/key.go
@@ -6,6 +6,7 @@
 package ckey
 
 import (
+	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/twmb/murmur3"
 )
 
@@ -61,14 +62,15 @@ type KeyGenerator struct {
 }
 
 // Generate returns the ContextKey hash for the given parameters.
-// The tags array is sorted in place to avoid heap allocations.
-func (g *KeyGenerator) Generate(name, hostname string, tags []string) ContextKey {
+func (g *KeyGenerator) Generate(name, hostname string, tagsBuf *util.TagsBuilder) ContextKey {
 	// between two generations, we have to set the hash to something neutral, let's
 	// use this big value seed from the murmur3 implementations
 	g.intb = 0xc6a4a7935bd1e995
 
 	g.intb = g.intb ^ murmur3.StringSum64(name)
 	g.intb = g.intb ^ murmur3.StringSum64(hostname)
+
+	tags := tagsBuf.Get()
 
 	// there is two implementations used here to deduplicate the tags depending on how
 	// many tags we have to process:

--- a/pkg/aggregator/ckey/key.go
+++ b/pkg/aggregator/ckey/key.go
@@ -64,9 +64,9 @@ type KeyGenerator struct {
 	// 16 and less than 512 tags.
 	seen [hashSetSize]uint64
 	// seenIdx is the index of the tag stored in the hashset
-	seenIdx [hashSetSize]int
+	seenIdx [hashSetSize]int16
 	// empty is an empty hashset with all values set to `blank`, to reset `seenIdx`
-	empty [hashSetSize]int
+	empty [hashSetSize]int16
 
 	// idx is used to deduplicate tags when there is less than 16 tags (faster than the
 	// hashset) or more than 512 tags (hashset has been allocated with 512 values max)
@@ -112,7 +112,7 @@ func (g *KeyGenerator) Generate(name, hostname string, tagsBuf *util.TagsBuilder
 				if g.seenIdx[j] == blank {
 					// not seen, we will add it to the hash
 					g.seen[j] = h
-					g.seenIdx[j] = g.idx
+					g.seenIdx[j] = int16(g.idx)
 					g.intb = g.intb ^ h // add this tag into the hash
 					tags[g.idx] = tags[i]
 					g.idx++

--- a/pkg/aggregator/ckey/key.go
+++ b/pkg/aggregator/ckey/key.go
@@ -43,15 +43,13 @@ const blank = -1
 
 // NewKeyGenerator creates a new key generator
 func NewKeyGenerator() *KeyGenerator {
-	empty := make([]int, 0, hashSetSize)
-	for len(empty) < hashSetSize {
-		empty = append(empty, blank)
+	g := &KeyGenerator{}
+
+	for i := 0; i < len(g.empty); i++{
+		g.empty[i] = blank
 	}
-	return &KeyGenerator{
-		seen:    make([]uint64, hashSetSize),
-		seenIdx: make([]int, hashSetSize),
-		empty:   empty,
-	}
+
+	return g
 }
 
 // KeyGenerator generates hash for the given name, hostname and tags.
@@ -64,11 +62,11 @@ type KeyGenerator struct {
 
 	// seen is used as a hashset to deduplicate the tags when there is more than
 	// 16 and less than 512 tags.
-	seen []uint64
+	seen [hashSetSize]uint64
 	// seenIdx is the index of the tag stored in the hashset
-	seenIdx []int
+	seenIdx [hashSetSize]int
 	// empty is an empty hashset with all values set to `blank`, to reset `seenIdx`
-	empty []int
+	empty [hashSetSize]int
 
 	// idx is used to deduplicate tags when there is less than 16 tags (faster than the
 	// hashset) or more than 512 tags (hashset has been allocated with 512 values max)
@@ -106,7 +104,7 @@ func (g *KeyGenerator) Generate(name, hostname string, tagsBuf *util.TagsBuilder
 	} else if len(tags) > bruteforceSize {
 		// reset the `seen` hashset.
 		// it copies `g.empty` instead of using make because it's faster
-		copy(g.seenIdx, g.empty)
+		copy(g.seenIdx[:], g.empty[:])
 		for i := range tags {
 			h := murmur3.StringSum64(tags[i])
 			j := h & (hashSetSize - 1) // address this hash into the hashset

--- a/pkg/aggregator/ckey/key.go
+++ b/pkg/aggregator/ckey/key.go
@@ -34,6 +34,8 @@ type ContextKey uint64
 // while generating the hash. This size has been selected to have space for
 // approximately 500 tags since it's not impacting much the performances,
 // even if the backend is truncating after 100 tags.
+//
+// Must be a power of two.
 const hashSetSize = 512
 
 // bruteforceSize is the threshold number of tags below which a bruteforce algorithm is

--- a/pkg/aggregator/ckey/key_test.go
+++ b/pkg/aggregator/ckey/key_test.go
@@ -25,7 +25,7 @@ func TestGenerateReproductible(t *testing.T) {
 	generator := NewKeyGenerator()
 
 	firstKey := generator.Generate(name, hostname, tags)
-	assert.Equal(t, ContextKey(0x5a2b4635eb90c410), firstKey)
+	assert.Equal(t, ContextKey(0x558b3fdbeb2ae197), firstKey)
 
 	for n := 0; n < 10; n++ {
 		t.Run(fmt.Sprintf("iteration %d:", n), func(t *testing.T) {
@@ -36,7 +36,7 @@ func TestGenerateReproductible(t *testing.T) {
 
 	otherKey := generator.Generate("othername", hostname, tags)
 	assert.NotEqual(t, firstKey, otherKey)
-	assert.Equal(t, ContextKey(0x90352c032ca3bcd), otherKey)
+	assert.Equal(t, ContextKey(0x76fd4f64609a9375), otherKey)
 }
 
 func TestCompare(t *testing.T) {
@@ -47,6 +47,32 @@ func TestCompare(t *testing.T) {
 	assert.True(t, Equals(base, base))
 	assert.True(t, Equals(base, same))
 	assert.False(t, Equals(base, diff))
+}
+
+func TestTagsOrderAndDupsDontMatter(t *testing.T) {
+	assert := assert.New(t)
+
+	name := "metrics.to.test.hashing"
+	hostname := "hostname.localhost"
+	tags := []string{"bar", "foo", "key:value", "key:value2"}
+
+	generator := NewKeyGenerator()
+	key := generator.Generate(name, hostname, tags)
+
+	// change tags order, the generated key should be the same
+	tags[0], tags[1], tags[2], tags[3] = tags[3], tags[0], tags[1], tags[2]
+	key2 := generator.Generate(name, hostname, tags)
+	assert.Equal(key, key2, "order of tags should not matter")
+
+	// add a duplicated tag
+	tags = append(tags, "key:value", "foo")
+	key3 := generator.Generate(name, hostname, tags)
+	assert.Equal(key, key3, "duplicated tags should not matter")
+
+	// and now, completely change of the tag, the generated key should NOT be the same
+	tags[2] = "another:tag"
+	key4 := generator.Generate(name, hostname, tags)
+	assert.NotEqual(key, key4, "tags content should matter")
 }
 
 func genTags(count int) []string {

--- a/pkg/aggregator/ckey/key_test.go
+++ b/pkg/aggregator/ckey/key_test.go
@@ -72,6 +72,7 @@ func TestTagsOrderAndDupsDontMatter(t *testing.T) {
 	tagsBuf3 := util.NewTagsBuilderFromSlice(tags)
 	key3 := generator.Generate(name, hostname, tagsBuf3)
 	assert.Equal(key, key3, "duplicated tags should not matter")
+	assert.Equal(tagsBuf2.Get(), tagsBuf3.Get(), "duplicated tags should be removed from the buffer")
 
 	// and now, completely change of the tag, the generated key should NOT be the same
 	tags[2] = "another:tag"

--- a/pkg/aggregator/ckey/key_test.go
+++ b/pkg/aggregator/ckey/key_test.go
@@ -131,7 +131,7 @@ func TestTagsAreDedupedWhileGeneratingCKey(t *testing.T) {
 			}
 		}
 	}
-	t.Run("smallish", withSizeAndSeed(10, 200, 0x398192f0a9c0))
+	t.Run("smallish", withSizeAndSeed(3, 200, 0x398192f0a9c0))
 	t.Run("bigger", withSizeAndSeed(50, 100, 0x398192f0a9c0))
 	t.Run("huge", withSizeAndSeed(600, 10, 0x398192f0a9c0))
 }

--- a/pkg/aggregator/ckey/key_test.go
+++ b/pkg/aggregator/ckey/key_test.go
@@ -85,7 +85,7 @@ func genTags(count int, div int) ([]string, []string) {
 	var tags []string
 	uniqMap := make(map[string]struct{})
 	for i := 0; i < count; i++ {
-		tag := fmt.Sprintf("tag%d:value%d", i / div, i / div)
+		tag := fmt.Sprintf("tag%d:value%d", i/div, i/div)
 		tags = append(tags, tag)
 		uniqMap[tag] = struct{}{}
 	}

--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -44,8 +44,8 @@ func newContextResolver() *contextResolver {
 
 // trackContext returns the contextKey associated with the context of the metricSample and tracks that context
 func (cr *contextResolver) trackContext(metricSampleContext metrics.MetricSampleContext) ckey.ContextKey {
-	metricSampleContext.GetTags(cr.tagsBuffer)
-	contextKey := cr.generateContextKey(metricSampleContext, cr.tagsBuffer)
+	metricSampleContext.GetTags(cr.tagsBuffer)                              // tags here are not sorted and can contain duplicates
+	contextKey := cr.generateContextKey(metricSampleContext, cr.tagsBuffer) // the generator is ignoring duplicates (and doesn't mind the order)
 
 	if _, ok := cr.contextsByKey[contextKey]; !ok {
 		// making a copy of tags for the context since tagsBuffer

--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -30,8 +30,8 @@ type contextResolver struct {
 }
 
 // generateContextKey generates the contextKey associated with the context of the metricSample
-func (cr *contextResolver) generateContextKey(metricSampleContext metrics.MetricSampleContext, tags *util.TagsBuilder) ckey.ContextKey {
-	return cr.keyGenerator.Generate(metricSampleContext.GetName(), metricSampleContext.GetHost(), tags.Get())
+func (cr *contextResolver) generateContextKey(metricSampleContext metrics.MetricSampleContext) ckey.ContextKey {
+	return cr.keyGenerator.Generate(metricSampleContext.GetName(), metricSampleContext.GetHost(), cr.tagsBuffer)
 }
 
 func newContextResolver() *contextResolver {
@@ -44,8 +44,8 @@ func newContextResolver() *contextResolver {
 
 // trackContext returns the contextKey associated with the context of the metricSample and tracks that context
 func (cr *contextResolver) trackContext(metricSampleContext metrics.MetricSampleContext) ckey.ContextKey {
-	metricSampleContext.GetTags(cr.tagsBuffer)                              // tags here are not sorted and can contain duplicates
-	contextKey := cr.generateContextKey(metricSampleContext, cr.tagsBuffer) // the generator is ignoring duplicates (and doesn't mind the order)
+	metricSampleContext.GetTags(cr.tagsBuffer)               // tags here are not sorted and can contain duplicates
+	contextKey := cr.generateContextKey(metricSampleContext) // the generator will remove duplicates from cr.tagsBuffer (and doesn't mind the order)
 
 	if _, ok := cr.contextsByKey[contextKey]; !ok {
 		// making a copy of tags for the context since tagsBuffer

--- a/pkg/aggregator/context_resolver_test.go
+++ b/pkg/aggregator/context_resolver_test.go
@@ -156,3 +156,15 @@ func TestCountBasedExpireContexts(t *testing.T) {
 	require.Len(t, contextResolver.expireContexts(), 0)
 	require.Len(t, contextResolver.resolver.contextsByKey, 0)
 }
+
+func TestTagDeduplication(t *testing.T) {
+	resolver := newContextResolver()
+
+	ckey := resolver.trackContext(&metrics.MetricSample{
+		Name: "foo",
+		Tags: []string{"bar", "bar"},
+	})
+
+	assert.Equal(t, len(resolver.contextsByKey[ckey].Tags), 1)
+	assert.Equal(t, resolver.contextsByKey[ckey].Tags, []string{"bar"})
+}

--- a/pkg/aggregator/context_resolver_test.go
+++ b/pkg/aggregator/context_resolver_test.go
@@ -9,7 +9,7 @@ package aggregator
 
 import (
 	// stdlib
-	"sort"
+
 	"testing"
 
 	// 3p
@@ -31,7 +31,7 @@ func TestGenerateContextKey(t *testing.T) {
 	}
 
 	contextKey := generateContextKey(&mSample)
-	assert.Equal(t, ckey.ContextKey(0xdd892472f57d5cf1), contextKey)
+	assert.Equal(t, ckey.ContextKey(0xd28d2867c6dd822c), contextKey)
 }
 
 func TestTrackContext(t *testing.T) {
@@ -79,15 +79,12 @@ func TestTrackContext(t *testing.T) {
 
 	// When we look up the 2 keys, they return the correct contexts
 	context1 := contextResolver.contextsByKey[contextKey1]
-	sort.Strings(expectedContext1.Tags) // context tags are sorted
 	assert.Equal(t, expectedContext1, *context1)
 
 	context2 := contextResolver.contextsByKey[contextKey2]
-	sort.Strings(expectedContext2.Tags) // context tags are sorted
 	assert.Equal(t, expectedContext2, *context2)
 
 	context3 := contextResolver.contextsByKey[contextKey3]
-	sort.Strings(expectedContext3.Tags) // context tags are sorted
 	assert.Equal(t, expectedContext3, *context3)
 
 	unknownContextKey := ckey.ContextKey(0xffffffffffffffff)

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -18,11 +18,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/quantile"
+	"github.com/DataDog/datadog-agent/pkg/util"
 )
 
 func generateSerieContextKey(serie *metrics.Serie) ckey.ContextKey {
 	l := ckey.NewKeyGenerator()
-	return l.Generate(serie.Name, serie.Host, serie.Tags)
+	return l.Generate(serie.Name, serie.Host, util.NewTagsBuilderFromSlice(serie.Tags))
 }
 
 // TimeSampler
@@ -319,7 +320,7 @@ func TestSketch(t *testing.T) {
 					Ts:     0,
 				},
 			},
-			ContextKey: keyGen.Generate(ctx.Name, ctx.Host, ctx.Tags),
+			ContextKey: keyGen.Generate(ctx.Name, ctx.Host, util.NewTagsBuilderFromSlice(ctx.Tags)),
 		}, flushed[0])
 
 		_, flushed = sampler.flush(now)

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -691,13 +691,18 @@ func (s *Server) Stop() {
 	s.Started = false
 }
 
+// storeMetricStats stores stats on the given metric sample.
+// It is storing the stats of the sample as they are received: it means that if
+// a metric is received with duplicated tags, it will be stored this way here.
+// It can help troubleshooting clients with bad behaviors but it is different that
+// what will be outputted by the aggregator, which takes care of deduping the tags
+// to aggregate the metrics.
 func (s *Server) storeMetricStats(sample metrics.MetricSample) {
 	now := time.Now()
 	s.Debug.Lock()
 	defer s.Debug.Unlock()
 
 	// key
-	util.SortUniqInPlace(sample.Tags)
 	key := s.Debug.keyGen.Generate(sample.Name, "", sample.Tags)
 
 	// store

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -659,8 +659,8 @@ func TestDebugStats(t *testing.T) {
 	require.Equal(t, metric3.Count, uint64(1))
 
 	// test context correctness
-	require.Equal(t, metric4.Tags, "b c")
-	require.Equal(t, metric5.Tags, "b c")
+	require.Equal(t, metric4.Tags, "c b")
+	require.Equal(t, metric5.Tags, "c b")
 	require.Equal(t, hash4, hash5)
 }
 

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util"
 )
 
 // getAvailableUDPPort requests a random port number and makes sure it is available
@@ -608,11 +609,11 @@ func TestDebugStats(t *testing.T) {
 	sample3 := metrics.MetricSample{Name: "some.metric3", Tags: make([]string, 0)}
 	sample4 := metrics.MetricSample{Name: "some.metric4", Tags: []string{"b", "c"}}
 	sample5 := metrics.MetricSample{Name: "some.metric4", Tags: []string{"c", "b"}}
-	hash1 := keygen.Generate(sample1.Name, "", sample1.Tags)
-	hash2 := keygen.Generate(sample2.Name, "", sample2.Tags)
-	hash3 := keygen.Generate(sample3.Name, "", sample3.Tags)
-	hash4 := keygen.Generate(sample4.Name, "", sample4.Tags)
-	hash5 := keygen.Generate(sample5.Name, "", sample5.Tags)
+	hash1 := keygen.Generate(sample1.Name, "", util.NewTagsBuilderFromSlice(sample1.Tags))
+	hash2 := keygen.Generate(sample2.Name, "", util.NewTagsBuilderFromSlice(sample2.Tags))
+	hash3 := keygen.Generate(sample3.Name, "", util.NewTagsBuilderFromSlice(sample3.Tags))
+	hash4 := keygen.Generate(sample4.Name, "", util.NewTagsBuilderFromSlice(sample4.Tags))
+	hash5 := keygen.Generate(sample5.Name, "", util.NewTagsBuilderFromSlice(sample5.Tags))
 
 	// test ingestion and ingestion time
 	s.storeMetricStats(sample1)

--- a/pkg/metrics/metric_sample.go
+++ b/pkg/metrics/metric_sample.go
@@ -123,6 +123,9 @@ func addOrchestratorTags(cardinality collectors.TagCardinality, tb *util.TagsBui
 }
 
 // EnrichTags expend a tag list with origin detection tags
+// NOTE(remy): it is not needed to sort/dedup the tags anymore since after the
+// enrichment, the metric and its tags is sent to the context key generator, which
+// is taking care of deduping the tags while generating the context key.
 func EnrichTags(tb *util.TagsBuilder, originID string, k8sOriginID string, cardinality string) {
 	taggerCard := taggerCardinality(cardinality)
 
@@ -135,8 +138,6 @@ func EnrichTags(tb *util.TagsBuilder, originID string, k8sOriginID string, cardi
 			log.Tracef("Cannot get tags for entity %s: %s", k8sOriginID, err)
 		}
 	}
-
-	tb.SortUniq()
 }
 
 // GetTags returns the metric sample tags

--- a/pkg/metrics/test_helper.go
+++ b/pkg/metrics/test_helper.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/quantile"
+	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -162,7 +163,7 @@ func Makeseries(i int) SketchSeries {
 	}
 
 	gen := ckey.NewKeyGenerator()
-	ss.ContextKey = gen.Generate(ss.Name, ss.Host, ss.Tags)
+	ss.ContextKey = gen.Generate(ss.Name, ss.Host, util.NewTagsBuilderFromSlice(ss.Tags))
 
 	return ss
 }

--- a/pkg/util/tags_builder.go
+++ b/pkg/util/tags_builder.go
@@ -44,6 +44,11 @@ func (tb *TagsBuilder) Reset() {
 	tb.data = tb.data[0:0]
 }
 
+// Truncate retains first n tags in the buffer without discarding the internal buffer
+func (tb *TagsBuilder) Truncate(len int) {
+	tb.data = tb.data[0:len]
+}
+
 // Get returns the internal slice
 func (tb *TagsBuilder) Get() []string {
 	return tb.data

--- a/releasenotes/notes/faster-ckey-hash-8f30ad530cce348a.yaml
+++ b/releasenotes/notes/faster-ckey-hash-8f30ad530cce348a.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Implemented a faster context key/hash generator: it should result in a reduced CPU
+    usage and a smaller RAM footprint for DogStatsD servers receiving a lot of metrics.


### PR DESCRIPTION
### What does this PR do?

Bring back context key optimization from #8529.

Re-arrange tags during context key generation, so the resulting set is unique and can be used for context entry.

Add fallback for metrics with more than 512 tags.

More tests, check that tags are de-duplicated by each of three algorithms.

Properly handle hash collisions and zero hash value.

### Motivation

Less CPU and memory load.

### Describe how to test your changes

```
log_level: debug
log_payloads: true
dogstatsd_socket: /tmp/dsd.sock
```

Check that metrics with 1, 10, 50, 100, 600 tags are sent to the back-end.

```
python -c 'print("my.stuff:1|c|#"+",".join(["t%d" % x for x in range(600)]))' | nc -uU /tmp/dsd.sock
```

Send a new metric with duplicate tags (new metric to avoid re-using context); check that metric is sent to the backend with unique tags. Send the same metric with unique tags, should be the same metric sent to the back end.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
