### PR TITLE
[orchestrator] rework cache stats tmpl

### DIFF
--- a/pkg/clusteragent/orchestrator/status.go
+++ b/pkg/clusteragent/orchestrator/status.go
@@ -24,6 +24,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 )
 
+type stats struct {
+	orchestrator.CheckStats
+	NodeType  string
+	TotalHits int64
+	TotalMiss int64
+}
+
 // GetStatus returns status info for the orchestrator explorer.
 func GetStatus(ctx context.Context, apiCl kubernetes.Interface) map[string]interface{} {
 	status := make(map[string]interface{})
@@ -68,22 +75,33 @@ func GetStatus(ctx context.Context, apiCl kubernetes.Interface) map[string]inter
 
 	// get cache hits
 	cacheHitsJSON := []byte(expvar.Get("orchestrator-cache").String())
-	cacheHits := make(map[string]interface{})
+	cacheHits := make(map[string]int64)
 	json.Unmarshal(cacheHitsJSON, &cacheHits) //nolint:errcheck
 	status["CacheHits"] = cacheHits
 
 	// get cache Miss
 	cacheMissJSON := []byte(expvar.Get("orchestrator-sends").String())
-	cacheMiss := make(map[string]interface{})
+	cacheMiss := make(map[string]int64)
 	json.Unmarshal(cacheMissJSON, &cacheMiss) //nolint:errcheck
 	status["CacheMiss"] = cacheMiss
+	cacheStats := make(map[string]stats)
 
 	// get cache efficiency
 	for _, node := range orchestrator.NodeTypes() {
 		if value, found := orchestrator.KubernetesResourceCache.Get(orchestrator.BuildStatsKey(node)); found {
-			status[node.String()+"sStats"] = value
+			orcStats := value.(orchestrator.CheckStats)
+			totalMiss := cacheMiss[orcStats.String()+"s"]
+			totalHit := cacheHits[orcStats.String()+"s"]
+			s := stats{
+				CheckStats: orcStats,
+				NodeType:   orcStats.String(),
+				TotalHits:  totalHit,
+				TotalMiss:  totalMiss,
+			}
+			cacheStats[node.String()+"sStats"] = s
 		}
 	}
+	status["CacheInformation"] = cacheStats
 
 	// get options
 	if config.Datadog.GetBool("orchestrator_explorer.container_scrubbing.enabled") {

--- a/pkg/status/templates/orchestrator.tmpl
+++ b/pkg/status/templates/orchestrator.tmpl
@@ -50,26 +50,10 @@ Orchestrator Explorer
   Cache Stats
   ===========
     Elements in the cache: {{.CacheNumber}}
-    Pods:
-      Last Run: (Hits: {{.PodsStats.CacheHits}} Miss: {{.PodsStats.CacheMiss}}) | Total: (Hits: {{.CacheHits.Pods}} Miss: {{.CacheMiss.Pods}})
-    Deployments:
-      Last Run: (Hits: {{.DeploymentsStats.CacheHits}} Miss: {{.DeploymentsStats.CacheMiss}}) | Total: (Hits: {{.CacheHits.Deployments}} Miss: {{.CacheMiss.Deployments}})
-    ReplicaSets:
-      Last Run: (Hits: {{.ReplicaSetsStats.CacheHits}} Miss: {{.ReplicaSetsStats.CacheMiss}}) | Total: (Hits: {{.CacheHits.ReplicaSets}} Miss: {{.CacheMiss.ReplicaSets}})
-    Services:
-      Last Run: (Hits: {{.ServicesStats.CacheHits}} Miss: {{.ServicesStats.CacheMiss}}) | Total: (Hits: {{.CacheHits.Services}} Miss: {{.CacheMiss.Services}})
-    Nodes:
-      Last Run: (Hits: {{.NodesStats.CacheHits}} Miss: {{.NodesStats.CacheMiss}}) | Total: (Hits: {{.CacheHits.Nodes}} Miss: {{.CacheMiss.Nodes}})
-    Cluster:
-      Last Run: (Hits: {{.ClustersStats.CacheHits}} Miss: {{.ClustersStats.CacheMiss}}) | Total: (Hits: {{.CacheHits.Clusters}} Miss: {{.CacheMiss.Clusters}})
-    Job:
-      Last Run: (Hits: {{.JobsStats.CacheHits}} Miss: {{.JobsStats.CacheMiss}}) | Total: (Hits: {{.CacheHits.Jobs}} Miss: {{.CacheMiss.Jobs}})
-    CronJob:
-      Last Run: (Hits: {{.CronJobsStats.CacheHits}} Miss: {{.CronJobsStats.CacheMiss}}) | Total: (Hits: {{.CacheHits.CronJobs}} Miss: {{.CacheMiss.CronJobs}})
-    DaemonSets:
-      Last Run: (Hits: {{.DaemonSetsStats.CacheHits}} Miss: {{.DaemonSetsStats.CacheMiss}}) | Total: (Hits: {{.CacheHits.DaemonSets}} Miss: {{.CacheMiss.DaemonSets}})
-    StatefulSets:
-      Last Run: (Hits: {{.StatefulSetsStats.CacheHits}} Miss: {{.StatefulSetsStats.CacheMiss}}) | Total: (Hits: {{.CacheHits.StatefulSets}} Miss: {{.CacheMiss.StatefulSets}})
+{{range $index, $element := .CacheInformation}}
+    {{ $element.NodeType }}
+      Last Run: (Hits: {{$element.CacheHits}} Miss: {{$element.CacheMiss}}) | Total: (Hits: {{$element.TotalHits}} Miss: {{$element.TotalMiss}})
+{{end}}
 {{else}}
 {{- if .LeaderName }}
   Status: Follower, cluster agent leader is: {{ .LeaderName }}


### PR DESCRIPTION
### What does this PR do?

Refactor the cache stats to be dynamically generated

### Motivation

copy paste 

### Additional Notes

**Note**: If we merge this we need to change: https://github.com/DataDog/datadog-agent/pull/8636 or other way around

### Describe how to test your changes

current output 
```
=====================
Orchestrator Explorer
=====================
  Collection Status: The collection is at least partially running since the cache has been populated.
  Cluster Name: nammn
  Cluster ID: 9e99cefc-06cb-44a7-a0d5-69aaf0ff5a47

  ======================
  Orchestrator Endpoints
  ======================
  https://orchestrator.datadoghq.com - API Key ending with: f975c

  ===========
  Cache Stats
  ===========
    Elements in the cache: 27

    Cluster
      Last Run: (Hits: 1 Miss: 0) | Total: (Hits: 20 Miss: 2)

    CronJob
      Last Run: (Hits: 1 Miss: 0) | Total: (Hits: 20 Miss: 2)

    DaemonSet
      Last Run: (Hits: 1 Miss: 0) | Total: (Hits: 20 Miss: 2)

    Deployment
      Last Run: (Hits: 2 Miss: 0) | Total: (Hits: 40 Miss: 4)

    Job
      Last Run: (Hits: 5 Miss: 0) | Total: (Hits: 100 Miss: 10)

    Node
      Last Run: (Hits: 1 Miss: 0) | Total: (Hits: 18 Miss: 4)

    Pod
      Last Run: (Hits: 1 Miss: 0) | Total: (Hits: 20 Miss: 2)

    ReplicaSet
      Last Run: (Hits: 2 Miss: 0) | Total: (Hits: 40 Miss: 4)

    Service
      Last Run: (Hits: 3 Miss: 0) | Total: (Hits: 60 Miss: 6)
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
