### PR TITLE
[Gitlab] Update kitchen CentOS 6 image

### DIFF
--- a/.gitlab/kitchen_testing/centos.yml
+++ b/.gitlab/kitchen_testing/centos.yml
@@ -14,7 +14,7 @@
 .kitchen_os_centos_all_non_fips:
   variables:
     KITCHEN_PLATFORM: "centos"
-    KITCHEN_OSVERS: "centos-69,centos-77,rhel-81"
+    KITCHEN_OSVERS: "centos-610,centos-77,rhel-81"
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - cd $DD_AGENT_TESTING_DIR
@@ -23,7 +23,7 @@
 .kitchen_os_centos_6_7_non_fips:
   variables:
     KITCHEN_PLATFORM: "centos"
-    KITCHEN_OSVERS: "centos-69,centos-77"
+    KITCHEN_OSVERS: "centos-610,centos-77"
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - cd $DD_AGENT_TESTING_DIR

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -2,7 +2,7 @@
     "centos" : {
         "azure" : {
             "x86_64": {
-                "centos-69": "urn,OpenLogic:CentOS:6.9:6.9.20180530",
+                "centos-610": "urn,OpenLogic:CentOS:6.10:6.10.2020042900",
                 "centos-76": "urn,OpenLogic:CentOS:7.6:7.6.201909120",
                 "centos-77": "urn,OpenLogic:CentOS:7.7:7.7.201912090",
                 "rhel-81": "urn,RedHat:RHEL:8.1:8.1.2021040910"


### PR DESCRIPTION
### What does this PR do?

Move from CentOS 6.9 image to CentOS 6.10 image

### Motivation

CentOS 6.9 image is gone.

### Additional Notes

Not sure if we need to backport this?

### Describe how to test your changes

Should be a no-op.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
