### PR TITLE
[Dependabot] Exclude nikos dependency

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -27,6 +27,7 @@ updates:
       - dependency-name: github.com/prometheus/client_golang
       - dependency-name: github.com/spf13/cast
       - dependency-name: github.com/ugorji/go
+      - dependency-name: github.com/DataDog/nikos
       # Ignore internal modules
       - dependency-name: github.com/DataDog/datadog-agent/*
     schedule:


### PR DESCRIPTION
### What does this PR do?

Follow up #8773

### Motivation

Ignore nikos dep

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
