### PR TITLE
Always run feature detection on config.load

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1042,6 +1042,15 @@ func findUnknownKeys(config Config) []string {
 func load(config Config, origin string, loadSecret bool) (*Warnings, error) {
 	warnings := Warnings{}
 
+	// Feature detection running in a defer func as it always  need to run (whether config load has been successful or not)
+	// Because some Agents (e.g. trace-agent) will run even if config file does not exist
+	defer func() {
+		// Environment feature detection needs to run before applying override funcs
+		// as it may provide such overrides
+		DetectFeatures()
+		applyOverrideFuncs(config)
+	}()
+
 	if err := config.ReadInConfig(); err != nil {
 		if errors.Is(err, os.ErrPermission) {
 			log.Warnf("Error loading config: %v (check config file permissions for dd-agent user)", err)
@@ -1074,10 +1083,6 @@ func load(config Config, origin string, loadSecret bool) (*Warnings, error) {
 
 	loadProxyFromEnv(config)
 	SanitizeAPIKeyConfig(config, "api_key")
-	// Environment feature detection needs to run before applying override funcs
-	// as it may provide such overrides
-	DetectFeatures()
-	applyOverrideFuncs(config)
 	// setTracemallocEnabled *must* be called before setNumWorkers
 	warnings.TraceMallocEnabledWithPy2 = setTracemallocEnabled(config)
 	setNumWorkers(config)


### PR DESCRIPTION
### What does this PR do?

If `config.load` fails, we do not run feature detection mechanism, which can cause issues later. One valid use case is running an Agent without `datadog.yaml` file (`trace-agent` for instance).

### Motivation

Bug

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Run the `trace-agent` locally without `/opt/datadog-agent/etc/datadog.yaml` file, it should not trigger a panic and you should see the log line: `Features detected from environment: ....`

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
