### PR TITLE
[Tagger] Run pulling, store, and bookkeeping on separate goroutines

### DIFF
--- a/pkg/tagger/collectors/kubernetes_metadata_mapper.go
+++ b/pkg/tagger/collectors/kubernetes_metadata_mapper.go
@@ -57,6 +57,12 @@ func (c *KubeMetadataCollector) getTagInfos(pods []*kubelet.Pod) []*TagInfo {
 		// result and avoid repeated calls to the DCA.
 		if po.Spec.HostNetwork == true || !kubelet.IsPodReady(po) {
 			for _, container := range po.Status.Containers {
+				// Ignore containers that haven't been created
+				// yet and have no ID.
+				if container.ID == "" {
+					continue
+				}
+
 				entityID, err := kubelet.KubeContainerIDToTaggerEntityID(container.ID)
 				if err != nil {
 					log.Warnf("Unable to parse container: %s", err)

--- a/releasenotes/notes/no_async_for_tagger-0e1f1c582f8fd61b.yaml
+++ b/releasenotes/notes/no_async_for_tagger-0e1f1c582f8fd61b.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    In case of internal problem to the tagger, flag the `tagger-pull` and
+    `tagger-store` components as unhealthy (in the output of `agent health`)
+    instead of leaking goroutines.


### PR DESCRIPTION
### What does this PR do?

This re-introduces the changes in #8511 but reverted in #8736 since it
caused the tagger to deadlock, since the change made the tagger
effectively run on a single goroutine. All it takes is for another
goroutine to cause a pull while the tagger is doing its own periodic
pull, and the tagger will deadlock.

To prevent the deadlocks, and at the same time prevent the leaking of
zombie goroutines originally intended in #8511, we're splitting the
tagger into three separate goroutines: one for general bookkeeping, one
for periodic pulls, and one for the store itself.

### Describe how to test your changes

Under normal operation, the tagger should still work (as in, `tagger-pull` and `tagger-store` are marked as healthy in `agent health`). If you really wanna try to break this under similar circumstances where the deadlock issue was originally found, run the tagger in a cluster with a lot of pod churn (such as cronjobs) and look out for health check failures.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
