### PR TITLE
[Serverless] remove files which include big libraries from the serverless build

### DIFF
--- a/pkg/autodiscovery/listeners/common.go
+++ b/pkg/autodiscovery/listeners/common.go
@@ -1,9 +1,9 @@
-// +build !serverless
-
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017-present Datadog, Inc.
+
+// +build !serverless
 
 package listeners
 

--- a/pkg/autodiscovery/listeners/common.go
+++ b/pkg/autodiscovery/listeners/common.go
@@ -1,3 +1,5 @@
+// +build !serverless
+
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).

--- a/pkg/snmp/traps/testing.go
+++ b/pkg/snmp/traps/testing.go
@@ -1,9 +1,9 @@
-// +build !serverless
-
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2020-present Datadog, Inc.
+
+// +build !serverless
 
 package traps
 

--- a/pkg/snmp/traps/testing.go
+++ b/pkg/snmp/traps/testing.go
@@ -1,3 +1,5 @@
+// +build !serverless
+
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).


### PR DESCRIPTION
### What does this PR do?

Add build tags to prevent 
- k8s.io/api/core/v1
- github.com/gosnmp/gosnmp

from being imported in the Serverless extension.

|      | Size (in bytes) |
| ----------- | ----------- |
| Baseline      | 31076352       |
| With this PR   | 25169920        |

Improvement : 19%

This results in the extension - no layer -  starting about 30ms faster.

<img width="1102" alt="Screen Shot 2021-08-09 at 11 15 33 AM" src="https://user-images.githubusercontent.com/864493/128731206-fa8e9d88-28d9-4909-9838-25f8163542bd.png">

### Motivation

Decrease cold start time


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
