### PR TITLE
[windows] Update signing certificate hash in kitchen tests

### DIFF
--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -393,7 +393,7 @@ def is_file_signed(fullpath)
   puts "checking file #{fullpath}"
   expect(File).to exist(fullpath)
   output = `powershell -command get-authenticodesignature -FilePath '#{fullpath}'`
-  signature_hash = "21FE8679BDFB16B879A87DF228003758B62ABF5E"
+  signature_hash = "748A3B5C681AF45FAC149A76FE59E7CBBDFF058C"
   if not output.include? signature_hash
     return false
   end


### PR DESCRIPTION
### What does this PR do?

Updates the signature hash used when verifying Windows Agent binary signatures.

### Motivation

We changed the signing certificate used to sign the Windows Agent.

### Describe how to test your changes

Check that Windows kitchen tests pass.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
