### PR TITLE
[tasks] Improve error message when workflow rules are not matched

### DIFF
--- a/tasks/libs/pipeline_tools.py
+++ b/tasks/libs/pipeline_tools.py
@@ -11,6 +11,10 @@ from .common.user_interactions import yes_no_question
 PIPELINE_FINISH_TIMEOUT_SEC = 3600 * 5
 
 
+class FilteredOutException(Exception):
+    pass
+
+
 def get_running_pipelines_on_same_ref(
     gitlab, project, ref, sha=None,
 ):
@@ -107,6 +111,10 @@ def trigger_agent_pipeline(
 
     if result and "id" in result:
         return result["id"]
+
+    if result and "filtered out by workflow rules" in result.get("message", {}).get("base", [""])[0]:
+        raise FilteredOutException
+
     raise RuntimeError("Invalid response from Gitlab: {}".format(result))
 
 


### PR DESCRIPTION
### What does this PR do?

Improve error message for `pipeline.run` task.

### Motivation

Make it clearer what went wrong.

### Describe how to test your changes

Run something like

```
inv pipeline.run --git-ref "7.29.1-beta-ibm-i.3" --release-version-6 "" --release-version-7 "7.29.1-beta-ibm-i.3" --repo-branch beta
```

and check the error message.

Run 

```
inv pipeline.run
```

and check that everything works.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
