### PR TITLE
[backport] [windows] Update signing certificate hash in kitchen tests

### DIFF
--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -393,7 +393,7 @@ def is_file_signed(fullpath)
   puts "checking file #{fullpath}"
   expect(File).to exist(fullpath)
   output = `powershell -command get-authenticodesignature -FilePath '#{fullpath}'`
-  signature_hash = "21FE8679BDFB16B879A87DF228003758B62ABF5E"
+  signature_hash = "748A3B5C681AF45FAC149A76FE59E7CBBDFF058C"
   if not output.include? signature_hash
     return false
   end


### PR DESCRIPTION
### What does this PR do?

Backport of #8838.
Updates the signature hash used when verifying Windows Agent binary signatures.

### Motivation

Fix kitchen tests.
