### PR TITLE
[CSPM] allow to execute fallback when there 1 process/file resource instance

### DIFF
--- a/pkg/compliance/checks/file_check.go
+++ b/pkg/compliance/checks/file_check.go
@@ -85,6 +85,11 @@ func resolveFile(_ context.Context, e env.Env, ruleID string, res compliance.Res
 		return nil, fmt.Errorf("no files found for file check %q", file.Path)
 	}
 
+	// NOTE(safchain) workaround to allow fallback on all this resource if there is only one file
+	if len(instances) == 1 {
+		return instances[0].(*_resolvedInstance), nil
+	}
+
 	return newResolvedInstances(instances), nil
 }
 

--- a/pkg/compliance/checks/process_check.go
+++ b/pkg/compliance/checks/process_check.go
@@ -62,8 +62,9 @@ func resolveProcess(_ context.Context, e env.Env, id string, res compliance.Reso
 		instances = append(instances, newResolvedInstance(instance, strconv.Itoa(int(mp.Pid)), "process"))
 	}
 
+	// NOTE(safchain) workaround to allow fallback on all this resource if there is only one file
 	if len(instances) == 1 {
-		return newResolvedInstance(instances[0], instances[0].ID(), instances[0].Type()), nil
+		return instances[0].(*_resolvedInstance), nil
 	}
 
 	return newResolvedInstances(instances), nil


### PR DESCRIPTION
### What does this PR do?

This PR allows to execute a fallback if the resource instances equals to 1. Before this fix it was possible to fallback on file resource type.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
