### PR TITLE
[Serverless] skip hostname resolution in Serverless context

### DIFF
--- a/pkg/serverless/trace/trace.go
+++ b/pkg/serverless/trace/trace.go
@@ -31,7 +31,7 @@ type LoadConfig struct {
 
 // Load loads the config from a file path
 func (l *LoadConfig) Load() (*config.AgentConfig, error) {
-	return config.Load(l.Path)
+	return config.LoadServerless(l.Path)
 }
 
 // Start starts the agent

--- a/pkg/serverless/trace/trace_test.go
+++ b/pkg/serverless/trace/trace_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/stretchr/testify/assert"
@@ -63,4 +64,21 @@ func TestStartEnabledTrueValidConfigValidPath(t *testing.T) {
 	assert.NotNil(t, agent.Get())
 	assert.NotNil(t, agent.cancel)
 
+}
+
+func TestLoadConfigShouldBeFast(t *testing.T) {
+	timeout := time.After(100 * time.Millisecond)
+	done := make(chan bool)
+	go func() {
+		var agent = &ServerlessTraceAgent{}
+		agent.Start(true, &LoadConfig{Path: "./testdata/valid.yml"})
+		defer agent.Stop()
+		done <- true
+	}()
+
+	select {
+	case <-timeout:
+		t.Fatal("Tracer config load/validation is too long")
+	case <-done:
+	}
 }

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -326,7 +326,7 @@ func Load(path string) (*AgentConfig, error) {
 }
 
 // LoadServerless see Load comment
-// This will skip hostname resolution as hostname need to be empty in a serverless context
+// This will skip hostname resolution as hostname is empty in a serverless context
 func LoadServerless(path string) (*AgentConfig, error) {
 	return load(path, false)
 }


### PR DESCRIPTION
### What does this PR do?

Skip hostname resolution in serverless context when loading and validation the agent config

### Motivation

Extension start time / cold start improvements

### Describe how to test your changes

Unit testing 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
