### PR TITLE
[process-agent] Better process collection on Windows

### DIFF
--- a/cmd/process-agent/collector_api_test.go
+++ b/cmd/process-agent/collector_api_test.go
@@ -163,7 +163,7 @@ func TestRTProcMessageNotRetried(t *testing.T) {
 	}
 
 	check := &testCheck{
-		name: checks.RTProcess.Name(),
+		name: checks.Process.RealTimeName(),
 		data: [][]process.MessageBody{{m}},
 	}
 
@@ -236,7 +236,7 @@ func TestQueueSpaceNotAvailable(t *testing.T) {
 	}
 
 	check := &testCheck{
-		name: checks.RTProcess.Name(),
+		name: checks.Process.RealTimeName(),
 		data: [][]process.MessageBody{{m}},
 	}
 
@@ -266,7 +266,7 @@ func TestQueueSpaceReleased(t *testing.T) {
 	}
 
 	check := &testCheck{
-		name: checks.RTProcess.Name(),
+		name: checks.Process.RealTimeName(),
 		data: [][]process.MessageBody{{m1}, {m2}},
 	}
 

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -366,7 +366,15 @@ func runCheckAsRealTime(cfg *config.AgentConfig, ch checks.CheckWithRealTime) er
 		RunStandard: true,
 		RunRealTime: true,
 	}
-	if _, err := ch.RunWithOptions(cfg, 0, options); err != nil {
+	var (
+		groupID     int32
+		nextGroupID = func() int32 {
+			groupID++
+			return groupID
+		}
+	)
+
+	if _, err := ch.RunWithOptions(cfg, nextGroupID, options); err != nil {
 		return fmt.Errorf("collection error: %s", err)
 	}
 
@@ -374,7 +382,7 @@ func runCheckAsRealTime(cfg *config.AgentConfig, ch checks.CheckWithRealTime) er
 
 	printResultsBanner(ch.RealTimeName())
 
-	run, err := ch.RunWithOptions(cfg, 1, options)
+	run, err := ch.RunWithOptions(cfg, nextGroupID, options)
 	if err != nil {
 		return fmt.Errorf("collection error: %s", err)
 	}

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -363,7 +363,7 @@ func runCheck(cfg *config.AgentConfig, ch checks.Check) error {
 
 func runCheckAsRealTime(cfg *config.AgentConfig, ch checks.CheckWithRealTime) error {
 	options := checks.RunOptions{
-		RunRegular:  true,
+		RunStandard: true,
 		RunRealTime: true,
 	}
 	if _, err := ch.RunWithOptions(cfg, 0, options); err != nil {
@@ -374,17 +374,12 @@ func runCheckAsRealTime(cfg *config.AgentConfig, ch checks.CheckWithRealTime) er
 
 	printResultsBanner(ch.RealTimeName())
 
-	runs, err := ch.RunWithOptions(cfg, 1, options)
+	run, err := ch.RunWithOptions(cfg, 1, options)
 	if err != nil {
 		return fmt.Errorf("collection error: %s", err)
 	}
 
-	for _, r := range runs {
-		if r.CheckName == ch.RealTimeName() {
-			return printResults(r.Messages)
-		}
-	}
-	return fmt.Errorf("collection error - missing results for: %s", ch.RealTimeName())
+	return printResults(run.RealTime)
 }
 
 func printResultsBanner(name string) {

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -374,6 +374,8 @@ func runCheckAsRealTime(cfg *config.AgentConfig, ch checks.CheckWithRealTime) er
 		}
 	)
 
+	// We need to run the check twice in order to initialize the stats
+	// Rate calculations rely on having two datapoints
 	if _, err := ch.RunWithOptions(cfg, nextGroupID, options); err != nil {
 		return fmt.Errorf("collection error: %s", err)
 	}

--- a/cmd/system-probe/modules/process.go
+++ b/cmd/system-probe/modules/process.go
@@ -39,7 +39,7 @@ var Process = module.Factory{
 
 var _ module.Module = &process{}
 
-type process struct{ probe *procutil.Probe }
+type process struct{ probe procutil.Probe }
 
 // GetStats returns stats for the module
 func (t *process) GetStats() map[string]interface{} {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -864,6 +864,7 @@ func InitConfig(config Config) {
 	config.SetKnown("process_config.strip_proc_arguments")
 	config.SetKnown("process_config.windows.args_refresh_interval")
 	config.SetKnown("process_config.windows.add_new_args")
+	config.SetKnown("process_config.windows.use_perf_counters")
 	config.SetKnown("process_config.additional_endpoints.*")
 	config.SetKnown("process_config.container_source")
 	config.SetKnown("process_config.intervals.connections")

--- a/pkg/process/checks/allprocesses_fallback.go
+++ b/pkg/process/checks/allprocesses_fallback.go
@@ -7,7 +7,7 @@ import (
 	"github.com/DataDog/gopsutil/process"
 )
 
-func getAllProcesses(probe *procutil.Probe, collectStats bool) (map[int32]*procutil.Process, error) {
+func getAllProcesses(probe procutil.Probe, collectStats bool) (map[int32]*procutil.Process, error) {
 	procs, err := process.AllProcesses()
 	if err != nil {
 		return nil, err
@@ -15,7 +15,7 @@ func getAllProcesses(probe *procutil.Probe, collectStats bool) (map[int32]*procu
 	return procutil.ConvertAllFilledProcesses(procs), nil
 }
 
-func getAllProcStats(probe *procutil.Probe, pids []int32) (map[int32]*procutil.Stats, error) {
+func getAllProcStats(probe procutil.Probe, pids []int32) (map[int32]*procutil.Stats, error) {
 	procs, err := process.AllProcesses()
 	if err != nil {
 		return nil, err

--- a/pkg/process/checks/allprocesses_linux.go
+++ b/pkg/process/checks/allprocesses_linux.go
@@ -8,10 +8,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
 
-func getAllProcesses(probe *procutil.Probe, collectStats bool) (map[int32]*procutil.Process, error) {
+func getAllProcesses(probe procutil.Probe, collectStats bool) (map[int32]*procutil.Process, error) {
 	return probe.ProcessesByPID(time.Now(), collectStats)
 }
 
-func getAllProcStats(probe *procutil.Probe, pids []int32) (map[int32]*procutil.Stats, error) {
+func getAllProcStats(probe procutil.Probe, pids []int32) (map[int32]*procutil.Stats, error) {
 	return probe.StatsForPIDs(pids, time.Now())
 }

--- a/pkg/process/checks/allprocesses_windows.go
+++ b/pkg/process/checks/allprocesses_windows.go
@@ -29,6 +29,7 @@ var (
 
 	// XXX: Cross-check state is stored globally so the checks are not thread-safe.
 	cachedProcesses = map[uint32]*cachedProcess{}
+	// TODO: remove locking here
 	// cacheProcessesMutex is a mutex to protect cachedProcesses from being accessed concurrently.
 	// So far this is the case for Process check and RTProcess check
 	// TODO: revisit cacheProcesses usage so that we don't need to lock the whole getAllProcesses()
@@ -36,21 +37,6 @@ var (
 	checkCount          = 0
 	haveWarnedNoArgs    = false
 )
-
-type SystemProcessInformation struct {
-	NextEntryOffset   uint64
-	NumberOfThreads   uint64
-	Reserved1         [48]byte
-	Reserved2         [3]byte
-	UniqueProcessID   uintptr
-	Reserved3         uintptr
-	HandleCount       uint64
-	Reserved4         [4]byte
-	Reserved5         [11]byte
-	PeakPagefileUsage uint64
-	PrivatePageCount  uint64
-	Reserved6         [6]uint64
-}
 
 type IO_COUNTERS struct {
 	ReadOperationCount  uint64

--- a/pkg/process/checks/allprocesses_windows.go
+++ b/pkg/process/checks/allprocesses_windows.go
@@ -34,8 +34,8 @@ type IO_COUNTERS struct {
 	OtherTransferCount  uint64
 }
 
-func getAllProcesses(probe procutil.Probe) (map[int32]*procutil.Process, error) {
-	return probe.ProcessesByPID(time.Now())
+func getAllProcesses(probe procutil.Probe, collectStats bool) (map[int32]*procutil.Process, error) {
+	return probe.ProcessesByPID(time.Now(), collectStats)
 }
 
 func getAllProcStats(probe procutil.Probe, pids []int32) (map[int32]*procutil.Stats, error) {

--- a/pkg/process/checks/allprocesses_windows.go
+++ b/pkg/process/checks/allprocesses_windows.go
@@ -66,19 +66,19 @@ func getProcessIoCounters(h windows.Handle, counters *IO_COUNTERS) (err error) {
 	return nil
 }
 
-type legacyWindowsProbe struct {
+type windowsToolhelpProbe struct {
 	cachedProcesses map[uint32]*cachedProcess
 }
 
-func newLegacyWindowsProbe() procutil.Probe {
-	return &legacyWindowsProbe{
+func newWindowsToolhelpProbe() procutil.Probe {
+	return &windowsToolhelpProbe{
 		cachedProcesses: map[uint32]*cachedProcess{},
 	}
 }
 
-func (p *legacyWindowsProbe) Close() {}
+func (p *windowsToolhelpProbe) Close() {}
 
-func (p *legacyWindowsProbe) StatsForPIDs(pids []int32, now time.Time) (map[int32]*procutil.Stats, error) {
+func (p *windowsToolhelpProbe) StatsForPIDs(pids []int32, now time.Time) (map[int32]*procutil.Stats, error) {
 	procs, err := p.ProcessesByPID(now)
 	if err != nil {
 		return nil, err
@@ -91,11 +91,11 @@ func (p *legacyWindowsProbe) StatsForPIDs(pids []int32, now time.Time) (map[int3
 }
 
 // StatsWithPermByPID is currently not implemented in non-linux environments
-func (p *legacyWindowsProbe) StatsWithPermByPID(pids []int32) (map[int32]*procutil.StatsWithPerm, error) {
-	return nil, fmt.Errorf("legacyWindowsProbe: StatsWithPermByPID is not implemented")
+func (p *windowsToolhelpProbe) StatsWithPermByPID(pids []int32) (map[int32]*procutil.StatsWithPerm, error) {
+	return nil, fmt.Errorf("windowsToolhelpProbe: StatsWithPermByPID is not implemented")
 }
 
-func (p *legacyWindowsProbe) ProcessesByPID(now time.Time, collectStats bool) (map[int32]*procutil.Process, error) {
+func (p *windowsToolhelpProbe) ProcessesByPID(now time.Time, collectStats bool) (map[int32]*procutil.Process, error) {
 	// make sure we get the consistent snapshot by using the same OS thread
 	runtime.LockOSThread()
 	defer runtime.UnlockOSThread()

--- a/pkg/process/checks/allprocesses_windows.go
+++ b/pkg/process/checks/allprocesses_windows.go
@@ -79,7 +79,7 @@ func newWindowsToolhelpProbe() procutil.Probe {
 func (p *windowsToolhelpProbe) Close() {}
 
 func (p *windowsToolhelpProbe) StatsForPIDs(pids []int32, now time.Time) (map[int32]*procutil.Stats, error) {
-	procs, err := p.ProcessesByPID(now)
+	procs, err := p.ProcessesByPID(now, true)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/process/checks/checks.go
+++ b/pkg/process/checks/checks.go
@@ -32,7 +32,7 @@ type RunResult struct {
 type CheckWithRealTime interface {
 	Check
 	RealTimeName() string
-	RunWithOptions(cfg *config.AgentConfig, groupID int32, options RunOptions) (*RunResult, error)
+	RunWithOptions(cfg *config.AgentConfig, nextGroupID func() int32, options RunOptions) (*RunResult, error)
 }
 
 // All is a list of all runnable checks. Putting a check in here does not guarantee it will be run,

--- a/pkg/process/checks/checks.go
+++ b/pkg/process/checks/checks.go
@@ -16,12 +16,30 @@ type Check interface {
 	Run(cfg *config.AgentConfig, groupID int32) ([]model.MessageBody, error)
 }
 
+// RunOptions provides run options for checks
+type RunOptions struct {
+	RunRegular  bool
+	RunRealTime bool
+}
+
+// RunResult is a result for a check run
+type RunResult struct {
+	CheckName string
+	Messages  []model.MessageBody
+}
+
+// CheckWithRealTime provides an extended interface for running composite checks
+type CheckWithRealTime interface {
+	Check
+	RealTimeName() string
+	RunWithOptions(cfg *config.AgentConfig, groupID int32, options RunOptions) ([]RunResult, error)
+}
+
 // All is a list of all runnable checks. Putting a check in here does not guarantee it will be run,
 // it just guarantees that the collector will be able to find the check.
 // If you want to add a check you MUST register it here.
 var All = []Check{
 	Process,
-	RTProcess,
 	Container,
 	RTContainer,
 	Connections,

--- a/pkg/process/checks/checks.go
+++ b/pkg/process/checks/checks.go
@@ -18,21 +18,21 @@ type Check interface {
 
 // RunOptions provides run options for checks
 type RunOptions struct {
-	RunRegular  bool
+	RunStandard bool
 	RunRealTime bool
 }
 
 // RunResult is a result for a check run
 type RunResult struct {
-	CheckName string
-	Messages  []model.MessageBody
+	Standard []model.MessageBody
+	RealTime []model.MessageBody
 }
 
 // CheckWithRealTime provides an extended interface for running composite checks
 type CheckWithRealTime interface {
 	Check
 	RealTimeName() string
-	RunWithOptions(cfg *config.AgentConfig, groupID int32, options RunOptions) ([]RunResult, error)
+	RunWithOptions(cfg *config.AgentConfig, groupID int32, options RunOptions) (*RunResult, error)
 }
 
 // All is a list of all runnable checks. Putting a check in here does not guarantee it will be run,

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -229,15 +229,15 @@ func procsToStats(procs map[int32]*procutil.Process) map[int32]*procutil.Stats {
 
 // RunWithOptions collects process data (regular metadata + stats) and/or realtime process data (stats only)
 // Messages are grouped as RunResult instances with CheckName identifying the type
-func (p *ProcessCheck) RunWithOptions(cfg *config.AgentConfig, groupID int32, options RunOptions) (*RunResult, error) {
+func (p *ProcessCheck) RunWithOptions(cfg *config.AgentConfig, nextGroupID func() int32, options RunOptions) (*RunResult, error) {
 	if options.RunStandard {
 		log.Tracef("Running process check")
-		return p.run(cfg, groupID, options.RunRealTime)
+		return p.run(cfg, nextGroupID(), options.RunRealTime)
 	}
 
 	if options.RunRealTime {
 		log.Tracef("Running rtprocess check")
-		return p.runRealtime(cfg, groupID)
+		return p.runRealtime(cfg, nextGroupID())
 	}
 	return nil, errors.New("invalid run options for check")
 }

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -231,10 +231,12 @@ func procsToStats(procs map[int32]*procutil.Process) map[int32]*procutil.Stats {
 // Messages are grouped as RunResult instances with CheckName identifying the type
 func (p *ProcessCheck) RunWithOptions(cfg *config.AgentConfig, groupID int32, options RunOptions) (*RunResult, error) {
 	if options.RunStandard {
+		log.Tracef("Running process check")
 		return p.run(cfg, groupID, options.RunRealTime)
 	}
 
 	if options.RunRealTime {
+		log.Tracef("Running rtprocess check")
 		return p.runRealtime(cfg, groupID)
 	}
 	return nil, errors.New("invalid run options for check")

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -549,9 +549,9 @@ func (p *ProcessCheck) storeCreateTimes() {
 }
 
 func (p *ProcessCheck) createTimesforPIDs(pids []int32) map[int32]int64 {
+	createTimeForPID := make(map[int32]int64)
 	if result := p.createTimes.Load(); result != nil {
 		createTimesAllPIDs := result.(map[int32]int64)
-		createTimeForPID := make(map[int32]int64)
 		for _, pid := range pids {
 			if ctime, ok := createTimesAllPIDs[pid]; ok {
 				createTimeForPID[pid] = ctime
@@ -559,7 +559,7 @@ func (p *ProcessCheck) createTimesforPIDs(pids []int32) map[int32]int64 {
 		}
 		return createTimeForPID
 	}
-	return nil
+	return createTimeForPID
 }
 
 // mergeProcWithSysprobeStats takes a process by PID map and fill the stats from system probe into the processes in the map

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -411,7 +411,7 @@ func fmtProcesses(
 			Command:                formatCommand(fp),
 			User:                   formatUser(fp),
 			Memory:                 formatMemory(fp.Stats),
-			Cpu:                    formatCPU(fp.Stats, fp.Stats.CPUTime, lastProcs[fp.Pid].Stats.CPUTime, syst2, syst1),
+			Cpu:                    formatCPU(fp.Stats, lastProcs[fp.Pid].Stats, syst2, syst1),
 			CreateTime:             fp.Stats.CreateTime,
 			OpenFdCount:            fp.Stats.OpenFdCount,
 			State:                  model.ProcessState(model.ProcessState_value[fp.Stats.Status]),
@@ -505,6 +505,18 @@ func formatNetworks(conns []*model.Connection, interval int) *model.ProcessNetwo
 	}
 	bytesRate := float32(totalTraffic) / float32(interval)
 	return &model.ProcessNetworks{ConnectionRate: connRate, BytesRate: bytesRate}
+}
+
+func formatCPU(statsNow, statsBefore *procutil.Stats, syst2, syst1 cpu.TimesStat) *model.CPUStat {
+	if statsNow.CPUPercent != nil {
+		return &model.CPUStat{
+			LastCpu:   "cpu",
+			TotalPct:  float32(statsNow.CPUPercent.UserPct + statsNow.CPUPercent.SystemPct),
+			UserPct:   float32(statsNow.CPUPercent.UserPct),
+			SystemPct: float32(statsNow.CPUPercent.UserPct),
+		}
+	}
+	return formatCPUTimes(statsNow, statsNow.CPUTime, statsBefore.CPUTime, syst2, syst1)
 }
 
 // skipProcess will skip a given process if it's blacklisted or hasn't existed

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -159,7 +159,7 @@ func (p *ProcessCheck) run(cfg *config.AgentConfig, groupID int32, collectRealTi
 			p.realtimeLastCtrRates = p.lastCtrRates
 			p.realtimeLastRun = p.lastRun
 		}
-		return nil, nil
+		return &RunResult{}, nil
 	}
 
 	connsByPID := Connections.getLastConnectionsByPID()

--- a/pkg/process/checks/process_discovery_check.go
+++ b/pkg/process/checks/process_discovery_check.go
@@ -15,7 +15,7 @@ var ProcessDiscovery = &ProcessDiscoveryCheck{probe: procutil.NewProcessProbe()}
 // It uses its own ProcessDiscovery payload.
 // The goal of this check is to collect information about possible integrations that may be enabled by the end user.
 type ProcessDiscoveryCheck struct {
-	probe      *procutil.Probe
+	probe      procutil.Probe
 	info       *model.SystemInfo
 	initCalled bool
 }

--- a/pkg/process/checks/process_nix.go
+++ b/pkg/process/checks/process_nix.go
@@ -33,7 +33,7 @@ func formatUser(fp *procutil.Process) *model.ProcessUser {
 	}
 }
 
-func formatCPU(fp *procutil.Stats, t2, t1 *procutil.CPUTimesStat, syst2, syst1 cpu.TimesStat) *model.CPUStat {
+func formatCPUTimes(fp *procutil.Stats, t2, t1 *procutil.CPUTimesStat, syst2, syst1 cpu.TimesStat) *model.CPUStat {
 	numCPU := float64(system.HostCPUCount())
 	deltaSys := syst2.Total() - syst1.Total()
 	return &model.CPUStat{

--- a/pkg/process/checks/process_probe.go
+++ b/pkg/process/checks/process_probe.go
@@ -1,0 +1,31 @@
+package checks
+
+import (
+	"runtime"
+	"sync"
+
+	"github.com/DataDog/datadog-agent/pkg/process/config"
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+var (
+	processProbe     procutil.Probe
+	processProbeOnce sync.Once
+	legacyProbe      procutil.Probe
+)
+
+func getProcessProbe(cfg *config.AgentConfig) procutil.Probe {
+	processProbeOnce.Do(func() {
+		if runtime.GOOS == "windows" {
+			if !cfg.Windows.UsePerfCounters {
+				log.Info("Using toolhelp API probe for process data collection")
+				processProbe = legacyProbe
+				return
+			}
+			log.Info("Using perf counters probe for process data collection")
+		}
+		processProbe = procutil.NewProcessProbe()
+	})
+	return processProbe
+}

--- a/pkg/process/checks/process_probe.go
+++ b/pkg/process/checks/process_probe.go
@@ -10,9 +10,9 @@ import (
 )
 
 var (
-	processProbe     procutil.Probe
-	processProbeOnce sync.Once
-	legacyProbe      procutil.Probe
+	processProbe        procutil.Probe
+	processProbeOnce    sync.Once
+	defaultWindowsProbe procutil.Probe
 )
 
 func getProcessProbe(cfg *config.AgentConfig) procutil.Probe {
@@ -20,7 +20,7 @@ func getProcessProbe(cfg *config.AgentConfig) procutil.Probe {
 		if runtime.GOOS == "windows" {
 			if !cfg.Windows.UsePerfCounters {
 				log.Info("Using toolhelp API probe for process data collection")
-				processProbe = legacyProbe
+				processProbe = defaultWindowsProbe
 				return
 			}
 			log.Info("Using perf counters probe for process data collection")

--- a/pkg/process/checks/process_rt.go
+++ b/pkg/process/checks/process_rt.go
@@ -13,13 +13,8 @@ import (
 	"github.com/DataDog/gopsutil/cpu"
 )
 
-// TODO: this comment is no longer accurate (describe procutil.Probe and hint at various implementations here)
-// runRealtime runs the RTProcessCheck to collect statistics about the running processes.
-// On most POSIX systems these statistics are collected from procfs. The bulk
-// of this collection is abstracted into the `gopsutil` library.
-// Processes are split up into a chunks of at most 100 processes per message to
-// limit the message size on intake.
-// See agent.proto for the schema of the message and models used.
+// runRealtime runs the realtime ProcessCheck to collect statistics about the running processes.
+// Underying procutil.Probe is responsible for the actual implementation
 func (p *ProcessCheck) runRealtime(cfg *config.AgentConfig, groupID int32) (*RunResult, error) {
 	cpuTimes, err := cpu.Times(false)
 	if err != nil {

--- a/pkg/process/checks/process_rt.go
+++ b/pkg/process/checks/process_rt.go
@@ -141,7 +141,7 @@ func fmtProcessStats(
 			Pid:                    pid,
 			CreateTime:             fp.CreateTime,
 			Memory:                 formatMemory(fp),
-			Cpu:                    formatCPU(fp, fp.CPUTime, lastProcs[pid].CPUTime, syst2, syst1),
+			Cpu:                    formatCPU(fp, lastProcs[pid], syst2, syst1),
 			Nice:                   fp.Nice,
 			Threads:                fp.NumThreads,
 			OpenFdCount:            fp.OpenFdCount,

--- a/pkg/process/checks/process_rt.go
+++ b/pkg/process/checks/process_rt.go
@@ -20,7 +20,7 @@ import (
 // Processes are split up into a chunks of at most 100 processes per message to
 // limit the message size on intake.
 // See agent.proto for the schema of the message and models used.
-func (p *ProcessCheck) runRealtime(cfg *config.AgentConfig, groupID int32) ([]RunResult, error) {
+func (p *ProcessCheck) runRealtime(cfg *config.AgentConfig, groupID int32) (*RunResult, error) {
 	cpuTimes, err := cpu.Times(false)
 	if err != nil {
 		return nil, err
@@ -97,11 +97,8 @@ func (p *ProcessCheck) runRealtime(cfg *config.AgentConfig, groupID int32) ([]Ru
 	p.realtimeLastCtrRates = util.ExtractContainerRateMetric(ctrList)
 	p.realtimeLastCPUTime = cpuTimes[0]
 
-	return []RunResult{
-		{
-			CheckName: p.RealTimeName(),
-			Messages:  messages,
-		},
+	return &RunResult{
+		RealTime: messages,
 	}, nil
 }
 

--- a/pkg/process/checks/process_rt.go
+++ b/pkg/process/checks/process_rt.go
@@ -31,7 +31,7 @@ func (p *ProcessCheck) runRealtime(cfg *config.AgentConfig, groupID int32) (*Run
 
 	// if processCheck haven't fetched any PIDs, return early
 	if len(p.lastPIDs) == 0 {
-		return nil, nil
+		return &RunResult{}, nil
 	}
 
 	var sysProbeUtil *net.RemoteSysProbeUtil
@@ -67,7 +67,7 @@ func (p *ProcessCheck) runRealtime(cfg *config.AgentConfig, groupID int32) (*Run
 		p.realtimeLastCPUTime = cpuTimes[0]
 		p.realtimeLastRun = time.Now()
 		log.Debug("first run of rtprocess check - no stats to report")
-		return nil, nil
+		return &RunResult{}, nil
 	}
 
 	connsByPID := Connections.getLastConnectionsByPID()

--- a/pkg/process/checks/process_windows.go
+++ b/pkg/process/checks/process_windows.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() {
-	legacyProbe = &legacyWindowsProbe{}
+	legacyProbe = newLegacyWindowsProbe()
 }
 
 func formatUser(fp *procutil.Process) *model.ProcessUser {

--- a/pkg/process/checks/process_windows.go
+++ b/pkg/process/checks/process_windows.go
@@ -11,6 +11,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
 
+func init() {
+	legacyProbe = &legacyWindowsProbe{}
+}
+
 func formatUser(fp *procutil.Process) *model.ProcessUser {
 	return &model.ProcessUser{
 		Name: fp.Username,

--- a/pkg/process/checks/process_windows.go
+++ b/pkg/process/checks/process_windows.go
@@ -12,7 +12,7 @@ import (
 )
 
 func init() {
-	legacyProbe = newLegacyWindowsProbe()
+	defaultWindowsProbe = newWindowsToolhelpProbe()
 }
 
 func formatUser(fp *procutil.Process) *model.ProcessUser {

--- a/pkg/process/checks/process_windows.go
+++ b/pkg/process/checks/process_windows.go
@@ -21,7 +21,7 @@ func formatUser(fp *procutil.Process) *model.ProcessUser {
 	}
 }
 
-func formatCPU(fp *procutil.Stats, t2, t1 *procutil.CPUTimesStat, syst2, syst1 cpu.TimesStat) *model.CPUStat {
+func formatCPUTimes(fp *procutil.Stats, t2, t1 *procutil.CPUTimesStat, syst2, syst1 cpu.TimesStat) *model.CPUStat {
 	numCPU := float64(runtime.NumCPU())
 	deltaSys := float64(t2.Timestamp - t1.Timestamp)
 	// under windows, utime & stime are number of 100-ns increments.  The elapsed time

--- a/pkg/process/checks/runner.go
+++ b/pkg/process/checks/runner.go
@@ -1,0 +1,99 @@
+package checks
+
+import (
+	"errors"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// RunnerConfig implements config for runners that work with CheckWithRealTime
+type RunnerConfig struct {
+	CheckInterval time.Duration
+	RtInterval    time.Duration
+
+	ExitChan       chan struct{}
+	RtIntervalChan chan time.Duration
+	RtEnabled      func() bool
+	RunCheck       func(options RunOptions)
+}
+
+type runnerWithRealTime struct {
+	RunnerConfig
+	ratio      int
+	counter    int
+	newTicker  func(d time.Duration) *time.Ticker
+	stopTicker func(t *time.Ticker)
+}
+
+// NewRunnerWithRealTime creates a runner func for CheckWithRealTime
+func NewRunnerWithRealTime(config RunnerConfig) (func(), error) {
+	_, err := getRtRatio(config.CheckInterval, config.RtInterval)
+	if err != nil {
+		return nil, err
+	}
+	r := &runnerWithRealTime{
+		RunnerConfig: config,
+		newTicker:    time.NewTicker,
+		stopTicker: func(t *time.Ticker) {
+			t.Stop()
+		},
+	}
+	return r.run, nil
+}
+
+// run performs runs for CheckWithRealTime checks
+func (r *runnerWithRealTime) run() {
+	var err error
+	r.ratio, err = getRtRatio(r.CheckInterval, r.RtInterval)
+	if err != nil {
+		return
+	}
+
+	ticker := r.newTicker(r.RtInterval)
+	for {
+		select {
+		case <-ticker.C:
+			if r.counter == r.ratio {
+				r.counter = 0
+			}
+
+			rtEnabled := r.RtEnabled()
+			if rtEnabled || r.counter == 0 {
+				r.RunCheck(RunOptions{
+					RunRegular:  r.counter == 0,
+					RunRealTime: rtEnabled,
+				})
+			}
+
+			r.counter++
+		case d := <-r.RtIntervalChan:
+			// Live-update the ticker.
+			newRatio, err := getRtRatio(r.CheckInterval, d)
+			if err != nil {
+				log.Errorf("failed to apply new RT interval: %v", err)
+				continue
+			}
+			r.RtInterval = d
+			r.stopTicker(ticker)
+			ticker = r.newTicker(d)
+
+			r.ratio = newRatio
+			r.counter = 0
+		case _, ok := <-r.ExitChan:
+			if !ok {
+				return
+			}
+		}
+	}
+}
+
+func getRtRatio(checkInterval, rtInterval time.Duration) (int, error) {
+	if checkInterval <= rtInterval {
+		return -1, errors.New("check interval should be larger than RT interval")
+	}
+	if checkInterval%rtInterval != 0 {
+		return -1, errors.New("check interval should be divisible by RT interval")
+	}
+	return int(checkInterval / rtInterval), nil
+}

--- a/pkg/process/checks/runner.go
+++ b/pkg/process/checks/runner.go
@@ -61,7 +61,7 @@ func (r *runnerWithRealTime) run() {
 			rtEnabled := r.RtEnabled()
 			if rtEnabled || r.counter == 0 {
 				r.RunCheck(RunOptions{
-					RunRegular:  r.counter == 0,
+					RunStandard: r.counter == 0,
 					RunRealTime: rtEnabled,
 				})
 			}

--- a/pkg/process/checks/runner_test.go
+++ b/pkg/process/checks/runner_test.go
@@ -1,0 +1,148 @@
+package checks
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	runOptionsWithRegular = RunOptions{
+		RunRegular:  true,
+		RunRealTime: false,
+	}
+	runOptionsWithRT = RunOptions{
+		RunRegular:  false,
+		RunRealTime: true,
+	}
+	runOptionsWithBoth = RunOptions{
+		RunRegular:  true,
+		RunRealTime: true,
+	}
+)
+
+func TestRunnerWithRealTime(t *testing.T) {
+	tests := []struct {
+		desc       string
+		rtEnabled  bool
+		expectRuns []RunOptions
+	}{
+		{
+			desc:      "rt-enabled",
+			rtEnabled: true,
+			expectRuns: []RunOptions{
+				runOptionsWithBoth,
+				runOptionsWithRT,
+				runOptionsWithRT,
+				runOptionsWithRT,
+				runOptionsWithRT,
+				runOptionsWithBoth,
+				runOptionsWithRT,
+			},
+		},
+		{
+			desc:      "rt-disabled",
+			rtEnabled: false,
+			expectRuns: []RunOptions{
+				runOptionsWithRegular,
+				runOptionsWithRegular,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.desc, func(t *testing.T) {
+			exitChan := make(chan struct{})
+			rtIntervalChan := make(chan time.Duration)
+			defer close(rtIntervalChan)
+
+			var runs []RunOptions
+			runCheck := func(options RunOptions) {
+				runs = append(runs, options)
+			}
+
+			tickerCh := make(chan time.Time)
+			defer close(tickerCh)
+			ticker := &time.Ticker{
+				C: tickerCh,
+			}
+
+			runner := &runnerWithRealTime{
+				RunnerConfig: RunnerConfig{
+					CheckInterval:  10 * time.Second,
+					RtInterval:     2 * time.Second,
+					ExitChan:       exitChan,
+					RtIntervalChan: rtIntervalChan,
+					RtEnabled:      func() bool { return test.rtEnabled },
+					RunCheck:       runCheck,
+				},
+				newTicker:  func(time.Duration) *time.Ticker { return ticker },
+				stopTicker: func(t *time.Ticker) {},
+			}
+
+			var wg sync.WaitGroup
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				runner.run()
+			}()
+
+			for i := 0; i < 7; i++ {
+				tickerCh <- time.Now()
+			}
+
+			close(exitChan)
+
+			wg.Wait()
+
+			assert.Equal(t, test.expectRuns, runs)
+		})
+	}
+}
+
+func TestRunnerWithRealTime_ReconfigureInterval(t *testing.T) {
+	exitChan := make(chan struct{})
+
+	rtIntervalChan := make(chan time.Duration)
+	defer close(rtIntervalChan)
+
+	tickerCh := make(chan time.Time)
+	defer close(tickerCh)
+	ticker := &time.Ticker{
+		C: tickerCh,
+	}
+
+	r := &runnerWithRealTime{
+		RunnerConfig: RunnerConfig{
+			CheckInterval: 10 * time.Second,
+			RtInterval:    2 * time.Second,
+
+			ExitChan:       exitChan,
+			RtIntervalChan: rtIntervalChan,
+			RtEnabled:      func() bool { return true },
+			RunCheck:       func(options RunOptions) {},
+		},
+		newTicker:  func(time.Duration) *time.Ticker { return ticker },
+		stopTicker: func(t *time.Ticker) {},
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		r.run()
+	}()
+
+	tickerCh <- time.Now()
+
+	rtIntervalChan <- time.Second
+
+	close(exitChan)
+
+	wg.Wait()
+
+	assert.Equal(t, 10, r.ratio)
+	assert.Equal(t, 0, r.counter)
+}

--- a/pkg/process/checks/runner_test.go
+++ b/pkg/process/checks/runner_test.go
@@ -9,16 +9,16 @@ import (
 )
 
 var (
-	runOptionsWithRegular = RunOptions{
-		RunRegular:  true,
+	runOptionsWithStandard = RunOptions{
+		RunStandard: true,
 		RunRealTime: false,
 	}
-	runOptionsWithRT = RunOptions{
-		RunRegular:  false,
+	runOptionsWithRealTime = RunOptions{
+		RunStandard: false,
 		RunRealTime: true,
 	}
 	runOptionsWithBoth = RunOptions{
-		RunRegular:  true,
+		RunStandard: true,
 		RunRealTime: true,
 	}
 )
@@ -34,20 +34,20 @@ func TestRunnerWithRealTime(t *testing.T) {
 			rtEnabled: true,
 			expectRuns: []RunOptions{
 				runOptionsWithBoth,
-				runOptionsWithRT,
-				runOptionsWithRT,
-				runOptionsWithRT,
-				runOptionsWithRT,
+				runOptionsWithRealTime,
+				runOptionsWithRealTime,
+				runOptionsWithRealTime,
+				runOptionsWithRealTime,
 				runOptionsWithBoth,
-				runOptionsWithRT,
+				runOptionsWithRealTime,
 			},
 		},
 		{
 			desc:      "rt-disabled",
 			rtEnabled: false,
 			expectRuns: []RunOptions{
-				runOptionsWithRegular,
-				runOptionsWithRegular,
+				runOptionsWithStandard,
+				runOptionsWithStandard,
 			},
 		},
 	}

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -53,12 +53,13 @@ const (
 	TCPQueueLengthCheckName = "TCP queue length"
 	ProcessModuleCheckName  = "Process Module"
 
-	ProcessCheckDefaultInterval     = 10 * time.Second
-	RTProcessCheckDefaultInterval   = 2 * time.Second
-	ContainerCheckDefaultInterval   = 10 * time.Second
-	RTContainerCheckDefaultInterval = 2 * time.Second
-	ConnectionsCheckDefaultInterval = 30 * time.Second
-	PodCheckDefaultInterval         = 10 * time.Second
+	ProcessCheckDefaultInterval          = 10 * time.Second
+	RTProcessCheckDefaultInterval        = 2 * time.Second
+	ContainerCheckDefaultInterval        = 10 * time.Second
+	RTContainerCheckDefaultInterval      = 2 * time.Second
+	ConnectionsCheckDefaultInterval      = 30 * time.Second
+	PodCheckDefaultInterval              = 10 * time.Second
+	ProcessDiscoveryCheckDefaultInterval = 4 * time.Hour
 )
 
 var (
@@ -235,7 +236,7 @@ func NewDefaultAgentConfig(canAccessContainers bool) *AgentConfig {
 			RTContainerCheckName: RTContainerCheckDefaultInterval,
 			ConnectionsCheckName: ConnectionsCheckDefaultInterval,
 			PodCheckName:         PodCheckDefaultInterval,
-			DiscoveryCheckName:   4 * time.Hour,
+			DiscoveryCheckName:   ProcessDiscoveryCheckDefaultInterval,
 		},
 
 		// DataScrubber to hide command line sensitive words

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -52,6 +52,13 @@ const (
 	OOMKillCheckName        = "OOM Kill"
 	TCPQueueLengthCheckName = "TCP queue length"
 	ProcessModuleCheckName  = "Process Module"
+
+	ProcessCheckDefaultInterval     = 10 * time.Second
+	RTProcessCheckDefaultInterval   = 2 * time.Second
+	ContainerCheckDefaultInterval   = 10 * time.Second
+	RTContainerCheckDefaultInterval = 2 * time.Second
+	ConnectionsCheckDefaultInterval = 30 * time.Second
+	PodCheckDefaultInterval         = 10 * time.Second
 )
 
 var (
@@ -222,12 +229,12 @@ func NewDefaultAgentConfig(canAccessContainers bool) *AgentConfig {
 		// Check config
 		EnabledChecks: enabledChecks,
 		CheckIntervals: map[string]time.Duration{
-			ProcessCheckName:     10 * time.Second,
-			RTProcessCheckName:   2 * time.Second,
-			ContainerCheckName:   10 * time.Second,
-			RTContainerCheckName: 2 * time.Second,
-			ConnectionsCheckName: 30 * time.Second,
-			PodCheckName:         10 * time.Second,
+			ProcessCheckName:     ProcessCheckDefaultInterval,
+			RTProcessCheckName:   RTProcessCheckDefaultInterval,
+			ContainerCheckName:   ContainerCheckDefaultInterval,
+			RTContainerCheckName: RTContainerCheckDefaultInterval,
+			ConnectionsCheckName: ConnectionsCheckDefaultInterval,
+			PodCheckName:         PodCheckDefaultInterval,
 			DiscoveryCheckName:   4 * time.Hour,
 		},
 

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -76,6 +76,8 @@ type WindowsConfig struct {
 	ArgsRefreshInterval int
 	// Controls getting process arguments immediately when a new process is discovered
 	AddNewArgs bool
+	// UsePerfCounters enables new process check using performance counters for process collection
+	UsePerfCounters bool
 }
 
 // AgentConfig is the global config for the process-agent. This information

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -420,6 +420,7 @@ func loadEnvVariables() {
 		{"DD_PROCESS_AGENT_MAX_PER_MESSAGE", "process_config.max_per_message"},
 		{"DD_PROCESS_AGENT_MAX_CTR_PROCS_PER_MESSAGE", "process_config.max_ctr_procs_per_message"},
 		{"DD_PROCESS_AGENT_CMD_PORT", "process_config.cmd_port"},
+		{"DD_PROCESS_AGENT_WINDOWS_USE_PERF_COUNTERS", "process_config.windows.use_perf_counters"},
 		{"DD_ORCHESTRATOR_URL", "orchestrator_explorer.orchestrator_dd_url"},
 		{"DD_HOSTNAME", "hostname"},
 		{"DD_DOGSTATSD_PORT", "dogstatsd_port"},

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -99,6 +99,19 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 	// and uses a different unit of time
 	a.initProcessDiscoveryCheck()
 
+	if a.CheckIntervals[ProcessCheckName]%a.CheckIntervals[RTProcessCheckName] != 0 {
+		// Process and RTProcess check intervals must be divisible to allow running on the same goroutine
+		log.Warnf(
+			"Invalid process check interval overrides [%s,%s], resetting to defaults [%s,%s]",
+			a.CheckIntervals[ProcessCheckName],
+			a.CheckIntervals[RTProcessCheckName],
+			ProcessCheckDefaultInterval,
+			RTProcessCheckDefaultInterval,
+		)
+		a.CheckIntervals[ProcessCheckName] = ProcessCheckDefaultInterval
+		a.CheckIntervals[RTProcessCheckName] = RTProcessCheckDefaultInterval
+	}
+
 	// A list of regex patterns that will exclude a process if matched.
 	if k := key(ns, "blacklist_patterns"); config.Datadog.IsSet(k) {
 		for _, b := range config.Datadog.GetStringSlice(k) {

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -199,6 +199,11 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 		a.Windows.AddNewArgs = config.Datadog.GetBool(addArgsKey)
 	}
 
+	// Windows: Controls using the new check based on performance counters PDH APIs
+	if usePerfCountersKey := key(ns, "windows", "use_perf_counters"); config.Datadog.IsSet(usePerfCountersKey) {
+		a.Windows.UsePerfCounters = config.Datadog.GetBool(usePerfCountersKey)
+	}
+
 	// Optional additional pairs of endpoint_url => []apiKeys to submit to other locations.
 	if k := key(ns, "additional_endpoints"); config.Datadog.IsSet(k) {
 		for endpointURL, apiKeys := range config.Datadog.GetStringMapStringSlice(k) {

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -99,8 +99,9 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 	// and uses a different unit of time
 	a.initProcessDiscoveryCheck()
 
-	if a.CheckIntervals[ProcessCheckName]%a.CheckIntervals[RTProcessCheckName] != 0 {
-		// Process and RTProcess check intervals must be divisible to allow running on the same goroutine
+	if a.CheckIntervals[ProcessCheckName] <= a.CheckIntervals[RTProcessCheckName] || a.CheckIntervals[ProcessCheckName]%a.CheckIntervals[RTProcessCheckName] != 0 {
+		// Process check interval must be greater than RTProcess check interval and the intervals must be divisible
+		// in order to be run on the same goroutine
 		log.Warnf(
 			"Invalid process check interval overrides [%s,%s], resetting to defaults [%s,%s]",
 			a.CheckIntervals[ProcessCheckName],

--- a/pkg/process/procutil/option_unsupported.go
+++ b/pkg/process/procutil/option_unsupported.go
@@ -1,0 +1,22 @@
+// +build !linux
+
+package procutil
+
+import "time"
+
+// WithReturnZeroPermStats configures whether StatsWithPermByPID() returns StatsWithPerm that
+// has zero values on all fields
+func WithReturnZeroPermStats(enabled bool) Option {
+	return func(p Probe) {}
+}
+
+// WithPermission configures if process collection should fetch fields
+// that require elevated permission or not
+func WithPermission(enabled bool) Option {
+	return func(p Probe) {}
+}
+
+// WithBootTimeRefreshInterval configures the boot time refresh interval
+func WithBootTimeRefreshInterval(bootTimeRefreshInterval time.Duration) Option {
+	return func(p Probe) {}
+}

--- a/pkg/process/procutil/probe.go
+++ b/pkg/process/procutil/probe.go
@@ -1,0 +1,16 @@
+package procutil
+
+import (
+	"time"
+)
+
+// Probe fetches process related info on current host
+type Probe interface {
+	Close()
+	StatsForPIDs(pids []int32, now time.Time) (map[int32]*Stats, error)
+	ProcessesByPID(now time.Time) (map[int32]*Process, error)
+	StatsWithPermByPID(pids []int32) (map[int32]*StatsWithPerm, error)
+}
+
+// Option is config options callback for system-probe
+type Option func(p Probe)

--- a/pkg/process/procutil/probe.go
+++ b/pkg/process/procutil/probe.go
@@ -8,7 +8,7 @@ import (
 type Probe interface {
 	Close()
 	StatsForPIDs(pids []int32, now time.Time) (map[int32]*Stats, error)
-	ProcessesByPID(now time.Time) (map[int32]*Process, error)
+	ProcessesByPID(now time.Time, collectStats bool) (map[int32]*Process, error)
 	StatsWithPermByPID(pids []int32) (map[int32]*StatsWithPerm, error)
 }
 

--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -54,34 +54,37 @@ type statInfo struct {
 	cpuStat    *CPUTimesStat
 }
 
-// Option is config options callback for system-probe
-type Option func(p *Probe)
-
 // WithReturnZeroPermStats configures whether StatsWithPermByPID() returns StatsWithPerm that
 // has zero values on all fields
 func WithReturnZeroPermStats(enabled bool) Option {
-	return func(p *Probe) {
-		p.returnZeroPermStats = enabled
+	return func(p Probe) {
+		if linuxProbe, ok := p.(*probe); ok {
+			linuxProbe.returnZeroPermStats = enabled
+		}
 	}
 }
 
 // WithPermission configures if process collection should fetch fields
 // that require elevated permission or not
 func WithPermission(enabled bool) Option {
-	return func(p *Probe) {
-		p.withPermission = enabled
+	return func(p Probe) {
+		if linuxProbe, ok := p.(*probe); ok {
+			linuxProbe.withPermission = enabled
+		}
 	}
 }
 
 // WithBootTimeRefreshInterval configures the boot time refresh interval
 func WithBootTimeRefreshInterval(bootTimeRefreshInterval time.Duration) Option {
-	return func(p *Probe) {
-		p.bootTimeRefreshInterval = bootTimeRefreshInterval
+	return func(p Probe) {
+		if linuxProbe, ok := p.(*probe); ok {
+			linuxProbe.bootTimeRefreshInterval = bootTimeRefreshInterval
+		}
 	}
 }
 
-// Probe is a service that fetches process related info on current host
-type Probe struct {
+// probe is a service that fetches process related info on current host
+type probe struct {
 	procRootLoc  string // ProcFS
 	procRootFile *os.File
 	uid          uint32 // UID
@@ -97,14 +100,14 @@ type Probe struct {
 }
 
 // NewProcessProbe initializes a new Probe object
-func NewProcessProbe(options ...Option) *Probe {
+func NewProcessProbe(options ...Option) Probe {
 	hostProc := util.HostProc()
 	bootTime, err := bootTime(hostProc)
 	if err != nil {
 		log.Errorf("could not parse boot time: %s", err)
 	}
 
-	p := &Probe{
+	p := &probe{
 		procRootLoc:             hostProc,
 		uid:                     uint32(os.Getuid()),
 		euid:                    uint32(os.Geteuid()),
@@ -124,7 +127,7 @@ func NewProcessProbe(options ...Option) *Probe {
 }
 
 // Close cleans up everything related to Probe object
-func (p *Probe) Close() {
+func (p *probe) Close() {
 	close(p.exit)
 	if p.procRootFile != nil {
 		p.procRootFile.Close()
@@ -134,7 +137,7 @@ func (p *Probe) Close() {
 
 // syncBootTime checks bootTime every minute and stores it.
 // Make sure we get the correct boot time if the clock of the host is temporarily drifted but gets corrected later on
-func (p *Probe) syncBootTime() {
+func (p *probe) syncBootTime() {
 	ticker := time.NewTicker(p.bootTimeRefreshInterval)
 	defer ticker.Stop()
 
@@ -152,7 +155,7 @@ func (p *Probe) syncBootTime() {
 }
 
 // StatsForPIDs returns a map of stats info indexed by PID using the given PIDs
-func (p *Probe) StatsForPIDs(pids []int32, now time.Time) (map[int32]*Stats, error) {
+func (p *probe) StatsForPIDs(pids []int32, now time.Time) (map[int32]*Stats, error) {
 	statsByPID := make(map[int32]*Stats, len(pids))
 	for _, pid := range pids {
 		pathForPID := filepath.Join(p.procRootLoc, strconv.Itoa(int(pid)))
@@ -192,7 +195,7 @@ func (p *Probe) StatsForPIDs(pids []int32, now time.Time) (map[int32]*Stats, err
 }
 
 // ProcessesByPID returns a map of process info indexed by PID
-func (p *Probe) ProcessesByPID(now time.Time, collectStats bool) (map[int32]*Process, error) {
+func (p *probe) ProcessesByPID(now time.Time, collectStats bool) (map[int32]*Process, error) {
 	pids, err := p.getActivePIDs()
 	if err != nil {
 		return nil, err
@@ -263,7 +266,7 @@ func (p *Probe) ProcessesByPID(now time.Time, collectStats bool) (map[int32]*Pro
 }
 
 // StatsWithPermByPID returns the stats that require elevated permission to collect for each process
-func (p *Probe) StatsWithPermByPID(pids []int32) (map[int32]*StatsWithPerm, error) {
+func (p *probe) StatsWithPermByPID(pids []int32) (map[int32]*StatsWithPerm, error) {
 	statsByPID := make(map[int32]*StatsWithPerm, len(pids))
 	for _, pid := range pids {
 		pathForPID := filepath.Join(p.procRootLoc, strconv.Itoa(int(pid)))
@@ -288,7 +291,7 @@ func (p *Probe) StatsWithPermByPID(pids []int32) (map[int32]*StatsWithPerm, erro
 	return statsByPID, nil
 }
 
-func (p *Probe) getRootProcFile() (*os.File, error) {
+func (p *probe) getRootProcFile() (*os.File, error) {
 	if p.procRootFile != nil {
 		return p.procRootFile, nil
 	}
@@ -302,7 +305,7 @@ func (p *Probe) getRootProcFile() (*os.File, error) {
 }
 
 // getActivePIDs retrieves a list of PIDs representing actively running processes.
-func (p *Probe) getActivePIDs() ([]int32, error) {
+func (p *probe) getActivePIDs() ([]int32, error) {
 	procFile, err := p.getRootProcFile()
 	if err != nil {
 		return nil, err
@@ -332,7 +335,7 @@ func (p *Probe) getActivePIDs() ([]int32, error) {
 }
 
 // getCmdline retrieves the command line text from "cmdline" file for a process in procfs
-func (p *Probe) getCmdline(pidPath string) []string {
+func (p *probe) getCmdline(pidPath string) []string {
 	cmdline, err := ioutil.ReadFile(filepath.Join(pidPath, "cmdline"))
 	if err != nil {
 		log.Debugf("Unable to read process command line from %s: %s", pidPath, err)
@@ -347,7 +350,7 @@ func (p *Probe) getCmdline(pidPath string) []string {
 }
 
 // parseIO retrieves io info from "io" file for a process in procfs
-func (p *Probe) parseIO(pidPath string) *IOCountersStat {
+func (p *probe) parseIO(pidPath string) *IOCountersStat {
 	path := filepath.Join(pidPath, "io")
 	var err error
 
@@ -376,7 +379,7 @@ func (p *Probe) parseIO(pidPath string) *IOCountersStat {
 }
 
 // parseIOLine extracts key and value for each line in "io" file
-func (p *Probe) parseIOLine(line []byte, io *IOCountersStat) {
+func (p *probe) parseIOLine(line []byte, io *IOCountersStat) {
 	for i := range line {
 		// the fields are all having format "field_name: field_value", so we always
 		// look for ": " and skip them
@@ -390,7 +393,7 @@ func (p *Probe) parseIOLine(line []byte, io *IOCountersStat) {
 }
 
 // parseIOKV matches key with a field in IOCountersStat model and fills in the value
-func (p *Probe) parseIOKV(key, value string, io *IOCountersStat) {
+func (p *probe) parseIOKV(key, value string, io *IOCountersStat) {
 	switch key {
 	case "syscr":
 		v, err := strconv.ParseInt(value, 10, 64)
@@ -416,7 +419,7 @@ func (p *Probe) parseIOKV(key, value string, io *IOCountersStat) {
 }
 
 // parseStatus retrieves status info from "status" file for a process in procfs
-func (p *Probe) parseStatus(pidPath string) *statusInfo {
+func (p *probe) parseStatus(pidPath string) *statusInfo {
 	path := filepath.Join(pidPath, "status")
 	var err error
 
@@ -445,7 +448,7 @@ func (p *Probe) parseStatus(pidPath string) *statusInfo {
 }
 
 // parseStatusLine takes each line in "status" file and parses info from it
-func (p *Probe) parseStatusLine(line []byte, sInfo *statusInfo) {
+func (p *probe) parseStatusLine(line []byte, sInfo *statusInfo) {
 	for i := range line {
 		// the fields are all having format "field_name:\tfield_value", so we always
 		// look for ":\t" and skip them
@@ -459,7 +462,7 @@ func (p *Probe) parseStatusLine(line []byte, sInfo *statusInfo) {
 }
 
 // parseStatusKV takes tokens parsed from each line in "status" file and populates statusInfo object
-func (p *Probe) parseStatusKV(key, value string, sInfo *statusInfo) {
+func (p *probe) parseStatusKV(key, value string, sInfo *statusInfo) {
 	switch key {
 	case "Name":
 		sInfo.name = strings.Trim(value, " \t")
@@ -525,7 +528,7 @@ func (p *Probe) parseStatusKV(key, value string, sInfo *statusInfo) {
 }
 
 // parseStat retrieves stat info from "stat" file for a process in procfs
-func (p *Probe) parseStat(pidPath string, pid int32, now time.Time) *statInfo {
+func (p *probe) parseStat(pidPath string, pid int32, now time.Time) *statInfo {
 	path := filepath.Join(pidPath, "stat")
 	var err error
 
@@ -543,7 +546,7 @@ func (p *Probe) parseStat(pidPath string, pid int32, now time.Time) *statInfo {
 }
 
 // parseStatContent takes the content of "stat" file and parses the values we care about
-func (p *Probe) parseStatContent(statContent []byte, sInfo *statInfo, pid int32, now time.Time) *statInfo {
+func (p *probe) parseStatContent(statContent []byte, sInfo *statInfo, pid int32, now time.Time) *statInfo {
 	// We want to skip past the executable name, which is wrapped in one or more parenthesis
 	startIndex := bytes.LastIndexByte(statContent, byte(')'))
 	if startIndex == -1 || startIndex+1 >= len(statContent) {
@@ -617,7 +620,7 @@ func (p *Probe) parseStatContent(statContent []byte, sInfo *statInfo, pid int32,
 }
 
 // parseStatm gets memory info from /proc/(pid)/statm
-func (p *Probe) parseStatm(pidPath string) *MemoryInfoExStat {
+func (p *probe) parseStatm(pidPath string) *MemoryInfoExStat {
 	path := filepath.Join(pidPath, "statm")
 	var err error
 
@@ -664,7 +667,7 @@ func (p *Probe) parseStatm(pidPath string) *MemoryInfoExStat {
 }
 
 // getLinkWithAuthCheck fetches the destination of a symlink with permission check
-func (p *Probe) getLinkWithAuthCheck(pidPath string, file string) string {
+func (p *probe) getLinkWithAuthCheck(pidPath string, file string) string {
 	path := filepath.Join(pidPath, file)
 	if err := p.ensurePathReadable(path); err != nil {
 		return ""
@@ -678,7 +681,7 @@ func (p *Probe) getLinkWithAuthCheck(pidPath string, file string) string {
 }
 
 // getFDCount gets num_fds from /proc/(pid)/fd
-func (p *Probe) getFDCount(pidPath string) int32 {
+func (p *probe) getFDCount(pidPath string) int32 {
 	path := filepath.Join(pidPath, "fd")
 
 	if err := p.ensurePathReadable(path); err != nil {
@@ -700,7 +703,7 @@ func (p *Probe) getFDCount(pidPath string) int32 {
 
 // getFDCountImproved gets num_fds from /proc/(pid)/fd WITHOUT using the native Readdirnames(),
 // this will skip the step of returning all file names(we don't need) in a dir which takes a lot of memory
-func (p *Probe) getFDCountImproved(pidPath string) int32 {
+func (p *probe) getFDCountImproved(pidPath string) int32 {
 	path := filepath.Join(pidPath, "fd")
 
 	if err := p.ensurePathReadable(path); err != nil {
@@ -738,7 +741,7 @@ func (p *Probe) getFDCountImproved(pidPath string) int32 {
 // 1. If the agent is running as root (real or via sudo), allow the request
 // 2. If the file is a not a symlink and has the other-readable permission bit set, allow the request
 // 3. If the owner of the file/link is the current user or effective user, allow the request.
-func (p *Probe) ensurePathReadable(path string) error {
+func (p *probe) ensurePathReadable(path string) error {
 	// User is (effectively or actually) root
 	if p.euid == 0 {
 		return nil

--- a/pkg/process/procutil/process_linux_test.go
+++ b/pkg/process/procutil/process_linux_test.go
@@ -26,9 +26,13 @@ var (
 	skipLocalTest = true
 )
 
-func getProbeWithPermission(options ...Option) *Probe {
+func getProbe(options ...Option) *probe {
+	return NewProcessProbe(options...).(*probe)
+}
+
+func getProbeWithPermission(options ...Option) *probe {
 	options = append(options, WithPermission(true))
-	return NewProcessProbe(options...)
+	return getProbe(options...)
 }
 
 func TestGetActivePIDs(t *testing.T) {
@@ -640,7 +644,7 @@ func testParseIO(t *testing.T) {
 
 func TestFetchFieldsWithoutPermission(t *testing.T) {
 	t.Skip("This test is not working in CI, but could be tested locally")
-	probe := NewProcessProbe()
+	probe := getProbe()
 	defer probe.Close()
 	// PID 1 should be owned by root so we would always get permission error
 	pid := int32(1)
@@ -903,7 +907,7 @@ func TestGetFDCountLocalFS(t *testing.T) {
 
 func TestGetFDCountLocalFSImproved(t *testing.T) {
 	maySkipLocalTest(t)
-	probe := NewProcessProbe()
+	probe := getProbe()
 	defer probe.Close()
 
 	pids, err := probe.getActivePIDs()

--- a/pkg/process/procutil/process_model.go
+++ b/pkg/process/procutil/process_model.go
@@ -21,6 +21,35 @@ type Process struct {
 	Stats *Stats
 }
 
+// DeepCopy creates a deep copy of Process
+func (p *Process) DeepCopy() *Process {
+	copy := &Process{
+		Pid:      p.Pid,
+		Ppid:     p.Ppid,
+		NsPid:    p.NsPid,
+		Name:     p.Name,
+		Cwd:      p.Cwd,
+		Exe:      p.Exe,
+		Username: p.Username,
+	}
+	copy.Cmdline = make([]string, len(p.Cmdline))
+	for i := range p.Cmdline {
+		copy.Cmdline[i] = p.Cmdline[i]
+	}
+	copy.Uids = make([]int32, len(p.Uids))
+	for i := range p.Uids {
+		copy.Uids[i] = p.Uids[i]
+	}
+	copy.Gids = make([]int32, len(p.Gids))
+	for i := range p.Gids {
+		copy.Gids[i] = p.Gids[i]
+	}
+	if p.Stats != nil {
+		copy.Stats = p.Stats.DeepCopy()
+	}
+	return copy
+}
+
 // Stats holds all relevant stats metrics of a process
 type Stats struct {
 	CreateTime int64
@@ -37,7 +66,44 @@ type Stats struct {
 	MemInfo     *MemoryInfoStat
 	MemInfoEx   *MemoryInfoExStat
 	IOStat      *IOCountersStat
+	IORateStat  *IOCountersRateStat
 	CtxSwitches *NumCtxSwitchesStat
+}
+
+// DeepCopy creates a deep copy of Stats
+func (s *Stats) DeepCopy() *Stats {
+	copy := &Stats{
+		CreateTime:  s.CreateTime,
+		Status:      s.Status,
+		Nice:        s.Nice,
+		OpenFdCount: s.OpenFdCount,
+		NumThreads:  s.NumThreads,
+	}
+	if s.CPUTime != nil {
+		copy.CPUTime = &CPUTimesStat{}
+		*copy.CPUTime = *s.CPUTime
+	}
+	if s.MemInfo != nil {
+		copy.MemInfo = &MemoryInfoStat{}
+		*copy.MemInfo = *s.MemInfo
+	}
+	if s.MemInfoEx != nil {
+		copy.MemInfoEx = &MemoryInfoExStat{}
+		*copy.MemInfoEx = *s.MemInfoEx
+	}
+	if s.IOStat != nil {
+		copy.IOStat = &IOCountersStat{}
+		*copy.IOStat = *s.IOStat
+	}
+	if s.IORateStat != nil {
+		copy.IORateStat = &IOCountersRateStat{}
+		*copy.IORateStat = *s.IORateStat
+	}
+	if s.CtxSwitches != nil {
+		copy.CtxSwitches = &NumCtxSwitchesStat{}
+		*copy.CtxSwitches = *s.CtxSwitches
+	}
+	return copy
 }
 
 // StatsWithPerm is a collection of stats that require elevated permission to collect in linux
@@ -92,6 +158,14 @@ type IOCountersStat struct {
 	WriteCount int64
 	ReadBytes  int64
 	WriteBytes int64
+}
+
+// IOCountersRateStat holds IO metrics for a process represented as rates (/sec)
+type IOCountersRateStat struct {
+	ReadRate       float64
+	WriteRate      float64
+	ReadBytesRate  float64
+	WriteBytesRate float64
 }
 
 // IsZeroValue checks whether all fields are 0 in value for IOCountersStat

--- a/pkg/process/procutil/process_model.go
+++ b/pkg/process/procutil/process_model.go
@@ -62,6 +62,7 @@ type Stats struct {
 	Nice        int32
 	OpenFdCount int32
 	NumThreads  int32
+	CPUPercent  *CPUPercentStat
 	CPUTime     *CPUTimesStat
 	MemInfo     *MemoryInfoStat
 	MemInfoEx   *MemoryInfoExStat
@@ -82,6 +83,10 @@ func (s *Stats) DeepCopy() *Stats {
 	if s.CPUTime != nil {
 		copy.CPUTime = &CPUTimesStat{}
 		*copy.CPUTime = *s.CPUTime
+	}
+	if s.CPUPercent != nil {
+		copy.CPUPercent = &CPUPercentStat{}
+		*copy.CPUPercent = *s.CPUPercent
 	}
 	if s.MemInfo != nil {
 		copy.MemInfo = &MemoryInfoStat{}
@@ -132,6 +137,12 @@ type CPUTimesStat struct {
 func (c *CPUTimesStat) Total() float64 {
 	total := c.User + c.System + c.Nice + c.Iowait + c.Irq + c.Softirq + c.Steal + c.Guest + c.GuestNice + c.Idle + c.Stolen
 	return total
+}
+
+// CPUPercentStat holds CPU stat metrics of a process as CPU usage percent
+type CPUPercentStat struct {
+	UserPct   float64
+	SystemPct float64
 }
 
 // MemoryInfoStat holds commonly used memory metrics for a process

--- a/pkg/process/procutil/process_model.go
+++ b/pkg/process/procutil/process_model.go
@@ -171,17 +171,17 @@ type IOCountersStat struct {
 	WriteBytes int64
 }
 
+// IsZeroValue checks whether all fields are 0 in value for IOCountersStat
+func (i *IOCountersStat) IsZeroValue() bool {
+	return i.ReadCount == 0 && i.WriteCount == 0 && i.ReadBytes == 0 && i.WriteBytes == 0
+}
+
 // IOCountersRateStat holds IO metrics for a process represented as rates (/sec)
 type IOCountersRateStat struct {
 	ReadRate       float64
 	WriteRate      float64
 	ReadBytesRate  float64
 	WriteBytesRate float64
-}
-
-// IsZeroValue checks whether all fields are 0 in value for IOCountersStat
-func (i *IOCountersStat) IsZeroValue() bool {
-	return i.ReadCount == 0 && i.WriteCount == 0 && i.ReadBytes == 0 && i.WriteBytes == 0
 }
 
 // NumCtxSwitchesStat holds context switch metrics for a process

--- a/pkg/process/procutil/process_unsupported.go
+++ b/pkg/process/procutil/process_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux
+// +build !linux,!windows
 
 package procutil
 
@@ -7,54 +7,29 @@ import (
 	"time"
 )
 
-// Option is config options callback for system-probe
-type Option func(p *Probe)
-
-// WithReturnZeroPermStats configures whether StatsWithPermByPID() returns StatsWithPerm that
-// has zero values on all fields
-func WithReturnZeroPermStats(enabled bool) Option {
-	return func(p *Probe) {
-		p.returnZeroPermStats = enabled
-	}
-}
-
-// WithPermission configures if process collection should fetch fields
-// that require elevated permission or not
-func WithPermission(enabled bool) Option {
-	return func(p *Probe) {
-		p.withPermission = enabled
-	}
-}
-
 // NewProcessProbe returns a Probe object
-func NewProcessProbe(options ...Option) *Probe {
-	probe := &Probe{}
+func NewProcessProbe(options ...Option) Probe {
+	p := &probe{}
 	for _, option := range options {
-		option(probe)
+		option(p)
 	}
-	return probe
+	return p
 }
 
-// Probe is an unimplemented struct for unsupported platforms
-type Probe struct {
-	returnZeroPermStats bool
-	withPermission      bool
+// probe is an unimplemented struct for unsupported platforms
+type probe struct {
 }
 
-// Close is currently not implemented in non-linux environments
-func (p *Probe) Close() {}
+func (p *probe) Close() {}
 
-// StatsForPIDs is currently not implemented in non-linux environments
-func (p *Probe) StatsForPIDs(pids []int32, now time.Time) (map[int32]*Stats, error) {
-	return nil, fmt.Errorf("StatsForPIDs is not implemented in non-linux environment")
+func (p *probe) StatsForPIDs(pids []int32, now time.Time) (map[int32]*Stats, error) {
+	return nil, fmt.Errorf("StatsForPIDs is not implemented in this environment")
 }
 
-// ProcessesByPID is currently not implemented in non-linux environments
-func (p *Probe) ProcessesByPID(now time.Time) (map[int32]*Process, error) {
-	return nil, fmt.Errorf("ProcessesByPID is not implemented in non-linux environment")
+func (p *probe) ProcessesByPID(now time.Time) (map[int32]*Process, error) {
+	return nil, fmt.Errorf("ProcessesByPID is not implemented in this environment")
 }
 
-// StatsWithPermByPID is currently not implemented in non-linux environments
-func (p *Probe) StatsWithPermByPID(pids []int32) (map[int32]*StatsWithPerm, error) {
-	return nil, fmt.Errorf("StatsWithPermByPID is not implemented in non-linux environment")
+func (p *probe) StatsWithPermByPID(pids []int32) (map[int32]*StatsWithPerm, error) {
+	return nil, fmt.Errorf("StatsWithPermByPID is not implemented in this environment")
 }

--- a/pkg/process/procutil/process_unsupported.go
+++ b/pkg/process/procutil/process_unsupported.go
@@ -26,7 +26,7 @@ func (p *probe) StatsForPIDs(pids []int32, now time.Time) (map[int32]*Stats, err
 	return nil, fmt.Errorf("StatsForPIDs is not implemented in this environment")
 }
 
-func (p *probe) ProcessesByPID(now time.Time) (map[int32]*Process, error) {
+func (p *probe) ProcessesByPID(now time.Time, collectStats bool) (map[int32]*Process, error) {
 	return nil, fmt.Errorf("ProcessesByPID is not implemented in this environment")
 }
 

--- a/pkg/process/procutil/process_windows.go
+++ b/pkg/process/procutil/process_windows.go
@@ -1,0 +1,514 @@
+// +build windows
+
+package procutil
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"time"
+
+	"golang.org/x/sys/windows"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
+	"github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
+)
+
+var (
+	counterPaths = []string{
+		pdhutil.CounterAllProcessPID,
+		pdhutil.CounterAllProcessParentPID,
+		pdhutil.CounterAllProcessPctUserTime,
+		pdhutil.CounterAllProcessPctPrivilegedTime,
+		pdhutil.CounterAllProcessWorkingSet,
+		pdhutil.CounterAllProcessPoolPagedBytes,
+		pdhutil.CounterAllProcessThreadCount,
+		pdhutil.CounterAllProcessHandleCount,
+		pdhutil.CounterAllProcessIOReadOpsPerSec,
+		pdhutil.CounterAllProcessIOWriteOpsPerSec,
+		pdhutil.CounterAllProcessIOReadBytesPerSec,
+		pdhutil.CounterAllProcessIOWriteBytesPerSec,
+	}
+)
+
+// NewProcessProbe returns a Probe object
+func NewProcessProbe(options ...Option) Probe {
+	p := &probe{}
+	p.init()
+	return p
+}
+
+// probe implements Probe on Windows
+type probe struct {
+	hQuery    pdhutil.PDH_HQUERY
+	counters  map[string]pdhutil.PDH_HCOUNTER
+	formatter pdhutil.PdhFormatter
+	enumSpecs map[string]counterEnumSpec
+	initError error
+
+	instanceToPID map[string]int32
+	procs         map[int32]*Process
+}
+
+func (p *probe) init() {
+	var err error
+
+	defer func() {
+		p.initError = err
+		if err != nil {
+			p.Close()
+		}
+	}()
+
+	status := pdhutil.PdhOpenQuery(0, 0, &p.hQuery)
+	if status != 0 {
+		err = fmt.Errorf("PdhOpenQuery failed with 0x%x", status)
+		return
+	}
+
+	p.counters = make(map[string]pdhutil.PDH_HCOUNTER)
+
+	for _, path := range counterPaths {
+		var hCounter pdhutil.PDH_HCOUNTER
+		status = pdhutil.PdhAddEnglishCounter(p.hQuery, path, 0, &hCounter)
+		if status != 0 {
+			err = fmt.Errorf("PdhAddEnglishCounter for %s failed with 0x%x", path, status)
+			return
+		}
+		p.counters[path] = hCounter
+	}
+
+	// Need to run PdhCollectQueryData once so that we have meaningful metrics on the first run
+	status = pdhutil.PdhCollectQueryData(p.hQuery)
+	if status != 0 {
+		err = fmt.Errorf("PdhCollectQueryData failed with 0x%x", status)
+		return
+	}
+
+	p.procs = make(map[int32]*Process)
+	p.initEnumSpecs()
+}
+
+type counterEnumSpec struct {
+	format      uint32
+	processMeta bool
+	enumFunc    pdhutil.ValueEnumFunc
+}
+
+func (p *probe) initEnumSpecs() {
+	p.enumSpecs = map[string]counterEnumSpec{
+		pdhutil.CounterAllProcessParentPID: {
+			format:      pdhutil.PDH_FMT_LARGE,
+			processMeta: true,
+			enumFunc:    p.mapParentPID,
+		},
+		pdhutil.CounterAllProcessPctUserTime: {
+			format:   pdhutil.PDH_FMT_DOUBLE | pdhutil.PDH_FMT_NOCAP100,
+			enumFunc: p.mapPctUserTime,
+		},
+		pdhutil.CounterAllProcessPctPrivilegedTime: {
+			format:   pdhutil.PDH_FMT_DOUBLE | pdhutil.PDH_FMT_NOCAP100,
+			enumFunc: p.mapPctPrivilegedTime,
+		},
+		pdhutil.CounterAllProcessWorkingSet: {
+			format:   pdhutil.PDH_FMT_LARGE,
+			enumFunc: p.mapWorkingSet,
+		},
+		pdhutil.CounterAllProcessPoolPagedBytes: {
+			format:   pdhutil.PDH_FMT_LARGE,
+			enumFunc: p.mapPoolPagedBytes,
+		},
+		pdhutil.CounterAllProcessThreadCount: {
+			format:   pdhutil.PDH_FMT_LARGE,
+			enumFunc: p.mapThreadCount,
+		},
+		pdhutil.CounterAllProcessHandleCount: {
+			format:   pdhutil.PDH_FMT_LARGE,
+			enumFunc: p.mapHandleCount,
+		},
+		pdhutil.CounterAllProcessIOReadOpsPerSec: {
+			format:   pdhutil.PDH_FMT_DOUBLE,
+			enumFunc: p.mapIOReadOpsPerSec,
+		},
+		pdhutil.CounterAllProcessIOWriteOpsPerSec: {
+			format:   pdhutil.PDH_FMT_DOUBLE,
+			enumFunc: p.mapIOWriteOpsPerSec,
+		},
+		pdhutil.CounterAllProcessIOReadBytesPerSec: {
+			format:   pdhutil.PDH_FMT_DOUBLE,
+			enumFunc: p.mapIOReadBytesPerSec,
+		},
+		pdhutil.CounterAllProcessIOWriteBytesPerSec: {
+			format:   pdhutil.PDH_FMT_DOUBLE,
+			enumFunc: p.mapIOWriteBytesPerSec,
+		},
+	}
+}
+
+func (p *probe) Close() {
+	if p.hQuery != pdhutil.PDH_HQUERY(0) {
+		pdhutil.PdhCloseQuery(p.hQuery)
+		p.hQuery = pdhutil.PDH_HQUERY(0)
+	}
+}
+
+func (p *probe) StatsForPIDs(pids []int32, now time.Time) (map[int32]*Stats, error) {
+	err := p.enumCounters(false)
+	if err != nil {
+		return nil, err
+	}
+	statsToReturn := make(map[int32]*Stats)
+	for _, pid := range pids {
+		if proc, ok := p.procs[pid]; ok {
+			statsToReturn[pid] = proc.Stats.DeepCopy()
+		}
+	}
+	return statsToReturn, nil
+}
+
+func (p *probe) ProcessesByPID(now time.Time) (map[int32]*Process, error) {
+	pids, err := getPIDs()
+	if err != nil {
+		return nil, err
+	}
+
+	knownPids := make(map[int32]struct{})
+	for pid := range p.procs {
+		knownPids[pid] = struct{}{}
+	}
+
+	for _, pid := range pids {
+		if pid == 0 {
+			// this is the "system idle process".  We'll never be able to open it,
+			// which will cause us to thrash WMI once per check, which we don't
+			// want to do
+			continue
+		}
+
+		delete(knownPids, pid)
+
+		if _, ok := p.procs[pid]; ok {
+			// Process already known, no need to collect metadata
+			continue
+		}
+
+		proc := &Process{
+			Pid: int32(pid),
+			Stats: &Stats{
+				CPUTime:     &CPUTimesStat{},
+				MemInfo:     &MemoryInfoStat{},
+				CtxSwitches: &NumCtxSwitchesStat{},
+				IORateStat:  &IOCountersRateStat{},
+			},
+		}
+
+		err := fillProcessDetails(pid, proc)
+
+		if err != nil {
+			continue
+		}
+
+		p.procs[pid] = proc
+	}
+
+	for pid := range knownPids {
+		proc := p.procs[pid]
+		log.Debugf("removing process %v %v", pid, proc.Exe)
+		delete(p.procs, pid)
+	}
+
+	err = p.enumCounters(true)
+	if err != nil {
+		return nil, err
+	}
+
+	procsToReturn := make(map[int32]*Process)
+
+	for pid, proc := range p.procs {
+		procsToReturn[pid] = proc.DeepCopy()
+	}
+	return procsToReturn, nil
+}
+
+func (p *probe) enumCounters(includeProcMeta bool) error {
+	p.instanceToPID = make(map[string]int32)
+
+	status := pdhutil.PdhCollectQueryData(p.hQuery)
+	if status != 0 {
+		return fmt.Errorf("PdhCollectQueryData failed with 0x%x", status)
+	}
+
+	err := p.formatter.Enum(p.counters[pdhutil.CounterAllProcessPID], pdhutil.PDH_FMT_LARGE, p.mapPID)
+	if err != nil {
+		return err
+	}
+
+	// handle case when instanceToPID does not contain some previously collected process PIDs
+	missingPids := make(map[int32]struct{})
+	for _, pid := range p.instanceToPID {
+		if _, ok := p.procs[pid]; !ok {
+			missingPids[pid] = struct{}{}
+		}
+	}
+
+	for pid := range missingPids {
+		delete(p.procs, pid)
+	}
+
+	for counter, spec := range p.enumSpecs {
+		if spec.processMeta && !includeProcMeta {
+			continue
+		}
+		err := p.formatter.Enum(p.counters[counter], spec.format, spec.enumFunc)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (p *probe) StatsWithPermByPID(pids []int32) (map[int32]*StatsWithPerm, error) {
+	return nil, fmt.Errorf("probe(Windows): StatsWithPermByPID is not implemented")
+}
+
+func (p *probe) mapToProc(instance string, fn func(proc *Process)) {
+	pid, ok := p.instanceToPID[instance]
+	if !ok {
+		// TODO: log
+		return
+	}
+
+	proc, ok := p.procs[pid]
+	if !ok {
+		// TODO: log
+		return
+	}
+
+	fn(proc)
+}
+
+func (p *probe) mapToStat(instance string, fn func(proc *Stats)) {
+	pid, ok := p.instanceToPID[instance]
+	if !ok {
+		// TODO: log
+		return
+	}
+
+	proc, ok := p.procs[pid]
+	if !ok {
+		// TODO: log
+		return
+	}
+
+	fn(proc.Stats)
+}
+
+func (p *probe) mapPID(instance string, value pdhutil.PdhCounterValue) {
+	p.instanceToPID[instance] = int32(value.Large)
+}
+
+func (p *probe) mapParentPID(instance string, value pdhutil.PdhCounterValue) {
+	p.mapToProc(instance, func(proc *Process) {
+		proc.Ppid = int32(value.Large)
+	})
+}
+
+func (p *probe) mapHandleCount(instance string, value pdhutil.PdhCounterValue) {
+	p.mapToStat(instance, func(stat *Stats) {
+		stat.OpenFdCount = int32(value.Large)
+	})
+}
+
+func (p *probe) mapThreadCount(instance string, value pdhutil.PdhCounterValue) {
+	p.mapToStat(instance, func(stat *Stats) {
+		stat.NumThreads = int32(value.Large)
+	})
+}
+
+func (p *probe) mapPctUserTime(instance string, value pdhutil.PdhCounterValue) {
+	p.mapToStat(instance, func(stat *Stats) {
+		stat.CPUTime.User = value.Double
+	})
+}
+
+func (p *probe) mapPctPrivilegedTime(instance string, value pdhutil.PdhCounterValue) {
+	p.mapToStat(instance, func(stat *Stats) {
+		stat.CPUTime.System = value.Double
+	})
+}
+
+func (p *probe) mapWorkingSet(instance string, value pdhutil.PdhCounterValue) {
+	p.mapToStat(instance, func(stat *Stats) {
+		stat.MemInfo.RSS = uint64(value.Large)
+	})
+}
+
+func (p *probe) mapPoolPagedBytes(instance string, value pdhutil.PdhCounterValue) {
+	p.mapToStat(instance, func(stat *Stats) {
+		stat.MemInfo.VMS = uint64(value.Large)
+	})
+}
+
+func (p *probe) mapIOReadOpsPerSec(instance string, value pdhutil.PdhCounterValue) {
+	p.mapToStat(instance, func(stat *Stats) {
+		stat.IORateStat.ReadRate = value.Double
+	})
+}
+
+func (p *probe) mapIOWriteOpsPerSec(instance string, value pdhutil.PdhCounterValue) {
+	p.mapToStat(instance, func(stat *Stats) {
+		stat.IORateStat.WriteRate = value.Double
+	})
+}
+
+func (p *probe) mapIOReadBytesPerSec(instance string, value pdhutil.PdhCounterValue) {
+	p.mapToStat(instance, func(stat *Stats) {
+		stat.IORateStat.ReadBytesRate = value.Double
+	})
+}
+
+func (p *probe) mapIOWriteBytesPerSec(instance string, value pdhutil.PdhCounterValue) {
+	p.mapToStat(instance, func(stat *Stats) {
+		stat.IORateStat.WriteBytesRate = value.Double
+	})
+}
+
+func getPIDs() ([]int32, error) {
+	var read uint32
+	var psSize uint32 = 1024
+	const dwordSize uint32 = 4
+
+	for {
+		buf := make([]uint32, psSize)
+		if err := windows.EnumProcesses(buf, &read); err != nil {
+			return nil, err
+		}
+		if uint32(len(buf)) == read {
+			psSize += 1024
+			continue
+		}
+		pids := make([]int32, read)
+		for i := range pids {
+			pids[i] = int32(buf[i])
+		}
+		return pids, nil
+	}
+}
+
+func fillProcessDetails(pid int32, proc *Process) error {
+	procHandle, err := openProcHandle(pid)
+	if err != nil {
+		return err
+	}
+	defer windows.Close(procHandle)
+
+	userName, usererr := getUsernameForProcess(procHandle)
+	if usererr != nil {
+		log.Debugf("Couldn't get process username %v %v", pid, err)
+	}
+	proc.Username = userName
+
+	var imagePath, cmdline string
+	if cmdParams, cmderr := winutil.GetCommandParamsForProcess(procHandle, true); cmderr != nil {
+		log.Debugf("Error retrieving command params %v", cmderr)
+	} else {
+		imagePath = cmdParams.ImagePath
+		cmdline = cmdParams.CmdLine
+	}
+
+	proc.Cmdline = parseCmdLineArgs(cmdline)
+	proc.Exe = imagePath
+
+	var CPU windows.Rusage
+	if err := windows.GetProcessTimes(procHandle, &CPU.CreationTime, &CPU.ExitTime, &CPU.KernelTime, &CPU.UserTime); err != nil {
+		log.Errorf("Could not get process times for %v %v", pid, err)
+		return err
+	}
+
+	ctime := CPU.CreationTime.Nanoseconds() / 1000000
+	proc.Stats.CreateTime = ctime
+	return nil
+}
+
+// TODO: deduplicate
+func openProcHandle(pid int32) (windows.Handle, error) {
+	// 0x1000 is PROCESS_QUERY_LIMITED_INFORMATION, but that constant isn't
+	//        defined in x/sys/windows
+	// 0x10   is PROCESS_VM_READ
+	procHandle, err := windows.OpenProcess(0x1010, false, uint32(pid))
+	if err != nil {
+		log.Debugf("Couldn't open process with PROCESS_VM_READ %v %v", pid, err)
+		procHandle, err = windows.OpenProcess(0x1000, false, uint32(pid))
+		if err != nil {
+			log.Debugf("Couldn't open process %v %v", pid, err)
+			return windows.Handle(0), err
+		}
+	}
+	return procHandle, nil
+}
+
+// TODO: deduplicate
+func getUsernameForProcess(h windows.Handle) (name string, err error) {
+	name = ""
+	err = nil
+	var t windows.Token
+	err = windows.OpenProcessToken(h, windows.TOKEN_QUERY, &t)
+	if err != nil {
+		log.Debugf("Failed to open process token %v", err)
+		return
+	}
+	defer t.Close()
+	tokenUser, err := t.GetTokenUser()
+
+	user, domain, _, err := tokenUser.User.Sid.LookupAccount("")
+	if nil != err {
+		return "", err
+	}
+	return domain + "\\" + user, err
+}
+
+// TODO: deduplicate
+func parseCmdLineArgs(cmdline string) (res []string) {
+	blocks := strings.Split(cmdline, " ")
+	findCloseQuote := false
+	donestring := false
+
+	var stringInProgress bytes.Buffer
+	for _, b := range blocks {
+		numquotes := strings.Count(b, "\"")
+		if numquotes == 0 {
+			stringInProgress.WriteString(b)
+			if !findCloseQuote {
+				donestring = true
+			} else {
+				stringInProgress.WriteString(" ")
+			}
+
+		} else if numquotes == 1 {
+			stringInProgress.WriteString(b)
+			if findCloseQuote {
+				donestring = true
+			} else {
+				findCloseQuote = true
+				stringInProgress.WriteString(" ")
+			}
+
+		} else if numquotes == 2 {
+			stringInProgress.WriteString(b)
+			donestring = true
+		} else {
+			log.Warnf("unexpected quotes in string, giving up (%v)", cmdline)
+			return res
+		}
+
+		if donestring {
+			res = append(res, stringInProgress.String())
+			stringInProgress.Reset()
+			findCloseQuote = false
+			donestring = false
+		}
+	}
+	return res
+}

--- a/pkg/process/procutil/process_windows.go
+++ b/pkg/process/procutil/process_windows.go
@@ -546,7 +546,6 @@ func OpenProcessHandle(pid int32) (windows.Handle, error) {
 
 // GetUsernameForProcess returns username for a process
 func GetUsernameForProcess(h windows.Handle) (name string, err error) {
-	name = ""
 	err = nil
 	var t windows.Token
 	err = windows.OpenProcessToken(h, windows.TOKEN_QUERY, &t)

--- a/pkg/process/procutil/process_windows.go
+++ b/pkg/process/procutil/process_windows.go
@@ -256,7 +256,7 @@ func (p *probe) enumCounters(includeProcMeta bool) error {
 		"Idle",   // System Idle process
 	}
 
-	err := p.formatter.Enum(p.counters[pdhutil.CounterAllProcessPID], pdhutil.PDH_FMT_LARGE, ignored, valueToUint64(p.mapPID))
+	err := p.formatter.Enum(pdhutil.CounterAllProcessPID, p.counters[pdhutil.CounterAllProcessPID], pdhutil.PDH_FMT_LARGE, ignored, valueToUint64(p.mapPID))
 
 	if err != nil {
 		return err
@@ -278,7 +278,7 @@ func (p *probe) enumCounters(includeProcMeta bool) error {
 		if spec.processMeta && !includeProcMeta {
 			continue
 		}
-		err := p.formatter.Enum(p.counters[counter], spec.format, ignored, spec.enumFunc)
+		err := p.formatter.Enum(counter, p.counters[counter], spec.format, ignored, spec.enumFunc)
 		if err != nil {
 			return err
 		}

--- a/pkg/process/procutil/process_windows.go
+++ b/pkg/process/procutil/process_windows.go
@@ -385,7 +385,7 @@ func (p *probe) mapWorkingSet(instance string, v uint64) {
 
 func setProcMemVMS(pid int32, stats *Stats, instance string, v uint64) {
 	log.Tracef("Mem.VMS[%s,pid=%d] %d", instance, pid, v)
-	stats.MemInfo.RSS = v
+	stats.MemInfo.VMS = v
 }
 
 func (p *probe) mapPoolPagedBytes(instance string, v uint64) {

--- a/pkg/process/procutil/process_windows.go
+++ b/pkg/process/procutil/process_windows.go
@@ -208,7 +208,7 @@ func (p *probe) ProcessesByPID(now time.Time) (map[int32]*Process, error) {
 		proc := &Process{
 			Pid: int32(pid),
 			Stats: &Stats{
-				CPUTime:     &CPUTimesStat{},
+				CPUPercent:  &CPUPercentStat{},
 				MemInfo:     &MemoryInfoStat{},
 				CtxSwitches: &NumCtxSwitchesStat{},
 				IORateStat:  &IOCountersRateStat{},
@@ -358,7 +358,7 @@ func (p *probe) mapThreadCount(instance string, v uint64) {
 
 func setProcCPUTimeUser(pid int32, stats *Stats, instance string, v float64) {
 	log.Tracef("CPU.User[%s,pid=%d] %f", instance, pid, v)
-	stats.CPUTime.User = v
+	stats.CPUPercent.UserPct = v
 }
 
 func (p *probe) mapPctUserTime(instance string, v float64) {
@@ -367,7 +367,7 @@ func (p *probe) mapPctUserTime(instance string, v float64) {
 
 func setProcCPUTimeSystem(pid int32, stats *Stats, instance string, v float64) {
 	log.Tracef("CPU.System[%s,pid=%d] %f", instance, pid, v)
-	stats.CPUTime.System = v
+	stats.CPUPercent.SystemPct = v
 }
 
 func (p *probe) mapPctPrivilegedTime(instance string, v float64) {

--- a/pkg/process/procutil/process_windows_test.go
+++ b/pkg/process/procutil/process_windows_test.go
@@ -1,12 +1,13 @@
 // +build windows
 
-package checks
+package procutil
 
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 )
 
 func TestCommandLineSplitting(t *testing.T) {
@@ -55,7 +56,7 @@ func TestCommandLineSplitting(t *testing.T) {
 			},
 		},
 	} {
-		assert.Equal(t, tc.expected, parseCmdLineArgs(tc.input))
+		assert.Equal(t, tc.expected, ParseCmdLineArgs(tc.input))
 	}
 }
 
@@ -77,5 +78,4 @@ func TestWindowsStringConversion(t *testing.T) {
 	} {
 		assert.Equal(t, tc.expected, winutil.ConvertWindowsString16(tc.input))
 	}
-
 }

--- a/pkg/util/winutil/pdhutil/pdh.go
+++ b/pkg/util/winutil/pdhutil/pdh.go
@@ -132,6 +132,42 @@ const (
 	ERROR_SUCCESS = 0
 )
 
+const (
+	CounterAllProcessPctProcessorTime   = `\Process(*)\% Processor Time`
+	CounterAllProcessPctUserTime        = `\Process(*)\% User Time`
+	CounterAllProcessPctPrivilegedTime  = `\Process(*)\% Privileged Time`
+	CounterAllProcessVirtualBytesPeak   = `\Process(*)\Virtual Bytes Peak`
+	CounterAllProcessVirtualBytes       = `\Process(*)\Virtual Bytes`
+	CounterAllProcessPageFaultsPerSec   = `\Process(*)\Page Faults/sec`
+	CounterAllProcessWorkingSetPeak     = `\Process(*)\Working Set Peak`
+	CounterAllProcessWorkingSet         = `\Process(*)\Working Set`
+	CounterAllProcessPageFileBytesPeak  = `\Process(*)\Page File Bytes Peak`
+	CounterAllProcessPageFileBytes      = `\Process(*)\Page File Bytes`
+	CounterAllProcessPrivateBytes       = `\Process(*)\Private Bytes`
+	CounterAllProcessThreadCount        = `\Process(*)\Thread Count`
+	CounterAllProcessPriorityBase       = `\Process(*)\Priority Base`
+	CounterAllProcessElapsedTime        = `\Process(*)\Elapsed Time`
+	CounterAllProcessPID                = `\Process(*)\ID Process`
+	CounterAllProcessParentPID          = `\Process(*)\Creating Process ID`
+	CounterAllProcessPoolPagedBytes     = `\Process(*)\Pool Paged Bytes`
+	CounterAllProcessPoolNonpagedBytes  = `\Process(*)\Pool Nonpaged Bytes`
+	CounterAllProcessHandleCount        = `\Process(*)\Handle Count`
+	CounterAllProcessIOReadOpsPerSec    = `\Process(*)\IO Read Operations/sec`
+	CounterAllProcessIOWriteOpsPerSec   = `\Process(*)\IO Write Operations/sec`
+	CounterAllProcessIODataOpsPerSec    = `\Process(*)\IO Data Operations/sec`
+	CounterAllProcessIOOtherOpsPerSec   = `\Process(*)\IO Other Operations/sec`
+	CounterAllProcessIOReadBytesPerSec  = `\Process(*)\IO Read Bytes/sec`
+	CounterAllProcessIOWriteBytesPerSec = `\Process(*)\IO Write Bytes/sec`
+	CounterAllProcessIODataBytesPerSec  = `\Process(*)\IO Data Bytes/sec`
+	CounterAllProcessIOOtherBytesPerSec = `\Process(*)\IO Other Bytes/sec`
+	CounterAllProcessWorkingSetPrivate  = `\Process(*)\Working Set - Private`
+)
+
+type PDH_FMT_COUNTERVALUE_ITEM struct {
+	szName *uint8
+	value  PDH_FMT_COUNTERVALUE_LONG
+}
+
 // PdhOpenQuery Creates a new query that is used to manage the collection of performance data.
 /*
 Parameters

--- a/pkg/util/winutil/pdhutil/pdh.go
+++ b/pkg/util/winutil/pdhutil/pdh.go
@@ -163,12 +163,22 @@ const (
 	CounterAllProcessWorkingSetPrivate  = `\Process(*)\Working Set - Private`
 )
 
-// PDH_FMT_COUNTERVALUE_ITEM structure contains the instance name and formatted value of a counter.
-type PDH_FMT_COUNTERVALUE_ITEM struct {
+// PDH_FMT_COUNTERVALUE_ITEM_LONG structure contains the instance name and formatted value of a PDH_FMT_COUNTERVALUE_LONG counter.
+type PDH_FMT_COUNTERVALUE_ITEM_LONG struct {
 	szName *uint8
-	// Note that while this field is declared as a PDH_FMT_COUNTERVALUE_LONG due to lack of unions in Go,
-	// we have to cast it to a specialization of PDH_FMT_COUNTERVALUE_*
-	value PDH_FMT_COUNTERVALUE_LONG
+	value  PDH_FMT_COUNTERVALUE_LONG
+}
+
+// PDH_FMT_COUNTERVALUE_ITEM_LARGE structure contains the instance name and formatted value of a PDH_FMT_COUNTERVALUE_LARGE counter.
+type PDH_FMT_COUNTERVALUE_ITEM_LARGE struct {
+	szName *uint8
+	value  PDH_FMT_COUNTERVALUE_LARGE
+}
+
+// PDH_FMT_COUNTERVALUE_ITEM_DOUBLE structure contains the instance name and formatted value of a PDH_FMT_COUNTERVALUE_DOUBLE counter.
+type PDH_FMT_COUNTERVALUE_ITEM_DOUBLE struct {
+	szName *uint8
+	value  PDH_FMT_COUNTERVALUE_DOUBLE
 }
 
 // PdhOpenQuery Creates a new query that is used to manage the collection of performance data.

--- a/pkg/util/winutil/pdhutil/pdh.go
+++ b/pkg/util/winutil/pdhutil/pdh.go
@@ -163,9 +163,12 @@ const (
 	CounterAllProcessWorkingSetPrivate  = `\Process(*)\Working Set - Private`
 )
 
+// PDH_FMT_COUNTERVALUE_ITEM structure contains the instance name and formatted value of a counter.
 type PDH_FMT_COUNTERVALUE_ITEM struct {
 	szName *uint8
-	value  PDH_FMT_COUNTERVALUE_LONG
+	// Note that while this field is declared as a PDH_FMT_COUNTERVALUE_LONG due to lack of unions in Go,
+	// we have to cast it to a specialization of PDH_FMT_COUNTERVALUE_*
+	value PDH_FMT_COUNTERVALUE_LONG
 }
 
 // PdhOpenQuery Creates a new query that is used to manage the collection of performance data.

--- a/pkg/util/winutil/pdhutil/pdhformatter.go
+++ b/pkg/util/winutil/pdhutil/pdhformatter.go
@@ -65,6 +65,8 @@ func (f *PdhFormatter) Enum(hCounter PDH_HCOUNTER, format uint32, fn ValueEnumFu
 	}
 
 	var items []PDH_FMT_COUNTERVALUE_ITEM
+	// Accessing the `SliceHeader` to manipulate the `items` slice
+	// In the future we can use unsafe.Slice instead https://pkg.go.dev/unsafe@master#Slice
 	hdrItems := (*reflect.SliceHeader)(unsafe.Pointer(&items))
 	hdrItems.Data = uintptr(unsafe.Pointer(&buf[0]))
 	hdrItems.Len = int(itemCount)
@@ -79,6 +81,8 @@ func (f *PdhFormatter) Enum(hCounter PDH_HCOUNTER, format uint32, fn ValueEnumFu
 	strBufLen := int(bufLen - uint32(unsafe.Sizeof(PDH_FMT_COUNTERVALUE_ITEM{}))*itemCount)
 	for _, item := range items {
 		var u []uint16
+
+		// Accessing the `SliceHeader` to manipulate the `u` slice
 		hdrU := (*reflect.SliceHeader)(unsafe.Pointer(&u))
 		hdrU.Data = uintptr(unsafe.Pointer(item.szName))
 		hdrU.Len = strBufLen / 2

--- a/pkg/util/winutil/pdhutil/pdhformatter.go
+++ b/pkg/util/winutil/pdhutil/pdhformatter.go
@@ -1,0 +1,130 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+// +build windows
+
+package pdhutil
+
+import (
+	"fmt"
+	"reflect"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+// PdhFormatter implements a formatter for PDH performance counters
+type PdhFormatter struct {
+	buf []uint8
+}
+
+// PdhCounterValue represents a counter value
+type PdhCounterValue struct {
+	Format  uint32
+	CStatus uint32
+	Double  float64
+	Large   int64
+	Long    int32
+}
+
+// ValueEnumFunc implements a callback for counter enumeration
+type ValueEnumFunc func(s string, v PdhCounterValue)
+
+// Enum enumerates performance counter values for a wildcard instance counter (e.g. `\Process(*)\% Processor Time`)
+func (f *PdhFormatter) Enum(hCounter PDH_HCOUNTER, format uint32, fn ValueEnumFunc) error {
+	var bufLen uint32
+	var itemCount uint32
+	r, _, _ := procPdhGetFormattedCounterArray.Call(
+		uintptr(hCounter),
+		uintptr(format),
+		uintptr(unsafe.Pointer(&bufLen)),
+		uintptr(unsafe.Pointer(&itemCount)),
+		uintptr(0),
+	)
+
+	if r != PDH_MORE_DATA {
+		return fmt.Errorf("Failed to get formatted counter array buffer size 0x%x", r)
+	}
+
+	if bufLen > uint32(len(f.buf)) {
+		f.buf = make([]uint8, bufLen)
+	}
+
+	buf := f.buf[:bufLen]
+
+	r, _, _ = procPdhGetFormattedCounterArray.Call(
+		uintptr(hCounter),
+		uintptr(format),
+		uintptr(unsafe.Pointer(&bufLen)),
+		uintptr(unsafe.Pointer(&itemCount)),
+		uintptr(unsafe.Pointer(&buf[0])),
+	)
+	if r != ERROR_SUCCESS {
+		return fmt.Errorf("Error getting formatted counter array 0x%x", r)
+	}
+
+	var items []PDH_FMT_COUNTERVALUE_ITEM
+	hdrItems := (*reflect.SliceHeader)(unsafe.Pointer(&items))
+	hdrItems.Data = uintptr(unsafe.Pointer(&buf[0]))
+	hdrItems.Len = int(itemCount)
+	hdrItems.Cap = int(itemCount)
+
+	var (
+		prevName    string
+		instanceIdx int
+	)
+
+	// Instance names are packed in the buffer following the items structs
+	strBufLen := int(bufLen - uint32(unsafe.Sizeof(PDH_FMT_COUNTERVALUE_ITEM{}))*itemCount)
+	for _, item := range items {
+		var u []uint16
+		hdrU := (*reflect.SliceHeader)(unsafe.Pointer(&u))
+		hdrU.Data = uintptr(unsafe.Pointer(item.szName))
+		hdrU.Len = strBufLen / 2
+		hdrU.Cap = strBufLen / 2
+
+		// Scan for terminating NUL char
+		for i, v := range u {
+			if v == 0 {
+				u = u[:i]
+				// subtract from the instance names buffer space
+				strBufLen -= (i + 1) * 2 // in bytes including terminating NUL char
+				break
+			}
+		}
+
+		name := windows.UTF16ToString(u)
+		if name != prevName {
+			instanceIdx = 0
+			prevName = name
+		} else {
+			instanceIdx++
+		}
+
+		value := formattedItemToValue(format, unsafe.Pointer(&item.value))
+		fn(fmt.Sprintf("%s#%d", name, instanceIdx), value)
+	}
+	return nil
+}
+
+func formattedItemToValue(format uint32, p unsafe.Pointer) PdhCounterValue {
+	value := PdhCounterValue{
+		Format: format,
+	}
+	switch format {
+	case PDH_FMT_DOUBLE:
+		from := (*PDH_FMT_COUNTERVALUE_DOUBLE)(p)
+		value.CStatus = from.CStatus
+		value.Double = from.DoubleValue
+	case PDH_FMT_LONG:
+		from := (*PDH_FMT_COUNTERVALUE_LONG)(p)
+		value.CStatus = from.CStatus
+		value.Long = from.LongValue
+	case PDH_FMT_LARGE:
+		from := (*PDH_FMT_COUNTERVALUE_LARGE)(p)
+		value.CStatus = from.CStatus
+		value.Large = from.LargeValue
+	}
+	return value
+}

--- a/pkg/util/winutil/pdhutil/pdhhelper.go
+++ b/pkg/util/winutil/pdhutil/pdhhelper.go
@@ -29,6 +29,7 @@ var (
 	procPdhCloseQuery               = modPdhDll.NewProc("PdhCloseQuery")
 	procPdhOpenQuery                = modPdhDll.NewProc("PdhOpenQuery")
 	procPdhRemoveCounter            = modPdhDll.NewProc("PdhRemoveCounter")
+	procPdhGetFormattedCounterArray = modPdhDll.NewProc("PdhGetFormattedCounterArrayW")
 )
 
 var (

--- a/releasenotes/notes/implement-windows-process-collection-using-pdh-a027db2fc4aded32.yaml
+++ b/releasenotes/notes/implement-windows-process-collection-using-pdh-a027db2fc4aded32.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Provides alternative implementation for process collection on Windows using performance counters.
+enhancements:
+  - |
+    Eliminates the need to synchronize state between regular and RT process collection.

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -28,6 +28,7 @@ MODULE_ALLOWLIST = [
     "pdh.go",
     "pdh_amd64.go",
     "pdh_386.go",
+    "pdhformatter.go",
     "pdhhelper.go",
     "shutil.go",
     "tailer_windows.go",
@@ -111,7 +112,7 @@ def lint(ctx, targets):
 
         if skipped_files:
             for skipped in skipped_files:
-                print("Allowed errors in whitelisted file {}".format(skipped))
+                print("Allowed errors in allowlisted file {}".format(skipped))
 
         # add whitespace for readability
         print()


### PR DESCRIPTION
### What does this PR do?

- Adds probe implementation based on using Windows PDH performance counter APIs which has has the following benefits over the existing `toolhelp` API collector:
  - No need to use process handles to collect process stats
  - Largely reduced number of API calls - we can collect data for all processes using very few calls to get PDH formatted value arrays.
  - New implementation can be turned on by setting `process_config.windows.use_perf_counters`, however the previous check implementation based on the `toolhelp` API will remain the default in the next release.

- Redefines `procutil.Probe` as an interface to allow for multiple implementations for the same OS.
- Consolidate `Process` and `RTProcess` checks:
    - Defines a new interface for a check that can run both regular and RT data collection (`CheckWithRealTime`)
    - Implements a custom check runner that performs skips of RT interval when RT is not enabled.
    - Consolidates functionality in `Process` and `RTProcess` allowing to use the same instance of `procutil.Probe`.
    - Eliminates the need for synchronization between regular and RT process data collection.
  
### Motivation

- Better, more maintainable process collection on Windows.
- Eliminate the need for `procutil.Probe` implementations to be thread safe and eliminate the synchronization between `RTProcess` and `Process` checks. 

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

These are pretty large changes that touch process collection code for multiple platforms.

- Validate that process and RT collection works correctly in all supported platforms.
- Validate the use of perf counter based probe and compare it to the existing legacy toolhelp implementation across supported versions of Windows.
- Validate that the `Connections` check can still properly use create time info from the `Process` check.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
