### PR TITLE
[Serverless] fix serverless build

### DIFF
--- a/.gitlab/binary_build/serverless.yml
+++ b/.gitlab/binary_build/serverless.yml
@@ -7,7 +7,7 @@ build_serverless-deb_x64:
   before_script:
     - !reference [.retrieve_linux_go_deps]
   script:
-    - cd cmd/serverless && go build -mod=mod -a -v -tags serverless
+    - cd cmd/serverless && GOOS=linux go build -mod=mod -a -v -tags serverless
 
 build_serverless-deb_arm64:
   rules:
@@ -19,4 +19,4 @@ build_serverless-deb_arm64:
   before_script:
     - !reference [.retrieve_linux_go_deps]
   script:
-    - cd cmd/serverless && go build -mod=mod -a -v -tags serverless
+    - cd cmd/serverless && GOOS=linux go build -mod=mod -a -v -tags serverless


### PR DESCRIPTION
### What does this PR do?

Add GOOS=linux to match the exact same command line we use to build the serverless extension

### Motivation

Extension was not building from main, we need to detect it as early as possible

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
