### PR TITLE
Use container instance guid for ADIdentifier

### DIFF
--- a/pkg/autodiscovery/listeners/cloudfoundry_test.go
+++ b/pkg/autodiscovery/listeners/cloudfoundry_test.go
@@ -94,7 +94,7 @@ func TestCloudFoundryListener(t *testing.T) {
 		{
 			// inputs with no AD_DATADOGHQ_COM set up => no services
 			aLRP: map[string][]*cloudfoundry.ActualLRP{
-				"processguid1": {{ProcessGUID: "processguid1", CellID: "cellX", Index: 0}, {ProcessGUID: "processguid1", CellID: "cellY", Index: 1}},
+				"processguid1": {{ProcessGUID: "processguid1", CellID: "cellX", InstanceGUID: "instance-guid-1-0"}, {ProcessGUID: "processguid1", CellID: "cellY", InstanceGUID: "instance-guid-1-1"}},
 			},
 			dLRP: map[string]*cloudfoundry.DesiredLRP{
 				"processguid1": {AppGUID: "appguid1", ProcessGUID: "processguid1"},
@@ -105,7 +105,7 @@ func TestCloudFoundryListener(t *testing.T) {
 		{
 			// inputs with AD_DATADOGHQ_COM containing config only for containers, but no containers of the app exist
 			aLRP: map[string][]*cloudfoundry.ActualLRP{
-				"processguid1": {{ProcessGUID: "processguid1", CellID: "cellX", Index: 0}, {ProcessGUID: "processguid1", CellID: "cellY", Index: 1}},
+				"processguid1": {{ProcessGUID: "processguid1", CellID: "cellX", InstanceGUID: "instance-guid-1-0"}, {ProcessGUID: "processguid1", CellID: "cellY", InstanceGUID: "instance-guid-1-1"}},
 			},
 			dLRP: map[string]*cloudfoundry.DesiredLRP{
 				"differentappguid": {
@@ -128,21 +128,20 @@ func TestCloudFoundryListener(t *testing.T) {
 					{
 						ProcessGUID:  "processguid1",
 						CellID:       "cellX",
-						InstanceGUID: "instance1",
+						InstanceGUID: "instance-guid-1-0",
 						ContainerIP:  "1.2.3.4",
-						Index:        0,
 						Ports:        []uint32{11, 22},
 						State:        cloudfoundry.ActualLrpStateRunning,
 					},
 				},
 				"differentprocessguid1": {
 					{
-						ProcessGUID: "differentprocessguid1",
-						CellID:      "cellY",
-						ContainerIP: "1.2.3.5",
-						Index:       1,
-						Ports:       []uint32{33, 44},
-						State:       cloudfoundry.ActualLrpStateRunning,
+						ProcessGUID:  "differentprocessguid1",
+						CellID:       "cellY",
+						ContainerIP:  "1.2.3.5",
+						InstanceGUID: "different-instance-guid-1-0",
+						Ports:        []uint32{33, 44},
+						State:        cloudfoundry.ActualLrpStateRunning,
 					},
 				},
 			},
@@ -157,9 +156,9 @@ func TestCloudFoundryListener(t *testing.T) {
 					}},
 				},
 			},
-			tagsByCellID: map[string]map[string][]string{"cellX": {"instance1": {"tag:x"}}, "cellY": {"differentinstance1": {"tag:y"}}},
+			tagsByCellID: map[string]map[string][]string{"cellX": {"instance-guid-1-0": {"tag:x"}}, "cellY": {"different-instance-guid-1-0": {"tag:y"}}},
 			expNew: map[string]Service{
-				"processguid1/flask-app/0": &CloudFoundryService{
+				"processguid1/flask-app/instance-guid-1-0": &CloudFoundryService{
 					containerIPs:   map[string]string{CfServiceContainerIP: "1.2.3.4"},
 					containerPorts: []ContainerPort{{Port: 11, Name: "p11"}, {Port: 22, Name: "p22"}},
 					creationTime:   integration.After,
@@ -174,7 +173,7 @@ func TestCloudFoundryListener(t *testing.T) {
 			dLRP:   map[string]*cloudfoundry.DesiredLRP{},
 			expNew: map[string]Service{},
 			expDel: map[string]Service{
-				"processguid1/flask-app/0": &CloudFoundryService{
+				"processguid1/flask-app/instance-guid-1-0": &CloudFoundryService{
 					containerIPs:   map[string]string{CfServiceContainerIP: "1.2.3.4"},
 					containerPorts: []ContainerPort{{Port: 11, Name: "p11"}, {Port: 22, Name: "p22"}},
 					creationTime:   integration.After,
@@ -185,7 +184,7 @@ func TestCloudFoundryListener(t *testing.T) {
 		{
 			// inputs with AD_DATADOGHQ_COM containing config only for non-containers, no container exists for the app
 			aLRP: map[string][]*cloudfoundry.ActualLRP{
-				"differentprocessguid1": {{ProcessGUID: "differentprocessguid1", CellID: "cellX", Index: 1, InstanceGUID: "differentinstance1"}},
+				"differentprocessguid1": {{ProcessGUID: "differentprocessguid1", CellID: "cellX", InstanceGUID: "different-instance-guid-1-0"}},
 			},
 			dLRP: map[string]*cloudfoundry.DesiredLRP{
 				"myprocessguid1": {
@@ -201,7 +200,7 @@ func TestCloudFoundryListener(t *testing.T) {
 					EnvVcapServices: map[string][]byte{"my-postgres": []byte(`{"credentials":{"host":"a.b.c","Username":"me","Password":"secret","database_name":"mydb"}}`)},
 				},
 			},
-			tagsByCellID: map[string]map[string][]string{"cellX": {"differentinstance1": {"tag:x"}}},
+			tagsByCellID: map[string]map[string][]string{"cellX": {"different-instance-guid-1-0": {"tag:x"}}},
 			expNew: map[string]Service{
 				"myappguid1/my-postgres": &CloudFoundryService{
 					containerIPs:   map[string]string{},
@@ -219,28 +218,25 @@ func TestCloudFoundryListener(t *testing.T) {
 				"processguid1": {
 					{
 						ProcessGUID:  "processguid1",
-						InstanceGUID: "instance11",
+						InstanceGUID: "instance-guid-1-0",
 						CellID:       "cellX",
 						ContainerIP:  "1.2.3.4",
-						Index:        0,
 						Ports:        []uint32{11, 22},
 						State:        cloudfoundry.ActualLrpStateRunning,
 					},
 					{
 						ProcessGUID:  "processguid1",
-						InstanceGUID: "instance12",
+						InstanceGUID: "instance-guid-1-1",
 						CellID:       "cellY",
 						ContainerIP:  "1.2.3.5",
-						Index:        1,
 						Ports:        []uint32{33, 44},
 						State:        cloudfoundry.ActualLrpStateRunning,
 					},
 					{
 						ProcessGUID:  "processguid1",
-						InstanceGUID: "instance13",
+						InstanceGUID: "instance-guid-1-2",
 						CellID:       "cellZ",
 						ContainerIP:  "1.2.3.6",
-						Index:        2,
 						Ports:        []uint32{55, 66},
 						State:        "NOTRUNNING",
 					},
@@ -248,19 +244,17 @@ func TestCloudFoundryListener(t *testing.T) {
 				"processguid2": {
 					{
 						ProcessGUID:  "processguid2",
-						InstanceGUID: "instance21",
+						InstanceGUID: "instance-guid-2-0",
 						CellID:       "cellY",
 						ContainerIP:  "1.2.3.7",
-						Index:        0,
 						Ports:        []uint32{77, 88},
 						State:        cloudfoundry.ActualLrpStateRunning,
 					},
 					{
 						ProcessGUID:  "processguid2",
-						InstanceGUID: "instance22",
+						InstanceGUID: "instance-guid-2-1",
 						CellID:       "cellZ",
 						ContainerIP:  "1.2.3.8",
-						Index:        1,
 						Ports:        []uint32{99, 111},
 						State:        cloudfoundry.ActualLrpStateRunning,
 					},
@@ -268,16 +262,15 @@ func TestCloudFoundryListener(t *testing.T) {
 				"processguid3": {
 					{
 						ProcessGUID:  "processguid3",
-						InstanceGUID: "instance31",
+						InstanceGUID: "instance-guid-3-0",
 						CellID:       "cellZ",
 						ContainerIP:  "1.2.3.9",
-						Index:        0,
 						Ports:        []uint32{222, 333},
 						State:        cloudfoundry.ActualLrpStateRunning,
 					},
 					{
 						ProcessGUID:  "processguid3",
-						InstanceGUID: "instance32",
+						InstanceGUID: "instance-guid-3-1",
 						CellID:       "cellZ",
 						ContainerIP:  "1.2.3.10",
 						Index:        1,
@@ -340,17 +333,17 @@ func TestCloudFoundryListener(t *testing.T) {
 			},
 			tagsByCellID: map[string]map[string][]string{
 				"cellX": {
-					"instance11": {"tag:11"},
+					"instance-guid-1-0": {"tag:11"},
 				},
 				"cellY": {
-					"instance12": {"tag:12"},
-					"instance21": {"tag:21"},
+					"instance-guid-1-1": {"tag:12"},
+					"instance-guid-2-0": {"tag:21"},
 				},
 				"cellZ": {
-					"instance13": {"tag:13"},
-					"instance22": {"tag:22"},
-					"instance31": {"tag:31"},
-					"instance32": {"tag:32"},
+					"instance-guid-1-2": {"tag:13"},
+					"instance-guid-2-1": {"tag:22"},
+					"instance-guid-3-0": {"tag:31"},
+					"instance-guid-3-1": {"tag:32"},
 				},
 			},
 			expDel: map[string]Service{
@@ -362,7 +355,7 @@ func TestCloudFoundryListener(t *testing.T) {
 				},
 			},
 			expNew: map[string]Service{
-				"processguid1/flask-app/0": &CloudFoundryService{
+				"processguid1/flask-app/instance-guid-1-0": &CloudFoundryService{
 					containerIPs: map[string]string{CfServiceContainerIP: "1.2.3.4"},
 					containerPorts: []ContainerPort{
 						{
@@ -377,7 +370,7 @@ func TestCloudFoundryListener(t *testing.T) {
 					creationTime: integration.After,
 					tags:         []string{"tag:11"},
 				},
-				"processguid1/flask-app/1": &CloudFoundryService{
+				"processguid1/flask-app/instance-guid-1-1": &CloudFoundryService{
 					containerIPs: map[string]string{CfServiceContainerIP: "1.2.3.5"},
 					containerPorts: []ContainerPort{
 						{
@@ -398,7 +391,7 @@ func TestCloudFoundryListener(t *testing.T) {
 					creationTime:   integration.After,
 					tags:           []string{"app_guid:appguid1", "app_id:appguid1", "app_name:appname1", "org_id:orgguid1", "org_name:orgname1", "space_id:spaceguid1", "space_name:spacename1"},
 				},
-				"processguid2/flask-app/0": &CloudFoundryService{
+				"processguid2/flask-app/instance-guid-2-0": &CloudFoundryService{
 					containerIPs: map[string]string{CfServiceContainerIP: "1.2.3.7"},
 					containerPorts: []ContainerPort{
 						{
@@ -413,7 +406,7 @@ func TestCloudFoundryListener(t *testing.T) {
 					creationTime: integration.After,
 					tags:         []string{"tag:21"},
 				},
-				"processguid2/flask-app/1": &CloudFoundryService{
+				"processguid2/flask-app/instance-guid-2-1": &CloudFoundryService{
 					containerIPs: map[string]string{CfServiceContainerIP: "1.2.3.8"},
 					containerPorts: []ContainerPort{
 						{

--- a/pkg/autodiscovery/providers/cloudfoundry_test.go
+++ b/pkg/autodiscovery/providers/cloudfoundry_test.go
@@ -99,7 +99,7 @@ func TestCloudFoundryConfigProvider_Collect(t *testing.T) {
 			// inputs with no AD_DATADOGHQ_COM set up => no configs
 			tc: "no_ad_config",
 			aLRP: map[string][]*cloudfoundry.ActualLRP{
-				"processguid1": {{ProcessGUID: "processguid1", CellID: "cellX", Index: 0}, {ProcessGUID: "processguid1", CellID: "cellY", Index: 1}},
+				"processguid1": {{ProcessGUID: "processguid1", CellID: "cellX", InstanceGUID: "instance-guid-1-0"}, {ProcessGUID: "processguid1", CellID: "cellY", InstanceGUID: "instance-guid-1-1"}},
 			},
 			dLRP: map[string]*cloudfoundry.DesiredLRP{
 				"processguid1": {AppGUID: "appguid1", ProcessGUID: "processguid1"},
@@ -110,7 +110,7 @@ func TestCloudFoundryConfigProvider_Collect(t *testing.T) {
 			// inputs with AD_DATADOGHQ_COM containing config only for containers, but no containers of the app exist
 			tc: "ad_config_present_but_no_containers_running",
 			aLRP: map[string][]*cloudfoundry.ActualLRP{
-				"processguid1": {{ProcessGUID: "processguid1", CellID: "cellX", Index: 0}, {ProcessGUID: "processguid1", CellID: "cellY", Index: 1}},
+				"processguid1": {{ProcessGUID: "processguid1", CellID: "cellX", InstanceGUID: "instance-guid-1-0"}, {ProcessGUID: "processguid1", CellID: "cellY", InstanceGUID: "instance-guid-1-1"}},
 			},
 			dLRP: map[string]*cloudfoundry.DesiredLRP{
 				"differentprocessguid": {
@@ -129,8 +129,8 @@ func TestCloudFoundryConfigProvider_Collect(t *testing.T) {
 			// inputs with AD_DATADOGHQ_COM containing config only for containers, 1 container exists for the app
 			tc: "ad_config_present_1_container_running",
 			aLRP: map[string][]*cloudfoundry.ActualLRP{
-				"processguid1":          {{ProcessGUID: "processguid1", CellID: "cellX", Index: 0}},
-				"differentprocessguid1": {{ProcessGUID: "differentprocessguid1", CellID: "cellY", Index: 1}},
+				"processguid1":          {{ProcessGUID: "processguid1", CellID: "cellX", InstanceGUID: "instance-guid-1-0"}},
+				"differentprocessguid1": {{ProcessGUID: "differentprocessguid1", CellID: "cellY", InstanceGUID: "different-instance-guid-1-0"}},
 			},
 			dLRP: map[string]*cloudfoundry.DesiredLRP{
 				"processguid1": {
@@ -145,9 +145,9 @@ func TestCloudFoundryConfigProvider_Collect(t *testing.T) {
 			},
 			expected: []integration.Config{
 				{
-					ADIdentifiers: []string{"processguid1/flask-app/0"},
+					ADIdentifiers: []string{"processguid1/flask-app/instance-guid-1-0"},
 					ClusterCheck:  true,
-					Entity:        "processguid1/flask-app/0",
+					Entity:        "processguid1/flask-app/instance-guid-1-0",
 					InitConfig:    []byte(`{}`),
 					Instances:     []integration.Data{[]byte(`{"name":"My Nginx","timeout":1,"url":"http://%%host%%:%%port_p8080%%"}`)},
 					Name:          "http_check",
@@ -159,8 +159,8 @@ func TestCloudFoundryConfigProvider_Collect(t *testing.T) {
 			// inputs with AD_DATADOGHQ_COM containing config only for containers, 2 containers exist for the app
 			tc: "ad_config_present_2_containers_running",
 			aLRP: map[string][]*cloudfoundry.ActualLRP{
-				"processguid1":          {{ProcessGUID: "processguid1", CellID: "cellX", Index: 0}, {ProcessGUID: "processguid1", CellID: "cellY", Index: 1}},
-				"differentprocessguid1": {{ProcessGUID: "differentprocessguid1", CellID: "cellZ", Index: 1}},
+				"processguid1":          {{ProcessGUID: "processguid1", CellID: "cellX", InstanceGUID: "instance-guid-1-0"}, {ProcessGUID: "processguid1", CellID: "cellY", InstanceGUID: "instance-guid-1-1"}},
+				"differentprocessguid1": {{ProcessGUID: "differentprocessguid1", CellID: "cellZ", InstanceGUID: "different-instance-guid-1-0"}},
 			},
 			dLRP: map[string]*cloudfoundry.DesiredLRP{
 				"processguid1": {
@@ -175,18 +175,18 @@ func TestCloudFoundryConfigProvider_Collect(t *testing.T) {
 			},
 			expected: []integration.Config{
 				{
-					ADIdentifiers: []string{"processguid1/flask-app/0"},
+					ADIdentifiers: []string{"processguid1/flask-app/instance-guid-1-0"},
 					ClusterCheck:  true,
-					Entity:        "processguid1/flask-app/0",
+					Entity:        "processguid1/flask-app/instance-guid-1-0",
 					InitConfig:    []byte(`{}`),
 					Instances:     []integration.Data{[]byte(`{"name":"My Nginx","timeout":1,"url":"http://%%host%%:%%port_p8080%%"}`)},
 					Name:          "http_check",
 					NodeName:      "cellX",
 				},
 				{
-					ADIdentifiers: []string{"processguid1/flask-app/1"},
+					ADIdentifiers: []string{"processguid1/flask-app/instance-guid-1-1"},
 					ClusterCheck:  true,
-					Entity:        "processguid1/flask-app/1",
+					Entity:        "processguid1/flask-app/instance-guid-1-1",
 					InitConfig:    []byte(`{}`),
 					Instances:     []integration.Data{[]byte(`{"name":"My Nginx","timeout":1,"url":"http://%%host%%:%%port_p8080%%"}`)},
 					Name:          "http_check",
@@ -261,9 +261,9 @@ func TestCloudFoundryConfigProvider_Collect(t *testing.T) {
 			// complex test with three apps, one having no AD configuration, two having different configurations for both container and non-container services
 			tc: "complex",
 			aLRP: map[string][]*cloudfoundry.ActualLRP{
-				"processguid1": {{ProcessGUID: "processguid1", CellID: "cellX", Index: 0}, {ProcessGUID: "processguid1", CellID: "cellY", Index: 1}},
-				"processguid2": {{ProcessGUID: "processguid2", CellID: "cellY", Index: 0}, {ProcessGUID: "processguid2", CellID: "cellZ", Index: 1}},
-				"processguid3": {{ProcessGUID: "processguid3", CellID: "cellZ", Index: 0}, {ProcessGUID: "processguid3", CellID: "cellZ", Index: 1}},
+				"processguid1": {{ProcessGUID: "processguid1", CellID: "cellX", InstanceGUID: "instance-guid-1-0"}, {ProcessGUID: "processguid1", CellID: "cellY", InstanceGUID: "instance-guid-1-1"}},
+				"processguid2": {{ProcessGUID: "processguid2", CellID: "cellY", InstanceGUID: "instance-guid-2-0"}, {ProcessGUID: "processguid2", CellID: "cellZ", InstanceGUID: "instance-guid-2-1"}},
+				"processguid3": {{ProcessGUID: "processguid3", CellID: "cellZ", InstanceGUID: "instance-guid-3-0"}, {ProcessGUID: "processguid3", CellID: "cellZ", InstanceGUID: "instance-guid-3-1"}},
 			},
 			dLRP: map[string]*cloudfoundry.DesiredLRP{
 				"processguid1": {
@@ -318,18 +318,18 @@ func TestCloudFoundryConfigProvider_Collect(t *testing.T) {
 					NodeName:      "cellX",
 				},
 				{
-					ADIdentifiers: []string{"processguid1/flask-app/0"},
+					ADIdentifiers: []string{"processguid1/flask-app/instance-guid-1-0"},
 					ClusterCheck:  true,
-					Entity:        "processguid1/flask-app/0",
+					Entity:        "processguid1/flask-app/instance-guid-1-0",
 					InitConfig:    []byte(`{}`),
 					Instances:     []integration.Data{[]byte(`{"name":"My Nginx","timeout":1,"url":"http://%%host%%:%%port_p8080%%"}`)},
 					Name:          "http_check",
 					NodeName:      "cellX",
 				},
 				{
-					ADIdentifiers: []string{"processguid1/flask-app/1"},
+					ADIdentifiers: []string{"processguid1/flask-app/instance-guid-1-1"},
 					ClusterCheck:  true,
-					Entity:        "processguid1/flask-app/1",
+					Entity:        "processguid1/flask-app/instance-guid-1-1",
 					InitConfig:    []byte(`{}`),
 					Instances:     []integration.Data{[]byte(`{"name":"My Nginx","timeout":1,"url":"http://%%host%%:%%port_p8080%%"}`)},
 					Name:          "http_check",
@@ -345,18 +345,18 @@ func TestCloudFoundryConfigProvider_Collect(t *testing.T) {
 					NodeName:      "cellY",
 				},
 				{
-					ADIdentifiers: []string{"processguid2/flask-app/0"},
+					ADIdentifiers: []string{"processguid2/flask-app/instance-guid-2-0"},
 					ClusterCheck:  true,
-					Entity:        "processguid2/flask-app/0",
+					Entity:        "processguid2/flask-app/instance-guid-2-0",
 					InitConfig:    []byte(`{}`),
 					Instances:     []integration.Data{[]byte(`{"name":"My Nginx","timeout":1,"url":"http://%%host%%:%%port_p8080%%"}`)},
 					Name:          "http_check",
 					NodeName:      "cellY",
 				},
 				{
-					ADIdentifiers: []string{"processguid2/flask-app/1"},
+					ADIdentifiers: []string{"processguid2/flask-app/instance-guid-2-1"},
 					ClusterCheck:  true,
-					Entity:        "processguid2/flask-app/1",
+					Entity:        "processguid2/flask-app/instance-guid-2-1",
 					InitConfig:    []byte(`{}`),
 					Instances:     []integration.Data{[]byte(`{"name":"My Nginx","timeout":1,"url":"http://%%host%%:%%port_p8080%%"}`)},
 					Name:          "http_check",

--- a/pkg/util/cloudfoundry/types.go
+++ b/pkg/util/cloudfoundry/types.go
@@ -94,7 +94,7 @@ func (id ADIdentifier) GetDesiredLRP() *DesiredLRP {
 func (id ADIdentifier) String() string {
 	if id.actualLRP != nil {
 		// For container checks, use processGUID to have 1 check per container, even during rolling redeployments
-		return fmt.Sprintf("%s/%s/%d", id.desiredLRP.ProcessGUID, id.svcName, id.actualLRP.Index)
+		return fmt.Sprintf("%s/%s/%s", id.desiredLRP.ProcessGUID, id.svcName, id.actualLRP.InstanceGUID)
 	}
 	// For non container checks, use appGUID to have one check per service, even during rolling redeployments
 	return fmt.Sprintf("%s/%s", id.desiredLRP.AppGUID, id.svcName)

--- a/pkg/util/cloudfoundry/types_test.go
+++ b/pkg/util/cloudfoundry/types_test.go
@@ -235,9 +235,9 @@ func TestADIdentifier(t *testing.T) {
 			},
 			svcName: "flask-app",
 			aLRP: &ActualLRP{
-				Index: 2,
+				InstanceGUID: "instance-guid",
 			},
-			expected: "4321/flask-app/2",
+			expected: "4321/flask-app/instance-guid",
 		},
 	} {
 		t.Run(fmt.Sprintf(""), func(t *testing.T) {

--- a/releasenotes/notes/cloudfoundry-ad-2d22f320dd2b172c.yaml
+++ b/releasenotes/notes/cloudfoundry-ad-2d22f320dd2b172c.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix an issue with autodiscovery on CloudFoundry where in case an application instance crash, a new integration configuration would not be created for the new app instance.


### PR DESCRIPTION
### What does this PR do?

Fixes the ADIdentifier to be unique in case an app instance crashes and is restarted. 

### Motivation

The index stays the same on crash and restart but the container is different, including the IP, making discovered checks to fail and never be updated.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.

Note: Adding GitHub labels is only possible for contributors with write access.
