### PR TITLE
[system-probe] Add to runtime compilation results

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	code.cloudfoundry.org/rep v0.0.0-20200325195957-1404b978e31e // indirect
 	code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a // indirect
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
-	github.com/DataDog/agent-payload v4.78.0+incompatible
+	github.com/DataDog/agent-payload v4.80.0+incompatible
 	github.com/DataDog/datadog-agent/pkg/util/log v0.30.0-rc.7
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.30.0-rc.7
 	github.com/DataDog/datadog-go v4.8.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -96,8 +96,8 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DataDog/agent-payload v4.78.0+incompatible h1:K1ViQVfIAEaSEBLug087JkcnVP+NKxKU4nQ1OucCglU=
-github.com/DataDog/agent-payload v4.78.0+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
+github.com/DataDog/agent-payload v4.80.0+incompatible h1:fYmbV/oW3rQub6add/Ikldh8t/SyI47oVJsHg1PhqVw=
+github.com/DataDog/agent-payload v4.80.0+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/DataDog/datadog-api-client-go v1.0.0-beta.18/go.mod h1:Gn0fZwIOBbSidO0OaPEh9nO5EmIPsxJrHfHvfVXEaoU=

--- a/pkg/ebpf/bytecode/runtime/runtime_asset.go
+++ b/pkg/ebpf/bytecode/runtime/runtime_asset.go
@@ -48,6 +48,7 @@ const (
 	compilationErr
 	resultReadErr
 	headerFetchErr
+	compiledOutputFound
 )
 
 type CompiledOutput interface {
@@ -154,12 +155,13 @@ func (a *RuntimeAsset) Compile(config *ebpf.Config, cflags []string) (CompiledOu
 			a.compilationResult = compilationErr
 			return nil, fmt.Errorf("failed to compile runtime version of %s: %s", a.filename, err)
 		}
+		a.compilationResult = compilationSuccess
+	} else {
+		a.compilationResult = compiledOutputFound
 	}
 
 	out, err := os.Open(outputFile)
-	if err == nil {
-		a.compilationResult = compilationSuccess
-	} else {
+	if err != nil {
 		a.compilationResult = resultReadErr
 	}
 	return out, err


### PR DESCRIPTION
### What does this PR do?

Adds `compiledOutputFound` as a possible runtime compilation result.

### Motivation

Getting more clarity on the number of hosts which are successfully compiling runtime assets vs re-using previously compiled assets

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

1. In your system-probe.yaml file, enable runtime compilation
```
system_probe_config:
  enabled: true
  enable_runtime_compiler: true
```
2. Start the system-probe & in a separate window, verify that the agent telemetry indicates runtime compilation succeeded:
```
$ curl -s --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/connections?client_id=1 | jq .compilationTelemetryByAsset.tracer.runtimeCompilationResult
"CompilationSuccess"
```
3. Restart the system-probe & in a separate window, verify that the agent telemetry indicates the previously compiled asset was used:
```
$ curl -s --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/connections?client_id=1 | jq .compilationTelemetryByAsset.tracer.runtimeCompilationResult
"CompiledOutputFound"
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.

Note: Adding GitHub labels is only possible for contributors with write access.
