### PR TITLE
[Serverless] skip hostname resolution in Serverless context (2)

### DIFF
--- a/pkg/serverless/trace/trace.go
+++ b/pkg/serverless/trace/trace.go
@@ -8,6 +8,7 @@ package trace
 import (
 	"context"
 
+	ddConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/agent"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -37,6 +38,9 @@ func (l *LoadConfig) Load() (*config.AgentConfig, error) {
 // Start starts the agent
 func (s *ServerlessTraceAgent) Start(enabled bool, loadConfig Load) {
 	if enabled {
+		//this will fail the grpc client and allow to skip hostname resolution
+		ddConfig.Datadog.Set("cmd_port", "0")
+
 		tc, confErr := loadConfig.Load()
 		if confErr != nil {
 			log.Errorf("Unable to load trace agent config: %s", confErr)

--- a/pkg/serverless/trace/trace.go
+++ b/pkg/serverless/trace/trace.go
@@ -38,7 +38,9 @@ func (l *LoadConfig) Load() (*config.AgentConfig, error) {
 // Start starts the agent
 func (s *ServerlessTraceAgent) Start(enabled bool, loadConfig Load) {
 	if enabled {
-		//this will fail the grpc client and allow to skip hostname resolution
+		// during hostname resolution the first step is to make a GRPC call which is timeboxed to a 2 seconds deadline
+		// in the serverless mode, we don't start the GRPC server so this call will fail and cause a 2 seconds delay
+		// by setting cmd_port to 0, this will cause the GRPC client to fail instantly
 		ddConfig.Datadog.Set("cmd_port", "0")
 
 		tc, confErr := loadConfig.Load()

--- a/pkg/serverless/trace/trace.go
+++ b/pkg/serverless/trace/trace.go
@@ -40,8 +40,8 @@ func (s *ServerlessTraceAgent) Start(enabled bool, loadConfig Load) {
 	if enabled {
 		// during hostname resolution the first step is to make a GRPC call which is timeboxed to a 2 seconds deadline
 		// in the serverless mode, we don't start the GRPC server so this call will fail and cause a 2 seconds delay
-		// by setting cmd_port to 0, this will cause the GRPC client to fail instantly
-		ddConfig.Datadog.Set("cmd_port", "0")
+		// by setting cmd_port to -1, this will cause the GRPC client to fail instantly
+		ddConfig.Datadog.Set("cmd_port", "-1")
 
 		tc, confErr := loadConfig.Load()
 		if confErr != nil {

--- a/pkg/serverless/trace/trace_test.go
+++ b/pkg/serverless/trace/trace_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"os"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/stretchr/testify/assert"
@@ -63,4 +64,21 @@ func TestStartEnabledTrueValidConfigValidPath(t *testing.T) {
 	assert.NotNil(t, agent.Get())
 	assert.NotNil(t, agent.cancel)
 
+}
+
+func TestLoadConfigShouldBeFast(t *testing.T) {
+	timeout := time.After(100 * time.Millisecond)
+	done := make(chan bool)
+	go func() {
+		var agent = &ServerlessTraceAgent{}
+		agent.Start(true, &LoadConfig{Path: "./testdata/valid.yml"})
+		defer agent.Stop()
+		done <- true
+	}()
+
+	select {
+	case <-timeout:
+		t.Fatal("Tracer config load/validation is too long")
+	case <-done:
+	}
 }

--- a/pkg/serverless/trace/trace_test.go
+++ b/pkg/serverless/trace/trace_test.go
@@ -67,7 +67,7 @@ func TestStartEnabledTrueValidConfigValidPath(t *testing.T) {
 }
 
 func TestLoadConfigShouldBeFast(t *testing.T) {
-	timeout := time.After(100 * time.Millisecond)
+	timeout := time.After(1 * time.Second)
 	done := make(chan bool)
 	go func() {
 		var agent = &ServerlessTraceAgent{}

--- a/pkg/util/grpc/agent_client.go
+++ b/pkg/util/grpc/agent_client.go
@@ -31,11 +31,9 @@ var defaultAgentDialOpts = []grpc.DialOption{
 // GetDDAgentClient creates a pb.AgentClient for IPC with the main agent via gRPC. This call is blocking by default, so
 // it is up to the caller to supply a context with appropriate timeout/cancel options
 func GetDDAgentClient(ctx context.Context, opts ...grpc.DialOption) (pb.AgentClient, error) {
-
 	if config.Datadog.GetString("cmd_port") == "0" {
 		return nil, errors.New("grpc client disabled via cmd_port: 0")
 	}
-
 	// This is needed as the server hangs when using "grpc.WithInsecure()"
 	tlsConf := tls.Config{InsecureSkipVerify: true}
 

--- a/pkg/util/grpc/agent_client.go
+++ b/pkg/util/grpc/agent_client.go
@@ -3,6 +3,7 @@ package grpc
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"net"
 	"time"
 
@@ -30,6 +31,11 @@ var defaultAgentDialOpts = []grpc.DialOption{
 // GetDDAgentClient creates a pb.AgentClient for IPC with the main agent via gRPC. This call is blocking by default, so
 // it is up to the caller to supply a context with appropriate timeout/cancel options
 func GetDDAgentClient(ctx context.Context, opts ...grpc.DialOption) (pb.AgentClient, error) {
+
+	if config.Datadog.GetString("cmd_port") == "0" {
+		return nil, errors.New("grpc client disabled via cmd_port: 0")
+	}
+
 	// This is needed as the server hangs when using "grpc.WithInsecure()"
 	tlsConf := tls.Config{InsecureSkipVerify: true}
 

--- a/pkg/util/grpc/agent_client.go
+++ b/pkg/util/grpc/agent_client.go
@@ -31,8 +31,8 @@ var defaultAgentDialOpts = []grpc.DialOption{
 // GetDDAgentClient creates a pb.AgentClient for IPC with the main agent via gRPC. This call is blocking by default, so
 // it is up to the caller to supply a context with appropriate timeout/cancel options
 func GetDDAgentClient(ctx context.Context, opts ...grpc.DialOption) (pb.AgentClient, error) {
-	if config.Datadog.GetString("cmd_port") == "0" {
-		return nil, errors.New("grpc client disabled via cmd_port: 0")
+	if config.Datadog.GetString("cmd_port") == "-1" {
+		return nil, errors.New("grpc client disabled via cmd_port: -1")
 	}
 	// This is needed as the server hangs when using "grpc.WithInsecure()"
 	tlsConf := tls.Config{InsecureSkipVerify: true}

--- a/pkg/util/grpc/agent_client_test.go
+++ b/pkg/util/grpc/agent_client_test.go
@@ -23,3 +23,14 @@ func TestGetDDAgentClientTimeout(t *testing.T) {
 	_, err := GetDDAgentClient(ctx)
 	assert.Equal(t, context.DeadlineExceeded, err)
 }
+
+func TestGetDDAgentClientWithCmdPort0(t *testing.T) {
+	os.Setenv("DD_CMD_PORT", "0")
+	defer os.Unsetenv("DD_CMD_PORT")
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+
+	_, err := GetDDAgentClient(ctx)
+	assert.NotNil(t, err)
+	assert.Equal(t, "grpc client disabled via cmd_port: 0", err.Error())
+}

--- a/pkg/util/grpc/agent_client_test.go
+++ b/pkg/util/grpc/agent_client_test.go
@@ -25,12 +25,12 @@ func TestGetDDAgentClientTimeout(t *testing.T) {
 }
 
 func TestGetDDAgentClientWithCmdPort0(t *testing.T) {
-	os.Setenv("DD_CMD_PORT", "0")
+	os.Setenv("DD_CMD_PORT", "-1")
 	defer os.Unsetenv("DD_CMD_PORT")
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
 
 	_, err := GetDDAgentClient(ctx)
 	assert.NotNil(t, err)
-	assert.Equal(t, "grpc client disabled via cmd_port: 0", err.Error())
+	assert.Equal(t, "grpc client disabled via cmd_port: -1", err.Error())
 }


### PR DESCRIPTION
### What does this PR do?

Skip hostname resolution in serverless context when loading and validation the agent config

### Motivation

Extension start time / cold start improvements

### Describe how to test your changes

Unit testing 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
