### PR TITLE
Fix broken consecutive table reference quantization 

### DIFF
--- a/pkg/trace/obfuscate/obfuscate.go
+++ b/pkg/trace/obfuscate/obfuscate.go
@@ -38,8 +38,8 @@ type Obfuscator struct {
 // SQLOptions holds options that change the behavior of the obfuscator for SQL.
 // easyjson:json
 type SQLOptions struct {
-	// QuantizeSQLTables determines if the obfuscator will perform quantization on the SQL tables.
-	QuantizeSQLTables bool `json:"quantize_sql_tables"`
+	// QuantizeSQL determines if the obfuscator will perform quantization on the SQL statement.
+	QuantizeSQL bool `json:"quantize_sql"`
 }
 
 // SetSQLLiteralEscapes sets whether or not escape characters should be treated literally by the SQL obfuscator.

--- a/pkg/trace/obfuscate/obfuscate_easyjson.go
+++ b/pkg/trace/obfuscate/obfuscate_easyjson.go
@@ -36,8 +36,8 @@ func easyjson4ef41860DecodeGithubComDataDogDatadogAgentPkgTraceObfuscate(in *jle
 			continue
 		}
 		switch key {
-		case "quantize_sql_tables":
-			out.QuantizeSQLTables = bool(in.Bool())
+		case "quantize_sql":
+			out.QuantizeSQL = bool(in.Bool())
 		default:
 			in.SkipRecursive()
 		}
@@ -53,9 +53,9 @@ func easyjson4ef41860EncodeGithubComDataDogDatadogAgentPkgTraceObfuscate(out *jw
 	first := true
 	_ = first
 	{
-		const prefix string = ",\"quantize_sql_tables\":"
+		const prefix string = ",\"quantize_sql\":"
 		out.RawString(prefix[1:])
-		out.Bool(bool(in.QuantizeSQLTables))
+		out.Bool(bool(in.QuantizeSQL))
 	}
 	out.RawByte('}')
 }

--- a/pkg/trace/obfuscate/obfuscate_test.go
+++ b/pkg/trace/obfuscate/obfuscate_test.go
@@ -281,7 +281,7 @@ func TestObfuscateConfig(t *testing.T) {
 // TestSQLObfuscationOptionsDeserializationMethod checks if the use of easyjson results in the same deserialization
 // output as encoding/json.
 func TestSQLObfuscationOptionsDeserializationMethod(t *testing.T) {
-	opts, err := json.Marshal(SQLOptions{QuantizeSQLTables: true})
+	opts, err := json.Marshal(SQLOptions{QuantizeSQL: true})
 	require.NoError(t, err)
 
 	var in, out SQLOptions
@@ -306,7 +306,7 @@ func BenchmarkSQLObfuscationOptionsEasyJSONDeserialization(b *testing.B) {
 
 func benchmarkSQLObfuscationOptionsEasyJSONDeserialization(b *testing.B) {
 	b.ReportAllocs()
-	opts, err := json.Marshal(SQLOptions{QuantizeSQLTables: true})
+	opts, err := json.Marshal(SQLOptions{QuantizeSQL: true})
 	require.NoError(b, err)
 	for i := 0; i < b.N; i++ {
 		var sqlCfg SQLOptions
@@ -325,7 +325,7 @@ func BenchmarkSQLObfuscationOptionsRegularJSONDeserialization(b *testing.B) {
 
 func benchmarkSQLObfuscationOptionsRegularJSONDeserialization(b *testing.B) {
 	b.ReportAllocs()
-	opts, err := json.Marshal(SQLOptions{QuantizeSQLTables: true})
+	opts, err := json.Marshal(SQLOptions{QuantizeSQL: true})
 	require.NoError(b, err)
 	for i := 0; i < b.N; i++ {
 		var sqlCfg SQLOptions

--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -117,7 +117,7 @@ func (f *replaceFilter) Filter(token, lastToken TokenKind, buffer []byte) (token
 	case '?':
 		// Cases like 'ARRAY [ ?, ? ]' should be collapsed into 'ARRAY [ ? ]'
 		return markFilteredGroupable(token), questionMark, nil
-	case TableName:
+	case TableName, ID:
 		if f.quantizeTableNames {
 			return token, replaceDigits(buffer), nil
 		}

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -265,12 +265,12 @@ func TestSQLQuantizeTableNames(t *testing.T) {
 				"REPLACE INTO sales_?_?_? ( itemID, date, qty, price ) VALUES ( ( SELECT itemID FROM item? WHERE sku = [ sku ] ), CURDATE ( ), [ qty ], ? )",
 			},
 			{
-				"SELECT ddh.name, ddt.tags FROM dd91219.host ddh, dd21916.host_tags ddt WHERE ddh.id = ddt.host_id AND ddh.org_id = 2 AND ddh.name = 'datadog'",
-				"SELECT ddh.name, ddt.tags FROM dd?.host ddh, dd?.host_tags ddt WHERE ddh.id = ddt.host_id AND ddh.org_id = ? AND ddh.name = ?",
+				"SELECT ddh19.name, ddt.tags FROM dd91219.host ddh19, dd21916.host_tags ddt WHERE ddh19.id = ddt.host_id AND ddh19.org_id = 2 AND ddh19.name = 'datadog'",
+				"SELECT ddh?.name, ddt.tags FROM dd?.host ddh?, dd?.host_tags ddt WHERE ddh?.id = ddt.host_id AND ddh?.org_id = ? AND ddh?.name = ?",
 			},
 			{
-				"SELECT ddu.name, ddo.id, ddk.app_key FROM dd3120.user ddu, dd1931.orgs ddo, dd53819.keys ddk",
-				"SELECT ddu.name, ddo.id, ddk.app_key FROM dd?.user ddu, dd?.orgs ddo, dd?.keys ddk",
+				"SELECT ddu2.name, ddo.id, ddk.app_key FROM dd3120.user ddu2, dd1931.orgs ddo, dd53819.keys ddk",
+				"SELECT ddu?.name, ddo.id, ddk.app_key FROM dd?.user ddu?, dd?.orgs ddo, dd?.keys ddk",
 			},
 		} {
 			t.Run("", func(t *testing.T) {
@@ -293,12 +293,12 @@ func TestSQLQuantizeTableNames(t *testing.T) {
 				"REPLACE INTO sales_2019_07_01 ( itemID, date, qty, price ) VALUES ( ( SELECT itemID FROM item1001 WHERE sku = [ sku ] ), CURDATE ( ), [ qty ], ? )",
 			},
 			{
-				"SELECT ddh.name, ddt.tags FROM dd91219.host ddh, dd21916.host_tags ddt WHERE ddh.id = ddt.host_id AND ddh.org_id = 2 AND ddh.name = 'datadog'",
-				"SELECT ddh.name, ddt.tags FROM dd91219.host ddh, dd21916.host_tags ddt WHERE ddh.id = ddt.host_id AND ddh.org_id = ? AND ddh.name = ?",
+				"SELECT ddh19.name, ddt.tags FROM dd91219.host ddh19, dd21916.host_tags ddt WHERE ddh19.id = ddt.host_id AND ddh19.org_id = 2 AND ddh19.name = 'datadog'",
+				"SELECT ddh19.name, ddt.tags FROM dd91219.host ddh19, dd21916.host_tags ddt WHERE ddh19.id = ddt.host_id AND ddh19.org_id = ? AND ddh19.name = ?",
 			},
 			{
-				"SELECT ddu.name, ddo.id, ddk.app_key FROM dd3120.user ddu, dd1931.orgs ddo, dd53819.keys ddk",
-				"SELECT ddu.name, ddo.id, ddk.app_key FROM dd3120.user ddu, dd1931.orgs ddo, dd53819.keys ddk",
+				"SELECT ddu2.name, ddo.id, ddk.app_key FROM dd3120.user ddu2, dd1931.orgs ddo, dd53819.keys ddk",
+				"SELECT ddu2.name, ddo.id, ddk.app_key FROM dd3120.user ddu2, dd1931.orgs ddo, dd53819.keys ddk",
 			},
 		} {
 			t.Run("", func(t *testing.T) {

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -264,6 +264,14 @@ func TestSQLQuantizeTableNames(t *testing.T) {
 				"REPLACE INTO sales_2019_07_01 (`itemID`, `date`, `qty`, `price`) VALUES ((SELECT itemID FROM item1001 WHERE `sku` = [sku]), CURDATE(), [qty], 0.00)",
 				"REPLACE INTO sales_?_?_? ( itemID, date, qty, price ) VALUES ( ( SELECT itemID FROM item? WHERE sku = [ sku ] ), CURDATE ( ), [ qty ], ? )",
 			},
+			{
+				"SELECT ddh.name, ddt.tags FROM dd91219.host ddh, dd21916.host_tags ddt WHERE ddh.id = ddt.host_id AND ddh.org_id = 2 AND ddh.name = 'datadog'",
+				"SELECT ddh.name, ddt.tags FROM dd?.host ddh, dd?.host_tags ddt WHERE ddh.id = ddt.host_id AND ddh.org_id = ? AND ddh.name = ?",
+			},
+			{
+				"SELECT ddu.name, ddo.id, ddk.app_key FROM dd3120.user ddu, dd1931.orgs ddo, dd53819.keys ddk",
+				"SELECT ddu.name, ddo.id, ddk.app_key FROM dd?.user ddu, dd?.orgs ddo, dd?.keys ddk",
+			},
 		} {
 			t.Run("", func(t *testing.T) {
 				assert := assert.New(t)
@@ -283,6 +291,14 @@ func TestSQLQuantizeTableNames(t *testing.T) {
 			{
 				"REPLACE INTO sales_2019_07_01 (`itemID`, `date`, `qty`, `price`) VALUES ((SELECT itemID FROM item1001 WHERE `sku` = [sku]), CURDATE(), [qty], 0.00)",
 				"REPLACE INTO sales_2019_07_01 ( itemID, date, qty, price ) VALUES ( ( SELECT itemID FROM item1001 WHERE sku = [ sku ] ), CURDATE ( ), [ qty ], ? )",
+			},
+			{
+				"SELECT ddh.name, ddt.tags FROM dd91219.host ddh, dd21916.host_tags ddt WHERE ddh.id = ddt.host_id AND ddh.org_id = 2 AND ddh.name = 'datadog'",
+				"SELECT ddh.name, ddt.tags FROM dd91219.host ddh, dd21916.host_tags ddt WHERE ddh.id = ddt.host_id AND ddh.org_id = ? AND ddh.name = ?",
+			},
+			{
+				"SELECT ddu.name, ddo.id, ddk.app_key FROM dd3120.user ddu, dd1931.orgs ddo, dd53819.keys ddk",
+				"SELECT ddu.name, ddo.id, ddk.app_key FROM dd3120.user ddu, dd1931.orgs ddo, dd53819.keys ddk",
 			},
 		} {
 			t.Run("", func(t *testing.T) {

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -275,7 +275,7 @@ func TestSQLQuantizeTableNames(t *testing.T) {
 		} {
 			t.Run("", func(t *testing.T) {
 				assert := assert.New(t)
-				oq, err := NewObfuscator(nil).ObfuscateSQLStringWithOptions(tt.query, SQLOptions{QuantizeSQLTables: true})
+				oq, err := NewObfuscator(nil).ObfuscateSQLStringWithOptions(tt.query, SQLOptions{QuantizeSQL: true})
 				assert.NoError(err)
 				assert.Empty(oq.TablesCSV)
 				assert.Equal(tt.obfuscated, oq.Query)
@@ -394,7 +394,7 @@ func TestSQLTableFinderAndQuantizeTableNames(t *testing.T) {
 		} {
 			t.Run("", func(t *testing.T) {
 				assert := assert.New(t)
-				oq, err := NewObfuscator(nil).ObfuscateSQLStringWithOptions(tt.query, SQLOptions{QuantizeSQLTables: true})
+				oq, err := NewObfuscator(nil).ObfuscateSQLStringWithOptions(tt.query, SQLOptions{QuantizeSQL: true})
 				assert.NoError(err)
 				assert.Equal(tt.tables, oq.TablesCSV)
 				assert.Equal(tt.obfuscated, oq.Query)
@@ -1391,7 +1391,7 @@ func BenchmarkObfuscateSQLString(b *testing.B) {
 			b.ResetTimer()
 			b.ReportAllocs()
 			for i := 0; i < b.N; i++ {
-				_, err := obf.ObfuscateSQLStringWithOptions(bm.query, SQLOptions{QuantizeSQLTables: true})
+				_, err := obf.ObfuscateSQLStringWithOptions(bm.query, SQLOptions{QuantizeSQL: true})
 				if err != nil {
 					b.Fatal(err)
 				}

--- a/releasenotes/notes/fix-broken-table-reference-quantization-4ecc793d68761520.yaml
+++ b/releasenotes/notes/fix-broken-table-reference-quantization-4ecc793d68761520.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes a bug where a SQL statement with consecutive table references do not receive quantization from the obfuscator.


### PR DESCRIPTION
### What does this PR do?

Fixes a bug where a SQL statement with consecutive table references do not receive quantization from the obfuscator.

### Motivation

There are some SQL statements with partially quantized table references due to the SQL obfuscator missing cases where there are consecutive table references.

### Additional Notes

#### Why it wasn't caught
Example:
```sql
SELECT ddh.name, ddt.tags FROM dd91219.host ddh, dd21916.host_tags ddt WHERE ddh.id = ddt.host_id AND ddh.org_id = 2 AND ddh.name = 'datadog'
```
How it currently obfuscates (Note `FROM` clause):
```sql
SELECT ddh.name, ddt.tags FROM dd?.host ddh, dd21916.host_tags ddt WHERE ddh.id = ddt.host_id AND ddh.org_id = ? AND ddh.name = ?
```
How it should obfuscate (Note `FROM` clause):
```sql
SELECT ddh.name, ddt.tags FROM dd?.host ddh, dd?.host_tags ddt WHERE ddh.id = ddt.host_id AND ddh.org_id = ? AND ddh.name = ?
```
Focusing on the `FROM` clause, the obfuscator misses this statement at the replace filter layer because of the `TokenKind`. The first table reference has a `TokenKind` of `TableName` (which **is** caught), but every table reference after that has a `TokenKind` of `ID` (which **is not** caught).

### Describe how to test your changes

Run: `invoke test --targets=./pkg/trace/obfuscate --skip-linters`

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
