### PR TITLE
[gitlab] Modifications to make stable nightlies and main nightlies not conflict

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,7 +108,7 @@ variables:
   WIN_S3_BUCKET: dd-agent-mstesting
   PROCESS_S3_BUCKET: datad0g-process-agent
   ANDROID_S3_BUCKET: dd-agent-androidtesting
-  DEB_RPM_BUCKET_BRANCH: nightly  # branch of the DEB_S3_BUCKET and RPM_S3_BUCKET repos to release to, 'nightly' or 'beta'
+  DEB_RPM_BUCKET_BRANCH: nightly  # branch of the DEB_S3_BUCKET and RPM_S3_BUCKET repos to release to: 'nightly', 'oldnightly' or 'beta'
   DEB_TESTING_S3_BUCKET: apttesting.datad0g.com
   RPM_TESTING_S3_BUCKET: yumtesting.datad0g.com
   WINDOWS_TESTING_S3_BUCKET_A6: pipelines/A6/$CI_PIPELINE_ID
@@ -182,7 +182,7 @@ variables:
   if: $CI_COMMIT_TAG != null
 
 .if_not_nightly_repo_branch: &if_not_nightly_repo_branch
-  if: $DEB_RPM_BUCKET_BRANCH != "nightly"
+  if: $DEB_RPM_BUCKET_BRANCH != "nightly" && $DEB_RPM_BUCKET_BRANCH != "oldnightly"
 
 .if_not_stable_or_beta_repo_branch: &if_not_stable_or_beta_repo_branch
   if: $DEB_RPM_BUCKET_BRANCH != "beta" && $DEB_RPM_BUCKET_BRANCH != "stable"

--- a/.gitlab/image_scan.yml
+++ b/.gitlab/image_scan.yml
@@ -19,7 +19,7 @@ scan_nightly-dogstatsd:
     IMG_REGISTRIES: dev
     IMG_SIGNING: "false"
     IMG_SOURCES: ${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
-    IMG_DESTINATIONS: dogstatsd-scan:nightly
+    IMG_DESTINATIONS: dogstatsd-scan:${DEB_RPM_BUCKET_BRANCH}
 
 scan_nightly-a6:
   extends: .docker_job_definition
@@ -39,9 +39,9 @@ scan_nightly-a6:
   parallel:
     matrix:
       - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-amd64
-        IMG_DESTINATIONS: agent-scan:nightly-py2
+        IMG_DESTINATIONS: agent-scan:${DEB_RPM_BUCKET_BRANCH}-py2
       - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-jmx-amd64
-        IMG_DESTINATIONS: agent-scan:nightly-py2-jmx
+        IMG_DESTINATIONS: agent-scan:${DEB_RPM_BUCKET_BRANCH}-py2-jmx
 
 scan_nightly-a7:
   extends: .docker_job_definition
@@ -61,9 +61,9 @@ scan_nightly-a7:
   parallel:
     matrix:
       - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64
-        IMG_DESTINATIONS: agent-scan:nightly-py3
+        IMG_DESTINATIONS: agent-scan:${DEB_RPM_BUCKET_BRANCH}-py3
       - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-amd64
-        IMG_DESTINATIONS: agent-scan:nightly-py3-jmx
+        IMG_DESTINATIONS: agent-scan:${DEB_RPM_BUCKET_BRANCH}-py3-jmx
 
 dca_scan_nightly:
   extends: .docker_job_definition
@@ -79,7 +79,7 @@ dca_scan_nightly:
     IMG_REGISTRIES: dev
     IMG_SIGNING: "false"
     IMG_SOURCES: ${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
-    IMG_DESTINATIONS: cluster-agent-scan:nightly
+    IMG_DESTINATIONS: cluster-agent-scan:${DEB_RPM_BUCKET_BRANCH}
 
 # push on master to docker hub agent-scan repo
 scan_master-dogstatsd:

--- a/.gitlab/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics.yml
@@ -41,7 +41,7 @@ send_pkg_size-a6:
     - |
       curl --fail -X POST -H "Content-type: application/json" \
       -d "{\"series\":[
-        {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $DEB_AGENT_SIZE]], \"tags\":[\"os:debian\", \"package:agent\", \"agent:6\", \"bucket_branch:$DEB_RPM_BUCKET_BRANCH\"]},
+            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $DEB_AGENT_SIZE]], \"tags\":[\"os:debian\", \"package:agent\", \"agent:6\", \"bucket_branch:$DEB_RPM_BUCKET_BRANCH\"]},
             {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $RPM_AGENT_SIZE]], \"tags\":[\"os:centos\", \"package:agent\", \"agent:6\", \"bucket_branch:$DEB_RPM_BUCKET_BRANCH\"]},
             {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $SUSE_AGENT_SIZE]], \"tags\":[\"os:suse\", \"package:agent\", \"agent:6\", \"bucket_branch:$DEB_RPM_BUCKET_BRANCH\"]}
           ]}" \

--- a/.gitlab/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics.yml
@@ -41,9 +41,9 @@ send_pkg_size-a6:
     - |
       curl --fail -X POST -H "Content-type: application/json" \
       -d "{\"series\":[
-            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $DEB_AGENT_SIZE]], \"tags\":[\"os:debian\", \"package:agent\", \"agent:6\"]},
-            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $RPM_AGENT_SIZE]], \"tags\":[\"os:centos\", \"package:agent\", \"agent:6\"]},
-            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $SUSE_AGENT_SIZE]], \"tags\":[\"os:suse\", \"package:agent\", \"agent:6\"]}
+        {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $DEB_AGENT_SIZE]], \"tags\":[\"os:debian\", \"package:agent\", \"agent:6\", \"bucket_branch:$DEB_RPM_BUCKET_BRANCH\"]},
+            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $RPM_AGENT_SIZE]], \"tags\":[\"os:centos\", \"package:agent\", \"agent:6\", \"bucket_branch:$DEB_RPM_BUCKET_BRANCH\"]},
+            {\"metric\":\"datadog.agent.package.size\",\"points\":[[$currenttime, $SUSE_AGENT_SIZE]], \"tags\":[\"os:suse\", \"package:agent\", \"agent:6\", \"bucket_branch:$DEB_RPM_BUCKET_BRANCH\"]}
           ]}" \
       "https://api.datadoghq.com/api/v1/series?api_key=$DD_API_KEY"
 
@@ -98,18 +98,18 @@ send_pkg_size-a7:
             local os="${2}"
 
             # record a the total uncompressed size of each package
-            add_metric datadog.agent.package.size $(du -sB1 ${base}/agent | sed 's/\([0-9]\+\).\+/\1/') os:${os} package:agent agent:7
-            add_metric datadog.agent.package.size $(du -sB1 ${base}/dogstatsd | sed 's/\([0-9]\+\).\+/\1/') os:${os} package:dogstatsd agent:7
-            add_metric datadog.agent.package.size $(du -sB1 ${base}/iot-agent | sed 's/\([0-9]\+\).\+/\1/') os:${os} package:iot-agent agent:7
+            add_metric datadog.agent.package.size $(du -sB1 ${base}/agent | sed 's/\([0-9]\+\).\+/\1/') os:${os} package:agent agent:7 bucket_branch:$DEB_RPM_BUCKET_BRANCH
+            add_metric datadog.agent.package.size $(du -sB1 ${base}/dogstatsd | sed 's/\([0-9]\+\).\+/\1/') os:${os} package:dogstatsd agent:7 bucket_branch:$DEB_RPM_BUCKET_BRANCH
+            add_metric datadog.agent.package.size $(du -sB1 ${base}/iot-agent | sed 's/\([0-9]\+\).\+/\1/') os:${os} package:iot-agent agent:7 bucket_branch:$DEB_RPM_BUCKET_BRANCH
 
             # record the size of each of the important binaries in each package
-            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/bin/agent/agent | sed 's/\([0-9]\+\).\+/\1/') bin:agent os:${os} package:agent agent:7
-            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/trace-agent | sed 's/\([0-9]\+\).\+/\1/') bin:trace-agent os:${os} package:agent agent:7
-            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/security-agent | sed 's/\([0-9]\+\).\+/\1/') bin:security-agent os:${os} package:agent agent:7
-            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/process-agent | sed 's/\([0-9]\+\).\+/\1/') bin:process-agent os:${os} package:agent agent:7
-            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/system-probe | sed 's/\([0-9]\+\).\+/\1/') bin:system-probe os:${os} package:agent agent:7
-            add_metric datadog.agent.binary.size $(du -sB1 ${base}/dogstatsd/opt/datadog-dogstatsd/bin/dogstatsd | sed 's/\([0-9]\+\).\+/\1/') bin:dogstatsd os:${os} package:dogstatsd agent:7
-            add_metric datadog.agent.binary.size $(du -sB1 ${base}/iot-agent/opt/datadog-agent/bin/agent/agent | sed 's/\([0-9]\+\).\+/\1/') bin:agent os:${os} package:iot-agent agent:7
+            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/bin/agent/agent | sed 's/\([0-9]\+\).\+/\1/') bin:agent os:${os} package:agent agent:7 bucket_branch:$DEB_RPM_BUCKET_BRANCH
+            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/trace-agent | sed 's/\([0-9]\+\).\+/\1/') bin:trace-agent os:${os} package:agent agent:7 bucket_branch:$DEB_RPM_BUCKET_BRANCH
+            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/security-agent | sed 's/\([0-9]\+\).\+/\1/') bin:security-agent os:${os} package:agent agent:7 bucket_branch:$DEB_RPM_BUCKET_BRANCH
+            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/process-agent | sed 's/\([0-9]\+\).\+/\1/') bin:process-agent os:${os} package:agent agent:7 bucket_branch:$DEB_RPM_BUCKET_BRANCH
+            add_metric datadog.agent.binary.size $(du -sB1 ${base}/agent/opt/datadog-agent/embedded/bin/system-probe | sed 's/\([0-9]\+\).\+/\1/') bin:system-probe os:${os} package:agent agent:7 bucket_branch:$DEB_RPM_BUCKET_BRANCH
+            add_metric datadog.agent.binary.size $(du -sB1 ${base}/dogstatsd/opt/datadog-dogstatsd/bin/dogstatsd | sed 's/\([0-9]\+\).\+/\1/') bin:dogstatsd os:${os} package:dogstatsd agent:7 bucket_branch:$DEB_RPM_BUCKET_BRANCH
+            add_metric datadog.agent.binary.size $(du -sB1 ${base}/iot-agent/opt/datadog-agent/bin/agent/agent | sed 's/\([0-9]\+\).\+/\1/') bin:agent os:${os} package:iot-agent agent:7 bucket_branch:$DEB_RPM_BUCKET_BRANCH
         }
     - currenttime=$(date +%s)
 

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -9,11 +9,7 @@ import yaml
 from invoke import task
 from invoke.exceptions import Exit
 
-from tasks.utils import (
-    DEFAULT_BRANCH,
-    get_all_allowed_repo_branches,
-    is_allowed_repo_branch,
-)
+from tasks.utils import DEFAULT_BRANCH, get_all_allowed_repo_branches, is_allowed_repo_branch
 
 from .libs.common.color import color_message
 from .libs.common.gitlab import Gitlab

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -47,7 +47,7 @@ def check_deploy_pipeline(gitlab, project_name, git_ref, release_version_6, rele
     if not is_allowed_repo_branch(repo_branch):
         print(
             "--repo-branch argument '{}' is not in the list of allowed repository branches: {}".format(
-                repo_branch, get_all_allowed_repo_branches
+                repo_branch, get_all_allowed_repo_branches()
             )
         )
         raise Exit(code=1)

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -9,7 +9,11 @@ import yaml
 from invoke import task
 from invoke.exceptions import Exit
 
-from tasks.utils import DEFAULT_BRANCH
+from tasks.utils import (
+    DEFAULT_BRANCH,
+    get_all_allowed_repo_branches,
+    is_allowed_repo_branch,
+)
 
 from .libs.common.color import color_message
 from .libs.common.gitlab import Gitlab
@@ -31,8 +35,6 @@ from .libs.types import SlackMessage, TeamMessage
 
 # Tasks to trigger pipelines
 
-ALLOWED_REPO_BRANCHES = {"stable", "beta", "nightly", "none"}
-
 
 def check_deploy_pipeline(gitlab, project_name, git_ref, release_version_6, release_version_7, repo_branch):
     """
@@ -42,10 +44,10 @@ def check_deploy_pipeline(gitlab, project_name, git_ref, release_version_6, rele
     """
 
     # Check that the target repo branch is valid
-    if repo_branch not in ALLOWED_REPO_BRANCHES:
+    if not is_allowed_repo_branch(repo_branch):
         print(
             "--repo-branch argument '{}' is not in the list of allowed repository branches: {}".format(
-                repo_branch, ALLOWED_REPO_BRANCHES
+                repo_branch, get_all_allowed_repo_branches
             )
         )
         raise Exit(code=1)

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -15,6 +15,21 @@ from invoke import task
 ORG_PATH = "github.com/DataDog"
 DEFAULT_BRANCH = "main"
 REPO_PATH = "{}/datadog-agent".format(ORG_PATH)
+ALLOWED_REPO_NON_NIGHTLY_BRANCHES = {"stable", "beta", "none"}
+ALLOWED_REPO_NIGHTLY_BRANCHES = {"nightly", "oldnightly"}
+ALLOWED_REPO_ALL_BRANCHES = ALLOWED_REPO_NON_NIGHTLY_BRANCHES.union(ALLOWED_REPO_NIGHTLY_BRANCHES)
+
+
+def get_all_allowed_repo_branches():
+    return ALLOWED_REPO_ALL_BRANCHES
+
+
+def is_allowed_repo_branch(branch):
+    return branch in ALLOWED_REPO_ALL_BRANCHES
+
+
+def is_allowed_repo_nightly_branch(branch):
+    return branch in ALLOWED_REPO_NIGHTLY_BRANCHES
 
 
 def bin_name(name, android=False):
@@ -284,7 +299,7 @@ def get_version(
         ctx, git_sha_length, prefix, major_version_hint=major_version
     )
 
-    is_nightly = os.getenv("DEB_RPM_BUCKET_BRANCH") == "nightly"
+    is_nightly = is_allowed_repo_nightly_branch(os.getenv("DEB_RPM_BUCKET_BRANCH"))
     if pre:
         version = "{0}-{1}".format(version, pre)
 


### PR DESCRIPTION
### What does this PR do?

Adds changes that will make `main` nightlies and latest-stable-branch nightlies not conflict/overwrite artifacts/touch the same repos.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
