### PR TITLE
[orchestrator] refactor informer usage

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -191,7 +191,7 @@ func (o *OrchestratorCheck) Configure(config, initConfig integration.Data, sourc
 		collectors = defaultResources
 	}
 
-	informersToSync := map[apiserver.InformerName]cache.SharedInformer{}
+	informersToSync := map[orchestrator.NodeType]cache.SharedInformer{}
 
 	for _, v := range collectors {
 		switch v {
@@ -199,47 +199,47 @@ func (o *OrchestratorCheck) Configure(config, initConfig integration.Data, sourc
 			podInformer := apiCl.UnassignedPodInformerFactory.Core().V1().Pods()
 			o.unassignedPodLister = podInformer.Lister()
 			o.unassignedPodListerSync = podInformer.Informer().HasSynced
-			informersToSync[apiserver.PodsInformer] = podInformer.Informer()
+			informersToSync[orchestrator.K8sPod] = podInformer.Informer()
 		case "deployments":
 			deployInformer := apiCl.InformerFactory.Apps().V1().Deployments()
 			o.deployLister = deployInformer.Lister()
 			o.deployListerSync = deployInformer.Informer().HasSynced
-			informersToSync[apiserver.DeploysInformer] = deployInformer.Informer()
+			informersToSync[orchestrator.K8sDeployment] = deployInformer.Informer()
 		case "replicasets":
 			rsInformer := apiCl.InformerFactory.Apps().V1().ReplicaSets()
 			o.rsLister = rsInformer.Lister()
 			o.rsListerSync = rsInformer.Informer().HasSynced
-			informersToSync[apiserver.ReplicaSetsInformer] = rsInformer.Informer()
+			informersToSync[orchestrator.K8sReplicaSet] = rsInformer.Informer()
 		case "services":
 			serviceInformer := apiCl.InformerFactory.Core().V1().Services()
 			o.serviceLister = serviceInformer.Lister()
 			o.serviceListerSync = serviceInformer.Informer().HasSynced
-			informersToSync[apiserver.ServicesInformer] = serviceInformer.Informer()
+			informersToSync[orchestrator.K8sService] = serviceInformer.Informer()
 		case "nodes":
 			nodesInformer := apiCl.InformerFactory.Core().V1().Nodes()
 			o.nodesLister = nodesInformer.Lister()
 			o.nodesListerSync = nodesInformer.Informer().HasSynced
-			informersToSync[apiserver.NodesInformer] = nodesInformer.Informer()
+			informersToSync[orchestrator.K8sNode] = nodesInformer.Informer()
 		case "jobs":
 			jobsInformer := apiCl.InformerFactory.Batch().V1().Jobs()
 			o.jobsLister = jobsInformer.Lister()
 			o.jobsListerSync = jobsInformer.Informer().HasSynced
-			informersToSync[apiserver.JobsInformer] = jobsInformer.Informer()
+			informersToSync[orchestrator.K8sJob] = jobsInformer.Informer()
 		case "cronjobs":
 			cronJobsInformer := apiCl.InformerFactory.Batch().V1beta1().CronJobs()
 			o.cronJobsLister = cronJobsInformer.Lister()
 			o.cronJobsListerSync = cronJobsInformer.Informer().HasSynced
-			informersToSync[apiserver.CronJobsInformer] = cronJobsInformer.Informer()
+			informersToSync[orchestrator.K8sCronJob] = cronJobsInformer.Informer()
 		case "daemonsets":
 			daemonSetsInformer := apiCl.InformerFactory.Apps().V1().DaemonSets()
 			o.daemonSetsLister = daemonSetsInformer.Lister()
 			o.daemonSetsListerSync = daemonSetsInformer.Informer().HasSynced
-			informersToSync[apiserver.DaemonSetsInformer] = daemonSetsInformer.Informer()
+			informersToSync[orchestrator.K8sDaemonSet] = daemonSetsInformer.Informer()
 		case "statefulsets":
 			statefulSetsInformer := apiCl.InformerFactory.Apps().V1().StatefulSets()
 			o.statefulSetsLister = statefulSetsInformer.Lister()
 			o.statefulSetsListerSync = statefulSetsInformer.Informer().HasSynced
-			informersToSync[apiserver.StatefulSetsInformer] = statefulSetsInformer.Informer()
+			informersToSync[orchestrator.K8sStatefulSet] = statefulSetsInformer.Informer()
 		default:
 			_ = o.Warnf("Unsupported collector: %s", v)
 		}
@@ -248,7 +248,7 @@ func (o *OrchestratorCheck) Configure(config, initConfig integration.Data, sourc
 	apiCl.UnassignedPodInformerFactory.Start(o.stopCh)
 	apiCl.InformerFactory.Start(o.stopCh)
 
-	return apiserver.SyncInformers(informersToSync)
+	return apiserver.SyncInformersOrchestrator(informersToSync)
 }
 
 // Run runs the orchestrator check

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -191,7 +191,7 @@ func (o *OrchestratorCheck) Configure(config, initConfig integration.Data, sourc
 		collectors = defaultResources
 	}
 
-	informersToSync := map[orchestrator.NodeType]cache.SharedInformer{}
+	informersToSync := map[apiserver.InformerName]cache.SharedInformer{}
 
 	for _, v := range collectors {
 		switch v {
@@ -199,47 +199,47 @@ func (o *OrchestratorCheck) Configure(config, initConfig integration.Data, sourc
 			podInformer := apiCl.UnassignedPodInformerFactory.Core().V1().Pods()
 			o.unassignedPodLister = podInformer.Lister()
 			o.unassignedPodListerSync = podInformer.Informer().HasSynced
-			informersToSync[orchestrator.K8sPod] = podInformer.Informer()
+			informersToSync[apiserver.InformerName(orchestrator.K8sPod.String())] = podInformer.Informer()
 		case "deployments":
 			deployInformer := apiCl.InformerFactory.Apps().V1().Deployments()
 			o.deployLister = deployInformer.Lister()
 			o.deployListerSync = deployInformer.Informer().HasSynced
-			informersToSync[orchestrator.K8sDeployment] = deployInformer.Informer()
+			informersToSync[apiserver.InformerName(orchestrator.K8sDeployment.String())] = deployInformer.Informer()
 		case "replicasets":
 			rsInformer := apiCl.InformerFactory.Apps().V1().ReplicaSets()
 			o.rsLister = rsInformer.Lister()
 			o.rsListerSync = rsInformer.Informer().HasSynced
-			informersToSync[orchestrator.K8sReplicaSet] = rsInformer.Informer()
+			informersToSync[apiserver.InformerName(orchestrator.K8sReplicaSet.String())] = rsInformer.Informer()
 		case "services":
 			serviceInformer := apiCl.InformerFactory.Core().V1().Services()
 			o.serviceLister = serviceInformer.Lister()
 			o.serviceListerSync = serviceInformer.Informer().HasSynced
-			informersToSync[orchestrator.K8sService] = serviceInformer.Informer()
+			informersToSync[apiserver.InformerName(orchestrator.K8sService.String())] = serviceInformer.Informer()
 		case "nodes":
 			nodesInformer := apiCl.InformerFactory.Core().V1().Nodes()
 			o.nodesLister = nodesInformer.Lister()
 			o.nodesListerSync = nodesInformer.Informer().HasSynced
-			informersToSync[orchestrator.K8sNode] = nodesInformer.Informer()
+			informersToSync[apiserver.InformerName(orchestrator.K8sNode.String())] = nodesInformer.Informer()
 		case "jobs":
 			jobsInformer := apiCl.InformerFactory.Batch().V1().Jobs()
 			o.jobsLister = jobsInformer.Lister()
 			o.jobsListerSync = jobsInformer.Informer().HasSynced
-			informersToSync[orchestrator.K8sJob] = jobsInformer.Informer()
+			informersToSync[apiserver.InformerName(orchestrator.K8sJob.String())] = jobsInformer.Informer()
 		case "cronjobs":
 			cronJobsInformer := apiCl.InformerFactory.Batch().V1beta1().CronJobs()
 			o.cronJobsLister = cronJobsInformer.Lister()
 			o.cronJobsListerSync = cronJobsInformer.Informer().HasSynced
-			informersToSync[orchestrator.K8sCronJob] = cronJobsInformer.Informer()
+			informersToSync[apiserver.InformerName(orchestrator.K8sCronJob.String())] = cronJobsInformer.Informer()
 		case "daemonsets":
 			daemonSetsInformer := apiCl.InformerFactory.Apps().V1().DaemonSets()
 			o.daemonSetsLister = daemonSetsInformer.Lister()
 			o.daemonSetsListerSync = daemonSetsInformer.Informer().HasSynced
-			informersToSync[orchestrator.K8sDaemonSet] = daemonSetsInformer.Informer()
+			informersToSync[apiserver.InformerName(orchestrator.K8sDaemonSet.String())] = daemonSetsInformer.Informer()
 		case "statefulsets":
 			statefulSetsInformer := apiCl.InformerFactory.Apps().V1().StatefulSets()
 			o.statefulSetsLister = statefulSetsInformer.Lister()
 			o.statefulSetsListerSync = statefulSetsInformer.Informer().HasSynced
-			informersToSync[orchestrator.K8sStatefulSet] = statefulSetsInformer.Informer()
+			informersToSync[apiserver.InformerName(orchestrator.K8sStatefulSet.String())] = statefulSetsInformer.Informer()
 		default:
 			_ = o.Warnf("Unsupported collector: %s", v)
 		}
@@ -248,7 +248,7 @@ func (o *OrchestratorCheck) Configure(config, initConfig integration.Data, sourc
 	apiCl.UnassignedPodInformerFactory.Start(o.stopCh)
 	apiCl.InformerFactory.Start(o.stopCh)
 
-	return apiserver.SyncInformersOrchestrator(informersToSync)
+	return apiserver.SyncInformers(informersToSync)
 }
 
 // Run runs the orchestrator check

--- a/pkg/util/kubernetes/apiserver/types.go
+++ b/pkg/util/kubernetes/apiserver/types.go
@@ -30,22 +30,6 @@ const (
 	SecretsInformer InformerName = "secrets"
 	// WebhooksInformer holds the name of the informer
 	WebhooksInformer InformerName = "webhooks"
-	// PodsInformer holds the name of the informer
-	PodsInformer InformerName = "pods"
-	// DeploysInformer holds the name of the informer
-	DeploysInformer InformerName = "deploys"
-	// ReplicaSetsInformer holds the name of the informer
-	ReplicaSetsInformer InformerName = "replicaSets"
 	// ServicesInformer holds the name of the informer
 	ServicesInformer InformerName = "services"
-	// NodesInformer holds the name of the informer
-	NodesInformer InformerName = "nodes"
-	// JobsInformer holds the name of the informer
-	JobsInformer InformerName = "jobs"
-	// CronJobsInformer holds the name of the informer
-	CronJobsInformer InformerName = "cronJobs"
-	// DaemonSetsInformer holds the name of the informer
-	DaemonSetsInformer InformerName = "daemonSets"
-	// StatefulSetsInformer holds the name of the informer
-	StatefulSetsInformer InformerName = "statefulSets"
 )

--- a/pkg/util/kubernetes/apiserver/util.go
+++ b/pkg/util/kubernetes/apiserver/util.go
@@ -18,6 +18,7 @@ import (
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/orchestrator"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/watermarkpodautoscaler/api/v1alpha1"
 )
@@ -25,6 +26,29 @@ import (
 // SyncInformers should be called after the instantiation of new informers.
 // It's blocking until the informers are synced or the timeout exceeded.
 func SyncInformers(informers map[InformerName]cache.SharedInformer) error {
+	var g errgroup.Group
+	// syncTimeout can be used to wait for the kubernetes client-go cache to sync.
+	// It cannot be retrieved at the package-level due to the package being imported before configs are loaded.
+	syncTimeout := config.Datadog.GetDuration("kube_cache_sync_timeout_seconds") * time.Second
+	for name := range informers {
+		name := name // https://golang.org/doc/faq#closures_and_goroutines
+		g.Go(func() error {
+			ctx, cancel := context.WithTimeout(context.Background(), syncTimeout)
+			defer cancel()
+			start := time.Now()
+			if !cache.WaitForCacheSync(ctx.Done(), informers[name].HasSynced) {
+				return fmt.Errorf("couldn't sync informer %s in %v", name, time.Now().Sub(start))
+			}
+			log.Debugf("Sync done for informer %s in %v", name, time.Now().Sub(start))
+			return nil
+		})
+	}
+	return g.Wait()
+}
+
+// SyncInformersOrchestrator should be called after the instantiation of new informers.
+// It's blocking until the informers are synced or the timeout exceeded.
+func SyncInformersOrchestrator(informers map[orchestrator.NodeType]cache.SharedInformer) error {
 	var g errgroup.Group
 	// syncTimeout can be used to wait for the kubernetes client-go cache to sync.
 	// It cannot be retrieved at the package-level due to the package being imported before configs are loaded.


### PR DESCRIPTION
### What does this PR do?

Additional set of changes to reduce code duplication during resource addition as introduced before:
- https://github.com/DataDog/datadog-agent/commit/a930f478b3b2d310f5e9c6b8789efc850e986d6e
- https://github.com/DataDog/datadog-agent/commit/2b84c22e6e0f80e740059f2cc944a646b70dff85


**Note:**
- The other informers are not used therefore a deletion was safe.
- As an alternative we can dynamically create them using `nodeTypes`

### Motivation

Reduce places to change code during resource additions

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Tested locally + on my GKE Cluster, by building a DCA with `orchestrator_explorer` enabled and running it. Same status output as before.
```
  Transaction Successes
  =====================
    Total number: 15
    Successes By Endpoint:
      check_run_v1: 3
      intake: 1
      orchestrator: 8
      series_v1: 3

==========
Endpoints
==========
  https://dddev.datadoghq.com - API Key ending with:
      - f975c

=====================
Orchestrator Explorer
=====================
  Collection Status: The collection is at least partially running since the cache has been populated.
  Cluster Name: nammn
  Cluster ID: 9e99cefc-06cb-44a7-a0d5-69aaf0ff5a47

  ======================
  Orchestrator Endpoints
  ======================
  https://orchestrator.datadoghq.com - API Key ending with: f975c

  ===========
  Cache Stats
  ===========
    Elements in the cache: 18

    Cluster
      Last Run: (Hits: 1 Miss: 0) | Total: (Hits: 4 Miss: 1)

...
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
