### PR TITLE
[config_check] Print message when metrics or logs reporting are disabled

### DIFF
--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -55,8 +55,8 @@ type Config struct {
 	CreationTime            CreationTime `json:"-"`                         // creation time of service (include in digest: false)
 	Source                  string       `json:"source"`                    // the source of the configuration (include in digest: false)
 	IgnoreAutodiscoveryTags bool         `json:"ignore_autodiscovery_tags"` // used to ignore tags coming from autodiscovery (include in digest: true)
-	MetricsExcluded         bool         `json:"-"`                         // whether metrics collection is disabled (set by container listeners only) (include in digest: false)
-	LogsExcluded            bool         `json:"-"`                         // whether logs collection is disabled (set by container listeners only) (include in digest: false)
+	MetricsExcluded         bool         `json:"metrics_excluded"`          // whether metrics collection is disabled (set by container listeners only) (include in digest: false)
+	LogsExcluded            bool         `json:"logs_excluded"`             // whether logs collection is disabled (set by container listeners only) (include in digest: false)
 }
 
 // CommonInstanceConfig holds the reserved fields for the yaml instance data

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -139,10 +139,24 @@ func PrintConfig(w io.Writer, c integration.Config) {
 		for _, id := range c.ADIdentifiers {
 			fmt.Fprintln(w, fmt.Sprintf("* %s", color.CyanString(id)))
 		}
+		printContainerExclusionRulesInfo(w, &c)
 	}
 	if c.NodeName != "" {
 		state := fmt.Sprintf("dispatched to %s", c.NodeName)
 		fmt.Fprintln(w, fmt.Sprintf("%s: %s", color.BlueString("State"), color.CyanString(state)))
 	}
 	fmt.Fprintln(w, "===")
+}
+
+func printContainerExclusionRulesInfo(w io.Writer, c *integration.Config) {
+	var msg string
+	if c.IsCheckConfig() && c.MetricsExcluded {
+		msg = "This configuration matched a metrics container-exclusion rule, so it will not be run by the Agent"
+	} else if c.IsLogConfig() && c.LogsExcluded {
+		msg = "This configuration matched a logs container-exclusion rule, so it will not be run by the Agent"
+	}
+
+	if msg != "" {
+		fmt.Fprintln(w, fmt.Sprintf("%s", color.BlueString(msg)))
+	}
 }

--- a/pkg/flare/config_check_test.go
+++ b/pkg/flare/config_check_test.go
@@ -1,0 +1,92 @@
+package flare
+
+import (
+	"bytes"
+	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type configType string
+
+const (
+	metricsConfig configType = "metrics"
+	logsConfig    configType = "logs"
+)
+
+func TestContainerExclusionRulesInfo(t *testing.T) {
+	outputMsgs := map[configType]string{
+		metricsConfig: "This configuration matched a metrics container-exclusion rule, so it will not be run by the Agent",
+		logsConfig:    "This configuration matched a logs container-exclusion rule, so it will not be run by the Agent",
+	}
+
+	testCases := []struct {
+		name       string
+		configType configType
+		excluded   bool
+		expectMsg  bool
+	}{
+		{
+			name:       "Is check config and matches exclusion rule",
+			configType: metricsConfig,
+			excluded:   true,
+			expectMsg:  true,
+		},
+		{
+			name:       "Is check config and does not match exclusion rule",
+			configType: metricsConfig,
+			excluded:   false,
+			expectMsg:  false,
+		},
+		{
+			name:       "Is log config and matches exclusion rule",
+			configType: logsConfig,
+			excluded:   true,
+			expectMsg:  true,
+		},
+		{
+			name:       "Is log config and does not match exclusion rule",
+			configType: logsConfig,
+			excluded:   false,
+			expectMsg:  false,
+		},
+	}
+
+	for i, test := range testCases {
+		t.Run(fmt.Sprintf("case %d: %s", i, test.name), func(t *testing.T) {
+			config := newConfig(test.configType, test.excluded)
+
+			var result bytes.Buffer
+			PrintConfig(&result, config)
+
+			if test.expectMsg {
+				assert.Contains(t, result.String(), outputMsgs[test.configType])
+			} else {
+				assert.NotContains(t, result.String(), outputMsgs[test.configType])
+			}
+		})
+	}
+}
+
+func newConfig(configType configType, excluded bool) integration.Config {
+	var config integration.Config
+
+	switch configType {
+	case metricsConfig:
+		config = integration.Config{
+			Instances:       []integration.Data{integration.Data("{foo:bar}")},
+			ADIdentifiers:   []string{"some_identifier"},
+			ClusterCheck:    false,
+			MetricsExcluded: excluded,
+		}
+	case logsConfig:
+		config = integration.Config{
+			LogsConfig:    integration.Data("[{\"service\":\"some_service\",\"source\":\"some_source\"}]"),
+			ADIdentifiers: []string{"some_identifier"},
+			LogsExcluded:  excluded,
+		}
+	}
+
+	return config
+}

--- a/releasenotes/notes/configcheck-print-not-reporting-msg-c7d2ff2a730d09a1.yaml
+++ b/releasenotes/notes/configcheck-print-not-reporting-msg-c7d2ff2a730d09a1.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The ``agent configcheck`` command prints a message for checks that matched a
+    container exclusion rule.


### PR DESCRIPTION
### What does this PR do?

Prints a message in the `agent configcheck` output for checks that have metrics or log reporting disabled using the `container_exclude_metrics` and `container_exclude_logs` options.

Example (see last message for the redisdb check):

![metrics_exclusion_rule_match](https://user-images.githubusercontent.com/907223/129191903-d132d2fa-fe54-4389-8b8b-016e367dddc2.png)


### Describe how to test your changes

1) Configure a metrics check and logs collection for an integration. redisdb as explained [here](https://github.com/DataDog/integrations-core/tree/master/redisdb) works.

2) Enable or disable metrics and logs reporting with the `container_exclude_metrics` and `container_exclude_logs` parameters.

3) Look at the output of `agent configcheck`. In your metrics check, you should see `This configuration matched a metrics container-exclusion rule, so it will not be run by the Agent` if you excluded the container with `container_exclude_metrics`. Similarly, in the logs check, you should see `This configuration matched a logs container-exclusion rule, so it will not be run by the Agent` if you excluded the container with `container_exclude_logs`.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
