### PR TITLE
[tasks] Rename token for pipeline schedules to correspond to real usage

### DIFF
--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -439,10 +439,10 @@ def notify_failure(_, notification_type="merge", print_to_stdout=False):
 def _init_pipeline_schedule_task():
     project_name = "DataDog/datadog-agent"
     try:
-        project_access_token = os.environ['GITLAB_BOT_TOKEN']
+        bot_token = os.environ['GITLAB_BOT_TOKEN']
     except KeyError:
         raise Exit(message="You must specify GITLAB_BOT_TOKEN environment variable", code=1)
-    gitlab = Gitlab(api_token=project_access_token)
+    gitlab = Gitlab(api_token=bot_token)
     gitlab.test_project_found(project_name)
     return project_name, gitlab
 

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -439,9 +439,9 @@ def notify_failure(_, notification_type="merge", print_to_stdout=False):
 def _init_pipeline_schedule_task():
     project_name = "DataDog/datadog-agent"
     try:
-        project_access_token = os.environ['GITLAB_PROJECT_ACCESS_TOKEN']
+        project_access_token = os.environ['GITLAB_BOT_TOKEN']
     except KeyError:
-        raise Exit(message="You must specify GITLAB_PROJECT_ACCESS_TOKEN environment variable", code=1)
+        raise Exit(message="You must specify GITLAB_BOT_TOKEN environment variable", code=1)
     gitlab = Gitlab(api_token=project_access_token)
     gitlab.test_project_found(project_name)
     return project_name, gitlab


### PR DESCRIPTION
### What does this PR do?

We won't be using project access token, but a robot account, so let's rename the env variable to be more meaningful.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
