### PR TITLE
[runtime-security] add `security-agent.yaml` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ agentmsg.h
 # go-generated files
 datadog.yaml
 system-probe.yaml
+security-agent.yaml
 dogstatsd.yaml
 cloudfoundry.yaml
 Dockerfiles/cluster-agent/datadog-cluster.yaml


### PR DESCRIPTION
### What does this PR do?

The `security-agent.build` task create a `security-agent.yaml` file under `cmd/agent/dist/`. The goal of this PR is to ignore this file, in the same way that `system-probe.yaml` and `datadog.yaml` files are already ignored.

### Motivation

Decrease risk of having a useless file committed.

### Describe how to test your changes

This should be a no-op.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
