### PR TITLE
[ci/test/lint-python] fixup isort check

### DIFF
--- a/cmd/agent/dist/checks/network_checks.py
+++ b/cmd/agent/dist/checks/network_checks.py
@@ -2,4 +2,4 @@
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2016-present Datadog, Inc.
-from datadog_checks.base.checks import NetworkCheck, Status, EventType  # noqa: F401
+from datadog_checks.base.checks import EventType, NetworkCheck, Status  # noqa: F401

--- a/cmd/agent/dist/checks/winwmi_check.py
+++ b/cmd/agent/dist/checks/winwmi_check.py
@@ -2,4 +2,4 @@
 # under the Apache License Version 2.0.
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2016-present Datadog, Inc.
-from datadog_checks.base.checks.win.wmi import WinWMICheck, WMIMetric, MissingTagBy, from_time, to_time  # noqa: F401
+from datadog_checks.base.checks.win.wmi import MissingTagBy, WinWMICheck, WMIMetric, from_time, to_time  # noqa: F401


### PR DESCRIPTION
### What does this PR do?

Alphabetically order python imports

### Motivation

inv -e lint-python was failing due to import not in order
