### PR TITLE
[kitchen] Fix kitchen logs in Gitlab artifacts

### DIFF
--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -130,10 +130,11 @@ for attempt in $(seq 0 ${KITCHEN_INFRASTRUCTURE_FLAKES_RETRY:-2}); do
   # Before destroying the kitchen machines, get the list of failed suites,
   # as their status will be reset to non-failing once they're destroyed.
   # failing_test_suites is a newline-separated list of the failing test suite names.
-  failing_test_suites=$(bundle exec kitchen list --json | jq -cr "[ .[] | select( .last_error != null ) ] | map( .instance ) | .[]")
+  failing_test_suites=$(bundle exec kitchen list --no-log-overwrite --json | jq -cr "[ .[] | select( .last_error != null ) ] | map( .instance ) | .[]")
 
   # Then, destroy the kitchen machines
   bundle exec kitchen destroy "$test_suites" --no-log-overwrite
+
   if [ "$result" -eq 0 ]; then
       # if kitchen test succeeded, exit with 0
       exit 0

--- a/test/kitchen/tasks/run-test-kitchen.sh
+++ b/test/kitchen/tasks/run-test-kitchen.sh
@@ -133,7 +133,7 @@ for attempt in $(seq 0 ${KITCHEN_INFRASTRUCTURE_FLAKES_RETRY:-2}); do
   failing_test_suites=$(bundle exec kitchen list --json | jq -cr "[ .[] | select( .last_error != null ) ] | map( .instance ) | .[]")
 
   # Then, destroy the kitchen machines
-  bundle exec kitchen destroy "$test_suites"
+  bundle exec kitchen destroy "$test_suites" --no-log-overwrite
   if [ "$result" -eq 0 ]; then
       # if kitchen test succeeded, exit with 0
       exit 0


### PR DESCRIPTION
### What does this PR do?

Any time a `kitchen` command is run, the log files are overwritten. Due to this, since #8821, the log files we save as Gitlab artifacts only contain logs about the last operation done (the `kitchen destroy`). This adds the `--no-log-overwrite` option to all kitchen commands to save the logs of all kitchen commands.

### Motivation

Fix missing logs in Gitlab artifacts.


### Describe how to test your changes

Check Gitlab artifacts for kitchen tests.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
