### PR TITLE
[config_check] Reuse existing config.IsTemplate func

### DIFF
--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -134,7 +134,7 @@ func PrintConfig(w io.Writer, c integration.Config) {
 		fmt.Fprintln(w, fmt.Sprintf("%s:", color.BlueString("Log Config")))
 		fmt.Fprintln(w, string(c.LogsConfig))
 	}
-	if len(c.ADIdentifiers) > 0 {
+	if c.IsTemplate() {
 		fmt.Fprintln(w, fmt.Sprintf("%s:", color.BlueString("Auto-discovery IDs")))
 		for _, id := range c.ADIdentifiers {
 			fmt.Fprintln(w, fmt.Sprintf("* %s", color.CyanString(id)))


### PR DESCRIPTION
### What does this PR do?

Minor refactor to reuse an existing function.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
