### PR TITLE
[windows] Clean up output of lint

### DIFF
--- a/tasks/go.py
+++ b/tasks/go.py
@@ -21,7 +21,7 @@ from .modules import DEFAULT_MODULES, generate_dummy_package
 from .utils import get_build_flags
 
 # List of modules to ignore when running lint
-MODULE_WHITELIST = [
+MODULE_ALLOWLIST = [
     # Windows
     "doflare.go",
     "iostats_pdh_windows.go",
@@ -93,24 +93,34 @@ def lint(ctx, targets):
 
     # add the /... suffix to the targets
     targets_list = ["{}/...".format(t) for t in targets]
-    result = ctx.run("revive {}".format(' '.join(targets_list)))
+    result = ctx.run("revive {}".format(' '.join(targets_list)), hide=True)
     if result.stdout:
-        files = []
+        files = set()
         skipped_files = set()
         for line in (out for out in result.stdout.split('\n') if out):
-            fname = os.path.basename(line.split(":")[0])
-            if fname in MODULE_WHITELIST:
-                skipped_files.add(fname)
+            fullname = line.split(":")[0]
+            fname = os.path.basename(fullname)
+            if fname in MODULE_ALLOWLIST:
+                skipped_files.add(fullname)
                 continue
-            files.append(fname)
+            print(line)
+            files.add(fullname)
 
-        if files:
-            print("Linting issues found in {} files.".format(len(files)))
-            raise Exit(code=1)
+        # add whitespace for readability
+        print()
 
         if skipped_files:
             for skipped in skipped_files:
                 print("Allowed errors in whitelisted file {}".format(skipped))
+
+        # add whitespace for readability
+        print("")
+
+        if files:
+            print("Linting issues found in {} files.".format(len(files)))
+            for f in files:
+                print("Error in {}".format(f))
+            raise Exit(code=1)
 
     print("revive found no issues")
 

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -114,7 +114,7 @@ def lint(ctx, targets):
                 print("Allowed errors in whitelisted file {}".format(skipped))
 
         # add whitespace for readability
-        print("")
+        print()
 
         if files:
             print("Linting issues found in {} files.".format(len(files)))


### PR DESCRIPTION
### What does this PR do?

On windows, we allow several files to skip the linter; specifically when wrapping Windows API calls with structure definitions in all caps.  We preserve the windows signature, which gives the linter fits.

However, the previous incarnation, we dumped all the linting "errors", even though they're in files that we're skipping and have no intention of fixing.

This makes the output very noisy, and it's very difficult to separate linting errors that cause CI to fail from linting errors we don't care about.  This PR cleans up the output so that only errors that stopped the build would be output.

### Motivation

Make it easier to see why builds failed.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
