### PR TITLE
Reduce log spam when encountering missing netns/pid/map keys

### DIFF
--- a/pkg/network/netlink/conntrack.go
+++ b/pkg/network/netlink/conntrack.go
@@ -59,7 +59,7 @@ func (c *conntrack) Exists(conn *Con) (bool, error) {
 
 	replies, err := c.conn.Execute(msg)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.ENOENT) {
 			return false, nil
 		}
 

--- a/pkg/network/tracer/cached_conntrack.go
+++ b/pkg/network/tracer/cached_conntrack.go
@@ -132,7 +132,7 @@ func (cache *cachedConntrack) ensureConntrack(ino uint64, pid int) (netlink.Conn
 
 	ns, err := util.GetNetNamespaceFromPid(cache.procRoot, pid)
 	if err != nil {
-		if errors.Is(err, os.ErrNotExist) {
+		if errors.Is(err, os.ErrNotExist) || errors.Is(err, unix.ENOENT) {
 			return nil, nil
 		}
 

--- a/pkg/process/util/netns.go
+++ b/pkg/process/util/netns.go
@@ -3,13 +3,16 @@
 package util
 
 import (
+	"errors"
 	"fmt"
+	"os"
 	"path"
 	"runtime"
 	"syscall"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/vishvananda/netns"
+	"golang.org/x/sys/unix"
 )
 
 // WithRootNS executes a function within root network namespace and then switch back
@@ -59,7 +62,9 @@ func GetNetNamespaces(procRoot string) ([]netns.NsHandle, error) {
 	err := WithAllProcs(procRoot, func(pid int) error {
 		ns, err := netns.GetFromPath(path.Join(procRoot, fmt.Sprintf("%d/ns/net", pid)))
 		if err != nil {
-			log.Errorf("error while reading %s: %s", path.Join(procRoot, fmt.Sprintf("%d/ns/net", pid)), err)
+			if !errors.Is(err, os.ErrNotExist) && !errors.Is(err, unix.ENOENT) {
+				log.Errorf("error while reading %s: %s", path.Join(procRoot, fmt.Sprintf("%d/ns/net", pid)), err)
+			}
 			return nil
 		}
 


### PR DESCRIPTION
### What does this PR do?

Reduces unnecessary logs.

### Motivation

Customer log files filled with unhelpful log messages.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.