### PR TITLE
[process] Lowercase UDP => udp when comparing in NetworkAddress

### DIFF
--- a/pkg/process/checks/container.go
+++ b/pkg/process/checks/container.go
@@ -215,7 +215,7 @@ func convertAddressList(ctr *containers.Container) []*model.ContainerAddr {
 	addrs := make([]*model.ContainerAddr, 0, len(ctr.AddressList))
 	for _, a := range ctr.AddressList {
 		protocol := model.ConnectionType_tcp
-		if a.Protocol == "UDP" {
+		if a.Protocol == "udp" {
 			protocol = model.ConnectionType_udp
 		}
 		addrs = append(addrs, &model.ContainerAddr{


### PR DESCRIPTION
### What does this PR do?

You can see it is lowercased [here](https://docs.docker.com/engine/api/v1.41/#operation/ContainerInspect) and [here](https://github.com/DataDog/datadog-agent/blob/main/pkg/util/docker/docker_test.go#L446)

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Validate that container UDP ports are correctly reported.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
