### PR TITLE
[profiling] display a warning when changing runtime settings

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -282,7 +282,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("log_format_json", false)
 
 	// IPC API server timeout
-	config.BindEnvAndSetDefault("server_timeout", 15)
+	config.BindEnvAndSetDefault("server_timeout", 30)
 
 	// Use to force client side TLS version to 1.2
 	config.BindEnvAndSetDefault("force_tls_12", false)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -432,10 +432,10 @@ api_key:
 #
 # enable_gohai: true
 
-## @param server_timeout - integer - optional - default: 15
+## @param server_timeout - integer - optional - default: 30
 ## IPC api server timeout in seconds.
 #
-# server_timeout: 15
+# server_timeout: 30
 
 ## @param procfs_path - string - optional
 ## Some environments may have the procfs file system mounted in a miscellaneous

--- a/pkg/config/settings/runtime_profiling_common.go
+++ b/pkg/config/settings/runtime_profiling_common.go
@@ -1,0 +1,14 @@
+package settings
+
+import (
+	"errors"
+
+	"github.com/DataDog/datadog-agent/pkg/util/profiling"
+)
+
+func checkProfilingNeedsRestart(old, new int) error {
+	if old == 0 && new != 0 && profiling.IsRunning() {
+		return errors.New("go runtime setting applied; manually restart internal profiling to capture profile data in the app")
+	}
+	return nil
+}

--- a/pkg/config/settings/runtime_setting_block_profile_rate.go
+++ b/pkg/config/settings/runtime_setting_block_profile_rate.go
@@ -38,8 +38,10 @@ func (r RuntimeBlockProfileRate) Set(value interface{}) error {
 		return err
 	}
 
+	err = checkProfilingNeedsRestart(profiling.GetBlockProfileRate(), rate)
+
 	profiling.SetBlockProfileRate(rate)
 	config.Datadog.Set("internal_profiling.block_profile_rate", rate)
 
-	return nil
+	return err
 }

--- a/pkg/config/settings/runtime_setting_mutex_profile_fraction.go
+++ b/pkg/config/settings/runtime_setting_mutex_profile_fraction.go
@@ -38,8 +38,10 @@ func (r RuntimeMutexProfileFraction) Set(value interface{}) error {
 		return err
 	}
 
+	err = checkProfilingNeedsRestart(profiling.GetMutexProfileFraction(), rate)
+
 	profiling.SetMutexProfileFraction(rate)
 	config.Datadog.Set("internal_profiling.mutex_profile_fraction", rate)
 
-	return nil
+	return err
 }

--- a/pkg/config/settings/runtime_setting_profiling.go
+++ b/pkg/config/settings/runtime_setting_profiling.go
@@ -7,6 +7,7 @@ package settings
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -19,7 +20,7 @@ type ProfilingRuntimeSetting string
 
 // Description returns the runtime setting's description
 func (l ProfilingRuntimeSetting) Description() string {
-	return "Enable/disable profiling on the agent, valid values are: true, false"
+	return "Enable/disable profiling on the agent, valid values are: true, false, restart"
 }
 
 // Hidden returns whether or not this setting is hidden from the list of runtime settings
@@ -41,6 +42,13 @@ func (l ProfilingRuntimeSetting) Get() (interface{}, error) {
 func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 	var profile bool
 	var err error
+
+	if v, ok := v.(string); ok && strings.ToLower(v) == "restart" {
+		if err := l.Set(false); err != nil {
+			return err
+		}
+		return l.Set(true)
+	}
 
 	profile, err = GetBool(v)
 

--- a/pkg/util/profiling/profiling.go
+++ b/pkg/util/profiling/profiling.go
@@ -83,3 +83,11 @@ func Stop() {
 		running = false
 	}
 }
+
+// IsRunning returns true if the profiler is running; this function is thread-safe.
+func IsRunning() bool {
+	mu.RLock()
+	v := running
+	mu.RUnlock()
+	return v
+}


### PR DESCRIPTION
### What does this PR do?

Add a warning when a go runtime setting is modified in a running agent with internal profiling enabled. 

Increase API server timeout, as `config set internal_profiling false` may block if a cpu profile is being collected, for up to duration of the profile (15s).

### Motivation

Internal profiling library will not pick up changes in go runtime settings, and profiling session needs to be restarted to add new profile types.

### Describe how to test your changes

Start the agent with internal profiling enabled: `DD_INTERNAL_PROFILING_ENABLED=true`

Change runtime profiling settings, and check that the warning message is displayed:

```
agent config set runtime_block_profile_rate 1
agent config set runtime_mutex_profile_fraction 1
```

Restart profiling:

```
agent config set internal_profiling restart
```

Wait 10 minutes, make sure block and mutex profiles are available in the app.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
