### PR TITLE
Use Processor PDH counter as fallback on system without Processor Information

### DIFF
--- a/pkg/collector/corechecks/system/cpu/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows.go
@@ -92,6 +92,17 @@ func (c *Check) Run() error {
 	return nil
 }
 
+// Configure the PDH counter according to the running environment.
+// On machines with more than 1 NUMA node, it uses "Process Information",
+// otherwise it uses "Processor" (e.g. in containers).
+func getProcessorPDHCounter(counterName, instance string) (pdhutil.PdhSingleInstanceCounterSet, error) {
+	counter, err := pdhutil.GetUnlocalizedCounter("Processor Information", counterName, instance)
+	if err != nil {
+		counter, err = pdhutil.GetUnlocalizedCounter("Processor", counterName, instance)
+	}
+	return counter, err
+}
+
 // Configure the CPU check doesn't need configuration
 func (c *Check) Configure(data integration.Data, initConfig integration.Data, source string) error {
 	if err := c.CommonConfigure(data, source); err != nil {
@@ -108,19 +119,19 @@ func (c *Check) Configure(data integration.Data, initConfig integration.Data, so
 
 	// Note we use "processor information" instead of "processor" because on multi-processor machines the later only gives
 	// you visibility about other applications running on the same processor as you
-	c.interruptsCounter, err = pdhutil.GetUnlocalizedCounter("Processor Information", "% Interrupt Time", "_Total")
+	c.interruptsCounter, err = getProcessorPDHCounter("% Interrupt Time", "_Total")
 	if err != nil {
 		return fmt.Errorf("cpu.Check could not establish interrupt time counter %v", err)
 	}
-	c.idleCounter, err = pdhutil.GetUnlocalizedCounter("Processor Information", "% Idle Time", "_Total")
+	c.idleCounter, err = getProcessorPDHCounter("% Idle Time", "_Total")
 	if err != nil {
 		return fmt.Errorf("cpu.Check could not establish idle time counter %v", err)
 	}
-	c.userCounter, err = pdhutil.GetUnlocalizedCounter("Processor Information", "% User Time", "_Total")
+	c.userCounter, err = getProcessorPDHCounter("% User Time", "_Total")
 	if err != nil {
 		return fmt.Errorf("cpu.Check could not establish user time counter %v", err)
 	}
-	c.privilegedCounter, err = pdhutil.GetUnlocalizedCounter("Processor Information", "% Privileged Time", "_Total")
+	c.privilegedCounter, err = getProcessorPDHCounter("% Privileged Time", "_Total")
 	if err != nil {
 		return fmt.Errorf("cpu.Check could not establish system time counter %v", err)
 	}

--- a/releasenotes/notes/fix_cpu_pdh_container-706c5ab1140a4554.yaml
+++ b/releasenotes/notes/fix_cpu_pdh_container-706c5ab1140a4554.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed a bug where the CPU check would not work within a container on Windows.


### PR DESCRIPTION
### What does this PR do?

This PR introduces a fallback CPU PDH counter in the case the "Processor Information" PDH counter is not available.

### Motivation

A support case revealed that within containers, the "Processor Information" PDH counter was not available and thus the cpu check was not working.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Run the Agent both on a host with a multi-socket CPU (AWS bare instances for example) and in a container.
The command `agent status` should not return an error in both cases, and the correct CPU usage should be seen in dogweb.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
