### PR TITLE
Factor HTTP request timeout into a separate function

### DIFF
--- a/cmd/agent/api/server.go
+++ b/cmd/agent/api/server.go
@@ -54,7 +54,7 @@ func grpcHandlerFunc(grpcServer *grpc.Server, otherHandler http.Handler) http.Ha
 // configured in `server_timeout`.
 func timeoutHandlerFunc(otherHandler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		deadline := time.Now().Add(config.Datadog.GetDuration("server_timeout") * time.Second)
+		deadline := time.Now().Add(time.Duration(config.Datadog.GetInt64("server_timeout")) * time.Second)
 
 		conn := agent.GetConnection(r)
 		_ = conn.SetWriteDeadline(deadline)
@@ -126,10 +126,14 @@ func StartServer() error {
 	mux.Handle("/check/", http.StripPrefix("/check", check.SetupHandlers(checkMux)))
 	mux.Handle("/", gwmux)
 
+	// apply server_timeout to all handlers in the mux (with a few exceptions
+	// such as streaming logs, which reset the deadlines back to zero)
+	handler := timeoutHandlerFunc(mux)
+
 	srv := &http.Server{
-		Addr:    tlsAddr,
-		Handler: grpcHandlerFunc(s, timeoutHandlerFunc(mux)),
-		// Handler: grpcHandlerFunc(s, r),
+		Addr: tlsAddr,
+		// handle grpc calls directly, falling back to `handler` for non-grpc reqs
+		Handler: grpcHandlerFunc(s, handler),
 		TLSConfig: &tls.Config{
 			Certificates: []tls.Certificate{*tlsKeyPair},
 			NextProtos:   []string{"h2"},


### PR DESCRIPTION
### Motivation

Minor refactor for greater readability

### Describe how to test your changes

* [DONE] Verify that any agent IPC still works
* Verify that `server_timeout` still applies:
  1. Set server_timeout to `1` (second)
  2. Use `curl` to request a flare, forcing http/1.1 (this timeout does not work for http/2): `curl --http1.1 -d{} -v -k -H "Authorization: Bearer $(<auth_token)" https://localhost:5001/agent/flare`
  3. You should get a TLS error after 1 second when the connection is severed.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
