### PR TITLE
Exempt the `/agent/flare` endpoint from `server_timeout`

### DIFF
--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -106,11 +106,9 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	// remove the server_timeout for this connection, as generating a flare can
-	// take some time
+	// Reset the `server_timeout` deadline for this connection as creating a flare can take some time
 	conn := GetConnection(r)
 	_ = conn.SetDeadline(time.Time{})
-	_ = conn.SetWriteDeadline(time.Time{})
 
 	logFile := config.Datadog.GetString("log_file")
 	if logFile == "" {
@@ -236,11 +234,9 @@ func streamLogs(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Reset the `server_timeout` deadline for this connection as streaming holds the connection open.
 	conn := GetConnection(r)
-
-	// Override the default server timeouts so the connection never times out
 	_ = conn.SetDeadline(time.Time{})
-	_ = conn.SetWriteDeadline(time.Time{})
 
 	done := make(chan struct{})
 	defer close(done)

--- a/cmd/agent/api/agent/agent.go
+++ b/cmd/agent/api/agent/agent.go
@@ -106,6 +106,12 @@ func makeFlare(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// remove the server_timeout for this connection, as generating a flare can
+	// take some time
+	conn := GetConnection(r)
+	_ = conn.SetDeadline(time.Time{})
+	_ = conn.SetWriteDeadline(time.Time{})
+
 	logFile := config.Datadog.GetString("log_file")
 	if logFile == "" {
 		logFile = common.DefaultLogFile

--- a/releasenotes/notes/no-timeout-for-flares-930505387df0e5c4.yaml
+++ b/releasenotes/notes/no-timeout-for-flares-930505387df0e5c4.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Flare generation is no longer subject to the `server_timeout` configuration,
+    as gathering all of the information for a flare can take quite some time.

--- a/releasenotes/notes/no-timeout-for-flares-930505387df0e5c4.yaml
+++ b/releasenotes/notes/no-timeout-for-flares-930505387df0e5c4.yaml
@@ -1,5 +1,5 @@
 ---
-enhancements:
+fixes:
   - |
     Flare generation is no longer subject to the `server_timeout` configuration,
     as gathering all of the information for a flare can take quite some time.


### PR DESCRIPTION
This follows the model of log-streaming, where it's expected that the
HTTP request may take many seconds.

### Motivation

Avoid failures during flare generation that interfere with debugging other issues.

### Describe how to test your changes

* Set `server_timeout` to 1
* Generate a flare successfully

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
