### PR TITLE
Allow re-introduction of the tcp log timeout

### DIFF
--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -32,8 +32,9 @@ const (
 type LogsConfig struct {
 	Type string
 
-	Port int    // Network
-	Path string // File, Journald
+	Port        int    // Network
+	IdleTimeout string `mapstructure:"idle_timeout" json:"idle_timeout"` // Network
+	Path        string // File, Journald
 
 	Encoding     string   `mapstructure:"encoding" json:"encoding"`             // File
 	ExcludePaths []string `mapstructure:"exclude_paths" json:"exclude_paths"`   // File

--- a/pkg/logs/input/listener/tcp.go
+++ b/pkg/logs/input/listener/tcp.go
@@ -124,7 +124,7 @@ func (l *TCPListener) startListener() error {
 
 // read reads data from connection, returns an error if it failed and stop the tailer.
 func (l *TCPListener) read(tailer *Tailer) ([]byte, error) {
-	if l.idleTimeout != 0 {
+	if l.idleTimeout > 0 {
 		tailer.conn.SetReadDeadline(time.Now().Add(l.idleTimeout)) //nolint:errcheck
 	}
 	frame := make([]byte, l.frameSize)

--- a/pkg/logs/input/listener/tcp.go
+++ b/pkg/logs/input/listener/tcp.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"net"
 	"sync"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -21,6 +22,7 @@ import (
 type TCPListener struct {
 	pipelineProvider pipeline.Provider
 	source           *config.LogSource
+	idleTimeout      time.Duration
 	frameSize        int
 	listener         net.Listener
 	tailers          []*Tailer
@@ -30,9 +32,20 @@ type TCPListener struct {
 
 // NewTCPListener returns an initialized TCPListener
 func NewTCPListener(pipelineProvider pipeline.Provider, source *config.LogSource, frameSize int) *TCPListener {
+	var idleTimeout time.Duration
+	if source.Config.IdleTimeout != "" {
+		var err error
+		idleTimeout, err = time.ParseDuration(source.Config.IdleTimeout)
+		if err != nil {
+			log.Errorf("Error parsing log's idle_timeout as a duration: %s", err)
+			idleTimeout = 0
+		}
+	}
+
 	return &TCPListener{
 		pipelineProvider: pipelineProvider,
 		source:           source,
+		idleTimeout:      idleTimeout,
 		frameSize:        frameSize,
 		tailers:          []*Tailer{},
 		stop:             make(chan struct{}, 1),
@@ -111,6 +124,9 @@ func (l *TCPListener) startListener() error {
 
 // read reads data from connection, returns an error if it failed and stop the tailer.
 func (l *TCPListener) read(tailer *Tailer) ([]byte, error) {
+	if l.idleTimeout != 0 {
+		tailer.conn.SetReadDeadline(time.Now().Add(l.idleTimeout)) //nolint:errcheck
+	}
 	frame := make([]byte, l.frameSize)
 	n, err := tailer.conn.Read(frame)
 	if err != nil {


### PR DESCRIPTION
This is a backstop in case #8762 proves problematic.  By adding
`idle_timeout` to the relevant `logs` clauses, we can re-instate the 60s
timeout (or whatever timeout is appropriate).  There are no known
circumstances where this would be necessary; this is just in case.

### Motivation

Concerns that #8762 might introduce issues such as resource exhaustion in cases of badly-behaved TCP clients.

### Describe how to test your changes

* Set up a TCP log intake
* Connect to it and leave the connection open for >60s (e.g., with `nc`)
* Add `idle_timeout: 1s` to the log intake config
* Connect to it and see the connection close after 1s
* Make a bogus configuration of `idle_timeout`
* See an error about "Error parsing log's idle_timeout" in the agent logs, but no failure.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
  - no release notes here as this is an undocumented "just in case" config
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
