### PR TITLE
[kitchen] Pin yum cookbook

### DIFF
--- a/test/kitchen/site-cookbooks/dd-agent-5/metadata.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-5/metadata.rb
@@ -6,4 +6,4 @@ version          "0.2.0"
 
 depends 'apt', '>= 2.1.0'
 depends 'datadog'
-depends 'yum'
+depends 'yum', '< 7.0.0'

--- a/test/kitchen/site-cookbooks/dd-agent-import-conf/metadata.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-import-conf/metadata.rb
@@ -6,4 +6,4 @@ version          "0.1.0"
 
 depends 'apt', '>= 2.1.0'
 depends 'datadog'
-depends 'yum'
+depends 'yum', '< 7.0.0'

--- a/test/kitchen/site-cookbooks/dd-agent-install/metadata.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install/metadata.rb
@@ -6,4 +6,4 @@ version          "0.2.0"
 
 depends 'apt', '>= 2.1.0'
 depends 'datadog'
-depends 'yum'
+depends 'yum', '< 7.0.0'

--- a/test/kitchen/site-cookbooks/dd-agent-reinstall/metadata.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-reinstall/metadata.rb
@@ -6,4 +6,4 @@ version          "0.2.0"
 
 depends 'apt', '>= 2.1.0'
 depends 'datadog'
-depends 'yum'
+depends 'yum', '< 7.0.0'

--- a/test/kitchen/site-cookbooks/dd-agent-upgrade/metadata.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-upgrade/metadata.rb
@@ -6,4 +6,4 @@ version          "0.2.0"
 
 depends 'apt', '>= 2.1.0'
 depends 'datadog'
-depends 'yum'
+depends 'yum', '< 7.0.0'


### PR DESCRIPTION
### What does this PR do?

Pin yum cookbook used in kitchen tests to a version lower than `7.0.0`, which breaks compatibility with chef 14.

### Motivation

Fix kitchen tests.

### Describe how to test your changes

Run kitchen tests: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/5195429

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
