### PR TITLE
[kitchen] Add Debian 11

### DIFF
--- a/.gitlab/kitchen_testing/debian.yml
+++ b/.gitlab/kitchen_testing/debian.yml
@@ -12,8 +12,8 @@
 .kitchen_os_debian:
   variables:
     KITCHEN_PLATFORM: "debian"
-    KITCHEN_OSVERS: "debian-8,debian-9,debian-10"
-    DEFAULT_KITCHEN_OSVERS: "debian-10"
+    KITCHEN_OSVERS: "debian-8,debian-9,debian-10,debian-11"
+    DEFAULT_KITCHEN_OSVERS: "debian-11"
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - cd $DD_AGENT_TESTING_DIR

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -27,7 +27,8 @@
             "x86_64": {
                 "debian-8": "urn,credativ:Debian:8:8.0.201901221",
                 "debian-9": "urn,credativ:Debian:9:9.20200722.0",
-                "debian-10": "urn,Debian:debian-10:10:0.20210208.542"
+                "debian-10": "urn,Debian:debian-10:10:0.20210208.542",
+                "debian-11": "urn,Debian:debian-11:11:0.20210814.734"
             }
         },
         "ec2": {


### PR DESCRIPTION
### What does this PR do?

Adds Debian 11 coverage to kitchen tests.

### Motivation

Test against all stable supported platforms.

### Describe how to test your changes

Run kitchen tests on a pipeline.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
