### PR TITLE
[pkg/quantile] Bundle into a Go module

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -33,6 +33,18 @@ updates:
     schedule:
       interval: weekly
   - package-ecosystem: gomod
+    directory: /pkg/quantile
+    labels:
+      - dependencies
+      - team/metrics-aggregation
+      - changelog/no-changelog
+    milestone: 22
+    ignore: 
+      # Ignore internal modules
+      - dependency-name: github.com/DataDog/datadog-agent/*
+    schedule:
+      interval: weekly
+  - package-ecosystem: gomod
     directory: /pkg/util/log
     labels:
       - dependencies

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ replace (
 )
 
 replace (
+	github.com/DataDog/datadog-agent/pkg/quantile => ./pkg/quantile
 	github.com/DataDog/datadog-agent/pkg/util/log => ./pkg/util/log
 	github.com/DataDog/datadog-agent/pkg/util/winutil => ./pkg/util/winutil
 )
@@ -47,6 +48,7 @@ require (
 	code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a // indirect
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
 	github.com/DataDog/agent-payload v4.80.0+incompatible
+	github.com/DataDog/datadog-agent/pkg/quantile v0.0.0
 	github.com/DataDog/datadog-agent/pkg/util/log v0.30.0-rc.7
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.30.0-rc.7
 	github.com/DataDog/datadog-go v4.8.1+incompatible

--- a/pkg/quantile/.golangci.yml
+++ b/pkg/quantile/.golangci.yml
@@ -1,0 +1,7 @@
+run:
+  skip-files:
+    # TODO metrics-aggregation
+    - key.go
+    - print.go
+    - sparse.go
+    - sparse_test.go 

--- a/pkg/quantile/go.mod
+++ b/pkg/quantile/go.mod
@@ -1,0 +1,8 @@
+module github.com/DataDog/datadog-agent/pkg/quantile
+
+go 1.15
+
+require (
+	github.com/dustin/go-humanize v1.0.0
+	github.com/stretchr/testify v1.7.0
+)

--- a/pkg/quantile/go.sum
+++ b/pkg/quantile/go.sum
@@ -1,0 +1,13 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
+github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/tasks/modules.py
+++ b/tasks/modules.py
@@ -67,12 +67,13 @@ class GoModule:
 
 
 DEFAULT_MODULES = {
-    ".": GoModule(".", targets=["./pkg", "./cmd"], dependencies=["pkg/util/log", "pkg/util/winutil"]),
+    ".": GoModule(".", targets=["./pkg", "./cmd"], dependencies=["pkg/util/log", "pkg/util/winutil", "pkg/quantile"]),
     "pkg/util/log": GoModule("pkg/util/log"),
     "internal/tools": GoModule("internal/tools", condition=lambda: False, should_tag=False),
     "pkg/util/winutil": GoModule(
         "pkg/util/winutil", condition=lambda: sys.platform == 'win32', dependencies=["pkg/util/log"]
     ),
+    "pkg/quantile": GoModule("pkg/quantile"),
 }
 
 MAIN_TEMPLATE = """package main


### PR DESCRIPTION
### What does this PR do?

Makes `pkg/quantile` into a module.

### Motivation

Sending sketches from the OpenTelemetry Collector Datadog Exporter.

We will need to copy over some code from `pkg/metrics` for the marshalling; we can consider moving this over in some way in the future, but for now this is the highest cost-to-benefit ratio bundling we can make.

### Additional Notes

This should be a no-op for the Agent, it just makes this part of the code available for other Go modules to consume.
[These instructions](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/modules.md) were followed for creating the module.

### Describe how to test your changes

(For Agent Core, which uses this module even though they don't own it) Test that the sketches functionality on the Agent works properly.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
