### PR TITLE
Add changelog and release for DCA 1.14.X

### DIFF
--- a/CHANGELOG-DCA.rst
+++ b/CHANGELOG-DCA.rst
@@ -2,6 +2,45 @@
 Release Notes
 =============
 
+.. _Release Notes_dca-1.14.0_dca-1.14.X:
+
+dca-1.14.0
+==========
+
+.. _Release Notes_dca-1.14.0_dca-1.14.X_Prelude:
+
+Prelude
+-------
+
+Released on: 2021-08-12
+Pinned to datadog-agent v7.30.0: `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#7300>`_.
+
+.. _Release Notes_dca-1.14.0_dca-1.14.X_New Features:
+
+New Features
+------------
+
+- Enable ``DaemonSet`` collection by default in the orchestrator check. Add ``StatefulSet`` collection in the orchestrator check.
+
+.. _Release Notes_dca-1.14.0_dca-1.14.X_Enhancement Notes:
+
+Enhancement Notes
+-----------------
+
+- The Cluster Agent's Admission Controller now uses the ``admissionregistration.k8s.io/v1`` kubernetes API when available.
+- The Cluster Agent can be instructed to dispatch cluster checks without decrypting secrets. The node Agent or the cluster check runner will fetch the secrets after receiving the configurations from the Cluster Agent. This can be enabled by setting ``DD_SECRET_BACKEND_SKIP_CHECKS`` to ``true`` in the Cluster Agent config.
+- The Cluster Agent's external metrics provider now serves an OpenAPI endpoint.
+- Add the ability to change log_level at runtime. To set the log_level to ``debug`` the following command should be used: ``agent config set log_level debug``.
+- Improve status and flare for the Cluster Check Runners.
+
+.. _Release Notes_dca-1.14.0_dca-1.14.X_Bug Fixes:
+
+Bug Fixes
+---------
+
+- Show different orchestrator status collection information between follower and leader.
+- Fix an edge case where the Admission Controller doesn't update the certificate according to the Cluster Agent configuration.
+
 .. _Release Notes_dca-1.13.1_dca-1.13.X:
 
 dca-1.13.1

--- a/release.json
+++ b/release.json
@@ -197,6 +197,9 @@
         "MACOS_BUILD_VERSION": "7.23.0",
         "SECURITY_AGENT_POLICIES_VERSION": "v0.5"
     },
+    "dca-1.14.0": {
+        "SECURITY_AGENT_POLICIES_VERSION": "v0.15"
+    },
     "dca-1.13.1": {
         "SECURITY_AGENT_POLICIES_VERSION": "v0.12"
     },


### PR DESCRIPTION
### What does this PR do?

Add changelog and release info for the Cluster Agent

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
