### PR TITLE
Enable logs intake v2 by default

### DIFF
--- a/cmd/cluster-agent/app/compliance.go
+++ b/cmd/cluster-agent/app/compliance.go
@@ -43,12 +43,12 @@ func runCompliance(ctx context.Context, apiCl *apiserver.APIClient, isLeader fun
 }
 
 func newLogContext(logsConfig *config.LogsConfigKeys, endpointPrefix string) (*config.Endpoints, *client.DestinationsContext, error) {
-	endpoints, err := config.BuildHTTPEndpointsWithConfig(logsConfig, endpointPrefix, intakeTrackType, config.DefaultIntakeProtocol, config.DefaultIntakeSource)
+	endpoints, err := config.BuildHTTPEndpointsWithConfig(logsConfig, endpointPrefix, intakeTrackType, config.DefaultIntakeProtocol, config.DefaultIntakeOrigin)
 	if err != nil {
-		endpoints, err = config.BuildHTTPEndpoints(intakeTrackType, config.DefaultIntakeProtocol, config.DefaultIntakeSource)
+		endpoints, err = config.BuildHTTPEndpoints(intakeTrackType, config.DefaultIntakeProtocol, config.DefaultIntakeOrigin)
 		if err == nil {
 			httpConnectivity := logshttp.CheckConnectivity(endpoints.Main)
-			endpoints, err = config.BuildEndpoints(httpConnectivity, intakeTrackType, config.DefaultIntakeProtocol, config.DefaultIntakeSource)
+			endpoints, err = config.BuildEndpoints(httpConnectivity, intakeTrackType, config.DefaultIntakeProtocol, config.DefaultIntakeOrigin)
 		}
 	}
 

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -116,13 +116,13 @@ func init() {
 	SecurityAgentCmd.AddCommand(startCmd)
 }
 
-func newLogContext(logsConfig *config.LogsConfigKeys, endpointPrefix string, intakeTrackType config.IntakeTrackType, intakeSource config.IntakeSource) (*config.Endpoints, *client.DestinationsContext, error) {
-	endpoints, err := config.BuildHTTPEndpointsWithConfig(logsConfig, endpointPrefix, intakeTrackType, config.DefaultIntakeProtocol, intakeSource)
+func newLogContext(logsConfig *config.LogsConfigKeys, endpointPrefix string, intakeTrackType config.IntakeTrackType, intakeOrigin config.IntakeOrigin) (*config.Endpoints, *client.DestinationsContext, error) {
+	endpoints, err := config.BuildHTTPEndpointsWithConfig(logsConfig, endpointPrefix, intakeTrackType, config.DefaultIntakeProtocol, intakeOrigin)
 	if err != nil {
-		endpoints, err = config.BuildHTTPEndpoints(intakeTrackType, config.DefaultIntakeProtocol, intakeSource)
+		endpoints, err = config.BuildHTTPEndpoints(intakeTrackType, config.DefaultIntakeProtocol, intakeOrigin)
 		if err == nil {
 			httpConnectivity := logshttp.CheckConnectivity(endpoints.Main)
-			endpoints, err = config.BuildEndpoints(httpConnectivity, intakeTrackType, config.DefaultIntakeProtocol, intakeSource)
+			endpoints, err = config.BuildEndpoints(httpConnectivity, intakeTrackType, config.DefaultIntakeProtocol, intakeOrigin)
 		}
 	}
 

--- a/cmd/security-agent/app/compliance.go
+++ b/cmd/security-agent/app/compliance.go
@@ -59,7 +59,7 @@ func init() {
 
 func newLogContextCompliance() (*config.Endpoints, *client.DestinationsContext, error) {
 	logsConfigComplianceKeys := config.NewLogsConfigKeys("compliance_config.endpoints.", coreconfig.Datadog)
-	return newLogContext(logsConfigComplianceKeys, "compliance-http-intake.logs.", "compliance", config.DefaultIntakeSource)
+	return newLogContext(logsConfigComplianceKeys, "compliance-http-intake.logs.", "compliance", config.DefaultIntakeOrigin)
 }
 
 func eventRun(cmd *cobra.Command, args []string) error {

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	cwsIntakeSource config.IntakeSource = "cloud-workload-security"
+	cwsIntakeOrigin config.IntakeOrigin = "cloud-workload-security"
 )
 
 var (
@@ -183,7 +183,7 @@ func newRuntimeReporter(stopper restart.Stopper, sourceName, sourceType string, 
 // This function will only be used on Linux. The only platforms where the runtime agent runs
 func newLogContextRuntime() (*config.Endpoints, *client.DestinationsContext, error) { // nolint: deadcode, unused
 	logsConfigComplianceKeys := config.NewLogsConfigKeys("runtime_security_config.endpoints.", coreconfig.Datadog)
-	return newLogContext(logsConfigComplianceKeys, "runtime-security-http-intake.logs.", "logs", cwsIntakeSource)
+	return newLogContext(logsConfigComplianceKeys, "runtime-security-http-intake.logs.", "logs", cwsIntakeOrigin)
 }
 
 func startRuntimeSecurity(hostname string, stopper restart.Stopper, statsdClient *ddgostatsd.Client) (*secagent.RuntimeSecurityAgent, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -702,10 +702,10 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("logs_config.use_http", false)
 	config.BindEnvAndSetDefault("logs_config.use_tcp", false)
 
-	bindEnvAndSetLogsConfigKeys(config, "logs_config.", false)
-	bindEnvAndSetLogsConfigKeys(config, "database_monitoring.samples.", false)
-	bindEnvAndSetLogsConfigKeys(config, "database_monitoring.metrics.", false)
-	bindEnvAndSetLogsConfigKeys(config, "network_devices.metadata.", false)
+	bindEnvAndSetLogsConfigKeys(config, "logs_config.")
+	bindEnvAndSetLogsConfigKeys(config, "database_monitoring.samples.")
+	bindEnvAndSetLogsConfigKeys(config, "database_monitoring.metrics.")
+	bindEnvAndSetLogsConfigKeys(config, "network_devices.metadata.")
 
 	config.BindEnvAndSetDefault("logs_config.dd_port", 10516)
 	config.BindEnvAndSetDefault("logs_config.dev_mode_use_proto", true)
@@ -873,7 +873,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("compliance_config.check_max_events_per_run", 100)
 	config.BindEnvAndSetDefault("compliance_config.dir", "/etc/datadog-agent/compliance.d")
 	config.BindEnvAndSetDefault("compliance_config.run_path", defaultRunPath)
-	bindEnvAndSetLogsConfigKeys(config, "compliance_config.endpoints.", false)
+	bindEnvAndSetLogsConfigKeys(config, "compliance_config.endpoints.")
 
 	// Datadog security agent (runtime)
 	config.BindEnvAndSetDefault("runtime_security_config.enabled", false)
@@ -902,7 +902,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.custom_sensitive_words", []string{})
 	config.BindEnvAndSetDefault("runtime_security_config.remote_tagger", true)
 	config.BindEnvAndSetDefault("runtime_security_config.log_patterns", []string{})
-	bindEnvAndSetLogsConfigKeys(config, "runtime_security_config.endpoints.", true)
+	bindEnvAndSetLogsConfigKeys(config, "runtime_security_config.endpoints.")
 	config.BindEnvAndSetDefault("runtime_security_config.self_test.enabled", true)
 
 	// Serverless Agent
@@ -1151,7 +1151,7 @@ func GetMultipleEndpoints() (map[string][]string, error) {
 	return getMultipleEndpointsWithConfig(Datadog)
 }
 
-func bindEnvAndSetLogsConfigKeys(config Config, prefix string, v2Api bool) {
+func bindEnvAndSetLogsConfigKeys(config Config, prefix string) {
 	config.BindEnv(prefix + "logs_dd_url") // Send the logs to a proxy. Must respect format '<HOST>:<PORT>' and '<PORT>' to be an integer
 	config.BindEnv(prefix + "dd_url")
 	config.BindEnv(prefix + "additional_endpoints")
@@ -1168,7 +1168,7 @@ func bindEnvAndSetLogsConfigKeys(config Config, prefix string, v2Api bool) {
 	config.BindEnvAndSetDefault(prefix+"sender_backoff_max", DefaultLogsSenderBackoffMax)
 	config.BindEnvAndSetDefault(prefix+"sender_recovery_interval", DefaultForwarderRecoveryInterval)
 	config.BindEnvAndSetDefault(prefix+"sender_recovery_reset", false)
-	config.BindEnvAndSetDefault(prefix+"use_v2_api", v2Api)
+	config.BindEnvAndSetDefault(prefix+"use_v2_api", true)
 }
 
 // getDomainPrefix provides the right prefix for agent X.Y.Z

--- a/pkg/epforwarder/epforwarder.go
+++ b/pkg/epforwarder/epforwarder.go
@@ -135,7 +135,8 @@ type passthroughPipeline struct {
 }
 
 type passthroughPipelineDesc struct {
-	eventType                     string
+	eventType string
+	// intakeTrackType is the track type to use for the v2 intake api. When blank, v1 is used instead.
 	intakeTrackType               config.IntakeTrackType
 	endpointsConfigPrefix         string
 	hostnameEndpointPrefix        string

--- a/pkg/epforwarder/epforwarder.go
+++ b/pkg/epforwarder/epforwarder.go
@@ -148,7 +148,7 @@ type passthroughPipelineDesc struct {
 // without any of the processing that exists in regular logs pipelines.
 func newHTTPPassthroughPipeline(desc passthroughPipelineDesc, destinationsContext *client.DestinationsContext) (p *passthroughPipeline, err error) {
 	configKeys := config.NewLogsConfigKeys(desc.endpointsConfigPrefix, coreConfig.Datadog)
-	endpoints, err := config.BuildHTTPEndpointsWithConfig(configKeys, desc.hostnameEndpointPrefix, desc.intakeTrackType, config.DefaultIntakeProtocol, config.DefaultIntakeSource)
+	endpoints, err := config.BuildHTTPEndpointsWithConfig(configKeys, desc.hostnameEndpointPrefix, desc.intakeTrackType, config.DefaultIntakeProtocol, config.DefaultIntakeOrigin)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/backoff"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 // ContentType options,
@@ -150,6 +151,7 @@ func (d *Destination) unconditionalSend(payload []byte) (err error) {
 	}
 	if d.origin != "" {
 		req.Header.Set("DD-EVP-ORIGIN", string(d.origin))
+		req.Header.Set("DD-EVP-ORIGIN-VERSION", version.AgentVersion)
 	}
 	req = req.WithContext(ctx)
 

--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -52,7 +52,7 @@ type Destination struct {
 	nbErrors            int
 	blockedUntil        time.Time
 	protocol            config.IntakeProtocol
-	source              config.IntakeSource
+	origin              config.IntakeOrigin
 }
 
 // NewDestination returns a new Destination.
@@ -87,7 +87,7 @@ func newDestination(endpoint config.Endpoint, contentType string, destinationsCo
 		climit:              make(chan struct{}, maxConcurrentBackgroundSends),
 		backoff:             policy,
 		protocol:            endpoint.Protocol,
-		source:              endpoint.Source,
+		origin:              endpoint.Origin,
 	}
 }
 
@@ -148,8 +148,8 @@ func (d *Destination) unconditionalSend(payload []byte) (err error) {
 	if d.protocol != "" {
 		req.Header.Set("DD-PROTOCOL", string(d.protocol))
 	}
-	if d.source != "" {
-		req.Header.Set("DD-SOURCE", string(d.source))
+	if d.origin != "" {
+		req.Header.Set("DD-EVP-ORIGIN", string(d.origin))
 	}
 	req = req.WithContext(ctx)
 

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -34,7 +34,7 @@ const (
 const DefaultIntakeProtocol IntakeProtocol = ""
 
 // DefaultIntakeOrigin indicates that no special DD_SOURCE header is in use for the endpoint intake track type.
-const DefaultIntakeOrigin IntakeOrigin = ""
+const DefaultIntakeOrigin IntakeOrigin = "agent"
 
 // logs-intake endpoints depending on the site and environment.
 var logsEndpoints = map[string]int{

--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -33,8 +33,8 @@ const (
 // DefaultIntakeProtocol indicates that no special protocol is in use for the endpoint intake track type.
 const DefaultIntakeProtocol IntakeProtocol = ""
 
-// DefaultIntakeSource indicates that no special DD_SOURCE header is in use for the endpoint intake track type.
-const DefaultIntakeSource IntakeSource = ""
+// DefaultIntakeOrigin indicates that no special DD_SOURCE header is in use for the endpoint intake track type.
+const DefaultIntakeOrigin IntakeOrigin = ""
 
 // logs-intake endpoints depending on the site and environment.
 var logsEndpoints = map[string]int{
@@ -108,19 +108,19 @@ func GlobalProcessingRules() ([]*ProcessingRule, error) {
 }
 
 // BuildEndpoints returns the endpoints to send logs.
-func BuildEndpoints(httpConnectivity HTTPConnectivity, intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeSource IntakeSource) (*Endpoints, error) {
+func BuildEndpoints(httpConnectivity HTTPConnectivity, intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeOrigin IntakeOrigin) (*Endpoints, error) {
 	coreConfig.SanitizeAPIKeyConfig(coreConfig.Datadog, "logs_config.api_key")
-	return BuildEndpointsWithConfig(defaultLogsConfigKeys(), httpEndpointPrefix, httpConnectivity, intakeTrackType, intakeProtocol, intakeSource)
+	return BuildEndpointsWithConfig(defaultLogsConfigKeys(), httpEndpointPrefix, httpConnectivity, intakeTrackType, intakeProtocol, intakeOrigin)
 }
 
 // BuildEndpointsWithConfig returns the endpoints to send logs.
-func BuildEndpointsWithConfig(logsConfig *LogsConfigKeys, endpointPrefix string, httpConnectivity HTTPConnectivity, intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeSource IntakeSource) (*Endpoints, error) {
+func BuildEndpointsWithConfig(logsConfig *LogsConfigKeys, endpointPrefix string, httpConnectivity HTTPConnectivity, intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeOrigin IntakeOrigin) (*Endpoints, error) {
 	if logsConfig.devModeNoSSL() {
 		log.Warnf("Use of illegal configuration parameter, if you need to send your logs to a proxy, "+
 			"please use '%s' and '%s' instead", logsConfig.getConfigKey("logs_dd_url"), logsConfig.getConfigKey("logs_no_ssl"))
 	}
 	if logsConfig.isForceHTTPUse() || (bool(httpConnectivity) && !(logsConfig.isForceTCPUse() || logsConfig.isSocks5ProxySet() || logsConfig.hasAdditionalEndpoints())) {
-		return BuildHTTPEndpointsWithConfig(logsConfig, endpointPrefix, intakeTrackType, intakeProtocol, intakeSource)
+		return BuildHTTPEndpointsWithConfig(logsConfig, endpointPrefix, intakeTrackType, intakeProtocol, intakeOrigin)
 	}
 	log.Warnf("You are currently sending Logs to Datadog through TCP (either because %s or %s is set or the HTTP connectivity test has failed) "+
 		"To benefit from increased reliability and better network performances, "+
@@ -130,9 +130,9 @@ func BuildEndpointsWithConfig(logsConfig *LogsConfigKeys, endpointPrefix string,
 }
 
 // BuildServerlessEndpoints returns the endpoints to send logs for the Serverless agent.
-func BuildServerlessEndpoints(intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeSource IntakeSource) (*Endpoints, error) {
+func BuildServerlessEndpoints(intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeOrigin IntakeOrigin) (*Endpoints, error) {
 	coreConfig.SanitizeAPIKeyConfig(coreConfig.Datadog, "logs_config.api_key")
-	return BuildHTTPEndpointsWithConfig(defaultLogsConfigKeys(), serverlessHTTPEndpointPrefix, intakeTrackType, intakeProtocol, intakeSource)
+	return BuildHTTPEndpointsWithConfig(defaultLogsConfigKeys(), serverlessHTTPEndpointPrefix, intakeTrackType, intakeProtocol, intakeOrigin)
 }
 
 // ExpectedTagsDuration returns a duration of the time expected tags will be submitted for.
@@ -191,12 +191,12 @@ func buildTCPEndpoints(logsConfig *LogsConfigKeys) (*Endpoints, error) {
 }
 
 // BuildHTTPEndpoints returns the HTTP endpoints to send logs to.
-func BuildHTTPEndpoints(intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeSource IntakeSource) (*Endpoints, error) {
-	return BuildHTTPEndpointsWithConfig(defaultLogsConfigKeys(), httpEndpointPrefix, intakeTrackType, intakeProtocol, intakeSource)
+func BuildHTTPEndpoints(intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeOrigin IntakeOrigin) (*Endpoints, error) {
+	return BuildHTTPEndpointsWithConfig(defaultLogsConfigKeys(), httpEndpointPrefix, intakeTrackType, intakeProtocol, intakeOrigin)
 }
 
 // BuildHTTPEndpointsWithConfig uses two arguments that instructs it how to access configuration parameters, then returns the HTTP endpoints to send logs to. This function is able to default to the 'classic' BuildHTTPEndpoints() w ldHTTPEndpointsWithConfigdefault variables logsConfigDefaultKeys and httpEndpointPrefix
-func BuildHTTPEndpointsWithConfig(logsConfig *LogsConfigKeys, endpointPrefix string, intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeSource IntakeSource) (*Endpoints, error) {
+func BuildHTTPEndpointsWithConfig(logsConfig *LogsConfigKeys, endpointPrefix string, intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeOrigin IntakeOrigin) (*Endpoints, error) {
 	// Provide default values for legacy settings when the configuration key does not exist
 	defaultNoSSL := logsConfig.logsNoSSL()
 
@@ -216,7 +216,7 @@ func BuildHTTPEndpointsWithConfig(logsConfig *LogsConfigKeys, endpointPrefix str
 		main.Version = EPIntakeVersion2
 		main.TrackType = intakeTrackType
 		main.Protocol = intakeProtocol
-		main.Source = intakeSource
+		main.Origin = intakeOrigin
 	} else {
 		main.Version = EPIntakeVersion1
 	}
@@ -244,7 +244,7 @@ func BuildHTTPEndpointsWithConfig(logsConfig *LogsConfigKeys, endpointPrefix str
 		if additionals[i].Version == EPIntakeVersion2 {
 			additionals[i].TrackType = intakeTrackType
 			additionals[i].Protocol = intakeProtocol
-			additionals[i].Source = intakeSource
+			additionals[i].Origin = intakeOrigin
 		}
 	}
 

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -338,7 +338,7 @@ func (suite *ConfigTestSuite) TestMultipleHttpEndpointsInConfig2() {
 		Version:          EPIntakeVersion2,
 		TrackType:        "test-track",
 		Protocol:         "test-proto",
-		Source:           "test-source",
+		Origin:           "test-source",
 	}
 	expectedAdditionalEndpoint1 := Endpoint{
 		APIKey:           "456",
@@ -359,7 +359,7 @@ func (suite *ConfigTestSuite) TestMultipleHttpEndpointsInConfig2() {
 		Version:          EPIntakeVersion2,
 		TrackType:        "test-track",
 		Protocol:         "test-proto",
-		Source:           "test-source",
+		Origin:           "test-source",
 	}
 
 	expectedEndpoints := NewEndpointsWithBatchSettings(expectedMainEndpoint, []Endpoint{expectedAdditionalEndpoint1, expectedAdditionalEndpoint2}, false, true,

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -42,6 +42,7 @@ func (suite *ConfigTestSuite) TestDefaultDatadogConfig() {
 	suite.Equal("", suite.config.GetString("logs_config.processing_rules"))
 	suite.Equal(false, suite.config.GetBool("logs_config.use_http"))
 	suite.Equal(false, suite.config.GetBool("logs_config.k8s_container_use_file"))
+	suite.Equal(true, suite.config.GetBool("logs_config.use_v2_api"))
 }
 
 func (suite *ConfigTestSuite) TestDefaultSources() {
@@ -154,6 +155,7 @@ func (suite *ConfigTestSuite) TestMultipleHttpEndpointsEnvVar() {
 	suite.config.Set("logs_config.sender_backoff_max", 2.0)
 	suite.config.Set("logs_config.sender_recovery_interval", 10)
 	suite.config.Set("logs_config.sender_recovery_reset", true)
+	suite.config.Set("logs_config.use_v2_api", false)
 
 	os.Setenv("DD_LOGS_CONFIG_ADDITIONAL_ENDPOINTS", `[
 	{"api_key": "456", "host": "additional.endpoint.1", "port": 1234, "use_compression": true, "compression_level": 2},
@@ -242,6 +244,8 @@ func (suite *ConfigTestSuite) TestMultipleHttpEndpointsInConfig() {
 	suite.config.Set("logs_config.use_compression", true)
 	suite.config.Set("logs_config.compression_level", 6)
 	suite.config.Set("logs_config.logs_no_ssl", false)
+	suite.config.Set("logs_config.use_v2_api", false)
+
 	endpointsInConfig := []map[string]interface{}{
 		{
 			"api_key":           "456     \n\n",
@@ -305,7 +309,6 @@ func (suite *ConfigTestSuite) TestMultipleHttpEndpointsInConfig2() {
 	suite.config.Set("logs_config.use_compression", true)
 	suite.config.Set("logs_config.compression_level", 6)
 	suite.config.Set("logs_config.logs_no_ssl", false)
-	suite.config.Set("logs_config.use_v2_api", true)
 	endpointsInConfig := []map[string]interface{}{
 		{
 			"api_key":           "456     \n\n",
@@ -432,7 +435,10 @@ func (suite *ConfigTestSuite) TestEndpointsSetLogsDDUrl() {
 			BackoffBase:      coreConfig.DefaultLogsSenderBackoffBase,
 			BackoffMax:       coreConfig.DefaultLogsSenderBackoffMax,
 			RecoveryInterval: coreConfig.DefaultLogsSenderBackoffRecoveryInterval,
-			Version:          EPIntakeVersion1,
+			Version:          EPIntakeVersion2,
+			TrackType:        "test-track",
+			Protocol:         "test-proto",
+			Origin:           "test-source",
 		},
 		BatchMaxSize:           coreConfig.DefaultBatchMaxSize,
 		BatchMaxContentSize:    coreConfig.DefaultBatchMaxContentSize,
@@ -471,7 +477,10 @@ func (suite *ConfigTestSuite) TestEndpointsSetDDSite() {
 			BackoffBase:      coreConfig.DefaultLogsSenderBackoffBase,
 			BackoffMax:       coreConfig.DefaultLogsSenderBackoffMax,
 			RecoveryInterval: coreConfig.DefaultLogsSenderBackoffRecoveryInterval,
-			Version:          EPIntakeVersion1,
+			Version:          EPIntakeVersion2,
+			TrackType:        "test-track",
+			Origin:           "test-source",
+			Protocol:         "test-proto",
 		},
 		BatchMaxSize:           coreConfig.DefaultBatchMaxSize,
 		BatchMaxContentSize:    coreConfig.DefaultBatchMaxContentSize,
@@ -500,7 +509,10 @@ func (suite *ConfigTestSuite) TestBuildServerlessEndpoints() {
 			BackoffBase:      coreConfig.DefaultLogsSenderBackoffBase,
 			BackoffMax:       coreConfig.DefaultLogsSenderBackoffMax,
 			RecoveryInterval: coreConfig.DefaultLogsSenderBackoffRecoveryInterval,
-			Version:          EPIntakeVersion1,
+			Version:          EPIntakeVersion2,
+			TrackType:        "test-track",
+			Origin:           "test-source",
+			Protocol:         "test-proto",
 		},
 		BatchMaxSize:           coreConfig.DefaultBatchMaxSize,
 		BatchMaxContentSize:    coreConfig.DefaultBatchMaxContentSize,

--- a/pkg/logs/config/endpoints.go
+++ b/pkg/logs/config/endpoints.go
@@ -20,8 +20,8 @@ type IntakeTrackType string
 // IntakeProtocol indicates the protocol to use for an endpoint intake.
 type IntakeProtocol string
 
-// IntakeSource indicates the log source to use for an endpoint intake.
-type IntakeSource string
+// IntakeOrigin indicates the log source to use for an endpoint intake.
+type IntakeOrigin string
 
 const (
 	_ EPIntakeVersion = iota
@@ -51,7 +51,7 @@ type Endpoint struct {
 	Version   EPIntakeVersion
 	TrackType IntakeTrackType
 	Protocol  IntakeProtocol
-	Source    IntakeSource
+	Origin    IntakeOrigin
 }
 
 // Endpoints holds the main endpoint and additional ones to dualship logs.

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -59,13 +59,13 @@ func StartServerless(getAC func() *autodiscovery.AutoConfig, logsChan chan *conf
 // buildEndpoints builds endpoints for the logs agent
 func buildEndpoints(serverless bool) (*config.Endpoints, error) {
 	if serverless {
-		return config.BuildServerlessEndpoints(intakeTrackType, config.DefaultIntakeProtocol, config.DefaultIntakeSource)
+		return config.BuildServerlessEndpoints(intakeTrackType, config.DefaultIntakeProtocol, config.DefaultIntakeOrigin)
 	}
 	httpConnectivity := config.HTTPConnectivityFailure
-	if endpoints, err := config.BuildHTTPEndpoints(intakeTrackType, intakeProtocol, config.DefaultIntakeSource); err == nil {
+	if endpoints, err := config.BuildHTTPEndpoints(intakeTrackType, intakeProtocol, config.DefaultIntakeOrigin); err == nil {
 		httpConnectivity = http.CheckConnectivity(endpoints.Main)
 	}
-	return config.BuildEndpoints(httpConnectivity, intakeTrackType, intakeProtocol, config.DefaultIntakeSource)
+	return config.BuildEndpoints(httpConnectivity, intakeTrackType, intakeProtocol, config.DefaultIntakeOrigin)
 }
 
 func start(getAC func() *autodiscovery.AutoConfig, serverless bool, logsChan chan *config.ChannelMessage, extraTags []string) error {


### PR DESCRIPTION
### What does this PR do?

Enable logs v2 intake by default and make sure we send right headers to the intake.

### Additional Notes

This is a follow up for #8555.

### Describe how to test your changes

Agent Core to test the logs agent (instructions below). Other teams please use a variation of this plan as applicable to your part of the agent.

Configure a logs check and enable logs agent:

- Configure a logs check and enable logs agent.
  ```yaml
  logs_config:
    enabled: true
  ```
- Check in the agent log that the logs connectivity check is done to `/api/v2/logs` and succeeds.
  ```
  [...] Sending HTTP connectivity request to https://agent-http-intake.logs.datadoghq.com/api/v2/logs
  [...] HTTP connectivity successful
  ```
- Add some log entries to the log file and check that they appear in the app.
- Disable v2 api and restart the agent.
  ```yaml
  logs_config:
    enabled: true
    use_v2_api: false
  ```
- Check in the agent log that the logs connectivity check is done to `/v1/input` and succeeds.
  ```
  [...] Sending HTTP connectivity request to https://agent-http-intake.logs.datadoghq.com/v1/input
  [...] HTTP connectivity successful
  ```
- Add some log entries to the log file and check that they appear in the app.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
