### PR TITLE
Added cobra support and deprecated non-posix flags

### DIFF
--- a/cmd/process-agent/main.go
+++ b/cmd/process-agent/main.go
@@ -3,29 +3,27 @@
 package main
 
 import (
-	"flag"
-	_ "net/http/pprof"
+	"fmt"
 
 	"github.com/DataDog/datadog-agent/cmd/process-agent/flags"
 )
 
 func main() {
 	ignore := ""
-	flag.StringVar(&opts.configPath, "config", flags.DefaultConfPath, "Path to datadog.yaml config")
-	flag.StringVar(&ignore, "ddconfig", "", "[deprecated] Path to dd-agent config")
+	rootCmd.PersistentFlags().StringVar(&opts.configPath, "config", flags.DefaultConfPath, "Path to datadog.yaml config")
+	rootCmd.PersistentFlags().StringVar(&ignore, "ddconfig", "", "[deprecated] Path to dd-agent config")
 
 	if flags.DefaultSysProbeConfPath != "" {
-		flag.StringVar(&opts.sysProbeConfigPath, "sysprobe-config", flags.DefaultSysProbeConfPath, "Path to system-probe.yaml config")
+		rootCmd.PersistentFlags().StringVar(&opts.sysProbeConfigPath, "sysprobe-config", flags.DefaultSysProbeConfPath, "Path to system-probe.yaml config")
 	}
 
-	flag.StringVar(&opts.pidfilePath, "pid", "", "Path to set pidfile for process")
-	flag.BoolVar(&opts.info, "info", false, "Show info about running process agent and exit")
-	flag.BoolVar(&opts.version, "version", false, "Print the version and exit")
-	flag.StringVar(&opts.check, "check", "", "Run a specific check and print the results. Choose from: process, connections, realtime")
-	flag.Parse()
+	rootCmd.PersistentFlags().StringVarP(&opts.pidfilePath, "pid", "p", "", "Path to set pidfile for process")
+	rootCmd.PersistentFlags().BoolVarP(&opts.info, "info", "i", false, "Show info about running process agent and exit")
+	rootCmd.PersistentFlags().BoolVarP(&opts.version, "version", "v", false, "Print the version and exit")
+	rootCmd.PersistentFlags().StringVar(&opts.check, "check", "", "Run a specific check and print the results. Choose from: process, connections, realtime")
 
-	exit := make(chan struct{})
-
-	// Invoke the Agent
-	runAgent(exit)
+	fixDeprecatedFlags()
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Println(err)
+	}
 }

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -4,11 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"net/http"
-	_ "net/http/pprof"
-	"os"
-	"time"
-
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/pidfile"
@@ -27,6 +22,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/profiling"
 	"github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/spf13/cobra"
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+	"time"
 )
 
 const loggerName ddconfig.LoggerName = "PROCESS"
@@ -49,6 +49,36 @@ var (
 	BuildDate string
 	GoVersion string
 )
+
+var rootCmd = &cobra.Command{
+	Run: func(cmd *cobra.Command, args []string) {
+		exit := make(chan struct{})
+
+		// Invoke the Agent
+		runAgent(exit)
+	},
+}
+
+// fixDeprecatedFlags modifies os.Args so that non-posix flags are converted to posix flags
+// it also displays a warning when a non-posix flag is found
+func fixDeprecatedFlags() {
+	deprecatedFlags := map[string]struct{}{
+		// Global flags
+		"-config": {}, "-ddconfig": {}, "-sysprobe-config": {}, "-pid": {}, "-info": {}, "-version": {}, "-check": {},
+
+		// Windows flags
+		"-install-service": {}, "-uninstall-service": {}, "-start-service": {}, "-stop-service": {}, "-foreground": {},
+	}
+
+	for i, a := range os.Args {
+		if _, ok := deprecatedFlags[a]; !ok {
+			continue
+		}
+		fmt.Printf("WARNING: `%s` argument is deprecated and will be removed in a future version. "+
+			"Please use `-%[1]s` instead.\n", a)
+		os.Args[i] = "-" + os.Args[i]
+	}
+}
 
 // versionString returns the version information filled in at build time
 func versionString(sep string) string {

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -4,6 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"net/http"
+	_ "net/http/pprof"
+	"os"
+	"time"
+
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/pidfile"
@@ -22,11 +27,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/profiling"
 	"github.com/DataDog/datadog-agent/pkg/version"
+
 	"github.com/spf13/cobra"
-	"net/http"
-	_ "net/http/pprof"
-	"os"
-	"time"
 )
 
 const loggerName ddconfig.LoggerName = "PROCESS"
@@ -65,18 +67,15 @@ func fixDeprecatedFlags() {
 	deprecatedFlags := map[string]struct{}{
 		// Global flags
 		"-config": {}, "-ddconfig": {}, "-sysprobe-config": {}, "-pid": {}, "-info": {}, "-version": {}, "-check": {},
-
 		// Windows flags
 		"-install-service": {}, "-uninstall-service": {}, "-start-service": {}, "-stop-service": {}, "-foreground": {},
 	}
 
 	for i, a := range os.Args {
-		if _, ok := deprecatedFlags[a]; !ok {
-			continue
+		if _, ok := deprecatedFlags[a]; ok {
+			fmt.Printf("WARNING: `%s` argument is deprecated and will be removed in a future version. Please use `-%[1]s` instead.\n", a)
+			os.Args[i] = "-" + os.Args[i]
 		}
-		fmt.Printf("WARNING: `%s` argument is deprecated and will be removed in a future version. "+
-			"Please use `-%[1]s` instead.\n", a)
-		os.Args[i] = "-" + os.Args[i]
 	}
 }
 

--- a/releasenotes/notes/process-agent-cobra-4be0f08037b8141e.yaml
+++ b/releasenotes/notes/process-agent-cobra-4be0f08037b8141e.yaml
@@ -1,10 +1,3 @@
-# Each section from every release note are combined when the
-# CHANGELOG.rst is rendered. So the text needs to be worded so that
-# it does not depend on any information only available in another
-# section. This may mean repeating some details, but each section
-# must be readable independently of the other.
-#
-# Each section note must be formatted as reStructuredText.
 ---
 enhancements:
   - |

--- a/releasenotes/notes/process-agent-cobra-4be0f08037b8141e.yaml
+++ b/releasenotes/notes/process-agent-cobra-4be0f08037b8141e.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Support posix-compliant flags for process-agent. Shorthand flags for "p" (pid), "i" (info), and "v" (version) are
+    now supported.
+deprecations:
+  - Deprecated non-posix compliant flags for process agent. A warning should now be displayed if one is detected.


### PR DESCRIPTION
### What does this PR do?

It represents initial support for using cobra commands/subcommands versus plain flag usage for process-agent.

### Motivation

This is in preparation for adding subcommands to change runtime configuration and runtime debugging.

### Describe how to test your changes


process-agent should still start and support the same command line parameters as before:
All OSes: 
- -config
- -ddconfig
- -sysprobe-config
- -info
- -verison
- -check

MacOS/Linux Specific:
- -pid

Windows Specific:
- -install-service
- -uninstall-service
- -start-service
- -stop-service
- -foreground

Additionally, the shorthand commands should also work ("-i", "-v", and, on mac/linux: "-p")

The behavior between two dashes (i.e. --pid vs -pid) should be the same, except the non-posix version (the one with only one "-" character) should display a warning.

It is important that both windows and linux/macos is tested, since their initialization sequence is different.

### Checklist
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
