### PR TITLE
Fix invocation of wingetcreate

### DIFF
--- a/tasks/winbuildscripts/Update-Winget.ps1
+++ b/tasks/winbuildscripts/Update-Winget.ps1
@@ -14,4 +14,4 @@ if ($rawAgentVersion -match $releasePattern) {
     exit 1
 }
 Write-Host ("Updating Winget manifest for Agent version {0}" -f $rawAgentVersion)
-wingetcreate.exe update --id "Datadog.Agent" --url "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-$($agentVersion).msi" --version $($agentVersion) --token $env:WINGET_GITHUB_ACCESS_TOKEN
+./wingetcreate.exe update --id "Datadog.Agent" --url "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-$($agentVersion).msi" --version $($agentVersion) --token $env:WINGET_GITHUB_ACCESS_TOKEN

--- a/tasks/winbuildscripts/Update-Winget.ps1
+++ b/tasks/winbuildscripts/Update-Winget.ps1
@@ -14,4 +14,4 @@ if ($rawAgentVersion -match $releasePattern) {
     exit 1
 }
 Write-Host ("Updating Winget manifest for Agent version {0}" -f $rawAgentVersion)
-./wingetcreate.exe update --id "Datadog.Agent" --url "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-$($agentVersion).msi" --version $($agentVersion) --token $env:WINGET_GITHUB_ACCESS_TOKEN
+.\wingetcreate.exe update --id "Datadog.Agent" --url "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-$($agentVersion).msi" --version $($agentVersion) --token $env:WINGET_GITHUB_ACCESS_TOKEN


### PR DESCRIPTION
## What does this PR do?

Fixes the winget promotion job not finding the `wingetcreate.exe` binary, since it’s on the current directory and not the PATH.

### Motivation

Promotion job failed in 7.30