### PR TITLE
Remove support for the unimplemented v2 series submission

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -349,7 +349,7 @@ func InitConfig(config Config) {
 	// Warning: do not change the two following values. Your payloads will get dropped by Datadog's intake.
 	config.BindEnvAndSetDefault("serializer_max_payload_size", 2*megaByte+megaByte/2)
 	config.BindEnvAndSetDefault("serializer_max_uncompressed_payload_size", 4*megaByte)
-	config.BindEnvAndSetDefault("use_v2_api.series", false)
+
 	config.BindEnvAndSetDefault("use_v2_api.events", false)
 	config.BindEnvAndSetDefault("use_v2_api.service_checks", false)
 	// Serializer: allow user to blacklist any kind of payload to be sent

--- a/pkg/forwarder/README.md
+++ b/pkg/forwarder/README.md
@@ -25,8 +25,7 @@ forwarder.Start()
 
 payload1 := []byte("some payload")
 payload2 := []byte("another payload")
-forwarder.SubmitSeries(Payloads{&payload1, &payload2}
-)
+forwarder.SubmitSeries(Payloads{&payload1, &payload2}, ...)
 
 // ...
 

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -59,7 +59,6 @@ type Forwarder interface {
 	SubmitV1Series(payload Payloads, extra http.Header) error
 	SubmitV1Intake(payload Payloads, extra http.Header) error
 	SubmitV1CheckRuns(payload Payloads, extra http.Header) error
-	SubmitSeries(payload Payloads, extra http.Header) error
 	SubmitEvents(payload Payloads, extra http.Header) error
 	SubmitServiceChecks(payload Payloads, extra http.Header) error
 	SubmitSketchSeries(payload Payloads, extra http.Header) error
@@ -424,12 +423,6 @@ func (f *DefaultForwarder) sendHTTPTransactions(transactions []*transaction.HTTP
 		}
 	}
 	return nil
-}
-
-// SubmitSeries will send a series type payload to Datadog backend.
-func (f *DefaultForwarder) SubmitSeries(payload Payloads, extra http.Header) error {
-	transactions := f.createHTTPTransactions(seriesEndpoint, payload, false, extra)
-	return f.sendHTTPTransactions(transactions)
 }
 
 // SubmitEvents will send an event type payload to Datadog backend.

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -120,7 +120,6 @@ func TestSubmitIfStopped(t *testing.T) {
 
 	require.NotNil(t, forwarder)
 	require.Equal(t, Stopped, forwarder.State())
-	assert.NotNil(t, forwarder.SubmitSeries(nil, make(http.Header)))
 	assert.NotNil(t, forwarder.SubmitEvents(nil, make(http.Header)))
 	assert.NotNil(t, forwarder.SubmitServiceChecks(nil, make(http.Header)))
 	assert.NotNil(t, forwarder.SubmitSketchSeries(nil, make(http.Header)))
@@ -298,7 +297,6 @@ func TestForwarderEndtoEnd(t *testing.T) {
 	assert.Nil(t, f.SubmitV1Series(payload, headers))
 	assert.Nil(t, f.SubmitV1Intake(payload, headers))
 	assert.Nil(t, f.SubmitV1CheckRuns(payload, headers))
-	assert.Nil(t, f.SubmitSeries(payload, headers))
 	assert.Nil(t, f.SubmitEvents(payload, headers))
 	assert.Nil(t, f.SubmitServiceChecks(payload, headers))
 	assert.Nil(t, f.SubmitSketchSeries(payload, headers))
@@ -308,11 +306,11 @@ func TestForwarderEndtoEnd(t *testing.T) {
 	// let's wait a second for every channel communication to trigger
 	<-time.After(1 * time.Second)
 
-	// We should receive 38 requests:
-	// - 9 transactions * 2 payloads per transactions * 2 api_keys
+	// We should receive the following requests:
+	// - 8 transactions * 2 payloads per transactions * 2 api_keys
 	// - 2 requests to check the validity of the two api_key
 	ts.Close()
-	assert.Equal(t, int64(38), requests)
+	assert.Equal(t, int64(8*2*2+2), requests)
 }
 
 func TestTransactionEventHandlers(t *testing.T) {

--- a/pkg/forwarder/sync_forwarder.go
+++ b/pkg/forwarder/sync_forwarder.go
@@ -78,12 +78,6 @@ func (f *SyncForwarder) SubmitV1CheckRuns(payload Payloads, extra http.Header) e
 	return f.sendHTTPTransactions(transactions)
 }
 
-// SubmitSeries will send a series type payload to Datadog backend.
-func (f *SyncForwarder) SubmitSeries(payload Payloads, extra http.Header) error {
-	transactions := f.defaultForwarder.createHTTPTransactions(seriesEndpoint, payload, false, extra)
-	return f.sendHTTPTransactions(transactions)
-}
-
 // SubmitEvents will send an event type payload to Datadog backend.
 func (f *SyncForwarder) SubmitEvents(payload Payloads, extra http.Header) error {
 	transactions := f.defaultForwarder.createHTTPTransactions(eventsEndpoint, payload, false, extra)

--- a/pkg/forwarder/test_common.go
+++ b/pkg/forwarder/test_common.go
@@ -102,11 +102,6 @@ func (tf *MockedForwarder) SubmitV1CheckRuns(payload Payloads, extra http.Header
 	return tf.Called(payload, extra).Error(0)
 }
 
-// SubmitSeries updates the internal mock struct
-func (tf *MockedForwarder) SubmitSeries(payload Payloads, extra http.Header) error {
-	return tf.Called(payload, extra).Error(0)
-}
-
 // SubmitEvents updates the internal mock struct
 func (tf *MockedForwarder) SubmitEvents(payload Payloads, extra http.Header) error {
 	return tf.Called(payload, extra).Error(0)

--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -61,7 +61,7 @@ type Series []*Serie
 
 // Marshal serialize timeseries using protobuf
 func (series Series) Marshal() ([]byte, error) {
-	return nil, fmt.Errorf("V5 Payload serialization is not implemented")
+	return nil, fmt.Errorf("Series payload serialization is not implemented")
 }
 
 // MarshalStrings converts the timeseries to a sorted slice of string slices

--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -15,8 +15,6 @@ import (
 	"strconv"
 	"strings"
 
-	agentpayload "github.com/DataDog/agent-payload/gogen"
-	"github.com/gogo/protobuf/proto"
 	jsoniter "github.com/json-iterator/go"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
@@ -61,38 +59,9 @@ type Serie struct {
 // Series represents a list of Serie ready to be serialize
 type Series []*Serie
 
-func marshalPoints(points []Point) []*agentpayload.MetricsPayload_Sample_Point {
-	pointsPayload := []*agentpayload.MetricsPayload_Sample_Point{}
-
-	for _, p := range points {
-		pointsPayload = append(pointsPayload, &agentpayload.MetricsPayload_Sample_Point{
-			Ts:    int64(p.Ts),
-			Value: p.Value,
-		})
-	}
-	return pointsPayload
-}
-
-// Marshal serialize timeseries using agent-payload definition
+// Marshal serialize timeseries using protobuf
 func (series Series) Marshal() ([]byte, error) {
-	payload := &agentpayload.MetricsPayload{
-		Samples:  []*agentpayload.MetricsPayload_Sample{},
-		Metadata: &agentpayload.CommonMetadata{},
-	}
-
-	for _, serie := range series {
-		payload.Samples = append(payload.Samples,
-			&agentpayload.MetricsPayload_Sample{
-				Metric:         serie.Name,
-				Type:           serie.MType.String(),
-				Host:           serie.Host,
-				Points:         marshalPoints(serie.Points),
-				Tags:           serie.Tags,
-				SourceTypeName: serie.SourceTypeName,
-			})
-	}
-
-	return proto.Marshal(payload)
+	return nil, fmt.Errorf("V5 Payload serialization is not implemented")
 }
 
 // MarshalStrings converts the timeseries to a sorted slice of string slices

--- a/pkg/metrics/series_test.go
+++ b/pkg/metrics/series_test.go
@@ -17,47 +17,11 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 
-	agentpayload "github.com/DataDog/agent-payload/gogen"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/serializer/stream"
-	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func TestMarshalSeries(t *testing.T) {
-	series := Series{{
-		Points: []Point{
-			{Ts: 12345.0, Value: float64(21.21)},
-			{Ts: 67890.0, Value: float64(12.12)},
-		},
-		MType: APIGaugeType,
-		Name:  "test.metrics",
-		Host:  "localHost",
-		Tags:  []string{"tag1", "tag2:yes"},
-	}}
-
-	payload, err := series.Marshal()
-	assert.Nil(t, err)
-	assert.NotNil(t, payload)
-
-	newPayload := &agentpayload.MetricsPayload{}
-	err = proto.Unmarshal(payload, newPayload)
-	assert.Nil(t, err)
-
-	require.Len(t, newPayload.Samples, 1)
-	assert.Equal(t, newPayload.Samples[0].Metric, "test.metrics")
-	assert.Equal(t, newPayload.Samples[0].Type, "gauge")
-	assert.Equal(t, newPayload.Samples[0].Host, "localHost")
-	require.Len(t, newPayload.Samples[0].Tags, 2)
-	assert.Equal(t, newPayload.Samples[0].Tags[0], "tag1")
-	assert.Equal(t, newPayload.Samples[0].Tags[1], "tag2:yes")
-	require.Len(t, newPayload.Samples[0].Points, 2)
-	assert.Equal(t, newPayload.Samples[0].Points[0].Ts, int64(12345))
-	assert.Equal(t, newPayload.Samples[0].Points[0].Value, float64(21.21))
-	assert.Equal(t, newPayload.Samples[0].Points[1].Ts, int64(67890))
-	assert.Equal(t, newPayload.Samples[0].Points[1].Value, float64(12.12))
-}
 
 func TestPopulateDeviceField(t *testing.T) {
 	for _, tc := range []struct {

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -293,7 +293,7 @@ func (s *Serializer) SendSeries(series marshaler.StreamJSONMarshaler) error {
 		return nil
 	}
 
-	useV1API := !config.Datadog.GetBool("use_v2_api.series")
+	const useV1API = true // v2 intake for series is not yet implemented
 
 	var seriesPayloads forwarder.Payloads
 	var extraHeaders http.Header
@@ -309,10 +309,7 @@ func (s *Serializer) SendSeries(series marshaler.StreamJSONMarshaler) error {
 		return fmt.Errorf("dropping series payload: %s", err)
 	}
 
-	if useV1API {
-		return s.Forwarder.SubmitV1Series(seriesPayloads, extraHeaders)
-	}
-	return s.Forwarder.SubmitSeries(seriesPayloads, extraHeaders)
+	return s.Forwarder.SubmitV1Series(seriesPayloads, extraHeaders)
 }
 
 // SendSketch serializes a list of SketSeriesList and sends the payload to the forwarder

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -331,26 +331,6 @@ func TestSendV1Series(t *testing.T) {
 	require.NotNil(t, err)
 }
 
-func TestSendSeries(t *testing.T) {
-	mockConfig := config.Mock()
-
-	f := &forwarder.MockedForwarder{}
-	f.On("SubmitSeries", protobufPayloads, protobufExtraHeadersWithCompression).Return(nil).Times(1)
-	mockConfig.Set("use_v2_api.series", true)
-	defer mockConfig.Set("use_v2_api.series", nil)
-
-	s := NewSerializer(f, nil)
-
-	payload := &testPayload{}
-	err := s.SendSeries(payload)
-	require.Nil(t, err)
-	f.AssertExpectations(t)
-
-	errPayload := &testErrorPayload{}
-	err = s.SendSeries(errPayload)
-	require.NotNil(t, err)
-}
-
 func TestSendSketch(t *testing.T) {
 	f := &forwarder.MockedForwarder{}
 	payloads, _ := mkPayloads(protobufString, true)
@@ -446,7 +426,6 @@ func TestSendWithDisabledKind(t *testing.T) {
 	f.AssertNotCalled(t, "SubmitV1CheckRuns")
 	f.AssertNotCalled(t, "SubmitServiceChecks")
 	f.AssertNotCalled(t, "SubmitV1Series")
-	f.AssertNotCalled(t, "SubmitSeries")
 	f.AssertNotCalled(t, "SubmitSketchSeries")
 
 	// We never disable metadata


### PR DESCRIPTION
A "new" v2 is in the works, but let's clear out the "old" v2 first to
avoid confusion.

### Describe how to test your changes

* Verify that metrics still work.
* Verify that we haven't been using `use_v2_api.series` internally, much less with customers.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.