### PR TITLE
[runtime-security] add hwe ubuntu 20.04 for kitchen tests on x64

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -40,7 +40,7 @@ kitchen_test_security_agent_x64:
       - KITCHEN_PLATFORM: "suse"
         KITCHEN_OSVERS: "sles-12,sles-15"
       - KITCHEN_PLATFORM: "debian"
-        KITCHEN_OSVERS: "debian-10"
+        KITCHEN_OSVERS: "debian-10,debian-11"
       - KITCHEN_PLATFORM: "oracle"
         KITCHEN_OSVERS: "oracle-7-9"
 

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -36,7 +36,7 @@ kitchen_test_security_agent_x64:
       - KITCHEN_PLATFORM: "centos"
         KITCHEN_OSVERS: "centos-77,rhel-81"
       - KITCHEN_PLATFORM: "ubuntu"
-        KITCHEN_OSVERS: "ubuntu-18-04,ubuntu-20-04,ubuntu-21-04"
+        KITCHEN_OSVERS: "ubuntu-18-04,ubuntu-20-04,ubuntu-20-04-hwe,ubuntu-21-04"
       - KITCHEN_PLATFORM: "suse"
         KITCHEN_OSVERS: "sles-12,sles-15"
       - KITCHEN_PLATFORM: "debian"

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -57,6 +57,7 @@
                 "ubuntu-16-04": "urn,Canonical:UbuntuServer:16.04.0-LTS:16.04.202106110",
                 "ubuntu-18-04": "urn,Canonical:UbuntuServer:18.04-LTS:18.04.201906040",
                 "ubuntu-20-04": "urn,Canonical:0001-com-ubuntu-server-focal:20_04-lts:20.04.202004230",
+                "ubuntu-20-04-hwe": "urn,Canonical:0001-com-ubuntu-server-focal:20_04-lts:20.04.202107200",
                 "ubuntu-21-04": "urn,Canonical:0001-com-ubuntu-server-hirsute:21_04:21.04.202107200"
             }
         },


### PR DESCRIPTION
### What does this PR do?

This PR adds ubuntu 20.04 lts hwe as a platform and instructs kitchen functional tests to run on it. It also add debian 11 in the set of debians to run functional tests on.

### Motivation

We found a bug in args and env variables collecting that is triggered only on this version. This should help in avoiding future regressions.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
