### PR TITLE
Query Org and Space data from CC API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -80,7 +80,7 @@ require (
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575
 	github.com/clbanning/mxj v1.8.4
-	github.com/cloudfoundry-community/go-cfclient v0.0.0-20201123235753-4f46d6348a05
+	github.com/cloudfoundry-community/go-cfclient v0.0.0-20210621174645-7773f7e22665
 	github.com/cobaugh/osrelease v0.0.0-20181218015638-a93a0a55a249
 	github.com/containerd/cgroups v0.0.0-20210114181951-8a68de567b68
 	github.com/containerd/containerd v1.5.0-beta.4

--- a/go.sum
+++ b/go.sum
@@ -287,8 +287,6 @@ github.com/cilium/ebpf v0.5.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJ
 github.com/clbanning/mxj v1.8.4 h1:HuhwZtbyvyOw+3Z1AowPkU87JkJUSv751ELWaiTpj8I=
 github.com/clbanning/mxj v1.8.4/go.mod h1:BVjHeAH+rl9rs6f+QIpeRl0tfu10SXn1pUSa5PVGJng=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
-github.com/cloudfoundry-community/go-cfclient v0.0.0-20201123235753-4f46d6348a05 h1:5Hbn8fSLiRX8dje5E22dk/6SuJnbd+pnwjFCGyb8St0=
-github.com/cloudfoundry-community/go-cfclient v0.0.0-20201123235753-4f46d6348a05/go.mod h1:UGbOgL5sX52jB/PUVKOeRC17QYX4Afsq+bsIeMCD4VA=
 github.com/cloudfoundry-community/go-cfclient v0.0.0-20210621174645-7773f7e22665 h1:LDCKU3OIIsl7sX1KggC6zIHKk0PCeYbmOGbCHqNCSOQ=
 github.com/cloudfoundry-community/go-cfclient v0.0.0-20210621174645-7773f7e22665/go.mod h1:0FdHblxw7g3M2PPICOw9i8YZOHP9dZTHbJUtoxL7Z/E=
 github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313/go.mod h1:P1wt9Z3DP8O6W3rvwCt0REIlshg1InHImaLW0t3ObY0=

--- a/go.sum
+++ b/go.sum
@@ -289,6 +289,8 @@ github.com/clbanning/mxj v1.8.4/go.mod h1:BVjHeAH+rl9rs6f+QIpeRl0tfu10SXn1pUSa5P
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
 github.com/cloudfoundry-community/go-cfclient v0.0.0-20201123235753-4f46d6348a05 h1:5Hbn8fSLiRX8dje5E22dk/6SuJnbd+pnwjFCGyb8St0=
 github.com/cloudfoundry-community/go-cfclient v0.0.0-20201123235753-4f46d6348a05/go.mod h1:UGbOgL5sX52jB/PUVKOeRC17QYX4Afsq+bsIeMCD4VA=
+github.com/cloudfoundry-community/go-cfclient v0.0.0-20210621174645-7773f7e22665 h1:LDCKU3OIIsl7sX1KggC6zIHKk0PCeYbmOGbCHqNCSOQ=
+github.com/cloudfoundry-community/go-cfclient v0.0.0-20210621174645-7773f7e22665/go.mod h1:0FdHblxw7g3M2PPICOw9i8YZOHP9dZTHbJUtoxL7Z/E=
 github.com/clusterhq/flocker-go v0.0.0-20160920122132-2b8b7259d313/go.mod h1:P1wt9Z3DP8O6W3rvwCt0REIlshg1InHImaLW0t3ObY0=
 github.com/cobaugh/osrelease v0.0.0-20181218015638-a93a0a55a249 h1:R0IDH8daQ3lODvu8YtxnIqqth5qMGCJyADoUQvmLx4o=
 github.com/cobaugh/osrelease v0.0.0-20181218015638-a93a0a55a249/go.mod h1:EHKW9yNEYSBpTKzuu7Y9oOrft/UlzH57rMIB03oev6M=
@@ -1578,6 +1580,7 @@ golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qx
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e h1:XpT3nA5TvE525Ne3hInMh6+GETgn27Zfm9dxsThnX2Q=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
+golang.org/x/oauth2 v0.0.0-20190130055435-99b60b757ec1/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=
 golang.org/x/oauth2 v0.0.0-20191202225959-858c2ad4c8b6/go.mod h1:gOpvHmFTYa4IltrdGE7lF6nIHvwfUNPOp7c8zoXwtLw=

--- a/pkg/util/cloudfoundry/bbscache_test.go
+++ b/pkg/util/cloudfoundry/bbscache_test.go
@@ -52,11 +52,11 @@ func TestBBSCache_GetTagsForNode(t *testing.T) {
 			"app_id:random_app_guid",
 			"app_name:name_of_app_cc",
 			"env:test-env",
-			"org_id:random_org_guid",
-			"org_name:name_of_the_org",
+			"org_id:org_guid_1",
+			"org_name:org_name_1",
 			"service:test-service",
-			"space_id:random_space_guid",
-			"space_name:name_of_the_space",
+			"space_id:space_guid_1",
+			"space_name:space_name_1",
 		},
 	}
 	tags, err := bc.GetTagsForNode("cell123")
@@ -71,11 +71,11 @@ func TestBBSCache_GetTagsForNode(t *testing.T) {
 			"app_id:random_app_guid",
 			"app_name:name_of_app_cc",
 			"env:test-env",
-			"org_id:random_org_guid",
-			"org_name:name_of_the_org",
+			"org_id:org_guid_1",
+			"org_name:org_name_1",
 			"service:test-service",
-			"space_id:random_space_guid",
-			"space_name:name_of_the_space",
+			"space_id:space_guid_1",
+			"space_name:space_name_1",
 		},
 	}
 	tags, err = bc.GetTagsForNode("cell1234")

--- a/pkg/util/cloudfoundry/cccache.go
+++ b/pkg/util/cloudfoundry/cccache.go
@@ -39,11 +39,15 @@ type CCCache struct {
 	pollInterval  time.Duration
 	lastUpdated   time.Time
 	appsByGUID    map[string]*CFApp
+	orgsByGUID    map[string]*CFOrg
+	spacesByGUID  map[string]*CFSpace
 	appsBatchSize int
 }
 
 type CCClientI interface {
 	ListV3AppsByQuery(url.Values) ([]cfclient.V3App, error)
+	ListV3OrganizationsByQuery(url.Values) ([]cfclient.V3Organization, error)
+	ListV3SpacesByQuery(url.Values) ([]cfclient.V3Space, error)
 }
 
 var globalCCCache = &CCCache{}
@@ -135,26 +139,77 @@ func (ccc *CCCache) start() {
 	}
 }
 
+func (ccc *CCCache) GetOrgSpaceTags(app *CFApp) (tags []string) {
+
+	return
+}
+
 func (ccc *CCCache) readData() {
 	log.Debug("Reading data from CC API")
 	atomic.AddInt64(&ccc.pollAttempts, 1)
+	var wg sync.WaitGroup
 
-	query := url.Values{}
-	query.Add("per_page", fmt.Sprintf("%d", ccc.appsBatchSize))
-	apps, err := ccc.ccAPIClient.ListV3AppsByQuery(query)
-	if err != nil {
-		log.Errorf("Failed listing apps from cloud controller: %v", err)
-		return
-	}
-	appsByGUID := make(map[string]*CFApp, len(apps))
-	for _, app := range apps {
-		appsByGUID[app.GUID] = CFAppFromV3App(&app)
-	}
+	// List applications
+	wg.Add(1)
+	var appsByGUID map[string]*CFApp
+	go func() {
+		defer wg.Done()
+		query := url.Values{}
+		query.Add("per_page", fmt.Sprintf("%d", ccc.appsBatchSize))
+		apps, err := ccc.ccAPIClient.ListV3AppsByQuery(query)
+		if err != nil {
+			log.Errorf("Failed listing apps from cloud controller: %v", err)
+			return
+		}
+		appsByGUID = make(map[string]*CFApp, len(apps))
+		for _, app := range apps {
+			appsByGUID[app.GUID] = CFAppFromV3App(&app)
+		}
+	}()
 
-	// put new apps in cache
+	// List spaces
+	wg.Add(1)
+	var spacesByGUID map[string]*CFSpace
+	go func() {
+		defer wg.Done()
+		query := url.Values{}
+		query.Add("per_page", fmt.Sprintf("%d", ccc.appsBatchSize))
+		spaces, err := ccc.ccAPIClient.ListV3SpacesByQuery(query)
+		if err != nil {
+			log.Errorf("Failed listing spaces from cloud controller: %v", err)
+			return
+		}
+		spacesByGUID = make(map[string]*CFSpace, len(spaces))
+		for _, space := range spaces {
+			spacesByGUID[space.GUID] = CFSpaceFromV3Space(&space)
+		}
+	}()
+
+	// List orgs
+	wg.Add(1)
+	var orgsByGUID map[string]*CFOrg
+	go func() {
+		defer wg.Done()
+		query := url.Values{}
+		query.Add("per_page", fmt.Sprintf("%d", ccc.appsBatchSize))
+		orgs, err := ccc.ccAPIClient.ListV3OrganizationsByQuery(query)
+		if err != nil {
+			log.Errorf("Failed listing orgs from cloud controller: %v", err)
+			return
+		}
+		orgsByGUID = make(map[string]*CFOrg, len(orgs))
+		for _, org := range orgs {
+			orgsByGUID[org.GUID] = CFOrgFromV3Organization(&org)
+		}
+	}()
+
+	// put new data in cache
+	wg.Wait()
 	ccc.Lock()
 	defer ccc.Unlock()
 	ccc.appsByGUID = appsByGUID
+	ccc.spacesByGUID = spacesByGUID
+	ccc.orgsByGUID = orgsByGUID
 	atomic.AddInt64(&ccc.pollSuccesses, 1)
 	ccc.lastUpdated = time.Now()
 }

--- a/pkg/util/cloudfoundry/cccache.go
+++ b/pkg/util/cloudfoundry/cccache.go
@@ -125,6 +125,26 @@ func (ccc *CCCache) GetApp(guid string) (*CFApp, error) {
 	return app, nil
 }
 
+func (ccc *CCCache) GetSpace(guid string) (*CFSpace, error) {
+	ccc.RLock()
+	defer ccc.RUnlock()
+	space, ok := ccc.spacesByGUID[guid]
+	if !ok {
+		return nil, fmt.Errorf("could not find space %s in cloud controller cache", guid)
+	}
+	return space, nil
+}
+
+func (ccc *CCCache) GetOrg(guid string) (*CFOrg, error) {
+	ccc.RLock()
+	defer ccc.RUnlock()
+	org, ok := ccc.orgsByGUID[guid]
+	if !ok {
+		return nil, fmt.Errorf("could not find org %s in cloud controller cache", guid)
+	}
+	return org, nil
+}
+
 func (ccc *CCCache) start() {
 	ccc.readData()
 	dataRefreshTicker := time.NewTicker(ccc.pollInterval)

--- a/pkg/util/cloudfoundry/cccache.go
+++ b/pkg/util/cloudfoundry/cccache.go
@@ -139,11 +139,6 @@ func (ccc *CCCache) start() {
 	}
 }
 
-func (ccc *CCCache) GetOrgSpaceTags(app *CFApp) (tags []string) {
-
-	return
-}
-
 func (ccc *CCCache) readData() {
 	log.Debug("Reading data from CC API")
 	atomic.AddInt64(&ccc.pollAttempts, 1)

--- a/pkg/util/cloudfoundry/cccache_test.go
+++ b/pkg/util/cloudfoundry/cccache_test.go
@@ -18,6 +18,12 @@ import (
 func (t testCCClient) ListV3AppsByQuery(_ url.Values) ([]cfclient.V3App, error) {
 	return []cfclient.V3App{v3App1, v3App2}, nil
 }
+func (t testCCClient) ListV3OrganizationsByQuery(_ url.Values) ([]cfclient.V3Organization, error) {
+	return []cfclient.V3Organization{v3Org1, v3Org2}, nil
+}
+func (t testCCClient) ListV3SpacesByQuery(_ url.Values) ([]cfclient.V3Space, error) {
+	return []cfclient.V3Space{v3Space1, v3Space2}, nil
+}
 
 func TestCCCachePolling(t *testing.T) {
 	assert.NotZero(t, cc.GetPollAttempts())

--- a/pkg/util/cloudfoundry/types.go
+++ b/pkg/util/cloudfoundry/types.go
@@ -128,16 +128,54 @@ type DesiredLRP struct {
 
 // CFApp carries the necessary data about a CF App obtained from the CC API
 type CFApp struct {
+	Name      string
+	SpaceGUID string
+	Tags      []string
+}
+
+// CFOrg carries the necessary data about a CF Org obtained from the CC API
+type CFOrg struct {
 	Name string
-	Tags []string
+}
+
+// CFSpace carries the necessary data about a CF Space obtained from the CC API
+type CFSpace struct {
+	Name    string
+	OrgGUID string
 }
 
 func CFAppFromV3App(app *cfclient.V3App) *CFApp {
 	tags := extractTagsFromAppMeta(app.Metadata.Labels)
 	tags = append(tags, extractTagsFromAppMeta(app.Metadata.Annotations)...)
+	var spaceGUID string
+	if s, ok := app.Relationships["space"]; ok {
+		spaceGUID = s.Data.GUID
+	} else {
+		log.Debugf("Failed to get space GUID for app %s", app.Name)
+	}
 	return &CFApp{
-		Name: app.Name,
-		Tags: tags,
+		Name:      app.Name,
+		Tags:      tags,
+		SpaceGUID: spaceGUID,
+	}
+}
+
+func CFSpaceFromV3Space(space *cfclient.V3Space) *CFSpace {
+	var orgGUID string
+	if s, ok := space.Relationships["organization"]; ok {
+		orgGUID = s.Data.GUID
+	} else {
+		log.Debugf("Failed to get org GUID for space %s", space.Name)
+	}
+	return &CFSpace{
+		Name:    space.Name,
+		OrgGUID: orgGUID,
+	}
+}
+
+func CFOrgFromV3Organization(org *cfclient.V3Organization) *CFOrg {
+	return &CFOrg{
+		Name: org.Name,
 	}
 }
 
@@ -240,7 +278,10 @@ func DesiredLRPFromBBSModel(bbsLRP *models.DesiredLRP, includeList, excludeList 
 	}
 	appName := extractVA[ApplicationNameKey]
 	appGUID := extractVA[ApplicationIDKey]
-
+	orgGUID := extractVA[OrganizationIDKey]
+	orgName := extractVA[OrganizationNameKey]
+	spaceGUID := extractVA[SpaceIDKey]
+	spaceName := extractVA[SpaceNameKey]
 	// try to get updated app name from CC API in case of app renames, as well as tags extracted from app metadata
 	ccCache, err := GetGlobalCCCache()
 	if err == nil {
@@ -249,6 +290,14 @@ func DesiredLRPFromBBSModel(bbsLRP *models.DesiredLRP, includeList, excludeList 
 		} else {
 			appName = ccApp.Name
 			customTags = append(customTags, ccApp.Tags...)
+			spaceGUID = ccApp.SpaceGUID
+			if space, ok := ccCache.spacesByGUID[spaceGUID]; ok {
+				spaceName = space.Name
+				orgGUID = space.OrgGUID
+			}
+			if org, ok := ccCache.orgsByGUID[orgGUID]; ok {
+				orgName = org.Name
+			}
 		}
 	} else {
 		log.Debugf("Could not get Cloud Foundry CCAPI cache: %v", err)
@@ -260,11 +309,11 @@ func DesiredLRPFromBBSModel(bbsLRP *models.DesiredLRP, includeList, excludeList 
 		EnvAD:              envAD,
 		EnvVcapServices:    envVS,
 		EnvVcapApplication: envVA,
-		OrganizationGUID:   extractVA[OrganizationIDKey],
-		OrganizationName:   extractVA[OrganizationNameKey],
+		OrganizationGUID:   orgGUID,
+		OrganizationName:   orgName,
 		ProcessGUID:        bbsLRP.ProcessGuid,
-		SpaceGUID:          extractVA[SpaceIDKey],
-		SpaceName:          extractVA[SpaceNameKey],
+		SpaceGUID:          spaceGUID,
+		SpaceName:          spaceName,
 		CustomTags:         customTags,
 	}
 	return d

--- a/pkg/util/cloudfoundry/types.go
+++ b/pkg/util/cloudfoundry/types.go
@@ -291,12 +291,16 @@ func DesiredLRPFromBBSModel(bbsLRP *models.DesiredLRP, includeList, excludeList 
 			appName = ccApp.Name
 			customTags = append(customTags, ccApp.Tags...)
 			spaceGUID = ccApp.SpaceGUID
-			if space, ok := ccCache.spacesByGUID[spaceGUID]; ok {
+			if space, err := ccCache.GetSpace(spaceGUID); err == nil {
 				spaceName = space.Name
 				orgGUID = space.OrgGUID
+			} else {
+				log.Debugf("Could not find space %s in cc cache", spaceGUID)
 			}
-			if org, ok := ccCache.orgsByGUID[orgGUID]; ok {
+			if org, err := ccCache.GetOrg(orgGUID); err == nil {
 				orgName = org.Name
+			} else {
+				log.Debugf("Could not find org %s in cc cache", orgGUID)
 			}
 		}
 	} else {

--- a/pkg/util/cloudfoundry/types_test.go
+++ b/pkg/util/cloudfoundry/types_test.go
@@ -245,25 +245,25 @@ var ExpectedD2 = DesiredLRP{
 	},
 }
 
-var ExpectedD3NoCCCache = DesiredLRP{
-	AppGUID:         "random_app_guid",
-	AppName:         "name_of_the_app",
-	EnvAD:           ADConfig{"xxx": {}},
-	EnvVcapServices: map[string][]byte{"xxx": []byte("{\"name\":\"xxx\"}")},
-	EnvVcapApplication: map[string]string{
-		"application_name":  "name_of_the_app",
-		"application_id":    "random_app_guid",
-		"organization_name": "name_of_the_org",
-		"organization_id":   "random_org_guid",
-		"space_name":        "name_of_the_space",
-		"space_id":          "random_space_guid",
-	},
-	OrganizationGUID: "random_org_guid",
-	OrganizationName: "name_of_the_org",
-	ProcessGUID:      "0123456789012345678901234567890123456789",
-	SpaceGUID:        "random_space_guid",
-	SpaceName:        "name_of_the_space",
-}
+//var ExpectedD3NoCCCache = DesiredLRP{
+//	AppGUID:         "random_app_guid",
+//	AppName:         "name_of_the_app",
+//	EnvAD:           ADConfig{"xxx": {}},
+//	EnvVcapServices: map[string][]byte{"xxx": []byte("{\"name\":\"xxx\"}")},
+//	EnvVcapApplication: map[string]string{
+//		"application_name":  "name_of_the_app",
+//		"application_id":    "random_app_guid",
+//		"organization_name": "name_of_the_org",
+//		"organization_id":   "random_org_guid",
+//		"space_name":        "name_of_the_space",
+//		"space_id":          "random_space_guid",
+//	},
+//	OrganizationGUID: "random_org_guid",
+//	OrganizationName: "name_of_the_org",
+//	ProcessGUID:      "0123456789012345678901234567890123456789",
+//	SpaceGUID:        "random_space_guid",
+//	SpaceName:        "name_of_the_space",
+//}
 
 func TestADIdentifier(t *testing.T) {
 	for _, tc := range []struct {
@@ -337,12 +337,12 @@ func TestDesiredLRPFromBBSModel(t *testing.T) {
 	assert.EqualValues(t, ExpectedD1, result)
 
 	// Temporarily disable global CC cache and acquire locks to prevent any refreshes of the caches in the background
-	globalBBSCache.Lock()
-	defer globalBBSCache.Unlock()
-	globalCCCache.configured = false
-	result = DesiredLRPFromBBSModel(&BBSModelD1, includeList, excludeList)
-	globalCCCache.configured = true
-	assert.EqualValues(t, ExpectedD3NoCCCache, result)
+	//globalBBSCache.Lock()
+	//defer globalBBSCache.Unlock()
+	//globalCCCache.configured = false
+	//result = DesiredLRPFromBBSModel(&BBSModelD1, includeList, excludeList)
+	//globalCCCache.configured = true
+	//assert.EqualValues(t, ExpectedD3NoCCCache, result)
 }
 
 func TestGetVcapServicesMap(t *testing.T) {

--- a/pkg/util/cloudfoundry/types_test.go
+++ b/pkg/util/cloudfoundry/types_test.go
@@ -75,11 +75,6 @@ var v3Space2 = cfclient.V3Space{
 	Relationships: map[string]cfclient.V3ToOneRelationship{"organization": {Data: cfclient.V3Relationship{GUID: "org_guid_2"}}},
 }
 
-var cfSpace2 = CFSpace{
-	Name:    "space_name_2",
-	OrgGUID: "org_guid_2",
-}
-
 var v3Org1 = cfclient.V3Organization{
 	Name: "org_name_1",
 	GUID: "org_guid_1",
@@ -92,10 +87,6 @@ var cfOrg1 = CFOrg{
 var v3Org2 = cfclient.V3Organization{
 	Name: "org_name_2",
 	GUID: "org_guid_2",
-}
-
-var cfOrg2 = CFOrg{
-	Name: "org_name_2",
 }
 
 var BBSModelA1 = models.ActualLRP{

--- a/pkg/util/cloudfoundry/types_test.go
+++ b/pkg/util/cloudfoundry/types_test.go
@@ -336,7 +336,9 @@ func TestDesiredLRPFromBBSModel(t *testing.T) {
 	result = DesiredLRPFromBBSModel(&BBSModelD1, includeList, excludeList)
 	assert.EqualValues(t, ExpectedD1, result)
 
-	// Temporarily disable global CC cache
+	// Temporarily disable global CC cache and acquire locks to prevent any refreshes of the caches in the background
+	globalBBSCache.Lock()
+	defer globalBBSCache.Unlock()
 	globalCCCache.configured = false
 	result = DesiredLRPFromBBSModel(&BBSModelD1, includeList, excludeList)
 	globalCCCache.configured = true

--- a/pkg/util/cloudfoundry/types_test.go
+++ b/pkg/util/cloudfoundry/types_test.go
@@ -24,7 +24,7 @@ var v3App1 = cfclient.V3App{
 	GUID:          "random_app_guid",
 	CreatedAt:     "",
 	UpdatedAt:     "",
-	Relationships: nil,
+	Relationships: map[string]cfclient.V3ToOneRelationship{"space": {Data: cfclient.V3Relationship{GUID: "space_guid_1"}}},
 	Links:         nil,
 	Metadata: cfclient.V3Metadata{
 		Labels:      map[string]string{"tags.datadoghq.com/env": "test-env", "toto": "tata"},
@@ -33,8 +33,9 @@ var v3App1 = cfclient.V3App{
 }
 
 var cfApp1 = CFApp{
-	Name: "name_of_app_cc",
-	Tags: []string{"env:test-env", "service:test-service"},
+	Name:      "name_of_app_cc",
+	Tags:      []string{"env:test-env", "service:test-service"},
+	SpaceGUID: "space_guid_1",
 }
 
 var v3App2 = cfclient.V3App{
@@ -44,7 +45,7 @@ var v3App2 = cfclient.V3App{
 	GUID:          "guid2",
 	CreatedAt:     "",
 	UpdatedAt:     "",
-	Relationships: nil,
+	Relationships: map[string]cfclient.V3ToOneRelationship{"space": {Data: cfclient.V3Relationship{GUID: "space_guid_2"}}},
 	Links:         nil,
 	Metadata: cfclient.V3Metadata{
 		Labels:      map[string]string{},
@@ -53,7 +54,48 @@ var v3App2 = cfclient.V3App{
 }
 
 var cfApp2 = CFApp{
-	Name: "app2",
+	Name:      "app2",
+	SpaceGUID: "space_guid_2",
+}
+
+var v3Space1 = cfclient.V3Space{
+	Name:          "space_name_1",
+	GUID:          "space_guid_1",
+	Relationships: map[string]cfclient.V3ToOneRelationship{"organization": {Data: cfclient.V3Relationship{GUID: "org_guid_1"}}},
+}
+
+var cfSpace1 = CFSpace{
+	Name:    "space_name_1",
+	OrgGUID: "org_guid_1",
+}
+
+var v3Space2 = cfclient.V3Space{
+	Name:          "space_name_2",
+	GUID:          "space_guid_2",
+	Relationships: map[string]cfclient.V3ToOneRelationship{"organization": {Data: cfclient.V3Relationship{GUID: "org_guid_2"}}},
+}
+
+var cfSpace2 = CFSpace{
+	Name:    "space_name_2",
+	OrgGUID: "org_guid_2",
+}
+
+var v3Org1 = cfclient.V3Organization{
+	Name: "org_name_1",
+	GUID: "org_guid_1",
+}
+
+var cfOrg1 = CFOrg{
+	Name: "org_name_1",
+}
+
+var v3Org2 = cfclient.V3Organization{
+	Name: "org_name_2",
+	GUID: "org_guid_2",
+}
+
+var cfOrg2 = CFOrg{
+	Name: "org_name_2",
 }
 
 var BBSModelA1 = models.ActualLRP{
@@ -178,11 +220,11 @@ var ExpectedD1 = DesiredLRP{
 		"space_name":        "name_of_the_space",
 		"space_id":          "random_space_guid",
 	},
-	OrganizationGUID: "random_org_guid",
-	OrganizationName: "name_of_the_org",
+	OrganizationGUID: "org_guid_1",
+	OrganizationName: "org_name_1",
 	ProcessGUID:      "0123456789012345678901234567890123456789",
-	SpaceGUID:        "random_space_guid",
-	SpaceName:        "name_of_the_space",
+	SpaceGUID:        "space_guid_1",
+	SpaceName:        "space_name_1",
 	CustomTags:       []string{"env:test-env", "service:test-service"},
 }
 
@@ -199,17 +241,37 @@ var ExpectedD2 = DesiredLRP{
 		"space_name":        "name_of_the_space",
 		"space_id":          "random_space_guid",
 	},
-	OrganizationGUID: "random_org_guid",
-	OrganizationName: "name_of_the_org",
+	OrganizationGUID: "org_guid_1",
+	OrganizationName: "org_name_1",
 	ProcessGUID:      "0123456789012345678901234567890123456789",
-	SpaceGUID:        "random_space_guid",
-	SpaceName:        "name_of_the_space",
+	SpaceGUID:        "space_guid_1",
+	SpaceName:        "space_name_1",
 	CustomTags: []string{
 		"CUSTOM_TAG_1:TEST1",
 		"CUSTOM_TAG_2:TEST2",
 		"env:test-env",
 		"service:test-service",
 	},
+}
+
+var ExpectedD3NoCCCache = DesiredLRP{
+	AppGUID:         "random_app_guid",
+	AppName:         "name_of_the_app",
+	EnvAD:           ADConfig{"xxx": {}},
+	EnvVcapServices: map[string][]byte{"xxx": []byte("{\"name\":\"xxx\"}")},
+	EnvVcapApplication: map[string]string{
+		"application_name":  "name_of_the_app",
+		"application_id":    "random_app_guid",
+		"organization_name": "name_of_the_org",
+		"organization_id":   "random_org_guid",
+		"space_name":        "name_of_the_space",
+		"space_id":          "random_space_guid",
+	},
+	OrganizationGUID: "random_org_guid",
+	OrganizationName: "name_of_the_org",
+	ProcessGUID:      "0123456789012345678901234567890123456789",
+	SpaceGUID:        "random_space_guid",
+	SpaceName:        "name_of_the_space",
 }
 
 func TestADIdentifier(t *testing.T) {
@@ -257,6 +319,16 @@ func TestCFAppFromV3App(t *testing.T) {
 	assert.EqualValues(t, cfApp1, *result)
 }
 
+func TestCFSpaceFromV3Space(t *testing.T) {
+	result := CFSpaceFromV3Space(&v3Space1)
+	assert.EqualValues(t, cfSpace1, *result)
+}
+
+func TestCFOrgFromV3Organization(t *testing.T) {
+	result := CFOrgFromV3Organization(&v3Org1)
+	assert.EqualValues(t, cfOrg1, *result)
+}
+
 func TestActualLRPFromBBSModel(t *testing.T) {
 	result := ActualLRPFromBBSModel(&BBSModelA1)
 	assert.EqualValues(t, ExpectedA1, result)
@@ -272,6 +344,12 @@ func TestDesiredLRPFromBBSModel(t *testing.T) {
 	excludeList = []*regexp.Regexp{}
 	result = DesiredLRPFromBBSModel(&BBSModelD1, includeList, excludeList)
 	assert.EqualValues(t, ExpectedD1, result)
+
+	// Temporarily disable global CC cache
+	globalCCCache.configured = false
+	result = DesiredLRPFromBBSModel(&BBSModelD1, includeList, excludeList)
+	globalCCCache.configured = true
+	assert.EqualValues(t, ExpectedD3NoCCCache, result)
 }
 
 func TestGetVcapServicesMap(t *testing.T) {

--- a/pkg/util/cloudfoundry/types_test.go
+++ b/pkg/util/cloudfoundry/types_test.go
@@ -245,25 +245,25 @@ var ExpectedD2 = DesiredLRP{
 	},
 }
 
-//var ExpectedD3NoCCCache = DesiredLRP{
-//	AppGUID:         "random_app_guid",
-//	AppName:         "name_of_the_app",
-//	EnvAD:           ADConfig{"xxx": {}},
-//	EnvVcapServices: map[string][]byte{"xxx": []byte("{\"name\":\"xxx\"}")},
-//	EnvVcapApplication: map[string]string{
-//		"application_name":  "name_of_the_app",
-//		"application_id":    "random_app_guid",
-//		"organization_name": "name_of_the_org",
-//		"organization_id":   "random_org_guid",
-//		"space_name":        "name_of_the_space",
-//		"space_id":          "random_space_guid",
-//	},
-//	OrganizationGUID: "random_org_guid",
-//	OrganizationName: "name_of_the_org",
-//	ProcessGUID:      "0123456789012345678901234567890123456789",
-//	SpaceGUID:        "random_space_guid",
-//	SpaceName:        "name_of_the_space",
-//}
+var ExpectedD3NoCCCache = DesiredLRP{
+	AppGUID:         "random_app_guid",
+	AppName:         "name_of_the_app",
+	EnvAD:           ADConfig{"xxx": {}},
+	EnvVcapServices: map[string][]byte{"xxx": []byte("{\"name\":\"xxx\"}")},
+	EnvVcapApplication: map[string]string{
+		"application_name":  "name_of_the_app",
+		"application_id":    "random_app_guid",
+		"organization_name": "name_of_the_org",
+		"organization_id":   "random_org_guid",
+		"space_name":        "name_of_the_space",
+		"space_id":          "random_space_guid",
+	},
+	OrganizationGUID: "random_org_guid",
+	OrganizationName: "name_of_the_org",
+	ProcessGUID:      "0123456789012345678901234567890123456789",
+	SpaceGUID:        "random_space_guid",
+	SpaceName:        "name_of_the_space",
+}
 
 func TestADIdentifier(t *testing.T) {
 	for _, tc := range []struct {
@@ -336,13 +336,13 @@ func TestDesiredLRPFromBBSModel(t *testing.T) {
 	result = DesiredLRPFromBBSModel(&BBSModelD1, includeList, excludeList)
 	assert.EqualValues(t, ExpectedD1, result)
 
-	// Temporarily disable global CC cache and acquire locks to prevent any refreshes of the caches in the background
-	//globalBBSCache.Lock()
-	//defer globalBBSCache.Unlock()
-	//globalCCCache.configured = false
-	//result = DesiredLRPFromBBSModel(&BBSModelD1, includeList, excludeList)
-	//globalCCCache.configured = true
-	//assert.EqualValues(t, ExpectedD3NoCCCache, result)
+	// Temporarily disable global CC cache and acquire lock to prevent any refresh of the BBS cache in the background
+	globalBBSCache.Lock()
+	defer globalBBSCache.Unlock()
+	globalCCCache.configured = false
+	result = DesiredLRPFromBBSModel(&BBSModelD1, includeList, excludeList)
+	globalCCCache.configured = true
+	assert.EqualValues(t, ExpectedD3NoCCCache, result)
 }
 
 func TestGetVcapServicesMap(t *testing.T) {

--- a/releasenotes/notes/dca-space-org-eb6b0cf762c5acdd.yaml
+++ b/releasenotes/notes/dca-space-org-eb6b0cf762c5acdd.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add calls to Cloudfoundry API for space and organization data to tag application containers with more up-to-date information compared to BBS API.


### PR DESCRIPTION
### What does this PR do?

Query org and space data from CC API to solve some cases where the BBS API doesn't have all the up to date information on those. CAPI is the source of truth for all of this.

### Motivation

Cases where there were no org data for old apps that didn't have all the information when first started, and that were never restarted for instance, so BBS API was never updated.


### Describe how to test your changes

Test on environment, enable cloudfoundry api data collection in cluster agent config, spin up some apps, and make sure all the space/org tags are present on containers

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.


Note: Adding GitHub labels is only possible for contributors with write access.
