### PR TITLE
[orchestrator] change endpoint

### DIFF
--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -226,6 +226,7 @@ func (l *Collector) messagesToResults(start time.Time, name string, messages []m
 		extraHeaders.Set(headers.HostHeader, l.cfg.HostName)
 		extraHeaders.Set(headers.ProcessVersionHeader, Version)
 		extraHeaders.Set(headers.ContainerCountHeader, strconv.Itoa(getContainerCount(m)))
+		extraHeaders.Set("Content-Type", headers.ProtobufContentType)
 
 		if l.cfg.Orchestrator.OrchestrationCollectionEnabled {
 			if cid, err := clustername.GetClusterID(); err == nil && cid != "" {

--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -28,6 +28,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/util/api/headers"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 type checkResult struct {
@@ -232,6 +233,8 @@ func (l *Collector) messagesToResults(start time.Time, name string, messages []m
 			if cid, err := clustername.GetClusterID(); err == nil && cid != "" {
 				extraHeaders.Set(headers.ClusterIDHeader, cid)
 			}
+			extraHeaders.Set(headers.EVPOriginHeader, "process-agent")
+			extraHeaders.Set(headers.EVPOriginVersionHeader, version.AgentVersion)
 		}
 
 		payloads = append(payloads, checkPayload{

--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -28,7 +28,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/util/api/headers"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 type checkResult struct {
@@ -233,8 +232,6 @@ func (l *Collector) messagesToResults(start time.Time, name string, messages []m
 			if cid, err := clustername.GetClusterID(); err == nil && cid != "" {
 				extraHeaders.Set(headers.ClusterIDHeader, cid)
 			}
-			extraHeaders.Set(headers.EVPOriginHeader, "process-agent")
-			extraHeaders.Set(headers.EVPOriginVersionHeader, version.AgentVersion)
 		}
 
 		payloads = append(payloads, checkPayload{

--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -227,7 +227,7 @@ func (l *Collector) messagesToResults(start time.Time, name string, messages []m
 		extraHeaders.Set(headers.HostHeader, l.cfg.HostName)
 		extraHeaders.Set(headers.ProcessVersionHeader, Version)
 		extraHeaders.Set(headers.ContainerCountHeader, strconv.Itoa(getContainerCount(m)))
-		extraHeaders.Set("Content-Type", headers.ProtobufContentType)
+		extraHeaders.Set(headers.ContentTypeHeader, headers.ProtobufContentType)
 
 		if l.cfg.Orchestrator.OrchestrationCollectionEnabled {
 			if cid, err := clustername.GetClusterID(); err == nil && cid != "" {

--- a/cmd/process-agent/collector_api_test.go
+++ b/cmd/process-agent/collector_api_test.go
@@ -274,7 +274,7 @@ func TestSendPodMessage(t *testing.T) {
 	runCollectorTest(t, check, cfg, &endpointConfig{}, ddconfig.Mock(), func(cfg *config.AgentConfig, ep *mockEndpoint) {
 		req := <-ep.Requests
 
-		assert.Equal(t, "/api/v1/orchestrator", req.uri)
+		assert.Equal(t, "/api/v2/orch", req.uri)
 
 		assert.Equal(t, cfg.HostName, req.headers.Get(headers.HostHeader))
 		assert.Equal(t, cfg.Orchestrator.OrchestratorEndpoints[0].APIKey, req.headers.Get("DD-Api-Key"))
@@ -489,7 +489,7 @@ func newMockEndpoint(t *testing.T, config *endpointConfig) *mockEndpoint {
 
 	orchestratorMux := http.NewServeMux()
 	orchestratorMux.HandleFunc("/api/v1/validate", m.handleValidate)
-	orchestratorMux.HandleFunc("/api/v1/orchestrator", m.handle)
+	orchestratorMux.HandleFunc("/api/v2/orch", m.handle)
 
 	m.collectorServer = &http.Server{Addr: ":", Handler: collectorMux}
 	m.orchestratorServer = &http.Server{Addr: ":", Handler: orchestratorMux}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -908,6 +908,7 @@ func InitConfig(config Config) {
 	config.BindEnv("orchestrator_explorer.max_per_message")
 	config.BindEnv("orchestrator_explorer.orchestrator_dd_url")
 	config.BindEnv("orchestrator_explorer.orchestrator_additional_endpoints")
+	config.BindEnv("orchestrator_explorer.use_legacy_endpoint")
 
 	// Container lifecycle configuration
 	config.BindEnvAndSetDefault("container_lifecycle.enabled", false)

--- a/pkg/forwarder/endpoints/endpoints.go
+++ b/pkg/forwarder/endpoints/endpoints.go
@@ -46,6 +46,8 @@ var (
 	RtContainerEndpoint = transaction.Endpoint{Route: "/api/v1/container", Name: "rtcontainer"}
 	// ConnectionsEndpoint is a v1 endpoint used to send connection checks
 	ConnectionsEndpoint = transaction.Endpoint{Route: "/api/v1/collector", Name: "connections"}
+	// LegacyOrchestratorEndpoint is a v1 endpoint used to send orchestrator checks
+	LegacyOrchestratorEndpoint = transaction.Endpoint{Route: "/api/v1/orchestrator", Name: "orchestrator"}
 	// OrchestratorEndpoint is a v2 endpoint used to send orchestrator checks
 	OrchestratorEndpoint = transaction.Endpoint{Route: "/api/v2/orch", Name: "orchestrator"}
 	// ContainerLifecycleEndpoint is an event platform endpoint used to send container lifecycle events

--- a/pkg/forwarder/endpoints/endpoints.go
+++ b/pkg/forwarder/endpoints/endpoints.go
@@ -46,8 +46,8 @@ var (
 	RtContainerEndpoint = transaction.Endpoint{Route: "/api/v1/container", Name: "rtcontainer"}
 	// ConnectionsEndpoint is a v1 endpoint used to send connection checks
 	ConnectionsEndpoint = transaction.Endpoint{Route: "/api/v1/collector", Name: "connections"}
-	// OrchestratorEndpoint is a v1 endpoint used to send orchestrator checks
-	OrchestratorEndpoint = transaction.Endpoint{Route: "/api/v1/orchestrator", Name: "orchestrator"}
+	// OrchestratorEndpoint is a v2 endpoint used to send orchestrator checks
+	OrchestratorEndpoint = transaction.Endpoint{Route: "/api/v2/orch", Name: "orchestrator"}
 	// ContainerLifecycleEndpoint is an event platform endpoint used to send container lifecycle events
 	ContainerLifecycleEndpoint = transaction.Endpoint{Route: "/api/v2/contlcycle", Name: "contlcycle"}
 )

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -553,7 +553,12 @@ func (f *DefaultForwarder) SubmitConnectionChecks(payload Payloads, extra http.H
 func (f *DefaultForwarder) SubmitOrchestratorChecks(payload Payloads, extra http.Header, payloadType int) (chan Response, error) {
 	bumpOrchestratorPayload(payloadType)
 
-	return f.submitProcessLikePayload(endpoints.OrchestratorEndpoint, payload, extra, true)
+	endpoint := endpoints.OrchestratorEndpoint
+	if config.Datadog.IsSet("orchestrator_explorer.use_legacy_endpoint") {
+		endpoint = endpoints.LegacyOrchestratorEndpoint
+	}
+
+	return f.submitProcessLikePayload(endpoint, payload, extra, true)
 }
 
 // SubmitContainerLifecycleEvents sends container lifecycle events

--- a/pkg/orchestrator/config/config.go
+++ b/pkg/orchestrator/config/config.go
@@ -63,7 +63,7 @@ func key(pieces ...string) string {
 	return strings.Join(pieces, ".")
 }
 
-// Load load orchestrator-specific configuration
+// Load loads orchestrator-specific configuration
 // at this point secrets should already be resolved by the core/process/cluster agent
 func (oc *OrchestratorConfig) Load() error {
 	URL, err := extractOrchestratorDDUrl()

--- a/pkg/process/util/api/headers/headers.go
+++ b/pkg/process/util/api/headers/headers.go
@@ -18,8 +18,4 @@ const (
 	TimestampHeader = "X-DD-Agent-Timestamp"
 	// ProtobufContentType contains that the content type is protobuf
 	ProtobufContentType = "application/x-protobuf"
-	// EVPOriginHeader is the source/origin sending a request to the intake. This field should be filled with the name of the library sending profiles.
-	EVPOriginHeader = "DD-EVP-ORIGIN"
-	// EVPOriginVersionHeader is the version of above origin
-	EVPOriginVersionHeader = "DD-EVP-ORIGIN-VERSION"
 )

--- a/pkg/process/util/api/headers/headers.go
+++ b/pkg/process/util/api/headers/headers.go
@@ -16,4 +16,6 @@ const (
 	ClusterIDHeader = "X-Dd-Orchestrator-ClusterID"
 	// TimestampHeader contains the timestamp that the check data was created
 	TimestampHeader = "X-DD-Agent-Timestamp"
+	// ProtobufContentType contains that the content type is protobuf
+	ProtobufContentType = "application/x-protobuf"
 )

--- a/pkg/process/util/api/headers/headers.go
+++ b/pkg/process/util/api/headers/headers.go
@@ -18,6 +18,8 @@ const (
 	TimestampHeader = "X-DD-Agent-Timestamp"
 	// ProtobufContentType contains that the content type is protobuf
 	ProtobufContentType = "application/x-protobuf"
+	// ContentTypeHeader contains the content type of the payload
+	ContentTypeHeader = "Content-Type"
 	// EVPOriginHeader is the source/origin sending a request to the intake. This field should be filled with the name of the library sending profiles.
 	EVPOriginHeader = "DD-EVP-ORIGIN"
 	// EVPOriginVersionHeader is the version of above origin

--- a/pkg/process/util/api/headers/headers.go
+++ b/pkg/process/util/api/headers/headers.go
@@ -18,4 +18,8 @@ const (
 	TimestampHeader = "X-DD-Agent-Timestamp"
 	// ProtobufContentType contains that the content type is protobuf
 	ProtobufContentType = "application/x-protobuf"
+	// EVPOriginHeader is the source/origin sending a request to the intake. This field should be filled with the name of the library sending profiles.
+	EVPOriginHeader = "DD-EVP-ORIGIN"
+	// EVPOriginVersionHeader is the version of above origin
+	EVPOriginVersionHeader = "DD-EVP-ORIGIN-VERSION"
 )

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -466,7 +466,7 @@ func (s *Serializer) SendOrchestratorMetadata(msgs []ProcessMessageBody, hostNam
 		extraHeaders.Set(headers.TimestampHeader, strconv.Itoa(int(time.Now().Unix())))
 		extraHeaders.Set(headers.EVPOriginHeader, "agent")
 		extraHeaders.Set(headers.EVPOriginVersionHeader, version.AgentVersion)
-		extraHeaders.Set("Content-Type", headers.ProtobufContentType)
+		extraHeaders.Set(headers.ContentTypeHeader, headers.ProtobufContentType)
 
 		body, err := processPayloadEncoder(m)
 		if err != nil {

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -464,7 +464,7 @@ func (s *Serializer) SendOrchestratorMetadata(msgs []ProcessMessageBody, hostNam
 		extraHeaders.Set(headers.HostHeader, hostName)
 		extraHeaders.Set(headers.ClusterIDHeader, clusterID)
 		extraHeaders.Set(headers.TimestampHeader, strconv.Itoa(int(time.Now().Unix())))
-		extraHeaders.Set(headers.EVPOriginHeader, "datadog-cluster-agent")
+		extraHeaders.Set(headers.EVPOriginHeader, "agent")
 		extraHeaders.Set(headers.EVPOriginVersionHeader, version.AgentVersion)
 		extraHeaders.Set("Content-Type", headers.ProtobufContentType)
 

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serializer/stream"
 	"github.com/DataDog/datadog-agent/pkg/util/compression"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/version"
 
 	"github.com/gogo/protobuf/proto"
 )
@@ -463,6 +464,8 @@ func (s *Serializer) SendOrchestratorMetadata(msgs []ProcessMessageBody, hostNam
 		extraHeaders.Set(headers.HostHeader, hostName)
 		extraHeaders.Set(headers.ClusterIDHeader, clusterID)
 		extraHeaders.Set(headers.TimestampHeader, strconv.Itoa(int(time.Now().Unix())))
+		extraHeaders.Set(headers.EVPOriginHeader, "datadog-cluster-agent")
+		extraHeaders.Set(headers.EVPOriginVersionHeader, version.AgentVersion)
 		extraHeaders.Set("Content-Type", headers.ProtobufContentType)
 
 		body, err := processPayloadEncoder(m)

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -463,6 +463,7 @@ func (s *Serializer) SendOrchestratorMetadata(msgs []ProcessMessageBody, hostNam
 		extraHeaders.Set(headers.HostHeader, hostName)
 		extraHeaders.Set(headers.ClusterIDHeader, clusterID)
 		extraHeaders.Set(headers.TimestampHeader, strconv.Itoa(int(time.Now().Unix())))
+		extraHeaders.Set("Content-Type", headers.ProtobufContentType)
 
 		body, err := processPayloadEncoder(m)
 		if err != nil {

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -22,7 +22,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serializer/stream"
 	"github.com/DataDog/datadog-agent/pkg/util/compression"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/version"
 
 	"github.com/gogo/protobuf/proto"
 )
@@ -464,8 +463,6 @@ func (s *Serializer) SendOrchestratorMetadata(msgs []ProcessMessageBody, hostNam
 		extraHeaders.Set(headers.HostHeader, hostName)
 		extraHeaders.Set(headers.ClusterIDHeader, clusterID)
 		extraHeaders.Set(headers.TimestampHeader, strconv.Itoa(int(time.Now().Unix())))
-		extraHeaders.Set(headers.EVPOriginHeader, "datadog-cluster-agent")
-		extraHeaders.Set(headers.EVPOriginVersionHeader, version.AgentVersion)
 		extraHeaders.Set("Content-Type", headers.ProtobufContentType)
 
 		body, err := processPayloadEncoder(m)

--- a/test/e2e/containers/fake_datadog/app/api.py
+++ b/test/e2e/containers/fake_datadog/app/api.py
@@ -250,7 +250,7 @@ def logs():
     return Response(status=200)
 
 
-@app.route("/api/v1/orchestrator", methods=["POST"])
+@app.route("/api/v2/orch", methods=["POST"])
 def orchestrator():
     # TODO
     return Response(status=200)


### PR DESCRIPTION
### What does this PR do?

The `orchestrator` endpoint has changed and therefore newer agents need to migrate to the new endpoint. Old agents will not be affected and still work. 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
