### PR TITLE
[gui] strengthen path handling

### DIFF
--- a/cmd/agent/gui/checks.go
+++ b/cmd/agent/gui/checks.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -155,13 +154,10 @@ func reloadCheck(w http.ResponseWriter, r *http.Request) {
 	w.Write([]byte(fmt.Sprintf("Removed %v old instance(s) and started %v new instance(s) of %s", len(killed), len(instances), name)))
 }
 
-// pathComponentPattern matches one file or folder name.
-var pathComponentPattern = regexp.MustCompile("^[a-zA-Z0-9_-][a-zA-Z0-9_.-]*$")
-
 func getPathComponentFromRequest(vars map[string]string, name string, allowEmpty bool) (string, error) {
 	val := vars[name]
 
-	if (val == "" && allowEmpty) || pathComponentPattern.MatchString(val) {
+	if (val == "" && allowEmpty) || (val != "" && !strings.Contains(val, "\\") && !strings.Contains(val, "/") && !strings.HasPrefix(val, ".")) {
 		return val, nil
 	}
 

--- a/cmd/agent/gui/checks_test.go
+++ b/cmd/agent/gui/checks_test.go
@@ -53,11 +53,14 @@ func TestGetFileNameAndFolder(t *testing.T) {
 		{"empty path", vars{"fileName": "foo"}, "foo", "", false},
 		{"empty name", vars{"checkFolder": "foo"}, "", "", true},
 		{"empty none", vars{"fileName": "foo", "checkFolder": "bar"}, "foo", "bar", false},
-		{"invalid name", vars{"fileName": "..", "checkFolder": "bar"}, "", "", true},
-		{"invalid path", vars{"fileName": "foo", "checkFolder": ".."}, "", "", true},
+		{"invalid name 1", vars{"fileName": "..", "checkFolder": "bar"}, "", "", true},
+		{"invalid name 2", vars{"fileName": "/foo", "checkFolder": "bar"}, "", "", true},
+		{"invalid path 1", vars{"fileName": "foo", "checkFolder": ".."}, "", "", true},
 		{"invalid path 2", vars{"fileName": "foo", "checkFolder": "..\\.."}, "", "", true},
 		{"invalid path 3", vars{"fileName": "foo", "checkFolder": "foo\\.."}, "", "", true},
-		{"invalid both", vars{"fileName": "\\foo", "checkFolder": ".."}, "", "", true},
+		{"invalid path 4", vars{"fileName": "foo", "checkFolder": "../.."}, "", "", true},
+		{"invalid path 5", vars{"fileName": "foo", "checkFolder": "foo/.."}, "", "", true},
+		{"invalid both", vars{"fileName": "/foo", "checkFolder": ".."}, "", "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/agent/gui/checks_test.go
+++ b/cmd/agent/gui/checks_test.go
@@ -39,3 +39,39 @@ func TestConfigsInPath(t *testing.T) {
 
 	assert.Equal(t, expected, files)
 }
+
+func TestGetFileNameAndFolder(t *testing.T) {
+	type vars map[string]string
+	tests := []struct {
+		name            string
+		vars            vars
+		wantFileName    string
+		wantCheckFolder string
+		wantErr         bool
+	}{
+		{"empty both", vars{}, "", "", true},
+		{"empty path", vars{"fileName": "foo"}, "foo", "", false},
+		{"empty name", vars{"checkFolder": "foo"}, "", "", true},
+		{"empty none", vars{"fileName": "foo", "checkFolder": "bar"}, "foo", "bar", false},
+		{"invalid name", vars{"fileName": "..", "checkFolder": "bar"}, "", "", true},
+		{"invalid path", vars{"fileName": "foo", "checkFolder": ".."}, "", "", true},
+		{"invalid path 2", vars{"fileName": "foo", "checkFolder": "..\\.."}, "", "", true},
+		{"invalid path 3", vars{"fileName": "foo", "checkFolder": "foo\\.."}, "", "", true},
+		{"invalid both", vars{"fileName": "\\foo", "checkFolder": ".."}, "", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotFileName, gotCheckFolder, err := getFileNameAndFolder(tt.vars)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getFileNameAndFolder() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotFileName != tt.wantFileName {
+				t.Errorf("getFileNameAndFolder() gotFileName = %v, want %v", gotFileName, tt.wantFileName)
+			}
+			if gotCheckFolder != tt.wantCheckFolder {
+				t.Errorf("getFileNameAndFolder() gotCheckFolder = %v, want %v", gotCheckFolder, tt.wantCheckFolder)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Strengthen path handling; Make sure the path we get is matching our expectations.

### Describe how to test your changes

Test changes on Windows and Unix. Check that manage checks option in the GUI works:
- edit existing config
- disable config
- customize default
- add a new config for a pre-installed check

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
