### PR TITLE
DOCS-2215 Add @env variables to datadog.yaml

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -181,7 +181,7 @@ api_key:
 # histogram_copy_to_distribution_prefix: "<PREFIX>"
 
 ## @param aggregator_stop_timeout - integer - optional - default: 2
-## env DD_AGGREGATOR_STOP_TIMEOUT - integer - optional - default: 2
+## @env DD_AGGREGATOR_STOP_TIMEOUT - integer - optional - default: 2
 ## When stopping the agent, the Aggregator will try to flush out data ready for
 ## aggregation (metrics, events, ...). Data are flushed to the Forwarder in order
 ## to be sent to Datadog, therefore the Agent might take at most
@@ -255,7 +255,6 @@ api_key:
 #
 # forwarder_outdated_file_in_days: 10
 
-
 ## @param cloud_provider_metadata - list of strings -  optional - default: ["aws", "gcp", "azure", "alibaba"]
 ## This option restricts which cloud provider endpoint will be used by the
 ## agent to retrieve metadata. By default the agent will try # AWS, GCP, Azure
@@ -280,6 +279,7 @@ api_key:
 #   - "alibaba"
 
 ## @param collect_ec2_tags - boolean - optional - default: false
+## @env DD_COLLECT_EC2_TAGS - boolean - optional - default: false
 ## Collect AWS EC2 custom tags as host tags.
 ## Requires the EC2 instance to have an IAM role with the `EC2:DescribeTags`
 ## permission. See docs for further details:
@@ -303,11 +303,13 @@ api_key:
 # ec2_prefer_imdsv2: false
 
 ## @param collect_gce_tags - boolean - optional - default: true
+## @env DD_COLLECT_GCE_TAGS - boolean - optional - default: true
 ## Collect Google Cloud Engine metadata as host tags
 #
 # collect_gce_tags: true
 
 ## @param exclude_gce_tags - list of strings - optional - default: ["kube-env", "kubelet-config", "containerd-configure-sh", "startup-script", "shutdown-script", "configure-sh", "sshKeys", "ssh-keys", "user-data", "cli-cert", "ipsec-cert", "ssl-cert", "google-container-manifest", "bosh_settings"]
+## @env DD_EXCLUDE_GCE_TAGS - space separated list of strings - optional - default: kube-env kubelet-config containerd-configure-sh startup-script shutdown-script configure-sh sshKeys ssh-keys user-data cli-cert ipsec-cert ssl-cert google-container-manifest bosh_settings
 ## Google Cloud Engine metadata attribute to exclude from being converted into
 ## host tags -- only applicable when collect_gce_tags is true.
 #
@@ -351,6 +353,7 @@ api_key:
 # azure_hostname_style: "os"
 
 ## @param flare_stripped_keys - list of strings - optional
+## @env DD_FLARE_STRIPPED_KEYS - space separated list of strings - optional
 ## By default, the Agent removes known sensitive keys from Agent and Integrations yaml configs before
 ## including them in the flare.
 ## Use this parameter to define additional sensitive keys that the Agent should scrub from
@@ -377,6 +380,7 @@ api_key:
 {{- if .Python }}
 {{- if .BothPythonPresent -}}
 ## @param python_version - integer - optional - default: 2
+## @env DD_PYTHON_VERSION - integer - optional - default: 2
 ## The major version of Python used to run integrations and custom checks.
 ## The only supported values are 2 (to use Python 2) or 3 (to use Python 3).
 ## Do not change this option when using the official Docker Agent images.
@@ -391,28 +395,33 @@ api_key:
 ############################
 
 ## @param confd_path - string - optional
+## @env DD_CONFD_PATH - string - optional
 ## The path containing check configuration files. By default, uses the conf.d folder
 ## located in the Agent configuration folder.
 #
 # confd_path: ""
 
 ## @param additional_checksd - string - optional
+## @env DD_ADDITIONAL_CHECKSD - string - optional
 ## Additional path indicating where to search for Python checks. By default, uses the checks.d folder
 ## located in the Agent configuration folder.
 #
 # additional_checksd: <CHECKD_FOLDER_PATH>
 
 ## @param expvar_port - integer - optional - default: 5000
+## @env DD_EXPVAR_PORT - integer - optional - default: 5000
 ## The port for the go_expvar server.
 #
 # expvar_port: 5000
 
 ## @param cmd_port - integer - optional - default: 5001
+## @env DD_CMD_PORT - integer - optional - default: 5001
 ## The port on which the IPC api listens.
 #
 # cmd_port: 5001
 
 ## @param GUI_port - integer - optional
+## @env DD_GUI_PORT - integer - optional
 ## The port for the browser GUI to be served.
 ## Setting 'GUI_port: -1' turns off the GUI completely
 ## Default is:
@@ -423,6 +432,7 @@ api_key:
 # GUI_port: <GUI_PORT>
 
 ## @param health_port - integer - optional - default: 0
+## @env DD_HEALTH_PORT - integer - optional - default: 0
 ## The Agent can expose its health check on a dedicated http port.
 ## This is useful for orchestrators that support http probes.
 ## Default is 0 (disabled), set a valid port number (eg. 5555) to enable.
@@ -430,6 +440,7 @@ api_key:
 # health_port: 0
 
 ## @param check_runners - integer - optional - default: 4
+## @env DD_CHECK_RUNNERS - integer - optional - default: 4
 ## The `check_runners` refers to the number of concurrent check runners available for check instance execution.
 ## The scheduler attempts to spread the instances over the collection interval and will _at most_ be
 ## running the number of check runners instances concurrently.
@@ -442,6 +453,7 @@ api_key:
 # check_runners: 4
 
 ## @param enable_metadata_collection - boolean - optional - default: true
+## @env DD_ENABLE_METADATA_COLLECTION - boolean - optional - default: true
 ## Metadata collection should always be enabled, except if you are running several
 ## agents/dsd instances per host. In that case, only one Agent should have it on.
 ## WARNING: disabling it on every Agent leads to display and billing issues.


### PR DESCRIPTION
### What does this PR do?

Add @env variables to datadog.yaml:

```
DD_ADDITIONAL_CHECKSD
DD_CHECK_RUNNERS
DD_CMD_PORT
DD_COLLECT_EC2_TAGS
DD_COLLECT_GCE_TAGS
DD_CONFD_PATH
DD_ENABLE_METADATA_COLLECTION
DD_EXCLUDE_GCE_TAGS
DD_EXPVAR_PORT
DD_GUI_PORT
DD_HEALTH_PORT
DD_PYTHON_VERSION
```

### Motivation

- Documentation OKR
- [RFC](https://github.com/DataDog/architecture/blob/master/rfcs/agent-env-var-docs/rfc.md)

### Additional Notes

Variables will be added in small batches.

### Describe how to test your changes

N/A

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
