### PR TITLE
Add support for sourcing tags from Kubernetes environment variables

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -477,6 +477,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("docker_env_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("kubernetes_pod_labels_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("kubernetes_pod_annotations_as_tags", map[string]string{})
+	config.BindEnvAndSetDefault("kubernetes_container_env_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("kubernetes_node_labels_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("kubernetes_namespace_labels_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("container_cgroup_prefix", "")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1864,6 +1864,15 @@ api_key:
 #   <ANNOTATION>: <TAG_KEY>
 #   <HIGH_CARDINALITY_ANNOTATION>: +<TAG_KEY>
 
+## @param kubernetes_container_env_as_tags - map - optional
+## @env DD_KUBERNETES_CONTAINER_ENV_AS_TAGS - JSON object - optional
+## The Agent can extract container environment variable values and set them as metric tag values associated to a <TAG_KEY>.
+## Prefix your tag name with `+`, to only add the values to high cardinality metrics.
+#
+# kubernetes_container_env_as_tags:
+#   <ENV_VAR>: <TAG_KEY>
+#   <HIGH_CARDINALITY_ENV_VAR>: +<TAG_KEY>
+
 ## @param kubernetes_namespace_labels_as_tags - map - optional
 ## The Agent can extract namespace label values and set them as metric tags values associated to a <TAG_KEY>.
 ## If you prefix your tag name with +, it will only be added to high cardinality metrics.

--- a/pkg/tagger/collectors/kubelet_extract.go
+++ b/pkg/tagger/collectors/kubelet_extract.go
@@ -212,6 +212,8 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 								cTags.AddStandard(tagKeyVersion, runtimeVal)
 							case envVarService:
 								cTags.AddStandard(tagKeyService, runtimeVal)
+							default:
+								utils.AddMetadataAsTags(env.Name, runtimeVal, c.envAsTags, c.globEnv, cTags)
 							}
 						} else if env.Name == envVarEnv || env.Name == envVarVersion || env.Name == envVarService {
 							log.Warnf("Reading %s from a ConfigMap, Secret or anything but a literal value is not implemented yet.", env.Name)

--- a/pkg/tagger/collectors/kubelet_main.go
+++ b/pkg/tagger/collectors/kubelet_main.go
@@ -36,8 +36,10 @@ type KubeletCollector struct {
 	expireFreq        time.Duration
 	labelsAsTags      map[string]string
 	annotationsAsTags map[string]string
+	envAsTags         map[string]string
 	globLabels        map[string]glob.Glob
 	globAnnotations   map[string]glob.Glob
+	globEnv           map[string]glob.Glob
 }
 
 // Detect tries to connect to the kubelet
@@ -55,12 +57,13 @@ func (c *KubeletCollector) Detect(ctx context.Context, out chan<- []*TagInfo) (C
 		out,
 		config.Datadog.GetStringMapString("kubernetes_pod_labels_as_tags"),
 		config.Datadog.GetStringMapString("kubernetes_pod_annotations_as_tags"),
+		config.Datadog.GetStringMapString("kubernetes_container_env_as_tags"),
 	)
 
 	return PullCollection, nil
 }
 
-func (c *KubeletCollector) init(watcher *kubelet.PodWatcher, out chan<- []*TagInfo, labelsAsTags, annotationsAsTags map[string]string) {
+func (c *KubeletCollector) init(watcher *kubelet.PodWatcher, out chan<- []*TagInfo, labelsAsTags, annotationsAsTags, envAsTags map[string]string) {
 	c.watcher = watcher
 	c.infoOut = out
 	c.lastExpire = time.Now()
@@ -68,6 +71,7 @@ func (c *KubeletCollector) init(watcher *kubelet.PodWatcher, out chan<- []*TagIn
 
 	c.labelsAsTags, c.globLabels = utils.InitMetadataAsTags(labelsAsTags)
 	c.annotationsAsTags, c.globAnnotations = utils.InitMetadataAsTags(annotationsAsTags)
+	c.envAsTags, c.globEnv = utils.InitMetadataAsTags(envAsTags)
 }
 
 // Pull triggers a podlist refresh and sends new info. It also triggers

--- a/releasenotes/notes/kubernetes-env-vars-as-tags-84ae28e84ace2cfc.yaml
+++ b/releasenotes/notes/kubernetes-env-vars-as-tags-84ae28e84ace2cfc.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add the ability to extract Kubernetes container environment variables as tags, similar to pod
+    annotations and labels. This can be set using the `kubernetes_container_env_as_tags` setting or
+    `DD_KUBERNETES_CONTAINER_ENV_AS_TAGS` environment variable.


### PR DESCRIPTION
### What does this PR do?

Add support for a new config, `kubernetes_container_env_as_tags`, which applies tags to Kubernetes containers based on environment variable values. This is done similarly to the existing `kubernetes_pod_labels_as_tags`/`kubernetes_pod_annotations_as_tags` features.

### Motivation

We would like to apply custom tags to our pods based on values from the downward API. Previously, we did so via the `DD_DOCKER_ENV_AS_TAGS` feature, since we could set envvars with downward API values, and Datadog would pick up the envvars from the containers themselves. However, we've recently begun migrating our Kubernetes clusters to containerd, and so `DD_DOCKER_ENV_AS_TAGS` will no longer work for us. Reading the envvars directly from the Kubernetes pod spec itself provides a replacement for `DD_DOCKER_ENV_AS_TAGS`.

(Since downward API values are not currently interpreted by the Kubelet tag collector, I have a followup PR which adds that functionality as well.)

### Additional Notes

An alternate approach (for our original usecase) would be to simply skip the environment variable plumbing altogether and support directly mapping downward API fields to tag names. Would that be a preferable approach? Even if so, would _this_ PR still be useful?

### Describe how to test your changes

- New unit test for envvar tag mapping added and passing
- Full agent container built and deployed with `DD_KUBERNETES_CONTAINER_ENV_AS_TAGS` configured; verified desired tags are reported back to Datadog.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
