### PR TITLE
Add unit tests to verify config update in Windows installer

### DIFF
--- a/tools/windows/install-help/cal/customaction-tests/FinalizeInstall_ShouldUpdateConfig.cpp
+++ b/tools/windows/install-help/cal/customaction-tests/FinalizeInstall_ShouldUpdateConfig.cpp
@@ -1,0 +1,45 @@
+#include <gtest/gtest.h>
+#include "customaction-tests.h"
+#include "customaction.h"
+
+class ShouldUpdateConfigTest : public testing::Test
+{
+
+};
+
+TEST_F(ShouldUpdateConfigTest, When_APIKEY_At_Start_Of_Line_Do_NOT_Replace)
+{
+    const std::wstring inputConfig =
+        L"\n"
+        L"#########################\n"
+        L"## Basic Configuration ##\n"
+        L"#########################\n"
+        L"\n"
+        L"api_key: asd\n"
+        L"\n"
+        L"## @param site - string - optional - default: datadoghq.com\n"
+        L"## The site of the Datadog intake to send Agent data to.\n"
+        L"## Set to 'datadoghq.eu' to send data to the EU site.\n"
+        L"#\n"
+        L"# site: datadoghq.com\n"
+        L"\n";
+    EXPECT_FALSE(ShouldUpdateConfig(inputConfig));
+}
+
+TEST_F(ShouldUpdateConfigTest, When_APIKEY_NOT_At_Start_Of_Line_Do_Replace)
+{
+    const std::wstring inputConfig = L"\n"
+                                     L"#########################\n"
+                                     L"## Basic Configuration ##\n"
+                                     L"#########################\n"
+                                     L"\n"
+                                     L"  api_key: asd\n"
+                                     L"\n"
+                                     L"## @param site - string - optional - default: datadoghq.com\n"
+                                     L"## The site of the Datadog intake to send Agent data to.\n"
+                                     L"## Set to 'datadoghq.eu' to send data to the EU site.\n"
+                                     L"#\n"
+                                     L"# site: datadoghq.com\n"
+                                     L"\n";
+    EXPECT_TRUE(ShouldUpdateConfig(inputConfig));
+}

--- a/tools/windows/install-help/cal/customaction-tests/customaction-tests.vcxproj
+++ b/tools/windows/install-help/cal/customaction-tests/customaction-tests.vcxproj
@@ -38,6 +38,7 @@
     <ClCompile Include="CustomActionDataTest.cpp" />
     <ClCompile Include="CustomActionData_Init.cpp" />
     <ClCompile Include="CustomActionData_CanInstall.cpp" />
+    <ClCompile Include="FinalizeInstall_ShouldUpdateConfig.cpp" />
     <ClCompile Include="ReplaceYamlProperties_APMTests.cpp">
       <DependentUpon>ReplaceYamlProperties_Tests.cpp</DependentUpon>
     </ClCompile>

--- a/tools/windows/install-help/cal/customaction.h
+++ b/tools/windows/install-help/cal/customaction.h
@@ -104,6 +104,7 @@ extern HMODULE hDllModule;
 */
 
 // FinalizeInstall.cpp
+bool ShouldUpdateConfig(std::wstring const &inputConfig);
 UINT doFinalizeInstall(CustomActionData &data);
 
 // doUninstall.cpp


### PR DESCRIPTION
### What does this PR do?

This PR adds two unit tests to the Windows installer to ensure that the `datadog.yaml` config file is only updated when necessary.

### Motivation

More tests coverage + support case.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
