### PR TITLE
pkg/trace/obfuscate: Fix SQL Normalization of Negative Integer Values

### DIFF
--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -466,6 +466,11 @@ func TestSQLTableFinderAndReplaceDigits(t *testing.T) {
 				"sales_2019_07_01,item1001",
 				"REPLACE INTO sales_?_?_? ( itemID, date, qty, price ) VALUES ( ( SELECT itemID FROM item? WHERE sku = [ sku ] ), CURDATE ( ), [ qty ], ? )",
 			},
+			{
+				"SELECT name FROM people WHERE person_id = -1",
+				"people",
+				"SELECT name FROM people WHERE person_id = ?",
+			},
 		} {
 			t.Run("", func(t *testing.T) {
 				assert := assert.New(t)

--- a/pkg/trace/obfuscate/sql_tokenizer.go
+++ b/pkg/trace/obfuscate/sql_tokenizer.go
@@ -254,11 +254,17 @@ func (tkn *SQLTokenizer) Scan() (TokenKind, []byte) {
 				return TokenKind(ch), tkn.bytes()
 			}
 		case '-':
-			if tkn.lastChar == '-' {
+			switch {
+			case tkn.lastChar == '-':
 				tkn.advance()
 				return tkn.scanCommentType1("--")
+			case isDigit(tkn.lastChar):
+				tkn.advance()
+				kind, tokenBytes := tkn.scanNumber(false)
+				return kind, append([]byte{'-'}, tokenBytes...)
+			default:
+				return TokenKind(ch), tkn.bytes()
 			}
-			return TokenKind(ch), tkn.bytes()
 		case '#':
 			tkn.advance()
 			return tkn.scanCommentType1("#")

--- a/releasenotes/notes/apm-fix-sql-normalization-of-negative-integers-4ffd29fc5dbcdff3.yaml
+++ b/releasenotes/notes/apm-fix-sql-normalization-of-negative-integers-4ffd29fc5dbcdff3.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fix bug in SQL normalization that resulted in negative integer values to be normalized with an extra minus sign token.


### PR DESCRIPTION
### What does this PR do?

This fixes a bug in the SQL normalization where negative integer values weren't parsed as a single obfuscated value by including an extra `-` token. 

Example:
```
SELECT name FROM people WHERE person_id = -1
``` 

was normalized (before the fix) to 

```
SELECT name FROM people WHERE person_id = - ?
```


### Motivation

We saw one of our queries looking for both positive and negative integer values which resulted in two different normalized query when they were the same.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
