### PR TITLE
Ensure conntracker is closed cleanly

### DIFF
--- a/pkg/network/netlink/circuit_breaker.go
+++ b/pkg/network/netlink/circuit_breaker.go
@@ -39,6 +39,8 @@ type CircuitBreaker struct {
 
 	// The timestamp in nanoseconds of when we last updated eventRate
 	lastUpdate int64
+
+	done chan struct{}
 }
 
 // NewCircuitBreaker instantiates a new CircuitBreaker that only allows
@@ -49,13 +51,21 @@ func NewCircuitBreaker(maxEventsPerSec int64) *CircuitBreaker {
 		maxEventsPerSec = math.MaxInt64
 	}
 
-	c := &CircuitBreaker{maxEventsPerSec: maxEventsPerSec}
+	c := &CircuitBreaker{
+		maxEventsPerSec: maxEventsPerSec,
+		done:            make(chan struct{}),
+	}
 	c.Reset()
 
 	go func() {
 		ticker := time.NewTicker(tickInterval)
-		for t := range ticker.C {
-			c.update(t)
+		for {
+			select {
+			case t := <-ticker.C:
+				c.update(t)
+			case <-c.done:
+				return
+			}
 		}
 	}()
 
@@ -84,6 +94,11 @@ func (c *CircuitBreaker) Reset() {
 	atomic.StoreInt64(&c.eventRate, 0)
 	atomic.StoreInt64(&c.lastUpdate, time.Now().UnixNano())
 	atomic.StoreInt64(&c.status, breakerClosed)
+}
+
+// Stop stops the circuit breaker.
+func (c *CircuitBreaker) Stop() {
+	close(c.done)
 }
 
 func (c *CircuitBreaker) update(now time.Time) {

--- a/pkg/network/netlink/consumer.go
+++ b/pkg/network/netlink/consumer.go
@@ -323,6 +323,7 @@ func (c *Consumer) Stop() {
 	if c.conn != nil {
 		c.conn.Close()
 	}
+	c.breaker.Stop()
 }
 
 func (c *Consumer) initNetlinkSocket(samplingRate float64) error {


### PR DESCRIPTION
### What does this PR do?

When the conntracker is closed/stopped, make sure goroutines exit and the circuit breaker is stopped.

### Motivation

Excessive amount of goroutines during test runs.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
