### PR TITLE
Tag eks fargate containers with eks_fargate_node

### DIFF
--- a/pkg/tagger/collectors/static_extract.go
+++ b/pkg/tagger/collectors/static_extract.go
@@ -14,7 +14,7 @@ import (
 
 func (c *StaticCollector) getTagInfo(entity string) []*TagInfo {
 	tags := utils.NewTagList()
-	for _, tag := range c.ddTagsEnvVar {
+	for _, tag := range c.tags {
 		tagParts := strings.SplitN(tag, ":", 2)
 		if len(tagParts) != 2 {
 			log.Warnf("Cannot split tag %s", tag)

--- a/pkg/tagger/collectors/static_extract_test.go
+++ b/pkg/tagger/collectors/static_extract_test.go
@@ -29,7 +29,7 @@ func TestGetTagInfo(t *testing.T) {
 	}
 
 	c := &StaticCollector{}
-	c.ddTagsEnvVar = config.Datadog.GetStringSlice("tags")
+	c.tags = config.Datadog.GetStringSlice("tags")
 
 	result := c.getTagInfo("some_entity_name")
 	assertTagInfoListEqual(t, result, expected)

--- a/pkg/tagger/collectors/static_main_test.go
+++ b/pkg/tagger/collectors/static_main_test.go
@@ -1,0 +1,70 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package collectors
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_fargateStaticTags(t *testing.T) {
+	mockConfig := config.Mock()
+	tests := []struct {
+		name        string
+		loadFunc    func()
+		cleanupFunc func()
+		want        []string
+	}{
+		{
+			name:        "dd tags",
+			loadFunc:    func() { mockConfig.Set("tags", "dd_tag1:dd_val1 dd_tag2:dd_val2") },
+			cleanupFunc: func() { mockConfig.Set("tags", "") },
+			want:        []string{"dd_tag1:dd_val1", "dd_tag2:dd_val2"},
+		},
+		{
+			name: "eks fargate node",
+			loadFunc: func() {
+				mockConfig.Set("eks_fargate", true)
+				mockConfig.Set("kubernetes_kubelet_nodename", "fargate_node_name")
+			},
+			cleanupFunc: func() {
+				mockConfig.Set("eks_fargate", false)
+				mockConfig.Set("kubernetes_kubelet_nodename", "")
+			},
+			want: []string{"eks_fargate_node:fargate_node_name"},
+		},
+		{
+			name: "dd tags and eks fargate node",
+			loadFunc: func() {
+				mockConfig.Set("tags", "dd_tag1:dd_val1 dd_tag2:dd_val2")
+				mockConfig.Set("eks_fargate", true)
+				mockConfig.Set("kubernetes_kubelet_nodename", "fargate_node_name")
+			},
+			cleanupFunc: func() {
+				mockConfig.Set("tags", "")
+				mockConfig.Set("eks_fargate", false)
+				mockConfig.Set("kubernetes_kubelet_nodename", "")
+			},
+			want: []string{"dd_tag1:dd_val1", "dd_tag2:dd_val2", "eks_fargate_node:fargate_node_name"},
+		},
+		{
+			name:        "no tags",
+			loadFunc:    func() {},
+			cleanupFunc: func() {},
+			want:        nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.loadFunc()
+			defer tt.cleanupFunc()
+
+			assert.Equal(t, tt.want, fargateStaticTags())
+		})
+	}
+}

--- a/releasenotes/notes/eks-fargate-node-tag-267dc014fdfc703b.yaml
+++ b/releasenotes/notes/eks-fargate-node-tag-267dc014fdfc703b.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    EKS Fargate containers are tagged with ``eks_fargate_node``.


### PR DESCRIPTION
### What does this PR do?

Tag eks fargate containers with `eks_fargate_node`

### Motivation

- Distinguish containers easier
- FR from APM Intake

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Deploy the agent on EKS Fargate as a sidecar, `agent tagger-list` should show the `eks_fargate_node` under the static collector

```
=== Entity container_id://5e45f1b69a75897b9cddcd9b1d2688eee574cfc7c790e2eef0f1664b56f59310 ===
== Source kubelet ==
Tags: [...]
== Source static ==
Tags: [... eks_fargate_node:fargate-ip-xxx-xxx-xxx-xxx.ec2.internal]
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
