### PR TITLE
Use non-localized regexp in getEphemeralRange

### DIFF
--- a/pkg/network/event_windows.go
+++ b/pkg/network/event_windows.go
@@ -82,17 +82,18 @@ func getEphemeralRange(f ConnectionFamily, t ConnectionType) (low, hi uint16, er
 		return
 	}
 	output := cmdOutput.Bytes()
-	var startPortLine = regexp.MustCompile(`Start.*: (\d+)`)
-	var numberLine = regexp.MustCompile(`Number.*: (\d+)`)
+	var r = regexp.MustCompile(`.*: (\d+)`)
 
-	startPort := startPortLine.FindStringSubmatch(string(output))
-	rangeLen := numberLine.FindStringSubmatch(string(output))
+	matches := r.FindAllStringSubmatch(string(output), -1)
+	if len(matches) != 2 {
+		return
+	}
 
-	portstart, err := strconv.Atoi(startPort[1])
+	portstart, err := strconv.Atoi(matches[0][1])
 	if err != nil {
 		return
 	}
-	plen, err := strconv.Atoi(rangeLen[1])
+	plen, err := strconv.Atoi(matches[1][1])
 	if err != nil {
 		return
 	}

--- a/pkg/network/event_windows.go
+++ b/pkg/network/event_windows.go
@@ -4,6 +4,7 @@ package network
 
 import (
 	"bytes"
+	"fmt"
 	"net"
 	"os/exec"
 	"regexp"
@@ -86,6 +87,7 @@ func getEphemeralRange(f ConnectionFamily, t ConnectionType) (low, hi uint16, er
 
 	matches := r.FindAllStringSubmatch(string(output), -1)
 	if len(matches) != 2 {
+		err = fmt.Errorf("could not parse output of netsh")
 		return
 	}
 

--- a/releasenotes/notes/use_unlocalized_regexp_in_getephemerealport-8a89fbd8e58d7bb4.yaml
+++ b/releasenotes/notes/use_unlocalized_regexp_in_getephemerealport-8a89fbd8e58d7bb4.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On non-English Windows, the Agent correctly parses the output of `netsh`.


### PR DESCRIPTION
### What does this PR do?

This PR replaces a localized regexp that uses the output of `netsh` that was introduced in https://github.com/DataDog/datadog-agent/pull/8267 by a non-localized one.

### Motivation

On non-English Windows system the output of `netsh` is localized and the regexp fails.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Take a non-English Windows VM and run the Agent with network-monitoring, it should not panic.
In the logs, there should not be any mention of  `could not parse output of netsh`.
Do the same on an English Windows VM.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.

