### PR TITLE
[aggregator/ckey] fix collision unit test broken after a merge into `main`

### DIFF
--- a/pkg/aggregator/ckey/tests/collisions_test.go
+++ b/pkg/aggregator/ckey/tests/collisions_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
+	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -30,7 +31,7 @@ func TestCollisions(t *testing.T) {
 		metricName := parts[0]
 		tagList := parts[1]
 		tags := strings.Split(tagList, " ")
-		ck := generator.Generate(metricName, host, tags)
+		ck := generator.Generate(metricName, host, util.NewTagsBuilderFromSlice(tags))
 		if v, exists := cache[ck]; exists {
 			assert.Fail("A collision happened:", v, "and", line)
 		} else {


### PR DESCRIPTION
### What does this PR do?

An old PR has been merged into `main` and a merge "conflict" has been under git radar. This PR is fixing this unit test.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
