### PR TITLE
[backport][7.30] #8934 Use non-localized regexp in getEphemeralRange

### DIFF
--- a/pkg/network/event_windows.go
+++ b/pkg/network/event_windows.go
@@ -31,6 +31,7 @@ uint32_t getTcp_retransmitCount(PER_FLOW_DATA *pfd)
 import "C"
 import (
 	"bytes"
+	"fmt"
 	"net"
 	"os/exec"
 	"regexp"
@@ -117,17 +118,19 @@ func getEphemeralRange(f ConnectionFamily, t ConnectionType) (low, hi uint16, er
 		return
 	}
 	output := cmdOutput.Bytes()
-	var startPortLine = regexp.MustCompile(`Start.*: (\d+)`)
-	var numberLine = regexp.MustCompile(`Number.*: (\d+)`)
+	var r = regexp.MustCompile(`.*: (\d+)`)
 
-	startPort := startPortLine.FindStringSubmatch(string(output))
-	rangeLen := numberLine.FindStringSubmatch(string(output))
+	matches := r.FindAllStringSubmatch(string(output), -1)
+	if len(matches) != 2 {
+		err = fmt.Errorf("could not parse output of netsh")
+		return
+	}
 
-	portstart, err := strconv.Atoi(startPort[1])
+	portstart, err := strconv.Atoi(matches[0][1])
 	if err != nil {
 		return
 	}
-	len, err := strconv.Atoi(rangeLen[1])
+	plen, err := strconv.Atoi(matches[1][1])
 	if err != nil {
 		return
 	}

--- a/pkg/network/event_windows.go
+++ b/pkg/network/event_windows.go
@@ -130,7 +130,7 @@ func getEphemeralRange(f ConnectionFamily, t ConnectionType) (low, hi uint16, er
 	if err != nil {
 		return
 	}
-	plen, err := strconv.Atoi(matches[1][1])
+	len, err := strconv.Atoi(matches[1][1])
 	if err != nil {
 		return
 	}

--- a/releasenotes/notes/use_unlocalized_regexp_in_getephemerealport-8a89fbd8e58d7bb4.yaml
+++ b/releasenotes/notes/use_unlocalized_regexp_in_getephemerealport-8a89fbd8e58d7bb4.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On non-English Windows, the Agent correctly parses the output of `netsh`.


### PR DESCRIPTION
### What does this PR do?

Backport #8934 to 7.30.x

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.

