### PR TITLE
[windows] Make windows always return `unknown` when checking whether port is in

### DIFF
--- a/pkg/network/event_windows.go
+++ b/pkg/network/event_windows.go
@@ -40,19 +40,6 @@ var (
 	}
 )
 
-func init() {
-	var families = [...]ConnectionFamily{AFINET, AFINET6}
-	var protos = [...]ConnectionType{UDP, TCP}
-	for _, f := range families {
-		for _, p := range protos {
-			l, h, err := getEphemeralRange(f, p)
-			if err == nil {
-				ephemeralRanges[f][p]["lo"] = l
-				ephemeralRanges[f][p]["hi"] = h
-			}
-		}
-	}
-}
 func getEphemeralRange(f ConnectionFamily, t ConnectionType) (low, hi uint16, err error) {
 	var protoarg string
 	var familyarg string
@@ -119,15 +106,7 @@ func getEphemeralRange(f ConnectionFamily, t ConnectionType) (low, hi uint16, er
 }
 
 func isPortInEphemeralRange(f ConnectionFamily, t ConnectionType, p uint16) EphemeralPortType {
-	rangeLow := ephemeralRanges[f][t]["lo"]
-	rangeHi := ephemeralRanges[f][t]["hi"]
-	if rangeLow == 0 || rangeHi == 0 {
-		return EphemeralUnknown
-	}
-	if p >= rangeLow && p <= rangeHi {
-		return EphemeralTrue
-	}
-	return EphemeralFalse
+	return EphemeralUnknown
 }
 func connFamily(addressFamily uint16) ConnectionFamily {
 	if addressFamily == syscall.AF_INET {

--- a/releasenotes/notes/tempremmovewinephemeral-89bcb327ffacdf64.yaml
+++ b/releasenotes/notes/tempremmovewinephemeral-89bcb327ffacdf64.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+
+fixes:
+  - |
+    On Windows, disables ephemeral port range detection.  Fixes crash on non 
+    EN-US windows


### PR DESCRIPTION
ephemeral range.  Removes implementation which crashes on non-ENUS
windows, to be fixed in later PR

### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

On non-en-us windows, implementation crashes.

### Describe how to test your changes

Start on non-en-us windows; ensure doesn't crash

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x ] The appropriate `team/..` label has been applied, if known.
- [ x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
