### PR TITLE
Make windows always return `unknown` when checking whether port is in

### DIFF
--- a/pkg/network/event_windows.go
+++ b/pkg/network/event_windows.go
@@ -74,19 +74,6 @@ var (
 	}
 )
 
-func init() {
-	var families = [...]ConnectionFamily{AFINET, AFINET6}
-	var protos = [...]ConnectionType{UDP, TCP}
-	for _, f := range families {
-		for _, p := range protos {
-			l, h, err := getEphemeralRange(f, p)
-			if err == nil {
-				ephemeralRanges[f][p]["lo"] = l
-				ephemeralRanges[f][p]["hi"] = h
-			}
-		}
-	}
-}
 func getEphemeralRange(f ConnectionFamily, t ConnectionType) (low, hi uint16, err error) {
 	var protoarg string
 	var familyarg string
@@ -151,15 +138,7 @@ func getEphemeralRange(f ConnectionFamily, t ConnectionType) (low, hi uint16, er
 }
 
 func isPortInEphemeralRange(f ConnectionFamily, t ConnectionType, p uint16) EphemeralPortType {
-	rangeLow := ephemeralRanges[f][t]["lo"]
-	rangeHi := ephemeralRanges[f][t]["hi"]
-	if rangeLow == 0 || rangeHi == 0 {
-		return EphemeralUnknown
-	}
-	if p >= rangeLow && p <= rangeHi {
-		return EphemeralTrue
-	}
-	return EphemeralFalse
+	return EphemeralUnknown
 }
 func connFamily(addressFamily C.uint16_t) ConnectionFamily {
 	if addressFamily == syscall.AF_INET {

--- a/releasenotes/notes/tempremmovewinephemeral-89bcb327ffacdf64.yaml
+++ b/releasenotes/notes/tempremmovewinephemeral-89bcb327ffacdf64.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+
+fixes:
+  - |
+    On Windows, disables ephemeral port range detection.  Fixes crash on non 
+    EN-US windows


### PR DESCRIPTION
ephemeral range.  Removes implementation which crashes on non-ENUS
windows, to be fixed in later PR

### Motivation

Crash on non- EN-US

### Describe how to test your changes

start on non-en-us windows
### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x ] The appropriate `team/..` label has been applied, if known.
- [x ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.

Note: Adding GitHub labels is only possible for contributors with write access.
