### PR TITLE
Fix hostname detection when on-host Agent monitors containerized workloads

### DIFF
--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -237,8 +237,8 @@ func GetHostnameData(ctx context.Context) (HostnameData, error) {
 		}
 	}
 
-	isContainerized, containerName := getContainerHostname(ctx)
-	if isContainerized {
+	if config.IsContainerized() {
+		containerName := getContainerHostname(ctx)
 		if containerName != "" {
 			hostName = containerName
 			provider = "container"

--- a/pkg/util/hostname_docker.go
+++ b/pkg/util/hostname_docker.go
@@ -18,16 +18,14 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func getContainerHostname(ctx context.Context) (bool, string) {
-	var name string
-
+func getContainerHostname(ctx context.Context) string {
 	if config.IsFeaturePresent(config.Kubernetes) {
 		// Cluster-agent logic: Kube apiserver
 		if getKubeHostname, found := hostname.ProviderCatalog["kube_apiserver"]; found {
 			log.Debug("GetHostname trying Kubernetes trough API server...")
 			name, err := getKubeHostname(ctx, nil)
 			if err == nil && validate.ValidHostname(name) == nil {
-				return true, name
+				return name
 			}
 		}
 	}
@@ -38,7 +36,7 @@ func getContainerHostname(ctx context.Context) (bool, string) {
 		if getDockerHostname, found := hostname.ProviderCatalog["docker"]; found {
 			name, err := getDockerHostname(ctx, nil)
 			if err == nil && validate.ValidHostname(name) == nil {
-				return true, name
+				return name
 			}
 		}
 	}
@@ -48,10 +46,10 @@ func getContainerHostname(ctx context.Context) (bool, string) {
 			log.Debug("GetHostname trying Kubernetes trough kubelet API...")
 			name, err := getKubeletHostname(ctx, nil)
 			if err == nil && validate.ValidHostname(name) == nil {
-				return true, name
+				return name
 			}
 		}
 	}
 
-	return false, name
+	return ""
 }

--- a/releasenotes/notes/fix-container-hostname-on-host-87b3cb8f3a5faa94.yaml
+++ b/releasenotes/notes/fix-container-hostname-on-host-87b3cb8f3a5faa94.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix hostname detection when Agent is running on-host and monitoring containerized workload by not using hostname coming from containerized providers (Docker, Kubernetes)


### PR DESCRIPTION
### What does this PR do?

Fix hostname detection when Agent is running on-host and monitoring containerized workload by not using hostname coming from containerized providers (Docker, Kubernetes).

### Motivation

Bugfix

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Install the Agent (on-host) on a host running Docker. Allow Agent user to access `docker.sock`. Check the hostname provider used by the Agent: it should NOT be `container`.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
