### PR TITLE
Add support for non-English windows netsh

### DIFF
--- a/pkg/network/event_windows.go
+++ b/pkg/network/event_windows.go
@@ -3,56 +3,54 @@
 package network
 
 import (
-	"bytes"
 	"fmt"
 	"net"
 	"os/exec"
 	"regexp"
 	"strconv"
+	"sync"
 	"syscall"
 
 	"github.com/DataDog/datadog-agent/pkg/network/driver"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 )
 
-var (
-	ephemeralRanges = map[ConnectionFamily]map[ConnectionType]map[string]uint16{
-		AFINET: {
-			UDP: {
-				"lo": 0,
-				"hi": 0,
-			},
-			TCP: {
-				"lo": 0,
-				"hi": 0,
-			},
-		},
-		AFINET6: {
-			UDP: {
-				"lo": 0,
-				"hi": 0,
-			},
-			TCP: {
-				"lo": 0,
-				"hi": 0,
-			},
-		},
-	}
+type portRangeEndpoint int
+
+const (
+	low  portRangeEndpoint = 1
+	high portRangeEndpoint = 2
 )
 
-func init() {
+var (
+	ephemeralRanges = map[ConnectionFamily]map[ConnectionType]map[portRangeEndpoint]uint16{
+		AFINET: {
+			UDP: {low: 0, high: 0},
+			TCP: {low: 0, high: 0},
+		},
+		AFINET6: {
+			UDP: {low: 0, high: 0},
+			TCP: {low: 0, high: 0},
+		},
+	}
+	rangeGetOnce = sync.Once{}
+	netshRegexp  = regexp.MustCompile(`^.*:\s+(\d+)$`)
+)
+
+func getEphemeralRanges() {
 	var families = [...]ConnectionFamily{AFINET, AFINET6}
 	var protos = [...]ConnectionType{UDP, TCP}
 	for _, f := range families {
 		for _, p := range protos {
 			l, h, err := getEphemeralRange(f, p)
 			if err == nil {
-				ephemeralRanges[f][p]["lo"] = l
-				ephemeralRanges[f][p]["hi"] = h
+				ephemeralRanges[f][p][low] = l
+				ephemeralRanges[f][p][high] = h
 			}
 		}
 	}
 }
+
 func getEphemeralRange(f ConnectionFamily, t ConnectionType) (low, hi uint16, err error) {
 	var protoarg string
 	var familyarg string
@@ -68,8 +66,14 @@ func getEphemeralRange(f ConnectionFamily, t ConnectionType) (low, hi uint16, er
 	default:
 		protoarg = "udp"
 	}
-	cmd := exec.Command("netsh", "int", familyarg, "show", "dynamicport", protoarg)
-	cmdOutput := &bytes.Buffer{}
+	output, err := exec.Command("netsh", "int", familyarg, "show", "dynamicport", protoarg).Output()
+	if err != nil {
+		return 0, 0, err
+	}
+	return parseNetshOutput(string(output))
+}
+
+func parseNetshOutput(output string) (low, hi uint16, err error) {
 	// output should be of the format
 	/*
 		Protocol tcp Dynamic Port Range
@@ -77,50 +81,28 @@ func getEphemeralRange(f ConnectionFamily, t ConnectionType) (low, hi uint16, er
 		Start Port      : 49000
 		Number of Ports : 16000
 	*/
-	cmd.Stdout = cmdOutput
-	err = cmd.Run()
-	if err != nil {
-		return
-	}
-	output := cmdOutput.Bytes()
-	var r = regexp.MustCompile(`.*: (\d+)`)
-
-	matches := r.FindAllStringSubmatch(string(output), -1)
+	matches := netshRegexp.FindAllStringSubmatch(output, -1)
 	if len(matches) != 2 {
-		err = fmt.Errorf("could not parse output of netsh")
-		return
+		return 0, 0, fmt.Errorf("could not parse output of netsh")
 	}
-
 	portstart, err := strconv.Atoi(matches[0][1])
 	if err != nil {
-		return
+		return 0, 0, err
 	}
 	plen, err := strconv.Atoi(matches[1][1])
 	if err != nil {
-		return
+		return 0, 0, err
 	}
-	// argh.  Windows defaults to
-	/*
-	 Protocol tcp Dynamic Port Range
-	 ---------------------------------
-	 Start Port      : 49152
-	 Number of Ports : 16384
-
-	 A quick bit of arithmetic says that adds up to 65536, which overflows the "hi" field.
-	 A bit of hackery to compensate
-	*/
 	low = uint16(portstart)
-	if portstart+plen > 0xFFFF {
-		hi = uint16(0xFFFF)
-	} else {
-		hi = uint16(portstart + plen)
-	}
-	return
+	hi = uint16(portstart + plen - 1)
+	return low, hi, nil
 }
 
 func isPortInEphemeralRange(f ConnectionFamily, t ConnectionType, p uint16) EphemeralPortType {
-	rangeLow := ephemeralRanges[f][t]["lo"]
-	rangeHi := ephemeralRanges[f][t]["hi"]
+	rangeGetOnce.Do(getEphemeralRanges)
+
+	rangeLow := ephemeralRanges[f][t][low]
+	rangeHi := ephemeralRanges[f][t][high]
 	if rangeLow == 0 || rangeHi == 0 {
 		return EphemeralUnknown
 	}
@@ -129,6 +111,7 @@ func isPortInEphemeralRange(f ConnectionFamily, t ConnectionType, p uint16) Ephe
 	}
 	return EphemeralFalse
 }
+
 func connFamily(addressFamily uint16) ConnectionFamily {
 	if addressFamily == syscall.AF_INET {
 		return AFINET

--- a/pkg/network/event_windows.go
+++ b/pkg/network/event_windows.go
@@ -34,7 +34,7 @@ var (
 		},
 	}
 	rangeGetOnce = sync.Once{}
-	netshRegexp  = regexp.MustCompile(`^.*:\s+(\d+)$`)
+	netshRegexp  = regexp.MustCompile(`.*: (\d+)`)
 )
 
 func getEphemeralRanges() {

--- a/pkg/network/event_windows_test.go
+++ b/pkg/network/event_windows_test.go
@@ -13,6 +13,7 @@ Protocol tcp Dynamic Port Range
 Start Port      : 49152
 Number of Ports : 16384`
 
+//nolint:misspell
 var frenchOut = `
 Plage de ports dynamique du protocole tcp
 ---------------------------------

--- a/pkg/network/event_windows_test.go
+++ b/pkg/network/event_windows_test.go
@@ -1,0 +1,36 @@
+package network
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+var englishOut = `
+Protocol tcp Dynamic Port Range
+---------------------------------
+Start Port      : 49152
+Number of Ports : 16384`
+
+var frenchOut = `
+Plage de ports dynamique du protocole tcp
+---------------------------------
+Port de démarrage   : 49152
+Nombre de ports     : 16384
+`
+
+func TestNetshParse(t *testing.T) {
+	t.Run("english", func(t *testing.T) {
+		low, hi, err := parseNetshOutput(englishOut)
+		require.NoError(t, err)
+		assert.Equal(t, 49152, low)
+		assert.Equal(t, 65535, hi)
+	})
+	t.Run("french", func(t *testing.T) {
+		low, hi, err := parseNetshOutput(frenchOut)
+		require.NoError(t, err)
+		assert.Equal(t, 49152, low)
+		assert.Equal(t, 65535, hi)
+	})
+}

--- a/pkg/network/event_windows_test.go
+++ b/pkg/network/event_windows_test.go
@@ -1,4 +1,3 @@
-//nolint:misspell
 package network
 
 import (

--- a/pkg/network/event_windows_test.go
+++ b/pkg/network/event_windows_test.go
@@ -1,3 +1,4 @@
+//nolint:misspell
 package network
 
 import (
@@ -13,7 +14,6 @@ Protocol tcp Dynamic Port Range
 Start Port      : 49152
 Number of Ports : 16384`
 
-//nolint:misspell
 var frenchOut = `
 Plage de ports dynamique du protocole tcp
 ---------------------------------

--- a/pkg/network/event_windows_test.go
+++ b/pkg/network/event_windows_test.go
@@ -24,13 +24,13 @@ func TestNetshParse(t *testing.T) {
 	t.Run("english", func(t *testing.T) {
 		low, hi, err := parseNetshOutput(englishOut)
 		require.NoError(t, err)
-		assert.Equal(t, 49152, low)
-		assert.Equal(t, 65535, hi)
+		assert.Equal(t, uint16(49152), low)
+		assert.Equal(t, uint16(65535), hi)
 	})
 	t.Run("french", func(t *testing.T) {
 		low, hi, err := parseNetshOutput(frenchOut)
 		require.NoError(t, err)
-		assert.Equal(t, 49152, low)
-		assert.Equal(t, 65535, hi)
+		assert.Equal(t, uint16(49152), low)
+		assert.Equal(t, uint16(65535), hi)
 	})
 }

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -48,6 +48,7 @@ MISSPELL_IGNORED_TARGETS = [
     os.path.join("cmd", "agent", "gui", "views", "private"),
     os.path.join("pkg", "collector", "corechecks", "system", "testfiles"),
     os.path.join("pkg", "ebpf", "testdata"),
+    os.path.join("pkg", "network", "event_windows_test.go"),
 ]
 
 # Packages that need go:generate


### PR DESCRIPTION
### What does this PR do?

Changes the parser to obtain ephemeral ports to not depend on english language strings. It now also only runs the commands on-demand, rather than always on startup.

### Motivation

Panic on startup in 7.30.0 on non-english hosts.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.