### PR TITLE
[kitchen] Skip signing keys package check on Windows

### DIFF
--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -493,9 +493,10 @@ end
 
 shared_examples_for "an installed Datadog Signing Keys" do
   it 'is installed (on Debian-based systems)' do
-    if has_dpkg # Only check on Debian-based systems, which have dpkg installed
-      expect(is_dpkg_package_installed('datadog-signing-keys')).to be_truthy
-    end
+    skip if os == :windows
+    skip unless has_dpkg
+    # Only check on Debian-based systems, which have dpkg installed
+    expect(is_dpkg_package_installed('datadog-signing-keys')).to be_truthy
   end
 end
 


### PR DESCRIPTION
### What does this PR do?

Skips the check which checks the presence of the `datadog-signing-keys` package on Windows.

### Motivation

Running that test made the Windows kitchen tests fail, even though the current logic was supposed to not fail on Windows.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Successful Windows kitchen tests.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
