### PR TITLE
Explicitly set empty string for question if not collecting DNS domains

### DIFF
--- a/pkg/network/dns/parser.go
+++ b/pkg/network/dns/parser.go
@@ -190,6 +190,8 @@ func (p *dnsParser) parseAnswerInto(
 		pktInfo.queryType = QueryType(question.Type)
 		if p.collectDNSDomains {
 			pktInfo.question = intern.GetByString(string(question.Name))
+		} else {
+			pktInfo.question = intern.GetByString("")
 		}
 		return nil
 	}


### PR DESCRIPTION
### What does this PR do?

If not collecting DNS domains, set question to interned empty string

### Motivation

Fix kitchen test failures in `main`

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
