### PR TITLE
[agent][process-agent][dca] Split common config command to own package and fix deprecated flags

### DIFF
--- a/cmd/agent/app/config.go
+++ b/cmd/agent/app/config.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/app/settings"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
-	"github.com/DataDog/datadog-agent/cmd/agent/common/commands"
+	cmdconfig "github.com/DataDog/datadog-agent/cmd/agent/common/commands/config"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	commonsettings "github.com/DataDog/datadog-agent/pkg/config/settings"
@@ -19,7 +19,7 @@ import (
 )
 
 func init() {
-	AgentCmd.AddCommand(commands.Config(getSettingsClient))
+	AgentCmd.AddCommand(cmdconfig.Config(getSettingsClient))
 }
 
 func setupConfig() error {

--- a/cmd/agent/common/commands/config/config.go
+++ b/cmd/agent/common/commands/config/config.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package commands
+package config
 
 import (
 	"fmt"

--- a/cmd/cluster-agent/app/config.go
+++ b/cmd/cluster-agent/app/config.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
-	"github.com/DataDog/datadog-agent/cmd/agent/common/commands"
+	cmdconfig "github.com/DataDog/datadog-agent/cmd/agent/common/commands/config"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	commonsettings "github.com/DataDog/datadog-agent/pkg/config/settings"
@@ -21,7 +21,7 @@ import (
 )
 
 func init() {
-	ClusterAgentCmd.AddCommand(commands.Config(getSettingsClient))
+	ClusterAgentCmd.AddCommand(cmdconfig.Config(getSettingsClient))
 }
 
 func setupConfig() error {

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	_ "net/http/pprof"
 	"os"
+	"strings"
 	"time"
 
 	cmdconfig "github.com/DataDog/datadog-agent/cmd/agent/common/commands/config"
@@ -96,16 +97,19 @@ func init() {
 // fixDeprecatedFlags modifies os.Args so that non-posix flags are converted to posix flags
 // it also displays a warning when a non-posix flag is found
 func fixDeprecatedFlags() {
-	deprecatedFlags := map[string]struct{}{
+	deprecatedFlags := []string{
 		// Global flags
-		"-config": {}, "-ddconfig": {}, "-sysprobe-config": {}, "-pid": {}, "-info": {}, "-version": {}, "-check": {},
+		"-config", "-ddconfig", "-sysprobe-config", "-pid", "-info", "-version", "-check",
 		// Windows flags
-		"-install-service": {}, "-uninstall-service": {}, "-start-service": {}, "-stop-service": {}, "-foreground": {},
+		"-install-service", "-uninstall-service", "-start-service", "-stop-service", "-foreground",
 	}
 
-	for i, a := range os.Args {
-		if _, ok := deprecatedFlags[a]; ok {
-			fmt.Printf("WARNING: `%s` argument is deprecated and will be removed in a future version. Please use `-%[1]s` instead.\n", a)
+	for i, arg := range os.Args {
+		for _, f := range deprecatedFlags {
+			if !strings.HasPrefix(arg, f) {
+				continue
+			}
+			fmt.Printf("WARNING: `%s` argument is deprecated and will be removed in a future version. Please use `-%[1]s` instead.\n", f)
 			os.Args[i] = "-" + os.Args[i]
 		}
 	}

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -286,12 +286,13 @@ func runAgent(exit chan struct{}) {
 		if err != nil && err != http.ErrServerClosed {
 			log.Errorf("Error creating expvar server on port %v: %v", cfg.ProcessExpVarPort, err)
 		}
-
-		err = api.StartServer()
-		if err != nil {
-			_ = log.Error(err)
-		}
 	}()
+
+	// Run API server
+	err = api.StartServer()
+	if err != nil {
+		_ = log.Error(err)
+	}
 
 	cl, err := NewCollector(cfg)
 	if err != nil {

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"time"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/common/commands"
+	cmdconfig "github.com/DataDog/datadog-agent/cmd/agent/common/commands/config"
 	"github.com/DataDog/datadog-agent/cmd/manager"
 	"github.com/DataDog/datadog-agent/cmd/process-agent/api"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
@@ -69,7 +69,7 @@ var (
 		},
 	}
 
-	configCommand = commands.Config(getSettingsClient)
+	configCommand = cmdconfig.Config(getSettingsClient)
 )
 
 func getSettingsClient() (settings.Client, error) {


### PR DESCRIPTION
### What does this PR do?

- Follow up to https://github.com/DataDog/datadog-agent/pull/8912 and https://github.com/DataDog/datadog-agent/pull/8899.
- Split `config` command to its own package to avoid dependency on `pkg/collector/python`.
- Addresses the issue with broken Windows build (`windows_zip_agent_binaries_x64` job).
- Fix handling of deprecated flags when they contain `=`, e.g. `-config=<path-to-config-file>` (e.g. in [helm install](https://github.com/DataDog/helm-charts/blob/main/charts/datadog/templates/_container-process-agent.yaml#L9)).
- Fix the new `config get/set` in the `process-agent`- `api.StartServer()` was never called (`http.ListenAndServe` is blocking`).

### Motivation

Fixing Windows build and handling of deprecated flags in the process agent.

### Describe how to test your changes

Since the `cmd/agent/common/commands` package is shared, these changes affect:
- core agent
- cluster agent
- process agent

The correct functioning of the config command should be tested in all three agents.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
