### PR TITLE
Rework tagging of rc images

### DIFF
--- a/.gitlab/deploy_6/docker.yml
+++ b/.gitlab/deploy_6/docker.yml
@@ -19,9 +19,9 @@
   dependencies: []
   script:
     - python3 -m pip install -r requirements.txt
-    - export VERSION="$(inv -e agent.version --major-version 6 --url-safe)"
+    - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv -e agent.version --major-version 6 --url-safe); fi"
     - export IMG_SOURCES="${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6${JMX}-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6${JMX}-arm64"
-    - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}${IMG_TAG_SUFFIX}${JMX}"
+    - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}${JMX}"
     - inv pipeline.trigger-child-pipeline --project-name "DataDog/public-images" --git-ref "main" --variables "IMG_REGISTRIES,IMG_SOURCES,IMG_DESTINATIONS"
   parallel:
     matrix:
@@ -37,7 +37,7 @@ deploy-a6:
 deploy-a6-rc:
   extends: .deploy-a6-base
   variables:
-    IMG_TAG_SUFFIX: -rc
+    VERSION: 6-rc
 
 
 #

--- a/.gitlab/deploy_7/docker.yml
+++ b/.gitlab/deploy_7/docker.yml
@@ -19,11 +19,11 @@
   dependencies: []
   script:
     - python3 -m pip install -r requirements.txt
-    - export VERSION="$(inv -e agent.version --major-version 7 --url-safe)"
+    - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv -e agent.version --major-version 7 --url-safe); fi"
     - export IMG_LINUX_SOURCES="${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7${JMX}-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7${JMX}-arm64"
     - export IMG_WINDOWS_SOURCES="${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7${JMX}-win1809${SERVERCORE}-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7${JMX}-win1909${SERVERCORE}-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7${JMX}-win2004${SERVERCORE}-amd64"
     - if [[ "$SERVERCORE" == "-servercore" ]]; then export IMG_SOURCES="${IMG_WINDOWS_SOURCES}"; else export IMG_SOURCES="${IMG_LINUX_SOURCES},${IMG_WINDOWS_SOURCES}"; fi
-    - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}{$IMG_TAG_SUFFIX}${SERVERCORE}${JMX}"
+    - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}${SERVERCORE}${JMX}"
     - inv pipeline.trigger-child-pipeline --project-name "DataDog/public-images" --git-ref "main" --variables "IMG_REGISTRIES,IMG_SOURCES,IMG_DESTINATIONS"
   parallel:
     matrix:
@@ -42,7 +42,7 @@ deploy-a7:
 deploy-a7-rc:
   extends: .deploy-a7-base
   variables:
-    IMG_TAG_SUFFIX: -rc
+    VERSION: 7-rc
 
 
 deploy-dogstatsd:


### PR DESCRIPTION
### What does this PR do?

The previous version actually appended `-rc` to a full version, so we'd
end up with `7.31.0-rc.0-rc`, while we actually wanted `7-rc` instead.

### Describe how to test your changes

Same as #8721.