### PR TITLE
[networks] Add configuration flag for HTTPS (via OpenSSL) monitoring

### DIFF
--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -118,6 +118,7 @@ func InitSystemProbeConfig(cfg Config) {
 
 	// network_config namespace only
 	cfg.BindEnvAndSetDefault(join(netNS, "enable_http_monitoring"), false, "DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTP_MONITORING")
+	cfg.BindEnvAndSetDefault(join(netNS, "enable_https_monitoring"), false, "DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTPS_MONITORING")
 	cfg.BindEnvAndSetDefault(join(netNS, "enable_gateway_lookup"), false, "DD_SYSTEM_PROBE_NETWORK_ENABLE_GATEWAY_LOOKUP")
 
 	// list of DNS query types to be recorded

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -59,6 +59,10 @@ type Config struct {
 	// EnableHTTPMonitoring specifies whether the tracer should monitor HTTP traffic
 	EnableHTTPMonitoring bool
 
+	// EnableHTTPMonitoring specifies whether the tracer should monitor HTTPS traffic
+	// Supported libraries: OpenSSL
+	EnableHTTPSMonitoring bool
+
 	// UDPConnTimeout determines the length of traffic inactivity between two
 	// (IP, port)-pairs before declaring a UDP connection as inactive. This is
 	// set to /proc/sys/net/netfilter/nf_conntrack_udp_timeout on Linux by
@@ -186,8 +190,9 @@ func New() *Config {
 		MaxDNSStatsBuffered: 75000,
 		DNSTimeout:          time.Duration(cfg.GetInt(join(spNS, "dns_timeout_in_s"))) * time.Second,
 
-		EnableHTTPMonitoring: cfg.GetBool(join(netNS, "enable_http_monitoring")),
-		MaxHTTPStatsBuffered: 100000,
+		EnableHTTPMonitoring:  cfg.GetBool(join(netNS, "enable_http_monitoring")),
+		EnableHTTPSMonitoring: cfg.GetBool(join(netNS, "enable_https_monitoring")),
+		MaxHTTPStatsBuffered:  100000,
 
 		EnableConntrack:              cfg.GetBool(join(spNS, "enable_conntrack")),
 		ConntrackMaxStateSize:        cfg.GetInt(join(spNS, "conntrack_max_state_size")),

--- a/pkg/network/http/ebpf_main.go
+++ b/pkg/network/http/ebpf_main.go
@@ -106,11 +106,13 @@ func newEBPFProgram(c *config.Config, offsets []manager.ConstantEditor, sockFD *
 		sockFDMap:   sockFD,
 	}
 
-	sharedLibraries := findOpenSSLLibraries(c.ProcRoot)
-	var subprograms []subprogram
-	subprograms = append(subprograms, createSSLPrograms(program, offsets, sharedLibraries)...)
-	subprograms = append(subprograms, createCryptoPrograms(program, sharedLibraries)...)
-	program.subprograms = subprograms
+	if c.EnableHTTPSMonitoring {
+		sharedLibraries := findOpenSSLLibraries(c.ProcRoot)
+		var subprograms []subprogram
+		subprograms = append(subprograms, createSSLPrograms(program, offsets, sharedLibraries)...)
+		subprograms = append(subprograms, createCryptoPrograms(program, sharedLibraries)...)
+		program.subprograms = subprograms
+	}
 
 	return program, nil
 }

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1519,6 +1519,7 @@ func TestHTTPSViaOpenSSLIntegration(t *testing.T) {
 	// Start tracer with HTTPS support
 	cfg := testConfig()
 	cfg.EnableHTTPMonitoring = true
+	cfg.EnableHTTPSMonitoring = true
 	tr, err := NewTracer(cfg)
 	require.NoError(t, err)
 	defer tr.Stop()


### PR DESCRIPTION
### What does this PR do?

Add configuration flag for HTTPS (via OpenSSL) monitoring

### Motivation

The OpenSSL instrumentation is an experimental feature and thus should be proteced by a configuration flag.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

1. Enable HTTPS monitoring flag:
```
network_config:
  enable_http_monitoring: true
  enable_https_monitoring: true
```
2. Make sure your `curl` is linked to OpenSSL: `ldd $(which curl) | grep ssl` 
3. Start system-probe with using the SSL_LIB_PATHS environment variable:
```
sudo SSL_LIB_PATHS="/usr/lib/x86_64-linux-gnu/libssl.so.1.1,/lib/x86_64-linux-gnu/libcrypto.so.1.1" bin/system-probe/system-probe --config=/etc/datadog-agent/system-probe.yaml
```
4. Verify you see log entries similar to:
```
2021-08-23 15:48:47 UTC | SYS-PROBE | DEBUG | (pkg/network/http/ebpf_crypto.go:93 in Init) | https (libcrypto) tracing enabled. library=/usr/lib/x86_64-linux-gnu/libcrypto.so.1.1
2021-08-23 15:48:47 UTC | SYS-PROBE | DEBUG | (pkg/network/http/ebpf_crypto.go:93 in Init) | https (libcrypto) tracing enabled. library=/lib/x86_64-linux-gnu/libcrypto.so.1.1
2021-08-23 15:48:47 UTC | SYS-PROBE | DEBUG | (pkg/network/http/ebpf_crypto.go:93 in Init) | https (libcrypto) tracing enabled. library=/lib/x86_64-linux-gnu/libcrypto.so.1.1
```
5. Now repeat the process  with `enable_https_monitoring: false` and verify the log entries no longer show up

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
