### PR TITLE
[Serverless] add DD_SERVICE support

### DIFF
--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -15,6 +15,7 @@ const (
 	qualifierEnvVar = "AWS_LAMBDA_FUNCTION_VERSION"
 	envEnvVar       = "DD_ENV"
 	versionEnvVar   = "DD_VERSION"
+	serviceEnvVar   = "DD_SERVICE"
 
 	traceOriginMetadataKey   = "_dd.origin"
 	traceOriginMetadataValue = "lambda"
@@ -30,6 +31,7 @@ const (
 	extensionVersionKey      = "dd_extension_version"
 	envKey                   = "env"
 	versionKey               = "version"
+	serviceKey               = "service"
 )
 
 // currentExtensionVersion represents the current version of the Datadog Lambda Extension.
@@ -43,6 +45,7 @@ func BuildTagMap(arn string, configTags []string) map[string]string {
 
 	tags = setIfNotEmpty(tags, envKey, os.Getenv(envEnvVar))
 	tags = setIfNotEmpty(tags, versionKey, os.Getenv(versionEnvVar))
+	tags = setIfNotEmpty(tags, serviceKey, os.Getenv(serviceEnvVar))
 
 	for _, tag := range configTags {
 		splitTags := strings.Split(tag, ",")

--- a/pkg/serverless/tags/tags_test.go
+++ b/pkg/serverless/tags/tags_test.go
@@ -106,17 +106,20 @@ func TestBuildTagMapFromArnComplete(t *testing.T) {
 	assert.Equal(t, "value1", tagMap["tag1"])
 }
 
-func TestBuildTagMapFromArnCompleteWithEnvAndVersion(t *testing.T) {
+func TestBuildTagMapFromArnCompleteWithEnvAndVersionAndService(t *testing.T) {
 	os.Setenv("DD_VERSION", "myTestVersion")
 	defer os.Unsetenv("DD_VERSION")
 	os.Setenv("DD_ENV", "myTestEnv")
 	defer os.Unsetenv("DD_ENV")
+	os.Setenv("DD_SERVICE", "myTestService")
+	defer os.Unsetenv("DD_SERVICE")
 
 	arn := "arn:aws:lambda:us-east-1:123456789012:function:my-function"
 	tagMap := BuildTagMap(arn, []string{"tag0:value0", "TAG1:VALUE1"})
-	assert.Equal(t, 13, len(tagMap))
+	assert.Equal(t, 14, len(tagMap))
 	assert.Equal(t, "mytestenv", tagMap["env"])
 	assert.Equal(t, "mytestversion", tagMap["version"])
+	assert.Equal(t, "mytestservice", tagMap["service"])
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
 	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])


### PR DESCRIPTION
### What does this PR do?

DD_SERVICE had inconsistent behaviour over runtimes. By setting it at the extension level, we're sure that this tag will be applied.

### Motivation

Consistency 

### Describe how to test your changes

unit + integration tests

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
