### PR TITLE
[Serverless] Set specific origin for log intake

### DIFF
--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -36,6 +36,9 @@ const DefaultIntakeProtocol IntakeProtocol = ""
 // DefaultIntakeOrigin indicates that no special DD_SOURCE header is in use for the endpoint intake track type.
 const DefaultIntakeOrigin IntakeOrigin = "agent"
 
+// ServerlessIntakeOrigin is the lambda extension origin
+const ServerlessIntakeOrigin IntakeOrigin = "lambda-extension"
+
 // logs-intake endpoints depending on the site and environment.
 var logsEndpoints = map[string]int{
 	"agent-intake.logs.datadoghq.com": 10516,
@@ -130,9 +133,9 @@ func BuildEndpointsWithConfig(logsConfig *LogsConfigKeys, endpointPrefix string,
 }
 
 // BuildServerlessEndpoints returns the endpoints to send logs for the Serverless agent.
-func BuildServerlessEndpoints(intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeOrigin IntakeOrigin) (*Endpoints, error) {
+func BuildServerlessEndpoints(intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol) (*Endpoints, error) {
 	coreConfig.SanitizeAPIKeyConfig(coreConfig.Datadog, "logs_config.api_key")
-	return BuildHTTPEndpointsWithConfig(defaultLogsConfigKeys(), serverlessHTTPEndpointPrefix, intakeTrackType, intakeProtocol, intakeOrigin)
+	return BuildHTTPEndpointsWithConfig(defaultLogsConfigKeys(), serverlessHTTPEndpointPrefix, intakeTrackType, intakeProtocol, ServerlessIntakeOrigin)
 }
 
 // ExpectedTagsDuration returns a duration of the time expected tags will be submitted for.

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -511,7 +511,7 @@ func (suite *ConfigTestSuite) TestBuildServerlessEndpoints() {
 			RecoveryInterval: coreConfig.DefaultLogsSenderBackoffRecoveryInterval,
 			Version:          EPIntakeVersion2,
 			TrackType:        "test-track",
-			Origin:           "test-source",
+			Origin:           "lambda-extension",
 			Protocol:         "test-proto",
 		},
 		BatchMaxSize:           coreConfig.DefaultBatchMaxSize,
@@ -519,7 +519,7 @@ func (suite *ConfigTestSuite) TestBuildServerlessEndpoints() {
 		BatchMaxConcurrentSend: coreConfig.DefaultBatchMaxConcurrentSend,
 	}
 
-	endpoints, err := BuildServerlessEndpoints("test-track", "test-proto", "test-source")
+	endpoints, err := BuildServerlessEndpoints("test-track", "test-proto")
 
 	suite.Nil(err)
 	suite.Equal(expectedEndpoints, endpoints)

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -59,7 +59,7 @@ func StartServerless(getAC func() *autodiscovery.AutoConfig, logsChan chan *conf
 // buildEndpoints builds endpoints for the logs agent
 func buildEndpoints(serverless bool) (*config.Endpoints, error) {
 	if serverless {
-		return config.BuildServerlessEndpoints(intakeTrackType, config.DefaultIntakeProtocol, config.DefaultIntakeOrigin)
+		return config.BuildServerlessEndpoints(intakeTrackType, config.DefaultIntakeProtocol)
 	}
 	httpConnectivity := config.HTTPConnectivityFailure
 	if endpoints, err := config.BuildHTTPEndpoints(intakeTrackType, intakeProtocol, config.DefaultIntakeOrigin); err == nil {

--- a/pkg/logs/logs_test.go
+++ b/pkg/logs/logs_test.go
@@ -15,6 +15,7 @@ func TestBuildServerlessEndpoints(t *testing.T) {
 	endpoints, err := buildEndpoints(true)
 	assert.Nil(t, err)
 	assert.Equal(t, "lambda-http-intake.logs.datadoghq.com", endpoints.Main.Host)
+	assert.Equal(t, "lambda-extension", string(endpoints.Main.Origin))
 }
 
 func TestBuildEndpoints(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Set a specific origin for log intake in a serverless environment

### Describe how to test your changes

Unit testing + deployed a function on AWS

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
