### PR TITLE
Add checks' version to the log line indicating when runs occur

### DIFF
--- a/pkg/collector/python/check.go
+++ b/pkg/collector/python/check.go
@@ -78,7 +78,7 @@ func (c *PythonCheck) runCheck(commitMetrics bool) error {
 	}
 	defer gstate.unlock()
 
-	log.Debugf("Running python check %s %s", c.ModuleName, c.id)
+	log.Debugf("Running python check %s version %s with ID %s", c.ModuleName, c.version, c.id)
 
 	cResult := C.run_check(rtloader, c.instance)
 	if cResult == nil {

--- a/pkg/collector/python/check.go
+++ b/pkg/collector/python/check.go
@@ -78,7 +78,7 @@ func (c *PythonCheck) runCheck(commitMetrics bool) error {
 	}
 	defer gstate.unlock()
 
-	log.Debugf("Running python check %s version %s with ID %s", c.ModuleName, c.version, c.id)
+	log.Debugf("Running python check %s (version: '%s', id: '%s')", c.ModuleName, c.version, c.id)
 
 	cResult := C.run_check(rtloader, c.instance)
 	if cResult == nil {


### PR DESCRIPTION
### Motivation

Occasionally, customers disable checks before flares are sent and therefore the version cannot be seen on the status page