### PR TITLE
Silenced config client and nil logs

### DIFF
--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	cmdconfig "github.com/DataDog/datadog-agent/cmd/agent/common/commands/config"
 	"github.com/DataDog/datadog-agent/cmd/manager"
 	"github.com/DataDog/datadog-agent/cmd/process-agent/api"
@@ -79,12 +78,16 @@ func getSettingsClient() (settings.Client, error) {
 	// We set this up differently from the main process-agent because this way is quieter
 	cfg := config.NewDefaultAgentConfig(false)
 	if opts.configPath != "" {
-		err := common.SetupConfigWithoutSecrets(opts.configPath, "")
+		ddconfig.Datadog.SetConfigFile(opts.configPath)
+		err := ddconfig.Datadog.ReadInConfig()
 		if err != nil {
-			return nil, fmt.Errorf("unable to set up global agent configuration: %v", err)
+			return nil, err
 		}
 	}
-	_ = cfg.LoadProcessYamlConfig(opts.configPath)
+	err := cfg.LoadProcessYamlConfig(opts.configPath)
+	if err != nil {
+		return nil, err
+	}
 
 	httpClient := apiutil.GetClient(false)
 	ipcAddress, err := ddconfig.GetIPCAddress()

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -84,7 +84,7 @@ func getSettingsClient() (settings.Client, error) {
 			return nil, fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}
 	}
-	cfg.LoadProcessYamlConfig(opts.configPath)
+	_ = cfg.LoadProcessYamlConfig(opts.configPath)
 
 	httpClient := apiutil.GetClient(false)
 	ipcAddress, err := ddconfig.GetIPCAddress()

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -78,9 +78,7 @@ func getSettingsClient() (settings.Client, error) {
 	// We set this up differently from the main process-agent because this way is quieter
 	cfg := config.NewDefaultAgentConfig(false)
 	if opts.configPath != "" {
-		ddconfig.Datadog.SetConfigFile(opts.configPath)
-		err := ddconfig.Datadog.ReadInConfig()
-		if err != nil {
+		if err := config.LoadConfigIfExists(opts.configPath); err != nil {
 			return nil, err
 		}
 	}

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -255,7 +255,9 @@ func NewDefaultAgentConfig(canAccessContainers bool) *AgentConfig {
 	return ac
 }
 
-func loadConfigIfExists(path string) error {
+// LoadConfigIfExists takes a path to either a directory containing datadog.yaml or a direct path to a datadog.yaml file
+// and loads it into ddconfig.Datadog. It does this silently, and does not produce any logs.
+func LoadConfigIfExists(path string) error {
 	if path != "" {
 		if util.PathExists(path) {
 			config.Datadog.AddConfigPath(path)
@@ -281,7 +283,7 @@ func NewAgentConfig(loggerName config.LoggerName, yamlPath, netYamlPath string) 
 	var err error
 
 	// For Agent 6 we will have a YAML config file to use.
-	if err := loadConfigIfExists(yamlPath); err != nil {
+	if err := LoadConfigIfExists(yamlPath); err != nil {
 		return nil, err
 	}
 

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -385,7 +385,7 @@ func initRuntimeSettings() {
 
 	// Before we begin listening, register runtime settings
 	for _, setting := range processRuntimeSettings {
-		settings.RegisterRuntimeSetting(setting)
+		_ = settings.RegisterRuntimeSetting(setting)
 	}
 }
 

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -171,8 +171,6 @@ func NewDefaultTransport() *http.Transport {
 
 // NewDefaultAgentConfig returns an AgentConfig with defaults initialized
 func NewDefaultAgentConfig(canAccessContainers bool) *AgentConfig {
-	initRuntimeSettings()
-
 	processEndpoint, err := url.Parse(defaultProcessEndpoint)
 	if err != nil {
 		// This is a hardcoded URL so parsing it should not fail
@@ -385,7 +383,10 @@ func initRuntimeSettings() {
 
 	// Before we begin listening, register runtime settings
 	for _, setting := range processRuntimeSettings {
-		_ = settings.RegisterRuntimeSetting(setting)
+		err := settings.RegisterRuntimeSetting(setting)
+		if err != nil {
+			_ = log.Warnf("cannot initialize the runtime settings: %v", err)
+		}
 	}
 }
 

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/config/settings"
 	"net"
 	"net/http"
 	"net/url"
@@ -19,6 +18,7 @@ import (
 	model "github.com/DataDog/agent-payload/process"
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/config/settings"
 	oconfig "github.com/DataDog/datadog-agent/pkg/orchestrator/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	apicfg "github.com/DataDog/datadog-agent/pkg/process/util/api/config"
@@ -171,6 +171,8 @@ func NewDefaultTransport() *http.Transport {
 
 // NewDefaultAgentConfig returns an AgentConfig with defaults initialized
 func NewDefaultAgentConfig(canAccessContainers bool) *AgentConfig {
+	initRuntimeSettings()
+
 	processEndpoint, err := url.Parse(defaultProcessEndpoint)
 	if err != nil {
 		// This is a hardcoded URL so parsing it should not fail
@@ -383,7 +385,7 @@ func initRuntimeSettings() {
 
 	// Before we begin listening, register runtime settings
 	for _, setting := range processRuntimeSettings {
-		_ = log.Warn(settings.RegisterRuntimeSetting(setting))
+		settings.RegisterRuntimeSetting(setting)
 	}
 }
 

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -278,8 +278,6 @@ func LoadConfigIfExists(path string) error {
 // NewAgentConfig returns an AgentConfig using a configuration file. It can be nil
 // if there is no file available. In this case we'll configure only via environment.
 func NewAgentConfig(loggerName config.LoggerName, yamlPath, netYamlPath string) (*AgentConfig, error) {
-	initRuntimeSettings()
-
 	var err error
 
 	// For Agent 6 we will have a YAML config file to use.
@@ -373,6 +371,8 @@ func NewAgentConfig(loggerName config.LoggerName, yamlPath, netYamlPath string) 
 		}
 	}
 
+	initRuntimeSettings()
+
 	return cfg, nil
 }
 
@@ -387,7 +387,7 @@ func initRuntimeSettings() {
 	for _, setting := range processRuntimeSettings {
 		err := settings.RegisterRuntimeSetting(setting)
 		if err != nil {
-			_ = log.Warnf("cannot initialize the runtime settings: %v", err)
+			_ = log.Warnf("cannot initialize the runtime setting %s: %v", setting.Name(), err)
 		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Fixes an error that causes process-agent to print out nil logs, and silences the config client.

This is intended to be a patch for https://github.com/DataDog/datadog-agent/pull/8912

### Motivation

There was an extra log called in config.go for nil errors and it produced unnecessary messages in the terminal. Additionally, the extra output from the core agent 

### Additional Notes

When testing make sure that the config client does not print any logs. (Regular stdout is fine, however)

Behavior should be the same on all platforms, so it is fine to test this locally.

### Describe how to test your changes

1. Run process-agent and make sure that there are no logs containing just `<nil>`
2. Run `process-agent config get_log level` to ensure it connects to the server.
3. Create a datadog.yaml file and put this in it:
```
process_config:
  enabled: "true"
  cmd_port: 12312
```
4. Run `process-agent --config datadog.yaml config get log_level` and ensure it *fails* to connect using the port 12312
5. Run `DD_PROCESS_AGENT_CMD_PORT=32132 process-agent config get log_level` and ensure it *fails* to connect using the port 32132
6. Run `DD_PROCESS_AGENT_CMD_PORT=32132 process-agent --config datadog.yaml config get log_level` and ensure it *fails* to connect using the port 32132.

