### PR TITLE
Fix metrics on missing cgroup files

### DIFF
--- a/pkg/collector/corechecks/containers/docker/docker.go
+++ b/pkg/collector/corechecks/containers/docker/docker.go
@@ -349,10 +349,22 @@ func (d *DockerCheck) reportCPUMetrics(cpu *cmetrics.ContainerCPUStats, limits *
 		return
 	}
 
-	sender.Rate("docker.cpu.system", cpu.System, "", tags)
-	sender.Rate("docker.cpu.user", cpu.User, "", tags)
-	sender.Rate("docker.cpu.usage", cpu.UsageTotal, "", tags)
-	sender.Gauge("docker.cpu.shares", cpu.Shares, "", tags)
+	if cpu.System != -1 {
+		sender.Rate("docker.cpu.system", cpu.System, "", tags)
+	}
+
+	if cpu.User != -1 {
+		sender.Rate("docker.cpu.user", cpu.User, "", tags)
+	}
+
+	if cpu.UsageTotal != -1 {
+		sender.Rate("docker.cpu.usage", cpu.UsageTotal, "", tags)
+	}
+
+	if cpu.Shares != 0 {
+		sender.Gauge("docker.cpu.shares", cpu.Shares, "", tags)
+	}
+
 	sender.Rate("docker.cpu.throttled", float64(cpu.NrThrottled), "", tags)
 	sender.Rate("docker.cpu.throttled.time", cpu.ThrottledTime, "", tags)
 	if cpu.ThreadCount != 0 {

--- a/pkg/util/containers/providers/cgroup/cgroup_metrics.go
+++ b/pkg/util/containers/providers/cgroup/cgroup_metrics.go
@@ -192,6 +192,7 @@ func (c ContainerCgroup) CPU() (*metrics.ContainerCPUStats, error) {
 		ret.User = -1
 		ret.System = -1
 		ret.Shares = -1
+		ret.UsageTotal = -1
 		return ret, nil
 	} else if err != nil {
 		return nil, err
@@ -222,6 +223,7 @@ func (c ContainerCgroup) CPU() (*metrics.ContainerCPUStats, error) {
 	if err == nil {
 		ret.UsageTotal = float64(usage) / NanoToUserHZDivisor
 	} else {
+		ret.UsageTotal = -1
 		log.Debugf("Missing total cpu usage stat for %s: %s", c.ContainerID, err.Error())
 	}
 
@@ -229,6 +231,7 @@ func (c ContainerCgroup) CPU() (*metrics.ContainerCPUStats, error) {
 	if err == nil {
 		ret.Shares = float64(shares)
 	} else {
+		// Shares cannot be 0, so not required to set to -1
 		log.Debugf("Missing cpu shares stat for %s: %s", c.ContainerID, err.Error())
 	}
 


### PR DESCRIPTION
### What does this PR do?

Testing #8805 showed that it does not fix container checks using cgroups (i.e. `docker.*` metrics), adding the missing piece here.

### Motivation

Bugfix.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Reproducing a `cgroup` failure is possible with the following setup:
- Install Datadog Agent on host (DEB/RPM) on a machine with Docker
- Add Agent user to `docker` group `usermod -G docker -a dd-agent`
- Restart the Agent
- Start a container doing some CPU: `docker run --rm -d vboulineau/stress-ng --cpu 1`
- Go to `/sys/fs/cgroup/cpuacct/docker/<container_id>`
- Run `chmod 600 cpuacct.usage; sleep 60; chmod 644 cpuacct.usage`

You should see missing points for `docker.cpu.usage` (use fill null) and should not see any spike when the data comes back.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
