### PR TITLE
Collapse diff of `go.sum` and avoid merge

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+go.sum -diff -merge
 *.pb.go -diff -merge
 *.pb.go linguist-generated=true
 *.pb.gw.go -diff -merge


### PR DESCRIPTION
### What does this PR do?

- Collapse diff of `go.sum` on ~~PRs and~~ local `git diff` calls
- Always fail on merge (requiring the user to do `inv -e tidy-all`)

### Motivation

Make diffs less cluttered by machine-generated files that are not relevant.

### Additional Notes

This should be a no-op.

### Describe how to test your changes

n/a

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
