### PR TITLE
[omnibus] Exclude IBM i from Python 2 env

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -76,8 +76,10 @@ blacklist_packages = Array.new
 # We build these manually
 blacklist_packages.push(/^snowflake-connector-python==/)
 
-# Avi Vantage is py3 only
+# py3 only checks
+# TODO: Remove once AP-1243 is done
 blacklist_folders.push('avi_vantage')
+blacklist_folders.push('ibm_i')
 
 if suse?
   # Temporarily blacklist Aerospike until builder supports new dependency


### PR DESCRIPTION
### What does this PR do?

Remove `ibm_i` from Python 3 check list.

### Motivation

IBM i check is Python 3 only.

### Additional Notes

Once AP-1243 is complete this can be avoided.

### Describe how to test your changes

Until the IBM i check is added this should be a no-op.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
