### PR TITLE
[Kitchen tests] Update spec_helper.rb to not rely on localized strings

### DIFF
--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -11,7 +11,7 @@
 .kitchen_os_windows:
   variables:
     KITCHEN_PLATFORM: "windows"
-    KITCHEN_OSVERS: "win2008r2,win2012,win2012r2,win2016,win2019"
+    KITCHEN_OSVERS: "win2008r2,win2012,win2012r2,win2016,win2019,win2019cn"
     DEFAULT_KITCHEN_OSVERS: "win2019"
   before_script:  # Note: if you are changing this, remember to also change .kitchen_test_windows_installer, which has a copy of this with less TEST_PLATFORMS defined.
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi
@@ -41,7 +41,7 @@
 .kitchen_test_windows_npm_driver:
   variables:
     KITCHEN_PLATFORM: "windows"
-    KITCHEN_OSVERS: "win2012r2,win2016,win2019,win1903,win1909,win2004,win20h2"
+    KITCHEN_OSVERS: "win2012r2,win2016,win2019,win2019cn,win1903,win1909,win2004,win20h2"
     DEFAULT_KITCHEN_OSVERS: "win20h2"
   before_script:  # test all of the kernels to make sure the driver loads and runs properly
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -90,6 +90,7 @@
                 "win2012r2": "urn,MicrosoftWindowsServer:WindowsServer:2012-R2-Datacenter:4.127.20190416",
                 "win2016": "urn,MicrosoftWindowsServer:WindowsServer:2016-Datacenter-Server-Core:2016.127.20190416",
                 "win2019": "urn,MicrosoftWindowsServer:WindowsServer:2019-Datacenter-Core:2019.0.20190410",
+                "win2019cn": "urn,MicrosoftWindowsServer:WindowsServer:2019-Datacenter-zhcn:17763.2114.2108051826",
                 "win1903": "urn,MicrosoftWindowsServer:WindowsServer:Datacenter-Core-1903-with-Containers-smalldisk:18362.1256.2012032308",
                 "win1909": "urn,MicrosoftWindowsServer:WindowsServer:datacenter-core-1909-with-containers-smalldisk:18363.1316.2101130054",
                 "win2004": "urn,MicrosoftWindowsServer:WindowsServer:datacenter-core-2004-with-containers-smalldisk:19041.746.2101092327",

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -287,7 +287,7 @@ end
 
 def is_windows_service_installed(service)
   raise "is_windows_service_installed is only for windows" unless os == :windows
-  return flavor_service_status(service) == "NOTINSTALLED"
+  return flavor_service_status(service) != "NOTINSTALLED"
 end
   
 def is_flavor_running?(flavor)

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -400,7 +400,7 @@ def is_file_signed(fullpath)
   puts "output is #{output} => #{output.bytes}"
   signature_hash = "748A3B5C681AF45FAC149A76FE59E7CBBDFF058C"
   puts "signature_hash is #{signature_hash} => #{signature_hash.bytes}"
-  return output.upcase == signature_hash
+  return output.upcase.strip == signature_hash
 end
 
 def is_dpkg_package_installed(package)

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -255,7 +255,7 @@ def json_info
 end
 
 def windows_service_status(service)
-  return (`powershell -command "try { (get-service "#{service}" -ErrorAction Stop).Status } catch { write-host "NOTINSTALLED" }"`).upcase.trim
+  return (`powershell -command "try { (get-service "#{service}" -ErrorAction Stop).Status } catch { write-host "NOTINSTALLED" }"`).upcase.strip
 end
 
 def flavor_service_status(flavor)

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -65,6 +65,25 @@ def os
   )
 end
 
+def safe_program_files
+  # HACK: on non-English Windows, Chef wrongly installs its 32-bit version on 64-bit hosts because
+  # of this issue: https://github.com/chef/mixlib-install/issues/343
+  # Because of this, the ENV['ProgramFiles'] content is wrong (it's `C:/Program Files (x86)`)
+  # while the Agent is installed in `C:/Program Files`
+  # To prevent this issue, we check the system arch and the ProgramFiles folder, and we fix it
+  # if needed.
+
+  # Env variables are frozen strings, they need to be duplicated to modify them
+  program_files = ENV['ProgramFiles'].dup
+  arch = `Powershell -command "(Get-WmiObject Win32_OperatingSystem).OsArchitecture"`
+  if arch.include? "64" and program_files.include? "(x86)"
+    program_files.slice!("(x86)")
+    program_files.strip!
+  end
+
+  program_files
+end
+
 
 def agent_command
   if os == :windows
@@ -464,11 +483,12 @@ shared_examples_for "an installed Agent" do
       is_signed = is_file_signed(msi_path)
       expect(is_signed).to be_truthy
 
+      program_files = safe_program_files
       verify_signature_files = [
-        "#{ENV['ProgramFiles']}\\DataDog\\Datadog Agent\\bin\\agent\\process-agent.exe",
-        "#{ENV['ProgramFiles']}\\DataDog\\Datadog Agent\\bin\\agent\\trace-agent.exe",
-        "#{ENV['ProgramFiles']}\\DataDog\\Datadog Agent\\bin\\agent\\ddtray.exe",
-        "#{ENV['ProgramFiles']}\\DataDog\\Datadog Agent\\bin\\agent.exe"
+        "#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\process-agent.exe",
+        "#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\trace-agent.exe",
+        "#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\ddtray.exe",
+        "#{program_files}\\DataDog\\Datadog Agent\\bin\\agent.exe"
       ]
       verify_signature_files.each do |vf|
         is_signed = is_file_signed(vf)

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -254,10 +254,14 @@ def json_info
   JSON.parse(info_output)
 end
 
+def windows_service_status(service)
+  return (`powershell -command "try { (get-service "#{service}" -ErrorAction Stop).Status } catch { write-host "NOTINSTALLED" }"`).upcase.trim
+end
+
 def flavor_service_status(flavor)
   service = get_service_name(flavor)
   if os == :windows
-    return (`powershell -command "try { (get-service "#{service}" -ErrorAction Stop).Status } catch { write-host "NOTINSTALLED" }"`).upcase.trim
+    return windows_service_status(service)
   else
     if has_systemctl
       system "sudo systemctl status --no-pager #{service}.service"
@@ -271,7 +275,7 @@ end
 
 def is_service_running?(service)
   if os == :windows
-    return flavor_service_status(service) == "RUNNING"
+    return windows_service_status(service) == "RUNNING"
   else
     if has_systemctl
       system "sudo systemctl status --no-pager #{service}.service"
@@ -287,7 +291,7 @@ end
 
 def is_windows_service_installed(service)
   raise "is_windows_service_installed is only for windows" unless os == :windows
-  return flavor_service_status(service) != "NOTINSTALLED"
+  return windows_service_status(service) != "NOTINSTALLED"
 end
   
 def is_flavor_running?(flavor)

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -397,9 +397,7 @@ def is_file_signed(fullpath)
   puts "checking file #{fullpath}"
   expect(File).to exist(fullpath)
   output = `powershell -command "(get-authenticodesignature -FilePath '#{fullpath}').SignerCertificate.Thumbprint"`
-  puts "output is #{output} => #{output.bytes}"
   signature_hash = "748A3B5C681AF45FAC149A76FE59E7CBBDFF058C"
-  puts "signature_hash is #{signature_hash} => #{signature_hash.bytes}"
   return output.upcase.strip == signature_hash
 end
 

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -396,18 +396,9 @@ end
 def is_file_signed(fullpath)
   puts "checking file #{fullpath}"
   expect(File).to exist(fullpath)
-  output = `powershell -command get-authenticodesignature -FilePath '#{fullpath}'`
+  output = `powershell -command (get-authenticodesignature -FilePath '#{fullpath}').SignerCertificate.Thumbprint`
   signature_hash = "748A3B5C681AF45FAC149A76FE59E7CBBDFF058C"
-  if not output.include? signature_hash
-    return false
-  end
-  if not output.include? "Valid"
-    return false
-  end
-  if output.include? "NotSigned"
-    return false
-  end
-  return true
+  return output.upcase == signature_hash
 end
 
 def is_dpkg_package_installed(package)

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -396,7 +396,7 @@ end
 def is_file_signed(fullpath)
   puts "checking file #{fullpath}"
   expect(File).to exist(fullpath)
-  output = `powershell -command (get-authenticodesignature -FilePath '#{fullpath}').SignerCertificate.Thumbprint`
+  output = `powershell -command "(get-authenticodesignature -FilePath '#{fullpath}').SignerCertificate.Thumbprint"`
   signature_hash = "748A3B5C681AF45FAC149A76FE59E7CBBDFF058C"
   return output.upcase == signature_hash
 end

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -257,8 +257,7 @@ end
 def flavor_service_status(flavor)
   service = get_service_name(flavor)
   if os == :windows
-    result = `powershell -command "try { (get-service "#{service}" -ErrorAction Stop).Status } catch { write-host "NOTINSTALLED" }"`
-    return result.upcase.trim == "RUNNING"
+    return (`powershell -command "try { (get-service "#{service}" -ErrorAction Stop).Status } catch { write-host "NOTINSTALLED" }"`).upcase.trim
   else
     if has_systemctl
       system "sudo systemctl status --no-pager #{service}.service"
@@ -272,8 +271,7 @@ end
 
 def is_service_running?(service)
   if os == :windows
-    result = `powershell -command "try { (get-service "#{service}" -ErrorAction Stop).Status } catch { write-host "NOTINSTALLED" }"`
-    return result.upcase.trim == "RUNNING"
+    return flavor_service_status(service) == "RUNNING"
   else
     if has_systemctl
       system "sudo systemctl status --no-pager #{service}.service"
@@ -289,8 +287,7 @@ end
 
 def is_windows_service_installed(service)
   raise "is_windows_service_installed is only for windows" unless os == :windows
-  result = `powershell -command "try { (get-service "#{service}" -ErrorAction Stop).Status } catch { write-host "NOTINSTALLED" }"`
-  return result.upcase.trim != "NOTINSTALLED"
+  return flavor_service_status(service) == "NOTINSTALLED"
 end
   
 def is_flavor_running?(flavor)

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -397,7 +397,9 @@ def is_file_signed(fullpath)
   puts "checking file #{fullpath}"
   expect(File).to exist(fullpath)
   output = `powershell -command "(get-authenticodesignature -FilePath '#{fullpath}').SignerCertificate.Thumbprint"`
+  puts "output is #{output} => #{output.bytes}"
   signature_hash = "748A3B5C681AF45FAC149A76FE59E7CBBDFF058C"
+  puts "signature_hash is #{signature_hash} => #{signature_hash.bytes}"
   return output.upcase == signature_hash
 end
 

--- a/test/kitchen/test/integration/common/rspec/windows_npm_spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/windows_npm_spec_helper.rb
@@ -6,9 +6,10 @@ shared_examples_for 'a Windows Agent with NPM driver that can start' do
     expect(is_windows_service_installed("ddnpm")).to be_truthy
   end
   it 'has Windows NPM driver files installed' do
-    expect(File).to exist("#{ENV['ProgramFiles']}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.cat")
-    expect(File).to exist("#{ENV['ProgramFiles']}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.sys")
-    expect(File).to exist("#{ENV['ProgramFiles']}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.inf")
+    program_files = safe_program_files
+    expect(File).to exist("#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.cat")
+    expect(File).to exist("#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.sys")
+    expect(File).to exist("#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.inf")
   end
 
   it 'does not have the driver running on install' do
@@ -31,9 +32,10 @@ shared_examples_for 'a Windows Agent with no NPM driver installed' do
     expect(is_windows_service_installed("ddnpm")).to be_falsey
   end
   it 'does not have the Windows NPM driver files installed' do
-    expect(File).not_to exist("#{ENV['ProgramFiles']}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.cat")
-    expect(File).not_to exist("#{ENV['ProgramFiles']}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.sys")
-    expect(File).not_to exist("#{ENV['ProgramFiles']}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.inf")
+    program_files = safe_program_files
+    expect(File).not_to exist("#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.cat")
+    expect(File).not_to exist("#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.sys")
+    expect(File).not_to exist("#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.inf")
   end
 end
 
@@ -45,9 +47,10 @@ shared_examples_for 'a Windows Agent with NPM driver installed' do
     expect(is_windows_service_installed("ddnpm")).to be_truthy
   end
   it 'has Windows NPM driver files installed' do
-    expect(File).to exist("#{ENV['ProgramFiles']}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.cat")
-    expect(File).to exist("#{ENV['ProgramFiles']}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.sys")
-    expect(File).to exist("#{ENV['ProgramFiles']}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.inf")
+    program_files = safe_program_files
+    expect(File).to exist("#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.cat")
+    expect(File).to exist("#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.sys")
+    expect(File).to exist("#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.inf")
   end
 end
 


### PR DESCRIPTION
### What does this PR do?

This PR updates the kitchen tests that verify that a file is signed to not use localized string output.

### Motivation

Test with international Windows machines in kitchen tests.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.

Note: Adding GitHub labels is only possible for contributors with write access.
