### PR TITLE
[corecheck/snmp] Add autodiscovery to snmp corecheck

### DIFF
--- a/pkg/collector/corechecks/snmp/.gitignore
+++ b/pkg/collector/corechecks/snmp/.gitignore
@@ -1,0 +1,1 @@
+/discovery/test/run_path

--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
@@ -50,10 +50,20 @@ func (d *DeviceCheck) SetSender(sender *report.MetricSender) {
 	d.sender = sender
 }
 
+// GetIPAddress returns device IP
+func (d *DeviceCheck) GetIPAddress() string {
+	return d.config.IPAddress
+}
+
+// GetIDTags returns device IDTags
+func (d *DeviceCheck) GetIDTags() []string {
+	return d.config.DeviceIDTags
+}
+
 // Run executes the check
 func (d *DeviceCheck) Run(collectionTime time.Time) error {
 	startTime := time.Now()
-	staticTags := d.config.GetStaticTags()
+	staticTags := append(d.config.GetStaticTags(), d.config.GetNetworkTags()...)
 
 	// Fetch and report metrics
 	var checkErr error

--- a/pkg/collector/corechecks/snmp/discovery/discovery.go
+++ b/pkg/collector/corechecks/snmp/discovery/discovery.go
@@ -1,0 +1,309 @@
+package discovery
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/persistentcache"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/checkconfig"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/devicecheck"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/session"
+)
+
+const cacheKeyPrefix = "snmp"
+const sysObjectIDOid = "1.3.6.1.2.1.1.2.0"
+
+// Discovery handles snmp discovery states
+type Discovery struct {
+	config    *checkconfig.CheckConfig
+	stop      chan struct{}
+	discDevMu sync.RWMutex
+
+	// TODO: use a new type for device deviceDigest
+	// discoveredDevices contains devices with device deviceDigest as map key
+	// see also CheckConfig.DeviceDigest()
+	discoveredDevices map[checkconfig.DeviceDigest]Device
+}
+
+// Device implements and store results from the Service interface for the SNMP listener
+type Device struct {
+	deviceDigest checkconfig.DeviceDigest
+	deviceIP     string
+	deviceCheck  *devicecheck.DeviceCheck
+}
+type snmpSubnet struct {
+	config     *checkconfig.CheckConfig
+	startingIP net.IP
+	network    net.IPNet
+
+	cacheKey string
+
+	// discoveredDevices contains devices ip with device deviceDigest as map key
+	// see also CheckConfig.DeviceDigest()
+	devices map[checkconfig.DeviceDigest]string
+
+	// discoveredDevices contains device failures count with device deviceDigest as map key
+	// see also CheckConfig.DeviceDigest()
+	deviceFailures map[checkconfig.DeviceDigest]int
+}
+
+type checkDeviceJob struct {
+	subnet    *snmpSubnet
+	currentIP net.IP
+}
+
+// Start discovery
+func (d *Discovery) Start() {
+	log.Debugf("subnet %s: Start discovery", d.config.Network)
+	go d.discoverDevices()
+}
+
+// Stop signal discovery to shut down
+func (d *Discovery) Stop() {
+	log.Debugf("subnet %s: Stop discovery", d.config.Network)
+	close(d.stop)
+}
+
+// GetDiscoveredDeviceConfigs returns discovered device configs
+func (d *Discovery) GetDiscoveredDeviceConfigs() []*devicecheck.DeviceCheck {
+	d.discDevMu.RLock()
+	defer d.discDevMu.RUnlock()
+
+	discoveredDevices := make([]*devicecheck.DeviceCheck, 0, len(d.discoveredDevices))
+	for _, device := range d.discoveredDevices {
+		discoveredDevices = append(discoveredDevices, device.deviceCheck)
+	}
+	return discoveredDevices
+}
+
+// Start discovery
+func (d *Discovery) runWorker(w int, jobs <-chan checkDeviceJob) {
+	log.Debugf("subnet %s: Start SNMP worker %d", d.config.Network, w)
+	for {
+		select {
+		case <-d.stop:
+			log.Debugf("subnet %s: Stop SNMP worker %d", d.config.Network, w)
+			return
+		case job := <-jobs:
+			log.Debugf("subnet %s: Handling IP %s", d.config.Network, job.currentIP.String())
+			err := d.checkDevice(job)
+			if err != nil {
+				log.Errorf(err.Error())
+			}
+		}
+	}
+}
+
+func (d *Discovery) discoverDevices() {
+	ipAddr, ipNet, err := net.ParseCIDR(d.config.Network)
+	if err != nil {
+		log.Errorf("subnet %s: Couldn't parse SNMP network: %s", d.config.Network, err)
+		return
+	}
+
+	startingIP := ipAddr.Mask(ipNet.Mask)
+
+	configHash := d.config.DeviceDigest(d.config.Network)
+	cacheKey := fmt.Sprintf("%s:%s", cacheKeyPrefix, configHash)
+
+	subnet := snmpSubnet{
+		config:     d.config,
+		startingIP: startingIP,
+		network:    *ipNet,
+		cacheKey:   cacheKey,
+
+		// Since subnet devices fields (`devices` and `deviceFailures`) are changed at the same time
+		// as Discovery.discoveredDevices, we rely on Discovery.discDevMu mutex to protect against concurrent changes.
+		devices:        map[checkconfig.DeviceDigest]string{},
+		deviceFailures: map[checkconfig.DeviceDigest]int{},
+	}
+
+	d.loadCache(&subnet)
+
+	jobs := make(chan checkDeviceJob)
+	for w := 0; w < d.config.DiscoveryWorkers; w++ {
+		go d.runWorker(w, jobs)
+	}
+
+	discoveryTicker := time.NewTicker(time.Duration(d.config.DiscoveryInterval) * time.Second)
+
+	for {
+		log.Debugf("subnet %s: Run discovery", d.config.Network)
+		startingIP := make(net.IP, len(subnet.startingIP))
+		copy(startingIP, subnet.startingIP)
+		for currentIP := startingIP; subnet.network.Contains(currentIP); incrementIP(currentIP) {
+
+			if ignored := subnet.config.IsIPIgnored(currentIP); ignored {
+				continue
+			}
+
+			jobIP := make(net.IP, len(currentIP))
+			copy(jobIP, currentIP)
+			job := checkDeviceJob{
+				subnet:    &subnet,
+				currentIP: jobIP,
+			}
+			jobs <- job
+
+			select {
+			case <-d.stop:
+				log.Debugf("subnet %s: Stop scheduling devices", d.config.Network)
+				return
+			default:
+			}
+		}
+
+		select {
+		case <-d.stop:
+			log.Debugf("subnet %s: Stop scheduling devices", d.config.Network)
+			return
+		case <-discoveryTicker.C:
+		}
+	}
+}
+
+func (d *Discovery) checkDevice(job checkDeviceJob) error {
+	deviceIP := job.currentIP.String()
+	config := *job.subnet.config // shallow copy
+	config.IPAddress = deviceIP
+	sess, err := session.NewSession(&config)
+	if err != nil {
+		return fmt.Errorf("error configure session for ip %s: %v", deviceIP, err)
+	}
+	deviceDigest := job.subnet.config.DeviceDigest(deviceIP)
+	if err := sess.Connect(); err != nil {
+		log.Debugf("subnet %s: SNMP connect to %s error: %v", d.config.Network, deviceIP, err)
+		d.deleteDevice(deviceDigest, job.subnet)
+	} else {
+		defer sess.Close()
+
+		oids := []string{sysObjectIDOid}
+		// Since `params<GoSNMP>.ContextEngineID` is empty
+		// `params.Get` might lead to multiple SNMP GET calls when using SNMP v3
+		// a first call might be needed to retrieve the engineID and then the call to get the oid values.
+		value, err := sess.Get(oids)
+		if err != nil {
+			log.Debugf("subnet %s: SNMP get to %s error: %v", d.config.Network, deviceIP, err)
+			d.deleteDevice(deviceDigest, job.subnet)
+		} else if len(value.Variables) < 1 || value.Variables[0].Value == nil {
+			log.Debugf("subnet %s: SNMP get to %s no data", d.config.Network, deviceIP)
+			d.deleteDevice(deviceDigest, job.subnet)
+		} else {
+			log.Debugf("subnet %s: SNMP get to %s success: %v", d.config.Network, deviceIP, value.Variables[0].Value)
+			d.createDevice(deviceDigest, job.subnet, deviceIP, true)
+		}
+	}
+	return nil
+}
+
+func (d *Discovery) createDevice(deviceDigest checkconfig.DeviceDigest, subnet *snmpSubnet, deviceIP string, writeCache bool) {
+	deviceCk, err := devicecheck.NewDeviceCheck(subnet.config, deviceIP)
+	if err != nil {
+		// should not happen since the deviceCheck is expected to be valid at this point
+		// and are only changing the device ip
+		log.Warnf("subnet %s: failed to create new device check `%s`: %s", d.config.Network, deviceIP, err)
+		return
+	}
+
+	d.discDevMu.Lock()
+	defer d.discDevMu.Unlock()
+
+	if _, present := d.discoveredDevices[deviceDigest]; present {
+		return
+	}
+	device := Device{
+		deviceDigest: deviceDigest,
+		deviceIP:     deviceIP,
+		deviceCheck:  deviceCk,
+	}
+	d.discoveredDevices[deviceDigest] = device
+	subnet.devices[deviceDigest] = deviceIP
+	subnet.deviceFailures[deviceDigest] = 0
+
+	if writeCache {
+		d.writeCache(subnet)
+	}
+}
+
+// deleteDevice removes a device from discovered devices list and cache
+// if the allowed device failures count is reached
+func (d *Discovery) deleteDevice(deviceDigest checkconfig.DeviceDigest, subnet *snmpSubnet) {
+	d.discDevMu.Lock()
+	defer d.discDevMu.Unlock()
+	if _, present := d.discoveredDevices[deviceDigest]; present {
+		failure, present := subnet.deviceFailures[deviceDigest]
+		if !present {
+			subnet.deviceFailures[deviceDigest] = 1
+			failure = 1
+		} else {
+			subnet.deviceFailures[deviceDigest]++
+			failure++
+		}
+
+		if d.config.DiscoveryAllowedFailures != -1 && failure >= d.config.DiscoveryAllowedFailures {
+			delete(d.discoveredDevices, deviceDigest)
+			delete(subnet.devices, deviceDigest)
+			delete(subnet.deviceFailures, deviceDigest)
+			d.writeCache(subnet)
+		}
+	}
+}
+
+func (d *Discovery) readCache(subnet *snmpSubnet) ([]net.IP, error) {
+	cacheValue, err := persistentcache.Read(subnet.cacheKey)
+	if err != nil {
+		return nil, fmt.Errorf("couldn't read cache for %s: %s", subnet.cacheKey, err)
+	}
+	if cacheValue == "" {
+		return []net.IP{}, nil
+	}
+	var devices []net.IP
+	if err = json.Unmarshal([]byte(cacheValue), &devices); err != nil {
+		return nil, fmt.Errorf("couldn't unmarshal cache for %s: %s", subnet.cacheKey, err)
+	}
+	return devices, nil
+}
+
+func (d *Discovery) loadCache(subnet *snmpSubnet) {
+	devices, err := d.readCache(subnet)
+	if err != nil {
+		log.Errorf("subnet %s: error reading cache: %s", d.config.Network, err)
+		return
+	}
+	for _, deviceIP := range devices {
+		deviceDigest := subnet.config.DeviceDigest(deviceIP.String())
+		d.createDevice(deviceDigest, subnet, deviceIP.String(), false)
+	}
+}
+
+func (d *Discovery) writeCache(subnet *snmpSubnet) {
+	// We don't lock the subnet for now, because the discovery ought to be already locked
+	devices := make([]string, 0, len(subnet.devices))
+	for _, v := range subnet.devices {
+		devices = append(devices, v)
+	}
+
+	cacheValue, err := json.Marshal(devices)
+	if err != nil {
+		log.Errorf("subnet %s: Couldn't marshal cache: %s", d.config.Network, err)
+		return
+	}
+
+	if err = persistentcache.Write(subnet.cacheKey, string(cacheValue)); err != nil {
+		log.Errorf("subnet %s: Couldn't write cache: %s", d.config.Network, err)
+	}
+}
+
+// NewDiscovery return a new Discovery instance
+func NewDiscovery(config *checkconfig.CheckConfig) Discovery {
+	return Discovery{
+		discoveredDevices: make(map[checkconfig.DeviceDigest]Device),
+		stop:              make(chan struct{}),
+		config:            config,
+	}
+}

--- a/pkg/collector/corechecks/snmp/discovery/discovery_test.go
+++ b/pkg/collector/corechecks/snmp/discovery/discovery_test.go
@@ -1,0 +1,338 @@
+package discovery
+
+import (
+	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/checkconfig"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/session"
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/assert"
+	"net"
+	"testing"
+	"time"
+)
+
+func TestDiscovery(t *testing.T) {
+	sess := session.CreateMockSession()
+	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+		return sess, nil
+	}
+
+	packet := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.3.6.1.2.1.1.2.0",
+				Type:  gosnmp.ObjectIdentifier,
+				Value: "1.3.6.1.4.1.3375.2.1.3.4.1",
+			},
+		},
+	}
+	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&packet, nil)
+
+	checkConfig := &checkconfig.CheckConfig{
+		Network:            "192.168.0.0/29",
+		CommunityString:    "public",
+		DiscoveryInterval:  3600,
+		DiscoveryWorkers:   1,
+		IgnoredIPAddresses: map[string]bool{"192.168.0.5": true},
+	}
+	discovery := NewDiscovery(checkConfig)
+	discovery.Start()
+	time.Sleep(100 * time.Millisecond)
+	discovery.Stop()
+
+	deviceConfigs := discovery.GetDiscoveredDeviceConfigs()
+
+	var actualDiscoveredIps []string
+	for _, deviceCk := range deviceConfigs {
+		actualDiscoveredIps = append(actualDiscoveredIps, deviceCk.GetIPAddress())
+	}
+	expectedDiscoveredIps := []string{
+		"192.168.0.0",
+		"192.168.0.1",
+		"192.168.0.2",
+		"192.168.0.3",
+		"192.168.0.4",
+		// 192.168.0.5 is ignored
+		"192.168.0.6",
+		"192.168.0.7",
+	}
+	assert.ElementsMatch(t, expectedDiscoveredIps, actualDiscoveredIps)
+}
+
+func TestDiscoveryCache(t *testing.T) {
+	SetTestRunPath()
+	sess := session.CreateMockSession()
+	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+		return sess, nil
+	}
+
+	packet := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.3.6.1.2.1.1.2.0",
+				Type:  gosnmp.ObjectIdentifier,
+				Value: "1.3.6.1.4.1.3375.2.1.3.4.1",
+			},
+		},
+	}
+	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&packet, nil)
+
+	checkConfig := &checkconfig.CheckConfig{
+		Network:           "192.168.0.0/30",
+		CommunityString:   "public",
+		DiscoveryInterval: 3600,
+		DiscoveryWorkers:  1,
+	}
+	discovery := NewDiscovery(checkConfig)
+	discovery.Start()
+	time.Sleep(100 * time.Millisecond)
+	discovery.Stop()
+
+	deviceConfigs := discovery.GetDiscoveredDeviceConfigs()
+
+	var actualDiscoveredIps []string
+	for _, deviceCk := range deviceConfigs {
+		actualDiscoveredIps = append(actualDiscoveredIps, deviceCk.GetIPAddress())
+	}
+	expectedDiscoveredIps := []string{
+		"192.168.0.0",
+		"192.168.0.1",
+		"192.168.0.2",
+		"192.168.0.3",
+	}
+	assert.ElementsMatch(t, expectedDiscoveredIps, actualDiscoveredIps)
+
+	// test cache
+	// session is never used, the devices are loaded from cache
+	sess2 := session.CreateMockSession()
+	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+		return sess2, nil
+	}
+
+	checkConfig = &checkconfig.CheckConfig{
+		Network:           "192.168.0.0/30",
+		CommunityString:   "public",
+		DiscoveryInterval: 3600,
+		DiscoveryWorkers:  0, // no workers, the devices will be loaded from cache
+	}
+	discovery2 := NewDiscovery(checkConfig)
+	discovery2.Start()
+	time.Sleep(100 * time.Millisecond)
+	discovery2.Stop()
+
+	deviceConfigsFromCache := discovery2.GetDiscoveredDeviceConfigs()
+
+	var actualDiscoveredIpsFromCache []string
+	for _, deviceCk := range deviceConfigsFromCache {
+		actualDiscoveredIpsFromCache = append(actualDiscoveredIpsFromCache, deviceCk.GetIPAddress())
+	}
+	assert.ElementsMatch(t, expectedDiscoveredIps, actualDiscoveredIpsFromCache)
+}
+
+func TestDiscoveryTicker(t *testing.T) {
+	t.Skip() // TODO: FIX ME, currently this test is leading to data race when ran with other tests
+
+	sess := session.CreateMockSession()
+	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+		return sess, nil
+	}
+
+	packet := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.3.6.1.2.1.1.2.0",
+				Type:  gosnmp.ObjectIdentifier,
+				Value: "1.3.6.1.4.1.3375.2.1.3.4.1",
+			},
+		},
+	}
+	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&packet, nil)
+
+	checkConfig := &checkconfig.CheckConfig{
+		Network:           "192.168.0.0/32",
+		CommunityString:   "public",
+		DiscoveryInterval: 1,
+		DiscoveryWorkers:  1,
+	}
+	discovery := NewDiscovery(checkConfig)
+	discovery.Start()
+	time.Sleep(1500 * time.Millisecond)
+	discovery.Stop()
+
+	// expected to be called 3 times for 1.5 sec
+	// first time on discovery.Start, then once every second for the first 1 sec
+	assert.Equal(t, 2, len(sess.Calls))
+}
+
+func TestDiscovery_checkDevice(t *testing.T) {
+	SetTestRunPath()
+	checkConfig := &checkconfig.CheckConfig{
+		Network:           "192.168.0.0/32",
+		CommunityString:   "public",
+		DiscoveryInterval: 1,
+		DiscoveryWorkers:  1,
+	}
+	discovery := NewDiscovery(checkConfig)
+	ipAddr, ipNet, err := net.ParseCIDR(checkConfig.Network)
+	assert.Nil(t, err)
+	startingIP := ipAddr.Mask(ipNet.Mask)
+
+	subnet := snmpSubnet{
+		config:         checkConfig,
+		startingIP:     startingIP,
+		network:        *ipNet,
+		cacheKey:       "abc:123",
+		devices:        map[checkconfig.DeviceDigest]string{},
+		deviceFailures: map[checkconfig.DeviceDigest]int{},
+	}
+
+	job := checkDeviceJob{
+		subnet:    &subnet,
+		currentIP: startingIP,
+	}
+
+	packet := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.3.6.1.2.1.1.2.0",
+				Type:  gosnmp.ObjectIdentifier,
+				Value: "1.3.6.1.4.1.3375.2.1.3.4.1",
+			},
+		},
+	}
+
+	var sess *session.MockSession
+
+	checkDeviceOnce := func() {
+		sess = session.CreateMockSession()
+		session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+			return sess, nil
+		}
+		sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&packet, nil)
+		err = discovery.checkDevice(job) // add device
+		assert.Nil(t, err)
+		assert.Equal(t, 1, len(discovery.discoveredDevices))
+	}
+
+	// session configuration error
+	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+		return nil, fmt.Errorf("some error")
+	}
+	err = discovery.checkDevice(job)
+	assert.EqualError(t, err, "error configure session for ip 192.168.0.0: some error")
+	assert.Equal(t, 0, len(discovery.discoveredDevices))
+	assert.Equal(t, "", discovery.config.IPAddress)
+
+	// Test session.Connect() error
+	checkDeviceOnce()
+	sess.ConnectErr = fmt.Errorf("connection error")
+	err = discovery.checkDevice(job)
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(discovery.discoveredDevices))
+
+	// Test session.Get() error
+	checkDeviceOnce()
+	sess = session.CreateMockSession()
+	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+		return sess, nil
+	}
+	var nilPacket *gosnmp.SnmpPacket
+	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(nilPacket, fmt.Errorf("get error"))
+	err = discovery.checkDevice(job) // check device with Get error
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(discovery.discoveredDevices))
+
+	// Test session.Get() packet with no variable
+	checkDeviceOnce()
+	sess = session.CreateMockSession()
+	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+		return sess, nil
+	}
+	packetNoVariable := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{},
+	}
+	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&packetNoVariable, nil)
+	err = discovery.checkDevice(job) // check device with Get error
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(discovery.discoveredDevices))
+
+	// Test session.Get() packet with nil value
+	checkDeviceOnce()
+	sess = session.CreateMockSession()
+	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+		return sess, nil
+	}
+	packetNilValue := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.3.6.1.2.1.1.2.0",
+				Type:  gosnmp.ObjectIdentifier,
+				Value: nil,
+			},
+		},
+	}
+	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&packetNilValue, nil)
+	err = discovery.checkDevice(job) // check device with Get error
+	assert.Nil(t, err)
+	assert.Equal(t, 0, len(discovery.discoveredDevices))
+}
+
+func TestDiscovery_createDevice(t *testing.T) {
+	SetTestRunPath()
+	checkConfig := &checkconfig.CheckConfig{
+		Network:                  "192.168.0.0/32",
+		CommunityString:          "public",
+		DiscoveryInterval:        1,
+		DiscoveryWorkers:         1,
+		DiscoveryAllowedFailures: 3,
+	}
+	discovery := NewDiscovery(checkConfig)
+	ipAddr, ipNet, err := net.ParseCIDR(checkConfig.Network)
+	assert.Nil(t, err)
+	startingIP := ipAddr.Mask(ipNet.Mask)
+
+	subnet := &snmpSubnet{
+		config:         checkConfig,
+		startingIP:     startingIP,
+		network:        *ipNet,
+		cacheKey:       "abc:123",
+		devices:        map[checkconfig.DeviceDigest]string{},
+		deviceFailures: map[checkconfig.DeviceDigest]int{},
+	}
+
+	device1Digest := subnet.config.DeviceDigest("192.168.0.1")
+	device2Digest := subnet.config.DeviceDigest("192.168.0.2")
+	device3Digest := subnet.config.DeviceDigest("192.168.0.3")
+	discovery.createDevice(device1Digest, subnet, "192.168.0.1", true)
+	discovery.createDevice(device2Digest, subnet, "192.168.0.2", true)
+	discovery.createDevice(device3Digest, subnet, "192.168.0.3", false)
+
+	assert.Equal(t, 3, len(discovery.discoveredDevices))
+
+	assert.Equal(t, device1Digest, discovery.discoveredDevices[device1Digest].deviceDigest)
+	assert.Equal(t, "192.168.0.1", discovery.discoveredDevices[device1Digest].deviceIP)
+	assert.Equal(t, "192.168.0.1", discovery.discoveredDevices[device1Digest].deviceCheck.GetIPAddress())
+	assert.Equal(t, []string{"snmp_device:192.168.0.1"}, discovery.discoveredDevices[device1Digest].deviceCheck.GetIDTags())
+
+	assert.Equal(t, device2Digest, discovery.discoveredDevices[device2Digest].deviceDigest)
+	assert.Equal(t, "192.168.0.2", discovery.discoveredDevices[device2Digest].deviceIP)
+
+	// test that only createDevice with writeCache:true are written to cache
+	ips, err := discovery.readCache(subnet)
+	assert.Nil(t, err)
+	assert.Equal(t, 2, len(ips))
+
+	// test deleteDevice
+	assert.Equal(t, 0, subnet.deviceFailures[device1Digest])
+	assert.Equal(t, 3, len(discovery.discoveredDevices))
+	discovery.deleteDevice(device1Digest, subnet) // increment failure count
+	assert.Equal(t, 1, subnet.deviceFailures[device1Digest])
+	assert.Equal(t, 3, len(discovery.discoveredDevices))
+	discovery.deleteDevice(device1Digest, subnet) // increment failure count
+	assert.Equal(t, 2, subnet.deviceFailures[device1Digest])
+	assert.Equal(t, 3, len(discovery.discoveredDevices))
+	_, present := subnet.deviceFailures[device1Digest]
+	assert.Equal(t, true, present)
+	discovery.deleteDevice(device1Digest, subnet) // really deletes the device
+	assert.Equal(t, 2, len(discovery.discoveredDevices))
+}

--- a/pkg/collector/corechecks/snmp/discovery/ip_utils.go
+++ b/pkg/collector/corechecks/snmp/discovery/ip_utils.go
@@ -1,0 +1,12 @@
+package discovery
+
+import "net"
+
+func incrementIP(ip net.IP) {
+	for i := len(ip) - 1; i >= 0; i-- {
+		ip[i]++
+		if ip[i] > 0 {
+			break
+		}
+	}
+}

--- a/pkg/collector/corechecks/snmp/discovery/ip_utils_test.go
+++ b/pkg/collector/corechecks/snmp/discovery/ip_utils_test.go
@@ -1,0 +1,44 @@
+package discovery
+
+import (
+	"github.com/stretchr/testify/assert"
+	"net"
+	"testing"
+)
+
+func Test_incrementIP(t *testing.T) {
+	tests := []struct {
+		name           string
+		ip             net.IP
+		expectedNextIP net.IP
+	}{
+		{
+			name:           "next ip from 0",
+			ip:             net.IPv4(127, 0, 0, 0),
+			expectedNextIP: net.IPv4(127, 0, 0, 1),
+		},
+		{
+			name:           "next ip from 2",
+			ip:             net.IPv4(127, 0, 1, 2),
+			expectedNextIP: net.IPv4(127, 0, 1, 3),
+		},
+		{
+			name:           "next ip 255 to 0",
+			ip:             net.IPv4(127, 0, 1, 255),
+			expectedNextIP: net.IPv4(127, 0, 2, 0),
+		},
+		{
+			name:           "next ip multiple digit change",
+			ip:             net.IPv4(10, 10, 255, 255),
+			expectedNextIP: net.IPv4(10, 11, 0, 0),
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			startingIP := make(net.IP, len(tt.ip))
+			copy(startingIP, tt.ip)
+			incrementIP(startingIP)
+			assert.Equal(t, tt.expectedNextIP, startingIP)
+		})
+	}
+}

--- a/pkg/collector/corechecks/snmp/discovery/testing.go
+++ b/pkg/collector/corechecks/snmp/discovery/testing.go
@@ -1,0 +1,13 @@
+package discovery
+
+import (
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+// SetTestRunPath sets run_path for testing
+func SetTestRunPath() {
+	path, _ := filepath.Abs(filepath.Join(".", "test", "run_path"))
+	config.Datadog.Set("run_path", path)
+}

--- a/pkg/collector/corechecks/snmp/fetch/fetch.go
+++ b/pkg/collector/corechecks/snmp/fetch/fetch.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Fetch oid values from device
-// TODO: pass only specific configs instead of the whole checkconfig.CheckConfig ?
+// TODO: pass only specific configs instead of the whole CheckConfig
 func Fetch(sess session.Session, config *checkconfig.CheckConfig) (*valuestore.ResultValueStore, error) {
 	// fetch scalar values
 	scalarResults, err := fetchScalarOidsWithBatching(sess, config.OidConfig.ScalarOids, config.OidBatchSize)

--- a/pkg/collector/corechecks/snmp/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/report/report_device_metadata.go
@@ -31,7 +31,7 @@ func (ms *MetricSender) ReportNetworkDeviceMetadata(config *checkconfig.CheckCon
 		log.Debugf("Unable to build interfaces metadata: %s", err)
 	}
 
-	metadataPayloads := batchPayloads(config.Subnet, collectTime, metadata.PayloadMetadataBatchSize, device, interfaces)
+	metadataPayloads := batchPayloads(config.ResolvedSubnetName, collectTime, metadata.PayloadMetadataBatchSize, device, interfaces)
 
 	for _, payload := range metadataPayloads {
 		payloadBytes, err := json.Marshal(payload)
@@ -65,7 +65,7 @@ func buildNetworkDeviceMetadata(deviceID string, idTags []string, config *checkc
 		Profile:     config.Profile,
 		Vendor:      vendor,
 		Tags:        tags,
-		Subnet:      config.Subnet,
+		Subnet:      config.ResolvedSubnetName,
 		Status:      deviceStatus,
 	}
 }

--- a/pkg/collector/corechecks/snmp/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/report/report_device_metadata_test.go
@@ -38,10 +38,10 @@ func Test_metricSender_reportNetworkDeviceMetadata_withoutInterfaces(t *testing.
 	}
 
 	config := &checkconfig.CheckConfig{
-		IPAddress:    "1.2.3.4",
-		DeviceID:     "1234",
-		DeviceIDTags: []string{"device_name:127.0.0.1"},
-		Subnet:       "127.0.0.0/29",
+		IPAddress:          "1.2.3.4",
+		DeviceID:           "1234",
+		DeviceIDTags:       []string{"device_name:127.0.0.1"},
+		ResolvedSubnetName: "127.0.0.0/29",
 	}
 	layout := "2006-01-02 15:04:05"
 	str := "2014-11-12 11:45:26"
@@ -105,10 +105,10 @@ func Test_metricSender_reportNetworkDeviceMetadata_withInterfaces(t *testing.T) 
 	}
 
 	config := &checkconfig.CheckConfig{
-		IPAddress:    "1.2.3.4",
-		DeviceID:     "1234",
-		DeviceIDTags: []string{"device_name:127.0.0.1"},
-		Subnet:       "127.0.0.0/29",
+		IPAddress:          "1.2.3.4",
+		DeviceID:           "1234",
+		DeviceIDTags:       []string{"device_name:127.0.0.1"},
+		ResolvedSubnetName: "127.0.0.0/29",
 	}
 
 	layout := "2006-01-02 15:04:05"

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -2,6 +2,7 @@ package snmp
 
 import (
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/checkconfig"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/devicecheck"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/discovery"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/report"
 )
 
@@ -26,27 +28,69 @@ type Check struct {
 	core.CheckBase
 	config         *checkconfig.CheckConfig
 	singleDeviceCk *devicecheck.DeviceCheck
+	discovery      discovery.Discovery
 }
 
 // Run executes the check
 func (c *Check) Run() error {
-
+	var checkErr error
 	sender, err := aggregator.GetSender(c.ID())
 	if err != nil {
 		return err
 	}
 
-	c.singleDeviceCk.SetSender(report.NewMetricSender(sender))
+	if c.config.IsDiscovery() {
+		var discoveredDevices []*devicecheck.DeviceCheck
+		discoveredDevices = c.discovery.GetDiscoveredDeviceConfigs()
 
-	collectionTime := timeNow()
+		jobs := make(chan *devicecheck.DeviceCheck, len(discoveredDevices))
 
-	err = c.singleDeviceCk.Run(collectionTime)
-	if err != nil {
-		return err
+		var wg sync.WaitGroup
+
+		for w := 1; w <= c.config.Workers; w++ {
+			wg.Add(1)
+			go c.runCheckDeviceWorker(w, &wg, jobs)
+		}
+
+		for i := range discoveredDevices {
+			deviceCk := discoveredDevices[i]
+			deviceCk.SetSender(report.NewMetricSender(sender))
+			jobs <- deviceCk
+		}
+		close(jobs)
+		wg.Wait() // wait for all workers to finish
+
+		tags := append(c.config.GetStaticTags(), "network:"+c.config.Network)
+		tags = append(tags, c.config.GetNetworkTags()...)
+		sender.Gauge("snmp.discovered_devices_count", float64(len(discoveredDevices)), "", tags)
+	} else {
+		c.singleDeviceCk.SetSender(report.NewMetricSender(sender))
+		checkErr = c.runCheckDevice(c.singleDeviceCk)
 	}
 
 	// Commit
 	sender.Commit()
+	return checkErr
+}
+
+func (c *Check) runCheckDeviceWorker(workerID int, wg *sync.WaitGroup, jobs <-chan *devicecheck.DeviceCheck) {
+	defer wg.Done()
+	for job := range jobs {
+		err := c.runCheckDevice(job)
+		if err != nil {
+			log.Errorf("worker %d : error collecting for device %s: %s", workerID, job.GetIPAddress(), err)
+		}
+	}
+}
+
+func (c *Check) runCheckDevice(deviceCk *devicecheck.DeviceCheck) error {
+	collectionTime := timeNow()
+
+	err := deviceCk.Run(collectionTime)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }
 
@@ -66,12 +110,21 @@ func (c *Check) Configure(rawInstance integration.Data, rawInitConfig integratio
 	}
 	log.Debugf("SNMP configuration: %s", c.config.ToString())
 
-	c.singleDeviceCk, err = devicecheck.NewDeviceCheck(c.config, c.config.IPAddress)
-	if err != nil {
-		return fmt.Errorf("failed to create device check: %s", err)
+	if c.config.IsDiscovery() {
+		c.discovery = discovery.NewDiscovery(c.config)
+		c.discovery.Start()
+	} else {
+		c.singleDeviceCk, err = devicecheck.NewDeviceCheck(c.config, c.config.IPAddress)
+		if err != nil {
+			return fmt.Errorf("failed to create device check: %s", err)
+		}
 	}
-
 	return nil
+}
+
+// Cancel is called when check is unscheduled
+func (c *Check) Cancel() {
+	c.discovery.Stop()
 }
 
 // Interval returns the scheduling time for the check

--- a/releasenotes/notes/snmp_corecheck_autodiscovery-5830c3e8fc76a9e8.yaml
+++ b/releasenotes/notes/snmp_corecheck_autodiscovery-5830c3e8fc76a9e8.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add snmp corecheck autodiscovery


### PR DESCRIPTION
Regression tests : https://github.com/DataDog/integrations-core/pull/10061

### What does this PR do?

Add autodiscovery to snmp corecheck with the same configs as Python SNMP autodiscovery.

### Motivation

For context, integration level autodiscovery is available for python, but due to performance issues seen with autodiscovery at integration level it wasn't ported to corecheck.

Here are the reasons we are also implementing autodiscovery in SNMP corecheck:
- much easier to user to configure snmp autodiscovery compared to snmp_listener (no need to configure at a different location `datadog.yaml`)
- it makes more sense to configure snmp in integration config folder `conf.d/snmp.d` than datadog.yaml (snmp_listener)
- performance shouldn't be an issue in most cases, corecheck snmp AD should perform better than python snmp AD

We should still keep SNMP Listener for now:
- when using DCA, user can dispatch integration instances per device granularity to worker Agents

### Additional Notes

Related PRs:
- https://github.com/DataDog/datadog-agent/pull/8996
- https://github.com/DataDog/datadog-agent/pull/8971
- https://github.com/DataDog/integrations-core/pull/10079

### Describe how to test your changes

- Test all new autodiscovery configurations
- Test that when the network check instance is unscheduled (see `Check.Cancel()` and `Discovery.Stop()`)


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
