### PR TITLE
[cluster_agent] Update DatadogMetricInternal.maxAge from the DatadogMetric spec

### DIFF
--- a/pkg/clusteragent/externalmetrics/model/datadogmetricinternal.go
+++ b/pkg/clusteragent/externalmetrics/model/datadogmetricinternal.go
@@ -131,6 +131,7 @@ func (d *DatadogMetricInternal) UpdateFrom(currentSpec datadoghq.DatadogMetricSp
 		d.resolveQuery(currentSpec.Query)
 	}
 	d.query = currentSpec.Query
+	d.MaxAge = currentSpec.MaxAge.Duration
 }
 
 // shouldResolveQuery returns whether we should try to resolve a new query

--- a/pkg/clusteragent/externalmetrics/model/datadogmetricinternal_test.go
+++ b/pkg/clusteragent/externalmetrics/model/datadogmetricinternal_test.go
@@ -9,7 +9,9 @@ package model
 
 import (
 	"errors"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"testing"
+	"time"
 
 	datadoghq "github.com/DataDog/datadog-operator/api/v1alpha1"
 
@@ -32,6 +34,7 @@ func TestDatadogMetricInternal_UpdateFrom(t *testing.T) {
 		newSpec               datadoghq.DatadogMetricSpec
 		expectedQuery         string
 		expectedResolvedQuery *string
+		expectedMaxAge        time.Duration
 	}{
 		{
 			name: "same query",
@@ -93,6 +96,50 @@ func TestDatadogMetricInternal_UpdateFrom(t *testing.T) {
 			expectedQuery:         invalidTemplatedQuery,
 			expectedResolvedQuery: nil,
 		},
+		{
+			name: "new max age",
+			ddmInternal: &DatadogMetricInternal{
+				MaxAge:        5 * time.Second,
+				query:         simpleQuery,
+				resolvedQuery: &simpleQuery,
+			},
+			newSpec: datadoghq.DatadogMetricSpec{
+				MaxAge: v1.Duration{Duration: 10 * time.Second},
+				Query:  simpleQuery,
+			},
+			expectedMaxAge:        10 * time.Second,
+			expectedQuery:         simpleQuery,
+			expectedResolvedQuery: &simpleQuery,
+		},
+		{
+			name: "same max age",
+			ddmInternal: &DatadogMetricInternal{
+				MaxAge:        5 * time.Second,
+				query:         simpleQuery,
+				resolvedQuery: &simpleQuery,
+			},
+			newSpec: datadoghq.DatadogMetricSpec{
+				MaxAge: v1.Duration{Duration: 5 * time.Second},
+				Query:  simpleQuery,
+			},
+			expectedMaxAge:        5 * time.Second,
+			expectedQuery:         simpleQuery,
+			expectedResolvedQuery: &simpleQuery,
+		},
+		{
+			name: "deleted max age",
+			ddmInternal: &DatadogMetricInternal{
+				MaxAge:        5 * time.Second,
+				query:         simpleQuery,
+				resolvedQuery: &simpleQuery,
+			},
+			newSpec: datadoghq.DatadogMetricSpec{
+				Query: simpleQuery,
+			},
+			expectedMaxAge:        0,
+			expectedQuery:         simpleQuery,
+			expectedResolvedQuery: &simpleQuery,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -103,6 +150,8 @@ func TestDatadogMetricInternal_UpdateFrom(t *testing.T) {
 			} else {
 				assert.Equal(t, *tt.expectedResolvedQuery, *tt.ddmInternal.resolvedQuery)
 			}
+
+			assert.Equal(t, tt.expectedMaxAge, tt.ddmInternal.MaxAge)
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug in the `DatadogMetric` controller. The `maxAge` attribute of the cached version of a `DatadogMetric` (`DatadogMetricInternal`) was not changed after updating the `maxAge` of the `DatadogMetric` spec.

This bug only affects the feature added in #8735 

### Describe how to test your changes

The setup is similar to #8735 .

Deploy an HPA that references a datadogmetric so it's active. I used a local kind cluster to deploy the `cyclic-cpu-burner` example in the `k8s-testing-resources` repo and adapted the query of the metric to something I know my cluster was reporting (`kube_apiserver.go_threads`), but any metric works for this test:

```YAML
apiVersion: datadoghq.com/v1alpha1
kind: DatadogMetric
metadata:
  name: cyclic-cpu-burner-server
spec:
  query: "100*(avg:kube_apiserver.go_threads{kube_cluster_name:your-cluster-name}.rollup(avg,30)/max:kube_apiserver.go_threads{kube_cluster_name:your-cluster-name}.rollup(avg,30))"
```

Remember to replace `your-cluster-name` above.

The config options `clusterAgent.metricsProvider.enabled` and `clusterAgent.metricsProvider.useDatadogMetrics` need to be set to true.

Wait until you see that the metric is active and valid in `kubectl get datadogmetric _your_datadog_metric_`.

Now run `kubectl edit datadogmetric _your_datadog_metric_` and set MaxAge to "5s" in the spec. 5s is so low that the backend will not be able to give us updated data. So if the change worked, after some seconds, you should see that the metric is not valid and an “Outdated result from backend” error in `kubectl get datadogmetrics _your_datadog_metric_-n default -o yaml`.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
