### PR TITLE
[pkg/collector/runner] Remove un-necessary expvar warning

### DIFF
--- a/pkg/collector/runner/expvars/expvars.go
+++ b/pkg/collector/runner/expvars/expvars.go
@@ -172,8 +172,6 @@ func CheckStats(id check.ID) (*check.Stats, bool) {
 
 	check, checkFound := stats[id]
 	if !checkFound {
-		// This in theory should never happen
-		log.Warnf("Check %s is in stats map but the object is missing the check itself", id)
 		return nil, false
 	}
 


### PR DESCRIPTION
### What does this PR do?

Removes stray `collector/runner` expvar access warning

### Motivation

The code removed here assumed that we would never have a situation where
the check type/name would be in our expvar stats without a matching
check ID already in the nested map. This assumption holds true for single
instances of a check type/name but when multiple checks of the same
type/name are scheduled to be run, all scheduled instances of the check
after the first one will generate this erroneous warning the first time they
run. Because of this, the warning is not useful and is also unnecessary
since the assumption under which it was added was wrong.

### Additional Notes

Related to https://github.com/DataDog/datadog-agent/pull/8756

### Describe how to test your changes

- Add a huge number of checks of the same type to the agent. 
  - Something similar to this could work for `http_check`:
    ```
    cd /etc/datadog-agent/conf.d/http_check.d
    sudo echo -e "init_config:\ninstances:\n" > conf.yaml
    for a in $(seq 1 50); do echo -e "  - name: Test_$a\n    url: http://datadoghq.com\n" >> conf.yaml; done
    sudo chown dd-agent conf.yaml
    ```
- Start the agent and ensure that there's no warnings in the log similar to this `... | WARN | (pkg/collector/runner/expvars/expvars.go:176 in CheckStats) | Check http_check:Test_22:<hash> is in stats map but the object is missing the check itself`

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
