### PR TITLE
[runtime-security] Migrate system-probe's runtime security module to DataDog/ebpf-manager

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -28,6 +28,7 @@ core,github.com/DataDog/agent-payload/process,BSD-3-Clause,"Datadog, Inc."
 core,github.com/DataDog/datadog-go/statsd,MIT,"Datadog, Inc."
 core,github.com/DataDog/datadog-operator/api/v1alpha1,Apache-2.0,"Datadog, Inc."
 core,github.com/DataDog/ebpf,MIT,"Datadog, Inc."
+core,github.com/DataDog/ebpf-manager,MIT,"Datadog, Inc."
 core,github.com/DataDog/ebpf/asm,MIT,"Datadog, Inc."
 core,github.com/DataDog/ebpf/internal,MIT,"Datadog, Inc."
 core,github.com/DataDog/ebpf/internal/btf,MIT,"Datadog, Inc."
@@ -181,6 +182,12 @@ core,github.com/cenkalti/backoff/v4,MIT,Cenk Altı
 core,github.com/cespare/xxhash,MIT,Caleb Spare
 core,github.com/cespare/xxhash/v2,MIT,Caleb Spare
 core,github.com/cihub/seelog,BSD-3-Clause,"Cloud Instruments Co., Ltd. <info@cin.io>"
+core,github.com/cilium/ebpf,MIT,Authors of Cilium | Cloudflare | Nathan Sweet
+core,github.com/cilium/ebpf/asm,MIT,Authors of Cilium | Cloudflare | Nathan Sweet
+core,github.com/cilium/ebpf/internal,MIT,Authors of Cilium | Cloudflare | Nathan Sweet
+core,github.com/cilium/ebpf/internal/btf,MIT,Authors of Cilium | Cloudflare | Nathan Sweet
+core,github.com/cilium/ebpf/internal/unix,MIT,Authors of Cilium | Cloudflare | Nathan Sweet
+core,github.com/cilium/ebpf/perf,MIT,Authors of Cilium | Cloudflare | Nathan Sweet
 core,github.com/clbanning/mxj,MIT,Charles Banning <clbanning@gmail.com> | The Go Authors
 core,github.com/cloudfoundry-community/go-cfclient,MIT,Long Nguyen
 core,github.com/cobaugh/osrelease,BSD-3-Clause,Andrew Cobaugh

--- a/go.mod
+++ b/go.mod
@@ -54,6 +54,7 @@ require (
 	github.com/DataDog/datadog-go v4.8.2+incompatible
 	github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a
 	github.com/DataDog/ebpf v0.0.0-20210419131141-ea64821c9793
+	github.com/DataDog/ebpf-manager v0.0.0-20210826153146-e8c086b72c5a
 	github.com/DataDog/gohai v0.0.0-20210303102637-6b668acb50dd
 	github.com/DataDog/gopsutil v0.0.0-20210826200402-bbfc5b0ae6e9
 	github.com/DataDog/mmh3 v0.0.0-20200316233529-f5b682d8c981 // indirect
@@ -70,7 +71,7 @@ require (
 	github.com/alecthomas/participle v0.7.1
 	github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1
 	github.com/andybalholm/brotli v1.0.1 // indirect
-	github.com/avast/retry-go v2.7.0+incompatible
+	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.40.38
 	github.com/beevik/ntp v0.3.0
 	github.com/benesch/cgosymbolizer v0.0.0-20190515212042-bec6fe6e597b
@@ -78,6 +79,7 @@ require (
 	github.com/blabber/go-freebsd-sysctl v0.0.0-20201130114544-503969f39d8f
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575
+	github.com/cilium/ebpf v0.6.2
 	github.com/clbanning/mxj v1.8.4
 	github.com/cloudfoundry-community/go-cfclient v0.0.0-20210621174645-7773f7e22665
 	github.com/cobaugh/osrelease v0.0.0-20181218015638-a93a0a55a249

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/DataDog/datadog-go v4.8.2+incompatible
 	github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a
 	github.com/DataDog/ebpf v0.0.0-20210419131141-ea64821c9793
-	github.com/DataDog/ebpf-manager v0.0.0-20210826153146-e8c086b72c5a
+	github.com/DataDog/ebpf-manager v0.0.0-20210827085405-e5ea1b643bf4
 	github.com/DataDog/gohai v0.0.0-20210303102637-6b668acb50dd
 	github.com/DataDog/gopsutil v0.0.0-20210826200402-bbfc5b0ae6e9
 	github.com/DataDog/mmh3 v0.0.0-20200316233529-f5b682d8c981 // indirect
@@ -153,7 +153,7 @@ require (
 	github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da
 	github.com/shirou/gopsutil v3.21.8+incompatible
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4
-	github.com/shuLhan/go-bindata v3.6.1+incompatible
+	github.com/shuLhan/go-bindata v4.0.0+incompatible
 	github.com/spf13/afero v1.6.0
 	github.com/spf13/cobra v1.2.1
 	github.com/spf13/pflag v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -54,7 +54,7 @@ require (
 	github.com/DataDog/datadog-go v4.8.2+incompatible
 	github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a
 	github.com/DataDog/ebpf v0.0.0-20210419131141-ea64821c9793
-	github.com/DataDog/ebpf-manager v0.0.0-20210827085405-e5ea1b643bf4
+	github.com/DataDog/ebpf-manager v0.0.0-20210917155050-c174a8b45802
 	github.com/DataDog/gohai v0.0.0-20210303102637-6b668acb50dd
 	github.com/DataDog/gopsutil v0.0.0-20210826200402-bbfc5b0ae6e9
 	github.com/DataDog/mmh3 v0.0.0-20200316233529-f5b682d8c981 // indirect
@@ -79,7 +79,7 @@ require (
 	github.com/blabber/go-freebsd-sysctl v0.0.0-20201130114544-503969f39d8f
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575
-	github.com/cilium/ebpf v0.6.2
+	github.com/cilium/ebpf v0.6.3-0.20210917122031-fc2955d2ecee
 	github.com/clbanning/mxj v1.8.4
 	github.com/cloudfoundry-community/go-cfclient v0.0.0-20210621174645-7773f7e22665
 	github.com/cobaugh/osrelease v0.0.0-20181218015638-a93a0a55a249
@@ -178,7 +178,7 @@ require (
 	golang.org/x/mobile v0.0.0-20201217150744-e6ae53a27f4f
 	golang.org/x/net v0.0.0-20210614182718-04defd469f4e
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
-	golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf
+	golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34
 	golang.org/x/text v0.3.7
 	golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba
 	golang.org/x/tools v0.1.5

--- a/go.sum
+++ b/go.sum
@@ -110,6 +110,8 @@ github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a h1
 github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a/go.mod h1:2qOvG41jii2ks6Umn6MbDGlHRgwoFiYXcjgQQ9VlsS0=
 github.com/DataDog/ebpf v0.0.0-20210419131141-ea64821c9793 h1:cqHOlzcc//2talOrZ+H7y3k9t3g16kH4EHRRYnDeRHU=
 github.com/DataDog/ebpf v0.0.0-20210419131141-ea64821c9793/go.mod h1:tSPYMUcskM0OLVEJSoydgYUVuhX8hOSmtaSLNtOQThg=
+github.com/DataDog/ebpf-manager v0.0.0-20210826153146-e8c086b72c5a h1:+6i0dz1NXoaY7Jt3eQeX/pFLWjmdJJShLc8LuVAbJ3c=
+github.com/DataDog/ebpf-manager v0.0.0-20210826153146-e8c086b72c5a/go.mod h1:9nh7d9k5CAVcxDKKonloCRcq1NLc/Tm0qpcPhWv5IwU=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c h1:a9OMhZzrrB4nd2eAsXZIBkQ061Gb/QT4CI2g+OWWevs=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c/go.mod h1:lMIXf2EAzxbIv2zEvWu1bdqlaclUWoCtN13MHuPcY5I=
 github.com/DataDog/gobpf v0.0.0-20210322155958-9866ef4cd22c h1:IlCUv480yLiHPGdB63f5Lw6TP8P1dEP/SjXzOVDRcWA=
@@ -223,8 +225,9 @@ github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:l
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aslakhellesoy/gox v1.0.100/go.mod h1:AJl542QsKKG96COVsv0N74HHzVQgDIQPceVUh1aeU2M=
 github.com/auth0/go-jwt-middleware v0.0.0-20170425171159-5493cabe49f7/go.mod h1:LWMyo4iOLWXHGdBki7NIht1kHru/0wM179h+d3g8ATM=
-github.com/avast/retry-go v2.7.0+incompatible h1:XaGnzl7gESAideSjr+I8Hki/JBi+Yb9baHlMRPeSC84=
 github.com/avast/retry-go v2.7.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
+github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
+github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/awalterschulze/gographviz v0.0.0-20160912181450-761fd5fbb34e/go.mod h1:GEV5wmg4YquNw7v1kkyoX9etIk8yVmXj+AkDHuuETHs=
 github.com/awalterschulze/gographviz v2.0.1+incompatible h1:XIECBRq9VPEQqkQL5pw2OtjCAdrtIgFKoJU8eT98AS8=
 github.com/awalterschulze/gographviz v2.0.1+incompatible/go.mod h1:GEV5wmg4YquNw7v1kkyoX9etIk8yVmXj+AkDHuuETHs=
@@ -504,8 +507,9 @@ github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW
 github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/florianl/go-conntrack v0.2.0 h1:JEB4w895ZX35tvNH5JjNM9pxa+Qn73paiA37VeCZGfc=
 github.com/florianl/go-conntrack v0.2.0/go.mod h1:HRSlXmrl5M//9hiHmkwyLDwlaoba2sVDcBpHFRiVo1Q=
-github.com/florianl/go-tc v0.2.0 h1:k3Dr3rtmMP2KCRlWgRUC6XKBZA5lL9rNBAr80H50/6k=
 github.com/florianl/go-tc v0.2.0/go.mod h1:aWdDOHrIpaff8cZp6z7dgJZ1bRsgTS6pXIW0xRdFTK8=
+github.com/florianl/go-tc v0.3.0 h1:qeqQB5kp2lwJP1p/8krLQIuRfkHWpiPPcYr3rhRSaC8=
+github.com/florianl/go-tc v0.3.0/go.mod h1:Ni/GTSK8ymDnsRQfL2meJeGmcXy7RFIvchiVHizU76U=
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/fogleman/gg v1.2.1-0.20190220221249-0403632d5b90/go.mod h1:R/bRT+9gY/C5z7JzPU0zXsXHKM4/ayA+zqcVNZzPa1k=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=

--- a/go.sum
+++ b/go.sum
@@ -110,8 +110,8 @@ github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a h1
 github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a/go.mod h1:2qOvG41jii2ks6Umn6MbDGlHRgwoFiYXcjgQQ9VlsS0=
 github.com/DataDog/ebpf v0.0.0-20210419131141-ea64821c9793 h1:cqHOlzcc//2talOrZ+H7y3k9t3g16kH4EHRRYnDeRHU=
 github.com/DataDog/ebpf v0.0.0-20210419131141-ea64821c9793/go.mod h1:tSPYMUcskM0OLVEJSoydgYUVuhX8hOSmtaSLNtOQThg=
-github.com/DataDog/ebpf-manager v0.0.0-20210826153146-e8c086b72c5a h1:+6i0dz1NXoaY7Jt3eQeX/pFLWjmdJJShLc8LuVAbJ3c=
-github.com/DataDog/ebpf-manager v0.0.0-20210826153146-e8c086b72c5a/go.mod h1:9nh7d9k5CAVcxDKKonloCRcq1NLc/Tm0qpcPhWv5IwU=
+github.com/DataDog/ebpf-manager v0.0.0-20210917155050-c174a8b45802 h1:t/F7Q6JsZiNsrvEjf7Uc7bBK9H+RvFBMHeZa0vHQrZM=
+github.com/DataDog/ebpf-manager v0.0.0-20210917155050-c174a8b45802/go.mod h1:DqqYWrCpPfP6mdseS1nFxWhqYm2Z28YacvPdqrhyK9I=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c h1:a9OMhZzrrB4nd2eAsXZIBkQ061Gb/QT4CI2g+OWWevs=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c/go.mod h1:lMIXf2EAzxbIv2zEvWu1bdqlaclUWoCtN13MHuPcY5I=
 github.com/DataDog/gobpf v0.0.0-20210322155958-9866ef4cd22c h1:IlCUv480yLiHPGdB63f5Lw6TP8P1dEP/SjXzOVDRcWA=
@@ -298,8 +298,9 @@ github.com/cilium/ebpf v0.0.0-20200702112145-1c8d4c9ef775/go.mod h1:7cR51M8ViRLI
 github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX2Qs=
 github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.5.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
-github.com/cilium/ebpf v0.6.2 h1:iHsfF/t4aW4heW2YKfeHrVPGdtYTL4C4KocpM8KTSnI=
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
+github.com/cilium/ebpf v0.6.3-0.20210917122031-fc2955d2ecee h1:eg3Xm5uBYJLRDVq750EFFx9CHTOEFIH/MjLNNpyTS3Y=
+github.com/cilium/ebpf v0.6.3-0.20210917122031-fc2955d2ecee/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2usCA=
 github.com/clbanning/mxj v1.8.4 h1:HuhwZtbyvyOw+3Z1AowPkU87JkJUSv751ELWaiTpj8I=
 github.com/clbanning/mxj v1.8.4/go.mod h1:BVjHeAH+rl9rs6f+QIpeRl0tfu10SXn1pUSa5PVGJng=
 github.com/clbanning/x2j v0.0.0-20191024224557-825249438eec/go.mod h1:jMjuTZXRI4dUb/I5gc9Hdhagfvm9+RyrPryS/auMzxE=
@@ -655,7 +656,6 @@ github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4er
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190702054246-869f871628b6/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20191227052852-215e87163ea7/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
-github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e h1:1r7pUrabqp18hOBcwBwiTsbnFeTZHV9eER/QT5JVZxY=
 github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da h1:oI5xCqsCo564l8iNU+DwB5epxmsaqB+rhGL0m5jtYqE=
 github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
@@ -742,7 +742,6 @@ github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm4
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.1/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
-github.com/google/uuid v1.2.0 h1:qJYtXnJRWmpe7m/3XlyhrsLrEURqHRM2kxzoxXqyUDs=
 github.com/google/uuid v1.2.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/google/uuid v1.3.0 h1:t6JiXgmwXMjEs8VusXIJk2BXHsn+wx8BZdTaoZ5fu7I=
 github.com/google/uuid v1.3.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -816,7 +815,6 @@ github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa
 github.com/hashicorp/go-rootcerts v1.0.1/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
 github.com/hashicorp/go-rootcerts v1.0.2 h1:jzhAVGtqPKbwpyCPELlgNWhE1znq+qwJtW5Oi2viEzc=
 github.com/hashicorp/go-rootcerts v1.0.2/go.mod h1:pqUvnprVnM5bf7AOirdbb01K4ccR319Vf4pU3K5EGc8=
-github.com/hashicorp/go-sockaddr v1.0.0 h1:GeH6tui99pF4NJgfnhp+L6+FfobzVW3Ah46sLo0ICXs=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-sockaddr v1.0.2 h1:ztczhD1jLxIRjVejw8gFomI1BQZOe2WoVOu0SyteCQc=
 github.com/hashicorp/go-sockaddr v1.0.2/go.mod h1:rB4wwRAUzs07qva3c5SdrY/NEtAUjGlgmH/UkBUC97A=
@@ -951,7 +949,6 @@ github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
-github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
 github.com/kr/pretty v0.3.0/go.mod h1:640gp4NfQd8pI5XOwp5fnNeVWj67G7CFk/SaSQn7NBk=
@@ -1204,7 +1201,6 @@ github.com/openzipkin/zipkin-go v0.2.2/go.mod h1:NaW6tEwdmWMaCDZzg8sh+IBNOxHMPnh
 github.com/oxtoacart/bpool v0.0.0-20150712133111-4e1c5567d7c2 h1:CXwSGu/LYmbjEab5aMCs5usQRVBGThelUKBNnoSOuso=
 github.com/oxtoacart/bpool v0.0.0-20150712133111-4e1c5567d7c2/go.mod h1:L3UMQOThbttwfYRNFOWLLVXMhk5Lkio4GGOtw5UrxS0=
 github.com/pact-foundation/pact-go v1.0.4/go.mod h1:uExwJY4kCzNPcHRj+hCR/HBbOOIwwtUjcrb0b5/5kLM=
-github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c h1:Lgl0gzECD8GnQ5QCWA8o6BtfL6mDH5rQgM4/fX3avOs=
 github.com/pascaldekloe/goe v0.0.0-20180627143212-57f6aae5913c/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
 github.com/pascaldekloe/goe v0.1.0 h1:cBOtyMzM9HTpWjXfbbunk26uA6nG3a8n06Wieeh0MwY=
 github.com/pascaldekloe/goe v0.1.0/go.mod h1:lzWF7FIEvWOWxwDKqyGYQf6ZUaNfKdP144TG7ZOy1lc=
@@ -1250,7 +1246,6 @@ github.com/prometheus/client_golang v1.1.0/go.mod h1:I1FGZT9+L76gKKOs5djB6ezCbFQ
 github.com/prometheus/client_golang v1.3.0/go.mod h1:hJaj2vgQTGQmVCsAACORcieXFeDPbaTKGT+JTgUa3og=
 github.com/prometheus/client_golang v1.4.1/go.mod h1:e9GMxYsXl05ICDXkRhurwBS4Q3OK1iX/F2sw+iXX5zU=
 github.com/prometheus/client_golang v1.7.1/go.mod h1:PY5Wy2awLA44sXw4AOSfFBetzPP4j5+D6mVACh+pe2M=
-github.com/prometheus/client_golang v1.10.0 h1:/o0BDeWzLWXNZ+4q5gXltUvaMpJqckTa+jTNoB+z4cg=
 github.com/prometheus/client_golang v1.10.0/go.mod h1:WJM3cc3yu7XKBKa/I8WeZm+V3eltZnBwfENSU7mdogU=
 github.com/prometheus/client_golang v1.11.0 h1:HNkLOAEQMIDv/K+04rukrLx6ch7msSRwf3/SASFAGtQ=
 github.com/prometheus/client_golang v1.11.0/go.mod h1:Z6t4BnS23TR94PD6BsDNk8yVqroYurpAkEiz0P2BEV0=
@@ -1272,7 +1267,6 @@ github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8b
 github.com/prometheus/common v0.10.0/go.mod h1:Tlit/dnDKsSWFlCLTWaA1cyBgKHSMdTB80sz/V91rCo=
 github.com/prometheus/common v0.15.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
 github.com/prometheus/common v0.18.0/go.mod h1:U+gB1OBLb1lF3O42bTCL+FK18tX9Oar16Clt/msog/s=
-github.com/prometheus/common v0.23.0 h1:GXWvPYuTUenIa+BhOq/x+L/QZzCqASkVRny5KTlPDGM=
 github.com/prometheus/common v0.23.0/go.mod h1:H6QK/N6XVT42whUeIdI3dp36w49c+/iMDk7UAI2qm7Q=
 github.com/prometheus/common v0.26.0/go.mod h1:M7rCNAaPfAosfx8veZJCuw84e35h3Cfd9VFqTh1DIvc=
 github.com/prometheus/common v0.28.0/go.mod h1:vu+V0TpY+O6vW9J44gczi3Ap/oXXR10b+M/gUGO4Hls=
@@ -1337,8 +1331,8 @@ github.com/shirou/gopsutil v3.21.8+incompatible h1:sh0foI8tMRlCidUJR+KzqWYWxrkuu
 github.com/shirou/gopsutil v3.21.8+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4 h1:udFKJ0aHUL60LboW/A+DfgoHVedieIzIXE8uylPue0U=
 github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4/go.mod h1:qsXQc7+bwAM3Q1u/4XEfrquwF8Lw7D7y5cD8CuHnfIc=
-github.com/shuLhan/go-bindata v3.6.1+incompatible h1:3mYSRYnbVAQlDGyk7KQKTMgNJ16NdPb61wFwNWlQACA=
-github.com/shuLhan/go-bindata v3.6.1+incompatible/go.mod h1:pkcPAATLBDD2+SpAPnX5vEM90F7fcwHCvvLCMXcmw3g=
+github.com/shuLhan/go-bindata v4.0.0+incompatible h1:xD8LkuVZLV5OOn/IEuFdt6EEAW7deWiqgwaaSGhjAJc=
+github.com/shuLhan/go-bindata v4.0.0+incompatible/go.mod h1:pkcPAATLBDD2+SpAPnX5vEM90F7fcwHCvvLCMXcmw3g=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
 github.com/sirupsen/logrus v1.0.4-0.20170822132746-89742aefa4b2/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
 github.com/sirupsen/logrus v1.0.6/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
@@ -1558,7 +1552,6 @@ go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.5.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
 go.uber.org/atomic v1.6.0/go.mod h1:sABNBOSYdrvTF6hTgEIbc7YasKWGhgEQZyfxyTvoXHQ=
-go.uber.org/atomic v1.7.0 h1:ADUqmZGgLDDfbSL9ZmPxKTybcoEYHgpYfELNoN+7hsw=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
@@ -1731,7 +1724,6 @@ golang.org/x/oauth2 v0.0.0-20210210192628-66670185b0cd/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210220000619-9bb904979d93/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602 h1:0Ja1LBD+yisY6RWM/BH7TJVXWsSjs2VwBSmvSX4HdBc=
 golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c h1:pkQiBZBvdos9qq4wBAHqlzuZHEXo07pqV06ef90u1WI=
 golang.org/x/oauth2 v0.0.0-20210514164344-f6687ab2804c/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
@@ -1868,8 +1860,9 @@ golang.org/x/sys v0.0.0-20210601080250-7ecdf8ef093b/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20210603081109-ebe580a85c40/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210611083646-a4fc73990273/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf h1:2ucpDCmfkl8Bd/FsLtiD653Wf96cW37s+iGx93zsu4k=
 golang.org/x/sys v0.0.0-20210823070655-63515b42dcdf/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34 h1:GkvMjFtXUmahfDtashnc1mnrCtuBVcwse5QV2lUk/tI=
+golang.org/x/sys v0.0.0-20210906170528-6f6e22806c34/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1 h1:v+OssWQX+hTHEmOBgwxdZxK4zHq3yOs8F9J7mk0PY8E=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Conntrack = NewRuntimeAsset("conntrack.c", "2f4ac71a61ef3a764322efc6ec7b466be9367599092ce963fe379e851d91d661")
+var Conntrack = NewRuntimeAsset("conntrack.c", "a72a9cf2b321f8825b1733b72e264a5df37c1aa280f0ff65c3900a5df84c993c")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "69f38781e7f63db8d59d43c0f20c1fc57acad6081dea1ef33cdfa1a9681736db")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "d2e9d0cb4078b47cf86c59e4af0444a1e52d8efd00575468ede26fa1c618719b")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "e7ed4607a0c4fcb6fe195c7cf632d00ea073061bfc9db8810a30db37ac5f8d5d")
+var Tracer = NewRuntimeAsset("tracer.c", "29339c91a2353e3f7aeda325e1dee9c07451ae8a6dd3850e74e2be1da4e1e4ac")

--- a/pkg/security/ebpf/c/cgroup.h
+++ b/pkg/security/ebpf/c/cgroup.h
@@ -98,22 +98,22 @@ static __attribute__((always_inline)) int trace__cgroup_write(struct pt_regs *ct
 }
 
 SEC("kprobe/cgroup_procs_write")
-int kprobe__cgroup_procs_write(struct pt_regs *ctx) {
+int kprobe_cgroup_procs_write(struct pt_regs *ctx) {
     return trace__cgroup_write(ctx);
 }
 
 SEC("kprobe/cgroup1_procs_write")
-int kprobe__cgroup1_procs_write(struct pt_regs *ctx) {
+int kprobe_cgroup1_procs_write(struct pt_regs *ctx) {
     return trace__cgroup_write(ctx);
 }
 
 SEC("kprobe/cgroup_tasks_write")
-int kprobe__cgroup_tasks_write(struct pt_regs *ctx) {
+int kprobe_cgroup_tasks_write(struct pt_regs *ctx) {
     return trace__cgroup_write(ctx);
 }
 
 SEC("kprobe/cgroup1_tasks_write")
-int kprobe__cgroup1_tasks_write(struct pt_regs *ctx) {
+int kprobe_cgroup1_tasks_write(struct pt_regs *ctx) {
     return trace__cgroup_write(ctx);
 }
 

--- a/pkg/security/ebpf/c/commit_creds.h
+++ b/pkg/security/ebpf/c/commit_creds.h
@@ -376,7 +376,7 @@ int tracepoint_handle_sys_commit_creds_exit(struct tracepoint_raw_syscalls_sys_e
 }
 
 SEC("kprobe/commit_creds")
-int kprobe__commit_creds(struct pt_regs *ctx) {
+int kprobe_commit_creds(struct pt_regs *ctx) {
     struct cred *credentials = (struct cred *)PT_REGS_PARM1(ctx);
     struct pid_cache_t new_pid_entry = {};
 

--- a/pkg/security/ebpf/c/dentry_resolver.h
+++ b/pkg/security/ebpf/c/dentry_resolver.h
@@ -194,13 +194,13 @@ int __attribute__((always_inline)) resolve_dentry_tail_call(struct dentry_resolv
     }                                                                                                                  \
 
 SEC("kprobe/dentry_resolver_kern")
-int kprobe__dentry_resolver_kern(struct pt_regs *ctx) {
+int kprobe_dentry_resolver_kern(struct pt_regs *ctx) {
     dentry_resolver_kern(ctx, &dentry_resolver_kprobe_progs, &dentry_resolver_kprobe_callbacks, DR_KPROBE_DENTRY_RESOLVER_KERN_KEY);
     return 0;
 }
 
 SEC("tracepoint/dentry_resolver_kern")
-int tracepoint__dentry_resolver_kern(void *ctx) {
+int tracepoint_dentry_resolver_kern(void *ctx) {
     dentry_resolver_kern(ctx, &dentry_resolver_tracepoint_progs, &dentry_resolver_tracepoint_callbacks, DR_TRACEPOINT_DENTRY_RESOLVER_KERN_KEY);
     return 0;
 }
@@ -302,7 +302,7 @@ exit:
 }
 
 SEC("kprobe/dentry_resolver_erpc")
-int kprobe__dentry_resolver_erpc(struct pt_regs *ctx) {
+int kprobe_dentry_resolver_erpc(struct pt_regs *ctx) {
     u32 key = 0;
     u32 resolution_err = 0;
     struct path_leaf_t *map_value = 0;

--- a/pkg/security/ebpf/c/dentry_resolver.h
+++ b/pkg/security/ebpf/c/dentry_resolver.h
@@ -375,7 +375,7 @@ exit:
 }
 
 SEC("kprobe/dentry_resolver_segment_erpc")
-int kprobe__dentry_resolver_segment_erpc(struct pt_regs *ctx) {
+int kprobe_dentry_resolver_segment_erpc(struct pt_regs *ctx) {
     u32 key = 0;
     u32 resolution_err = 0;
     struct dr_erpc_state_t *state = bpf_map_lookup_elem(&dr_erpc_state, &key);
@@ -419,7 +419,7 @@ exit:
 }
 
 SEC("kprobe/dentry_resolver_parent_erpc")
-int kprobe__dentry_resolver_parent_erpc(struct pt_regs *ctx) {
+int kprobe_dentry_resolver_parent_erpc(struct pt_regs *ctx) {
     u32 key = 0;
     u32 resolution_err = 0;
     struct dr_erpc_state_t *state = bpf_map_lookup_elem(&dr_erpc_state, &key);

--- a/pkg/security/ebpf/c/exec.h
+++ b/pkg/security/ebpf/c/exec.h
@@ -154,7 +154,7 @@ void __attribute__((always_inline)) parse_str_array(struct pt_regs *ctx, struct 
 
 
 SEC("kprobe/parse_args_envs")
-int parse_args_envs(struct pt_regs *ctx) {
+int kprobe_parse_args_envs(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_EXEC);
     if (!syscall) {
         return 0;
@@ -311,7 +311,7 @@ int kprobe_kernel_clone(struct pt_regs *ctx) {
 }
 
 SEC("kprobe/do_fork")
-int krpobe_do_fork(struct pt_regs *ctx) {
+int kprobe_do_fork(struct pt_regs *ctx) {
     return handle_do_fork(ctx);
 }
 

--- a/pkg/security/ebpf/c/filename.h
+++ b/pkg/security/ebpf/c/filename.h
@@ -4,7 +4,7 @@
 #include "syscalls.h"
 
 SEC("kprobe/filename_create")
-int kprobe__filename_create(struct pt_regs *ctx) {
+int kprobe_filename_create(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_ANY);
     if (!syscall)
         return 0;

--- a/pkg/security/ebpf/c/ioctl.h
+++ b/pkg/security/ebpf/c/ioctl.h
@@ -4,7 +4,7 @@
 #include "erpc.h"
 
 SEC("kprobe/do_vfs_ioctl")
-int kprobe__do_vfs_ioctl(struct pt_regs *ctx) {
+int kprobe_do_vfs_ioctl(struct pt_regs *ctx) {
     if (is_erpc_request(ctx)) {
         return handle_erpc_request(ctx);
     }

--- a/pkg/security/ebpf/c/link.h
+++ b/pkg/security/ebpf/c/link.h
@@ -42,7 +42,7 @@ SYSCALL_KPROBE0(linkat) {
 }
 
 SEC("kprobe/vfs_link")
-int kprobe__vfs_link(struct pt_regs *ctx) {
+int kprobe_vfs_link(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_LINK);
     if (!syscall)
         return 0;
@@ -85,7 +85,7 @@ int kprobe__vfs_link(struct pt_regs *ctx) {
 }
 
 SEC("kprobe/dr_link_src_callback")
-int __attribute__((always_inline)) dr_link_src_callback(struct pt_regs *ctx) {
+int __attribute__((always_inline)) kprobe_dr_link_src_callback(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_LINK);
     if (!syscall)
         return 0;

--- a/pkg/security/ebpf/c/mkdir.h
+++ b/pkg/security/ebpf/c/mkdir.h
@@ -47,7 +47,7 @@ SYSCALL_KPROBE3(mkdirat, int, dirfd, const char*, filename, umode_t, mode)
 }
 
 SEC("kprobe/vfs_mkdir")
-int kprobe__vfs_mkdir(struct pt_regs *ctx) {
+int kprobe_vfs_mkdir(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_MKDIR);
     if (!syscall)
         return 0;

--- a/pkg/security/ebpf/c/mnt.h
+++ b/pkg/security/ebpf/c/mnt.h
@@ -4,12 +4,12 @@
 #include "syscalls.h"
 
 int __attribute__((always_inline)) mnt_want_write_predicate(u64 type) {
-    return type == EVENT_UTIME || type == EVENT_CHMOD || type == EVENT_CHOWN || type == EVENT_RENAME || 
+    return type == EVENT_UTIME || type == EVENT_CHMOD || type == EVENT_CHOWN || type == EVENT_RENAME ||
         type == EVENT_RMDIR || type == EVENT_UNLINK || type == EVENT_SETXATTR || type == EVENT_REMOVEXATTR;
 }
 
 SEC("kprobe/mnt_want_write")
-int kprobe__mnt_want_write(struct pt_regs *ctx) {
+int kprobe_mnt_want_write(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall_with(mnt_want_write_predicate);
     if (!syscall)
         return 0;
@@ -96,13 +96,13 @@ int __attribute__((always_inline)) trace__mnt_want_write_file(struct pt_regs *ct
 }
 
 SEC("kprobe/mnt_want_write_file")
-int kprobe__mnt_want_write_file(struct pt_regs *ctx) {
+int kprobe_mnt_want_write_file(struct pt_regs *ctx) {
     return trace__mnt_want_write_file(ctx);
 }
 
 // mnt_want_write_file_path was used on old kernels (RHEL 7)
 SEC("kprobe/mnt_want_write_file_path")
-int kprobe__mnt_want_write_file_path(struct pt_regs *ctx) {
+int kprobe_mnt_want_write_file_path(struct pt_regs *ctx) {
     return trace__mnt_want_write_file(ctx);
 }
 

--- a/pkg/security/ebpf/c/mount.h
+++ b/pkg/security/ebpf/c/mount.h
@@ -31,7 +31,7 @@ SYSCALL_COMPAT_KPROBE3(mount, const char*, source, const char*, target, const ch
 }
 
 SEC("kprobe/attach_recursive_mnt")
-int kprobe__attach_recursive_mnt(struct pt_regs *ctx) {
+int kprobe_attach_recursive_mnt(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_MOUNT);
     if (!syscall)
         return 0;
@@ -61,7 +61,7 @@ int kprobe__attach_recursive_mnt(struct pt_regs *ctx) {
 }
 
 SEC("kprobe/propagate_mnt")
-int kprobe__propagate_mnt(struct pt_regs *ctx) {
+int kprobe_propagate_mnt(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_MOUNT);
     if (!syscall)
         return 0;

--- a/pkg/security/ebpf/c/open.h
+++ b/pkg/security/ebpf/c/open.h
@@ -127,7 +127,7 @@ int __attribute__((always_inline)) handle_open_event(struct syscall_cache_t *sys
 }
 
 SEC("kprobe/vfs_truncate")
-int kprobe__vfs_truncate(struct pt_regs *ctx) {
+int kprobe_vfs_truncate(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_OPEN);
     if (!syscall)
         return 0;
@@ -152,7 +152,7 @@ int kprobe__vfs_truncate(struct pt_regs *ctx) {
 }
 
 SEC("kprobe/vfs_open")
-int kprobe__vfs_open(struct pt_regs *ctx) {
+int kprobe_vfs_open(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_OPEN);
     if (!syscall)
         return 0;
@@ -166,7 +166,7 @@ int kprobe__vfs_open(struct pt_regs *ctx) {
 }
 
 SEC("kprobe/do_dentry_open")
-int kprobe__do_dentry_open(struct pt_regs *ctx) {
+int kprobe_do_dentry_open(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_EXEC);
     if (!syscall)
         return 0;
@@ -191,7 +191,7 @@ struct io_open {
 };
 
 SEC("kprobe/io_openat2")
-int kprobe__io_openat2(struct pt_regs *ctx) {
+int kprobe_io_openat2(struct pt_regs *ctx) {
     struct io_open req;
     if (bpf_probe_read(&req, sizeof(req), (void*) PT_REGS_PARM1(ctx))) {
         return 0;
@@ -299,7 +299,7 @@ int tracepoint_handle_sys_open_exit(struct tracepoint_raw_syscalls_sys_exit_t *a
 }
 
 SEC("kretprobe/io_openat2")
-int kretprobe__io_openat2(struct pt_regs *ctx) {
+int kretprobe_io_openat2(struct pt_regs *ctx) {
     struct file *f = (struct file *) PT_REGS_RC(ctx);
     if (IS_ERR(f))
         return 0;
@@ -308,7 +308,7 @@ int kretprobe__io_openat2(struct pt_regs *ctx) {
 }
 
 SEC("kprobe/filp_close")
-int kprobe__filp_close(struct pt_regs *ctx) {
+int kprobe_filp_close(struct pt_regs *ctx) {
     struct file *file = (struct file *) PT_REGS_PARM1(ctx);
     u32 mount_id = get_file_mount_id(file);
     if (mount_id) {

--- a/pkg/security/ebpf/c/procfs.h
+++ b/pkg/security/ebpf/c/procfs.h
@@ -11,7 +11,7 @@ struct bpf_map_def SEC("maps/exec_file_cache") exec_file_cache = {
 };
 
 SEC("kprobe/security_inode_getattr")
-int kprobe__security_inode_getattr(struct pt_regs *ctx) {
+int kprobe_security_inode_getattr(struct pt_regs *ctx) {
     u64 pid;
     LOAD_CONSTANT("runtime_pid", pid);
 

--- a/pkg/security/ebpf/c/rename.h
+++ b/pkg/security/ebpf/c/rename.h
@@ -41,7 +41,7 @@ SYSCALL_KPROBE0(renameat2) {
 }
 
 SEC("kprobe/vfs_rename")
-int kprobe__vfs_rename(struct pt_regs *ctx) {
+int kprobe_vfs_rename(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_RENAME);
     if (!syscall)
         return 0;

--- a/pkg/security/ebpf/c/rmdir.h
+++ b/pkg/security/ebpf/c/rmdir.h
@@ -33,7 +33,7 @@ int __attribute__((always_inline)) rmdir_predicate(u64 type) {
 
 // security_inode_rmdir is shared between rmdir and unlink syscalls
 SEC("kprobe/security_inode_rmdir")
-int kprobe__security_inode_rmdir(struct pt_regs *ctx) {
+int kprobe_security_inode_rmdir(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall_with(rmdir_predicate);
     if (!syscall)
         return 0;
@@ -103,7 +103,7 @@ int kprobe__security_inode_rmdir(struct pt_regs *ctx) {
 }
 
 SEC("kprobe/dr_security_inode_rmdir_callback")
-int __attribute__((always_inline)) dr_security_inode_rmdir_callback(struct pt_regs *ctx) {
+int __attribute__((always_inline)) kprobe_dr_security_inode_rmdir_callback(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall_with(rmdir_predicate);
     if (!syscall)
         return 0;

--- a/pkg/security/ebpf/c/selinux.h
+++ b/pkg/security/ebpf/c/selinux.h
@@ -196,7 +196,7 @@ int __attribute__((always_inline)) kprobe_dr_selinux_callback(struct pt_regs *ct
 
 #define PROBE_SEL_WRITE_FUNC(func_name, source_event)                       \
     SEC("kprobe/" #func_name)                                               \
-    int kprobe__##func_name(struct pt_regs *ctx) {                          \
+    int kprobe_##func_name(struct pt_regs *ctx) {                           \
         struct file *file = (struct file *)PT_REGS_PARM1(ctx);              \
         const char *buf = (const char *)PT_REGS_PARM2(ctx);                 \
         size_t count = (size_t)PT_REGS_PARM3(ctx);                          \

--- a/pkg/security/ebpf/c/setattr.h
+++ b/pkg/security/ebpf/c/setattr.h
@@ -12,7 +12,7 @@ int __attribute__((always_inline)) security_inode_predicate(u64 type) {
 }
 
 SEC("kprobe/security_inode_setattr")
-int kprobe__security_inode_setattr(struct pt_regs *ctx) {
+int kprobe_security_inode_setattr(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall_with(security_inode_predicate);
     if (!syscall)
         return 0;
@@ -80,7 +80,7 @@ int kprobe__security_inode_setattr(struct pt_regs *ctx) {
 }
 
 SEC("kprobe/dr_setattr_callback")
-int __attribute__((always_inline)) dr_setattr_callback(struct pt_regs *ctx) {
+int __attribute__((always_inline)) kprobe_dr_setattr_callback(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall_with(security_inode_predicate);
     if (!syscall)
         return 0;

--- a/pkg/security/ebpf/c/setxattr.h
+++ b/pkg/security/ebpf/c/setxattr.h
@@ -105,7 +105,7 @@ int __attribute__((always_inline)) xattr_predicate(u64 type) {
 }
 
 SEC("kprobe/dr_setxattr_callback")
-int __attribute__((always_inline)) dr_setxattr_callback(struct pt_regs *ctx) {
+int __attribute__((always_inline)) kprobe_dr_setxattr_callback(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall_with(xattr_predicate);
     if (!syscall)
         return 0;
@@ -118,12 +118,12 @@ int __attribute__((always_inline)) dr_setxattr_callback(struct pt_regs *ctx) {
 }
 
 SEC("kprobe/vfs_setxattr")
-int kprobe__vfs_setxattr(struct pt_regs *ctx) {
+int kprobe_vfs_setxattr(struct pt_regs *ctx) {
     return trace__vfs_setxattr(ctx, EVENT_SETXATTR);
 }
 
 SEC("kprobe/vfs_removexattr")
-int kprobe__vfs_removexattr(struct pt_regs *ctx) {
+int kprobe_vfs_removexattr(struct pt_regs *ctx) {
     return trace__vfs_setxattr(ctx, EVENT_REMOVEXATTR);
 }
 

--- a/pkg/security/ebpf/c/umount.h
+++ b/pkg/security/ebpf/c/umount.h
@@ -16,7 +16,7 @@ SYSCALL_KPROBE0(umount) {
 }
 
 SEC("kprobe/security_sb_umount")
-int kprobe__security_sb_umount(struct pt_regs *ctx) {
+int kprobe_security_sb_umount(struct pt_regs *ctx) {
     struct syscall_cache_t syscall = {
         .type = EVENT_UMOUNT,
         .umount = {

--- a/pkg/security/ebpf/c/umount.h
+++ b/pkg/security/ebpf/c/umount.h
@@ -54,7 +54,7 @@ int __attribute__((always_inline)) sys_umount_ret(void *ctx, int retval) {
 }
 
 SEC("tracepoint/syscalls/sys_exit_umount")
-int handle_sys_umount_exit(struct tracepoint_syscalls_sys_exit_t *args) {
+int tracepoint_syscalls_sys_exit_umount(struct tracepoint_syscalls_sys_exit_t *args) {
     return sys_umount_ret(args, args->ret);
 }
 

--- a/pkg/security/ebpf/c/unlink.h
+++ b/pkg/security/ebpf/c/unlink.h
@@ -41,7 +41,7 @@ SYSCALL_KPROBE3(unlinkat, int, dirfd, const char*, filename, int, flags) {
 }
 
 SEC("kprobe/vfs_unlink")
-int kprobe__vfs_unlink(struct pt_regs *ctx) {
+int kprobe_vfs_unlink(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_UNLINK);
     if (!syscall)
         return 0;
@@ -77,7 +77,7 @@ int kprobe__vfs_unlink(struct pt_regs *ctx) {
 }
 
 SEC("kprobe/dr_unlink_callback")
-int __attribute__((always_inline)) dr_unlink_callback(struct pt_regs *ctx) {
+int __attribute__((always_inline)) kprobe_dr_unlink_callback(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_UNLINK);
     if (!syscall)
         return 0;

--- a/pkg/security/ebpf/manager.go
+++ b/pkg/security/ebpf/manager.go
@@ -11,8 +11,8 @@ import (
 	"math"
 	"os"
 
-	"github.com/DataDog/ebpf"
-	"github.com/DataDog/ebpf/manager"
+	"github.com/DataDog/ebpf-manager/manager"
+	"github.com/cilium/ebpf"
 	"golang.org/x/sys/unix"
 
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/probes"

--- a/pkg/security/ebpf/manager.go
+++ b/pkg/security/ebpf/manager.go
@@ -11,7 +11,7 @@ import (
 	"math"
 	"os"
 
-	"github.com/DataDog/ebpf-manager/manager"
+	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cilium/ebpf"
 	"golang.org/x/sys/unix"
 

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -10,7 +10,7 @@ package probes
 import (
 	"math"
 
-	"github.com/DataDog/ebpf-manager/manager"
+	manager "github.com/DataDog/ebpf-manager"
 )
 
 // allProbes contain the list of all the probes of the runtime security module

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -10,7 +10,7 @@ package probes
 import (
 	"math"
 
-	"github.com/DataDog/ebpf/manager"
+	"github.com/DataDog/ebpf-manager/manager"
 )
 
 // allProbes contain the list of all the probes of the runtime security module
@@ -39,21 +39,33 @@ func AllProbes() []*manager.Probe {
 	allProbes = append(allProbes,
 		// Syscall monitor
 		&manager.Probe{
-			UID:     SecurityAgentUID,
-			Section: "tracepoint/raw_syscalls/sys_enter",
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFSection:  "tracepoint/raw_syscalls/sys_enter",
+				EBPFFuncName: "sys_enter",
+			},
 		},
 		&manager.Probe{
-			UID:     SecurityAgentUID,
-			Section: "tracepoint/raw_syscalls/sys_exit",
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFSection:  "tracepoint/raw_syscalls/sys_exit",
+				EBPFFuncName: "sys_exit",
+			},
 		},
 		&manager.Probe{
-			UID:     SecurityAgentUID,
-			Section: "tracepoint/sched/sched_process_exec",
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFSection:  "tracepoint/sched/sched_process_exec",
+				EBPFFuncName: "sched_process_exec",
+			},
 		},
 		// Snapshot probe
 		&manager.Probe{
-			UID:     SecurityAgentUID,
-			Section: "kprobe/security_inode_getattr",
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID:          SecurityAgentUID,
+				EBPFSection:  "kprobe/security_inode_getattr",
+				EBPFFuncName: "kprobe_security_inode_getattr",
+			},
 		},
 	)
 

--- a/pkg/security/ebpf/probes/attr.go
+++ b/pkg/security/ebpf/probes/attr.go
@@ -7,92 +7,131 @@
 
 package probes
 
-import "github.com/DataDog/ebpf/manager"
+import "github.com/DataDog/ebpf-manager/manager"
 
 // attrProbes holds the list of probes used to track link events
 var attrProbes = []*manager.Probe{
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/security_inode_setattr",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/security_inode_setattr",
+			EBPFFuncName: "kprobe_security_inode_setattr",
+		},
 	},
 }
 
 func getAttrProbes() []*manager.Probe {
 	// chmod
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "chmod",
 	}, EntryAndExit)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "fchmod",
 	}, EntryAndExit)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "fchmodat",
 	}, EntryAndExit)...)
 
 	// chown
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "chown",
 	}, EntryAndExit)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "chown16",
 	}, EntryAndExit)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "fchown",
 	}, EntryAndExit)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "fchown16",
 	}, EntryAndExit)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "fchownat",
 	}, EntryAndExit)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "lchown",
 	}, EntryAndExit)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "lchown16",
 	}, EntryAndExit)...)
 
 	// utime
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "utime",
 	}, EntryAndExit, true)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "utime32",
 	}, EntryAndExit)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "utimes",
 	}, EntryAndExit, true)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "utimes",
 	}, EntryAndExit|ExpandTime32)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "utimensat",
 	}, EntryAndExit, true)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "utimensat",
 	}, EntryAndExit|ExpandTime32)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "futimesat",
 	}, EntryAndExit, true)...)
 	attrProbes = append(attrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "futimesat",
 	}, EntryAndExit|ExpandTime32)...)
 	return attrProbes

--- a/pkg/security/ebpf/probes/attr.go
+++ b/pkg/security/ebpf/probes/attr.go
@@ -7,7 +7,7 @@
 
 package probes
 
-import "github.com/DataDog/ebpf-manager/manager"
+import manager "github.com/DataDog/ebpf-manager"
 
 // attrProbes holds the list of probes used to track link events
 var attrProbes = []*manager.Probe{

--- a/pkg/security/ebpf/probes/dentry.go
+++ b/pkg/security/ebpf/probes/dentry.go
@@ -7,7 +7,7 @@
 
 package probes
 
-import "github.com/DataDog/ebpf/manager"
+import manager "github.com/DataDog/ebpf-manager"
 
 // getDentryResolverTailCallRoutes is the list of routes used during the dentry resolution process
 func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled bool) []manager.TailCallRoute {
@@ -17,14 +17,16 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled bool) []manager
 			ProgArrayName: "dentry_resolver_kprobe_progs",
 			Key:           DentryResolverKernKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "kprobe/dentry_resolver_kern",
+				EBPFSection:  "kprobe/dentry_resolver_kern",
+				EBPFFuncName: "kprobe_dentry_resolver_kern",
 			},
 		},
 		{
 			ProgArrayName: "dentry_resolver_tracepoint_progs",
 			Key:           DentryResolverKernTracepointKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "tracepoint/dentry_resolver_kern",
+				EBPFSection:  "tracepoint/dentry_resolver_kern",
+				EBPFFuncName: "tracepoint_dentry_resolver_kern",
 			},
 		},
 
@@ -33,77 +35,88 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled bool) []manager
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverOpenCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "kprobe/dr_open_callback",
+				EBPFSection:  "kprobe/dr_open_callback",
+				EBPFFuncName: "kprobe_dr_open_callback",
 			},
 		},
 		{
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverSetAttrCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "kprobe/dr_setattr_callback",
+				EBPFSection:  "kprobe/dr_setattr_callback",
+				EBPFFuncName: "kprobe_dr_setattr_callback",
 			},
 		},
 		{
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverMkdirCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "kprobe/dr_mkdir_callback",
+				EBPFSection:  "kprobe/dr_mkdir_callback",
+				EBPFFuncName: "kprobe_dr_mkdir_callback",
 			},
 		},
 		{
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverMountCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "kprobe/dr_mount_callback",
+				EBPFSection:  "kprobe/dr_mount_callback",
+				EBPFFuncName: "kprobe_dr_mount_callback",
 			},
 		},
 		{
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverSecurityInodeRmdirCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "kprobe/dr_security_inode_rmdir_callback",
+				EBPFSection:  "kprobe/dr_security_inode_rmdir_callback",
+				EBPFFuncName: "kprobe_dr_security_inode_rmdir_callback",
 			},
 		},
 		{
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverSetXAttrCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "kprobe/dr_setxattr_callback",
+				EBPFSection:  "kprobe/dr_setxattr_callback",
+				EBPFFuncName: "kprobe_dr_setxattr_callback",
 			},
 		},
 		{
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverUnlinkCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "kprobe/dr_unlink_callback",
+				EBPFSection:  "kprobe/dr_unlink_callback",
+				EBPFFuncName: "kprobe_dr_unlink_callback",
 			},
 		},
 		{
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverLinkSrcCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "kprobe/dr_link_src_callback",
+				EBPFSection:  "kprobe/dr_link_src_callback",
+				EBPFFuncName: "kprobe_dr_link_src_callback",
 			},
 		},
 		{
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverLinkDstCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "kprobe/dr_link_dst_callback",
+				EBPFSection:  "kprobe/dr_link_dst_callback",
+				EBPFFuncName: "kprobe_dr_link_dst_callback",
 			},
 		},
 		{
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverRenameCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "kprobe/dr_rename_callback",
+				EBPFSection:  "kprobe/dr_rename_callback",
+				EBPFFuncName: "kprobe_dr_rename_callback",
 			},
 		},
 		{
 			ProgArrayName: "dentry_resolver_kprobe_callbacks",
 			Key:           DentryResolverSELinuxCallbackKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "kprobe/dr_selinux_callback",
+				EBPFSection:  "kprobe/dr_selinux_callback",
+				EBPFFuncName: "kprobe_dr_selinux_callback",
 			},
 		},
 
@@ -112,35 +125,40 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled bool) []manager
 			ProgArrayName: "dentry_resolver_tracepoint_callbacks",
 			Key:           DentryResolverOpenCallbackTracepointKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "tracepoint/dr_open_callback",
+				EBPFSection:  "tracepoint/dr_open_callback",
+				EBPFFuncName: "tracepoint_dr_open_callback",
 			},
 		},
 		{
 			ProgArrayName: "dentry_resolver_tracepoint_callbacks",
 			Key:           DentryResolverMkdirCallbackTracepointKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "tracepoint/dr_mkdir_callback",
+				EBPFSection:  "tracepoint/dr_mkdir_callback",
+				EBPFFuncName: "tracepoint_dr_mkdir_callback",
 			},
 		},
 		{
 			ProgArrayName: "dentry_resolver_tracepoint_callbacks",
 			Key:           DentryResolverMountCallbackTracepointKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "tracepoint/dr_mount_callback",
+				EBPFSection:  "tracepoint/dr_mount_callback",
+				EBPFFuncName: "tracepoint_dr_mount_callback",
 			},
 		},
 		{
 			ProgArrayName: "dentry_resolver_tracepoint_callbacks",
 			Key:           DentryResolverLinkDstCallbackTracepointKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "tracepoint/dr_link_dst_callback",
+				EBPFSection:  "tracepoint/dr_link_dst_callback",
+				EBPFFuncName: "tracepoint_dr_link_dst_callback",
 			},
 		},
 		{
 			ProgArrayName: "dentry_resolver_tracepoint_callbacks",
 			Key:           DentryResolverRenameCallbackTracepointKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "tracepoint/dr_rename_callback",
+				EBPFSection:  "tracepoint/dr_rename_callback",
+				EBPFFuncName: "tracepoint_dr_rename_callback",
 			},
 		},
 	}
@@ -152,21 +170,24 @@ func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled bool) []manager
 				ProgArrayName: "dentry_resolver_kprobe_progs",
 				Key:           DentryResolverERPCKey,
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					Section: "kprobe/dentry_resolver_erpc",
+					EBPFSection:  "kprobe/dentry_resolver_erpc",
+					EBPFFuncName: "kprobe_dentry_resolver_erpc",
 				},
 			},
 			{
 				ProgArrayName: "dentry_resolver_kprobe_progs",
 				Key:           DentryResolverParentERPCKey,
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					Section: "kprobe/dentry_resolver_parent_erpc",
+					EBPFSection:  "kprobe/dentry_resolver_parent_erpc",
+					EBPFFuncName: "kprobe_dentry_resolver_parent_erpc",
 				},
 			},
 			{
 				ProgArrayName: "dentry_resolver_kprobe_progs",
 				Key:           DentryResolverSegmentERPCKey,
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					Section: "kprobe/dentry_resolver_segment_erpc",
+					EBPFSection:  "kprobe/dentry_resolver_segment_erpc",
+					EBPFFuncName: "kprobe_dentry_resolver_segment_erpc",
 				},
 			},
 		}...)

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -8,7 +8,7 @@
 package probes
 
 import (
-	"github.com/DataDog/ebpf-manager/manager"
+	manager "github.com/DataDog/ebpf-manager"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/eval"
 )

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -8,15 +8,15 @@
 package probes
 
 import (
-	"github.com/DataDog/ebpf/manager"
+	"github.com/DataDog/ebpf-manager/manager"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/eval"
 )
 
 // SyscallMonitorSelectors is the list of probes that should be activated for the syscall monitor feature
 var SyscallMonitorSelectors = []manager.ProbesSelector{
-	&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "tracepoint/raw_syscalls/sys_enter"}},
-	&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "tracepoint/sched/sched_process_exec"}},
+	&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "tracepoint/raw_syscalls/sys_enter", EBPFFuncName: "sys_enter"}},
+	&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "tracepoint/sched/sched_process_exec", EBPFFuncName: "sched_process_exec"}},
 }
 
 // SelectorsPerEventType is the list of probes that should be activated for each event
@@ -26,361 +26,361 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 	"*": {
 		// Exec probes
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "tracepoint/raw_syscalls/sys_exit"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "tracepoint/sched/sched_process_fork"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/do_exit"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/security_bprm_committed_creds"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/exit_itimers"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "tracepoint/raw_syscalls/sys_exit", EBPFFuncName: "sys_exit"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "tracepoint/sched/sched_process_fork", EBPFFuncName: "sched_process_fork"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/do_exit", EBPFFuncName: "kprobe_do_exit"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_bprm_committed_creds", EBPFFuncName: "kprobe_security_bprm_committed_creds"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/exit_itimers", EBPFFuncName: "kprobe_exit_itimers"}},
 			&manager.BestEffort{Selectors: []manager.ProbesSelector{
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/prepare_binprm"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/bprm_execve"}},
-				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/security_bprm_check"}},
+				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/prepare_binprm", EBPFFuncName: "kprobe_prepare_binprm"}},
+				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/bprm_execve", EBPFFuncName: "kprobe_bprm_execve"}},
+				&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_bprm_check", EBPFFuncName: "kprobe_security_bprm_check"}},
 			}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/vfs_open"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/do_dentry_open"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/commit_creds"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/vfs_open", EBPFFuncName: "kprobe_vfs_open"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/do_dentry_open", EBPFFuncName: "kprobe_do_dentry_open"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/commit_creds", EBPFFuncName: "kprobe_commit_creds"}},
 		}},
 		&manager.OneOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/cgroup_procs_write"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/cgroup1_procs_write"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/cgroup_procs_write", EBPFFuncName: "kprobe_cgroup_procs_write"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/cgroup1_procs_write", EBPFFuncName: "kprobe_cgroup1_procs_write"}},
 		}},
 		&manager.OneOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/_do_fork"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/do_fork"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/kernel_clone"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/_do_fork", EBPFFuncName: "kprobe__do_fork"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/do_fork", EBPFFuncName: "kprobe_do_fork"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/kernel_clone", EBPFFuncName: "kprobe_kernel_clone"}},
 		}},
 		&manager.OneOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/cgroup_tasks_write"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/cgroup1_tasks_write"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/cgroup_tasks_write", EBPFFuncName: "kprobe_cgroup_tasks_write"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/cgroup1_tasks_write", EBPFFuncName: "kprobe_cgroup1_tasks_write"}},
 		}},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "execve"}, Entry),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "execve"}, Entry),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "execveat"}, Entry),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "execveat"}, Entry),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "setuid"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setuid"}, EntryAndExit),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "setuid16"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setuid16"}, EntryAndExit),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "setgid"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setgid"}, EntryAndExit),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "setgid16"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setgid16"}, EntryAndExit),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "seteuid"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "seteuid"}, EntryAndExit),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "seteuid16"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "seteuid16"}, EntryAndExit),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "setegid"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setegid"}, EntryAndExit),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "setegid16"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setegid16"}, EntryAndExit),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "setfsuid"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setfsuid"}, EntryAndExit),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "setfsuid16"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setfsuid16"}, EntryAndExit),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "setfsgid"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setfsgid"}, EntryAndExit),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "setfsgid16"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setfsgid16"}, EntryAndExit),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "setreuid"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setreuid"}, EntryAndExit),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "setreuid16"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setreuid16"}, EntryAndExit),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "setregid"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setregid"}, EntryAndExit),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "setregid16"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setregid16"}, EntryAndExit),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "setresuid"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setresuid"}, EntryAndExit),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "setresuid16"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setresuid16"}, EntryAndExit),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "setresgid"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setresgid"}, EntryAndExit),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "setresgid16"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setresgid16"}, EntryAndExit),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "capset"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "capset"}, EntryAndExit),
 		},
 
 		// Open probes
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/vfs_truncate"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/vfs_truncate", EBPFFuncName: "kprobe_vfs_truncate"}},
 		}},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "open"}, EntryAndExit, true),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "open"}, EntryAndExit, true),
 		},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "creat"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "creat"}, EntryAndExit),
 		},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "truncate"}, EntryAndExit, true),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "truncate"}, EntryAndExit, true),
 		},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "openat"}, EntryAndExit, true),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "openat"}, EntryAndExit, true),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "openat2"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "openat2"}, EntryAndExit),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "open_by_handle_at"}, EntryAndExit, true),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "open_by_handle_at"}, EntryAndExit, true),
 		},
 		&manager.BestEffort{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/io_openat2"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kretprobe/io_openat2"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/io_openat2", EBPFFuncName: "kprobe_io_openat2"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/io_openat2", EBPFFuncName: "kretprobe_io_openat2"}},
 		}},
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/filp_close"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/filp_close", EBPFFuncName: "kprobe_filp_close"}},
 		}},
 
 		// Mount probes
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/attach_recursive_mnt"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/propagate_mnt"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/security_sb_umount"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/attach_recursive_mnt", EBPFFuncName: "kprobe_attach_recursive_mnt"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/propagate_mnt", EBPFFuncName: "kprobe_propagate_mnt"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_sb_umount", EBPFFuncName: "kprobe_security_sb_umount"}},
 		}},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "mount"}, EntryAndExit, true),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "mount"}, EntryAndExit, true),
 		},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "umount"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "umount"}, EntryAndExit),
 		},
 
 		// Rename probes
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/vfs_rename"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/mnt_want_write"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/vfs_rename", EBPFFuncName: "kprobe_vfs_rename"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write", EBPFFuncName: "kprobe_mnt_want_write"}},
 		}},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "rename"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "rename"}, EntryAndExit),
 		},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "renameat"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "renameat"}, EntryAndExit),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "renameat2"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "renameat2"}, EntryAndExit),
 		},
 
 		// unlink rmdir probes
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/mnt_want_write"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write", EBPFFuncName: "kprobe_mnt_want_write"}},
 		}},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "unlinkat"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "unlinkat"}, EntryAndExit),
 		},
 
 		// Rmdir probes
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/security_inode_rmdir"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_inode_rmdir", EBPFFuncName: "kprobe_security_inode_rmdir"}},
 		}},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "rmdir"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "rmdir"}, EntryAndExit),
 		},
 
 		// Unlink probes
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/vfs_unlink"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/vfs_unlink", EBPFFuncName: "kprobe_vfs_unlink"}},
 		}},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "unlink"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "unlink"}, EntryAndExit),
 		},
 
 		// ioctl probes
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/do_vfs_ioctl"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/do_vfs_ioctl", EBPFFuncName: "kprobe_do_vfs_ioctl"}},
 		}},
 
 		// snapshot
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/security_inode_getattr"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_inode_getattr", EBPFFuncName: "kprobe_security_inode_getattr"}},
 		}},
 	},
 
 	// List of probes to activate to capture chmod events
 	"chmod": {
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/security_inode_setattr"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/mnt_want_write"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_inode_setattr", EBPFFuncName: "kprobe_security_inode_setattr"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write", EBPFFuncName: "kprobe_mnt_want_write"}},
 		}},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "chmod"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "chmod"}, EntryAndExit),
 		},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "fchmod"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "fchmod"}, EntryAndExit),
 		},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "fchmodat"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "fchmodat"}, EntryAndExit),
 		},
 	},
 
 	// List of probes to activate to capture chown events
 	"chown": {
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/security_inode_setattr"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/mnt_want_write"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_inode_setattr", EBPFFuncName: "kprobe_security_inode_setattr"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write", EBPFFuncName: "kprobe_mnt_want_write"}},
 		}},
 		&manager.OneOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/mnt_want_write_file"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/mnt_want_write_file_path"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write_file", EBPFFuncName: "kprobe_mnt_want_write_file"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write_file_path", EBPFFuncName: "kprobe_mnt_want_write_file_path"}},
 		}},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "chown"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "chown"}, EntryAndExit),
 		},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "chown16"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "chown16"}, EntryAndExit),
 		},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "fchown"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "fchown"}, EntryAndExit),
 		},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "fchown16"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "fchown16"}, EntryAndExit),
 		},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "fchownat"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "fchownat"}, EntryAndExit),
 		},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "lchown"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "lchown"}, EntryAndExit),
 		},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "lchown16"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "lchown16"}, EntryAndExit),
 		},
 	},
 
 	// List of probes to activate to capture link events
 	"link": {
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/vfs_link"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/filename_create"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/vfs_link", EBPFFuncName: "kprobe_vfs_link"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/filename_create", EBPFFuncName: "kprobe_filename_create"}},
 		}},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "link"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "link"}, EntryAndExit),
 		},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "linkat"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "linkat"}, EntryAndExit),
 		},
 	},
 
 	// List of probes to activate to capture mkdir events
 	"mkdir": {
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/vfs_mkdir"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/filename_create"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/vfs_mkdir", EBPFFuncName: "kprobe_vfs_mkdir"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/filename_create", EBPFFuncName: "kprobe_filename_create"}},
 		}},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "mkdir"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "mkdir"}, EntryAndExit),
 		},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "mkdirat"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "mkdirat"}, EntryAndExit),
 		},
 	},
 
 	// List of probes to activate to capture removexattr events
 	"removexattr": {
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/vfs_removexattr"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/mnt_want_write"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/vfs_removexattr", EBPFFuncName: "kprobe_vfs_removexattr"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write", EBPFFuncName: "kprobe_mnt_want_write"}},
 		}},
 		&manager.OneOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/mnt_want_write_file"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/mnt_want_write_file_path"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write_file", EBPFFuncName: "kprobe_mnt_want_write_file"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write_file_path", EBPFFuncName: "kprobe_mnt_want_write_file_path"}},
 		}},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "removexattr"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "removexattr"}, EntryAndExit),
 		},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "fremovexattr"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "fremovexattr"}, EntryAndExit),
 		},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "lremovexattr"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "lremovexattr"}, EntryAndExit),
 		},
 	},
 
 	// List of probes to activate to capture setxattr events
 	"setxattr": {
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/vfs_setxattr"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/mnt_want_write"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/vfs_setxattr", EBPFFuncName: "kprobe_vfs_setxattr"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write", EBPFFuncName: "kprobe_mnt_want_write"}},
 		}},
 		&manager.OneOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/mnt_want_write_file"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/mnt_want_write_file_path"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write_file", EBPFFuncName: "kprobe_mnt_want_write_file"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write_file_path", EBPFFuncName: "kprobe_mnt_want_write_file_path"}},
 		}},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "setxattr"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "setxattr"}, EntryAndExit),
 		},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "fsetxattr"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "fsetxattr"}, EntryAndExit),
 		},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "lsetxattr"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "lsetxattr"}, EntryAndExit),
 		},
 	},
 
 	// List of probes to activate to capture utimes events
 	"utimes": {
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/security_inode_setattr"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/mnt_want_write"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_inode_setattr", EBPFFuncName: "kprobe_security_inode_setattr"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/mnt_want_write", EBPFFuncName: "kprobe_mnt_want_write"}},
 		}},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "utime"}, EntryAndExit, true),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "utime"}, EntryAndExit, true),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "utime32"}, EntryAndExit),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "utime32"}, EntryAndExit),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "utimes"}, EntryAndExit, true),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "utimes"}, EntryAndExit, true),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "utimes"}, EntryAndExit|ExpandTime32),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "utimes"}, EntryAndExit|ExpandTime32),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "utimensat"}, EntryAndExit, true),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "utimensat"}, EntryAndExit, true),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "utimensat"}, EntryAndExit|ExpandTime32),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "utimensat"}, EntryAndExit|ExpandTime32),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "futimesat"}, EntryAndExit, true),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "futimesat"}, EntryAndExit, true),
 		},
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "futimesat"}, EntryAndExit|ExpandTime32),
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "futimesat"}, EntryAndExit|ExpandTime32),
 		},
 	},
 
 	"selinux": {
 		// This needs to be best effort, as sel_write_disable is in the process to be removed
 		&manager.BestEffort{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/sel_write_disable"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/sel_write_disable", EBPFFuncName: "kprobe_sel_write_disable"}},
 		}},
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/sel_write_enforce"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/sel_write_enforce", EBPFFuncName: "kprobe_sel_write_enforce"}},
 		}},
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/sel_write_bool"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/sel_write_bool", EBPFFuncName: "kprobe_sel_write_bool"}},
 		}},
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, Section: "kprobe/sel_commit_bools_write"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/sel_commit_bools_write", EBPFFuncName: "kprobe_sel_commit_bools_write"}},
 		}},
 	},
 }

--- a/pkg/security/ebpf/probes/exec.go
+++ b/pkg/security/ebpf/probes/exec.go
@@ -7,7 +7,7 @@
 
 package probes
 
-import "github.com/DataDog/ebpf-manager/manager"
+import manager "github.com/DataDog/ebpf-manager"
 
 // execProbes holds the list of probes used to track processes execution
 var execProbes = []*manager.Probe{

--- a/pkg/security/ebpf/probes/exec.go
+++ b/pkg/security/ebpf/probes/exec.go
@@ -7,81 +7,128 @@
 
 package probes
 
-import (
-	"github.com/DataDog/ebpf/manager"
-)
+import "github.com/DataDog/ebpf-manager/manager"
 
 // execProbes holds the list of probes used to track processes execution
 var execProbes = []*manager.Probe{
 	{
-		UID:     SecurityAgentUID,
-		Section: "tracepoint/sched/sched_process_fork",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "tracepoint/sched/sched_process_fork",
+			EBPFFuncName: "sched_process_fork",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/do_exit",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/do_exit",
+			EBPFFuncName: "kprobe_do_exit",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/do_fork",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/do_fork",
+			EBPFFuncName: "kprobe_do_fork",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/_do_fork",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/_do_fork",
+			EBPFFuncName: "kprobe__do_fork",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/kernel_clone",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/kernel_clone",
+			EBPFFuncName: "kprobe_kernel_clone",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/cgroup_procs_write",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/cgroup_procs_write",
+			EBPFFuncName: "kprobe_cgroup_procs_write",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/cgroup1_procs_write",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/cgroup1_procs_write",
+			EBPFFuncName: "kprobe_cgroup1_procs_write",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/cgroup_tasks_write",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/cgroup_tasks_write",
+			EBPFFuncName: "kprobe_cgroup_tasks_write",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/cgroup1_tasks_write",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/cgroup1_tasks_write",
+			EBPFFuncName: "kprobe_cgroup1_tasks_write",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/exit_itimers",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/exit_itimers",
+			EBPFFuncName: "kprobe_exit_itimers",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/prepare_binprm",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/prepare_binprm",
+			EBPFFuncName: "kprobe_prepare_binprm",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/bprm_execve",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/bprm_execve",
+			EBPFFuncName: "kprobe_bprm_execve",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/security_bprm_check",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/security_bprm_check",
+			EBPFFuncName: "kprobe_security_bprm_check",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/security_bprm_committed_creds",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/security_bprm_committed_creds",
+			EBPFFuncName: "kprobe_security_bprm_committed_creds",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/commit_creds",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/commit_creds",
+			EBPFFuncName: "kprobe_commit_creds",
+		},
 	},
 }
 
 func getExecProbes() []*manager.Probe {
 	execProbes = append(execProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "execve",
 	}, Entry)...)
 	execProbes = append(execProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "execveat",
 	}, Entry)...)
 
@@ -109,7 +156,9 @@ func getExecProbes() []*manager.Probe {
 		"capset",
 	} {
 		execProbes = append(execProbes, ExpandSyscallProbes(&manager.Probe{
-			UID:             SecurityAgentUID,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				UID: SecurityAgentUID,
+			},
 			SyscallFuncName: name,
 		}, EntryAndExit)...)
 	}
@@ -125,7 +174,8 @@ func getExecTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "args_envs_progs",
 			Key:           i,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "kprobe/parse_args_envs",
+				EBPFSection:  "kprobe/parse_args_envs",
+				EBPFFuncName: "kprobe_parse_args_envs",
 			},
 		}
 		routes = append(routes, route)

--- a/pkg/security/ebpf/probes/ioctl.go
+++ b/pkg/security/ebpf/probes/ioctl.go
@@ -7,7 +7,7 @@
 
 package probes
 
-import "github.com/DataDog/ebpf-manager/manager"
+import manager "github.com/DataDog/ebpf-manager"
 
 // ioctlProbes holds the list of probes used to track ioctl events
 var ioctlProbes = []*manager.Probe{

--- a/pkg/security/ebpf/probes/ioctl.go
+++ b/pkg/security/ebpf/probes/ioctl.go
@@ -7,13 +7,16 @@
 
 package probes
 
-import "github.com/DataDog/ebpf/manager"
+import "github.com/DataDog/ebpf-manager/manager"
 
 // ioctlProbes holds the list of probes used to track ioctl events
 var ioctlProbes = []*manager.Probe{
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/do_vfs_ioctl",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/do_vfs_ioctl",
+			EBPFFuncName: "kprobe_do_vfs_ioctl",
+		},
 	},
 }
 

--- a/pkg/security/ebpf/probes/link.go
+++ b/pkg/security/ebpf/probes/link.go
@@ -7,7 +7,7 @@
 
 package probes
 
-import "github.com/DataDog/ebpf-manager/manager"
+import manager "github.com/DataDog/ebpf-manager"
 
 // linkProbes holds the list of probes used to track link events
 var linkProbes = []*manager.Probe{

--- a/pkg/security/ebpf/probes/link.go
+++ b/pkg/security/ebpf/probes/link.go
@@ -7,23 +7,30 @@
 
 package probes
 
-import "github.com/DataDog/ebpf/manager"
+import "github.com/DataDog/ebpf-manager/manager"
 
 // linkProbes holds the list of probes used to track link events
 var linkProbes = []*manager.Probe{
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/vfs_link",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/vfs_link",
+			EBPFFuncName: "kprobe_vfs_link",
+		},
 	},
 }
 
 func getLinkProbe() []*manager.Probe {
 	linkProbes = append(linkProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "link",
 	}, EntryAndExit)...)
 	linkProbes = append(linkProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "linkat",
 	}, EntryAndExit)...)
 	return linkProbes

--- a/pkg/security/ebpf/probes/mkdir.go
+++ b/pkg/security/ebpf/probes/mkdir.go
@@ -7,7 +7,7 @@
 
 package probes
 
-import "github.com/DataDog/ebpf-manager/manager"
+import manager "github.com/DataDog/ebpf-manager"
 
 // mkdirProbes holds the list of probes used to track mkdir events
 var mkdirProbes = []*manager.Probe{

--- a/pkg/security/ebpf/probes/mkdir.go
+++ b/pkg/security/ebpf/probes/mkdir.go
@@ -7,23 +7,30 @@
 
 package probes
 
-import "github.com/DataDog/ebpf/manager"
+import "github.com/DataDog/ebpf-manager/manager"
 
 // mkdirProbes holds the list of probes used to track mkdir events
 var mkdirProbes = []*manager.Probe{
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/vfs_mkdir",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/vfs_mkdir",
+			EBPFFuncName: "kprobe_vfs_mkdir",
+		},
 	},
 }
 
 func getMkdirProbes() []*manager.Probe {
 	mkdirProbes = append(mkdirProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "mkdir",
 	}, EntryAndExit)...)
 	mkdirProbes = append(mkdirProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "mkdirat",
 	}, EntryAndExit)...)
 	return mkdirProbes

--- a/pkg/security/ebpf/probes/mount.go
+++ b/pkg/security/ebpf/probes/mount.go
@@ -7,33 +7,44 @@
 
 package probes
 
-import (
-	"github.com/DataDog/ebpf/manager"
-)
+import "github.com/DataDog/ebpf-manager/manager"
 
 // mountProbes holds the list of probes used to track mount points events
 var mountProbes = []*manager.Probe{
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/attach_recursive_mnt",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/attach_recursive_mnt",
+			EBPFFuncName: "kprobe_attach_recursive_mnt",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/propagate_mnt",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/propagate_mnt",
+			EBPFFuncName: "kprobe_propagate_mnt",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/security_sb_umount",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/security_sb_umount",
+			EBPFFuncName: "kprobe_security_sb_umount",
+		},
 	},
 }
 
 func getMountProbes() []*manager.Probe {
 	mountProbes = append(mountProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "mount",
 	}, EntryAndExit, true)...)
 	mountProbes = append(mountProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "umount",
 	}, EntryAndExit)...)
 	return mountProbes

--- a/pkg/security/ebpf/probes/mount.go
+++ b/pkg/security/ebpf/probes/mount.go
@@ -7,7 +7,7 @@
 
 package probes
 
-import "github.com/DataDog/ebpf-manager/manager"
+import manager "github.com/DataDog/ebpf-manager"
 
 // mountProbes holds the list of probes used to track mount points events
 var mountProbes = []*manager.Probe{

--- a/pkg/security/ebpf/probes/open.go
+++ b/pkg/security/ebpf/probes/open.go
@@ -7,7 +7,7 @@
 
 package probes
 
-import "github.com/DataDog/ebpf-manager/manager"
+import manager "github.com/DataDog/ebpf-manager"
 
 // openProbes holds the list of probes used to track file open events
 var openProbes = []*manager.Probe{

--- a/pkg/security/ebpf/probes/open.go
+++ b/pkg/security/ebpf/probes/open.go
@@ -7,61 +7,89 @@
 
 package probes
 
-import (
-	"github.com/DataDog/ebpf/manager"
-)
+import "github.com/DataDog/ebpf-manager/manager"
 
 // openProbes holds the list of probes used to track file open events
 var openProbes = []*manager.Probe{
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/vfs_truncate",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/vfs_truncate",
+			EBPFFuncName: "kprobe_vfs_truncate",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/vfs_open",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/vfs_open",
+			EBPFFuncName: "kprobe_vfs_open",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/do_dentry_open",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/do_dentry_open",
+			EBPFFuncName: "kprobe_do_dentry_open",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/io_openat2",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/io_openat2",
+			EBPFFuncName: "kprobe_io_openat2",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kretprobe/io_openat2",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kretprobe/io_openat2",
+			EBPFFuncName: "kretprobe_io_openat2",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/filp_close",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/filp_close",
+			EBPFFuncName: "kprobe_filp_close",
+		},
 	},
 }
 
 func getOpenProbes() []*manager.Probe {
 	openProbes = append(openProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "open",
 	}, EntryAndExit, true)...)
 	openProbes = append(openProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "creat",
 	}, EntryAndExit)...)
 	openProbes = append(openProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "open_by_handle_at",
 	}, EntryAndExit, true)...)
 	openProbes = append(openProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "truncate",
 	}, EntryAndExit, true)...)
 	openProbes = append(openProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "openat",
 	}, EntryAndExit, true)...)
 	openProbes = append(openProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "openat2",
 	}, EntryAndExit)...)
 	return openProbes

--- a/pkg/security/ebpf/probes/raw_sys_exit.go
+++ b/pkg/security/ebpf/probes/raw_sys_exit.go
@@ -9,7 +9,7 @@ package probes
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/security/model"
-	"github.com/DataDog/ebpf-manager/manager"
+	manager "github.com/DataDog/ebpf-manager"
 )
 
 func getSysExitTailCallRoutes() []manager.TailCallRoute {

--- a/pkg/security/ebpf/probes/raw_sys_exit.go
+++ b/pkg/security/ebpf/probes/raw_sys_exit.go
@@ -9,7 +9,7 @@ package probes
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/security/model"
-	"github.com/DataDog/ebpf/manager"
+	"github.com/DataDog/ebpf-manager/manager"
 )
 
 func getSysExitTailCallRoutes() []manager.TailCallRoute {
@@ -18,112 +18,128 @@ func getSysExitTailCallRoutes() []manager.TailCallRoute {
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileChmodEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "tracepoint/handle_sys_chmod_exit",
+				EBPFSection:  "tracepoint/handle_sys_chmod_exit",
+				EBPFFuncName: "tracepoint_handle_sys_chmod_exit",
 			},
 		},
 		{
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileChownEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "tracepoint/handle_sys_chown_exit",
+				EBPFSection:  "tracepoint/handle_sys_chown_exit",
+				EBPFFuncName: "tracepoint_handle_sys_chown_exit",
 			},
 		},
 		{
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileLinkEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "tracepoint/handle_sys_link_exit",
+				EBPFSection:  "tracepoint/handle_sys_link_exit",
+				EBPFFuncName: "tracepoint_handle_sys_link_exit",
 			},
 		},
 		{
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileMkdirEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "tracepoint/handle_sys_mkdir_exit",
+				EBPFSection:  "tracepoint/handle_sys_mkdir_exit",
+				EBPFFuncName: "tracepoint_handle_sys_mkdir_exit",
 			},
 		},
 		{
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileMountEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "tracepoint/handle_sys_mount_exit",
+				EBPFSection:  "tracepoint/handle_sys_mount_exit",
+				EBPFFuncName: "tracepoint_handle_sys_mount_exit",
 			},
 		},
 		{
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileOpenEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "tracepoint/handle_sys_open_exit",
+				EBPFSection:  "tracepoint/handle_sys_open_exit",
+				EBPFFuncName: "tracepoint_handle_sys_open_exit",
 			},
 		},
 		{
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileRenameEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "tracepoint/handle_sys_rename_exit",
+				EBPFSection:  "tracepoint/handle_sys_rename_exit",
+				EBPFFuncName: "tracepoint_handle_sys_rename_exit",
 			},
 		},
 		{
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileRmdirEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "tracepoint/handle_sys_rmdir_exit",
+				EBPFSection:  "tracepoint/handle_sys_rmdir_exit",
+				EBPFFuncName: "tracepoint_handle_sys_rmdir_exit",
 			},
 		},
 		{
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileSetXAttrEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "tracepoint/handle_sys_setxattr_exit",
+				EBPFSection:  "tracepoint/handle_sys_setxattr_exit",
+				EBPFFuncName: "tracepoint_handle_sys_setxattr_exit",
 			},
 		},
 		{
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileRemoveXAttrEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "tracepoint/handle_sys_removexattr_exit",
+				EBPFSection:  "tracepoint/handle_sys_removexattr_exit",
+				EBPFFuncName: "tracepoint_handle_sys_removexattr_exit",
 			},
 		},
 		{
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileUmountEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "tracepoint/handle_sys_umount_exit",
+				EBPFSection:  "tracepoint/handle_sys_umount_exit",
+				EBPFFuncName: "tracepoint_handle_sys_umount_exit",
 			},
 		},
 		{
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileUnlinkEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "tracepoint/handle_sys_unlink_exit",
+				EBPFSection:  "tracepoint/handle_sys_unlink_exit",
+				EBPFFuncName: "tracepoint_handle_sys_unlink_exit",
 			},
 		},
 		{
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.FileUtimesEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "tracepoint/handle_sys_utimes_exit",
+				EBPFSection:  "tracepoint/handle_sys_utimes_exit",
+				EBPFFuncName: "tracepoint_handle_sys_utimes_exit",
 			},
 		},
 		{
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.SetuidEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "tracepoint/handle_sys_commit_creds_exit",
+				EBPFSection:  "tracepoint/handle_sys_commit_creds_exit",
+				EBPFFuncName: "tracepoint_handle_sys_commit_creds_exit",
 			},
 		},
 		{
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.SetgidEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "tracepoint/handle_sys_commit_creds_exit",
+				EBPFSection:  "tracepoint/handle_sys_commit_creds_exit",
+				EBPFFuncName: "tracepoint_handle_sys_commit_creds_exit",
 			},
 		},
 		{
 			ProgArrayName: "sys_exit_progs",
 			Key:           uint32(model.CapsetEventType),
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "tracepoint/handle_sys_commit_creds_exit",
+				EBPFSection:  "tracepoint/handle_sys_commit_creds_exit",
+				EBPFFuncName: "tracepoint_handle_sys_commit_creds_exit",
 			},
 		},
 	}

--- a/pkg/security/ebpf/probes/rename.go
+++ b/pkg/security/ebpf/probes/rename.go
@@ -7,7 +7,7 @@
 
 package probes
 
-import "github.com/DataDog/ebpf-manager/manager"
+import manager "github.com/DataDog/ebpf-manager"
 
 // renameProbes holds the list of probes used to track file rename events
 var renameProbes = []*manager.Probe{

--- a/pkg/security/ebpf/probes/rename.go
+++ b/pkg/security/ebpf/probes/rename.go
@@ -7,27 +7,36 @@
 
 package probes
 
-import "github.com/DataDog/ebpf/manager"
+import "github.com/DataDog/ebpf-manager/manager"
 
 // renameProbes holds the list of probes used to track file rename events
 var renameProbes = []*manager.Probe{
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/vfs_rename",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/vfs_rename",
+			EBPFFuncName: "kprobe_vfs_rename",
+		},
 	},
 }
 
 func getRenameProbes() []*manager.Probe {
 	renameProbes = append(renameProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "rename",
 	}, EntryAndExit)...)
 	renameProbes = append(renameProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "renameat",
 	}, EntryAndExit)...)
 	renameProbes = append(renameProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "renameat2",
 	}, EntryAndExit)...)
 	return renameProbes

--- a/pkg/security/ebpf/probes/rmdir.go
+++ b/pkg/security/ebpf/probes/rmdir.go
@@ -7,7 +7,7 @@
 
 package probes
 
-import "github.com/DataDog/ebpf-manager/manager"
+import manager "github.com/DataDog/ebpf-manager"
 
 // rmdirProbes holds the list of probes used to track file rmdir events
 var rmdirProbes = []*manager.Probe{

--- a/pkg/security/ebpf/probes/rmdir.go
+++ b/pkg/security/ebpf/probes/rmdir.go
@@ -7,19 +7,24 @@
 
 package probes
 
-import "github.com/DataDog/ebpf/manager"
+import "github.com/DataDog/ebpf-manager/manager"
 
 // rmdirProbes holds the list of probes used to track file rmdir events
 var rmdirProbes = []*manager.Probe{
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/security_inode_rmdir",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/security_inode_rmdir",
+			EBPFFuncName: "kprobe_security_inode_rmdir",
+		},
 	},
 }
 
 func getRmdirProbe() []*manager.Probe {
 	rmdirProbes = append(rmdirProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "rmdir",
 	}, EntryAndExit)...)
 	return rmdirProbes

--- a/pkg/security/ebpf/probes/selinux.go
+++ b/pkg/security/ebpf/probes/selinux.go
@@ -7,7 +7,7 @@
 
 package probes
 
-import "github.com/DataDog/ebpf-manager/manager"
+import manager "github.com/DataDog/ebpf-manager"
 
 // selinuxProbes holds the list of probes used to track fs write events
 var selinuxProbes = []*manager.Probe{

--- a/pkg/security/ebpf/probes/selinux.go
+++ b/pkg/security/ebpf/probes/selinux.go
@@ -7,27 +7,37 @@
 
 package probes
 
-import (
-	"github.com/DataDog/ebpf/manager"
-)
+import "github.com/DataDog/ebpf-manager/manager"
 
 // selinuxProbes holds the list of probes used to track fs write events
 var selinuxProbes = []*manager.Probe{
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/sel_write_disable",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/sel_write_disable",
+			EBPFFuncName: "kprobe_sel_write_disable",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/sel_write_enforce",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/sel_write_enforce",
+			EBPFFuncName: "kprobe_sel_write_enforce",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/sel_write_bool",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/sel_write_bool",
+			EBPFFuncName: "kprobe_sel_write_bool",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/sel_commit_bools_write",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/sel_commit_bools_write",
+			EBPFFuncName: "kprobe_sel_commit_bools_write",
+		},
 	},
 }
 

--- a/pkg/security/ebpf/probes/shared.go
+++ b/pkg/security/ebpf/probes/shared.go
@@ -7,24 +7,36 @@
 
 package probes
 
-import "github.com/DataDog/ebpf/manager"
+import "github.com/DataDog/ebpf-manager/manager"
 
 // sharedProbes is the list of probes that are shared across multiple events
 var sharedProbes = []*manager.Probe{
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/filename_create",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/filename_create",
+			EBPFFuncName: "kprobe_filename_create",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/mnt_want_write",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/mnt_want_write",
+			EBPFFuncName: "kprobe_mnt_want_write",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/mnt_want_write_file",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/mnt_want_write_file",
+			EBPFFuncName: "kprobe_mnt_want_write_file",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/mnt_want_write_file_path",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/mnt_want_write_file_path",
+			EBPFFuncName: "kprobe_mnt_want_write_file_path",
+		},
 	},
 }

--- a/pkg/security/ebpf/probes/shared.go
+++ b/pkg/security/ebpf/probes/shared.go
@@ -7,7 +7,7 @@
 
 package probes
 
-import "github.com/DataDog/ebpf-manager/manager"
+import manager "github.com/DataDog/ebpf-manager"
 
 // sharedProbes is the list of probes that are shared across multiple events
 var sharedProbes = []*manager.Probe{

--- a/pkg/security/ebpf/probes/syscall_helpers.go
+++ b/pkg/security/ebpf/probes/syscall_helpers.go
@@ -135,7 +135,8 @@ const (
 func getFunctionNameFromSection(section string) string {
 	funcName := strings.ReplaceAll(section, "__ia32_", "__32_")
 	funcName = strings.ReplaceAll(funcName, "__x64_", "__64_")
-	funcName = strings.ReplaceAll(funcName, "/", "")
+	funcName = strings.ReplaceAll(funcName, "/_", "_")
+	funcName = strings.ReplaceAll(funcName, "/", "__64_")
 	return funcName
 }
 

--- a/pkg/security/ebpf/probes/syscall_helpers.go
+++ b/pkg/security/ebpf/probes/syscall_helpers.go
@@ -11,7 +11,7 @@ import (
 	"bytes"
 	"strings"
 
-	"github.com/DataDog/ebpf-manager/manager"
+	manager "github.com/DataDog/ebpf-manager"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 

--- a/pkg/security/ebpf/probes/syscall_helpers.go
+++ b/pkg/security/ebpf/probes/syscall_helpers.go
@@ -133,10 +133,16 @@ const (
 
 // getFunctionNameFromSection returns the generated function name from the generated section
 func getFunctionNameFromSection(section string) string {
-	funcName := strings.ReplaceAll(section, "__ia32_", "__32_")
-	funcName = strings.ReplaceAll(funcName, "__x64_", "__64_")
-	funcName = strings.ReplaceAll(funcName, "/_", "_")
-	funcName = strings.ReplaceAll(funcName, "/", "__64_")
+	funcName := section
+	if syscallPrefix == "sys_" {
+		funcName = strings.ReplaceAll(funcName, "kprobe/", "kprobe__64_")
+		funcName = strings.ReplaceAll(funcName, "kretprobe/", "kretprobe__64_")
+	} else {
+		funcName = strings.ReplaceAll(funcName, "__ia32_", "__32_")
+		funcName = strings.ReplaceAll(funcName, "__x64_", "__64_")
+		funcName = strings.ReplaceAll(funcName, "/_", "_")
+	}
+	funcName = strings.ReplaceAll(funcName, "tracepoint/syscalls/", "tracepoint_syscalls_")
 	return funcName
 }
 

--- a/pkg/security/ebpf/probes/unlink.go
+++ b/pkg/security/ebpf/probes/unlink.go
@@ -7,7 +7,7 @@
 
 package probes
 
-import "github.com/DataDog/ebpf-manager/manager"
+import manager "github.com/DataDog/ebpf-manager"
 
 // unlinkProbes holds the list of probes used to track unlink events
 var unlinkProbes = []*manager.Probe{

--- a/pkg/security/ebpf/probes/unlink.go
+++ b/pkg/security/ebpf/probes/unlink.go
@@ -7,25 +7,30 @@
 
 package probes
 
-import (
-	"github.com/DataDog/ebpf/manager"
-)
+import "github.com/DataDog/ebpf-manager/manager"
 
 // unlinkProbes holds the list of probes used to track unlink events
 var unlinkProbes = []*manager.Probe{
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/vfs_unlink",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/vfs_unlink",
+			EBPFFuncName: "kprobe_vfs_unlink",
+		},
 	},
 }
 
 func getUnlinkProbes() []*manager.Probe {
 	unlinkProbes = append(unlinkProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "unlink",
 	}, EntryAndExit)...)
 	unlinkProbes = append(unlinkProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "unlinkat",
 	}, EntryAndExit)...)
 	return unlinkProbes

--- a/pkg/security/ebpf/probes/xattr.go
+++ b/pkg/security/ebpf/probes/xattr.go
@@ -7,7 +7,7 @@
 
 package probes
 
-import "github.com/DataDog/ebpf-manager/manager"
+import manager "github.com/DataDog/ebpf-manager"
 
 // xattrProbes holds the list of probes used to track xattr events
 var xattrProbes = []*manager.Probe{

--- a/pkg/security/ebpf/probes/xattr.go
+++ b/pkg/security/ebpf/probes/xattr.go
@@ -7,43 +7,61 @@
 
 package probes
 
-import "github.com/DataDog/ebpf/manager"
+import "github.com/DataDog/ebpf-manager/manager"
 
 // xattrProbes holds the list of probes used to track xattr events
 var xattrProbes = []*manager.Probe{
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/vfs_setxattr",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/vfs_setxattr",
+			EBPFFuncName: "kprobe_vfs_setxattr",
+		},
 	},
 	{
-		UID:     SecurityAgentUID,
-		Section: "kprobe/vfs_removexattr",
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kprobe/vfs_removexattr",
+			EBPFFuncName: "kprobe_vfs_removexattr",
+		},
 	},
 }
 
 func getXattrProbes() []*manager.Probe {
 	xattrProbes = append(xattrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "setxattr",
 	}, EntryAndExit)...)
 	xattrProbes = append(xattrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "fsetxattr",
 	}, EntryAndExit)...)
 	xattrProbes = append(xattrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "lsetxattr",
 	}, EntryAndExit)...)
 	xattrProbes = append(xattrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "removexattr",
 	}, EntryAndExit)...)
 	xattrProbes = append(xattrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "fremovexattr",
 	}, EntryAndExit)...)
 	xattrProbes = append(xattrProbes, ExpandSyscallProbes(&manager.Probe{
-		UID:             SecurityAgentUID,
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID: SecurityAgentUID,
+		},
 		SyscallFuncName: "lremovexattr",
 	}, EntryAndExit)...)
 	return xattrProbes

--- a/pkg/security/probe/dentry_resolver.go
+++ b/pkg/security/probe/dentry_resolver.go
@@ -16,7 +16,7 @@ import (
 	"unsafe"
 
 	"github.com/DataDog/datadog-go/statsd"
-	lib "github.com/DataDog/ebpf"
+	lib "github.com/cilium/ebpf"
 	lru "github.com/hashicorp/golang-lru"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -17,7 +17,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/ebpf-manager/manager"
+	manager "github.com/DataDog/ebpf-manager"
 	lib "github.com/cilium/ebpf"
 	"github.com/hashicorp/golang-lru/simplelru"
 	"github.com/pkg/errors"

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -17,8 +17,8 @@ import (
 	"strings"
 	"time"
 
-	lib "github.com/DataDog/ebpf"
-	"github.com/DataDog/ebpf/manager"
+	"github.com/DataDog/ebpf-manager/manager"
+	lib "github.com/cilium/ebpf"
 	"github.com/hashicorp/golang-lru/simplelru"
 	"github.com/pkg/errors"
 

--- a/pkg/security/probe/erpc.go
+++ b/pkg/security/probe/erpc.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/DataDog/ebpf/manager"
+	"github.com/DataDog/ebpf-manager/manager"
 )
 
 const (

--- a/pkg/security/probe/erpc.go
+++ b/pkg/security/probe/erpc.go
@@ -11,7 +11,7 @@ import (
 	"syscall"
 	"unsafe"
 
-	"github.com/DataDog/ebpf-manager/manager"
+	manager "github.com/DataDog/ebpf-manager"
 )
 
 const (

--- a/pkg/security/probe/perf_buffer_monitor.go
+++ b/pkg/security/probe/perf_buffer_monitor.go
@@ -12,8 +12,8 @@ import (
 	"sync/atomic"
 
 	"github.com/DataDog/datadog-go/statsd"
-	lib "github.com/DataDog/ebpf"
-	"github.com/DataDog/ebpf/manager"
+	"github.com/DataDog/ebpf-manager/manager"
+	lib "github.com/cilium/ebpf"
 	"github.com/pkg/errors"
 
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/probes"

--- a/pkg/security/probe/perf_buffer_monitor.go
+++ b/pkg/security/probe/perf_buffer_monitor.go
@@ -12,7 +12,7 @@ import (
 	"sync/atomic"
 
 	"github.com/DataDog/datadog-go/statsd"
-	"github.com/DataDog/ebpf-manager/manager"
+	manager "github.com/DataDog/ebpf-manager"
 	lib "github.com/cilium/ebpf"
 	"github.com/pkg/errors"
 

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -18,7 +18,7 @@ import (
 	"unsafe"
 
 	"github.com/DataDog/datadog-go/statsd"
-	"github.com/DataDog/ebpf-manager/manager"
+	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cihub/seelog"
 	lib "github.com/cilium/ebpf"
 	"github.com/pkg/errors"

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -18,9 +18,9 @@ import (
 	"unsafe"
 
 	"github.com/DataDog/datadog-go/statsd"
-	lib "github.com/DataDog/ebpf"
-	"github.com/DataDog/ebpf/manager"
+	"github.com/DataDog/ebpf-manager/manager"
 	"github.com/cihub/seelog"
+	lib "github.com/cilium/ebpf"
 	"github.com/pkg/errors"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 
 	"github.com/DataDog/datadog-go/statsd"
-	"github.com/DataDog/ebpf-manager/manager"
+	manager "github.com/DataDog/ebpf-manager"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 
 	"github.com/DataDog/datadog-go/statsd"
-	"github.com/DataDog/ebpf/manager"
+	"github.com/DataDog/ebpf-manager/manager"
 	"github.com/hashicorp/go-multierror"
 	"github.com/pkg/errors"
 

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -20,9 +20,9 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-go/statsd"
-	lib "github.com/DataDog/ebpf"
-	"github.com/DataDog/ebpf/manager"
+	"github.com/DataDog/ebpf-manager/manager"
 	"github.com/DataDog/gopsutil/process"
+	lib "github.com/cilium/ebpf"
 	"github.com/hashicorp/golang-lru/simplelru"
 	"github.com/pkg/errors"
 

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -20,7 +20,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-go/statsd"
-	"github.com/DataDog/ebpf-manager/manager"
+	manager "github.com/DataDog/ebpf-manager"
 	"github.com/DataDog/gopsutil/process"
 	lib "github.com/cilium/ebpf"
 	"github.com/hashicorp/golang-lru/simplelru"

--- a/pkg/security/probe/reorderer.go
+++ b/pkg/security/probe/reorderer.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/ebpf-manager/manager"
+	manager "github.com/DataDog/ebpf-manager"
 )
 
 type reOrdererNodePool struct {

--- a/pkg/security/probe/reorderer.go
+++ b/pkg/security/probe/reorderer.go
@@ -12,7 +12,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/ebpf/manager"
+	"github.com/DataDog/ebpf-manager/manager"
 )
 
 type reOrdererNodePool struct {

--- a/pkg/security/probe/selinux_resolver.go
+++ b/pkg/security/probe/selinux_resolver.go
@@ -12,7 +12,7 @@ import (
 	"strings"
 
 	sebpf "github.com/DataDog/datadog-agent/pkg/security/ebpf"
-	"github.com/DataDog/ebpf"
+	"github.com/cilium/ebpf"
 )
 
 const (

--- a/pkg/security/probe/syscall_stats.go
+++ b/pkg/security/probe/syscall_stats.go
@@ -15,8 +15,8 @@ import (
 	"unsafe"
 
 	"github.com/DataDog/datadog-go/statsd"
-	lib "github.com/DataDog/ebpf"
-	"github.com/DataDog/ebpf/manager"
+	"github.com/DataDog/ebpf-manager/manager"
+	lib "github.com/cilium/ebpf"
 	"github.com/pkg/errors"
 
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf"

--- a/pkg/security/probe/syscall_stats.go
+++ b/pkg/security/probe/syscall_stats.go
@@ -15,7 +15,7 @@ import (
 	"unsafe"
 
 	"github.com/DataDog/datadog-go/statsd"
-	"github.com/DataDog/ebpf-manager/manager"
+	manager "github.com/DataDog/ebpf-manager"
 	lib "github.com/cilium/ebpf"
 	"github.com/pkg/errors"
 

--- a/releasenotes/notes/runtime-security-ebpf-manager-be479d16360687bc.yaml
+++ b/releasenotes/notes/runtime-security-ebpf-manager-be479d16360687bc.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    the runtime security module of system-probe is now powered by DataDog/ebpf-manager instead of DataDog/ebpf.


### PR DESCRIPTION
### What does this PR do?

This PR migrates the runtime security module of system-probe from [DataDog/ebpf](https://github.com/DataDog/ebpf) to [DataDog/ebpf-manager](https://github.com/DataDog/ebpf-manager).

### Motivation

While DataDog/ebpf is a fork of cilium/ebpf, DataDog/ebpf-manager is a wrapper of cilium/ebpf. The reason why we are migrating from the fork to the wrapper is to make it easier to integrate Cilium's upstream changes into the Datadog Agent.

### Describe how to test your changes

This PR should not introduce any change to the Runtime Security module. In other words, simply make sure that the entire test suite runs normally to test this PR.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
