### PR TITLE
Silenced usage and fixed duplicate errors

### DIFF
--- a/cmd/process-agent/main.go
+++ b/cmd/process-agent/main.go
@@ -3,7 +3,7 @@
 package main
 
 import (
-	"fmt"
+	"os"
 
 	"github.com/DataDog/datadog-agent/cmd/process-agent/flags"
 )
@@ -24,6 +24,6 @@ func main() {
 
 	fixDeprecatedFlags()
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		os.Exit(-1)
 	}
 }

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -68,6 +68,7 @@ var (
 			// Invoke the Agent
 			runAgent(exit)
 		},
+		SilenceUsage: true,
 	}
 
 	configCommand = cmdconfig.Config(getSettingsClient)

--- a/cmd/process-agent/main_windows.go
+++ b/cmd/process-agent/main_windows.go
@@ -190,7 +190,7 @@ func main() {
 	// Invoke the Agent
 	fixDeprecatedFlags()
 	if err := rootCmd.Execute(); err != nil {
-		fmt.Println(err)
+		os.Exit(-1)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?
Fixes duplicate errors and removed help message when an error occurs

### Motivation
Small nitpick noticed in QA.
### Additional Notes
### Describe how to test your changes
Run any command that returns an error and make sure that process-agent does not print help text, and that errors are printed exactly one time. An example of a command that you can run is `process-agent config get use_magic`, which should print
`Error: Get "http://localhost:6162/config/use_magic": dial tcp [::1]:6162: connectex: No connection could be made because the target machine actively refused it.`

You should also check to make sure that after returning an error, the exit code is -1.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
