### PR TITLE
Use ProtoStream to encode sketches

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -524,6 +524,9 @@ core,github.com/prometheus/common/model,Apache-2.0,The Prometheus Authors
 core,github.com/prometheus/procfs,Apache-2.0,The Prometheus Authors
 core,github.com/prometheus/procfs/internal/fs,Apache-2.0,The Prometheus Authors
 core,github.com/prometheus/procfs/internal/util,Apache-2.0,The Prometheus Authors
+core,github.com/richardartoul/molecule,MIT,Richard Artoul
+core,github.com/richardartoul/molecule/src/codec,Apache-2.0,Richard Artoul
+core,github.com/richardartoul/molecule/src/protowire,BSD-3-Clause,Richard Artoul | The Go Authors
 core,github.com/robfig/cron/v3,MIT,Rob Figueiredo
 core,github.com/samuel/go-zookeeper/zk,BSD-3-Clause,Samuel Stauffer <samuel@descolada.com>
 core,github.com/sassoftware/go-rpmutils,Apache-2.0,UNKNOWN

--- a/go.mod
+++ b/go.mod
@@ -149,6 +149,7 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.3 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.10.0
+	github.com/richardartoul/molecule v0.0.0-20210914193524-25d8911bb85b
 	github.com/samuel/go-zookeeper v0.0.0-20190923202752-2cc03de413da
 	github.com/shirou/gopsutil v3.21.7+incompatible
 	github.com/shirou/w32 v0.0.0-20160930032740-bb4de0191aa4

--- a/go.sum
+++ b/go.sum
@@ -1239,6 +1239,8 @@ github.com/prometheus/tsdb v0.7.1/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40T
 github.com/quobyte/api v0.1.8/go.mod h1:jL7lIHrmqQ7yh05OJ+eEEdHr0u/kmT1Ff9iHd+4H6VI=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/remyoudompheng/bigfft v0.0.0-20170806203942-52369c62f446/go.mod h1:uYEyJGbgTkfkS4+E/PavXkNJcbFIpEtjt2B0KDQ5+9M=
+github.com/richardartoul/molecule v0.0.0-20210914193524-25d8911bb85b h1:mbJ/v+xr6vdyRt8JqWm4WJKu6pO1h/t2vInWU0eKPL4=
+github.com/richardartoul/molecule v0.0.0-20210914193524-25d8911bb85b/go.mod h1:uvX/8buq8uVeiZiFht+0lqSLBHF+uGV8BrTv8W/SIwk=
 github.com/robfig/cron v1.1.0 h1:jk4/Hud3TTdcrJgUOBgsqrZBarcxl6ADIjSC2iniwLY=
 github.com/robfig/cron v1.1.0/go.mod h1:JGuDeoQd7Z6yL4zQhZ3OPEVHB7fL6Ka6skscFHfmt2k=
 github.com/robfig/cron/v3 v3.0.0/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=

--- a/pkg/metrics/sketch_series.go
+++ b/pkg/metrics/sketch_series.go
@@ -172,7 +172,6 @@ func (sl SketchSeriesList) MarshalSplitCompress(bufferContext *marshaler.BufferC
 
 	finishPayload := func() error {
 		var payload []byte
-		// Since the compression buffer is full - flush it and rotate
 		payload, err = compressor.Close()
 		if err != nil {
 			return err
@@ -276,6 +275,7 @@ func (sl SketchSeriesList) MarshalSplitCompress(bufferContext *marshaler.BufferC
 			expvarsPayloadFull.Add(1)
 			tlmPayloadFull.Inc()
 
+			// Since the compression buffer is full - flush it and start a new one
 			err = finishPayload()
 			if err != nil {
 				return nil, err

--- a/pkg/metrics/sketch_series.go
+++ b/pkg/metrics/sketch_series.go
@@ -143,18 +143,6 @@ func (sl SketchSeriesList) MarshalSplitCompress(bufferContext *marshaler.BufferC
 	const dogsketchK = 7
 	const dogsketchN = 8
 
-	// generate a footer containing an empty Metadata field (TODO: this isn't
-	// necessary; an omitted field will be assumed empty)
-	var footer []byte
-	{
-		buf := bytes.NewBuffer([]byte{})
-		ps := molecule.NewProtoStream(buf)
-		ps.Embedded(payloadMetadata, func(ps *molecule.ProtoStream) error {
-			return nil
-		})
-		footer = buf.Bytes()
-	}
-
 	// Prepare to write the next payload
 	startPayload := func() error {
 		var err error
@@ -162,7 +150,7 @@ func (sl SketchSeriesList) MarshalSplitCompress(bufferContext *marshaler.BufferC
 		bufferContext.CompressorInput.Reset()
 		bufferContext.CompressorOutput.Reset()
 
-		compressor, err = stream.NewCompressor(bufferContext.CompressorInput, bufferContext.CompressorOutput, []byte{}, footer, []byte{})
+		compressor, err = stream.NewCompressor(bufferContext.CompressorInput, bufferContext.CompressorOutput, []byte{}, []byte{}, []byte{})
 		if err != nil {
 			return err
 		}

--- a/pkg/metrics/sketch_series.go
+++ b/pkg/metrics/sketch_series.go
@@ -115,25 +115,24 @@ func (sl SketchSeriesList) MarshalSplitCompress(bufferContext *marshaler.BufferC
 
 	// constants for the protobuf data we will be writing, taken from
 	// https://github.com/DataDog/agent-payload/blob/a2cd634bc9c088865b75c6410335270e6d780416/proto/metrics/agent_payload.proto#L47-L81
+	// Unused fields are commented out
 	const payloadSketches = 1
-	const payloadMetadata = 2
+	// const payloadMetadata = 2
 	const sketchMetric = 1
 	const sketchHost = 2
-	const sketchDistributions = 3
+	// const sketchDistributions = 3
 	const sketchTags = 4
 	const sketchDogsketches = 7
-	/* unused
-	const distributionTs = 1
-	const distributionCnt = 2
-	const distributionMin = 3
-	const distributionMax = 4
-	const distributionAvg = 5
-	const distributionSum = 6
-	const distributionV = 7
-	const distributionG = 8
-	const distributionDelta = 9
-	const distributionBuf = 10
-	*/
+	// const distributionTs = 1
+	// const distributionCnt = 2
+	// const distributionMin = 3
+	// const distributionMax = 4
+	// const distributionAvg = 5
+	// const distributionSum = 6
+	// const distributionV = 7
+	// const distributionG = 8
+	// const distributionDelta = 9
+	// const distributionBuf = 10
 	const dogsketchTs = 1
 	const dogsketchCnt = 2
 	const dogsketchMin = 3

--- a/pkg/metrics/sketch_series.go
+++ b/pkg/metrics/sketch_series.go
@@ -13,6 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/serializer/stream"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/common"
+	"github.com/richardartoul/molecule"
 )
 
 // A SketchSeries is a timeseries of quantile sketches.
@@ -106,98 +107,198 @@ func (sl SketchSeriesList) MarshalJSON() ([]byte, error) {
 // it's contents are marshaled individually, packed with the appropriate protobuf metadata, and compressed in stream.
 // The resulting payloads (when decompressed) are binary equal to the result of marshaling the whole object at once.
 func (sl SketchSeriesList) MarshalSplitCompress(bufferContext *marshaler.BufferContext) ([]*[]byte, error) {
-	// The Metadata field of gogen.SketchPayload is never written to - so pack an empty metadata as the footer
-	footer := []byte{0x12, 0}
-
-	bufferContext.CompressorInput.Reset()
-	bufferContext.CompressorOutput.Reset()
-
-	compressor, e := stream.NewCompressor(bufferContext.CompressorInput, bufferContext.CompressorOutput, []byte{}, footer, []byte{})
-	if e != nil {
-		return nil, e
-	}
+	var err error
+	var compressor *stream.Compressor
+	buf := bufferContext.PrecompressionBuf
+	ps := molecule.NewProtoStream(buf)
 	payloads := []*[]byte{}
 
-	dsl := make([]gogen.SketchPayload_Sketch_Dogsketch, 1)
+	// constants for the protobuf data we will be writing, taken from
+	// https://github.com/DataDog/agent-payload/blob/a2cd634bc9c088865b75c6410335270e6d780416/proto/metrics/agent_payload.proto#L47-L81
+	const payloadSketches = 1
+	const payloadMetadata = 2
+	const sketchMetric = 1
+	const sketchHost = 2
+	const sketchDistributions = 3
+	const sketchTags = 4
+	const sketchDogsketches = 7
+	/* unused
+	const distributionTs = 1
+	const distributionCnt = 2
+	const distributionMin = 3
+	const distributionMax = 4
+	const distributionAvg = 5
+	const distributionSum = 6
+	const distributionV = 7
+	const distributionG = 8
+	const distributionDelta = 9
+	const distributionBuf = 10
+	*/
+	const dogsketchTs = 1
+	const dogsketchCnt = 2
+	const dogsketchMin = 3
+	const dogsketchMax = 4
+	const dogsketchAvg = 5
+	const dogsketchSum = 6
+	const dogsketchK = 7
+	const dogsketchN = 8
+
+	// generate a footer containing an empty Metadata field (TODO: this isn't
+	// necessary; an omitted field will be assumed empty)
+	var footer []byte
+	{
+		buf := bytes.NewBuffer([]byte{})
+		ps := molecule.NewProtoStream(buf)
+		ps.Embedded(payloadMetadata, func(ps *molecule.ProtoStream) error {
+			return nil
+		})
+		footer = buf.Bytes()
+	}
+
+	// Prepare to write the next payload
+	startPayload := func() error {
+		var err error
+
+		bufferContext.CompressorInput.Reset()
+		bufferContext.CompressorOutput.Reset()
+
+		compressor, err = stream.NewCompressor(bufferContext.CompressorInput, bufferContext.CompressorOutput, []byte{}, footer, []byte{})
+		if err != nil {
+			return err
+		}
+
+		return nil
+	}
+
+	finishPayload := func() error {
+		var payload []byte
+		// Since the compression buffer is full - flush it and rotate
+		payload, err = compressor.Close()
+		if err != nil {
+			return err
+		}
+
+		payloads = append(payloads, &payload)
+
+		return nil
+	}
+
+	// start things off
+	err = startPayload()
+	if err != nil {
+		return nil, err
+	}
+
 	for _, ss := range sl {
-		if len(ss.Points) > cap(dsl) {
-			dsl = make([]gogen.SketchPayload_Sketch_Dogsketch, len(ss.Points))
-		}
+		buf.Reset()
+		err = ps.Embedded(payloadSketches, func(ps *molecule.ProtoStream) error {
+			var err error
 
-		for i, p := range ss.Points {
-			b := p.Sketch.Basic
-			k, n := p.Sketch.Cols()
-			dsl[i] = gogen.SketchPayload_Sketch_Dogsketch{
-				Ts:  p.Ts,
-				Cnt: b.Cnt,
-				Min: b.Min,
-				Max: b.Max,
-				Avg: b.Avg,
-				Sum: b.Sum,
-				K:   k,
-				N:   n,
+			err = ps.String(sketchMetric, ss.Name)
+			if err != nil {
+				return err
 			}
-		}
 
-		sketch := gogen.SketchPayload_Sketch{
-			Metric:      ss.Name,
-			Host:        ss.Host,
-			Tags:        ss.Tags,
-			Dogsketches: dsl[:len(ss.Points)],
-		}
+			err = ps.String(sketchHost, ss.Host)
+			if err != nil {
+				return err
+			}
 
-		// Pack the protobuf metadata - see SketchPayload.MarshalTo in agent_payload.pb.go for reference.
-		metadataSize := 0
-		// Magic number that occurs before the varint encoding
-		bufferContext.PrecompressionBuf[metadataSize] = 0xa
-		metadataSize++
-		metadataSize = encodeVarintAgentPayload(bufferContext.PrecompressionBuf, metadataSize, uint64(sketch.Size()))
+			for _, tag := range ss.Tags {
+				err = ps.String(sketchTags, tag)
+				if err != nil {
+					return err
+				}
+			}
 
-		// Resize the pre-compression buffer if needed
-		totalItemSize := sketch.Size() + metadataSize
-		if totalItemSize > cap(bufferContext.PrecompressionBuf) {
-			bufferContext.PrecompressionBuf = append(bufferContext.PrecompressionBuf, make([]byte, totalItemSize-cap(bufferContext.PrecompressionBuf))...)
-			bufferContext.PrecompressionBuf = bufferContext.PrecompressionBuf[:cap(bufferContext.PrecompressionBuf)]
-		}
+			for _, p := range ss.Points {
+				err = ps.Embedded(sketchDogsketches, func(ps *molecule.ProtoStream) error {
+					b := p.Sketch.Basic
+					k, n := p.Sketch.Cols()
 
-		// Marshal the sketch to the precompression buffer after the metadata
-		_, e := sketch.MarshalTo(bufferContext.PrecompressionBuf[metadataSize:])
-		if e != nil {
-			return nil, e
+					err = ps.Int64(dogsketchTs, p.Ts)
+					if err != nil {
+						return err
+					}
+
+					err = ps.Int64(dogsketchCnt, b.Cnt)
+					if err != nil {
+						return err
+					}
+
+					err = ps.Double(dogsketchMin, b.Min)
+					if err != nil {
+						return err
+					}
+
+					err = ps.Double(dogsketchMax, b.Max)
+					if err != nil {
+						return err
+					}
+
+					err = ps.Double(dogsketchAvg, b.Avg)
+					if err != nil {
+						return err
+					}
+
+					err = ps.Double(dogsketchSum, b.Sum)
+					if err != nil {
+						return err
+					}
+
+					err = ps.Sint32Packed(dogsketchK, k)
+					if err != nil {
+						return err
+					}
+
+					err = ps.Uint32Packed(dogsketchN, n)
+					if err != nil {
+						return err
+					}
+
+					return nil
+				})
+				if err != nil {
+					return err
+				}
+			}
+
+			return nil
+		})
+		if err != nil {
+			return nil, err
 		}
 
 		// Compress the protobuf metadata and the marshaled sketch
-		switch compressor.AddItem(bufferContext.PrecompressionBuf[:totalItemSize]) {
+		err = compressor.AddItem(buf.Bytes())
+		switch err {
 		case stream.ErrPayloadFull:
 			expvarsPayloadFull.Add(1)
 			tlmPayloadFull.Inc()
 
-			// Since the compression buffer is full - flush it and rotate
-			payload, e := compressor.Close()
-			if e != nil {
-				return nil, e
+			err = finishPayload()
+			if err != nil {
+				return nil, err
 			}
-			payloads = append(payloads, &payload)
-			bufferContext.CompressorInput.Reset()
-			bufferContext.CompressorOutput.Reset()
-			compressor, e = stream.NewCompressor(bufferContext.CompressorInput, bufferContext.CompressorOutput, []byte{}, footer, []byte{})
-			if e != nil {
-				return nil, e
+
+			err = startPayload()
+			if err != nil {
+				return nil, err
 			}
 
 			// Add it to the new compression buffer
-			e = compressor.AddItem(bufferContext.PrecompressionBuf[:totalItemSize])
-			if e == stream.ErrItemTooBig {
+			err = compressor.AddItem(buf.Bytes())
+			if err == stream.ErrItemTooBig {
 				// Item was too big, drop it
 				expvarsItemTooBig.Add(1)
 				tlmItemTooBig.Inc()
 				continue
 			}
-			if e != nil {
+			if err != nil {
 				// Unexpected error bail out
 				expvarsUnexpectedItemDrops.Add(1)
 				tlmUnexpectedItemDrops.Inc()
-				return nil, e
+				return nil, err
 			}
 		case stream.ErrItemTooBig:
 			// Item was too big, drop it
@@ -209,17 +310,15 @@ func (sl SketchSeriesList) MarshalSplitCompress(bufferContext *marshaler.BufferC
 			// Unexpected error bail out
 			expvarsUnexpectedItemDrops.Add(1)
 			tlmUnexpectedItemDrops.Inc()
-			return nil, e
+			return nil, err
 		}
 	}
 
-	payload, e := compressor.Close()
-	if e != nil {
-		return nil, e
+	err = finishPayload()
+	if err != nil {
+		return nil, err
 	}
-	payloads = append(payloads, &payload)
 
-	// return payloads, nonCompressed
 	return payloads, nil
 }
 

--- a/pkg/metrics/sketch_series.go
+++ b/pkg/metrics/sketch_series.go
@@ -322,17 +322,6 @@ func (sl SketchSeriesList) MarshalSplitCompress(bufferContext *marshaler.BufferC
 	return payloads, nil
 }
 
-// taken from agent_payload.pb.go
-func encodeVarintAgentPayload(dAtA []byte, offset int, v uint64) int {
-	for v >= 1<<7 {
-		dAtA[offset] = uint8(v&0x7f | 0x80)
-		v >>= 7
-		offset++
-	}
-	dAtA[offset] = uint8(v)
-	return offset + 1
-}
-
 // Marshal encodes this series list.
 func (sl SketchSeriesList) Marshal() ([]byte, error) {
 	pb := &gogen.SketchPayload{

--- a/pkg/metrics/sketch_series_test.go
+++ b/pkg/metrics/sketch_series_test.go
@@ -158,8 +158,7 @@ func TestSketchSeriesMarshalSplitCompress(t *testing.T) {
 
 	payload, _ := sl.Marshal()
 	payloads, err := sl.MarshalSplitCompress(marshaler.DefaultBufferContext())
-
-	assert.Nil(t, err)
+	require.NoError(t, err)
 
 	reader := bytes.NewReader(*payloads[0])
 	r, _ := zlib.NewReader(reader)
@@ -170,9 +169,8 @@ func TestSketchSeriesMarshalSplitCompress(t *testing.T) {
 	assert.Equal(t, decompressed, payload)
 
 	pl := new(gogen.SketchPayload)
-	if err := pl.Unmarshal(decompressed); err != nil {
-		t.Fatal(err)
-	}
+	err = pl.Unmarshal(decompressed)
+	require.NoError(t, err)
 
 	require.Len(t, pl.Sketches, len(sl))
 

--- a/pkg/serializer/marshaler/marshaler.go
+++ b/pkg/serializer/marshaler/marshaler.go
@@ -33,7 +33,7 @@ type StreamJSONMarshaler interface {
 type BufferContext struct {
 	CompressorInput   *bytes.Buffer
 	CompressorOutput  *bytes.Buffer
-	PrecompressionBuf []byte
+	PrecompressionBuf *bytes.Buffer
 }
 
 // DefaultBufferContext initialize the default compression buffers
@@ -41,6 +41,6 @@ func DefaultBufferContext() *BufferContext {
 	return &BufferContext{
 		bytes.NewBuffer(make([]byte, 0, 1024)),
 		bytes.NewBuffer(make([]byte, 0, 1024)),
-		make([]byte, 1024),
+		bytes.NewBuffer(make([]byte, 0, 1024)),
 	}
 }

--- a/pkg/serializer/stream/compressor.go
+++ b/pkg/serializer/stream/compressor.go
@@ -132,6 +132,11 @@ func (c *Compressor) pack() error {
 	return nil
 }
 
+func (c *Compressor) Write(data []byte) (int, error) {
+	err := c.AddItem(data)
+	return len(data), err
+}
+
 // AddItem will try to add the given item
 func (c *Compressor) AddItem(data []byte) error {
 	// check item size sanity


### PR DESCRIPTION
### What does this PR do?

This rewrites the sketch_series marhsaling to use ProtoStream (c.f. #9008).

In running the existing benchmarks, this is about 8% faster, but more importantly saves 50% on allocations / RAM.

```
name                          old time/op        new time/op        delta
MarshalSplitCompress1-16            1.97ms ± 0%        1.91ms ± 0%   -2.82%  (p=0.000 n=10+10)
MarshalSplitCompress10-16           18.1ms ± 0%        16.6ms ± 0%   -8.24%  (p=0.000 n=10+10)
MarshalSplitCompress100-16           176ms ± 1%         162ms ± 0%   -8.10%  (p=0.000 n=10+10)
MarshalSplitCompress1000-16          1.74s ± 0%         1.59s ± 0%   -8.37%  (p=0.000 n=9+9)
MarshalSplitCompress10000-16         17.4s ± 0%         15.9s ± 1%   -8.31%  (p=0.016 n=4+5)

name                          old payload-bytes  new payload-bytes  delta
MarshalSplitCompress1-16            5.15kB ± 0%        5.15kB ± 0%     ~     (all equal)
MarshalSplitCompress10-16           50.0kB ± 0%        50.0kB ± 0%     ~     (all equal)
MarshalSplitCompress100-16           498kB ± 0%         498kB ± 0%     ~     (all equal)
MarshalSplitCompress1000-16         4.98MB ± 0%        4.98MB ± 0%     ~     (all equal)
MarshalSplitCompress10000-16        49.8MB ± 0%        49.8MB ± 0%     ~     (all equal)

name                          old payloads       new payloads       delta
MarshalSplitCompress1-16              1.00 ± 0%          1.00 ± 0%     ~     (all equal)
MarshalSplitCompress10-16             1.00 ± 0%          1.00 ± 0%     ~     (all equal)
MarshalSplitCompress100-16            2.00 ± 0%          2.00 ± 0%     ~     (all equal)
MarshalSplitCompress1000-16           15.0 ± 0%          15.0 ± 0%     ~     (all equal)
MarshalSplitCompress10000-16           145 ± 0%           145 ± 0%     ~     (all equal)

name                          old alloc/op       new alloc/op       delta
MarshalSplitCompress1-16            1.41MB ± 0%        1.32MB ± 0%   -6.74%  (p=0.000 n=9+9)
MarshalSplitCompress10-16           6.93MB ± 0%        4.37MB ± 0%  -36.96%  (p=0.000 n=9+9)
MarshalSplitCompress100-16          52.8MB ± 0%        25.6MB ± 0%  -51.53%  (p=0.000 n=9+10)
MarshalSplitCompress1000-16          445MB ± 0%         172MB ± 0%  -61.48%  (p=0.000 n=10+8)
MarshalSplitCompress10000-16        4.37GB ± 0%        1.63GB ± 0%  -62.69%  (p=0.016 n=4+5)

name                          old allocs/op      new allocs/op      delta
MarshalSplitCompress1-16               857 ± 0%           469 ± 0%  -45.27%  (p=0.000 n=10+10)
MarshalSplitCompress10-16            8.21k ± 0%         4.15k ± 0%  -49.47%  (p=0.000 n=10+10)
MarshalSplitCompress100-16           81.7k ± 0%         40.9k ± 0%  -49.93%  (p=0.000 n=10+10)
MarshalSplitCompress1000-16           816k ± 0%          408k ± 0%  -49.97%  (p=0.000 n=10+8)
MarshalSplitCompress10000-16         8.16M ± 0%         4.08M ± 0%  -49.98%  (p=0.029 n=4+4)
```

### Motivation

The existing code did a bit of this manual assembly of PB messages, but with
```
               // Magic number that occurs before the varint encoding
```

ProtoStream regularizes that a bit.

### Describe how to test your changes

* Configure an agent to produce large quantities of sketches (so that multiple payloads will be required)
* Observe no crashes, see the sketches in the app

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.