### PR TITLE
[cws] restore agent rule version

### DIFF
--- a/pkg/security/module/event.go
+++ b/pkg/security/module/event.go
@@ -11,6 +11,7 @@ package module
 // easyjson:json
 type AgentContext struct {
 	RuleID        string `json:"rule_id"`
+	RuleVersion   string `json:"rule_version,omitempty"`
 	PolicyName    string `json:"policy_name,omitempty"`
 	PolicyVersion string `json:"policy_version,omitempty"`
 	Version       string `json:"version,omitempty"`

--- a/pkg/security/module/event_easyjson.go
+++ b/pkg/security/module/event_easyjson.go
@@ -124,6 +124,8 @@ func easyjsonF642ad3eDecodeGithubComDataDogDatadogAgentPkgSecurityModule1(in *jl
 		switch key {
 		case "rule_id":
 			out.RuleID = string(in.String())
+		case "rule_version":
+			out.RuleVersion = string(in.String())
 		case "policy_name":
 			out.PolicyName = string(in.String())
 		case "policy_version":
@@ -148,6 +150,11 @@ func easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgSecurityModule1(out *j
 		const prefix string = ",\"rule_id\":"
 		out.RawString(prefix[1:])
 		out.String(string(in.RuleID))
+	}
+	if in.RuleVersion != "" {
+		const prefix string = ",\"rule_version\":"
+		out.RawString(prefix)
+		out.String(string(in.RuleVersion))
 	}
 	if in.PolicyName != "" {
 		const prefix string = ",\"policy_name\":"

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -236,8 +236,9 @@ func (a *APIServer) RunSelfTest(ctx context.Context, params *api.RunSelfTestPara
 // SendEvent forwards events sent by the runtime security module to Datadog
 func (a *APIServer) SendEvent(rule *rules.Rule, event Event, extTagsCb func() []string, service string) {
 	agentContext := &AgentContext{
-		RuleID:  rule.Definition.ID,
-		Version: version.AgentVersion,
+		RuleID:      rule.Definition.ID,
+		RuleVersion: rule.Definition.Version,
+		Version:     version.AgentVersion,
 	}
 
 	ruleEvent := &Signal{

--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -222,6 +222,7 @@ func NewRuleSetLoadedEvent(rs *rules.RuleSet, err *multierror.Error) (*rules.Rul
 		}
 		policy.RulesLoaded = append(policy.RulesLoaded, &RuleLoaded{
 			ID:         rule.ID,
+			Version:    rule.Definition.Version,
 			Expression: rule.Definition.Expression,
 		})
 	}
@@ -238,6 +239,7 @@ func NewRuleSetLoadedEvent(rs *rules.RuleSet, err *multierror.Error) (*rules.Rul
 				}
 				policy.RulesIgnored = append(policy.RulesIgnored, &RuleIgnored{
 					ID:         rerr.Definition.ID,
+					Version:    rerr.Definition.Version,
 					Expression: rerr.Definition.Expression,
 					Reason:     rerr.Err.Error(),
 				})

--- a/pkg/security/rules/ruleset.go
+++ b/pkg/security/rules/ruleset.go
@@ -36,6 +36,7 @@ type RuleID = string
 // RuleDefinition holds the definition of a rule
 type RuleDefinition struct {
 	ID          RuleID            `yaml:"id"`
+	Version     string            `yaml:"version"`
 	Expression  string            `yaml:"expression"`
 	Description string            `yaml:"description"`
 	Tags        map[string]string `yaml:"tags"`


### PR DESCRIPTION
### What does this PR do?

Restore the `rule_version` attribute sent to the backend.

### Motivation

`rule_version` is used by the backend to distinguish between default and custom rules.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
