### PR TITLE
Add US5 to windows installer

### DIFF
--- a/omnibus/resources/agent/msi/assets/sitedlg.wxi
+++ b/omnibus/resources/agent/msi/assets/sitedlg.wxi
@@ -3,6 +3,7 @@
     <ListItem Text="datadoghq.com" Value="datadoghq.com"/>
     <ListItem Text="datadoghq.eu" Value="datadoghq.eu"/>
     <ListItem Text="us3.datadoghq.com" Value="us3.datadoghq.com"/>
+    <ListItem Text="us5.datadoghq.com" Value="us5.datadoghq.com"/>
     <ListItem Text="ddog-gov.com" Value="ddog-gov.com"/>
   </ComboBox>
  <Dialog Id="SiteDlg" Width="370" Height="270" Title="!(loc.SiteDialogTitle)">

--- a/releasenotes/notes/add_us5_to_win_installer-26badc2313e5edec.yaml
+++ b/releasenotes/notes/add_us5_to_win_installer-26badc2313e5edec.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    The Windows installer now offers US5 as a new site choice.


### PR DESCRIPTION
### What does this PR do?

This PR adds the US5 site to the Windows installer.

### Motivation

Support new site.

### Describe how to test your changes

Run the installer in GUI mode and check that the new site is available for selection in the site dropdown.

### Checklist
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
