### PR TITLE
Add suggestion to forwarder error message

### DIFF
--- a/pkg/forwarder/domain_forwarder.go
+++ b/pkg/forwarder/domain_forwarder.go
@@ -251,7 +251,7 @@ func (f *domainForwarder) sendHTTPTransactions(t transaction.Transaction) error 
 		f.addToTransactionRetryQueue(t)
 		transactionsDroppedOnInput.Add(1)
 		tlmTxDroppedOnInput.Inc(f.domain, t.GetEndpointName())
-		return fmt.Errorf("the forwarder input queue for %s is full: dropping transaction", f.domain)
+		return fmt.Errorf("dropping transaction because the forwarder input queue for %s is full; consider increasing forwarder_num_workers", f.domain)
 	}
 	return nil
 }


### PR DESCRIPTION
When the forwarder's queues are full, it may be because it just does not have enough workers running.  This PR adds a note to the error message to suggest increasing the relevant configuration value

### Describe how to test your changes

Trigger the error on a running agent.  Perhaps by setting the intake URL to something that does not exist or hangs.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
