### PR TITLE
[process-agent] Fix trace on failure to parse cgroup paths

### DIFF
--- a/pkg/util/containers/providers/cgroup/cgroup_detect.go
+++ b/pkg/util/containers/providers/cgroup/cgroup_detect.go
@@ -183,7 +183,7 @@ func scrapeAllCgroups() (map[string]*ContainerCgroup, error) {
 		mP, mFound := paths["memory"]
 		fP, fFound := paths["freezer"]
 		if !fFound || !mFound || mP != fP {
-			log.Tracef("skipping cgroup from pid: %s as it does not appear to be a container cgroup")
+			log.Tracef("skipping cgroup from pid: %d - does not appear to be a container: memory path: %s, freezer path: %s", pid, mP, fP)
 			continue
 		}
 


### PR DESCRIPTION
### What does this PR do?

Fixes the trace on encountering an unexpected cgroup condition when parsing cgroups.
Follow up to https://github.com/DataDog/datadog-agent/pull/8618

### Motivation

Fixing trace logs.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

```
DD_LOG_LEVEL=trace process-agent --check container
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
