### PR TITLE
Fix missing store unlock in DatadogMetric store

### DIFF
--- a/pkg/clusteragent/externalmetrics/datadogmetric_controller_test.go
+++ b/pkg/clusteragent/externalmetrics/datadogmetric_controller_test.go
@@ -618,6 +618,16 @@ func TestLeaderDeleteCleanup(t *testing.T) {
 	assert.Equal(t, 0, f.store.Count())
 }
 
+// Scenario: Another event comes after Kubernetes object and internal store has been cleaned up
+func TestLeaderDuplicatedDelete(t *testing.T) {
+	f := newFixture(t)
+
+	f.runControllerSync(true, "default/dd-metric-0", nil)
+
+	// Check internal store content has not changed
+	assert.Equal(t, 0, f.store.Count())
+}
+
 // Scenario: Test that followers only follows (no action, always update store) even if local content is newer
 func TestFollower(t *testing.T) {
 	f := newFixture(t)


### PR DESCRIPTION
### What does this PR do?

Fix missing store unlock in DatadogMetric store

### Motivation

Bugfix

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

It's nearly impossible to trigger this bug inside a running cluster. The added unit test makes sure the scenario is covered.
It should remove occurrences of 429s.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
