### PR TITLE
 [kitchen] Add non-English Windows VM to test platforms

### DIFF
--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -11,7 +11,7 @@
 .kitchen_os_windows:
   variables:
     KITCHEN_PLATFORM: "windows"
-    KITCHEN_OSVERS: "win2008r2,win2012,win2012r2,win2016,win2019"
+    KITCHEN_OSVERS: "win2008r2,win2012,win2012r2,win2016,win2019,win2019cn"
     DEFAULT_KITCHEN_OSVERS: "win2019"
   before_script:  # Note: if you are changing this, remember to also change .kitchen_test_windows_installer, which has a copy of this with less TEST_PLATFORMS defined.
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi
@@ -41,7 +41,7 @@
 .kitchen_test_windows_npm_driver:
   variables:
     KITCHEN_PLATFORM: "windows"
-    KITCHEN_OSVERS: "win2012r2,win2016,win2019,win1903,win1909,win2004,win20h2"
+    KITCHEN_OSVERS: "win2012r2,win2016,win2019,win2019cn,win1903,win1909,win2004,win20h2"
     DEFAULT_KITCHEN_OSVERS: "win20h2"
   before_script:  # test all of the kernels to make sure the driver loads and runs properly
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -90,6 +90,7 @@
                 "win2012r2": "urn,MicrosoftWindowsServer:WindowsServer:2012-R2-Datacenter:4.127.20190416",
                 "win2016": "urn,MicrosoftWindowsServer:WindowsServer:2016-Datacenter-Server-Core:2016.127.20190416",
                 "win2019": "urn,MicrosoftWindowsServer:WindowsServer:2019-Datacenter-Core:2019.0.20190410",
+                "win2019cn": "urn,MicrosoftWindowsServer:WindowsServer:2019-Datacenter-zhcn:17763.2114.2108051826",
                 "win1903": "urn,MicrosoftWindowsServer:WindowsServer:Datacenter-Core-1903-with-Containers-smalldisk:18362.1256.2012032308",
                 "win1909": "urn,MicrosoftWindowsServer:WindowsServer:datacenter-core-1909-with-containers-smalldisk:18363.1316.2101130054",
                 "win2004": "urn,MicrosoftWindowsServer:WindowsServer:datacenter-core-2004-with-containers-smalldisk:19041.746.2101092327",

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -470,10 +470,11 @@ shared_examples_for "an installed Agent" do
       # while the Agent is installed in `C:/Program Files`
       # To prevent this issue, we check the system arch and the ProgramFiles folder, and we fix it
       # if needed.
-      program_files = ENV['ProgramFiles']
+      program_files = ENV['ProgramFiles'].dup
       arch = `Powershell -command "(Get-WmiObject Win32_OperatingSystem).OsArchitecture"`
-      if arch.include? "64" && program_files.include? "(x86)"
-        program_files = program_files.slice(" (x86)").strip
+      if arch.include? "64" and program_files.include? "(x86)"
+        program_files.slice!("(x86)")
+        program_files.strip!
       end
 
       verify_signature_files = [

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -65,6 +65,25 @@ def os
   )
 end
 
+def safe_program_files
+  # HACK: on non-English Windows, Chef wrongly installs its 32-bit version on 64-bit hosts because
+  # of this issue: https://github.com/chef/mixlib-install/issues/343
+  # Because of this, the ENV['ProgramFiles'] content is wrong (it's `C:/Program Files (x86)`)
+  # while the Agent is installed in `C:/Program Files`
+  # To prevent this issue, we check the system arch and the ProgramFiles folder, and we fix it
+  # if needed.
+
+  # Env variables are frozen strings, they need to be duplicated to modify them
+  program_files = ENV['ProgramFiles'].dup
+  arch = `Powershell -command "(Get-WmiObject Win32_OperatingSystem).OsArchitecture"`
+  if arch.include? "64" and program_files.include? "(x86)"
+    program_files.slice!("(x86)")
+    program_files.strip!
+  end
+
+  program_files
+end
+
 
 def agent_command
   if os == :windows
@@ -464,19 +483,7 @@ shared_examples_for "an installed Agent" do
       is_signed = is_file_signed(msi_path)
       expect(is_signed).to be_truthy
 
-      # HACK: on non-English Windows, Chef wrongly installs its 32-bit version on 64-bit hosts because
-      # of this issue: https://github.com/chef/mixlib-install/issues/343
-      # Because of this, the ENV['ProgramFiles'] content is wrong (it's `C:/Program Files (x86)`)
-      # while the Agent is installed in `C:/Program Files`
-      # To prevent this issue, we check the system arch and the ProgramFiles folder, and we fix it
-      # if needed.
-      program_files = ENV['ProgramFiles'].dup
-      arch = `Powershell -command "(Get-WmiObject Win32_OperatingSystem).OsArchitecture"`
-      if arch.include? "64" and program_files.include? "(x86)"
-        program_files.slice!("(x86)")
-        program_files.strip!
-      end
-
+      program_files = safe_program_files
       verify_signature_files = [
         "#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\process-agent.exe",
         "#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\trace-agent.exe",

--- a/test/kitchen/test/integration/common/rspec/windows_npm_spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/windows_npm_spec_helper.rb
@@ -6,9 +6,10 @@ shared_examples_for 'a Windows Agent with NPM driver that can start' do
     expect(is_windows_service_installed("ddnpm")).to be_truthy
   end
   it 'has Windows NPM driver files installed' do
-    expect(File).to exist("#{ENV['ProgramFiles']}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.cat")
-    expect(File).to exist("#{ENV['ProgramFiles']}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.sys")
-    expect(File).to exist("#{ENV['ProgramFiles']}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.inf")
+    program_files = safe_program_files
+    expect(File).to exist("#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.cat")
+    expect(File).to exist("#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.sys")
+    expect(File).to exist("#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.inf")
   end
 
   it 'does not have the driver running on install' do
@@ -31,9 +32,10 @@ shared_examples_for 'a Windows Agent with no NPM driver installed' do
     expect(is_windows_service_installed("ddnpm")).to be_falsey
   end
   it 'does not have the Windows NPM driver files installed' do
-    expect(File).not_to exist("#{ENV['ProgramFiles']}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.cat")
-    expect(File).not_to exist("#{ENV['ProgramFiles']}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.sys")
-    expect(File).not_to exist("#{ENV['ProgramFiles']}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.inf")
+    program_files = safe_program_files
+    expect(File).not_to exist("#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.cat")
+    expect(File).not_to exist("#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.sys")
+    expect(File).not_to exist("#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.inf")
   end
 end
 
@@ -45,9 +47,10 @@ shared_examples_for 'a Windows Agent with NPM driver installed' do
     expect(is_windows_service_installed("ddnpm")).to be_truthy
   end
   it 'has Windows NPM driver files installed' do
-    expect(File).to exist("#{ENV['ProgramFiles']}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.cat")
-    expect(File).to exist("#{ENV['ProgramFiles']}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.sys")
-    expect(File).to exist("#{ENV['ProgramFiles']}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.inf")
+    program_files = safe_program_files
+    expect(File).to exist("#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.cat")
+    expect(File).to exist("#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.sys")
+    expect(File).to exist("#{program_files}\\DataDog\\Datadog Agent\\bin\\agent\\driver\\ddnpm.inf")
   end
 end
 


### PR DESCRIPTION
### What does this PR do?

Adds a Chinese Windows Server VM to the list of test platforms, to check the Agent's behavior on non-English environments.

Requires #8992 to fix some kitchen tests that depended on localized strings..

### Motivation

Try to catch errors specific to running on non-English envs.

### Additional Notes

I had to add some hacks to fix a wrong behavior of Chef's install script, reported here: https://github.com/chef/mixlib-install/issues/343.

### Describe how to test your changes

Run pipeline with kitchen tests, check that they all pass.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
