### PR TITLE
upgrade to go 1.16.7 in circleci docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ experimental:
 templates:
   job_template: &job_template
     docker:
-      - image: datadog/datadog-agent-runner-circle:go11511
+      - image: datadog/datadog-agent-runner-circle:go1167
         environment:
           USE_SYSTEM_LIBS: "1"
     working_directory: /go/src/github.com/DataDog/datadog-agent

--- a/.circleci/images/runner/Dockerfile
+++ b/.circleci/images/runner/Dockerfile
@@ -29,7 +29,7 @@ RUN set -ex \
         ssh
 
 # Golang
-ENV GIMME_GO_VERSION 1.15.13
+ENV GIMME_GO_VERSION 1.16.7
 ENV GOROOT /root/.gimme/versions/go$GIMME_GO_VERSION.linux.amd64
 ENV GOPATH /go
 ENV PATH $GOROOT/bin:$GOPATH/bin:$PATH


### PR DESCRIPTION
### What does this PR do?

Upgrade the Go version used in CircleCI

### Describe how to test your changes

None; this affects CI only.  (Prod go version will be upgraded in other PRs)

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
