### PR TITLE
use go 1.16.7 in Appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,8 +10,8 @@ image: "Visual Studio 2017"
 # environment must be set for python 64 bit
 environment:
   GOPATH: C:\gopath
-  GOVERSION: '1.15.13'
-  GOROOT: C:\go_1.15.13
+  GOVERSION: '1.16.7'
+  GOROOT: C:\go_1.16.7
   # Give hints to CMake to find Pythons
   Python2_ROOT_DIR: C:\Python27-x64
   Python3_ROOT_DIR: C:\Python38-x64


### PR DESCRIPTION
Update Appveyor config to use Go 1.16.7.

### Describe how to test your changes

CI only, so no QA.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
