### PR TITLE
add a comment about http/2 being subtly disabled

### DIFF
--- a/pkg/util/http/transport.go
+++ b/pkg/util/http/transport.go
@@ -62,7 +62,10 @@ func CreateHTTPTransport() *http.Transport {
 
 	// Most of the following timeouts are a copy of Golang http.DefaultTransport
 	// They are mostly used to act as safeguards in case we forget to add a general
-	// timeout to our http clients.
+	// timeout to our http clients.  Setting DialContext and TLSClientConfig has the
+	// desirable side-effect of disabling http/2; if removing those fields then
+	// consider the implication of the protocol switch for intakes and other http
+	// servers. See ForceAttemptHTTP2 in https://pkg.go.dev/net/http#Transport.
 	transport := &http.Transport{
 		TLSClientConfig: tlsConfig,
 		DialContext: (&net.Dialer{


### PR DESCRIPTION
We disable http/2 by virtue of supplying some nonzero values for the http.Transport.  This is pretty subtle and easy to miss, particularly since the documentation of this behavior is not on those struct fields!  So, this adds a comment to clarify.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
