### PR TITLE
register the binary as the eventlog source when creating the container

### DIFF
--- a/Dockerfiles/agent/install.ps1
+++ b/Dockerfiles/agent/install.ps1
@@ -12,7 +12,6 @@ function Install-Service {
   } else {
       New-Service -Name $SvcName -StartupType Manual -BinaryPathName $BinPath
   }
-  #New-EventLog -Source $SvcName -LogName Application -MessageResourceFile $BinPath -CategoryResourceFile $BinPath
   $eventSourceData = new-object System.Diagnostics.EventSourceCreationData("$SvcName", "Application")  
   $eventSourceData.CategoryResourceFile = $BinPath
   $eventSourceData.MessageResourceFile = $BinPath

--- a/Dockerfiles/agent/install.ps1
+++ b/Dockerfiles/agent/install.ps1
@@ -1,6 +1,20 @@
 $ErrorActionPreference = "Stop"
 Trap { Write-Host "Error in install.ps1: $_" }
 
+function Install-Service {
+  param(
+    [Parameter(Mandatory=$true)][string] $SvcName,
+    [Parameter(Mandatory=$true)][string] $BinPath,
+    [Parameter(Mandatory=$false)][string[]] $Depends
+  )
+  if ( $Depends.count -gt 0 ){
+      New-Service -Name $SvcName -StartupType Manual -BinaryPathName $BinPath -Depends $Depends
+  } else {
+      New-Service -Name $SvcName -StartupType Manual -BinaryPathName $BinPath
+  }
+  New-Eventlog -Source $SvcName -LogName Application -MessageResourceFile $BinPath -CategoryResourceFile $BinPath
+}
+
 if ("$env:WITH_JMX" -ne "false") {
     Invoke-WebRequest -OutFile jre-11.0.6.zip https://github.com/AdoptOpenJDK/openjdk11-binaries/releases/download/jdk-11.0.6%2B10/OpenJDK11U-jre_x64_windows_hotspot_11.0.6_10.zip
     Expand-Archive -Path jre-11.0.6.zip -DestinationPath C:/
@@ -22,10 +36,16 @@ Move-Item "Datadog Agent" "C:/Program Files/Datadog/"
 New-Item -ItemType directory -Path 'C:/ProgramData/Datadog'
 Move-Item "C:/Program Files/Datadog/Datadog Agent/EXAMPLECONFSLOCATION" "C:/ProgramData/Datadog/conf.d"
 
-# Register as a service
-New-Service -Name "datadogagent" -StartupType "Manual" -BinaryPathName "C:\Program Files\Datadog\Datadog Agent\bin\agent.exe"
-New-Service -Name "datadog-process-agent" -StartupType "Manual" -BinaryPathName "C:\Program Files\Datadog\Datadog Agent\bin\agent\process-agent.exe" -DependsOn "datadogagent"
-New-Service -Name "datadog-trace-agent" -StartupType "Manual" -BinaryPathName "C:\Program Files\Datadog\Datadog Agent\bin\agent\trace-agent.exe" -DependsOn "datadogagent"
+$services = [ordered]@{
+  "datadogagent" = "C:\Program Files\Datadog\Datadog Agent\bin\agent.exe",@()
+  "datadog-process-agent" = "C:\Program Files\Datadog\Datadog Agent\bin\agent\process-agent.exe",@("datadogagent")
+  "datadog-trace-agent" = "C:\Program Files\Datadog\Datadog Agent\bin\agent\trace-agent.exe",@("datadogagent")
+}
+
+foreach ($s in $services.Keys) {
+    Install-Service -SvcName $s -BinPath $services[$s][0] $services[$s][1]
+}
+
 
 # Allow to run agent binaries as `agent`
 setx /m PATH "$Env:Path;C:/Program Files/Datadog/Datadog Agent/bin;C:/Program Files/Datadog/Datadog Agent/bin/agent"

--- a/Dockerfiles/agent/install.ps1
+++ b/Dockerfiles/agent/install.ps1
@@ -12,7 +12,15 @@ function Install-Service {
   } else {
       New-Service -Name $SvcName -StartupType Manual -BinaryPathName $BinPath
   }
-  New-Eventlog -Source $SvcName -LogName Application -MessageResourceFile $BinPath -CategoryResourceFile $BinPath
+  #New-EventLog -Source $SvcName -LogName Application -MessageResourceFile $BinPath -CategoryResourceFile $BinPath
+  $eventSourceData = new-object System.Diagnostics.EventSourceCreationData("$SvcName", "Application")  
+  $eventSourceData.CategoryResourceFile = $BinPath
+  $eventSourceData.MessageResourceFile = $BinPath
+
+  If (![System.Diagnostics.EventLog]::SourceExists($eventSourceData.Source))
+  {      
+  [System.Diagnostics.EventLog]::CreateEventSource($eventSourceData)  
+  } 
 }
 
 if ("$env:WITH_JMX" -ne "false") {


### PR DESCRIPTION
### What does this PR do?

Registers each agent binary as the eventlog source

### Motivation

Wasn't being done before; therefore the eventlogs just had error messages, which makes troubleshooting harder.


### Describe how to test your changes

Run the container.
Run ` get-winevent -logname application | where-object { $_.ProviderName -eq "DatadogAgent" } ` and ensure that the datadog log messages are present.

Before the fix, the output is like:
```ProviderName: DatadogAgent 

TimeCreated                     Id LevelDisplayName Message
-----------                     -- ---------------- -------
8/31/2021 9:59:45 PM             4
8/31/2021 9:59:45 PM            11
8/31/2021 9:59:45 PM             7
```

After, should be like
```get-winevent -logname application | where-object { $_.ProviderName -eq "DatadogAgent" }  
    
   ProviderName: DatadogAgent

TimeCreated                     Id LevelDisplayName Message
-----------                     -- ---------------- -------
8/31/2021 10:04:08 PM            4 Information      The DatadogAgent service has stopped.
8/31/2021 10:04:08 PM           11 Error            The service failed to start. Error unable to set up global agent configuration: unable to load Datadog config file: Config File "datadog" Not Found in "[c:\\programdata\\dat… 
8/31/2021 10:04:08 PM            7 Information      starting the DatadogAgent service.
8/31/2021 10:04:08 PM           15 Warning          Unable to determine the location of Program Data using the default value c:\programdata\datadog.
8/31/2021 10:04:08 PM           15 Warning          Unable to determine the location of Program Data using the default value c:\programdata\datadog\conf.d.
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ x ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ x ] The appropriate `team/..` label has been applied, if known.
