### PR TITLE
[pipeline] Run Docker & Chocolatey promotion jobs automatically on RCs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -319,7 +319,12 @@ variables:
       AGENT_REPOSITORY: agent
       IMG_REGISTRIES: public
 
-.on_deploy_a6_manual_except_rc:
+# This rule is a variation of on_deploy_a6_manual where
+# the job is usually run manually, except when the pipeline
+# builds an RC: in this case, the job is run automatically.
+# This is done to reduce the number of manual steps that have
+# to be done when creating RCs.
+.on_deploy_a6_manual_auto_on_rc:
   - <<: *if_not_version_6
     when: never
   - <<: *if_not_deploy
@@ -330,8 +335,6 @@ variables:
     variables:
       AGENT_REPOSITORY: agent-dev
       IMG_REGISTRIES: dev
-  # Exception: we want to automatically run these jobs on RCs, to
-  # simplify the RC creation process
   - <<: *if_rc_tag_on_beta_repo_branch
     when: on_success
     variables:
@@ -368,7 +371,12 @@ variables:
       DSD_REPOSITORY: dogstatsd
       IMG_REGISTRIES: public
 
-.on_deploy_a7_manual_except_rc:
+# This rule is a variation of on_deploy_a7_manual where
+# the job is usually run manually, except when the pipeline
+# builds an RC: in this case, the job is run automatically.
+# This is done to reduce the number of manual steps that have
+# to be done when creating RCs.
+.on_deploy_a7_manual_auto_on_rc:
   - <<: *if_not_version_7
     when: never
   - <<: *if_not_deploy
@@ -380,8 +388,6 @@ variables:
       AGENT_REPOSITORY: agent-dev
       DSD_REPOSITORY: dogstatsd-dev
       IMG_REGISTRIES: dev
-  # Exception: we want to automatically run these jobs on RCs, to
-  # simplify the RC creation process
   - <<: *if_rc_tag_on_beta_repo_branch
     when: on_success
     variables:
@@ -454,13 +460,16 @@ variables:
     when: manual
     allow_failure: true
 
-.on_deploy_stable_or_beta_repo_branch_a7_manual_except_rc:
+# This rule is a variation of on_deploy_stable_or_beta_repo_branch_a7_manual where
+# the job is usually run manually, except when the pipeline
+# builds an RC: in this case, the job is run automatically.
+# This is done to reduce the number of manual steps that have
+# to be done when creating RCs.
+.on_deploy_stable_or_beta_repo_branch_a7_manual_auto_on_rc:
   - <<: *if_not_version_7
     when: never
   - <<: *if_not_stable_or_beta_repo_branch
     when: never
-  # Exception: we want to automatically run these jobs on RCs, to
-  # simplify the RC creation process
   - <<: *if_rc_tag_on_beta_repo_branch
     when: on_success
   - <<: *if_deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -187,6 +187,9 @@ variables:
 .if_not_stable_or_beta_repo_branch: &if_not_stable_or_beta_repo_branch
   if: $DEB_RPM_BUCKET_BRANCH != "beta" && $DEB_RPM_BUCKET_BRANCH != "stable"
 
+.if_not_stable_repo_branch: &if_not_stable_repo_branch
+  if: $DEB_RPM_BUCKET_BRANCH != "stable"
+
 # Rule to trigger all builds conditionally.
 # By default:
 # - on main and deploy pipelines, all builds are run
@@ -217,6 +220,14 @@ variables:
 
 .if_testing_cleanup: &if_testing_cleanup
   if: $TESTING_CLEANUP == "true"
+
+# Rule to trigger jobs only when a tag matches a given pattern (for RCs)
+# on the beta branch.
+# Note: due to workflow rules, rc tag => deploy pipeline, so there's technically no
+# need to check again if the pipeline is a deploy pipeline, but it doesn't hurt
+# to explicitly add it.
+.if_deploy_on_rc_tag_on_beta_repo_branch: &if_rc_tag_on_beta_repo_branch
+  if: $DEPLOY_AGENT == "true" && $DEB_RPM_BUCKET_BRANCH == "beta" && $CI_COMMIT_TAG =~ /^[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$/
 
 #
 # List of rule blocks used in the pipeline
@@ -308,6 +319,31 @@ variables:
       AGENT_REPOSITORY: agent
       IMG_REGISTRIES: public
 
+.on_deploy_a6_manual_except_rc:
+  - <<: *if_not_version_6
+    when: never
+  - <<: *if_not_deploy
+    when: never
+  - <<: *if_not_stable_or_beta_repo_branch
+    when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: agent-dev
+      IMG_REGISTRIES: dev
+  # Exception: we want to automatically run these jobs on RCs, to
+  # simplify the RC creation process
+  - <<: *if_rc_tag_on_beta_repo_branch
+    when: on_success
+    variables:
+      AGENT_REPOSITORY: agent
+      DSD_REPOSITORY: dogstatsd
+      IMG_REGISTRIES: public
+  - when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: agent
+      IMG_REGISTRIES: public
+
 .on_deploy_a7:
   - <<: *if_not_version_7
     when: never
@@ -325,6 +361,33 @@ variables:
       AGENT_REPOSITORY: agent-dev
       DSD_REPOSITORY: dogstatsd-dev
       IMG_REGISTRIES: dev
+  - when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: agent
+      DSD_REPOSITORY: dogstatsd
+      IMG_REGISTRIES: public
+
+.on_deploy_a7_manual_except_rc:
+  - <<: *if_not_version_7
+    when: never
+  - <<: *if_not_deploy
+    when: never
+  - <<: *if_not_stable_or_beta_repo_branch
+    when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: agent-dev
+      DSD_REPOSITORY: dogstatsd-dev
+      IMG_REGISTRIES: dev
+  # Exception: we want to automatically run these jobs on RCs, to
+  # simplify the RC creation process
+  - <<: *if_rc_tag_on_beta_repo_branch
+    when: on_success
+    variables:
+      AGENT_REPOSITORY: agent
+      DSD_REPOSITORY: dogstatsd
+      IMG_REGISTRIES: public
   - when: manual
     allow_failure: true
     variables:
@@ -391,6 +454,19 @@ variables:
     when: manual
     allow_failure: true
 
+.on_deploy_stable_or_beta_repo_branch_a7_manual_except_rc:
+  - <<: *if_not_version_7
+    when: never
+  - <<: *if_not_stable_or_beta_repo_branch
+    when: never
+  # Exception: we want to automatically run these jobs on RCs, to
+  # simplify the RC creation process
+  - <<: *if_rc_tag_on_beta_repo_branch
+    when: on_success
+  - <<: *if_deploy
+    when: manual
+    allow_failure: true
+
 .on_deploy_stable_or_beta_repo_branch_a7_always:
   - <<: *if_not_version_7
     when: never
@@ -398,6 +474,15 @@ variables:
     when: never
   - <<: *if_deploy
     when: always
+
+.on_deploy_stable_repo_branch_a7_manual:
+  - <<: *if_not_version_7
+    when: never
+  - <<: *if_not_stable_repo_branch
+    when: never
+  - <<: *if_deploy
+    when: manual
+    allow_failure: true
 
 .except_deploy:
   - <<: *if_deploy

--- a/.gitlab/choco_deploy.yml
+++ b/.gitlab/choco_deploy.yml
@@ -4,7 +4,7 @@
 
 publish_choco_7_x64:
   rules:
-    !reference [.on_deploy_stable_or_beta_repo_branch_a7_manual_except_rc]
+    !reference [.on_deploy_stable_or_beta_repo_branch_a7_manual_auto_on_rc]
   stage: choco_deploy
   tags: ["runner:windows-docker", "windowsversion:1809"]
   needs: ["windows_choco_online_7_x64"]

--- a/.gitlab/choco_deploy.yml
+++ b/.gitlab/choco_deploy.yml
@@ -4,7 +4,7 @@
 
 publish_choco_7_x64:
   rules:
-    !reference [.on_deploy_stable_or_beta_repo_branch_a7_manual]
+    !reference [.on_deploy_stable_or_beta_repo_branch_a7_manual_except_rc]
   stage: choco_deploy
   tags: ["runner:windows-docker", "windowsversion:1809"]
   needs: ["windows_choco_online_7_x64"]

--- a/.gitlab/deploy_6/docker.yml
+++ b/.gitlab/deploy_6/docker.yml
@@ -15,7 +15,7 @@
   tags: ["runner:main"]
   stage: deploy6
   rules:
-    !reference [.on_deploy_a6_manual]
+    !reference [.on_deploy_a6_manual_except_rc]
   dependencies: []
   script:
     - python3 -m pip install -r requirements.txt

--- a/.gitlab/deploy_6/docker.yml
+++ b/.gitlab/deploy_6/docker.yml
@@ -15,7 +15,7 @@
   tags: ["runner:main"]
   stage: deploy6
   rules:
-    !reference [.on_deploy_a6_manual_except_rc]
+    !reference [.on_deploy_a6_manual_auto_on_rc]
   dependencies: []
   script:
     - python3 -m pip install -r requirements.txt

--- a/.gitlab/deploy_7/docker.yml
+++ b/.gitlab/deploy_7/docker.yml
@@ -15,7 +15,7 @@
   tags: ["runner:main"]
   stage: deploy7
   rules:
-    !reference [.on_deploy_a7_manual_except_rc]
+    !reference [.on_deploy_a7_manual_auto_on_rc]
   dependencies: []
   script:
     - python3 -m pip install -r requirements.txt
@@ -51,7 +51,7 @@ deploy-dogstatsd:
   tags: ["runner:main"]
   stage: deploy7
   rules:
-    !reference [.on_deploy_a7_manual_except_rc]
+    !reference [.on_deploy_a7_manual_auto_on_rc]
   dependencies: []
   script:
     - python3 -m pip install -r requirements.txt

--- a/.gitlab/deploy_7/docker.yml
+++ b/.gitlab/deploy_7/docker.yml
@@ -15,7 +15,7 @@
   tags: ["runner:main"]
   stage: deploy7
   rules:
-    !reference [.on_deploy_a7_manual]
+    !reference [.on_deploy_a7_manual_except_rc]
   dependencies: []
   script:
     - python3 -m pip install -r requirements.txt
@@ -51,7 +51,7 @@ deploy-dogstatsd:
   tags: ["runner:main"]
   stage: deploy7
   rules:
-    !reference [.on_deploy_a7_manual]
+    !reference [.on_deploy_a7_manual_except_rc]
   dependencies: []
   script:
     - python3 -m pip install -r requirements.txt

--- a/.gitlab/deploy_7/winget.yml
+++ b/.gitlab/deploy_7/winget.yml
@@ -4,7 +4,7 @@
 
 publish_winget_7_x64:
   rules:
-    !reference [.on_deploy_stable_or_beta_repo_branch_a7_manual]
+    !reference [.on_deploy_stable_repo_branch_a7_manual]
   stage: deploy7
   tags: ["runner:windows-docker", "windowsversion:1809"]
   variables:


### PR DESCRIPTION
### What does this PR do?

Modifies the manual deploy jobs to run automatically when the pipeline targets an RC tag. All non-latest Docker publish jobs are affected, as well as the chocolatey publish job.
Fixes the `publish_winget_7_x64` job, which is only supposed to run on stable pipelines.

### Motivation

Remove manual steps for RCs.

### Describe how to test your changes

Has to be tested on an RC & a stable release to check that they behave as expected.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
