### PR TITLE
pkg/trace/api: add metrics for UDS connections

### DIFF
--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -158,7 +158,6 @@ func (r *HTTPReceiver) Start() {
 	go func() {
 		defer watchdog.LogOnPanic()
 		r.server.Serve(ln)
-		ln.Close()
 	}()
 	log.Infof("Listening for traces at http://%s", addr)
 
@@ -170,7 +169,6 @@ func (r *HTTPReceiver) Start() {
 		go func() {
 			defer watchdog.LogOnPanic()
 			r.server.Serve(ln)
-			ln.Close()
 		}()
 		log.Infof("Listening for traces at unix://%s", path)
 	}
@@ -186,7 +184,6 @@ func (r *HTTPReceiver) Start() {
 		go func() {
 			defer watchdog.LogOnPanic()
 			r.server.Serve(ln)
-			ln.Close()
 		}()
 		log.Infof("Listening for traces on Windowes pipe %q. Security descriptor is %q", pipepath, secdec)
 	}
@@ -255,7 +252,7 @@ func (r *HTTPReceiver) listenUnix(path string) (net.Listener, error) {
 	if err := os.Chmod(path, 0722); err != nil {
 		return nil, fmt.Errorf("error setting socket permissions: %v", err)
 	}
-	return ln, err
+	return NewMeasuredListener(ln, "uds_connections"), err
 }
 
 // listenTCP creates a new net.Listener on the provided TCP address.
@@ -272,7 +269,7 @@ func (r *HTTPReceiver) listenTCP(addr string) (net.Listener, error) {
 		}()
 		return ln, err
 	}
-	return tcpln, err
+	return NewMeasuredListener(tcpln, "tcp_connections"), err
 }
 
 // Stop stops the receiver and shuts down the HTTP server.

--- a/pkg/trace/api/listener.go
+++ b/pkg/trace/api/listener.go
@@ -15,6 +15,84 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// measuredListener wraps an existing net.Listener and emits metrics upon accepting connections.
+type measuredListener struct {
+	net.Listener
+
+	name     string        // metric name to emit
+	accepted uint32        // accepted connection count
+	timedout uint32        // timedout connection count
+	errored  uint32        // errored connection count
+	exit     chan struct{} // exit signal channel (on Close call)
+}
+
+// NewMeasuredListener wraps ln and emits metrics every 10 seconds. The metric name is
+// datadog.trace_agent.receiver.<name>. Additionally, a "status" tag will be added with
+// potential values "accepted", "timedout" or "errored".
+func NewMeasuredListener(ln net.Listener, name string) net.Listener {
+	ml := &measuredListener{
+		Listener: ln,
+		name:     "datadog.trace_agent.receiver." + name,
+		exit:     make(chan struct{}),
+	}
+	go ml.run()
+	return ml
+}
+
+func (ln *measuredListener) run() {
+	tick := time.NewTicker(10 * time.Second)
+	defer tick.Stop()
+	defer close(ln.exit)
+	for {
+		select {
+		case <-tick.C:
+			ln.flushMetrics()
+		case <-ln.exit:
+			return
+		}
+	}
+}
+
+func (ln *measuredListener) flushMetrics() {
+	for tag, stat := range map[string]*uint32{
+		"status:accepted": &ln.accepted,
+		"status:timedout": &ln.timedout,
+		"status:errored":  &ln.errored,
+	} {
+		if v := int64(atomic.SwapUint32(stat, 0)); v > 0 {
+			metrics.Count(ln.name, v, []string{tag}, 1)
+		}
+	}
+}
+
+// Accept implements net.Listener and keeps counts on connection statuses.
+func (ln *measuredListener) Accept() (net.Conn, error) {
+	conn, err := ln.Listener.Accept()
+	if err != nil {
+		if ne, ok := err.(net.Error); ok && ne.Timeout() && !ne.Temporary() {
+			atomic.AddUint32(&ln.timedout, 1)
+		} else {
+			atomic.AddUint32(&ln.errored, 1)
+		}
+	} else {
+		atomic.AddUint32(&ln.accepted, 1)
+	}
+	log.Tracef("Accepted connection named %q.", ln.name)
+	return conn, err
+}
+
+// Close implements net.Listener.
+func (ln measuredListener) Close() error {
+	err := ln.Listener.Close()
+	ln.flushMetrics()
+	ln.exit <- struct{}{}
+	<-ln.exit
+	return err
+}
+
+// Addr implements net.Listener.
+func (ln measuredListener) Addr() net.Addr { return ln.Listener.Addr() }
+
 // rateLimitedListener wraps a regular TCPListener with rate limiting.
 type rateLimitedListener struct {
 	*net.TCPListener

--- a/pkg/trace/api/listener_test.go
+++ b/pkg/trace/api/listener_test.go
@@ -1,0 +1,150 @@
+package api
+
+import (
+	"net"
+	"sync"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
+	"github.com/DataDog/datadog-agent/pkg/trace/test/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockNetError struct{ timeout bool }
+
+func (e mockNetError) Error() string   { return "mock-net-error" }
+func (e mockNetError) Timeout() bool   { return e.timeout }
+func (e mockNetError) Temporary() bool { return !e.timeout }
+
+type mockListener struct {
+	mu  sync.RWMutex // guards below fields
+	err net.Error    // returned error, if non-nil
+}
+
+var _ net.Listener = (*mockListener)(nil)
+
+func (ml *mockListener) Accept() (net.Conn, error) {
+	ml.mu.RLock()
+	defer ml.mu.RUnlock()
+	return nil, ml.err
+}
+
+func (ml *mockListener) SetSuccess() {
+	ml.mu.Lock()
+	defer ml.mu.Unlock()
+	ml.err = nil
+}
+
+func (ml *mockListener) SetError() {
+	ml.mu.Lock()
+	defer ml.mu.Unlock()
+	ml.err = mockNetError{timeout: false}
+}
+
+func (ml *mockListener) SetTimeoutError() {
+	ml.mu.Lock()
+	defer ml.mu.Unlock()
+	ml.err = mockNetError{timeout: true}
+}
+
+func (ml *mockListener) Close() error { return nil }
+
+func (ml *mockListener) Addr() net.Addr { return nil }
+
+func TestMockListener(t *testing.T) {
+	t.Run("default", func(t *testing.T) {
+		var ln mockListener
+		_, err := ln.Accept()
+		assert.NoError(t, err)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		assert := assert.New(t)
+		var ln mockListener
+		ln.SetError()
+		_, err := ln.Accept()
+		nerr, ok := err.(net.Error)
+		assert.True(ok)
+		assert.True(nerr.Temporary())
+		assert.False(nerr.Timeout())
+	})
+
+	t.Run("timeout", func(t *testing.T) {
+		assert := assert.New(t)
+		var ln mockListener
+		ln.SetTimeoutError()
+		_, err := ln.Accept()
+		nerr, ok := err.(net.Error)
+		assert.True(ok)
+		assert.False(nerr.Temporary())
+		assert.True(nerr.Timeout())
+	})
+
+	t.Run("toggle", func(t *testing.T) {
+		assert := assert.New(t)
+		var ln mockListener
+
+		ln.SetTimeoutError()
+		_, err := ln.Accept()
+		nerr, ok := err.(net.Error)
+		assert.True(ok)
+		assert.False(nerr.Temporary())
+		assert.True(nerr.Timeout())
+
+		ln.SetSuccess()
+		_, err = ln.Accept()
+		assert.NoError(err)
+
+		ln.SetError()
+		_, err = ln.Accept()
+		nerr, ok = err.(net.Error)
+		assert.True(ok)
+		assert.True(nerr.Temporary())
+		assert.False(nerr.Timeout())
+
+		ln.SetSuccess()
+		_, err = ln.Accept()
+		assert.NoError(err)
+	})
+}
+
+func TestMeasuredListener(t *testing.T) {
+	assert := assert.New(t)
+	stats := &testutil.TestStatsClient{}
+	defer func(old metrics.StatsClient) { metrics.Client = old }(metrics.Client)
+	metrics.Client = stats
+
+	var mockln mockListener
+	ln := NewMeasuredListener(&mockln, "test-metric").(*measuredListener)
+	mockln.SetSuccess()
+	ln.Accept()
+	ln.Accept()
+	ln.Accept()
+	ln.flushMetrics()
+	call, ok := stats.GetCountSummaries()["datadog.trace_agent.receiver.test-metric"]
+	assert.True(ok)
+	assert.Len(call.Calls, 1)
+	assert.EqualValues(call.Calls[0].Tags, []string{"status:accepted"})
+	assert.EqualValues(call.Calls[0].Value, 3)
+
+	stats.Reset()
+	mockln.SetError()
+	ln.Accept()
+	ln.Accept()
+	ln.flushMetrics()
+	call, ok = stats.GetCountSummaries()["datadog.trace_agent.receiver.test-metric"]
+	assert.True(ok)
+	assert.Len(call.Calls, 1)
+	assert.EqualValues(call.Calls[0].Tags, []string{"status:errored"})
+	assert.EqualValues(call.Calls[0].Value, 2)
+
+	stats.Reset()
+	mockln.SetTimeoutError()
+	ln.Accept()
+	ln.flushMetrics()
+	call, ok = stats.GetCountSummaries()["datadog.trace_agent.receiver.test-metric"]
+	assert.True(ok)
+	assert.Len(call.Calls, 1)
+	assert.EqualValues(call.Calls[0].Tags, []string{"status:timedout"})
+	assert.EqualValues(call.Calls[0].Value, 1)
+}

--- a/pkg/trace/api/pipe.go
+++ b/pkg/trace/api/pipe.go
@@ -14,8 +14,9 @@ import (
 )
 
 func listenPipe(path string, secdec string, bufferSize int) (net.Listener, error) {
-	return winio.ListenPipe(path, &winio.PipeConfig{
+	ln, err := winio.ListenPipe(path, &winio.PipeConfig{
 		SecurityDescriptor: secdec,
 		InputBufferSize:    int32(bufferSize),
 	})
+	return NewMeasuredListener(ln, "pipe_connections"), err
 }

--- a/releasenotes/notes/apm-uds-connection-metrics-97dd7c13813e22c8.yaml
+++ b/releasenotes/notes/apm-uds-connection-metrics-97dd7c13813e22c8.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: Metrics are now available for Windows Pipes and UDS connections via datadog.trace_agent.receiver.{uds_connections,pipe_connections}.


### PR DESCRIPTION
This change adds a new structure called measuredListener which is able
to wrap any net.Listener and emit metrics based on the outcome of
accepting connections.

Internal reference: APMAGENT-91