### PR TITLE
[runtime-security] use exponential backoff for log when failing to connect to the socket

### DIFF
--- a/pkg/security/agent/agent.go
+++ b/pkg/security/agent/agent.go
@@ -90,12 +90,7 @@ func (rsa *RuntimeSecurityAgent) StartEventListener() {
 
 	rsa.connected.Store(false)
 
-	expBackoff := backoff.NewExponentialBackOff()
-	expBackoff.InitialInterval = 2 * time.Second
-	expBackoff.MaxInterval = 60 * time.Second
-	expBackoff.MaxElapsedTime = 0
-	expBackoff.Reset()
-	logTicker := backoff.NewTicker(expBackoff)
+	logTicker := newLogBackoffTicker()
 
 	rsa.running.Store(true)
 	for rsa.running.Load() == true {
@@ -149,4 +144,14 @@ func (rsa *RuntimeSecurityAgent) GetStatus() map[string]interface{} {
 		"connected":     rsa.connected.Load(),
 		"eventReceived": atomic.LoadUint64(&rsa.eventReceived),
 	}
+}
+
+// newLogBackoffTicker returns a ticker based on an exponential backoff, used to trigger connect error logs
+func newLogBackoffTicker() *backoff.Ticker {
+	expBackoff := backoff.NewExponentialBackOff()
+	expBackoff.InitialInterval = 2 * time.Second
+	expBackoff.MaxInterval = 60 * time.Second
+	expBackoff.MaxElapsedTime = 0
+	expBackoff.Reset()
+	return backoff.NewTicker(expBackoff)
 }

--- a/releasenotes/notes/security-agent-log-exp-backoff-5e39878383f69b1d.yaml
+++ b/releasenotes/notes/security-agent-log-exp-backoff-5e39878383f69b1d.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Security Agent: use exponential backoff for log warning when the security agent fails to
+    connect to the system probe.


### PR DESCRIPTION
### What does this PR do?

When failing to connect to the gRPC socket linked to the system probe, the security agent periodically retries (every 2 seconds) and logs an error. This PR keeps the retry but implement an exponential backoff in the log in order to not overload the client machine with logs.

### Motivation

The current log overflow was problematic to some clients.

### Describe how to test your changes

Run the security agent without the system probe and observe the log appearance pattern.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
