### PR TITLE
[7.31.x backport][process-agent] Correct order in which winopts are parsed and checked

### DIFF
--- a/cmd/process-agent/main.go
+++ b/cmd/process-agent/main.go
@@ -5,8 +5,17 @@ package main
 import (
 	"os"
 
+	"github.com/spf13/cobra"
+
 	"github.com/DataDog/datadog-agent/cmd/process-agent/flags"
 )
+
+func rootCmdRun(cmd *cobra.Command, args []string) {
+	exit := make(chan struct{})
+
+	// Invoke the Agent
+	runAgent(exit)
+}
 
 func main() {
 	ignore := ""

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -62,12 +62,7 @@ var (
 
 var (
 	rootCmd = &cobra.Command{
-		Run: func(cmd *cobra.Command, args []string) {
-			exit := make(chan struct{})
-
-			// Invoke the Agent
-			runAgent(exit)
-		},
+		Run:          rootCmdRun,
 		SilenceUsage: true,
 	}
 

--- a/cmd/process-agent/main_windows.go
+++ b/cmd/process-agent/main_windows.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/DataDog/datadog-agent/pkg/util/containers/providers/windows"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 
+	"github.com/spf13/cobra"
 	"golang.org/x/sys/windows/svc"
 	"golang.org/x/sys/windows/svc/debug"
 	"golang.org/x/sys/windows/svc/eventlog"
@@ -129,6 +130,14 @@ func main() {
 	rootCmd.PersistentFlags().BoolVar(&winopts.stopService, "stop-service", false, "Stops the process agent service")
 	rootCmd.PersistentFlags().BoolVar(&winopts.foreground, "foreground", false, "Always run foreground instead whether session is interactive or not")
 
+	// Invoke the Agent
+	fixDeprecatedFlags()
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(-1)
+	}
+}
+
+func rootCmdRun(cmd *cobra.Command, args []string) {
 	if !winopts.foreground {
 		isIntSess, err := svc.IsAnInteractiveSession()
 		if err != nil {
@@ -187,11 +196,9 @@ func main() {
 		}
 	}
 
+	exit := make(chan struct{})
 	// Invoke the Agent
-	fixDeprecatedFlags()
-	if err := rootCmd.Execute(); err != nil {
-		os.Exit(-1)
-	}
+	runAgent(exit)
 }
 
 func startService() error {


### PR DESCRIPTION
### What does this PR do?

Backport of https://github.com/DataDog/datadog-agent/pull/9033 to `7.31.x`

- Follow-up to https://github.com/DataDog/datadog-agent/pull/8899
- Ensure that winopts flags are parsed before they are checked

This addresses a bug where process-agent silently exits in Windows containers regardless of `-foreground`.

### Motivation

Addresses a bug where process-agent fails to start in Windows containers.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
