### PR TITLE
[flare] Include logs with the existing subdirectory tree

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -401,7 +401,8 @@ func zipLogFiles(tempDir, hostname, logFilePath string, permsInfos permissionsIn
 		}
 
 		if filepath.Ext(f.Name()) == ".log" || getFirstSuffix(f.Name()) == ".log" {
-			dst := filepath.Join(tempDir, hostname, "logs", f.Name())
+			baseName := strings.Replace(src, logFileDir, "", 1)
+			dst := filepath.Join(tempDir, hostname, "logs", baseName)
 
 			if permsInfos != nil {
 				permsInfos.add(src)

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -396,6 +396,7 @@ func zipLogFiles(tempDir, hostname, logFilePath string, permsInfos permissionsIn
 		log.Errorf("Error getting absolute path to log directory of %q: %v", logFilePath, err)
 		return err
 	}
+	permsInfos.add(logFileDir)
 
 	err = filepath.Walk(logFileDir, func(src string, f os.FileInfo, err error) error {
 		if f == nil {

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -390,9 +390,14 @@ func addParentPerms(dirPath string, permsInfos permissionsInfos) {
 }
 
 func zipLogFiles(tempDir, hostname, logFilePath string, permsInfos permissionsInfos) error {
-	logFileDir := filepath.Dir(logFilePath)
+	// Force dir path to be absolute first
+	logFileDir, err := filepath.Abs(filepath.Dir(logFilePath))
+	if err != nil {
+		log.Errorf("Error getting absolute path to log directory of %q: %v", logFilePath, err)
+		return err
+	}
 
-	err := filepath.Walk(logFileDir, func(src string, f os.FileInfo, err error) error {
+	err = filepath.Walk(logFileDir, func(src string, f os.FileInfo, err error) error {
 		if f == nil {
 			return nil
 		}
@@ -401,8 +406,12 @@ func zipLogFiles(tempDir, hostname, logFilePath string, permsInfos permissionsIn
 		}
 
 		if filepath.Ext(f.Name()) == ".log" || getFirstSuffix(f.Name()) == ".log" {
-			baseName := strings.Replace(src, logFileDir, "", 1)
-			dst := filepath.Join(tempDir, hostname, "logs", baseName)
+			targRelPath, relErr := filepath.Rel(logFileDir, src)
+			if relErr != nil {
+				log.Errorf("Can't get relative path to %q: %v", src, relErr)
+				return nil
+			}
+			dst := filepath.Join(tempDir, hostname, "logs", targRelPath)
 
 			if permsInfos != nil {
 				permsInfos.add(src)
@@ -415,12 +424,7 @@ func zipLogFiles(tempDir, hostname, logFilePath string, permsInfos permissionsIn
 
 	// The permsInfos map is empty when we cannot read the auth token.
 	if len(permsInfos) != 0 {
-		// Force path to be absolute for getting parent permissions.
-		absPath, err := filepath.Abs(logFileDir)
-		if err != nil {
-			log.Errorf("Error while getting absolute file path for parent directory: %v", err)
-		}
-		addParentPerms(absPath, permsInfos)
+		addParentPerms(logFileDir, permsInfos)
 	}
 
 	return err

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -266,7 +266,9 @@ func TestZipLogFiles(t *testing.T) {
 	_, err = os.Create(filepath.Join(srcDir, "archive", "agent.log"))
 	require.NoError(t, err)
 
-	err = zipLogFiles(dstDir, "test", filepath.Join(srcDir, "agent.log"), nil)
+	permsInfos := make(permissionsInfos)
+
+	err = zipLogFiles(dstDir, "test", filepath.Join(srcDir, "agent.log"), permsInfos)
 	assert.NoError(t, err)
 
 	// Check all the log files are in the destination path, at the right subdirectories

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -252,10 +252,10 @@ func TestCleanDirectoryName(t *testing.T) {
 func TestZipLogFiles(t *testing.T) {
 	srcDir, err := ioutil.TempDir("", "logs")
 	require.NoError(t, err)
-	// defer os.RemoveAll(srcDir)
+	defer os.RemoveAll(srcDir)
 	dstDir, err := ioutil.TempDir("", "TestZipLogFiles")
 	require.NoError(t, err)
-	// defer os.RemoveAll(dstDir)
+	defer os.RemoveAll(dstDir)
 
 	_, err = os.Create(filepath.Join(srcDir, "agent.log"))
 	require.NoError(t, err)

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -19,11 +19,13 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/DataDog/datadog-agent/cmd/agent/api/response"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestCreateArchive(t *testing.T) {
@@ -245,6 +247,35 @@ func TestCleanDirectoryName(t *testing.T) {
 
 	assert.Len(t, cleanedHostname, directoryNameMaxSize)
 	assert.True(t, !directoryNameFilter.MatchString(cleanedHostname))
+}
+
+func TestZipLogFiles(t *testing.T) {
+	srcDir, err := ioutil.TempDir("", "logs")
+	require.NoError(t, err)
+	// defer os.RemoveAll(srcDir)
+	dstDir, err := ioutil.TempDir("", "TestZipLogFiles")
+	require.NoError(t, err)
+	// defer os.RemoveAll(dstDir)
+
+	_, err = os.Create(filepath.Join(srcDir, "agent.log"))
+	require.NoError(t, err)
+	_, err = os.Create(filepath.Join(srcDir, "trace-agent.log"))
+	require.NoError(t, err)
+	err = os.Mkdir(filepath.Join(srcDir, "archive"), 0700)
+	require.NoError(t, err)
+	_, err = os.Create(filepath.Join(srcDir, "archive", "agent.log"))
+	require.NoError(t, err)
+
+	err = zipLogFiles(dstDir, "test", filepath.Join(srcDir, "agent.log"), nil)
+	assert.NoError(t, err)
+
+	// Check all the log files are in the destination path, at the right subdirectories
+	_, err = os.Stat(filepath.Join(dstDir, "test", "logs", "agent.log"))
+	assert.NoError(t, err)
+	_, err = os.Stat(filepath.Join(dstDir, "test", "logs", "trace-agent.log"))
+	assert.NoError(t, err)
+	_, err = os.Stat(filepath.Join(dstDir, "test", "logs", "archive", "agent.log"))
+	assert.NoError(t, err)
 }
 
 func TestZipTaggerList(t *testing.T) {

--- a/releasenotes/notes/flare-log-subdirectories-e64dd654a49040ba.yaml
+++ b/releasenotes/notes/flare-log-subdirectories-e64dd654a49040ba.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The flare command now correctly copies agent logs located in subdirectories
+    of the agent's root log directory.


### PR DESCRIPTION
### What does this PR do?

If the user creates subdirectories in the agent's log directory,
and for example moves agent logs to these subdirectories, this
change allows the log files to be copied in the flare.

In addition, add the permissions of the log directory itself (ex. `/var/log/datadog/`), which were missing from `permissions.log`.

### Motivation

Previously, in this scenario, log files in these subdirectories
could overwrite the log files in the root log directory
with the same basename.

For example:

```
/var/log/datadog/agent.log
/var/log/datadog/archive/agent.log
```

would previously, in the flare, result in (only one log file included):

```
<unzipped_flare>/logs/agent.log   // file copied from /var/log/datadog/archive/agent.log, /var/log/datadog/agent.log is not included in flare
```

now correctly results in:

```
<unzipped_flare>/logs/agent.log
<unzipped_flare>/logs/archive/agent.log
```

### Describe how to test your changes

Added a unit test.
To QA:
1. create the `archive` subdirectory in the agent's log directory, and create `agent.log` in that directory, as described in the example above
2. generate a flare and inspect it: the `logs` directory should include both `agent.log` and `archive/agent.log`. `permissions.log` should include the permissions to the agent's log dir (e.g. `/var/log/datadog` on Linux)

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
