### PR TITLE
Backport #9006 to 7.31.x: Copy `netapi32.dll` from servercore image in nano-based Windows image

### DIFF
--- a/.gitlab/image_build/docker_windows.yml
+++ b/.gitlab/image_build/docker_windows.yml
@@ -65,7 +65,7 @@
   needs: ["windows_msi_and_bosh_zip_x64-a7", "build_windows_container_entrypoint"]
   variables:
     AGENT_ZIP: "datadog-agent-7*-x86_64.zip"
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT}"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-${VARIANT} --build-arg NETAPI32_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT}"
     TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-amd64"
 
 .docker_build_agent6_windows_common:
@@ -77,21 +77,21 @@
   needs: ["windows_msi_x64-a6", "build_windows_container_entrypoint"]
   variables:
     AGENT_ZIP: "datadog-agent-6*-x86_64.zip"
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT}"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-${VARIANT} --build-arg NETAPI32_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT}"
     TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-amd64"
 
 .docker_build_agent6_windows_servercore_common:
   extends:
     - .docker_build_agent6_windows_common
   variables:
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT}"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg NETAPI32_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT}"
     TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-servercore-amd64"
 
 .docker_build_agent7_windows_servercore_common:
   extends:
     - .docker_build_agent7_windows_common
   variables:
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT}"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg NETAPI32_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT}"
     TARGET_TAG: "${IMAGE}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}${TAG_SUFFIX}-win${VARIANT}-servercore-amd64"
 
 include:

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -1,5 +1,11 @@
 ARG BASE_IMAGE=mcr.microsoft.com/powershell:lts-windowsservercore-1809
-FROM ${BASE_IMAGE}
+ARG NETAPI32_IMAGE=mcr.microsoft.com/powershell:lts-windowsservercore-1809
+
+FROM ${NETAPI32_IMAGE} AS netapi32
+
+FROM ${BASE_IMAGE} AS final
+# This "copy netapi32.dll" hack can be reverted once https://github.com/microsoft/Windows-Containers/issues/72 is fixed.
+COPY --from=netapi32 /Windows/System32/netapi32.dll /netapi32.dll
 
 ARG WITH_JMX="false"
 ARG VARIANT="unknown"
@@ -9,6 +15,12 @@ LABEL maintainer "Datadog <package@datadoghq.com>"
 USER ContainerAdministrator
 
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop';"]
+
+RUN if (-not (Test-Path /Windows/System32/netapi32.dll)) { \
+        Move-Item /netapi32.dll -Destination /Windows/System32/netapi32.dll \
+    } else { \
+        Remove-Item /netapi32.dll \
+    }
 
 COPY datadog-agent-latest.amd64.zip install.ps1 ./
 RUN . ./install.ps1


### PR DESCRIPTION
### What does this PR do?

Copy `netapi32.dll` from servercore Windows image into nano-based agent Windows image.

### Motivation

Fix the following failure:
```
panic: Failed to load netapi32.dll: The specified module could not be found.

goroutine 1 [running]:
syscall.(*LazyProc).mustFind(...)
	c:/go/src/syscall/dll_windows.go:320
syscall.(*LazyProc).Addr(...)
	c:/go/src/syscall/dll_windows.go:327
syscall.NetGetJoinInformation(0x0, 0xc00061fa48, 0xc00061fa44, 0x16, 0xc0000c96e0)
	c:/go/src/syscall/zsyscall_windows.go:1804 +0x107
os/user.isDomainJoined(0xc00061faa0, 0xf3624e, 0x0)
	c:/go/src/os/user/lookup_windows.go:18 +0x5a
os/user.lookupFullName(0xc000063b30, 0xc, 0xc000259bc0, 0x16, 0xc0000c96e0, 0x23, 0x16, 0xc0000c96e0, 0x23, 0x1)
	c:/go/src/os/user/lookup_windows.go:51 +0x2d
os/user.newUser(0xc000063ad0, 0xc, 0xc000063b10, 0xc, 0xc0000c9680, 0x1f, 0xc000259bc0, 0x16, 0xc000063b30, 0xc, ...)
	c:/go/src/os/user/lookup_windows.go:181 +0xd4
os/user.current(0x0, 0x0, 0x0)
	c:/go/src/os/user/lookup_windows.go:225 +0x2d8
os/user.Current.func1()
	c:/go/src/os/user/lookup.go:15 +0x29
sync.(*Once).doSlow(0x593ff00, 0x40b75b0)
	c:/go/src/sync/once.go:66 +0xf7
sync.(*Once).Do(...)
	c:/go/src/sync/once.go:57
os/user.Current(0xc0002599c0, 0x1b, 0x3f56005)
	c:/go/src/os/user/lookup.go:15 +0x105
github.com/golang/glog.init.1()
	C:/gomodcache/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b/gomodcache/github.com/golang/glog@v0.0.0-20160126235308-23def4e6c14b/glog_file.go:63 +0x4b
```

### Additional Notes

This ugly hack is needed because the [bump of github.com/dgraph-io/ristretto from 0.0.3 to 0.1.0](https://github.com/DataDog/datadog-agent/pull/8500) [introduced a new dependency to `glog`](https://github.com/dgraph-io/ristretto/pull/263) which is triggering [this issue with the Windows nano docker image](https://github.com/microsoft/Windows-Containers/issues/72).

Once [the Windows nano issue](https://github.com/microsoft/Windows-Containers/issues/72) is solved, this hack can be reverted.

### Describe how to test your changes

Start the non-`servercore` Windows docker image.
It shouldn’t panic anymore.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.