### PR TITLE
Fix isContainerized in the Cluster Agent

### DIFF
--- a/Dockerfiles/cluster-agent/amd64/Dockerfile
+++ b/Dockerfiles/cluster-agent/amd64/Dockerfile
@@ -29,10 +29,10 @@ FROM ubuntu:21.04
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 
-ENV PATH="/opt/datadog-agent/bin/:$PATH"
-
-# Allow User Group to exec the secret backend script.
-ENV DD_SECRET_BACKEND_COMMAND_ALLOW_GROUP_EXEC_PERM="true"
+ENV PATH="/opt/datadog-agent/bin/:$PATH" \
+    DOCKER_DD_AGENT="true" \
+    # Allow User Group to exec the secret backend script.
+    DD_SECRET_BACKEND_COMMAND_ALLOW_GROUP_EXEC_PERM="true"
 
 RUN apt-get update \
     && apt full-upgrade -y \

--- a/Dockerfiles/cluster-agent/arm64/Dockerfile
+++ b/Dockerfiles/cluster-agent/arm64/Dockerfile
@@ -28,10 +28,10 @@ FROM ubuntu:21.04
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 
-ENV PATH="/opt/datadog-agent/bin/:$PATH"
-
-# Allow User Group to exec the secret backend script.
-ENV DD_SECRET_BACKEND_COMMAND_ALLOW_GROUP_EXEC_PERM="true"
+ENV PATH="/opt/datadog-agent/bin/:$PATH" \
+    DOCKER_DD_AGENT="true" \
+    # Allow User Group to exec the secret backend script.
+    DD_SECRET_BACKEND_COMMAND_ALLOW_GROUP_EXEC_PERM="true"
 
 RUN apt-get update \
     && apt full-upgrade -y \


### PR DESCRIPTION
### What does this PR do?

Return true for `isContainerized` in Cluster Agent, required by #8949.

### Motivation

Bugfix.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Run Cluster Agent inside Kubernetes without cloud provider support, it should use container provider to get hostname.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
