### PR TITLE
Cherry-pick: Fix missing store unlock in DatadogMetric store #9024

### DIFF
--- a/pkg/clusteragent/externalmetrics/datadogmetric_controller_test.go
+++ b/pkg/clusteragent/externalmetrics/datadogmetric_controller_test.go
@@ -618,6 +618,16 @@ func TestLeaderDeleteCleanup(t *testing.T) {
 	assert.Equal(t, 0, f.store.Count())
 }
 
+// Scenario: Another event comes after Kubernetes object and internal store has been cleaned up
+func TestLeaderDuplicatedDelete(t *testing.T) {
+	f := newFixture(t)
+
+	f.runControllerSync(true, "default/dd-metric-0", nil)
+
+	// Check internal store content has not changed
+	assert.Equal(t, 0, f.store.Count())
+}
+
 // Scenario: Test that followers only follows (no action, always update store) even if local content is newer
 func TestFollower(t *testing.T) {
 	f := newFixture(t)


### PR DESCRIPTION
### What does this PR do?

Fix missing store unlock in DatadogMetric store #9024

### Motivation

Major issue detected during the releasing of DCA 1.15.0

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
