### PR TITLE
[CI] Remove fallback master references on Gitlab and CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,7 +10,6 @@ experimental:
   notify:
     branches:
       only:
-        - master
         - main
 
 templates:
@@ -33,7 +32,6 @@ templates:
           - gen18-godeps-{{ .Branch }}-{{ .Revision }}
           - gen18-godeps-{{ .Branch }}-
           - gen18-godeps-main-
-          - gen18-godeps-master-
     - save_cache: &save_deps
         key: gen18-godeps-{{ .Branch }}-{{ .Revision }}
     - restore_cache: &restore_source
@@ -262,7 +260,6 @@ jobs:
             - v5-macosdeps-{{ .Branch }}-{{ .Revision }}
             - v5-macosdeps-{{ .Branch }}-
             - v5-macosdeps-main-
-            - v5-macosdeps-master-
       - run:
           name: Setup runner
           command: |
@@ -326,7 +323,6 @@ workflows:
           filters:
             branches:
               ignore:
-                - master
                 - main
           requires:
             - dependencies
@@ -334,7 +330,6 @@ workflows:
           filters:
             branches:
               ignore:
-                - master
                 - main
           requires:
             - dependencies
@@ -342,7 +337,6 @@ workflows:
           filters:
             branches:
               ignore:
-                - master
                 - main
           requires:
             - dependencies

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -152,10 +152,10 @@ variables:
 # Condition mixins for simplification of rules
 #
 .if_main_branch: &if_main_branch
-  if: $CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "main"
+  if: $CI_COMMIT_BRANCH == "main"
 
 .if_not_main_branch: &if_not_main_branch
-  if: $CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "main"
+  if: $CI_COMMIT_BRANCH != "main"
 
 .if_release_branch: &if_release_branch
   if: $CI_COMMIT_BRANCH =~ /^[0-9]+\.[0-9]+\.x$/
@@ -195,10 +195,10 @@ variables:
 # RUN_ALL_BUILDS has no effect on main/deploy pipelines: they always run all builds (as some jobs
 # on main and deploy pipelines depend on jobs that are only run if we run all builds).
 .if_run_all_builds: &if_run_all_builds
-  if: $CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "main" || $DEPLOY_AGENT == "true" || $RUN_ALL_BUILDS == "true"
+  if: $CI_COMMIT_BRANCH == "main" || $DEPLOY_AGENT == "true" || $RUN_ALL_BUILDS == "true"
 
 .if_not_run_all_builds: &if_not_run_all_builds
-  if: $CI_COMMIT_BRANCH != "master" && $CI_COMMIT_BRANCH != "main" && $DEPLOY_AGENT != "true" && $RUN_ALL_BUILDS != "true"
+  if: $CI_COMMIT_BRANCH != "main" && $DEPLOY_AGENT != "true" && $RUN_ALL_BUILDS != "true"
 
 # Rule to trigger test kitchen setup, run, and cleanup.
 # By default:
@@ -207,7 +207,7 @@ variables:
 # RUN_KITCHEN_TESTS can be set to true to force kitchen tests to be run on a branch pipeline.
 # RUN_KITCHEN_TESTS can be set to false to force kithcen tests to not run on main/deploy pipelines.
 .if_kitchen: &if_kitchen
-  if: ($CI_COMMIT_BRANCH == "master" || $CI_COMMIT_BRANCH == "main"  || $DEPLOY_AGENT == "true" || $RUN_KITCHEN_TESTS == "true") && $RUN_KITCHEN_TESTS != "false"
+  if: ($CI_COMMIT_BRANCH == "main"  || $DEPLOY_AGENT == "true" || $RUN_KITCHEN_TESTS == "true") && $RUN_KITCHEN_TESTS != "false"
 
 # Rules to trigger default kitchen tests.
 # Some of the kitchen tests are run on all pipelines by default. They can only be disabled

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -64,7 +64,7 @@ tests_ebpf_x64:
     # Compile runtime security stress tests to be executed in kitchen tests
     - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
     # Compile main version for comparison, uncomment following lines when merged
-    - git checkout -f main || git checkout -f master
+    - git checkout -f main
     - git pull
     - inv -e deps
     - inv -e system-probe.build --bundle-ebpf --incremental-build


### PR DESCRIPTION
### What does this PR do?

Remove `master` references on Gitlab and CircleCI.

### Motivation

It's been a while since we renamed: caches are empty and we don't plan on reverting.

### Describe how to test your changes

Should be a no-op.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
