### PR TITLE
[Tagger] Add a containerd collector and support container_env_as_tags

### DIFF
--- a/pkg/collector/corechecks/containers/containerd/containerd_events_test.go
+++ b/pkg/collector/corechecks/containers/containerd/containerd_events_test.go
@@ -27,19 +27,32 @@ import (
 )
 
 type mockItf struct {
-	mockEvents      func() containerd.EventService
-	mockContainer   func() ([]containerd.Container, error)
-	mockMetadata    func() (containerd.Version, error)
-	mockImageSize   func(ctn containerd.Container) (int64, error)
-	mockTaskMetrics func(ctn containerd.Container) (*types.Metric, error)
-	mockTaskPids    func(ctn containerd.Container) ([]containerd.ProcessInfo, error)
-	mockInfo        func(ctn containerd.Container) (containers.Container, error)
-	mockNamespace   func() string
-	mockSpec        func(ctn containerd.Container) (*oci.Spec, error)
+	mockEvents            func() containerd.EventService
+	mockContainers        func() ([]containerd.Container, error)
+	mockContainer         func(id string) (containerd.Container, error)
+	mockContainerWithCtx  func(ctx context.Context, id string) (containerd.Container, error)
+	mockMetadata          func() (containerd.Version, error)
+	mockImageSize         func(ctn containerd.Container) (int64, error)
+	mockTaskMetrics       func(ctn containerd.Container) (*types.Metric, error)
+	mockTaskPids          func(ctn containerd.Container) ([]containerd.ProcessInfo, error)
+	mockInfo              func(ctn containerd.Container) (containers.Container, error)
+	mockLabels            func(ctn containerd.Container) (map[string]string, error)
+	mockLabelsWithContext func(ctx context.Context, ctn containerd.Container) (map[string]string, error)
+	mockNamespace         func() string
+	mockSpec              func(ctn containerd.Container) (*oci.Spec, error)
+	mockSpecWithContext   func(ctx context.Context, ctn containerd.Container) (*oci.Spec, error)
 }
 
 func (m *mockItf) ImageSize(ctn containerd.Container) (int64, error) {
 	return m.mockImageSize(ctn)
+}
+
+func (m *mockItf) Labels(ctn containerd.Container) (map[string]string, error) {
+	return m.mockLabels(ctn)
+}
+
+func (m *mockItf) LabelsWithContext(ctx context.Context, ctn containerd.Container) (map[string]string, error) {
+	return m.mockLabelsWithContext(ctx, ctn)
 }
 
 func (m *mockItf) Info(ctn containerd.Container) (containers.Container, error) {
@@ -63,7 +76,15 @@ func (m *mockItf) Namespace() string {
 }
 
 func (m *mockItf) Containers() ([]containerd.Container, error) {
-	return m.mockContainer()
+	return m.mockContainers()
+}
+
+func (m *mockItf) Container(id string) (containerd.Container, error) {
+	return m.mockContainer(id)
+}
+
+func (m *mockItf) ContainerWithContext(ctx context.Context, id string) (containerd.Container, error) {
+	return m.mockContainerWithCtx(ctx, id)
 }
 
 func (m *mockItf) GetEvents() containerd.EventService {
@@ -72,6 +93,10 @@ func (m *mockItf) GetEvents() containerd.EventService {
 
 func (m *mockItf) Spec(ctn containerd.Container) (*oci.Spec, error) {
 	return m.mockSpec(ctn)
+}
+
+func (m *mockItf) SpecWithContext(ctx context.Context, ctn containerd.Container) (*oci.Spec, error) {
+	return m.mockSpecWithContext(ctx, ctn)
 }
 
 type mockEvt struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -494,6 +494,7 @@ func InitConfig(config Config) {
 	// Containerd
 	// We only support containerd in Kubernetes. By default containerd cri uses `k8s.io` https://github.com/containerd/cri/blob/release/1.2/pkg/constants/constants.go#L22-L23
 	config.BindEnvAndSetDefault("containerd_namespace", "k8s.io")
+	config.BindEnvAndSetDefault("container_env_as_tags", map[string]string{})
 
 	// Kubernetes
 	config.BindEnvAndSetDefault("kubernetes_kubelet_host", "")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1940,6 +1940,13 @@ api_key:
 #   <NAMESPACE_LABEL>: <TAG_KEY>
 #   <HIGH_CARDINALITY_NAMESPACE_LABEL_NAME>: +<TAG_KEY>
 
+## @param container_env_as_tags - map - optional
+## The Agent can extract environment variable values and set them as metric tags values associated to a <TAG_KEY>.
+## Requires the container runtime socket to be reachable. (Supported container runtimes: Containerd)
+#
+# container_env_as_tags:
+#   <ENV>: <TAG_KEY>
+
 {{ end -}}
 {{- if .ECS }}
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1941,6 +1941,7 @@ api_key:
 #   <HIGH_CARDINALITY_NAMESPACE_LABEL_NAME>: +<TAG_KEY>
 
 ## @param container_env_as_tags - map - optional
+## @env DD_CONTAINER_ENV_AS_TAGS - map - optional
 ## The Agent can extract environment variable values and set them as metric tags values associated to a <TAG_KEY>.
 ## Requires the container runtime socket to be reachable. (Supported container runtimes: Containerd)
 #

--- a/pkg/tagger/collectors/containerd_extract.go
+++ b/pkg/tagger/collectors/containerd_extract.go
@@ -1,0 +1,43 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build containerd
+
+package collectors
+
+import (
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
+
+	"github.com/containerd/containerd/oci"
+	"github.com/gobwas/glob"
+)
+
+// extractTags generates container tags from its spec.
+func (c *ContainderdCollector) extractTags(spec *oci.Spec) ([]string, []string, []string, []string) {
+	if spec == nil || spec.Process == nil {
+		return nil, nil, nil, nil
+	}
+
+	tags := utils.NewTagList()
+	extractContainerdEnvVariables(tags, spec.Process.Env, c.envAsTags, c.globEnv)
+	low, orchestrator, high, standard := tags.Compute()
+
+	return low, orchestrator, high, standard
+}
+
+// extractContainerdEnvVariables uses the env as tags config to generate tagger tags.
+func extractContainerdEnvVariables(tags *utils.TagList, envValues []string, envAsTags map[string]string, globEnv map[string]glob.Glob) {
+	for _, env := range envValues {
+		envSplit := strings.SplitN(env, "=", 2)
+		if len(envSplit) != 2 {
+			continue
+		}
+
+		// Env as tags
+		utils.AddMetadataAsTags(envSplit[0], envSplit[1], envAsTags, globEnv, tags)
+	}
+}

--- a/pkg/tagger/collectors/containerd_extract_test.go
+++ b/pkg/tagger/collectors/containerd_extract_test.go
@@ -1,0 +1,146 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build containerd
+
+package collectors
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
+
+	"github.com/containerd/containerd/oci"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
+)
+
+var commnOCISpec = &oci.Spec{
+	Process: &specs.Process{
+		Env: []string{
+			"PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+			"HOSTNAME=redis",
+			"GOSU_VERSION=1.12",
+			"REDIS_VERSION=6.2.5",
+			"REDIS_DOWNLOAD_URL=http://download.redis.io/releases/redis-6.2.5.tar.gz",
+			"REDIS_DOWNLOAD_SHA=4b9a75709a1b74b3785e20a6c158cab94cf52298aa381eea947a678a60d551ae",
+			"env=dev",
+			"SERVICE=my_redis_svc",
+			"POD_NAME=redis",
+			"KUBERNETES_PORT_443_TCP_PORT=443",
+			"KUBERNETES_PORT_443_TCP_ADDR=10.96.0.1",
+			"KUBERNETES_SERVICE_HOST=10.96.0.1",
+			"KUBERNETES_SERVICE_PORT=443",
+			"KUBERNETES_SERVICE_PORT_HTTPS=443",
+			"KUBERNETES_PORT=tcp://10.96.0.1:443",
+			"KUBERNETES_PORT_443_TCP=tcp://10.96.0.1:443",
+			"KUBERNETES_PORT_443_TCP_PROTO=tcp",
+		},
+	},
+}
+
+func TestContainderdCollector_extractTags(t *testing.T) {
+	mockConfig := config.Mock()
+	tests := []struct {
+		name      string
+		loadFunc  func(*ContainderdCollector)
+		resetFunc func()
+		spec      *oci.Spec
+		low       []string
+		orch      []string
+		high      []string
+		std       []string
+	}{
+		{
+			name: "no container_env_as_tags",
+			loadFunc: func(c *ContainderdCollector) {
+				c.envAsTags, c.globEnv = utils.InitMetadataAsTags(config.Datadog.GetStringMapString("container_env_as_tags"))
+			},
+			spec: commnOCISpec,
+			low:  []string{},
+			orch: []string{},
+			high: []string{},
+			std:  []string{},
+		},
+		{
+			name: "basic container_env_as_tags",
+			loadFunc: func(c *ContainderdCollector) {
+				mockConfig.Set("container_env_as_tags", `{"env":"env"}`)
+				c.envAsTags, c.globEnv = utils.InitMetadataAsTags(config.Datadog.GetStringMapString("container_env_as_tags"))
+			},
+			resetFunc: func() { mockConfig.Set("container_env_as_tags", "") },
+			spec:      commnOCISpec,
+			low:       []string{"env:dev"},
+			orch:      []string{},
+			high:      []string{},
+			std:       []string{},
+		},
+		{
+			name: "advanced container_env_as_tags",
+			loadFunc: func(c *ContainderdCollector) {
+				mockConfig.Set("container_env_as_tags", `{"env":"env", "SERVICE":"service", "POD_NAME":"pod_name"}`)
+				c.envAsTags, c.globEnv = utils.InitMetadataAsTags(config.Datadog.GetStringMapString("container_env_as_tags"))
+			},
+			resetFunc: func() { mockConfig.Set("container_env_as_tags", "") },
+			spec:      commnOCISpec,
+			low:       []string{"env:dev", "service:my_redis_svc", "pod_name:redis"},
+			orch:      []string{},
+			high:      []string{},
+			std:       []string{},
+		},
+		{
+			name: "container_env_as_tags with wildcard",
+			loadFunc: func(c *ContainderdCollector) {
+				mockConfig.Set("container_env_as_tags", `{"REDIS*":"%%env%%"}`)
+				c.envAsTags, c.globEnv = utils.InitMetadataAsTags(config.Datadog.GetStringMapString("container_env_as_tags"))
+			},
+			resetFunc: func() { mockConfig.Set("container_env_as_tags", "") },
+			spec:      commnOCISpec,
+			low: []string{
+				"REDIS_VERSION:6.2.5",
+				"REDIS_DOWNLOAD_URL:http://download.redis.io/releases/redis-6.2.5.tar.gz",
+				"REDIS_DOWNLOAD_SHA:4b9a75709a1b74b3785e20a6c158cab94cf52298aa381eea947a678a60d551ae",
+			},
+			orch: []string{},
+			high: []string{},
+			std:  []string{},
+		},
+		{
+			name: "nil spec",
+			spec: nil,
+			low:  nil,
+			orch: nil,
+			high: nil,
+			std:  nil,
+		},
+		{
+			name: "nil spec.process",
+			spec: &specs.Spec{},
+			low:  nil,
+			orch: nil,
+			high: nil,
+			std:  nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &ContainderdCollector{}
+			if tt.loadFunc != nil {
+				tt.loadFunc(c)
+			}
+
+			low, orch, high, std := c.extractTags(tt.spec)
+			assert.ElementsMatch(t, tt.low, low)
+			assert.ElementsMatch(t, tt.orch, orch)
+			assert.ElementsMatch(t, tt.high, high)
+			assert.ElementsMatch(t, tt.std, std)
+
+			if tt.resetFunc != nil {
+				tt.resetFunc()
+			}
+		})
+	}
+}

--- a/pkg/tagger/collectors/containerd_main.go
+++ b/pkg/tagger/collectors/containerd_main.go
@@ -1,0 +1,240 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build containerd
+
+package collectors
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/status/health"
+	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
+	cutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	"github.com/containerd/containerd"
+	apievents "github.com/containerd/containerd/api/events"
+	containerdevents "github.com/containerd/containerd/events"
+	"github.com/gobwas/glob"
+	"github.com/gogo/protobuf/proto"
+)
+
+const (
+	containerdCollectorName = "containerd"
+	containerCreationTopic  = "/containers/create"
+	containerUpdateTopic    = "/containers/update"
+	containerDeletionTopic  = "/containers/delete"
+)
+
+// containerLifecycleFilters allows subscribing to containers lifecycle updates only.
+var containerLifecycleFilters = []string{
+	fmt.Sprintf(`topic==%q`, containerCreationTopic),
+	fmt.Sprintf(`topic==%q`, containerUpdateTopic),
+	fmt.Sprintf(`topic==%q`, containerDeletionTopic),
+}
+
+// ContainderdCollector listens to events on the containerd socket and gets containers lifecycle updates.
+// ContainderdCollector implements the Collector, Streamer and Fetcher interfaces.
+type ContainderdCollector struct {
+	client    cutil.ContainerdItf
+	envAsTags map[string]string
+	globEnv   map[string]glob.Glob
+	infoOut   chan<- []*TagInfo
+	stop      chan struct{}
+}
+
+var (
+	_ Collector = &ContainderdCollector{}
+	_ Streamer  = &ContainderdCollector{}
+	_ Fetcher   = &ContainderdCollector{}
+)
+
+// Detect tries to connect to the containerd socket and initializes the ContainderdCollector attributes.
+// Fast return if containerd wasn't detected by env discovery.
+func (c *ContainderdCollector) Detect(_ context.Context, out chan<- []*TagInfo) (CollectionMode, error) {
+	if !config.IsFeaturePresent(config.Containerd) {
+		return NoCollection, nil
+	}
+
+	client, err := cutil.GetContainerdUtil()
+	if err != nil {
+		return NoCollection, err
+	}
+
+	c.client = client
+	c.infoOut = out
+	c.stop = make(chan struct{})
+	c.envAsTags, c.globEnv = utils.InitMetadataAsTags(config.Datadog.GetStringMapString("container_env_as_tags"))
+
+	return StreamCollection, nil
+}
+
+// Stream watches and processes containers lifecycle events.
+func (c *ContainderdCollector) Stream() error {
+	healthCtx, healthCancel := context.WithCancel(context.Background())
+	health := health.RegisterLiveness("tagger-containerd")
+
+	streamCtx, streamCancel := context.WithCancel(context.Background())
+	stream, streamErrors := c.client.GetEvents().Subscribe(streamCtx, containerLifecycleFilters...)
+
+	for {
+		select {
+		case <-c.stop:
+			healthCancel()
+			streamCancel()
+			return health.Deregister()
+		case healthDeadline := <-health.C:
+			healthCancel()
+			healthCtx, healthCancel = context.WithDeadline(context.Background(), healthDeadline)
+		case event := <-stream:
+			c.processEvent(healthCtx, event)
+		case err := <-streamErrors:
+			if err == nil {
+				continue
+			}
+
+			log.Errorf("Containerd events stream error: %w", err)
+			healthCancel()
+			streamCancel()
+
+			return err
+		}
+	}
+}
+
+// Fetch tries to get tags for a specific container by its ID.
+func (c *ContainderdCollector) Fetch(ctx context.Context, entity string) ([]string, []string, []string, error) {
+	entityType, id := containers.SplitEntityName(entity)
+	if entityType != containers.ContainerEntityName || len(id) == 0 {
+		return nil, nil, nil, nil
+	}
+
+	container, isPauseContainer, err := c.containerByID(ctx, id)
+	if err != nil {
+		log.Debugf("Could not fetch container %s - %w", id, err)
+		return nil, nil, nil, err
+	}
+
+	if isPauseContainer {
+		log.Debugf("Ignoring pause container %s", id)
+		return nil, nil, nil, nil
+	}
+
+	low, orchestrator, high, _, err := c.tagsForContainer(ctx, container)
+	return low, orchestrator, high, err
+}
+
+// Stop shut down the container events watching loop.
+func (c *ContainderdCollector) Stop() error {
+	close(c.stop)
+	return nil
+}
+
+// processEvent handles container creation/update/deletion events and sends a TagInfo accordingly.
+func (c *ContainderdCollector) processEvent(ctx context.Context, event *containerdevents.Envelope) {
+	var handleCreateUpdate = func(id string) {
+		container, isPauseContainer, err := c.containerByID(ctx, id)
+		if err != nil {
+			log.Debugf("Could not fetch container %q: %w", id, err)
+			return
+		}
+
+		if isPauseContainer {
+			log.Debugf("Ignoring pause container %q", id)
+			return
+		}
+
+		low, orchestrator, high, standard, err := c.tagsForContainer(ctx, container)
+		if err != nil {
+			log.Debugf("Error fetching tags for container %q: %w", id, err)
+			return
+		}
+
+		c.infoOut <- []*TagInfo{{
+			Entity:               containers.BuildTaggerEntityName(id),
+			Source:               containerdCollectorName,
+			LowCardTags:          low,
+			OrchestratorCardTags: orchestrator,
+			HighCardTags:         high,
+			StandardTags:         standard,
+		}}
+	}
+
+	switch event.Topic {
+	case containerCreationTopic:
+		created := &apievents.ContainerCreate{}
+		if err := proto.Unmarshal(event.Event.Value, created); err != nil {
+			log.Debugf("Could not process container creation event: %w", err)
+			return
+		}
+
+		log.Tracef("Container %q created", created.ID)
+		handleCreateUpdate(created.ID)
+	case containerUpdateTopic:
+		updated := &apievents.ContainerUpdate{}
+		if err := proto.Unmarshal(event.Event.Value, updated); err != nil {
+			log.Debugf("Could not process container update event: %w", err)
+			return
+		}
+
+		log.Tracef("Container %q updated", updated.ID)
+		handleCreateUpdate(updated.ID)
+	case containerDeletionTopic:
+		deleted := &apievents.ContainerDelete{}
+		if err := proto.Unmarshal(event.Event.Value, deleted); err != nil {
+			log.Warnf("Could not process container deletion event: %w", err)
+			return
+		}
+
+		log.Tracef("Container %q deleted", deleted.ID)
+		c.infoOut <- []*TagInfo{{
+			Entity:       containers.BuildTaggerEntityName(deleted.ID),
+			Source:       containerdCollectorName,
+			DeleteEntity: true,
+		}}
+	default:
+		log.Debugf("Unsupported event topic: %s", event.Topic)
+		return
+	}
+}
+
+// containerByID fetches a containerd.Container by ID.
+func (c *ContainderdCollector) containerByID(ctx context.Context, id string) (containerd.Container, bool, error) {
+	container, err := c.client.ContainerWithContext(ctx, id)
+	if err != nil {
+		return nil, false, err
+	}
+
+	labels, err := c.client.LabelsWithContext(ctx, container)
+	if err != nil {
+		return nil, false, err
+	}
+
+	return container, containers.IsPauseContainer(labels), nil
+}
+
+// tagsForContainer extracts tas for a given container.
+func (c *ContainderdCollector) tagsForContainer(ctx context.Context, container containerd.Container) ([]string, []string, []string, []string, error) {
+	containerSpec, err := c.client.SpecWithContext(ctx, container)
+	if err != nil {
+		log.Debugf("Could not get container spec %s - %v", container.ID(), err)
+		return nil, nil, nil, nil, err
+	}
+
+	low, orchestrator, high, standard := c.extractTags(containerSpec)
+	return low, orchestrator, high, standard, nil
+}
+
+func containerdFactory() Collector {
+	return &ContainderdCollector{}
+}
+
+func init() {
+	registerCollector(containerdCollectorName, containerdFactory, NodeRuntime)
+}

--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -53,7 +53,7 @@ func (c *DockerCollector) Detect(_ context.Context, out chan<- []*TagInfo) (Coll
 
 	// We lower-case the values collected by viper as well as the ones from inspecting the labels of containers.
 	c.labelsAsTags = retrieveMappingFromConfig("docker_labels_as_tags")
-	c.envAsTags = retrieveMappingFromConfig("docker_env_as_tags")
+	c.envAsTags = retrieveMappingFromConfig("docker_env_as_tags") // TODO: Merge with container_env_as_tags
 
 	// TODO: list and inspect existing containers once docker utils are merged
 

--- a/pkg/tagger/utils/k8s_metadata.go
+++ b/pkg/tagger/utils/k8s_metadata.go
@@ -54,9 +54,10 @@ func AddMetadataAsTags(name, value string, metadataAsTags map[string]string, glo
 var templateVariables = map[string]struct{}{
 	"label":      {},
 	"annotation": {},
+	"env":        {},
 }
 
-// resolveTag replaces %%label%% and %%annotation%% by their values
+// resolveTag replaces %%label%%, %%annotation%% and %%env%% by their values
 func resolveTag(tmpl, label string) string {
 	vars := tmplvar.ParseString(tmpl)
 	tagName := tmpl

--- a/pkg/tagger/utils/k8s_metadata_test.go
+++ b/pkg/tagger/utils/k8s_metadata_test.go
@@ -42,6 +42,13 @@ func TestMetadataAsTags(t *testing.T) {
 			want:           []string{"foo:bar"},
 		},
 		{
+			name:           "env tpl var",
+			k:              "foo",
+			v:              "bar",
+			metadataAsTags: map[string]string{"foo": "%%env%%"},
+			want:           []string{"foo:bar"},
+		},
+		{
 			name:           "label tpl var with prefix",
 			k:              "foo",
 			v:              "bar",
@@ -53,6 +60,13 @@ func TestMetadataAsTags(t *testing.T) {
 			k:              "foo",
 			v:              "bar",
 			metadataAsTags: map[string]string{"foo": "%%annotation%%_suffix"},
+			want:           []string{"foo_suffix:bar"},
+		},
+		{
+			name:           "env tpl var with suffix",
+			k:              "foo",
+			v:              "bar",
+			metadataAsTags: map[string]string{"foo": "%%env%%_suffix"},
 			want:           []string{"foo_suffix:bar"},
 		},
 		{
@@ -74,6 +88,13 @@ func TestMetadataAsTags(t *testing.T) {
 			k:              "foo",
 			v:              "bar",
 			metadataAsTags: map[string]string{"*": "%%annotation%%"},
+			want:           []string{"foo:bar"},
+		},
+		{
+			name:           "match all envs",
+			k:              "foo",
+			v:              "bar",
+			metadataAsTags: map[string]string{"*": "%%env%%"},
 			want:           []string{"foo:bar"},
 		},
 	}

--- a/pkg/util/containerd/containerd_util.go
+++ b/pkg/util/containerd/containerd_util.go
@@ -13,11 +13,14 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
+
 	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/errdefs"
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/containerd/oci"
 )
@@ -35,11 +38,16 @@ var (
 
 // ContainerdItf is the interface implementing a subset of methods that leverage the Containerd api.
 type ContainerdItf interface {
+	Container(id string) (containerd.Container, error)
+	ContainerWithContext(ctx context.Context, id string) (containerd.Container, error)
 	Containers() ([]containerd.Container, error)
 	GetEvents() containerd.EventService
 	Info(ctn containerd.Container) (containers.Container, error)
+	Labels(ctn containerd.Container) (map[string]string, error)
+	LabelsWithContext(ctx context.Context, ctn containerd.Container) (map[string]string, error)
 	ImageSize(ctn containerd.Container) (int64, error)
 	Spec(ctn containerd.Container) (*oci.Spec, error)
+	SpecWithContext(ctx context.Context, ctn containerd.Container) (*oci.Spec, error)
 	Metadata() (containerd.Version, error)
 	Namespace() string
 	TaskMetrics(ctn containerd.Container) (*types.Metric, error)
@@ -134,6 +142,25 @@ func (c *ContainerdUtil) GetEvents() containerd.EventService {
 	return c.cl.EventService()
 }
 
+// Container interfaces with the containerd api to get a container by ID.
+func (c *ContainerdUtil) Container(id string) (containerd.Container, error) {
+	return c.ContainerWithContext(context.Background(), id)
+}
+
+// ContainerWithContext interfaces with the containerd api to get a container by ID.
+// It allows passing the parent context
+func (c *ContainerdUtil) ContainerWithContext(ctx context.Context, id string) (containerd.Container, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.queryTimeout)
+	defer cancel()
+	ctxNamespace := namespaces.WithNamespace(ctx, c.namespace)
+	ctn, err := c.cl.LoadContainer(ctxNamespace, id)
+	if errdefs.IsNotFound(err) {
+		return ctn, errors.NewNotFound(id)
+	}
+
+	return ctn, err
+}
+
 // Containers interfaces with the containerd api to get the list of Containers.
 func (c *ContainerdUtil) Containers() ([]containerd.Container, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), c.queryTimeout)
@@ -164,9 +191,30 @@ func (c *ContainerdUtil) Info(ctn containerd.Container) (containers.Container, e
 	return ctn.Info(ctxNamespace)
 }
 
+// Labels interfaces with the containerd api to get Container labels
+func (c *ContainerdUtil) Labels(ctn containerd.Container) (map[string]string, error) {
+	return c.LabelsWithContext(context.Background(), ctn)
+}
+
+// LabelsWithContext interfaces with the containerd api to get Container labels
+// It allows passing the parent context
+func (c *ContainerdUtil) LabelsWithContext(ctx context.Context, ctn containerd.Container) (map[string]string, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.queryTimeout)
+	defer cancel()
+	ctxNamespace := namespaces.WithNamespace(ctx, c.namespace)
+
+	return ctn.Labels(ctxNamespace)
+}
+
 // Spec interfaces with the containerd api to get container OCI Spec
 func (c *ContainerdUtil) Spec(ctn containerd.Container) (*oci.Spec, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), c.queryTimeout)
+	return c.SpecWithContext(context.Background(), ctn)
+}
+
+// SpecWithContext interfaces with the containerd api to get container OCI Spec
+// It allows passing the parent context
+func (c *ContainerdUtil) SpecWithContext(ctx context.Context, ctn containerd.Container) (*oci.Spec, error) {
+	ctx, cancel := context.WithTimeout(ctx, c.queryTimeout)
 	defer cancel()
 	ctxNamespace := namespaces.WithNamespace(ctx, c.namespace)
 

--- a/releasenotes/notes/container-env-as-tags-f208f5d35ada84d4.yaml
+++ b/releasenotes/notes/container-env-as-tags-f208f5d35ada84d4.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Introduce a new configuration parameter ``container_env_as_tags``
+    to allow converting containerd containers' environment variables into tags.


### PR DESCRIPTION
### What does this PR do?

- Build a `containerd` tagger collector
- Support `container_env_as_tags`

### Motivation

Feature request

### Additional Notes

Will make the `docker` collector support `container_env_as_tags` in a separate PR.

### Describe how to test your changes

* The collector should be auto-enabled in a k8s containerd environment
* Configure some env as tags, example: `'{"env":"env", "foo":"bar", "POD_NAME":"custom_pod_name"}'`
```
agent tagger-list
...
=== Entity container_id://ff6da781abecee727221862630faded41769af6fbd2b5f1137fa1e218bd4bdea ===
== Source containerd ==
Tags: [bar:foo_val custom_pod_name:redis env:dev]
== Source kube-metadata-collector ==
Tags: []
== Source kubelet ==
Tags: [container_id:ff6da781abecee727221862630faded41769af6fbd2b5f1137fa1e218bd4bdea display_container_name:redis_redis env:dev image_name:redis/redis image_tag:latest kube_container_name:redis kube_namespace:default pod_name:redis pod_phase:running service:redis-svc short_image:redis version:v1]
...
===
```
* Kill and create multiple pods, make sure the `containerd` tagger collector detects the container lifecycle events and apply the `container_env_as_tags` config if it matches.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
