### PR TITLE
[Tagger] Support container_env_as_tags for Docker

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1943,7 +1943,7 @@ api_key:
 ## @param container_env_as_tags - map - optional
 ## @env DD_CONTAINER_ENV_AS_TAGS - map - optional
 ## The Agent can extract environment variable values and set them as metric tags values associated to a <TAG_KEY>.
-## Requires the container runtime socket to be reachable. (Supported container runtimes: Containerd)
+## Requires the container runtime socket to be reachable. (Supported container runtimes: Containerd, Docker)
 #
 # container_env_as_tags:
 #   <ENV>: <TAG_KEY>

--- a/pkg/tagger/collectors/common.go
+++ b/pkg/tagger/collectors/common.go
@@ -33,6 +33,17 @@ func retrieveMappingFromConfig(configKey string) map[string]string {
 	return labelsList
 }
 
+// mergeMaps merges two maps, in case of conflict the first argument is prioritized
+func mergeMaps(first, second map[string]string) map[string]string {
+	for k, v := range second {
+		if _, found := first[k]; !found {
+			first[k] = v
+		}
+	}
+
+	return first
+}
+
 func parseContainerADTagsLabels(tags *utils.TagList, labelValue string) {
 	tagNames := []string{}
 	err := json.Unmarshal([]byte(labelValue), &tagNames)

--- a/pkg/tagger/collectors/common_test.go
+++ b/pkg/tagger/collectors/common_test.go
@@ -63,3 +63,39 @@ func assertTagInfoListEqual(t *testing.T, expectedUpdates []*TagInfo, updates []
 		assertTagInfoEqual(t, expectedUpdates[i], updates[i])
 	}
 }
+
+func Test_mergeMaps(t *testing.T) {
+	tests := []struct {
+		name   string
+		first  map[string]string
+		second map[string]string
+		want   map[string]string
+	}{
+		{
+			name:   "no conflict",
+			first:  map[string]string{"first-k1": "first-v1", "first-k2": "first-v2"},
+			second: map[string]string{"second-k1": "second-v1", "second-k2": "second-v2"},
+			want: map[string]string{
+				"first-k1":  "first-v1",
+				"first-k2":  "first-v2",
+				"second-k1": "second-v1",
+				"second-k2": "second-v2",
+			},
+		},
+		{
+			name:   "conflict",
+			first:  map[string]string{"first-k1": "first-v1", "first-k2": "first-v2"},
+			second: map[string]string{"first-k2": "second-v1", "second-k2": "second-v2"},
+			want: map[string]string{
+				"first-k1":  "first-v1",
+				"first-k2":  "first-v2",
+				"second-k2": "second-v2",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.EqualValues(t, tt.want, mergeMaps(tt.first, tt.second))
+		})
+	}
+}

--- a/pkg/tagger/collectors/docker_main.go
+++ b/pkg/tagger/collectors/docker_main.go
@@ -53,7 +53,7 @@ func (c *DockerCollector) Detect(_ context.Context, out chan<- []*TagInfo) (Coll
 
 	// We lower-case the values collected by viper as well as the ones from inspecting the labels of containers.
 	c.labelsAsTags = retrieveMappingFromConfig("docker_labels_as_tags")
-	c.envAsTags = retrieveMappingFromConfig("docker_env_as_tags") // TODO: Merge with container_env_as_tags
+	c.envAsTags = mergeMaps(retrieveMappingFromConfig("docker_env_as_tags"), retrieveMappingFromConfig("container_env_as_tags"))
 
 	// TODO: list and inspect existing containers once docker utils are merged
 


### PR DESCRIPTION
### What does this PR do?

Make the Docker tagger collector support `container_env_as_tags` alongside `docker_env_as_tags` without breaking compatibility.

### Motivation

Follow-up on https://github.com/DataDog/datadog-agent/pull/9054

### Additional Notes

To be merged after https://github.com/DataDog/datadog-agent/pull/9054

### Describe how to test your changes

- Same as https://github.com/DataDog/datadog-agent/pull/9054 but for Docker
- Configure both `docker_env_as_tags` and `container_env_as_tags`, make sure the configs are merged and that `docker_env_as_tags` is prioritized in case of conflict.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
