### PR TITLE
DBM-561: Update dbquery track endpoint to dbquery-intake.

### DIFF
--- a/pkg/epforwarder/epforwarder.go
+++ b/pkg/epforwarder/epforwarder.go
@@ -30,7 +30,7 @@ var passthroughPipelineDescs = []passthroughPipelineDesc{
 	{
 		eventType:              eventTypeDBMSamples,
 		endpointsConfigPrefix:  "database_monitoring.samples.",
-		hostnameEndpointPrefix: "dbquery-http-intake.logs.",
+		hostnameEndpointPrefix: "dbquery-intake.",
 		intakeTrackType:        "databasequery",
 		// raise the default batch_max_concurrent_send from 0 to 10 to ensure this pipeline is able to handle 4k events/s
 		defaultBatchMaxConcurrentSend: 10,


### PR DESCRIPTION
### What does this PR do?

Changes `hostnameEndpointPrefix` for dbm-samples to `dbquery-intake.`

DNS entries have been created here https://github.com/DataDog/cloudops/pull/26034

### Motivation

EP Intake asked us to migrate it to outside of the logs subdomain as it is not part of the logs product

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Deploy change to our integration env and confirm DBM events are still flowing in-app. I have already updated endpoint in our team's configuration for our integration envs so we know this works.  

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
