### PR TITLE
Do not send host metadata from CLC

### DIFF
--- a/pkg/metadata/scheduler.go
+++ b/pkg/metadata/scheduler.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common/signals"
@@ -47,7 +48,7 @@ func NewScheduler(s *serializer.Serializer) *Scheduler {
 		collectors: make(map[string]*scheduledCollector),
 	}
 
-	if enableFirstRunCollection {
+	if enableFirstRunCollection && config.Datadog.GetBool("enable_metadata_collection") {
 		err := scheduler.firstRun()
 		if err != nil {
 			log.Errorf("Unable to send host metadata at first run: %v", err)

--- a/releasenotes/notes/CLC-do-not-send-host-metadata-d1a83bf84cc879af.yaml
+++ b/releasenotes/notes/CLC-do-not-send-host-metadata-d1a83bf84cc879af.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Make sure ``DD_ENABLE_METADATA_COLLECTION="false"`` prevent all host metadata emission, including the initial one.


### PR DESCRIPTION
### What does this PR do?

Prevent the CLC from sending host metadata.

### Motivation

The host metadata should be sent only by the node agent.

### Additional Notes


### Describe how to test your changes

* Deploy the agent on a Kubernetes cluster with CLC enabled.
* Configure the node agent with `DD_TAGS=lenaic:gke foo:node`
* Configure the CLC with `DD_TAGS=lenaic:gke foo:clc`
* Deploy a workload with a check and ensure with a `nodeSelector` that this workload will always run on a node where a CLC is also running.
* Look at the `foo` tag with a query like `count:network.http.response_time{lenaic:gke} by {foo}.fill(null)`
* Try to kill the CLC pod (to force host metadata collection) and kill the workload few seconds after.

With the previous version of the agent, we saw the `foo` tag flipping like this:
![image](https://user-images.githubusercontent.com/1437785/131981858-fbe6aa35-631a-4d53-984f-5ecc11a5b0f4.png)

With this change, we should never see `foo:clc`.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [X] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [X] The appropriate `team/..` label has been applied, if known.
- [X] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [X] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
