### PR TITLE
[AD] Resolve template vars and envs in log configs

### DIFF
--- a/pkg/autodiscovery/configresolver/configresolver.go
+++ b/pkg/autodiscovery/configresolver/configresolver.go
@@ -33,7 +33,8 @@ var templateVariables = map[string]variableGetter{
 }
 
 // SubstituteTemplateVariables replaces %%VARIABLES%% in the config init,
-// instances, and logs config
+// instances, and logs config.
+// When there is an error, it stops processing.
 func SubstituteTemplateVariables(ctx context.Context, config *integration.Config, svc listeners.Service) error {
 	var err error
 
@@ -48,7 +49,9 @@ func SubstituteTemplateVariables(ctx context.Context, config *integration.Config
 }
 
 // SubstituteTemplateEnvVars replaces %%ENV_VARIABLE%% from environment
-// variables in the config init, instances, and logs config
+// variables in the config init, instances, and logs config.
+// When there is an error, it continues replacing. When there are multiple
+// errors, the one returned is the one that happened first.
 func SubstituteTemplateEnvVars(config *integration.Config) error {
 	var retErr error
 

--- a/pkg/autodiscovery/configresolver/configresolver.go
+++ b/pkg/autodiscovery/configresolver/configresolver.go
@@ -32,22 +32,6 @@ var templateVariables = map[string]variableGetter{
 	"kube":     getAdditionalTplVariables,
 }
 
-// SubstituteTemplateVariables replaces %%VARIABLES%% in the config init,
-// instances, and logs config.
-// When there is an error, it stops processing.
-func SubstituteTemplateVariables(ctx context.Context, config *integration.Config, svc listeners.Service) error {
-	var err error
-
-	for _, toResolve := range dataToResolve(config) {
-		*toResolve, err = resolveDataWithTemplateVars(ctx, *toResolve, svc)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 // SubstituteTemplateEnvVars replaces %%ENV_VARIABLE%% from environment
 // variables in the config init, instances, and logs config.
 // When there is an error, it continues replacing. When there are multiple
@@ -116,7 +100,7 @@ func Resolve(tpl integration.Config, svc listeners.Service) (integration.Config,
 		return resolvedConfig, "", errors.New("unable to resolve, service not ready")
 	}
 
-	if err := SubstituteTemplateVariables(ctx, &resolvedConfig, svc); err != nil {
+	if err := substituteTemplateVariables(ctx, &resolvedConfig, svc); err != nil {
 		return resolvedConfig, "", err
 	}
 
@@ -137,6 +121,22 @@ func Resolve(tpl integration.Config, svc listeners.Service) (integration.Config,
 	}
 
 	return resolvedConfig, tagsHash, nil
+}
+
+// substituteTemplateVariables replaces %%VARIABLES%% in the config init,
+// instances, and logs config.
+// When there is an error, it stops processing.
+func substituteTemplateVariables(ctx context.Context, config *integration.Config, svc listeners.Service) error {
+	var err error
+
+	for _, toResolve := range dataToResolve(config) {
+		*toResolve, err = resolveDataWithTemplateVars(ctx, *toResolve, svc)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func dataToResolve(config *integration.Config) []*integration.Data {

--- a/pkg/autodiscovery/configresolver/configresolver.go
+++ b/pkg/autodiscovery/configresolver/configresolver.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/util/tmplvar"
 	"os"
 	"strconv"
 
@@ -31,46 +32,34 @@ var templateVariables = map[string]variableGetter{
 	"kube":     getAdditionalTplVariables,
 }
 
-// SubstituteTemplateVariables replaces %%VARIABLES%% using the variableGetters passed in
-func SubstituteTemplateVariables(ctx context.Context, config *integration.Config, getters map[string]variableGetter, svc listeners.Service) error {
-	for i := 0; i < len(config.Instances); i++ {
-		vars := config.GetTemplateVariablesForInstance(i)
-		for _, v := range vars {
-			if f, found := getters[string(v.Name)]; found {
-				resolvedVar, err := f(ctx, v.Key, svc)
-				if err != nil {
-					return err
-				}
-				// init config vars are replaced by the first found
-				config.InitConfig = bytes.Replace(config.InitConfig, v.Raw, resolvedVar, -1)
-				config.Instances[i] = bytes.Replace(config.Instances[i], v.Raw, resolvedVar, -1)
-			}
+// SubstituteTemplateVariables replaces %%VARIABLES%% in the config init,
+// instances, and logs config
+func SubstituteTemplateVariables(ctx context.Context, config *integration.Config, svc listeners.Service) error {
+	var err error
+
+	for _, toResolve := range dataToResolve(config) {
+		*toResolve, err = resolveDataWithTemplateVars(ctx, *toResolve, svc)
+		if err != nil {
+			return err
 		}
 	}
+
 	return nil
 }
 
-// SubstituteTemplateEnvVars replaces %%ENV_VARIABLE%% from environment variables
+// SubstituteTemplateEnvVars replaces %%ENV_VARIABLE%% from environment
+// variables in the config init, instances, and logs config
 func SubstituteTemplateEnvVars(config *integration.Config) error {
 	var retErr error
-	for i := 0; i < len(config.Instances); i++ {
-		vars := config.GetTemplateVariablesForInstance(i)
-		for _, v := range vars {
-			if "env" == string(v.Name) {
-				resolvedVar, err := getEnvvar(v.Key)
-				if err != nil {
-					log.Warnf("variable not replaced: %s", err)
-					if retErr == nil {
-						retErr = err
-					}
-					continue
-				}
-				// init config vars are replaced by the first found
-				config.InitConfig = bytes.Replace(config.InitConfig, v.Raw, resolvedVar, -1)
-				config.Instances[i] = bytes.Replace(config.Instances[i], v.Raw, resolvedVar, -1)
-			}
+
+	for _, toResolve := range dataToResolve(config) {
+		var err error
+		*toResolve, err = resolveDataWithEnvs(*toResolve)
+		if err != nil && retErr == nil {
+			retErr = err
 		}
 	}
+
 	return retErr
 }
 
@@ -124,7 +113,7 @@ func Resolve(tpl integration.Config, svc listeners.Service) (integration.Config,
 		return resolvedConfig, "", errors.New("unable to resolve, service not ready")
 	}
 
-	if err := SubstituteTemplateVariables(ctx, &resolvedConfig, templateVariables, svc); err != nil {
+	if err := SubstituteTemplateVariables(ctx, &resolvedConfig, svc); err != nil {
 		return resolvedConfig, "", err
 	}
 
@@ -145,6 +134,59 @@ func Resolve(tpl integration.Config, svc listeners.Service) (integration.Config,
 	}
 
 	return resolvedConfig, tagsHash, nil
+}
+
+func dataToResolve(config *integration.Config) []*integration.Data {
+	res := []*integration.Data{&config.InitConfig}
+
+	for i := 0; i < len(config.Instances); i++ {
+		res = append(res, &config.Instances[i])
+	}
+
+	if config.IsLogConfig() {
+		res = append(res, &config.LogsConfig)
+	}
+
+	return res
+}
+
+func resolveDataWithTemplateVars(ctx context.Context, data integration.Data, svc listeners.Service) ([]byte, error) {
+	res := append([]byte(nil), data...)
+
+	templateVars := tmplvar.Parse(data)
+	for _, tVar := range templateVars {
+		if f, found := templateVariables[string(tVar.Name)]; found {
+			resolvedVar, err := f(ctx, tVar.Key, svc)
+			if err != nil {
+				return res, err
+			}
+			res = bytes.Replace(res, tVar.Raw, resolvedVar, -1)
+		}
+	}
+
+	return res, nil
+}
+
+func resolveDataWithEnvs(data integration.Data) ([]byte, error) {
+	var retErr error
+	res := append([]byte(nil), data...)
+
+	templateVars := tmplvar.Parse(data)
+	for _, tVar := range templateVars {
+		if "env" == string(tVar.Name) {
+			resolvedVar, err := getEnvvar(tVar.Key)
+			if err != nil {
+				log.Warnf("variable not replaced: %s", err)
+				if retErr == nil {
+					retErr = err
+				}
+				continue
+			}
+			res = bytes.Replace(res, tVar.Raw, resolvedVar, -1)
+		}
+	}
+
+	return res, retErr
 }
 
 func addServiceTags(resolvedConfig *integration.Config, tags []string) error {

--- a/pkg/autodiscovery/configresolver/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver/configresolver_test.go
@@ -342,9 +342,47 @@ func TestResolve(t *testing.T) {
 			},
 			errorString: "no port found for container a5901276aed1 - ignoring it",
 		},
-		//// envvars
+		//// logs config
 		{
-			testName: "simple %%env_test_envvar_key%%",
+			testName: "resolve logs config",
+			svc: &dummyService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Hosts:         map[string]string{"bridge": "127.0.0.1"},
+			},
+			tpl: integration.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []integration.Data{},
+				LogsConfig:    integration.Data("host: %%host%%"),
+			},
+			out: integration.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []integration.Data{},
+				Entity:        "a5901276aed1",
+				LogsConfig:    integration.Data("host: 127.0.0.1"),
+			},
+		},
+		{
+			testName: "resolve logs config with %%host%% and no host in service",
+			svc: &dummyService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Hosts:         map[string]string{},
+			},
+			tpl: integration.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []integration.Data{},
+				LogsConfig:    integration.Data("host: %%host%%"),
+				Entity:        "a5901276aed1",
+			},
+			errorString: "no network found for container a5901276aed1, ignoring it",
+		},
+		//// envvars (metrics check)
+		{
+			testName: "simple %%env_test_envvar_key%% (metrics check)",
 			svc: &dummyService{
 				ID:            "a5901276aed1",
 				ADIdentifiers: []string{"redis"},
@@ -363,7 +401,7 @@ func TestResolve(t *testing.T) {
 			},
 		},
 		{
-			testName: "not found %%env_test_envvar_not_set%%",
+			testName: "not found %%env_test_envvar_not_set%% (metrics check)",
 			svc: &dummyService{
 				ID:            "a5901276aed1",
 				ADIdentifiers: []string{"redis"},
@@ -376,7 +414,7 @@ func TestResolve(t *testing.T) {
 			},
 			errorString: "failed to retrieve envvar test_envvar_not_set, skipping service a5901276aed1"},
 		{
-			testName: "invalid %%env%%",
+			testName: "invalid %%env%% (metrics check)",
 			svc: &dummyService{
 				ID:            "a5901276aed1",
 				ADIdentifiers: []string{"redis"},
@@ -386,6 +424,57 @@ func TestResolve(t *testing.T) {
 				Name:          "cpu",
 				ADIdentifiers: []string{"redis"},
 				Instances:     []integration.Data{integration.Data("test: %%env%%")},
+			},
+			errorString: "envvar name is missing, skipping service a5901276aed1",
+		},
+		//// envvars (logs check)
+		{
+			testName: "simple %%env_test_envvar_key%% (logs check)",
+			svc: &dummyService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Pid:           1337,
+			},
+			tpl: integration.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []integration.Data{},
+				LogsConfig:    integration.Data("test: %%env_test_envvar_key%%"),
+			},
+			out: integration.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []integration.Data{},
+				LogsConfig:    integration.Data("test: test_value"),
+				Entity:        "a5901276aed1",
+			},
+		},
+		{
+			testName: "not found %%env_test_envvar_not_set%% (logs check)",
+			svc: &dummyService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Pid:           1337,
+			},
+			tpl: integration.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []integration.Data{},
+				LogsConfig:    integration.Data("test: %%env_test_envvar_not_set%%"),
+			},
+			errorString: "failed to retrieve envvar test_envvar_not_set, skipping service a5901276aed1"},
+		{
+			testName: "invalid %%env%% (logs check)",
+			svc: &dummyService{
+				ID:            "a5901276aed1",
+				ADIdentifiers: []string{"redis"},
+				Pid:           1337,
+			},
+			tpl: integration.Config{
+				Name:          "cpu",
+				ADIdentifiers: []string{"redis"},
+				Instances:     []integration.Data{},
+				LogsConfig:    integration.Data("test: %%env%%"),
 			},
 			errorString: "envvar name is missing, skipping service a5901276aed1",
 		},
@@ -432,7 +521,7 @@ func TestResolve(t *testing.T) {
 		},
 		//// unknown tag
 		{
-			testName: "invalid %%FOO%% tag",
+			testName: "invalid %%FOO%% tag in metrics check",
 			svc: &dummyService{
 				ID:            "a5901276aed1",
 				ADIdentifiers: []string{"redis"},
@@ -511,7 +600,6 @@ func TestResolve(t *testing.T) {
 				Name:          "redis",
 				ADIdentifiers: []string{"redis"},
 				Instances:     []integration.Data{integration.Data("host: localhost\ntags:\n- foo:bar\n")},
-				InitConfig:    integration.Data{},
 				Entity:        "a5901276aed1",
 				Source:        "file:/etc/datadog-agent/conf.d/redisdb.d/auto_conf.yaml",
 				Provider:      "file",
@@ -535,7 +623,6 @@ func TestResolve(t *testing.T) {
 				Name:          "redis",
 				ADIdentifiers: []string{"redis"},
 				Instances:     []integration.Data{integration.Data("host: localhost\ntags:\n- foo:bar\n")},
-				InitConfig:    integration.Data{},
 				Entity:        "a5901276aed1",
 				Source:        "file:/etc/datadog-agent/conf.d/redisdb.d/auto_conf.yaml",
 				Provider:      "file",

--- a/pkg/autodiscovery/configresolver/configresolver_test.go
+++ b/pkg/autodiscovery/configresolver/configresolver_test.go
@@ -707,7 +707,6 @@ func TestResolve(t *testing.T) {
 			},
 		},
 	}
-	validTemplates := 0
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("case %d: %s", i, tc.testName), func(t *testing.T) {
@@ -722,7 +721,6 @@ func TestResolve(t *testing.T) {
 				assert.Equal(t, tc.out, cfg)
 				assert.Equal(t, checksum, tc.tpl.Digest())
 				assert.Equal(t, "hash", hash) // Resolve must return a non-empty hash if err == nil
-				validTemplates++
 			}
 		})
 	}

--- a/releasenotes/notes/ad-template-vars-in-logs-be75bad673178a0c.yaml
+++ b/releasenotes/notes/ad-template-vars-in-logs-be75bad673178a0c.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Autodiscovery can now resolve template variables and environment variables in log configurations.


### PR DESCRIPTION
### What does this PR do?

This PR adds support for resolving template vars and envs in log configs.

It enables the option to add things like `%%host%%` and `%%env_SOME_ENV%%` in the logs annotation used by the autodiscovery. This is the same feature that already exists for metric checks (check the [docs](https://docs.datadoghq.com/agent/faq/template_variables/) for more info).

### Describe how to test your changes

Deploy a service annotated with the logs collection annotation. You can use redis like [here](https://github.com/DataDog/integrations-core/tree/master/redisdb#log-collection-2).

In the annotation specify an attribute like `"host: %%host%%"`. Any supported variable works ([docs](https://docs.datadoghq.com/agent/faq/template_variables/)).

Specify also an attribute like `my_env: %%env_MY_ENV%%"`. You'll need to set `MY_ENV` so it's seen by the agent process. In Helm you can set `datadog.env` for that.

Run `agent configcheck`, find you log check and verify that `%%host%%` and `%%env_MY_ENV%%` have been resolved and have the correct values.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
