### PR TITLE
[CI notifications] Silence arm jobs

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -44,3 +44,8 @@ cleanup_kitchen_functional_test      @DataDog/agent-network @DataDog/agent-secur
 
 # E2E
 k8s-e2e-*                         @DataDog/container-integrations
+
+
+# TODO(AP-1208): Remove once arm runners are in a better shape
+*arm64*  @DataDog/do-not-notify
+*armhf*  @DataDog/do-not-notify


### PR DESCRIPTION
### What does this PR do?

Skip arm jobs from CI notifications.

### Motivation

Too flaky and no short-term fix.

### Additional Notes

Should be removed once the task is complete, notifications will still reach #datadog-agent-pipelines.

### Describe how to test your changes

Example run

```sh
❯ CI_PIPELINE_ID=5354416 inv -e pipeline.notify-failure --print-to-stdout
Would send to #datadog-agent-pipelines:
:host-red: :merged: datadog-agent merge pipeline <None|5354416> for None failed.
None (<None/commit/None|None>) by Pablo Baeyens
Failed jobs:
- <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/83214185|iot_agent_rpm-armhf>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/83214184|iot_agent_rpm-arm64>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/83214176|iot_agent_deb-armhf>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/83214175|iot_agent_deb-arm64> (`package_build` stage)
- <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/83214167|build_serverless-deb_arm64>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/83214164|build_system-probe-arm64>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/83214157|cluster_agent-build_arm64> (`binary_build` stage)
- <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/83214149|tests_rpm-arm64-py3>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/83214147|tests_deb-arm64-py3>, <https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/83214140|tests_ebpf_arm64> (`source_test` stage)
If there is something wrong with the notification please contact #agent-platform

```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
