### PR TITLE
tagger: don't clean up empty tags with expiration date

### DIFF
--- a/pkg/tagger/local/tagstore.go
+++ b/pkg/tagger/local/tagstore.go
@@ -256,7 +256,7 @@ func (s *tagStore) prune() {
 		}
 
 		// remove all sourceTags only if they're all empty
-		if storedTags.isEmpty() {
+		if storedTags.shouldRemove() {
 			storedTags.sourceTags = nil
 			changed = true
 		}
@@ -414,9 +414,9 @@ func (e *entityTags) computeCache() {
 	e.cachedOrchestrator = e.cachedAll[:len(lowCardTags)+len(orchestratorCardTags)]
 }
 
-func (e *entityTags) isEmpty() bool {
+func (e *entityTags) shouldRemove() bool {
 	for _, tags := range e.sourceTags {
-		if !tags.isEmpty() {
+		if !tags.expiryDate.IsZero() || !tags.isEmpty() {
 			return false
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

This prevents tags for entities that were fetched but returned nothing
from being pruned too early, as currently they're pruned every minute
instead of every 5 minutes as intended.

### Describe how to test your changes

This is hard to test outside of the environments where it was identified in the first place. It requires consumers of `tagger.Tag` to request entities that don't exist in the store, but to the best of my knowledge that has been fixed in DataDog/integrations-core#10030 now. Before that, there was a very distinctive pattern in `datadog.agent.tagger_fetches{status:not_found}` metrics, peaking around every minute when pruning kicked in. Now, pruning should be much more even, and there should be no spikes in fetches returning `not_found`. It should also result in a much lower amount of not founds overall as compared to 7.31, which is probably the best way to QA this.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
