### PR TITLE
[omnibus] Check integration classifiers for inclusion

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -62,8 +62,6 @@ blacklist_folders = [
   'docker_daemon',
   'kubernetes',
   'ntp',                           # provided as a go check by the core agent
-  # Python 2-only
-  'tokumx',
 ]
 
 # package names of dependencies that won't be added to the Agent Python environment
@@ -265,6 +263,15 @@ build do
 
       check_conf_dir = "#{conf_dir}/#{check}.d"
 
+      setup_file_path = "#{check_dir}/setup.py"
+      File.file?(setup_file_path) || next
+      # Check if it supports Python 3.
+      support = `inv agent.check-supports-python-version #{setup_file_path} 3`
+      if support == "False"
+        log.info(log_key) { "Skipping '#{check}' since it does not support Python 3." }
+        next
+      end
+
       # For each conf file, if it already exists, that means the `datadog-agent` software def
       # wrote it first. In that case, since the agent's confs take precedence, skip the conf
 
@@ -302,7 +309,6 @@ build do
         copy profiles, "#{check_conf_dir}/"
       end
 
-      File.file?("#{check_dir}/setup.py") || next
       if windows?
         command "#{python} -m pip wheel . --no-deps --no-index --wheel-dir=#{wheel_build_dir}", :cwd => "#{windows_safe_path(project_dir)}\\#{check}"
         command "#{python} -m pip install datadog-#{check} --no-deps --no-index --find-links=#{wheel_build_dir}"


### PR DESCRIPTION
### What does this PR do?

Check the `classifiers` on a given integration to decide wether to include it or not on a Python environment.

### Motivation

Automate process to avoid accidentally breaking the datadog-agent pipeline when adding Python 3-only integrations.

### Additional Notes

When an integration is skipped a message is logged indicating it. Currently, two integrations are skipped: `tokumx` on Python 3 and `avi_vantage` on Python 2.

The invoke task uses the `ast` module to parse the Python code, looks for a keyword argument with name `classifiers` and evaluates its list of values. This could fail in some edge cases (indirect call to `setup` with a different argument name, some other function with a `classifiers` keyword argument) which we don't support today as they seem very unlikely.

### Describe how to test your changes

For each supported platform (Linux, Windows and macOS), compare the integration list in a previous version of the Agent for both Python 2 and Python 3 (e.g. by doing `pip freeze` on the embedded Python env) with the one after this change. The only differences should be new integrations added.

Also compare the configuration files list on each version.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
