### PR TITLE
[AD] Refactor unnecessary for in ConfigResolver

### DIFF
--- a/pkg/autodiscovery/configresolver/configresolver.go
+++ b/pkg/autodiscovery/configresolver/configresolver.go
@@ -192,11 +192,12 @@ func getFallbackHost(hosts map[string]string) (string, error) {
 			return host, nil
 		}
 	}
-	for k, v := range hosts {
-		if k == "bridge" {
-			return v, nil
-		}
+
+	bridgeIP, bridgeIsPresent := hosts["bridge"]
+	if bridgeIsPresent {
+		return bridgeIP, nil
 	}
+
 	return "", errors.New("not able to determine which network is reachable")
 }
 


### PR DESCRIPTION
### What does this PR do?

Minor refactor.

### Describe how to test your changes

Just a refactor. Nothing for QA.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
