### PR TITLE
[Serverless] merge v10 into main

### DIFF
--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -36,6 +36,9 @@ const DefaultIntakeProtocol IntakeProtocol = ""
 // DefaultIntakeOrigin indicates that no special DD_SOURCE header is in use for the endpoint intake track type.
 const DefaultIntakeOrigin IntakeOrigin = "agent"
 
+// ServerlessIntakeOrigin is the lambda extension origin
+const ServerlessIntakeOrigin IntakeOrigin = "lambda-extension"
+
 // logs-intake endpoints depending on the site and environment.
 var logsEndpoints = map[string]int{
 	"agent-intake.logs.datadoghq.com": 10516,
@@ -130,9 +133,9 @@ func BuildEndpointsWithConfig(logsConfig *LogsConfigKeys, endpointPrefix string,
 }
 
 // BuildServerlessEndpoints returns the endpoints to send logs for the Serverless agent.
-func BuildServerlessEndpoints(intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol, intakeOrigin IntakeOrigin) (*Endpoints, error) {
+func BuildServerlessEndpoints(intakeTrackType IntakeTrackType, intakeProtocol IntakeProtocol) (*Endpoints, error) {
 	coreConfig.SanitizeAPIKeyConfig(coreConfig.Datadog, "logs_config.api_key")
-	return BuildHTTPEndpointsWithConfig(defaultLogsConfigKeys(), serverlessHTTPEndpointPrefix, intakeTrackType, intakeProtocol, intakeOrigin)
+	return BuildHTTPEndpointsWithConfig(defaultLogsConfigKeys(), serverlessHTTPEndpointPrefix, intakeTrackType, intakeProtocol, ServerlessIntakeOrigin)
 }
 
 // ExpectedTagsDuration returns a duration of the time expected tags will be submitted for.

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -511,7 +511,7 @@ func (suite *ConfigTestSuite) TestBuildServerlessEndpoints() {
 			RecoveryInterval: coreConfig.DefaultLogsSenderBackoffRecoveryInterval,
 			Version:          EPIntakeVersion2,
 			TrackType:        "test-track",
-			Origin:           "test-source",
+			Origin:           "lambda-extension",
 			Protocol:         "test-proto",
 		},
 		BatchMaxSize:           coreConfig.DefaultBatchMaxSize,
@@ -519,7 +519,7 @@ func (suite *ConfigTestSuite) TestBuildServerlessEndpoints() {
 		BatchMaxConcurrentSend: coreConfig.DefaultBatchMaxConcurrentSend,
 	}
 
-	endpoints, err := BuildServerlessEndpoints("test-track", "test-proto", "test-source")
+	endpoints, err := BuildServerlessEndpoints("test-track", "test-proto")
 
 	suite.Nil(err)
 	suite.Equal(expectedEndpoints, endpoints)

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -59,7 +59,7 @@ func StartServerless(getAC func() *autodiscovery.AutoConfig, logsChan chan *conf
 // buildEndpoints builds endpoints for the logs agent
 func buildEndpoints(serverless bool) (*config.Endpoints, error) {
 	if serverless {
-		return config.BuildServerlessEndpoints(intakeTrackType, config.DefaultIntakeProtocol, config.DefaultIntakeOrigin)
+		return config.BuildServerlessEndpoints(intakeTrackType, config.DefaultIntakeProtocol)
 	}
 	httpConnectivity := config.HTTPConnectivityFailure
 	if endpoints, err := config.BuildHTTPEndpoints(intakeTrackType, intakeProtocol, config.DefaultIntakeOrigin); err == nil {

--- a/pkg/logs/logs_test.go
+++ b/pkg/logs/logs_test.go
@@ -15,6 +15,7 @@ func TestBuildServerlessEndpoints(t *testing.T) {
 	endpoints, err := buildEndpoints(true)
 	assert.Nil(t, err)
 	assert.Equal(t, "lambda-http-intake.logs.datadoghq.com", endpoints.Main.Host)
+	assert.Equal(t, "lambda-extension", string(endpoints.Main.Origin))
 }
 
 func TestBuildEndpoints(t *testing.T) {

--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -15,6 +15,7 @@ const (
 	qualifierEnvVar = "AWS_LAMBDA_FUNCTION_VERSION"
 	envEnvVar       = "DD_ENV"
 	versionEnvVar   = "DD_VERSION"
+	serviceEnvVar   = "DD_SERVICE"
 
 	traceOriginMetadataKey   = "_dd.origin"
 	traceOriginMetadataValue = "lambda"
@@ -30,6 +31,7 @@ const (
 	extensionVersionKey      = "dd_extension_version"
 	envKey                   = "env"
 	versionKey               = "version"
+	serviceKey               = "service"
 )
 
 // currentExtensionVersion represents the current version of the Datadog Lambda Extension.
@@ -43,6 +45,7 @@ func BuildTagMap(arn string, configTags []string) map[string]string {
 
 	tags = setIfNotEmpty(tags, envKey, os.Getenv(envEnvVar))
 	tags = setIfNotEmpty(tags, versionKey, os.Getenv(versionEnvVar))
+	tags = setIfNotEmpty(tags, serviceKey, os.Getenv(serviceEnvVar))
 
 	for _, tag := range configTags {
 		splitTags := strings.Split(tag, ",")

--- a/pkg/serverless/tags/tags_test.go
+++ b/pkg/serverless/tags/tags_test.go
@@ -106,17 +106,20 @@ func TestBuildTagMapFromArnComplete(t *testing.T) {
 	assert.Equal(t, "value1", tagMap["tag1"])
 }
 
-func TestBuildTagMapFromArnCompleteWithEnvAndVersion(t *testing.T) {
+func TestBuildTagMapFromArnCompleteWithEnvAndVersionAndService(t *testing.T) {
 	os.Setenv("DD_VERSION", "myTestVersion")
 	defer os.Unsetenv("DD_VERSION")
 	os.Setenv("DD_ENV", "myTestEnv")
 	defer os.Unsetenv("DD_ENV")
+	os.Setenv("DD_SERVICE", "myTestService")
+	defer os.Unsetenv("DD_SERVICE")
 
 	arn := "arn:aws:lambda:us-east-1:123456789012:function:my-function"
 	tagMap := BuildTagMap(arn, []string{"tag0:value0", "TAG1:VALUE1"})
-	assert.Equal(t, 13, len(tagMap))
+	assert.Equal(t, 14, len(tagMap))
 	assert.Equal(t, "mytestenv", tagMap["env"])
 	assert.Equal(t, "mytestversion", tagMap["version"])
+	assert.Equal(t, "mytestservice", tagMap["service"])
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
 	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])


### PR DESCRIPTION
### What does this PR do?

Since the branch was frozen a new branch was created to fix two bugs before releasing v10.
Here is the PR to merge them back into main

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
