### PR TITLE
[lambda extension] Disable aggregator flushing

### DIFF
--- a/pkg/serverless/metrics/metric.go
+++ b/pkg/serverless/metrics/metric.go
@@ -111,5 +111,7 @@ func buildBufferedAggregator(multipleEndpointConfig MultipleEndpointConfig, forw
 	f := forwarder.NewSyncForwarder(keysPerDomain, forwarderTimeout)
 	f.Start() //nolint:errcheck
 	serializer := serializer.NewSerializer(f, nil)
-	return aggregator.InitAggregator(serializer, nil, "serverless")
+
+	// flushInterval is set to 0 (disabled) because we want to control flushing from the daemon
+	return aggregator.InitAggregatorWithFlushInterval(serializer, nil, "serverless", 0)
 }


### PR DESCRIPTION
### What does this PR do?

Sets the flushInterval of the aggregator to 0 (disabled) in the Lambda Extension.

In the context of the Lambda Extension, we have implemented our own flushing logic that is coordinated by a central daemon goroutine. Because the aggregator currently periodically flushes on its own, there is a risk of two flushes being triggered simultaneously, creating concurrency bugs.

### Motivation

WIP

### Describe how to test your changes

WIP

### Checklist
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
