### PR TITLE
[Tagger] Collect image_id tag from kubelet

### DIFF
--- a/pkg/tagger/collectors/kubelet_extract.go
+++ b/pkg/tagger/collectors/kubelet_extract.go
@@ -159,6 +159,7 @@ func (c *KubeletCollector) parsePods(pods []*kubelet.Pod) ([]*TagInfo, error) {
 			}
 			cTags := tags.Copy()
 			cTags.AddLow("kube_container_name", container.Name)
+			cTags.AddLow("image_id", container.ImageID)
 			cTags.AddHigh("container_id", kubelet.TrimRuntimeFromCID(container.ID))
 			if container.Name != "" && pod.Metadata.Name != "" {
 				cTags.AddHigh("display_container_name", fmt.Sprintf("%s_%s", container.Name, pod.Metadata.Name))

--- a/pkg/tagger/collectors/kubelet_extract_test.go
+++ b/pkg/tagger/collectors/kubelet_extract_test.go
@@ -18,19 +18,22 @@ import (
 
 func TestParsePods(t *testing.T) {
 	dockerEntityID := "container_id://d0242fc32d53137526dc365e7c86ef43b5f50b6f72dfd53dcb948eff4560376f"
+	dockerImageID := "docker://sha256:77e1fa12f59b01e7e23de95ae01aacc6f09027575ec23b340bb2d6004945f8d4"
 	dockerContainerStatus := kubelet.Status{
 		Containers: []kubelet.ContainerStatus{
 			{
-				ID:    dockerEntityID,
-				Image: "datadog/docker-dd-agent:latest5",
-				Name:  "dd-agent",
+				ID:      dockerEntityID,
+				Image:   "datadog/docker-dd-agent:latest5",
+				ImageID: dockerImageID,
+				Name:    "dd-agent",
 			},
 		},
 		AllContainers: []kubelet.ContainerStatus{
 			{
-				ID:    dockerEntityID,
-				Image: "datadog/docker-dd-agent:latest5",
-				Name:  "dd-agent",
+				ID:      dockerEntityID,
+				Image:   "datadog/docker-dd-agent:latest5",
+				ImageID: dockerImageID,
+				Name:    "dd-agent",
 			},
 		},
 		Phase: "Running",
@@ -112,26 +115,30 @@ func TestParsePods(t *testing.T) {
 	dockerTwoContainersStatus := kubelet.Status{
 		Containers: []kubelet.ContainerStatus{
 			{
-				ID:    dockerEntityID,
-				Image: "datadog/docker-dd-agent:latest5",
-				Name:  "dd-agent",
+				ID:      dockerEntityID,
+				Image:   "datadog/docker-dd-agent:latest5",
+				ImageID: dockerImageID,
+				Name:    "dd-agent",
 			},
 			{
-				ID:    dockerEntityID2,
-				Image: "datadog/docker-filter:latest",
-				Name:  "filter",
+				ID:      dockerEntityID2,
+				Image:   "datadog/docker-filter:latest",
+				ImageID: dockerImageID,
+				Name:    "filter",
 			},
 		},
 		AllContainers: []kubelet.ContainerStatus{
 			{
-				ID:    dockerEntityID,
-				Image: "datadog/docker-dd-agent:latest5",
-				Name:  "dd-agent",
+				ID:      dockerEntityID,
+				Image:   "datadog/docker-dd-agent:latest5",
+				ImageID: dockerImageID,
+				Name:    "dd-agent",
 			},
 			{
-				ID:    dockerEntityID2,
-				Image: "datadog/docker-filter:latest",
-				Name:  "filter",
+				ID:      dockerEntityID2,
+				Image:   "datadog/docker-filter:latest",
+				ImageID: dockerImageID,
+				Name:    "filter",
 			},
 		},
 		Phase: "Pending",
@@ -153,16 +160,18 @@ func TestParsePods(t *testing.T) {
 	dockerContainerStatusCassandra := kubelet.Status{
 		Containers: []kubelet.ContainerStatus{
 			{
-				ID:    dockerEntityIDCassandra,
-				Image: "gcr.io/google-samples/cassandra:v13",
-				Name:  "cassandra",
+				ID:      dockerEntityIDCassandra,
+				Image:   "gcr.io/google-samples/cassandra:v13",
+				ImageID: dockerImageID,
+				Name:    "cassandra",
 			},
 		},
 		AllContainers: []kubelet.ContainerStatus{
 			{
-				ID:    dockerEntityIDCassandra,
-				Image: "gcr.io/google-samples/cassandra:v13",
-				Name:  "cassandra",
+				ID:      dockerEntityIDCassandra,
+				Image:   "gcr.io/google-samples/cassandra:v13",
+				ImageID: dockerImageID,
+				Name:    "cassandra",
 			},
 		},
 		Phase: "Running",
@@ -208,19 +217,22 @@ func TestParsePods(t *testing.T) {
 	}
 
 	criEntityID := "container_id://acbe44ff07525934cab9bf7c38c6627d64fd0952d8e6b87535d57092bfa6e9d1"
+	criImageID := "sha256:43940c34f24f39bc9a00b4f9dbcab51a3b28952a7c392c119b877fcb48fe65a3"
 	criContainerStatus := kubelet.Status{
 		Containers: []kubelet.ContainerStatus{
 			{
-				ID:    criEntityID,
-				Image: "sha256:0f006d265944c984e05200fab1c14ac54163cbcd4e8ae0ba3b35eb46fc559823",
-				Name:  "redis-master",
+				ID:      criEntityID,
+				Image:   "sha256:0f006d265944c984e05200fab1c14ac54163cbcd4e8ae0ba3b35eb46fc559823",
+				ImageID: criImageID,
+				Name:    "redis-master",
 			},
 		},
 		AllContainers: []kubelet.ContainerStatus{
 			{
-				ID:    criEntityID,
-				Image: "sha256:0f006d265944c984e05200fab1c14ac54163cbcd4e8ae0ba3b35eb46fc559823",
-				Name:  "redis-master",
+				ID:      criEntityID,
+				Image:   "sha256:0f006d265944c984e05200fab1c14ac54163cbcd4e8ae0ba3b35eb46fc559823",
+				ImageID: criImageID,
+				Name:    "redis-master",
 			},
 		},
 		Phase: "Running",
@@ -298,6 +310,7 @@ func TestParsePods(t *testing.T) {
 					"kube_app_component:dd-agent",
 					"kube_app_part_of:dd",
 					"kube_app_managed_by:spinnaker",
+					"image_id:docker://sha256:77e1fa12f59b01e7e23de95ae01aacc6f09027575ec23b340bb2d6004945f8d4",
 					"image_name:datadog/docker-dd-agent",
 					"short_image:docker-dd-agent",
 					"pod_phase:running",
@@ -338,6 +351,7 @@ func TestParsePods(t *testing.T) {
 					"kube_container_name:dd-agent",
 					"kube_daemon_set:dd-agent-rc",
 					"image_tag:latest5",
+					"image_id:docker://sha256:77e1fa12f59b01e7e23de95ae01aacc6f09027575ec23b340bb2d6004945f8d4",
 					"image_name:datadog/docker-dd-agent",
 					"short_image:docker-dd-agent",
 					"kube_ownerref_kind:daemonset",
@@ -398,6 +412,7 @@ func TestParsePods(t *testing.T) {
 						"kube_container_name:dd-agent",
 						"kube_daemon_set:dd-agent-rc",
 						"image_tag:latest5",
+						"image_id:docker://sha256:77e1fa12f59b01e7e23de95ae01aacc6f09027575ec23b340bb2d6004945f8d4",
 						"image_name:datadog/docker-dd-agent",
 						"short_image:docker-dd-agent",
 						"kube_ownerref_kind:daemonset",
@@ -421,6 +436,7 @@ func TestParsePods(t *testing.T) {
 						"kube_container_name:filter",
 						"kube_daemon_set:dd-agent-rc",
 						"image_tag:latest",
+						"image_id:docker://sha256:77e1fa12f59b01e7e23de95ae01aacc6f09027575ec23b340bb2d6004945f8d4",
 						"image_name:datadog/docker-filter",
 						"short_image:docker-filter",
 						"kube_ownerref_kind:daemonset",
@@ -461,6 +477,7 @@ func TestParsePods(t *testing.T) {
 					"kube_ownerref_kind:replicaset",
 					"kube_replica_set:kubernetes-dashboard",
 					"image_tag:latest5",
+					"image_id:docker://sha256:77e1fa12f59b01e7e23de95ae01aacc6f09027575ec23b340bb2d6004945f8d4",
 					"image_name:datadog/docker-dd-agent",
 					"short_image:docker-dd-agent",
 					"pod_phase:running",
@@ -498,6 +515,7 @@ func TestParsePods(t *testing.T) {
 					"kube_replica_set:frontend-2891696001",
 					"kube_ownerref_kind:replicaset",
 					"image_tag:latest5",
+					"image_id:docker://sha256:77e1fa12f59b01e7e23de95ae01aacc6f09027575ec23b340bb2d6004945f8d4",
 					"image_name:datadog/docker-dd-agent",
 					"short_image:docker-dd-agent",
 					"pod_phase:running",
@@ -535,6 +553,7 @@ func TestParsePods(t *testing.T) {
 					"kube_replica_set:front-end-768dd754b7",
 					"kube_ownerref_kind:replicaset",
 					"image_tag:latest5",
+					"image_id:docker://sha256:77e1fa12f59b01e7e23de95ae01aacc6f09027575ec23b340bb2d6004945f8d4",
 					"image_name:datadog/docker-dd-agent",
 					"short_image:docker-dd-agent",
 					"pod_phase:running",
@@ -577,6 +596,7 @@ func TestParsePods(t *testing.T) {
 					"kube_container_name:dd-agent",
 					"team:Kenafeh",
 					"component:kube-proxy",
+					"image_id:docker://sha256:77e1fa12f59b01e7e23de95ae01aacc6f09027575ec23b340bb2d6004945f8d4",
 					"tier:node",
 					"image_tag:latest5",
 					"image_name:datadog/docker-dd-agent",
@@ -633,6 +653,7 @@ func TestParsePods(t *testing.T) {
 					"short_image:docker-dd-agent",
 					"pod_template_version:1.0.0",
 					"agent_version:6.9.0",
+					"image_id:docker://sha256:77e1fa12f59b01e7e23de95ae01aacc6f09027575ec23b340bb2d6004945f8d4",
 					"pod_phase:running",
 				},
 				OrchestratorCardTags: []string{},
@@ -685,6 +706,7 @@ func TestParsePods(t *testing.T) {
 					"image_name:datadog/docker-dd-agent",
 					"short_image:docker-dd-agent",
 					"env:production",
+					"image_id:docker://sha256:77e1fa12f59b01e7e23de95ae01aacc6f09027575ec23b340bb2d6004945f8d4",
 					"service:dd-agent",
 					"version:1.1.0",
 					"pod_phase:running",
@@ -743,6 +765,7 @@ func TestParsePods(t *testing.T) {
 					"image_name:datadog/docker-dd-agent",
 					"short_image:docker-dd-agent",
 					"env:production",
+					"image_id:docker://sha256:77e1fa12f59b01e7e23de95ae01aacc6f09027575ec23b340bb2d6004945f8d4",
 					"service:dd-agent",
 					"version:1.1.0",
 					"pod_phase:running",
@@ -804,6 +827,7 @@ func TestParsePods(t *testing.T) {
 					"image_name:datadog/docker-dd-agent",
 					"short_image:docker-dd-agent",
 					"env:production",
+					"image_id:docker://sha256:77e1fa12f59b01e7e23de95ae01aacc6f09027575ec23b340bb2d6004945f8d4",
 					"service:dd-agent",
 					"service:pod-service",
 					"version:1.1.0",
@@ -863,6 +887,7 @@ func TestParsePods(t *testing.T) {
 					"image_name:datadog/docker-dd-agent",
 					"short_image:docker-dd-agent",
 					"env:production",
+					"image_id:docker://sha256:77e1fa12f59b01e7e23de95ae01aacc6f09027575ec23b340bb2d6004945f8d4",
 					"service:dd-agent",
 					"version:1.1.0",
 					"pod_phase:running",
@@ -918,6 +943,7 @@ func TestParsePods(t *testing.T) {
 					"image_name:datadog/docker-dd-agent",
 					"short_image:docker-dd-agent",
 					"env:production2",
+					"image_id:docker://sha256:77e1fa12f59b01e7e23de95ae01aacc6f09027575ec23b340bb2d6004945f8d4",
 					"service:dd-agent",
 					"version:1.2.3",
 					"pod_phase:running",
@@ -951,6 +977,7 @@ func TestParsePods(t *testing.T) {
 				Source: "kubelet",
 				Entity: dockerEntityID,
 				LowCardTags: []string{
+					"image_id:docker://sha256:77e1fa12f59b01e7e23de95ae01aacc6f09027575ec23b340bb2d6004945f8d4",
 					"kube_container_name:dd-agent",
 					"oshift_deployment_config:gitlab-ce",
 					"pod_phase:running",
@@ -988,6 +1015,7 @@ func TestParsePods(t *testing.T) {
 					"kube_ownerref_kind:replicaset",
 					"kube_deployment:redis-master",
 					"kube_replica_set:redis-master-546dc4865f",
+					"image_id:sha256:43940c34f24f39bc9a00b4f9dbcab51a3b28952a7c392c119b877fcb48fe65a3",
 					"image_name:gcr.io/google_containers/redis",
 					"image_tag:e2e",
 					"short_image:redis",
@@ -1035,6 +1063,7 @@ func TestParsePods(t *testing.T) {
 					"foo_pod-template-hash:490794276",
 					"foo_app.kubernetes.io/managed-by:spinnaker",
 					"kube_app_managed_by:spinnaker",
+					"image_id:docker://sha256:77e1fa12f59b01e7e23de95ae01aacc6f09027575ec23b340bb2d6004945f8d4",
 					"image_name:datadog/docker-dd-agent",
 					"image_tag:latest5",
 					"kube_container_name:dd-agent",
@@ -1068,6 +1097,7 @@ func TestParsePods(t *testing.T) {
 				LowCardTags: []string{
 					"kube_namespace:default",
 					"kube_ownerref_kind:job",
+					"image_id:docker://sha256:77e1fa12f59b01e7e23de95ae01aacc6f09027575ec23b340bb2d6004945f8d4",
 					"image_name:datadog/docker-dd-agent",
 					"image_tag:latest5",
 					"kube_container_name:dd-agent",
@@ -1110,6 +1140,7 @@ func TestParsePods(t *testing.T) {
 				LowCardTags: []string{
 					"kube_namespace:default",
 					"kube_ownerref_kind:statefulset",
+					"image_id:docker://sha256:77e1fa12f59b01e7e23de95ae01aacc6f09027575ec23b340bb2d6004945f8d4",
 					"image_name:gcr.io/google-samples/cassandra",
 					"image_tag:v13",
 					"kube_container_name:cassandra",
@@ -1152,6 +1183,7 @@ func TestParsePods(t *testing.T) {
 				LowCardTags: []string{
 					"kube_namespace:default",
 					"kube_ownerref_kind:statefulset",
+					"image_id:docker://sha256:77e1fa12f59b01e7e23de95ae01aacc6f09027575ec23b340bb2d6004945f8d4",
 					"image_name:gcr.io/google-samples/cassandra",
 					"image_tag:v13",
 					"kube_container_name:cassandra",
@@ -1196,6 +1228,7 @@ func TestParsePods(t *testing.T) {
 					"team:A",
 					"team:B",
 					"agent_version:6.9.0",
+					"image_id:docker://sha256:77e1fa12f59b01e7e23de95ae01aacc6f09027575ec23b340bb2d6004945f8d4",
 					"python_version:2",
 					"python_version:3",
 					"pod_phase:running",
@@ -1234,6 +1267,7 @@ func TestParsePods(t *testing.T) {
 					"foo_component:kube-proxy",
 					"component:kube-proxy",
 					"foo_tier:node",
+					"image_id:docker://sha256:77e1fa12f59b01e7e23de95ae01aacc6f09027575ec23b340bb2d6004945f8d4",
 					"foo_k8s-app:kubernetes-dashboard",
 					"foo_pod-template-hash:490794276",
 					"foo_app.kubernetes.io/managed-by:spinnaker",

--- a/pkg/util/kubernetes/kubelet/types_kubelet.go
+++ b/pkg/util/kubernetes/kubelet/types_kubelet.go
@@ -117,11 +117,12 @@ type Conditions struct {
 
 // ContainerStatus contains fields for unmarshalling a Pod.Status.Containers
 type ContainerStatus struct {
-	Name  string         `json:"name"`
-	Image string         `json:"image"`
-	ID    string         `json:"containerID"`
-	Ready bool           `json:"ready"`
-	State ContainerState `json:"state"`
+	Name    string         `json:"name"`
+	Image   string         `json:"image"`
+	ImageID string         `json:"imageID"`
+	ID      string         `json:"containerID"`
+	Ready   bool           `json:"ready"`
+	State   ContainerState `json:"state"`
 }
 
 // IsPending returns if the container doesn't have an ID

--- a/releasenotes/notes/image-id-tag-a3bf63b586f3b5fa.yaml
+++ b/releasenotes/notes/image-id-tag-a3bf63b586f3b5fa.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Tag Kubernetes containers with ``image_id`` tag.


### PR DESCRIPTION
### What does this PR do?

Add a new tag `image_id` attached to containers in Kubernetes.

### Motivation

Surface the `Image ID` value printed by `kubectl describe pod` 

### Describe how to test your changes

```
agent tagger-list
...
== Source kubelet ==
Tags: [container_id:3da1e091758c975981329965dd8ca557b4849e5abd2add9fc259dabab741a30b display_container_name:kube-proxy_kube-proxy-gke-xx-xx-pool-xx-xx image_id:docker://sha256:77e1fa12f59b01e7e23de95ae01aacc6f09027575ec23b340bb2d6004945f8d4 image_name:gke.gcr.io/kube-proxy-amd64 image_tag:v1.18.20-gke.901 kube_container_name:kube-proxy kube_namespace:kube-system pod_name:kube-proxy-gke-xx-xx-pool-xx-xx pod_phase:running short_image:kube-proxy-amd64]
...
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
