### PR TITLE
feat: Make failure policy configurable

### DIFF
--- a/pkg/clusteragent/admission/controllers/webhook/config.go
+++ b/pkg/clusteragent/admission/controllers/webhook/config.go
@@ -26,6 +26,7 @@ type Config struct {
 	svcName                  string
 	svcPort                  int32
 	timeout                  int32
+	failurePolicy            string
 }
 
 // NewConfig creates a webhook controller configuration
@@ -39,6 +40,7 @@ func NewConfig(admissionV1Enabled, namespaceSelectorEnabled bool) Config {
 		svcName:                  config.Datadog.GetString("admission_controller.service_name"),
 		svcPort:                  int32(443),
 		timeout:                  config.Datadog.GetInt32("admission_controller.timeout_seconds"),
+		failurePolicy:            config.Datadog.GetString("admission_controller.failure_policy"),
 	}
 }
 
@@ -51,6 +53,7 @@ func (w *Config) getServiceNs() string       { return w.namespace }
 func (w *Config) getServiceName() string     { return w.svcName }
 func (w *Config) getServicePort() int32      { return w.svcPort }
 func (w *Config) getTimeout() int32          { return w.timeout }
+func (w *Config) getFailurePolicy() string   { return w.failurePolicy }
 func (w *Config) configName(suffix string) string {
 	return strings.ReplaceAll(fmt.Sprintf("%s.%s", w.webhookName, suffix), "-", ".")
 }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -195,7 +195,7 @@ func (c *ControllerV1) generateTemplates() {
 }
 
 func (c *ControllerV1) getWebhookSkeleton(nameSuffix, path string) admiv1.MutatingWebhook {
-	failurePolicy := admiv1.Ignore
+	failurePolicy := c.config.getFailurePolicy()
 	matchPolicy := admiv1.Exact
 	sideEffects := admiv1.SideEffectClassNone
 	port := c.config.getServicePort()

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -195,7 +195,7 @@ func (c *ControllerV1beta1) generateTemplates() {
 }
 
 func (c *ControllerV1beta1) getWebhookSkeleton(nameSuffix, path string) admiv1beta1.MutatingWebhook {
-	failurePolicy := admiv1beta1.Ignore
+	failurePolicy := c.config.getFailurePolicy()
 	matchPolicy := admiv1beta1.Exact
 	sideEffects := admiv1beta1.SideEffectClassNone
 	port := c.config.getServicePort()

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -780,6 +780,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("clc_runner_server_readheader_timeout", 10)
 	// Admission controller
 	config.BindEnvAndSetDefault("admission_controller.enabled", false)
+	config.BindEnvAndSetDefault("admission_controller.failure_policy", "Ignore")
 	config.BindEnvAndSetDefault("admission_controller.mutate_unlabelled", false)
 	config.BindEnvAndSetDefault("admission_controller.port", 8000)
 	config.BindEnvAndSetDefault("admission_controller.timeout_seconds", 10) // in seconds (see kubernetes/kubernetes#71508)

--- a/releasenotes/notes/make-failurepolicy-configurable-d17a007f3529d800.yaml
+++ b/releasenotes/notes/make-failurepolicy-configurable-d17a007f3529d800.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Make the admission controller failure policy configurable.
+    Previously this was hardcoded to Ignore.


### PR DESCRIPTION
### What does this PR do?

Make the admission controller failure policy configurable

### Motivation

Keep having the datadog agents fail to mutate things during disruption

Fixes #8475

### Additional Notes

Starting looking at adding a test, got stuck due to:

```
Running tool: /usr/local/bin/go test -timeout 30s -run ^TestGenerateTemplatesV1$

package github.com/DataDog/datadog-agent/pkg/clusteragent/admission/controllers/webhook: build constraints exclude all Go files in /Users/mikebryant/go/src/github.com/DataDog/datadog-agent/pkg/clusteragent/admission/controllers/webhook
```


### Describe how to test your changes

Not done yet. Providing a work in progress in the hope someone else can help finish this


Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
