### PR TITLE
[invoke] Make pipeline.run fail if target ref is not specified

### DIFF
--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -158,7 +158,7 @@ instead.""".format(
 @task
 def run(
     ctx,
-    git_ref=DEFAULT_BRANCH,
+    git_ref=None,
     here=False,
     use_release_entries=False,
     major_versions='6,7',
@@ -168,7 +168,7 @@ def run(
     kitchen_tests=True,
 ):
     """
-    Run a pipeline on the given git ref, or on the current branch if --here is given.
+    Run a pipeline on the given git ref (--git-ref <git ref>), or on the current branch if --here is given.
     By default, this pipeline will run all builds & tests, including all kitchen tests, but is not a deploy pipeline.
     Use --deploy to make this pipeline a deploy pipeline, which will upload artifacts to the staging repositories.
     Use --no-all-builds to not run builds for all architectures (only a subset of jobs will run. No effect on pipelines on the default branch).
@@ -203,6 +203,9 @@ def run(
     project_name = "DataDog/datadog-agent"
     gitlab = Gitlab()
     gitlab.test_project_found(project_name)
+
+    if not git_ref and not here:
+        raise Exit("Either --here or --git-ref <git ref> must be specified.", code=1)
 
     if use_release_entries:
         release_version_6 = release_entry_for(6)


### PR DESCRIPTION
### What does this PR do?

Adds a check at the start of the `pipeline.run` invoke task to make sure a target was specified (either through `--here` or `--git-ref`).

### Motivation

Prevents confusing behavior when no options are specified (`main` was targeted, which is usually not what you want).


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
