### PR TITLE
[DCA][Admission] Fix Webhook object not picking config changes

### DIFF
--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -278,12 +278,13 @@ func start(cmd *cobra.Command, args []string) error {
 
 	if config.Datadog.GetBool("admission_controller.enabled") {
 		admissionCtx := admissionpkg.ControllerContext{
-			IsLeaderFunc:     le.IsLeader,
-			SecretInformers:  apiCl.CertificateSecretInformerFactory,
-			WebhookInformers: apiCl.WebhookConfigInformerFactory,
-			Client:           apiCl.Cl,
-			DiscoveryClient:  apiCl.DiscoveryCl,
-			StopCh:           stopCh,
+			IsLeaderFunc:        le.IsLeader,
+			LeaderSubscribeFunc: le.Subscribe,
+			SecretInformers:     apiCl.CertificateSecretInformerFactory,
+			WebhookInformers:    apiCl.WebhookConfigInformerFactory,
+			Client:              apiCl.Cl,
+			DiscoveryClient:     apiCl.DiscoveryCl,
+			StopCh:              stopCh,
 		}
 		err = admissionpkg.StartControllers(admissionCtx)
 		if err != nil {

--- a/pkg/clusteragent/admission/controllers/secret/controller.go
+++ b/pkg/clusteragent/admission/controllers/secret/controller.go
@@ -40,10 +40,11 @@ type Controller struct {
 	dnsNamesDigest uint64
 	queue          workqueue.RateLimitingInterface
 	isLeaderFunc   func() bool
+	isLeaderNotif  <-chan struct{}
 }
 
 // NewController returns a new Secret Controller.
-func NewController(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, isLeaderFunc func() bool, config Config) *Controller {
+func NewController(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, isLeaderFunc func() bool, isLeaderNotif <-chan struct{}, config Config) *Controller {
 	dnsNames := generateDNSNames(config.GetNs(), config.GetSvc())
 	controller := &Controller{
 		clientSet:      client,
@@ -54,6 +55,7 @@ func NewController(client kubernetes.Interface, secretInformer coreinformers.Sec
 		dnsNamesDigest: digestDNSNames(dnsNames),
 		queue:          workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "secrets"),
 		isLeaderFunc:   isLeaderFunc,
+		isLeaderNotif:  isLeaderNotif,
 	}
 	secretInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
 		AddFunc:    controller.handleObject,
@@ -75,12 +77,34 @@ func (c *Controller) Run(stopCh <-chan struct{}) {
 		return
 	}
 
+	go c.enqueueOnLeaderNotif(stopCh)
 	go wait.Until(c.run, time.Second, stopCh)
 
 	// Trigger a reconciliation to create the Secret if it doesn't exist
-	c.queue.Add(fmt.Sprintf("%s/%s", c.config.GetNs(), c.config.GetName()))
+	c.triggerReconciliation()
 
 	<-stopCh
+}
+
+// enqueueOnLeaderNotif watches leader notifications and triggers a
+// reconciliation in case the current process becomes leader.
+// This ensures that the latest configuration of the leader
+// is applied to the secret object. Typically, during a rolling update.
+func (c *Controller) enqueueOnLeaderNotif(stop <-chan struct{}) {
+	for {
+		select {
+		case <-c.isLeaderNotif:
+			log.Infof("Got a leader notification, enqueuing a reconciliation for %s/%s", c.config.GetNs(), c.config.GetName())
+			c.triggerReconciliation()
+		case <-stop:
+			return
+		}
+	}
+}
+
+// triggerReconciliation forces a reconciliation loop by enqueuing the secret object namespaced name.
+func (c *Controller) triggerReconciliation() {
+	c.queue.Add(fmt.Sprintf("%s/%s", c.config.GetNs(), c.config.GetName()))
 }
 
 // handleObject enqueues the targeted Secret object when an event occurs.
@@ -133,6 +157,10 @@ func (c *Controller) run() {
 // of the Secret when new item is added to the work queue.
 // Always returns true unless the work queue was shutdown.
 func (c *Controller) processNextWorkItem() bool {
+	if !c.isLeaderFunc() {
+		return true
+	}
+
 	key, shutdown := c.queue.Get()
 	if shutdown {
 		return false

--- a/pkg/clusteragent/admission/controllers/secret/controller_test.go
+++ b/pkg/clusteragent/admission/controllers/secret/controller_test.go
@@ -187,6 +187,7 @@ func (f *fixture) run(t *testing.T) *Controller {
 		f.client,
 		factory.Core().V1().Secrets(),
 		func() bool { return true },
+		make(chan struct{}),
 		cfg,
 	)
 

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -31,12 +31,12 @@ type Controller interface {
 }
 
 // NewController returns the adequate implementation of the Controller interface.
-func NewController(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, admissionInterface admissionregistration.Interface, isLeaderFunc func() bool, config Config) Controller {
+func NewController(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, admissionInterface admissionregistration.Interface, isLeaderFunc func() bool, isLeaderNotif <-chan struct{}, config Config) Controller {
 	if config.useAdmissionV1() {
-		return NewControllerV1(client, secretInformer, admissionInterface.V1().MutatingWebhookConfigurations(), isLeaderFunc, config)
+		return NewControllerV1(client, secretInformer, admissionInterface.V1().MutatingWebhookConfigurations(), isLeaderFunc, isLeaderNotif, config)
 	}
 
-	return NewControllerV1beta1(client, secretInformer, admissionInterface.V1beta1().MutatingWebhookConfigurations(), isLeaderFunc, config)
+	return NewControllerV1beta1(client, secretInformer, admissionInterface.V1beta1().MutatingWebhookConfigurations(), isLeaderFunc, isLeaderNotif, config)
 }
 
 // controllerBase acts as a base class for ControllerV1 and ControllerV1beta1.
@@ -50,6 +50,28 @@ type controllerBase struct {
 	webhooksSynced cache.InformerSynced //nolint:structcheck
 	queue          workqueue.RateLimitingInterface
 	isLeaderFunc   func() bool
+	isLeaderNotif  <-chan struct{}
+}
+
+// enqueueOnLeaderNotif watches leader notifications and triggers a
+// reconciliation in case the current process becomes leader.
+// This ensures that the latest configuration of the leader
+// is applied to the webhook object. Typically, during a rolling update.
+func (c *controllerBase) enqueueOnLeaderNotif(stop <-chan struct{}) {
+	for {
+		select {
+		case <-c.isLeaderNotif:
+			log.Infof("Got a leader notification, enqueuing a reconciliation for %q", c.config.getWebhookName())
+			c.triggerReconciliation()
+		case <-stop:
+			return
+		}
+	}
+}
+
+// triggerReconciliation forces a reconciliation loop by enqueuing the webhook object name.
+func (c *controllerBase) triggerReconciliation() {
+	c.queue.Add(c.config.getWebhookName())
 }
 
 func (c *controllerBase) getSecret() (*corev1.Secret, error) {
@@ -137,6 +159,10 @@ func (c *controllerBase) requeue(key interface{}) {
 // of the Webhook when new item is added to the work queue.
 // Always returns true unless the work queue was shutdown.
 func (c *controllerBase) processNextWorkItem(reconcile func() error) bool {
+	if !c.isLeaderFunc() {
+		return true
+	}
+
 	key, shutdown := c.queue.Get()
 	if shutdown {
 		return false

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base_test.go
@@ -26,6 +26,7 @@ func TestNewController(t *testing.T) {
 		factory.Core().V1().Secrets(),
 		factory.Admissionregistration(),
 		func() bool { return true },
+		make(chan struct{}),
 		v1Cfg,
 	)
 
@@ -37,6 +38,7 @@ func TestNewController(t *testing.T) {
 		factory.Core().V1().Secrets(),
 		factory.Admissionregistration(),
 		func() bool { return true },
+		make(chan struct{}),
 		v1beta1Cfg,
 	)
 

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1.go
@@ -38,7 +38,7 @@ type ControllerV1 struct {
 }
 
 // NewControllerV1 returns a new Webhook Controller using admissionregistration/v1.
-func NewControllerV1(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, webhookInformer admissioninformers.MutatingWebhookConfigurationInformer, isLeaderFunc func() bool, config Config) *ControllerV1 {
+func NewControllerV1(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, webhookInformer admissioninformers.MutatingWebhookConfigurationInformer, isLeaderFunc func() bool, isLeaderNotif <-chan struct{}, config Config) *ControllerV1 {
 	controller := &ControllerV1{}
 	controller.clientSet = client
 	controller.config = config
@@ -48,6 +48,7 @@ func NewControllerV1(client kubernetes.Interface, secretInformer coreinformers.S
 	controller.webhooksSynced = webhookInformer.Informer().HasSynced
 	controller.queue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "webhooks")
 	controller.isLeaderFunc = isLeaderFunc
+	controller.isLeaderNotif = isLeaderNotif
 	controller.generateTemplates()
 
 	secretInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -77,10 +78,11 @@ func (c *ControllerV1) Run(stopCh <-chan struct{}) {
 		return
 	}
 
+	go c.enqueueOnLeaderNotif(stopCh)
 	go wait.Until(c.run, time.Second, stopCh)
 
 	// Trigger a reconciliation to create the Webhook if it doesn't exist
-	c.queue.Add(c.config.getWebhookName())
+	c.triggerReconciliation()
 
 	<-stopCh
 }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1_test.go
@@ -443,6 +443,7 @@ func (f *fixtureV1) run(t *testing.T) *ControllerV1 {
 		factory.Core().V1().Secrets(),
 		factory.Admissionregistration().V1().MutatingWebhookConfigurations(),
 		func() bool { return true },
+		make(chan struct{}),
 		v1Cfg,
 	)
 

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1.go
@@ -38,7 +38,7 @@ type ControllerV1beta1 struct {
 }
 
 // NewControllerV1beta1 returns a new Webhook Controller using admissionregistration/v1beta1.
-func NewControllerV1beta1(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, webhookInformer admissioninformers.MutatingWebhookConfigurationInformer, isLeaderFunc func() bool, config Config) *ControllerV1beta1 {
+func NewControllerV1beta1(client kubernetes.Interface, secretInformer coreinformers.SecretInformer, webhookInformer admissioninformers.MutatingWebhookConfigurationInformer, isLeaderFunc func() bool, isLeaderNotif <-chan struct{}, config Config) *ControllerV1beta1 {
 	controller := &ControllerV1beta1{}
 	controller.clientSet = client
 	controller.config = config
@@ -48,6 +48,7 @@ func NewControllerV1beta1(client kubernetes.Interface, secretInformer coreinform
 	controller.webhooksSynced = webhookInformer.Informer().HasSynced
 	controller.queue = workqueue.NewNamedRateLimitingQueue(workqueue.DefaultControllerRateLimiter(), "webhooks")
 	controller.isLeaderFunc = isLeaderFunc
+	controller.isLeaderNotif = isLeaderNotif
 	controller.generateTemplates()
 
 	secretInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
@@ -77,10 +78,11 @@ func (c *ControllerV1beta1) Run(stopCh <-chan struct{}) {
 		return
 	}
 
+	go c.enqueueOnLeaderNotif(stopCh)
 	go wait.Until(c.run, time.Second, stopCh)
 
 	// Trigger a reconciliation to create the Webhook if it doesn't exist
-	c.queue.Add(c.config.getWebhookName())
+	c.triggerReconciliation()
 
 	<-stopCh
 }

--- a/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_v1beta1_test.go
@@ -443,6 +443,7 @@ func (f *fixtureV1beta1) run(t *testing.T) *ControllerV1beta1 {
 		factory.Core().V1().Secrets(),
 		factory.Admissionregistration().V1beta1().MutatingWebhookConfigurations(),
 		func() bool { return true },
+		make(chan struct{}),
 		v1beta1Cfg,
 	)
 

--- a/pkg/clusteragent/admission/start.go
+++ b/pkg/clusteragent/admission/start.go
@@ -25,12 +25,13 @@ import (
 
 // ControllerContext holds necessary context for the admission controllers
 type ControllerContext struct {
-	IsLeaderFunc     func() bool
-	SecretInformers  informers.SharedInformerFactory
-	WebhookInformers informers.SharedInformerFactory
-	Client           kubernetes.Interface
-	DiscoveryClient  discovery.DiscoveryInterface
-	StopCh           chan struct{}
+	IsLeaderFunc        func() bool
+	LeaderSubscribeFunc func() <-chan struct{}
+	SecretInformers     informers.SharedInformerFactory
+	WebhookInformers    informers.SharedInformerFactory
+	Client              kubernetes.Interface
+	DiscoveryClient     discovery.DiscoveryInterface
+	StopCh              chan struct{}
 }
 
 // StartControllers starts the secret and webhook controllers
@@ -52,6 +53,7 @@ func StartControllers(ctx ControllerContext) error {
 		ctx.Client,
 		ctx.SecretInformers.Core().V1().Secrets(),
 		ctx.IsLeaderFunc,
+		ctx.LeaderSubscribeFunc(),
 		secretConfig,
 	)
 
@@ -71,6 +73,7 @@ func StartControllers(ctx ControllerContext) error {
 		ctx.SecretInformers.Core().V1().Secrets(),
 		ctx.WebhookInformers.Admissionregistration(),
 		ctx.IsLeaderFunc,
+		ctx.LeaderSubscribeFunc(),
 		webhookConfig,
 	)
 

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection.go
@@ -50,6 +50,7 @@ type LeaderEngine struct {
 	m       sync.Mutex
 	once    sync.Once
 
+	subscribers         []chan struct{}
 	HolderIdentity      string
 	LeaseDuration       time.Duration
 	LeaseName           string
@@ -72,6 +73,7 @@ func newLeaderEngine() *LeaderEngine {
 		LeaderNamespace: common.GetResourcesNamespace(),
 		ServiceName:     config.Datadog.GetString("cluster_agent.kubernetes_service_name"),
 		leaderMetric:    metrics.NewLeaderMetric(),
+		subscribers:     []chan struct{}{},
 	}
 }
 
@@ -235,6 +237,19 @@ func (le *LeaderEngine) GetLeaderIP() (string, error) {
 // IsLeader returns true if the last observed leader was this client else returns false.
 func (le *LeaderEngine) IsLeader() bool {
 	return le.GetLeader() == le.HolderIdentity
+}
+
+// Subscribe allows any component to receive a notification
+// when the current process becomes leader.
+// Calling Subscribe is optional, use IsLeader if the client doesn't need an event-based approach.
+func (le *LeaderEngine) Subscribe() <-chan struct{} {
+	c := make(chan struct{}, 5) // buffered channel to avoid blocking in case of stuck subscriber
+
+	le.m.Lock()
+	le.subscribers = append(le.subscribers, c)
+	le.m.Unlock()
+
+	return c
 }
 
 // GetLeaderElectionRecord is used in for the Flare and for the Status commands.

--- a/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
+++ b/pkg/util/kubernetes/apiserver/leaderelection/leaderelection_test.go
@@ -99,6 +99,60 @@ func TestNewLeaseAcquiring(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestSubscribe(t *testing.T) {
+	const leaseName = "datadog-leader-election"
+
+	client := fake.NewSimpleClientset()
+	le := &LeaderEngine{
+		HolderIdentity:  "foo",
+		LeaseName:       leaseName,
+		LeaderNamespace: "default",
+		LeaseDuration:   1 * time.Second,
+		coreClient:      client.CoreV1(),
+		leaderMetric:    &dummyGauge{},
+	}
+
+	notif1 := le.Subscribe()
+	notif2 := le.Subscribe()
+	require.Len(t, le.subscribers, 2)
+
+	_, err := client.CoreV1().ConfigMaps("default").Get(context.TODO(), leaseName, metav1.GetOptions{})
+	require.True(t, errors.IsNotFound(err))
+
+	le.leaderElector, err = le.newElection()
+	require.NoError(t, err)
+
+	le.EnsureLeaderElectionRuns()
+	require.True(t, le.IsLeader())
+
+	counter1, counter2 := 0, 0
+	for {
+		select {
+		case <-notif1:
+			counter1++
+			if counter1 > 1 {
+				require.Fail(t, "Received too many notifications")
+				return
+			}
+
+		case <-notif2:
+			counter2++
+			if counter2 > 1 {
+				require.Fail(t, "Received too many notifications")
+				return
+			}
+
+		case <-time.After(5 * time.Second):
+			require.Fail(t, "Waiting on leader notification timed out")
+			return
+		}
+
+		if counter1 == 1 && counter2 == 1 {
+			break
+		}
+	}
+}
+
 func TestGetLeaderIPFollower(t *testing.T) {
 	const leaseName = "datadog-leader-election"
 	const endpointsName = "datadog-cluster-agent"

--- a/releasenotes-dca/notes/fix-admission-leader-bug-812a3d5a7df8e64f.yaml
+++ b/releasenotes-dca/notes/fix-admission-leader-bug-812a3d5a7df8e64f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed an edge case in which the Cluster Agent's Admission Controller
+    doesn't update the Webhook object according to specified configuration.


### PR DESCRIPTION
### What does this PR do?

- Fix an edge case in which the admission controller config changes don't persist
- Introduce a leader election notification mechanism

### Motivation

Bug fix

### Describe how to test your changes

The bug: When deploying a new cluster agent config (e.g set `DD_ADMISSION_CONTROLLER_INJECT_TAGS_ENABLED` to `false`), during the upgrade, the new cluster agent applies the new config and modify the webhook object accordingly, but there is a good chance that the old cluster agent pod is not dead yet and still leader so it modifies the webhook object back to the old config.

Reproducer: Deploy the cluster agent with the [admission controller enabled](https://docs.datadoghq.com/agent/cluster_agent/admission_controller/), then introduce a config change in the cluster agent (e.g set `DD_ADMISSION_CONTROLLER_INJECT_TAGS_ENABLED` to `false`) and upgrade the deployment, with this fix, the config change should be applied to the `datadog-webhook` object and should persist, once the new cluster agent pod becomes leader.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
