### PR TITLE
[kitchen] Add Windows Server 2022 to test platforms

### DIFF
--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -11,8 +11,8 @@
 .kitchen_os_windows:
   variables:
     KITCHEN_PLATFORM: "windows"
-    KITCHEN_OSVERS: "win2008r2,win2012,win2012r2,win2016,win2019,win2019cn"
-    DEFAULT_KITCHEN_OSVERS: "win2019"
+    KITCHEN_OSVERS: "win2008r2,win2012,win2012r2,win2016,win2019,win2019cn,win2022"
+    DEFAULT_KITCHEN_OSVERS: "win2022"
   before_script:  # Note: if you are changing this, remember to also change .kitchen_test_windows_installer, which has a copy of this with less TEST_PLATFORMS defined.
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi
     - rsync -azr --delete ./ $SRC_PATH
@@ -41,8 +41,8 @@
 .kitchen_test_windows_npm_driver:
   variables:
     KITCHEN_PLATFORM: "windows"
-    KITCHEN_OSVERS: "win2012r2,win2016,win2019,win2019cn,win1903,win1909,win2004,win20h2"
-    DEFAULT_KITCHEN_OSVERS: "win20h2"
+    KITCHEN_OSVERS: "win2012r2,win2016,win2019,win2019cn,win1903,win1909,win2004,win20h2,win2022"
+    DEFAULT_KITCHEN_OSVERS: "win2022"
   before_script:  # test all of the kernels to make sure the driver loads and runs properly
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export RELEASE_VERSION=$RELEASE_VERSION_7; else export RELEASE_VERSION=$RELEASE_VERSION_6; fi

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -94,7 +94,8 @@
                 "win1903": "urn,MicrosoftWindowsServer:WindowsServer:Datacenter-Core-1903-with-Containers-smalldisk:18362.1256.2012032308",
                 "win1909": "urn,MicrosoftWindowsServer:WindowsServer:datacenter-core-1909-with-containers-smalldisk:18363.1316.2101130054",
                 "win2004": "urn,MicrosoftWindowsServer:WindowsServer:datacenter-core-2004-with-containers-smalldisk:19041.746.2101092327",
-                "win20h2": "urn,MicrosoftWindowsServer:WindowsServer:datacenter-core-20h2-with-containers-smalldisk:19042.746.2101092352"
+                "win20h2": "urn,MicrosoftWindowsServer:WindowsServer:datacenter-core-20h2-with-containers-smalldisk:19042.746.2101092352",
+                "win2022": "urn,MicrosoftWindowsServer:WindowsServer:2022-datacenter-core:20348.169.2108120020"
             }
         },
         "ec2" : {


### PR DESCRIPTION
### What does this PR do?

Adds a Windows Server 2022 instance to the kitchen test platforms.

### Motivation

Test new supported platform.

### Describe how to test your changes

Run pipeline with kitchen tests.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
