### PR TITLE
[kitchen] Refactor test utils

### DIFF
--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -274,22 +274,8 @@ def json_info
 end
 
 def windows_service_status(service)
+  # Language-independent way of getting the service status
   return (`powershell -command "try { (get-service "#{service}" -ErrorAction Stop).Status } catch { write-host "NOTINSTALLED" }"`).upcase.strip
-end
-
-def flavor_service_status(flavor)
-  service = get_service_name(flavor)
-  if os == :windows
-    return windows_service_status(service)
-  else
-    if has_systemctl
-      system "sudo systemctl status --no-pager #{service}.service"
-    elsif has_upstart
-      system "sudo initctl status #{service}"
-    else
-      system "sudo /sbin/service #{service} status"
-    end
-  end
 end
 
 def is_service_running?(service)
@@ -515,7 +501,7 @@ shared_examples_for "a running Agent with no errors" do
   end
 
   it 'is running' do
-    expect(flavor_service_status "datadog-agent").to be_truthy
+    expect(is_flavor_running? "datadog-agent").to be_truthy
   end
 
   it 'has a config file' do
@@ -632,7 +618,7 @@ shared_examples_for 'an Agent that stops' do
     if os != :windows
       expect(output).to be_truthy
     end
-    expect(flavor_service_status "datadog-agent").to be_truthy
+    expect(is_flavor_running? "datadog-agent").to be_truthy
   end
 end
 


### PR DESCRIPTION
### What does this PR do?

Simplifies the kitchen test utility functions: the `flavor_service_status` function is not needed, its functionality can be replaced by `is_flavor_running?`.

### Motivation

Multiple functions with very similar purposes found in the test utilities.

### Describe how to test your changes

Run pipeline with kitchen tests.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
