### PR TITLE
[kitchen] Exclude Windows Defender Scheduled Scan from system files check

### DIFF
--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -816,7 +816,8 @@ shared_examples_for 'an Agent that is removed' do
             'c:/windows/System32/LogFiles/',
             'c:/windows/SoftwareDistribution/',
             'c:/windows/ServiceProfiles/NetworkService/AppData/',
-            'c:/windows/System32/Tasks/Microsoft/Windows/UpdateOrchestrator/'
+            'c:/windows/System32/Tasks/Microsoft/Windows/UpdateOrchestrator/',
+            'c:/windows/System32/Tasks/Microsoft/Windows/Windows Defender/Windows Defender Scheduled Scan'
       ].each { |e| e.downcase! }
 
       # We don't really need to create this file since we consume it right afterwards, but it's useful for debugging


### PR DESCRIPTION
### What does this PR do?

Adds `c:/windows/System32/Tasks/Microsoft/Windows/Windows Defender/Windows Defender Scheduled Scan` to the list of files that are allowed to be absent at the end of kitchen tests.

### Motivation

Multiple failures due to this missing file (https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/84048298, https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/84028299).


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

