### PR TITLE
Added clarifying comment for no-proxy metadata payload

### DIFF
--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -269,7 +269,7 @@ func getLogsMeta() *LogsMeta {
 
 // Expose the value of no_proxy_nonexact_match as well as any warnings of proxy behavior change in the metadata payload.
 // The NoProxy maps contain any errors or warnings due to the behavior changing when no_proxy_nonexact_match is enabled.
-// ProxyBehaviorChanged is true in the metadata if there would be any errors or warnings indicating that there would a 
+// ProxyBehaviorChanged is true in the metadata if there would be any errors or warnings indicating that there would a
 // behavior change if 'no_proxy_nonexact_match' was enabled.
 func getProxyMeta() *ProxyMeta {
 	httputils.NoProxyMapMutex.Lock()

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -267,7 +267,7 @@ func getLogsMeta() *LogsMeta {
 	return &LogsMeta{Transport: string(status.CurrentTransport)}
 }
 
-// Expose the no_proxy_nonexact_match as well as any warnings of proxy behavior change in the metadata payload.
+// Expose the value of no_proxy_nonexact_match as well as any warnings of proxy behavior change in the metadata payload.
 // The NoProxy maps contain any errors or warnings due to the behavior changing when no_proxy_nonexact_match is enabled.
 func getProxyMeta() *ProxyMeta {
 	httputils.NoProxyMapMutex.Lock()

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -269,6 +269,7 @@ func getLogsMeta() *LogsMeta {
 
 // Expose the value of no_proxy_nonexact_match as well as any warnings of proxy behavior change in the metadata payload.
 // The NoProxy maps contain any errors or warnings due to the behavior changing when no_proxy_nonexact_match is enabled.
+// ProxyBehaviorChanged is true in the metadata if there are any errors or warnings indicating that there was a behavior change.
 func getProxyMeta() *ProxyMeta {
 	httputils.NoProxyMapMutex.Lock()
 	defer httputils.NoProxyMapMutex.Unlock()

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -267,6 +267,8 @@ func getLogsMeta() *LogsMeta {
 	return &LogsMeta{Transport: string(status.CurrentTransport)}
 }
 
+// Expose the no_proxy_nonexact_match as well as any warnings of proxy behavior change in the metadata payload.
+// The NoProxy maps contain any errors or warnings due to the behavior changing when no_proxy_nonexact_match is enabled.
 func getProxyMeta() *ProxyMeta {
 	httputils.NoProxyMapMutex.Lock()
 	defer httputils.NoProxyMapMutex.Unlock()

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -269,7 +269,8 @@ func getLogsMeta() *LogsMeta {
 
 // Expose the value of no_proxy_nonexact_match as well as any warnings of proxy behavior change in the metadata payload.
 // The NoProxy maps contain any errors or warnings due to the behavior changing when no_proxy_nonexact_match is enabled.
-// ProxyBehaviorChanged is true in the metadata if there are any errors or warnings indicating that there was a behavior change.
+// ProxyBehaviorChanged is true in the metadata if there would be any errors or warnings indicating that there would a 
+// behavior change if 'no_proxy_nonexact_match' was enabled.
 func getProxyMeta() *ProxyMeta {
 	httputils.NoProxyMapMutex.Lock()
 	defer httputils.NoProxyMapMutex.Unlock()


### PR DESCRIPTION
### What does this PR do?

Adds a comment

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
