### PR TITLE
Fix reporting of system probe status during datadog-agent {status, flare}

### DIFF
--- a/cmd/agent/app/status.go
+++ b/cmd/agent/app/status.go
@@ -63,10 +63,7 @@ var statusCmd = &cobra.Command{
 			return err
 		}
 
-		if err = common.SetupSystemProbeConfig(sysProbeConfFilePath); err != nil {
-			// log.Infof("System probe config not found, disabling pulling system probe info in the status page: %v", err)
-			// TODO log?
-		}
+		_ = common.SetupSystemProbeConfig(sysProbeConfFilePath)
 
 		return requestStatus()
 	},

--- a/cmd/agent/app/status.go
+++ b/cmd/agent/app/status.go
@@ -63,6 +63,11 @@ var statusCmd = &cobra.Command{
 			return err
 		}
 
+		if err = common.SetupSystemProbeConfig(sysProbeConfFilePath); err != nil {
+			// log.Infof("System probe config not found, disabling pulling system probe info in the status page: %v", err)
+			// TODO log?
+		}
+
 		return requestStatus()
 	},
 }

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -197,6 +197,7 @@ func load(configPath string) (*Config, error) {
 
 	if len(c.EnabledModules) > 0 {
 		c.Enabled = true
+		cfg.Set(key(spNS, "enabled"), c.Enabled)
 	}
 
 	return c, nil

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -60,12 +60,6 @@ func FormatStatus(data []byte) (string, error) {
 	if config.Datadog.GetBool("system_probe_config.enabled") {
 		renderStatusTemplate(b, "/systemprobe.tmpl", systemProbeStats)
 	}
-	// TODO is this a better heuristic?
-	// if systemProbeStatsMap, ok := systemProbeStats.(map[string]interface{}); ok {
-	// 	if _, ok := systemProbeStatsMap["Errors"]; !ok {
-	// 		renderStatusTemplate(b, "/systemprobe.tmpl", systemProbeStats)
-	// 	}
-	// }
 	renderStatusTemplate(b, "/trace-agent.tmpl", stats["apmStats"])
 	renderStatusTemplate(b, "/aggregator.tmpl", aggregatorStats)
 	renderStatusTemplate(b, "/dogstatsd.tmpl", dogstatsdStats)

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -60,6 +60,12 @@ func FormatStatus(data []byte) (string, error) {
 	if config.Datadog.GetBool("system_probe_config.enabled") {
 		renderStatusTemplate(b, "/systemprobe.tmpl", systemProbeStats)
 	}
+	// TODO is this a better heuristic?
+	// if systemProbeStatsMap, ok := systemProbeStats.(map[string]interface{}); ok {
+	// 	if _, ok := systemProbeStatsMap["Errors"]; !ok {
+	// 		renderStatusTemplate(b, "/systemprobe.tmpl", systemProbeStats)
+	// 	}
+	// }
 	renderStatusTemplate(b, "/trace-agent.tmpl", stats["apmStats"])
 	renderStatusTemplate(b, "/aggregator.tmpl", aggregatorStats)
 	renderStatusTemplate(b, "/dogstatsd.tmpl", dogstatsdStats)


### PR DESCRIPTION
### What does this PR do?

This PR fixes the reporting of the status of the system probe by ensuring that the `system_probe_config.enabled` config value is dual-written to when the `config.Enabled` field is set during system probe config loading. This fixes the check to see if the system probe is enabled, which determines [whether its status gets added to the larger status map when gathering statuses](https://github.com/DataDog/datadog-agent/blob/main/pkg/status/status.go#L74-L76) for both `datadog-agent status` and `datadog-agent flare`. Additionally, to correctly render the status of the system probe in `datadog-agent status`'s textual output mode, we also make sure that the `system_probe_config.enabled` config value is set when running the status command in the process that runs the command.

### Motivation

When running `datadog-agent status` or `datadog-agent flare`, the status of the system probe is missing (either in the direct output from `datadog-agent status` or within the `status.log` file in the archive produced by `datadog-agent flare`).

### Describe how to test your changes

To manually test this PR, I used a fresh Ubuntu 18.04 VM with the datadog agent installed and the system probe's network module enabled (via the `network_config.enabled` flag according to [these docs](https://docs.datadoghq.com/network_monitoring/performance/setup/?tab=agentlinux)).

When running `datadog-agent status`, there were no lines containing "System Probe", and accordingly, when I generated a flare without uploading it (just creating the local archive), the `status.log` file also didn't contain any lines containing "System Probe."

With the changes in this PR built to the agent binary, both status and flare now include the following snippet in their output:

```
============
System Probe
============
System Probe is running
```

<!-- Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms. -->

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
