### PR TITLE
[aggregator] query time once per batch

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -776,8 +776,9 @@ func (agg *BufferedAggregator) run() {
 		case ms := <-agg.bufferedMetricIn:
 			aggregatorDogstatsdMetricSample.Add(int64(len(ms)))
 			tlmProcessed.Add(float64(len(ms)), "dogstatsd_metrics")
+			t := timeNowNano()
 			for i := 0; i < len(ms); i++ {
-				agg.addSample(&ms[i], timeNowNano())
+				agg.addSample(&ms[i], t)
 			}
 			agg.MetricSamplePool.PutBatch(ms)
 		case serviceChecks := <-agg.bufferedServiceCheckIn:


### PR DESCRIPTION
### What does this PR do?

Call time.Now() once per batch of samples.

### Motivation

Reduce CPU usage by about 5% mcores in the benchmark environment.

### Additional notes

This may cause a sample to be assigned to an earlier bucket that it would be otherwise. This will not cause problems with flushing, as flushing never happens concurrently.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
