### PR TITLE
[Windows][Unit Tests] Add missing ErrorActionPreference

### DIFF
--- a/tasks/winbuildscripts/unittests.ps1
+++ b/tasks/winbuildscripts/unittests.ps1
@@ -1,3 +1,4 @@
+$ErrorActionPreference = "Stop"
 $Password = ConvertTo-SecureString "dummyPW_:-gch6Rejae9" -AsPlainText -Force
 New-LocalUser -Name "ddagentuser" -Description "Test user for the secrets feature on windows." -Password $Password
 


### PR DESCRIPTION
### What does this PR do?

This PR adds `ErrorActionPreference="stop"` to `unittest.sps1`.

### Motivation

The `unittests.ps1` was not failing if an error occurred (such as failing to build the unit test binary !)

See for instance a job that *should* have failed: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/84322251
Compared to what we expect to happen: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/84364020