### PR TITLE
[Windows][Installer] Use correct format specifier for WcaLog

### DIFF
--- a/releasenotes/notes/fix_logging_win_installer-c750541f4fd49b77.yaml
+++ b/releasenotes/notes/fix_logging_win_installer-c750541f4fd49b77.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix some string logging in the Windows installer.

--- a/tools/windows/install-help/cal/FinalizeInstall.cpp
+++ b/tools/windows/install-help/cal/FinalizeInstall.cpp
@@ -368,7 +368,7 @@ UINT doFinalizeInstall(CustomActionData &data)
         if (!bRet)
         {
             DWORD lastErr = GetLastError();
-            auto lastErrStr = GetErrorMessageStr(lastErr);
+            auto lastErrStr = GetErrorMessageStrW(lastErr);
             WcaLog(LOGMSG_STANDARD, "CreateSymbolicLink: %S (%d)", lastErrStr.c_str(), lastErr);
         }
         else

--- a/tools/windows/install-help/cal/FinalizeInstall.cpp
+++ b/tools/windows/install-help/cal/FinalizeInstall.cpp
@@ -369,7 +369,7 @@ UINT doFinalizeInstall(CustomActionData &data)
         {
             DWORD lastErr = GetLastError();
             std::string lastErrStr = GetErrorMessageStr(lastErr);
-            WcaLog(LOGMSG_STANDARD, "CreateSymbolicLink: %s (%d)", lastErrStr.c_str(), lastErr);
+            WcaLog(LOGMSG_STANDARD, "CreateSymbolicLink: %S (%d)", lastErrStr.c_str(), lastErr);
         }
         else
         {

--- a/tools/windows/install-help/cal/FinalizeInstall.cpp
+++ b/tools/windows/install-help/cal/FinalizeInstall.cpp
@@ -368,7 +368,7 @@ UINT doFinalizeInstall(CustomActionData &data)
         if (!bRet)
         {
             DWORD lastErr = GetLastError();
-            std::string lastErrStr = GetErrorMessageStr(lastErr);
+            auto lastErrStr = GetErrorMessageStr(lastErr);
             WcaLog(LOGMSG_STANDARD, "CreateSymbolicLink: %S (%d)", lastErrStr.c_str(), lastErr);
         }
         else

--- a/tools/windows/install-help/cal/TargetMachine.cpp
+++ b/tools/windows/install-help/cal/TargetMachine.cpp
@@ -214,7 +214,7 @@ DWORD TargetMachine::DetectDomainInformation()
                 return nErr;
             }
             _dcFlags = dcInfo->Flags;
-            WcaLog(LOGMSG_STANDARD, "Domain Controller is %s", IsReadOnlyDomainController() ? "Read-Only" : "Writable");
+            WcaLog(LOGMSG_STANDARD, "Domain Controller is %S", IsReadOnlyDomainController() ? "Read-Only" : "Writable");
             NetApiBufferFree(dcInfo);
         }
     }

--- a/tools/windows/install-help/cal/TargetMachine.cpp
+++ b/tools/windows/install-help/cal/TargetMachine.cpp
@@ -214,7 +214,7 @@ DWORD TargetMachine::DetectDomainInformation()
                 return nErr;
             }
             _dcFlags = dcInfo->Flags;
-            WcaLog(LOGMSG_STANDARD, "Domain Controller is %S", IsReadOnlyDomainController() ? "Read-Only" : "Writable");
+            WcaLog(LOGMSG_STANDARD, "Domain Controller is %S", IsReadOnlyDomainController() ? L"Read-Only" : L"Writable");
             NetApiBufferFree(dcInfo);
         }
     }

--- a/tools/windows/install-help/cal/customaction.h
+++ b/tools/windows/install-help/cal/customaction.h
@@ -118,17 +118,17 @@ UINT doUninstallAs(UNINSTALL_TYPE t);
 
 // see https://stackoverflow.com/a/45565001/425565
 // Template ErrType can be HRESULT (long) or DWORD (unsigned long)
-template <class ErrType> std::string GetErrorMessageStr(ErrType errCode)
+template<class ErrType> std::wstring GetErrorMessageStr(ErrType errCode)
 {
     const int buffsize = 4096;
-    char buffer[buffsize];
+    wchar_t buffer[buffsize];
     const DWORD len =
-        FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
+        FormatMessageW(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS | FORMAT_MESSAGE_MAX_WIDTH_MASK,
                        nullptr, // (not used with FORMAT_MESSAGE_FROM_SYSTEM)
                        errCode, MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), &buffer[0], buffsize, nullptr);
     if (len > 0)
     {
-        return std::string(buffer, len);
+        return std::wstring(buffer, len);
     }
-    return "Failed to retrieve error message string.";
+    return L"Failed to retrieve error message string.";
 }

--- a/tools/windows/install-help/cal/customaction.h
+++ b/tools/windows/install-help/cal/customaction.h
@@ -118,7 +118,7 @@ UINT doUninstallAs(UNINSTALL_TYPE t);
 
 // see https://stackoverflow.com/a/45565001/425565
 // Template ErrType can be HRESULT (long) or DWORD (unsigned long)
-template<class ErrType> std::wstring GetErrorMessageStr(ErrType errCode)
+template<class ErrType> std::wstring GetErrorMessageStrW(ErrType errCode)
 {
     const int buffsize = 4096;
     wchar_t buffer[buffsize];
@@ -130,5 +130,7 @@ template<class ErrType> std::wstring GetErrorMessageStr(ErrType errCode)
     {
         return std::wstring(buffer, len);
     }
-    return L"Failed to retrieve error message string.";
+    std::wstringstream wsstr;
+    wsstr << L"Failed to retrieve error message string for code " << errCode;
+    return  wsstr.str();
 }

--- a/tools/windows/install-help/cal/stopservices.cpp
+++ b/tools/windows/install-help/cal/stopservices.cpp
@@ -881,7 +881,7 @@ int uninstallServices(CustomActionData &data)
         DWORD rbret = services[i].destroy(hScManager);
         if (rbret != 0)
         {
-            auto lastErrStr = GetErrorMessageStr(rbret);
+            auto lastErrStr = GetErrorMessageStrW(rbret);
             WcaLog(LOGMSG_STANDARD, "Failed to uninstall service %S (%d)", lastErrStr.c_str(), rbret);
         }
     }

--- a/tools/windows/install-help/cal/stopservices.cpp
+++ b/tools/windows/install-help/cal/stopservices.cpp
@@ -881,7 +881,7 @@ int uninstallServices(CustomActionData &data)
         DWORD rbret = services[i].destroy(hScManager);
         if (rbret != 0)
         {
-            std::string lastErrStr = GetErrorMessageStr(rbret);
+            auto lastErrStr = GetErrorMessageStr(rbret);
             WcaLog(LOGMSG_STANDARD, "Failed to uninstall service %S (%d)", lastErrStr.c_str(), rbret);
         }
     }

--- a/tools/windows/install-help/cal/stopservices.cpp
+++ b/tools/windows/install-help/cal/stopservices.cpp
@@ -882,7 +882,7 @@ int uninstallServices(CustomActionData &data)
         if (rbret != 0)
         {
             std::string lastErrStr = GetErrorMessageStr(rbret);
-            WcaLog(LOGMSG_STANDARD, "Failed to uninstall service %s (%d)", lastErrStr.c_str(), rbret);
+            WcaLog(LOGMSG_STANDARD, "Failed to uninstall service %S (%d)", lastErrStr.c_str(), rbret);
         }
     }
     WcaLog(LOGMSG_STANDARD, "done uinstalling services");

--- a/tools/windows/install-help/cal/userrights.cpp
+++ b/tools/windows/install-help/cal/userrights.cpp
@@ -328,7 +328,7 @@ DWORD AddUserToGroup(PSID userSid, wchar_t *groupSidString, wchar_t *defaultGrou
     nErr = NetLocalGroupAddMembers(NULL, groupname.c_str(), 0, (LPBYTE)&lmi0, 1);
     if (nErr == NERR_Success)
     {
-        WcaLog(LOGMSG_STANDARD, "Added ddagentuser to %s", asciiname.c_str());
+        WcaLog(LOGMSG_STANDARD, "Added ddagentuser to %S", asciiname.c_str());
     }
     else if (nErr == ERROR_MEMBER_IN_GROUP || nErr == ERROR_MEMBER_IN_ALIAS)
     {
@@ -352,7 +352,7 @@ DWORD DelUserFromGroup(PSID userSid, wchar_t *groupSidString, wchar_t *defaultGr
     lmi0.lgrmi0_sid = userSid;
 
     getGroupNameFromSidString(groupSidString, defaultGroupName, groupname);
-    WcaLog(LOGMSG_STANDARD, "Attempting to remove from group %s", groupname.c_str());
+    WcaLog(LOGMSG_STANDARD, "Attempting to remove from group %S", groupname.c_str());
     nErr = NetLocalGroupDelMembers(NULL, L"Performance Monitor Users", 0, (LPBYTE)&lmi0, 1);
     if (nErr == NERR_Success)
     {

--- a/tools/windows/install-help/cal/userrights.cpp
+++ b/tools/windows/install-help/cal/userrights.cpp
@@ -321,14 +321,12 @@ DWORD AddUserToGroup(PSID userSid, wchar_t *groupSidString, wchar_t *defaultGrou
     memset(&lmi0, 0, sizeof(LOCALGROUP_MEMBERS_INFO_0));
     lmi0.lgrmi0_sid = userSid;
 
-    std::string asciiname;
-
     getGroupNameFromSidString(groupSidString, defaultGroupName, groupname);
     WcaLog(LOGMSG_STANDARD, "Attempting to add to group %S", groupname.c_str());
     nErr = NetLocalGroupAddMembers(NULL, groupname.c_str(), 0, (LPBYTE)&lmi0, 1);
     if (nErr == NERR_Success)
     {
-        WcaLog(LOGMSG_STANDARD, "Added ddagentuser to %S", asciiname.c_str());
+        WcaLog(LOGMSG_STANDARD, "Added user to %S", groupname.c_str());
     }
     else if (nErr == ERROR_MEMBER_IN_GROUP || nErr == ERROR_MEMBER_IN_ALIAS)
     {


### PR DESCRIPTION
### What does this PR do?

Some string log specifier were lowercase where others were uppercase. Uppercase `%S` is for wide-char strings, so this PR replaces all the occurences of `%s` by `%S` for `WcaLog` (not `wprintf` which already assumes wide-char usage).

Example of incorrect logging in the installer:
```
Will delete user ddagentuser from local user store
Got account sid from BUILTIN

Attempting to remove from group P
Removed ddagentuser from Performance Monitor Users
Got account sid from BUILTIN

Attempting to remove from group E
User wasn't in group, continuing 1377
```

Example of correct logging in the installer:
```
Will delete user ddagentuser from local user store
Got account sid from BUILTIN

Attempting to remove from group Performance Monitor Users
Removed ddagentuser from Performance Monitor Users
Got account sid from BUILTIN

Attempting to remove from group Event Log Readers
User wasn't in group, continuing 1377
```

### Motivation

Correct logging in the installer.

### Describe how to test your changes

Install the Agent on a Domain Controller, this will check both the `CreateSymbolicLink`, the `Domain Controller Is` and the `Added ddagentuser to` strings.
Uninstall the Agent which will check the `Attempting to remove from group` string.
The `Failed to uninstall service` is not really possible to test in normal conditions - it should be possible to manually delete the service *before* uninstalling the Agent and it should trigger this string.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
