### PR TITLE
[runtime-security] make use of a pool to allocate dentry cache entry

### DIFF
--- a/pkg/security/probe/dentry_resolver.go
+++ b/pkg/security/probe/dentry_resolver.go
@@ -234,10 +234,8 @@ func (dr *DentryResolver) DelCacheEntry(mountID uint32, inode uint64) {
 			if !exists {
 				break
 			}
+			// this is also call the onEvict function of LRU thus releasing the entry from the pool
 			entries.Remove(key.Inode)
-
-			// place the entry to the pool
-			dr.pathEntryPool.Put(path)
 
 			parent := path.(*PathEntry).Parent
 			if parent.Inode == 0 {
@@ -293,8 +291,8 @@ func (dr *DentryResolver) cacheInode(key PathKey, path *PathEntry) error {
 	}
 
 	// release before in case of override
-	if _, exists := entries.Get(key.Inode); exists {
-		dr.pathEntryPool.Put(path)
+	if prev, exists := entries.Get(key.Inode); exists {
+		dr.pathEntryPool.Put(prev)
 	}
 
 	entries.Add(key.Inode, path)

--- a/pkg/security/tests/schemas/link.schema.json
+++ b/pkg/security/tests/schemas/link.schema.json
@@ -1,0 +1,30 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "rename.json",
+    "type": "object",
+    "anyOf": [
+        {
+            "$ref": "file:///container_event.json"
+        },
+        {
+            "$ref": "file:///host_event.json"
+        }
+    ],
+    "allOf": [
+        {
+            "properties": {
+                "file": {
+                    "type": "object",
+                    "required": [
+                        "destination"
+                    ],
+                    "properties": {
+                        "destination": {
+                            "$ref": "file:///file.json"
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}


### PR DESCRIPTION
### What does this PR do?

This PR makes use of a sync.Pool for dentry cache entry allocations in order to low down the number of memory allocation.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
