### PR TITLE
[tests] Exclude flaky utilization tests from Windows/Darwin

### DIFF
--- a/pkg/collector/worker/utilization_tracker_test.go
+++ b/pkg/collector/worker/utilization_tracker_test.go
@@ -8,6 +8,7 @@ package worker
 import (
 	"expvar"
 	"math/rand"
+	"runtime"
 	"testing"
 	"time"
 
@@ -204,6 +205,10 @@ func TestUtilizationTrackerCheckLifecycle(t *testing.T) {
 }
 
 func TestUtilizationTrackerAccuracy(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("Skipping flaky test on Darwin")
+	}
+
 	windowSize := 3000 * time.Millisecond
 	pollingInterval := 50 * time.Millisecond
 

--- a/pkg/util/sliding_window_test.go
+++ b/pkg/util/sliding_window_test.go
@@ -7,6 +7,7 @@ package util
 
 import (
 	"math/rand"
+	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -68,6 +69,10 @@ func TestSlidingWindow(t *testing.T) {
 }
 
 func TestSlidingWindowAccuracy(t *testing.T) {
+	if runtime.GOOS == "darwin" {
+		t.Skip("Skipping flaky test on Darwin")
+	}
+
 	// Floats don't really have good atomic primitives
 	var cbLock sync.RWMutex
 	lastAverage := 0.0
@@ -97,6 +102,10 @@ func TestSlidingWindowAccuracy(t *testing.T) {
 }
 
 func TestSlidingWindowAverage(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping flaky test on Windows")
+	}
+
 	sw, err := NewSlidingWindow(1*time.Second, 100*time.Millisecond)
 	require.Nil(t, err)
 


### PR DESCRIPTION
### What does this PR do?

On some platforms in our CI, timing exactness cannot be guaranteed and
as such creates flaky test results. This commit adds skips for those
tests in the impacted environments.

### Motivation

Test failures in CircleCI and Appveyor

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

N/A (ensure that tests don't fail)

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.

Note: Adding GitHub labels is only possible for contributors with write access.
