### PR TITLE
[networks] Add support for DNS with NAT

### DIFF
--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -8,7 +8,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/dns"
 	"github.com/DataDog/datadog-agent/pkg/network/http"
-	"github.com/DataDog/datadog-agent/pkg/network/nat"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/gogo/protobuf/proto"
 	"go4.org/intern"
@@ -204,8 +203,8 @@ func FormatHTTPStats(httpData map[http.Key]http.RequestStats) map[http.Key]*mode
 // Build the key for the http map based on whether the local or remote side is http.
 func httpKeyFromConn(c network.ConnectionStats) http.Key {
 	// Retrieve translated addresses
-	laddr, lport := nat.GetLocalAddress(c)
-	raddr, rport := nat.GetRemoteAddress(c)
+	laddr, lport := network.GetNATLocalAddress(c)
+	raddr, rport := network.GetNATRemoteAddress(c)
 
 	// HTTP data is always indexed as (client, server), so we flip
 	// the lookup key if necessary using the port range heuristic

--- a/pkg/network/nat.go
+++ b/pkg/network/nat.go
@@ -1,12 +1,11 @@
-package nat
+package network
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 )
 
-// GetLocalAddress returns the translated (local ip, local port) pair
-func GetLocalAddress(c network.ConnectionStats) (util.Address, uint16) {
+// GetNATLocalAddress returns the translated (local ip, local port) pair
+func GetNATLocalAddress(c ConnectionStats) (util.Address, uint16) {
 	localIP := c.Source
 	localPort := c.SPort
 
@@ -18,8 +17,8 @@ func GetLocalAddress(c network.ConnectionStats) (util.Address, uint16) {
 	return localIP, localPort
 }
 
-// GetRemoteAddress returns the translated (remote ip, remote port) pair
-func GetRemoteAddress(c network.ConnectionStats) (util.Address, uint16) {
+// GetNATRemoteAddress returns the translated (remote ip, remote port) pair
+func GetNATRemoteAddress(c ConnectionStats) (util.Address, uint16) {
 	remoteIP := c.Dest
 	remotePort := c.DPort
 

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -232,10 +232,13 @@ func (ns *networkState) addDNSStats(id string, conns []ConnectionStats) {
 		if conn.DPort != 53 {
 			continue
 		}
+
+		serverIP, _ := GetNATRemoteAddress(*conn)
+		clientIP, clientPort := GetNATLocalAddress(*conn)
 		key := dns.Key{
-			ServerIP:   conn.Dest,
-			ClientIP:   conn.Source,
-			ClientPort: conn.SPort,
+			ServerIP:   serverIP,
+			ClientIP:   clientIP,
+			ClientPort: clientPort,
 		}
 		switch conn.Type {
 		case TCP:

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -437,8 +437,8 @@ func (t *Tracer) getConnections(buffer []network.ConnectionStats) ([]network.Con
 		return nil, 0, err
 	}
 
-	for _, conn := range active {
-		conn.IPTranslation = t.conntracker.GetTranslationForConn(conn)
+	for i, conn := range active {
+		active[i].IPTranslation = t.conntracker.GetTranslationForConn(conn)
 	}
 
 	entryCount := uint(len(active))

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/http"
 	"github.com/DataDog/datadog-agent/pkg/network/http/testutil"
-	nettestutil "github.com/DataDog/datadog-agent/pkg/network/testutil"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -1057,19 +1056,6 @@ func TestDNSStatsForInvalidDomain(t *testing.T) {
 
 func TestDNSStatsForTimeout(t *testing.T) {
 	testDNSStats(t, "golang.org", 0, 0, 1, "1.2.3.4")
-}
-
-func TestDNSStatsWithNAT(t *testing.T) {
-	// Setup a NAT rule to translate 2.2.2.2 to 8.8.8.8 and issue a DNS request to 2.2.2.2
-	cmds := []string{"iptables -t nat -A OUTPUT -d 2.2.2.2 -j DNAT --to-destination 8.8.8.8"}
-	nettestutil.RunCommands(t, cmds, true)
-
-	defer func() {
-		cmds = []string{"iptables -t nat -D OUTPUT -d 2.2.2.2 -j DNAT --to-destination 8.8.8.8"}
-		nettestutil.RunCommands(t, cmds, true)
-	}()
-
-	testDNSStats(t, "golang.org", 1, 0, 0, "2.2.2.2")
 }
 
 func TestTCPEstablished(t *testing.T) {

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1063,9 +1063,13 @@ func TestDNSStatsWithNAT(t *testing.T) {
 	// Setup a NAT rule to translate 2.2.2.2 to 8.8.8.8 and issue a DNS request to 2.2.2.2
 	cmds := []string{"iptables -t nat -A OUTPUT -d 2.2.2.2 -j DNAT --to-destination 8.8.8.8"}
 	nettestutil.RunCommands(t, cmds, true)
+
+	defer func() {
+		cmds = []string{"iptables -t nat -D OUTPUT -d 2.2.2.2 -j DNAT --to-destination 8.8.8.8"}
+		nettestutil.RunCommands(t, cmds, true)
+	}()
+
 	testDNSStats(t, "golang.org", 1, 0, 0, "2.2.2.2")
-	cmds = []string{"iptables -t nat -D OUTPUT -d 2.2.2.2 -j DNAT --to-destination 8.8.8.8"}
-	nettestutil.RunCommands(t, cmds, true)
 }
 
 func TestTCPEstablished(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Extend support for DNS stats in the context of NAT.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Change covered by integration test.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
