### PR TITLE
Fix a memory leak in auto-discovery code

### DIFF
--- a/pkg/autodiscovery/templatecache.go
+++ b/pkg/autodiscovery/templatecache.go
@@ -105,10 +105,14 @@ func (cache *TemplateCache) Del(tpl integration.Config) error {
 	for _, id := range tpl.ADIdentifiers {
 		digests := cache.adIDToDigests[id]
 		// remove the template from id2templates
-		for i, digest := range digests {
-			if digest == d {
-				cache.adIDToDigests[id] = append(digests[:i], digests[i+1:]...)
-				break
+		if len(digests) == 1 && digests[0] == d {
+			delete(cache.adIDToDigests, id)
+		} else {
+			for i, digest := range digests {
+				if digest == d {
+					cache.adIDToDigests[id] = append(digests[:i], digests[i+1:]...)
+					break
+				}
 			}
 		}
 	}

--- a/pkg/autodiscovery/templatecache_test.go
+++ b/pkg/autodiscovery/templatecache_test.go
@@ -58,13 +58,22 @@ func TestDel(t *testing.T) {
 	tpl := integration.Config{ADIdentifiers: []string{"foo", "bar"}}
 	err := cache.Set(tpl)
 	require.Nil(t, err)
+	tpl2 := integration.Config{ADIdentifiers: []string{"foo"}}
+	err = cache.Set(tpl2)
+	require.Nil(t, err)
 
 	err = cache.Del(tpl)
 	require.Nil(t, err)
 
-	require.Len(t, cache.adIDToDigests, 2)
-	assert.Len(t, cache.adIDToDigests["foo"], 0)
-	assert.Len(t, cache.adIDToDigests["bar"], 0)
+	require.Len(t, cache.adIDToDigests, 1)
+	assert.Len(t, cache.adIDToDigests["foo"], 1)
+	assert.Len(t, cache.digestToADId, 1)
+	assert.Len(t, cache.digestToTemplate, 1)
+
+	err = cache.Del(tpl2)
+	require.Nil(t, err)
+
+	require.Len(t, cache.adIDToDigests, 0)
 	assert.Len(t, cache.digestToADId, 0)
 	assert.Len(t, cache.digestToTemplate, 0)
 


### PR DESCRIPTION
### What does this PR do?

Fix a memory leak in auto-discovery code.

### Motivation

Memory leaks are bad.

### Additional Notes

There’s currently a bigger leak in `metrics.ContextMetrics.AddSample` that makes the leak fixed by this PR less obvious.

### Describe how to test your changes

Start a workload on your Kubernetes cluster which generates a lot of AD events with a lot of container and pod churn.
Here is what I used: DataDog/k8s-testing-resources#25.
Then, check the heap pprof profile.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [X] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [X] The appropriate `team/..` label has been applied, if known.
- [X] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [X] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
