### PR TITLE
[secrets] Add new executable to fetch secrets from files and Kubernetes secrets

### DIFF
--- a/Dockerfiles/agent/amd64/Dockerfile
+++ b/Dockerfiles/agent/amd64/Dockerfile
@@ -133,7 +133,7 @@ COPY --from=extract /output/ /
 # S6 entrypoint, service definitions, healthcheck probe
 COPY s6-services /etc/services.d/
 COPY cont-init.d /etc/cont-init.d/
-COPY probe.sh initlog.sh secrets-helper/readsecret.py secrets-helper/readsecret.sh /
+COPY probe.sh initlog.sh secrets-helper/readsecret.py secrets-helper/readsecret.sh secrets-helper/readsecret_multiple_providers.sh /
 
 # Extract s6-overlay
 #
@@ -155,10 +155,8 @@ RUN tar xzf s6.tgz -C / --exclude="./bin" \
  && chown -R dd-agent:root /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ \
  && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ \
  && chmod 755 /probe.sh /initlog.sh \
- && chown root:root /readsecret.py \
- && chmod 500 /readsecret.py \
- && chown root:root /readsecret.sh \
- && chmod 500 /readsecret.sh
+ && chown root:root /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh \
+ && chmod 500 /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh
 
 # Update links to python binaries
 

--- a/Dockerfiles/agent/arm64/Dockerfile
+++ b/Dockerfiles/agent/arm64/Dockerfile
@@ -133,7 +133,7 @@ COPY --from=extract /output/ /
 # S6 entrypoint, service definitions, healthcheck probe
 COPY s6-services /etc/services.d/
 COPY cont-init.d /etc/cont-init.d/
-COPY probe.sh initlog.sh secrets-helper/readsecret.py secrets-helper/readsecret.sh /
+COPY probe.sh initlog.sh secrets-helper/readsecret.py secrets-helper/readsecret.sh secrets-helper/readsecret_multiple_providers.sh /
 
 # Extract s6-overlay
 #
@@ -155,10 +155,8 @@ RUN tar xzf s6.tgz -C / --exclude="./bin" \
  && chown -R dd-agent:root /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ \
  && chmod g+r,g+w,g+X -R /etc/datadog-agent/ /etc/s6/ /var/run/s6/ /var/log/datadog/ \
  && chmod 755 /probe.sh /initlog.sh \
- && chown root:root /readsecret.py \
- && chmod 500 /readsecret.py \
- && chown root:root /readsecret.sh \
- && chmod 500 /readsecret.sh
+ && chown root:root /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh \
+ && chmod 500 /readsecret.py /readsecret.sh /readsecret_multiple_providers.sh
 
 # Update links to python binaries
 

--- a/Dockerfiles/agent/secrets-helper/readsecret_multiple_providers.sh
+++ b/Dockerfiles/agent/secrets-helper/readsecret_multiple_providers.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2016-present Datadog, Inc.
+
+/opt/datadog-agent/bin/agent/agent secret-helper read --with-provider-prefixes

--- a/Dockerfiles/cluster-agent/amd64/Dockerfile
+++ b/Dockerfiles/cluster-agent/amd64/Dockerfile
@@ -12,11 +12,11 @@ COPY ./datadog-cluster.yaml etc/datadog-agent/datadog-cluster.yaml
 COPY ./security-agent-policies/compliance/containers/ etc/datadog-agent/compliance.d
 COPY ./install_info etc/datadog-agent/install_info
 COPY entrypoint.sh .
-COPY readsecret.sh .
+COPY readsecret.sh readsecret_multiple_providers.sh ./
 
 RUN chmod 755 entrypoint.sh \
-    && chown root:root readsecret.sh \
-    && chmod 550 readsecret.sh \
+    && chown root:root readsecret.sh readsecret_multiple_providers.sh \
+    && chmod 550 readsecret.sh readsecret_multiple_providers.sh \
     && chmod g+r,g+w,g+X -R etc/datadog-agent/ \
     && chmod +x opt/datadog-agent/bin/datadog-cluster-agent \
     && ln -s /opt/datadog-agent/bin/datadog-cluster-agent opt/datadog-agent/bin/agent

--- a/Dockerfiles/cluster-agent/arm64/Dockerfile
+++ b/Dockerfiles/cluster-agent/arm64/Dockerfile
@@ -11,11 +11,11 @@ COPY ./conf.d etc/datadog-agent/conf.d
 COPY ./datadog-cluster.yaml etc/datadog-agent/datadog-cluster.yaml
 COPY ./security-agent-policies/compliance/containers/ etc/datadog-agent/compliance.d
 COPY entrypoint.sh .
-COPY readsecret.sh .
+COPY readsecret.sh readsecret_multiple_providers.sh ./
 
 RUN chmod 755 entrypoint.sh \
-    && chown root:root readsecret.sh \
-    && chmod 550 readsecret.sh \
+    && chown root:root readsecret.sh readsecret_multiple_providers.sh \
+    && chmod 550 readsecret.sh readsecret_multiple_providers.sh\
     && chmod g+r,g+w,g+X -R etc/datadog-agent/ \
     && chmod +x opt/datadog-agent/bin/datadog-cluster-agent \
     && ln -s /opt/datadog-agent/bin/datadog-cluster-agent opt/datadog-agent/bin/agent

--- a/Dockerfiles/cluster-agent/readsecret_multiple_providers.sh
+++ b/Dockerfiles/cluster-agent/readsecret_multiple_providers.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+set -e
+
+# Unless explicitly stated otherwise all files in this repository are licensed
+# under the Apache License Version 2.0.
+# This product includes software developed at Datadog (https://www.datadoghq.com/).
+# Copyright 2016-present Datadog, Inc.
+
+/opt/datadog-agent/bin/agent/agent secret-helper read --with-provider-prefixes

--- a/cmd/secrets/providers/file.go
+++ b/cmd/secrets/providers/file.go
@@ -1,0 +1,76 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build secrets
+
+package providers
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	s "github.com/DataDog/datadog-agent/pkg/secrets"
+)
+
+const (
+	maxSecretFileSize = 8192
+)
+
+func ReadSecretFile(path string) s.Secret {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return s.Secret{Value: "", ErrorMsg: "secret does not exist"}
+		}
+		return s.Secret{Value: "", ErrorMsg: err.Error()}
+	}
+
+	if fi.Mode()&os.ModeSymlink != 0 {
+		// Ensure that the symlink is in the same dir
+		target, err := os.Readlink(path)
+		if err != nil {
+			return s.Secret{Value: "", ErrorMsg: fmt.Sprintf("failed to read symlink target: %v", err)}
+		}
+
+		dir := filepath.Dir(path)
+		if !filepath.IsAbs(target) {
+			target, err = filepath.Abs(filepath.Join(dir, target))
+			if err != nil {
+				return s.Secret{Value: "", ErrorMsg: fmt.Sprintf("failed to resolve symlink absolute path: %v", err)}
+			}
+		}
+
+		dirAbs, err := filepath.Abs(dir)
+		if err != nil {
+			return s.Secret{Value: "", ErrorMsg: fmt.Sprintf("failed to resolve absolute path of directory: %v", err)}
+		}
+
+		if !filepath.HasPrefix(target, dirAbs) {
+			return s.Secret{Value: "", ErrorMsg: fmt.Sprintf("not following symlink %q outside of %q", target, dir)}
+		}
+	}
+	fi, err = os.Stat(path)
+	if err != nil {
+		return s.Secret{Value: "", ErrorMsg: err.Error()}
+	}
+
+	if fi.Size() > maxSecretFileSize {
+		return s.Secret{Value: "", ErrorMsg: "secret exceeds max allowed size"}
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return s.Secret{Value: "", ErrorMsg: err.Error()}
+	}
+
+	bytes, err := ioutil.ReadAll(file)
+	if err != nil {
+		return s.Secret{Value: "", ErrorMsg: err.Error()}
+	}
+
+	return s.Secret{Value: string(bytes), ErrorMsg: ""}
+}

--- a/cmd/secrets/providers/file_test.go
+++ b/cmd/secrets/providers/file_test.go
@@ -1,0 +1,91 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build secrets
+
+package providers
+
+import (
+	"fmt"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var testDataPath = "../testdata"
+var testSecretsPath = testDataPath + "/read-secrets"
+
+// All these are defined according to the test files in testSecretsDir
+var fileThatExists = "secret1"
+var contentsOfFileThatExists = "secret1-value"
+var fileThatDoesNotExist = "secret2"
+var fileThatExceedsMaxSize = "secret3"
+var fileThatIsASymlinkToSameDir = "secret4" // Points to "secret1"
+var fileThatIsASymlinkToOtherDir = "secret5"
+
+func TestReadSecretFile(t *testing.T) {
+	testDataAbsPath, err := filepath.Abs(testDataPath)
+	assert.NoError(t, err)
+	testSecretsAbsPath, err := filepath.Abs(testSecretsPath)
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name                string
+		inputFile           string
+		expectedSecretValue string
+		expectedError       string
+		skipWindows         bool
+	}{
+		{
+			name:                "file exists",
+			inputFile:           fileThatExists,
+			expectedSecretValue: contentsOfFileThatExists,
+		},
+		{
+			name:          "file does not exist",
+			inputFile:     fileThatDoesNotExist,
+			expectedError: "secret does not exist",
+		},
+		{
+			name:          "file exceeds max allowed size",
+			inputFile:     fileThatExceedsMaxSize,
+			expectedError: "secret exceeds max allowed size",
+		},
+		{
+			name:                "file is a symlink pointing to the same dir",
+			inputFile:           fileThatIsASymlinkToSameDir,
+			expectedSecretValue: contentsOfFileThatExists,
+			skipWindows:         true,
+		},
+		{
+			name:      "file is a symlink to other dir",
+			inputFile: fileThatIsASymlinkToOtherDir,
+			expectedError: fmt.Sprintf(
+				"not following symlink \"%s\" outside of \"%s\"",
+				testDataAbsPath+"/secret5-target",
+				testSecretsAbsPath,
+			),
+			skipWindows: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.skipWindows && runtime.GOOS == "windows" {
+				t.Skip("skipped on windows")
+			}
+
+			secret := ReadSecretFile(filepath.Join(testSecretsAbsPath, test.inputFile))
+
+			if test.expectedError != "" {
+				assert.Equal(t, test.expectedError, secret.ErrorMsg)
+			} else {
+				assert.Equal(t, test.expectedSecretValue, secret.Value)
+			}
+		})
+	}
+}

--- a/cmd/secrets/providers/k8s_secret.go
+++ b/cmd/secrets/providers/k8s_secret.go
@@ -1,0 +1,41 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build secrets
+
+package providers
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	s "github.com/DataDog/datadog-agent/pkg/secrets"
+)
+
+func ReadKubernetesSecret(kubeClient kubernetes.Interface, path string) s.Secret {
+	splitName := strings.Split(path, "/")
+
+	if len(splitName) != 3 {
+		return s.Secret{ErrorMsg: fmt.Sprintf("invalid format. Use: \"namespace/name/key\"")}
+	}
+
+	namespace, name, key := splitName[0], splitName[1], splitName[2]
+
+	secret, err := kubeClient.CoreV1().Secrets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return s.Secret{ErrorMsg: err.Error()}
+	}
+
+	value, ok := secret.Data[key]
+	if !ok {
+		return s.Secret{ErrorMsg: fmt.Sprintf("key %s not found in secret %s/%s", key, namespace, name)}
+	}
+
+	return s.Secret{Value: string(value)}
+}

--- a/cmd/secrets/providers/k8s_secret_test.go
+++ b/cmd/secrets/providers/k8s_secret_test.go
@@ -1,0 +1,89 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build secrets
+
+package providers
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestReadKubernetesSecret(t *testing.T) {
+	tests := []struct {
+		name            string
+		existingSecrets []v1.Secret
+		secretPath      string
+		expectedValue   string
+		expectedError   string
+	}{
+		{
+			name:            "invalid path format",
+			existingSecrets: []v1.Secret{},
+			secretPath:      "not_valid",
+			expectedError:   "invalid format. Use: \"namespace/name/key\"",
+		},
+		{
+			name:            "secret does not exist",
+			existingSecrets: []v1.Secret{},
+			secretPath:      "some_namespace/some_name/some_key",
+			expectedError:   "secrets \"some_name\" not found",
+		},
+		{
+			name: "secret exists, but the key does not",
+			existingSecrets: []v1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "some_name",
+						Namespace: "some_namespace",
+					},
+					Data: map[string][]byte{"another_key": []byte("some_value")},
+				},
+			},
+			secretPath:    "some_namespace/some_name/some_key",
+			expectedError: "key some_key not found in secret some_namespace/some_name",
+		},
+		{
+			name: "secret and key exist",
+			existingSecrets: []v1.Secret{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "some_name",
+						Namespace: "some_namespace",
+					},
+					Data: map[string][]byte{"some_key": []byte("some_value")},
+				},
+			},
+			secretPath:    "some_namespace/some_name/some_key",
+			expectedValue: "some_value",
+			expectedError: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var kubeObjects []runtime.Object
+			for _, secret := range test.existingSecrets {
+				kubeObjects = append(kubeObjects, &secret)
+			}
+			kubeClient := fake.NewSimpleClientset(kubeObjects...)
+
+			resolvedSecret := ReadKubernetesSecret(kubeClient, test.secretPath)
+
+			if test.expectedError != "" {
+				assert.Equal(t, test.expectedError, resolvedSecret.ErrorMsg)
+			} else {
+				assert.Equal(t, test.expectedValue, resolvedSecret.Value)
+				assert.Empty(t, test.expectedError, resolvedSecret.ErrorMsg)
+			}
+		})
+	}
+}

--- a/pkg/util/kubernetes/apiserver/apiserver.go
+++ b/pkg/util/kubernetes/apiserver/apiserver.go
@@ -191,7 +191,7 @@ func getClientConfig(timeout time.Duration) (*rest.Config, error) {
 	return clientConfig, nil
 }
 
-func getKubeClient(timeout time.Duration) (kubernetes.Interface, error) {
+func GetKubeClient(timeout time.Duration) (kubernetes.Interface, error) {
 	// TODO: Remove custom warning logger when we remove usage of ComponentStatus
 	rest.SetDefaultWarningHandler(CustomWarningLogger{})
 	clientConfig, err := getClientConfig(timeout)
@@ -253,7 +253,7 @@ func getDDInformerFactory() (dynamicinformer.DynamicSharedInformerFactory, error
 
 func getInformerFactory() (informers.SharedInformerFactory, error) {
 	resyncPeriodSeconds := time.Duration(config.Datadog.GetInt64("kubernetes_informers_resync_period"))
-	client, err := getKubeClient(0) // No timeout for the Informers, to allow long watch.
+	client, err := GetKubeClient(0) // No timeout for the Informers, to allow long watch.
 	if err != nil {
 		log.Errorf("Could not get apiserver client: %v", err)
 		return nil, err
@@ -263,7 +263,7 @@ func getInformerFactory() (informers.SharedInformerFactory, error) {
 
 func getInformerFactoryWithOption(options ...informers.SharedInformerOption) (informers.SharedInformerFactory, error) {
 	resyncPeriodSeconds := time.Duration(config.Datadog.GetInt64("kubernetes_informers_resync_period"))
-	client, err := getKubeClient(0) // No timeout for the Informers, to allow long watch.
+	client, err := GetKubeClient(0) // No timeout for the Informers, to allow long watch.
 	if err != nil {
 		log.Errorf("Could not get apiserver client: %v", err)
 		return nil, err
@@ -273,7 +273,7 @@ func getInformerFactoryWithOption(options ...informers.SharedInformerOption) (in
 
 func (c *APIClient) connect() error {
 	var err error
-	c.Cl, err = getKubeClient(time.Duration(c.timeoutSeconds) * time.Second)
+	c.Cl, err = GetKubeClient(time.Duration(c.timeoutSeconds) * time.Second)
 	if err != nil {
 		log.Infof("Could not get apiserver client: %v", err)
 		return err

--- a/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
+++ b/pkg/util/kubernetes/apiserver/apiserver_nocompile.go
@@ -10,9 +10,11 @@ package apiserver
 import (
 	"context"
 	"errors"
+	"time"
 
 	apiv1 "github.com/DataDog/datadog-agent/pkg/clusteragent/api/v1"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"k8s.io/client-go/kubernetes"
 )
 
 var (
@@ -60,4 +62,9 @@ func GetMetadataMapBundleOnAllNodes(_ *APIClient) (*apiv1.MetadataResponse, erro
 func GetNodeLabels(_ *APIClient, nodeName string) (map[string]string, error) {
 	log.Errorf("GetNodeLabels not implemented %s", ErrNotCompiled.Error())
 	return nil, nil
+}
+
+// GetKubeClient returns a Kubernetes client.
+func GetKubeClient(timeout time.Duration) (kubernetes.Interface, error) {
+	return nil, ErrNotCompiled
 }

--- a/releasenotes/notes/read-secrets-from-multiple-backends-a2cc225cd86c9256.yaml
+++ b/releasenotes/notes/read-secrets-from-multiple-backends-a2cc225cd86c9256.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Added new executable `readsecret_multiple_providers.sh` that allows the
+    agent to read secrets both from files and Kubernetes secrets. Please refer
+    to the `docs <https://docs.datadoghq.com/agent/guide/secrets-management>`_
+    for more details.


### PR DESCRIPTION
### What does this PR do?

This PR adds a new executable (`readsecret_multiple_providers.sh`) that fetches configuration secrets using different secret providers. For now, only the file system and Kubernetes providers are supported.

To use this feature, users need to set `DD_SECRET_BACKEND_COMMAND=/readsecret_multiple_providers.sh` and specify their secrets with the format `ENC[provider@some/path]`. For example, for the “file” provider, a valid secret would be `ENC[file@/some/path]`. For the Kubernetes provider, the format is `ENC[k8s_secret@some_namespace/some_name/a_key]`.

The functionality introduced in this PR is similar to the one provided by the `readsecret.sh` executable ([docs](https://docs.datadoghq.com/agent/guide/secrets-management/?tab=linux#kubernetes-secrets)). The difference is that the new executable reads Kubernetes secrets via API instead of relying on mounted volumes. This allows us to read secrets from any namespace assuming that the needed roles have been set.

This PR modifies the “secret-helper” CLI command used by the existing `/readsecret.sh` executable adding a new “—with-provider-prefixes” option. This PR does not break compatibility,  the `/readsecret.sh` command keeps working the same way.

### Describe how to test your changes

#### Read a secret from Kubernetes

- Create a Kubernetes secret with your Api key or any other configuration param. API key will make things obvious if the feature is not working properly: `kubectl create secret generic datadog-secret --from-literal api-key=your_key`.
- Set the proper roles and role bindings so the agent can read that secret. I provided an example YAML file below, but you might need to adapt it to your environment (check namespaces, service account, etc.).
- Deploy the agent (Note that in order for this to work you'll need to set the proper roles so the `datadog-agent` service account can read that secret):
	- With `DD_SECRET_BACKEND_COMMAND=/readsecret_multiple_providers.sh`
	- With a secret in your config with ENC[]. For example,  If you are using the secret specified in the step above: `apiKey: ENC[k8s_secret@default/datadog-secret/api-key]`
- When everything is ready, check `agent status` and verify that it says that the API key is valid. You can also check `agent secret` and check that the secret has been fetched correctly.
- You can repeat the same process but with a non-existing secret in ENC[]. The agent will show an error in the logs.

#### Read a secret from a file

Similar to the steps above, but using the "file" provider. For example, for `ENC[file@/some/path/secret_file`], the value will be the contents of the “/some/path/secret_file” file. Doing this in Kubernetes requires extra steps to make a file accessible in the image. Another option consists of running the helper directly: `agent secret-helper read --with-provider-prefixes` and ask for the secret with the specified format in https://docs.datadoghq.com/agent/guide/secrets-management/?tab=linux : `{"version": "1.0", "secrets": ["file@/some/path/secret_file"]}`. The output should show the contents of the file with the secret.

#### Example YAML with role and role binding to read secrets

```yaml
apiVersion: rbac.authorization.k8s.io/v1
kind: Role
metadata:
  name: secret-reader
  namespace: default
rules:
  - apiGroups: [""]
    resources: ["secrets"]
    verbs: ["get", "watch", "list"]
---
apiVersion: rbac.authorization.k8s.io/v1
kind: RoleBinding
metadata:
  name: read-secrets
  namespace: default
subjects:
  - kind: ServiceAccount
    name: datadog-agent
    apiGroup: ""
    namespace: default
roleRef:
  kind: Role
  name: secret-reader
  apiGroup: ""
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
