### PR TITLE
Be more resilient to server errors when sending flares

### DIFF
--- a/pkg/flare/flare.go
+++ b/pkg/flare/flare.go
@@ -15,6 +15,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -144,9 +145,19 @@ func analyzeResponse(r *http.Response, err error) (string, error) {
 		return response, fmt.Errorf("HTTP 403 Forbidden: %s", errStr)
 	}
 
+	var res flareResponse
 	b, _ := ioutil.ReadAll(r.Body)
-	var res = flareResponse{}
-	err = json.Unmarshal(b, &res)
+	if r.StatusCode != http.StatusOK {
+		err = fmt.Errorf("HTTP %d %s", r.StatusCode, r.Status)
+	} else if contentType := r.Header.Get("Content-Type"); !strings.HasPrefix(contentType, "application/json") {
+		if contentType != "" {
+			err = fmt.Errorf("Server returned unknown content-type %s", contentType)
+		} else {
+			err = fmt.Errorf("Server returned no content-type header")
+		}
+	} else {
+		err = json.Unmarshal(b, &res)
+	}
 	if err != nil {
 		response = fmt.Sprintf("Error: could not deserialize response body -- Please contact support by email.")
 		sample := string(b)

--- a/pkg/flare/flare.go
+++ b/pkg/flare/flare.go
@@ -149,7 +149,11 @@ func analyzeResponse(r *http.Response, err error) (string, error) {
 	err = json.Unmarshal(b, &res)
 	if err != nil {
 		response = fmt.Sprintf("Error: could not deserialize response body -- Please contact support by email.")
-		return response, fmt.Errorf("%v\nServer returned:\n%s", err, string(b)[:150])
+		sample := string(b)
+		if len(sample) > 150 {
+			sample = sample[:150]
+		}
+		return response, fmt.Errorf("%v\nServer returned:\n%s", err, sample)
 	}
 
 	if res.Error != "" {

--- a/pkg/flare/flare_test.go
+++ b/pkg/flare/flare_test.go
@@ -6,7 +6,10 @@
 package flare
 
 import (
+	"bytes"
+	"errors"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -15,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestMkURL(t *testing.T) {
@@ -65,4 +69,97 @@ func TestFlareHasRightForm(t *testing.T) {
 	assert.Equal(t, email, lastRequest.FormValue("email"))
 	assert.Equal(t, av.String(), lastRequest.FormValue("agent_version"))
 
+}
+
+func TestAnalyzeResponse(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
+		r := &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBuffer([]byte("{\"case_id\": 1234}"))),
+		}
+		resstr, reserr := analyzeResponse(r, nil)
+		require.NoError(t, reserr)
+		require.Equal(t,
+			"Your logs were successfully uploaded. For future reference, your internal case id is 1234",
+			resstr)
+	})
+
+	t.Run("error-from-server", func(t *testing.T) {
+		r := &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBuffer([]byte("{\"case_id\": 1234, \"error\": \"uhoh\"}"))),
+		}
+		resstr, reserr := analyzeResponse(r, nil)
+		require.Equal(t, errors.New("uhoh"), reserr)
+		require.Equal(t,
+			"An error occurred while uploading the flare: uhoh. Please contact support by email.",
+			resstr)
+	})
+
+	t.Run("unparseable-from-server", func(t *testing.T) {
+		r := &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBuffer([]byte("thats-not-json"))),
+		}
+		resstr, reserr := analyzeResponse(r, nil)
+		require.Equal(t,
+			errors.New("invalid character 'h' in literal true (expecting 'r')\n"+
+				"Server returned:\n"+
+				"thats-not-json"),
+			reserr)
+		require.Equal(t,
+			"Error: could not deserialize response body -- Please contact support by email.",
+			resstr)
+	})
+
+	t.Run("unparseable-from-server-huge", func(t *testing.T) {
+		resp := "uhoh"
+		for i := 0; i < 100; i++ {
+			resp += "\npad this out to be pretty long"
+		}
+		r := &http.Response{
+			StatusCode: 200,
+			Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(resp))),
+		}
+		resstr, reserr := analyzeResponse(r, nil)
+		require.Equal(t,
+			errors.New("invalid character 'u' looking for beginning of value\n"+
+				"Server returned:\n"+
+				resp[:150]),
+			reserr)
+		require.Equal(t,
+			"Error: could not deserialize response body -- Please contact support by email.",
+			resstr)
+	})
+
+	t.Run("forbidden-no-api-key", func(t *testing.T) {
+		config.Datadog.Set("api_key", "")
+		r := &http.Response{
+			StatusCode: 403,
+		}
+		resstr, reserr := analyzeResponse(r, nil)
+		require.Equal(t,
+			errors.New("HTTP 403 Forbidden: API key is missing"),
+			reserr)
+		require.Equal(t, "", resstr)
+	})
+
+	t.Run("forbidden-with-api-key", func(t *testing.T) {
+		config.Datadog.Set("api_key", "abcd123abcd12344abcd1234")
+		r := &http.Response{
+			StatusCode: 403,
+		}
+		resstr, reserr := analyzeResponse(r, nil)
+		require.Equal(t,
+			errors.New("HTTP 403 Forbidden: Make sure your API key is valid. API Key ending with: d1234"),
+			reserr)
+		require.Equal(t, "", resstr)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		r := &http.Response{}
+		resstr, reserr := analyzeResponse(r, errors.New("uhoh"))
+		require.Equal(t, errors.New("uhoh"), reserr)
+		require.Equal(t, "", resstr)
+	})
 }


### PR DESCRIPTION
### What does this PR do?

Checks the response code and content-type when posting a flare, and reports those appropriately to the user.

### Motivation

An issue where flare submission was broken, and the agent gave misleading / incomplete information about the issue.

### Describe how to test your changes

Send a flare.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
