### PR TITLE
[networks] Remove allocations from `NetIPFromAddress`

### DIFF
--- a/pkg/network/dns/snooper.go
+++ b/pkg/network/dns/snooper.go
@@ -165,7 +165,6 @@ func (s *socketFilterSnooper) processPacket(data []byte, ts time.Time) error {
 			atomic.AddInt64(&s.truncatedPkts, 1)
 		default:
 			atomic.AddInt64(&s.decodingErrors, 1)
-			log.Tracef("error decoding DNS payload: %v", err)
 		}
 		return nil
 	}

--- a/pkg/network/network_filter.go
+++ b/pkg/network/network_filter.go
@@ -5,7 +5,6 @@ import (
 	"net"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -149,12 +148,6 @@ func parsePortString(port string) (uint64, error) {
 	return p, nil
 }
 
-var ipBufferPool = sync.Pool{
-	New: func() interface{} {
-		return make([]byte, 16)
-	},
-}
-
 // IsExcludedConnection returns true if a given connection should be excluded
 // by the tracer based on user defined filters
 func IsExcludedConnection(scf []*ConnectionFilter, dcf []*ConnectionFilter, conn *ConnectionStats) bool {
@@ -163,8 +156,8 @@ func IsExcludedConnection(scf []*ConnectionFilter, dcf []*ConnectionFilter, conn
 		return false
 	}
 
-	buf := ipBufferPool.Get().([]byte)
-	defer ipBufferPool.Put(buf)
+	buf := util.IPBufferPool.Get().([]byte)
+	defer util.IPBufferPool.Put(buf)
 
 	if len(scf) > 0 && conn.Source != nil {
 		if findMatchingFilter(scf, util.NetIPFromAddress(conn.Source, buf), conn.SPort, conn.Type) {

--- a/pkg/network/tracer/gateway_lookup.go
+++ b/pkg/network/tracer/gateway_lookup.go
@@ -22,7 +22,6 @@ type gatewayLookup struct {
 	routeCache          network.RouteCache
 	subnetCache         *simplelru.LRU // interface index to subnet cache
 	subnetForHwAddrFunc func(net.HardwareAddr) (network.Subnet, error)
-	ipBuffer            []byte
 }
 
 type cloudProvider interface {
@@ -63,7 +62,6 @@ func newGatewayLookup(config *config.Config) *gatewayLookup {
 		subnetCache:         lru,
 		routeCache:          network.NewRouteCache(routeCacheSize, router),
 		subnetForHwAddrFunc: ec2SubnetForHardwareAddr,
-		ipBuffer:            make([]byte, 16),
 	}
 }
 
@@ -78,9 +76,11 @@ func (g *gatewayLookup) Lookup(cs *network.ConnectionStats) *network.Via {
 		return nil
 	}
 
+	buf := util.IPBufferPool.Get().([]byte)
+	defer util.IPBufferPool.Put(buf)
 	// if there is no gateway, we don't need to add subnet info
 	// for gateway resolution in the backend
-	if util.NetIPFromAddress(r.Gateway, g.ipBuffer).IsUnspecified() {
+	if util.NetIPFromAddress(r.Gateway, buf).IsUnspecified() {
 		return nil
 	}
 

--- a/pkg/process/util/address.go
+++ b/pkg/process/util/address.go
@@ -32,8 +32,24 @@ func AddressFromString(ip string) Address {
 }
 
 // NetIPFromAddress returns a net.IP from an Address
-func NetIPFromAddress(addr Address) net.IP {
-	return net.IP(addr.Bytes())
+func NetIPFromAddress(addr Address, buf []byte) net.IP {
+	var addrLen int
+	switch addr.(type) {
+	case v4Address:
+		addrLen = 4
+	case v6Address:
+		addrLen = 16
+	default:
+		return nil
+	}
+
+	if len(buf) < addrLen {
+		// if the function is misused we allocate
+		buf = make([]byte, addrLen)
+	}
+
+	n := addr.WriteTo(buf)
+	return net.IP(buf[:n])
 }
 
 // ToLowHigh converts an address into a pair of uint64 numbers

--- a/pkg/process/util/address.go
+++ b/pkg/process/util/address.go
@@ -3,6 +3,7 @@ package util
 import (
 	"encoding/binary"
 	"net"
+	"sync"
 )
 
 // Address is an IP abstraction that is family (v4/v6) agnostic
@@ -142,4 +143,11 @@ func (a v6Address) String() string {
 // IsLoopback returns true if this address is the loopback address
 func (a v6Address) IsLoopback() bool {
 	return net.IP(a[:]).IsLoopback()
+}
+
+// IPBufferPool is meant to be used in conjunction with `NetIPFromAddress`
+var IPBufferPool = sync.Pool{
+	New: func() interface{} {
+		return make([]byte, net.IPv6len)
+	},
 }


### PR DESCRIPTION
### What does this PR do?

* Remove allocations from `NetIPFromAddress` function
* Remove log function call from DNS hot path

Before:

```
goos: linux
goarch: amd64
pkg: github.com/DataDog/datadog-agent/pkg/process/util
BenchmarkNetIPFromAddress
BenchmarkNetIPFromAddress-4   	83140153	        13.3 ns/op	       4 B/op	       1 allocs/op
```

After:
```
goos: linux
goarch: amd64
pkg: github.com/DataDog/datadog-agent/pkg/process/util
BenchmarkNetIPFromAddress
BenchmarkNetIPFromAddress-4   	181735777	         6.96 ns/op	       0 B/op	       0 allocs/op
```

### Motivation

I came across a few memory profiles that had `NetIPFromAddress` accounting for ~%20 of the allocations and `log.Tracef` accounting for ~%14.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

QA already covered by unit tests.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
