### PR TITLE
Document the inventories metadata payload

### DIFF
--- a/pkg/metadata/common/common.go
+++ b/pkg/metadata/common/common.go
@@ -6,14 +6,8 @@
 package common
 
 import (
-	"strings"
-
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/version"
-)
-
-var (
-	apiKey string
 )
 
 // CachePrefix is the common root to use to prefix all the cache
@@ -26,16 +20,8 @@ func GetPayload(hostname string) *Payload {
 		// olivier: I _think_ `APIKey` is only a legacy field, and
 		// is not actually used by the backend
 		AgentVersion:     version.AgentVersion,
-		APIKey:           getAPIKey(),
+		APIKey:           config.SanitizeAPIKey(config.Datadog.GetString("api_key")),
 		UUID:             getUUID(),
 		InternalHostname: hostname,
 	}
-}
-
-func getAPIKey() string {
-	if apiKey == "" {
-		apiKey = strings.Split(config.Datadog.GetString("api_key"), ",")[0]
-	}
-
-	return config.SanitizeAPIKey(apiKey)
 }

--- a/pkg/metadata/common/common_test.go
+++ b/pkg/metadata/common/common_test.go
@@ -14,19 +14,11 @@ import (
 )
 
 func TestGetPayload(t *testing.T) {
-	apiKey = "foo"
+	mockConfig := config.Mock()
+	mockConfig.Set("api_key", "foo")
+
 	p := GetPayload("hostname")
 	assert.Equal(t, p.APIKey, "foo")
 	assert.Equal(t, p.AgentVersion, version.AgentVersion)
 	assert.Equal(t, p.InternalHostname, "hostname")
-	apiKey = ""
-}
-
-func TestGetAPIKey(t *testing.T) {
-	mockConfig := config.Mock()
-	mockConfig.Set("api_key", "bar,baz")
-	assert.Equal(t, "bar", getAPIKey())
-	assert.Equal(t, "bar", apiKey)
-	apiKey = "foo"
-	assert.Equal(t, "foo", getAPIKey())
 }

--- a/pkg/metadata/inventories/README.md
+++ b/pkg/metadata/inventories/README.md
@@ -1,0 +1,120 @@
+# Inventory Payload
+
+This package populates some of the agent-related fields in the `inventories` product in DataDog.
+
+This is enabled by default but can be turned off using `inventories_enabled` config.
+
+The payload is sent every 10min (see `inventories_max_interval` in the config) or whenever it's updated with at most 1
+update every 5 minutes (see `inventories_min_interval`).
+
+# Content
+
+The package offers 2 method to add data to the payload: `SetAgentMetadata` and `SetCheckMetadata`. As the name suggests,
+checks use `SetCheckMetadata` and each metadata is linked to a check ID. Everything agent-related uses the other one.
+
+Any part of the agent can add metadata to the inventory payload.
+
+## Check metadata
+
+`SetCheckMetadata` registers data per check instance. Metadata can include the check version, the version of the
+monitored software, ... It depends on each check.
+
+## Agent metadata
+
+`SetAgentMetadata` registers data about the agent itself.
+
+# Format
+
+The payload is a JSON dict with the following fields
+
+- `hostname` - **string**: the hostname of the agent as shown on the status page.
+- `timestamp` - **int**: the timestamp when the payload was created.
+- `check_metadata` - **dict of string to list**: dictionary with check names as keys; values are a list of the metadata for each
+  instance of that check.
+  Each instance is composed of:
+    - `last_updated` - **int**: timestamp of the last metadata update for this instance
+    - `config.hash` - **string**: the instance ID for this instance (as shown in the status page).
+    - `config.provider` - **string**: where the configuration came from for this instance (disk, docker labels, ...).
+    - Any other metadata registered by the instance (instance version, version of the software monitored, ...).
+- `agent_metadata` - **dict of string to JSON type**:
+  - `cloud_provider` - **string**: the name of the cloud provider detected by the Agent (omitted if no cloud is detected).
+  - `hostname_source` - **string**: the source for the agent hostname (see pkg/util/hostname.go:GetHostnameData).
+
+## Example Payload
+
+Here an example of an inventory payload:
+
+```
+{
+    "agent_metadata": {
+        "hostname_source": "os"
+    },
+    "check_metadata": {
+        "cpu": [
+            {
+                "config.hash": "cpu",
+                "config.provider": "file",
+                "last_updated": 1631281744506400319
+            }
+        ],
+        "disk": [
+            {
+                "config.hash": "disk:e5dffb8bef24336f",
+                "config.provider": "file",
+                "last_updated": 1631281744506400319
+            }
+        ],
+        "file_handle": [
+            {
+                "config.hash": "file_handle",
+                "config.provider": "file",
+                "last_updated": 1631281744506400319
+            }
+        ],
+        "io": [
+            {
+                "config.hash": "io",
+                "config.provider": "file",
+                "last_updated": 1631281744506400319
+            }
+        ],
+        "load": [
+            {
+                "config.hash": "load",
+                "config.provider": "file",
+                "last_updated": 1631281744506400319
+            }
+        ],
+        "memory": [
+            {
+                "config.hash": "memory",
+                "config.provider": "file",
+                "last_updated": 1631281744506400319
+            }
+        ],
+        "network": [
+            {
+                "config.hash": "network:d884b5186b651429",
+                "config.provider": "file",
+                "last_updated": 1631281744506400319
+            }
+        ],
+        "ntp": [
+            {
+                "config.hash": "ntp:d884b5186b651429",
+                "config.provider": "file",
+                "last_updated": 1631281744506400319
+            }
+        ],
+        "uptime": [
+            {
+                "config.hash": "uptime",
+                "config.provider": "file",
+                "last_updated": 1631281744506400319
+            }
+        ]
+    },
+    "hostname": "my-host",
+    "timestamp": 1631281754507358895
+}
+```

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -58,6 +58,9 @@ const (
 	// CloudProviderMetatadaName is the field name to use to set the cloud
 	// provider name in the agent metadata.
 	CloudProviderMetatadaName = "cloud_provider"
+	// HostnameSourceMetadataName is the field name to use to set the hostname
+	// source in the agent metadata.
+	HostnameSourceMetadataName = "hostname_source"
 )
 
 // SetAgentMetadata updates the agent metadata value in the cache

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -65,7 +65,7 @@ func Fqdn(hostname string) string {
 
 func setHostnameProvider(name string) {
 	hostnameProvider.Set(name)
-	inventories.SetAgentMetadata("hostname_source", name)
+	inventories.SetAgentMetadata(inventories.HostnameSourceMetadataName, name)
 }
 
 // isOSHostnameUsable returns `false` if it has the certainty that the agent is running


### PR DESCRIPTION
### What does this PR do?

This PR adds documentation about the inventories payload as well as some cleanup about old logic.

### Motivation

The documentation will be the base for new feature. 

### Describe how to test your changes

The inventory payload should not change, just check it's the same as before.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
