### PR TITLE
[network] Use explicit relative paths instead of PWD

### DIFF
--- a/pkg/network/tracer/compile.go
+++ b/pkg/network/tracer/compile.go
@@ -7,8 +7,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 )
 
-//go:generate go run $PWD/pkg/ebpf/include_headers.go $PWD/pkg/network/ebpf/c/runtime/conntrack.c $PWD/pkg/ebpf/bytecode/build/runtime/conntrack.c $PWD/pkg/ebpf/c $PWD/pkg/network/ebpf/c/runtime $PWD/pkg/network/ebpf/c
-//go:generate go run $PWD/pkg/ebpf/bytecode/runtime/integrity.go $PWD/pkg/ebpf/bytecode/build/runtime/conntrack.c $PWD/pkg/ebpf/bytecode/runtime/conntrack.go runtime
+//go:generate go run ../../../pkg/ebpf/include_headers.go ../../../pkg/network/ebpf/c/runtime/conntrack.c ../../../pkg/ebpf/bytecode/build/runtime/conntrack.c ../../../pkg/ebpf/c ../../../pkg/network/ebpf/c/runtime ../../../pkg/network/ebpf/c
+//go:generate go run ../../../pkg/ebpf/bytecode/runtime/integrity.go ../../../pkg/ebpf/bytecode/build/runtime/conntrack.c ../../../pkg/ebpf/bytecode/runtime/conntrack.go runtime
 
 func getRuntimeCompiledConntracker(config *config.Config) (runtime.CompiledOutput, error) {
 	return runtime.Conntrack.Compile(&config.Config, getCFlags(config))

--- a/pkg/network/tracer/connection/kprobe/compile.go
+++ b/pkg/network/tracer/connection/kprobe/compile.go
@@ -7,8 +7,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 )
 
-//go:generate go run $PWD/pkg/ebpf/include_headers.go $PWD/pkg/network/ebpf/c/runtime/tracer.c $PWD/pkg/ebpf/bytecode/build/runtime/tracer.c $PWD/pkg/ebpf/c $PWD/pkg/network/ebpf/c/runtime $PWD/pkg/network/ebpf/c
-//go:generate go run $PWD/pkg/ebpf/bytecode/runtime/integrity.go $PWD/pkg/ebpf/bytecode/build/runtime/tracer.c $PWD/pkg/ebpf/bytecode/runtime/tracer.go runtime
+//go:generate go run ../../../../../pkg/ebpf/include_headers.go ../../../../../pkg/network/ebpf/c/runtime/tracer.c ../../../../../pkg/ebpf/bytecode/build/runtime/tracer.c ../../../../../pkg/ebpf/c ../../../../../pkg/network/ebpf/c/runtime ../../../../../pkg/network/ebpf/c
+//go:generate go run ../../../../../pkg/ebpf/bytecode/runtime/integrity.go ../../../../../pkg/ebpf/bytecode/build/runtime/tracer.c ../../../../../pkg/ebpf/bytecode/runtime/tracer.go runtime
 
 func getRuntimeCompiledTracer(config *config.Config) (runtime.CompiledOutput, error) {
 	return runtime.Tracer.Compile(&config.Config, getCFlags(config))


### PR DESCRIPTION
### What does this PR do?

This PR replaces all the PWD of the network tracer compilation files.

### Motivation

Starting with go 1.17, using "$PWD" in a "go generate" command will no longer resolve into the current directory, but will resolve into the directory containing the generator file. With this PR, system-probe can be compiled with go 1.17 again.

### Describe how to test your changes

Build system-probe with go 1.17.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
