### PR TITLE
Refactor agent inventory metadata property list

### DIFF
--- a/pkg/metadata/inventories/README.md
+++ b/pkg/metadata/inventories/README.md
@@ -36,6 +36,7 @@ The payload is a JSON dict with the following fields
     - `config.hash` - **string**: the instance ID for this instance (as shown in the status page).
     - `config.provider` - **string**: where the configuration came from for this instance (disk, docker labels, ...).
     - Any other metadata registered by the instance (instance version, version of the software monitored, ...).
+<!-- NOTE: when modifying this list, please also update the constants in `inventories.go` -->
 - `agent_metadata` - **dict of string to JSON type**:
   - `cloud_provider` - **string**: the name of the cloud provider detected by the Agent (omitted if no cloud is detected).
   - `hostname_source` - **string**: the source for the agent hostname (see pkg/util/hostname.go:GetHostnameData).

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -54,22 +54,23 @@ var (
 	timeSince = time.Since
 )
 
+type AgentMetadataName string
+
+// Constants for the metadata names; these are defined in
+// pkg/metadata/inventories/README.md and any additions should
+// be updated there as well.
 const (
-	// CloudProviderMetatadaName is the field name to use to set the cloud
-	// provider name in the agent metadata.
-	CloudProviderMetatadaName = "cloud_provider"
-	// HostnameSourceMetadataName is the field name to use to set the hostname
-	// source in the agent metadata.
-	HostnameSourceMetadataName = "hostname_source"
+	AgentCloudProvider  AgentMetadataName = "cloud_provider"
+	AgentHostnameSource                   = "hostname_source"
 )
 
 // SetAgentMetadata updates the agent metadata value in the cache
-func SetAgentMetadata(name string, value interface{}) {
+func SetAgentMetadata(name AgentMetadataName, value interface{}) {
 	agentCacheMutex.Lock()
 	defer agentCacheMutex.Unlock()
 
-	if agentMetadataCache[name] != value {
-		agentMetadataCache[name] = value
+	if agentMetadataCache[string(name)] != value {
+		agentMetadataCache[string(name)] = value
 
 		select {
 		case metadataUpdatedC <- nil:

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -54,6 +54,8 @@ var (
 	timeSince = time.Since
 )
 
+// AgentMetadataName is an enum type containing all defined keys for
+// SetAgentMetadata.
 type AgentMetadataName string
 
 // Constants for the metadata names; these are defined in

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -63,7 +63,7 @@ type AgentMetadataName string
 // be updated there as well.
 const (
 	AgentCloudProvider  AgentMetadataName = "cloud_provider"
-	AgentHostnameSource                   = "hostname_source"
+	AgentHostnameSource AgentMetadataName = "hostname_source"
 )
 
 // SetAgentMetadata updates the agent metadata value in the cache

--- a/pkg/metadata/inventories/inventories_test.go
+++ b/pkg/metadata/inventories/inventories_test.go
@@ -19,12 +19,12 @@ import (
 )
 
 func clearMetadata() {
-	checkCacheMutex.Lock()
-	defer checkCacheMutex.Unlock()
-	checkMetadataCache = make(map[string]*checkMetadataCacheEntry)
-	agentCacheMutex.Lock()
-	defer agentCacheMutex.Unlock()
-	agentMetadataCache = make(AgentMetadata)
+	checkMetadataMutex.Lock()
+	defer checkMetadataMutex.Unlock()
+	checkMetadata = make(map[string]*checkMetadataCacheEntry)
+	agentMetadataMutex.Lock()
+	defer agentMetadataMutex.Unlock()
+	agentMetadata = make(AgentMetadata)
 
 	// purge metadataUpdatedC
 L:
@@ -269,7 +269,7 @@ func Test_createCheckInstanceMetadata_returnsNewMetadata(t *testing.T) {
 		metadataKey    = "a-metadata-key"
 	)
 
-	checkMetadataCache[checkID] = &checkMetadataCacheEntry{
+	checkMetadata[checkID] = &checkMetadataCacheEntry{
 		CheckInstanceMetadata: CheckInstanceMetadata{
 			metadataKey: "a-metadata-value",
 		},
@@ -278,5 +278,5 @@ func Test_createCheckInstanceMetadata_returnsNewMetadata(t *testing.T) {
 	md := createCheckInstanceMetadata(checkID, configProvider)
 	(*md)[metadataKey] = "a-different-metadata-value"
 
-	assert.NotEqual(t, checkMetadataCache[checkID].CheckInstanceMetadata[metadataKey], (*md)[metadataKey])
+	assert.NotEqual(t, checkMetadata[checkID].CheckInstanceMetadata[metadataKey], (*md)[metadataKey])
 }

--- a/pkg/util/cloudprovider.go
+++ b/pkg/util/cloudprovider.go
@@ -48,7 +48,7 @@ func DetectCloudProvider(ctx context.Context) {
 
 	for _, cloudDetector := range detectors {
 		if cloudDetector.callback(ctx) {
-			inventories.SetAgentMetadata(inventories.CloudProviderMetatadaName, cloudDetector.name)
+			inventories.SetAgentMetadata(inventories.AgentCloudProvider, cloudDetector.name)
 			log.Infof("Cloud provider %s detected", cloudDetector.name)
 			return
 		}

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -65,7 +65,7 @@ func Fqdn(hostname string) string {
 
 func setHostnameProvider(name string) {
 	hostnameProvider.Set(name)
-	inventories.SetAgentMetadata(inventories.HostnameSourceMetadataName, name)
+	inventories.SetAgentMetadata(inventories.AgentHostnameSource, name)
 }
 
 // isOSHostnameUsable returns `false` if it has the certainty that the agent is running


### PR DESCRIPTION
This puts the names of all of the agent inventory metadata keys in one place, where they can be consistently documented, and enforces them with a runtime panic.

### Describe how to test your changes

nothing specific to this PR
