### PR TITLE
[networks] Re-use same IP strings during encoding

### DIFF
--- a/pkg/network/encoding/encoding.go
+++ b/pkg/network/encoding/encoding.go
@@ -55,6 +55,7 @@ func modelConnections(conns *network.Connections) *model.Connections {
 	routeIndex := make(map[string]RouteIdx)
 	httpIndex := FormatHTTPStats(conns.HTTP)
 	httpMatches := make(map[http.Key]struct{}, len(httpIndex))
+	ipc := make(ipCache, len(conns.Conns)/2)
 
 	dnsWithQueryType := config.Datadog.GetBool("network_config.enable_dns_by_querytype")
 
@@ -65,7 +66,7 @@ func modelConnections(conns *network.Connections) *model.Connections {
 			httpMatches[httpKey] = struct{}{}
 		}
 
-		agentConns[i] = FormatConnection(conn, domainSet, routeIndex, httpAggregations, dnsWithQueryType)
+		agentConns[i] = FormatConnection(conn, domainSet, routeIndex, httpAggregations, dnsWithQueryType, ipc)
 	}
 
 	if orphans := len(httpIndex) - len(httpMatches); orphans > 0 {
@@ -88,7 +89,7 @@ func modelConnections(conns *network.Connections) *model.Connections {
 	payload := connsPool.Get().(*model.Connections)
 	payload.Conns = agentConns
 	payload.Domains = domains
-	payload.Dns = FormatDNS(conns.DNS)
+	payload.Dns = FormatDNS(conns.DNS, ipc)
 	payload.ConnTelemetry = FormatConnTelemetry(conns.ConnTelemetry)
 	payload.CompilationTelemetryByAsset = FormatCompilationTelemetry(conns.CompilationTelemetryByAsset)
 	payload.Routes = routes

--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -33,12 +33,31 @@ type RouteIdx struct {
 	Route model.Route
 }
 
+type ipCache map[util.Address]string
+
+func (ipc ipCache) Get(addr util.Address) string {
+	if v, ok := ipc[addr]; ok {
+		return v
+	}
+
+	v := addr.String()
+	ipc[addr] = v
+	return v
+}
+
 // FormatConnection converts a ConnectionStats into an model.Connection
-func FormatConnection(conn network.ConnectionStats, domainSet map[string]int, routes map[string]RouteIdx, httpStats *model.HTTPAggregations, dnsWithQueryType bool) *model.Connection {
+func FormatConnection(
+	conn network.ConnectionStats,
+	domainSet map[string]int,
+	routes map[string]RouteIdx,
+	httpStats *model.HTTPAggregations,
+	dnsWithQueryType bool,
+	ipc ipCache,
+) *model.Connection {
 	c := connPool.Get().(*model.Connection)
 	c.Pid = int32(conn.Pid)
-	c.Laddr = formatAddr(conn.Source, conn.SPort)
-	c.Raddr = formatAddr(conn.Dest, conn.DPort)
+	c.Laddr = formatAddr(conn.Source, conn.SPort, ipc)
+	c.Raddr = formatAddr(conn.Dest, conn.DPort, ipc)
 	c.Family = formatFamily(conn.Family)
 	c.Type = formatType(conn.Type)
 	c.IsLocalPortEphemeral = formatEphemeralType(conn.SPortIsEphemeral)
@@ -51,7 +70,7 @@ func FormatConnection(conn network.ConnectionStats, domainSet map[string]int, ro
 	c.Direction = formatDirection(conn.Direction)
 	c.NetNS = conn.NetNS
 	c.RemoteNetworkId = ""
-	c.IpTranslation = formatIPTranslation(conn.IPTranslation)
+	c.IpTranslation = formatIPTranslation(conn.IPTranslation, ipc)
 	c.Rtt = conn.RTT
 	c.RttVar = conn.RTTVar
 	c.IntraHost = conn.IntraHost
@@ -88,7 +107,7 @@ var dnsPool = sync.Pool{
 }
 
 // FormatDNS converts a map[util.Address][]string to a map using IPs string representation
-func FormatDNS(dns map[util.Address][]string) map[string]*model.DNSEntry {
+func FormatDNS(dns map[util.Address][]string, ipc ipCache) map[string]*model.DNSEntry {
 	if dns == nil {
 		return nil
 	}
@@ -97,7 +116,7 @@ func FormatDNS(dns map[util.Address][]string) map[string]*model.DNSEntry {
 	for addr, names := range dns {
 		entry := dnsPool.Get().(*model.DNSEntry)
 		entry.Names = names
-		ipToNames[addr.String()] = entry
+		ipToNames[ipc.Get(addr)] = entry
 	}
 
 	return ipToNames
@@ -231,12 +250,12 @@ func returnToPool(c *model.Connections) {
 	connsPool.Put(c)
 }
 
-func formatAddr(addr util.Address, port uint16) *model.Addr {
+func formatAddr(addr util.Address, port uint16, ipc ipCache) *model.Addr {
 	if addr == nil {
 		return nil
 	}
 
-	return &model.Addr{Ip: addr.String(), Port: int32(port)}
+	return &model.Addr{Ip: ipc.Get(addr), Port: int32(port)}
 }
 
 func formatFamily(f network.ConnectionFamily) model.ConnectionFamily {
@@ -344,14 +363,14 @@ func formatDNSStatsByDomain(stats map[*intern.Value]map[dns.QueryType]dns.Stats,
 	return m
 }
 
-func formatIPTranslation(ct *network.IPTranslation) *model.IPTranslation {
+func formatIPTranslation(ct *network.IPTranslation, ipc ipCache) *model.IPTranslation {
 	if ct == nil {
 		return nil
 	}
 
 	return &model.IPTranslation{
-		ReplSrcIP:   ct.ReplSrcIP.String(),
-		ReplDstIP:   ct.ReplDstIP.String(),
+		ReplSrcIP:   ipc.Get(ct.ReplSrcIP),
+		ReplDstIP:   ipc.Get(ct.ReplDstIP),
 		ReplSrcPort: int32(ct.ReplSrcPort),
 		ReplDstPort: int32(ct.ReplDstPort),
 	}


### PR DESCRIPTION
### What does this PR do?

Re-use IP strings during payload encoding.

### Motivation

I noticed that IP allocations during encoding are accounting for nearly ~11%  of the global allocations (on our load testing cluster). This PR brings it down to ~4% by caching IP strings. This is based on the observation that many of the IPs appear several times (especially the source ones).

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

QA not necessary

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
