### PR TITLE
[security] allow provisioning auth token via an env var

### DIFF
--- a/pkg/api/security/security.go
+++ b/pkg/api/security/security.go
@@ -132,9 +132,14 @@ func fetchAuthToken(tokenCreationAllowed bool) (string, error) {
 	// Create a new token if it doesn't exist and if permitted by calling func
 	if _, e := os.Stat(authTokenFile); os.IsNotExist(e) && tokenCreationAllowed {
 		key := make([]byte, authTokenMinimalLen)
-		_, e = rand.Read(key)
-		if e != nil {
-			return "", fmt.Errorf("can't create agent authentication token value: %s", e)
+
+		if len([]byte(config.Datadog.GetString("auth_token"))) >= authTokenMinimalLen {
+			copy(key, []byte(config.Datadog.GetString("auth_token")))
+		} else {
+			_, e = rand.Read(key)
+			if e != nil {
+				return "", fmt.Errorf("can't create agent authentication token value: %s", e)
+			}
 		}
 
 		// Write the auth token to the auth token file (platform-specific)

--- a/pkg/api/security/security_test.go
+++ b/pkg/api/security/security_test.go
@@ -84,7 +84,7 @@ func TestFetchAuthTokenFromEnv(t *testing.T) {
 	os.Setenv(tokenEnvVar, tokenValue)
 	defer os.Unsetenv(tokenEnvVar)
 
-	sourceToken := string(hex.EncodeToString([]byte(tokenValue[:authTokenMinimalLen])))
+	sourceToken := hex.EncodeToString([]byte(tokenValue[:authTokenMinimalLen]))
 
 	newToken, err := CreateOrFetchToken()
 	require.Nil(t, err, fmt.Sprintf("%v", err))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -212,6 +212,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("enable_metadata_collection", true)
 	config.BindEnvAndSetDefault("enable_gohai", true)
 	config.BindEnvAndSetDefault("check_runners", int64(4))
+	config.BindEnvAndSetDefault("auth_token", "")
 	config.BindEnvAndSetDefault("auth_token_file_path", "")
 	config.BindEnv("bind_host")
 	config.BindEnvAndSetDefault("ipc_address", "localhost")


### PR DESCRIPTION
### What does this PR do?

This feature simply allows us to set the token (pre hex-encoding) via an environment variable. This feature can prove useful for certain settings where a shared secrets is preferable to a mount of `/etc/datadog-agent/auth_token`. Only very specific scenarios would require of this feature.

### Motivation

Simplifies deployment of benchmark scenarios.

### Additional Notes

The environment variable provided is truncated, so only the first 32 bytes are relevant when creating the auth token. Please keep this in mind.

### Describe how to test your changes

TODO

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
