### PR TITLE
[runtime-security] Do not load eRPC programs when eRPC resolution is disabled

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "dc077dcaf4df5816ca715f02a719002ddea515c4c4216c48a417dff6a0ee63dd")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "69f38781e7f63db8d59d43c0f20c1fc57acad6081dea1ef33cdfa1a9681736db")

--- a/pkg/security/ebpf/c/dentry_resolver.h
+++ b/pkg/security/ebpf/c/dentry_resolver.h
@@ -78,13 +78,15 @@ struct bpf_map_def SEC("maps/dentry_resolver_tracepoint_callbacks") dentry_resol
 #define DR_TRACEPOINT 2
 
 #define DR_ERPC_KEY                        0
-#define DR_KPROBE_DENTRY_RESOLVER_KERN_KEY 1
+#define DR_ERPC_PARENT_KEY                 1
+#define DR_ERPC_SEGMENT_KEY                2
+#define DR_KPROBE_DENTRY_RESOLVER_KERN_KEY 3
 
 struct bpf_map_def SEC("maps/dentry_resolver_kprobe_progs") dentry_resolver_kprobe_progs = {
     .type = BPF_MAP_TYPE_PROG_ARRAY,
     .key_size = sizeof(u32),
     .value_size = sizeof(u32),
-    .max_entries = 2,
+    .max_entries = 4,
 };
 
 #define DR_TRACEPOINT_DENTRY_RESOLVER_KERN_KEY 0
@@ -252,6 +254,53 @@ struct bpf_map_def SEC("maps/dr_erpc_stats_bb") dr_erpc_stats_bb = {
     .namespace = "",
 };
 
+int __attribute__((always_inline)) monitor_resolution_err(u32 resolution_err) {
+    if (resolution_err > 0) {
+        struct bpf_map_def *erpc_stats = select_buffer(&dr_erpc_stats_fb, &dr_erpc_stats_bb, ERPC_MONITOR_KEY);
+        if (erpc_stats == NULL) {
+            return 0;
+        }
+
+        struct dr_erpc_stats_t *stats = bpf_map_lookup_elem(erpc_stats, &resolution_err);
+        if (stats == NULL) {
+            return 0;
+        }
+        __sync_fetch_and_add(&stats->count, 1);
+    }
+    return 0;
+}
+
+u32 __attribute__((always_inline)) parse_erpc_request(struct dr_erpc_state_t *state, void *data) {
+    u32 err = 0;
+    int ret = bpf_probe_read(&state->key, sizeof(state->key), data);
+    if (ret < 0) {
+        err = DR_ERPC_READ_PAGE_FAULT;
+        goto exit;
+    }
+    ret = bpf_probe_read(&state->userspace_buffer, sizeof(state->userspace_buffer), data + sizeof(state->key));
+    if (ret < 0) {
+        err = DR_ERPC_READ_PAGE_FAULT;
+        goto exit;
+    }
+    ret = bpf_probe_read(&state->buffer_size, sizeof(state->buffer_size), data + sizeof(state->key) + sizeof(state->userspace_buffer));
+    if (ret < 0) {
+        err = DR_ERPC_READ_PAGE_FAULT;
+        goto exit;
+    }
+    ret = bpf_probe_read(&state->challenge, sizeof(state->challenge), data + sizeof(state->key) + sizeof(state->userspace_buffer) + sizeof(state->buffer_size));
+    if (ret < 0) {
+        err = DR_ERPC_READ_PAGE_FAULT;
+        goto exit;
+    }
+
+    state->iteration = 0;
+    state->ret = 0;
+    state->cursor = 0;
+
+exit:
+    return err;
+}
+
 SEC("kprobe/dentry_resolver_erpc")
 int kprobe__dentry_resolver_erpc(struct pt_regs *ctx) {
     u32 key = 0;
@@ -321,211 +370,108 @@ int kprobe__dentry_resolver_erpc(struct pt_regs *ctx) {
     }
 
 exit:
-    if (resolution_err > 0) {
-        struct bpf_map_def *erpc_stats = select_buffer(&dr_erpc_stats_fb, &dr_erpc_stats_bb, ERPC_MONITOR_KEY);
-        if (erpc_stats == NULL) {
-            return 0;
-        }
-
-        struct dr_erpc_stats_t *stats = bpf_map_lookup_elem(erpc_stats, &resolution_err);
-        if (stats == NULL) {
-            return 0;
-        }
-        __sync_fetch_and_add(&stats->count, 1);
-    }
+    monitor_resolution_err(resolution_err);
     return 0;
 }
 
-int __attribute__((always_inline)) handle_resolve_path(struct pt_regs* ctx, void *data) {
+SEC("kprobe/dentry_resolver_segment_erpc")
+int kprobe__dentry_resolver_segment_erpc(struct pt_regs *ctx) {
     u32 key = 0;
-    u32 err = 0;
+    u32 resolution_err = 0;
     struct dr_erpc_state_t *state = bpf_map_lookup_elem(&dr_erpc_state, &key);
     if (state == NULL) {
         return 0;
     }
 
-    int ret = bpf_probe_read(&state->key, sizeof(state->key), data);
-    if (ret < 0) {
-        err = DR_ERPC_READ_PAGE_FAULT;
-        goto error;
-    }
-    ret = bpf_probe_read(&state->userspace_buffer, sizeof(state->userspace_buffer), data + sizeof(state->key));
-    if (ret < 0) {
-        err = DR_ERPC_READ_PAGE_FAULT;
-        goto error;
-    }
-    ret = bpf_probe_read(&state->buffer_size, sizeof(state->buffer_size), data + sizeof(state->key) + sizeof(state->userspace_buffer));
-    if (ret < 0) {
-        err = DR_ERPC_READ_PAGE_FAULT;
-        goto error;
-    }
-    ret = bpf_probe_read(&state->challenge, sizeof(state->challenge), data + sizeof(state->key) + sizeof(state->userspace_buffer) + sizeof(state->buffer_size));
-    if (ret < 0) {
-        err = DR_ERPC_READ_PAGE_FAULT;
-        goto error;
-    }
-
-    state->iteration = 0;
-    state->ret = 0;
-    state->cursor = 0;
-
-    bpf_tail_call(ctx, &dentry_resolver_kprobe_progs, DR_ERPC_KEY);
-
-error:
-    if (err > 0) {
-        struct bpf_map_def *erpc_stats = select_buffer(&dr_erpc_stats_fb, &dr_erpc_stats_bb, ERPC_MONITOR_KEY);
-        if (erpc_stats == NULL) {
-            return 0;
-        }
-
-        struct dr_erpc_stats_t *stats = bpf_map_lookup_elem(erpc_stats, &err);
-        if (stats == NULL) {
-            return 0;
-        }
-        __sync_fetch_and_add(&stats->count, 1);
-    }
-    return 0;
-}
-
-int __attribute__((always_inline)) handle_resolve_segment(void *data) {
-    struct path_key_t key = {};
-    char *userspace_buffer = 0;
-    u32 buffer_size = 0;
-    u32 resolution_err = 0;
-    u32 challenge = 0;
-
-    int ret = bpf_probe_read(&key, sizeof(key), data);
-    if (ret < 0) {
-        resolution_err = DR_ERPC_READ_PAGE_FAULT;
-        goto exit;
-    }
-    ret = bpf_probe_read(&userspace_buffer, sizeof(userspace_buffer), data + sizeof(key));
-    if (ret < 0) {
-        resolution_err = DR_ERPC_READ_PAGE_FAULT;
-        goto exit;
-    }
-    ret = bpf_probe_read(&buffer_size, sizeof(buffer_size), data + sizeof(key) + sizeof(userspace_buffer));
-    if (ret < 0) {
-        resolution_err = DR_ERPC_READ_PAGE_FAULT;
-        goto exit;
-    }
-    ret = bpf_probe_read(&challenge, sizeof(challenge), data + sizeof(key) + sizeof(userspace_buffer) + sizeof(buffer_size));
-    if (ret < 0) {
-        resolution_err = DR_ERPC_READ_PAGE_FAULT;
-        goto exit;
-    }
-
     // resolve segment and write in buffer
-    struct path_leaf_t *map_value = bpf_map_lookup_elem(&pathnames, &key);
+    struct path_leaf_t *map_value = bpf_map_lookup_elem(&pathnames, &state->key);
     if (map_value == NULL) {
         resolution_err = DR_ERPC_CACHE_MISS;
         goto exit;
     }
 
-    if (map_value->len + sizeof(key) > buffer_size) {
+    if (map_value->len + sizeof(key) > state->buffer_size) {
         // make sure we do not write outside of the provided buffer
         resolution_err = DR_ERPC_BUFFER_SIZE;
         goto exit;
     }
 
-    ret = bpf_probe_write_user((void *) userspace_buffer, &key, sizeof(key));
+    int ret = bpf_probe_write_user((void *) state->userspace_buffer, &state->key, sizeof(state->key));
     if (ret < 0) {
         resolution_err = ret == -14 ? DR_ERPC_WRITE_PAGE_FAULT : DR_ERPC_UNKNOWN_ERROR;
         goto exit;
     }
-    ret = bpf_probe_write_user((void *) userspace_buffer + offsetof(struct path_key_t, path_id), &challenge, sizeof(challenge));
+    ret = bpf_probe_write_user((void *) state->userspace_buffer + offsetof(struct path_key_t, path_id), &state->challenge, sizeof(state->challenge));
     if (ret < 0) {
         resolution_err = ret == -14 ? DR_ERPC_WRITE_PAGE_FAULT : DR_ERPC_UNKNOWN_ERROR;
         goto exit;
     }
 
-    ret = bpf_probe_write_user((void *) userspace_buffer + sizeof(key), map_value->name, DR_MAX_SEGMENT_LENGTH + 1);
+    ret = bpf_probe_write_user((void *) state->userspace_buffer + sizeof(state->key), map_value->name, DR_MAX_SEGMENT_LENGTH + 1);
     if (ret < 0) {
         resolution_err = ret == -14 ? DR_ERPC_WRITE_PAGE_FAULT : DR_ERPC_UNKNOWN_ERROR;
         goto exit;
     }
 
 exit:
-    if (resolution_err > 0) {
-        struct bpf_map_def *erpc_stats = select_buffer(&dr_erpc_stats_fb, &dr_erpc_stats_bb, ERPC_MONITOR_KEY);
-        if (erpc_stats == NULL) {
-            return 0;
-        }
-
-        struct dr_erpc_stats_t *stats = bpf_map_lookup_elem(erpc_stats, &resolution_err);
-        if (stats == NULL) {
-            return 0;
-        }
-        __sync_fetch_and_add(&stats->count, 1);
-    }
+    monitor_resolution_err(resolution_err);
     return 0;
 }
 
-int __attribute__((always_inline)) handle_resolve_parent(void *data) {
-    struct path_key_t key = {};
-    char *userspace_buffer = 0;
-    u32 buffer_size = 0;
+SEC("kprobe/dentry_resolver_parent_erpc")
+int kprobe__dentry_resolver_parent_erpc(struct pt_regs *ctx) {
+    u32 key = 0;
     u32 resolution_err = 0;
-    u32 challenge = 0;
-
-    int ret = bpf_probe_read(&key, sizeof(key), data);
-    if (ret < 0) {
-        resolution_err = DR_ERPC_READ_PAGE_FAULT;
-        goto exit;
-    }
-    ret = bpf_probe_read(&userspace_buffer, sizeof(userspace_buffer), data + sizeof(key));
-    if (ret < 0) {
-        resolution_err = DR_ERPC_READ_PAGE_FAULT;
-        goto exit;
-    }
-    ret = bpf_probe_read(&buffer_size, sizeof(buffer_size), data + sizeof(key) + sizeof(userspace_buffer));
-    if (ret < 0) {
-        resolution_err = DR_ERPC_READ_PAGE_FAULT;
-        goto exit;
-    }
-    ret = bpf_probe_read(&challenge, sizeof(challenge), data + sizeof(key) + sizeof(userspace_buffer) + sizeof(buffer_size));
-    if (ret < 0) {
-        resolution_err = DR_ERPC_READ_PAGE_FAULT;
-        goto exit;
+    struct dr_erpc_state_t *state = bpf_map_lookup_elem(&dr_erpc_state, &key);
+    if (state == NULL) {
+        return 0;
     }
 
     // resolve segment and write in buffer
-    struct path_leaf_t *map_value = bpf_map_lookup_elem(&pathnames, &key);
+    struct path_leaf_t *map_value = bpf_map_lookup_elem(&pathnames, &state->key);
     if (map_value == NULL) {
         resolution_err = DR_ERPC_CACHE_MISS;
         goto exit;
     }
 
-    if (sizeof(map_value->parent) > buffer_size) {
+    if (sizeof(map_value->parent) > state->buffer_size) {
         // make sure we do not write outside of the provided buffer
         resolution_err = DR_ERPC_BUFFER_SIZE;
         goto exit;
     }
 
-    ret = bpf_probe_write_user((void *) userspace_buffer, &map_value->parent, sizeof(map_value->parent));
+    int ret = bpf_probe_write_user((void *) state->userspace_buffer, &map_value->parent, sizeof(map_value->parent));
     if (ret < 0) {
         resolution_err = ret == -14 ? DR_ERPC_WRITE_PAGE_FAULT : DR_ERPC_UNKNOWN_ERROR;
         goto exit;
     }
-    ret = bpf_probe_write_user((void *) userspace_buffer + offsetof(struct path_key_t, path_id), &challenge, sizeof(challenge));
+    ret = bpf_probe_write_user((void *) state->userspace_buffer + offsetof(struct path_key_t, path_id), &state->challenge, sizeof(state->challenge));
     if (ret < 0) {
         resolution_err = ret == -14 ? DR_ERPC_WRITE_PAGE_FAULT : DR_ERPC_UNKNOWN_ERROR;
         goto exit;
     }
 
 exit:
-    if (resolution_err > 0) {
-        struct bpf_map_def *erpc_stats = select_buffer(&dr_erpc_stats_fb, &dr_erpc_stats_bb, ERPC_MONITOR_KEY);
-        if (erpc_stats == NULL) {
-            return 0;
-        }
+    monitor_resolution_err(resolution_err);
+    return 0;
+}
 
-        struct dr_erpc_stats_t *stats = bpf_map_lookup_elem(erpc_stats, &resolution_err);
-        if (stats == NULL) {
-            return 0;
-        }
-        __sync_fetch_and_add(&stats->count, 1);
+int __attribute__((always_inline)) handle_dr_request(struct pt_regs *ctx, void *data, u32 dr_erpc_key) {
+    u32 key = 0;
+    struct dr_erpc_state_t *state = bpf_map_lookup_elem(&dr_erpc_state, &key);
+    if (state == NULL) {
+        return 0;
     }
+
+    u32 resolution_err = parse_erpc_request(state, data);
+    if (resolution_err > 0) {
+        goto exit;
+    }
+
+    bpf_tail_call(ctx, &dentry_resolver_kprobe_progs, dr_erpc_key);
+
+exit:
+    monitor_resolution_err(resolution_err);
     return 0;
 }
 

--- a/pkg/security/ebpf/c/erpc.h
+++ b/pkg/security/ebpf/c/erpc.h
@@ -116,11 +116,11 @@ int __attribute__((always_inline)) handle_erpc_request(struct pt_regs *ctx) {
 
     switch (op) {
         case RESOLVE_SEGMENT_OP:
-            return handle_resolve_segment(data);
+            return handle_dr_request(ctx, data, DR_ERPC_SEGMENT_KEY);
         case RESOLVE_PATH_OP:
-            return handle_resolve_path(ctx, data);
+            return handle_dr_request(ctx, data, DR_ERPC_KEY);
         case RESOLVE_PARENT_OP:
-            return handle_resolve_parent(data);
+            return handle_dr_request(ctx, data, DR_ERPC_PARENT_KEY);
     }
 
     return 0;

--- a/pkg/security/ebpf/manager.go
+++ b/pkg/security/ebpf/manager.go
@@ -10,7 +10,6 @@ package ebpf
 import (
 	"math"
 	"os"
-	"time"
 
 	"github.com/DataDog/ebpf"
 	"github.com/DataDog/ebpf/manager"
@@ -29,10 +28,6 @@ func NewDefaultOptions() manager.Options {
 		// PLEASE NOTE: for the perf ring buffer usage metrics to be accurate, the provided value must have the
 		// following form: (1 + 2^n) * pages. Checkout https://github.com/DataDog/ebpf for more.
 		DefaultPerfRingBufferSize: 4097 * os.Getpagesize(),
-
-		// DefaultProbeAttach is the default number of attach / detach retries on error
-		DefaultProbeRetry:      1,
-		DefaultProbeRetryDelay: time.Second,
 
 		VerifierOptions: ebpf.CollectionOptions{
 			Programs: ebpf.ProgramOptions{

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -121,14 +121,23 @@ func AllPerfMaps() []*manager.PerfMap {
 }
 
 // AllTailRoutes returns the list of all the tail call routes
-func AllTailRoutes() []manager.TailCallRoute {
+func AllTailRoutes(ERPCDentryResolutionEnabled bool) []manager.TailCallRoute {
 	var routes []manager.TailCallRoute
 
 	routes = append(routes, getExecTailCallRoutes()...)
-	routes = append(routes, getDentryResolverTailCallRoutes()...)
+	routes = append(routes, getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled)...)
 	routes = append(routes, getSysExitTailCallRoutes()...)
 
 	return routes
+}
+
+// AllBPFProbeWriteUserSections returns the list of program sections that use the bpf_probe_write_user helper
+func AllBPFProbeWriteUserSections() []string {
+	return []string{
+		"kprobe/dentry_resolver_erpc",
+		"kprobe/dentry_resolver_parent_erpc",
+		"kprobe/dentry_resolver_segment_erpc",
+	}
 }
 
 // GetPerfBufferStatisticsMaps returns the list of maps used to monitor the performances of each perf buffers

--- a/pkg/security/ebpf/probes/const.go
+++ b/pkg/security/ebpf/probes/const.go
@@ -15,6 +15,10 @@ const (
 const (
 	// DentryResolverERPCKey is the key to the eRPC dentry resolver tail call program
 	DentryResolverERPCKey uint32 = iota
+	// DentryResolverParentERPCKey is the key to the eRPC dentry parent resolver tail call program
+	DentryResolverParentERPCKey
+	// DentryResolverSegmentERPCKey is the key to the eRPC dentry segment resolver tail call program
+	DentryResolverSegmentERPCKey
 	// DentryResolverKernKprobeKey is the key to the kernel dentry resolver tail call program
 	DentryResolverKernKprobeKey
 )

--- a/pkg/security/ebpf/probes/dentry.go
+++ b/pkg/security/ebpf/probes/dentry.go
@@ -22,6 +22,20 @@ func getDentryResolverTailCallRoutes() []manager.TailCallRoute {
 		},
 		{
 			ProgArrayName: "dentry_resolver_kprobe_progs",
+			Key:           DentryResolverParentERPCKey,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "kprobe/dentry_resolver_parent_erpc",
+			},
+		},
+		{
+			ProgArrayName: "dentry_resolver_kprobe_progs",
+			Key:           DentryResolverSegmentERPCKey,
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				Section: "kprobe/dentry_resolver_segment_erpc",
+			},
+		},
+		{
+			ProgArrayName: "dentry_resolver_kprobe_progs",
 			Key:           DentryResolverKernKprobeKey,
 			ProbeIdentificationPair: manager.ProbeIdentificationPair{
 				Section: "kprobe/dentry_resolver_kern",

--- a/pkg/security/ebpf/probes/dentry.go
+++ b/pkg/security/ebpf/probes/dentry.go
@@ -10,30 +10,9 @@ package probes
 import "github.com/DataDog/ebpf/manager"
 
 // getDentryResolverTailCallRoutes is the list of routes used during the dentry resolution process
-func getDentryResolverTailCallRoutes() []manager.TailCallRoute {
-	return []manager.TailCallRoute{
+func getDentryResolverTailCallRoutes(ERPCDentryResolutionEnabled bool) []manager.TailCallRoute {
+	routes := []manager.TailCallRoute{
 		// dentry resolver programs
-		{
-			ProgArrayName: "dentry_resolver_kprobe_progs",
-			Key:           DentryResolverERPCKey,
-			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "kprobe/dentry_resolver_erpc",
-			},
-		},
-		{
-			ProgArrayName: "dentry_resolver_kprobe_progs",
-			Key:           DentryResolverParentERPCKey,
-			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "kprobe/dentry_resolver_parent_erpc",
-			},
-		},
-		{
-			ProgArrayName: "dentry_resolver_kprobe_progs",
-			Key:           DentryResolverSegmentERPCKey,
-			ProbeIdentificationPair: manager.ProbeIdentificationPair{
-				Section: "kprobe/dentry_resolver_segment_erpc",
-			},
-		},
 		{
 			ProgArrayName: "dentry_resolver_kprobe_progs",
 			Key:           DentryResolverKernKprobeKey,
@@ -165,4 +144,33 @@ func getDentryResolverTailCallRoutes() []manager.TailCallRoute {
 			},
 		},
 	}
+
+	// add routes for programs with the bpf_probe_write_user only if necessary
+	if ERPCDentryResolutionEnabled {
+		routes = append(routes, []manager.TailCallRoute{
+			{
+				ProgArrayName: "dentry_resolver_kprobe_progs",
+				Key:           DentryResolverERPCKey,
+				ProbeIdentificationPair: manager.ProbeIdentificationPair{
+					Section: "kprobe/dentry_resolver_erpc",
+				},
+			},
+			{
+				ProgArrayName: "dentry_resolver_kprobe_progs",
+				Key:           DentryResolverParentERPCKey,
+				ProbeIdentificationPair: manager.ProbeIdentificationPair{
+					Section: "kprobe/dentry_resolver_parent_erpc",
+				},
+			},
+			{
+				ProgArrayName: "dentry_resolver_kprobe_progs",
+				Key:           DentryResolverSegmentERPCKey,
+				ProbeIdentificationPair: manager.ProbeIdentificationPair{
+					Section: "kprobe/dentry_resolver_segment_erpc",
+				},
+			},
+		}...)
+	}
+
+	return routes
 }

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -910,7 +910,11 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 	}
 
 	// tail calls
-	p.managerOptions.TailCallRouter = probes.AllTailRoutes()
+	p.managerOptions.TailCallRouter = probes.AllTailRoutes(p.config.ERPCDentryResolutionEnabled)
+	if !p.config.ERPCDentryResolutionEnabled {
+		// exclude the programs that use the bpf_probe_write_user helper
+		p.managerOptions.ExcludedSections = probes.AllBPFProbeWriteUserSections()
+	}
 
 	resolvers, err := NewResolvers(config, p)
 	if err != nil {


### PR DESCRIPTION
### What does this PR do?

This PR ensures that eRPC programs are not loaded if eRPC resolution is disabled.

### Motivation

eRPC programs use the `bpf_probe_write_user` helper which isn't permitted by default when the Linux `lockdown` is set to `integrity`. By excluding the eRPC programs, we ensure that system-probe can start and will fallback to the legacy map resolution instead of eRPC.

### Additional Notes

- [Linux Lockdown](https://linuxplumbersconf.org/event/7/contributions/678/attachments/580/1174/eBPF-lockdown-LPC-2020.pdf)

### Describe how to test your changes

Start a VM with Lockdown set to `integrity` and make sure that the runtime security module runs normally.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

