### PR TITLE
Remove dependencies for Winget job

### DIFF
--- a/.gitlab/deploy_7/winget.yml
+++ b/.gitlab/deploy_7/winget.yml
@@ -3,6 +3,7 @@
 # Contains a job which deploys the Winget Agent package.
 
 publish_winget_7_x64:
+  dependencies: []
   rules:
     !reference [.on_deploy_stable_repo_branch_a7_manual]
   stage: deploy7


### PR DESCRIPTION
### What does this PR do?

This PR makes the Winget deploy job totally independent.

### Motivation

Winget doesn't require downloading artifacts from previous stages.
