### PR TITLE
Use AWS Ubuntu mirror when building Docker images in CI

### DIFF
--- a/.gitlab/image_build/docker_linux.yml
+++ b/.gitlab/image_build/docker_linux.yml
@@ -14,9 +14,9 @@
     # Pull base images
     - inv -e docker.pull-base-images --signed-pull $BUILD_CONTEXT/$ARCH/Dockerfile
     # Build testing stage if provided
-    - test "$TESTING_ARG" && docker build --file $BUILD_CONTEXT/$ARCH/Dockerfile $TESTING_ARG $BUILD_CONTEXT
+    - test "$TESTING_ARG" && docker build --build-arg CIBUILD=true --file $BUILD_CONTEXT/$ARCH/Dockerfile $TESTING_ARG $BUILD_CONTEXT
     # Build release stage and push to ECR
-    - docker build $BUILD_ARG --file $BUILD_CONTEXT/$ARCH/Dockerfile --pull --tag ${TARGET_TAG}-unsquashed $BUILD_CONTEXT
+    - docker build --build-arg CIBUILD=true $BUILD_ARG --file $BUILD_CONTEXT/$ARCH/Dockerfile --pull --tag ${TARGET_TAG}-unsquashed $BUILD_CONTEXT
     - docker-squash ${TARGET_TAG}-unsquashed -t ${TARGET_TAG}
     - docker push $TARGET_TAG
 

--- a/Dockerfiles/agent/amd64/Dockerfile
+++ b/Dockerfiles/agent/amd64/Dockerfile
@@ -1,5 +1,10 @@
-FROM ubuntu:21.04 AS faccessat
+FROM ubuntu:21.04 AS baseimage
+ARG CIBUILD
+RUN if [ "$CIBUILD" = "true" ]; then \
+  sed -i 's#http://archive.ubuntu.com#http://us-east-1.ec2.archive.ubuntu.com#g' /etc/apt/sources.list; \
+  fi
 
+FROM baseimage AS faccessat
 COPY faccessat/faccessat.c   /tmp/faccessat.c
 COPY faccessat/faccessat.sym /tmp/faccessat.sym
 ENV DEBIAN_FRONTEND=noninteractive
@@ -11,7 +16,7 @@ RUN gcc -pipe -Wall -Wextra -O2 -shared -o /tmp/libfaccessat.so /tmp/faccessat.c
 #  Preparation stage: extract and cleanup  #
 ############################################
 
-FROM ubuntu:21.04 AS extract
+FROM baseimage AS extract
 ARG WITH_JMX
 ARG PYTHON_VERSION
 ARG DD_AGENT_ARTIFACT=datadog-agent*_amd64.deb
@@ -86,7 +91,7 @@ COPY install_info etc/datadog-agent/
 #  Actual docker image construction  #
 ######################################
 
-FROM ubuntu:21.04 AS release
+FROM baseimage AS release
 LABEL maintainer "Datadog <package@datadoghq.com>"
 ARG WITH_JMX
 ARG PYTHON_VERSION

--- a/Dockerfiles/agent/arm64/Dockerfile
+++ b/Dockerfiles/agent/arm64/Dockerfile
@@ -1,5 +1,10 @@
-FROM ubuntu:21.04 AS faccessat
+FROM ubuntu:21.04 AS baseimage
+ARG CIBUILD
+RUN if [ "$CIBUILD" = "true" ]; then \
+  sed -i 's#http://archive.ubuntu.com#http://us-east-1.ec2.archive.ubuntu.com#g' /etc/apt/sources.list; \
+  fi
 
+FROM baseimage AS faccessat
 COPY faccessat/faccessat.c   /tmp/faccessat.c
 COPY faccessat/faccessat.sym /tmp/faccessat.sym
 ENV DEBIAN_FRONTEND=noninteractive
@@ -11,7 +16,7 @@ RUN gcc -pipe -Wall -Wextra -O2 -shared -o /tmp/libfaccessat.so /tmp/faccessat.c
 #  Preparation stage: extract and cleanup  #
 ############################################
 
-FROM ubuntu:21.04 AS extract
+FROM baseimage AS extract
 ARG WITH_JMX
 ARG PYTHON_VERSION
 ARG DD_AGENT_ARTIFACT=datadog-agent*_arm64.deb
@@ -86,7 +91,7 @@ COPY install_info etc/datadog-agent/
 #  Actual docker image construction  #
 ######################################
 
-FROM ubuntu:21.04 AS release
+FROM baseimage AS release
 LABEL maintainer "Datadog <package@datadoghq.com>"
 ARG WITH_JMX
 ARG PYTHON_VERSION


### PR DESCRIPTION
### What does this PR do?

Internal CI improvement: use AWS Ubuntu mirror when building Docker images in CI

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
