### PR TITLE
calculate ipv4 header length and check packet boundary

### DIFF
--- a/pkg/network/ebpf/c/ip.h
+++ b/pkg/network/ebpf/c/ip.h
@@ -36,12 +36,18 @@ static __always_inline __u64 read_conn_tuple_skb(struct __sk_buff *skb, skb_info
     __u8 l4_proto = 0;
     switch (l3_proto) {
     case ETH_P_IP:
+    {
+        __u8 ipv4_hdr_len = (load_byte(skb, info->data_off) & 0x0f) << 2;
+        if (ipv4_hdr_len < sizeof(struct iphdr)) {
+            return 0;
+        }
         l4_proto = load_byte(skb, info->data_off + offsetof(struct iphdr, protocol));
         info->tup.metadata |= CONN_V4;
         read_ipv4_skb(skb, info->data_off + offsetof(struct iphdr, saddr), &info->tup.saddr_l);
         read_ipv4_skb(skb, info->data_off + offsetof(struct iphdr, daddr), &info->tup.daddr_l);
-        info->data_off += sizeof(struct iphdr); // TODO: this assumes there are no IP options
+        info->data_off += ipv4_hdr_len;
         break;
+    }
     case ETH_P_IPV6:
         l4_proto = load_byte(skb, info->data_off + offsetof(struct ipv6hdr, nexthdr));
         info->tup.metadata |= CONN_V6;
@@ -70,6 +76,10 @@ static __always_inline __u64 read_conn_tuple_skb(struct __sk_buff *skb, skb_info
         info->data_off += ((load_byte(skb, info->data_off + offsetof(struct tcphdr, ack_seq) + 4) & 0xF0) >> 4) * 4;
         break;
     default:
+        return 0;
+    }
+
+    if ((skb->len - info->data_off) < 0) {
         return 0;
     }
 


### PR DESCRIPTION
### What does this PR do?

Take the IPv4 header length into account
Check the packet boundary after calculating the offset from L3/L4 headers

### Motivation

Parsing correctly IPv4 packets and drop out of bound/un-correct IPv4 packets

### Additional information
Prebuilt dns and http are affected by this change

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
