### PR TITLE
Fix system-probe build on arm

### DIFF
--- a/.gitlab/binary_build/system_probe.yml
+++ b/.gitlab/binary_build/system_probe.yml
@@ -58,3 +58,4 @@ build_system-probe-arm64:
   extends: .system-probe_build_common
   variables:
     ARCH: arm64
+    NIKOS_EMBEDDED_PATH: None

--- a/.gitlab/deps_build.yml
+++ b/.gitlab/deps_build.yml
@@ -76,4 +76,15 @@ build_omnibus-nikos_x64:
   tags: ["runner:main"]
   variables:
     ARCH: amd64
+
+build_omnibus-nikos_arm64:
+  extends: .build_omnibus-nikos_common
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/omnibus-nikos_x64:$DATADOG_AGENT_NIKOS_BUILDIMAGES
+  tags: ["runner:main"]
+  variables:
+    ARCH: arm64
+  script:
+    # for now, upload a dummy artifact in order to fix the system-probe arm build
+    - tar czf nikos.tar.gz --files-from /dev/null
+    - $S3_CP_CMD nikos.tar.gz $S3_PERMANENT_ARTIFACTS_URI/nikos-$ARCH.tar.gz
   

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -98,7 +98,7 @@ def build(
     build_tags = get_default_build_tags(build="system-probe", arch=arch)
     if bundle_ebpf:
         build_tags.append(BUNDLE_TAG)
-    if nikos_embedded_path:
+    if nikos_embedded_path and nikos_embedded_path != 'None':
         build_tags.append(DNF_TAG)
 
     cmd = 'go build -mod={go_mod} {race_opt} {build_type} -tags "{go_build_tags}" '

--- a/tasks/utils.py
+++ b/tasks/utils.py
@@ -174,7 +174,7 @@ def get_build_flags(
     )
 
     # adding nikos libs to the env
-    if nikos_embedded_path:
+    if nikos_embedded_path and nikos_embedded_path != 'None':
         env['PKG_CONFIG_PATH'] = env.get('PKG_CONFIG_PATH', '') + ':' + nikos_embedded_path + '/lib/pkgconfig'
         env["CGO_LDFLAGS"] = env.get('CGO_LDFLAGS', '') + get_nikos_linker_flags(nikos_embedded_path + '/lib')
 


### PR DESCRIPTION
### What does this PR do?

Fixes the system-probe build on `arm64` so that it no longer tries to build with `nikos`.

### Motivation

https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/85006244

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
