### PR TITLE
[runtime-security] add kernel lockdown sanity check

### DIFF
--- a/pkg/process/util/util.go
+++ b/pkg/process/util/util.go
@@ -110,6 +110,19 @@ func GetProcRoot() string {
 	return "/proc"
 }
 
+// GetSysRoot retrieves the current sysfs dir we should use
+func GetSysRoot() string {
+	if v := os.Getenv("HOST_SYS"); v != "" {
+		return v
+	}
+
+	if config.IsContainerized() && PathExists("/host") {
+		return "/host/sys"
+	}
+
+	return "/sys"
+}
+
 // WithAllProcs will execute `fn` for every pid under procRoot. `fn` is
 // passed the `pid`. If `fn` returns an error the iteration aborts,
 // returning the last error returned from `fn`.

--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -37,6 +37,8 @@ var (
 	Kernel5_4 = kernel.VersionCode(5, 4, 0) //nolint:deadcode,unused
 	// Kernel5_12 is the KernelVersion representation of kernel version 5.12
 	Kernel5_12 = kernel.VersionCode(5, 12, 0) //nolint:deadcode,unused
+	// Kernel5_13 is the KernelVersion representation of kernel version 5.13
+	Kernel5_13 = kernel.VersionCode(5, 13, 0) //nolint:deadcode,unused
 )
 
 // Version defines a kernel version helper

--- a/pkg/security/probe/mount_resolver.go
+++ b/pkg/security/probe/mount_resolver.go
@@ -21,9 +21,9 @@ import (
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 
-	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
+	skernel "github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/model"
-	"github.com/DataDog/datadog-agent/pkg/security/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 )
 
 var (
@@ -87,7 +87,7 @@ func (mr *MountResolver) SyncCache(proc *process.Process) error {
 	mr.lock.Lock()
 	defer mr.lock.Unlock()
 
-	mnts, err := utils.ParseMountInfoFile(proc.Pid)
+	mnts, err := kernel.ParseMountInfoFile(proc.Pid)
 	if err != nil {
 		pErr, ok := err.(*os.PathError)
 		if !ok {
@@ -370,9 +370,9 @@ func getMountIDOffset(probe *Probe) uint64 {
 	offset := uint64(284)
 
 	switch {
-	case probe.kernelVersion.IsSuseKernel() || probe.kernelVersion.Code >= kernel.Kernel5_12:
+	case probe.kernelVersion.IsSuseKernel() || probe.kernelVersion.Code >= skernel.Kernel5_12:
 		offset = 292
-	case probe.kernelVersion.Code != 0 && probe.kernelVersion.Code < kernel.Kernel4_13:
+	case probe.kernelVersion.Code != 0 && probe.kernelVersion.Code < skernel.Kernel4_13:
 		offset = 268
 	}
 
@@ -393,7 +393,7 @@ func getSizeOfStructInode(probe *Probe) uint64 {
 		sizeOf = 592
 	case probe.kernelVersion.IsOracleUEKKernel():
 		sizeOf = 632
-	case probe.kernelVersion.Code != 0 && probe.kernelVersion.Code < kernel.Kernel4_16:
+	case probe.kernelVersion.Code != 0 && probe.kernelVersion.Code < skernel.Kernel4_16:
 		sizeOf = 608
 	}
 

--- a/pkg/security/utils/proc.go
+++ b/pkg/security/utils/proc.go
@@ -18,7 +18,6 @@ import (
 	"strings"
 
 	"github.com/DataDog/gopsutil/process"
-	"github.com/moby/sys/mountinfo"
 
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 )
@@ -32,16 +31,6 @@ func Getpid() int32 {
 		}
 	}
 	return int32(os.Getpid())
-}
-
-// MountInfoPath returns the path to the mountinfo file of the current pid in /proc
-func MountInfoPath() string {
-	return filepath.Join(util.HostProc(), "/self/mountinfo")
-}
-
-// MountInfoPidPath returns the path to the mountinfo file of a pid in /proc
-func MountInfoPidPath(pid int32) string {
-	return filepath.Join(util.HostProc(), fmt.Sprintf("/%d/mountinfo", pid))
 }
 
 // CgroupTaskPath returns the path to the cgroup file of a pid in /proc
@@ -111,17 +100,6 @@ func PidTTY(pid int32) string {
 	}
 
 	return ""
-}
-
-// ParseMountInfoFile collects the mounts for a specific process ID.
-func ParseMountInfoFile(pid int32) ([]*mountinfo.Info, error) {
-	f, err := os.Open(MountInfoPidPath(pid))
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	return mountinfo.GetMountsFromReader(f, nil)
 }
 
 // GetProcesses returns list of active processes

--- a/pkg/util/kernel/fs.go
+++ b/pkg/util/kernel/fs.go
@@ -3,9 +3,51 @@
 package kernel
 
 import (
+	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/moby/sys/mountinfo"
 )
+
+// MountInfoPidPath returns the path to the mountinfo file of a pid in /proc
+func MountInfoPidPath(pid int32) string {
+	return filepath.Join(util.HostProc(), fmt.Sprintf("/%d/mountinfo", pid))
+}
+
+// ParseMountInfoFile collects the mounts for a specific process ID.
+func ParseMountInfoFile(pid int32) ([]*mountinfo.Info, error) {
+	f, err := os.Open(MountInfoPidPath(pid))
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	return mountinfo.GetMountsFromReader(f, nil)
+}
+
+// GetMountPoint returns the mount point of the given path
+func GetMountPoint(path string) (*mountinfo.Info, error) {
+	mi, err := ParseMountInfoFile(int32(os.Getpid()))
+	if err != nil {
+		return nil, err
+	}
+
+	for path != "" {
+		for _, m := range mi {
+			if path == m.Mountpoint {
+				return m, nil
+			}
+		}
+
+		path = filepath.Dir(path)
+	}
+
+	return nil, nil
+}
 
 // IsDebugFSMounted would test the existence of file /sys/kernel/debug/tracing/kprobe_events to determine if debugfs is mounted or not
 // returns a boolean and a possible error message
@@ -21,5 +63,22 @@ func IsDebugFSMounted() (bool, error) {
 			return false, fmt.Errorf("an error occurred while accessing debugfs: %w", err)
 		}
 	}
+
+	mi, err := GetMountPoint("/sys/kernel/debug/tracing/kprobe_events")
+	if err != nil {
+		return false, errors.New("unable to detect debugfs mount point")
+	}
+
+	if mi.FSType != "tracefs" && mi.FSType != "debugfs" {
+		return false, fmt.Errorf("kprobe_events mount point(%s): wrong fs type(%s)", mi.Mountpoint, mi.FSType)
+	}
+
+	options := strings.Split(mi.Options, ",")
+	for _, option := range options {
+		if option == "ro" {
+			return false, fmt.Errorf("kprobe_events mount point(%s) is in read-only mode", mi.Mountpoint)
+		}
+	}
+
 	return true, nil
 }

--- a/pkg/util/kernel/fs.go
+++ b/pkg/util/kernel/fs.go
@@ -14,7 +14,7 @@ func IsDebugFSMounted() (bool, error) {
 
 	if err != nil {
 		if os.IsPermission(err) {
-			return false, fmt.Errorf("system-probe does not have permission to access debugfs")
+			return false, fmt.Errorf("eBPF not supported, does not have permission to access debugfs")
 		} else if os.IsNotExist(err) {
 			return false, fmt.Errorf("debugfs is not mounted and is needed for eBPF-based checks, run \"sudo mount -t debugfs none /sys/kernel/debug\" to mount debugfs")
 		} else {

--- a/pkg/util/kernel/lockdown.go
+++ b/pkg/util/kernel/lockdown.go
@@ -1,0 +1,52 @@
+// +build linux
+
+package kernel
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"regexp"
+
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+)
+
+type LockdownMode string
+
+const (
+	None            LockdownMode = "none"
+	Integrity       LockdownMode = "integrity"
+	Confidentiality LockdownMode = "confidentiality"
+	Unknown         LockdownMode = "unknown"
+)
+
+var re = regexp.MustCompile(`\[(.*)\]`)
+
+func getLockdownMode(data string) LockdownMode {
+	mode := re.FindString(data)
+
+	switch mode {
+	case "[none]":
+		return None
+	case "[integrity]":
+		return Integrity
+	case "[confidentiality]":
+		return Confidentiality
+	}
+	return Unknown
+}
+
+func GetLockdownMode() LockdownMode {
+	data, err := ioutil.ReadFile(filepath.Join(util.GetSysRoot(), "kernel/security/lockdown"))
+	if err != nil {
+		return Unknown
+	}
+
+	return getLockdownMode(string(data))
+}
+
+func IsLockdownEnabled() bool {
+	if mode := GetLockdownMode(); mode != None && mode != Unknown {
+		return true
+	}
+	return false
+}

--- a/pkg/util/kernel/lockdown.go
+++ b/pkg/util/kernel/lockdown.go
@@ -10,13 +10,18 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 )
 
+// LockdownMode defines a lockdown type
 type LockdownMode string
 
 const (
-	None            LockdownMode = "none"
-	Integrity       LockdownMode = "integrity"
+	// None mode
+	None LockdownMode = "none"
+	// Integrity mode
+	Integrity LockdownMode = "integrity"
+	// Confidentiality mode
 	Confidentiality LockdownMode = "confidentiality"
-	Unknown         LockdownMode = "unknown"
+	// Unknown mode
+	Unknown LockdownMode = "unknown"
 )
 
 var re = regexp.MustCompile(`\[(.*)\]`)
@@ -35,6 +40,7 @@ func getLockdownMode(data string) LockdownMode {
 	return Unknown
 }
 
+// GetLockdownMode returns the lockdown
 func GetLockdownMode() LockdownMode {
 	data, err := ioutil.ReadFile(filepath.Join(util.GetSysRoot(), "kernel/security/lockdown"))
 	if err != nil {

--- a/pkg/util/kernel/lockdown.go
+++ b/pkg/util/kernel/lockdown.go
@@ -43,10 +43,3 @@ func GetLockdownMode() LockdownMode {
 
 	return getLockdownMode(string(data))
 }
-
-func IsLockdownEnabled() bool {
-	if mode := GetLockdownMode(); mode != None && mode != Unknown {
-		return true
-	}
-	return false
-}

--- a/pkg/util/kernel/lockdown_test.go
+++ b/pkg/util/kernel/lockdown_test.go
@@ -1,0 +1,26 @@
+// +build linux
+
+package kernel
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLockdown(t *testing.T) {
+	mode := getLockdownMode(`none integrity [confidentiality]`)
+	assert.Equal(t, Confidentiality, mode)
+
+	mode = getLockdownMode(`none [integrity] confidentiality`)
+	assert.Equal(t, Integrity, mode)
+
+	mode = getLockdownMode(`[none] integrity confidentiality`)
+	assert.Equal(t, None, mode)
+
+	mode = getLockdownMode(`none integrity confidentiality`)
+	assert.Equal(t, Unknown, mode)
+
+	mode = getLockdownMode(`none integrity confidentiality [aaa]`)
+	assert.Equal(t, Unknown, mode)
+}


### PR DESCRIPTION
### What does this PR do?

This PR add some sanity checks at runtime module start. It checks debugfs and kernel lockdown.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
