### PR TITLE
[runtime-security] Support kernel 5.12 and later

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -36,7 +36,7 @@ kitchen_test_security_agent_x64:
       - KITCHEN_PLATFORM: "centos"
         KITCHEN_OSVERS: "centos-77,rhel-81"
       - KITCHEN_PLATFORM: "ubuntu"
-        KITCHEN_OSVERS: "ubuntu-18-04,ubuntu-20-04,ubuntu-20-04-hwe,ubuntu-21-04"
+        KITCHEN_OSVERS: "ubuntu-18-04,ubuntu-20-04,ubuntu-20-04-hwe,ubuntu-21-10"
       - KITCHEN_PLATFORM: "suse"
         KITCHEN_OSVERS: "sles-12,sles-15"
       - KITCHEN_PLATFORM: "debian"

--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -35,6 +35,8 @@ var (
 	Kernel5_3 = kernel.VersionCode(5, 3, 0) //nolint:deadcode,unused
 	// Kernel5_4 is the KernelVersion representation of kernel version 5.4
 	Kernel5_4 = kernel.VersionCode(5, 4, 0) //nolint:deadcode,unused
+	// Kernel5_12 is the KernelVersion representation of kernel version 5.12
+	Kernel5_12 = kernel.VersionCode(5, 12, 0) //nolint:deadcode,unused
 )
 
 // Version defines a kernel version helper

--- a/pkg/security/probe/mount_resolver.go
+++ b/pkg/security/probe/mount_resolver.go
@@ -370,7 +370,7 @@ func getMountIDOffset(probe *Probe) uint64 {
 	offset := uint64(284)
 
 	switch {
-	case probe.kernelVersion.IsSuseKernel():
+	case probe.kernelVersion.IsSuseKernel() || probe.kernelVersion.Code >= kernel.Kernel5_12:
 		offset = 292
 	case probe.kernelVersion.Code != 0 && probe.kernelVersion.Code < kernel.Kernel4_13:
 		offset = 268

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -58,7 +58,7 @@
                 "ubuntu-18-04": "urn,Canonical:UbuntuServer:18.04-LTS:18.04.201906040",
                 "ubuntu-20-04": "urn,Canonical:0001-com-ubuntu-server-focal:20_04-lts:20.04.202004230",
                 "ubuntu-20-04-hwe": "urn,Canonical:0001-com-ubuntu-server-focal:20_04-lts:20.04.202107200",
-                "ubuntu-21-04": "urn,Canonical:0001-com-ubuntu-server-hirsute:21_04:21.04.202107200"
+                "ubuntu-21-10": "urn,Canonical:0001-com-ubuntu-server-impish-daily:21_10-daily:21.10.202109040"
             }
         },
         "ec2": {

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -58,6 +58,12 @@ if node['platform_family'] != 'windows'
       service 'docker' do
         action [ :enable, :start ]
       end
+    elsif ['ubuntu'].include?(node[:platform])
+      docker_installation_package 'default' do
+        action :create
+        setup_docker_repo false
+        package_name 'docker.io'
+      end
     else
       docker_service 'default' do
         action [:create, :start]


### PR DESCRIPTION
### What does this PR do?

Change mount_id offset and run Kitchen tests on Ubuntu 21.10 

### Motivation

Path resolution is failing on kernel 5.12 and later
