### PR TITLE
Adding 'flavor' and 'version' to the inventory payload

### DIFF
--- a/pkg/metadata/inventories/README.md
+++ b/pkg/metadata/inventories/README.md
@@ -40,6 +40,9 @@ The payload is a JSON dict with the following fields
 - `agent_metadata` - **dict of string to JSON type**:
   - `cloud_provider` - **string**: the name of the cloud provider detected by the Agent (omitted if no cloud is detected).
   - `hostname_source` - **string**: the source for the agent hostname (see pkg/util/hostname.go:GetHostnameData).
+  - `version` - **string**: the version of the Agent.
+  - `flavor` - **string**: the flavor of the Agent. The Agent can be build under different flavor such as standalone
+    dogstatsd, iot, serverless ... (see `pkg/util/flavor` package).
 
 ## Example Payload
 

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -13,6 +13,8 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 type schedulerInterface interface {
@@ -64,6 +66,8 @@ type AgentMetadataName string
 const (
 	AgentCloudProvider  AgentMetadataName = "cloud_provider"
 	AgentHostnameSource AgentMetadataName = "hostname_source"
+	AgentVersion        AgentMetadataName = "version"
+	AgentFlavor         AgentMetadataName = "flavor"
 )
 
 // SetAgentMetadata updates the agent metadata value in the cache
@@ -203,4 +207,10 @@ func StartMetadataUpdatedGoroutine(sc schedulerInterface, minSendInterval time.D
 		}
 	}()
 	return nil
+}
+
+// InitializeData inits the inventories payload with basic and static information (agent version, flavor name, ...)
+func InitializeData() {
+	SetAgentMetadata(AgentVersion, version.AgentVersion)
+	SetAgentMetadata(AgentFlavor, flavor.GetFlavor())
 }

--- a/pkg/metadata/inventories_collector.go
+++ b/pkg/metadata/inventories_collector.go
@@ -48,6 +48,7 @@ func (c inventoriesCollector) Send(ctx context.Context, s *serializer.Serializer
 
 // Init initializes the inventory metadata collection
 func (c inventoriesCollector) Init() error {
+	inventories.InitializeData()
 	return inventories.StartMetadataUpdatedGoroutine(c.sc, config.Datadog.GetDuration("inventories_min_interval")*time.Second)
 }
 
@@ -78,5 +79,6 @@ func SetupInventories(sc *Scheduler, ac inventories.AutoConfigInterface, coll in
 	}
 
 	SetupInventoriesExpvar(ac, coll)
+
 	return nil
 }


### PR DESCRIPTION
### What does this PR do?

Adding 'flavor' and 'version' to the inventory payload.

### Describe how to test your changes

The agent in debug mode will print the metadata payload.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
