### PR TITLE
Fix winget update script

### DIFF
--- a/.gitlab/deploy_7/winget.yml
+++ b/.gitlab/deploy_7/winget.yml
@@ -4,7 +4,7 @@
 
 publish_winget_7_x64:
   rules:
-    !reference [.on_deploy_stable_repo_branch_a7_manual]
+    !reference [.on_deploy_stable_or_beta_repo_branch_a7_manual_auto_on_rc]
   stage: deploy7
   tags: ["runner:windows-docker", "windowsversion:1809"]
   variables:

--- a/tasks/winbuildscripts/Update-Winget.ps1
+++ b/tasks/winbuildscripts/Update-Winget.ps1
@@ -18,8 +18,8 @@ if ($m) {
 }
 if ($rc) {
     Write-Host ("Updating Winget manifest for Agent version ${agentVersion}-${rc}")
-    .\wingetcreate.exe update --urls "https://s3.amazonaws.com/dd-agent-mstesting/builds/tagged/datadog-agent-${agentVersion}-rc.${rc}-1-x86_64.msi" --version "${agentVersion}-rc.${rc}" --token $env:WINGET_GITHUB_ACCESS_TOKEN "Datadog.Agent"
+    .\wingetcreate.exe update --urls "https://s3.amazonaws.com/dd-agent-mstesting/builds/tagged/datadog-agent-${agentVersion}-rc.${rc}-1-x86_64.msi" --version "${agentVersion}-rc.${rc}" --submit --token "${env:WINGET_GITHUB_ACCESS_TOKEN}" "Datadog.Agent"
 } else {
     Write-Host ("Updating Winget manifest for Agent version ${agentVersion}")
-    .\wingetcreate.exe update --urls "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-${agentVersion}.msi" --version "${agentVersion}" --token $env:WINGET_GITHUB_ACCESS_TOKEN "Datadog.Agent"
+    .\wingetcreate.exe update --urls "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-${agentVersion}.msi" --version "${agentVersion}.1" --submit --token "${env:WINGET_GITHUB_ACCESS_TOKEN}" "Datadog.Agent"
 }

--- a/tasks/winbuildscripts/Update-Winget.ps1
+++ b/tasks/winbuildscripts/Update-Winget.ps1
@@ -23,3 +23,6 @@ if ($rc) {
     Write-Host ("Updating Winget manifest for Agent version ${agentVersion}.1")
     .\wingetcreate.exe update --urls "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-${agentVersion}.msi" --version "${agentVersion}.1" --submit --token "${env:WINGET_GITHUB_ACCESS_TOKEN}" "Datadog.Agent"
 }
+if ($lastExitCode -ne 0) {
+    Write-Error -Message "Wingetcreate update did not run successfully."
+}

--- a/tasks/winbuildscripts/Update-Winget.ps1
+++ b/tasks/winbuildscripts/Update-Winget.ps1
@@ -13,11 +13,11 @@ if ($m) {
     $agentVersion = $m.Groups[1].Value
     $rc = $m.Groups[3].Value
 } else {
-    Write-Host "Unsupported agent version '$agentVersion', aborting"
+    Write-Host "Unsupported agent version '$rawAgentVersion', aborting"
     exit 1
 }
 if ($rc) {
-    Write-Host ("Updating Winget manifest for Agent version ${agentVersion}-${rc}")
+    Write-Host ("Updating Winget manifest for Agent version ${agentVersion}-rc.${rc}")
     .\wingetcreate.exe update --urls "https://s3.amazonaws.com/dd-agent-mstesting/builds/tagged/datadog-agent-${agentVersion}-rc.${rc}-1-x86_64.msi" --version "${agentVersion}-rc.${rc}" --submit --token "${env:WINGET_GITHUB_ACCESS_TOKEN}" "Datadog.Agent"
 } else {
     Write-Host ("Updating Winget manifest for Agent version ${agentVersion}")

--- a/tasks/winbuildscripts/Update-Winget.ps1
+++ b/tasks/winbuildscripts/Update-Winget.ps1
@@ -20,6 +20,6 @@ if ($rc) {
     Write-Host ("Updating Winget manifest for Agent version ${agentVersion}-rc.${rc}")
     .\wingetcreate.exe update --urls "https://s3.amazonaws.com/dd-agent-mstesting/builds/tagged/datadog-agent-${agentVersion}-rc.${rc}-1-x86_64.msi" --version "${agentVersion}-rc.${rc}" --submit --token "${env:WINGET_GITHUB_ACCESS_TOKEN}" "Datadog.Agent"
 } else {
-    Write-Host ("Updating Winget manifest for Agent version ${agentVersion}")
+    Write-Host ("Updating Winget manifest for Agent version ${agentVersion}.1")
     .\wingetcreate.exe update --urls "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-${agentVersion}.msi" --version "${agentVersion}.1" --submit --token "${env:WINGET_GITHUB_ACCESS_TOKEN}" "Datadog.Agent"
 }

--- a/tasks/winbuildscripts/Update-Winget.ps1
+++ b/tasks/winbuildscripts/Update-Winget.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop';
 Set-Location c:\mnt
 
-(New-Object System.Net.WebClient).DownloadFile("https://aka.ms/wingetcreate/latest", ".\wingetcreate.exe")
+(New-Object System.Net.WebClient).DownloadFile("https://github.com/microsoft/winget-create/releases/download/v0.4.0.3-preview/wingetcreate.exe", ".\wingetcreate.exe")
 
 # Install dev tools, including invoke
 pip3 install -r requirements.txt

--- a/tasks/winbuildscripts/Update-Winget.ps1
+++ b/tasks/winbuildscripts/Update-Winget.ps1
@@ -1,17 +1,25 @@
 $ErrorActionPreference = 'Stop';
 Set-Location c:\mnt
 
-Invoke-WebRequest https://aka.ms/wingetcreate/latest -OutFile wingetcreate.exe
+(New-Object System.Net.WebClient).DownloadFile("https://aka.ms/wingetcreate/latest", ".\wingetcreate.exe")
 
 # Install dev tools, including invoke
 pip3 install -r requirements.txt
 
 $rawAgentVersion = (inv agent.version)
-$releasePattern = "(\d+\.\d+\.\d+)"
-if ($rawAgentVersion -match $releasePattern) {
+Write-Host "Detected agent version ${rawAgentVersion}"
+$m = [regex]::match($rawAgentVersion, "(\d+\.\d+\.\d+)(-rc.(\d+))?")
+if ($m) {
+    $agentVersion = $m.Groups[1].Value
+    $rc = $m.Groups[3].Value
 } else {
-    Write-Host "Unsupported agent version '$rawAgentVersion', aborting"
+    Write-Host "Unsupported agent version '$agentVersion', aborting"
     exit 1
 }
-Write-Host ("Updating Winget manifest for Agent version {0}" -f $rawAgentVersion)
-.\wingetcreate.exe update --id "Datadog.Agent" --url "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-$($agentVersion).msi" --version $($agentVersion) --token $env:WINGET_GITHUB_ACCESS_TOKEN
+if ($rc) {
+    Write-Host ("Updating Winget manifest for Agent version ${agentVersion}-${rc}")
+    .\wingetcreate.exe update --urls "https://s3.amazonaws.com/dd-agent-mstesting/builds/tagged/datadog-agent-${agentVersion}-rc.${rc}-1-x86_64.msi" --version "${agentVersion}-rc.${rc}" --token $env:WINGET_GITHUB_ACCESS_TOKEN "Datadog.Agent"
+} else {
+    Write-Host ("Updating Winget manifest for Agent version ${agentVersion}")
+    .\wingetcreate.exe update --urls "https://s3.amazonaws.com/ddagent-windows-stable/ddagent-cli-${agentVersion}.msi" --version "${agentVersion}" --token $env:WINGET_GITHUB_ACCESS_TOKEN "Datadog.Agent"
+}


### PR DESCRIPTION
### What does this PR do?

This PR fixes the Winget update script.

### Motivation

Publish Winget manifest during releases.

### Additional Notes

This PR also adds the ability to publish Winget manifest updates for each RC. It's not clear yet if this will work with their version number.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
