### PR TITLE
[pkg/otlp/model] Move `attributes` package from Datadog exporter

### DIFF
--- a/pkg/otlp/model/attributes/attributes.go
+++ b/pkg/otlp/model/attributes/attributes.go
@@ -1,0 +1,122 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attributes
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/collector/model/pdata"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+)
+
+var (
+	// conventionsMappings defines the mapping between OpenTelemetry semantic conventions
+	// and Datadog Agent conventions
+	conventionsMapping = map[string]string{
+		// Datadog conventions
+		// https://docs.datadoghq.com/getting_started/tagging/unified_service_tagging/
+		conventions.AttributeDeploymentEnvironment: "env",
+		conventions.AttributeServiceName:           "service",
+		conventions.AttributeServiceVersion:        "version",
+
+		// Cloud conventions
+		// https://www.datadoghq.com/blog/tagging-best-practices/
+		conventions.AttributeCloudProvider:         "cloud_provider",
+		conventions.AttributeCloudRegion:           "region",
+		conventions.AttributeCloudAvailabilityZone: "zone",
+
+		// ECS conventions
+		// https://github.com/DataDog/datadog-agent/blob/e081bed/pkg/tagger/collectors/ecs_extract.go
+		conventions.AttributeAWSECSTaskFamily: "task_family",
+		conventions.AttributeAWSECSClusterARN: "ecs_cluster_name",
+		"aws.ecs.task.revision":               "task_version",
+
+		// Kubernetes resource name (via semantic conventions)
+		// https://github.com/DataDog/datadog-agent/blob/e081bed/pkg/util/kubernetes/const.go
+		conventions.AttributeK8SPodName:         "pod_name",
+		conventions.AttributeK8SDeploymentName:  "kube_deployment",
+		conventions.AttributeK8SReplicaSetName:  "kube_replica_set",
+		conventions.AttributeK8SStatefulSetName: "kube_stateful_set",
+		conventions.AttributeK8SDaemonSetName:   "kube_daemon_set",
+		conventions.AttributeK8SJobName:         "kube_job",
+		conventions.AttributeK8SCronJobName:     "kube_cronjob",
+	}
+
+	// Kubernetes mappings defines the mapping between Kubernetes conventions (both general and Datadog specific)
+	// and Datadog Agent conventions. The Datadog Agent conventions can be found at
+	// https://github.com/DataDog/datadog-agent/blob/e081bed/pkg/tagger/collectors/const.go and
+	// https://github.com/DataDog/datadog-agent/blob/e081bed/pkg/util/kubernetes/const.go
+	kubernetesMapping = map[string]string{
+		// Standard Datadog labels
+		"tags.datadoghq.com/env":     "env",
+		"tags.datadoghq.com/service": "service",
+		"tags.datadoghq.com/version": "version",
+
+		// Standard Kubernetes labels
+		"app.kubernetes.io/name":       "kube_app_name",
+		"app.kubernetes.io/instance":   "kube_app_instance",
+		"app.kubernetes.io/version":    "kube_app_version",
+		"app.kuberenetes.io/component": "kube_app_component",
+		"app.kubernetes.io/part-of":    "kube_app_part_of",
+		"app.kubernetes.io/managed-by": "kube_app_managed_by",
+	}
+)
+
+// TagsFromAttributes converts a selected list of attributes
+// to a tag list that can be added to metrics.
+func TagsFromAttributes(attrs pdata.AttributeMap) []string {
+	tags := make([]string, 0, attrs.Len())
+
+	var processAttributes processAttributes
+	var systemAttributes systemAttributes
+
+	attrs.Range(func(key string, value pdata.AttributeValue) bool {
+		switch key {
+		// Process attributes
+		case conventions.AttributeProcessExecutableName:
+			processAttributes.ExecutableName = value.StringVal()
+		case conventions.AttributeProcessExecutablePath:
+			processAttributes.ExecutablePath = value.StringVal()
+		case conventions.AttributeProcessCommand:
+			processAttributes.Command = value.StringVal()
+		case conventions.AttributeProcessCommandLine:
+			processAttributes.CommandLine = value.StringVal()
+		case conventions.AttributeProcessPID:
+			processAttributes.PID = value.IntVal()
+		case conventions.AttributeProcessOwner:
+			processAttributes.Owner = value.StringVal()
+
+		// System attributes
+		case conventions.AttributeOSType:
+			systemAttributes.OSType = value.StringVal()
+		}
+
+		// conventions mapping
+		if datadogKey, found := conventionsMapping[key]; found && value.StringVal() != "" {
+			tags = append(tags, fmt.Sprintf("%s:%s", datadogKey, value.StringVal()))
+		}
+
+		// Kubernetes labels mapping
+		if datadogKey, found := kubernetesMapping[key]; found && value.StringVal() != "" {
+			tags = append(tags, fmt.Sprintf("%s:%s", datadogKey, value.StringVal()))
+		}
+		return true
+	})
+
+	tags = append(tags, processAttributes.extractTags()...)
+	tags = append(tags, systemAttributes.extractTags()...)
+
+	return tags
+}

--- a/pkg/otlp/model/attributes/attributes_test.go
+++ b/pkg/otlp/model/attributes/attributes_test.go
@@ -1,0 +1,54 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attributes
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/model/pdata"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+)
+
+func TestTagsFromAttributes(t *testing.T) {
+	attributeMap := map[string]pdata.AttributeValue{
+		conventions.AttributeProcessExecutableName: pdata.NewAttributeValueString("otelcol"),
+		conventions.AttributeProcessExecutablePath: pdata.NewAttributeValueString("/usr/bin/cmd/otelcol"),
+		conventions.AttributeProcessCommand:        pdata.NewAttributeValueString("cmd/otelcol"),
+		conventions.AttributeProcessCommandLine:    pdata.NewAttributeValueString("cmd/otelcol --config=\"/path/to/config.yaml\""),
+		conventions.AttributeProcessPID:            pdata.NewAttributeValueInt(1),
+		conventions.AttributeProcessOwner:          pdata.NewAttributeValueString("root"),
+		conventions.AttributeOSType:                pdata.NewAttributeValueString("LINUX"),
+		conventions.AttributeK8SDaemonSetName:      pdata.NewAttributeValueString("daemon_set_name"),
+		conventions.AttributeAWSECSClusterARN:      pdata.NewAttributeValueString("cluster_arn"),
+		"tags.datadoghq.com/service":               pdata.NewAttributeValueString("service_name"),
+	}
+	attrs := pdata.NewAttributeMapFromMap(attributeMap)
+
+	assert.ElementsMatch(t, []string{
+		fmt.Sprintf("%s:%s", conventions.AttributeProcessExecutableName, "otelcol"),
+		fmt.Sprintf("%s:%s", conventions.AttributeOSType, "LINUX"),
+		fmt.Sprintf("%s:%s", "kube_daemon_set", "daemon_set_name"),
+		fmt.Sprintf("%s:%s", "ecs_cluster_name", "cluster_arn"),
+		fmt.Sprintf("%s:%s", "service", "service_name"),
+	}, TagsFromAttributes(attrs))
+}
+
+func TestTagsFromAttributesEmpty(t *testing.T) {
+	attrs := pdata.NewAttributeMap()
+
+	assert.Equal(t, []string{}, TagsFromAttributes(attrs))
+}

--- a/pkg/otlp/model/attributes/azure/azure.go
+++ b/pkg/otlp/model/attributes/azure/azure.go
@@ -1,0 +1,68 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package azure
+
+import (
+	"strings"
+
+	"go.opentelemetry.io/collector/model/pdata"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+)
+
+const (
+	// AttributeResourceGroupName is the Azure resource group name attribute
+	AttributeResourceGroupName = "azure.resourcegroup.name"
+)
+
+// HostInfo has the Azure host information
+type HostInfo struct {
+	HostAliases []string
+}
+
+// HostInfoFromAttributes gets Azure host info from attributes following
+// OpenTelemetry semantic conventions
+func HostInfoFromAttributes(attrs pdata.AttributeMap) (hostInfo *HostInfo) {
+	hostInfo = &HostInfo{}
+
+	// Add Azure VM ID as a host alias if available for compatibility with Azure integration
+	if vmID, ok := attrs.Get(conventions.AttributeHostID); ok {
+		hostInfo.HostAliases = append(hostInfo.HostAliases, vmID.StringVal())
+	}
+
+	return
+}
+
+// HostnameFromAttributes gets the Azure hostname from attributes
+func HostnameFromAttributes(attrs pdata.AttributeMap) (string, bool) {
+	if hostname, ok := attrs.Get(conventions.AttributeHostName); ok {
+		return hostname.StringVal(), true
+	}
+
+	return "", false
+}
+
+// ClusterNameFromAttributes gets the Azure cluster name from attributes
+func ClusterNameFromAttributes(attrs pdata.AttributeMap) (string, bool) {
+	// Get cluster name from resource group
+	// https://github.com/DataDog/datadog-agent/blob/aad29b8/pkg/util/azure/azure.go#L51
+	if resourceGroup, ok := attrs.Get(AttributeResourceGroupName); ok {
+		splitAll := strings.Split(resourceGroup.StringVal(), "_")
+		if len(splitAll) < 4 || strings.ToLower(splitAll[0]) != "mc" {
+			return "", false // Failed to parse
+		}
+		return splitAll[len(splitAll)-2], true
+	}
+
+	return "", false
+}

--- a/pkg/otlp/model/attributes/azure/azure.go
+++ b/pkg/otlp/model/attributes/azure/azure.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package azure
 
 import (

--- a/pkg/otlp/model/attributes/azure/azure_test.go
+++ b/pkg/otlp/model/attributes/azure/azure_test.go
@@ -1,0 +1,79 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package azure
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+
+	"github.com/DataDog/datadog-agent/pkg/otlp/model/internal/testutils"
+)
+
+var (
+	testVMID     = "02aab8a4-74ef-476e-8182-f6d2ba4166a6"
+	testHostname = "test-hostname"
+	testAttrs    = testutils.NewAttributeMap(map[string]string{
+		conventions.AttributeCloudProvider:  conventions.AttributeCloudProviderAzure,
+		conventions.AttributeHostName:       testHostname,
+		conventions.AttributeCloudRegion:    "location",
+		conventions.AttributeHostID:         testVMID,
+		conventions.AttributeCloudAccountID: "subscriptionID",
+		AttributeResourceGroupName:          "resourceGroup",
+	})
+	testEmpty = testutils.NewAttributeMap(map[string]string{})
+)
+
+func TestHostInfoFromAttributes(t *testing.T) {
+	hostInfo := HostInfoFromAttributes(testAttrs)
+	require.NotNil(t, hostInfo)
+	assert.ElementsMatch(t, hostInfo.HostAliases, []string{testVMID})
+
+	emptyHostInfo := HostInfoFromAttributes(testEmpty)
+	require.NotNil(t, emptyHostInfo)
+	assert.ElementsMatch(t, emptyHostInfo.HostAliases, []string{})
+}
+
+func TestHostnameFromAttributes(t *testing.T) {
+	hostname, ok := HostnameFromAttributes(testAttrs)
+	assert.True(t, ok)
+	assert.Equal(t, hostname, testHostname)
+
+	_, ok = HostnameFromAttributes(testEmpty)
+	assert.False(t, ok)
+}
+
+func TestClusterNameFromAttributes(t *testing.T) {
+	cluster, ok := ClusterNameFromAttributes(testutils.NewAttributeMap(map[string]string{
+		AttributeResourceGroupName: "MC_aks-kenafeh_aks-kenafeh-eu_westeurope",
+	}))
+	assert.True(t, ok)
+	assert.Equal(t, cluster, "aks-kenafeh-eu")
+
+	cluster, ok = ClusterNameFromAttributes(testutils.NewAttributeMap(map[string]string{
+		AttributeResourceGroupName: "mc_foo-bar-aks-k8s-rg_foo-bar-aks-k8s_westeurope",
+	}))
+	assert.True(t, ok)
+	assert.Equal(t, cluster, "foo-bar-aks-k8s")
+
+	_, ok = ClusterNameFromAttributes(testutils.NewAttributeMap(map[string]string{
+		AttributeResourceGroupName: "unexpected-resource-group-name-format",
+	}))
+	assert.False(t, ok)
+
+	_, ok = ClusterNameFromAttributes(testutils.NewAttributeMap(map[string]string{}))
+	assert.False(t, ok)
+}

--- a/pkg/otlp/model/attributes/ec2/ec2.go
+++ b/pkg/otlp/model/attributes/ec2/ec2.go
@@ -1,0 +1,99 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ec2
+
+import (
+	"fmt"
+	"strings"
+
+	"go.opentelemetry.io/collector/model/pdata"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+)
+
+var (
+	defaultPrefixes  = [3]string{"ip-", "domu", "ec2amaz-"}
+	ec2TagPrefix     = "ec2.tag."
+	clusterTagPrefix = ec2TagPrefix + "kubernetes.io/cluster/"
+)
+
+type HostInfo struct {
+	InstanceID  string
+	EC2Hostname string
+	EC2Tags     []string
+}
+
+// isDefaultHostname checks if a hostname is an EC2 default
+func isDefaultHostname(hostname string) bool {
+	for _, val := range defaultPrefixes {
+		if strings.HasPrefix(hostname, val) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// HostnameFromAttributes gets a valid hostname from labels
+// if available
+func HostnameFromAttributes(attrs pdata.AttributeMap) (string, bool) {
+	hostName, ok := attrs.Get(conventions.AttributeHostName)
+	if ok && !isDefaultHostname(hostName.StringVal()) {
+		return hostName.StringVal(), true
+	}
+
+	if hostID, ok := attrs.Get(conventions.AttributeHostID); ok {
+		return hostID.StringVal(), true
+	}
+
+	return "", false
+}
+
+// HostInfoFromAttributes gets EC2 host info from attributes following
+// OpenTelemetry semantic conventions
+func HostInfoFromAttributes(attrs pdata.AttributeMap) (hostInfo *HostInfo) {
+	hostInfo = &HostInfo{}
+
+	if hostID, ok := attrs.Get(conventions.AttributeHostID); ok {
+		hostInfo.InstanceID = hostID.StringVal()
+	}
+
+	if hostName, ok := attrs.Get(conventions.AttributeHostName); ok {
+		hostInfo.EC2Hostname = hostName.StringVal()
+	}
+
+	attrs.Range(func(k string, v pdata.AttributeValue) bool {
+		if strings.HasPrefix(k, ec2TagPrefix) {
+			tag := fmt.Sprintf("%s:%s", strings.TrimPrefix(k, ec2TagPrefix), v.StringVal())
+			hostInfo.EC2Tags = append(hostInfo.EC2Tags, tag)
+		}
+		return true
+	})
+
+	return
+}
+
+// ClusterNameFromAttributes gets the AWS cluster name from attributes
+func ClusterNameFromAttributes(attrs pdata.AttributeMap) (clusterName string, ok bool) {
+	// Get cluster name from tag keys
+	// https://github.com/DataDog/datadog-agent/blob/1c94b11/pkg/util/ec2/ec2.go#L238
+	attrs.Range(func(k string, _ pdata.AttributeValue) bool {
+		if strings.HasPrefix(k, clusterTagPrefix) {
+			clusterName = strings.Split(k, "/")[2]
+			ok = true
+		}
+		return true
+	})
+	return
+}

--- a/pkg/otlp/model/attributes/ec2/ec2.go
+++ b/pkg/otlp/model/attributes/ec2/ec2.go
@@ -28,6 +28,7 @@ var (
 	clusterTagPrefix = ec2TagPrefix + "kubernetes.io/cluster/"
 )
 
+// HostInfo holds the EC2 host information.
 type HostInfo struct {
 	InstanceID  string
 	EC2Hostname string

--- a/pkg/otlp/model/attributes/ec2/ec2_test.go
+++ b/pkg/otlp/model/attributes/ec2/ec2_test.go
@@ -1,0 +1,78 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ec2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+
+	"github.com/DataDog/datadog-agent/pkg/otlp/model/internal/testutils"
+)
+
+const (
+	testIP         = "ip-12-34-56-78.us-west-2.compute.internal"
+	testDomu       = "domu-12-34-56-78.us-west-2.compute.internal"
+	testEC2        = "ec2amaz-12-34-56-78.us-west-2.compute.internal"
+	customHost     = "custom-hostname"
+	testInstanceID = "i-0123456789"
+)
+
+func TestDefaultHostname(t *testing.T) {
+	assert.True(t, isDefaultHostname(testIP))
+	assert.True(t, isDefaultHostname(testDomu))
+	assert.True(t, isDefaultHostname(testEC2))
+	assert.False(t, isDefaultHostname(customHost))
+}
+
+func TestHostnameFromAttributes(t *testing.T) {
+	attrs := testutils.NewAttributeMap(map[string]string{
+		conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAWS,
+		conventions.AttributeHostID:        testInstanceID,
+		conventions.AttributeHostName:      testIP,
+	})
+	hostname, ok := HostnameFromAttributes(attrs)
+	assert.True(t, ok)
+	assert.Equal(t, hostname, testInstanceID)
+}
+
+func TestHostInfoFromAttributes(t *testing.T) {
+	attrs := testutils.NewAttributeMap(map[string]string{
+		conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAWS,
+		conventions.AttributeHostID:        testInstanceID,
+		conventions.AttributeHostName:      testIP,
+		"ec2.tag.tag1":                     "val1",
+		"ec2.tag.tag2":                     "val2",
+		"ignored":                          "ignored",
+	})
+
+	hostInfo := HostInfoFromAttributes(attrs)
+
+	assert.Equal(t, hostInfo.InstanceID, testInstanceID)
+	assert.Equal(t, hostInfo.EC2Hostname, testIP)
+	assert.ElementsMatch(t, hostInfo.EC2Tags, []string{"tag1:val1", "tag2:val2"})
+}
+
+func TestClusterNameFromAttributes(t *testing.T) {
+	cluster, ok := ClusterNameFromAttributes(testutils.NewAttributeMap(map[string]string{
+		"ec2.tag.kubernetes.io/cluster/clustername": "dummy_value",
+	}))
+	assert.True(t, ok)
+	assert.Equal(t, cluster, "clustername")
+
+	_, ok = ClusterNameFromAttributes(testutils.NewAttributeMap(map[string]string{}))
+	assert.False(t, ok)
+}

--- a/pkg/otlp/model/attributes/gcp/gcp.go
+++ b/pkg/otlp/model/attributes/gcp/gcp.go
@@ -1,0 +1,63 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package gcp
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/collector/model/pdata"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+)
+
+type HostInfo struct {
+	HostAliases []string
+	GCPTags     []string
+}
+
+// HostnameFromAttributes gets a valid hostname from labels
+// if available
+func HostnameFromAttributes(attrs pdata.AttributeMap) (string, bool) {
+	if hostName, ok := attrs.Get(conventions.AttributeHostName); ok {
+		return hostName.StringVal(), true
+	}
+
+	return "", false
+}
+
+// HostInfoFromAttributes gets GCP host info from attributes following
+// OpenTelemetry semantic conventions
+func HostInfoFromAttributes(attrs pdata.AttributeMap) (hostInfo *HostInfo) {
+	hostInfo = &HostInfo{}
+
+	if hostID, ok := attrs.Get(conventions.AttributeHostID); ok {
+		// Add host id as a host alias to preserve backwards compatibility
+		// The Datadog Agent does not do this
+		hostInfo.HostAliases = append(hostInfo.HostAliases, hostID.StringVal())
+		hostInfo.GCPTags = append(hostInfo.GCPTags, fmt.Sprintf("instance-id:%s", hostID.StringVal()))
+	}
+
+	if cloudZone, ok := attrs.Get(conventions.AttributeCloudAvailabilityZone); ok {
+		hostInfo.GCPTags = append(hostInfo.GCPTags, fmt.Sprintf("zone:%s", cloudZone.StringVal()))
+	}
+
+	if hostType, ok := attrs.Get(conventions.AttributeHostType); ok {
+		hostInfo.GCPTags = append(hostInfo.GCPTags, fmt.Sprintf("instance-type:%s", hostType.StringVal()))
+	}
+
+	if cloudAccount, ok := attrs.Get(conventions.AttributeCloudAccountID); ok {
+		hostInfo.GCPTags = append(hostInfo.GCPTags, fmt.Sprintf("project:%s", cloudAccount.StringVal()))
+	}
+
+	return
+}

--- a/pkg/otlp/model/attributes/gcp/gcp.go
+++ b/pkg/otlp/model/attributes/gcp/gcp.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package gcp
 
 import (
@@ -20,6 +21,7 @@ import (
 	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
 )
 
+// HostInfo holds the GCP host information.
 type HostInfo struct {
 	HostAliases []string
 	GCPTags     []string

--- a/pkg/otlp/model/attributes/gcp/gcp_test.go
+++ b/pkg/otlp/model/attributes/gcp/gcp_test.go
@@ -1,0 +1,61 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package gcp
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+
+	"github.com/DataDog/datadog-agent/pkg/otlp/model/internal/testutils"
+)
+
+const (
+	testHostname     = "hostname"
+	testHostID       = "hostID"
+	testCloudZone    = "zone"
+	testHostType     = "machineType"
+	testCloudAccount = "projectID"
+)
+
+func TestHostnameFromAttributes(t *testing.T) {
+	attrs := testutils.NewAttributeMap(map[string]string{
+		conventions.AttributeCloudProvider: conventions.AttributeCloudProviderGCP,
+		conventions.AttributeHostID:        testHostID,
+		conventions.AttributeHostName:      testHostname,
+	})
+	hostname, ok := HostnameFromAttributes(attrs)
+	assert.True(t, ok)
+	assert.Equal(t, hostname, testHostname)
+
+	attrs = testutils.NewAttributeMap(map[string]string{})
+	_, ok = HostnameFromAttributes(attrs)
+	assert.False(t, ok)
+}
+
+func TestHostInfoFromAttributes(t *testing.T) {
+	attrs := testutils.NewAttributeMap(map[string]string{
+		conventions.AttributeCloudProvider:         conventions.AttributeCloudProviderGCP,
+		conventions.AttributeHostID:                testHostID,
+		conventions.AttributeHostName:              testHostname,
+		conventions.AttributeCloudAvailabilityZone: testCloudZone,
+		conventions.AttributeHostType:              testHostType,
+		conventions.AttributeCloudAccountID:        testCloudAccount,
+	})
+	hostInfo := HostInfoFromAttributes(attrs)
+	assert.ElementsMatch(t, hostInfo.HostAliases, []string{testHostID})
+	assert.ElementsMatch(t, hostInfo.GCPTags,
+		[]string{"instance-id:hostID", "zone:zone", "instance-type:machineType", "project:projectID"})
+}

--- a/pkg/otlp/model/attributes/hostname.go
+++ b/pkg/otlp/model/attributes/hostname.go
@@ -1,0 +1,97 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attributes
+
+import (
+	"go.opentelemetry.io/collector/model/pdata"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+
+	"github.com/DataDog/datadog-agent/pkg/otlp/model/attributes/azure"
+	"github.com/DataDog/datadog-agent/pkg/otlp/model/attributes/ec2"
+	"github.com/DataDog/datadog-agent/pkg/otlp/model/attributes/gcp"
+)
+
+const (
+	// AttributeDatadogHostname the datadog host name attribute
+	AttributeDatadogHostname = "datadog.host.name"
+	// AttributeK8sNodeName the datadog k8s node name attribute
+	AttributeK8sNodeName = "k8s.node.name"
+)
+
+func getClusterName(attrs pdata.AttributeMap) (string, bool) {
+	if k8sClusterName, ok := attrs.Get(conventions.AttributeK8SClusterName); ok {
+		return k8sClusterName.StringVal(), true
+	}
+
+	cloudProvider, ok := attrs.Get(conventions.AttributeCloudProvider)
+	if ok && cloudProvider.StringVal() == conventions.AttributeCloudProviderAzure {
+		return azure.ClusterNameFromAttributes(attrs)
+	} else if ok && cloudProvider.StringVal() == conventions.AttributeCloudProviderAWS {
+		return ec2.ClusterNameFromAttributes(attrs)
+	}
+
+	return "", false
+}
+
+// HostnameFromAttributes tries to get a valid hostname from attributes by checking, in order:
+//
+//   1. a custom Datadog hostname provided by the "datadog.host.name" attribute
+//   2. the Kubernetes node name (and cluster name if available),
+//   3. cloud provider specific hostname for AWS or GCP
+//   4. the container ID,
+//   5. the cloud provider host ID and
+//   6. the host.name attribute.
+//
+//  It returns a boolean value indicated if any name was found
+func HostnameFromAttributes(attrs pdata.AttributeMap) (string, bool) {
+	// Custom hostname: useful for overriding in k8s/cloud envs
+	if customHostname, ok := attrs.Get(AttributeDatadogHostname); ok {
+		return customHostname.StringVal(), true
+	}
+
+	// Kubernetes: node-cluster if cluster name is available, else node
+	if k8sNodeName, ok := attrs.Get(AttributeK8sNodeName); ok {
+		if k8sClusterName, ok := getClusterName(attrs); ok {
+			return k8sNodeName.StringVal() + "-" + k8sClusterName, true
+		}
+		return k8sNodeName.StringVal(), true
+	}
+
+	cloudProvider, ok := attrs.Get(conventions.AttributeCloudProvider)
+	if ok && cloudProvider.StringVal() == conventions.AttributeCloudProviderAWS {
+		return ec2.HostnameFromAttributes(attrs)
+	} else if ok && cloudProvider.StringVal() == conventions.AttributeCloudProviderGCP {
+		return gcp.HostnameFromAttributes(attrs)
+	} else if ok && cloudProvider.StringVal() == conventions.AttributeCloudProviderAzure {
+		return azure.HostnameFromAttributes(attrs)
+	}
+
+	// host id from cloud provider
+	if hostID, ok := attrs.Get(conventions.AttributeHostID); ok {
+		return hostID.StringVal(), true
+	}
+
+	// hostname from cloud provider or OS
+	if hostName, ok := attrs.Get(conventions.AttributeHostName); ok {
+		return hostName.StringVal(), true
+	}
+
+	// container id (e.g. from Docker)
+	if containerID, ok := attrs.Get(conventions.AttributeContainerID); ok {
+		return containerID.StringVal(), true
+	}
+
+	return "", false
+}

--- a/pkg/otlp/model/attributes/hostname_test.go
+++ b/pkg/otlp/model/attributes/hostname_test.go
@@ -1,0 +1,172 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attributes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+
+	"github.com/DataDog/datadog-agent/pkg/otlp/model/attributes/azure"
+	"github.com/DataDog/datadog-agent/pkg/otlp/model/internal/testutils"
+)
+
+const (
+	testHostID      = "example-host-id"
+	testHostName    = "example-host-name"
+	testContainerID = "example-container-id"
+	testClusterName = "clusterName"
+	testNodeName    = "nodeName"
+	testCustomName  = "example-custom-host-name"
+)
+
+func TestHostnameFromAttributes(t *testing.T) {
+	// Custom hostname
+	attrs := testutils.NewAttributeMap(map[string]string{
+		AttributeDatadogHostname:            testCustomName,
+		AttributeK8sNodeName:                testNodeName,
+		conventions.AttributeK8SClusterName: testClusterName,
+		conventions.AttributeContainerID:    testContainerID,
+		conventions.AttributeHostID:         testHostID,
+		conventions.AttributeHostName:       testHostName,
+	})
+	hostname, ok := HostnameFromAttributes(attrs)
+	assert.True(t, ok)
+	assert.Equal(t, hostname, testCustomName)
+
+	// Container ID
+	attrs = testutils.NewAttributeMap(map[string]string{
+		conventions.AttributeContainerID: testContainerID,
+	})
+	hostname, ok = HostnameFromAttributes(attrs)
+	assert.True(t, ok)
+	assert.Equal(t, hostname, testContainerID)
+
+	// AWS cloud provider means relying on the EC2 function
+	attrs = testutils.NewAttributeMap(map[string]string{
+		conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAWS,
+		conventions.AttributeHostID:        testHostID,
+		conventions.AttributeHostName:      testHostName,
+	})
+	hostname, ok = HostnameFromAttributes(attrs)
+	assert.True(t, ok)
+	assert.Equal(t, hostname, testHostName)
+
+	// GCP cloud provider means relying on the GCP function
+	attrs = testutils.NewAttributeMap(map[string]string{
+		conventions.AttributeCloudProvider: conventions.AttributeCloudProviderGCP,
+		conventions.AttributeHostID:        testHostID,
+		conventions.AttributeHostName:      testHostName,
+	})
+	hostname, ok = HostnameFromAttributes(attrs)
+	assert.True(t, ok)
+	assert.Equal(t, hostname, testHostName)
+
+	// Azure cloud provider means relying on the Azure function
+	attrs = testutils.NewAttributeMap(map[string]string{
+		conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAzure,
+		conventions.AttributeHostID:        testHostID,
+		conventions.AttributeHostName:      testHostName,
+	})
+	hostname, ok = HostnameFromAttributes(attrs)
+	assert.True(t, ok)
+	assert.Equal(t, hostname, testHostName)
+
+	// Host Id takes preference
+	attrs = testutils.NewAttributeMap(map[string]string{
+		conventions.AttributeHostID:   testHostID,
+		conventions.AttributeHostName: testHostName,
+	})
+	hostname, ok = HostnameFromAttributes(attrs)
+	assert.True(t, ok)
+	assert.Equal(t, hostname, testHostID)
+
+	// No labels means no hostname
+	attrs = testutils.NewAttributeMap(map[string]string{})
+	hostname, ok = HostnameFromAttributes(attrs)
+	assert.False(t, ok)
+	assert.Empty(t, hostname)
+}
+
+func TestGetClusterName(t *testing.T) {
+	// OpenTelemetry convention
+	attrs := testutils.NewAttributeMap(map[string]string{
+		conventions.AttributeK8SClusterName: testClusterName,
+	})
+	cluster, ok := getClusterName(attrs)
+	assert.True(t, ok)
+	assert.Equal(t, cluster, testClusterName)
+
+	// Azure
+	attrs = testutils.NewAttributeMap(map[string]string{
+		conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAzure,
+		azure.AttributeResourceGroupName:   "MC_aks-kenafeh_aks-kenafeh-eu_westeurope",
+	})
+	cluster, ok = getClusterName(attrs)
+	assert.True(t, ok)
+	assert.Equal(t, cluster, "aks-kenafeh-eu")
+
+	// AWS
+	attrs = testutils.NewAttributeMap(map[string]string{
+		conventions.AttributeCloudProvider:          conventions.AttributeCloudProviderAWS,
+		"ec2.tag.kubernetes.io/cluster/clustername": "dummy_value",
+	})
+	cluster, ok = getClusterName(attrs)
+	assert.True(t, ok)
+	assert.Equal(t, cluster, "clustername")
+
+	// None
+	attrs = testutils.NewAttributeMap(map[string]string{})
+	_, ok = getClusterName(attrs)
+	assert.False(t, ok)
+}
+
+func TestHostnameKubernetes(t *testing.T) {
+	// Node name and cluster name
+	attrs := testutils.NewAttributeMap(map[string]string{
+		AttributeK8sNodeName:                testNodeName,
+		conventions.AttributeK8SClusterName: testClusterName,
+		conventions.AttributeContainerID:    testContainerID,
+		conventions.AttributeHostID:         testHostID,
+		conventions.AttributeHostName:       testHostName,
+	})
+	hostname, ok := HostnameFromAttributes(attrs)
+	assert.True(t, ok)
+	assert.Equal(t, hostname, "nodeName-clusterName")
+
+	// Node name, no cluster name
+	attrs = testutils.NewAttributeMap(map[string]string{
+		AttributeK8sNodeName:             testNodeName,
+		conventions.AttributeContainerID: testContainerID,
+		conventions.AttributeHostID:      testHostID,
+		conventions.AttributeHostName:    testHostName,
+	})
+	hostname, ok = HostnameFromAttributes(attrs)
+	assert.True(t, ok)
+	assert.Equal(t, hostname, "nodeName")
+
+	// no node name, cluster name
+	attrs = testutils.NewAttributeMap(map[string]string{
+		conventions.AttributeK8SClusterName: testClusterName,
+		conventions.AttributeContainerID:    testContainerID,
+		conventions.AttributeHostID:         testHostID,
+		conventions.AttributeHostName:       testHostName,
+	})
+	hostname, ok = HostnameFromAttributes(attrs)
+	assert.True(t, ok)
+	// cluster name gets ignored, fallback to next option
+	assert.Equal(t, hostname, testHostID)
+}

--- a/pkg/otlp/model/attributes/process.go
+++ b/pkg/otlp/model/attributes/process.go
@@ -1,0 +1,55 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attributes
+
+import (
+	"fmt"
+
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+)
+
+type processAttributes struct {
+	ExecutableName string
+	ExecutablePath string
+	Command        string
+	CommandLine    string
+	PID            int64
+	Owner          string
+}
+
+func (pattrs *processAttributes) extractTags() []string {
+	tags := make([]string, 0, 1)
+
+	// According to OTel conventions: https://github.com/open-telemetry/opentelemetry-specification/blob/main/specification/resource/semantic_conventions/process.md,
+	// a process can be defined by any of the 4 following attributes: process.executable.name, process.executable.path, process.command or process.command_line
+	// (process.command_args isn't in the current attribute conventions: https://github.com/open-telemetry/opentelemetry-collector/blob/ecb27f49d4e26ae42d82e6ea18d57b08e252452d/model/semconv/opentelemetry.go#L58-L63)
+	// We go through them, and add the first available one as a tag to identify the process.
+	// We don't want to add all of them to avoid unnecessarily increasing the number of tags attached to a metric.
+
+	// TODO: check if this order should be changed.
+	if pattrs.ExecutableName != "" { // otelcol
+		tags = append(tags, fmt.Sprintf("%s:%s", conventions.AttributeProcessExecutableName, pattrs.ExecutableName))
+	} else if pattrs.ExecutablePath != "" { // /usr/bin/cmd/otelcol
+		tags = append(tags, fmt.Sprintf("%s:%s", conventions.AttributeProcessExecutablePath, pattrs.ExecutablePath))
+	} else if pattrs.Command != "" { // cmd/otelcol
+		tags = append(tags, fmt.Sprintf("%s:%s", conventions.AttributeProcessCommand, pattrs.Command))
+	} else if pattrs.CommandLine != "" { // cmd/otelcol --config="/path/to/config.yaml"
+		tags = append(tags, fmt.Sprintf("%s:%s", conventions.AttributeProcessCommandLine, pattrs.CommandLine))
+	}
+
+	// For now, we don't care about the process ID nor the process owner.
+
+	return tags
+}

--- a/pkg/otlp/model/attributes/process_test.go
+++ b/pkg/otlp/model/attributes/process_test.go
@@ -1,0 +1,77 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attributes
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+)
+
+func TestProcessExtractTags(t *testing.T) {
+	pattrs := processAttributes{
+		ExecutableName: "otelcol",
+		ExecutablePath: "/usr/bin/cmd/otelcol",
+		Command:        "cmd/otelcol",
+		CommandLine:    "cmd/otelcol --config=\"/path/to/config.yaml\"",
+		PID:            1,
+		Owner:          "root",
+	}
+
+	assert.Equal(t, []string{
+		fmt.Sprintf("%s:%s", conventions.AttributeProcessExecutableName, "otelcol"),
+	}, pattrs.extractTags())
+
+	pattrs = processAttributes{
+		ExecutablePath: "/usr/bin/cmd/otelcol",
+		Command:        "cmd/otelcol",
+		CommandLine:    "cmd/otelcol --config=\"/path/to/config.yaml\"",
+		PID:            1,
+		Owner:          "root",
+	}
+
+	assert.Equal(t, []string{
+		fmt.Sprintf("%s:%s", conventions.AttributeProcessExecutablePath, "/usr/bin/cmd/otelcol"),
+	}, pattrs.extractTags())
+
+	pattrs = processAttributes{
+		Command:     "cmd/otelcol",
+		CommandLine: "cmd/otelcol --config=\"/path/to/config.yaml\"",
+		PID:         1,
+		Owner:       "root",
+	}
+
+	assert.Equal(t, []string{
+		fmt.Sprintf("%s:%s", conventions.AttributeProcessCommand, "cmd/otelcol"),
+	}, pattrs.extractTags())
+
+	pattrs = processAttributes{
+		CommandLine: "cmd/otelcol --config=\"/path/to/config.yaml\"",
+		PID:         1,
+		Owner:       "root",
+	}
+
+	assert.Equal(t, []string{
+		fmt.Sprintf("%s:%s", conventions.AttributeProcessCommandLine, "cmd/otelcol --config=\"/path/to/config.yaml\""),
+	}, pattrs.extractTags())
+}
+
+func TestProcessExtractTagsEmpty(t *testing.T) {
+	pattrs := processAttributes{}
+
+	assert.Equal(t, []string{}, pattrs.extractTags())
+}

--- a/pkg/otlp/model/attributes/system.go
+++ b/pkg/otlp/model/attributes/system.go
@@ -1,0 +1,36 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attributes
+
+import (
+	"fmt"
+
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+)
+
+type systemAttributes struct {
+	OSType string
+}
+
+func (sattrs *systemAttributes) extractTags() []string {
+	tags := make([]string, 0, 1)
+
+	// Add OS type, eg. WINDOWS, LINUX, etc.
+	if sattrs.OSType != "" {
+		tags = append(tags, fmt.Sprintf("%s:%s", conventions.AttributeOSType, sattrs.OSType))
+	}
+
+	return tags
+}

--- a/pkg/otlp/model/attributes/system_test.go
+++ b/pkg/otlp/model/attributes/system_test.go
@@ -1,0 +1,39 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attributes
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+)
+
+func TestSystemExtractTags(t *testing.T) {
+	sattrs := systemAttributes{
+		OSType: "WINDOWS",
+	}
+
+	assert.Equal(t, []string{
+		fmt.Sprintf("%s:%s", conventions.AttributeOSType, "WINDOWS"),
+	}, sattrs.extractTags())
+}
+
+func TestSystemExtractTagsEmpty(t *testing.T) {
+	sattrs := systemAttributes{}
+
+	assert.Equal(t, []string{}, sattrs.extractTags())
+}

--- a/pkg/otlp/model/internal/testutils/test_utils.go
+++ b/pkg/otlp/model/internal/testutils/test_utils.go
@@ -1,0 +1,19 @@
+package testutils
+
+import "go.opentelemetry.io/collector/model/pdata"
+
+func fillAttributeMap(attrs pdata.AttributeMap, mp map[string]string) {
+	attrs.Clear()
+	attrs.EnsureCapacity(len(mp))
+	for k, v := range mp {
+		attrs.Insert(k, pdata.NewAttributeValueString(v))
+	}
+}
+
+// NewAttributeMap creates a new attribute map (string only)
+// from a Go map
+func NewAttributeMap(mp map[string]string) pdata.AttributeMap {
+	attrs := pdata.NewAttributeMap()
+	fillAttributeMap(attrs, mp)
+	return attrs
+}


### PR DESCRIPTION
### What does this PR do?

Moves OpenTelemetry Collector Contrib Datadog exporter [`attributes` package](https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/v0.35.0/exporter/datadogexporter/internal/attributes) as of version `v0.35.0` to `pkg/otlp/model`.

**All the code has already been reviewed on the OpenTelemetry Collector.**

To do this I

1. copied the attributes code,
2. copied the testutils function used in tests to an internal package and
3. replaced imports using the following commands:

```
rg -l github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/testutils | xargs sd github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/testutils github.com/DataDog/datadog-agent/pkg/otlp/model/internal/testutils
rg -l github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/attributes | xargs sd github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/attributes github.com/DataDog/datadog-agent/pkg/otlp/model/attributes
```

I also had to address some `revive` comments (1721db43ca2548574985015b7f406332a16d8781).

### Motivation

DataDog/architecture#892

### Additional Notes

A future PR will bundle this into a Go module for Collector reuse (together with the translator).

### Describe how to test your changes

This is a noop, to be tested together with future PRs.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
