### PR TITLE
Adding install tool metadata info to the inventory payload

### DIFF
--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/status"
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
+	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/alibaba"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
@@ -311,6 +312,9 @@ func getInstallMethod(infoPath string) *InstallMethod {
 
 	// if we could not get install info
 	if err != nil {
+		inventories.SetAgentMetadata(inventories.AgentInstallTool, "undefined")
+		inventories.SetAgentMetadata(inventories.AgentInstallToolVersion, "")
+		inventories.SetAgentMetadata(inventories.AgentInstallerVersion, "")
 		// consider install info is kept "undefined"
 		return &InstallMethod{
 			ToolVersion:      "undefined",
@@ -319,6 +323,9 @@ func getInstallMethod(infoPath string) *InstallMethod {
 		}
 	}
 
+	inventories.SetAgentMetadata(inventories.AgentInstallTool, install.Method.Tool)
+	inventories.SetAgentMetadata(inventories.AgentInstallToolVersion, install.Method.ToolVersion)
+	inventories.SetAgentMetadata(inventories.AgentInstallerVersion, install.Method.InstallerVersion)
 	return &InstallMethod{
 		ToolVersion:      install.Method.ToolVersion,
 		Tool:             &install.Method.Tool,

--- a/pkg/metadata/inventories/README.md
+++ b/pkg/metadata/inventories/README.md
@@ -43,6 +43,11 @@ The payload is a JSON dict with the following fields
   - `version` - **string**: the version of the Agent.
   - `flavor` - **string**: the flavor of the Agent. The Agent can be build under different flavor such as standalone
     dogstatsd, iot, serverless ... (see `pkg/util/flavor` package).
+  - `install_method_tool` - **string**: the name of the tool used to install the agent (ie, Chef, Ansible, ...).
+  - `install_method_tool_version` - **string**: the tool version used to install the agent (ie: Chef version, Ansible
+    version, ...). This defaults to `"undefined"` when not installed through a tool (like when installed with apt, source
+    build, ...).
+  - `install_method_installer_version` - **string**:  The version of Datadog module (ex: the Chef Datadog package, the Datadog Ansible playbook, ...).
 
 ## Example Payload
 

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -64,10 +64,13 @@ type AgentMetadataName string
 // pkg/metadata/inventories/README.md and any additions should
 // be updated there as well.
 const (
-	AgentCloudProvider  AgentMetadataName = "cloud_provider"
-	AgentHostnameSource AgentMetadataName = "hostname_source"
-	AgentVersion        AgentMetadataName = "version"
-	AgentFlavor         AgentMetadataName = "flavor"
+	AgentCloudProvider      AgentMetadataName = "cloud_provider"
+	AgentHostnameSource     AgentMetadataName = "hostname_source"
+	AgentVersion            AgentMetadataName = "version"
+	AgentFlavor             AgentMetadataName = "flavor"
+	AgentInstallerVersion   AgentMetadataName = "install_method_installer_version"
+	AgentInstallTool        AgentMetadataName = "install_method_tool"
+	AgentInstallToolVersion AgentMetadataName = "install_method_tool_version"
 )
 
 // SetAgentMetadata updates the agent metadata value in the cache


### PR DESCRIPTION
### What does this PR do?
Adding install tool metadata info to the inventory payload

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
