### PR TITLE
[network/agent/ebpf] connections tags

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a // indirect
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
 	github.com/BurntSushi/toml v0.4.1 // indirect
-	github.com/DataDog/agent-payload/v5 v5.0.4
+	github.com/DataDog/agent-payload/v5 v5.0.6
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/otlp/model v0.33.0-rc.4
 	github.com/DataDog/datadog-agent/pkg/quantile v0.33.0-rc.4

--- a/go.sum
+++ b/go.sum
@@ -105,8 +105,8 @@ github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw
 github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/DataDog/agent-payload/v5 v5.0.4 h1:4iFVwqPoBi+FbViN37gPtMUAbiwCtI1NiLleHI+fQ8M=
-github.com/DataDog/agent-payload/v5 v5.0.4/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
+github.com/DataDog/agent-payload/v5 v5.0.6 h1:XIcWuoQRkF74UWcVo8kuUwIS8Z5vS8dju9xROkCKhT4=
+github.com/DataDog/agent-payload/v5 v5.0.6/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/DataDog/datadog-api-client-go v1.0.0-beta.18/go.mod h1:Gn0fZwIOBbSidO0OaPEh9nO5EmIPsxJrHfHvfVXEaoU=

--- a/pkg/network/ebpf/c/http-types.h
+++ b/pkg/network/ebpf/c/http-types.h
@@ -64,6 +64,7 @@ typedef struct {
     // be populated with the "original" (pre-normalization) source port number of
     // the TCP segment containing the beginning of a given HTTP request
     __u16 owned_by_src_port;
+    __u64 tags;
 } http_transaction_t;
 
 typedef struct {

--- a/pkg/network/ebpf/c/http.h
+++ b/pkg/network/ebpf/c/http.h
@@ -167,7 +167,7 @@ static __always_inline void http_parse_data(char *p, http_packet_t *packet_type,
     }
 }
 
-static __always_inline int http_process(char *buffer, skb_info_t *skb_info, u16 src_port) {
+static __always_inline int http_process(char *buffer, skb_info_t *skb_info, u16 src_port, u64 tags) {
     http_packet_t packet_type = HTTP_PACKET_UNKNOWN;
     http_method_t method = HTTP_METHOD_UNKNOWN;
     http_parse_data(buffer, &packet_type, &method);
@@ -200,6 +200,8 @@ static __always_inline int http_process(char *buffer, skb_info_t *skb_info, u16 
             return 0;
         }
     }
+
+    http->tags |= tags;
 
     // If we have a (L7/application-layer) payload we want to update the response_last_seen
     // This is to prevent things such as a keep-alive adding up to the transaction latency

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -6,6 +6,7 @@
 #include "http-buffer.h"
 #include "sock.h"
 #include "sockfd.h"
+#include "tags-types.h"
 
 // TODO: Replace those by injected constants based on system configuration
 // once we have port range detection merged into the codebase.
@@ -61,7 +62,7 @@ int socket__http_filter(struct __sk_buff* skb) {
     char buffer[HTTP_BUFFER_SIZE];
     __builtin_memset(buffer, 0, sizeof(buffer));
     read_skb_data(skb, skb_info.data_off, buffer);
-    http_process(buffer, &skb_info, src_port);
+    http_process(buffer, &skb_info, src_port, NO_TAGS);
     return 0;
 }
 
@@ -202,7 +203,7 @@ int uretprobe__SSL_read(struct pt_regs* ctx) {
 
     skb_info_t skb_info = {0};
     __builtin_memcpy(&skb_info.tup, t, sizeof(conn_tuple_t));
-    http_process(buffer, &skb_info, skb_info.tup.sport);
+    http_process(buffer, &skb_info, skb_info.tup.sport, LIBSSL);
  cleanup:
     bpf_map_delete_elem(&ssl_read_args, &pid_tgid);
     return 0;
@@ -224,7 +225,7 @@ int uprobe__SSL_write(struct pt_regs* ctx) {
 
     skb_info_t skb_info = {0};
     __builtin_memcpy(&skb_info.tup, t, sizeof(conn_tuple_t));
-    http_process(buffer, &skb_info, skb_info.tup.sport);
+    http_process(buffer, &skb_info, skb_info.tup.sport, LIBSSL);
     return 0;
 }
 
@@ -245,7 +246,7 @@ int uprobe__SSL_shutdown(struct pt_regs* ctx) {
 
     // TODO: this is just a hack. Let's get rid of this skb_info argument altogether
     skb_info.tcp_flags |= TCPHDR_FIN;
-    http_process(buffer, &skb_info, skb_info.tup.sport);
+    http_process(buffer, &skb_info, skb_info.tup.sport, LIBSSL);
     bpf_map_delete_elem(&ssl_sock_by_ctx, &ssl_ctx);
     return 0;
 }
@@ -331,7 +332,7 @@ int uretprobe__gnutls_record_recv(struct pt_regs* ctx) {
 
     skb_info_t skb_info = {0};
     __builtin_memcpy(&skb_info.tup, t, sizeof(conn_tuple_t));
-    http_process(buffer, &skb_info, skb_info.tup.sport);
+    http_process(buffer, &skb_info, skb_info.tup.sport, LIBGNUTLS);
  cleanup:
     bpf_map_delete_elem(&ssl_read_args, &pid_tgid);
     return 0;
@@ -355,7 +356,7 @@ int uprobe__gnutls_record_send(struct pt_regs* ctx) {
 
     skb_info_t skb_info = {0};
     __builtin_memcpy(&skb_info.tup, t, sizeof(conn_tuple_t));
-    http_process(buffer, &skb_info, skb_info.tup.sport);
+    http_process(buffer, &skb_info, skb_info.tup.sport, LIBGNUTLS);
     return 0;
 }
 
@@ -378,7 +379,7 @@ int uprobe__gnutls_bye(struct pt_regs* ctx) {
 
     // TODO: this is just a hack. Let's get rid of this skb_info argument altogether
     skb_info.tcp_flags |= TCPHDR_FIN;
-    http_process(buffer, &skb_info, skb_info.tup.sport);
+    http_process(buffer, &skb_info, skb_info.tup.sport, LIBGNUTLS);
     bpf_map_delete_elem(&ssl_sock_by_ctx, &ssl_session);
     return 0;
 }

--- a/pkg/network/ebpf/c/prebuilt/tracer.c
+++ b/pkg/network/ebpf/c/prebuilt/tracer.c
@@ -5,6 +5,7 @@
 #include "tracer-stats.h"
 #include "tracer-telemetry.h"
 #include "sockfd.h"
+#include "tags.h"
 
 #include "bpf_helpers.h"
 #include "bpf_endian.h"

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -6,6 +6,7 @@
 #include "http-buffer.h"
 #include "sockfd.h"
 #include "conn-tuple.h"
+#include "tags-types.h"
 
 // TODO: Replace those by injected constants based on system configuration
 // once we have port range detection merged into the codebase.
@@ -61,7 +62,7 @@ int socket__http_filter(struct __sk_buff* skb) {
     char buffer[HTTP_BUFFER_SIZE];
     __builtin_memset(buffer, 0, sizeof(buffer));
     read_skb_data(skb, skb_info.data_off, buffer);
-    http_process(buffer, &skb_info, src_port);
+    http_process(buffer, &skb_info, src_port, NO_TAGS);
     return 0;
 }
 
@@ -202,7 +203,7 @@ int uretprobe__SSL_read(struct pt_regs* ctx) {
 
     skb_info_t skb_info = {0};
     __builtin_memcpy(&skb_info.tup, t, sizeof(conn_tuple_t));
-    http_process(buffer, &skb_info, skb_info.tup.sport);
+    http_process(buffer, &skb_info, skb_info.tup.sport, LIBSSL);
  cleanup:
     bpf_map_delete_elem(&ssl_read_args, &pid_tgid);
     return 0;
@@ -224,7 +225,7 @@ int uprobe__SSL_write(struct pt_regs* ctx) {
 
     skb_info_t skb_info = {0};
     __builtin_memcpy(&skb_info.tup, t, sizeof(conn_tuple_t));
-    http_process(buffer, &skb_info, skb_info.tup.sport);
+    http_process(buffer, &skb_info, skb_info.tup.sport, LIBSSL);
     return 0;
 }
 
@@ -245,7 +246,7 @@ int uprobe__SSL_shutdown(struct pt_regs* ctx) {
 
     // TODO: this is just a hack. Let's get rid of this skb_info argument altogether
     skb_info.tcp_flags |= TCPHDR_FIN;
-    http_process(buffer, &skb_info, skb_info.tup.sport);
+    http_process(buffer, &skb_info, skb_info.tup.sport, LIBSSL);
     bpf_map_delete_elem(&ssl_sock_by_ctx, &ssl_ctx);
     return 0;
 }
@@ -331,7 +332,7 @@ int uretprobe__gnutls_record_recv(struct pt_regs* ctx) {
 
     skb_info_t skb_info = {0};
     __builtin_memcpy(&skb_info.tup, t, sizeof(conn_tuple_t));
-    http_process(buffer, &skb_info, skb_info.tup.sport);
+    http_process(buffer, &skb_info, skb_info.tup.sport, LIBGNUTLS);
  cleanup:
     bpf_map_delete_elem(&ssl_read_args, &pid_tgid);
     return 0;
@@ -355,7 +356,7 @@ int uprobe__gnutls_record_send(struct pt_regs* ctx) {
 
     skb_info_t skb_info = {0};
     __builtin_memcpy(&skb_info.tup, t, sizeof(conn_tuple_t));
-    http_process(buffer, &skb_info, skb_info.tup.sport);
+    http_process(buffer, &skb_info, skb_info.tup.sport, LIBGNUTLS);
     return 0;
 }
 
@@ -378,7 +379,7 @@ int uprobe__gnutls_bye(struct pt_regs* ctx) {
 
     // TODO: this is just a hack. Let's get rid of this skb_info argument altogether
     skb_info.tcp_flags |= TCPHDR_FIN;
-    http_process(buffer, &skb_info, skb_info.tup.sport);
+    http_process(buffer, &skb_info, skb_info.tup.sport, LIBGNUTLS);
     bpf_map_delete_elem(&ssl_sock_by_ctx, &ssl_session);
     return 0;
 }

--- a/pkg/network/ebpf/c/runtime/tracer.c
+++ b/pkg/network/ebpf/c/runtime/tracer.c
@@ -10,6 +10,7 @@
 #include "netns.h"
 #include "sockfd.h"
 #include "conn-tuple.h"
+#include "tags.h"
 
 #ifdef FEATURE_IPV6_ENABLED
 #include "ipv6.h"

--- a/pkg/network/ebpf/c/tags-types.h
+++ b/pkg/network/ebpf/c/tags-types.h
@@ -1,0 +1,11 @@
+#ifndef __TAGS_TYPES_H
+#define __TAGS_TYPES_H
+
+// static tags limited to 64 tags per unique connection
+enum static_tags {
+    NO_TAGS = 0,
+    LIBGNUTLS = (1<<0),
+    LIBSSL = (1<<1),
+};
+
+#endif

--- a/pkg/network/ebpf/c/tags.h
+++ b/pkg/network/ebpf/c/tags.h
@@ -1,0 +1,20 @@
+#ifndef __TAGS_H
+#define __TAGS_H
+
+#include "tracer.h"
+#include "tracer-stats.h"
+#include "tags-types.h"
+
+// Static tags
+static __always_inline void add_tags_stats(conn_stats_ts_t *stats, __u64 tags) {
+    stats->tags |= tags;
+}
+
+static __always_inline void add_tags_tuple(conn_tuple_t *t, __u64 tags) {
+    conn_stats_ts_t *stats = get_conn_stats(t);
+    if (!stats) {
+        return;
+    }
+    add_tags_stats(stats, tags);
+}
+#endif

--- a/pkg/network/ebpf/c/tracer.h
+++ b/pkg/network/ebpf/c/tracer.h
@@ -31,6 +31,7 @@ typedef struct {
     __u8 direction;
     __u64 sent_packets;
     __u64 recv_packets;
+    __u64 tags;
 } conn_stats_ts_t;
 
 // Connection flags

--- a/pkg/network/ebpf/kprobe_types.go
+++ b/pkg/network/ebpf/kprobe_types.go
@@ -11,6 +11,7 @@ package ebpf
 /*
 #include "./c/tracer.h"
 #include "./c/tcp_states.h"
+#include "./c/tags-types.h"
 #include "./c/prebuilt/offset-guess.h"
 */
 import "C"
@@ -53,3 +54,10 @@ const (
 )
 
 const BatchSize = C.CONN_CLOSED_BATCH_SIZE
+
+var (
+	StaticTags = map[uint64]string{
+		C.LIBGNUTLS: "tls.library:gnutls",
+		C.LIBSSL:    "tls.library:openssl",
+	}
+)

--- a/pkg/network/ebpf/kprobe_types.go
+++ b/pkg/network/ebpf/kprobe_types.go
@@ -55,9 +55,16 @@ const (
 
 const BatchSize = C.CONN_CLOSED_BATCH_SIZE
 
+type ConnTag = uint64
+
+const (
+	GnuTLS  ConnTag = C.LIBGNUTLS
+	OpenSSL ConnTag = C.LIBSSL
+)
+
 var (
-	StaticTags = map[uint64]string{
-		C.LIBGNUTLS: "tls.library:gnutls",
-		C.LIBSSL:    "tls.library:openssl",
+	StaticTags = map[ConnTag]string{
+		GnuTLS:  "tls.library:gnutls",
+		OpenSSL: "tls.library:openssl",
 	}
 )

--- a/pkg/network/ebpf/kprobe_types_linux.go
+++ b/pkg/network/ebpf/kprobe_types_linux.go
@@ -96,9 +96,16 @@ const (
 
 const BatchSize = 0x4
 
+type ConnTag = uint64
+
+const (
+	GnuTLS  ConnTag = 0x1
+	OpenSSL ConnTag = 0x2
+)
+
 var (
-	StaticTags = map[uint64]string{
-		0x1: "tls.library:gnutls",
-		0x2: "tls.library:openssl",
+	StaticTags = map[ConnTag]string{
+		GnuTLS:  "tls.library:gnutls",
+		OpenSSL: "tls.library:openssl",
 	}
 )

--- a/pkg/network/ebpf/kprobe_types_linux.go
+++ b/pkg/network/ebpf/kprobe_types_linux.go
@@ -29,6 +29,7 @@ type ConnStats struct {
 	Direction    uint8
 	Sent_packets uint64
 	Recv_packets uint64
+	Tags         uint64
 }
 type Conn struct {
 	Tup        ConnTuple
@@ -94,3 +95,10 @@ const (
 )
 
 const BatchSize = 0x4
+
+var (
+	StaticTags = map[uint64]string{
+		0x1: "tls.library:gnutls",
+		0x2: "tls.library:openssl",
+	}
+)

--- a/pkg/network/ebpf/probes/probes.go
+++ b/pkg/network/ebpf/probes/probes.go
@@ -131,6 +131,7 @@ const (
 	DoSendfileArgsMap     BPFMapName = "do_sendfile_args"
 	SockByPidFDMap        BPFMapName = "sock_by_pid_fd"
 	PidFDBySockMap        BPFMapName = "pid_fd_by_sock"
+	TagsMap               BPFMapName = "conn_tags"
 )
 
 // SectionName returns the SectionName for the given BPF map

--- a/pkg/network/encoding/encoding.go
+++ b/pkg/network/encoding/encoding.go
@@ -68,19 +68,21 @@ func modelConnections(conns *network.Connections) *model.Connections {
 
 	agentConns := make([]*model.Connection, len(conns.Conns))
 	routeIndex := make(map[string]RouteIdx)
-	httpIndex := FormatHTTPStats(conns.HTTP)
+	httpIndex, tagsIndex := FormatHTTPStats(conns.HTTP)
 	httpMatches := make(map[http.Key]struct{}, len(httpIndex))
 	ipc := make(ipCache, len(conns.Conns)/2)
 	dnsFormatter := newDNSFormatter(conns, ipc)
+	tagsSet := network.NewTagsSet()
 
 	for i, conn := range conns.Conns {
 		httpKey := httpKeyFromConn(conn)
 		httpAggregations := httpIndex[httpKey]
 		if httpAggregations != nil {
 			httpMatches[httpKey] = struct{}{}
+			conn.Tags |= tagsIndex[httpKey]
 		}
 
-		agentConns[i] = FormatConnection(conn, routeIndex, httpAggregations, dnsFormatter, ipc)
+		agentConns[i] = FormatConnection(conn, routeIndex, httpAggregations, dnsFormatter, ipc, tagsSet)
 	}
 
 	if orphans := len(httpIndex) - len(httpMatches); orphans > 0 {
@@ -103,6 +105,7 @@ func modelConnections(conns *network.Connections) *model.Connections {
 	payload.ConnTelemetry = FormatConnTelemetry(conns.ConnTelemetry)
 	payload.CompilationTelemetryByAsset = FormatCompilationTelemetry(conns.CompilationTelemetryByAsset)
 	payload.Routes = routes
+	payload.Tags = tagsSet.GetStrings()
 
 	return payload
 }

--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -49,6 +49,7 @@ func FormatConnection(
 	httpStats *model.HTTPAggregations,
 	dnsFormatter *dnsFormatter,
 	ipc ipCache,
+	tagsSet *network.TagsSet,
 ) *model.Connection {
 	c := connPool.Get().(*model.Connection)
 	c.Pid = int32(conn.Pid)
@@ -75,6 +76,7 @@ func FormatConnection(
 
 	c.RouteIdx = formatRouteIdx(conn.Via, routes)
 	dnsFormatter.FormatConnectionDNS(conn, c)
+	c.Tags = formatTags(tagsSet, conn)
 
 	if httpStats != nil {
 		c.HttpAggregations, _ = proto.Marshal(httpStats)
@@ -123,9 +125,10 @@ func FormatCompilationTelemetry(telByAsset map[string]network.RuntimeCompilation
 }
 
 // FormatHTTPStats converts the HTTP map into a suitable format for serialization
-func FormatHTTPStats(httpData map[http.Key]http.RequestStats) map[http.Key]*model.HTTPAggregations {
+func FormatHTTPStats(httpData map[http.Key]http.RequestStats) (map[http.Key]*model.HTTPAggregations, map[http.Key]uint64) {
 	var (
 		aggregationsByKey = make(map[http.Key]*model.HTTPAggregations, len(httpData))
+		tagsByKey         = make(map[http.Key]uint64, len(httpData))
 
 		// Pre-allocate some of the objects
 		dataPool = make([]model.HTTPStats_Data, len(httpData)*http.NumStatusClasses)
@@ -154,6 +157,7 @@ func FormatHTTPStats(httpData map[http.Key]http.RequestStats) map[http.Key]*mode
 			StatsByResponseStatus: ptrPool[poolIdx : poolIdx+http.NumStatusClasses],
 		}
 
+		var tags uint64
 		for i := 0; i < len(stats); i++ {
 			data := &dataPool[poolIdx+i]
 			ms.StatsByResponseStatus[i] = data
@@ -165,13 +169,15 @@ func FormatHTTPStats(httpData map[http.Key]http.RequestStats) map[http.Key]*mode
 			} else {
 				data.FirstLatencySample = stats[i].FirstLatencySample
 			}
+			tags |= stats[i].Tags
 		}
+		tagsByKey[key] |= tags
 
 		poolIdx += http.NumStatusClasses
 		httpAggregations.EndpointAggregations = append(httpAggregations.EndpointAggregations, ms)
 	}
 
-	return aggregationsByKey
+	return aggregationsByKey, tagsByKey
 }
 
 // Build the key for the http map based on whether the local or remote side is http.
@@ -301,4 +307,11 @@ func formatRouteIdx(v *network.Via, routes map[string]RouteIdx) int32 {
 
 func routeKey(v *network.Via) string {
 	return v.Subnet.Alias
+}
+
+func formatTags(tagsSet *network.TagsSet, c network.ConnectionStats) (tagsIdx []uint32) {
+	for _, tag := range network.GetStaticTags(c.Tags) {
+		tagsIdx = append(tagsIdx, tagsSet.Add(tag))
+	}
+	return tagsIdx
 }

--- a/pkg/network/encoding/format_test.go
+++ b/pkg/network/encoding/format_test.go
@@ -157,6 +157,9 @@ func TestFormatHTTPStats(t *testing.T) {
 	aggregations := result[aggregationKey].EndpointAggregations
 	assert.ElementsMatch(t, out.EndpointAggregations, aggregations)
 
+	// http.NumStatusClasses is the number of http class bucket of http.RequestStats
+	// For this test we spread the bits (one per RequestStats) and httpStats1,2
+	// and we test if all the bits has been aggregated together
 	assert.Equal(t, uint64((1<<(http.NumStatusClasses))-1), tags[aggregationKey])
 }
 

--- a/pkg/network/encoding/format_test.go
+++ b/pkg/network/encoding/format_test.go
@@ -102,6 +102,9 @@ func TestFormatHTTPStats(t *testing.T) {
 	for i := range httpStats1 {
 		httpStats1[i].Count = 1
 		httpStats1[i].FirstLatencySample = 10
+		if i < len(httpStats1)/2 {
+			httpStats1[i].Tags = (1 << i)
+		}
 	}
 
 	httpKey2 := httpKey1
@@ -110,6 +113,9 @@ func TestFormatHTTPStats(t *testing.T) {
 	for i := range httpStats2 {
 		httpStats2[i].Count = 1
 		httpStats2[i].FirstLatencySample = 20
+		if i >= len(httpStats1)/2 {
+			httpStats2[i].Tags = (1 << i)
+		}
 	}
 
 	in := map[http.Key]http.RequestStats{
@@ -143,13 +149,15 @@ func TestFormatHTTPStats(t *testing.T) {
 		},
 	}
 
-	result := FormatHTTPStats(in)
+	result, tags := FormatHTTPStats(in)
 
 	aggregationKey := httpKey1
 	aggregationKey.Path = ""
 	aggregationKey.Method = http.MethodUnknown
 	aggregations := result[aggregationKey].EndpointAggregations
 	assert.ElementsMatch(t, out.EndpointAggregations, aggregations)
+
+	assert.Equal(t, uint64((1<<(http.NumStatusClasses))-1), tags[aggregationKey])
 }
 
 func BenchmarkConnectionReset(b *testing.B) {

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -197,6 +197,7 @@ type ConnectionStats struct {
 	IPTranslation    *IPTranslation
 	IntraHost        bool
 	Via              *Via
+	Tags             uint64
 
 	IsAssured bool
 }

--- a/pkg/network/http/http_statkeeper.go
+++ b/pkg/network/http/http_statkeeper.go
@@ -78,7 +78,7 @@ func (h *httpStatKeeper) add(tx httpTX) {
 		return
 	}
 
-	stats.AddRequest(tx.StatusClass(), tx.RequestLatency())
+	stats.AddRequest(tx.StatusClass(), tx.RequestLatency(), tx.Tags())
 	h.stats[key] = stats
 }
 

--- a/pkg/network/http/http_stats.go
+++ b/pkg/network/http/http_stats.go
@@ -107,6 +107,9 @@ type RequestStats [NumStatusClasses]struct {
 	// a single value. This is quite common in the context of HTTP requests without
 	// keep-alives where a short-lived TCP connection is used for a single request.
 	FirstLatencySample float64
+
+	// Tags bitfields from tags-types.h
+	Tags uint64
 }
 
 // CombineWith merges the data in 2 RequestStats objects
@@ -115,6 +118,8 @@ func (r *RequestStats) CombineWith(newStats RequestStats) {
 	for i := 0; i < len(r); i++ {
 		statusClass := 100 * (i + 1)
 
+		r[i].Tags |= newStats[i].Tags
+
 		if newStats[i].Count == 0 {
 			// Nothing to do in this case
 			continue
@@ -122,7 +127,7 @@ func (r *RequestStats) CombineWith(newStats RequestStats) {
 
 		if newStats[i].Count == 1 {
 			// The other bucket has a single latency sample, so we "manually" add it
-			r.AddRequest(statusClass, newStats[i].FirstLatencySample)
+			r.AddRequest(statusClass, newStats[i].FirstLatencySample, newStats[i].Tags)
 			continue
 		}
 
@@ -153,11 +158,13 @@ func (r *RequestStats) CombineWith(newStats RequestStats) {
 }
 
 // AddRequest takes information about a HTTP transaction and adds it to the request stats
-func (r *RequestStats) AddRequest(statusClass int, latency float64) {
+func (r *RequestStats) AddRequest(statusClass int, latency float64, tags uint64) {
 	i := statusClass/100 - 1
 	if i < 0 || i >= len(r) {
 		return
 	}
+
+	r[i].Tags |= tags
 
 	r[i].Count++
 	if r[i].Count == 1 {

--- a/pkg/network/http/http_stats_test.go
+++ b/pkg/network/http/http_stats_test.go
@@ -17,9 +17,9 @@ import (
 
 func TestAddRequest(t *testing.T) {
 	var stats RequestStats
-	stats.AddRequest(400, 10.0)
-	stats.AddRequest(404, 15.0)
-	stats.AddRequest(405, 20.0)
+	stats.AddRequest(400, 10.0, 1)
+	stats.AddRequest(404, 15.0, 2)
+	stats.AddRequest(405, 20.0, 3)
 
 	for i := 0; i < 5; i++ {
 		if i == 3 {
@@ -44,9 +44,9 @@ func TestCombineWith(t *testing.T) {
 	}
 
 	var stats2, stats3, stats4 RequestStats
-	stats2.AddRequest(400, 10.0)
-	stats3.AddRequest(404, 15.0)
-	stats4.AddRequest(405, 20.0)
+	stats2.AddRequest(400, 10.0, 2)
+	stats3.AddRequest(404, 15.0, 3)
+	stats4.AddRequest(405, 20.0, 4)
 
 	stats.CombineWith(stats2)
 	stats.CombineWith(stats3)

--- a/pkg/network/http/model.go
+++ b/pkg/network/http/model.go
@@ -82,6 +82,12 @@ func (tx *httpTX) Incomplete() bool {
 	return tx.request_started == 0 || tx.response_status_code == 0
 }
 
+// Tags returns an uint64 representing the tags bitfields
+// Tags are defined here : pkg/network/ebpf/kprobe_types.go
+func (tx *httpTX) Tags() uint64 {
+	return uint64(tx.tags)
+}
+
 // IsDirty detects whether the batch page we're supposed to read from is still
 // valid.  A "dirty" page here means that between the time the
 // http_notification_t message was sent to userspace and the time we performed

--- a/pkg/network/tags.go
+++ b/pkg/network/tags.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package network
+
+// TagsSet a set of tags
+type TagsSet struct {
+	set          map[string]uint32
+	nextTagValue uint32
+}
+
+// NewTagsSet create a new set of Tags
+func NewTagsSet() *TagsSet {
+	return &TagsSet{
+		set:          make(map[string]uint32),
+		nextTagValue: uint32(0),
+	}
+}
+
+// Size return the numbers of unique tag
+func (ts *TagsSet) Size() int {
+	return len(ts.set)
+}
+
+// Add a tag to the set and return his index
+func (ts *TagsSet) Add(tag string) (v uint32) {
+	if v, found := ts.set[tag]; found {
+		return v
+	}
+	v = ts.nextTagValue
+	ts.set[tag] = v
+	ts.nextTagValue++
+	return v
+}
+
+// GetStrings return in order the tags
+func (ts *TagsSet) GetStrings() []string {
+	strs := make([]string, len(ts.set))
+	for k, v := range ts.set {
+		strs[v] = k
+	}
+	return strs
+}

--- a/pkg/network/tags_linux.go
+++ b/pkg/network/tags_linux.go
@@ -1,0 +1,23 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package network
+
+import (
+	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
+)
+
+// GetStaticTags return the string list of static tags from network.ConnectionStats.Tags
+func GetStaticTags(staticTags uint64) (tags []string) {
+	for tag, str := range netebpf.StaticTags {
+		if (staticTags & tag) > 0 {
+			tags = append(tags, str)
+		}
+	}
+	return tags
+}

--- a/pkg/network/tags_nolinux.go
+++ b/pkg/network/tags_nolinux.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !linux
+// +build !linux
+
+package network
+
+// GetStaticTags return the string list of static tags from network.ConnectionStats.Tags
+func GetStaticTags(staticTags uint64) (tags []string) {
+	return tags
+}

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -388,6 +388,7 @@ func populateConnStats(stats *network.ConnectionStats, t *netebpf.ConnTuple, s *
 		MonotonicRecvPackets: s.Recv_packets,
 		LastUpdateEpoch:      s.Timestamp,
 		IsAssured:            s.IsAssured(),
+		Tags:                 s.Tags,
 	}
 
 	if t.Type() == netebpf.TCP {

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -103,7 +103,7 @@ func (c *ConnectionsCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 	c.lastConnsByPID.Store(getConnectionsByPID(conns))
 
 	log.Debugf("collected connections in %s", time.Since(start))
-	return batchConnections(cfg, groupID, c.enrichConnections(conns.Conns), conns.Dns, c.networkID, connTel, conns.CompilationTelemetryByAsset, conns.Domains, conns.Routes, conns.AgentConfiguration), nil
+	return batchConnections(cfg, groupID, c.enrichConnections(conns.Conns), conns.Dns, c.networkID, connTel, conns.CompilationTelemetryByAsset, conns.Domains, conns.Routes, conns.Tags, conns.AgentConfiguration), nil
 }
 
 func (c *ConnectionsCheck) getConnections() (*model.Connections, error) {
@@ -282,6 +282,7 @@ func batchConnections(
 	compilationTelemetry map[string]*model.RuntimeCompilationTelemetry,
 	domains []string,
 	routes []*model.Route,
+	tags []string,
 	agentCfg *model.AgentConfiguration,
 ) []model.MessageBody {
 	groupSize := groupSize(len(cxs), cfg.MaxConnsPerMessage)
@@ -308,6 +309,8 @@ func batchConnections(
 		namemap := make(map[string]int32)
 		namedb := make([]string, 0)
 
+		tagsEncoder := model.NewV2TagEncoder()
+
 		for _, c := range batchConns { // We only want to include DNS entries relevant to this batch of connections
 			if entries, ok := dns[c.Raddr.Ip]; ok {
 				if _, present := batchDNS[c.Raddr.Ip]; !present {
@@ -325,6 +328,18 @@ func batchConnections(
 			// in the namedb.  Each unique string should only occur once.
 			remapDNSStatsByDomain(c, namemap, &namedb, domains)
 			remapDNSStatsByDomainByQueryType(c, namemap, &namedb, domains)
+
+			// tags remap
+			if len(c.Tags) > 0 {
+				var tagsStr []string
+				for _, t := range c.Tags {
+					tagsStr = append(tagsStr, tags[t])
+				}
+				c.Tags = nil
+				c.TagsIdx = int32(tagsEncoder.Encode(tagsStr))
+			} else {
+				c.TagsIdx = -1
+			}
 
 		}
 
@@ -375,17 +390,18 @@ func batchConnections(
 			}
 		}
 		cc := &model.CollectorConnections{
-			AgentConfiguration:    agentCfg,
-			HostName:              cfg.HostName,
-			NetworkId:             networkID,
-			Connections:           batchConns,
-			GroupId:               groupID,
-			GroupSize:             groupSize,
-			ContainerForPid:       ctrIDForPID,
-			EncodedDomainDatabase: encodedNameDb,
-			EncodedDnsLookups:     mappedDNSLookups,
-			ContainerHostType:     cfg.ContainerHostType,
-			Routes:                batchRoutes,
+			AgentConfiguration:     agentCfg,
+			HostName:               cfg.HostName,
+			NetworkId:              networkID,
+			Connections:            batchConns,
+			GroupId:                groupID,
+			GroupSize:              groupSize,
+			ContainerForPid:        ctrIDForPID,
+			EncodedDomainDatabase:  encodedNameDb,
+			EncodedDnsLookups:      mappedDNSLookups,
+			ContainerHostType:      cfg.ContainerHostType,
+			Routes:                 batchRoutes,
+			EncodedConnectionsTags: tagsEncoder.Buffer(),
 		}
 
 		// Add OS telemetry


### PR DESCRIPTION
### What does this PR do?

Add a mechanism to tags our connections

### Motivation

We would like to tags our connections aim via static tags (ex: protocol classification)
or tag the connection based on a payload. 

### Additional Notes

Dependency on agent-payload PR : https://github.com/DataDog/agent-payload/pull/120

### Describe how to test your changes

0.1: to make life easier during testing, may start wget and sigstop the process it aim to keep it "alive" before running system-probe so it can lookup libssl.so offsets
 
1. Start system-probe with the following configuration:

```
system_probe_config:
  log_level: debug
  enable_runtime_compiler: true
network_config:
  enabled: true
  enable_http_monitoring: true
  enable_https_monitoring: true
```

2. Do the following requests: `wget https://httpbin.org/anything/foo`
3. Verify you see `tls.library:openssl` tag and his connection index
4. You can try tls.library:gnutls
```
sudo curl -s --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/connections | tee cnx | jq '.conns[].tags , .tags'
```
(please note your unix-socket path may be different)

jq output should be
```
[]
[
  0
]
[]
...
[
  "tls.library:openssl"
]
```
`
[
  0
]
`
is conns.Tags array index (`0` pointing to `.tags[0] = "tls.library:openssl"`)
The last json array contains all aggregated tags from all connections ["tls.library:openssl"]

You can look at the full connections (pid, addresses, ports) via `cat cnx | jq '[ .conns[] | select( .tags | length > 0 ) ]'`

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
