### PR TITLE
Rename misleading telemetry name

### DIFF
--- a/pkg/forwarder/domain_forwarder.go
+++ b/pkg/forwarder/domain_forwarder.go
@@ -251,6 +251,6 @@ func (f *domainForwarder) sendHTTPTransactions(t transaction.Transaction) {
 		f.addToTransactionRetryQueue(t)
 		highPriorityQueueFull.Add(1)
 		tlmTxHighPriorityQueueFull.Inc(f.domain, t.GetEndpointName())
-		log.Infof("adding the transaction to the retry queue because the forwarder input queue for %s is full; consider increasing forwarder_num_workers", f.domain)
+		log.Debugf("Adding the transaction to the retry queue because the forwarder input queue for %s is full; consider increasing forwarder_num_workers", f.domain)
 	}
 }

--- a/pkg/forwarder/domain_forwarder.go
+++ b/pkg/forwarder/domain_forwarder.go
@@ -243,15 +243,14 @@ func (f *domainForwarder) State() uint32 {
 	return f.internalState
 }
 
-func (f *domainForwarder) sendHTTPTransactions(t transaction.Transaction) error {
+func (f *domainForwarder) sendHTTPTransactions(t transaction.Transaction) {
 	// We don't want to block the collector if the highPrio queue is full
 	select {
 	case f.highPrio <- t:
 	default:
 		f.addToTransactionRetryQueue(t)
-		transactionsDroppedOnInput.Add(1)
-		tlmTxDroppedOnInput.Inc(f.domain, t.GetEndpointName())
-		return fmt.Errorf("dropping transaction because the forwarder input queue for %s is full; consider increasing forwarder_num_workers", f.domain)
+		highPriorityQueueFull.Add(1)
+		tlmTxHighPriorityQueueFull.Inc(f.domain, t.GetEndpointName())
+		log.Infof("adding the transaction to the retry queue because the forwarder input queue for %s is full; consider increasing forwarder_num_workers", f.domain)
 	}
-	return nil
 }

--- a/pkg/forwarder/domain_forwarder_test.go
+++ b/pkg/forwarder/domain_forwarder_test.go
@@ -89,16 +89,14 @@ func TestDomainForwarderSendHTTPTransactions(t *testing.T) {
 	tr := newTestTransactionDomainForwarder()
 
 	// fw is stopped, we should get an error
-	err := forwarder.sendHTTPTransactions(tr)
-	assert.NotNil(t, err)
+	forwarder.sendHTTPTransactions(tr)
 
 	defer forwarder.Stop(false)
 	forwarder.Start()
 	// Stopping the worker for the TestRequeueTransaction
 	forwarder.workers[0].Stop(false)
 
-	err = forwarder.sendHTTPTransactions(tr)
-	assert.Nil(t, err)
+	forwarder.sendHTTPTransactions(tr)
 	transactionToProcess := <-forwarder.highPrio
 	assert.Equal(t, tr, transactionToProcess)
 

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -418,9 +418,7 @@ func (f *DefaultForwarder) sendHTTPTransactions(transactions []*transaction.HTTP
 	}
 
 	for _, t := range transactions {
-		if err := f.domainForwarders[t.Domain].sendHTTPTransactions(t); err != nil {
-			log.Errorf(err.Error())
-		}
+		f.domainForwarders[t.Domain].sendHTTPTransactions(t)
 	}
 	return nil
 }

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -267,7 +267,7 @@ func TestSubmitV1Intake(t *testing.T) {
 // per component.
 func TestForwarderEndtoEnd(t *testing.T) {
 	// reseting DroppedOnInput
-	transactionsDroppedOnInput.Set(0)
+	highPriorityQueueFull.Set(0)
 
 	requests := int64(0)
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -576,7 +576,7 @@ func TestHighPriorityTransaction(t *testing.T) {
 }
 
 func TestCustomCompletionHandler(t *testing.T) {
-	transactionsDroppedOnInput.Set(0)
+	highPriorityQueueFull.Set(0)
 
 	// Setup a test HTTP server
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/forwarder/telemetry.go
+++ b/pkg/forwarder/telemetry.go
@@ -51,7 +51,7 @@ var (
 	tlmTxInputCount = telemetry.NewCounter("transactions", "input_count",
 		[]string{"domain", "endpoint"}, "Incoming transaction count")
 	tlmTxHighPriorityQueueFull = telemetry.NewCounter("transactions", "high_priority_queue_full",
-		[]string{"domain", "endpoint"}, "Count of transactions added to the retry queue because the high priotiy queue is full")
+		[]string{"domain", "endpoint"}, "Count of transactions added to the retry queue because the high priority queue is full")
 	tlmTxRequeued = telemetry.NewCounter("transactions", "requeued",
 		[]string{"domain", "endpoint"}, "Transaction requeue count")
 	tlmTxRetried = telemetry.NewCounter("transactions", "retries",

--- a/pkg/forwarder/telemetry.go
+++ b/pkg/forwarder/telemetry.go
@@ -37,7 +37,7 @@ var (
 	connectionsEndpoint  = transaction.Endpoint{Route: "/api/v1/collector", Name: "connections"}
 	orchestratorEndpoint = transaction.Endpoint{Route: "/api/v1/orchestrator", Name: "orchestrator"}
 
-	transactionsDroppedOnInput       = expvar.Int{}
+	highPriorityQueueFull            = expvar.Int{}
 	transactionsInputBytesByEndpoint = expvar.Map{}
 	transactionsInputCountByEndpoint = expvar.Map{}
 	transactionsRequeued             = expvar.Int{}
@@ -50,8 +50,8 @@ var (
 		[]string{"domain", "endpoint"}, "Incoming transaction sizes in bytes")
 	tlmTxInputCount = telemetry.NewCounter("transactions", "input_count",
 		[]string{"domain", "endpoint"}, "Incoming transaction count")
-	tlmTxDroppedOnInput = telemetry.NewCounter("transactions", "dropped_on_input",
-		[]string{"domain", "endpoint"}, "Count of transactions dropped on input")
+	tlmTxHighPriorityQueueFull = telemetry.NewCounter("transactions", "high_priority_queue_full",
+		[]string{"domain", "endpoint"}, "Count of transactions added to the retry queue because the high priotiy queue is full")
 	tlmTxRequeued = telemetry.NewCounter("transactions", "requeued",
 		[]string{"domain", "endpoint"}, "Transaction requeue count")
 	tlmTxRetried = telemetry.NewCounter("transactions", "retries",
@@ -116,7 +116,7 @@ func initTransactionsExpvars() {
 	transactionsRetriedByEndpoint.Init()
 	transaction.TransactionsExpvars.Set("InputCountByEndpoint", &transactionsInputCountByEndpoint)
 	transaction.TransactionsExpvars.Set("InputBytesByEndpoint", &transactionsInputBytesByEndpoint)
-	transaction.TransactionsExpvars.Set("DroppedOnInput", &transactionsDroppedOnInput)
+	transaction.TransactionsExpvars.Set("HighPriorityQueueFull", &highPriorityQueueFull)
 	transaction.TransactionsExpvars.Set("Requeued", &transactionsRequeued)
 	transaction.TransactionsExpvars.Set("RequeuedByEndpoint", &transactionsRequeuedByEndpoint)
 	transaction.TransactionsExpvars.Set("Retried", &transactionsRetried)


### PR DESCRIPTION
### What does this PR do?

Rename some misleading telemetry metrics in the forwarder.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
