### PR TITLE
Adding top level feature status to the inventories metadata payload

### DIFF
--- a/pkg/metadata/inventories/README.md
+++ b/pkg/metadata/inventories/README.md
@@ -58,6 +58,16 @@ The payload is a JSON dict with the following fields
   - `install_method_installer_version` - **string**:  The version of Datadog module (ex: the Chef Datadog package, the Datadog Ansible playbook, ...).
   - `logs_transport` - **string**:  The transport used to send logs to Datadog. Value is either `"HTTP"` or `"TCP"` when logs collection is
     enabled, otherwise the field is omitted.
+  - `feature_cws_enabled` - **bool**: True if the Cloud Workload Security is enabled (see: `runtime_security_config.enabled`
+    config option).
+  - `feature_process_enabled` - **bool**: True if the Process Agent is enabled (see: `process_config.enabled` config
+    option).
+  - `feature_networks_enabled` - **bool**: True if the Network Performance Monitoring is enabled (see:
+    `network_config.enabled` config option in `system-probe.yaml`).
+  - `feature_logs_enabled` - **bool**: True if the logs collection is enabled (see: `logs_enabled` config option).
+  - `feature_cspm_enabled` - **bool**: True if the Cloud Security Posture Management is enabled (see:
+    `compliance_config.enabled` config option).
+  - `feature_apm_enabled` - **bool**: True if the APM Agent is enabled (see: `apm_config.enabled` config option).
 
 ("scrubbed" indicates that secrets are removed from the field value just as they are in logs)
 

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -83,6 +83,12 @@ const (
 	AgentInstallTool                  AgentMetadataName = "install_method_tool"
 	AgentInstallToolVersion           AgentMetadataName = "install_method_tool_version"
 	AgentLogsTransport                AgentMetadataName = "logs_transport"
+	AgentSecurityEnabled              AgentMetadataName = "feature_cws_enabled"
+	AgentProcessEnabled               AgentMetadataName = "feature_process_enabled"
+	AgentNetworksEnabled              AgentMetadataName = "feature_networks_enabled"
+	AgentLogsEnabled                  AgentMetadataName = "feature_logs_enabled"
+	AgentComplianceEnabled            AgentMetadataName = "feature_cspm_enabled"
+	AgentAPMEnabled                   AgentMetadataName = "feature_apm_enabled"
 )
 
 // SetAgentMetadata updates the agent metadata value in the cache
@@ -256,4 +262,10 @@ func initializeConfig(cfg config.Config) {
 	SetAgentMetadata(AgentConfigProcessDDURL, clean(cfg.GetString("process_config.process_dd_url")))
 	SetAgentMetadata(AgentConfigProxyHTTP, clean(cfg.GetString("proxy.http")))
 	SetAgentMetadata(AgentConfigProxyHTTPS, clean(cfg.GetString("proxy.https")))
+	SetAgentMetadata(AgentSecurityEnabled, config.Datadog.GetBool("runtime_security_config.enabled"))
+	SetAgentMetadata(AgentProcessEnabled, config.Datadog.GetBool("process_config.enabled"))
+	SetAgentMetadata(AgentNetworksEnabled, config.Datadog.GetBool("network_config.enabled"))
+	SetAgentMetadata(AgentLogsEnabled, config.Datadog.GetBool("logs_enabled"))
+	SetAgentMetadata(AgentComplianceEnabled, config.Datadog.GetBool("compliance_config.enabled"))
+	SetAgentMetadata(AgentAPMEnabled, config.Datadog.GetBool("apm_config.enabled"))
 }


### PR DESCRIPTION
### What does this PR do?

Adding top level feature status to the inventories metadata payload

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
