### PR TITLE
[network/ebpf] GetConnections() avoid set tcpStats that are not used by the filter

### DIFF
--- a/pkg/network/tracer/connection/kprobe/perf_batching.go
+++ b/pkg/network/tracer/connection/kprobe/perf_batching.go
@@ -148,7 +148,9 @@ func (p *perfBatchManager) extractBatchInto(buffer []network.ConnectionStats, b 
 			panic("batch size is out of sync")
 		}
 
-		buffer = append(buffer, connStats(&ct.Tup, &ct.Conn_stats, &ct.Tcp_stats))
+		conn := connStats(&ct.Tup, &ct.Conn_stats)
+		updateTCPStats(&conn, &ct.Tcp_stats)
+		buffer = append(buffer, conn)
 	}
 	return buffer
 }

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -196,10 +196,14 @@ func (t *kprobeTracer) GetConnections(buffer []network.ConnectionStats, filter f
 	seen := make(map[netebpf.ConnTuple]struct{})
 	entries := t.conns.IterateFrom(unsafe.Pointer(&netebpf.ConnTuple{}))
 	for entries.Next(unsafe.Pointer(key), unsafe.Pointer(stats)) {
-		conn := connStats(key, stats, t.getTCPStats(key, seen))
-		if filter != nil && filter(&conn) {
-			buffer = append(buffer, conn)
+		conn := connStats(key, stats)
+		if filter != nil && filter(&conn) == false {
+			continue
 		}
+		if tcpStats := t.getTCPStats(key, seen); tcpStats != nil {
+			updateTCPStats(&conn, tcpStats)
+		}
+		buffer = append(buffer, conn)
 	}
 
 	if err := entries.Err(); err != nil {
@@ -382,17 +386,28 @@ func initializePortBindingMaps(config *config.Config, m *manager.Manager) error 
 	return nil
 }
 
+func updateTCPStats(conn *network.ConnectionStats, tcpStats *netebpf.TCPStats) {
+	if conn.Type != network.TCP {
+		return
+	}
+	conn.MonotonicRetransmits = tcpStats.Retransmits
+	conn.MonotonicTCPEstablished = uint32(tcpStats.State_transitions >> netebpf.Established & 1)
+	conn.MonotonicTCPClosed = uint32(tcpStats.State_transitions >> netebpf.Close & 1)
+	conn.RTT = tcpStats.Rtt
+	conn.RTTVar = tcpStats.Rtt_var
+}
+
 // getTCPStats reads tcp related stats for the given ConnTuple
 func (t *kprobeTracer) getTCPStats(tuple *netebpf.ConnTuple, seen map[netebpf.ConnTuple]struct{}) *netebpf.TCPStats {
-	stats := new(netebpf.TCPStats)
 	if tuple.Type() != netebpf.TCP {
-		return stats
+		return nil
 	}
 
 	// The PID isn't used as a key in the stats map, we will temporarily set it to 0 here and reset it when we're done
 	pid := tuple.Pid
 	tuple.Pid = 0
 
+	stats := new(netebpf.TCPStats)
 	err := t.tcpStats.Lookup(unsafe.Pointer(tuple), unsafe.Pointer(stats))
 	if err == nil {
 		// This is required to avoid (over)reporting retransmits for connections sharing the same socket.
@@ -416,7 +431,7 @@ func (t *kprobeTracer) getMap(name probes.BPFMapName) (*ebpf.Map, error) {
 	return mp, nil
 }
 
-func connStats(t *netebpf.ConnTuple, s *netebpf.ConnStats, tcpStats *netebpf.TCPStats) network.ConnectionStats {
+func connStats(t *netebpf.ConnTuple, s *netebpf.ConnStats) network.ConnectionStats {
 	stats := network.ConnectionStats{
 		Pid:                  t.Pid,
 		NetNS:                t.Netns,
@@ -435,11 +450,6 @@ func connStats(t *netebpf.ConnTuple, s *netebpf.ConnStats, tcpStats *netebpf.TCP
 
 	if t.Type() == netebpf.TCP {
 		stats.Type = network.TCP
-		stats.MonotonicRetransmits = tcpStats.Retransmits
-		stats.MonotonicTCPEstablished = uint32(tcpStats.State_transitions >> netebpf.Established & 1)
-		stats.MonotonicTCPClosed = uint32(tcpStats.State_transitions >> netebpf.Close & 1)
-		stats.RTT = tcpStats.Rtt
-		stats.RTTVar = tcpStats.Rtt_var
 	} else {
 		stats.Type = network.UDP
 	}

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -197,7 +197,7 @@ func (t *kprobeTracer) GetConnections(buffer []network.ConnectionStats, filter f
 	entries := t.conns.IterateFrom(unsafe.Pointer(&netebpf.ConnTuple{}))
 	for entries.Next(unsafe.Pointer(key), unsafe.Pointer(stats)) {
 		conn := connStats(key, stats)
-		if filter != nil && filter(&conn) == false {
+		if filter != nil && !filter(&conn) {
 			continue
 		}
 		if tcpStats := t.getTCPStats(key, seen); tcpStats != nil {


### PR DESCRIPTION

### What does this PR do?

This PR will avoid updating ConnectionStats before calling the filter, as the current filter implementation (via callback) doesn't look at tcp stats.
current filter call only :
 * t.connectionExpired()
 * t.shouldSkipConnection() 

This would avoid a map.lookup call per TCP connections

Another change behaviour : a nil filter will return all ConnectionsStats

### Motivation

Simplify and improve runtime

### Additional Notes

Another change behaviour : a nil filter will return all ConnectionsStats

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
