### PR TITLE
Update 'version' metadata for 'agent_version'

### DIFF
--- a/pkg/metadata/inventories/README.md
+++ b/pkg/metadata/inventories/README.md
@@ -40,7 +40,7 @@ The payload is a JSON dict with the following fields
 - `agent_metadata` - **dict of string to JSON type**:
   - `cloud_provider` - **string**: the name of the cloud provider detected by the Agent (omitted if no cloud is detected).
   - `hostname_source` - **string**: the source for the agent hostname (see pkg/util/hostname.go:GetHostnameData).
-  - `version` - **string**: the version of the Agent.
+  - `agent_version` - **string**: the version of the Agent.
   - `flavor` - **string**: the flavor of the Agent. The Agent can be build under different flavor such as standalone
     dogstatsd, iot, serverless ... (see `pkg/util/flavor` package).
   - `install_method_tool` - **string**: the name of the tool used to install the agent (ie, Chef, Ansible, ...).

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -66,7 +66,7 @@ type AgentMetadataName string
 const (
 	AgentCloudProvider      AgentMetadataName = "cloud_provider"
 	AgentHostnameSource     AgentMetadataName = "hostname_source"
-	AgentVersion            AgentMetadataName = "version"
+	AgentVersion            AgentMetadataName = "agent_version"
 	AgentFlavor             AgentMetadataName = "flavor"
 	AgentInstallerVersion   AgentMetadataName = "install_method_installer_version"
 	AgentInstallTool        AgentMetadataName = "install_method_tool"


### PR DESCRIPTION
### What does this PR do?

Update `version` metadata for `agent_version`

### Motivation

We have many things with version in the agent, the old naming was confusing.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
