### PR TITLE
[invoke] Fix ordering in pipeline.run

### DIFF
--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -220,6 +220,9 @@ def run(
     if '7' not in major_versions:
         release_version_7 = ""
 
+    if here:
+        git_ref = ctx.run("git rev-parse --abbrev-ref HEAD", hide=True).stdout.strip()
+
     if deploy:
         # Check the validity of the deploy pipeline
         check_deploy_pipeline(gitlab, project_name, git_ref, release_version_6, release_version_7, repo_branch)
@@ -240,9 +243,6 @@ def run(
                 )
             )
             kitchen_tests = True
-
-    if here:
-        git_ref = ctx.run("git rev-parse --abbrev-ref HEAD", hide=True).stdout.strip()
 
     pipelines = get_running_pipelines_on_same_ref(gitlab, project_name, git_ref)
 


### PR DESCRIPTION
### What does this PR do?

When `--here` is specified, compute the git ref before running `check_deploy_pipeline`, which needs it.

### Motivation

Fix failure in `inv pipeline.run --deploy --here`

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
