### PR TITLE
Remove Windows x86 gitlab jobs

### DIFF
--- a/.gitlab/package_build/windows.yml
+++ b/.gitlab/package_build/windows.yml
@@ -34,36 +34,12 @@ windows_msi_and_bosh_zip_x64-a7:
   before_script:
     - set RELEASE_VERSION $RELEASE_VERSION_7
 
-windows_msi_x86-a7:
-  extends: .windows_main_agent_base
-  rules:
-    !reference [.on_a7_except_deploy]
-  allow_failure: true
-  variables:
-    ARCH: "x86"
-    AGENT_MAJOR_VERSION: 7
-    PYTHON_RUNTIMES: '3'
-  before_script:
-    - set RELEASE_VERSION $RELEASE_VERSION_7
-
 windows_msi_x64-a6:
   extends: .windows_main_agent_base
   rules:
     !reference [.on_a6]
   variables:
     ARCH: "x64"
-    AGENT_MAJOR_VERSION: 6
-    PYTHON_RUNTIMES: '2,3'
-  before_script:
-    - set RELEASE_VERSION $RELEASE_VERSION_6
-
-windows_msi_x86-a6:
-  extends: .windows_main_agent_base
-  rules:
-    !reference [.on_a6_except_deploy]
-  allow_failure: true
-  variables:
-    ARCH: "x86"
     AGENT_MAJOR_VERSION: 6
     PYTHON_RUNTIMES: '2,3'
   before_script:

--- a/.gitlab/source_test/windows.yml
+++ b/.gitlab/source_test/windows.yml
@@ -19,11 +19,3 @@ tests_windows-x64:
   variables:
     PYTHON_RUNTIMES: 3
     ARCH: "x64"
-
-tests_windows-x86:
-  rules:
-    !reference [.except_deploy]
-  extends: .tests_windows_base
-  variables:
-    PYTHON_RUNTIMES: 3
-    ARCH: "x86"


### PR DESCRIPTION
### What does this PR do?

Remove the Windows x86 test and package jobs.

### Motivation

We don't have plans to release it and the tests are [flaky](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/85832824)
