### PR TITLE
[corechecks/snmp] Add config to use DeviceID as hostname for metrics and service checks

### DIFF
--- a/pkg/collector/corechecks/snmp/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config.go
@@ -60,25 +60,24 @@ type InitConfig struct {
 
 // InstanceConfig is used to deserialize integration instance config
 type InstanceConfig struct {
-	IPAddress        string            `yaml:"ip_address"`
-	Port             Number            `yaml:"port"`
-	CommunityString  string            `yaml:"community_string"`
-	SnmpVersion      string            `yaml:"snmp_version"`
-	Timeout          Number            `yaml:"timeout"`
-	Retries          Number            `yaml:"retries"`
-	User             string            `yaml:"user"`
-	AuthProtocol     string            `yaml:"authProtocol"`
-	AuthKey          string            `yaml:"authKey"`
-	PrivProtocol     string            `yaml:"privProtocol"`
-	PrivKey          string            `yaml:"privKey"`
-	ContextName      string            `yaml:"context_name"`
-	Metrics          []MetricsConfig   `yaml:"metrics"`     // SNMP metrics definition
-	MetricTags       []MetricTagConfig `yaml:"metric_tags"` // SNMP metric tags definition
-	Profile          string            `yaml:"profile"`
-	UseGlobalMetrics bool              `yaml:"use_global_metrics"`
-
-	CollectDeviceMetadata *Boolean `yaml:"collect_device_metadata"`
-	UseDeviceIDAsHostname *Boolean `yaml:"use_device_id_as_hostname"`
+	IPAddress             string            `yaml:"ip_address"`
+	Port                  Number            `yaml:"port"`
+	CommunityString       string            `yaml:"community_string"`
+	SnmpVersion           string            `yaml:"snmp_version"`
+	Timeout               Number            `yaml:"timeout"`
+	Retries               Number            `yaml:"retries"`
+	User                  string            `yaml:"user"`
+	AuthProtocol          string            `yaml:"authProtocol"`
+	AuthKey               string            `yaml:"authKey"`
+	PrivProtocol          string            `yaml:"privProtocol"`
+	PrivKey               string            `yaml:"privKey"`
+	ContextName           string            `yaml:"context_name"`
+	Metrics               []MetricsConfig   `yaml:"metrics"`     // SNMP metrics definition
+	MetricTags            []MetricTagConfig `yaml:"metric_tags"` // SNMP metric tags definition
+	Profile               string            `yaml:"profile"`
+	UseGlobalMetrics      bool              `yaml:"use_global_metrics"`
+	CollectDeviceMetadata *Boolean          `yaml:"collect_device_metadata"`
+	UseDeviceIDAsHostname *Boolean          `yaml:"use_device_id_as_hostname"`
 
 	// ExtraTags is a workaround to pass tags from snmp listener to snmp integration via AD template
 	// (see cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml) that only works with strings.

--- a/pkg/collector/corechecks/snmp/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config.go
@@ -54,28 +54,31 @@ type InitConfig struct {
 	OidBatchSize          Number           `yaml:"oid_batch_size"`
 	BulkMaxRepetitions    Number           `yaml:"bulk_max_repetitions"`
 	CollectDeviceMetadata Boolean          `yaml:"collect_device_metadata"`
+	UseDeviceIDAsHostname Boolean          `yaml:"use_device_id_as_hostname"`
 	MinCollectionInterval int              `yaml:"min_collection_interval"`
 }
 
 // InstanceConfig is used to deserialize integration instance config
 type InstanceConfig struct {
-	IPAddress             string            `yaml:"ip_address"`
-	Port                  Number            `yaml:"port"`
-	CommunityString       string            `yaml:"community_string"`
-	SnmpVersion           string            `yaml:"snmp_version"`
-	Timeout               Number            `yaml:"timeout"`
-	Retries               Number            `yaml:"retries"`
-	User                  string            `yaml:"user"`
-	AuthProtocol          string            `yaml:"authProtocol"`
-	AuthKey               string            `yaml:"authKey"`
-	PrivProtocol          string            `yaml:"privProtocol"`
-	PrivKey               string            `yaml:"privKey"`
-	ContextName           string            `yaml:"context_name"`
-	Metrics               []MetricsConfig   `yaml:"metrics"`     // SNMP metrics definition
-	MetricTags            []MetricTagConfig `yaml:"metric_tags"` // SNMP metric tags definition
-	Profile               string            `yaml:"profile"`
-	UseGlobalMetrics      bool              `yaml:"use_global_metrics"`
-	CollectDeviceMetadata *Boolean          `yaml:"collect_device_metadata"`
+	IPAddress        string            `yaml:"ip_address"`
+	Port             Number            `yaml:"port"`
+	CommunityString  string            `yaml:"community_string"`
+	SnmpVersion      string            `yaml:"snmp_version"`
+	Timeout          Number            `yaml:"timeout"`
+	Retries          Number            `yaml:"retries"`
+	User             string            `yaml:"user"`
+	AuthProtocol     string            `yaml:"authProtocol"`
+	AuthKey          string            `yaml:"authKey"`
+	PrivProtocol     string            `yaml:"privProtocol"`
+	PrivKey          string            `yaml:"privKey"`
+	ContextName      string            `yaml:"context_name"`
+	Metrics          []MetricsConfig   `yaml:"metrics"`     // SNMP metrics definition
+	MetricTags       []MetricTagConfig `yaml:"metric_tags"` // SNMP metric tags definition
+	Profile          string            `yaml:"profile"`
+	UseGlobalMetrics bool              `yaml:"use_global_metrics"`
+
+	CollectDeviceMetadata *Boolean `yaml:"collect_device_metadata"`
+	UseDeviceIDAsHostname *Boolean `yaml:"use_device_id_as_hostname"`
 
 	// ExtraTags is a workaround to pass tags from snmp listener to snmp integration via AD template
 	// (see cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml) that only works with strings.
@@ -132,6 +135,7 @@ type CheckConfig struct {
 	ExtraTags             []string
 	InstanceTags          []string
 	CollectDeviceMetadata bool
+	UseDeviceIDAsHostname bool
 	DeviceID              string
 	DeviceIDTags          []string
 	ResolvedSubnetName    string
@@ -273,6 +277,12 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 		c.CollectDeviceMetadata = bool(*instance.CollectDeviceMetadata)
 	} else {
 		c.CollectDeviceMetadata = bool(initConfig.CollectDeviceMetadata)
+	}
+
+	if instance.UseDeviceIDAsHostname != nil {
+		c.UseDeviceIDAsHostname = bool(*instance.UseDeviceIDAsHostname)
+	} else {
+		c.UseDeviceIDAsHostname = bool(initConfig.UseDeviceIDAsHostname)
 	}
 
 	if instance.ExtraTags != "" {
@@ -524,6 +534,7 @@ func (c *CheckConfig) Copy() *CheckConfig {
 	newConfig.ExtraTags = common.CopyStrings(c.ExtraTags)
 	newConfig.InstanceTags = common.CopyStrings(c.InstanceTags)
 	newConfig.CollectDeviceMetadata = c.CollectDeviceMetadata
+	newConfig.UseDeviceIDAsHostname = c.UseDeviceIDAsHostname
 	newConfig.DeviceID = c.DeviceID
 
 	newConfig.DeviceIDTags = common.CopyStrings(c.DeviceIDTags)

--- a/pkg/collector/corechecks/snmp/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config_test.go
@@ -996,6 +996,64 @@ collect_device_metadata: true
 	assert.Equal(t, false, config.CollectDeviceMetadata)
 }
 
+func Test_buildConfig_UseDeviceIDAsHostname(t *testing.T) {
+	// language=yaml
+	rawInstanceConfig := []byte(`
+ip_address: 1.2.3.4
+community_string: "abc"
+`)
+	// language=yaml
+	rawInitConfig := []byte(`
+oid_batch_size: 10
+`)
+	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	assert.Nil(t, err)
+	assert.Equal(t, false, config.UseDeviceIDAsHostname)
+
+	// language=yaml
+	rawInstanceConfig = []byte(`
+ip_address: 1.2.3.4
+community_string: "abc"
+`)
+	// language=yaml
+	rawInitConfig = []byte(`
+oid_batch_size: 10
+use_device_id_as_hostname: true
+`)
+	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	assert.Nil(t, err)
+	assert.Equal(t, true, config.UseDeviceIDAsHostname)
+
+	// language=yaml
+	rawInstanceConfig = []byte(`
+ip_address: 1.2.3.4
+community_string: "abc"
+use_device_id_as_hostname: true
+`)
+	// language=yaml
+	rawInitConfig = []byte(`
+oid_batch_size: 10
+`)
+	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	assert.Nil(t, err)
+	assert.Equal(t, true, config.UseDeviceIDAsHostname)
+
+	// language=yaml
+	rawInstanceConfig = []byte(`
+ip_address: 1.2.3.4
+community_string: "abc"
+use_device_id_as_hostname: false
+`)
+	// language=yaml
+	rawInitConfig = []byte(`
+oid_batch_size: 10
+use_device_id_as_hostname: true
+`)
+	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	assert.Nil(t, err)
+	assert.Equal(t, false, config.UseDeviceIDAsHostname)
+}
+
 func Test_buildConfig_minCollectionInterval(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -1367,6 +1425,7 @@ func TestCheckConfig_Copy(t *testing.T) {
 		ExtraTags:             []string{"ExtraTags:tag"},
 		InstanceTags:          []string{"InstanceTags:tag"},
 		CollectDeviceMetadata: true,
+		UseDeviceIDAsHostname: true,
 		DeviceID:              "123",
 		DeviceIDTags:          []string{"DeviceIDTags:tag"},
 		ResolvedSubnetName:    "1.2.3.4/28",
@@ -1404,6 +1463,7 @@ func TestCheckConfig_Copy(t *testing.T) {
 	assertNotSameButEqualElements(t, config.ExtraTags, configCopy.ExtraTags)
 	assertNotSameButEqualElements(t, config.InstanceTags, configCopy.InstanceTags)
 	assert.Equal(t, config.CollectDeviceMetadata, configCopy.CollectDeviceMetadata)
+	assert.Equal(t, config.UseDeviceIDAsHostname, configCopy.UseDeviceIDAsHostname)
 	assert.Equal(t, config.DeviceID, configCopy.DeviceID)
 	assertNotSameButEqualElements(t, config.DeviceIDTags, configCopy.DeviceIDTags)
 	assert.Equal(t, config.ResolvedSubnetName, configCopy.ResolvedSubnetName)

--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
@@ -72,7 +72,6 @@ func (d *DeviceCheck) GetHostname() string {
 func (d *DeviceCheck) Run(collectionTime time.Time) error {
 	startTime := time.Now()
 	staticTags := append(d.config.GetStaticTags(), d.config.GetNetworkTags()...)
-	//staticTags = append(staticTags, fmt.Sprintf("host:device_id:%s", d.config.DeviceID))
 
 	// Fetch and report metrics
 	var checkErr error

--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
@@ -19,8 +19,9 @@ import (
 )
 
 const (
-	snmpLoaderTag    = "loader:core"
-	serviceCheckName = "snmp.can_check"
+	snmpLoaderTag        = "loader:core"
+	serviceCheckName     = "snmp.can_check"
+	deviceHostnamePrefix = "snmp:device:"
 )
 
 // DeviceCheck hold info necessary to collect info for a single device
@@ -63,7 +64,7 @@ func (d *DeviceCheck) GetIDTags() []string {
 // GetHostname returns DeviceID as hostname if UseDeviceIDAsHostname is true
 func (d *DeviceCheck) GetHostname() string {
 	if d.config.UseDeviceIDAsHostname {
-		return "device_id:" + d.config.DeviceID
+		return deviceHostnamePrefix + d.config.DeviceID
 	}
 	return ""
 }

--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
@@ -168,8 +168,7 @@ func (d *DeviceCheck) doAutodetectProfile(sess session.Session) error {
 }
 
 func (d *DeviceCheck) submitTelemetryMetrics(startTime time.Time, tags []string) {
-	host := fmt.Sprintf("device_id_using_tag:%s", d.config.DeviceID)
-	newTags := append(common.CopyStrings(tags), snmpLoaderTag, "host:"+host)
+	newTags := append(common.CopyStrings(tags), snmpLoaderTag)
 
 	d.sender.Gauge("snmp.devices_monitored", float64(1), newTags)
 

--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
@@ -21,7 +21,7 @@ import (
 const (
 	snmpLoaderTag        = "loader:core"
 	serviceCheckName     = "snmp.can_check"
-	deviceHostnamePrefix = "snmp:device:"
+	deviceHostnamePrefix = "device:"
 )
 
 // DeviceCheck hold info necessary to collect info for a single device

--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
@@ -64,6 +64,7 @@ func (d *DeviceCheck) GetIDTags() []string {
 func (d *DeviceCheck) Run(collectionTime time.Time) error {
 	startTime := time.Now()
 	staticTags := append(d.config.GetStaticTags(), d.config.GetNetworkTags()...)
+	//staticTags = append(staticTags, fmt.Sprintf("host:device_id:%s", d.config.DeviceID))
 
 	// Fetch and report metrics
 	var checkErr error
@@ -159,7 +160,8 @@ func (d *DeviceCheck) doAutodetectProfile(sess session.Session) error {
 }
 
 func (d *DeviceCheck) submitTelemetryMetrics(startTime time.Time, tags []string) {
-	newTags := append(common.CopyStrings(tags), snmpLoaderTag)
+	host := fmt.Sprintf("device_id_using_tag:%s", d.config.DeviceID)
+	newTags := append(common.CopyStrings(tags), snmpLoaderTag, "host:" + host)
 
 	d.sender.Gauge("snmp.devices_monitored", float64(1), "", newTags)
 

--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck_test.go
@@ -203,7 +203,7 @@ community_string: public
 
 	// with hostname
 	deviceCk.config.UseDeviceIDAsHostname = true
-	deviceCk.SetSender(report.NewMetricSender(sender, "snmp:device:123"))
+	deviceCk.SetSender(report.NewMetricSender(sender, "device:123"))
 	deviceCk.sender.Gauge("snmp.devices_monitored", float64(1), []string{"snmp_device:1.2.3.4"})
-	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "snmp:device:123", []string{"snmp_device:1.2.3.4"})
+	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "device:123", []string{"snmp_device:1.2.3.4"})
 }

--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck_test.go
@@ -203,7 +203,7 @@ community_string: public
 
 	// with hostname
 	deviceCk.config.UseDeviceIDAsHostname = true
-	deviceCk.SetSender(report.NewMetricSender(sender, "device_id:123"))
+	deviceCk.SetSender(report.NewMetricSender(sender, "snmp:device:123"))
 	deviceCk.sender.Gauge("snmp.devices_monitored", float64(1), []string{"snmp_device:1.2.3.4"})
-	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "device_id:123", []string{"snmp_device:1.2.3.4"})
+	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "snmp:device:123", []string{"snmp_device:1.2.3.4"})
 }

--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck_test.go
@@ -47,7 +47,7 @@ profiles:
 	sender.On("ServiceCheck", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	sender.On("Commit").Return()
 
-	deviceCk.SetSender(report.NewMetricSender(sender))
+	deviceCk.SetSender(report.NewMetricSender(sender, ""))
 
 	sysObjectIDPacket := gosnmp.SnmpPacket{
 		Variables: []gosnmp.SnmpPDU{
@@ -174,4 +174,36 @@ profiles:
 
 	assert.Len(t, deviceCk.config.Metrics, len(firstRunMetrics))
 	assert.Len(t, deviceCk.config.MetricTags, len(firstRunMetricsTags))
+}
+
+func TestDeviceCheck_GetHostname(t *testing.T) {
+	checkconfig.SetConfdPathAndCleanProfiles()
+	// language=yaml
+	rawInstanceConfig := []byte(`
+ip_address: 1.2.3.4
+community_string: public
+`)
+	// language=yaml
+	rawInitConfig := []byte(`
+`)
+
+	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	assert.Nil(t, err)
+
+	deviceCk, err := NewDeviceCheck(config, "1.2.3.4")
+	assert.Nil(t, err)
+
+	sender := mocksender.NewMockSender("123") // required to initiate aggregator
+	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+
+	// without hostname
+	deviceCk.SetSender(report.NewMetricSender(sender, ""))
+	deviceCk.sender.Gauge("snmp.devices_monitored", float64(1), []string{"snmp_device:1.2.3.4"})
+	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "", []string{"snmp_device:1.2.3.4"})
+
+	// with hostname
+	deviceCk.config.UseDeviceIDAsHostname = true
+	deviceCk.SetSender(report.NewMetricSender(sender, "device_id:123"))
+	deviceCk.sender.Gauge("snmp.devices_monitored", float64(1), []string{"snmp_device:1.2.3.4"})
+	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "device_id:123", []string{"snmp_device:1.2.3.4"})
 }

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -54,7 +54,7 @@ func (c *Check) Run() error {
 
 		for i := range discoveredDevices {
 			deviceCk := discoveredDevices[i]
-			deviceCk.SetSender(report.NewMetricSender(sender))
+			deviceCk.SetSender(report.NewMetricSender(sender, deviceCk.GetHostname()))
 			jobs <- deviceCk
 		}
 		close(jobs)
@@ -64,7 +64,7 @@ func (c *Check) Run() error {
 		tags = append(tags, c.config.GetNetworkTags()...)
 		sender.Gauge("snmp.discovered_devices_count", float64(len(discoveredDevices)), "", tags)
 	} else {
-		c.singleDeviceCk.SetSender(report.NewMetricSender(sender))
+		c.singleDeviceCk.SetSender(report.NewMetricSender(sender, c.singleDeviceCk.GetHostname()))
 		checkErr = c.runCheckDevice(c.singleDeviceCk)
 	}
 

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -1623,7 +1623,7 @@ use_device_id_as_hostname: true
 	err = chk.Run()
 	assert.Nil(t, err)
 
-	hostname := "device_id:74f22f3320d2d692"
+	hostname := "snmp:device:74f22f3320d2d692"
 	snmpTags := []string{"snmp_device:1.2.3.4"}
 	snmpGlobalTags := common.CopyStrings(snmpTags)
 	snmpGlobalTagsWithLoader := append(common.CopyStrings(snmpGlobalTags), "loader:core")
@@ -1723,7 +1723,7 @@ metrics:
 	assert.Nil(t, err)
 
 	for _, deviceData := range deviceMap {
-		hostname := "device_id:" + deviceData.deviceID
+		hostname := "snmp:device:" + deviceData.deviceID
 		snmpTags := []string{"snmp_device:" + deviceData.ipAddress, "autodiscovery_subnet:10.10.0.0/30"}
 		snmpGlobalTags := common.CopyStrings(snmpTags)
 		snmpGlobalTagsWithLoader := append(common.CopyStrings(snmpGlobalTags), "loader:core")

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -1623,7 +1623,7 @@ use_device_id_as_hostname: true
 	err = chk.Run()
 	assert.Nil(t, err)
 
-	hostname := "snmp:device:74f22f3320d2d692"
+	hostname := "device:74f22f3320d2d692"
 	snmpTags := []string{"snmp_device:1.2.3.4"}
 	snmpGlobalTags := common.CopyStrings(snmpTags)
 	snmpGlobalTagsWithLoader := append(common.CopyStrings(snmpGlobalTags), "loader:core")
@@ -1723,7 +1723,7 @@ metrics:
 	assert.Nil(t, err)
 
 	for _, deviceData := range deviceMap {
-		hostname := "snmp:device:" + deviceData.deviceID
+		hostname := "device:" + deviceData.deviceID
 		snmpTags := []string{"snmp_device:" + deviceData.ipAddress, "autodiscovery_subnet:10.10.0.0/30"}
 		snmpGlobalTags := common.CopyStrings(snmpTags)
 		snmpGlobalTagsWithLoader := append(common.CopyStrings(snmpGlobalTags), "loader:core")

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -1570,3 +1570,173 @@ metric_tags:
 		assert.Equal(t, strings.Count(logs, "error collecting for device 10.10.0."+strconv.Itoa(i)), 1, logs)
 	}
 }
+
+func TestDeviceIDAsHostname(t *testing.T) {
+	checkconfig.SetConfdPathAndCleanProfiles()
+	sess := session.CreateMockSession()
+	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+		return sess, nil
+	}
+	chk := Check{}
+	aggregator.InitAggregatorWithFlushInterval(nil, nil, "", 1*time.Hour)
+
+	// language=yaml
+	rawInstanceConfig := []byte(`
+ip_address: 1.2.3.4
+community_string: public
+metrics:
+- symbol:
+    OID: 1.3.6.1.2.1.2.1
+    name: ifNumber
+  metric_tags:
+  - symboltag1:1
+  - symboltag2:2
+use_device_id_as_hostname: true
+`)
+
+	err := chk.Configure(rawInstanceConfig, []byte(``), "test")
+	assert.Nil(t, err)
+
+	sender := mocksender.NewMockSender(chk.ID()) // required to initiate aggregator
+	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("MonotonicCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("ServiceCheck", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("Commit").Return()
+
+	packet := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.3.6.1.2.1.1.3.0",
+				Type:  gosnmp.TimeTicks,
+				Value: 20,
+			},
+			{
+				Name:  "1.3.6.1.2.1.2.1",
+				Type:  gosnmp.Integer,
+				Value: 30,
+			},
+		},
+	}
+
+	sess.On("Get", mock.Anything).Return(&packet, nil)
+
+	err = chk.Run()
+	assert.Nil(t, err)
+
+	hostname := "device_id:74f22f3320d2d692"
+	snmpTags := []string{"snmp_device:1.2.3.4"}
+	snmpGlobalTags := common.CopyStrings(snmpTags)
+	snmpGlobalTagsWithLoader := append(common.CopyStrings(snmpGlobalTags), "loader:core")
+	scalarTags := append(common.CopyStrings(snmpGlobalTags), "symboltag1:1", "symboltag2:2")
+
+	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), hostname, snmpGlobalTags)
+	sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), hostname, snmpGlobalTags)
+	sender.AssertMetric(t, "Gauge", "snmp.ifNumber", float64(30), hostname, scalarTags)
+
+	sender.AssertMetricTaggedWith(t, "MonotonicCount", "datadog.snmp.check_interval", snmpGlobalTagsWithLoader)
+	sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.check_duration", snmpGlobalTagsWithLoader)
+	sender.AssertMetric(t, "Gauge", "datadog.snmp.submitted_metrics", 2, hostname, snmpGlobalTagsWithLoader)
+}
+
+func TestDiscoveryDeviceIDAsHostname(t *testing.T) {
+	timeNow = common.MockTimeNow
+	checkconfig.SetConfdPathAndCleanProfiles()
+	sess := session.CreateMockSession()
+	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+		return sess, nil
+	}
+	chk := Check{}
+	aggregator.InitAggregatorWithFlushInterval(nil, nil, "", 1*time.Hour)
+
+	// language=yaml
+	rawInstanceConfig := []byte(`
+network_address: 10.10.0.0/30
+community_string: public
+use_device_id_as_hostname: true
+oid_batch_size: 10
+metrics:
+- symbol:
+    OID: 1.3.6.1.2.1.2.1
+    name: ifNumber
+  metric_tags:
+  - symboltag1:1
+  - symboltag2:2
+`)
+
+	discoveryPacket := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.3.6.1.2.1.1.2.0",
+				Type:  gosnmp.ObjectIdentifier,
+				Value: "1.2.3",
+			},
+		},
+	}
+	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&discoveryPacket, nil)
+
+	err := chk.Configure(rawInstanceConfig, []byte(``), "test")
+	assert.Nil(t, err)
+
+	time.Sleep(100 * time.Millisecond)
+	devices := chk.discovery.GetDiscoveredDeviceConfigs()
+	assert.Equal(t, 4, len(devices))
+
+	sender := mocksender.NewMockSender(chk.ID()) // required to initiate aggregator
+	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("MonotonicCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("ServiceCheck", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("Commit").Return()
+
+	packet := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.3.6.1.2.1.1.3.0",
+				Type:  gosnmp.TimeTicks,
+				Value: 20,
+			},
+			{
+				Name:  "1.3.6.1.2.1.1.5.0",
+				Type:  gosnmp.OctetString,
+				Value: []byte("foo_sys_name"),
+			},
+			{
+				Name:  "1.3.6.1.2.1.2.1",
+				Type:  gosnmp.Integer,
+				Value: 30,
+			},
+		},
+	}
+
+	sess.On("Get", mock.Anything).Return(&packet, nil)
+
+	deviceMap := []struct {
+		ipAddress string
+		deviceID  string
+	}{
+		{ipAddress: "10.10.0.0", deviceID: "e162c69954d2b408"},
+		{ipAddress: "10.10.0.1", deviceID: "e162c69954d2b409"},
+		{ipAddress: "10.10.0.2", deviceID: "e162c69954d2b40a"},
+		{ipAddress: "10.10.0.3", deviceID: "e162c69954d2b40b"},
+	}
+
+	err = chk.Run()
+	assert.Nil(t, err)
+
+	for _, deviceData := range deviceMap {
+		hostname := "device_id:" + deviceData.deviceID
+		snmpTags := []string{"snmp_device:" + deviceData.ipAddress, "autodiscovery_subnet:10.10.0.0/30"}
+		snmpGlobalTags := common.CopyStrings(snmpTags)
+		snmpGlobalTagsWithLoader := append(common.CopyStrings(snmpGlobalTags), "loader:core")
+		scalarTags := append(common.CopyStrings(snmpGlobalTags), "symboltag1:1", "symboltag2:2")
+
+		sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), hostname, snmpGlobalTags)
+		sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), hostname, snmpGlobalTags)
+		sender.AssertMetric(t, "Gauge", "snmp.ifNumber", float64(30), hostname, scalarTags)
+
+		sender.AssertMetricTaggedWith(t, "MonotonicCount", "datadog.snmp.check_interval", snmpGlobalTagsWithLoader)
+		sender.AssertMetricTaggedWith(t, "Gauge", "datadog.snmp.check_duration", snmpGlobalTagsWithLoader)
+		sender.AssertMetric(t, "Gauge", "datadog.snmp.submitted_metrics", 2, hostname, snmpGlobalTagsWithLoader)
+	}
+	networkTags := []string{"network:10.10.0.0/30", "autodiscovery_subnet:10.10.0.0/30"}
+	sender.AssertMetric(t, "Gauge", "snmp.discovered_devices_count", 4, "", networkTags)
+}


### PR DESCRIPTION
Reverted here https://github.com/DataDog/datadog-agent/pull/9209

### What does this PR do?

Add config to use DeviceID as hostname for metrics and service checks

### Motivation

Needed for NDM custom tags feature.

### Additional Notes


### Describe how to test your changes

Test that using `use_device_id_as_hostname` will add use device_id as hostname.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
