### PR TITLE
[gui] Fix check runner count status value

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -6,7 +6,7 @@
       <br>Flavor: {{.flavor}}
       <br>PID: {{.pid}}
       {{- if .runnerStats.Workers}}
-        <br>Check Workers: {{.runnerStats.Workers}}
+        <br>Check Workers: {{.runnerStats.Workers.Count}}
       {{end}}
       <br>Agent start: {{ formatUnixTime .agent_start_nano }}
       {{- if .config.log_file}}


### PR DESCRIPTION
### What does this PR do?

After implementation of runner utilization tracking, the expvar
`Workers` changed its structure but the GUI was not updated at that
time which uses it. This change fixes the GUI check runner count.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

- Start the agent
- Start the Agent GUI (`datadog-agent launch-gui`)
- Ensure that the Check Runners field has the correct integer value

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
