### PR TITLE
[corechecks/snmp] Use getnext for reachable device status

### DIFF
--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
@@ -6,12 +6,15 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cihub/seelog"
+
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/checkconfig"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/common"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/fetch"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/gosnmplib"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/metadata"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/report"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/session"
@@ -68,7 +71,7 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 	// Fetch and report metrics
 	var checkErr error
 	var deviceStatus metadata.DeviceStatus
-	tags, values, checkErr := d.getValuesAndTags(staticTags)
+	deviceReachable, tags, values, checkErr := d.getValuesAndTags(staticTags)
 	if checkErr != nil {
 		d.sender.ServiceCheck(serviceCheckName, metrics.ServiceCheckCritical, "", tags, checkErr.Error())
 	} else {
@@ -79,7 +82,7 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 	}
 
 	if d.config.CollectDeviceMetadata {
-		if values != nil {
+		if deviceReachable {
 			deviceStatus = metadata.DeviceStatusReachable
 		} else {
 			deviceStatus = metadata.DeviceStatusUnreachable
@@ -97,14 +100,15 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 	return checkErr
 }
 
-func (d *DeviceCheck) getValuesAndTags(staticTags []string) ([]string, *valuestore.ResultValueStore, error) {
+func (d *DeviceCheck) getValuesAndTags(staticTags []string) (bool, []string, *valuestore.ResultValueStore, error) {
+	var deviceReachable bool
 	var checkErrors []string
 	tags := common.CopyStrings(staticTags)
 
 	// Create connection
 	connErr := d.session.Connect()
 	if connErr != nil {
-		return tags, nil, fmt.Errorf("snmp connection error: %s", connErr)
+		return false, tags, nil, fmt.Errorf("snmp connection error: %s", connErr)
 	}
 	defer func() {
 		err := d.session.Close()
@@ -113,7 +117,20 @@ func (d *DeviceCheck) getValuesAndTags(staticTags []string) ([]string, *valuesto
 		}
 	}()
 
-	err := d.doAutodetectProfile(d.session)
+	// Get any value under 1.3 (iso.org) to check if the device is reachable
+	getNextValue, err := d.session.GetNext([]string{"1.3"})
+	if err != nil {
+		deviceReachable = false
+		checkErrors = append(checkErrors, fmt.Sprintf("check device reachable: failed: %s", err))
+	} else {
+		deviceReachable = true
+		if logLevel, err := log.GetLogLevel(); err != nil || logLevel == seelog.DebugLvl {
+			values := gosnmplib.ResultToScalarValues(getNextValue)
+			log.Debugf("check device reachable: success: %+v", values)
+		}
+	}
+
+	err = d.doAutodetectProfile(d.session)
 	if err != nil {
 		checkErrors = append(checkErrors, fmt.Sprintf("failed to autodetect profile: %s", err))
 	}
@@ -133,7 +150,7 @@ func (d *DeviceCheck) getValuesAndTags(staticTags []string) ([]string, *valuesto
 	if len(checkErrors) > 0 {
 		joinedError = errors.New(strings.Join(checkErrors, "; "))
 	}
-	return tags, valuesStore, joinedError
+	return deviceReachable, tags, valuesStore, joinedError
 }
 
 func (d *DeviceCheck) doAutodetectProfile(sess session.Session) error {

--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
@@ -24,6 +24,9 @@ import (
 const (
 	snmpLoaderTag    = "loader:core"
 	serviceCheckName = "snmp.can_check"
+
+	// 1.3 (iso.org) is the OID used for getNext call to check if the device is reachable
+	deviceReachableGetNextOid = "1.3"
 )
 
 // DeviceCheck hold info necessary to collect info for a single device
@@ -117,8 +120,8 @@ func (d *DeviceCheck) getValuesAndTags(staticTags []string) (bool, []string, *va
 		}
 	}()
 
-	// Get any value under 1.3 (iso.org) to check if the device is reachable
-	getNextValue, err := d.session.GetNext([]string{"1.3"})
+	// Check if the device is reachable
+	getNextValue, err := d.session.GetNext([]string{deviceReachableGetNextOid})
 	if err != nil {
 		deviceReachable = false
 		checkErrors = append(checkErrors, fmt.Sprintf("check device reachable: failed: %s", err))

--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/checkconfig"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/common"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/gosnmplib"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/report"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/session"
 )
@@ -144,6 +145,7 @@ profiles:
 		},
 	}
 
+	sess.On("GetNext", []string{"1.3"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&sysObjectIDPacket, nil)
 	sess.On("Get", []string{"1.3.6.1.2.1.1.3.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.999", "1.2.3.4.5", "1.3.6.1.2.1.1.5.0"}).Return(&packet, nil)
 	sess.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.13", "1.3.6.1.2.1.2.2.1.14", "1.3.6.1.2.1.31.1.1.1.1", "1.3.6.1.2.1.31.1.1.1.18"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkPacket, nil)

--- a/pkg/collector/corechecks/snmp/gosnmplib/testing_utils.go
+++ b/pkg/collector/corechecks/snmp/gosnmplib/testing_utils.go
@@ -1,0 +1,14 @@
+package gosnmplib
+
+import "github.com/gosnmp/gosnmp"
+
+// MockValidReachableGetNextPacket valid reachable packet
+var MockValidReachableGetNextPacket = gosnmp.SnmpPacket{
+	Variables: []gosnmp.SnmpPDU{
+		{
+			Name:  "1.3.6.1.2.1.1.2.0",
+			Type:  gosnmp.ObjectIdentifier,
+			Value: "1.3.6.1.4.1.3375.2.1.3.4.1",
+		},
+	},
+}


### PR DESCRIPTION
### What does this PR do?

[snmp] Use getnext for reachable device status

### Motivation

- For device reachability, testing using GetNext is more reliable than relaying on presence of `values` being collected or not.
A device might be reachable, but no values can be collected.
- GetNext result can help troubleshooting since it will tell us if a device is reachable or not (if we can get any value from it) 

### Additional Notes

Downside of adding a getnext call:
- Every check run will have an new overhead of 1 GETNEXT call. (I think this is fine since it's only 1 small call, it's not substantial compared to the rest of calls needed to collect metrics/metadata)

### Describe how to test your changes

- Check in agent status that `check device reachable: failed` appear when a device is not reachable
- Check in agent logs that `check device reachable: success` (debug log) is present when a device is reachable


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
