### PR TITLE
[compliance] fix send on closed chan

### DIFF
--- a/pkg/compliance/event/reporter.go
+++ b/pkg/compliance/event/reporter.go
@@ -39,12 +39,13 @@ func NewLogReporter(stopper restart.Stopper, sourceName, sourceType, runPath str
 	// setup the auditor
 	auditor := auditor.New(runPath, sourceType+"-registry.json", coreconfig.DefaultAuditorTTL, health)
 	auditor.Start()
-	stopper.Add(auditor)
 
 	// setup the pipeline provider that provides pairs of processor and sender
 	pipelineProvider := pipeline.NewProvider(config.NumberOfPipelines, auditor, &diagnostic.NoopMessageReceiver{}, nil, endpoints, context)
 	pipelineProvider.Start()
+
 	stopper.Add(pipelineProvider)
+	stopper.Add(auditor)
 
 	logSource := config.NewLogSource(
 		sourceName,


### PR DESCRIPTION
### What does this PR do?

stop stoppables in the right order to avoid send of closed chan

```
$ security-agent compliance event

panic: send on closed channel

goroutine 173 [running]:
github.com/DataDog/datadog-agent/pkg/logs/sender.(*batchStrategy).sendMessages(0xc000338ea0, 0xc000322a80, 0x1, 0x64, 0xc000338240, 0xc000278190)
	/home/vagrant/go/src/github.com/DataDog/datadog-agent/pkg/logs/sender/batch_strategy.go:163 +0x1a6
github.com/DataDog/datadog-agent/pkg/logs/sender.(*batchStrategy).flushBuffer(0xc000338ea0, 0xc000338240, 0xc000278190)
	/home/vagrant/go/src/github.com/DataDog/datadog-agent/pkg/logs/sender/batch_strategy.go:138 +0xf7
github.com/DataDog/datadog-agent/pkg/logs/sender.(*batchStrategy).Send.func1(0xc000338ea0, 0xc000338240, 0xc000278190, 0xc0003241e0)
	/home/vagrant/go/src/github.com/DataDog/datadog-agent/pkg/logs/sender/batch_strategy.go:88 +0x3f
github.com/DataDog/datadog-agent/pkg/logs/sender.(*batchStrategy).Send(0xc000338ea0, 0xc000338de0, 0xc000338240, 0xc000278190)
	/home/vagrant/go/src/github.com/DataDog/datadog-agent/pkg/logs/sender/batch_strategy.go:97 +0x1ef
github.com/DataDog/datadog-agent/pkg/logs/sender.(*Sender).run(0xc000478180)
	/home/vagrant/go/src/github.com/DataDog/datadog-agent/pkg/logs/sender/sender.go:64 +0xa2
created by github.com/DataDog/datadog-agent/pkg/logs/sender.(*Sender).Start
	/home/vagrant/go/src/github.com/DataDog/datadog-agent/pkg/logs/sender/sender.go:45 +0x3f
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
