### PR TITLE
Windows Dockerfile: Include kernel ver in installer_version

### DIFF
--- a/Dockerfiles/agent/install.ps1
+++ b/Dockerfiles/agent/install.ps1
@@ -68,5 +68,5 @@ Write-Output @"
 install_method:
   tool: docker
   tool_version: docker-win-$env:VARIANT
-  installer_version: docker
+  installer_version: docker-win-$env:VARIANT
 "@ > C:/ProgramData/Datadog/install_info


### PR DESCRIPTION
### What does this PR do?

Also include the Windows kernel version in the `installer_version` field, in addition to the existing `tool_version`

### Motivation

We only check `installer_version` in some places, so we didn't have all the info.

