### PR TITLE
improve sysvinit agent exit messages

### DIFF
--- a/omnibus/config/templates/datadog-agent/sysvinit_debian.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_debian.erb
@@ -25,7 +25,7 @@ DESC="Datadog Agent"
 
 
 if [ ! -x $AGENTPATH ]; then
-	echo "$AGENTPATH not found. Exiting."
+	echo "$AGENTPATH not found. Exiting $NAME"
 	exit 0
 fi
 

--- a/omnibus/config/templates/datadog-agent/sysvinit_debian.process.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_debian.process.erb
@@ -24,7 +24,7 @@ DESC="Datadog Process Agent"
 
 
 if [ ! -x $AGENTPATH ]; then
-	echo "$AGENTPATH not found. Exiting."
+	echo "$AGENTPATH not found. Exiting $NAME"
 	exit 0
 fi
 

--- a/omnibus/config/templates/datadog-agent/sysvinit_debian.security.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_debian.security.erb
@@ -24,12 +24,12 @@ DESC="Datadog Security Agent"
 
 
 if [ ! -x $AGENTPATH ]; then
-	echo "$AGENTPATH not found. Exiting."
+	echo "$AGENTPATH not found. Exiting $NAME"
 	exit 0
 fi
 
 if [ ! -x $SECURITY_AGENT_CONFIG_FILE ]; then
-	echo "$SECURITY_AGENT_CONFIG_FILE not found. Exiting."
+	echo "$SECURITY_AGENT_CONFIG_FILE not found. Exiting $NAME"
 	exit 0
 fi
 

--- a/omnibus/config/templates/datadog-agent/sysvinit_debian.trace.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_debian.trace.erb
@@ -24,7 +24,7 @@ DESC="Datadog Trace Agent (APM)"
 
 
 if [ ! -x $AGENTPATH ]; then
-	echo "$AGENTPATH not found. Exiting."
+	echo "$AGENTPATH not found. Exiting $NAME"
 	exit 0
 fi
 

--- a/omnibus/config/templates/datadog-agent/sysvinit_suse.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_suse.erb
@@ -55,7 +55,7 @@ DESC="Datadog Agent"
 rc_reset
 
 if [ ! -x $AGENTPATH ]; then
-  echo "$AGENTPATH not found. Exiting."
+  echo "$AGENTPATH not found. Exiting $NAME"
   exit 1
 fi
 

--- a/omnibus/config/templates/datadog-agent/sysvinit_suse.process.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_suse.process.erb
@@ -56,7 +56,7 @@ DESC="Datadog Process Agent"
 rc_reset
 
 if [ ! -x $AGENTPATH ]; then
-  echo "$AGENTPATH not found. Exiting."
+  echo "$AGENTPATH not found. Exiting $NAME"
   exit 1
 fi
 

--- a/omnibus/config/templates/datadog-agent/sysvinit_suse.security.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_suse.security.erb
@@ -56,12 +56,12 @@ DESC="Datadog Security Agent"
 rc_reset
 
 if [ ! -x $AGENTPATH ]; then
-  echo "$AGENTPATH not found. Exiting."
+  echo "$AGENTPATH not found. Exiting $NAME"
   exit 1
 fi
 
 if [ ! -x $SECURITY_AGENT_CONFIG_FILE ]; then
-	echo "$SECURITY_AGENT_CONFIG_FILE not found. Exiting."
+	echo "$SECURITY_AGENT_CONFIG_FILE not found. Exiting $NAME"
 	exit 1
 fi
 

--- a/omnibus/config/templates/datadog-agent/sysvinit_suse.trace.erb
+++ b/omnibus/config/templates/datadog-agent/sysvinit_suse.trace.erb
@@ -56,7 +56,7 @@ DESC="Datadog Trace Agent (APM)"
 rc_reset
 
 if [ ! -x $AGENTPATH ]; then
-  echo "$AGENTPATH not found. Exiting."
+  echo "$AGENTPATH not found. Exiting $NAME"
   exit 1
 fi
 


### PR DESCRIPTION
### What does this PR do?

Improve "exit" message due to config file not present in sysvinit script.

message like : 

```
Error /etc/datadog-agent/security-agent.yaml not found. Exiting
```

will be :

```
Error /etc/datadog-agent/security-agent.yaml not found. Exiting datadog-security-agent
```

### Motivation

See issue : https://github.com/DataDog/datadog-agent/issues/8876

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
