### PR TITLE
Add logs_transpors to the inventory payload

### DIFF
--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -16,6 +16,7 @@ import (
 	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/client/http"
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
+	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -92,6 +93,7 @@ func start(getAC func() *autodiscovery.AutoConfig, serverless bool, logsChan cha
 	if endpoints.UseHTTP {
 		status.CurrentTransport = status.TransportHTTP
 	}
+	inventories.SetAgentMetadata(inventories.AgentLogsTransport, status.CurrentTransport)
 
 	// setup the status
 	status.Init(&isRunning, endpoints, sources, metrics.LogsExpvars)

--- a/pkg/metadata/inventories/README.md
+++ b/pkg/metadata/inventories/README.md
@@ -56,6 +56,8 @@ The payload is a JSON dict with the following fields
     version, ...). This defaults to `"undefined"` when not installed through a tool (like when installed with apt, source
     build, ...).
   - `install_method_installer_version` - **string**:  The version of Datadog module (ex: the Chef Datadog package, the Datadog Ansible playbook, ...).
+  - `logs_transport` - **string**:  The transport used to send logs to Datadog. Value is either `"HTTP"` or `"TCP"` when logs collection is
+    enabled, otherwise the field is omitted.
 
 ("scrubbed" indicates that secrets are removed from the field value just as they are in logs)
 

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -82,6 +82,7 @@ const (
 	AgentInstallerVersion             AgentMetadataName = "install_method_installer_version"
 	AgentInstallTool                  AgentMetadataName = "install_method_tool"
 	AgentInstallToolVersion           AgentMetadataName = "install_method_tool_version"
+	AgentLogsTransport                AgentMetadataName = "logs_transport"
 )
 
 // SetAgentMetadata updates the agent metadata value in the cache


### PR DESCRIPTION
### What does this PR do?

Add logs_transpors to the inventory payload.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
