### PR TITLE
Ensure log lines for dependencies don't contain build path

### DIFF
--- a/pkg/config/log.go
+++ b/pkg/config/log.go
@@ -358,18 +358,15 @@ func extractShortPathFromFullPath(fullPath string) string {
 		shortPath = slices[len(slices)-1]
 	} else {
 		// For logging from dependencies, we want to log e.g.
-		// "go.opentelemetry.io/collector@v0.35.0/service/collector.go"
+		// "collector@v0.35.0/service/collector.go"
 		slices := strings.Split(fullPath, "/")
-		pkgNameIndex := len(slices) - 1
-		for ; pkgNameIndex > 0; pkgNameIndex-- {
-			if strings.Contains(slices[pkgNameIndex], "@") {
-				if pkgNameIndex > 0 {
-					pkgNameIndex--
-				}
+		atSignIndex := len(slices) - 1
+		for ; atSignIndex > 0; atSignIndex-- {
+			if strings.Contains(slices[atSignIndex], "@") {
 				break
 			}
 		}
-		shortPath = strings.Join(slices[pkgNameIndex:], "/")
+		shortPath = strings.Join(slices[atSignIndex:], "/")
 	}
 	return shortPath
 }

--- a/pkg/config/log_test.go
+++ b/pkg/config/log_test.go
@@ -27,8 +27,8 @@ func TestExtractShortPathFromFullPath(t *testing.T) {
 	// process agent
 	assert.Equal(t, "cmd/agent/collector.go", extractShortPathFromFullPath("/home/jenkins/workspace/process-agent-build-ddagent/go/src/github.com/DataDog/datadog-process-agent/cmd/agent/collector.go"))
 	// various possible dependency paths
-	assert.Equal(t, "go.opentelemetry.io/collector@v0.35.0/receiver/otlpreceiver/otlp.go", extractShortPathFromFullPath("/Users/runner/programming/go/pkg/mod/go.opentelemetry.io/collector@v0.35.0/receiver/otlpreceiver/otlp.go"))
-	assert.Equal(t, "go.opentelemetry.io/collector@v0.35.0/receiver/otlpreceiver/otlp.go", extractShortPathFromFullPath("/gomodcache/go.opentelemetry.io/collector@v0.35.0/receiver/otlpreceiver/otlp.go"))
+	assert.Equal(t, "collector@v0.35.0/receiver/otlpreceiver/otlp.go", extractShortPathFromFullPath("/Users/runner/programming/go/pkg/mod/go.opentelemetry.io/collector@v0.35.0/receiver/otlpreceiver/otlp.go"))
+	assert.Equal(t, "collector@v0.35.0/receiver/otlpreceiver/otlp.go", extractShortPathFromFullPath("/gomodcache/go.opentelemetry.io/collector@v0.35.0/receiver/otlpreceiver/otlp.go"))
 }
 
 func TestSeelogConfig(t *testing.T) {

--- a/pkg/config/log_test.go
+++ b/pkg/config/log_test.go
@@ -27,7 +27,7 @@ func TestExtractShortPathFromFullPath(t *testing.T) {
 	// process agent
 	assert.Equal(t, "cmd/agent/collector.go", extractShortPathFromFullPath("/home/jenkins/workspace/process-agent-build-ddagent/go/src/github.com/DataDog/datadog-process-agent/cmd/agent/collector.go"))
 	// various possible dependency paths
-	assert.Equal(t, "go.opentelemetry.io/collector@v0.35.0/receiver/otlpreceiver/otlp.go", extractShortPathFromFullPath("/Users/slavek.kabrda/programming/go/pkg/mod/go.opentelemetry.io/collector@v0.35.0/receiver/otlpreceiver/otlp.go"))
+	assert.Equal(t, "go.opentelemetry.io/collector@v0.35.0/receiver/otlpreceiver/otlp.go", extractShortPathFromFullPath("/Users/runner/programming/go/pkg/mod/go.opentelemetry.io/collector@v0.35.0/receiver/otlpreceiver/otlp.go"))
 	assert.Equal(t, "go.opentelemetry.io/collector@v0.35.0/receiver/otlpreceiver/otlp.go", extractShortPathFromFullPath("/gomodcache/go.opentelemetry.io/collector@v0.35.0/receiver/otlpreceiver/otlp.go"))
 }
 

--- a/pkg/config/log_test.go
+++ b/pkg/config/log_test.go
@@ -26,6 +26,9 @@ func TestExtractShortPathFromFullPath(t *testing.T) {
 	assert.Equal(t, "main.go", extractShortPathFromFullPath("main.go"))
 	// process agent
 	assert.Equal(t, "cmd/agent/collector.go", extractShortPathFromFullPath("/home/jenkins/workspace/process-agent-build-ddagent/go/src/github.com/DataDog/datadog-process-agent/cmd/agent/collector.go"))
+	// various possible dependency paths
+	assert.Equal(t, "go.opentelemetry.io/collector@v0.35.0/receiver/otlpreceiver/otlp.go", extractShortPathFromFullPath("/Users/slavek.kabrda/programming/go/pkg/mod/go.opentelemetry.io/collector@v0.35.0/receiver/otlpreceiver/otlp.go"))
+	assert.Equal(t, "go.opentelemetry.io/collector@v0.35.0/receiver/otlpreceiver/otlp.go", extractShortPathFromFullPath("/gomodcache/go.opentelemetry.io/collector@v0.35.0/receiver/otlpreceiver/otlp.go"))
 }
 
 func TestSeelogConfig(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Up until now, the log lines for files in dependencies would look something like this:

```
2021-09-14 10:15:31 CEST | CORE | INFO | (/Users/runner/gomodcache/go.opentelemetry.io/collector@v0.35.0/service/collector.go:218 in runAndWaitForShutdownEvent) | Everything is ready. Begin running and processing data.
```

While with this patch they will look like this:

```
2021-09-14 10:15:31 CEST | CORE | INFO | (collector@v0.35.0/service/collector.go:218 in runAndWaitForShutdownEvent) | Everything is ready. Begin running and processing data.
```

The `/Users/runner/gomodcache/go.opentelemetry.io/` part is omitted. I feel like we should keep the imported module name, as using only `service/collector.go:218` would make it look like this is in file from agent itself, which could be confusing.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Configure the agent to run with OTLP enabled - right now this means adding e.g. following to the config file:

```
experimental:
  otlp:
    http_port: 9000
```

Run the agent and ensure the log lines related to OTLP start with `collector@` instead of a path.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
