### PR TITLE
[gitlab] Stop muting ARM job notifications

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -43,8 +43,3 @@ cleanup_kitchen_functional_test      @DataDog/agent-network @DataDog/agent-secur
 
 # E2E
 k8s-e2e-*                         @DataDog/container-integrations
-
-
-# TODO(AP-1208): Remove once arm runners are in a better shape
-*arm64*  @DataDog/do-not-notify
-*armhf*  @DataDog/do-not-notify


### PR DESCRIPTION
### What does this PR do?

Removes the exception in `JOBOWNERS` that made ARM job failures not send notifications to teams.

### Motivation

The pipelines are now more stable.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
