### PR TITLE
[tests] Skip flappy `TestUtilizationTrackerAccuracy` on Windows

### DIFF
--- a/pkg/collector/worker/utilization_tracker_test.go
+++ b/pkg/collector/worker/utilization_tracker_test.go
@@ -209,6 +209,10 @@ func TestUtilizationTrackerAccuracy(t *testing.T) {
 		t.Skip("Skipping flaky test on Darwin")
 	}
 
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping flaky test on Windows")
+	}
+
 	windowSize := 3000 * time.Millisecond
 	pollingInterval := 50 * time.Millisecond
 


### PR DESCRIPTION
Timing-based tests on Appveyor seem to be generally flaky and while this
test in most cases passes without issues, the false negative case is
still high enough of a probability to be an annoyance. Since this test
uses no OS-specific functinality and passes on Linux with much higher
confidence, we still have assurance that this logic works as expected.

### What does this PR do?

Skips flappy `TestUtilizationTrackerAccuracy` on Windows platforms

### Motivation

High chance of a false negative test result

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

N/A

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.