### PR TITLE
Fix the python object count

### DIFF
--- a/cmd/agent/dist/utils/py_mem.py
+++ b/cmd/agent/dist/utils/py_mem.py
@@ -11,7 +11,7 @@ def get_mem_stats():
         entry_type = ref.split(' ')[0]
 
         stat = stats.get(entry_type, {})
-        stat['num'] = stat.get('n', 0) + n
+        stat['num'] = stat.get('num', 0) + n
         stat['sz'] = stat.get('sz', 0) + n * sz
 
         entries = stat.get('entries', [])


### PR DESCRIPTION
This value was incorrectly derived from pympler's output, resulting in
only the latest count being included.

### Motivation

I noticed this discrepancy while trying to figure out the output format.  This causes the top-level `/*/NObjects` values to always be equal to NObjects of the last entry, instead of the sum of the NObjects from the entries.

### Describe how to test your changes

No need

### Checklist
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.

Note: Adding GitHub labels is only possible for contributors with write access.
