### PR TITLE
pkg/trace/api: add telemetry to /v*/traces responses

### DIFF
--- a/pkg/trace/api/responses.go
+++ b/pkg/trace/api/responses.go
@@ -74,7 +74,7 @@ type writeCounter struct {
 	n uint64
 }
 
-func NewWriteCounter(w io.Writer) *writeCounter {
+func newWriteCounter(w io.Writer) *writeCounter {
 	return &writeCounter{w: w}
 }
 
@@ -92,7 +92,7 @@ func httpRateByService(w http.ResponseWriter, dynConf *sampler.DynamicConfig) ui
 	response := traceResponse{
 		Rates: dynConf.RateByService.GetAll(), // this is thread-safe
 	}
-	wc := NewWriteCounter(w)
+	wc := newWriteCounter(w)
 	encoder := json.NewEncoder(wc)
 	if err := encoder.Encode(response); err != nil {
 		tags := []string{"error:response-error"}

--- a/pkg/trace/api/responses_test.go
+++ b/pkg/trace/api/responses_test.go
@@ -1,0 +1,22 @@
+package api
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestWriteCounter(t *testing.T) {
+	assert := assert.New(t)
+	var buf bytes.Buffer
+	wc := NewWriteCounter(&buf)
+	assert.Zero(wc.N())
+	wc.Write([]byte{1})
+	wc.Write([]byte{2})
+	assert.EqualValues(wc.N(), 2)
+	assert.EqualValues(buf.Bytes(), []byte{1, 2})
+	wc.Write([]byte{3})
+	assert.EqualValues(wc.N(), 3)
+	assert.EqualValues(buf.Bytes(), []byte{1, 2, 3})
+}

--- a/pkg/trace/api/responses_test.go
+++ b/pkg/trace/api/responses_test.go
@@ -10,7 +10,7 @@ import (
 func TestWriteCounter(t *testing.T) {
 	assert := assert.New(t)
 	var buf bytes.Buffer
-	wc := NewWriteCounter(&buf)
+	wc := newWriteCounter(&buf)
 	assert.Zero(wc.N())
 	wc.Write([]byte{1})
 	wc.Write([]byte{2})

--- a/releasenotes/notes/apm-response-telemetry-8d87163131b401d3.yaml
+++ b/releasenotes/notes/apm-response-telemetry-8d87163131b401d3.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: New telemetry was added to measure `/v.*/traces` endpoints latency and response size.
+    These metrics are `datadog.trace_agent.receiver.{rate_response_bytes,serve_traces_ms}`.


### PR DESCRIPTION
This changed adds two new metrics:
* `datadog.trace_agent.receiver.rate_response_bytes` which counts the
  number of bytes in the response.
* `datadog.trace_agent.receiver.serve_traces_ms` which counts the time
  in miliseconds it takes to respond to the request (latency)

APMS-5755