### PR TITLE
[gitlab] Skip displaying deploy_latest jobs for RC pipelines

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -222,6 +222,9 @@ variables:
 .if_testing_cleanup: &if_testing_cleanup
   if: $TESTING_CLEANUP == "true"
 
+.if_deploy_on_beta_repo_branch: &if_beta_repo_branch
+  if: $DEPLOY_AGENT == "true" && $DEB_RPM_BUCKET_BRANCH == "beta"
+
 # Rule to trigger jobs only when a tag matches a given pattern (for RCs)
 # on the beta branch.
 # Note: due to workflow rules, rc tag => deploy pipeline, so there's technically no
@@ -320,14 +323,14 @@ variables:
       AGENT_REPOSITORY: agent
       IMG_REGISTRIES: public
 
-# Same as on_deploy_a6_manual, except the job would not run
-# on RC pipelines, it would only run for the final release.
+# Same as on_deploy_a6_manual, except the job would not run on pipelines
+# using beta branch, it would only run for the final release.
 .on_deploy_a6_manual_final:
   - <<: *if_not_version_6
     when: never
   - <<: *if_not_deploy
     when: never
-  - <<: *if_rc_tag_on_beta_repo_branch
+  - <<: *if_beta_repo_branch
     when: never
   - <<: *if_not_stable_or_beta_repo_branch
     when: manual
@@ -393,14 +396,14 @@ variables:
       DSD_REPOSITORY: dogstatsd
       IMG_REGISTRIES: public
 
-# Same as on_deploy_a7_manual, except the job would not run
-# on RC pipelines, it would only run for the final release.
+# Same as on_deploy_a7_manual, except the job would not run on pipelines
+# using beta branch, it would only run for the final release.
 .on_deploy_a7_manual_final:
   - <<: *if_not_version_7
     when: never
   - <<: *if_not_deploy
     when: never
-  - <<: *if_rc_tag_on_beta_repo_branch
+  - <<: *if_beta_repo_branch
     when: never
   - <<: *if_not_stable_or_beta_repo_branch
     when: manual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -222,7 +222,7 @@ variables:
 .if_testing_cleanup: &if_testing_cleanup
   if: $TESTING_CLEANUP == "true"
 
-.if_deploy_on_beta_repo_branch: &if_beta_repo_branch
+.if_deploy_on_beta_repo_branch: &if_deploy_on_beta_repo_branch
   if: $DEPLOY_AGENT == "true" && $DEB_RPM_BUCKET_BRANCH == "beta"
 
 # Rule to trigger jobs only when a tag matches a given pattern (for RCs)
@@ -330,7 +330,7 @@ variables:
     when: never
   - <<: *if_not_deploy
     when: never
-  - <<: *if_beta_repo_branch
+  - <<: *if_deploy_on_beta_repo_branch
     when: never
   - <<: *if_not_stable_or_beta_repo_branch
     when: manual
@@ -403,7 +403,7 @@ variables:
     when: never
   - <<: *if_not_deploy
     when: never
-  - <<: *if_beta_repo_branch
+  - <<: *if_deploy_on_beta_repo_branch
     when: never
   - <<: *if_not_stable_or_beta_repo_branch
     when: manual

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -320,6 +320,27 @@ variables:
       AGENT_REPOSITORY: agent
       IMG_REGISTRIES: public
 
+# Same as on_deploy_a6_manual, except the job would not run
+# on RC pipelines, it would only run for the final release.
+.on_deploy_a6_manual_final:
+  - <<: *if_not_version_6
+    when: never
+  - <<: *if_not_deploy
+    when: never
+  - <<: *if_rc_tag_on_beta_repo_branch
+    when: never
+  - <<: *if_not_stable_or_beta_repo_branch
+    when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: agent-dev
+      IMG_REGISTRIES: dev
+  - when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: agent
+      IMG_REGISTRIES: public
+
 # This rule is a variation of on_deploy_a6_manual where
 # the job is usually run manually, except when the pipeline
 # builds an RC: in this case, the job is run automatically.
@@ -357,6 +378,29 @@ variables:
   - <<: *if_not_version_7
     when: never
   - <<: *if_not_deploy
+    when: never
+  - <<: *if_not_stable_or_beta_repo_branch
+    when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: agent-dev
+      DSD_REPOSITORY: dogstatsd-dev
+      IMG_REGISTRIES: dev
+  - when: manual
+    allow_failure: true
+    variables:
+      AGENT_REPOSITORY: agent
+      DSD_REPOSITORY: dogstatsd
+      IMG_REGISTRIES: public
+
+# Same as on_deploy_a7_manual, except the job would not run
+# on RC pipelines, it would only run for the final release.
+.on_deploy_a7_manual_final:
+  - <<: *if_not_version_7
+    when: never
+  - <<: *if_not_deploy
+    when: never
+  - <<: *if_rc_tag_on_beta_repo_branch
     when: never
   - <<: *if_not_stable_or_beta_repo_branch
     when: manual

--- a/.gitlab/deploy_6/docker.yml
+++ b/.gitlab/deploy_6/docker.yml
@@ -50,7 +50,7 @@ deploy_latest-a6:
   tags: ["runner:main"]
   stage: deploy6
   rules:
-    !reference [.on_deploy_a6_manual]
+    !reference [.on_deploy_a6_manual_final]
   dependencies: []
   script: # We can't use the 'trigger' keyword on manual jobs, otherwise they can't be run if the pipeline fails and is retried
     - python3 -m pip install -r requirements.txt

--- a/.gitlab/deploy_7/docker.yml
+++ b/.gitlab/deploy_7/docker.yml
@@ -71,7 +71,7 @@ deploy_latest-a7:
   tags: ["runner:main"]
   stage: deploy7
   rules:
-    !reference [.on_deploy_a7_manual]
+    !reference [.on_deploy_a7_manual_final]
   dependencies: []
   script: # We can't use the 'trigger' keyword on manual jobs, otherwise they can't be run if the pipeline fails and is retried
     - python3 -m pip install -r requirements.txt
@@ -93,7 +93,7 @@ deploy_latest-dogstatsd:
   tags: ["runner:main"]
   stage: deploy7
   rules:
-    !reference [.on_deploy_a7_manual]
+    !reference [.on_deploy_a7_manual_final]
   dependencies: []
   script: # We can't use the 'trigger' keyword on manual jobs, otherwise they can't be run if the pipeline fails and is retried
     - python3 -m pip install -r requirements.txt


### PR DESCRIPTION
### What does this PR do?

Removes the deploy_latest jobs from RC pipelines to ensure nobody triggers them by accident.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
