### PR TITLE
[invoke] Fix latest_workflow_run_for_ref method

### DIFF
--- a/tasks/libs/common/github_workflows.py
+++ b/tasks/libs/common/github_workflows.py
@@ -76,7 +76,7 @@ class GithubWorkflows(RemoteAPI):
         """
         Gets latest workflow run for a given reference
         """
-        runs = self.workflow_runs(self.repository, workflow_name)
+        runs = self.workflow_runs(workflow_name)
         ref_runs = [run for run in runs["workflow_runs"] if run["head_branch"] == ref]
         return max(ref_runs, key=lambda run: run['created_at'], default=None)
 


### PR DESCRIPTION
### What does this PR do?

Removes superfluous parameter in the `GithubWorkflows.workflow_runs` call in `GithubWorkflows.latest_workflow_run_for_ref` (the parameter was removed in #9158).

### Motivation

Fix MacOS builds.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
