### PR TITLE
[Serverless] Prevent panic when DD_API_KEY is not set

### DIFF
--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -340,6 +340,8 @@ func (d *Daemon) ComputeGlobalTags(configTags []string) {
 	}
 }
 
+// setTraceTags tries to set extra tags to the Trace agent.
+// setTraceTags returns a boolean which indicate whether or not the operation succeed for testing purpose.
 func (d *Daemon) setTraceTags(tagMap map[string]string) bool {
 	if d.TraceAgent != nil && d.TraceAgent.Get() != nil {
 		d.TraceAgent.Get().SetGlobalTagsUnsafe(tags.BuildTracerTags(tagMap))

--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -331,15 +331,21 @@ func (d *Daemon) ComputeGlobalTags(configTags []string) {
 		if d.MetricAgent != nil {
 			d.MetricAgent.SetExtraTags(tagArray)
 		}
-		if d.TraceAgent != nil {
-			d.TraceAgent.Get().SetGlobalTagsUnsafe(tags.BuildTracerTags(tagMap))
-		}
+		d.setTraceTags(tagMap)
 		d.ExtraTags.Tags = tagArray
 		source := serverlessLog.GetLambdaSource()
 		if source != nil {
 			source.Config.Tags = tagArray
 		}
 	}
+}
+
+func (d *Daemon) setTraceTags(tagMap map[string]string) bool {
+	if d.TraceAgent != nil && d.TraceAgent.Get() != nil {
+		d.TraceAgent.Get().SetGlobalTagsUnsafe(tags.BuildTracerTags(tagMap))
+		return true
+	}
+	return false
 }
 
 // SetExecutionContext sets the current context to the daemon


### PR DESCRIPTION
### What does this PR do?

When DD_API_KEY is not set, a panic is thrown (without preventing customer code to execute)

### Motivation

Cleaner log

### Describe how to test your changes

Unit testing

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
