### PR TITLE
pkg/trace/traceutil: card obfuscation

### DIFF
--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -85,6 +85,8 @@ func setupAPM(config Config) {
 	config.BindEnv("apm_config.internal_profiling.enabled", "DD_APM_INTERNAL_PROFILING_ENABLED")
 	config.BindEnv("apm_config.debugger_dd_url", "DD_APM_DEBUGGER_DD_URL")
 	config.BindEnv("apm_config.debugger_api_key", "DD_APM_DEBUGGER_API_KEY")
+	config.BindEnv("apm_config.obfuscation.credit_cards.enabled", "DD_APM_OBFUSCATION_CREDIT_CARDS_ENABLED")
+	config.BindEnv("apm_config.obfuscation.credit_cards.luhn", "DD_APM_OBFUSCATION_CREDIT_CARDS_LUHN")
 
 	config.SetEnvKeyTransformer("apm_config.ignore_resources", func(in string) interface{} {
 		r, err := splitCSVString(in, ',')

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -227,18 +227,6 @@ func (a *Agent) Process(p *api.Payload) {
 				traceutil.SetMeta(span, k, v)
 			}
 			a.obfuscator.Obfuscate(span)
-			if p.RunMetaHook {
-				// the payload decoder was not able to run the MetaHook (pkg/trace/pb/hook.go) at
-				// decode time, so we need to run it here. This should only happen in cases where
-				// the Content-Type is not Msgpack (e.g. deprecated JSON).
-				if hook, ok := pb.MetaHook(); ok {
-					for k, v := range span.Meta {
-						if newv := hook(k, v); newv != v {
-							span.Meta[k] = newv
-						}
-					}
-				}
-			}
 			Truncate(span)
 			if p.ClientComputedTopLevel {
 				traceutil.UpdateTracerTopLevel(span)

--- a/pkg/trace/api/api.go
+++ b/pkg/trace/api/api.go
@@ -383,14 +383,16 @@ func (r *HTTPReceiver) tagStats(v Version, header http.Header) *info.TagStats {
 	})
 }
 
-func decodeTraces(v Version, req *http.Request) (pb.Traces, error) {
+func decodeTraces(v Version, req *http.Request) (*decodedTraces, error) {
 	switch v {
 	case v01:
 		var spans []pb.Span
 		if err := json.NewDecoder(req.Body).Decode(&spans); err != nil {
 			return nil, err
 		}
-		return tracesFromSpans(spans), nil
+		return &decodedTraces{
+			Traces: tracesFromSpans(spans),
+		}, nil
 	case v05:
 		buf := getBuffer()
 		defer putBuffer(buf)
@@ -399,13 +401,12 @@ func decodeTraces(v Version, req *http.Request) (pb.Traces, error) {
 		}
 		var traces pb.Traces
 		err := traces.UnmarshalMsgDictionary(buf.Bytes())
-		return traces, err
+		return &decodedTraces{
+			Traces:  traces,
+			RanHook: true,
+		}, err
 	default:
-		var traces pb.Traces
-		if err := decodeRequest(req, &traces); err != nil {
-			return nil, err
-		}
-		return traces, nil
+		return decodeRequest(req)
 	}
 }
 
@@ -517,12 +518,13 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 		atomic.AddInt64(&ts.PayloadRefused, 1)
 		return
 	}
+
 	start := time.Now()
-	traces, err := decodeTraces(v, req)
 	defer func(err error) {
 		tags := append(ts.AsTags(), fmt.Sprintf("success:%v", err == nil))
 		metrics.Histogram("datadog.trace_agent.receiver.serve_traces_ms", float64(time.Since(start))/float64(time.Millisecond), tags, 1)
 	}(err)
+	dectraces, err := decodeTraces(v, req)
 	if err != nil {
 		httpDecodingError(err, []string{"handler:traces", fmt.Sprintf("v:%s", v)}, w)
 		switch err {
@@ -545,6 +547,7 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 		metrics.Histogram("datadog.trace_agent.receiver.rate_response_bytes", float64(n), tags, 1)
 	}
 
+	traces := dectraces.Traces
 	atomic.AddInt64(&ts.TracesReceived, int64(len(traces)))
 	atomic.AddInt64(&ts.TracesBytes, req.Body.(*apiutil.LimitedReader).Count)
 	atomic.AddInt64(&ts.PayloadAccepted, 1)
@@ -558,6 +561,7 @@ func (r *HTTPReceiver) handleTraces(v Version, w http.ResponseWriter, req *http.
 		ClientComputedTopLevel: req.Header.Get(headerComputedTopLevel) != "",
 		ClientComputedStats:    req.Header.Get(headerComputedStats) != "",
 		ClientDroppedP0s:       droppedTracesFromHeader(req.Header, ts),
+		RunMetaHook:            !dectraces.RanHook,
 	}
 
 	select {
@@ -622,6 +626,10 @@ type Payload struct {
 
 	// ClientDroppedP0s specifies the number of P0 traces chunks dropped by the client.
 	ClientDroppedP0s int64
+
+	// RunMetaHook specifies whether the agent.Agent processor should run the pb.MetaHook
+	// See pkg/trace/pb/hook.go
+	RunMetaHook bool
 }
 
 // handleServices handle a request with a list of several services
@@ -747,38 +755,52 @@ func (r *HTTPReceiver) Languages() string {
 	return strings.Join(str, "|")
 }
 
-func decodeRequest(req *http.Request, dest *pb.Traces) error {
+type decodedTraces struct {
+	// Traces contains the decoded request.
+	Traces pb.Traces
+	// RanHook reports whether the decoder was able to run the pb.MetaHook
+	// See pkg/trace/pb/hook.go
+	RanHook bool
+}
+
+func decodeRequest(req *http.Request) (*decodedTraces, error) {
+	var dest pb.Traces
 	switch mediaType := getMediaType(req); mediaType {
 	case "application/msgpack":
 		buf := getBuffer()
 		defer putBuffer(buf)
 		_, err := io.Copy(buf, req.Body)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		_, err = dest.UnmarshalMsg(buf.Bytes())
-		return err
+		return &decodedTraces{
+			Traces:  dest,
+			RanHook: true,
+		}, err
 	case "application/json":
 		fallthrough
 	case "text/json":
 		fallthrough
 	case "":
-		return json.NewDecoder(req.Body).Decode(dest)
+		err := json.NewDecoder(req.Body).Decode(&dest)
+		return &decodedTraces{Traces: dest}, err
 	default:
 		// do our best
-		if err1 := json.NewDecoder(req.Body).Decode(dest); err1 != nil {
+		if err1 := json.NewDecoder(req.Body).Decode(&dest); err1 != nil {
 			buf := getBuffer()
 			defer putBuffer(buf)
 			_, err2 := io.Copy(buf, req.Body)
 			if err2 != nil {
-				return fmt.Errorf("could not decode JSON (%q), nor Msgpack (%q)", err1, err2)
+				return nil, err2
 			}
 			_, err2 = dest.UnmarshalMsg(buf.Bytes())
-			if err2 != nil {
-				return fmt.Errorf("could not decode JSON (%q), nor Msgpack (%q)", err1, err2)
-			}
+			return &decodedTraces{
+				Traces:  dest,
+				RanHook: true,
+			}, err2
 		}
-		return nil
+		return &decodedTraces{Traces: dest}, nil
 	}
 }
 

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -497,9 +497,9 @@ func TestDecodeV05(t *testing.T) {
 	assert.NoError(err)
 	req, err := http.NewRequest("POST", "/v0.5/traces", bytes.NewReader(b))
 	assert.NoError(err)
-	traces, err := decodeTraces(v05, req)
+	dectraces, err := decodeTraces(v05, req)
 	assert.NoError(err)
-	assert.EqualValues(traces, pb.Traces{
+	assert.EqualValues(dectraces.Traces, pb.Traces{
 		{
 			{
 				Service:  "Service",

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -74,6 +74,21 @@ type ObfuscationConfig struct {
 	// Memcached holds the configuration for obfuscating the "memcached.command" tag
 	// for spans of type "memcached".
 	Memcached Enablable `mapstructure:"memcached"`
+
+	// CreditCards holds the configuration for obfuscating credit cards.
+	CreditCards CreditCardsConfig `mapstructure:"credit_cards"`
+}
+
+// CreditCardsConfig holds the configuration for credit card obfuscation in
+// (Meta) tags.
+type CreditCardsConfig struct {
+	// Enabled specifies whether this feature should be enabled.
+	Enabled bool `mapstructure:"enabled"`
+
+	// Luhn specifies whether Luhn checksum validation should be enabled.
+	// https://dev.to/shiraazm/goluhn-a-simple-library-for-generating-calculating-and-verifying-luhn-numbers-588j
+	// It reduces false positives, but increases the CPU time X3.
+	Luhn bool `mapstructure:"luhn"`
 }
 
 // HTTPObfuscationConfig holds the configuration settings for HTTP obfuscation.

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -305,6 +305,7 @@ func (c *AgentConfig) applyDatadogConfig() error {
 		MaxRequestBytes: c.MaxRequestBytes,
 	}
 
+	c.Obfuscation = new(ObfuscationConfig)
 	if config.Datadog.IsSet("apm_config.obfuscation") {
 		var o ObfuscationConfig
 		err := config.Datadog.UnmarshalKey("apm_config.obfuscation", &o)
@@ -313,6 +314,17 @@ func (c *AgentConfig) applyDatadogConfig() error {
 			if c.Obfuscation.RemoveStackTraces {
 				c.addReplaceRule("error.stack", `(?s).*`, "?")
 			}
+		}
+	}
+	{
+		// TODO(x): There is an issue with config.Datadog.IsSet("apm_config.obfuscation"), probably coming from Viper,
+		// where it returns false even is "apm_config.obfuscation.credit_cards.enabled" is set via an environment
+		// variable, so we need a temporary workaround by specifically setting env. var. accessible fields.
+		if config.Datadog.IsSet("apm_config.obfuscation.credit_cards.enabled") {
+			c.Obfuscation.CreditCards.Enabled = config.Datadog.GetBool("apm_config.obfuscation.credit_cards.enabled")
+		}
+		if config.Datadog.IsSet("apm_config.obfuscation.credit_cards.luhn") {
+			c.Obfuscation.CreditCards.Luhn = config.Datadog.GetBool("apm_config.obfuscation.credit_cards.luhn")
 		}
 	}
 

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -306,6 +306,8 @@ func TestFullYamlConfig(t *testing.T) {
 	assert.True(o.RemoveStackTraces)
 	assert.True(c.Obfuscation.Redis.Enabled)
 	assert.True(c.Obfuscation.Memcached.Enabled)
+	assert.True(c.Obfuscation.CreditCards.Enabled)
+	assert.True(c.Obfuscation.CreditCards.Luhn)
 }
 
 func TestUndocumentedYamlConfig(t *testing.T) {

--- a/pkg/trace/config/env_test.go
+++ b/pkg/trace/config/env_test.go
@@ -399,6 +399,30 @@ func TestLoadEnv(t *testing.T) {
 		assert.Equal(50066, config.Datadog.GetInt(config.ExperimentalOTLPgRPCPort))
 	})
 
+	env = "DD_APM_OBFUSCATION_CREDIT_CARDS_ENABLED"
+	t.Run(env, func(t *testing.T) {
+		defer cleanConfig()()
+		assert := assert.New(t)
+		err := os.Setenv(env, "false")
+		assert.NoError(err)
+		defer os.Unsetenv(env)
+		_, err = Load("./testdata/full.yaml")
+		assert.NoError(err)
+		assert.False(config.Datadog.GetBool("apm_config.obfuscation.credit_cards.enabled"))
+	})
+
+	env = "DD_APM_OBFUSCATION_CREDIT_CARDS_LUHN"
+	t.Run(env, func(t *testing.T) {
+		defer cleanConfig()()
+		assert := assert.New(t)
+		err := os.Setenv(env, "false")
+		assert.NoError(err)
+		defer os.Unsetenv(env)
+		_, err = Load("./testdata/full.yaml")
+		assert.NoError(err)
+		assert.False(config.Datadog.GetBool("apm_config.obfuscation.credit_cards.luhn"))
+	})
+
 	env = "DD_APM_PROFILING_ADDITIONAL_ENDPOINTS"
 	t.Run(env, func(t *testing.T) {
 		defer cleanConfig()()

--- a/pkg/trace/config/testdata/full.yaml
+++ b/pkg/trace/config/testdata/full.yaml
@@ -67,6 +67,9 @@ apm_config:
       enabled: true
     memcached:
       enabled: true
+    credit_cards:
+      enabled: true 
+      luhn: true
 experimental:
   otlp:
     http_port: 50051

--- a/pkg/trace/obfuscate/credit_cards.go
+++ b/pkg/trace/obfuscate/credit_cards.go
@@ -22,7 +22,7 @@ func newCreditCardsObfuscator(useLuhn bool) *ccObfuscator {
 	return cco
 }
 
-func (cco *ccObfuscator) unhook() { pb.SetMetaHook(nil) }
+func (cco *ccObfuscator) Disable() { pb.SetMetaHook(nil) }
 
 // MetaHook checks the tag with the given key and val and returns the final
 // value to be assigned to this tag.

--- a/pkg/trace/obfuscate/credit_cards.go
+++ b/pkg/trace/obfuscate/credit_cards.go
@@ -1,0 +1,272 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package obfuscate
+
+import (
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+)
+
+// ccObfuscator maintains credit card obfuscation state and processing.
+type ccObfuscator struct {
+	luhn bool
+}
+
+func newCreditCardsObfuscator(useLuhn bool) *ccObfuscator {
+	cco := &ccObfuscator{luhn: useLuhn}
+	pb.SetMetaHook(cco.MetaHook)
+	return cco
+}
+
+func (cco *ccObfuscator) unhook() { pb.SetMetaHook(nil) }
+
+// MetaHook checks the tag with the given key and val and returns the final
+// value to be assigned to this tag.
+//
+// For example, in this specific use-case, if the val is detected to be a credit
+// card number, "?" will be returned.
+func (cco *ccObfuscator) MetaHook(k, v string) (newval string) {
+	switch k {
+	case "_sample_rate",
+		"_sampling_priority_v1",
+		"error",
+		"error.msg",
+		"error.type",
+		"error.stack",
+		"env",
+		"graphql.field",
+		"graphql.query",
+		"graphql.type",
+		"graphql.operation.name",
+		"grpc.code",
+		"grpc.method",
+		"grpc.request",
+		"http.status_code",
+		"http.method",
+		"runtime-id",
+		"out.host",
+		"out.port",
+		"sampling.priority",
+		"span.type",
+		"span.name",
+		"service.name",
+		"service",
+		"sql.query",
+		"version":
+		// these tags are known to not be credit card numbers
+		return v
+	}
+	if strings.HasPrefix(k, "_dd") {
+		return v
+	}
+	if isCardNumber(v, cco.luhn) {
+		return "?"
+	}
+	return v
+}
+
+// isSensitve checks if b could be a credit card number by checking the digit count and IIN prefix.
+// If validateLuhn is true, the Luhn checksum is also applied to potential candidates.
+func isCardNumber(b string, validateLuhn bool) (ok bool) {
+	//
+	// Just credit card numbers for now, based on:
+	// • https://baymard.com/checkout-usability/credit-card-patterns
+	// • https://www.regular-expressions.info/creditcard.html
+	//
+	if len(b) == 0 {
+		return false
+	}
+	if b[0] != ' ' && b[0] != '-' && (b[0] < '0' || b[0] > '9') {
+		// fast path: only valid characters are 0-9, space (" ") and dash("-")
+		return false
+	}
+	prefix := 0                 // holds up to b[:6] digits as a numeric value (for example []byte{"523"} becomes int(523)) for checking prefixes
+	count := 0                  // counts digits encountered
+	foundPrefix := false        // reports whether we've detected a valid prefix
+	recdigit := func(_ byte) {} // callback on each found digit; no-op by default (we only need this for Luhn)
+	if validateLuhn {
+		// we need Luhn checksum validation, so we have to take additional action
+		// and record all digits found
+		buf := make([]byte, 0, len(b))
+		recdigit = func(b byte) { buf = append(buf, b) }
+		defer func() {
+			if !ok {
+				// if isCardNumber returned false, it means that b can not be
+				// a credit card number
+				return
+			}
+			// potentially a credit card number, run the Luhn checksum
+			ok = luhnValid(buf)
+		}()
+	}
+loop:
+	for i := range b {
+		// We traverse and search b for a valid IIN credit card prefix based
+		// on the digits found, ignoring spaces and dashes.
+		// Source: https://www.regular-expressions.info/creditcard.html
+		switch b[i] {
+		case ' ', '-':
+			// ignore space (' ') and dash ('-')
+			continue loop
+		}
+		if b[i] < '0' || b[i] > '9' {
+			// not a 0 to 9 digit; can not be a credit card number; abort
+			return false
+		}
+		count++
+		recdigit(b[i])
+		if !foundPrefix {
+			// we have not yet found a valid prefix so we convert the digits
+			// that we have so far into a numeric value:
+			prefix = prefix*10 + (int(b[i]) - '0')
+			maybe, yes := validCardPrefix(prefix)
+			if yes {
+				// we've found a valid prefix; continue counting
+				foundPrefix = true
+			} else if !maybe {
+				// this is not a valid prefix and we should not continue looking
+				return false
+			}
+		}
+		if count > 16 {
+			// too many digits
+			return false
+		}
+	}
+	if count < 12 {
+		// too few digits
+		return false
+	}
+	return foundPrefix
+}
+
+// luhnValid checks that the number represented in the given string validates the Luhn Checksum algorithm.
+// str is expected to contain exclusively digits at all positions.
+//
+// See:
+// • https://en.wikipedia.org/wiki/Luhn_algorithm
+// • https://dev.to/shiraazm/goluhn-a-simple-library-for-generating-calculating-and-verifying-luhn-numbers-588j
+//
+func luhnValid(str []byte) bool {
+	var (
+		sum int
+		alt bool
+	)
+	n := len(str)
+	for i := n - 1; i > -1; i-- {
+		if str[i] < '0' || str[i] > '9' {
+			return false // not a number!
+		}
+		mod := int(str[i] - 0x30) // convert byte to int
+		if alt {
+			mod *= 2
+			if mod > 9 {
+				mod = (mod % 10) + 1
+			}
+		}
+		alt = !alt
+		sum += mod
+	}
+	return sum%10 == 0
+}
+
+// validCardPrefix validates whether b is a valid card prefix. Maybe returns true if
+// the prefix could be an IIN once more digits are revealed and yes reports whether
+// b is a fully valid IIN.
+//
+// If yes is false and maybe is false, there is no reason to continue searching. The
+// prefix is invalid.
+//
+// IMPORTANT: If adding new prefixes to this algorithm, make sure that you update
+// the "maybe" clauses above, in the shorter prefixes than the one you are adding.
+// This refers to the cases which return true, false.
+//
+// TODO(x): this whole code could be code generated from a prettier data structure.
+// Ultimately, it could even be user-configurable.
+func validCardPrefix(n int) (maybe, yes bool) {
+	// Validates IIN prefix possibilities
+	// Source: https://www.regular-expressions.info/creditcard.html
+	if n > 699999 {
+		// too long for any known prefix; stop looking
+		return false, false
+	}
+	if n < 10 {
+		switch n {
+		case 1, 4:
+			// 1 & 4 are valid IIN
+			return false, true
+		case 2, 3, 5, 6:
+			// 2, 3, 5, 6 could be the start of valid IIN
+			return true, false
+		default:
+			// invalid IIN
+			return false, false
+		}
+	}
+	if n < 100 {
+		if (n >= 34 && n <= 39) ||
+			(n >= 51 && n <= 55) ||
+			n == 62 ||
+			n == 65 {
+			// 34-39, 51-55, 62, 65 are valid IIN
+			return false, true
+		}
+		if n == 30 || n == 63 || n == 64 || n == 35 || n == 50 || n == 60 ||
+			(n >= 22 && n <= 27) || (n >= 56 && n <= 58) || (n >= 60 && n <= 69) {
+			// 30, 63, 64, 35, 50, 60, 22-27, 56-58, 60-69 may end up as valid IIN
+			return true, false
+		}
+	}
+	if n < 1000 {
+		if (n >= 300 && n <= 305) ||
+			(n >= 644 && n <= 649) ||
+			n == 309 ||
+			n == 636 {
+			// 300‑305, 309, 636, 644‑649 are valid IIN
+			return false, true
+		}
+		if (n >= 352 && n <= 358) || n == 501 || n == 601 ||
+			(n >= 222 && n <= 272) || (n >= 500 && n <= 509) ||
+			(n >= 560 && n <= 589) || (n >= 600 && n <= 699) {
+			// 352-358, 501, 601, 222-272, 500-509, 560-589, 600-699 may be a 4 or 6 digit IIN prefix
+			return true, false
+		}
+	}
+	if n < 10000 {
+		if (n >= 3528 && n <= 3589) ||
+			n == 5019 ||
+			n == 6011 {
+			// 3528‑3589, 5019, 6011 are valid IINs
+			return false, true
+		}
+		if (n >= 2221 && n <= 2720) || (n >= 5000 && n <= 5099) ||
+			(n >= 5600 && n <= 5899) || (n >= 6000 && n <= 6999) {
+			// maybe a 6-digit IIN
+			return true, false
+		}
+	}
+	if n < 100000 {
+		if (n >= 22210 && n <= 27209) ||
+			(n >= 50000 && n <= 50999) ||
+			(n >= 56000 && n <= 58999) ||
+			(n >= 60000 && n <= 69999) {
+			// maybe a 6-digit IIN
+			return true, false
+		}
+	}
+	if n < 1000000 {
+		if (n >= 222100 && n <= 272099) ||
+			(n >= 500000 && n <= 509999) ||
+			(n >= 560000 && n <= 589999) ||
+			(n >= 600000 && n <= 699999) {
+			// 222100‑272099, 500000‑509999, 560000‑589999, 600000‑699999 are valid IIN
+			return false, true
+		}
+	}
+	// unknown IIN
+	return false, false
+}

--- a/pkg/trace/obfuscate/credit_cards.go
+++ b/pkg/trace/obfuscate/credit_cards.go
@@ -80,6 +80,10 @@ func isCardNumber(b string, validateLuhn bool) (ok bool) {
 	if len(b) == 0 {
 		return false
 	}
+	if len(b) < 12 {
+		// fast path: can not be a credit card
+		return false
+	}
 	if b[0] != ' ' && b[0] != '-' && (b[0] < '0' || b[0] > '9') {
 		// fast path: only valid characters are 0-9, space (" ") and dash("-")
 		return false

--- a/pkg/trace/obfuscate/credit_cards_test.go
+++ b/pkg/trace/obfuscate/credit_cards_test.go
@@ -18,14 +18,14 @@ func TestNewCreditCardsObfuscator(t *testing.T) {
 	_, ok := pb.MetaHook()
 	assert.False(t, ok)
 	cco := newCreditCardsObfuscator(false)
-	defer cco.unhook()
+	defer cco.Disable()
 	_, ok = pb.MetaHook()
 	assert.True(t, ok)
 }
 
 func TestMetaHook(t *testing.T) {
 	cco := newCreditCardsObfuscator(false)
-	defer cco.unhook()
+	defer cco.Disable()
 	for _, tt := range []struct {
 		k, v string
 		out  string

--- a/pkg/trace/obfuscate/credit_cards_test.go
+++ b/pkg/trace/obfuscate/credit_cards_test.go
@@ -1,0 +1,317 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package obfuscate
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewCreditCardsObfuscator(t *testing.T) {
+	_, ok := pb.MetaHook()
+	assert.False(t, ok)
+	cco := newCreditCardsObfuscator(false)
+	defer cco.unhook()
+	_, ok = pb.MetaHook()
+	assert.True(t, ok)
+}
+
+func TestMetaHook(t *testing.T) {
+	cco := newCreditCardsObfuscator(false)
+	defer cco.unhook()
+	for _, tt := range []struct {
+		k, v string
+		out  string
+	}{
+		// these tags are not even checked:
+		{"error", "5105-1051-0510-5100", "5105-1051-0510-5100"},
+		{"_dd.something", "5105-1051-0510-5100", "5105-1051-0510-5100"},
+		{"env", "5105-1051-0510-5100", "5105-1051-0510-5100"},
+		{"service", "5105-1051-0510-5100", "5105-1051-0510-5100"},
+		{"version", "5105-1051-0510-5100", "5105-1051-0510-5100"},
+
+		{"card.number", "5105", "5105"},
+		{"card.number", "5105-1051-0510-5100", "?"},
+	} {
+		assert.Equal(t, tt.out, cco.MetaHook(tt.k, tt.v))
+	}
+}
+
+func TestIINValidCardPrefix(t *testing.T) {
+	for _, tt := range []struct {
+		in         int
+		maybe, yes bool
+	}{
+		// yes
+		{1, false, true},
+		{4, false, true},
+		// maybe
+		{2, true, false},
+		{3, true, false},
+		{5, true, false},
+		{6, true, false},
+		// no
+		{7, false, false},
+		{8, false, false},
+		{9, false, false},
+
+		// yes
+		{34, false, true},
+		{37, false, true},
+		{39, false, true},
+		{51, false, true},
+		{55, false, true},
+		{62, false, true},
+		{65, false, true},
+		// maybe
+		{30, true, false},
+		{63, true, false},
+		{22, true, false},
+		{27, true, false},
+		{69, true, false},
+		// no
+		{31, false, false},
+		{29, false, false},
+		{21, false, false},
+
+		// yes
+		{300, false, true},
+		{305, false, true},
+		{644, false, true},
+		{649, false, true},
+		{309, false, true},
+		{636, false, true},
+		// maybe
+		{352, true, false},
+		{358, true, false},
+		{501, true, false},
+		{601, true, false},
+		{222, true, false},
+		{272, true, false},
+		{500, true, false},
+		{509, true, false},
+		{560, true, false},
+		{589, true, false},
+		{600, true, false},
+		{699, true, false},
+
+		// yes
+		{3528, false, true},
+		{3589, false, true},
+		{5019, false, true},
+		{6011, false, true},
+		// maybe
+		{2221, true, false},
+		{2720, true, false},
+		{5000, true, false},
+		{5099, true, false},
+		{5600, true, false},
+		{5899, true, false},
+		{6000, true, false},
+		{6999, true, false},
+
+		// maybe
+		{22210, true, false},
+		{27209, true, false},
+		{50000, true, false},
+		{50999, true, false},
+		{56000, true, false},
+		{58999, true, false},
+		{60000, true, false},
+		{69999, true, false},
+		// no
+		{21000, false, false},
+		{55555, false, false},
+
+		// yes
+		{222100, false, true},
+		{272099, false, true},
+		{500000, false, true},
+		{509999, false, true},
+		{560000, false, true},
+		{589999, false, true},
+		{600000, false, true},
+		{699999, false, true},
+		// no
+		{551234, false, false},
+		{594388, false, false},
+		{219899, false, false},
+	} {
+		t.Run(fmt.Sprintf("%d", tt.in), func(t *testing.T) {
+			maybe, yes := validCardPrefix(tt.in)
+			assert.Equal(t, maybe, tt.maybe)
+			assert.Equal(t, yes, tt.yes)
+		})
+	}
+}
+
+func TestIINIsSensitive(t *testing.T) {
+	t.Run("valid", func(t *testing.T) {
+		for i, valid := range []string{
+			"378282246310005",
+			"  378282246310005",
+			"  3782-8224-6310-005 ",
+			"371449635398431",
+			"378734493671000",
+			"5610591081018250",
+			"30569309025904",
+			"38520000023237",
+			"6011 1111 1111 1117",
+			"6011000990139424",
+			" 3530111333--300000  ",
+			"3566002020360505",
+			"5555555555554444",
+			"5105-1051-0510-5100",
+			" 4111111111111111",
+			"4012888888881881 ",
+			"422222 2222222",
+			"5019717010103742",
+			"6331101999990016",
+			" 4242-4242-4242-4242 ",
+			"4242-4242-4242-4242 ",
+			"4242-4242-4242-4242  ",
+			"4000056655665556",
+			"5555555555554444",
+			"2223003122003222",
+			"5200828282828210",
+			"5105105105105100",
+			"378282246310005",
+			"371449635398431",
+			"6011111111111117",
+			"6011000990139424",
+			"3056930009020004",
+			"3566002020360505",
+			"620000000000000",
+			"2222 4053 4324 8877",
+			"2222 9909 0525 7051",
+			"2223 0076 4872 6984",
+			"2223 5771 2001 7656",
+			"5105 1051 0510 5100",
+			"5111 0100 3017 5156",
+			"5185 5408 1000 0019",
+			"5200 8282 8282 8210",
+			"5204 2300 8000 0017",
+			"5204 7400 0990 0014",
+			"5420 9238 7872 4339",
+			"5455 3307 6000 0018",
+			"5506 9004 9000 0436",
+			"5506 9004 9000 0444",
+			"5506 9005 1000 0234",
+			"5506 9208 0924 3667",
+			"5506 9224 0063 4930",
+			"5506 9274 2731 7625",
+			"5553 0422 4198 4105",
+			"5555 5537 5304 8194",
+			"5555 5555 5555 4444",
+			"4012 8888 8888 1881",
+			"4111 1111 1111 1111",
+			"6011 0009 9013 9424",
+			"6011 1111 1111 1117",
+			"3714 496353 98431",
+			"3782 822463 10005",
+			"3056 9309 0259 04",
+			"3852 0000 0232 37",
+			"3530 1113 3330 0000",
+			"3566 0020 2036 0505",
+			"3700 0000 0000 002",
+			"3700 0000 0100 018",
+			"6703 4444 4444 4449",
+			"4871 0499 9999 9910",
+			"4035 5010 0000 0008",
+			"4360 0000 0100 0005",
+			"6243 0300 0000 0001",
+			"5019 5555 4444 5555",
+			"3607 0500 0010 20",
+			"6011 6011 6011 6611",
+			"6445 6445 6445 6445",
+			"5066 9911 1111 1118",
+			"6062 8288 8866 6688",
+			"3569 9900 1009 5841",
+			"6771 7980 2100 0008",
+			"2222 4000 7000 0005",
+			"5555 3412 4444 1115",
+			"5577 0000 5577 0004",
+			"5555 4444 3333 1111",
+			"2222 4107 4036 0010",
+			"5555 5555 5555 4444",
+			"2222 4107 0000 0002",
+			"2222 4000 1000 0008",
+			"2223 0000 4841 0010",
+			"2222 4000 6000 0007",
+			"2223 5204 4356 0010",
+			"2222 4000 3000 0004",
+			"5100 0600 0000 0002",
+			"2222 4000 5000 0009",
+			"1354 1001 4004 955",
+			"4111 1111 4555 1142",
+			"4988 4388 4388 4305",
+			"4166 6766 6766 6746",
+			"4646 4646 4646 4644",
+			"4000 6200 0000 0007",
+			"4000 0600 0000 0006",
+			"4293 1891 0000 0008",
+			"4988 0800 0000 0000",
+			"4111 1111 1111 1111",
+			"4444 3333 2222 1111",
+			"4001 5900 0000 0001",
+			"4000 1800 0000 0002",
+			"4000 0200 0000 0000",
+			"4000 1600 0000 0004",
+			"4002 6900 0000 0008",
+			"4400 0000 0000 0008",
+			"4484 6000 0000 0004",
+			"4607 0000 0000 0009",
+			"4977 9494 9494 9497",
+			"4000 6400 0000 0005",
+			"4003 5500 0000 0003",
+			"4000 7600 0000 0001",
+			"4017 3400 0000 0003",
+			"4005 5190 0000 0006",
+			"4131 8400 0000 0003",
+			"4035 5010 0000 0008",
+			"4151 5000 0000 0008",
+			"4571 0000 0000 0001",
+			"4199 3500 0000 0002",
+			"4001 0200 0000 0009",
+		} {
+			t.Run("", func(t *testing.T) {
+				assert.True(t, isCardNumber(valid, true), i)
+			})
+		}
+	})
+
+	t.Run("invalid", func(t *testing.T) {
+		for i, invalid := range []string{
+			"37828224631000521389798", // valid but too long
+			"37828224631",             // valid but too short
+			"   3782822-4631 ",
+			"3714djkkkksii31",  // invalid character
+			"x371413321323331", // invalid characters
+			"",
+			"7712378231899",
+			"   -  ",
+		} {
+			assert.False(t, isCardNumber(invalid, false), i)
+		}
+	})
+}
+
+func BenchmarkIsSensitive(b *testing.B) {
+	run := func(str string, luhn bool) func(b *testing.B) {
+		return func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				isCardNumber(str, luhn)
+			}
+		}
+	}
+
+	b.Run("basic", run("4001 0200 0000 0009", false))
+	b.Run("luhn", run("4001 0200 0000 0009", true))
+}

--- a/pkg/trace/obfuscate/obfuscate.go
+++ b/pkg/trace/obfuscate/obfuscate.go
@@ -26,6 +26,7 @@ type Obfuscator struct {
 	mongo                *jsonObfuscator // nil if disabled
 	sqlExecPlan          *jsonObfuscator // nil if disabled
 	sqlExecPlanNormalize *jsonObfuscator // nil if disabled
+	creditCards          *ccObfuscator   // nil if disabled
 	// sqlLiteralEscapes reports whether we should treat escape characters literally or as escape characters.
 	// A non-zero value means 'yes'. Different SQL engines behave in different ways and the tokenizer needs
 	// to be generic.
@@ -76,6 +77,9 @@ func NewObfuscator(cfg *config.ObfuscationConfig) *Obfuscator {
 	}
 	if cfg.SQLExecPlanNormalize.Enabled {
 		o.sqlExecPlanNormalize = newJSONObfuscator(&cfg.SQLExecPlanNormalize, &o)
+	}
+	if cfg.CreditCards.Enabled {
+		o.creditCards = newCreditCardsObfuscator(cfg.CreditCards.Luhn)
 	}
 	return &o
 }

--- a/pkg/trace/obfuscate/obfuscate.go
+++ b/pkg/trace/obfuscate/obfuscate.go
@@ -85,7 +85,10 @@ func NewObfuscator(cfg *config.ObfuscationConfig) *Obfuscator {
 }
 
 // Stop cleans up after a finished Obfuscator.
-func (o *Obfuscator) Stop() { o.queryCache.Close() }
+func (o *Obfuscator) Stop() {
+	o.queryCache.Close()
+	o.creditCards.Disable()
+}
 
 // Obfuscate may obfuscate span's properties based on its type and on the Obfuscator's
 // configuration.

--- a/pkg/trace/obfuscate/obfuscate_test.go
+++ b/pkg/trace/obfuscate/obfuscate_test.go
@@ -57,14 +57,19 @@ func TestNewObfuscator(t *testing.T) {
 	assert.Nil(o.mongo)
 	assert.Nil(o.creditCards)
 
+	_, ok := pb.MetaHook()
+	assert.False(ok) // there is no hook without CC obfuscation on
 	o = NewObfuscator(&config.ObfuscationConfig{
 		ES:          config.JSONObfuscationConfig{Enabled: true},
 		Mongo:       config.JSONObfuscationConfig{Enabled: true},
 		CreditCards: config.CreditCardsConfig{Enabled: true},
 	})
+	defer o.Stop()
 	assert.NotNil(o.creditCards)
 	assert.NotNil(o.es)
 	assert.NotNil(o.mongo)
+	_, ok = pb.MetaHook()
+	assert.True(ok)
 }
 
 func TestCompactWhitespaces(t *testing.T) {

--- a/pkg/trace/obfuscate/obfuscate_test.go
+++ b/pkg/trace/obfuscate/obfuscate_test.go
@@ -55,11 +55,14 @@ func TestNewObfuscator(t *testing.T) {
 	o = NewObfuscator(nil)
 	assert.Nil(o.es)
 	assert.Nil(o.mongo)
+	assert.Nil(o.creditCards)
 
 	o = NewObfuscator(&config.ObfuscationConfig{
-		ES:    config.JSONObfuscationConfig{Enabled: true},
-		Mongo: config.JSONObfuscationConfig{Enabled: true},
+		ES:          config.JSONObfuscationConfig{Enabled: true},
+		Mongo:       config.JSONObfuscationConfig{Enabled: true},
+		CreditCards: config.CreditCardsConfig{Enabled: true},
 	})
+	assert.NotNil(o.creditCards)
 	assert.NotNil(o.es)
 	assert.NotNil(o.mongo)
 }

--- a/pkg/trace/pb/decoder_v05.go
+++ b/pkg/trace/pb/decoder_v05.go
@@ -3,6 +3,7 @@ package pb
 import (
 	"errors"
 	"fmt"
+
 	"github.com/tinylib/msgp/msgp"
 )
 
@@ -153,6 +154,7 @@ func (z *Span) UnmarshalMsgDictionary(bts []byte, dict []string) ([]byte, error)
 			delete(z.Meta, key)
 		}
 	}
+	hook, hookok := MetaHook()
 	for sz > 0 {
 		sz--
 		var key, val string
@@ -164,7 +166,11 @@ func (z *Span) UnmarshalMsgDictionary(bts []byte, dict []string) ([]byte, error)
 		if err != nil {
 			return bts, err
 		}
-		z.Meta[key] = val
+		if hookok {
+			z.Meta[key] = hook(key, val)
+		} else {
+			z.Meta[key] = val
+		}
 	}
 	// Metrics (10)
 	sz, bts, err = msgp.ReadMapHeaderBytes(bts)

--- a/pkg/trace/pb/hook.go
+++ b/pkg/trace/pb/hook.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package pb
+
+import "sync"
+
+var (
+	mu       sync.RWMutex // guards metahook
+	metahook func(_, v string) string
+)
+
+// SetMetaHook registers a callback which will run upon decoding each map
+// entry in the span's Meta field. The hook has the opportunity to alter the
+// value that is assigned to span.Meta[k] at decode time. By default, if no
+// hook is defined, the behaviour is span.Meta[k] = v.
+func SetMetaHook(hook func(k, v string) string) {
+	mu.Lock()
+	defer mu.Unlock()
+	metahook = hook
+}
+
+// MetaHook returns the active meta hook. A MetaHook is a function which is ran
+// for each span.Meta[k] = v value and has the opportunity to alter the final v.
+func MetaHook() (hook func(k, v string) string, ok bool) {
+	mu.RLock()
+	defer mu.RUnlock()
+	return metahook, metahook != nil
+}

--- a/pkg/trace/pb/hook_test.go
+++ b/pkg/trace/pb/hook_test.go
@@ -1,0 +1,39 @@
+package pb
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/tinylib/msgp/msgp"
+)
+
+func TestMetaHook(t *testing.T) {
+	t.Run("off", func(t *testing.T) {
+		b := newEmptyMessage()
+		b = msgp.AppendString(b, "meta")
+		b = msgp.AppendMapHeader(b, 1)
+		b = msgp.AppendString(b, "card.number")
+		b = msgp.AppendString(b, "4166 6766 6766 6746")
+		s, err := decodeBytes(b)
+
+		assert := assert.New(t)
+		assert.Nil(err)
+		assert.Equal(map[string]string{"card.number": "4166 6766 6766 6746"}, s.Meta)
+	})
+
+	t.Run("on", func(t *testing.T) {
+		SetMetaHook(func(k, v string) string { return "test" })
+		defer SetMetaHook(nil)
+
+		b := newEmptyMessage()
+		b = msgp.AppendString(b, "meta")
+		b = msgp.AppendMapHeader(b, 1)
+		b = msgp.AppendString(b, "card.number")
+		b = msgp.AppendString(b, "4166 6766 6766 6746")
+		s, err := decodeBytes(b)
+
+		assert := assert.New(t)
+		assert.Nil(err)
+		assert.Equal(map[string]string{"card.number": "test"}, s.Meta, "Warning! pkg/trace/pb: MetaHook was not applied. One possible cause is regenerating the code in this folder without porting custom modifications of it.")
+	})
+}

--- a/pkg/trace/pb/span.pb.go
+++ b/pkg/trace/pb/span.pb.go
@@ -22,12 +22,19 @@
 
 package pb
 
-import proto "github.com/gogo/protobuf/proto"
-import fmt "fmt"
-import math "math"
-import _ "github.com/gogo/protobuf/gogoproto" // plug-in
+import (
+	fmt "fmt"
 
-import io "io"
+	proto "github.com/gogo/protobuf/proto"
+
+	math "math"
+
+	_ "github.com/gogo/protobuf/gogoproto"
+
+	// plug-in
+
+	io "io"
+)
 
 // Reference imports to suppress errors if they are not otherwise used.
 var _ = proto.Marshal
@@ -42,18 +49,18 @@ const _ = proto.GoGoProtoPackageIsVersion2 // please upgrade the proto package
 
 // Span specifies the common Datadog API and trace agent span.
 type Span struct {
-	Service  string             `protobuf:"bytes,1,opt,name=service,proto3" json:"service" msg:"service"`
-	Name     string             `protobuf:"bytes,2,opt,name=name,proto3" json:"name" msg:"name"`
-	Resource string             `protobuf:"bytes,3,opt,name=resource,proto3" json:"resource" msg:"resource"`
-	TraceID  uint64             `protobuf:"varint,4,opt,name=traceID,proto3" json:"trace_id" msg:"trace_id"`
-	SpanID   uint64             `protobuf:"varint,5,opt,name=spanID,proto3" json:"span_id" msg:"span_id"`
-	ParentID uint64             `protobuf:"varint,6,opt,name=parentID,proto3" json:"parent_id" msg:"parent_id"`
-	Start    int64              `protobuf:"varint,7,opt,name=start,proto3" json:"start" msg:"start"`
-	Duration int64              `protobuf:"varint,8,opt,name=duration,proto3" json:"duration" msg:"duration"`
-	Error    int32              `protobuf:"varint,9,opt,name=error,proto3" json:"error" msg:"error"`
-	Meta     map[string]string  `protobuf:"bytes,10,rep,name=meta" json:"meta" msg:"meta" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
-	Metrics  map[string]float64 `protobuf:"bytes,11,rep,name=metrics" json:"metrics" msg:"metrics" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"fixed64,2,opt,name=value,proto3"`
-	Type     string             `protobuf:"bytes,12,opt,name=type,proto3" json:"type" msg:"type"`
+	Service  string             `protobuf:"bytes,1,opt,name=service,proto3" json:"service" msg:"service" msgpack:"service"`
+	Name     string             `protobuf:"bytes,2,opt,name=name,proto3" json:"name" msg:"name" msgpack:"name"`
+	Resource string             `protobuf:"bytes,3,opt,name=resource,proto3" json:"resource" msg:"resource" msgpack:"resource"`
+	TraceID  uint64             `protobuf:"varint,4,opt,name=traceID,proto3" json:"trace_id" msg:"trace_id" msgpack:"trace_id"`
+	SpanID   uint64             `protobuf:"varint,5,opt,name=spanID,proto3" json:"span_id" msg:"span_id" msgpack:"span_id"`
+	ParentID uint64             `protobuf:"varint,6,opt,name=parentID,proto3" json:"parent_id" msg:"parent_id" msgpack:"parent_id"`
+	Start    int64              `protobuf:"varint,7,opt,name=start,proto3" json:"start" msg:"start" msgpack:"start"`
+	Duration int64              `protobuf:"varint,8,opt,name=duration,proto3" json:"duration" msg:"duration" msgpack:"duration"`
+	Error    int32              `protobuf:"varint,9,opt,name=error,proto3" json:"error" msg:"error" msgpack:"error"`
+	Meta     map[string]string  `protobuf:"bytes,10,rep,name=meta" json:"meta" msg:"meta" msgpack:"meta" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"bytes,2,opt,name=value,proto3"`
+	Metrics  map[string]float64 `protobuf:"bytes,11,rep,name=metrics" json:"metrics" msg:"metrics" msgpack:"metrics" protobuf_key:"bytes,1,opt,name=key,proto3" protobuf_val:"fixed64,2,opt,name=value,proto3"`
+	Type     string             `protobuf:"bytes,12,opt,name=type,proto3" json:"type" msg:"type" msgpack:"type"`
 }
 
 func (m *Span) Reset()                    { *m = Span{} }

--- a/pkg/trace/pb/span_gen.go
+++ b/pkg/trace/pb/span_gen.go
@@ -74,6 +74,7 @@ func (z *Span) UnmarshalMsg(bts []byte) (o []byte, err error) {
 		err = msgp.WrapError(err)
 		return
 	}
+	hook, hookok := MetaHook()
 	for zb0001 > 0 {
 		zb0001--
 		field, bts, err = msgp.ReadMapKeyZC(bts)
@@ -169,7 +170,11 @@ func (z *Span) UnmarshalMsg(bts []byte) (o []byte, err error) {
 					err = msgp.WrapError(err, "Meta", za0001)
 					return
 				}
-				z.Meta[za0001] = za0002
+				if hookok {
+					z.Meta[za0001] = hook(za0001, za0002)
+				} else {
+					z.Meta[za0001] = za0002
+				}
 			}
 		case "metrics":
 			if msgp.IsNil(bts) {

--- a/pkg/trace/test/testsuite/cards_test.go
+++ b/pkg/trace/test/testsuite/cards_test.go
@@ -1,0 +1,62 @@
+package testsuite
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+	"github.com/DataDog/datadog-agent/pkg/trace/test"
+	"github.com/DataDog/datadog-agent/pkg/trace/test/testutil"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreditCards(t *testing.T) {
+	var r test.Runner
+	if err := r.Start(); err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := r.Shutdown(time.Second); err != nil {
+			t.Log("shutdown: ", err)
+		}
+	}()
+
+	for _, tt := range []struct {
+		conf []byte
+		out  string
+	}{
+		{
+			conf: []byte(""),
+			out:  "4166 6766 6766 6746",
+		},
+		{
+			conf: []byte(`
+apm_config:
+  env: my-env
+  obfuscation:
+    credit_cards:
+      enabled: true`),
+			out: "?",
+		},
+	} {
+		t.Run(tt.out, func(t *testing.T) {
+			if err := r.RunAgent(tt.conf); err != nil {
+				t.Fatal(err)
+			}
+			defer r.KillAgent()
+
+			p := testutil.GeneratePayload(1, &testutil.TraceConfig{
+				MaxSpans: 1,
+				Keep:     true,
+			}, &testutil.SpanConfig{MinTags: 2})
+			p[0][0].Meta["credit_card_number"] = "4166 6766 6766 6746"
+			if err := r.Post(p); err != nil {
+				t.Fatal(err)
+			}
+			waitForTrace(t, &r, func(v pb.TracePayload) {
+				payloadsEqual(t, p, v)
+				assert.Equal(t, v.Traces[0].Spans[0].Meta["credit_card_number"], tt.out)
+			})
+		})
+	}
+}

--- a/pkg/trace/traceutil/span.go
+++ b/pkg/trace/traceutil/span.go
@@ -5,7 +5,9 @@
 
 package traceutil
 
-import "github.com/DataDog/datadog-agent/pkg/trace/pb"
+import (
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+)
 
 const (
 	// This is a special metric, it's 1 if the span is top-level, 0 if not.

--- a/pkg/trace/traceutil/span_test.go
+++ b/pkg/trace/traceutil/span_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/releasenotes/notes/apm-credit-cards-obfuscation-918935ff76b3d897.yaml
+++ b/releasenotes/notes/apm-credit-cards-obfuscation-918935ff76b3d897.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: Added credit card obfuscation. It is off by default and can be enabled using the
+    env. var. DD_APM_OBFUSCATION_CREDIT_CARDS_ENABLED or `apm_config.obfuscation.credit_cards.enabled`

--- a/releasenotes/notes/apm-credit-cards-obfuscation-918935ff76b3d897.yaml
+++ b/releasenotes/notes/apm-credit-cards-obfuscation-918935ff76b3d897.yaml
@@ -9,4 +9,7 @@
 features:
   - |
     APM: Added credit card obfuscation. It is off by default and can be enabled using the
-    env. var. DD_APM_OBFUSCATION_CREDIT_CARDS_ENABLED or `apm_config.obfuscation.credit_cards.enabled`
+    env. var. DD_APM_OBFUSCATION_CREDIT_CARDS_ENABLED or `apm_config.obfuscation.credit_cards.enabled`.
+    There is also an option to enable an additional Luhn checksum check in order to eliminate
+    false negatives, but it comes with a performance cost and should not be used unless absolutely
+    needed. The option is DD_APM_OBFUSCATION_CREDIT_CARDS_LUHN or `apm_config.obfuscation.credit_cards.luhn`.


### PR DESCRIPTION
The PR adds support for credit card number obfuscation in span tags by means of configuration:
```yaml
apm_config:
  obfuscation:
    credit_cards:
      enabled: true # enables obfuscation in span tags
      luhn: true    # enables Luhn check
```
It is also possible to apply these settings via `DD_APM_OBFUSCATION_CREDIT_CARDS_ENABLED` and `DD_APM_OBFUSCATION_CREDIT_CARDS_LUHN`.

The feature is off by default. Applying the Luhn algorithm has a performance impact but eliminates any potential false positives. Without it, the algorithm simply checks for valid IIN credit card prefixes (and lengths) in numeric tags, which should be sufficient for most use cases.

The check and obfuscation is applied at decode time to avoid iterating and reading the map again. This is possible only for Msgpack. For JSON, the iteration happens since we don't own the decoding code.