### PR TITLE
Add `labels_as_tags` parameter to the KSM core check.

### DIFF
--- a/releasenotes/notes/Add-labels_as_tags-for-KSM-core-check-d278424925d4e199.yaml
+++ b/releasenotes/notes/Add-labels_as_tags-for-KSM-core-check-d278424925d4e199.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    KSM core check has a new `labels_as_tags` parameter to configure which pod labels should be used as datadog tag in an easier way than with the `label_joins` parameter.


### PR DESCRIPTION
### What does this PR do?

Add a `labels_as_tags` parameter to the KSM core check that provides a way to get resource labels and add them as tags on KSM metrics more easily than with the `label_joins` parameter.

### Motivation

Properly setting the `label_joins` parameter can be error prone and attaching resource labels as tags is a very common use case.

### Additional Notes

Corresponding change in the Helm chart: DataDog/helm-charts#395.

### Describe how to test your changes

Attach some custom tags to some pods and deployments.

Configure the KSM core check with
```
labels_as_tags:
  pod:
    my_custom_label: my_custom_tag
  deployment:
    my_other_custom_label: my_other_custom_tag
```

And check that the KSM metrics have the proper tag.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [X] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [X] The appropriate `team/..` label has been applied, if known.
- [X] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [X] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
