### PR TITLE
[invoke] Prevent invoke.create-rc from using dep versions higher than Agent version

### DIFF
--- a/tasks/libs/version.py
+++ b/tasks/libs/version.py
@@ -63,6 +63,9 @@ class Version:
             return other.rc is not None
         return self.rc > other.rc
 
+    def clone(self):
+        return deepcopy(self)
+
     def is_rc(self):
         return self._safe_value("rc") != 0
 
@@ -76,12 +79,12 @@ class Version:
         return "{}.{}.x".format(self._safe_value("major"), self._safe_value("minor"))
 
     def non_devel_version(self):
-        new_version = deepcopy(self)
+        new_version = self.clone()
         new_version.devel = False
         return new_version
 
     def next_version(self, bump_major=False, bump_minor=False, bump_patch=False, rc=False):
-        new_version = deepcopy(self)
+        new_version = self.clone()
 
         if bump_patch:
             new_version.patch = self._safe_value("patch") + 1

--- a/tasks/libs/version.py
+++ b/tasks/libs/version.py
@@ -58,9 +58,9 @@ class Version:
         if self.devel != other.devel:
             return not self.devel and other.devel
 
-        if self.rc is None or other.rc is None:
-            # Everything else being equal, self can only be higher than other if other is not a released version
-            return other.rc is not None
+        if self._safe_value("rc") == 0 or other._safe_value("rc") == 0:
+            # Everything else being equal, self can only be higher than other if other is an rc
+            return other.is_rc()
         return self.rc > other.rc
 
     def clone(self):


### PR DESCRIPTION
### What does this PR do?

Adds a check when determining which version to use from dependency repositories, to make sure we're not using versions that are higher than the Agent version.

### Motivation

In the case where a new version is being prepared while the old version is still in the process of being released, avoid using the new version in the old version's build.

### Additional Notes

When a dep repo has tagged a higher version (RC or final) that still matches the major + minor + patch version of the current Agent version, that version is not discarded (to take into account situations when a dep repo creates more RC tags than the Agent, or when it decides that it reached its final state for a release).

### Describe how to test your changes

Run `invoke release.create-rc` in a situation where this applies (eg. create a dummy `6.30.0-rc.100` tag, the tool should pick up `7.30.0` from integrations-core and not `7.30.1`).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
