### PR TITLE
Ensure NPM enabled config flag is reliable

### DIFF
--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -176,6 +176,8 @@ func load(configPath string) (*Config, error) {
 		// enable the connections/network check.
 		log.Info("network_config not found, but system-probe was enabled, enabling network module by default")
 		c.EnabledModules[NetworkTracerModule] = struct{}{}
+		// ensure others can key off of this single config value for NPM status
+		cfg.Set("network_config.enabled", true)
 	}
 
 	if cfg.GetBool(key(spNS, "enable_tcp_queue_length")) {


### PR DESCRIPTION
### What does this PR do?

Set network_config.enabled in backwards compatibility case

### Motivation

#9175 

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.