### PR TITLE
DOCS-2215 Add @env variables to datadog.yaml

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1229,16 +1229,19 @@ api_key:
 # system_probe_config:
 {{- if (eq .OS "windows")}}
   ## @param sysprobe_socket - string - optional - default: localhost:3333
+  ## @env DD_SYSTEM_PROBE_CONFIG_SYSPROBE_SOCKET - string - optional - default: localhost:3333
   ## The TCP address where system probes are accessed.
   #
   # sysprobe_socket: localhost:3333
 {{else}}
   ## @param sysprobe_socket - string - optional - default: /opt/datadog-agent/run/sysprobe.sock
+  ## @env DD_SYSTEM_PROBE_CONFIG_SYSPROBE_SOCKET - string - optional - default: /opt/datadog-agent/run/sysprobe.sock
   ## The full path to the location of the unix socket where system probes are accessed.
   #
   # sysprobe_socket: /opt/datadog-agent/run/sysprobe.sock
 {{ end }}
   ## @param log_file - string - optional - default: /var/log/datadog/system-probe.log
+  ## @env DD_SYSTEM_PROBE_CONFIG_LOG_FILE - string - optional - default: /var/log/datadog/system-probe.log
   ## The full path to the file where system-probe logs are written.
   #
   # log_file: /var/log/datadog/system-probe.log
@@ -1365,17 +1368,20 @@ api_key:
 #############################
 
 ## @param use_dogstatsd - boolean - optional - default: true
+## @env DD_USE_DOGSTATSD - boolean - optional - default: true
 ## Set this option to false to disable the Agent DogStatsD server.
 #
 # use_dogstatsd: true
 
 ## @param dogstatsd_port - integer - optional - default: 8125
+## @env DD_DOGSTATSD_PORT - integer - optional - default: 8125
 ## Override the Agent DogStatsD port.
 ## Note: Make sure your client is sending to the same UDP port.
 #
 # dogstatsd_port: 8125
 
 ## @param bind_host - string - optional - default: localhost
+## @env DD_BIND_HOST - string - optional - default: localhost
 ## The host to listen on for Dogstatsd and traces. This is ignored by APM when
 ## `apm_config.apm_non_local_traffic` is enabled and ignored by DogStatsD when `dogstatsd_non_local_traffic`
 ## is enabled. The trace-agent uses this host to send metrics to.
@@ -1385,32 +1391,38 @@ api_key:
 # bind_host: localhost
 
 ## @param dogstatsd_socket - string - optional - default: ""
+## @env DD_DOGSTATSD_SOCKET - string - optional - default: ""
 ## Listen for Dogstatsd metrics on a Unix Socket (*nix only). Set to a valid filesystem path to enable.
 #
 # dogstatsd_socket: ""
 
 ## @param dogstatsd_origin_detection - boolean - optional - default: false
+## @env DD_DOGSTATSD_ORIGIN_DETECTION - boolean - optional - default: false
 ## When using Unix Socket, DogStatsD can tag metrics with container metadata.
 ## If running DogStatsD in a container, host PID mode (e.g. with --pid=host) is required.
 #
 # dogstatsd_origin_detection: false
 
 ## @param dogstatsd_buffer_size - integer - optional - default: 8192
+## @env DD_DOGSTATSD_BUFFER_SIZE - integer - optional - default: 8192
 ## The buffer size use to receive statsd packets, in bytes.
 #
 # dogstatsd_buffer_size: 8192
 
 ## @param dogstatsd_non_local_traffic - boolean - optional - default: false
+## @env DD_DOGSTATSD_NON_LOCAL_TRAFFIC - boolean - optional - default: false
 ## Set to true to make DogStatsD listen to non local UDP traffic.
 #
 # dogstatsd_non_local_traffic: false
 
 ## @param dogstatsd_stats_enable - boolean - optional - default: false
+## @env DD_DOGSTATSD_STATS_ENABLE - boolean - optional - default: false
 ## Publish DogStatsD's internal stats as Go expvars.
 #
 # dogstatsd_stats_enable: false
 
 ## @param dogstatsd_queue_size - integer - optional - default: 1024
+## @env DD_DOGSTATSD_QUEUE_SIZE - integer - optional - default: 1024
 ## Configure the internal queue size of the Dogstatsd server.
 ## Reducing the size of this queue will reduce the maximum memory usage of the
 ## Dogstatsd server but as a trade-off, it could increase the number of packet drops.
@@ -1418,16 +1430,19 @@ api_key:
 # dogstatsd_queue_size: 1024
 
 ## @param dogstatsd_stats_buffer - integer - optional - default: 10
+## @env DD_DOGSTATSD_STATS_BUFFER - integer - optional - default: 10
 ## Set how many items should be in the DogStatsD's stats circular buffer.
 #
 # dogstatsd_stats_buffer: 10
 
 ## @param dogstatsd_stats_port - integer - optional - default: 5000
+## @env DD_DOGSTATSD_STATS_PORT - integer - optional - default: 5000
 ## The port for the go_expvar server.
 #
 # dogstatsd_stats_port: 5000
 
 ## @param dogstatsd_so_rcvbuf - integer - optional - default: 0
+## @env DD_DOGSTATSD_SO_RCVBUF - integer - optional - default: 0
 ## The number of bytes allocated to DogStatsD's socket receive buffer (POSIX system only).
 ## By default, the system sets this value. If you need to increase the size of this buffer
 ## but keep the OS default value the same, you can set DogStatsD's receive buffer size here.
@@ -1436,13 +1451,15 @@ api_key:
 # dogstatsd_so_rcvbuf: 0
 
 ## @param dogstatsd_metrics_stats_enable - boolean - optional - default: false
+## @env DD_DOGSTATSD_METRICS_STATS_ENABLE - boolean - optional - default: false
 ## Set this parameter to true to have DogStatsD collects basic statistics (count/last seen)
-## about the metrics it processsed. Use the Agent command "dogstatsd-stats" to visualize
+## about the metrics it processed. Use the Agent command "dogstatsd-stats" to visualize
 ## those statistics.
 #
 # dogstatsd_metrics_stats_enable: false
 
 ## @param dogstatsd_tags - list of key:value elements - optional
+## @env DD_DOGSTATSD_TAGS - list of key:value elements - optional
 ## Additional tags to append to all metrics, events and service checks received by
 ## this DogStatsD server.
 #
@@ -1450,6 +1467,7 @@ api_key:
 #   - <TAG_KEY>:<TAG_VALUE>
 #
 ## @param dogstatsd_mapper_profiles - list of custom object - optional
+## @env DD_DOGSTATSD_MAPPER_PROFILES - list of custom object - optional
 ## The profiles will be used to convert parts of metrics names into tags.
 ## If a profile prefix is matched, other profiles won't be tried even if that profile matching rules doesn't match.
 ## The profiles and matching rules are processed in the order defined in this configuration.
@@ -1488,16 +1506,19 @@ api_key:
 #           task_name: '$2'
 
 ## @param dogstatsd_mapper_cache_size - integer - optional - default: 1000
+## @env DD_DOGSTATSD_MAPPER_CACHE_SIZE - integer - optional - default: 1000
 ## Size of the cache (max number of mapping results) used by Dogstatsd mapping feature.
 #
 # dogstatsd_mapper_cache_size: 1000
 
 ## @param dogstatsd_entity_id_precedence - boolean - optional - default: false
+## @env DD_DOGSTATSD_ENTITY_ID_PRECEDENCE - boolean - optional - default: false
 ## Disable enriching Dogstatsd metrics with tags from "origin detection" when Entity-ID is set.
 #
 # dogstatsd_entity_id_precedence: false
 
 ## @param statsd_forward_host - string - optional - default: ""
+## @env DD_STATSD_FORWARD_HOST - string - optional - default: ""
 ## Forward every packet received by the DogStatsD server to another statsd server.
 ## WARNING: Make sure that forwarded packets are regular statsd packets and not "DogStatsD" packets,
 ## as your other statsd server might not be able to handle them.
@@ -1505,11 +1526,13 @@ api_key:
 # statsd_forward_host: ""
 
 ## @param statsd_forward_port - integer - optional - default: 0
+## @env DD_STATSD_FORWARD_PORT - integer - optional - default: 0
 ## Port or the "statsd_forward_host" to forward StatsD packet to.
 #
 # statsd_forward_port: 0
 
 ## @param statsd_metric_namespace - string - optional - default: ""
+## @env DD_STATSD_METRIC_NAMESPACE - string - optional - default: ""
 ## Set a namespace for all StatsD metrics coming from this host.
 ## Each metric received is prefixed with the namespace before it's sent to Datadog.
 #


### PR DESCRIPTION
### What does this PR do?

- Add @env variables to datadog.yaml:

```
DD_BIND_HOST
DD_DOGSTATSD_ENTITY_ID_PRECEDENCE
DD_DOGSTATSD_MAPPER_CACHE_SIZE
DD_DOGSTATSD_MAPPER_PROFILES
DD_DOGSTATSD_METRICS_STATS_ENABLE
DD_DOGSTATSD_NON_LOCAL_TRAFFIC
DD_DOGSTATSD_ORIGIN_DETECTION
DD_DOGSTATSD_PORT
DD_DOGSTATSD_QUEUE_SIZE
DD_DOGSTATSD_SO_RCVBUF
DD_DOGSTATSD_SOCKET
DD_DOGSTATSD_STATS_BUFFER
DD_DOGSTATSD_STATS_ENABLE
DD_DOGSTATSD_STATS_PORT
DD_DOGSTATSD_TAGS
DD_STATSD_FORWARD_HOST
DD_STATSD_FORWARD_PORT
DD_STATSD_METRIC_NAMESPACE
DD_SYSTEM_PROBE_CONFIG_LOG_FILE
DD_SYSTEM_PROBE_CONFIG_SYSPROBE_SOCKET
DD_USE_DOGSTATSD
```
- Update a few docs links

### Motivation

- Documentation OKR
- [RFC](https://github.com/DataDog/architecture/blob/master/rfcs/agent-env-var-docs/rfc.md)

### Additional Notes

Variables will be added in small batches.

### Describe how to test your changes

N/A

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
