### PR TITLE
Factor out profiling settings

### DIFF
--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -443,5 +443,16 @@ func enableProfiling(cfg *config.AgentConfig) error {
 
 	v, _ := version.Agent()
 
-	return profiling.Start(site, cfg.ProfilingEnvironment, "process-agent", cfg.ProfilingPeriod, cfg.ProfilingCPUDuration, cfg.ProfilingMutexFraction, cfg.ProfilingBlockRate, cfg.ProfilingWithGoroutines, fmt.Sprintf("version:%v", v))
+	settings := profiling.Settings{
+		Site:                 site,
+		Env:                  cfg.ProfilingEnvironment,
+		Service:              "process-agent",
+		Period:               cfg.ProfilingPeriod,
+		CPUDuration:          cfg.ProfilingCPUDuration,
+		MutexProfileFraction: cfg.ProfilingMutexFraction,
+		BlockProfileRate:     cfg.ProfilingBlockRate,
+		WithGoroutineProfile: cfg.ProfilingWithGoroutines,
+		Tags:                 []string{fmt.Sprintf("version:%v", v)},
+	}
+	return profiling.Start(settings)
 }

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -35,7 +35,6 @@ import (
 	ddutil "github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/profiling"
-	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 
 	// register all workloadmeta collectors
@@ -258,8 +257,8 @@ func runAgent(exit chan struct{}) {
 	// we just pass down empty string
 	updateDockerSocket(dockerSock)
 
-	if cfg.ProfilingEnabled {
-		if err := enableProfiling(cfg); err != nil {
+	if cfg.ProfilingSettings != nil {
+		if err := profiling.Start(*cfg.ProfilingSettings); err != nil {
 			log.Warnf("failed to enable profiling: %s", err)
 		} else {
 			log.Info("start profiling process-agent")
@@ -427,32 +426,4 @@ func cleanupAndExit(status int) {
 	}
 
 	os.Exit(status)
-}
-
-func enableProfiling(cfg *config.AgentConfig) error {
-	// allow full url override for development use
-	s := ddconfig.DefaultSite
-	if cfg.ProfilingSite != "" {
-		s = cfg.ProfilingSite
-	}
-
-	site := fmt.Sprintf(profiling.ProfileURLTemplate, s)
-	if cfg.ProfilingURL != "" {
-		site = cfg.ProfilingURL
-	}
-
-	v, _ := version.Agent()
-
-	settings := profiling.Settings{
-		Site:                 site,
-		Env:                  cfg.ProfilingEnvironment,
-		Service:              "process-agent",
-		Period:               cfg.ProfilingPeriod,
-		CPUDuration:          cfg.ProfilingCPUDuration,
-		MutexProfileFraction: cfg.ProfilingMutexFraction,
-		BlockProfileRate:     cfg.ProfilingBlockRate,
-		WithGoroutineProfile: cfg.ProfilingWithGoroutines,
-		Tags:                 []string{fmt.Sprintf("version:%v", v)},
-	}
-	return profiling.Start(settings)
 }

--- a/cmd/system-probe/app/run.go
+++ b/cmd/system-probe/app/run.go
@@ -27,7 +27,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/profiling"
-	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 // ErrNotEnabled represents the case in which system-probe is not enabled
@@ -164,8 +163,8 @@ func StartSystemProbe() error {
 		return ErrNotEnabled
 	}
 
-	if cfg.ProfilingEnabled {
-		if err := enableProfiling(cfg); err != nil {
+	if cfg.ProfilingSettings != nil {
+		if err := profiling.Start(*cfg.ProfilingSettings); err != nil {
 			log.Warnf("failed to enable profiling: %s", err)
 		}
 	}
@@ -196,32 +195,4 @@ func StopSystemProbe() {
 	profiling.Stop()
 	_ = os.Remove(pidfilePath)
 	log.Flush()
-}
-
-func enableProfiling(cfg *config.Config) error {
-	var site string
-	v, _ := version.Agent()
-
-	// check if TRACE_AGENT_URL is set, in which case, forward the profiles to the trace agent
-	if traceAgentURL := os.Getenv("TRACE_AGENT_URL"); len(traceAgentURL) > 0 {
-		site = fmt.Sprintf(profiling.ProfilingLocalURLTemplate, traceAgentURL)
-	} else {
-		site = fmt.Sprintf(profiling.ProfileURLTemplate, cfg.ProfilingSite)
-		if cfg.ProfilingURL != "" {
-			site = cfg.ProfilingURL
-		}
-	}
-
-	settings := profiling.Settings{
-		Site:                 site,
-		Env:                  cfg.ProfilingEnvironment,
-		Service:              "system-probe",
-		Period:               cfg.ProfilingPeriod,
-		CPUDuration:          cfg.ProfilingCPUDuration,
-		MutexProfileFraction: cfg.ProfilingMutexFraction,
-		BlockProfileRate:     cfg.ProfilingBlockRate,
-		WithGoroutineProfile: cfg.ProfilingWithGoroutines,
-		Tags:                 []string{fmt.Sprintf("version:%v", v)},
-	}
-	return profiling.Start(settings)
 }

--- a/cmd/system-probe/app/run.go
+++ b/cmd/system-probe/app/run.go
@@ -212,15 +212,16 @@ func enableProfiling(cfg *config.Config) error {
 		}
 	}
 
-	return profiling.Start(
-		site,
-		cfg.ProfilingEnvironment,
-		"system-probe",
-		cfg.ProfilingPeriod,
-		cfg.ProfilingCPUDuration,
-		cfg.ProfilingMutexFraction,
-		cfg.ProfilingBlockRate,
-		cfg.ProfilingWithGoroutines,
-		fmt.Sprintf("version:%v", v),
-	)
+	settings := profiling.Settings{
+		Site:                 site,
+		Env:                  cfg.ProfilingEnvironment,
+		Service:              "system-probe",
+		Period:               cfg.ProfilingPeriod,
+		CPUDuration:          cfg.ProfilingCPUDuration,
+		MutexProfileFraction: cfg.ProfilingMutexFraction,
+		BlockProfileRate:     cfg.ProfilingBlockRate,
+		WithGoroutineProfile: cfg.ProfilingWithGoroutines,
+		Tags:                 []string{fmt.Sprintf("version:%v", v)},
+	}
+	return profiling.Start(settings)
 }

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -7,10 +7,11 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
-	"time"
 
 	aconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/profiling"
+	"github.com/DataDog/datadog-agent/pkg/version"
 	"github.com/DataDog/viper"
 )
 
@@ -59,15 +60,8 @@ type Config struct {
 	StatsdHost string
 	StatsdPort int
 
-	ProfilingEnabled        bool
-	ProfilingSite           string
-	ProfilingURL            string
-	ProfilingEnvironment    string
-	ProfilingPeriod         time.Duration
-	ProfilingCPUDuration    time.Duration
-	ProfilingMutexFraction  int
-	ProfilingBlockRate      int
-	ProfilingWithGoroutines bool
+	// Settings for profiling, or nil if not enabled
+	ProfilingSettings *profiling.Settings
 }
 
 // New creates a config object for system-probe. It assumes no configuration has been loaded as this point.
@@ -129,6 +123,35 @@ func load(configPath string) (*Config, error) {
 		return nil, err
 	}
 
+	var profSettings *profiling.Settings
+	if cfg.GetBool(key(spNS, "internal_profiling.enabled")) {
+		v, _ := version.Agent()
+
+		var site string
+		cfgSite := cfg.GetString(key(spNS, "internal_profiling.site"))
+		cfgURL := cfg.GetString(key(spNS, "internal_profiling.profile_dd_url"))
+		// check if TRACE_AGENT_URL is set, in which case, forward the profiles to the trace agent
+		if traceAgentURL := os.Getenv("TRACE_AGENT_URL"); len(traceAgentURL) > 0 {
+			site = fmt.Sprintf(profiling.ProfilingLocalURLTemplate, traceAgentURL)
+		} else {
+			site = fmt.Sprintf(profiling.ProfileURLTemplate, cfgSite)
+			if cfgURL != "" {
+				site = cfgURL
+			}
+		}
+
+		profSettings = &profiling.Settings{
+			Site:                 site,
+			Env:                  cfg.GetString(key(spNS, "internal_profiling.env")),
+			Service:              "system-probe",
+			Period:               cfg.GetDuration(key(spNS, "internal_profiling.period")),
+			CPUDuration:          cfg.GetDuration(key(spNS, "internal_profiling.cpu_duration")),
+			MutexProfileFraction: cfg.GetInt(key(spNS, "internal_profiling.mutex_profile_fraction")),
+			BlockProfileRate:     cfg.GetInt(key(spNS, "internal_profiling.block_profile_rate")),
+			WithGoroutineProfile: cfg.GetBool(key(spNS, "internal_profiling.enable_goroutine_stacktraces")),
+			Tags:                 []string{fmt.Sprintf("version:%v", v)},
+		}
+	}
 	c := &Config{
 		Enabled:             cfg.GetBool(key(spNS, "enabled")),
 		EnabledModules:      make(map[ModuleName]struct{}),
@@ -144,15 +167,7 @@ func load(configPath string) (*Config, error) {
 		StatsdHost: aconfig.GetBindHost(),
 		StatsdPort: cfg.GetInt("dogstatsd_port"),
 
-		ProfilingEnabled:        cfg.GetBool(key(spNS, "internal_profiling.enabled")),
-		ProfilingSite:           cfg.GetString(key(spNS, "internal_profiling.site")),
-		ProfilingURL:            cfg.GetString(key(spNS, "internal_profiling.profile_dd_url")),
-		ProfilingEnvironment:    cfg.GetString(key(spNS, "internal_profiling.env")),
-		ProfilingPeriod:         cfg.GetDuration(key(spNS, "internal_profiling.period")),
-		ProfilingCPUDuration:    cfg.GetDuration(key(spNS, "internal_profiling.cpu_duration")),
-		ProfilingMutexFraction:  cfg.GetInt(key(spNS, "internal_profiling.mutex_profile_fraction")),
-		ProfilingBlockRate:      cfg.GetInt(key(spNS, "internal_profiling.block_profile_rate")),
-		ProfilingWithGoroutines: cfg.GetBool(key(spNS, "internal_profiling.enable_goroutine_stacktraces")),
+		ProfilingSettings: profSettings,
 	}
 
 	if err := ValidateSocketAddress(c.SocketAddress); err != nil {

--- a/pkg/config/settings/runtime_setting_profiling.go
+++ b/pkg/config/settings/runtime_setting_profiling.go
@@ -70,17 +70,18 @@ func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 		}
 
 		v, _ := version.Agent()
-		err := profiling.Start(
-			site,
-			config.Datadog.GetString("env"),
-			profiling.ProfileCoreService,
-			profiling.DefaultProfilingPeriod,
-			15*time.Second,
-			profiling.GetMutexProfileFraction(),
-			profiling.GetBlockProfileRate(),
-			config.Datadog.GetBool("internal_profiling.enable_goroutine_stacktraces"),
-			fmt.Sprintf("version:%v", v),
-		)
+		settings := profiling.Settings{
+			Site:                 site,
+			Env:                  config.Datadog.GetString("env"),
+			Service:              profiling.ProfileCoreService,
+			Period:               profiling.DefaultProfilingPeriod,
+			CPUDuration:          15 * time.Second,
+			MutexProfileFraction: profiling.GetMutexProfileFraction(),
+			BlockProfileRate:     profiling.GetBlockProfileRate(),
+			WithGoroutineProfile: config.Datadog.GetBool("internal_profiling.enable_goroutine_stacktraces"),
+			Tags:                 []string{fmt.Sprintf("version:%v", v)},
+		}
+		err := profiling.Start(settings)
 		if err == nil {
 			config.Datadog.Set("internal_profiling.enabled", true)
 		}

--- a/pkg/config/settings/runtime_setting_profiling.go
+++ b/pkg/config/settings/runtime_setting_profiling.go
@@ -68,6 +68,8 @@ func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 			site = config.Datadog.GetString("internal_profiling.profile_dd_url")
 		}
 
+		// Note that we must derive a new profiling.Settings on every
+		// invocation, as many of these settings may have changed at runtime.
 		v, _ := version.Agent()
 		settings := profiling.Settings{
 			Site:                 site,

--- a/pkg/config/settings/runtime_setting_profiling.go
+++ b/pkg/config/settings/runtime_setting_profiling.go
@@ -8,7 +8,6 @@ package settings
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/profiling"
@@ -73,9 +72,8 @@ func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 		settings := profiling.Settings{
 			Site:                 site,
 			Env:                  config.Datadog.GetString("env"),
-			Service:              profiling.ProfileCoreService,
+			Service:              "datadog-agent",
 			Period:               profiling.DefaultProfilingPeriod,
-			CPUDuration:          15 * time.Second,
 			MutexProfileFraction: profiling.GetMutexProfileFraction(),
 			BlockProfileRate:     profiling.GetBlockProfileRate(),
 			WithGoroutineProfile: config.Datadog.GetBool("internal_profiling.enable_goroutine_stacktraces"),

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -27,6 +27,7 @@ import (
 	ddgrpc "github.com/DataDog/datadog-agent/pkg/util/grpc"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname/validate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/profiling"
 	"google.golang.org/grpc"
 )
 
@@ -111,15 +112,10 @@ type AgentConfig struct {
 	StatsdHost                string
 	StatsdPort                int
 	ProcessExpVarPort         int
-	ProfilingEnabled          bool
-	ProfilingSite             string
-	ProfilingURL              string
-	ProfilingEnvironment      string
-	ProfilingPeriod           time.Duration
-	ProfilingCPUDuration      time.Duration
-	ProfilingMutexFraction    int
-	ProfilingBlockRate        int
-	ProfilingWithGoroutines   bool
+
+	// profiling settings, or nil if profiling is not enabled
+	ProfilingSettings *profiling.Settings
+
 	// host type of the agent, used to populate container payload with additional host information
 	ContainerHostType model.ContainerHostType
 

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -243,16 +243,13 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 	// but use the configuration from main agent to fill the settings
 	if config.Datadog.IsSet(key(ns, "internal_profiling.enabled")) {
 		// allow full url override for development use
-		s := config.DefaultSite
-		cfgSite := config.Datadog.GetString("site")
-		cfgURL := config.Datadog.GetString("internal_profiling.profile_dd_url")
-		if cfgSite != "" {
-			s = cfgSite
-		}
-
-		site := fmt.Sprintf(profiling.ProfileURLTemplate, s)
-		if cfgURL != "" {
-			site = cfgURL
+		site := config.Datadog.GetString("internal_profiling.profile_dd_url")
+		if site == "" {
+			s := config.Datadog.GetString("site")
+			if s == "" {
+				s = config.DefaultSite
+			}
+			site = fmt.Sprintf(profiling.ProfileURLTemplate, s)
 		}
 
 		v, _ := version.Agent()

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -16,6 +16,8 @@ import (
 	apicfg "github.com/DataDog/datadog-agent/pkg/process/util/api/config"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/profiling"
+	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
 const (
@@ -240,15 +242,31 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 	// use `internal_profiling.enabled` field in `process_config` section to enable/disable profiling for process-agent,
 	// but use the configuration from main agent to fill the settings
 	if config.Datadog.IsSet(key(ns, "internal_profiling.enabled")) {
-		a.ProfilingEnabled = config.Datadog.GetBool(key(ns, "internal_profiling.enabled"))
-		a.ProfilingSite = config.Datadog.GetString("site")
-		a.ProfilingURL = config.Datadog.GetString("internal_profiling.profile_dd_url")
-		a.ProfilingEnvironment = config.Datadog.GetString("env")
-		a.ProfilingPeriod = config.Datadog.GetDuration("internal_profiling.period")
-		a.ProfilingCPUDuration = config.Datadog.GetDuration("internal_profiling.cpu_duration")
-		a.ProfilingMutexFraction = config.Datadog.GetInt("internal_profiling.mutex_profile_fraction")
-		a.ProfilingBlockRate = config.Datadog.GetInt("internal_profiling.block_profile_rate")
-		a.ProfilingWithGoroutines = config.Datadog.GetBool("internal_profiling.enable_goroutine_stacktraces")
+		// allow full url override for development use
+		s := config.DefaultSite
+		cfgSite := config.Datadog.GetString("site")
+		cfgURL := config.Datadog.GetString("internal_profiling.profile_dd_url")
+		if cfgSite != "" {
+			s = cfgSite
+		}
+
+		site := fmt.Sprintf(profiling.ProfileURLTemplate, s)
+		if cfgURL != "" {
+			site = cfgURL
+		}
+
+		v, _ := version.Agent()
+		a.ProfilingSettings = &profiling.Settings{
+			Site:                 site,
+			Env:                  config.Datadog.GetString("env"),
+			Service:              "process-agent",
+			Period:               config.Datadog.GetDuration("internal_profiling.period"),
+			CPUDuration:          config.Datadog.GetDuration("internal_profiling.cpu_duration"),
+			MutexProfileFraction: config.Datadog.GetInt("internal_profiling.mutex_profile_fraction"),
+			BlockProfileRate:     config.Datadog.GetInt("internal_profiling.block_profile_rate"),
+			WithGoroutineProfile: config.Datadog.GetBool("internal_profiling.enable_goroutine_stacktraces"),
+			Tags:                 []string{fmt.Sprintf("version:%v", v)},
+		}
 	}
 
 	// Used to override container source auto-detection

--- a/pkg/trace/agent/run.go
+++ b/pkg/trace/agent/run.go
@@ -32,7 +32,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/profiling"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
-	"gopkg.in/DataDog/dd-trace-go.v1/profiler"
 
 	// register all workloadmeta collectors
 	_ "github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors"
@@ -204,7 +203,6 @@ func runProfiling(cfg *config.AgentConfig) {
 	settings := profiling.Settings{
 		Site:                 fmt.Sprintf("https://intake.profile.%s/v1/input", site),
 		Period:               profiling.DefaultProfilingPeriod,
-		CPUDuration:          profiler.DefaultDuration,
 		Tags:                 []string{fmt.Sprintf("version:%s", info.Version)},
 		MutexProfileFraction: coreconfig.Datadog.GetInt("internal_profiling.mutex_profile_fraction"),
 		BlockProfileRate:     coreconfig.Datadog.GetInt("internal_profiling.block_profile_rate"),

--- a/pkg/trace/agent/run.go
+++ b/pkg/trace/agent/run.go
@@ -195,25 +195,42 @@ func runProfiling(cfg *config.AgentConfig) {
 		// fail safe
 		return
 	}
+
 	site := "datadoghq.com"
 	if v := coreconfig.Datadog.GetString("site"); v != "" {
 		site = v
 	}
-	addr := fmt.Sprintf("https://intake.profile.%s/v1/input", site)
+
+	settings := profiling.Settings{
+		Site:                 fmt.Sprintf("https://intake.profile.%s/v1/input", site),
+		Period:               profiling.DefaultProfilingPeriod,
+		CPUDuration:          profiler.DefaultDuration,
+		Tags:                 []string{fmt.Sprintf("version:%s", info.Version)},
+		MutexProfileFraction: coreconfig.Datadog.GetInt("internal_profiling.mutex_profile_fraction"),
+		BlockProfileRate:     coreconfig.Datadog.GetInt("internal_profiling.block_profile_rate"),
+		WithGoroutineProfile: coreconfig.Datadog.GetBool("internal_profiling.enable_goroutine_stacktraces"),
+	}
+
 	if v := coreconfig.Datadog.GetString("internal_profiling.profile_dd_url"); v != "" {
-		addr = v
+		settings.Site = v
 	}
-	period := profiling.DefaultProfilingPeriod
+
 	if v := coreconfig.Datadog.GetDuration("internal_profiling.period"); v != 0 {
-		period = v
+		settings.Period = v
 	}
-	cpudur := profiler.DefaultDuration
 	if v := coreconfig.Datadog.GetDuration("internal_profiling.cpu_duration"); v != 0 {
-		cpudur = v
+		settings.CPUDuration = v
 	}
-	mutexFraction := coreconfig.Datadog.GetInt("internal_profiling.mutex_profile_fraction")
-	blockRate := coreconfig.Datadog.GetInt("internal_profiling.block_profile_rate")
-	routines := coreconfig.Datadog.GetBool("internal_profiling.enable_goroutine_stacktraces")
-	profiling.Start(addr, cfg.DefaultEnv, "trace-agent", period, cpudur, mutexFraction, blockRate, routines, fmt.Sprintf("version:%s", info.Version))
-	log.Infof("Internal profiling enabled: [Target:%q][Env:%q][Period:%s][CPU:%s][Mutex:%d][Block:%d][Routines:%v].", addr, cfg.DefaultEnv, period, cpudur, mutexFraction, blockRate, routines)
+
+	profiling.Start(settings)
+
+	log.Infof("Internal profiling enabled: [Target:%q][Env:%q][Period:%s][CPU:%s][Mutex:%d][Block:%d][Routines:%v].",
+		settings.Site,
+		settings.Env,
+		settings.Period,
+		settings.CPUDuration,
+		settings.MutexProfileFraction,
+		settings.BlockProfileRate,
+		settings.WithGoroutineProfile,
+	)
 }

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -27,6 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/grpc"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/profiling"
 )
 
 // ErrMissingAPIKey is returned when the config could not be validated due to missing API key.
@@ -131,6 +132,9 @@ type AgentConfig struct {
 
 	// OTLPReceiver holds the configuration for OpenTelemetry receiver.
 	OTLPReceiver *OTLP
+
+	// Profiling settings, or nil if profiling is disabled
+	ProfilingSettings *profiling.Settings
 }
 
 // Tag represents a key/value pair.

--- a/pkg/util/profiling/profiling.go
+++ b/pkg/util/profiling/profiling.go
@@ -22,8 +22,6 @@ var (
 const (
 	// ProfileURLTemplate constant template for expected profiling endpoint URL.
 	ProfileURLTemplate = "https://intake.profile.%s/v1/input"
-	// ProfileCoreService default service for the core agent profiler.
-	ProfileCoreService = "datadog-agent"
 	// ProfilingLocalURLTemplate is the constant used to compute the URL of the local trace agent
 	ProfilingLocalURLTemplate = "http://%v/profiling/v1/input"
 	// DefaultProfilingPeriod defines the default profiling period
@@ -38,6 +36,8 @@ func Start(settings Settings) error {
 	if running {
 		return nil
 	}
+
+	settings.applyDefaults()
 
 	types := []profiler.ProfileType{profiler.CPUProfile, profiler.HeapProfile}
 	if settings.WithGoroutineProfile {

--- a/pkg/util/profiling/profiling_test.go
+++ b/pkg/util/profiling/profiling_test.go
@@ -16,7 +16,7 @@ func TestProfiling(t *testing.T) {
 	settings := Settings{
 		Site:                 "https://nowhere.testing.dev",
 		Env:                  "testing",
-		Service:              ProfileCoreService,
+		Service:              "test-agent",
 		Period:               time.Minute,
 		CPUDuration:          15 * time.Second,
 		MutexProfileFraction: 0,

--- a/pkg/util/profiling/profiling_test.go
+++ b/pkg/util/profiling/profiling_test.go
@@ -13,17 +13,18 @@ import (
 )
 
 func TestProfiling(t *testing.T) {
-	err := Start(
-		"https://nowhere.testing.dev",
-		"testing",
-		ProfileCoreService,
-		time.Minute,
-		15*time.Second,
-		0,
-		0,
-		false,
-		"1.0.0",
-	)
+	settings := Settings{
+		Site:                 "https://nowhere.testing.dev",
+		Env:                  "testing",
+		Service:              ProfileCoreService,
+		Period:               time.Minute,
+		CPUDuration:          15 * time.Second,
+		MutexProfileFraction: 0,
+		BlockProfileRate:     0,
+		WithGoroutineProfile: false,
+		Tags:                 []string{"1.0.0"},
+	}
+	err := Start(settings)
 	assert.Nil(t, err)
 
 	Stop()

--- a/pkg/util/profiling/settings.go
+++ b/pkg/util/profiling/settings.go
@@ -1,0 +1,27 @@
+package profiling
+
+import "time"
+
+// Settings contains the settings for internal profiling, to be passed to Start().
+type Settings struct {
+	// Site specifies the datadog site (datadoghq.com, datadoghq.eu, etc.) which profiles will be sent to.
+	Site string
+	// Env specifies the environment to which profiles should be registered.
+	Env string
+	// Service specifies the service name to attach to a profile.
+	Service string
+	// Period specifies the interval at which to collect profiles.
+	Period time.Duration
+	// CPUDuration specifies the length at which to collect CPU profiles.
+	CPUDuration time.Duration
+	// MutexProfileFraction, if set, turns on mutex profiles with rate
+	// indicating the fraction of mutex contention events reported in the mutex
+	// profile.
+	MutexProfileFraction int
+	// BlockProfileRate turns on block profiles with the given rate.
+	BlockProfileRate int
+	// WithGoroutineProfile additionally reports stack traces of all current goroutines
+	WithGoroutineProfile bool
+	// Tags are the additional tags to attach to profiles.
+	Tags []string
+}

--- a/pkg/util/profiling/settings.go
+++ b/pkg/util/profiling/settings.go
@@ -1,6 +1,10 @@
 package profiling
 
-import "time"
+import (
+	"time"
+
+	"gopkg.in/DataDog/dd-trace-go.v1/profiler"
+)
 
 // Settings contains the settings for internal profiling, to be passed to Start().
 type Settings struct {
@@ -24,4 +28,11 @@ type Settings struct {
 	WithGoroutineProfile bool
 	// Tags are the additional tags to attach to profiles.
 	Tags []string
+}
+
+// Apply default value for a struct created using struct-literal notation
+func (settings *Settings) applyDefaults() {
+	if settings.CPUDuration == 0 {
+		settings.CPUDuration = profiler.DefaultDuration
+	}
 }

--- a/pkg/util/profiling/settings.go
+++ b/pkg/util/profiling/settings.go
@@ -1,6 +1,7 @@
 package profiling
 
 import (
+	"fmt"
 	"time"
 
 	"gopkg.in/DataDog/dd-trace-go.v1/profiler"
@@ -30,9 +31,25 @@ type Settings struct {
 	Tags []string
 }
 
+func (settings *Settings) String() string {
+	return fmt.Sprintf("[Target:%q][Env:%q][Period:%s][CPU:%s][Mutex:%d][Block:%d][Routines:%v]",
+		settings.Site,
+		settings.Env,
+		settings.Period,
+		settings.CPUDuration,
+		settings.MutexProfileFraction,
+		settings.BlockProfileRate,
+		settings.WithGoroutineProfile,
+	)
+}
+
 // Apply default value for a struct created using struct-literal notation
 func (settings *Settings) applyDefaults() {
 	if settings.CPUDuration == 0 {
 		settings.CPUDuration = profiler.DefaultDuration
+	}
+
+	if settings.Tags == nil {
+		settings.Tags = []string{}
 	}
 }


### PR DESCRIPTION
This factors profiling settings into a settings struct, and then stores settings in that struct instead of a half-dozen fields of other AgentConfig structs.

### Additional Notes

Because the core agent uses runtime settings for profiling, instead of using an AgentConfig, we can't store the settings in one place, so the refactor is minimal in that agent (but still cleaner!)

### Describe how to test your changes

Enable profiling for each agent, and verify that profiles appear in the app.

For datadog-agent, also enable and disable profiles at runtime.

### Checklist
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
