### PR TITLE
[system-probe] Collect telemetry from all runtime-compiled assets

### DIFF
--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -11,7 +11,6 @@ import (
 
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode"
-	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
@@ -70,7 +69,6 @@ func New(config *config.Config, constants []manager.ConstantEditor) (connection.
 	var buf bytecode.AssetReader
 	var err error
 	if config.EnableRuntimeCompiler {
-		runtime.RuntimeCompilationEnabled = true
 		buf, err = getRuntimeCompiledTracer(config)
 		if err != nil {
 			if !config.AllowPrecompiledFallback {

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -356,8 +356,11 @@ func (t *Tracer) getConnTelemetry(mapSize int) *network.ConnectionsTelemetry {
 
 func (t *Tracer) getRuntimeCompilationTelemetry() map[string]network.RuntimeCompilationTelemetry {
 	telemetryByAsset := map[string]map[string]int64{
-		"tracer":    runtime.Tracer.GetTelemetry(),
-		"conntrack": runtime.Conntrack.GetTelemetry(),
+		"tracer":          runtime.Tracer.GetTelemetry(),
+		"conntrack":       runtime.Conntrack.GetTelemetry(),
+		"oomKill":         runtime.OomKill.GetTelemetry(),
+		"runtimeSecurity": runtime.RuntimeSecurity.GetTelemetry(),
+		"tcpQueueLength":  runtime.TcpQueueLength.GetTelemetry(),
 	}
 
 	result := make(map[string]network.RuntimeCompilationTelemetry)


### PR DESCRIPTION
### What does this PR do?

Adds `OomKill`, `RuntimeSecurity` and `TcpQueueLength` to the list of assets which we query when gathering runtime compilation telemetry.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

No changes are required in the backend / in the agent payload for this telemetry to be emitted.

### Describe how to test your changes

1. Run the system-probe
2. In a separate window, query the `connections` endpoint & verify that you see runtime compilation telemetry for all 5 assets:
```
$ curl -s --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/connections?client_id=1 | jq .compilationTelemetryByAsset

{
  "conntrack": {...},
  "oomKill": {...},
  "runtimeSecurity": {...},
  "tcpQueueLength": {...},
  "tracer": {...},
}
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
