### PR TITLE
[corechecks/snmp] Add config to use DeviceID as hostname for metrics and service checks

### DIFF
--- a/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
+++ b/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
@@ -119,3 +119,9 @@ instances:
     ## Changing namespace will cause devices being recreated in NDM app.
     #
     namespace: "%%extra_namespace%%"
+
+    ## @param use_device_id_as_hostname - boolean - optional - default: false
+    ## Use an hash of a device ip address and the namespace as `hostname` for metrics and
+    ## service checks. This enables custom tags. It overrides any `hostname` tag.
+    #
+    use_device_id_as_hostname: "%%extra_use_device_id_as_hostname%%"

--- a/pkg/collector/corechecks/snmp/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config.go
@@ -57,6 +57,7 @@ type InitConfig struct {
 	OidBatchSize          Number           `yaml:"oid_batch_size"`
 	BulkMaxRepetitions    Number           `yaml:"bulk_max_repetitions"`
 	CollectDeviceMetadata Boolean          `yaml:"collect_device_metadata"`
+	UseDeviceIDAsHostname Boolean          `yaml:"use_device_id_as_hostname"`
 	MinCollectionInterval int              `yaml:"min_collection_interval"`
 	Namespace             string           `yaml:"namespace"`
 }
@@ -80,6 +81,7 @@ type InstanceConfig struct {
 	Profile               string            `yaml:"profile"`
 	UseGlobalMetrics      bool              `yaml:"use_global_metrics"`
 	CollectDeviceMetadata *Boolean          `yaml:"collect_device_metadata"`
+	UseDeviceIDAsHostname *Boolean          `yaml:"use_device_id_as_hostname"`
 
 	// ExtraTags is a workaround to pass tags from snmp listener to snmp integration via AD template
 	// (see cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml) that only works with strings.
@@ -137,6 +139,7 @@ type CheckConfig struct {
 	ExtraTags             []string
 	InstanceTags          []string
 	CollectDeviceMetadata bool
+	UseDeviceIDAsHostname bool
 	DeviceID              string
 	DeviceIDTags          []string
 	ResolvedSubnetName    string
@@ -278,6 +281,12 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 		c.CollectDeviceMetadata = bool(*instance.CollectDeviceMetadata)
 	} else {
 		c.CollectDeviceMetadata = bool(initConfig.CollectDeviceMetadata)
+	}
+
+	if instance.UseDeviceIDAsHostname != nil {
+		c.UseDeviceIDAsHostname = bool(*instance.UseDeviceIDAsHostname)
+	} else {
+		c.UseDeviceIDAsHostname = bool(initConfig.UseDeviceIDAsHostname)
 	}
 
 	if instance.ExtraTags != "" {
@@ -542,6 +551,7 @@ func (c *CheckConfig) Copy() *CheckConfig {
 	newConfig.ExtraTags = common.CopyStrings(c.ExtraTags)
 	newConfig.InstanceTags = common.CopyStrings(c.InstanceTags)
 	newConfig.CollectDeviceMetadata = c.CollectDeviceMetadata
+	newConfig.UseDeviceIDAsHostname = c.UseDeviceIDAsHostname
 	newConfig.DeviceID = c.DeviceID
 
 	newConfig.DeviceIDTags = common.CopyStrings(c.DeviceIDTags)

--- a/pkg/collector/corechecks/snmp/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config_test.go
@@ -1090,6 +1090,64 @@ community_string: "abc"
 	assert.EqualError(t, err, "namespace cannot be empty")
 }
 
+func Test_buildConfig_UseDeviceIDAsHostname(t *testing.T) {
+	// language=yaml
+	rawInstanceConfig := []byte(`
+ip_address: 1.2.3.4
+community_string: "abc"
+`)
+	// language=yaml
+	rawInitConfig := []byte(`
+oid_batch_size: 10
+`)
+	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	assert.Nil(t, err)
+	assert.Equal(t, false, config.UseDeviceIDAsHostname)
+
+	// language=yaml
+	rawInstanceConfig = []byte(`
+ip_address: 1.2.3.4
+community_string: "abc"
+`)
+	// language=yaml
+	rawInitConfig = []byte(`
+oid_batch_size: 10
+use_device_id_as_hostname: true
+`)
+	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	assert.Nil(t, err)
+	assert.Equal(t, true, config.UseDeviceIDAsHostname)
+
+	// language=yaml
+	rawInstanceConfig = []byte(`
+ip_address: 1.2.3.4
+community_string: "abc"
+use_device_id_as_hostname: true
+`)
+	// language=yaml
+	rawInitConfig = []byte(`
+oid_batch_size: 10
+`)
+	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	assert.Nil(t, err)
+	assert.Equal(t, true, config.UseDeviceIDAsHostname)
+
+	// language=yaml
+	rawInstanceConfig = []byte(`
+ip_address: 1.2.3.4
+community_string: "abc"
+use_device_id_as_hostname: false
+`)
+	// language=yaml
+	rawInitConfig = []byte(`
+oid_batch_size: 10
+use_device_id_as_hostname: true
+`)
+	config, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	assert.Nil(t, err)
+	assert.Equal(t, false, config.UseDeviceIDAsHostname)
+}
+
 func Test_buildConfig_minCollectionInterval(t *testing.T) {
 	tests := []struct {
 		name              string
@@ -1461,6 +1519,7 @@ func TestCheckConfig_Copy(t *testing.T) {
 		ExtraTags:             []string{"ExtraTags:tag"},
 		InstanceTags:          []string{"InstanceTags:tag"},
 		CollectDeviceMetadata: true,
+		UseDeviceIDAsHostname: true,
 		DeviceID:              "123",
 		DeviceIDTags:          []string{"DeviceIDTags:tag"},
 		ResolvedSubnetName:    "1.2.3.4/28",
@@ -1498,6 +1557,7 @@ func TestCheckConfig_Copy(t *testing.T) {
 	assertNotSameButEqualElements(t, config.ExtraTags, configCopy.ExtraTags)
 	assertNotSameButEqualElements(t, config.InstanceTags, configCopy.InstanceTags)
 	assert.Equal(t, config.CollectDeviceMetadata, configCopy.CollectDeviceMetadata)
+	assert.Equal(t, config.UseDeviceIDAsHostname, configCopy.UseDeviceIDAsHostname)
 	assert.Equal(t, config.DeviceID, configCopy.DeviceID)
 	assertNotSameButEqualElements(t, config.DeviceIDTags, configCopy.DeviceIDTags)
 	assert.Equal(t, config.ResolvedSubnetName, configCopy.ResolvedSubnetName)

--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
@@ -22,9 +22,9 @@ import (
 )
 
 const (
-	snmpLoaderTag    = "loader:core"
-	serviceCheckName = "snmp.can_check"
-
+	snmpLoaderTag        = "loader:core"
+	serviceCheckName     = "snmp.can_check"
+	deviceHostnamePrefix = "device:"
 	// 1.3 (iso.org) is the OID used for getNext call to check if the device is reachable
 	deviceReachableGetNextOid = "1.3"
 )
@@ -66,6 +66,14 @@ func (d *DeviceCheck) GetIDTags() []string {
 	return d.config.DeviceIDTags
 }
 
+// GetHostname returns DeviceID as hostname if UseDeviceIDAsHostname is true
+func (d *DeviceCheck) GetHostname() string {
+	if d.config.UseDeviceIDAsHostname {
+		return deviceHostnamePrefix + d.config.DeviceID
+	}
+	return ""
+}
+
 // Run executes the check
 func (d *DeviceCheck) Run(collectionTime time.Time) error {
 	startTime := time.Now()
@@ -76,9 +84,9 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 	var deviceStatus metadata.DeviceStatus
 	deviceReachable, tags, values, checkErr := d.getValuesAndTags(staticTags)
 	if checkErr != nil {
-		d.sender.ServiceCheck(serviceCheckName, metrics.ServiceCheckCritical, "", tags, checkErr.Error())
+		d.sender.ServiceCheck(serviceCheckName, metrics.ServiceCheckCritical, tags, checkErr.Error())
 	} else {
-		d.sender.ServiceCheck(serviceCheckName, metrics.ServiceCheckOK, "", tags, "")
+		d.sender.ServiceCheck(serviceCheckName, metrics.ServiceCheckOK, tags, "")
 	}
 	if values != nil {
 		d.sender.ReportMetrics(d.config.Metrics, values, tags)
@@ -181,10 +189,10 @@ func (d *DeviceCheck) doAutodetectProfile(sess session.Session) error {
 func (d *DeviceCheck) submitTelemetryMetrics(startTime time.Time, tags []string) {
 	newTags := append(common.CopyStrings(tags), snmpLoaderTag)
 
-	d.sender.Gauge("snmp.devices_monitored", float64(1), "", newTags)
+	d.sender.Gauge("snmp.devices_monitored", float64(1), newTags)
 
 	// SNMP Performance metrics
-	d.sender.MonotonicCount("datadog.snmp.check_interval", time.Duration(startTime.UnixNano()).Seconds(), "", newTags)
-	d.sender.Gauge("datadog.snmp.check_duration", time.Since(startTime).Seconds(), "", newTags)
-	d.sender.Gauge("datadog.snmp.submitted_metrics", float64(d.sender.GetSubmittedMetrics()), "", newTags)
+	d.sender.MonotonicCount("datadog.snmp.check_interval", time.Duration(startTime.UnixNano()).Seconds(), newTags)
+	d.sender.Gauge("datadog.snmp.check_duration", time.Since(startTime).Seconds(), newTags)
+	d.sender.Gauge("datadog.snmp.submitted_metrics", float64(d.sender.GetSubmittedMetrics()), newTags)
 }

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -54,7 +54,7 @@ func (c *Check) Run() error {
 
 		for i := range discoveredDevices {
 			deviceCk := discoveredDevices[i]
-			deviceCk.SetSender(report.NewMetricSender(sender))
+			deviceCk.SetSender(report.NewMetricSender(sender, deviceCk.GetHostname()))
 			jobs <- deviceCk
 		}
 		close(jobs)
@@ -64,7 +64,7 @@ func (c *Check) Run() error {
 		tags = append(tags, c.config.GetNetworkTags()...)
 		sender.Gauge("snmp.discovered_devices_count", float64(len(discoveredDevices)), "", tags)
 	} else {
-		c.singleDeviceCk.SetSender(report.NewMetricSender(sender))
+		c.singleDeviceCk.SetSender(report.NewMetricSender(sender, c.singleDeviceCk.GetHostname()))
 		checkErr = c.runCheckDevice(c.singleDeviceCk)
 	}
 

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -37,6 +37,7 @@ type ListenerConfig struct {
 	CollectDeviceMetadata bool     `mapstructure:"collect_device_metadata"`
 	MinCollectionInterval uint     `mapstructure:"min_collection_interval"`
 	Namespace             string   `mapstructure:"namespace"`
+	UseDeviceISAsHostname bool     `mapstructure:"use_device_id_as_hostname"`
 	Configs               []Config `mapstructure:"configs"`
 
 	// legacy
@@ -64,6 +65,8 @@ type Config struct {
 	Loader                      string          `mapstructure:"loader"`
 	CollectDeviceMetadataConfig *bool           `mapstructure:"collect_device_metadata"`
 	CollectDeviceMetadata       bool
+	UseDeviceIDAsHostnameConfig *bool `mapstructure:"use_device_id_as_hostname"`
+	UseDeviceIDAsHostname       bool
 	Namespace                   string   `mapstructure:"namespace"`
 	Tags                        []string `mapstructure:"tags"`
 	MinCollectionInterval       uint     `mapstructure:"min_collection_interval"`
@@ -125,9 +128,17 @@ func NewListenerConfig() (ListenerConfig, error) {
 		} else {
 			config.CollectDeviceMetadata = snmpConfig.CollectDeviceMetadata
 		}
+
+		if config.UseDeviceIDAsHostnameConfig != nil {
+			config.UseDeviceIDAsHostname = *config.UseDeviceIDAsHostnameConfig
+		} else {
+			config.UseDeviceIDAsHostname = snmpConfig.UseDeviceISAsHostname
+		}
+
 		if config.Loader == "" {
 			config.Loader = snmpConfig.Loader
 		}
+
 		if config.MinCollectionInterval == 0 {
 			config.MinCollectionInterval = snmpConfig.MinCollectionInterval
 		}

--- a/pkg/snmp/snmp_test.go
+++ b/pkg/snmp/snmp_test.go
@@ -224,6 +224,7 @@ snmp_listener:
 	assert.Equal(t, 11, conf.DiscoveryInterval)
 	assert.Equal(t, 5, conf.AllowedFailures)
 	assert.Equal(t, true, conf.CollectDeviceMetadata)
+	assert.Equal(t, false, conf.UseDeviceISAsHostname)
 	assert.Equal(t, "core", conf.Loader)
 	assert.Equal(t, "someAuthProtocol", networkConf.AuthProtocol)
 	assert.Equal(t, "someAuthKey", networkConf.AuthKey)
@@ -320,4 +321,23 @@ func TestFirstNonEmpty(t *testing.T) {
 	assert.Equal(t, firstNonEmpty("", "mononoke", "ponyo"), "mononoke")
 	assert.Equal(t, firstNonEmpty("", "", "ponyo"), "ponyo")
 	assert.Equal(t, firstNonEmpty("", "", ""), "")
+}
+
+func Test_UseDeviceIDAsHostname(t *testing.T) {
+	config.Datadog.SetConfigType("yaml")
+	err := config.Datadog.ReadConfig(strings.NewReader(`
+snmp_listener:
+  use_device_id_as_hostname: true
+  configs:
+   - network: 127.1.0.0/30
+     use_device_id_as_hostname: false
+   - network: 127.2.0.0/30
+`))
+	assert.NoError(t, err)
+
+	conf, err := NewListenerConfig()
+	assert.NoError(t, err)
+
+	assert.Equal(t, false, conf.Configs[0].UseDeviceIDAsHostname)
+	assert.Equal(t, true, conf.Configs[1].UseDeviceIDAsHostname)
 }

--- a/releasenotes/notes/add-use-device-id-as-hostname-e4b72dd63784711d.yaml
+++ b/releasenotes/notes/add-use-device-id-as-hostname-e4b72dd63784711d.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add `use_device_id_as_hostname` in snmp check and snmp_listener configuration to use DeviceId as hostname for metrics and service checks


### PR DESCRIPTION
Reverts DataDog/datadog-agent#9209, that reverted DataDog/datadog-agent#9186

### What does this PR do?
Add config to use DeviceID as hostname for metrics and service checks

### Motivation
Needed for NDM custom tags feature.

### Additional Notes
Describe how to test your changes
Test that using use_device_id_as_hostname will add use device_id as hostname.

### Checklist
 A release note has been added or the changelog/no-changelog label has been applied.
 The need-change/operator and need-change/helm labels has been applied if applicable.
 The appropriate team/.. label has been applied, if known.
 If known, an appropriate milestone has been selected; otherwise the Triage milestone is set.
 The config template has been updated if applicable.
Note: Adding GitHub labels is only possible for contributors with write access.