### PR TITLE
[corechecks/snmp] Add namespace to SNMP integration and SNMP Listener

### DIFF
--- a/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
+++ b/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
@@ -113,3 +113,9 @@ instances:
     ## Enable device metadata collection
     #
     collect_device_metadata: "%%extra_collect_device_metadata%%"
+
+    ## @param namespace - string - optional - default: default
+    ## Namespace can be used to disambiguate devices with same IPs.
+    ## Changing namespace will cause devices being recreated in NDM app.
+    #
+    namespace: "%%extra_namespace%%"

--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -416,6 +416,8 @@ func (s *SNMPService) GetExtraConfig(key []byte) ([]byte, error) {
 		return []byte(s.config.Network), nil
 	case "loader":
 		return []byte(s.config.Loader), nil
+	case "namespace":
+		return []byte(s.config.Namespace), nil
 	case "collect_device_metadata":
 		return []byte(strconv.FormatBool(s.config.CollectDeviceMetadata)), nil
 	case "tags":

--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -163,6 +163,7 @@ func TestExtraConfig(t *testing.T) {
 		Timeout:      5,
 		Retries:      2,
 		OidBatchSize: 10,
+		Namespace:    "my-ns",
 	}
 
 	svc := SNMPService{
@@ -219,6 +220,10 @@ func TestExtraConfig(t *testing.T) {
 	info, err = svc.GetExtraConfig([]byte("min_collection_interval"))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "60", string(info))
+
+	info, err = svc.GetExtraConfig([]byte("namespace"))
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "my-ns", string(info))
 }
 
 func TestExtraConfigExtraTags(t *testing.T) {

--- a/pkg/collector/corechecks/snmp/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check/defaults"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/common"
@@ -104,6 +105,7 @@ type InstanceConfig struct {
 	DiscoveryAllowedFailures int      `yaml:"discovery_allowed_failures"`
 	DiscoveryWorkers         int      `yaml:"discovery_workers"`
 	Workers                  int      `yaml:"workers"`
+	Namespace                string   `yaml:"namespace"`
 }
 
 // CheckConfig holds config needed for an integration instance to run
@@ -135,6 +137,7 @@ type CheckConfig struct {
 	DeviceID              string
 	DeviceIDTags          []string
 	ResolvedSubnetName    string
+	Namespace             string
 	AutodetectProfile     bool
 	MinCollectionInterval time.Duration
 
@@ -369,6 +372,12 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	}
 	c.BulkMaxRepetitions = uint32(bulkMaxRepetitions)
 
+	if instance.Namespace != "" {
+		c.Namespace = instance.Namespace
+	} else {
+		c.Namespace = config.Datadog.GetString("network_devices.namespace")
+	}
+
 	// metrics Configs
 	if instance.UseGlobalMetrics {
 		c.Metrics = append(c.Metrics, initConfig.GlobalMetrics...)
@@ -528,6 +537,7 @@ func (c *CheckConfig) Copy() *CheckConfig {
 
 	newConfig.DeviceIDTags = common.CopyStrings(c.DeviceIDTags)
 	newConfig.ResolvedSubnetName = c.ResolvedSubnetName
+	newConfig.Namespace = c.Namespace
 	newConfig.AutodetectProfile = c.AutodetectProfile
 	newConfig.MinCollectionInterval = c.MinCollectionInterval
 

--- a/pkg/collector/corechecks/snmp/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config.go
@@ -377,6 +377,10 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	} else {
 		c.Namespace = config.Datadog.GetString("network_devices.namespace")
 	}
+	if c.Namespace == "" {
+		// Can only happen if set network_devices.namespace to empty string in `datadog.yaml`
+		return nil, fmt.Errorf("namespace cannot be empty")
+	}
 
 	// metrics Configs
 	if instance.UseGlobalMetrics {

--- a/pkg/collector/corechecks/snmp/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config.go
@@ -185,8 +185,6 @@ func (c *CheckConfig) addUptimeMetric() {
 }
 
 // GetStaticTags return static tags built from configuration
-// warning: changing GetStaticTags logic might lead to different deviceID
-// GetStaticTags does not contain tags from instance[].tags config
 func (c *CheckConfig) GetStaticTags() []string {
 	tags := append(common.CopyStrings(c.ExtraTags), c.getDeviceIDTags()...)
 	return tags

--- a/pkg/collector/corechecks/snmp/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config.go
@@ -378,7 +378,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 		c.Namespace = config.Datadog.GetString("network_devices.namespace")
 	}
 	if c.Namespace == "" {
-		// Can only happen if set network_devices.namespace to empty string in `datadog.yaml`
+		// Can only happen if network_devices.namespace config is set to empty string in `datadog.yaml`
 		return nil, fmt.Errorf("namespace cannot be empty")
 	}
 

--- a/pkg/collector/corechecks/snmp/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config.go
@@ -187,7 +187,7 @@ func (c *CheckConfig) addUptimeMetric() {
 // GetStaticTags return static tags built from configuration
 func (c *CheckConfig) GetStaticTags() []string {
 	tags := common.CopyStrings(c.ExtraTags)
-	tags = append(tags, deviceNamespaceTagKey + ":" + c.Namespace)
+	tags = append(tags, deviceNamespaceTagKey+":"+c.Namespace)
 	if c.IPAddress != "" {
 		tags = append(tags, deviceIPTagKey+":"+c.IPAddress)
 	}
@@ -208,7 +208,7 @@ func (c *CheckConfig) GetNetworkTags() []string {
 // getDeviceIDTags return sorted tags used for generating device id
 // warning: changing getDeviceIDTags logic might lead to different deviceID
 func (c *CheckConfig) getDeviceIDTags() []string {
-	tags := []string{deviceNamespaceTagKey + ":" + c.Namespace, deviceIPTagKey+":"+c.IPAddress}
+	tags := []string{deviceNamespaceTagKey + ":" + c.Namespace, deviceIPTagKey + ":" + c.IPAddress}
 	sort.Strings(tags)
 	return tags
 }

--- a/pkg/collector/corechecks/snmp/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config.go
@@ -186,7 +186,11 @@ func (c *CheckConfig) addUptimeMetric() {
 
 // GetStaticTags return static tags built from configuration
 func (c *CheckConfig) GetStaticTags() []string {
-	tags := append(common.CopyStrings(c.ExtraTags), c.getDeviceIDTags()...)
+	tags := common.CopyStrings(c.ExtraTags)
+	tags = append(tags, deviceNamespaceTagKey + ":" + c.Namespace)
+	if c.IPAddress != "" {
+		tags = append(tags, deviceIPTagKey+":"+c.IPAddress)
+	}
 	return tags
 }
 
@@ -204,14 +208,7 @@ func (c *CheckConfig) GetNetworkTags() []string {
 // getDeviceIDTags return sorted tags used for generating device id
 // warning: changing getDeviceIDTags logic might lead to different deviceID
 func (c *CheckConfig) getDeviceIDTags() []string {
-	tags := []string{deviceNamespaceTagKey + ":" + c.Namespace}
-	if c.IPAddress != "" {
-		// TODO: refactor to use getDeviceIDTags only for CheckConfig with IPAddress
-		// IPAddress should be always present for ndm device metadata
-		// the if condition is needed since getDeviceIDTags is also called by GetStaticTags and
-		// it might be called for network/subnet configs (without IP address)
-		tags = append(tags, deviceIPTagKey+":"+c.IPAddress)
-	}
+	tags := []string{deviceNamespaceTagKey + ":" + c.Namespace, deviceIPTagKey+":"+c.IPAddress}
 	sort.Strings(tags)
 	return tags
 }

--- a/pkg/collector/corechecks/snmp/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config.go
@@ -206,6 +206,10 @@ func (c *CheckConfig) GetNetworkTags() []string {
 func (c *CheckConfig) getDeviceIDTags() []string {
 	tags := []string{deviceNamespaceTagKey + ":" + c.Namespace}
 	if c.IPAddress != "" {
+		// TODO: refactor to use getDeviceIDTags only for CheckConfig with IPAddress
+		// IPAddress should be always present for ndm device metadata
+		// the if condition is needed since getDeviceIDTags is also called by GetStaticTags and
+		// it might be called for network/subnet configs (without IP address)
 		tags = append(tags, deviceIPTagKey+":"+c.IPAddress)
 	}
 	sort.Strings(tags)

--- a/pkg/collector/corechecks/snmp/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config_test.go
@@ -1037,7 +1037,7 @@ community_string: "abc"
 ip_address: 1.2.3.4
 community_string: "abc"
 `)
-	config.Datadog.Set("network_devices.namespace", "")
+	coreconfig.Datadog.Set("network_devices.namespace", "")
 	conf, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
 	assert.EqualError(t, err, "namespace cannot be empty")
 }

--- a/pkg/collector/corechecks/snmp/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config_test.go
@@ -130,7 +130,7 @@ bulk_max_repetitions: 20
 	assert.Equal(t, "aes", config.PrivProtocol)
 	assert.Equal(t, "my-privKey", config.PrivKey)
 	assert.Equal(t, "my-contextName", config.ContextName)
-	assert.Equal(t, []string{"snmp_device:1.2.3.4"}, config.GetStaticTags())
+	assert.Equal(t, []string{"device_namespace:default", "snmp_device:1.2.3.4"}, config.GetStaticTags())
 	metrics := []MetricsConfig{
 		{Symbol: SymbolConfig{OID: "1.3.6.1.2.1.2.1", Name: "ifNumber"}},
 		{Symbol: SymbolConfig{OID: "1.3.6.1.2.1.2.2", Name: "ifNumber2"}, MetricTags: MetricTagConfigList{
@@ -212,8 +212,8 @@ bulk_max_repetitions: 20
 	assert.Equal(t, metrics, config.Metrics)
 	assert.Equal(t, metricsTags, config.MetricTags)
 	assert.Equal(t, 1, len(config.Profiles))
-	assert.Equal(t, "780a58c96c908df8", config.DeviceID)
-	assert.Equal(t, []string{"snmp_device:1.2.3.4", "tag1", "tag2:val2"}, config.DeviceIDTags)
+	assert.Equal(t, "5eb4b5284574c173", config.DeviceID)
+	assert.Equal(t, []string{"device_namespace:default", "snmp_device:1.2.3.4"}, config.DeviceIDTags)
 	assert.Equal(t, "127.0.0.0/30", config.ResolvedSubnetName)
 	assert.Equal(t, false, config.AutodetectProfile)
 }
@@ -282,7 +282,7 @@ profiles:
 	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig)
 
 	assert.Nil(t, err)
-	assert.Equal(t, []string{"snmp_device:1.2.3.4"}, config.GetStaticTags())
+	assert.Equal(t, []string{"device_namespace:default", "snmp_device:1.2.3.4"}, config.GetStaticTags())
 	metrics := []MetricsConfig{
 		{Symbol: SymbolConfig{OID: "1.4.5", Name: "myMetric"}, ForcedType: "gauge"},
 	}
@@ -297,8 +297,8 @@ profiles:
 	assert.Equal(t, metrics, config.Metrics)
 	assert.Equal(t, metricsTags, config.MetricTags)
 	assert.Equal(t, 2, len(config.Profiles))
-	assert.Equal(t, "74f22f3320d2d692", config.DeviceID)
-	assert.Equal(t, []string{"snmp_device:1.2.3.4"}, config.DeviceIDTags)
+	assert.Equal(t, "5eb4b5284574c173", config.DeviceID)
+	assert.Equal(t, []string{"device_namespace:default", "snmp_device:1.2.3.4"}, config.DeviceIDTags)
 	assert.Equal(t, false, config.AutodetectProfile)
 	assert.Equal(t, 3600, config.DiscoveryInterval)
 	assert.Equal(t, 3, config.DiscoveryAllowedFailures)
@@ -828,7 +828,7 @@ community_string: abc
 `)
 	config, err := NewCheckConfig(rawInstanceConfig, []byte(``))
 	assert.Nil(t, err)
-	assert.Equal(t, []string{"snmp_device:1.2.3.4"}, config.GetStaticTags())
+	assert.Equal(t, []string{"device_namespace:default", "snmp_device:1.2.3.4"}, config.GetStaticTags())
 
 	// language=yaml
 	rawInstanceConfigWithExtraTags := []byte(`
@@ -838,7 +838,7 @@ extra_tags: "extratag1:val1,extratag2:val2"
 `)
 	config, err = NewCheckConfig(rawInstanceConfigWithExtraTags, []byte(``))
 	assert.Nil(t, err)
-	assert.ElementsMatch(t, []string{"snmp_device:1.2.3.4", "extratag1:val1", "extratag2:val2"}, config.GetStaticTags())
+	assert.ElementsMatch(t, []string{"device_namespace:default", "snmp_device:1.2.3.4", "extratag1:val1", "extratag2:val2"}, config.GetStaticTags())
 }
 
 func Test_snmpConfig_getDeviceIDTags(t *testing.T) {
@@ -846,10 +846,11 @@ func Test_snmpConfig_getDeviceIDTags(t *testing.T) {
 		IPAddress:    "1.2.3.4",
 		ExtraTags:    []string{"extratag1:val1", "extratag2"},
 		InstanceTags: []string{"instancetag1:val1", "instancetag2"},
+		Namespace:    "hey",
 	}
 	actualTags := c.getDeviceIDTags()
 
-	expectedTags := []string{"extratag1:val1", "extratag2", "instancetag1:val1", "instancetag2", "snmp_device:1.2.3.4"}
+	expectedTags := []string{"device_namespace:hey", "snmp_device:1.2.3.4"}
 	assert.Equal(t, expectedTags, actualTags)
 }
 

--- a/pkg/collector/corechecks/snmp/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config_test.go
@@ -999,6 +999,8 @@ collect_device_metadata: true
 }
 
 func Test_buildConfig_namespace(t *testing.T) {
+	defer config.Datadog.Set("network_devices.namespace", "default")
+
 	// language=yaml
 	rawInstanceConfig := []byte(`
 ip_address: 1.2.3.4
@@ -1029,6 +1031,15 @@ community_string: "abc"
 	conf, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
 	assert.Nil(t, err)
 	assert.Equal(t, "ns-from-datadog-conf", conf.Namespace)
+
+	// language=yaml
+	rawInstanceConfig = []byte(`
+ip_address: 1.2.3.4
+community_string: "abc"
+`)
+	config.Datadog.Set("network_devices.namespace", "")
+	conf, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	assert.EqualError(t, err, "namespace cannot be empty")
 }
 
 func Test_buildConfig_minCollectionInterval(t *testing.T) {

--- a/pkg/collector/corechecks/snmp/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	"github.com/DataDog/datadog-agent/pkg/config"
+	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 )
 
 func TestConfigurations(t *testing.T) {
@@ -316,22 +316,22 @@ community_string: abc
 `)
 	// language=yaml
 	rawInitConfig := []byte(``)
-	conf, err := NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig)
 
 	assert.Nil(t, err)
-	assert.Equal(t, "default", conf.Namespace)
-	assert.Equal(t, "1.2.3.4", conf.IPAddress)
-	assert.Equal(t, uint16(161), conf.Port)
-	assert.Equal(t, 2, conf.Timeout)
-	assert.Equal(t, 3, conf.Retries)
+	assert.Equal(t, "default", config.Namespace)
+	assert.Equal(t, "1.2.3.4", config.IPAddress)
+	assert.Equal(t, uint16(161), config.Port)
+	assert.Equal(t, 2, config.Timeout)
+	assert.Equal(t, 3, config.Retries)
 	metrics := []MetricsConfig{{Symbol: SymbolConfig{OID: "1.3.6.1.2.1.1.3.0", Name: "sysUpTimeInstance"}}}
 
 	var metricsTags []MetricTagConfig
 
-	assert.Equal(t, metrics, conf.Metrics)
-	assert.Equal(t, metricsTags, conf.MetricTags)
-	assert.Equal(t, 1, len(conf.Profiles))
-	assert.Equal(t, mockProfilesDefinitions()["f5-big-ip"].Metrics, conf.Profiles["f5-big-ip"].Metrics)
+	assert.Equal(t, metrics, config.Metrics)
+	assert.Equal(t, metricsTags, config.MetricTags)
+	assert.Equal(t, 1, len(config.Profiles))
+	assert.Equal(t, mockProfilesDefinitions()["f5-big-ip"].Metrics, config.Profiles["f5-big-ip"].Metrics)
 }
 
 func TestPortConfiguration(t *testing.T) {
@@ -999,7 +999,7 @@ collect_device_metadata: true
 }
 
 func Test_buildConfig_namespace(t *testing.T) {
-	defer config.Datadog.Set("network_devices.namespace", "default")
+	defer coreconfig.Datadog.Set("network_devices.namespace", "default")
 
 	// language=yaml
 	rawInstanceConfig := []byte(`
@@ -1027,7 +1027,7 @@ community_string: "abc"
 ip_address: 1.2.3.4
 community_string: "abc"
 `)
-	config.Datadog.Set("network_devices.namespace", "ns-from-datadog-conf")
+	coreconfig.Datadog.Set("network_devices.namespace", "ns-from-datadog-conf")
 	conf, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
 	assert.Nil(t, err)
 	assert.Equal(t, "ns-from-datadog-conf", conf.Namespace)

--- a/pkg/collector/corechecks/snmp/checkconfig/config_utils.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config_utils.go
@@ -16,7 +16,7 @@ func buildDeviceID(origTags []string) (string, []string) {
 		// When using snmp_listener, the `autodiscovery_subnet` tag is passed
 		// via autodiscovery template. We are ignoring it to avoid deviceID
 		// being changed when we change subnet e.g. 10.10.0.0/29 -> 10.10.0.0/30
-		if strings.HasPrefix(tag, subnetTagPrefix+":") {
+		if strings.HasPrefix(tag, subnetTagKey+":") {
 			continue
 		}
 

--- a/pkg/collector/corechecks/snmp/discovery/discovery_test.go
+++ b/pkg/collector/corechecks/snmp/discovery/discovery_test.go
@@ -285,6 +285,7 @@ func TestDiscovery_createDevice(t *testing.T) {
 		DiscoveryInterval:        1,
 		DiscoveryWorkers:         1,
 		DiscoveryAllowedFailures: 3,
+		Namespace:                "default",
 	}
 	discovery := NewDiscovery(checkConfig)
 	ipAddr, ipNet, err := net.ParseCIDR(checkConfig.Network)
@@ -312,7 +313,7 @@ func TestDiscovery_createDevice(t *testing.T) {
 	assert.Equal(t, device1Digest, discovery.discoveredDevices[device1Digest].deviceDigest)
 	assert.Equal(t, "192.168.0.1", discovery.discoveredDevices[device1Digest].deviceIP)
 	assert.Equal(t, "192.168.0.1", discovery.discoveredDevices[device1Digest].deviceCheck.GetIPAddress())
-	assert.Equal(t, []string{"snmp_device:192.168.0.1"}, discovery.discoveredDevices[device1Digest].deviceCheck.GetIDTags())
+	assert.Equal(t, []string{"device_namespace:default", "snmp_device:192.168.0.1"}, discovery.discoveredDevices[device1Digest].deviceCheck.GetIDTags())
 
 	assert.Equal(t, device2Digest, discovery.discoveredDevices[device2Digest].deviceDigest)
 	assert.Equal(t, "192.168.0.2", discovery.discoveredDevices[device2Digest].deviceIP)

--- a/pkg/collector/corechecks/snmp/metadata/payload.go
+++ b/pkg/collector/corechecks/snmp/metadata/payload.go
@@ -17,6 +17,7 @@ const (
 // NetworkDevicesMetadata contains network devices metadata
 type NetworkDevicesMetadata struct {
 	Subnet           string              `json:"subnet"`
+	Namespace        string              `json:"namespace"`
 	Devices          []DeviceMetadata    `json:"devices,omitempty"`
 	Interfaces       []InterfaceMetadata `json:"interfaces,omitempty"`
 	CollectTimestamp int64               `json:"collect_timestamp"`

--- a/pkg/collector/corechecks/snmp/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/report/report_device_metadata.go
@@ -31,7 +31,7 @@ func (ms *MetricSender) ReportNetworkDeviceMetadata(config *checkconfig.CheckCon
 		log.Debugf("Unable to build interfaces metadata: %s", err)
 	}
 
-	metadataPayloads := batchPayloads(config.ResolvedSubnetName, collectTime, metadata.PayloadMetadataBatchSize, device, interfaces)
+	metadataPayloads := batchPayloads(config.Namespace, config.ResolvedSubnetName, collectTime, metadata.PayloadMetadataBatchSize, device, interfaces)
 
 	for _, payload := range metadataPayloads {
 		payloadBytes, err := json.Marshal(payload)
@@ -106,7 +106,7 @@ func buildNetworkInterfacesMetadata(deviceID string, store *valuestore.ResultVal
 	return interfaces, err
 }
 
-func batchPayloads(subnet string, collectTime time.Time, batchSize int, device metadata.DeviceMetadata, interfaces []metadata.InterfaceMetadata) []metadata.NetworkDevicesMetadata {
+func batchPayloads(namespace string, subnet string, collectTime time.Time, batchSize int, device metadata.DeviceMetadata, interfaces []metadata.InterfaceMetadata) []metadata.NetworkDevicesMetadata {
 	var payloads []metadata.NetworkDevicesMetadata
 	var resourceCount int
 	payload := metadata.NetworkDevicesMetadata{
@@ -114,6 +114,7 @@ func batchPayloads(subnet string, collectTime time.Time, batchSize int, device m
 			device,
 		},
 		Subnet:           subnet,
+		Namespace:        namespace,
 		CollectTimestamp: collectTime.Unix(),
 	}
 	resourceCount++
@@ -123,6 +124,7 @@ func batchPayloads(subnet string, collectTime time.Time, batchSize int, device m
 			payloads = append(payloads, payload)
 			payload = metadata.NetworkDevicesMetadata{
 				Subnet:           subnet,
+				Namespace:        namespace,
 				CollectTimestamp: collectTime.Unix(),
 			}
 			resourceCount = 0

--- a/pkg/collector/corechecks/snmp/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/report/report_device_metadata_test.go
@@ -42,6 +42,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withoutInterfaces(t *testing.
 		DeviceID:           "1234",
 		DeviceIDTags:       []string{"device_name:127.0.0.1"},
 		ResolvedSubnetName: "127.0.0.0/29",
+		Namespace:          "my-ns",
 	}
 	layout := "2006-01-02 15:04:05"
 	str := "2014-11-12 11:45:26"
@@ -54,6 +55,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withoutInterfaces(t *testing.
 	event := []byte(`
 {
     "subnet": "127.0.0.0/29",
+    "namespace": "my-ns",
     "devices": [
         {
             "id": "1234",
@@ -109,6 +111,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withInterfaces(t *testing.T) 
 		DeviceID:           "1234",
 		DeviceIDTags:       []string{"device_name:127.0.0.1"},
 		ResolvedSubnetName: "127.0.0.0/29",
+		Namespace:          "my-ns",
 	}
 
 	layout := "2006-01-02 15:04:05"
@@ -121,6 +124,7 @@ func Test_metricSender_reportNetworkDeviceMetadata_withInterfaces(t *testing.T) 
 	event := []byte(`
 {
     "subnet": "127.0.0.0/29",
+    "namespace": "my-ns",
     "devices": [
         {
             "id": "1234",
@@ -188,10 +192,11 @@ func Test_batchPayloads(t *testing.T) {
 	for i := 0; i < 350; i++ {
 		interfaces = append(interfaces, metadata.InterfaceMetadata{DeviceID: deviceID, Index: int32(i)})
 	}
-	payloads := batchPayloads("127.0.0.0/30", collectTime, 100, device, interfaces)
+	payloads := batchPayloads("my-ns", "127.0.0.0/30", collectTime, 100, device, interfaces)
 
 	assert.Equal(t, 4, len(payloads))
 
+	assert.Equal(t, "my-ns", payloads[0].Namespace)
 	assert.Equal(t, "127.0.0.0/30", payloads[0].Subnet)
 	assert.Equal(t, int64(946684800), payloads[0].CollectTimestamp)
 	assert.Equal(t, []metadata.DeviceMetadata{device}, payloads[0].Devices)

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -500,6 +500,7 @@ profiles:
 	event := []byte(`
 {
   "subnet": "127.0.0.0/30",
+  "namespace":"default",
   "devices": [
     {
       "id": "173b2077d0770b8",
@@ -1064,6 +1065,7 @@ tags:
 	event := []byte(`
 {
   "subnet": "127.0.0.0/30",
+  "namespace":"default",
   "devices": [
     {
       "id": "173b2077d0770b8",
@@ -1175,6 +1177,7 @@ tags:
 	event := []byte(`
 {
   "subnet": "127.0.0.0/30",
+  "namespace":"default",
   "devices": [
     {
       "id": "173b2077d0770b9",
@@ -1431,6 +1434,7 @@ metric_tags:
 		event := []byte(fmt.Sprintf(`
 {
   "subnet": "10.10.0.0/30",
+  "namespace":"default",
   "devices": [
     {
       "id": "%s",

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -484,7 +484,7 @@ profiles:
 	err = chk.Run()
 	assert.Nil(t, err)
 
-	snmpTags := []string{"snmp_device:1.2.3.4", "snmp_profile:f5-big-ip", "device_vendor:f5", "snmp_host:foo_sys_name"}
+	snmpTags := []string{"device_namespace:default", "snmp_device:1.2.3.4", "snmp_profile:f5-big-ip", "device_vendor:f5", "snmp_host:foo_sys_name"}
 	row1Tags := append(common.CopyStrings(snmpTags), "interface:nameRow1", "interface_alias:descRow1")
 	row2Tags := append(common.CopyStrings(snmpTags), "interface:nameRow2", "interface_alias:descRow2")
 
@@ -503,9 +503,9 @@ profiles:
   "namespace":"default",
   "devices": [
     {
-      "id": "173b2077d0770b8",
+      "id": "5eb4b5284574c173",
       "id_tags": [
-        "mytag:val1",
+        "device_namespace:default",
         "snmp_device:1.2.3.4"
       ],
       "name": "foo_sys_name",
@@ -517,6 +517,7 @@ profiles:
       "subnet": "127.0.0.0/30",
       "tags": [
         "autodiscovery_subnet:127.0.0.0/30",
+        "device_namespace:default",
         "device_vendor:f5",
         "mytag:val1",
         "prefix:f",
@@ -531,7 +532,7 @@ profiles:
   ],
   "interfaces": [
     {
-      "device_id": "173b2077d0770b8",
+      "device_id": "5eb4b5284574c173",
       "id_tags": ["interface:nameRow1"],
       "index": 1,
       "name": "nameRow1",
@@ -542,7 +543,7 @@ profiles:
       "oper_status": 1
     },
     {
-      "device_id": "173b2077d0770b8",
+      "device_id": "5eb4b5284574c173",
 	  "id_tags": ["interface:nameRow2"],
       "index": 2,
       "name": "nameRow2",
@@ -1056,7 +1057,7 @@ tags:
 	err = chk.Run()
 	assert.EqualError(t, err, "failed to autodetect profile: failed to fetch sysobjectid: cannot get sysobjectid: no value")
 
-	snmpTags := []string{"snmp_device:1.2.3.4"}
+	snmpTags := []string{"device_namespace:default", "snmp_device:1.2.3.4"}
 
 	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "", snmpTags)
 	sender.AssertMetric(t, "Gauge", "snmp.sysUpTimeInstance", float64(20), "", snmpTags)
@@ -1068,9 +1069,9 @@ tags:
   "namespace":"default",
   "devices": [
     {
-      "id": "173b2077d0770b8",
+      "id": "5eb4b5284574c173",
       "id_tags": [
-        "mytag:val1",
+        "device_namespace:default",
         "snmp_device:1.2.3.4"
       ],
       "name": "foo_sys_name",
@@ -1082,6 +1083,7 @@ tags:
       "subnet": "127.0.0.0/30",
       "tags": [
         "autodiscovery_subnet:127.0.0.0/30",
+        "device_namespace:default",
         "mytag:val1",
         "snmp_device:1.2.3.4"
       ],
@@ -1090,7 +1092,7 @@ tags:
   ],
   "interfaces": [
     {
-      "device_id": "173b2077d0770b8",
+      "device_id": "5eb4b5284574c173",
       "id_tags": ["interface:nameRow1"],
       "index": 1,
       "name": "nameRow1",
@@ -1101,7 +1103,7 @@ tags:
       "oper_status": 1
     },
     {
-      "device_id": "173b2077d0770b8",
+      "device_id": "5eb4b5284574c173",
       "id_tags": ["interface:nameRow2"],
       "index": 2,
       "name": "nameRow2",
@@ -1169,7 +1171,7 @@ tags:
 	err = chk.Run()
 	assert.EqualError(t, err, "failed to autodetect profile: failed to fetch sysobjectid: cannot get sysobjectid: no value; failed to fetch values: failed to fetch scalar oids with batching: failed to fetch scalar oids: fetch scalar: error getting oids `[1.3.6.1.2.1.1.5.0 1.3.6.1.2.1.1.1.0 1.3.6.1.2.1.1.2.0 1.3.6.1.2.1.1.3.0]`: device failure")
 
-	snmpTags := []string{"snmp_device:1.2.3.5"}
+	snmpTags := []string{"device_namespace:default", "snmp_device:1.2.3.5"}
 
 	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "", snmpTags)
 
@@ -1180,9 +1182,9 @@ tags:
   "namespace":"default",
   "devices": [
     {
-      "id": "173b2077d0770b9",
+      "id": "5eb4b5284574c172",
       "id_tags": [
-        "mytag:val1",
+        "device_namespace:default",
         "snmp_device:1.2.3.5"
       ],
       "name": "",
@@ -1194,6 +1196,7 @@ tags:
       "subnet": "127.0.0.0/30",
       "tags": [
         "autodiscovery_subnet:127.0.0.0/30",
+        "device_namespace:default",
         "mytag:val1",
         "snmp_device:1.2.3.5"
       ],
@@ -1407,17 +1410,17 @@ metric_tags:
 		ipAddress string
 		deviceID  string
 	}{
-		{ipAddress: "10.10.0.0", deviceID: "e162c69954d2b408"},
-		{ipAddress: "10.10.0.1", deviceID: "e162c69954d2b409"},
-		{ipAddress: "10.10.0.2", deviceID: "e162c69954d2b40a"},
-		{ipAddress: "10.10.0.3", deviceID: "e162c69954d2b40b"},
+		{ipAddress: "10.10.0.0", deviceID: "fb83a12c4a90c1d1"},
+		{ipAddress: "10.10.0.1", deviceID: "fb83a12c4a90c1d0"},
+		{ipAddress: "10.10.0.2", deviceID: "fb83a12c4a90c1d3"},
+		{ipAddress: "10.10.0.3", deviceID: "fb83a12c4a90c1d2"},
 	}
 
 	err = chk.Run()
 	assert.Nil(t, err)
 
 	for _, deviceData := range deviceMap {
-		snmpTags := []string{"snmp_device:" + deviceData.ipAddress, "autodiscovery_subnet:10.10.0.0/30"}
+		snmpTags := []string{"device_namespace:default", "snmp_device:" + deviceData.ipAddress, "autodiscovery_subnet:10.10.0.0/30"}
 		snmpGlobalTags := append(common.CopyStrings(snmpTags), "snmp_host:foo_sys_name")
 		snmpGlobalTagsWithLoader := append(common.CopyStrings(snmpGlobalTags), "loader:core")
 		scalarTags := append(common.CopyStrings(snmpGlobalTags), "symboltag1:1", "symboltag2:2")
@@ -1439,6 +1442,7 @@ metric_tags:
     {
       "id": "%s",
       "id_tags": [
+        "device_namespace:default",
         "snmp_device:%s"
       ],
       "name": "foo_sys_name",
@@ -1450,6 +1454,7 @@ metric_tags:
       "subnet": "10.10.0.0/30",
       "tags": [
         "autodiscovery_subnet:10.10.0.0/30",
+        "device_namespace:default",
         "snmp_device:%s",
         "snmp_host:foo_sys_name"
       ],

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -716,6 +716,7 @@ func InitConfig(config Config) {
 	bindEnvAndSetLogsConfigKeys(config, "database_monitoring.activity.")
 	bindEnvAndSetLogsConfigKeys(config, "database_monitoring.metrics.")
 	bindEnvAndSetLogsConfigKeys(config, "network_devices.metadata.")
+	config.BindEnvAndSetDefault("network_devices.namespace", "default")
 
 	config.BindEnvAndSetDefault("logs_config.dd_port", 10516)
 	config.BindEnvAndSetDefault("logs_config.dev_mode_use_proto", true)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2385,9 +2385,20 @@ api_key:
 {{ end -}}
 {{- if .SNMP }}
 
-########################
-## SNMP Configuration ##
-########################
+###################################
+## Network Devices Configuration ##
+###################################
+
+## @param network_devices - custom object - optional
+## Configuration related to Network Devices.
+#
+# network_devices:
+
+  ## @param namespace - string - optional - default: default
+  ## Namespace can be used to disambiguate devices
+  ## when multiple agents are used to monitor devices with the same IPs.
+  #
+  # namespace: default
 
 ## @param snmp_traps_enabled - boolean - optional - default: false
 ## Set to true to enable collection of traps.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2395,8 +2395,8 @@ api_key:
 # network_devices:
 
   ## @param namespace - string - optional - default: default
-  ## Namespace can be used to disambiguate devices
-  ## when multiple agents are used to monitor devices with the same IPs.
+  ## Namespace can be used to disambiguate devices with the same IP.
+  ## Changing namespace will cause devices being recreated in NDM app.
   #
   # namespace: default
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1004,3 +1004,18 @@ func TestGetValidHostAliasesWithConfig(t *testing.T) {
 	config := setupConfFromYAML(`host_aliases: ["foo", "-bar"]`)
 	assert.EqualValues(t, getValidHostAliasesWithConfig(config), []string{"foo"})
 }
+
+func TestNetworkDevicesNamespace(t *testing.T) {
+	datadogYaml := `
+network_devices:
+`
+	config := setupConfFromYAML(datadogYaml)
+	assert.Equal(t, "default", config.GetString("network_devices.namespace"))
+
+	datadogYaml = `
+network_devices:
+  namespace: dev
+`
+	config = setupConfFromYAML(datadogYaml)
+	assert.Equal(t, "dev", config.GetString("network_devices.namespace"))
+}

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -16,7 +16,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
+	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 
 	"github.com/DataDog/viper"
 	"github.com/gosnmp/gosnmp"
@@ -97,7 +97,7 @@ func NewListenerConfig() (ListenerConfig, error) {
 		},
 	)
 
-	if err := config.Datadog.UnmarshalKey("snmp_listener", &snmpConfig, opt); err != nil {
+	if err := coreconfig.Datadog.UnmarshalKey("snmp_listener", &snmpConfig, opt); err != nil {
 		return snmpConfig, err
 	}
 
@@ -108,37 +108,37 @@ func NewListenerConfig() (ListenerConfig, error) {
 	// Set the default values, we can't otherwise on an array
 	for i := range snmpConfig.Configs {
 		// We need to modify the struct in place
-		conf := &snmpConfig.Configs[i]
-		if conf.Port == 0 {
-			conf.Port = defaultPort
+		config := &snmpConfig.Configs[i]
+		if config.Port == 0 {
+			config.Port = defaultPort
 		}
-		if conf.Timeout == 0 {
-			conf.Timeout = defaultTimeout
+		if config.Timeout == 0 {
+			config.Timeout = defaultTimeout
 		}
-		if conf.Retries == 0 {
-			conf.Retries = defaultRetries
+		if config.Retries == 0 {
+			config.Retries = defaultRetries
 		}
-		if conf.CollectDeviceMetadataConfig != nil {
-			conf.CollectDeviceMetadata = *conf.CollectDeviceMetadataConfig
+		if config.CollectDeviceMetadataConfig != nil {
+			config.CollectDeviceMetadata = *config.CollectDeviceMetadataConfig
 		} else {
-			conf.CollectDeviceMetadata = snmpConfig.CollectDeviceMetadata
+			config.CollectDeviceMetadata = snmpConfig.CollectDeviceMetadata
 		}
-		if conf.Loader == "" {
-			conf.Loader = snmpConfig.Loader
+		if config.Loader == "" {
+			config.Loader = snmpConfig.Loader
 		}
-		if conf.Namespace == "" {
-			conf.Namespace = config.Datadog.GetString("network_devices.namespace")
+		if config.Namespace == "" {
+			config.Namespace = coreconfig.Datadog.GetString("network_devices.namespace")
 		}
-		if conf.MinCollectionInterval == 0 {
-			conf.MinCollectionInterval = snmpConfig.MinCollectionInterval
+		if config.MinCollectionInterval == 0 {
+			config.MinCollectionInterval = snmpConfig.MinCollectionInterval
 		}
-		conf.Community = firstNonEmpty(conf.Community, conf.CommunityLegacy)
-		conf.AuthKey = firstNonEmpty(conf.AuthKey, conf.AuthKeyLegacy)
-		conf.AuthProtocol = firstNonEmpty(conf.AuthProtocol, conf.AuthProtocolLegacy)
-		conf.PrivKey = firstNonEmpty(conf.PrivKey, conf.PrivKeyLegacy)
-		conf.PrivProtocol = firstNonEmpty(conf.PrivProtocol, conf.PrivProtocolLegacy)
-		conf.Network = firstNonEmpty(conf.Network, conf.NetworkLegacy)
-		conf.Version = firstNonEmpty(conf.Version, conf.VersionLegacy)
+		config.Community = firstNonEmpty(config.Community, config.CommunityLegacy)
+		config.AuthKey = firstNonEmpty(config.AuthKey, config.AuthKeyLegacy)
+		config.AuthProtocol = firstNonEmpty(config.AuthProtocol, config.AuthProtocolLegacy)
+		config.PrivKey = firstNonEmpty(config.PrivKey, config.PrivKeyLegacy)
+		config.PrivProtocol = firstNonEmpty(config.PrivProtocol, config.PrivProtocolLegacy)
+		config.Network = firstNonEmpty(config.Network, config.NetworkLegacy)
+		config.Version = firstNonEmpty(config.Version, config.VersionLegacy)
 	}
 	return snmpConfig, nil
 }

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -63,6 +63,7 @@ type Config struct {
 	Loader                      string          `mapstructure:"loader"`
 	CollectDeviceMetadataConfig *bool           `mapstructure:"collect_device_metadata"`
 	CollectDeviceMetadata       bool
+	Namespace                   string   `mapstructure:"namespace"`
 	Tags                        []string `mapstructure:"tags"`
 	MinCollectionInterval       uint     `mapstructure:"min_collection_interval"`
 
@@ -107,34 +108,37 @@ func NewListenerConfig() (ListenerConfig, error) {
 	// Set the default values, we can't otherwise on an array
 	for i := range snmpConfig.Configs {
 		// We need to modify the struct in place
-		config := &snmpConfig.Configs[i]
-		if config.Port == 0 {
-			config.Port = defaultPort
+		conf := &snmpConfig.Configs[i]
+		if conf.Port == 0 {
+			conf.Port = defaultPort
 		}
-		if config.Timeout == 0 {
-			config.Timeout = defaultTimeout
+		if conf.Timeout == 0 {
+			conf.Timeout = defaultTimeout
 		}
-		if config.Retries == 0 {
-			config.Retries = defaultRetries
+		if conf.Retries == 0 {
+			conf.Retries = defaultRetries
 		}
-		if config.CollectDeviceMetadataConfig != nil {
-			config.CollectDeviceMetadata = *config.CollectDeviceMetadataConfig
+		if conf.CollectDeviceMetadataConfig != nil {
+			conf.CollectDeviceMetadata = *conf.CollectDeviceMetadataConfig
 		} else {
-			config.CollectDeviceMetadata = snmpConfig.CollectDeviceMetadata
+			conf.CollectDeviceMetadata = snmpConfig.CollectDeviceMetadata
 		}
-		if config.Loader == "" {
-			config.Loader = snmpConfig.Loader
+		if conf.Loader == "" {
+			conf.Loader = snmpConfig.Loader
 		}
-		if config.MinCollectionInterval == 0 {
-			config.MinCollectionInterval = snmpConfig.MinCollectionInterval
+		if conf.Namespace == "" {
+			conf.Namespace = config.Datadog.GetString("network_devices.namespace")
 		}
-		config.Community = firstNonEmpty(config.Community, config.CommunityLegacy)
-		config.AuthKey = firstNonEmpty(config.AuthKey, config.AuthKeyLegacy)
-		config.AuthProtocol = firstNonEmpty(config.AuthProtocol, config.AuthProtocolLegacy)
-		config.PrivKey = firstNonEmpty(config.PrivKey, config.PrivKeyLegacy)
-		config.PrivProtocol = firstNonEmpty(config.PrivProtocol, config.PrivProtocolLegacy)
-		config.Network = firstNonEmpty(config.Network, config.NetworkLegacy)
-		config.Version = firstNonEmpty(config.Version, config.VersionLegacy)
+		if conf.MinCollectionInterval == 0 {
+			conf.MinCollectionInterval = snmpConfig.MinCollectionInterval
+		}
+		conf.Community = firstNonEmpty(conf.Community, conf.CommunityLegacy)
+		conf.AuthKey = firstNonEmpty(conf.AuthKey, conf.AuthKeyLegacy)
+		conf.AuthProtocol = firstNonEmpty(conf.AuthProtocol, conf.AuthProtocolLegacy)
+		conf.PrivKey = firstNonEmpty(conf.PrivKey, conf.PrivKeyLegacy)
+		conf.PrivProtocol = firstNonEmpty(conf.PrivProtocol, conf.PrivProtocolLegacy)
+		conf.Network = firstNonEmpty(conf.Network, conf.NetworkLegacy)
+		conf.Version = firstNonEmpty(conf.Version, conf.VersionLegacy)
 	}
 	return snmpConfig, nil
 }

--- a/pkg/snmp/snmp_test.go
+++ b/pkg/snmp/snmp_test.go
@@ -214,3 +214,34 @@ snmp_listener:
 	assert.Equal(t, "legacySnmpVersion", legacyConfig.Version)
 	assert.Equal(t, "127.2.0.0/30", legacyConfig.Network)
 }
+
+func Test_NamespaceConfig(t *testing.T) {
+	// Default Namespace
+	config.Datadog.SetConfigType("yaml")
+	err := config.Datadog.ReadConfig(strings.NewReader(`
+snmp_listener:
+  configs:
+   - community_string: someCommunityString
+     network_address: 127.1.0.0/30
+`))
+	assert.NoError(t, err)
+	conf, err := NewListenerConfig()
+	assert.NoError(t, err)
+	networkConf := conf.Configs[0]
+	assert.Equal(t, "default", networkConf.Namespace)
+
+	// Custom Namespace
+	config.Datadog.SetConfigType("yaml")
+	err = config.Datadog.ReadConfig(strings.NewReader(`
+snmp_listener:
+  configs:
+   - community_string: someCommunityString
+     network_address: 127.1.0.0/30
+     namespace: hello
+`))
+	assert.NoError(t, err)
+	conf, err = NewListenerConfig()
+	assert.NoError(t, err)
+	networkConf = conf.Configs[0]
+	assert.Equal(t, "hello", networkConf.Namespace)
+}

--- a/releasenotes/notes/snmp_add_namespace-298a0d4f07ee1ef5.yaml
+++ b/releasenotes/notes/snmp_add_namespace-298a0d4f07ee1ef5.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add namespace to SNMP integration and SNMP Listener to disambiguate
+    devices with same IP.


### PR DESCRIPTION
### What does this PR do?

[corechecks/snmp] Add namespace

### Motivation

The DeviceID/DeviceIDTags depend on static tags set by users. This is an issue if the user want to add new static tags. That will generate new DeviceID and create duplicate devices in NDM (for a period of time before they are out of scope, 1 day).

Some reasons why user might want to add new tags:

- Tags to differentiate datacenter, network, cluster
- Tags to differentiate prod/dev
- Tags to indicate location, site

### Additional Notes

### Describe how to test your changes

1/ Test namespace for SNMP corecheck (e.g. agent check command or using ddev)

Test with different namespaces and check it's send as metadata to backend.

2/ Test namespace for SNMP Listener
Example using:

```
ddev start env py38-snmplistener --agent <agent_rc_image>
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
