### PR TITLE
[runtime-security] do not cache file with hardlinks 

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "d2e9d0cb4078b47cf86c59e4af0444a1e52d8efd00575468ede26fa1c618719b")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "6d44a122fe5cc0dd4795231285678b35517e3fa2cb9bf2cb957c9a165893e777")

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "6d44a122fe5cc0dd4795231285678b35517e3fa2cb9bf2cb957c9a165893e777")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "5265bcf20ccbbe719546712ace8dce23cfa60beb70ce5ba9bb2dc62c1de84647")

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -253,8 +253,9 @@ struct ktimeval {
 struct file_metadata_t {
     u32 uid;
     u32 gid;
+    u32 nlink;
     u16 mode;
-    char padding[6];
+    char padding[2];
 
     struct ktimeval ctime;
     struct ktimeval mtime;

--- a/pkg/security/ebpf/c/dentry.h
+++ b/pkg/security/ebpf/c/dentry.h
@@ -143,6 +143,7 @@ void __attribute__((always_inline)) fill_file_metadata(struct dentry* dentry, st
     struct inode *d_inode;
     bpf_probe_read(&d_inode, sizeof(d_inode), &dentry->d_inode);
 
+    bpf_probe_read(&file->nlink, sizeof(file->nlink), (void *)&d_inode->i_nlink);
     bpf_probe_read(&file->mode, sizeof(file->mode), &d_inode->i_mode);
     bpf_probe_read(&file->uid, sizeof(file->uid), &d_inode->i_uid);
     bpf_probe_read(&file->gid, sizeof(file->gid), &d_inode->i_gid);

--- a/pkg/security/ebpf/c/link.h
+++ b/pkg/security/ebpf/c/link.h
@@ -106,13 +106,15 @@ int __attribute__((always_inline)) sys_link_ret(void *ctx, int retval, int dr_ty
     if (!syscall)
         return 0;
 
+    int pass_to_userspace = !syscall->discarded && is_event_enabled(EVENT_LINK);
+
     // invalidate user face inode, so no need to bump the discarder revision in the event
     if (retval >= 0) {
         // for hardlink we need to invalidate the cache as the nlink counter in now > 1
-        invalidate_inode(ctx, syscall->link.src_file.path_key.mount_id, syscall->link.src_file.path_key.ino, !is_event_enabled(EVENT_LINK));
+        invalidate_inode(ctx, syscall->link.src_file.path_key.mount_id, syscall->link.src_file.path_key.ino, !pass_to_userspace);
     }
 
-    if (!syscall->discarded && is_event_enabled(EVENT_LINK)) {
+    if (pass_to_userspace) {
         syscall->resolver.dentry = syscall->link.target_dentry;
         syscall->resolver.key = syscall->link.target_file.path_key;
         syscall->resolver.discarder_type = 0;

--- a/pkg/security/ebpf/c/link.h
+++ b/pkg/security/ebpf/c/link.h
@@ -109,10 +109,10 @@ int __attribute__((always_inline)) sys_link_ret(void *ctx, int retval, int dr_ty
     // invalidate user face inode, so no need to bump the discarder revision in the event
     if (retval >= 0) {
         // for hardlink we need to invalidate the cache as the nlink counter in now > 1
-        invalidate_inode(ctx, syscall->link.src_file.path_key.mount_id, syscall->link.src_file.path_key.ino, !is_event_enabled(EVENT_RENAME));
+        invalidate_inode(ctx, syscall->link.src_file.path_key.mount_id, syscall->link.src_file.path_key.ino, !is_event_enabled(EVENT_LINK));
     }
 
-    if (!syscall->discarded && is_event_enabled(EVENT_RENAME)) {
+    if (!syscall->discarded && is_event_enabled(EVENT_LINK)) {
         syscall->resolver.dentry = syscall->link.target_dentry;
         syscall->resolver.key = syscall->link.target_file.path_key;
         syscall->resolver.discarder_type = 0;

--- a/pkg/security/ebpf/c/link.h
+++ b/pkg/security/ebpf/c/link.h
@@ -108,7 +108,7 @@ int __attribute__((always_inline)) sys_link_ret(void *ctx, int retval, int dr_ty
 
     int pass_to_userspace = !syscall->discarded && is_event_enabled(EVENT_LINK);
 
-    // invalidate user face inode, so no need to bump the discarder revision in the event
+    // invalidate user space inode, so no need to bump the discarder revision in the event
     if (retval >= 0) {
         // for hardlink we need to invalidate the cache as the nlink counter in now > 1
         invalidate_inode(ctx, syscall->link.src_file.path_key.mount_id, syscall->link.src_file.path_key.ino, !pass_to_userspace);

--- a/pkg/security/ebpf/c/rename.h
+++ b/pkg/security/ebpf/c/rename.h
@@ -116,7 +116,7 @@ int __attribute__((always_inline)) sys_rename_ret(void *ctx, int retval, int dr_
 
     // invalidate user face inode, so no need to bump the discarder revision in the event
     if (retval >= 0) {
-        invalidate_inode(ctx, syscall->rename.target_file.path_key.mount_id, syscall->rename.target_file.path_key.ino, 1);
+        invalidate_inode(ctx, syscall->rename.target_file.path_key.mount_id, syscall->rename.target_file.path_key.ino, !is_event_enabled(EVENT_RENAME));
     }
 
     if (!syscall->discarded && is_event_enabled(EVENT_RENAME)) {

--- a/pkg/security/ebpf/c/rename.h
+++ b/pkg/security/ebpf/c/rename.h
@@ -116,7 +116,7 @@ int __attribute__((always_inline)) sys_rename_ret(void *ctx, int retval, int dr_
 
     int pass_to_userspace = !syscall->discarded && is_event_enabled(EVENT_RENAME);
 
-    // invalidate user face inode, so no need to bump the discarder revision in the event
+    // invalidate user space inode, so no need to bump the discarder revision in the event
     if (retval >= 0) {
         invalidate_inode(ctx, syscall->rename.target_file.path_key.mount_id, syscall->rename.target_file.path_key.ino, !pass_to_userspace);
     }

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -214,6 +214,18 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 		&manager.AllOf{Selectors: []manager.ProbesSelector{
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/security_inode_getattr", EBPFFuncName: "kprobe_security_inode_getattr"}},
 		}},
+
+		// Link
+		&manager.AllOf{Selectors: []manager.ProbesSelector{
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/vfs_link", EBPFFuncName: "kprobe_vfs_link"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/filename_create", EBPFFuncName: "kprobe_filename_create"}},
+		}},
+		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "link"}, EntryAndExit),
+		},
+		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
+			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "linkat"}, EntryAndExit),
+		},
 	},
 
 	// List of probes to activate to capture chmod events
@@ -263,20 +275,6 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 		},
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
 			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "lchown16"}, EntryAndExit),
-		},
-	},
-
-	// List of probes to activate to capture link events
-	"link": {
-		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/vfs_link", EBPFFuncName: "kprobe_vfs_link"}},
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/filename_create", EBPFFuncName: "kprobe_filename_create"}},
-		}},
-		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "link"}, EntryAndExit),
-		},
-		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
-			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "linkat"}, EntryAndExit),
 		},
 	},
 

--- a/pkg/security/model/model.go
+++ b/pkg/security/model/model.go
@@ -288,8 +288,6 @@ type FileFields struct {
 
 	MountID      uint32 `field:"mount_id"` // Mount ID of the file
 	Inode        uint64 `field:"inode"`    // Inode of the file
-	PathID       uint32 `field:"-"`
-	Flags        int32  `field:"-"`
 	InUpperLayer bool   `field:"in_upper_layer,ResolveFileFieldsInUpperLayer"` // Indicator of the file layer, in an OverlayFS for example
 
 	NLink  uint32 `field:"-"`

--- a/pkg/security/model/model.go
+++ b/pkg/security/model/model.go
@@ -291,6 +291,15 @@ type FileFields struct {
 	PathID       uint32 `field:"-"`
 	Flags        int32  `field:"-"`
 	InUpperLayer bool   `field:"in_upper_layer,ResolveFileFieldsInUpperLayer"` // Indicator of the file layer, in an OverlayFS for example
+
+	NLink  uint32 `field:"-"`
+	PathID uint32 `field:"-"`
+	Flags  int32  `field:"-"`
+}
+
+// HasHardLinks returns whether the file has hardlink
+func (f *FileFields) HasHardLinks() bool {
+	return f.NLink > 1
 }
 
 // GetInLowerLayer returns whether a file is in a lower layer

--- a/pkg/security/model/model.go
+++ b/pkg/security/model/model.go
@@ -286,8 +286,8 @@ type FileFields struct {
 	CTime uint64 `field:"change_time"`                       // Change time of the file
 	MTime uint64 `field:"modification_time"`                 // Modification time of the file
 
-	MountID      uint32 `field:"mount_id"` // Mount ID of the file
-	Inode        uint64 `field:"inode"`    // Inode of the file
+	MountID      uint32 `field:"mount_id"`                                     // Mount ID of the file
+	Inode        uint64 `field:"inode"`                                        // Inode of the file
 	InUpperLayer bool   `field:"in_upper_layer,ResolveFileFieldsInUpperLayer"` // Indicator of the file layer, in an OverlayFS for example
 
 	NLink  uint32 `field:"-"`

--- a/pkg/security/model/unmarshallers.go
+++ b/pkg/security/model/unmarshallers.go
@@ -229,9 +229,10 @@ func (e *FileFields) UnmarshalBinary(data []byte) (int, error) {
 
 	e.UID = ByteOrder.Uint32(data[24:28])
 	e.GID = ByteOrder.Uint32(data[28:32])
-	e.Mode = ByteOrder.Uint16(data[32:34])
+	e.NLink = ByteOrder.Uint32(data[32:36])
+	e.Mode = ByteOrder.Uint16(data[36:38])
 
-	// +6 for padding
+	// +2 for padding
 
 	timeSec := ByteOrder.Uint64(data[40:48])
 	timeNsec := ByteOrder.Uint64(data[48:56])

--- a/pkg/security/probe/dentry_resolver.go
+++ b/pkg/security/probe/dentry_resolver.go
@@ -549,16 +549,15 @@ func (dr *DentryResolver) cacheEntries(keys []PathKey, entries []PathEntry) {
 	var cacheEntry PathEntry
 
 	for i, k := range keys {
+		if i >= len(entries) {
+			break
+		}
+
 		if IsFakeInode(k.Inode) {
 			continue
 		}
 
-		if len(entries) > i {
-			cacheEntry = entries[i]
-		} else {
-			continue
-		}
-
+		cacheEntry = entries[i]
 		if len(keys) > i+1 {
 			cacheEntry.Parent = keys[i+1]
 		}

--- a/pkg/security/probe/dentry_resolver.go
+++ b/pkg/security/probe/dentry_resolver.go
@@ -404,7 +404,7 @@ func (dr *DentryResolver) ResolveFromCache(mountID uint32, inode uint64) (string
 }
 
 // ResolveFromMap resolves the path of the provided inode / mount id / path id
-func (dr *DentryResolver) ResolveFromMap(mountID uint32, inode uint64, pathID uint32) (string, error) {
+func (dr *DentryResolver) ResolveFromMap(mountID uint32, inode uint64, pathID uint32, cache bool) (string, error) {
 	var cacheKey PathKey
 	var cacheEntry *PathEntry
 	var err, resolutionErr error
@@ -419,7 +419,9 @@ func (dr *DentryResolver) ResolveFromMap(mountID uint32, inode uint64, pathID ui
 	}
 
 	depth := int64(0)
-	toAdd := make(map[PathKey]*PathEntry)
+
+	var keys []PathKey
+	var entries []PathEntry
 
 	// Fetch path recursively
 	for i := 0; i <= model.MaxPathDepth; i++ {
@@ -451,9 +453,11 @@ func (dr *DentryResolver) ResolveFromMap(mountID uint32, inode uint64, pathID ui
 		}
 
 		// do not cache fake path keys in the case of rename events
-		if !IsFakeInode(key.Inode) {
+		if !IsFakeInode(key.Inode) && cache {
 			cacheEntry = dr.getPathEntryFromPool(path.Parent, name)
-			toAdd[cacheKey] = cacheEntry
+
+			keys = append(keys, cacheKey)
+			entries = append(entries, cacheEntry)
 		}
 
 		if path.Parent.Inode == 0 {
@@ -474,11 +478,8 @@ func (dr *DentryResolver) ResolveFromMap(mountID uint32, inode uint64, pathID ui
 	}
 
 	if err == nil {
-		for k, v := range toAdd {
-			if err := dr.cacheInode(k, v); err != nil {
-				dr.pathEntryPool.Put(v)
-			}
-		}
+		dr.cacheEntries(keys, entries)
+
 		if depth > 0 {
 			atomic.AddInt64(dr.hitsCounters[metrics.PathResolutionTag][metrics.KernelMapsTag], depth)
 		}
@@ -544,12 +545,35 @@ func (dr *DentryResolver) GetNameFromERPC(mountID uint32, inode uint64, pathID u
 	return seg, nil
 }
 
+func (dr *DentryResolver) cacheEntries(keys []PathKey, entries []PathEntry) {
+	var cacheEntry PathEntry
+
+	for i, k := range keys {
+		if IsFakeInode(k.Inode) {
+			continue
+		}
+
+		if len(entries) > i {
+			cacheEntry = entries[i]
+		} else {
+			continue
+		}
+
+		if len(keys) > i+1 {
+			cacheEntry.Parent = keys[i+1]
+		}
+
+		if err := dr.cacheInode(k, cacheEntry); err != nil {
+			dr.pathEntryPool.Put(cacheEntry)
+		}
+	}
+}
+
 // ResolveFromERPC resolves the path of the provided inode / mount id / path id
-func (dr *DentryResolver) ResolveFromERPC(mountID uint32, inode uint64, pathID uint32) (string, error) {
+func (dr *DentryResolver) ResolveFromERPC(mountID uint32, inode uint64, pathID uint32, cache bool) (string, error) {
 	var filename, segment string
 	var err, resolutionErr error
 	var cacheKey PathKey
-	var cacheEntry *PathEntry
 	depth := int64(0)
 	challenge := rand.Uint32()
 
@@ -612,7 +636,7 @@ func (dr *DentryResolver) ResolveFromERPC(mountID uint32, inode uint64, pathID u
 			break
 		}
 
-		if !IsFakeInode(cacheKey.Inode) {
+		if !IsFakeInode(cacheKey.Inode) && cache {
 			keys = append(keys, cacheKey)
 
 			entry := dr.getPathEntryFromPool(PathKey{}, segment)
@@ -625,21 +649,7 @@ func (dr *DentryResolver) ResolveFromERPC(mountID uint32, inode uint64, pathID u
 	}
 
 	if resolutionErr == nil {
-		for i, k := range keys {
-			if len(entries) > i {
-				cacheEntry = entries[i]
-			} else {
-				continue
-			}
-
-			if len(keys) > i+1 {
-				cacheEntry.Parent = keys[i+1]
-			}
-
-			if err := dr.cacheInode(k, cacheEntry); err != nil {
-				dr.pathEntryPool.Put(cacheEntry)
-			}
-		}
+		dr.cacheEntries(keys, entries)
 
 		if depth > 0 {
 			atomic.AddInt64(dr.hitsCounters[metrics.PathResolutionTag][metrics.ERPCTag], depth)
@@ -652,13 +662,13 @@ func (dr *DentryResolver) ResolveFromERPC(mountID uint32, inode uint64, pathID u
 }
 
 // Resolve the pathname of a dentry, starting at the pathnameKey in the pathnames table
-func (dr *DentryResolver) Resolve(mountID uint32, inode uint64, pathID uint32) (string, error) {
+func (dr *DentryResolver) Resolve(mountID uint32, inode uint64, pathID uint32, cache bool) (string, error) {
 	path, err := dr.ResolveFromCache(mountID, inode)
 	if err != nil && dr.erpcEnabled {
-		path, err = dr.ResolveFromERPC(mountID, inode, pathID)
+		path, err = dr.ResolveFromERPC(mountID, inode, pathID, cache)
 	}
 	if err != nil && err != errTruncatedParentsERPC && dr.mapEnabled {
-		path, err = dr.ResolveFromMap(mountID, inode, pathID)
+		path, err = dr.ResolveFromMap(mountID, inode, pathID, cache)
 	}
 	return path, err
 }

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -128,7 +128,7 @@ func (ev *Event) ResolveXAttrNamespace(e *model.SetXAttrEvent) string {
 
 // SetMountPoint set the mount point information
 func (ev *Event) SetMountPoint(e *model.MountEvent) {
-	e.MountPointStr, e.MountPointPathResolutionError = ev.resolvers.DentryResolver.Resolve(e.ParentMountID, e.ParentInode, 0)
+	e.MountPointStr, e.MountPointPathResolutionError = ev.resolvers.DentryResolver.Resolve(e.ParentMountID, e.ParentInode, 0, true)
 }
 
 // ResolveMountPoint resolves the mountpoint to a full path
@@ -141,7 +141,7 @@ func (ev *Event) ResolveMountPoint(e *model.MountEvent) string {
 
 // SetMountRoot set the mount point information
 func (ev *Event) SetMountRoot(e *model.MountEvent) {
-	e.RootStr, e.RootPathResolutionError = ev.resolvers.DentryResolver.Resolve(e.RootMountID, e.RootInode, 0)
+	e.RootStr, e.RootPathResolutionError = ev.resolvers.DentryResolver.Resolve(e.RootMountID, e.RootInode, 0, true)
 }
 
 // ResolveMountRoot resolves the mountpoint to a full path

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -441,6 +441,12 @@ func (p *Probe) handleEvent(CPU uint64, data []byte) {
 			log.Errorf("failed to decode link event: %s (offset %d, len %d)", err, offset, dataLen)
 			return
 		}
+
+		// need to invalidate as now nlink > 1
+		if event.Link.Retval >= 0 {
+			// defer it do ensure that it will be done after the dispatch that could re-add it
+			defer p.invalidateDentry(event.Link.Source.MountID, event.Link.Source.Inode)
+		}
 	case model.FileSetXAttrEventType:
 		if _, err = event.SetXAttr.UnmarshalBinary(data[offset:]); err != nil {
 			log.Errorf("failed to decode setxattr event: %s (offset %d, len %d)", err, offset, dataLen)

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -79,7 +79,7 @@ func (r *Resolvers) resolveBasename(e *model.FileFields) string {
 
 // resolveFileFieldsPath resolves the inode to a full path
 func (r *Resolvers) resolveFileFieldsPath(e *model.FileFields) (string, error) {
-	pathStr, err := r.DentryResolver.Resolve(e.MountID, e.Inode, e.PathID)
+	pathStr, err := r.DentryResolver.Resolve(e.MountID, e.Inode, e.PathID, !e.HasHardLinks())
 	if err != nil {
 		return pathStr, err
 	}

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -242,7 +242,7 @@ func newFileSerializer(fe *model.FileEvent, e *Event, forceInode ...uint64) *Fil
 		Inode:               getUint64Pointer(&inode),
 		MountID:             getUint32Pointer(&fe.MountID),
 		Filesystem:          e.ResolveFileFilesystem(fe),
-		Mode:                getUint32Pointer(&mode),
+		Mode:                getUint32Pointer(&mode), // only used by open events
 		UID:                 fe.UID,
 		GID:                 fe.GID,
 		User:                e.ResolveFileFieldsUser(&fe.FileFields),

--- a/pkg/security/tests/hardlink_test.go
+++ b/pkg/security/tests/hardlink_test.go
@@ -1,0 +1,105 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build functionaltests
+
+package tests
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+
+	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/DataDog/datadog-agent/pkg/security/rules"
+)
+
+func TestHardLink(t *testing.T) {
+	executable := which("touch")
+
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "test_rule_orig",
+			Expression: fmt.Sprintf(`exec.file.path == "%s"`, executable),
+		},
+		{
+			ID:         "test_rule_link",
+			Expression: `exec.file.path == "{{.Root}}/mytouch"`,
+		},
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	t.Run("hardlink-creation", ifSyscallSupported("SYS_LINK", func(t *testing.T, syscallNB uintptr) {
+		err = test.GetSignal(t, func() error {
+			cmd := exec.Command(executable, "/tmp/test1")
+			return cmd.Run()
+		}, func(event *sprobe.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_rule_orig")
+		})
+		if err != nil {
+			t.Error(err)
+		}
+
+		testNewExecutable, _, err := test.Path("mytouch")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(testNewExecutable)
+
+		err = os.Link(executable, testNewExecutable)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = test.GetSignal(t, func() error {
+			cmd := exec.Command(testNewExecutable, "/tmp/test2")
+			return cmd.Run()
+		}, func(event *sprobe.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_rule_link")
+		})
+		if err != nil {
+			t.Error(err)
+		}
+	}))
+
+	t.Run("hardlink-created", ifSyscallSupported("SYS_LINK", func(t *testing.T, syscallNB uintptr) {
+		testNewExecutable, _, err := test.Path("mytouch")
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(testNewExecutable)
+
+		err = os.Link(executable, testNewExecutable)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		err = test.GetSignal(t, func() error {
+			cmd := exec.Command(executable, "/tmp/test1")
+			return cmd.Run()
+		}, func(event *sprobe.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_rule_orig")
+		})
+		if err != nil {
+			t.Error(err)
+		}
+
+		err = test.GetSignal(t, func() error {
+			cmd := exec.Command(testNewExecutable, "/tmp/test2")
+			return cmd.Run()
+		}, func(event *sprobe.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_rule_link")
+		})
+		if err != nil {
+			t.Error(err)
+		}
+	}))
+}

--- a/pkg/security/tests/hardlink_test.go
+++ b/pkg/security/tests/hardlink_test.go
@@ -8,7 +8,6 @@
 package tests
 
 import (
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -44,13 +43,7 @@ func runHardlinkTests(t *testing.T, opts testOpts) {
 	}
 	defer os.Remove(testOrigExecutable)
 
-	input, err := ioutil.ReadFile(executable)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	err = ioutil.WriteFile(testOrigExecutable, input, 0755)
-	if err != nil {
+	if err := copyFile(executable, testOrigExecutable, 0755); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -121,18 +121,6 @@ func TestProcessContext(t *testing.T) {
 	}
 	defer test.Close()
 
-	which := func(name string) string {
-		executable := "/usr/bin/" + name
-		if resolved, err := os.Readlink(executable); err == nil {
-			executable = resolved
-		} else {
-			if os.IsNotExist(err) {
-				executable = "/bin/" + name
-			}
-		}
-		return executable
-	}
-
 	t.Run("exec-time", func(t *testing.T) {
 		testFile, _, err := test.Path("test-exec-time")
 		if err != nil {

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -9,7 +9,6 @@ package tests
 
 import (
 	"fmt"
-	"io"
 	"math"
 	"os"
 	"os/exec"
@@ -522,29 +521,6 @@ func TestProcessExecCTime(t *testing.T) {
 		}
 	}
 
-	copy := func(src string, dst string) error {
-		in, err := os.Open(src)
-		if err != nil {
-			return err
-		}
-		defer in.Close()
-
-		out, err := os.Create(dst)
-		if err != nil {
-			return err
-		}
-		defer out.Close()
-
-		if _, err = io.Copy(out, in); err != nil {
-			return err
-		}
-		if err := os.Chmod(dst, 0o755); err != nil {
-			return err
-		}
-
-		return nil
-	}
-
 	ruleDef := &rules.RuleDefinition{
 		ID:         "test_exec_ctime",
 		Expression: "exec.file.change_time < 5s",
@@ -561,7 +537,7 @@ func TestProcessExecCTime(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		copy(executable, testFile)
+		copyFile(executable, testFile, 0755)
 
 		cmd := exec.Command(testFile, "/tmp/test")
 		return cmd.Run()

--- a/pkg/security/tests/setup_test.go
+++ b/pkg/security/tests/setup_test.go
@@ -245,6 +245,18 @@ func getInode(t *testing.T, path string) uint64 {
 	return stats.Ino
 }
 
+func which(name string) string {
+	executable := "/usr/bin/" + name
+	if resolved, err := os.Readlink(executable); err == nil {
+		executable = resolved
+	} else {
+		if os.IsNotExist(err) {
+			executable = "/bin/" + name
+		}
+	}
+	return executable
+}
+
 func assertMode(t *testing.T, actualMode, expectedMode uint32, msgAndArgs ...interface{}) {
 	t.Helper()
 	if len(msgAndArgs) == 0 {

--- a/pkg/security/tests/setup_test.go
+++ b/pkg/security/tests/setup_test.go
@@ -13,6 +13,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
+	"io/fs"
 	"io/ioutil"
 	"net"
 	"os"
@@ -255,6 +256,20 @@ func which(name string) string {
 		}
 	}
 	return executable
+}
+
+func copyFile(src string, dst string, mode fs.FileMode) error {
+	input, err := ioutil.ReadFile(src)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(dst, input, mode)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 func assertMode(t *testing.T, actualMode, expectedMode uint32, msgAndArgs ...interface{}) {

--- a/pkg/security/tests/stress_test.go
+++ b/pkg/security/tests/stress_test.go
@@ -405,7 +405,7 @@ func BenchmarkERPCDentryResolutionPath(b *testing.B) {
 	if err := resolver.Start(test.probe); err != nil {
 		b.Fatal(err)
 	}
-	f, err := resolver.ResolveFromERPC(mountID, inode, pathID)
+	f, err := resolver.ResolveFromERPC(mountID, inode, pathID, true)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -413,7 +413,7 @@ func BenchmarkERPCDentryResolutionPath(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		f, err := resolver.ResolveFromERPC(mountID, inode, pathID)
+		f, err := resolver.ResolveFromERPC(mountID, inode, pathID, true)
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -537,7 +537,7 @@ func BenchmarkMapDentryResolutionPath(b *testing.B) {
 	if err := resolver.Start(test.probe); err != nil {
 		b.Fatal(err)
 	}
-	f, err := resolver.ResolveFromMap(mountID, inode, pathID)
+	f, err := resolver.ResolveFromMap(mountID, inode, pathID, true)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -545,7 +545,7 @@ func BenchmarkMapDentryResolutionPath(b *testing.B) {
 
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		f, err := resolver.ResolveFromMap(mountID, inode, pathID)
+		f, err := resolver.ResolveFromMap(mountID, inode, pathID, true)
 		if err != nil {
 			b.Fatal(err)
 		}


### PR DESCRIPTION
### What does this PR do?

Do not cache path for file with hardlink so that the path resolution works with multiple path to a same file, meaning same inode. With this fix, busybox executables are now correctly resolved.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
