### PR TITLE
[corechecks/snmp] Enable collect device metadata by default

### DIFF
--- a/pkg/collector/corechecks/snmp/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config.go
@@ -240,6 +240,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 
 	// Set defaults before unmarshalling
 	instance.UseGlobalMetrics = true
+	initConfig.CollectDeviceMetadata = true
 
 	err := yaml.Unmarshal(rawInitConfig, &initConfig)
 	if err != nil {

--- a/pkg/collector/corechecks/snmp/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config_test.go
@@ -953,7 +953,7 @@ oid_batch_size: 10
 `)
 	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig)
 	assert.Nil(t, err)
-	assert.Equal(t, false, config.CollectDeviceMetadata)
+	assert.Equal(t, true, config.CollectDeviceMetadata)
 
 	// language=yaml
 	rawInstanceConfig = []byte(`

--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck_test.go
@@ -46,6 +46,7 @@ profiles:
 	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	sender.On("MonotonicCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	sender.On("ServiceCheck", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return()
 	sender.On("Commit").Return()
 
 	deviceCk.SetSender(report.NewMetricSender(sender))
@@ -60,95 +61,184 @@ profiles:
 		},
 	}
 
-	packet := gosnmp.SnmpPacket{
-		Variables: []gosnmp.SnmpPDU{
-			{
-				Name:  "1.3.6.1.2.1.1.3.0",
-				Type:  gosnmp.TimeTicks,
-				Value: 20,
-			},
-			{
-				Name:  "1.3.6.1.2.1.1.5.0",
-				Type:  gosnmp.OctetString,
-				Value: []byte("foo_sys_name"),
-			},
-			{
-				Name:  "1.3.6.1.4.1.3375.2.1.1.2.1.44.0",
-				Type:  gosnmp.Integer,
-				Value: 30,
+	packets := []gosnmp.SnmpPacket{
+		{
+			Variables: []gosnmp.SnmpPDU{
+				{
+					Name:  "1.3.6.1.2.1.1.5.0",
+					Type:  gosnmp.OctetString,
+					Value: []byte("foo_sys_name"),
+				},
+				{
+					Name:  "1.3.6.1.2.1.1.1.0",
+					Type:  gosnmp.OctetString,
+					Value: []byte("my_desc"),
+				},
+				{
+					Name:  "1.3.6.1.2.1.1.2.0",
+					Type:  gosnmp.ObjectIdentifier,
+					Value: "1.2.3.4",
+				},
+				{
+					Name:  "1.3.6.1.2.1.1.3.0",
+					Type:  gosnmp.TimeTicks,
+					Value: 20,
+				},
+				{
+					Name:  "1.3.6.1.4.1.3375.2.1.1.2.1.44.0",
+					Type:  gosnmp.Integer,
+					Value: 30,
+				},
 			},
 		},
+		{},
 	}
 
-	bulkPacket := gosnmp.SnmpPacket{
-		Variables: []gosnmp.SnmpPDU{
-			{
-				Name:  "1.3.6.1.2.1.2.2.1.13.1",
-				Type:  gosnmp.Integer,
-				Value: 131,
-			},
-			{
-				Name:  "1.3.6.1.2.1.2.2.1.14.1",
-				Type:  gosnmp.Integer,
-				Value: 141,
-			},
-			{
-				Name:  "1.3.6.1.2.1.31.1.1.1.1.1",
-				Type:  gosnmp.OctetString,
-				Value: []byte("nameRow1"),
-			},
-			{
-				Name:  "1.3.6.1.2.1.31.1.1.1.18.1",
-				Type:  gosnmp.OctetString,
-				Value: []byte("descRow1"),
-			},
-			{
-				Name:  "1.3.6.1.2.1.2.2.1.13.2",
-				Type:  gosnmp.Integer,
-				Value: 132,
-			},
-			{
-				Name:  "1.3.6.1.2.1.2.2.1.14.2",
-				Type:  gosnmp.Integer,
-				Value: 142,
-			},
-			{
-				Name:  "1.3.6.1.2.1.31.1.1.1.1.2",
-				Type:  gosnmp.OctetString,
-				Value: []byte("nameRow2"),
-			},
-			{
-				Name:  "1.3.6.1.2.1.31.1.1.1.18.2",
-				Type:  gosnmp.OctetString,
-				Value: []byte("descRow2"),
-			},
-			{
-				Name:  "9", // exit table
-				Type:  gosnmp.Integer,
-				Value: 999,
-			},
-			{
-				Name:  "9", // exit table
-				Type:  gosnmp.Integer,
-				Value: 999,
-			},
-			{
-				Name:  "9", // exit table
-				Type:  gosnmp.Integer,
-				Value: 999,
-			},
-			{
-				Name:  "9", // exit table
-				Type:  gosnmp.Integer,
-				Value: 999,
+	bulkPackets := []gosnmp.SnmpPacket{
+		{
+			Variables: []gosnmp.SnmpPDU{
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.13.1",
+					Type:  gosnmp.Integer,
+					Value: 131,
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.14.1",
+					Type:  gosnmp.Integer,
+					Value: 141,
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.2.1",
+					Type:  gosnmp.OctetString,
+					Value: []byte("ifDescRow1"),
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.6.1",
+					Type:  gosnmp.OctetString,
+					Value: []byte("00:00:00:00:00:01"),
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.7.1",
+					Type:  gosnmp.Integer,
+					Value: 1,
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.13.2",
+					Type:  gosnmp.Integer,
+					Value: 132,
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.14.2",
+					Type:  gosnmp.Integer,
+					Value: 142,
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.2.2",
+					Type:  gosnmp.OctetString,
+					Value: []byte("ifDescRow2"),
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.6.2",
+					Type:  gosnmp.OctetString,
+					Value: []byte("00:00:00:00:00:02"),
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.7.2",
+					Type:  gosnmp.Integer,
+					Value: 1,
+				},
+				{
+					Name:  "9", // exit table
+					Type:  gosnmp.Integer,
+					Value: 999,
+				},
+				{
+					Name:  "9", // exit table
+					Type:  gosnmp.Integer,
+					Value: 999,
+				},
+				{
+					Name:  "9", // exit table
+					Type:  gosnmp.Integer,
+					Value: 999,
+				},
+				{
+					Name:  "9", // exit table
+					Type:  gosnmp.Integer,
+					Value: 999,
+				},
+				{
+					Name:  "9", // exit table
+					Type:  gosnmp.Integer,
+					Value: 999,
+				}},
+		},
+		{
+			Variables: []gosnmp.SnmpPDU{
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.8.1",
+					Type:  gosnmp.Integer,
+					Value: 1,
+				},
+				{
+					Name:  "1.3.6.1.2.1.31.1.1.1.1.1",
+					Type:  gosnmp.OctetString,
+					Value: []byte("nameRow1"),
+				},
+				{
+					Name:  "1.3.6.1.2.1.31.1.1.1.18.1",
+					Type:  gosnmp.OctetString,
+					Value: []byte("descRow1"),
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.8.2",
+					Type:  gosnmp.Integer,
+					Value: 1,
+				},
+				{
+					Name:  "1.3.6.1.2.1.31.1.1.1.1.2",
+					Type:  gosnmp.OctetString,
+					Value: []byte("nameRow2"),
+				},
+				{
+					Name:  "1.3.6.1.2.1.31.1.1.1.18.2",
+					Type:  gosnmp.OctetString,
+					Value: []byte("descRow2"),
+				},
+				{
+					Name:  "9", // exit table
+					Type:  gosnmp.Integer,
+					Value: 999,
+				},
+				{
+					Name:  "9", // exit table
+					Type:  gosnmp.Integer,
+					Value: 999,
+				},
+				{
+					Name:  "9", // exit table
+					Type:  gosnmp.Integer,
+					Value: 999,
+				},
 			},
 		},
 	}
 
 	sess.On("GetNext", []string{"1.3"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&sysObjectIDPacket, nil)
-	sess.On("Get", []string{"1.3.6.1.2.1.1.3.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.999", "1.2.3.4.5", "1.3.6.1.2.1.1.5.0"}).Return(&packet, nil)
-	sess.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.13", "1.3.6.1.2.1.2.2.1.14", "1.3.6.1.2.1.31.1.1.1.1", "1.3.6.1.2.1.31.1.1.1.18"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkPacket, nil)
+	sess.On("Get", []string{
+		"1.3.6.1.2.1.1.5.0",
+		"1.3.6.1.2.1.1.1.0",
+		"1.3.6.1.2.1.1.2.0",
+		"1.3.6.1.2.1.1.3.0",
+		"1.3.6.1.4.1.3375.2.1.1.2.1.44.0",
+	}).Return(&packets[0], nil)
+	sess.On("Get", []string{
+		"1.3.6.1.4.1.3375.2.1.1.2.1.44.999",
+		"1.2.3.4.5",
+	}).Return(&packets[1], nil)
+	sess.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.13", "1.3.6.1.2.1.2.2.1.14", "1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.6", "1.3.6.1.2.1.2.2.1.7"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkPackets[0], nil)
+	sess.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.8", "1.3.6.1.2.1.31.1.1.1.1", "1.3.6.1.2.1.31.1.1.1.18"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkPackets[1], nil)
 
 	err = deviceCk.Run(time.Now())
 	assert.Nil(t, err)

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -87,6 +87,8 @@ tags:
 	sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	sender.On("MonotonicCount", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
 	sender.On("ServiceCheck", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
+	sender.On("EventPlatformEvent", mock.Anything, mock.Anything).Return()
+
 	sender.On("Commit").Return()
 
 	packet := gosnmp.SnmpPacket{
@@ -114,57 +116,141 @@ tags:
 		},
 	}
 
-	bulkPacket := gosnmp.SnmpPacket{
-		Variables: []gosnmp.SnmpPDU{
-			{
-				Name:  "1.3.6.1.2.1.2.2.1.14.1",
-				Type:  gosnmp.Integer,
-				Value: 141,
-			},
-			{
-				Name:  "1.3.6.1.2.1.2.2.1.2.1",
-				Type:  gosnmp.OctetString,
-				Value: []byte("desc1"),
-			},
-			{
-				Name:  "1.3.6.1.2.1.2.2.1.20.1",
-				Type:  gosnmp.Integer,
-				Value: 201,
-			},
-			{
-				Name:  "1.3.6.1.2.1.2.2.1.14.2",
-				Type:  gosnmp.Integer,
-				Value: 142,
-			},
-			{
-				Name:  "1.3.6.1.2.1.2.2.1.2.2",
-				Type:  gosnmp.OctetString,
-				Value: []byte("desc2"),
-			},
-			{
-				Name:  "1.3.6.1.2.1.2.2.1.20.2",
-				Type:  gosnmp.Integer,
-				Value: 202,
+	bulkPackets := []gosnmp.SnmpPacket{
+		{
+			Variables: []gosnmp.SnmpPDU{
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.14.1",
+					Type:  gosnmp.Integer,
+					Value: 141,
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.2.1",
+					Type:  gosnmp.OctetString,
+					Value: []byte("desc1"),
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.20.1",
+					Type:  gosnmp.Integer,
+					Value: 201,
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.6.1",
+					Type:  gosnmp.OctetString,
+					Value: []byte("00:00:00:00:00:01"),
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.7.1",
+					Type:  gosnmp.Integer,
+					Value: 1,
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.14.2",
+					Type:  gosnmp.Integer,
+					Value: 142,
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.2.2",
+					Type:  gosnmp.OctetString,
+					Value: []byte("desc2"),
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.20.2",
+					Type:  gosnmp.Integer,
+					Value: 202,
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.6.2",
+					Type:  gosnmp.OctetString,
+					Value: []byte("00:00:00:00:00:02"),
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.7.2",
+					Type:  gosnmp.Integer,
+					Value: 3,
+				},
 			},
 		},
-	}
-
-	bulkPacket2 := gosnmp.SnmpPacket{
-		Variables: []gosnmp.SnmpPDU{
-			{
-				Name:  "1.3.6.1.2.1.2.2.1.15.1",
-				Type:  gosnmp.Integer,
-				Value: 141,
+		{
+			Variables: []gosnmp.SnmpPDU{
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.15.1",
+					Type:  gosnmp.Integer,
+					Value: 141,
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.3.2",
+					Type:  gosnmp.OctetString,
+					Value: []byte("none"),
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.21.1",
+					Type:  gosnmp.Integer,
+					Value: 201,
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.7.2",
+					Type:  gosnmp.Integer,
+					Value: 3,
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.8.2",
+					Type:  gosnmp.Integer,
+					Value: 1,
+				},
 			},
-			{
-				Name:  "1.3.6.1.2.1.2.2.1.3.2",
-				Type:  gosnmp.OctetString,
-				Value: []byte("none"),
+		},
+		{
+			Variables: []gosnmp.SnmpPDU{
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.8.1",
+					Type:  gosnmp.Integer,
+					Value: 1,
+				},
+				{
+					Name:  "1.3.6.1.2.1.31.1.1.1.1.1",
+					Type:  gosnmp.OctetString,
+					Value: []byte("nameRow1"),
+				},
+				{
+					Name:  "1.3.6.1.2.1.31.1.1.1.18.1",
+					Type:  gosnmp.OctetString,
+					Value: []byte("descRow1"),
+				},
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.8.2",
+					Type:  gosnmp.Integer,
+					Value: 1,
+				},
+				{
+					Name:  "1.3.6.1.2.1.31.1.1.1.1.2",
+					Type:  gosnmp.OctetString,
+					Value: []byte("nameRow2"),
+				},
+				{
+					Name:  "1.3.6.1.2.1.31.1.1.1.18.2",
+					Type:  gosnmp.OctetString,
+					Value: []byte("descRow2"),
+				},
 			},
-			{
-				Name:  "1.3.6.1.2.1.2.2.1.21.1",
-				Type:  gosnmp.Integer,
-				Value: 201,
+		},
+		{
+			Variables: []gosnmp.SnmpPDU{
+				{
+					Name:  "1.3.6.1.2.1.2.2.1.9.2",
+					Type:  gosnmp.TimeTicks,
+					Value: 123,
+				},
+				{
+					Name:  "1.3.6.1.2.1.31.1.1.1.2.2",
+					Type:  gosnmp.Integer,
+					Value: 596,
+				},
+				{
+					Name:  "1.3.6.1.2.1.31.1.1.1.19.2",
+					Type:  gosnmp.TimeTicks,
+					Value: 707,
+				},
 			},
 		},
 	}
@@ -172,8 +258,10 @@ tags:
 	sess.On("GetNext", []string{"1.3"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", mock.Anything).Return(&packet, nil)
 	sess.On("Get", mock.Anything).Return(&packet, nil)
-	sess.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.14", "1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.20"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkPacket, nil)
-	sess.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.14.2", "1.3.6.1.2.1.2.2.1.2.2", "1.3.6.1.2.1.2.2.1.20.2"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkPacket2, nil)
+	sess.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.14", "1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.20", "1.3.6.1.2.1.2.2.1.6", "1.3.6.1.2.1.2.2.1.7"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkPackets[0], nil)
+	sess.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.14.2", "1.3.6.1.2.1.2.2.1.2.2", "1.3.6.1.2.1.2.2.1.20.2", "1.3.6.1.2.1.2.2.1.6.2", "1.3.6.1.2.1.2.2.1.7.2"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkPackets[1], nil)
+	sess.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.8", "1.3.6.1.2.1.31.1.1.1.1", "1.3.6.1.2.1.31.1.1.1.18"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkPackets[2], nil)
+	sess.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.8.2", "1.3.6.1.2.1.31.1.1.1.1.2", "1.3.6.1.2.1.31.1.1.1.18.2"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkPackets[3], nil)
 
 	err = chk.Run()
 	assert.Nil(t, err)
@@ -208,6 +296,7 @@ func TestSupportedMetricTypes(t *testing.T) {
 	chk := Check{}
 	// language=yaml
 	rawInstanceConfig := []byte(`
+collect_device_metadata: false
 ip_address: 1.2.3.4
 community_string: public
 metrics:
@@ -582,6 +671,7 @@ func TestServiceCheckFailures(t *testing.T) {
 
 	// language=yaml
 	rawInstanceConfig := []byte(`
+collect_device_metadata: false
 ip_address: 1.2.3.4
 community_string: public
 `)
@@ -810,6 +900,7 @@ func TestCheck_Run(t *testing.T) {
 
 			// language=yaml
 			rawInstanceConfig := []byte(`
+collect_device_metadata: false
 ip_address: 1.2.3.4
 community_string: public
 `)
@@ -869,6 +960,7 @@ func TestCheck_Run_sessionCloseError(t *testing.T) {
 
 	// language=yaml
 	rawInstanceConfig := []byte(`
+collect_device_metadata: false
 ip_address: 1.2.3.4
 community_string: public
 metrics:
@@ -1547,6 +1639,7 @@ func TestDiscovery_CheckError(t *testing.T) {
 
 	// language=yaml
 	rawInstanceConfig := []byte(`
+collect_device_metadata: false
 network_address: 10.10.0.0/30
 community_string: public
 metrics:

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -96,7 +96,8 @@ func NewListenerConfig() (ListenerConfig, error) {
 			return newData, nil
 		},
 	)
-
+	// Set defaults before unmarshalling
+	snmpConfig.CollectDeviceMetadata = true
 	if err := coreconfig.Datadog.UnmarshalKey("snmp_listener", &snmpConfig, opt); err != nil {
 		return snmpConfig, err
 	}

--- a/pkg/snmp/snmp_test.go
+++ b/pkg/snmp/snmp_test.go
@@ -6,9 +6,10 @@
 package snmp
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"strings"
 	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
 
 	"github.com/gosnmp/gosnmp"
 	"github.com/stretchr/testify/assert"
@@ -65,7 +66,54 @@ func TestBuildSNMPParams(t *testing.T) {
 
 func TestNewListenerConfig(t *testing.T) {
 	config.Datadog.SetConfigType("yaml")
+
+	// default collect_device_metadata should be true
 	err := config.Datadog.ReadConfig(strings.NewReader(`
+snmp_listener:
+  configs:
+   - network: 127.0.0.1/30
+   - network: 127.0.0.2/30
+     collect_device_metadata: true
+   - network: 127.0.0.3/30
+     collect_device_metadata: false
+`))
+	assert.NoError(t, err)
+
+	conf, err := NewListenerConfig()
+	assert.NoError(t, err)
+
+	assert.Equal(t, "127.0.0.1/30", conf.Configs[0].Network)
+	assert.Equal(t, true, conf.Configs[0].CollectDeviceMetadata)
+	assert.Equal(t, "127.0.0.2/30", conf.Configs[1].Network)
+	assert.Equal(t, true, conf.Configs[1].CollectDeviceMetadata)
+	assert.Equal(t, "127.0.0.3/30", conf.Configs[2].Network)
+	assert.Equal(t, false, conf.Configs[2].CollectDeviceMetadata)
+
+	// collect_device_metadata: false
+	err = config.Datadog.ReadConfig(strings.NewReader(`
+snmp_listener:
+  collect_device_metadata: false
+  configs:
+   - network: 127.0.0.1/30
+   - network: 127.0.0.2/30
+     collect_device_metadata: true
+   - network: 127.0.0.3/30
+     collect_device_metadata: false
+`))
+	assert.NoError(t, err)
+
+	conf, err = NewListenerConfig()
+	assert.NoError(t, err)
+
+	assert.Equal(t, "127.0.0.1/30", conf.Configs[0].Network)
+	assert.Equal(t, false, conf.Configs[0].CollectDeviceMetadata)
+	assert.Equal(t, "127.0.0.2/30", conf.Configs[1].Network)
+	assert.Equal(t, true, conf.Configs[1].CollectDeviceMetadata)
+	assert.Equal(t, "127.0.0.3/30", conf.Configs[2].Network)
+	assert.Equal(t, false, conf.Configs[2].CollectDeviceMetadata)
+
+	// collect_device_metadata: true
+	err = config.Datadog.ReadConfig(strings.NewReader(`
 snmp_listener:
   collect_device_metadata: true
   configs:
@@ -77,7 +125,7 @@ snmp_listener:
 `))
 	assert.NoError(t, err)
 
-	conf, err := NewListenerConfig()
+	conf, err = NewListenerConfig()
 	assert.NoError(t, err)
 
 	assert.Equal(t, "127.0.0.1/30", conf.Configs[0].Network)

--- a/releasenotes/notes/snmp_enable_ndm_by_default-0ed93f5fe55c0af5.yaml
+++ b/releasenotes/notes/snmp_enable_ndm_by_default-0ed93f5fe55c0af5.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Enable SNMP device metadata collection by default


### PR DESCRIPTION
### What does this PR do?

Enable snmp metadata collection by default. Orgs will still need to opt in to enable the product. 

### Motivation

Turn on metadata submission by default.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

* Configure core check without explicit `collect_device_metadata`
* Verify NDM receives metadata

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
