### PR TITLE
DOCS-2215 Add @env variables to datadog.yaml

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1542,6 +1542,7 @@ api_key:
 {{- if .Metadata }}
 
 ## @param metadata_providers - list of custom object - optional
+## @env DD_METADATA_PROVIDERS - list of custom object - optional
 ## Metadata providers, add or remove from the list to enable or disable collection.
 ## Intervals are expressed in seconds. You can also set a provider's interval to 0
 ## to disable it.
@@ -1558,6 +1559,7 @@ api_key:
 #######################
 
 ## @param jmx_custom_jars - list of strings - optional
+## @env DD_JMX_CUSTOM_JARS - space separated list of strings - optional
 ## If you only run Autodiscovery tests, jmxfetch might fail to pick up custom_jar_paths
 ## set in the check templates. If that is the case, force custom jars here.
 #
@@ -1565,6 +1567,7 @@ api_key:
 #   - /jmx-jars/jboss-cli-client.jar
 
 ## @param jmx_use_cgroup_memory_limit - boolean - optional - default: false
+## @env DD_JMX_USE_CGROUP_MEMORY_LIMIT - boolean - optional - default: false
 ## When running in a memory cgroup, openjdk 8u131 and higher can automatically adjust
 ## its heap memory usage in accordance to the cgroup/container's memory limit.
 ## The Agent set a Xmx of 200MB if none is configured.
@@ -1574,6 +1577,7 @@ api_key:
 # jmx_use_cgroup_memory_limit: false
 
 ## @param jmx_use_container_support - boolean - optional - default: false
+## @env DD_JMX_USE_CONTAINER_SUPPORT - boolean - optional - default: false
 ## When running in a container, openjdk 10 and higher can automatically detect
 ## container specific configuration instead of querying the operating system
 ## to adjust resources allotted to the JVM.
@@ -1588,21 +1592,25 @@ api_key:
 # jmx_log_file: <JMXFETCH_LOG_FILE_PATH>
 
 ## @param jmx_max_restarts - integer - optional - default: 3
+## @env DD_JMX_MAX_RESTARTS - integer - optional - default: 3
 ## Number of JMX restarts allowed in the restart-interval before giving up.
 #
 # jmx_max_restarts: 3
 
 ## @param jmx_restart_interval - integer - optional - default: 5
+## @env DD_JMX_RESTART_INTERVAL - integer - optional - default: 5
 ## Duration of the restart interval in seconds.
 #
 # jmx_restart_interval: 5
 
 ## @param jmx_check_period - integer - optional - default: 15000
+## @env DD_JMX_CHECK_PERIOD - integer - optional - default: 15000
 ## Duration of the period for check collections in milliseconds.
 #
 # jmx_check_period: 15000
 
 ## @param jmx_thread_pool_size - integer - optional - default: 3
+## @env DD_JMX_THREAD_POOL_SIZE - integer - optional - default: 3
 ## JMXFetch collects multiples instances concurrently. Defines the maximum level of concurrency:
 ##   * Higher concurrency increases CPU utilization during metric collection.
 ##   * Lower concurrency results in lower CPU usage but may increase the total collection time.
@@ -1611,11 +1619,13 @@ api_key:
 # jmx_thread_pool_size: 3
 
 ## @param jmx_collection_timeout - integer - optional - default: 60
+## @env DD_JMX_COLLECTION_TIMEOUT - integer - optional - default: 60
 ## Defines the maximum waiting period in seconds before timing up on metric collection.
 #
 # jmx_collection_timeout: 60
 
 ## @param jmx_reconnection_thread_pool_size - integer - optional - default: 3
+## @env DD_JMX_RECONNECTION_THREAD_POOL_SIZE - integer - optional - default: 3
 ## JMXFetch reconnects to multiples instances concurrently. Defines the maximum level of concurrency:
 ##   * Higher concurrency increases CPU utilization during reconnection.
 ##   * Lower concurrency results in lower CPU usage but may increase the total reconnection time
@@ -1624,6 +1634,7 @@ api_key:
 # jmx_reconnection_thread_pool_size: 3
 
 ## @param jmx_reconnection_timeout - integer - optional - default: 60
+## @env DD_JMX_RECONNECTION_TIMEOUT - integer - optional - default: 60
 ## Determines the maximum waiting period in seconds before timing up on instance reconnection.
 #
 # jmx_reconnection_timeout: 60


### PR DESCRIPTION
### What does this PR do?

- Add @env variables to datadog.yaml:

```
DD_JMX_CHECK_PERIOD
DD_JMX_COLLECTION_TIMEOUT
DD_JMX_CUSTOM_JARS
DD_JMX_MAX_RESTARTS
DD_JMX_RECONNECTION_THREAD_POOL_SIZE
DD_JMX_RECONNECTION_TIMEOUT
DD_JMX_RESTART_INTERVAL
DD_JMX_THREAD_POOL_SIZE
DD_JMX_USE_CGROUP_MEMORY_LIMIT
DD_JMX_USE_CONTAINER_SUPPORT
DD_METADATA_PROVIDERS
```
- Update a few docs links

### Motivation

- Documentation OKR
- [RFC](https://github.com/DataDog/architecture/blob/master/rfcs/agent-env-var-docs/rfc.md)

### Additional Notes

Variables will be added in small batches.

### Describe how to test your changes

N/A

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
