### PR TITLE
Deploy PDBs to staging using bash instead of powershell

### DIFF
--- a/.gitlab/deploy_6/windows.yml
+++ b/.gitlab/deploy_6/windows.yml
@@ -9,10 +9,16 @@ deploy_staging_windows_master-a6:
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
-    - for pkg in "datadog-agent-6*.msi" "datadog-agent-6*.debug.zip" "datadog-agent-6.*.wixpdb" "customaction-6*.pdb"
-      do
-        $S3_CP_CMD --recursive --exclude "*" --include "$pkg" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/master/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
-      done
+    - $S3_CP_CMD
+      --recursive
+      --exclude "*"
+      --include "datadog-agent-6*.msi"
+      --include "datadog-agent-6*.debug.zip"
+      --include "datadog-agent-6.*.wixpdb"
+      --include "customaction-6*.pdb"
+      $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/master/
+      --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+      full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 deploy_staging_windows_master-latest-a6:
   rules:
@@ -24,7 +30,11 @@ deploy_staging_windows_master-latest-a6:
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
-    - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-agent-6*-x86_64.msi "s3://$WINDOWS_BUILDS_S3_BUCKET/master/datadog-agent-6-latest.amd64.msi" --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+    - $S3_CP_CMD
+      $OMNIBUS_PACKAGE_DIR/datadog-agent-6*-x86_64.msi
+      "s3://$WINDOWS_BUILDS_S3_BUCKET/master/datadog-agent-6-latest.amd64.msi"
+      --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+      full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 deploy_staging_windows_tags-a6:
   rules:
@@ -36,7 +46,14 @@ deploy_staging_windows_tags-a6:
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
-    - for pkg in "datadog-agent-6*.msi", "datadog-agent-6*.debug.zip", "datadog-agent-6*.wixpdb", "customaction-6*.pdb"
-      do
-        $S3_CP_CMD --recursive --exclude "*" --include "$pkg" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
-      done
+    - $S3_CP_CMD
+      --recursive
+      --exclude "*"
+      --include "datadog-agent-6*.msi"
+      --include "datadog-agent-6*.debug.zip"
+      --include "datadog-agent-6*.wixpdb"
+      --include "customaction-6*.pdb"
+      $OMNIBUS_PACKAGE_DIR
+      s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/
+      --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+      full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732

--- a/.gitlab/deploy_6/windows.yml
+++ b/.gitlab/deploy_6/windows.yml
@@ -4,20 +4,22 @@ deploy_staging_windows_master-a6:
     !reference [.on_deploy_nightly_repo_branch_a6]
   stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  tags: ["runner:main"]
   dependencies: ["windows_msi_x64-a6"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
-    - '@("datadog-agent-6*.msi", "datadog-agent-6*.debug.zip", "datadog-agent-6.*.wixpdb", "customaction-6*.pdb") |
-      ForEach-Object { $S3_CP_CMD --recursive --exclude "*" --include "$_" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/master/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732 }'
+    - for pkg in "datadog-agent-6*.msi" "datadog-agent-6*.debug.zip" "datadog-agent-6.*.wixpdb" "customaction-6*.pdb"
+      do
+        $S3_CP_CMD --recursive --exclude "*" --include "$pkg" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/master/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+      done
 
 deploy_staging_windows_master-latest-a6:
   rules:
     !reference [.on_deploy_nightly_repo_branch_a6]
   stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  tags: ["runner:main"]
   dependencies: ["windows_msi_x64-a6"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -29,10 +31,12 @@ deploy_staging_windows_tags-a6:
     !reference [.on_deploy_stable_or_beta_repo_branch_a6]
   stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  tags: ["runner:main"]
   dependencies: ["windows_msi_x64-a6"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
-    - '@("datadog-agent-6*.msi", "datadog-agent-6*.debug.zip", "datadog-agent-6*.wixpdb", "customaction-6*.pdb") |
-      ForEach-Object { $S3_CP_CMD --recursive --exclude "*" --include "$_" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732 }'
+    - for pkg in "datadog-agent-6*.msi", "datadog-agent-6*.debug.zip", "datadog-agent-6*.wixpdb", "customaction-6*.pdb"
+      do
+        $S3_CP_CMD --recursive --exclude "*" --include "$pkg" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+      done

--- a/.gitlab/deploy_6/windows.yml
+++ b/.gitlab/deploy_6/windows.yml
@@ -4,7 +4,7 @@ deploy_staging_windows_master-a6:
     !reference [.on_deploy_nightly_repo_branch_a6]
   stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main"]
+  tags: ["runner:windows-docker", "windowsversion:1809"]
   dependencies: ["windows_msi_x64-a6"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -17,7 +17,7 @@ deploy_staging_windows_master-latest-a6:
     !reference [.on_deploy_nightly_repo_branch_a6]
   stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main"]
+  tags: ["runner:windows-docker", "windowsversion:1809"]
   dependencies: ["windows_msi_x64-a6"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -29,7 +29,7 @@ deploy_staging_windows_tags-a6:
     !reference [.on_deploy_stable_or_beta_repo_branch_a6]
   stage: deploy6
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main"]
+  tags: ["runner:windows-docker", "windowsversion:1809"]
   dependencies: ["windows_msi_x64-a6"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR

--- a/.gitlab/deploy_7/windows.yml
+++ b/.gitlab/deploy_7/windows.yml
@@ -4,7 +4,7 @@ deploy_staging_windows_master-a7:
     !reference [.on_deploy_nightly_repo_branch_a7]
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main"]
+  tags: ["runner:windows-docker", "windowsversion:1809"]
   dependencies: ["windows_msi_and_bosh_zip_x64-a7"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -17,7 +17,7 @@ deploy_staging_windows_master-latest-a7:
     !reference [.on_deploy_nightly_repo_branch_a7]
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main"]
+  tags: ["runner:windows-docker", "windowsversion:1809"]
   dependencies: ["windows_msi_and_bosh_zip_x64-a7"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -29,7 +29,7 @@ deploy_staging_windows_tags-a7:
     !reference [.on_deploy_stable_or_beta_repo_branch_a7]
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:main"]
+  tags: ["runner:windows-docker", "windowsversion:1809"]
   dependencies: ["windows_msi_and_bosh_zip_x64-a7", "windows_zip_agent_binaries_x64-a7"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR

--- a/.gitlab/deploy_7/windows.yml
+++ b/.gitlab/deploy_7/windows.yml
@@ -9,10 +9,17 @@ deploy_staging_windows_master-a7:
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
-    - for pkg in "datadog-agent-7*.msi", "datadog-agent-7*.debug.zip", "datadog-agent-7*.wixpdb", "customaction-7*.pdb"
-      do
-        $S3_CP_CMD --recursive --exclude "*" --include "$pkg" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/master/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
-      done
+    - $S3_CP_CMD
+      --recursive
+      --exclude "*"
+      --include "datadog-agent-7*.msi"
+      --include "datadog-agent-7*.debug.zip"
+      --include "datadog-agent-7*.wixpdb"
+      --include "customaction-7*.pdb"
+      $OMNIBUS_PACKAGE_DIR
+      s3://$WINDOWS_BUILDS_S3_BUCKET/master/
+      --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+      full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 deploy_staging_windows_master-latest-a7:
   rules:
@@ -24,7 +31,11 @@ deploy_staging_windows_master-latest-a7:
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
-    - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-agent-7*-x86_64.msi "s3://$WINDOWS_BUILDS_S3_BUCKET/master/datadog-agent-7-latest.amd64.msi" --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+    - $S3_CP_CMD
+      $OMNIBUS_PACKAGE_DIR/datadog-agent-7*-x86_64.msi
+      "s3://$WINDOWS_BUILDS_S3_BUCKET/master/datadog-agent-7-latest.amd64.msi"
+      --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+      full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
 deploy_staging_windows_tags-a7:
   rules:
@@ -36,11 +47,31 @@ deploy_staging_windows_tags-a7:
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
-    - for pkg in "datadog-agent-7*.msi", "datadog-agent-7*.debug.zip", "datadog-agent-7*.wixpdb", "customaction-7*.pdb"
-      do
-        $S3_CP_CMD --recursive --exclude "*" --include "$pkg" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
-      done
-      # used for cloudfoundry bosh
-    - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-7.*.zip" $OMNIBUS_PACKAGE_DIR $S3_DSD6_URI/windows/agent7/bosh/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+    - $S3_CP_CMD
+      --recursive
+      --exclude "*"
+      --include "datadog-agent-7*.msi"
+      --include "datadog-agent-7*.debug.zip"
+      --include "datadog-agent-7*.wixpdb"
+      --include "customaction-7*.pdb"
+      $OMNIBUS_PACKAGE_DIR
+      s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/
+      --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+      full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+    # used for cloudfoundry bosh
+    - $S3_CP_CMD
+      --recursive
+      --exclude "*"
+      --include "datadog-agent-7.*.zip"
+      $OMNIBUS_PACKAGE_DIR
+      $S3_DSD6_URI/windows/agent7/bosh/
+      --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+      full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
     # used for cloudfoundry buildpack and azure-app-services
-    - $S3_CP_CMD --recursive --exclude "*" --include "agent-binaries-7.*.zip" $OMNIBUS_PACKAGE_DIR $S3_DSD6_URI/windows/agent7/buildpack/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+    - $S3_CP_CMD
+      --recursive
+      --exclude "*"
+      --include "agent-binaries-7.*.zip"
+      $OMNIBUS_PACKAGE_DIR $S3_DSD6_URI/windows/agent7/buildpack/
+      --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+      full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732

--- a/.gitlab/deploy_7/windows.yml
+++ b/.gitlab/deploy_7/windows.yml
@@ -4,20 +4,22 @@ deploy_staging_windows_master-a7:
     !reference [.on_deploy_nightly_repo_branch_a7]
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  tags: ["runner:main"]
   dependencies: ["windows_msi_and_bosh_zip_x64-a7"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
-    - '@("datadog-agent-7*.msi", "datadog-agent-7*.debug.zip", "datadog-agent-7*.wixpdb", "customaction-7*.pdb") |
-      ForEach-Object { $S3_CP_CMD --recursive --exclude "*" --include "$_" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/master/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732 }'
+    - for pkg in "datadog-agent-7*.msi", "datadog-agent-7*.debug.zip", "datadog-agent-7*.wixpdb", "customaction-7*.pdb"
+      do
+        $S3_CP_CMD --recursive --exclude "*" --include "$pkg" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/master/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+      done
 
 deploy_staging_windows_master-latest-a7:
   rules:
     !reference [.on_deploy_nightly_repo_branch_a7]
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  tags: ["runner:main"]
   dependencies: ["windows_msi_and_bosh_zip_x64-a7"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
@@ -29,13 +31,15 @@ deploy_staging_windows_tags-a7:
     !reference [.on_deploy_stable_or_beta_repo_branch_a7]
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
-  tags: ["runner:windows-docker", "windowsversion:1809"]
+  tags: ["runner:main"]
   dependencies: ["windows_msi_and_bosh_zip_x64-a7", "windows_zip_agent_binaries_x64-a7"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
-    - '@("datadog-agent-7*.msi", "datadog-agent-7*.debug.zip", "datadog-agent-7*.wixpdb", "customaction-7*.pdb") |
-      ForEach-Object { $S3_CP_CMD --recursive --exclude "*" --include "$_" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732 }'
+    - for pkg in "datadog-agent-7*.msi", "datadog-agent-7*.debug.zip", "datadog-agent-7*.wixpdb", "customaction-7*.pdb"
+      do
+        $S3_CP_CMD --recursive --exclude "*" --include "$pkg" $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/tagged/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
+      done
       # used for cloudfoundry bosh
     - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-7.*.zip" $OMNIBUS_PACKAGE_DIR $S3_DSD6_URI/windows/agent7/bosh/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
     # used for cloudfoundry buildpack and azure-app-services


### PR DESCRIPTION
### What does this PR do?

Fix bug introduced in #8995 where the deploy jobs were running on Linux hosts but the code was Powershell.
This PR converts the Powershell code to bash.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
