### PR TITLE
[runtime-security] look for /etc/os-release file in HOST_ROOT when defined

### DIFF
--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -9,6 +9,7 @@ package kernel
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -62,6 +63,13 @@ func NewKernelVersion() (*Version, error) {
 		osReleasePaths = append([]string{
 			filepath.Join("/host", osrelease.EtcOsRelease),
 			filepath.Join("/host", osrelease.UsrLibOsRelease),
+		}, osReleasePaths...)
+	}
+
+	if hostRoot := os.Getenv("HOST_ROOT"); hostRoot != "" {
+		osReleasePaths = append([]string{
+			filepath.Join(hostRoot, osrelease.EtcOsRelease),
+			filepath.Join(hostRoot, osrelease.UsrLibOsRelease),
 		}, osReleasePaths...)
 	}
 


### PR DESCRIPTION
### What does this PR do?

Look for the /etc/os-release file in the HOST_ROOT bind mount if it exists.

### Motivation

Documentation did not specify that /etc/os-release had to be bind mounted.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
