### PR TITLE
WIP: Create a badger based context-resolver

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,7 @@ require (
 	github.com/coreos/go-semver v0.3.0
 	github.com/coreos/go-systemd v0.0.0-20190620071333-e64a0ec8b42a
 	github.com/davecgh/go-spew v1.1.1
-	github.com/dgraph-io/badger/v3 v3.2103.1 // indirect
+	github.com/dgraph-io/badger/v3 v3.2103.1
 	github.com/dgraph-io/ristretto v0.1.0
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible
 	github.com/docker/go-connections v0.4.0
@@ -110,7 +110,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.2
-	github.com/golang/snappy v0.0.3 // indirect
 	github.com/google/gofuzz v1.2.0
 	github.com/google/gopacket v1.1.19
 	github.com/google/pprof v0.0.0-20210226084205-cbba55b83ad5

--- a/go.mod
+++ b/go.mod
@@ -89,7 +89,8 @@ require (
 	github.com/coreos/go-semver v0.3.0
 	github.com/coreos/go-systemd v0.0.0-20190620071333-e64a0ec8b42a
 	github.com/davecgh/go-spew v1.1.1
-	github.com/dgraph-io/ristretto v0.0.3
+	github.com/dgraph-io/badger/v3 v3.2103.1 // indirect
+	github.com/dgraph-io/ristretto v0.1.0
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible
 	github.com/docker/go-connections v0.4.0
 	github.com/dustin/go-humanize v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -427,6 +427,7 @@ github.com/coreos/go-systemd/v22 v22.3.2/go.mod h1:Y58oyj3AT4RCenI/lSvhwexgC+NSV
 github.com/coreos/pkg v0.0.0-20160727233714-3ac0863d7acf/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f h1:lBNOc5arjvs8E5mO2tbpBpLoyyu8B6e44T7hJy6potg=
 github.com/coreos/pkg v0.0.0-20180928190104-399ea9e2e55f/go.mod h1:E3G3o1h8I7cfcXa63jLwjI0eiQQMgzzUDFVpN/nH/eA=
+github.com/cpuguy83/go-md2man v1.0.10/go.mod h1:SmD6nW6nTyfqj6ABTjUi3V3JVMnlJmwcJI5acqYI6dE=
 github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
@@ -443,8 +444,12 @@ github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
+github.com/dgraph-io/badger/v3 v3.2103.1 h1:zaX53IRg7ycxVlkd5pYdCeFp1FynD6qBGQoQql3R3Hk=
+github.com/dgraph-io/badger/v3 v3.2103.1/go.mod h1:dULbq6ehJ5K0cGW/1TQ9iSfUk0gbSiToDWmWmTsJ53E=
 github.com/dgraph-io/ristretto v0.0.3 h1:jh22xisGBjrEVnRZ1DVTpBVQm0Xndu8sMl0CWDzSIBI=
 github.com/dgraph-io/ristretto v0.0.3/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
+github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/LuerPI=
+github.com/dgraph-io/ristretto v0.1.0/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2 h1:tdlZCpZ/P9DhczCTSixgIKmwPv6+wP5DGjqLYw5SUiA=
@@ -698,6 +703,8 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/cadvisor v0.38.8/go.mod h1:1OFB9sOOMkBdUBGCO/1SArawTnDscgMzTodacVDe8mA=
+github.com/google/flatbuffers v1.12.0 h1:/PtAHvnBY4Kqnx/xCQ3OIV9uYcSFGScBsWI3Oogeh6w=
+github.com/google/flatbuffers v1.12.0/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -936,6 +943,8 @@ github.com/klauspost/compress v1.10.10/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdY
 github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.13 h1:eSvu8Tmq6j2psUJqJrLcWH6K3w5Dwc+qipbaA6eVEN4=
 github.com/klauspost/compress v1.11.13/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
+github.com/klauspost/compress v1.12.3 h1:G5AfA94pHPysR56qqrkO2pxEexdDzrpFJ6yt/VqWxVU=
+github.com/klauspost/compress v1.12.3/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/pgzip v1.2.4/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/pgzip v1.2.5 h1:qnWYvvKqedOF2ulHpMG72XQol4ILEJ8k2wwRl/Km8oE=
@@ -1363,12 +1372,15 @@ github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4k
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
+github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
+github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spf13/afero v1.1.2/go.mod h1:j4pytiNVoe2o6bmDsKpLACNPDBIoEAkihy7loJ1B0CQ=
 github.com/spf13/afero v1.2.2/go.mod h1:9ZxEEn6pIJ8Rxe320qSDBk6AsU0r9pR7Q4OcevTdifk=
 github.com/spf13/afero v1.6.0 h1:xoax2sJ2DT8S8xA2paPFjDCScCNeWsg75VG0DLRreiY=
 github.com/spf13/afero v1.6.0/go.mod h1:Ai8FlHk4v/PARR026UzYexafAt9roJ7LcLMAmO6Z93I=
 github.com/spf13/cobra v0.0.2-0.20171109065643-2da4a54c5cee/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/cobra v0.0.3/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
+github.com/spf13/cobra v0.0.5/go.mod h1:3K3wKZymM7VvHMDS9+Akkh4K60UwM26emMESw8tLCHU=
 github.com/spf13/cobra v1.0.0/go.mod h1:/6GTrnGXV9HjY+aR4k0oJ5tcvakLuG6EuKReYlHNrgE=
 github.com/spf13/cobra v1.1.1/go.mod h1:WnodtKOvamDL/PwE2M4iKs8aMDBZ5Q5klgD3qfVJQMI=
 github.com/spf13/cobra v1.2.1 h1:+KmjbUw1hriSNMF55oPrkZcb27aECyrj8V2ytv7kWDw=
@@ -1382,6 +1394,7 @@ github.com/spf13/pflag v1.0.1/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnIn
 github.com/spf13/pflag v1.0.3/go.mod h1:DYY7MBk1bdzusC3SYhjObp+wFpr4gzcvqqNjLnInEg4=
 github.com/spf13/pflag v1.0.5 h1:iy+VFUOCP1a+8yFto/drg2CJ5u0yRoB7fZw3DKv/JXA=
 github.com/spf13/pflag v1.0.5/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+github.com/spf13/viper v1.3.2/go.mod h1:ZiWeW+zYFKm7srdB9IoDzzZXaJaI5eL9QjNiN/DMA2s=
 github.com/spf13/viper v1.4.0/go.mod h1:PTJ7Z/lr49W6bUbkmS1V3by4uWynFiR9p7+dSq/yZzE=
 github.com/spf13/viper v1.6.2/go.mod h1:t3iDnF5Jlj76alVNuyFBk5oUMCvsrkbvZK0WQdfDi5k=
 github.com/spf13/viper v1.7.0/go.mod h1:8WkrPz2fc9jxqZNCJI/76HCieCp4Q8HaLFoCha5qpdg=
@@ -1435,6 +1448,7 @@ github.com/twmb/murmur3 v1.1.6 h1:mqrRot1BRxm+Yct+vavLMou2/iJt0tNVTTC0QoIjaZg=
 github.com/twmb/murmur3 v1.1.6/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 github.com/ugorji/go v1.1.7 h1:/68gy2h+1mWMrwZFeD1kQialdSzAb432dtpeJ42ovdo=
 github.com/ugorji/go v1.1.7/go.mod h1:kZn38zHttfInRq0xu/PH0az30d+z6vm202qpg1oXVMw=
+github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ugorji/go/codec v1.1.7 h1:2SvQaVZ1ouYrrKKwoSk2pzd4A9evlKJb9oTL+OaLUSs=
 github.com/ugorji/go/codec v1.1.7/go.mod h1:Ax+UKWsSmolVDwsd+7N3ZtXu+yMGCf907BLYF3GoBXY=
 github.com/ulikunitz/xz v0.5.6/go.mod h1:2bypXElzHzzJZwzH67Y6wb67pO62Rzfn7BSiF4ABRW8=
@@ -1578,6 +1592,7 @@ golang.org/x/crypto v0.0.0-20180904163835-0709b304e793/go.mod h1:6SG95UA2DQfeDnf
 golang.org/x/crypto v0.0.0-20181009213950-7c1a557ab941/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181029021203-45a5f77698d3/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20181127143415-eb0de9b17e85/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
+golang.org/x/crypto v0.0.0-20181203042331-505ab145d0a9/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190123085648-057139ce5d2b/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190211182817-74369b46fc67/go.mod h1:6SG95UA2DQfeDnfUPMdvaQW0Q7yPrPDi9nlGo2tz2b4=
 golang.org/x/crypto v0.0.0-20190228161510-8dd112bcdc25/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
@@ -1742,6 +1757,7 @@ golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8/go.mod h1:STP8DvDyc/dI5b8T5h
 golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181128092732-4ed8d59d0b35/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20181205085412-a5c9d58dba9a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190124100055-b90733256f2e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190129075346-302c3dd5f1cc/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190209173611-3b5209105503/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/go.sum
+++ b/go.sum
@@ -446,8 +446,6 @@ github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSs
 github.com/daviddengcn/go-colortext v0.0.0-20160507010035-511bcaf42ccd/go.mod h1:dv4zxwHi5C/8AeI+4gX4dCWOIvNi7I6JCSX0HvlKPgE=
 github.com/dgraph-io/badger/v3 v3.2103.1 h1:zaX53IRg7ycxVlkd5pYdCeFp1FynD6qBGQoQql3R3Hk=
 github.com/dgraph-io/badger/v3 v3.2103.1/go.mod h1:dULbq6ehJ5K0cGW/1TQ9iSfUk0gbSiToDWmWmTsJ53E=
-github.com/dgraph-io/ristretto v0.0.3 h1:jh22xisGBjrEVnRZ1DVTpBVQm0Xndu8sMl0CWDzSIBI=
-github.com/dgraph-io/ristretto v0.0.3/go.mod h1:KPxhHT9ZxKefz+PCeOGsrHpl1qZ7i70dGTu2u+Ahh6E=
 github.com/dgraph-io/ristretto v0.1.0 h1:Jv3CGQHp9OjuMBSne1485aDpUkTKEcUqF+jm/LuerPI=
 github.com/dgraph-io/ristretto v0.1.0/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
 github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
@@ -941,7 +939,6 @@ github.com/kjk/lzma v0.0.0-20161016003348-3fd93898850d/go.mod h1:phT/jsRPBAEqjAi
 github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0guNDohfE1A=
 github.com/klauspost/compress v1.10.10/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
-github.com/klauspost/compress v1.11.13 h1:eSvu8Tmq6j2psUJqJrLcWH6K3w5Dwc+qipbaA6eVEN4=
 github.com/klauspost/compress v1.11.13/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.12.3 h1:G5AfA94pHPysR56qqrkO2pxEexdDzrpFJ6yt/VqWxVU=
 github.com/klauspost/compress v1.12.3/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
@@ -1370,7 +1367,6 @@ github.com/smira/go-xz v0.0.0-20150414201226-0c531f070014/go.mod h1:smSuTvETRIkX
 github.com/soheilhy/cmux v0.1.4 h1:0HKaf1o97UwFjHH9o5XsHUOF+tqmdA7KEzXLpiyaw0E=
 github.com/soheilhy/cmux v0.1.4/go.mod h1:IM3LyeVVIOuxMH7sFAkER9+bJ4dT7Ms6E4xg4kGIyLM=
 github.com/sony/gobreaker v0.4.1/go.mod h1:ZKptC7FHNvhBz7dN2LGjPVBz2sZJmc0/PkyDJOjmxWY=
-github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72 h1:qLC7fQah7D6K1B0ujays3HV9gkFtllcxhzImRR7ArPQ=
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
 github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -374,6 +374,7 @@ func (agg *BufferedAggregator) registerSender(id check.ID) error {
 
 func (agg *BufferedAggregator) deregisterSender(id check.ID) {
 	agg.mu.Lock()
+	agg.checkSamplers[id].close()
 	delete(agg.checkSamplers, id)
 	agg.mu.Unlock()
 }
@@ -703,6 +704,7 @@ func (agg *BufferedAggregator) Flush(start time.Time, waitForSerializer bool) {
 // Stop stops the aggregator. Based on 'flushData' waiting metrics (from checks
 // or closed dogstatsd buckets) will be sent to the serializer before stopping.
 func (agg *BufferedAggregator) Stop() {
+	agg.statsdSampler.Close()
 	agg.stopChan <- struct{}{}
 
 	timeout := config.Datadog.GetDuration("aggregator_stop_timeout") * time.Second

--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -179,3 +179,7 @@ func (cs *CheckSampler) flush() (metrics.Series, metrics.SketchSeriesList) {
 
 	return series, sketches
 }
+
+func (cs *CheckSampler) close() {
+	cs.contextResolver.close()
+}

--- a/pkg/aggregator/ckey/key.go
+++ b/pkg/aggregator/ckey/key.go
@@ -168,3 +168,12 @@ func Equals(a, b ContextKey) bool {
 func (k ContextKey) IsZero() bool {
 	return k == 0
 }
+
+// ToBytes returns the bytes of the key
+func (k ContextKey) ToBytes() []byte {
+	r := make([]byte, 8)
+	for i := 0; i < 8; i++ {
+		r[i] = byte((k >> (i * 8)) & 0xff)
+	}
+	return r
+}

--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -33,7 +33,6 @@ type contextResolver interface {
 func newContextResolver() contextResolver {
 	if UseBadger {
 		return newContextResolverBadger()
-	} else {
-		return newContextResolverInMemory()
 	}
+	return newContextResolverInMemory()
 }

--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -6,11 +6,8 @@
 package aggregator
 
 import (
-	"fmt"
-
 	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
-	"github.com/DataDog/datadog-agent/pkg/util"
 )
 
 // Context holds the elements that form a context, and can be serialized into a context key
@@ -20,164 +17,23 @@ type Context struct {
 	Host string
 }
 
+// FIXME: make this an option.
+const UseBadger = true
+
 // contextResolver allows tracking and expiring contexts
-type contextResolver struct {
-	contextsByKey map[ckey.ContextKey]*Context
-	keyGenerator  *ckey.KeyGenerator
-	// buffer slice allocated once per contextResolver to combine and sort
-	// tags, origin detection tags and k8s tags.
-	tagsBuffer *util.TagsBuilder
+type contextResolver interface {
+	generateContextKey(metricSampleContext metrics.MetricSampleContext) ckey.ContextKey
+	trackContext(metricSampleContext metrics.MetricSampleContext) ckey.ContextKey
+	get(key ckey.ContextKey) (*Context, bool)
+	length() int
+	removeKeys(expiredContextKeys []ckey.ContextKey)
+	close()
 }
 
-// generateContextKey generates the contextKey associated with the context of the metricSample
-func (cr *contextResolver) generateContextKey(metricSampleContext metrics.MetricSampleContext) ckey.ContextKey {
-	return cr.keyGenerator.Generate(metricSampleContext.GetName(), metricSampleContext.GetHost(), cr.tagsBuffer)
-}
-
-func newContextResolver() *contextResolver {
-	return &contextResolver{
-		contextsByKey: make(map[ckey.ContextKey]*Context),
-		keyGenerator:  ckey.NewKeyGenerator(),
-		tagsBuffer:    util.NewTagsBuilder(),
+func newContextResolver() contextResolver {
+	if UseBadger {
+		return newContextResolverBadger()
+	} else {
+		return newContextResolverInMemory()
 	}
-}
-
-// trackContext returns the contextKey associated with the context of the metricSample and tracks that context
-func (cr *contextResolver) trackContext(metricSampleContext metrics.MetricSampleContext) ckey.ContextKey {
-	metricSampleContext.GetTags(cr.tagsBuffer)               // tags here are not sorted and can contain duplicates
-	contextKey := cr.generateContextKey(metricSampleContext) // the generator will remove duplicates from cr.tagsBuffer (and doesn't mind the order)
-
-	if _, ok := cr.contextsByKey[contextKey]; !ok {
-		// making a copy of tags for the context since tagsBuffer
-		// will be reused later. This allow us to allocate one slice
-		// per context instead of one per sample.
-		cr.contextsByKey[contextKey] = &Context{
-			Name: metricSampleContext.GetName(),
-			Tags: cr.tagsBuffer.Copy(),
-			Host: metricSampleContext.GetHost(),
-		}
-	}
-
-	cr.tagsBuffer.Reset()
-	return contextKey
-}
-
-func (cr *contextResolver) get(key ckey.ContextKey) (*Context, bool) {
-	ctx, found := cr.contextsByKey[key]
-	return ctx, found
-}
-
-func (cr *contextResolver) length() int {
-	return len(cr.contextsByKey)
-}
-
-func (cr *contextResolver) removeKeys(expiredContextKeys []ckey.ContextKey) {
-	for _, expiredContextKey := range expiredContextKeys {
-		delete(cr.contextsByKey, expiredContextKey)
-	}
-}
-
-// timestampContextResolver allows tracking and expiring contexts based on time.
-type timestampContextResolver struct {
-	resolver      *contextResolver
-	lastSeenByKey map[ckey.ContextKey]float64
-}
-
-func newTimestampContextResolver() *timestampContextResolver {
-	return &timestampContextResolver{
-		resolver:      newContextResolver(),
-		lastSeenByKey: make(map[ckey.ContextKey]float64),
-	}
-}
-
-// updateTrackedContext updates the last seen timestamp on a given context key
-func (cr *timestampContextResolver) updateTrackedContext(contextKey ckey.ContextKey, timestamp float64) error {
-	if _, ok := cr.lastSeenByKey[contextKey]; ok && cr.lastSeenByKey[contextKey] < timestamp {
-		cr.lastSeenByKey[contextKey] = timestamp
-	} else if !ok {
-		return fmt.Errorf("Trying to update a context that is not tracked")
-	}
-
-	return nil
-}
-
-// trackContext returns the contextKey associated with the context of the metricSample and tracks that context
-func (cr *timestampContextResolver) trackContext(metricSampleContext metrics.MetricSampleContext, currentTimestamp float64) ckey.ContextKey {
-	contextKey := cr.resolver.trackContext(metricSampleContext)
-	cr.lastSeenByKey[contextKey] = currentTimestamp
-	return contextKey
-}
-
-func (cr *timestampContextResolver) length() int {
-	return cr.resolver.length()
-}
-
-func (cr *timestampContextResolver) get(key ckey.ContextKey) (*Context, bool) {
-	return cr.resolver.get(key)
-}
-
-// expireContexts cleans up the contexts that haven't been tracked since the given timestamp
-// and returns the associated contextKeys
-func (cr *timestampContextResolver) expireContexts(expireTimestamp float64) []ckey.ContextKey {
-	var expiredContextKeys []ckey.ContextKey
-
-	// Find expired context keys
-	for contextKey, lastSeen := range cr.lastSeenByKey {
-		if lastSeen < expireTimestamp {
-			expiredContextKeys = append(expiredContextKeys, contextKey)
-		}
-	}
-
-	cr.resolver.removeKeys(expiredContextKeys)
-
-	// Delete expired context keys
-	for _, expiredContextKey := range expiredContextKeys {
-		delete(cr.lastSeenByKey, expiredContextKey)
-	}
-
-	return expiredContextKeys
-}
-
-// countBasedContextResolver allows tracking and expiring contexts based on the number
-// of calls of `expireContexts`.
-type countBasedContextResolver struct {
-	resolver            *contextResolver
-	expireCountByKey    map[ckey.ContextKey]int64
-	expireCount         int64
-	expireCountInterval int64
-}
-
-func newCountBasedContextResolver(expireCountInterval int) *countBasedContextResolver {
-	return &countBasedContextResolver{
-		resolver:            newContextResolver(),
-		expireCountByKey:    make(map[ckey.ContextKey]int64),
-		expireCount:         0,
-		expireCountInterval: int64(expireCountInterval),
-	}
-}
-
-// trackContext returns the contextKey associated with the context of the metricSample and tracks that context
-func (cr *countBasedContextResolver) trackContext(metricSampleContext metrics.MetricSampleContext) ckey.ContextKey {
-	contextKey := cr.resolver.trackContext(metricSampleContext)
-	cr.expireCountByKey[contextKey] = cr.expireCount
-	return contextKey
-}
-
-func (cr *countBasedContextResolver) get(key ckey.ContextKey) (*Context, bool) {
-	return cr.resolver.get(key)
-}
-
-// expireContexts cleans up the contexts that haven't been tracked since `expirationCount`
-// call to `expireContexts` and returns the associated contextKeys
-func (cr *countBasedContextResolver) expireContexts() []ckey.ContextKey {
-	var keys []ckey.ContextKey
-	for key, index := range cr.expireCountByKey {
-		if index <= cr.expireCount-cr.expireCountInterval {
-			keys = append(keys, key)
-			delete(cr.expireCountByKey, key)
-		}
-	}
-	cr.resolver.removeKeys(keys)
-	cr.expireCount++
-	return keys
 }

--- a/pkg/aggregator/context_resolver_badger.go
+++ b/pkg/aggregator/context_resolver_badger.go
@@ -1,0 +1,179 @@
+package aggregator
+
+import (
+	"bytes"
+	"encoding/gob"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/dgraph-io/badger/v3"
+	"log"
+	"time"
+)
+
+// contextResolver allows tracking and expiring contexts
+type contextResolverBadger struct {
+	db *badger.DB
+	ticker *time.Ticker
+	contextsByKey map[ckey.ContextKey]*Context
+	keyGenerator  *ckey.KeyGenerator
+	// buffer slice allocated once per contextResolver to combine and sort
+	// tags, origin detection tags and k8s tags.
+	tagsBuffer *util.TagsBuilder
+}
+
+// generateContextKey generates the contextKey associated with the context of the metricSample
+func (cr *contextResolverBadger) generateContextKey(metricSampleContext metrics.MetricSampleContext) ckey.ContextKey {
+	return cr.keyGenerator.Generate(metricSampleContext.GetName(), metricSampleContext.GetHost(), cr.tagsBuffer)
+}
+
+func (cr *contextResolverBadger) serializeContextKey(key ckey.ContextKey) []byte {
+	return key.ToBytes()
+}
+
+// TODO: we probably want to encode it manually to be a bit more efficient here.
+func (cr *contextResolverBadger) serializeContext(c *Context) []byte {
+	var buffer bytes.Buffer
+	enc := gob.NewEncoder(&buffer)
+	enc.Encode(*c)
+	return buffer.Bytes()
+}
+
+func (cr *contextResolverBadger) deserializeContext(b []byte) *Context {
+	buffer := bytes.NewBuffer(b)
+	dec := gob.NewDecoder(buffer)
+	c := &Context{}
+	dec.Decode(&c)
+	return c
+}
+
+func newContextResolverBadger() *contextResolverBadger {
+	// TODO: Also try ondisk with the proper options, this would reduce memory usage at almost
+	//   no cost since we can disable fsync()
+	opt := badger.DefaultOptions("").WithInMemory(true)
+	db, err := badger.Open(opt)
+	if err != nil {
+		log.Fatal(err)
+	}
+	ticker := time.NewTicker(1 * time.Minute)
+
+	cr := &contextResolverBadger{
+		db: db,
+		ticker: ticker,
+		contextsByKey: make(map[ckey.ContextKey]*Context),
+		keyGenerator:  ckey.NewKeyGenerator(),
+		tagsBuffer:    util.NewTagsBuilder(),
+	}
+	go cr.runGC()
+	return cr
+}
+
+// trackContext returns the contextKey associated with the context of the metricSample and tracks that context
+func (cr *contextResolverBadger) trackContext(metricSampleContext metrics.MetricSampleContext) ckey.ContextKey {
+	metricSampleContext.GetTags(cr.tagsBuffer)               // tags here are not sorted and can contain duplicates
+	contextKey := cr.generateContextKey(metricSampleContext) // the generator will remove duplicates from cr.tagsBuffer (and doesn't mind the order)
+
+	if _, ok := cr.contextsByKey[contextKey]; !ok {
+		// making a copy of tags for the context since tagsBuffer
+		// will be reused later. This allows us to allocate one slice
+		// per context instead of one per sample.
+		c := &Context{
+			Name: metricSampleContext.GetName(),
+			Tags: cr.tagsBuffer.Copy(),
+			Host: metricSampleContext.GetHost(),
+		}
+		err := cr.db.Update(func(txn *badger.Txn) error {
+			err := txn.Set(cr.serializeContextKey(contextKey), cr.serializeContext(c))
+			return err
+		})
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	cr.tagsBuffer.Reset()
+	return contextKey
+}
+
+func (cr *contextResolverBadger) get(key ckey.ContextKey) (*Context, bool) {
+	var context *Context = nil
+
+	// FIXME: review error handling.
+	err := cr.db.View(func(txn *badger.Txn) error {
+		item, err := txn.Get(cr.serializeContextKey(key))
+		if err != nil {
+			return err
+		}
+		if item.IsDeletedOrExpired() {
+			return nil
+		}
+		err = item.Value(func(val []byte) error {
+			context = cr.deserializeContext(val)
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, false
+	}
+
+	return context, context != nil
+}
+
+func (cr *contextResolverBadger) length() int {
+	count := 0
+	err := cr.db.View(func(txn *badger.Txn) error {
+		opts := badger.DefaultIteratorOptions
+		opts.PrefetchValues = false
+		it := txn.NewIterator(opts)
+		defer it.Close()
+		for it.Rewind(); it.Valid(); it.Next() {
+			if it.Item().IsDeletedOrExpired() {
+				continue
+			}
+			count++
+
+		}
+		return nil
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+	return count
+}
+
+func (cr *contextResolverBadger) removeKeys(expiredContextKeys []ckey.ContextKey) {
+	err := cr.db.Update(func(txn *badger.Txn) error {
+		for _, expiredContextKey := range expiredContextKeys {
+			err := txn.Delete(cr.serializeContextKey(expiredContextKey))
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func (cr *contextResolverBadger) runGC() {
+	for range cr.ticker.C {
+	again:
+		err := cr.db.RunValueLogGC(0.7)
+		if err == nil {
+			goto again
+		}
+	}
+}
+
+func (cr *contextResolverBadger) close() {
+	cr.ticker.Stop()
+	err := cr.db.Close()
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/pkg/aggregator/context_resolver_count.go
+++ b/pkg/aggregator/context_resolver_count.go
@@ -1,0 +1,54 @@
+package aggregator
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+// countBasedContextResolver allows tracking and expiring contexts based on the number
+// of calls of `expireContexts`.
+type countBasedContextResolver struct {
+	resolver            contextResolver
+	expireCountByKey    map[ckey.ContextKey]int64
+	expireCount         int64
+	expireCountInterval int64
+}
+
+func newCountBasedContextResolver(expireCountInterval int) *countBasedContextResolver {
+	return &countBasedContextResolver{
+		resolver:            newContextResolver(),
+		expireCountByKey:    make(map[ckey.ContextKey]int64),
+		expireCount:         0,
+		expireCountInterval: int64(expireCountInterval),
+	}
+}
+
+// trackContext returns the contextKey associated with the context of the metricSample and tracks that context
+func (cr *countBasedContextResolver) trackContext(metricSampleContext metrics.MetricSampleContext) ckey.ContextKey {
+	contextKey := cr.resolver.trackContext(metricSampleContext)
+	cr.expireCountByKey[contextKey] = cr.expireCount
+	return contextKey
+}
+
+func (cr *countBasedContextResolver) get(key ckey.ContextKey) (*Context, bool) {
+	return cr.resolver.get(key)
+}
+
+// expireContexts cleans up the contexts that haven't been tracked since `expirationCount`
+// call to `expireContexts` and returns the associated contextKeys
+func (cr *countBasedContextResolver) expireContexts() []ckey.ContextKey {
+	var keys []ckey.ContextKey
+	for key, index := range cr.expireCountByKey {
+		if index <= cr.expireCount-cr.expireCountInterval {
+			keys = append(keys, key)
+			delete(cr.expireCountByKey, key)
+		}
+	}
+	cr.resolver.removeKeys(keys)
+	cr.expireCount++
+	return keys
+}
+
+func (cr *countBasedContextResolver) close() {
+	cr.resolver.close()
+}

--- a/pkg/aggregator/context_resolver_memory.go
+++ b/pkg/aggregator/context_resolver_memory.go
@@ -1,0 +1,67 @@
+package aggregator
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util"
+)
+
+// contextResolver allows tracking and expiring contexts
+type contextResolverInMemory struct {
+	contextsByKey map[ckey.ContextKey]*Context
+	keyGenerator  *ckey.KeyGenerator
+	// buffer slice allocated once per contextResolver to combine and sort
+	// tags, origin detection tags and k8s tags.
+	tagsBuffer *util.TagsBuilder
+}
+
+// generateContextKey generates the contextKey associated with the context of the metricSample
+func (cr *contextResolverInMemory) generateContextKey(metricSampleContext metrics.MetricSampleContext) ckey.ContextKey {
+	return cr.keyGenerator.Generate(metricSampleContext.GetName(), metricSampleContext.GetHost(), cr.tagsBuffer)
+}
+
+func newContextResolverInMemory() *contextResolverInMemory {
+	return &contextResolverInMemory{
+		contextsByKey: make(map[ckey.ContextKey]*Context),
+		keyGenerator:  ckey.NewKeyGenerator(),
+		tagsBuffer:    util.NewTagsBuilder(),
+	}
+}
+
+// trackContext returns the contextKey associated with the context of the metricSample and tracks that context
+func (cr *contextResolverInMemory) trackContext(metricSampleContext metrics.MetricSampleContext) ckey.ContextKey {
+	metricSampleContext.GetTags(cr.tagsBuffer)               // tags here are not sorted and can contain duplicates
+	contextKey := cr.generateContextKey(metricSampleContext) // the generator will remove duplicates from cr.tagsBuffer (and doesn't mind the order)
+
+	if _, ok := cr.contextsByKey[contextKey]; !ok {
+		// making a copy of tags for the context since tagsBuffer
+		// will be reused later. This allow us to allocate one slice
+		// per context instead of one per sample.
+		cr.contextsByKey[contextKey] = &Context{
+			Name: metricSampleContext.GetName(),
+			Tags: cr.tagsBuffer.Copy(),
+			Host: metricSampleContext.GetHost(),
+		}
+	}
+
+	cr.tagsBuffer.Reset()
+	return contextKey
+}
+
+func (cr *contextResolverInMemory) get(key ckey.ContextKey) (*Context, bool) {
+	ctx, found := cr.contextsByKey[key]
+	return ctx, found
+}
+
+func (cr *contextResolverInMemory) length() int {
+	return len(cr.contextsByKey)
+}
+
+func (cr *contextResolverInMemory) removeKeys(expiredContextKeys []ckey.ContextKey) {
+	for _, expiredContextKey := range expiredContextKeys {
+		delete(cr.contextsByKey, expiredContextKey)
+	}
+}
+
+func (cr *contextResolverInMemory) close() {
+}

--- a/pkg/aggregator/context_resolver_test.go
+++ b/pkg/aggregator/context_resolver_test.go
@@ -138,6 +138,7 @@ func TestCountBasedExpireContexts(t *testing.T) {
 	mSample2 := metrics.MetricSample{Name: "my.metric.name2"}
 	mSample3 := metrics.MetricSample{Name: "my.metric.name3"}
 	contextResolver := newCountBasedContextResolver(2)
+	defer contextResolver.close()
 
 	contextKey1 := contextResolver.trackContext(&mSample1)
 	contextKey2 := contextResolver.trackContext(&mSample2)

--- a/pkg/aggregator/context_resolver_timestamp.go
+++ b/pkg/aggregator/context_resolver_timestamp.go
@@ -66,3 +66,7 @@ func (cr *timestampContextResolver) expireContexts(expireTimestamp float64) []ck
 
 	return expiredContextKeys
 }
+
+func (cr *timestampContextResolver) close() {
+	cr.resolver.close()
+}

--- a/pkg/aggregator/context_resolver_timestamp.go
+++ b/pkg/aggregator/context_resolver_timestamp.go
@@ -1,0 +1,68 @@
+package aggregator
+
+import (
+	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+// timestampContextResolver allows tracking and expiring contexts based on time.
+type timestampContextResolver struct {
+	resolver      contextResolver
+	lastSeenByKey map[ckey.ContextKey]float64
+}
+
+func newTimestampContextResolver() *timestampContextResolver {
+	return &timestampContextResolver{
+		resolver:      newContextResolver(),
+		lastSeenByKey: make(map[ckey.ContextKey]float64),
+	}
+}
+
+// updateTrackedContext updates the last seen timestamp on a given context key
+func (cr *timestampContextResolver) updateTrackedContext(contextKey ckey.ContextKey, timestamp float64) error {
+	if _, ok := cr.lastSeenByKey[contextKey]; ok && cr.lastSeenByKey[contextKey] < timestamp {
+		cr.lastSeenByKey[contextKey] = timestamp
+	} else if !ok {
+		return fmt.Errorf("Trying to update a context that is not tracked")
+	}
+
+	return nil
+}
+
+// trackContext returns the contextKey associated with the context of the metricSample and tracks that context
+func (cr *timestampContextResolver) trackContext(metricSampleContext metrics.MetricSampleContext, currentTimestamp float64) ckey.ContextKey {
+	contextKey := cr.resolver.trackContext(metricSampleContext)
+	cr.lastSeenByKey[contextKey] = currentTimestamp
+	return contextKey
+}
+
+func (cr *timestampContextResolver) length() int {
+	return cr.resolver.length()
+}
+
+func (cr *timestampContextResolver) get(key ckey.ContextKey) (*Context, bool) {
+	return cr.resolver.get(key)
+}
+
+// expireContexts cleans up the contexts that haven't been tracked since the given timestamp
+// and returns the associated contextKeys
+func (cr *timestampContextResolver) expireContexts(expireTimestamp float64) []ckey.ContextKey {
+	var expiredContextKeys []ckey.ContextKey
+
+	// Find expired context keys
+	for contextKey, lastSeen := range cr.lastSeenByKey {
+		if lastSeen < expireTimestamp {
+			expiredContextKeys = append(expiredContextKeys, contextKey)
+		}
+	}
+
+	cr.resolver.removeKeys(expiredContextKeys)
+
+	// Delete expired context keys
+	for _, expiredContextKey := range expiredContextKeys {
+		delete(cr.lastSeenByKey, expiredContextKey)
+	}
+
+	return expiredContextKeys
+}

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -235,3 +235,7 @@ func (s *TimeSampler) countersSampleZeroValue(timestamp int64, contextMetrics me
 		}
 	}
 }
+
+func (s *TimeSampler) Close() {
+	s.contextResolver.close()
+}

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -29,6 +29,7 @@ func generateSerieContextKey(serie *metrics.Serie) ckey.ContextKey {
 // TimeSampler
 func TestCalculateBucketStart(t *testing.T) {
 	sampler := NewTimeSampler(10)
+	defer sampler.Close()
 
 	assert.Equal(t, int64(123450), sampler.calculateBucketStart(123456.5))
 	assert.Equal(t, int64(123460), sampler.calculateBucketStart(123460.5))
@@ -36,6 +37,7 @@ func TestCalculateBucketStart(t *testing.T) {
 
 func TestBucketSampling(t *testing.T) {
 	sampler := NewTimeSampler(10)
+	defer sampler.Close()
 
 	mSample := metrics.MetricSample{
 		Name:       "my.metric.name",
@@ -67,6 +69,7 @@ func TestBucketSampling(t *testing.T) {
 
 func TestContextSampling(t *testing.T) {
 	sampler := NewTimeSampler(10)
+	defer sampler.Close()
 
 	mSample1 := metrics.MetricSample{
 		Name:       "my.metric.name1",
@@ -131,6 +134,8 @@ func TestContextSampling(t *testing.T) {
 
 func TestCounterExpirySeconds(t *testing.T) {
 	sampler := NewTimeSampler(10)
+	defer sampler.Close()
+
 	math.Abs(1)
 	sampleCounter1 := &metrics.MetricSample{
 		Name:       "my.counter1",
@@ -283,6 +288,7 @@ func TestSketch(t *testing.T) {
 			}
 		}
 	)
+	defer sampler.Close()
 
 	assert.EqualValues(t, defaultBucketSize, sampler.interval,
 		"interval should default to 10")
@@ -332,6 +338,7 @@ func TestSketch(t *testing.T) {
 func TestSketchBucketSampling(t *testing.T) {
 
 	sampler := NewTimeSampler(10)
+	defer sampler.Close()
 
 	mSample1 := metrics.MetricSample{
 		Name:       "test.metric.name",
@@ -375,6 +382,7 @@ func TestSketchBucketSampling(t *testing.T) {
 
 func TestSketchContextSampling(t *testing.T) {
 	sampler := NewTimeSampler(10)
+	defer sampler.Close()
 
 	mSample1 := metrics.MetricSample{
 		Name:       "test.metric.name1",
@@ -425,6 +433,7 @@ func TestSketchContextSampling(t *testing.T) {
 
 func TestBucketSamplingWithSketchAndSeries(t *testing.T) {
 	sampler := NewTimeSampler(10)
+	defer sampler.Close()
 
 	dSample1 := metrics.MetricSample{
 		Name:       "distribution.metric.name1",
@@ -481,6 +490,8 @@ func TestBucketSamplingWithSketchAndSeries(t *testing.T) {
 
 func BenchmarkTimeSampler(b *testing.B) {
 	sampler := NewTimeSampler(10)
+	defer sampler.Close()
+
 	sample := metrics.MetricSample{
 		Name:       "my.metric.name",
 		Value:      1,

--- a/pkg/aggregator/time_sampler_test.go
+++ b/pkg/aggregator/time_sampler_test.go
@@ -252,13 +252,13 @@ func TestCounterExpirySeconds(t *testing.T) {
 	// Counter2 should still report
 	assert.Equal(t, 1, len(series))
 	assert.Equal(t, 1, len(sampler.counterLastSampledByContext))
-	assert.Equal(t, 2, len(sampler.contextResolver.resolver.contextsByKey))
+	assert.Equal(t, 2, sampler.contextResolver.resolver.length())
 
 	series, _ = sampler.flush(1800.0)
 	// Everything stopped reporting and is expired
 	assert.Equal(t, 0, len(series))
 	assert.Equal(t, 0, len(sampler.counterLastSampledByContext))
-	assert.Equal(t, 0, len(sampler.contextResolver.resolver.contextsByKey))
+	assert.Equal(t, 0, sampler.contextResolver.resolver.length())
 }
 
 func TestSketch(t *testing.T) {


### PR DESCRIPTION
The idea here is to use [badger](https://dgraph.io/docs/badger/) to store contexts.

It came from the idea of using a trie to keep contexts (because metrics usually share the same prefix, and tags usually share the same keys) and realising that getting the context out of the tree was probably not going to be much faster than a compression mechanism like snappy.

So instead the idea is to use a compressed kv store. This PR starts in diskless mode but we could eventually enable disk to reduce memory usage at the cost of disk and slightly increased latency (but there's a block cache ..)

Let's see what it can get us!