### PR TITLE
[networks] Fix `kprobeTracer` termination

### DIFF
--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -147,23 +147,20 @@ func New(config *config.Config, constants []manager.ConstantEditor) (connection.
 }
 
 func (t *kprobeTracer) Start(closeFilter func(*network.ConnectionStats) bool) (err error) {
-	// this is to ensure that it is safe to call Stop() on a kprobeTracer that fails to Start()
 	defer func() {
 		if err != nil {
-			t = nil
+			t.Stop()
 		}
 	}()
 
 	closeConsumer, err := newTCPCloseConsumer(t.config, t.m, t.closeHandler, closeFilter)
 	if err != nil {
-		t.Stop()
 		return fmt.Errorf("could not create tcpCloseConsumer: %s", err)
 	}
 	t.closeConsumer = closeConsumer
 
 	err = initializePortBindingMaps(t.config, t.m)
 	if err != nil {
-		t.Stop()
 		return fmt.Errorf("error initializing port binding maps: %s", err)
 	}
 
@@ -174,12 +171,8 @@ func (t *kprobeTracer) Start(closeFilter func(*network.ConnectionStats) bool) (e
 }
 
 func (t *kprobeTracer) Stop() {
-	if t == nil {
-		return
-	}
-
-	t.closeConsumer.Stop()
 	_ = t.m.Stop(manager.CleanAll)
+	t.closeConsumer.Stop()
 }
 
 func (t *kprobeTracer) GetMap(name string) *ebpf.Map {


### PR DESCRIPTION
### What does this PR do?

Fixes `kprobeTracer` termination.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
