### PR TITLE
Fix cgroup parsing for PCF containers

### DIFF
--- a/pkg/util/containers/providers/cgroup/cgroup_detect.go
+++ b/pkg/util/containers/providers/cgroup/cgroup_detect.go
@@ -182,7 +182,7 @@ func scrapeAllCgroups() (map[string]*ContainerCgroup, error) {
 
 		mP, mFound := paths["memory"]
 		fP, fFound := paths["freezer"]
-		if !fFound || !mFound || mP != fP {
+		if !fFound || !mFound || mP != fP && !strings.Contains(mP, "garden.service") {
 			log.Tracef("skipping cgroup from pid: %d - does not appear to be a container: memory path: %s, freezer path: %s", pid, mP, fP)
 			continue
 		}

--- a/releasenotes/notes/fix-pcf-containers-metrics-collection-299f02a5bbf180d1.yaml
+++ b/releasenotes/notes/fix-pcf-containers-metrics-collection-299f02a5bbf180d1.yaml
@@ -1,10 +1,3 @@
-# Each section from every release note are combined when the
-# CHANGELOG.rst is rendered. So the text needs to be worded so that
-# it does not depend on any information only available in another
-# section. This may mean repeating some details, but each section
-# must be readable independently of the other.
-#
-# Each section note must be formatted as reStructuredText.
 ---
 fixes:
   - |

--- a/releasenotes/notes/fix-pcf-containers-metrics-collection-299f02a5bbf180d1.yaml
+++ b/releasenotes/notes/fix-pcf-containers-metrics-collection-299f02a5bbf180d1.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix the cgroup collector to correctly pickup PCF containers.

--- a/releasenotes/notes/fix-pcf-containers-metrics-collection-299f02a5bbf180d1.yaml
+++ b/releasenotes/notes/fix-pcf-containers-metrics-collection-299f02a5bbf180d1.yaml
@@ -1,4 +1,4 @@
 ---
 fixes:
   - |
-    Fix the cgroup collector to correctly pickup PCF containers.
+    Fix the cgroup collector to correctly pickup Cloud Foundry containers.


### PR DESCRIPTION
### What does this PR do?

Fix the `cgroup` collector to correctly pickup PCF containers.

### Motivation

Bugfix.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Deploy a `process-agent` in a PCF environment, the `Live Container View` should display metrics correctly.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
