### PR TITLE
Adding 'site' configuration to the inventory payload

### DIFF
--- a/pkg/metadata/inventories/README.md
+++ b/pkg/metadata/inventories/README.md
@@ -45,6 +45,7 @@ The payload is a JSON dict with the following fields
     dogstatsd, iot, serverless ... (see `pkg/util/flavor` package).
   - `config_apm_dd_url` - **string**: the configuration value `apm_config.dd_url` (scrubbed)
   - `config_dd_url` - **string**: the configuration value `dd_url` (scrubbed)
+  - `config_site` - **string**: the configuration value `site` (scrubbed)
   - `config_logs_dd_url` - **string**: the configuration value `logs_config.logs_dd_url` (scrubbed)
   - `config_logs_socks5_proxy_address` - **string**: the configuration value `logs_config.socks5_proxy_address` (scrubbed)
   - `config_no_proxy` - **array of strings**: the configuration value `proxy.no_proxy` (scrubbed)
@@ -77,9 +78,32 @@ Here an example of an inventory payload:
 
 ```
 {
-    "agent_metadata": {
-        "hostname_source": "os"
-    },
+   "agent_metadata": {
+      "agent_version": "7.32.0-devel+git.146.7bd17a1",
+      "config_apm_dd_url": "",
+      "config_dd_url": "",
+      "config_logs_dd_url": "",
+      "config_logs_socks5_proxy_address": "",
+      "config_no_proxy": [
+        "http://some-no-proxy"
+      ],
+      "config_process_dd_url": "",
+      "config_proxy_http": "",
+      "config_proxy_https": "http://localhost:9999",
+      "config_site": "",
+      "feature_apm_enabled": true,
+      "feature_cspm_enabled": false,
+      "feature_cws_enabled": false,
+      "feature_logs_enabled": true,
+      "feature_networks_enabled": false,
+      "feature_process_enabled": false,
+      "flavor": "agent",
+      "hostname_source": "os",
+      "install_method_installer_version": "",
+      "install_method_tool": "undefined",
+      "install_method_tool_version": "",
+      "logs_transport": "HTTP",
+    }
     "check_metadata": {
         "cpu": [
             {

--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -73,6 +73,7 @@ const (
 	AgentFlavor                       AgentMetadataName = "flavor"
 	AgentConfigApmDDURL               AgentMetadataName = "config_apm_dd_url"
 	AgentConfigDDURL                  AgentMetadataName = "config_dd_url"
+	AgentConfigSite                   AgentMetadataName = "config_site"
 	AgentConfigLogsDDURL              AgentMetadataName = "config_logs_dd_url"
 	AgentConfigLogsSocks5ProxyAddress AgentMetadataName = "config_logs_socks5_proxy_address"
 	AgentConfigNoProxy                AgentMetadataName = "config_no_proxy"
@@ -256,6 +257,7 @@ func initializeConfig(cfg config.Config) {
 
 	SetAgentMetadata(AgentConfigApmDDURL, clean(cfg.GetString("apm_config.apm_dd_url")))
 	SetAgentMetadata(AgentConfigDDURL, clean(cfg.GetString("dd_url")))
+	SetAgentMetadata(AgentConfigSite, clean(cfg.GetString("dd_site")))
 	SetAgentMetadata(AgentConfigLogsDDURL, clean(cfg.GetString("logs_config.logs_dd_url")))
 	SetAgentMetadata(AgentConfigLogsSocks5ProxyAddress, clean(cfg.GetString("logs_config.socks5_proxy_address")))
 	SetAgentMetadata(AgentConfigNoProxy, cleanSlice(cfg.GetStringSlice("proxy.no_proxy")))


### PR DESCRIPTION
### What does this PR do?

Adding 'site' configuration to the inventory payload.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
