### PR TITLE
Introduce a fake-able time module

### DIFF
--- a/pkg/util/time/copy.go
+++ b/pkg/util/time/copy.go
@@ -1,0 +1,74 @@
+package time
+
+import gotime "time"
+
+// this file just copies items from the "real" time module
+
+const (
+	ANSIC       = gotime.ANSIC
+	UnixDate    = gotime.UnixDate
+	RubyDate    = gotime.RubyDate
+	RFC822      = gotime.RFC822
+	RFC822Z     = gotime.RFC822Z
+	RFC850      = gotime.RFC850
+	RFC1123     = gotime.RFC1123
+	RFC1123Z    = gotime.RFC1123Z
+	RFC3339     = gotime.RFC3339
+	RFC3339Nano = gotime.RFC3339Nano
+	Kitchen     = gotime.Kitchen
+	Stamp       = gotime.Stamp
+	StampMilli  = gotime.StampMilli
+	StampMicro  = gotime.StampMicro
+	StampNano   = gotime.StampNano
+)
+
+const (
+	Hour        = gotime.Hour
+	Minute      = gotime.Minute
+	Second      = gotime.Second
+	Millisecond = gotime.Millisecond
+	Microsecond = gotime.Microsecond
+	Nanosecond  = gotime.Nanosecond
+)
+
+type Duration = gotime.Duration
+
+func ParseDuration(s string) (Duration, error) {
+	return gotime.ParseDuration(s)
+}
+
+type Location = gotime.Location
+
+func FixedZone(name string, offset int) *Location {
+	return gotime.FixedZone(name, offset)
+}
+
+func LoadLocation(name string) (*Location, error) {
+	return gotime.LoadLocation(name)
+}
+
+func LoadLocationFromTZData(name string, data []byte) (*Location, error) {
+	return LoadLocationFromTZData(name, data)
+}
+
+type Month = gotime.Month
+
+type ParseError = gotime.ParseError
+
+type Time = gotime.Time
+
+func Date(year int, month Month, day, hour, min, sec, nsec int, loc *Location) Time {
+	return gotime.Date(year, month, day, hour, min, sec, nsec, loc)
+}
+
+func Parse(layout, value string) (Time, error) {
+	return gotime.Parse(layout, value)
+}
+
+func ParseInLocation(layout, value string, loc *Location) (Time, error) {
+	return gotime.ParseInLocation(layout, value, loc)
+}
+
+func Unix(sec int64, nsec int64) Time {
+	return gotime.Unix(sec, nsec)
+}

--- a/pkg/util/time/fake.go
+++ b/pkg/util/time/fake.go
@@ -1,0 +1,228 @@
+// This package implements an API very similar to that of the built-in 'time'
+// package, but in such a way that it can be "faked" in tests.
+//
+// Specifically, this package implements "accelerated" time, which skips the
+// fake clock forward during times when all goroutines might otherwise be
+// sleeping.  It does this by sleeping for a configurable interval, which
+// should be long enough to allow any active cpu usage to finish and leave
+// only pending timers.  When the interval expires, the fake time is skipped
+// ahead to the earliest of those timers, which fires immediately.  The result
+// is that tests can use "real" durations, such as a 30-second connection
+// timeout, and this package will avoid waiting that long in terms of
+// wall-clock time.
+package time
+
+import (
+	"container/heap"
+	"sync"
+	gotime "time"
+)
+
+var faker *accelFaker
+
+type Event struct {
+	when    Time
+	trigger chan<- struct{}
+}
+
+type EventQueue []*Event
+
+func (eq EventQueue) Len() int { return len(eq) }
+
+func (eq EventQueue) Less(i, j int) bool {
+	return eq[i].when.Before(eq[j].when)
+}
+
+func (eq EventQueue) Swap(i, j int) {
+	eq[i], eq[j] = eq[j], eq[i]
+}
+
+func (eq *EventQueue) Push(x interface{}) {
+	*eq = append(*eq, x.(*Event))
+}
+
+func (eq *EventQueue) Pop() interface{} {
+	old := *eq
+	n := len(old)
+	evt := old[n-1]
+	old[n-1] = nil // avoid memory leak
+	*eq = old[0 : n-1]
+	return evt
+}
+
+// A Faker exists while time is being faked, and allows returning to "real"
+// time with its Stop method.  Typically a Faker is created in a test case
+// with something like `defer time.StartAcceleratedFake().Stop()`.
+type Faker interface {
+	// Stop the faker.  This will block until the faker is fully stopped.
+	Stop()
+}
+
+type accelFaker struct {
+	// This is the time interval after which we assume all blocking operations
+	// have completed, and we can skip to the next interesting point in time.
+	// Increasing this value will make tests run slower, but too small a value
+	// may result in timers firing in unexpected orders.  The default value is
+	// 10ms.
+	interval Duration
+
+	// indicate that the faker should stop
+	stop chan<- struct{}
+
+	// indicate that the faker *has* stopped
+	done <-chan struct{}
+
+	// remainder of the fields are protected by this mutex
+	sync.Mutex
+
+	// priority queue of future events and the time they should
+	// occur
+	futureEvents EventQueue
+
+	// the current time
+	now Time
+}
+
+// Start faking time.  Between this call and the subsequent faker.Stop() call,
+// any delays for sleeping or tickers will be shortened.  The interval
+// parameter should be longer than the time required to accomplish any
+// non-sleeping operations, but no longer.  Increasing the interval will make
+// tests take longer in a linear fashion (that is, doubling interval will
+// double the time the test takes).
+func StartAcceleratedFake(interval Duration) Faker {
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	futureEvents := make(EventQueue, 0)
+	faker = &accelFaker{
+		interval:     interval,
+		stop:         stop,
+		done:         done,
+		futureEvents: futureEvents,
+		now:          gotime.Now(),
+	}
+	heap.Init(&faker.futureEvents)
+	faker.start(stop, done)
+	return faker
+}
+
+// Run an event loop to simulate time.  This uses a ticker to advance time to
+// the next moment something will happen every interval.  The idea is that
+// interval should be enough time for any non-blocking test operations to
+// complete, so we are merely skipping the blocking (sleeping) operations.
+func (fkr *accelFaker) start(stop <-chan struct{}, done chan<- struct{}) {
+	go func() {
+		for {
+			// If there was a lengthy GC operation, then the tick invocation
+			// may have taken longer than fkr.interval, which would leave us
+			// performing two ticks back-to-back.  To avoid this, we use a
+			// timer that is reset at the beginning of each loop.
+			tick := gotime.After(fkr.interval)
+
+			select {
+			case <-stop:
+				close(done)
+				return
+			case <-tick:
+				fkr.tick()
+			}
+		}
+	}()
+}
+
+// Tick along to the next event
+func (fkr *accelFaker) tick() {
+	fkr.Lock()
+
+	if len(fkr.futureEvents) == 0 {
+		// no further events, so nothing to do ("now" remains unchanged)
+		fkr.Unlock()
+		return
+	}
+
+	// peek at the next event to see how far to advance
+	nextEvt := fkr.futureEvents[0]
+	toTrigger := fkr.advance(nextEvt.when.Sub(fkr.now))
+
+	// unlock the faker before sending events, to avoid unnecessary
+	// churn waiting on the mutex
+	fkr.Unlock()
+
+	for _, evt := range toTrigger {
+		close(evt.trigger)
+	}
+}
+
+// Advance the fake clock by the given duration, returning the
+// events that should be triggered
+//
+// NOTE: this method assumes fkr is locked
+func (fkr *accelFaker) advance(d Duration) []*Event {
+	fkr.now = fkr.now.Add(d)
+
+	// we must trigger the events with the faker unlocked, so
+	// make a list of them first
+	toTrigger := []*Event{}
+	for len(fkr.futureEvents) > 0 && !fkr.futureEvents[0].when.After(fkr.now) {
+		toTrigger = append(toTrigger, heap.Pop(&fkr.futureEvents).(*Event))
+	}
+
+	return toTrigger
+}
+
+// Get the current time
+func (fkr *accelFaker) Now() Time {
+	fkr.Lock()
+	defer fkr.Unlock()
+
+	return fkr.now
+}
+
+// Create a channel that will be closed at the given (fake) time.
+func (fkr *accelFaker) at(when Time) <-chan struct{} {
+	fkr.Lock()
+	defer fkr.Unlock()
+
+	c := make(chan struct{})
+
+	// for times in the past, or now, just trigger immediately
+	if !when.After(fkr.now) {
+		close(c)
+		return c
+	}
+
+	heap.Push(&fkr.futureEvents, &Event{
+		when:    when,
+		trigger: c,
+	})
+
+	return c
+}
+
+// Create a channel that will be closed after the given (fake) // duration has passed.
+func (fkr *accelFaker) after(d Duration) <-chan struct{} {
+	fkr.Lock()
+	defer fkr.Unlock()
+
+	c := make(chan struct{})
+
+	heap.Push(&fkr.futureEvents, &Event{
+		when:    fkr.now.Add(d),
+		trigger: c,
+	})
+
+	return c
+}
+
+// Stop faking time.  This will restore all functions to their normal,
+// production behavior.
+func (fkr *accelFaker) Stop() {
+	if faker != fkr {
+		panic("method call on stopped faker")
+	}
+
+	// stop the goroutine and wait for it
+	close(fkr.stop)
+	<-fkr.done
+
+	faker = nil
+}

--- a/pkg/util/time/fake_test.go
+++ b/pkg/util/time/fake_test.go
@@ -1,0 +1,17 @@
+package time
+
+import (
+	"testing"
+	"time"
+)
+
+func withRealAndFake(t *testing.T, f func(*testing.T)) {
+	t.Run("real", func(t *testing.T) {
+		f(t)
+	})
+	t.Run("fake", func(t *testing.T) {
+		fkr := StartAcceleratedFake(1 * time.Millisecond)
+		defer fkr.Stop()
+		f(t)
+	})
+}

--- a/pkg/util/time/sleep.go
+++ b/pkg/util/time/sleep.go
@@ -1,0 +1,116 @@
+package time
+
+import (
+	gotime "time"
+)
+
+func Sleep(d Duration) {
+	if faker != nil {
+		<-faker.after(d)
+	} else {
+		gotime.Sleep(d)
+	}
+}
+
+// Interface satisfied by the real time.Timer struct
+type Timer interface {
+	Stop() bool
+	Reset(Duration) bool
+}
+
+type fakeTimer struct {
+	// stop is closed when the timer should stop
+	stop chan struct{}
+
+	// done is closed when the ticker's goroutine has stopped
+	done chan struct{}
+
+	// the ticker channel
+	c chan Time
+
+	// if not nil, a function that should be called when the timer is
+	// triggered (used for AfterFunc)
+	f func()
+
+	// true if this timer stopped
+	stopped bool
+}
+
+func newFakeTimer(d Duration) *fakeTimer {
+	// The "real" time.Timer uses a buffered channel with one slot
+	c := make(chan Time, 1)
+
+	tmr := &fakeTimer{
+		c:       c,
+		stopped: false,
+	}
+	tmr.start(d)
+	return tmr
+}
+
+func (tmr *fakeTimer) start(d Duration) {
+	// use a fresh set of stop/done channels for each (re)start
+	// of the timer
+	tmr.stop = make(chan struct{})
+	tmr.done = make(chan struct{})
+	tmr.stopped = false
+	go func() {
+		after := faker.after(d)
+		select {
+		case <-tmr.stop:
+			tmr.stopped = true
+		case <-after:
+			if tmr.f != nil {
+				go (tmr.f)()
+			} else {
+				tmr.c <- faker.Now()
+			}
+		}
+		close(tmr.done)
+	}()
+}
+
+func (tmr *fakeTimer) Reset(d Duration) bool {
+	stopped := tmr.Stop()
+	tmr.start(d)
+	// NOTE: docs say Reset's return value cannot be used correctly,
+	// so its accuracy is not critical (and it is not tested)
+	return stopped
+}
+
+func (tmr *fakeTimer) Stop() bool {
+	if tmr.stop != nil {
+		close(tmr.stop)
+		<-tmr.done
+		tmr.stop = nil
+	}
+	stopped := tmr.stopped
+	tmr.stopped = false
+	return stopped
+}
+
+func NewTimer(d Duration) (Timer, <-chan Time) {
+	if faker != nil {
+		tmr := newFakeTimer(d)
+		return tmr, tmr.c
+	} else {
+		tmr := gotime.NewTimer(d)
+		return tmr, tmr.C
+	}
+}
+
+func After(d Duration) <-chan Time {
+	_, c := NewTimer(d)
+	return c
+}
+
+func AfterFunc(d Duration, f func()) (Timer, <-chan Time) {
+	if faker != nil {
+		tmr := newFakeTimer(d)
+		tmr.f = f
+		return tmr, tmr.c
+	} else {
+		tmr := gotime.AfterFunc(d, f)
+		return tmr, tmr.C
+	}
+}

--- a/pkg/util/time/sleep_test.go
+++ b/pkg/util/time/sleep_test.go
@@ -1,0 +1,180 @@
+package time
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSleep(t *testing.T) {
+	withRealAndFake(t, func(t *testing.T) {
+		start := Now()
+		Sleep(10 * Millisecond)
+		end := Now()
+		require.LessOrEqual(t, 5*Millisecond, end.Sub(start))
+	})
+}
+
+func TestTimer(t *testing.T) {
+	withRealAndFake(t, func(t *testing.T) {
+		_, c := NewTimer(30 * Millisecond)
+
+		select {
+		case <-c:
+			require.Fail(t, "should not have triggered yet")
+		default:
+		}
+
+		Sleep(40 * Millisecond)
+
+		select {
+		case <-c:
+		default:
+			require.Fail(t, "should have triggered already")
+		}
+	})
+}
+
+func TestTimerStop(t *testing.T) {
+	withRealAndFake(t, func(t *testing.T) {
+		tmr, c := NewTimer(30 * Millisecond)
+
+		select {
+		case <-c:
+			require.Fail(t, "should not have triggered yet")
+		default:
+		}
+
+		stopped := tmr.Stop()
+		require.True(t, stopped)
+		Sleep(40 * Millisecond)
+
+		select {
+		case <-c:
+			require.Fail(t, "should not have triggered")
+		default:
+		}
+
+		stopped = tmr.Stop()
+		require.False(t, stopped)
+	})
+}
+
+func TestTimerReset(t *testing.T) {
+	withRealAndFake(t, func(t *testing.T) {
+		tmr, c := NewTimer(30 * Millisecond)
+
+		select {
+		case <-c:
+			require.Fail(t, "should not have triggered yet")
+		default:
+		}
+
+		tmr.Reset(60 * Millisecond)
+		Sleep(40 * Millisecond)
+
+		select {
+		case <-c:
+			require.Fail(t, "still should not have triggered")
+		default:
+		}
+
+		Sleep(40 * Millisecond)
+
+		select {
+		case <-c:
+		default:
+			require.Fail(t, "should have triggered")
+		}
+	})
+}
+
+func TestAfter(t *testing.T) {
+	withRealAndFake(t, func(t *testing.T) {
+		c := After(30 * Millisecond)
+
+		select {
+		case <-c:
+			require.Fail(t, "should not have triggered yet")
+		default:
+		}
+
+		Sleep(40 * Millisecond)
+
+		select {
+		case <-c:
+		default:
+			require.Fail(t, "should have triggered already")
+		}
+	})
+}
+
+func TestAfterFunc(t *testing.T) {
+	withRealAndFake(t, func(t *testing.T) {
+		var triggered int32
+
+		AfterFunc(
+			30*Millisecond,
+			func() { atomic.StoreInt32(&triggered, 1) },
+		)
+
+		Sleep(1 * Millisecond)
+
+		require.Equal(t, int32(0), atomic.LoadInt32(&triggered))
+
+		Sleep(40 * Millisecond)
+
+		require.Equal(t, int32(1), atomic.LoadInt32(&triggered))
+	})
+}
+
+func TestAfterFuncReset(t *testing.T) {
+	withRealAndFake(t, func(t *testing.T) {
+		var triggered int32
+
+		tmr, _ := AfterFunc(
+			30*Millisecond,
+			func() {
+				atomic.StoreInt32(&triggered, 1)
+			},
+		)
+
+		Sleep(1 * Millisecond)
+
+		require.Equal(t, int32(0), atomic.LoadInt32(&triggered))
+		tmr.Reset(80 * Millisecond)
+
+		Sleep(40 * Millisecond)
+
+		require.Equal(t, int32(0), atomic.LoadInt32(&triggered))
+
+		Sleep(60 * Millisecond)
+
+		require.Equal(t, int32(1), atomic.LoadInt32(&triggered))
+	})
+}
+
+func TestAfterFuncStop(t *testing.T) {
+	withRealAndFake(t, func(t *testing.T) {
+		var triggered int32
+
+		timer, _ := AfterFunc(
+			30*Millisecond,
+			func() { atomic.StoreInt32(&triggered, 1) },
+		)
+
+		Sleep(1 * Millisecond)
+
+		require.Equal(t, int32(0), atomic.LoadInt32(&triggered))
+
+		stopped := timer.Stop()
+		require.True(t, stopped)
+		Sleep(40 * Millisecond)
+
+		require.Equal(t, int32(0), atomic.LoadInt32(&triggered))
+
+		stopped = timer.Stop()
+		require.False(t, stopped)
+	})
+}

--- a/pkg/util/time/ticker.go
+++ b/pkg/util/time/ticker.go
@@ -1,0 +1,97 @@
+package time
+
+import (
+	gotime "time"
+)
+
+// Ticker is an interface satisfied by the "real" time.Ticker
+type Ticker interface {
+	Reset(Duration)
+	Stop()
+}
+
+type fakeTicker struct {
+	// reset sends a duration on this channel; stop closes it
+	reset chan<- Duration
+
+	// done is closed when the ticker's goroutine has stopped
+	done <-chan struct{}
+
+	// the ticker channel
+	c <-chan Time
+}
+
+func newFakeTicker(d Duration) *fakeTicker {
+	reset := make(chan Duration)
+	done := make(chan struct{})
+
+	// The "real" time.Ticker uses a buffered channel with one slot
+	c := make(chan Time, 1)
+
+	tkr := &fakeTicker{reset, done, c}
+	tkr.start(d, reset, done, c)
+
+	return tkr
+}
+
+func (tkr *fakeTicker) start(
+	d Duration,
+	reset <-chan Duration,
+	done chan<- struct{},
+	c chan<- Time,
+) {
+	go func() {
+		nextTick := faker.after(d)
+		for {
+			select {
+			case dur, ok := <-reset:
+				// reset channel was closed, signalling this
+				// goroutine to exit
+				if !ok {
+					close(done)
+					return
+				}
+				// we got reset to a new duration, so update
+				// the stored duration value and restart the
+				// timer
+				d = dur
+				nextTick = faker.after(d)
+			case <-nextTick:
+				nextTick = faker.after(d)
+				// the "real" time.Ticker uses a non-blocking send, so
+				// do the same here
+				select {
+				case c <- faker.Now():
+				default:
+				}
+			}
+		}
+	}()
+}
+
+func (tkr *fakeTicker) Reset(d Duration) {
+	tkr.reset <- d
+}
+
+func (tkr *fakeTicker) Stop() {
+	close(tkr.reset)
+	<-tkr.done
+}
+
+func Tick(d Duration) <-chan Time {
+	if d <= 0 {
+		return nil
+	}
+	_, c := NewTicker(d)
+	return c
+}
+
+func NewTicker(d Duration) (Ticker, <-chan Time) {
+	if faker != nil {
+		tkr := newFakeTicker(d)
+		return tkr, tkr.c
+	} else {
+		tkr := gotime.NewTicker(d)
+		return tkr, tkr.C
+	}
+}

--- a/pkg/util/time/ticker_test.go
+++ b/pkg/util/time/ticker_test.go
@@ -1,0 +1,56 @@
+package time
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTicker(t *testing.T) {
+	withRealAndFake(t, func(t *testing.T) {
+		ticker, tickerC := NewTicker(10 * Millisecond)
+		defer ticker.Stop()
+		done := make(chan bool)
+		go func() {
+			Sleep(500 * Millisecond)
+			done <- true
+		}()
+		ticks := 0
+		for {
+			select {
+			case <-tickerC:
+				ticks++
+			case <-done:
+				// ticks should be ~50, but at least once..
+				require.NotEqual(t, 0, ticks)
+				return
+			}
+		}
+	})
+}
+
+func TestTickerReset(t *testing.T) {
+	withRealAndFake(t, func(t *testing.T) {
+		dur := 1 * Millisecond
+
+		ticker, tickerC := NewTicker(dur)
+		defer ticker.Stop()
+
+		start := Now()
+
+		ticks := 0
+		for range tickerC {
+			ticks++
+			dur = dur * 2
+			if dur > 32*Millisecond {
+				break
+			}
+			ticker.Reset(dur)
+		}
+
+		elapsed := Since(start)
+		// if Reset did nothing, then we spent about ticks ms
+		// in the loop above; otherwise we spent about 63ms
+		require.Less(t, Duration(ticks)*Millisecond, elapsed)
+	})
+}

--- a/pkg/util/time/time.go
+++ b/pkg/util/time/time.go
@@ -1,0 +1,19 @@
+package time
+
+import gotime "time"
+
+func Now() Time {
+	if faker != nil {
+		return faker.Now()
+	} else {
+		return gotime.Now()
+	}
+}
+
+func Since(t Time) Duration {
+	return Now().Sub(t)
+}
+
+func Until(t Time) Duration {
+	return t.Sub(Now())
+}

--- a/pkg/util/time/time_test.go
+++ b/pkg/util/time/time_test.go
@@ -1,0 +1,23 @@
+package time
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSince(t *testing.T) {
+	withRealAndFake(t, func(t *testing.T) {
+		start := Now()
+		Sleep(10 * Millisecond)
+		require.GreaterOrEqual(t, Since(start), 5*Millisecond)
+	})
+}
+
+func TestUntil(t *testing.T) {
+	withRealAndFake(t, func(t *testing.T) {
+		start := Now()
+		later := start.Add(Minute)
+		require.LessOrEqual(t, Until(later), Minute)
+	})
+}


### PR DESCRIPTION
This introduces a new time-faking module.  The API is meant to mimic that of `time`, but is subtly different in a few places where structs with public fields were returned (because those are now interfaces and thus cannot have fields).

### Motivation

Lots of intermittent failures of time-based tests

### Additional Notes

This is a draft so far, as it just introduces the module.  After feedback, I'd like to:
 * use this to make at least one intermittent timing test pass
 * improve the docs somewhat (perhaps with an example)
 * configure the tests for _this_ package, to run the "real" tests more slowly (on the scale of seconds) since otherwise they will be intermittent as well

One thing I'd like some feedback on is the design here.  When faking time, there are really two options:
 * Make the fake clock not "move" until something asks it to (something like `fkr.advance(10 * time.Millisecond)`).  Then tests have a separate goroutine that advances time a little bit, then tests conditions, then advances time a little more, and so on.  This is a typical approach in asynchronous programming contexts (JS, Python, Rust).
 * Make the fake clock run "automatically" and just skip ahead at moments where otherwise all goroutines would be asleep.

I've taken the second approach here, as I think it feels a lot more natural in Go.  Because of Go's CSP nature, it would be difficult to ensure that any events that were supposed to occur in 10ms had actually occurred when `fkr.advance(10 * time.Millisecond)` returned.  So something like

```go
fkr.advance(10 * time.Millisecond)
require.Equal(t, 1, atomic.LoadInt32(somethingHappened))
```
would be a data race, between the check of `somethingHappened` and whatever goroutine should be updating `somethingHappened`.

### Describe how to test your changes

Tests in CI :)
