### PR TITLE
Use buffered i/o to reduce allocations in procfs io parsing

### DIFF
--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -3,6 +3,7 @@
 package procutil
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"io/ioutil"
@@ -354,19 +355,16 @@ func (p *Probe) parseIO(pidPath string) *IOCountersStat {
 		return io
 	}
 
-	content, err := ioutil.ReadFile(path)
+	f, err := os.Open(path)
 	if err != nil {
 		return io
 	}
+	defer f.Close()
 
-	lineStart := 0
-	for i, r := range content {
-		if r == '\n' {
-			p.parseIOLine(content[lineStart:i], io)
-			lineStart = i + 1
-		}
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		p.parseIOLine(scanner.Bytes(), io)
 	}
-
 	return io
 }
 


### PR DESCRIPTION
### What does this PR do?

Uses buffered i/o to improve memory usage, rather than reading in the entire procfs `io` file.

### Motivation

This showed up when profiling system-probe for memory usage.  While only ~3% of the total, this seemed like low-hanging fruit.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
