### PR TITLE
[JOBOWNERS] Rename sysprobe tests

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -37,7 +37,7 @@ deploy_*docker_hub*                  @DataDog/container-integrations
 deploy_*google_container_repository* @DataDog/container-integrations
 
 # Functional test
-kitchen_*_sysprobe*                  @DataDog/agent-network
+kitchen_*_system_probe*              @DataDog/agent-network
 kitchen_*_security_agent*            @DataDog/agent-security
 cleanup_kitchen_functional_test      @DataDog/agent-network @DataDog/agent-security
 


### PR DESCRIPTION
### What does this PR do?

Update kitchen system probe tests JOBOWNERS line.

### Motivation

Correct CI notifications

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
