### PR TITLE
[omnibus/pip{2,3}] Fix license location

### DIFF
--- a/omnibus/config/software/pip2.rb
+++ b/omnibus/config/software/pip2.rb
@@ -11,7 +11,7 @@ source :url => "https://github.com/pypa/pip/archive/#{version}.tar.gz",
 relative_path "pip-#{version}"
 
 build do
-  ship_license "https://raw.githubusercontent.com/pypa/pip/develop/LICENSE.txt"
+  ship_license "https://raw.githubusercontent.com/pypa/pip/main/LICENSE.txt"
 
   patch :source => "remove-python27-deprecation-warning.patch", :target => "src/pip/_internal/cli/base_command.py"
 

--- a/omnibus/config/software/pip3.rb
+++ b/omnibus/config/software/pip3.rb
@@ -11,7 +11,7 @@ source :url => "https://github.com/pypa/pip/archive/#{version}.tar.gz",
 relative_path "pip-#{version}"
 
 build do
-  ship_license "https://raw.githubusercontent.com/pypa/pip/develop/LICENSE.txt"
+  ship_license "https://raw.githubusercontent.com/pypa/pip/main/LICENSE.txt"
 
   if ohai["platform"] == "windows"
     python_bin = "#{windows_safe_path(python_3_embedded)}\\python.exe"


### PR DESCRIPTION
### What does this PR do?

Fixes the license location for the `pip2` and `pip3` software definitions.

### Motivation

https://raw.githubusercontent.com/pypa/pip/develop/LICENSE.txt leads to a 404 page.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
