### PR TITLE
[pkg/otlp] Add support for OTLP metrics

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -683,6 +683,7 @@ core,go.opentelemetry.io/collector/config/experimental/configsource,Apache-2.0,O
 core,go.opentelemetry.io/collector/consumer,Apache-2.0,Open Telemetry Maintainers
 core,go.opentelemetry.io/collector/consumer/consumererror,Apache-2.0,Open Telemetry Maintainers
 core,go.opentelemetry.io/collector/consumer/consumerhelper,Apache-2.0,Open Telemetry Maintainers
+core,go.opentelemetry.io/collector/consumer/consumertest,Apache-2.0,Open Telemetry Maintainers
 core,go.opentelemetry.io/collector/exporter/exporterhelper,Apache-2.0,Open Telemetry Maintainers
 core,go.opentelemetry.io/collector/exporter/exporterhelper/internal,Apache-2.0,Open Telemetry Maintainers
 core,go.opentelemetry.io/collector/exporter/otlpexporter,Apache-2.0,Open Telemetry Maintainers
@@ -696,6 +697,7 @@ core,go.opentelemetry.io/collector/internal/middleware,Apache-2.0,Open Telemetry
 core,go.opentelemetry.io/collector/internal/obsreportconfig,Apache-2.0,Open Telemetry Maintainers
 core,go.opentelemetry.io/collector/internal/obsreportconfig/obsmetrics,Apache-2.0,Open Telemetry Maintainers
 core,go.opentelemetry.io/collector/internal/sharedcomponent,Apache-2.0,Open Telemetry Maintainers
+core,go.opentelemetry.io/collector/internal/testdata,Apache-2.0,Open Telemetry Maintainers
 core,go.opentelemetry.io/collector/internal/version,Apache-2.0,Open Telemetry Maintainers
 core,go.opentelemetry.io/collector/model/internal,Apache-2.0,Open Telemetry Maintainers
 core,go.opentelemetry.io/collector/model/internal/data,Apache-2.0,Open Telemetry Maintainers

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -388,7 +388,7 @@ func StartAgent() error {
 	// Start OTLP intake
 	if otlp.IsEnabled(config.Datadog) {
 		var err error
-		common.OTLP, err = otlp.BuildAndStart(common.MainCtx, config.Datadog)
+		common.OTLP, err = otlp.BuildAndStart(common.MainCtx, config.Datadog, s)
 		if err != nil {
 			log.Errorf("Could not start OTLP: %s", err)
 		}

--- a/pkg/config/otlp.go
+++ b/pkg/config/otlp.go
@@ -7,6 +7,8 @@ package config
 
 func setupOTLP(config Config) {
 	config.BindEnvAndSetDefault("experimental.otlp.internal_traces_port", 5003)
+	config.BindEnvAndSetDefault("experimental.otlp.metrics_enabled", true)
+	config.BindEnvAndSetDefault("experimental.otlp.traces_enabled", true)
 	config.BindEnv("experimental.otlp.http_port", "DD_OTLP_HTTP_PORT")
 	config.BindEnv("experimental.otlp.grpc_port", "DD_OTLP_GRPC_PORT")
 }

--- a/pkg/otlp/collector_test.go
+++ b/pkg/otlp/collector_test.go
@@ -3,16 +3,21 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021-present Datadog, Inc.
 
+//go:build test
+// +build test
+
 package otlp
 
 import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/serializer"
 )
 
 func TestGetComponents(t *testing.T) {
-	_, err := getComponents()
+	_, err := getComponents(&serializer.MockSerializer{})
 	// No duplicate component
 	require.NoError(t, err)
 }

--- a/pkg/otlp/config.go
+++ b/pkg/otlp/config.go
@@ -16,6 +16,8 @@ const (
 	experimentalHTTPPortSetting  = "experimental.otlp.http_port"
 	experimentalgRPCPortSetting  = "experimental.otlp.grpc_port"
 	experimentalTracePortSetting = "experimental.otlp.internal_traces_port"
+	experimentalMetricsEnabled   = "experimental.otlp.metrics_enabled"
+	experimentalTracesEnabled    = "experimental.otlp.traces_enabled"
 )
 
 // getReceiverHost gets the receiver host for the OTLP endpoint in a given config.
@@ -70,11 +72,19 @@ func fromExperimentalConfig(cfg config.Config) (PipelineConfig, error) {
 		errs = append(errs, fmt.Errorf("internal trace port is invalid: %w", err))
 	}
 
+	metricsEnabled := cfg.GetBool(experimentalMetricsEnabled)
+	tracesEnabled := cfg.GetBool(experimentalTracesEnabled)
+	if !metricsEnabled && !tracesEnabled {
+		errs = append(errs, fmt.Errorf("at least one OTLP signal needs to be enabled"))
+	}
+
 	return PipelineConfig{
-		BindHost:  getReceiverHost(cfg),
-		HTTPPort:  httpPort,
-		GRPCPort:  gRPCPort,
-		TracePort: tracePort,
+		BindHost:       getReceiverHost(cfg),
+		HTTPPort:       httpPort,
+		GRPCPort:       gRPCPort,
+		TracePort:      tracePort,
+		MetricsEnabled: metricsEnabled,
+		TracesEnabled:  tracesEnabled,
 	}, multierr.Combine(errs...)
 }
 

--- a/pkg/otlp/config_parser.go
+++ b/pkg/otlp/config_parser.go
@@ -14,11 +14,11 @@ import (
 	"go.opentelemetry.io/collector/service/parserprovider"
 )
 
-// baseConfig is the base OTLP pipeline configuration.
+// tracesConfig is the base traces OTLP pipeline configuration.
 // This pipeline is extended through the datadog.yaml configuration values.
 // It is written in YAML because it is easier to read and write than a map.
 // TODO (AP-1254): Set service-level configuration when available.
-const baseConfig string = `
+const tracesConfig string = `
 receivers:
   otlp:
 
@@ -34,41 +34,83 @@ service:
       exporters: [otlp]
 `
 
+// metricsConfig is the metrics OTLP pipeline configuration.
+// TODO (AP-1254): Set service-level configuration when available.
+const metricsConfig string = `
+receivers:
+  otlp:
+
+processors:
+  batch:
+
+exporters:
+  serializer:
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [serializer]
+`
+
 // buildKey creates a key for use in the ConfigMap.Set function.
 func buildKey(keys ...string) string {
 	return strings.Join(keys, configparser.KeyDelimiter)
 }
 
-// newParser creates a configparser.ConfigMap with the fixed configuration.
-func newParser(cfg PipelineConfig) (*configparser.ConfigMap, error) {
-	parser, err := configparser.NewConfigMapFromBuffer(strings.NewReader(baseConfig))
-	if err != nil {
-		return nil, err
+// newMap creates a configparser.ConfigMap with the fixed configuration.
+// TODO (AP-1254): Refactor with MergeProvider when available.
+func newMap(cfg PipelineConfig) (*configparser.ConfigMap, error) {
+	configMap := configparser.NewConfigMap()
+
+	if cfg.TracesEnabled {
+		tracesMap, err := configparser.NewConfigMapFromBuffer(strings.NewReader(tracesConfig))
+		if err != nil {
+			return nil, err
+		}
+
+		err = configMap.MergeStringMap(tracesMap.ToStringMap())
+		if err != nil {
+			return nil, fmt.Errorf("failed to merge traces map: %w", err)
+		}
+
+		configMap.Set(
+			buildKey("exporters", "otlp", "endpoint"),
+			fmt.Sprintf("%s:%d", "localhost", cfg.TracePort),
+		)
+	}
+
+	if cfg.MetricsEnabled {
+		metricsMap, err := configparser.NewConfigMapFromBuffer(strings.NewReader(metricsConfig))
+		if err != nil {
+			return nil, err
+		}
+
+		err = configMap.MergeStringMap(metricsMap.ToStringMap())
+		if err != nil {
+			return nil, fmt.Errorf("failed to merge metrics map: %w", err)
+		}
 	}
 
 	if cfg.GRPCPort > 0 {
-		parser.Set(
+		configMap.Set(
 			buildKey("receivers", "otlp", "protocols", "grpc", "endpoint"),
 			fmt.Sprintf("%s:%d", cfg.BindHost, cfg.GRPCPort),
 		)
 	}
 
 	if cfg.HTTPPort > 0 {
-		parser.Set(
+		configMap.Set(
 			buildKey("receivers", "otlp", "protocols", "http", "endpoint"),
 			fmt.Sprintf("%s:%d", cfg.BindHost, cfg.HTTPPort),
 		)
 	}
 
-	parser.Set(
-		buildKey("exporters", "otlp", "endpoint"),
-		fmt.Sprintf("%s:%d", "localhost", cfg.TracePort),
-	)
-
-	return parser, nil
+	return configMap, nil
 }
 
-// TODO: Use a  InMemory provider instead of this.
+// TODO(AP-1254): Use a  InMemory provider instead of this.
 var _ parserprovider.ParserProvider = (*parserProvider)(nil)
 
 type parserProvider configparser.ConfigMap

--- a/pkg/otlp/config_parser.go
+++ b/pkg/otlp/config_parser.go
@@ -14,11 +14,11 @@ import (
 	"go.opentelemetry.io/collector/service/parserprovider"
 )
 
-// tracesConfig is the base traces OTLP pipeline configuration.
+// defaultTracesConfig is the base traces OTLP pipeline configuration.
 // This pipeline is extended through the datadog.yaml configuration values.
 // It is written in YAML because it is easier to read and write than a map.
 // TODO (AP-1254): Set service-level configuration when available.
-const tracesConfig string = `
+const defaultTracesConfig string = `
 receivers:
   otlp:
 
@@ -34,9 +34,9 @@ service:
       exporters: [otlp]
 `
 
-// metricsConfig is the metrics OTLP pipeline configuration.
+// defaultMetricsConfig is the metrics OTLP pipeline configuration.
 // TODO (AP-1254): Set service-level configuration when available.
-const metricsConfig string = `
+const defaultMetricsConfig string = `
 receivers:
   otlp:
 
@@ -65,7 +65,7 @@ func newMap(cfg PipelineConfig) (*configparser.ConfigMap, error) {
 	configMap := configparser.NewConfigMap()
 
 	if cfg.TracesEnabled {
-		tracesMap, err := configparser.NewConfigMapFromBuffer(strings.NewReader(tracesConfig))
+		tracesMap, err := configparser.NewConfigMapFromBuffer(strings.NewReader(defaultTracesConfig))
 		if err != nil {
 			return nil, err
 		}
@@ -82,7 +82,7 @@ func newMap(cfg PipelineConfig) (*configparser.ConfigMap, error) {
 	}
 
 	if cfg.MetricsEnabled {
-		metricsMap, err := configparser.NewConfigMapFromBuffer(strings.NewReader(metricsConfig))
+		metricsMap, err := configparser.NewConfigMapFromBuffer(strings.NewReader(defaultMetricsConfig))
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/otlp/config_parser_test.go
+++ b/pkg/otlp/config_parser_test.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021-present Datadog, Inc.
 
+//go:build test
+// +build test
+
 package otlp
 
 import (
@@ -13,9 +16,11 @@ import (
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/config/configparser"
 	"go.opentelemetry.io/collector/config/configunmarshaler"
+
+	"github.com/DataDog/datadog-agent/pkg/serializer"
 )
 
-func TestNewParser(t *testing.T) {
+func TestNewMap(t *testing.T) {
 	tests := []struct {
 		name string
 		pcfg PipelineConfig
@@ -23,11 +28,12 @@ func TestNewParser(t *testing.T) {
 		cfg  map[string]interface{}
 	}{
 		{
-			name: "only gRPC",
+			name: "only gRPC, only Traces",
 			pcfg: PipelineConfig{
-				GRPCPort:  1234,
-				TracePort: 5003,
-				BindHost:  "bindhost",
+				GRPCPort:      1234,
+				TracePort:     5003,
+				BindHost:      "bindhost",
+				TracesEnabled: true,
 			},
 			ocfg: `
 receivers:
@@ -48,11 +54,13 @@ service:
 `,
 		},
 		{
-			name: "only HTTP",
+			name: "only HTTP, metrics and traces",
 			pcfg: PipelineConfig{
-				HTTPPort:  1234,
-				TracePort: 5003,
-				BindHost:  "bindhost",
+				HTTPPort:       1234,
+				TracePort:      5003,
+				BindHost:       "bindhost",
+				TracesEnabled:  true,
+				MetricsEnabled: true,
 			},
 			ocfg: `
 receivers:
@@ -60,25 +68,36 @@ receivers:
     protocols:
       http:
         endpoint: bindhost:1234
+
+processors:
+  batch:
+
 exporters:
   otlp:
     tls:
       insecure: true
     endpoint: localhost:5003
+  serializer:
+
 service:
   pipelines:
     traces:
       receivers: [otlp]
       exporters: [otlp]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [serializer]
 `,
 		},
 		{
 			name: "with both",
 			pcfg: PipelineConfig{
-				GRPCPort:  1234,
-				HTTPPort:  5678,
-				TracePort: 5003,
-				BindHost:  "bindhost",
+				GRPCPort:      1234,
+				HTTPPort:      5678,
+				TracePort:     5003,
+				BindHost:      "bindhost",
+				TracesEnabled: true,
 			},
 			ocfg: `
 receivers:
@@ -104,7 +123,7 @@ service:
 
 	for _, testInstance := range tests {
 		t.Run(testInstance.name, func(t *testing.T) {
-			cfg, err := newParser(testInstance.pcfg)
+			cfg, err := newMap(testInstance.pcfg)
 			require.NoError(t, err)
 			tcfg, err := configparser.NewConfigMapFromBuffer(strings.NewReader(testInstance.ocfg))
 			require.NoError(t, err)
@@ -114,15 +133,17 @@ service:
 }
 
 func TestUnmarshal(t *testing.T) {
-	configMap, err := newParser(PipelineConfig{
-		GRPCPort:  4317,
-		HTTPPort:  4318,
-		TracePort: 5001,
-		BindHost:  "localhost",
+	configMap, err := newMap(PipelineConfig{
+		GRPCPort:       4317,
+		HTTPPort:       4318,
+		TracePort:      5001,
+		BindHost:       "localhost",
+		MetricsEnabled: true,
+		TracesEnabled:  true,
 	})
 	require.NoError(t, err)
 
-	components, err := getComponents()
+	components, err := getComponents(&serializer.MockSerializer{})
 	require.NoError(t, err)
 
 	cu := configunmarshaler.NewDefault()

--- a/pkg/otlp/config_parser_test.go
+++ b/pkg/otlp/config_parser_test.go
@@ -119,6 +119,35 @@ service:
       exporters: [otlp]
 `,
 		},
+		{
+			name: "only HTTP, only metrics",
+			pcfg: PipelineConfig{
+				HTTPPort:       1234,
+				TracePort:      5003,
+				BindHost:       "bindhost",
+				MetricsEnabled: true,
+			},
+			ocfg: `
+receivers:
+  otlp:
+    protocols:
+      http:
+        endpoint: bindhost:1234
+
+processors:
+  batch:
+
+exporters:
+  serializer:
+
+service:
+  pipelines:
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [serializer]
+`,
+		},
 	}
 
 	for _, testInstance := range tests {

--- a/pkg/otlp/config_test.go
+++ b/pkg/otlp/config_test.go
@@ -16,8 +16,11 @@ import (
 
 func loadConfig(path string) (config.Config, error) {
 	cfg := config.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
+	cfg.BindEnvAndSetDefault(experimentalMetricsEnabled, true)
+	cfg.BindEnvAndSetDefault(experimentalTracesEnabled, true)
 	cfg.BindEnv(experimentalHTTPPortSetting, "DD_OTLP_HTTP_PORT")
 	cfg.BindEnv(experimentalgRPCPortSetting, "DD_OTLP_GRPC_PORT")
+
 	cfg.BindEnvAndSetDefault(experimentalTracePortSetting, 5003)
 	cfg.BindEnv("apm_config.apm_non_local_traffic", "DD_APM_NON_LOCAL_TRAFFIC")
 
@@ -83,20 +86,24 @@ func TestFromAgentConfig(t *testing.T) {
 			name: "bind_host",
 			path: "./testdata/bindhost.yaml",
 			cfg: PipelineConfig{
-				BindHost:  "bindhost",
-				HTTPPort:  1234,
-				GRPCPort:  5678,
-				TracePort: 5003,
+				BindHost:       "bindhost",
+				HTTPPort:       1234,
+				GRPCPort:       5678,
+				TracePort:      5003,
+				MetricsEnabled: true,
+				TracesEnabled:  true,
 			},
 		},
 		{
 			name: "no bind_host",
 			path: "./testdata/nobindhost.yaml",
 			cfg: PipelineConfig{
-				BindHost:  "localhost",
-				HTTPPort:  1234,
-				GRPCPort:  5678,
-				TracePort: 5003,
+				BindHost:       "localhost",
+				HTTPPort:       1234,
+				GRPCPort:       5678,
+				TracePort:      5003,
+				MetricsEnabled: true,
+				TracesEnabled:  true,
 			},
 		},
 		{
@@ -110,16 +117,22 @@ func TestFromAgentConfig(t *testing.T) {
 				"; ",
 			),
 		},
-
 		{
 			name: "nonlocal",
 			path: "./testdata/nonlocal.yaml",
 			cfg: PipelineConfig{
-				BindHost:  "0.0.0.0",
-				HTTPPort:  1234,
-				GRPCPort:  5678,
-				TracePort: 5003,
+				BindHost:       "0.0.0.0",
+				HTTPPort:       1234,
+				GRPCPort:       5678,
+				TracePort:      5003,
+				MetricsEnabled: true,
+				TracesEnabled:  true,
 			},
+		},
+		{
+			name: "all disabled",
+			path: "./testdata/alldisabled.yaml",
+			err:  "at least one OTLP signal needs to be enabled",
 		},
 	}
 

--- a/pkg/otlp/internal/serializerexporter/consumer.go
+++ b/pkg/otlp/internal/serializerexporter/consumer.go
@@ -1,0 +1,66 @@
+package serializerexporter
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/otlp/model/translator"
+	"github.com/DataDog/datadog-agent/pkg/quantile"
+	"github.com/DataDog/datadog-agent/pkg/serializer"
+)
+
+var _ translator.Consumer = (*serializerConsumer)(nil)
+
+type serializerConsumer struct {
+	series   metrics.Series
+	sketches metrics.SketchSeriesList
+}
+
+func (c *serializerConsumer) ConsumeSketch(_ context.Context, name string, ts uint64, qsketch *quantile.Sketch, tags []string, host string) {
+	c.sketches = append(c.sketches, metrics.SketchSeries{
+		Name:     name,
+		Tags:     tags,
+		Host:     host,
+		Interval: 1,
+		Points: []metrics.SketchPoint{{
+			Ts:     int64(ts / 1e9),
+			Sketch: qsketch,
+		}},
+	})
+}
+
+func apiTypeFromTranslatorType(typ translator.MetricDataType) metrics.APIMetricType {
+	switch typ {
+	case translator.Count:
+		return metrics.APICountType
+	case translator.Gauge:
+		return metrics.APIGaugeType
+	}
+	panic(fmt.Sprintf("unreachable: received non-count non-gauge type: %d", typ))
+}
+
+func (c *serializerConsumer) ConsumeTimeSeries(ctx context.Context, name string, typ translator.MetricDataType, ts uint64, value float64, tags []string, host string) {
+	c.series = append(c.series,
+		&metrics.Serie{
+			Name:     name,
+			Points:   []metrics.Point{{Ts: float64(ts / 1e9), Value: value}},
+			Tags:     tags,
+			Host:     host,
+			MType:    apiTypeFromTranslatorType(typ),
+			Interval: 1,
+		},
+	)
+}
+
+// flush all metrics and sketches in consumer.
+func (c *serializerConsumer) flush(s serializer.MetricSerializer) error {
+	if err := s.SendSketch(c.sketches); err != nil {
+		return err
+	}
+	if err := s.SendSeries(c.series); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/otlp/internal/serializerexporter/exporter.go
+++ b/pkg/otlp/internal/serializerexporter/exporter.go
@@ -1,0 +1,69 @@
+package serializerexporter
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/otlp/model/translator"
+	"github.com/DataDog/datadog-agent/pkg/serializer"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/model/pdata"
+	"go.uber.org/zap"
+)
+
+var _ config.Exporter = (*exporterConfig)(nil)
+
+// exporterConfig is the exporter configuration.
+type exporterConfig struct {
+	config.ExporterSettings `mapstructure:",squash"`
+}
+
+func newDefaultConfig() config.Exporter {
+	return &exporterConfig{}
+}
+
+var _ translator.HostnameProvider = (*hostnameProviderFunc)(nil)
+
+// hostnameProviderFunc is an adapter to allow the use of a function as a translator.HostnameProvider.
+type hostnameProviderFunc func(context.Context) (string, error)
+
+// Hostname calls f.
+func (f hostnameProviderFunc) Hostname(ctx context.Context) (string, error) {
+	return f(ctx)
+}
+
+// exporter translate OTLP metrics into the Datadog format and sends
+// them to the agent serializer.
+type exporter struct {
+	tr *translator.Translator
+	s  serializer.MetricSerializer
+}
+
+func newExporter(logger *zap.Logger, s serializer.MetricSerializer) (*exporter, error) {
+	// TODO (AP-1267): Expose these settings in datadog.yaml.
+	tr, err := translator.New(logger,
+		translator.WithFallbackHostnameProvider(hostnameProviderFunc(util.GetHostname)),
+		translator.WithHistogramMode(translator.HistogramModeDistributions),
+		translator.WithNumberMode(translator.NumberModeCumulativeToDelta),
+		translator.WithQuantiles(),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build translator: %w", err)
+	}
+
+	return &exporter{tr, s}, nil
+}
+
+func (e *exporter) ConsumeMetrics(ctx context.Context, ld pdata.Metrics) error {
+	consumer := &serializerConsumer{}
+	err := e.tr.MapMetrics(ctx, ld, consumer)
+	if err != nil {
+		return err
+	}
+
+	if err := consumer.flush(e.s); err != nil {
+		return fmt.Errorf("failed to flush metrics: %w", err)
+	}
+	return nil
+}

--- a/pkg/otlp/internal/serializerexporter/factory.go
+++ b/pkg/otlp/internal/serializerexporter/factory.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
+package serializerexporter
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/pkg/serializer"
+	"go.opentelemetry.io/collector/component"
+	"go.opentelemetry.io/collector/config"
+	"go.opentelemetry.io/collector/exporter/exporterhelper"
+)
+
+const (
+	// TypeStr defines the serializer exporter type string.
+	TypeStr = "serializer"
+)
+
+type factory struct {
+	s serializer.MetricSerializer
+}
+
+// NewFactory creates a new serializer exporter factory.
+func NewFactory(s serializer.MetricSerializer) component.ExporterFactory {
+	f := &factory{s}
+
+	return exporterhelper.NewFactory(
+		TypeStr,
+		newDefaultConfig,
+		exporterhelper.WithMetrics(f.createMetricExporter),
+	)
+}
+
+func (f *factory) createMetricExporter(_ context.Context, params component.ExporterCreateSettings, cfg config.Exporter) (component.MetricsExporter, error) {
+	exp, err := newExporter(params.Logger, f.s)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO (AP-1294): Fine-tune queue settings and look into retry settings.
+	return exporterhelper.NewMetricsExporter(cfg, params, exp.ConsumeMetrics,
+		exporterhelper.WithQueue(exporterhelper.DefaultQueueSettings()),
+		// Disable timeout; we don't really do HTTP requests on the ConsumeMetrics call.
+		exporterhelper.WithTimeout(exporterhelper.TimeoutSettings{Timeout: 0}),
+	)
+}

--- a/pkg/otlp/internal/serializerexporter/factory_test.go
+++ b/pkg/otlp/internal/serializerexporter/factory_test.go
@@ -1,0 +1,55 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
+//go:build test
+// +build test
+
+package serializerexporter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/component/componenttest"
+	"go.opentelemetry.io/collector/config/configtest"
+
+	"github.com/DataDog/datadog-agent/pkg/serializer"
+)
+
+func TestNewFactory(t *testing.T) {
+	factory := NewFactory(&serializer.MockSerializer{})
+	cfg := factory.CreateDefaultConfig()
+	assert.NoError(t, configtest.CheckConfigStruct(cfg))
+	_, ok := factory.CreateDefaultConfig().(*exporterConfig)
+	assert.True(t, ok)
+}
+
+func TestNewMetricsExporter(t *testing.T) {
+	factory := NewFactory(&serializer.MockSerializer{})
+	cfg := factory.CreateDefaultConfig()
+	set := componenttest.NewNopExporterCreateSettings()
+	exp, err := factory.CreateMetricsExporter(context.Background(), set, cfg)
+	assert.NoError(t, err)
+	assert.NotNil(t, exp)
+}
+
+func TestNewTracesExporter(t *testing.T) {
+	factory := NewFactory(&serializer.MockSerializer{})
+	cfg := factory.CreateDefaultConfig()
+
+	set := componenttest.NewNopExporterCreateSettings()
+	_, err := factory.CreateTracesExporter(context.Background(), set, cfg)
+	assert.Error(t, err)
+}
+
+func TestNewLogsExporter(t *testing.T) {
+	factory := NewFactory(&serializer.MockSerializer{})
+	cfg := factory.CreateDefaultConfig()
+
+	set := componenttest.NewNopExporterCreateSettings()
+	_, err := factory.CreateLogsExporter(context.Background(), set, cfg)
+	assert.Error(t, err)
+}

--- a/pkg/otlp/testdata/alldisabled.yaml
+++ b/pkg/otlp/testdata/alldisabled.yaml
@@ -1,0 +1,5 @@
+experimental:
+  otlp:
+    http_port: 4318
+    metrics_enabled: false
+    traces_enabled: false

--- a/releasenotes/notes/otlp-metrics-3e16a331d6915be0.yaml
+++ b/releasenotes/notes/otlp-metrics-3e16a331d6915be0.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Added *experimental* support for OTLP metrics via
+    experimental.otlp.{http_port,grpc_port} or their corresponding
+    environment variables (DD_OTLP_{HTTP,GRPC}_PORT).


### PR DESCRIPTION
### What does this PR do?

- Add `TracesEnabled` OTLP pipeline configuration.
- Add a `serializerexporter` that translates and sends OTLP metrics to a metrics serializer.
- Add support for OTLP metrics to the OTLP pipeline.

### Motivation

DataDog/architecture#892

### Additional Notes

Metrics are enabled by default since this is still experimental. Should they be?

### Describe how to test your changes

Set up the OTLP pipeline by providing a port. Check that:
- [ ] if sent via an instrumentation library, timeseries metrics (e.g. OTLP Gauges or Sums) are correctly sent to the backend and that there are no logs.
- [ ] OTLP Histograms are sent correctly: if you send a `test.histogram` metric it will come up as `test.histogram` in the backend and have the usual functions available, with no extra `.count` or `.sum` metrics.
- [ ] The endpoint can receive metrics and traces at the same time.
- [ ] Both gRPC and HTTP work correctly.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
