### PR TITLE
[pkg/otlp] Replace usages of consumererror.Combine by multierr

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -173,6 +173,7 @@ require (
 	go.opentelemetry.io/collector v0.36.0
 	go.opentelemetry.io/collector/model v0.36.0
 	go.uber.org/automaxprocs v1.4.0
+	go.uber.org/multierr v1.6.0
 	go.uber.org/zap v1.19.1
 	go4.org/intern v0.0.0-20210108033219-3eb7198706b2
 	golang.org/x/mobile v0.0.0-20201217150744-e6ae53a27f4f

--- a/pkg/otlp/collector.go
+++ b/pkg/otlp/collector.go
@@ -10,10 +10,10 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/component"
-	"go.opentelemetry.io/collector/consumer/consumererror"
 	"go.opentelemetry.io/collector/exporter/otlpexporter"
 	"go.opentelemetry.io/collector/receiver/otlpreceiver"
 	"go.opentelemetry.io/collector/service"
+	"go.uber.org/multierr"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -61,7 +61,7 @@ func getComponents() (
 		Exporters:  exporters,
 	}
 
-	return factories, consumererror.Combine(errs)
+	return factories, multierr.Combine(errs...)
 }
 
 func getBuildInfo() (component.BuildInfo, error) {

--- a/pkg/otlp/config.go
+++ b/pkg/otlp/config.go
@@ -9,7 +9,7 @@ import (
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"go.opentelemetry.io/collector/consumer/consumererror"
+	"go.uber.org/multierr"
 )
 
 const (
@@ -75,7 +75,7 @@ func fromExperimentalConfig(cfg config.Config) (PipelineConfig, error) {
 		HTTPPort:  httpPort,
 		GRPCPort:  gRPCPort,
 		TracePort: tracePort,
-	}, consumererror.Combine(errs)
+	}, multierr.Combine(errs...)
 }
 
 // IsEnabled checks if OTLP pipeline is enabled in a given config.

--- a/pkg/otlp/config_test.go
+++ b/pkg/otlp/config_test.go
@@ -6,7 +6,6 @@
 package otlp
 
 import (
-	"fmt"
 	"strings"
 	"testing"
 
@@ -78,7 +77,7 @@ func TestFromAgentConfig(t *testing.T) {
 		name string
 		path string
 		cfg  PipelineConfig
-		err  error
+		err  string
 	}{
 		{
 			name: "bind_host",
@@ -103,11 +102,13 @@ func TestFromAgentConfig(t *testing.T) {
 		{
 			name: "invalid",
 			path: "./testdata/invalid.yaml",
-			err: fmt.Errorf("[" +
-				"http port is invalid: -1 is out of [0, 65535] range; " +
-				"gRPC port is invalid: -1 is out of [0, 65535] range; " +
-				"internal trace port is invalid: -1 is out of [0, 65535] range" +
-				"]"),
+			err: strings.Join([]string{
+				"http port is invalid: -1 is out of [0, 65535] range",
+				"gRPC port is invalid: -1 is out of [0, 65535] range",
+				"internal trace port is invalid: -1 is out of [0, 65535] range",
+			},
+				"; ",
+			),
 		},
 
 		{
@@ -127,8 +128,8 @@ func TestFromAgentConfig(t *testing.T) {
 			cfg, err := loadConfig(testInstance.path)
 			require.NoError(t, err)
 			pcfg, err := FromAgentConfig(cfg)
-			if err != nil || testInstance.err != nil {
-				assert.Equal(t, testInstance.err, err)
+			if err != nil || testInstance.err != "" {
+				assert.Equal(t, testInstance.err, err.Error())
 			} else {
 				assert.Equal(t, testInstance.cfg, pcfg)
 			}


### PR DESCRIPTION
### What does this PR do?

Remove usages of `consumererror.Combine` and replace by `multierr` package.

### Motivation

This function will be removed from the Collector.

### Describe how to test your changes

Check that all errors are logged (in the same line) if you set invalid ports on OTLP configuration.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
