### PR TITLE
[networks] Add `ClientBuffer`

### DIFF
--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -164,6 +164,8 @@ func getClientID(req *http.Request) string {
 }
 
 func writeConnections(w http.ResponseWriter, marshaler encoding.Marshaler, cs *network.Connections) {
+	defer network.Reclaim(cs)
+
 	buf, err := marshaler.Marshal(cs)
 	if err != nil {
 		log.Errorf("unable to marshall connections with type %s: %s", marshaler.ContentType(), err)

--- a/cmd/system-probe/modules/network_tracer_test.go
+++ b/cmd/system-probe/modules/network_tracer_test.go
@@ -18,31 +18,33 @@ func TestDecode(t *testing.T) {
 	rec := httptest.NewRecorder()
 
 	in := &network.Connections{
-		Conns: []network.ConnectionStats{
-			{
-				Source:               util.AddressFromString("10.1.1.1"),
-				Dest:                 util.AddressFromString("10.2.2.2"),
-				MonotonicSentBytes:   1,
-				LastSentBytes:        2,
-				MonotonicRecvBytes:   100,
-				LastRecvBytes:        101,
-				LastUpdateEpoch:      50,
-				MonotonicRetransmits: 201,
-				LastRetransmits:      201,
-				Pid:                  6000,
-				NetNS:                7,
-				SPort:                1000,
-				DPort:                9000,
-				IPTranslation: &network.IPTranslation{
-					ReplSrcIP:   util.AddressFromString("20.1.1.1"),
-					ReplDstIP:   util.AddressFromString("20.1.1.1"),
-					ReplSrcPort: 40,
-					ReplDstPort: 70,
-				},
+		BufferedData: network.BufferedData{
+			Conns: []network.ConnectionStats{
+				{
+					Source:               util.AddressFromString("10.1.1.1"),
+					Dest:                 util.AddressFromString("10.2.2.2"),
+					MonotonicSentBytes:   1,
+					LastSentBytes:        2,
+					MonotonicRecvBytes:   100,
+					LastRecvBytes:        101,
+					LastUpdateEpoch:      50,
+					MonotonicRetransmits: 201,
+					LastRetransmits:      201,
+					Pid:                  6000,
+					NetNS:                7,
+					SPort:                1000,
+					DPort:                9000,
+					IPTranslation: &network.IPTranslation{
+						ReplSrcIP:   util.AddressFromString("20.1.1.1"),
+						ReplDstIP:   util.AddressFromString("20.1.1.1"),
+						ReplSrcPort: 40,
+						ReplDstPort: 70,
+					},
 
-				Type:      network.UDP,
-				Family:    network.AFINET6,
-				Direction: network.LOCAL,
+					Type:      network.UDP,
+					Family:    network.AFINET6,
+					Direction: network.LOCAL,
+				},
 			},
 		},
 	}

--- a/pkg/network/client_pool.go
+++ b/pkg/network/client_pool.go
@@ -6,9 +6,9 @@ var clientPool *clientBufferPool
 
 const defaultClientBufferSize = 1024
 
-// ClientBuffer amortizes the allocations of objects generated when a client
+// clientBuffer amortizes the allocations of objects generated when a client
 // calls `GetConnections`.
-type ClientBuffer struct {
+type clientBuffer struct {
 	clientID string
 	*ConnectionBuffer
 	// TODO: consider recycling objects for HTTP and DNS data as well
@@ -16,10 +16,10 @@ type ClientBuffer struct {
 
 type clientBufferPool struct {
 	mux            sync.Mutex
-	bufferByClient map[string]*ClientBuffer
+	bufferByClient map[string]*clientBuffer
 }
 
-func (p *clientBufferPool) Get(clientID string) *ClientBuffer {
+func (p *clientBufferPool) Get(clientID string) *clientBuffer {
 	p.mux.Lock()
 	defer p.mux.Unlock()
 
@@ -29,13 +29,13 @@ func (p *clientBufferPool) Get(clientID string) *ClientBuffer {
 		return buffer
 	}
 
-	return &ClientBuffer{
+	return &clientBuffer{
 		clientID:         clientID,
 		ConnectionBuffer: NewConnectionBuffer(defaultClientBufferSize),
 	}
 }
 
-func (p *clientBufferPool) Put(b *ClientBuffer) {
+func (p *clientBufferPool) Put(b *clientBuffer) {
 	p.mux.Lock()
 	defer p.mux.Unlock()
 
@@ -51,7 +51,7 @@ func (p *clientBufferPool) RemoveExpiredClient(clientID string) {
 
 // Reclaim memory from the `Connections` underlying buffer
 func Reclaim(c *Connections) {
-	b := c.Buffer
+	b := c.buffer
 	if b == nil {
 		return
 	}
@@ -61,6 +61,6 @@ func Reclaim(c *Connections) {
 
 func init() {
 	clientPool = &clientBufferPool{
-		bufferByClient: make(map[string]*ClientBuffer),
+		bufferByClient: make(map[string]*clientBuffer),
 	}
 }

--- a/pkg/network/client_pool.go
+++ b/pkg/network/client_pool.go
@@ -6,15 +6,17 @@ var clientPool *clientBufferPool
 
 const defaultClientBufferSize = 1024
 
-type clientBufferPool struct {
-	mux            sync.Mutex
-	bufferByClient map[string]*ClientBuffer
-}
-
+// ClientBuffer amortizes the allocations of objects generated when a client
+// calls `GetConnections`.
 type ClientBuffer struct {
 	clientID string
 	*ConnectionBuffer
 	// TODO: consider recycling objects for HTTP and DNS data as well
+}
+
+type clientBufferPool struct {
+	mux            sync.Mutex
+	bufferByClient map[string]*ClientBuffer
 }
 
 func (p *clientBufferPool) Get(clientID string) *ClientBuffer {

--- a/pkg/network/client_pool.go
+++ b/pkg/network/client_pool.go
@@ -1,0 +1,64 @@
+package network
+
+import "sync"
+
+var clientPool *clientBufferPool
+
+const defaultClientBufferSize = 1024
+
+type clientBufferPool struct {
+	mux            sync.Mutex
+	bufferByClient map[string]*ClientBuffer
+}
+
+type ClientBuffer struct {
+	clientID string
+	*ConnectionBuffer
+	// TODO: consider recycling objects for HTTP and DNS data as well
+}
+
+func (p *clientBufferPool) Get(clientID string) *ClientBuffer {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+
+	buffer := p.bufferByClient[clientID]
+	if buffer != nil {
+		p.bufferByClient[clientID] = nil
+		return buffer
+	}
+
+	return &ClientBuffer{
+		clientID:         clientID,
+		ConnectionBuffer: NewConnectionBuffer(defaultClientBufferSize),
+	}
+}
+
+func (p *clientBufferPool) Put(b *ClientBuffer) {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+
+	b.Reset()
+	p.bufferByClient[b.clientID] = b
+}
+
+func (p *clientBufferPool) RemoveExpiredClient(clientID string) {
+	p.mux.Lock()
+	defer p.mux.Unlock()
+	delete(p.bufferByClient, clientID)
+}
+
+// Reclaim memory from the `Connections` underlying buffer
+func Reclaim(c *Connections) {
+	b := c.Buffer
+	if b == nil {
+		return
+	}
+
+	clientPool.Put(b)
+}
+
+func init() {
+	clientPool = &clientBufferPool{
+		bufferByClient: make(map[string]*ClientBuffer),
+	}
+}

--- a/pkg/network/client_pool.go
+++ b/pkg/network/client_pool.go
@@ -57,6 +57,7 @@ func Reclaim(c *Connections) {
 	}
 
 	clientPool.Put(b)
+	c.buffer = nil
 }
 
 func init() {

--- a/pkg/network/client_pool_test.go
+++ b/pkg/network/client_pool_test.go
@@ -1,0 +1,33 @@
+package network
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientBufferPool(t *testing.T) {
+	pool := &clientBufferPool{
+		bufferByClient: make(map[string]*ClientBuffer),
+	}
+
+	buffer := pool.Get("client_id")
+
+	// Add twice the elements the buffer originally supports
+	assert.Equal(t, 0, buffer.Len())
+	assert.Equal(t, defaultClientBufferSize, buffer.Capacity())
+	for i := 0; i < 2*defaultClientBufferSize; i++ {
+		buffer.Next().Pid = uint32(i)
+	}
+	assert.Equal(t, 2*defaultClientBufferSize, buffer.Len())
+	increasedCapacity := buffer.Capacity()
+
+	// Now we return the buffer and retrieve it again
+	pool.Put(buffer)
+	buffer = pool.Get("client_id")
+
+	// Buffer length has to be 0, as buffers are cleared when returned to the pool
+	assert.Equal(t, 0, buffer.Len())
+	// Capacity should be retained
+	assert.Equal(t, increasedCapacity, buffer.Capacity())
+}

--- a/pkg/network/client_pool_test.go
+++ b/pkg/network/client_pool_test.go
@@ -8,7 +8,7 @@ import (
 
 func TestClientBufferPool(t *testing.T) {
 	pool := &clientBufferPool{
-		bufferByClient: make(map[string]*ClientBuffer),
+		bufferByClient: make(map[string]*clientBuffer),
 	}
 
 	buffer := pool.Get("client_id")

--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -112,48 +112,50 @@ func getExpectedConnections(encodedWithQueryType bool, httpOutBlob []byte) *mode
 func TestSerialization(t *testing.T) {
 	var httpReqStats http.RequestStats
 	in := &network.Connections{
-		Conns: []network.ConnectionStats{
-			{
-				Source:               util.AddressFromString("10.1.1.1"),
-				Dest:                 util.AddressFromString("10.2.2.2"),
-				MonotonicSentBytes:   1,
-				LastSentBytes:        2,
-				MonotonicRecvBytes:   100,
-				LastRecvBytes:        101,
-				LastUpdateEpoch:      50,
-				LastTCPEstablished:   1,
-				LastTCPClosed:        1,
-				MonotonicRetransmits: 201,
-				LastRetransmits:      201,
-				Pid:                  6000,
-				NetNS:                7,
-				SPort:                1000,
-				DPort:                9000,
-				IPTranslation: &network.IPTranslation{
-					ReplSrcIP:   util.AddressFromString("20.1.1.1"),
-					ReplDstIP:   util.AddressFromString("20.1.1.1"),
-					ReplSrcPort: 40,
-					ReplDstPort: 80,
-				},
+		BufferedData: network.BufferedData{
+			Conns: []network.ConnectionStats{
+				{
+					Source:               util.AddressFromString("10.1.1.1"),
+					Dest:                 util.AddressFromString("10.2.2.2"),
+					MonotonicSentBytes:   1,
+					LastSentBytes:        2,
+					MonotonicRecvBytes:   100,
+					LastRecvBytes:        101,
+					LastUpdateEpoch:      50,
+					LastTCPEstablished:   1,
+					LastTCPClosed:        1,
+					MonotonicRetransmits: 201,
+					LastRetransmits:      201,
+					Pid:                  6000,
+					NetNS:                7,
+					SPort:                1000,
+					DPort:                9000,
+					IPTranslation: &network.IPTranslation{
+						ReplSrcIP:   util.AddressFromString("20.1.1.1"),
+						ReplDstIP:   util.AddressFromString("20.1.1.1"),
+						ReplSrcPort: 40,
+						ReplDstPort: 80,
+					},
 
-				Type:      network.UDP,
-				Family:    network.AFINET6,
-				Direction: network.LOCAL,
+					Type:      network.UDP,
+					Family:    network.AFINET6,
+					Direction: network.LOCAL,
 
-				DNSCountByRcode: map[uint32]uint32{0: 1},
-				DNSStatsByDomainByQueryType: map[*intern.Value]map[dns.QueryType]dns.Stats{
-					intern.GetByString("foo.com"): {
-						dns.TypeA: {
-							Timeouts:          0,
-							SuccessLatencySum: 0,
-							FailureLatencySum: 0,
-							CountByRcode:      map[uint32]uint32{0: 1},
+					DNSCountByRcode: map[uint32]uint32{0: 1},
+					DNSStatsByDomainByQueryType: map[*intern.Value]map[dns.QueryType]dns.Stats{
+						intern.GetByString("foo.com"): {
+							dns.TypeA: {
+								Timeouts:          0,
+								SuccessLatencySum: 0,
+								FailureLatencySum: 0,
+								CountByRcode:      map[uint32]uint32{0: 1},
+							},
 						},
 					},
-				},
-				Via: &network.Via{
-					Subnet: network.Subnet{
-						Alias: "subnet-foo",
+					Via: &network.Via{
+						Subnet: network.Subnet{
+							Alias: "subnet-foo",
+						},
 					},
 				},
 			},
@@ -285,7 +287,11 @@ func TestSerialization(t *testing.T) {
 		assert.Equal("application/json", marshaler.ContentType())
 
 		// Empty connection batch
-		blob, err := marshaler.Marshal(&network.Connections{Conns: []network.ConnectionStats{{}}})
+		blob, err := marshaler.Marshal(&network.Connections{
+			BufferedData: network.BufferedData{
+				Conns: []network.ConnectionStats{{}},
+			},
+		})
 		require.NoError(t, err)
 
 		res := struct {
@@ -426,18 +432,20 @@ func TestHTTPSerializationWithLocalhostTraffic(t *testing.T) {
 
 	var httpReqStats http.RequestStats
 	in := &network.Connections{
-		Conns: []network.ConnectionStats{
-			{
-				Source: localhost,
-				Dest:   localhost,
-				SPort:  clientPort,
-				DPort:  serverPort,
-			},
-			{
-				Source: localhost,
-				Dest:   localhost,
-				SPort:  serverPort,
-				DPort:  clientPort,
+		BufferedData: network.BufferedData{
+			Conns: []network.ConnectionStats{
+				{
+					Source: localhost,
+					Dest:   localhost,
+					SPort:  clientPort,
+					DPort:  serverPort,
+				},
+				{
+					Source: localhost,
+					Dest:   localhost,
+					SPort:  serverPort,
+					DPort:  clientPort,
+				},
 			},
 		},
 		HTTP: map[http.Key]http.RequestStats{
@@ -516,12 +524,14 @@ func TestPooledObjectGarbageRegression(t *testing.T) {
 	)
 
 	in := &network.Connections{
-		Conns: []network.ConnectionStats{
-			{
-				Source: util.AddressFromString("10.0.15.1"),
-				SPort:  uint16(60000),
-				Dest:   util.AddressFromString("172.217.10.45"),
-				DPort:  uint16(8080),
+		BufferedData: network.BufferedData{
+			Conns: []network.ConnectionStats{
+				{
+					Source: util.AddressFromString("10.0.15.1"),
+					SPort:  uint16(60000),
+					Dest:   util.AddressFromString("172.217.10.45"),
+					DPort:  uint16(8080),
+				},
 			},
 		},
 	}

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -104,15 +104,19 @@ func (e EphemeralPortType) String() string {
 	}
 }
 
+// BufferedData encapsulates data whose underlying memory can be recycled
+type BufferedData struct {
+	Conns  []ConnectionStats
+	buffer *clientBuffer
+}
+
 // Connections wraps a collection of ConnectionStats
 type Connections struct {
+	BufferedData
 	DNS                         map[util.Address][]string
-	Conns                       []ConnectionStats
 	ConnTelemetry               *ConnectionsTelemetry
 	CompilationTelemetryByAsset map[string]RuntimeCompilationTelemetry
 	HTTP                        map[http.Key]http.RequestStats
-
-	Buffer *ClientBuffer
 }
 
 // ConnectionsTelemetry stores telemetry from the system probe related to connections collection

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -111,6 +111,8 @@ type Connections struct {
 	ConnTelemetry               *ConnectionsTelemetry
 	CompilationTelemetryByAsset map[string]RuntimeCompilationTelemetry
 	HTTP                        map[http.Key]http.RequestStats
+
+	Buffer *ClientBuffer
 }
 
 // ConnectionsTelemetry stores telemetry from the system probe related to connections collection

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -225,7 +225,7 @@ func (ns *networkState) GetDelta(
 
 	return Delta{
 		BufferedData: BufferedData{
-			Conns:  clientBuffer.Connections(),
+			Conns:  conns,
 			buffer: clientBuffer,
 		},
 		HTTP: ns.getHTTPDelta(id),

--- a/pkg/network/state_test.go
+++ b/pkg/network/state_test.go
@@ -115,10 +115,10 @@ func TestRemoveConnections(t *testing.T) {
 
 	clientID := "1"
 	state := newDefaultState().(*networkState)
-	conns := state.GetDelta(clientID, latestEpochTime(), nil, nil, nil, nil).Connections
+	conns := state.GetDelta(clientID, latestEpochTime(), nil, nil, nil, nil).Conns
 	assert.Equal(t, 0, len(conns))
 
-	conns = state.GetDelta(clientID, latestEpochTime(), []ConnectionStats{conn}, nil, nil, nil).Connections
+	conns = state.GetDelta(clientID, latestEpochTime(), []ConnectionStats{conn}, nil, nil, nil).Conns
 	assert.Equal(t, 1, len(conns))
 	assert.Equal(t, conn, conns[0])
 
@@ -151,7 +151,7 @@ func TestRetrieveClosedConnection(t *testing.T) {
 
 	t.Run("without prior registration", func(t *testing.T) {
 		state := newDefaultState()
-		conns := state.GetDelta(clientID, latestEpochTime(), nil, []ConnectionStats{conn}, nil, nil).Connections
+		conns := state.GetDelta(clientID, latestEpochTime(), nil, []ConnectionStats{conn}, nil, nil).Conns
 
 		assert.Equal(t, 0, len(conns))
 	})
@@ -159,19 +159,19 @@ func TestRetrieveClosedConnection(t *testing.T) {
 	t.Run("with registration", func(t *testing.T) {
 		state := newDefaultState()
 
-		conns := state.GetDelta(clientID, latestEpochTime(), nil, nil, nil, nil).Connections
+		conns := state.GetDelta(clientID, latestEpochTime(), nil, nil, nil, nil).Conns
 		assert.Equal(t, 0, len(conns))
 
-		conns = state.GetDelta(clientID, latestEpochTime(), nil, []ConnectionStats{conn}, nil, nil).Connections
+		conns = state.GetDelta(clientID, latestEpochTime(), nil, []ConnectionStats{conn}, nil, nil).Conns
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, conn, conns[0])
 
 		// An other client that is not registered should not have the closed connection
-		conns = state.GetDelta("2", latestEpochTime(), nil, nil, nil, nil).Connections
+		conns = state.GetDelta("2", latestEpochTime(), nil, nil, nil, nil).Conns
 		assert.Equal(t, 0, len(conns))
 
 		// It should no more have connections stored
-		conns = state.GetDelta(clientID, latestEpochTime(), nil, nil, nil, nil).Connections
+		conns = state.GetDelta(clientID, latestEpochTime(), nil, nil, nil, nil).Conns
 		assert.Equal(t, 0, len(conns))
 	})
 }
@@ -183,7 +183,7 @@ func TestCleanupClient(t *testing.T) {
 	clients := state.(*networkState).getClients()
 	assert.Equal(t, 0, len(clients))
 
-	conns := state.GetDelta(clientID, latestEpochTime(), nil, nil, nil, nil).Connections
+	conns := state.GetDelta(clientID, latestEpochTime(), nil, nil, nil, nil).Conns
 	assert.Equal(t, 0, len(conns))
 
 	// Should be a no op
@@ -233,15 +233,15 @@ func TestLastStats(t *testing.T) {
 	conn3.MonotonicRetransmits += dRetransmits
 
 	// First get, we should not have any connections stored
-	conns := state.GetDelta(client1, latestEpochTime(), nil, nil, nil, nil).Connections
+	conns := state.GetDelta(client1, latestEpochTime(), nil, nil, nil, nil).Conns
 	assert.Equal(t, 0, len(conns))
 
 	// Same for an other client
-	conns = state.GetDelta(client2, latestEpochTime(), nil, nil, nil, nil).Connections
+	conns = state.GetDelta(client2, latestEpochTime(), nil, nil, nil, nil).Conns
 	assert.Equal(t, 0, len(conns))
 
 	// We should have only one connection but with last stats equal to monotonic
-	conns = state.GetDelta(client1, latestEpochTime(), []ConnectionStats{conn}, nil, nil, nil).Connections
+	conns = state.GetDelta(client1, latestEpochTime(), []ConnectionStats{conn}, nil, nil, nil).Conns
 	assert.Equal(t, 1, len(conns))
 	assert.Equal(t, conn.MonotonicSentBytes, conns[0].LastSentBytes)
 	assert.Equal(t, conn.MonotonicRecvBytes, conns[0].LastRecvBytes)
@@ -251,7 +251,7 @@ func TestLastStats(t *testing.T) {
 	assert.Equal(t, conn.MonotonicRetransmits, conns[0].MonotonicRetransmits)
 
 	// This client didn't collect the first connection so last stats = monotonic
-	conns = state.GetDelta(client2, latestEpochTime(), []ConnectionStats{conn2}, nil, nil, nil).Connections
+	conns = state.GetDelta(client2, latestEpochTime(), []ConnectionStats{conn2}, nil, nil, nil).Conns
 	assert.Equal(t, 1, len(conns))
 	assert.Equal(t, conn2.MonotonicSentBytes, conns[0].LastSentBytes)
 	assert.Equal(t, conn2.MonotonicRecvBytes, conns[0].LastRecvBytes)
@@ -261,7 +261,7 @@ func TestLastStats(t *testing.T) {
 	assert.Equal(t, conn2.MonotonicRetransmits, conns[0].MonotonicRetransmits)
 
 	// client 1 should have conn3 - conn1 since it did not collected conn2
-	conns = state.GetDelta(client1, latestEpochTime(), []ConnectionStats{conn3}, nil, nil, nil).Connections
+	conns = state.GetDelta(client1, latestEpochTime(), []ConnectionStats{conn3}, nil, nil, nil).Conns
 	assert.Equal(t, 1, len(conns))
 	assert.Equal(t, 2*dSent, conns[0].LastSentBytes)
 	assert.Equal(t, 2*dRecv, conns[0].LastRecvBytes)
@@ -271,7 +271,7 @@ func TestLastStats(t *testing.T) {
 	assert.Equal(t, conn3.MonotonicRetransmits, conns[0].MonotonicRetransmits)
 
 	// client 2 should have conn3 - conn2
-	conns = state.GetDelta(client2, latestEpochTime(), []ConnectionStats{conn3}, nil, nil, nil).Connections
+	conns = state.GetDelta(client2, latestEpochTime(), []ConnectionStats{conn3}, nil, nil, nil).Conns
 	assert.Equal(t, 1, len(conns))
 	assert.Equal(t, dSent, conns[0].LastSentBytes)
 	assert.Equal(t, dRecv, conns[0].LastRecvBytes)
@@ -308,11 +308,11 @@ func TestLastStatsForClosedConnection(t *testing.T) {
 	conn2.MonotonicRetransmits += dRetransmits
 
 	// First get, we should not have any connections stored
-	conns := state.GetDelta(clientID, latestEpochTime(), nil, nil, nil, nil).Connections
+	conns := state.GetDelta(clientID, latestEpochTime(), nil, nil, nil, nil).Conns
 	assert.Equal(t, 0, len(conns))
 
 	// We should have one connection with last stats equal to monotonic stats
-	conns = state.GetDelta(clientID, latestEpochTime(), []ConnectionStats{conn}, nil, nil, nil).Connections
+	conns = state.GetDelta(clientID, latestEpochTime(), []ConnectionStats{conn}, nil, nil, nil).Conns
 	assert.Equal(t, 1, len(conns))
 	assert.Equal(t, conn.MonotonicSentBytes, conns[0].LastSentBytes)
 	assert.Equal(t, conn.MonotonicRecvBytes, conns[0].LastRecvBytes)
@@ -322,7 +322,7 @@ func TestLastStatsForClosedConnection(t *testing.T) {
 	assert.Equal(t, conn.MonotonicRetransmits, conns[0].MonotonicRetransmits)
 
 	// We should have one connection with last stats
-	conns = state.GetDelta(clientID, latestEpochTime(), nil, []ConnectionStats{conn2}, nil, nil).Connections
+	conns = state.GetDelta(clientID, latestEpochTime(), nil, []ConnectionStats{conn2}, nil, nil).Conns
 
 	assert.Equal(t, 1, len(conns))
 	assert.Equal(t, dSent, conns[0].LastSentBytes)
@@ -412,11 +412,11 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state := newDefaultState()
 
 		// First get, we should have nothing
-		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Connections
+		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Conns
 		assert.Equal(t, 0, len(conns))
 
 		// Second get, we should have monotonic and last stats = 3
-		conns = state.GetDelta(client, latestEpochTime(), nil, []ConnectionStats{conn}, nil, nil).Connections
+		conns = state.GetDelta(client, latestEpochTime(), nil, []ConnectionStats{conn}, nil, nil).Conns
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 3, int(conns[0].LastSentBytes))
@@ -438,7 +438,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state := newDefaultState()
 
 		// First get, we should have nothing
-		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Connections
+		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Conns
 		assert.Equal(t, 0, len(conns))
 
 		conn2 := conn
@@ -446,7 +446,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		conn2.LastUpdateEpoch++
 
 		// Second get, we should have monotonic and last stats = 8
-		conns = state.GetDelta(client, latestEpochTime(), nil, []ConnectionStats{conn, conn2}, nil, nil).Connections
+		conns = state.GetDelta(client, latestEpochTime(), nil, []ConnectionStats{conn, conn2}, nil, nil).Conns
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 8, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 8, int(conns[0].LastSentBytes))
@@ -470,7 +470,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state := newDefaultState()
 
 		// First get for client c, we should have nothing
-		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Connections
+		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Conns
 		assert.Len(t, conns, 0)
 
 		conn := ConnectionStats{
@@ -485,7 +485,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		}
 
 		// Simulate this connection starting
-		conns = state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn}, nil, nil, nil).Connections
+		conns = state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn}, nil, nil, nil).Conns
 		require.Len(t, conns, 1)
 		assert.EqualValues(t, 1, conns[0].LastSentBytes)
 		assert.EqualValues(t, 1, conns[0].MonotonicSentBytes)
@@ -498,7 +498,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		conn.MonotonicSentBytes = 1
 		conn.LastUpdateEpoch = latestEpochTime()
 		// Retrieve the connections
-		conns = state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn}, closed, nil, nil).Connections
+		conns = state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn}, closed, nil, nil).Conns
 		require.Len(t, conns, 1)
 		assert.EqualValues(t, 2, conns[0].LastSentBytes)
 		assert.EqualValues(t, 3, conns[0].MonotonicSentBytes)
@@ -506,7 +506,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		conn.MonotonicSentBytes++
 		conn.LastUpdateEpoch = latestEpochTime()
 		// Store the connection as closed
-		conns = state.GetDelta(client, latestEpochTime(), nil, []ConnectionStats{conn}, nil, nil).Connections
+		conns = state.GetDelta(client, latestEpochTime(), nil, []ConnectionStats{conn}, nil, nil).Conns
 		require.Len(t, conns, 1)
 		assert.EqualValues(t, 1, conns[0].LastSentBytes)
 		assert.EqualValues(t, 2, conns[0].MonotonicSentBytes)
@@ -530,7 +530,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state := newDefaultState()
 
 		// First get, we should have nothing
-		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Connections
+		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Conns
 		assert.Equal(t, 0, len(conns))
 
 		conn2 := conn
@@ -539,7 +539,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		cs := []ConnectionStats{conn2}
 
 		// Second get, we should have monotonic and last stats = 5
-		conns = state.GetDelta(client, latestEpochTime(), cs, []ConnectionStats{conn}, nil, nil).Connections
+		conns = state.GetDelta(client, latestEpochTime(), cs, []ConnectionStats{conn}, nil, nil).Conns
 		require.Equal(t, 1, len(conns))
 		assert.Equal(t, 5, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 5, int(conns[0].LastSentBytes))
@@ -554,7 +554,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		conn3.LastUpdateEpoch++
 
 		// Third get, we should have monotonic = 6 and last stats = 4
-		conns = state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn3}, []ConnectionStats{conn2}, nil, nil).Connections
+		conns = state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn3}, []ConnectionStats{conn2}, nil, nil).Conns
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 6, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 4, int(conns[0].LastSentBytes))
@@ -563,7 +563,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		conn3.MonotonicSentBytes += 2
 
 		// 4th get, we should have monotonic = 3 and last stats = 2
-		conns = state.GetDelta(client, latestEpochTime(), nil, []ConnectionStats{conn3}, nil, nil).Connections
+		conns = state.GetDelta(client, latestEpochTime(), nil, []ConnectionStats{conn3}, nil, nil).Conns
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 2, int(conns[0].LastSentBytes))
@@ -585,14 +585,14 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state := newDefaultState()
 
 		// this is to register we should not have anything
-		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Connections
+		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Conns
 		assert.Equal(t, 0, len(conns))
 
 		// Store the connection as opened
 		cs := []ConnectionStats{conn}
 
 		// First get, we should have monotonic = 3 and last seen = 3
-		conns = state.GetDelta(client, latestEpochTime(), cs, nil, nil, nil).Connections
+		conns = state.GetDelta(client, latestEpochTime(), cs, nil, nil, nil).Conns
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 3, int(conns[0].LastSentBytes))
@@ -602,7 +602,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		conn2.MonotonicSentBytes = 8
 
 		// Second get, we should have monotonic = 8 and last stats = 5
-		conns = state.GetDelta(client, latestEpochTime(), nil, []ConnectionStats{conn2}, nil, nil).Connections
+		conns = state.GetDelta(client, latestEpochTime(), nil, []ConnectionStats{conn2}, nil, nil).Conns
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 8, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 5, int(conns[0].LastSentBytes))
@@ -642,15 +642,15 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state := newDefaultState()
 
 		// First get for client c, we should have nothing
-		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Connections
+		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Conns
 		assert.Equal(t, 0, len(conns))
 
 		// First get for client d, we should have nothing
-		conns = state.GetDelta(clientD, latestEpochTime(), nil, nil, nil, nil).Connections
+		conns = state.GetDelta(clientD, latestEpochTime(), nil, nil, nil, nil).Conns
 		assert.Equal(t, 0, len(conns))
 
 		// Second get for client d we should have monotonic and last stats = 3
-		conns = state.GetDelta(clientD, latestEpochTime(), nil, []ConnectionStats{conn}, nil, nil).Connections
+		conns = state.GetDelta(clientD, latestEpochTime(), nil, []ConnectionStats{conn}, nil, nil).Conns
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 3, int(conns[0].LastSentBytes))
@@ -662,7 +662,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		cs := []ConnectionStats{conn2}
 
 		// Second get, for client c we should have monotonic and last stats = 5
-		conns = state.GetDelta(client, latestEpochTime(), cs, nil, nil, nil).Connections
+		conns = state.GetDelta(client, latestEpochTime(), cs, nil, nil, nil).Conns
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 5, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 5, int(conns[0].LastSentBytes))
@@ -673,7 +673,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		cs = []ConnectionStats{conn2}
 
 		// Third get, for client d we should have monotonic = 3 and last stats = 3
-		conns = state.GetDelta(clientD, latestEpochTime(), cs, nil, nil, nil).Connections
+		conns = state.GetDelta(clientD, latestEpochTime(), cs, nil, nil, nil).Conns
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 3, int(conns[0].LastSentBytes))
@@ -689,7 +689,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		cs = []ConnectionStats{conn3}
 
 		// Third get, for client c, we should have monotonic = 6 and last stats = 4
-		conns = state.GetDelta(client, latestEpochTime(), cs, []ConnectionStats{conn2}, nil, nil).Connections
+		conns = state.GetDelta(client, latestEpochTime(), cs, []ConnectionStats{conn2}, nil, nil).Conns
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 6, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 4, int(conns[0].LastSentBytes))
@@ -700,7 +700,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		cs = []ConnectionStats{conn3}
 
 		// 4th get, for client d, we should have monotonic = 7 and last stats = 4
-		conns = state.GetDelta(clientD, latestEpochTime(), cs, nil, nil, nil).Connections
+		conns = state.GetDelta(clientD, latestEpochTime(), cs, nil, nil, nil).Conns
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 7, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 4, int(conns[0].LastSentBytes))
@@ -710,13 +710,13 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		conn3.LastUpdateEpoch++
 
 		// 4th get, for client c we should have monotonic = 3 and last stats = 2
-		conns = state.GetDelta(client, latestEpochTime(), nil, []ConnectionStats{conn3}, nil, nil).Connections
+		conns = state.GetDelta(client, latestEpochTime(), nil, []ConnectionStats{conn3}, nil, nil).Conns
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 2, int(conns[0].LastSentBytes))
 
 		// 5th get, for client d we should have monotonic = 3 and last stats = 1
-		conns = state.GetDelta(clientD, latestEpochTime(), nil, nil, nil, nil).Connections
+		conns = state.GetDelta(clientD, latestEpochTime(), nil, nil, nil, nil).Conns
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 1, int(conns[0].LastSentBytes))
@@ -764,15 +764,15 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state := newDefaultState()
 
 		// First get for client c, we should have nothing
-		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Connections
+		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Conns
 		assert.Equal(t, 0, len(conns))
 
 		// First get for client d, we should have nothing
-		conns = state.GetDelta(clientD, latestEpochTime(), nil, nil, nil, nil).Connections
+		conns = state.GetDelta(clientD, latestEpochTime(), nil, nil, nil, nil).Conns
 		assert.Equal(t, 0, len(conns))
 
 		// First get for client e, we should have nothing
-		conns = state.GetDelta(clientE, latestEpochTime(), nil, nil, nil, nil).Connections
+		conns = state.GetDelta(clientE, latestEpochTime(), nil, nil, nil, nil).Conns
 		assert.Equal(t, 0, len(conns))
 
 		// Store the connection
@@ -781,7 +781,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		cs := []ConnectionStats{conn}
 
 		// Second get for client e we should have monotonic and last stats = 2
-		conns = state.GetDelta(clientE, latestEpochTime(), cs, nil, nil, nil).Connections
+		conns = state.GetDelta(clientE, latestEpochTime(), cs, nil, nil, nil).Conns
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 2, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 2, int(conns[0].LastSentBytes))
@@ -791,13 +791,13 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		conn.LastUpdateEpoch++
 
 		// Second get for client d we should have monotonic and last stats = 3
-		conns = state.GetDelta(clientD, latestEpochTime(), nil, []ConnectionStats{conn}, nil, nil).Connections
+		conns = state.GetDelta(clientD, latestEpochTime(), nil, []ConnectionStats{conn}, nil, nil).Conns
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 3, int(conns[0].LastSentBytes))
 
 		// Third get for client e we should have monotonic = 3and last stats = 1
-		conns = state.GetDelta(clientE, latestEpochTime(), nil, nil, nil, nil).Connections
+		conns = state.GetDelta(clientE, latestEpochTime(), nil, nil, nil, nil).Conns
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 1, int(conns[0].LastSentBytes))
@@ -809,7 +809,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		cs = []ConnectionStats{conn2}
 
 		// Second get, for client c we should have monotonic and last stats = 5
-		conns = state.GetDelta(client, latestEpochTime(), cs, nil, nil, nil).Connections
+		conns = state.GetDelta(client, latestEpochTime(), cs, nil, nil, nil).Conns
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 5, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 5, int(conns[0].LastSentBytes))
@@ -820,7 +820,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		cs = []ConnectionStats{conn2}
 
 		// Third get, for client d we should have monotonic = 3 and last stats = 3
-		conns = state.GetDelta(clientD, latestEpochTime(), cs, nil, nil, nil).Connections
+		conns = state.GetDelta(clientD, latestEpochTime(), cs, nil, nil, nil).Conns
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 3, int(conns[0].LastSentBytes))
@@ -830,7 +830,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		conn2.LastUpdateEpoch++
 
 		// 4th get, for client e we should have monotonic = 5 and last stats = 5
-		conns = state.GetDelta(clientE, latestEpochTime(), nil, []ConnectionStats{conn2}, nil, nil).Connections
+		conns = state.GetDelta(clientE, latestEpochTime(), nil, []ConnectionStats{conn2}, nil, nil).Conns
 		assert.Equal(t, 1, len(conns))
 		assert.Equal(t, 5, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 5, int(conns[0].LastSentBytes))
@@ -866,11 +866,11 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		state := newDefaultState()
 
 		// First get for client c, we should have nothing
-		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Connections
+		conns := state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Conns
 		assert.Equal(t, 0, len(conns))
 
 		// Second get for client c we should have monotonic and last stats = 3
-		conns = state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn}, nil, nil, nil).Connections
+		conns = state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn}, nil, nil, nil).Conns
 		assert.Len(t, conns, 1)
 		assert.Equal(t, 3, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 3, int(conns[0].LastSentBytes))
@@ -880,7 +880,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		conn2.LastUpdateEpoch++
 
 		// First get for client d we should have monotonic = 4 and last bytes = 4
-		conns = state.GetDelta(clientD, latestEpochTime(), []ConnectionStats{conn2}, nil, nil, nil).Connections
+		conns = state.GetDelta(clientD, latestEpochTime(), []ConnectionStats{conn2}, nil, nil, nil).Conns
 		assert.Len(t, conns, 1)
 		assert.Equal(t, 4, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 0, int(conns[0].LastSentBytes))
@@ -890,7 +890,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		conn3.LastUpdateEpoch++
 
 		// Third get for client c we should have monotonic = 7 and last bytes = 4
-		conns = state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn3}, nil, nil, nil).Connections
+		conns = state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn3}, nil, nil, nil).Conns
 		assert.Len(t, conns, 1)
 		assert.Equal(t, 7, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 4, int(conns[0].LastSentBytes))
@@ -900,7 +900,7 @@ func TestSameKeyEdgeCases(t *testing.T) {
 		conn4.LastUpdateEpoch++
 
 		// Second get for client d we should have monotonic = 9 and last bytes = 5
-		conns = state.GetDelta(clientD, latestEpochTime(), []ConnectionStats{conn4}, nil, nil, nil).Connections
+		conns = state.GetDelta(clientD, latestEpochTime(), []ConnectionStats{conn4}, nil, nil, nil).Conns
 		assert.Len(t, conns, 1)
 		assert.Equal(t, 9, int(conns[0].MonotonicSentBytes))
 		assert.Equal(t, 5, int(conns[0].LastSentBytes))
@@ -923,10 +923,10 @@ func TestStatsResetOnUnderflow(t *testing.T) {
 	state := newDefaultState()
 
 	// Register the client
-	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Connections, 0)
+	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Conns, 0)
 
 	// Get the connections once to register stats
-	conns := state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn}, nil, nil, nil).Connections
+	conns := state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn}, nil, nil, nil).Conns
 	require.Len(t, conns, 1)
 
 	// Expect LastStats to be 3
@@ -936,7 +936,7 @@ func TestStatsResetOnUnderflow(t *testing.T) {
 	// Get the connections again but by simulating an underflow
 	conn.MonotonicSentBytes--
 
-	conns = state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn}, nil, nil, nil).Connections
+	conns = state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn}, nil, nil, nil).Conns
 	require.Len(t, conns, 1)
 	expected := conn
 	expected.LastSentBytes = 2
@@ -966,8 +966,8 @@ func TestDoubleCloseOnTwoClients(t *testing.T) {
 	state := newDefaultState()
 
 	// Register the clients
-	assert.Len(t, state.GetDelta(client1, latestEpochTime(), nil, nil, nil, nil).Connections, 0)
-	assert.Len(t, state.GetDelta(client2, latestEpochTime(), nil, nil, nil, nil).Connections, 0)
+	assert.Len(t, state.GetDelta(client1, latestEpochTime(), nil, nil, nil, nil).Conns, 0)
+	assert.Len(t, state.GetDelta(client2, latestEpochTime(), nil, nil, nil, nil).Conns, 0)
 
 	// Store the closed connection twice
 	conn2 := conn
@@ -976,12 +976,12 @@ func TestDoubleCloseOnTwoClients(t *testing.T) {
 
 	expectedConn.LastUpdateEpoch = conn2.LastUpdateEpoch
 	// Get the connections for client1 we should have only one with stats = 2*conn
-	conns := state.GetDelta(client1, latestEpochTime(), nil, closed, nil, nil).Connections
+	conns := state.GetDelta(client1, latestEpochTime(), nil, closed, nil, nil).Conns
 	require.Len(t, conns, 1)
 	assert.Equal(t, expectedConn, conns[0])
 
 	// Same for client2
-	conns = state.GetDelta(client2, latestEpochTime(), nil, nil, nil, nil).Connections
+	conns = state.GetDelta(client2, latestEpochTime(), nil, nil, nil, nil).Conns
 	require.Len(t, conns, 1)
 	assert.Equal(t, expectedConn, conns[0])
 }
@@ -1000,7 +1000,7 @@ func TestUnorderedCloseEvent(t *testing.T) {
 	state := newDefaultState()
 
 	// Register the client
-	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Connections, 0)
+	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Conns, 0)
 
 	// Simulate storing a closed connection while we were reading from the eBPF map
 	// in this case the closed conn will have an earlier epoch
@@ -1012,22 +1012,22 @@ func TestUnorderedCloseEvent(t *testing.T) {
 	conn.LastUpdateEpoch--
 	conn.MonotonicSentBytes--
 	conn.MonotonicRecvBytes = 0
-	conns := state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn}, closed, nil, nil).Connections
+	conns := state.GetDelta(client, latestEpochTime(), []ConnectionStats{conn}, closed, nil, nil).Conns
 	require.Len(t, conns, 1)
 	assert.EqualValues(t, 4, conns[0].LastSentBytes)
 	assert.EqualValues(t, 1, conns[0].LastRecvBytes)
 
 	// Simulate some other gets
-	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Connections, 0)
-	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Connections, 0)
-	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Connections, 0)
+	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Conns, 0)
+	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Conns, 0)
+	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Conns, 0)
 
 	// Simulate having the connection getting active again
 	conn.LastUpdateEpoch = latestEpochTime()
 	conn.MonotonicSentBytes--
 	closed = []ConnectionStats{conn}
 
-	conns = state.GetDelta(client, latestEpochTime(), nil, closed, nil, nil).Connections
+	conns = state.GetDelta(client, latestEpochTime(), nil, closed, nil, nil).Conns
 	require.Len(t, conns, 1)
 	assert.EqualValues(t, 2, conns[0].LastSentBytes)
 	assert.EqualValues(t, 0, conns[0].LastRecvBytes)
@@ -1035,7 +1035,7 @@ func TestUnorderedCloseEvent(t *testing.T) {
 	// Ensure we don't have underflows / unordered conns
 	assert.Zero(t, state.(*networkState).telemetry.statsResets)
 
-	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Connections, 0)
+	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Conns, 0)
 }
 
 func TestAggregateClosedConnectionsTimestamp(t *testing.T) {
@@ -1052,7 +1052,7 @@ func TestAggregateClosedConnectionsTimestamp(t *testing.T) {
 	state := newDefaultState()
 
 	// Register the client
-	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Connections, 0)
+	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Conns, 0)
 
 	conn1 := conn
 	conn1.LastUpdateEpoch = latestEpochTime()
@@ -1065,7 +1065,7 @@ func TestAggregateClosedConnectionsTimestamp(t *testing.T) {
 
 	// Make sure the connections we get has the latest timestamp
 	delta := state.GetDelta(client, latestEpochTime(), nil, []ConnectionStats{conn1, conn2, conn3}, nil, nil)
-	assert.Equal(t, conn3.LastUpdateEpoch, delta.Connections[0].LastUpdateEpoch)
+	assert.Equal(t, conn3.LastUpdateEpoch, delta.Conns[0].LastUpdateEpoch)
 }
 
 func TestDNSStatsWithMultipleClients(t *testing.T) {
@@ -1099,22 +1099,22 @@ func TestDNSStatsWithMultipleClients(t *testing.T) {
 	state := newDefaultState()
 
 	// Register the first two clients
-	assert.Len(t, state.GetDelta(client1, latestEpochTime(), nil, nil, nil, nil).Connections, 0)
-	assert.Len(t, state.GetDelta(client2, latestEpochTime(), nil, nil, nil, nil).Connections, 0)
+	assert.Len(t, state.GetDelta(client1, latestEpochTime(), nil, nil, nil, nil).Conns, 0)
+	assert.Len(t, state.GetDelta(client2, latestEpochTime(), nil, nil, nil, nil).Conns, 0)
 
 	c.LastUpdateEpoch = latestEpochTime()
 
-	conns := state.GetDelta(client1, latestEpochTime(), nil, []ConnectionStats{c}, getStats(), nil).Connections
+	conns := state.GetDelta(client1, latestEpochTime(), nil, []ConnectionStats{c}, getStats(), nil).Conns
 	require.Len(t, conns, 1)
 	assert.EqualValues(t, 1, conns[0].DNSSuccessfulResponses)
 
 	// Register the third client but also pass in dns stats
-	conns = state.GetDelta(client3, latestEpochTime(), []ConnectionStats{c}, nil, getStats(), nil).Connections
+	conns = state.GetDelta(client3, latestEpochTime(), []ConnectionStats{c}, nil, getStats(), nil).Conns
 	require.Len(t, conns, 1)
 	// DNS stats should be available for the new client
 	assert.EqualValues(t, 1, conns[0].DNSSuccessfulResponses)
 
-	conns = state.GetDelta(client2, latestEpochTime(), []ConnectionStats{c}, nil, getStats(), nil).Connections
+	conns = state.GetDelta(client2, latestEpochTime(), []ConnectionStats{c}, nil, getStats(), nil).Conns
 	require.Len(t, conns, 1)
 	// 2nd client should get accumulated stats
 	assert.EqualValues(t, 3, conns[0].DNSSuccessfulResponses)
@@ -1150,26 +1150,26 @@ func TestDNSStatsWithMultipleClientsWithDomainCollectionEnabled(t *testing.T) {
 	state := NewState(2*time.Minute, 50000, 75000, 75000, 7500, true)
 
 	// Register the first two clients
-	assert.Len(t, state.GetDelta(client1, latestEpochTime(), nil, nil, nil, nil).Connections, 0)
-	assert.Len(t, state.GetDelta(client2, latestEpochTime(), nil, nil, nil, nil).Connections, 0)
+	assert.Len(t, state.GetDelta(client1, latestEpochTime(), nil, nil, nil, nil).Conns, 0)
+	assert.Len(t, state.GetDelta(client2, latestEpochTime(), nil, nil, nil, nil).Conns, 0)
 
 	c.LastUpdateEpoch = latestEpochTime()
 
-	conns := state.GetDelta(client1, latestEpochTime(), nil, []ConnectionStats{c}, getStats(), nil).Connections
+	conns := state.GetDelta(client1, latestEpochTime(), nil, []ConnectionStats{c}, getStats(), nil).Conns
 	require.Len(t, conns, 1)
 	assert.EqualValues(t, 1, conns[0].DNSStatsByDomainByQueryType[d][dns.TypeA].CountByRcode[DNSResponseCodeNoError])
 	// domain agnostic stats should be 0
 	assert.EqualValues(t, 0, conns[0].DNSSuccessfulResponses)
 
 	// Register the third client but also pass in dns stats
-	conns = state.GetDelta(client3, latestEpochTime(), []ConnectionStats{c}, nil, getStats(), nil).Connections
+	conns = state.GetDelta(client3, latestEpochTime(), []ConnectionStats{c}, nil, getStats(), nil).Conns
 	require.Len(t, conns, 1)
 	// DNS stats should be available for the new client
 	assert.EqualValues(t, 1, conns[0].DNSStatsByDomainByQueryType[d][dns.TypeA].CountByRcode[DNSResponseCodeNoError])
 	// domain agnostic stats should be 0
 	assert.EqualValues(t, 0, conns[0].DNSSuccessfulResponses)
 
-	conns = state.GetDelta(client2, latestEpochTime(), []ConnectionStats{c}, nil, getStats(), nil).Connections
+	conns = state.GetDelta(client2, latestEpochTime(), []ConnectionStats{c}, nil, getStats(), nil).Conns
 	require.Len(t, conns, 1)
 	// 2nd client should get accumulated stats
 	assert.EqualValues(t, 3, conns[0].DNSStatsByDomainByQueryType[d][dns.TypeA].CountByRcode[DNSResponseCodeNoError])
@@ -1202,7 +1202,7 @@ func TestDNSStatsPIDCollisions(t *testing.T) {
 	state := newDefaultState()
 
 	// Register the client
-	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Connections, 0)
+	assert.Len(t, state.GetDelta(client, latestEpochTime(), nil, nil, nil, nil).Conns, 0)
 
 	c.LastUpdateEpoch = latestEpochTime()
 	var closed []ConnectionStats
@@ -1212,7 +1212,7 @@ func TestDNSStatsPIDCollisions(t *testing.T) {
 	c.Pid++
 	closed = append(closed, c)
 
-	conns := state.GetDelta(client, latestEpochTime(), nil, closed, statsByDomain, nil).Connections
+	conns := state.GetDelta(client, latestEpochTime(), nil, closed, statsByDomain, nil).Conns
 	require.Len(t, conns, 2)
 	successes := 0
 	for _, conn := range conns {

--- a/pkg/network/tracer/connection/kprobe/perf_batching.go
+++ b/pkg/network/tracer/connection/kprobe/perf_batching.go
@@ -148,7 +148,7 @@ func (p *perfBatchManager) extractBatchInto(buffer *network.ConnectionBuffer, b 
 		}
 
 		conn := buffer.Next()
-		*conn = connStats(&ct.Tup, &ct.Conn_stats)
+		populateConnStats(conn, &ct.Tup, &ct.Conn_stats)
 
 		// Run callback/filter and verify if the connection should be filtered out
 		if p.filter != nil && !p.filter(conn) {

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -311,6 +311,7 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 		HTTP:                        delta.HTTP,
 		ConnTelemetry:               ctm,
 		CompilationTelemetryByAsset: rctm,
+		Buffer:                      delta.Buffer,
 	}, nil
 }
 

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -297,8 +297,8 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 	t.activeBuffer.Reset()
 	t.closedBuffer.Reset()
 
-	ips := make([]util.Address, 0, len(delta.Connections)*2)
-	for _, conn := range delta.Connections {
+	ips := make([]util.Address, 0, len(delta.Conns)*2)
+	for _, conn := range delta.Conns {
 		ips = append(ips, conn.Source, conn.Dest)
 	}
 	names := t.reverseDNS.Resolve(ips)
@@ -306,12 +306,11 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 	rctm := t.getRuntimeCompilationTelemetry()
 
 	return &network.Connections{
-		Conns:                       delta.Connections,
+		BufferedData:                delta.BufferedData,
 		DNS:                         names,
 		HTTP:                        delta.HTTP,
 		ConnTelemetry:               ctm,
 		CompilationTelemetryByAsset: rctm,
-		Buffer:                      delta.Buffer,
 	}, nil
 }
 
@@ -552,7 +551,12 @@ func (t *Tracer) DebugNetworkMaps() (*network.Connections, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving connections: %s", err)
 	}
-	return &network.Connections{Conns: activeBuffer.Connections()}, nil
+	return &network.Connections{
+		BufferedData: network.BufferedData{
+			Conns: activeBuffer.Connections(),
+		},
+	}, nil
+
 }
 
 // connectionExpired returns true if the passed in connection has expired

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -385,6 +385,8 @@ func TestConnectionExpirationRegression(t *testing.T) {
 }
 
 func TestConntrackExpiration(t *testing.T) {
+	t.Skip("flaky test")
+
 	setupDNAT(t)
 	defer teardownDNAT(t)
 

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -385,8 +385,6 @@ func TestConnectionExpirationRegression(t *testing.T) {
 }
 
 func TestConntrackExpiration(t *testing.T) {
-	t.Skip("flaky test")
-
 	setupDNAT(t)
 	defer teardownDNAT(t)
 

--- a/pkg/network/tracer/tracer_windows.go
+++ b/pkg/network/tracer/tracer_windows.go
@@ -121,13 +121,13 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 	t.state.RemoveExpiredClients(time.Now())
 
 	delta := t.state.GetDelta(clientID, uint64(time.Now().Nanosecond()), activeConnStats, closedConnStats, t.reverseDNS.GetDNSStats(), nil)
-	conns := delta.Connections
+	conns := delta.Conns
 	var ips []util.Address
-	for _, conn := range delta.Connections {
+	for _, conn := range delta.Conns {
 		ips = append(ips, conn.Source, conn.Dest)
 	}
 	names := t.reverseDNS.Resolve(ips)
-	return &network.Connections{Conns: conns, DNS: names}, nil
+	return &network.Connections{BufferedData: delta.BufferedData, DNS: names}, nil
 }
 
 // GetStats returns a map of statistics about the current tracer's internal state

--- a/pkg/network/tracer/tracer_windows.go
+++ b/pkg/network/tracer/tracer_windows.go
@@ -121,7 +121,6 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 	t.state.RemoveExpiredClients(time.Now())
 
 	delta := t.state.GetDelta(clientID, uint64(time.Now().Nanosecond()), activeConnStats, closedConnStats, t.reverseDNS.GetDNSStats(), nil)
-	conns := delta.Conns
 	var ips []util.Address
 	for _, conn := range delta.Conns {
 		ips = append(ips, conn.Source, conn.Dest)


### PR DESCRIPTION
### What does this PR do?

* Add `ClientBuffer` where short-lived objects retrieved from `state.GetDelta` are placed
* Remove unnecessary allocations from `kprobeTracer.GetConnections()`

### Motivation

We're doing a round of perfomance improvements on network-tracer and this seemed like a low hanging fruit.

### Additional Notes

Anything else we should know when reviewing?


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
