### PR TITLE
[pkg/otlp] Fixes on translator and NewPipeline

### DIFF
--- a/pkg/otlp/collector.go
+++ b/pkg/otlp/collector.go
@@ -127,6 +127,10 @@ func NewPipeline(cfg PipelineConfig) (*Pipeline, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// HACK: ensure flags are not-nil
+	// TODO: fix this upstream.
+	_ = service.NewCommand(col)
 	return &Pipeline{col}, nil
 }
 

--- a/pkg/otlp/model/translator/config.go
+++ b/pkg/otlp/model/translator/config.go
@@ -94,7 +94,7 @@ func WithHistogramMode(mode HistogramMode) Option {
 	return func(t *translatorConfig) error {
 
 		switch mode {
-		case HistogramModeNoBuckets, HistogramModeCounters:
+		case HistogramModeNoBuckets, HistogramModeCounters, HistogramModeDistributions:
 			t.HistMode = mode
 		default:
 			return fmt.Errorf("unknown histogram mode: %q", mode)


### PR DESCRIPTION
### What does this PR do?

1. Fixes pipeline after bump to v0.36.0. Version 0.36 introduces a bug that I need to fix upstream where a flag is checked [even if the collector is not ran as a command](https://github.com/open-telemetry/opentelemetry-collector/blob/176186b30ea36bf8fd89a9df9a9a9941f68a2512/service/internal/telemetrylogs/logger.go#L67)
2. Adds support for distributions on translator config.

### Motivation

DataDog/architecture#892

### Additional Notes

The alternative is to go back to 0.35 but I would prefer not to do that (0.36 is the first stable release for traces).

### Describe how to test your changes

Can be tested alongside other OTLP metrics PRs

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
