### PR TITLE
[ksm-core] Fix job metrics `kubernetes_state.job.failed` and `kubernetes_state.job.succeeded`

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_transformers_test.go
@@ -529,7 +529,11 @@ func Test_jobStatusFailedTransformer(t *testing.T) {
 				},
 				tags: []string{"job_name:foo-1509998340", "namespace:default"},
 			},
-			expected: nil,
+			expected: &metricsExpected{
+				name: "kubernetes_state.job.failed",
+				val:  0,
+				tags: []string{"job:foo", "namespace:default"},
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -1447,7 +1451,7 @@ func Test_validateJob(t *testing.T) {
 			name:  "invalid",
 			val:   0.0,
 			tags:  []string{"foo:bar", "job_name:foo"},
-			want:  nil,
+			want:  []string{"foo:bar", "job_name:foo"},
 			want1: false,
 		},
 	}

--- a/releasenotes/notes/generate-job-completion-metrics-even-when-0-a559dd225505a2a7.yaml
+++ b/releasenotes/notes/generate-job-completion-metrics-even-when-0-a559dd225505a2a7.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Kubernetes state core check: `job.status.succeeded` and `job.status.failed` gauges were not sent when equal 0. 0 values are now sent.


### PR DESCRIPTION
### What does this PR do?

Fix job metrics `kubernetes_state.job.failed` and `kubernetes_state.job.succeeded`.

The metrics returned always 1 so it didn't reflect what is in `job.status.succeeded` and `job.status.failed`.
If the value in `job.status.succeeded` and `job.status.failed` is equal to 0, the metrics were not returned.

Change:

`kubernetes_state.job.failed` now returns the value present in `job.status.failed`, the metric also returns the value 0.
`kubernetes_state.job.succeeded` now returns the value present in `job.status.succeeded`, the metric also returns the value 0.

### Motivation

Avoid surprise and have the metric flip between `1` and `0` instead of between `1` and `NO DATA`.
The original behaviour could lead to inaccurate figures because of the “fill with last” feature.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Start the ksm core check and check the `job.status` metrics.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [X] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [X] The appropriate `team/..` label has been applied, if known.
- [X] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [X] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
