### PR TITLE
DOCS-2215 Add @env variables to datadog.yaml

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1660,6 +1660,7 @@ api_key:
 ###########################
 
 ## @param log_level - string - optional - default: info
+## @env DD_LOG_LEVEL - string - optional - default: info
 ## Minimum log level of the Datadog Agent.
 ## Valid log levels are: trace, debug, info, warn, error, critical, and off.
 ## Note: When using the 'off' log level, quotes are mandatory.
@@ -1667,39 +1668,46 @@ api_key:
 # log_level: 'info'
 
 ## @param log_file - string - optional
+## @env DD_LOG_FILE - string - optional
 ## Path of the log file for the Datadog Agent.
 ## See https://docs.datadoghq.com/agent/guide/agent-log-files/
 #
 # log_file: <AGENT_LOG_FILE_PATH>
 
 ## @param log_format_json - boolean - optional - default: false
+## @env DD_LOG_FORMAT_JSON - boolean - optional - default: false
 ## Set to 'true' to output Agent logs in JSON format.
 #
 # log_format_json: false
 
 ## @param log_to_console - boolean - optional - default: true
+## @env DD_LOG_TO_CONSOLE - boolean - optional - default: true
 ## Set to 'false' to disable Agent logging to stdout.
 #
 # log_to_console: true
 
 ## @param disable_file_logging - boolean - optional - default: false
+## @env DD_DISABLE_FILE_LOGGING - boolean - optional - default: false
 ## Set to 'true' to disable logging to the log file.
 #
 # disable_file_logging: false
 
 ## @param log_file_max_size - custom - optional - default: 10MB
+## @env DD_LOG_FILE_MAX_SIZE - custom - optional - default: 10MB
 ## Maximum size of one log file. Use either a size (e.g. 10MB) or
 ## provide value in bytes: 10485760
 #
 # log_file_max_size: 10MB
 
 ## @param log_file_max_rolls - integer - optional - default: 1
+## @env DD_LOG_FILE_MAX_ROLLS - integer - optional - default: 1
 ## Maximum amount of "old" log files to keep.
 ## Set to 0 to not limit the number of files to create.
 #
 # log_file_max_rolls: 1
 
 ## @param log_to_syslog - boolean - optional - default: false
+## @env DD_LOG_TO_SYSLOG - boolean - optional - default: false
 ## Set to 'true' to enable logging to syslog.
 ## Note: Even if this option is set to 'false', the service launcher of your environment
 ## may redirect the Agent process' stdout/stderr to syslog. In that case, if you wish
@@ -1708,27 +1716,32 @@ api_key:
 # log_to_syslog: false
 
 ## @param syslog_uri - string - optional
+## @env DD_SYSLOG_URI - string - optional
 ## Define a custom remote syslog uri if needed. If 'syslog_uri' is left undefined/empty,
 ## a local domain socket connection is attempted.
 #
 # syslog_uri: <SYSLOG_URI>
 
 ## @param syslog_rfc - boolean - optional - default: false
+## @env DD_SYSLOG_RFC - boolean - optional - default: false
 ## Set to 'true' to output in an RFC 5424-compliant format for Agent logs.
 #
 # syslog_rfc: false
 
 ## @param syslog_pem - string - optional
+## @env DD_SYSLOG_PEM - string - optional
 ## If TLS enabled, you must specify a path to a PEM certificate here.
 #
 # syslog_pem: <PEM_CERTIFICATE_PATH>
 
 ## @param syslog_key - string - optional
+## @env DD_SYSLOG_KEY - string - optional
 ## If TLS enabled, you must specify a path to a private key here.
 #
 # syslog_key: <PEM_KEY_PATH>
 
 ## @param syslog_tls_verify - boolean - optional - default: true
+## @env DD_SYSLOG_TLS_VERIFY - boolean - optional - default: true
 ## If TLS enabled, you may enforce TLS verification here.
 #
 # syslog_tls_verify: true


### PR DESCRIPTION
### What does this PR do?

- Add `@env` variables to datadog.yaml:

```
DD_DISABLE_FILE_LOGGING
DD_LOG_FILE
DD_LOG_FILE_MAX_ROLLS
DD_LOG_FILE_MAX_SIZE
DD_LOG_FORMAT_JSON
DD_LOG_LEVEL
DD_LOG_TO_CONSOLE
DD_LOG_TO_SYSLOG
DD_SYSLOG_KEY
DD_SYSLOG_PEM
DD_SYSLOG_RFC
DD_SYSLOG_TLS_VERIFY
DD_SYSLOG_URI
```
- Update a few docs links

### Motivation

- Documentation OKR
- [RFC](https://github.com/DataDog/architecture/blob/master/rfcs/agent-env-var-docs/rfc.md)

### Additional Notes

Variables will be added in small batches.

### Describe how to test your changes

N/A

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
