### PR TITLE
[ci] Add `golang_deps_generate` step to main branch builds

### DIFF
--- a/.gitlab/JOBOWNERS
+++ b/.gitlab/JOBOWNERS
@@ -9,6 +9,9 @@ tests_*                              @DataDog/multiple
 tests_ebpf                           @DataDog/agent-network
 security_go_generate_check           @DataDog/agent-security
 
+# Golang dependency list generation
+golang_deps_generate                 @DataDog/agent-core
+
 # Binary build
 build_system-probe*                  @DataDog/agent-network
 cluster_agent_cloudfoundry-build*    @Datadog/integrations-tools-and-libs

--- a/.gitlab/source_test.yml
+++ b/.gitlab/source_test.yml
@@ -9,3 +9,4 @@ include:
   - /.gitlab/source_test/security_scan.yml
   - /.gitlab/source_test/windows.yml
   - /.gitlab/source_test/go_generate_check.yml
+  - /.gitlab/source_test/golang_deps_generate.yml

--- a/.gitlab/source_test/golang_deps_generate.yml
+++ b/.gitlab/source_test/golang_deps_generate.yml
@@ -8,8 +8,6 @@ golang_deps_generate:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main"]
   needs: ["linux_x64_go_deps"]
-  variables:
-    ARCH: "x64"
   before_script:
     - !reference [.retrieve_linux_go_deps]
     - python3 -m pip install --upgrade --ignore-installed pip setuptools

--- a/.gitlab/source_test/golang_deps_generate.yml
+++ b/.gitlab/source_test/golang_deps_generate.yml
@@ -1,0 +1,22 @@
+---
+# golang_deps_generate stage
+# Contains the step to build the golang dependency chain and preserve it
+golang_deps_generate:
+  rules:
+    !reference [.on_main_or_release_branch]
+  stage: source_test
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["runner:main"]
+  needs: ["linux_x64_go_deps"]
+  variables:
+    ARCH: "x64"
+  before_script:
+    - !reference [.retrieve_linux_go_deps]
+    - python3 -m pip install --upgrade --ignore-installed pip setuptools
+    - python3 -m pip install -r requirements.txt
+  script:
+    - inv agent.build-dep-tree
+    - tar -czf dependency_tree.tgz dependency_tree.txt
+  artifacts:
+    paths:
+      - dependency_tree.tgz

--- a/.gitlab/source_test/golang_deps_generate.yml
+++ b/.gitlab/source_test/golang_deps_generate.yml
@@ -18,3 +18,4 @@ golang_deps_generate:
   artifacts:
     paths:
       - dependency_tree.tgz
+    expire_in: never


### PR DESCRIPTION
### What does this PR do?

Runs `inv agent.build-dep-tree` on main or release branches and saves the artifacts

### Motivation

We want to preserve and automate Golang dependency generation artifacts
for the Agent so this change ensures that we do that for all stable and
main branch builds.

### Additional Notes

This is a rebase of a PR made much earlier but it required Golang 1.16 on the main
branch to work.

### Describe how to test your changes

Check that main/release branches on GitLab run `golang_deps_generate` step under `source tests` group and contain an archived `dependency_tree.tgz` file

### Checklist

- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.