### PR TITLE
[pkg/otlp/model] Fix default for sendCountSum

### DIFF
--- a/pkg/otlp/model/translator/metrics_translator.go
+++ b/pkg/otlp/model/translator/metrics_translator.go
@@ -40,7 +40,7 @@ type Translator struct {
 func New(logger *zap.Logger, options ...Option) (*Translator, error) {
 	cfg := translatorConfig{
 		HistMode:                 HistogramModeNoBuckets,
-		SendCountSum:             true,
+		SendCountSum:             false,
 		Quantiles:                false,
 		SendMonotonic:            true,
 		ResourceAttributesAsTags: false,

--- a/pkg/otlp/model/translator/metrics_translator.go
+++ b/pkg/otlp/model/translator/metrics_translator.go
@@ -39,7 +39,7 @@ type Translator struct {
 // New creates a new translator with given options.
 func New(logger *zap.Logger, options ...Option) (*Translator, error) {
 	cfg := translatorConfig{
-		HistMode:                 HistogramModeNoBuckets,
+		HistMode:                 HistogramModeDistributions,
 		SendCountSum:             false,
 		Quantiles:                false,
 		SendMonotonic:            true,

--- a/pkg/otlp/model/translator/metrics_translator.go
+++ b/pkg/otlp/model/translator/metrics_translator.go
@@ -55,7 +55,7 @@ func New(logger *zap.Logger, options ...Option) (*Translator, error) {
 			return nil, err
 		}
 	}
-	
+
 	if cfg.HistMode == HistogramModeNoBuckets && !cfg.SendCountSum {
 		return nil, fmt.Errorf("no buckets mode and no send count sum are incompatible")
 	}

--- a/pkg/otlp/model/translator/metrics_translator.go
+++ b/pkg/otlp/model/translator/metrics_translator.go
@@ -55,6 +55,10 @@ func New(logger *zap.Logger, options ...Option) (*Translator, error) {
 			return nil, err
 		}
 	}
+	
+	if cfg.HistMode == HistogramModeNoBuckets && !cfg.SendCountSum {
+		return nil, fmt.Errorf("no buckets mode and no send count sum are incompatible")
+	}
 
 	cache := newTTLCache(cfg.sweepInterval, cfg.deltaTTL)
 	return &Translator{cache, logger, cfg}, nil


### PR DESCRIPTION
### What does this PR do?

Fix default value for `SendCountSum`

### Motivation

`WithCountSumMetric` is useless otherwise.

### Describe how to test your changes

End user change is that user does not see the `.sum` and `.count` metrics. Adding `skip-qa` and will clarify on the main PR.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
