### PR TITLE
[CWS] remove jinja2 dependency as a temporary fix

### DIFF
--- a/.gitlab/source_test/go_generate_check.yml
+++ b/.gitlab/source_test/go_generate_check.yml
@@ -8,8 +8,6 @@ security_go_generate_check:
   before_script:
     - !reference [.retrieve_linux_go_deps]
   script:
-    - pip3 install -r requirements.txt # for jinja2
     - go generate ./pkg/security/...
-    - inv -e security-agent.generate-documentation
     - git status --porcelain
     - test -z "$(git status --porcelain)"

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,3 @@ docker-squash==1.0.8
 requests==2.23.0
 PyYAML==5.4
 toml==0.9.4
-jinja2==3.0.1


### PR DESCRIPTION
### What does this PR do?

The jinja2 dependency is failing on arm64. To give us more time to investigate and fix the issue this PR temporarily removes this dependency.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
