### PR TITLE
[process-agent] Small Fixes for Process Discovery Check

### DIFF
--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -305,9 +305,10 @@ func (a *AgentConfig) initProcessDiscoveryCheck() {
 	// We use a minimum of 10 minutes for this value.
 	discoveryInterval := config.Datadog.GetDuration(key(root, "interval"))
 	if discoveryInterval < discoveryMinInterval {
-		a.CheckIntervals[DiscoveryCheckName] = discoveryMinInterval
+		discoveryInterval = discoveryMinInterval
 		_ = log.Warnf("Invalid interval for process discovery (<= %sm) using default value of %[1]s", discoveryMinInterval.String())
 	}
+	a.CheckIntervals[DiscoveryCheckName] = discoveryInterval
 
 	// Discovery check should be only enabled when process_config.process_discovery.enabled = true and
 	// process_config.enabled is set to "false". This effectively makes sure the check only runs when the process check is

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -306,7 +306,7 @@ func (a *AgentConfig) initProcessDiscoveryCheck() {
 	discoveryInterval := config.Datadog.GetDuration(key(root, "interval"))
 	if discoveryInterval < discoveryMinInterval {
 		discoveryInterval = discoveryMinInterval
-		_ = log.Warnf("Invalid interval for process discovery (<= %sm) using default value of %[1]s", discoveryMinInterval.String())
+		_ = log.Warnf("Invalid interval for process discovery (<= %s) using default value of %[1]s", discoveryMinInterval.String())
 	}
 	a.CheckIntervals[DiscoveryCheckName] = discoveryInterval
 

--- a/pkg/process/procutil/process_linux.go
+++ b/pkg/process/procutil/process_linux.go
@@ -218,13 +218,15 @@ func (p *probe) ProcessesByPID(now time.Time, collectStats bool) (map[int32]*Pro
 
 		statusInfo := p.parseStatus(pathForPID)
 		statInfo := p.parseStat(pathForPID, pid, now)
-		memInfoEx := &MemoryInfoExStat{}
 
 		// On linux, setting the `collectStats` parameter to false will only prevent collection of memory stats.
 		// It does not prevent collection of stats from the /proc/(pid)/stat file, since we need to read the
 		// createTime to make a bytekey
+		var memInfoEx *MemoryInfoExStat
 		if collectStats {
 			memInfoEx = p.parseStatm(pathForPID)
+		} else {
+			memInfoEx = &MemoryInfoExStat{}
 		}
 
 		proc := &Process{

--- a/pkg/process/procutil/process_windows_toolhelp.go
+++ b/pkg/process/procutil/process_windows_toolhelp.go
@@ -146,7 +146,7 @@ func (p *windowsToolhelpProbe) ProcessesByPID(now time.Time, collectStats bool) 
 		}
 		ctime := CPU.CreationTime.Nanoseconds() / 1000000
 
-		stats := &Stats{CreateTime: ctime}
+		var stats *Stats
 		if collectStats {
 			var handleCount uint32
 			if err := getProcessHandleCount(procHandle, &handleCount); err != nil {
@@ -192,6 +192,8 @@ func (p *windowsToolhelpProbe) ProcessesByPID(now time.Time, collectStats bool) 
 				},
 				CtxSwitches: &NumCtxSwitchesStat{},
 			}
+		} else {
+			stats = &Stats{CreateTime: ctime}
 		}
 
 		delete(knownPids, pid)


### PR DESCRIPTION
### What does this PR do?
This PR contains small fixes that didn't make it into https://github.com/DataDog/datadog-agent/pull/9082, namely:
- Fixed extra allocations for process collection on windows and linux
- Added message for when the user specifies a value below the minimum (currently 10m) for `process_config.process_discovery.interval`
 
### Motivation
The original PR (https://github.com/DataDog/datadog-agent/pull/9082) was holding back a couple of our teams other PR's, so we decided to go ahead with merging it and fix a couple of outstanding issues in a separate PR.

### Additional Notes

### Describe how to test your changes
- Set a value below `10m` for `process_config.process_discovery.interval` in your `datadog.yaml`, and make sure that a message appears saying it has been reset.
- Run the process and process_discovery check on linux and windows and ensure that it works as expected.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
