### PR TITLE
Test SlidingWindow using a mock clock

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -172,6 +172,7 @@ core,github.com/aws/aws-sdk-go/service/sso/ssoiface,Apache-2.0,"Amazon.com, Inc.
 core,github.com/aws/aws-sdk-go/service/sts,Apache-2.0,"Amazon.com, Inc. or its affiliates | Stripe, Inc."
 core,github.com/aws/aws-sdk-go/service/sts/stsiface,Apache-2.0,"Amazon.com, Inc. or its affiliates | Stripe, Inc."
 core,github.com/beevik/ntp,BSD-2-Clause,Anton Tolchanov (knyar) | Ask Bjørn Hansen (abh) | Brett Vickers | Brett Vickers (beevik) | Christopher Batey (chbatey) | Leonid Evdokimov (darkk) | Meng Zhuo (mengzhuo) | Mikhail Salosin (AlphaB)
+core,github.com/benbjohnson/clock,MIT,Ben Johnson
 core,github.com/benesch/cgosymbolizer,BSD-3-Clause,Cockroach Labs
 core,github.com/beorn7/perks/quantile,MIT,Blake Mizerany
 core,github.com/bhmj/jsonslice,MIT,bhmj

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -1,0 +1,17 @@
+# Guidelines For Testing
+
+TBD
+
+## Testing Timing-Related Functionality
+
+Tests based on time are a major source of intermittents.
+If you find yourself thinking something like "the ticker should run three times in 500ms", you will be disappointed at how often that is not true in CI.
+Even if that test is not intermittent, it will take at least 500ms to run.
+Summing such delays over thousands of tests means _very_ long test runs and slower work for everyone.
+
+When the code you are testing requiers time, the first strategy is to remove that requirement.
+For example, if you are testing the functionality of a poller, factor the code such that the tests can call the `poll()` method directly, instead of waiting for a Ticker to do so.
+
+Where this is not possible, refactor the code to use a Clock from https://pkg.go.dev/github.com/benbjohnson/clock.
+In production, create a `clock.Clock`, and in tests, inject a `clock.Mock`.
+When time should pass in your test execution, call `clock.Add(..)` to deterministically advance the clock.

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -9,7 +9,7 @@ If you find yourself thinking something like "the ticker should run three times 
 Even if that test is not intermittent, it will take at least 500ms to run.
 Summing such delays over thousands of tests means _very_ long test runs and slower work for everyone.
 
-When the code you are testing requiers time, the first strategy is to remove that requirement.
+When the code you are testing requires time, the first strategy is to remove that requirement.
 For example, if you are testing the functionality of a poller, factor the code such that the tests can call the `poll()` method directly, instead of waiting for a Ticker to do so.
 
 Where this is not possible, refactor the code to use a Clock from https://pkg.go.dev/github.com/benbjohnson/clock.

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.40.38
 	github.com/beevik/ntp v0.3.0
-	github.com/benbjohnson/clock v1.1.0 // indirect
+	github.com/benbjohnson/clock v1.1.0
 	github.com/benesch/cgosymbolizer v0.0.0-20190515212042-bec6fe6e597b
 	github.com/bhmj/jsonslice v0.0.0-20200323023432-92c3edaad8e2
 	github.com/blabber/go-freebsd-sysctl v0.0.0-20201130114544-503969f39d8f

--- a/go.mod
+++ b/go.mod
@@ -75,6 +75,7 @@ require (
 	github.com/avast/retry-go v3.0.0+incompatible
 	github.com/aws/aws-sdk-go v1.40.38
 	github.com/beevik/ntp v0.3.0
+	github.com/benbjohnson/clock v1.1.0 // indirect
 	github.com/benesch/cgosymbolizer v0.0.0-20190515212042-bec6fe6e597b
 	github.com/bhmj/jsonslice v0.0.0-20200323023432-92c3edaad8e2
 	github.com/blabber/go-freebsd-sysctl v0.0.0-20201130114544-503969f39d8f

--- a/pkg/util/sliding_window.go
+++ b/pkg/util/sliding_window.go
@@ -10,6 +10,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/benbjohnson/clock"
+
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -38,7 +40,8 @@ type slidingWindow struct {
 	statsUpdateFunc StatsUpdateFunc
 	stopChan        chan struct{}
 	stopped         bool
-	ticker          *time.Ticker
+	clock           clock.Clock
+	ticker          *clock.Ticker
 	windowSize      time.Duration
 }
 
@@ -83,6 +86,7 @@ func NewSlidingWindow(windowSize time.Duration, pollingInterval time.Duration) (
 		numBuckets:      int(windowSize / pollingInterval),
 		pollingInterval: pollingInterval,
 		windowSize:      windowSize,
+		clock:           clock.New(),
 	}, nil
 }
 
@@ -121,7 +125,7 @@ func (sw *slidingWindow) Start(
 }
 
 func (sw *slidingWindow) newTicker() {
-	sw.ticker = time.NewTicker(sw.pollingInterval)
+	sw.ticker = sw.clock.Ticker(sw.pollingInterval)
 
 	go func() {
 		for {

--- a/pkg/util/sliding_window.go
+++ b/pkg/util/sliding_window.go
@@ -65,6 +65,10 @@ type SlidingWindow interface {
 
 // NewSlidingWindow creates a new instance of a slidingWindow
 func NewSlidingWindow(windowSize time.Duration, pollingInterval time.Duration) (SlidingWindow, error) {
+	return newSlidingWindowWithClock(windowSize, pollingInterval, clock.New())
+}
+
+func newSlidingWindowWithClock(windowSize time.Duration, pollingInterval time.Duration, clock clock.Clock) (SlidingWindow, error) {
 	if windowSize == 0 {
 		return nil, fmt.Errorf("SlidingWindow windowSize cannot be 0")
 	}
@@ -86,7 +90,7 @@ func NewSlidingWindow(windowSize time.Duration, pollingInterval time.Duration) (
 		numBuckets:      int(windowSize / pollingInterval),
 		pollingInterval: pollingInterval,
 		windowSize:      windowSize,
-		clock:           clock.New(),
+		clock:           clock,
 	}, nil
 }
 

--- a/pkg/util/sliding_window_test.go
+++ b/pkg/util/sliding_window_test.go
@@ -7,7 +7,6 @@ package util
 
 import (
 	"math/rand"
-	"runtime"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -71,10 +70,6 @@ func TestSlidingWindow(t *testing.T) {
 }
 
 func TestSlidingWindowAccuracy(t *testing.T) {
-	if runtime.GOOS == "darwin" {
-		t.Skip("Skipping flaky test on Darwin")
-	}
-
 	// Floats don't really have good atomic primitives
 	var cbLock sync.RWMutex
 	lastAverage := 0.0
@@ -105,10 +100,6 @@ func TestSlidingWindowAccuracy(t *testing.T) {
 }
 
 func TestSlidingWindowAverage(t *testing.T) {
-	if runtime.GOOS == "windows" {
-		t.Skip("Skipping flaky test on Windows")
-	}
-
 	clk := clock.NewMock()
 	sw, err := newSlidingWindowWithClock(1*time.Second, 100*time.Millisecond, clk)
 	require.Nil(t, err)

--- a/pkg/util/sliding_window_test.go
+++ b/pkg/util/sliding_window_test.go
@@ -52,18 +52,11 @@ func dummyFractionalPollingFunc() float64 {
 	return randBusy
 }
 
-func useMockClock(sw SlidingWindow) *clock.Mock {
-	mock := clock.NewMock()
-	swObj := sw.(*slidingWindow)
-	swObj.clock = mock
-	return mock
-}
-
 func TestSlidingWindow(t *testing.T) {
-	sw, err := NewSlidingWindow(2*time.Second, 100*time.Millisecond)
+	clk := clock.NewMock()
+	sw, err := newSlidingWindowWithClock(2*time.Second, 100*time.Millisecond, clk)
 	require.Nil(t, err)
 	require.NotNil(t, sw)
-	clk := useMockClock(sw)
 
 	err = sw.Start(dummyTogglingPollingFunc, dummyStatsUpdateFunc)
 	require.Nil(t, err)
@@ -92,9 +85,9 @@ func TestSlidingWindowAccuracy(t *testing.T) {
 		lastAverage = sw.Average()
 	}
 
-	sw, err := NewSlidingWindow(1*time.Second, 10*time.Millisecond)
+	clk := clock.NewMock()
+	sw, err := newSlidingWindowWithClock(1*time.Second, 10*time.Millisecond, clk)
 	require.Nil(t, err)
-	clk := useMockClock(sw)
 
 	err = sw.Start(dummyFractionalPollingFunc, statsUpdateFunc)
 	require.Nil(t, err)
@@ -116,9 +109,9 @@ func TestSlidingWindowAverage(t *testing.T) {
 		t.Skip("Skipping flaky test on Windows")
 	}
 
-	sw, err := NewSlidingWindow(1*time.Second, 100*time.Millisecond)
+	clk := clock.NewMock()
+	sw, err := newSlidingWindowWithClock(1*time.Second, 100*time.Millisecond, clk)
 	require.Nil(t, err)
-	clk := useMockClock(sw)
 
 	err = sw.Start(dummyFractionalPollingFunc, nil)
 	require.Nil(t, err)
@@ -137,9 +130,9 @@ func TestSlidingWindowCallback(t *testing.T) {
 	atomic.StoreInt64(&statsUpdateFuncInvocationCount, 0)
 	atomic.StoreInt64(&pollingFuncInvocationCount, 0)
 
-	sw, err := NewSlidingWindow(100*time.Millisecond, 10*time.Millisecond)
+	clk := clock.NewMock()
+	sw, err := newSlidingWindowWithClock(100*time.Millisecond, 10*time.Millisecond, clk)
 	require.Nil(t, err)
-	clk := useMockClock(sw)
 
 	pollingFunc := func() float64 {
 		atomic.StoreInt64(&pollingFuncInvocationCount, 1)
@@ -173,9 +166,9 @@ func TestSlidingWindowFuncInvocationCounts(t *testing.T) {
 	windowSize := 2000 * time.Millisecond
 	pollingInterval := 100 * time.Millisecond
 
-	sw, err := NewSlidingWindow(windowSize, pollingInterval)
+	clk := clock.NewMock()
+	sw, err := newSlidingWindowWithClock(windowSize, pollingInterval, clk)
 	require.Nil(t, err)
-	clk := useMockClock(sw)
 
 	err = sw.Start(dummyFractionalPollingFunc, dummyStatsUpdateFunc)
 	require.Nil(t, err)


### PR DESCRIPTION
### What does this PR do?

Updates the tests for SlidingWindow to use github.com/benbjohnson/clock instead of the "real" clock

### Motivation

Timing-based tests are usually intermittent, but this has gotten worse in Go1.16 because `time.Sleep`'s resolution has [gotten a lot worse](https://github.com/golang/go/issues/44343) without a fix in sight.

### Additional Notes

I also added a new docs/dev file that we can hopefully fill out with other "how to write good tests" documentation, and point to frequently.

### Describe how to test your changes

Observe fewer failing gitlab pipelines :)

### Checklist
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
