### PR TITLE
Fix kernel header downloading on COS

### DIFF
--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -147,12 +147,8 @@ func getDefaultHeaderDirs() []string {
 
 	dirs := []string{
 		fmt.Sprintf(kernelModulesPath, hi.KernelVersion),
-	}
-	switch hi.Platform {
-	case "debian":
-		dirs = append(dirs, fmt.Sprintf(debKernelModulesPath, hi.KernelVersion))
-	case "cos":
-		dirs = append(dirs, fmt.Sprintf(cosKernelModulesPath, hi.KernelVersion))
+		fmt.Sprintf(debKernelModulesPath, hi.KernelVersion),
+		fmt.Sprintf(cosKernelModulesPath, hi.KernelVersion),
 	}
 	return dirs
 }

--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -80,7 +80,7 @@ func GetKernelHeaders(headerDirs []string, headerDownloadDir, aptConfigDir, yumR
 
 	d := headerDownloader{aptConfigDir, yumReposDir, zypperReposDir}
 	if err = d.downloadHeaders(headerDownloadDir); err == nil {
-		log.Infof("successfully downloaded kernel headers to %s", dirs)
+		log.Infof("successfully downloaded kernel headers to %s", headerDownloadDir)
 		if err = validateHeaderDirs(hv, dirs); err == nil {
 			return dirs, downloadSuccess, nil
 		}


### PR DESCRIPTION
### What does this PR do?

Fixes a kernel header downloading bug where system-probe containers running on COS hosts are unable to find downloaded kernel headers.

This was occurring because the system-probe was detecting the running platform to be `ubuntu` instead of `COS`, causing it to look in the wrong location for kernel headers. The solution is simply to always check all possible places where kernel headers might be downloaded.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
