### PR TITLE
[networks] Decouple DNS information from `ConnectionStats`

### DIFF
--- a/pkg/network/dns.go
+++ b/pkg/network/dns.go
@@ -1,0 +1,29 @@
+package network
+
+import (
+	"syscall"
+
+	"github.com/DataDog/datadog-agent/pkg/network/dns"
+)
+
+func DNSKey(c *ConnectionStats) (dns.Key, bool) {
+	if c == nil || c.DPort != 53 {
+		return dns.Key{}, false
+	}
+
+	serverIP, _ := GetNATRemoteAddress(*c)
+	clientIP, clientPort := GetNATLocalAddress(*c)
+	key := dns.Key{
+		ServerIP:   serverIP,
+		ClientIP:   clientIP,
+		ClientPort: clientPort,
+	}
+	switch c.Type {
+	case TCP:
+		key.Protocol = syscall.IPPROTO_TCP
+	case UDP:
+		key.Protocol = syscall.IPPROTO_UDP
+	}
+
+	return key, true
+}

--- a/pkg/network/dns.go
+++ b/pkg/network/dns.go
@@ -6,6 +6,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/dns"
 )
 
+// DNSKey generates a key suitable for looking up DNS stats based on a ConnectionStats object
 func DNSKey(c *ConnectionStats) (dns.Key, bool) {
 	if c == nil || c.DPort != 53 {
 		return dns.Key{}, false

--- a/pkg/network/encoding/dns.go
+++ b/pkg/network/encoding/dns.go
@@ -1,0 +1,156 @@
+package encoding
+
+import (
+	"sync"
+
+	model "github.com/DataDog/agent-payload/process"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/network/dns"
+	"go4.org/intern"
+)
+
+var dnsPool = sync.Pool{
+	New: func() interface{} {
+		return new(model.DNSEntry)
+	},
+}
+
+type dnsFormatter struct {
+	conns     *network.Connections
+	ipc       ipCache
+	domainSet map[string]int
+
+	// Configuration flags
+	queryTypeEnabled  bool
+	dnsDomainsEnabled bool
+}
+
+func newDNSFormatter(conns *network.Connections, ipc ipCache) *dnsFormatter {
+	return &dnsFormatter{
+		conns:             conns,
+		ipc:               ipc,
+		domainSet:         make(map[string]int),
+		queryTypeEnabled:  config.Datadog.GetBool("network_config.enable_dns_by_querytype"),
+		dnsDomainsEnabled: config.Datadog.GetBool("network_config.collect_dns_domains"),
+	}
+}
+
+func (f *dnsFormatter) FormatConnectionDNS(nc network.ConnectionStats, mc *model.Connection) {
+	key, ok := network.DNSKey(&nc)
+	if !ok {
+		return
+	}
+
+	// Retrieve DNS information for this particular connection
+	stats, ok := f.conns.DNSStats[key]
+	if !ok {
+		return
+	}
+
+	if !f.dnsDomainsEnabled {
+		var total uint32
+		mc.DnsCountByRcode = make(map[uint32]uint32)
+		for _, byType := range stats {
+			for _, typeStats := range byType {
+				mc.DnsSuccessfulResponses += typeStats.CountByRcode[network.DNSResponseCodeNoError]
+				mc.DnsTimeouts += typeStats.Timeouts
+				mc.DnsSuccessLatencySum += typeStats.SuccessLatencySum
+				mc.DnsFailureLatencySum += typeStats.FailureLatencySum
+
+				for rcode, count := range typeStats.CountByRcode {
+					mc.DnsCountByRcode[rcode] += count
+					total += count
+				}
+			}
+		}
+		mc.DnsFailedResponses = total - mc.DnsSuccessfulResponses
+	}
+
+	if f.queryTypeEnabled {
+		mc.DnsStatsByDomainByQueryType = formatDNSStatsByDomainByQueryType(stats, f.domainSet)
+	} else {
+		// downconvert to simply by domain
+		mc.DnsStatsByDomain = formatDNSStatsByDomain(stats, f.domainSet)
+	}
+}
+
+func (f *dnsFormatter) DNS() map[string]*model.DNSEntry {
+	if f.conns.DNS == nil {
+		return nil
+	}
+
+	ipToNames := make(map[string]*model.DNSEntry, len(f.conns.DNS))
+	for addr, names := range f.conns.DNS {
+		entry := dnsPool.Get().(*model.DNSEntry)
+		entry.Names = names
+		ipToNames[f.ipc.Get(addr)] = entry
+	}
+
+	return ipToNames
+}
+
+func (f *dnsFormatter) Domains() []string {
+	domains := make([]string, len(f.domainSet))
+	for k, v := range f.domainSet {
+		domains[v] = k
+	}
+	return domains
+}
+
+func formatDNSStatsByDomainByQueryType(stats map[*intern.Value]map[dns.QueryType]dns.Stats, domainSet map[string]int) map[int32]*model.DNSStatsByQueryType {
+	m := make(map[int32]*model.DNSStatsByQueryType)
+	for d, bytype := range stats {
+
+		byqtype := &model.DNSStatsByQueryType{}
+		byqtype.DnsStatsByQueryType = make(map[int32]*model.DNSStats)
+		for t, stat := range bytype {
+			var ms model.DNSStats
+			ms.DnsCountByRcode = stat.CountByRcode
+			ms.DnsFailureLatencySum = stat.FailureLatencySum
+			ms.DnsSuccessLatencySum = stat.SuccessLatencySum
+			ms.DnsTimeouts = stat.Timeouts
+			byqtype.DnsStatsByQueryType[int32(t)] = &ms
+		}
+		pos, ok := domainSet[d.Get().(string)]
+		if !ok {
+			pos = len(domainSet)
+			domainSet[d.Get().(string)] = pos
+		}
+		m[int32(pos)] = byqtype
+	}
+	return m
+}
+
+func formatDNSStatsByDomain(stats map[*intern.Value]map[dns.QueryType]dns.Stats, domainSet map[string]int) map[int32]*model.DNSStats {
+	m := make(map[int32]*model.DNSStats)
+	for d, bytype := range stats {
+		pos, ok := domainSet[d.Get().(string)]
+		if !ok {
+			pos = len(domainSet)
+			domainSet[d.Get().(string)] = pos
+		}
+
+		for _, stat := range bytype {
+
+			if ms, ok := m[int32(pos)]; ok {
+				for rcode, count := range stat.CountByRcode {
+					ms.DnsCountByRcode[rcode] += count
+				}
+				ms.DnsFailureLatencySum += stat.FailureLatencySum
+				ms.DnsSuccessLatencySum += stat.SuccessLatencySum
+				ms.DnsTimeouts += stat.Timeouts
+
+			} else {
+				var ms model.DNSStats
+				ms.DnsCountByRcode = stat.CountByRcode
+				ms.DnsFailureLatencySum = stat.FailureLatencySum
+				ms.DnsSuccessLatencySum = stat.SuccessLatencySum
+				ms.DnsTimeouts = stat.Timeouts
+
+				m[int32(pos)] = &ms
+			}
+		}
+	}
+	return m
+}

--- a/pkg/network/encoding/dns_test.go
+++ b/pkg/network/encoding/dns_test.go
@@ -1,0 +1,1 @@
+package encoding

--- a/pkg/network/encoding/dns_test.go
+++ b/pkg/network/encoding/dns_test.go
@@ -1,1 +1,160 @@
 package encoding
+
+import (
+	"syscall"
+	"testing"
+
+	"github.com/DataDog/agent-payload/process"
+	model "github.com/DataDog/agent-payload/process"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/network/dns"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/stretchr/testify/assert"
+	"go4.org/intern"
+)
+
+func TestFormatConnectionDNS(t *testing.T) {
+	payload := &network.Connections{
+		Conns: []network.ConnectionStats{
+			{
+				Source:    util.AddressFromString("10.1.1.1"),
+				Dest:      util.AddressFromString("8.8.8.8"),
+				SPort:     1000,
+				DPort:     53,
+				Type:      network.UDP,
+				Family:    network.AFINET6,
+				Direction: network.LOCAL,
+			},
+		},
+		DNSStats: dns.StatsByKeyByNameByType{
+			dns.Key{
+				ClientIP:   util.AddressFromString("10.1.1.1"),
+				ServerIP:   util.AddressFromString("8.8.8.8"),
+				ClientPort: uint16(1000),
+				Protocol:   syscall.IPPROTO_UDP,
+			}: map[*intern.Value]map[dns.QueryType]dns.Stats{
+				intern.GetByString("foo.com"): {
+					dns.TypeA: {
+						Timeouts:          0,
+						SuccessLatencySum: 0,
+						FailureLatencySum: 0,
+						CountByRcode:      map[uint32]uint32{0: 1},
+					},
+				},
+			},
+		},
+	}
+
+	t.Run("DNS with collect_domains_enabled=true,enable_dns_by_querytype=false", func(t *testing.T) {
+		config.Datadog.Set("network_config.collect_dns_domains", true)
+		config.Datadog.Set("network_config.enable_dns_by_querytype", false)
+
+		ipc := make(ipCache)
+		formatter := newDNSFormatter(payload, ipc)
+		in := payload.Conns[0]
+		out := new(model.Connection)
+
+		formatter.FormatConnectionDNS(in, out)
+		expected := &model.Connection{
+			DnsStatsByDomain: map[int32]*process.DNSStats{
+				0: {
+					DnsTimeouts:          0,
+					DnsSuccessLatencySum: 0,
+					DnsFailureLatencySum: 0,
+					DnsCountByRcode: map[uint32]uint32{
+						0: 1,
+					},
+				},
+			},
+		}
+
+		assert.Equal(t, expected, out)
+	})
+
+	t.Run("DNS with collect_domains_enabled=true,enable_dns_by_querytype=true", func(t *testing.T) {
+		config.Datadog.Set("network_config.collect_dns_domains", true)
+		config.Datadog.Set("network_config.enable_dns_by_querytype", true)
+
+		ipc := make(ipCache)
+		formatter := newDNSFormatter(payload, ipc)
+		in := payload.Conns[0]
+		out := new(model.Connection)
+
+		formatter.FormatConnectionDNS(in, out)
+		expected := &model.Connection{
+			DnsStatsByDomainByQueryType: map[int32]*model.DNSStatsByQueryType{
+				0: {
+					DnsStatsByQueryType: map[int32]*model.DNSStats{
+						int32(dns.TypeA): {
+							DnsTimeouts:          0,
+							DnsSuccessLatencySum: 0,
+							DnsFailureLatencySum: 0,
+							DnsCountByRcode:      map[uint32]uint32{0: 1},
+						},
+					},
+				},
+			},
+		}
+
+		assert.Equal(t, expected, out)
+	})
+}
+
+func TestDNSPIDCollision(t *testing.T) {
+	payload := &network.Connections{
+		Conns: []network.ConnectionStats{
+			{
+				Source:    util.AddressFromString("10.1.1.1"),
+				Dest:      util.AddressFromString("8.8.8.8"),
+				Pid:       1,
+				SPort:     1000,
+				DPort:     53,
+				Type:      network.UDP,
+				Family:    network.AFINET6,
+				Direction: network.LOCAL,
+			},
+			{
+				Source:    util.AddressFromString("10.1.1.1"),
+				Dest:      util.AddressFromString("8.8.8.8"),
+				Pid:       2,
+				SPort:     1000,
+				DPort:     53,
+				Type:      network.UDP,
+				Family:    network.AFINET6,
+				Direction: network.LOCAL,
+			},
+		},
+		DNSStats: dns.StatsByKeyByNameByType{
+			dns.Key{
+				ClientIP:   util.AddressFromString("10.1.1.1"),
+				ServerIP:   util.AddressFromString("8.8.8.8"),
+				ClientPort: uint16(1000),
+				Protocol:   syscall.IPPROTO_UDP,
+			}: map[*intern.Value]map[dns.QueryType]dns.Stats{
+				intern.GetByString("foo.com"): {
+					dns.TypeA: {
+						Timeouts:          0,
+						SuccessLatencySum: 0,
+						FailureLatencySum: 0,
+						CountByRcode:      map[uint32]uint32{0: 1},
+					},
+				},
+			},
+		},
+	}
+
+	config.Datadog.Set("network_config.collect_dns_domains", true)
+	config.Datadog.Set("network_config.enable_dns_by_querytype", false)
+
+	ipc := make(ipCache)
+	formatter := newDNSFormatter(payload, ipc)
+	out1 := new(model.Connection)
+	out2 := new(model.Connection)
+	formatter.FormatConnectionDNS(payload.Conns[0], out1)
+	formatter.FormatConnectionDNS(payload.Conns[1], out2)
+
+	// Only the first connection should be bound to DNS stats in the context of a PID collision
+	assert.NotNil(t, out1.DnsStatsByDomain)
+	assert.Nil(t, out2.DnsStatsByDomain)
+}

--- a/pkg/network/encoding/encoding.go
+++ b/pkg/network/encoding/encoding.go
@@ -5,7 +5,6 @@ import (
 	"sync"
 
 	model "github.com/DataDog/agent-payload/process"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/http"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -62,13 +61,11 @@ func modelConnections(conns *network.Connections) *model.Connections {
 	})
 
 	agentConns := make([]*model.Connection, len(conns.Conns))
-	domainSet := make(map[string]int)
 	routeIndex := make(map[string]RouteIdx)
 	httpIndex := FormatHTTPStats(conns.HTTP)
 	httpMatches := make(map[http.Key]struct{}, len(httpIndex))
 	ipc := make(ipCache, len(conns.Conns)/2)
-
-	dnsWithQueryType := config.Datadog.GetBool("network_config.enable_dns_by_querytype")
+	dnsFormatter := newDNSFormatter(conns, ipc)
 
 	for i, conn := range conns.Conns {
 		httpKey := httpKeyFromConn(conn)
@@ -77,7 +74,7 @@ func modelConnections(conns *network.Connections) *model.Connections {
 			httpMatches[httpKey] = struct{}{}
 		}
 
-		agentConns[i] = FormatConnection(conn, domainSet, routeIndex, httpAggregations, dnsWithQueryType, ipc)
+		agentConns[i] = FormatConnection(conn, routeIndex, httpAggregations, dnsFormatter, ipc)
 	}
 
 	if orphans := len(httpIndex) - len(httpMatches); orphans > 0 {
@@ -85,11 +82,6 @@ func modelConnections(conns *network.Connections) *model.Connections {
 			"detected orphan http aggreggations. this can be either caused by conntrack sampling or missed tcp close events. count=%d",
 			orphans,
 		)
-	}
-
-	domains := make([]string, len(domainSet))
-	for k, v := range domainSet {
-		domains[v] = k
 	}
 
 	routes := make([]*model.Route, len(routeIndex))
@@ -100,8 +92,8 @@ func modelConnections(conns *network.Connections) *model.Connections {
 	payload := connsPool.Get().(*model.Connections)
 	payload.AgentConfiguration = agentCfg
 	payload.Conns = agentConns
-	payload.Domains = domains
-	payload.Dns = FormatDNS(conns.DNS, ipc)
+	payload.Domains = dnsFormatter.Domains()
+	payload.Dns = dnsFormatter.DNS()
 	payload.ConnTelemetry = FormatConnTelemetry(conns.ConnTelemetry)
 	payload.CompilationTelemetryByAsset = FormatCompilationTelemetry(conns.CompilationTelemetryByAsset)
 	payload.Routes = routes

--- a/pkg/network/encoding/encoding.go
+++ b/pkg/network/encoding/encoding.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	model "github.com/DataDog/agent-payload/process"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/http"
 	"github.com/DataDog/datadog-agent/pkg/util/log"

--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go4.org/intern"
 )
 
 var originalConfig = config.Datadog
@@ -140,17 +139,17 @@ func TestSerialization(t *testing.T) {
 				Family:    network.AFINET6,
 				Direction: network.LOCAL,
 
-				DNSCountByRcode: map[uint32]uint32{0: 1},
-				DNSStatsByDomainByQueryType: map[*intern.Value]map[dns.QueryType]dns.Stats{
-					intern.GetByString("foo.com"): {
-						dns.TypeA: {
-							Timeouts:          0,
-							SuccessLatencySum: 0,
-							FailureLatencySum: 0,
-							CountByRcode:      map[uint32]uint32{0: 1},
-						},
-					},
-				},
+				// DNSCountByRcode: map[uint32]uint32{0: 1},
+				// DNSStatsByDomainByQueryType: map[*intern.Value]map[dns.QueryType]dns.Stats{
+				// 	intern.GetByString("foo.com"): {
+				// 		dns.TypeA: {
+				// 			Timeouts:          0,
+				// 			SuccessLatencySum: 0,
+				// 			FailureLatencySum: 0,
+				// 			CountByRcode:      map[uint32]uint32{0: 1},
+				// 		},
+				// 	},
+				// },
 				Via: &network.Via{
 					Subnet: network.Subnet{
 						Alias: "subnet-foo",

--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -6,11 +6,9 @@ import (
 
 	model "github.com/DataDog/agent-payload/process"
 	"github.com/DataDog/datadog-agent/pkg/network"
-	"github.com/DataDog/datadog-agent/pkg/network/dns"
 	"github.com/DataDog/datadog-agent/pkg/network/http"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/gogo/protobuf/proto"
-	"go4.org/intern"
 )
 
 const maxRoutes = math.MaxInt32
@@ -48,10 +46,9 @@ func (ipc ipCache) Get(addr util.Address) string {
 // FormatConnection converts a ConnectionStats into an model.Connection
 func FormatConnection(
 	conn network.ConnectionStats,
-	domainSet map[string]int,
 	routes map[string]RouteIdx,
 	httpStats *model.HTTPAggregations,
-	dnsWithQueryType bool,
+	dnsFormatter *dnsFormatter,
 	ipc ipCache,
 ) *model.Connection {
 	c := connPool.Get().(*model.Connection)
@@ -74,52 +71,17 @@ func FormatConnection(
 	c.Rtt = conn.RTT
 	c.RttVar = conn.RTTVar
 	c.IntraHost = conn.IntraHost
-	c.DnsSuccessfulResponses = conn.DNSSuccessfulResponses
-	c.DnsFailedResponses = conn.DNSFailedResponses
-	c.DnsTimeouts = conn.DNSTimeouts
-	c.DnsSuccessLatencySum = conn.DNSSuccessLatencySum
-	c.DnsFailureLatencySum = conn.DNSFailureLatencySum
-	c.DnsCountByRcode = conn.DNSCountByRcode
 	c.LastTcpEstablished = conn.LastTCPEstablished
 	c.LastTcpClosed = conn.LastTCPClosed
 
-	if dnsWithQueryType {
-		c.DnsStatsByDomain = make(map[int32]*model.DNSStats)
-		c.DnsStatsByDomainByQueryType = formatDNSStatsByDomainByQueryType(conn.DNSStatsByDomainByQueryType, domainSet)
-	} else {
-		// downconvert to simply by domain
-		c.DnsStatsByDomain = formatDNSStatsByDomain(conn.DNSStatsByDomainByQueryType, domainSet)
-		c.DnsStatsByDomainByQueryType = make(map[int32]*model.DNSStatsByQueryType)
-	}
 	c.RouteIdx = formatRouteIdx(conn.Via, routes)
+	dnsFormatter.FormatConnectionDNS(conn, c)
 
 	if httpStats != nil {
 		c.HttpAggregations, _ = proto.Marshal(httpStats)
 	}
 
 	return c
-}
-
-var dnsPool = sync.Pool{
-	New: func() interface{} {
-		return new(model.DNSEntry)
-	},
-}
-
-// FormatDNS converts a map[util.Address][]string to a map using IPs string representation
-func FormatDNS(dns map[util.Address][]string, ipc ipCache) map[string]*model.DNSEntry {
-	if dns == nil {
-		return nil
-	}
-
-	ipToNames := make(map[string]*model.DNSEntry, len(dns))
-	for addr, names := range dns {
-		entry := dnsPool.Get().(*model.DNSEntry)
-		entry.Names = names
-		ipToNames[ipc.Get(addr)] = entry
-	}
-
-	return ipToNames
 }
 
 var telemetryPool = sync.Pool{
@@ -304,63 +266,6 @@ func formatEphemeralType(e network.EphemeralPortType) model.EphemeralPortState {
 	default:
 		return model.EphemeralPortState_ephemeralUnspecified
 	}
-}
-
-func formatDNSStatsByDomainByQueryType(stats map[*intern.Value]map[dns.QueryType]dns.Stats, domainSet map[string]int) map[int32]*model.DNSStatsByQueryType {
-	m := make(map[int32]*model.DNSStatsByQueryType)
-	for d, bytype := range stats {
-
-		byqtype := &model.DNSStatsByQueryType{}
-		byqtype.DnsStatsByQueryType = make(map[int32]*model.DNSStats)
-		for t, stat := range bytype {
-			var ms model.DNSStats
-			ms.DnsCountByRcode = stat.CountByRcode
-			ms.DnsFailureLatencySum = stat.FailureLatencySum
-			ms.DnsSuccessLatencySum = stat.SuccessLatencySum
-			ms.DnsTimeouts = stat.Timeouts
-			byqtype.DnsStatsByQueryType[int32(t)] = &ms
-		}
-		pos, ok := domainSet[d.Get().(string)]
-		if !ok {
-			pos = len(domainSet)
-			domainSet[d.Get().(string)] = pos
-		}
-		m[int32(pos)] = byqtype
-	}
-	return m
-}
-
-func formatDNSStatsByDomain(stats map[*intern.Value]map[dns.QueryType]dns.Stats, domainSet map[string]int) map[int32]*model.DNSStats {
-	m := make(map[int32]*model.DNSStats)
-	for d, bytype := range stats {
-		pos, ok := domainSet[d.Get().(string)]
-		if !ok {
-			pos = len(domainSet)
-			domainSet[d.Get().(string)] = pos
-		}
-
-		for _, stat := range bytype {
-
-			if ms, ok := m[int32(pos)]; ok {
-				for rcode, count := range stat.CountByRcode {
-					ms.DnsCountByRcode[rcode] += count
-				}
-				ms.DnsFailureLatencySum += stat.FailureLatencySum
-				ms.DnsSuccessLatencySum += stat.SuccessLatencySum
-				ms.DnsTimeouts += stat.Timeouts
-
-			} else {
-				var ms model.DNSStats
-				ms.DnsCountByRcode = stat.CountByRcode
-				ms.DnsFailureLatencySum = stat.FailureLatencySum
-				ms.DnsSuccessLatencySum = stat.SuccessLatencySum
-				ms.DnsTimeouts = stat.Timeouts
-
-				m[int32(pos)] = &ms
-			}
-		}
-	}
-	return m
 }
 
 func formatIPTranslation(ct *network.IPTranslation, ipc ipCache) *model.IPTranslation {

--- a/pkg/network/encoding/json.go
+++ b/pkg/network/encoding/json.go
@@ -42,12 +42,11 @@ var _ Marshaler = jsonSerializer{}
 var _ Unmarshaler = jsonSerializer{}
 
 // this code is a hack to fix the way zero value maps are handled during a
-// roundtrip (eg. marshaling/unmarshaling) by the JSON marshaler as we use
-// the `EmitDefaults` option.  please note this function is executed *only for
-// debugging purposes* since the JSON marshaller is not used for communication
-// between system-probe and the process-agent.
-// TODO: Make this more future-proof using reflection (we don't care about they
-// perfomance penalty of doing so because this only runs during tests)
+// roundtrip (eg. marshaling/unmarshaling) by the JSON marshaler as we use the
+// `EmitDefaults` option. please note this function is executed *only in
+// tests* since the JSON unmarshaller is not used in the communication between
+// system-probe and the process-agent.
+// TODO: Make this more future-proof using reflection
 func handleZeroValues(conns *model.Connections) {
 	if conns == nil {
 		return

--- a/pkg/network/encoding/json.go
+++ b/pkg/network/encoding/json.go
@@ -29,6 +29,8 @@ func (jsonSerializer) Unmarshal(blob []byte) (*model.Connections, error) {
 	if err := jsonpb.Unmarshal(reader, conns); err != nil {
 		return nil, err
 	}
+
+	handleZeroValues(conns)
 	return conns, nil
 }
 
@@ -38,3 +40,32 @@ func (j jsonSerializer) ContentType() string {
 
 var _ Marshaler = jsonSerializer{}
 var _ Unmarshaler = jsonSerializer{}
+
+// this code is a hack to fix the way zero value maps are handled during a
+// roundtrip (eg. marshaling/unmarshaling) by the JSON marshaler as we use
+// the `EmitDefaults` option.  please note this function is executed *only for
+// debugging purposes* since the JSON marshaller is not used for communication
+// between system-probe and the process-agent.
+// TODO: Make this more future-proof using reflection (we don't care about they
+// perfomance penalty of doing so because this only runs during tests)
+func handleZeroValues(conns *model.Connections) {
+	if conns == nil {
+		return
+	}
+
+	if len(conns.CompilationTelemetryByAsset) == 0 {
+		conns.CompilationTelemetryByAsset = nil
+	}
+
+	for _, c := range conns.Conns {
+		if len(c.DnsCountByRcode) == 0 {
+			c.DnsCountByRcode = nil
+		}
+		if len(c.DnsStatsByDomain) == 0 {
+			c.DnsStatsByDomain = nil
+		}
+		if len(c.DnsStatsByDomainByQueryType) == 0 {
+			c.DnsStatsByDomainByQueryType = nil
+		}
+	}
+}

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -10,7 +10,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/http"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/dustin/go-humanize"
-	"go4.org/intern"
 )
 
 // ConnectionType will be either TCP or UDP
@@ -111,6 +110,7 @@ type Connections struct {
 	ConnTelemetry               *ConnectionsTelemetry
 	CompilationTelemetryByAsset map[string]RuntimeCompilationTelemetry
 	HTTP                        map[http.Key]http.RequestStats
+	DNSStats                    dns.StatsByKeyByNameByType
 }
 
 // ConnectionsTelemetry stores telemetry from the system probe related to connections collection
@@ -177,23 +177,15 @@ type ConnectionStats struct {
 	Pid   uint32
 	NetNS uint32
 
-	SPort                       uint16
-	DPort                       uint16
-	Type                        ConnectionType
-	Family                      ConnectionFamily
-	Direction                   ConnectionDirection
-	SPortIsEphemeral            EphemeralPortType
-	IPTranslation               *IPTranslation
-	IntraHost                   bool
-	DNSSuccessfulResponses      uint32
-	DNSFailedResponses          uint32
-	DNSTimeouts                 uint32
-	DNSSuccessLatencySum        uint64
-	DNSFailureLatencySum        uint64
-	DNSCountByRcode             map[uint32]uint32
-	DNSStatsByDomainByQueryType map[*intern.Value]map[dns.QueryType]dns.Stats
-
-	Via *Via
+	SPort            uint16
+	DPort            uint16
+	Type             ConnectionType
+	Family           ConnectionFamily
+	Direction        ConnectionDirection
+	SPortIsEphemeral EphemeralPortType
+	IPTranslation    *IPTranslation
+	IntraHost        bool
+	Via              *Via
 
 	IsAssured bool
 }

--- a/pkg/network/event_windows.go
+++ b/pkg/network/event_windows.go
@@ -105,12 +105,6 @@ func FlowToConnStat(cs *ConnectionStats, flow *driver.PerFlowData, enableMonoton
 	cs.NetNS = 0
 	cs.IPTranslation = nil
 	cs.IntraHost = false
-	cs.DNSSuccessfulResponses = 0
-	cs.DNSFailedResponses = 0
-	cs.DNSTimeouts = 0
-	cs.DNSSuccessLatencySum = 0
-	cs.DNSFailureLatencySum = 0
-	cs.DNSCountByRcode = nil
 	cs.LastSentBytes = 0
 	cs.LastRecvBytes = 0
 	cs.MonotonicRetransmits = 0

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -105,26 +105,24 @@ type networkState struct {
 	latestTimeEpoch uint64
 
 	// Network state configuration
-	clientExpiry      time.Duration
-	maxClosedConns    int
-	maxClientStats    int
-	maxDNSStats       int
-	maxHTTPStats      int
-	collectDNSDomains bool
+	clientExpiry   time.Duration
+	maxClosedConns int
+	maxClientStats int
+	maxDNSStats    int
+	maxHTTPStats   int
 }
 
 // NewState creates a new network state
-func NewState(clientExpiry time.Duration, maxClosedConns, maxClientStats int, maxDNSStats int, maxHTTPStats int, collectDNSDomains bool) State {
+func NewState(clientExpiry time.Duration, maxClosedConns, maxClientStats int, maxDNSStats int, maxHTTPStats int) State {
 	return &networkState{
-		clients:           map[string]*client{},
-		telemetry:         telemetry{},
-		clientExpiry:      clientExpiry,
-		maxClosedConns:    maxClosedConns,
-		maxClientStats:    maxClientStats,
-		maxDNSStats:       maxDNSStats,
-		maxHTTPStats:      maxHTTPStats,
-		collectDNSDomains: collectDNSDomains,
-		buf:               make([]byte, ConnectionByteKeyMaxLen),
+		clients:        map[string]*client{},
+		telemetry:      telemetry{},
+		clientExpiry:   clientExpiry,
+		maxClosedConns: maxClosedConns,
+		maxClientStats: maxClientStats,
+		maxDNSStats:    maxDNSStats,
+		maxHTTPStats:   maxHTTPStats,
+		buf:            make([]byte, ConnectionByteKeyMaxLen),
 	}
 }
 

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -308,6 +308,7 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 	return &network.Connections{
 		Conns:                       delta.Connections,
 		DNS:                         names,
+		DNSStats:                    delta.DNSStats,
 		HTTP:                        delta.HTTP,
 		ConnTelemetry:               ctm,
 		CompilationTelemetryByAsset: rctm,

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -141,7 +141,6 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 		config.MaxConnectionsStateBuffered,
 		config.MaxDNSStatsBuffered,
 		config.MaxHTTPStatsBuffered,
-		config.CollectDNSDomains,
 	)
 
 	tr := &Tracer{

--- a/pkg/network/tracer/tracer_windows.go
+++ b/pkg/network/tracer/tracer_windows.go
@@ -62,7 +62,6 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 		config.MaxConnectionsStateBuffered,
 		config.MaxDNSStatsBuffered,
 		config.MaxHTTPStatsBuffered,
-		config.CollectDNSDomains,
 	)
 
 	reverseDNS := dns.NewNullReverseDNS()

--- a/pkg/network/tracer/tracer_windows.go
+++ b/pkg/network/tracer/tracer_windows.go
@@ -122,11 +122,11 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 	delta := t.state.GetDelta(clientID, uint64(time.Now().Nanosecond()), activeConnStats, closedConnStats, t.reverseDNS.GetDNSStats(), nil)
 	conns := delta.Connections
 	var ips []util.Address
-	for _, conn := range delta.Connections {
+	for _, conn := range conns {
 		ips = append(ips, conn.Source, conn.Dest)
 	}
 	names := t.reverseDNS.Resolve(ips)
-	return &network.Connections{Conns: conns, DNS: names}, nil
+	return &network.Connections{Conns: conns, DNS: names, DNSStats: delta.DNSStats}, nil
 }
 
 // GetStats returns a map of statistics about the current tracer's internal state


### PR DESCRIPTION
### What does this PR do?

Remove DNS-specific information from `ConnectionStats`.
This change resulted in **10%** reduction in RSS for our load test server.

### Motivation

`ConnStats` objects are responsible for the majority long-lived objects in the heap. This type is currently bloated with information that isn't really necessary until the encoding stage.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

QA covered by unit tests

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
