### PR TITLE
Changes the message that appears in eg flamegraph when the SQL cannot be obfuscated

### DIFF
--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -20,7 +20,7 @@ import (
 )
 
 const sqlQueryTag = "sql.query"
-const nonParsableResource = "Non-parsable SQL query"
+const nonParsableResource = "Cannot obfuscate: Non-parsable SQL query"
 
 var questionMark = []byte("?")
 

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -178,8 +178,8 @@ func TestSQLResourceWithError(t *testing.T) {
 
 	for _, tc := range testCases {
 		NewObfuscator(nil).Obfuscate(&tc.span)
-		assert.Equal("Non-parsable SQL query", tc.span.Resource)
-		assert.Equal("Non-parsable SQL query", tc.span.Meta["sql.query"])
+		assert.Equal("Cannot obfuscate: Non-parsable SQL query", tc.span.Resource)
+		assert.Equal("Cannot obfuscate: Non-parsable SQL query", tc.span.Meta["sql.query"])
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Changes the message that appears in eg flamegraph when the SQL obfuscator fails from "Non-parsable SQL query" to "Cannot obfuscate: Non-parsable SQL query".

This makes is clearer as to the origin of the error - otherwise to the uninitiated it looks as if it is the database throwing an error during SQL execution, when it is the logging tool, datadog, throwing an error during logging (specifically obfuscation).

### Motivation

My team spent a few days diving down a rabbit-hole trying to debug what they thought was a complex SQL error, when in fact, everything was working fine and they should have ignored this error.

### Additional Notes

If I save the sanity of another team, it will all have been worth it.

### Describe how to test your changes

Throw a suitably complex, but correct, SQL statement at your database and watch the obfuscator weep. Ours was about 2000 lines long, but that's our problem.