### PR TITLE
[tagger] Enable pull collection for ECS collector

### DIFF
--- a/pkg/tagger/collectors/ecs_extract.go
+++ b/pkg/tagger/collectors/ecs_extract.go
@@ -18,7 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func (c *ECSCollector) parseTasks(ctx context.Context, tasks []v1.Task, targetDockerID string, containerHandlers ...func(ctx context.Context, containerID string, tags *utils.TagList) error) ([]*TagInfo, error) {
+func (c *ECSCollector) parseTasks(ctx context.Context, tasks []v1.Task, containerHandlers ...func(ctx context.Context, containerID string, tags *utils.TagList) error) ([]*TagInfo, error) {
 	var output []*TagInfo
 	now := time.Now()
 	for _, task := range tasks {
@@ -26,51 +26,51 @@ func (c *ECSCollector) parseTasks(ctx context.Context, tasks []v1.Task, targetDo
 		if task.KnownStatus == "STOPPED" {
 			continue
 		}
+
 		for _, container := range task.Containers {
 			entityID := containers.BuildTaggerEntityName(container.DockerID)
-			// Only collect new containers + the targeted container, to avoid empty tags on race conditions
-			if c.expire.Update(entityID, now) || container.DockerID == targetDockerID {
-				tags := utils.NewTagList()
-				tags.AddLow("task_version", task.Version)
-				tags.AddLow("task_name", task.Family)
-				tags.AddLow("task_family", task.Family)
-				tags.AddLow("ecs_container_name", container.Name)
+			c.expire.Update(entityID, now)
 
-				if c.clusterName != "" {
-					if !config.Datadog.GetBool("disable_cluster_name_tag_key") {
-						tags.AddLow("cluster_name", c.clusterName)
-					}
-					tags.AddLow("ecs_cluster_name", c.clusterName)
+			tags := utils.NewTagList()
+			tags.AddLow("task_version", task.Version)
+			tags.AddLow("task_name", task.Family)
+			tags.AddLow("task_family", task.Family)
+			tags.AddLow("ecs_container_name", container.Name)
+
+			if c.clusterName != "" {
+				if !config.Datadog.GetBool("disable_cluster_name_tag_key") {
+					tags.AddLow("cluster_name", c.clusterName)
 				}
-
-				var expiryDate time.Time
-				for _, fn := range containerHandlers {
-					if fn != nil {
-						err := fn(ctx, container.DockerID, tags)
-						if err != nil {
-							log.Warnf("container handler func failed: %s", err)
-
-							// cache result for 1 sencond
-							// it prevents tagger to aggresivelly retry fetch
-							expiryDate = time.Now().Add(1 * time.Second)
-						}
-					}
-				}
-
-				tags.AddOrchestrator("task_arn", task.Arn)
-
-				low, orch, high, _ := tags.Compute()
-
-				info := &TagInfo{
-					Source:               ecsCollectorName,
-					Entity:               entityID,
-					HighCardTags:         high,
-					OrchestratorCardTags: orch,
-					LowCardTags:          low,
-					ExpiryDate:           expiryDate,
-				}
-				output = append(output, info)
+				tags.AddLow("ecs_cluster_name", c.clusterName)
 			}
+
+			var expiryDate time.Time
+			for _, fn := range containerHandlers {
+				if fn != nil {
+					err := fn(ctx, container.DockerID, tags)
+					if err != nil {
+						log.Warnf("container handler func failed: %s", err)
+
+						// cache result for 1 sencond
+						// it prevents tagger to aggresivelly retry fetch
+						expiryDate = time.Now().Add(1 * time.Second)
+					}
+				}
+			}
+
+			tags.AddOrchestrator("task_arn", task.Arn)
+
+			low, orch, high, _ := tags.Compute()
+
+			info := &TagInfo{
+				Source:               ecsCollectorName,
+				Entity:               entityID,
+				HighCardTags:         high,
+				OrchestratorCardTags: orch,
+				LowCardTags:          low,
+				ExpiryDate:           expiryDate,
+			}
+			output = append(output, info)
 		}
 	}
 	return output, nil


### PR DESCRIPTION
### What does this PR do?

The ECS collector already sorta-kinda did a pull collection on a fetch,
by fetching all tasks and only emitting TagInfos for new or previously
missed containers. Now we make that behavior explicit by doing a proper
pull, and parsing tags for all tasks on every pull.

### Describe how to test your changes

Run the agent as an ECS EC2 task. Run `agent tagger-list` to ensure that tags are present for all the containers running on the machine.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
