### PR TITLE
[containerd] Add support for Windows

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -79,6 +79,7 @@ core,github.com/Microsoft/go-winio/pkg/guid,MIT,Microsoft
 core,github.com/Microsoft/go-winio/pkg/security,MIT,Microsoft
 core,github.com/Microsoft/go-winio/vhd,MIT,Microsoft
 core,github.com/Microsoft/hcsshim,MIT,Microsoft | Microsoft Corp
+core,github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats,MIT,Microsoft | Microsoft Corp
 core,github.com/Microsoft/hcsshim/computestorage,MIT,Microsoft | Microsoft Corp
 core,github.com/Microsoft/hcsshim/internal/cow,MIT,Microsoft | Microsoft Corp
 core,github.com/Microsoft/hcsshim/internal/hcs,MIT,Microsoft | Microsoft Corp

--- a/go.mod
+++ b/go.mod
@@ -68,6 +68,7 @@ require (
 	github.com/Masterminds/semver v1.5.0
 	github.com/Masterminds/sprig v2.22.0+incompatible
 	github.com/Microsoft/go-winio v0.4.17
+	github.com/Microsoft/hcsshim v0.8.18
 	github.com/alecthomas/jsonschema v0.0.0-20210526225647-edb03dcab7bc
 	github.com/alecthomas/participle v0.7.1
 	github.com/alecthomas/repr v0.0.0-20181024024818-d37bc2a10ba1

--- a/pkg/collector/corechecks/containers/containerd/containerd.go
+++ b/pkg/collector/corechecks/containers/containerd/containerd.go
@@ -31,7 +31,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	cutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
 	ddContainers "github.com/DataDog/datadog-agent/pkg/util/containers"
-	cgroup "github.com/DataDog/datadog-agent/pkg/util/containers/providers/cgroup"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/providers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/system"
 )
@@ -249,7 +249,7 @@ func computeMetrics(sender aggregator.Sender, cu cutil.ContainerdItf, fil *ddCon
 		fileDescCount := 0
 		for _, p := range processes {
 			pid := p.Pid
-			fdCount, err := cgroup.GetFileDescriptorLen(int(pid))
+			fdCount, err := providers.ContainerImpl().GetNumFileDescriptors(int(pid))
 			if err != nil {
 				log.Debugf("Failed to get file desc length for pid %d, container %s: %s", pid, ctn.ID()[:12], err)
 				continue

--- a/pkg/collector/corechecks/containers/containerd/containerd_test.go
+++ b/pkg/collector/corechecks/containers/containerd/containerd_test.go
@@ -8,16 +8,12 @@
 package containerd
 
 import (
-	"encoding/json"
 	"sort"
 	"testing"
 	"time"
 
 	v1 "github.com/containerd/cgroups/stats/v1"
-	"github.com/containerd/containerd/api/types"
 	"github.com/containerd/containerd/containers"
-	"github.com/containerd/typeurl"
-	prototypes "github.com/gogo/protobuf/types"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -389,62 +385,6 @@ func TestComputeUptime(t *testing.T) {
 			computeUptime(mocked, test.ctn, currentTime, []string{})
 			for name, val := range test.expected {
 				mocked.AssertMetric(t, "Gauge", name, val, "", []string{})
-			}
-		})
-	}
-}
-
-// TestConvertTaskToMetrics checks the convertTasktoMetrics
-func TestConvertTaskToMetrics(t *testing.T) {
-	typeurl.Register(&v1.Metrics{}, "io.containerd.cgroups.v1.Metrics") // Need to register the type to be used in UnmarshalAny later on.
-
-	tests := []struct {
-		name     string
-		typeURL  string
-		values   v1.Metrics
-		error    string
-		expected *v1.Metrics
-	}{
-		{
-			"unregistered type",
-			"io.containerd.cgroups.v1.Doge",
-			v1.Metrics{},
-			"type with url io.containerd.cgroups.v1.Doge: not found",
-			nil,
-		},
-		{
-			"missing values",
-			"io.containerd.cgroups.v1.Metrics",
-			v1.Metrics{},
-			"",
-			&v1.Metrics{},
-		},
-		{
-			"fully functional",
-			"io.containerd.cgroups.v1.Metrics",
-			v1.Metrics{Memory: &v1.MemoryStat{Cache: 100}},
-			"",
-			&v1.Metrics{
-				Memory: &v1.MemoryStat{
-					Cache: 100,
-				},
-			},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			typeURL := test.typeURL
-			jsonValue, _ := json.Marshal(test.values)
-			metric := &types.Metric{
-				Data: &prototypes.Any{
-					TypeUrl: typeURL,
-					Value:   jsonValue,
-				},
-			}
-			m, e := convertTasktoMetrics(metric)
-			require.Equal(t, test.expected, m)
-			if e != nil {
-				require.Equal(t, e.Error(), test.error)
 			}
 		})
 	}

--- a/pkg/collector/corechecks/containers/containerd/containerd_test.go
+++ b/pkg/collector/corechecks/containers/containerd/containerd_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	wstats "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
 	v1 "github.com/containerd/cgroups/stats/v1"
 	"github.com/containerd/containerd/containers"
 	"github.com/opencontainers/runtime-spec/specs-go"
@@ -179,7 +180,7 @@ func TestComputeEvents(t *testing.T) {
 	}
 }
 
-func TestComputeCPU(t *testing.T) {
+func TestComputeCPULinux(t *testing.T) {
 	containerdCheck := &ContainerdCheck{
 		instance:  &ContainerdConfig{},
 		CheckBase: corechecks.NewCheckBase("containerd"),
@@ -245,7 +246,7 @@ func TestComputeCPU(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			computeCPU(mocked, test.cpu, test.cpuLimit, test.startTime, test.currentTime, []string{})
+			computeCPULinux(mocked, test.cpu, test.cpuLimit, test.startTime, test.currentTime, []string{})
 			for name, val := range test.expected {
 				mocked.AssertMetric(t, "Rate", name, val, "", []string{})
 			}
@@ -253,7 +254,58 @@ func TestComputeCPU(t *testing.T) {
 	}
 }
 
-func TestComputeMem(t *testing.T) {
+func TestComputeCPUWindows(t *testing.T) {
+	containerdCheck := &ContainerdCheck{
+		instance:  &ContainerdConfig{},
+		CheckBase: corechecks.NewCheckBase("containerd"),
+	}
+	mocked := mocksender.NewMockSender(containerdCheck.ID())
+	mocked.SetupAcceptAll()
+
+	tests := []struct {
+		name                    string
+		cpuStats                *wstats.WindowsContainerProcessorStatistics
+		tags                    []string
+		expectedMetricsReported map[string]float64
+	}{
+		{
+			name: "CPU stats not nil",
+			cpuStats: &wstats.WindowsContainerProcessorStatistics{
+				TotalRuntimeNS:  50,
+				RuntimeUserNS:   10,
+				RuntimeKernelNS: 40,
+			},
+			tags: []string{"foo:bar"},
+			expectedMetricsReported: map[string]float64{
+				"containerd.cpu.total":  50,
+				"containerd.cpu.user":   10,
+				"containerd.cpu.system": 40,
+			},
+		},
+		{
+			name:                    "CPU stats is nil",
+			cpuStats:                nil,
+			tags:                    []string{"foo:bar"},
+			expectedMetricsReported: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			computeCPUWindows(mocked, test.cpuStats, test.tags)
+
+			if test.cpuStats == nil {
+				mocked.AssertNotCalled(t, "Rate")
+			} else {
+				for metricName, metricVal := range test.expectedMetricsReported {
+					mocked.AssertMetric(t, "Rate", metricName, metricVal, "", test.tags)
+				}
+			}
+		})
+	}
+}
+
+func TestComputeMemLinux(t *testing.T) {
 	containerdCheck := &ContainerdCheck{
 		instance:  &ContainerdConfig{},
 		CheckBase: corechecks.NewCheckBase("containerd"),
@@ -340,9 +392,109 @@ func TestComputeMem(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			computeMem(mocked, test.mem, []string{})
+			computeMemLinux(mocked, test.mem, []string{})
 			for name, val := range test.expected {
 				mocked.AssertMetric(t, "Gauge", name, val, "", []string{})
+			}
+		})
+	}
+}
+
+func TestComputeMemWindows(t *testing.T) {
+	containerdCheck := &ContainerdCheck{
+		instance:  &ContainerdConfig{},
+		CheckBase: corechecks.NewCheckBase("containerd"),
+	}
+	mocked := mocksender.NewMockSender(containerdCheck.ID())
+	mocked.SetupAcceptAll()
+
+	tests := []struct {
+		name                    string
+		memStats                *wstats.WindowsContainerMemoryStatistics
+		tags                    []string
+		expectedMetricsReported map[string]float64
+	}{
+		{
+			name: "Memory stats not nil",
+			memStats: &wstats.WindowsContainerMemoryStatistics{
+				MemoryUsageCommitBytes:            1024,
+				MemoryUsageCommitPeakBytes:        2048,
+				MemoryUsagePrivateWorkingSetBytes: 512,
+			},
+			tags: []string{"foo:bar"},
+			expectedMetricsReported: map[string]float64{
+				"containerd.mem.commit":              1024,
+				"containerd.mem.commit_peak":         2048,
+				"containerd.mem.private_working_set": 512,
+			},
+		},
+		{
+			name:                    "Memory stats is nil",
+			memStats:                nil,
+			tags:                    []string{"foo:bar"},
+			expectedMetricsReported: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			computeMemWindows(mocked, test.memStats, test.tags)
+
+			if test.memStats == nil {
+				mocked.AssertNotCalled(t, "Gauge")
+			} else {
+				for metricName, metricVal := range test.expectedMetricsReported {
+					mocked.AssertMetric(t, "Gauge", metricName, metricVal, "", test.tags)
+				}
+			}
+		})
+	}
+}
+
+func TestComputeStorageWindows(t *testing.T) {
+	containerdCheck := &ContainerdCheck{
+		instance:  &ContainerdConfig{},
+		CheckBase: corechecks.NewCheckBase("containerd"),
+	}
+	mocked := mocksender.NewMockSender(containerdCheck.ID())
+	mocked.SetupAcceptAll()
+
+	tests := []struct {
+		name                    string
+		storageStats            *wstats.WindowsContainerStorageStatistics
+		tags                    []string
+		expectedMetricsReported map[string]float64
+	}{
+		{
+			name: "Storage stats not nil",
+			storageStats: &wstats.WindowsContainerStorageStatistics{
+				ReadSizeBytes:  256,
+				WriteSizeBytes: 128,
+			},
+			tags: []string{"foo:bar"},
+			expectedMetricsReported: map[string]float64{
+				"containerd.storage.read":  256,
+				"containerd.storage.write": 128,
+			},
+		},
+		{
+			name:                    "Storage stats is nil",
+			storageStats:            nil,
+			tags:                    []string{"foo:bar"},
+			expectedMetricsReported: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			computeStorageWindows(mocked, test.storageStats, test.tags)
+
+			if test.storageStats == nil {
+				mocked.AssertNotCalled(t, "Rate")
+			} else {
+				for metricName, metricVal := range test.expectedMetricsReported {
+					mocked.AssertMetric(t, "Rate", metricName, metricVal, "", test.tags)
+				}
 			}
 		})
 	}

--- a/pkg/config/environment_containers.go
+++ b/pkg/config/environment_containers.go
@@ -120,10 +120,7 @@ func detectContainerd(features FeatureMap) {
 	}
 
 	if criSocket != "" {
-		// Containerd support was historically meant for K8S
-		// However, containerd is now used standalone elsewhere.
-		// TODO: Consider having a dedicated setting for containerd standalone
-		if IsKubernetes() {
+		if isCriSupported() {
 			features[Cri] = struct{}{}
 		}
 
@@ -131,6 +128,14 @@ func detectContainerd(features FeatureMap) {
 			features[Containerd] = struct{}{}
 		}
 	}
+}
+
+func isCriSupported() bool {
+	// Containerd support was historically meant for K8S
+	// However, containerd is now used standalone elsewhere.
+	// TODO: Consider having a dedicated setting for containerd standalone
+	// Also, cri is not enabled on Windows (check build_tags.py).
+	return IsKubernetes() && runtime.GOOS != "windows"
 }
 
 func detectFargate(features FeatureMap) {

--- a/pkg/util/containers/providers/cgroup/provider.go
+++ b/pkg/util/containers/providers/cgroup/provider.go
@@ -202,6 +202,12 @@ func (mp *provider) GetDefaultHostIPs() ([]string, error) {
 	return defaultHostIPs()
 }
 
+// GetNumFileDescriptors returns the number of open file descriptors for a given
+// pid
+func (mp *provider) GetNumFileDescriptors(pid int) (int, error) {
+	return GetFileDescriptorLen(pid)
+}
+
 func (mp *provider) getCgroup(containerID string) (*ContainerCgroup, error) {
 	mp.lock.RLock()
 	defer mp.lock.RUnlock()

--- a/pkg/util/containers/providers/mock/mock.go
+++ b/pkg/util/containers/providers/mock/mock.go
@@ -75,3 +75,8 @@ func (f FakeContainerImpl) GetContainerLimits(containerID string) (*metrics.Cont
 func (f FakeContainerImpl) GetNetworkMetrics(containerID string, networks map[string]string) (metrics.ContainerNetStats, error) {
 	return nil, nil
 }
+
+// GetNumFileDescriptors mocks the GetNumFileDescriptors interface method
+func (f FakeContainerImpl) GetNumFileDescriptors(pid int) (int, error) {
+	return 0, nil
+}

--- a/pkg/util/containers/providers/windows/provider.go
+++ b/pkg/util/containers/providers/windows/provider.go
@@ -322,6 +322,12 @@ func (mp *provider) GetDefaultHostIPs() ([]string, error) {
 	return []string{fields[3]}, nil
 }
 
+// GetNumFileDescriptors returns the number of open file descriptors for a given
+// pid
+func (mp *provider) GetNumFileDescriptors(pid int) (int, error) {
+	return 0, fmt.Errorf("not supported on windows")
+}
+
 // Output from route print 0.0.0.0:
 //
 // λ route print 0.0.0.0

--- a/pkg/util/containers/types.go
+++ b/pkg/util/containers/types.go
@@ -110,6 +110,7 @@ type ContainerImplementation interface {
 	ContainerIDForPID(pid int) (string, error)
 	GetDefaultGateway() (net.IP, error)
 	GetDefaultHostIPs() ([]string, error)
+	GetNumFileDescriptors(pid int) (int, error)
 
 	metrics.ContainerMetricsProvider
 }

--- a/releasenotes/notes/containerd-windows-231ae803cb047baa.yaml
+++ b/releasenotes/notes/containerd-windows-231ae803cb047baa.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    The "containerd" check is now supported on Windows.

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -98,7 +98,7 @@ TEST_TAGS = AGENT_TAGS.union(set(["clusterchecks"]))
 ### Tag exclusion lists
 
 # List of tags to always remove when not building on Linux
-LINUX_ONLY_TAGS = set(["containerd", "cri", "netcgo", "systemd", "jetson", "linux_bpf"])
+LINUX_ONLY_TAGS = set(["cri", "netcgo", "systemd", "jetson", "linux_bpf"])
 
 # List of tags to always remove when building on Windows
 WINDOWS_EXCLUDE_TAGS = set(["linux_bpf"])


### PR DESCRIPTION
### What does this PR do?

Adds support for the `containerd` check on Windows hosts.

This PR includes the check on Windows images and makes sure it can run without errors.

The metrics metrics reported are:

- CPU (reporting some of the metrics already reported in Linux): `containerd.cpu.total`, `containerd.cpu.user`, `containerd.cpu.system`. (rates)
- Memory (reporting new metrics because I didn't find an equivalent in the ones already reported): `containerd.mem.commit`, `containerd.mem.commit_peak`, `containerd.mem.private_working_set`. (gauges)
- Storage (reporting new metrics also): `containerd.storage.read`, `containerd.storage.write`. (rates)
- Others (reported also in Linux): `containerd.uptime`, `containerd.image.size`.

### Additional Notes

These are the steps I followed for implementing this:
- Removed the `containerd` tag from the Linux-only list so it could be included also on Windows images.
- The `containerd` package had a dependency on cgroups (Linux only). This dependency was only to fetch one of the metrics (open file descriptors). In order to remove that dependency, I exposed a new function `GetNumFileDescriptors` in the `containers/providers` package, and implemented a mock method for Windows.
- The code was assuming that the containerd response contained Linux metrics. I had to change that a bit to support also responses that contain Windows metrics.

### Describe how to test your changes

You'll need to deploy the agent on a Windows node. I ran this on Azure AKS (using containerd 1.4.8), but it can work on other environments. ~I couldn't deploy on GKE because the latest release uses containerd 1.5.2 which has a bug around init-containers.~ Works now on `1.21.4-gke.2300`.

~When deploying the agent, you'll need to specify the CRI socket path. In helm: `datadog.criSocketPath:"\\.\pipe\containerd-containerd"`~ No longer needed with the latest version of the helm charts, only set it if you're not using the default path.

Once the agent is deployed, check that the agent is reporting the metrics mentioned above.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
