### PR TITLE
pkg/trace/writer: change intake to v2

### DIFF
--- a/pkg/trace/test/backend.go
+++ b/pkg/trace/test/backend.go
@@ -46,7 +46,7 @@ func newFakeBackend(channelSize int) *fakeBackend {
 		out: make(chan interface{}, size),
 	}
 	mux := http.NewServeMux()
-	mux.HandleFunc("/api/v0.2/traces", fb.handleTraces)
+	mux.HandleFunc("/api/v2/spans", fb.handleTraces)
 	mux.HandleFunc("/api/v0.2/stats", fb.handleStats)
 	mux.HandleFunc("/_health", fb.handleHealth)
 

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -26,7 +26,7 @@ import (
 )
 
 // pathTraces is the target host API path for delivering traces.
-const pathTraces = "/api/v0.2/traces"
+const pathTraces = "/api/v2/spans"
 
 // MaxPayloadSize specifies the maximum accumulated payload size that is allowed before
 // a flush is triggered; replaced in tests.

--- a/releasenotes/notes/apm-change-trace-writer-to-intake-v2-672ae59119912955.yaml
+++ b/releasenotes/notes/apm-change-trace-writer-to-intake-v2-672ae59119912955.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: Change the PATH in the HTTP requests sent by trace writer to Intake v2


### PR DESCRIPTION
### What does this PR do?

Change to PATH in the HTTP requests when submitting traces to Event-Platform Intake, to conform to Intake v2 API

### Motivation

What inspired you to submit this pull request?

### Additional Notes

This change will affect all customers upgrading the agent

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
