### PR TITLE
Try building without static

### DIFF
--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -304,7 +304,7 @@ def image_build(ctx, arch='amd64', skip_build=False):
     dst = os.path.join("Dockerfiles", "dogstatsd", "alpine", "static")
 
     if not skip_build:
-        build(ctx, rebuild=True, static=True)
+        build(ctx, rebuild=True)
     if not os.path.exists(src):
         print("Could not find dogstatsd static binary at {} ".format(src))
         raise Exit(code=1)

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -300,7 +300,7 @@ def image_build(ctx, arch='amd64', skip_build=False):
 
     client = docker.from_env()
 
-    src = os.path.join(STATIC_BIN_PATH, bin_name("dogstatsd"))
+    src = os.path.join(DOGSTATSD_BIN_PATH, bin_name("dogstatsd"))
     dst = os.path.join("Dockerfiles", "dogstatsd", "alpine", "static")
 
     if not skip_build:


### PR DESCRIPTION
### What does this PR do?

Build dogstatsd binary without `static=True`

### Motivation

Fix docker-tests CircleCI job.

### Additional Notes

No idea if this will work, just blindly following StackOverflow/error advice.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
