### PR TITLE
[invoke/macos] Refresh Github App tokens

### DIFF
--- a/tasks/libs/common/github_workflows.py
+++ b/tasks/libs/common/github_workflows.py
@@ -18,8 +18,9 @@ class GithubWorkflows(RemoteAPI):
 
     BASE_URL = "https://api.github.com"
 
-    def __init__(self, repository="", api_token=""):
+    def __init__(self, repository="", api_token="", api_token_expiration_date=""):
         self.api_token = api_token
+        self.api_token_expiration_date = api_token_expiration_date
         self.repository = repository
         self.api_name = "GitHub Workflows"
         self.authorization_error_message = (

--- a/tasks/libs/common/githubapp.py
+++ b/tasks/libs/common/githubapp.py
@@ -2,6 +2,7 @@ import base64
 import logging
 import os
 import time
+from datetime import datetime
 
 logger = logging.getLogger(__name__)
 logger.setLevel(os.environ.get('LOGGING_LEVEL', 'INFO'))
@@ -90,7 +91,7 @@ class GithubApp:
                 )
                 time.sleep(1)
                 continue
-            return r.json().get("token")
+            return r.json().get("token"), datetime.strptime(r.json().get("expires_at"), "%Y-%m-%dT%H:%M:%SZ")
         raise GithubAppException(
             """Unable to retrieve an access token.
         Status code: {} Response Text: {}""".format(

--- a/tasks/libs/common/remote_api.py
+++ b/tasks/libs/common/remote_api.py
@@ -69,7 +69,7 @@ class RemoteAPI(object):
             if r.status_code == 401:
                 print(self.authorization_error_message)
 
-                print("{} says: {}".format(self.api_name, r.json()["error_description"]))
+                print("{} says: {}".format(self.api_name, r.json()))
                 raise Exit(code=1)
         except requests.exceptions.Timeout:
             print("Connection to {} ({}) timed out.".format(self.api_name, url))

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -1,7 +1,7 @@
 import sys
 import tempfile
 import zipfile
-from datetime import datetime
+from datetime import datetime, timedelta
 from time import sleep
 
 from invoke.exceptions import Exit
@@ -10,6 +10,19 @@ from tasks.utils import DEFAULT_BRANCH
 
 from .common.color import color_message
 from .common.github_workflows import GithubException, GithubWorkflows, get_github_app_token
+
+
+def create_or_refresh_macos_build_github_workflows(github_workflows=None):
+    # If no token or token is going to expire, refresh token
+    if (
+        github_workflows is None
+        or datetime.utcnow() + timedelta(minutes=5) > github_workflows.api_token_expiration_date
+    ):
+        token, expiration_date = get_github_app_token()
+        return GithubWorkflows(
+            repository="DataDog/datadog-agent-macos-build", api_token=token, api_token_expiration_date=expiration_date
+        )
+    return github_workflows
 
 
 def trigger_macos_workflow(
@@ -47,9 +60,7 @@ def trigger_macos_workflow(
 
     # The workflow trigger endpoint doesn't return anything. You need to fetch the workflow run id
     # by yourself.
-    GithubWorkflows(repository="DataDog/datadog-agent-macos-build", api_token=get_github_app_token()).trigger_workflow(
-        "macos.yaml", github_action_ref, inputs
-    )
+    create_or_refresh_macos_build_github_workflows().trigger_workflow("macos.yaml", github_action_ref, inputs)
 
     # Thus the following hack: query the latest run for ref, wait until we get a non-completed run
     # that started after we triggered the workflow.
@@ -73,18 +84,17 @@ def get_macos_workflow_run_for_ref(github_action_ref="master"):
     """
     Get the latest workflow for the given ref.
     """
-    return GithubWorkflows(
-        repository="DataDog/datadog-agent-macos-build", api_token=get_github_app_token()
-    ).latest_workflow_run_for_ref("macos.yaml", github_action_ref)
+    return create_or_refresh_macos_build_github_workflows().latest_workflow_run_for_ref("macos.yaml", github_action_ref)
 
 
 def follow_workflow_run(run_id):
     """
     Follow the workflow run until completion.
     """
-    github_workflows = GithubWorkflows(repository="DataDog/datadog-agent-macos-build", api_token=get_github_app_token())
+    github_workflows = None
 
     try:
+        github_workflows = create_or_refresh_macos_build_github_workflows(github_workflows)
         run = github_workflows.workflow_run(run_id)
     except GithubException:
         raise Exit(code=1)
@@ -101,6 +111,7 @@ def follow_workflow_run(run_id):
     while True:
         # Do not fail outright for temporary failures
         try:
+            github_workflows = create_or_refresh_macos_build_github_workflows(github_workflows)
             run = github_workflows.workflow_run(run_id)
         except GithubException:
             failures += 1
@@ -134,10 +145,9 @@ def download_artifacts(run_id, destination="."):
     """
     Download all artifacts for a given job in the specified location.
     """
-    github_workflows = GithubWorkflows(repository="DataDog/datadog-agent-macos-build", api_token=get_github_app_token())
-
     print(color_message("Downloading artifacts for run {} to {}".format(run_id, destination), "blue"))
 
+    github_workflows = create_or_refresh_macos_build_github_workflows()
     run_artifacts = github_workflows.workflow_run_artifacts(run_id)
     if run_artifacts is None:
         print("Workflow run not found.")
@@ -147,6 +157,7 @@ def download_artifacts(run_id, destination="."):
     with tempfile.TemporaryDirectory() as tmpdir:
         for artifact in run_artifacts["artifacts"]:
             # Download artifact
+            github_workflows = create_or_refresh_macos_build_github_workflows(github_workflows)
             zip_path = github_workflows.download_artifact(artifact["id"], tmpdir)
 
             # Unzip it in the target destination

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -91,10 +91,9 @@ def follow_workflow_run(run_id):
     """
     Follow the workflow run until completion.
     """
-    github_workflows = None
 
     try:
-        github_workflows = create_or_refresh_macos_build_github_workflows(github_workflows)
+        github_workflows = create_or_refresh_macos_build_github_workflows()
         run = github_workflows.workflow_run(run_id)
     except GithubException:
         raise Exit(code=1)


### PR DESCRIPTION
### What does this PR do?

Adds logic in the invoke tasks that follow MacOS builds to automatically refresh tokens when they're about to expire.

### Motivation

Prevent failures due to holding and trying to use an expired token (tokens expire after 1h).

### Describe how to test your changes

Run pipeline with MacOS builds, check that it doesn't fail after 1h: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/88303763

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
