### PR TITLE
Improve flaky TestBatchStrategySendsPayloadWhenBufferIsOutdated

### DIFF
--- a/pkg/logs/sender/batch_strategy_test.go
+++ b/pkg/logs/sender/batch_strategy_test.go
@@ -67,13 +67,10 @@ func TestBatchStrategySendsPayloadWhenBufferIsOutdated(t *testing.T) {
 		m := message.NewMessage([]byte("a"), nil, "", 0)
 		input <- m
 
-		// it should have flushed in this time
-		<-time.After(2 * timerInterval)
-
 		select {
 		case mOut := <-output:
 			assert.EqualValues(t, m, mOut)
-		default:
+		case <-time.After(5 * timerInterval):
 			assert.Fail(t, "the output channel should not be empty")
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

Try to fix flacky TestBatchStrategySendsPayloadWhenBufferIsOutdated test

### Motivation

TestBatchStrategySendsPayloadWhenBufferIsOutdated can fail on slow machine. Instead
of waiting a fixed duration of 200 milliseconds use a 500 milliseconds timeout.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
