### PR TITLE
[gitlab] Fix wheel cache upload condition

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -348,7 +348,7 @@ build do
           command "#{pip} wheel . --no-deps --no-index --wheel-dir=#{wheel_build_dir}", :env => nix_build_env, :cwd => "#{project_dir}/#{check}"
           command "#{pip} install datadog-#{check} --no-deps --no-index --find-links=#{wheel_build_dir}"
         end
-        if cache_bucket
+        if cache_bucket != ''
           command "inv -e agent.upload-integration-to-cache " \
             "--python 2 --bucket #{cache_bucket} " \
             "--integrations-dir #{windows_safe_path(project_dir)} " \

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -351,7 +351,7 @@ build do
           command "#{pip} wheel . --no-deps --no-index --wheel-dir=#{wheel_build_dir}", :env => nix_build_env, :cwd => "#{project_dir}/#{check}"
           command "#{pip} install datadog-#{check} --no-deps --no-index --find-links=#{wheel_build_dir}"
         end
-        if cache_bucket
+        if cache_bucket != ''
           command "inv -e agent.upload-integration-to-cache " \
             "--python 3 --bucket #{cache_bucket} " \
             "--integrations-dir #{windows_safe_path(project_dir)} " \


### PR DESCRIPTION
### What does this PR do?

Fixes the condition for uploading wheel to cache (empty string still evaluates to true in Ruby).

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
