### PR TITLE
Fix race when stopping utilization tracker

### DIFF
--- a/pkg/util/sliding_window.go
+++ b/pkg/util/sliding_window.go
@@ -140,14 +140,13 @@ func (sw *slidingWindow) newTicker() {
 				// Invoke the polling function
 
 				sw.stateChangeLock.RLock()
-
 				if sw.stopped {
 					sw.stateChangeLock.RUnlock()
 					return
 				}
+				sw.stateChangeLock.RUnlock()
 
 				value := sw.pollingFunc()
-				sw.stateChangeLock.RUnlock()
 
 				// Store the data and update any needed variables
 


### PR DESCRIPTION
### What does this PR do?

Try deadlock when stopping utlization tracker.

### Motivation

TestUtilizationTracker can fail because of a deadlock when stopping utilization tracker:
Calling Stop on UtilizationTracker cause its embedded lock to be taken. If, in the meantime,
if the ticker in SlidingWindow.newTicker is triggered, it first takes its stateChangeLock then tries
to acquire the UtilizationTracker lock, causing the deadlock.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
