### PR TITLE
[corecheck/snmp] add namespace doc

### DIFF
--- a/pkg/collector/corechecks/snmp/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check/defaults"
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/common"
@@ -58,6 +57,7 @@ type InitConfig struct {
 	BulkMaxRepetitions    Number           `yaml:"bulk_max_repetitions"`
 	CollectDeviceMetadata Boolean          `yaml:"collect_device_metadata"`
 	MinCollectionInterval int              `yaml:"min_collection_interval"`
+	Namespace             string           `yaml:"namespace"`
 }
 
 // InstanceConfig is used to deserialize integration instance config
@@ -241,6 +241,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	// Set defaults before unmarshalling
 	instance.UseGlobalMetrics = true
 	initConfig.CollectDeviceMetadata = true
+	initConfig.Namespace = "default"
 
 	err := yaml.Unmarshal(rawInitConfig, &initConfig)
 	if err != nil {
@@ -376,10 +377,10 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	if instance.Namespace != "" {
 		c.Namespace = instance.Namespace
 	} else {
-		c.Namespace = config.Datadog.GetString("network_devices.namespace")
+		c.Namespace = initConfig.Namespace
 	}
 	if c.Namespace == "" {
-		// Can only happen if network_devices.namespace config is set to empty string in `datadog.yaml`
+		// Can only happen if snmp_listener.namespace config is set to empty string in `datadog.yaml`
 		return nil, fmt.Errorf("namespace cannot be empty")
 	}
 

--- a/pkg/collector/corechecks/snmp/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/common"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/metadata"
+	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 )
 
 // Using high oid batch size might lead to snmp calls timing out.
@@ -241,7 +242,6 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 	// Set defaults before unmarshalling
 	instance.UseGlobalMetrics = true
 	initConfig.CollectDeviceMetadata = true
-	initConfig.Namespace = "default"
 
 	err := yaml.Unmarshal(rawInitConfig, &initConfig)
 	if err != nil {
@@ -376,9 +376,12 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 
 	if instance.Namespace != "" {
 		c.Namespace = instance.Namespace
-	} else {
+	} else if initConfig.Namespace != "" {
 		c.Namespace = initConfig.Namespace
+	} else {
+		c.Namespace = coreconfig.Datadog.GetString("network_devices.namespace")
 	}
+
 	if c.Namespace == "" {
 		// Can only happen if snmp_listener.namespace config is set to empty string in `datadog.yaml`
 		return nil, fmt.Errorf("namespace cannot be empty")

--- a/pkg/collector/corechecks/snmp/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 )
 
 func TestConfigurations(t *testing.T) {
@@ -999,30 +1000,33 @@ collect_device_metadata: true
 }
 
 func Test_buildConfig_namespace(t *testing.T) {
-	// language=yaml
-	rawInitConfig := []byte(`
-namespace: default`)
+	defer coreconfig.Datadog.Set("network_devices.namespace", "default")
 
+	// Should use namespace defined in instance config
 	// language=yaml
 	rawInstanceConfig := []byte(`
 ip_address: 1.2.3.4
 community_string: "abc"
 namespace: my-ns
 `)
+	rawInitConfig := []byte(``)
 
 	conf, err := NewCheckConfig(rawInstanceConfig, rawInitConfig)
 	assert.Nil(t, err)
 	assert.Equal(t, "my-ns", conf.Namespace)
 
+	// Should use namespace defined in datadog.yaml network_devices
 	// language=yaml
 	rawInstanceConfig = []byte(`
 ip_address: 1.2.3.4
 community_string: "abc"
 `)
+	rawInitConfig = []byte(``)
 	conf, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
 	assert.Nil(t, err)
 	assert.Equal(t, "default", conf.Namespace)
 
+	// Should use namespace defined in init config
 	// language=yaml
 	rawInstanceConfig = []byte(`
 ip_address: 1.2.3.4
@@ -1034,6 +1038,34 @@ namespace: ns-from-datadog-conf`)
 	assert.Nil(t, err)
 	assert.Equal(t, "ns-from-datadog-conf", conf.Namespace)
 
+	// Should use namespace defined in datadog.yaml network_devices
+	// language=yaml
+	rawInstanceConfig = []byte(`
+ip_address: 1.2.3.4
+community_string: "abc"
+`)
+	rawInitConfig = []byte(``)
+	coreconfig.Datadog.Set("network_devices.namespace", "totoro")
+	conf, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	assert.Nil(t, err)
+	assert.Equal(t, "totoro", conf.Namespace)
+
+	// Should use namespace defined in init config
+	// when namespace is empty in instance config
+	// language=yaml
+	rawInstanceConfig = []byte(`
+ip_address: 1.2.3.4
+community_string: "abc"
+namespace: ""
+`)
+	rawInitConfig = []byte(`
+namespace: ponyo`)
+	conf, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	assert.Nil(t, err)
+	assert.Equal(t, "ponyo", conf.Namespace)
+
+	// Should use namespace defined in datadog.yaml network_devices
+	// when namespace is empty in init config
 	// language=yaml
 	rawInstanceConfig = []byte(`
 ip_address: 1.2.3.4
@@ -1041,6 +1073,19 @@ community_string: "abc"
 `)
 	rawInitConfig = []byte(`
 namespace: `)
+	coreconfig.Datadog.Set("network_devices.namespace", "mononoke")
+	conf, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
+	assert.Nil(t, err)
+	assert.Equal(t, "mononoke", conf.Namespace)
+
+	// Should throw error when namespace is empty in datadog.yaml network_devices
+	// language=yaml
+	rawInstanceConfig = []byte(`
+ip_address: 1.2.3.4
+community_string: "abc"
+`)
+	rawInitConfig = []byte(``)
+	coreconfig.Datadog.Set("network_devices.namespace", "")
 	conf, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
 	assert.EqualError(t, err, "namespace cannot be empty")
 }

--- a/pkg/collector/corechecks/snmp/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
-	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
 )
 
 func TestConfigurations(t *testing.T) {
@@ -1000,7 +999,9 @@ collect_device_metadata: true
 }
 
 func Test_buildConfig_namespace(t *testing.T) {
-	defer coreconfig.Datadog.Set("network_devices.namespace", "default")
+	// language=yaml
+	rawInitConfig := []byte(`
+namespace: default`)
 
 	// language=yaml
 	rawInstanceConfig := []byte(`
@@ -1008,8 +1009,7 @@ ip_address: 1.2.3.4
 community_string: "abc"
 namespace: my-ns
 `)
-	// language=yaml
-	rawInitConfig := []byte(``)
+
 	conf, err := NewCheckConfig(rawInstanceConfig, rawInitConfig)
 	assert.Nil(t, err)
 	assert.Equal(t, "my-ns", conf.Namespace)
@@ -1028,7 +1028,8 @@ community_string: "abc"
 ip_address: 1.2.3.4
 community_string: "abc"
 `)
-	coreconfig.Datadog.Set("network_devices.namespace", "ns-from-datadog-conf")
+	rawInitConfig = []byte(`
+namespace: ns-from-datadog-conf`)
 	conf, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
 	assert.Nil(t, err)
 	assert.Equal(t, "ns-from-datadog-conf", conf.Namespace)
@@ -1038,7 +1039,8 @@ community_string: "abc"
 ip_address: 1.2.3.4
 community_string: "abc"
 `)
-	coreconfig.Datadog.Set("network_devices.namespace", "")
+	rawInitConfig = []byte(`
+namespace: `)
 	conf, err = NewCheckConfig(rawInstanceConfig, rawInitConfig)
 	assert.EqualError(t, err, "namespace cannot be empty")
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -546,6 +546,7 @@ func InitConfig(config Config) {
 	config.SetKnown("snmp_listener.configs")
 	config.SetKnown("snmp_listener.loader")
 	config.SetKnown("snmp_listener.min_collection_interval")
+	config.SetKnown("snmp_listener.namespace")
 
 	config.BindEnvAndSetDefault("snmp_traps_enabled", false)
 	config.BindEnvAndSetDefault("snmp_traps_config.port", 162)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -721,7 +721,6 @@ func InitConfig(config Config) {
 	bindEnvAndSetLogsConfigKeys(config, "database_monitoring.activity.")
 	bindEnvAndSetLogsConfigKeys(config, "database_monitoring.metrics.")
 	bindEnvAndSetLogsConfigKeys(config, "network_devices.metadata.")
-	config.BindEnvAndSetDefault("network_devices.namespace", "default")
 
 	config.BindEnvAndSetDefault("logs_config.dd_port", 10516)
 	config.BindEnvAndSetDefault("logs_config.dev_mode_use_proto", true)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -721,6 +721,7 @@ func InitConfig(config Config) {
 	bindEnvAndSetLogsConfigKeys(config, "database_monitoring.activity.")
 	bindEnvAndSetLogsConfigKeys(config, "database_monitoring.metrics.")
 	bindEnvAndSetLogsConfigKeys(config, "network_devices.metadata.")
+	config.BindEnvAndSetDefault("network_devices.namespace", "default")
 
 	config.BindEnvAndSetDefault("logs_config.dd_port", 10516)
 	config.BindEnvAndSetDefault("logs_config.dev_mode_use_proto", true)

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -636,6 +636,7 @@ api_key:
   ## @param namespace - string - optional - default: default
   ## Namespace can be used to disambiguate devices with same IPs.
   ## Changing namespace will cause devices being recreated in NDM app.
+  ## Only available using corecheck SNMP integration with `loader: core` config.
   #
   # namespace: default
 
@@ -763,6 +764,7 @@ api_key:
     ## @param namespace - string - optional - default: default
     ## Namespace can be used to disambiguate devices with same IPs.
     ## Changing namespace will cause devices being recreated in NDM app.
+    ## Only available using corecheck SNMP integration with `loader: core` config.
     #
     # namespace: default
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -633,6 +633,12 @@ api_key:
   #
   # min_collection_interval: 15
 
+  ## @param namespace - string - optional - default: default
+  ## Namespace can be used to disambiguate devices with same IPs.
+  ## Changing namespace will cause devices being recreated in NDM app.
+  #
+  # namespace: default
+
   ## @param configs - list - required
   ## The actual list of configurations used to discover SNMP devices in various subnets.
   ## Example:
@@ -753,6 +759,12 @@ api_key:
     ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
     #
     # min_collection_interval: 15
+
+    ## @param namespace - string - optional - default: default
+    ## Namespace can be used to disambiguate devices with same IPs.
+    ## Changing namespace will cause devices being recreated in NDM app.
+    #
+    # namespace: default
 
 {{- if .InternalProfiling -}}
 ## @param profiling - custom object - optional
@@ -2426,17 +2438,6 @@ api_key:
 ###################################
 ## Network Devices Configuration ##
 ###################################
-
-## @param network_devices - custom object - optional
-## Configuration related to Network Devices.
-#
-# network_devices:
-
-  ## @param namespace - string - optional - default: default
-  ## Namespace can be used to disambiguate devices with the same IP.
-  ## Changing namespace will cause devices being recreated in NDM app.
-  #
-  # namespace: default
 
 ## @param snmp_traps_enabled - boolean - optional - default: false
 ## Set to true to enable collection of traps.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1011,3 +1011,18 @@ func TestGetValidHostAliasesWithConfig(t *testing.T) {
 	config := setupConfFromYAML(`host_aliases: ["foo", "-bar"]`)
 	assert.EqualValues(t, getValidHostAliasesWithConfig(config), []string{"foo"})
 }
+
+func TestNetworkDevicesNamespace(t *testing.T) {
+	datadogYaml := `
+network_devices:
+`
+	config := setupConfFromYAML(datadogYaml)
+	assert.Equal(t, "default", config.GetString("network_devices.namespace"))
+
+	datadogYaml = `
+network_devices:
+  namespace: dev
+`
+	config = setupConfFromYAML(datadogYaml)
+	assert.Equal(t, "dev", config.GetString("network_devices.namespace"))
+}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1011,18 +1011,3 @@ func TestGetValidHostAliasesWithConfig(t *testing.T) {
 	config := setupConfFromYAML(`host_aliases: ["foo", "-bar"]`)
 	assert.EqualValues(t, getValidHostAliasesWithConfig(config), []string{"foo"})
 }
-
-func TestNetworkDevicesNamespace(t *testing.T) {
-	datadogYaml := `
-network_devices:
-`
-	config := setupConfFromYAML(datadogYaml)
-	assert.Equal(t, "default", config.GetString("network_devices.namespace"))
-
-	datadogYaml = `
-network_devices:
-  namespace: dev
-`
-	config = setupConfFromYAML(datadogYaml)
-	assert.Equal(t, "dev", config.GetString("network_devices.namespace"))
-}

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -36,6 +36,7 @@ type ListenerConfig struct {
 	Loader                string   `mapstructure:"loader"`
 	CollectDeviceMetadata bool     `mapstructure:"collect_device_metadata"`
 	MinCollectionInterval uint     `mapstructure:"min_collection_interval"`
+	Namespace             string   `mapstructure:"namespace"`
 	Configs               []Config `mapstructure:"configs"`
 
 	// legacy
@@ -98,6 +99,7 @@ func NewListenerConfig() (ListenerConfig, error) {
 	)
 	// Set defaults before unmarshalling
 	snmpConfig.CollectDeviceMetadata = true
+	snmpConfig.Namespace = "default"
 	if err := coreconfig.Datadog.UnmarshalKey("snmp_listener", &snmpConfig, opt); err != nil {
 		return snmpConfig, err
 	}
@@ -128,7 +130,7 @@ func NewListenerConfig() (ListenerConfig, error) {
 			config.Loader = snmpConfig.Loader
 		}
 		if config.Namespace == "" {
-			config.Namespace = coreconfig.Datadog.GetString("network_devices.namespace")
+			config.Namespace = snmpConfig.Namespace
 		}
 		if config.MinCollectionInterval == 0 {
 			config.MinCollectionInterval = snmpConfig.MinCollectionInterval

--- a/pkg/snmp/snmp_test.go
+++ b/pkg/snmp/snmp_test.go
@@ -281,15 +281,19 @@ snmp_listener:
 	// Custom Namespace
 	config.Datadog.SetConfigType("yaml")
 	err = config.Datadog.ReadConfig(strings.NewReader(`
+network_devices:
+  namespace: totoro
 snmp_listener:
   configs:
-   - community_string: someCommunityString
-     network_address: 127.1.0.0/30
-     namespace: hello
+  - community_string: someCommunityString
+    network_address: 127.1.0.0/30
+  - community_string: someCommunityString
+    network_address: 127.2.0.0/30
+    namespace: mononoke
 `))
 	assert.NoError(t, err)
 	conf, err = NewListenerConfig()
 	assert.NoError(t, err)
-	networkConf = conf.Configs[0]
-	assert.Equal(t, "hello", networkConf.Namespace)
+	assert.Equal(t, "totoro", conf.Configs[0].Namespace)
+	assert.Equal(t, "mononoke", conf.Configs[1].Namespace)
 }

--- a/pkg/snmp/snmp_test.go
+++ b/pkg/snmp/snmp_test.go
@@ -281,9 +281,8 @@ snmp_listener:
 	// Custom Namespace
 	config.Datadog.SetConfigType("yaml")
 	err = config.Datadog.ReadConfig(strings.NewReader(`
-network_devices:
-  namespace: totoro
 snmp_listener:
+  namespace: totoro
   configs:
   - community_string: someCommunityString
     network_address: 127.1.0.0/30

--- a/pkg/snmp/snmp_test.go
+++ b/pkg/snmp/snmp_test.go
@@ -278,7 +278,23 @@ snmp_listener:
 	networkConf := conf.Configs[0]
 	assert.Equal(t, "default", networkConf.Namespace)
 
-	// Custom Namespace
+	// Custom Namespace in network_devices
+	config.Datadog.SetConfigType("yaml")
+	err = config.Datadog.ReadConfig(strings.NewReader(`
+network_devices:
+  namespace: ponyo
+snmp_listener:
+  configs:
+  - community_string: someCommunityString
+    network_address: 127.1.0.0/30
+`))
+	assert.NoError(t, err)
+	conf, err = NewListenerConfig()
+	assert.NoError(t, err)
+	networkConf = conf.Configs[0]
+	assert.Equal(t, "ponyo", networkConf.Namespace)
+
+	// Custom Namespace in snmp_listener
 	config.Datadog.SetConfigType("yaml")
 	err = config.Datadog.ReadConfig(strings.NewReader(`
 snmp_listener:
@@ -295,4 +311,13 @@ snmp_listener:
 	assert.NoError(t, err)
 	assert.Equal(t, "totoro", conf.Configs[0].Namespace)
 	assert.Equal(t, "mononoke", conf.Configs[1].Namespace)
+}
+
+func TestFirstNonEmpty(t *testing.T) {
+	assert.Equal(t, firstNonEmpty(), "")
+	assert.Equal(t, firstNonEmpty("totoro"), "totoro")
+	assert.Equal(t, firstNonEmpty("", "mononoke"), "mononoke")
+	assert.Equal(t, firstNonEmpty("", "mononoke", "ponyo"), "mononoke")
+	assert.Equal(t, firstNonEmpty("", "", "ponyo"), "ponyo")
+	assert.Equal(t, firstNonEmpty("", "", ""), "")
 }

--- a/releasenotes/notes/add-namespace-doc-949433c626520762.yaml
+++ b/releasenotes/notes/add-namespace-doc-949433c626520762.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - Add `namespace` to snmp listener config
+  - Remove `network_devices` from `datadog.yaml` configuration


### PR DESCRIPTION
### What does this PR do?

Add `namespace` documentation in `snmp_listener` config template. Remove `network_devices.namespace` to avoid having an additional level of configuration in `snmp` (`snmp_listener`, `snmp_listener.configs[x]`, check.initConfig, check.instanceConfig)

### Motivation

Documenting `namespace` that avoids ambiguity between devices with the same IP within the same organisation 

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
