### PR TITLE
Give some time to the DSDListeningTest container to listen

### DIFF
--- a/test/integration/docker/dsd_listening.py
+++ b/test/integration/docker/dsd_listening.py
@@ -1,4 +1,5 @@
 import os
+import time
 import unittest
 
 import docker
@@ -50,6 +51,7 @@ def waitUntilListening(container, retries=20):
         out = container.exec_run(cmd="netstat -a").output
         if b":8125" in out or SOCKET_PATH in out:
             return True
+        time.sleep(0.5)
     return False
 
 


### PR DESCRIPTION
### What does this PR do?

The function waitUntilListening tries to run netstat a few times but does not
wait between each run.

### Motivation

The DSDListeningTest is failing on CI

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
