### PR TITLE
Send process discovery payloads to its own endpoint

### DIFF
--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -426,6 +426,8 @@ func (l *Collector) consumePayloads(results *api.WeightedQueue, fwd forwarder.Fo
 				updateRTStatus = false
 				responses, err = fwd.SubmitOrchestratorChecks(forwarderPayload, payload.headers, int(orchestrator.K8sPod))
 			case checks.ProcessDiscovery.Name():
+				// A Process Discovery check does not change the RT mode
+				updateRTStatus = false
 				responses, err = fwd.SubmitProcessDiscoveryChecks(forwarderPayload, payload.headers)
 			default:
 				err = fmt.Errorf("unsupported payload type: %s", result.name)

--- a/pkg/forwarder/telemetry.go
+++ b/pkg/forwarder/telemetry.go
@@ -31,7 +31,7 @@ var (
 	metadataEndpoint      = transaction.Endpoint{Route: "/api/v2/metadata", Name: "metadata_v2"}
 
 	processesEndpoint        = transaction.Endpoint{Route: "/api/v1/collector", Name: "process"}
-	processDiscoveryEndpoint = transaction.Endpoint{Route: "/api/v1/collector", Name: "process_discovery"}
+	processDiscoveryEndpoint = transaction.Endpoint{Route: "/api/v1/discovery", Name: "process_discovery"}
 	rtProcessesEndpoint      = transaction.Endpoint{Route: "/api/v1/collector", Name: "rtprocess"}
 	containerEndpoint        = transaction.Endpoint{Route: "/api/v1/container", Name: "container"}
 	rtContainerEndpoint      = transaction.Endpoint{Route: "/api/v1/container", Name: "rtcontainer"}


### PR DESCRIPTION
### What does this PR do?

This updates the endpoint where we send process-discovery messages to.

### Motivation

Utilize the URL path to disambiguate between messages types.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

- Enable the process discovery check
Set the following in the datadog.yaml
```
process_config:
  enabled: false
  process_discovery:
    enabled: true
```
- Validate the checks run and they are sending the discovery payloads to `/api/v1/discovery`
  - Check the logs to see if the `process_discovery` check is enable:
     `2021-09-30 16:44:51 UTC | PROCESS | INFO | (collector.go:218 in run) | Starting process-agent for host=william-yu-test, endpoints=[https://process.datad0g.com], orchestrator endpoints=[https://orchestrator.datad0g.com], enabled checks=[container rtcontainer process_discovery]`
  - Verify the check runs 
    `2021-09-30 16:44:51 UTC | PROCESS | INFO | (collector.go:152 in logCheckDuration) | Finished process_disco
very check #1 in 5.151762ms`
   - Check for any other log output for discovery checks and it's function
   
### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
