### PR TITLE
Reporting number of traces using any priorities between -10 and 10 including PriorityRuleSampler priorities (3,-3)

### DIFF
--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -258,11 +258,12 @@ func TestProcess(t *testing.T) {
 			})
 		}
 
+		samplingPriorityTagValues := want.TracesPerSamplingPriority.TagValues()
 		assert.EqualValues(t, 1, want.TracesPriorityNone)
-		assert.EqualValues(t, 2, want.TracesPriorityNeg)
-		assert.EqualValues(t, 3, want.TracesPriority0)
-		assert.EqualValues(t, 4, want.TracesPriority1)
-		assert.EqualValues(t, 5, want.TracesPriority2)
+		assert.EqualValues(t, 2, samplingPriorityTagValues["-1"])
+		assert.EqualValues(t, 3, samplingPriorityTagValues["0"])
+		assert.EqualValues(t, 4, samplingPriorityTagValues["1"])
+		assert.EqualValues(t, 5, samplingPriorityTagValues["2"])
 	})
 
 	t.Run("GlobalTags", func(t *testing.T) {

--- a/releasenotes/notes/apm-sampling-priority-stats-extension-68de07f56a23e7f9.yaml
+++ b/releasenotes/notes/apm-sampling-priority-stats-extension-68de07f56a23e7f9.yaml
@@ -1,0 +1,7 @@
+---
+enhancements:
+  - |
+    Now we report counts of how many traces per priority we receive for all priority codes between -10 and 10.
+fixes:
+  - |
+    Count of traces with priority 2 (PriorityUserKeep) were not being updated correctly.


### PR DESCRIPTION
This commit adds counts for the number of traces received with any priorities between -10 and 10 using the metric datadog.trace_agent.receiver.traces_priority

### Motivation
Previously, only priorities between -1 and 2 would be reported, however we have recently introduced PriorityRuleSamplerKeep(3) and PriorityRuleSamplerReject(-3) and we plan to introduce new priority codes for various upcoming features. 

### What does this PR do?
The code changes on this PR make the tracing sampling priority count stats more flexible, allowing to handle more priorities codes without further changes.

### Additional Notes
    - There is a bit less code repetition, preventing the derived defects, for example, previously priority 2 stats were not being updated in the update() function.
    - Priority counts are not sent when they have value 0, which is OK for this particular metric and reduces the footprint of these stats

### Describe how to test your changes
I tested via unit tests and setting up a local go application with tracing, then checking that the traces are correctly received and statistics reported by the agent

### Checklist
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
