### PR TITLE
pkg/trace/info: reporting number of traces using any priorities between -10 and 10 including PriorityRuleSampler priorities (3,-3)

### DIFF
--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -258,11 +258,12 @@ func TestProcess(t *testing.T) {
 			})
 		}
 
+		samplingPriorityTagValues := want.TracesPerSamplingPriority.TagValues()
 		assert.EqualValues(t, 1, want.TracesPriorityNone)
-		assert.EqualValues(t, 2, want.TracesPriorityNeg)
-		assert.EqualValues(t, 3, want.TracesPriority0)
-		assert.EqualValues(t, 4, want.TracesPriority1)
-		assert.EqualValues(t, 5, want.TracesPriority2)
+		assert.EqualValues(t, 2, samplingPriorityTagValues["-1"])
+		assert.EqualValues(t, 3, samplingPriorityTagValues["0"])
+		assert.EqualValues(t, 4, samplingPriorityTagValues["1"])
+		assert.EqualValues(t, 5, samplingPriorityTagValues["2"])
 	})
 
 	t.Run("GlobalTags", func(t *testing.T) {

--- a/pkg/trace/info/stats.go
+++ b/pkg/trace/info/stats.go
@@ -8,9 +8,12 @@ package info
 import (
 	"fmt"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -134,10 +137,6 @@ func (ts *TagStats) publish() {
 	tracesReceived := atomic.LoadInt64(&ts.TracesReceived)
 	tracesFiltered := atomic.LoadInt64(&ts.TracesFiltered)
 	tracesPriorityNone := atomic.LoadInt64(&ts.TracesPriorityNone)
-	tracesPriorityNeg := atomic.LoadInt64(&ts.TracesPriorityNeg)
-	tracesPriority0 := atomic.LoadInt64(&ts.TracesPriority0)
-	tracesPriority1 := atomic.LoadInt64(&ts.TracesPriority1)
-	tracesPriority2 := atomic.LoadInt64(&ts.TracesPriority2)
 	clientDroppedP0Spans := atomic.LoadInt64(&ts.ClientDroppedP0Spans)
 	clientDroppedP0Traces := atomic.LoadInt64(&ts.ClientDroppedP0Traces)
 	tracesBytes := atomic.LoadInt64(&ts.TracesBytes)
@@ -156,10 +155,6 @@ func (ts *TagStats) publish() {
 	metrics.Count("datadog.trace_agent.receiver.traces_received", tracesReceived, tags, 1)
 	metrics.Count("datadog.trace_agent.receiver.traces_filtered", tracesFiltered, tags, 1)
 	metrics.Count("datadog.trace_agent.receiver.traces_priority", tracesPriorityNone, append(tags, "priority:none"), 1)
-	metrics.Count("datadog.trace_agent.receiver.traces_priority", tracesPriorityNeg, append(tags, "priority:neg"), 1)
-	metrics.Count("datadog.trace_agent.receiver.traces_priority", tracesPriority0, append(tags, "priority:0"), 1)
-	metrics.Count("datadog.trace_agent.receiver.traces_priority", tracesPriority1, append(tags, "priority:1"), 1)
-	metrics.Count("datadog.trace_agent.receiver.traces_priority", tracesPriority2, append(tags, "priority:2"), 1)
 	metrics.Count("datadog.trace_agent.receiver.traces_bytes", tracesBytes, tags, 1)
 	metrics.Count("datadog.trace_agent.receiver.spans_received", spansReceived, tags, 1)
 	metrics.Count("datadog.trace_agent.receiver.spans_dropped", spansDropped, tags, 1)
@@ -176,6 +171,9 @@ func (ts *TagStats) publish() {
 	}
 	for reason, count := range ts.SpansMalformed.tagValues() {
 		metrics.Count("datadog.trace_agent.normalizer.spans_malformed", count, append(tags, "reason:"+reason), 1)
+	}
+	for priority, count := range ts.TracesPerSamplingPriority.TagValues() {
+		metrics.Count("datadog.trace_agent.receiver.traces_priority", count, append(tags, "priority:"+priority), 1)
 	}
 }
 
@@ -288,6 +286,50 @@ func (s *SpansMalformed) String() string {
 	return mapToString(s.tagValues())
 }
 
+// maxAbsPriority specifies the absolute maximum priority for stats purposes. For example, with a value
+// of 10, the range of priorities reported will be [-10, 10].
+const maxAbsPriority = 10
+
+// samplingPriorityStats holds the sampling priority metrics that will be reported every 10s by the agent.
+type samplingPriorityStats struct {
+	// counts holds counters for each priority in position maxAbsPriorityValue + priority.
+	// Priority values are expected to be in the range [-10, 10].
+	counts [maxAbsPriority*2 + 1]int64
+}
+
+// CountSamplingPriority increments the counter of observed traces with the given sampling priority by 1
+func (s *samplingPriorityStats) CountSamplingPriority(p sampler.SamplingPriority) {
+	if p >= (-1*maxAbsPriority) && p <= maxAbsPriority {
+		atomic.AddInt64(&s.counts[maxAbsPriority+p], 1)
+	}
+}
+
+// reset sets stats to 0
+func (s *samplingPriorityStats) reset() {
+	for i := range s.counts {
+		atomic.StoreInt64(&s.counts[i], 0)
+	}
+}
+
+// update absorbs recent stats on top of existing ones.
+func (s *samplingPriorityStats) update(recent *samplingPriorityStats) {
+	for i := range s.counts {
+		atomic.AddInt64(&s.counts[i], atomic.LoadInt64(&recent.counts[i]))
+	}
+}
+
+// TagValues returns a map with the number of traces that have been observed for each priority tag
+func (s *samplingPriorityStats) TagValues() map[string]int64 {
+	stats := make(map[string]int64)
+	for i := range s.counts {
+		count := atomic.LoadInt64(&s.counts[i])
+		if count > 0 {
+			stats[strconv.Itoa(i-maxAbsPriority)] = count
+		}
+	}
+	return stats
+}
+
 // Stats holds the metrics that will be reported every 10s by the agent.
 // Its fields require to be accessed in an atomic way.
 type Stats struct {
@@ -301,14 +343,8 @@ type Stats struct {
 	TracesFiltered int64
 	// TracesPriorityNone is the number of traces with no sampling priority.
 	TracesPriorityNone int64
-	// TracesPriorityNeg is the number of traces with a negative sampling priority.
-	TracesPriorityNeg int64
-	// TracesPriority0 is the number of traces with sampling priority set to zero.
-	TracesPriority0 int64
-	// TracesPriority1 is the number of traces with sampling priority automatically set to 1.
-	TracesPriority1 int64
-	// TracesPriority2 is the number of traces with sampling priority manually set to 2 or more.
-	TracesPriority2 int64
+	// TracesPerPriority holds counters for each priority in position MaxAbsPriorityValue + priority.
+	TracesPerSamplingPriority samplingPriorityStats
 	// ClientDroppedP0Traces number of P0 traces dropped by client.
 	ClientDroppedP0Traces int64
 	// ClientDroppedP0Spans number of P0 spans dropped by client.
@@ -333,7 +369,6 @@ type Stats struct {
 
 func (s *Stats) update(recent *Stats) {
 	atomic.AddInt64(&s.TracesReceived, atomic.LoadInt64(&recent.TracesReceived))
-
 	atomic.AddInt64(&s.TracesDropped.DecodingError, atomic.LoadInt64(&recent.TracesDropped.DecodingError))
 	atomic.AddInt64(&s.TracesDropped.EmptyTrace, atomic.LoadInt64(&recent.TracesDropped.EmptyTrace))
 	atomic.AddInt64(&s.TracesDropped.TraceIDZero, atomic.LoadInt64(&recent.TracesDropped.TraceIDZero))
@@ -351,12 +386,7 @@ func (s *Stats) update(recent *Stats) {
 	atomic.AddInt64(&s.SpansMalformed.InvalidStartDate, atomic.LoadInt64(&recent.SpansMalformed.InvalidStartDate))
 	atomic.AddInt64(&s.SpansMalformed.InvalidDuration, atomic.LoadInt64(&recent.SpansMalformed.InvalidDuration))
 	atomic.AddInt64(&s.SpansMalformed.InvalidHTTPStatusCode, atomic.LoadInt64(&recent.SpansMalformed.InvalidHTTPStatusCode))
-
 	atomic.AddInt64(&s.TracesFiltered, atomic.LoadInt64(&recent.TracesFiltered))
-	atomic.AddInt64(&s.TracesPriorityNone, atomic.LoadInt64(&recent.TracesPriorityNone))
-	atomic.AddInt64(&s.TracesPriorityNeg, atomic.LoadInt64(&recent.TracesPriorityNeg))
-	atomic.AddInt64(&s.TracesPriority0, atomic.LoadInt64(&recent.TracesPriority0))
-	atomic.AddInt64(&s.TracesPriority1, atomic.LoadInt64(&recent.TracesPriority1))
 	atomic.AddInt64(&s.ClientDroppedP0Traces, atomic.LoadInt64(&recent.ClientDroppedP0Traces))
 	atomic.AddInt64(&s.ClientDroppedP0Spans, atomic.LoadInt64(&recent.ClientDroppedP0Spans))
 	atomic.AddInt64(&s.TracesBytes, atomic.LoadInt64(&recent.TracesBytes))
@@ -367,6 +397,7 @@ func (s *Stats) update(recent *Stats) {
 	atomic.AddInt64(&s.EventsSampled, atomic.LoadInt64(&recent.EventsSampled))
 	atomic.AddInt64(&s.PayloadAccepted, atomic.LoadInt64(&recent.PayloadAccepted))
 	atomic.AddInt64(&s.PayloadRefused, atomic.LoadInt64(&recent.PayloadRefused))
+	s.TracesPerSamplingPriority.update(&recent.TracesPerSamplingPriority)
 }
 
 func (s *Stats) reset() {
@@ -393,10 +424,6 @@ func (s *Stats) reset() {
 	atomic.StoreInt64(&s.SpansMalformed.InvalidHTTPStatusCode, 0)
 	atomic.StoreInt64(&s.TracesFiltered, 0)
 	atomic.StoreInt64(&s.TracesPriorityNone, 0)
-	atomic.StoreInt64(&s.TracesPriorityNeg, 0)
-	atomic.StoreInt64(&s.TracesPriority0, 0)
-	atomic.StoreInt64(&s.TracesPriority1, 0)
-	atomic.StoreInt64(&s.TracesPriority2, 0)
 	atomic.StoreInt64(&s.ClientDroppedP0Traces, 0)
 	atomic.StoreInt64(&s.ClientDroppedP0Spans, 0)
 	atomic.StoreInt64(&s.TracesBytes, 0)
@@ -407,6 +434,7 @@ func (s *Stats) reset() {
 	atomic.StoreInt64(&s.EventsSampled, 0)
 	atomic.StoreInt64(&s.PayloadAccepted, 0)
 	atomic.StoreInt64(&s.PayloadRefused, 0)
+	s.TracesPerSamplingPriority.reset()
 }
 
 func (s *Stats) isEmpty() bool {


### PR DESCRIPTION
This commit adds counts for the number of traces received with any priorities between -10 and 10 using the metric datadog.trace_agent.receiver.traces_priority

### Motivation
Previously, only priorities between -1 and 2 would be reported, however we have recently introduced PriorityRuleSamplerKeep(3) and PriorityRuleSamplerReject(-3) and we plan to introduce new priority codes for various upcoming features. 

### What does this PR do?
The code changes on this PR make the tracing sampling priority count stats more flexible, allowing to handle more priorities codes without further changes.

### Additional Notes
    - There is a bit less code repetition, preventing the derived defects, for example, previously priority 2 stats were not being updated in the update() function.
    - Priority counts are not sent when they have value 0, which is OK for this particular metric and reduces the footprint of these stats

### Describe how to test your changes
I tested via unit tests and setting up a local go application with tracing, then checking that the traces are correctly received and statistics reported by the agent

### Checklist
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
