### PR TITLE
[gitlab] Install all cached wheels in one pip install invocation

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -287,11 +287,41 @@ build do
         "--integrations #{checks_to_install.join(',')} " \
         "--awscli #{awscli}",
         :cwd => tasks_dir_in
+
+      # install all wheels from cache in one pip invocation to speed things up
+      if windows?
+        command "#{python} -m pip install --no-deps --no-index -r #{windows_safe_path(cached_wheels_dir)}\\found.txt"
+      else
+        command "#{pip} install --no-deps --no-index -r #{cached_wheels_dir}/found.txt"
+      end
     end
 
     block do
       # we have to do this operation in block, so that it can access files created by the
       # inv agent.get-integrations-from-cache command
+
+      # get list of integration wheels already installed from cache
+      installed_list = Array.new
+      if cache_bucket != ''
+        if windows?
+          installed_out = `#{python} -m pip list --format json`
+        else
+          installed_out = `#{pip} list --format json`
+        end
+        if $?.exitstatus == 0
+          installed = JSON.parse(installed_out)
+          installed.each do |package|
+            package.each do |key, value|
+              if key == "name" && value.start_with?("datadog-")
+                installed_list.push(value["datadog-".length..-1])
+              end
+            end
+          end
+        else
+          raise "Failed to list pip installed packages"
+        end
+      end
+
       checks_to_install.each do |check|
         check_dir = File.join(project_dir, check)
         check_conf_dir = "#{conf_dir}/#{check}.d"
@@ -332,13 +362,11 @@ build do
           copy profiles, "#{check_conf_dir}/"
         end
 
-        cached_wheel_glob = Dir.glob(File.join(cached_wheels_dir.gsub("\\", "/"), "datadog_#{check}-*.whl"))
-        if cached_wheel_glob.length == 1
-          wheel_path = windows_safe_path(cached_wheel_glob[0])
-          command "#{pip} install --no-deps --no-index #{wheel_path}"
+        # pip < 21.2 replace underscores by dashes in package names per https://pip.pypa.io/en/stable/news/#v21-2
+        # whether or not this might switch back in the future is not guaranteed, so we check for both name
+        # with dashes and underscores
+        if installed_list.include?(check) || installed_list.include?(check.gsub('_', '-'))
           next
-        elsif cached_wheel_glob.length > 1
-            raise "Found multiple wheels for #{check}: #{cached_wheel_glob}"
         end
 
         if windows?

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -316,8 +316,8 @@ build do
           installed = JSON.parse(installed_out)
           installed.each do |package|
             package.each do |key, value|
-              if key == "name" && value.start_with?("datadog_")
-                installed_list.push(value["datadog_".length..-1])
+              if key == "name" && value.start_with?("datadog-")
+                installed_list.push(value["datadog-".length..-1])
               end
             end
           end

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -290,11 +290,41 @@ build do
         "--integrations #{checks_to_install.join(',')} " \
         "--awscli #{awscli}",
         :cwd => tasks_dir_in
+
+      # install all wheels from cache in one pip invocation to speed things up
+      if windows?
+        command "#{python} -m pip install --no-deps --no-index -r #{windows_safe_path(target_dir)}\\found.txt"
+      else
+        command "#{pip} install --no-deps --no-index -r #{target_dir}/found.txt"
+      end
     end
 
     block do
       # we have to do this operation in block, so that it can access files created by the
       # inv agent.get-integrations-from-cache command
+
+      # get list of integration wheels already installed from cache
+      installed_list = Array.new
+      if cache_bucket != ''
+        if windows?
+          installed_out = `#{python} -m pip list --format json`
+        else
+          installed_out = `#{pip} list --format json`
+        end
+        if $?.exitstatus == 0
+          installed = JSON.parse(installed_out)
+          installed.each do |package|
+            package.each do |key, value|
+              if key == "name" && value.start_with?("datadog_")
+                installed_list.push(value["datadog_".length..-1])
+              end
+            end
+          end
+        else
+          raise "Failed to list pip installed packages"
+        end
+      end
+
       checks_to_install.each do |check|
         check_dir = File.join(project_dir, check)
         check_conf_dir = "#{conf_dir}/#{check}.d"
@@ -335,13 +365,8 @@ build do
           copy profiles, "#{check_conf_dir}/"
         end
 
-        cached_wheel_glob = Dir.glob(File.join(cached_wheels_dir.gsub("\\", "/"), "datadog_#{check}-*.whl"))
-        if cached_wheel_glob.length == 1
-          wheel_path = windows_safe_path(cached_wheel_glob[0])
-          command "#{pip} install --no-deps --no-index #{wheel_path}"
+        if installed_list.include? check
           next
-        elsif cached_wheel_glob.length > 1
-            raise "Found multiple wheels for #{check}: #{cached_wheel_glob}"
         end
 
         if windows?

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -293,9 +293,9 @@ build do
 
       # install all wheels from cache in one pip invocation to speed things up
       if windows?
-        command "#{python} -m pip install --no-deps --no-index -r #{windows_safe_path(target_dir)}\\found.txt"
+        command "#{python} -m pip install --no-deps --no-index -r #{windows_safe_path(cached_wheels_dir)}\\found.txt"
       else
-        command "#{pip} install --no-deps --no-index -r #{target_dir}/found.txt"
+        command "#{pip} install --no-deps --no-index -r #{cached_wheels_dir}/found.txt"
       end
     end
 

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -366,7 +366,10 @@ build do
           copy profiles, "#{check_conf_dir}/"
         end
 
-        if installed_list.include? check
+        # pip < 21.2 replace underscores by dashes in package names per https://pip.pypa.io/en/stable/news/#v21-2
+        # whether or not this might switch back in the future is not guaranteed, so we check for both name
+        # with dashes and underscores
+        if installed_list.include?(check) || installed_list.include?(check.gsub('_', '-'))
           next
         end
 

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -304,7 +304,6 @@ build do
       # inv agent.get-integrations-from-cache command
 
       # get list of integration wheels already installed from cache
-      puts File.readlines("#{cached_wheels_dir}/found.txt")
       installed_list = Array.new
       if cache_bucket != ''
         if windows?

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -304,6 +304,7 @@ build do
       # inv agent.get-integrations-from-cache command
 
       # get list of integration wheels already installed from cache
+      puts File.readlines("#{cached_wheels_dir}/found.txt")
       installed_list = Array.new
       if cache_bucket != ''
         if windows?

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -737,7 +737,7 @@ def get_integrations_from_cache(ctx, python, bucket, integrations_dir, target_di
     for sync_command in sync_commands:
         ctx.run("".join(sync_command[0]))
 
-    found = 0
+    found = []
     # move all wheel files directly to the target_dir, so they're easy to find/work with in Omnibus
     for integration in sorted(integrations_hashes):
         hash = integrations_hashes[integration]
@@ -757,9 +757,11 @@ def get_integrations_from_cache(ctx, python, bucket, integrations_dir, target_di
         wheel_path = files_matched[0]
         print("Found cached wheel for integration {}".format(integration))
         shutil.move(wheel_path, target_dir)
-        found += 1
+        found.append(wheel_path)
 
-    print("Found {} cached integration wheels".format(found))
+    print("Found {} cached integration wheels".format(len(found)))
+    with open(os.path.join(target_dir, "found.txt"), "w") as f:
+        f.write('\n'.join(found))
 
 
 @task

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -757,7 +757,7 @@ def get_integrations_from_cache(ctx, python, bucket, integrations_dir, target_di
         wheel_path = files_matched[0]
         print("Found cached wheel for integration {}".format(integration))
         shutil.move(wheel_path, target_dir)
-        found.append(wheel_path)
+        found.append(os.path.join(target_dir, os.path.basename(wheel_path)))
 
     print("Found {} cached integration wheels".format(len(found)))
     with open(os.path.join(target_dir, "found.txt"), "w") as f:


### PR DESCRIPTION
### What does this PR do?

This PR makes the omnibus integration build scripts install all cached integrations in one go, making them much faster (by my measurements, this saves ~0.5 second per integration, so around 1.5 minutes with the current number of integrations).

### Motivation

Speeding up the `package_build` stage.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
