### PR TITLE
[tagger] Enable remote tagger by default

### DIFF
--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -33,6 +33,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+
+	// register all workloadmeta collectors
+	_ "github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors"
 )
 
 var (
@@ -205,6 +209,9 @@ func runAgent(ctx context.Context) (err error) {
 
 	// container tagging initialisation if origin detection is on
 	if config.Datadog.GetBool("dogstatsd_origin_detection") {
+		// Start workload metadata store before tagger
+		workloadmeta.GetGlobalStore().Start(context.Background())
+
 		tagger.SetDefaultTagger(local.NewTagger(collectors.DefaultCatalog))
 		tagger.Init()
 	}

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -198,14 +198,14 @@ func runAgent(exit chan struct{}) {
 	log.Infof("running on platform: %s", hostInfo.Platform)
 	log.Infof("running version: %s", versionString(", "))
 
-	// Start workload metadata store before tagger
-	workloadmeta.GetGlobalStore().Start(context.Background())
-
 	// Tagger must be initialized after agent config has been setup
 	var t tagger.Tagger
 	if ddconfig.Datadog.GetBool("process_config.remote_tagger") {
 		t = remote.NewTagger()
 	} else {
+		// Start workload metadata store before tagger
+		workloadmeta.GetGlobalStore().Start(context.Background())
+
 		t = local.NewTagger(collectors.DefaultCatalog)
 	}
 	tagger.SetDefaultTagger(t)

--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -56,7 +56,7 @@ func setupAPM(config Config) {
 	config.BindEnvAndSetDefault("apm_config.receiver_port", 8126, "DD_APM_RECEIVER_PORT", "DD_RECEIVER_PORT")
 	config.BindEnvAndSetDefault("apm_config.windows_pipe_buffer_size", 1_000_000, "DD_APM_WINDOWS_PIPE_BUFFER_SIZE")                          //nolint:errcheck
 	config.BindEnvAndSetDefault("apm_config.windows_pipe_security_descriptor", "D:AI(A;;GA;;;WD)", "DD_APM_WINDOWS_PIPE_SECURITY_DESCRIPTOR") //nolint:errcheck
-	config.BindEnvAndSetDefault("apm_config.remote_tagger", false, "DD_APM_REMOTE_TAGGER")                                                    //nolint:errcheck
+	config.BindEnvAndSetDefault("apm_config.remote_tagger", true, "DD_APM_REMOTE_TAGGER")                                                     //nolint:errcheck
 
 	config.BindEnv("apm_config.max_catalog_services", "DD_APM_MAX_CATALOG_SERVICES")
 	config.BindEnv("apm_config.receiver_timeout", "DD_APM_RECEIVER_TIMEOUT")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -877,7 +877,8 @@ func InitConfig(config Config) {
 	config.SetKnown("process_config.expvar_port")
 	config.SetKnown("process_config.log_file")
 	config.SetKnown("process_config.internal_profiling.enabled")
-	config.SetKnown("process_config.remote_tagger")
+
+	config.BindEnvAndSetDefault("process_config.remote_tagger", true)
 
 	// Process Discovery Check
 	config.BindEnvAndSetDefault("process_config.process_discovery.enabled", false)
@@ -895,7 +896,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("security_agent.cmd_port", 5010)
 	config.BindEnvAndSetDefault("security_agent.expvar_port", 5011)
 	config.BindEnvAndSetDefault("security_agent.log_file", defaultSecurityAgentLogFile)
-	config.BindEnvAndSetDefault("security_agent.remote_tagger", false)
+	config.BindEnvAndSetDefault("security_agent.remote_tagger", true)
 
 	// Datadog security agent (compliance)
 	config.BindEnvAndSetDefault("compliance_config.enabled", false)

--- a/pkg/trace/agent/run.go
+++ b/pkg/trace/agent/run.go
@@ -145,13 +145,13 @@ func Run(ctx context.Context) {
 
 	rand.Seed(time.Now().UTC().UnixNano())
 
-	// Start workload metadata store before tagger
-	workloadmeta.GetGlobalStore().Start(context.Background())
-
 	var t tagger.Tagger
 	if coreconfig.Datadog.GetBool("apm_config.remote_tagger") {
 		t = remote.NewTagger()
 	} else {
+		// Start workload metadata store before tagger
+		workloadmeta.GetGlobalStore().Start(context.Background())
+
 		t = local.NewTagger(collectors.DefaultCatalog)
 	}
 	tagger.SetDefaultTagger(t)

--- a/pkg/trace/test/agent.go
+++ b/pkg/trace/test/agent.go
@@ -173,6 +173,10 @@ func (s *agentRunner) createConfigFile(conf []byte) (string, error) {
 		v.Set("apm_config.trace_writer.flush_period_seconds", 0.1)
 	}
 	v.Set("log_level", "debug")
+
+	// disable remote tagger to avoid running a core agent for testing
+	v.Set("apm_config.remote_tagger", false)
+
 	out, err := yaml.Marshal(v.AllSettings())
 	if err != nil {
 		return "", err

--- a/pkg/trace/test/testsuite/secrets_test.go
+++ b/pkg/trace/test/testsuite/secrets_test.go
@@ -58,6 +58,7 @@ func TestSecrets(t *testing.T) {
 		"DD_SECRET_BACKEND_COMMAND=" + binSecrets,
 		"DD_HOSTNAME=ENC[secret1]",
 		"DD_API_KEY=123",
+		"DD_APM_REMOTE_TAGGER=false",
 	}
 	cmd.Stdout = &buf
 	cmd.Stderr = &buf

--- a/releasenotes/notes/remote-tagger-by-default-6ccbe955041871ec.yaml
+++ b/releasenotes/notes/remote-tagger-by-default-6ccbe955041871ec.yaml
@@ -1,0 +1,10 @@
+---
+enhancements:
+  - |
+    The Process, APM, and Security agent now use the remote tagger introduced
+    in Agent 7.26 by default. To disable it in the respective agent, the following
+    settings need to be set to `false`:
+
+    - apm_config.remote_tagger
+    - process_config.remote_tagger
+    - security_agent.remote_tagger


### PR DESCRIPTION
### What does this PR do?

This enables the remote tagger by default. It was introduced several versions ago, but after remaining issues that prevented us from using it in some AWS environments have been addressed (#9294, #9312) we can finally enable this.

### Describe how to test your changes

* Test that the remote tagger is actually enabled in process, trace, and security agent.
* Check that tagging still works for those agents. This is especially important for environments in which the remote tagger is new: ECS EC2 and ECS Fargate.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
