### PR TITLE
[ksm core] Remove the `reason` tag from the `.job.failed` metric

### DIFF
--- a/releasenotes/notes/remove-reason-from-kubernetes_state.job.failed-ed68ab9bb7700630.yaml
+++ b/releasenotes/notes/remove-reason-from-kubernetes_state.job.failed-ed68ab9bb7700630.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Remove the `reason` tag from the `kubernetes_state.job.failed` metric to reduce cardinality


### PR DESCRIPTION
### What does this PR do?

Kubernetes state core check: Remove the `reason` tag from the `kubernetes_state.job.failed` metric.

### Motivation

Limit the cardinality

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Spawn a job that fails.
Check that, with the previous agent version, there was one `kubernetes_state.job.failed` metric per possible reason.
With the new version, there should be only one metric per job. And the `reason` tag should have been removed.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [X] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [X] The appropriate `team/..` label has been applied, if known.
- [X] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [X] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
