### PR TITLE
[cri] Simplify CRIUtil test using strings.TrimPrefix

### DIFF
--- a/pkg/util/containers/cri/util_test.go
+++ b/pkg/util/containers/cri/util_test.go
@@ -9,6 +9,7 @@ package cri
 
 import (
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -20,7 +21,7 @@ import (
 func TestCRIUtilInit(t *testing.T) {
 	fakeRuntime, endpoint := createAndStartFakeRemoteRuntime(t)
 	defer fakeRuntime.Stop()
-	socketFile := endpoint[7:] // remove unix://
+	socketFile := strings.TrimPrefix(endpoint, "unix://")
 	fileInfo, err := os.Stat(socketFile)
 	require.NoError(t, err)
 	assert.Equal(t, fileInfo.Mode()&os.ModeSocket, os.ModeSocket)
@@ -38,7 +39,7 @@ func TestCRIUtilInit(t *testing.T) {
 func TestCRIUtilListContainerStats(t *testing.T) {
 	fakeRuntime, endpoint := createAndStartFakeRemoteRuntime(t)
 	defer fakeRuntime.Stop()
-	socketFile := endpoint[7:] // remove unix://
+	socketFile := strings.TrimPrefix(endpoint, "unix://")
 	util := &CRIUtil{
 		queryTimeout:      1 * time.Second,
 		connectionTimeout: 1 * time.Second,


### PR DESCRIPTION
### What does this PR do?

Simplifies a test in `pkg/util/containers/cri/util_test.go`.

### Describe how to test your changes

Skip.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
