### PR TITLE
[CWS] fix kitchen functional tests on arm64

### DIFF
--- a/pkg/security/ebpf/probes/syscall_helpers.go
+++ b/pkg/security/ebpf/probes/syscall_helpers.go
@@ -138,8 +138,13 @@ func getFunctionNameFromSection(section string) string {
 		funcName = strings.ReplaceAll(funcName, "kprobe/", "kprobe__64_")
 		funcName = strings.ReplaceAll(funcName, "kretprobe/", "kretprobe__64_")
 	} else {
+		// amd64
 		funcName = strings.ReplaceAll(funcName, "__ia32_", "__32_")
 		funcName = strings.ReplaceAll(funcName, "__x64_", "__64_")
+		// arm
+		funcName = strings.ReplaceAll(funcName, "__arm64_", "__64_")
+		funcName = strings.ReplaceAll(funcName, "__arm32_", "__32_")
+		// utils
 		funcName = strings.ReplaceAll(funcName, "/_", "_")
 	}
 	funcName = strings.ReplaceAll(funcName, "tracepoint/syscalls/", "tracepoint_syscalls_")


### PR DESCRIPTION
### What does this PR do?

Due to the migration to the new ebpf manager for the security agent, the functional tests were failing on arm64. This PR fixes this issue.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
