### PR TITLE
Include the metadata payload to the flares

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -255,6 +255,16 @@ func createArchive(confSearchPaths SearchPaths, local bool, zipFilePath string, 
 		log.Errorf("Could not zip env vars: %s", err)
 	}
 
+	err = zipMetadataInventories(tempDir, hostname)
+	if err != nil {
+		log.Errorf("Could not zip inventories metadata payload: %s", err)
+	}
+
+	err = zipMetadataV5(tempDir, hostname)
+	if err != nil {
+		log.Errorf("Could not zip v5 metadata payload: %s", err)
+	}
+
 	err = zipHealth(tempDir, hostname)
 	if err != nil {
 		log.Errorf("Could not zip health check: %s", err)

--- a/pkg/flare/metadata.go
+++ b/pkg/flare/metadata.go
@@ -1,0 +1,51 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package flare
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
+	v5 "github.com/DataDog/datadog-agent/pkg/metadata/v5"
+	"github.com/DataDog/datadog-agent/pkg/util"
+)
+
+func addMetadata(tempDir, hostname, filename string, data []byte) error {
+	f := filepath.Join(tempDir, hostname, filename)
+	w, err := NewRedactingWriter(f, os.ModePerm, true)
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
+	_, err = w.Write(data)
+	return err
+}
+
+func zipMetadataInventories(tempDir, hostname string) error {
+	payload, err := inventories.GetLastPayload()
+	if err != nil {
+		return err
+	}
+
+	return addMetadata(tempDir, hostname, "metadata_inventories.json", payload)
+}
+
+func zipMetadataV5(tempDir, hostname string) error {
+	ctx := context.Background()
+	hostnameData, _ := util.GetHostnameData(ctx)
+	payload := v5.GetPayload(ctx, hostnameData)
+
+	data, err := json.MarshalIndent(payload, "", "    ")
+	if err != nil {
+		return err
+	}
+
+	return addMetadata(tempDir, hostname, "metadata_v5.json", data)
+}

--- a/releasenotes/notes/add-metadata-to-flare-ac60b58459cb8077.yaml
+++ b/releasenotes/notes/add-metadata-to-flare-ac60b58459cb8077.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Metadata information sent by the Agent are now part of the flares. This will allow for easier troubleshooting of
+    issues related to metadata.


### PR DESCRIPTION
### What does this PR do?

Include the metadata payload to the flares.

### Motivation

Easier toubleshooting of metadata issues.

### Describe how to test your changes

Generate a flare and check that the `metadata_inventories.json` and `metadata_v5.json` files are present and contains the same information sent to the backend.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
