### PR TITLE
Fix data race in LogStatus

### DIFF
--- a/pkg/logs/config/status.go
+++ b/pkg/logs/config/status.go
@@ -51,20 +51,28 @@ func (s *LogStatus) Error(err error) {
 
 // IsPending returns whether the current status is not yet determined.
 func (s *LogStatus) IsPending() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.status == isPending
 }
 
 // IsSuccess returns whether the current status is a success.
 func (s *LogStatus) IsSuccess() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.status == isSuccess
 }
 
 // IsError returns whether the current status is an error.
 func (s *LogStatus) IsError() bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.status == isError
 }
 
 // GetError returns the error.
 func (s *LogStatus) GetError() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
 	return s.err
 }


### PR DESCRIPTION
The LogStatus struct has a lock that was used to protect modifications, but not to protect reads.  Both are necessary!

### Motivation

Ran an agent built with `inv agent.build --race` for a few seconds and it discovered this issue.

### Additional Notes

Regarding the counter-argument that this is just reading an integer:

https://golang.org/doc/articles/race_detector
> Even such "innocent" data races can lead to hard-to-debug problems caused by non-atomicity of the memory accesses, interference with compiler optimizations, or reordering issues accessing processor memory .

### Describe how to test your changes

Run `agent status`, which calls these functions.
