### PR TITLE
Fix the `image_scan` GitLab jobs

### DIFF
--- a/.gitlab/docker_common/publish_job_templates.yml
+++ b/.gitlab/docker_common/publish_job_templates.yml
@@ -13,4 +13,4 @@
     - python3 -m pip install -r requirements.txt
     - ECR_RELEASE_SUFFIX="${CI_COMMIT_TAG+-release}"
     - IMG_SOURCES="$(sed -E "s#(${SRC_AGENT}|${SRC_DSD}|${SRC_DCA})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_SOURCES")"
-    - inv pipeline.trigger-child-pipeline --project-name "DataDog/public-images" --git-ref "main" --variables "IMG_REGISTRIES,IMG_SOURCES,IMG_DESTINATIONS"
+    - inv pipeline.trigger-child-pipeline --project-name "DataDog/public-images" --git-ref "main" --variables "IMG_REGISTRIES,IMG_SOURCES,IMG_DESTINATIONS,IMG_SIGNING"


### PR DESCRIPTION
### What does this PR do?

Fix the GitLab jobs of the `image_scan` stage.

### Motivation

Since the merge of #8560, the publication of the `*-scan` docker images is broken.
* [nighly pipeline](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/5621876)
* [exemple of job failing: `dogstatsd-scan`](https://gitlab.ddbuild.io/DataDog/public-images/-/jobs/88744844)

Notary fails to sign the images.
That’s because [the `IMG_SIGNING: "false"` environment variable](https://github.com/DataDog/datadog-agent/blob/fb997d89e0e9cbfc22fab6f3e66876fc1c3d8850/.gitlab/image_scan.yml#L16) wasn’t properly propagated to the downstream `public-images` job.

### Additional Notes



### Describe how to test your changes

Check that the publication of the `*-scan` docker images done by the nightly builds is working.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
