### PR TITLE
Fix dependabot after force push

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -253,4 +253,4 @@ replace gopkg.in/DataDog/dd-trace-go.v1 => gopkg.in/DataDog/dd-trace-go.v1 v1.30
 replace k8s.io/kube-state-metrics/v2 => github.com/ahmed-mez/kube-state-metrics/v2 v2.1.0-rc.0.0.20210629115837-e46f17606d22
 
 // Remove once the PR aptly-dev/aptly#967 is merged and released.
-replace github.com/aptly-dev/aptly => github.com/lebauce/aptly v0.7.2-0.20210723103859-345a32860f4d
+replace github.com/aptly-dev/aptly => github.com/lebauce/aptly v0.7.2-0.20210927125351-710eda859941

--- a/go.sum
+++ b/go.sum
@@ -967,8 +967,8 @@ github.com/kubernetes-sigs/custom-metrics-apiserver v0.0.0-20210311094424-0ca2b1
 github.com/kubernetes-sigs/custom-metrics-apiserver v0.0.0-20210311094424-0ca2b1909cdc/go.mod h1:o4psv/D+LJC+NGyL66BoKWXLkzlJeUqhL6/3rjFKXw0=
 github.com/kylelemons/godebug v0.0.0-20170820004349-d65d576e9348/go.mod h1:B69LEHPfb2qLo0BaaOLcbitczOKLWTsrBG9LczfCD4k=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
-github.com/lebauce/aptly v0.7.2-0.20210723103859-345a32860f4d h1:6k4uyp3yRFzEmzQZjnneNYhIvNvvcu9XIvFyalzuBAE=
-github.com/lebauce/aptly v0.7.2-0.20210723103859-345a32860f4d/go.mod h1:Uot/EzgnIw6okZTyEZ/Q8+er5ZXy2Bqrrabr/M6OxUE=
+github.com/lebauce/aptly v0.7.2-0.20210927125351-710eda859941 h1:5PdduvQqTpwsJWBEen+qCQKxrH3rNAxDEqeuP+qhcGk=
+github.com/lebauce/aptly v0.7.2-0.20210927125351-710eda859941/go.mod h1:Uot/EzgnIw6okZTyEZ/Q8+er5ZXy2Bqrrabr/M6OxUE=
 github.com/leodido/go-urn v1.1.0/go.mod h1:+cyI34gQWZcE1eQU7NVgKkkzdXDQHr1dBMtdAPozLkw=
 github.com/leodido/go-urn v1.2.0/go.mod h1:+8+nEpDfqqsY+g338gtMEUOtuK+4dEMhiQEgxpxOKII=
 github.com/lib/pq v1.10.0 h1:Zx5DJFEYQXio93kgXnQ09fXNiUKsqv4OUEu2UtGcB1E=


### PR DESCRIPTION
### What does this PR do?

Update `replace` directive for aptly. 

### Motivation

Force push on PR is making dependabot fail.

### Additional Notes

Should be a noop

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
