### PR TITLE
[WorkloadMetaCollector] Fix panic in handleContainer()

### DIFF
--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -72,7 +72,7 @@ func (c *WorkloadMetaCollector) handleContainer(ev workloadmeta.Event) []*TagInf
 	tagInfos := []*TagInfo{}
 	tags := utils.NewTagList()
 
-	container := ev.Entity.(*workloadmeta.Container)
+	container := ev.Entity.(workloadmeta.Container)
 
 	for tag, value := range c.staticTags {
 		tags.AddLow(tag, value)

--- a/pkg/tagger/collectors/workloadmeta_test.go
+++ b/pkg/tagger/collectors/workloadmeta_test.go
@@ -364,7 +364,7 @@ func TestHandleContainerStaticTags(t *testing.T) {
 
 	actual := collector.handleContainer(workloadmeta.Event{
 		Type:   workloadmeta.EventTypeSet,
-		Entity: &container,
+		Entity: container,
 	})
 
 	assertTagInfoListEqual(t, expected, actual)


### PR DESCRIPTION
### What does this PR do?

Fixes a panic that I saw while running `main` on Kubernetes:
```
 2021-10-01 10:52:22 UTC | CORE | INFO | (pkg/collector/runner/runner.go:95 in ensureMinWorkers) | Runner 1 added 4 workers (total: 4)                                                                                                                                                 │
│ panic: interface conversion: workloadmeta.Entity is workloadmeta.Container, not *workloadmeta.Container                                                                                                                                                                               │
│ goroutine 303 [running]:                                                                                                                                                                                                                                                              │
│ github.com/DataDog/datadog-agent/pkg/tagger/collectors.(*WorkloadMetaCollector).handleContainer(0xc00075d770, 0x7, 0x0, 0x0, 0x45715a0, 0xc0007d7320, 0x0, 0x2, 0x3)                                                                                                                  │
│     /home/datadog/go/src/github.com/DataDog/datadog-agent/pkg/tagger/collectors/workloadmeta_extract.go:75 +0x68b                                                                                                                                                                     │
│ github.com/DataDog/datadog-agent/pkg/tagger/collectors.(*WorkloadMetaCollector).processEvents(0xc00075d770, 0xc0001def00, 0x1b, 0x20, 0xc000ca7bc0)                                                                                                                                   │
│     /home/datadog/go/src/github.com/DataDog/datadog-agent/pkg/tagger/collectors/workloadmeta_extract.go:40 +0x334                                                                                                                                                                     │
│ github.com/DataDog/datadog-agent/pkg/tagger/collectors.(*WorkloadMetaCollector).Stream(0xc00075d770, 0xc, 0xc000abce48)                                                                                                                                                               │
│     /home/datadog/go/src/github.com/DataDog/datadog-agent/pkg/tagger/collectors/workloadmeta_main.go:76 +0x199                                                                                                                                                                        │
│ created by github.com/DataDog/datadog-agent/pkg/tagger/local.(*Tagger).registerCollectors                                                                                                                                                                                             │
│     /home/datadog/go/src/github.com/DataDog/datadog-agent/pkg/tagger/local/tagger.go:223 +0x37f   
```

### Describe how to test your changes

Agent should not panic when running on Kubernetes.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
