### PR TITLE
Fix docker image publication job

### DIFF
--- a/.gitlab/docker_common/publish_job_templates.yml
+++ b/.gitlab/docker_common/publish_job_templates.yml
@@ -9,6 +9,7 @@
   tags: ["runner:main"]
   variables:
     <<: *docker_variables
+    IMG_SIGNING: "true"
   script: # We can't use the 'trigger' keyword on manual jobs, otherwise they can't be run if the pipeline fails and is retried
     - python3 -m pip install -r requirements.txt
     - ECR_RELEASE_SUFFIX="${CI_COMMIT_TAG+-release}"


### PR DESCRIPTION
### What does this PR do?

Fix #9339.

### Motivation

In order to prevent typos, `inv pipeline.trigger-child-pipeline` fails on missing environment variables.
So, if `IMG_SIGNING: "false"` is needed by a subset of jobs, we need to explicitly set a default value.
Omitting the env var is not permitted.

### Additional Notes


### Describe how to test your changes

Check that the GitLab pipeline successfully publishes docker images.
On Docker Hub, the `{agent,cluster-agent,dogstatsd}{,-dev}` should be signed.
The `{agent,cluster-agent,dogstatsd}-scan` aren’t signed.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
