### PR TITLE
[runtime-security] Check CI error

### DIFF
--- a/pkg/security/tests/mkdir_test.go
+++ b/pkg/security/tests/mkdir_test.go
@@ -62,6 +62,9 @@ func TestMkdir(t *testing.T) {
 			assertNearTime(t, event.Mkdir.File.MTime)
 			assertNearTime(t, event.Mkdir.File.CTime)
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	}))
 
 	t.Run("mkdirat", func(t *testing.T) {
@@ -87,6 +90,9 @@ func TestMkdir(t *testing.T) {
 			assertNearTime(t, event.Mkdir.File.MTime)
 			assertNearTime(t, event.Mkdir.File.CTime)
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 }
 

--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -64,6 +64,9 @@ func TestOpen(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	}))
 
 	t.Run("openat", func(t *testing.T) {
@@ -81,6 +84,9 @@ func TestOpen(t *testing.T) {
 			assertRights(t, uint16(event.Open.Mode), 0711)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 
 	openHow := unix.OpenHow{
@@ -106,6 +112,9 @@ func TestOpen(t *testing.T) {
 			assertRights(t, uint16(event.Open.Mode), 0711)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 
 	t.Run("creat", ifSyscallSupported("SYS_CREAT", func(t *testing.T, syscallNB uintptr) {
@@ -123,6 +132,9 @@ func TestOpen(t *testing.T) {
 			assertRights(t, uint16(event.Open.Mode), 0711)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	}))
 
 	t.Run("truncate", func(t *testing.T) {
@@ -153,6 +165,9 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT|syscall.O_WRONLY|syscall.O_TRUNC, int(event.Open.Flags), "wrong flags")
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 
 	t.Run("open_by_handle_at", func(t *testing.T) {
@@ -199,6 +214,9 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 
 	t.Run("io_uring", func(t *testing.T) {
@@ -259,6 +277,9 @@ func TestOpen(t *testing.T) {
 			assertRights(t, uint16(event.Open.Mode), 0747)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 		})
+		if err != nil {
+			t.Error(err)
+		}
 
 		prepRequest, err = iouring.Openat2(unix.AT_FDCWD, testFile, &openHow)
 		if err != nil {
@@ -289,6 +310,9 @@ func TestOpen(t *testing.T) {
 			assertRights(t, uint16(event.Open.Mode), 0711)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 
 	_ = os.Remove(testFile)

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -156,6 +156,9 @@ func TestProcessContext(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 
 	t.Run("inode", func(t *testing.T) {
@@ -180,6 +183,9 @@ func TestProcessContext(t *testing.T) {
 			assertFieldEqual(t, event, "process.file.path", executable)
 			assert.Equal(t, getInode(t, executable), event.ResolveProcessCacheEntry().FileFields.Inode, "wrong inode")
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 
 	test.Run(t, "args-envs", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
@@ -244,6 +250,9 @@ func TestProcessContext(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 
 	t.Run("argv", func(t *testing.T) {
@@ -351,6 +360,9 @@ func TestProcessContext(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 
 	t.Run("tty", func(t *testing.T) {
@@ -447,6 +459,9 @@ func TestProcessContext(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 
 	test.Run(t, "pid1", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {

--- a/pkg/security/tests/rmdir_test.go
+++ b/pkg/security/tests/rmdir_test.go
@@ -60,6 +60,9 @@ func TestRmdir(t *testing.T) {
 			assertNearTime(t, event.Rmdir.File.MTime)
 			assertNearTime(t, event.Rmdir.File.CTime)
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	}))
 
 	t.Run("unlinkat-at_removedir", func(t *testing.T) {
@@ -88,6 +91,9 @@ func TestRmdir(t *testing.T) {
 			assertNearTime(t, event.Rmdir.File.MTime)
 			assertNearTime(t, event.Rmdir.File.CTime)
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 }
 

--- a/pkg/security/tests/unlink_test.go
+++ b/pkg/security/tests/unlink_test.go
@@ -55,6 +55,9 @@ func TestUnlink(t *testing.T) {
 			assertNearTime(t, event.Unlink.File.MTime)
 			assertNearTime(t, event.Unlink.File.CTime)
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	}))
 
 	testAtFile, testAtFilePtr, err := test.CreateWithOptions("test-unlinkat", 98, 99, fileMode)
@@ -79,6 +82,9 @@ func TestUnlink(t *testing.T) {
 			assertNearTime(t, event.Unlink.File.MTime)
 			assertNearTime(t, event.Unlink.File.CTime)
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 }
 

--- a/pkg/security/tests/utimes_test.go
+++ b/pkg/security/tests/utimes_test.go
@@ -62,6 +62,9 @@ func TestUtimes(t *testing.T) {
 			assertNearTime(t, event.Utimes.File.MTime)
 			assertNearTime(t, event.Utimes.File.CTime)
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	}))
 
 	t.Run("utimes", ifSyscallSupported("SYS_UTIMES", func(t *testing.T, syscallNB uintptr) {
@@ -100,6 +103,9 @@ func TestUtimes(t *testing.T) {
 			assertNearTime(t, event.Utimes.File.MTime)
 			assertNearTime(t, event.Utimes.File.CTime)
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	}))
 
 	t.Run("utimensat", func(t *testing.T) {
@@ -141,5 +147,8 @@ func TestUtimes(t *testing.T) {
 			assertNearTime(t, event.Utimes.File.MTime)
 			assertNearTime(t, event.Utimes.File.CTime)
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 }

--- a/pkg/security/tests/xattr_test.go
+++ b/pkg/security/tests/xattr_test.go
@@ -72,6 +72,9 @@ func TestSetXAttr(t *testing.T) {
 			assertNearTime(t, event.SetXAttr.File.MTime)
 			assertNearTime(t, event.SetXAttr.File.CTime)
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 
 	t.Run("lsetxattr", func(t *testing.T) {
@@ -110,6 +113,9 @@ func TestSetXAttr(t *testing.T) {
 			assertNearTime(t, event.SetXAttr.File.MTime)
 			assertNearTime(t, event.SetXAttr.File.CTime)
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 
 	t.Run("fsetxattr", func(t *testing.T) {
@@ -141,6 +147,9 @@ func TestSetXAttr(t *testing.T) {
 			assertNearTime(t, event.SetXAttr.File.MTime)
 			assertNearTime(t, event.SetXAttr.File.CTime)
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 }
 
@@ -208,6 +217,9 @@ func TestRemoveXAttr(t *testing.T) {
 			assertNearTime(t, event.RemoveXAttr.File.MTime)
 			assertNearTime(t, event.RemoveXAttr.File.CTime)
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 
 	t.Run("lremovexattr", func(t *testing.T) {
@@ -253,6 +265,9 @@ func TestRemoveXAttr(t *testing.T) {
 			assertNearTime(t, event.RemoveXAttr.File.MTime)
 			assertNearTime(t, event.RemoveXAttr.File.CTime)
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 
 	t.Run("fremovexattr", func(t *testing.T) {
@@ -308,5 +323,8 @@ func TestRemoveXAttr(t *testing.T) {
 				t.Errorf("expected ctime close to %s, got %s", now, ctime)
 			}
 		})
+		if err != nil {
+			t.Error(err)
+		}
 	})
 }


### PR DESCRIPTION
### What does this PR do?

Some CI error are currently not checked. Make sure we check CI errors.

### Motivation

Use the CI :)

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
