### PR TITLE
Make the kubelet collector able to retry kubelet connection

### DIFF
--- a/pkg/util/containers/collectors/kubelet.go
+++ b/pkg/util/containers/collectors/kubelet.go
@@ -32,9 +32,9 @@ func (c *KubeletCollector) Detect() error {
 		return errors.New("Kubernetes feature is deactivated")
 	}
 
-	util, err := kubelet.GetKubeUtil()
-	if err != nil {
-		return err
+	util, retrier := kubelet.GetKubeUtilWithRetrier()
+	if util == nil {
+		return retrier.LastError()
 	}
 	c.kubeUtil = util
 	return nil

--- a/releasenotes/notes/make-the-kubelet-collector-able-to-return-a-retriable-b68752777b712b48.yaml
+++ b/releasenotes/notes/make-the-kubelet-collector-able-to-return-a-retriable-b68752777b712b48.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    In case of temporary network connectivity issue with the kubelet, let the agent tagger retry instead of definitively giving up.


### PR DESCRIPTION
### What does this PR do?

Make the kubelet collector able to retry kubelet connection in case of temporary network failure.

### Motivation

In case of temporary kubelet network connectivity issue, allow the kubelet to retry instead of giving up.

### Additional Notes

Here is the log that the agent is currently generating when giving up:
```
2021-09-07 12:06:32 UTC | CORE | DEBUG | (pkg/tagger/local/tagger.go:157 in tryCollectors) | kubelet tag collector cannot start: impossible to reach Kubelet with host: 10.72.131.19. Please check if your setup requires kubelet_tls_verify = false. Activate debug logs to see all attempts made
```

### Describe how to test your changes



### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [X] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [X] The appropriate `team/..` label has been applied, if known.
- [X] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [X] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
