### PR TITLE
Infer HTTP(S) monitoring settings from service monitoring

### DIFF
--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -88,7 +88,6 @@ func InitSystemProbeConfig(cfg Config) {
 
 	// network_tracer settings
 	// we cannot use BindEnvAndSetDefault for network_config.enabled because we need to know if it was manually set.
-	cfg.SetKnown(join(netNS, "enabled"))
 	cfg.BindEnv(join(netNS, "enabled"), "DD_SYSTEM_PROBE_NETWORK_ENABLED") //nolint:errcheck
 	cfg.BindEnvAndSetDefault(join(spNS, "disable_tcp"), false, "DD_DISABLE_TCP_TRACING")
 	cfg.BindEnvAndSetDefault(join(spNS, "disable_udp"), false, "DD_DISABLE_UDP_TRACING")
@@ -118,8 +117,8 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "dest_excludes"), map[string][]string{})
 
 	// network_config namespace only
-	cfg.BindEnvAndSetDefault(join(netNS, "enable_http_monitoring"), false, "DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTP_MONITORING")
-	cfg.BindEnvAndSetDefault(join(netNS, "enable_https_monitoring"), false, "DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTPS_MONITORING")
+	cfg.BindEnv(join(netNS, "enable_http_monitoring"), "DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTP_MONITORING")
+	cfg.BindEnv(join(netNS, "enable_https_monitoring"), "DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTPS_MONITORING")
 	cfg.BindEnvAndSetDefault(join(netNS, "enable_gateway_lookup"), false, "DD_SYSTEM_PROBE_NETWORK_ENABLE_GATEWAY_LOOKUP")
 
 	// list of DNS query types to be recorded

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -237,5 +237,14 @@ func New() *Config {
 		log.Info("network tracer DNS inspection disabled by configuration")
 	}
 
+	if c.ServiceMonitoringEnabled {
+		cfg.Set(join(netNS, "enable_http_monitoring"), true)
+		c.EnableHTTPMonitoring = true
+		if !cfg.IsSet(join(netNS, "enable_https_monitoring")) {
+			cfg.Set(join(netNS, "enable_https_monitoring"), true)
+			c.EnableHTTPSMonitoring = true
+		}
+	}
+
 	return c
 }


### PR DESCRIPTION
### What does this PR do?

Enables HTTP(s) if service monitoring is enabled. Allows HTTPS to be turned off if user explicitly sets to `false`.

### Motivation

TSM config should be as simple as possible.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
