### PR TITLE
[appveyor] Do not cache go mod pkg directory

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -36,7 +36,8 @@ install:
 cache:
   - '%GOPATH%\bin'
   - '%LOCALAPPDATA%\pip\Cache'
-  - '%GOPATH%\pkg\mod'
+  # note: we don't cache go mod's directory ($GOPATH/pkg/mod):
+  # it's much slower for appveyor to download and unzip it than for go mod to re-download all deps from scratch
 
 build: off
 


### PR DESCRIPTION
### What does this PR do?

Do not cache go mod pkg directory on Appveyor

### Motivation

Builds get stuck trying to download and unzip the directory.
Example: https://ci.appveyor.com/project/Datadog/datadog-agent/builds/40989711
In addition, `go mod download` only takes a couple of minutes on Appveyor, so caching this dir given the slowness of the cache is useless.

### Describe how to test your changes

Successful appveyor builds.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.

Note: Adding GitHub labels is only possible for contributors with write access.
