### PR TITLE
Add /usr/include/linux to default kernel header paths

### DIFF
--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -22,6 +22,7 @@ const sysfsHeadersPath = "/sys/kernel/kheaders.tar.xz"
 const kernelModulesPath = "/lib/modules/%s/build"
 const debKernelModulesPath = "/lib/modules/%s/source"
 const cosKernelModulesPath = "/usr/src/linux-headers-%s"
+const fedoraKernelModulesPath = "/usr"
 
 var versionCodeRegexp = regexp.MustCompile(`^#define[\t ]+LINUX_VERSION_CODE[\t ]+(\d+)$`)
 
@@ -115,8 +116,13 @@ func getHeaderVersion(path string) (Version, error) {
 	vh := filepath.Join(path, "include/generated/uapi/linux/version.h")
 	f, err := os.Open(vh)
 	if err != nil {
-		return 0, err
+		vh = filepath.Join(path, "include/linux/version.h")
+		f, err = os.Open(vh)
+		if err != nil {
+			return 0, err
+		}
 	}
+
 	defer f.Close()
 	return parseHeaderVersion(f)
 }
@@ -149,6 +155,7 @@ func getDefaultHeaderDirs() []string {
 		fmt.Sprintf(kernelModulesPath, hi.KernelVersion),
 		fmt.Sprintf(debKernelModulesPath, hi.KernelVersion),
 		fmt.Sprintf(cosKernelModulesPath, hi.KernelVersion),
+		fedoraKernelModulesPath,
 	}
 	return dirs
 }


### PR DESCRIPTION
### What does this PR do?

Adds the path to kernel headers on fedora (`/usr/include/linux`) to the list of paths we check for kernel headers.

Note: no changes are needed to the ebpf compiler are needed, since the necessary include flag to support this change already exists: https://github.com/DataDog/datadog-agent/blob/bf4ea714568b53048f388678100e301a7e4b0c0f/pkg/ebpf/compiler/compiler.go#L137

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
