### PR TITLE
Always use atomics to access an atomic value

### DIFF
--- a/pkg/logs/pipeline/provider.go
+++ b/pkg/logs/pipeline/provider.go
@@ -37,7 +37,7 @@ type provider struct {
 	endpoints                 *config.Endpoints
 
 	pipelines            []*Pipeline
-	currentPipelineIndex int32
+	currentPipelineIndex uint32
 	destinationsContext  *client.DestinationsContext
 
 	serverless bool
@@ -96,8 +96,7 @@ func (p *provider) NextPipelineChan() chan *message.Message {
 	if pipelinesLen == 0 {
 		return nil
 	}
-	index := int(p.currentPipelineIndex+1) % pipelinesLen
-	defer atomic.StoreInt32(&p.currentPipelineIndex, int32(index))
+	index := atomic.AddUint32(&p.currentPipelineIndex, uint32(1)) % uint32(pipelinesLen)
 	nextPipeline := p.pipelines[index]
 	return nextPipeline.InputChan
 }

--- a/pkg/logs/pipeline/provider_test.go
+++ b/pkg/logs/pipeline/provider_test.go
@@ -37,19 +37,24 @@ func (suite *ProviderTestSuite) SetupTest() {
 func (suite *ProviderTestSuite) TestProvider() {
 	suite.a.Start()
 	suite.p.Start()
-	suite.Equal(int32(0), suite.p.currentPipelineIndex)
+	suite.Equal(uint32(0), suite.p.currentPipelineIndex)
 	suite.Equal(3, len(suite.p.pipelines))
 
 	c := suite.p.NextPipelineChan()
-	suite.Equal(int32(1), suite.p.currentPipelineIndex)
+	suite.Equal(uint32(1), suite.p.currentPipelineIndex)
+	suite.Equal(suite.p.pipelines[1].InputChan, c)
 
-	suite.p.NextPipelineChan()
-	suite.Equal(int32(2), suite.p.currentPipelineIndex)
+	c = suite.p.NextPipelineChan()
+	suite.Equal(uint32(2), suite.p.currentPipelineIndex)
+	suite.Equal(suite.p.pipelines[2].InputChan, c)
 
-	suite.p.NextPipelineChan()
-	suite.Equal(int32(0), suite.p.currentPipelineIndex)
-	suite.Equal(c, suite.p.NextPipelineChan())
-	suite.Equal(int32(1), suite.p.currentPipelineIndex)
+	c = suite.p.NextPipelineChan()
+	suite.Equal(uint32(3), suite.p.currentPipelineIndex)
+	suite.Equal(suite.p.pipelines[0].InputChan, c) // wraps
+
+	c = suite.p.NextPipelineChan()
+	suite.Equal(uint32(4), suite.p.currentPipelineIndex)
+	suite.Equal(suite.p.pipelines[1].InputChan, c)
 
 	suite.p.Stop()
 	suite.a.Stop()


### PR DESCRIPTION
The existing implementation used a "normal" read to read a value,
increment it, and then write it atomically.  This mixed "normal" and
atomic reads of the same value, and also did not accomplish the intended
atomic increment.

In this case, because this operation is meant only to distribute the
load over a number of pipelines, the result of any problems here would
be, at worst, uneven distribute of pipelines.  Still, let's not keep
incorrect implementations of low-level operations around in the
codebase.

This changes from int32 to uint32 since it's used as an array index
which must be nonnegative.

### Motivation

Spotted this while reading source code, is all :)

### Describe how to test your changes

Any situation with multiple log sources should cover this code.
