### PR TITLE
[tests] Reduce jitter-based failures in collector tests

### DIFF
--- a/pkg/collector/worker/utilization_tracker_test.go
+++ b/pkg/collector/worker/utilization_tracker_test.go
@@ -242,10 +242,11 @@ func TestUtilizationTrackerAccuracy(t *testing.T) {
 		idleDuration := time.Duration(totalMs-runtimeMs) * time.Millisecond
 		clk.Add(idleDuration)
 
-		// Every cycle, we should be getting closer and closer to 0.3. The
-		// function below goes from 0.5 initially to ~0.1 at the end of the
-		// iterator.
-		assert.InDelta(t, getWorkerUtilizationExpvar(t, "worker"), 0.3, 0.1)
+		// Due to jitter in the aggregation of random data points, we wait a few
+		// collection intervals before comparing the values.
+		if checkIdx > 5 {
+			require.InDelta(t, getWorkerUtilizationExpvar(t, "worker"), 0.3, 0.1)
+		}
 	}
 
 	// Assert after many data points that we're really close to 0.3


### PR DESCRIPTION
### What does this PR do?

Even though the TestUtilizationTrackerAccuracy test no longer uses a
real-time clock, the random samples may rise above the expected delta
during the initial first assertion checks against the expected delta.
This change skips a few of those initial checks so that we do not get
false positives.

### Motivation

Infrequent flake test

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

N/A

### Checklist

- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.