### PR TITLE
[listeners/snmp] Handle use_device_id_as_hostname in GetExtraConfig

### DIFF
--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -420,6 +420,8 @@ func (s *SNMPService) GetExtraConfig(key []byte) ([]byte, error) {
 		return []byte(s.config.Namespace), nil
 	case "collect_device_metadata":
 		return []byte(strconv.FormatBool(s.config.CollectDeviceMetadata)), nil
+	case "use_device_id_as_hostname":
+		return []byte(strconv.FormatBool(s.config.UseDeviceIDAsHostname)), nil
 	case "tags":
 		return []byte(convertToCommaSepTags(s.config.Tags)), nil
 	case "min_collection_interval":

--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -216,6 +216,11 @@ func TestExtraConfig(t *testing.T) {
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "0", string(info))
 
+	svc.config.UseDeviceIDAsHostname = false
+	info, err = svc.GetExtraConfig([]byte("use_device_id_as_hostname"))
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "false", string(info))
+
 	svc.config.MinCollectionInterval = 60
 	info, err = svc.GetExtraConfig([]byte("min_collection_interval"))
 	assert.Equal(t, nil, err)


### PR DESCRIPTION
E2E Tests build https://github.com/DataDog/integrations-core/pull/10324

### What does this PR do?

Handle `use_device_id_as_hostname` in `GetExtraConfig` 

### Motivation

Fix for https://github.com/DataDog/datadog-agent/pull/9224/s

`use_device_id_as_hostname` must be handled in GetExtraConfig


### Additional Notes

### Describe how to test your changes

Test that `use_device_id_as_hostname` can be passed using snmp listener

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
