### PR TITLE
[invoke] Fix PR milestone & label update in release.create-rc

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1220,7 +1220,7 @@ Make sure that milestone is open before trying again.""".format(
 
     updated_pr = github.update_pr(
         pull_number=pr["number"],
-        milestone=milestone["number"],
+        milestone_number=milestone["number"],
         labels=["changelog/no-changelog", "team/agent-platform", "team/agent-core"],
     )
 

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1221,7 +1221,7 @@ Make sure that milestone is open before trying again.""".format(
     updated_pr = github.update_pr(
         pull_number=pr["number"],
         milestone_number=milestone["number"],
-        labels=["changelog/no-changelog", "team/agent-platform", "team/agent-core"],
+        labels=["changelog/no-changelog", "qa/skip-qa", "team/agent-platform", "team/agent-core"],
     )
 
     if not updated_pr or not updated_pr.get("number") or not updated_pr.get("html_url"):


### PR DESCRIPTION
### What does this PR do?

Fixes an issue in `invoke release.create-rc` due to a change in the `GithubAPI.update_pr` function signature.

### Motivation

Fix release tasks.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
