### PR TITLE
Fix windows TestConnectionClobber test

### DIFF
--- a/pkg/network/network_filter.go
+++ b/pkg/network/network_filter.go
@@ -62,7 +62,7 @@ func ParseConnectionFilters(filters map[string][]string) (excludelist []*Connect
 
 			// Port filter for is a wildcard
 			if lowerPort == 0 && upperPort == 0 {
-				if subnet == nil && transportFilter.UDP && transportFilter.TCP { // Check that theres no wildcard filter above, or we'd just skip everything which is invalid
+				if subnet == nil { // Check that theres no wildcard filter above, or we'd just skip everything which is invalid
 					err = log.Errorf("Given rule will not be respected. Invalid filter with IP/CIDR as * and port as *")
 					break
 				}

--- a/pkg/network/network_filter.go
+++ b/pkg/network/network_filter.go
@@ -62,7 +62,7 @@ func ParseConnectionFilters(filters map[string][]string) (excludelist []*Connect
 
 			// Port filter for is a wildcard
 			if lowerPort == 0 && upperPort == 0 {
-				if subnet == nil { // Check that theres no wildcard filter above, or we'd just skip everything which is invalid
+				if subnet == nil && transportFilter.UDP && transportFilter.TCP { // Check that theres no wildcard filter above, or we'd just skip everything which is invalid
 					err = log.Errorf("Given rule will not be respected. Invalid filter with IP/CIDR as * and port as *")
 					break
 				}

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -286,11 +286,11 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 	log.Tracef("GetActiveConnections clientID=%s", clientID)
 
 	latestTime, err := t.getConnections(t.activeBuffer, t.closedBuffer)
-	active := t.activeBuffer.Connections()
-	closed := t.closedBuffer.Connections()
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving connections: %s", err)
 	}
+	active := t.activeBuffer.Connections()
+	closed := t.closedBuffer.Connections()
 
 	delta := t.state.GetDelta(clientID, latestTime, active, closed, t.reverseDNS.GetDNSStats(), t.httpMonitor.GetHTTPStats())
 	t.activeBuffer.Reset()

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1218,8 +1218,8 @@ func TestConnectedUDPSendIPv6(t *testing.T) {
 
 func TestConnectionClobber(t *testing.T) {
 	cfg := testConfig()
+	cfg.CollectUDPConns = false
 	cfg.ExcludedDestinationConnections = map[string][]string{
-		"*":           {"udp *"},
 		"0.0.0.0/2":   {"*"},
 		"64.0.0.0/3":  {"*"},
 		"96.0.0.0/4":  {"*"},
@@ -1228,9 +1228,6 @@ func TestConnectionClobber(t *testing.T) {
 		"124.0.0.0/7": {"*"},
 		"126.0.0.0/8": {"*"},
 		"128.0.0.0/1": {"*"},
-	}
-	cfg.ExcludedSourceConnections = map[string][]string{
-		"*": {"udp *"},
 	}
 	tr, err := NewTracer(cfg)
 	require.NoError(t, err)

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1217,10 +1217,23 @@ func TestConnectedUDPSendIPv6(t *testing.T) {
 }
 
 func TestConnectionClobber(t *testing.T) {
-	tr, err := NewTracer(testConfig())
-	if err != nil {
-		t.Fatal(err)
+	cfg := testConfig()
+	cfg.ExcludedDestinationConnections = map[string][]string{
+		"*":           {"udp *"},
+		"0.0.0.0/2":   {"*"},
+		"64.0.0.0/3":  {"*"},
+		"96.0.0.0/4":  {"*"},
+		"112.0.0.0/5": {"*"},
+		"120.0.0.0/6": {"*"},
+		"124.0.0.0/7": {"*"},
+		"126.0.0.0/8": {"*"},
+		"128.0.0.0/1": {"*"},
 	}
+	cfg.ExcludedSourceConnections = map[string][]string{
+		"*": {"udp *"},
+	}
+	tr, err := NewTracer(cfg)
+	require.NoError(t, err)
 	defer tr.Stop()
 
 	// Create TCP Server which, for every line, sends back a message with size=serverMessageSize

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1288,10 +1288,10 @@ func TestConnectionClobber(t *testing.T) {
 
 	// wait for tracer to pick up all connections
 	//
-	// there is not good way do this other than a sleep since we
-	// can't call getConnections in a require.Eventually call
+	// there is not a good way do this other than a sleep since we
+	// can't call getConnections in a `require.Eventually` call
 	// to the get the number of connections as that could
-	// affect the tr.buffer length
+	// affect the `activeBuffer` length
 	time.Sleep(2 * time.Second)
 
 	preCap := tr.activeBuffer.Capacity()
@@ -1301,7 +1301,7 @@ func TestConnectionClobber(t *testing.T) {
 	dst := connections.Conns[0].DPort
 	t.Logf("got %d connections", len(connections.Conns))
 	// ensure we didn't grow or shrink the buffer
-	require.Equal(t, preCap, tr.activeBuffer.Capacity())
+	assert.Equal(t, preCap, tr.activeBuffer.Capacity())
 
 	for _, c := range append(conns, serverConns...) {
 		c.Close()
@@ -1319,9 +1319,9 @@ func TestConnectionClobber(t *testing.T) {
 	time.Sleep(2 * time.Second)
 
 	t.Logf("got %d connections", len(getConnections(t, tr).Conns))
-	require.Equal(t, src, connections.Conns[0].SPort, "source port should not change")
-	require.Equal(t, dst, connections.Conns[0].DPort, "dest port should not change")
-	require.Equal(t, preCap, tr.activeBuffer.Capacity())
+	assert.Equal(t, src, connections.Conns[0].SPort, "source port should not change")
+	assert.Equal(t, dst, connections.Conns[0].DPort, "dest port should not change")
+	assert.Equal(t, preCap, tr.activeBuffer.Capacity())
 }
 
 func TestTCPDirection(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Fixes the `TestConnectionClobber` test on windows, by matching where we reset the buffers between Linux and Windows.

### Motivation

Broken tests on `main`

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
