### PR TITLE
[CWS] clean cgo pollution

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -676,14 +676,22 @@ def generate_cgo_types(ctx, windows=is_windows):
 
     for f in def_files:
         fdir, file = os.path.split(f)
+        absolute_input_file = os.path.abspath(f)
         base, _ = os.path.splitext(file)
         with ctx.cd(fdir):
+            output_file = "{base}_{platform}.go".format(base=base, platform=platform)
             ctx.run(
-                "go tool cgo -godefs -- -fsigned-char {file} > {base}_{platform}.go".format(
-                    file=file, base=base, platform=platform
+                "go tool cgo -godefs -- -fsigned-char {file} > {output_file}".format(
+                    file=file, output_file=output_file
                 )
             )
-            ctx.run("gofmt -w -s {base}_{platform}.go".format(base=base, platform=platform))
+            ctx.run("gofmt -w -s {output_file}".format(output_file=output_file))
+            # replace absolute path with relative ones in generated file
+            ctx.run("sed -i 's={abs}={rel}=gi' {working_file}".format(
+                abs=absolute_input_file,
+                rel=file,
+                working_file=output_file
+            ))
 
 
 def is_root():

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -681,18 +681,16 @@ def generate_cgo_types(ctx, windows=is_windows, replace_absolutes=True):
         with ctx.cd(fdir):
             output_file = "{base}_{platform}.go".format(base=base, platform=platform)
             ctx.run(
-                "go tool cgo -godefs -- -fsigned-char {file} > {output_file}".format(
-                    file=file, output_file=output_file
-                )
+                "go tool cgo -godefs -- -fsigned-char {file} > {output_file}".format(file=file, output_file=output_file)
             )
             ctx.run("gofmt -w -s {output_file}".format(output_file=output_file))
             if replace_absolutes:
                 # replace absolute path with relative ones in generated file
-                ctx.run("sed -i 's={abs}={rel}=gi' {working_file}".format(
-                    abs=absolute_input_file,
-                    rel=file,
-                    working_file=output_file
-                ))
+                ctx.run(
+                    "sed -i 's={abs}={rel}=gi' {working_file}".format(
+                        abs=absolute_input_file, rel=file, working_file=output_file
+                    )
+                )
 
 
 def is_root():

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -87,7 +87,7 @@ def build(
         # Only build ebpf files on unix
         build_object_files(ctx, parallel_build=parallel_build)
 
-    generate_cgo_types(ctx, windows=windows)
+    generate_cgo_types(ctx, windows=windows, replace_absolutes=not windows)
     ldflags, gcflags, env = get_build_flags(
         ctx,
         major_version=major_version,

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -87,7 +87,7 @@ def build(
         # Only build ebpf files on unix
         build_object_files(ctx, parallel_build=parallel_build)
 
-    generate_cgo_types(ctx, windows=windows, replace_absolutes=not windows)
+    generate_cgo_types(ctx, windows=windows)
     ldflags, gcflags, env = get_build_flags(
         ctx,
         major_version=major_version,

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -687,7 +687,7 @@ def generate_cgo_types(ctx, windows=is_windows, replace_absolutes=True):
             if replace_absolutes:
                 # replace absolute path with relative ones in generated file
                 ctx.run(
-                    "sed -i 's={abs}={rel}=gi' {working_file}".format(
+                    "sed -i '2 s={abs}={rel}=gi' {working_file}".format(
                         abs=absolute_input_file, rel=file, working_file=output_file
                     )
                 )

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -677,6 +677,7 @@ def replace_cgo_tag_absolute_path(file_path, absolute_path, relative_path):
     f.write(res)
     f.close()
 
+
 @task
 def generate_cgo_types(ctx, windows=is_windows, replace_absolutes=True):
     if windows:

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -661,7 +661,7 @@ def generate_runtime_files(ctx):
 
 
 @task
-def generate_cgo_types(ctx, windows=is_windows):
+def generate_cgo_types(ctx, windows=is_windows, replace_absolutes=True):
     if windows:
         platform = "windows"
         def_files = ["./pkg/network/driver/types.go"]
@@ -686,12 +686,13 @@ def generate_cgo_types(ctx, windows=is_windows):
                 )
             )
             ctx.run("gofmt -w -s {output_file}".format(output_file=output_file))
-            # replace absolute path with relative ones in generated file
-            ctx.run("sed -i 's={abs}={rel}=gi' {working_file}".format(
-                abs=absolute_input_file,
-                rel=file,
-                working_file=output_file
-            ))
+            if replace_absolutes:
+                # replace absolute path with relative ones in generated file
+                ctx.run("sed -i 's={abs}={rel}=gi' {working_file}".format(
+                    abs=absolute_input_file,
+                    rel=file,
+                    working_file=output_file
+                ))
 
 
 def is_root():


### PR DESCRIPTION
### What does this PR do?

The command `cgo -godefs` currently used by the network team is generating a bit of noise in the git status when working on the system-probe. This PR tries to address this issue by:

- adding `_cgo` folders to the gitignore
- replacing absolute paths with relative ones in generated files

This last issue is most likely due to different version of go tools being used by different teams members, with some version (the more recent ones ?) incorporating absolute in the header of generated files instead of the currently commited relative paths.

### Describe how to test your changes

This should be a no-op on the feature side, please test that this is working as expected on Windows.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
