### PR TITLE
Fix dogstatsd sync flushing behaviour

### DIFF
--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -437,10 +437,6 @@ func (s *Server) forwarder(fcon net.Conn, packetsChannel chan packets.Packets) {
 // Flush flushes all the data to the aggregator to them send it to the Datadog intake.
 func (s *Server) Flush() {
 	log.Debug("Received a Flush trigger")
-	// make all workers flush their aggregated data (in the batcher) to the aggregator.
-	for _, w := range s.workers {
-		w.flush()
-	}
 	// flush the aggregator to have the serializer/forwarder send data to the backend.
 	// We add 10 seconds to the interval to ensure that we're getting the whole sketches bucket
 	s.aggregator.Flush(time.Now().Add(time.Second*10), true)

--- a/pkg/dogstatsd/server_worker.go
+++ b/pkg/dogstatsd/server_worker.go
@@ -32,15 +32,16 @@ func newWorker(s *Server) *worker {
 		server:    s,
 		batcher:   newBatcher(s.aggregator),
 		parser:    newParser(s.sharedFloat64List),
-		flushChan: make(chan chan struct{}, 1),
+		flushChan: make(chan chan struct{}, 0),
 		samples:   make([]metrics.MetricSample, 0, defaultSampleSize),
 	}
 }
 
 func (w *worker) flush() {
-	// Blocks until any
-	notify := make(chan struct{}, 1)
+	notify := make(chan struct{}, 0)
 	w.flushChan <- notify
+	// Blocks until notify has been received in the run loop, and
+	// returned a value.
 	<-notify
 }
 

--- a/pkg/serverless/metrics/metric.go
+++ b/pkg/serverless/metrics/metric.go
@@ -111,5 +111,6 @@ func buildBufferedAggregator(multipleEndpointConfig MultipleEndpointConfig, forw
 	f := forwarder.NewSyncForwarder(keysPerDomain, forwarderTimeout)
 	f.Start() //nolint:errcheck
 	serializer := serializer.NewSerializer(f, nil)
-	return aggregator.InitAggregator(serializer, nil, "serverless")
+	// flushInterval is set to 0 (disabled) because we want to control flushing from the daemon
+	return aggregator.InitAggregatorWithFlushInterval(serializer, nil, "serverless", 0)
 }


### PR DESCRIPTION
### What does this PR do?

Disables the periodic flush timer for metrics, and introduces a thread safe mechanism to synchronize metric workers.

### Motivation

It appears there is the potential for a sporadic panic from the lambda extension, due to synchronous flushing being initiated from multiple threads in the metric processor.

### Additional Notes

The Flush route on metric Service, and the flush route on the server_worker are only used by the Lambda Extension

### Describe how to test your changes

I'm doing a multiday test with our serverless sample app to see if the issue still occurs. In our testing, the crash was very rare, so longer testing periods are necessary.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
