### PR TITLE
[dogstatsd] replay: add mode to avoid mmap

### DIFF
--- a/cmd/agent/app/dogstatsd_replay.go
+++ b/cmd/agent/app/dogstatsd_replay.go
@@ -42,7 +42,7 @@ func init() {
 	AgentCmd.AddCommand(dogstatsdReplayCmd)
 	dogstatsdReplayCmd.Flags().StringVarP(&dsdReplayFilePath, "file", "f", "", "Input file with TCP traffic to replay.")
 	dogstatsdReplayCmd.Flags().BoolVarP(&dsdVerboseReplay, "verbose", "v", false, "Verbose replay.")
-	dogstatsdReplayCmd.Flags().BoolVarP(&dsdMmapReplay, "mmap", "m", true, "Mmap file for replay.")
+	dogstatsdReplayCmd.Flags().BoolVarP(&dsdMmapReplay, "mmap", "m", true, "Mmap file for replay. Set to false to load the entire file into memory instead")
 	dogstatsdReplayCmd.Flags().IntVarP(&dsdReplayIterations, "loops", "l", defaultIterations, "Number of iterationsi to replay.")
 }
 

--- a/cmd/agent/app/dogstatsd_replay.go
+++ b/cmd/agent/app/dogstatsd_replay.go
@@ -30,6 +30,7 @@ import (
 var (
 	dsdReplayFilePath   string
 	dsdVerboseReplay    bool
+	dsdMmapReplay       bool
 	dsdReplayIterations int
 )
 
@@ -41,6 +42,7 @@ func init() {
 	AgentCmd.AddCommand(dogstatsdReplayCmd)
 	dogstatsdReplayCmd.Flags().StringVarP(&dsdReplayFilePath, "file", "f", "", "Input file with TCP traffic to replay.")
 	dogstatsdReplayCmd.Flags().BoolVarP(&dsdVerboseReplay, "verbose", "v", false, "Verbose replay.")
+	dogstatsdReplayCmd.Flags().BoolVarP(&dsdMmapReplay, "mmap", "m", true, "Mmap file for replay.")
 	dogstatsdReplayCmd.Flags().IntVarP(&dsdReplayIterations, "loops", "l", defaultIterations, "Number of iterationsi to replay.")
 }
 
@@ -117,7 +119,7 @@ func dogstatsdReplay() error {
 	cli := pb.NewAgentSecureClient(apiconn)
 
 	depth := 10
-	reader, err := replay.NewTrafficCaptureReader(dsdReplayFilePath, depth)
+	reader, err := replay.NewTrafficCaptureReader(dsdReplayFilePath, depth, dsdMmapReplay)
 	if reader != nil {
 		defer reader.Close()
 	}

--- a/pkg/dogstatsd/replay/reader.go
+++ b/pkg/dogstatsd/replay/reader.go
@@ -35,10 +35,10 @@ type TrafficCaptureReader struct {
 }
 
 // NewTrafficCaptureReader creates a TrafficCaptureReader instance
-func NewTrafficCaptureReader(path string, depth int) (*TrafficCaptureReader, error) {
+func NewTrafficCaptureReader(path string, depth int, mmap bool) (*TrafficCaptureReader, error) {
 
 	// MMap file so that we can have reasonable performance with very large files
-	c, err := getFileMap(path)
+	c, err := getFileMap(path, mmap)
 	if err != nil {
 		fmt.Printf("Unable to map file: %v\n", err)
 		return nil, err

--- a/pkg/dogstatsd/replay/reader.go
+++ b/pkg/dogstatsd/replay/reader.go
@@ -37,8 +37,7 @@ type TrafficCaptureReader struct {
 // NewTrafficCaptureReader creates a TrafficCaptureReader instance
 func NewTrafficCaptureReader(path string, depth int, mmap bool) (*TrafficCaptureReader, error) {
 
-	// MMap file so that we can have reasonable performance with very large files
-	c, err := getFileMap(path, mmap)
+	c, err := getFileContent(path, mmap)
 	if err != nil {
 		fmt.Printf("Unable to map file: %v\n", err)
 		return nil, err

--- a/pkg/dogstatsd/replay/reader_nix.go
+++ b/pkg/dogstatsd/replay/reader_nix.go
@@ -8,12 +8,17 @@
 package replay
 
 import (
+	"io/ioutil"
 	"os"
 
 	"golang.org/x/sys/unix"
 )
 
-func getFileMap(path string) ([]byte, error) {
+func getFileMap(path string, mmap bool) ([]byte, error) {
+
+	if !mmap {
+		return ioutil.ReadFile(path)
+	}
 
 	f, err := os.Open(path)
 	if err != nil {

--- a/pkg/dogstatsd/replay/reader_nix.go
+++ b/pkg/dogstatsd/replay/reader_nix.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !windows
 // +build !windows
 
 package replay
@@ -14,7 +15,10 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func getFileMap(path string, mmap bool) ([]byte, error) {
+// getFileContent returns a slice of bytes with the contents of the file specified in the path.
+// The mmap flag will try to MMap file so as to achieve reasonable performance with very large
+// files while not loading the entire thing into memory.
+func getFileContent(path string, mmap bool) ([]byte, error) {
 
 	if !mmap {
 		return ioutil.ReadFile(path)

--- a/pkg/dogstatsd/replay/reader_test.go
+++ b/pkg/dogstatsd/replay/reader_test.go
@@ -12,9 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func readerTest(t *testing.T, path string) {
+func readerTest(t *testing.T, path string, mmap bool) {
 	// well-formed input file
-	tc, err := NewTrafficCaptureReader(path, 1)
+	tc, err := NewTrafficCaptureReader(path, 1, mmap)
 	assert.Nil(t, err)
 	assert.NotNil(t, tc)
 
@@ -46,16 +46,24 @@ func readerTest(t *testing.T, path string) {
 }
 
 func TestReader(t *testing.T) {
-	readerTest(t, "resources/test/datadog-capture.dog")
+	readerTest(t, "resources/test/datadog-capture.dog", true)
 }
 
 func TestReaderZstd(t *testing.T) {
-	readerTest(t, "resources/test/datadog-capture.dog.zstd")
+	readerTest(t, "resources/test/datadog-capture.dog.zstd", true)
+}
+
+func TestReaderNoMmap(t *testing.T) {
+	readerTest(t, "resources/test/datadog-capture.dog", false)
+}
+
+func TestReaderZstdNoMmap(t *testing.T) {
+	readerTest(t, "resources/test/datadog-capture.dog.zstd", false)
 }
 
 func TestSeek(t *testing.T) {
 	// well-formed input file
-	tc, err := NewTrafficCaptureReader("resources/test/datadog-capture.dog.zstd", 1)
+	tc, err := NewTrafficCaptureReader("resources/test/datadog-capture.dog.zstd", 1, true)
 	assert.Nil(t, err)
 	assert.NotNil(t, tc)
 

--- a/pkg/dogstatsd/replay/reader_windows.go
+++ b/pkg/dogstatsd/replay/reader_windows.go
@@ -9,6 +9,7 @@ package replay
 
 import (
 	"errors"
+	"io/ioutil"
 	"os"
 	"reflect"
 	"sync"
@@ -33,7 +34,11 @@ func (m *memoryMap) header() *reflect.SliceHeader {
 	return (*reflect.SliceHeader)(unsafe.Pointer(m))
 }
 
-func getFileMap(path string) ([]byte, error) {
+func getFileMap(path string, mmap bool) ([]byte, error) {
+
+	if !mmap {
+		return ioutil.ReadFile(path)
+	}
 
 	f, err := os.Open(path)
 	if err != nil {

--- a/pkg/dogstatsd/replay/reader_windows.go
+++ b/pkg/dogstatsd/replay/reader_windows.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build windows
 // +build windows
 
 package replay
@@ -34,7 +35,10 @@ func (m *memoryMap) header() *reflect.SliceHeader {
 	return (*reflect.SliceHeader)(unsafe.Pointer(m))
 }
 
-func getFileMap(path string, mmap bool) ([]byte, error) {
+// getFileContent returns a slice of bytes with the contents of the file specified in the path.
+// The mmap flag will try to Map the file so as to achieve reasonable performance with very large
+// files while not loading the entire thing into memory.
+func getFileContent(path string, mmap bool) ([]byte, error) {
 
 	if !mmap {
 		return ioutil.ReadFile(path)

--- a/releasenotes/notes/dogstatsd-replay-nommap-9648eef0f6f47488.yaml
+++ b/releasenotes/notes/dogstatsd-replay-nommap-9648eef0f6f47488.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    Allow replay files to be fully loaded into memory as opposed
+    Allow dogstatsd replay files to be fully loaded into memory as opposed
     to relying on MMAP. We still default to MMAPing replay targets.

--- a/releasenotes/notes/dogstatsd-replay-nommap-9648eef0f6f47488.yaml
+++ b/releasenotes/notes/dogstatsd-replay-nommap-9648eef0f6f47488.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Allow replay files to be fully loaded into memory as opposed
+    to relying on MMAP. We still default to MMAPing replay targets.


### PR DESCRIPTION
### What does this PR do?

This PR allows us to replay files loading them entirely into memory explicitly. Our default mode will rely on MMAP, which is preferable, especially for larger files. But in certain scenarios (ie. remote filesystems, smaller files, etc), forcing a full read of the file into memory might be useful. This mode also offers the most performant alternative if resources are available.  

### Motivation

This was originally something we had considered but the implementation was finally triggered by the behavior in our benchmark environment where capture files are read from a GCS buckets. The latency, and ways in which gcsfuse work was causing issues with MMAP'd files, so this not only provided a workaround, but was also a straight-forward, performant approach that had been previously considered. 

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

To test these changes, find a replay file and make sure both replay modes work correctly:

```
datadog-agent -c /etc/dastadog-agent/datadog.yaml dogstatsd-replay -f /some/replay/file -l 1 
datadog-agent -c /etc/dastadog-agent/datadog.yaml dogstatsd-replay -f /some/replay/file -l 1 -m=true   # this and the above are identical
datadog-agent -c /etc/dastadog-agent/datadog.yaml dogstatsd-replay -f /some/replay/file -l 1 -m=false
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
