### PR TITLE
[CI] fix e2e setup script

### DIFF
--- a/test/e2e/README.md
+++ b/test/e2e/README.md
@@ -41,13 +41,13 @@ There are 3 main directories:
 
 ```bash
 $ cd ${GOPATH}/src/github.com/DataDog/datadog-agent 
-$ aws-vault exec ${DEV} -- inv -e e2e-tests -t dev --image datadog/agent-dev:master
+$ aws-vault exec ${DEV} -- inv -e e2e-tests -t dev --agent-image datadog/agent-dev:master --dca-image datadog/cluster-agent-dev:master
 ```
 
 ### Locally (Linux only)
 
 ```bash
-$ inv -e e2e-tests -t local --image datadog/agent-dev:master
+$ inv -e e2e-tests -t local --agent-image datadog/agent-dev:master --dca-image datadog/cluster-agent-dev:master
 ```
 
 # Argo workflow

--- a/test/e2e/scripts/setup-instance/01-ignition.sh
+++ b/test/e2e/scripts/setup-instance/01-ignition.sh
@@ -9,16 +9,16 @@ ssh-keygen -b 4096 -t rsa -C "datadog" -N "" -f "id_rsa"
 SSH_RSA=$(cat id_rsa.pub)
 
 case "$(uname)" in
-    Linux)  fcct="fcct-$(uname -m)-unknown-linux-gnu";;
-    Darwin) fcct="fcct-$(uname -m)-apple-darwin";;
+    Linux)  butane="butane-$(uname -m)-unknown-linux-gnu";;
+    Darwin) butane="butane-$(uname -m)-apple-darwin";;
 esac
-curl -LOC - "https://github.com/coreos/fcct/releases/download/v0.6.0/${fcct}"
-curl -LO    "https://github.com/coreos/fcct/releases/download/v0.6.0/${fcct}.asc"
+curl -LOC - "https://github.com/coreos/butane/releases/download/v0.13.1/${butane}"
+curl -LO    "https://github.com/coreos/butane/releases/download/v0.13.1/${butane}.asc"
 curl https://getfedora.org/static/fedora.gpg | gpg --import
-gpg --verify "${fcct}.asc" "$fcct"
-chmod +x "$fcct"
+gpg --verify "${butane}.asc" "$butane"
+chmod +x "$butane"
 
-"./$fcct" --pretty --strict <<EOF | tee ignition.json
+"./$butane" --pretty --strict <<EOF | tee ignition.json
 variant: fcos
 version: 1.1.0
 passwd:


### PR DESCRIPTION
### What does this PR do?

Updates setup script used for e2e tests due to CoreOS update of `fcct` to `butane`
https://docs.fedoraproject.org/en-US/fedora-coreos/producing-ign/#_standalone_binary

### Motivation

Fix broken k8s-e2e-main job

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [X] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
