### PR TITLE
Fix a regression preventing docker and kubelet retries

### DIFF
--- a/pkg/util/retry/retrier.go
+++ b/pkg/util/retry/retrier.go
@@ -80,11 +80,9 @@ func (r *Retrier) NextRetry() time.Time {
 }
 
 // LastError allows users to know what the last retry failure error was
-func (r *Retrier) LastError() error {
-	r.RLock()
-	defer r.RUnlock()
-
-	return r.lastTryError
+func (r *Retrier) LastError() *Error {
+	// Thread safety is handled by wrapError
+	return r.wrapError(r.lastTryError)
 }
 
 // TriggerRetry triggers a new retry and returns the result

--- a/releasenotes/notes/docker-kubelet-retry-fix-9bae7e5a5902d429.yaml
+++ b/releasenotes/notes/docker-kubelet-retry-fix-9bae7e5a5902d429.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixed a regression that was preventing the Agent from retrying kubelet and docker connections in case of failure.


### PR DESCRIPTION
### What does this PR do?

Fixed a regression that was preventing the Agent from retrying kubelet and docker connections in case of failure.

### Motivation

Bug fix

### Additional Notes

Regression introduced by https://github.com/DataDog/datadog-agent/pull/8148 and impacting Agent 7.29+

### Describe how to test your changes

Just run the agent with wrong docker and kubelet configs, make sure it retries the connection and doesn't consider it a permanent failure at the first try.

```
docker run -d --name dd-agent -v /proc/:/host/proc/:ro -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro -e DD_API_KEY=xxx -e DD_AUTOCONFIG_INCLUDE_FEATURES="kubernetes docker" -e DOCKER_HOST="/var/run/fake-docker.sock" -e DD_KUBERNETES_KUBELET_HOST=foo datadog/agent:<version including this fix>
```

The Agent logs shouldn't print permanent failures

```
2021-10-05 07:56:40 UTC | CORE | ERROR | (pkg/autodiscovery/config_poller.go:128 in collect) | Unable to collect configurations from provider docker: temporary failure in dockerutil, will retry later: unable to parse docker host `/var/run/fake-docker.sock`
...
2021-10-05 07:57:11 UTC | CORE | ERROR | (pkg/autodiscovery/config_poller.go:128 in collect) | Unable to collect configurations from provider kubernetes: temporary failure in kubeutil, will retry later: impossible to reach Kubelet with host: foo. Please check if your setup requires kubelet_tls_verify = false. Activate debug logs to see all attempts made
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
