### PR TITLE
Removed host from ProcessDiscovery message

### DIFF
--- a/pkg/process/checks/process_discovery_check.go
+++ b/pkg/process/checks/process_discovery_check.go
@@ -52,7 +52,7 @@ func (d *ProcessDiscoveryCheck) Run(cfg *config.AgentConfig, groupID int32) ([]m
 		NumCpus:     calculateNumCores(d.info),
 		TotalMemory: d.info.TotalMemory,
 	}
-	procDiscoveryChunks := chunkProcessDiscoveries(pidMapToProcDiscoveries(procs, host), cfg.MaxPerMessage)
+	procDiscoveryChunks := chunkProcessDiscoveries(pidMapToProcDiscoveries(procs), cfg.MaxPerMessage)
 	payload := make([]model.MessageBody, len(procDiscoveryChunks))
 	for i, procDiscoveryChunk := range procDiscoveryChunks {
 		payload[i] = &model.CollectorProcDiscovery{
@@ -67,13 +67,12 @@ func (d *ProcessDiscoveryCheck) Run(cfg *config.AgentConfig, groupID int32) ([]m
 	return payload, nil
 }
 
-func pidMapToProcDiscoveries(pidMap map[int32]*procutil.Process, host *model.Host) []*model.ProcessDiscovery {
+func pidMapToProcDiscoveries(pidMap map[int32]*procutil.Process) []*model.ProcessDiscovery {
 	pd := make([]*model.ProcessDiscovery, 0, len(pidMap))
 	for _, proc := range pidMap {
 		pd = append(pd, &model.ProcessDiscovery{
 			Pid:        proc.Pid,
 			NsPid:      proc.NsPid,
-			Host:       host,
 			Command:    formatCommand(proc),
 			User:       formatUser(proc),
 			CreateTime: proc.Stats.CreateTime,

--- a/pkg/process/checks/process_discovery_check_test.go
+++ b/pkg/process/checks/process_discovery_check_test.go
@@ -23,7 +23,9 @@ func TestProcessDiscoveryCheck(t *testing.T) {
 	for _, elem := range result {
 		assert.IsType(t, &model.CollectorProcDiscovery{}, elem)
 		collectorProcDiscovery := elem.(*model.CollectorProcDiscovery)
-
+		for _, proc := range collectorProcDiscovery.ProcessDiscoveries {
+			assert.Empty(t, proc.Host)
+		}
 		if len(collectorProcDiscovery.ProcessDiscoveries) > cfg.MaxPerMessage {
 			t.Errorf("Expected less than %d messages in chunk, got %d",
 				cfg.MaxPerMessage, len(collectorProcDiscovery.ProcessDiscoveries))


### PR DESCRIPTION
### What does this PR do?
Originally, host info was put into every ProcessDiscovery message. This PR makes that field nil.

### Motivation
If we were to continue to put host data into ProcessDiscovery we would see an unnecessary O(n) increase in space complexity for Process Discovery payloads.

### Additional Notes

### Describe how to test your changes
Run `process-agent --check process_discovery` and make sure that host info is not duplicated in the ProcessDiscovery payload.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
