### PR TITLE
Remove all unnecessary files from nikos embedded dir

### DIFF
--- a/omnibus/config/software/system-probe.rb
+++ b/omnibus/config/software/system-probe.rb
@@ -38,10 +38,18 @@ build do
   if ENV.has_key?('NIKOS_PATH') and not ENV['NIKOS_PATH'].empty?
     copy "#{ENV['NIKOS_PATH']}/bin/gpg", "#{install_dir}/embedded/nikos/embedded/bin/"
     copy "#{ENV['NIKOS_PATH']}/lib/rpm", "#{install_dir}/embedded/nikos/embedded/lib/"
-    copy "#{ENV['NIKOS_PATH']}/lib/libreadline.s*", "#{install_dir}/embedded/nikos/embedded/lib/"
-    copy "#{ENV['NIKOS_PATH']}/lib/libncursesw.s* ", "#{install_dir}/embedded/nikos/embedded/lib/"
-    copy "#{ENV['NIKOS_PATH']}/lib/libtinfow.s* ", "#{install_dir}/embedded/nikos/embedded/lib/"
-    copy "#{ENV['NIKOS_PATH']}/lib/libtinfo.s* ", "#{install_dir}/embedded/nikos/embedded/lib/"
+    copy "#{ENV['NIKOS_PATH']}/lib/libreadline.so", "#{install_dir}/embedded/nikos/embedded/lib/"
+    copy "#{ENV['NIKOS_PATH']}/lib/libreadline.so.8", "#{install_dir}/embedded/nikos/embedded/lib/"
+    copy "#{ENV['NIKOS_PATH']}/lib/libreadline.so.8.0", "#{install_dir}/embedded/nikos/embedded/lib/"
+    copy "#{ENV['NIKOS_PATH']}/lib/libncursesw.so", "#{install_dir}/embedded/nikos/embedded/lib/"
+    copy "#{ENV['NIKOS_PATH']}/lib/libncursesw.so.5", "#{install_dir}/embedded/nikos/embedded/lib/"
+    copy "#{ENV['NIKOS_PATH']}/lib/libncursesw.so.5.9", "#{install_dir}/embedded/nikos/embedded/lib/"
+    copy "#{ENV['NIKOS_PATH']}/lib/libtinfow.so", "#{install_dir}/embedded/nikos/embedded/lib/"
+    copy "#{ENV['NIKOS_PATH']}/lib/libtinfow.so.5", "#{install_dir}/embedded/nikos/embedded/lib/"
+    copy "#{ENV['NIKOS_PATH']}/lib/libtinfow.so.5.9", "#{install_dir}/embedded/nikos/embedded/lib/"
+    copy "#{ENV['NIKOS_PATH']}/lib/libtinfo.so", "#{install_dir}/embedded/nikos/embedded/lib/"
+    copy "#{ENV['NIKOS_PATH']}/lib/libtinfo.so.5", "#{install_dir}/embedded/nikos/embedded/lib/"
+    copy "#{ENV['NIKOS_PATH']}/lib/libtinfo.so.5.9", "#{install_dir}/embedded/nikos/embedded/lib/"
     copy "#{ENV['NIKOS_PATH']}/ssl", "#{install_dir}/embedded/nikos/embedded/"
   end
 end

--- a/omnibus/config/software/system-probe.rb
+++ b/omnibus/config/software/system-probe.rb
@@ -38,6 +38,10 @@ build do
   if ENV.has_key?('NIKOS_PATH') and not ENV['NIKOS_PATH'].empty?
     copy "#{ENV['NIKOS_PATH']}/bin/gpg", "#{install_dir}/embedded/nikos/embedded/bin/"
     copy "#{ENV['NIKOS_PATH']}/lib/rpm", "#{install_dir}/embedded/nikos/embedded/lib/"
+    command "rm #{install_dir}/embedded/nikos/embedded/lib/rpm/debugedit"
+    command "rm #{install_dir}/embedded/nikos/embedded/lib/rpm/elfdeps"
+    command "rm #{install_dir}/embedded/nikos/embedded/lib/rpm/rpmdeps"
+    command "rm #{install_dir}/embedded/nikos/embedded/lib/rpm/sepdebugcrcfix"
     copy "#{ENV['NIKOS_PATH']}/lib/libreadline.so", "#{install_dir}/embedded/nikos/embedded/lib/"
     copy "#{ENV['NIKOS_PATH']}/lib/libreadline.so.8", "#{install_dir}/embedded/nikos/embedded/lib/"
     copy "#{ENV['NIKOS_PATH']}/lib/libreadline.so.8.0", "#{install_dir}/embedded/nikos/embedded/lib/"

--- a/omnibus/config/software/system-probe.rb
+++ b/omnibus/config/software/system-probe.rb
@@ -11,7 +11,8 @@ relative_path 'src/github.com/DataDog/datadog-agent'
 build do
   mkdir "#{install_dir}/embedded/share/system-probe/ebpf"
   mkdir "#{install_dir}/embedded/share/system-probe/ebpf/runtime"
-  mkdir "#{install_dir}/embedded/nikos/embedded"
+  mkdir "#{install_dir}/embedded/nikos/embedded/bin"
+  mkdir "#{install_dir}/embedded/nikos/embedded/lib"
 
   if ENV.has_key?('SYSTEM_PROBE_BIN') and not ENV['SYSTEM_PROBE_BIN'].empty?
     copy "#{ENV['SYSTEM_PROBE_BIN']}/system-probe", "#{install_dir}/embedded/bin/system-probe"
@@ -35,6 +36,12 @@ build do
   copy 'pkg/ebpf/c/COPYING', "#{install_dir}/embedded/share/system-probe/ebpf/"
 
   if ENV.has_key?('NIKOS_PATH') and not ENV['NIKOS_PATH'].empty?
-    copy "#{ENV['NIKOS_PATH']}/*", "#{install_dir}/embedded/nikos/embedded/"
+    copy "#{ENV['NIKOS_PATH']}/bin/gpg", "#{install_dir}/embedded/nikos/embedded/bin/"
+    copy "#{ENV['NIKOS_PATH']}/lib/rpm", "#{install_dir}/embedded/nikos/embedded/lib/"
+    copy "#{ENV['NIKOS_PATH']}/lib/libreadline.s*", "#{install_dir}/embedded/nikos/embedded/lib/"
+    copy "#{ENV['NIKOS_PATH']}/lib/libncursesw.s* ", "#{install_dir}/embedded/nikos/embedded/lib/"
+    copy "#{ENV['NIKOS_PATH']}/lib/libtinfow.s* ", "#{install_dir}/embedded/nikos/embedded/lib/"
+    copy "#{ENV['NIKOS_PATH']}/lib/libtinfo.s* ", "#{install_dir}/embedded/nikos/embedded/lib/"
+    copy "#{ENV['NIKOS_PATH']}/ssl", "#{install_dir}/embedded/nikos/embedded/"
   end
 end


### PR DESCRIPTION
### What does this PR do?

Reduces the size of the embedded `nikos` directory by removing all files that aren't necessary at runtime.

This brings the agent package size down from ~307 MB to ~235 MB.

### Motivation

The `nikos` directory previously included all of the files which the `omnibus-nikos` project creates, which was bloating the datadog-agent package.

### Additional Notes

A corresponding change in the DataDog/nikos repository has tested that the files we are including in the agent package are sufficient for `nikos` to function as expected: https://github.com/DataDog/nikos/pull/19

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
