### PR TITLE
[pkg/otlp] Use same version as Agent

### DIFF
--- a/pkg/otlp/collector.go
+++ b/pkg/otlp/collector.go
@@ -71,15 +71,10 @@ func getComponents(s serializer.MetricSerializer) (
 }
 
 func getBuildInfo() (component.BuildInfo, error) {
-	version, err := version.Agent()
-	if err != nil {
-		return component.BuildInfo{}, err
-	}
-
 	return component.BuildInfo{
 		Command:     flavor.GetFlavor(),
 		Description: flavor.GetFlavor(),
-		Version:     version.String(),
+		Version:     version.AgentVersion,
 	}, nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Use `version.AgentVersion` instead of `version.Agent().String()`

### Motivation

Have the same version in logs as in `datadog-agent status`.

### Additional Notes

Reported by @KSerrania .

### Describe how to test your changes

Run Agent with OTLP support enabled and check the version string.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
