### PR TITLE
Remove processes team as code owner of .gitlab/internal_deploy.yml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -67,7 +67,7 @@
 
 /.gitlab/image_scan.yml                              @DataDog/container-integrations @DataDog/agent-platform
 
-/.gitlab/internal_deploy.yml                         @DataDog/processes @DataDog/agent-network @DataDog/agent-platform
+/.gitlab/internal_deploy.yml                         @DataDog/agent-network @DataDog/agent-platform
 
 /.gitlab/internal_image_deploy.yml                   @DataDog/container-integrations @DataDog/agent-platform
 


### PR DESCRIPTION
### What does this PR do?

Removes the Processes team as a code owner of `.gitlab/internal_deploy.yml`

### Motivation

Cleanup

### Additional Notes

None

### Describe how to test your changes

N/A

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.

Note: Adding GitHub labels is only possible for contributors with write access.
