### PR TITLE
Fix e2e tests 

### DIFF
--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -38,8 +38,8 @@ k8s-e2e-dev:
 k8s-e2e-main:
   extends: .k8s_e2e_template
   allow_failure: true # temporary while investigating
-  # rules:
-  #   !reference [.on_main]
+  rules:
+    !reference [.on_main]
   # needs:
   #   - dev_master-a6
   #   - dev_master-a7

--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -38,8 +38,8 @@ k8s-e2e-dev:
 k8s-e2e-main:
   extends: .k8s_e2e_template
   allow_failure: true # temporary while investigating
-  rules:
-    !reference [.on_main]
+  # rules:
+  #   !reference [.on_main]
   # needs:
   #   - dev_master-a6
   #   - dev_master-a7

--- a/test/e2e/scripts/setup-instance/01-ignition.sh
+++ b/test/e2e/scripts/setup-instance/01-ignition.sh
@@ -12,8 +12,8 @@ case "$(uname)" in
     Linux)  butane="butane-$(uname -m)-unknown-linux-gnu";;
     Darwin) butane="butane-$(uname -m)-apple-darwin";;
 esac
-curl -LOC - "https://github.com/coreos/butane/releases/download/v0.13.1/${butane}"
-curl -LO    "https://github.com/coreos/butane/releases/download/v0.13.1/${butane}.asc"
+curl -LOC - "https://github.com/coreos/butane/releases/download/v0.11.0/${butane}"
+curl -LO    "https://github.com/coreos/butane/releases/download/v0.11.0/${butane}.asc"
 curl https://getfedora.org/static/fedora.gpg | gpg --import
 gpg --verify "${butane}.asc" "$butane"
 chmod +x "$butane"

--- a/test/e2e/scripts/setup-instance/01-ignition.sh
+++ b/test/e2e/scripts/setup-instance/01-ignition.sh
@@ -9,16 +9,47 @@ ssh-keygen -b 4096 -t rsa -C "datadog" -N "" -f "id_rsa"
 SSH_RSA=$(cat id_rsa.pub)
 
 case "$(uname)" in
-    Linux)  butane="butane-$(uname -m)-unknown-linux-gnu";;
-    Darwin) butane="butane-$(uname -m)-apple-darwin";;
+    Linux)  fcct="fcct-$(uname -m)-unknown-linux-gnu";;
+    Darwin) fcct="fcct-$(uname -m)-apple-darwin";;
 esac
-curl -LOC - "https://github.com/coreos/butane/releases/download/v0.11.0/${butane}"
-curl -LO    "https://github.com/coreos/butane/releases/download/v0.11.0/${butane}.asc"
-curl https://getfedora.org/static/fedora.gpg | gpg --import
-gpg --verify "${butane}.asc" "$butane"
-chmod +x "$butane"
+curl -LOC - "https://github.com/coreos/butane/releases/download/v0.6.0/${fcct}"
+curl -LO    "https://github.com/coreos/butane/releases/download/v0.6.0/${fcct}.asc"
 
-"./$butane" --pretty --strict <<EOF | tee ignition.json
+gpg --import <<EOF
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+
+mQINBF1RVqsBEADWMBqYv/G1r4PwyiPQCfg5fXFGXV1FCZ32qMi9gLUTv1CX7rYy
+H4Inj93oic+lt1kQ0kQCkINOwQczOkm6XDkEekmMrHknJpFLwrTK4AS28bYF2RjL
+M+QJ/dGXDMPYsP0tkLvoxaHr9WTRq89A+AmONcUAQIMJg3JxXAAafBi2UszUUEPI
+U35MyufFt2ePd1k/6hVAO8S2VT72TxXSY7Ha4X2J0pGzbqQ6Dq3AVzogsnoIi09A
+7fYutYZPVVAEGRUqavl0th8LyuZShASZ38CdAHBMvWV4bVZghd/wDV5ev3LXUE0o
+itLAqNSeiDJ3grKWN6v0qdU0l3Ya60sugABd3xaE+ROe8kDCy3WmAaO51Q880ZA2
+iXOTJFObqkBTP9j9+ZeQ+KNE8SBoiH1EybKtBU8HmygZvu8ZC1TKUyL5gwGUJt8v
+ergy5Bw3Q7av520sNGD3cIWr4fBAVYwdBoZT8RcsnU1PP67NmOGFcwSFJ/LpiOMC
+pZ1IBvjOC7KyKEZY2/63kjW73mB7OHOd18BHtGVkA3QAdVlcSule/z68VOAy6bih
+E6mdxP28D4INsts8w6yr4G+3aEIN8u0qRQq66Ri5mOXTyle+ONudtfGg3U9lgicg
+z6oVk17RT0jV9uL6K41sGZ1sH/6yTXQKagdAYr3w1ix2L46JgzC+/+6SSwARAQAB
+tDFGZWRvcmEgKDMyKSA8ZmVkb3JhLTMyLXByaW1hcnlAZmVkb3JhcHJvamVjdC5v
+cmc+iQI4BBMBAgAiBQJdUVarAhsPBgsJCAcDAgYVCAIJCgsEFgIDAQIeAQIXgAAK
+CRBsEwJtEslE0LdAD/wKdAMtfzr7O2y06/sOPnrb3D39Y2DXbB8y0iEmRdBL29Bq
+5btxwmAka7JZRJVFxPsOVqZ6KARjS0/oCBmJc0jCRANFCtM4UjVHTSsxrJfuPkel
+vrlNE9tcR6OCRpuj/PZgUa39iifF/FTUfDgh4Q91xiQoLqfBxOJzravQHoK9VzrM
+NTOu6J6l4zeGzY/ocj6DpT+5fdUO/3HgGFNiNYPC6GVzeiA3AAVR0sCyGENuqqdg
+wUxV3BIht05M5Wcdvxg1U9x5I3yjkLQw+idvX4pevTiCh9/0u+4g80cT/21Cxsdx
+7+DVHaewXbF87QQIcOAing0S5QE67r2uPVxmWy/56TKUqDoyP8SNsV62lT2jutsj
+LevNxUky011g5w3bc61UeaeKrrurFdRs+RwBVkXmtqm/i6g0ZTWZyWGO6gJd+HWA
+qY1NYiq4+cMvNLatmA2sOoCsRNmE9q6jM/ESVgaH8hSp8GcLuzt9/r4PZZGl5CvU
+eldOiD221u8rzuHmLs4dsgwJJ9pgLT0cUAsOpbMPI0JpGIPQ2SG6yK7LmO6HFOxb
+Akz7IGUt0gy1MzPTyBvnB+WgD1I+IQXXsJbhP5+d+d3mOnqsd6oDM/grKBzrhoUe
+oNadc9uzjqKlOrmrdIR3Bz38SSiWlde5fu6xPqJdmGZRNjXtcyJlbSPVDIloxw==
+=QWRO
+-----END PGP PUBLIC KEY BLOCK-----
+EOF
+
+gpg --verify "${fcct}.asc" "$fcct"
+chmod +x "$fcct"
+
+"./$fcct" --pretty --strict <<EOF | tee ignition.json
 variant: fcos
 version: 1.1.0
 passwd:


### PR DESCRIPTION
### What does this PR do?

This is a follow up to https://github.com/DataDog/datadog-agent/pull/9379

It was discovered that the base image we use does not include a late-enough version of a dependency (glibc), so this PR reverts back to the original fcct version. However, the gpg key seems to have been phased out of those returned from `https://getfedora.org/static/fedora.gpg`, so including a copy directly in the script.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [X] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
