### PR TITLE
[networks] Remove double channel send

### DIFF
--- a/pkg/network/tracer/connection/kprobe/perf_batching_test.go
+++ b/pkg/network/tracer/connection/kprobe/perf_batching_test.go
@@ -141,7 +141,7 @@ func newTestBatchManager(t *testing.T) (*perfBatchManager, func()) {
 	require.NoError(t, err)
 
 	tr := ctr.(*kprobeTracer)
-	tr.Start()
+	tr.Start(func(_ []network.ConnectionStats) {})
 	manager := tr.closeConsumer.batchManager
 	doneFn := func() { tr.Stop() }
 	return manager, doneFn

--- a/pkg/network/tracer/connection/tracer.go
+++ b/pkg/network/tracer/connection/tracer.go
@@ -1,8 +1,6 @@
 package connection
 
 import (
-	"sync"
-
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/ebpf"
 )
@@ -10,17 +8,14 @@ import (
 // Tracer is the common interface implemented by all connection tracers.
 type Tracer interface {
 	// Start begins collecting network connection data.
-	// It returns a channel which contains closed connections batches as they arrive
-	Start() (<-chan *ClosedBatch, error)
+	Start(func([]network.ConnectionStats)) error
 	// Stop halts all network data collection.
 	Stop()
 	// GetConnections returns the list of currently active connections, using the buffer provided.
 	// The optional filter function is used to prevent unwanted connections from being returned and consuming resources.
 	GetConnections(buffer *network.ConnectionBuffer, filter func(*network.ConnectionStats) bool) error
-	// FlushPending forces any closed connections waiting for batching to be returned immediately.
-	// This allows synchronous processing to occur, rather than waiting an unknown amount of time for closed connections
-	// to appear on the channel returned from Start.
-	FlushPending() *ClosedBatch
+	// FlushPending forces any closed connections waiting for batching to be processed immediately.
+	FlushPending()
 	// Remove deletes the connection from tracking state.
 	// It does not prevent the connection from re-appearing later, if additional traffic occurs.
 	Remove(conn *network.ConnectionStats) error
@@ -31,34 +26,4 @@ type Tracer interface {
 	GetMap(string) *ebpf.Map
 	// DumpMaps (for debugging purpose) returns all maps content by default or selected maps from maps parameter.
 	DumpMaps(maps ...string) (string, error)
-}
-
-// ClosedBatch encapsulates a short-lived (pooled) buffer for closed connections
-type ClosedBatch struct {
-	Buffer *network.ConnectionBuffer
-}
-
-// Release underlying buffer so it can be re-used
-func (c *ClosedBatch) Release() {
-	if c.Buffer.Capacity() != batchSize {
-		return
-	}
-
-	c.Buffer.Reset()
-	batchPool.Put(c)
-}
-
-// GetBatch from the pool
-func GetBatch() *ClosedBatch {
-	return batchPool.Get().(*ClosedBatch)
-}
-
-const batchSize = 5
-
-var batchPool = sync.Pool{
-	New: func() interface{} {
-		return &ClosedBatch{
-			Buffer: network.NewConnectionBuffer(batchSize, batchSize),
-		}
-	},
 }


### PR DESCRIPTION
### What does this PR do?

Fix a performance regression recently introduced by https://github.com/DataDog/datadog-agent/pull/9040 that was essentially caused by an additional channel send operation in a hot codepath.
To address the increased CPU usage we're replacing the channel-based API for one based on a callback function.

### Motivation

Ensure that system-probe CPU overhead doesn't increase with the introduction of `connection.Tracer` interface

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

This change is covered by unit and integrations tests.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
