### PR TITLE
Fix Winget download path

### DIFF
--- a/tasks/winbuildscripts/Update-Winget.ps1
+++ b/tasks/winbuildscripts/Update-Winget.ps1
@@ -1,7 +1,7 @@
 $ErrorActionPreference = 'Stop';
 Set-Location c:\mnt
 
-(New-Object System.Net.WebClient).DownloadFile("https://github.com/microsoft/winget-create/releases/download/v0.4.0.3-preview/wingetcreate.exe", ".\wingetcreate.exe")
+(New-Object System.Net.WebClient).DownloadFile("https://github.com/microsoft/winget-create/releases/download/v0.4.0.3-preview/wingetcreate.exe", "$(Get-Location)\wingetcreate.exe")
 
 # Install dev tools, including invoke
 pip3 install -r requirements.txt


### PR DESCRIPTION
### What does this PR do?

This PR makes it so that the update script for Winget to use `Get-Location` to store the downloaded `wingetcreate` executable since ".\" doesn't work in `DownloadFile`.

### Motivation

Make the Winget job pass.