### PR TITLE
Remove collect_device_metadata from datadog.yaml

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -633,12 +633,6 @@ api_key:
   #
   # min_collection_interval: 15
 
-  ## @param collect_device_metadata - boolean - optional - default: true
-  ## Enable device metadata collection
-  ## Only available using corecheck SNMP integration with `loader: core` config.
-  #
-  # collect_device_metadata: true
-
   ## @param namespace - string - optional - default: default
   ## Namespace can be used to disambiguate devices with same IPs.
   ## Changing namespace will cause devices being recreated in NDM app.
@@ -766,12 +760,6 @@ api_key:
     ## https://docs.datadoghq.com/developers/write_agent_check/#collection-interval
     #
     # min_collection_interval: 15
-
-    ## @param collect_device_metadata - boolean - optional - default: true
-    ## Enable device metadata collection
-    ## Only available using corecheck SNMP integration with `loader: core` config.
-    #
-    # collect_device_metadata: true
 
     ## @param namespace - string - optional - default: default
     ## Namespace can be used to disambiguate devices with same IPs.


### PR DESCRIPTION
### What does this PR do?

Remove collect_device_metadata from datadog.yaml (the config has been added here https://github.com/DataDog/datadog-agent/pull/9293)

### Motivation

This config is true by default and doesn't need to be visible to the user.

### Additional Notes

### Describe how to test your changes


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
