### PR TITLE
Introduce generic metrics provider and generic container check

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -61,6 +61,7 @@ import (
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/containerd"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/cri"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/docker"
+	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/containers/generic"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/ebpf"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/embed"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/net"

--- a/cmd/agent/dist/conf.d/container.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/container.d/conf.yaml.default
@@ -1,0 +1,5 @@
+ad_identifiers:
+  - _container
+init_config:
+instances:
+  -

--- a/pkg/collector/corechecks/containers/generic/adapters.go
+++ b/pkg/collector/corechecks/containers/generic/adapters.go
@@ -1,0 +1,45 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package generic
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+)
+
+// MetricsAdapter provides a way to change metrics and tags before sending them out
+type MetricsAdapter interface {
+	// AdaptTags can be used to change Tagger tags before submitting the metrics
+	AdaptTags(tags []string, c *workloadmeta.Container) []string
+	// AdaptMetrics can be used to change metrics (change name or value) before submitting the metric.
+	AdaptMetrics(metricName string, value float64) (string, float64)
+}
+
+// ContainerLister abstracts away how to list all known containers
+type ContainerLister interface {
+	List() ([]*workloadmeta.Container, error)
+}
+
+// MetadataContainerLister implements ContainerLister interface using Workload meta service
+type MetadataContainerLister struct{}
+
+// List returns all known containers
+func (l MetadataContainerLister) List() ([]*workloadmeta.Container, error) {
+	return workloadmeta.GetGlobalStore().ListContainers()
+}
+
+// GenericMetricsAdapter implements MetricsAdapter API in a basic way.
+// Adds `runtime` tag and do not change metrics.
+type GenericMetricsAdapter struct{}
+
+// AdaptTags adds a `runtime` tag for all containers
+func (a GenericMetricsAdapter) AdaptTags(tags []string, c *workloadmeta.Container) []string {
+	return append(tags, "runtime:"+string(c.Runtime))
+}
+
+// AdaptMetrics is a passthrough (does not change anything)
+func (a GenericMetricsAdapter) AdaptMetrics(metricName string, value float64) (string, float64) {
+	return metricName, value
+}

--- a/pkg/collector/corechecks/containers/generic/check.go
+++ b/pkg/collector/corechecks/containers/generic/check.go
@@ -1,0 +1,74 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package generic
+
+import (
+	yaml "gopkg.in/yaml.v2"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics"
+)
+
+const (
+	genericContainerCheckName = "container"
+)
+
+// ContainerConfig holds the check configuration
+type ContainerConfig struct{}
+
+// Parse parses the container check config and set default values
+func (c *ContainerConfig) Parse(data []byte) error {
+	return yaml.Unmarshal(data, c)
+}
+
+// ContainerCheck generates metrics for all containers
+type ContainerCheck struct {
+	core.CheckBase
+	instance  *ContainerConfig
+	processor Processor
+}
+
+func init() {
+	core.RegisterCheck("container", ContainerCheckFactory)
+}
+
+// ContainerCheckFactory is exported for integration testing
+func ContainerCheckFactory() check.Check {
+	return &ContainerCheck{
+		CheckBase: core.NewCheckBase(genericContainerCheckName),
+		instance:  &ContainerConfig{},
+	}
+}
+
+// Configure parses the check configuration and init the check
+func (c *ContainerCheck) Configure(config, initConfig integration.Data, source string) error {
+	err := c.CommonConfigure(config, source)
+	if err != nil {
+		return err
+	}
+
+	filter, err := containers.GetSharedMetricFilter()
+	if err != nil {
+		return err
+	}
+
+	c.processor = NewProcessor(metrics.GetProvider(), MetadataContainerLister{}, GenericMetricsAdapter{}, filter)
+	return c.instance.Parse(config)
+}
+
+// Run executes the check
+func (c *ContainerCheck) Run() error {
+	sender, err := aggregator.GetSender(c.ID())
+	if err != nil {
+		return err
+	}
+
+	return c.processor.Run(sender, c.Interval()/2)
+}

--- a/pkg/collector/corechecks/containers/generic/processor.go
+++ b/pkg/collector/corechecks/containers/generic/processor.go
@@ -1,0 +1,174 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package generic
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/security/log"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+)
+
+// Processor contains the core logic of the generic check, allowing reusability
+type Processor struct {
+	metricsProvider metrics.Provider
+	ctrLister       ContainerLister
+	metricsAdapter  MetricsAdapter
+	ctrFilter       *containers.Filter
+}
+
+// NewProcessor creates a new processor
+func NewProcessor(provider metrics.Provider, lister ContainerLister, adapter MetricsAdapter, filter *containers.Filter) Processor {
+	return Processor{
+		metricsProvider: provider,
+		ctrLister:       lister,
+		metricsAdapter:  adapter,
+		ctrFilter:       filter,
+	}
+}
+
+// Run executes the check
+func (p *Processor) Run(sender aggregator.Sender, cacheValidity time.Duration) error {
+	allContainers, err := p.ctrLister.List()
+	if err != nil {
+		return fmt.Errorf("cannot list containers from metadata store, container metrics will be missing, err: %w", err)
+	}
+
+	collectorsCache := make(map[workloadmeta.ContainerRuntime]metrics.Collector)
+	getCollector := func(runtime workloadmeta.ContainerRuntime) metrics.Collector {
+		if collector, found := collectorsCache[runtime]; found {
+			return collector
+		}
+
+		collector := p.metricsProvider.GetCollector(string(runtime))
+		if collector != nil {
+			collectorsCache[runtime] = collector
+		}
+		return collector
+	}
+
+	for _, container := range allContainers {
+		// We surely won't get stats for not running containers
+		if !container.State.Running {
+			continue
+		}
+
+		if p.ctrFilter.IsExcluded(container.Name, container.Image.Name, container.Labels["io.kubernetes.pod.namespace"]) {
+			log.Tracef("Container excluded due to filter, name: %s - image: %s - namespace: %s", container.Name, container.Image.Name, container.Labels["io.kubernetes.pod.namespace"])
+			continue
+		}
+
+		entityID := containers.BuildTaggerEntityName(container.ID)
+		tags, err := tagger.Tag(entityID, collectors.HighCardinality)
+		if err != nil {
+			log.Errorf("Could not collect tags for container %s: %s", container.ID[:12], err)
+			continue
+		}
+		tags = p.metricsAdapter.AdaptTags(tags, container)
+
+		collector := getCollector(container.Runtime)
+		if collector == nil {
+			log.Warnf("Collector not found for container: %v, metrics will ne missing", container)
+			continue
+		}
+
+		containerStats, err := collector.GetContainerStats(container.ID, cacheValidity)
+		if err != nil {
+			log.Debugf("Container stats for: %v not available through collector: %s", container, collector.ID())
+			continue
+		}
+
+		if err := p.processContainer(sender, tags, container, containerStats); err != nil {
+			log.Debugf("Generating metrics for container: %v failed, metrics may be missing, err: %w", container, err)
+			continue
+		}
+
+		// TODO: Implement container stats. We currently don't have enough information from Metadata service to do it.
+	}
+
+	sender.Commit()
+	return nil
+}
+
+func (p *Processor) processContainer(sender aggregator.Sender, tags []string, container *workloadmeta.Container, containerStats *metrics.ContainerStats) error {
+	if uptime := time.Since(container.State.StartedAt); uptime > 0 {
+		p.sendMetric(sender.Gauge, "container.uptime", util.Float64Ptr(uptime.Seconds()), tags)
+	}
+
+	if containerStats.CPU != nil {
+		p.sendMetric(sender.Rate, "container.cpu.usage", containerStats.CPU.Total, tags)
+		p.sendMetric(sender.Rate, "container.cpu.user", containerStats.CPU.User, tags)
+		p.sendMetric(sender.Rate, "container.cpu.system", containerStats.CPU.System, tags)
+		p.sendMetric(sender.Rate, "container.cpu.throttled.time", containerStats.CPU.ThrottledTime, tags)
+		p.sendMetric(sender.Rate, "container.cpu.throttled.periods", containerStats.CPU.ThrottledPeriods, tags)
+		p.sendMetric(sender.Gauge, "container.cpu.shares", containerStats.CPU.Shares, tags)
+		// Convert CPU Limit to nanoseconds to allow easy percentage computation in the App.
+		if containerStats.CPU.Limit != nil {
+			p.sendMetric(sender.Gauge, "container.cpu.limit", util.Float64Ptr(*containerStats.CPU.Limit*float64(time.Second/100)), tags)
+		}
+	}
+
+	if containerStats.Memory != nil {
+		p.sendMetric(sender.Gauge, "container.memory.usage", containerStats.Memory.UsageTotal, tags)
+		p.sendMetric(sender.Gauge, "container.memory.kernel", containerStats.Memory.KernelMemory, tags)
+		p.sendMetric(sender.Gauge, "container.memory.limit", containerStats.Memory.Limit, tags)
+		p.sendMetric(sender.Gauge, "container.memory.soft_limit", containerStats.Memory.Softlimit, tags)
+		p.sendMetric(sender.Gauge, "container.memory.rss", containerStats.Memory.RSS, tags)
+		p.sendMetric(sender.Gauge, "container.memory.cache", containerStats.Memory.Cache, tags)
+		p.sendMetric(sender.Gauge, "container.memory.swap", containerStats.Memory.Swap, tags)
+		p.sendMetric(sender.Gauge, "container.memory.oomevents", containerStats.Memory.OOMEvents, tags)
+		p.sendMetric(sender.Gauge, "container.memory.working_set", containerStats.Memory.PrivateWorkingSet, tags)
+		p.sendMetric(sender.Gauge, "container.memory.commit", containerStats.Memory.CommitBytes, tags)
+		p.sendMetric(sender.Gauge, "container.memory.commit.peak", containerStats.Memory.CommitPeakBytes, tags)
+	}
+
+	if containerStats.IO != nil {
+		for deviceName, deviceStats := range containerStats.IO.Devices {
+			deviceTags := extraTags(tags, "device_name:"+deviceName)
+			p.sendMetric(sender.Rate, "container.io.read", deviceStats.ReadBytes, deviceTags)
+			p.sendMetric(sender.Rate, "container.io.read.operations", deviceStats.ReadOperations, deviceTags)
+			p.sendMetric(sender.Rate, "container.io.write", deviceStats.WriteBytes, deviceTags)
+			p.sendMetric(sender.Rate, "container.io.write.operations", deviceStats.WriteOperations, deviceTags)
+		}
+
+		if len(containerStats.IO.Devices) == 0 {
+			p.sendMetric(sender.Rate, "container.io.read", containerStats.IO.ReadBytes, tags)
+			p.sendMetric(sender.Rate, "container.io.read.operations", containerStats.IO.ReadOperations, tags)
+			p.sendMetric(sender.Rate, "container.io.write", containerStats.IO.WriteBytes, tags)
+			p.sendMetric(sender.Rate, "container.io.write.operations", containerStats.IO.WriteOperations, tags)
+		}
+	}
+
+	if containerStats.PID != nil {
+		p.sendMetric(sender.Gauge, "container.pid.thread_count", containerStats.PID.ThreadCount, tags)
+		p.sendMetric(sender.Gauge, "container.pid.thread_limit", containerStats.PID.ThreadLimit, tags)
+	}
+
+	return nil
+}
+
+func (p *Processor) sendMetric(senderFunc func(string, float64, string, []string), metricName string, value *float64, tags []string) {
+	if value == nil {
+		return
+	}
+
+	metricName, val := p.metricsAdapter.AdaptMetrics(metricName, *value)
+	senderFunc(metricName, val, "", tags)
+}
+
+func extraTags(tags []string, extraTags ...string) []string {
+	finalTags := make([]string, 0, len(tags)+len(extraTags))
+	finalTags = append(finalTags, tags...)
+	finalTags = append(finalTags, extraTags...)
+	return finalTags
+}

--- a/pkg/collector/corechecks/containers/generic/processor_test.go
+++ b/pkg/collector/corechecks/containers/generic/processor_test.go
@@ -1,0 +1,207 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package generic
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+	"github.com/stretchr/testify/assert"
+)
+
+type mockContainerLister struct {
+	containers []*workloadmeta.Container
+	err        error
+}
+
+func (l *mockContainerLister) List() ([]*workloadmeta.Container, error) {
+	return l.containers, l.err
+}
+
+func createTestProcessor(listerContainers []*workloadmeta.Container, listerError error, metricsContainers map[string]metrics.MockContainerEntry) (*mocksender.MockSender, *Processor) {
+	mockProvider := metrics.NewMockMetricsProvider()
+	mockCollector := metrics.NewMockCollector("testCollector")
+	mockProvider.RegisterCollector("docker", mockCollector)
+	mockProvider.RegisterCollector("containerd", mockCollector)
+	for cID, entry := range metricsContainers {
+		mockCollector.SetContainerEntry(cID, entry)
+	}
+
+	mockLister := mockContainerLister{
+		containers: listerContainers,
+		err:        listerError,
+	}
+
+	filter, _ := containers.GetSharedMetricFilter()
+
+	mockedSender := mocksender.NewMockSender("generic-container")
+	mockedSender.SetupAcceptAll()
+
+	p := &Processor{
+		metricsProvider: mockProvider,
+		ctrLister:       &mockLister,
+		metricsAdapter:  GenericMetricsAdapter{},
+		ctrFilter:       filter,
+	}
+
+	return mockedSender, p
+}
+
+func createContainerMeta(runtime, cID string) *workloadmeta.Container {
+	return &workloadmeta.Container{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindContainer,
+			ID:   cID,
+		},
+		Runtime: workloadmeta.ContainerRuntime(runtime),
+		State: workloadmeta.ContainerState{
+			Running:   true,
+			StartedAt: time.Now(),
+		},
+	}
+}
+
+func TestProcessorRunFullStatsLinux(t *testing.T) {
+	containersMeta := []*workloadmeta.Container{
+		// Container with full stats
+		createContainerMeta("docker", "cID100"),
+	}
+
+	containersStats := map[string]metrics.MockContainerEntry{
+		"cID100": {
+			Error: nil,
+			NetworkStats: metrics.ContainerNetworkStats{
+				BytesSent:   util.Float64Ptr(42),
+				BytesRcvd:   util.Float64Ptr(43),
+				PacketsSent: util.Float64Ptr(420),
+				PacketsRcvd: util.Float64Ptr(421),
+				Interfaces: map[string]metrics.InterfaceNetStats{
+					"eth42": {
+						BytesSent:   util.Float64Ptr(42),
+						BytesRcvd:   util.Float64Ptr(43),
+						PacketsSent: util.Float64Ptr(420),
+						PacketsRcvd: util.Float64Ptr(421),
+					},
+				},
+			},
+			ContainerStats: metrics.ContainerStats{
+				CPU: &metrics.ContainerCPUStats{
+					Total:            util.Float64Ptr(100),
+					System:           util.Float64Ptr(200),
+					User:             util.Float64Ptr(300),
+					Shares:           util.Float64Ptr(400),
+					Limit:            util.Float64Ptr(50),
+					ElapsedPeriods:   util.Float64Ptr(500),
+					ThrottledPeriods: util.Float64Ptr(0),
+					ThrottledTime:    util.Float64Ptr(100),
+				},
+				Memory: &metrics.ContainerMemStats{
+					UsageTotal:   util.Float64Ptr(100),
+					KernelMemory: util.Float64Ptr(40),
+					Limit:        util.Float64Ptr(42000),
+					Softlimit:    util.Float64Ptr(40000),
+					RSS:          util.Float64Ptr(300),
+					Cache:        util.Float64Ptr(200),
+					Swap:         util.Float64Ptr(0),
+					OOMEvents:    util.Float64Ptr(10),
+				},
+				IO: &metrics.ContainerIOStats{
+					Devices: map[string]metrics.DeviceIOStats{
+						"/dev/foo": {
+							ReadBytes:       util.Float64Ptr(100),
+							WriteBytes:      util.Float64Ptr(200),
+							ReadOperations:  util.Float64Ptr(10),
+							WriteOperations: util.Float64Ptr(20),
+						},
+						"/dev/bar": {
+							ReadBytes:       util.Float64Ptr(100),
+							WriteBytes:      util.Float64Ptr(200),
+							ReadOperations:  util.Float64Ptr(10),
+							WriteOperations: util.Float64Ptr(20),
+						},
+					},
+					ReadBytes:       util.Float64Ptr(200),
+					WriteBytes:      util.Float64Ptr(400),
+					ReadOperations:  util.Float64Ptr(20),
+					WriteOperations: util.Float64Ptr(40),
+				},
+				PID: &metrics.ContainerPIDStats{
+					PIDs:        []int{4, 2},
+					ThreadCount: util.Float64Ptr(10),
+					ThreadLimit: util.Float64Ptr(20),
+				},
+			},
+		},
+	}
+
+	mockSender, processor := createTestProcessor(containersMeta, nil, containersStats)
+	err := processor.Run(mockSender, 0)
+	assert.ErrorIs(t, err, nil)
+
+	expectedTags := []string{"runtime:docker"}
+	mockSender.AssertNumberOfCalls(t, "Rate", 13)
+	mockSender.AssertNumberOfCalls(t, "Gauge", 13)
+
+	mockSender.AssertMetricInRange(t, "Gauge", "container.uptime", 0, 600, "", expectedTags)
+	mockSender.AssertMetric(t, "Rate", "container.cpu.usage", 100, "", expectedTags)
+	mockSender.AssertMetric(t, "Rate", "container.cpu.user", 300, "", expectedTags)
+	mockSender.AssertMetric(t, "Rate", "container.cpu.system", 200, "", expectedTags)
+	mockSender.AssertMetric(t, "Rate", "container.cpu.throttled.time", 100, "", expectedTags)
+	mockSender.AssertMetric(t, "Rate", "container.cpu.throttled.periods", 0, "", expectedTags)
+	mockSender.AssertMetric(t, "Gauge", "container.cpu.shares", 400, "", expectedTags)
+	mockSender.AssertMetric(t, "Gauge", "container.cpu.limit", 500000000, "", expectedTags)
+
+	mockSender.AssertMetric(t, "Gauge", "container.memory.usage", 100, "", expectedTags)
+	mockSender.AssertMetric(t, "Gauge", "container.memory.kernel", 40, "", expectedTags)
+	mockSender.AssertMetric(t, "Gauge", "container.memory.limit", 42000, "", expectedTags)
+	mockSender.AssertMetric(t, "Gauge", "container.memory.soft_limit", 40000, "", expectedTags)
+	mockSender.AssertMetric(t, "Gauge", "container.memory.rss", 300, "", expectedTags)
+	mockSender.AssertMetric(t, "Gauge", "container.memory.cache", 200, "", expectedTags)
+	mockSender.AssertMetric(t, "Gauge", "container.memory.swap", 0, "", expectedTags)
+	mockSender.AssertMetric(t, "Gauge", "container.memory.oomevents", 10, "", expectedTags)
+
+	expectedFooTags := extraTags(expectedTags, "device_name:/dev/foo")
+	mockSender.AssertMetric(t, "Rate", "container.io.read", 100, "", expectedFooTags)
+	mockSender.AssertMetric(t, "Rate", "container.io.read.operations", 10, "", expectedFooTags)
+	mockSender.AssertMetric(t, "Rate", "container.io.write", 200, "", expectedFooTags)
+	mockSender.AssertMetric(t, "Rate", "container.io.write.operations", 20, "", expectedFooTags)
+	expectedBarTags := extraTags(expectedTags, "device_name:/dev/bar")
+	mockSender.AssertMetric(t, "Rate", "container.io.read", 100, "", expectedBarTags)
+	mockSender.AssertMetric(t, "Rate", "container.io.read.operations", 10, "", expectedBarTags)
+	mockSender.AssertMetric(t, "Rate", "container.io.write", 200, "", expectedBarTags)
+	mockSender.AssertMetric(t, "Rate", "container.io.write.operations", 20, "", expectedBarTags)
+
+	mockSender.AssertMetric(t, "Gauge", "container.pid.thread_count", 10, "", expectedTags)
+	mockSender.AssertMetric(t, "Gauge", "container.pid.thread_limit", 20, "", expectedTags)
+}
+
+func TestProcessorRunPartialStats(t *testing.T) {
+	containersMeta := []*workloadmeta.Container{
+		// Container without stats
+		createContainerMeta("containerd", "cID201"),
+		// Container with explicit error
+		createContainerMeta("containerd", "cID202"),
+	}
+
+	containersStats := map[string]metrics.MockContainerEntry{
+		"cID202": {
+			Error: fmt.Errorf("Unable to read some stuff"),
+		},
+	}
+
+	mockSender, processor := createTestProcessor(containersMeta, nil, containersStats)
+	err := processor.Run(mockSender, 0)
+	assert.ErrorIs(t, err, nil)
+
+	mockSender.AssertNumberOfCalls(t, "Rate", 0)
+	mockSender.AssertNumberOfCalls(t, "Gauge", 0)
+}

--- a/pkg/util/cgroups/cgroup_shared.go
+++ b/pkg/util/cgroups/cgroup_shared.go
@@ -13,7 +13,10 @@ import (
 	"strings"
 )
 
-// format is 0,1,5-8
+// parseCPUSetFormat counts CPUs in CPUSet specs like "0,1,5-8". These are comma-separated lists
+// of processor IDs, with hyphenated ranges representing closed sets.
+// So "0,1,5-8" represents processors 0, 1, 5, 6, 7, 8.
+// The function returns the count of CPUs, in this case 6.
 func parseCPUSetFormat(line string) uint64 {
 	var numCPUs uint64
 

--- a/pkg/util/cgroups/cgroupv1_io.go
+++ b/pkg/util/cgroups/cgroupv1_io.go
@@ -27,8 +27,8 @@ func (c *cgroupV1) GetIOStats(stats *IOStats) error {
 	stats.ReadOperations = uint64Ptr(0)
 	stats.WriteOperations = uint64Ptr(0)
 
-	c.parseV1blkio(c.pathFor("blkio", "blkio.throttle.io_service_bytes"), stats.Devices, bytesWritter(stats))
-	c.parseV1blkio(c.pathFor("blkio", "blkio.throttle.io_serviced"), stats.Devices, opsWritter(stats))
+	c.parseV1blkio(c.pathFor("blkio", "blkio.throttle.io_service_bytes"), stats.Devices, bytesWriter(stats))
+	c.parseV1blkio(c.pathFor("blkio", "blkio.throttle.io_serviced"), stats.Devices, opsWriter(stats))
 
 	// In case we did not get any device info, clearing everything
 	if len(stats.Devices) == 0 {
@@ -42,7 +42,7 @@ func (c *cgroupV1) GetIOStats(stats *IOStats) error {
 	return nil
 }
 
-func (c *cgroupV1) parseV1blkio(path string, perDevice map[string]DeviceIOStats, writter func(*DeviceIOStats, string, uint64) bool) {
+func (c *cgroupV1) parseV1blkio(path string, perDevice map[string]DeviceIOStats, Writer func(*DeviceIOStats, string, uint64) bool) {
 	if err := parseColumnStats(c.fr, path, func(fields []string) error {
 		if len(fields) < 3 {
 			return nil
@@ -55,7 +55,7 @@ func (c *cgroupV1) parseV1blkio(path string, perDevice map[string]DeviceIOStats,
 		}
 
 		device := perDevice[fields[0]]
-		if writter(&device, fields[1], value) {
+		if Writer(&device, fields[1], value) {
 			perDevice[fields[0]] = device
 		}
 
@@ -65,7 +65,7 @@ func (c *cgroupV1) parseV1blkio(path string, perDevice map[string]DeviceIOStats,
 	}
 }
 
-func bytesWritter(stats *IOStats) func(*DeviceIOStats, string, uint64) bool {
+func bytesWriter(stats *IOStats) func(*DeviceIOStats, string, uint64) bool {
 	return func(device *DeviceIOStats, opType string, value uint64) bool {
 		written := false
 
@@ -84,7 +84,7 @@ func bytesWritter(stats *IOStats) func(*DeviceIOStats, string, uint64) bool {
 	}
 }
 
-func opsWritter(stats *IOStats) func(*DeviceIOStats, string, uint64) bool {
+func opsWriter(stats *IOStats) func(*DeviceIOStats, string, uint64) bool {
 	return func(device *DeviceIOStats, opType string, value uint64) bool {
 		written := false
 

--- a/pkg/util/cgroups/cgroupv1_memory.go
+++ b/pkg/util/cgroups/cgroupv1_memory.go
@@ -16,7 +16,7 @@ import (
 
 // When no memory limit is set, the Kernel returns a maximum value, being computed as:
 // See https://unix.stackexchange.com/questions/420906/what-is-the-value-for-the-cgroups-limit-in-bytes-if-the-memory-is-not-restricte
-var memoryUnlimitedValue = uint64((math.MaxInt64 / os.Getpagesize()) * os.Getpagesize())
+var memoryUnlimitedValue = (uint64(math.MaxInt64) / uint64(os.Getpagesize())) * uint64(os.Getpagesize())
 
 func (c *cgroupV1) GetMemoryStats(stats *MemoryStats) error {
 	if stats == nil {

--- a/pkg/util/cgroups/stats.go
+++ b/pkg/util/cgroups/stats.go
@@ -21,6 +21,9 @@ type PSIStats struct {
 
 // MemoryStats - all metrics in bytes except if otherwise specified
 // All statistics are hierarchical (i.e. includes all descendants)
+// Meaning for each value can be checked at:
+// https://www.kernel.org/doc/Documentation/cgroup-v1/memory.txt
+// or https://www.kernel.org/doc/Documentation/cgroup-v2.txt
 // Source:
 // cgroupv1: memory controller
 // cgroupv2: memory controller

--- a/pkg/util/containers/providers/cgroup/provider.go
+++ b/pkg/util/containers/providers/cgroup/provider.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017-present Datadog, Inmetrics.
 
+//go:build linux
 // +build linux
 
 package cgroup

--- a/pkg/util/containers/v2/metrics/collector.go
+++ b/pkg/util/containers/v2/metrics/collector.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metrics
+
+import "time"
+
+// Collector defines an interface allowing to get stats from a containerID.
+// All implementations should allow for concurrent access.
+type Collector interface {
+	ID() string
+	GetContainerStats(containerID string, cacheValidity time.Duration) (*ContainerStats, error)
+	GetContainerNetworkStats(containerID string, cacheValidity time.Duration, networks map[string]string) (*ContainerNetworkStats, error)
+}

--- a/pkg/util/containers/v2/metrics/collector_disk_linux.go
+++ b/pkg/util/containers/v2/metrics/collector_disk_linux.go
@@ -1,0 +1,112 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package metrics
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	diskMappingCacheExpiration = time.Minute
+)
+
+var diskMappingCacheKey = cache.BuildAgentKey("containers", "disk_mapping")
+
+func buildIOStats(procPath string, cgs *cgroups.IOStats) *ContainerIOStats {
+	if cgs == nil {
+		return nil
+	}
+	cs := &ContainerIOStats{}
+
+	convertField(cgs.ReadBytes, &cs.ReadBytes)
+	convertField(cgs.WriteBytes, &cs.WriteBytes)
+	convertField(cgs.ReadOperations, &cs.ReadOperations)
+	convertField(cgs.WriteOperations, &cs.WriteOperations)
+
+	deviceMapping, err := getDiskDeviceMapping(procPath)
+	if err != nil {
+		log.Debugf("Error while getting disk mapping, no disk metrics will be present, err:  %w", err)
+		return cs
+	}
+
+	csDevicesStats := make(map[string]DeviceIOStats, len(deviceMapping))
+	for deviceID, deviceStats := range cgs.Devices {
+		if deviceName, found := deviceMapping[deviceID]; found {
+			targetDeviceStats := DeviceIOStats{}
+			convertField(deviceStats.ReadBytes, &targetDeviceStats.ReadBytes)
+			convertField(deviceStats.ReadBytes, &targetDeviceStats.ReadBytes)
+			convertField(deviceStats.WriteBytes, &targetDeviceStats.WriteBytes)
+			convertField(deviceStats.ReadOperations, &targetDeviceStats.ReadOperations)
+			convertField(deviceStats.WriteOperations, &targetDeviceStats.WriteOperations)
+
+			csDevicesStats[deviceName] = targetDeviceStats
+		}
+	}
+
+	if len(csDevicesStats) > 0 {
+		cs.Devices = csDevicesStats
+	}
+
+	return cs
+}
+
+// getDiskDeviceMapping scrapes /proc/diskstats to build a mapping from
+// "major:minor" device numbers to device name.
+// It is cached for 1 minute
+// Format:
+// 7       0 loop0 0 0 0 0 0 0 0 0 0 0 0
+// 7       1 loop1 0 0 0 0 0 0 0 0 0 0 0
+// 8       0 sda 24398 2788 1317975 40488 25201 46267 1584744 142336 0 22352 182660
+// 8       1 sda1 24232 2788 1312025 40376 25201 46267 1584744 142336 0 22320 182552
+// 8      16 sdb 189 0 4063 220 0 0 0 0 0 112 204
+func getDiskDeviceMapping(procPath string) (map[string]string, error) {
+	// Cache lookup
+	if cached, hit := cache.Cache.Get(diskMappingCacheKey); hit {
+		if mapping, ok := cached.(map[string]string); ok {
+			return mapping, nil
+		}
+	}
+
+	// Cache miss, parse file
+	statfile := filepath.Join(procPath, "diskstats")
+	f, err := os.Open(statfile)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	mapping := make(map[string]string)
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) < 14 {
+			// malformed line in /proc/diskstats, avoid panic by ignoring.
+			log.Debugf("Malformed line in %s, fields: %v", statfile, fields)
+			continue
+		}
+		mapping[fmt.Sprintf("%s:%s", fields[0], fields[1])] = fields[2]
+	}
+	if err := scanner.Err(); err != nil {
+		log.Debugf("Error while reading %s, disk metrics may be missing, err:  %w", statfile, err)
+		return mapping, nil
+	}
+
+	// Keep value in cache
+	cache.Cache.Set(diskMappingCacheKey, mapping, diskMappingCacheExpiration)
+	return mapping, nil
+}

--- a/pkg/util/containers/v2/metrics/collector_disk_linux_test.go
+++ b/pkg/util/containers/v2/metrics/collector_disk_linux_test.go
@@ -1,0 +1,88 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/testutil"
+)
+
+type DiskMappingTestSuite struct {
+	suite.Suite
+	proc *testutil.TempFolder
+}
+
+func (s *DiskMappingTestSuite) SetupTest() {
+	var err error
+	s.proc, err = testutil.NewTempFolder("test-disk-mapping")
+	assert.NoError(s.T(), err)
+}
+
+func (s *DiskMappingTestSuite) TearDownTest() {
+	cache.Cache.Delete(diskMappingCacheKey)
+	s.proc.RemoveAll()
+	s.proc = nil
+}
+
+func (s *DiskMappingTestSuite) TestParsing() {
+	s.proc.Add("diskstats", testutil.Detab(`
+        7       0 loop0 0 0 0 0 0 0 0 0 0 0 0
+        7       1 loop1 0 0 0 0 0 0 0 0 0 0 0
+        invalidline
+        8       0 sda 24398 2788 1317975 40488 25201 46267 1584744 142336 0 22352 182660
+        8       1 sda1 24232 2788 1312025 40376 25201 46267 1584744 142336 0 22320 182552
+        8      16 sdb 189 0 4063 220 0 0 0 0 0 112 204
+    `))
+
+	expectedMap := map[string]string{
+		"7:0":  "loop0",
+		"7:1":  "loop1",
+		"8:0":  "sda",
+		"8:1":  "sda1",
+		"8:16": "sdb",
+	}
+
+	mapping, err := getDiskDeviceMapping(s.proc.RootPath)
+	assert.NoError(s.T(), err)
+	assert.Equal(s.T(), expectedMap, mapping)
+
+	cached, ok := cache.Cache.Get(diskMappingCacheKey)
+	assert.True(s.T(), ok)
+	assert.EqualValues(s.T(), expectedMap, cached)
+}
+
+func (s *DiskMappingTestSuite) TestNotFound() {
+	mapping, err := getDiskDeviceMapping(s.proc.RootPath)
+	require.Error(s.T(), err)
+	assert.Contains(s.T(), err.Error(), "no such file or directory")
+	assert.Nil(s.T(), mapping)
+}
+
+func (s *DiskMappingTestSuite) TestCached() {
+	cachedMapping := map[string]string{
+		"1:2": "one",
+		"2:3": "two",
+	}
+	cache.Cache.Set(diskMappingCacheKey, cachedMapping, time.Minute)
+
+	mapping, err := getDiskDeviceMapping(s.proc.RootPath)
+	require.NoError(s.T(), err)
+	assert.Equal(s.T(), cachedMapping, mapping)
+}
+
+func TestDiskMappingTestSuite(t *testing.T) {
+	suite.Run(t, new(DiskMappingTestSuite))
+}

--- a/pkg/util/containers/v2/metrics/collector_network_linux.go
+++ b/pkg/util/containers/v2/metrics/collector_network_linux.go
@@ -1,0 +1,231 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package metrics
+
+import (
+	"bufio"
+	"encoding/binary"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/util/filesystem"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+func buildNetworkStats(procPath string, networks map[string]string, cgs *cgroups.PIDStats) (*ContainerNetworkStats, error) {
+	if len(cgs.PIDs) > 0 {
+		return collectNetworkStats(procPath, cgs.PIDs[0], networks)
+	}
+
+	return nil, fmt.Errorf("no process found inside this cgroup, impossible to gather network stats")
+}
+
+// collectNetworkStats retrieves the network statistics for a given pid.
+// The networks map allows to optionnaly map interface name to user-friendly
+// network names. If not found in the map, the interface name is used.
+func collectNetworkStats(procPath string, pid int, networks map[string]string) (*ContainerNetworkStats, error) {
+	procNetFile := filepath.Join(procPath, strconv.Itoa(pid), "net", "dev")
+	if !filesystem.FileExists(procNetFile) {
+		log.Debugf("Unable to read %s for pid %d", procNetFile, pid)
+		return nil, nil
+	}
+	lines, err := filesystem.ReadLines(procNetFile)
+	if err != nil {
+		log.Debugf("Unable to read %s for pid %d", procNetFile, pid)
+		return nil, nil
+	}
+	if len(lines) < 2 {
+		return nil, fmt.Errorf("invalid format for %s", procNetFile)
+	}
+
+	var totalRcvd, totalSent, totalPktRcvd, totalPktSent uint64
+	ifaceStats := make(map[string]InterfaceNetStats)
+
+	// Format:
+	//
+	// Inter-|   Receive                                                |  Transmit
+	// face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+	// eth0:    1296      16    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+	// lo:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+	//
+	for _, line := range lines[2:] {
+		fields := strings.Fields(line)
+		if len(fields) < 11 {
+			continue
+		}
+		iface := strings.TrimSuffix(fields[0], ":")
+
+		var stat InterfaceNetStats
+		var networkName string
+
+		if nw, ok := networks[iface]; ok {
+			networkName = nw
+		} else if iface == "lo" {
+			continue // Ignore loopback
+		} else {
+			networkName = iface
+		}
+
+		rcvd, _ := strconv.ParseUint(fields[1], 10, 64)
+		totalRcvd += rcvd
+		convertField(&rcvd, &stat.BytesRcvd)
+		pktRcvd, _ := strconv.ParseUint(fields[2], 10, 64)
+		totalPktRcvd += pktRcvd
+		convertField(&pktRcvd, &stat.PacketsRcvd)
+		sent, _ := strconv.ParseUint(fields[9], 10, 64)
+		totalSent += sent
+		convertField(&sent, &stat.BytesSent)
+		pktSent, _ := strconv.ParseUint(fields[10], 10, 64)
+		totalPktSent += pktSent
+		convertField(&pktSent, &stat.PacketsSent)
+
+		ifaceStats[networkName] = stat
+	}
+
+	if len(ifaceStats) > 0 {
+		netStats := ContainerNetworkStats{Interfaces: ifaceStats}
+		convertField(&totalRcvd, &netStats.BytesRcvd)
+		convertField(&totalSent, &netStats.BytesSent)
+		convertField(&totalPktRcvd, &netStats.PacketsRcvd)
+		convertField(&totalPktSent, &netStats.PacketsSent)
+
+		return &netStats, nil
+	}
+
+	return nil, nil
+}
+
+// DetectNetworkDestinations lists all the networks available
+// to a given PID and parses them in NetworkInterface objects
+func detectNetworkDestinations(procPath string, pid int) ([]containers.NetworkDestination, error) {
+	procNetFile := filepath.Join(procPath, strconv.Itoa(pid), "net", "route")
+	if !filesystem.FileExists(procNetFile) {
+		return nil, fmt.Errorf("%s not found", procNetFile)
+	}
+	lines, err := filesystem.ReadLines(procNetFile)
+	if err != nil {
+		return nil, err
+	}
+	if len(lines) < 1 {
+		return nil, fmt.Errorf("empty network file %s", procNetFile)
+	}
+
+	destinations := make([]containers.NetworkDestination, 0)
+	for _, line := range lines[1:] {
+		fields := strings.Fields(line)
+		if len(fields) < 8 {
+			continue
+		}
+		if fields[1] == "00000000" {
+			continue
+		}
+		dest, err := strconv.ParseUint(fields[1], 16, 32)
+		if err != nil {
+			log.Debugf("Cannot parse destination %q: %v", fields[1], err)
+			continue
+		}
+		mask, err := strconv.ParseUint(fields[7], 16, 32)
+		if err != nil {
+			log.Debugf("Cannot parse mask %q: %v", fields[7], err)
+			continue
+		}
+		d := containers.NetworkDestination{
+			Interface: fields[0],
+			Subnet:    dest,
+			Mask:      mask,
+		}
+		destinations = append(destinations, d)
+	}
+	return destinations, nil
+}
+
+// DefaultGateway returns the default Docker gateway.
+func defaultGateway(procPath string) (net.IP, error) {
+	fields, err := defaultGatewayFields(procPath)
+	if err != nil || len(fields) < 3 {
+		return nil, err
+	}
+
+	ipInt, err := strconv.ParseUint(fields[2], 16, 32)
+	if err != nil {
+		return nil, fmt.Errorf("unable to parse ip %s from route file: %s", fields[2], err)
+	}
+	ip := make(net.IP, 4)
+	binary.LittleEndian.PutUint32(ip, uint32(ipInt))
+	return ip, nil
+}
+
+// DefaultHostIPs returns the IP addresses bound to the default network interface.
+// The default network interface is the one connected to the network gateway, and it is determined
+// by parsing the routing table file in the proc file system.
+func defaultHostIPs(procPath string) ([]string, error) {
+	fields, err := defaultGatewayFields(procPath)
+	if err != nil {
+		return nil, err
+	}
+	if len(fields) == 0 {
+		return nil, fmt.Errorf("missing interface information from routing file")
+	}
+	iface, err := net.InterfaceByName(fields[0])
+	if err != nil {
+		return nil, err
+	}
+
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return nil, err
+	}
+
+	ips := make([]string, len(addrs))
+	for i, addr := range addrs {
+		// Translate CIDR blocks into IPs, if necessary
+		ips[i] = strings.Split(addr.String(), "/")[0]
+	}
+
+	return ips, nil
+}
+
+// defaultGatewayFields extracts the fields associated to the interface connected
+// to the network gateway from the linux routing table. As an example, for the given file in /proc/net/routes:
+//
+// Iface   Destination  Gateway   Flags  RefCnt  Use  Metric  Mask      MTU  Window  IRTT
+// enp0s3  00000000     0202000A  0003   0       0    0       00000000  0    0       0
+// enp0s3  0002000A     00000000  0001   0       0    0       00FFFFFF  0    0       0
+//
+// The returned value would be ["enp0s3","00000000","0202000A","0003","0","0","0","00000000","0","0","0"]
+//
+func defaultGatewayFields(procPath string) ([]string, error) {
+	netRouteFile := filepath.Join(procPath, "net", "route")
+	f, err := os.Open(netRouteFile)
+	if err != nil {
+		if os.IsNotExist(err) || os.IsPermission(err) {
+			log.Errorf("Unable to open %s: %s", netRouteFile, err)
+			return nil, nil
+		}
+		// Unknown error types will bubble up for handling.
+		return nil, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		fields := strings.Fields(scanner.Text())
+		if len(fields) >= 1 && fields[1] == "00000000" {
+			return fields, nil
+		}
+	}
+
+	return nil, fmt.Errorf("couldn't retrieve default gateway information")
+}

--- a/pkg/util/containers/v2/metrics/collector_network_linux_test.go
+++ b/pkg/util/containers/v2/metrics/collector_network_linux_test.go
@@ -1,0 +1,345 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package metrics
+
+import (
+	"io/ioutil"
+	"net"
+	"os"
+	"path"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+	"github.com/DataDog/datadog-agent/pkg/util/testutil"
+)
+
+func TestCollectNetworkStats(t *testing.T) {
+	dummyProcDir, err := testutil.NewTempFolder("test-find-docker-networks")
+	assert.Nil(t, err)
+	defer dummyProcDir.RemoveAll() // clean up
+
+	for _, tc := range []struct {
+		pid        int
+		name       string
+		dev        string
+		networks   map[string]string
+		stat       ContainerNetworkStats
+		summedStat *InterfaceNetStats
+	}{
+		{
+			pid:  1245,
+			name: "one-container-interface",
+			dev: testutil.Detab(`
+                Inter-|   Receive                                                |  Transmit
+                 face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+                  eth0:    1345      10    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+                    lo:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+            `),
+			networks: map[string]string{
+				"eth0": "bridge",
+			},
+			stat: ContainerNetworkStats{
+				Interfaces: map[string]InterfaceNetStats{
+					"bridge": {
+						BytesRcvd:   util.Float64Ptr(1345),
+						PacketsRcvd: util.Float64Ptr(10),
+						BytesSent:   util.Float64Ptr(0),
+						PacketsSent: util.Float64Ptr(0),
+					},
+				},
+				BytesRcvd:   util.Float64Ptr(1345),
+				PacketsRcvd: util.Float64Ptr(10),
+				BytesSent:   util.Float64Ptr(0),
+				PacketsSent: util.Float64Ptr(0),
+			},
+		},
+		// Multiple docker networks
+		{
+			pid:  5153,
+			name: "multiple-networks",
+			dev: testutil.Detab(`
+                Inter-|   Receive                                                |  Transmit
+                 face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+                    lo:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+                  eth0:     648       8    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+                  eth1:    1478      19    0    0    0     0          0         0      182       3    0    0    0     0       0          0`),
+			networks: map[string]string{
+				"eth0": "bridge",
+				"eth1": "test",
+			},
+			stat: ContainerNetworkStats{
+				Interfaces: map[string]InterfaceNetStats{
+					"bridge": {
+						BytesRcvd:   util.Float64Ptr(648),
+						PacketsRcvd: util.Float64Ptr(8),
+						BytesSent:   util.Float64Ptr(0),
+						PacketsSent: util.Float64Ptr(0),
+					},
+					"test": {
+						BytesRcvd:   util.Float64Ptr(1478),
+						PacketsRcvd: util.Float64Ptr(19),
+						BytesSent:   util.Float64Ptr(182),
+						PacketsSent: util.Float64Ptr(3),
+					},
+				},
+				BytesRcvd:   util.Float64Ptr(2126),
+				PacketsRcvd: util.Float64Ptr(27),
+				BytesSent:   util.Float64Ptr(182),
+				PacketsSent: util.Float64Ptr(3),
+			},
+		},
+		// Fallback to interface name if network not in map
+		{
+			pid:  5155,
+			name: "multiple-ifaces-missing-network",
+			dev: testutil.Detab(`
+                Inter-|   Receive                                                |  Transmit
+                 face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+                    lo:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+                  eth0:     648       8    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+                  eth1:    1478      19    0    0    0     0          0         0      182       3    0    0    0     0       0          0`),
+			networks: map[string]string{
+				"eth1": "test",
+			},
+			stat: ContainerNetworkStats{
+				Interfaces: map[string]InterfaceNetStats{
+					"eth0": {
+						BytesRcvd:   util.Float64Ptr(648),
+						PacketsRcvd: util.Float64Ptr(8),
+						BytesSent:   util.Float64Ptr(0),
+						PacketsSent: util.Float64Ptr(0),
+					},
+					"test": {
+						BytesRcvd:   util.Float64Ptr(1478),
+						PacketsRcvd: util.Float64Ptr(19),
+						BytesSent:   util.Float64Ptr(182),
+						PacketsSent: util.Float64Ptr(3),
+					},
+				},
+				BytesRcvd:   util.Float64Ptr(2126),
+				PacketsRcvd: util.Float64Ptr(27),
+				BytesSent:   util.Float64Ptr(182),
+				PacketsSent: util.Float64Ptr(3),
+			},
+		},
+		// Dumb error case to make sure we don't panic, fallback to interface name
+		{
+			pid:  5157,
+			name: "nil-network-map",
+			dev: testutil.Detab(`
+                Inter-|   Receive                                                |  Transmit
+                 face |bytes    packets errs drop fifo frame compressed multicast|bytes    packets errs drop fifo colls carrier compressed
+                  eth0:    1111       2    0    0    0     0          0         0     1024      80    0    0    0     0       0          0
+                    lo:       0       0    0    0    0     0          0         0        0       0    0    0    0     0       0          0
+            `),
+			networks: nil,
+			stat: ContainerNetworkStats{
+				Interfaces: map[string]InterfaceNetStats{
+					"eth0": {
+						BytesRcvd:   util.Float64Ptr(1111),
+						PacketsRcvd: util.Float64Ptr(2),
+						BytesSent:   util.Float64Ptr(1024),
+						PacketsSent: util.Float64Ptr(80),
+					},
+				},
+				BytesRcvd:   util.Float64Ptr(1111),
+				PacketsRcvd: util.Float64Ptr(2),
+				BytesSent:   util.Float64Ptr(1024),
+				PacketsSent: util.Float64Ptr(80),
+			},
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			err = dummyProcDir.Add(filepath.Join(strconv.Itoa(tc.pid), "net", "dev"), tc.dev)
+			assert.NoError(t, err)
+
+			stat, err := collectNetworkStats(dummyProcDir.RootPath, tc.pid, tc.networks)
+			assert.NoError(t, err)
+			assert.Equal(t, &tc.stat, stat)
+		})
+	}
+}
+
+func TestDetectNetworkDestinations(t *testing.T) {
+	dummyProcDir, err := testutil.NewTempFolder("test-find-docker-networks")
+	assert.Nil(t, err)
+	defer dummyProcDir.RemoveAll() // clean up
+
+	for _, tc := range []struct {
+		pid          int
+		routes       string
+		destinations []containers.NetworkDestination
+	}{
+		// One interface
+		{
+			pid: 1245,
+			routes: testutil.Detab(`
+                Iface   Destination Gateway     Flags   RefCnt  Use Metric  Mask        MTU Window  IRTT
+                eth0    00000000    010011AC    0003    0   0   0   00000000    0   0   0
+                eth0    000011AC    00000000    0001    0   0   0   0000FFFF    0   0   0
+            `),
+			destinations: []containers.NetworkDestination{{
+				Interface: "eth0",
+				Subnet:    0x000011AC,
+				Mask:      0x0000FFFF,
+			}},
+		},
+
+		// previous int32 overflow bug, now we parse uint32
+		{
+			pid: 1249,
+			routes: testutil.Detab(`
+                Iface   Destination Gateway     Flags   RefCnt  Use Metric  Mask        MTU Window  IRTT
+                eth0    00000000    FEFEA8C0    0003    0   0   0   00000000    0   0   0
+                eth0    00FEA8C0    00000000    0001    0   0   0   00FFFFFF    0   0   0
+			`),
+			destinations: []containers.NetworkDestination{{
+				Interface: "eth0",
+				Subnet:    0x00FEA8C0,
+				Mask:      0x00FFFFFF,
+			}},
+		},
+		// Multiple interfaces
+		{
+			pid: 5153,
+			routes: testutil.Detab(`
+                Iface   Destination Gateway     Flags   RefCnt  Use Metric  Mask        MTU Window  IRTT
+                eth0    00000000    010011AC    0003    0   0   0   00000000    0   0   0
+                eth0    000011AC    00000000    0001    0   0   0   0000FFFF    0   0   0
+                eth1    000012AC    00000000    0001    0   0   0   0000FFFF    0   0   0
+            `),
+			destinations: []containers.NetworkDestination{{
+				Interface: "eth0",
+				Subnet:    0x000011AC,
+				Mask:      0x0000FFFF,
+			}, {
+				Interface: "eth1",
+				Subnet:    0x000012AC,
+				Mask:      0x0000FFFF,
+			}},
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			// Create temporary files on disk with the routes and stats.
+			err = dummyProcDir.Add(filepath.Join(strconv.Itoa(tc.pid), "net", "route"), tc.routes)
+			assert.NoError(t, err)
+
+			dest, err := detectNetworkDestinations(dummyProcDir.RootPath, tc.pid)
+			assert.NoError(t, err)
+			assert.Equal(t, tc.destinations, dest)
+		})
+	}
+}
+
+func TestDefaultGateway(t *testing.T) {
+	testCases := []struct {
+		netRouteContent []byte
+		expectedIP      string
+	}{
+		{
+			[]byte(`Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
+ens33	00000000	0280A8C0	0003	0	0	100	00000000	0	0	0
+`),
+			"192.168.128.2",
+		},
+		{
+			[]byte(`Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
+ens33	00000000	FE01A8C0	0003	0	0	100	00000000	0	0	0
+`),
+			"192.168.1.254",
+		},
+		{
+			[]byte(`Iface	Destination	Gateway 	Flags	RefCnt	Use	Metric	Mask		MTU	Window	IRTT
+ens33	00000000	FEFEA8C0	0003	0	0	100	00000000	0	0	0
+`),
+			"192.168.254.254",
+		},
+	}
+	for _, testCase := range testCases {
+		t.Run("", func(t *testing.T) {
+			testProc, err := testutil.NewTempFolder("test-default-gateway")
+			require.NoError(t, err)
+			defer testProc.RemoveAll()
+			err = os.MkdirAll(path.Join(testProc.RootPath, "net"), os.ModePerm)
+			require.NoError(t, err)
+
+			err = ioutil.WriteFile(path.Join(testProc.RootPath, "net", "route"), testCase.netRouteContent, os.ModePerm)
+			require.NoError(t, err)
+			ip, err := defaultGateway(testProc.RootPath)
+			require.NoError(t, err)
+			assert.Equal(t, testCase.expectedIP, ip.String())
+
+			testProc.RemoveAll()
+			ip, err = defaultGateway(testProc.RootPath)
+			require.NoError(t, err)
+			require.Nil(t, ip)
+		})
+	}
+}
+
+func TestDefaulHostIPs(t *testing.T) {
+	dummyProcDir, err := testutil.NewTempFolder("test-default-host-ips")
+	require.Nil(t, err)
+	defer dummyProcDir.RemoveAll()
+
+	t.Run("routing table contains a gateway entry", func(t *testing.T) {
+		routes := `
+		    Iface    Destination Gateway  Flags RefCnt Use Metric Mask     MTU Window IRTT
+		    default  00000000    010011AC 0003  0      0   0      00000000 0   0      0
+		    default  000011AC    00000000 0001  0      0   0      0000FFFF 0   0      0
+		    eth1     000012AC    00000000 0001  0      0   0      0000FFFF 0   0      0 `
+
+		// Pick an existing device and replace the "default" placeholder by its name
+		interfaces, err := net.Interfaces()
+		require.NoError(t, err)
+		require.NotEmpty(t, interfaces)
+		netInterface := interfaces[0]
+		routes = strings.ReplaceAll(routes, "default", netInterface.Name)
+
+		// Populate routing table file
+		err = dummyProcDir.Add(filepath.Join("net", "route"), routes)
+		require.NoError(t, err)
+
+		// Retrieve IPs bound to the "default" network interface
+		var expectedIPs []string
+		netAddrs, err := netInterface.Addrs()
+		require.NoError(t, err)
+		require.NotEmpty(t, netAddrs)
+		for _, address := range netAddrs {
+			ip := strings.Split(address.String(), "/")[0]
+			require.NotNil(t, net.ParseIP(ip))
+			expectedIPs = append(expectedIPs, ip)
+		}
+
+		// Verify they match the IPs returned by DefaultHostIPs()
+		defaultIPs, err := defaultHostIPs(dummyProcDir.RootPath)
+		assert.Nil(t, err)
+		assert.Equal(t, expectedIPs, defaultIPs)
+	})
+
+	t.Run("routing table missing a gateway entry", func(t *testing.T) {
+		routes := `
+	        Iface    Destination Gateway  Flags RefCnt Use Metric Mask     MTU Window IRTT
+	        eth0     000011AC    00000000 0001  0      0   0      0000FFFF 0   0      0
+	        eth1     000012AC    00000000 0001  0      0   0      0000FFFF 0   0      0 `
+
+		err = dummyProcDir.Add(filepath.Join("net", "route"), routes)
+		require.NoError(t, err)
+		ips, err := defaultHostIPs(dummyProcDir.RootPath)
+		assert.Nil(t, ips)
+		assert.NotNil(t, err)
+	})
+}

--- a/pkg/util/containers/v2/metrics/collector_system_linux.go
+++ b/pkg/util/containers/v2/metrics/collector_system_linux.go
@@ -1,0 +1,209 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package metrics
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/system"
+)
+
+const (
+	systemCollectorID = "system"
+)
+
+func init() {
+	metricsProvider.registerCollector(collectorMetadata{
+		id:       systemCollectorID,
+		priority: 0,
+		runtimes: allLinuxRuntimes,
+		factory: func() (Collector, error) {
+			return newCgroupCollector()
+		},
+	})
+}
+
+type cgroupCollector struct {
+	reader   *cgroups.Reader
+	procPath string
+}
+
+func newCgroupCollector() (*cgroupCollector, error) {
+	var err error
+	var hostPrefix string
+
+	procPath := config.Datadog.GetString("container_proc_root")
+	if strings.HasPrefix(procPath, "/host") {
+		hostPrefix = "/host"
+	}
+
+	reader, err := cgroups.NewReader(
+		cgroups.WithCgroupV1BaseController("freezer"),
+		cgroups.WithProcPath(procPath),
+		cgroups.WithHostPrefix(hostPrefix),
+		cgroups.WithReaderFilter(cgroups.ContainerFilter),
+	)
+	if err != nil {
+		// Cgroup provider is pretty static. Except not having required mounts, it should always work.
+		log.Errorf("Unable to initialize cgroup provider (cgroups not mounted?), err: %v", err)
+		return nil, ErrPermaFail
+	}
+
+	return &cgroupCollector{
+		reader:   reader,
+		procPath: procPath,
+	}, nil
+}
+
+func (c *cgroupCollector) ID() string {
+	return systemCollectorID
+}
+
+func (c *cgroupCollector) GetContainerStats(containerID string, cacheValidity time.Duration) (*ContainerStats, error) {
+	cg, err := c.getCgroup(containerID, cacheValidity)
+	if err != nil {
+		return nil, err
+	}
+
+	var stats cgroups.Stats
+	err = cg.GetStats(&stats)
+	if err != nil {
+		return nil, fmt.Errorf("cgroup parsing failed, incomplete data for containerID: %s, err: %w", containerID, err)
+	}
+
+	return c.buildContainerMetrics(stats), nil
+}
+
+func (c *cgroupCollector) GetContainerNetworkStats(containerID string, cacheValidity time.Duration, networks map[string]string) (*ContainerNetworkStats, error) {
+	cg, err := c.getCgroup(containerID, cacheValidity)
+	if err != nil {
+		return nil, err
+	}
+
+	pidStats := &cgroups.PIDStats{}
+	err = cg.GetPIDStats(pidStats)
+	if err != nil {
+		return nil, err
+	}
+
+	return buildNetworkStats(c.procPath, networks, pidStats)
+}
+
+func (c *cgroupCollector) getCgroup(containerID string, cacheValidity time.Duration) (cgroups.Cgroup, error) {
+	cg := c.reader.GetCgroup(containerID)
+	if cg == nil {
+		err := c.reader.RefreshCgroups(cacheValidity)
+		if err != nil {
+			return nil, fmt.Errorf("containerdID not found and unable to refresh cgroups, err: %w", err)
+		}
+
+		cg = c.reader.GetCgroup(containerID)
+		if cg == nil {
+			return nil, fmt.Errorf("containerID not found")
+		}
+	}
+
+	return cg, nil
+}
+
+func (c *cgroupCollector) buildContainerMetrics(cgs cgroups.Stats) *ContainerStats {
+	cs := &ContainerStats{
+		Timestamp: time.Now(),
+		Memory:    buildMemoryStats(cgs.Memory),
+		CPU:       buildCPUStats(cgs.CPU),
+		IO:        buildIOStats(c.procPath, cgs.IO),
+		PID:       buildPIDStats(cgs.PID),
+	}
+
+	return cs
+}
+
+func buildMemoryStats(cgs *cgroups.MemoryStats) *ContainerMemStats {
+	if cgs == nil {
+		return nil
+	}
+	cs := &ContainerMemStats{}
+
+	convertField(cgs.UsageTotal, &cs.UsageTotal)
+	convertField(cgs.KernelMemory, &cs.KernelMemory)
+	convertField(cgs.Limit, &cs.Limit)
+	convertField(cgs.LowThreshold, &cs.Softlimit)
+	convertField(cgs.RSS, &cs.RSS)
+	convertField(cgs.Cache, &cs.Cache)
+	convertField(cgs.Swap, &cs.Swap)
+	convertField(cgs.OOMEvents, &cs.OOMEvents)
+
+	return cs
+}
+
+func buildCPUStats(cgs *cgroups.CPUStats) *ContainerCPUStats {
+	if cgs == nil {
+		return nil
+	}
+	cs := &ContainerCPUStats{}
+
+	// Copy basid fields
+	convertField(cgs.Total, &cs.Total)
+	convertField(cgs.System, &cs.System)
+	convertField(cgs.User, &cs.User)
+	convertField(cgs.Shares, &cs.Shares)
+	convertField(cgs.ElapsedPeriods, &cs.ElapsedPeriods)
+	convertField(cgs.ThrottledPeriods, &cs.ThrottledPeriods)
+	convertField(cgs.ThrottledTime, &cs.ThrottledTime)
+
+	// Compute complex fields
+	cs.Limit = computeCPULimitPct(cgs)
+
+	return cs
+}
+
+func computeCPULimitPct(cgs *cgroups.CPUStats) *float64 {
+	// Limit is computed using min(CPUSet, CFS CPU Quota)
+	var limitPct float64
+	if cgs.CPUCount != nil {
+		limitPct = float64(*cgs.CPUCount) * 100
+	}
+	if cgs.SchedulerQuota != nil && cgs.SchedulerPeriod != nil {
+		quotaLimitPct := 100 * (float64(*cgs.SchedulerQuota) / float64(*cgs.SchedulerPeriod))
+		if quotaLimitPct < limitPct {
+			limitPct = quotaLimitPct
+		}
+	}
+	// If no limit is available, setting the limit to number of CPUs.
+	// Always reporting a limit allows to compute CPU % accurately.
+	if limitPct == 0 {
+		limitPct = float64(system.HostCPUCount()) * 100
+	}
+	return &limitPct
+}
+
+func buildPIDStats(cgs *cgroups.PIDStats) *ContainerPIDStats {
+	if cgs == nil {
+		return nil
+	}
+	cs := &ContainerPIDStats{}
+
+	cs.PIDs = cgs.PIDs
+	convertField(cgs.HierarchicalThreadCount, &cs.ThreadCount)
+	convertField(cgs.HierarchicalThreadLimit, &cs.ThreadLimit)
+
+	return cs
+}
+
+func convertField(s *uint64, t **float64) {
+	if s != nil {
+		*t = util.Float64Ptr(float64(*s))
+	}
+}

--- a/pkg/util/containers/v2/metrics/collector_system_linux_test.go
+++ b/pkg/util/containers/v2/metrics/collector_system_linux_test.go
@@ -1,0 +1,146 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package metrics
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
+	"github.com/DataDog/datadog-agent/pkg/util/system"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuildContainerMetrics(t *testing.T) {
+	tests := []struct {
+		name string
+		cgs  cgroups.Stats
+		want *ContainerStats
+	}{
+		{
+			name: "everything empty",
+			cgs:  cgroups.Stats{},
+			want: &ContainerStats{},
+		},
+		{
+			name: "structs with all stats",
+			cgs: cgroups.Stats{
+				CPU: &cgroups.CPUStats{
+					Total:            util.UInt64Ptr(100),
+					System:           util.UInt64Ptr(200),
+					User:             util.UInt64Ptr(300),
+					Shares:           util.UInt64Ptr(400),
+					ElapsedPeriods:   util.UInt64Ptr(500),
+					ThrottledPeriods: util.UInt64Ptr(0),
+					ThrottledTime:    util.UInt64Ptr(100),
+					CPUCount:         util.UInt64Ptr(10),
+					SchedulerPeriod:  util.UInt64Ptr(100),
+					SchedulerQuota:   util.UInt64Ptr(50),
+				},
+				Memory: &cgroups.MemoryStats{
+					UsageTotal:   util.UInt64Ptr(100),
+					KernelMemory: util.UInt64Ptr(40),
+					Limit:        util.UInt64Ptr(42000),
+					LowThreshold: util.UInt64Ptr(40000),
+					RSS:          util.UInt64Ptr(300),
+					Cache:        util.UInt64Ptr(200),
+					Swap:         util.UInt64Ptr(0),
+					OOMEvents:    util.UInt64Ptr(10),
+				},
+				IO: &cgroups.IOStats{
+					ReadBytes:       util.UInt64Ptr(100),
+					WriteBytes:      util.UInt64Ptr(200),
+					ReadOperations:  util.UInt64Ptr(10),
+					WriteOperations: util.UInt64Ptr(20),
+					// Device will be ignored as no matching device name
+					Devices: map[string]cgroups.DeviceIOStats{
+						"foo": {
+							ReadBytes:       util.UInt64Ptr(100),
+							WriteBytes:      util.UInt64Ptr(200),
+							ReadOperations:  util.UInt64Ptr(10),
+							WriteOperations: util.UInt64Ptr(20),
+						},
+					},
+				},
+				PID: &cgroups.PIDStats{
+					PIDs:                    []int{4, 2},
+					HierarchicalThreadCount: util.UInt64Ptr(10),
+					HierarchicalThreadLimit: util.UInt64Ptr(20),
+				},
+			},
+			want: &ContainerStats{
+				CPU: &ContainerCPUStats{
+					Total:            util.Float64Ptr(100),
+					System:           util.Float64Ptr(200),
+					User:             util.Float64Ptr(300),
+					Shares:           util.Float64Ptr(400),
+					Limit:            util.Float64Ptr(50),
+					ElapsedPeriods:   util.Float64Ptr(500),
+					ThrottledPeriods: util.Float64Ptr(0),
+					ThrottledTime:    util.Float64Ptr(100),
+				},
+				Memory: &ContainerMemStats{
+					UsageTotal:   util.Float64Ptr(100),
+					KernelMemory: util.Float64Ptr(40),
+					Limit:        util.Float64Ptr(42000),
+					Softlimit:    util.Float64Ptr(40000),
+					RSS:          util.Float64Ptr(300),
+					Cache:        util.Float64Ptr(200),
+					Swap:         util.Float64Ptr(0),
+					OOMEvents:    util.Float64Ptr(10),
+				},
+				IO: &ContainerIOStats{
+					ReadBytes:       util.Float64Ptr(100),
+					WriteBytes:      util.Float64Ptr(200),
+					ReadOperations:  util.Float64Ptr(10),
+					WriteOperations: util.Float64Ptr(20),
+				},
+				PID: &ContainerPIDStats{
+					PIDs:        []int{4, 2},
+					ThreadCount: util.Float64Ptr(10),
+					ThreadLimit: util.Float64Ptr(20),
+				},
+			},
+		},
+		{
+			name: "limit cpu count no quota",
+			cgs: cgroups.Stats{
+				CPU: &cgroups.CPUStats{
+					CPUCount: util.UInt64Ptr(10),
+				},
+			},
+			want: &ContainerStats{
+				CPU: &ContainerCPUStats{
+					Limit: util.Float64Ptr(1000),
+				},
+			},
+		},
+		{
+			name: "limit no cpu count, no quota",
+			cgs: cgroups.Stats{
+				CPU: &cgroups.CPUStats{},
+			},
+			want: &ContainerStats{
+				CPU: &ContainerCPUStats{
+					Limit: util.Float64Ptr(float64(system.HostCPUCount()) * 100),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &cgroupCollector{}
+			got := c.buildContainerMetrics(tt.cgs)
+			tt.want.Timestamp = got.Timestamp
+			assert.Empty(t, cmp.Diff(tt.want, got))
+		})
+	}
+}

--- a/pkg/util/containers/v2/metrics/mock.go
+++ b/pkg/util/containers/v2/metrics/mock.go
@@ -1,0 +1,102 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metrics
+
+import (
+	"fmt"
+	"time"
+)
+
+// MockMetricsProvider can be used to create tests
+type MockMetricsProvider struct {
+	collectors map[string]Collector
+}
+
+// NewMockMetricsProvider creates a mock provider
+func NewMockMetricsProvider() *MockMetricsProvider {
+	return &MockMetricsProvider{
+		collectors: make(map[string]Collector),
+	}
+}
+
+// GetCollector emulates the MetricsProvider interface
+func (mp *MockMetricsProvider) GetCollector(runtime string) Collector {
+	return mp.collectors[runtime]
+}
+
+// RegisterCollector registers a collector
+func (mp *MockMetricsProvider) RegisterCollector(runtime string, c Collector) {
+	mp.collectors[runtime] = c
+}
+
+// RemoveCollector removes a collector
+func (mp *MockMetricsProvider) RemoveCollector(runtime string) {
+	delete(mp.collectors, runtime)
+}
+
+// Clear removes all collectors
+func (mp *MockMetricsProvider) Clear() {
+	mp.collectors = make(map[string]Collector)
+}
+
+// MockContainerEntry allows to customize mock responses
+type MockContainerEntry struct {
+	ContainerStats ContainerStats
+	NetworkStats   ContainerNetworkStats
+	Error          error
+}
+
+// MockCollector is a mocked collector
+type MockCollector struct {
+	id         string
+	containers map[string]MockContainerEntry
+}
+
+// NewMockCollector creates a MockCollector
+func NewMockCollector(id string) *MockCollector {
+	return &MockCollector{
+		id:         id,
+		containers: make(map[string]MockContainerEntry),
+	}
+}
+
+// ID returns collector ID
+func (mp *MockCollector) ID() string {
+	return mp.id
+}
+
+// SetContainerEntry sets an entry for a given containerID
+func (mp *MockCollector) SetContainerEntry(containerID string, cEntry MockContainerEntry) {
+	mp.containers[containerID] = cEntry
+}
+
+// DeleteContainerEntry removes the entry for containerID
+func (mp *MockCollector) DeleteContainerEntry(containerID string) {
+	delete(mp.containers, containerID)
+}
+
+// Clear removes all entries
+func (mp *MockCollector) Clear() {
+	mp.containers = make(map[string]MockContainerEntry)
+}
+
+// GetContainerStats returns stats from MockContainerEntry
+func (mp *MockCollector) GetContainerStats(containerID string, cacheValidity time.Duration) (*ContainerStats, error) {
+	if entry, found := mp.containers[containerID]; found {
+		return &entry.ContainerStats, entry.Error
+	}
+
+	return nil, fmt.Errorf("container not found")
+}
+
+// GetContainerNetworkStats returns stats from MockContainerEntry
+func (mp *MockCollector) GetContainerNetworkStats(containerID string, cacheValidity time.Duration, networks map[string]string) (*ContainerNetworkStats, error) {
+	if entry, found := mp.containers[containerID]; found {
+		return &entry.NetworkStats, entry.Error
+	}
+
+	return nil, fmt.Errorf("container not found")
+}

--- a/pkg/util/containers/v2/metrics/provider.go
+++ b/pkg/util/containers/v2/metrics/provider.go
@@ -1,0 +1,181 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metrics
+
+import (
+	"errors"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/retry"
+)
+
+// Known container runtimes
+const (
+	RuntimeNameDocker     string = "docker"
+	RuntimeNameContainerd string = "containerd"
+	RuntimeNameCRIO       string = "cri-o"
+	RuntimeNameGarden     string = "garden"
+)
+
+const (
+	minRetryInterval = 2 * time.Second
+)
+
+var (
+	// ErrNothingYet is returned when no collector is currently detected.
+	// This might change in the future if new collectors are valid.
+	ErrNothingYet = &retry.Error{
+		LogicError:    errors.New("no collector detected for runtime"),
+		RessourceName: "catalog",
+		RetryStatus:   retry.FailWillRetry,
+	}
+
+	// ErrPermaFail is returned when a collector will never be available
+	ErrPermaFail = &retry.Error{
+		LogicError:    errors.New("no collector available for runtime"),
+		RessourceName: "catalog",
+		RetryStatus:   retry.PermaFail,
+	}
+
+	// nolint: deadcode, unused
+	allLinuxRuntimes = []string{
+		RuntimeNameDocker,
+		RuntimeNameContainerd,
+		RuntimeNameCRIO,
+	}
+	// nolint: deadcode, unused
+	allWindowsRuntimes = []string{
+		RuntimeNameDocker,
+		RuntimeNameContainerd,
+	}
+)
+
+// Provider interface allows to mock the metrics provider
+type Provider interface {
+	GetCollector(runtime string) Collector
+}
+
+type collectorFactory func() (Collector, error)
+
+type collectorMetadata struct {
+	id       string
+	priority int // lowest gets higher priority (0 more prioritary than 1)
+	runtimes []string
+	factory  collectorFactory
+}
+
+type collectorReference struct {
+	id        string
+	priority  int
+	collector Collector
+}
+
+// GenericProvider offers an interface to retrieve a metrics collector
+type GenericProvider struct {
+	collectors          map[string]collectorMetadata // key is catalogEntry.id
+	collectorsLock      sync.Mutex
+	effectiveCollectors map[string]*collectorReference // key is runtime
+	effectiveLock       sync.RWMutex
+	lastRetryTimestamp  time.Time
+	remainingCandidates uint32
+}
+
+var metricsProvider = newProvider()
+
+// GetProvider returns the metrics provider singleton
+func GetProvider() Provider {
+	return metricsProvider
+}
+
+func newProvider() *GenericProvider {
+	return &GenericProvider{
+		collectors:          make(map[string]collectorMetadata),
+		effectiveCollectors: make(map[string]*collectorReference),
+	}
+}
+
+// GetCollector returns the best collector for given runtime.
+// The best collector may change depending on other collectors availability.
+// You should not cache the result from this function.
+func (mp *GenericProvider) GetCollector(runtime string) Collector {
+	mp.retryCollectors(minRetryInterval)
+	return mp.getCollector(runtime)
+}
+
+func (mp *GenericProvider) registerCollector(collectorMeta collectorMetadata) {
+	mp.collectorsLock.Lock()
+	defer mp.collectorsLock.Unlock()
+
+	mp.collectors[collectorMeta.id] = collectorMeta
+	atomic.StoreUint32(&mp.remainingCandidates, uint32(len(mp.collectors)))
+}
+
+func (mp *GenericProvider) getCollector(runtime string) Collector {
+	mp.effectiveLock.RLock()
+	defer mp.effectiveLock.RUnlock()
+
+	if entry, found := mp.effectiveCollectors[runtime]; found {
+		return entry.collector
+	}
+
+	return nil
+}
+
+func (mp *GenericProvider) retryCollectors(cacheValidity time.Duration) {
+	if atomic.LoadUint32(&mp.remainingCandidates) == 0 {
+		return
+	}
+
+	mp.collectorsLock.Lock()
+	defer mp.collectorsLock.Unlock()
+
+	// Only refresh if last attempt is too old (incl. processing time)
+	if time.Now().Before(mp.lastRetryTimestamp.Add(cacheValidity)) {
+		return
+	}
+
+	mp.lastRetryTimestamp = time.Now()
+
+	for _, collectorEntry := range mp.collectors {
+		collector, err := collectorEntry.factory()
+		if err == nil {
+			mp.updateEffectiveCollectors(collector, collectorEntry)
+			delete(mp.collectors, collectorEntry.id)
+		} else {
+			if errors.Is(err, ErrPermaFail) {
+				delete(mp.collectors, collectorEntry.id)
+				log.Debugf("Metrics collector: %s went into PermaFail, removed from candidates")
+			}
+		}
+	}
+
+	atomic.StoreUint32(&mp.remainingCandidates, uint32(len(mp.collectors)))
+}
+
+func (mp *GenericProvider) updateEffectiveCollectors(newCollector Collector, newCollectorDesc collectorMetadata) {
+	mp.effectiveLock.Lock()
+	defer mp.effectiveLock.Unlock()
+
+	newRef := collectorReference{
+		id:        newCollectorDesc.id,
+		priority:  newCollectorDesc.priority,
+		collector: newCollector,
+	}
+
+	for _, runtime := range newCollectorDesc.runtimes {
+		currentCollector := mp.effectiveCollectors[runtime]
+		if currentCollector == nil {
+			log.Infof("Using metrics collector: %s for runtime: %s", newRef.id, runtime)
+			mp.effectiveCollectors[runtime] = &newRef
+		} else if currentCollector.priority > newCollectorDesc.priority { // do not replace on same priority to favor consistency
+			log.Infof("Replaced old collector: %s by new collector: %s for runtime: %s", currentCollector.id, newRef.id, runtime)
+			mp.effectiveCollectors[runtime] = &newRef
+		}
+	}
+}

--- a/pkg/util/containers/v2/metrics/provider_test.go
+++ b/pkg/util/containers/v2/metrics/provider_test.go
@@ -1,0 +1,132 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metrics
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type dummyCollector struct {
+	id string
+}
+
+func (d dummyCollector) ID() string {
+	return d.id
+}
+
+func (d dummyCollector) GetContainerStats(string, time.Duration) (*ContainerStats, error) {
+	return nil, nil
+}
+
+func (d dummyCollector) GetContainerNetworkStats(containerID string, cacheValidity time.Duration, networks map[string]string) (*ContainerNetworkStats, error) {
+	return nil, nil
+}
+
+func TestMetricsProvider(t *testing.T) {
+	c := newProvider()
+	assert.Equal(t, nil, c.getCollector("foo"))
+
+	c.retryCollectors(0)
+	assert.Equal(t, nil, c.getCollector("foo"))
+
+	c.registerCollector(collectorMetadata{
+		id:       "dummy1",
+		priority: 10,
+		runtimes: []string{"foo", "bar", "baz"},
+		factory: func() (Collector, error) {
+			return dummyCollector{
+				id: "dummy1",
+			}, nil
+		},
+	})
+	c.registerCollector(collectorMetadata{
+		id:       "dummy2",
+		priority: 9,
+		runtimes: []string{"foo"},
+		factory: func() (Collector, error) {
+			return nil, ErrPermaFail
+		},
+	})
+
+	var dummy3Retries int
+	c.registerCollector(collectorMetadata{
+		id:       "dummy3",
+		priority: 9,
+		runtimes: []string{"baz"},
+		factory: func() (Collector, error) {
+			if dummy3Retries < 2 {
+				dummy3Retries++
+				return nil, fmt.Errorf("not yet okay")
+			}
+
+			return dummyCollector{
+				id: "dummy3",
+			}, nil
+		},
+	})
+
+	// No retry, should still fail
+	assert.Equal(t, nil, c.getCollector("foo"))
+
+	// dummy1 should answer to everything
+	c.retryCollectors(0)
+	fooCollector := c.getCollector("foo")
+	barCollector := c.getCollector("bar")
+	bazCollector := c.getCollector("baz")
+	assert.Equal(t, "dummy1", fooCollector.(dummyCollector).id)
+	assert.Equal(t, "dummy1", barCollector.(dummyCollector).id)
+	assert.Equal(t, "dummy1", bazCollector.(dummyCollector).id)
+
+	// dummy3 still not there, dummy2 never ok
+	c.retryCollectors(0)
+	fooCollector = c.getCollector("foo")
+	barCollector = c.getCollector("bar")
+	bazCollector = c.getCollector("baz")
+	assert.Equal(t, "dummy1", fooCollector.(dummyCollector).id)
+	assert.Equal(t, "dummy1", barCollector.(dummyCollector).id)
+	assert.Equal(t, "dummy1", bazCollector.(dummyCollector).id)
+
+	// dummy3 still not there as retry did not really happen due to cache validity
+	c.retryCollectors(42 * time.Second)
+	fooCollector = c.getCollector("foo")
+	barCollector = c.getCollector("bar")
+	bazCollector = c.getCollector("baz")
+	assert.Equal(t, "dummy1", fooCollector.(dummyCollector).id)
+	assert.Equal(t, "dummy1", barCollector.(dummyCollector).id)
+	assert.Equal(t, "dummy1", bazCollector.(dummyCollector).id)
+
+	c.retryCollectors(0)
+	fooCollector = c.getCollector("foo")
+	barCollector = c.getCollector("bar")
+	bazCollector = c.getCollector("baz")
+	assert.Equal(t, "dummy1", fooCollector.(dummyCollector).id)
+	assert.Equal(t, "dummy1", barCollector.(dummyCollector).id)
+	assert.Equal(t, "dummy3", bazCollector.(dummyCollector).id)
+
+	// Registering a new collector
+	c.registerCollector(collectorMetadata{
+		id:       "dummy4",
+		priority: 8,
+		runtimes: []string{"foo"},
+		factory: func() (Collector, error) {
+			return dummyCollector{
+				id: "dummy4",
+			}, nil
+		},
+	})
+
+	c.retryCollectors(0)
+	fooCollector = c.getCollector("foo")
+	barCollector = c.getCollector("bar")
+	bazCollector = c.getCollector("baz")
+	assert.Equal(t, "dummy4", fooCollector.(dummyCollector).id)
+	assert.Equal(t, "dummy1", barCollector.(dummyCollector).id)
+	assert.Equal(t, "dummy3", bazCollector.(dummyCollector).id)
+}

--- a/pkg/util/containers/v2/metrics/types.go
+++ b/pkg/util/containers/v2/metrics/types.go
@@ -1,0 +1,102 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metrics
+
+import "time"
+
+// This file represents a generic type aggregating all container stats.
+// All fields are float64 as that's is required by the sender API.
+// Common units: nanoseconds, bytes
+
+// ContainerMemStats stores memory statistics.
+type ContainerMemStats struct {
+	// Common fields
+	UsageTotal   *float64
+	KernelMemory *float64
+	Limit        *float64
+	Softlimit    *float64
+
+	// Linux-only fields
+	RSS       *float64
+	Cache     *float64
+	Swap      *float64
+	OOMEvents *float64 // Number of events where memory allocation failed
+
+	// Windows-only fields
+	PrivateWorkingSet *float64
+	CommitBytes       *float64
+	CommitPeakBytes   *float64
+}
+
+// ContainerCPUStats stores CPU stats.
+type ContainerCPUStats struct {
+	// Common fields
+	Total  *float64
+	System *float64
+	User   *float64
+	Limit  *float64 // Percentage 0-100*numCPU
+
+	// Linux-only fields
+	Shares           *float64
+	ElapsedPeriods   *float64
+	ThrottledPeriods *float64
+	ThrottledTime    *float64
+}
+
+// DeviceIOStats stores Device IO stats.
+type DeviceIOStats struct {
+	// Common fields
+	ReadBytes       *float64
+	WriteBytes      *float64
+	ReadOperations  *float64
+	WriteOperations *float64
+}
+
+// ContainerIOStats store I/O statistics about a container.
+type ContainerIOStats struct {
+	// Common fields
+	ReadBytes       *float64
+	WriteBytes      *float64
+	ReadOperations  *float64
+	WriteOperations *float64
+	OpenFiles       *float64
+
+	Devices map[string]DeviceIOStats
+}
+
+// ContainerPIDStats stores stats about threads & processes.
+type ContainerPIDStats struct {
+	// Common fields
+	PIDs        []int
+	ThreadCount *float64
+	ThreadLimit *float64
+}
+
+// InterfaceNetStats stores network statistics about a network interface
+type InterfaceNetStats struct {
+	BytesSent   *float64
+	BytesRcvd   *float64
+	PacketsSent *float64
+	PacketsRcvd *float64
+}
+
+// ContainerNetworkStats stores network statistics about a container per interface
+type ContainerNetworkStats struct {
+	BytesSent   *float64
+	BytesRcvd   *float64
+	PacketsSent *float64
+	PacketsRcvd *float64
+	Interfaces  map[string]InterfaceNetStats
+}
+
+// ContainerStats wraps all container metrics
+type ContainerStats struct {
+	Timestamp time.Time
+	CPU       *ContainerCPUStats
+	Memory    *ContainerMemStats
+	IO        *ContainerIOStats
+	PID       *ContainerPIDStats
+}

--- a/pkg/util/filesystem/file.go
+++ b/pkg/util/filesystem/file.go
@@ -5,10 +5,29 @@
 
 package filesystem
 
-import "os"
+import (
+	"bufio"
+	"os"
+)
 
 // FileExists returns true if a file exists and is accessible, false otherwise
 func FileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
+}
+
+// ReadLines reads a file line by line
+func ReadLines(filename string) ([]string, error) {
+	f, err := os.Open(filename)
+	if err != nil {
+		return []string{""}, err
+	}
+	defer f.Close()
+
+	var ret []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		ret = append(ret, scanner.Text())
+	}
+	return ret, scanner.Err()
 }

--- a/pkg/util/pointer.go
+++ b/pkg/util/pointer.go
@@ -1,0 +1,16 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package util
+
+// UInt64Ptr returns a pointer from a value. It will allocate a new heap object for it.
+func UInt64Ptr(v uint64) *uint64 {
+	return &v
+}
+
+// Float64Ptr returns a pointer from a value. It will allocate a new heap object for it.
+func Float64Ptr(v float64) *float64 {
+	return &v
+}

--- a/pkg/util/testutil/tempfolder.go
+++ b/pkg/util/testutil/tempfolder.go
@@ -48,7 +48,8 @@ func (f *TempFolder) Add(fileName string, contents string) error {
 	return err
 }
 
-func (f *TempFolder) delete(fileName string) error {
+// Delete removes a specific file
+func (f *TempFolder) Delete(fileName string) error {
 	return os.Remove(filepath.Join(f.RootPath, fileName))
 }
 

--- a/pkg/workloadmeta/testing/store.go
+++ b/pkg/workloadmeta/testing/store.go
@@ -33,6 +33,22 @@ func (s *Store) GetContainer(id string) (*workloadmeta.Container, error) {
 	return entity.(*workloadmeta.Container), nil
 }
 
+// ListContainers returns metadata about all known containers.
+func (s *Store) ListContainers() ([]*workloadmeta.Container, error) {
+	entities, err := s.listEntitiesByKind(workloadmeta.KindContainer)
+	if err != nil {
+		return nil, err
+	}
+
+	// Not very efficient
+	containers := make([]*workloadmeta.Container, 0, len(entities))
+	for _, entity := range entities {
+		containers = append(containers, entity.(*workloadmeta.Container))
+	}
+
+	return containers, nil
+}
+
 // GetKubernetesPod returns metadata about a Kubernetes pod.
 func (s *Store) GetKubernetesPod(id string) (*workloadmeta.KubernetesPod, error) {
 	entity, err := s.getEntityByKind(workloadmeta.KindKubernetesPod, id)
@@ -135,4 +151,21 @@ func (s *Store) getEntityByKind(kind workloadmeta.Kind, id string) (workloadmeta
 	}
 
 	return entity, nil
+}
+
+func (s *Store) listEntitiesByKind(kind workloadmeta.Kind) ([]workloadmeta.Entity, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	entitiesOfKind, ok := s.store[kind]
+	if !ok {
+		return nil, errors.NewNotFound(string(kind))
+	}
+
+	entities := make([]workloadmeta.Entity, 0, len(entitiesOfKind))
+	for _, entity := range entitiesOfKind {
+		entities = append(entities, entity)
+	}
+
+	return entities, nil
 }

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -25,6 +25,7 @@ type Store interface {
 	Subscribe(name string, filter *Filter) chan EventBundle
 	Unsubscribe(ch chan EventBundle)
 	GetContainer(id string) (*Container, error)
+	ListContainers() ([]*Container, error)
 	GetKubernetesPod(id string) (*KubernetesPod, error)
 	GetKubernetesPodForContainer(containerID string) (*KubernetesPod, error)
 	GetECSTask(id string) (*ECSTask, error)

--- a/releasenotes/notes/container-check-0b68ad11c6684b02.yaml
+++ b/releasenotes/notes/container-check-0b68ad11c6684b02.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add a generic `container` check. It generates `container.*` metrics based on all running containers, regardless of the container runtime used (among the supported ones). Currently only available on Linux.


### PR DESCRIPTION
### What does this PR do?

With the introduction of the generic container check, the Agent learns to generate common metrics for any container runtime, in the `container.*` namespace.

This new check leverages the new generic container metrics provider, which, in turns leverages the new cgroup parsing library in the Linux system collector.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

The Disk and Network pieces are borrowed from current Docker/Kubelet collector. The new code is put under `v2/` to allow smooth migration from old code (esp. Live process).
The old code will be removed when no packages reference old code.

### Describe how to test your changes

Currently this check only supports Linux. The container metadata can come from anything that's supported by the Metadata service.
The `container` check should auto-activate as soon as the Docker, containerd or Kubernetes feature is activated.
As the feature covers a lot of different environments, it would be good to test it on at least K8S and ECS.

In terms of expectations, you should see the `container` check running and all `container.*` metrics in the App.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
