### PR TITLE
[invoke] Improve release tasks behavior when commit signing fails

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -908,11 +908,22 @@ def tag_version(ctx, agent_version, commit="HEAD", verify=True, push=True, force
     for module in DEFAULT_MODULES.values():
         if module.should_tag:
             for tag in module.tag(agent_version):
-                ctx.run(
+                ok = try_git_command(
+                    ctx,
                     "git tag -m {tag} {tag} {commit}{force_option}".format(
                         tag=tag, commit=commit, force_option=force_option
-                    )
+                    ),
                 )
+                if not ok:
+                    raise Exit(
+                        color_message(
+                            "Could not create tag {}. Please rerun the task to retry creating the tags (do you need the --force option?)".format(
+                                tag,
+                            ),
+                            "red",
+                        ),
+                        code=1,
+                    )
                 print("Created tag {tag}".format(tag=tag))
                 if push:
                     ctx.run("git push origin {tag}{force_option}".format(tag=tag, force_option=force_option))
@@ -1000,6 +1011,32 @@ def check_upstream_branch(github, branch):
 
 def parse_major_versions(major_versions):
     return sorted(int(x) for x in major_versions.split(","))
+
+
+def try_git_command(ctx, git_command):
+    """
+    Try a git command that should be retried (after user confirmation) if it fails.
+    Primarily useful for commands which can fail if commit signing fails: we don't want the
+    whole workflow to fail if that happens, we want to retry.
+    """
+
+    do_retry = True
+
+    while do_retry:
+        res = ctx.run(git_command, warn=True)
+        if res.exited is None or res.exited > 0:
+            print(
+                color_message(
+                    "Failed to run \"{}\" (did the commit/tag signing operation fail?)".format(git_command),
+                    "orange",
+                )
+            )
+            do_retry = yes_no_question("Do you want to retry this operation?", color="orange", default=True)
+            continue
+
+        return True
+
+    return False
 
 
 @task
@@ -1169,8 +1206,8 @@ Make sure that milestone is open before trying again.""".format(
     ctx.run("git add release.json")
     ctx.run("git ls-files . | grep 'go.mod$' | xargs git add")
 
-    res = ctx.run("git commit -m 'Update release.json and Go modules for {}'".format(versions_string), warn=True)
-    if res.exited is None or res.exited > 0:
+    ok = try_git_command(ctx, "git commit -m 'Update release.json and Go modules for {}'".format(versions_string))
+    if not ok:
         raise Exit(
             color_message(
                 "Could not create commit. Please commit manually, push the {} branch and then open a PR against {}.".format(

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -917,7 +917,7 @@ def tag_version(ctx, agent_version, commit="HEAD", verify=True, push=True, force
                 if not ok:
                     raise Exit(
                         color_message(
-                            "Could not create tag {}. Please rerun the task to retry creating the tags (do you need the --force option?)".format(
+                            "Could not create tag {}. Please rerun the task to retry creating the tags (you may need the --force option)".format(
                                 tag,
                             ),
                             "red",

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -915,15 +915,8 @@ def tag_version(ctx, agent_version, commit="HEAD", verify=True, push=True, force
                     ),
                 )
                 if not ok:
-                    raise Exit(
-                        color_message(
-                            "Could not create tag {}. Please rerun the task to retry creating the tags (you may need the --force option)".format(
-                                tag,
-                            ),
-                            "red",
-                        ),
-                        code=1,
-                    )
+                    message = f"Could not create tag {tag}. Please rerun the task to retry creating the tags (you may need the --force option)"
+                    raise Exit(color_message(message, "red"), code=1)
                 print("Created tag {tag}".format(tag=tag))
                 if push:
                     ctx.run("git push origin {tag}{force_option}".format(tag=tag, force_option=force_option))


### PR DESCRIPTION
### What does this PR do?

Adds a retry mechanism to some git commands made during `invoke release.create-rc` and `invoke release.build-rc`, as these commands can fail if commit signing is enabled & the signing fails (eg. wrong pin, user away from keyboard, etc.).

### Motivation

Prevent disrupting the whole workflow if one (retriable) operation fails.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
