### PR TITLE
[corechecks/snmp] Sort OIDs used to fetch values

### DIFF
--- a/pkg/collector/corechecks/snmp/checkconfig/config_oid.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config_oid.go
@@ -1,5 +1,7 @@
 package checkconfig
 
+import "sort"
+
 // OidConfig holds configs for OIDs to fetch
 type OidConfig struct {
 	// ScalarOids are all scalar oids to fetch
@@ -30,5 +32,6 @@ func (oc *OidConfig) addOidsIfNotPresent(configOids []string, oidsToAdd []string
 		}
 		configOids = append(configOids, oidToAdd)
 	}
+	sort.Strings(configOids)
 	return configOids
 }

--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck_test.go
@@ -65,9 +65,9 @@ profiles:
 		{
 			Variables: []gosnmp.SnmpPDU{
 				{
-					Name:  "1.3.6.1.2.1.1.5.0",
+					Name:  "1.2.3.4.5",
 					Type:  gosnmp.OctetString,
-					Value: []byte("foo_sys_name"),
+					Value: []byte("some_value"),
 				},
 				{
 					Name:  "1.3.6.1.2.1.1.1.0",
@@ -85,13 +85,26 @@ profiles:
 					Value: 20,
 				},
 				{
+					Name:  "1.3.6.1.2.1.1.5.0",
+					Type:  gosnmp.OctetString,
+					Value: []byte("foo_sys_name"),
+				},
+			},
+		},
+		{
+			Variables: []gosnmp.SnmpPDU{
+				{
 					Name:  "1.3.6.1.4.1.3375.2.1.1.2.1.44.0",
 					Type:  gosnmp.Integer,
 					Value: 30,
 				},
+				{
+					Name:  "1.3.6.1.4.1.3375.2.1.1.2.1.44.999",
+					Type:  gosnmp.Integer,
+					Value: 40,
+				},
 			},
 		},
-		{},
 	}
 
 	bulkPackets := []gosnmp.SnmpPacket{
@@ -227,15 +240,15 @@ profiles:
 	sess.On("GetNext", []string{"1.3"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&sysObjectIDPacket, nil)
 	sess.On("Get", []string{
-		"1.3.6.1.2.1.1.5.0",
+		"1.2.3.4.5",
 		"1.3.6.1.2.1.1.1.0",
 		"1.3.6.1.2.1.1.2.0",
 		"1.3.6.1.2.1.1.3.0",
-		"1.3.6.1.4.1.3375.2.1.1.2.1.44.0",
+		"1.3.6.1.2.1.1.5.0",
 	}).Return(&packets[0], nil)
 	sess.On("Get", []string{
+		"1.3.6.1.4.1.3375.2.1.1.2.1.44.0",
 		"1.3.6.1.4.1.3375.2.1.1.2.1.44.999",
-		"1.2.3.4.5",
 	}).Return(&packets[1], nil)
 	sess.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.13", "1.3.6.1.2.1.2.2.1.14", "1.3.6.1.2.1.2.2.1.2", "1.3.6.1.2.1.2.2.1.6", "1.3.6.1.2.1.2.2.1.7"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkPackets[0], nil)
 	sess.On("GetBulk", []string{"1.3.6.1.2.1.2.2.1.8", "1.3.6.1.2.1.31.1.1.1.1", "1.3.6.1.2.1.31.1.1.1.18"}, checkconfig.DefaultBulkMaxRepetitions).Return(&bulkPackets[1], nil)

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -402,9 +402,9 @@ profiles:
 	packet := gosnmp.SnmpPacket{
 		Variables: []gosnmp.SnmpPDU{
 			{
-				Name:  "1.3.6.1.2.1.1.5.0",
-				Type:  gosnmp.OctetString,
-				Value: []byte("foo_sys_name"),
+				Name:  "1.2.3.4.5",
+				Type:  gosnmp.ObjectIdentifier,
+				Value: "1.2.3.4",
 			},
 			{
 				Name:  "1.3.6.1.2.1.1.1.0",
@@ -417,14 +417,24 @@ profiles:
 				Value: "1.2.3.4",
 			},
 			{
+				Name:  "1.3.6.1.2.1.1.3.0",
+				Type:  gosnmp.TimeTicks,
+				Value: 20,
+			},
+			{
+				Name:  "1.3.6.1.2.1.1.5.0",
+				Type:  gosnmp.OctetString,
+				Value: []byte("foo_sys_name"),
+			},
+			{
 				Name:  "1.3.6.1.4.1.3375.2.1.1.2.1.44.0",
 				Type:  gosnmp.Integer,
 				Value: 30,
 			},
 			{
-				Name:  "1.3.6.1.2.1.1.3.0",
-				Type:  gosnmp.TimeTicks,
-				Value: 20,
+				Name:  "1.3.6.1.4.1.3375.2.1.1.2.1.44.999",
+				Type:  gosnmp.Integer,
+				Value: 40,
 			},
 		},
 	}
@@ -556,13 +566,13 @@ profiles:
 
 	sess.On("GetNext", []string{"1.3"}).Return(&gosnmplib.MockValidReachableGetNextPacket, nil)
 	sess.On("Get", []string{
-		"1.3.6.1.2.1.1.5.0",
+		"1.2.3.4.5",
 		"1.3.6.1.2.1.1.1.0",
 		"1.3.6.1.2.1.1.2.0",
+		"1.3.6.1.2.1.1.3.0",
+		"1.3.6.1.2.1.1.5.0",
 		"1.3.6.1.4.1.3375.2.1.1.2.1.44.0",
 		"1.3.6.1.4.1.3375.2.1.1.2.1.44.999",
-		"1.2.3.4.5",
-		"1.3.6.1.2.1.1.3.0",
 	}).Return(&packet, nil)
 	sess.On("GetBulk", []string{
 		"1.3.6.1.2.1.2.2.1.13",
@@ -869,7 +879,7 @@ func TestCheck_Run(t *testing.T) {
 			sysObjectIDPacket:     sysObjectIDPacketOkMock,
 			valuesPacket:          valuesPacketErrMock,
 			valuesError:           fmt.Errorf("no value"),
-			expectedErr:           "failed to fetch values: failed to fetch scalar oids with batching: failed to fetch scalar oids: fetch scalar: error getting oids `[1.3.6.1.2.1.1.3.0 1.3.6.1.4.1.3375.2.1.1.2.1.44.0 1.3.6.1.4.1.3375.2.1.1.2.1.44.999 1.2.3.4.5 1.3.6.1.2.1.1.5.0]`: no value",
+			expectedErr:           "failed to fetch values: failed to fetch scalar oids with batching: failed to fetch scalar oids: fetch scalar: error getting oids `[1.2.3.4.5 1.3.6.1.2.1.1.3.0 1.3.6.1.2.1.1.5.0 1.3.6.1.4.1.3375.2.1.1.2.1.44.0 1.3.6.1.4.1.3375.2.1.1.2.1.44.999]`: no value",
 		},
 		{
 			name:                  "failed to fetch sysobjectid and failed to fetch values",
@@ -918,7 +928,7 @@ community_string: public
 
 			sess.On("GetNext", []string{"1.3"}).Return(&tt.reachableValuesPacket, tt.reachableGetNextError)
 			sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&tt.sysObjectIDPacket, tt.sysObjectIDError)
-			sess.On("Get", []string{"1.3.6.1.2.1.1.3.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.999", "1.2.3.4.5", "1.3.6.1.2.1.1.5.0"}).Return(&tt.valuesPacket, tt.valuesError)
+			sess.On("Get", []string{"1.2.3.4.5", "1.3.6.1.2.1.1.3.0", "1.3.6.1.2.1.1.5.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.0", "1.3.6.1.4.1.3375.2.1.1.2.1.44.999"}).Return(&tt.valuesPacket, tt.valuesError)
 			sess.On("Get", []string{"1.3.6.1.2.1.1.3.0"}).Return(&tt.valuesPacket, tt.valuesError)
 
 			sender.On("Gauge", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return()
@@ -1156,10 +1166,10 @@ tags:
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(sysObjectIDPacket, fmt.Errorf("no value"))
 
 	sess.On("Get", []string{
-		"1.3.6.1.2.1.1.5.0",
 		"1.3.6.1.2.1.1.1.0",
 		"1.3.6.1.2.1.1.2.0",
 		"1.3.6.1.2.1.1.3.0",
+		"1.3.6.1.2.1.1.5.0",
 	}).Return(&packet, nil)
 	sess.On("GetBulk", []string{
 		//"1.3.6.1.2.1.2.2.1.13",
@@ -1281,13 +1291,13 @@ tags:
 	sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(nilPacket, fmt.Errorf("no value"))
 
 	sess.On("Get", []string{
-		"1.3.6.1.2.1.1.5.0",
 		"1.3.6.1.2.1.1.1.0",
 		"1.3.6.1.2.1.1.2.0",
 		"1.3.6.1.2.1.1.3.0",
+		"1.3.6.1.2.1.1.5.0",
 	}).Return(nilPacket, fmt.Errorf("device failure"))
 
-	expectedErrMsg := "check device reachable: failed: no value for GetNext; failed to autodetect profile: failed to fetch sysobjectid: cannot get sysobjectid: no value; failed to fetch values: failed to fetch scalar oids with batching: failed to fetch scalar oids: fetch scalar: error getting oids `[1.3.6.1.2.1.1.5.0 1.3.6.1.2.1.1.1.0 1.3.6.1.2.1.1.2.0 1.3.6.1.2.1.1.3.0]`: device failure"
+	expectedErrMsg := "check device reachable: failed: no value for GetNext; failed to autodetect profile: failed to fetch sysobjectid: cannot get sysobjectid: no value; failed to fetch values: failed to fetch scalar oids with batching: failed to fetch scalar oids: fetch scalar: error getting oids `[1.3.6.1.2.1.1.1.0 1.3.6.1.2.1.1.2.0 1.3.6.1.2.1.1.3.0 1.3.6.1.2.1.1.5.0]`: device failure"
 
 	err = chk.Run()
 	assert.EqualError(t, err, expectedErrMsg)


### PR DESCRIPTION
### What does this PR do?

Sort OIDs used to fetch values

### Motivation

Can help getBulk/getNext be more efficient by grouping OIDs from same table.

### Additional Notes

### Describe how to test your changes

Test snmp corecheck still works as before, e.g. same number of metrics.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
