### PR TITLE
Fix Arch tests in extension-v12 

### DIFF
--- a/pkg/serverless/serverless.go
+++ b/pkg/serverless/serverless.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// +build !windows
-
 package serverless
 
 import (

--- a/pkg/serverless/serverless.go
+++ b/pkg/serverless/serverless.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// +build !windows
+
 package serverless
 
 import (

--- a/pkg/serverless/serverless_test.go
+++ b/pkg/serverless/serverless_test.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// +build !windows
-
 package serverless
 
 import (
@@ -62,7 +60,7 @@ func TestHandleInvocationShouldSetExtraTags(t *testing.T) {
 
 func TestComputeTimeout(t *testing.T) {
 	fakeCurrentTime := time.Date(2021, time.January, 1, 0, 0, 0, 0, time.UTC)
-	// add 10ms
+	// add 10m
 	fakeDeadLineInMs := fakeCurrentTime.UnixNano()/int64(time.Millisecond) + 10
 	safetyBuffer := 3 * time.Millisecond
 	assert.Equal(t, 7*time.Millisecond, computeTimeout(fakeCurrentTime, fakeDeadLineInMs, safetyBuffer))

--- a/pkg/serverless/serverless_test.go
+++ b/pkg/serverless/serverless_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// +build !windows
+
 package serverless
 
 import (

--- a/pkg/serverless/serverless_test.go
+++ b/pkg/serverless/serverless_test.go
@@ -6,12 +6,14 @@
 package serverless
 
 import (
+	"fmt"
 	"os"
 	"sort"
 	"testing"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/serverless/daemon"
+	"github.com/DataDog/datadog-agent/pkg/serverless/tags"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -32,6 +34,7 @@ func TestHandleInvocationShouldSetExtraTags(t *testing.T) {
 	os.Setenv("DD_EXTRA_TAGS", "a3:valueA3 a4:valueA4")
 
 	callInvocationHandler(d, "arn:aws:lambda:us-east-1:123456789012:function:my-function", deadlineMs, 0, "myRequestID", handleInvocation)
+	architecture := fmt.Sprintf("architecture:%s", tags.ResolveRuntimeArch())
 
 	expectedTagArray := []string{
 		"a1:valuea1",
@@ -40,6 +43,7 @@ func TestHandleInvocationShouldSetExtraTags(t *testing.T) {
 		"a4:valuea4",
 		"a_maj:valueamaj",
 		"account_id:123456789012",
+		architecture,
 		"aws_account:123456789012",
 		"dd_extension_version:xxx",
 		"function_arn:arn:aws:lambda:us-east-1:123456789012:function:my-function",

--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -8,12 +8,9 @@
 package tags
 
 import (
-	"bytes"
 	"fmt"
 	"os"
 	"strings"
-
-	"golang.org/x/sys/unix"
 )
 
 const (
@@ -139,19 +136,4 @@ func addTag(tagMap map[string]string, tag string) map[string]string {
 		tagMap[strings.ToLower(extract[0])] = strings.ToLower(extract[1])
 	}
 	return tagMap
-}
-
-// ResolveRuntimeArch determines the architecture of the lambda at runtime
-func ResolveRuntimeArch() string {
-	var uname unix.Utsname
-	if err := unix.Uname(&uname); err != nil {
-		return "amd64"
-	}
-
-	switch string(uname.Machine[:bytes.IndexByte(uname.Machine[:], 0)]) {
-	case "aarch64":
-		return "arm64"
-	default:
-		return "x86_64"
-	}
 }

--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// +build !windows
-
 package tags
 
 import (

--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -47,7 +47,7 @@ var currentExtensionVersion = "xxx"
 func BuildTagMap(arn string, configTags []string) map[string]string {
 	tags := make(map[string]string)
 
-	architecture := resolveRuntimeArch()
+	architecture := ResolveRuntimeArch()
 	tags = setIfNotEmpty(tags, architectureKey, architecture)
 
 	tags = setIfNotEmpty(tags, envKey, os.Getenv(envEnvVar))
@@ -139,7 +139,8 @@ func addTag(tagMap map[string]string, tag string) map[string]string {
 	return tagMap
 }
 
-func resolveRuntimeArch() string {
+// ResolveRuntimeArch determines the architecture of the lambda at runtime
+func ResolveRuntimeArch() string {
 	var uname unix.Utsname
 	if err := unix.Uname(&uname); err != nil {
 		return "amd64"

--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// +build !windows
+
 package tags
 
 import (

--- a/pkg/serverless/tags/tags_arch_unix.go
+++ b/pkg/serverless/tags/tags_arch_unix.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build !windows
+
+package tags
+
+import (
+	"bytes"
+
+	"golang.org/x/sys/unix"
+)
+
+// ResolveRuntimeArch determines the architecture of the lambda at runtime
+func ResolveRuntimeArch() string {
+	var uname unix.Utsname
+	if err := unix.Uname(&uname); err != nil {
+		return "amd64"
+	}
+
+	switch string(uname.Machine[:bytes.IndexByte(uname.Machine[:], 0)]) {
+	case "aarch64":
+		return "arm64"
+	default:
+		return "x86_64"
+	}
+}

--- a/pkg/serverless/tags/tags_arch_windows.go
+++ b/pkg/serverless/tags/tags_arch_windows.go
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build windows
+
+package tags
+
+// ResolveRuntimeArch determines the architecture of the lambda at runtime
+func ResolveRuntimeArch() string {
+	return "x86_64"
+}

--- a/pkg/serverless/tags/tags_test.go
+++ b/pkg/serverless/tags/tags_test.go
@@ -3,8 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-// +build !windows
-
 package tags
 
 import (

--- a/pkg/serverless/tags/tags_test.go
+++ b/pkg/serverless/tags/tags_test.go
@@ -73,7 +73,8 @@ func TestBuildTagMapFromArnIncomplete(t *testing.T) {
 	assert.Equal(t, "xxx", tagMap["dd_extension_version"])
 	assert.Equal(t, "value0", tagMap["tag0"])
 	assert.Equal(t, "value1", tagMap["tag1"])
-	assert.Equal(t, "x86_64", tagMap["architecture"])
+	// Result of this test depends on build environment
+	assert.True(t, tagMap["architecture"] == "x86_64" || tagMap["architecture"] == "arm64")
 
 }
 
@@ -89,7 +90,8 @@ func TestBuildTagMapFromArnIncompleteWithCommaAndSpaceTags(t *testing.T) {
 	assert.Equal(t, "value1", tagMap["tag1"])
 	assert.Equal(t, "value2", tagMap["tag2"])
 	assert.Equal(t, "value3", tagMap["tag3"])
-	assert.Equal(t, "x86_64", tagMap["architecture"])
+	// Result of this test depends on build environment
+	assert.True(t, tagMap["architecture"] == "x86_64" || tagMap["architecture"] == "arm64")
 }
 
 func TestBuildTagMapFromArnComplete(t *testing.T) {
@@ -107,7 +109,8 @@ func TestBuildTagMapFromArnComplete(t *testing.T) {
 	assert.Equal(t, "xxx", tagMap["dd_extension_version"])
 	assert.Equal(t, "value0", tagMap["tag0"])
 	assert.Equal(t, "value1", tagMap["tag1"])
-	assert.Equal(t, "x86_64", tagMap["architecture"])
+	// Result of this test depends on build environment
+	assert.True(t, tagMap["architecture"] == "x86_64" || tagMap["architecture"] == "arm64")
 }
 
 func TestBuildTagMapFromArnCompleteWithEnvAndVersionAndService(t *testing.T) {
@@ -135,7 +138,8 @@ func TestBuildTagMapFromArnCompleteWithEnvAndVersionAndService(t *testing.T) {
 	assert.Equal(t, "xxx", tagMap["dd_extension_version"])
 	assert.Equal(t, "value0", tagMap["tag0"])
 	assert.Equal(t, "value1", tagMap["tag1"])
-	assert.Equal(t, "x86_64", tagMap["architecture"])
+	// Result of this test depends on build environment
+	assert.True(t, tagMap["architecture"] == "x86_64" || tagMap["architecture"] == "arm64")
 }
 
 func TestBuildTagMapFromArnCompleteWithUpperCase(t *testing.T) {
@@ -153,7 +157,7 @@ func TestBuildTagMapFromArnCompleteWithUpperCase(t *testing.T) {
 	assert.Equal(t, "xxx", tagMap["dd_extension_version"])
 	assert.Equal(t, "value0", tagMap["tag0"])
 	assert.Equal(t, "value1", tagMap["tag1"])
-	assert.Equal(t, "x86_64", tagMap["architecture"])
+	assert.True(t, tagMap["architecture"] == "x86_64" || tagMap["architecture"] == "arm64")
 }
 
 func TestBuildTagMapFromArnCompleteWithLatest(t *testing.T) {
@@ -172,7 +176,7 @@ func TestBuildTagMapFromArnCompleteWithLatest(t *testing.T) {
 	assert.Equal(t, "xxx", tagMap["dd_extension_version"])
 	assert.Equal(t, "value0", tagMap["tag0"])
 	assert.Equal(t, "value1", tagMap["tag1"])
-	assert.Equal(t, "x86_64", tagMap["architecture"])
+	assert.True(t, tagMap["architecture"] == "x86_64" || tagMap["architecture"] == "arm64")
 }
 
 func TestBuildTagMapFromArnCompleteWithVersionNumber(t *testing.T) {
@@ -192,7 +196,7 @@ func TestBuildTagMapFromArnCompleteWithVersionNumber(t *testing.T) {
 	assert.Equal(t, "xxx", tagMap["dd_extension_version"])
 	assert.Equal(t, "value0", tagMap["tag0"])
 	assert.Equal(t, "value1", tagMap["tag1"])
-	assert.Equal(t, "x86_64", tagMap["architecture"])
+	assert.True(t, tagMap["architecture"] == "x86_64" || tagMap["architecture"] == "arm64")
 }
 
 func TestAddTagInvalid(t *testing.T) {

--- a/pkg/serverless/tags/tags_test.go
+++ b/pkg/serverless/tags/tags_test.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+// +build !windows
+
 package tags
 
 import (


### PR DESCRIPTION
### What does this PR do?

Breaks out unix specifc tag functionality into it's own file, and excludes from the windows build. A windows build of the extension is never used.

### Motivation

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
