### PR TITLE
[corechecks/snmp,listeners/snmp] Set collect_device_metadata to false by default

### DIFF
--- a/pkg/collector/corechecks/snmp/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config.go
@@ -246,7 +246,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 
 	// Set defaults before unmarshalling
 	instance.UseGlobalMetrics = true
-	initConfig.CollectDeviceMetadata = true
+	initConfig.CollectDeviceMetadata = false
 
 	err := yaml.Unmarshal(rawInitConfig, &initConfig)
 	if err != nil {

--- a/pkg/collector/corechecks/snmp/checkconfig/config_test.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config_test.go
@@ -953,7 +953,7 @@ oid_batch_size: 10
 `)
 	config, err := NewCheckConfig(rawInstanceConfig, rawInitConfig)
 	assert.Nil(t, err)
-	assert.Equal(t, true, config.CollectDeviceMetadata)
+	assert.Equal(t, false, config.CollectDeviceMetadata)
 
 	// language=yaml
 	rawInstanceConfig = []byte(`

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -101,7 +101,7 @@ func NewListenerConfig() (ListenerConfig, error) {
 		},
 	)
 	// Set defaults before unmarshalling
-	snmpConfig.CollectDeviceMetadata = true
+	snmpConfig.CollectDeviceMetadata = false
 	if err := coreconfig.Datadog.UnmarshalKey("snmp_listener", &snmpConfig, opt); err != nil {
 		return snmpConfig, err
 	}

--- a/pkg/snmp/snmp_test.go
+++ b/pkg/snmp/snmp_test.go
@@ -67,7 +67,7 @@ func TestBuildSNMPParams(t *testing.T) {
 func TestNewListenerConfig(t *testing.T) {
 	config.Datadog.SetConfigType("yaml")
 
-	// default collect_device_metadata should be true
+	// test default collect_device_metadata
 	err := config.Datadog.ReadConfig(strings.NewReader(`
 snmp_listener:
   configs:
@@ -83,7 +83,7 @@ snmp_listener:
 	assert.NoError(t, err)
 
 	assert.Equal(t, "127.0.0.1/30", conf.Configs[0].Network)
-	assert.Equal(t, true, conf.Configs[0].CollectDeviceMetadata)
+	assert.Equal(t, false, conf.Configs[0].CollectDeviceMetadata)
 	assert.Equal(t, "127.0.0.2/30", conf.Configs[1].Network)
 	assert.Equal(t, true, conf.Configs[1].CollectDeviceMetadata)
 	assert.Equal(t, "127.0.0.3/30", conf.Configs[2].Network)


### PR DESCRIPTION
### What does this PR do?

[corechecks/snmp,listeners/snmp] Set collect_device_metadata to false by default

### Motivation

Not setting collect_device_metadata to true by default for now since product not available for all clusters.

### Additional Notes

### Describe how to test your changes

- Test that ndm metadata is disabled by default for corecheck
- Test that ndm metadata is disabled by default for snmp listener

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
