### PR TITLE
Don't run chocolatey online jobs on custom beta

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -524,6 +524,18 @@ variables:
     when: on_success
   - when: never
 
+.on_deploy_stable_or_rc_tag_on_beta_repo_branch_a7_manual:
+  - <<: *if_not_version_7
+    when: never
+  - <<: *if_not_stable_or_beta_repo_branch
+    when: never
+  - <<: *if_rc_tag_on_beta_repo_branch
+    when: on_success
+  - <<: *if_deploy_on_stable_repo_branch
+    when: manual
+    allow_failure: true
+  - when: never
+
 # This rule is a variation of on_deploy_stable_or_beta_repo_branch_a7_manual where
 # the job is usually run manually, except when the pipeline
 # builds an RC: in this case, the job is run automatically.

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -524,7 +524,7 @@ variables:
     when: on_success
   - when: never
 
-.on_deploy_stable_or_rc_tag_on_beta_repo_branch_a7_manual:
+.on_deploy_stable_or_rc_tag_on_beta_repo_branch_a7_manual_on_stable:
   - <<: *if_not_version_7
     when: never
   - <<: *if_not_stable_or_beta_repo_branch

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -227,6 +227,9 @@ variables:
 .if_deploy_on_beta_repo_branch: &if_deploy_on_beta_repo_branch
   if: $DEPLOY_AGENT == "true" && $DEB_RPM_BUCKET_BRANCH == "beta"
 
+.if_deploy_on_stable_repo_branch: &if_deploy_on_stable_repo_branch
+  if: $DEPLOY_AGENT == "true" && $DEB_RPM_BUCKET_BRANCH == "stable"
+
 # Rule to trigger jobs only when a tag matches a given pattern (for RCs)
 # on the beta branch.
 # Note: due to workflow rules, rc tag => deploy pipeline, so there's technically no
@@ -509,6 +512,17 @@ variables:
   - <<: *if_deploy
     when: manual
     allow_failure: true
+
+.on_build_chocolatey:
+  - <<: *if_not_version_7
+    when: never
+  - <<: *if_not_stable_or_beta_repo_branch
+    when: never
+  - <<: *if_rc_tag_on_beta_repo_branch
+    when: on_success
+  - <<: *if_deploy_on_stable_repo_branch
+    when: on_success
+  - when: never
 
 # This rule is a variation of on_deploy_stable_or_beta_repo_branch_a7_manual where
 # the job is usually run manually, except when the pipeline

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -513,7 +513,7 @@ variables:
     when: manual
     allow_failure: true
 
-.on_build_chocolatey:
+.on_deploy_stable_or_rc_tag_on_beta_repo_branch_a7:
   - <<: *if_not_version_7
     when: never
   - <<: *if_not_stable_or_beta_repo_branch

--- a/.gitlab/choco_build.yml
+++ b/.gitlab/choco_build.yml
@@ -27,7 +27,7 @@ windows_choco_offline_7_x64:
 # it is run only once the msi package is pushed
 windows_choco_online_7_x64:
   rules:
-    !reference [.on_build_chocolatey]
+    !reference [.on_deploy_stable_or_rc_tag_on_beta_repo_branch_a7]
   stage: choco_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
   needs: ["deploy_staging_windows_tags-a7"]

--- a/.gitlab/choco_build.yml
+++ b/.gitlab/choco_build.yml
@@ -27,7 +27,7 @@ windows_choco_offline_7_x64:
 # it is run only once the msi package is pushed
 windows_choco_online_7_x64:
   rules:
-    !reference [.on_deploy_stable_or_beta_repo_branch_a7]
+    !reference [.on_deploy_stable_or_beta_repo_branch_a7_manual_auto_on_rc]
   stage: choco_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
   needs: ["deploy_staging_windows_tags-a7"]

--- a/.gitlab/choco_build.yml
+++ b/.gitlab/choco_build.yml
@@ -27,7 +27,7 @@ windows_choco_offline_7_x64:
 # it is run only once the msi package is pushed
 windows_choco_online_7_x64:
   rules:
-    !reference [.on_deploy_stable_or_beta_repo_branch_a7_manual_auto_on_rc]
+    !reference [.on_build_chocolatey]
   stage: choco_build
   tags: ["runner:windows-docker", "windowsversion:1809"]
   needs: ["deploy_staging_windows_tags-a7"]

--- a/.gitlab/choco_deploy.yml
+++ b/.gitlab/choco_deploy.yml
@@ -4,7 +4,7 @@
 
 publish_choco_7_x64:
   rules:
-    !reference [.on_deploy_stable_or_beta_repo_branch_a7_manual_auto_on_rc]
+    !reference [.on_build_chocolatey]
   stage: choco_deploy
   tags: ["runner:windows-docker", "windowsversion:1809"]
   needs: ["windows_choco_online_7_x64"]

--- a/.gitlab/choco_deploy.yml
+++ b/.gitlab/choco_deploy.yml
@@ -4,7 +4,7 @@
 
 publish_choco_7_x64:
   rules:
-    !reference [.on_build_chocolatey]
+    !reference [.on_deploy_stable_or_rc_tag_on_beta_repo_branch_a7]
   stage: choco_deploy
   tags: ["runner:windows-docker", "windowsversion:1809"]
   needs: ["windows_choco_online_7_x64"]

--- a/.gitlab/choco_deploy.yml
+++ b/.gitlab/choco_deploy.yml
@@ -4,7 +4,7 @@
 
 publish_choco_7_x64:
   rules:
-    !reference [.on_deploy_stable_or_rc_tag_on_beta_repo_branch_a7_manual]
+    !reference [.on_deploy_stable_or_rc_tag_on_beta_repo_branch_a7_manual_on_stable]
   stage: choco_deploy
   tags: ["runner:windows-docker", "windowsversion:1809"]
   needs: ["windows_choco_online_7_x64"]

--- a/.gitlab/choco_deploy.yml
+++ b/.gitlab/choco_deploy.yml
@@ -4,7 +4,7 @@
 
 publish_choco_7_x64:
   rules:
-    !reference [.on_deploy_stable_or_rc_tag_on_beta_repo_branch_a7]
+    !reference [.on_deploy_stable_or_rc_tag_on_beta_repo_branch_a7_manual]
   stage: choco_deploy
   tags: ["runner:windows-docker", "windowsversion:1809"]
   needs: ["windows_choco_online_7_x64"]


### PR DESCRIPTION
### What does this PR do?

This PR changes the rules of the chocolatey online jobs to no run in custom beta deploy pipelines, where they failed systematically.

### Motivation

Not waste resources on jobs that we know are going to fail.
