### PR TITLE
Fix informer sync for new resources

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -275,22 +275,22 @@ func (o *OrchestratorCheck) Configure(config, initConfig integration.Data, sourc
 			roleBindingsInformer := apiCl.InformerFactory.Rbac().V1().RoleBindings()
 			o.roleBindingsLister = roleBindingsInformer.Lister()
 			o.roleBindingsListerSync = roleBindingsInformer.Informer().HasSynced
-			informersToSync[apiserver.InformerName(orchestrator.K8sRole.String())] = roleBindingsInformer.Informer()
+			informersToSync[apiserver.InformerName(orchestrator.K8sRoleBinding.String())] = roleBindingsInformer.Informer()
 		case "clusterroles":
 			clusterRolesInformer := apiCl.InformerFactory.Rbac().V1().ClusterRoles()
 			o.clusterRolesLister = clusterRolesInformer.Lister()
 			o.clusterRolesListerSync = clusterRolesInformer.Informer().HasSynced
-			informersToSync[apiserver.InformerName(orchestrator.K8sRole.String())] = clusterRolesInformer.Informer()
+			informersToSync[apiserver.InformerName(orchestrator.K8sClusterRole.String())] = clusterRolesInformer.Informer()
 		case "clusterrolebindings":
 			clusterRoleBindingsInformer := apiCl.InformerFactory.Rbac().V1().ClusterRoleBindings()
 			o.clusterRoleBindingsLister = clusterRoleBindingsInformer.Lister()
 			o.clusterRoleBindingsListerSync = clusterRoleBindingsInformer.Informer().HasSynced
-			informersToSync[apiserver.InformerName(orchestrator.K8sRole.String())] = clusterRoleBindingsInformer.Informer()
+			informersToSync[apiserver.InformerName(orchestrator.K8sClusterRoleBinding.String())] = clusterRoleBindingsInformer.Informer()
 		case "serviceaccounts":
 			serviceAccountsInformer := apiCl.InformerFactory.Core().V1().ServiceAccounts()
 			o.serviceAccountsLister = serviceAccountsInformer.Lister()
 			o.serviceAccountsListerSync = serviceAccountsInformer.Informer().HasSynced
-			informersToSync[apiserver.InformerName(orchestrator.K8sRole.String())] = serviceAccountsInformer.Informer()
+			informersToSync[apiserver.InformerName(orchestrator.K8sServiceAccount.String())] = serviceAccountsInformer.Informer()
 		default:
 			_ = o.Warnf("Unsupported collector: %s", v)
 		}


### PR DESCRIPTION
### What does this PR do?

Fix informer sync in https://github.com/DataDog/datadog-agent/pull/9026

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
