### PR TITLE
[runtime-security] fix 4.15 compatibility

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "92d513030390999dbbefd681782a31df0700a923a599fe848b4f244661bda309")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "cb8b84c723a0d8de0779a19c400d0cee7c68bd7324eae132b0618b2031ebce38")

--- a/pkg/security/ebpf/c/dentry_resolver.h
+++ b/pkg/security/ebpf/c/dentry_resolver.h
@@ -384,7 +384,8 @@ int kprobe_dentry_resolver_segment_erpc(struct pt_regs *ctx) {
     }
 
     // resolve segment and write in buffer
-    struct path_leaf_t *map_value = bpf_map_lookup_elem(&pathnames, &state->key);
+    struct path_key_t path_key = state->key;
+    struct path_leaf_t *map_value = bpf_map_lookup_elem(&pathnames, &path_key);
     if (map_value == NULL) {
         resolution_err = DR_ERPC_CACHE_MISS;
         goto exit;
@@ -428,7 +429,8 @@ int kprobe_dentry_resolver_parent_erpc(struct pt_regs *ctx) {
     }
 
     // resolve segment and write in buffer
-    struct path_leaf_t *map_value = bpf_map_lookup_elem(&pathnames, &state->key);
+    struct path_key_t path_key = state->key;
+    struct path_leaf_t *map_value = bpf_map_lookup_elem(&pathnames, &path_key);
     if (map_value == NULL) {
         resolution_err = DR_ERPC_CACHE_MISS;
         goto exit;

--- a/pkg/security/tests/chown32_test.go
+++ b/pkg/security/tests/chown32_test.go
@@ -48,7 +48,11 @@ func TestChown32(t *testing.T) {
 
 	syscallTester, err := loadSyscallTester(t, test, "syscall_x86_tester")
 	if err != nil {
-		t.Fatal(err)
+		if _, ok := err.(ErrUnsupportedArch); ok {
+			t.Skip(err)
+		} else {
+			t.Fatal(err)
+		}
 	}
 
 	prevUID := 98

--- a/pkg/security/tests/setup_test.go
+++ b/pkg/security/tests/setup_test.go
@@ -15,6 +15,7 @@ import (
 	"io"
 	"io/fs"
 	"io/ioutil"
+	"math/rand"
 	"net"
 	"os"
 	"os/exec"
@@ -1024,4 +1025,16 @@ func init() {
 	flag.BoolVar(&useReload, "reload", true, "reload rules instead of stopping/starting the agent for every test")
 	flag.StringVar(&logLevelStr, "loglevel", seelog.WarnStr, "log level")
 	flag.Var(&logPatterns, "logpattern", "List of log pattern")
+	rand.Seed(time.Now().UnixNano())
+}
+
+var letterRunes = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+
+// randStringRunes returns a random string of the requested size
+func randStringRunes(n int) string {
+	b := make([]rune, n)
+	for i := range b {
+		b[i] = letterRunes[rand.Intn(len(letterRunes))]
+	}
+	return string(b)
 }

--- a/pkg/security/tests/span_test.go
+++ b/pkg/security/tests/span_test.go
@@ -89,7 +89,11 @@ func TestSpan(t *testing.T) {
 	t.Run("exec", func(t *testing.T) {
 		syscallTester, err := loadSyscallTester(t, test, "syscall_tester")
 		if err != nil {
-			t.Fatal(err)
+			if _, ok := err.(ErrUnsupportedArch); ok {
+				t.Skip(err)
+			} else {
+				t.Fatal(err)
+			}
 		}
 
 		err = test.GetSignal(t, func() error {

--- a/pkg/security/tests/syscall_tester.go
+++ b/pkg/security/tests/syscall_tester.go
@@ -8,15 +8,38 @@
 package tests
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
 	"testing"
 
+	"golang.org/x/sys/unix"
+
 	"github.com/DataDog/datadog-agent/pkg/security/tests/syscall_tester"
 )
 
+// ErrUnsupportedArch is the error returned for unsupported architectures
+type ErrUnsupportedArch struct {
+	arch string
+}
+
+// Error returns the error string
+func (ua ErrUnsupportedArch) Error() string {
+	return fmt.Sprintf("unsupported_arch: %s", ua.arch)
+}
+
 func loadSyscallTester(t *testing.T, test *testModule, binary string) (string, error) {
+	var uname unix.Utsname
+	if err := unix.Uname(&uname); err != nil {
+		return "", fmt.Errorf("couldn't resolve arch: %s", err)
+	}
+
+	switch string(uname.Machine[:bytes.IndexByte(uname.Machine[:], 0)]) {
+	case "aarch64":
+		return "", ErrUnsupportedArch{arch: "aarch64"}
+	}
+
 	testerBin, err := syscall_tester.Asset("/" + binary)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
### What does this PR do?

4.15 kernel compatibility was broken [in this previous commit](https://github.com/DataDog/datadog-agent/commit/f7301563392a88821788ea39e40409e5ebc0b918). This PR fixes it so that the agent can run on 4.15 kernels.

### Motivation

Support Ubuntu Bionic with 4.15 kernels.

### Describe how to test your changes

Boot a Ubuntu Bionic VM with a 4.15 kernel and make sure the functional tests are successful.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.