### PR TITLE
Use t4g.xlarge for kitchen arm64 testing

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -52,7 +52,7 @@ kitchen_test_security_agent_arm64:
   needs: [ "tests_ebpf_arm64" ]
   variables:
     KITCHEN_ARCH: arm64
-    KITCHEN_EC2_INSTANCE_TYPE: "t4g.large"
+    KITCHEN_EC2_INSTANCE_TYPE: "t4g.xlarge"
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - cd $DD_AGENT_TESTING_DIR

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -49,7 +49,7 @@ kitchen_test_system_probe_linux_arm64:
   needs: [ "tests_ebpf_arm64" ]
   variables:
     KITCHEN_ARCH: arm64
-    KITCHEN_EC2_INSTANCE_TYPE: "t4g.large"
+    KITCHEN_EC2_INSTANCE_TYPE: "t4g.xlarge"
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - cd $DD_AGENT_TESTING_DIR


### PR DESCRIPTION
### What does this PR do?

Use `t4g.xlarge` instances for arm64 kitchen testing

### Motivation

Spot requests were failing to be fulfilled with `t4g.large` instances, resulting in no arm64 CI kitchen testing

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
