### PR TITLE
[networks] Fix path resolution for OpenSSL

### DIFF
--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -262,6 +262,7 @@ int kprobe__do_sys_open(struct pt_regs* ctx) {
     }
 
     u64 pid_tgid = bpf_get_current_pid_tgid();
+    path.pid = pid_tgid >> 32;
     bpf_map_update_elem(&open_at_args, &pid_tgid, &path, BPF_ANY);
     return 0;
 }

--- a/pkg/network/http/shared_libraries.go
+++ b/pkg/network/http/shared_libraries.go
@@ -113,7 +113,7 @@ func (w *soWatcher) Start() {
 
 						// resolving paths is expensive so we cache the libraries we already seen
 						k := seenKey{pidPath, libPath}
-						if _, ok := seen[seenKey{pidPath, libPath}]; ok {
+						if _, ok := seen[k]; ok {
 							break
 						}
 						seen[k] = struct{}{}

--- a/pkg/network/http/shared_libraries.go
+++ b/pkg/network/http/shared_libraries.go
@@ -48,12 +48,15 @@ type soRule struct {
 
 // soWatcher provides a way to tie callback functions to the lifecycle of shared libraries
 type soWatcher struct {
-	procRoot     string
-	pathResolver *psfilepath.Resolver
-	all          *regexp.Regexp
-	rules        []soRule
-	registered   map[string]func(string) error
-	loadEvents   *ddebpf.PerfHandler
+	procRoot   string
+	all        *regexp.Regexp
+	rules      []soRule
+	registered map[string]func(string) error
+	loadEvents *ddebpf.PerfHandler
+}
+
+type seenKey struct {
+	pid, path string
 }
 
 func newSOWatcher(procRoot string, perfHandler *ddebpf.PerfHandler, rules ...soRule) *soWatcher {
@@ -64,16 +67,16 @@ func newSOWatcher(procRoot string, perfHandler *ddebpf.PerfHandler, rules ...soR
 
 	all := regexp.MustCompile(fmt.Sprintf("(%s)", strings.Join(allFilters, "|")))
 	return &soWatcher{
-		procRoot:     procRoot,
-		pathResolver: psfilepath.NewResolver(procRoot),
-		all:          all,
-		rules:        rules,
-		loadEvents:   perfHandler,
+		procRoot:   procRoot,
+		all:        all,
+		rules:      rules,
+		loadEvents: perfHandler,
 	}
 }
 
 // Start consuming shared-library events
 func (w *soWatcher) Start() {
+	seen := make(map[seenKey]struct{})
 	sharedLibraries := getSharedLibraries(w.procRoot, w.all)
 	w.sync(sharedLibraries)
 	go func() {
@@ -84,6 +87,7 @@ func (w *soWatcher) Start() {
 		for {
 			select {
 			case <-ticker.C:
+				seen = make(map[seenKey]struct{})
 				sharedLibraries := getSharedLibraries(w.procRoot, w.all)
 				w.sync(sharedLibraries)
 			case event, ok := <-w.loadEvents.DataChannel:
@@ -103,12 +107,20 @@ func (w *soWatcher) Start() {
 				for _, r := range w.rules {
 					if r.re.Match(path) {
 						var (
-							libPath  = string(path)
-							pidPath  = fmt.Sprintf("%s/%d", w.procRoot, lib.pid)
-							hostPath = w.pathResolver.LoadPIDMounts(pidPath).Resolve(libPath)
+							libPath = string(path)
+							pidPath = fmt.Sprintf("%s/%d", w.procRoot, lib.pid)
 						)
 
-						if hostPath != "" {
+						// resolving paths is expensive so we cache the libraries we already seen
+						k := seenKey{pidPath, libPath}
+						if _, ok := seen[seenKey{pidPath, libPath}]; ok {
+							break
+						}
+						seen[k] = struct{}{}
+
+						pathResolver := psfilepath.NewResolver(w.procRoot)
+						pathResolver.LoadPIDMounts(pidPath)
+						if hostPath := pathResolver.Resolve(libPath); hostPath != "" {
 							libPath = hostPath
 						}
 


### PR DESCRIPTION
### What does this PR do?

Fix translation from a namespaced library path to a host path.
* The data sent from eBPF (tracing `do_sys_open`) was missing the PID param, so we were not being able to retrieve the appropriate mount information to translate to the host path;
* We were also re-using the same instance of `pspath.Resolver`, which doesn't reload the mount information for the root namespace which causes the resolution to fail in certain cases;

### Motivation

This is necessary for tracing OpenSSL in containerized environments.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

1. Install system-probe *and docker* in your QA box;
2. Add the following lines to your `system-probe.yaml` file:
```
system_probe_config:
  log_level: debug
network_config:
  enable_http_monitoring: true
  enable_https_monitoring: true
```
3. Start system-probe
4. Launch a container (eg. `docker run -it ubuntu:20.04 /bin/bash`) and issue a few HTTPS requests using `curl --http1.1 https://httpbin.org/status/200`
5. You should see a log entry like the following:
```
2021-09-22 17:24:42 UTC | SYS-PROBE | DEBUG | (pkg/network/http/shared_libraries.go:168 in register) | registering library=/lib/x86_64-linux-gnu/libssl.so.1.1
2021-09-22 17:24:42 UTC | SYS-PROBE | DEBUG | (pkg/network/http/shared_libraries.go:168 in register) | registering library=/lib/x86_64-linux-gnu/libcrypto.so.1.1
```
Now, verify the requests show up in: 
```
curl --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/debug/http_monitoring | jq
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
