### PR TITLE
Split tagstore into multiple source files

### DIFF
--- a/pkg/tagger/tagstore/entity_tags.go
+++ b/pkg/tagger/tagstore/entity_tags.go
@@ -1,0 +1,161 @@
+package tagstore
+
+import (
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
+	"github.com/DataDog/datadog-agent/pkg/tagger/types"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// EntityTags holds the tag information for a given entity. It is not
+// thread-safe, so should not be shared outside of the store. Usage inside the
+// store is safe since it relies on a global lock.
+type EntityTags struct {
+	entityID           string
+	sourceTags         map[string]sourceTags
+	cacheValid         bool
+	cachedSource       []string
+	cachedAll          util.HashedTags // Low + orchestrator + high
+	cachedOrchestrator util.HashedTags // Low + orchestrator (subslice of cachedAll)
+	cachedLow          util.HashedTags // Sub-slice of cachedAll
+}
+
+func newEntityTags(entityID string) *EntityTags {
+	return &EntityTags{
+		entityID:   entityID,
+		sourceTags: make(map[string]sourceTags),
+		cacheValid: true,
+	}
+}
+
+func (e *EntityTags) getStandard() []string {
+	tags := []string{}
+	for _, t := range e.sourceTags {
+		tags = append(tags, t.standardTags...)
+	}
+	return tags
+}
+
+func (e *EntityTags) get(cardinality collectors.TagCardinality) ([]string, []string) {
+	tags, sources := e.getHashedTags(cardinality)
+	return tags.Get(), sources
+}
+
+func (e *EntityTags) getHashedTags(cardinality collectors.TagCardinality) (util.HashedTags, []string) {
+	e.computeCache()
+
+	if cardinality == collectors.HighCardinality {
+		return e.cachedAll, e.cachedSource
+	} else if cardinality == collectors.OrchestratorCardinality {
+		return e.cachedOrchestrator, e.cachedSource
+	}
+	return e.cachedLow, e.cachedSource
+}
+
+func (e *EntityTags) toEntity() types.Entity {
+	e.computeCache()
+
+	cachedAll := e.cachedAll.Get()
+	cachedOrchestrator := e.cachedOrchestrator.Get()
+	cachedLow := e.cachedLow.Get()
+
+	return types.Entity{
+		ID:           e.entityID,
+		StandardTags: e.getStandard(),
+		// cachedAll contains low, orchestrator and high cardinality tags, in this order.
+		// cachedOrchestrator and cachedLow are subslices of cachedAll, starting at index 0.
+		HighCardinalityTags:         cachedAll[len(cachedOrchestrator):],
+		OrchestratorCardinalityTags: cachedOrchestrator[len(cachedLow):],
+		LowCardinalityTags:          cachedLow,
+	}
+}
+
+type tagPriority struct {
+	tag         string                       // full tag
+	priority    collectors.CollectorPriority // collector priority
+	cardinality collectors.TagCardinality    // cardinality level of the tag (low, orchestrator, high)
+}
+
+func (e *EntityTags) computeCache() {
+	if e.cacheValid {
+		return
+	}
+
+	var sources []string
+	tagPrioMapper := make(map[string][]tagPriority)
+
+	for source, tags := range e.sourceTags {
+		sources = append(sources, source)
+		insertWithPriority(tagPrioMapper, tags.lowCardTags, source, collectors.LowCardinality)
+		insertWithPriority(tagPrioMapper, tags.orchestratorCardTags, source, collectors.OrchestratorCardinality)
+		insertWithPriority(tagPrioMapper, tags.highCardTags, source, collectors.HighCardinality)
+	}
+
+	var lowCardTags []string
+	var orchestratorCardTags []string
+	var highCardTags []string
+	for _, tags := range tagPrioMapper {
+		for i := 0; i < len(tags); i++ {
+			insert := true
+			for j := 0; j < len(tags); j++ {
+				// if we find a duplicate tag with higher priority we do not insert the tag
+				if i != j && tags[i].priority < tags[j].priority {
+					insert = false
+					break
+				}
+			}
+			if !insert {
+				continue
+			}
+			if tags[i].cardinality == collectors.HighCardinality {
+				highCardTags = append(highCardTags, tags[i].tag)
+				continue
+			} else if tags[i].cardinality == collectors.OrchestratorCardinality {
+				orchestratorCardTags = append(orchestratorCardTags, tags[i].tag)
+				continue
+			}
+			lowCardTags = append(lowCardTags, tags[i].tag)
+		}
+	}
+
+	tags := append(lowCardTags, orchestratorCardTags...)
+	tags = append(tags, highCardTags...)
+
+	cached := util.NewHashedTagsFromSlice(tags)
+
+	// Write cache
+	e.cacheValid = true
+	e.cachedSource = sources
+	e.cachedAll = cached
+	e.cachedLow = cached.Slice(0, len(lowCardTags))
+	e.cachedOrchestrator = cached.Slice(0, len(lowCardTags)+len(orchestratorCardTags))
+}
+
+func (e *EntityTags) shouldRemove() bool {
+	for _, tags := range e.sourceTags {
+		if !tags.expiryDate.IsZero() || !tags.isEmpty() {
+			return false
+		}
+	}
+
+	return true
+}
+
+func insertWithPriority(tagPrioMapper map[string][]tagPriority, tags []string, source string, cardinality collectors.TagCardinality) {
+	priority, found := collectors.CollectorPriorities[source]
+	if !found {
+		log.Warnf("Tagger: %s collector has no defined priority, assuming low", source)
+		priority = collectors.NodeRuntime
+	}
+
+	for _, t := range tags {
+		tagName := strings.Split(t, ":")[0]
+		tagPrioMapper[tagName] = append(tagPrioMapper[tagName], tagPriority{
+			tag:         t,
+			priority:    priority,
+			cardinality: cardinality,
+		})
+	}
+}

--- a/pkg/tagger/tagstore/source_tags.go
+++ b/pkg/tagger/tagstore/source_tags.go
@@ -1,0 +1,25 @@
+package tagstore
+
+import "time"
+
+// sourceTags holds the tags for a given entity collected from a single source,
+// grouped by their cardinality.
+type sourceTags struct {
+	lowCardTags          []string
+	orchestratorCardTags []string
+	highCardTags         []string
+	standardTags         []string
+	expiryDate           time.Time
+}
+
+func (st *sourceTags) isEmpty() bool {
+	return len(st.lowCardTags) == 0 && len(st.orchestratorCardTags) == 0 && len(st.highCardTags) == 0 && len(st.standardTags) == 0
+}
+
+func (st *sourceTags) isExpired(t time.Time) bool {
+	if st.expiryDate.IsZero() {
+		return false
+	}
+
+	return st.expiryDate.Before(t)
+}

--- a/pkg/tagger/tagstore/tagstore.go
+++ b/pkg/tagger/tagstore/tagstore.go
@@ -8,7 +8,6 @@ package tagstore
 import (
 	"context"
 	"errors"
-	"strings"
 	"sync"
 	"time"
 
@@ -30,37 +29,6 @@ const (
 
 // ErrNotFound is returned when entity id is not found in the store.
 var ErrNotFound = errors.New("entity not found")
-
-// EntityTags holds the tag information for a given entity. It is not
-// thread-safe, so should not be shared outside of the store. Usage inside the
-// store is safe since it relies on a global lock.
-type EntityTags struct {
-	entityID           string
-	sourceTags         map[string]sourceTags
-	cacheValid         bool
-	cachedSource       []string
-	cachedAll          util.HashedTags // Low + orchestrator + high
-	cachedOrchestrator util.HashedTags // Low + orchestrator (subslice of cachedAll)
-	cachedLow          util.HashedTags // Sub-slice of cachedAll
-}
-
-func newEntityTags(entityID string) *EntityTags {
-	return &EntityTags{
-		entityID:   entityID,
-		sourceTags: make(map[string]sourceTags),
-		cacheValid: true,
-	}
-}
-
-// sourceTags holds the tags for a given entity collected from a single source,
-// grouped by their cardinality.
-type sourceTags struct {
-	lowCardTags          []string
-	orchestratorCardTags []string
-	highCardTags         []string
-	standardTags         []string
-	expiryDate           time.Time
-}
 
 // TagStore stores entity tags in memory and handles search and collation.
 // Queries should go through the Tagger for cache-miss handling
@@ -330,7 +298,7 @@ func (s *TagStore) LookupStandard(entityID string) ([]string, error) {
 	return storedTags.getStandard(), nil
 }
 
-// GetEntityTags returns the standard tags recorded for a given entity
+// GetEntityTags returns the EntityTags for a given entity
 func (s *TagStore) GetEntityTags(entityID string) (*EntityTags, error) {
 	s.RLock()
 	defer s.RUnlock()
@@ -341,54 +309,6 @@ func (s *TagStore) GetEntityTags(entityID string) (*EntityTags, error) {
 	}
 
 	return storedTags, nil
-}
-
-func (e *EntityTags) getStandard() []string {
-	tags := []string{}
-	for _, t := range e.sourceTags {
-		tags = append(tags, t.standardTags...)
-	}
-	return tags
-}
-
-type tagPriority struct {
-	tag         string                       // full tag
-	priority    collectors.CollectorPriority // collector priority
-	cardinality collectors.TagCardinality    // cardinality level of the tag (low, orchestrator, high)
-}
-
-func (e *EntityTags) get(cardinality collectors.TagCardinality) ([]string, []string) {
-	tags, sources := e.getHashedTags(cardinality)
-	return tags.Get(), sources
-}
-
-func (e *EntityTags) getHashedTags(cardinality collectors.TagCardinality) (util.HashedTags, []string) {
-	e.computeCache()
-
-	if cardinality == collectors.HighCardinality {
-		return e.cachedAll, e.cachedSource
-	} else if cardinality == collectors.OrchestratorCardinality {
-		return e.cachedOrchestrator, e.cachedSource
-	}
-	return e.cachedLow, e.cachedSource
-}
-
-func (e *EntityTags) toEntity() types.Entity {
-	e.computeCache()
-
-	cachedAll := e.cachedAll.Get()
-	cachedOrchestrator := e.cachedOrchestrator.Get()
-	cachedLow := e.cachedLow.Get()
-
-	return types.Entity{
-		ID:           e.entityID,
-		StandardTags: e.getStandard(),
-		// cachedAll contains low, orchestrator and high cardinality tags, in this order.
-		// cachedOrchestrator and cachedLow are subslices of cachedAll, starting at index 0.
-		HighCardinalityTags:         cachedAll[len(cachedOrchestrator):],
-		OrchestratorCardinalityTags: cachedOrchestrator[len(cachedLow):],
-		LowCardinalityTags:          cachedLow,
-	}
 }
 
 // List returns full list of entities and their tags per source in an API format.
@@ -416,100 +336,6 @@ func (s *TagStore) List() response.TaggerListResponse {
 	}
 
 	return r
-}
-
-func (e *EntityTags) computeCache() {
-	if e.cacheValid {
-		return
-	}
-
-	var sources []string
-	tagPrioMapper := make(map[string][]tagPriority)
-
-	for source, tags := range e.sourceTags {
-		sources = append(sources, source)
-		insertWithPriority(tagPrioMapper, tags.lowCardTags, source, collectors.LowCardinality)
-		insertWithPriority(tagPrioMapper, tags.orchestratorCardTags, source, collectors.OrchestratorCardinality)
-		insertWithPriority(tagPrioMapper, tags.highCardTags, source, collectors.HighCardinality)
-	}
-
-	var lowCardTags []string
-	var orchestratorCardTags []string
-	var highCardTags []string
-	for _, tags := range tagPrioMapper {
-		for i := 0; i < len(tags); i++ {
-			insert := true
-			for j := 0; j < len(tags); j++ {
-				// if we find a duplicate tag with higher priority we do not insert the tag
-				if i != j && tags[i].priority < tags[j].priority {
-					insert = false
-					break
-				}
-			}
-			if !insert {
-				continue
-			}
-			if tags[i].cardinality == collectors.HighCardinality {
-				highCardTags = append(highCardTags, tags[i].tag)
-				continue
-			} else if tags[i].cardinality == collectors.OrchestratorCardinality {
-				orchestratorCardTags = append(orchestratorCardTags, tags[i].tag)
-				continue
-			}
-			lowCardTags = append(lowCardTags, tags[i].tag)
-		}
-	}
-
-	tags := append(lowCardTags, orchestratorCardTags...)
-	tags = append(tags, highCardTags...)
-
-	cached := util.NewHashedTagsFromSlice(tags)
-
-	// Write cache
-	e.cacheValid = true
-	e.cachedSource = sources
-	e.cachedAll = cached
-	e.cachedLow = cached.Slice(0, len(lowCardTags))
-	e.cachedOrchestrator = cached.Slice(0, len(lowCardTags)+len(orchestratorCardTags))
-}
-
-func (e *EntityTags) shouldRemove() bool {
-	for _, tags := range e.sourceTags {
-		if !tags.expiryDate.IsZero() || !tags.isEmpty() {
-			return false
-		}
-	}
-
-	return true
-}
-
-func (st *sourceTags) isEmpty() bool {
-	return len(st.lowCardTags) == 0 && len(st.orchestratorCardTags) == 0 && len(st.highCardTags) == 0 && len(st.standardTags) == 0
-}
-
-func (st *sourceTags) isExpired(t time.Time) bool {
-	if st.expiryDate.IsZero() {
-		return false
-	}
-
-	return st.expiryDate.Before(t)
-}
-
-func insertWithPriority(tagPrioMapper map[string][]tagPriority, tags []string, source string, cardinality collectors.TagCardinality) {
-	priority, found := collectors.CollectorPriorities[source]
-	if !found {
-		log.Warnf("Tagger: %s collector has no defined priority, assuming low", source)
-		priority = collectors.NodeRuntime
-	}
-
-	for _, t := range tags {
-		tagName := strings.Split(t, ":")[0]
-		tagPrioMapper[tagName] = append(tagPrioMapper[tagName], tagPriority{
-			tag:         t,
-			priority:    priority,
-			cardinality: cardinality,
-		})
-	}
 }
 
 // GetEntity returns the entity corresponding to the specified id and an error


### PR DESCRIPTION
This does not actually change any of the implementations, but separates
each struct into its own file with its associated methods.

### Motivation

Reading the tagger implementation to learn how it works, this file was particularly confusing since the methods for the various structs were intermingled.