### PR TITLE
Remove Process Discovery Interval Message When Process Discovery is Disabled

### DIFF
--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -637,6 +637,7 @@ func TestGetHostnameShellCmd(t *testing.T) {
 // TestProcessDiscoveryConfig tests to make sure that the process discovery check is properly configured
 func TestProcessDiscoveryConfig(t *testing.T) {
 	assert := assert.New(t)
+
 	procConfigEnabledValues := []string{"true", "false", "disabled"}
 	procDiscoveryEnabledValues := []bool{true, false}
 	for _, procConfigEnabled := range procConfigEnabledValues {
@@ -647,19 +648,22 @@ func TestProcessDiscoveryConfig(t *testing.T) {
 			cfg := AgentConfig{EnabledChecks: []string{}, CheckIntervals: map[string]time.Duration{}}
 			cfg.initProcessDiscoveryCheck()
 
-			// Make sure that the discovery check interval can be overridden
-			assert.Equal(time.Hour, cfg.CheckIntervals[DiscoveryCheckName])
-
-			// Ensure that the minimum interval for the process_discovery check is enforced
-			config.Datadog.Set("process_config.process_discovery.interval", time.Second)
-			cfg = AgentConfig{EnabledChecks: []string{}, CheckIntervals: map[string]time.Duration{}}
-			cfg.initProcessDiscoveryCheck()
-			assert.Equal(10*time.Minute, cfg.CheckIntervals[DiscoveryCheckName])
-
 			// Make sure that the process discovery check is only enabled when both the process-agent is set to false,
 			// and procDiscoveryEnabled isn't overridden.
 			if procDiscoveryEnabled == true && procConfigEnabled == "false" {
 				assert.ElementsMatch([]string{DiscoveryCheckName}, cfg.EnabledChecks)
+
+				// Interval Tests:
+				// These can only be done while the check is enabled, which is why we do them here.
+
+				// Make sure that the discovery check interval can be overridden.
+				assert.Equal(time.Hour, cfg.CheckIntervals[DiscoveryCheckName])
+
+				// Ensure that the minimum interval for the process_discovery check is enforced
+				config.Datadog.Set("process_config.process_discovery.interval", time.Second)
+				cfg = AgentConfig{EnabledChecks: []string{}, CheckIntervals: map[string]time.Duration{}}
+				cfg.initProcessDiscoveryCheck()
+				assert.Equal(10*time.Minute, cfg.CheckIntervals[DiscoveryCheckName])
 			} else {
 				assert.ElementsMatch([]string{}, cfg.EnabledChecks)
 			}

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -301,15 +301,6 @@ func (a *AgentConfig) setCheckInterval(ns, check, checkKey string) {
 func (a *AgentConfig) initProcessDiscoveryCheck() {
 	root := key(ns, "process_discovery")
 
-	// We don't need to check if the key exists since we already bound it to a default in InitConfig.
-	// We use a minimum of 10 minutes for this value.
-	discoveryInterval := config.Datadog.GetDuration(key(root, "interval"))
-	if discoveryInterval < discoveryMinInterval {
-		discoveryInterval = discoveryMinInterval
-		_ = log.Warnf("Invalid interval for process discovery (<= %s) using default value of %[1]s", discoveryMinInterval.String())
-	}
-	a.CheckIntervals[DiscoveryCheckName] = discoveryInterval
-
 	// Discovery check should be only enabled when process_config.process_discovery.enabled = true and
 	// process_config.enabled is set to "false". This effectively makes sure the check only runs when the process check is
 	// disabled, while also respecting the users wishes when they want to disable either the check or the process agent completely.
@@ -317,5 +308,14 @@ func (a *AgentConfig) initProcessDiscoveryCheck() {
 	checkEnabled := config.Datadog.GetBool(key(root, "enabled"))
 	if checkEnabled && processAgentEnabled == "false" {
 		a.EnabledChecks = append(a.EnabledChecks, DiscoveryCheckName)
+
+		// We don't need to check if the key exists since we already bound it to a default in InitConfig.
+		// We use a minimum of 10 minutes for this value.
+		discoveryInterval := config.Datadog.GetDuration(key(root, "interval"))
+		if discoveryInterval < discoveryMinInterval {
+			discoveryInterval = discoveryMinInterval
+			_ = log.Warnf("Invalid interval for process discovery (<= %s) using default value of %[1]s", discoveryMinInterval.String())
+		}
+		a.CheckIntervals[DiscoveryCheckName] = discoveryInterval
 	}
 }


### PR DESCRIPTION
### What does this PR do?
Makes it so the process discovery invalid interval message is not shown when process discovery is disabled.

### Motivation

### Additional Notes

### Describe how to test your changes
Set this config in your `datadog.yaml`:
```
process_config:
  process_discovery:
    enabled: false
    interval: 10s
```
Then run the agent and make sure sure the "Invalid interval for process discovery (<= 10m0s)..." message does not appear.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
