### PR TITLE
[process-agent] Allow RTProcess check interval to be equal to the standard interval

### DIFF
--- a/pkg/process/checks/runner.go
+++ b/pkg/process/checks/runner.go
@@ -89,8 +89,8 @@ func (r *runnerWithRealTime) run() {
 }
 
 func getRtRatio(checkInterval, rtInterval time.Duration) (int, error) {
-	if checkInterval <= rtInterval {
-		return -1, errors.New("check interval should be larger than RT interval")
+	if checkInterval < rtInterval {
+		return -1, errors.New("check interval should be larger or equal to RT interval")
 	}
 	if checkInterval%rtInterval != 0 {
 		return -1, errors.New("check interval should be divisible by RT interval")

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -99,8 +99,8 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 	// and uses a different unit of time
 	a.initProcessDiscoveryCheck()
 
-	if a.CheckIntervals[ProcessCheckName] <= a.CheckIntervals[RTProcessCheckName] || a.CheckIntervals[ProcessCheckName]%a.CheckIntervals[RTProcessCheckName] != 0 {
-		// Process check interval must be greater than RTProcess check interval and the intervals must be divisible
+	if a.CheckIntervals[ProcessCheckName] < a.CheckIntervals[RTProcessCheckName] || a.CheckIntervals[ProcessCheckName]%a.CheckIntervals[RTProcessCheckName] != 0 {
+		// Process check interval must be greater or equal to RTProcess check interval and the intervals must be divisible
 		// in order to be run on the same goroutine
 		log.Warnf(
 			"Invalid process check interval overrides [%s,%s], resetting to defaults [%s,%s]",


### PR DESCRIPTION
### What does this PR do?

- Relaxes requirement for the RT interval allowing it to equal the standard Process check interval (this was valid config in prior versions).

- This enables both checks to reuse stats collection with low/negligible increase to CPU (only in payload submission).

### Motivation

Better config compatibility + allowing overrides for cases when we have high CPU and want to eliminate the impact of RT mode completely.

### Describe how to test your changes

Configure RTProcess and Process checks to have the same interval values:
```
intervals:
  process: 10
  process_realtime: 10
```
Ensure that checks run with these intervals as configured.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
