### PR TITLE
[gitlab] Fix cached wheel installation to provide expected pip freeze output

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -292,9 +292,11 @@ build do
 
       # install all wheels from cache in one pip invocation to speed things up
       if windows?
-        command "#{python} -m pip install --no-deps --no-index -r #{windows_safe_path(cached_wheels_dir)}\\found.txt"
+        command "#{python} -m pip install --no-deps --no-index " \
+          "--find-links #{windows_safe_path(cached_wheels_dir)} -r #{windows_safe_path(cached_wheels_dir)}\\found.txt"
       else
-        command "#{pip} install --no-deps --no-index -r #{cached_wheels_dir}/found.txt"
+        command "#{pip} install --no-deps --no-index " \
+          " --find-links #{cached_wheels_dir} -r #{cached_wheels_dir}/found.txt"
       end
     end
 

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -295,9 +295,9 @@ build do
 
       # install all wheels from cache in one pip invocation to speed things up
       if windows?
-        command "#{python} -m pip install --no-deps --no-index -r #{windows_safe_path(cached_wheels_dir)}\\found.txt"
+        command "#{python} -m pip install --no-deps --no-index --find-links #{windows_safe_path(cached_wheels_dir)} -r #{windows_safe_path(cached_wheels_dir)}\\found.txt"
       else
-        command "#{pip} install --no-deps --no-index -r #{cached_wheels_dir}/found.txt"
+        command "#{pip} install --no-deps --no-index --find-links #{cached_wheels_dir} -r #{cached_wheels_dir}/found.txt"
       end
     end
 

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -295,9 +295,11 @@ build do
 
       # install all wheels from cache in one pip invocation to speed things up
       if windows?
-        command "#{python} -m pip install --no-deps --no-index --find-links #{windows_safe_path(cached_wheels_dir)} -r #{windows_safe_path(cached_wheels_dir)}\\found.txt"
+        command "#{python} -m pip install --no-deps --no-index " \
+          " --find-links #{windows_safe_path(cached_wheels_dir)} -r #{windows_safe_path(cached_wheels_dir)}\\found.txt"
       else
-        command "#{pip} install --no-deps --no-index --find-links #{cached_wheels_dir} -r #{cached_wheels_dir}/found.txt"
+        command "#{pip} install --no-deps --no-index " \
+          "--find-links #{cached_wheels_dir} -r #{cached_wheels_dir}/found.txt"
       end
     end
 

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -768,7 +768,7 @@ def get_integrations_from_cache(ctx, python, bucket, branch, integrations_dir, t
         wheel_path = files_matched[0]
         print("Found cached wheel for integration {}".format(integration))
         shutil.move(wheel_path, target_dir)
-        found.append(os.path.join(target_dir, os.path.basename(wheel_path)))
+        found.append("datadog_{}".format(integration))
 
     print("Found {} cached integration wheels".format(len(found)))
     with open(os.path.join(target_dir, "found.txt"), "w") as f:


### PR DESCRIPTION
### What does this PR do?

Currently, because we list full wheel paths in `found.txt`, the output of `pip freeze` looks like this:

```
datadog-activemq @ file:///omnibus/src/datadog-agent-integrations-py3/integrations-core/.wheels/.cached/datadog_activemq-2.2.0-py3-none-any.whl
```

while the desired output (without the cache, what we had previously) was:

```
datadog-activemq==2.1.0
```

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Ensure that output of `pip freeze` contains lines in form `datadog-activemq==2.1.0` instead of `datadog-activemq @ file:///omnibus/src/datadog-agent-integrations-py3/integrations-core/.wheels/.cached/datadog_activemq-2.2.0-py3-none-any.whl` - test for both Python 2 and Python 3 integrations.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
