### PR TITLE
Run winget manually only

### DIFF
--- a/.gitlab/deploy_7/winget.yml
+++ b/.gitlab/deploy_7/winget.yml
@@ -5,7 +5,7 @@
 publish_winget_7_x64:
   dependencies: []
   rules:
-    !reference [.on_deploy_stable_or_beta_repo_branch_a7_manual_auto_on_rc]
+    !reference [.on_deploy_stable_or_beta_repo_branch_a7_manual]
   stage: deploy7
   tags: ["runner:windows-docker", "windowsversion:1809"]
   variables:


### PR DESCRIPTION
### What does this PR do?

This PR changes the winget publish job to be manual only.

### Motivation

Don't release RCs to winget public repository since it doesn't have a flag to distinguish between released versions and release candidates when installing the latest.
