### PR TITLE
Add default path to auto-activate containerd on Windows

### DIFF
--- a/pkg/config/environment_containers.go
+++ b/pkg/config/environment_containers.go
@@ -35,13 +35,14 @@ const (
 	// CloudFoundry socket present
 	CloudFoundry Feature = "cloudfoundry"
 
-	defaultLinuxDockerSocket       = "/var/run/docker.sock"
-	defaultWindowsDockerSocketPath = "//./pipe/docker_engine"
-	defaultLinuxContainerdSocket   = "/var/run/containerd/containerd.sock"
-	defaultLinuxCrioSocket         = "/var/run/crio/crio.sock"
-	defaultHostMountPrefix         = "/host"
-	unixSocketPrefix               = "unix://"
-	winNamedPipePrefix             = "npipe://"
+	defaultLinuxDockerSocket           = "/var/run/docker.sock"
+	defaultWindowsDockerSocketPath     = "//./pipe/docker_engine"
+	defaultLinuxContainerdSocket       = "/var/run/containerd/containerd.sock"
+	defaultWindowsContainerdSocketPath = "//./pipe/containerd-containerd"
+	defaultLinuxCrioSocket             = "/var/run/crio/crio.sock"
+	defaultHostMountPrefix             = "/host"
+	unixSocketPrefix                   = "unix://"
+	winNamedPipePrefix                 = "npipe://"
 
 	socketTimeout = 500 * time.Millisecond
 )
@@ -184,6 +185,10 @@ func getDefaultDockerPaths() []string {
 }
 
 func getDefaultCriPaths() []string {
+	if runtime.GOOS == "windows" {
+		return []string{defaultWindowsContainerdSocketPath}
+	}
+
 	paths := []string{}
 	for _, prefix := range getHostMountPrefixes() {
 		paths = append(paths, path.Join(prefix, defaultLinuxContainerdSocket), path.Join(prefix, defaultLinuxCrioSocket))


### PR DESCRIPTION
### What does this PR do?

Fix missing auto activation from #9296.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

`containerd` check should auto activate on Windows as soon as the default named pipe is mounted `\\.\pipe\containerd-containerd`

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
