### PR TITLE
[runtime-security] add linter to cws functional tests

### DIFF
--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -59,6 +59,8 @@ tests_ebpf_x64:
     - !reference [.retrieve_sysprobe_deps]
   script:
     - !reference [.build_sysprobe_artifacts]
+    - inv -e install-tools
+    - export PATH=$PATH:$GOPATH/bin
     # Compile runtime security functional tests to be executed in kitchen tests
     - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --build-flags "-race"
     # Compile runtime security stress tests to be executed in kitchen tests
@@ -90,6 +92,8 @@ tests_ebpf_arm64:
     - !reference [.retrieve_sysprobe_deps]
   script:
     - !reference [.build_sysprobe_artifacts]
+    - inv -e install-tools
+    - export PATH=$PATH:$GOPATH/bin
     # Compile runtime security functional tests to be executed in kitchen tests
     - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --build-flags "-race"
     # Compile runtime security stress tests to be executed in kitchen tests

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -151,7 +151,7 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 		c.EnableKernelFilters = false
 	}
 
-	if c.ERPCDentryResolutionEnabled == false && c.MapDentryResolutionEnabled == false {
+	if !c.ERPCDentryResolutionEnabled && !c.MapDentryResolutionEnabled {
 		c.MapDentryResolutionEnabled = true
 	}
 

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -389,16 +389,14 @@ func isInvalidDiscarder(field eval.Field, value interface{}) bool {
 func createInvalidDiscardersCache() map[eval.Field]map[interface{}]bool {
 	invalidDiscarders := make(map[eval.Field]map[interface{}]bool)
 
-	if InvalidDiscarders != nil {
-		for field, values := range InvalidDiscarders {
-			ivalues := invalidDiscarders[field]
-			if ivalues == nil {
-				ivalues = make(map[interface{}]bool)
-				invalidDiscarders[field] = ivalues
-			}
-			for _, value := range values {
-				ivalues[value] = true
-			}
+	for field, values := range InvalidDiscarders {
+		ivalues := invalidDiscarders[field]
+		if ivalues == nil {
+			ivalues = make(map[interface{}]bool)
+			invalidDiscarders[field] = ivalues
+		}
+		for _, value := range values {
+			ivalues[value] = true
 		}
 	}
 

--- a/pkg/security/probe/model_test.go
+++ b/pkg/security/probe/model_test.go
@@ -110,7 +110,7 @@ func TestExecArgsFlags(t *testing.T) {
 	}
 
 	flags := e.ResolveExecArgsFlags(&e.Exec)
-	sort.Sort(sort.StringSlice(flags))
+	sort.Strings(flags)
 
 	hasFlag := func(flags []string, flag string) bool {
 		i := sort.SearchStrings(flags, flag)

--- a/pkg/security/probe/perf_buffer_monitor.go
+++ b/pkg/security/probe/perf_buffer_monitor.go
@@ -163,7 +163,6 @@ func (pbm *PerfBufferMonitor) GetLostCount(perfMap string, cpu int) uint64 {
 		for i := range pbm.readLostEvents[perfMap] {
 			total += pbm.getLostCount(perfMap, i)
 		}
-		break
 	case cpu >= 0 && pbm.numCPU > cpu:
 		total += pbm.getLostCount(perfMap, cpu)
 	}
@@ -222,7 +221,6 @@ func (pbm *PerfBufferMonitor) GetAndResetLostCount(perfMap string, cpu int) uint
 		for i := range pbm.readLostEvents[perfMap] {
 			total += pbm.getAndResetReadLostCount(perfMap, i)
 		}
-		break
 	case cpu >= 0 && pbm.numCPU > cpu:
 		total += pbm.getAndResetReadLostCount(perfMap, cpu)
 	}
@@ -268,7 +266,6 @@ func (pbm *PerfBufferMonitor) GetEventStats(eventType model.EventType, perfMap s
 		for m := range pbm.stats {
 			maps = append(maps, m)
 		}
-		break
 	case pbm.stats[perfMap] != nil:
 		maps = append(maps, perfMap)
 	}
@@ -281,7 +278,6 @@ func (pbm *PerfBufferMonitor) GetEventStats(eventType model.EventType, perfMap s
 				stats.Count += pbm.getEventCount(eventType, perfMap, i)
 				stats.Bytes += pbm.getEventBytes(eventType, perfMap, i)
 			}
-			break
 		case cpu >= 0 && pbm.numCPU > cpu:
 			stats.Count += pbm.getEventCount(eventType, perfMap, cpu)
 			stats.Bytes += pbm.getEventBytes(eventType, perfMap, cpu)

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -813,7 +813,7 @@ func (p *ProcessResolver) cacheFlush(ctx context.Context) {
 
 	for {
 		select {
-		case _ = <-ticker.C:
+		case <-ticker.C:
 			var pids []uint32
 
 			p.RLock()

--- a/pkg/security/rules/bucket.go
+++ b/pkg/security/rules/bucket.go
@@ -89,12 +89,12 @@ func (rb *RuleBucket) GetApprovers(event eval.Event, fieldCaps FieldCapabilities
 
 			// only one approver is currently required to ensure that the rule will be applied
 			// this could be improve by adding weight to use the most valuable one
-			if ruleApprovers != nil && len(ruleApprovers) > 0 && fieldCaps.Validate(ruleApprovers) {
+			if len(ruleApprovers) > 0 && fieldCaps.Validate(ruleApprovers) {
 				break
 			}
 		}
 
-		if ruleApprovers == nil || len(ruleApprovers) == 0 || !fieldCaps.Validate(ruleApprovers) {
+		if len(ruleApprovers) == 0 || !fieldCaps.Validate(ruleApprovers) {
 			return nil, &ErrNoApprover{Fields: fieldCaps.GetFields()}
 		}
 		for field, values := range ruleApprovers {

--- a/pkg/security/rules/policy.go
+++ b/pkg/security/rules/policy.go
@@ -140,7 +140,7 @@ func LoadPolicies(policiesDir string, ruleSet *RuleSet) *multierror.Error {
 
 		if len(macros) > 0 {
 			// Add the macros to the ruleset and generate macros evaluators
-			if err := ruleSet.AddMacros(macros); err != nil {
+			if mErr := ruleSet.AddMacros(macros); mErr.ErrorOrNil() != nil {
 				result = multierror.Append(result, err)
 			}
 		}

--- a/pkg/security/rules/ruleset.go
+++ b/pkg/security/rules/ruleset.go
@@ -135,7 +135,7 @@ func (rs *RuleSet) ListMacroIDs() []MacroID {
 }
 
 // AddMacros parses the macros AST and adds them to the list of macros of the ruleset
-func (rs *RuleSet) AddMacros(macros []*MacroDefinition) error {
+func (rs *RuleSet) AddMacros(macros []*MacroDefinition) *multierror.Error {
 	var result *multierror.Error
 
 	// Build the list of macros for the ruleset

--- a/pkg/security/rules/ruleset_test.go
+++ b/pkg/security/rules/ruleset_test.go
@@ -39,7 +39,7 @@ func (f *testHandler) EventDiscarderFound(rs *RuleSet, event eval.Event, field s
 
 	ctx := eval.NewContext(event.GetPointer())
 
-	value := evaluator.(eval.Evaluator).Eval(ctx)
+	value := evaluator.Eval(ctx)
 
 	found := false
 	for _, d := range discarders {
@@ -49,7 +49,7 @@ func (f *testHandler) EventDiscarderFound(rs *RuleSet, event eval.Event, field s
 	}
 
 	if !found {
-		discarders = append(discarders, evaluator.(eval.Evaluator).Eval(ctx))
+		discarders = append(discarders, evaluator.Eval(ctx))
 	}
 	values[field] = discarders
 }

--- a/pkg/security/secl/eval/eval.go
+++ b/pkg/security/secl/eval/eval.go
@@ -764,10 +764,8 @@ func nodeToEvaluator(obj interface{}, opts *Opts, state *state) (interface{}, le
 					return boolEvaluator, obj.Pos, nil
 				}
 			case *IntEvaluator:
-				switch next.(type) {
+				switch nextInt := next.(type) {
 				case *IntEvaluator:
-					nextInt := next.(*IntEvaluator)
-
 					if nextInt.isDuration {
 						switch *obj.ScalarComparison.Op {
 						case "<":

--- a/pkg/security/secl/eval/operators.go
+++ b/pkg/security/secl/eval/operators.go
@@ -75,17 +75,11 @@ func StringEquals(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *sta
 
 	if a.regexp != nil {
 		arrayOp = func(as string, bs string) bool {
-			if a.regexp.MatchString(bs) {
-				return true
-			}
-			return false
+			return a.regexp.MatchString(bs)
 		}
 	} else if b.regexp != nil {
 		arrayOp = func(as string, bs string) bool {
-			if b.regexp.MatchString(as) {
-				return true
-			}
-			return false
+			return b.regexp.MatchString(as)
 		}
 	} else {
 		arrayOp = func(as string, bs string) bool {

--- a/pkg/security/tests/chmod_test.go
+++ b/pkg/security/tests/chmod_test.go
@@ -48,7 +48,7 @@ func TestChmod(t *testing.T) {
 			expectedMode = 0o707
 		}()
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			if _, _, errno := syscall.Syscall(syscall.SYS_FCHMOD, f.Fd(), uintptr(0o707), 0); errno != 0 {
 				return errno
 			}
@@ -66,15 +66,12 @@ func TestChmod(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("fchmodat", func(t *testing.T) {
 		defer func() { expectedMode = 0o757 }()
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			if _, _, errno := syscall.Syscall6(syscall.SYS_FCHMODAT, 0, uintptr(testFilePtr), uintptr(0o757), 0, 0, 0); errno != 0 {
 				t.Fatal(errno)
 			}
@@ -92,13 +89,10 @@ func TestChmod(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("chmod", ifSyscallSupported("SYS_CHMOD", func(t *testing.T, syscallNB uintptr) {
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			if _, _, errno := syscall.Syscall(syscallNB, uintptr(testFilePtr), uintptr(0o717), 0); errno != 0 {
 				t.Fatal(errno)
 			}
@@ -116,9 +110,5 @@ func TestChmod(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-
-		if err != nil {
-			t.Error(err)
-		}
 	}))
 }

--- a/pkg/security/tests/chown32_test.go
+++ b/pkg/security/tests/chown32_test.go
@@ -71,7 +71,7 @@ func TestChown32(t *testing.T) {
 			prevGID = 200
 		}()
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			// fchown syscall
 			return runSyscallTesterFunc(t, syscallTester, "chown", testFile, "100", "200")
 		}, func(event *sprobe.Event, r *rules.Rule) {
@@ -90,10 +90,6 @@ func TestChown32(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("fchown", func(t *testing.T) {
@@ -102,7 +98,7 @@ func TestChown32(t *testing.T) {
 			prevGID = 201
 		}()
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			// fchown syscall
 			return runSyscallTesterFunc(t, syscallTester, "fchown", testFile, "101", "201")
 		}, func(event *sprobe.Event, r *rules.Rule) {
@@ -121,10 +117,6 @@ func TestChown32(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("fchownat", func(t *testing.T) {
@@ -133,7 +125,7 @@ func TestChown32(t *testing.T) {
 			prevGID = 202
 		}()
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			// fchown syscall
 			return runSyscallTesterFunc(t, syscallTester, "fchownat", testFile, "102", "202")
 		}, func(event *sprobe.Event, r *rules.Rule) {
@@ -152,10 +144,6 @@ func TestChown32(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("lchown", func(t *testing.T) {
@@ -169,7 +157,7 @@ func TestChown32(t *testing.T) {
 		}
 		defer os.Remove(testSymlink)
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			// fchown syscall
 			return runSyscallTesterFunc(t, syscallTester, "lchown", testSymlink, "103", "203")
 		}, func(event *sprobe.Event, r *rules.Rule) {
@@ -188,10 +176,6 @@ func TestChown32(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("lchown32", func(t *testing.T) {
@@ -205,7 +189,7 @@ func TestChown32(t *testing.T) {
 		}
 		defer os.Remove(testSymlink)
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			// fchown syscall
 			return runSyscallTesterFunc(t, syscallTester, "lchown32", testSymlink, "104", "204")
 		}, func(event *sprobe.Event, r *rules.Rule) {
@@ -224,10 +208,6 @@ func TestChown32(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("fchown32", func(t *testing.T) {
@@ -237,7 +217,7 @@ func TestChown32(t *testing.T) {
 			prevGID = 205
 		}()
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			// fchown syscall
 			return runSyscallTesterFunc(t, syscallTester, "fchown32", testFile, "105", "205")
 		}, func(event *sprobe.Event, r *rules.Rule) {
@@ -256,10 +236,6 @@ func TestChown32(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("chown32", func(t *testing.T) {
@@ -268,7 +244,7 @@ func TestChown32(t *testing.T) {
 			prevGID = 206
 		}()
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			// fchown syscall
 			return runSyscallTesterFunc(t, syscallTester, "chown32", testFile, "106", "206")
 		}, func(event *sprobe.Event, r *rules.Rule) {
@@ -287,9 +263,5 @@ func TestChown32(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-
-		if err != nil {
-			t.Error(err)
-		}
 	})
 }

--- a/pkg/security/tests/chown_test.go
+++ b/pkg/security/tests/chown_test.go
@@ -56,7 +56,7 @@ func TestChown(t *testing.T) {
 			prevGID = 200
 		}()
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			// fchown syscall
 			if _, _, errno := syscall.Syscall(syscall.SYS_FCHOWN, f.Fd(), 100, 200); errno != 0 {
 				t.Fatal(err)
@@ -78,9 +78,6 @@ func TestChown(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("fchownat", func(t *testing.T) {
@@ -89,7 +86,7 @@ func TestChown(t *testing.T) {
 			prevGID = 201
 		}()
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			if _, _, errno := syscall.Syscall6(syscall.SYS_FCHOWNAT, 0, uintptr(testFilePtr), uintptr(101), uintptr(201), 0x100, 0); errno != 0 {
 				t.Fatal(err)
 			}
@@ -110,9 +107,6 @@ func TestChown(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("lchown", ifSyscallSupported("SYS_LCHOWN", func(t *testing.T, syscallNB uintptr) {
@@ -127,7 +121,7 @@ func TestChown(t *testing.T) {
 
 		defer os.Remove(testSymlink)
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			if _, _, errno := syscall.Syscall(syscallNB, uintptr(testSymlinkPtr), uintptr(102), uintptr(202)); errno != 0 {
 				if errno == unix.ENOSYS {
 					t.Skip("lchown is not supported")
@@ -152,9 +146,6 @@ func TestChown(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	}))
 
 	t.Run("chown", ifSyscallSupported("SYS_CHOWN", func(t *testing.T, syscallNB uintptr) {
@@ -163,7 +154,7 @@ func TestChown(t *testing.T) {
 			prevGID = 203
 		}()
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			if _, _, errno := syscall.Syscall(syscallNB, uintptr(testFilePtr), 103, 203); errno != 0 {
 				t.Fatal(err)
 			}
@@ -184,8 +175,5 @@ func TestChown(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	}))
 }

--- a/pkg/security/tests/cmdwrapper.go
+++ b/pkg/security/tests/cmdwrapper.go
@@ -17,9 +17,8 @@ type wrapperType string
 
 const (
 	stdWrapperType    wrapperType = "std"
-	dockerWrapperType             = "docker"
-	multiWrapperType              = "multi"
-	skipWrapperType               = "skip"
+	dockerWrapperType wrapperType = "docker"
+	multiWrapperType  wrapperType = "multi"
 )
 
 type cmdWrapper interface {

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -279,7 +279,7 @@ func TestDiscarderFilterMask(t *testing.T) {
 		defer os.Remove(testFile)
 
 		// not check that we still have the open allowed
-		if err := test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			testFile, testFilePtr, err = test.CreateWithOptions("test-mask", 98, 99, 0o447)
 			if err != nil {
 				t.Fatal(err)
@@ -287,9 +287,7 @@ func TestDiscarderFilterMask(t *testing.T) {
 			return nil
 		}, func(event *probe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_mask_open_rule")
-		}); err != nil {
-			t.Error(err)
-		}
+		})
 
 		utimbuf := &syscall.Utimbuf{
 			Actime:  123,
@@ -314,7 +312,7 @@ func TestDiscarderFilterMask(t *testing.T) {
 		}
 
 		// not check that we still have the open allowed
-		if err := test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			f, err := os.OpenFile(testFile, os.O_CREATE, 0)
 			if err != nil {
 				t.Fatal(err)
@@ -324,9 +322,7 @@ func TestDiscarderFilterMask(t *testing.T) {
 			return nil
 		}, func(event *probe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_mask_open_rule")
-		}); err != nil {
-			t.Error(err)
-		}
+		})
 	}))
 }
 
@@ -516,7 +512,7 @@ func TestDiscarderRetentionFilter(t *testing.T) {
 		t.Fatalf("should be discarded")
 	}
 
-	if diff := time.Now().Sub(start); uint64(diff) < uint64(probe.DiscardRetention)-uint64(time.Second) {
+	if diff := time.Since(start); uint64(diff) < uint64(probe.DiscardRetention)-uint64(time.Second) {
 		t.Errorf("discarder retention (%s) not reached: %s", time.Duration(uint64(probe.DiscardRetention)-uint64(time.Second)), diff)
 	}
 }

--- a/pkg/security/tests/hardlink_test.go
+++ b/pkg/security/tests/hardlink_test.go
@@ -48,15 +48,12 @@ func runHardlinkTests(t *testing.T, opts testOpts) {
 	}
 
 	t.Run("hardlink-creation", ifSyscallSupported("SYS_LINK", func(t *testing.T, syscallNB uintptr) {
-		err := test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			cmd := exec.Command(testOrigExecutable, "/tmp/test1")
 			return cmd.Run()
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_orig")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 
 		testNewExecutable, _, err := test.Path("my-touch")
 		if err != nil {
@@ -69,15 +66,12 @@ func runHardlinkTests(t *testing.T, opts testOpts) {
 			t.Fatal(err)
 		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			cmd := exec.Command(testNewExecutable, "/tmp/test2")
 			return cmd.Run()
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_link")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	}))
 
 	t.Run("hardlink-created", ifSyscallSupported("SYS_LINK", func(t *testing.T, syscallNB uintptr) {
@@ -92,25 +86,19 @@ func runHardlinkTests(t *testing.T, opts testOpts) {
 			t.Fatal(err)
 		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			cmd := exec.Command(testOrigExecutable, "/tmp/test1")
 			return cmd.Run()
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_orig")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			cmd := exec.Command(testNewExecutable, "/tmp/test2")
 			return cmd.Run()
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_link")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	}))
 }
 

--- a/pkg/security/tests/link_test.go
+++ b/pkg/security/tests/link_test.go
@@ -43,7 +43,7 @@ func TestLink(t *testing.T) {
 	}
 
 	t.Run("link", ifSyscallSupported("SYS_LINK", func(t *testing.T, syscallNB uintptr) {
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			_, _, errno := syscall.Syscall(syscallNB, uintptr(testOldFilePtr), uintptr(testNewFilePtr), 0)
 			if errno != 0 {
 				t.Fatal(errno)
@@ -65,9 +65,6 @@ func TestLink(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-		if err != nil {
-			t.Error(err)
-		}
 
 		if err := os.Remove(testNewFile); err != nil {
 			t.Error(err)
@@ -75,7 +72,7 @@ func TestLink(t *testing.T) {
 	}))
 
 	t.Run("linkat", func(t *testing.T) {
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			_, _, errno := syscall.Syscall6(syscall.SYS_LINKAT, 0, uintptr(testOldFilePtr), 0, uintptr(testNewFilePtr), 0, 0)
 			if errno != 0 {
 				t.Fatal(errno)
@@ -97,8 +94,5 @@ func TestLink(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 }

--- a/pkg/security/tests/macros_test.go
+++ b/pkg/security/tests/macros_test.go
@@ -47,7 +47,7 @@ func TestMacros(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	err = test.GetSignal(t, func() error {
+	test.WaitSignal(t, func() error {
 		if err := os.Mkdir(testFile, 0777); err != nil {
 			return err
 		}
@@ -55,7 +55,4 @@ func TestMacros(t *testing.T) {
 	}, func(event *sprobe.Event, rule *rules.Rule) {
 		assert.Equal(t, "mkdir", event.GetType(), "wrong event type")
 	})
-	if err != nil {
-		t.Error(err)
-	}
 }

--- a/pkg/security/tests/mkdir_test.go
+++ b/pkg/security/tests/mkdir_test.go
@@ -48,7 +48,7 @@ func TestMkdir(t *testing.T) {
 		}
 		defer syscall.Rmdir(testFile)
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			if _, _, errno := syscall.Syscall(syscallNB, uintptr(testFilePtr), uintptr(mkdirMode), 0); errno != 0 {
 				t.Fatal(errno)
 			}
@@ -62,9 +62,6 @@ func TestMkdir(t *testing.T) {
 			assertNearTime(t, event.Mkdir.File.MTime)
 			assertNearTime(t, event.Mkdir.File.CTime)
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	}))
 
 	t.Run("mkdirat", func(t *testing.T) {
@@ -74,7 +71,7 @@ func TestMkdir(t *testing.T) {
 		}
 		defer syscall.Rmdir(testatFile)
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			if _, _, errno := syscall.Syscall(syscall.SYS_MKDIRAT, 0, uintptr(testatFilePtr), uintptr(0777)); errno != 0 {
 				t.Fatal(error(errno))
 			}
@@ -90,9 +87,6 @@ func TestMkdir(t *testing.T) {
 			assertNearTime(t, event.Mkdir.File.MTime)
 			assertNearTime(t, event.Mkdir.File.CTime)
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 }
 
@@ -120,7 +114,7 @@ func TestMkdirError(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			var wg sync.WaitGroup
 			wg.Add(1)
 
@@ -149,8 +143,5 @@ func TestMkdirError(t *testing.T) {
 			assertTriggeredRule(t, rule, "test_rule_mkdirat_error")
 			assertReturnValue(t, event.Mkdir.Retval, -int64(syscall.EACCES))
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 }

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -97,15 +97,12 @@ func TestMount(t *testing.T) {
 		}
 		defer os.Remove(file)
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			return os.Chmod(file, 0707)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "chmod", event.GetType(), "wrong event type")
 			assert.Equal(t, file, event.Chmod.File.PathnameStr, "wrong path")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	releaseFile, err := os.Create(path.Join(dstMntPath, "test-release"))
@@ -132,14 +129,11 @@ func TestMount(t *testing.T) {
 	})
 
 	t.Run("release-mount", func(t *testing.T) {
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			return syscall.Fchownat(int(releaseFile.Fd()), "", 123, 123, unix.AT_EMPTY_PATH)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "chown", event.GetType(), "wrong event type")
 			assertTriggeredRule(t, rule, "test_rule_pending")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 }

--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -48,7 +48,7 @@ func TestOpen(t *testing.T) {
 	t.Run("open", ifSyscallSupported("SYS_OPEN", func(t *testing.T, syscallNB uintptr) {
 		defer os.Remove(testFile)
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			fd, _, errno := syscall.Syscall(syscallNB, uintptr(testFilePtr), syscall.O_CREAT, 0755)
 			if errno != 0 {
 				t.Fatal(errno)
@@ -64,15 +64,12 @@ func TestOpen(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	}))
 
 	t.Run("openat", func(t *testing.T) {
 		defer os.Remove(testFile)
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			fd, _, errno := syscall.Syscall6(syscall.SYS_OPENAT, 0, uintptr(testFilePtr), syscall.O_CREAT, 0711, 0, 0)
 			if errno != 0 {
 				t.Fatal(errno)
@@ -84,9 +81,6 @@ func TestOpen(t *testing.T) {
 			assertRights(t, uint16(event.Open.Mode), 0711)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	openHow := unix.OpenHow{
@@ -97,7 +91,7 @@ func TestOpen(t *testing.T) {
 	t.Run("openat2", func(t *testing.T) {
 		defer os.Remove(testFile)
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			fd, _, errno := syscall.Syscall6(unix.SYS_OPENAT2, 0, uintptr(testFilePtr), uintptr(unsafe.Pointer(&openHow)), unix.SizeofOpenHow, 0, 0)
 			if errno != 0 {
 				if errno == unix.ENOSYS {
@@ -112,15 +106,12 @@ func TestOpen(t *testing.T) {
 			assertRights(t, uint16(event.Open.Mode), 0711)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("creat", ifSyscallSupported("SYS_CREAT", func(t *testing.T, syscallNB uintptr) {
 		defer os.Remove(testFile)
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			fd, _, errno := syscall.Syscall(syscallNB, uintptr(testFilePtr), 0711, 0)
 			if errno != 0 {
 				t.Fatal(errno)
@@ -132,15 +123,12 @@ func TestOpen(t *testing.T) {
 			assertRights(t, uint16(event.Open.Mode), 0711)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	}))
 
 	t.Run("truncate", func(t *testing.T) {
 		defer os.Remove(testFile)
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			f, err := os.OpenFile(testFile, os.O_RDWR|os.O_CREATE, 0755)
 			if err != nil {
 				t.Error(err)
@@ -149,11 +137,8 @@ func TestOpen(t *testing.T) {
 			syscall.Write(int(f.Fd()), []byte("this data will soon be truncated\n"))
 			return f.Close()
 		}, func(event *sprobe.Event, r *rules.Rule) {})
-		if err != nil {
-			t.Error(err)
-		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			// truncate
 			_, _, errno := syscall.Syscall(syscall.SYS_TRUNCATE, uintptr(testFilePtr), 4, 0)
 			if errno != 0 {
@@ -165,16 +150,13 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT|syscall.O_WRONLY|syscall.O_TRUNC, int(event.Open.Flags), "wrong flags")
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("open_by_handle_at", func(t *testing.T) {
 		defer os.Remove(testFile)
 
 		// wait for this first event
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			f, err := os.OpenFile(testFile, os.O_RDWR|os.O_CREATE, 0755)
 			if err != nil {
 				t.Fatal(err)
@@ -183,9 +165,6 @@ func TestOpen(t *testing.T) {
 		}, func(event *sprobe.Event, r *rules.Rule) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 
 		h, mountID, err := unix.NameToHandleAt(unix.AT_FDCWD, testFile, 0)
 		if err != nil {
@@ -200,7 +179,7 @@ func TestOpen(t *testing.T) {
 		}
 		defer mount.Close()
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			fdInt, err := unix.OpenByHandleAt(int(mount.Fd()), h, unix.O_CREAT)
 			if err != nil {
 				if err == unix.EINVAL {
@@ -214,15 +193,12 @@ func TestOpen(t *testing.T) {
 			assert.Equal(t, syscall.O_CREAT, int(event.Open.Flags), "wrong flags")
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("io_uring", func(t *testing.T) {
 		defer os.Remove(testFile)
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			f, err := os.OpenFile(testFile, os.O_RDWR|os.O_CREATE, 0755)
 			if err != nil {
 				t.Fatal(err)
@@ -232,9 +208,6 @@ func TestOpen(t *testing.T) {
 		}, func(event *sprobe.Event, r *rules.Rule) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 
 		iour, err := iouring.New(1)
 		if err != nil {
@@ -251,7 +224,7 @@ func TestOpen(t *testing.T) {
 		}
 
 		ch := make(chan iouring.Result, 1)
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			if _, err := iour.SubmitRequest(prepRequest, ch); err != nil {
 				t.Fatal(err)
 			}
@@ -277,9 +250,6 @@ func TestOpen(t *testing.T) {
 			assertRights(t, uint16(event.Open.Mode), 0747)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 
 		prepRequest, err = iouring.Openat2(unix.AT_FDCWD, testFile, &openHow)
 		if err != nil {
@@ -287,7 +257,7 @@ func TestOpen(t *testing.T) {
 		}
 
 		// same with openat2
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			if _, err := iour.SubmitRequest(prepRequest, ch); err != nil {
 				t.Fatal(err)
 			}
@@ -310,9 +280,6 @@ func TestOpen(t *testing.T) {
 			assertRights(t, uint16(event.Open.Mode), 0711)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	_ = os.Remove(testFile)
@@ -340,7 +307,7 @@ func TestOpenMetadata(t *testing.T) {
 	t.Run("metadata", func(t *testing.T) {
 		defer os.Remove(testFile)
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			// CreateWithOptions creates the file and then chmod the user / group. When the file was created it didn't
 			// have the right uid / gid, thus didn't match the rule. Open the file again to trigger the rule.
 			f, err := os.Open(testFile)
@@ -350,15 +317,12 @@ func TestOpenMetadata(t *testing.T) {
 			return f.Close()
 		}, func(event *sprobe.Event, r *rules.Rule) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
-			assertRights(t, uint16(event.Open.File.Mode), expectedMode)
+			assertRights(t, event.Open.File.Mode, expectedMode)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
 
 			assertNearTime(t, event.Open.File.MTime)
 			assertNearTime(t, event.Open.File.CTime)
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 }
 

--- a/pkg/security/tests/overlayfs_test.go
+++ b/pkg/security/tests/overlayfs_test.go
@@ -171,7 +171,7 @@ func TestOverlayFS(t *testing.T) {
 
 		var inode uint64
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			f, err := os.OpenFile(testFile, os.O_RDONLY, 0755)
 			if err != nil {
 				return err
@@ -187,16 +187,13 @@ func TestOverlayFS(t *testing.T) {
 			t.Error(err)
 		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			return os.Remove(testFile)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
 			inUpperLayer, _ := event.GetFieldValue("open.file.in_upper_layer")
 			assert.Equal(t, false, inUpperLayer, "should be in base layer")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("override-lower", func(t *testing.T) {
@@ -207,7 +204,7 @@ func TestOverlayFS(t *testing.T) {
 
 		var inode uint64
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			f, err := os.OpenFile(testFile, os.O_RDWR, 0755)
 			if err != nil {
 				return err
@@ -219,20 +216,14 @@ func TestOverlayFS(t *testing.T) {
 			inUpperLayer, _ := event.GetFieldValue("open.file.in_upper_layer")
 			assert.Equal(t, false, inUpperLayer, "should be in base layer")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			return os.Remove(testFile)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
 			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("create-upper", func(t *testing.T) {
@@ -243,7 +234,7 @@ func TestOverlayFS(t *testing.T) {
 
 		var inode uint64
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			f, err := os.OpenFile(testFile, os.O_CREATE, 0755)
 			if err != nil {
 				return err
@@ -255,20 +246,14 @@ func TestOverlayFS(t *testing.T) {
 			inUpperLayer, _ := event.GetFieldValue("open.file.in_upper_layer")
 			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			return os.Remove(testFile)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
 			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("rename-lower", func(t *testing.T) {
@@ -284,7 +269,7 @@ func TestOverlayFS(t *testing.T) {
 
 		var inode uint64
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			return os.Rename(oldFile, newFile)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			if value, _ := event.GetFieldValue("rename.file.path"); value.(string) != oldFile {
@@ -299,20 +284,14 @@ func TestOverlayFS(t *testing.T) {
 			inUpperLayer, _ = event.GetFieldValue("rename.file.destination.in_upper_layer")
 			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			return os.Remove(newFile)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
 			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("rmdir-lower", func(t *testing.T) {
@@ -323,16 +302,13 @@ func TestOverlayFS(t *testing.T) {
 
 		inode := getInode(t, testDir)
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			return os.Remove(testDir)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, inode, event.Rmdir.File.Inode, "wrong rmdir inode")
 			inUpperLayer, _ := event.GetFieldValue("rmdir.file.in_upper_layer")
 			assert.Equal(t, false, inUpperLayer, "should be in base layer")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("chmod-lower", func(t *testing.T) {
@@ -343,7 +319,7 @@ func TestOverlayFS(t *testing.T) {
 
 		var inode uint64
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			return os.Chmod(testFile, 0777)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			inode = getInode(t, testFile)
@@ -351,20 +327,14 @@ func TestOverlayFS(t *testing.T) {
 			inUpperLayer, _ := event.GetFieldValue("chmod.file.in_upper_layer")
 			assert.Equal(t, false, inUpperLayer, "should be in base layer")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			return os.Remove(testFile)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
 			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("mkdir-lower", func(t *testing.T) {
@@ -373,7 +343,7 @@ func TestOverlayFS(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			return syscall.Mkdir(testFile, 0777)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			inode := getInode(t, testFile)
@@ -381,9 +351,6 @@ func TestOverlayFS(t *testing.T) {
 			inUpperLayer, _ := event.GetFieldValue("mkdir.file.in_upper_layer")
 			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("utimes-lower", func(t *testing.T) {
@@ -394,7 +361,7 @@ func TestOverlayFS(t *testing.T) {
 
 		var inode uint64
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			return os.Chtimes(testFile, time.Now(), time.Now())
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			inode = getInode(t, testFile)
@@ -402,20 +369,14 @@ func TestOverlayFS(t *testing.T) {
 			inUpperLayer, _ := event.GetFieldValue("utimes.file.in_upper_layer")
 			assert.Equal(t, false, inUpperLayer, "should be in base layer")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			return os.Remove(testFile)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
 			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("chown-lower", func(t *testing.T) {
@@ -426,7 +387,7 @@ func TestOverlayFS(t *testing.T) {
 
 		var inode uint64
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			return os.Chown(testFile, os.Getuid(), os.Getgid())
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			inode = getInode(t, testFile)
@@ -434,20 +395,14 @@ func TestOverlayFS(t *testing.T) {
 			inUpperLayer, _ := event.GetFieldValue("chown.file.in_upper_layer")
 			assert.Equal(t, false, inUpperLayer, "should be in base layer")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			return os.Remove(testFile)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
 			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("xattr-lower", func(t *testing.T) {
@@ -465,7 +420,7 @@ func TestOverlayFS(t *testing.T) {
 
 		var inode uint64
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			_, _, errno := syscall.Syscall6(syscall.SYS_SETXATTR, uintptr(testFilePtr), uintptr(xattrNamePtr), uintptr(xattrValuePtr), 0, unix.XATTR_CREATE, 0)
 			if errno != 0 {
 				return error(errno)
@@ -477,20 +432,14 @@ func TestOverlayFS(t *testing.T) {
 			inUpperLayer, _ := event.GetFieldValue("setxattr.file.in_upper_layer")
 			assert.Equal(t, false, inUpperLayer, "should be in base layer")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			return os.Remove(testFile)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
 			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("truncate-lower", func(t *testing.T) {
@@ -501,7 +450,7 @@ func TestOverlayFS(t *testing.T) {
 
 		var inode uint64
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			return os.Truncate(testFile, 0)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			inode = getInode(t, testFile)
@@ -509,20 +458,14 @@ func TestOverlayFS(t *testing.T) {
 			inUpperLayer, _ := event.GetFieldValue("open.file.in_upper_layer")
 			assert.Equal(t, false, inUpperLayer, "should be in base layer")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			return os.Remove(testFile)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
 			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("link-lower", func(t *testing.T) {
@@ -538,7 +481,7 @@ func TestOverlayFS(t *testing.T) {
 
 		var inode uint64
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			return os.Link(testSrc, testTarget)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			inode = getInode(t, testSrc)
@@ -550,30 +493,21 @@ func TestOverlayFS(t *testing.T) {
 			inUpperLayer, _ = event.GetFieldValue("link.file.destination.in_upper_layer")
 			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			return os.Remove(testSrc)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
 			assert.Equal(t, true, inUpperLayer, "should be in base layer")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			return os.Remove(testTarget)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong unlink inode")
 			inUpperLayer, _ := event.GetFieldValue("unlink.file.in_upper_layer")
 			assert.Equal(t, true, inUpperLayer, "should be in upper layer")
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 }

--- a/pkg/security/tests/probe_monitor_test.go
+++ b/pkg/security/tests/probe_monitor_test.go
@@ -8,7 +8,6 @@
 package tests
 
 import (
-	"fmt"
 	"os"
 	"path"
 	"strings"
@@ -18,7 +17,6 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/security/model"
-	"github.com/DataDog/datadog-agent/pkg/security/probe"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
 )
@@ -40,7 +38,7 @@ func TestRulesetLoaded(t *testing.T) {
 			test.reloadConfiguration()
 			return nil
 		}, func(rule *rules.Rule, customEvent *sprobe.CustomEvent) bool {
-			assert.Equal(t, probe.RulesetLoadedRuleID, rule.ID, "wrong rule")
+			assert.Equal(t, sprobe.RulesetLoadedRuleID, rule.ID, "wrong rule")
 			return true
 		}, model.CustomRulesetLoadedEventType); err != nil {
 			t.Error(err)
@@ -64,7 +62,7 @@ func truncatedParents(t *testing.T, opts testOpts) {
 		t.Fatal(err)
 	}
 
-	truncatedParentsFile, _, err := test.Path(fmt.Sprintf("%s", truncatedParents))
+	truncatedParentsFile, _, err := test.Path(truncatedParents)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -83,14 +81,14 @@ func truncatedParents(t *testing.T, opts testOpts) {
 			}
 			return f.Close()
 		}, func(rule *rules.Rule, customEvent *sprobe.CustomEvent) bool {
-			assert.Equal(t, probe.AbnormalPathRuleID, rule.ID, "wrong rule")
+			assert.Equal(t, sprobe.AbnormalPathRuleID, rule.ID, "wrong rule")
 			return true
 		}, model.CustomTruncatedParentsEventType)
 		if err != nil {
 			t.Error(err)
 		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			f, err := os.OpenFile(truncatedParentsFile, os.O_CREATE, 0755)
 			if err != nil {
 				t.Fatal(err)
@@ -111,9 +109,6 @@ func truncatedParents(t *testing.T, opts testOpts) {
 				assert.Equal(t, model.MaxPathDepth, len(splittedFilepath), "invalid path depth")
 			}
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 }
 
@@ -154,7 +149,7 @@ func TestNoisyProcess(t *testing.T) {
 			}
 			return nil
 		}, func(rule *rules.Rule, customEvent *sprobe.CustomEvent) bool {
-			assert.Equal(t, probe.NoisyProcessRuleID, rule.ID, "wrong rule")
+			assert.Equal(t, sprobe.NoisyProcessRuleID, rule.ID, "wrong rule")
 			return true
 		}, model.CustomNoisyProcessEventType)
 		if err != nil {

--- a/pkg/security/tests/rename_test.go
+++ b/pkg/security/tests/rename_test.go
@@ -50,7 +50,7 @@ func TestRename(t *testing.T) {
 	defer os.Remove(testOldFile)
 
 	t.Run("rename", ifSyscallSupported("SYS_RENAME", func(t *testing.T, syscallNB uintptr) {
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			_, _, errno := syscall.Syscall(syscallNB, uintptr(testOldFilePtr), uintptr(testNewFilePtr), 0)
 			if errno != 0 {
 				t.Fatal(errno)
@@ -73,9 +73,6 @@ func TestRename(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-		if err != nil {
-			t.Error(err)
-		}
 
 		if err := os.Rename(testNewFile, testOldFile); err != nil {
 			t.Fatal(err)
@@ -83,7 +80,7 @@ func TestRename(t *testing.T) {
 	}))
 
 	t.Run("renameat", func(t *testing.T) {
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			_, _, errno := syscall.Syscall6(syscall.SYS_RENAMEAT, 0, uintptr(testOldFilePtr), 0, uintptr(testNewFilePtr), 0, 0)
 			if errno != 0 {
 				t.Fatal(errno)
@@ -106,9 +103,6 @@ func TestRename(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	if err := os.Rename(testNewFile, testOldFile); err != nil {
@@ -116,7 +110,7 @@ func TestRename(t *testing.T) {
 	}
 
 	t.Run("renameat2", func(t *testing.T) {
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			_, _, errno := syscall.Syscall6(unix.SYS_RENAMEAT2, 0, uintptr(testOldFilePtr), 0, uintptr(testNewFilePtr), 0, 0)
 			if errno != 0 {
 				if errno == syscall.ENOSYS {
@@ -142,9 +136,6 @@ func TestRename(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 }
 
@@ -180,7 +171,7 @@ func TestRenameInvalidate(t *testing.T) {
 	}
 
 	for i := 0; i != 5; i++ {
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			if err := os.Rename(testOldFile, testNewFile); err != nil {
 				t.Fatal(err)
 			}
@@ -193,9 +184,6 @@ func TestRenameInvalidate(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-		if err != nil {
-			t.Error(err)
-		}
 
 		// swap
 		old := testOldFile
@@ -246,7 +234,7 @@ func TestRenameReuseInode(t *testing.T) {
 	}
 	defer os.Remove(testNewFile)
 
-	err = test.GetSignal(t, func() error {
+	test.WaitSignal(t, func() error {
 		f, err = os.Create(testNewFile)
 		if err != nil {
 			t.Fatal(err)
@@ -255,9 +243,6 @@ func TestRenameReuseInode(t *testing.T) {
 	}, func(event *sprobe.Event, rule *rules.Rule) {
 		assert.Equal(t, "open", event.GetType(), "wrong event type")
 	})
-	if err != nil {
-		t.Error(err)
-	}
 
 	testNewFileInode := getInode(t, testNewFile)
 
@@ -280,7 +265,7 @@ func TestRenameReuseInode(t *testing.T) {
 
 	defer os.Remove(testReuseInodeFile)
 
-	err = test.GetSignal(t, func() error {
+	test.WaitSignal(t, func() error {
 		f, err = os.Create(testReuseInodeFile)
 		if err != nil {
 			t.Fatal(err)
@@ -295,9 +280,6 @@ func TestRenameReuseInode(t *testing.T) {
 			t.Error(event.String())
 		}
 	})
-	if err != nil {
-		t.Error(err)
-	}
 }
 
 func TestRenameFolder(t *testing.T) {
@@ -329,7 +311,7 @@ func TestRenameFolder(t *testing.T) {
 	defer os.Remove(filename.Load().(string))
 
 	for i := 0; i != 5; i++ {
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			testFile, err := os.OpenFile(filename.Load().(string), os.O_RDWR|os.O_CREATE, 0755)
 			if err != nil {
 				t.Fatal(err)
@@ -354,8 +336,5 @@ func TestRenameFolder(t *testing.T) {
 
 			filename.Store(fmt.Sprintf("%s/test-rename", testOldFolder))
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	}
 }

--- a/pkg/security/tests/rmdir_test.go
+++ b/pkg/security/tests/rmdir_test.go
@@ -47,7 +47,7 @@ func TestRmdir(t *testing.T) {
 
 		inode := getInode(t, testFile)
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			if _, _, err := syscall.Syscall(syscallNB, uintptr(testFilePtr), 0, 0); err != 0 {
 				t.Fatal(error(err))
 			}
@@ -60,9 +60,6 @@ func TestRmdir(t *testing.T) {
 			assertNearTime(t, event.Rmdir.File.MTime)
 			assertNearTime(t, event.Rmdir.File.CTime)
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	}))
 
 	t.Run("unlinkat-at_removedir", func(t *testing.T) {
@@ -78,7 +75,7 @@ func TestRmdir(t *testing.T) {
 
 		inode := getInode(t, testDir)
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			if _, _, err := syscall.Syscall(syscall.SYS_UNLINKAT, 0, uintptr(testDirPtr), 512); err != 0 {
 				t.Fatal(err)
 			}
@@ -91,9 +88,6 @@ func TestRmdir(t *testing.T) {
 			assertNearTime(t, event.Rmdir.File.MTime)
 			assertNearTime(t, event.Rmdir.File.CTime)
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 }
 
@@ -119,7 +113,7 @@ func TestRmdirInvalidate(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			if err := syscall.Rmdir(testFile); err != nil {
 				t.Fatal(err)
 			}
@@ -128,8 +122,5 @@ func TestRmdirInvalidate(t *testing.T) {
 			assert.Equal(t, "rmdir", event.GetType(), "wrong event type")
 			assertFieldEqual(t, event, "rmdir.file.path", testFile)
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	}
 }

--- a/pkg/security/tests/schemas.go
+++ b/pkg/security/tests/schemas.go
@@ -36,12 +36,7 @@ func (v ValidInodeFormatChecker) IsFormat(input interface{}) bool {
 	default:
 		return false
 	}
-
-	if sprobe.IsFakeInode(inode) {
-		return false
-	}
-
-	return true
+	return !sprobe.IsFakeInode(inode)
 }
 
 func validateSchema(t *testing.T, event *sprobe.Event, path string) bool {

--- a/pkg/security/tests/selinux_test.go
+++ b/pkg/security/tests/selinux_test.go
@@ -21,8 +21,8 @@ import (
 	"gotest.tools/assert"
 )
 
-const TEST_BOOL_NAME = "selinuxuser_ping"
-const TEST_BOOL_NAME2 = "httpd_enable_cgi"
+const TestBoolName = "selinuxuser_ping"
+const TestBoolName2 = "httpd_enable_cgi"
 
 func TestSELinux(t *testing.T) {
 	ruleset := []*rules.RuleDefinition{
@@ -57,14 +57,14 @@ func TestSELinux(t *testing.T) {
 	}
 	defer test.Close()
 
-	savedBoolValue, err := getBoolValue(TEST_BOOL_NAME)
+	savedBoolValue, err := getBoolValue(TestBoolName)
 	if err != nil {
 		t.Errorf("failed to save bool state: %v", err)
 	}
-	defer setBoolValue(TEST_BOOL_NAME, savedBoolValue)
+	defer setBoolValue(TestBoolName, savedBoolValue)
 
 	t.Run("setenforce", func(t *testing.T) {
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			if err := setEnforceStatus("permissive"); err != nil {
 				t.Errorf("failed to run setenforce: %v", err)
 			}
@@ -79,13 +79,10 @@ func TestSELinux(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("sel_disable", func(t *testing.T) {
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			if err := rawSudoWrite("/sys/fs/selinux/disable", "0", false); err != nil {
 				t.Errorf("failed to write to selinuxfs: %v", err)
 			}
@@ -98,14 +95,11 @@ func TestSELinux(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("setsebool_true_value", func(t *testing.T) {
-		err = test.GetSignal(t, func() error {
-			if err := setBoolValue(TEST_BOOL_NAME, true); err != nil {
+		test.WaitSignal(t, func() error {
+			if err := setBoolValue(TestBoolName, true); err != nil {
 				t.Errorf("failed to run setsebool: %v", err)
 			}
 			return nil
@@ -113,21 +107,18 @@ func TestSELinux(t *testing.T) {
 			assertTriggeredRule(t, rule, "test_selinux_write_bool_true")
 			assert.Equal(t, "selinux", event.GetType(), "wrong event type")
 
-			assertFieldEqual(t, event, "selinux.bool.name", TEST_BOOL_NAME, "wrong bool name")
+			assertFieldEqual(t, event, "selinux.bool.name", TestBoolName, "wrong bool name")
 			assertFieldEqual(t, event, "selinux.bool.state", "on", "wrong bool value")
 
 			if !validateSELinuxSchema(t, event) {
 				t.Error(event.String())
 			}
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("setsebool_false_value", func(t *testing.T) {
-		err = test.GetSignal(t, func() error {
-			if err := setBoolValue(TEST_BOOL_NAME, false); err != nil {
+		test.WaitSignal(t, func() error {
+			if err := setBoolValue(TestBoolName, false); err != nil {
 				t.Errorf("failed to run setsebool: %v", err)
 			}
 			return nil
@@ -135,16 +126,13 @@ func TestSELinux(t *testing.T) {
 			assertTriggeredRule(t, rule, "test_selinux_write_bool_false")
 			assert.Equal(t, "selinux", event.GetType(), "wrong event type")
 
-			assertFieldEqual(t, event, "selinux.bool.name", TEST_BOOL_NAME, "wrong bool name")
+			assertFieldEqual(t, event, "selinux.bool.name", TestBoolName, "wrong bool name")
 			assertFieldEqual(t, event, "selinux.bool.state", "off", "wrong bool value")
 
 			if !validateSELinuxSchema(t, event) {
 				t.Error(event.String())
 			}
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("setsebool_error_value", func(t *testing.T) {
@@ -183,15 +171,15 @@ func TestSELinuxCommitBools(t *testing.T) {
 		t.Skipf("SELinux is not available, skipping tests")
 	}
 
-	savedBoolValue, err := getBoolValue(TEST_BOOL_NAME)
+	savedBoolValue, err := getBoolValue(TestBoolName)
 	if err != nil {
 		t.Errorf("failed to save bool state: %v", err)
 	}
-	defer setBoolValue(TEST_BOOL_NAME, savedBoolValue)
+	defer setBoolValue(TestBoolName, savedBoolValue)
 
 	t.Run("sel_commit_bools", func(t *testing.T) {
-		err = test.GetSignal(t, func() error {
-			if err := setBoolValue(TEST_BOOL_NAME, true); err != nil {
+		test.WaitSignal(t, func() error {
+			if err := setBoolValue(TestBoolName, true); err != nil {
 				t.Errorf("failed to run setsebool: %v", err)
 			}
 			return nil
@@ -205,9 +193,6 @@ func TestSELinuxCommitBools(t *testing.T) {
 				t.Error(event.String())
 			}
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 }
 
@@ -225,9 +210,8 @@ func rawSudoWrite(filePath, writeContent string, ignoreRunError bool) error {
 
 	if err := cmd.Run(); !ignoreRunError {
 		return err
-	} else {
-		return nil
 	}
+	return nil
 }
 
 func getBoolValue(boolName string) (bool, error) {

--- a/pkg/security/tests/span_test.go
+++ b/pkg/security/tests/span_test.go
@@ -67,7 +67,7 @@ func TestSpan(t *testing.T) {
 		tls[offset] = 123
 		tls[offset+1] = 456
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			testFile, _, err := test.Create("test-span")
 			os.Remove(testFile)
 			return err
@@ -81,9 +81,6 @@ func TestSpan(t *testing.T) {
 			assert.Equal(t, uint64(123), event.SpanContext.SpanID)
 			assert.Equal(t, uint64(456), event.SpanContext.TraceID)
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("exec", func(t *testing.T) {
@@ -96,7 +93,7 @@ func TestSpan(t *testing.T) {
 			}
 		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			return runSyscallTesterFunc(t, syscallTester, "span-exec", "104", "204", executable, "/tmp/test_span_rule_exec")
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_span_rule_exec")
@@ -108,8 +105,5 @@ func TestSpan(t *testing.T) {
 			assert.Equal(t, uint64(204), event.SpanContext.SpanID)
 			assert.Equal(t, uint64(104), event.SpanContext.TraceID)
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 }

--- a/pkg/security/tests/stress_test.go
+++ b/pkg/security/tests/stress_test.go
@@ -320,7 +320,7 @@ func BenchmarkERPCDentryResolutionSegment(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		return syscall.Close(int(fd))
+		return syscall.Close(fd)
 	}, func(event *sprobe.Event, _ *rules.Rule) {
 		mountID = event.Open.File.MountID
 		inode = event.Open.File.Inode
@@ -389,12 +389,15 @@ func BenchmarkERPCDentryResolutionPath(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		return syscall.Close(int(fd))
+		return syscall.Close(fd)
 	}, func(event *sprobe.Event, _ *rules.Rule) {
 		mountID = event.Open.File.MountID
 		inode = event.Open.File.Inode
 		pathID = event.Open.File.PathID
 	})
+	if err != nil {
+		b.Fatal(err)
+	}
 
 	// create a new dentry resolver to avoid concurrent map access errors
 	resolver, err := probe.NewDentryResolver(test.probe)
@@ -455,12 +458,15 @@ func BenchmarkMapDentryResolutionSegment(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		return syscall.Close(int(fd))
+		return syscall.Close(fd)
 	}, func(event *sprobe.Event, _ *rules.Rule) {
 		mountID = event.Open.File.MountID
 		inode = event.Open.File.Inode
 		pathID = event.Open.File.PathID
 	})
+	if err != nil {
+		b.Fatal(err)
+	}
 
 	// create a new dentry resolver to avoid concurrent map access errors
 	resolver, err := probe.NewDentryResolver(test.probe)
@@ -521,12 +527,15 @@ func BenchmarkMapDentryResolutionPath(b *testing.B) {
 		if err != nil {
 			b.Fatal(err)
 		}
-		return syscall.Close(int(fd))
+		return syscall.Close(fd)
 	}, func(event *sprobe.Event, _ *rules.Rule) {
 		mountID = event.Open.File.MountID
 		inode = event.Open.File.Inode
 		pathID = event.Open.File.PathID
 	})
+	if err != nil {
+		b.Fatal(err)
+	}
 
 	// create a new dentry resolver to avoid concurrent map access errors
 	resolver, err := probe.NewDentryResolver(test.probe)

--- a/pkg/security/tests/syscall_tester.go
+++ b/pkg/security/tests/syscall_tester.go
@@ -46,7 +46,7 @@ func loadSyscallTester(t *testing.T, test *testModule, binary string) (string, e
 	}
 
 	perm := 0o700
-	binPath, _, err := test.CreateWithOptions(binary, -1, -1, perm)
+	binPath, _, _ := test.CreateWithOptions(binary, -1, -1, perm)
 
 	f, err := os.OpenFile(binPath, os.O_WRONLY|os.O_CREATE, os.FileMode(perm))
 	if err != nil {

--- a/pkg/security/tests/syscalls_amd64.go
+++ b/pkg/security/tests/syscalls_amd64.go
@@ -4,6 +4,7 @@ package tests
 
 import "syscall"
 
+//nolint:unused
 var supportedSyscalls = map[string]uintptr{
 	"SYS_CHMOD":  syscall.SYS_CHMOD,
 	"SYS_CHOWN":  syscall.SYS_CHOWN,

--- a/pkg/security/tests/syscalls_arm64.go
+++ b/pkg/security/tests/syscalls_arm64.go
@@ -2,4 +2,5 @@
 
 package tests
 
+//nolint:unused
 var supportedSyscalls = map[string]uintptr{}

--- a/pkg/security/tests/unlink_test.go
+++ b/pkg/security/tests/unlink_test.go
@@ -42,7 +42,7 @@ func TestUnlink(t *testing.T) {
 	inode := getInode(t, testFile)
 
 	t.Run("unlink", ifSyscallSupported("SYS_UNLINK", func(t *testing.T, syscallNB uintptr) {
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			if _, _, err := syscall.Syscall(syscallNB, uintptr(testFilePtr), 0, 0); err != 0 {
 				t.Fatal(err)
 			}
@@ -55,9 +55,6 @@ func TestUnlink(t *testing.T) {
 			assertNearTime(t, event.Unlink.File.MTime)
 			assertNearTime(t, event.Unlink.File.CTime)
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	}))
 
 	testAtFile, testAtFilePtr, err := test.CreateWithOptions("test-unlinkat", 98, 99, fileMode)
@@ -69,7 +66,7 @@ func TestUnlink(t *testing.T) {
 	inode = getInode(t, testAtFile)
 
 	t.Run("unlinkat", func(t *testing.T) {
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			if _, _, err := syscall.Syscall(syscall.SYS_UNLINKAT, 0, uintptr(testAtFilePtr), 0); err != 0 {
 				t.Fatal(err)
 			}
@@ -82,9 +79,6 @@ func TestUnlink(t *testing.T) {
 			assertNearTime(t, event.Unlink.File.MTime)
 			assertNearTime(t, event.Unlink.File.CTime)
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 }
 
@@ -114,15 +108,12 @@ func TestUnlinkInvalidate(t *testing.T) {
 		}
 		f.Close()
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			os.Remove(testFile)
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "unlink", event.GetType(), "wrong event type")
 			assertFieldEqual(t, event, "unlink.file.path", testFile)
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	}
 }

--- a/pkg/security/tests/utimes_test.go
+++ b/pkg/security/tests/utimes_test.go
@@ -46,7 +46,7 @@ func TestUtimes(t *testing.T) {
 			Modtime: 456,
 		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			if _, _, errno := syscall.Syscall(syscallNB, uintptr(testFilePtr), uintptr(unsafe.Pointer(utimbuf)), 0); errno != 0 {
 				t.Fatal(errno)
 			}
@@ -57,14 +57,11 @@ func TestUtimes(t *testing.T) {
 			assert.Equal(t, int64(456), event.Utimes.Mtime.Unix())
 			assert.Equal(t, getInode(t, testFile), event.Utimes.File.Inode, "wrong inode")
 
-			assertRights(t, uint16(event.Utimes.File.Mode), expectedMode)
+			assertRights(t, event.Utimes.File.Mode, expectedMode)
 
 			assertNearTime(t, event.Utimes.File.MTime)
 			assertNearTime(t, event.Utimes.File.CTime)
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	}))
 
 	t.Run("utimes", ifSyscallSupported("SYS_UTIMES", func(t *testing.T, syscallNB uintptr) {
@@ -87,7 +84,7 @@ func TestUtimes(t *testing.T) {
 			},
 		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			if _, _, errno := syscall.Syscall(syscallNB, uintptr(testFilePtr), uintptr(unsafe.Pointer(&times[0])), 0); errno != 0 {
 				t.Fatal(errno)
 			}
@@ -98,14 +95,11 @@ func TestUtimes(t *testing.T) {
 
 			assert.Equal(t, int64(222), event.Utimes.Atime.UnixNano()%int64(time.Second)/int64(time.Microsecond))
 			assert.Equal(t, getInode(t, testFile), event.Utimes.File.Inode)
-			assertRights(t, uint16(event.Utimes.File.Mode), expectedMode)
+			assertRights(t, event.Utimes.File.Mode, expectedMode)
 
 			assertNearTime(t, event.Utimes.File.MTime)
 			assertNearTime(t, event.Utimes.File.CTime)
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	}))
 
 	t.Run("utimensat", func(t *testing.T) {
@@ -128,7 +122,7 @@ func TestUtimes(t *testing.T) {
 			},
 		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			if _, _, errno := syscall.Syscall6(syscall.SYS_UTIMENSAT, 0, uintptr(testFilePtr), uintptr(unsafe.Pointer(&ntimes[0])), 0, 0, 0); errno != 0 {
 				if errno == syscall.EINVAL {
 					t.Skip("utimensat not supported")
@@ -142,13 +136,10 @@ func TestUtimes(t *testing.T) {
 
 			assert.Equal(t, int64(666), event.Utimes.Mtime.UnixNano()%int64(time.Second)/int64(time.Nanosecond))
 			assert.Equal(t, getInode(t, testFile), event.Utimes.File.Inode)
-			assertRights(t, uint16(event.Utimes.File.Mode), expectedMode)
+			assertRights(t, event.Utimes.File.Mode, expectedMode)
 
 			assertNearTime(t, event.Utimes.File.MTime)
 			assertNearTime(t, event.Utimes.File.CTime)
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 }

--- a/pkg/security/tests/xattr_test.go
+++ b/pkg/security/tests/xattr_test.go
@@ -56,7 +56,7 @@ func TestSetXAttr(t *testing.T) {
 		}
 		defer os.Remove(testFile)
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			_, _, errno := syscall.Syscall6(syscall.SYS_SETXATTR, uintptr(testFilePtr), uintptr(xattrNamePtr), uintptr(xattrValuePtr), 0, unix.XATTR_CREATE, 0)
 			if errno != 0 {
 				return error(errno)
@@ -67,14 +67,11 @@ func TestSetXAttr(t *testing.T) {
 			assert.Equal(t, "user.test_xattr", event.SetXAttr.Name)
 			assert.Equal(t, "user", event.SetXAttr.Namespace)
 			assert.Equal(t, getInode(t, testFile), event.SetXAttr.File.Inode, "wrong inode")
-			assertRights(t, event.SetXAttr.File.Mode, uint16(expectedMode))
+			assertRights(t, event.SetXAttr.File.Mode, expectedMode)
 
 			assertNearTime(t, event.SetXAttr.File.MTime)
 			assertNearTime(t, event.SetXAttr.File.CTime)
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("lsetxattr", func(t *testing.T) {
@@ -94,7 +91,7 @@ func TestSetXAttr(t *testing.T) {
 		}
 		defer os.Remove(testFile)
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			_, _, errno := syscall.Syscall6(syscall.SYS_LSETXATTR, uintptr(testFilePtr), uintptr(xattrNamePtr), uintptr(xattrValuePtr), 0, unix.XATTR_CREATE, 0)
 			// Linux and Android don't support xattrs on symlinks according
 			// to xattr(7), so just test that we get the proper error.
@@ -113,9 +110,6 @@ func TestSetXAttr(t *testing.T) {
 			assertNearTime(t, event.SetXAttr.File.MTime)
 			assertNearTime(t, event.SetXAttr.File.CTime)
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("fsetxattr", func(t *testing.T) {
@@ -131,7 +125,7 @@ func TestSetXAttr(t *testing.T) {
 		defer f.Close()
 		defer os.Remove(testFile)
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			_, _, errno := syscall.Syscall6(syscall.SYS_FSETXATTR, f.Fd(), uintptr(xattrNamePtr), uintptr(xattrValuePtr), 0, unix.XATTR_CREATE, 0)
 			if errno != 0 {
 				t.Fatal(error(errno))
@@ -142,14 +136,11 @@ func TestSetXAttr(t *testing.T) {
 			assert.Equal(t, "user.test_xattr", event.SetXAttr.Name)
 			assert.Equal(t, "user", event.SetXAttr.Namespace)
 			assert.Equal(t, getInode(t, testFile), event.SetXAttr.File.Inode, "wrong inode")
-			assertRights(t, event.SetXAttr.File.Mode, uint16(expectedMode))
+			assertRights(t, event.SetXAttr.File.Mode, expectedMode)
 
 			assertNearTime(t, event.SetXAttr.File.MTime)
 			assertNearTime(t, event.SetXAttr.File.CTime)
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 }
 
@@ -201,7 +192,7 @@ func TestRemoveXAttr(t *testing.T) {
 			t.Fatal(error(errno))
 		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			_, _, errno = syscall.Syscall(syscall.SYS_REMOVEXATTR, uintptr(testFilePtr), uintptr(xattrNamePtr), 0)
 			if errno != 0 {
 				t.Fatal(error(errno))
@@ -217,9 +208,6 @@ func TestRemoveXAttr(t *testing.T) {
 			assertNearTime(t, event.RemoveXAttr.File.MTime)
 			assertNearTime(t, event.RemoveXAttr.File.CTime)
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("lremovexattr", func(t *testing.T) {
@@ -247,7 +235,7 @@ func TestRemoveXAttr(t *testing.T) {
 			t.Fatal(error(errno))
 		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			_, _, errno = syscall.Syscall(syscall.SYS_LREMOVEXATTR, uintptr(testFilePtr), uintptr(xattrNamePtr), 0)
 			// Linux and Android don't support xattrs on symlinks according
 			// to xattr(7), so just test that we get the proper error.
@@ -265,9 +253,6 @@ func TestRemoveXAttr(t *testing.T) {
 			assertNearTime(t, event.RemoveXAttr.File.MTime)
 			assertNearTime(t, event.RemoveXAttr.File.CTime)
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 
 	t.Run("fremovexattr", func(t *testing.T) {
@@ -289,7 +274,7 @@ func TestRemoveXAttr(t *testing.T) {
 			t.Fatal(error(errno))
 		}
 
-		err = test.GetSignal(t, func() error {
+		test.WaitSignal(t, func() error {
 			_, _, errno = syscall.Syscall(syscall.SYS_FREMOVEXATTR, f.Fd(), uintptr(xattrNamePtr), 0)
 			if errno != 0 {
 				t.Fatal(error(errno))
@@ -323,8 +308,5 @@ func TestRemoveXAttr(t *testing.T) {
 				t.Errorf("expected ctime close to %s, got %s", now, ctime)
 			}
 		})
-		if err != nil {
-			t.Error(err)
-		}
 	})
 }

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -237,8 +237,10 @@ def staticcheck(ctx, targets, build_tags=None, arch="x64"):
 
     tags = copy.copy(build_tags or get_default_build_tags(build="test", arch=arch))
     # these two don't play well with static checking
-    tags.remove("python")
-    tags.remove("jmx")
+    if "python" in tags:
+        tags.remove("python")
+    if "jmx" in tags:
+        tags.remove("jmx")
 
     ctx.run("staticcheck -checks=SA1027 -tags=" + ",".join(tags) + " " + " ".join(pkgs))
     # staticcheck exits with status 1 when it finds an issue, if we're here


### PR DESCRIPTION
### What does this PR do?

Execute linters on cws functional tests and made the modification accordingly.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
