### PR TITLE
[listeners/snmp] Add namespace to digest

### DIFF
--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -170,6 +170,7 @@ func (c *Config) Digest(address string) string {
 	h.Write([]byte(c.ContextEngineID))         //nolint:errcheck
 	h.Write([]byte(c.ContextName))             //nolint:errcheck
 	h.Write([]byte(c.Loader))                  //nolint:errcheck
+	h.Write([]byte(c.Namespace))               //nolint:errcheck
 
 	// Sort the addresses to get a stable digest
 	addresses := make([]string, 0, len(c.IgnoredIPAddresses))

--- a/pkg/snmp/snmp_test.go
+++ b/pkg/snmp/snmp_test.go
@@ -293,3 +293,135 @@ snmp_listener:
 	assert.Equal(t, false, conf.Configs[0].UseDeviceIDAsHostname)
 	assert.Equal(t, true, conf.Configs[1].UseDeviceIDAsHostname)
 }
+
+func TestConfig_Digest(t *testing.T) {
+	tests := []struct {
+		name         string
+		configA      Config
+		configB      Config
+		ipAddressA   string
+		ipAddressB   string
+		isSameDigest bool
+	}{
+		{
+			name:         "same ipaddress",
+			ipAddressA:   "1.2.3.4",
+			ipAddressB:   "1.2.3.4",
+			isSameDigest: true,
+		},
+		{
+			name:       "test different ipaddress",
+			ipAddressA: "1.2.3.4",
+			ipAddressB: "1.2.3.5",
+		},
+		{
+			name:       "test port",
+			ipAddressA: "1.2.3.5",
+			ipAddressB: "1.2.3.5",
+			configA:    Config{Port: 123},
+			configB:    Config{Port: 124},
+		},
+		{
+			name:       "test version",
+			ipAddressA: "1.2.3.5",
+			ipAddressB: "1.2.3.5",
+			configA:    Config{Version: "1"},
+			configB:    Config{Version: "2"},
+		},
+		{
+			name:       "test community",
+			ipAddressA: "1.2.3.5",
+			ipAddressB: "1.2.3.5",
+			configA:    Config{Community: "something"},
+			configB:    Config{Community: "somethingElse"},
+		},
+		{
+			name:       "test user",
+			ipAddressA: "1.2.3.5",
+			ipAddressB: "1.2.3.5",
+			configA:    Config{User: "myuser"},
+			configB:    Config{User: "myuser2"},
+		},
+		{
+			name:       "test AuthKey",
+			ipAddressA: "1.2.3.5",
+			ipAddressB: "1.2.3.5",
+			configA:    Config{AuthKey: "my-AuthKey"},
+			configB:    Config{AuthKey: "my-AuthKey2"},
+		},
+		{
+			name:       "test AuthProtocol",
+			ipAddressA: "1.2.3.5",
+			ipAddressB: "1.2.3.5",
+			configA:    Config{AuthProtocol: "sha"},
+			configB:    Config{AuthProtocol: "md5"},
+		},
+		{
+			name:       "test PrivKey",
+			ipAddressA: "1.2.3.5",
+			ipAddressB: "1.2.3.5",
+			configA:    Config{PrivKey: "abc"},
+			configB:    Config{PrivKey: "123"},
+		},
+		{
+			name:       "test PrivProtocol",
+			ipAddressA: "1.2.3.5",
+			ipAddressB: "1.2.3.5",
+			configA:    Config{PrivProtocol: "AES"},
+			configB:    Config{PrivProtocol: "DES"},
+		},
+		{
+			name:       "test ContextEngineID",
+			ipAddressA: "1.2.3.5",
+			ipAddressB: "1.2.3.5",
+			configA:    Config{ContextEngineID: "engineID"},
+			configB:    Config{ContextEngineID: "engineID2"},
+		},
+		{
+			name:       "test ContextName",
+			ipAddressA: "1.2.3.5",
+			ipAddressB: "1.2.3.5",
+			configA:    Config{ContextName: "someContextName"},
+			configB:    Config{ContextName: "someContextName2"},
+		},
+		{
+			name:       "test Loader",
+			ipAddressA: "1.2.3.5",
+			ipAddressB: "1.2.3.5",
+			configA:    Config{Loader: "core"},
+			configB:    Config{Loader: "python"},
+		},
+		{
+			name:       "test Namespace",
+			ipAddressA: "1.2.3.5",
+			ipAddressB: "1.2.3.5",
+			configA:    Config{Namespace: "ns1"},
+			configB:    Config{Namespace: "ns2"},
+		},
+		{
+			name:       "test different IgnoredIPAddresses",
+			ipAddressA: "1.2.3.5",
+			ipAddressB: "1.2.3.5",
+			configA:    Config{IgnoredIPAddresses: map[string]bool{"1.2.3.3": true}},
+			configB:    Config{IgnoredIPAddresses: map[string]bool{"1.2.3.4": true}},
+		},
+		{
+			name:       "test empty IgnoredIPAddresses",
+			ipAddressA: "1.2.3.5",
+			ipAddressB: "1.2.3.5",
+			configA:    Config{IgnoredIPAddresses: map[string]bool{}},
+			configB:    Config{IgnoredIPAddresses: map[string]bool{"1.2.3.4": true}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			digestA := tt.configA.Digest(tt.ipAddressA)
+			digestB := tt.configB.Digest(tt.ipAddressB)
+			if tt.isSameDigest {
+				assert.Equal(t, digestA, digestB)
+			} else {
+				assert.NotEqual(t, digestA, digestB)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Add namespace to digest

### Motivation

Namespace should be part of the digest to use the same subnet with different namespaces.

### Additional Notes

### Describe how to test your changes

Test with 2 snmp_listener configs that differ only by its namespace like this:

```
listeners:
- {name: snmp}
snmp_listener:
  namespace: instance00
  configs:
  - community: generic-router
    loader: core
    network: 172.20.0.0/29
    port: 1161
    retries: 2
    tags: ['tag1:val1', 'tag2:val2']
    timeout: 1
    version: 2
  - community: generic-router
    loader: core
    network: 172.20.0.0/29
    port: 1161
    retries: 2
    tags: ['tag1:val1', 'tag2:val2']
    timeout: 1
    version: 2
    namespace: instance22
```

That should create multiple instances of the same subnet IPs with different namespace.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
