### PR TITLE
[Dockerfiles/cluster-agent] Fix path in readsecret_multiple_providers.sh

### DIFF
--- a/Dockerfiles/cluster-agent/readsecret_multiple_providers.sh
+++ b/Dockerfiles/cluster-agent/readsecret_multiple_providers.sh
@@ -6,4 +6,4 @@ set -e
 # This product includes software developed at Datadog (https://www.datadoghq.com/).
 # Copyright 2016-present Datadog, Inc.
 
-/opt/datadog-agent/bin/agent/agent secret-helper read --with-provider-prefixes
+/opt/datadog-agent/bin/datadog-cluster-agent secret-helper read --with-provider-prefixes


### PR DESCRIPTION
### What does this PR do?

Fixes a path in a script used in the cluster-agent Dockerfile. The bug was introduced in https://github.com/DataDog/datadog-agent/pull/9132

### Describe how to test your changes

The ` /readsecret_multiple_providers.sh` script should work in the DCA as described in the PR above.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
