### PR TITLE
[system-probe] change system-probe socket access rights and owner

### DIFF
--- a/cmd/system-probe/api/restart.go
+++ b/cmd/system-probe/api/restart.go
@@ -14,6 +14,11 @@ func restartModuleHandler(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 	moduleName := config.ModuleName(vars["module-name"])
 
+	if moduleName == config.SecurityRuntimeModule {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
 	var target module.Factory
 	for _, f := range modules.All {
 		if f.Name == moduleName {

--- a/pkg/process/net/uds_test.go
+++ b/pkg/process/net/uds_test.go
@@ -48,7 +48,7 @@ func testWorkingNewUDSListener(t *testing.T, socketPath string) {
 	time.Sleep(1 * time.Second)
 	fi, err := os.Stat(socketPath)
 	require.NoError(t, err)
-	assert.Equal(t, "Srwx-w--w-", fi.Mode().String())
+	assert.Equal(t, "Srwx-w----", fi.Mode().String())
 }
 
 func TestNewUDSListener(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

- Change the access rights and user / group owner of the system-probe socket
- Disable the restart feature of system-probe for the Runtime Security module

### Motivation

Prevent the agent from leaking sensitive data to unauthenticated users.

### Describe how to test your changes

Make sure that only the dd-agent (and root) users can issue command to system-probe.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

