### PR TITLE
[CWS fix] lazyfy the "--cfgpath" option fetching for configuration in `compliance check`

### DIFF
--- a/cmd/cluster-agent/app/compliance_cmd.go
+++ b/cmd/cluster-agent/app/compliance_cmd.go
@@ -21,7 +21,8 @@ var (
 )
 
 func init() {
-	confPathArray := []string{confPath}
-	complianceCmd.AddCommand(app.CheckCmd(confPathArray))
+	complianceCmd.AddCommand(app.CheckCmd(func() []string {
+		return []string{confPath}
+	}))
 	ClusterAgentCmd.AddCommand(complianceCmd)
 }

--- a/cmd/security-agent/app/check.go
+++ b/cmd/security-agent/app/check.go
@@ -52,13 +52,13 @@ func setupCheckCmd(cmd *cobra.Command) {
 }
 
 // CheckCmd returns a cobra command to run security agent checks
-func CheckCmd(confPathArray []string) *cobra.Command {
+func CheckCmd(confPathArrayGetter func() []string) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "check",
 		Short: "Run compliance check(s)",
 		Long:  ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCheck(cmd, confPathArray, args)
+			return runCheck(cmd, confPathArrayGetter(), args)
 		},
 	}
 	setupCheckCmd(cmd)
@@ -229,5 +229,7 @@ func (r *RunCheckReporter) ReportRaw(content []byte, service string, tags ...str
 }
 
 func init() {
-	complianceCmd.AddCommand(CheckCmd(confPathArray))
+	complianceCmd.AddCommand(CheckCmd(func() []string {
+		return confPathArray
+	}))
 }


### PR DESCRIPTION
### What does this PR do?

Fix the `compliance check` `--cfgpath` command line arguments.

### Motivation

When trying to run a specific compliance check with the agent you can run:
```sh
security-agent compliance check
datadog-cluster-agent compliance check
```
Those commands can look for configuration at a specific path provided with `--cfgpath`. This argument was not correctly respected.

### Describe how to test your changes

You should be able to provide configuration path to the `compliance check` commands.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
