### PR TITLE
Add Docker image for Windows 20H2

### DIFF
--- a/.gitlab/deploy_7/docker.yml
+++ b/.gitlab/deploy_7/docker.yml
@@ -17,8 +17,9 @@
   dependencies: []
   before_script:
     - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv -e agent.version --major-version 7 --url-safe)"; fi
-    - export IMG_LINUX_SOURCES="${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7${JMX}-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7${JMX}-arm64"
-    - export IMG_WINDOWS_SOURCES="${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7${JMX}-win1809${SERVERCORE}-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7${JMX}-win1909${SERVERCORE}-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7${JMX}-win2004${SERVERCORE}-amd64"
+    - export IMG_BASE_SRC="${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}"
+    - export IMG_LINUX_SOURCES="${IMG_BASE_SRC}-7${JMX}-amd64,${IMG_BASE_SRC}-7${JMX}-arm64"
+    - export IMG_WINDOWS_SOURCES="${IMG_BASE_SRC}-7${JMX}-win1809${SERVERCORE}-amd64,${IMG_BASE_SRC}-7${JMX}-win1909${SERVERCORE}-amd64,${IMG_BASE_SRC}-7${JMX}-win2004${SERVERCORE}-amd64,${IMG_BASE_SRC}-7${JMX}-win20h2${SERVERCORE}-amd64"
     - if [[ "$SERVERCORE" == "-servercore" ]]; then export IMG_SOURCES="${IMG_WINDOWS_SOURCES}"; else export IMG_SOURCES="${IMG_LINUX_SOURCES},${IMG_WINDOWS_SOURCES}"; fi
     - export IMG_DESTINATIONS="${AGENT_REPOSITORY}:${VERSION}${SERVERCORE}${JMX}"
   parallel:
@@ -65,13 +66,17 @@ deploy_latest-a7:
   dependencies: []
   parallel:
     matrix:
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-arm64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1809-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1909-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win2004-amd64
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
+        IMG_SOURCES: "%BASE%-amd64,%BASE%-arm64,%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64"
         IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7,${AGENT_REPOSITORY}:latest
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-arm64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win1809-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win1909-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win2004-amd64
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
+        IMG_SOURCES: "%BASE%-amd64,%BASE%-arm64,%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64"
         IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7-jmx,${AGENT_REPOSITORY}:latest-jmx
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1809-servercore-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1909-servercore-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win2004-servercore-amd64
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64"
         IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7-servercore,${AGENT_REPOSITORY}:latest-servercore
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win1809-servercore-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win1909-servercore-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win2004-servercore-amd64
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64"
         IMG_DESTINATIONS: ${AGENT_REPOSITORY}:7-servercore-jmx,${AGENT_REPOSITORY}:latest-servercore-jmx
 
 deploy_latest-dogstatsd:

--- a/.gitlab/image_build/docker_windows_agent6.yml
+++ b/.gitlab/image_build/docker_windows_agent6.yml
@@ -26,3 +26,12 @@ docker_build_agent6_windows2004_core:
     VARIANT: 2004
     TAG_SUFFIX: -6
     WITH_JMX: "false"
+
+docker_build_agent6_windows20h2_core:
+  extends:
+    - .docker_build_agent6_windows_servercore_common
+  tags: ["runner:windows-docker", "windowsversion:20h2"]
+  variables:
+    VARIANT: 20h2
+    TAG_SUFFIX: -6
+    WITH_JMX: "false"

--- a/.gitlab/image_build/docker_windows_agent7.yml
+++ b/.gitlab/image_build/docker_windows_agent7.yml
@@ -54,6 +54,25 @@ docker_build_agent7_windows2004_jmx:
     TAG_SUFFIX: -7-jmx
     WITH_JMX: "true"
 
+docker_build_agent7_windows20h2:
+  extends:
+    - .docker_build_agent7_windows_common
+  tags: ["runner:windows-docker", "windowsversion:20h2"]
+  variables:
+    VARIANT: 20h2
+    TAG_SUFFIX: "-7"
+    WITH_JMX: "false"
+
+docker_build_agent7_windows20h2_jmx:
+  extends:
+    - .docker_build_agent7_windows_common
+  tags: ["runner:windows-docker", "windowsversion:20h2"]
+  needs: ["windows_msi_and_bosh_zip_x64-a7", "build_windows_container_entrypoint"]
+  variables:
+    VARIANT: 20h2
+    TAG_SUFFIX: -7-jmx
+    WITH_JMX: "true"
+
 docker_build_agent7_windows1809_core:
   extends:
     - .docker_build_agent7_windows_servercore_common
@@ -106,5 +125,24 @@ docker_build_agent7_windows2004_core_jmx:
   needs: ["windows_msi_and_bosh_zip_x64-a7", "build_windows_container_entrypoint"]
   variables:
     VARIANT: 2004
+    TAG_SUFFIX: -7-jmx
+    WITH_JMX: "true"
+
+docker_build_agent7_windows20h2_core:
+  extends:
+    - .docker_build_agent7_windows_servercore_common
+  tags: ["runner:windows-docker", "windowsversion:20h2"]
+  variables:
+    VARIANT: 20h2
+    TAG_SUFFIX: "-7"
+    WITH_JMX: "false"
+
+docker_build_agent7_windows20h2_core_jmx:
+  extends:
+    - .docker_build_agent7_windows_servercore_common
+  tags: ["runner:windows-docker", "windowsversion:20h2"]
+  needs: ["windows_msi_and_bosh_zip_x64-a7", "build_windows_container_entrypoint"]
+  variables:
+    VARIANT: 20h2
     TAG_SUFFIX: -7-jmx
     WITH_JMX: "true"

--- a/.gitlab/image_deploy/docker_windows.yml
+++ b/.gitlab/image_deploy/docker_windows.yml
@@ -23,17 +23,25 @@ dev_branch-a7-windows:
     - docker_build_agent7_windows2004_jmx
     - docker_build_agent7_windows2004_core
     - docker_build_agent7_windows2004_core_jmx
+    - docker_build_agent7_windows20h2
+    - docker_build_agent7_windows20h2_jmx
+    - docker_build_agent7_windows20h2_core
+    - docker_build_agent7_windows20h2_core_jmx
   variables:
     IMG_REGISTRIES: dev
   parallel:
     matrix:
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1809-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1909-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win2004-amd64
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-win
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win1809-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win1909-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win2004-amd64
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1809-servercore-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1909-servercore-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win2004-servercore-amd64
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-win-servercore
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win1809-servercore-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win1909-servercore-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win2004-servercore-amd64
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win-servercore
 
 dev_branch-a6-windows:
@@ -45,11 +53,13 @@ dev_branch-a6-windows:
     - docker_build_agent6_windows1809_core
     - docker_build_agent6_windows1909_core
     - docker_build_agent6_windows2004_core
+    - docker_build_agent6_windows20h2_core
   variables:
     IMG_REGISTRIES: dev
   parallel:
     matrix:
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-win1809-servercore-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-win1909-servercore-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-win2004-servercore-amd64
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py2-win-servercore
 
 dev_master-a7-windows:
@@ -70,17 +80,25 @@ dev_master-a7-windows:
     - docker_build_agent7_windows2004_jmx
     - docker_build_agent7_windows2004_core
     - docker_build_agent7_windows2004_core_jmx
+    - docker_build_agent7_windows20h2
+    - docker_build_agent7_windows20h2_jmx
+    - docker_build_agent7_windows20h2_core
+    - docker_build_agent7_windows20h2_core_jmx
   variables:
     IMG_REGISTRIES: dev
   parallel:
     matrix:
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1809-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1909-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win2004-amd64
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64"
         IMG_DESTINATIONS: agent-dev:master-py3-win
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win1809-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win1909-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win2004-amd64
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64"
         IMG_DESTINATIONS: agent-dev:master-py3-jmx-win
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1809-servercore-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1909-servercore-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win2004-servercore-amd64
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:master-py3-win-servercore
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win1809-servercore-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win1909-servercore-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win2004-servercore-amd64
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:master-py3-jmx-win-servercore
 
 dev_master-a6-windows:
@@ -92,11 +110,13 @@ dev_master-a6-windows:
     - docker_build_agent6_windows1809_core
     - docker_build_agent6_windows1909_core
     - docker_build_agent6_windows2004_core
+    - docker_build_agent6_windows20h2_core
   variables:
     IMG_REGISTRIES: dev
   parallel:
     matrix:
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-win1809-servercore-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-win1909-servercore-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-win2004-servercore-amd64
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:master-py2-win-servercore
 
 dev_nightly-a7-windows:
@@ -107,27 +127,35 @@ dev_nightly-a7-windows:
   needs:
     - docker_build_agent7_windows1809
     - docker_build_agent7_windows1809_jmx
-    - docker_build_agent7_windows1909
-    - docker_build_agent7_windows1909_jmx
-    - docker_build_agent7_windows2004
-    - docker_build_agent7_windows2004_jmx
     - docker_build_agent7_windows1809_core
     - docker_build_agent7_windows1809_core_jmx
+    - docker_build_agent7_windows1909
+    - docker_build_agent7_windows1909_jmx
     - docker_build_agent7_windows1909_core
     - docker_build_agent7_windows1909_core_jmx
+    - docker_build_agent7_windows2004
+    - docker_build_agent7_windows2004_jmx
     - docker_build_agent7_windows2004_core
     - docker_build_agent7_windows2004_core_jmx
+    - docker_build_agent7_windows20h2
+    - docker_build_agent7_windows20h2_jmx
+    - docker_build_agent7_windows20h2_core
+    - docker_build_agent7_windows20h2_core_jmx
   variables:
     IMG_REGISTRIES: dev
   parallel:
     matrix:
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1809-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1909-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win2004-amd64
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win1809-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win1909-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win2004-amd64
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1809-servercore-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win1909-servercore-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-win2004-servercore-amd64
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win-servercore
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win1809-servercore-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win1909-servercore-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx-win2004-servercore-amd64
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win-servercore
 
 dev_nightly-a6-windows:
@@ -139,9 +167,11 @@ dev_nightly-a6-windows:
     - docker_build_agent6_windows1809_core
     - docker_build_agent6_windows1909_core
     - docker_build_agent6_windows2004_core
+    - docker_build_agent6_windows20h2_core
   variables:
     IMG_REGISTRIES: dev
   parallel:
     matrix:
-      - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-win1809-servercore-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-win1909-servercore-amd64,${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-win2004-servercore-amd64
+      - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py2-win-servercore

--- a/releasenotes/notes/windows20h2-0ff7ac3b3d5c08c0.yaml
+++ b/releasenotes/notes/windows20h2-0ff7ac3b3d5c08c0.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add support for Windows 20H2 in published Docker images


### PR DESCRIPTION
### What does this PR do?

Adding support for Windows 20H2 in our Docker images.
Requires a change in `public-images` repo.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Publish dev image in DockerHub, you should generate a `20h2` image and the manifest `docker manifest inspect <target>` should contains 4 versions incl. 20h2 `19042`

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
