### PR TITLE
[pipeline] Retry go deps fetch jobs

### DIFF
--- a/.gitlab/deps_fetch.yml
+++ b/.gitlab/deps_fetch.yml
@@ -17,6 +17,7 @@
     expire_in: 1 day
     paths:
       - $CI_PROJECT_DIR/modcache.tar.gz
+  retry: 1
 
 linux_x64_go_deps:
   extends: .go_deps


### PR DESCRIPTION
### What does this PR do?

Adds `retry: 1` to the jobs which fetch go deps.

### Motivation

We created these jobs to limit the number of network errors we got in the pipeline, by only downloading go deps once. We can reduce the number of failures further by retrying these jobs when they fail.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
