### PR TITLE
[backport] Give some time to the DSDListeningTest container to listen

### DIFF
--- a/test/integration/docker/dsd_listening.py
+++ b/test/integration/docker/dsd_listening.py
@@ -1,4 +1,5 @@
 import os
+import time
 import unittest
 
 import docker
@@ -50,6 +51,7 @@ def waitUntilListening(container, retries=20):
         out = container.exec_run(cmd="netstat -a").output
         if b":8125" in out or SOCKET_PATH in out:
             return True
+        time.sleep(0.5)
     return False
 
 


### PR DESCRIPTION
### What does this PR do?

Backport of #9304.

### Motivation

Fix docker tests.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
