### PR TITLE
Fix metrics panic in serverless agent

### DIFF
--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -436,10 +436,6 @@ func (s *Server) forwarder(fcon net.Conn, packetsChannel chan packets.Packets) {
 // Flush flushes all the data to the aggregator to them send it to the Datadog intake.
 func (s *Server) Flush() {
 	log.Debug("Received a Flush trigger")
-	// make all workers flush their aggregated data (in the batcher) to the aggregator.
-	for _, w := range s.workers {
-		w.flush()
-	}
 	// flush the aggregator to have the serializer/forwarder send data to the backend.
 	// We add 10 seconds to the interval to ensure that we're getting the whole sketches bucket
 	s.aggregator.Flush(time.Now().Add(time.Second*10), true)

--- a/pkg/dogstatsd/server_worker.go
+++ b/pkg/dogstatsd/server_worker.go
@@ -32,15 +32,16 @@ func newWorker(s *Server) *worker {
 		server:    s,
 		batcher:   newBatcher(s.aggregator),
 		parser:    newParser(s.sharedFloat64List),
-		flushChan: make(chan chan struct{}, 1),
+		flushChan: make(chan chan struct{}, 0),
 		samples:   make([]metrics.MetricSample, 0, defaultSampleSize),
 	}
 }
 
 func (w *worker) flush() {
-	// Blocks until any
-	notify := make(chan struct{}, 1)
+	notify := make(chan struct{}, 0)
 	w.flushChan <- notify
+	// Blocks until notify has been received in the run loop, and
+	// returned a value.
 	<-notify
 }
 

--- a/pkg/serverless/metrics/metric.go
+++ b/pkg/serverless/metrics/metric.go
@@ -111,5 +111,6 @@ func buildBufferedAggregator(multipleEndpointConfig MultipleEndpointConfig, forw
 	f := forwarder.NewSyncForwarder(keysPerDomain, forwarderTimeout)
 	f.Start() //nolint:errcheck
 	serializer := serializer.NewSerializer(f, nil)
-	return aggregator.InitAggregator(serializer, nil, "serverless")
+	// flushInterval is set to 0 (disabled) because we want to control flushing from the daemon
+	return aggregator.InitAggregatorWithFlushInterval(serializer, nil, "serverless", 0)
 }


### PR DESCRIPTION
### What does this PR do?

Fixes a panic that is present in the serverless agent, due to non-thread safe code being called from multiple goroutines.

### Motivation

Reports of the crash.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
