### PR TITLE
pkg/trace/api: tone down logging level of internal port

### DIFF
--- a/pkg/otlp/config.go
+++ b/pkg/otlp/config.go
@@ -51,7 +51,7 @@ func fromExperimentalConfig(cfg config.Config) (PipelineConfig, error) {
 
 	httpPort, err := portToUint(cfg.GetInt(config.ExperimentalOTLPHTTPPort))
 	if err != nil {
-		errs = append(errs, fmt.Errorf("http port is invalid: %w", err))
+		errs = append(errs, fmt.Errorf("HTTP port is invalid: %w", err))
 	}
 
 	gRPCPort, err := portToUint(cfg.GetInt(config.ExperimentalOTLPgRPCPort))

--- a/pkg/otlp/config_test.go
+++ b/pkg/otlp/config_test.go
@@ -103,7 +103,7 @@ func TestFromAgentConfig(t *testing.T) {
 			name: "invalid",
 			path: "./testdata/invalid.yaml",
 			err: strings.Join([]string{
-				"http port is invalid: -1 is out of [0, 65535] range",
+				"HTTP port is invalid: -1 is out of [0, 65535] range",
 				"gRPC port is invalid: -1 is out of [0, 65535] range",
 				"internal trace port is invalid: -1 is out of [0, 65535] range",
 			},

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -78,7 +78,7 @@ func (o *OTLPReceiver) Start() {
 				}
 			}
 		}()
-		log.Infof("OpenTelemetry HTTP receiver running on http://%s:%d", o.cfg.BindHost, o.cfg.HTTPPort)
+		log.Debugf("OpenTelemetry HTTP receiver running on http://%s:%d (internal use only)", o.cfg.BindHost, o.cfg.HTTPPort)
 	}
 	if o.cfg.GRPCPort != 0 {
 		ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", o.cfg.BindHost, o.cfg.GRPCPort))
@@ -94,7 +94,7 @@ func (o *OTLPReceiver) Start() {
 					log.Criticalf("Error starting OpenTelemetry gRPC server: %v", err)
 				}
 			}()
-			log.Infof("OpenTelemetry gRPC receiver running on %s:%d", o.cfg.BindHost, o.cfg.GRPCPort)
+			log.Debugf("OpenTelemetry gRPC receiver running on %s:%d (internal use only)", o.cfg.BindHost, o.cfg.GRPCPort)
 		}
 	}
 }


### PR DESCRIPTION
Starting the trace-agent internal OpenTelemetry ports should not
confuse the user into using them. When the OpenTelemetry collector
starts, it is logged as such by the core agent:

```
2021-10-08 10:35:50 UTC | CORE | INFO | (collector@v0.36.0/receiver/otlpreceiver/otlp.go:74 in startGRPCServer) | kind:receiver,name:otlp | Starting GRPC server on endpoint 0.0.0.0:50052
2021-10-08 10:35:50 UTC | CORE | INFO | (collector@v0.36.0/receiver/otlpreceiver/otlp.go:92 in startHTTPServer) | kind:receiver,name:otlp | Starting HTTP server on endpoint 0.0.0.0:50051
```