### PR TITLE
[CSPM] fix name mangling when building rego input

### DIFF
--- a/pkg/compliance/checks/rego_check.go
+++ b/pkg/compliance/checks/rego_check.go
@@ -114,8 +114,9 @@ func (r *regoCheck) compileRule(rule *compliance.RegoRule, ruleScope compliance.
 func (r *regoCheck) normalizeInputMap(vars map[string]interface{}) map[string]interface{} {
 	normalized := make(map[string]interface{})
 	for k, v := range vars {
-		ps := strings.SplitN(k, ".", 2)
-		normalized[ps[1]] = v
+		ps := strings.Split(k, ".")
+		name := ps[len(ps)-1]
+		normalized[name] = v
 	}
 
 	return normalized


### PR DESCRIPTION
### What does this PR do?

The rego input document for k8s resources was not correctly formed:
```json
{
		"context": {
			"hostname": "kind-control-plane"
		},
		"pods": [
			{
				"resource.group": "",
				"resource.kind": "Pod",
				"resource.name": "datadog-1633687976-5t5gs",
				"resource.namespace": "default",
				"resource.resource": {
...
```

This PR fixes it to:
```json
{
		"context": {
			"hostname": "kind-control-plane"
		},
		"pods": [
			{
				"group": "",
				"kind": "Pod",
				"name": "datadog-1633687976-5t5gs",
				"namespace": "default",
				"resource": {
...
```

### Describe how to test your changes

Dump a rego input on a k8s rule and check that the input document is looking as expected.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
