### PR TITLE
[CSPM] add requirement on status field when decoding rego findings

### DIFF
--- a/pkg/compliance/checks/rego_check.go
+++ b/pkg/compliance/checks/rego_check.go
@@ -346,11 +346,36 @@ func parseFindings(regoData interface{}) ([]regoFinding, error) {
 		}
 
 		var finding regoFinding
-		if err := mapstructure.Decode(m, &finding); err != nil {
+		var decodeMetadata mapstructure.Metadata
+		if err := mapstructure.DecodeMetadata(m, &finding, &decodeMetadata); err != nil {
 			return nil, err
 		}
+
+		if err := checkFindingsRequiredFields(&decodeMetadata); err != nil {
+			return nil, err
+		}
+
 		res = append(res, finding)
 	}
 
 	return res, nil
+}
+
+func checkFindingsRequiredFields(metadata *mapstructure.Metadata) error {
+	requiredFields := make(map[string]bool)
+	requiredFields["status"] = false
+
+	for _, decodedField := range metadata.Keys {
+		if _, present := requiredFields[decodedField]; present {
+			requiredFields[decodedField] = true
+		}
+	}
+
+	for field, present := range requiredFields {
+		if !present {
+			return fmt.Errorf("missing field `%s` when decoding rego finding", field)
+		}
+	}
+
+	return nil
 }


### PR DESCRIPTION
### What does this PR do?

When decoding a finding from the output of a rego rule, we were not checking if the status field was present, possibly resulting in a failing finding where an error finding would have been expected. This PR fixes this. 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
