### PR TITLE
[ksm core] Strip tags with empty values

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_label_joins.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_label_joins.go
@@ -166,7 +166,7 @@ func (lj *labelJoiner) insertMetric(metric ksmstore.DDMetric, config *JoinsConfi
 
 		for _, labelToGet := range config.LabelsToGet {
 			labelValue, found := metric.Labels[labelToGet]
-			if found {
+			if found && labelValue != "" {
 				current.labelsToAdd = append(current.labelsToAdd, label{labelToGet, labelValue})
 			}
 		}

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_label_joins_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_label_joins_test.go
@@ -380,6 +380,58 @@ func Test_labelJoiner(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "Skip tags with empty value",
+			config: map[string]*JoinsConfig{
+				"kube_pod_info": {
+					LabelsToMatch: []string{"foo_key"},
+					LabelsToGet:   []string{"qux_key"},
+				},
+			},
+			families: map[string][]ksmstore.DDMetricsFam{
+				"uuid1": {
+					{
+						Name: "kube_pod_info",
+						ListMetrics: []ksmstore.DDMetric{
+							{
+								Labels: map[string]string{
+									"foo_key": "foo_value1",
+									"qux_key": "qux_value1",
+								},
+							},
+						},
+					},
+				},
+				"uuid2": {
+					{
+						Name: "kube_pod_info",
+						ListMetrics: []ksmstore.DDMetric{
+							{
+								Labels: map[string]string{
+									"foo_key": "foo_value2",
+									"qux_key": "",
+								},
+							},
+						},
+					},
+				},
+			},
+			expected: []struct {
+				inputLabels map[string]string
+				labelsToAdd []label
+			}{
+				{
+					inputLabels: map[string]string{"foo_key": "foo_value1"},
+					labelsToAdd: []label{
+						{key: "qux_key", value: "qux_value1"},
+					},
+				},
+				{
+					inputLabels: map[string]string{"foo_key": "foo_value2"},
+					labelsToAdd: []label{},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/releasenotes/notes/Do-not-create-tag-with-empty-value-7e8bc470b82d860a.yaml
+++ b/releasenotes/notes/Do-not-create-tag-with-empty-value-7e8bc470b82d860a.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Most checks are stripping tags with an empty value. KSM was missing this logic so that KSM specific metrics could have a tag with an empty value.
+    They will now be stripped like for any other check.


### PR DESCRIPTION
### What does this PR do?

Make KSM core check strip tags with an empty value.

### Motivation

Stripping tags with empty values is already done by other checks [here](https://github.com/DataDog/datadog-agent/blob/0454961e636342c9fbab9e561e6346ae804679a9/pkg/tagger/utils/taglist.go#L37-L38).

### Additional Notes


### Describe how to test your changes

Look at the KSM metrics and more specifically at the `kube_priority_class` tag that has been introduced by #9172.
Before this fix, pods without any priority class had their metrics decorated with `kube_priority_class:` tag.
With this fix, it shouldn’t be the case any more.

#### Before

```
$ kubectl exec datadog-agent-linux-cluster-agent-658d6f8696-gf5fj -- agent check kubernetes_state_core -r | grep priority_class | sort | uniq -c

   1069         "kube_priority_class:",
     68         "kube_priority_class:system-cluster-critical",
    180         "kube_priority_class:system-node-critical",
```

#### After

```
$ kubectl exec datadog-agent-linux-cluster-agent-6f9db7479f-rhj9n -- agent check kubernetes_state_core -r | grep priority_class | sort | uniq -c

     68         "kube_priority_class:system-cluster-critical",
    180         "kube_priority_class:system-node-critical",
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [X] The appropriate `team/..` label has been applied, if known.
- [X] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
