### PR TITLE
Update the log level when dropping a file containing payloads 

### DIFF
--- a/pkg/forwarder/internal/retry/on_disk_retry_queue.go
+++ b/pkg/forwarder/internal/retry/on_disk_retry_queue.go
@@ -156,7 +156,7 @@ func (s *onDiskRetryQueue) makeRoomFor(bufferSize int64) error {
 	for len(s.filenames) > 0 && s.currentSizeInBytes+bufferSize > maxStorageInBytes {
 		index := 0
 		filename := s.filenames[index]
-		log.Infof("Maximum disk space for retry transactions is reached. Removing %s", filename)
+		log.Errorf("Maximum disk space for retry transactions is reached. Removing %s", filename)
 		if err := s.removeFileAt(index); err != nil {
 			return err
 		}


### PR DESCRIPTION
### What does this PR do?

Update the message when dropping a file containing payloads from log level `Info` to `Error`.

### Motivation

When removing a file containing payloads, some metrics are dropped.

### Additional Notes

Anything else we should know when reviewing?


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
