### PR TITLE
[runtime-security] fix SELinux detection

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "cb8b84c723a0d8de0779a19c400d0cee7c68bd7324eae132b0618b2031ebce38")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "b59a58ec69396aef97dbe6266821fc6147cabfe99291d84063cb31be8be63539")

--- a/pkg/security/ebpf/c/selinux.h
+++ b/pkg/security/ebpf/c/selinux.h
@@ -139,7 +139,7 @@ int __attribute__((always_inline)) handle_selinux_event(void *ctx, struct file *
         case SELINUX_DISABLE_CHANGE_SOURCE_EVENT:
             syscall.selinux.event_kind = SELINUX_STATUS_CHANGE_EVENT_KIND;
             if (value >= 0) {
-                u32 key = SELINUX_ENFORCE_STATUS_ENFORCE_KEY;
+                u32 key = SELINUX_ENFORCE_STATUS_DISABLE_KEY;
                 bpf_map_update_elem(&selinux_enforce_status, &key, &value, BPF_ANY);
             }
             fill_selinux_status_payload(&syscall);

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -226,6 +226,21 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 		&manager.OneOf{Selectors: ExpandSyscallProbesSelector(
 			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "linkat"}, EntryAndExit),
 		},
+
+		// selinux
+		// This needs to be best effort, as sel_write_disable is in the process to be removed
+		&manager.BestEffort{Selectors: []manager.ProbesSelector{
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/sel_write_disable", EBPFFuncName: "kprobe_sel_write_disable"}},
+		}},
+		&manager.AllOf{Selectors: []manager.ProbesSelector{
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/sel_write_enforce", EBPFFuncName: "kprobe_sel_write_enforce"}},
+		}},
+		&manager.AllOf{Selectors: []manager.ProbesSelector{
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/sel_write_bool", EBPFFuncName: "kprobe_sel_write_bool"}},
+		}},
+		&manager.AllOf{Selectors: []manager.ProbesSelector{
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/sel_commit_bools_write", EBPFFuncName: "kprobe_sel_commit_bools_write"}},
+		}},
 	},
 
 	// List of probes to activate to capture chmod events
@@ -364,21 +379,5 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 		&manager.BestEffort{Selectors: ExpandSyscallProbesSelector(
 			manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "futimesat"}, EntryAndExit|ExpandTime32),
 		},
-	},
-
-	"selinux": {
-		// This needs to be best effort, as sel_write_disable is in the process to be removed
-		&manager.BestEffort{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/sel_write_disable", EBPFFuncName: "kprobe_sel_write_disable"}},
-		}},
-		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/sel_write_enforce", EBPFFuncName: "kprobe_sel_write_enforce"}},
-		}},
-		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/sel_write_bool", EBPFFuncName: "kprobe_sel_write_bool"}},
-		}},
-		&manager.AllOf{Selectors: []manager.ProbesSelector{
-			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/sel_commit_bools_write", EBPFFuncName: "kprobe_sel_commit_bools_write"}},
-		}},
 	},
 }

--- a/pkg/security/probe/selinux_resolver.go
+++ b/pkg/security/probe/selinux_resolver.go
@@ -19,7 +19,7 @@ const (
 	// SELinuxStatusDisableKey represents the key in the kernel map managing the current SELinux disable status
 	SELinuxStatusDisableKey uint32 = 0
 	// SELinuxStatusEnforceKey represents the key in the kernel map managing the current SELinux enforce status
-	SELinuxStatusEnforceKey uint32 = 0
+	SELinuxStatusEnforceKey uint32 = 1
 )
 
 func snapshotSELinux(selinuxStatusMap *ebpf.Map) error {

--- a/pkg/security/tests/selinux_test.go
+++ b/pkg/security/tests/selinux_test.go
@@ -49,7 +49,6 @@ func TestSELinux(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to save enforce status")
 	}
-	setEnforceStatus("permissive")
 	defer setEnforceStatus(currentEnforceStatus)
 
 	test, err := newTestModule(t, nil, ruleset, testOpts{})
@@ -64,15 +63,17 @@ func TestSELinux(t *testing.T) {
 	}
 	defer setBoolValue(TEST_BOOL_NAME, savedBoolValue)
 
-	t.Run("sel_disable", func(t *testing.T) {
+	t.Run("setenforce", func(t *testing.T) {
 		err = test.GetSignal(t, func() error {
-			if err := rawSudoWrite("/sys/fs/selinux/disable", "0", false); err != nil {
-				t.Errorf("failed to write to selinuxfs: %v", err)
+			if err := setEnforceStatus("permissive"); err != nil {
+				t.Errorf("failed to run setenforce: %v", err)
 			}
 			return nil
 		}, func(event *probe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_selinux_enforce")
 			assert.Equal(t, "selinux", event.GetType(), "wrong event type")
+
+			assertFieldEqual(t, event, "selinux.enforce.status", "permissive", "wrong enforce value")
 
 			if !validateSELinuxSchema(t, event) {
 				t.Error(event.String())
@@ -83,17 +84,15 @@ func TestSELinux(t *testing.T) {
 		}
 	})
 
-	t.Run("setenforce", func(t *testing.T) {
+	t.Run("sel_disable", func(t *testing.T) {
 		err = test.GetSignal(t, func() error {
-			if cmd := exec.Command("sudo", "-n", "setenforce", "0"); cmd.Run() != nil {
-				t.Errorf("Failed to run setenforce")
+			if err := rawSudoWrite("/sys/fs/selinux/disable", "0", false); err != nil {
+				t.Errorf("failed to write to selinuxfs: %v", err)
 			}
 			return nil
 		}, func(event *probe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_selinux_enforce")
 			assert.Equal(t, "selinux", event.GetType(), "wrong event type")
-
-			assertFieldEqual(t, event, "selinux.enforce.status", "permissive", "wrong enforce value")
 
 			if !validateSELinuxSchema(t, event) {
 				t.Error(event.String())

--- a/pkg/security/tests/selinux_test.go
+++ b/pkg/security/tests/selinux_test.go
@@ -28,7 +28,7 @@ func TestSELinux(t *testing.T) {
 	ruleset := []*rules.RuleDefinition{
 		{
 			ID:         "test_selinux_enforce",
-			Expression: `selinux.enforce.status in ["enabled", "permissive"]`,
+			Expression: `selinux.enforce.status in ["disabled", "permissive"]`,
 		},
 		{
 			ID:         "test_selinux_write_bool_true",


### PR DESCRIPTION
### What does this PR do?

This PR fixes the SELinux detection feature of the agent.

### Motivation

The SELinux feature is currently broken on main: the selinux enforce status retrieved by the snapshot is incorrect, leading the probe to believe that SELinux is disabled when it is enforcing ...

### Describe how to test your changes

The functional should now work properly.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
