### PR TITLE
Add support for tracing HTTPS requests in GnuTLS

### DIFF
--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Http = NewRuntimeAsset("http.c", "6605c420ac372a0a80767e3801481e396fb3e98a1e9602b96a18296f85528674")
+var Http = NewRuntimeAsset("http.c", "651b57aba4f385486acc1e5904cbc416d20c3b14909d0665e258d012b48b9873")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Http = NewRuntimeAsset("http.c", "a23ea9837c7346e6b8ad574ce4b5e95baf1d537b85c1cda216f2c31b2da6e71a")
+var Http = NewRuntimeAsset("http.c", "6605c420ac372a0a80767e3801481e396fb3e98a1e9602b96a18296f85528674")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "55ad744c70725c6c30708b8dde770d62d00e476f2c2ec296976e71e0159d2c86")
+var Tracer = NewRuntimeAsset("tracer.c", "ca572f0b9b5e26f76a5d22dce4d83c3304477400c5af2d604f7cb2b285c8dfe0")

--- a/pkg/network/ebpf/c/http.h
+++ b/pkg/network/ebpf/c/http.h
@@ -125,6 +125,9 @@ static __always_inline int http_begin_response(http_transaction_t *http, const c
     __u8 space_found = 0;
 #pragma unroll
     for (int i = 0; i < HTTP_BUFFER_SIZE - 1; i++) {
+	    // buffer might contain a null terminator in the middle
+        if (buffer[i] == 0) break;
+
         if (!space_found && buffer[i] == ' ') {
             space_found = 1;
         } else if (space_found && status_code < 100) {

--- a/pkg/network/ebpf/c/http.h
+++ b/pkg/network/ebpf/c/http.h
@@ -181,7 +181,6 @@ static __always_inline int http_process(char *buffer, skb_info_t *skb_info, u16 
         bpf_map_update_elem(&http_in_flight, &skb_info->tup, &new_entry, BPF_NOEXIST);
         http = bpf_map_lookup_elem(&http_in_flight, &skb_info->tup);
         if (http == NULL || http->owned_by_src_port != src_port) {
-            // log_debug("http_process > req but no t. or obsp != src_port src_port=%d\n", src_port);
             return 0;
         }
         http_begin_request(http, method, buffer, &skb_info->tup);
@@ -190,7 +189,6 @@ static __always_inline int http_process(char *buffer, skb_info_t *skb_info, u16 
         bpf_map_update_elem(&http_in_flight, &skb_info->tup, &new_entry, BPF_NOEXIST);
         http = bpf_map_lookup_elem(&http_in_flight, &skb_info->tup);
         if (http == NULL) {
-            // log_debug("http_process > res but no t. src_port=%d\n", src_port);
             return 0;
         }
         http_begin_response(http, buffer);
@@ -199,11 +197,6 @@ static __always_inline int http_process(char *buffer, skb_info_t *skb_info, u16 
         // We're either in the middle of either a request or response
         http = bpf_map_lookup_elem(&http_in_flight, &skb_info->tup);
         if (http == NULL) {
-            log_debug("http_process > mid of req/res but no t. src_port=%d\n", src_port);
-            log_debug("             t.saddr_h=%llu t.saddr_l=%llu\n", skb_info->tup.saddr_h, skb_info->tup.saddr_l);
-            log_debug("             t.daddr_h=%llu t.daddr_l=%llu\n", skb_info->tup.daddr_h, skb_info->tup.daddr_l);
-            log_debug("             t.sport=%u t.dport=%u\n", skb_info->tup.sport, skb_info->tup.dport);
-            log_debug("             t.netns=%lu t.pid=%lu t.metadata=%lu\n", skb_info->tup.netns, skb_info->tup.pid, skb_info->tup.metadata);
             return 0;
         }
     }
@@ -217,18 +210,6 @@ static __always_inline int http_process(char *buffer, skb_info_t *skb_info, u16 
     if (skb_info->tcp_flags & TCPHDR_FIN && http->owned_by_src_port == src_port) {
         http_enqueue(http, &skb_info->tup);
         bpf_map_delete_elem(&http_in_flight, &skb_info->tup);
-        log_debug("http_process > end t.\n");
-        // log_debug("http_process > end of t. src_port=%d http->owned_by_src_port=%d\n", src_port, http->owned_by_src_port);
-        // log_debug("             t.saddr_h=%llu t.saddr_l=%llu\n", skb_info->tup.saddr_h, skb_info->tup.saddr_l);
-        // log_debug("             t.daddr_h=%llu t.daddr_l=%llu\n", skb_info->tup.daddr_h, skb_info->tup.daddr_l);
-        // log_debug("             t.sport=%u t.dport=%u\n", skb_info->tup.sport, skb_info->tup.dport);
-        // log_debug("             t.netns=%lu t.pid=%lu t.metadata=%lu\n", skb_info->tup.netns, skb_info->tup.pid, skb_info->tup.metadata);
-    } else {
-        log_debug("http_process > t. src_port=%d http->owned_by_src_port=%d\n", src_port, http->owned_by_src_port);
-        log_debug("             t.saddr_h=%llu t.saddr_l=%llu\n", skb_info->tup.saddr_h, skb_info->tup.saddr_l);
-        log_debug("             t.daddr_h=%llu t.daddr_l=%llu\n", skb_info->tup.daddr_h, skb_info->tup.daddr_l);
-        log_debug("             t.sport=%u t.dport=%u\n", skb_info->tup.sport, skb_info->tup.dport);
-        log_debug("             t.netns=%lu t.pid=%lu t.metadata=%lu\n", skb_info->tup.netns, skb_info->tup.pid, skb_info->tup.metadata);
     }
 
     return 0;

--- a/pkg/network/ebpf/c/http.h
+++ b/pkg/network/ebpf/c/http.h
@@ -181,6 +181,7 @@ static __always_inline int http_process(char *buffer, skb_info_t *skb_info, u16 
         bpf_map_update_elem(&http_in_flight, &skb_info->tup, &new_entry, BPF_NOEXIST);
         http = bpf_map_lookup_elem(&http_in_flight, &skb_info->tup);
         if (http == NULL || http->owned_by_src_port != src_port) {
+            // log_debug("http_process > req but no t. or obsp != src_port src_port=%d\n", src_port);
             return 0;
         }
         http_begin_request(http, method, buffer, &skb_info->tup);
@@ -189,6 +190,7 @@ static __always_inline int http_process(char *buffer, skb_info_t *skb_info, u16 
         bpf_map_update_elem(&http_in_flight, &skb_info->tup, &new_entry, BPF_NOEXIST);
         http = bpf_map_lookup_elem(&http_in_flight, &skb_info->tup);
         if (http == NULL) {
+            // log_debug("http_process > res but no t. src_port=%d\n", src_port);
             return 0;
         }
         http_begin_response(http, buffer);
@@ -197,6 +199,11 @@ static __always_inline int http_process(char *buffer, skb_info_t *skb_info, u16 
         // We're either in the middle of either a request or response
         http = bpf_map_lookup_elem(&http_in_flight, &skb_info->tup);
         if (http == NULL) {
+            log_debug("http_process > mid of req/res but no t. src_port=%d\n", src_port);
+            log_debug("             t.saddr_h=%llu t.saddr_l=%llu\n", skb_info->tup.saddr_h, skb_info->tup.saddr_l);
+            log_debug("             t.daddr_h=%llu t.daddr_l=%llu\n", skb_info->tup.daddr_h, skb_info->tup.daddr_l);
+            log_debug("             t.sport=%u t.dport=%u\n", skb_info->tup.sport, skb_info->tup.dport);
+            log_debug("             t.netns=%lu t.pid=%lu t.metadata=%lu\n", skb_info->tup.netns, skb_info->tup.pid, skb_info->tup.metadata);
             return 0;
         }
     }
@@ -210,6 +217,18 @@ static __always_inline int http_process(char *buffer, skb_info_t *skb_info, u16 
     if (skb_info->tcp_flags & TCPHDR_FIN && http->owned_by_src_port == src_port) {
         http_enqueue(http, &skb_info->tup);
         bpf_map_delete_elem(&http_in_flight, &skb_info->tup);
+        log_debug("http_process > end t.\n");
+        // log_debug("http_process > end of t. src_port=%d http->owned_by_src_port=%d\n", src_port, http->owned_by_src_port);
+        // log_debug("             t.saddr_h=%llu t.saddr_l=%llu\n", skb_info->tup.saddr_h, skb_info->tup.saddr_l);
+        // log_debug("             t.daddr_h=%llu t.daddr_l=%llu\n", skb_info->tup.daddr_h, skb_info->tup.daddr_l);
+        // log_debug("             t.sport=%u t.dport=%u\n", skb_info->tup.sport, skb_info->tup.dport);
+        // log_debug("             t.netns=%lu t.pid=%lu t.metadata=%lu\n", skb_info->tup.netns, skb_info->tup.pid, skb_info->tup.metadata);
+    } else {
+        log_debug("http_process > t. src_port=%d http->owned_by_src_port=%d\n", src_port, http->owned_by_src_port);
+        log_debug("             t.saddr_h=%llu t.saddr_l=%llu\n", skb_info->tup.saddr_h, skb_info->tup.saddr_l);
+        log_debug("             t.daddr_h=%llu t.daddr_l=%llu\n", skb_info->tup.daddr_h, skb_info->tup.daddr_l);
+        log_debug("             t.sport=%u t.dport=%u\n", skb_info->tup.sport, skb_info->tup.dport);
+        log_debug("             t.netns=%lu t.pid=%lu t.metadata=%lu\n", skb_info->tup.netns, skb_info->tup.pid, skb_info->tup.metadata);
     }
 
     return 0;

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -36,12 +36,13 @@ int socket__http_filter(struct __sk_buff* skb) {
         return 0;
     }
 
+    // If the socket is for https and it is finishing,
+    // make sure we pass it on to `http_process` to ensure that any ongoing transaction is flushed.
+    // Otherwise, don't bother to inspect packet contents
+    // when there is no chance we're dealing with plain HTTP (or a finishing HTTPS socket)
     if (!(skb_info.tup.metadata&CONN_TYPE_TCP)) {
         return 0;
     }
-
-    // If the socket is for https and it is finishing,
-    // make sure we pass it on to `http_process` to ensure that any ongoing transaction is flushed.
     if ((skb_info.tup.sport == HTTPS_PORT || skb_info.tup.dport == HTTPS_PORT) && !(skb_info.tcp_flags & TCPHDR_FIN)) {
         // log_debug("socket/http_filter > https, not TCPHDR_FIN skb_info.sport=%d skb_info.dport=%d skb_info.tcp_flags%d\n", skb_info.tup.sport, skb_info.tup.dport, skb_info.tcp_flags);
         log_debug("socket/http_filter > https, !fin\n");

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -335,7 +335,9 @@ int uretprobe__gnutls_record_recv(struct pt_regs* ctx) {
 
     char buffer[HTTP_BUFFER_SIZE];
     __builtin_memset(buffer, 0, sizeof(buffer));
-    if (read_len >= HTTP_BUFFER_SIZE) {
+    if (read_len < sizeof(buffer)) {
+        bpf_probe_read(buffer, read_len, args->buf);
+    } else {
         bpf_probe_read(buffer, sizeof(buffer), args->buf);
     }
 
@@ -362,7 +364,9 @@ int uprobe__gnutls_record_send(struct pt_regs* ctx) {
 
     char buffer[HTTP_BUFFER_SIZE];
     __builtin_memset(buffer, 0, sizeof(buffer));
-    if (data_size >= HTTP_BUFFER_SIZE) {
+    if (data_size < sizeof(buffer)) {
+        bpf_probe_read(buffer, data_size, data);
+    } else {
         bpf_probe_read(buffer, sizeof(buffer), data);
     }
 

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -276,10 +276,9 @@ int uprobe__gnutls_transport_set_int2(struct pt_regs* ctx) {
 SEC("uprobe/gnutls_transport_set_ptr")
 int uprobe__gnutls_transport_set_ptr(struct pt_regs* ctx) {
     void *ssl_session = (void *)PT_REGS_PARM1(ctx);
-    // This should include the file descriptor cast as a pointer
-    void *fd_as_ptr = (void *)PT_REGS_PARM2(ctx);
+    // This is a void*, but it might contain the socket fd cast as a pointer.
+    int fd = (int)PT_REGS_PARM2(ctx);
 
-    int fd = (int)(uintptr_t)fd_as_ptr;
     init_ssl_sock(ssl_session, (u32)fd);
     return 0;
 }
@@ -291,10 +290,9 @@ int uprobe__gnutls_transport_set_ptr2(struct pt_regs* ctx) {
     void *ssl_session = (void *)PT_REGS_PARM1(ctx);
     // Use the recv_ptr and ignore the send_ptr;
     // in most real-world scenarios, they are the same.
-    // This should include the file descriptor cast as a pointer
-    void *recv_fd_as_ptr = (void *)PT_REGS_PARM2(ctx);
+    // This is a void*, but it might contain the socket fd cast as a pointer.
+    int recv_fd = (int)PT_REGS_PARM2(ctx);
 
-    int recv_fd = (int)(uintptr_t)recv_fd_as_ptr;
     init_ssl_sock(ssl_session, (u32)recv_fd);
     return 0;
 }

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -36,11 +36,19 @@ int socket__http_filter(struct __sk_buff* skb) {
         return 0;
     }
 
-    // don't bother to inspect packet contents when there is no chance we're dealing with plain HTTP
-    if (!(skb_info.tup.metadata&CONN_TYPE_TCP) || skb_info.tup.sport == HTTPS_PORT || skb_info.tup.dport == HTTPS_PORT) {
+    if (!(skb_info.tup.metadata&CONN_TYPE_TCP)) {
         return 0;
     }
 
+    // If the socket is for https and it is finishing,
+    // make sure we pass it on to `http_process` to ensure that any ongoing transaction is flushed.
+    if ((skb_info.tup.sport == HTTPS_PORT || skb_info.tup.dport == HTTPS_PORT) && !(skb_info.tcp_flags & TCPHDR_FIN)) {
+        // log_debug("socket/http_filter > https, not TCPHDR_FIN skb_info.sport=%d skb_info.dport=%d skb_info.tcp_flags%d\n", skb_info.tup.sport, skb_info.tup.dport, skb_info.tcp_flags);
+        log_debug("socket/http_filter > https, !fin\n");
+        return 0;
+    }
+    // log_debug("socket/http_filter > inspecting TCP skb_info.sport=%d skb_info.dport=%d skb_info.tcp_flags%d\n", skb_info.tup.sport, skb_info.tup.dport, skb_info.tcp_flags);
+    log_debug("socket/http_filter > i tcp\n");
 
     // src_port represents the source port number *before* normalization
     // for more context please refer to http-types.h comment on `owned_by_src_port` field
@@ -101,6 +109,16 @@ static __always_inline conn_tuple_t* tup_from_ssl_ctx(void *ssl_ctx, u64 pid_tgi
         log_debug("CANONICAL-GNUTLS-DEBUG-LINE                  > could not read conn tuple from sock\n");
         return NULL;
     }
+
+    // Set the `.netns` and `.pid` values to always be 0.
+    // They can't be sourced from inside `read_conn_tuple_skb`,
+    // which is used elsewhere to produce the same `conn_tuple_t` value from a `struct __sk_buff*` value,
+    // so we ensure it is always 0 here so that both paths produce the same `conn_tuple_t` value.
+    // `netns` is not used in the userspace program part that binds http information to `ConnectionStats`,
+    // so this is isn't a problem.
+    t.netns = 0;
+    t.pid = 0;
+
     __builtin_memcpy(&ssl_sock->tup, &t, sizeof(conn_tuple_t));
 
     if (!is_ephemeral_port(ssl_sock->tup.sport)) {

--- a/pkg/network/ebpf/c/prebuilt/tracer.c
+++ b/pkg/network/ebpf/c/prebuilt/tracer.c
@@ -591,14 +591,9 @@ int kprobe__sockfd_lookup_light(struct pt_regs* ctx) {
     };
     struct sock** sock = bpf_map_lookup_elem(&sock_by_pid_fd, &key);
     if (sock != NULL) {
-        log_debug("CANONICAL-GNUTLS-DEBUG-LINE kprobe/sockfd_lookup_light sockfd=%d pid_tgid=0x%llx\n", sockfd, pid_tgid);
-        log_debug("CANONICAL-GNUTLS-DEBUG-LINE                            sock=0x%llx\n", *sock);
-        log_debug("CANONICAL-GNUTLS-DEBUG-LINE                            > sock already in sock_by_pid_fd\n");
         // TODO un-comment this line eventually
         // return 0;
     }
-    log_debug("CANONICAL-GNUTLS-DEBUG-LINE kprobe/sockfd_lookup_light sockfd=%d pid_tgid=0x%llx\n", sockfd, pid_tgid);
-    log_debug("CANONICAL-GNUTLS-DEBUG-LINE                            > storing args in map for kretprobe\n");
 
     bpf_map_update_elem(&sockfd_lookup_args, &pid_tgid, &sockfd, BPF_ANY);
     return 0;
@@ -612,7 +607,6 @@ int kretprobe__sockfd_lookup_light(struct pt_regs* ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
     int *sockfd = bpf_map_lookup_elem(&sockfd_lookup_args, &pid_tgid);
     if (sockfd == NULL) {
-        log_debug("CANONICAL-GNUTLS-DEBUG-LINE kretprobe/sockfd_lookup_light > no stored arguments in map from kprobe\n");
         return 0;
     }
 
@@ -621,9 +615,6 @@ int kretprobe__sockfd_lookup_light(struct pt_regs* ctx) {
     enum sock_type sock_type = 0;
     bpf_probe_read(&sock_type, sizeof(short), &socket->type);
     if (sock_type != SOCK_STREAM) {
-        log_debug("CANONICAL-GNUTLS-DEBUG-LINE kretprobe/sockfd_lookup_light sockfd=%d pid_tgid=0x%llx\n", *sockfd, pid_tgid);
-        log_debug("CANONICAL-GNUTLS-DEBUG-LINE                               socket=0x%llx sock_type=%d\n", socket, sock_type);
-        log_debug("CANONICAL-GNUTLS-DEBUG-LINE                               > socket is not SOCK_STREAM; skipping\n");
         goto cleanup;
     }
 
@@ -636,24 +627,9 @@ int kretprobe__sockfd_lookup_light(struct pt_regs* ctx) {
         .fd = (*sockfd),
     };
 
-    void* debug_existing_sock = 0;
-    struct sock** debug_existing_sock_entry = bpf_map_lookup_elem(&sock_by_pid_fd, &pid_fd);
-    if (debug_existing_sock_entry != NULL) {
-        debug_existing_sock = *debug_existing_sock_entry;
-    }
-
     // These entries are cleaned up by tcp_close
     bpf_map_update_elem(&pid_fd_by_sock, &sock, &pid_fd, BPF_ANY);
     bpf_map_update_elem(&sock_by_pid_fd, &pid_fd, &sock, BPF_ANY);
-    log_debug("CANONICAL-GNUTLS-DEBUG-LINE kretprobe/sockfd_lookup_light sockfd=%d pid_tgid=0x%llx\n", *sockfd, pid_tgid);
-    log_debug("CANONICAL-GNUTLS-DEBUG-LINE                               socket=0x%llx sock_type=%d\n", socket, sock_type);
-    log_debug("CANONICAL-GNUTLS-DEBUG-LINE                               sock(old)=0x%llx sock(new)=0x%llx\n", debug_existing_sock, sock);
-    // log_debug("CANONICAL-GNUTLS-DEBUG-LINE                               sock(new)=0x%llx\n", sock);
-    if (debug_existing_sock == sock) {
-        log_debug("CANONICAL-GNUTLS-DEBUG-LINE                               > stored same TCP socket in maps\n");
-    } else {
-        log_debug("CANONICAL-GNUTLS-DEBUG-LINE                               > stored new TCP socket in maps\n");
-    }
 cleanup:
     bpf_map_delete_elem(&sockfd_lookup_args, &pid_tgid);
     return 0;

--- a/pkg/network/ebpf/c/prebuilt/tracer.c
+++ b/pkg/network/ebpf/c/prebuilt/tracer.c
@@ -591,8 +591,7 @@ int kprobe__sockfd_lookup_light(struct pt_regs* ctx) {
     };
     struct sock** sock = bpf_map_lookup_elem(&sock_by_pid_fd, &key);
     if (sock != NULL) {
-        // TODO un-comment this line eventually
-        // return 0;
+        return 0;
     }
 
     bpf_map_update_elem(&sockfd_lookup_args, &pid_tgid, &sockfd, BPF_ANY);

--- a/pkg/network/ebpf/c/prebuilt/tracer.c
+++ b/pkg/network/ebpf/c/prebuilt/tracer.c
@@ -614,8 +614,11 @@ int kretprobe__sockfd_lookup_light(struct pt_regs* ctx) {
     enum sock_type sock_type = 0;
     bpf_probe_read(&sock_type, sizeof(short), &socket->type);
 
+    // (struct socket).ops is always directly after (struct socket).sk,
+    // which is a pointer.
+    u64 ops_offset = offset_socket_sk() + sizeof(void*);
     struct proto_ops *proto_ops = NULL;
-    bpf_probe_read(&proto_ops, sizeof(proto_ops), &socket->ops);
+    bpf_probe_read(&proto_ops, sizeof(proto_ops), (void*)(socket) + ops_offset);
     if (!proto_ops) {
         goto cleanup;
     }

--- a/pkg/network/ebpf/c/prebuilt/tracer.c
+++ b/pkg/network/ebpf/c/prebuilt/tracer.c
@@ -594,6 +594,7 @@ int kprobe__sockfd_lookup_light(struct pt_regs* ctx) {
         log_debug("CANONICAL-GNUTLS-DEBUG-LINE kprobe/sockfd_lookup_light sockfd=%d pid_tgid=0x%llx\n", sockfd, pid_tgid);
         log_debug("CANONICAL-GNUTLS-DEBUG-LINE                            sock=0x%llx\n", *sock);
         log_debug("CANONICAL-GNUTLS-DEBUG-LINE                            > sock already in sock_by_pid_fd\n");
+        // TODO un-comment this line eventually
         // return 0;
     }
     log_debug("CANONICAL-GNUTLS-DEBUG-LINE kprobe/sockfd_lookup_light sockfd=%d pid_tgid=0x%llx\n", sockfd, pid_tgid);
@@ -635,10 +636,10 @@ int kretprobe__sockfd_lookup_light(struct pt_regs* ctx) {
         .fd = (*sockfd),
     };
 
-    void* debug_exis_sock_raw = 0;
-    struct sock** debug_exis_sock = bpf_map_lookup_elem(&sock_by_pid_fd, &pid_fd);
-    if (debug_exis_sock != NULL) {
-        debug_exis_sock_raw = *debug_exis_sock;
+    void* debug_existing_sock = 0;
+    struct sock** debug_existing_sock_entry = bpf_map_lookup_elem(&sock_by_pid_fd, &pid_fd);
+    if (debug_existing_sock_entry != NULL) {
+        debug_existing_sock = *debug_existing_sock_entry;
     }
 
     // These entries are cleaned up by tcp_close
@@ -646,9 +647,9 @@ int kretprobe__sockfd_lookup_light(struct pt_regs* ctx) {
     bpf_map_update_elem(&sock_by_pid_fd, &pid_fd, &sock, BPF_ANY);
     log_debug("CANONICAL-GNUTLS-DEBUG-LINE kretprobe/sockfd_lookup_light sockfd=%d pid_tgid=0x%llx\n", *sockfd, pid_tgid);
     log_debug("CANONICAL-GNUTLS-DEBUG-LINE                               socket=0x%llx sock_type=%d\n", socket, sock_type);
-    log_debug("CANONICAL-GNUTLS-DEBUG-LINE                               sock(old)=0x%llx sock(new)=0x%llx debug_exis_sock=0xllx\n", debug_exis_sock_raw, sock, debug_exis_sock);
+    log_debug("CANONICAL-GNUTLS-DEBUG-LINE                               sock(old)=0x%llx sock(new)=0x%llx\n", debug_existing_sock, sock);
     // log_debug("CANONICAL-GNUTLS-DEBUG-LINE                               sock(new)=0x%llx\n", sock);
-    if (debug_exis_sock_raw == sock) {
+    if (debug_existing_sock == sock) {
         log_debug("CANONICAL-GNUTLS-DEBUG-LINE                               > stored same TCP socket in maps\n");
     } else {
         log_debug("CANONICAL-GNUTLS-DEBUG-LINE                               > stored new TCP socket in maps\n");

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -335,7 +335,9 @@ int uretprobe__gnutls_record_recv(struct pt_regs* ctx) {
 
     char buffer[HTTP_BUFFER_SIZE];
     __builtin_memset(buffer, 0, sizeof(buffer));
-    if (read_len >= HTTP_BUFFER_SIZE) {
+    if (read_len < sizeof(buffer)) {
+        bpf_probe_read(buffer, read_len, args->buf);
+    } else {
         bpf_probe_read(buffer, sizeof(buffer), args->buf);
     }
 
@@ -362,7 +364,9 @@ int uprobe__gnutls_record_send(struct pt_regs* ctx) {
 
     char buffer[HTTP_BUFFER_SIZE];
     __builtin_memset(buffer, 0, sizeof(buffer));
-    if (data_size >= HTTP_BUFFER_SIZE) {
+    if (data_size < sizeof(buffer)) {
+        bpf_probe_read(buffer, data_size, data);
+    } else {
         bpf_probe_read(buffer, sizeof(buffer), data);
     }
 

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -36,11 +36,16 @@ int socket__http_filter(struct __sk_buff* skb) {
         return 0;
     }
 
-    // don't bother to inspect packet contents when there is no chance we're dealing with plain HTTP
-    if (!(skb_info.tup.metadata&CONN_TYPE_TCP) || skb_info.tup.sport == HTTPS_PORT || skb_info.tup.dport == HTTPS_PORT) {
+    // If the socket is for https and it is finishing,
+    // make sure we pass it on to `http_process` to ensure that any ongoing transaction is flushed.
+    // Otherwise, don't bother to inspect packet contents
+    // when there is no chance we're dealing with plain HTTP (or a finishing HTTPS socket)
+    if (!(skb_info.tup.metadata&CONN_TYPE_TCP)) {
         return 0;
     }
-
+    if ((skb_info.tup.sport == HTTPS_PORT || skb_info.tup.dport == HTTPS_PORT) && !(skb_info.tcp_flags & TCPHDR_FIN)) {
+        return 0;
+    }
 
     // src_port represents the source port number *before* normalization
     // for more context please refer to http-types.h comment on `owned_by_src_port` field
@@ -92,6 +97,16 @@ static __always_inline conn_tuple_t* tup_from_ssl_ctx(void *ssl_ctx, u64 pid_tgi
     if (!read_conn_tuple(&t, *sock, pid_tgid, CONN_TYPE_TCP)) {
         return NULL;
     }
+
+    // Set the `.netns` and `.pid` values to always be 0.
+    // They can't be sourced from inside `read_conn_tuple_skb`,
+    // which is used elsewhere to produce the same `conn_tuple_t` value from a `struct __sk_buff*` value,
+    // so we ensure it is always 0 here so that both paths produce the same `conn_tuple_t` value.
+    // `netns` is not used in the userspace program part that binds http information to `ConnectionStats`,
+    // so this is isn't a problem.
+    t.netns = 0;
+    t.pid = 0;
+
     __builtin_memcpy(&ssl_sock->tup, &t, sizeof(conn_tuple_t));
 
     if (!is_ephemeral_port(ssl_sock->tup.sport)) {
@@ -237,6 +252,147 @@ int uprobe__SSL_shutdown(struct pt_regs* ctx) {
     skb_info.tcp_flags |= TCPHDR_FIN;
     http_process(buffer, &skb_info, skb_info.tup.sport);
     bpf_map_delete_elem(&ssl_sock_by_ctx, &ssl_ctx);
+    return 0;
+}
+
+// void gnutls_transport_set_int (gnutls_session_t session, int fd)
+// Note: this function is implemented as a macro in gnutls
+// that calls gnutls_transport_set_int2, so no uprobe is needed
+
+// void gnutls_transport_set_int2 (gnutls_session_t session, int recv_fd, int send_fd)
+SEC("uprobe/gnutls_transport_set_int2")
+int uprobe__gnutls_transport_set_int2(struct pt_regs* ctx) {
+    void *ssl_session = (void *)PT_REGS_PARM1(ctx);
+    // Use the recv_fd and ignore the send_fd;
+    // in most real-world scenarios, they are the same.
+    int recv_fd = (int)PT_REGS_PARM2(ctx);
+
+    init_ssl_sock(ssl_session, (u32)recv_fd);
+    return 0;
+}
+
+// void gnutls_transport_set_ptr (gnutls_session_t session, gnutls_transport_ptr_t ptr)
+// "In berkeley style sockets this function will set the connection descriptor."
+SEC("uprobe/gnutls_transport_set_ptr")
+int uprobe__gnutls_transport_set_ptr(struct pt_regs* ctx) {
+    void *ssl_session = (void *)PT_REGS_PARM1(ctx);
+    // This should include the file descriptor cast as a pointer
+    void *fd_as_ptr = (void *)PT_REGS_PARM2(ctx);
+
+    int fd = (int)(uintptr_t)fd_as_ptr;
+    init_ssl_sock(ssl_session, (u32)fd);
+    return 0;
+}
+
+// void gnutls_transport_set_ptr2 (gnutls_session_t session, gnutls_transport_ptr_t recv_ptr, gnutls_transport_ptr_t send_ptr)
+// "In berkeley style sockets this function will set the connection descriptor."
+SEC("uprobe/gnutls_transport_set_ptr2")
+int uprobe__gnutls_transport_set_ptr2(struct pt_regs* ctx) {
+    void *ssl_session = (void *)PT_REGS_PARM1(ctx);
+    // Use the recv_ptr and ignore the send_ptr;
+    // in most real-world scenarios, they are the same.
+    // This should include the file descriptor cast as a pointer
+    void *recv_fd_as_ptr = (void *)PT_REGS_PARM2(ctx);
+
+    int recv_fd = (int)(uintptr_t)recv_fd_as_ptr;
+    init_ssl_sock(ssl_session, (u32)recv_fd);
+    return 0;
+}
+
+// ssize_t gnutls_record_recv (gnutls_session_t session, void * data, size_t data_size)
+SEC("uprobe/gnutls_record_recv")
+int uprobe__gnutls_record_recv(struct pt_regs* ctx) {
+    void *ssl_session = (void *)PT_REGS_PARM1(ctx);
+    void *data = (void *)PT_REGS_PARM2(ctx);
+
+    // Re-use the map for SSL_read
+    ssl_read_args_t args = {
+        .ctx = ssl_session,
+        .buf = data,
+    };
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    bpf_map_update_elem(&ssl_read_args, &pid_tgid, &args, BPF_ANY);
+    return 0;
+}
+
+// ssize_t gnutls_record_recv (gnutls_session_t session, void * data, size_t data_size)
+SEC("uretprobe/gnutls_record_recv")
+int uretprobe__gnutls_record_recv(struct pt_regs* ctx) {
+    ssize_t read_len = (ssize_t)PT_REGS_RC(ctx);
+
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    // Re-use the map for SSL_read
+    ssl_read_args_t *args = bpf_map_lookup_elem(&ssl_read_args, &pid_tgid);
+    if (args == NULL) {
+        return 0;
+    }
+
+    void *ssl_session = args->ctx;
+    conn_tuple_t *t = tup_from_ssl_ctx(ssl_session, pid_tgid);
+    if (t == NULL) {
+        goto cleanup;
+    }
+
+    char buffer[HTTP_BUFFER_SIZE];
+    __builtin_memset(buffer, 0, sizeof(buffer));
+    if (read_len >= HTTP_BUFFER_SIZE) {
+        bpf_probe_read(buffer, sizeof(buffer), args->buf);
+    }
+
+    skb_info_t skb_info = {0};
+    __builtin_memcpy(&skb_info.tup, t, sizeof(conn_tuple_t));
+    http_process(buffer, &skb_info, skb_info.tup.sport);
+ cleanup:
+    bpf_map_delete_elem(&ssl_read_args, &pid_tgid);
+    return 0;
+}
+
+// ssize_t gnutls_record_send (gnutls_session_t session, const void * data, size_t data_size)
+SEC("uprobe/gnutls_record_send")
+int uprobe__gnutls_record_send(struct pt_regs* ctx) {
+    void *ssl_session = (void *)PT_REGS_PARM1(ctx);
+    void *data = (void *)PT_REGS_PARM2(ctx);
+    size_t data_size = (size_t)PT_REGS_PARM3(ctx);
+
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    conn_tuple_t *t = tup_from_ssl_ctx(ssl_session, pid_tgid);
+    if (t == NULL) {
+        return 0;
+    }
+
+    char buffer[HTTP_BUFFER_SIZE];
+    __builtin_memset(buffer, 0, sizeof(buffer));
+    if (data_size >= HTTP_BUFFER_SIZE) {
+        bpf_probe_read(buffer, sizeof(buffer), data);
+    }
+
+    skb_info_t skb_info = {0};
+    __builtin_memcpy(&skb_info.tup, t, sizeof(conn_tuple_t));
+    http_process(buffer, &skb_info, skb_info.tup.sport);
+    return 0;
+}
+
+// int gnutls_bye (gnutls_session_t session, gnutls_close_request_t how)
+SEC("uprobe/gnutls_bye")
+int uprobe__gnutls_bye(struct pt_regs* ctx) {
+    void *ssl_session = (void *)PT_REGS_PARM1(ctx);
+
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+    conn_tuple_t *t = tup_from_ssl_ctx(ssl_session, pid_tgid);
+    if (t == NULL) {
+        return 0;
+    }
+
+    char buffer[HTTP_BUFFER_SIZE];
+    __builtin_memset(buffer, 0, sizeof(buffer));
+
+    skb_info_t skb_info = {0};
+    __builtin_memcpy(&skb_info.tup, t, sizeof(conn_tuple_t));
+
+    // TODO: this is just a hack. Let's get rid of this skb_info argument altogether
+    skb_info.tcp_flags |= TCPHDR_FIN;
+    http_process(buffer, &skb_info, skb_info.tup.sport);
+    bpf_map_delete_elem(&ssl_sock_by_ctx, &ssl_session);
     return 0;
 }
 

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -276,10 +276,9 @@ int uprobe__gnutls_transport_set_int2(struct pt_regs* ctx) {
 SEC("uprobe/gnutls_transport_set_ptr")
 int uprobe__gnutls_transport_set_ptr(struct pt_regs* ctx) {
     void *ssl_session = (void *)PT_REGS_PARM1(ctx);
-    // This should include the file descriptor cast as a pointer
-    void *fd_as_ptr = (void *)PT_REGS_PARM2(ctx);
+    // This is a void*, but it might contain the socket fd cast as a pointer.
+    int fd = (int)PT_REGS_PARM2(ctx);
 
-    int fd = (int)(uintptr_t)fd_as_ptr;
     init_ssl_sock(ssl_session, (u32)fd);
     return 0;
 }
@@ -291,10 +290,9 @@ int uprobe__gnutls_transport_set_ptr2(struct pt_regs* ctx) {
     void *ssl_session = (void *)PT_REGS_PARM1(ctx);
     // Use the recv_ptr and ignore the send_ptr;
     // in most real-world scenarios, they are the same.
-    // This should include the file descriptor cast as a pointer
-    void *recv_fd_as_ptr = (void *)PT_REGS_PARM2(ctx);
+    // This is a void*, but it might contain the socket fd cast as a pointer.
+    int recv_fd = (int)PT_REGS_PARM2(ctx);
 
-    int recv_fd = (int)(uintptr_t)recv_fd_as_ptr;
     init_ssl_sock(ssl_session, (u32)recv_fd);
     return 0;
 }

--- a/pkg/network/ebpf/c/runtime/tracer.c
+++ b/pkg/network/ebpf/c/runtime/tracer.c
@@ -578,7 +578,16 @@ int kretprobe__sockfd_lookup_light(struct pt_regs* ctx) {
     struct socket* socket = (struct socket*)PT_REGS_RC(ctx);
     enum sock_type sock_type = 0;
     bpf_probe_read(&sock_type, sizeof(short), &socket->type);
-    if (sock_type != SOCK_STREAM) {
+
+    struct proto_ops *proto_ops = NULL;
+    bpf_probe_read(&proto_ops, sizeof(proto_ops), &socket->ops);
+    if (!proto_ops) {
+        goto cleanup;
+    }
+
+    int family = 0;
+    bpf_probe_read(&family, sizeof(family), &proto_ops->family);
+    if (sock_type != SOCK_STREAM || !(family == AF_INET || family == AF_INET6)) {
         goto cleanup;
     }
 

--- a/pkg/network/http/ebpf_main.go
+++ b/pkg/network/http/ebpf_main.go
@@ -103,14 +103,14 @@ func newEBPFProgram(c *config.Config, offsets []manager.ConstantEditor, sockFD *
 		},
 	}
 
-	openSSLProgram, _ := newOpenSSLProgram(c, sockFD)
+	sslProgram, _ := newSSLProgram(c, sockFD)
 	program := &ebpfProgram{
 		Manager:                mgr,
 		bytecode:               bytecode,
 		cfg:                    c,
 		offsets:                offsets,
 		batchCompletionHandler: batchCompletionHandler,
-		subprograms:            []subprogram{openSSLProgram},
+		subprograms:            []subprogram{sslProgram},
 	}
 
 	return program, nil

--- a/pkg/network/http/ebpf_ssl.go
+++ b/pkg/network/http/ebpf_ssl.go
@@ -18,7 +18,7 @@ import (
 	"github.com/DataDog/ebpf/manager"
 )
 
-var sslProbes = []string{
+var openSSLProbes = []string{
 	"uprobe/SSL_set_bio",
 	"uprobe/SSL_set_fd",
 	"uprobe/SSL_read",
@@ -30,6 +30,16 @@ var sslProbes = []string{
 var cryptoProbes = []string{
 	"uprobe/BIO_new_socket",
 	"uretprobe/BIO_new_socket",
+}
+
+var gnuTLSProbes = []string{
+	"uprobe/gnutls_transport_set_int2",
+	"uprobe/gnutls_transport_set_ptr",
+	"uprobe/gnutls_transport_set_ptr2",
+	"uprobe/gnutls_record_recv",
+	"uretprobe/gnutls_record_recv",
+	"uprobe/gnutls_record_send",
+	"uprobe/gnutls_bye",
 }
 
 const (
@@ -130,13 +140,18 @@ func (o *openSSLProgram) Start() {
 	o.watcher = newSOWatcher(o.cfg.ProcRoot, o.perfHandler,
 		soRule{
 			re:           regexp.MustCompile(`libssl.so`),
-			registerCB:   addHooks(o.manager, sslProbes),
-			unregisterCB: removeHooks(o.manager, sslProbes),
+			registerCB:   addHooks(o.manager, openSSLProbes),
+			unregisterCB: removeHooks(o.manager, openSSLProbes),
 		},
 		soRule{
 			re:           regexp.MustCompile(`libcrypto.so`),
 			registerCB:   addHooks(o.manager, cryptoProbes),
 			unregisterCB: removeHooks(o.manager, cryptoProbes),
+		},
+		soRule{
+			re:           regexp.MustCompile(`libgnutls.so`),
+			registerCB:   addHooks(m, gnuTLSProbes),
+			unregisterCB: removeHooks(m, gnuTLSProbes),
 		},
 	)
 

--- a/pkg/network/http/ebpf_ssl.go
+++ b/pkg/network/http/ebpf_ssl.go
@@ -3,10 +3,7 @@
 package http
 
 import (
-	"crypto/md5"
-	"fmt"
 	"os"
-	"path/filepath"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -17,7 +14,6 @@ import (
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/ebpf"
 	"github.com/DataDog/ebpf/manager"
 )

--- a/pkg/network/http/ebpf_ssl.go
+++ b/pkg/network/http/ebpf_ssl.go
@@ -51,7 +51,7 @@ const (
 	doSysOpenRet = "kretprobe/do_sys_open"
 )
 
-type openSSLProgram struct {
+type sslProgram struct {
 	cfg         *config.Config
 	sockFDMap   *ebpf.Map
 	perfHandler *ddebpf.PerfHandler
@@ -59,21 +59,21 @@ type openSSLProgram struct {
 	manager     *manager.Manager
 }
 
-var _ subprogram = &openSSLProgram{}
+var _ subprogram = &sslProgram{}
 
-func newOpenSSLProgram(c *config.Config, sockFDMap *ebpf.Map) (*openSSLProgram, error) {
+func newSSLProgram(c *config.Config, sockFDMap *ebpf.Map) (*sslProgram, error) {
 	if !c.EnableHTTPSMonitoring {
 		return nil, nil
 	}
 
-	return &openSSLProgram{
+	return &sslProgram{
 		cfg:         c,
 		sockFDMap:   sockFDMap,
 		perfHandler: ddebpf.NewPerfHandler(batchNotificationsChanSize),
 	}, nil
 }
 
-func (o *openSSLProgram) ConfigureManager(m *manager.Manager) {
+func (o *sslProgram) ConfigureManager(m *manager.Manager) {
 	if o == nil {
 		return
 	}
@@ -98,7 +98,7 @@ func (o *openSSLProgram) ConfigureManager(m *manager.Manager) {
 	}
 }
 
-func (o *openSSLProgram) ConfigureOptions(options *manager.Options) {
+func (o *sslProgram) ConfigureOptions(options *manager.Options) {
 	if o == nil {
 		return
 	}
@@ -131,7 +131,7 @@ func (o *openSSLProgram) ConfigureOptions(options *manager.Options) {
 	options.MapEditors[string(probes.SockByPidFDMap)] = o.sockFDMap
 }
 
-func (o *openSSLProgram) Start() {
+func (o *sslProgram) Start() {
 	if o == nil {
 		return
 	}
@@ -158,7 +158,7 @@ func (o *openSSLProgram) Start() {
 	o.watcher.Start()
 }
 
-func (o *openSSLProgram) Stop() {
+func (o *sslProgram) Stop() {
 	if o == nil {
 		return
 	}

--- a/pkg/network/http/ebpf_ssl.go
+++ b/pkg/network/http/ebpf_ssl.go
@@ -3,7 +3,10 @@
 package http
 
 import (
+	"crypto/md5"
+	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strconv"
@@ -14,6 +17,7 @@ import (
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/ebpf"
 	"github.com/DataDog/ebpf/manager"
 )
@@ -150,8 +154,8 @@ func (o *openSSLProgram) Start() {
 		},
 		soRule{
 			re:           regexp.MustCompile(`libgnutls.so`),
-			registerCB:   addHooks(m, gnuTLSProbes),
-			unregisterCB: removeHooks(m, gnuTLSProbes),
+			registerCB:   addHooks(o.manager, gnuTLSProbes),
+			unregisterCB: removeHooks(o.manager, gnuTLSProbes),
 		},
 	)
 

--- a/pkg/network/http/model.go
+++ b/pkg/network/http/model.go
@@ -40,7 +40,7 @@ func (tx *httpTX) Path(buffer []byte) []byte {
 	b := *(*[HTTPBufferSize]byte)(unsafe.Pointer(&tx.request_fragment))
 
 	// b might contain a null terminator in the middle
-	bLen := strlen(b)
+	bLen := strlen(b[:])
 
 	var i, j int
 	for i = 0; i < bLen && b[i] != ' '; i++ {

--- a/pkg/network/http/model.go
+++ b/pkg/network/http/model.go
@@ -39,16 +39,19 @@ func (k *httpBatchKey) Prepare(n httpNotification) {
 func (tx *httpTX) Path(buffer []byte) []byte {
 	b := *(*[HTTPBufferSize]byte)(unsafe.Pointer(&tx.request_fragment))
 
+	// b might contain a null terminator in the middle
+	bLen := strlen(b)
+
 	var i, j int
-	for i = 0; i < len(b) && b[i] != ' '; i++ {
+	for i = 0; i < bLen && b[i] != ' '; i++ {
 	}
 
 	i++
 
-	for j = i; j < len(b) && b[j] != ' ' && b[j] != '?'; j++ {
+	for j = i; j < bLen && b[j] != ' ' && b[j] != '?'; j++ {
 	}
 
-	if i < j && j <= len(b) {
+	if i < j && j <= bLen {
 		n := copy(buffer, b[i:j])
 		return buffer[:n]
 	}
@@ -98,4 +101,14 @@ func nsTimestampToFloat(ns uint64) float64 {
 		shift++
 	}
 	return float64(ns << shift)
+}
+
+// strlen returns the length of a null-terminated string
+func strlen(str []byte) int {
+	for i := 0; i < len(str); i++ {
+		if str[i] == 0 {
+			return i
+		}
+	}
+	return len(str)
 }

--- a/pkg/network/http/model_test.go
+++ b/pkg/network/http/model_test.go
@@ -20,6 +20,21 @@ func TestPath(t *testing.T) {
 	assert.Equal(t, "/foo/bar", string(tx.Path(b)))
 }
 
+func TestPathHandlesNullTerminator(t *testing.T) {
+	tx := httpTX{
+		request_fragment: requestFragment(
+			// This probably isn't a valid HTTP request
+			// (since it's missing a version before the end),
+			// but if the null byte isn't handled
+			// then the path becomes "/foo/\x00bar"
+			[]byte("GET /foo/\x00bar?var1=value HTTP/1.1\nHost: example.com\nUser-Agent: example-browser/1.0"),
+		),
+	}
+
+	b := make([]byte, HTTPBufferSize)
+	assert.Equal(t, "/foo/", string(tx.Path(b)))
+}
+
 func TestLatency(t *testing.T) {
 	tx := httpTX{
 		response_last_seen: 2e6,

--- a/pkg/network/http/shared_libraries.go
+++ b/pkg/network/http/shared_libraries.go
@@ -200,13 +200,6 @@ func (w *soWatcher) getSharedLibraries() []so.Library {
 	// libraries will include all host-resolved library paths mapped into memory
 	libraries := so.FindProc(w.procRoot, w.all)
 
-	// Resolve all symlinks in library host paths
-	for i := range libraries {
-		if withoutSymLinks, err := filepath.EvalSymlinks(libraries[i].HostPath); err == nil {
-			libraries[i].HostPath = withoutSymLinks
-		}
-	}
-
 	// TODO: should we ensure all entries are unique in the `so` package instead?
 	seen := make(map[string]struct{}, len(libraries))
 	i := 0

--- a/pkg/network/http/shared_libraries.go
+++ b/pkg/network/http/shared_libraries.go
@@ -200,6 +200,13 @@ func (w *soWatcher) getSharedLibraries() []so.Library {
 	// libraries will include all host-resolved library paths mapped into memory
 	libraries := so.FindProc(w.procRoot, w.all)
 
+	// Resolve all symlinks in library host paths
+	for i := range libraries {
+		if withoutSymLinks, err := filepath.EvalSymlinks(libraries[i].HostPath); err == nil {
+			libraries[i].HostPath = withoutSymLinks
+		}
+	}
+
 	// TODO: should we ensure all entries are unique in the `so` package instead?
 	seen := make(map[string]struct{}, len(libraries))
 	i := 0


### PR DESCRIPTION
### What does this PR do?

This PR adds basic support for tracing HTTPS (<= HTTP/1.1) transactions in the system-probe for applications that utilize a subset of the APIs available in [GnuTLS](https://www.gnutls.org/). To do this, it mirrors much of the implementation of HTTPS transaction tracing for OpenSSL:
- It adds a series of uprobes for library functions in GnuTLS that closely mirror many of the traced library functions in OpenSSL:
  - [`gnutls_transport_set_int2`](https://www.gnutls.org/manual/html_node/Core-TLS-API.html#gnutls_005ftransport_005fset_005fint2), [`gnutls_transport_set_ptr`](https://www.gnutls.org/manual/html_node/Core-TLS-API.html#gnutls_005ftransport_005fset_005fptr), and [`gnutls_transport_set_ptr2`](https://www.gnutls.org/manual/html_node/Core-TLS-API.html#gnutls_005ftransport_005fset_005fptr2) ([`gnutls_transport_set_int`](https://www.gnutls.org/manual/html_node/Core-TLS-API.html#gnutls_005ftransport_005fset_005fint) too, but it is implemented as a macro that just calls [`gnutls_transport_set_int2`](https://www.gnutls.org/manual/html_node/Core-TLS-API.html#gnutls_005ftransport_005fset_005fint2) in the library, so it doesn't need its own uprobe) correspond to `SSL_set_fd`, in that they are used to associate the `gnutls_session_t*` pointer with the socket file descriptor and combined PID/TGID (in some cases; see *Limitations*).
  - [`gnutls_record_recv`](https://www.gnutls.org/manual/html_node/Core-TLS-API.html#index-gnutls_005frecord_005frecv-1) (and its uretprobe) are similar to `SSL_read`, in that they are used to intercept/parse the plaintext HTTP response data as it goes back to the application.
    - As with `SSL_read`, the uprobe is used to have access to the arguments in the uretprobe; the GnuTLS implementation even shares the same EBF map to do this.
  - [`gnutls_record_send`](https://www.gnutls.org/manual/html_node/Core-TLS-API.html#gnutls_005frecord_005fsend-1) is similar to `SSL_write`, in that it is used to intercept/parse the plaintext HTTP request data as it gets sent from the application.
  - [`gnutls_bye`](https://www.gnutls.org/manual/html_node/Core-TLS-API.html#index-gnutls_005fbye-1) is similar to `SSL_shutdown`, in that it used to flush any ongoing HTTP transactions as the socket is closed.
- It adds support to the `openSSLProgram` struct in Go to load in the uprobes at runtime and attach them to functions in shared libraries with the name `libgnutls.so`

The implementation in this PR is able to successfully trace HTTPS requests made from [wget](https://www.gnu.org/software/wget/) when it is compiled/linked against GnuTLS.

#### Limitations

There are a couple limitations of this implementation, however. The first one is that there are additional API functions for sending and receiving data that this PR doesn't attach uprobes to (such as `gnutls_record_send2`, `gnutls_record_send_early_data`, `gnutls_record_send_range`, `gnutls_record_recv_early_data`, or `gnutls_record_recv_seq`). As a result, it's possible that programs that use these alternate API functions won't have their HTTPS requests traced successfully.

The second and more disappointing limitation is that there is a completely different, more advanced API for sending and receiving data on a TLS connection **that doesn't ever see the socket file descriptor cross a library function boundary** (in the parameters/return value). As a result, programs that use this API can't be reliably traced with this approach. Unfortunately, one such program is [curl](https://curl.se/), which, when compiled/linked against GnuTLS, uses this advanced API.

#### Workarounds needed / issues encountered

<details>
<summary>This part is pretty long 😅 ; click to expand</summary>

##### Probes getting "double-attached"

When writing and testing my initial implementation, one thing I noticed is that all of my debug log messages were showing up twice, and any side effects were being run twice. It turns out that this was due to the library that `wget` was linked against being resolved to a symlink on my system (at `/lib/x86_64-linux-gnu/libgnutls.so.30`, which points to `/lib/x86_64-linux-gnu/libgnutls.so.30.27.0`). It seems like system-probe was attaching uprobes to both the original file and the symlink, which essentially caused them to be run twice. This was fixed in #9436.

##### Probes getting attached to the wrong function

Another strange behavior I noticed when testing was that [a minimal, sample program from the GnuTLS docs](https://gnutls.org/manual/html_node/Client-example-with-X_002e509-certificate-support.html) was showing up in the debug logs as calling functions I knew it didn't call. Specifically, it calls the `gnutls_transport_set_int` "function" (actually just a macro that [internally calls `gnutls_transport_set_int2`](https://github.com/gnutls/gnutls/blob/9571f3a9e202ca2eeb369bb320bb93b638bb718c/lib/includes/gnutls/gnutls.h.in#L2408). However, the debug logs were indicating that the uprobes for `gnutls_transport_set_int2`, `gnutls_transport_set_ptr`, and `gnutls_transport_set_ptr2` were all getting called each time.

Printing out the `/sys/kernel/debug/tracing/uprobe_events` file and listing the `/sys/kernel/debug/tracing/events/uprobes     ` directory ultimately pointed to what the problem was:

```sh
$ sudo ls -la /sys/kernel/debug/tracing/events/uprobes                                       
...
drwxr-xr-x   2 root root 0 Oct  1 00:44 p_gnutls_bye__usr_lib_x_3525
drwxr-xr-x   2 root root 0 Oct  1 00:44 p_gnutls_rec__usr_lib_x_3525
drwxr-xr-x   2 root root 0 Oct  1 00:40 p_gnutls_tra__usr_lib_x_3525
drwxr-xr-x   2 root root 0 Oct  1 00:44 r_gnutls_rec__usr_lib_x_3525
$ sudo cat /sys/kernel/debug/tracing/uprobe_events
...
p:uprobes/p_gnutls_tra__usr_lib_x_3525 /usr/lib/x86_64-linux-gnu/libgnutls.so.30.27.0:0x0000000000030f40
p:uprobes/p_gnutls_tra__usr_lib_x_3525 /usr/lib/x86_64-linux-gnu/libgnutls.so.30.27.0:0x0000000000030f00
p:uprobes/p_gnutls_tra__usr_lib_x_3525 /usr/lib/x86_64-linux-gnu/libgnutls.so.30.27.0:0x0000000000030f20
p:uprobes/p_gnutls_rec__usr_lib_x_3525 /usr/lib/x86_64-linux-gnu/libgnutls.so.30.27.0:0x0000000000034c10
r:uprobes/r_gnutls_rec__usr_lib_x_3525 /usr/lib/x86_64-linux-gnu/libgnutls.so.30.27.0:0x0000000000034c10
p:uprobes/p_gnutls_rec__usr_lib_x_3525 /usr/lib/x86_64-linux-gnu/libgnutls.so.30.27.0:0x00000000000348e0
p:uprobes/p_gnutls_bye__usr_lib_x86_64_linux_gnu_libgnutls_so_30_27_0_3525 /usr/lib/x86_64-linux-gnu/libgnutls.so.30.27.0:0x0000000000034140
```

I'm not sure exactly what the significance of the `uprobe_events` file is, but it shows the expected number of probes (for `gnutls_transport_set_int2`, `gnutls_transport_set_ptr`, `gnutls_transport_set_ptr2`, `gnutls_record_recv` (and its uretprobe), `gnutls_record_send`, and `gnutls_bye`), albeit with truncated names. However, in the `uprobes` directory, there were only entries for 4 of these. It turns out that the truncated names was the cause of/a side effect of the problem: at some point in attaching the uprobe, the names of the uprobes are shortened to always be less than 64 characters long. However, the shortening algorithm that is used seems to try to intelligently shorten from multiple "segments" of the name (i.e. the "raw" name of `p_gnutls_record_send_/usr/lib/x86_64-linux-gnu/libgnutls.so.30.27.0_3525` (or something like that) gets shortened to `p_gnutls_rec__usr_lib_x_3525`). This wouldn't be a problem, except for the fact that it causes multiple similarly-named functions (in this case, `gnutls_transport_set_int2`, `gnutls_transport_set_ptr`, and `gnutls_transport_set_ptr2`, plus `gnutls_record_recv` and `gnutls_record_send`) to ultimately get their uprobe names shortened to the same strings.

Again, I'm not very well-versed in exactly where this breaks things, but the end result is that all of the probes for one of these "groups" of similarly-named functions get attached to only one of the functions (and for the rest of their intended targets to not get attached to at all). This explains why my sample program that calls `gnutls_transport_set_int` (and through it, `gnutls_transport_set_int2`) was showing up in the debug logs as running the uprobe for `gnutls_transport_set_int2`, `gnutls_transport_set_ptr`, and `gnutls_transport_set_ptr2`: all of those probes attached to `gnutls_transport_set_int2` as a result of the name shortening.

Fixing this involved not using the library path as part of the uprobe names (since `/usr/lib/x86_64-linux-gnu/libgnutls.so.30.27.0` is a pretty big part of `p_gnutls_record_send_/usr/lib/x86_64-linux-gnu/libgnutls.so.30.27.0_3525`) and instead use a short hash of the library path. This was implemented in #9420, which fixes this problem (see the `getUID` function).

##### Existing code was giving an old, invalid `struct sock*` pointer for a given file descriptor & combined PID/TGID

The stale `struct sock*` pointer seemed to be caused by the sock not getting cleaned up via `tcp_close` due to the type of the socket used; see NETAGENT-210 for more details.

##### `conn_tuple_t*` values produced from two different code paths were different

The two code paths in question were ones that derived `conn_tuple_t*` from different contexts: one based on `struct sock*` and one based on `struct __sk_buff*` (in the socket filter programs).

This was fixed by always setting the two fields (`.netns` and `.pid`) that could not be sourced in the `struct __sk_buff*` code path to 0 in the `struct sock*` code path. This ensured that the values produced by both are the same, and as I understand these fields aren't relied upon in the system-probe/agent code to trace requests (so effectively removing them should be fine).
  
</details>

### Motivation

Enhances the functionality already present in the system-probe by expanding the contexts it can trace HTTPS transactions in.

GnuTLS support is present in a few different programs; these are the most significant-seeming non-GUI programs I found that support it:
- [wget](https://www.gnu.org/software/wget/) - I'm not actually sure if this (or curl) is compiled/linked against GnuTLS in any common Linux distribution, but each project does support it as an alternative over OpenSSL.
- [curl](https://curl.se/) - Unfortunately, the implementation in this PR doesn't work to trace HTTPS request in curl with GnuTLS; see *Limitations*
- [Apache server/httpd](https://httpd.apache.org/) (via [mod_gnutls](https://mod.gnutls.org/)) - I didn't test whether the implementation in this PR will work with this, but my hunch is that it will *not*, since mod_gnutls, much like curl, utilizes the more advanced API that doesn't involve calling any library functions with the socket file descriptor.

### Describe how to test your changes

To test these changes, I used the agent-dev-box (or an equivalent Ubuntu 20.04 machine) with the system-probe being built and invoked on its own (without the rest of the agent). Other than the system-probe (which I compiled using `inv -e system-probe.build`), I also compiled `wget` from source and configured it to use GnuTLS.

To do this, I first made sure `libgnutls28-dev` was installed via apt. Then, I downloaded the wget source from https://ftp.gnu.org/gnu/wget/wget-latest.tar.gz to my machine and unzipped it. In the unzipped directory, I ran the following commands:

```sh
./configure --with-gnutls --prefix="$(pwd)/install"
make
make install
```

This should result in the wget binary residing in `./install/bin/wget`, which should be configured to use GnuTLS. An easy way to make sure is to run `ldd` on it and look for `libgnutls`:

```sh
ldd ./install/bin/wget | grep "libgnutls.so"
```

Once this is done, it's ready to test against the system-probe. I ran system-probe with the following configuration at `/etc/datadog-agent/system-probe.yaml`:

```yaml
system_probe_config:
  enabled: true
network_config:
  enabled: true
  enable_http_monitoring: true
  enable_https_monitoring: true
```

Then, I ran it using:

```sh
sudo /path/to/datadog-agent-repo/bin/system-probe/system-probe -- --config=/etc/datadog-agent/system-probe.yaml
```

Next, in another terminal,  I ran:

```
/path/to/wget-compiled-against-gnutls -O- --https-only "https://httpbin.org/status/200"
```

Finally, running the following command should have an element appear in the array that gives details of the HTTP request that the previous command sent:

```
sudo curl -s --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/debug/http_monitoring | jq
```

#### Testing runtime-compiled program

It also works when using the runtime-compiled EBPF programs. To test that, use instead the following config at `/etc/datadog-agent/system-probe.yaml`:

```yaml
system_probe_config:
  enabled: true
  enable_runtime_compiler: true
  allow_precompiled_fallback: false
network_config:
  enabled: true
  enable_http_monitoring: true
  enable_https_monitoring: true
```

Then, re-run the rest of the steps and it should work just the same.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.

Note: Adding GitHub labels is only possible for contributors with write access.
