### PR TITLE
[networks] Prepend paths with host file system mounting point

### DIFF
--- a/pkg/network/http/shared_libraries.go
+++ b/pkg/network/http/shared_libraries.go
@@ -148,20 +148,18 @@ func (w *soWatcher) sync(libraries []so.Library) {
 	old := w.registered
 	w.registered = make(map[string]func(string) error)
 
-OuterLoop:
 	for _, lib := range libraries {
+		if callback, ok := old[path]; ok {
+			w.registered[path] = callback
+			delete(old, path)
+			continue
+		}
+
 		for _, r := range w.rules {
 			path := lib.HostPath
-
-			if callback, ok := old[path]; ok {
-				w.registered[path] = callback
-				delete(old, path)
-				continue OuterLoop
-			}
-
 			if r.re.MatchString(path) {
 				w.register(path, r)
-				continue OuterLoop
+				break
 			}
 		}
 	}

--- a/pkg/network/http/shared_libraries.go
+++ b/pkg/network/http/shared_libraries.go
@@ -68,6 +68,7 @@ func newSOWatcher(procRoot string, perfHandler *ddebpf.PerfHandler, rules ...soR
 	all := regexp.MustCompile(fmt.Sprintf("(%s)", strings.Join(allFilters, "|")))
 	return &soWatcher{
 		procRoot:   procRoot,
+		hostMount:  os.Getenv("HOST_FS"),
 		all:        all,
 		rules:      rules,
 		loadEvents: perfHandler,
@@ -77,7 +78,7 @@ func newSOWatcher(procRoot string, perfHandler *ddebpf.PerfHandler, rules ...soR
 // Start consuming shared-library events
 func (w *soWatcher) Start() {
 	seen := make(map[seenKey]struct{})
-	sharedLibraries := getSharedLibraries(w.procRoot, w.all)
+	sharedLibraries := w.getSharedLibraries()
 	w.sync(sharedLibraries)
 	go func() {
 		ticker := time.NewTicker(soSyncInterval)
@@ -88,7 +89,7 @@ func (w *soWatcher) Start() {
 			select {
 			case <-ticker.C:
 				seen = make(map[seenKey]struct{})
-				sharedLibraries := getSharedLibraries(w.procRoot, w.all)
+				sharedLibraries := getSharedLibraries()
 				w.sync(sharedLibraries)
 			case event, ok := <-w.loadEvents.DataChannel:
 				if !ok {
@@ -125,9 +126,7 @@ func (w *soWatcher) Start() {
 							libPath = hostPath
 						}
 
-						// follow symlink
-						libPath = followSymlink(libPath)
-
+						libPath = canonicalizePath(libPath)
 						if _, registered := w.registered[libPath]; registered {
 							break
 						}
@@ -188,45 +187,44 @@ func (w *soWatcher) register(libPath string, r soRule) {
 	w.registered[libPath] = r.unregisterCB
 }
 
-func getSharedLibraries(procRoot string, filter *regexp.Regexp) []so.Library {
+func (w *soWatcher) canonicalizePath(path string) {
+	if w.hostMount != "" {
+		path = filepath.Join(w.hostMount, path)
+	}
+
+	return followSymlink(path)
+}
+
+func (w *soWatcher) getSharedLibraries() []so.Library {
 	// libraries will include all host-resolved library paths mapped into memory
-	libraries := so.FindProc(procRoot, filter)
+	libraries := so.FindProc(w.procRoot, w.all)
 
 	// TODO: should we ensure all entries are unique in the `so` package instead?
 	seen := make(map[string]struct{}, len(libraries))
 	i := 0
 	for _, lib := range libraries {
-		_, ok := seen[lib.HostPath]
-		if ok {
+		originalPath := lib.HostPath
+		if _, ok := seen[originalPath]; ok {
 			continue
 		}
-		seen[lib.HostPath] = struct{}{}
+		seen[originalPath] = struct{}{}
 
 		// this ensures that all symlinks are resolved only once
-		resolved := followSymlink(lib.HostPath)
-		if resolved != lib.HostPath {
-			if _, ok := seen[resolved]; ok {
+		canonicalPath := w.canonicalizePath(originalPath)
+		if canonicalPath != originalPath {
+			if _, ok := seen[canonicalPath]; ok {
 				continue
 			} else {
-				seen[resolved] = struct{}{}
-				lib.HostPath = resolved
+				seen[canonicalPath] = struct{}{}
+				lib.HostPath = canonicalPath
 			}
 		}
 
 		libraries[i] = lib
 		i++
 	}
-	libraries = libraries[0:i]
 
-	// prepend everything with the HOST_FS, which designates where the underlying
-	// host file system is mounted. This is intended for internal testing only.
-	if hostFS := os.Getenv("HOST_FS"); hostFS != "" {
-		for i, lib := range libraries {
-			libraries[i].HostPath = filepath.Join(hostFS, lib.HostPath)
-		}
-	}
-
-	return libraries
+	return libraries[0:i]
 }
 
 func followSymlink(path string) string {


### PR DESCRIPTION
### What does this PR do?

Prepends shared library paths with the host file system mounting point in case system-probe is running inside a container.

### Motivation

This is necessary when system-probe runs inside a container, but needs access to an external `.so` file.
In that case the underlying host file system must be mounted into system-probe container and configured via the `HOST_FS` environment variable.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
