### PR TITLE
Fix stale informer

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -86,45 +86,29 @@ func (c *OrchestratorInstance) parse(data []byte) error {
 // OrchestratorCheck wraps the config and the informers needed to run the check
 type OrchestratorCheck struct {
 	core.CheckBase
-	orchestratorConfig               *orchcfg.OrchestratorConfig
-	instance                         *OrchestratorInstance
-	stopCh                           chan struct{}
-	clusterID                        string
-	groupID                          int32
-	isCLCRunner                      bool
-	apiClient                        *apiserver.APIClient
-	unassignedPodLister              corelisters.PodLister
-	unassignedPodListerSync          cache.InformerSynced
-	deployLister                     appslisters.DeploymentLister
-	deployListerSync                 cache.InformerSynced
-	rsLister                         appslisters.ReplicaSetLister
-	rsListerSync                     cache.InformerSynced
-	serviceLister                    corelisters.ServiceLister
-	serviceListerSync                cache.InformerSynced
-	nodesLister                      corelisters.NodeLister
-	nodesListerSync                  cache.InformerSynced
-	jobsLister                       batchlisters.JobLister
-	jobsListerSync                   cache.InformerSynced
-	cronJobsLister                   batchlistersBeta1.CronJobLister
-	cronJobsListerSync               cache.InformerSynced
-	daemonSetsLister                 appslisters.DaemonSetLister
-	daemonSetsListerSync             cache.InformerSynced
-	statefulSetsLister               appslisters.StatefulSetLister
-	statefulSetsListerSync           cache.InformerSynced
-	persistentVolumesLister          corelisters.PersistentVolumeLister
-	persistentVolumesListerSync      cache.InformerSynced
-	persistentVolumeClaimsLister     corelisters.PersistentVolumeClaimLister
-	persistentVolumeClaimsListerSync cache.InformerSynced
-	rolesLister                      rbaclisters.RoleLister
-	rolesListerSync                  cache.InformerSynced
-	roleBindingsLister               rbaclisters.RoleBindingLister
-	roleBindingsListerSync           cache.InformerSynced
-	clusterRolesLister               rbaclisters.ClusterRoleLister
-	clusterRolesListerSync           cache.InformerSynced
-	clusterRoleBindingsLister        rbaclisters.ClusterRoleBindingLister
-	clusterRoleBindingsListerSync    cache.InformerSynced
-	serviceAccountsLister            corelisters.ServiceAccountLister
-	serviceAccountsListerSync        cache.InformerSynced
+	orchestratorConfig           *orchcfg.OrchestratorConfig
+	instance                     *OrchestratorInstance
+	stopCh                       chan struct{}
+	clusterID                    string
+	groupID                      int32
+	isCLCRunner                  bool
+	apiClient                    *apiserver.APIClient
+	unassignedPodLister          corelisters.PodLister
+	deployLister                 appslisters.DeploymentLister
+	rsLister                     appslisters.ReplicaSetLister
+	serviceLister                corelisters.ServiceLister
+	nodesLister                  corelisters.NodeLister
+	jobsLister                   batchlisters.JobLister
+	cronJobsLister               batchlistersBeta1.CronJobLister
+	daemonSetsLister             appslisters.DaemonSetLister
+	statefulSetsLister           appslisters.StatefulSetLister
+	persistentVolumesLister      corelisters.PersistentVolumeLister
+	persistentVolumeClaimsLister corelisters.PersistentVolumeClaimLister
+	rolesLister                  rbaclisters.RoleLister
+	roleBindingsLister           rbaclisters.RoleBindingLister
+	clusterRolesLister           rbaclisters.ClusterRoleLister
+	clusterRoleBindingsLister    rbaclisters.ClusterRoleBindingLister
+	serviceAccountsLister        corelisters.ServiceAccountLister
 }
 
 func newOrchestratorCheck(base core.CheckBase, instance *OrchestratorInstance) *OrchestratorCheck {
@@ -214,82 +198,66 @@ func (o *OrchestratorCheck) Configure(config, initConfig integration.Data, sourc
 		case "pods":
 			podInformer := apiCl.UnassignedPodInformerFactory.Core().V1().Pods()
 			o.unassignedPodLister = podInformer.Lister()
-			o.unassignedPodListerSync = podInformer.Informer().HasSynced
 			informersToSync[apiserver.InformerName(orchestrator.K8sPod.String())] = podInformer.Informer()
 		case "deployments":
 			deployInformer := apiCl.InformerFactory.Apps().V1().Deployments()
 			o.deployLister = deployInformer.Lister()
-			o.deployListerSync = deployInformer.Informer().HasSynced
 			informersToSync[apiserver.InformerName(orchestrator.K8sDeployment.String())] = deployInformer.Informer()
 		case "replicasets":
 			rsInformer := apiCl.InformerFactory.Apps().V1().ReplicaSets()
 			o.rsLister = rsInformer.Lister()
-			o.rsListerSync = rsInformer.Informer().HasSynced
 			informersToSync[apiserver.InformerName(orchestrator.K8sReplicaSet.String())] = rsInformer.Informer()
 		case "services":
 			serviceInformer := apiCl.InformerFactory.Core().V1().Services()
 			o.serviceLister = serviceInformer.Lister()
-			o.serviceListerSync = serviceInformer.Informer().HasSynced
 			informersToSync[apiserver.InformerName(orchestrator.K8sService.String())] = serviceInformer.Informer()
 		case "nodes":
 			nodesInformer := apiCl.InformerFactory.Core().V1().Nodes()
 			o.nodesLister = nodesInformer.Lister()
-			o.nodesListerSync = nodesInformer.Informer().HasSynced
 			informersToSync[apiserver.InformerName(orchestrator.K8sNode.String())] = nodesInformer.Informer()
 		case "jobs":
 			jobsInformer := apiCl.InformerFactory.Batch().V1().Jobs()
 			o.jobsLister = jobsInformer.Lister()
-			o.jobsListerSync = jobsInformer.Informer().HasSynced
 			informersToSync[apiserver.InformerName(orchestrator.K8sJob.String())] = jobsInformer.Informer()
 		case "cronjobs":
 			cronJobsInformer := apiCl.InformerFactory.Batch().V1beta1().CronJobs()
 			o.cronJobsLister = cronJobsInformer.Lister()
-			o.cronJobsListerSync = cronJobsInformer.Informer().HasSynced
 			informersToSync[apiserver.InformerName(orchestrator.K8sCronJob.String())] = cronJobsInformer.Informer()
 		case "daemonsets":
 			daemonSetsInformer := apiCl.InformerFactory.Apps().V1().DaemonSets()
 			o.daemonSetsLister = daemonSetsInformer.Lister()
-			o.daemonSetsListerSync = daemonSetsInformer.Informer().HasSynced
 			informersToSync[apiserver.InformerName(orchestrator.K8sDaemonSet.String())] = daemonSetsInformer.Informer()
 		case "statefulsets":
 			statefulSetsInformer := apiCl.InformerFactory.Apps().V1().StatefulSets()
 			o.statefulSetsLister = statefulSetsInformer.Lister()
-			o.statefulSetsListerSync = statefulSetsInformer.Informer().HasSynced
 			informersToSync[apiserver.InformerName(orchestrator.K8sStatefulSet.String())] = statefulSetsInformer.Informer()
 		case "persistentvolumes":
 			persistentVolumesInformer := apiCl.InformerFactory.Core().V1().PersistentVolumes()
 			o.persistentVolumesLister = persistentVolumesInformer.Lister()
-			o.persistentVolumesListerSync = persistentVolumesInformer.Informer().HasSynced
 			informersToSync[apiserver.InformerName(orchestrator.K8sPersistentVolume.String())] = persistentVolumesInformer.Informer()
 		case "persistentvolumeclaims":
 			persistentVolumeClaimsInformer := apiCl.InformerFactory.Core().V1().PersistentVolumeClaims()
 			o.persistentVolumeClaimsLister = persistentVolumeClaimsInformer.Lister()
-			o.persistentVolumeClaimsListerSync = persistentVolumeClaimsInformer.Informer().HasSynced
 			informersToSync[apiserver.InformerName(orchestrator.K8sPersistentVolumeClaim.String())] = persistentVolumeClaimsInformer.Informer()
 		case "roles":
 			rolesInformer := apiCl.InformerFactory.Rbac().V1().Roles()
 			o.rolesLister = rolesInformer.Lister()
-			o.rolesListerSync = rolesInformer.Informer().HasSynced
 			informersToSync[apiserver.InformerName(orchestrator.K8sRole.String())] = rolesInformer.Informer()
 		case "rolebindings":
 			roleBindingsInformer := apiCl.InformerFactory.Rbac().V1().RoleBindings()
 			o.roleBindingsLister = roleBindingsInformer.Lister()
-			o.roleBindingsListerSync = roleBindingsInformer.Informer().HasSynced
 			informersToSync[apiserver.InformerName(orchestrator.K8sRoleBinding.String())] = roleBindingsInformer.Informer()
 		case "clusterroles":
 			clusterRolesInformer := apiCl.InformerFactory.Rbac().V1().ClusterRoles()
 			o.clusterRolesLister = clusterRolesInformer.Lister()
-			o.clusterRolesListerSync = clusterRolesInformer.Informer().HasSynced
 			informersToSync[apiserver.InformerName(orchestrator.K8sClusterRole.String())] = clusterRolesInformer.Informer()
 		case "clusterrolebindings":
 			clusterRoleBindingsInformer := apiCl.InformerFactory.Rbac().V1().ClusterRoleBindings()
 			o.clusterRoleBindingsLister = clusterRoleBindingsInformer.Lister()
-			o.clusterRoleBindingsListerSync = clusterRoleBindingsInformer.Informer().HasSynced
 			informersToSync[apiserver.InformerName(orchestrator.K8sClusterRoleBinding.String())] = clusterRoleBindingsInformer.Informer()
 		case "serviceaccounts":
 			serviceAccountsInformer := apiCl.InformerFactory.Core().V1().ServiceAccounts()
 			o.serviceAccountsLister = serviceAccountsInformer.Lister()
-			o.serviceAccountsListerSync = serviceAccountsInformer.Informer().HasSynced
 			informersToSync[apiserver.InformerName(orchestrator.K8sServiceAccount.String())] = serviceAccountsInformer.Informer()
 		default:
 			_ = o.Warnf("Unsupported collector: %s", v)

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -264,6 +264,9 @@ func (o *OrchestratorCheck) Configure(config, initConfig integration.Data, sourc
 		}
 	}
 
+	// we run each enabled informer individually as starting them through the factory
+	// would prevent us to restarting them again if the check is unscheduled/rescheduled
+	// see https://github.com/kubernetes/client-go/blob/3511ef41b1fbe1152ef5cab2c0b950dfd607eea7/informers/factory.go#L64-L66
 	for _, informer := range informersToSync {
 		go informer.Run(o.stopCh)
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -264,8 +264,9 @@ func (o *OrchestratorCheck) Configure(config, initConfig integration.Data, sourc
 		}
 	}
 
-	apiCl.UnassignedPodInformerFactory.Start(o.stopCh)
-	apiCl.InformerFactory.Start(o.stopCh)
+	for _, informer := range informersToSync {
+		go informer.Run(o.stopCh)
+	}
 
 	return apiserver.SyncInformers(informersToSync)
 }

--- a/pkg/util/kubernetes/apiserver/util.go
+++ b/pkg/util/kubernetes/apiserver/util.go
@@ -38,7 +38,7 @@ func SyncInformers(informers map[InformerName]cache.SharedInformer) error {
 			if !cache.WaitForCacheSync(ctx.Done(), informers[name].HasSynced) {
 				return fmt.Errorf("couldn't sync informer %s in %v", name, time.Now().Sub(start))
 			}
-			log.Debugf("Sync done for informer %s in %v", name, time.Now().Sub(start))
+			log.Debugf("Sync done for informer %s in %v, last resource version: %s", name, time.Now().Sub(start), informers[name].LastSyncResourceVersion())
 			return nil
 		})
 	}

--- a/releasenotes/notes/fix-stale-informer-ae35fc499557b98f.yaml
+++ b/releasenotes/notes/fix-stale-informer-ae35fc499557b98f.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fix an issue where the orchestrator check would stop sending
+    updates when run on as a cluster-check.


### PR DESCRIPTION
### What does this PR do?

Run specified informer instead of starting them through the factory.

### Motivation

This fixes a bug where the informer would keep a stale check if the orchestrator check using a specific informer would be scheduled/unscheduled/rescheduled on the same CLC worker because the informer factory would not reset the state that the informer was already started:

https://github.com/kubernetes/client-go/blob/3511ef41b1fbe1152ef5cab2c0b950dfd607eea7/informers/factory.go#L64-L66

https://github.com/kubernetes/client-go/blob/3511ef41b1fbe1152ef5cab2c0b950dfd607eea7/informers/factory.go#L133-L134

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

To reproduce it you would need to rebalance the orchestrator checks among worker until the orchestator check is scheduled/unscheduled/rescheduled on the same worker.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
