### PR TITLE
[AD] Do not re-create existing container services

### DIFF
--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -288,7 +288,10 @@ func (l *KubeletListener) createContainerService(pod workloadmeta.KubernetesPod,
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	if old, found := l.services[entity]; found {
+	svcID := buildSvcID(container.GetID())
+	podSvcID := buildSvcID(pod.GetID())
+
+	if old, found := l.services[svcID]; found {
 		if kubeletSvcEqual(old, svc) {
 			log.Tracef("Received a duplicated kubelet service '%s'", svc.entity)
 			return
@@ -297,9 +300,6 @@ func (l *KubeletListener) createContainerService(pod workloadmeta.KubernetesPod,
 		log.Tracef("Kubelet service '%s' has been updated, removing the old one", svc.entity)
 		l.delService <- old
 	}
-
-	svcID := buildSvcID(container.GetID())
-	podSvcID := buildSvcID(pod.GetID())
 
 	l.services[svcID] = svc
 	l.podContainers[podSvcID] = append(l.podContainers[podSvcID], svcID)


### PR DESCRIPTION
### What does this PR do?

This was a regression introduced with the workloadmeta changes. The
previously existing check for an existing container service was not
effective since it was checking for services with an ID in a different
format than the one that's used now. This fixes the check and adds a new
unit test to guard against such a regression.

### Describe how to test your changes

This can be checked on any k8s cluster running for some time, with several containers that can be autodiscovered (staging or production clusters are easier due to more workloads than a local one, and the non-deterministic nature of how events get generated). An `agent status` should not show any duplicated checks scheduled for the same container ID. This is a quick and easy way:

```
$ agent status | grep "Configuration Source: kubelet" | uniq -c
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
