### PR TITLE
Fix log formatting

### DIFF
--- a/pkg/workloadmeta/store.go
+++ b/pkg/workloadmeta/store.go
@@ -254,7 +254,7 @@ func (s *Store) startCandidates(ctx context.Context) {
 			log.Infof("workloadmeta collector %q started successfully", id)
 			s.collectors[id] = c
 		} else {
-			log.Info("workloadmeta collector %q could not start. error: %s", id, err)
+			log.Infof("workloadmeta collector %q could not start. error: %s", id, err)
 		}
 
 		// Remove non-retriable and successfully started collectors


### PR DESCRIPTION
### What does this PR do?

Fix log

### Motivation

The agent produces logs where placeholder are not replaced like:

```
2021-10-11 12:39:09 UTC | CORE | INFO | (pkg/workloadmeta/store.go:257 in startCandidates) | workloadmeta collector %q could not start. error: %s kubelet the Agent is not running in Kubernetes
```

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
