### PR TITLE
[CSPM] add `expire_at` in events to the backend

### DIFF
--- a/pkg/compliance/checks/check.go
+++ b/pkg/compliance/checks/check.go
@@ -141,6 +141,7 @@ func (c *complianceCheck) Run() error {
 			ResourceType:     quadID.ResourceType,
 			Result:           result,
 			Data:             data,
+			ExpireAt:         c.computeExpireAt(),
 		}
 
 		log.Debugf("%s: reporting [%s] [%s] [%s]", c.ruleID, e.Result, e.ResourceID, e.ResourceType)
@@ -152,6 +153,16 @@ func (c *complianceCheck) Run() error {
 	}
 
 	return err
+}
+
+// ExpireAtIntervalFactor represents the amount of intervals between a check and its expiration
+const ExpireAtIntervalFactor = 3
+
+func (c *complianceCheck) computeExpireAt() time.Time {
+	base := time.Now().Add(c.interval * ExpireAtIntervalFactor).UTC()
+	// remove sub-second precision
+	truncated := base.Truncate(1 * time.Second)
+	return truncated
 }
 
 func reportToEventData(report *compliance.Report) (event.Data, string) {

--- a/pkg/compliance/checks/check_test.go
+++ b/pkg/compliance/checks/check_test.go
@@ -8,11 +8,14 @@ package checks
 import (
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/compliance"
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
 	"github.com/DataDog/datadog-agent/pkg/compliance/mocks"
 	"github.com/DataDog/datadog-agent/pkg/version"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/mock"
 	assert "github.com/stretchr/testify/require"
 )
 
@@ -123,7 +126,10 @@ func TestCheckRun(t *testing.T) {
 			env.On("Hostname").Return(resourceID)
 			env.On("IsLeader").Return(true)
 			env.On("Reporter").Return(reporter)
-			reporter.On("Report", test.expectEvent).Maybe()
+			reporter.On("Report", mock.MatchedBy(func(e *event.Event) bool {
+				e.ExpireAt = time.Time{}
+				return cmp.Equal(e, test.expectEvent)
+			})).Maybe()
 			checkable.On("check", check).Return(test.checkReports)
 
 			err := check.Run()

--- a/pkg/compliance/event/event.go
+++ b/pkg/compliance/event/event.go
@@ -5,6 +5,8 @@
 
 package event
 
+import "time"
+
 const (
 	// Passed is used to report successful result of a rule check (condition passed)
 	Passed = "passed"
@@ -28,4 +30,5 @@ type Event struct {
 	ResourceID       string      `json:"resource_id,omitempty"`
 	Tags             []string    `json:"tags"`
 	Data             interface{} `json:"data,omitempty"`
+	ExpireAt         time.Time   `json:"expire_at,omitempty"`
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds an `expire_at` field to the CSPM event. This field is configured to be equal to 3 times the check duration (that is user configurable). This will allow the backend to have a better of stale/expired resources.

### Motivation

Backend improvement.

### Describe how to test your changes

You can manually run a check (`compliance check -f ...`) and see the value of the `expire_at` field.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
