### PR TITLE
pkg/trace/obfuscate: fix issue with literals following comments

### DIFF
--- a/pkg/trace/obfuscate/sql.go
+++ b/pkg/trace/obfuscate/sql.go
@@ -78,7 +78,9 @@ func (f *discardFilter) Filter(token, lastToken TokenKind, buffer []byte) (Token
 	// filters based on the current token; if the next token should be ignored,
 	// return the same token value (not FilteredGroupable) and nil
 	switch token {
-	case Comment, ';':
+	case Comment:
+		return Filtered, nil, nil
+	case ';':
 		return markFilteredGroupable(token), nil, nil
 	case As:
 		if !features.Has("keep_sql_alias") {

--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -274,7 +274,7 @@ func TestSQLReplaceDigits(t *testing.T) {
 			},
 			{`SELECT daily_values1529.*, LEAST((5040000 - @runtot), value1830) AS value1830,
 (@runtot := @runtot + daily_values1529.value1830) AS total
-FROM (SELECT @runtot:=0) AS n, 
+FROM (SELECT @runtot:=0) AS n,
 daily_values1529 WHERE daily_values1529.subject_id = 12345 AND daily_values1592.subject_type = 'Skippity'
 AND (daily_values1529.date BETWEEN '2018-05-09' AND '2018-06-19') HAVING value >= 0 ORDER BY date`,
 				"SELECT daily_values?.*, LEAST ( ( ? - @runtot ), value? ), ( @runtot := @runtot + daily_values?.value? ) FROM ( SELECT @runtot := ? ), daily_values? WHERE daily_values?.subject_id = ? AND daily_values?.subject_type = ? AND ( daily_values?.date BETWEEN ? AND ? ) HAVING value >= ? ORDER BY date",
@@ -340,7 +340,7 @@ GROUP BY sales1828.product_key`,
 			},
 			{`SELECT daily_values1529.*, LEAST((5040000 - @runtot), value1830) AS value1830,
 (@runtot := @runtot + daily_values1529.value1830) AS total
-FROM (SELECT @runtot:=0) AS n, 
+FROM (SELECT @runtot:=0) AS n,
 daily_values1529 WHERE daily_values1529.subject_id = 12345 AND daily_values1592.subject_type = 'Skippity'
 AND (daily_values1529.date BETWEEN '2018-05-09' AND '2018-06-19') HAVING value >= 0 ORDER BY date`,
 				"SELECT daily_values1529.*, LEAST ( ( ? - @runtot ), value1830 ), ( @runtot := @runtot + daily_values1529.value1830 ) FROM ( SELECT @runtot := ? ), daily_values1529 WHERE daily_values1529.subject_id = ? AND daily_values1592.subject_type = ? AND ( daily_values1529.date BETWEEN ? AND ? ) HAVING value >= ? ORDER BY date",
@@ -913,6 +913,10 @@ LIMIT 1
 		{
 			query:    `SELECT nspname FROM pg_class where nspname ~* '.*matchingInsensitive.*'`,
 			expected: `SELECT nspname FROM pg_class where nspname ~* ?`,
+		},
+		{
+			query:    `SELECT * FROM dbo.Items WHERE id = 1 or /*!obfuscation*/ 1 = 1`,
+			expected: `SELECT * FROM dbo.Items WHERE id = ? or ? = ?`,
 		},
 	}
 

--- a/releasenotes/notes/fix-sql-obfuscation-9d86af6ef3f3090a.yaml
+++ b/releasenotes/notes/fix-sql-obfuscation-9d86af6ef3f3090a.yaml
@@ -8,4 +8,4 @@
 ---
 fixes:
   - |
-    SQL query obfuscation doesn't drop redacted literals from the obfuscated query when they are preceded by a SQL comment.
+    APM: SQL query obfuscation doesn't drop redacted literals from the obfuscated query when they are preceded by a SQL comment.

--- a/releasenotes/notes/fix-sql-obfuscation-9d86af6ef3f3090a.yaml
+++ b/releasenotes/notes/fix-sql-obfuscation-9d86af6ef3f3090a.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    SQL query obfuscation doesn't drop redacted literals from the obfuscated query when they are preceded by a SQL comment.


### PR DESCRIPTION
### What does this PR do?

This PR fix a small issue in the obfuscator that would confuse comment removal and literal grouping, resulting in the disappearance of literals from the obfuscated query. 

### Additional Notes

The following query: `SELECT * FROM dbo.Items WHERE id = 1 or /*!obfuscation*/ 1 = 1`
Is currently obfuscated as `SELECT * FROM dbo.Items WHERE id = ? or = ?`
Instead of the correct `SELECT * FROM dbo.Items WHERE id = ? or ? = ?`

### Describe how to test your changes

A unit test was introduced.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
