### PR TITLE
Make benchmarks and default policy owned by root

### DIFF
--- a/omnibus/package-scripts/agent/postinst
+++ b/omnibus/package-scripts/agent/postinst
@@ -74,6 +74,14 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
       chmod 0440 ${CONFIG_DIR}/security-agent.yaml || true
     fi
 
+    if [ -d "$CONFIG_DIR/compliance.d" ]; then
+      chown -R root:root ${CONFIG_DIR}/compliance.d || true
+    fi
+
+    if [ -d "$CONFIG_DIR/runtime-security.d" ]; then
+      chown -R root:root ${CONFIG_DIR}/runtime-security.d || true
+    fi
+
     # Make the system-probe and security-agent binaries and eBPF programs owned by root
     chown root:root ${INSTALL_DIR}/embedded/bin/system-probe
     chown root:root ${INSTALL_DIR}/embedded/bin/security-agent


### PR DESCRIPTION
### What does this PR do?

Make the CWS default policy and CSPM benchmarks owned by root

### Motivation

Both security-agent and system-probe runs as root and should therefore not
load files not owned by root.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
