### PR TITLE
(rc) add an RC specific api_key override

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -225,6 +225,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("remote_configuration.enabled", false)
 	config.BindEnvAndSetDefault("remote_configuration.endpoint", "")
 	config.BindEnvAndSetDefault("remote_configuration.key", "")
+	config.BindEnvAndSetDefault("remote_configuration.api_key", "")
 	config.BindEnvAndSetDefault("remote_configuration.config_root", "")
 	config.BindEnvAndSetDefault("remote_configuration.director_root", "")
 	config.BindEnvAndSetDefault("remote_configuration.refresh_interval", 60) // in seconds

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -435,7 +435,11 @@ func NewService(opts Opts) (*Service, error) {
 	}
 
 	if opts.APIKey == "" {
-		opts.APIKey = config.SanitizeAPIKey(config.Datadog.GetString("api_key"))
+		apiKey := config.Datadog.GetString("api_key")
+		if config.Datadog.IsSet("remote_configuration.api_key") {
+			apiKey = config.Datadog.GetString("remote_configuration.api_key")
+		}
+		opts.APIKey = config.SanitizeAPIKey(apiKey)
 	}
 
 	if opts.RemoteConfigurationKey == "" {


### PR DESCRIPTION
### What does this PR do?

Allows the api key used by remote config to be overwritten.
 
### Motivation

In some advanced setups with multiple outputs the main `api_key` might not correspond to the key we actually want to use to pull remote configs. Realistically this only happens internally.