### PR TITLE
Lowercase cluster names from cloud providers

### DIFF
--- a/pkg/util/kubernetes/clustername/clustername.go
+++ b/pkg/util/kubernetes/clustername/clustername.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"strings"
 	"sync"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -110,8 +111,17 @@ func getClusterName(ctx context.Context, data *clusterNameData, hostname string)
 				data.clusterName = clusterName
 			}
 		}
+
+		if data.clusterName != "" {
+			if lower := strings.ToLower(data.clusterName); lower != data.clusterName {
+				log.Infof("Putting cluster name %q in lowercase, became: %q", data.clusterName, lower)
+				data.clusterName = lower
+			}
+		}
+
 		data.initDone = true
 	}
+
 	return data.clusterName
 }
 
@@ -163,4 +173,9 @@ func GetClusterID() (string, error) {
 
 	cache.Cache.Set(cacheClusterIDKey, clusterID, cache.NoExpiration)
 	return clusterID, nil
+}
+
+// setProviderCatalog should only be used for testing.
+func setProviderCatalog(catalog map[string]Provider) {
+	ProviderCatalog = catalog
 }

--- a/pkg/util/kubernetes/clustername/clustername_test.go
+++ b/pkg/util/kubernetes/clustername/clustername_test.go
@@ -57,6 +57,15 @@ func TestGetClusterName(t *testing.T) {
 		freshData = newClusterNameData()
 		assert.Equal(t, "", getClusterName(ctx, freshData, "hostname"))
 	}
+
+	mockConfig.Set("cluster_name", "")
+
+	// Test lowercase
+	wantedClustername := "foo"
+	discoveredClustername := "FoO"
+	dummyFunc := func(c context.Context) (string, error) { return discoveredClustername, nil }
+	setProviderCatalog(map[string]Provider{"dummyProvider": dummyFunc})
+	assert.Equal(t, wantedClustername, getClusterName(ctx, newClusterNameData(), "hostname"))
 }
 
 func TestGetClusterID(t *testing.T) {

--- a/releasenotes/notes/lowercase-clusternames-384ecaaece935a66.yaml
+++ b/releasenotes/notes/lowercase-clusternames-384ecaaece935a66.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Lowercase the cluster names discovered from cloud providers
+    to ease moving between different Datadog products.


### PR DESCRIPTION
### What does this PR do?

Lowercase the cluster names discovered from cloud providers to ease moving between different Datadog products.

### Motivation

Support case

### Describe how to test your changes

Can be tested on EKS, as it allows defining cluster names with uppercase letters. The agent should automatically lowercase the value of the `kube_cluster_name` tag.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
