### PR TITLE
Fixing deadlock in the metadata scheduler

### DIFF
--- a/releasenotes/notes/fix-deadlock-metadata-scheduler-17eebe008ffb6441.yaml
+++ b/releasenotes/notes/fix-deadlock-metadata-scheduler-17eebe008ffb6441.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixing deadlock when stopping the agent righ when a metadata provider is scheduled.


### PR DESCRIPTION
### What does this PR do?

When stopping the metadata scheduler we lock its main mutex and then
stop the job queues. The issue is that the job queues might call
'scheduler.IsCheckScheduled' which tries lock the main mutex again.

Deadlock order when stopping the scheduler:
1. We lock the scheduler mutex.
2. The jobQueue call 'IsCheckScheduled' trying to lock the mutex and blocking for ever.
3. The scheduler hang forever trying to stop the job queues who are
   blocked on the `IsCheckScheduled' mutex.

Adding a secondary RWLock to around 'checkToQueue' solves the issue.

### Describe how to test your changes

This deadlock is really hard to reproduce: you have to stop the agent right when a metadata provider is scheduled.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
