### PR TITLE
[HOLD, do not merge][corechecks/snmp] Add agent level tags to NDM metadata

### DIFF
--- a/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
+++ b/cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml
@@ -125,3 +125,9 @@ instances:
     ## service checks. This enables custom tags. It overrides any `hostname` tag.
     #
     use_device_id_as_hostname: "%%extra_use_device_id_as_hostname%%"
+
+    ## @param disable_global_tags - boolean - optional - default: false
+    ## DisableGlobalTags disables adding the global host tags defined via tags/DD_TAG
+    ## in the Agent config.
+    #
+    disable_global_tags: "%%extra_disable_global_tags%%"

--- a/pkg/autodiscovery/listeners/snmp.go
+++ b/pkg/autodiscovery/listeners/snmp.go
@@ -426,6 +426,8 @@ func (s *SNMPService) GetExtraConfig(key []byte) ([]byte, error) {
 		return []byte(convertToCommaSepTags(s.config.Tags)), nil
 	case "min_collection_interval":
 		return []byte(fmt.Sprintf("%d", s.config.MinCollectionInterval)), nil
+	case "disable_global_tags":
+		return []byte(strconv.FormatBool(s.config.DisableGlobalTags)), nil
 	}
 	return []byte{}, ErrNotSupported
 }

--- a/pkg/autodiscovery/listeners/snmp_test.go
+++ b/pkg/autodiscovery/listeners/snmp_test.go
@@ -158,12 +158,13 @@ func TestSNMPListenerIgnoredAdresses(t *testing.T) {
 
 func TestExtraConfig(t *testing.T) {
 	snmpConfig := snmp.Config{
-		Network:      "192.168.0.0/24",
-		Community:    "public",
-		Timeout:      5,
-		Retries:      2,
-		OidBatchSize: 10,
-		Namespace:    "my-ns",
+		Network:           "192.168.0.0/24",
+		Community:         "public",
+		Timeout:           5,
+		Retries:           2,
+		OidBatchSize:      10,
+		Namespace:         "my-ns",
+		DisableGlobalTags: true,
 	}
 
 	svc := SNMPService{
@@ -229,6 +230,10 @@ func TestExtraConfig(t *testing.T) {
 	info, err = svc.GetExtraConfig([]byte("namespace"))
 	assert.Equal(t, nil, err)
 	assert.Equal(t, "my-ns", string(info))
+
+	info, err = svc.GetExtraConfig([]byte("disable_global_tags"))
+	assert.Equal(t, nil, err)
+	assert.Equal(t, "true", string(info))
 }
 
 func TestExtraConfigExtraTags(t *testing.T) {

--- a/pkg/collector/corechecks/snmp/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config.go
@@ -577,6 +577,11 @@ func (c *CheckConfig) IsDiscovery() bool {
 	return c.Network != ""
 }
 
+// GetAgentLevelTags return agent level tags
+func (c *CheckConfig) GetAgentLevelTags() []string {
+	return coreconfig.GetConfiguredTags(false)
+}
+
 func parseScalarOids(metrics []MetricsConfig, metricTags []MetricTagConfig) []string {
 	var oids []string
 	for _, metric := range metrics {

--- a/pkg/collector/corechecks/snmp/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config.go
@@ -112,6 +112,9 @@ type InstanceConfig struct {
 	DiscoveryWorkers         int      `yaml:"discovery_workers"`
 	Workers                  int      `yaml:"workers"`
 	Namespace                string   `yaml:"namespace"`
+
+	// DisableGlobalTags disables adding the global host tags defined via tags/DD_TAG in the Agent config, default false.
+	DisableGlobalTags Boolean `yaml:"disable_global_tags"`
 }
 
 // CheckConfig holds config needed for an integration instance to run
@@ -154,6 +157,7 @@ type CheckConfig struct {
 	DiscoveryInterval        int
 	IgnoredIPAddresses       map[string]bool
 	DiscoveryAllowedFailures int
+	DisableGlobalTags        bool
 }
 
 // RefreshWithProfile refreshes config based on profile
@@ -397,6 +401,8 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 		return nil, fmt.Errorf("namespace cannot be empty")
 	}
 
+	c.DisableGlobalTags = bool(instance.DisableGlobalTags)
+
 	// metrics Configs
 	if instance.UseGlobalMetrics {
 		c.Metrics = append(c.Metrics, initConfig.GlobalMetrics...)
@@ -560,6 +566,7 @@ func (c *CheckConfig) Copy() *CheckConfig {
 	newConfig.Namespace = c.Namespace
 	newConfig.AutodetectProfile = c.AutodetectProfile
 	newConfig.MinCollectionInterval = c.MinCollectionInterval
+	newConfig.DisableGlobalTags = c.DisableGlobalTags
 
 	return &newConfig
 }
@@ -579,6 +586,9 @@ func (c *CheckConfig) IsDiscovery() bool {
 
 // GetAgentLevelTags return agent level tags
 func (c *CheckConfig) GetAgentLevelTags() []string {
+	if c.DisableGlobalTags {
+		return []string{}
+	}
 	return coreconfig.GetConfiguredTags(false)
 }
 

--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
@@ -99,12 +99,7 @@ func (d *DeviceCheck) Run(collectionTime time.Time) error {
 			deviceStatus = metadata.DeviceStatusUnreachable
 		}
 
-		// We include instance tags to `deviceMetadataTags` since device metadata tags are not enriched with `checkSender.checkTags`.
-		// `checkSender.checkTags` are added for metrics, service checks, events only.
-		// Note that we don't add some extra tags like `service` tag that might be present in `checkSender.checkTags`.
-		deviceMetadataTags := append(common.CopyStrings(tags), d.config.InstanceTags...)
-
-		d.sender.ReportNetworkDeviceMetadata(d.config, values, deviceMetadataTags, collectionTime, deviceStatus)
+		d.sender.ReportNetworkDeviceMetadata(d.config, values, tags, collectionTime, deviceStatus)
 	}
 
 	d.submitTelemetryMetrics(startTime, tags)

--- a/pkg/collector/corechecks/snmp/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/report/report_device_metadata.go
@@ -22,6 +22,12 @@ var interfaceNameTagKey = "interface"
 // ReportNetworkDeviceMetadata reports device metadata
 func (ms *MetricSender) ReportNetworkDeviceMetadata(config *checkconfig.CheckConfig, store *valuestore.ResultValueStore, origTags []string, collectTime time.Time, deviceStatus metadata.DeviceStatus) {
 	tags := common.CopyStrings(origTags)
+
+	// We include instance tags to `deviceMetadataTags` since device metadata tags are not enriched with `checkSender.checkTags`.
+	// `checkSender.checkTags` are added for metrics, service checks, events only.
+	// Note that we don't add some extra tags like `service` tag that might be present in `checkSender.checkTags`.
+	tags = append(tags, config.InstanceTags...)
+
 	tags = append(tags, config.GetAgentLevelTags()...)
 	tags = util.SortUniqInPlace(tags)
 

--- a/pkg/collector/corechecks/snmp/report/report_device_metadata.go
+++ b/pkg/collector/corechecks/snmp/report/report_device_metadata.go
@@ -22,6 +22,7 @@ var interfaceNameTagKey = "interface"
 // ReportNetworkDeviceMetadata reports device metadata
 func (ms *MetricSender) ReportNetworkDeviceMetadata(config *checkconfig.CheckConfig, store *valuestore.ResultValueStore, origTags []string, collectTime time.Time, deviceStatus metadata.DeviceStatus) {
 	tags := common.CopyStrings(origTags)
+	tags = append(tags, config.GetAgentLevelTags()...)
 	tags = util.SortUniqInPlace(tags)
 
 	device := buildNetworkDeviceMetadata(config.DeviceID, config.DeviceIDTags, config, store, tags, deviceStatus)

--- a/pkg/collector/corechecks/snmp/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/report/report_device_metadata_test.go
@@ -65,6 +65,7 @@ extra_tags:
 		DeviceIDTags:       []string{"device_name:127.0.0.1"},
 		ResolvedSubnetName: "127.0.0.0/29",
 		Namespace:          "my-ns",
+		InstanceTags:       []string{"inst_tag1:val1", "inst_tag2:val2"},
 	}
 	layout := "2006-01-02 15:04:05"
 	str := "2014-11-12 11:45:26"
@@ -96,6 +97,8 @@ extra_tags:
 				"agent_extratag2:val2",
 				"agent_tag1:val1",
 				"agent_tag2:val2",
+				"inst_tag1:val1",
+				"inst_tag2:val2",
                 "tag1",
                 "tag2"
             ],

--- a/pkg/collector/corechecks/snmp/report/report_device_metadata_test.go
+++ b/pkg/collector/corechecks/snmp/report/report_device_metadata_test.go
@@ -93,16 +93,16 @@ extra_tags:
             "vendor": "",
             "subnet": "127.0.0.0/29",
             "tags": [
-				"agent_extratag1:val1",
-				"agent_extratag2:val2",
-				"agent_tag1:val1",
-				"agent_tag2:val2",
-				"inst_tag1:val1",
-				"inst_tag2:val2",
+                "agent_extratag1:val1",
+                "agent_extratag2:val2",
+                "agent_tag1:val1",
+                "agent_tag2:val2",
+                "inst_tag1:val1",
+                "inst_tag2:val2",
                 "tag1",
                 "tag2"
             ],
-			"status":1
+            "status":1
         }
     ],
 	"collect_timestamp":1415792726

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -768,6 +768,12 @@ api_key:
     #
     # namespace: default
 
+    ## @param disable_global_tags - boolean - optional - default: false
+    ## DisableGlobalTags disables adding the global host tags defined via tags/DD_TAG
+    ## in the Agent config.
+    #
+    # disable_global_tags: false
+
 {{- if .InternalProfiling -}}
 ## @param profiling - custom object - optional
 ## Enter specific configurations for internal profiling.

--- a/pkg/snmp/snmp.go
+++ b/pkg/snmp/snmp.go
@@ -71,6 +71,9 @@ type Config struct {
 	Tags                        []string `mapstructure:"tags"`
 	MinCollectionInterval       uint     `mapstructure:"min_collection_interval"`
 
+	// DisableGlobalTags disables adding the global host tags defined via tags/DD_TAG in the Agent config, default false.
+	DisableGlobalTags bool `mapstructure:"disable_global_tags"`
+
 	// Legacy
 	NetworkLegacy      string `mapstructure:"network"`
 	VersionLegacy      string `mapstructure:"version"`

--- a/pkg/snmp/snmp_test.go
+++ b/pkg/snmp/snmp_test.go
@@ -266,6 +266,37 @@ snmp_listener:
 	assert.Equal(t, "mononoke", conf.Configs[1].Namespace)
 }
 
+func Test_DisableGlobalTagsConfig(t *testing.T) {
+	// Default Namespace
+	config.Datadog.SetConfigType("yaml")
+	err := config.Datadog.ReadConfig(strings.NewReader(`
+snmp_listener:
+  configs:
+   - community_string: someCommunityString
+     network_address: 127.1.0.0/30
+`))
+	assert.NoError(t, err)
+	conf, err := NewListenerConfig()
+	assert.NoError(t, err)
+	networkConf := conf.Configs[0]
+	assert.Equal(t, false, networkConf.DisableGlobalTags)
+
+	// Custom Namespace in network_devices
+	config.Datadog.SetConfigType("yaml")
+	err = config.Datadog.ReadConfig(strings.NewReader(`
+snmp_listener:
+  configs:
+    - community_string: somxeCommunityString
+      network_address: 127.1.0.0/30
+      disable_global_tags: true
+`))
+	assert.NoError(t, err)
+	conf, err = NewListenerConfig()
+	assert.NoError(t, err)
+	networkConf = conf.Configs[0]
+	assert.Equal(t, true, networkConf.DisableGlobalTags)
+}
+
 func TestFirstNonEmpty(t *testing.T) {
 	assert.Equal(t, firstNonEmpty(), "")
 	assert.Equal(t, firstNonEmpty("totoro"), "totoro")


### PR DESCRIPTION
### What does this PR do?

[corechecks/snmp] Add Agent level tags

### Motivation

- consistency with metrics/service checks/ etc that also include Agent level tags
- having agent level tags is likely expected by user

### Additional Notes

Do we need to provide a way disable Agent Level tags like kubernetes_state does ? https://github.com/DataDog/datadog-agent/blob/c73d3219b5f892faacde570e518c75dcd3880de5/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go#L95-L96

Not sure why user would want to disable agent level tags. Do you see a use case where user might want to disable agent level tags ?

The only case that might be an issue is when using DCA and each node/worker Agent have a different set of Agent Level tags. But I'm not sure this is expected since it would be an issue for metrics too.

### Describe how to test your changes

- test that agent level tags are passed to ndm meatadata
- test that `disable_global_tags` works for snmp listener and SNMP direct ip instances

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
