### PR TITLE
pkg/trace/api: add config for debugger endpoint api key

### DIFF
--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -84,6 +84,7 @@ func setupAPM(config Config) {
 	config.BindEnv("apm_config.filter_tags.reject", "DD_APM_FILTER_TAGS_REJECT")
 	config.BindEnv("apm_config.internal_profiling.enabled", "DD_APM_INTERNAL_PROFILING_ENABLED")
 	config.BindEnv("apm_config.debugger_dd_url", "DD_APM_DEBUGGER_DD_URL")
+	config.BindEnv("apm_config.debugger_api_key", "DD_APM_DEBUGGER_API_KEY")
 
 	config.SetEnvKeyTransformer("apm_config.ignore_resources", func(in string) interface{} {
 		r, err := splitCSVString(in, ',')

--- a/pkg/trace/api/debugger.go
+++ b/pkg/trace/api/debugger.go
@@ -45,7 +45,11 @@ func (r *HTTPReceiver) debuggerProxyHandler() http.Handler {
 		log.Criticalf("Error parsing debugger intake URL %q: %v", intake, err)
 		return debuggerErrorHandler(fmt.Errorf("error parsing debugger intake URL %q: %v", intake, err))
 	}
-	return newDebuggerProxy(r.conf.NewHTTPTransport(), target, r.conf.APIKey(), tags)
+	apiKey := r.conf.APIKey()
+	if k := config.Datadog.GetString("apm_config.debugger_api_key"); k != "" {
+		apiKey = k
+	}
+	return newDebuggerProxy(r.conf.NewHTTPTransport(), target, config.SanitizeAPIKey(apiKey), tags)
 }
 
 // debuggerErrorHandler always returns http.StatusInternalServerError with a clarifying message.

--- a/pkg/trace/config/env_test.go
+++ b/pkg/trace/config/env_test.go
@@ -363,6 +363,18 @@ func TestLoadEnv(t *testing.T) {
 		assert.Equal("my-site.com", config.Datadog.GetString("apm_config.debugger_dd_url"))
 	})
 
+	env = "DD_APM_DEBUGGER_API_KEY"
+	t.Run(env, func(t *testing.T) {
+		defer cleanConfig()()
+		assert := assert.New(t)
+		err := os.Setenv(env, "my-key")
+		assert.NoError(err)
+		defer os.Unsetenv(env)
+		_, err = Load("./testdata/full.yaml")
+		assert.NoError(err)
+		assert.Equal("my-key", config.Datadog.GetString("apm_config.debugger_api_key"))
+	})
+
 	env = "DD_OTLP_HTTP_PORT"
 	t.Run(env, func(t *testing.T) {
 		defer cleanConfig()()

--- a/releasenotes/notes/live-debugger-endpoint-6e57f9f8e98e4679.yaml
+++ b/releasenotes/notes/live-debugger-endpoint-6e57f9f8e98e4679.yaml
@@ -8,4 +8,6 @@
 ---
 enhancements:
   - |
-    APM: Added API key configuration parameter for live debugging proxy endpoint
+    APM: Added a configuration option to set the API key separately for Live
+    Debugger. It can be set via `apm_config.debugger_api_key` or
+    `DD_APM_DEBUGGER_API_KEY`.

--- a/releasenotes/notes/live-debugger-endpoint-6e57f9f8e98e4679.yaml
+++ b/releasenotes/notes/live-debugger-endpoint-6e57f9f8e98e4679.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: Added API key configuration parameter for live debugging proxy endpoint


### PR DESCRIPTION
### What does this PR do?

Allow configuring a custom api key (`"apm_config.debugger_api_key", "DD_APM_DEBUGGER_API_KEY"`) for live debugging.

### Motivation

In cases where the `debugger_dd_url` config setting is set explicitly there are cases where we have to supply a custom api key as well.

### Checklist
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.

Note: Adding GitHub labels is only possible for contributors with write access.
