### PR TITLE
[KSM Core] Fix the phase tag on pv, pvc and ns metrics

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -343,15 +343,17 @@ func (k *KSMCheck) processMetrics(sender aggregator.Sender, metrics map[string][
 				// So, let’s continue the processing.
 			}
 			if transform, found := metricTransformers[metricFamily.Name]; found {
+				lMapperOverride := labelsMapperOverride(metricFamily.Name)
 				for _, m := range metricFamily.ListMetrics {
-					hostname, tags := k.hostnameAndTags(m.Labels, labelJoiner)
+					hostname, tags := k.hostnameAndTags(m.Labels, labelJoiner, lMapperOverride)
 					transform(sender, metricFamily.Name, m, hostname, tags)
 				}
 				continue
 			}
 			if ddname, found := metricNamesMapper[metricFamily.Name]; found {
+				lMapperOverride := labelsMapperOverride(metricFamily.Name)
 				for _, m := range metricFamily.ListMetrics {
-					hostname, tags := k.hostnameAndTags(m.Labels, labelJoiner)
+					hostname, tags := k.hostnameAndTags(m.Labels, labelJoiner, lMapperOverride)
 					sender.Gauge(ksmMetricPrefix+ddname, m.Val, hostname, tags)
 				}
 				continue
@@ -375,7 +377,7 @@ func (k *KSMCheck) processMetrics(sender aggregator.Sender, metrics map[string][
 }
 
 // hostnameAndTags returns the tags and the hostname for a metric based on the metric labels and the check configuration
-func (k *KSMCheck) hostnameAndTags(labels map[string]string, labelJoiner *labelJoiner) (string, []string) {
+func (k *KSMCheck) hostnameAndTags(labels map[string]string, labelJoiner *labelJoiner, lMapperOverride map[string]string) (string, []string) {
 	hostname := ""
 
 	labelsToAdd := labelJoiner.getLabelsToAdd(labels)
@@ -389,7 +391,7 @@ func (k *KSMCheck) hostnameAndTags(labels map[string]string, labelJoiner *labelJ
 		case createdByNameKey, ownerNameKey:
 			ownerName = value
 		default:
-			tag, hostTag := k.buildTag(key, value)
+			tag, hostTag := k.buildTag(key, value, lMapperOverride)
 			tags = append(tags, tag)
 			if hostTag != "" {
 				if k.clusterName != "" {
@@ -409,7 +411,7 @@ func (k *KSMCheck) hostnameAndTags(labels map[string]string, labelJoiner *labelJ
 		case createdByNameKey, ownerNameKey:
 			ownerName = label.value
 		default:
-			tag, hostTag := k.buildTag(label.key, label.value)
+			tag, hostTag := k.buildTag(label.key, label.value, lMapperOverride)
 			tags = append(tags, tag)
 			if hostTag != "" {
 				if k.clusterName != "" {
@@ -448,9 +450,15 @@ func (k *KSMCheck) metricFilter(m ksmstore.DDMetric) bool {
 
 // buildTag applies the LabelsMapper config and returns the tag in a key:value string format
 // The second return value is the hostname of the metric if a 'node' or 'host' tag is found, empty string otherwise
-func (k *KSMCheck) buildTag(key, value string) (tag, hostname string) {
+func (k *KSMCheck) buildTag(key, value string, lMapperOverride map[string]string) (tag, hostname string) {
 	if newKey, found := k.instance.LabelsMapper[key]; found {
 		key = newKey
+	}
+
+	if lMapperOverride != nil {
+		if keyOverride, found := lMapperOverride[key]; found {
+			key = keyOverride
+		}
 	}
 
 	var sb strings.Builder
@@ -686,4 +694,20 @@ func ownerTags(kind, name string) []string {
 	}
 
 	return tags
+}
+
+// podLabelsMapperOverride defines the label mapper overrides
+// that should be applied on pod metrics only.
+var podLabelsMapperOverride = map[string]string{"phase": "pod_phase"}
+
+// labelsMapperOverride allows overriding the default label mapping for
+// a given metric depending on the metric family.
+// Current use-case:
+//   - `phase` tag should be mapped to `pod_phase` on pod metrics only.
+func labelsMapperOverride(metricName string) map[string]string {
+	if strings.HasPrefix(metricName, "kube_pod") {
+		return podLabelsMapperOverride
+	}
+
+	return nil
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
@@ -158,13 +158,13 @@
 : Describes the unschedulable status for the pod. Tags:`kube_namespace` `pod_name` (`env` `service` `version` from standard labels).
 
 `kubernetes_state.pod.status_phase`
-: The pods current phase. Tags:`kube_namespace` `pod_name` `phase` (`env` `service` `version` from standard labels).
+: The pods current phase. Tags:`kube_namespace` `pod_name` `pod_phase` (`env` `service` `version` from standard labels).
 
 `kubernetes_state.pod.age`
-: The time in seconds since the creation of the pod. Tags:`kube_namespace` `pod_name` `phase` (`env` `service` `version` from standard labels).
+: The time in seconds since the creation of the pod. Tags:`kube_namespace` `pod_name` `pod_phase` (`env` `service` `version` from standard labels).
 
 `kubernetes_state.pod.uptime`
-: The time in seconds since the pod has been scheduled and acknowledged by the Kubelet. Tags:`kube_namespace` `pod_name` `phase` (`env` `service` `version` from standard labels).
+: The time in seconds since the pod has been scheduled and acknowledged by the Kubelet. Tags:`kube_namespace` `pod_name` `pod_phase` (`env` `service` `version` from standard labels).
 
 `kubernetes_state.pod.count`
 : Number of Pods. Tags:`kube_namespace` `kube_<owner kind>`.

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
@@ -26,7 +26,8 @@ type metricAggregator interface {
 const maxNumberOfAllowedLabels = 4
 
 type counterAggregator struct {
-	metricName    string
+	ddMetricName  string
+	ksmMetricName string
 	allowedLabels []string
 
 	accumulator map[[maxNumberOfAllowedLabels]string]float64
@@ -40,7 +41,7 @@ type countObjectsAggregator struct {
 	counterAggregator
 }
 
-func newSumValuesAggregator(metricName string, allowedLabels []string) metricAggregator {
+func newSumValuesAggregator(ddMetricName, ksmMetricName string, allowedLabels []string) metricAggregator {
 	if len(allowedLabels) > maxNumberOfAllowedLabels {
 		// `maxNumberOfAllowedLabels` is hardcoded to the maximum number of labels passed to this function from the metricsAggregators definition below.
 		// The only possibility to arrive here is to add a new aggregator in `metricAggregator` below and to forget to update `maxNumberOfAllowedLabels` accordingly.
@@ -50,14 +51,15 @@ func newSumValuesAggregator(metricName string, allowedLabels []string) metricAgg
 
 	return &sumValuesAggregator{
 		counterAggregator{
-			metricName:    metricName,
+			ddMetricName:  ddMetricName,
+			ksmMetricName: ksmMetricName,
 			allowedLabels: allowedLabels,
 			accumulator:   make(map[[maxNumberOfAllowedLabels]string]float64),
 		},
 	}
 }
 
-func newCountObjectsAggregator(metricName string, allowedLabels []string) metricAggregator {
+func newCountObjectsAggregator(ddMetricName, ksmMetricName string, allowedLabels []string) metricAggregator {
 	if len(allowedLabels) > maxNumberOfAllowedLabels {
 		// `maxNumberOfAllowedLabels` is hardcoded to the maximum number of labels passed to this function from the metricsAggregators definition below.
 		// The only possibility to arrive here is to add a new aggregator in `metricAggregator` below and to forget to update `maxNumberOfAllowedLabels` accordingly.
@@ -67,7 +69,8 @@ func newCountObjectsAggregator(metricName string, allowedLabels []string) metric
 
 	return &countObjectsAggregator{
 		counterAggregator{
-			metricName:    metricName,
+			ddMetricName:  ddMetricName,
+			ksmMetricName: ksmMetricName,
 			allowedLabels: allowedLabels,
 			accumulator:   make(map[[maxNumberOfAllowedLabels]string]float64),
 		},
@@ -114,9 +117,9 @@ func (a *counterAggregator) flush(sender aggregator.Sender, k *KSMCheck, labelJo
 			labels[allowedLabel] = labelValues[i]
 		}
 
-		hostname, tags := k.hostnameAndTags(labels, labelJoiner)
+		hostname, tags := k.hostnameAndTags(labels, labelJoiner, labelsMapperOverride(a.ksmMetricName))
 
-		sender.Gauge(ksmMetricPrefix+a.metricName, count, hostname, tags)
+		sender.Gauge(ksmMetricPrefix+a.ddMetricName, count, hostname, tags)
 	}
 
 	a.accumulator = make(map[[maxNumberOfAllowedLabels]string]float64)
@@ -125,58 +128,72 @@ func (a *counterAggregator) flush(sender aggregator.Sender, k *KSMCheck, labelJo
 var metricAggregators = map[string]metricAggregator{
 	"kube_persistentvolume_status_phase": newSumValuesAggregator(
 		"persistentvolumes.by_phase",
+		"kube_persistentvolume_status_phase",
 		[]string{"storageclass", "phase"},
 	),
 	"kube_service_spec_type": newCountObjectsAggregator(
 		"service.count",
+		"kube_service_spec_type",
 		[]string{"namespace", "type"},
 	),
 	"kube_namespace_status_phase": newSumValuesAggregator(
 		"namespace.count",
+		"kube_namespace_status_phase",
 		[]string{"phase"},
 	),
 	"kube_replicaset_owner": newCountObjectsAggregator(
 		"replicaset.count",
+		"kube_replicaset_owner",
 		[]string{"namespace", "owner_name", "owner_kind"},
 	),
 	"kube_job_owner": newCountObjectsAggregator(
 		"job.count",
+		"kube_job_owner",
 		[]string{"namespace", "owner_name", "owner_kind"},
 	),
 	"kube_deployment_labels": newCountObjectsAggregator(
 		"deployment.count",
+		"kube_deployment_labels",
 		[]string{"namespace"},
 	),
 	"kube_daemonset_labels": newCountObjectsAggregator(
 		"daemonset.count",
+		"kube_daemonset_labels",
 		[]string{"namespace"},
 	),
 	"kube_statefulset_labels": newCountObjectsAggregator(
 		"statefulset.count",
+		"kube_statefulset_labels",
 		[]string{"namespace"},
 	),
 	"kube_cronjob_labels": newCountObjectsAggregator(
 		"cronjob.count",
+		"kube_cronjob_labels",
 		[]string{"namespace"},
 	),
 	"kube_endpoint_labels": newCountObjectsAggregator(
 		"endpoint.count",
+		"kube_endpoint_labels",
 		[]string{"namespace"},
 	),
 	"kube_horizontalpodautoscaler_labels": newCountObjectsAggregator(
 		"hpa.count",
+		"kube_horizontalpodautoscaler_labels",
 		[]string{"namespace"},
 	),
 	"kube_verticalpodautoscaler_labels": newCountObjectsAggregator(
 		"vpa.count",
+		"kube_verticalpodautoscaler_labels",
 		[]string{"namespace"},
 	),
 	"kube_node_info": newCountObjectsAggregator(
 		"node.count",
+		"kube_node_info",
 		[]string{"kubelet_version", "container_runtime_version", "kernel_version", "os_image"},
 	),
 	"kube_pod_info": newCountObjectsAggregator(
 		"pod.count",
+		"kube_pod_info",
 		[]string{"namespace", "created_by_kind", "created_by_name"},
 	),
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators_test.go
@@ -21,14 +21,14 @@ var _ metricAggregator = &countObjectsAggregator{}
 func Test_counterAggregator(t *testing.T) {
 	tests := []struct {
 		name          string
-		metricName    string
+		ddMetricName  string
 		allowedLabels []string
 		metrics       []ksmstore.DDMetric
 		expected      []metricsExpected
 	}{
 		{
 			name:          "One allowed label",
-			metricName:    "my.count",
+			ddMetricName:  "my.count",
 			allowedLabels: []string{"foo"},
 			metrics: []ksmstore.DDMetric{
 				{
@@ -75,7 +75,7 @@ func Test_counterAggregator(t *testing.T) {
 		},
 		{
 			name:          "Two allowed labels",
-			metricName:    "my.count",
+			ddMetricName:  "my.count",
 			allowedLabels: []string{"foo", "bar"},
 			metrics: []ksmstore.DDMetric{
 				{
@@ -175,7 +175,7 @@ func Test_counterAggregator(t *testing.T) {
 		s.SetupAcceptAll()
 
 		t.Run(tt.name, func(t *testing.T) {
-			agg := newSumValuesAggregator(tt.metricName, tt.allowedLabels)
+			agg := newSumValuesAggregator(tt.ddMetricName, "", tt.allowedLabels)
 			for _, metric := range tt.metrics {
 				agg.accumulate(metric)
 			}

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -23,7 +23,6 @@ var (
 		"job_name":                            "kube_job",
 		"cronjob":                             "kube_cronjob",
 		"pod":                                 "pod_name",
-		"phase":                               "pod_phase",
 		"priority_class":                      "kube_priority_class",
 		"daemonset":                           "kube_daemon_set",
 		"replicationcontroller":               "kube_replication_controller",

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -328,6 +328,90 @@ func TestProcessMetrics(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:   "phase tag for pod",
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper},
+			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
+				"kube_pod_status_phase": {
+					{
+						Type: "*v1.Pod",
+						Name: "kube_pod_status_phase",
+						ListMetrics: []ksmstore.DDMetric{
+							{
+								Labels: map[string]string{"namespace": "default", "pod": "redis", "phase": "Running"},
+								Val:    1,
+							},
+						},
+					},
+				},
+			},
+			metricsToGet:       []ksmstore.DDMetricsFam{},
+			metricTransformers: metricTransformers,
+			expected: []metricsExpected{
+				{
+					name:     "kubernetes_state.pod.status_phase",
+					val:      1,
+					tags:     []string{"kube_namespace:default", "pod_name:redis", "pod_phase:Running"},
+					hostname: "",
+				},
+			},
+		},
+		{
+			name:   "phase tag for pvc",
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper},
+			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
+				"kube_persistentvolumeclaim_status_phase": {
+					{
+						Type: "*v1.PersistentVolumeClaim",
+						Name: "kube_persistentvolumeclaim_status_phase",
+						ListMetrics: []ksmstore.DDMetric{
+							{
+								Labels: map[string]string{"namespace": "default", "persistentvolumeclaim": "pvc", "phase": "Bound"},
+								Val:    1,
+							},
+						},
+					},
+				},
+			},
+			metricsToGet:       []ksmstore.DDMetricsFam{},
+			metricTransformers: metricTransformers,
+			expected: []metricsExpected{
+				{
+					name:     "kubernetes_state.persistentvolumeclaim.status",
+					val:      1,
+					tags:     []string{"kube_namespace:default", "persistentvolumeclaim:pvc", "phase:Bound"},
+					hostname: "",
+				},
+			},
+		},
+		{
+			name:   "phase tag for ns",
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper},
+			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
+				"kube_namespace_status_phase": {
+					{
+						Type: "*v1.Namespace",
+						Name: "kube_namespace_status_phase",
+						ListMetrics: []ksmstore.DDMetric{
+							{
+								Labels: map[string]string{"namespace": "default", "phase": "Active"},
+								Val:    1,
+							},
+						},
+					},
+				},
+			},
+			metricsToGet:       []ksmstore.DDMetricsFam{},
+			metricTransformers: metricTransformers,
+			expected: []metricsExpected{
+				{
+					name:     "kubernetes_state.namespace.count",
+					val:      1,
+					tags:     []string{"phase:Active"},
+					hostname: "",
+				},
+			},
+		},
 	}
 	for _, test := range tests {
 		kubeStateMetricsSCheck := newKSMCheck(core.NewCheckBase(kubeStateMetricsCheckName), test.config)
@@ -610,9 +694,10 @@ func TestSendTelemetry(t *testing.T) {
 
 func TestKSMCheck_hostnameAndTags(t *testing.T) {
 	type args struct {
-		labels       map[string]string
-		metricsToGet []ksmstore.DDMetricsFam
-		clusterName  string
+		labels          map[string]string
+		lMapperOverride map[string]string
+		metricsToGet    []ksmstore.DDMetricsFam
+		clusterName     string
 	}
 	tests := []struct {
 		name         string
@@ -880,6 +965,17 @@ func TestKSMCheck_hostnameAndTags(t *testing.T) {
 			wantTags:     []string{"foo_label:foo_value", "kube_daemon_set:foo_name"},
 			wantHostname: "",
 		},
+		{
+			name:   "labels mapper override",
+			config: &KSMConfig{},
+			args: args{
+				labels:          map[string]string{"foo_label": "foo_value"},
+				metricsToGet:    []ksmstore.DDMetricsFam{},
+				lMapperOverride: map[string]string{"foo_label": "new_foo_label"},
+			},
+			wantTags:     []string{"new_foo_label:foo_value"},
+			wantHostname: "",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -890,7 +986,7 @@ func TestKSMCheck_hostnameAndTags(t *testing.T) {
 				labelJoiner.insertFamily(metricFam)
 			}
 
-			hostname, tags := kubeStateMetricsSCheck.hostnameAndTags(tt.args.labels, labelJoiner)
+			hostname, tags := kubeStateMetricsSCheck.hostnameAndTags(tt.args.labels, labelJoiner, tt.args.lMapperOverride)
 			assert.ElementsMatch(t, tt.wantTags, tags)
 			assert.Equal(t, tt.wantHostname, hostname)
 		})

--- a/releasenotes-dca/notes/ksm-phase-tag-fix-05fffa48b0bb8d80.yaml
+++ b/releasenotes-dca/notes/ksm-phase-tag-fix-05fffa48b0bb8d80.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Tag Namespace and PV and PVC metrics correctly with ``phase`` instead of ``pod_phase``
+    in the Kube State Metrics Core check.

--- a/releasenotes/notes/ksm-phase-tag-fix-05fffa48b0bb8d80.yaml
+++ b/releasenotes/notes/ksm-phase-tag-fix-05fffa48b0bb8d80.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Tag Namespace and PV and PVC metrics correctly with ``phase`` instead of ``pod_phase``
+    in the Kube State Metrics Core check.


### PR DESCRIPTION
### What does this PR do?

Tag Namespace, PV and PVC metrics correctly with `phase` instead of `pod_phase` in the Kube State Metrics Core check.

### Motivation

Bug fix

### Additional Notes

`labelsMapperOverride` can be used in the future for other label overrides

### Describe how to test your changes

Run the check and verify the following:
- PVC, PV and NS metrics like `kubernetes_state.persistentvolumeclaim.status`, `kubernetes_state.namespace.count` and `kubernetes_state.persistentvolumes.by_phase` should be tagged with `phase`
- Pod metrics like `kubernetes_state.pod.status_phase` should be tagged with `pod_phase`

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
