### PR TITLE
[corechecks/snmp] Improve snmp integrations debug logs

### DIFF
--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
@@ -135,10 +135,7 @@ func (d *DeviceCheck) getValuesAndTags(staticTags []string) (bool, []string, *va
 		checkErrors = append(checkErrors, fmt.Sprintf("check device reachable: failed: %s", err))
 	} else {
 		deviceReachable = true
-		if logLevel, err := log.GetLogLevel(); err != nil || logLevel == seelog.DebugLvl {
-			values := gosnmplib.ResultToScalarValues(getNextValue)
-			log.Debugf("check device reachable: success: %+v", values)
-		}
+		log.Debugf("check device reachable: success: %v", gosnmplib.PacketAsStringIfLoglevel(getNextValue, seelog.DebugLvl))
 	}
 
 	err = d.doAutodetectProfile(d.session)
@@ -149,7 +146,7 @@ func (d *DeviceCheck) getValuesAndTags(staticTags []string) (bool, []string, *va
 	tags = append(tags, d.config.ProfileTags...)
 
 	valuesStore, err := fetch.Fetch(d.session, d.config)
-	log.Debugf("fetched values: %v", valuesStore)
+	log.Debugf("fetched values: %v", valuestore.ResultValueStoreAsStringIfLoglevel(valuesStore, seelog.DebugLvl))
 
 	if err != nil {
 		checkErrors = append(checkErrors, fmt.Sprintf("failed to fetch values: %s", err))

--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
@@ -135,7 +135,9 @@ func (d *DeviceCheck) getValuesAndTags(staticTags []string) (bool, []string, *va
 		checkErrors = append(checkErrors, fmt.Sprintf("check device reachable: failed: %s", err))
 	} else {
 		deviceReachable = true
-		log.Debugf("check device reachable: success: %v", gosnmplib.PacketAsStringIfLoglevel(getNextValue, seelog.DebugLvl))
+		if log.ShouldLog(seelog.DebugLvl) {
+			log.Debugf("check device reachable: success: %v", gosnmplib.PacketAsString(getNextValue))
+		}
 	}
 
 	err = d.doAutodetectProfile(d.session)
@@ -146,7 +148,9 @@ func (d *DeviceCheck) getValuesAndTags(staticTags []string) (bool, []string, *va
 	tags = append(tags, d.config.ProfileTags...)
 
 	valuesStore, err := fetch.Fetch(d.session, d.config)
-	log.Debugf("fetched values: %v", valuestore.ResultValueStoreAsStringIfLoglevel(valuesStore, seelog.DebugLvl))
+	if log.ShouldLog(seelog.DebugLvl) {
+		log.Debugf("fetched values: %v", valuestore.ResultValueStoreAsString(valuesStore))
+	}
 
 	if err != nil {
 		checkErrors = append(checkErrors, fmt.Sprintf("failed to fetch values: %s", err))

--- a/pkg/collector/corechecks/snmp/fetch/fetch_column.go
+++ b/pkg/collector/corechecks/snmp/fetch/fetch_column.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"sort"
 
+	"github.com/cihub/seelog"
 	"github.com/gosnmp/gosnmp"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -69,6 +70,7 @@ func fetchColumnOids(sess session.Session, oids map[string]string, bulkMaxRepeti
 		sort.Strings(requestOids)
 
 		results, err := getResults(sess, requestOids, bulkMaxRepetitions)
+		log.Debugf("fetch column: results: %v", gosnmplib.PacketAsStringIfLoglevel(results, seelog.DebugLvl))
 		if err != nil {
 			return nil, err
 		}
@@ -97,7 +99,6 @@ func getResults(sess session.Session, requestOids []string, bulkMaxRepetitions u
 			return nil, fmt.Errorf("fetch column: failed getting oids `%v` using GetBulk: %s", requestOids, err)
 		}
 		results = getBulkResults
-		log.Debugf("fetch column: GetBulk results Variables: %v", results.Variables)
 	}
 	return results, nil
 }

--- a/pkg/collector/corechecks/snmp/fetch/fetch_column.go
+++ b/pkg/collector/corechecks/snmp/fetch/fetch_column.go
@@ -70,7 +70,6 @@ func fetchColumnOids(sess session.Session, oids map[string]string, bulkMaxRepeti
 		sort.Strings(requestOids)
 
 		results, err := getResults(sess, requestOids, bulkMaxRepetitions)
-		log.Debugf("fetch column: results: %v", gosnmplib.PacketAsStringIfLoglevel(results, seelog.DebugLvl))
 		if err != nil {
 			return nil, err
 		}
@@ -90,6 +89,7 @@ func getResults(sess session.Session, requestOids []string, bulkMaxRepetitions u
 			log.Debugf("fetch column: failed getting oids `%v` using GetNext: %s", requestOids, err)
 			return nil, fmt.Errorf("fetch column: failed getting oids `%v` using GetNext: %s", requestOids, err)
 		}
+		log.Debugf("fetch column: GetNext results: %v", gosnmplib.PacketAsStringIfLoglevel(results, seelog.DebugLvl))
 		results = getNextResults
 	} else {
 		getBulkResults, err := sess.GetBulk(requestOids, bulkMaxRepetitions)
@@ -98,6 +98,7 @@ func getResults(sess session.Session, requestOids []string, bulkMaxRepetitions u
 			return nil, fmt.Errorf("fetch column: failed getting oids `%v` using GetBulk: %s", requestOids, err)
 		}
 		results = getBulkResults
+		log.Debugf("fetch column: GetBulk results: %v", gosnmplib.PacketAsStringIfLoglevel(results, seelog.DebugLvl))
 	}
 	return results, nil
 }

--- a/pkg/collector/corechecks/snmp/fetch/fetch_column.go
+++ b/pkg/collector/corechecks/snmp/fetch/fetch_column.go
@@ -89,7 +89,9 @@ func getResults(sess session.Session, requestOids []string, bulkMaxRepetitions u
 			log.Debugf("fetch column: failed getting oids `%v` using GetNext: %s", requestOids, err)
 			return nil, fmt.Errorf("fetch column: failed getting oids `%v` using GetNext: %s", requestOids, err)
 		}
-		log.Debugf("fetch column: GetNext results: %v", gosnmplib.PacketAsStringIfLoglevel(results, seelog.DebugLvl))
+		if log.ShouldLog(seelog.DebugLvl) {
+			log.Debugf("fetch column: GetNext results: %v", gosnmplib.PacketAsString(results))
+		}
 		results = getNextResults
 	} else {
 		getBulkResults, err := sess.GetBulk(requestOids, bulkMaxRepetitions)
@@ -98,7 +100,9 @@ func getResults(sess session.Session, requestOids []string, bulkMaxRepetitions u
 			return nil, fmt.Errorf("fetch column: failed getting oids `%v` using GetBulk: %s", requestOids, err)
 		}
 		results = getBulkResults
-		log.Debugf("fetch column: GetBulk results: %v", gosnmplib.PacketAsStringIfLoglevel(results, seelog.DebugLvl))
+		if log.ShouldLog(seelog.DebugLvl) {
+			log.Debugf("fetch column: GetBulk results: %v", gosnmplib.PacketAsString(results))
+		}
 	}
 	return results, nil
 }

--- a/pkg/collector/corechecks/snmp/fetch/fetch_column.go
+++ b/pkg/collector/corechecks/snmp/fetch/fetch_column.go
@@ -89,10 +89,10 @@ func getResults(sess session.Session, requestOids []string, bulkMaxRepetitions u
 			log.Debugf("fetch column: failed getting oids `%v` using GetNext: %s", requestOids, err)
 			return nil, fmt.Errorf("fetch column: failed getting oids `%v` using GetNext: %s", requestOids, err)
 		}
+		results = getNextResults
 		if log.ShouldLog(seelog.DebugLvl) {
 			log.Debugf("fetch column: GetNext results: %v", gosnmplib.PacketAsString(results))
 		}
-		results = getNextResults
 	} else {
 		getBulkResults, err := sess.GetBulk(requestOids, bulkMaxRepetitions)
 		if err != nil {

--- a/pkg/collector/corechecks/snmp/fetch/fetch_column.go
+++ b/pkg/collector/corechecks/snmp/fetch/fetch_column.go
@@ -91,7 +91,6 @@ func getResults(sess session.Session, requestOids []string, bulkMaxRepetitions u
 			return nil, fmt.Errorf("fetch column: failed getting oids `%v` using GetNext: %s", requestOids, err)
 		}
 		results = getNextResults
-		log.Debugf("fetch column: GetNext results Variables: %v", results.Variables)
 	} else {
 		getBulkResults, err := sess.GetBulk(requestOids, bulkMaxRepetitions)
 		if err != nil {

--- a/pkg/collector/corechecks/snmp/fetch/fetch_scalar.go
+++ b/pkg/collector/corechecks/snmp/fetch/fetch_scalar.go
@@ -2,10 +2,10 @@ package fetch
 
 import (
 	"fmt"
+	"github.com/cihub/seelog"
 	"sort"
 	"strings"
 
-	"github.com/cihub/seelog"
 	"github.com/gosnmp/gosnmp"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -121,6 +121,8 @@ func doDoFetchScalarOids(session session.Session, oids []string) (*gosnmp.SnmpPa
 		log.Debugf("fetch scalar: error getting oids `%v`: %v", oids, err)
 		return nil, fmt.Errorf("fetch scalar: error getting oids `%v`: %v", oids, err)
 	}
-	log.Debugf("fetch scalar: results: %s", gosnmplib.PacketAsStringIfLoglevel(results, seelog.DebugLvl))
+	if log.ShouldLog(seelog.DebugLvl) {
+		log.Debugf("fetch scalar: results: %s", gosnmplib.PacketAsString(results))
+	}
 	return results, nil
 }

--- a/pkg/collector/corechecks/snmp/fetch/fetch_scalar.go
+++ b/pkg/collector/corechecks/snmp/fetch/fetch_scalar.go
@@ -2,10 +2,10 @@ package fetch
 
 import (
 	"fmt"
-	"github.com/cihub/seelog"
 	"sort"
 	"strings"
 
+	"github.com/cihub/seelog"
 	"github.com/gosnmp/gosnmp"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"

--- a/pkg/collector/corechecks/snmp/fetch/fetch_scalar.go
+++ b/pkg/collector/corechecks/snmp/fetch/fetch_scalar.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/cihub/seelog"
 	"github.com/gosnmp/gosnmp"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -120,6 +121,6 @@ func doDoFetchScalarOids(session session.Session, oids []string) (*gosnmp.SnmpPa
 		log.Debugf("fetch scalar: error getting oids `%v`: %v", oids, err)
 		return nil, fmt.Errorf("fetch scalar: error getting oids `%v`: %v", oids, err)
 	}
-	log.Debugf("fetch scalar: results: Variables=%v, Error=%v, ErrorIndex=%v", results.Variables, results.Error, results.ErrorIndex)
+	log.Debugf("fetch scalar: results: %s", gosnmplib.PacketAsStringIfLoglevel(results, seelog.DebugLvl))
 	return results, nil
 }

--- a/pkg/collector/corechecks/snmp/gosnmplib/gosnmp_utils.go
+++ b/pkg/collector/corechecks/snmp/gosnmplib/gosnmp_utils.go
@@ -1,0 +1,52 @@
+package gosnmplib
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/cihub/seelog"
+	"github.com/gosnmp/gosnmp"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+type debugVariable struct {
+	Oid      string      `json:"oid"`
+	Type     string      `json:"type"`
+	Value    interface{} `json:"value"`
+	ParseErr string      `json:"parse_err,omitempty"`
+}
+
+// PacketAsStringIfLoglevel used to format gosnmp.SnmpPacket for debug logging
+func PacketAsStringIfLoglevel(packet *gosnmp.SnmpPacket, logLevel seelog.LogLevel) string {
+	if packet == nil {
+		return ""
+	}
+	if curLogLevel, err := log.GetLogLevel(); err != nil || curLogLevel <= logLevel {
+		var debugVariables []debugVariable
+		for _, pduVariable := range packet.Variables {
+			var parseError string
+			name := pduVariable.Name
+			value := fmt.Sprintf("%v", pduVariable.Value)
+			_, resValue, err := GetValueFromPDU(pduVariable)
+			if err == nil {
+				resValueStr, err := resValue.ToString()
+				if err == nil {
+					value = resValueStr
+				}
+			}
+			if err != nil {
+				parseError = fmt.Sprintf("`%s`", err)
+			}
+			debugVar := debugVariable{Oid: name, Type: fmt.Sprintf("%v", pduVariable.Type), Value: value, ParseErr: parseError}
+			debugVariables = append(debugVariables, debugVar)
+		}
+
+		jsonPayload, err := json.Marshal(debugVariables)
+		if err != nil {
+			log.Debugf("error marshaling debugVar: %s", err)
+		}
+		return fmt.Sprintf("error=%s(code:%d, idx:%d), values=%s", packet.Error, packet.Error, packet.ErrorIndex, jsonPayload)
+	}
+	return ""
+}

--- a/pkg/collector/corechecks/snmp/gosnmplib/gosnmp_utils.go
+++ b/pkg/collector/corechecks/snmp/gosnmplib/gosnmp_utils.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 
-	"github.com/cihub/seelog"
 	"github.com/gosnmp/gosnmp"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -17,36 +16,33 @@ type debugVariable struct {
 	ParseErr string      `json:"parse_err,omitempty"`
 }
 
-// PacketAsStringIfLoglevel used to format gosnmp.SnmpPacket for debug logging
-func PacketAsStringIfLoglevel(packet *gosnmp.SnmpPacket, logLevel seelog.LogLevel) string {
+// PacketAsString used to format gosnmp.SnmpPacket for debug logging
+func PacketAsString(packet *gosnmp.SnmpPacket) string {
 	if packet == nil {
 		return ""
 	}
-	if curLogLevel, err := log.GetLogLevel(); err != nil || curLogLevel <= logLevel {
-		var debugVariables []debugVariable
-		for _, pduVariable := range packet.Variables {
-			var parseError string
-			name := pduVariable.Name
-			value := fmt.Sprintf("%v", pduVariable.Value)
-			_, resValue, err := GetValueFromPDU(pduVariable)
+	var debugVariables []debugVariable
+	for _, pduVariable := range packet.Variables {
+		var parseError string
+		name := pduVariable.Name
+		value := fmt.Sprintf("%v", pduVariable.Value)
+		_, resValue, err := GetValueFromPDU(pduVariable)
+		if err == nil {
+			resValueStr, err := resValue.ToString()
 			if err == nil {
-				resValueStr, err := resValue.ToString()
-				if err == nil {
-					value = resValueStr
-				}
+				value = resValueStr
 			}
-			if err != nil {
-				parseError = fmt.Sprintf("`%s`", err)
-			}
-			debugVar := debugVariable{Oid: name, Type: fmt.Sprintf("%v", pduVariable.Type), Value: value, ParseErr: parseError}
-			debugVariables = append(debugVariables, debugVar)
 		}
-
-		jsonPayload, err := json.Marshal(debugVariables)
 		if err != nil {
-			log.Debugf("error marshaling debugVar: %s", err)
+			parseError = fmt.Sprintf("`%s`", err)
 		}
-		return fmt.Sprintf("error=%s(code:%d, idx:%d), values=%s", packet.Error, packet.Error, packet.ErrorIndex, jsonPayload)
+		debugVar := debugVariable{Oid: name, Type: fmt.Sprintf("%v", pduVariable.Type), Value: value, ParseErr: parseError}
+		debugVariables = append(debugVariables, debugVar)
 	}
-	return ""
+
+	jsonPayload, err := json.Marshal(debugVariables)
+	if err != nil {
+		log.Debugf("error marshaling debugVar: %s", err)
+	}
+	return fmt.Sprintf("error=%s(code:%d, idx:%d), values=%s", packet.Error, packet.Error, packet.ErrorIndex, jsonPayload)
 }

--- a/pkg/collector/corechecks/snmp/gosnmplib/gosnmp_utils.go
+++ b/pkg/collector/corechecks/snmp/gosnmplib/gosnmp_utils.go
@@ -16,7 +16,7 @@ type debugVariable struct {
 	ParseErr string      `json:"parse_err,omitempty"`
 }
 
-// PacketAsString used to format gosnmp.SnmpPacket for debug logging
+// PacketAsString used to format gosnmp.SnmpPacket for debug/trace logging
 func PacketAsString(packet *gosnmp.SnmpPacket) string {
 	if packet == nil {
 		return ""

--- a/pkg/collector/corechecks/snmp/gosnmplib/gosnmp_utils.go
+++ b/pkg/collector/corechecks/snmp/gosnmplib/gosnmp_utils.go
@@ -43,6 +43,7 @@ func PacketAsString(packet *gosnmp.SnmpPacket) string {
 	jsonPayload, err := json.Marshal(debugVariables)
 	if err != nil {
 		log.Debugf("error marshaling debugVar: %s", err)
+		jsonPayload = []byte(``)
 	}
 	return fmt.Sprintf("error=%s(code:%d, idx:%d), values=%s", packet.Error, packet.Error, packet.ErrorIndex, jsonPayload)
 }

--- a/pkg/collector/corechecks/snmp/gosnmplib/gosnmp_utils_test.go
+++ b/pkg/collector/corechecks/snmp/gosnmplib/gosnmp_utils_test.go
@@ -1,0 +1,108 @@
+package gosnmplib
+
+import (
+	"bufio"
+	"bytes"
+	"testing"
+
+	"github.com/cihub/seelog"
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+func TestPacketAsStringIfLoglevel(t *testing.T) {
+	tests := []struct {
+		name        string
+		packet      *gosnmp.SnmpPacket
+		curLogLevel string
+		logLevel    seelog.LogLevel
+		expectedStr string
+	}{
+		{
+			name: "same level as current log level",
+			packet: &gosnmp.SnmpPacket{
+				Variables: []gosnmp.SnmpPDU{
+					{
+						Name:  "1.3.6.1.2.1.1.2.0",
+						Type:  gosnmp.ObjectIdentifier,
+						Value: "1.3.6.1.4.1.3375.2.1.3.4.1",
+					},
+					{
+						Name:  "1.3.6.1.2.1.1.3.0",
+						Type:  gosnmp.Counter32,
+						Value: 10,
+					},
+				},
+			},
+			curLogLevel: "debug",
+			logLevel:    seelog.DebugLvl,
+			expectedStr: "error=NoError(code:0, idx:0), values=[{\"oid\":\"1.3.6.1.2.1.1.2.0\",\"type\":\"ObjectIdentifier\",\"value\":\"1.3.6.1.4.1.3375.2.1.3.4.1\"},{\"oid\":\"1.3.6.1.2.1.1.3.0\",\"type\":\"Counter32\",\"value\":\"10\"}]",
+		},
+		{
+			name: "current log is higher",
+			packet: &gosnmp.SnmpPacket{
+				Variables: []gosnmp.SnmpPDU{
+					{
+						Name:  "1.3.6.1.2.1.1.2.0",
+						Type:  gosnmp.ObjectIdentifier,
+						Value: "1.3.6.1.4.1.3375.2.1.3.4.1",
+					},
+				},
+			},
+			curLogLevel: "trace",
+			logLevel:    seelog.DebugLvl,
+			expectedStr: "error=NoError(code:0, idx:0), values=[{\"oid\":\"1.3.6.1.2.1.1.2.0\",\"type\":\"ObjectIdentifier\",\"value\":\"1.3.6.1.4.1.3375.2.1.3.4.1\"}]",
+		},
+		{
+			name: "invalid ipaddr",
+			packet: &gosnmp.SnmpPacket{
+				Variables: []gosnmp.SnmpPDU{
+					{
+						Name:  "1.3.6.1.2.1.1.2.0",
+						Type:  gosnmp.IPAddress,
+						Value: 10,
+					},
+				},
+			},
+			curLogLevel: "debug",
+			logLevel:    seelog.DebugLvl,
+			expectedStr: "error=NoError(code:0, idx:0), values=[{\"oid\":\"1.3.6.1.2.1.1.2.0\",\"type\":\"IPAddress\",\"value\":\"10\",\"parse_err\":\"`oid 1.3.6.1.2.1.1.2.0: IPAddress should be string type but got int type: gosnmp.SnmpPDU{Name:\\\"1.3.6.1.2.1.1.2.0\\\", Type:0x40, Value:10}`\"}]",
+		},
+		{
+			name: "not enough loglevel",
+			packet: &gosnmp.SnmpPacket{
+				Variables: []gosnmp.SnmpPDU{
+					{
+						Name:  "1.3.6.1.2.1.1.2.0",
+						Type:  gosnmp.IPAddress,
+						Value: 10,
+					},
+				},
+			},
+			curLogLevel: "debug",
+			logLevel:    seelog.TraceLvl,
+			expectedStr: "",
+		},
+		{
+			name:        "nil packet loglevel",
+			curLogLevel: "debug",
+			logLevel:    seelog.DebugLvl,
+			expectedStr: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var b bytes.Buffer
+			w := bufio.NewWriter(&b)
+			l, err := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.TraceLvl, "[%LEVEL] %FuncShort: %Msg")
+			require.NoError(t, err)
+			log.SetupLogger(l, tt.curLogLevel)
+
+			str := PacketAsStringIfLoglevel(tt.packet, tt.logLevel)
+			assert.Equal(t, tt.expectedStr, str)
+		})
+	}
+}

--- a/pkg/collector/corechecks/snmp/gosnmplib/gosnmp_utils_test.go
+++ b/pkg/collector/corechecks/snmp/gosnmplib/gosnmp_utils_test.go
@@ -1,28 +1,20 @@
 package gosnmplib
 
 import (
-	"bufio"
-	"bytes"
 	"testing"
 
-	"github.com/cihub/seelog"
 	"github.com/gosnmp/gosnmp"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func TestPacketAsStringIfLoglevel(t *testing.T) {
+func TestPacketToString(t *testing.T) {
 	tests := []struct {
 		name        string
 		packet      *gosnmp.SnmpPacket
-		curLogLevel string
-		logLevel    seelog.LogLevel
 		expectedStr string
 	}{
 		{
-			name: "same level as current log level",
+			name: "to string",
 			packet: &gosnmp.SnmpPacket{
 				Variables: []gosnmp.SnmpPDU{
 					{
@@ -37,24 +29,7 @@ func TestPacketAsStringIfLoglevel(t *testing.T) {
 					},
 				},
 			},
-			curLogLevel: "debug",
-			logLevel:    seelog.DebugLvl,
 			expectedStr: "error=NoError(code:0, idx:0), values=[{\"oid\":\"1.3.6.1.2.1.1.2.0\",\"type\":\"ObjectIdentifier\",\"value\":\"1.3.6.1.4.1.3375.2.1.3.4.1\"},{\"oid\":\"1.3.6.1.2.1.1.3.0\",\"type\":\"Counter32\",\"value\":\"10\"}]",
-		},
-		{
-			name: "current log is higher",
-			packet: &gosnmp.SnmpPacket{
-				Variables: []gosnmp.SnmpPDU{
-					{
-						Name:  "1.3.6.1.2.1.1.2.0",
-						Type:  gosnmp.ObjectIdentifier,
-						Value: "1.3.6.1.4.1.3375.2.1.3.4.1",
-					},
-				},
-			},
-			curLogLevel: "trace",
-			logLevel:    seelog.DebugLvl,
-			expectedStr: "error=NoError(code:0, idx:0), values=[{\"oid\":\"1.3.6.1.2.1.1.2.0\",\"type\":\"ObjectIdentifier\",\"value\":\"1.3.6.1.4.1.3375.2.1.3.4.1\"}]",
 		},
 		{
 			name: "invalid ipaddr",
@@ -67,41 +42,16 @@ func TestPacketAsStringIfLoglevel(t *testing.T) {
 					},
 				},
 			},
-			curLogLevel: "debug",
-			logLevel:    seelog.DebugLvl,
 			expectedStr: "error=NoError(code:0, idx:0), values=[{\"oid\":\"1.3.6.1.2.1.1.2.0\",\"type\":\"IPAddress\",\"value\":\"10\",\"parse_err\":\"`oid 1.3.6.1.2.1.1.2.0: IPAddress should be string type but got int type: gosnmp.SnmpPDU{Name:\\\"1.3.6.1.2.1.1.2.0\\\", Type:0x40, Value:10}`\"}]",
 		},
 		{
-			name: "not enough loglevel",
-			packet: &gosnmp.SnmpPacket{
-				Variables: []gosnmp.SnmpPDU{
-					{
-						Name:  "1.3.6.1.2.1.1.2.0",
-						Type:  gosnmp.IPAddress,
-						Value: 10,
-					},
-				},
-			},
-			curLogLevel: "debug",
-			logLevel:    seelog.TraceLvl,
-			expectedStr: "",
-		},
-		{
 			name:        "nil packet loglevel",
-			curLogLevel: "debug",
-			logLevel:    seelog.DebugLvl,
 			expectedStr: "",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var b bytes.Buffer
-			w := bufio.NewWriter(&b)
-			l, err := seelog.LoggerFromWriterWithMinLevelAndFormat(w, seelog.TraceLvl, "[%LEVEL] %FuncShort: %Msg")
-			require.NoError(t, err)
-			log.SetupLogger(l, tt.curLogLevel)
-
-			str := PacketAsStringIfLoglevel(tt.packet, tt.logLevel)
+			str := PacketAsString(tt.packet)
 			assert.Equal(t, tt.expectedStr, str)
 		})
 	}

--- a/pkg/collector/corechecks/snmp/report/report_metrics.go
+++ b/pkg/collector/corechecks/snmp/report/report_metrics.go
@@ -43,7 +43,6 @@ func (ms *MetricSender) GetCheckInstanceMetricTags(metricTags []checkconfig.Metr
 	for _, metricTag := range metricTags {
 		value, err := values.GetScalarValue(metricTag.OID)
 		if err != nil {
-			log.Debugf("metric tags: error getting scalar value: %v", err)
 			continue
 		}
 		strValue, err := value.ToString()
@@ -73,14 +72,12 @@ func (ms *MetricSender) reportColumnMetrics(metricConfig checkconfig.MetricsConf
 	for _, symbol := range metricConfig.Symbols {
 		metricValues, err := values.GetColumnValues(symbol.OID)
 		if err != nil {
-			log.Debugf("report column: error getting column value: %v", err)
 			continue
 		}
 		for fullIndex, value := range metricValues {
 			// cache row tags by fullIndex to avoid rebuilding it for every column rows
 			if _, ok := rowTagsCache[fullIndex]; !ok {
 				rowTagsCache[fullIndex] = append(common.CopyStrings(tags), metricConfig.GetTags(fullIndex, values)...)
-				log.Debugf("report column: caching tags `%v` for fullIndex `%s`", rowTagsCache[fullIndex], fullIndex)
 			}
 			rowTags := rowTagsCache[fullIndex]
 			ms.sendMetric(symbol.Name, value, rowTags, metricConfig.ForcedType, metricConfig.Options, symbol.ExtractValuePattern)

--- a/pkg/collector/corechecks/snmp/report/report_metrics_test.go
+++ b/pkg/collector/corechecks/snmp/report/report_metrics_test.go
@@ -305,66 +305,6 @@ func Test_metricSender_reportMetrics(t *testing.T) {
 				{"[DEBUG] reportScalarMetrics: report scalar: error getting scalar value: value for Scalar OID `1.2.3.4.5` not found in results", 1},
 			},
 		},
-		{
-			name: "report column error",
-			metrics: []checkconfig.MetricsConfig{
-				{
-					ForcedType: "monotonic_count",
-					Symbols: []checkconfig.SymbolConfig{
-						{OID: "1.3.6.1.2.1.2.2.1.14", Name: "ifInErrors"},
-						{OID: "1.3.6.1.2.1.2.2.1.13", Name: "ifInDiscards"},
-					},
-					MetricTags: []checkconfig.MetricTagConfig{
-						{Tag: "interface", Column: checkconfig.SymbolConfig{OID: "1.3.6.1.2.1.31.1.1.1.1", Name: "ifName"}},
-						{Tag: "interface_alias", Column: checkconfig.SymbolConfig{OID: "1.3.6.1.2.1.31.1.1.1.18", Name: "ifAlias"}},
-					},
-				},
-			},
-			values: &valuestore.ResultValueStore{},
-			expectedLogs: []logCount{
-				{"[DEBUG] reportColumnMetrics: report column: error getting column value: value for Column OID `1.3.6.1.2.1.2.2.1.13` not found in results", 1},
-				{"[DEBUG] reportColumnMetrics: report column: error getting column value: value for Column OID `1.3.6.1.2.1.2.2.1.14` not found in results", 1},
-			},
-		},
-		{
-			name: "report column cache",
-			metrics: []checkconfig.MetricsConfig{
-				{
-					ForcedType: "monotonic_count",
-					Symbols: []checkconfig.SymbolConfig{
-						{OID: "1.3.6.1.2.1.2.2.1.14", Name: "ifInErrors"},
-						{OID: "1.3.6.1.2.1.2.2.1.13", Name: "ifInDiscards"},
-					},
-					MetricTags: []checkconfig.MetricTagConfig{
-						{Tag: "interface", Column: checkconfig.SymbolConfig{OID: "1.3.6.1.2.1.31.1.1.1.1", Name: "ifName"}},
-					},
-				},
-			},
-			values: &valuestore.ResultValueStore{
-				ColumnValues: valuestore.ColumnResultValuesType{
-					"1.3.6.1.2.1.2.2.1.14": map[string]valuestore.ResultValue{
-						"10": {
-							SubmissionType: "gauge",
-							Value:          10,
-						},
-					},
-					"1.3.6.1.2.1.2.2.1.13": map[string]valuestore.ResultValue{
-						"10": {
-							SubmissionType: "gauge",
-							Value:          10,
-						},
-					},
-					"1.3.6.1.2.1.31.1.1.1.1": map[string]valuestore.ResultValue{
-						"10": {
-							Value: "myIfName",
-						},
-					},
-				},
-			},
-			expectedLogs: []logCount{
-				{"[DEBUG] reportColumnMetrics: report column: caching tags `[interface:myIfName]` for fullIndex `10`", 1},
-			},
-		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -405,16 +345,14 @@ func Test_metricSender_getCheckInstanceMetricTags(t *testing.T) {
 		expectedLogs []logCount
 	}{
 		{
-			name: "report scalar error",
+			name: "no scalar oids found",
 			metricsTags: []checkconfig.MetricTagConfig{
 				{Tag: "my_symbol", OID: "1.2.3", Name: "mySymbol"},
 				{Tag: "snmp_host", OID: "1.3.6.1.2.1.1.5.0", Name: "sysName"},
 			},
-			values: &valuestore.ResultValueStore{},
-			expectedLogs: []logCount{
-				{"[DEBUG] GetCheckInstanceMetricTags: metric tags: error getting scalar value: value for Scalar OID `1.2.3` not found in results", 1},
-				{"[DEBUG] GetCheckInstanceMetricTags: metric tags: error getting scalar value: value for Scalar OID `1.3.6.1.2.1.1.5.0` not found in results", 1},
-			},
+			values:       &valuestore.ResultValueStore{},
+			expectedTags: []string{},
+			expectedLogs: []logCount{},
 		},
 		{
 			name: "report scalar tags with regex",

--- a/pkg/collector/corechecks/snmp/valuestore/value.go
+++ b/pkg/collector/corechecks/snmp/valuestore/value.go
@@ -8,8 +8,8 @@ import (
 
 // ResultValue represent a snmp value
 type ResultValue struct {
-	SubmissionType string      // used when sending the metric
-	Value          interface{} // might be a `string` or `float64` type
+	SubmissionType string      `json:"sub_type,omitempty"` // used when sending the metric
+	Value          interface{} `json:"value"`              // might be a `string` or `float64` type
 }
 
 // ToFloat64 converts value to float64

--- a/pkg/collector/corechecks/snmp/valuestore/values.go
+++ b/pkg/collector/corechecks/snmp/valuestore/values.go
@@ -131,11 +131,15 @@ func (v *ResultValueStore) GetColumnIndexes(columnOid string) ([]string, error) 
 	return indexes, nil
 }
 
-// ResultValueStoreAsString used to format ResultValueStore for debug logging
+// ResultValueStoreAsString used to format ResultValueStore for debug/trace logging
 func ResultValueStoreAsString(values *ResultValueStore) string {
+	if values == nil {
+		return ""
+	}
 	jsonPayload, err := json.Marshal(values)
 	if err != nil {
 		log.Debugf("error marshaling debugVar: %s", err)
+		return ""
 	}
 	return string(jsonPayload)
 }

--- a/pkg/collector/corechecks/snmp/valuestore/values.go
+++ b/pkg/collector/corechecks/snmp/valuestore/values.go
@@ -1,7 +1,9 @@
 package valuestore
 
 import (
+	"encoding/json"
 	"fmt"
+	"github.com/cihub/seelog"
 	"sort"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -21,8 +23,8 @@ type ScalarResultValuesType map[string]ResultValue
 // ResultValueStore store OID values
 type ResultValueStore struct {
 	// TODO: make fields private + use a constructor instead
-	ScalarValues ScalarResultValuesType
-	ColumnValues ColumnResultValuesType
+	ScalarValues ScalarResultValuesType `json:"scalar_values"`
+	ColumnValues ColumnResultValuesType `json:"column_values"`
 }
 
 // GetScalarValue look for oid in ResultValueStore and returns the value and boolean
@@ -128,4 +130,16 @@ func (v *ResultValueStore) GetColumnIndexes(columnOid string) ([]string, error) 
 
 	sort.Strings(indexes) // sort indexes for better consistency
 	return indexes, nil
+}
+
+// ResultValueStoreAsStringIfLoglevel used to format ResultValueStore for debug logging
+func ResultValueStoreAsStringIfLoglevel(values *ResultValueStore, logLevel seelog.LogLevel) string {
+	if curLogLevel, err := log.GetLogLevel(); err != nil || curLogLevel <= logLevel {
+		jsonPayload, err := json.Marshal(values)
+		if err != nil {
+			log.Debugf("error marshaling debugVar: %s", err)
+		}
+		return string(jsonPayload)
+	}
+	return ""
 }

--- a/pkg/collector/corechecks/snmp/valuestore/values.go
+++ b/pkg/collector/corechecks/snmp/valuestore/values.go
@@ -3,8 +3,9 @@ package valuestore
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/cihub/seelog"
 	"sort"
+
+	"github.com/cihub/seelog"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )

--- a/pkg/collector/corechecks/snmp/valuestore/values.go
+++ b/pkg/collector/corechecks/snmp/valuestore/values.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/cihub/seelog"
-
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -133,14 +131,11 @@ func (v *ResultValueStore) GetColumnIndexes(columnOid string) ([]string, error) 
 	return indexes, nil
 }
 
-// ResultValueStoreAsStringIfLoglevel used to format ResultValueStore for debug logging
-func ResultValueStoreAsStringIfLoglevel(values *ResultValueStore, logLevel seelog.LogLevel) string {
-	if curLogLevel, err := log.GetLogLevel(); err != nil || curLogLevel <= logLevel {
-		jsonPayload, err := json.Marshal(values)
-		if err != nil {
-			log.Debugf("error marshaling debugVar: %s", err)
-		}
-		return string(jsonPayload)
+// ResultValueStoreAsString used to format ResultValueStore for debug logging
+func ResultValueStoreAsString(values *ResultValueStore) string {
+	jsonPayload, err := json.Marshal(values)
+	if err != nil {
+		log.Debugf("error marshaling debugVar: %s", err)
 	}
-	return ""
+	return string(jsonPayload)
 }

--- a/pkg/collector/corechecks/snmp/valuestore/values_test.go
+++ b/pkg/collector/corechecks/snmp/valuestore/values_test.go
@@ -73,4 +73,8 @@ func TestResultValueStoreAsString(t *testing.T) {
 	}
 	str := ResultValueStoreAsString(store)
 	assert.Equal(t, "{\"scalar_values\":{\"1.1.1.1.0\":{\"value\":10}},\"column_values\":{\"1.1.1\":{\"1\":{\"value\":10}}}}", str)
+
+	str = ResultValueStoreAsString(nil)
+	assert.Equal(t, "", str)
+
 }

--- a/pkg/collector/corechecks/snmp/valuestore/values_test.go
+++ b/pkg/collector/corechecks/snmp/valuestore/values_test.go
@@ -59,3 +59,18 @@ func Test_resultValueStore_GetColumnIndexes(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []string{"1", "2", "3"}, indexes)
 }
+
+func TestResultValueStoreAsString(t *testing.T) {
+	store := &ResultValueStore{
+		ScalarValues: ScalarResultValuesType{
+			"1.1.1.1.0": {Value: float64(10)}, // a float value
+		},
+		ColumnValues: ColumnResultValuesType{
+			"1.1.1": {
+				"1": ResultValue{Value: float64(10)}, // a float value
+			},
+		},
+	}
+	str := ResultValueStoreAsString(store)
+	assert.Equal(t, "{\"scalar_values\":{\"1.1.1.1.0\":{\"value\":10}},\"column_values\":{\"1.1.1\":{\"1\":{\"value\":10}}}}", str)
+}


### PR DESCRIPTION
### What does this PR do?

[corechecks/snmp] Improve snmp integrations debug logs
- Use `GetValueFromPDU` to convert snmp types into human readable types (instead of e.g. []bytes)
- Use json as output for snmp values/results

Using json as output for snmp values/results have some advantages:
- Well structure
- Very readable
- Easy to reformat json using text editors to make it more readable (example below). Especially when logging the whole valuestore.

This log line:
```
2021-10-12 17:52:16 CEST | CORE | DEBUG | (pkg/collector/corechecks/snmp/fetch/fetch_scalar.go:124 in doDoFetchScalarOids) | fetch scalar: results: error=NoError(code:0, idx:0), values=[{"oid":".1.3.6.1.2.1.6.18.0","type":"NoSuchInstance","value":"\u003cnil\u003e","parse_err":"`oid .1.3.6.1.2.1.6.18.0: invalid type: NoSuchInstance`"},{"oid":".1.3.6.1.2.1.6.12.0","type":"Counter32","value":"0"},{"oid":".1.3.6.1.2.1.6.14.0","type":"Counter32","value":"0"},{"oid":".1.3.6.1.2.1.6.15.0","type":"Counter32","value":"0"},{"oid":".1.3.6.1.2.1.7.8.0","type":"NoSuchInstance","value":"\u003cnil\u003e","parse_err":"`oid .1.3.6.1.2.1.7.8.0: invalid type: NoSuchInstance`"}]
```

Can be formatted as
```
[
    {
        "oid": ".1.3.6.1.2.1.6.18.0",
        "parse_err": "`oid .1.3.6.1.2.1.6.18.0: invalid type: NoSuchInstance`",
        "type": "NoSuchInstance",
        "value": "<nil>"
    },
    {
        "oid": ".1.3.6.1.2.1.6.12.0",
        "type": "Counter32",
        "value": "0"
    },
    {
        "oid": ".1.3.6.1.2.1.6.14.0",
        "type": "Counter32",
        "value": "0"
    },
    {
        "oid": ".1.3.6.1.2.1.6.15.0",
        "type": "Counter32",
        "value": "0"
    },
    {
        "oid": ".1.3.6.1.2.1.7.8.0",
        "parse_err": "`oid .1.3.6.1.2.1.7.8.0: invalid type: NoSuchInstance`",
        "type": "NoSuchInstance",
        "value": "<nil>"
    }
]
```

### Motivation

More readable and useful debug logs

### Additional Notes


### Describe how to test your changes

- Verify logging works by using multiple log level e.g. info/debug/trace

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
