### PR TITLE
[cli] Fix check worker count in `agent status`

### DIFF
--- a/pkg/status/templates/header.tmpl
+++ b/pkg/status/templates/header.tmpl
@@ -14,8 +14,8 @@ NOTE: Changes made to this template should be reflected on the following templat
   {{- end }}
   Build arch: {{.build_arch}}
   Agent flavor: {{.flavor}}
-  {{- if .runnerStats.Workers}}
-  Check Runners: {{.runnerStats.Workers}}
+  {{- if and (.runnerStats.Workers) (.runnerStats.Workers.Count) }}
+  Check Runners: {{.runnerStats.Workers.Count}}
   {{- end }}
   {{- if .config.log_file}}
   Log File: {{.config.log_file}}


### PR DESCRIPTION
### What does this PR do?

After implementation of runner utilization tracking, the expvar
`Workers` changed its structure but the `agent status` template
was still pointing to the old value. This change fixes the template
and the reported value.

### Motivation

Regression in the expected value of this field.

### Additional Notes

N/A

### Describe how to test your changes

- Run `agent status`
- Ensure that `Check Runner` field reports an integer value

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
