### PR TITLE
[runtime-security] allow approver on pattern with static basename

### DIFF
--- a/pkg/security/probe/capabilities.go
+++ b/pkg/security/probe/capabilities.go
@@ -8,6 +8,9 @@
 package probe
 
 import (
+	"path"
+	"strings"
+
 	"github.com/DataDog/datadog-agent/pkg/security/rules"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/eval"
 )
@@ -19,6 +22,7 @@ var allCapabilities = make(map[eval.EventType]Capabilities)
 type Capability struct {
 	PolicyFlags     PolicyFlag
 	FieldValueTypes eval.FieldValueType
+	ValidateFnc     func(value rules.FilterValue) bool
 }
 
 // Capabilities represents the filtering capabilities for a set of fields
@@ -50,19 +54,35 @@ func (caps Capabilities) GetFieldCapabilities() rules.FieldCapabilities {
 
 	for field, cap := range caps {
 		fcs = append(fcs, rules.FieldCapability{
-			Field: field,
-			Types: cap.FieldValueTypes,
+			Field:       field,
+			Types:       cap.FieldValueTypes,
+			ValidateFnc: cap.ValidateFnc,
 		})
 	}
 
 	return fcs
 }
 
+func validateBasenameFilter(value rules.FilterValue) bool {
+	switch value.Type {
+	case eval.ScalarValueType:
+		return true
+	case eval.PatternValueType:
+		basename := path.Base(value.Value.(string))
+		if !strings.Contains(basename, "*") {
+			return true
+		}
+	}
+
+	return false
+}
+
 func oneBasenameCapabilities(event string) Capabilities {
 	return Capabilities{
 		event + ".file.path": {
 			PolicyFlags:     PolicyFlagBasename,
-			FieldValueTypes: eval.ScalarValueType,
+			FieldValueTypes: eval.ScalarValueType | eval.PatternValueType,
+			ValidateFnc:     validateBasenameFilter,
 		},
 		event + ".file.name": {
 			PolicyFlags:     PolicyFlagBasename,
@@ -75,7 +95,8 @@ func twoBasenameCapabilities(event string, field1, field2 string) Capabilities {
 	return Capabilities{
 		event + "." + field1 + ".path": {
 			PolicyFlags:     PolicyFlagBasename,
-			FieldValueTypes: eval.ScalarValueType,
+			FieldValueTypes: eval.ScalarValueType | eval.PatternValueType,
+			ValidateFnc:     validateBasenameFilter,
 		},
 		event + "." + field1 + ".name": {
 			PolicyFlags:     PolicyFlagBasename,
@@ -83,7 +104,8 @@ func twoBasenameCapabilities(event string, field1, field2 string) Capabilities {
 		},
 		event + "." + field2 + ".path": {
 			PolicyFlags:     PolicyFlagBasename,
-			FieldValueTypes: eval.ScalarValueType,
+			FieldValueTypes: eval.ScalarValueType | eval.PatternValueType,
+			ValidateFnc:     validateBasenameFilter,
 		},
 		event + "." + field2 + ".name": {
 			PolicyFlags:     PolicyFlagBasename,

--- a/pkg/security/probe/open.go
+++ b/pkg/security/probe/open.go
@@ -18,7 +18,8 @@ import (
 var openCapabilities = Capabilities{
 	"open.file.path": {
 		PolicyFlags:     PolicyFlagBasename,
-		FieldValueTypes: eval.ScalarValueType,
+		FieldValueTypes: eval.ScalarValueType | eval.PatternValueType,
+		ValidateFnc:     validateBasenameFilter,
 	},
 	"open.file.name": {
 		PolicyFlags:     PolicyFlagBasename,

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -261,7 +261,8 @@ func (p *Probe) sendDiscardersStats() {
 	for eventType, value := range p.inodeDiscardersCounters {
 		val := atomic.SwapInt64(value, 0)
 		if val > 0 {
-			_ = p.statsdClient.Count(metrics.MetricInodeDiscardersAdded, val, []string{eventType.String()}, 1.0)
+			tag := fmt.Sprintf("event_type:%s", eventType)
+			_ = p.statsdClient.Count(metrics.MetricInodeDiscardersAdded, val, []string{tag}, 1.0)
 		}
 	}
 }

--- a/pkg/security/rules/capabilities.go
+++ b/pkg/security/rules/capabilities.go
@@ -14,8 +14,9 @@ type FieldCapabilities []FieldCapability
 
 // FieldCapability represents a field and the type of its value (scalar, pattern, bitmask, ...)
 type FieldCapability struct {
-	Field eval.Field
-	Types eval.FieldValueType
+	Field       eval.Field
+	Types       eval.FieldValueType
+	ValidateFnc func(FilterValue) bool
 }
 
 // GetFields returns all the fields of FieldCapabilities
@@ -38,6 +39,12 @@ func (fcs FieldCapabilities) Validate(approvers map[eval.Field]FilterValues) boo
 		for _, value := range values {
 			if value.Type&fc.Types == 0 {
 				return false
+			}
+
+			if fc.ValidateFnc != nil {
+				if !fc.ValidateFnc(value) {
+					return false
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

This PR allow basename approvers on pattern if the pattern doesn't end up with a wildcard.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
