### PR TITLE
[runtime-security] add inode discarders metric

### DIFF
--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -64,6 +64,11 @@ var (
 	// Tags: ret
 	MetricDentryERPC = newRuntimeMetric(".dentry_resolver.erpc")
 
+	// filtering metrics
+
+	// MetricInodeDiscardersAdded is the number of inode discarder added
+	MetricInodeDiscardersAdded = newRuntimeMetric(".discarders.inode.added")
+
 	// Perf buffer metrics
 
 	// MetricPerfBufferLostWrite is the name of the metric used to count the number of lost events, as reported by a

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -354,10 +354,13 @@ func filenameDiscarderWrapper(eventType model.EventType, handler onDiscarderHand
 					seclog.Tracef("Apply `%s.file.path` inode discarder for event `%s`, inode: %d(%s)", eventType, eventType, inode, filename)
 
 					// not able to discard the parent then only discard the filename
-					err = probe.inodeDiscarders.discardInode(eventType, mountID, inode, true)
+					if err = probe.inodeDiscarders.discardInode(eventType, mountID, inode, true); err == nil {
+						probe.countNewInodeDiscarder(eventType)
+					}
 				}
-			} else {
+			} else if !isDeleted {
 				seclog.Tracef("Apply `%s.file.path` parent inode discarder for event `%s`, inode: %d(%s)", eventType, eventType, parentInode, filename)
+				probe.countNewInodeDiscarder(eventType)
 			}
 
 			if err != nil {

--- a/pkg/security/probe/kfilters_test.go
+++ b/pkg/security/probe/kfilters_test.go
@@ -156,6 +156,13 @@ func TestIsParentDiscarder(t *testing.T) {
 	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileOpenEventType, "open.file.path", "/tmp/runc"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
+
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	addRuleExpr(t, rs, `open.file.path =~ "/run/secrets/kubernetes.io/serviceaccount/*/token"`, `open.file.path == "/etc/secret"`)
+
+	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileOpenEventType, "open.file.path", "/tmp/token"); !is {
+		t.Error("should be a parent discarder")
+	}
 }
 
 func TestApproverAncestors1(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Add metrics to evaluate the number of discarders being pushed in the kernel.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
