### PR TITLE
(rc) codeowners for remote-config

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -165,6 +165,7 @@
 /pkg/config/apm.go                      @DataDog/agent-apm
 /pkg/config/environment*.go             @DataDog/container-integrations @DataDog/container-app
 /pkg/config/system_probe.go             @DataDog/agent-network
+/pkg/config/remote/                     @DataDog/remote-config
 /pkg/otlp/                              @DataDog/agent-platform
 /pkg/tagger/                            @DataDog/container-integrations
 /pkg/tagger/collectors/garden*.go       @DataDog/integrations-tools-and-libraries

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -166,6 +166,7 @@
 /pkg/config/environment*.go             @DataDog/container-integrations @DataDog/container-app
 /pkg/config/system_probe.go             @DataDog/agent-network
 /pkg/config/remote/                     @DataDog/remote-config
+/pkg/config/remote/service/meta/        @DataDog/remote-config @DataDog/software-integrity-and-trust
 /pkg/otlp/                              @DataDog/agent-platform
 /pkg/tagger/                            @DataDog/container-integrations
 /pkg/tagger/collectors/garden*.go       @DataDog/integrations-tools-and-libraries


### PR DESCRIPTION
### What does this PR do?

Adds remote-config to github's CODEOWNERS