### PR TITLE
Remove unused embedded interface

### DIFF
--- a/pkg/logs/decoder/matcher.go
+++ b/pkg/logs/decoder/matcher.go
@@ -22,7 +22,6 @@ type EndLineMatcher interface {
 
 // NewLineMatcher implements EndLineMatcher for line ending with '\n'
 type NewLineMatcher struct {
-	EndLineMatcher
 }
 
 // Match returns true whenever a '\n' (newline) is met.


### PR DESCRIPTION
The syntax

```go
type struct NewLineMatcher {
    EndLineMatcher
}
```

where EndLineMatcher is an interface type, simply embeds a
EndLineMatcher into Foo.  In this case, that embedded EndLineMatcher is
never initialized, so calling any of its methods would fail with a
segfault.  But all of its methods are redefined for NewLineMatcher
anyway.  So the interface is just a wasted 16 bytes of 0's.

### Describe how to test your changes

If it compiles..