### PR TITLE
[gitlab] Make sure latest oldnightly MSIs don't overwrite latest nightly MSIs

### DIFF
--- a/.gitlab/deploy_6/windows.yml
+++ b/.gitlab/deploy_6/windows.yml
@@ -9,6 +9,7 @@ deploy_staging_windows_master-a6:
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
+    - if [ "$DEB_RPM_BUCKET_BRANCH" = "oldnightly" ]; then BUCKET_BRANCH="oldnightly"; else BUCKET_BRANCH="master"; fi
     - $S3_CP_CMD
       --recursive
       --exclude "*"
@@ -16,7 +17,7 @@ deploy_staging_windows_master-a6:
       --include "datadog-agent-6*.debug.zip"
       --include "datadog-agent-6.*.wixpdb"
       --include "customaction-6*.pdb"
-      $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/master/
+      $OMNIBUS_PACKAGE_DIR s3://$WINDOWS_BUILDS_S3_BUCKET/$BUCKET_BRANCH/
       --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
       full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
@@ -30,9 +31,10 @@ deploy_staging_windows_master-latest-a6:
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
+    - if [ "$DEB_RPM_BUCKET_BRANCH" = "oldnightly" ]; then BUCKET_BRANCH="oldnightly"; else BUCKET_BRANCH="master"; fi
     - $S3_CP_CMD
       $OMNIBUS_PACKAGE_DIR/datadog-agent-6*-x86_64.msi
-      "s3://$WINDOWS_BUILDS_S3_BUCKET/master/datadog-agent-6-latest.amd64.msi"
+      "s3://$WINDOWS_BUILDS_S3_BUCKET/$BUCKET_BRANCH/datadog-agent-6-latest.amd64.msi"
       --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
       full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 

--- a/.gitlab/deploy_7/windows.yml
+++ b/.gitlab/deploy_7/windows.yml
@@ -9,6 +9,7 @@ deploy_staging_windows_master-a7:
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
+    - if [ "$DEB_RPM_BUCKET_BRANCH" = "oldnightly" ]; then BUCKET_BRANCH="oldnightly"; else BUCKET_BRANCH="master"; fi
     - $S3_CP_CMD
       --recursive
       --exclude "*"
@@ -17,7 +18,7 @@ deploy_staging_windows_master-a7:
       --include "datadog-agent-7*.wixpdb"
       --include "customaction-7*.pdb"
       $OMNIBUS_PACKAGE_DIR
-      s3://$WINDOWS_BUILDS_S3_BUCKET/master/
+      s3://$WINDOWS_BUILDS_S3_BUCKET/$BUCKET_BRANCH/
       --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
       full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
@@ -31,9 +32,10 @@ deploy_staging_windows_master-latest-a7:
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
+    - if [ "$DEB_RPM_BUCKET_BRANCH" = "oldnightly" ]; then BUCKET_BRANCH="oldnightly"; else BUCKET_BRANCH="master"; fi
     - $S3_CP_CMD
       $OMNIBUS_PACKAGE_DIR/datadog-agent-7*-x86_64.msi
-      "s3://$WINDOWS_BUILDS_S3_BUCKET/master/datadog-agent-7-latest.amd64.msi"
+      "s3://$WINDOWS_BUILDS_S3_BUCKET/$BUCKET_BRANCH/datadog-agent-7-latest.amd64.msi"
       --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
       full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 


### PR DESCRIPTION
### What does this PR do?

Without this patch, MSIs from both `oldnightly` and `nightly` overwrite the same `latest` msi, which causes it to flip between two different versions. This patch ensures that only the `nightly` builds write to `master` and `oldnightly` get their separate namespace.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
