### PR TITLE
[runtime-security] Fix 5.11+ kernels compatibility

### DIFF
--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -561,4 +561,25 @@ static __attribute__((always_inline)) u64 get_vfs_removexattr_dentry_position() 
     return vfs_removexattr_dentry_position;
 }
 
+#define VFS_RENAME_REGISTER_INPUT 1
+#define VFS_RENAME_STRUCT_INPUT   2
+
+static __attribute__((always_inline)) u64 get_vfs_rename_input_type() {
+    u64 vfs_rename_input_type;
+    LOAD_CONSTANT("vfs_rename_input_type", vfs_rename_input_type);
+    return vfs_rename_input_type;
+}
+
+static __attribute__((always_inline)) u64 get_vfs_rename_src_dentry_offset() {
+    u64 offset;
+    LOAD_CONSTANT("vfs_rename_src_dentry_offset", offset);
+    return offset ? offset : 16; // offsetof(struct renamedata, old_dentry)
+}
+
+static __attribute__((always_inline)) u64 get_vfs_rename_target_dentry_offset() {
+    u64 offset;
+    LOAD_CONSTANT("vfs_rename_target_dentry_offset", offset);
+    return offset ? offset : 40; // offsetof(struct renamedata, new_dentry)
+}
+
 #endif

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -524,4 +524,41 @@ static __attribute__((always_inline)) void add_event_to_mask(u64 *mask, enum eve
     *mask |= 1 << (event - EVENT_FIRST_DISCARDER);
 }
 
+#define VFS_ARG_POSITION1 1
+#define VFS_ARG_POSITION2 2
+#define VFS_ARG_POSITION3 3
+#define VFS_ARG_POSITION4 4
+#define VFS_ARG_POSITION5 5
+#define VFS_ARG_POSITION6 6
+
+static __attribute__((always_inline)) u64 get_vfs_unlink_dentry_position() {
+    u64 vfs_unlink_dentry_position;
+    LOAD_CONSTANT("vfs_unlink_dentry_position", vfs_unlink_dentry_position);
+    return vfs_unlink_dentry_position;
+}
+
+static __attribute__((always_inline)) u64 get_vfs_mkdir_dentry_position() {
+    u64 vfs_mkdir_dentry_position;
+    LOAD_CONSTANT("vfs_mkdir_dentry_position", vfs_mkdir_dentry_position);
+    return vfs_mkdir_dentry_position;
+}
+
+static __attribute__((always_inline)) u64 get_vfs_link_target_dentry_position() {
+    u64 vfs_link_target_dentry_position;
+    LOAD_CONSTANT("vfs_link_target_dentry_position", vfs_link_target_dentry_position);
+    return vfs_link_target_dentry_position;;
+}
+
+static __attribute__((always_inline)) u64 get_vfs_setxattr_dentry_position() {
+    u64 vfs_setxattr_dentry_position;
+    LOAD_CONSTANT("vfs_setxattr_dentry_position", vfs_setxattr_dentry_position);
+    return vfs_setxattr_dentry_position;
+}
+
+static __attribute__((always_inline)) u64 get_vfs_removexattr_dentry_position() {
+    u64 vfs_removexattr_dentry_position;
+    LOAD_CONSTANT("vfs_removexattr_dentry_position", vfs_removexattr_dentry_position);
+    return vfs_removexattr_dentry_position;
+}
+
 #endif

--- a/pkg/security/ebpf/c/unlink.h
+++ b/pkg/security/ebpf/c/unlink.h
@@ -41,9 +41,6 @@ SYSCALL_KPROBE3(unlinkat, int, dirfd, const char*, filename, int, flags) {
     return trace__sys_unlink(flags);
 }
 
-#define VFS_UNLINK_POSITION2 1
-#define VFS_UNLINK_POSITION3 2
-
 SEC("kprobe/vfs_unlink")
 int kprobe_vfs_unlink(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_UNLINK);
@@ -54,16 +51,11 @@ int kprobe_vfs_unlink(struct pt_regs *ctx) {
         return 0;
     }
 
-    u64 vfs_unlink_dentry_position;
-    LOAD_CONSTANT("vfs_unlink_dentry_position", vfs_unlink_dentry_position);
-
     struct dentry *dentry = (struct dentry *) PT_REGS_PARM2(ctx);
-
-    // prevent a verifier bug
-    bpf_probe_read(&dentry, sizeof(dentry), &dentry);
-
     // change the register based on the value of vfs_unlink_dentry_position
-    if (vfs_unlink_dentry_position == VFS_UNLINK_POSITION3) {
+    if (get_vfs_unlink_dentry_position() == VFS_ARG_POSITION3) {
+        // prevent the verifier from whining
+        bpf_probe_read(&dentry, sizeof(dentry), &dentry);
         dentry = (struct dentry *) PT_REGS_PARM3(ctx);
     }
 

--- a/pkg/security/probe/mount_resolver.go
+++ b/pkg/security/probe/mount_resolver.go
@@ -419,6 +419,46 @@ func getSuperBlockMagicOffset(probe *Probe) uint64 {
 }
 
 func getVFSLinkDentryPosition(probe *Probe) uint64 {
+	position := uint64(2)
+
+	if probe.kernelVersion.Code != 0 && probe.kernelVersion.Code >= skernel.Kernel5_12 {
+		position = 3
+	}
+
+	return position
+}
+
+func getVFSMKDirDentryPosition(probe *Probe) uint64 {
+	position := uint64(2)
+
+	if probe.kernelVersion.Code != 0 && probe.kernelVersion.Code >= skernel.Kernel5_12 {
+		position = 3
+	}
+
+	return position
+}
+
+func getVFSLinkTargetDentryPosition(probe *Probe) uint64 {
+	position := uint64(3)
+
+	if probe.kernelVersion.Code != 0 && probe.kernelVersion.Code >= skernel.Kernel5_12 {
+		position = 4
+	}
+
+	return position
+}
+
+func getVFSSetxattrDentryPosition(probe *Probe) uint64 {
+	position := uint64(1)
+
+	if probe.kernelVersion.Code != 0 && probe.kernelVersion.Code >= skernel.Kernel5_12 {
+		position = 2
+	}
+
+	return position
+}
+
+func getVFSRemovexattrDentryPosition(probe *Probe) uint64 {
 	position := uint64(1)
 
 	if probe.kernelVersion.Code != 0 && probe.kernelVersion.Code >= skernel.Kernel5_12 {

--- a/pkg/security/probe/mount_resolver.go
+++ b/pkg/security/probe/mount_resolver.go
@@ -468,6 +468,16 @@ func getVFSRemovexattrDentryPosition(probe *Probe) uint64 {
 	return position
 }
 
+func getVFSRenameInputType(probe *Probe) uint64 {
+	inputType := uint64(1)
+
+	if probe.kernelVersion.Code != 0 && probe.kernelVersion.Code >= skernel.Kernel5_12 {
+		inputType = 2
+	}
+
+	return inputType
+}
+
 // NewMountResolver instantiates a new mount resolver
 func NewMountResolver(probe *Probe) *MountResolver {
 	return &MountResolver{

--- a/pkg/security/probe/mount_resolver.go
+++ b/pkg/security/probe/mount_resolver.go
@@ -401,6 +401,8 @@ func getSizeOfStructInode(probe *Probe) uint64 {
 		sizeOf = 608
 	case skernel.Kernel5_0 <= probe.kernelVersion.Code && probe.kernelVersion.Code < skernel.Kernel5_1:
 		sizeOf = 584
+	case probe.kernelVersion.Code != 0 && probe.kernelVersion.Code >= skernel.Kernel5_13:
+		sizeOf = 592
 	}
 
 	return sizeOf
@@ -414,6 +416,16 @@ func getSuperBlockMagicOffset(probe *Probe) uint64 {
 	}
 
 	return sizeOf
+}
+
+func getVFSLinkDentryPosition(probe *Probe) uint64 {
+	position := uint64(1)
+
+	if probe.kernelVersion.Code != 0 && probe.kernelVersion.Code >= skernel.Kernel5_12 {
+		position = 2
+	}
+
+	return position
 }
 
 // NewMountResolver instantiates a new mount resolver

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -916,6 +916,10 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 			Name:  "getattr2",
 			Value: getAttr2(p),
 		},
+		manager.ConstantEditor{
+			Name:  "vfs_unlink_dentry_position",
+			Value: getVFSLinkDentryPosition(p),
+		},
 	)
 	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, TTYConstants(p)...)
 	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, DiscarderConstants...)

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -936,6 +936,10 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 			Name:  "vfs_removexattr_dentry_position",
 			Value: getVFSRemovexattrDentryPosition(p),
 		},
+		manager.ConstantEditor{
+			Name:  "vfs_rename_input_type",
+			Value: getVFSRenameInputType(p),
+		},
 	)
 	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, TTYConstants(p)...)
 	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, DiscarderConstants...)

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -920,6 +920,22 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 			Name:  "vfs_unlink_dentry_position",
 			Value: getVFSLinkDentryPosition(p),
 		},
+		manager.ConstantEditor{
+			Name:  "vfs_mkdir_dentry_position",
+			Value: getVFSMKDirDentryPosition(p),
+		},
+		manager.ConstantEditor{
+			Name:  "vfs_link_target_dentry_position",
+			Value: getVFSLinkTargetDentryPosition(p),
+		},
+		manager.ConstantEditor{
+			Name:  "vfs_setxattr_dentry_position",
+			Value: getVFSSetxattrDentryPosition(p),
+		},
+		manager.ConstantEditor{
+			Name:  "vfs_removexattr_dentry_position",
+			Value: getVFSRemovexattrDentryPosition(p),
+		},
 	)
 	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, TTYConstants(p)...)
 	p.managerOptions.ConstantEditors = append(p.managerOptions.ConstantEditors, DiscarderConstants...)

--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -202,7 +202,7 @@ func TestOpen(t *testing.T) {
 	t.Run("io_uring", func(t *testing.T) {
 		defer os.Remove(testFile)
 
-		test.WaitSignal(t, func() error {
+		err = test.GetSignal(t, func() error {
 			f, err := os.OpenFile(testFile, os.O_RDWR|os.O_CREATE, 0755)
 			if err != nil {
 				return err
@@ -211,6 +211,10 @@ func TestOpen(t *testing.T) {
 		}, func(event *sprobe.Event, r *rules.Rule) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 		})
+		if err != nil {
+			// if the file was not created, we can't open it with io_uring
+			t.Fatal(err)
+		}
 
 		iour, err := iouring.New(1)
 		if err != nil {

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -59,7 +59,7 @@
                 "ubuntu-18-04-3": "urn,Canonical:UbuntuServer:18.04-LTS:18.04.201912180",
                 "ubuntu-20-04": "urn,Canonical:0001-com-ubuntu-server-focal:20_04-lts:20.04.202004230",
                 "ubuntu-20-04-2": "urn,Canonical:0001-com-ubuntu-server-focal:20_04-lts:20.04.202107200",
-                "ubuntu-21-10": "urn,Canonical:0001-com-ubuntu-server-impish-daily:21_10-daily:21.10.202109040"
+                "ubuntu-21-10": "urn,Canonical:0001-com-ubuntu-server-impish-daily:21_10-daily:21.10.202110040"
             }
         },
         "ec2": {


### PR DESCRIPTION
### What does this PR do?

This PR fixes some compatibility issues with 5.11+ kernels.

### Motivation

The latest release of Ubuntu (Ubuntu Impish) will run a 5.12 kernel, this PR ensures that CWS will work on this new kernel.

### Describe how to test your changes

The Ubuntu Impish VM was updated to the latest current RC.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
