### PR TITLE
[Appveyor] Add `--rerun-fails=2`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -46,7 +46,7 @@ test_script:
   - inv -e rtloader.install
   - inv -e rtloader.format --raise-if-changed
   - inv -e rtloader.test
-  - inv -e test --python-runtimes 3 --coverage --profile --fail-on-fmt --python-home-2=%Python2_ROOT_DIR% --python-home-3=%Python3_ROOT_DIR%
+  - inv -e test --rerun-fails=2 --python-runtimes 3 --coverage --profile --fail-on-fmt --python-home-2=%Python2_ROOT_DIR% --python-home-3=%Python3_ROOT_DIR%
   - codecov -f profile.cov -F windows
 
 # uncomment to debug builds


### PR DESCRIPTION
### What does this PR do?

Add `--rerun-fails=2` to test task.

### Motivation

- Be consistent with other CI providers.
- Reduce flakiness.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
