### PR TITLE
Adds a colon to the end of process_discovery

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1131,7 +1131,7 @@ api_key:
 
   ## @param process_discovery - custom object - optional
   ## Specifies custom settings for the `process_discovery` object.
-  # process_discovery
+  # process_discovery:
       ## @param enabled - boolean - optional - default: false
       ## Toggles the `process_discovery` check. If enabled, this check gathers information about possible running integrations.
       ## This check is experimental.


### PR DESCRIPTION

### What does this PR do?
This ensures that if the customer uncomments the yaml file, it will be valid syntax

### Motivation
The config for process_discovery didn't have a colon at the end of the key, and wouldn't be valid syntax. 

### Additional Notes

### Describe how to test your changes
No testing needed

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
