### PR TITLE
[DRAFT][corechecks/snmp] Fix metric_tags for profile.metric_tags / instances[].metric_tags

### DIFF
--- a/pkg/collector/corechecks/snmp/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config.go
@@ -65,24 +65,24 @@ type InitConfig struct {
 
 // InstanceConfig is used to deserialize integration instance config
 type InstanceConfig struct {
-	IPAddress             string            `yaml:"ip_address"`
-	Port                  Number            `yaml:"port"`
-	CommunityString       string            `yaml:"community_string"`
-	SnmpVersion           string            `yaml:"snmp_version"`
-	Timeout               Number            `yaml:"timeout"`
-	Retries               Number            `yaml:"retries"`
-	User                  string            `yaml:"user"`
-	AuthProtocol          string            `yaml:"authProtocol"`
-	AuthKey               string            `yaml:"authKey"`
-	PrivProtocol          string            `yaml:"privProtocol"`
-	PrivKey               string            `yaml:"privKey"`
-	ContextName           string            `yaml:"context_name"`
-	Metrics               []MetricsConfig   `yaml:"metrics"`     // SNMP metrics definition
-	MetricTags            []MetricTagConfig `yaml:"metric_tags"` // SNMP metric tags definition
-	Profile               string            `yaml:"profile"`
-	UseGlobalMetrics      bool              `yaml:"use_global_metrics"`
-	CollectDeviceMetadata *Boolean          `yaml:"collect_device_metadata"`
-	UseDeviceIDAsHostname *Boolean          `yaml:"use_device_id_as_hostname"`
+	IPAddress             string              `yaml:"ip_address"`
+	Port                  Number              `yaml:"port"`
+	CommunityString       string              `yaml:"community_string"`
+	SnmpVersion           string              `yaml:"snmp_version"`
+	Timeout               Number              `yaml:"timeout"`
+	Retries               Number              `yaml:"retries"`
+	User                  string              `yaml:"user"`
+	AuthProtocol          string              `yaml:"authProtocol"`
+	AuthKey               string              `yaml:"authKey"`
+	PrivProtocol          string              `yaml:"privProtocol"`
+	PrivKey               string              `yaml:"privKey"`
+	ContextName           string              `yaml:"context_name"`
+	Metrics               []MetricsConfig     `yaml:"metrics"`     // SNMP metrics definition
+	MetricTags            MetricTagConfigList `yaml:"metric_tags"` // SNMP metric tags definition
+	Profile               string              `yaml:"profile"`
+	UseGlobalMetrics      bool                `yaml:"use_global_metrics"`
+	CollectDeviceMetadata *Boolean            `yaml:"collect_device_metadata"`
+	UseDeviceIDAsHostname *Boolean            `yaml:"use_device_id_as_hostname"`
 
 	// ExtraTags is a workaround to pass tags from snmp listener to snmp integration via AD template
 	// (see cmd/agent/dist/conf.d/snmp.d/auto_conf.yaml) that only works with strings.

--- a/pkg/collector/corechecks/snmp/checkconfig/profile.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/profile.go
@@ -23,11 +23,11 @@ type deviceMeta struct {
 }
 
 type profileDefinition struct {
-	Metrics      []MetricsConfig   `yaml:"metrics"`
-	MetricTags   []MetricTagConfig `yaml:"metric_tags"`
-	Extends      []string          `yaml:"extends"`
-	Device       deviceMeta        `yaml:"device"`
-	SysObjectIds StringArray       `yaml:"sysobjectid"`
+	Metrics      []MetricsConfig     `yaml:"metrics"`
+	MetricTags   MetricTagConfigList `yaml:"metric_tags"`
+	Extends      []string            `yaml:"extends"`
+	Device       deviceMeta          `yaml:"device"`
+	SysObjectIds StringArray         `yaml:"sysobjectid"`
 }
 
 var defaultProfilesMu = &sync.Mutex{}


### PR DESCRIPTION
### What does this PR do?

A brief description of the change being made with this pull request.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
