### PR TITLE
[containerd] Choose default namespace according to env

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -506,8 +506,12 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("cri_query_timeout", int64(5))      // in seconds
 
 	// Containerd
-	// We only support containerd in Kubernetes. By default containerd cri uses `k8s.io` https://github.com/containerd/cri/blob/release/1.2/pkg/constants/constants.go#L22-L23
-	config.BindEnvAndSetDefault("containerd_namespace", "k8s.io")
+	if IsKubernetes() {
+		// By default containerd cri uses `k8s.io` https://github.com/containerd/cri/blob/release/1.2/pkg/constants/constants.go#L22-L23
+		config.BindEnvAndSetDefault("containerd_namespace", "k8s.io")
+	} else {
+		config.BindEnvAndSetDefault("containerd_namespace", "default")
+	}
 	config.BindEnvAndSetDefault("container_env_as_tags", map[string]string{})
 
 	// Kubernetes

--- a/releasenotes/notes/containerd-default-namespace-76dadef9a68eef74.yaml
+++ b/releasenotes/notes/containerd-default-namespace-76dadef9a68eef74.yaml
@@ -1,0 +1,4 @@
+enhancements:
+  - |
+    The default containerd namespace is now set according to the env where the
+    agent is deployed. "k8s.io" on Kubernetes and "default" otherwise.


### PR DESCRIPTION
### What does this PR do?

Sets the default containerd namespace according to the env where the agent is deployed: "k8s.io" on Kubernetes and "default" otherwise.

It was set to "k8s.io" always. This means that to use it outside Kubernetes, users needed to set `DD_CONTAINERD_NAMESPACE` to make it work. With this PR, it will work out of the box for users using the default namespace.

### Describe how to test your changes

1) Deploy in Kubernetes and check that containerd.* metrics are reported.
2) Deploy outside Kubernetes and check that containerd.* metrics are reported for the containers deployed in the "default" namespace.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
