### PR TITLE
[config_template] Add the Cluster Agent config options

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1958,6 +1958,64 @@ api_key:
   # listen_address: /var/vcap/data/garden/garden.sock
 
 {{ end -}}
+{{- if .ClusterAgent }}
+
+#################################
+## Cluster Agent Configuration ##
+#################################
+
+## @param cluster_agent - custom object - optional
+## Settings for the Cluster Agent.
+## See https://docs.datadoghq.com/agent/cluster_agent/
+#
+# cluster_agent:
+
+  ## @param enabled - boolean - optional - default: false
+  ## Set to true to enable the Cluster Agent.
+  #
+  # enabled: false
+
+  ## @param auth_token - string - optional - default: ""
+  ## Auth token used to make requests to the Kubernetes API server.
+  #
+  # auth_token: ""
+
+  ## @param url - string - optional - default: ""
+  ## The Cluster Agent endpoint. There's no need to set it if "kubernetes_service_name" is set.
+  #
+  # url: ""
+
+  ## @param kubernetes_service_name - string - optional - default: "datadog-cluster-agent"
+  ## Name of the Kubernetes service for the Cluster Agent.
+  #
+  # kubernetes_service_name: "datadog-cluster-agent"
+
+  ## @param tagging_fallback - boolean - optional - default: false
+  ## Set to true to enabled fallback to local metamapper when the connection with the Cluster Agent fails.
+  #
+  # tagging_fallback: false
+
+  ## @param server - custom object - optional
+  ## Sets the connection timeouts
+  #
+  # server:
+
+      ## @param read_timeout_seconds - integer - optional - default: 2
+      ## Read timeout in seconds.
+      #
+      # read_timeout_seconds: 2
+
+      ## @param write_timeout_seconds - integer - optional - default: 2
+      ## Write timeout in seconds.
+      #
+      # write_timeout_seconds: 2
+
+      ## @param idle_timeout_seconds - integer - optional - default: 60
+      ## Idle timeout in seconds.
+      #
+      # idle_timeout_seconds: 60
+
+{{ end -}}
 {{- if .ClusterChecks }}
 
 #################################

--- a/pkg/config/render_config.go
+++ b/pkg/config/render_config.go
@@ -41,6 +41,7 @@ type context struct {
 	SystemProbe       bool
 	KubeApiServer     bool
 	TraceAgent        bool
+	ClusterAgent      bool
 	ClusterChecks     bool
 	CloudFoundryBBS   bool
 	CloudFoundryCC    bool
@@ -114,6 +115,7 @@ func mkContext(buildType string) context {
 		}
 	case "dca":
 		return context{
+			ClusterAgent:  true,
 			Common:        true,
 			Logging:       true,
 			KubeApiServer: true,
@@ -121,6 +123,7 @@ func mkContext(buildType string) context {
 		}
 	case "dcacf":
 		return context{
+			ClusterAgent:    true,
 			Common:          true,
 			Logging:         true,
 			ClusterChecks:   true,


### PR DESCRIPTION
### What does this PR do?

Adds the cluster agent configuration options in `pkg/config/config_template.yaml`.

### Describe how to test your changes

Run `go run ./pkg/config/render_config.go dca ./pkg/config/config_template.yaml out.yaml` (out.yaml is the destination file, you can use any other). Check that `out.yaml` contains the `Cluster Agent Configuration` section.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
