### PR TITLE
[kitchen] Install fixed latest stable version in upgrade tests

### DIFF
--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -75,9 +75,9 @@ kitchen_test_system_probe_windows_x64:
     KITCHEN_OSVERS: "win2012r2"
     CHEF_VERSION: 14.12.9
   before_script:
-    - export WINDOWS_DDNPM_DRIVER=$(inv release.get-variable --name WINDOWS_DDNPM_DRIVER --version $RELEASE_VERSION_7)
-    - export WINDOWS_DDNPM_VERSION=$(inv release.get-variable --name WINDOWS_DDNPM_VERSION --version $RELEASE_VERSION_7)
-    - export WINDOWS_DDNPM_SHASUM=$(inv release.get-variable --name WINDOWS_DDNPM_SHASUM --version $RELEASE_VERSION_7)
+    - export WINDOWS_DDNPM_DRIVER=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDNPM_DRIVER")
+    - export WINDOWS_DDNPM_VERSION=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDNPM_VERSION")
+    - export WINDOWS_DDNPM_SHASUM=$(inv release.get-release-json-value "$RELEASE_VERSION_7::WINDOWS_DDNPM_SHASUM")
     - rsync -azr --delete ./ $SRC_PATH
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh

--- a/.gitlab/kitchen_common/testing.yml
+++ b/.gitlab/kitchen_common/testing.yml
@@ -63,10 +63,12 @@
 
 .kitchen_test_upgrade6:
   script:
+    - export LAST_STABLE_VERSION=$(cd ../.. && invoke release.get-release-json-value "last_stable::6")
     - bash -l tasks/run-test-kitchen.sh upgrade6-test $AGENT_MAJOR_VERSION
 
 .kitchen_test_upgrade7:
   script:
+    - export LAST_STABLE_VERSION=$(cd ../.. && invoke release.get-release-json-value "last_stable::7")
     - bash -l tasks/run-test-kitchen.sh upgrade7-test $AGENT_MAJOR_VERSION
 
 

--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -46,7 +46,7 @@
   before_script:  # test all of the kernels to make sure the driver loads and runs properly
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export RELEASE_VERSION=$RELEASE_VERSION_7; else export RELEASE_VERSION=$RELEASE_VERSION_6; fi
-    - export WINDOWS_DDNPM_DRIVER=$(inv release.get-variable --name WINDOWS_DDNPM_DRIVER --version $RELEASE_VERSION)
+    - export WINDOWS_DDNPM_DRIVER=$(inv release.get-release-json-value "$RELEASE_VERSION::WINDOWS_DDNPM_DRIVER")
     - rsync -azr --delete ./ $SRC_PATH
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
@@ -60,11 +60,12 @@
   before_script:  # Use only 2016 and 2019 for testing that we upgrade properly and don't install the driver when not specified
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A7; else export WINDOWS_TESTING_S3_BUCKET=$WINDOWS_TESTING_S3_BUCKET_A6; fi
     - if [ $AGENT_MAJOR_VERSION == "7" ]; then export RELEASE_VERSION=$RELEASE_VERSION_7; else export RELEASE_VERSION=$RELEASE_VERSION_6; fi
-    - export WINDOWS_DDNPM_DRIVER=$(inv release.get-variable --name WINDOWS_DDNPM_DRIVER --version $RELEASE_VERSION)
+    - export WINDOWS_DDNPM_DRIVER=$(inv release.get-release-json-value "$RELEASE_VERSION::WINDOWS_DDNPM_DRIVER")
     - rsync -azr --delete ./ $SRC_PATH
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
   script:
+    - export LAST_STABLE_VERSION=$(cd ../.. && invoke release.get-release-json-value "last_stable::$AGENT_MAJOR_VERSION")
     - bash -l tasks/run-test-kitchen.sh windows-npm-test $AGENT_MAJOR_VERSION
 
 # Kitchen: Test types (test suite * agent flavor + azure location)

--- a/release.json
+++ b/release.json
@@ -1,4 +1,8 @@
 {
+    "last_stable": {
+        "6": "6.31.0",
+        "7": "7.31.0"
+    },
     "nightly": {
         "INTEGRATIONS_CORE_VERSION": "master",
         "OMNIBUS_SOFTWARE_VERSION": "master",

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -691,13 +691,6 @@ def _get_windows_ddnpm_release_json_info(release_json, agent_major_version, is_f
     return win_ddnpm_driver, win_ddnpm_version, win_ddnpm_shasum
 
 
-@task
-def get_variable(_, name, version='nightly'):
-    with open("release.json", "r") as release_json_stream:
-        release_json = json.load(release_json_stream, object_pairs_hook=OrderedDict)
-    print(release_json[version][name])
-
-
 ##
 ## release_json object update function
 ##
@@ -1354,3 +1347,19 @@ def build_rc(ctx, major_versions="6,7", patch_version=False, redo=False):
         repo_branch="beta",
         deploy=True,
     )
+
+
+@task(help={'key': "Path to the release.json key, separated with double colons, eg. 'last_stable::6'"})
+def get_release_json_value(_, key):
+
+    release_json = _load_release_json()
+
+    path = key.split('::')
+
+    for element in path:
+        if element not in release_json:
+            raise Exit(code=1, message=f"Couldn't find '{key}' in release.json")
+
+        release_json = release_json.get(element)
+
+    print(release_json)

--- a/test/kitchen/site-cookbooks/dd-agent-install/attributes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install/attributes/default.rb
@@ -4,6 +4,7 @@
 
 default['datadog']['agent_start'] = true
 default['datadog']['agent_enable'] = true
+default['datadog']['agent_version'] = nil
 
 # On SUSE 11, skip system-probe management since it's not shipped with the Agent.
 if node['platform_family'] == 'suse' && node['platform_version'].to_i <= 11

--- a/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows_base.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install/recipes/_install_windows_base.rb
@@ -9,41 +9,43 @@
 
 package_retries = node['dd-agent-install']['agent_package_retries']
 package_retry_delay = node['dd-agent-install']['agent_package_retry_delay']
-dd_agent_version = node['dd-agent-install']['windows_version']
+dd_agent_version = node['datadog']['agent_version'] || node['dd-agent-install']['windows_version']
 dd_agent_filename = node['dd-agent-install']['windows_agent_filename']
+
+source_url = node['dd-agent-install']['windows_agent_url']
+if !source_url.end_with? '/'
+  source_url += '/'
+end
 
 if dd_agent_filename
   dd_agent_installer_basename = dd_agent_filename
 else
-  if dd_agent_version
+  # HACK: the packages have different names in the stable repos and the testing repos
+  # Check the source URL to know if we need to use the "stable" filename, or the "testing" filename
+  if source_url == "https://ddagent-windows-stable.s3.amazonaws.com/" # Use a version of the Agent from the official repos
+    dd_agent_installer_basename = "ddagent-cli-#{dd_agent_version}"
+  else # Use a version of the Agent from the testing repos
     dd_agent_installer_basename = "datadog-agent-#{dd_agent_version}-1-x86_64"
-  else
-    dd_agent_installer_basename = "datadog-agent-6.0.0-beta.latest.amd64"
   end
 end
 
 temp_file_basename = ::File.join(Chef::Config[:file_cache_path], 'ddagent-cli').gsub(File::SEPARATOR, File::ALT_SEPARATOR || File::SEPARATOR)
 
 dd_agent_installer = "#{dd_agent_installer_basename}.msi"
+source_url += dd_agent_installer
+
 temp_file = "#{temp_file_basename}.msi"
-installer_type = :msi
+
 # Agent >= 5.12.0 installs per-machine by default, but specifying ALLUSERS=1 shouldn't affect the install
 agent_install_options = node['dd-agent-install']['agent_install_options']
 install_options = "/norestart ALLUSERS=1  #{agent_install_options}"
-use_windows_package_resource = true
 
 package 'Datadog Agent removal' do
   package_name 'Datadog Agent'
   action :nothing
 end
 
-source_url = node['dd-agent-install']['windows_agent_url']
-if !source_url.end_with? '/'
-  source_url += '/'
-end
-source_url += dd_agent_installer
-
-  # Download the installer to a temp location
+# Download the installer to a temp location
 remote_file temp_file do
   source source_url
   checksum node['dd-agent-install']['windows_agent_checksum'] if node['dd-agent-install']['windows_agent_checksum']

--- a/test/kitchen/test-definitions/upgrade6-test.yml
+++ b/test/kitchen/test-definitions/upgrade6-test.yml
@@ -19,6 +19,7 @@ suites:
       unattended_upgrades:
         enable: false
     datadog:
+      agent_major_version: 6
       agent_version: <%= ENV['LAST_STABLE_VERSION'] %>
       api_key: <%= api_key %>
     dd-agent-upgrade:

--- a/test/kitchen/test-definitions/upgrade6-test.yml
+++ b/test/kitchen/test-definitions/upgrade6-test.yml
@@ -19,11 +19,8 @@ suites:
       unattended_upgrades:
         enable: false
     datadog:
-      agent_major_version: 6
+      agent_version: <%= ENV['LAST_STABLE_VERSION'] %>
       api_key: <%= api_key %>
-    dd-agent-install:
-      windows_agent_url: https://ddagent-windows-stable.s3.amazonaws.com/
-      windows_agent_filename: datadog-agent-6-latest.amd64
     dd-agent-upgrade:
       add_new_repo: true
       <% dd_agent_config.each do |key, value| %>

--- a/test/kitchen/test-definitions/upgrade7-test.yml
+++ b/test/kitchen/test-definitions/upgrade7-test.yml
@@ -19,6 +19,7 @@ suites:
       unattended_upgrades:
         enable: false
     datadog:
+      agent_major_version: 7
       agent_version: <%= ENV['LAST_STABLE_VERSION'] %>
       api_key: <%= api_key %>
       <% if ENV['AGENT_FLAVOR'] == 'datadog-iot-agent' %>

--- a/test/kitchen/test-definitions/upgrade7-test.yml
+++ b/test/kitchen/test-definitions/upgrade7-test.yml
@@ -19,14 +19,11 @@ suites:
       unattended_upgrades:
         enable: false
     datadog:
-      agent_major_version: 7
+      agent_version: <%= ENV['LAST_STABLE_VERSION'] %>
       api_key: <%= api_key %>
       <% if ENV['AGENT_FLAVOR'] == 'datadog-iot-agent' %>
       agent_flavor: 'datadog-iot-agent'
       <% end %>
-    dd-agent-install:
-      windows_agent_url: https://ddagent-windows-stable.s3.amazonaws.com/
-      windows_agent_filename: datadog-agent-7-latest.amd64
     dd-agent-upgrade:
       add_new_repo: true
       <% if ENV['AGENT_FLAVOR'] == 'datadog-iot-agent' %>

--- a/test/kitchen/test-definitions/windows-npm-test.yml
+++ b/test/kitchen/test-definitions/windows-npm-test.yml
@@ -8,7 +8,7 @@ suites:
     - "recipe[dd-agent-upgrade]"
   attributes:
     datadog:
-      agent_major_version: 7
+      agent_version: <%= ENV['LAST_STABLE_VERSION'] %>
       api_key: <%= api_key %>
       <% if ENV['AGENT_FLAVOR'] == 'datadog-iot-agent' %>
       agent_flavor: 'datadog-iot-agent'
@@ -48,7 +48,7 @@ suites:
     - "recipe[dd-agent-upgrade]"
   attributes:
     datadog:
-      agent_major_version: 7
+      agent_version: <%= ENV['LAST_STABLE_VERSION'] %>
       api_key: <%= api_key %>
       <% if ENV['AGENT_FLAVOR'] == 'datadog-iot-agent' %>
       agent_flavor: 'datadog-iot-agent'

--- a/test/kitchen/test-definitions/windows-npm-test.yml
+++ b/test/kitchen/test-definitions/windows-npm-test.yml
@@ -8,6 +8,7 @@ suites:
     - "recipe[dd-agent-upgrade]"
   attributes:
     datadog:
+      agent_major_version: 7
       agent_version: <%= ENV['LAST_STABLE_VERSION'] %>
       api_key: <%= api_key %>
       <% if ENV['AGENT_FLAVOR'] == 'datadog-iot-agent' %>
@@ -48,6 +49,7 @@ suites:
     - "recipe[dd-agent-upgrade]"
   attributes:
     datadog:
+      agent_major_version: 7
       agent_version: <%= ENV['LAST_STABLE_VERSION'] %>
       api_key: <%= api_key %>
       <% if ENV['AGENT_FLAVOR'] == 'datadog-iot-agent' %>


### PR DESCRIPTION
### What does this PR do?

In upgrade tests, use a fixed version of the Agent instead of `latest`.
Adds an invoke task to fetch an arbitrary field in the `release.json` file.

### Motivation

These tests always tried to install the latest version of the Agent. This could lead to failures when a new version of the Agent is released (with a version number higher than the version being tested in a pipeline).

### Additional Notes

The `last_stable` section should be updated after each Agent release. Once the release finish tasks are automated, this update will be part of the changelog update.

The Windows kitchen test recipes need to be refactored / rewritten, they're confusing right now (sometimes the official cookbook is used, sometimes not ; some attributes are not used ; the filename that needs to be used isn't always the same).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
