### PR TITLE
Publish and retract a v0.9.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,15 @@ module github.com/DataDog/datadog-agent
 
 go 1.16
 
+// v0.8.0 was tagged long ago, and appared on pkg.go.dev.  We do not want any tagged version
+// to appear there.  The trick to accomplish this is to make a new version (in this case v0.9.0)
+// that retracts itself and the previous version.
+
+retract (
+	v0.9.0
+	v0.8.0
+)
+
 // NOTE: Prefer using simple `require` directives instead of using `replace` if possible.
 // See https://github.com/DataDog/datadog-agent/blob/main/docs/dev/gomodreplace.md
 // for more details.


### PR DESCRIPTION
This should have the effect of convincing pkg.go.dev to show the latest
version from the default branch.

### What does this PR do?

Alone, nothing.  But when tagged as `v0.9.0`, it should eventually result in https://pkg.go.dev/github.com/DataDog/datadog-agent displaying docs from a recent commit to the repo

### Motivation

https://pkg.go.dev/github.com/DataDog/datadog-agent currently shows docs from over a year ago.

