### PR TITLE
[AD] Remove services for containers removed from a pod

### DIFF
--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -44,7 +44,7 @@ type KubeletListener struct {
 	mu            sync.RWMutex
 	filters       *containerFilters
 	services      map[string]Service
-	podContainers map[string][]string
+	podContainers map[string]map[string]struct{}
 
 	newService chan<- Service
 	delService chan<- Service
@@ -61,7 +61,7 @@ func NewKubeletListener() (ServiceListener, error) {
 		store:         workloadmeta.GetGlobalStore(),
 		filters:       filters,
 		services:      make(map[string]Service),
-		podContainers: make(map[string][]string),
+		podContainers: make(map[string]map[string]struct{}),
 		stop:          make(chan struct{}),
 	}, nil
 }
@@ -138,8 +138,15 @@ func (l *KubeletListener) processEvents(evBundle workloadmeta.EventBundle, first
 }
 
 func (l *KubeletListener) processPod(pod *workloadmeta.KubernetesPod, firstRun bool) {
-	containers := make([]*workloadmeta.Container, 0, len(pod.Containers))
+	// unseen keeps track of which previous container services are no
+	// longer present in the pod, to be removed at the end of this func
+	svcID := buildSvcID(pod.GetID())
+	unseen := make(map[string]struct{})
+	for svcID := range l.podContainers[svcID] {
+		unseen[svcID] = struct{}{}
+	}
 
+	containers := make([]*workloadmeta.Container, 0, len(pod.Containers))
 	for _, containerID := range pod.Containers {
 		container, err := l.store.GetContainer(containerID)
 		if err != nil {
@@ -150,9 +157,18 @@ func (l *KubeletListener) processPod(pod *workloadmeta.KubernetesPod, firstRun b
 		l.createContainerService(pod, container, firstRun)
 
 		containers = append(containers, container)
+
+		containerSvcID := buildSvcID(container.GetID())
+		delete(unseen, containerSvcID)
 	}
 
 	l.createPodService(pod, containers, firstRun)
+
+	// remove the container services that weren't seen when processing this
+	// pod
+	for containerSvcID := range unseen {
+		l.removeService(containerSvcID)
+	}
 }
 
 func (l *KubeletListener) createPodService(pod *workloadmeta.KubernetesPod, containers []*workloadmeta.Container, firstRun bool) {
@@ -306,8 +322,12 @@ func (l *KubeletListener) createContainerService(pod *workloadmeta.KubernetesPod
 		l.delService <- old
 	}
 
+	if _, ok := l.podContainers[podSvcID]; !ok {
+		l.podContainers[podSvcID] = make(map[string]struct{})
+	}
+
 	l.services[svcID] = svc
-	l.podContainers[podSvcID] = append(l.podContainers[podSvcID], svcID)
+	l.podContainers[podSvcID][svcID] = struct{}{}
 	l.newService <- svc
 }
 
@@ -320,7 +340,7 @@ func (l *KubeletListener) removePodService(entityID workloadmeta.EntityID) {
 	delete(l.podContainers, svcID)
 	l.mu.Unlock()
 
-	for _, containerSvcID := range containerSvcIDs {
+	for containerSvcID := range containerSvcIDs {
 		l.removeService(containerSvcID)
 	}
 }

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -142,8 +142,8 @@ func (l *KubeletListener) processPod(pod *workloadmeta.KubernetesPod, firstRun b
 	// longer present in the pod, to be removed at the end of this func
 	svcID := buildSvcID(pod.GetID())
 	unseen := make(map[string]struct{})
-	for svcID := range l.podContainers[svcID] {
-		unseen[svcID] = struct{}{}
+	for id := range l.podContainers[svcID] {
+		unseen[id] = struct{}{}
 	}
 
 	containers := make([]*workloadmeta.Container, 0, len(pod.Containers))

--- a/pkg/autodiscovery/listeners/kubelet_test.go
+++ b/pkg/autodiscovery/listeners/kubelet_test.go
@@ -461,7 +461,7 @@ func newKubeletListener(t *testing.T, newCh, delCh chan Service) *KubeletListene
 
 	return &KubeletListener{
 		services:      make(map[string]Service),
-		podContainers: make(map[string][]string),
+		podContainers: make(map[string]map[string]struct{}),
 		newService:    newCh,
 		delService:    delCh,
 		filters:       filters,


### PR DESCRIPTION
### What does this PR do?

When `podContainers` was introduced, it tracked containers during the
entire lifetime of the pod, removing them when the pod itself went away.
This did not account for restarted containers: they would get new IDs,
but their services would not be removed until the pod was removed too.

This presented a problem for pods in CrashLoopBackoff: new services
would be generated all the time, consuming memory both in autodiscovery
with the container services, but also the tagger, as it would not allow
the gone entities to be removed from the store, as they kept being
requested.

Now, after each pod service is re-evaluated, we remove any services for
containers that were not seen in that iteration.

### Describe how to test your changes

This needs a pod in CrashLoopBackoff, the deployment below should be sufficient. As AD currently has no telemetry, we have to observe secondary effects, so `datadog.agent.tagger_stored_entities` should remain stable over time (spikiness is fine, since entities will be added then removed in ~5 minutes again, as long as the spikes are of a similar magnitude) to verify the issue is gone.

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: crashloop
  namespace: default
spec:
  replicas: 1
  selector:
    matchLabels:
      app: crashloop
  template:
    metadata:
      labels:
        app: crashloop
    spec:
      containers:
      - image: busybox
        name: crashloop
        command: ["/bin/sh"]
        args: ["-c", "sleep 15 && exit 1"]
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
