### PR TITLE
Migrate to Ubuntu 21.10 base image

### DIFF
--- a/.gitlab/image_build/docker_linux.yml
+++ b/.gitlab/image_build/docker_linux.yml
@@ -13,7 +13,7 @@
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
     # Pull base images
-    - inv -e docker.pull-base-images --signed-pull $BUILD_CONTEXT/$ARCH/Dockerfile
+    - inv -e docker.pull-base-images $BUILD_CONTEXT/$ARCH/Dockerfile # --signed-pull currently removed as ubuntu:21.10 is not properly signed on DockerHub
     # Build testing stage if provided
     - test "$TESTING_ARG" && docker build --build-arg CIBUILD=true --file $BUILD_CONTEXT/$ARCH/Dockerfile $TESTING_ARG $BUILD_CONTEXT
     # Build release stage and push to ECR

--- a/.gitlab/image_build/docker_linux.yml
+++ b/.gitlab/image_build/docker_linux.yml
@@ -13,7 +13,7 @@
     - DOCKER_REGISTRY_LOGIN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_LOGIN_SSM_KEY --with-decryption --query "Parameter.Value" --out text)
     - aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.$DOCKER_REGISTRY_PWD_SSM_KEY --with-decryption --query "Parameter.Value" --out text | docker login --username "$DOCKER_REGISTRY_LOGIN" --password-stdin "$DOCKER_REGISTRY_URL"
     # Pull base images
-    - inv -e docker.pull-base-images $BUILD_CONTEXT/$ARCH/Dockerfile # --signed-pull currently removed as ubuntu:21.10 is not properly signed on DockerHub
+    - inv -e docker.pull-base-images $BUILD_CONTEXT/$ARCH/Dockerfile --no-signed-pull # FIXME: currently --no-signed-pull as ubuntu:21.10 is not properly signed on DockerHub
     # Build testing stage if provided
     - test "$TESTING_ARG" && docker build --build-arg CIBUILD=true --file $BUILD_CONTEXT/$ARCH/Dockerfile $TESTING_ARG $BUILD_CONTEXT
     # Build release stage and push to ECR

--- a/Dockerfiles/agent/amd64/Dockerfile
+++ b/Dockerfiles/agent/amd64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04 AS baseimage
+FROM ubuntu:21.10 AS baseimage
 ARG CIBUILD
 RUN if [ "$CIBUILD" = "true" ]; then \
   sed -i 's#http://archive.ubuntu.com#http://us-east-1.ec2.archive.ubuntu.com#g' /etc/apt/sources.list; \

--- a/Dockerfiles/agent/arm64/Dockerfile
+++ b/Dockerfiles/agent/arm64/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:21.04 AS baseimage
+FROM ubuntu:21.10 AS baseimage
 ARG CIBUILD
 RUN if [ "$CIBUILD" = "true" ]; then \
   sed -i 's#http://archive.ubuntu.com#http://us-east-1.ec2.archive.ubuntu.com#g' /etc/apt/sources.list; \

--- a/Dockerfiles/cluster-agent/amd64/Dockerfile
+++ b/Dockerfiles/cluster-agent/amd64/Dockerfile
@@ -2,7 +2,7 @@
 # Preparation stage: layout and chmods #
 ########################################
 
-FROM ubuntu:21.04 as builder
+FROM ubuntu:21.10 as builder
 
 WORKDIR /output
 
@@ -25,7 +25,7 @@ RUN chmod 755 entrypoint.sh \
 # Actual docker image construction #
 ####################################
 
-FROM ubuntu:21.04
+FROM ubuntu:21.10
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 

--- a/Dockerfiles/cluster-agent/arm64/Dockerfile
+++ b/Dockerfiles/cluster-agent/arm64/Dockerfile
@@ -2,7 +2,7 @@
 # Preparation stage: layout and chmods #
 ########################################
 
-FROM ubuntu:21.04 as builder
+FROM ubuntu:21.10 as builder
 
 WORKDIR /output
 
@@ -24,7 +24,7 @@ RUN chmod 755 entrypoint.sh \
 # Actual docker image construction #
 ####################################
 
-FROM ubuntu:21.04
+FROM ubuntu:21.10
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 

--- a/releasenotes/notes/ubuntu21.10-2ab35eac047f3433.yaml
+++ b/releasenotes/notes/ubuntu21.10-2ab35eac047f3433.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    Upgrade Docker base image to ubuntu:21.10 as new stable release.

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -277,7 +277,7 @@ def system_tests(_):
 
 
 @task
-def image_build(ctx, arch='amd64', base_dir="omnibus", python_version="2", skip_tests=False):
+def image_build(ctx, arch='amd64', base_dir="omnibus", python_version="2", skip_tests=False, signed_pull=True):
     """
     Build the docker image
     """
@@ -299,9 +299,8 @@ def image_build(ctx, arch='amd64', base_dir="omnibus", python_version="2", skip_
         raise Exit(code=1)
     latest_file = max(list_of_files, key=os.path.getctime)
     shutil.copy2(latest_file, build_context)
-
     # Pull base image with content trust enabled
-    pull_base_images(ctx, dockerfile_path, signed_pull=True)
+    pull_base_images(ctx, dockerfile_path, signed_pull)
     common_build_opts = "-t {} -f {}".format(AGENT_TAG, dockerfile_path)
     if python_version not in BOTH_VERSIONS:
         common_build_opts = "{} --build-arg PYTHON_VERSION={}".format(common_build_opts, python_version)

--- a/tasks/docker.py
+++ b/tasks/docker.py
@@ -135,7 +135,7 @@ def pull_base_images(ctx, dockerfile, signed_pull=True):
         print("Ignoring intermediate stage names: {}".format(", ".join(stages)))
         images -= stages
 
-    print("Pulling following base images: {} (content-trust:{})".format(", ".join(images),signed_pull))
+    print("Pulling following base images: {} (content-trust:{})".format(", ".join(images), signed_pull))
 
     pull_env = {}
     if signed_pull:

--- a/tasks/docker.py
+++ b/tasks/docker.py
@@ -3,7 +3,6 @@ Docker related tasks
 """
 
 
-import operator
 import os
 import shutil
 import sys

--- a/tasks/docker.py
+++ b/tasks/docker.py
@@ -3,6 +3,7 @@ Docker related tasks
 """
 
 
+import operator
 import os
 import shutil
 import sys
@@ -135,7 +136,7 @@ def pull_base_images(ctx, dockerfile, signed_pull=True):
         print("Ignoring intermediate stage names: {}".format(", ".join(stages)))
         images -= stages
 
-    print("Pulling following base images: {}".format(", ".join(images)))
+    print("Pulling following base images: {} (content-trust:{})".format(", ".join(images),signed_pull))
 
     pull_env = {}
     if signed_pull:


### PR DESCRIPTION
### What does this PR do?

Upgrade Docker base image to ubuntu:21.10 as new stable release.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

We needed to disable `content-trust` for this image, because it wasn't properly signed on dockerhub by docker CI. An issue is open but no fix was made yet.

### Describe how to test your changes

As usual with `glibc` changes: test on older Kernels/container runtime that everything still work properly.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
