### PR TITLE
[release] Update release.json and Go modules for 6/7.32.0-rc.7

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,10 +49,10 @@ require (
 	code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a // indirect
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
 	github.com/DataDog/agent-payload v4.85.0+incompatible
-	github.com/DataDog/datadog-agent/pkg/otlp/model v0.32.0-rc.6
-	github.com/DataDog/datadog-agent/pkg/quantile v0.32.0-rc.6
-	github.com/DataDog/datadog-agent/pkg/util/log v0.32.0-rc.6
-	github.com/DataDog/datadog-agent/pkg/util/winutil v0.32.0-rc.6
+	github.com/DataDog/datadog-agent/pkg/otlp/model v0.32.0-rc.7
+	github.com/DataDog/datadog-agent/pkg/quantile v0.32.0-rc.7
+	github.com/DataDog/datadog-agent/pkg/util/log v0.32.0-rc.7
+	github.com/DataDog/datadog-agent/pkg/util/winutil v0.32.0-rc.7
 	github.com/DataDog/datadog-go v4.8.2+incompatible
 	github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a
 	github.com/DataDog/ebpf v0.0.0-20210923171847-87e6c3a89de8

--- a/pkg/otlp/model/go.mod
+++ b/pkg/otlp/model/go.mod
@@ -5,7 +5,7 @@ go 1.16
 replace github.com/DataDog/datadog-agent/pkg/quantile => ../../quantile
 
 require (
-	github.com/DataDog/datadog-agent/pkg/quantile v0.32.0-rc.6
+	github.com/DataDog/datadog-agent/pkg/quantile v0.32.0-rc.7
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/stretchr/testify v1.7.0
 	go.opentelemetry.io/collector/model v0.36.0

--- a/pkg/util/winutil/go.mod
+++ b/pkg/util/winutil/go.mod
@@ -5,7 +5,7 @@ go 1.16
 replace github.com/DataDog/datadog-agent/pkg/util/log => ../log
 
 require (
-	github.com/DataDog/datadog-agent/pkg/util/log v0.32.0-rc.6
+	github.com/DataDog/datadog-agent/pkg/util/log v0.32.0-rc.7
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20200930185726-fdedc70b468f
 )


### PR DESCRIPTION
No release.json update - there were no dependency changes between RC6 and RC7.