### PR TITLE
[invoke] Fix flake in version tests

### DIFF
--- a/tasks/libs/version_tests.py
+++ b/tasks/libs/version_tests.py
@@ -13,7 +13,9 @@ class TestVersionComparison(unittest.TestCase):
             random.randint(0, 99),
             random.randint(0, 99),
             random.randint(0, 99),
-            random.randint(0, 99),
+            # For tests, rc must be non-0, as 0 signifies a release version, which would
+            # break some tests like test_rc_higher and test_rc_lower
+            random.randint(1, 99),
             random.choice([True, False]),
         )
 


### PR DESCRIPTION
### What does this PR do?

Fixes a flake in the version tests which had a 1/100 chance of happening.

### Motivation

For `Version` objects, `rc == 0 <=> rc == None <=> version is not an rc`. Therefore, if you increment the `rc` number, you get a lower version (which breaks `test_rc_higher` and `test_rc_lower`).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
