### PR TITLE
[workloadmeta] Add support for "labels as tags"

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -509,6 +509,7 @@ func InitConfig(config Config) {
 	// We only support containerd in Kubernetes. By default containerd cri uses `k8s.io` https://github.com/containerd/cri/blob/release/1.2/pkg/constants/constants.go#L22-L23
 	config.BindEnvAndSetDefault("containerd_namespace", "k8s.io")
 	config.BindEnvAndSetDefault("container_env_as_tags", map[string]string{})
+	config.BindEnvAndSetDefault("container_labels_as_tags", map[string]string{})
 
 	// Kubernetes
 	config.BindEnvAndSetDefault("kubernetes_kubelet_host", "")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2181,6 +2181,16 @@ api_key:
 # container_env_as_tags:
 #   <ENV>: <TAG_KEY>
 
+## @param container_labels_as_tags - map - optional
+## @env DD_CONTAINER_LABELS_AS_TAGS - map - optional
+## The Agent can extract container label values and set them as metric tags values associated to a <TAG_KEY>.
+## If you prefix your tag name with `+`, it will only be added to high cardinality metrics. (Supported container
+## runtimes: Containerd, Docker).
+#
+# container_labels_as_tags:
+#   <LABEL_NAME>: <TAG_KEY>
+#   <HIGH_CARDINALITY_LABEL_NAME>: +<TAG_KEY>
+
 {{ end -}}
 {{- if .ECS }}
 

--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -127,6 +127,11 @@ func (c *WorkloadMetaCollector) handleContainer(ev workloadmeta.Event) []*TagInf
 	// standard tags from labels
 	c.extractFromMapWithFn(container.Labels, standardDockerLabels, tags.AddStandard)
 
+	// container labels as tags
+	for labelName, labelValue := range container.Labels {
+		utils.AddMetadataAsTags(labelName, labelValue, c.containerLabelsAsTags, c.globContainerLabels, tags)
+	}
+
 	// orchestrator tags from labels
 	c.extractFromMapWithFn(container.Labels, lowCardOrchestratorLabels, tags.AddLow)
 	c.extractFromMapWithFn(container.Labels, highCardOrchestratorLabels, tags.AddHigh)
@@ -147,7 +152,9 @@ func (c *WorkloadMetaCollector) handleContainer(ev workloadmeta.Event) []*TagInf
 	c.extractFromMapWithFn(container.EnvVars, orchCardOrchestratorEnvKeys, tags.AddOrchestrator)
 
 	// extract env as tags
-	c.extractFromMapNormalizedWithFn(container.EnvVars, c.containerEnvAsTags, tags.AddAuto)
+	for envName, envValue := range container.EnvVars {
+		utils.AddMetadataAsTags(envName, envValue, c.containerEnvAsTags, c.globContainerEnvLabels, tags)
+	}
 
 	// static tags for ECS Fargate
 	for tag, value := range c.staticTags {

--- a/pkg/tagger/collectors/workloadmeta_main.go
+++ b/pkg/tagger/collectors/workloadmeta_main.go
@@ -62,7 +62,10 @@ func (c *WorkloadMetaCollector) Detect(ctx context.Context, out chan<- []*TagInf
 	c.children = make(map[string]map[string]struct{})
 	c.collectEC2ResourceTags = config.Datadog.GetBool("ecs_collect_resource_tags_ec2")
 
-	containerLabelsAsTags := retrieveMappingFromConfig("docker_labels_as_tags")
+	containerLabelsAsTags := mergeMaps(
+		retrieveMappingFromConfig("docker_labels_as_tags"),
+		retrieveMappingFromConfig("container_labels_as_tags"),
+	)
 	containerEnvAsTags := mergeMaps(
 		retrieveMappingFromConfig("docker_env_as_tags"),
 		retrieveMappingFromConfig("container_env_as_tags"),

--- a/pkg/tagger/collectors/workloadmeta_main.go
+++ b/pkg/tagger/collectors/workloadmeta_main.go
@@ -44,13 +44,15 @@ type WorkloadMetaCollector struct {
 	containerEnvAsTags    map[string]string
 	containerLabelsAsTags map[string]string
 
-	staticTags        map[string]string
-	labelsAsTags      map[string]string
-	annotationsAsTags map[string]string
-	nsLabelsAsTags    map[string]string
-	globLabels        map[string]glob.Glob
-	globAnnotations   map[string]glob.Glob
-	globNsLabels      map[string]glob.Glob
+	staticTags             map[string]string
+	labelsAsTags           map[string]string
+	annotationsAsTags      map[string]string
+	nsLabelsAsTags         map[string]string
+	globLabels             map[string]glob.Glob
+	globAnnotations        map[string]glob.Glob
+	globNsLabels           map[string]glob.Glob
+	globContainerLabels    map[string]glob.Glob
+	globContainerEnvLabels map[string]glob.Glob
 
 	collectEC2ResourceTags bool
 }
@@ -83,15 +85,8 @@ func (c *WorkloadMetaCollector) Detect(ctx context.Context, out chan<- []*TagInf
 }
 
 func (c *WorkloadMetaCollector) initContainerMetaAsTags(labelsAsTags, envAsTags map[string]string) {
-	c.containerLabelsAsTags = make(map[string]string)
-	for label, tag := range labelsAsTags {
-		c.containerLabelsAsTags[strings.ToLower(label)] = tag
-	}
-
-	c.containerEnvAsTags = make(map[string]string)
-	for label, tag := range envAsTags {
-		c.containerEnvAsTags[strings.ToLower(label)] = tag
-	}
+	c.containerLabelsAsTags, c.globContainerLabels = utils.InitMetadataAsTags(labelsAsTags)
+	c.containerEnvAsTags, c.globContainerEnvLabels = utils.InitMetadataAsTags(envAsTags)
 }
 
 func (c *WorkloadMetaCollector) initPodMetaAsTags(labelsAsTags, annotationsAsTags, nsLabelsAsTags map[string]string) {

--- a/pkg/tagger/collectors/workloadmeta_test.go
+++ b/pkg/tagger/collectors/workloadmeta_test.go
@@ -662,6 +662,45 @@ func TestHandleContainer(t *testing.T) {
 			},
 		},
 		{
+			name: "tags from labels and envs with prefix (using *)",
+			container: workloadmeta.Container{
+				EntityID: entityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: containerName,
+					Labels: map[string]string{
+						"team": "container-integrations",
+					},
+				},
+				EnvVars: map[string]string{
+					"some_env": "some_env_val",
+				},
+			},
+			labelsAsTags: map[string]string{
+				"*": "custom_label_prefix_%%label%%",
+			},
+			envAsTags: map[string]string{
+				"*": "custom_env_prefix_%%env%%",
+			},
+			expected: []*TagInfo{
+				{
+					Source: sourceContainer,
+					Entity: taggerEntityID,
+					HighCardTags: []string{
+						fmt.Sprintf("container_name:%s", containerName),
+						fmt.Sprintf("container_id:%s", entityID.ID),
+					},
+					OrchestratorCardTags: []string{},
+					LowCardTags: append([]string{
+						// Notice that the names include the custom prefixes
+						// added in labelsAsTags and envAsTags.
+						"custom_label_prefix_team:container-integrations",
+						"custom_env_prefix_some_env:some_env_val",
+					}),
+					StandardTags: []string{},
+				},
+			},
+		},
+		{
 			name: "nomad container",
 			container: workloadmeta.Container{
 				EntityID: entityID,

--- a/releasenotes/notes/containerd-labels-as-tags-a04b95cdc9c63adf.yaml
+++ b/releasenotes/notes/containerd-labels-as-tags-a04b95cdc9c63adf.yaml
@@ -1,0 +1,6 @@
+features:
+  - |
+    Added new option "container_labels_as_tags" that allows the Agent to
+    extract container label values and set them as metric tags values. It's
+    equivalent to the existing "docker_labels_as_tags", but it also works with
+    containerd.


### PR DESCRIPTION
### What does this PR do?

Introduces a new option "container_labels_as_tags" that allows the agent to extract container label values and set them as metric tags values. It's equivalent to the existing "docker_labels_as_tags", but it also works with containerd.

This PR also adds support for that new option in the tagger workloadmeta collector.

This PR also fixes a regression. The new containerd collector didn't support advanced options in env as tags like: '{"*":"<PREFIX>_%%env%%"}'. That has been fixed.

### Describe how to test your changes

This needs to be tested on Kubernetes. Also, this only works in containerd >= 1.5.6 because previous versions didn't propagate labels correctly. At the moment of writing this, kind does not come with that containerd version by default, but you can install it in a custom image like explained here: https://github.com/kubernetes-sigs/kind/issues/1637#issuecomment-636397888

- Set `DD_CONTAINER_LABELS_AS_TAGS` to: "{"test_label": "test_label_as_tag"}", for example.
- Deploy the agent on Kubernetes.
- Build a Docker image with labels and deploy it to your Kubernetes cluster. For example:
```Dockerfile
FROM redis
LABEL test_label=test_val
```
- Check `agent tagger-list` and verify that the tag "test_label_as_tag" has the value "test_val" in the `workloadmeta-container` section of the container that you deployed.
- Check that advanced "as tags" configs (documented [here](https://docs.datadoghq.com/agent/kubernetes/tag/?tab=containerizedagent#pod-labels-as-tags)) work. Both with envs and tags. You can try something like: set `DD_CONTAINER_ENV_AS_TAGS` to `{"*":"ENVPREFIX_%%env%%"}` and set `DD_CONTAINER_LABELS_AS_TAGS` to `{"*":"LABELPREFIX_%%label%%"}`. You should see those prefixes in `agent tagger-list`.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
