### PR TITLE
Remove hanging AD errors from deleted pods in agent status

### DIFF
--- a/pkg/autodiscovery/providers/kubelet.go
+++ b/pkg/autodiscovery/providers/kubelet.go
@@ -125,10 +125,10 @@ func (k *KubeletConfigProvider) parseKubeletPodlist(podlist []*kubelet.Pod) ([]i
 				ADErrors[namespacedName][err.Error()] = struct{}{}
 			}
 		}
-		k.Lock()
-		k.configErrors = ADErrors
-		k.Unlock()
 	}
+	k.Lock()
+	k.configErrors = ADErrors
+	k.Unlock()
 	return configs, nil
 }
 

--- a/releasenotes/notes/remove-hanging-ad-error-agent-status-3644078dba51d192.yaml
+++ b/releasenotes/notes/remove-hanging-ad-error-agent-status-3644078dba51d192.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    Remove occasionally hanging autodiscovery errors 
+    from the agent status once a pod is deleted.


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in which the agent status sometimes shows old autodiscovery errors from a deleted pod.

### Describe how to test your changes

I couldn't consistently reproduce the bug but it occurred more frequently on a 2+ node cluster with an app pod that would be scheduled on a different node when it was deleted. The app pod should have AD annotations containing errors and it helps if it is the only pod with AD annotations. This way, the agent status should switch between having AD errors and having no AD errors each time the app pod is deleted. Example annotations with errors:
```
      annotations:
        ad.datadoghq.com/pause.check_names: '["etcd"]'
        ad.datadoghq.com/pause.init_configs: "[{}]"
        ad.datadoghq.com/pause.instances: |
          [{
            "prometheus_url": "https://%%host%%:2379/metrics",
            # INVALID
            "tls_ca_cert": "/host/etc/kubernetes/ssl/kube-ca.pem",
            "tls_cert": "/host/etc/kubernetes/ssl/kube-etcd.pem",
            "tls_private_key": "/host/etc/kubernetes/ssl/kube-etcd.pem"
          }]
```

Delete the app pod and ensure the agent status output correctly removes the AD error about the deleted pod within ~10 sec. Repeat this several times.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
