### PR TITLE
Fix flaky tests for pkg/logs/tag

### DIFF
--- a/pkg/logs/config/config_keys.go
+++ b/pkg/logs/config/config_keys.go
@@ -142,6 +142,8 @@ func (l *LogsConfigKeys) expectedTagsDuration() time.Duration {
 }
 
 func (l *LogsConfigKeys) taggerWarmupDuration() time.Duration {
+	// note that this multiplies a duration (in ns) by 1 second (in ns), so the user must specify
+	// an integer number of seconds ("5") and not a duration expression ("5s").
 	return l.getConfig().GetDuration(l.getConfigKey("tagger_warmup_duration")) * time.Second
 }
 

--- a/pkg/logs/tag/provider_benchmark_test.go
+++ b/pkg/logs/tag/provider_benchmark_test.go
@@ -7,9 +7,21 @@ package tag
 
 import (
 	"testing"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
+
+func setupConfig(tags []string) (*config.MockConfig, time.Time) {
+	mockConfig := config.Mock()
+
+	startTime := config.StartTime
+	config.StartTime = time.Now()
+
+	mockConfig.Set("tags", tags)
+
+	return mockConfig, startTime
+}
 
 func BenchmarkProviderExpectedTags(b *testing.B) {
 	b.ReportAllocs()

--- a/pkg/logs/tag/provider_test.go
+++ b/pkg/logs/tag/provider_test.go
@@ -10,52 +10,52 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/stretchr/testify/assert"
+	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/benbjohnson/clock"
+	"github.com/stretchr/testify/require"
 )
 
-func setupConfig(tags []string) (*config.MockConfig, time.Time) {
-	mockConfig := config.Mock()
-
-	startTime := config.StartTime
-	config.StartTime = time.Now()
-
-	mockConfig.Set("tags", tags)
-
-	return mockConfig, startTime
-}
-
 func TestProviderExpectedTags(t *testing.T) {
+	m := coreConfig.Mock()
+	clock := clock.NewMock()
 
-	tags := []string{"tag1:value1", "tag2", "tag3"}
-	m, start := setupConfig(tags)
+	oldStartTime := coreConfig.StartTime
+	coreConfig.StartTime = clock.Now()
 	defer func() {
-		config.StartTime = start
+		coreConfig.StartTime = oldStartTime
 	}()
 
+	tags := []string{"tag1:value1", "tag2", "tag3"}
+	m.Set("tags", tags)
 	defer m.Set("tags", nil)
 
-	// Setting a test-friendly value for the deadline
+	m.Set("logs_config.tagger_warmup_duration", "2")
+
+	expectedTagsDuration := 5 * time.Second
 	m.Set("logs_config.expected_tags_duration", "5s")
 	defer m.Set("logs_config.expected_tags_duration", 0)
 
-	p := NewProvider("foo")
+	p := newProviderWithClock("foo", clock)
 	pp := p.(*provider)
 
-	// Is provider expected?
-	d := m.GetDuration("logs_config.expected_tags_duration")
-	l := pp.localTagProvider
-	ll := l.(*localProvider)
+	var tt []string
 
-	assert.InDelta(t, config.StartTime.Add(d).Unix(), ll.expectedTagsDeadline.Unix(), 1)
+	// this will block for two (mock) seconds, so do it in a goroutine
+	go func() {
+		tt = pp.GetTags()
+	}()
 
-	tt := pp.GetTags()
+	clock.Add(time.Second)
+	require.Empty(t, tt) // still waiting..
+
+	clock.Add(2 * time.Second)
 	sort.Strings(tags)
 	sort.Strings(tt)
-	assert.Equal(t, tags, tt)
+	require.Equal(t, tags, tt)
 
-	// let the deadline expire + a little grace period
-	<-time.After(time.Until(ll.expectedTagsDeadline.Add(2 * time.Second)))
+	// let the deadline expire
+	clock.Add(expectedTagsDuration)
 
-	assert.Empty(t, pp.GetTags())
+	// tags are now empty
+	require.Empty(t, pp.GetTags())
 }

--- a/pkg/logs/tag/provider_test.go
+++ b/pkg/logs/tag/provider_test.go
@@ -41,14 +41,17 @@ func TestProviderExpectedTags(t *testing.T) {
 	var tt []string
 
 	// this will block for two (mock) seconds, so do it in a goroutine
+	gotTags := make(chan struct{})
 	go func() {
 		tt = pp.GetTags()
+		close(gotTags)
 	}()
 
 	clock.Add(time.Second)
 	require.Empty(t, tt) // still waiting..
 
 	clock.Add(2 * time.Second)
+	<-gotTags // got the tags now!
 	sort.Strings(tags)
 	sort.Strings(tt)
 	require.Equal(t, tags, tt)


### PR DESCRIPTION
This makes some additional refactors for the packages, beyond using
clock.Clock:
 * localProvider does not need to store expectedTagsDeadline in the
   struct.
 * Use `AfterFunc` to run a function after a delay, instead of sleeping
   in a goroutine.  The latter is ambiguous as to when the goroutine
   starts.
 * Include tests for the tagger warmup duration
 * Add a comment highlighting a bug in parsing of the
   `logs_config.tagger_warmup_duration` setting.  Since this is hidden and
   fixing the bug would change the meaning for existing users, this is the
   most we can do.

### Motivation

Flaky test

### Additional Notes

This turned out to be more than a simple test change, but hopefully is still manageable.

### Describe how to test your changes

#### warmup
Set `logging_config.tagger_warmup_duration` to `30` (_not_ `30s`), configure payload logging and any log source.  Start the agent and observe that no logs are sent to the intake until about 30s after the agent starts.

#### expected tags
Set `logs_config.expected_tags_duration` to `30s` (_not_ `30`), set `tags` to something silly, configure payload logging and any log source.  Start the angent and observe that the logs sent for the first 30s only have the host tags, and after that have the silly tags.