### PR TITLE
[SLS-1525] Add runtime & memorysize tags to enhanced metrics

### DIFF
--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -16,6 +16,8 @@ const (
 	envEnvVar       = "DD_ENV"
 	versionEnvVar   = "DD_VERSION"
 	serviceEnvVar   = "DD_SERVICE"
+	runtimeVar      = "AWS_EXECUTION_ENV"
+	memorySizeVar   = "AWS_LAMBDA_FUNCTION_MEMORY_SIZE"
 
 	traceOriginMetadataKey   = "_dd.origin"
 	traceOriginMetadataValue = "lambda"
@@ -32,6 +34,8 @@ const (
 	envKey                   = "env"
 	versionKey               = "version"
 	serviceKey               = "service"
+	runtimeKey               = "runtime"
+	memorySizeKey            = "memorysize"
 	architectureKey          = "architecture"
 )
 
@@ -46,6 +50,11 @@ func BuildTagMap(arn string, configTags []string) map[string]string {
 
 	architecture := ResolveRuntimeArch()
 	tags = setIfNotEmpty(tags, architectureKey, architecture)
+
+	cleanedRuntime := strings.Replace(os.Getenv(runtimeVar), "AWS_Lambda_", "", 1)
+
+	tags = setIfNotEmpty(tags, runtimeKey, cleanedRuntime)
+	tags = setIfNotEmpty(tags, memorySizeKey, os.Getenv(memorySizeVar))
 
 	tags = setIfNotEmpty(tags, envKey, os.Getenv(envEnvVar))
 	tags = setIfNotEmpty(tags, versionKey, os.Getenv(versionEnvVar))

--- a/pkg/serverless/tags/tags_test.go
+++ b/pkg/serverless/tags/tags_test.go
@@ -268,3 +268,24 @@ func TestAddColdStartTagWithColdStart(t *testing.T) {
 		"cold_start:true",
 	})
 }
+
+func TestBuildTagMapWithRuntimeAndMemoryTag(t *testing.T) {
+	os.Setenv("AWS_EXECUTION_ENV", "AWS_Lambda_java")
+	os.Setenv("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", "128")
+	arn := "arn:aws:lambda:us-east-1:123456789012:function:my-function"
+	tagMap := BuildTagMap(arn, []string{"tag0:value0", "TAG1:VALUE1"})
+	assert.Equal(t, 14, len(tagMap))
+	assert.Equal(t, "lambda", tagMap["_dd.origin"])
+	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
+	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
+	assert.Equal(t, "us-east-1", tagMap["region"])
+	assert.Equal(t, "123456789012", tagMap["aws_account"])
+	assert.Equal(t, "123456789012", tagMap["account_id"])
+	assert.Equal(t, "my-function", tagMap["functionname"])
+	assert.Equal(t, "my-function:888", tagMap["resource"])
+	assert.Equal(t, "xxx", tagMap["dd_extension_version"])
+	assert.Equal(t, "value0", tagMap["tag0"])
+	assert.Equal(t, "value1", tagMap["tag1"])
+	assert.Equal(t, "java", tagMap["runtime"])
+	assert.Equal(t, "128", tagMap["memorysize"])
+}


### PR DESCRIPTION
### What does this PR do?

Add `runtime` & `memorysize` tags to enhanced metrics emitted by the Datadog Lambda Extension (used by the Serverless Detail page).

![image](https://user-images.githubusercontent.com/6404023/134406360-dbaeb6ca-4509-4ac5-965f-1115cf289eea.png)

### Motivation

https://datadoghq.atlassian.net/browse/SLS-1525

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
