### PR TITLE
Improve negative caching of NAT gateway lookups

### DIFF
--- a/pkg/network/tracer/gateway_lookup.go
+++ b/pkg/network/tracer/gateway_lookup.go
@@ -5,6 +5,7 @@ package tracer
 import (
 	"context"
 	"net"
+	"time"
 
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/network"
@@ -89,10 +90,14 @@ func (g *gatewayLookup) Lookup(cs *network.ConnectionStats) *network.Via {
 		ifi, err := net.InterfaceByIndex(r.IfIndex)
 		if err != nil {
 			log.Errorf("error getting interface for interface index %d: %s", r.IfIndex, err)
+			// negative cache for 1 minute
+			g.subnetCache.Add(r.IfIndex, time.Now().Add(1*time.Minute))
 			return nil
 		}
 
 		if ifi.Flags&net.FlagLoopback != 0 {
+			// negative cache loopback interfaces
+			g.subnetCache.Add(r.IfIndex, nil)
 			return nil
 		}
 
@@ -111,7 +116,17 @@ func (g *gatewayLookup) Lookup(cs *network.ConnectionStats) *network.Via {
 		return nil
 	}
 
-	return &network.Via{Subnet: v.(network.Subnet)}
+	switch cv := v.(type) {
+	case time.Time:
+		if time.Now().After(cv) {
+			g.subnetCache.Remove(r.IfIndex)
+		}
+		return nil
+	case network.Subnet:
+		return &network.Via{Subnet: cv}
+	default:
+		return nil
+	}
 }
 
 func (g *gatewayLookup) purge() {


### PR DESCRIPTION
### What does this PR do?

Add negative cache entries during NAT gateway lookup to:
1. prevent thrashing in the face of errors
2. prevent excessive syscalls when loopback interfaces are used.

### Motivation

Preparation for wider-scale usage of NAT gateway feature.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.