### PR TITLE
Use cached values when reading from cloud metadata fails

### DIFF
--- a/pkg/util/cachedfetch/fetcher.go
+++ b/pkg/util/cachedfetch/fetcher.go
@@ -1,0 +1,88 @@
+// Package cachedfetch provides a read-through cache for fetched values.
+package cachedfetch
+
+import (
+	"context"
+	"sync"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// Fetcher supports fetching a value, such as from a cloud service API.  An
+// attempt is made to fetch the value on each call to Fetch, but if that
+// attempt fails then a cached value from the last successful attempt is
+// returned, if such a value exists.  This helps the agent to "ride out"
+// temporary failures in cloud APIs while still fetching fresh data when those
+// APIs are functioning properly.  Cached values do not expire.
+//
+// Callers should instantiate one fetcher per piece of data required.
+type Fetcher struct {
+	// function that attempts to fetch the value
+	Attempt func(context.Context) (interface{}, error)
+
+	// the name of the thing being fetched, used in the default log message.  At
+	// least one of Name and LogFailure must be non-nil.
+	Name string
+
+	// function to log a fetch failure, given the error and the last successful
+	// value.  This function is not called if there is no last successful value.
+	// If left at its zero state, a default log message will be generated, using
+	// Name.
+	LogFailure func(error, interface{})
+
+	// previous successfully fetched value
+	lastValue interface{}
+
+	// mutex to protect access to lastValue
+	sync.Mutex
+}
+
+// Fetch attempts to fetch the value, returning the result or the last successful
+// value, or an error if no attempt has ever been successful.  No special handling
+// is included for the Context: both context.Cancelled and context.DeadlineExceeded
+// are handled like any other error by returning the cached value.
+//
+// This can be called from multiple goroutines, in which case it will call Attempt
+// concurrently.
+func (f *Fetcher) Fetch(ctx context.Context) (interface{}, error) {
+	value, err := f.Attempt(ctx)
+	if err == nil {
+		f.Lock()
+		f.lastValue = value
+		f.Unlock()
+		return value, nil
+	}
+
+	f.Lock()
+	lastValue := f.lastValue
+	f.Unlock()
+
+	if lastValue == nil {
+		// attempt was never successful
+		return value, err
+	}
+
+	if f.LogFailure == nil {
+		log.Debugf("Unable to get %s; returning cached value instead", f.Name)
+	} else {
+		f.LogFailure(err, lastValue)
+	}
+
+	return lastValue, nil
+}
+
+// FetchString is a convenience wrapper around Fetch that returns a string
+func (f *Fetcher) FetchString(ctx context.Context) (string, error) {
+	v, err := f.Fetch(ctx)
+	if err != nil {
+		return "", err
+	}
+	return v.(string), nil
+}
+
+// Reset resets the cached value (used for testing)
+func (f *Fetcher) Reset() {
+	f.Lock()
+	f.lastValue = nil
+	f.Unlock()
+}

--- a/pkg/util/cachedfetch/fetcher_test.go
+++ b/pkg/util/cachedfetch/fetcher_test.go
@@ -1,0 +1,132 @@
+package cachedfetch
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// If Attempt never succeeds, f.Fetch returns an error
+func TestFetcherNeverSucceeds(t *testing.T) {
+	f := Fetcher{
+		Attempt: func(ctx context.Context) (interface{}, error) { return nil, fmt.Errorf("uhoh") },
+	}
+
+	v, err := f.Fetch(context.TODO())
+	require.Nil(t, v)
+	require.Error(t, err)
+
+	v, err = f.Fetch(context.TODO())
+	require.Nil(t, v)
+	require.Error(t, err)
+}
+
+// Each call to f.Fetch() calls Attempt again
+func TestFetcherCalledEachFetch(t *testing.T) {
+	count := 0
+	f := Fetcher{
+		Attempt: func(ctx context.Context) (interface{}, error) {
+			count++
+			return count, nil
+		},
+	}
+
+	v, err := f.Fetch(context.TODO())
+	require.Equal(t, 1, v)
+	require.NoError(t, err)
+
+	v, err = f.Fetch(context.TODO())
+	require.Equal(t, 2, v)
+	require.NoError(t, err)
+}
+
+// After a successful call, f.Fetch does not fail
+func TestFetcherUsesCachedValue(t *testing.T) {
+	count := 0
+	f := Fetcher{
+		Name: "test",
+		Attempt: func(ctx context.Context) (interface{}, error) {
+			count++
+			if count%2 == 0 {
+				return nil, fmt.Errorf("uhoh")
+			}
+			return count, nil
+		},
+	}
+
+	for iter, exp := range []int{1, 1, 3, 3, 5, 5} {
+		v, err := f.Fetch(context.TODO())
+		require.Equal(t, exp, v, "on iteration %d", iter)
+		require.NoError(t, err)
+	}
+}
+
+// Errors are logged with LogFailure
+func TestFetcherLogsWhenUsingCached(t *testing.T) {
+	count := 0
+	errs := []string{}
+	f := Fetcher{
+		Attempt: func(ctx context.Context) (interface{}, error) {
+			count++
+			if count%2 == 0 {
+				return nil, fmt.Errorf("uhoh")
+			}
+			return count, nil
+		},
+		LogFailure: func(err error, v interface{}) {
+			errs = append(errs, fmt.Sprintf("%v, %v", err, v))
+		},
+	}
+
+	for iter, exp := range []int{1, 1, 3, 3} {
+		v, err := f.Fetch(context.TODO())
+		require.Equal(t, exp, v, "on iteration %d", iter)
+		require.NoError(t, err)
+	}
+
+	require.Equal(t, []string{"uhoh, 1", "uhoh, 3"}, errs)
+}
+
+// FetchString casts to a string
+func TestFetchString(t *testing.T) {
+	f := Fetcher{
+		Attempt: func(ctx context.Context) (interface{}, error) { return "hello", nil },
+	}
+	v, err := f.FetchString(context.TODO())
+	require.Equal(t, "hello", v)
+	require.NoError(t, err)
+}
+
+// FetchString casts to a string
+func TestFetchStringError(t *testing.T) {
+	f := Fetcher{
+		Attempt: func(ctx context.Context) (interface{}, error) { return nil, fmt.Errorf("uhoh") },
+	}
+	v, err := f.FetchString(context.TODO())
+	require.Equal(t, "", v)
+	require.Error(t, err)
+}
+
+func TestReset(t *testing.T) {
+	succeed := func(ctx context.Context) (interface{}, error) { return "yay", nil }
+	fail := func(ctx context.Context) (interface{}, error) { return nil, fmt.Errorf("uhoh") }
+	f := Fetcher{}
+
+	f.Attempt = succeed
+	v, err := f.FetchString(context.TODO())
+	require.Equal(t, "yay", v)
+	require.NoError(t, err)
+
+	f.Attempt = fail
+	v, err = f.FetchString(context.TODO())
+	require.Equal(t, "yay", v)
+	require.NoError(t, err)
+
+	f.Reset()
+
+	v, err = f.FetchString(context.TODO())
+	require.Equal(t, "", v)
+	require.Error(t, err)
+}

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -17,7 +17,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/cachedfetch"
 	"github.com/DataDog/datadog-agent/pkg/util/common"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -39,51 +39,50 @@ var (
 	tokenRenewalWindow = 15 * time.Second
 	// CloudProviderName contains the inventory name of for EC2
 	CloudProviderName = "AWS"
-
-	// cache keys
-	instanceIDCacheKey = cache.BuildAgentKey("ec2", "GetInstanceID")
-	hostnameCacheKey   = cache.BuildAgentKey("ec2", "GetHostname")
 )
+
+var instanceIDFetcher = cachedfetch.Fetcher{
+	Name: "EC2 InstanceID",
+	Attempt: func(ctx context.Context) (interface{}, error) {
+		return getMetadataItemWithMaxLength(ctx,
+			"/instance-id",
+			config.Datadog.GetInt("metadata_endpoints_max_hostname_size"),
+		)
+	},
+}
 
 // GetInstanceID fetches the instance id for current host from the EC2 metadata API
 func GetInstanceID(ctx context.Context) (string, error) {
-	if !config.IsCloudProviderEnabled(CloudProviderName) {
-		return "", fmt.Errorf("cloud provider is disabled by configuration")
-	}
+	return instanceIDFetcher.FetchString(ctx)
+}
 
-	instanceID, err := getMetadataItemWithMaxLength(ctx, "/instance-id", config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
-	if err != nil {
-		if instanceID, found := cache.Cache.Get(instanceIDCacheKey); found {
-			log.Debugf("Unable to get ec2 instanceID from aws metadata, returning cached instanceID '%s': %s", instanceID, err)
-			return instanceID.(string), nil
-		}
-		return "", err
-	}
-
-	cache.Cache.Set(instanceIDCacheKey, instanceID, cache.NoExpiration)
-
-	return instanceID, nil
+var localIPv4Fetcher = cachedfetch.Fetcher{
+	Name: "EC2 Local IPv4 Address",
+	Attempt: func(ctx context.Context) (interface{}, error) {
+		return getMetadataItem(ctx, "/local-ipv4")
+	},
 }
 
 // GetLocalIPv4 gets the local IPv4 for the currently running host using the EC2 metadata API.
 // Returns a []string to implement the HostIPProvider interface expected in pkg/process/util
 func GetLocalIPv4() ([]string, error) {
-	if !config.IsCloudProviderEnabled(CloudProviderName) {
-		return nil, fmt.Errorf("cloud provider is disabled by configuration")
-	}
-	ip, err := getMetadataItem(context.TODO(), "/local-ipv4")
+	v, err := localIPv4Fetcher.Fetch(context.TODO())
 	if err != nil {
 		return nil, err
 	}
-	return []string{ip}, nil
+	return []string{v.(string)}, nil
+}
+
+var publicIPv4Fetcher = cachedfetch.Fetcher{
+	Name: "EC2 Public IPv4 Address",
+	Attempt: func(ctx context.Context) (interface{}, error) {
+		return getMetadataItem(ctx, "/public-ipv4")
+	},
 }
 
 // GetPublicIPv4 gets the public IPv4 for the currently running host using the EC2 metadata API.
 func GetPublicIPv4(ctx context.Context) (string, error) {
-	if !config.IsCloudProviderEnabled(CloudProviderName) {
-		return "", fmt.Errorf("cloud provider is disabled by configuration")
-	}
-	return getMetadataItem(ctx, "/public-ipv4")
+	return publicIPv4Fetcher.FetchString(ctx)
 }
 
 // IsRunningOn returns true if the agent is running on AWS
@@ -94,61 +93,60 @@ func IsRunningOn(ctx context.Context) bool {
 	return false
 }
 
+var hostnameFetcher = cachedfetch.Fetcher{
+	Name: "EC2 Hostname",
+	Attempt: func(ctx context.Context) (interface{}, error) {
+		return getMetadataItemWithMaxLength(ctx,
+			"/hostname",
+			config.Datadog.GetInt("metadata_endpoints_max_hostname_size"),
+		)
+	},
+}
+
 // GetHostname fetches the hostname for current host from the EC2 metadata API
 func GetHostname(ctx context.Context) (string, error) {
-	if !config.IsCloudProviderEnabled(CloudProviderName) {
-		return "", fmt.Errorf("cloud provider is disabled by configuration")
-	}
+	return hostnameFetcher.FetchString(ctx)
+}
 
-	hostname, err := getMetadataItemWithMaxLength(ctx, "/hostname", config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
-	if err != nil {
-		if hostname, found := cache.Cache.Get(hostnameCacheKey); found {
-			log.Debugf("Unable to get ec2 hostname from aws metadata, returning cached hostname '%s': %s", hostname, err)
-			return hostname.(string), nil
+var networkIDFetcher = cachedfetch.Fetcher{
+	Name: "VPC IDs",
+	Attempt: func(ctx context.Context) (interface{}, error) {
+		resp, err := getMetadataItem(ctx, "/network/interfaces/macs")
+		if err != nil {
+			return "", err
 		}
-		return "", err
-	}
 
-	cache.Cache.Set(hostnameCacheKey, hostname, cache.NoExpiration)
+		macs := strings.Split(strings.TrimSpace(resp), "\n")
+		vpcIDs := common.NewStringSet()
 
-	return hostname, nil
+		for _, mac := range macs {
+			if mac == "" {
+				continue
+			}
+			mac = strings.TrimSuffix(mac, "/")
+			id, err := getMetadataItem(ctx, fmt.Sprintf("/network/interfaces/macs/%s/vpc-id", mac))
+			if err != nil {
+				return "", err
+			}
+			vpcIDs.Add(id)
+		}
+
+		switch len(vpcIDs) {
+		case 0:
+			return "", fmt.Errorf("EC2: GetNetworkID no mac addresses returned")
+		case 1:
+			return vpcIDs.GetAll()[0], nil
+		default:
+			return "", fmt.Errorf("EC2: GetNetworkID too many mac addresses returned")
+		}
+	},
 }
 
 // GetNetworkID retrieves the network ID using the EC2 metadata endpoint. For
 // EC2 instances, the the network ID is the VPC ID, if the instance is found to
 // be a part of exactly one VPC.
 func GetNetworkID(ctx context.Context) (string, error) {
-	if !config.IsCloudProviderEnabled(CloudProviderName) {
-		return "", fmt.Errorf("cloud provider is disabled by configuration")
-	}
-	resp, err := getMetadataItem(ctx, "/network/interfaces/macs")
-	if err != nil {
-		return "", err
-	}
-
-	macs := strings.Split(strings.TrimSpace(resp), "\n")
-	vpcIDs := common.NewStringSet()
-
-	for _, mac := range macs {
-		if mac == "" {
-			continue
-		}
-		mac = strings.TrimSuffix(mac, "/")
-		id, err := getMetadataItem(ctx, fmt.Sprintf("/network/interfaces/macs/%s/vpc-id", mac))
-		if err != nil {
-			return "", err
-		}
-		vpcIDs.Add(id)
-	}
-
-	switch len(vpcIDs) {
-	case 0:
-		return "", fmt.Errorf("EC2: GetNetworkID no mac addresses returned")
-	case 1:
-		return vpcIDs.GetAll()[0], nil
-	default:
-		return "", fmt.Errorf("EC2: GetNetworkID too many mac addresses returned")
-	}
+	return networkIDFetcher.FetchString(ctx)
 }
 
 // Subnet stores information about an AWS subnet
@@ -160,11 +158,6 @@ type Subnet struct {
 // GetSubnetForHardwareAddr returns info about the subnet associated with a hardware
 // address (mac address) on the current host
 func GetSubnetForHardwareAddr(ctx context.Context, hwAddr net.HardwareAddr) (subnet Subnet, err error) {
-	if !config.IsCloudProviderEnabled(CloudProviderName) {
-		err = fmt.Errorf("cloud provider is disabled by configuration")
-		return
-	}
-
 	if len(hwAddr) == 0 {
 		err = fmt.Errorf("could not get subnet for empty hw addr")
 		return
@@ -209,6 +202,10 @@ func getMetadataItemWithMaxLength(ctx context.Context, endpoint string, maxLengt
 }
 
 func getMetadataItem(ctx context.Context, endpoint string) (string, error) {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return "", fmt.Errorf("cloud provider is disabled by configuration")
+	}
+
 	res, err := doHTTPRequest(ctx, metadataURL+endpoint, http.MethodGet, map[string]string{}, config.Datadog.GetBool("ec2_prefer_imdsv2"))
 	if err != nil {
 		return "", fmt.Errorf("unable to fetch EC2 API, %s", err)

--- a/pkg/util/ec2/ec2_test.go
+++ b/pkg/util/ec2/ec2_test.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -32,6 +31,12 @@ func resetPackageVars() {
 	metadataURL = initialMetadataURL
 	tokenURL = initialTokenURL
 	token = ec2Token{}
+
+	instanceIDFetcher.Reset()
+	localIPv4Fetcher.Reset()
+	publicIPv4Fetcher.Reset()
+	hostnameFetcher.Reset()
+	networkIDFetcher.Reset()
 }
 
 func TestIsDefaultHostname(t *testing.T) {
@@ -153,7 +158,8 @@ func TestGetHostname(t *testing.T) {
 	assert.Equal(t, lastRequest.URL.Path, "/hostname")
 
 	// clear internal cache
-	cache.Cache.Delete(hostnameCacheKey)
+	hostnameFetcher.Reset()
+
 	// ensure we get an empty string along with the error when not on EC2
 	metadataURL = "foo"
 	val, err = GetHostname(ctx)

--- a/pkg/util/gce/gce.go
+++ b/pkg/util/gce/gce.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/cachedfetch"
 	"github.com/DataDog/datadog-agent/pkg/util/common"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -23,7 +24,7 @@ import (
 var (
 	metadataURL = "http://169.254.169.254/computeMetadata/v1"
 
-	// CloudProviderName contains the inventory name of for EC2
+	// CloudProviderName contains the inventory name of the cloud
 	CloudProviderName = "GCP"
 )
 
@@ -35,25 +36,25 @@ func IsRunningOn(ctx context.Context) bool {
 	return false
 }
 
+var hostnameFetcher = cachedfetch.Fetcher{
+	Name: "GCP Hostname",
+	Attempt: func(ctx context.Context) (interface{}, error) {
+		hostname, err := getResponseWithMaxLength(ctx, metadataURL+"/instance/hostname",
+			config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
+		if err != nil {
+			return "", fmt.Errorf("unable to retrieve hostname from GCE: %s", err)
+		}
+		return hostname, nil
+	},
+}
+
 // GetHostname returns the hostname querying GCE Metadata api
 func GetHostname(ctx context.Context) (string, error) {
-	if !config.IsCloudProviderEnabled(CloudProviderName) {
-		return "", fmt.Errorf("cloud provider is disabled by configuration")
-	}
-	hostname, err := getResponseWithMaxLength(ctx, metadataURL+"/instance/hostname",
-		config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
-	if err != nil {
-		return "", fmt.Errorf("unable to retrieve hostname from GCE: %s", err)
-	}
-	return hostname, nil
+	return hostnameFetcher.FetchString(ctx)
 }
 
 // GetHostAliases returns the host aliases from GCE
 func GetHostAliases(ctx context.Context) ([]string, error) {
-	if !config.IsCloudProviderEnabled(CloudProviderName) {
-		return nil, fmt.Errorf("cloud provider is disabled by configuration")
-	}
-
 	aliases := []string{}
 
 	hostname, err := GetHostname(ctx)
@@ -72,9 +73,30 @@ func GetHostAliases(ctx context.Context) ([]string, error) {
 	return aliases, nil
 }
 
+var nameFetcher = cachedfetch.Fetcher{
+	Name: "GCP Instance Name",
+	Attempt: func(ctx context.Context) (interface{}, error) {
+		return getResponseWithMaxLength(ctx,
+			metadataURL+"/instance/name",
+			config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
+	},
+}
+
+var projectIDFetcher = cachedfetch.Fetcher{
+	Name: "GCP Project ID",
+	Attempt: func(ctx context.Context) (interface{}, error) {
+		projectID, err := getResponseWithMaxLength(ctx,
+			metadataURL+"/project/project-id",
+			config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
+		if err != nil {
+			return "", fmt.Errorf("unable to retrieve project ID from GCE: %s", err)
+		}
+		return projectID, err
+	},
+}
+
 func getInstanceAlias(ctx context.Context, hostname string) (string, error) {
-	instanceName, err := getResponseWithMaxLength(ctx, metadataURL+"/instance/name",
-		config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
+	instanceName, err := nameFetcher.FetchString(ctx)
 	if err != nil {
 		// If the endpoint is not reachable, fallback on the old way to get the alias.
 		// For instance, it happens in GKE, where the metadata server is only a subset
@@ -86,76 +108,87 @@ func getInstanceAlias(ctx context.Context, hostname string) (string, error) {
 		instanceName = strings.SplitN(hostname, ".", 2)[0]
 	}
 
-	projectID, err := getResponseWithMaxLength(ctx, metadataURL+"/project/project-id",
-		config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
+	projectID, err := projectIDFetcher.FetchString(ctx)
 	if err != nil {
-		return "", fmt.Errorf("unable to retrieve project ID from GCE: %s", err)
+		return "", err
 	}
+
 	return fmt.Sprintf("%s.%s", instanceName, projectID), nil
+}
+
+var clusterNameFetcher = cachedfetch.Fetcher{
+	Name: "GCP Cluster Name",
+	Attempt: func(ctx context.Context) (interface{}, error) {
+		clusterName, err := getResponseWithMaxLength(ctx, metadataURL+"/instance/attributes/cluster-name",
+			config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
+		if err != nil {
+			return "", fmt.Errorf("unable to retrieve clustername from GCE: %s", err)
+		}
+		return clusterName, nil
+	},
 }
 
 // GetClusterName returns the name of the cluster containing the current GCE instance
 func GetClusterName(ctx context.Context) (string, error) {
-	if !config.IsCloudProviderEnabled(CloudProviderName) {
-		return "", fmt.Errorf("cloud provider is disabled by configuration")
-	}
-	clusterName, err := getResponseWithMaxLength(ctx, metadataURL+"/instance/attributes/cluster-name",
-		config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
-	if err != nil {
-		return "", fmt.Errorf("unable to retrieve clustername from GCE: %s", err)
-	}
-	return clusterName, nil
+	return clusterNameFetcher.FetchString(ctx)
+}
+
+var publicIPv4Fetcher = cachedfetch.Fetcher{
+	Name: "GCP Public IP",
+	Attempt: func(ctx context.Context) (interface{}, error) {
+		publicIPv4, err := getResponseWithMaxLength(ctx, metadataURL+"/instance/network-interfaces/0/access-configs/0/external-ip",
+			config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
+		if err != nil {
+			return "", fmt.Errorf("unable to retrieve public IPv4 from GCE: %s", err)
+		}
+		return publicIPv4, nil
+	},
 }
 
 // GetPublicIPv4 returns the public IPv4 address of the current GCE instance
 func GetPublicIPv4(ctx context.Context) (string, error) {
-	if !config.IsCloudProviderEnabled(CloudProviderName) {
-		return "", fmt.Errorf("cloud provider is disabled by configuration")
-	}
-	publicIPv4, err := getResponseWithMaxLength(ctx, metadataURL+"/instance/network-interfaces/0/access-configs/0/external-ip",
-		config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
-	if err != nil {
-		return "", fmt.Errorf("unable to retrieve public IPv4 from GCE: %s", err)
-	}
-	return publicIPv4, nil
+	return publicIPv4Fetcher.FetchString(ctx)
+}
+
+var networkIDFetcher = cachedfetch.Fetcher{
+	Name: "GCP Network ID",
+	Attempt: func(ctx context.Context) (interface{}, error) {
+		resp, err := getResponse(ctx, metadataURL+"/instance/network-interfaces/")
+		if err != nil {
+			return "", fmt.Errorf("unable to retrieve network-interfaces from GCE: %s", err)
+		}
+
+		interfaceIDs := strings.Split(strings.TrimSpace(resp), "\n")
+		vpcIDs := common.NewStringSet()
+
+		for _, interfaceID := range interfaceIDs {
+			if interfaceID == "" {
+				continue
+			}
+			interfaceID = strings.TrimSuffix(interfaceID, "/")
+			id, err := getResponse(ctx, metadataURL+fmt.Sprintf("/instance/network-interfaces/%s/network", interfaceID))
+			if err != nil {
+				return "", err
+			}
+			vpcIDs.Add(id)
+		}
+
+		switch len(vpcIDs) {
+		case 0:
+			return "", fmt.Errorf("zero network interfaces detected")
+		case 1:
+			return vpcIDs.GetAll()[0], nil
+		default:
+			return "", fmt.Errorf("more than one network interface detected, cannot get network ID")
+		}
+	},
 }
 
 // GetNetworkID retrieves the network ID using the metadata endpoint. For
 // GCE instances, the the network ID is the VPC ID, if the instance is found to
 // be a part of exactly one VPC.
 func GetNetworkID(ctx context.Context) (string, error) {
-	if !config.IsCloudProviderEnabled(CloudProviderName) {
-		return "", fmt.Errorf("cloud provider is disabled by configuration")
-	}
-	resp, err := getResponse(ctx, metadataURL+"/instance/network-interfaces/")
-	if err != nil {
-		return "", fmt.Errorf("unable to retrieve network-interfaces from GCE: %s", err)
-	}
-
-	interfaceIDs := strings.Split(strings.TrimSpace(resp), "\n")
-	vpcIDs := common.NewStringSet()
-
-	for _, interfaceID := range interfaceIDs {
-		if interfaceID == "" {
-			continue
-		}
-		interfaceID = strings.TrimSuffix(interfaceID, "/")
-		id, err := getResponse(ctx, metadataURL+fmt.Sprintf("/instance/network-interfaces/%s/network", interfaceID))
-		if err != nil {
-			return "", err
-		}
-		vpcIDs.Add(id)
-	}
-
-	switch len(vpcIDs) {
-	case 0:
-		return "", fmt.Errorf("zero network interfaces detected")
-	case 1:
-		return vpcIDs.GetAll()[0], nil
-	default:
-		return "", fmt.Errorf("more than one network interface detected, cannot get network ID")
-	}
-
+	return networkIDFetcher.FetchString(ctx)
 }
 
 // GetNTPHosts returns the NTP hosts for GCE if it is detected as the cloud provider, otherwise an empty array.
@@ -180,6 +213,10 @@ func getResponseWithMaxLength(ctx context.Context, endpoint string, maxLength in
 }
 
 func getResponse(ctx context.Context, url string) (string, error) {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return "", fmt.Errorf("cloud provider is disabled by configuration")
+	}
+
 	client := http.Client{
 		Transport: httputils.CreateHTTPTransport(),
 		Timeout:   time.Duration(config.Datadog.GetInt("gce_metadata_timeout")) * time.Millisecond,

--- a/pkg/util/gce/gce_test.go
+++ b/pkg/util/gce/gce_test.go
@@ -18,7 +18,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
+func reset() {
+	hostnameFetcher.Reset()
+	nameFetcher.Reset()
+	clusterNameFetcher.Reset()
+	publicIPv4Fetcher.Reset()
+	networkIDFetcher.Reset()
+}
+
 func TestGetHostname(t *testing.T) {
+	reset()
 	ctx := context.Background()
 	expected := "gke-cluster-massi-agent59-default-pool-6087cc76-9cfa"
 	var lastRequest *http.Request
@@ -37,6 +46,7 @@ func TestGetHostname(t *testing.T) {
 }
 
 func TestGetHostnameEmptyBody(t *testing.T) {
+	reset()
 	ctx := context.Background()
 	var lastRequest *http.Request
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -53,6 +63,7 @@ func TestGetHostnameEmptyBody(t *testing.T) {
 }
 
 func TestGetHostAliases(t *testing.T) {
+	reset()
 	ctx := context.Background()
 	lastRequests := []*http.Request{}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -78,6 +89,7 @@ func TestGetHostAliases(t *testing.T) {
 }
 
 func TestGetHostAliasesInstanceNameError(t *testing.T) {
+	reset()
 	ctx := context.Background()
 	lastRequests := []*http.Request{}
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -103,6 +115,7 @@ func TestGetHostAliasesInstanceNameError(t *testing.T) {
 }
 
 func TestGetClusterName(t *testing.T) {
+	reset()
 	ctx := context.Background()
 	expected := "test-cluster-name"
 	var lastRequest *http.Request
@@ -121,6 +134,7 @@ func TestGetClusterName(t *testing.T) {
 }
 
 func TestGetPublicIPv4(t *testing.T) {
+	reset()
 	ctx := context.Background()
 	expected := "10.0.0.2"
 	var lastRequest *http.Request
@@ -139,6 +153,7 @@ func TestGetPublicIPv4(t *testing.T) {
 }
 
 func TestGetNetwork(t *testing.T) {
+	reset()
 	ctx := context.Background()
 	expected := "projects/123456789/networks/my-network-name"
 
@@ -162,6 +177,7 @@ func TestGetNetwork(t *testing.T) {
 }
 
 func TestGetNetworkNoInferface(t *testing.T) {
+	reset()
 	ctx := context.Background()
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/plain")
@@ -176,6 +192,7 @@ func TestGetNetworkNoInferface(t *testing.T) {
 }
 
 func TestGetNetworkMultipleVPC(t *testing.T) {
+	reset()
 	ctx := context.Background()
 	vpc := "projects/123456789/networks/my-network-name"
 	vpcOther := "projects/123456789/networks/my-other-name"

--- a/pkg/util/tencent/tencent.go
+++ b/pkg/util/tencent/tencent.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/cachedfetch"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -35,22 +36,23 @@ func IsRunningOn(ctx context.Context) bool {
 
 // GetHostAlias returns the VM ID from the Tencent Metadata api
 func GetHostAlias(ctx context.Context) (string, error) {
-	if !config.IsCloudProviderEnabled(CloudProviderName) {
-		return "", fmt.Errorf("cloud provider is disabled by configuration")
-	}
 	return GetInstanceID(ctx)
+}
+
+var instanceIDFetcher = cachedfetch.Fetcher{
+	Name: "Tencent InstanceID",
+	Attempt: func(ctx context.Context) (interface{}, error) {
+		res, err := getMetadataItemWithMaxLength(ctx, metadataURL+"/meta-data/instance-id", config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
+		if err != nil {
+			return "", fmt.Errorf("unable to get TencentCloud CVM instanceID: %s", err)
+		}
+		return res, err
+	},
 }
 
 // GetInstanceID fetches the instance id for current host from the Tencent metadata API
 func GetInstanceID(ctx context.Context) (string, error) {
-	if !config.IsCloudProviderEnabled(CloudProviderName) {
-		return "", fmt.Errorf("cloud provider is disabled by configuration")
-	}
-	res, err := getMetadataItemWithMaxLength(ctx, metadataURL+"/meta-data/instance-id", config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
-	if err != nil {
-		return "", fmt.Errorf("unable to get TencentCloud CVM instanceID: %s", err)
-	}
-	return res, err
+	return instanceIDFetcher.FetchString(ctx)
 }
 
 // HostnameProvider gets the hostname
@@ -81,6 +83,10 @@ func getMetadataItemWithMaxLength(ctx context.Context, endpoint string, maxLengt
 }
 
 func getMetadataItem(ctx context.Context, endpoint string) (string, error) {
+	if !config.IsCloudProviderEnabled(CloudProviderName) {
+		return "", fmt.Errorf("cloud provider is disabled by configuration")
+	}
+
 	res, err := getResponse(ctx, endpoint)
 	if err != nil {
 		return "", fmt.Errorf("unable to fetch Tencent Metadata API, %s", err)

--- a/releasenotes/notes/retry_cloud_apis-f87cd3a868a150eb.yaml
+++ b/releasenotes/notes/retry_cloud_apis-f87cd3a868a150eb.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Calls to cloud metadata APIs for metadata like hostnames and IP addresses
+    are now cached and the existing values used when the metadata service
+    returns an error.  This will prevent such metadata from temporarily
+    "disappearing" from hosts.


### PR DESCRIPTION
This adds a new cached_fetch.Fetcher, returning cached data on error.

It then uses this functionality to avoid losing tags when metadata servers fail, which appears to happen frequently in at least one cloud.

### Motivation

Support issue

### Describe how to test your changes

Create an instance in each cloud, running an agent, and verify in the host metadata:

* EC2
  * instance ID is correct
  * local IP is correct
  * public IP is correct
  * hostname is correct (based on IP)
  * network name is the name of the VPC the host is in
* GCP
  * it may be easiest to hop on a k8s node to test this
  * hostname is correct (based on instance hostname)
  * host aliases contains hostname and `$instancename.$projectid`
  * cluster name is correct (I suspect this is "" for an instance that is not a k8s node)
  * public IP is correct
  * network ID is correct (name of the network containing the IP)
* Tencent
  * instance ID, host aliases, and hostname are all equal to the hostname
* Alibaba
  * Host aliases contain the instance id
* Azure
  * Use a resource group named `mc_somerg_somecluster_somezone` (note: this may require elevated permissions)
  * Hostname is the VM name
  * Host aliases contain the vmID
  * Cluster name is `somecluster`
