### PR TITLE
DOCS-2215 Add @env variables to datadog.yaml

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2173,12 +2173,14 @@ api_key:
 ###################################
 
 ## @param ecs_agent_container_name - string - optional - default: ecs-agent
+## @env DD_ECS_AGENT_CONTAINER_NAME - string - optional - default: ecs-agent
 ## The ECS Agent container should be autodetected when running with the
 ## default (ecs-agent) name. If not, change the container name here:
 #
 # ecs_agent_container_name: ecs-agent
 
 ## @param ecs_agent_url - string - optional - default: http://localhost:51678
+## @env DD_ECS_AGENT_URL - string - optional - default: http://localhost:51678
 ## The ECS Agent container should be autodetected when running with the
 ## default (ecs-agent) name. If not, change the container name the
 ## Agent should look for with ecs_agent_container_name, or force a fixed url here:
@@ -2186,6 +2188,7 @@ api_key:
 # ecs_agent_url: http://localhost:51678
 
 ## @param ecs_collect_resource_tags_ec2 - boolean - optional - default: false
+## @env DD_ECS_COLLECT_RESOURCE_TAGS_EC2 - boolean - optional - default: false
 ## The Agent can collect resource tags from the metadata API exposed by the
 ## ECS Agent for tasks scheduled with the EC2 launch type.
 #
@@ -2209,6 +2212,7 @@ api_key:
 ###################################
 
 ## @param cri_socket_path - string - optional - default: ""
+## @env DD_CRI_SOCKET_PATH - string - optional - default: ""
 ## To activate the CRI check, indicate the path of the CRI socket you're using
 ## and mount it in the container if needed.
 ## If left empty, the CRI check is disabled.
@@ -2217,11 +2221,13 @@ api_key:
 # cri_socket_path: ""
 
 ## @param cri_connection_timeout - integer - optional - default: 5
+## @env DD_CRI_CONNECTION_TIMEOUT - integer - optional - default: 5
 ## Configure the initial connection timeout in seconds.
 #
 # cri_connection_timeout: 5
 
 ## @param cri_query_timeout - integer - optional - default: 5
+## @env DD_CRI_QUERY_TIMEOUT - integer - optional - default: 5
 ## Configure the timeout in seconds for querying the CRI.
 #
 # cri_query_timeout: 5
@@ -2234,6 +2240,7 @@ api_key:
 ##########################################
 
 ## @param cri_socket_path - string - optional - default: /var/run/containerd/containerd.sock
+## @env DD_CRI_SOCKET_PATH - string - optional - default: /var/run/containerd/containerd.sock
 ## To activate the Containerd check, indicate the path of the Containerd socket you're using
 ## and mount it in the container if needed.
 ## see: https://docs.datadoghq.com/integrations/containerd/
@@ -2241,11 +2248,13 @@ api_key:
 # cri_socket_path: /var/run/containerd/containerd.sock
 
 ## @param cri_query_timeout - integer - optional - default: 5
+## @env DD_CRI_QUERY_TIMEOUT - integer - optional - default: 5
 ## Configure the timeout in seconds for querying the Containerd API.
 #
 # cri_query_timeout: 5
 
 ## @param containerd_namespace - string - optional - default: k8s.io
+## @env DD_CONTAINERD_NAMESPACE - string - optional - default: k8s.io
 ## Activating the Containerd check also activates the CRI check, as it contains an additional subset of useful metrics.
 ## Specify here the namespace that Containerd is using on your system. As the Containerd check
 ## only supports Kubernetes, the default value is `k8s.io`
@@ -2261,34 +2270,40 @@ api_key:
 ###################################################
 
 ## @param kubernetes_kubelet_host - string - optional
+## @env DD_KUBERNETES_KUBELET_HOST - string - optional
 ## The kubelet host should be autodetected when running inside a pod.
 ## If you run into connectivity issues, set the host here according to your cluster setup.
 #
 # kubernetes_kubelet_host: <KUBLET_HOST>
 
 ## @param kubernetes_http_kubelet_port - integer - optional - default: 10255
+## @env DD_KUBERNETES_HTTP_KUBELET_PORT - integer - optional - default: 10255
 ## The kubelet http port should be autodetected when running inside a pod.
 ## If you run into connectivity issues, set the http port here according to your cluster setup.
 #
 # kubernetes_http_kubelet_port: 10255
 
 ## @param kubernetes_https_kubelet_port - integer - optional - default: 10250
+## @env DD_KUBERNETES_HTTPS_KUBELET_PORT - integer - optional - default: 10250
 ## The kubelet https port should be autodetected when running inside a pod.
 ## If you run into connectivity issues, set the https port here according to your cluster setup.
 #
 # kubernetes_https_kubelet_port: 10250
 
 ## @param kubelet_tls_verify - boolean - optional - default: true
+## @env DD_KUBELET_TLS_VERIFY - boolean - optional - default: true
 ## Set to false if you don't want the Agent to verify the kubelet's certificate when using HTTPS.
 #
 # kubelet_tls_verify: true
 
 ## @param kubelet_client_ca - string - optional - default: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+## @env DD_KUBELET_CLIENT_CA - string - optional - default: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 ## Kublet client CA file path.
 #
 # kubelet_client_ca: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
 
 ## @param kubelet_auth_token_path - string - optional
+## @env DD_KUBELET_AUTH_TOKEN_PATH - string - optional
 ## If authentication is needed, the Agent uses the pod's service account's
 ## credentials. If you want to use a different account, or are running the Agent
 ## on the host, set a custom token file path here.
@@ -2296,16 +2311,19 @@ api_key:
 # kubelet_auth_token_path: <TOKEN_FILE_PATH>
 
 ## @param kubelet_client_crt - string - optional
+## @env DD_KUBELET_CLIENT_CRT - string - optional
 ## Set a custom Client CRT file path.
 #
 # kubelet_client_crt: <CRT_FILE_PATH>
 
 ## @param kubelet_client_key - string - optional
+## @env DD_KUBELET_CLIENT_KEY - string - optional
 ## Set a custom Client key file path.
 #
 # kubelet_client_key: <CLIENT_KEY_FILE_PATH>
 
 ## @param kubelet_wait_on_missing_container - integer - optional - default: 0
+## @env DD_KUBELET_WAIT_ON_MISSING_CONTAINER - integer - optional - default: 0
 ## On some kubelet versions, containers can take up to a second to
 ## register in the podlist. This option allows to wait for up to a given
 ## number of seconds (in 250ms chunks) when a container does not exist in the podlist.
@@ -2313,17 +2331,20 @@ api_key:
 # kubelet_wait_on_missing_container: 0
 
 ## @param kubelet_cache_pods_duration - integer - optional - default: 5
+## @env DD_KUBELET_CACHE_PODS_DURATION - integer - optional - default: 5
 ## Polling frequency in seconds of the Agent to the kubelet "/pods" endpoint.
 #
 # kubelet_cache_pods_duration: 5
 
 ## @param kubernetes_pod_expiration_duration - integer - optional - default: 900
+## @env DD_KUBERNETES_POD_EXPIRATION_DURATION - integer - optional - default: 900
 ## Set the time in second after which the Agent ignores the pods that have exited.
 ## Set the duration to 0 to disable this filtering.
 #
 # kubernetes_pod_expiration_duration: 900
 
 ## @param kubelet_listener_polling_interval - integer - optional - default: 5
+## @env DD_KUBELET_LISTENER_POLLING_INTERVAL - integer - optional - default: 5
 ## Polling frequency in seconds at which autodiscovery will query the pod watcher to detect new pods/containers.
 ## Note that kubelet_cache_pods_duration needs to be lower than this setting, or autodiscovery will only poll more frequently the same cached data (kubelet_cache_pods_duration controls the cache refresh frequency).
 #


### PR DESCRIPTION
### What does this PR do?

- Add `@env` variables to datadog.yaml:

```
DD_CONTAINERD_NAMESPACE
DD_CRI_CONNECTION_TIMEOUT
DD_CRI_QUERY_TIMEOUT
DD_CRI_SOCKET_PATH
DD_ECS_AGENT_CONTAINER_NAME
DD_ECS_AGENT_URL
DD_ECS_COLLECT_RESOURCE_TAGS_EC2
DD_KUBELET_AUTH_TOKEN_PATH
DD_KUBELET_CACHE_PODS_DURATION
DD_KUBELET_CLIENT_CA
DD_KUBELET_CLIENT_CRT
DD_KUBELET_CLIENT_KEY
DD_KUBELET_LISTENER_POLLING_INTERVAL
DD_KUBELET_TLS_VERIFY
DD_KUBELET_WAIT_ON_MISSING_CONTAINER
DD_KUBERNETES_HTTP_KUBELET_PORT
DD_KUBERNETES_HTTPS_KUBELET_PORT
DD_KUBERNETES_KUBELET_HOST
DD_KUBERNETES_POD_EXPIRATION_DURATION
```

### Motivation

- Documentation OKR
- [RFC](https://github.com/DataDog/architecture/blob/master/rfcs/agent-env-var-docs/rfc.md)

### Additional Notes

Variables will be added in small batches.

### Describe how to test your changes

N/A

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
