### PR TITLE
Trigger pipelines: do not run always

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -486,14 +486,6 @@ variables:
     when: manual
     allow_failure: true
 
-.on_deploy_stable_or_beta_repo_branch_a6_always:
-  - <<: *if_not_version_6
-    when: never
-  - <<: *if_not_stable_or_beta_repo_branch
-    when: never
-  - <<: *if_deploy
-    when: always
-
 .on_deploy_stable_or_beta_repo_branch_a7:
   - <<: *if_not_version_7
     when: never
@@ -525,14 +517,6 @@ variables:
   - <<: *if_deploy
     when: manual
     allow_failure: true
-
-.on_deploy_stable_or_beta_repo_branch_a7_always:
-  - <<: *if_not_version_7
-    when: never
-  - <<: *if_not_stable_or_beta_repo_branch
-    when: never
-  - <<: *if_deploy
-    when: always
 
 .on_deploy_stable_repo_branch_a7_manual:
   - <<: *if_not_version_7

--- a/.gitlab/trigger_release.yml
+++ b/.gitlab/trigger_release.yml
@@ -10,19 +10,16 @@
     - python3 -m pip install -r requirements.txt
     - inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-release-management" --git-ref "master" --variables "RELEASE_VERSION"
 
-# The trigger jobs are always run (even on failing pipelines)
-# because there's no way to retry a trigger job once it gets skipped
-# because of a pipeline failure, even when retrying the pipeline.
 trigger_release_6:
   extends: .agent_release_management_trigger
   rules:
-    !reference [.on_deploy_stable_or_beta_repo_branch_a6_always]
+    !reference [.on_deploy_stable_or_beta_repo_branch_a6]
   before_script:
     - export RELEASE_VERSION=$(inv -e agent.version --major-version 6 --url-safe --omnibus-format)-1
 
 trigger_release_7:
   extends: .agent_release_management_trigger
   rules:
-    !reference [.on_deploy_stable_or_beta_repo_branch_a7_always]
+    !reference [.on_deploy_stable_or_beta_repo_branch_a7]
   before_script:
     - export RELEASE_VERSION=$(inv -e agent.version --major-version 7 --url-safe --omnibus-format)-1


### PR DESCRIPTION
### What does this PR do?

Removes a workaround that is no longer needed because we don't use Gitlab's
trigger keyword.

