### PR TITLE
Add a --follow option to trigger-child-pipeline

### DIFF
--- a/.gitlab/docker_common/publish_job_templates.yml
+++ b/.gitlab/docker_common/publish_job_templates.yml
@@ -11,7 +11,7 @@
     <<: *docker_variables
     IMG_VARIABLES: ""
   script: # We can't use the 'trigger' keyword on manual jobs, otherwise they can't be run if the pipeline fails and is retried
-    - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_read_api_token --with-decryption --query "Parameter.Value" --out text)
+    - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
     - python3 -m pip install -r requirements.txt
     - ECR_RELEASE_SUFFIX="${CI_COMMIT_TAG+-release}"
     - IMG_SOURCES="$(sed -E "s#(${SRC_AGENT}|${SRC_DSD}|${SRC_DCA})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_SOURCES")"

--- a/.gitlab/docker_common/publish_job_templates.yml
+++ b/.gitlab/docker_common/publish_job_templates.yml
@@ -11,6 +11,7 @@
     <<: *docker_variables
     IMG_VARIABLES: ""
   script: # We can't use the 'trigger' keyword on manual jobs, otherwise they can't be run if the pipeline fails and is retried
+    - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_read_api_token --with-decryption --query "Parameter.Value" --out text)
     - python3 -m pip install -r requirements.txt
     - ECR_RELEASE_SUFFIX="${CI_COMMIT_TAG+-release}"
     - IMG_SOURCES="$(sed -E "s#(${SRC_AGENT}|${SRC_DSD}|${SRC_DCA})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_SOURCES")"

--- a/.gitlab/trigger_release.yml
+++ b/.gitlab/trigger_release.yml
@@ -8,7 +8,7 @@
   tags: ["runner:main"]
   script:
     - python3 -m pip install -r requirements.txt
-    - inv pipeline.trigger-child-pipeline --project-name "DataDog/agent-release-management" --git-ref "master" --variables "RELEASE_VERSION"
+    - inv pipeline.trigger-child-pipeline --no-follow --project-name "DataDog/agent-release-management" --git-ref "master" --variables "RELEASE_VERSION"
 
 trigger_release_6:
   extends: .agent_release_management_trigger

--- a/tasks/libs/pipeline_tools.py
+++ b/tasks/libs/pipeline_tools.py
@@ -157,14 +157,14 @@ def get_commit_for_pipeline(gitlab, pipeline_id):
 
 def loop_status(callable, timeout_sec):
     """
-    Utility to loop a function that takes and returns a status, until it returns True.
+    Utility to loop a function that takes a status and returns [done, status], until done is True.
     """
     start = time()
     status = dict()
     while True:
-        res, status = callable(status)
-        if res:
-            return res
+        done, status = callable(status)
+        if done:
+            return status
         if time() - start > timeout_sec:
             raise ErrorMsg("Timed out.")
         sleep(10)

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -284,12 +284,13 @@ def run(
 
 
 @task
-def follow(ctx, id=None, git_ref=None, here=False):
+def follow(ctx, id=None, git_ref=None, here=False, project_name="DataDog/datadog-agent"):
     """
     Follow a pipeline's progress in the CLI.
     Use --here to follow the latest pipeline on your current branch.
     Use --git-ref to follow the latest pipeline on a given tag or branch.
     Use --id to follow a specific pipeline.
+    Use --project-name to specify a repo other than DataDog/datadog-agent (default)
 
     Examples:
     inv pipeline.follow --git-ref my-branch
@@ -297,7 +298,6 @@ def follow(ctx, id=None, git_ref=None, here=False):
     inv pipeline.follow --id 1234567
     """
 
-    project_name = "DataDog/datadog-agent"
     gitlab = Gitlab(project_name=project_name, api_token=get_gitlab_token())
     gitlab.test_project_found()
 


### PR DESCRIPTION
### What does this PR do?

When `follow` is True (it is by default), the task waits for the pipeline to finish and fails if the pipeline fails.

### Motivation

We want to bubble up errors from triggered child pipelines on the main pipeline, to not miss failures.