### PR TITLE
[Windows][Kitchen tests] Don't check that datadog.yaml was removed

### DIFF
--- a/test/kitchen/test/integration/win-install-fail/rspec/win-install-fail_spec.rb
+++ b/test/kitchen/test/integration/win-install-fail/rspec/win-install-fail_spec.rb
@@ -1,5 +1,5 @@
 
-  
+
 
 def check_user_exists(name)
   selectstatement = "powershell -command \"get-wmiobject -query \\\"Select * from Win32_UserAccount where Name='#{name}'\\\"\""
@@ -13,7 +13,9 @@ shared_examples_for 'a device with no files installed' do
   it 'has no DataDog program data directory' do
     expect(File).not_to exist("#{ENV['ProgramData']}\\DataDog\\conf.d")
     expect(File).not_to exist("#{ENV['ProgramData']}\\DataDog\\checks.d")
-    expect(File).not_to exist("#{ENV['ProgramData']}\\DataDog\\datadog.yaml")
+    # Do not check that the datadog.yaml file was removed because once it's created
+    # it's risky to delete it.
+    # expect(File).not_to exist("#{ENV['ProgramData']}\\DataDog\\datadog.yaml")
     expect(File).not_to exist("#{ENV['ProgramData']}\\DataDog\\auth_token")
   end
 end
@@ -28,4 +30,3 @@ describe 'dd-agent-win-install-fail' do
   it_behaves_like 'a device with no files installed'
   it_behaves_like 'a device with no dd-agent-user'
 end
-  


### PR DESCRIPTION
### What does this PR do?

This PR fixes the `win-install-fail` kitchen test, which broke because of #9504 
This is because with the previous logic the `datadog.yaml` file was managed by the MSI installer whereas it's no longer the case. The test `win-install-fail` should therefore no longer test the absence of `datadog.yaml`.

### Motivation

The tests must pass.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
