### PR TITLE
[workloadmeta/containerd] Watch tasks to properly set the "running" status

### DIFF
--- a/pkg/util/containerd/containerd_util.go
+++ b/pkg/util/containerd/containerd_util.go
@@ -295,7 +295,11 @@ func (c *ContainerdUtil) Status(ctn containerd.Container) (containerd.ProcessSta
 		return "", err
 	}
 
-	taskStatus, err := task.Status(ctx)
+	ctx, cancel = context.WithTimeout(context.Background(), c.queryTimeout)
+	defer cancel()
+	ctxNamespace = namespaces.WithNamespace(ctx, c.namespace)
+
+	taskStatus, err := task.Status(ctxNamespace)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/workloadmeta/collectors/containerd/container_builder.go
+++ b/pkg/workloadmeta/collectors/containerd/container_builder.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/errdefs"
 
 	cutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
@@ -50,7 +51,14 @@ func buildWorkloadMetaContainer(container containerd.Container, containerdClient
 
 	status, err := containerdClient.Status(container)
 	if err != nil {
-		return workloadmeta.Container{}, err
+		if !errdefs.IsNotFound(err) {
+			return workloadmeta.Container{}, err
+		}
+
+		// The container exists, but there isn't a task associated to it. That
+		// means that the container is not running, which is all we need to know
+		// in this function (we can set any status != containerd.Running).
+		status = ""
 	}
 
 	// Some attributes in workloadmeta.Container cannot be fetched from

--- a/pkg/workloadmeta/collectors/containerd/containerd.go
+++ b/pkg/workloadmeta/collectors/containerd/containerd.go
@@ -32,6 +32,16 @@ const (
 	containerCreationTopic = "/containers/create"
 	containerUpdateTopic   = "/containers/update"
 	containerDeletionTopic = "/containers/delete"
+
+	// These are not all the task-related topics, but enough to detect changes
+	// in the state of the container (only need to know if it's running or not).
+
+	TaskStartTopic   = "/tasks/start"
+	TaskOOMTopic     = "/tasks/oom"
+	TaskExitTopic    = "/tasks/exit"
+	TaskDeleteTopic  = "/tasks/delete"
+	TaskPausedTopic  = "/tasks/paused"
+	TaskResumedTopic = "/tasks/resumed"
 )
 
 // containerLifecycleFilters allows subscribing to containers lifecycle updates only.
@@ -39,6 +49,12 @@ var containerLifecycleFilters = []string{
 	fmt.Sprintf(`topic==%q`, containerCreationTopic),
 	fmt.Sprintf(`topic==%q`, containerUpdateTopic),
 	fmt.Sprintf(`topic==%q`, containerDeletionTopic),
+	fmt.Sprintf(`topic==%q`, TaskStartTopic),
+	fmt.Sprintf(`topic==%q`, TaskOOMTopic),
+	fmt.Sprintf(`topic==%q`, TaskExitTopic),
+	fmt.Sprintf(`topic==%q`, TaskDeleteTopic),
+	fmt.Sprintf(`topic==%q`, TaskPausedTopic),
+	fmt.Sprintf(`topic==%q`, TaskResumedTopic),
 }
 
 type collector struct {

--- a/pkg/workloadmeta/collectors/containerd/event_builder.go
+++ b/pkg/workloadmeta/collectors/containerd/event_builder.go
@@ -19,16 +19,29 @@ import (
 
 // buildCollectorEvent generates a CollectorEvent from a containerdevents.Envelope
 func buildCollectorEvent(ctx context.Context, containerdEvent *containerdevents.Envelope, containerdClient cutil.ContainerdItf) (workloadmeta.CollectorEvent, error) {
-	ID, hasID := containerdEvent.Field([]string{"event", "id"})
-	if !hasID {
-		return workloadmeta.CollectorEvent{}, fmt.Errorf("missing ID in containerd event")
-	}
-
 	switch containerdEvent.Topic {
 	case containerCreationTopic, containerUpdateTopic:
+		ID, hasID := containerdEvent.Field([]string{"event", "id"})
+		if !hasID {
+			return workloadmeta.CollectorEvent{}, fmt.Errorf("missing ID in containerd event")
+		}
+
 		return createSetEvent(ctx, ID, containerdClient)
 	case containerDeletionTopic:
+		ID, hasID := containerdEvent.Field([]string{"event", "id"})
+		if !hasID {
+			return workloadmeta.CollectorEvent{}, fmt.Errorf("missing ID in containerd event")
+		}
+
 		return createDeletionEvent(ID), nil
+	case TaskStartTopic, TaskOOMTopic, TaskExitTopic, TaskDeleteTopic, TaskPausedTopic, TaskResumedTopic:
+		// Notice that the ID field in this case is stored in "ContainerID".
+		ID, hasID := containerdEvent.Field([]string{"event", "container_id"})
+		if !hasID {
+			return workloadmeta.CollectorEvent{}, fmt.Errorf("missing ID in containerd event")
+		}
+
+		return createSetEvent(ctx, ID, containerdClient)
 	default:
 		return workloadmeta.CollectorEvent{}, fmt.Errorf("unknown action type %s, ignoring", containerdEvent.Topic)
 	}

--- a/pkg/workloadmeta/collectors/containerd/event_builder_test.go
+++ b/pkg/workloadmeta/collectors/containerd/event_builder_test.go
@@ -38,18 +38,48 @@ func TestBuildCollectorEvent(t *testing.T) {
 	workloadMetaContainer, err := buildWorkloadMetaContainer(&container, &client)
 	assert.NoError(t, err)
 
-	creationEvent, err := proto.Marshal(&events.ContainerCreate{
+	containerCreationEvent, err := proto.Marshal(&events.ContainerCreate{
 		ID: containerID,
 	})
 	assert.NoError(t, err)
 
-	updateEvent, err := proto.Marshal(&events.ContainerUpdate{
+	containerUpdateEvent, err := proto.Marshal(&events.ContainerUpdate{
 		ID: containerID,
 	})
 	assert.NoError(t, err)
 
-	deleteEvent, err := proto.Marshal(&events.ContainerDelete{
+	containerDeleteEvent, err := proto.Marshal(&events.ContainerDelete{
 		ID: containerID,
+	})
+	assert.NoError(t, err)
+
+	taskStartEvent, err := proto.Marshal(&events.TaskStart{
+		ContainerID: containerID,
+	})
+	assert.NoError(t, err)
+
+	taskOOMEvent, err := proto.Marshal(&events.TaskOOM{
+		ContainerID: containerID,
+	})
+	assert.NoError(t, err)
+
+	taskExitEvent, err := proto.Marshal(&events.TaskExit{
+		ContainerID: containerID,
+	})
+	assert.NoError(t, err)
+
+	taskDeleteEvent, err := proto.Marshal(&events.TaskDelete{
+		ContainerID: containerID,
+	})
+	assert.NoError(t, err)
+
+	taskPausedEvent, err := proto.Marshal(&events.TaskPaused{
+		ContainerID: containerID,
+	})
+	assert.NoError(t, err)
+
+	taskResumedEvent, err := proto.Marshal(&events.TaskResumed{
+		ContainerID: containerID,
 	})
 	assert.NoError(t, err)
 
@@ -65,11 +95,11 @@ func TestBuildCollectorEvent(t *testing.T) {
 		expectsError  bool
 	}{
 		{
-			name: "create event",
+			name: "container create event",
 			event: containerdevents.Envelope{
 				Topic: containerCreationTopic,
 				Event: &types.Any{
-					TypeUrl: "containerd.events.ContainerCreate", Value: creationEvent,
+					TypeUrl: "containerd.events.ContainerCreate", Value: containerCreationEvent,
 				},
 			},
 			expectedEvent: workloadmeta.CollectorEvent{
@@ -79,11 +109,11 @@ func TestBuildCollectorEvent(t *testing.T) {
 			},
 		},
 		{
-			name: "update event",
+			name: "container update event",
 			event: containerdevents.Envelope{
 				Topic: containerUpdateTopic,
 				Event: &types.Any{
-					TypeUrl: "containerd.events.ContainerUpdate", Value: updateEvent,
+					TypeUrl: "containerd.events.ContainerUpdate", Value: containerUpdateEvent,
 				},
 			},
 			expectedEvent: workloadmeta.CollectorEvent{
@@ -93,11 +123,11 @@ func TestBuildCollectorEvent(t *testing.T) {
 			},
 		},
 		{
-			name: "delete event",
+			name: "container delete event",
 			event: containerdevents.Envelope{
 				Topic: containerDeletionTopic,
 				Event: &types.Any{
-					TypeUrl: "containerd.events.ContainerDelete", Value: deleteEvent,
+					TypeUrl: "containerd.events.ContainerDelete", Value: containerDeleteEvent,
 				},
 			},
 			expectedEvent: workloadmeta.CollectorEvent{
@@ -115,7 +145,7 @@ func TestBuildCollectorEvent(t *testing.T) {
 				Topic: "Unknown Topic", // This causes the error
 				Event: &types.Any{
 					// Uses delete, but could be any other event in this test
-					TypeUrl: "containerd.events.ContainerDelete", Value: deleteEvent,
+					TypeUrl: "containerd.events.ContainerDelete", Value: containerDeleteEvent,
 				},
 			},
 			expectsError: true,
@@ -129,6 +159,90 @@ func TestBuildCollectorEvent(t *testing.T) {
 				},
 			},
 			expectsError: true,
+		},
+		{
+			name: "task start event",
+			event: containerdevents.Envelope{
+				Topic: TaskStartTopic,
+				Event: &types.Any{
+					TypeUrl: "containerd.events.TaskStart", Value: taskStartEvent,
+				},
+			},
+			expectedEvent: workloadmeta.CollectorEvent{
+				Type:   workloadmeta.EventTypeSet,
+				Source: collectorID,
+				Entity: &workloadMetaContainer,
+			},
+		},
+		{
+			name: "task OOM event",
+			event: containerdevents.Envelope{
+				Topic: TaskOOMTopic,
+				Event: &types.Any{
+					TypeUrl: "containerd.events.TaskOOM", Value: taskOOMEvent,
+				},
+			},
+			expectedEvent: workloadmeta.CollectorEvent{
+				Type:   workloadmeta.EventTypeSet,
+				Source: collectorID,
+				Entity: &workloadMetaContainer,
+			},
+		},
+		{
+			name: "task exit event",
+			event: containerdevents.Envelope{
+				Topic: TaskExitTopic,
+				Event: &types.Any{
+					TypeUrl: "containerd.events.TaskExit", Value: taskExitEvent,
+				},
+			},
+			expectedEvent: workloadmeta.CollectorEvent{
+				Type:   workloadmeta.EventTypeSet,
+				Source: collectorID,
+				Entity: &workloadMetaContainer,
+			},
+		},
+		{
+			name: "task delete event",
+			event: containerdevents.Envelope{
+				Topic: TaskDeleteTopic,
+				Event: &types.Any{
+					TypeUrl: "containerd.events.TaskDelete", Value: taskDeleteEvent,
+				},
+			},
+			expectedEvent: workloadmeta.CollectorEvent{
+				Type:   workloadmeta.EventTypeSet,
+				Source: collectorID,
+				Entity: &workloadMetaContainer,
+			},
+		},
+		{
+			name: "task paused event",
+			event: containerdevents.Envelope{
+				Topic: TaskStartTopic,
+				Event: &types.Any{
+					TypeUrl: "containerd.events.TaskPaused", Value: taskPausedEvent,
+				},
+			},
+			expectedEvent: workloadmeta.CollectorEvent{
+				Type:   workloadmeta.EventTypeSet,
+				Source: collectorID,
+				Entity: &workloadMetaContainer,
+			},
+		},
+		{
+			name: "task resumed event",
+			event: containerdevents.Envelope{
+				Topic: TaskStartTopic,
+				Event: &types.Any{
+					TypeUrl: "containerd.events.TaskResumed", Value: taskResumedEvent,
+				},
+			},
+			expectedEvent: workloadmeta.CollectorEvent{
+				Type:   workloadmeta.EventTypeSet,
+				Source: collectorID,
+				Entity: &workloadMetaContainer,
+			},
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in the workloadmeta containerd collector introduced in https://github.com/DataDog/datadog-agent/pull/9530.
The `State.Running` attribute of the `workloadmeta.Container`s generated was not correct. This PR modifies the collector so it watches "task" containerd events (and not only container events like before). Task events are the ones that contain the necessary information to determine whether a container is running, stopped, paused, etc.

### Describe how to test your changes

Same instructions as https://github.com/DataDog/datadog-agent/pull/9530

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
