### PR TITLE
Add retry to customaction build invoke task

### DIFF
--- a/tasks/customaction.py
+++ b/tasks/customaction.py
@@ -10,12 +10,36 @@ import sys
 from invoke import task
 from invoke.exceptions import Exit
 
+from tasks.libs.common.color import color_message
+
 from .utils import get_version, get_version_numeric_only
 
 # constants
 BIN_PATH = os.path.join(".", "bin", "agent")
 AGENT_TAG = "datadog/agent:master"
 CUSTOM_ACTION_ROOT_DIR = "tools\\windows\\install-help"
+
+
+def try_run(ctx, cmd, n):
+    """
+    Tries to run a command n number of times. If after n tries it still
+    fails, returns False.
+    """
+
+    i = 0
+    while i < n:
+        i += 1
+        res = ctx.run(cmd, warn=True)
+        if res.exited is None or res.exited > 0:
+            print(
+                color_message(
+                    "Failed to run \"{}\" - retrying".format(cmd),
+                    "orange",
+                )
+            )
+            continue
+        return True
+    return False
 
 
 @task
@@ -60,7 +84,13 @@ def build(ctx, vstudio_root=None, arch="x64", major_version='7', debug=False):
     cmd += verprops
     print("Build Command: %s" % cmd)
 
-    ctx.run(cmd)
+    # Try to run the command 3 times to alleviate transient
+    # network failures
+    succeeded = try_run(ctx, cmd, 3)
+    if not succeeded:
+        print("Failed to build the customaction.")
+        raise Exit(code=1)
+
     artefacts = [
         {"source": "customaction.dll", "target": "customaction.dll"},
         {"source": "customaction.pdb", "target": "customaction-{}.pdb".format(package_version)},

--- a/tasks/customaction.py
+++ b/tasks/customaction.py
@@ -26,9 +26,7 @@ def try_run(ctx, cmd, n):
     fails, returns False.
     """
 
-    i = 0
-    while i < n:
-        i += 1
+    for _ in range(n):
         res = ctx.run(cmd, warn=True)
         if res.exited is None or res.exited > 0:
             print(
@@ -88,8 +86,7 @@ def build(ctx, vstudio_root=None, arch="x64", major_version='7', debug=False):
     # network failures
     succeeded = try_run(ctx, cmd, 3)
     if not succeeded:
-        print("Failed to build the customaction.")
-        raise Exit(code=1)
+        raise Exit("Failed to build the customaction.", code=1)
 
     artefacts = [
         {"source": "customaction.dll", "target": "customaction.dll"},


### PR DESCRIPTION
### What does this PR do?

This PR adds a retry logic to the customaction build invoke task.

### Motivation

Prevent transient network failures from failing an entire build by retrying up to 3 times.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
