### PR TITLE
Fix ebpf tracer close consumer stats

### DIFF
--- a/pkg/network/tracer/connection/kprobe/tcp_close_consumer.go
+++ b/pkg/network/tracer/connection/kprobe/tcp_close_consumer.go
@@ -12,6 +12,11 @@ import (
 	"github.com/DataDog/ebpf/manager"
 )
 
+const (
+	perfReceivedStat = "perf_recv"
+	perfLostStat     = "perf_lost"
+)
+
 type tcpCloseConsumer struct {
 	perfHandler  *ddebpf.PerfHandler
 	batchManager *perfBatchManager
@@ -60,8 +65,8 @@ func (c *tcpCloseConsumer) FlushPending() {
 
 func (c *tcpCloseConsumer) GetStats() map[string]int64 {
 	return map[string]int64{
-		"perf_recv": atomic.SwapInt64(&c.perfReceived, 0),
-		"perf_lost": atomic.SwapInt64(&c.perfLost, 0),
+		perfReceivedStat: atomic.SwapInt64(&c.perfReceived, 0),
+		perfLostStat:     atomic.SwapInt64(&c.perfLost, 0),
 	}
 }
 

--- a/pkg/network/tracer/connection/kprobe/tracer.go
+++ b/pkg/network/tracer/connection/kprobe/tracer.go
@@ -272,8 +272,8 @@ func (t *kprobeTracer) GetTelemetry() map[string]int64 {
 	pidCollisions := atomic.LoadInt64(&t.pidCollisions)
 
 	return map[string]int64{
-		"closed_conn_polling_lost":     closeStats["lost"],
-		"closed_conn_polling_received": closeStats["rcvd"],
+		"closed_conn_polling_lost":     closeStats[perfLostStat],
+		"closed_conn_polling_received": closeStats[perfReceivedStat],
 		"pid_collisions":               pidCollisions,
 
 		"tcp_sent_miscounts":         int64(telemetry.Tcp_sent_miscounts),


### PR DESCRIPTION
### What does this PR do?

Fixes a mismatch in stats names between reporting and reading

### Motivation

Improved expvar stats.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
