### PR TITLE
Support configurable container log path

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -745,6 +745,11 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_default_match_timeout", 30) // Seconds
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_default_match_threshold", 0.48)
 
+	// If true, the agent looks for container logs in the location used by podman, rather
+	// than docker.  This is a temporary configuration parameter to support podman logs until
+	// a more substantial refactor of autodiscovery is made to determine this automatically.
+	config.BindEnvAndSetDefault("logs_config.use_podman_logs", false)
+
 	config.BindEnvAndSetDefault("logs_config.auditor_ttl", DefaultAuditorTTL) // in hours
 	// Timeout in milliseonds used when performing agreggation operations,
 	// including multi-line log processing rules and chunked line reaggregation.

--- a/pkg/logs/input/docker/launcher_test.go
+++ b/pkg/logs/input/docker/launcher_test.go
@@ -8,12 +8,15 @@
 package docker
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
+	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker/api/types"
 )
@@ -177,4 +180,23 @@ func TestGetFileSource(t *testing.T) {
 			assert.Equal(t, tt.wantRules, fileSource.source.Config.ProcessingRules)
 		})
 	}
+}
+
+func TestGetPath(t *testing.T) {
+	t.Run("use_podman_logs=false", func(t *testing.T) {
+		mockConfig := coreConfig.Mock()
+		mockConfig.Set("logs_config.use_podman_logs", false)
+
+		require.Equal(t,
+			filepath.Join(basePath, "123abc/123abc-json.log"),
+			getPath("123abc"))
+	})
+	t.Run("use_podman_logs=true", func(t *testing.T) {
+		mockConfig := coreConfig.Mock()
+		mockConfig.Set("logs_config.use_podman_logs", true)
+
+		require.Equal(t,
+			"/var/lib/containers/storage/overlay-containers/123abc/userdata/ctr.log",
+			getPath("123abc"))
+	})
 }


### PR DESCRIPTION
### What does this PR do?

Allows users to configure the path at which their container runtime stores logs for containers

### Describe how to test your changes

Set up an agent logging container logs, and verify this by starting a container up and seeing its logs.

```
log_payloads: true
log_level: debug
logs_enabled: true
listeners:
    - name: docker
config_providers:
    - name: docker
      polling: true
logs_config:
    container_collect_all: true
```
Configure `logs_config.container_log_path_template` to something bogus and try again.  Errors should appear:

```
Could not collect files: file <bogus> does not exist
```
