### PR TITLE
Update agent-payload and its dep mmh3

### DIFF
--- a/.wwhrd.yml
+++ b/.wwhrd.yml
@@ -16,9 +16,8 @@ allowlist:
   - NewBSD
   - FreeBSD
 
-overrides:
-  # https://datadoghq.atlassian.net/browse/AC-1296
-  "github.com/DataDog/mmh3": "MIT"
+overrides: {}
+  # format is `package: licence`
 
 exceptions:
   - "golang.org/x/mobile/..."

--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	code.cloudfoundry.org/rep v0.0.0-20200325195957-1404b978e31e // indirect
 	code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a // indirect
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
-	github.com/DataDog/agent-payload v4.85.0+incompatible
+	github.com/DataDog/agent-payload v4.87.0+incompatible
 	github.com/DataDog/datadog-agent/pkg/otlp/model v0.32.0-rc.6
 	github.com/DataDog/datadog-agent/pkg/quantile v0.32.0-rc.6
 	github.com/DataDog/datadog-agent/pkg/util/log v0.32.0-rc.6
@@ -59,7 +59,7 @@ require (
 	github.com/DataDog/ebpf-manager v0.0.0-20210917155050-c174a8b45802
 	github.com/DataDog/gohai v0.0.0-20210303102637-6b668acb50dd
 	github.com/DataDog/gopsutil v0.0.0-20210930103100-d4e8ef640507
-	github.com/DataDog/mmh3 v0.0.0-20200316233529-f5b682d8c981 // indirect
+	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect
 	github.com/DataDog/nikos v1.5.0
 	github.com/DataDog/sketches-go v1.2.1
 	github.com/DataDog/viper v1.9.0

--- a/go.sum
+++ b/go.sum
@@ -106,8 +106,8 @@ github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBp
 github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
-github.com/DataDog/agent-payload v4.85.0+incompatible h1:AjNteNxI3nIuGbvJu1VmxujE8lJHukdZgEp6v/wAA6Y=
-github.com/DataDog/agent-payload v4.85.0+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
+github.com/DataDog/agent-payload v4.87.0+incompatible h1:jw/Azd1EjYwkwwuBeOPw0BRPgDKMKS2CQm5XRgUFZ7o=
+github.com/DataDog/agent-payload v4.87.0+incompatible/go.mod h1:/2RW4IC/2z54jtB6RLgq5UtVI1TsX0joDRjKbkLT+mk=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/DataDog/datadog-api-client-go v1.0.0-beta.18/go.mod h1:Gn0fZwIOBbSidO0OaPEh9nO5EmIPsxJrHfHvfVXEaoU=
@@ -131,8 +131,8 @@ github.com/DataDog/gopsutil v0.0.0-20210930103100-d4e8ef640507 h1:fMNabkPHX5nxj3
 github.com/DataDog/gopsutil v0.0.0-20210930103100-d4e8ef640507/go.mod h1:glkxNt/qRu9lnpmUEQwOIAXW+COWDTBOTEAHqbgBPts=
 github.com/DataDog/gostackparse v0.5.0 h1:jb72P6GFHPHz2W0onsN51cS3FkaMDcjb0QzgxxA4gDk=
 github.com/DataDog/gostackparse v0.5.0/go.mod h1:lTfqcJKqS9KnXQGnyQMCugq3u1FP6UZMfWR0aitKFMM=
-github.com/DataDog/mmh3 v0.0.0-20200316233529-f5b682d8c981 h1:UcKqIrOowv2PjTkOC27Xm9TMZlPbRi3CK1OCoawdvl0=
-github.com/DataDog/mmh3 v0.0.0-20200316233529-f5b682d8c981/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
+github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
+github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
 github.com/DataDog/nikos v1.5.0 h1:NoKb6t2MiNX6mw6OL8mUcvidf7DRh1TAxSpbPRQQ42M=
 github.com/DataDog/nikos v1.5.0/go.mod h1:hQeaaGGsiNDI3tMlsrI/AfXBesf800q5dVKauYnAp1A=
 github.com/DataDog/sketches-go v1.2.1 h1:qTBzWLnZ3kM2kw39ymh6rMcnN+5VULwFs++lEYUUsro=


### PR DESCRIPTION
This should have no functional impact, but gets the mmh3 LICENSE in
place, avoiding the need to override it.

### Motivation

Licenses

### Describe how to test your changes

v4.86.0 changes some bits of the DNS resolution, and is used by the process agent (pkg/process/checks/net.go).

No functionality changes in v4.87.0.

