### PR TITLE
[corechecks/snmp] Strip special chars from OctetString

### DIFF
--- a/pkg/collector/corechecks/snmp/gosnmplib/gosnmp_value_test.go
+++ b/pkg/collector/corechecks/snmp/gosnmplib/gosnmp_value_test.go
@@ -63,6 +63,17 @@ func Test_getValueFromPDU(t *testing.T) {
 			nil,
 		},
 		{
+			"OctetString newline dont hexify",
+			gosnmp.SnmpPDU{
+				Name:  ".1.2.3",
+				Type:  gosnmp.OctetString,
+				Value: []byte("m\ny\rV\ta\n\r\tl"),
+			},
+			"1.2.3",
+			valuestore.ResultValue{Value: "myVal"},
+			nil,
+		},
+		{
 			"BitString",
 			gosnmp.SnmpPDU{
 				Name:  ".1.2.3",

--- a/releasenotes/notes/[ndm]-Strip-special-chars-from-OctetString-3f263b13272f41ca.yaml
+++ b/releasenotes/notes/[ndm]-Strip-special-chars-from-OctetString-3f263b13272f41ca.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Strip special characters (\n, \r and \t) from OctetString


### PR DESCRIPTION
### What does this PR do?
If an OctetString contains one of these special characters `\n`, `\t` or `\r`, the string was considered to be a byte array and was hex-ified.
Now such a string is still correctly converted to a string, and the special characters are removed.

A longer-term feature will be to provide additional configuration options to force casting into string or hex, but this will help in the generic case.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

### How to test
Make sure that there is a device in mimic where the sysName contains a new line. At time of writing, device 10.0.1.1 has a sysName of `nyc-\ncsw-123`
With an old agent version, the snmp_host tag will be something like `snmp_host:0x6e...`, with this PR we see `snmp_host:nyc-csw-123`