### PR TITLE
Allow custom filters in Docker event subscriber, fixes issue where metrics include/exclude is applied on autodiscovery

### DIFF
--- a/pkg/collector/corechecks/containers/docker/docker_events.go
+++ b/pkg/collector/corechecks/containers/docker/docker_events.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build docker && !darwin
 // +build docker,!darwin
 
 package docker
@@ -28,7 +29,7 @@ func (d *DockerCheck) retrieveEvents(du *docker.DockerUtil) ([]*docker.Container
 	if d.lastEventTime.IsZero() {
 		d.lastEventTime = time.Now().Add(-60 * time.Second)
 	}
-	events, latest, err := du.LatestContainerEvents(context.TODO(), d.lastEventTime)
+	events, latest, err := du.LatestContainerEvents(context.TODO(), d.lastEventTime, d.containerFilter)
 	if err != nil {
 		return events, err
 	}

--- a/pkg/util/containers/filter.go
+++ b/pkg/util/containers/filter.go
@@ -144,6 +144,32 @@ func GetSharedMetricFilter() (*Filter, error) {
 	return f, nil
 }
 
+// GetPauseContainerFilter returns a filter only excluding pause containers
+func GetPauseContainerFilter() (*Filter, error) {
+	var excludeList []string
+	if config.Datadog.GetBool("exclude_pause_container") {
+		excludeList = append(excludeList,
+			pauseContainerGCR,
+			pauseContainerOpenshift,
+			pauseContainerOpenshift3,
+			pauseContainerKubernetes,
+			pauseContainerGoogle,
+			pauseContainerAzure,
+			pauseContainerECS,
+			pauseContainerEKS,
+			pauseContainerRancher,
+			pauseContainerMCR,
+			pauseContainerWin,
+			pauseContainerAKS,
+			pauseContainerECR,
+			pauseContainerUpstream,
+			pauseContainerCDK,
+		)
+	}
+
+	return NewFilter(nil, excludeList)
+}
+
 // ResetSharedFilter is only to be used in unit tests: it resets the global
 // filter instance to force re-parsing of the configuration.
 func ResetSharedFilter() {

--- a/pkg/util/docker/event_pull.go
+++ b/pkg/util/docker/event_pull.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build docker
 // +build docker
 
 package docker
@@ -15,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/docker/docker/api/types"
@@ -42,7 +44,7 @@ func (d *DockerUtil) openEventChannel(ctx context.Context, since, until time.Tim
 
 // processContainerEvent formats the events from a channel.
 // It can return nil, nil if the event is filtered out, one should check for nil pointers before using the event.
-func (d *DockerUtil) processContainerEvent(ctx context.Context, msg events.Message) (*ContainerEvent, error) {
+func (d *DockerUtil) processContainerEvent(ctx context.Context, msg events.Message, filter *containers.Filter) (*ContainerEvent, error) {
 	// Type filtering
 	if msg.Type != "container" {
 		return nil, nil
@@ -68,7 +70,7 @@ func (d *DockerUtil) processContainerEvent(ctx context.Context, msg events.Messa
 			log.Warnf("can't resolve image name %s: %s", imageName, err)
 		}
 	}
-	if d.cfg.filter.IsExcluded(containerName, imageName, "") {
+	if filter != nil && filter.IsExcluded(containerName, imageName, "") {
 		log.Tracef("events from %s are skipped as the image is excluded for the event collection", containerName)
 		return nil, nil
 	}
@@ -104,7 +106,7 @@ func (d *DockerUtil) processContainerEvent(ctx context.Context, msg events.Messa
 
 // LatestContainerEvents returns events matching the filter that occurred after the time passed.
 // It returns the latest event timestamp in the slice for the user to store and pass again in the next call.
-func (d *DockerUtil) LatestContainerEvents(ctx context.Context, since time.Time) ([]*ContainerEvent, time.Time, error) {
+func (d *DockerUtil) LatestContainerEvents(ctx context.Context, since time.Time, filter *containers.Filter) ([]*ContainerEvent, time.Time, error) {
 	var events []*ContainerEvent
 	filters := map[string]string{"type": "container"}
 
@@ -117,7 +119,7 @@ func (d *DockerUtil) LatestContainerEvents(ctx context.Context, since time.Time)
 	for {
 		select {
 		case msg := <-msgChan:
-			event, err := d.processContainerEvent(ctx, msg)
+			event, err := d.processContainerEvent(ctx, msg, filter)
 			if err != nil {
 				log.Warnf("error parsing docker message: %s", err)
 				continue

--- a/pkg/util/docker/event_pull_test.go
+++ b/pkg/util/docker/event_pull_test.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build docker
 // +build docker
 
 package docker
@@ -32,9 +33,7 @@ func TestProcessContainerEvent(t *testing.T) {
 	assert.Nil(err)
 
 	dockerUtil := &DockerUtil{
-		cfg: &Config{
-			filter: filter,
-		},
+		cfg: &Config{},
 	}
 
 	for nb, tc := range []struct {
@@ -175,7 +174,7 @@ func TestProcessContainerEvent(t *testing.T) {
 		ctx := context.Background()
 
 		t.Logf("test case %d", nb)
-		event, err := dockerUtil.processContainerEvent(ctx, tc.source)
+		event, err := dockerUtil.processContainerEvent(ctx, tc.source, filter)
 		assert.Equal(tc.event, event)
 
 		if tc.err == nil {
@@ -194,5 +193,4 @@ func TestContainerEntityName(t *testing.T) {
 		ContainerID: "ada5d83e6c2d3dfaaf7dd9ff83e735915da1174dc56880c06a6c99a9a58d5c73",
 	}
 	assert.Equal(t, "container_id://ada5d83e6c2d3dfaaf7dd9ff83e735915da1174dc56880c06a6c99a9a58d5c73", ev.ContainerEntityName())
-
 }

--- a/pkg/util/docker/event_stream_test.go
+++ b/pkg/util/docker/event_stream_test.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build docker
 // +build docker
 
 package docker
@@ -17,17 +18,17 @@ func TestSubscribe(t *testing.T) {
 	state := newEventStreamState()
 	assert.Equal(t, 0, len(state.subscribers))
 
-	sub1, err := state.subscribe("listener1")
+	sub1, err := state.subscribe("listener1", nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, sub1)
 	assert.Equal(t, 1, len(state.subscribers))
 
-	sub2, err := state.subscribe("listener2")
+	sub2, err := state.subscribe("listener2", nil)
 	assert.NoError(t, err)
 	assert.NotNil(t, sub2)
 	assert.Equal(t, 2, len(state.subscribers))
 
-	_, err = state.subscribe("listener2")
+	_, err = state.subscribe("listener2", nil)
 	assert.Equal(t, ErrAlreadySubscribed, err)
 	assert.Equal(t, 2, len(state.subscribers))
 }
@@ -36,7 +37,7 @@ func TestUnsubscribe(t *testing.T) {
 	state := newEventStreamState()
 	assert.Equal(t, 0, len(state.subscribers))
 
-	_, err := state.subscribe("listener1")
+	_, err := state.subscribe("listener1", nil)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(state.subscribers))
 

--- a/pkg/util/docker/event_types.go
+++ b/pkg/util/docker/event_types.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build docker
 // +build docker
 
 package docker
@@ -11,6 +12,8 @@ import (
 	"errors"
 	"sync"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
 )
 
 const (
@@ -52,6 +55,7 @@ type eventSubscriber struct {
 	eventChan  chan *ContainerEvent
 	errorChan  chan error
 	cancelChan chan struct{}
+	filter     *containers.Filter
 }
 
 // eventStreamState holds the state for event streaming towards subscribers

--- a/releasenotes/notes/fix-docker-ad-inclexcl-766d9167baef2589.yaml
+++ b/releasenotes/notes/fix-docker-ad-inclexcl-766d9167baef2589.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix a bug where container_include/exclude_metrics was applied on Autodiscovery when using Docker, preventing logs collection configured through container_include/exclude_logs.


### PR DESCRIPTION
### What does this PR do?

Allow custom filters in Docker event subscriber, fixes issue where metrics include/exclude is applied on autodiscovery

### Motivation

Bugfix

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Run the Agent on a Docker-only environment (not Kubernetes). Deploy the agent with a configuration like:
```
      DD_LOGS_ENABLED: "true"
      DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL: "true"
      DD_CONTAINER_EXCLUDE_METRICS: image:.*
      DD_CONTAINER_EXCLUDE_LOGS: image:.*
      DD_CONTAINER_INCLUDE_LOGS: image:nginx
      DD_LOGS_CONFIG_DOCKER_CONTAINER_USE_FILE: "true"
```

After the Agent has started, run a container based on an `nginx` image:
```
docker run --rm nginx:1.20.1-alpine
```

Verify that:
- Logs are tailed for this container
- Metrics are not sent for this container (except the running/stopped metrics, which are always send)

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
