### PR TITLE
[disk] Convert /dev/root device to real device path

### DIFF
--- a/omnibus/config/patches/datadog-agent-integrations-py2/psutil-pr2000.patch
+++ b/omnibus/config/patches/datadog-agent-integrations-py2/psutil-pr2000.patch
@@ -1,3 +1,5 @@
+# convert /dev/root device to real path
+# https://github.com/giampaolo/psutil/pull/2000
 diff --git a/psutil/_pslinux.py b/psutil/_pslinux.py
 index 1917e20d0..f6a833017 100644
 --- a/psutil/_pslinux.py

--- a/omnibus/config/patches/datadog-agent-integrations-py2/psutil-pr2000.patch
+++ b/omnibus/config/patches/datadog-agent-integrations-py2/psutil-pr2000.patch
@@ -1,0 +1,94 @@
+diff --git a/psutil/_pslinux.py b/psutil/_pslinux.py
+index 1917e20d0..f6a833017 100644
+--- a/psutil/_pslinux.py
++++ b/psutil/_pslinux.py
+@@ -1189,6 +1189,80 @@ def read_sysfs():
+     return retdict
+
+
++class RootFsDeviceFinder:
++    """disk_partitions() may return partitions with device == "/dev/root"
++    or "rootfs". This container class uses different strategies to try to
++    obtain the real device path. Resources:
++    https://bootlin.com/blog/find-root-device/
++    https://www.systutorials.com/how-to-find-the-disk-where-root-is-on-in-bash-on-linux/
++    """
++    __slots__ = ['major', 'minor']
++
++    def __init__(self):
++        dev = os.stat("/").st_dev
++        self.major = os.major(dev)
++        self.minor = os.minor(dev)
++
++    def ask_proc_partitions(self):
++        with open_text("%s/partitions" % get_procfs_path()) as f:
++            for line in f.readlines()[2:]:
++                fields = line.split()
++                if len(fields) < 4:  # just for extra safety
++                    continue
++                major = int(fields[0]) if fields[0].isdigit() else None
++                minor = int(fields[1]) if fields[1].isdigit() else None
++                name = fields[3]
++                if major == self.major and minor == self.minor:
++                    if name:  # just for extra safety
++                        return "/dev/%s" % name
++
++    def ask_sys_dev_block(self):
++        path = "/sys/dev/block/%s:%s/uevent" % (self.major, self.minor)
++        with open_text(path) as f:
++            for line in f:
++                if line.startswith("DEVNAME="):
++                    name = line.strip().rpartition("DEVNAME=")[2]
++                    if name:  # just for extra safety
++                        return "/dev/%s" % name
++
++    def ask_sys_class_block(self):
++        needle = "%s:%s" % (self.major, self.minor)
++        files = glob.iglob("/sys/class/block/*/dev")
++        for file in files:
++            try:
++                f = open_text(file)
++            except FileNotFoundError:  # race condition
++                continue
++            else:
++                with f:
++                    data = f.read().strip()
++                    if data == needle:
++                        name = os.path.basename(os.path.dirname(file))
++                        return "/dev/%s" % name
++
++    def find(self):
++        path = None
++        if path is None:
++            try:
++                path = self.ask_proc_partitions()
++            except (IOError, OSError) as err:
++                debug(err)
++        if path is None:
++            try:
++                path = self.ask_sys_dev_block()
++            except (IOError, OSError) as err:
++                debug(err)
++        if path is None:
++            try:
++                path = self.ask_sys_class_block()
++            except (IOError, OSError) as err:
++                debug(err)
++        # We use exists() because the "/dev/*" part of the path is hard
++        # coded, so we want to be sure.
++        if path is not None and os.path.exists(path):
++            return path
++
++
+ def disk_partitions(all=False):
+     """Return mounted disk partitions as a list of namedtuples."""
+     fstypes = set()
+@@ -1216,6 +1290,8 @@ def disk_partitions(all=False):
+         device, mountpoint, fstype, opts = partition
+         if device == 'none':
+             device = ''
++        if device in ("/dev/root", "rootfs"):
++            device = RootFsDeviceFinder().find() or device
+         if not all:
+             if device == '' or fstype not in fstypes:
+                 continue

--- a/omnibus/config/patches/datadog-agent-integrations-py3/psutil-pr2000.patch
+++ b/omnibus/config/patches/datadog-agent-integrations-py3/psutil-pr2000.patch
@@ -1,3 +1,5 @@
+# convert /dev/root device to real path
+# https://github.com/giampaolo/psutil/pull/2000
 diff --git a/psutil/_pslinux.py b/psutil/_pslinux.py
 index 1917e20d0..f6a833017 100644
 --- a/psutil/_pslinux.py

--- a/omnibus/config/patches/datadog-agent-integrations-py3/psutil-pr2000.patch
+++ b/omnibus/config/patches/datadog-agent-integrations-py3/psutil-pr2000.patch
@@ -1,0 +1,94 @@
+diff --git a/psutil/_pslinux.py b/psutil/_pslinux.py
+index 1917e20d0..f6a833017 100644
+--- a/psutil/_pslinux.py
++++ b/psutil/_pslinux.py
+@@ -1189,6 +1189,80 @@ def read_sysfs():
+     return retdict
+
+
++class RootFsDeviceFinder:
++    """disk_partitions() may return partitions with device == "/dev/root"
++    or "rootfs". This container class uses different strategies to try to
++    obtain the real device path. Resources:
++    https://bootlin.com/blog/find-root-device/
++    https://www.systutorials.com/how-to-find-the-disk-where-root-is-on-in-bash-on-linux/
++    """
++    __slots__ = ['major', 'minor']
++
++    def __init__(self):
++        dev = os.stat("/").st_dev
++        self.major = os.major(dev)
++        self.minor = os.minor(dev)
++
++    def ask_proc_partitions(self):
++        with open_text("%s/partitions" % get_procfs_path()) as f:
++            for line in f.readlines()[2:]:
++                fields = line.split()
++                if len(fields) < 4:  # just for extra safety
++                    continue
++                major = int(fields[0]) if fields[0].isdigit() else None
++                minor = int(fields[1]) if fields[1].isdigit() else None
++                name = fields[3]
++                if major == self.major and minor == self.minor:
++                    if name:  # just for extra safety
++                        return "/dev/%s" % name
++
++    def ask_sys_dev_block(self):
++        path = "/sys/dev/block/%s:%s/uevent" % (self.major, self.minor)
++        with open_text(path) as f:
++            for line in f:
++                if line.startswith("DEVNAME="):
++                    name = line.strip().rpartition("DEVNAME=")[2]
++                    if name:  # just for extra safety
++                        return "/dev/%s" % name
++
++    def ask_sys_class_block(self):
++        needle = "%s:%s" % (self.major, self.minor)
++        files = glob.iglob("/sys/class/block/*/dev")
++        for file in files:
++            try:
++                f = open_text(file)
++            except FileNotFoundError:  # race condition
++                continue
++            else:
++                with f:
++                    data = f.read().strip()
++                    if data == needle:
++                        name = os.path.basename(os.path.dirname(file))
++                        return "/dev/%s" % name
++
++    def find(self):
++        path = None
++        if path is None:
++            try:
++                path = self.ask_proc_partitions()
++            except (IOError, OSError) as err:
++                debug(err)
++        if path is None:
++            try:
++                path = self.ask_sys_dev_block()
++            except (IOError, OSError) as err:
++                debug(err)
++        if path is None:
++            try:
++                path = self.ask_sys_class_block()
++            except (IOError, OSError) as err:
++                debug(err)
++        # We use exists() because the "/dev/*" part of the path is hard
++        # coded, so we want to be sure.
++        if path is not None and os.path.exists(path):
++            return path
++
++
+ def disk_partitions(all=False):
+     """Return mounted disk partitions as a list of namedtuples."""
+     fstypes = set()
+@@ -1216,6 +1290,8 @@ def disk_partitions(all=False):
+         device, mountpoint, fstype, opts = partition
+         if device == 'none':
+             device = ''
++        if device in ("/dev/root", "rootfs"):
++            device = RootFsDeviceFinder().find() or device
+         if not all:
+             if device == '' or fstype not in fstypes:
+                 continue

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -404,6 +404,10 @@ build do
         patch :source => "create-regex-at-runtime.patch", :target => "#{install_dir}/embedded/lib/python2.7/site-packages/yaml/reader.py"
       end
 
+      if linux?
+        patch :source => "psutil-pr2000.patch", :target => "#{install_dir}/embedded/lib/python2.7/site-packages/psutil/_pslinux.py"
+      end
+
       # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
       if windows?
         command "#{python} -m pip check"

--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -400,6 +400,10 @@ build do
       # We have to run these operations in block, so they get applied after operations
       # from the last block
 
+      if linux?
+        patch :source => "psutil-pr2000.patch", :target => "#{install_dir}/embedded/lib/python3.8/site-packages/psutil/_pslinux.py"
+      end
+
       # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible
       if windows?
         command "#{python} -m pip check"

--- a/releasenotes/notes/psutils-convert-dev-root-path-a0ce13794788f1c2.yaml
+++ b/releasenotes/notes/psutils-convert-dev-root-path-a0ce13794788f1c2.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix disk check reporting /dev/root instead of the actual
+    block device path and missing its tags when tag_by_label
+    is enabled.


### PR DESCRIPTION
### What does this PR do?

Backport of upstream PR: https://github.com/giampaolo/psutil/pull/2000

### Motivation

On some Linux setups (eg: default Ubuntu 20.04 AWS instances), psutils
would return /dev/root instead of the actual block device (eg: /dev/xvda1).

When using the `tag_by_label` option, the disk check tries to match the
output of psutil with the output of `lsblk` or `blkid` to find disk labels.
However, these return the actual path instead of /dev/root, resulting in
missing tags.

### Describe how to test your changes

Run `import psutil; psutil.disk_partitions()` on both the py2 and py3 interpreters of an Agent running on an Ubuntu 20.04 AWS instance. It should list `/dev/xvda1` with this patch and `/dev/root` without.
