### PR TITLE
[networks] Prepend paths with host file system mounting point

### DIFF
--- a/pkg/network/http/shared_libraries.go
+++ b/pkg/network/http/shared_libraries.go
@@ -178,7 +178,7 @@ func (w *soWatcher) sync(libraries []so.Library) {
 func (w *soWatcher) register(libPath string, r soRule) {
 	err := r.registerCB(libPath)
 	if err != nil {
-		log.Errorf("error registering library=%s: %s", libPath, err)
+		log.Debugf("error registering library=%s: %s", libPath, err)
 		r.unregisterCB(libPath)
 		w.registered[libPath] = nil
 		return

--- a/pkg/network/http/shared_libraries.go
+++ b/pkg/network/http/shared_libraries.go
@@ -148,20 +148,18 @@ func (w *soWatcher) sync(libraries []so.Library) {
 	old := w.registered
 	w.registered = make(map[string]func(string) error)
 
-OuterLoop:
 	for _, lib := range libraries {
+		if callback, ok := old[path]; ok {
+			w.registered[path] = callback
+			delete(old, path)
+			continue
+		}
+
 		for _, r := range w.rules {
 			path := lib.HostPath
-
-			if callback, ok := old[path]; ok {
-				w.registered[path] = callback
-				delete(old, path)
-				continue OuterLoop
-			}
-
 			if r.re.MatchString(path) {
 				w.register(path, r)
-				continue OuterLoop
+				break
 			}
 		}
 	}

--- a/pkg/network/http/shared_libraries.go
+++ b/pkg/network/http/shared_libraries.go
@@ -49,6 +49,7 @@ type soRule struct {
 // soWatcher provides a way to tie callback functions to the lifecycle of shared libraries
 type soWatcher struct {
 	procRoot   string
+	hostMount  string
 	all        *regexp.Regexp
 	rules      []soRule
 	registered map[string]func(string) error
@@ -68,6 +69,7 @@ func newSOWatcher(procRoot string, perfHandler *ddebpf.PerfHandler, rules ...soR
 	all := regexp.MustCompile(fmt.Sprintf("(%s)", strings.Join(allFilters, "|")))
 	return &soWatcher{
 		procRoot:   procRoot,
+		hostMount:  os.Getenv("HOST_FS"),
 		all:        all,
 		rules:      rules,
 		loadEvents: perfHandler,
@@ -77,7 +79,7 @@ func newSOWatcher(procRoot string, perfHandler *ddebpf.PerfHandler, rules ...soR
 // Start consuming shared-library events
 func (w *soWatcher) Start() {
 	seen := make(map[seenKey]struct{})
-	sharedLibraries := getSharedLibraries(w.procRoot, w.all)
+	sharedLibraries := w.getSharedLibraries()
 	w.sync(sharedLibraries)
 	go func() {
 		ticker := time.NewTicker(soSyncInterval)
@@ -88,7 +90,7 @@ func (w *soWatcher) Start() {
 			select {
 			case <-ticker.C:
 				seen = make(map[seenKey]struct{})
-				sharedLibraries := getSharedLibraries(w.procRoot, w.all)
+				sharedLibraries := w.getSharedLibraries()
 				w.sync(sharedLibraries)
 			case event, ok := <-w.loadEvents.DataChannel:
 				if !ok {
@@ -125,9 +127,7 @@ func (w *soWatcher) Start() {
 							libPath = hostPath
 						}
 
-						// follow symlink
-						libPath = followSymlink(libPath)
-
+						libPath = w.canonicalizePath(libPath)
 						if _, registered := w.registered[libPath]; registered {
 							break
 						}
@@ -149,6 +149,7 @@ func (w *soWatcher) sync(libraries []so.Library) {
 	w.registered = make(map[string]func(string) error)
 
 	for _, lib := range libraries {
+		path := lib.HostPath
 		if callback, ok := old[path]; ok {
 			w.registered[path] = callback
 			delete(old, path)
@@ -156,7 +157,6 @@ func (w *soWatcher) sync(libraries []so.Library) {
 		}
 
 		for _, r := range w.rules {
-			path := lib.HostPath
 			if r.re.MatchString(path) {
 				w.register(path, r)
 				break
@@ -188,45 +188,44 @@ func (w *soWatcher) register(libPath string, r soRule) {
 	w.registered[libPath] = r.unregisterCB
 }
 
-func getSharedLibraries(procRoot string, filter *regexp.Regexp) []so.Library {
+func (w *soWatcher) canonicalizePath(path string) string {
+	if w.hostMount != "" {
+		path = filepath.Join(w.hostMount, path)
+	}
+
+	return followSymlink(path)
+}
+
+func (w *soWatcher) getSharedLibraries() []so.Library {
 	// libraries will include all host-resolved library paths mapped into memory
-	libraries := so.FindProc(procRoot, filter)
+	libraries := so.FindProc(w.procRoot, w.all)
 
 	// TODO: should we ensure all entries are unique in the `so` package instead?
 	seen := make(map[string]struct{}, len(libraries))
 	i := 0
 	for _, lib := range libraries {
-		_, ok := seen[lib.HostPath]
-		if ok {
+		originalPath := lib.HostPath
+		if _, ok := seen[originalPath]; ok {
 			continue
 		}
-		seen[lib.HostPath] = struct{}{}
+		seen[originalPath] = struct{}{}
 
 		// this ensures that all symlinks are resolved only once
-		resolved := followSymlink(lib.HostPath)
-		if resolved != lib.HostPath {
-			if _, ok := seen[resolved]; ok {
+		canonicalPath := w.canonicalizePath(originalPath)
+		if canonicalPath != originalPath {
+			if _, ok := seen[canonicalPath]; ok {
 				continue
 			} else {
-				seen[resolved] = struct{}{}
-				lib.HostPath = resolved
+				seen[canonicalPath] = struct{}{}
+				lib.HostPath = canonicalPath
 			}
 		}
 
 		libraries[i] = lib
 		i++
 	}
-	libraries = libraries[0:i]
 
-	// prepend everything with the HOST_FS, which designates where the underlying
-	// host file system is mounted. This is intended for internal testing only.
-	if hostFS := os.Getenv("HOST_FS"); hostFS != "" {
-		for i, lib := range libraries {
-			libraries[i].HostPath = filepath.Join(hostFS, lib.HostPath)
-		}
-	}
-
-	return libraries
+	return libraries[0:i]
 }
 
 func followSymlink(path string) string {


### PR DESCRIPTION
### What does this PR do?

Prepends shared library paths with the host file system mounting point in case system-probe is running inside a container.

### Motivation

This is necessary when system-probe runs inside a container, but needs access to an external `.so` file.
In that case the underlying host file system must be mounted into system-probe container and configured via the `HOST_FS` environment variable.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Run system-probe inside a container mounting the whole host file system under `/host` and setting it via `HOST_FS`:

```
docker run -it -e DD_API_KEY="<DATADOG_API_KEY>" -e DD_SYSTEM_PROBE_ENABLED=true -e DD_PROCESS_AGENT_ENABLED=true -e DD_LOG_LEVEL=debug -e HOST_FS=/host -e DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTP_MONITORING=true -e DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTPS_MONITORING=true -v /var/run/docker.sock:/var/run/docker.sock:ro -v /:/host:ro -v /sys/kernel/debug:/sys/kernel/debug --security-opt apparmor:unconfined --cap-add=SYS_ADMIN --cap-add=SYS_RESOURCE --cap-add=SYS_PTRACE --cap-add=NET_ADMIN --cap-add=IPC_LOCK datadog/agent:<RC_TAG> system-probe
```

Make sure that running `curl` **outside** the agent container results in a log entry such as the following:

```
2021-10-19 13:39:53 UTC | SYS-PROBE | DEBUG | (pkg/network/http/shared_libraries.go:187 in register) | registering library=/host/usr/lib/x86_64-linux-gnu/libssl.so.1.1
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
