### PR TITLE
[rtloader] add datadog_agent.get_process_start_time

### DIFF
--- a/pkg/collector/python/datadog_agent.go
+++ b/pkg/collector/python/datadog_agent.go
@@ -432,3 +432,8 @@ var defaultSQLPlanObfuscateSettings = traceconfig.JSONObfuscationConfig{
 	}, defaultSQLPlanNormalizeSettings.KeepValues...),
 	ObfuscateSQLValues: defaultSQLPlanNormalizeSettings.ObfuscateSQLValues,
 }
+
+//export getProcessStartTime
+func getProcessStartTime() float64 {
+	return float64(config.StartTime.Unix())
+}

--- a/pkg/collector/python/init.go
+++ b/pkg/collector/python/init.go
@@ -88,6 +88,7 @@ void WritePersistentCache(char *, char *);
 bool TracemallocEnabled();
 char* ObfuscateSQL(char *, char *, char **);
 char* ObfuscateSQLExecPlan(char *, bool, char **);
+double getProcessStartTime();
 
 void initDatadogAgentModule(rtloader_t *rtloader) {
 	set_get_clustername_cb(rtloader, GetClusterName);
@@ -102,6 +103,7 @@ void initDatadogAgentModule(rtloader_t *rtloader) {
 	set_tracemalloc_enabled_cb(rtloader, TracemallocEnabled);
 	set_obfuscate_sql_cb(rtloader, ObfuscateSQL);
 	set_obfuscate_sql_exec_plan_cb(rtloader, ObfuscateSQLExecPlan);
+	set_get_process_start_time_cb(rtloader, getProcessStartTime);
 }
 
 //

--- a/rtloader/common/builtins/datadog_agent.h
+++ b/rtloader/common/builtins/datadog_agent.h
@@ -148,6 +148,7 @@ void _set_write_persistent_cache_cb(cb_write_persistent_cache_t);
 void _set_read_persistent_cache_cb(cb_read_persistent_cache_t);
 void _set_obfuscate_sql_cb(cb_obfuscate_sql_t);
 void _set_obfuscate_sql_exec_plan_cb(cb_obfuscate_sql_exec_plan_t);
+void _set_get_process_start_time_cb(cb_get_process_start_time_t);
 
 PyObject *_public_headers(PyObject *self, PyObject *args, PyObject *kwargs);
 

--- a/rtloader/include/datadog_agent_rtloader.h
+++ b/rtloader/include/datadog_agent_rtloader.h
@@ -611,6 +611,16 @@ DATADOG_AGENT_RTLOADER_API void set_obfuscate_sql_cb(rtloader_t *, cb_obfuscate_
 */
 DATADOG_AGENT_RTLOADER_API void set_obfuscate_sql_exec_plan_cb(rtloader_t *, cb_obfuscate_sql_exec_plan_t);
 
+/*! \fn void set_get_process_start_time_cb(rtloader_t *, cb_get_process_start_time_t)
+    \brief Sets a callback to be used by rtloader to retrieve agent process start time.
+    \param rtloader_t A rtloader_t * pointer to the RtLoader instance.
+    \param object A function pointer with cb_get_process_start_time_t prototype to the callback
+    function.
+
+    The callback is expected to be provided by the rtloader caller - in go-context: CGO.
+*/
+DATADOG_AGENT_RTLOADER_API void set_get_process_start_time_cb(rtloader_t *, cb_get_process_start_time_t);
+
 #ifdef __cplusplus
 }
 #endif

--- a/rtloader/include/rtloader.h
+++ b/rtloader/include/rtloader.h
@@ -441,6 +441,15 @@ public:
     */
     virtual void setObfuscateSqlExecPlanCb(cb_obfuscate_sql_exec_plan_t) = 0;
 
+    //! setGetProcessStartTimeCb member.
+    /*!
+      \param A cb_get_process_start_time_t function pointer to the CGO callback.
+
+      This allows us to set the relevant CGO callback that will allow retrieving value for
+      specific check instances.
+    */
+    virtual void setGetProcessStartTimeCb(cb_get_process_start_time_t) = 0;
+
 private:
     mutable std::string _error; /*!< string containing a RtLoader error */
     mutable bool _errorFlag; /*!< boolean indicating whether an error was set on RtLoader */

--- a/rtloader/include/rtloader_types.h
+++ b/rtloader/include/rtloader_types.h
@@ -131,6 +131,8 @@ typedef char *(*cb_read_persistent_cache_t)(char *);
 typedef char *(*cb_obfuscate_sql_t)(char *, char *, char **);
 // (exec_plan, normalize, error_message)
 typedef char *(*cb_obfuscate_sql_exec_plan_t)(char *, bool, char **);
+// ()
+typedef double (*cb_get_process_start_time_t)(void);
 
 // _util
 // (argv, env, stdout, stderr, ret_code, exception)

--- a/rtloader/rtloader/api.cpp
+++ b/rtloader/rtloader/api.cpp
@@ -556,6 +556,11 @@ void set_obfuscate_sql_exec_plan_cb(rtloader_t *rtloader, cb_obfuscate_sql_exec_
     AS_TYPE(RtLoader, rtloader)->setObfuscateSqlExecPlanCb(cb);
 }
 
+void set_get_process_start_time_cb(rtloader_t *rtloader, cb_get_process_start_time_t cb)
+{
+    AS_TYPE(RtLoader, rtloader)->setGetProcessStartTimeCb(cb);
+}
+
 /*
  * _util API
  */

--- a/rtloader/test/datadog_agent/datadog_agent.go
+++ b/rtloader/test/datadog_agent/datadog_agent.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"time"
 	"runtime"
 	"strings"
 	"unsafe"
@@ -33,6 +34,7 @@ extern void writePersistentCache(char*, char*);
 extern char* readPersistentCache(char*);
 extern char* obfuscateSQL(char*, char*, char**);
 extern char* obfuscateSQLExecPlan(char*, bool, char**);
+extern double getProcessStartTime();
 
 
 static void initDatadogAgentTests(rtloader_t *rtloader) {
@@ -50,6 +52,7 @@ static void initDatadogAgentTests(rtloader_t *rtloader) {
    set_read_persistent_cache_cb(rtloader, readPersistentCache);
    set_obfuscate_sql_cb(rtloader, obfuscateSQL);
    set_obfuscate_sql_exec_plan_cb(rtloader, obfuscateSQLExecPlan);
+   set_get_process_start_time_cb(rtloader, getProcessStartTime);
 }
 */
 import "C"
@@ -281,4 +284,11 @@ func obfuscateSQLExecPlan(rawQuery *C.char, normalize C.bool, errResult **C.char
 		*errResult = (*C.char)(helpers.TrackedCString("unknown test case"))
 		return nil
 	}
+}
+
+var processStartTime = float64(time.Now().Unix())
+
+//export getProcessStartTime
+func getProcessStartTime() float64 {
+	return processStartTime
 }

--- a/rtloader/three/three.cpp
+++ b/rtloader/three/three.cpp
@@ -945,6 +945,11 @@ void Three::setObfuscateSqlExecPlanCb(cb_obfuscate_sql_exec_plan_t cb)
     _set_obfuscate_sql_exec_plan_cb(cb);
 }
 
+void Three::setGetProcessStartTimeCb(cb_get_process_start_time_t cb)
+{
+    _set_get_process_start_time_cb(cb);
+}
+
 // Python Helpers
 
 // get_integration_list return a list of every datadog's wheels installed.

--- a/rtloader/three/three.h
+++ b/rtloader/three/three.h
@@ -108,6 +108,7 @@ public:
     void setReadPersistentCacheCb(cb_read_persistent_cache_t);
     void setObfuscateSqlCb(cb_obfuscate_sql_t);
     void setObfuscateSqlExecPlanCb(cb_obfuscate_sql_exec_plan_t);
+    void setGetProcessStartTimeCb(cb_get_process_start_time_t);
 
     // _util API
     virtual void setSubprocessOutputCb(cb_get_subprocess_output_t);

--- a/rtloader/two/two.cpp
+++ b/rtloader/two/two.cpp
@@ -941,6 +941,11 @@ void Two::setObfuscateSqlExecPlanCb(cb_obfuscate_sql_exec_plan_t cb)
     _set_obfuscate_sql_exec_plan_cb(cb);
 }
 
+void Two::setGetProcessStartTimeCb(cb_get_process_start_time_t cb)
+{
+    _set_get_process_start_time_cb(cb);
+}
+
 // Python Helpers
 
 // get_integration_list return a list of every datadog's wheels installed.

--- a/rtloader/two/two.h
+++ b/rtloader/two/two.h
@@ -107,6 +107,7 @@ public:
     void setReadPersistentCacheCb(cb_read_persistent_cache_t);
     void setObfuscateSqlCb(cb_obfuscate_sql_t);
     void setObfuscateSqlExecPlanCb(cb_obfuscate_sql_exec_plan_t);
+    void setGetProcessStartTimeCb(cb_get_process_start_time_t);
 
     // _util API
     virtual void setSubprocessOutputCb(cb_get_subprocess_output_t);


### PR DESCRIPTION
### What does this PR do?

Add a new method to return datadog agent process start time, in seconds since the epoch.

### Motivation

This will be used by the openmetrics check to decide whether to submit counter values on the first scrape.

### How to test changes

What really needs QA is https://github.com/DataDog/integrations-core/pull/10463

See [this link](https://github.com/DataDog/croissant-integration-resources/tree/master/kubernetes/monotonic-count-first-sample) (internal) for pre-set test scenario.

1. Run a openmetrics server that reports a counter and increments it once soon after start up (before first scrape from the agent).
2. Run the agent with a openmetrics integration enabled.
3. Verify the integration works (by checking one of the default metrics from the openmetrics exporter). The counter from step one should be missing.
4. Enable `use_process_start_time` option on the openmetrics check instance.
5. Restart the server, and verify that the counter metric from step 1 is resent.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
