### PR TITLE
[networks] Fix eBPF program clone

### DIFF
--- a/pkg/network/http/ebpf_ssl.go
+++ b/pkg/network/http/ebpf_ssl.go
@@ -191,7 +191,12 @@ func removeHooks(m *manager.Manager, probes []string) func(string) error {
 			if !found {
 				continue
 			}
-			p.Detach()
+
+			program := p.Program()
+			m.DetachHook(sec, uid)
+			if program != nil {
+				program.Close()
+			}
 		}
 
 		return nil

--- a/pkg/network/http/ebpf_ssl.go
+++ b/pkg/network/http/ebpf_ssl.go
@@ -39,9 +39,6 @@ const (
 	// probe used for streaming shared library events
 	doSysOpen    = "kprobe/do_sys_open"
 	doSysOpenRet = "kretprobe/do_sys_open"
-
-	// UID used to create the base probes
-	baseUID = "base"
 )
 
 type openSSLProgram struct {
@@ -88,17 +85,6 @@ func (o *openSSLProgram) ConfigureManager(m *manager.Manager) {
 			&manager.Probe{Section: doSysOpen, KProbeMaxActive: maxActive},
 			&manager.Probe{Section: doSysOpenRet, KProbeMaxActive: maxActive},
 		)
-	}
-
-	// Load SSL & Crypto "base" probes
-	var extraProbes []string
-	extraProbes = append(extraProbes, sslProbes...)
-	extraProbes = append(extraProbes, cryptoProbes...)
-	for _, sec := range extraProbes {
-		m.Probes = append(m.Probes, &manager.Probe{
-			Section: sec,
-			UID:     baseUID,
-		})
 	}
 }
 
@@ -187,7 +173,7 @@ func addHooks(m *manager.Manager, probes []string) func(string) error {
 				UID:        uid,
 			}
 
-			err := m.AddHook(baseUID, newProbe)
+			err := m.AddHook("", newProbe)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
### What does this PR do?

Fixes the issue described [here](https://github.com/DataDog/ebpf/pull/57#issuecomment-947019081) where multiple SSL probes were inadvertently sharing the same program FD.

### Motivation

Since multiple probes were sharing the same FD, in certain cases where a probe failed to attach, that resulted in the underlying program being closed and thus invalidating all other activated probes.

### Additional Notes

Anything else we should know when reviewing?

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
