### PR TITLE
Support reading podman logs

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -755,6 +755,11 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_default_match_timeout", 30) // Seconds
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_default_match_threshold", 0.48)
 
+	// If true, the agent looks for container logs in the location used by podman, rather
+	// than docker.  This is a temporary configuration parameter to support podman logs until
+	// a more substantial refactor of autodiscovery is made to determine this automatically.
+	config.BindEnvAndSetDefault("logs_config.use_podman_logs", false)
+
 	config.BindEnvAndSetDefault("logs_config.auditor_ttl", DefaultAuditorTTL) // in hours
 	// Timeout in milliseonds used when performing agreggation operations,
 	// including multi-line log processing rules and chunked line reaggregation.

--- a/pkg/logs/input/docker/launcher.go
+++ b/pkg/logs/input/docker/launcher.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
-	"strings"
 	"sync"
 	"time"
 
@@ -300,14 +299,10 @@ func (l *Launcher) getFileSource(container *Container, source *config.LogSource)
 
 // getPath returns the file path of the container log to tail.
 func getPath(id string) string {
-	var tpl string
-	switch coreConfig.Datadog.GetBool("logs_config.use_podman_logs") {
-	case false:
-		tpl = filepath.Join(basePath, "$ID/$ID-json.log")
-	case true:
-		tpl = "/var/lib/containers/storage/overlay-containers/$ID/userdata/ctr.log"
+	if coreConfig.Datadog.GetBool("logs_config.use_podman_logs") {
+		return fmt.Sprintf("/var/lib/containers/storage/overlay-containers/%s/userdata/ctr.log", id)
 	}
-	return strings.ReplaceAll(tpl, "$ID", id)
+	return filepath.Join(basePath, id, fmt.Sprintf("%s-json.log", id))
 }
 
 // newOverridenSource is separated from overrideSource for testing purpose

--- a/pkg/logs/input/docker/launcher_test.go
+++ b/pkg/logs/input/docker/launcher_test.go
@@ -8,12 +8,15 @@
 package docker
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
+	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/docker/docker/api/types"
 )
@@ -177,4 +180,23 @@ func TestGetFileSource(t *testing.T) {
 			assert.Equal(t, tt.wantRules, fileSource.source.Config.ProcessingRules)
 		})
 	}
+}
+
+func TestGetPath(t *testing.T) {
+	t.Run("use_podman_logs=false", func(t *testing.T) {
+		mockConfig := coreConfig.Mock()
+		mockConfig.Set("logs_config.use_podman_logs", false)
+
+		require.Equal(t,
+			filepath.Join(basePath, "123abc/123abc-json.log"),
+			getPath("123abc"))
+	})
+	t.Run("use_podman_logs=true", func(t *testing.T) {
+		mockConfig := coreConfig.Mock()
+		mockConfig.Set("logs_config.use_podman_logs", true)
+
+		require.Equal(t,
+			"/var/lib/containers/storage/overlay-containers/123abc/userdata/ctr.log",
+			getPath("123abc"))
+	})
 }

--- a/pkg/logs/input/file/tailer.go
+++ b/pkg/logs/input/file/tailer.go
@@ -76,7 +76,13 @@ func NewDecoderFromSourceWithPattern(source *config.LogSource, multiLinePattern 
 		lineParser = parser.KubernetesFormat
 		matcher = &decoder.NewLineMatcher{}
 	case config.DockerSourceType:
-		lineParser = parser.DockerFileFormat
+		switch coreConfig.Datadog.GetBool("logs_config.use_podman_logs") {
+		case false:
+			lineParser = parser.DockerFileFormat
+		case true:
+			// podman's on-disk logs are in kubernetes format
+			lineParser = parser.KubernetesFormat
+		}
 		matcher = &decoder.NewLineMatcher{}
 	default:
 		switch source.Config.Encoding {

--- a/pkg/logs/input/file/tailer.go
+++ b/pkg/logs/input/file/tailer.go
@@ -76,12 +76,11 @@ func NewDecoderFromSourceWithPattern(source *config.LogSource, multiLinePattern 
 		lineParser = parser.KubernetesFormat
 		matcher = &decoder.NewLineMatcher{}
 	case config.DockerSourceType:
-		switch coreConfig.Datadog.GetBool("logs_config.use_podman_logs") {
-		case false:
-			lineParser = parser.DockerFileFormat
-		case true:
+		if coreConfig.Datadog.GetBool("logs_config.use_podman_logs") {
 			// podman's on-disk logs are in kubernetes format
 			lineParser = parser.KubernetesFormat
+		} else {
+			lineParser = parser.DockerFileFormat
 		}
 		matcher = &decoder.NewLineMatcher{}
 	default:


### PR DESCRIPTION
This is controlled by a config flag as a temporary measure until we have a more refined approach in autodiscovery.

* Look in a podman-specific directory
* Parse logs in the format podman writes (kubernetes)

### Motivation

Get basic support for podman logs in the 7.33.0 release.

### Additional Notes

This PR is currently based on #9588 and thus shouldn't be reviewed until that lands, at which point I will rebase this PR and it will contain only a single commit.

### Describe how to test your changes

Run the containerized agent in podman to enable AD to identify podman.  Note that podman can be installed on a mac (brew install podman) or in a VM.  But the latest Ubuntu versions of podman [are broken](https://github.com/kubic-project/issues/issues/15).

```
[core@localhost ~]$ API_KEY=...
[core@localhost ~]$ HOST=...
[core@localhost ~]$ IMAGE=...
[core@localhost ~]$ sudo podman run -d \
     --name dd-agent \
     -v /run/podman/podman.sock:/run/podman/podman.sock:ro \
     -v /proc/:/host/proc/:ro \
     -v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro \
     -e DD_API_KEY=$API_KEY \
     -e DOCKER_HOST=unix:///run/podman/podman.sock \
     --privileged \
     -e DD_LOGS_ENABLED=true \
     -e DD_LOGS_CONFIG_CONTAINER_COLLECT_ALL=true \
     -e DD_HOSTNAME=$HOST \
     -e DD_LOGS_CONFIG_USE_PODMAN_LOGS=true \
     $IMAGE
...
[core@localhost ~]$ sudo podman run -d bash -c 'while true; do date; sleep 1; done'
..
[core@localhost ~]$ sudo podman ps
CONTAINER ID  IMAGE                                                    COMMAND               CREATED         STATUS                       PORTS       NAMES
a7738ce94558  docker.io/datadog/agent-dev:dustin-mitchell-ac-1054-py3  /bin/entrypoint.s...  39 seconds ago  Up 38 seconds ago (healthy)              dd-agent
dd7ad06a44e6  docker.io/library/bash:latest                            -c while true; do...  4 seconds ago   Up 4 seconds ago                         inspiring_shaw
[core@localhost ~]$ sudo podman exec -ti dd-agent agent stream-logs
...
```