### PR TITLE
DOCS-2215 Add @env variables to datadog.yaml

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2506,27 +2506,32 @@ api_key:
 # cloud_foundry_bbs:
 
   ## @param url - string - optional - default: https://bbs.service.cf.internal:8889
+  ## @env DD_CLOUD_FOUNDRY_BBS_URL - string - optional - default: https://bbs.service.cf.internal:8889
   ## URL of the BBS API.
   #
   # url: https://bbs.service.cf.internal:8889
 
   ## @param poll_interval - integer - optional - default: 15
+  ## @env DD_CLOUD_FOUNDRY_BBS_POLL_INTERVAL - integer - optional - default: 15
   ## Refresh rate of BBS API, in seconds. Values lower than 10 might influence
   ## performance of other operations in the cluster.
   #
   # poll_interval: 15
 
   ## @param ca_file - string - optional - default: ""
+  ## @env DD_CLOUD_FOUNDRY_BBS_CA_FILE - string - optional - default: ""
   ## PEM-encoded CA certificate used when connecting to the BBS API.
   #
   # ca_file: ""
 
   ## @param cert_file - string - optional - default: ""
+  ## @env DD_CLOUD_FOUNDRY_BBS_CERT_FILE - string - optional - default: ""
   ## PEM-encoded client certificate used when connecting to the BBS API.
   #
   # cert_file: ""
 
   ## @param key_file - string - optional - default: ""
+  ## @env DD_CLOUD_FOUNDRY_BBS_KEY_FILE - string - optional - default: ""
   ## PEM-encoded client key used when connecting to the BBS API.
   #
   # key_file: ""


### PR DESCRIPTION
### What does this PR do?

- Add `@env` variables to datadog.yaml:

```
DD_CLOUD_FOUNDRY_BBS_CA_FILE
DD_CLOUD_FOUNDRY_BBS_CERT_FILE
DD_CLOUD_FOUNDRY_BBS_KEY_FILE
DD_CLOUD_FOUNDRY_BBS_POLL_INTERVAL
DD_CLOUD_FOUNDRY_BBS_URL
```

### Motivation

- Documentation OKR
- [RFC](https://github.com/DataDog/architecture/blob/master/rfcs/agent-env-var-docs/rfc.md)

### Additional Notes

Variables will be added in small batches.

### Describe how to test your changes

N/A

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
