### PR TITLE
Add labels to Dependabot PRs

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -94,5 +94,10 @@ updates:
       interval: monthly
   - package-ecosystem: "pip"
     directory: "/"
+      - team/agent-platform
+      - changelog/no-changelog
+      - qa/skip-qa
+      - dev/tooling
+    milestone: 22
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -94,6 +94,9 @@ updates:
       interval: monthly
   - package-ecosystem: "pip"
     directory: "/"
+    labels:
+      - dependencies
+      - python
       - team/agent-platform
       - changelog/no-changelog
       - qa/skip-qa


### PR DESCRIPTION
### What does this PR do?

Follow up to #7032

### Motivation

Add labels that we always have to add

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.

Note: Adding GitHub labels is only possible for contributors with write access.
