### PR TITLE
[runtime-security] Add timeout metrics

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "b59a58ec69396aef97dbe6266821fc6147cabfe99291d84063cb31be8be63539")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "0801d8d68a4177da29d91dbf91d0b4f528210f041fd113589f6a61aace90f442")

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -452,6 +452,10 @@ func (m *Module) metricsSender() {
 	for {
 		select {
 		case <-statsTicker.C:
+			if os.Getenv("RUNTIME_SECURITY_TESTSUITE") == "true" {
+				continue
+			}
+
 			if err := m.probe.SendStats(); err != nil {
 				log.Debug(err)
 			}

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -150,13 +150,13 @@ func (m *Module) Start() error {
 		return errors.Wrap(err, "failed to start probe")
 	}
 
-	// fetch the current state of the system (example: mount points, running processes, ...) so that our user space
-	// context is ready when we start the probes
-	if err := m.probe.Snapshot(); err != nil {
+	if err := m.Reload(); err != nil {
 		return err
 	}
 
-	if err := m.Reload(); err != nil {
+	// fetch the current state of the system (example: mount points, running processes, ...) so that our user space
+	// context is ready when we start the probes
+	if err := m.probe.Snapshot(); err != nil {
 		return err
 	}
 

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -138,6 +138,7 @@ type inodeDiscarder struct {
 	Padding uint32
 }
 
+// inodeDiscarders is used to issue eRPC discarder requests
 type inodeDiscarders struct {
 	*lib.Map
 	erpc           *ERPC
@@ -176,6 +177,18 @@ func (id *inodeDiscarders) discardInode(eventType model.EventType, mountID uint3
 	model.ByteOrder.PutUint64(req.Data[offset:offset+8], inode)
 	model.ByteOrder.PutUint32(req.Data[offset+8:offset+12], mountID)
 	model.ByteOrder.PutUint32(req.Data[offset+12:offset+16], isLeafInt)
+
+	return id.erpc.Request(&req)
+}
+
+// expireInodeDiscarder sends an eRPC request to expire a discarder
+func (id *inodeDiscarders) expireInodeDiscarder(mountID uint32, inode uint64) error {
+	req := ERPCRequest{
+		OP: ExpireInodeDiscarderOp,
+	}
+
+	model.ByteOrder.PutUint64(req.Data[0:8], inode)
+	model.ByteOrder.PutUint32(req.Data[8:12], mountID)
 
 	return id.erpc.Request(&req)
 }

--- a/pkg/security/probe/erpc.go
+++ b/pkg/security/probe/erpc.go
@@ -32,6 +32,8 @@ const (
 	ResolveParentOp
 	// RegisterSpanTLSOP is used for span TLS registration
 	RegisterSpanTLSOP //nolint:deadcode,unused
+	// ExpireInodeDiscarderOp is used to expire an inode discarder
+	ExpireInodeDiscarderOp
 )
 
 // ERPC defines a krpc object

--- a/pkg/security/probe/perf_buffer_monitor.go
+++ b/pkg/security/probe/perf_buffer_monitor.go
@@ -175,9 +175,9 @@ func (pbm *PerfBufferMonitor) getKernelLostCount(eventType model.EventType, perf
 	return atomic.LoadUint64(&pbm.kernelStats[perfMap][cpu][eventType].Lost)
 }
 
-// GetAndResetKernelLostCount returns the number of lost events for a given map and cpu. If a cpu of -1 is provided, the function will
+// GetKernelLostCount returns the number of lost events for a given map and cpu. If a cpu of -1 is provided, the function will
 // return the sum of all the lost events of all the cpus.
-func (pbm *PerfBufferMonitor) GetAndResetKernelLostCount(perfMap string, cpu int, evtTypes ...model.EventType) uint64 {
+func (pbm *PerfBufferMonitor) GetKernelLostCount(perfMap string, cpu int, evtTypes ...model.EventType) uint64 {
 	var total uint64
 	var shouldCount bool
 
@@ -238,6 +238,16 @@ func (pbm *PerfBufferMonitor) getEventBytes(eventType model.EventType, perfMap s
 }
 
 // getKernelEventCount is an internal function, it can segfault if its parameters are incorrect.
+func (pbm *PerfBufferMonitor) getKernelEventCount(eventType model.EventType, perfMap string, cpu int) uint64 {
+	return atomic.LoadUint64(&pbm.kernelStats[perfMap][cpu][eventType].Count)
+}
+
+// getEventBytes is an internal function, it can segfault if its parameters are incorrect.
+func (pbm *PerfBufferMonitor) getKernelEventBytes(eventType model.EventType, perfMap string, cpu int) uint64 {
+	return atomic.LoadUint64(&pbm.kernelStats[perfMap][cpu][eventType].Bytes)
+}
+
+// getKernelEventCount is an internal function, it can segfault if its parameters are incorrect.
 func (pbm *PerfBufferMonitor) swapKernelEventCount(eventType model.EventType, perfMap string, cpu int, value uint64) uint64 {
 	return atomic.SwapUint64(&pbm.kernelStats[perfMap][cpu][eventType].Count, value)
 }
@@ -252,13 +262,13 @@ func (pbm *PerfBufferMonitor) swapKernelLostCount(eventType model.EventType, per
 	return atomic.SwapUint64(&pbm.kernelStats[perfMap][cpu][eventType].Lost, value)
 }
 
-// GetEventStats returns the number of received events of the specified type and resets the counter
-func (pbm *PerfBufferMonitor) GetEventStats(eventType model.EventType, perfMap string, cpu int) PerfMapStats {
-	var stats PerfMapStats
+// GetEventStats returns the number of received events of the specified type
+func (pbm *PerfBufferMonitor) GetEventStats(eventType model.EventType, perfMap string, cpu int) (PerfMapStats, PerfMapStats) {
+	var stats, kernelStats PerfMapStats
 	var maps []string
 
 	if eventType >= model.MaxEventType {
-		return stats
+		return stats, kernelStats
 	}
 
 	switch {
@@ -277,14 +287,22 @@ func (pbm *PerfBufferMonitor) GetEventStats(eventType model.EventType, perfMap s
 			for i := range pbm.stats[m] {
 				stats.Count += pbm.getEventCount(eventType, perfMap, i)
 				stats.Bytes += pbm.getEventBytes(eventType, perfMap, i)
+
+				kernelStats.Count += pbm.getKernelEventCount(eventType, perfMap, i)
+				kernelStats.Bytes += pbm.getKernelEventBytes(eventType, perfMap, i)
+				kernelStats.Lost += pbm.getKernelLostCount(eventType, perfMap, i)
 			}
 		case cpu >= 0 && pbm.numCPU > cpu:
 			stats.Count += pbm.getEventCount(eventType, perfMap, cpu)
 			stats.Bytes += pbm.getEventBytes(eventType, perfMap, cpu)
+
+			kernelStats.Count += pbm.getKernelEventCount(eventType, perfMap, cpu)
+			kernelStats.Bytes += pbm.getKernelEventBytes(eventType, perfMap, cpu)
+			kernelStats.Lost += pbm.getKernelLostCount(eventType, perfMap, cpu)
 		}
 
 	}
-	return stats
+	return stats, kernelStats
 }
 
 // getAndResetEventCount is an internal function, it can segfault if its parameters are incorrect.

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -737,7 +737,6 @@ func (p *Probe) FlushDiscarders() error {
 	if !atomic.CompareAndSwapInt64(&p.flushingDiscarders, 0, 1) {
 		return errors.New("already flushing discarders")
 	}
-	time.Sleep(100 * time.Millisecond)
 
 	var discardedInodes []inodeDiscarder
 	var mapValue [256]byte
@@ -765,7 +764,7 @@ func (p *Probe) FlushDiscarders() error {
 		log.Debugf("Flushing discarders")
 
 		for _, inode := range discardedInodes {
-			if err := p.inodeDiscarders.Delete(unsafe.Pointer(&inode)); err != nil {
+			if err := p.inodeDiscarders.expireInodeDiscarder(inode.PathKey.MountID, inode.PathKey.Inode); err != nil {
 				seclog.Tracef("Failed to flush discarder for inode %d: %s", inode, err)
 			}
 

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -155,9 +155,11 @@ func TestOpenBasenameApproverFilterMapDentryResolution(t *testing.T) {
 }
 
 func TestOpenLeafDiscarderFilter(t *testing.T) {
+	// We need to write a rule with no approver on the file path, and that won't match the real opened file (so that
+	// a discarder is created).
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
-		Expression: `open.filename =~ "{{.Root}}/test-obc-1" && open.flags & (O_CREAT | O_SYNC) > 0`,
+		Expression: `open.filename =~ "{{.Root}}/no-approver-*" && open.flags & (O_CREAT | O_SYNC) > 0`,
 	}
 
 	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
@@ -166,9 +168,6 @@ func TestOpenLeafDiscarderFilter(t *testing.T) {
 	}
 	defer test.Close()
 
-	// ensure that all the previous discarder are removed
-	test.probe.FlushDiscarders()
-
 	var fd int
 	var testFile string
 
@@ -176,15 +175,21 @@ func TestOpenLeafDiscarderFilter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	fd, err = openTestFile(test, testFile, syscall.O_CREAT|syscall.O_SYNC)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer syscall.Close(fd)
 	defer os.Remove(testFile)
 
-	if err := test.GetEventDiscarder(t, func(d *testDiscarder) bool {
+	if err := test.GetEventDiscarder(t, func() error {
+		// The policy file inode is likely to be reused by the kernel after deletion. On deletion, the inode discarder will
+		// be marked as retained in kernel space and will therefore no longer discard events. By waiting for the discard
+		// retention period to expire, we're making sure that a newly created discarder will properly take effect.
+		time.Sleep(probe.DiscardRetention)
+
+		fd, err = openTestFile(test, testFile, syscall.O_CREAT|syscall.O_SYNC)
+		if err != nil {
+			return err
+		}
+		_ = syscall.Close(fd)
+		return nil
+	}, func(d *testDiscarder) bool {
 		e := d.event.(*probe.Event)
 		if e == nil || (e != nil && e.GetEventType() != model.FileOpenEventType) {
 			return false
@@ -213,9 +218,11 @@ func TestOpenLeafDiscarderFilter(t *testing.T) {
 }
 
 func TestOpenParentDiscarderFilter(t *testing.T) {
+	// We need to write a rule with no approver on the file path, and that won't match the real opened file (so that
+	// a discarder is created).
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
-		Expression: `open.file.path =~ "/usr/local/test-obd-2" && open.flags & (O_CREAT | O_SYNC) > 0`,
+		Expression: `open.file.path =~ "/usr/local/no-approver-*" && open.flags & (O_CREAT | O_SYNC) > 0`,
 	}
 
 	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
@@ -224,9 +231,6 @@ func TestOpenParentDiscarderFilter(t *testing.T) {
 	}
 	defer test.Close()
 
-	// ensure that all the previous discarder are removed
-	test.probe.FlushDiscarders()
-
 	var fd int
 	var testFile string
 
@@ -234,15 +238,21 @@ func TestOpenParentDiscarderFilter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	fd, err = openTestFile(test, testFile, syscall.O_CREAT|syscall.O_SYNC)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer syscall.Close(fd)
 	defer os.Remove(testFile)
 
-	if err := test.GetEventDiscarder(t, func(d *testDiscarder) bool {
+	if err := test.GetEventDiscarder(t, func() error {
+		// The policy file inode is likely to be reused by the kernel after deletion. On deletion, the inode discarder will
+		// be marked as retained in kernel space and will therefore no longer discard events. By waiting for the discard
+		// retention period to expire, we're making sure that a newly created discarder will properly take effect.
+		time.Sleep(probe.DiscardRetention)
+
+		fd, err = openTestFile(test, testFile, syscall.O_CREAT|syscall.O_SYNC)
+		if err != nil {
+			return err
+		}
+		_ = syscall.Close(fd)
+		return nil
+	}, func(d *testDiscarder) bool {
 		e := d.event.(*probe.Event)
 		if e == nil || (e != nil && e.GetEventType() != model.FileOpenEventType) {
 			return false
@@ -288,9 +298,6 @@ func TestDiscarderFilterMask(t *testing.T) {
 	}
 	defer test.Close()
 
-	// ensure that all the previous discarder are removed
-	test.probe.FlushDiscarders()
-
 	t.Run("mask", ifSyscallSupported("SYS_UTIME", func(t *testing.T, syscallNB uintptr) {
 		var testFile string
 		var testFilePtr unsafe.Pointer
@@ -300,6 +307,11 @@ func TestDiscarderFilterMask(t *testing.T) {
 
 		// not check that we still have the open allowed
 		test.WaitSignal(t, func() error {
+			// The policy file inode is likely to be reused by the kernel after deletion. On deletion, the inode discarder will
+			// be marked as retained in kernel space and will therefore no longer discard events. By waiting for the discard
+			// retention period to expire, we're making sure that a newly created discarder will properly take effect.
+			time.Sleep(probe.DiscardRetention)
+
 			testFile, testFilePtr, err = test.CreateWithOptions("test-mask", 98, 99, 0o447)
 			if err != nil {
 				t.Fatal(err)
@@ -402,7 +414,7 @@ func TestOpenFlagsApproverFilter(t *testing.T) {
 func TestOpenProcessPidDiscarder(t *testing.T) {
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
-		Expression: `open.file.path =="{{.Root}}/test-oba-1" && process.file.path == "/bin/cat"`,
+		Expression: `open.file.path == "{{.Root}}/test-oba-1" && process.file.path == "/bin/cat"`,
 	}
 
 	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{})
@@ -411,9 +423,6 @@ func TestOpenProcessPidDiscarder(t *testing.T) {
 	}
 	defer test.Close()
 
-	// ensure that all the previous discarder are removed
-	test.probe.FlushDiscarders()
-
 	var fd int
 	var testFile string
 
@@ -421,15 +430,21 @@ func TestOpenProcessPidDiscarder(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	fd, err = openTestFile(test, testFile, syscall.O_CREAT)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer syscall.Close(fd)
 	defer os.Remove(testFile)
 
-	if err := test.GetEventDiscarder(t, func(d *testDiscarder) bool {
+	if err := test.GetEventDiscarder(t, func() error {
+		// The policy file inode is likely to be reused by the kernel after deletion. On deletion, the inode discarder will
+		// be marked as retained in kernel space and will therefore no longer discard events. By waiting for the discard
+		// retention period to expire, we're making sure that a newly created discarder will properly take effect.
+		time.Sleep(probe.DiscardRetention)
+
+		fd, err = openTestFile(test, testFile, syscall.O_CREAT)
+		if err != nil {
+			return err
+		}
+		_ = syscall.Close(fd)
+		return nil
+	}, func(d *testDiscarder) bool {
 		e := d.event.(*probe.Event)
 		if e == nil || (e != nil && e.GetEventType() != model.FileOpenEventType) {
 			return false
@@ -460,9 +475,11 @@ func TestOpenProcessPidDiscarder(t *testing.T) {
 }
 
 func TestDiscarderRetentionFilter(t *testing.T) {
+	// We need to write a rule with no approver on the file path, and that won't match the real opened file (so that
+	// a discarder is created).
 	rule := &rules.RuleDefinition{
 		ID:         "test_rule",
-		Expression: `open.file.path =~ "{{.Root}}/test-obc-1" && open.flags & (O_CREAT | O_SYNC) > 0`,
+		Expression: `open.file.path =~ "{{.Root}}/no-approver-*" && open.flags & (O_CREAT | O_SYNC) > 0`,
 	}
 
 	testDrive, err := newTestDrive("xfs", nil)
@@ -477,9 +494,6 @@ func TestDiscarderRetentionFilter(t *testing.T) {
 	}
 	defer test.Close()
 
-	// ensure that all the previous discarder are removed
-	test.probe.FlushDiscarders()
-
 	var fd int
 	var testFile string
 
@@ -487,24 +501,35 @@ func TestDiscarderRetentionFilter(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	fd, err = openTestFile(test, testFile, syscall.O_CREAT|syscall.O_SYNC)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer syscall.Close(fd)
 	defer os.Remove(testFile)
 
-	if err := test.GetEventDiscarder(t, func(d *testDiscarder) bool {
+	if err := test.GetEventDiscarder(t, func() error {
+		// The policy file inode is likely to be reused by the kernel after deletion. On deletion, the inode discarder will
+		// be marked as retained in kernel space and will therefore no longer discard events. By waiting for the discard
+		// retention period to expire, we're making sure that a newly created discarder will properly take effect.
+		time.Sleep(probe.DiscardRetention)
+
+		fd, err = openTestFile(test, testFile, syscall.O_CREAT|syscall.O_SYNC)
+		if err != nil {
+			return err
+		}
+		_ = syscall.Close(fd)
+
+		return nil
+
+	}, func(d *testDiscarder) bool {
 		e := d.event.(*probe.Event)
 		if e == nil || (e != nil && e.GetEventType() != model.FileOpenEventType) {
 			return false
 		}
+
 		v, _ := e.GetFieldValue("open.file.path")
 		if v == testFile {
 			return true
 		}
+
 		return false
+
 	}); err != nil {
 		inode := getInode(t, testFile)
 		parentInode := getInode(t, path.Dir(testFile))

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -184,11 +184,21 @@ func TestOpenLeafDiscarderFilter(t *testing.T) {
 	defer syscall.Close(fd)
 	defer os.Remove(testFile)
 
-	if err := waitForOpenDiscarder(test, testFile); err != nil {
+	if err := test.GetEventDiscarder(t, func(d *testDiscarder) bool {
+		e := d.event.(*probe.Event)
+		if e == nil || (e != nil && e.GetEventType() != model.FileOpenEventType) {
+			return false
+		}
+		v, _ := e.GetFieldValue("open.file.path")
+		if v == testFile {
+			return true
+		}
+		return false
+	}); err != nil {
 		inode := getInode(t, testFile)
 		parentInode := getInode(t, path.Dir(testFile))
 
-		t.Fatalf("not able to get the expected event inode: %d, parent inode: %d", inode, parentInode)
+		t.Fatalf("event inode: %d, parent inode: %d, error: %v", inode, parentInode, err)
 	}
 
 	if err := waitForOpenProbeEvent(test, func() error {
@@ -232,11 +242,21 @@ func TestOpenParentDiscarderFilter(t *testing.T) {
 	defer syscall.Close(fd)
 	defer os.Remove(testFile)
 
-	if err := waitForOpenDiscarder(test, testFile); err != nil {
+	if err := test.GetEventDiscarder(t, func(d *testDiscarder) bool {
+		e := d.event.(*probe.Event)
+		if e == nil || (e != nil && e.GetEventType() != model.FileOpenEventType) {
+			return false
+		}
+		v, _ := e.GetFieldValue("open.file.path")
+		if v == testFile {
+			return true
+		}
+		return false
+	}); err != nil {
 		inode := getInode(t, testFile)
 		parentInode := getInode(t, path.Dir(testFile))
 
-		t.Fatalf("not able to get the expected event inode: %d, parent inode: %d", inode, parentInode)
+		t.Fatalf("event inode: %d, parent inode: %d, error: %v", inode, parentInode, err)
 	}
 
 	if err := waitForOpenProbeEvent(test, func() error {
@@ -409,8 +429,21 @@ func TestOpenProcessPidDiscarder(t *testing.T) {
 	defer syscall.Close(fd)
 	defer os.Remove(testFile)
 
-	if err := waitForOpenDiscarder(test, testFile); err != nil {
-		t.Fatal(err)
+	if err := test.GetEventDiscarder(t, func(d *testDiscarder) bool {
+		e := d.event.(*probe.Event)
+		if e == nil || (e != nil && e.GetEventType() != model.FileOpenEventType) {
+			return false
+		}
+		v, _ := e.GetFieldValue("open.file.path")
+		if v == testFile {
+			return true
+		}
+		return false
+	}); err != nil {
+		inode := getInode(t, testFile)
+		parentInode := getInode(t, path.Dir(testFile))
+
+		t.Fatalf("event inode: %d, parent inode: %d, error: %v", inode, parentInode, err)
 	}
 
 	defer os.Remove(testFile)
@@ -462,7 +495,17 @@ func TestDiscarderRetentionFilter(t *testing.T) {
 	defer syscall.Close(fd)
 	defer os.Remove(testFile)
 
-	if err = waitForOpenDiscarder(test, testFile); err != nil {
+	if err := test.GetEventDiscarder(t, func(d *testDiscarder) bool {
+		e := d.event.(*probe.Event)
+		if e == nil || (e != nil && e.GetEventType() != model.FileOpenEventType) {
+			return false
+		}
+		v, _ := e.GetFieldValue("open.file.path")
+		if v == testFile {
+			return true
+		}
+		return false
+	}); err != nil {
 		inode := getInode(t, testFile)
 		parentInode := getInode(t, path.Dir(testFile))
 

--- a/pkg/security/tests/probe_monitor_test.go
+++ b/pkg/security/tests/probe_monitor_test.go
@@ -32,6 +32,7 @@ func TestRulesetLoaded(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer test.Close()
 
 	t.Run("ruleset_loaded", func(t *testing.T) {
 		if err := test.GetProbeCustomEvent(t, func() error {
@@ -61,6 +62,7 @@ func truncatedParents(t *testing.T, opts testOpts) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer test.Close()
 
 	truncatedParentsFile, _, err := test.Path(truncatedParents)
 	if err != nil {
@@ -130,6 +132,7 @@ func TestNoisyProcess(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer test.Close()
 
 	file, _, err := test.Path("test-open")
 	if err != nil {

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -129,7 +129,9 @@ func TestProcessContext(t *testing.T) {
 			}
 
 			return f.Close()
-		}, func(event *sprobe.Event, rule *rules.Rule) {})
+		}, func(event *sprobe.Event, rule *rules.Rule) {
+			t.Errorf("got event: %s", event)
+		})
 		if err == nil {
 			t.Error("shouldn't get an event")
 		}

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -1018,12 +1018,6 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 			}
 		})
 	})
-
-	// test_capset can be somewhat noisy and some events may leak to the next tests (there is a short delay between the
-	// reset of the maps and the reload of the rules, we can't move the reset after the reload either, otherwise the
-	// ruleset_reload test won't work => we would have reset the channel that contains the reload event).
-	// Load a fake new test module to empty the rules and properly cleanup the channels.
-	_, _ = newTestModule(t, nil, nil, testOpts{})
 }
 
 func parseCapIntoSet(capabilities uint64, flag capability.CapType, c capability.Capabilities, t *testing.T) {

--- a/pkg/security/tests/selinux_test.go
+++ b/pkg/security/tests/selinux_test.go
@@ -148,7 +148,8 @@ func TestSELinux(t *testing.T) {
 		if err == nil {
 			t.Error("expected error")
 		} else {
-			assert.Equal(t, "timeout", err.Error(), "wrong error type, expected timeout")
+			_, ok := err.(ErrTimeout)
+			assert.Equal(t, true, ok, "wrong error type, expected ErrTimeout")
 		}
 	})
 }

--- a/pkg/security/tests/stress_test.go
+++ b/pkg/security/tests/stress_test.go
@@ -56,7 +56,7 @@ func stressOpen(t *testing.T, rule *rules.RuleDefinition, pathname string, size 
 
 	perfBufferMonitor := test.probe.GetMonitor().GetPerfBufferMonitor()
 	perfBufferMonitor.GetAndResetLostCount("events", -1)
-	perfBufferMonitor.GetAndResetKernelLostCount("events", -1)
+	perfBufferMonitor.GetKernelLostCount("events", -1)
 
 	fnc := func() error {
 		f, err := os.Create(testFile)
@@ -100,7 +100,7 @@ func stressOpen(t *testing.T, rule *rules.RuleDefinition, pathname string, size 
 	}
 
 	report.AddMetric("lost", float64(perfBufferMonitor.GetLostCount("events", -1)), "lost")
-	report.AddMetric("kernel_lost", float64(perfBufferMonitor.GetAndResetKernelLostCount("events", -1)), "lost")
+	report.AddMetric("kernel_lost", float64(perfBufferMonitor.GetKernelLostCount("events", -1)), "lost")
 	report.AddMetric("events", float64(events), "events")
 	report.AddMetric("events/sec", float64(events)/report.Duration.Seconds(), "event/s")
 
@@ -202,7 +202,7 @@ func stressExec(t *testing.T, rule *rules.RuleDefinition, pathname string, execu
 
 	perfBufferMonitor := test.probe.GetMonitor().GetPerfBufferMonitor()
 	perfBufferMonitor.GetAndResetLostCount("events", -1)
-	perfBufferMonitor.GetAndResetKernelLostCount("events", -1)
+	perfBufferMonitor.GetKernelLostCount("events", -1)
 
 	fnc := func() error {
 		cmd := exec.Command(executable, testFile)
@@ -237,7 +237,7 @@ func stressExec(t *testing.T, rule *rules.RuleDefinition, pathname string, execu
 	time.Sleep(2 * time.Second)
 
 	report.AddMetric("lost", float64(perfBufferMonitor.GetLostCount("events", -1)), "lost")
-	report.AddMetric("kernel_lost", float64(perfBufferMonitor.GetAndResetKernelLostCount("events", -1)), "lost")
+	report.AddMetric("kernel_lost", float64(perfBufferMonitor.GetKernelLostCount("events", -1)), "lost")
 	report.AddMetric("events", float64(events), "events")
 	report.AddMetric("events/sec", float64(events)/report.Duration.Seconds(), "event/s")
 

--- a/pkg/security/tests/xattr_test.go
+++ b/pkg/security/tests/xattr_test.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"syscall"
 	"testing"
-	"time"
 	"unsafe"
 
 	"github.com/stretchr/testify/assert"
@@ -297,16 +296,8 @@ func TestRemoveXAttr(t *testing.T) {
 				t.Errorf("expected initial mode %d, got %d", expectedMode, int(event.RemoveXAttr.File.Mode)&expectedMode)
 			}
 
-			now := time.Now()
-			mtime := time.Unix(0, int64(event.RemoveXAttr.File.MTime))
-			if mtime.After(now) || mtime.Before(now.Add(-1*time.Hour)) {
-				t.Errorf("expected mtime close to %s, got %s", now, mtime)
-			}
-
-			ctime := time.Unix(0, int64(event.RemoveXAttr.File.CTime))
-			if ctime.After(now) || ctime.Before(now.Add(-1*time.Hour)) {
-				t.Errorf("expected ctime close to %s, got %s", now, ctime)
-			}
+			assertNearTime(t, event.RemoveXAttr.File.MTime)
+			assertNearTime(t, event.RemoveXAttr.File.CTime)
 		})
 	})
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds metrics to the timeout error in the runtime-security module functional tests. Namely the following metrics will now show up:

- the number of lost events (kernel space total count)
- the number of events per event type (user space count, kernel space count, kernel space lost count)

### Motivation

This will help debug the CI.

### Describe how to test your changes

Nothing to test in QA, this is an improvement of our CI.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
