### PR TITLE
[CWS] add cgo generated object files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,6 +130,9 @@ pkg/ebpf/bytecode/build/
 pkg/ebpf/bytecode/bindata/
 *.bc
 
+# CGo generated object files
+pkg/network/**/_obj/
+
 # windows container build output
 build.out/
 
@@ -141,7 +144,6 @@ packer.json
 devenv/iso
 devenv/output-virtualbox-iso/
 devenv/packer_cache
-pkg/network/driver/_obj/
 test_output.json
 
 # doxygen doc & error log


### PR DESCRIPTION
### What does this PR do?

This PR is a cherry-pick of the `.gitignore` part of https://github.com/DataDog/datadog-agent/pull/9376 since other parts of this PR were not well received.

### Motivation

Keep a clean workspace

### Describe how to test your changes

This should be a no-op

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
