### PR TITLE
Remove old v2 serialization for service checks

### DIFF
--- a/pkg/metrics/service_check.go
+++ b/pkg/metrics/service_check.go
@@ -15,10 +15,8 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/gogo/protobuf/proto"
 	jsoniter "github.com/json-iterator/go"
 
-	agentpayload "github.com/DataDog/agent-payload/gogen"
 	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
 	utiljson "github.com/DataDog/datadog-agent/pkg/util/json"
@@ -90,26 +88,9 @@ type ServiceCheck struct {
 // ServiceChecks represents a list of service checks ready to be serialize
 type ServiceChecks []*ServiceCheck
 
-// Marshal serialize service checks using agent-payload definition
+// Marshal serializes service checks using protobuf (v2)
 func (sc ServiceChecks) Marshal() ([]byte, error) {
-	payload := &agentpayload.ServiceChecksPayload{
-		ServiceChecks: []*agentpayload.ServiceChecksPayload_ServiceCheck{},
-		Metadata:      &agentpayload.CommonMetadata{},
-	}
-
-	for _, c := range sc {
-		payload.ServiceChecks = append(payload.ServiceChecks,
-			&agentpayload.ServiceChecksPayload_ServiceCheck{
-				Name:    c.CheckName,
-				Host:    c.Host,
-				Ts:      c.Ts,
-				Status:  int32(c.Status),
-				Message: c.Message,
-				Tags:    c.Tags,
-			})
-	}
-
-	return proto.Marshal(payload)
+	return nil, fmt.Errorf("ServiceChecks payload serialization is not implemented")
 }
 
 // MarshalJSON serializes service checks to JSON so it can be sent to V1 endpoints

--- a/pkg/metrics/service_check_test.go
+++ b/pkg/metrics/service_check_test.go
@@ -12,45 +12,14 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	agentpayload "github.com/DataDog/agent-payload/gogen"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 	"github.com/DataDog/datadog-agent/pkg/serializer/split"
 	"github.com/DataDog/datadog-agent/pkg/serializer/stream"
 )
-
-func TestMarshalServiceChecks(t *testing.T) {
-	serviceChecks := ServiceChecks{{
-		CheckName: "test.check",
-		Host:      "test.localhost",
-		Ts:        1000,
-		Status:    ServiceCheckOK,
-		Message:   "this is fine",
-		Tags:      []string{"tag1", "tag2:yes"},
-	}}
-
-	payload, err := serviceChecks.Marshal()
-	assert.Nil(t, err)
-	assert.NotNil(t, payload)
-
-	newPayload := &agentpayload.ServiceChecksPayload{}
-	err = proto.Unmarshal(payload, newPayload)
-	assert.Nil(t, err)
-
-	require.Len(t, newPayload.ServiceChecks, 1)
-	assert.Equal(t, newPayload.ServiceChecks[0].Name, "test.check")
-	assert.Equal(t, newPayload.ServiceChecks[0].Host, "test.localhost")
-	assert.Equal(t, newPayload.ServiceChecks[0].Ts, int64(1000))
-	assert.Equal(t, newPayload.ServiceChecks[0].Status, int32(ServiceCheckOK))
-	assert.Equal(t, newPayload.ServiceChecks[0].Message, "this is fine")
-	require.Len(t, newPayload.ServiceChecks[0].Tags, 2)
-	assert.Equal(t, newPayload.ServiceChecks[0].Tags[0], "tag1")
-	assert.Equal(t, newPayload.ServiceChecks[0].Tags[1], "tag2:yes")
-}
 
 func TestMarshalJSONServiceChecks(t *testing.T) {
 	serviceChecks := ServiceChecks{{

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -265,7 +265,7 @@ func (s *Serializer) SendServiceChecks(sc marshaler.StreamJSONMarshaler) error {
 		return nil
 	}
 
-	useV1API := !config.Datadog.GetBool("use_v2_api.service_checks")
+	useV1API := true
 
 	var serviceCheckPayloads forwarder.Payloads
 	var extraHeaders http.Header

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -293,26 +293,6 @@ func TestSendV1ServiceChecks(t *testing.T) {
 	require.NotNil(t, err)
 }
 
-func TestSendServiceChecks(t *testing.T) {
-	mockConfig := config.Mock()
-
-	f := &forwarder.MockedForwarder{}
-	f.On("SubmitServiceChecks", protobufPayloads, protobufExtraHeadersWithCompression).Return(nil).Times(1)
-	mockConfig.Set("use_v2_api.service_checks", true)
-	defer mockConfig.Set("use_v2_api.service_checks", nil)
-
-	s := NewSerializer(f, nil)
-
-	payload := &testPayload{}
-	err := s.SendServiceChecks(payload)
-	require.Nil(t, err)
-	f.AssertExpectations(t)
-
-	errPayload := &testErrorPayload{}
-	err = s.SendServiceChecks(errPayload)
-	require.NotNil(t, err)
-}
-
 func TestSendV1Series(t *testing.T) {
 	f := &forwarder.MockedForwarder{}
 	f.On("SubmitV1Series", jsonPayloads, jsonExtraHeadersWithCompression).Return(nil).Times(1)


### PR DESCRIPTION
This serialization is not handled by the intakes, so there's no reason
to keep it around here.

### Additional Notes

See https://github.com/DataDog/agent-payload/pull/135

### Describe how to test your changes

Configure an agent to run any service check, and see that the results appear in the app.
