### PR TITLE
Patch cve on tuf 0.17.0  (#9581)

### DIFF
--- a/omnibus/config/patches/datadog-agent-integrations-py2/tuf-0.17.0-cve-2021-41131.patch
+++ b/omnibus/config/patches/datadog-agent-integrations-py2/tuf-0.17.0-cve-2021-41131.patch
@@ -1,0 +1,123 @@
+This change is fixing a python-tuf 0.17.0 CVE. 
+There is a path traversal vulnerability that in the worst case can overwrite files 
+ending in .json anywhere on the client system on a call to get_one_valid_targetinfo(). 
+It occurs because the rolename is used to form the filename,
+and may contain path traversal characters (ie ../../name.json).
+This change is escaping path characters to prevent this vulnerability.
+diff --git a/tuf/client/updater.py b/tuf/client/updater.py
+index 9ada0974..4a97bd1d 100755
+--- a/tuf/client/updater.py
++++ b/tuf/client/updater.py
+@@ -145,6 +145,7 @@ import securesystemslib.hash
+ import securesystemslib.keys
+ import securesystemslib.util
+ import six
++import six.moves.urllib.parse as parse
+ import requests.exceptions
+ 
+ # The Timestamp role does not have signed metadata about it; otherwise we
+@@ -766,6 +767,15 @@ class Updater(object):
+ 
+ 
+ 
++  @staticmethod
++  def _get_local_filename(rolename):
++    """Return safe local filename for roles metadata
++    Use URL encoding to prevent issues with path separators and
++    with forbidden characters in Windows filesystems"""
++    return parse.quote(rolename, '') + '.json'
++
++
++
+ 
+   def __str__(self):
+     """
+@@ -821,7 +831,7 @@ class Updater(object):
+ 
+     # Save and construct the full metadata path.
+     metadata_directory = self.metadata_directory[metadata_set]
+-    metadata_filename = metadata_role + '.json'
++    metadata_filename = self._get_local_filename(metadata_role)
+     metadata_filepath = os.path.join(metadata_directory, metadata_filename)
+ 
+     # Ensure the metadata path is valid/exists, else ignore the call.
+@@ -1605,7 +1615,7 @@ class Updater(object):
+       return file_object
+ 
+     else:
+-      logger.debug('Failed to update ' + repr(remote_filename) + ' from all'
++      logger.warning('Failed to update ' + repr(remote_filename) + ' from all'
+         ' mirrors: ' + repr(file_mirror_errors))
+       raise tuf.exceptions.NoWorkingMirrorError(file_mirror_errors)
+ 
+@@ -1652,10 +1662,6 @@ class Updater(object):
+       None.
+     """
+ 
+-    # Construct the metadata filename as expected by the download/mirror
+-    # modules.
+-    metadata_filename = metadata_role + '.json'
+-
+     # Attempt a file download from each mirror until the file is downloaded and
+     # verified.  If the signature of the downloaded file is valid, proceed,
+     # otherwise log a warning and try the next mirror.  'metadata_file_object'
+@@ -1672,7 +1678,11 @@ class Updater(object):
+     # best length we can get for it, not request a specific version, but
+     # perform the rest of the checks (e.g., signature verification).
+ 
+-    remote_filename = metadata_filename
++    # Construct the metadata filename as expected by the download/mirror
++    # modules. Local filename is quoted to protect against names like"../file".
++
++    remote_filename = metadata_role + '.json'
++    local_filename = self._get_local_filename(metadata_role)
+     filename_version = ''
+ 
+     if self.consistent_snapshot and version:
+@@ -1689,12 +1699,12 @@ class Updater(object):
+     # First, move the 'current' metadata file to the 'previous' directory
+     # if it exists.
+     current_filepath = os.path.join(self.metadata_directory['current'],
+-                metadata_filename)
++                local_filename)
+     current_filepath = os.path.abspath(current_filepath)
+     securesystemslib.util.ensure_parent_dir(current_filepath)
+ 
+     previous_filepath = os.path.join(self.metadata_directory['previous'],
+-        metadata_filename)
++        local_filename)
+     previous_filepath = os.path.abspath(previous_filepath)
+ 
+     if os.path.exists(current_filepath):
+@@ -1722,7 +1732,7 @@ class Updater(object):
+     logger.debug('Updated ' + repr(current_filepath) + '.')
+     self.metadata['previous'][metadata_role] = current_metadata_object
+     self.metadata['current'][metadata_role] = updated_metadata_object
+-    self._update_versioninfo(metadata_filename)
++    self._update_versioninfo(remote_filename)
+ 
+ 
+ 
+@@ -1969,9 +1979,11 @@ class Updater(object):
+     # __init__ (such as with delegated metadata), then get the version
+     # info now.
+ 
+-    # Save the path to the current metadata file for 'metadata_filename'.
++    # 'metadata_filename' is the key from meta dictionary: build the
++    # corresponding local filepath like _get_local_filename()
++    local_filename = parse.quote(metadata_filename, "")
+     current_filepath = os.path.join(self.metadata_directory['current'],
+-        metadata_filename)
++        local_filename)
+ 
+     # If the path is invalid, simply return and leave versioninfo unset.
+     if not os.path.exists(current_filepath):
+@@ -2172,7 +2184,7 @@ class Updater(object):
+     """
+ 
+     # Get the 'current' and 'previous' full file paths for 'metadata_role'
+-    metadata_filepath = metadata_role + '.json'
++    metadata_filepath = self._get_local_filename(metadata_role)
+     previous_filepath = os.path.join(self.metadata_directory['previous'],
+                                      metadata_filepath)
+     current_filepath = os.path.join(self.metadata_directory['current'],

--- a/omnibus/config/software/datadog-agent-integrations-py2.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py2.rb
@@ -400,8 +400,10 @@ build do
       # Patch applies to only one file: set it explicitly as a target, no need for -p
       if windows?
         patch :source => "create-regex-at-runtime.patch", :target => "#{python_2_embedded}/Lib/site-packages/yaml/reader.py"
+        patch :source => "tuf-0.17.0-cve-2021-41131.patch", :target => "#{python_2_embedded}/Lib/site-packages/tuf/client/updater.py"
       else
         patch :source => "create-regex-at-runtime.patch", :target => "#{install_dir}/embedded/lib/python2.7/site-packages/yaml/reader.py"
+        patch :source => "tuf-0.17.0-cve-2021-41131.patch", :target => "#{install_dir}/embedded/lib/python2.7/site-packages/tuf/client/updater.py"
       end
 
       # Run pip check to make sure the agent's python environment is clean, all the dependencies are compatible

--- a/releasenotes/notes/fix-tuf-cve-2021-41131.yaml
+++ b/releasenotes/notes/fix-tuf-cve-2021-41131.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Port python-tuf CVE fix on the embedded Python 2
+    see `<https://github.com/theupdateframework/python-tuf/security/advisories/GHSA-wjw6-2cqr-j4qr>`_.


### PR DESCRIPTION
### What does this PR do?

Backport #9581 to 7.32

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
