### PR TITLE
[Gitlab] Bump snyk base image

### DIFF
--- a/.gitlab/source_test/security_scan.yml
+++ b/.gitlab/source_test/security_scan.yml
@@ -1,6 +1,8 @@
 ---
 # Scan the dependencies for security vulnerabilities with snyk
 security_scan_test:
+  rules:
+    !reference [.on_main_or_release_branch]
   stage: source_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/snyk:v5817527-cb0e69f-next
   tags: ["runner:main"]
@@ -12,10 +14,9 @@ security_scan_test:
     - cd $GOPATH/src/github.com/DataDog/datadog-agent
     - python3 -m pip install -r requirements.txt
   script:
-    - snyk --version
     - set +x     # don't print the api key to the logs
     # send the list of the dependencies to snyk
     - SNYK_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.snyk_token --with-decryption --query "Parameter.Value" --out text)
       snyk monitor --command=python3 --project-name=datadog-agent-requirements.txt --file=requirements.txt --package-manager=pip
     - SNYK_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.snyk_token --with-decryption --query "Parameter.Value" --out text)
-      snyk monitor -d --project-name=datadog-agent-go.sum --file=go.mod
+      snyk monitor --project-name=datadog-agent-go.sum --file=go.mod

--- a/.gitlab/source_test/security_scan.yml
+++ b/.gitlab/source_test/security_scan.yml
@@ -12,6 +12,7 @@ security_scan_test:
     - cd $GOPATH/src/github.com/DataDog/datadog-agent
     - python3 -m pip install -r requirements.txt
   script:
+    - snyk --version
     - set +x     # don't print the api key to the logs
     # send the list of the dependencies to snyk
     - SNYK_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.snyk_token --with-decryption --query "Parameter.Value" --out text)

--- a/.gitlab/source_test/security_scan.yml
+++ b/.gitlab/source_test/security_scan.yml
@@ -18,4 +18,4 @@ security_scan_test:
     - SNYK_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.snyk_token --with-decryption --query "Parameter.Value" --out text)
       snyk monitor --command=python3 --project-name=datadog-agent-requirements.txt --file=requirements.txt --package-manager=pip
     - SNYK_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.snyk_token --with-decryption --query "Parameter.Value" --out text)
-      snyk monitor --project-name=datadog-agent-go.sum --file=go.mod
+      snyk monitor -d --project-name=datadog-agent-go.sum --file=go.mod

--- a/.gitlab/source_test/security_scan.yml
+++ b/.gitlab/source_test/security_scan.yml
@@ -4,7 +4,7 @@ security_scan_test:
   rules:
     !reference [.on_main_or_release_branch]
   stage: source_test
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/snyk:v3523070-7400854-next
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/snyk:v5815942-8517c69-next
   tags: ["runner:main"]
   needs: ["linux_x64_go_deps"]
   before_script:

--- a/.gitlab/source_test/security_scan.yml
+++ b/.gitlab/source_test/security_scan.yml
@@ -2,7 +2,7 @@
 # Scan the dependencies for security vulnerabilities with snyk
 security_scan_test:
   stage: source_test
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/snyk:v5815942-8517c69-next
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/snyk:v5817527-cb0e69f-next
   tags: ["runner:main"]
   needs: ["linux_x64_go_deps"]
   before_script:

--- a/.gitlab/source_test/security_scan.yml
+++ b/.gitlab/source_test/security_scan.yml
@@ -1,8 +1,6 @@
 ---
 # Scan the dependencies for security vulnerabilities with snyk
 security_scan_test:
-  rules:
-    !reference [.on_main_or_release_branch]
   stage: source_test
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/snyk:v5815942-8517c69-next
   tags: ["runner:main"]

--- a/pkg/kubestatemetrics/builder/doc.go
+++ b/pkg/kubestatemetrics/builder/doc.go
@@ -1,0 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
+// package builder includes a metric store builder.
+
+package builder


### PR DESCRIPTION
### What does this PR do?

Update snyk base image.

### Motivation

- Bump Go version from 1.14.12 to 1.16.7 to support `retract` clauses on `go.mod`.
- Bump `snyk` to 1.744.0 to support Go 1.16 
- Add doc.go file to package to ensure there is at least one non-excluded file.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
