### PR TITLE
Fix config path for collect_dns_domains

### DIFF
--- a/pkg/network/encoding/dns.go
+++ b/pkg/network/encoding/dns.go
@@ -34,7 +34,7 @@ func newDNSFormatter(conns *network.Connections, ipc ipCache) *dnsFormatter {
 		domainSet:         make(map[string]int),
 		seen:              make(map[dns.Key]struct{}),
 		queryTypeEnabled:  config.Datadog.GetBool("network_config.enable_dns_by_querytype"),
-		dnsDomainsEnabled: config.Datadog.GetBool("network_config.collect_dns_domains"),
+		dnsDomainsEnabled: config.Datadog.GetBool("system_probe_config.collect_dns_domains"),
 	}
 }
 

--- a/pkg/network/encoding/dns_test.go
+++ b/pkg/network/encoding/dns_test.go
@@ -49,7 +49,7 @@ func TestFormatConnectionDNS(t *testing.T) {
 	}
 
 	t.Run("DNS with collect_domains_enabled=true,enable_dns_by_querytype=false", func(t *testing.T) {
-		config.Datadog.Set("network_config.collect_dns_domains", true)
+		config.Datadog.Set("system_probe_config.collect_dns_domains", true)
 		config.Datadog.Set("network_config.enable_dns_by_querytype", false)
 
 		ipc := make(ipCache)
@@ -75,7 +75,7 @@ func TestFormatConnectionDNS(t *testing.T) {
 	})
 
 	t.Run("DNS with collect_domains_enabled=true,enable_dns_by_querytype=true", func(t *testing.T) {
-		config.Datadog.Set("network_config.collect_dns_domains", true)
+		config.Datadog.Set("system_probe_config.collect_dns_domains", true)
 		config.Datadog.Set("network_config.enable_dns_by_querytype", true)
 
 		ipc := make(ipCache)
@@ -148,7 +148,7 @@ func TestDNSPIDCollision(t *testing.T) {
 		},
 	}
 
-	config.Datadog.Set("network_config.collect_dns_domains", true)
+	config.Datadog.Set("system_probe_config.collect_dns_domains", true)
 	config.Datadog.Set("network_config.enable_dns_by_querytype", false)
 
 	ipc := make(ipCache)

--- a/pkg/network/encoding/encoding_test.go
+++ b/pkg/network/encoding/encoding_test.go
@@ -236,7 +236,7 @@ func TestSerialization(t *testing.T) {
 	t.Run("requesting application/json serialization (no query types)", func(t *testing.T) {
 		newConfig()
 		defer restoreGlobalConfig()
-		config.Datadog.Set("network_config.collect_dns_domains", false)
+		config.Datadog.Set("system_probe_config.collect_dns_domains", false)
 		out := getExpectedConnections(false, httpOutBlob)
 		assert := assert.New(t)
 		marshaler := GetMarshaler("application/json")
@@ -254,7 +254,7 @@ func TestSerialization(t *testing.T) {
 	t.Run("requesting application/json serialization (with query types)", func(t *testing.T) {
 		newConfig()
 		defer restoreGlobalConfig()
-		config.Datadog.Set("network_config.collect_dns_domains", false)
+		config.Datadog.Set("system_probe_config.collect_dns_domains", false)
 		config.Datadog.Set("network_config.enable_dns_by_querytype", true)
 		out := getExpectedConnections(true, httpOutBlob)
 		assert := assert.New(t)
@@ -273,7 +273,7 @@ func TestSerialization(t *testing.T) {
 	t.Run("requesting empty serialization", func(t *testing.T) {
 		newConfig()
 		defer restoreGlobalConfig()
-		config.Datadog.Set("network_config.collect_dns_domains", false)
+		config.Datadog.Set("system_probe_config.collect_dns_domains", false)
 		out := getExpectedConnections(false, httpOutBlob)
 		assert := assert.New(t)
 		marshaler := GetMarshaler("")
@@ -292,7 +292,7 @@ func TestSerialization(t *testing.T) {
 	t.Run("requesting unsupported serialization format", func(t *testing.T) {
 		newConfig()
 		defer restoreGlobalConfig()
-		config.Datadog.Set("network_config.collect_dns_domains", false)
+		config.Datadog.Set("system_probe_config.collect_dns_domains", false)
 		out := getExpectedConnections(false, httpOutBlob)
 
 		assert := assert.New(t)
@@ -341,7 +341,7 @@ func TestSerialization(t *testing.T) {
 	t.Run("requesting application/protobuf serialization (no query types)", func(t *testing.T) {
 		newConfig()
 		defer restoreGlobalConfig()
-		config.Datadog.Set("network_config.collect_dns_domains", false)
+		config.Datadog.Set("system_probe_config.collect_dns_domains", false)
 		out := getExpectedConnections(false, httpOutBlob)
 
 		assert := assert.New(t)
@@ -360,7 +360,7 @@ func TestSerialization(t *testing.T) {
 	t.Run("requesting application/protobuf serialization (with query types)", func(t *testing.T) {
 		newConfig()
 		defer restoreGlobalConfig()
-		config.Datadog.Set("network_config.collect_dns_domains", false)
+		config.Datadog.Set("system_probe_config.collect_dns_domains", false)
 		config.Datadog.Set("network_config.enable_dns_by_querytype", true)
 		out := getExpectedConnections(true, httpOutBlob)
 


### PR DESCRIPTION
### What does this PR do?

Fixes the config variable path used to have the correct prefix.

### Motivation

I noticed the incorrect path during some code exploration.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.

