### PR TITLE
[omnibus] Allow anonymous access to the omnibus artifacts cache

### DIFF
--- a/omnibus/omnibus.rb
+++ b/omnibus/omnibus.rb
@@ -20,7 +20,7 @@ if ENV["S3_OMNIBUS_CACHE_BUCKET"]
   s3_endpoint "https://s3.amazonaws.com"
   s3_region 'us-east-1'
   s3_force_path_style true
-  s3_authenticated_download true
+  s3_authenticated_download ENV.fetch('S3_OMNIBUS_CACHE_ANONYMOUS_ACCESS', '') == '' ? true : false
   if ENV['WINDOWS_BUILDER']
     s3_role true
     s3_role_arn 'arn:aws:iam::486234852809:role/ci-datadog-agent'


### PR DESCRIPTION
### What does this PR do?

This will allow anonymous access to the omnibus S3 artifacts cache, which we'll be using from https://github.com/DataDog/datadog-agent-macos-build/. I intentionally left this to default to authenticated access, because we want to be able to understand the places that fail because they don't have access credentials (and thus would be unable to prefill the cache with newer version of artifacts).

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
