### PR TITLE
Remove unimplemented `Marshal() ([]byte, error)` methods

### DIFF
--- a/pkg/collector/metadata/agentchecks/payload.go
+++ b/pkg/collector/metadata/agentchecks/payload.go
@@ -51,11 +51,6 @@ func (p *Payload) MarshalJSON() ([]byte, error) {
 	return json.Marshal((*PayloadAlias)(p))
 }
 
-// Marshal not implemented
-func (p *Payload) Marshal() ([]byte, error) {
-	return nil, fmt.Errorf("V5 Payload serialization is not implemented")
-}
-
 // SplitPayload breaks the payload into times number of pieces
 func (p *Payload) SplitPayload(times int) ([]marshaler.AbstractMarshaler, error) {
 	return nil, fmt.Errorf("AgentChecks Payload splitting is not implemented")

--- a/pkg/collector/metadata/agentchecks/payload.go
+++ b/pkg/collector/metadata/agentchecks/payload.go
@@ -57,7 +57,7 @@ func (p *Payload) Marshal() ([]byte, error) {
 }
 
 // SplitPayload breaks the payload into times number of pieces
-func (p *Payload) SplitPayload(times int) ([]marshaler.Marshaler, error) {
+func (p *Payload) SplitPayload(times int) ([]marshaler.AbstractMarshaler, error) {
 	return nil, fmt.Errorf("AgentChecks Payload splitting is not implemented")
 }
 

--- a/pkg/metadata/inventories/payload.go
+++ b/pkg/metadata/inventories/payload.go
@@ -37,11 +37,6 @@ func (p *Payload) MarshalJSON() ([]byte, error) {
 	return json.Marshal((*PayloadAlias)(p))
 }
 
-// Marshal not implemented
-func (p *Payload) Marshal() ([]byte, error) {
-	return nil, fmt.Errorf("V5 Payload serialization is not implemented")
-}
-
 // SplitPayload breaks the payload into times number of pieces
 func (p *Payload) SplitPayload(times int) ([]marshaler.AbstractMarshaler, error) {
 	return nil, fmt.Errorf("Inventories Payload splitting is not implemented")

--- a/pkg/metadata/inventories/payload.go
+++ b/pkg/metadata/inventories/payload.go
@@ -43,7 +43,7 @@ func (p *Payload) Marshal() ([]byte, error) {
 }
 
 // SplitPayload breaks the payload into times number of pieces
-func (p *Payload) SplitPayload(times int) ([]marshaler.Marshaler, error) {
+func (p *Payload) SplitPayload(times int) ([]marshaler.AbstractMarshaler, error) {
 	return nil, fmt.Errorf("Inventories Payload splitting is not implemented")
 }
 

--- a/pkg/metadata/v5/payload.go
+++ b/pkg/metadata/v5/payload.go
@@ -37,7 +37,7 @@ type MarshalledGohaiPayload struct {
 }
 
 // SplitPayload breaks the payload into times number of pieces
-func (p *Payload) SplitPayload(times int) ([]marshaler.Marshaler, error) {
+func (p *Payload) SplitPayload(times int) ([]marshaler.AbstractMarshaler, error) {
 	// Metadata payloads are analyzed as a whole, so they cannot be split
 	return nil, fmt.Errorf("V5 Payload splitting is not implemented")
 }

--- a/pkg/metadata/v5/payload_common.go
+++ b/pkg/metadata/v5/payload_common.go
@@ -7,7 +7,6 @@ package v5
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/metadata/common"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
@@ -35,9 +34,4 @@ func (p *Payload) MarshalJSON() ([]byte, error) {
 	type PayloadAlias Payload
 
 	return json.Marshal((*PayloadAlias)(p))
-}
-
-// Marshal not implemented
-func (p *Payload) Marshal() ([]byte, error) {
-	return nil, fmt.Errorf("V5 Payload serialization is not implemented")
 }

--- a/pkg/metadata/v5/payload_no_gohai.go
+++ b/pkg/metadata/v5/payload_no_gohai.go
@@ -22,7 +22,7 @@ type Payload struct {
 }
 
 // SplitPayload breaks the payload into times number of pieces
-func (p *Payload) SplitPayload(times int) ([]marshaler.Marshaler, error) {
+func (p *Payload) SplitPayload(times int) ([]marshaler.AbstractMarshaler, error) {
 	// Metadata payloads are analyzed as a whole, so they cannot be split
 	return nil, fmt.Errorf("V5 Payload splitting is not implemented")
 }

--- a/pkg/metrics/event.go
+++ b/pkg/metrics/event.go
@@ -167,7 +167,7 @@ func (events Events) MarshalJSON() ([]byte, error) {
 }
 
 // SplitPayload breaks the payload into times number of pieces
-func (events Events) SplitPayload(times int) ([]marshaler.Marshaler, error) {
+func (events Events) SplitPayload(times int) ([]marshaler.AbstractMarshaler, error) {
 	eventExpvar.Add("TimesSplit", 1)
 	tlmEvent.Inc("times_split")
 	// An individual event cannot be split,
@@ -179,7 +179,7 @@ func (events Events) SplitPayload(times int) ([]marshaler.Marshaler, error) {
 		tlmEvent.Inc("shorter")
 		times = len(events)
 	}
-	splitPayloads := make([]marshaler.Marshaler, times)
+	splitPayloads := make([]marshaler.AbstractMarshaler, times)
 
 	batchSize := len(events) / times
 	n := 0

--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -153,7 +153,7 @@ func (series Series) MarshalJSON() ([]byte, error) {
 }
 
 // SplitPayload breaks the payload into, at least, "times" number of pieces
-func (series Series) SplitPayload(times int) ([]marshaler.Marshaler, error) {
+func (series Series) SplitPayload(times int) ([]marshaler.AbstractMarshaler, error) {
 	seriesExpvar.Add("TimesSplit", 1)
 	tlmSeries.Inc("times_split")
 
@@ -177,7 +177,7 @@ func (series Series) SplitPayload(times int) ([]marshaler.Marshaler, error) {
 
 	nbSeriesPerPayload := len(series) / times
 
-	payloads := []marshaler.Marshaler{}
+	payloads := []marshaler.AbstractMarshaler{}
 	current := Series{}
 	for _, m := range metricsPerName {
 		// If on metric is bigger than the targeted size we directly

--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -59,11 +59,6 @@ type Serie struct {
 // Series represents a list of Serie ready to be serialize
 type Series []*Serie
 
-// Marshal serialize timeseries using protobuf
-func (series Series) Marshal() ([]byte, error) {
-	return nil, fmt.Errorf("Series payload serialization is not implemented")
-}
-
 // MarshalStrings converts the timeseries to a sorted slice of string slices
 func (series Series) MarshalStrings() ([]string, [][]string) {
 	var headers = []string{"Metric", "Type", "Timestamp", "Value", "Tags"}

--- a/pkg/metrics/service_check.go
+++ b/pkg/metrics/service_check.go
@@ -144,7 +144,7 @@ func (sc ServiceChecks) MarshalStrings() ([]string, [][]string) {
 }
 
 // SplitPayload breaks the payload into times number of pieces
-func (sc ServiceChecks) SplitPayload(times int) ([]marshaler.Marshaler, error) {
+func (sc ServiceChecks) SplitPayload(times int) ([]marshaler.AbstractMarshaler, error) {
 	serviceCheckExpvar.Add("TimesSplit", 1)
 	tlmServiceCheck.Inc("times_split")
 	// only split it up as much as possible
@@ -153,7 +153,7 @@ func (sc ServiceChecks) SplitPayload(times int) ([]marshaler.Marshaler, error) {
 		tlmServiceCheck.Inc("shorter")
 		times = len(sc)
 	}
-	splitPayloads := make([]marshaler.Marshaler, times)
+	splitPayloads := make([]marshaler.AbstractMarshaler, times)
 	batchSize := len(sc) / times
 	n := 0
 	for i := 0; i < times; i++ {

--- a/pkg/metrics/service_check.go
+++ b/pkg/metrics/service_check.go
@@ -88,11 +88,6 @@ type ServiceCheck struct {
 // ServiceChecks represents a list of service checks ready to be serialize
 type ServiceChecks []*ServiceCheck
 
-// Marshal serializes service checks using protobuf (v2)
-func (sc ServiceChecks) Marshal() ([]byte, error) {
-	return nil, fmt.Errorf("ServiceChecks payload serialization is not implemented")
-}
-
 // MarshalJSON serializes service checks to JSON so it can be sent to V1 endpoints
 //FIXME(olivier): to be removed when v2 endpoints are available
 func (sc ServiceChecks) MarshalJSON() ([]byte, error) {

--- a/pkg/metrics/service_check_test.go
+++ b/pkg/metrics/service_check_test.go
@@ -189,7 +189,7 @@ func benchmarkPayloadsServiceCheck(b *testing.B, numberOfItem int) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		split.Payloads(serviceChecks, true, split.MarshalJSON)
+		split.Payloads(serviceChecks, true, split.JSONMarshalFct)
 	}
 }
 

--- a/pkg/metrics/sketch_benchmark_test.go
+++ b/pkg/metrics/sketch_benchmark_test.go
@@ -25,7 +25,7 @@ func benchmarkSplitPayloadsSketchesSplit(b *testing.B, numPoints int) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		split.Payloads(testSketchSeries, true, split.Marshal)
+		split.Payloads(testSketchSeries, true, split.ProtoMarshalFct)
 	}
 }
 

--- a/pkg/metrics/sketch_series.go
+++ b/pkg/metrics/sketch_series.go
@@ -358,12 +358,12 @@ func (sl SketchSeriesList) Marshal() ([]byte, error) {
 }
 
 // SplitPayload breaks the payload into times number of pieces
-func (sl SketchSeriesList) SplitPayload(times int) ([]marshaler.Marshaler, error) {
+func (sl SketchSeriesList) SplitPayload(times int) ([]marshaler.AbstractMarshaler, error) {
 	// Only break it down as much as possible
 	if len(sl) < times {
 		times = len(sl)
 	}
-	splitPayloads := make([]marshaler.Marshaler, times)
+	splitPayloads := make([]marshaler.AbstractMarshaler, times)
 	batchSize := len(sl) / times
 	n := 0
 	for i := 0; i < times; i++ {

--- a/pkg/serializer/marshaler/marshaler.go
+++ b/pkg/serializer/marshaler/marshaler.go
@@ -28,7 +28,7 @@ type MarshalerProto interface {
 }
 
 type AbstractMarshaler interface {
-	SplitPayload(int) ([]Marshaler, error)
+	SplitPayload(int) ([]AbstractMarshaler, error)
 	MarshalSplitCompress(*BufferContext) ([]*[]byte, error)
 }
 

--- a/pkg/serializer/marshaler/marshaler.go
+++ b/pkg/serializer/marshaler/marshaler.go
@@ -13,8 +13,21 @@ import (
 
 // Marshaler is an interface for metrics that are able to serialize themselves to JSON and protobuf
 type Marshaler interface {
+	MarshalerJSON
+	MarshalerProto
+}
+
+type MarshalerJSON interface {
+	AbstractMarshaler
 	MarshalJSON() ([]byte, error)
+}
+
+type MarshalerProto interface {
+	AbstractMarshaler
 	Marshal() ([]byte, error)
+}
+
+type AbstractMarshaler interface {
 	SplitPayload(int) ([]Marshaler, error)
 	MarshalSplitCompress(*BufferContext) ([]*[]byte, error)
 }

--- a/pkg/serializer/marshaler/marshaler.go
+++ b/pkg/serializer/marshaler/marshaler.go
@@ -34,7 +34,7 @@ type AbstractMarshaler interface {
 
 // StreamJSONMarshaler is an interface for metrics that are able to serialize themselves in a stream
 type StreamJSONMarshaler interface {
-	Marshaler
+	MarshalerJSON
 	WriteHeader(*jsoniter.Stream) error
 	WriteFooter(*jsoniter.Stream) error
 	WriteItem(*jsoniter.Stream, int) error

--- a/pkg/serializer/marshaler/marshaler.go
+++ b/pkg/serializer/marshaler/marshaler.go
@@ -13,20 +13,23 @@ import (
 
 // Marshaler is an interface for metrics that are able to serialize themselves to JSON and protobuf
 type Marshaler interface {
-	MarshalerJSON
-	MarshalerProto
+	JSONMarshaler
+	ProtoMarshaler
 }
 
-type MarshalerJSON interface {
+// JSONMarshaler is a AbstractMarshaler that implement JSON marshaling.
+type JSONMarshaler interface {
 	AbstractMarshaler
 	MarshalJSON() ([]byte, error)
 }
 
-type MarshalerProto interface {
+// ProtoMarshaler is a AbstractMarshaler that implement proto marshaling.
+type ProtoMarshaler interface {
 	AbstractMarshaler
 	Marshal() ([]byte, error)
 }
 
+// AbstractMarshaler is an abstract marshaler.
 type AbstractMarshaler interface {
 	SplitPayload(int) ([]AbstractMarshaler, error)
 	MarshalSplitCompress(*BufferContext) ([]*[]byte, error)
@@ -34,7 +37,7 @@ type AbstractMarshaler interface {
 
 // StreamJSONMarshaler is an interface for metrics that are able to serialize themselves in a stream
 type StreamJSONMarshaler interface {
-	MarshalerJSON
+	JSONMarshaler
 	WriteHeader(*jsoniter.Stream) error
 	WriteFooter(*jsoniter.Stream) error
 	WriteItem(*jsoniter.Stream, int) error

--- a/pkg/serializer/marshaler/marshaler.go
+++ b/pkg/serializer/marshaler/marshaler.go
@@ -20,18 +20,25 @@ type Marshaler interface {
 // JSONMarshaler is a AbstractMarshaler that implement JSON marshaling.
 type JSONMarshaler interface {
 	AbstractMarshaler
+
+	// MarshalJSON serialization a Payload to JSON
 	MarshalJSON() ([]byte, error)
 }
 
 // ProtoMarshaler is a AbstractMarshaler that implement proto marshaling.
 type ProtoMarshaler interface {
 	AbstractMarshaler
+
+	// Marshal serialize objects using agent-payload definition.
 	Marshal() ([]byte, error)
 }
 
 // AbstractMarshaler is an abstract marshaler.
 type AbstractMarshaler interface {
+	// SplitPayload breaks the payload into times number of pieces
 	SplitPayload(int) ([]AbstractMarshaler, error)
+
+	// MarshalSplitCompress uses the stream compressor to marshal and compress payloads.
 	MarshalSplitCompress(*BufferContext) ([]*[]byte, error)
 }
 

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -284,7 +284,7 @@ func (s *Serializer) SendServiceChecks(sc marshaler.StreamJSONMarshaler) error {
 	if useV1API && s.enableServiceChecksJSONStream {
 		serviceCheckPayloads, extraHeaders, err = s.serializeStreamablePayload(sc, stream.DropItemOnErrItemTooBig)
 	} else {
-		serviceCheckPayloads, extraHeaders, err = s.serializePayload(sc, true, useV1API)
+		serviceCheckPayloads, extraHeaders, err = s.serializePayloadJSON(sc, true)
 	}
 	if err != nil {
 		return fmt.Errorf("dropping service check payload: %s", err)
@@ -312,7 +312,7 @@ func (s *Serializer) SendSeries(series marshaler.StreamJSONMarshaler) error {
 	if useV1API && s.enableJSONStream {
 		seriesPayloads, extraHeaders, err = s.serializeStreamablePayload(series, stream.DropItemOnErrItemTooBig)
 	} else {
-		seriesPayloads, extraHeaders, err = s.serializePayload(series, true, useV1API)
+		seriesPayloads, extraHeaders, err = s.serializePayloadJSON(series, true)
 	}
 
 	if err != nil {

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -168,7 +168,7 @@ func (s Serializer) serializePayload(payload marshaler.Marshaler, compress bool,
 	return s.serializePayloadProto(payload, compress)
 }
 
-func (s Serializer) serializePayloadJSON(payload marshaler.Marshaler, compress bool) (forwarder.Payloads, http.Header, error) {
+func (s Serializer) serializePayloadJSON(payload marshaler.MarshalerJSON, compress bool) (forwarder.Payloads, http.Header, error) {
 	var extraHeaders http.Header
 
 	if compress {
@@ -180,7 +180,7 @@ func (s Serializer) serializePayloadJSON(payload marshaler.Marshaler, compress b
 	return s.serializePayloadInternal(payload, compress, extraHeaders, split.JSONMarshalFct)
 }
 
-func (s Serializer) serializePayloadProto(payload marshaler.Marshaler, compress bool) (forwarder.Payloads, http.Header, error) {
+func (s Serializer) serializePayloadProto(payload marshaler.MarshalerProto, compress bool) (forwarder.Payloads, http.Header, error) {
 	var extraHeaders http.Header
 	if compress {
 		extraHeaders = protobufExtraHeadersWithCompression
@@ -190,7 +190,7 @@ func (s Serializer) serializePayloadProto(payload marshaler.Marshaler, compress 
 	return s.serializePayloadInternal(payload, compress, extraHeaders, split.ProtoMarshalFct)
 }
 
-func (s Serializer) serializePayloadInternal(payload marshaler.Marshaler, compress bool, extraHeaders http.Header, marshalFct split.MarshalFct) (forwarder.Payloads, http.Header, error) {
+func (s Serializer) serializePayloadInternal(payload marshaler.AbstractMarshaler, compress bool, extraHeaders http.Header, marshalFct split.MarshalFct) (forwarder.Payloads, http.Header, error) {
 	payloads, err := split.Payloads(payload, compress, marshalFct)
 
 	if err != nil {

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -95,8 +95,8 @@ type MetricSerializer interface {
 	SendServiceChecks(sc marshaler.StreamJSONMarshaler) error
 	SendSeries(series marshaler.StreamJSONMarshaler) error
 	SendSketch(sketches marshaler.Marshaler) error
-	SendMetadata(m marshaler.MarshalerJSON) error
-	SendHostMetadata(m marshaler.MarshalerJSON) error
+	SendMetadata(m marshaler.JSONMarshaler) error
+	SendHostMetadata(m marshaler.JSONMarshaler) error
 	SendProcessesMetadata(data interface{}) error
 	SendOrchestratorMetadata(msgs []ProcessMessageBody, hostName, clusterID string, payloadType int) error
 }
@@ -168,7 +168,7 @@ func (s Serializer) serializePayload(payload marshaler.Marshaler, compress bool,
 	return s.serializePayloadProto(payload, compress)
 }
 
-func (s Serializer) serializePayloadJSON(payload marshaler.MarshalerJSON, compress bool) (forwarder.Payloads, http.Header, error) {
+func (s Serializer) serializePayloadJSON(payload marshaler.JSONMarshaler, compress bool) (forwarder.Payloads, http.Header, error) {
 	var extraHeaders http.Header
 
 	if compress {
@@ -180,7 +180,7 @@ func (s Serializer) serializePayloadJSON(payload marshaler.MarshalerJSON, compre
 	return s.serializePayloadInternal(payload, compress, extraHeaders, split.JSONMarshalFct)
 }
 
-func (s Serializer) serializePayloadProto(payload marshaler.MarshalerProto, compress bool) (forwarder.Payloads, http.Header, error) {
+func (s Serializer) serializePayloadProto(payload marshaler.ProtoMarshaler, compress bool) (forwarder.Payloads, http.Header, error) {
 	var extraHeaders http.Header
 	if compress {
 		extraHeaders = protobufExtraHeadersWithCompression
@@ -348,21 +348,21 @@ func (s *Serializer) SendSketch(sketches marshaler.Marshaler) error {
 }
 
 // SendMetadata serializes a metadata payload and sends it to the forwarder
-func (s *Serializer) SendMetadata(m marshaler.MarshalerJSON) error {
+func (s *Serializer) SendMetadata(m marshaler.JSONMarshaler) error {
 	return s.sendMetadata(m, s.Forwarder.SubmitMetadata)
 }
 
 // SendHostMetadata serializes a metadata payload and sends it to the forwarder
-func (s *Serializer) SendHostMetadata(m marshaler.MarshalerJSON) error {
+func (s *Serializer) SendHostMetadata(m marshaler.JSONMarshaler) error {
 	return s.sendMetadata(m, s.Forwarder.SubmitHostMetadata)
 }
 
 // SendAgentchecksMetadata serializes a metadata payload and sends it to the forwarder
-func (s *Serializer) SendAgentchecksMetadata(m marshaler.MarshalerJSON) error {
+func (s *Serializer) SendAgentchecksMetadata(m marshaler.JSONMarshaler) error {
 	return s.sendMetadata(m, s.Forwarder.SubmitAgentChecksMetadata)
 }
 
-func (s *Serializer) sendMetadata(m marshaler.MarshalerJSON, submit func(payload forwarder.Payloads, extra http.Header) error) error {
+func (s *Serializer) sendMetadata(m marshaler.JSONMarshaler, submit func(payload forwarder.Payloads, extra http.Header) error) error {
 	mustSplit, compressedPayload, payload, err := split.CheckSizeAndSerialize(m, true, split.JSONMarshalFct)
 	if err != nil {
 		return fmt.Errorf("could not determine size of metadata payload: %s", err)

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -95,8 +95,8 @@ type MetricSerializer interface {
 	SendServiceChecks(sc marshaler.StreamJSONMarshaler) error
 	SendSeries(series marshaler.StreamJSONMarshaler) error
 	SendSketch(sketches marshaler.Marshaler) error
-	SendMetadata(m marshaler.Marshaler) error
-	SendHostMetadata(m marshaler.Marshaler) error
+	SendMetadata(m marshaler.MarshalerJSON) error
+	SendHostMetadata(m marshaler.MarshalerJSON) error
 	SendProcessesMetadata(data interface{}) error
 	SendOrchestratorMetadata(msgs []ProcessMessageBody, hostName, clusterID string, payloadType int) error
 }
@@ -348,21 +348,21 @@ func (s *Serializer) SendSketch(sketches marshaler.Marshaler) error {
 }
 
 // SendMetadata serializes a metadata payload and sends it to the forwarder
-func (s *Serializer) SendMetadata(m marshaler.Marshaler) error {
+func (s *Serializer) SendMetadata(m marshaler.MarshalerJSON) error {
 	return s.sendMetadata(m, s.Forwarder.SubmitMetadata)
 }
 
 // SendHostMetadata serializes a metadata payload and sends it to the forwarder
-func (s *Serializer) SendHostMetadata(m marshaler.Marshaler) error {
+func (s *Serializer) SendHostMetadata(m marshaler.MarshalerJSON) error {
 	return s.sendMetadata(m, s.Forwarder.SubmitHostMetadata)
 }
 
 // SendAgentchecksMetadata serializes a metadata payload and sends it to the forwarder
-func (s *Serializer) SendAgentchecksMetadata(m marshaler.Marshaler) error {
+func (s *Serializer) SendAgentchecksMetadata(m marshaler.MarshalerJSON) error {
 	return s.sendMetadata(m, s.Forwarder.SubmitAgentChecksMetadata)
 }
 
-func (s *Serializer) sendMetadata(m marshaler.Marshaler, submit func(payload forwarder.Payloads, extra http.Header) error) error {
+func (s *Serializer) sendMetadata(m marshaler.MarshalerJSON, submit func(payload forwarder.Payloads, extra http.Header) error) error {
 	mustSplit, compressedPayload, payload, err := split.CheckSizeAndSerialize(m, true, split.JSONMarshalFct)
 	if err != nil {
 		return fmt.Errorf("could not determine size of metadata payload: %s", err)

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -162,18 +162,18 @@ func NewSerializer(forwarder forwarder.Forwarder, orchestratorForwarder forwarde
 }
 
 func (s Serializer) serializePayload(payload marshaler.Marshaler, compress bool, useV1API bool) (forwarder.Payloads, http.Header, error) {
-	var marshalType split.MarshalType
+	var marshalFct split.MarshalFct
 	var extraHeaders http.Header
 
 	if useV1API {
-		marshalType = split.MarshalJSON
+		marshalFct = split.JSONMarshalFct
 		if compress {
 			extraHeaders = jsonExtraHeadersWithCompression
 		} else {
 			extraHeaders = jsonExtraHeaders
 		}
 	} else {
-		marshalType = split.Marshal
+		marshalFct = split.ProtoMarshalFct
 		if compress {
 			extraHeaders = protobufExtraHeadersWithCompression
 		} else {
@@ -181,7 +181,7 @@ func (s Serializer) serializePayload(payload marshaler.Marshaler, compress bool,
 		}
 	}
 
-	payloads, err := split.Payloads(payload, compress, marshalType)
+	payloads, err := split.Payloads(payload, compress, marshalFct)
 
 	if err != nil {
 		return nil, nil, fmt.Errorf("could not split payload into small enough chunks: %s", err)
@@ -353,7 +353,7 @@ func (s *Serializer) SendAgentchecksMetadata(m marshaler.Marshaler) error {
 }
 
 func (s *Serializer) sendMetadata(m marshaler.Marshaler, submit func(payload forwarder.Payloads, extra http.Header) error) error {
-	mustSplit, compressedPayload, payload, err := split.CheckSizeAndSerialize(m, true, split.MarshalJSON)
+	mustSplit, compressedPayload, payload, err := split.CheckSizeAndSerialize(m, true, split.JSONMarshalFct)
 	if err != nil {
 		return fmt.Errorf("could not determine size of metadata payload: %s", err)
 	}

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -181,6 +181,10 @@ func (s Serializer) serializePayload(payload marshaler.Marshaler, compress bool,
 		}
 	}
 
+	return s.serializePayloadInternal(payload, compress, extraHeaders, marshalFct)
+}
+
+func (s Serializer) serializePayloadInternal(payload marshaler.Marshaler, compress bool, extraHeaders http.Header, marshalFct split.MarshalFct) (forwarder.Payloads, http.Header, error) {
 	payloads, err := split.Payloads(payload, compress, marshalFct)
 
 	if err != nil {

--- a/pkg/serializer/serializer_benchmark_test.go
+++ b/pkg/serializer/serializer_benchmark_test.go
@@ -55,7 +55,7 @@ func benchmarkSplit(b *testing.B, numberOfSeries int) {
 	b.ResetTimer()
 
 	for n := 0; n < b.N; n++ {
-		results, _ = split.Payloads(series, true, split.MarshalJSON)
+		results, _ = split.Payloads(series, true, split.JSONMarshalFct)
 	}
 }
 

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -116,8 +116,8 @@ func (p *testPayload) MarshalSplitCompress(bufferContext *marshaler.BufferContex
 	payloads = append(payloads, &payload)
 	return payloads, nil
 }
-func (p *testPayload) SplitPayload(int) ([]marshaler.Marshaler, error) {
-	return []marshaler.Marshaler{}, nil
+func (p *testPayload) SplitPayload(int) ([]marshaler.AbstractMarshaler, error) {
+	return []marshaler.AbstractMarshaler{}, nil
 }
 
 func (p *testPayload) WriteHeader(stream *jsoniter.Stream) error {
@@ -139,8 +139,8 @@ type testErrorPayload struct{}
 
 func (p *testErrorPayload) MarshalJSON() ([]byte, error) { return nil, fmt.Errorf("some error") }
 func (p *testErrorPayload) Marshal() ([]byte, error)     { return nil, fmt.Errorf("some error") }
-func (p *testErrorPayload) SplitPayload(int) ([]marshaler.Marshaler, error) {
-	return []marshaler.Marshaler{}, fmt.Errorf("some error")
+func (p *testErrorPayload) SplitPayload(int) ([]marshaler.AbstractMarshaler, error) {
+	return []marshaler.AbstractMarshaler{}, fmt.Errorf("some error")
 }
 func (p *testErrorPayload) MarshalSplitCompress(bufferContext *marshaler.BufferContext) ([]*[]byte, error) {
 	return nil, fmt.Errorf("some error")

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -178,13 +178,13 @@ type testEventsPayload struct {
 	mock.Mock
 }
 
-func createTestEventsPayloadMock(marshaler marshaler.StreamJSONMarshaler) *testEventsPayload {
+func createTestEventsPayloadMock(marshaler marshaler.Marshaler) *testEventsPayload {
 	p := &testEventsPayload{}
 	p.Marshaler = marshaler
 	return p
 }
 
-func createTestEventsPayload(marshaler marshaler.StreamJSONMarshaler) *testEventsPayload {
+func createTestEventsPayload(marshaler marshaler.Marshaler) *testEventsPayload {
 	p := createTestEventsPayloadMock(marshaler)
 	p.On("CreateSingleMarshaler").Return(marshaler)
 	return p

--- a/pkg/serializer/split/split.go
+++ b/pkg/serializer/split/split.go
@@ -23,11 +23,14 @@ var maxPayloadSizeUnCompressed = 64 * 1024 * 1024
 // MarshalFct marshal m. Must be either JSONMarshalFct or ProtoMarshalFct.
 type MarshalFct func(m marshaler.AbstractMarshaler) ([]byte, error)
 
+// JSONMarshalFct marshal with MarshalJSON method.
 func JSONMarshalFct(m marshaler.AbstractMarshaler) ([]byte, error) {
-	return (m.(marshaler.MarshalerJSON)).MarshalJSON()
+	return (m.(marshaler.JSONMarshaler)).MarshalJSON()
 }
+
+// ProtoMarshalFct marshal with Marshal method.
 func ProtoMarshalFct(m marshaler.AbstractMarshaler) ([]byte, error) {
-	return (m.(marshaler.MarshalerProto)).Marshal()
+	return (m.(marshaler.ProtoMarshaler)).Marshal()
 }
 
 var (

--- a/pkg/serializer/split/split_test.go
+++ b/pkg/serializer/split/split_test.go
@@ -69,7 +69,7 @@ func testSplitPayloadsSeries(t *testing.T, numPoints int, compress bool) {
 		testSeries = append(testSeries, &point)
 	}
 
-	payloads, err := Payloads(testSeries, compress, MarshalJSON)
+	payloads, err := Payloads(testSeries, compress, JSONMarshalFct)
 	require.Nil(t, err)
 
 	originalLength := len(testSeries)
@@ -119,7 +119,7 @@ func BenchmarkSplitPayloadsSeries(b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		// always record the result of Payloads to prevent
 		// the compiler eliminating the function call.
-		r, _ = Payloads(testSeries, true, MarshalJSON)
+		r, _ = Payloads(testSeries, true, JSONMarshalFct)
 
 	}
 	// ensure we actually had to split
@@ -181,7 +181,7 @@ func testSplitPayloadsEvents(t *testing.T, numPoints int, compress bool) {
 		testEvent = append(testEvent, &event)
 	}
 
-	payloads, err := Payloads(testEvent, compress, MarshalJSON)
+	payloads, err := Payloads(testEvent, compress, JSONMarshalFct)
 	require.Nil(t, err)
 
 	originalLength := len(testEvent)
@@ -246,7 +246,7 @@ func testSplitPayloadsServiceChecks(t *testing.T, numPoints int, compress bool) 
 		testServiceChecks = append(testServiceChecks, &sc)
 	}
 
-	payloads, err := Payloads(testServiceChecks, compress, MarshalJSON)
+	payloads, err := Payloads(testServiceChecks, compress, JSONMarshalFct)
 	require.Nil(t, err)
 
 	originalLength := len(testServiceChecks)
@@ -301,7 +301,7 @@ func testSplitPayloadsSketches(t *testing.T, numPoints int, compress bool) {
 		testSketchSeries[i] = metrics.Makeseries(i)
 	}
 
-	payloads, err := Payloads(testSketchSeries, compress, MarshalJSON)
+	payloads, err := Payloads(testSketchSeries, compress, JSONMarshalFct)
 	require.Nil(t, err)
 
 	var splitSketches = []metrics.SketchSeriesList{}

--- a/pkg/serializer/stream/compressor_test.go
+++ b/pkg/serializer/stream/compressor_test.go
@@ -73,7 +73,7 @@ func (d *dummyMarshaller) Marshal() ([]byte, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
-func (d *dummyMarshaller) SplitPayload(int) ([]marshaler.Marshaler, error) {
+func (d *dummyMarshaller) SplitPayload(int) ([]marshaler.AbstractMarshaler, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 

--- a/pkg/serializer/test_common.go
+++ b/pkg/serializer/test_common.go
@@ -39,12 +39,12 @@ func (s *MockSerializer) SendSketch(sketches marshaler.Marshaler) error {
 }
 
 // SendMetadata serializes a metadata payload and sends it to the forwarder
-func (s *MockSerializer) SendMetadata(m marshaler.MarshalerJSON) error {
+func (s *MockSerializer) SendMetadata(m marshaler.JSONMarshaler) error {
 	return s.Called(m).Error(0)
 }
 
 // SendHostMetadata serializes a host metadata payload and sends it to the forwarder
-func (s *MockSerializer) SendHostMetadata(m marshaler.MarshalerJSON) error {
+func (s *MockSerializer) SendHostMetadata(m marshaler.JSONMarshaler) error {
 	return s.Called(m).Error(0)
 }
 

--- a/pkg/serializer/test_common.go
+++ b/pkg/serializer/test_common.go
@@ -39,12 +39,12 @@ func (s *MockSerializer) SendSketch(sketches marshaler.Marshaler) error {
 }
 
 // SendMetadata serializes a metadata payload and sends it to the forwarder
-func (s *MockSerializer) SendMetadata(m marshaler.Marshaler) error {
+func (s *MockSerializer) SendMetadata(m marshaler.MarshalerJSON) error {
 	return s.Called(m).Error(0)
 }
 
 // SendHostMetadata serializes a host metadata payload and sends it to the forwarder
-func (s *MockSerializer) SendHostMetadata(m marshaler.Marshaler) error {
+func (s *MockSerializer) SendHostMetadata(m marshaler.MarshalerJSON) error {
 	return s.Called(m).Error(0)
 }
 


### PR DESCRIPTION
### What does this PR do?

Remove unimplemented `Marshal() ([]byte, error)` methods.

### Motivation

https://github.com/DataDog/datadog-agent/pull/9608#discussion_r733648680

### Additional Notes

**Reviewing commit by commit is recommended.**

### Describe how to test your changes

I sent several DogStatsD metrics which are series and checked I received them in the backend.

For QA: Send several ServiceCheck and check you received them in the backend

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [X] The appropriate `team/..` label has been applied, if known.
- [X] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
