### PR TITLE
[inv test] Do not run gofmt unless fail-on-fmt is set

### DIFF
--- a/tasks/test.py
+++ b/tasks/test.py
@@ -164,7 +164,8 @@ def test(
 
             with ctx.cd(module.full_path()):
                 vet(ctx, targets=module.targets, rtloader_root=rtloader_root, build_tags=build_tags, arch=arch)
-                fmt(ctx, targets=module.targets, fail_on_fmt=fail_on_fmt)
+                if fail_on_fmt:
+                    fmt(ctx, targets=module.targets, fail_on_fmt=True)
                 lint(ctx, targets=module.targets)
                 misspell(ctx, targets=module.targets)
                 ineffassign(ctx, targets=module.targets)


### PR DESCRIPTION
### What does this PR do?

Do not run `gofmt` as part of the linting stage of the `test` invoke task unless we want formatting errors to fail the test (ie: `--fail-on-fmt` is passed in).

### Motivation

I don't think it's any useful.
