### PR TITLE
[pkg/security/secl] Add doc file to secl module to fix mod-tidy check

### DIFF
--- a/pkg/security/secl/doc.go
+++ b/pkg/security/secl/doc.go
@@ -1,0 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
+// Package secl provides utilities related to Datadog’s Security Language.
+// This module has no API stability guarantees.
+package secl

--- a/pkg/security/secl/doc.go
+++ b/pkg/security/secl/doc.go
@@ -3,6 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021-present Datadog, Inc.
 
-// Package secl provides utilities related to Datadog’s Security Language.
+// Package secl provides utilities related to Datadog Cloud Workload Security Policy Language.
 // This module has no API stability guarantees.
 package secl


### PR DESCRIPTION
### What does this PR do?

Add `doc.go` file to SECL module.

### Motivation

Fix `go_mod_tidy_check` (see [run here](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/93394631))

### Additional Notes

Follow up to #9628.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
