### PR TITLE
[PodWatcher] Generate events for ready->unready->ready pods

### DIFF
--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -189,7 +189,18 @@ func (l *KubeletListener) createPodService(pod workloadmeta.KubernetesPod, conta
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	l.services[buildSvcID(pod.GetID())] = svc
+	svcID := buildSvcID(pod.GetID())
+	if old, found := l.services[svcID]; found {
+		if kubeletSvcEqual(old, svc) {
+			log.Debugf("Received a duplicated kubelet service '%s'", svc.entity)
+			return
+		}
+
+		log.Debugf("Kubelet service '%s' has been updated, removing the old one", svc.entity)
+		l.delService <- old
+	}
+
+	l.services[svcID] = svc
 	l.newService <- svc
 }
 

--- a/pkg/util/kubernetes/kubelet/podwatcher_test.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher_test.go
@@ -49,6 +49,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherComputeChanges() {
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
+		oldReadiness:   make(map[string]bool),
 		expiryDuration: 5 * time.Minute,
 	}
 
@@ -90,6 +91,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherComputeChangesInConditions() {
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
+		oldReadiness:   make(map[string]bool),
 		expiryDuration: 5 * time.Minute,
 	}
 
@@ -131,6 +133,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherWithInitContainers() {
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
+		oldReadiness:   make(map[string]bool),
 		expiryDuration: 5 * time.Minute,
 	}
 
@@ -159,6 +162,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherWithShortLivedContainers() {
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
+		oldReadiness:   make(map[string]bool),
 		expiryDuration: 5 * time.Minute,
 	}
 
@@ -187,6 +191,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherReadinessChange() {
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
+		oldReadiness:   make(map[string]bool),
 		expiryDuration: 5 * time.Minute,
 	}
 
@@ -218,7 +223,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherReadinessChange() {
 	require.Len(suite.T(), sourcePods, 5)
 	changes, err = watcher.computeChanges(sourcePods)
 	require.Nil(suite.T(), err)
-	require.Len(suite.T(), changes, 0)
+	require.Len(suite.T(), changes, 1)
 	expire, err = watcher.Expire()
 	require.Nil(suite.T(), err)
 	require.Len(suite.T(), expire, 0)
@@ -244,7 +249,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherReadinessChange() {
 	require.Len(suite.T(), sourcePods, 5)
 	changes, err = watcher.computeChanges(sourcePods)
 	require.Nil(suite.T(), err)
-	require.Len(suite.T(), changes, 0)
+	require.Len(suite.T(), changes, 1)
 	expire, err = watcher.Expire()
 	require.Nil(suite.T(), err)
 	require.Len(suite.T(), expire, 0)
@@ -257,7 +262,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherReadinessChange() {
 	require.Len(suite.T(), sourcePods, 5)
 	changes, err = watcher.computeChanges(sourcePods)
 	require.Nil(suite.T(), err)
-	require.Len(suite.T(), changes, 0)
+	require.Len(suite.T(), changes, 1)
 	require.Len(suite.T(), watcher.lastSeenReady, 5)
 	expire, err = watcher.Expire()
 	require.Nil(suite.T(), err)
@@ -288,6 +293,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireUnready() {
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
+		oldReadiness:   make(map[string]bool),
 		expiryDuration: 5 * time.Minute,
 	}
 
@@ -331,6 +337,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireDelay() {
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
+		oldReadiness:   make(map[string]bool),
 		tagsDigest:     make(map[string]string),
 		oldPhase:       make(map[string]string),
 		expiryDuration: 5 * time.Minute,
@@ -373,6 +380,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherExpireWholePod() {
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
+		oldReadiness:   make(map[string]bool),
 		tagsDigest:     make(map[string]string),
 		oldPhase:       make(map[string]string),
 		expiryDuration: 5 * time.Minute,
@@ -454,6 +462,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherLabelsValueChange() {
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
 		tagsDigest:     make(map[string]string),
+		oldReadiness:   make(map[string]bool),
 		oldPhase:       make(map[string]string),
 		expiryDuration: 5 * time.Minute,
 	}
@@ -496,6 +505,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherPhaseChange() {
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
+		oldReadiness:   make(map[string]bool),
 		tagsDigest:     make(map[string]string),
 		oldPhase:       make(map[string]string),
 		expiryDuration: 5 * time.Minute,
@@ -521,6 +531,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherPhaseChangeNotRegistered() {
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
+		oldReadiness:   make(map[string]bool),
 		expiryDuration: 5 * time.Minute,
 	}
 	twoPods := sourcePods[:2]
@@ -542,6 +553,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherAnnotationsValueChange() {
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
+		oldReadiness:   make(map[string]bool),
 		tagsDigest:     make(map[string]string),
 		oldPhase:       make(map[string]string),
 		expiryDuration: 5 * time.Minute,
@@ -585,6 +597,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherContainerCreating() {
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
+		oldReadiness:   make(map[string]bool),
 		expiryDuration: 5 * time.Minute,
 	}
 
@@ -601,6 +614,7 @@ func (suite *PodwatcherTestSuite) TestPodWatcherContainerCreatingTags() {
 	watcher := &PodWatcher{
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
+		oldReadiness:   make(map[string]bool),
 		tagsDigest:     make(map[string]string),
 		oldPhase:       make(map[string]string),
 		expiryDuration: 5 * time.Minute,


### PR DESCRIPTION
### What does this PR do?

Previously, once a pod was observed as ready, going unready and back to
ready would not re-schedule checks, making previously running ones go
away, with an "unable to resolve, service not ready" error and never
come back as the pod became ready again.

This commit also addresses the fact that a pod could now generate many
services for the same pod. Now we also check that pod services aren't
duplicated, just like we do with containers.

### Describe how to test your changes

I used the following deployment to verify this:

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: redis
  namespace: default
spec:
  replicas: 1
  selector:
    matchLabels:
      app: redis
  template:
    metadata:
      labels:
        app: redis
      annotations:
        ad.datadoghq.com/redis.check_names: '["redisdb"]'
        ad.datadoghq.com/redis.init_configs: '[{}]'
        ad.datadoghq.com/redis.instances: |
          [
            {
              "host": "%%host%%",
              "port":"6379"
            }
          ]
        ad.datadoghq.com/redis.logs: '[{"source":"redis", "host": "%%host%%"}]'
    spec:
      containers:
      - name: readiness
        image: k8s.gcr.io/busybox
        args:
        - /bin/sh
        - -c
        - while true; do touch /tmp/healthy; sleep 60; rm -rf /tmp/healthy; sleep 60; done
        readinessProbe:
          exec:
            command:
            - cat
            - /tmp/healthy
          initialDelaySeconds: 5
          periodSeconds: 5
      - image: redis
        imagePullPolicy: Always
        name: redis
        env:
          - name: ALLOW_EMPTY_PASSWORD
            value: "yes"
```

This will switch a redis pod between ready and unready every 60 seconds. When the pod is not ready, `agent configcheck` should not show a related check, while it should come back once the pod is ready again. Note that this only applies to the `redisdb` check in this example, not the logs config, as that one should not go away.