### PR TITLE
Refactor deployment manifest collection

### DIFF
--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -140,8 +140,9 @@ func TestGetAndSetSender(t *testing.T) {
 	eventChan := make(chan metrics.Event, 10)
 	bucketChan := make(chan senderHistogramBucket, 10)
 	orchestratorChan := make(chan senderOrchestratorMetadata, 10)
+	orchestratorManifestChan := make(chan senderOrchestratorManifest, 10)
 	eventPlatformChan := make(chan senderEventPlatformEvent, 10)
-	testCheckSender := newCheckSender(checkID1, "", senderMetricSampleChan, serviceCheckChan, eventChan, bucketChan, orchestratorChan, eventPlatformChan)
+	testCheckSender := newCheckSender(checkID1, "", senderMetricSampleChan, serviceCheckChan, eventChan, bucketChan, orchestratorChan, orchestratorManifestChan, eventPlatformChan)
 
 	err := SetSender(testCheckSender, checkID1)
 	assert.Nil(t, err)

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -336,7 +336,7 @@ func (o *OrchestratorCheck) processDeploys(sender aggregator.Sender) {
 		return
 	}
 
-	messages, err := processDeploymentList(deployList, atomic.AddInt32(&o.groupID, 1), o.orchestratorConfig, o.clusterID)
+	messages, manifests, err := processDeploymentList(deployList, atomic.AddInt32(&o.groupID, 1), o.orchestratorConfig, o.clusterID)
 	if err != nil {
 		_ = o.Warnf("Unable to process deployment list: %v", err)
 		return
@@ -351,6 +351,7 @@ func (o *OrchestratorCheck) processDeploys(sender aggregator.Sender) {
 	orchestrator.KubernetesResourceCache.Set(orchestrator.BuildStatsKey(orchestrator.K8sDeployment), stats, orchestrator.NoExpiration)
 
 	sender.OrchestratorMetadata(messages, o.clusterID, int(orchestrator.K8sDeployment))
+	sender.OrchestratorManifest(manifests, o.orchestratorConfig.KubeClusterName, o.clusterID)
 }
 
 func (o *OrchestratorCheck) processReplicaSets(sender aggregator.Sender) {

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -72,6 +72,7 @@ type Forwarder interface {
 	SubmitRTContainerChecks(payload Payloads, extra http.Header) (chan Response, error)
 	SubmitConnectionChecks(payload Payloads, extra http.Header) (chan Response, error)
 	SubmitOrchestratorChecks(payload Payloads, extra http.Header, payloadType int) (chan Response, error)
+	SubmitOrchestratorManifests(payload Payloads, extra http.Header) (chan Response, error)
 }
 
 // Compile-time check to ensure that DefaultForwarder implements the Forwarder interface
@@ -534,6 +535,10 @@ func (f *DefaultForwarder) SubmitConnectionChecks(payload Payloads, extra http.H
 func (f *DefaultForwarder) SubmitOrchestratorChecks(payload Payloads, extra http.Header, payloadType int) (chan Response, error) {
 	bumpOrchestratorPayload(payloadType)
 
+	return f.submitProcessLikePayload(orchestratorEndpoint, payload, extra, true)
+}
+
+func (f *DefaultForwarder) SubmitOrchestratorManifests(payload Payloads, extra http.Header) (chan Response, error) {
 	return f.submitProcessLikePayload(orchestratorEndpoint, payload, extra, true)
 }
 

--- a/pkg/forwarder/sync_forwarder.go
+++ b/pkg/forwarder/sync_forwarder.go
@@ -145,3 +145,8 @@ func (f *SyncForwarder) SubmitConnectionChecks(payload Payloads, extra http.Head
 func (f *SyncForwarder) SubmitOrchestratorChecks(payload Payloads, extra http.Header, payloadType int) (chan Response, error) {
 	return f.defaultForwarder.SubmitOrchestratorChecks(payload, extra, payloadType)
 }
+
+// SubmitOrchestratorManifests sends orchestrator manifests
+func (f *SyncForwarder) SubmitOrchestratorManifests(payload Payloads, extra http.Header, payloadType int) (chan Response, error) {
+	return f.defaultForwarder.SubmitOrchestratorManifests(payload, extra)
+}

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -99,6 +99,7 @@ type MetricSerializer interface {
 	SendHostMetadata(m marshaler.Marshaler) error
 	SendProcessesMetadata(data interface{}) error
 	SendOrchestratorMetadata(msgs []ProcessMessageBody, hostName, clusterID string, payloadType int) error
+	SendOrchestratorManifests(msgs []ProcessMessageBody, hostName, clusterID string) error
 }
 
 // Serializer serializes metrics to the correct format and routes the payloads to the correct endpoint in the Forwarder
@@ -415,6 +416,37 @@ func (s *Serializer) SendOrchestratorMetadata(msgs []ProcessMessageBody, hostNam
 
 		payloads := forwarder.Payloads{&body}
 		responses, err := s.orchestratorForwarder.SubmitOrchestratorChecks(payloads, extraHeaders, payloadType)
+		if err != nil {
+			return log.Errorf("Unable to submit payload: %s", err)
+		}
+
+		// Consume the responses so that writers to the channel do not become blocked
+		// we don't need the bodies here though
+		for range responses {
+
+		}
+	}
+	return nil
+}
+
+// SendOrchestratorManifests serializes & send orchestrator manifest payloads
+func (s *Serializer) SendOrchestratorManifests(msgs []ProcessMessageBody, hostName, clusterID string) error {
+	if s.orchestratorForwarder == nil {
+		return errors.New("orchestrator forwarder is not setup")
+	}
+	for _, m := range msgs {
+		extraHeaders := make(http.Header)
+		extraHeaders.Set(headers.HostHeader, hostName)
+		extraHeaders.Set(headers.ClusterIDHeader, clusterID)
+		extraHeaders.Set(headers.TimestampHeader, strconv.Itoa(int(time.Now().Unix())))
+
+		body, err := processPayloadEncoder(m)
+		if err != nil {
+			return log.Errorf("Unable to encode message: %s", err)
+		}
+
+		payloads := forwarder.Payloads{&body}
+		responses, err := s.orchestratorForwarder.SubmitOrchestratorManifests(payloads, extraHeaders)
 		if err != nil {
 			return log.Errorf("Unable to submit payload: %s", err)
 		}


### PR DESCRIPTION
### What does this PR do?

Refactor of https://github.com/DataDog/datadog-agent/pull/7157 following the core check migration

### Motivation

What inspired you to submit this pull request?

### Additional Notes

- this PR only does the change for `deployment` other resources to be added
- the pod manifest collection in the process agent is still to be done
- it still sends the payload to the orchestrator intake

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
