### PR TITLE
Add storage disk section to agent status command.

### DIFF
--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -253,6 +253,24 @@
             </span>
           </span>
         {{- end}}
+      {{- end -}}
+      <span class="stat_subtitle">On-disk storage</span>
+      <span class="stat_subdata">
+      {{- if .config.forwarder_storage_max_size_in_bytes }}
+        {{- if .forwarderStats.FileStorage.CurrentSizeInBytes }}
+        Disk usage in bytes: {{ .forwarderStats.FileStorage.CurrentSizeInBytes }}<br>
+        Number of files: {{ .forwarderStats.FileStorage.FilesCount }}<br>
+        Number of files removed: {{ .forwarderStats.FileStorage.FilesRemovedCount }}<br>
+        Deserialization errors count: {{ .forwarderStats.FileStorage.DeserializeErrorsCount }}<br>
+        Outdated files removed at startup: {{ .forwarderStats.RemovalPolicy.OutdatedFilesCount }}<br>
+        {{- else }}
+        Enabled, not in-use.<br>
+        {{- end}}
+      {{- else }}
+        On-disk storage is disabled. Configure `forwarder_storage_max_size_in_bytes` to enable it.<br>
+      {{- end}}
+      </span>
+      {{- with .forwarderStats -}}
         {{- if .APIKeyStatus}}
           <span class="stat_subtitle">API Keys Status</span>
           <span class="stat_subdata">
@@ -264,7 +282,7 @@
       {{- end -}}
     </span>
   </div>
-
+  
   <div class="stat">
     <span class="stat_title">Endpoints</span>
     <span class="stat_data">

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -254,6 +254,7 @@
           </span>
         {{- end}}
       {{- end -}}
+      {{/* The subsection `On-disk storage` is not inside `{{- with .forwarderStats -}}` as it need to access `.config` */}}
       <span class="stat_subtitle">On-disk storage</span>
       <span class="stat_subdata">
       {{- if .config.forwarder_storage_max_size_in_bytes }}
@@ -282,7 +283,7 @@
       {{- end -}}
     </span>
   </div>
-  
+
   <div class="stat">
     <span class="stat_title">Endpoints</span>
     <span class="stat_data">

--- a/cmd/agent/gui/views/templates/generalStatus.tmpl
+++ b/cmd/agent/gui/views/templates/generalStatus.tmpl
@@ -261,7 +261,7 @@
         {{- if .forwarderStats.FileStorage.CurrentSizeInBytes }}
         Disk usage in bytes: {{ .forwarderStats.FileStorage.CurrentSizeInBytes }}<br>
         Number of files: {{ .forwarderStats.FileStorage.FilesCount }}<br>
-        Number of files removed: {{ .forwarderStats.FileStorage.FilesRemovedCount }}<br>
+        Number of files dropped: {{ .forwarderStats.FileStorage.FilesRemovedCount }}<br>
         Deserialization errors count: {{ .forwarderStats.FileStorage.DeserializeErrorsCount }}<br>
         Outdated files removed at startup: {{ .forwarderStats.RemovalPolicy.OutdatedFilesCount }}<br>
         {{- else }}

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -30,6 +30,11 @@ func FormatStatus(data []byte) (string, error) {
 	stats := make(map[string]interface{})
 	json.Unmarshal(data, &stats) //nolint:errcheck
 	forwarderStats := stats["forwarderStats"]
+	if forwarderStatsMap, ok := forwarderStats.(map[string]interface{}); ok {
+		forwarderStatsMap["config"] = stats["config"]
+	} else {
+		log.Warn("The Forwarder status format is invalid. Some parts of the `Forwarder` section may be missing.")
+	}
 	runnerStats := stats["runnerStats"]
 	pyLoaderStats := stats["pyLoaderStats"]
 	pythonInit := stats["pythonInit"]

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -253,9 +253,9 @@ func getPartialConfig() map[string]string {
 	conf["log_level"] = config.Datadog.GetString("log_level")
 	conf["confd_path"] = config.Datadog.GetString("confd_path")
 	conf["additional_checksd"] = config.Datadog.GetString("additional_checksd")
-	forwarder_storage_max_size_in_bytes := config.Datadog.GetInt("forwarder_storage_max_size_in_bytes")
-	if forwarder_storage_max_size_in_bytes > 0 {
-		conf["forwarder_storage_max_size_in_bytes"] = strconv.Itoa(forwarder_storage_max_size_in_bytes)
+	forwarderStorageMaxSizeInBytes := config.Datadog.GetInt("forwarder_storage_max_size_in_bytes")
+	if forwarderStorageMaxSizeInBytes > 0 {
+		conf["forwarder_storage_max_size_in_bytes"] = strconv.Itoa(forwarderStorageMaxSizeInBytes)
 	}
 	return conf
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -253,6 +253,7 @@ func getPartialConfig() map[string]string {
 	conf["log_level"] = config.Datadog.GetString("log_level")
 	conf["confd_path"] = config.Datadog.GetString("confd_path")
 	conf["additional_checksd"] = config.Datadog.GetString("additional_checksd")
+	conf["forwarder_storage_max_size_in_bytes"] = strconv.Itoa(config.Datadog.GetInt("forwarder_storage_max_size_in_bytes"))
 	return conf
 }
 

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -253,7 +253,10 @@ func getPartialConfig() map[string]string {
 	conf["log_level"] = config.Datadog.GetString("log_level")
 	conf["confd_path"] = config.Datadog.GetString("confd_path")
 	conf["additional_checksd"] = config.Datadog.GetString("additional_checksd")
-	conf["forwarder_storage_max_size_in_bytes"] = strconv.Itoa(config.Datadog.GetInt("forwarder_storage_max_size_in_bytes"))
+	forwarder_storage_max_size_in_bytes := config.Datadog.GetInt("forwarder_storage_max_size_in_bytes")
+	if forwarder_storage_max_size_in_bytes > 0 {
+		conf["forwarder_storage_max_size_in_bytes"] = strconv.Itoa(forwarder_storage_max_size_in_bytes)
+	}
 	return conf
 }
 

--- a/pkg/status/templates/forwarder.tmpl
+++ b/pkg/status/templates/forwarder.tmpl
@@ -60,8 +60,8 @@ Forwarder
   {{- if .config.forwarder_storage_max_size_in_bytes }}
     {{- if .FileStorage.CurrentSizeInBytes }}
     Disk usage in bytes: {{ .FileStorage.CurrentSizeInBytes }}
-    Number of files: {{ .FileStorage.FilesCount }}
-    Number of files removed: {{ .FileStorage.FilesRemovedCount }}
+    Current number of files: {{ .FileStorage.FilesCount }}
+    Number of files removed containing payloads: {{ .FileStorage.FilesRemovedCount }}
     Deserialization errors count: {{ .FileStorage.DeserializeErrorsCount }}
     Outdated files removed at startup: {{ .RemovalPolicy.OutdatedFilesCount }}
     {{- else }}

--- a/pkg/status/templates/forwarder.tmpl
+++ b/pkg/status/templates/forwarder.tmpl
@@ -61,7 +61,7 @@ Forwarder
     {{- if .FileStorage.CurrentSizeInBytes }}
     Disk usage in bytes: {{ .FileStorage.CurrentSizeInBytes }}
     Current number of files: {{ .FileStorage.FilesCount }}
-    Number of files removed containing payloads: {{ .FileStorage.FilesRemovedCount }}
+    Number of files dropped: {{ .FileStorage.FilesRemovedCount }}
     Deserialization errors count: {{ .FileStorage.DeserializeErrorsCount }}
     Outdated files removed at startup: {{ .RemovalPolicy.OutdatedFilesCount }}
     {{- else }}

--- a/pkg/status/templates/forwarder.tmpl
+++ b/pkg/status/templates/forwarder.tmpl
@@ -55,6 +55,22 @@ Forwarder
   {{- end}}
 {{- end}}
 
+  On-disk storage
+  ===============
+  {{- if .config.forwarder_storage_max_size_in_bytes }}
+    {{- if .FileStorage.CurrentSizeInBytes }}
+    Disk usage in bytes: {{ .FileStorage.CurrentSizeInBytes }}
+    Number of files: {{ .FileStorage.FilesCount }}
+    Number of files removed: {{ .FileStorage.FilesRemovedCount }}
+    Deserialization errors count: {{ .FileStorage.DeserializeErrorsCount }}
+    Outdated files removed at startup: {{ .RemovalPolicy.OutdatedFilesCount }}
+    {{- else }}
+    Enabled, not in-use.
+    {{- end}}
+  {{- else }}
+    On-disk storage is disabled. Configure `forwarder_storage_max_size_in_bytes` to enable it.
+  {{- end}}
+
 {{- if .APIKeyStatus }}
 
   API Keys status

--- a/releasenotes/notes/agent-status-storage-on-disk-bae502a19ff9e3b0.yaml
+++ b/releasenotes/notes/agent-status-storage-on-disk-bae502a19ff9e3b0.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add a new `On-disk storage` section to `agent status` command.


### PR DESCRIPTION
### What does this PR do?

Add  `storage disk` section to `agent status` command.

### Describe how to test your changes
Check the following cases on `agent stats` command and on the Web UI:
```
forwarder_retry_queue_payloads_max_size: 100
```
=> On-disk storage is disabled. Configure `forwarder_storage_max_size_in_bytes` to enable it.

```
forwarder_retry_queue_payloads_max_size: 100
forwarder_storage_max_size_in_bytes: 0
```
=> On-disk storage is disabled. Configure `forwarder_storage_max_size_in_bytes` to enable it.

```
forwarder_retry_queue_payloads_max_size: 100
forwarder_storage_max_size_in_bytes: 1000
```
=> `Enabled, not in-use.` then after few seconds it should display the following sections:
```
Disk usage in bytes: 465
Number of files: 1
Number of files removed: 2
Deserialization errors count: 0
Outdated files removed at startup: 0
```
### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [X] The appropriate `team/..` label has been applied, if known.
- [X] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
