### PR TITLE
Sign the `{agent,cluster-agent,dogstatsd}-scan` docker images

### DIFF
--- a/.gitlab/docker_common/publish_job_templates.yml
+++ b/.gitlab/docker_common/publish_job_templates.yml
@@ -9,10 +9,9 @@
   tags: ["runner:main"]
   variables:
     <<: *docker_variables
-    IMG_SIGNING: "true"
     IMG_VARIABLES: ""
   script: # We can't use the 'trigger' keyword on manual jobs, otherwise they can't be run if the pipeline fails and is retried
     - python3 -m pip install -r requirements.txt
     - ECR_RELEASE_SUFFIX="${CI_COMMIT_TAG+-release}"
     - IMG_SOURCES="$(sed -E "s#(${SRC_AGENT}|${SRC_DSD}|${SRC_DCA})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_SOURCES")"
-    - inv pipeline.trigger-child-pipeline --project-name "DataDog/public-images" --git-ref "main" --variables "IMG_VARIABLES,IMG_REGISTRIES,IMG_SOURCES,IMG_DESTINATIONS,IMG_SIGNING"
+    - inv pipeline.trigger-child-pipeline --project-name "DataDog/public-images" --git-ref "main" --variables "IMG_VARIABLES,IMG_REGISTRIES,IMG_SOURCES,IMG_DESTINATIONS"

--- a/.gitlab/image_scan.yml
+++ b/.gitlab/image_scan.yml
@@ -13,7 +13,6 @@ scan_nightly-dogstatsd:
     - docker_build_dogstatsd_amd64
   variables:
     IMG_REGISTRIES: dev
-    IMG_SIGNING: "false"
     IMG_SOURCES: ${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
     IMG_DESTINATIONS: dogstatsd-scan:${DEB_RPM_BUCKET_BRANCH}
 
@@ -27,7 +26,6 @@ scan_nightly-a6:
     - docker_build_agent6_jmx
   variables:
     IMG_REGISTRIES: dev
-    IMG_SIGNING: "false"
   parallel:
     matrix:
       - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-amd64
@@ -45,7 +43,6 @@ scan_nightly-a7:
     - docker_build_agent7_jmx
   variables:
     IMG_REGISTRIES: dev
-    IMG_SIGNING: "false"
   parallel:
     matrix:
       - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64
@@ -61,7 +58,6 @@ dca_scan_nightly:
   needs: ["docker_build_cluster_agent_amd64"]
   variables:
     IMG_REGISTRIES: dev
-    IMG_SIGNING: "false"
     IMG_SOURCES: ${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
     IMG_DESTINATIONS: cluster-agent-scan:${DEB_RPM_BUCKET_BRANCH}
 
@@ -75,7 +71,6 @@ scan_master-dogstatsd:
     - docker_build_dogstatsd_amd64
   variables:
     IMG_REGISTRIES: dev
-    IMG_SIGNING: "false"
     IMG_SOURCES: ${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
     IMG_DESTINATIONS: dogstatsd-scan:master
 
@@ -89,7 +84,6 @@ scan_master-a6:
     - docker_build_agent6_jmx
   variables:
     IMG_REGISTRIES: dev
-    IMG_SIGNING: "false"
   parallel:
     matrix:
       - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6-amd64
@@ -107,7 +101,6 @@ scan_master-a7:
     - docker_build_agent7_jmx
   variables:
     IMG_REGISTRIES: dev
-    IMG_SIGNING: "false"
   parallel:
     matrix:
       - IMG_SOURCES: ${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-amd64
@@ -123,6 +116,5 @@ dca_scan_master:
   needs: ["docker_build_cluster_agent_amd64"]
   variables:
     IMG_REGISTRIES: dev
-    IMG_SIGNING: "false"
     IMG_SOURCES: ${SRC_DCA}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
     IMG_DESTINATIONS: cluster-agent-scan:master


### PR DESCRIPTION
### What does this PR do?

Sign the `{agent,cluster-agent,dogstatsd}-scan` docker images.

### Motivation

Notary has just been setup up for those registries.
It’s better to have an homogeneous setup.
It provides us an extra sandbox to validate the key rotation procedure.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Run a pipeline and check that docker push to `{agent,cluster-agent,dogstatsd}-scan` are working and are signed.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
