### PR TITLE
Log about unknown DD_.. env variables

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1085,15 +1085,19 @@ func findUnknownKeys(config Config) []string {
 
 func findUnknownEnvVars(config Config) []string {
 	var unknownVars []string
-	knownVars := config.GetKnownEnvVars()
+
+	knownVars := map[string]struct{}{}
+	for _, key := range config.GetEnvVars() {
+		knownVars[key] = struct{}{}
+	}
 
 	for _, equality := range os.Environ() {
-		v := strings.SplitN(equality, "=", 2)[0]
-		if !strings.HasPrefix(v, "DD_") {
+		key := strings.SplitN(equality, "=", 2)[0]
+		if !strings.HasPrefix(key, "DD_") {
 			continue
 		}
-		if _, known := knownVars[v]; !known {
-			unknownVars = append(unknownVars, v)
+		if _, known := knownVars[key]; !known {
+			unknownVars = append(unknownVars, key)
 		}
 	}
 	return unknownVars

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -76,8 +76,6 @@ type Config interface {
 	// GetKnownKeys returns all the keys that meet at least one of these criteria:
 	// 1) have a default, 2) have an environment variable binded, 3) are an alias or 4) have been SetKnown()
 	GetKnownKeys() map[string]interface{}
-	// GetKnownEnvVars returns all the nev vars defined via BindEnv and similar methods.
-	GetKnownEnvVars() map[string]struct{}
 
 	// API not implemented by viper.Viper and that have proven useful for our config usage
 
@@ -87,6 +85,8 @@ type Config interface {
 	// If env is provided, it will override the name of the environment variable used for this
 	// config key
 	BindEnvAndSetDefault(key string, val interface{}, env ...string)
-	// GetEnvVars returns a list of the non-sensitive env vars that the config supports
+
+	// GetEnvVars returns a list of the env vars that the config supports.
+	// These have had the EnvPrefix applied, as well as the EnvKeyReplacer.
 	GetEnvVars() []string
 }

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -76,6 +76,8 @@ type Config interface {
 	// GetKnownKeys returns all the keys that meet at least one of these criteria:
 	// 1) have a default, 2) have an environment variable binded, 3) are an alias or 4) have been SetKnown()
 	GetKnownKeys() map[string]interface{}
+	// GetKnownEnvVars returns all the nev vars defined via BindEnv and similar methods.
+	GetKnownEnvVars() map[string]struct{}
 
 	// API not implemented by viper.Viper and that have proven useful for our config usage
 

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -26,8 +26,9 @@ import (
 type safeConfig struct {
 	*viper.Viper
 	sync.RWMutex
-	envPrefix     string
-	configEnvVars []string
+	envPrefix      string
+	envKeyReplacer *strings.Replacer
+	configEnvVars  []string
 }
 
 // Set wraps Viper for concurrent access
@@ -60,19 +61,6 @@ func (c *safeConfig) GetKnownKeys() map[string]interface{} {
 	// GetKnownKeys returns a fresh map, so the caller may do with it
 	// as they please without holding the lock.
 	return c.Viper.GetKnownKeys()
-}
-
-// GetKnownEnvVars returns all the nev vars defined via BindEnv and similar methods.
-func (c *safeConfig) GetKnownEnvVars() map[string]struct{} {
-	c.Lock()
-	defer c.Unlock()
-
-	rv := map[string]struct{}{}
-	for _, v := range c.configEnvVars {
-		rv[v] = struct{}{}
-	}
-
-	return rv
 }
 
 // SetEnvKeyTransformer allows defining a transformer function which decides
@@ -282,17 +270,33 @@ func (c *safeConfig) SetEnvPrefix(in string) {
 	c.envPrefix = in
 }
 
+// mergeWithEnvPrefix derives the environment variable that Viper will use for a given key.
+func (c *safeConfig) mergeWithEnvPrefix(key string) string {
+	return strings.Join([]string{c.envPrefix, strings.ToUpper(key)}, "_")
+}
+
 // BindEnv wraps Viper for concurrent access, and adds tracking of the configurable env vars
 func (c *safeConfig) BindEnv(input ...string) {
 	c.Lock()
 	defer c.Unlock()
+	var envKeys []string
+
+	// If one input is given, viper derives an env key from it; otherwise, all inputs after
+	// the first are literal env vars.
 	if len(input) == 1 {
-		// FIXME: for the purposes of GetEnvVars implementation, we only track env var keys
-		// that are interpolated by viper from the config option key name
-		key := input[0]
-		envVarName := strings.Join([]string{c.envPrefix, strings.ToUpper(key)}, "_")
-		c.configEnvVars = append(c.configEnvVars, envVarName)
+		envKeys = []string{c.mergeWithEnvPrefix(input[0])}
+	} else {
+		envKeys = input[1:]
 	}
+
+	for _, key := range envKeys {
+		// apply EnvKeyReplacer to each key
+		if c.envKeyReplacer != nil {
+			key = c.envKeyReplacer.Replace(key)
+		}
+		c.configEnvVars = append(c.configEnvVars, key)
+	}
+
 	_ = c.Viper.BindEnv(input...)
 }
 
@@ -301,6 +305,7 @@ func (c *safeConfig) SetEnvKeyReplacer(r *strings.Replacer) {
 	c.RLock()
 	defer c.RUnlock()
 	c.Viper.SetEnvKeyReplacer(r)
+	c.envKeyReplacer = r
 }
 
 // UnmarshalKey wraps Viper for concurrent access

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -62,6 +62,19 @@ func (c *safeConfig) GetKnownKeys() map[string]interface{} {
 	return c.Viper.GetKnownKeys()
 }
 
+// GetKnownEnvVars returns all the nev vars defined via BindEnv and similar methods.
+func (c *safeConfig) GetKnownEnvVars() map[string]struct{} {
+	c.Lock()
+	defer c.Unlock()
+
+	rv := map[string]struct{}{}
+	for _, v := range c.configEnvVars {
+		rv[v] = struct{}{}
+	}
+
+	return rv
+}
+
 // SetEnvKeyTransformer allows defining a transformer function which decides
 // how an environment variables value gets assigned to key.
 func (c *safeConfig) SetEnvKeyTransformer(key string, fn func(string) interface{}) {

--- a/pkg/config/viper_test.go
+++ b/pkg/config/viper_test.go
@@ -95,10 +95,8 @@ func TestGetConfigEnvVars(t *testing.T) {
 	config.BindEnv("logs_config.run_path")
 	assert.Contains(t, config.GetEnvVars(), "DD_LOGS_CONFIG.RUN_PATH")
 
-	// FIXME: ideally we should also track env vars when BindEnv is used with
-	// 2 arguments. Not the case at the moment, as demonstrated below.
 	config.BindEnv("config_option", "DD_CONFIG_OPTION")
-	assert.NotContains(t, config.GetEnvVars(), "DD_CONFIG_OPTION")
+	assert.Contains(t, config.GetEnvVars(), "DD_CONFIG_OPTION")
 }
 
 func TestGetFloat64SliceE(t *testing.T) {

--- a/pkg/config/viper_test.go
+++ b/pkg/config/viper_test.go
@@ -9,17 +9,15 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 
-	"github.com/DataDog/viper"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestConcurrencySetGet(t *testing.T) {
-	config := safeConfig{
-		Viper: viper.New(),
-	}
+	config := NewConfig("test", "DD", strings.NewReplacer(".", "_"))
 
 	var wg sync.WaitGroup
 
@@ -42,9 +40,8 @@ func TestConcurrencySetGet(t *testing.T) {
 }
 
 func TestConcurrencyUnmarshalling(t *testing.T) {
-	config := safeConfig{
-		Viper: viper.New(),
-	}
+	config := NewConfig("test", "DD", strings.NewReplacer(".", "_"))
+
 	config.SetDefault("foo", map[string]string{})
 	config.SetDefault("BAR", "test")
 	config.SetDefault("baz", "test")
@@ -85,25 +82,20 @@ func TestConcurrencyUnmarshalling(t *testing.T) {
 }
 
 func TestGetConfigEnvVars(t *testing.T) {
-	config := safeConfig{
-		Viper: viper.New(),
-	}
-	config.SetEnvPrefix("DD")
+	config := NewConfig("test", "DD", strings.NewReplacer(".", "_"))
 
 	config.BindEnv("app_key")
 	assert.Contains(t, config.GetEnvVars(), "DD_APP_KEY")
 	config.BindEnv("logs_config.run_path")
-	assert.Contains(t, config.GetEnvVars(), "DD_LOGS_CONFIG.RUN_PATH")
+	assert.Contains(t, config.GetEnvVars(), "DD_LOGS_CONFIG_RUN_PATH")
 
 	config.BindEnv("config_option", "DD_CONFIG_OPTION")
 	assert.Contains(t, config.GetEnvVars(), "DD_CONFIG_OPTION")
 }
 
 func TestGetFloat64SliceE(t *testing.T) {
-	config := safeConfig{
-		Viper: viper.New(),
-	}
-	config.SetEnvPrefix("DD")
+	config := NewConfig("test", "DD", strings.NewReplacer(".", "_"))
+
 	config.BindEnv("float_list")
 	config.SetConfigType("yaml")
 	yamlExample := []byte(`---
@@ -133,10 +125,8 @@ float_list:
 }
 
 func TestGetFloat64SliceEEnv(t *testing.T) {
-	config := safeConfig{
-		Viper: viper.New(),
-	}
-	config.SetEnvPrefix("DD")
+	config := NewConfig("test", "DD", strings.NewReplacer(".", "_"))
+
 	config.BindEnv("float_list")
 	config.SetConfigType("yaml")
 

--- a/pkg/flare/envvars.go
+++ b/pkg/flare/envvars.go
@@ -85,11 +85,6 @@ var allowedEnvvarNames = []string{
 func getAllowedEnvvars() []string {
 	allowed := allowedEnvvarNames
 	for _, envName := range config.Datadog.GetEnvVars() {
-		// config.Datadog.GetEnvVars() returns nested config using the format DD_FOO.BAR
-		// we should consider the format DD_FOO_BAR
-		if replaced := strings.ReplaceAll(envName, ".", "_"); replaced != envName {
-			allowed = append(allowed, replaced)
-		}
 		allowed = append(allowed, envName)
 	}
 	var found []string

--- a/pkg/flare/envvars_test.go
+++ b/pkg/flare/envvars_test.go
@@ -91,14 +91,12 @@ func TestEnvvarFiltering(t *testing.T) {
 			in: map[string]string{
 				"DOCKER_HOST":                                   "tcp://10.0.0.10:8888",
 				"DD_EXTERNAL_METRICS_PROVIDER_MAX_AGE":          "500",  // external_metrics_provider.max_age
-				"DD_EXTERNAL_METRICS_PROVIDER.MAX_AGE":          "500",  // external_metrics_provider.max_age
 				"DD_ADMISSION_CONTROLLER_INJECT_CONFIG_ENABLED": "true", // admission_controller.inject_config.enabled
 				"GOGC": "120",
 			},
 			out: []string{
 				"DOCKER_HOST=tcp://10.0.0.10:8888",
 				"DD_EXTERNAL_METRICS_PROVIDER_MAX_AGE=500",
-				"DD_EXTERNAL_METRICS_PROVIDER.MAX_AGE=500",
 				"DD_ADMISSION_CONTROLLER_INJECT_CONFIG_ENABLED=true",
 				"GOGC=120",
 			},

--- a/releasenotes/notes/unused-env-e9cf916ee8d49bb4.yaml
+++ b/releasenotes/notes/unused-env-e9cf916ee8d49bb4.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    If unrecognized ``DD_..`` environment variables are set, the agent will now log a warning at startup, to help catch deployment typos.


### PR DESCRIPTION
### What does this PR do?

Adds logging for unknown configuration env vars, which are probably due to a typo.

### Describe how to test your changes

Start an agent with both a correct and an incorrect DD_.. variable set.  Use something nested for the correct key, like DD_TELEMETRY_ENABLED.  You should see something like

```
2021-10-25 13:11:29 EDT | CORE | WARN | (pkg/util/log/log.go:630 in func1) | Unknown environment variable: DD_FOOEY
```
at startup, for the incorrect variable (and not the correct variable)

Additionally, run a local flare and ensure that it includes the DD_.. variable you set (the correct one).