### PR TITLE
pkg/trace/obfuscate: fix bug where obfuscation fails for autovacuum sql text

### DIFF
--- a/pkg/trace/obfuscate/sql_test.go
+++ b/pkg/trace/obfuscate/sql_test.go
@@ -83,6 +83,30 @@ func TestKeepSQLAlias(t *testing.T) {
 	})
 }
 
+func TestCanObfuscateAutoVacuum(t *testing.T) {
+	assert := assert.New(t)
+	for _, tt := range []struct{ in, out string }{
+		{
+			in:  "autovacuum: VACUUM ANALYZE fake.table",
+			out: "autovacuum : VACUUM ANALYZE fake.table",
+		},
+		{
+			in:  "autovacuum: VACUUM ANALYZE fake.table_downtime",
+			out: "autovacuum : VACUUM ANALYZE fake.table_downtime",
+		},
+		{
+			in:  "autovacuum: VACUUM fake.big_table (to prevent wraparound)",
+			out: "autovacuum : VACUUM fake.big_table ( to prevent wraparound )",
+		},
+	} {
+		t.Run("", func(t *testing.T) {
+			oq, err := NewObfuscator(nil).ObfuscateSQLString(tt.in)
+			assert.NoError(err)
+			assert.Equal(tt.out, oq.Query)
+		})
+	}
+}
+
 func TestDollarQuotedFunc(t *testing.T) {
 	q := `SELECT $func$INSERT INTO table VALUES ('a', 1, 2)$func$ FROM users`
 

--- a/pkg/trace/obfuscate/sql_tokenizer.go
+++ b/pkg/trace/obfuscate/sql_tokenizer.go
@@ -223,6 +223,10 @@ func (tkn *SQLTokenizer) Scan() (TokenKind, []byte) {
 				tkn.advance()
 				return ColonCast, []byte("::")
 			}
+			if unicode.IsSpace(tkn.lastChar) {
+				// example scenario: "autovacuum: VACUUM ANALYZE fake.table"
+				return TokenKind(ch), tkn.bytes()
+			}
 			if tkn.lastChar != '=' {
 				return tkn.scanBindVar()
 			}

--- a/releasenotes/notes/apm-fix-obfuscation-autovacuum-sql-text-1266db4af8dba140.yaml
+++ b/releasenotes/notes/apm-fix-obfuscation-autovacuum-sql-text-1266db4af8dba140.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fix bug where obfuscation fails for autovacuum sql text. 
+    For example, SQL text like `autovacuum: VACUUM ANALYZE fake.table` will no longer fail obfuscation. 


### PR DESCRIPTION
### What does this PR do?

we are seeing query text like `autovacuum: VACUUM ANALYZE fake.table` fail obfuscation in the postgres integration check, and we want to be able to ingest things like this for DBM. It is failing due to the fact that it has a `:` followed by a space char. Because it has a `:`, the obfuscater assumes it is the beginning of a [bind variable]( https://github.com/DataDog/datadog-agent/blob/main/pkg/trace/obfuscate/sql_tokenizer.go#L221-L228). Since the bindVar scanner code does not handle [this case](https://github.com/DataDog/datadog-agent/blob/ec0b667ba1423b8b466be30b7aef1cc684733d79/pkg/trace/obfuscate/sql_tokenizer.go#L556-L569 ), obfuscation fails. 

simply checking if the char in front of the `:` is a space will prevent this from happening

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
