### PR TITLE
[CWS] fix security go generate check job

### DIFF
--- a/.gitlab/source_test/go_generate_check.yml
+++ b/.gitlab/source_test/go_generate_check.yml
@@ -9,7 +9,7 @@ security_go_generate_check:
     - !reference [.retrieve_linux_go_deps]
     - pip3 install -r docs/cloud-workload-security/scripts/requirements-docs.txt
   script:
-    - go generate ./pkg/security/...
+    - inv -e security-agent.cws-go-generate
     - inv -e security-agent.generate-documentation
     - git status --porcelain
     - test -z "$(git status --porcelain)"


### PR DESCRIPTION
### What does this PR do?

With the added SECL package, the command `go generate ./pkg/security/...` no longer generates files in `./pkg/security/secl`. This PR fixes this issue by running the generation for all security packages in the `security_go_generate_check` job.

### Describe how to test your changes

Should be a no-op.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
