### PR TITLE
pkg/trace: rename exception sampler to rare sampler

### DIFF
--- a/pkg/trace/sampler/rare_sampler_test.go
+++ b/pkg/trace/sampler/rare_sampler_test.go
@@ -27,7 +27,7 @@ func TestSpanSeenTTLExpiration(t *testing.T) {
 		{"p0-ttl-expired", true, testTime.Add(priorityTTL + defaultTTL + 2*time.Nanosecond), map[string]float64{"_dd.measured": 1}},
 	}
 
-	e := NewExceptionSampler()
+	e := NewRareSampler()
 	e.Stop()
 
 	for _, tc := range testCases {
@@ -56,7 +56,7 @@ func TestConsideredSpans(t *testing.T) {
 		{"p0-non-top-non-measured-blocked", false, "s4", nil},
 	}
 
-	e := NewExceptionSampler()
+	e := NewRareSampler()
 	e.Stop()
 
 	for _, tc := range testCases {
@@ -71,7 +71,7 @@ func TestConsideredSpans(t *testing.T) {
 }
 
 func TestExceptionSamplerRace(t *testing.T) {
-	e := NewExceptionSampler()
+	e := NewRareSampler()
 	e.Stop()
 	for i := 0; i < 2; i++ {
 		go func() {
@@ -87,7 +87,7 @@ func TestExceptionSamplerRace(t *testing.T) {
 
 func TestCardinalityLimit(t *testing.T) {
 	assert := assert.New(t)
-	e := NewExceptionSampler()
+	e := NewRareSampler()
 	e.Stop()
 	for j := 1; j <= cardinalityLimit; j++ {
 		tr := pb.Trace{


### PR DESCRIPTION
Renaming the exception to rare sampler. The statsd/tag rename have no impact.

This sampler is dedicated to catch rare endpoints. Renaming before adding agent knobs to control it

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
