### PR TITLE
[gitlab] Add jobs to check package sizes against latest stable

### DIFF
--- a/.gitlab/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics.yml
@@ -166,7 +166,7 @@ send_pkg_size-a7:
             failures=$((${failures}+$?))
             set -e
         done
-    - if [ ! -z "${failures}" ]; then false; fi
+    - if [ "${failures}" -ne "0" ]; then false; fi
 
 check_pkg_size-a6:
   extends: .check_pkg_size

--- a/.gitlab/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics.yml
@@ -135,3 +135,92 @@ send_pkg_size-a7:
 
     - DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key --with-decryption --query "Parameter.Value" --out text)
     - 'curl --fail -X POST -H "Content-type: application/json" -d "$post_body" "https://api.datadoghq.com/api/v1/series?api_key=$DD_API_KEY"'
+
+.check_pkg_size:
+  stage: pkg_metrics
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["runner:main"]
+  script:
+    - ls -l $OMNIBUS_PACKAGE_DIR
+    - ls -l $OMNIBUS_PACKAGE_DIR_SUSE
+    - source /root/.bashrc && conda activate ddpy3
+    - export failures=""
+    - export last_stable=$(inv release.get-release-json-value "last_stable::${MAJOR_VERSION}")
+    - |
+        compare_size() {
+            local package_type="${1}"
+            local max_diff="${2}"
+            local stable_package="${3}"
+            local new_package="${4}"
+
+            stable_size=$(stat --printf="%s" $stable_package)
+            new_size=$(stat --printf="%s" $new_package)
+            diff=$((new_size-stable_size))
+
+            if [ $diff -gt $max_diff ]; then
+                failures="${failures}${package_type} size increase is too large:\n"
+                failures="${failures}  New package size is ${new_size}B\n"
+                failures="${failures}  Stable package (${last_stable}) size is ${stable_size}B\n"
+                failures="${failures}  Diff is ${diff}B ${max_diff}B (max allowed diff)\n"
+            else
+              echo "${package_type} is OK"
+              echo "  New package size is ${new_size}B"
+              echo "  Stable package (${last_stable}) size is ${stable_size}B"
+              echo "  Diff is ${diff}B (max allowed diff is ${max_diff}B)"
+            fi
+        }
+    # Get stable packages from S3 buckets & compare sizes
+    # The loop assumes that all flavors start with "da", which is currently the case
+    - |
+        for flavor in ${FLAVORS}; do
+            mkdir -p "/tmp/stable/${flavor}" "/tmp/stable/${flavor}/suse"
+            curl -sSL "https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/${flavor}_${last_stable}-1_amd64.deb" -o "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_amd64.deb"
+            curl -sSL "https://s3.amazonaws.com/yum.datadoghq.com/stable/${MAJOR_VERSION}/x86_64/${flavor}-${last_stable}-1.x86_64.rpm" -o "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.x86_64.rpm"
+            curl -sSL "https://s3.amazonaws.com/yum.datadoghq.com/suse/stable/${MAJOR_VERSION}/x86_64/${flavor}-${last_stable}-1.x86_64.rpm" -o "/tmp/stable/${flavor}/suse/${flavor}-${last_stable}-1.x86_64.rpm"
+            compare_size "${flavor} deb" "${max_sizes[${flavor}]}" "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_amd64.deb" "$OMNIBUS_PACKAGE_DIR/${flavor}_${MAJOR_VERSION}*_amd64.deb"
+            compare_size "${flavor} rpm" "${max_sizes[${flavor}]}" "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.x86_64.rpm" "$OMNIBUS_PACKAGE_DIR/${flavor}-${MAJOR_VERSION}.*.x86_64.rpm"
+            compare_size "${flavor} suse rpm" "${max_sizes[${flavor}]}" "/tmp/stable/${flavor}/suse/${flavor}-${last_stable}-1.x86_64.rpm" "$OMNIBUS_PACKAGE_DIR_SUSE/${flavor}-${MAJOR_VERSION}.*.x86_64.rpm"
+        done
+    - if [ "${failures}" != "" ]; then echo -e "${failures}" && false; fi
+
+check_pkg_size-a6:
+  extends: .check_pkg_size
+  rules:
+    !reference [.on_a6]
+  needs:
+    - agent_deb-x64-a6
+    - agent_rpm-x64-a6
+    - agent_suse-x64-a6
+  variables:
+    MAJOR_VERSION: 6
+    FLAVORS: "datadog-agent"
+  before_script:
+    - |
+        declare -Ar max_sizes=(
+            ["datadog-agent"]="15000000"
+        )
+
+check_pkg_size-a7:
+  extends: .check_pkg_size
+  rules:
+    !reference [.on_a7]
+  needs:
+    - agent_deb-x64-a7
+    - iot_agent_deb-x64
+    - dogstatsd_deb-x64
+    - agent_rpm-x64-a7
+    - iot_agent_rpm-x64
+    - dogstatsd_rpm-x64
+    - agent_suse-x64-a7
+    - dogstatsd_suse-x64
+    - iot_agent_suse-x64
+  variables:
+    MAJOR_VERSION: 7
+    FLAVORS: "datadog-agent datadog-iot-agent datadog-dogstatsd"
+  before_script:
+    - |
+        declare -Ar max_sizes=(
+            ["datadog-agent"]="15000000"
+            ["datadog-iot-agent"]="10000000"
+            ["datadog-dogstatsd"]="10000000"
+        )

--- a/.gitlab/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics.yml
@@ -144,44 +144,29 @@ send_pkg_size-a7:
     - ls -l $OMNIBUS_PACKAGE_DIR
     - ls -l $OMNIBUS_PACKAGE_DIR_SUSE
     - source /root/.bashrc && conda activate ddpy3
-    - export failures=""
+    - export failures=0
     - export last_stable=$(inv release.get-release-json-value "last_stable::${MAJOR_VERSION}")
-    - |
-        compare_size() {
-            local package_type="${1}"
-            local max_diff="${2}"
-            local stable_package="${3}"
-            local new_package="${4}"
-
-            stable_size=$(stat --printf="%s" $stable_package)
-            new_size=$(stat --printf="%s" $new_package)
-            diff=$((new_size-stable_size))
-
-            if [ $diff -gt $max_diff ]; then
-                failures="${failures}${package_type} size increase is too large:\n"
-                failures="${failures}  New package size is ${new_size}B\n"
-                failures="${failures}  Stable package (${last_stable}) size is ${stable_size}B\n"
-                failures="${failures}  Diff is ${diff}B ${max_diff}B (max allowed diff)\n"
-            else
-              echo "${package_type} is OK"
-              echo "  New package size is ${new_size}B"
-              echo "  Stable package (${last_stable}) size is ${stable_size}B"
-              echo "  Diff is ${diff}B (max allowed diff is ${max_diff}B)"
-            fi
-        }
     # Get stable packages from S3 buckets & compare sizes
     # The loop assumes that all flavors start with "da", which is currently the case
+    # We want to run all package size comparisons before failing, so we set +e while doing the comparisons
+    # to get the error codes without exiting the shell.
     - |
         for flavor in ${FLAVORS}; do
             mkdir -p "/tmp/stable/${flavor}" "/tmp/stable/${flavor}/suse"
             curl -sSL "https://s3.amazonaws.com/apt.datadoghq.com/pool/d/da/${flavor}_${last_stable}-1_amd64.deb" -o "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_amd64.deb"
             curl -sSL "https://s3.amazonaws.com/yum.datadoghq.com/stable/${MAJOR_VERSION}/x86_64/${flavor}-${last_stable}-1.x86_64.rpm" -o "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.x86_64.rpm"
             curl -sSL "https://s3.amazonaws.com/yum.datadoghq.com/suse/stable/${MAJOR_VERSION}/x86_64/${flavor}-${last_stable}-1.x86_64.rpm" -o "/tmp/stable/${flavor}/suse/${flavor}-${last_stable}-1.x86_64.rpm"
-            compare_size "${flavor} deb" "${max_sizes[${flavor}]}" "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_amd64.deb" "$OMNIBUS_PACKAGE_DIR/${flavor}_${MAJOR_VERSION}*_amd64.deb"
-            compare_size "${flavor} rpm" "${max_sizes[${flavor}]}" "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.x86_64.rpm" "$OMNIBUS_PACKAGE_DIR/${flavor}-${MAJOR_VERSION}.*.x86_64.rpm"
-            compare_size "${flavor} suse rpm" "${max_sizes[${flavor}]}" "/tmp/stable/${flavor}/suse/${flavor}-${last_stable}-1.x86_64.rpm" "$OMNIBUS_PACKAGE_DIR_SUSE/${flavor}-${MAJOR_VERSION}.*.x86_64.rpm"
+            
+            set +e
+            inv package.compare-size --package-type "${flavor} deb" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR/${flavor}_${MAJOR_VERSION}*_amd64.deb" --stable-package "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_amd64.deb"
+            failures=$((${failures}+$?))
+            inv package.compare-size --package-type "${flavor} rpm" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR/${flavor}-${MAJOR_VERSION}.*.x86_64.rpm" --stable-package "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.x86_64.rpm"
+            failures=$((${failures}+$?))
+            inv package.compare-size --package-type "${flavor} suse rpm" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR_SUSE/${flavor}-${MAJOR_VERSION}.*.x86_64.rpm" --stable-package "/tmp/stable/${flavor}/suse/${flavor}-${last_stable}-1.x86_64.rpm"
+            failures=$((${failures}+$?))
+            set -e
         done
-    - if [ "${failures}" != "" ]; then echo -e "${failures}" && false; fi
+    - if [ ! -z "${failures}" ]; then false; fi
 
 check_pkg_size-a6:
   extends: .check_pkg_size

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -18,6 +18,7 @@ from . import (
     dogstatsd,
     github,
     installcmd,
+    package,
     pipeline,
     process_agent,
     pylauncher,
@@ -103,6 +104,7 @@ ns.add_collection(trace_agent)
 ns.add_collection(docker)
 ns.add_collection(dogstatsd)
 ns.add_collection(github)
+ns.add_collection(package)
 ns.add_collection(pipeline)
 ns.add_collection(pylauncher)
 ns.add_collection(selinux)

--- a/tasks/package.py
+++ b/tasks/package.py
@@ -1,0 +1,43 @@
+import glob
+import os
+
+from invoke import task
+from invoke.exceptions import Exit
+
+from .libs.common.color import color_message
+
+
+def get_package_path(glob_pattern):
+    package_paths = glob.glob(glob_pattern)
+    if len(package_paths) > 1:
+        raise Exit(code=1, message=color_message(f"Too many files matching {glob_pattern}: {package_paths}", "red"))
+    elif len(package_paths) == 0:
+        raise Exit(code=1, message=color_message(f"Couldn't find any file matching {glob_pattern}", "red"))
+
+    return package_paths[0]
+
+
+@task
+def compare_size(_, new_package, stable_package, package_type, last_stable, threshold):
+    new_package_size = os.path.getsize(get_package_path(new_package))
+    stable_package_size = os.path.getsize(get_package_path(stable_package))
+
+    threshold = int(threshold)
+
+    diff = new_package_size - stable_package_size
+
+    if diff > threshold:
+        print(
+            f"""{package_type} size increase is too large:
+  New package size is {new_package_size/1000000:.2f}MB
+  Stable package ({last_stable}) size is {stable_package_size/1000000:.2f}MB
+  Diff is {diff/1000000:.2f}MB > {threshold/1000000:.2f}MB (max allowed diff)"""
+        )
+        raise Exit(code=1)
+
+    print(
+        f"""{package_type} size increase is OK:
+  New package size is {new_package_size/1000000:.2f}MB
+  Stable package ({last_stable}) size is {stable_package_size/1000000:.2f}MB
+  Diff is {diff/1000000:.2f}MB (max allowed diff: {threshold/1000000:.2f}MB)"""
+    )

--- a/tasks/package.py
+++ b/tasks/package.py
@@ -19,6 +19,8 @@ def get_package_path(glob_pattern):
 
 @task
 def compare_size(_, new_package, stable_package, package_type, last_stable, threshold):
+    mb = 1000000
+
     new_package_size = os.path.getsize(get_package_path(new_package))
     stable_package_size = os.path.getsize(get_package_path(stable_package))
 
@@ -26,18 +28,27 @@ def compare_size(_, new_package, stable_package, package_type, last_stable, thre
 
     diff = new_package_size - stable_package_size
 
+    # For printing purposes
+    new_package_size_mb = new_package_size / mb
+    stable_package_size_mb = stable_package_size / mb
+    threshold_mb = threshold / mb
+    diff_mb = diff / mb
+
     if diff > threshold:
         print(
-            f"""{package_type} size increase is too large:
-  New package size is {new_package_size/1000000:.2f}MB
-  Stable package ({last_stable}) size is {stable_package_size/1000000:.2f}MB
-  Diff is {diff/1000000:.2f}MB > {threshold/1000000:.2f}MB (max allowed diff)"""
+            color_message(
+                f"""{package_type} size increase is too large:
+  New package size is {new_package_size_mb:.2f}MB
+  Stable package ({last_stable}) size is {stable_package_size_mb:.2f}MB
+  Diff is {diff_mb:.2f}MB > {threshold_mb:.2f}MB (max allowed diff)""",
+                "red",
+            )
         )
         raise Exit(code=1)
 
     print(
         f"""{package_type} size increase is OK:
-  New package size is {new_package_size/1000000:.2f}MB
-  Stable package ({last_stable}) size is {stable_package_size/1000000:.2f}MB
-  Diff is {diff/1000000:.2f}MB (max allowed diff: {threshold/1000000:.2f}MB)"""
+  New package size is {new_package_size_mb:.2f}MB
+  Stable package ({last_stable}) size is {stable_package_size_mb:.2f}MB
+  Diff is {diff_mb:.2f}MB (max allowed diff: {threshold_mb:.2f}MB)"""
     )


### PR DESCRIPTION
### What does this PR do?

Adds two new jobs, `check_pkg_size-a6` and `check_pkg_size-a7`, which run on all pipelines, compare the sizes of the built package against the latest stable packages, and fail if the difference reaches a given threshold.

### Motivation

Track package size increases & noticeable bumps in package size.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
