### PR TITLE
[tagger/workloadmeta] Use container image from pod spec

### DIFF
--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -395,7 +395,7 @@ func (c *WorkloadMetaCollector) extractTagsFromPodContainer(pod *workloadmeta.Ku
 		tags.AddHigh("display_container_name", fmt.Sprintf("%s_%s", container.Name, pod.Name))
 	}
 
-	image := container.Image
+	image := podContainer.Image
 	tags.AddLow("image_name", image.Name)
 	tags.AddLow("short_image", image.ShortName)
 	tags.AddLow("image_tag", image.Tag)

--- a/pkg/tagger/collectors/workloadmeta_test.go
+++ b/pkg/tagger/collectors/workloadmeta_test.go
@@ -43,6 +43,14 @@ func TestHandleKubePod(t *testing.T) {
 	fullyFleshedContainerTaggerEntityID := fmt.Sprintf("container_id://%s", fullyFleshedContainerID)
 	noEnvContainerTaggerEntityID := fmt.Sprintf("container_id://%s", noEnvContainerID)
 
+	image := workloadmeta.ContainerImage{
+		ID:        "datadog/agent@sha256:a63d3f66fb2f69d955d4f2ca0b229385537a77872ffc04290acae65aed5317d2",
+		RawName:   "datadog/agent@sha256:a63d3f66fb2f69d955d4f2ca0b229385537a77872ffc04290acae65aed5317d2",
+		Name:      "datadog/agent",
+		ShortName: "agent",
+		Tag:       "latest",
+	}
+
 	store := workloadmetatesting.NewStore()
 	store.Set(&workloadmeta.Container{
 		EntityID: workloadmeta.EntityID{
@@ -52,13 +60,7 @@ func TestHandleKubePod(t *testing.T) {
 		EntityMeta: workloadmeta.EntityMeta{
 			Name: containerName,
 		},
-		Image: workloadmeta.ContainerImage{
-			ID:        "datadog/agent@sha256:a63d3f66fb2f69d955d4f2ca0b229385537a77872ffc04290acae65aed5317d2",
-			RawName:   "datadog/agent@sha256:a63d3f66fb2f69d955d4f2ca0b229385537a77872ffc04290acae65aed5317d2",
-			Name:      "datadog/agent",
-			ShortName: "agent",
-			Tag:       "latest",
-		},
+		Image: image,
 		EnvVars: map[string]string{
 			"DD_ENV":     env,
 			"DD_SERVICE": svc,
@@ -201,8 +203,9 @@ func TestHandleKubePod(t *testing.T) {
 				},
 				Containers: []workloadmeta.OrchestratorContainer{
 					{
-						ID:   fullyFleshedContainerID,
-						Name: containerName,
+						ID:    fullyFleshedContainerID,
+						Name:  containerName,
+						Image: image,
 					},
 				},
 			},

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -150,8 +150,9 @@ type ContainerPort struct {
 // OrchestratorContainer is a reference to a Container with
 // orchestrator-specific data attached to it.
 type OrchestratorContainer struct {
-	ID   string
-	Name string
+	ID    string
+	Name  string
+	Image ContainerImage
 }
 
 // Container is a containerized workload.


### PR DESCRIPTION
### What does this PR do?

Similar to work done in c6bbe0bc2d10ac57073ffc307d3f90dce8d94bf0, we
need to expose the image name as defined by the user, instead of the one
exposed by the container runtime. This did not seem to be a problem for
k8s+docker environments, but once we added the containerd collector, we
noticed that in k8s+containerd environments, any image with an implicit
registry (say "nginx") would be reported by with the resolved registry
(so "docker.io/library/nginx"), so `image_name` tags would change and
possibly break dashboards.

Now, we have a distinction between the image as defined by the user (in
OrchestratorContainer.Image), and the actual image that the name
resolves to (in Container.Image).

### Describe how to test your changes

* E2E tests need to pass (this is how the issue was initially identified)
* Logs and metrics generated by the deployment below should have the `image_name:nginx` tag instead of `image_name:docker.io/library/nginx`.

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: nginx
  labels:
    app: nginx
  namespace: default
spec:
  replicas: 1
  selector:
    matchLabels:
      app: nginx
  template:
    metadata:
      labels:
        app: nginx
      annotations:
        ad.datadoghq.com/nginx.check_names: '["nginx"]'
        ad.datadoghq.com/nginx.init_configs: '[{}]'
        ad.datadoghq.com/nginx.instances: '[{"nginx_status_url": "http://%%host%%/nginx_status", "tags": "%%tags%%"}]'
        ad.datadoghq.com/nginx.logs: '[{"type": "docker","image": "nginx","service": "nginx","source": "nginx"}]'
    spec:
      containers:
      - name: nginx
        image: nginx:latest
        ports:
        - name: http
          containerPort: 80
```