### PR TITLE
[release tooling] Add missing update_release_json arg in release.finish

### DIFF
--- a/tasks/release.py
+++ b/tasks/release.py
@@ -1050,7 +1050,7 @@ def finish(ctx, major_versions="6,7"):
 
     for major_version in list_major_versions:
         new_version = next_final_version(ctx, major_version)
-        update_release_json(github_token, new_version)
+        update_release_json(ctx, github_token, new_version)
 
     # Update internal module dependencies
     update_modules(ctx, str(new_version))


### PR DESCRIPTION
### What does this PR do?

Fix `update_release_json` call that's missing an arg in the `release.finish` invoke task.
Partial backport of #9647.

### Motivation

Fix tooling for 7.32.0 release.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
