### PR TITLE
[pkg/otlp] skip nil sketches

### DIFF
--- a/pkg/otlp/model/translator/metrics_translator.go
+++ b/pkg/otlp/model/translator/metrics_translator.go
@@ -216,7 +216,10 @@ func (t *Translator) getSketchBuckets(
 
 	}
 
-	consumer.ConsumeSketch(ctx, name, ts, as.Finish(), tags, host)
+	sketch := as.Finish()
+	if sketch != nil {
+		consumer.ConsumeSketch(ctx, name, ts, sketch, tags, host)
+	}
 }
 
 func (t *Translator) getLegacyBuckets(

--- a/pkg/otlp/model/translator/metrics_translator_test.go
+++ b/pkg/otlp/model/translator/metrics_translator_test.go
@@ -512,9 +512,6 @@ type mockFullConsumer struct {
 }
 
 func (c *mockFullConsumer) ConsumeSketch(_ context.Context, name string, ts uint64, sk *quantile.Sketch, tags []string, host string) {
-	if sk == nil {
-		return
-	}
 	c.sketches = append(c.sketches,
 		sketch{
 			name:      name,


### PR DESCRIPTION
### What does this PR do?

Skip `nil` sketches. Follow up to #9623

### Motivation

The `Finish` method of `quantile.Agent` sketches returns a `nil` sketch when a sketch is empty.

### Additional Notes

This causes a `nil` dereference panic on the Agent.

### Describe how to test your changes

Send an OTLP cumulative histogram to the OTLP endpoint .

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
