### PR TITLE
[PodWatcher] Remove isWatchingTags

### DIFF
--- a/pkg/util/kubernetes/kubelet/podwatcher.go
+++ b/pkg/util/kubernetes/kubelet/podwatcher.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build kubelet
 // +build kubelet
 
 package kubelet
@@ -30,12 +31,13 @@ type PodWatcher struct {
 	lastSeenReady  map[string]time.Time
 	tagsDigest     map[string]string
 	oldPhase       map[string]string
+	oldReadiness   map[string]bool
 }
 
 // NewPodWatcher creates a new watcher given an expiry duration
 // and if the watcher should watch label/annotation changes on pods.
 // User call must then trigger PullChanges and Expire when needed.
-func NewPodWatcher(expiryDuration time.Duration, isWatchingTags bool) (*PodWatcher, error) {
+func NewPodWatcher(expiryDuration time.Duration) (*PodWatcher, error) {
 	kubeutil, err := GetKubeUtil()
 	if err != nil {
 		return nil, err
@@ -44,19 +46,12 @@ func NewPodWatcher(expiryDuration time.Duration, isWatchingTags bool) (*PodWatch
 		kubeUtil:       kubeutil,
 		lastSeen:       make(map[string]time.Time),
 		lastSeenReady:  make(map[string]time.Time),
+		tagsDigest:     make(map[string]string),
+		oldPhase:       make(map[string]string),
+		oldReadiness:   make(map[string]bool),
 		expiryDuration: expiryDuration,
 	}
-	if isWatchingTags {
-		watcher.tagsDigest = make(map[string]string)
-		watcher.oldPhase = make(map[string]string)
-	}
 	return watcher, nil
-}
-
-// isWatchingTags returns true if the pod watcher should
-// watch for tag changes on pods
-func (w *PodWatcher) isWatchingTags() bool {
-	return w.tagsDigest != nil
 }
 
 // PullChanges pulls a new podList from the kubelet and returns Pod objects for
@@ -81,17 +76,11 @@ func (w *PodWatcher) computeChanges(podList []*Pod) ([]*Pod, error) {
 	for _, pod := range podList {
 		podEntity := PodUIDToEntityName(pod.Metadata.UID)
 		newPod := false
-		_, foundPod := w.lastSeen[podEntity]
 
-		if w.isWatchingTags() && !foundPod {
+		_, foundPod := w.lastSeen[podEntity]
+		if !foundPod {
 			w.tagsDigest[podEntity] = digestPodMeta(pod.Metadata)
 			w.oldPhase[podEntity] = pod.Status.Phase
-			newPod = true
-		}
-
-		// static pods are included specifically because they won't have any container
-		// as they're not updated in the pod list after creation
-		if isPodStatic(pod) && !foundPod {
 			newPod = true
 		}
 
@@ -103,51 +92,60 @@ func (w *PodWatcher) computeChanges(podList []*Pod) ([]*Pod, error) {
 		isPodReady := IsPodReady(pod)
 
 		for _, container := range pod.Status.GetAllContainers() {
-			// We don't check container readiness as init containers are never ready
-			// We check if the container has an ID instead (has run or is running)
-			if !container.IsPending() {
-				// new container are always sent ignoring the pod state
-				if _, found := w.lastSeen[container.ID]; !found {
-					updatedContainer = true
-				}
-				w.lastSeen[container.ID] = now
+			if container.IsPending() {
+				// We don't check container readiness as init
+				// containers are never ready. We check if the
+				// container has an ID instead (has run or is
+				// running)
+				continue
+			}
 
-				// for existing ones we look at the readiness state
-				if _, found := w.lastSeenReady[container.ID]; !found && isPodReady {
-					// the pod has never been seen ready or was removed when
-					// reaching the unreadinessTimeout
-					updatedContainer = true
-				}
+			// new container are always sent ignoring the pod state
+			if _, found := w.lastSeen[container.ID]; !found {
+				updatedContainer = true
+			}
+			w.lastSeen[container.ID] = now
 
-				// update the readiness expiry cache
-				if isPodReady {
-					w.lastSeenReady[container.ID] = now
-				}
+			// for existing containers, check whether the
+			// readiness has changed since last time
+			if oldReadiness, found := w.oldReadiness[container.ID]; !found || oldReadiness != isPodReady {
+				// the pod has never been seen ready or was removed when
+				// reaching the unreadinessTimeout
+				updatedContainer = true
+			}
+
+			w.oldReadiness[container.ID] = isPodReady
+
+			if isPodReady {
+				w.lastSeenReady[container.ID] = now
 			}
 		}
 
-		// Detect changes in labels and annotations values
 		newLabelsOrAnnotations := false
-		// Detect changes in the pod phase
 		newPhase := false
-		if w.isWatchingTags() {
-			newTagsDigest := digestPodMeta(pod.Metadata)
-			if foundPod && newTagsDigest != w.tagsDigest[podEntity] {
-				// update tags digest
+		newTagsDigest := digestPodMeta(pod.Metadata)
+
+		// if the pod already existed, check whether tagsDigest or
+		// phase changed
+		if foundPod {
+			if newTagsDigest != w.tagsDigest[podEntity] {
 				w.tagsDigest[podEntity] = newTagsDigest
 				newLabelsOrAnnotations = true
 			}
-			// compared to our last seen phase the pod phase has changed.
-			if foundPod && pod.Status.Phase != w.oldPhase[podEntity] {
+
+			if pod.Status.Phase != w.oldPhase[podEntity] {
 				w.oldPhase[podEntity] = pod.Status.Phase
 				newPhase = true
 			}
 		}
+
 		if newPod || updatedContainer || newLabelsOrAnnotations || newPhase {
 			updatedPods = append(updatedPods, pod)
 		}
 	}
+
 	log.Debugf("Found %d changed pods out of %d", len(updatedPods), len(podList))
+
 	return updatedPods, nil
 }
 
@@ -167,10 +165,9 @@ func (w *PodWatcher) Expire() ([]string, error) {
 		if now.Sub(lastSeen) > w.expiryDuration {
 			delete(w.lastSeen, id)
 			delete(w.lastSeenReady, id)
-			if w.isWatchingTags() {
-				delete(w.tagsDigest, id)
-				delete(w.oldPhase, id)
-			}
+			delete(w.tagsDigest, id)
+			delete(w.oldPhase, id)
+			delete(w.oldReadiness, id)
 			expiredContainers = append(expiredContainers, id)
 		}
 	}

--- a/pkg/workloadmeta/collectors/kubelet/kubelet.go
+++ b/pkg/workloadmeta/collectors/kubelet/kubelet.go
@@ -51,7 +51,7 @@ func (c *collector) Start(_ context.Context, store workloadmeta.Store) error {
 	c.store = store
 	c.lastExpire = time.Now()
 	c.expireFreq = expireFreq
-	c.watcher, err = kubelet.NewPodWatcher(expireFreq, true)
+	c.watcher, err = kubelet.NewPodWatcher(expireFreq)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What does this PR do?

Now that the kubelet workloadmeta collector is the only user of the
PodWatcher, and it always uses isWatchingTags, we can remove all
instances of code that expected isWatchingTags to be false.

This also applies the fix introduced in
0c1b0af05ac204f9b3bf744f631d5f296bb325b5 for 7.32.

### Describe how to test your changes

Same as #9640, plus also test that changing annotations or labels generates events that eventually propagate to the tagger and tags get updated.