### PR TITLE
[Serverless] Detect runtime from the extension

### DIFF
--- a/pkg/serverless/serverless_test.go
+++ b/pkg/serverless/serverless_test.go
@@ -50,6 +50,7 @@ func TestHandleInvocationShouldSetExtraTags(t *testing.T) {
 		"functionname:my-function",
 		"region:us-east-1",
 		"resource:my-function",
+		"runtime:custom",
 	}
 
 	sort.Strings(d.ExtraTags.Tags)

--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -59,7 +59,7 @@ func BuildTagMap(arn string, configTags []string) map[string]string {
 	runtime, err := detectRuntime(bootstrapPath, runtimeVar)
 	if err != nil {
 		log.Debug(err)
-		runtime = "unknown"
+		runtime = "custom"
 	}
 
 	tags = setIfNotEmpty(tags, runtimeKey, runtime)

--- a/pkg/serverless/tags/tags_test.go
+++ b/pkg/serverless/tags/tags_test.go
@@ -75,7 +75,7 @@ func TestBuildTagMapFromArnIncomplete(t *testing.T) {
 	assert.Equal(t, "value1", tagMap["tag1"])
 	// Result of this test depends on build environment
 	assert.True(t, tagMap["architecture"] == "x86_64" || tagMap["architecture"] == "arm64")
-	assert.Equal(t, "unknown", tagMap["runtime"])
+	assert.Equal(t, "custom", tagMap["runtime"])
 }
 
 func TestBuildTagMapFromArnIncompleteWithCommaAndSpaceTags(t *testing.T) {
@@ -92,7 +92,7 @@ func TestBuildTagMapFromArnIncompleteWithCommaAndSpaceTags(t *testing.T) {
 	assert.Equal(t, "value3", tagMap["tag3"])
 	// Result of this test depends on build environment
 	assert.True(t, tagMap["architecture"] == "x86_64" || tagMap["architecture"] == "arm64")
-	assert.Equal(t, "unknown", tagMap["runtime"])
+	assert.Equal(t, "custom", tagMap["runtime"])
 }
 
 func TestBuildTagMapFromArnComplete(t *testing.T) {
@@ -112,7 +112,7 @@ func TestBuildTagMapFromArnComplete(t *testing.T) {
 	assert.Equal(t, "value1", tagMap["tag1"])
 	// Result of this test depends on build environment
 	assert.True(t, tagMap["architecture"] == "x86_64" || tagMap["architecture"] == "arm64")
-	assert.Equal(t, "unknown", tagMap["runtime"])
+	assert.Equal(t, "custom", tagMap["runtime"])
 }
 
 func TestBuildTagMapFromArnCompleteWithEnvAndVersionAndService(t *testing.T) {
@@ -142,7 +142,7 @@ func TestBuildTagMapFromArnCompleteWithEnvAndVersionAndService(t *testing.T) {
 	assert.Equal(t, "value1", tagMap["tag1"])
 	// Result of this test depends on build environment
 	assert.True(t, tagMap["architecture"] == "x86_64" || tagMap["architecture"] == "arm64")
-	assert.Equal(t, "unknown", tagMap["runtime"])
+	assert.Equal(t, "custom", tagMap["runtime"])
 }
 
 func TestBuildTagMapFromArnCompleteWithUpperCase(t *testing.T) {
@@ -161,7 +161,7 @@ func TestBuildTagMapFromArnCompleteWithUpperCase(t *testing.T) {
 	assert.Equal(t, "value0", tagMap["tag0"])
 	assert.Equal(t, "value1", tagMap["tag1"])
 	assert.True(t, tagMap["architecture"] == "x86_64" || tagMap["architecture"] == "arm64")
-	assert.Equal(t, "unknown", tagMap["runtime"])
+	assert.Equal(t, "custom", tagMap["runtime"])
 }
 
 func TestBuildTagMapFromArnCompleteWithLatest(t *testing.T) {
@@ -181,7 +181,7 @@ func TestBuildTagMapFromArnCompleteWithLatest(t *testing.T) {
 	assert.Equal(t, "value0", tagMap["tag0"])
 	assert.Equal(t, "value1", tagMap["tag1"])
 	assert.True(t, tagMap["architecture"] == "x86_64" || tagMap["architecture"] == "arm64")
-	assert.Equal(t, "unknown", tagMap["runtime"])
+	assert.Equal(t, "custom", tagMap["runtime"])
 }
 
 func TestBuildTagMapFromArnCompleteWithVersionNumber(t *testing.T) {
@@ -202,7 +202,7 @@ func TestBuildTagMapFromArnCompleteWithVersionNumber(t *testing.T) {
 	assert.Equal(t, "value0", tagMap["tag0"])
 	assert.Equal(t, "value1", tagMap["tag1"])
 	assert.True(t, tagMap["architecture"] == "x86_64" || tagMap["architecture"] == "arm64")
-	assert.Equal(t, "unknown", tagMap["runtime"])
+	assert.Equal(t, "custom", tagMap["runtime"])
 }
 
 func TestAddTagInvalid(t *testing.T) {
@@ -291,7 +291,7 @@ func TestBuildTagMapWithMemoryTag(t *testing.T) {
 	assert.Equal(t, "xxx", tagMap["dd_extension_version"])
 	assert.Equal(t, "value0", tagMap["tag0"])
 	assert.Equal(t, "value1", tagMap["tag1"])
-	assert.Equal(t, "unknown", tagMap["runtime"])
+	assert.Equal(t, "custom", tagMap["runtime"])
 	assert.Equal(t, "128", tagMap["memorysize"])
 	assert.True(t, tagMap["architecture"] == "x86_64" || tagMap["architecture"] == "arm64")
 }

--- a/pkg/serverless/tags/tags_test.go
+++ b/pkg/serverless/tags/tags_test.go
@@ -66,7 +66,7 @@ func TestBuildTagsFromMap(t *testing.T) {
 func TestBuildTagMapFromArnIncomplete(t *testing.T) {
 	arn := "function:my-function"
 	tagMap := BuildTagMap(arn, []string{"tag0:value0", "TAG1:VALUE1"})
-	assert.Equal(t, 7, len(tagMap))
+	assert.Equal(t, 8, len(tagMap))
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
 	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "function:my-function", tagMap["function_arn"])
@@ -75,13 +75,13 @@ func TestBuildTagMapFromArnIncomplete(t *testing.T) {
 	assert.Equal(t, "value1", tagMap["tag1"])
 	// Result of this test depends on build environment
 	assert.True(t, tagMap["architecture"] == "x86_64" || tagMap["architecture"] == "arm64")
-
+	assert.Equal(t, "unknown", tagMap["runtime"])
 }
 
 func TestBuildTagMapFromArnIncompleteWithCommaAndSpaceTags(t *testing.T) {
 	arn := "function:my-function"
 	tagMap := BuildTagMap(arn, []string{"tag0:value0", "tag1:value1,tag2:VALUE2", "TAG3:VALUE3"})
-	assert.Equal(t, 9, len(tagMap))
+	assert.Equal(t, 10, len(tagMap))
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
 	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "function:my-function", tagMap["function_arn"])
@@ -92,12 +92,13 @@ func TestBuildTagMapFromArnIncompleteWithCommaAndSpaceTags(t *testing.T) {
 	assert.Equal(t, "value3", tagMap["tag3"])
 	// Result of this test depends on build environment
 	assert.True(t, tagMap["architecture"] == "x86_64" || tagMap["architecture"] == "arm64")
+	assert.Equal(t, "unknown", tagMap["runtime"])
 }
 
 func TestBuildTagMapFromArnComplete(t *testing.T) {
 	arn := "arn:aws:lambda:us-east-1:123456789012:function:my-function"
 	tagMap := BuildTagMap(arn, []string{"tag0:value0", "TAG1:VALUE1"})
-	assert.Equal(t, 12, len(tagMap))
+	assert.Equal(t, 13, len(tagMap))
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
 	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
@@ -111,6 +112,7 @@ func TestBuildTagMapFromArnComplete(t *testing.T) {
 	assert.Equal(t, "value1", tagMap["tag1"])
 	// Result of this test depends on build environment
 	assert.True(t, tagMap["architecture"] == "x86_64" || tagMap["architecture"] == "arm64")
+	assert.Equal(t, "unknown", tagMap["runtime"])
 }
 
 func TestBuildTagMapFromArnCompleteWithEnvAndVersionAndService(t *testing.T) {
@@ -123,7 +125,7 @@ func TestBuildTagMapFromArnCompleteWithEnvAndVersionAndService(t *testing.T) {
 
 	arn := "arn:aws:lambda:us-east-1:123456789012:function:my-function"
 	tagMap := BuildTagMap(arn, []string{"tag0:value0", "TAG1:VALUE1"})
-	assert.Equal(t, 15, len(tagMap))
+	assert.Equal(t, 16, len(tagMap))
 	assert.Equal(t, "mytestenv", tagMap["env"])
 	assert.Equal(t, "mytestversion", tagMap["version"])
 	assert.Equal(t, "mytestservice", tagMap["service"])
@@ -140,12 +142,13 @@ func TestBuildTagMapFromArnCompleteWithEnvAndVersionAndService(t *testing.T) {
 	assert.Equal(t, "value1", tagMap["tag1"])
 	// Result of this test depends on build environment
 	assert.True(t, tagMap["architecture"] == "x86_64" || tagMap["architecture"] == "arm64")
+	assert.Equal(t, "unknown", tagMap["runtime"])
 }
 
 func TestBuildTagMapFromArnCompleteWithUpperCase(t *testing.T) {
 	arn := "arn:aws:lambda:us-east-1:123456789012:function:My-Function"
 	tagMap := BuildTagMap(arn, []string{"tag0:value0", "TAG1:VALUE1"})
-	assert.Equal(t, 12, len(tagMap))
+	assert.Equal(t, 13, len(tagMap))
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
 	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
@@ -158,13 +161,14 @@ func TestBuildTagMapFromArnCompleteWithUpperCase(t *testing.T) {
 	assert.Equal(t, "value0", tagMap["tag0"])
 	assert.Equal(t, "value1", tagMap["tag1"])
 	assert.True(t, tagMap["architecture"] == "x86_64" || tagMap["architecture"] == "arm64")
+	assert.Equal(t, "unknown", tagMap["runtime"])
 }
 
 func TestBuildTagMapFromArnCompleteWithLatest(t *testing.T) {
 	os.Setenv("AWS_LAMBDA_FUNCTION_VERSION", "$LATEST")
 	arn := "arn:aws:lambda:us-east-1:123456789012:function:my-function"
 	tagMap := BuildTagMap(arn, []string{"tag0:value0", "TAG1:VALUE1"})
-	assert.Equal(t, 12, len(tagMap))
+	assert.Equal(t, 13, len(tagMap))
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
 	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
@@ -177,13 +181,14 @@ func TestBuildTagMapFromArnCompleteWithLatest(t *testing.T) {
 	assert.Equal(t, "value0", tagMap["tag0"])
 	assert.Equal(t, "value1", tagMap["tag1"])
 	assert.True(t, tagMap["architecture"] == "x86_64" || tagMap["architecture"] == "arm64")
+	assert.Equal(t, "unknown", tagMap["runtime"])
 }
 
 func TestBuildTagMapFromArnCompleteWithVersionNumber(t *testing.T) {
 	os.Setenv("AWS_LAMBDA_FUNCTION_VERSION", "888")
 	arn := "arn:aws:lambda:us-east-1:123456789012:function:my-function"
 	tagMap := BuildTagMap(arn, []string{"tag0:value0", "TAG1:VALUE1"})
-	assert.Equal(t, 13, len(tagMap))
+	assert.Equal(t, 14, len(tagMap))
 	assert.Equal(t, "lambda", tagMap["_dd.origin"])
 	assert.Equal(t, "1", tagMap["_dd.compute_stats"])
 	assert.Equal(t, "arn:aws:lambda:us-east-1:123456789012:function:my-function", tagMap["function_arn"])
@@ -197,6 +202,7 @@ func TestBuildTagMapFromArnCompleteWithVersionNumber(t *testing.T) {
 	assert.Equal(t, "value0", tagMap["tag0"])
 	assert.Equal(t, "value1", tagMap["tag1"])
 	assert.True(t, tagMap["architecture"] == "x86_64" || tagMap["architecture"] == "arm64")
+	assert.Equal(t, "unknown", tagMap["runtime"])
 }
 
 func TestAddTagInvalid(t *testing.T) {
@@ -269,8 +275,7 @@ func TestAddColdStartTagWithColdStart(t *testing.T) {
 	})
 }
 
-func TestBuildTagMapWithRuntimeAndMemoryTag(t *testing.T) {
-	os.Setenv("AWS_EXECUTION_ENV", "AWS_Lambda_java")
+func TestBuildTagMapWithMemoryTag(t *testing.T) {
 	os.Setenv("AWS_LAMBDA_FUNCTION_MEMORY_SIZE", "128")
 	arn := "arn:aws:lambda:us-east-1:123456789012:function:my-function"
 	tagMap := BuildTagMap(arn, []string{"tag0:value0", "TAG1:VALUE1"})
@@ -286,7 +291,36 @@ func TestBuildTagMapWithRuntimeAndMemoryTag(t *testing.T) {
 	assert.Equal(t, "xxx", tagMap["dd_extension_version"])
 	assert.Equal(t, "value0", tagMap["tag0"])
 	assert.Equal(t, "value1", tagMap["tag1"])
-	assert.Equal(t, "java", tagMap["runtime"])
+	assert.Equal(t, "unknown", tagMap["runtime"])
 	assert.Equal(t, "128", tagMap["memorysize"])
 	assert.True(t, tagMap["architecture"] == "x86_64" || tagMap["architecture"] == "arm64")
+}
+
+func TestExtractRuntimeFromLineValid(t *testing.T) {
+	runtime, err := extractRuntimeFromLine("AWS_EXECUTION_ENV=AWS_Lambda_nodejs14.x")
+	assert.NoError(t, err)
+	assert.Equal(t, "nodejs14.x", runtime)
+}
+
+func TestExtractRuntimeFromLineIncorrectFormat(t *testing.T) {
+	_, err := extractRuntimeFromLine("AWS_EXECUTION_ENV AWS_Lambda_nodejs14.x")
+	assert.NotNil(t, err)
+}
+
+func TestDetectRuntimeInvalidPath(t *testing.T) {
+	_, err := detectRuntime("/invalidPath", "AWS_EXECUTION_ENV")
+	assert.NotNil(t, err)
+	assert.Equal(t, "could not detect the runtime: bootstrap file cannot be read", err.Error())
+}
+
+func TestDetectRuntimeInvalidFileContent(t *testing.T) {
+	_, err := detectRuntime("./testData/invalid", "AWS_EXECUTION_ENV")
+	assert.NotNil(t, err)
+	assert.Equal(t, "could not detect the runtime: cannot find the runtime value in the bootstrap file", err.Error())
+}
+
+func TestDetectRuntimeValid(t *testing.T) {
+	runtime, err := detectRuntime("./testData/valid", "AWS_EXECUTION_ENV")
+	assert.Nil(t, err)
+	assert.Equal(t, "nodejs14.x", runtime)
 }

--- a/pkg/serverless/tags/testData/invalid
+++ b/pkg/serverless/tags/testData/invalid
@@ -1,0 +1,3 @@
+bla bla bla
+bla bla bla
+bla bla bla

--- a/pkg/serverless/tags/testData/valid
+++ b/pkg/serverless/tags/testData/valid
@@ -1,0 +1,3 @@
+bla bla bla
+export AWS_EXECUTION_ENV=AWS_Lambda_nodejs14.x
+bla bla bla


### PR DESCRIPTION
### What does this PR do?

AWS sets the `AWS_EXECUTION_ENV` after that the extension starts so this environment variable is not available in the extension.
This PR reads the `bootstrap` in `/var/runtime`
In this file, AWS is explicitly sets this env with `export AWS_EXECUTION_ENV=AWS_Lambda_nodejs14.x`
This is where we extract the runtime value.

Quick note about the performance, this is extremely fast ( < 100µs) and the code is called only during cold start (as the runtime value cannot change during the lifetime of the lambda environment)

<img width="626" alt="Screen Shot 2021-10-27 at 1 27 56 PM" src="https://user-images.githubusercontent.com/864493/139116138-c9d30747-5f51-45ff-8c88-133928939ecd.png">

### Motivation

We need the `runtime` tag in our metrics, logs and traces

### Additional Notes

100% test coverage on the newly introduced code 

<img width="1124" alt="Screen Shot 2021-10-27 at 1 22 02 PM" src="https://user-images.githubusercontent.com/864493/139115292-da832997-c75c-4543-9e63-6abc43522351.png">

### Describe how to test your changes

Use extension `v279` in `sa-east-1` on sandbox

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
