### PR TITLE
[Flare][CLI] Dump workloadmeta store

### DIFF
--- a/cmd/agent/app/workload_list.go
+++ b/cmd/agent/app/workload_list.go
@@ -1,0 +1,88 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/cmd/agent/common"
+	"github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+)
+
+var verboseList bool
+
+func init() {
+	AgentCmd.AddCommand(workloadListCommand)
+	workloadListCommand.Flags().BoolVarP(&verboseList, "verbose", "v", false, "print out a full dump of the workload store")
+}
+
+var workloadListCommand = &cobra.Command{
+	Use:   "workload-list",
+	Short: "Print the workload content of a running agent",
+	Long:  ``,
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		if flagNoColor {
+			color.NoColor = true
+		}
+
+		err := common.SetupConfigWithoutSecrets(confFilePath, "")
+		if err != nil {
+			return fmt.Errorf("unable to set up global agent configuration: %v", err)
+		}
+
+		err = config.SetupLogger(loggerName, config.GetEnvDefault("DD_LOG_LEVEL", "off"), "", "", false, true, false)
+		if err != nil {
+			fmt.Printf("Cannot setup logger, exiting: %v\n", err)
+			return err
+		}
+
+		c := util.GetClient(false) // FIX: get certificates right then make this true
+
+		// Set session token
+		err = util.SetAuthToken()
+		if err != nil {
+			return err
+		}
+		ipcAddress, err := config.GetIPCAddress()
+		if err != nil {
+			return err
+		}
+
+		r, err := util.DoGet(c, workloadURL(verboseList, ipcAddress, config.Datadog.GetInt("cmd_port")))
+		if err != nil {
+			if r != nil && string(r) != "" {
+				fmt.Fprintf(color.Output, "The agent ran into an error while getting tags list: %s\n", string(r))
+			} else {
+				fmt.Fprintf(color.Output, "Failed to query the agent (running?): %s\n", err)
+			}
+		}
+
+		workload := workloadmeta.WorkloadDumpResponse{}
+		err = json.Unmarshal(r, &workload)
+		if err != nil {
+			return err
+		}
+
+		workload.Write(color.Output)
+
+		return nil
+	},
+}
+
+func workloadURL(verbose bool, address string, port int) string {
+	if verbose {
+		return fmt.Sprintf("https://%v:%v/agent/workload-list/verbose", address, port)
+	}
+
+	return fmt.Sprintf("https://%v:%v/agent/workload-list/short", address, port)
+}

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -34,6 +34,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/scrubber"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 
 	"github.com/mholt/archiver/v3"
 	"gopkg.in/yaml.v2"
@@ -206,6 +207,11 @@ func createArchive(confSearchPaths SearchPaths, local bool, zipFilePath string, 
 		err = zipTaggerList(tempDir, hostname)
 		if err != nil {
 			log.Errorf("Could not zip tagger list: %s", err)
+		}
+
+		err = zipWorkloadList(tempDir, hostname)
+		if err != nil {
+			log.Errorf("Could not zip workload list: %s", err)
 		}
 	}
 
@@ -745,6 +751,53 @@ func zipTaggerList(tempDir, hostname string) error {
 	writer.Flush()
 
 	_, err = w.Write(b.Bytes())
+	return err
+}
+
+// workloadListURL allows mocking the agent HTTP server
+var workloadListURL string
+
+func zipWorkloadList(tempDir, hostname string) error {
+	f := filepath.Join(tempDir, hostname, "workload-list.log")
+	err := ensureParentDirsExist(f)
+	if err != nil {
+		return err
+	}
+
+	w, err := newRedactingWriter(f, os.ModePerm, true)
+	if err != nil {
+		return err
+	}
+	defer w.Close()
+
+	ipcAddress, err := config.GetIPCAddress()
+	if err != nil {
+		return err
+	}
+
+	if workloadListURL == "" {
+		workloadListURL = fmt.Sprintf("https://%v:%v/agent/workload-list/verbose", ipcAddress, config.Datadog.GetInt("cmd_port"))
+	}
+
+	c := apiutil.GetClient(false) // FIX: get certificates right then make this true
+
+	r, err := apiutil.DoGet(c, workloadListURL)
+	if err != nil {
+		return err
+	}
+
+	workload := workloadmeta.WorkloadDumpResponse{}
+	err = json.Unmarshal(r, &workload)
+	if err != nil {
+		return err
+	}
+
+	var b bytes.Buffer
+	writer := bufio.NewWriter(&b)
+	workload.Write(writer)
+	_ = writer.Flush()
+	_, err = w.Write(b.Bytes())
+
 	return err
 }
 

--- a/pkg/workloadmeta/dump.go
+++ b/pkg/workloadmeta/dump.go
@@ -1,0 +1,98 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package workloadmeta
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/fatih/color"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// WorkloadDumpResponse is used to dump the store content.
+type WorkloadDumpResponse struct {
+	Entities map[string]WorkloadEntity `json:"entities"`
+}
+
+// WorkloadEntity contains entity data.
+type WorkloadEntity struct {
+	Infos map[string]string `json:"infos"`
+}
+
+// Write writes the stores content in a given writer.
+// Useful for agent's CLI and Flare.
+func (wdr WorkloadDumpResponse) Write(writer io.Writer) {
+	if writer != color.Output {
+		color.NoColor = true
+	}
+
+	for kind, entities := range wdr.Entities {
+		for entity, info := range entities.Infos {
+			fmt.Fprintf(writer, "\n=== Entity %s %s ===\n", color.GreenString(kind), color.GreenString(entity))
+			fmt.Fprint(writer, info)
+			fmt.Fprintln(writer, "===")
+		}
+	}
+}
+
+// Dump lists the content of the store.
+// Useful for agent's CLI and Flare.
+func (s *store) Dump(verbose bool) WorkloadDumpResponse {
+	workloadList := WorkloadDumpResponse{
+		Entities: make(map[string]WorkloadEntity),
+	}
+
+	entityToString := func(entity Entity) (string, error) {
+		var info string
+		switch e := entity.(type) {
+		case *Container:
+			info = e.String(verbose)
+		case *KubernetesPod:
+			info = e.String(verbose)
+		case *ECSTask:
+			info = e.String(verbose)
+		default:
+			return "", fmt.Errorf("unsupported type %T", e)
+		}
+
+		return info, nil
+	}
+
+	s.storeMut.RLock()
+	defer s.storeMut.RUnlock()
+
+	for kind, store := range s.store {
+		entities := WorkloadEntity{Infos: make(map[string]string)}
+		for id, srcToEntity := range store {
+			if verbose && len(srcToEntity) > 1 {
+				for source, entity := range srcToEntity {
+					info, err := entityToString(entity)
+					if err != nil {
+						log.Debugf("Ignoring entity %s: %w", entity.GetID().ID, err)
+						continue
+					}
+
+					entities.Infos["source:"+source+" id: "+id] = info
+				}
+			}
+
+			e := srcToEntity.merge(nil)
+			info, err := entityToString(e)
+			if err != nil {
+				log.Debugf("Ignoring entity %s: %w", e.GetID().ID, err)
+				continue
+			}
+
+			entities.Infos[fmt.Sprintf("sources(merged):%v", srcToEntity.sources())+" id: "+id] = info
+		}
+
+		workloadList.Entities[string(kind)] = entities
+	}
+
+	return workloadList
+}

--- a/pkg/workloadmeta/dump.go
+++ b/pkg/workloadmeta/dump.go
@@ -77,7 +77,7 @@ func (s *store) Dump(verbose bool) WorkloadDumpResponse {
 						continue
 					}
 
-					entities.Infos["source:"+source+" id: "+id] = info
+					entities.Infos["source:"+string(source)+" id: "+id] = info
 				}
 			}
 

--- a/pkg/workloadmeta/dump_test.go
+++ b/pkg/workloadmeta/dump_test.go
@@ -1,0 +1,162 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package workloadmeta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDump(t *testing.T) {
+	s := newStore()
+
+	container := &Container{
+		EntityID: EntityID{
+			Kind: KindContainer,
+			ID:   "ctr-id",
+		},
+		EntityMeta: EntityMeta{
+			Name: "ctr-name",
+		},
+		Image: ContainerImage{
+			Name: "ctr-image",
+		},
+		Runtime: ContainerRuntimeDocker,
+	}
+
+	ctrToMerge := &Container{
+		EntityID: EntityID{
+			Kind: KindContainer,
+			ID:   "ctr-id",
+		},
+		EntityMeta: EntityMeta{
+			Labels: map[string]string{"foo": "bar"},
+		},
+		Image: ContainerImage{
+			Tag: "latest",
+		},
+		PID: 1,
+	}
+
+	s.handleEvents([]CollectorEvent{
+		{
+			Type:   EventTypeSet,
+			Source: "source1",
+			Entity: container,
+		},
+		{
+			Type:   EventTypeSet,
+			Source: "source2",
+			Entity: ctrToMerge,
+		},
+	})
+
+	shortDump := s.Dump(false)
+	expectedShort := WorkloadDumpResponse{
+		Entities: map[string]WorkloadEntity{
+			"container": {
+				Infos: map[string]string{
+					"sources(merged):[source1 source2] id: ctr-id": `----------- Entity ID -----------
+Kind: container ID: ctr-id
+----------- Entity Meta -----------
+Name: ctr-name
+Namespace: 
+----------- Image -----------
+Name: ctr-image
+Tag: latest
+----------- Container Info -----------
+Runtime: docker
+Running: false
+`,
+				},
+			},
+		},
+	}
+
+	assert.EqualValues(t, expectedShort, shortDump)
+
+	verboseDump := s.Dump(true)
+	expectedVerbose := WorkloadDumpResponse{
+		Entities: map[string]WorkloadEntity{
+			"container": {
+				Infos: map[string]string{
+					"source:source1 id: ctr-id": `----------- Entity ID -----------
+Kind: container ID: ctr-id
+----------- Entity Meta -----------
+Name: ctr-name
+Namespace: 
+Annotations: 
+Labels: 
+----------- Image -----------
+Name: ctr-image
+Tag: 
+ID: 
+Raw Name: 
+Short Name: 
+----------- Container Info -----------
+Runtime: docker
+Running: false
+Started At: 0001-01-01 00:00:00 +0000 UTC
+Finished At: 0001-01-01 00:00:00 +0000 UTC
+Env Variables: 
+Hostname: 
+Network IPs: 
+PID: 0
+`,
+					"source:source2 id: ctr-id": `----------- Entity ID -----------
+Kind: container ID: ctr-id
+----------- Entity Meta -----------
+Name: 
+Namespace: 
+Annotations: 
+Labels: foo:bar 
+----------- Image -----------
+Name: 
+Tag: latest
+ID: 
+Raw Name: 
+Short Name: 
+----------- Container Info -----------
+Runtime: 
+Running: false
+Started At: 0001-01-01 00:00:00 +0000 UTC
+Finished At: 0001-01-01 00:00:00 +0000 UTC
+Env Variables: 
+Hostname: 
+Network IPs: 
+PID: 1
+`,
+					"sources(merged):[source1 source2] id: ctr-id": `----------- Entity ID -----------
+Kind: container ID: ctr-id
+----------- Entity Meta -----------
+Name: ctr-name
+Namespace: 
+Annotations: 
+Labels: foo:bar 
+----------- Image -----------
+Name: ctr-image
+Tag: latest
+ID: 
+Raw Name: 
+Short Name: 
+----------- Container Info -----------
+Runtime: docker
+Running: false
+Started At: 0001-01-01 00:00:00 +0000 UTC
+Finished At: 0001-01-01 00:00:00 +0000 UTC
+Env Variables: 
+Hostname: 
+Network IPs: 
+PID: 1
+`,
+				},
+			},
+		},
+	}
+
+	assert.EqualValues(t, expectedVerbose, verboseDump)
+}

--- a/pkg/workloadmeta/testing/store.go
+++ b/pkg/workloadmeta/testing/store.go
@@ -120,6 +120,11 @@ func (s *Store) Notify(events []workloadmeta.CollectorEvent) {
 	panic("not implemented")
 }
 
+// Dump is not implemented in the testing store.
+func (s *Store) Dump(verbose bool) workloadmeta.WorkloadDumpResponse {
+	panic("not implemented")
+}
+
 func (s *Store) getEntityByKind(kind workloadmeta.Kind, id string) (workloadmeta.Entity, error) {
 	entitiesOfKind, ok := s.store[kind]
 	if !ok {

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/imdario/mergo"
@@ -29,6 +30,7 @@ type Store interface {
 	GetKubernetesPodForContainer(containerID string) (*KubernetesPod, error)
 	GetECSTask(id string) (*ECSTask, error)
 	Notify(events []CollectorEvent)
+	Dump(verbose bool) WorkloadDumpResponse
 }
 
 // Kind is the kind of an entity.
@@ -75,6 +77,7 @@ type Entity interface {
 	GetID() EntityID
 	Merge(Entity) error
 	DeepCopy() Entity
+	String(verbose bool) string
 }
 
 // EntityID represents the ID of an Entity.
@@ -101,6 +104,14 @@ func (i EntityID) DeepCopy() Entity {
 	return i
 }
 
+// String returns a string representation of EntityID.
+func (i EntityID) String(_ bool) string {
+	var sb strings.Builder
+	_, _ = sb.WriteString(fmt.Sprintln("Kind:", i.Kind, "ID:", i.ID))
+
+	return sb.String()
+}
+
 var _ Entity = EntityID{}
 
 // EntityMeta represents generic metadata about an Entity.
@@ -109,6 +120,20 @@ type EntityMeta struct {
 	Namespace   string
 	Annotations map[string]string
 	Labels      map[string]string
+}
+
+// String returns a string representation of EntityMeta.
+func (e EntityMeta) String(verbose bool) string {
+	var sb strings.Builder
+	_, _ = sb.WriteString(fmt.Sprintln("Name:", e.Name))
+	_, _ = sb.WriteString(fmt.Sprintln("Namespace:", e.Namespace))
+
+	if verbose {
+		_, _ = sb.WriteString(fmt.Sprintln("Annotations:", mapToString(e.Annotations)))
+		_, _ = sb.WriteString(fmt.Sprintln("Labels:", mapToString(e.Labels)))
+	}
+
+	return sb.String()
 }
 
 // ContainerImage is the an image used by a container.
@@ -143,11 +168,39 @@ func NewContainerImage(imageName string) (ContainerImage, error) {
 	return image, nil
 }
 
+// String returns a string representation of ContainerImage.
+func (c ContainerImage) String(verbose bool) string {
+	var sb strings.Builder
+	_, _ = sb.WriteString(fmt.Sprintln("Name:", c.Name))
+	_, _ = sb.WriteString(fmt.Sprintln("Tag:", c.Tag))
+
+	if verbose {
+		_, _ = sb.WriteString(fmt.Sprintln("ID:", c.ID))
+		_, _ = sb.WriteString(fmt.Sprintln("Raw Name:", c.RawName))
+		_, _ = sb.WriteString(fmt.Sprintln("Short Name:", c.ShortName))
+	}
+
+	return sb.String()
+}
+
 // ContainerState is the state of a container.
 type ContainerState struct {
 	Running    bool
 	StartedAt  time.Time
 	FinishedAt time.Time
+}
+
+// String returns a string representation of ContainerState.
+func (c ContainerState) String(verbose bool) string {
+	var sb strings.Builder
+	_, _ = sb.WriteString(fmt.Sprintln("Running:", c.Running))
+
+	if verbose {
+		_, _ = sb.WriteString(fmt.Sprintln("Started At:", c.StartedAt))
+		_, _ = sb.WriteString(fmt.Sprintln("Finished At:", c.FinishedAt))
+	}
+
+	return sb.String()
 }
 
 // ContainerPort is a port open in the container.
@@ -157,12 +210,33 @@ type ContainerPort struct {
 	Protocol string
 }
 
+// String returns a string representation of ContainerPort.
+func (c ContainerPort) String(verbose bool) string {
+	var sb strings.Builder
+	_, _ = sb.WriteString(fmt.Sprintln("Port:", c.Port))
+
+	if verbose {
+		_, _ = sb.WriteString(fmt.Sprintln("Name:", c.Name))
+		_, _ = sb.WriteString(fmt.Sprintln("Protocol:", c.Protocol))
+	}
+
+	return sb.String()
+}
+
 // OrchestratorContainer is a reference to a Container with
 // orchestrator-specific data attached to it.
 type OrchestratorContainer struct {
 	ID    string
 	Name  string
 	Image ContainerImage
+}
+
+// String returns a string representation of OrchestratorContainer.
+func (o OrchestratorContainer) String(_ bool) string {
+	var sb strings.Builder
+	_, _ = sb.WriteString(fmt.Sprintln("Name:", o.Name, "ID:", o.ID))
+
+	return sb.String()
 }
 
 // Container is a containerized workload.
@@ -199,6 +273,40 @@ func (c *Container) Merge(e Entity) error {
 func (c Container) DeepCopy() Entity {
 	cp := deepcopy.Copy(c).(Container)
 	return &cp
+}
+
+// String returns a string representation of Container.
+func (c Container) String(verbose bool) string {
+	var sb strings.Builder
+
+	_, _ = sb.WriteString(fmt.Sprintln("----------- Entity ID -----------"))
+	_, _ = sb.WriteString(c.EntityID.String(verbose))
+
+	_, _ = sb.WriteString(fmt.Sprintln("----------- Entity Meta -----------"))
+	_, _ = sb.WriteString(c.EntityMeta.String(verbose))
+
+	_, _ = sb.WriteString(fmt.Sprintln("----------- Image -----------"))
+	_, _ = sb.WriteString(c.Image.String(verbose))
+
+	_, _ = sb.WriteString(fmt.Sprintln("----------- Container Info -----------"))
+	_, _ = sb.WriteString(fmt.Sprintln("Runtime:", c.Runtime))
+	_, _ = sb.WriteString(c.State.String(verbose))
+
+	if verbose {
+		_, _ = sb.WriteString(fmt.Sprintln("Env Variables:", mapToString(c.EnvVars)))
+		_, _ = sb.WriteString(fmt.Sprintln("Hostname:", c.Hostname))
+		_, _ = sb.WriteString(fmt.Sprintln("Network IPs:", mapToString(c.NetworkIPs)))
+		_, _ = sb.WriteString(fmt.Sprintln("PID:", c.PID))
+	}
+
+	if len(c.Ports) > 0 && verbose {
+		_, _ = sb.WriteString(fmt.Sprintln("----------- Ports -----------"))
+		for _, p := range c.Ports {
+			_, _ = sb.WriteString(p.String(verbose))
+		}
+	}
+
+	return sb.String()
 }
 
 var _ Entity = &Container{}
@@ -240,6 +348,44 @@ func (p KubernetesPod) DeepCopy() Entity {
 	return &cp
 }
 
+// String returns a string representation of KubernetesPod.
+func (p KubernetesPod) String(verbose bool) string {
+	var sb strings.Builder
+	_, _ = sb.WriteString(fmt.Sprintln("----------- Entity ID -----------"))
+	_, _ = sb.WriteString(p.EntityID.String(verbose))
+
+	_, _ = sb.WriteString(fmt.Sprintln("----------- Entity Meta -----------"))
+	_, _ = sb.WriteString(p.EntityMeta.String(verbose))
+
+	if len(p.Owners) > 0 {
+		_, _ = sb.WriteString(fmt.Sprintln("----------- Owners -----------"))
+		for _, o := range p.Owners {
+			_, _ = sb.WriteString(o.String(verbose))
+		}
+	}
+
+	if len(p.Containers) > 0 {
+		_, _ = sb.WriteString(fmt.Sprintln("----------- Containers -----------"))
+		for _, c := range p.Containers {
+			_, _ = sb.WriteString(c.String(verbose))
+		}
+	}
+
+	_, _ = sb.WriteString(fmt.Sprintln("----------- Pod Info -----------"))
+	_, _ = sb.WriteString(fmt.Sprintln("Ready:", p.Ready))
+	_, _ = sb.WriteString(fmt.Sprintln("Phase:", p.Phase))
+	_, _ = sb.WriteString(fmt.Sprintln("IP:", p.IP))
+
+	if verbose {
+		_, _ = sb.WriteString(fmt.Sprintln("Priority Class:", p.PriorityClass))
+		_, _ = sb.WriteString(fmt.Sprintln("PVCs:", sliceToString(p.PersistentVolumeClaimNames)))
+		_, _ = sb.WriteString(fmt.Sprintln("Kube Services:", sliceToString(p.KubeServices)))
+		_, _ = sb.WriteString(fmt.Sprintln("Namespace Labels:", mapToString(p.NamespaceLabels)))
+	}
+
+	return sb.String()
+}
+
 var _ Entity = &KubernetesPod{}
 
 // KubernetesPodOwner is extracted from a pod's owner references.
@@ -247,6 +393,19 @@ type KubernetesPodOwner struct {
 	Kind string
 	Name string
 	ID   string
+}
+
+// String returns a string representation of KubernetesPodOwner.
+func (o KubernetesPodOwner) String(verbose bool) string {
+	var sb strings.Builder
+	_, _ = sb.WriteString(fmt.Sprintln("Kind:", o.Kind, "Name:", o.Name))
+
+	if verbose {
+		_, _ = sb.WriteString(fmt.Sprintln("ID:", o.ID))
+
+	}
+
+	return sb.String()
 }
 
 // ECSTask is an ECS Task.
@@ -284,6 +443,35 @@ func (t *ECSTask) Merge(e Entity) error {
 func (t ECSTask) DeepCopy() Entity {
 	cp := deepcopy.Copy(t).(ECSTask)
 	return &cp
+}
+
+// String returns a string representation of ECSTask.
+func (t ECSTask) String(verbose bool) string {
+	var sb strings.Builder
+	_, _ = sb.WriteString(fmt.Sprintln("----------- Entity ID -----------"))
+	_, _ = sb.WriteString(t.EntityID.String(verbose))
+
+	_, _ = sb.WriteString(fmt.Sprintln("----------- Entity Meta -----------"))
+	_, _ = sb.WriteString(t.EntityMeta.String(verbose))
+
+	_, _ = sb.WriteString(fmt.Sprintln("----------- Containers -----------"))
+	for _, c := range t.Containers {
+		_, _ = sb.WriteString(c.String(verbose))
+	}
+
+	if verbose {
+		_, _ = sb.WriteString(fmt.Sprintln("----------- Task Info -----------"))
+		_, _ = sb.WriteString(fmt.Sprintln("Tags:", mapToString(t.Tags)))
+		_, _ = sb.WriteString(fmt.Sprintln("Container Instance Tags:", mapToString(t.ContainerInstanceTags)))
+		_, _ = sb.WriteString(fmt.Sprintln("Cluster Name:", t.ClusterName))
+		_, _ = sb.WriteString(fmt.Sprintln("Region:", t.Region))
+		_, _ = sb.WriteString(fmt.Sprintln("Availability Zone:", t.AvailabilityZone))
+		_, _ = sb.WriteString(fmt.Sprintln("Family:", t.Family))
+		_, _ = sb.WriteString(fmt.Sprintln("Version:", t.Version))
+		_, _ = sb.WriteString(fmt.Sprintln("Launch Type:", t.LaunchType))
+	}
+
+	return sb.String()
 }
 
 var _ Entity = &ECSTask{}

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -106,10 +106,7 @@ func (i EntityID) DeepCopy() Entity {
 
 // String returns a string representation of EntityID.
 func (i EntityID) String(_ bool) string {
-	var sb strings.Builder
-	_, _ = sb.WriteString(fmt.Sprintln("Kind:", i.Kind, "ID:", i.ID))
-
-	return sb.String()
+	return fmt.Sprintln("Kind:", i.Kind, "ID:", i.ID)
 }
 
 var _ Entity = EntityID{}
@@ -125,12 +122,12 @@ type EntityMeta struct {
 // String returns a string representation of EntityMeta.
 func (e EntityMeta) String(verbose bool) string {
 	var sb strings.Builder
-	_, _ = sb.WriteString(fmt.Sprintln("Name:", e.Name))
-	_, _ = sb.WriteString(fmt.Sprintln("Namespace:", e.Namespace))
+	_, _ = fmt.Fprintln(&sb, "Name:", e.Name)
+	_, _ = fmt.Fprintln(&sb, "Namespace:", e.Namespace)
 
 	if verbose {
-		_, _ = sb.WriteString(fmt.Sprintln("Annotations:", mapToString(e.Annotations)))
-		_, _ = sb.WriteString(fmt.Sprintln("Labels:", mapToString(e.Labels)))
+		_, _ = fmt.Fprintln(&sb, "Annotations:", mapToString(e.Annotations))
+		_, _ = fmt.Fprintln(&sb, "Labels:", mapToString(e.Labels))
 	}
 
 	return sb.String()
@@ -171,13 +168,13 @@ func NewContainerImage(imageName string) (ContainerImage, error) {
 // String returns a string representation of ContainerImage.
 func (c ContainerImage) String(verbose bool) string {
 	var sb strings.Builder
-	_, _ = sb.WriteString(fmt.Sprintln("Name:", c.Name))
-	_, _ = sb.WriteString(fmt.Sprintln("Tag:", c.Tag))
+	_, _ = fmt.Fprintln(&sb, "Name:", c.Name)
+	_, _ = fmt.Fprintln(&sb, "Tag:", c.Tag)
 
 	if verbose {
-		_, _ = sb.WriteString(fmt.Sprintln("ID:", c.ID))
-		_, _ = sb.WriteString(fmt.Sprintln("Raw Name:", c.RawName))
-		_, _ = sb.WriteString(fmt.Sprintln("Short Name:", c.ShortName))
+		_, _ = fmt.Fprintln(&sb, "ID:", c.ID)
+		_, _ = fmt.Fprintln(&sb, "Raw Name:", c.RawName)
+		_, _ = fmt.Fprintln(&sb, "Short Name:", c.ShortName)
 	}
 
 	return sb.String()
@@ -193,11 +190,11 @@ type ContainerState struct {
 // String returns a string representation of ContainerState.
 func (c ContainerState) String(verbose bool) string {
 	var sb strings.Builder
-	_, _ = sb.WriteString(fmt.Sprintln("Running:", c.Running))
+	_, _ = fmt.Fprintln(&sb, "Running:", c.Running)
 
 	if verbose {
-		_, _ = sb.WriteString(fmt.Sprintln("Started At:", c.StartedAt))
-		_, _ = sb.WriteString(fmt.Sprintln("Finished At:", c.FinishedAt))
+		_, _ = fmt.Fprintln(&sb, "Started At:", c.StartedAt)
+		_, _ = fmt.Fprintln(&sb, "Finished At:", c.FinishedAt)
 	}
 
 	return sb.String()
@@ -213,11 +210,11 @@ type ContainerPort struct {
 // String returns a string representation of ContainerPort.
 func (c ContainerPort) String(verbose bool) string {
 	var sb strings.Builder
-	_, _ = sb.WriteString(fmt.Sprintln("Port:", c.Port))
+	_, _ = fmt.Fprintln(&sb, "Port:", c.Port)
 
 	if verbose {
-		_, _ = sb.WriteString(fmt.Sprintln("Name:", c.Name))
-		_, _ = sb.WriteString(fmt.Sprintln("Protocol:", c.Protocol))
+		_, _ = fmt.Fprintln(&sb, "Name:", c.Name)
+		_, _ = fmt.Fprintln(&sb, "Protocol:", c.Protocol)
 	}
 
 	return sb.String()
@@ -233,10 +230,7 @@ type OrchestratorContainer struct {
 
 // String returns a string representation of OrchestratorContainer.
 func (o OrchestratorContainer) String(_ bool) string {
-	var sb strings.Builder
-	_, _ = sb.WriteString(fmt.Sprintln("Name:", o.Name, "ID:", o.ID))
-
-	return sb.String()
+	return fmt.Sprintln("Name:", o.Name, "ID:", o.ID)
 }
 
 // Container is a containerized workload.
@@ -279,30 +273,30 @@ func (c Container) DeepCopy() Entity {
 func (c Container) String(verbose bool) string {
 	var sb strings.Builder
 
-	_, _ = sb.WriteString(fmt.Sprintln("----------- Entity ID -----------"))
-	_, _ = sb.WriteString(c.EntityID.String(verbose))
+	_, _ = fmt.Fprintln(&sb, "----------- Entity ID -----------")
+	_, _ = fmt.Fprint(&sb, c.EntityID.String(verbose))
 
-	_, _ = sb.WriteString(fmt.Sprintln("----------- Entity Meta -----------"))
-	_, _ = sb.WriteString(c.EntityMeta.String(verbose))
+	_, _ = fmt.Fprintln(&sb, "----------- Entity Meta -----------")
+	_, _ = fmt.Fprint(&sb, c.EntityMeta.String(verbose))
 
-	_, _ = sb.WriteString(fmt.Sprintln("----------- Image -----------"))
-	_, _ = sb.WriteString(c.Image.String(verbose))
+	_, _ = fmt.Fprintln(&sb, "----------- Image -----------")
+	_, _ = fmt.Fprint(&sb, c.Image.String(verbose))
 
-	_, _ = sb.WriteString(fmt.Sprintln("----------- Container Info -----------"))
-	_, _ = sb.WriteString(fmt.Sprintln("Runtime:", c.Runtime))
-	_, _ = sb.WriteString(c.State.String(verbose))
+	_, _ = fmt.Fprintln(&sb, "----------- Container Info -----------")
+	_, _ = fmt.Fprintln(&sb, "Runtime:", c.Runtime)
+	_, _ = fmt.Fprint(&sb, c.State.String(verbose))
 
 	if verbose {
-		_, _ = sb.WriteString(fmt.Sprintln("Env Variables:", mapToString(c.EnvVars)))
-		_, _ = sb.WriteString(fmt.Sprintln("Hostname:", c.Hostname))
-		_, _ = sb.WriteString(fmt.Sprintln("Network IPs:", mapToString(c.NetworkIPs)))
-		_, _ = sb.WriteString(fmt.Sprintln("PID:", c.PID))
+		_, _ = fmt.Fprintln(&sb, "Env Variables:", mapToString(c.EnvVars))
+		_, _ = fmt.Fprintln(&sb, "Hostname:", c.Hostname)
+		_, _ = fmt.Fprintln(&sb, "Network IPs:", mapToString(c.NetworkIPs))
+		_, _ = fmt.Fprintln(&sb, "PID:", c.PID)
 	}
 
 	if len(c.Ports) > 0 && verbose {
-		_, _ = sb.WriteString(fmt.Sprintln("----------- Ports -----------"))
+		_, _ = fmt.Fprintln(&sb, "----------- Ports -----------")
 		for _, p := range c.Ports {
-			_, _ = sb.WriteString(p.String(verbose))
+			_, _ = fmt.Fprint(&sb, p.String(verbose))
 		}
 	}
 
@@ -351,36 +345,36 @@ func (p KubernetesPod) DeepCopy() Entity {
 // String returns a string representation of KubernetesPod.
 func (p KubernetesPod) String(verbose bool) string {
 	var sb strings.Builder
-	_, _ = sb.WriteString(fmt.Sprintln("----------- Entity ID -----------"))
-	_, _ = sb.WriteString(p.EntityID.String(verbose))
+	_, _ = fmt.Fprintln(&sb, "----------- Entity ID -----------")
+	_, _ = fmt.Fprintln(&sb, p.EntityID.String(verbose))
 
-	_, _ = sb.WriteString(fmt.Sprintln("----------- Entity Meta -----------"))
-	_, _ = sb.WriteString(p.EntityMeta.String(verbose))
+	_, _ = fmt.Fprintln(&sb, "----------- Entity Meta -----------")
+	_, _ = fmt.Fprint(&sb, p.EntityMeta.String(verbose))
 
 	if len(p.Owners) > 0 {
-		_, _ = sb.WriteString(fmt.Sprintln("----------- Owners -----------"))
+		_, _ = fmt.Fprintln(&sb, "----------- Owners -----------")
 		for _, o := range p.Owners {
-			_, _ = sb.WriteString(o.String(verbose))
+			_, _ = fmt.Fprint(&sb, o.String(verbose))
 		}
 	}
 
 	if len(p.Containers) > 0 {
-		_, _ = sb.WriteString(fmt.Sprintln("----------- Containers -----------"))
+		_, _ = fmt.Fprintln(&sb, "----------- Containers -----------")
 		for _, c := range p.Containers {
-			_, _ = sb.WriteString(c.String(verbose))
+			_, _ = fmt.Fprint(&sb, c.String(verbose))
 		}
 	}
 
-	_, _ = sb.WriteString(fmt.Sprintln("----------- Pod Info -----------"))
-	_, _ = sb.WriteString(fmt.Sprintln("Ready:", p.Ready))
-	_, _ = sb.WriteString(fmt.Sprintln("Phase:", p.Phase))
-	_, _ = sb.WriteString(fmt.Sprintln("IP:", p.IP))
+	_, _ = fmt.Fprintln(&sb, "----------- Pod Info -----------")
+	_, _ = fmt.Fprintln(&sb, "Ready:", p.Ready)
+	_, _ = fmt.Fprintln(&sb, "Phase:", p.Phase)
+	_, _ = fmt.Fprintln(&sb, "IP:", p.IP)
 
 	if verbose {
-		_, _ = sb.WriteString(fmt.Sprintln("Priority Class:", p.PriorityClass))
-		_, _ = sb.WriteString(fmt.Sprintln("PVCs:", sliceToString(p.PersistentVolumeClaimNames)))
-		_, _ = sb.WriteString(fmt.Sprintln("Kube Services:", sliceToString(p.KubeServices)))
-		_, _ = sb.WriteString(fmt.Sprintln("Namespace Labels:", mapToString(p.NamespaceLabels)))
+		_, _ = fmt.Fprintln(&sb, "Priority Class:", p.PriorityClass)
+		_, _ = fmt.Fprintln(&sb, "PVCs:", sliceToString(p.PersistentVolumeClaimNames))
+		_, _ = fmt.Fprintln(&sb, "Kube Services:", sliceToString(p.KubeServices))
+		_, _ = fmt.Fprintln(&sb, "Namespace Labels:", mapToString(p.NamespaceLabels))
 	}
 
 	return sb.String()
@@ -398,10 +392,10 @@ type KubernetesPodOwner struct {
 // String returns a string representation of KubernetesPodOwner.
 func (o KubernetesPodOwner) String(verbose bool) string {
 	var sb strings.Builder
-	_, _ = sb.WriteString(fmt.Sprintln("Kind:", o.Kind, "Name:", o.Name))
+	_, _ = fmt.Fprintln(&sb, "Kind:", o.Kind, "Name:", o.Name)
 
 	if verbose {
-		_, _ = sb.WriteString(fmt.Sprintln("ID:", o.ID))
+		_, _ = fmt.Fprintln(&sb, "ID:", o.ID)
 
 	}
 
@@ -448,27 +442,27 @@ func (t ECSTask) DeepCopy() Entity {
 // String returns a string representation of ECSTask.
 func (t ECSTask) String(verbose bool) string {
 	var sb strings.Builder
-	_, _ = sb.WriteString(fmt.Sprintln("----------- Entity ID -----------"))
-	_, _ = sb.WriteString(t.EntityID.String(verbose))
+	_, _ = fmt.Fprintln(&sb, "----------- Entity ID -----------")
+	_, _ = fmt.Fprint(&sb, t.EntityID.String(verbose))
 
-	_, _ = sb.WriteString(fmt.Sprintln("----------- Entity Meta -----------"))
-	_, _ = sb.WriteString(t.EntityMeta.String(verbose))
+	_, _ = fmt.Fprintln(&sb, "----------- Entity Meta -----------")
+	_, _ = fmt.Fprint(&sb, t.EntityMeta.String(verbose))
 
-	_, _ = sb.WriteString(fmt.Sprintln("----------- Containers -----------"))
+	_, _ = fmt.Fprintln(&sb, "----------- Containers -----------")
 	for _, c := range t.Containers {
-		_, _ = sb.WriteString(c.String(verbose))
+		_, _ = fmt.Fprint(&sb, c.String(verbose))
 	}
 
 	if verbose {
-		_, _ = sb.WriteString(fmt.Sprintln("----------- Task Info -----------"))
-		_, _ = sb.WriteString(fmt.Sprintln("Tags:", mapToString(t.Tags)))
-		_, _ = sb.WriteString(fmt.Sprintln("Container Instance Tags:", mapToString(t.ContainerInstanceTags)))
-		_, _ = sb.WriteString(fmt.Sprintln("Cluster Name:", t.ClusterName))
-		_, _ = sb.WriteString(fmt.Sprintln("Region:", t.Region))
-		_, _ = sb.WriteString(fmt.Sprintln("Availability Zone:", t.AvailabilityZone))
-		_, _ = sb.WriteString(fmt.Sprintln("Family:", t.Family))
-		_, _ = sb.WriteString(fmt.Sprintln("Version:", t.Version))
-		_, _ = sb.WriteString(fmt.Sprintln("Launch Type:", t.LaunchType))
+		_, _ = fmt.Fprintln(&sb, "----------- Task Info -----------")
+		_, _ = fmt.Fprintln(&sb, "Tags:", mapToString(t.Tags))
+		_, _ = fmt.Fprintln(&sb, "Container Instance Tags:", mapToString(t.ContainerInstanceTags))
+		_, _ = fmt.Fprintln(&sb, "Cluster Name:", t.ClusterName)
+		_, _ = fmt.Fprintln(&sb, "Region:", t.Region)
+		_, _ = fmt.Fprintln(&sb, "Availability Zone:", t.AvailabilityZone)
+		_, _ = fmt.Fprintln(&sb, "Family:", t.Family)
+		_, _ = fmt.Fprintln(&sb, "Version:", t.Version)
+		_, _ = fmt.Fprintln(&sb, "Launch Type:", t.LaunchType)
 	}
 
 	return sb.String()

--- a/pkg/workloadmeta/utils.go
+++ b/pkg/workloadmeta/utils.go
@@ -1,0 +1,21 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package workloadmeta
+
+import "strings"
+
+func mapToString(m map[string]string) string {
+	var sb strings.Builder
+	for k, v := range m {
+		_, _ = sb.WriteString(k + ":" + v + " ")
+	}
+
+	return sb.String()
+}
+
+func sliceToString(s []string) string {
+	return strings.Join(s, " ")
+}

--- a/pkg/workloadmeta/utils.go
+++ b/pkg/workloadmeta/utils.go
@@ -5,12 +5,15 @@
 
 package workloadmeta
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 func mapToString(m map[string]string) string {
 	var sb strings.Builder
 	for k, v := range m {
-		_, _ = sb.WriteString(k + ":" + v + " ")
+		fmt.Fprintf(&sb, "%s:%s ", k, v)
 	}
 
 	return sb.String()

--- a/releasenotes/notes/workload-meta-dump-f601aa6ffe80c8e9.yaml
+++ b/releasenotes/notes/workload-meta-dump-f601aa6ffe80c8e9.yaml
@@ -1,0 +1,4 @@
+enhancements:
+  - |
+    Add a new agent command to dump the content of the workloadmeta store ``agent workload-list``.
+    The output of ``agent workload-list --verbose`` is included in the agent flare.


### PR DESCRIPTION
### What does this PR do?

- New agent command:
  - `agent workload-list` Short output: Only few entity fields are dumped + entities collected from different sources are merged.
  - `agent workload-list --verbose` Long dump: All entity fields are dumped + all entities are printed before and after being merged.

- New file in the agent flare: The equivalent of `agent workload-list --verbose` will be added to the flare, in `workload-list.log`

### Motivation

Ease debugging the `workloadmeta` store

### Describe how to test your changes

To be tested in different environments: Docker, Kubernetes, ECS Fargate:
- Run `agent workload-list` and `agent workload-list --verbose`, make sure the output is accurate.
- Generate a flare (`agent flare`), make sure `workload-list.log` exists and contains the expected data.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
