### PR TITLE
[workloadmeta/containerd] Fix entity generation with SHA256 image names

### DIFF
--- a/pkg/workloadmeta/collectors/containerd/container_builder.go
+++ b/pkg/workloadmeta/collectors/containerd/container_builder.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build containerd
 // +build containerd
 
 package containerd
@@ -48,7 +49,7 @@ func buildWorkloadMetaContainer(container containerd.Container, containerdClient
 	imageName := containerdImage.Name()
 	image, err := workloadmeta.NewContainerImage(imageName)
 	if err != nil {
-		log.Warnf("cannot split image name %q: %s", imageName, err)
+		log.Debugf("cannot split image name %q: %s", imageName, err)
 	}
 
 	status, err := containerdClient.Status(container)

--- a/pkg/workloadmeta/collectors/containerd/container_builder.go
+++ b/pkg/workloadmeta/collectors/containerd/container_builder.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containerd/containerd/errdefs"
 
 	cutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
@@ -44,9 +45,10 @@ func buildWorkloadMetaContainer(container containerd.Container, containerdClient
 		return workloadmeta.Container{}, err
 	}
 
-	image, err := workloadmeta.NewContainerImage(containerdImage.Name())
+	imageName := containerdImage.Name()
+	image, err := workloadmeta.NewContainerImage(imageName)
 	if err != nil {
-		return workloadmeta.Container{}, err
+		log.Warnf("cannot split image name %q: %s", imageName, err)
 	}
 
 	status, err := containerdClient.Status(container)

--- a/pkg/workloadmeta/collectors/containerd/containerd.go
+++ b/pkg/workloadmeta/collectors/containerd/containerd.go
@@ -146,6 +146,7 @@ func (c *collector) generateEventsFromContainerList(ctx context.Context) error {
 		ev, err := buildCollectorEvent(ctx, &containerdEvent, c.containerdClient)
 		if err != nil {
 			log.Warnf(err.Error())
+			continue
 		}
 
 		events = append(events, ev)

--- a/pkg/workloadmeta/collectors/ecsfargate/ecsfargate.go
+++ b/pkg/workloadmeta/collectors/ecsfargate/ecsfargate.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build docker
 // +build docker
 
 package ecsfargate
@@ -151,7 +152,7 @@ func (c *collector) parseTaskContainers(task *v2.Task) ([]workloadmeta.Orchestra
 
 		image, err := workloadmeta.NewContainerImage(container.Image)
 		if err != nil {
-			log.Warnf("cannot split image name %q: %s", container.Image, err)
+			log.Debugf("cannot split image name %q: %s", container.Image, err)
 		}
 
 		ips := make(map[string]string)

--- a/pkg/workloadmeta/collectors/kubelet/kubelet.go
+++ b/pkg/workloadmeta/collectors/kubelet/kubelet.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build kubelet
 // +build kubelet
 
 package kubelet
@@ -174,7 +175,7 @@ func (c *collector) parsePodContainers(
 			var err error
 			image, err = workloadmeta.NewContainerImage(containerSpec.Image)
 			if err != nil {
-				log.Warnf("cannot split image name %q: %s", containerSpec.Image, err)
+				log.Debugf("cannot split image name %q: %s", containerSpec.Image, err)
 			}
 
 			ports = make([]workloadmeta.ContainerPort, 0, len(containerSpec.Ports))


### PR DESCRIPTION
### What does this PR do?

We found this error when loading the agent on GKE:

```
(pkg/workloadmeta/collectors/containerd/containerd.go:148 in generateEventsFromContainerList) | could not fetch info for container 583261d33f39dee2189a830a90f08bd3b7675dc074a7d91ac4dd7db64697976d: invalid image name (is a sha256)
(pkg/workloadmeta/collectors/containerd/containerd.go:148 in generateEventsFromContainerList) | could not fetch info for container 67502b7eae442fe4a37a8577473e3d345448d1046c737adc5af92f18ea9d1d5a: invalid image name (is a sha256)
(pkg/workloadmeta/collectors/containerd/containerd.go:148 in generateEventsFromContainerList) | could not fetch info for container 7c0d11d8827ef4095a850e89fc8327148f424c86f4e9e70800da7c3a67d5cbcd: invalid image name (is a sha256)
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x20 pc=0x2755637]

goroutine 296 [running]:
github.com/DataDog/datadog-agent/pkg/workloadmeta.(*store).handleEvents(0xc000b28880, 0xc0002a5200, 0x1c, 0x1c)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/store.go:351 +0xb7
github.com/DataDog/datadog-agent/pkg/workloadmeta.(*store).Start.func1(0xc000011278, 0xc000b486e0, 0xc000011290, 0x50ddaa0, 0xc00011e010, 0xc000b788d0, 0xc000b28880, 0xc000b48690)
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/store.go:136 +0x27f
created by github.com/DataDog/datadog-agent/pkg/workloadmeta.(*store).Start
	/omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/workloadmeta/store.go:121 +0x187
```

The reason is twofold:

1. We bail out from generating a container if we find that we cannot
   parse the image name. This does not need to be the case: we might
   still want the remaining information even if the ContainerImage
   struct is not fully formed.

2. When the containerd collector got an error when generating an event,
   we were missing a `continue`, so we added a malformed event to the
   list, which caused a nil pointer dereference down the line.

### Describe how to test your changes

Load the agent on a GKE cluster, make sure it does not crash.
