### PR TITLE
[workloadmeta] Make workload source a custom type

### DIFF
--- a/pkg/autodiscovery/listeners/container.go
+++ b/pkg/autodiscovery/listeners/container.go
@@ -36,7 +36,7 @@ func NewContainerListener() (ServiceListener, error) {
 	l := &ContainerListener{}
 	f := workloadmeta.NewFilter(
 		[]workloadmeta.Kind{workloadmeta.KindContainer},
-		[]string{"docker", "containerd"},
+		[]workloadmeta.Source{workloadmeta.SourceDocker, workloadmeta.SourceContainerd},
 	)
 
 	var err error

--- a/pkg/autodiscovery/listeners/ecs_fargate.go
+++ b/pkg/autodiscovery/listeners/ecs_fargate.go
@@ -30,7 +30,7 @@ func NewECSFargateListener() (ServiceListener, error) {
 	l := &ECSFargateListener{}
 	f := workloadmeta.NewFilter(
 		[]workloadmeta.Kind{workloadmeta.KindECSTask},
-		[]string{"ecs_fargate"},
+		[]workloadmeta.Source{workloadmeta.SourceECSFargate},
 	)
 
 	var err error

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -46,7 +46,7 @@ func NewKubeletListener() (ServiceListener, error) {
 	l := &KubeletListener{}
 	f := workloadmeta.NewFilter(
 		[]workloadmeta.Kind{workloadmeta.KindKubernetesPod},
-		[]string{"kubelet"},
+		[]workloadmeta.Source{workloadmeta.SourceKubelet},
 	)
 
 	var err error

--- a/pkg/autodiscovery/providers/container.go
+++ b/pkg/autodiscovery/providers/container.go
@@ -80,7 +80,7 @@ func (d *ContainerConfigProvider) listen() {
 
 	workloadmetaEventsChannel := d.workloadmetaStore.Subscribe("ad-containerprovider", workloadmeta.NewFilter(
 		[]workloadmeta.Kind{workloadmeta.KindContainer},
-		[]string{"docker", "containerd"},
+		[]workloadmeta.Source{workloadmeta.SourceDocker, workloadmeta.SourceContainerd},
 	))
 
 	for {

--- a/pkg/workloadmeta/collectors/containerd/event_builder.go
+++ b/pkg/workloadmeta/collectors/containerd/event_builder.go
@@ -60,7 +60,7 @@ func createSetEvent(ctx context.Context, containerID string, containerdClient cu
 
 	return workloadmeta.CollectorEvent{
 		Type:   workloadmeta.EventTypeSet,
-		Source: collectorID,
+		Source: workloadmeta.SourceContainerd,
 		Entity: &entity,
 	}, nil
 }
@@ -68,7 +68,7 @@ func createSetEvent(ctx context.Context, containerID string, containerdClient cu
 func createDeletionEvent(containerID string) workloadmeta.CollectorEvent {
 	return workloadmeta.CollectorEvent{
 		Type:   workloadmeta.EventTypeUnset,
-		Source: collectorID,
+		Source: workloadmeta.SourceContainerd,
 		Entity: workloadmeta.EntityID{
 			Kind: workloadmeta.KindContainer,
 			ID:   containerID,

--- a/pkg/workloadmeta/collectors/docker/docker.go
+++ b/pkg/workloadmeta/collectors/docker/docker.go
@@ -168,7 +168,7 @@ func (c *collector) handleEvent(ctx context.Context, ev *docker.ContainerEvent) 
 
 func (c *collector) buildCollectorEvent(ctx context.Context, ev *docker.ContainerEvent) (workloadmeta.CollectorEvent, error) {
 	event := workloadmeta.CollectorEvent{
-		Source: collectorID,
+		Source: workloadmeta.SourceDocker,
 	}
 
 	entityID := workloadmeta.EntityID{

--- a/pkg/workloadmeta/collectors/ecs/ecs.go
+++ b/pkg/workloadmeta/collectors/ecs/ecs.go
@@ -85,7 +85,7 @@ func (c *collector) Pull(ctx context.Context) error {
 	for _, expired := range expires {
 		events = append(events, workloadmeta.CollectorEvent{
 			Type:   workloadmeta.EventTypeUnset,
-			Source: collectorID,
+			Source: workloadmeta.SourceECS,
 			Entity: expired,
 		})
 	}
@@ -160,7 +160,7 @@ func (c *collector) parseTasks(ctx context.Context, tasks []v1.Task) []workloadm
 
 		events = append(events, containerEvents...)
 		events = append(events, workloadmeta.CollectorEvent{
-			Source: collectorID,
+			Source: workloadmeta.SourceECS,
 			Type:   workloadmeta.EventTypeSet,
 			Entity: entity,
 		})
@@ -189,7 +189,7 @@ func (c *collector) parseTaskContainers(task v1.Task) ([]workloadmeta.Orchestrat
 		c.expire.Update(entityID, now)
 
 		events = append(events, workloadmeta.CollectorEvent{
-			Source: collectorID,
+			Source: workloadmeta.SourceECS,
 			Type:   workloadmeta.EventTypeSet,
 			Entity: &workloadmeta.Container{
 				EntityID: entityID,

--- a/pkg/workloadmeta/collectors/ecsfargate/ecsfargate.go
+++ b/pkg/workloadmeta/collectors/ecsfargate/ecsfargate.go
@@ -74,7 +74,7 @@ func (c *collector) Pull(ctx context.Context) error {
 	for _, expired := range expires {
 		events = append(events, workloadmeta.CollectorEvent{
 			Type:   workloadmeta.EventTypeUnset,
-			Source: collectorID,
+			Source: workloadmeta.SourceECSFargate,
 			Entity: expired,
 		})
 	}
@@ -122,7 +122,7 @@ func (c *collector) parseTask(ctx context.Context, task *v2.Task) []workloadmeta
 
 	events = append(events, containerEvents...)
 	events = append(events, workloadmeta.CollectorEvent{
-		Source: collectorID,
+		Source: workloadmeta.SourceECSFargate,
 		Type:   workloadmeta.EventTypeSet,
 		Entity: entity,
 	})
@@ -171,7 +171,7 @@ func (c *collector) parseTaskContainers(task *v2.Task) ([]workloadmeta.Orchestra
 		}
 
 		events = append(events, workloadmeta.CollectorEvent{
-			Source: collectorID,
+			Source: workloadmeta.SourceECSFargate,
 			Type:   workloadmeta.EventTypeSet,
 			Entity: &workloadmeta.Container{
 				EntityID: entityID,

--- a/pkg/workloadmeta/collectors/kubelet/kubelet.go
+++ b/pkg/workloadmeta/collectors/kubelet/kubelet.go
@@ -134,7 +134,7 @@ func (c *collector) parsePods(pods []*kubelet.Pod) []workloadmeta.CollectorEvent
 
 		events = append(events, containerEvents...)
 		events = append(events, workloadmeta.CollectorEvent{
-			Source: collectorID,
+			Source: workloadmeta.SourceKubelet,
 			Type:   workloadmeta.EventTypeSet,
 			Entity: entity,
 		})
@@ -209,7 +209,7 @@ func (c *collector) parsePodContainers(
 
 		podContainers = append(podContainers, podContainer)
 		events = append(events, workloadmeta.CollectorEvent{
-			Source: collectorID,
+			Source: workloadmeta.SourceKubelet,
 			Type:   workloadmeta.EventTypeSet,
 			Entity: &workloadmeta.Container{
 				EntityID: workloadmeta.EntityID{
@@ -277,7 +277,7 @@ func (c *collector) parseExpires(expiredIDs []string) []workloadmeta.CollectorEv
 		}
 
 		events = append(events, workloadmeta.CollectorEvent{
-			Source: collectorID,
+			Source: workloadmeta.SourceKubelet,
 			Type:   workloadmeta.EventTypeUnset,
 			Entity: workloadmeta.EntityID{
 				Kind: kind,

--- a/pkg/workloadmeta/collectors/kubemetadata/kubemetadata.go
+++ b/pkg/workloadmeta/collectors/kubemetadata/kubemetadata.go
@@ -135,7 +135,7 @@ func (c *collector) Pull(ctx context.Context) error {
 	for _, expired := range expires {
 		events = append(events, workloadmeta.CollectorEvent{
 			Type:   workloadmeta.EventTypeUnset,
-			Source: collectorID,
+			Source: workloadmeta.SourceKubeMetadata,
 			Entity: expired,
 		})
 	}
@@ -214,7 +214,7 @@ func (c *collector) parsePods(ctx context.Context, pods []*kubelet.Pod) ([]workl
 		}
 
 		events = append(events, workloadmeta.CollectorEvent{
-			Source: collectorID,
+			Source: workloadmeta.SourceKubeMetadata,
 			Type:   workloadmeta.EventTypeSet,
 			Entity: entity,
 		})

--- a/pkg/workloadmeta/filter.go
+++ b/pkg/workloadmeta/filter.go
@@ -8,11 +8,11 @@ package workloadmeta
 // Filter allows a subscriber to filter events by entity kind or event source.
 type Filter struct {
 	kinds   map[Kind]struct{}
-	sources map[string]struct{}
+	sources map[Source]struct{}
 }
 
 // NewFilter creates a new filter for subscribing to workloadmeta events.
-func NewFilter(kinds []Kind, sources []string) *Filter {
+func NewFilter(kinds []Kind, sources []Source) *Filter {
 	var kindSet map[Kind]struct{}
 	if len(kinds) > 0 {
 		kindSet = make(map[Kind]struct{})
@@ -21,9 +21,9 @@ func NewFilter(kinds []Kind, sources []string) *Filter {
 		}
 	}
 
-	var sourceSet map[string]struct{}
+	var sourceSet map[Source]struct{}
 	if len(sources) > 0 {
-		sourceSet = make(map[string]struct{})
+		sourceSet = make(map[Source]struct{})
 		for _, s := range sources {
 			sourceSet[s] = struct{}{}
 		}
@@ -49,20 +49,20 @@ func (f *Filter) MatchKind(k Kind) bool {
 
 // MatchSource returns true if the filter matches the passed sources. If the
 // filter is nil, or has no sources, it always matches.
-func (f *Filter) MatchSource(source string) bool {
-	_, ok := f.SelectSources([]string{source})
+func (f *Filter) MatchSource(source Source) bool {
+	_, ok := f.SelectSources([]Source{source})
 
 	return ok
 }
 
 // SelectSources returns a subset of the passed sources that match the filter.
-func (f *Filter) SelectSources(sources []string) ([]string, bool) {
+func (f *Filter) SelectSources(sources []Source) ([]Source, bool) {
 	if f == nil || len(f.sources) == 0 {
 		return sources, true
 	}
 
 	var (
-		selectedSources []string
+		selectedSources []Source
 		found           bool
 	)
 

--- a/pkg/workloadmeta/filter_test.go
+++ b/pkg/workloadmeta/filter_test.go
@@ -65,7 +65,7 @@ func TestFilterMatch(t *testing.T) {
 			name: "matching single source",
 			filter: NewFilter(
 				nil,
-				[]string{fooSource},
+				[]Source{fooSource},
 			),
 			event:    ev,
 			expected: true,
@@ -74,7 +74,7 @@ func TestFilterMatch(t *testing.T) {
 			name: "matching one of sources",
 			filter: NewFilter(
 				nil,
-				[]string{fooSource, barSource},
+				[]Source{fooSource, barSource},
 			),
 			event:    ev,
 			expected: true,
@@ -83,7 +83,7 @@ func TestFilterMatch(t *testing.T) {
 			name: "matching no source",
 			filter: NewFilter(
 				nil,
-				[]string{barSource},
+				[]Source{barSource},
 			),
 			event:    ev,
 			expected: false,
@@ -93,7 +93,7 @@ func TestFilterMatch(t *testing.T) {
 			name: "matching source but not kind",
 			filter: NewFilter(
 				[]Kind{KindKubernetesPod},
-				[]string{fooSource},
+				[]Source{fooSource},
 			),
 			event:    ev,
 			expected: false,
@@ -102,7 +102,7 @@ func TestFilterMatch(t *testing.T) {
 			name: "matching kind but not source",
 			filter: NewFilter(
 				[]Kind{KindContainer},
-				[]string{barSource},
+				[]Source{barSource},
 			),
 			event:    ev,
 			expected: false,
@@ -111,7 +111,7 @@ func TestFilterMatch(t *testing.T) {
 			name: "matching both kind and source",
 			filter: NewFilter(
 				[]Kind{KindContainer},
-				[]string{fooSource},
+				[]Source{fooSource},
 			),
 			event:    ev,
 			expected: true,

--- a/pkg/workloadmeta/store.go
+++ b/pkg/workloadmeta/store.go
@@ -35,9 +35,9 @@ type subscriber struct {
 	filter *Filter
 }
 
-type sourceToEntity map[string]Entity
+type sourceToEntity map[Source]Entity
 
-func (s sourceToEntity) merge(sources []string) Entity {
+func (s sourceToEntity) merge(sources []Source) Entity {
 	if len(sources) == 0 {
 		sources = s.sources()
 	}
@@ -59,14 +59,14 @@ func (s sourceToEntity) merge(sources []string) Entity {
 	return merged
 }
 
-func (s sourceToEntity) sources() []string {
-	sources := make([]string, 0, len(s))
+func (s sourceToEntity) sources() []Source {
+	sources := make([]Source, 0, len(s))
 
 	for source := range s {
 		sources = append(sources, source)
 	}
 
-	sort.Strings(sources)
+	sort.SliceStable(sources, func(i, j int) bool { return sources[i] < sources[j] })
 
 	return sources
 }
@@ -397,7 +397,7 @@ func (s *store) handleEvents(evs []CollectorEvent) {
 
 		for _, ev := range evs {
 			entityID := ev.Entity.GetID()
-			evSources, ok := filter.SelectSources([]string{ev.Source})
+			evSources, ok := filter.SelectSources([]Source{ev.Source})
 
 			if !filter.MatchKind(entityID.Kind) || !ok {
 				// event should be filtered out because it

--- a/pkg/workloadmeta/store_test.go
+++ b/pkg/workloadmeta/store_test.go
@@ -129,7 +129,7 @@ func TestSubscribe(t *testing.T) {
 					Events: []Event{
 						{
 							Type:    EventTypeSet,
-							Sources: []string{fooSource},
+							Sources: []Source{fooSource},
 							Entity:  fooContainer,
 						},
 					},
@@ -143,7 +143,7 @@ func TestSubscribe(t *testing.T) {
 			// the filter. entities that don't match the filter at
 			// all should not generate an event.
 			name:   "receive events for entities in the store pre-subscription with filter",
-			filter: NewFilter(nil, []string{fooSource}),
+			filter: NewFilter(nil, []Source{fooSource}),
 			preEvents: []CollectorEvent{
 				// set container with two sources, delete one source
 				{
@@ -187,12 +187,12 @@ func TestSubscribe(t *testing.T) {
 					Events: []Event{
 						{
 							Type:    EventTypeSet,
-							Sources: []string{fooSource},
+							Sources: []Source{fooSource},
 							Entity:  barContainer,
 						},
 						{
 							Type:    EventTypeSet,
-							Sources: []string{fooSource},
+							Sources: []Source{fooSource},
 							Entity:  fooContainer,
 						},
 					},
@@ -223,7 +223,7 @@ func TestSubscribe(t *testing.T) {
 					Events: []Event{
 						{
 							Type:    EventTypeSet,
-							Sources: []string{fooSource},
+							Sources: []Source{fooSource},
 							Entity: &Container{
 								EntityID: fooContainer.EntityID,
 								EntityMeta: EntityMeta{
@@ -238,7 +238,7 @@ func TestSubscribe(t *testing.T) {
 					Events: []Event{
 						{
 							Type:    EventTypeSet,
-							Sources: []string{barSource, fooSource},
+							Sources: []Source{barSource, fooSource},
 							Entity: &Container{
 								EntityID: fooContainer.EntityID,
 								EntityMeta: EntityMeta{
@@ -274,7 +274,7 @@ func TestSubscribe(t *testing.T) {
 					Events: []Event{
 						{
 							Type:    EventTypeSet,
-							Sources: []string{barSource, fooSource},
+							Sources: []Source{barSource, fooSource},
 							Entity: &Container{
 								EntityID: fooContainer.EntityID,
 								EntityMeta: EntityMeta{
@@ -311,7 +311,7 @@ func TestSubscribe(t *testing.T) {
 					Events: []Event{
 						{
 							Type:    EventTypeSet,
-							Sources: []string{fooSource},
+							Sources: []Source{fooSource},
 							Entity:  fooContainer,
 						},
 					},
@@ -320,7 +320,7 @@ func TestSubscribe(t *testing.T) {
 					Events: []Event{
 						{
 							Type:    EventTypeUnset,
-							Sources: []string{fooSource},
+							Sources: []Source{fooSource},
 							Entity:  fooContainer.GetID(),
 						},
 					},
@@ -332,7 +332,7 @@ func TestSubscribe(t *testing.T) {
 			// unsetting from only one (that matches the filter)
 			// correctly generates an unset event
 			name:   "sets and unsets an entity with source filters",
-			filter: NewFilter(nil, []string{fooSource}),
+			filter: NewFilter(nil, []Source{fooSource}),
 			postEvents: [][]CollectorEvent{
 				{
 					{
@@ -361,7 +361,7 @@ func TestSubscribe(t *testing.T) {
 					Events: []Event{
 						{
 							Type:    EventTypeSet,
-							Sources: []string{fooSource},
+							Sources: []Source{fooSource},
 							Entity:  fooContainer,
 						},
 					},
@@ -370,7 +370,7 @@ func TestSubscribe(t *testing.T) {
 					Events: []Event{
 						{
 							Type:    EventTypeUnset,
-							Sources: []string{fooSource},
+							Sources: []Source{fooSource},
 							Entity:  fooContainer.GetID(),
 						},
 					},

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -34,6 +34,9 @@ type Store interface {
 // Kind is the kind of an entity.
 type Kind string
 
+// Source is the source name of an entity.
+type Source string
+
 // ContainerRuntime is the container runtime used by a container.
 type ContainerRuntime string
 
@@ -48,6 +51,13 @@ const (
 	KindContainer     Kind = "container"
 	KindKubernetesPod Kind = "kubernetes_pod"
 	KindECSTask       Kind = "ecs_task"
+
+	SourceDocker       Source = "docker"
+	SourceContainerd   Source = "containerd"
+	SourceECS          Source = "ecs"
+	SourceECSFargate   Source = "ecs_fargate"
+	SourceKubelet      Source = "kubelet"
+	SourceKubeMetadata Source = "kube_metadata"
 
 	ContainerRuntimeDocker     ContainerRuntime = "docker"
 	ContainerRuntimeContainerd ContainerRuntime = "containerd"
@@ -282,7 +292,7 @@ var _ Entity = &ECSTask{}
 // by the metadata store.
 type CollectorEvent struct {
 	Type   EventType
-	Source string
+	Source Source
 	Entity Entity
 }
 
@@ -290,7 +300,7 @@ type CollectorEvent struct {
 // subscribers.
 type Event struct {
 	Type    EventType
-	Sources []string
+	Sources []Source
 	Entity  Entity
 }
 


### PR DESCRIPTION
### What does this PR do?

Make workload source a custom type

### Motivation

Reduce the risk of typos in the workloadmeta collectors and consumers

### Describe how to test your changes

no-op

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
