### PR TITLE
[workloadmeta] Separate pulling and event processing

### DIFF
--- a/pkg/workloadmeta/store.go
+++ b/pkg/workloadmeta/store.go
@@ -109,16 +109,36 @@ func NewStore(catalog map[string]collectorFactory) Store {
 
 // Start starts the workload metadata store.
 func (s *store) Start(ctx context.Context) {
-	retryTicker := time.NewTicker(retryCollectorInterval)
-	pullTicker := time.NewTicker(pullCollectorInterval)
-	health := health.RegisterLiveness("workloadmeta-store")
-
-	pullCtx, pullCancel := context.WithTimeout(ctx, pullCollectorInterval)
-
-	// Start processing events before starting collectors, as in some cases
-	// they may be able to generate more events than what fits in eventCh's
-	// buffer, and the store will deadlock.
 	go func() {
+		health := health.RegisterLiveness("workloadmeta-store")
+		for {
+			select {
+			case <-health.C:
+
+			case evs := <-s.eventCh:
+				s.handleEvents(evs)
+
+			case <-ctx.Done():
+				err := health.Deregister()
+				if err != nil {
+					log.Warnf("error de-registering health check: %s", err)
+				}
+
+				return
+			}
+		}
+	}()
+
+	go func() {
+		retryTicker := time.NewTicker(retryCollectorInterval)
+		pullTicker := time.NewTicker(pullCollectorInterval)
+		health := health.RegisterLiveness("workloadmeta-puller")
+		pullCtx, pullCancel := context.WithTimeout(ctx, pullCollectorInterval)
+
+		// Start a pull immediately to fill the store without waiting for the
+		// next tick.
+		s.pull(pullCtx)
+
 		for {
 			select {
 			case <-health.C:
@@ -132,9 +152,6 @@ func (s *store) Start(ctx context.Context) {
 				pullCtx, pullCancel = context.WithTimeout(ctx, pullCollectorInterval)
 				s.pull(pullCtx)
 
-			case evs := <-s.eventCh:
-				s.handleEvents(evs)
-
 			case <-retryTicker.C:
 				stop := s.startCandidates(ctx)
 
@@ -146,6 +163,8 @@ func (s *store) Start(ctx context.Context) {
 				retryTicker.Stop()
 				pullTicker.Stop()
 
+				pullCancel()
+
 				err := health.Deregister()
 				if err != nil {
 					log.Warnf("error de-registering health check: %s", err)
@@ -156,12 +175,7 @@ func (s *store) Start(ctx context.Context) {
 		}
 	}()
 
-	// Start collectors immediately
 	s.startCandidates(ctx)
-
-	// Start a pull immediately to fill the store without waiting for the
-	// next tick.
-	s.pull(pullCtx)
 
 	log.Info("workloadmeta store initialized successfully")
 }


### PR DESCRIPTION
### What does this PR do?

This applies the same strategy as #8830, for a related (albeit much
rarer) reason. The store could still deadlock if the initial
`startCandidates` held a lock on collectorMut for long enough to a
`pullTicker` to trigger, and caused enough events to be generated to
fill up `eventCh`. In that case, `startCandidates` will be blocked on
any sends to `eventCh`, and the store goroutine will be stuck `pull`
waiting for `startCandidates` to release its lock.

As a bonus, this also fixes a data race on `pullCtx` and `pullCancel`
being written to (in the <-retryTicker case) while they're being read
(in the main goroutine).

### Describe how to test your changes

The actual deadlock has not been observed in the wild (it came as a sort of a shower thought), so verifying that the store does not deadlock (by checking `agent health`) is enough. The data race was, though, so we need to run the integration tests a few times successfully to make sure it's gone.