### PR TITLE
Remove code duplication with a http.Get helper

### DIFF
--- a/pkg/util/alibaba/alibaba.go
+++ b/pkg/util/alibaba/alibaba.go
@@ -8,8 +8,6 @@ package alibaba
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -37,10 +35,19 @@ func IsRunningOn(ctx context.Context) bool {
 var instanceIDFetcher = cachedfetch.Fetcher{
 	Name: "Alibaba InstanceID",
 	Attempt: func(ctx context.Context) (interface{}, error) {
-		res, err := getResponseWithMaxLength(ctx, metadataURL+"/latest/meta-data/instance-id",
-			config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
+
+		if !config.IsCloudProviderEnabled(CloudProviderName) {
+			return "", fmt.Errorf("cloud provider is disabled by configuration")
+		}
+
+		endpoint := metadataURL + "/latest/meta-data/instance-id"
+		res, err := httputils.Get(ctx, endpoint, nil, timeout)
 		if err != nil {
 			return "", fmt.Errorf("Alibaba HostAliases: unable to query metadata endpoint: %s", err)
+		}
+		maxLength := config.Datadog.GetInt("metadata_endpoints_max_hostname_size")
+		if len(res) > maxLength {
+			return "", fmt.Errorf("%v gave a response with length > to %v", endpoint, maxLength)
 		}
 		return res, err
 	},
@@ -64,48 +71,4 @@ func GetNTPHosts(ctx context.Context) []string {
 	}
 
 	return nil
-}
-
-func getResponseWithMaxLength(ctx context.Context, endpoint string, maxLength int) (string, error) {
-	result, err := getResponse(ctx, endpoint)
-	if err != nil {
-		return result, err
-	}
-	if len(result) > maxLength {
-		return "", fmt.Errorf("%v gave a response with length > to %v", endpoint, maxLength)
-	}
-	return result, err
-}
-
-func getResponse(ctx context.Context, url string) (string, error) {
-	if !config.IsCloudProviderEnabled(CloudProviderName) {
-		return "", fmt.Errorf("cloud provider is disabled by configuration")
-	}
-
-	client := http.Client{
-		Transport: httputils.CreateHTTPTransport(),
-		Timeout:   timeout,
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return "", err
-	}
-
-	res, err := client.Do(req)
-	if err != nil {
-		return "", err
-	}
-
-	if res.StatusCode != 200 {
-		return "", fmt.Errorf("status code %d trying to GET %s", res.StatusCode, url)
-	}
-
-	defer res.Body.Close()
-	all, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return "", fmt.Errorf("error while reading response from alibaba metadata endpoint: %s", err)
-	}
-
-	return string(all), nil
 }

--- a/pkg/util/azure/azure.go
+++ b/pkg/util/azure/azure.go
@@ -9,8 +9,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"strings"
 	"time"
 
@@ -111,33 +109,7 @@ func getResponse(ctx context.Context, url string) (string, error) {
 		return "", fmt.Errorf("cloud provider is disabled by configuration")
 	}
 
-	client := http.Client{
-		Transport: httputils.CreateHTTPTransport(),
-		Timeout:   timeout,
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return "", err
-	}
-
-	req.Header.Add("Metadata", "true")
-	res, err := client.Do(req)
-	if err != nil {
-		return "", err
-	}
-
-	if res.StatusCode != 200 {
-		return "", fmt.Errorf("status code %d trying to GET %s", res.StatusCode, url)
-	}
-
-	defer res.Body.Close()
-	all, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return "", fmt.Errorf("error while reading response from azure metadata endpoint: %s", err)
-	}
-
-	return string(all), nil
+	return httputils.Get(ctx, url, map[string]string{"Metadata": "true"}, timeout)
 }
 
 // GetHostname returns hostname based on Azure instance metadata.

--- a/pkg/util/http/helpers.go
+++ b/pkg/util/http/helpers.go
@@ -1,0 +1,48 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package http
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"time"
+)
+
+// Get is a high level helper to query an url and return its body as a string
+func Get(ctx context.Context, url string, headers map[string]string, timeout time.Duration) (string, error) {
+	client := http.Client{
+		Transport: CreateHTTPTransport(),
+		Timeout:   timeout,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	for header, value := range headers {
+		req.Header.Add(header, value)
+	}
+
+	res, err := client.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	if res.StatusCode != 200 {
+		return "", fmt.Errorf("status code %d trying to GET %s", res.StatusCode, url)
+	}
+
+	defer res.Body.Close()
+	all, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return "", fmt.Errorf("error while reading response from oraclecloud metadata endpoint: %s", err)
+	}
+
+	return string(all), nil
+}

--- a/pkg/util/http/helpers_test.go
+++ b/pkg/util/http/helpers_test.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package http
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGet(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("test ok"))
+	}))
+	defer ts.Close()
+
+	res, err := Get(context.Background(), ts.URL, nil, 5*time.Second)
+
+	require.NoError(t, err)
+	assert.Equal(t, "test ok", res)
+}
+
+func TestGetHeader(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		assert.Equal(t, "value", r.Header.Get("header"))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("test ok"))
+	}))
+	defer ts.Close()
+
+	res, err := Get(context.Background(), ts.URL, map[string]string{"header": "value"}, 5*time.Second)
+
+	require.NoError(t, err)
+	assert.Equal(t, "test ok", res)
+}
+
+func TestGetTimeout(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		time.Sleep(5 * time.Second)
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("test ok"))
+	}))
+	defer ts.Close()
+
+	_, err := Get(context.Background(), ts.URL, map[string]string{"header": "value"}, 100*time.Millisecond)
+
+	require.Error(t, err)
+}
+
+func TestGetError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "GET", r.Method)
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte("test ok"))
+	}))
+	defer ts.Close()
+
+	_, err := Get(context.Background(), ts.URL, map[string]string{"header": "value"}, 5*time.Second)
+
+	require.Error(t, err)
+}

--- a/pkg/util/tencent/tencent.go
+++ b/pkg/util/tencent/tencent.go
@@ -8,12 +8,11 @@ package tencent
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
-	"net/http"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/cachedfetch"
+	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -87,38 +86,9 @@ func getMetadataItem(ctx context.Context, endpoint string) (string, error) {
 		return "", fmt.Errorf("cloud provider is disabled by configuration")
 	}
 
-	res, err := getResponse(ctx, endpoint)
+	res, err := httputils.Get(ctx, endpoint, nil, timeout)
 	if err != nil {
 		return "", fmt.Errorf("unable to fetch Tencent Metadata API, %s", err)
 	}
-
-	defer res.Body.Close()
-	all, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return "", fmt.Errorf("unable to read response body, %s", err)
-	}
-
-	return string(all), nil
-}
-
-func getResponse(ctx context.Context, url string) (*http.Response, error) {
-	client := http.Client{
-		Timeout: timeout,
-	}
-
-	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	res, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-
-	if res.StatusCode != 200 {
-		return nil, fmt.Errorf("status code %d trying to fetch %s", res.StatusCode, url)
-	}
-
 	return res, nil
 }


### PR DESCRIPTION
### What does this PR do?

All cloud metadata provider had duplicated code to "Get" a HTTP endpoint. This is now replace by an helper.
### Motivation

This will make adding new cloud provider easier

### Additional Notes


### Describe how to test your changes

Deploy the agent somewhere (any cloud provider) and double check the metadata are still being collected.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
