### PR TITLE
[networks] Rename ENV var

### DIFF
--- a/pkg/network/http/shared_libraries.go
+++ b/pkg/network/http/shared_libraries.go
@@ -69,7 +69,7 @@ func newSOWatcher(procRoot string, perfHandler *ddebpf.PerfHandler, rules ...soR
 	all := regexp.MustCompile(fmt.Sprintf("(%s)", strings.Join(allFilters, "|")))
 	return &soWatcher{
 		procRoot:   procRoot,
-		hostMount:  os.Getenv("HOST_FS"),
+		hostMount:  os.Getenv("HOST_ROOT"),
 		all:        all,
 		rules:      rules,
 		loadEvents: perfHandler,


### PR DESCRIPTION
### What does this PR do?

Use same environment variable name used by the security module to designate the host root.

### Motivation

Standardize the names of environment variables used in the agent.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

No QA required.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
