### PR TITLE
[Serverless] fix arn should be lowercased in telemetry

### DIFF
--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -10,6 +10,7 @@ import (
 	"encoding/json"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
@@ -389,7 +390,7 @@ func (d *Daemon) setTraceTags(tagMap map[string]string) bool {
 
 // SetExecutionContext sets the current context to the daemon
 func (d *Daemon) SetExecutionContext(arn string, requestID string) {
-	d.ExecutionContext.ARN = arn
+	d.ExecutionContext.ARN = strings.ToLower(arn)
 	d.ExecutionContext.LastRequestID = requestID
 	if len(d.ExecutionContext.ColdstartRequestID) == 0 {
 		d.ExecutionContext.Coldstart = true

--- a/pkg/serverless/daemon/daemon_test.go
+++ b/pkg/serverless/daemon/daemon_test.go
@@ -120,3 +120,29 @@ func TestSetTraceTagOk(t *testing.T) {
 	}
 	assert.True(t, d.setTraceTags(tagsMap))
 }
+
+func TestSetExecutionContextUppercase(t *testing.T) {
+	assert := assert.New(t)
+	d := StartDaemon("http://localhost:8124")
+	defer d.Stop()
+	testArn := "arn:aws:lambda:us-east-1:123456789012:function:MY-SUPER-function"
+	testRequestID := "8286a188-ba32-4475-8077-530cd35c09a9"
+	d.SetExecutionContext(testArn, testRequestID)
+	assert.Equal("arn:aws:lambda:us-east-1:123456789012:function:my-super-function", d.ExecutionContext.ARN)
+	assert.Equal(testRequestID, d.ExecutionContext.LastRequestID)
+	assert.Equal(true, d.ExecutionContext.Coldstart)
+	assert.Equal(testRequestID, d.ExecutionContext.ColdstartRequestID)
+}
+
+func TestSetExecutionContextNoColdstart(t *testing.T) {
+	assert := assert.New(t)
+	d := StartDaemon("http://localhost:8124")
+	defer d.Stop()
+	d.ExecutionContext.ColdstartRequestID = "coldstart-request-id"
+	testArn := "arn:aws:lambda:us-east-1:123456789012:function:MY-SUPER-function"
+	testRequestID := "8286a188-ba32-4475-8077-530cd35c09a9"
+	d.SetExecutionContext(testArn, testRequestID)
+	assert.Equal("arn:aws:lambda:us-east-1:123456789012:function:my-super-function", d.ExecutionContext.ARN)
+	assert.Equal(testRequestID, d.ExecutionContext.LastRequestID)
+	assert.Equal(false, d.ExecutionContext.Coldstart)
+}


### PR DESCRIPTION
### What does this PR do?

This fix was already done here : https://github.com/DataDog/datadog-agent/pull/9408 but forgotten while release v12.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
