### PR TITLE
[Dockerfiles/Windows] Fix script to run the ECS Fargate check

### DIFF
--- a/Dockerfiles/agent/entrypoint-ps1/02-set-env-vars.ps1
+++ b/Dockerfiles/agent/entrypoint-ps1/02-set-env-vars.ps1
@@ -1,7 +1,7 @@
 # Set process environment variables (from Docker) from Process to Machine level to allow Windows Services
 # (process-agent, trace-agent) to get their configuration properly
 foreach($key in [System.Environment]::GetEnvironmentVariables([System.EnvironmentVariableTarget]::Process).Keys) {
-	if ($key.StartsWith("DD_") -Or $key -Like "*PROXY*") {
+	if ($key.StartsWith("DD_") -Or $key -Like "*PROXY*" -Or $key -eq "ECS_FARGATE" -Or $key -eq "AWS_EXECUTION_ENV") {
 		Write-Output "Setting ENV var: $key to machine scope"
 		$value = [System.Environment]::GetEnvironmentVariable($key, [System.EnvironmentVariableTarget]::Process)
 		[System.Environment]::SetEnvironmentVariable($key, $value, [System.EnvironmentVariableTarget]::Machine)

--- a/releasenotes/notes/ecs-fargate-windows-setup-envs-82a56e5d2768d311.yaml
+++ b/releasenotes/notes/ecs-fargate-windows-setup-envs-82a56e5d2768d311.yaml
@@ -1,0 +1,5 @@
+---
+fixes:
+  - |
+    Fixed Windows Dockerfile scripts to make the ECS Fargate Python check run
+    when the agent is deployed in ECS Fargate Windows.


### PR DESCRIPTION
### What does this PR do?

Sets the ENVs that we need to enable the ECS Fargate Python check in the `entrypoint-ps1/02-set-env-vars.ps1` script, which is used by the Windows Dockerfile.

We rely on a couple of ENVs to detect that the agent is running on ECS Fargate: `ECS_FARGATE` and `AWS_EXECUTION_ENV`. See:
- https://github.com/DataDog/datadog-agent/blob/d7dfbc25b167c73e6603b0eb31c2b4755cdc1cf6/pkg/config/environment.go#L49
- https://github.com/DataDog/datadog-agent/blob/be59410d2c6d6321289287d8563e2c17493f369f/pkg/util/ecs/detection.go#L53

When I ran the agent in ECS Fargate Windows, I realized that those 2 were not being set, so the Agent did not enable the ECS Fargate Python check. With the changes introduced in this PR the check runs, but it does not report anything because it gives an error while parsing the Fargate responses. This is something that will need to be fixed in the integrations-core repo.

### Describe how to test your changes

Run the agent on ECS Fargate. When configuring the task make sure to select "Windows Server 2019" as the Operating System.

You should see in the logs that the ECS Fargate feature has been detected (`Features detected from environment: ecsfargate`). You should also see the check running (`check:ecs_fargate | Running check...`). Notice that right now the check does not report any data (you'll see some errors). As mentioned above, this needs to be fixed in the integrations-core repo.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
