### PR TITLE
[corechecks/snmp] Set device id as instance name

### DIFF
--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -215,6 +215,25 @@ func (c *Data) GetNameForInstance() string {
 	return commonOptions.Namespace
 }
 
+// SetNameForInstance set name for instance
+func (c *Data) SetNameForInstance(name string) error {
+	commonOptions := CommonInstanceConfig{}
+	err := yaml.Unmarshal(*c, &commonOptions)
+	if err != nil {
+		return fmt.Errorf("invalid instance section: %s", err)
+	}
+	commonOptions.Name = name
+
+	// modify original config
+	out, err := yaml.Marshal(&commonOptions)
+	if err != nil {
+		return err
+	}
+	*c = Data(out)
+
+	return nil
+}
+
 // MergeAdditionalTags merges additional tags to possible existing config tags
 func (c *Data) MergeAdditionalTags(tags []string) error {
 	rawConfig := RawMap{}

--- a/pkg/autodiscovery/integration/config_test.go
+++ b/pkg/autodiscovery/integration/config_test.go
@@ -262,6 +262,19 @@ func TestGetNameForInstance(t *testing.T) {
 	assert.Equal(t, config.Instances[0].GetNameForInstance(), "")
 }
 
+func TestSetNameForInstance(t *testing.T) {
+	config := &Config{}
+
+	config.Name = "foo"
+	config.InitConfig = Data("fooBarBaz")
+	config.Instances = []Data{Data("name: foobar")}
+	assert.Equal(t, config.Instances[0].GetNameForInstance(), "foobar")
+
+	err := config.Instances[0].SetNameForInstance("new-name")
+	assert.NoError(t, err)
+	assert.Equal(t, config.Instances[0].GetNameForInstance(), "new-name")
+}
+
 // this is here to prevent compiler optimization on the benchmarking code
 var result string
 

--- a/pkg/collector/corechecks/snmp/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config.go
@@ -65,6 +65,7 @@ type InitConfig struct {
 
 // InstanceConfig is used to deserialize integration instance config
 type InstanceConfig struct {
+	Name                  string            `yaml:"name"`
 	IPAddress             string            `yaml:"ip_address"`
 	Port                  Number            `yaml:"port"`
 	CommunityString       string            `yaml:"community_string"`
@@ -116,6 +117,7 @@ type InstanceConfig struct {
 
 // CheckConfig holds config needed for an integration instance to run
 type CheckConfig struct {
+	Name                  string
 	IPAddress             string
 	Port                  uint16
 	CommunityString       string
@@ -260,6 +262,7 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 
 	c := &CheckConfig{}
 
+	c.Name = instance.Name
 	c.SnmpVersion = instance.SnmpVersion
 	c.IPAddress = instance.IPAddress
 	c.Port = uint16(instance.Port)

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -104,7 +104,8 @@ func (c *Check) Configure(rawInstance integration.Data, rawInitConfig integratio
 	}
 	log.Debugf("SNMP configuration: %s", c.config.ToString())
 
-	if rawInstance.GetNameForInstance() == "" {
+	instanceName := rawInstance.GetNameForInstance()
+	if instanceName == "" || instanceName == c.config.Namespace {
 		setNameErr := rawInstance.SetNameForInstance(c.config.DeviceID)
 		if setNameErr != nil {
 			log.Debugf("error setting device_id as name: %s", setNameErr)

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -104,8 +104,10 @@ func (c *Check) Configure(rawInstance integration.Data, rawInitConfig integratio
 	}
 	log.Debugf("SNMP configuration: %s", c.config.ToString())
 
-	instanceName := rawInstance.GetNameForInstance()
-	if instanceName == "" || instanceName == c.config.Namespace {
+	if c.config.Name == "" {
+		// Set 'name' field of the instance if not already defined in rawInstance config.
+		// The name/device_id will be used by Check.BuildID for building the check id.
+		// Example of check id: `snmp:<DEVICE_ID>:a3ec59dfb03e4457`
 		setNameErr := rawInstance.SetNameForInstance(c.config.DeviceID)
 		if setNameErr != nil {
 			log.Debugf("error setting device_id as name: %s", setNameErr)

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -717,8 +717,8 @@ community_string: abc
 	err = check2.Configure(rawInstanceConfig2, []byte(``), "test")
 	assert.Nil(t, err)
 
-	assert.Equal(t, check.ID("snmp:ed97702503abb6ec"), check1.ID())
-	assert.Equal(t, check.ID("snmp:e4bdb13416d918f4"), check2.ID())
+	assert.Equal(t, check.ID("snmp:default:1.1.1.1:a3ec59dfb03e4457"), check1.ID())
+	assert.Equal(t, check.ID("snmp:default:2.2.2.2:3979cd473e4beb3f"), check2.ID())
 	assert.NotEqual(t, check1.ID(), check2.ID())
 }
 

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -700,6 +700,7 @@ func TestCheckID(t *testing.T) {
 	checkconfig.SetConfdPathAndCleanProfiles()
 	check1 := snmpFactory()
 	check2 := snmpFactory()
+	check3 := snmpFactory()
 	// language=yaml
 	rawInstanceConfig1 := []byte(`
 ip_address: 1.1.1.1
@@ -710,15 +711,23 @@ community_string: abc
 ip_address: 2.2.2.2
 community_string: abc
 `)
+	// language=yaml
+	rawInstanceConfig3 := []byte(`
+ip_address: 3.3.3.3
+community_string: abc
+namespace: ns3
+`)
 
 	err := check1.Configure(rawInstanceConfig1, []byte(``), "test")
 	assert.Nil(t, err)
-
 	err = check2.Configure(rawInstanceConfig2, []byte(``), "test")
+	assert.Nil(t, err)
+	err = check3.Configure(rawInstanceConfig3, []byte(``), "test")
 	assert.Nil(t, err)
 
 	assert.Equal(t, check.ID("snmp:default:1.1.1.1:a3ec59dfb03e4457"), check1.ID())
 	assert.Equal(t, check.ID("snmp:default:2.2.2.2:3979cd473e4beb3f"), check2.ID())
+	assert.Equal(t, check.ID("snmp:ns3:3.3.3.3:819516f4c3986cc6"), check3.ID())
 	assert.NotEqual(t, check1.ID(), check2.ID())
 }
 


### PR DESCRIPTION
### What does this PR do?

Set check_id as instance name. 

Instance name will be then used as part of check_id, that will be displayed in Agent Status.

### Motivation

When looking at flares, it happen often that we need to look at both status.log and configcheck.log to know what’s the status of a device with specific IP addr. Having device_id (namespace+IP) should avoid this extra time consuming manual lookup.

### Additional Notes

Example:

```
    snmp
    ----
      Instance ID: snmp:default:127.0.0.1:2129722a1974d2d3 [OK]
      Configuration Source: file:/opt/datadog-agent/etc/conf.d/snmp.d/conf.yaml
      Total Runs: 2
      Metric Samples: Last Run: 938, Total: 1,876
      Events: Last Run: 0, Total: 0
      Network Devices Metadata: Last Run: 1, Total: 2
      Service Checks: Last Run: 1, Total: 2
      Average Execution Time : 1.329s
      Last Execution Date : 2021-10-29 11:40:46 CEST / 2021-10-29 09:40:46 UTC (1635500446000)
      Last Successful Execution Date : 2021-10-29 11:40:46 CEST / 2021-10-29 09:40:46 UTC (1635500446000)

      Instance ID: snmp:ns1:127.0.0.1:fab57405014b31e6 [OK]
      Configuration Source: file:/opt/datadog-agent/etc/conf.d/snmp.d/conf.yaml
      Total Runs: 1
      Metric Samples: Last Run: 938, Total: 938
      Events: Last Run: 0, Total: 0
      Network Devices Metadata: Last Run: 1, Total: 1
      Service Checks: Last Run: 1, Total: 1
      Average Execution Time : 1.018s
      Last Execution Date : 2021-10-29 11:40:38 CEST / 2021-10-29 09:40:38 UTC (1635500438000)
      Last Successful Execution Date : 2021-10-29 11:40:38 CEST / 2021-10-29 09:40:38 UTC (1635500438000)

      Instance ID: snmp:ns2:127.0.0.1:88f27aebd184c0a5 [OK]
      Configuration Source: file:/opt/datadog-agent/etc/conf.d/snmp.d/conf.yaml
      Total Runs: 1
      Metric Samples: Last Run: 938, Total: 938
      Events: Last Run: 0, Total: 0
      Network Devices Metadata: Last Run: 1, Total: 1
      Service Checks: Last Run: 1, Total: 1
      Average Execution Time : 1.086s
      Last Execution Date : 2021-10-29 11:40:45 CEST / 2021-10-29 09:40:45 UTC (1635500445000)
      Last Successful Execution Date : 2021-10-29 11:40:45 CEST / 2021-10-29 09:40:45 UTC (1635500445000)
```

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
