### PR TITLE
[runtime-security] Use a 1 minute ticker for the containers_running metric

### DIFF
--- a/pkg/compliance/agent/telemetry.go
+++ b/pkg/compliance/agent/telemetry.go
@@ -40,7 +40,7 @@ func (t *telemetry) run(ctx context.Context) {
 	log.Info("Start collecting Compliance telemetry")
 	defer log.Info("Stopping Compliance telemetry")
 
-	metricsTicker := time.NewTicker(2 * time.Minute)
+	metricsTicker := time.NewTicker(1 * time.Minute)
 	defer metricsTicker.Stop()
 
 	for {

--- a/pkg/security/agent/telemetry.go
+++ b/pkg/security/agent/telemetry.go
@@ -45,7 +45,7 @@ func (t *telemetry) run(ctx context.Context) {
 	log.Info("started collecting Runtime Security Agent telemetry")
 	defer log.Info("stopping Runtime Security Agent telemetry")
 
-	metricsTicker := time.NewTicker(5 * time.Minute)
+	metricsTicker := time.NewTicker(1 * time.Minute)
 	defer metricsTicker.Stop()
 
 	for {


### PR DESCRIPTION
### What does this PR do?

This PR changes the `containers_running` metric ticker for CWS from 5 minutes to 1 minute.

### Motivation

This will make sure that we get multiple data points per window of 5 minutes.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
