### PR TITLE
[tagger] Prevent workloadmeta fetches from overwriting good tags

### DIFF
--- a/pkg/tagger/collectors/workloadmeta_main.go
+++ b/pkg/tagger/collectors/workloadmeta_main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gobwas/glob"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -96,7 +97,7 @@ func (c *WorkloadMetaCollector) Stop() error {
 // workloadmeta.Store will eventually own notifying all downstream consumers,
 // this codepath should never trigger anyway.
 func (c *WorkloadMetaCollector) Fetch(ctx context.Context, entity string) ([]string, []string, []string, error) {
-	return nil, nil, nil, nil
+	return nil, nil, nil, errors.NewNotFound(entity)
 }
 
 func workloadmetaFactory() Collector {


### PR DESCRIPTION
### What does this PR do?

This fixes a race condition where tagger.Tag finds no tags for an
entity and triggers a Fetch, while at the same time the workloadmeta
collector is processing a batch of events that would've satisfied the
query. Whenever the Fetch wins the race, it overwrites a valid set of
tags with empty tags.

### Describe how to test your changes

This is hard to replicated, but somewhat easy to spot on a decently sized cluster with actual workloads. Verify that `count_nonzero(max:kubernetes.cpu.user.total{!image_name:*} by {host})` is down significantly after the agent is running in a cluster for a few minutes. It won't quite reach zero due to the way some checks know about pods/containers before they get to the tagger. If you want to double check, an `agent tagger-list` in the host should show no container without tags. This is easier to see in clusters without a lot of workload churn (like pods in crashloop backoff).