### PR TITLE
[corechecks/snmp] Use GetNext as fallback on GetBulk failure

### DIFF
--- a/pkg/collector/corechecks/snmp/fetch/fetch.go
+++ b/pkg/collector/corechecks/snmp/fetch/fetch.go
@@ -10,6 +10,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/valuestore"
 )
 
+type columnFetchStrategy int
+
+const (
+	useGetBulk columnFetchStrategy = iota
+	useGetNext
+)
+
 // Fetch oid values from device
 // TODO: pass only specific configs instead of the whole CheckConfig
 func Fetch(sess session.Session, config *checkconfig.CheckConfig) (*valuestore.ResultValueStore, error) {
@@ -25,11 +32,11 @@ func Fetch(sess session.Session, config *checkconfig.CheckConfig) (*valuestore.R
 		oids[value] = value
 	}
 
-	columnResults, err := fetchColumnOidsWithBatching(sess, oids, config.OidBatchSize, config.BulkMaxRepetitions, false)
+	columnResults, err := fetchColumnOidsWithBatching(sess, oids, config.OidBatchSize, config.BulkMaxRepetitions, useGetBulk)
 	if err != nil {
 		log.Debugf("failed to fetch oids with GetBulk batching: %v", err)
 
-		columnResults, err = fetchColumnOidsWithBatching(sess, oids, config.OidBatchSize, config.BulkMaxRepetitions, true)
+		columnResults, err = fetchColumnOidsWithBatching(sess, oids, config.OidBatchSize, config.BulkMaxRepetitions, useGetNext)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch oids with GetNext batching: %v", err)
 		}

--- a/pkg/collector/corechecks/snmp/fetch/fetch.go
+++ b/pkg/collector/corechecks/snmp/fetch/fetch.go
@@ -2,6 +2,7 @@ package fetch
 
 import (
 	"fmt"
+	"strconv"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -16,6 +17,17 @@ const (
 	useGetBulk columnFetchStrategy = iota
 	useGetNext
 )
+
+func (c columnFetchStrategy) String() string {
+	switch c {
+	case useGetBulk:
+		return "useGetBulk"
+	case useGetNext:
+		return "useGetNext"
+	default:
+		return strconv.Itoa(int(c))
+	}
+}
 
 // Fetch oid values from device
 // TODO: pass only specific configs instead of the whole CheckConfig

--- a/pkg/collector/corechecks/snmp/fetch/fetch_column.go
+++ b/pkg/collector/corechecks/snmp/fetch/fetch_column.go
@@ -59,7 +59,7 @@ func fetchColumnOids(sess session.Session, oids map[string]string, bulkMaxRepeti
 		if len(curOids) == 0 {
 			break
 		}
-		log.Debugf("fetch column: request oids (maxRep:%d,fetchStrategy:%t): %v", bulkMaxRepetitions, fetchStrategy, curOids)
+		log.Debugf("fetch column: request oids (maxRep:%d,fetchStrategy:%s): %v", bulkMaxRepetitions, fetchStrategy, curOids)
 		var columnOids, requestOids []string
 		for k, v := range curOids {
 			columnOids = append(columnOids, k)

--- a/pkg/collector/corechecks/snmp/fetch/fetch_column.go
+++ b/pkg/collector/corechecks/snmp/fetch/fetch_column.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/valuestore"
 )
 
-func fetchColumnOidsWithBatching(sess session.Session, oids map[string]string, oidBatchSize int, bulkMaxRepetitions uint32) (valuestore.ColumnResultValuesType, error) {
+func fetchColumnOidsWithBatching(sess session.Session, oids map[string]string, oidBatchSize int, bulkMaxRepetitions uint32, useGetNext bool) (valuestore.ColumnResultValuesType, error) {
 	retValues := make(valuestore.ColumnResultValuesType, len(oids))
 
 	columnOids := getOidsMapKeys(oids)
@@ -31,7 +31,7 @@ func fetchColumnOidsWithBatching(sess session.Session, oids map[string]string, o
 			oidsToFetch[oid] = oids[oid]
 		}
 
-		results, err := fetchColumnOids(sess, oidsToFetch, bulkMaxRepetitions)
+		results, err := fetchColumnOids(sess, oidsToFetch, bulkMaxRepetitions, useGetNext)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch column oids: %s", err)
 		}
@@ -52,7 +52,7 @@ func fetchColumnOidsWithBatching(sess session.Session, oids map[string]string, o
 // fetchColumnOids has an `oids` argument representing a `map[string]string`,
 // the key of the map is the column oid, and the value is the oid used to fetch the next value for the column.
 // The value oid might be equal to column oid or a row oid of the same column.
-func fetchColumnOids(sess session.Session, oids map[string]string, bulkMaxRepetitions uint32) (valuestore.ColumnResultValuesType, error) {
+func fetchColumnOids(sess session.Session, oids map[string]string, bulkMaxRepetitions uint32, useGetNext bool) (valuestore.ColumnResultValuesType, error) {
 	returnValues := make(valuestore.ColumnResultValuesType, len(oids))
 	curOids := oids
 	for {
@@ -69,7 +69,7 @@ func fetchColumnOids(sess session.Session, oids map[string]string, bulkMaxRepeti
 		sort.Strings(columnOids)
 		sort.Strings(requestOids)
 
-		results, err := getResults(sess, requestOids, bulkMaxRepetitions)
+		results, err := getResults(sess, requestOids, bulkMaxRepetitions, useGetNext)
 		if err != nil {
 			return nil, err
 		}
@@ -80,9 +80,9 @@ func fetchColumnOids(sess session.Session, oids map[string]string, bulkMaxRepeti
 	return returnValues, nil
 }
 
-func getResults(sess session.Session, requestOids []string, bulkMaxRepetitions uint32) (*gosnmp.SnmpPacket, error) {
+func getResults(sess session.Session, requestOids []string, bulkMaxRepetitions uint32, useGetNext bool) (*gosnmp.SnmpPacket, error) {
 	var results *gosnmp.SnmpPacket
-	if sess.GetVersion() == gosnmp.Version1 {
+	if sess.GetVersion() == gosnmp.Version1 || useGetNext {
 		// snmp v1 doesn't support GetBulk
 		getNextResults, err := sess.GetNext(requestOids)
 		if err != nil {

--- a/pkg/collector/corechecks/snmp/fetch/fetch_test.go
+++ b/pkg/collector/corechecks/snmp/fetch/fetch_test.go
@@ -78,7 +78,7 @@ func Test_fetchColumnOids(t *testing.T) {
 
 	oids := map[string]string{"1.1.1": "1.1.1", "1.1.2": "1.1.2"}
 
-	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 100, checkconfig.DefaultBulkMaxRepetitions)
+	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 100, checkconfig.DefaultBulkMaxRepetitions, false)
 	assert.Nil(t, err)
 
 	expectedColumnValues := valuestore.ColumnResultValuesType{
@@ -169,7 +169,7 @@ func Test_fetchColumnOidsBatch_usingGetBulk(t *testing.T) {
 
 	oids := map[string]string{"1.1.1": "1.1.1", "1.1.2": "1.1.2"}
 
-	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 2, 10)
+	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 2, 10, false)
 	assert.Nil(t, err)
 
 	expectedColumnValues := valuestore.ColumnResultValuesType{
@@ -266,7 +266,7 @@ func Test_fetchColumnOidsBatch_usingGetNext(t *testing.T) {
 
 	oids := map[string]string{"1.1.1": "1.1.1", "1.1.2": "1.1.2", "1.1.3": "1.1.3"}
 
-	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 2, 10)
+	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 2, 10, false)
 	assert.Nil(t, err)
 
 	expectedColumnValues := valuestore.ColumnResultValuesType{
@@ -279,6 +279,109 @@ func Test_fetchColumnOidsBatch_usingGetNext(t *testing.T) {
 		},
 		"1.1.3": {
 			"1": valuestore.ResultValue{Value: float64(31)},
+		},
+	}
+	assert.Equal(t, expectedColumnValues, columnValues)
+}
+
+func Test_fetchColumnOidsBatch_usingGetBulkAndGetNextFallback(t *testing.T) {
+	sess := session.CreateMockSession()
+	// When using snmp v2+, we will try GetBulk first and fallback using GetNext
+	sess.Version = gosnmp.Version2c
+
+	bulkPacket := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.1.1.1",
+				Type:  gosnmp.TimeTicks,
+				Value: 11,
+			},
+			{
+				Name:  "1.1.2.1",
+				Type:  gosnmp.TimeTicks,
+				Value: 21,
+			},
+		},
+	}
+
+	bulkPacket2 := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.1.1.2",
+				Type:  gosnmp.TimeTicks,
+				Value: 12,
+			},
+			{
+				Name:  "1.1.9.1",
+				Type:  gosnmp.TimeTicks,
+				Value: 91,
+			},
+		},
+	}
+	bulkPacket3 := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.1.9.2",
+				Type:  gosnmp.TimeTicks,
+				Value: 91,
+			},
+		},
+	}
+
+	secondBatchPacket1 := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.1.3.1",
+				Type:  gosnmp.TimeTicks,
+				Value: 31,
+			},
+		},
+	}
+
+	secondBatchPacket2 := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.1.9.1",
+				Type:  gosnmp.TimeTicks,
+				Value: 91,
+			},
+		},
+	}
+
+	sess.On("GetBulk", []string{"1.1.1", "1.1.2"}, checkconfig.DefaultBulkMaxRepetitions).Return(&gosnmp.SnmpPacket{}, fmt.Errorf("bulk error"))
+
+	// First batch
+	sess.On("GetNext", []string{"1.1.1", "1.1.2"}).Return(&bulkPacket, nil)
+	sess.On("GetNext", []string{"1.1.1.1", "1.1.2.1"}).Return(&bulkPacket2, nil)
+	sess.On("GetNext", []string{"1.1.1.2"}).Return(&bulkPacket3, nil)
+
+	// Second batch
+	sess.On("GetNext", []string{"1.1.3"}).Return(&secondBatchPacket1, nil)
+	sess.On("GetNext", []string{"1.1.3.1"}).Return(&secondBatchPacket2, nil)
+
+	config := &checkconfig.CheckConfig{
+		BulkMaxRepetitions: checkconfig.DefaultBulkMaxRepetitions,
+		OidBatchSize:       2,
+		OidConfig: checkconfig.OidConfig{
+			ColumnOids: []string{"1.1.1", "1.1.2", "1.1.3"},
+		},
+	}
+	columnValues, err := Fetch(sess, config)
+	assert.Nil(t, err)
+
+	expectedColumnValues := &valuestore.ResultValueStore{
+		ScalarValues: valuestore.ScalarResultValuesType{},
+		ColumnValues: valuestore.ColumnResultValuesType{
+			"1.1.1": {
+				"1": valuestore.ResultValue{Value: float64(11)},
+				"2": valuestore.ResultValue{Value: float64(12)},
+			},
+			"1.1.2": {
+				"1": valuestore.ResultValue{Value: float64(21)},
+			},
+			"1.1.3": {
+				"1": valuestore.ResultValue{Value: float64(31)},
+			},
 		},
 	}
 	assert.Equal(t, expectedColumnValues, columnValues)
@@ -629,7 +732,7 @@ func Test_fetchValues_errors(t *testing.T) {
 					ColumnOids: []string{"1.1", "2.2"},
 				},
 			},
-			expectedError: fmt.Errorf("failed to fetch oids with batching: failed to fetch column oids: fetch column: failed getting oids `[1.1 2.2]` using GetBulk: bulk error"),
+			expectedError: fmt.Errorf("failed to fetch oids with GetNext batching: failed to fetch column oids: fetch column: failed getting oids `[1.1 2.2]` using GetNext: getnext error"),
 		},
 	}
 	for _, tt := range tests {
@@ -637,6 +740,7 @@ func Test_fetchValues_errors(t *testing.T) {
 			sess := session.CreateMockSession()
 			sess.On("Get", []string{"1.1", "2.2"}).Return(&gosnmp.SnmpPacket{}, fmt.Errorf("get error"))
 			sess.On("GetBulk", []string{"1.1", "2.2"}, checkconfig.DefaultBulkMaxRepetitions).Return(&gosnmp.SnmpPacket{}, fmt.Errorf("bulk error"))
+			sess.On("GetNext", []string{"1.1", "2.2"}).Return(&gosnmp.SnmpPacket{}, fmt.Errorf("getnext error"))
 
 			_, err := Fetch(sess, &tt.config)
 

--- a/pkg/collector/corechecks/snmp/fetch/fetch_test.go
+++ b/pkg/collector/corechecks/snmp/fetch/fetch_test.go
@@ -78,7 +78,7 @@ func Test_fetchColumnOids(t *testing.T) {
 
 	oids := map[string]string{"1.1.1": "1.1.1", "1.1.2": "1.1.2"}
 
-	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 100, checkconfig.DefaultBulkMaxRepetitions, false)
+	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 100, checkconfig.DefaultBulkMaxRepetitions, useGetBulk)
 	assert.Nil(t, err)
 
 	expectedColumnValues := valuestore.ColumnResultValuesType{
@@ -169,7 +169,7 @@ func Test_fetchColumnOidsBatch_usingGetBulk(t *testing.T) {
 
 	oids := map[string]string{"1.1.1": "1.1.1", "1.1.2": "1.1.2"}
 
-	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 2, 10, false)
+	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 2, 10, useGetBulk)
 	assert.Nil(t, err)
 
 	expectedColumnValues := valuestore.ColumnResultValuesType{
@@ -266,7 +266,7 @@ func Test_fetchColumnOidsBatch_usingGetNext(t *testing.T) {
 
 	oids := map[string]string{"1.1.1": "1.1.1", "1.1.2": "1.1.2", "1.1.3": "1.1.3"}
 
-	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 2, 10, false)
+	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 2, 10, useGetBulk)
 	assert.Nil(t, err)
 
 	expectedColumnValues := valuestore.ColumnResultValuesType{


### PR DESCRIPTION
### What does this PR do?

[corechecks/snmp] Use GetNext as fallback on GetBulk failure

### Motivation

GetBulk might fail with request timeout due to request size being too big.

### Additional Notes

### Describe how to test your changes

1/ `ddev env start snmp py38`

2/ Use this config as `snmp.d/conf.yaml` with 10sec timeout and 1 retry

```
init_config:
  loader: core

instances:
  - ip_address: 127.0.0.1
    port: 1161
    community_string: public
    timeout: 10
    retries: 1
    # snmp_version: 1
    metrics:
      - table:
          OID: 1.3.6.1.2.1.2.2
          name: ifTable
        symbols:
        - OID: 1.3.6.1.2.1.2.2.1.14
          name: ifInErrors
        metric_tags:
        - column:
            OID: 1.3.6.1.2.1.31.1.1.1.1
            name: ifName
          table: ifXTable
          tag: interface
```

tip: you can use `ddev env edit snmp py38`

3/ In snmpsim container (dd-snmp), change this line in public.snmprec:

`1.3.6.1.2.1.2.2.1.7.1|2|1` to `1.3.6.1.2.1.2.2.1.7.1|2:delay|value=1,wait=15000`

It will simulate an OID that timeout in 15sec.

Then restart docker container `docker restart dd-snmp`

4/ Run 
```
ddev env check snmp py38 -r --log-level debug
```
Wait until `fetch column: request oids (maxRep: 10, useGetNext:true)`

5/ Within 10sec:
- Revert the change made in 3/ 
- and restart snmpsim container (dd-snmp) again.

6/ At this point, you should see:
- `snmp.ifInErrors` being correctly reported in `=== Series ===` section of the `ddev env check snmp py38 -r --log-level debug` command output
- multiple lines with `fetch column: GetNext results: error=NoError` 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
