### PR TITLE
Enable zypper RPM debug mode

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -539,7 +539,7 @@ elif [ "$OS" = "SUSE" ]; then
   fi
   echo -e "  \033[33mInstalling package: $agent_flavor\n\033[0m"
 
-  $sudo_cmd zypper --non-interactive install "$agent_flavor"
+  $sudo_cmd ZYPP_RPM_DEBUG=${ZYPP_RPM_DEBUG:-0} zypper --non-interactive install "$agent_flavor"
 
 else
     printf "\033[31mYour OS or distribution are not supported by this install script.

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -539,7 +539,7 @@ elif [ "$OS" = "SUSE" ]; then
   fi
   echo -e "  \033[33mInstalling package: $agent_flavor\n\033[0m"
 
-  $sudo_cmd ZYPP_RPM_DEBUG=${ZYPP_RPM_DEBUG:-0} zypper --non-interactive install "$agent_flavor"
+  $sudo_cmd ZYPP_RPM_DEBUG="${ZYPP_RPM_DEBUG:-0}" zypper --non-interactive install "$agent_flavor"
 
 else
     printf "\033[31mYour OS or distribution are not supported by this install script.

--- a/releasenotes-installscript/notes/support-zypp-rpm-debug-a041f1c818a0ec16.yaml
+++ b/releasenotes-installscript/notes/support-zypp-rpm-debug-a041f1c818a0ec16.yaml
@@ -1,0 +1,13 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG-INSTALLSCRIPT.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Environment variable ``ZYPP_RPM_DEBUG`` value is now propagated through
+    ``install_script.sh`` to the ``zypper install`` command to enable
+    RPM transaction debugging.

--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -27,7 +27,6 @@ provisioner:
   wait_for_retry: 90
   client_rb:
     client_fork: false
-  log_level: debug
 
 driver:
   name: azurerm

--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -27,6 +27,7 @@ provisioner:
   wait_for_retry: 90
   client_rb:
     client_fork: false
+  log_level: debug
 
 driver:
   name: azurerm

--- a/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-install-script/recipes/default.rb
@@ -41,6 +41,7 @@ kitchen_environment_variables = {
   'TESTING_YUM_URL' => node['dd-agent-install-script']['repo_domain_yum'],
   'TESTING_APT_REPO_VERSION' => "#{node['dd-agent-install-script']['repo_branch_apt']} #{node['dd-agent-install-script']['repo_component_apt']}",
   'TESTING_YUM_VERSION_PATH' => node['dd-agent-install-script']['repo_branch_yum'],
+  'ZYPP_RPM_DEBUG' => '1',
 }.compact
 
 # Transform hash into bash syntax for exporting environment variables

--- a/test/kitchen/site-cookbooks/dd-agent-upgrade/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-upgrade/recipes/default.rb
@@ -83,6 +83,7 @@ if node['platform_family'] != 'windows'
       command "zypper --non-interactive install --auto-agree-with-licenses #{node['dd-agent-upgrade']['package_name']}=#{node['dd-agent-upgrade']['version']}"
 
       environment({'ZYPP_RPM_DEBUG' => '1'})
+      live_stream true
       action :run
     end
   end

--- a/test/kitchen/site-cookbooks/dd-agent-upgrade/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-upgrade/recipes/default.rb
@@ -75,6 +75,11 @@ if node['platform_family'] != 'windows'
     package node['dd-agent-upgrade']['package_name'] do
       action :remove
     end
+    # We have this commented and run it as `execute` command to be able to provide
+    # ZYPP_RPM_DEBUG=1 and see debug output. Whenever we solve/understand
+    # https://bugzilla.suse.com/show_bug.cgi?id=1192034, we can uncomment
+    # and remove the command.
+    #
     # package node['dd-agent-upgrade']['package_name'] do
     #   action :install
     #   version node['dd-agent-upgrade']['version']

--- a/test/kitchen/site-cookbooks/dd-agent-upgrade/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-upgrade/recipes/default.rb
@@ -75,9 +75,15 @@ if node['platform_family'] != 'windows'
     package node['dd-agent-upgrade']['package_name'] do
       action :remove
     end
-    package node['dd-agent-upgrade']['package_name'] do
-      action :install
-      version node['dd-agent-upgrade']['version']
+    # package node['dd-agent-upgrade']['package_name'] do
+    #   action :install
+    #   version node['dd-agent-upgrade']['version']
+    # end
+    execute 'install agent' do
+      command "zypper --non-interactive install --auto-agree-with-licenses #{node['dd-agent-upgrade']['package_name']}=#{node['dd-agent-upgrade']['version']}"
+
+      environment({'ZYPP_RPM_DEBUG' => '1'})
+      action :run
     end
   end
 end


### PR DESCRIPTION
### What does this PR do?

* Allows propagating of `ZYPP_RPM_DEBUG` env variable through `install_script.sh` to the executed `zypper install` command.
* Adds `ZYPP_RPM_DEBUG=1` to execution of `install_script.sh` in CI while installing datadog-iot-agent on SUSE.
* Also modifies the zypper upgrade recipe for datadog-iot-agent to print additional RPM debug information.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

For install_script.sh:
* Ensure that without having `ZYPP_RPM_DEBUG` set in environment, the install script still works fine on SUSE >= 15.2 and prints no additional debug info.
* Ensure that having `ZYPP_RPM_DEBUG=1` set in environment prints additional RPM transaction debug information. 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
