### PR TITLE
[networks] Handle TCP_CLOSE/conntrack race

### DIFF
--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -246,6 +246,12 @@ func (c ConnectionStats) ByteKey(buf []byte) ([]byte, error) {
 	return buf[:n], nil
 }
 
+// IsShortLived returns true when a connection went through its whole lifecycle
+// between two connection checks
+func (c ConnectionStats) IsShortLived() bool {
+	return c.MonotonicTCPEstablished >= 1 && c.MonotonicTCPClosed >= 1
+}
+
 const keyFmt = "p:%d|src:%s:%d|dst:%s:%d|f:%d|t:%d"
 
 // BeautifyKey returns a human readable byte key (used for debugging purposes)

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -249,7 +249,7 @@ func (c ConnectionStats) ByteKey(buf []byte) ([]byte, error) {
 // IsShortLived returns true when a connection went through its whole lifecycle
 // between two connection checks
 func (c ConnectionStats) IsShortLived() bool {
-	return c.MonotonicTCPEstablished >= 1 && c.MonotonicTCPClosed >= 1
+	return c.LastTCPEstablished >= 1 && c.LastTCPClosed >= 1
 }
 
 const keyFmt = "p:%d|src:%s:%d|dst:%s:%d|f:%d|t:%d"

--- a/pkg/network/netlink/conntracker.go
+++ b/pkg/network/netlink/conntracker.go
@@ -28,6 +28,7 @@ const (
 type Conntracker interface {
 	GetTranslationForConn(network.ConnectionStats) *network.IPTranslation
 	DeleteTranslation(network.ConnectionStats)
+	IsSampling() bool
 	GetStats() map[string]int64
 	Close()
 }
@@ -212,6 +213,10 @@ func (ctr *realConntracker) DeleteTranslation(c network.ConnectionStats) {
 	if ctr.cache.Remove(k) {
 		atomic.AddInt64(&ctr.stats.unregisters, 1)
 	}
+}
+
+func (ctr *realConntracker) IsSampling() bool {
+	return ctr.consumer.GetStats()[samplingPct] < 100
 }
 
 func (ctr *realConntracker) Close() {

--- a/pkg/network/netlink/consumer.go
+++ b/pkg/network/netlink/consumer.go
@@ -39,6 +39,11 @@ const (
 	// netlinkBufferSize is size (in bytes) of the Netlink socket receive buffer
 	// We set it to a large enough size to support bursts of Conntrack events.
 	netlinkBufferSize = 1024 * 1024
+
+	// telemetry field name used to designate the rate at which conntrack events are sampled.
+	// a value of 100 means all events are processed, whereas 0 means that all events
+	// are rejected
+	samplingPct = "sampling_pct"
 )
 
 var errShortErrorMessage = errors.New("not enough data for netlink error code")
@@ -310,11 +315,11 @@ func (c *Consumer) dumpTable(family uint8, output chan Event, ns netns.NsHandle)
 // GetStats returns telemetry associated to the Consumer
 func (c *Consumer) GetStats() map[string]int64 {
 	return map[string]int64{
-		"enobufs":      atomic.LoadInt64(&c.enobufs),
-		"throttles":    atomic.LoadInt64(&c.throttles),
-		"sampling_pct": atomic.LoadInt64(&c.samplingPct),
-		"read_errors":  atomic.LoadInt64(&c.readErrors),
-		"msg_errors":   atomic.LoadInt64(&c.msgErrors),
+		"enobufs":     atomic.LoadInt64(&c.enobufs),
+		"throttles":   atomic.LoadInt64(&c.throttles),
+		samplingPct:   atomic.LoadInt64(&c.samplingPct),
+		"read_errors": atomic.LoadInt64(&c.readErrors),
+		"msg_errors":  atomic.LoadInt64(&c.msgErrors),
 	}
 }
 

--- a/pkg/network/netlink/noop.go
+++ b/pkg/network/netlink/noop.go
@@ -20,6 +20,10 @@ func (*noOpConntracker) DeleteTranslation(c network.ConnectionStats) {
 
 }
 
+func (*noOpConntracker) IsSampling() bool {
+	return false
+}
+
 func (*noOpConntracker) Close() {}
 
 func (*noOpConntracker) GetStats() map[string]int64 {

--- a/pkg/network/netlink/testutil/conntrack.go
+++ b/pkg/network/netlink/testutil/conntrack.go
@@ -4,8 +4,11 @@ package testutil
 
 import (
 	"strings"
+	"sync"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/network/netlink"
 	nettestutil "github.com/DataDog/datadog-agent/pkg/network/testutil"
 )
 
@@ -110,4 +113,36 @@ func TeardownCrossNsDNAT(t *testing.T) {
 		"conntrack -F",
 	}
 	nettestutil.RunCommands(t, cmds, true)
+}
+
+type delayedConntracker struct {
+	netlink.Conntracker
+
+	mux          sync.Mutex
+	numDelays    int
+	delayPerConn map[string]int
+}
+
+// NewDelayedConntracker returns a netlink.Conntracker that returns `nil` for `numDelays`
+// consecutive times. After that lookups are routed to the actual Conntracker implementation.
+func NewDelayedConntracker(ctr netlink.Conntracker, numDelays int) netlink.Conntracker {
+	return &delayedConntracker{
+		Conntracker:  ctr,
+		numDelays:    numDelays,
+		delayPerConn: make(map[string]int),
+	}
+}
+
+func (ctr *delayedConntracker) GetTranslationForConn(c network.ConnectionStats) *network.IPTranslation {
+	ctr.mux.Lock()
+	defer ctr.mux.Unlock()
+
+	key, _ := c.ByteKey(make([]byte, 64))
+	delays := ctr.delayPerConn[string(key)]
+	if delays < ctr.numDelays {
+		ctr.delayPerConn[string(key)]++
+		return nil
+	}
+
+	return ctr.Conntracker.GetTranslationForConn(c)
 }

--- a/pkg/network/netlink/testutil/conntrack.go
+++ b/pkg/network/netlink/testutil/conntrack.go
@@ -4,11 +4,8 @@ package testutil
 
 import (
 	"strings"
-	"sync"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/network"
-	"github.com/DataDog/datadog-agent/pkg/network/netlink"
 	nettestutil "github.com/DataDog/datadog-agent/pkg/network/testutil"
 )
 
@@ -113,36 +110,4 @@ func TeardownCrossNsDNAT(t *testing.T) {
 		"conntrack -F",
 	}
 	nettestutil.RunCommands(t, cmds, true)
-}
-
-type delayedConntracker struct {
-	netlink.Conntracker
-
-	mux          sync.Mutex
-	numDelays    int
-	delayPerConn map[string]int
-}
-
-// NewDelayedConntracker returns a netlink.Conntracker that returns `nil` for `numDelays`
-// consecutive times. After that lookups are routed to the actual Conntracker implementation.
-func NewDelayedConntracker(ctr netlink.Conntracker, numDelays int) netlink.Conntracker {
-	return &delayedConntracker{
-		Conntracker:  ctr,
-		numDelays:    numDelays,
-		delayPerConn: make(map[string]int),
-	}
-}
-
-func (ctr *delayedConntracker) GetTranslationForConn(c network.ConnectionStats) *network.IPTranslation {
-	ctr.mux.Lock()
-	defer ctr.mux.Unlock()
-
-	key, _ := c.ByteKey(make([]byte, 64))
-	delays := ctr.delayPerConn[string(key)]
-	if delays < ctr.numDelays {
-		ctr.delayPerConn[string(key)]++
-		return nil
-	}
-
-	return ctr.Conntracker.GetTranslationForConn(c)
 }

--- a/pkg/network/state.go
+++ b/pkg/network/state.go
@@ -697,4 +697,8 @@ func addConnections(a, b *ConnectionStats) {
 	if b.LastUpdateEpoch > a.LastUpdateEpoch {
 		a.LastUpdateEpoch = b.LastUpdateEpoch
 	}
+
+	if a.IPTranslation == nil {
+		a.IPTranslation = b.IPTranslation
+	}
 }

--- a/pkg/network/tracer/ebpf_conntracker.go
+++ b/pkg/network/tracer/ebpf_conntracker.go
@@ -240,6 +240,10 @@ func (e *ebpfConntracker) GetTranslationForConn(stats network.ConnectionStats) *
 	}
 }
 
+func (*ebpfConntracker) IsSampling() bool {
+	return false
+}
+
 func (e *ebpfConntracker) get(src *netebpf.ConntrackTuple) *netebpf.ConntrackTuple {
 	dst := tuplePool.Get().(*netebpf.ConntrackTuple)
 	if err := e.ctMap.Lookup(unsafe.Pointer(src), unsafe.Pointer(dst)); err != nil {

--- a/pkg/network/tracer/testutil/conntrack.go
+++ b/pkg/network/tracer/testutil/conntrack.go
@@ -1,3 +1,5 @@
+// +build linux
+
 package testutil
 
 import (

--- a/pkg/network/tracer/testutil/conntrack.go
+++ b/pkg/network/tracer/testutil/conntrack.go
@@ -1,0 +1,40 @@
+package testutil
+
+import (
+	"sync"
+
+	"github.com/DataDog/datadog-agent/pkg/network"
+	"github.com/DataDog/datadog-agent/pkg/network/netlink"
+)
+
+type delayedConntracker struct {
+	netlink.Conntracker
+
+	mux          sync.Mutex
+	numDelays    int
+	delayPerConn map[string]int
+}
+
+// NewDelayedConntracker returns a netlink.Conntracker that returns `nil` for `numDelays`
+// consecutive times. After that lookups are routed to the actual Conntracker implementation.
+func NewDelayedConntracker(ctr netlink.Conntracker, numDelays int) netlink.Conntracker {
+	return &delayedConntracker{
+		Conntracker:  ctr,
+		numDelays:    numDelays,
+		delayPerConn: make(map[string]int),
+	}
+}
+
+func (ctr *delayedConntracker) GetTranslationForConn(c network.ConnectionStats) *network.IPTranslation {
+	ctr.mux.Lock()
+	defer ctr.mux.Unlock()
+
+	key, _ := c.ByteKey(make([]byte, 64))
+	delays := ctr.delayPerConn[string(key)]
+	if delays < ctr.numDelays {
+		ctr.delayPerConn[string(key)]++
+		return nil
+	}
+
+	return ctr.Conntracker.GetTranslationForConn(c)
+}

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -645,7 +645,7 @@ func (t *Tracer) retryConntrack(connections []network.ConnectionStats) {
 	// The motivation here is to catch a race condition where the netlink event is processed
 	// after the connection is closed
 	for i, c := range connections {
-		if c.IsShortLived() && c.IPTranslation == nil {
+		if c.IPTranslation == nil && (c.Type == network.UDP || c.IsShortLived()) {
 			translation := t.conntracker.GetTranslationForConn(c)
 			if translation != nil {
 				connections[i].IPTranslation = translation

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -19,8 +19,8 @@ import (
 	"testing"
 	"time"
 
-	netlinktest "github.com/DataDog/datadog-agent/pkg/network/netlink/testutil"
 	nettestutil "github.com/DataDog/datadog-agent/pkg/network/testutil"
+	tracertest "github.com/DataDog/datadog-agent/pkg/network/tracer/testutil"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
@@ -449,7 +449,7 @@ func TestConntrackDelays(t *testing.T) {
 	defer tr.Stop()
 
 	// This will ensure that the first lookup for every connection fails, while the following ones succeed
-	tr.conntracker = netlinktest.NewDelayedConntracker(tr.conntracker, 1)
+	tr.conntracker = tracertest.NewDelayedConntracker(tr.conntracker, 1)
 
 	// Warm-up tracer state
 	_ = getConnections(t, tr)


### PR DESCRIPTION
### What does this PR do?

This PR addresses a race condition between TCP close events (read off the perf ring) and conntrack events, which causes `network.ConnectionStats` objects to occasionally miss IPTranslation objects in the context of short-lived connections.
The race can happen as follows:
1. a TCP connection is open and closed in quick succession (this can happen, for example, in a HTTP request);
2. The connection data is read off the perf ring;
3. Conntrack cache is looked up resulting in a miss;
4. Conntrack event is read off the netlink socket and added to the cache;

Aside from that I noticed a small issue in the connection merge codepath that, when combined to the race condition, can aggravate the problem. That may happen in the context of port re-use, and when multiple connections are merged, we can inadvertently override the `IPTranslation` field with a `nil` value. This was also fixed in this PR.

### Motivation

Improve network data resolution.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

No QA required.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
