### PR TITLE
[KSMCore] Add node info as tags with a default label join

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -64,7 +64,8 @@ type KSMConfig struct {
 	// deployment metrics.
 	// label_joins:
 	//   kube_deployment_labels:
-	//     label_to_match: deployment
+	//     labels_to_match:
+	//       - deployment
 	//     labels_to_get:
 	//       - label_addonmanager_kubernetes_io_mode
 	LabelJoins map[string]*JoinsConfig `yaml:"label_joins"`

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_defaults.go
@@ -209,5 +209,9 @@ var (
 				"label_failure_domain_beta_kubernetes_io_zone",   // k8s < v1.17
 			},
 		},
+		"kube_node_info": {
+			LabelsToMatch: []string{"node"},
+			LabelsToGet:   []string{"container_runtime_version", "kernel_version", "kubelet_version", "os_image"},
+		},
 	}
 )

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_test.go
@@ -329,6 +329,39 @@ func TestProcessMetrics(t *testing.T) {
 			},
 		},
 		{
+			name:   "node info tags from default label joins",
+			config: &KSMConfig{LabelsMapper: defaultLabelsMapper, LabelJoins: defaultLabelJoins},
+			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
+				"kube_node_status_capacity": {
+					{
+						Type: "*v1.Node",
+						Name: "kube_node_status_capacity",
+						ListMetrics: []ksmstore.DDMetric{
+							{
+								Labels: map[string]string{"node": "nodename", "resource": "cpu", "unit": "core"},
+								Val:    4,
+							},
+						},
+					},
+				},
+			},
+			metricsToGet: []ksmstore.DDMetricsFam{
+				{
+					Name:        "kube_node_info",
+					ListMetrics: []ksmstore.DDMetric{{Labels: map[string]string{"node": "nodename", "container_runtime_version": "docker://19.3.15", "kernel_version": "5.4.109+", "kubelet_version": "v1.18.20-gke.901", "os_image": "Container-Optimized OS from Google"}}},
+				},
+			},
+			metricTransformers: metricTransformers,
+			expected: []metricsExpected{
+				{
+					name:     "kubernetes_state.node.cpu_capacity",
+					val:      4,
+					tags:     []string{"node:nodename", "resource:cpu", "unit:core", "container_runtime_version:docker://19.3.15", "kernel_version:5.4.109+", "kubelet_version:v1.18.20-gke.901", "os_image:Container-Optimized OS from Google"},
+					hostname: "nodename",
+				},
+			},
+		},
+		{
 			name:   "phase tag for pod",
 			config: &KSMConfig{LabelsMapper: defaultLabelsMapper},
 			metricsToProcess: map[string][]ksmstore.DDMetricsFam{
@@ -1112,6 +1145,7 @@ var metadataMetrics = []string{
 	"kube_deployment_labels",
 	"kube_namespace_labels",
 	"kube_node_labels",
+	"kube_node_info",
 	"kube_daemonset_labels",
 	"kube_pod_labels",
 	"kube_service_labels",

--- a/releasenotes-dca/notes/ksm-core-node-info-df4fe65746707ef7.yaml
+++ b/releasenotes-dca/notes/ksm-core-node-info-df4fe65746707ef7.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    ``kubernetes_state.node.*`` metrics are tagged with ``kubelet_version``,
+    ``container_runtime_version``, ``kernel_version``, and ``os_image``.

--- a/releasenotes/notes/ksm-core-node-info-df4fe65746707ef7.yaml
+++ b/releasenotes/notes/ksm-core-node-info-df4fe65746707ef7.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    ``kubernetes_state.node.*`` metrics are tagged with ``kubelet_version``,
+    ``container_runtime_version``, ``kernel_version``, and ``os_image``.


### PR DESCRIPTION
### What does this PR do?

Tag `kubernetes_state.node.*` metrics with `kubelet_version`, `container_runtime_version`, `kernel_version`, and `os_image` by default.

### Motivation

Enrich node tags for metrics who already have `host` tags.

### Describe how to test your changes

Enable the ksm core check, all `node.*` metrics that have a `host` tag should be tagged with `kubelet_version`, `container_runtime_version`, `kernel_version`, and `os_image`.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
