### PR TITLE
[networks] replace GetDNSNamesV2

### DIFF
--- a/pkg/process/checks/net_test.go
+++ b/pkg/process/checks/net_test.go
@@ -249,7 +249,7 @@ func TestNetworkConnectionBatchingWithDomainsByQueryType(t *testing.T) {
 		connections := c.(*model.CollectorConnections)
 		total += len(connections.Connections)
 
-		domaindb := connections.GetDNSNames()
+		domaindb, _ := connections.GetDNSNames()
 
 		// verify nothing was put in the DnsStatsByDomain bucket by mistake
 		assert.Equal(t, len(connections.Connections[0].DnsStatsByDomain), 0)
@@ -368,7 +368,7 @@ func TestNetworkConnectionBatchingWithDomains(t *testing.T) {
 		connections := c.(*model.CollectorConnections)
 		total += len(connections.Connections)
 
-		domaindb := connections.GetDNSNames()
+		domaindb, _ := connections.GetDNSNames()
 
 		// verify nothing was put in the DnsStatsByDomain bucket by mistake
 		assert.Equal(t, len(connections.Connections[0].DnsStatsByDomain), 0)

--- a/pkg/process/checks/net_test.go
+++ b/pkg/process/checks/net_test.go
@@ -249,7 +249,7 @@ func TestNetworkConnectionBatchingWithDomainsByQueryType(t *testing.T) {
 		connections := c.(*model.CollectorConnections)
 		total += len(connections.Connections)
 
-		domaindb := connections.GetDNSNamesV2()
+		domaindb := connections.GetDNSNames()
 
 		// verify nothing was put in the DnsStatsByDomain bucket by mistake
 		assert.Equal(t, len(connections.Connections[0].DnsStatsByDomain), 0)
@@ -368,7 +368,7 @@ func TestNetworkConnectionBatchingWithDomains(t *testing.T) {
 		connections := c.(*model.CollectorConnections)
 		total += len(connections.Connections)
 
-		domaindb := connections.GetDNSNamesV2()
+		domaindb := connections.GetDNSNames()
 
 		// verify nothing was put in the DnsStatsByDomain bucket by mistake
 		assert.Equal(t, len(connections.Connections[0].DnsStatsByDomain), 0)


### PR DESCRIPTION
### What does this PR do?

Replaces `GetDNSNamesV2` with the more generic version `GetDNSNames` which chooses the appropriate version under the hood.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
