### PR TITLE
Improve datetime output when cleaning pipelines

### DIFF
--- a/tasks/libs/pipeline_tools.py
+++ b/tasks/libs/pipeline_tools.py
@@ -1,7 +1,7 @@
+import datetime
 import functools
 import platform
 from time import sleep, time
-import datetime
 
 from tasks.utils import DEFAULT_BRANCH
 

--- a/tasks/libs/pipeline_tools.py
+++ b/tasks/libs/pipeline_tools.py
@@ -45,17 +45,14 @@ def cancel_pipelines_with_confirmation(gitlab, pipelines):
             ),
         )
 
-        try:
-            pipeline_creation_date = pipeline['created_at']
-            print(
-                "{} {:%c} ({})".format(
-                    color_message("Started at", "blue"),
-                    parse_datetime(pipeline_creation_date).astimezone(),
-                    pipeline_creation_date,
-                )
+        pipeline_creation_date = pipeline['created_at']
+        print(
+            "{} {:%c} ({})".format(
+                color_message("Started at", "blue"),
+                parse_datetime(pipeline_creation_date).astimezone(),
+                pipeline_creation_date,
             )
-        except ValueError:
-            pass
+        )
 
         print(
             color_message("Commit:", "blue"),


### PR DESCRIPTION
### What does this PR do?

This PR adds a human readable (local dependant) start time for the pipeline display.

### Motivation

The current display is directly the result of the Gitlab API call, a UTC datetime, which is quite difficult to reason about.

### Describe how to test your changes

This PR is only changing internal tasks.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
