### PR TITLE
[cws] improve performances parent discarders

### DIFF
--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -13,13 +13,11 @@ import (
 	"math/rand"
 	"path"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"time"
 
 	manager "github.com/DataDog/ebpf-manager"
 	lib "github.com/cilium/ebpf"
-	"github.com/hashicorp/golang-lru/simplelru"
 	"github.com/pkg/errors"
 
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf"
@@ -141,25 +139,20 @@ type inodeDiscarder struct {
 // inodeDiscarders is used to issue eRPC discarder requests
 type inodeDiscarders struct {
 	*lib.Map
-	erpc           *ERPC
-	revisions      *lib.Map
-	revisionCache  [discarderRevisionSize]uint32
-	dentryResolver *DentryResolver
-	regexCache     *simplelru.LRU
+	erpc               *ERPC
+	revisions          *lib.Map
+	revisionCache      [discarderRevisionSize]uint32
+	dentryResolver     *DentryResolver
+	rs                 *rules.RuleSet
+	parentDiscarderFnc map[eval.Field]func(dirname string) (bool, error)
 }
 
 func newInodeDiscarders(inodesMap, revisionsMap *lib.Map, erpc *ERPC, dentryResolver *DentryResolver) (*inodeDiscarders, error) {
-	regexCache, err := simplelru.NewLRU(64, nil)
-	if err != nil {
-		return nil, err
-	}
-
 	return &inodeDiscarders{
 		Map:            inodesMap,
 		erpc:           erpc,
 		revisions:      revisionsMap,
 		dentryResolver: dentryResolver,
-		regexCache:     regexCache,
 	}, nil
 }
 
@@ -219,30 +212,51 @@ var (
 
 // Important should always be called after having checked that the file is not a discarder itself otherwise it can report incorrect
 // parent discarder
-func isParentPathDiscarder(rs *rules.RuleSet, regexCache *simplelru.LRU, eventType model.EventType, filenameField eval.Field, filename string) (bool, error) {
+func (id *inodeDiscarders) isParentPathDiscarder(rs *rules.RuleSet, eventType model.EventType, filenameField eval.Field, filename string) (bool, error) {
 	dirname := filepath.Dir(filename)
+
+	// check cache first
+	if id.rs != rs {
+		id.parentDiscarderFnc = make(map[eval.Field]func(dirname string) (bool, error))
+		id.rs = rs
+	} else {
+		if fnc, exists := id.parentDiscarderFnc[filenameField]; exists {
+			return fnc(dirname)
+		}
+	}
+
+	// compile
+	if _, err := discarderEvent.GetFieldType(filenameField); err != nil {
+		fnc := func(dirname string) (bool, error) {
+			return false, err
+		}
+		id.parentDiscarderFnc[filenameField] = fnc
+		return fnc(dirname)
+	}
+
+	if !strings.HasSuffix(filenameField, model.PathSuffix) {
+		fnc := func(dirname string) (bool, error) {
+			return false, errors.New("path suffix not found")
+		}
+		id.parentDiscarderFnc[filenameField] = fnc
+		return fnc(dirname)
+	}
+
+	basenameField := strings.Replace(filenameField, model.PathSuffix, model.NameSuffix, 1)
+	if _, err := discarderEvent.GetFieldType(basenameField); err != nil {
+		fnc := func(dirname string) (bool, error) {
+			return false, err
+		}
+		id.parentDiscarderFnc[filenameField] = fnc
+		return fnc(dirname)
+	}
+
+	var valueFnc func(dirname string) (bool, bool, error)
+	var valueFncs []func(dirname string) (bool, bool, error)
 
 	bucket := rs.GetBucket(eventType.String())
 	if bucket == nil {
 		return false, nil
-	}
-
-	event := discarderEvent
-	defer func() {
-		*discarderEvent = eventZero
-	}()
-
-	if _, err := event.GetFieldType(filenameField); err != nil {
-		return false, err
-	}
-
-	if !strings.HasSuffix(filenameField, model.PathSuffix) {
-		return false, errors.New("path suffix not found")
-	}
-
-	basenameField := strings.Replace(filenameField, model.PathSuffix, model.NameSuffix, 1)
-	if _, err := event.GetFieldType(basenameField); err != nil {
-		return false, err
 	}
 
 	for _, rule := range bucket.GetRules() {
@@ -262,63 +276,88 @@ func isParentPathDiscarder(rs *rules.RuleSet, regexCache *simplelru.LRU, eventTy
 		if values := rule.GetFieldValues(filenameField); len(values) > 0 {
 			for _, value := range values {
 				if value.Type == eval.PatternValueType {
-					if value.Regexp.MatchString(dirname) {
-						return false, nil
-					}
-
 					valueDir := path.Dir(value.Value.(string))
-					var regexDir *regexp.Regexp
-					if entry, found := regexCache.Get(valueDir); found {
-						regexDir = entry.(*regexp.Regexp)
-					} else {
-						var err error
-						regexDir, err = eval.PatternToRegexp(valueDir)
-						if err != nil {
-							return false, err
-						}
-						regexCache.Add(valueDir, regexDir)
+					regexDir, err := eval.PatternToRegexp(valueDir)
+					if err != nil {
+						return false, err
 					}
 
-					if regexDir.MatchString(dirname) {
-						return false, nil
+					regexValue := value.Regexp
+					valueFnc = func(dirname string) (bool, bool, error) {
+						if regexValue.MatchString(dirname) || regexDir.MatchString(dirname) {
+							return false, false, nil
+						}
+
+						return true, false, nil
 					}
 				} else if value.Type == eval.ScalarValueType {
-					if strings.HasPrefix(value.Value.(string), dirname) {
-						return false, nil
+					str := value.Value.(string)
+					valueFnc = func(dirname string) (bool, bool, error) {
+						return !strings.HasPrefix(str, dirname), false, nil
 					}
 				} else {
-					return false, nil
+					valueFnc = func(dirname string) (bool, bool, error) {
+						return false, false, nil
+					}
 				}
+
+				valueFncs = append(valueFncs, valueFnc)
 			}
 		}
 
 		// check basename
 		if values := rule.GetFieldValues(basenameField); len(values) > 0 {
-			if err := event.SetFieldValue(basenameField, path.Base(dirname)); err != nil {
-				return false, err
-			}
+			valueFnc = func(dirname string) (bool, bool, error) {
+				if err := discarderEvent.SetFieldValue(basenameField, path.Base(dirname)); err != nil {
+					return false, false, err
+				}
 
-			if isDiscarder, _ := rs.IsDiscarder(event, basenameField); !isDiscarder {
-				return false, nil
+				if isDiscarder, _ := rs.IsDiscarder(discarderEvent, basenameField); !isDiscarder {
+					return false, true, nil
+				}
+
+				return true, true, nil
 			}
+			valueFncs = append(valueFncs, valueFnc)
 		}
 	}
 
-	if err := event.SetFieldValue(filenameField, dirname); err != nil {
-		return false, err
-	}
+	parentDiscarderFnc := func(dirname string) (bool, error) {
+		var result, altered bool
+		var err error
 
-	if isDiscarder, _ := rs.IsDiscarder(event, filenameField); !isDiscarder {
-		return false, nil
+		defer func() {
+			if altered {
+				*discarderEvent = eventZero
+			}
+		}()
+
+		for _, fnc := range valueFncs {
+			result, altered, err = fnc(dirname)
+			if !result {
+				return false, err
+			}
+		}
+
+		if err := discarderEvent.SetFieldValue(filenameField, dirname); err != nil {
+			return false, err
+		}
+
+		if isDiscarder, _ := rs.IsDiscarder(discarderEvent, filenameField); !isDiscarder {
+			return false, nil
+		}
+
+		return true, nil
 	}
+	id.parentDiscarderFnc[filenameField] = parentDiscarderFnc
 
 	seclog.Tracef("`%s` discovered as parent discarder", dirname)
 
-	return true, nil
+	return parentDiscarderFnc(dirname)
 }
 
 func (id *inodeDiscarders) discardParentInode(rs *rules.RuleSet, eventType model.EventType, field eval.Field, filename string, mountID uint32, inode uint64, pathID uint32) (bool, uint32, uint64, error) {
-	isDiscarder, err := isParentPathDiscarder(rs, id.regexCache, eventType, field, filename)
+	isDiscarder, err := id.isParentPathDiscarder(rs, eventType, field, filename)
 	if !isDiscarder {
 		return false, 0, 0, err
 	}

--- a/pkg/security/probe/discarders_test.go
+++ b/pkg/security/probe/discarders_test.go
@@ -12,14 +12,12 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/security/log"
-
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
-	"github.com/hashicorp/golang-lru/simplelru"
 )
 
-func addRuleExpr(t *testing.T, rs *rules.RuleSet, exprs ...string) {
+func addRuleExpr(t testing.TB, rs *rules.RuleSet, exprs ...string) {
 	var ruleDefs []*rules.RuleDefinition
 
 	for i, expr := range exprs {
@@ -37,59 +35,56 @@ func addRuleExpr(t *testing.T, rs *rules.RuleSet, exprs ...string) {
 }
 
 func TestIsParentDiscarder(t *testing.T) {
-	regexCache, err := simplelru.NewLRU(64, nil)
-	if err != nil {
-		t.Fatal(err)
-	}
+	id := inodeDiscarders{}
 
 	enabled := map[eval.EventType]bool{"*": true}
 
 	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/var/log/datadog/system-probe.log"); is {
+	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/log/datadog/system-probe.log"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/datadog/system-probe.sock"); !is {
+	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/datadog/system-probe.sock"); !is {
 		t.Error("should be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path == "/var/log/datadog/system-probe.log"`, `unlink.file.name == "datadog"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/var/log/datadog/datadog-agent.log"); is {
+	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/log/datadog/datadog-agent.log"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.name =~ ".*"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/.runc/1234"); is {
+	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/.runc/1234"); is {
 		t.Error("shouldn't be able to find a parent discarder, due to partial evaluation: true && unlink.file.name =~ '.*'")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path == "/etc/conf.d/httpd.conf" || unlink.file.name == "conf.d"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/nginx.conf"); is {
+	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/nginx.conf"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path == "/etc/conf.d/httpd.conf" || unlink.file.name == "sys.d"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/sys.d/nginx.conf"); is {
+	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/sys.d/nginx.conf"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.name == "conf.d"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/nginx.conf"); is {
+	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/nginx.conf"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
@@ -97,77 +92,77 @@ func TestIsParentDiscarder(t *testing.T) {
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `rename.file.path == "/etc/conf.d/abc"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileRenameEventType, "rename.file.path", "/etc/conf.d/nginx.conf"); is {
+	if is, _ := id.isParentPathDiscarder(rs, model.FileRenameEventType, "rename.file.path", "/etc/conf.d/nginx.conf"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `rename.file.path == "/etc/conf.d/abc"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileRenameEventType, "rename.file.path", "/etc/nginx/nginx.conf"); !is {
+	if is, _ := id.isParentPathDiscarder(rs, model.FileRenameEventType, "rename.file.path", "/etc/nginx/nginx.conf"); !is {
 		t.Error("should be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/conf.d/*"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/sys.d/nginx.conf"); !is {
+	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/sys.d/nginx.conf"); !is {
 		t.Error("should be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.*"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
+	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/conf.d/ab*"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
+	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.d/ab*"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
+	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.d"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
+	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/*"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileUnlinkEventType, "unlink.file.path", "/etc/cron.d/log"); is {
+	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/cron.d/log"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `open.file.path == "/tmp/passwd"`, `open.file.path == "/tmp/secret"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileOpenEventType, "open.file.path", "/tmp/runc"); is {
+	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/runc"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `open.file.path =~ "/run/secrets/kubernetes.io/serviceaccount/*/token"`, `open.file.path == "/etc/secret"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileOpenEventType, "open.file.path", "/tmp/token"); !is {
+	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/token"); !is {
 		t.Error("should be a parent discarder")
 	}
 
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `open.file.path =~ "*/token"`, `open.file.path == "/etc/secret"`)
 
-	is, err := isParentPathDiscarder(rs, regexCache, model.FileOpenEventType, "open.file.path", "/tmp/token")
+	is, err := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/token")
 	if err != nil {
 		t.Error(err)
 	}
@@ -178,7 +173,21 @@ func TestIsParentDiscarder(t *testing.T) {
 	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
 	addRuleExpr(t, rs, `open.file.path =~ "/tmp/dir/no-approver-*"`)
 
-	if is, _ := isParentPathDiscarder(rs, regexCache, model.FileOpenEventType, "open.file.path", "/tmp/dir/a/test"); !is {
+	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/dir/a/test"); !is {
 		t.Error("should be a parent discarder")
+	}
+}
+
+func BenchmarkParentDiscarder(b *testing.B) {
+	id := inodeDiscarders{}
+
+	enabled := map[eval.EventType]bool{"*": true}
+
+	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	addRuleExpr(b, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_, _ = id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/log/datadog/system-probe.log")
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Remove the use of the LRU and use a cached function chain instead:

from
```
BenchmarkParentDiscarder-2   	 2792313	       443.2 ns/op
```

to
```
BenchmarkParentDiscarder-2   	 4585756	       263.0 ns/op
```
### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
