### PR TITLE
Remove duplicate code by adding helpers for the hostname package

### DIFF
--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -179,7 +179,7 @@ func GetHostnameData(ctx context.Context) (HostnameData, error) {
 	configHostnameFilepath := config.Datadog.GetString("hostname_file")
 	if configHostnameFilepath != "" {
 		log.Debug("GetHostname trying `hostname_file` config option...")
-		if fileHostnameProvider, found := hostname.ProviderCatalog["file"]; found {
+		if fileHostnameProvider := hostname.GetProvider("file"); fileHostnameProvider != nil {
 			if hostname, err := fileHostnameProvider(
 				ctx,
 				map[string]interface{}{
@@ -206,7 +206,7 @@ func GetHostnameData(ctx context.Context) (HostnameData, error) {
 
 	// GCE metadata
 	log.Debug("GetHostname trying GCE metadata...")
-	if getGCEHostname, found := hostname.ProviderCatalog["gce"]; found {
+	if getGCEHostname := hostname.GetProvider("gce"); getGCEHostname != nil {
 		gceName, err := getGCEHostname(ctx, nil)
 		if err == nil {
 			hostnameData := saveHostnameData(cacheHostnameKey, gceName, "gce")
@@ -269,7 +269,7 @@ func GetHostnameData(ctx context.Context) (HostnameData, error) {
 
 	// We use the instance id if we're on an ECS cluster or we're on EC2
 	// and the hostname is one of the default ones
-	if getEC2Hostname, found := hostname.ProviderCatalog["ec2"]; found {
+	if getEC2Hostname := hostname.GetProvider("ec2"); getEC2Hostname != nil {
 		log.Debug("GetHostname trying EC2 metadata...")
 
 		if ecs.IsECSInstance() || ec2.IsDefaultHostname(hostName) {
@@ -307,7 +307,7 @@ func GetHostnameData(ctx context.Context) (HostnameData, error) {
 		}
 	}
 
-	if getAzureHostname, found := hostname.ProviderCatalog["azure"]; found {
+	if getAzureHostname := hostname.GetProvider("azure"); getAzureHostname != nil {
 		log.Debug("GetHostname trying Azure metadata...")
 
 		azureHostname, err := getAzureHostname(ctx, nil)

--- a/pkg/util/hostname/providers.go
+++ b/pkg/util/hostname/providers.go
@@ -5,15 +5,45 @@
 
 package hostname
 
-import "context"
+import (
+	"context"
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/util/hostname/validate"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
 
 // Provider is a generic function to grab the hostname and return it
 type Provider func(ctx context.Context, options map[string]interface{}) (string, error)
 
-// ProviderCatalog holds all the various kinds of hostname providers
-var ProviderCatalog = make(map[string]Provider)
+// providerCatalog holds all the various kinds of hostname providers
+var providerCatalog = make(map[string]Provider)
 
 // RegisterHostnameProvider registers a hostname provider as part of the catalog
 func RegisterHostnameProvider(name string, p Provider) {
-	ProviderCatalog[name] = p
+	providerCatalog[name] = p
+}
+
+// GetProvider returns a Provider if it was register before.
+func GetProvider(providerName string) Provider {
+	if provider, found := providerCatalog[providerName]; found {
+		return provider
+	}
+	return nil
+}
+
+// GetHostname returns the hostname for a specific Provider if it was register
+func GetHostname(ctx context.Context, providerName string, options map[string]interface{}) (string, error) {
+	if provider, found := providerCatalog[providerName]; found {
+		log.Debugf("GetHostname trying provider '%s' ...", providerName)
+		name, err := provider(ctx, options)
+		if err != nil {
+			return "", err
+		}
+		if validate.ValidHostname(name) != nil {
+			return "", fmt.Errorf("Invalid hostname '%s' from %s provider", name, providerName)
+		}
+		return name, nil
+	}
+	return "", fmt.Errorf("hostname provider %s not found", providerName)
 }

--- a/pkg/util/hostname/providers_test.go
+++ b/pkg/util/hostname/providers_test.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package hostname
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func dummyProvider(ctx context.Context, options map[string]interface{}) (string, error) {
+	return "dummy-hostname", nil
+}
+
+func dummyErrorProvider(ctx context.Context, options map[string]interface{}) (string, error) {
+	return "", fmt.Errorf("Some error")
+}
+
+func dummyInvalideProvider(ctx context.Context, options map[string]interface{}) (string, error) {
+	return "some invalid hostname", nil
+}
+
+func TestRegisterHostnameProvider(t *testing.T) {
+	RegisterHostnameProvider("dummy", dummyProvider)
+	assert.Contains(t, providerCatalog, "dummy")
+	delete(providerCatalog, "dummy")
+}
+
+func TestGetProvider(t *testing.T) {
+	RegisterHostnameProvider("dummy", dummyProvider)
+	defer delete(providerCatalog, "dummy")
+	assert.NotNil(t, GetProvider("dummy"))
+	assert.Nil(t, GetProvider("does not exists"))
+}
+
+func TestGetHostname(t *testing.T) {
+	RegisterHostnameProvider("dummy", dummyProvider)
+	defer delete(providerCatalog, "dummy")
+
+	name, err := GetHostname(context.Background(), "dummy", nil)
+	assert.NoError(t, err)
+	assert.Equal(t, "dummy-hostname", name)
+}
+
+func TestGetHostnameUnknown(t *testing.T) {
+	_, err := GetHostname(context.Background(), "dummy", nil)
+	assert.Error(t, err)
+}
+
+func TestGetHostnameError(t *testing.T) {
+	RegisterHostnameProvider("dummy", dummyErrorProvider)
+	defer delete(providerCatalog, "dummy")
+
+	_, err := GetHostname(context.Background(), "dummy", nil)
+	assert.Error(t, err)
+}
+
+func TestGetHostnameInvalid(t *testing.T) {
+	RegisterHostnameProvider("dummy", dummyInvalideProvider)
+	defer delete(providerCatalog, "dummy")
+
+	_, err := GetHostname(context.Background(), "dummy", nil)
+	assert.Error(t, err)
+}

--- a/pkg/util/hostname_docker.go
+++ b/pkg/util/hostname_docker.go
@@ -14,41 +14,35 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/hostname"
-	"github.com/DataDog/datadog-agent/pkg/util/hostname/validate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func getContainerHostname(ctx context.Context) string {
 	if config.IsFeaturePresent(config.Kubernetes) {
 		// Cluster-agent logic: Kube apiserver
-		if getKubeHostname, found := hostname.ProviderCatalog["kube_apiserver"]; found {
-			log.Debug("GetHostname trying Kubernetes trough API server...")
-			name, err := getKubeHostname(ctx, nil)
-			if err == nil && validate.ValidHostname(name) == nil {
-				return name
-			}
+		name, err := hostname.GetHostname(ctx, "kube_apiserver", nil)
+		if err == nil {
+			return name
 		}
+		log.Debug(err.Error())
 	}
 
 	// Node-agent logic: docker or kubelet
 	if config.IsFeaturePresent(config.Docker) {
 		log.Debug("GetHostname trying Docker API...")
-		if getDockerHostname, found := hostname.ProviderCatalog["docker"]; found {
-			name, err := getDockerHostname(ctx, nil)
-			if err == nil && validate.ValidHostname(name) == nil {
-				return name
-			}
+		name, err := hostname.GetHostname(ctx, "docker", nil)
+		if err == nil {
+			return name
 		}
+		log.Debug(err.Error())
 	}
 
 	if config.IsFeaturePresent(config.Kubernetes) {
-		if getKubeletHostname, found := hostname.ProviderCatalog["kubelet"]; found {
-			log.Debug("GetHostname trying Kubernetes trough kubelet API...")
-			name, err := getKubeletHostname(ctx, nil)
-			if err == nil && validate.ValidHostname(name) == nil {
-				return name
-			}
+		name, err := hostname.GetHostname(ctx, "kubelet", nil)
+		if err == nil {
+			return name
 		}
+		log.Debug(err.Error())
 	}
 
 	return ""

--- a/pkg/util/hostname_docker_stub.go
+++ b/pkg/util/hostname_docker_stub.go
@@ -9,6 +9,6 @@ package util
 
 import "context"
 
-func getContainerHostname(ctx context.Context) (bool, string) {
-	return false, ""
+func getContainerHostname(ctx context.Context) string {
+	return ""
 }


### PR DESCRIPTION
### What does this PR do?

Remove duplicate code by adding helpers for the hostname package

### Motivation

The hostname package was split between multiple places making it harder to add new hostname providers.

### Describe how to test your changes

Deploy somewhere  and check that the hostname haven't changed. This could be tested on our staging/QA infra.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
