### PR TITLE
Revert "Revert "[corechecks/snmp] Use GetNext as fallback on GetBulk failure""

### DIFF
--- a/pkg/collector/corechecks/snmp/fetch/fetch.go
+++ b/pkg/collector/corechecks/snmp/fetch/fetch.go
@@ -2,11 +2,32 @@ package fetch
 
 import (
 	"fmt"
+	"strconv"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/checkconfig"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/session"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/valuestore"
 )
+
+type columnFetchStrategy int
+
+const (
+	useGetBulk columnFetchStrategy = iota
+	useGetNext
+)
+
+func (c columnFetchStrategy) String() string {
+	switch c {
+	case useGetBulk:
+		return "useGetBulk"
+	case useGetNext:
+		return "useGetNext"
+	default:
+		return strconv.Itoa(int(c))
+	}
+}
 
 // Fetch oid values from device
 // TODO: pass only specific configs instead of the whole CheckConfig
@@ -22,9 +43,15 @@ func Fetch(sess session.Session, config *checkconfig.CheckConfig) (*valuestore.R
 	for _, value := range config.OidConfig.ColumnOids {
 		oids[value] = value
 	}
-	columnResults, err := fetchColumnOidsWithBatching(sess, oids, config.OidBatchSize, config.BulkMaxRepetitions)
+
+	columnResults, err := fetchColumnOidsWithBatching(sess, oids, config.OidBatchSize, config.BulkMaxRepetitions, useGetBulk)
 	if err != nil {
-		return nil, fmt.Errorf("failed to fetch oids with batching: %v", err)
+		log.Debugf("failed to fetch oids with GetBulk batching: %v", err)
+
+		columnResults, err = fetchColumnOidsWithBatching(sess, oids, config.OidBatchSize, config.BulkMaxRepetitions, useGetNext)
+		if err != nil {
+			return nil, fmt.Errorf("failed to fetch oids with GetNext batching: %v", err)
+		}
 	}
 
 	return &valuestore.ResultValueStore{ScalarValues: scalarResults, ColumnValues: columnResults}, nil

--- a/pkg/collector/corechecks/snmp/fetch/fetch_column.go
+++ b/pkg/collector/corechecks/snmp/fetch/fetch_column.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/valuestore"
 )
 
-func fetchColumnOidsWithBatching(sess session.Session, oids map[string]string, oidBatchSize int, bulkMaxRepetitions uint32) (valuestore.ColumnResultValuesType, error) {
+func fetchColumnOidsWithBatching(sess session.Session, oids map[string]string, oidBatchSize int, bulkMaxRepetitions uint32, fetchStrategy columnFetchStrategy) (valuestore.ColumnResultValuesType, error) {
 	retValues := make(valuestore.ColumnResultValuesType, len(oids))
 
 	columnOids := getOidsMapKeys(oids)
@@ -31,7 +31,7 @@ func fetchColumnOidsWithBatching(sess session.Session, oids map[string]string, o
 			oidsToFetch[oid] = oids[oid]
 		}
 
-		results, err := fetchColumnOids(sess, oidsToFetch, bulkMaxRepetitions)
+		results, err := fetchColumnOids(sess, oidsToFetch, bulkMaxRepetitions, fetchStrategy)
 		if err != nil {
 			return nil, fmt.Errorf("failed to fetch column oids: %s", err)
 		}
@@ -52,7 +52,7 @@ func fetchColumnOidsWithBatching(sess session.Session, oids map[string]string, o
 // fetchColumnOids has an `oids` argument representing a `map[string]string`,
 // the key of the map is the column oid, and the value is the oid used to fetch the next value for the column.
 // The value oid might be equal to column oid or a row oid of the same column.
-func fetchColumnOids(sess session.Session, oids map[string]string, bulkMaxRepetitions uint32) (valuestore.ColumnResultValuesType, error) {
+func fetchColumnOids(sess session.Session, oids map[string]string, bulkMaxRepetitions uint32, fetchStrategy columnFetchStrategy) (valuestore.ColumnResultValuesType, error) {
 	returnValues := make(valuestore.ColumnResultValuesType, len(oids))
 	alreadyProcessedOids := make(map[string]bool)
 	curOids := oids
@@ -60,7 +60,7 @@ func fetchColumnOids(sess session.Session, oids map[string]string, bulkMaxRepeti
 		if len(curOids) == 0 {
 			break
 		}
-		log.Debugf("fetch column: request oids: %v", curOids)
+		log.Debugf("fetch column: request oids (maxRep:%d,fetchStrategy:%s): %v", bulkMaxRepetitions, fetchStrategy, curOids)
 		var columnOids, requestOids []string
 		for k, v := range curOids {
 			if alreadyProcessedOids[v] {
@@ -78,7 +78,7 @@ func fetchColumnOids(sess session.Session, oids map[string]string, bulkMaxRepeti
 		sort.Strings(columnOids)
 		sort.Strings(requestOids)
 
-		results, err := getResults(sess, requestOids, bulkMaxRepetitions)
+		results, err := getResults(sess, requestOids, bulkMaxRepetitions, fetchStrategy)
 		if err != nil {
 			return nil, err
 		}
@@ -89,9 +89,9 @@ func fetchColumnOids(sess session.Session, oids map[string]string, bulkMaxRepeti
 	return returnValues, nil
 }
 
-func getResults(sess session.Session, requestOids []string, bulkMaxRepetitions uint32) (*gosnmp.SnmpPacket, error) {
+func getResults(sess session.Session, requestOids []string, bulkMaxRepetitions uint32, fetchStrategy columnFetchStrategy) (*gosnmp.SnmpPacket, error) {
 	var results *gosnmp.SnmpPacket
-	if sess.GetVersion() == gosnmp.Version1 {
+	if sess.GetVersion() == gosnmp.Version1 || fetchStrategy == useGetNext {
 		// snmp v1 doesn't support GetBulk
 		getNextResults, err := sess.GetNext(requestOids)
 		if err != nil {

--- a/pkg/collector/corechecks/snmp/fetch/fetch_test.go
+++ b/pkg/collector/corechecks/snmp/fetch/fetch_test.go
@@ -85,7 +85,7 @@ func Test_fetchColumnOids(t *testing.T) {
 
 	oids := map[string]string{"1.1.1": "1.1.1", "1.1.2": "1.1.2"}
 
-	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 100, checkconfig.DefaultBulkMaxRepetitions)
+	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 100, checkconfig.DefaultBulkMaxRepetitions, useGetBulk)
 	assert.Nil(t, err)
 
 	expectedColumnValues := valuestore.ColumnResultValuesType{
@@ -176,7 +176,7 @@ func Test_fetchColumnOidsBatch_usingGetBulk(t *testing.T) {
 
 	oids := map[string]string{"1.1.1": "1.1.1", "1.1.2": "1.1.2"}
 
-	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 2, 10)
+	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 2, 10, useGetBulk)
 	assert.Nil(t, err)
 
 	expectedColumnValues := valuestore.ColumnResultValuesType{
@@ -273,7 +273,7 @@ func Test_fetchColumnOidsBatch_usingGetNext(t *testing.T) {
 
 	oids := map[string]string{"1.1.1": "1.1.1", "1.1.2": "1.1.2", "1.1.3": "1.1.3"}
 
-	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 2, 10)
+	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 2, 10, useGetBulk)
 	assert.Nil(t, err)
 
 	expectedColumnValues := valuestore.ColumnResultValuesType{
@@ -286,6 +286,109 @@ func Test_fetchColumnOidsBatch_usingGetNext(t *testing.T) {
 		},
 		"1.1.3": {
 			"1": valuestore.ResultValue{Value: float64(31)},
+		},
+	}
+	assert.Equal(t, expectedColumnValues, columnValues)
+}
+
+func Test_fetchColumnOidsBatch_usingGetBulkAndGetNextFallback(t *testing.T) {
+	sess := session.CreateMockSession()
+	// When using snmp v2+, we will try GetBulk first and fallback using GetNext
+	sess.Version = gosnmp.Version2c
+
+	bulkPacket := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.1.1.1",
+				Type:  gosnmp.TimeTicks,
+				Value: 11,
+			},
+			{
+				Name:  "1.1.2.1",
+				Type:  gosnmp.TimeTicks,
+				Value: 21,
+			},
+		},
+	}
+
+	bulkPacket2 := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.1.1.2",
+				Type:  gosnmp.TimeTicks,
+				Value: 12,
+			},
+			{
+				Name:  "1.1.9.1",
+				Type:  gosnmp.TimeTicks,
+				Value: 91,
+			},
+		},
+	}
+	bulkPacket3 := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.1.9.2",
+				Type:  gosnmp.TimeTicks,
+				Value: 91,
+			},
+		},
+	}
+
+	secondBatchPacket1 := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.1.3.1",
+				Type:  gosnmp.TimeTicks,
+				Value: 31,
+			},
+		},
+	}
+
+	secondBatchPacket2 := gosnmp.SnmpPacket{
+		Variables: []gosnmp.SnmpPDU{
+			{
+				Name:  "1.1.9.1",
+				Type:  gosnmp.TimeTicks,
+				Value: 91,
+			},
+		},
+	}
+
+	sess.On("GetBulk", []string{"1.1.1", "1.1.2"}, checkconfig.DefaultBulkMaxRepetitions).Return(&gosnmp.SnmpPacket{}, fmt.Errorf("bulk error"))
+
+	// First batch
+	sess.On("GetNext", []string{"1.1.1", "1.1.2"}).Return(&bulkPacket, nil)
+	sess.On("GetNext", []string{"1.1.1.1", "1.1.2.1"}).Return(&bulkPacket2, nil)
+	sess.On("GetNext", []string{"1.1.1.2"}).Return(&bulkPacket3, nil)
+
+	// Second batch
+	sess.On("GetNext", []string{"1.1.3"}).Return(&secondBatchPacket1, nil)
+	sess.On("GetNext", []string{"1.1.3.1"}).Return(&secondBatchPacket2, nil)
+
+	config := &checkconfig.CheckConfig{
+		BulkMaxRepetitions: checkconfig.DefaultBulkMaxRepetitions,
+		OidBatchSize:       2,
+		OidConfig: checkconfig.OidConfig{
+			ColumnOids: []string{"1.1.1", "1.1.2", "1.1.3"},
+		},
+	}
+	columnValues, err := Fetch(sess, config)
+	assert.Nil(t, err)
+
+	expectedColumnValues := &valuestore.ResultValueStore{
+		ScalarValues: valuestore.ScalarResultValuesType{},
+		ColumnValues: valuestore.ColumnResultValuesType{
+			"1.1.1": {
+				"1": valuestore.ResultValue{Value: float64(11)},
+				"2": valuestore.ResultValue{Value: float64(12)},
+			},
+			"1.1.2": {
+				"1": valuestore.ResultValue{Value: float64(21)},
+			},
+			"1.1.3": {
+				"1": valuestore.ResultValue{Value: float64(31)},
+			},
 		},
 	}
 	assert.Equal(t, expectedColumnValues, columnValues)
@@ -636,7 +739,7 @@ func Test_fetchValues_errors(t *testing.T) {
 					ColumnOids: []string{"1.1", "2.2"},
 				},
 			},
-			expectedError: fmt.Errorf("failed to fetch oids with batching: failed to fetch column oids: fetch column: failed getting oids `[1.1 2.2]` using GetBulk: bulk error"),
+			expectedError: fmt.Errorf("failed to fetch oids with GetNext batching: failed to fetch column oids: fetch column: failed getting oids `[1.1 2.2]` using GetNext: getnext error"),
 		},
 	}
 	for _, tt := range tests {
@@ -644,6 +747,7 @@ func Test_fetchValues_errors(t *testing.T) {
 			sess := session.CreateMockSession()
 			sess.On("Get", []string{"1.1", "2.2"}).Return(&gosnmp.SnmpPacket{}, fmt.Errorf("get error"))
 			sess.On("GetBulk", []string{"1.1", "2.2"}, checkconfig.DefaultBulkMaxRepetitions).Return(&gosnmp.SnmpPacket{}, fmt.Errorf("bulk error"))
+			sess.On("GetNext", []string{"1.1", "2.2"}).Return(&gosnmp.SnmpPacket{}, fmt.Errorf("getnext error"))
 
 			_, err := Fetch(sess, &tt.config)
 

--- a/pkg/collector/corechecks/snmp/fetch/fetch_test.go
+++ b/pkg/collector/corechecks/snmp/fetch/fetch_test.go
@@ -857,7 +857,7 @@ func Test_fetchColumnOids_alreadyProcessed(t *testing.T) {
 
 	oids := map[string]string{"1.1.1": "1.1.1", "1.1.2": "1.1.2"}
 
-	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 100, checkconfig.DefaultBulkMaxRepetitions)
+	columnValues, err := fetchColumnOidsWithBatching(sess, oids, 100, checkconfig.DefaultBulkMaxRepetitions, useGetBulk)
 	assert.Nil(t, err)
 
 	expectedColumnValues := valuestore.ColumnResultValuesType{


### PR DESCRIPTION
Reverts DataDog/datadog-agent#9729

This is a revert-revert of this initial PR https://github.com/DataDog/datadog-agent/pull/9704

It has been previously reverted (https://github.com/DataDog/datadog-agent/pull/9729) due to a conflict on main branch with this other PR (https://github.com/DataDog/datadog-agent/pull/9704), it's fixed by this commit https://github.com/DataDog/datadog-agent/pull/9730/commits/51fd5788ba83beb377e992ea02de0463355441d2