### PR TITLE
[networks] Fix HTTP connection joining in certain cases

### DIFF
--- a/pkg/network/http/http_statkeeper.go
+++ b/pkg/network/http/http_statkeeper.go
@@ -89,6 +89,16 @@ func (h *httpStatKeeper) handleIncomplete(tx httpTX) {
 		request, response = response, request
 	}
 
+	if request.request_started == 0 || response.response_status_code == 0 || request.request_started > response.response_last_seen {
+		// This means we can't join these parts as they don't belong to the same transaction.
+		// In this case, as a best-effort we override the incomplete entry with the latest one
+		// we got from eBPF, so it can be joined by it's other half at a later moment.
+		// This can happen because we can get out-of-order half transactions from eBPF
+		atomic.AddInt64(&h.telemetry.dropped, 1)
+		h.incomplete[key] = tx
+		return
+	}
+
 	// Merge response into request
 	request.response_status_code = response.response_status_code
 	request.response_last_seen = response.response_last_seen

--- a/pkg/network/http/monitor_test.go
+++ b/pkg/network/http/monitor_test.go
@@ -44,8 +44,51 @@ func TestHTTPMonitorIntegrationWithNAT(t *testing.T) {
 	testHTTPMonitor(t, targetAddr, serverAddr, 10)
 }
 
+func TestUnknownMethodRegression(t *testing.T) {
+	currKernelVersion, err := kernel.HostVersion()
+	require.NoError(t, err)
+	if currKernelVersion < kernel.VersionCode(4, 1, 0) {
+		t.Skip("HTTP feature not available on pre 4.1.0 kernels")
+	}
+
+	// SetupDNAT sets up a NAT translation from 2.2.2.2 to 1.1.1.1
+	netlink.SetupDNAT(t)
+	defer netlink.TeardownDNAT(t)
+
+	targetAddr := "2.2.2.2:8080"
+	serverAddr := "1.1.1.1:8080"
+	srvDoneFn := testutil.HTTPServer(t, serverAddr, testutil.Options{
+		EnableTLS:        false,
+		EnableKeepAlives: true,
+	})
+	defer srvDoneFn()
+
+	monitor, err := NewMonitor(config.New(), nil, nil)
+	require.NoError(t, err)
+	err = monitor.Start()
+	require.NoError(t, err)
+	defer monitor.Stop()
+
+	requestFn := requestGenerator(t, targetAddr)
+	for i := 0; i < 100; i++ {
+		requestFn()
+	}
+
+	time.Sleep(10 * time.Millisecond)
+	stats := monitor.GetHTTPStats()
+
+	for key := range stats {
+		if key.Method == MethodUnknown {
+			t.Error("detected HTTP request with method unknown")
+		}
+	}
+}
+
 func testHTTPMonitor(t *testing.T, targetAddr, serverAddr string, numReqs int) {
-	srvDoneFn := testutil.HTTPServer(t, serverAddr, false)
+	srvDoneFn := testutil.HTTPServer(t, serverAddr, testutil.Options{
+		EnableTLS:        false,
+		EnableKeepAlives: false,
+	})
 	defer srvDoneFn()
 
 	monitor, err := NewMonitor(config.New(), nil, nil)

--- a/pkg/network/http/testutil/testutil.go
+++ b/pkg/network/http/testutil/testutil.go
@@ -16,13 +16,19 @@ import (
 	"time"
 )
 
+// Options wraps all configurable params for the HTTPServer
+type Options struct {
+	EnableTLS        bool
+	EnableKeepAlives bool
+}
+
 // HTTPServer spins up a HTTP test server that returns the status code included in the URL
 // Example:
 // * GET /200/foo returns a 200 status code;
 // * PUT /404/bar returns a 404 status code;
 // Optional TLS support using a self-signed certificate can be enabled trough the `enableTLS` argument
 // nolint
-func HTTPServer(t *testing.T, addr string, enableTLS bool) func() {
+func HTTPServer(t *testing.T, addr string, options Options) func() {
 	handler := func(w http.ResponseWriter, req *http.Request) {
 		statusCode := StatusFromPath(req.URL.Path)
 		io.Copy(ioutil.Discard, req.Body)
@@ -39,7 +45,7 @@ func HTTPServer(t *testing.T, addr string, enableTLS bool) func() {
 	listenFn := func() { _ = srv.ListenAndServe() }
 
 	// If certPath is set we enabled TLS
-	if enableTLS {
+	if options.EnableTLS {
 		curDir, _ := curDir()
 		crtPath := filepath.Join(curDir, "testdata/cert.pem.0")
 		keyPath := filepath.Join(curDir, "testdata/server.key")
@@ -47,7 +53,7 @@ func HTTPServer(t *testing.T, addr string, enableTLS bool) func() {
 	}
 
 	go listenFn()
-	srv.SetKeepAlivesEnabled(false)
+	srv.SetKeepAlivesEnabled(options.EnableKeepAlives)
 	return func() { srv.Shutdown(context.Background()) }
 }
 

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1558,8 +1558,9 @@ func TestHTTPSViaOpenSSLIntegration(t *testing.T) {
 	defer tr.Stop()
 
 	// Spin-up HTTPS server
-	enableTLS := true
-	serverDoneFn := testutil.HTTPServer(t, "127.0.0.1:443", enableTLS)
+	serverDoneFn := testutil.HTTPServer(t, "127.0.0.1:443", testutil.Options{
+		EnableTLS: true,
+	})
 	defer serverDoneFn()
 
 	// Run wget once to make sure the OpenSSL is detected and uprobes are attached


### PR DESCRIPTION
### What does this PR do?

Ensure that we don't accidentally join two unrelated parts ("request" and "response") of a HTTP transaction.
This should only affect HTTP traffic that 
1) has NAT
2) is internal (both source and destination addresses belong to localhost)

### Motivation

Address incorrect data that is being occasionally reported.
(This has been surfacing as requests of `Unknown` method)

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
