### PR TITLE
pkg/trace: enable configuration of error sampler tps

### DIFF
--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -64,6 +64,7 @@ func setupAPM(config Config) {
 	config.BindEnv("apm_config.log_file", "DD_APM_LOG_FILE")
 	config.BindEnv("apm_config.max_events_per_second", "DD_APM_MAX_EPS", "DD_MAX_EPS")
 	config.BindEnv("apm_config.max_traces_per_second", "DD_APM_MAX_TPS", "DD_MAX_TPS")
+	config.BindEnv("apm_config.errors_per_second", "DD_APM_ERROR_TPS")
 	config.BindEnv("apm_config.max_memory", "DD_APM_MAX_MEMORY")
 	config.BindEnv("apm_config.max_cpu_percent", "DD_APM_MAX_CPU_PERCENT")
 	config.BindEnv("apm_config.env", "DD_APM_ENV")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -959,7 +959,7 @@ api_key:
 
   ## @param max_traces_per_second - integer - optional - default: 10
   ## @env DD_APM_CONFIG_MAX_TRACES_PER_SECOND - integer - optional - default: 10
-  ## Target traces per second to sample. Sampling rates to apply are adjusted given
+  ## The target traces per second to sample. Sampling rates to apply are adjusted given
   ## the received traffic and communicated to tracers. This configures head base sampling.
   ## Set to 0 to disable sampling.
   #
@@ -967,8 +967,8 @@ api_key:
 
   ## @param errors_per_second - integer - optional - default: 10
   ## @env DD_APM_ERROR_TPS - integer - optional - default: 10
-  ## Target error trace chunks to receive per second. The tps is spread
-  ## to catch all combinations of (service, name, resource, http.status, error.type).
+  ## The target error trace chunks to receive per second. The TPS is spread
+  ## to catch all combinations of service, name, resource, http.status, and error.type.
   ## Set to 0 to disable the errors sampler.
   #
   # errors_per_second: 10

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -959,10 +959,19 @@ api_key:
 
   ## @param max_traces_per_second - integer - optional - default: 10
   ## @env DD_APM_CONFIG_MAX_TRACES_PER_SECOND - integer - optional - default: 10
-  ## Maximum number of traces per second to sample. The limit is applied over an average over
-  ## a few minutes ; much bigger spikes are possible. Set to 0 to disable the limit.
+  ## Target traces per second to sample. Sampling rates to apply are adjusted given
+  ## the received traffic and communicated to tracers. This configures head base sampling.
+  ## Set to 0 to disable sampling.
   #
   # max_traces_per_second: 10
+
+  ## @param errors_per_second - integer - optional - default: 10
+  ## @env DD_APM_ERROR_TPS - integer - optional - default: 10
+  ## Target error trace chunks to receive per second. The tps is spread
+  ## to catch all combinations of (service, name, resource, http.status, error.type).
+  ## Set to 0 to disable the errors sampler.
+  #
+  # errors_per_second: 10
 
   ## @param max_events_per_second - integer - optional - default: 200
   ## @env DD_APM_CONFIG_MAX_EVENTS_PER_SECOND - integer - optional - default: 200

--- a/pkg/flare/envvars.go
+++ b/pkg/flare/envvars.go
@@ -53,6 +53,7 @@ var allowedEnvvarNames = []string{
 	"DD_APM_MAX_EPS",
 	"DD_APM_TPS", //deprecated
 	"DD_APM_MAX_TPS",
+	"DD_APM_ERROR_TPS",
 	"DD_APM_MAX_MEMORY",
 	"DD_APM_MAX_CPU_PERCENT",
 	"DD_APM_FEATURES",

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -623,7 +623,7 @@ func TestSampling(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			cfg := &config.AgentConfig{}
-			sampledCfg := &config.AgentConfig{ExtraSampleRate: 1}
+			sampledCfg := &config.AgentConfig{ExtraSampleRate: 1, ErrorTPS: 10}
 			a := &Agent{
 				NoPrioritySampler: sampler.NewNoPrioritySampler(cfg),
 				ErrorsSampler:     sampler.NewErrorsSampler(cfg),

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -260,6 +260,10 @@ func (c *AgentConfig) applyDatadogConfig() error {
 	if config.Datadog.IsSet("apm_config.max_traces_per_second") {
 		c.TargetTPS = config.Datadog.GetFloat64("apm_config.max_traces_per_second")
 	}
+	if config.Datadog.IsSet("apm_config.errors_per_second") {
+		c.ErrorTPS = config.Datadog.GetFloat64("apm_config.errors_per_second")
+	}
+
 	if k := "apm_config.ignore_resources"; config.Datadog.IsSet(k) {
 		c.Ignore["resource"] = config.Datadog.GetStringSlice(k)
 	}

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -70,6 +70,7 @@ type AgentConfig struct {
 	// Sampler configuration
 	ExtraSampleRate float64
 	TargetTPS       float64
+	ErrorTPS        float64
 	MaxEPS          float64
 
 	// Receiver
@@ -160,6 +161,7 @@ func New() *AgentConfig {
 
 		ExtraSampleRate: 1.0,
 		TargetTPS:       10,
+		ErrorTPS:        10,
 		MaxEPS:          200,
 
 		ReceiverHost:    "localhost",

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -328,6 +328,7 @@ func TestUndocumentedYamlConfig(t *testing.T) {
 	assert.Equal("apikey_12", c.Endpoints[0].APIKey)
 	assert.Equal(0.33, c.ExtraSampleRate)
 	assert.Equal(100.0, c.TargetTPS)
+	assert.Equal(37.0, c.ErrorTPS)
 	assert.Equal(1000.0, c.MaxEPS)
 	assert.Equal(25, c.ReceiverPort)
 	assert.Equal(120*time.Second, c.ConnectionResetInterval)

--- a/pkg/trace/config/env_test.go
+++ b/pkg/trace/config/env_test.go
@@ -310,6 +310,21 @@ func TestLoadEnv(t *testing.T) {
 	}
 
 	for _, envKey := range []string{
+		"DD_APM_ERROR_TPS",
+	} {
+		t.Run(envKey, func(t *testing.T) {
+			defer cleanConfig()()
+			assert := assert.New(t)
+			err := os.Setenv(envKey, "12")
+			assert.NoError(err)
+			defer os.Unsetenv(envKey)
+			cfg, err := Load("./testdata/full.yaml")
+			assert.NoError(err)
+			assert.Equal(12., cfg.ErrorTPS)
+		})
+	}
+
+	for _, envKey := range []string{
 		"DD_MAX_EPS", // deprecated
 		"DD_APM_MAX_EPS",
 	} {

--- a/pkg/trace/config/testdata/undocumented.yaml
+++ b/pkg/trace/config/testdata/undocumented.yaml
@@ -4,6 +4,7 @@ apm_config:
   extra_sample_rate: 0.33
   dd_agent_bin: /path/to/bin
   max_traces_per_second: 100.0
+  errors_per_second: 37.0
   max_events_per_second: 1000.0
   connection_reset_interval: 120
   receiver_port: 25

--- a/pkg/trace/sampler/scoresampler_test.go
+++ b/pkg/trace/sampler/scoresampler_test.go
@@ -20,14 +20,14 @@ import (
 
 const defaultEnv = "none"
 
-func getTestErrorsSampler() *ErrorsSampler {
+func getTestErrorsSampler(tps float64) *ErrorsSampler {
 	// Disable debug logs in these tests
 	seelog.UseLogger(seelog.Disabled)
 
 	// No extra fixed sampling, no maximum TPS
 	conf := &config.AgentConfig{
 		ExtraSampleRate: 1,
-		TargetTPS:       0,
+		ErrorTPS:        tps,
 	}
 	return NewErrorsSampler(conf)
 }
@@ -44,7 +44,7 @@ func getTestTrace() (pb.Trace, *pb.Span) {
 func TestExtraSampleRate(t *testing.T) {
 	assert := assert.New(t)
 
-	s := getTestErrorsSampler()
+	s := getTestErrorsSampler(10)
 	trace, root := getTestTrace()
 	signature := testComputeSignature(trace)
 
@@ -61,33 +61,12 @@ func TestExtraSampleRate(t *testing.T) {
 	assert.Equal(s.GetSampleRate(trace, root, signature), s.extraRate*sRate)
 }
 
-func TestErrorSampleThresholdTo1(t *testing.T) {
-	assert := assert.New(t)
-	env := defaultEnv
-
-	s := getTestErrorsSampler()
-	for i := 0; i < 1e2; i++ {
-		trace, root := getTestTrace()
-		s.Sample(trace, root, env)
-		rate, _ := root.Metrics["_dd.errors_sr"]
-		assert.Equal(1.0, rate)
-	}
-	for i := 0; i < 1e3; i++ {
-		trace, root := getTestTrace()
-		s.Sample(trace, root, env)
-		rate, _ := root.Metrics["_dd.errors_sr"]
-		if rate < 1 {
-			assert.True(rate < errorSamplingRateThresholdTo1)
-		}
-	}
-}
-
 func TestTargetTPS(t *testing.T) {
 	// Test the "effectiveness" of the targetTPS option.
 	assert := assert.New(t)
-	s := getTestErrorsSampler()
-
 	targetTPS := 5.0
+	s := getTestErrorsSampler(targetTPS)
+
 	tps := 100.0
 	// To avoid the edge effects from an non-initialized sampler, wait a bit before counting samples.
 	initPeriods := 20
@@ -127,13 +106,23 @@ func TestTargetTPS(t *testing.T) {
 		0.01+defaultDecayFactor-1)
 }
 
+func TestDisable(t *testing.T) {
+	assert := assert.New(t)
+
+	s := getTestErrorsSampler(0)
+	trace, root := getTestTrace()
+	for i := 0; i < int(1e2); i++ {
+		assert.False(s.Sample(trace, root, defaultEnv))
+	}
+}
+
 func BenchmarkSampler(b *testing.B) {
 	// Benchmark the resource consumption of many traces sampling
 
 	// Up to signatureCount different signatures
 	signatureCount := 20
 
-	s := getTestErrorsSampler()
+	s := getTestErrorsSampler(10)
 
 	b.ResetTimer()
 	b.ReportAllocs()

--- a/releasenotes/notes/apm-error-sampler-configurable-90589d4753bdc1d6.yaml
+++ b/releasenotes/notes/apm-error-sampler-configurable-90589d4753bdc1d6.yaml
@@ -1,4 +1,4 @@
-# Each section from every release note are combined when the
+# Each section from every release note is combined when the
 # CHANGELOG.rst is rendered. So the text needs to be worded so that
 # it does not depend on any information only available in another
 # section. This may mean repeating some details, but each section
@@ -11,8 +11,8 @@ features:
     APM: The error sampler TPS can be configured using the environment variable DD_APM_ERROR_TPS
     or the `apm_config.error_traces_per_second` configuration. It defaults to 10 extra trace chunks sampled 
     per second on top of the base head sampling.
-    The TPS is spread to catch all combinations of service, name, resource, http.status and error.type.
+    The TPS is spread to catch all combinations of service, name, resource, http.status, and error.type.
 upgrade:
   - |
-    APM: The `apm_config.max_traces_per_second` setting no longer affects errors sampling.
+    APM: The `apm_config.max_traces_per_second` setting no longer affects error sampling.
     To change the TPS for errors, use `apm_config.error_traces_per_second` instead.

--- a/releasenotes/notes/apm-error-sampler-configurable-90589d4753bdc1d6.yaml
+++ b/releasenotes/notes/apm-error-sampler-configurable-90589d4753bdc1d6.yaml
@@ -12,6 +12,6 @@ features:
     DD_APM_ERROR_TPS or the configuration `apm_config.error_traces_per_second`. The trace-agent 
     defaults to 10 extra trace chunks sampled per second above the head base sampling.
     The tps is spread to catch all combinations of (service, name, resource, http.status, error.type).
-upgrades:
+upgrade:
   - |
     APM: Configuration `max_traces_per_second` does not affect anymore errors sampling.

--- a/releasenotes/notes/apm-error-sampler-configurable-90589d4753bdc1d6.yaml
+++ b/releasenotes/notes/apm-error-sampler-configurable-90589d4753bdc1d6.yaml
@@ -1,0 +1,17 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: Enable configuration of the error sampler. The target tps can be set with the env var
+    DD_APM_ERROR_TPS or the configuration `apm_config.error_traces_per_second`. The trace-agent 
+    defaults to 10 extra trace chunks sampled per second above the head base sampling.
+    The tps is spread to catch all combinations of (service, name, resource, http.status, error.type).
+upgrades:
+  - |
+    APM: Configuration `max_traces_per_second` does not affect anymore errors sampling.

--- a/releasenotes/notes/apm-error-sampler-configurable-90589d4753bdc1d6.yaml
+++ b/releasenotes/notes/apm-error-sampler-configurable-90589d4753bdc1d6.yaml
@@ -8,10 +8,11 @@
 ---
 features:
   - |
-    APM: Enable configuration of the error sampler. The target tps can be set with the env var
-    DD_APM_ERROR_TPS or the configuration `apm_config.error_traces_per_second`. The trace-agent 
-    defaults to 10 extra trace chunks sampled per second above the head base sampling.
-    The tps is spread to catch all combinations of (service, name, resource, http.status, error.type).
+    APM: The error sampler TPS can be configured using the environment variable DD_APM_ERROR_TPS
+    or the `apm_config.error_traces_per_second` configuration. It defaults to 10 extra trace chunks sampled 
+    per second on top of the base head sampling.
+    The TPS is spread to catch all combinations of service, name, resource, http.status and error.type.
 upgrade:
   - |
-    APM: Configuration `max_traces_per_second` does not affect anymore errors sampling.
+    APM: The `apm_config. max_traces_per_second` setting no longer affects errors sampling.
+    To change the TPS for errors, use `apm_config.error_traces_per_second` instead.

--- a/releasenotes/notes/apm-error-sampler-configurable-90589d4753bdc1d6.yaml
+++ b/releasenotes/notes/apm-error-sampler-configurable-90589d4753bdc1d6.yaml
@@ -14,5 +14,5 @@ features:
     The TPS is spread to catch all combinations of service, name, resource, http.status and error.type.
 upgrade:
   - |
-    APM: The `apm_config. max_traces_per_second` setting no longer affects errors sampling.
+    APM: The `apm_config.max_traces_per_second` setting no longer affects errors sampling.
     To change the TPS for errors, use `apm_config.error_traces_per_second` instead.


### PR DESCRIPTION
Enables configuration of the error sampler. Users can now set the target TPS used by the error sampler with the env variable  `DD_APM_ERROR_TPS` or the configuration `apm_config.error_traces_per_second`. 

The error sampler catches by default 10 trace pieces with errors that are not caught by head base sampling (priority = 0). The tps is spread to catch all combinations of (service, name, resource, http.status, error.type).

Breaking change:
TargetTPS parameter does not change error sampler behavior anymore.