### PR TITLE
[runtime-security] Fix multiple races in testModule and unload policies at the end of a test

### DIFF
--- a/pkg/security/probe/mount_resolver_test.go
+++ b/pkg/security/probe/mount_resolver_test.go
@@ -12,7 +12,7 @@ import (
 	"testing"
 	"time"
 
-	"gotest.tools/assert"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 )

--- a/pkg/security/tests/chmod_test.go
+++ b/pkg/security/tests/chmod_test.go
@@ -50,7 +50,7 @@ func TestChmod(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			if _, _, errno := syscall.Syscall(syscall.SYS_FCHMOD, f.Fd(), uintptr(0o707), 0); errno != 0 {
-				return errno
+				return error(errno)
 			}
 			return nil
 		}, func(event *sprobe.Event, r *rules.Rule) {
@@ -58,7 +58,6 @@ func TestChmod(t *testing.T) {
 			assertRights(t, uint16(event.Chmod.Mode), 0o707)
 			assert.Equal(t, getInode(t, testFile), event.Chmod.File.Inode, "wrong inode")
 			assertRights(t, event.Chmod.File.Mode, expectedMode, "wrong initial mode")
-
 			assertNearTime(t, event.Chmod.File.MTime)
 			assertNearTime(t, event.Chmod.File.CTime)
 
@@ -73,7 +72,7 @@ func TestChmod(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			if _, _, errno := syscall.Syscall6(syscall.SYS_FCHMODAT, 0, uintptr(testFilePtr), uintptr(0o757), 0, 0, 0); errno != 0 {
-				t.Fatal(errno)
+				return error(errno)
 			}
 			return nil
 		}, func(event *sprobe.Event, r *rules.Rule) {
@@ -81,7 +80,6 @@ func TestChmod(t *testing.T) {
 			assertRights(t, uint16(event.Chmod.Mode), 0o757)
 			assert.Equal(t, getInode(t, testFile), event.Chmod.File.Inode, "wrong inode")
 			assertRights(t, event.Chmod.File.Mode, expectedMode)
-
 			assertNearTime(t, event.Chmod.File.MTime)
 			assertNearTime(t, event.Chmod.File.CTime)
 
@@ -94,7 +92,7 @@ func TestChmod(t *testing.T) {
 	t.Run("chmod", ifSyscallSupported("SYS_CHMOD", func(t *testing.T, syscallNB uintptr) {
 		test.WaitSignal(t, func() error {
 			if _, _, errno := syscall.Syscall(syscallNB, uintptr(testFilePtr), uintptr(0o717), 0); errno != 0 {
-				t.Fatal(errno)
+				return error(errno)
 			}
 			return nil
 		}, func(event *sprobe.Event, r *rules.Rule) {
@@ -102,7 +100,6 @@ func TestChmod(t *testing.T) {
 			assertRights(t, uint16(event.Chmod.Mode), 0o717, "wrong mode")
 			assert.Equal(t, getInode(t, testFile), event.Chmod.File.Inode, "wrong inode")
 			assertRights(t, event.Chmod.File.Mode, expectedMode, "wrong initial mode")
-
 			assertNearTime(t, event.Chmod.File.MTime)
 			assertNearTime(t, event.Chmod.File.CTime)
 

--- a/pkg/security/tests/chown32_test.go
+++ b/pkg/security/tests/chown32_test.go
@@ -11,10 +11,11 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
-	"gotest.tools/assert"
 )
 
 func TestChown32(t *testing.T) {
@@ -82,7 +83,6 @@ func TestChown32(t *testing.T) {
 			assertRights(t, event.Chown.File.Mode, uint16(expectedMode), "wrong initial mode")
 			assert.Equal(t, uint32(prevUID), event.Chown.File.UID, "wrong initial user")
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
-
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
 
@@ -109,7 +109,6 @@ func TestChown32(t *testing.T) {
 			assertRights(t, event.Chown.File.Mode, uint16(expectedMode), "wrong initial mode")
 			assert.Equal(t, uint32(prevUID), event.Chown.File.UID, "wrong initial user")
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
-
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
 
@@ -136,7 +135,6 @@ func TestChown32(t *testing.T) {
 			assertRights(t, event.Chown.File.Mode, uint16(expectedMode), "wrong initial mode")
 			assert.Equal(t, uint32(prevUID), event.Chown.File.UID, "wrong initial user")
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
-
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
 
@@ -168,7 +166,6 @@ func TestChown32(t *testing.T) {
 			assertRights(t, event.Chown.File.Mode, uint16(0o777), "wrong initial mode")
 			assert.Equal(t, uint32(0), event.Chown.File.UID, "wrong initial user")
 			assert.Equal(t, uint32(0), event.Chown.File.GID, "wrong initial group")
-
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
 
@@ -200,7 +197,6 @@ func TestChown32(t *testing.T) {
 			assertRights(t, event.Chown.File.Mode, uint16(0o777), "wrong initial mode")
 			assert.Equal(t, uint32(0), event.Chown.File.UID, "wrong initial user")
 			assert.Equal(t, uint32(0), event.Chown.File.GID, "wrong initial group")
-
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
 
@@ -228,7 +224,6 @@ func TestChown32(t *testing.T) {
 			assertRights(t, event.Chown.File.Mode, uint16(expectedMode), "wrong initial mode")
 			assert.Equal(t, uint32(prevUID), event.Chown.File.UID, "wrong initial user")
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
-
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
 
@@ -255,7 +250,6 @@ func TestChown32(t *testing.T) {
 			assertRights(t, event.Chown.File.Mode, uint16(expectedMode), "wrong initial mode")
 			assert.Equal(t, uint32(prevUID), event.Chown.File.UID, "wrong initial user")
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
-
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
 

--- a/pkg/security/tests/chown_test.go
+++ b/pkg/security/tests/chown_test.go
@@ -59,7 +59,7 @@ func TestChown(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			// fchown syscall
 			if _, _, errno := syscall.Syscall(syscall.SYS_FCHOWN, f.Fd(), 100, 200); errno != 0 {
-				t.Fatal(err)
+				return error(errno)
 			}
 			return nil
 		}, func(event *sprobe.Event, r *rules.Rule) {
@@ -70,7 +70,6 @@ func TestChown(t *testing.T) {
 			assertRights(t, event.Chown.File.Mode, uint16(expectedMode), "wrong initial mode")
 			assert.Equal(t, uint32(prevUID), event.Chown.File.UID, "wrong initial user")
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
-
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
 
@@ -88,7 +87,7 @@ func TestChown(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			if _, _, errno := syscall.Syscall6(syscall.SYS_FCHOWNAT, 0, uintptr(testFilePtr), uintptr(101), uintptr(201), 0x100, 0); errno != 0 {
-				t.Fatal(err)
+				return error(errno)
 			}
 			return nil
 		}, func(event *sprobe.Event, r *rules.Rule) {
@@ -99,7 +98,6 @@ func TestChown(t *testing.T) {
 			assertRights(t, event.Chown.File.Mode, uint16(expectedMode), "wrong initial mode")
 			assert.Equal(t, uint32(prevUID), event.Chown.File.UID, "wrong initial user")
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
-
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
 
@@ -124,9 +122,9 @@ func TestChown(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			if _, _, errno := syscall.Syscall(syscallNB, uintptr(testSymlinkPtr), uintptr(102), uintptr(202)); errno != 0 {
 				if errno == unix.ENOSYS {
-					t.Skip("lchown is not supported")
+					return ErrSkipTest{"lchown is not supported"}
 				}
-				t.Fatal(errno)
+				return error(errno)
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
@@ -138,7 +136,6 @@ func TestChown(t *testing.T) {
 			assertRights(t, event.Chown.File.Mode, 0o777, "wrong initial mode")
 			assert.Equal(t, uint32(0), event.Chown.File.UID, "wrong initial user")
 			assert.Equal(t, uint32(0), event.Chown.File.GID, "wrong initial group")
-
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
 
@@ -156,7 +153,7 @@ func TestChown(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			if _, _, errno := syscall.Syscall(syscallNB, uintptr(testFilePtr), 103, 203); errno != 0 {
-				t.Fatal(err)
+				return error(errno)
 			}
 			return nil
 		}, func(event *sprobe.Event, r *rules.Rule) {
@@ -167,7 +164,6 @@ func TestChown(t *testing.T) {
 			assertRights(t, event.Chown.File.Mode, uint16(expectedMode), "wrong initial mode")
 			assert.Equal(t, uint32(prevUID), event.Chown.File.UID, "wrong initial user")
 			assert.Equal(t, uint32(prevGID), event.Chown.File.GID, "wrong initial group")
-
 			assertNearTime(t, event.Chown.File.MTime)
 			assertNearTime(t, event.Chown.File.CTime)
 

--- a/pkg/security/tests/cmdwrapper.go
+++ b/pkg/security/tests/cmdwrapper.go
@@ -90,11 +90,13 @@ func (d *dockerCmdWrapper) Run(t *testing.T, name string, fnc func(t *testing.T,
 		_, _ = d.stop()
 
 		if out, err := d.start(); err != nil {
-			t.Fatalf("%s: %s", string(out), err)
+			t.Errorf("%s: %s", string(out), err)
+			return
 		}
 		fnc(t, d.Type(), d.Command)
 		if out, err := d.stop(); err != nil {
-			t.Fatalf("%s: %s", string(out), err)
+			t.Errorf("%s: %s", string(out), err)
+			return
 		}
 	})
 }

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -357,7 +357,7 @@ func TestDiscarderFilterMask(t *testing.T) {
 			t.Fatal(error(errno))
 		}
 		if err := waitForProbeEvent(test, nil, "utimes.file.path", testFile, model.FileUtimesEventType); err != nil {
-			t.Fatal("shoud get a utimes event")
+			t.Fatal("should get a utimes event")
 		}
 
 		// wait a bit and ensure utimes event has been discarded
@@ -367,7 +367,7 @@ func TestDiscarderFilterMask(t *testing.T) {
 			t.Fatal(error(errno))
 		}
 		if err := waitForProbeEvent(test, nil, "utimes.file.path", testFile, model.FileUtimesEventType); err == nil {
-			t.Fatal("shoudn't get a utimes event")
+			t.Fatal("shouldn't get a utimes event")
 		}
 
 		// not check that we still have the open allowed

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -316,7 +316,7 @@ func TestDiscarderFilterMask(t *testing.T) {
 		},
 		{
 			ID:         "test_mask_utimes_rule",
-			Expression: `utimes.file.path =~ "{{.Root}}/test-mask-aaa-*"`,
+			Expression: `utimes.file.path == "{{.Root}}/do_not_match/test-mask"`,
 		},
 	}
 

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -74,11 +74,14 @@ func TestOpenBasenameApproverFilterERPCDentryResolution(t *testing.T) {
 	if err := waitForOpenProbeEvent(test, func() error {
 		fd1, err = openTestFile(test, testFile1, syscall.O_CREAT)
 		if err != nil {
-			t.Fatal(err)
+			return err
 		}
-		return syscall.Close(fd1)
+		if err = syscall.Close(fd1); err != nil {
+			return err
+		}
+		return nil
 	}, testFile1); err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	defer os.Remove(testFile2)
@@ -91,9 +94,12 @@ func TestOpenBasenameApproverFilterERPCDentryResolution(t *testing.T) {
 	if err := waitForOpenProbeEvent(test, func() error {
 		fd2, err = openTestFile(test, testFile2, syscall.O_CREAT)
 		if err != nil {
-			t.Fatal(err)
+			return err
 		}
-		return syscall.Close(fd2)
+		if err = syscall.Close(fd2); err != nil {
+			return err
+		}
+		return nil
 	}, testFile2); err == nil {
 		t.Fatal("shouldn't get an event")
 	}
@@ -129,9 +135,12 @@ func TestOpenBasenameApproverFilterMapDentryResolution(t *testing.T) {
 	if err := waitForOpenProbeEvent(test, func() error {
 		fd1, err = openTestFile(test, testFile1, syscall.O_CREAT)
 		if err != nil {
-			t.Fatal(err)
+			return err
 		}
-		return syscall.Close(fd1)
+		if err = syscall.Close(fd1); err != nil {
+			return err
+		}
+		return nil
 	}, testFile1); err != nil {
 		t.Fatal(err)
 	}
@@ -146,11 +155,14 @@ func TestOpenBasenameApproverFilterMapDentryResolution(t *testing.T) {
 	if err := waitForOpenProbeEvent(test, func() error {
 		fd2, err = openTestFile(test, testFile2, syscall.O_CREAT)
 		if err != nil {
-			t.Fatal(err)
+			return err
 		}
-		return syscall.Close(fd2)
+		if err = syscall.Close(fd2); err != nil {
+			return err
+		}
+		return nil
 	}, testFile2); err == nil {
-		t.Fatalf("shouldn't get an event")
+		t.Fatal("shouldn't get an event")
 	}
 }
 
@@ -187,7 +199,9 @@ func TestOpenLeafDiscarderFilter(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		_ = syscall.Close(fd)
+		if err = syscall.Close(fd); err != nil {
+			return err
+		}
 		return nil
 	}, func(d *testDiscarder) bool {
 		e := d.event.(*probe.Event)
@@ -209,11 +223,14 @@ func TestOpenLeafDiscarderFilter(t *testing.T) {
 	if err := waitForOpenProbeEvent(test, func() error {
 		fd, err = openTestFile(test, testFile, syscall.O_CREAT|syscall.O_SYNC)
 		if err != nil {
-			t.Fatal(err)
+			return err
 		}
-		return syscall.Close(fd)
+		if err = syscall.Close(fd); err != nil {
+			return err
+		}
+		return nil
 	}, testFile); err == nil {
-		t.Fatalf("shouldn't get an event")
+		t.Fatal("shouldn't get an event")
 	}
 }
 
@@ -250,7 +267,9 @@ func TestOpenParentDiscarderFilter(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		_ = syscall.Close(fd)
+		if err = syscall.Close(fd); err != nil {
+			return err
+		}
 		return nil
 	}, func(d *testDiscarder) bool {
 		e := d.event.(*probe.Event)
@@ -278,11 +297,14 @@ func TestOpenParentDiscarderFilter(t *testing.T) {
 	if err := waitForOpenProbeEvent(test, func() error {
 		fd, err = openTestFile(test, testFile, syscall.O_CREAT|syscall.O_SYNC)
 		if err != nil {
-			t.Fatal(err)
+			return err
 		}
-		return syscall.Close(fd)
+		if err = syscall.Close(fd); err != nil {
+			return err
+		}
+		return nil
 	}, testFile); err == nil {
-		t.Fatalf("shouldn't get an event")
+		t.Fatal("shouldn't get an event")
 	}
 }
 
@@ -307,7 +329,6 @@ func TestDiscarderFilterMask(t *testing.T) {
 	t.Run("mask", ifSyscallSupported("SYS_UTIME", func(t *testing.T, syscallNB uintptr) {
 		var testFile string
 		var testFilePtr unsafe.Pointer
-		var err error
 
 		defer os.Remove(testFile)
 
@@ -320,7 +341,7 @@ func TestDiscarderFilterMask(t *testing.T) {
 
 			testFile, testFilePtr, err = test.CreateWithOptions("test-mask", 98, 99, 0o447)
 			if err != nil {
-				t.Fatal(err)
+				return err
 			}
 			return nil
 		}, func(event *probe.Event, rule *rules.Rule) {
@@ -333,30 +354,31 @@ func TestDiscarderFilterMask(t *testing.T) {
 		}
 
 		if _, _, errno := syscall.Syscall(syscallNB, uintptr(testFilePtr), uintptr(unsafe.Pointer(utimbuf)), 0); errno != 0 {
-			t.Fatal(errno)
+			t.Fatal(error(errno))
 		}
 		if err := waitForProbeEvent(test, nil, "utimes.file.path", testFile, model.FileUtimesEventType); err != nil {
-			t.Error("shoud get a utimes event")
+			t.Fatal("shoud get a utimes event")
 		}
 
 		// wait a bit and ensure utimes event has been discarded
 		time.Sleep(2 * time.Second)
 
 		if _, _, errno := syscall.Syscall(syscallNB, uintptr(testFilePtr), uintptr(unsafe.Pointer(utimbuf)), 0); errno != 0 {
-			t.Fatal(errno)
+			t.Fatal(error(errno))
 		}
 		if err := waitForProbeEvent(test, nil, "utimes.file.path", testFile, model.FileUtimesEventType); err == nil {
-			t.Error("shoudn't get a utimes event")
+			t.Fatal("shoudn't get a utimes event")
 		}
 
 		// not check that we still have the open allowed
 		test.WaitSignal(t, func() error {
 			f, err := os.OpenFile(testFile, os.O_CREATE, 0)
 			if err != nil {
-				t.Fatal(err)
+				return err
 			}
-			f.Close()
-
+			if err = f.Close(); err != nil {
+				return err
+			}
 			return nil
 		}, func(event *probe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_mask_open_rule")
@@ -389,31 +411,40 @@ func TestOpenFlagsApproverFilter(t *testing.T) {
 	if err := waitForOpenProbeEvent(test, func() error {
 		fd, err = openTestFile(test, testFile, syscall.O_CREAT|syscall.O_NOCTTY)
 		if err != nil {
-			t.Fatal(err)
+			return err
 		}
-		return syscall.Close(fd)
+		if err = syscall.Close(fd); err != nil {
+			return err
+		}
+		return nil
 	}, testFile); err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if err := waitForOpenProbeEvent(test, func() error {
 		fd, err = openTestFile(test, testFile, syscall.O_SYNC)
 		if err != nil {
-			t.Fatal(err)
+			return err
 		}
-		return syscall.Close(fd)
+		if err = syscall.Close(fd); err != nil {
+			return err
+		}
+		return nil
 	}, testFile); err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 
 	if err := waitForOpenProbeEvent(test, func() error {
 		fd, err = openTestFile(test, testFile, syscall.O_RDONLY)
 		if err != nil {
-			t.Fatal(err)
+			return err
 		}
-		return syscall.Close(fd)
+		if err = syscall.Close(fd); err != nil {
+			return err
+		}
+		return nil
 	}, testFile); err == nil {
-		t.Error("shouldn't get an event")
+		t.Fatal("shouldn't get an event")
 	}
 }
 
@@ -448,7 +479,9 @@ func TestOpenProcessPidDiscarder(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		_ = syscall.Close(fd)
+		if err = syscall.Close(fd); err != nil {
+			return err
+		}
 		return nil
 	}, func(d *testDiscarder) bool {
 		e := d.event.(*probe.Event)
@@ -467,14 +500,15 @@ func TestOpenProcessPidDiscarder(t *testing.T) {
 		t.Fatalf("event inode: %d, parent inode: %d, error: %v", inode, parentInode, err)
 	}
 
-	defer os.Remove(testFile)
-
 	if err := waitForOpenProbeEvent(test, func() error {
 		fd, err = openTestFile(test, testFile, syscall.O_TRUNC)
 		if err != nil {
-			t.Fatal(err)
+			return err
 		}
-		return syscall.Close(fd)
+		if err = syscall.Close(fd); err != nil {
+			return err
+		}
+		return nil
 	}, testFile); err == nil {
 		t.Fatalf("shouldn't get an event")
 	}
@@ -503,7 +537,7 @@ func TestDiscarderRetentionFilter(t *testing.T) {
 	var fd int
 	var testFile string
 
-	testFile, _, err = test.Path("test-obc-2")
+	testFile, _, err = test.Path("to_be_discarded/test-obc-2")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -519,8 +553,9 @@ func TestDiscarderRetentionFilter(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		_ = syscall.Close(fd)
-
+		if err = syscall.Close(fd); err != nil {
+			return err
+		}
 		return nil
 
 	}, func(d *testDiscarder) bool {
@@ -546,11 +581,14 @@ func TestDiscarderRetentionFilter(t *testing.T) {
 	if err := waitForOpenProbeEvent(test, func() error {
 		fd, err = openTestFile(test, testFile, syscall.O_CREAT|syscall.O_SYNC)
 		if err != nil {
-			t.Fatal(err)
+			return err
 		}
-		return syscall.Close(fd)
+		if err = syscall.Close(fd); err != nil {
+			return err
+		}
+		return nil
 	}, testFile); err == nil {
-		t.Fatalf("shouldn't get an event")
+		t.Fatal("shouldn't get an event")
 	}
 
 	// check the retention, we should have event during the retention period
@@ -573,9 +611,12 @@ func TestDiscarderRetentionFilter(t *testing.T) {
 		if err := waitForOpenProbeEvent(test, func() error {
 			fd, err = openTestFile(test, newFile, syscall.O_CREAT|syscall.O_SYNC)
 			if err != nil {
-				t.Fatal(err)
+				return err
 			}
-			return syscall.Close(fd)
+			if err = syscall.Close(fd); err != nil {
+				return err
+			}
+			return nil
 		}, newFile); err != nil {
 			discarded = true
 			break
@@ -583,10 +624,10 @@ func TestDiscarderRetentionFilter(t *testing.T) {
 	}
 
 	if !discarded {
-		t.Fatalf("should be discarded")
+		t.Fatal("should be discarded")
 	}
 
 	if diff := time.Since(start); uint64(diff) < uint64(probe.DiscardRetention)-uint64(time.Second) {
-		t.Errorf("discarder retention (%s) not reached: %s", time.Duration(uint64(probe.DiscardRetention)-uint64(time.Second)), diff)
+		t.Fatalf("discarder retention (%s) not reached: %s", time.Duration(uint64(probe.DiscardRetention)-uint64(time.Second)), diff)
 	}
 }

--- a/pkg/security/tests/hardlink_test.go
+++ b/pkg/security/tests/hardlink_test.go
@@ -43,7 +43,7 @@ func runHardlinkTests(t *testing.T, opts testOpts) {
 	}
 	defer os.Remove(testOrigExecutable)
 
-	if err := copyFile(executable, testOrigExecutable, 0755); err != nil {
+	if err = copyFile(executable, testOrigExecutable, 0755); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/security/tests/link_test.go
+++ b/pkg/security/tests/link_test.go
@@ -46,16 +46,14 @@ func TestLink(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			_, _, errno := syscall.Syscall(syscallNB, uintptr(testOldFilePtr), uintptr(testNewFilePtr), 0)
 			if errno != 0 {
-				t.Fatal(errno)
+				return error(errno)
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "link", event.GetType(), "wrong event type")
 			assert.Equal(t, getInode(t, testNewFile), event.Link.Source.Inode, "wrong inode")
-
 			assertRights(t, event.Link.Source.Mode, uint16(expectedMode))
 			assertRights(t, event.Link.Target.Mode, uint16(expectedMode))
-
 			assertNearTime(t, event.Link.Source.MTime)
 			assertNearTime(t, event.Link.Source.CTime)
 			assertNearTime(t, event.Link.Target.MTime)
@@ -66,8 +64,8 @@ func TestLink(t *testing.T) {
 			}
 		})
 
-		if err := os.Remove(testNewFile); err != nil {
-			t.Error(err)
+		if err = os.Remove(testNewFile); err != nil {
+			t.Fatal(err)
 		}
 	}))
 
@@ -75,16 +73,14 @@ func TestLink(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			_, _, errno := syscall.Syscall6(syscall.SYS_LINKAT, 0, uintptr(testOldFilePtr), 0, uintptr(testNewFilePtr), 0, 0)
 			if errno != 0 {
-				t.Fatal(errno)
+				return error(errno)
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "link", event.GetType(), "wrong event type")
 			assert.Equal(t, getInode(t, testNewFile), event.Link.Source.Inode, "wrong inode")
-
 			assertRights(t, event.Link.Source.Mode, uint16(expectedMode))
 			assertRights(t, event.Link.Target.Mode, uint16(expectedMode))
-
 			assertNearTime(t, event.Link.Source.MTime)
 			assertNearTime(t, event.Link.Source.CTime)
 			assertNearTime(t, event.Link.Target.MTime)

--- a/pkg/security/tests/macros_test.go
+++ b/pkg/security/tests/macros_test.go
@@ -48,7 +48,7 @@ func TestMacros(t *testing.T) {
 	}
 
 	test.WaitSignal(t, func() error {
-		if err := os.Mkdir(testFile, 0777); err != nil {
+		if err = os.Mkdir(testFile, 0777); err != nil {
 			return err
 		}
 		return os.Remove(testFile)

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -196,6 +196,7 @@ type testcustomEventHandler struct {
 
 type testProbeHandler struct {
 	sync.RWMutex
+	reloading          sync.RWMutex
 	module             *module.Module
 	eventHandler       *testEventHandler
 	customEventHandler *testcustomEventHandler
@@ -208,6 +209,9 @@ func (h *testProbeHandler) HandleEvent(event *sprobe.Event) {
 	if h.module == nil {
 		return
 	}
+
+	h.reloading.Lock()
+	defer h.reloading.Unlock()
 
 	h.module.HandleEvent(event)
 
@@ -458,6 +462,8 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 			testMod.st = st
 			testMod.cmdWrapper = cmdWrapper
 			testMod.t = t
+			testMod.probeHandler.reloading.Lock()
+			defer testMod.probeHandler.reloading.Unlock()
 			return testMod, testMod.reloadConfiguration()
 		}
 		testMod.probeHandler.SetModule(nil)

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -65,19 +65,26 @@ func TestMount(t *testing.T) {
 		err = test.GetProbeEvent(func() error {
 			// Test mount
 			if err := syscall.Mount(mntPath, dstMntPath, "bind", syscall.MS_BIND, ""); err != nil {
-				t.Fatalf("could not create bind mount: %s", err)
+				return fmt.Errorf("could not create bind mount: %s", err)
 			}
 			return nil
 		}, func(event *sprobe.Event) bool {
-			assert.Equal(t, "mount", event.GetType(), "wrong event type")
-			assert.Equal(t, "/"+dstMntBasename, event.Mount.MountPointStr, "wrong mount point")
-			assert.Equal(t, "xfs", event.Mount.GetFSType(), "wrong mount fs type")
-
 			mntID = event.Mount.MountID
-			return true
+
+			if !assert.Equal(t, "mount", event.GetType(), "wrong event type") {
+				return true
+			}
+
+			// filter by pid
+			if pce := event.ResolveProcessCacheEntry(); pce.Pid != testSuitePid {
+				return false
+			}
+
+			return assert.Equal(t, "/"+dstMntBasename, event.Mount.MountPointStr, "wrong mount point") &&
+				assert.Equal(t, "xfs", event.Mount.GetFSType(), "wrong mount fs type")
 		}, 3*time.Second, model.FileMountEventType)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 	})
 
@@ -92,7 +99,7 @@ func TestMount(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if err := f.Close(); err != nil {
+		if err = f.Close(); err != nil {
 			t.Fatal(err)
 		}
 		defer os.Remove(file)
@@ -114,14 +121,21 @@ func TestMount(t *testing.T) {
 	t.Run("umount", func(t *testing.T) {
 		err = test.GetProbeEvent(func() error {
 			// Test umount
-			if err := syscall.Unmount(dstMntPath, syscall.MNT_DETACH); err != nil {
-				t.Fatalf("could not unmount test-mount: %s", err)
+			if err = syscall.Unmount(dstMntPath, syscall.MNT_DETACH); err != nil {
+				return fmt.Errorf("could not unmount test-mount: %s", err)
 			}
 			return nil
 		}, func(event *sprobe.Event) bool {
-			assert.Equal(t, "umount", event.GetType(), "wrong event type")
-			assert.Equal(t, mntID, event.Umount.MountID, "wrong mount id")
-			return true
+			if !assert.Equal(t, "umount", event.GetType(), "wrong event type") {
+				return true
+			}
+
+			// filter by process
+			if pce := event.ResolveProcessCacheEntry(); pce.Pid != testSuitePid {
+				return false
+			}
+
+			return assert.Equal(t, mntID, event.Umount.MountID, "wrong mount id")
 		}, 3*time.Second, model.FileUmountEventType)
 		if err != nil {
 			t.Error(err)

--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -51,7 +51,7 @@ func TestOpen(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			fd, _, errno := syscall.Syscall(syscallNB, uintptr(testFilePtr), syscall.O_CREAT, 0755)
 			if errno != 0 {
-				t.Fatal(errno)
+				return error(errno)
 			}
 			return syscall.Close(int(fd))
 		}, func(event *sprobe.Event, r *rules.Rule) {
@@ -72,7 +72,7 @@ func TestOpen(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			fd, _, errno := syscall.Syscall6(syscall.SYS_OPENAT, 0, uintptr(testFilePtr), syscall.O_CREAT, 0711, 0, 0)
 			if errno != 0 {
-				t.Fatal(errno)
+				return error(errno)
 			}
 			return syscall.Close(int(fd))
 		}, func(event *sprobe.Event, r *rules.Rule) {
@@ -95,9 +95,9 @@ func TestOpen(t *testing.T) {
 			fd, _, errno := syscall.Syscall6(unix.SYS_OPENAT2, 0, uintptr(testFilePtr), uintptr(unsafe.Pointer(&openHow)), unix.SizeofOpenHow, 0, 0)
 			if errno != 0 {
 				if errno == unix.ENOSYS {
-					t.Skip("openat2 is not supported")
+					return ErrSkipTest{"openat2 is not supported"}
 				}
-				t.Fatal(errno)
+				return error(errno)
 			}
 			return syscall.Close(int(fd))
 		}, func(event *sprobe.Event, r *rules.Rule) {
@@ -114,7 +114,7 @@ func TestOpen(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			fd, _, errno := syscall.Syscall(syscallNB, uintptr(testFilePtr), 0711, 0)
 			if errno != 0 {
-				t.Fatal(errno)
+				return error(errno)
 			}
 			return syscall.Close(int(fd))
 		}, func(event *sprobe.Event, r *rules.Rule) {
@@ -131,10 +131,14 @@ func TestOpen(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			f, err := os.OpenFile(testFile, os.O_RDWR|os.O_CREATE, 0755)
 			if err != nil {
-				t.Error(err)
+				return err
 			}
 
-			syscall.Write(int(f.Fd()), []byte("this data will soon be truncated\n"))
+			_, err = syscall.Write(int(f.Fd()), []byte("this data will soon be truncated\n"))
+			if err != nil {
+				return err
+			}
+
 			return f.Close()
 		}, func(event *sprobe.Event, r *rules.Rule) {})
 
@@ -142,7 +146,7 @@ func TestOpen(t *testing.T) {
 			// truncate
 			_, _, errno := syscall.Syscall(syscall.SYS_TRUNCATE, uintptr(testFilePtr), 4, 0)
 			if errno != 0 {
-				t.Fatal(error(errno))
+				return error(errno)
 			}
 			return nil
 		}, func(event *sprobe.Event, r *rules.Rule) {
@@ -159,7 +163,7 @@ func TestOpen(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			f, err := os.OpenFile(testFile, os.O_RDWR|os.O_CREATE, 0755)
 			if err != nil {
-				t.Fatal(err)
+				return err
 			}
 			return f.Close()
 		}, func(event *sprobe.Event, r *rules.Rule) {
@@ -183,9 +187,9 @@ func TestOpen(t *testing.T) {
 			fdInt, err := unix.OpenByHandleAt(int(mount.Fd()), h, unix.O_CREAT)
 			if err != nil {
 				if err == unix.EINVAL {
-					t.Skip("open_by_handle_at not supported")
+					return ErrSkipTest{"open_by_handle_at not supported"}
 				}
-				t.Fatalf("OpenByHandleAt: %v", err)
+				return fmt.Errorf("OpenByHandleAt: %v", err)
 			}
 			return unix.Close(fdInt)
 		}, func(event *sprobe.Event, r *rules.Rule) {
@@ -201,10 +205,9 @@ func TestOpen(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			f, err := os.OpenFile(testFile, os.O_RDWR|os.O_CREATE, 0755)
 			if err != nil {
-				t.Fatal(err)
+				return err
 			}
-			f.Close()
-			return nil
+			return f.Close()
 		}, func(event *sprobe.Event, r *rules.Rule) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 		})
@@ -224,22 +227,23 @@ func TestOpen(t *testing.T) {
 		}
 
 		ch := make(chan iouring.Result, 1)
+
 		test.WaitSignal(t, func() error {
-			if _, err := iour.SubmitRequest(prepRequest, ch); err != nil {
-				t.Fatal(err)
+			if _, err = iour.SubmitRequest(prepRequest, ch); err != nil {
+				return err
 			}
 
 			result := <-ch
 			fd, err := result.ReturnInt()
 			if err != nil {
-				if err != syscall.EBADF {
-					t.Fatal(err)
+				if err == syscall.EBADF {
+					return ErrSkipTest{"openat not supported by io_uring"}
 				}
-				t.Skip("openat not supported by io_uring")
+				return err
 			}
 
 			if fd < 0 {
-				t.Fatalf("failed to open file with io_uring: %d", fd)
+				return fmt.Errorf("failed to open file with io_uring: %d", fd)
 			}
 
 			return unix.Close(fd)
@@ -259,17 +263,20 @@ func TestOpen(t *testing.T) {
 		// same with openat2
 		test.WaitSignal(t, func() error {
 			if _, err := iour.SubmitRequest(prepRequest, ch); err != nil {
-				t.Fatal(err)
+				return err
 			}
 
 			result := <-ch
 			fd, err := result.ReturnInt()
 			if err != nil {
-				t.Fatal(err)
+				if err == syscall.EBADF {
+					return ErrSkipTest{"openat2 not supported by io_uring"}
+				}
+				return err
 			}
 
 			if fd < 0 {
-				t.Fatalf("failed to open file with io_uring: %d", fd)
+				return fmt.Errorf("failed to open file with io_uring: %d", fd)
 			}
 
 			return unix.Close(fd)
@@ -312,14 +319,13 @@ func TestOpenMetadata(t *testing.T) {
 			// have the right uid / gid, thus didn't match the rule. Open the file again to trigger the rule.
 			f, err := os.Open(testFile)
 			if err != nil {
-				t.Fatal(err)
+				return err
 			}
 			return f.Close()
 		}, func(event *sprobe.Event, r *rules.Rule) {
 			assert.Equal(t, "open", event.GetType(), "wrong event type")
 			assertRights(t, event.Open.File.Mode, expectedMode)
 			assert.Equal(t, getInode(t, testFile), event.Open.File.Inode, "wrong inode")
-
 			assertNearTime(t, event.Open.File.MTime)
 			assertNearTime(t, event.Open.File.CTime)
 		})

--- a/pkg/security/tests/probe_monitor_test.go
+++ b/pkg/security/tests/probe_monitor_test.go
@@ -133,7 +133,7 @@ func TestNoisyProcess(t *testing.T) {
 	rule := &rules.RuleDefinition{
 		ID: "path_test",
 		// using a wilcard to avoid approvers on basename. events will not match thus will be noisy
-		Expression: `open.file.path =~ "{{.Root}}/no-test-open*" && open.flags & O_CREAT != 0`,
+		Expression: `open.file.path == "{{.Root}}/do_not_match/test-open"`,
 	}
 
 	test, err := newTestModule(t, nil, []*rules.RuleDefinition{rule}, testOpts{disableDiscarders: true, eventsCountThreshold: 1000})

--- a/pkg/security/tests/probe_monitor_test.go
+++ b/pkg/security/tests/probe_monitor_test.go
@@ -35,14 +35,21 @@ func TestRulesetLoaded(t *testing.T) {
 	defer test.Close()
 
 	t.Run("ruleset_loaded", func(t *testing.T) {
-		if err := test.GetProbeCustomEvent(t, func() error {
-			test.reloadConfiguration()
+		if err = test.GetProbeCustomEvent(t, func() error {
+			// This test is an exception, we should never use any t.* method in the action function (especially within a
+			// goroutine). We don't have a choice here because we're not triggering a kernel space event: the same
+			// goroutine that calls test.reloadConfiguration will eventually call the callback.
+			go func() {
+				if err := test.reloadConfiguration(); err != nil {
+					t.Errorf("failed to reload configuration: %v", err)
+				}
+			}()
 			return nil
 		}, func(rule *rules.Rule, customEvent *sprobe.CustomEvent) bool {
 			assert.Equal(t, sprobe.RulesetLoadedRuleID, rule.ID, "wrong rule")
 			return true
 		}, model.CustomRulesetLoadedEventType); err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 	})
 }
@@ -79,7 +86,7 @@ func truncatedParents(t *testing.T, opts testOpts) {
 		err = test.GetProbeCustomEvent(t, func() error {
 			f, err := os.OpenFile(truncatedParentsFile, os.O_CREATE, 0755)
 			if err != nil {
-				t.Fatal(err)
+				return err
 			}
 			return f.Close()
 		}, func(rule *rules.Rule, customEvent *sprobe.CustomEvent) bool {
@@ -87,13 +94,13 @@ func truncatedParents(t *testing.T, opts testOpts) {
 			return true
 		}, model.CustomTruncatedParentsEventType)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 
 		test.WaitSignal(t, func() error {
 			f, err := os.OpenFile(truncatedParentsFile, os.O_CREATE, 0755)
 			if err != nil {
-				t.Fatal(err)
+				return err
 			}
 			return f.Close()
 		}, func(event *sprobe.Event, rule *rules.Rule) {
@@ -146,10 +153,14 @@ func TestNoisyProcess(t *testing.T) {
 			for i := int64(0); i < testMod.config.LoadControllerEventsCountThreshold*2; i++ {
 				f, err := os.OpenFile(file, os.O_CREATE, 0755)
 				if err != nil {
-					t.Fatal(err)
+					return err
 				}
-				_ = f.Close()
-				_ = os.Remove(file)
+				if err = f.Close(); err != nil {
+					return err
+				}
+				if err = os.Remove(file); err != nil {
+					return err
+				}
 			}
 			return nil
 		}, func(rule *rules.Rule, customEvent *sprobe.CustomEvent) bool {
@@ -157,7 +168,7 @@ func TestNoisyProcess(t *testing.T) {
 			return true
 		}, model.CustomNoisyProcessEventType)
 		if err != nil {
-			t.Error(err)
+			t.Fatal(err)
 		}
 
 		// make sure the discarder has expired before moving on to other tests

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -51,8 +51,10 @@ func TestProcess(t *testing.T) {
 
 	test.WaitSignal(t, func() error {
 		testFile, _, err := test.Create("test-process")
-		os.Remove(testFile)
-		return err
+		if err != nil {
+			return err
+		}
+		return os.Remove(testFile)
 	}, func(event *sprobe.Event, rule *rules.Rule) {
 		assertTriggeredRule(t, rule, "test_rule")
 	})
@@ -130,10 +132,10 @@ func TestProcessContext(t *testing.T) {
 
 			return f.Close()
 		}, func(event *sprobe.Event, rule *rules.Rule) {
-			t.Errorf("got event: %s", event)
+			t.Errorf("shouldn't get an event: got event: %s", event)
 		})
 		if err == nil {
-			t.Error("shouldn't get an event")
+			t.Fatal("shouldn't get an event")
 		}
 
 		defer os.Remove(testFile)
@@ -186,6 +188,7 @@ func TestProcessContext(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			cmd := cmdFunc("ls", args, envs)
+			// we need to ignore the error because "--password" is not a valid option for ls
 			_ = cmd.Run()
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
@@ -249,7 +252,10 @@ func TestProcessContext(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			cmd := exec.Command(lsExecutable, "-ll")
-			return cmd.Run()
+			if err = cmd.Run(); err != nil {
+				return err
+			}
+			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_argv")
 		})
@@ -260,7 +266,10 @@ func TestProcessContext(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			cmd := exec.Command(lsExecutable, "-ls", "--escape")
-			return cmd.Run()
+			if err = cmd.Run(); err != nil {
+				return err
+			}
+			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_args_flags")
 		})
@@ -290,6 +299,7 @@ func TestProcessContext(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			cmd := cmdFunc("ls", args, envs)
+			// we need to ignore the error because the string of "a" generates a "File name too long" error
 			_ = cmd.Run()
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
@@ -311,6 +321,7 @@ func TestProcessContext(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			cmd := cmdFunc("ls", args, envs)
+			// we need to ignore the error because the string of "a" generates a "File name too long" error
 			_ = cmd.Run()
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
@@ -360,6 +371,8 @@ func TestProcessContext(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			var wg sync.WaitGroup
 
+			errChan := make(chan error, 1)
+
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -367,7 +380,7 @@ func TestProcessContext(t *testing.T) {
 				time.Sleep(2 * time.Second)
 				cmd := exec.Command("script", "/dev/null", "-c", executable+" -f "+testFile)
 				if err := cmd.Start(); err != nil {
-					t.Error(err)
+					errChan <- err
 					return
 				}
 				time.Sleep(2 * time.Second)
@@ -377,7 +390,14 @@ func TestProcessContext(t *testing.T) {
 			}()
 
 			wg.Wait()
+
+			select {
+			case err = <-errChan:
+				return err
+			default:
+			}
 			return nil
+
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertFieldEqual(t, event, "process.file.path", executable)
 
@@ -412,7 +432,7 @@ func TestProcessContext(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := cmdFunc("sh", args, nil)
 			if out, err := cmd.CombinedOutput(); err != nil {
-				t.Errorf("%s: %s", out, err)
+				return fmt.Errorf("%s: %s", out, err)
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
@@ -440,7 +460,7 @@ func TestProcessContext(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := cmdFunc(shell, args, nil)
 			if out, err := cmd.CombinedOutput(); err != nil {
-				t.Errorf("%s: %s", out, err)
+				return fmt.Errorf("%s: %s", out, err)
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
@@ -468,7 +488,7 @@ func TestProcessContext(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := cmdFunc(shell, args, envs)
 			if out, err := cmd.CombinedOutput(); err != nil {
-				t.Errorf("%s: %s", out, err)
+				return fmt.Errorf("%s: %s", out, err)
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
@@ -501,7 +521,7 @@ func TestProcessExecCTime(t *testing.T) {
 	test.WaitSignal(t, func() error {
 		testFile, _, err := test.Path("touch")
 		if err != nil {
-			t.Fatal(err)
+			return err
 		}
 		copyFile(executable, testFile, 0755)
 
@@ -567,7 +587,7 @@ func TestProcessMetadata(t *testing.T) {
 
 	f, err := os.OpenFile(testFile, os.O_WRONLY, 0)
 	if err != nil {
-		t.Error(err)
+		t.Fatal(err)
 	}
 	f.WriteString("#!/bin/bash\n")
 	f.Close()
@@ -586,25 +606,40 @@ func TestProcessMetadata(t *testing.T) {
 
 	t.Run("credentials", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
+			errChan := make(chan error, 1)
+			var wg sync.WaitGroup
+			wg.Add(1)
+
 			go func() {
+				defer wg.Done()
+
 				runtime.LockOSThread()
 				// do not unlock, we want the thread to be killed when exiting the goroutine
 
 				if _, _, errno := syscall.Syscall(syscall.SYS_SETREGID, 2001, 2001, 0); errno != 0 {
-					t.Error(errno)
+					errChan <- error(errno)
+					return
 				}
 				if _, _, errno := syscall.Syscall(syscall.SYS_SETREUID, 1001, 1001, 0); errno != 0 {
-					t.Error(errno)
+					errChan <- error(errno)
+					return
 				}
 
-				if _, err := syscall.ForkExec(testFile, []string{}, nil); err != nil {
-					t.Error(err)
+				if _, err = syscall.ForkExec(testFile, []string{}, nil); err != nil {
+					errChan <- err
 				}
 			}()
+
+			wg.Wait()
+
+			select {
+			case err = <-errChan:
+				return err
+			default:
+			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "exec", event.GetType(), "wrong event type")
-
 			assert.Equal(t, 1001, int(event.Exec.Credentials.UID), "wrong uid")
 			assert.Equal(t, 1001, int(event.Exec.Credentials.EUID), "wrong euid")
 			assert.Equal(t, 1001, int(event.Exec.Credentials.FSUID), "wrong fsuid")
@@ -649,7 +684,7 @@ func TestProcessExecExit(t *testing.T) {
 			}
 		}
 		return false
-	}, time.Second*3, model.ExecEventType, model.ExitEventType)
+	}, 3*time.Second, model.ExecEventType, model.ExitEventType)
 	if err != nil {
 		t.Error(err)
 	}
@@ -752,6 +787,7 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 	t.Run("setuid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			var wg sync.WaitGroup
+			errChan := make(chan error, 1)
 
 			wg.Add(1)
 			go func() {
@@ -761,11 +797,17 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 				// do not unlock, we want the thread to be killed when exiting the goroutine
 
 				if _, _, errno := syscall.Syscall(syscall.SYS_SETUID, 1001, 0, 0); errno != 0 {
-					t.Error(errno)
+					errChan <- error(errno)
 				}
 			}()
 
 			wg.Wait()
+
+			select {
+			case err = <-errChan:
+				return err
+			default:
+			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setuid")
@@ -776,18 +818,25 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 	t.Run("setreuid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			var wg sync.WaitGroup
-			wg.Add(1)
+			errChan := make(chan error, 1)
 
+			wg.Add(1)
 			go func() {
 				defer wg.Done()
 				runtime.LockOSThread()
 				// do not unlock, we want the thread to be killed when exiting the goroutine
 
 				if _, _, errno := syscall.Syscall(syscall.SYS_SETREUID, 1002, 1003, 0); errno != 0 {
-					t.Error(errno)
+					errChan <- error(errno)
 				}
 			}()
 			wg.Wait()
+
+			select {
+			case err = <-errChan:
+				return err
+			default:
+			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setreuid")
@@ -799,19 +848,26 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 	t.Run("setresuid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			var wg sync.WaitGroup
-			wg.Add(1)
+			errChan := make(chan error, 1)
 
+			wg.Add(1)
 			go func() {
 				defer wg.Done()
 				runtime.LockOSThread()
 				// do not unlock, we want the thread to be killed when exiting the goroutine
 
 				if _, _, errno := syscall.Syscall(syscall.SYS_SETRESUID, 1002, 1003, 0); errno != 0 {
-					t.Error(errno)
+					errChan <- error(errno)
 				}
 			}()
 
 			wg.Wait()
+
+			select {
+			case err = <-errChan:
+				return err
+			default:
+			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setreuid")
@@ -823,18 +879,25 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 	t.Run("setfsuid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			var wg sync.WaitGroup
-			wg.Add(1)
+			errChan := make(chan error, 1)
 
+			wg.Add(1)
 			go func() {
 				defer wg.Done()
 				runtime.LockOSThread()
 				// do not unlock, we want the thread to be killed when exiting the goroutine
 
 				if _, _, errno := syscall.Syscall(syscall.SYS_SETFSUID, 1004, 0, 0); errno != 0 {
-					t.Error(errno)
+					errChan <- error(errno)
 				}
 			}()
 			wg.Wait()
+
+			select {
+			case err = <-errChan:
+				return err
+			default:
+			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setfsuid")
@@ -845,18 +908,25 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 	t.Run("setgid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			var wg sync.WaitGroup
-			wg.Add(1)
+			errChan := make(chan error, 1)
 
+			wg.Add(1)
 			go func() {
 				defer wg.Done()
 				runtime.LockOSThread()
 				// do not unlock, we want the thread to be killed when exiting the goroutine
 
 				if _, _, errno := syscall.Syscall(syscall.SYS_SETGID, 1005, 0, 0); errno != 0 {
-					t.Error(errno)
+					errChan <- error(errno)
 				}
 			}()
 			wg.Wait()
+
+			select {
+			case err = <-errChan:
+				return err
+			default:
+			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setgid")
@@ -867,18 +937,25 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 	t.Run("setregid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			var wg sync.WaitGroup
-			wg.Add(1)
+			errChan := make(chan error, 1)
 
+			wg.Add(1)
 			go func() {
 				defer wg.Done()
 				runtime.LockOSThread()
 				// do not unlock, we want the thread to be killed when exiting the goroutine
 
 				if _, _, errno := syscall.Syscall(syscall.SYS_SETREGID, 1006, 1007, 0); errno != 0 {
-					t.Error(errno)
+					errChan <- error(errno)
 				}
 			}()
 			wg.Wait()
+
+			select {
+			case err = <-errChan:
+				return err
+			default:
+			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setregid")
@@ -890,18 +967,25 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 	t.Run("setresgid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			var wg sync.WaitGroup
-			wg.Add(1)
+			errChan := make(chan error, 1)
 
+			wg.Add(1)
 			go func() {
 				defer wg.Done()
 				runtime.LockOSThread()
 				// do not unlock, we want the thread to be killed when exiting the goroutine
 
 				if _, _, errno := syscall.Syscall(syscall.SYS_SETRESGID, 1006, 1007, 0); errno != 0 {
-					t.Error(errno)
+					errChan <- error(errno)
 				}
 			}()
 			wg.Wait()
+
+			select {
+			case err = <-errChan:
+				return err
+			default:
+			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setregid")
@@ -913,18 +997,25 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 	t.Run("setfsgid", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			var wg sync.WaitGroup
-			wg.Add(1)
+			errChan := make(chan error, 1)
 
+			wg.Add(1)
 			go func() {
 				defer wg.Done()
 				runtime.LockOSThread()
 				// do not unlock, we want the thread to be killed when exiting the goroutine
 
 				if _, _, errno := syscall.Syscall(syscall.SYS_SETFSGID, 1008, 0, 0); errno != 0 {
-					t.Error(errno)
+					errChan <- error(errno)
 				}
 			}()
 			wg.Wait()
+
+			select {
+			case err = <-errChan:
+				return err
+			default:
+			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_setfsgid")
@@ -946,8 +1037,9 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			var wg sync.WaitGroup
-			wg.Add(1)
+			errChan := make(chan error, 1)
 
+			wg.Add(1)
 			go func() {
 				defer wg.Done()
 				threadCapabilitiesLock.Lock()
@@ -960,10 +1052,16 @@ func TestProcessCredentialsUpdate(t *testing.T) {
 				threadCapabilities.Unset(capability.PERMITTED|capability.EFFECTIVE, capability.CAP_SYS_BOOT)
 				threadCapabilities.Unset(capability.EFFECTIVE, capability.CAP_WAKE_ALARM)
 				if err := threadCapabilities.Apply(capability.CAPS); err != nil {
-					t.Error(err)
+					errChan <- err
 				}
 			}()
 			wg.Wait()
+
+			select {
+			case err = <-errChan:
+				return err
+			default:
+			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_capset")

--- a/pkg/security/tests/rmdir_test.go
+++ b/pkg/security/tests/rmdir_test.go
@@ -48,15 +48,14 @@ func TestRmdir(t *testing.T) {
 		inode := getInode(t, testFile)
 
 		test.WaitSignal(t, func() error {
-			if _, _, err := syscall.Syscall(syscallNB, uintptr(testFilePtr), 0, 0); err != 0 {
-				t.Fatal(error(err))
+			if _, _, errno := syscall.Syscall(syscallNB, uintptr(testFilePtr), 0, 0); errno != 0 {
+				return error(errno)
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "rmdir", event.GetType(), "wrong event type")
 			assert.Equal(t, inode, event.Rmdir.File.Inode, "wrong inode")
 			assertRights(t, event.Rmdir.File.Mode, expectedMode, "wrong initial mode")
-
 			assertNearTime(t, event.Rmdir.File.MTime)
 			assertNearTime(t, event.Rmdir.File.CTime)
 		})
@@ -77,14 +76,13 @@ func TestRmdir(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			if _, _, err := syscall.Syscall(syscall.SYS_UNLINKAT, 0, uintptr(testDirPtr), 512); err != 0 {
-				t.Fatal(err)
+				return err
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "rmdir", event.GetType(), "wrong event type")
 			assert.Equal(t, inode, event.Rmdir.File.Inode, "wrong inode")
 			assertRights(t, event.Rmdir.File.Mode, expectedMode, "wrong initial mode")
-
 			assertNearTime(t, event.Rmdir.File.MTime)
 			assertNearTime(t, event.Rmdir.File.CTime)
 		})
@@ -115,7 +113,7 @@ func TestRmdirInvalidate(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			if err := syscall.Rmdir(testFile); err != nil {
-				t.Fatal(err)
+				return err
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {

--- a/pkg/security/tests/schemas.go
+++ b/pkg/security/tests/schemas.go
@@ -21,7 +21,7 @@ import (
 //go:embed schemas
 var schemaAssetFS embed.FS
 
-// Define the format inode checker
+// ValidInodeFormatChecker defines the format inode checker
 type ValidInodeFormatChecker struct{}
 
 // IsFormat check inode format
@@ -49,7 +49,8 @@ func validateSchema(t *testing.T, event *sprobe.Event, path string) bool {
 
 	result, err := gojsonschema.Validate(schemaLoader, documentLoader)
 	if err != nil {
-		t.Fatal(err)
+		t.Error(err)
+		return false
 	}
 
 	if !result.Valid() {

--- a/pkg/security/tests/selinux_test.go
+++ b/pkg/security/tests/selinux_test.go
@@ -16,9 +16,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
-	"gotest.tools/assert"
 )
 
 const TestBoolName = "selinuxuser_ping"
@@ -47,9 +48,15 @@ func TestSELinux(t *testing.T) {
 	// initial setup
 	currentEnforceStatus, err := getEnforceStatus()
 	if err != nil {
-		t.Errorf("failed to save enforce status")
+		t.Fatal("failed to save enforce status")
 	}
 	defer setEnforceStatus(currentEnforceStatus)
+
+	savedBoolValue, err := getBoolValue(TestBoolName)
+	if err != nil {
+		t.Fatalf("failed to save bool state: %v", err)
+	}
+	defer setBoolValue(TestBoolName, savedBoolValue)
 
 	test, err := newTestModule(t, nil, ruleset, testOpts{})
 	if err != nil {
@@ -57,22 +64,15 @@ func TestSELinux(t *testing.T) {
 	}
 	defer test.Close()
 
-	savedBoolValue, err := getBoolValue(TestBoolName)
-	if err != nil {
-		t.Errorf("failed to save bool state: %v", err)
-	}
-	defer setBoolValue(TestBoolName, savedBoolValue)
-
 	t.Run("setenforce", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			if err := setEnforceStatus("permissive"); err != nil {
-				t.Errorf("failed to run setenforce: %v", err)
+				return fmt.Errorf("failed to run setenforce: %v", err)
 			}
 			return nil
 		}, func(event *probe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_selinux_enforce")
 			assert.Equal(t, "selinux", event.GetType(), "wrong event type")
-
 			assertFieldEqual(t, event, "selinux.enforce.status", "permissive", "wrong enforce value")
 
 			if !validateSELinuxSchema(t, event) {
@@ -84,7 +84,7 @@ func TestSELinux(t *testing.T) {
 	t.Run("sel_disable", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			if err := rawSudoWrite("/sys/fs/selinux/disable", "0", false); err != nil {
-				t.Errorf("failed to write to selinuxfs: %v", err)
+				return fmt.Errorf("failed to write to selinuxfs: %v", err)
 			}
 			return nil
 		}, func(event *probe.Event, rule *rules.Rule) {
@@ -100,13 +100,12 @@ func TestSELinux(t *testing.T) {
 	t.Run("setsebool_true_value", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			if err := setBoolValue(TestBoolName, true); err != nil {
-				t.Errorf("failed to run setsebool: %v", err)
+				return fmt.Errorf("failed to run setsebool: %v", err)
 			}
 			return nil
 		}, func(event *probe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_selinux_write_bool_true")
 			assert.Equal(t, "selinux", event.GetType(), "wrong event type")
-
 			assertFieldEqual(t, event, "selinux.bool.name", TestBoolName, "wrong bool name")
 			assertFieldEqual(t, event, "selinux.bool.state", "on", "wrong bool value")
 
@@ -119,13 +118,12 @@ func TestSELinux(t *testing.T) {
 	t.Run("setsebool_false_value", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			if err := setBoolValue(TestBoolName, false); err != nil {
-				t.Errorf("failed to run setsebool: %v", err)
+				return fmt.Errorf("failed to run setsebool: %v", err)
 			}
 			return nil
 		}, func(event *probe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_selinux_write_bool_false")
 			assert.Equal(t, "selinux", event.GetType(), "wrong event type")
-
 			assertFieldEqual(t, event, "selinux.bool.name", TestBoolName, "wrong bool name")
 			assertFieldEqual(t, event, "selinux.bool.state", "off", "wrong bool value")
 
@@ -138,15 +136,14 @@ func TestSELinux(t *testing.T) {
 	t.Run("setsebool_error_value", func(t *testing.T) {
 		err = test.GetSignal(t, func() error {
 			if err := rawSudoWrite("/sys/fs/selinux/booleans/httpd_enable_cgi", "test_error", true); err != nil {
-				t.Errorf("failed to write to selinuxfs: %v", err)
+				return fmt.Errorf("failed to write to selinuxfs: %v", err)
 			}
 			return nil
 		}, func(event *probe.Event, rule *rules.Rule) {
-			t.Error("expected error and got an event")
+			t.Errorf("expected error and got an event: %s", event)
 		})
-
 		if err == nil {
-			t.Error("expected error")
+			t.Fatal("expected error")
 		} else {
 			_, ok := err.(ErrTimeout)
 			assert.Equal(t, true, ok, "wrong error type, expected ErrTimeout")
@@ -174,20 +171,19 @@ func TestSELinuxCommitBools(t *testing.T) {
 
 	savedBoolValue, err := getBoolValue(TestBoolName)
 	if err != nil {
-		t.Errorf("failed to save bool state: %v", err)
+		t.Fatalf("failed to save bool state: %v", err)
 	}
 	defer setBoolValue(TestBoolName, savedBoolValue)
 
 	t.Run("sel_commit_bools", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			if err := setBoolValue(TestBoolName, true); err != nil {
-				t.Errorf("failed to run setsebool: %v", err)
+				return fmt.Errorf("failed to run setsebool: %v", err)
 			}
 			return nil
 		}, func(event *probe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_selinux_commit_bools")
 			assert.Equal(t, "selinux", event.GetType(), "wrong event type")
-
 			assertFieldEqual(t, event, "selinux.bool_commit.state", true, "wrong bool value")
 
 			if !validateSELinuxSchema(t, event) {

--- a/pkg/security/tests/serializers_test.go
+++ b/pkg/security/tests/serializers_test.go
@@ -36,19 +36,16 @@ func BenchmarkSerializers(b *testing.B) {
 	}
 
 	var workingEvent *sprobe.Event
-	err = test.WaitSignal(b, func() error {
+	test.WaitSignal(b, func() error {
 		fd, _, errno := syscall.Syscall6(syscall.SYS_OPENAT, 0, uintptr(testFilePtr), syscall.O_CREAT, 0711, 0, 0)
 		if errno != 0 {
-			b.Fatal(errno)
+			return error(errno)
 		}
 		return syscall.Close(int(fd))
 	}, func(event *sprobe.Event, r *rules.Rule) {
-		assert.Equal(b, "open", event.GetType(), "wrong event type")
 		workingEvent = event
+		assert.Equal(b, "open", event.GetType(), "wrong event type")
 	})
-	if err != nil {
-		b.Fatal(err)
-	}
 
 	// then we run the benchmark
 	b.ResetTimer()

--- a/pkg/security/tests/span_test.go
+++ b/pkg/security/tests/span_test.go
@@ -69,13 +69,15 @@ func TestSpan(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			testFile, _, err := test.Create("test-span")
-			os.Remove(testFile)
-			return err
+			if err != nil {
+				return err
+			}
+			return os.Remove(testFile)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_span_rule_open")
 
 			if !validateSpanSchema(t, event) {
-				t.Fatal(event.String())
+				t.Error(event.String())
 			}
 
 			assert.Equal(t, uint64(123), event.SpanContext.SpanID)
@@ -99,7 +101,7 @@ func TestSpan(t *testing.T) {
 			assertTriggeredRule(t, rule, "test_span_rule_exec")
 
 			if !validateSpanSchema(t, event) {
-				t.Fatal(event.String())
+				t.Error(event.String())
 			}
 
 			assert.Equal(t, uint64(204), event.SpanContext.SpanID)

--- a/pkg/security/tests/stress_test.go
+++ b/pkg/security/tests/stress_test.go
@@ -304,7 +304,7 @@ func BenchmarkERPCDentryResolutionSegment(b *testing.B) {
 	err = test.GetSignal(b, func() error {
 		fd, err := syscall.Open(testFile, syscall.O_CREAT, 0755)
 		if err != nil {
-			b.Fatal(err)
+			return err
 		}
 		return syscall.Close(fd)
 	}, func(event *sprobe.Event, _ *rules.Rule) {
@@ -373,7 +373,7 @@ func BenchmarkERPCDentryResolutionPath(b *testing.B) {
 	err = test.GetSignal(b, func() error {
 		fd, err := syscall.Open(testFile, syscall.O_CREAT, 0755)
 		if err != nil {
-			b.Fatal(err)
+			return err
 		}
 		return syscall.Close(fd)
 	}, func(event *sprobe.Event, _ *rules.Rule) {
@@ -442,9 +442,12 @@ func BenchmarkMapDentryResolutionSegment(b *testing.B) {
 	err = test.GetSignal(b, func() error {
 		fd, err := syscall.Open(testFile, syscall.O_CREAT, 0755)
 		if err != nil {
-			b.Fatal(err)
+			return err
 		}
-		return syscall.Close(fd)
+		if err = syscall.Close(fd); err != nil {
+			return err
+		}
+		return nil
 	}, func(event *sprobe.Event, _ *rules.Rule) {
 		mountID = event.Open.File.MountID
 		inode = event.Open.File.Inode
@@ -511,7 +514,7 @@ func BenchmarkMapDentryResolutionPath(b *testing.B) {
 	err = test.GetSignal(b, func() error {
 		fd, err := syscall.Open(testFile, syscall.O_CREAT, 0755)
 		if err != nil {
-			b.Fatal(err)
+			return err
 		}
 		return syscall.Close(fd)
 	}, func(event *sprobe.Event, _ *rules.Rule) {

--- a/pkg/security/tests/unlink_test.go
+++ b/pkg/security/tests/unlink_test.go
@@ -44,14 +44,13 @@ func TestUnlink(t *testing.T) {
 	t.Run("unlink", ifSyscallSupported("SYS_UNLINK", func(t *testing.T, syscallNB uintptr) {
 		test.WaitSignal(t, func() error {
 			if _, _, err := syscall.Syscall(syscallNB, uintptr(testFilePtr), 0, 0); err != 0 {
-				t.Fatal(err)
+				return err
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "unlink", event.GetType(), "wrong event type")
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong inode")
 			assertRights(t, event.Unlink.File.Mode, expectedMode)
-
 			assertNearTime(t, event.Unlink.File.MTime)
 			assertNearTime(t, event.Unlink.File.CTime)
 		})
@@ -68,14 +67,13 @@ func TestUnlink(t *testing.T) {
 	t.Run("unlinkat", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			if _, _, err := syscall.Syscall(syscall.SYS_UNLINKAT, 0, uintptr(testAtFilePtr), 0); err != 0 {
-				t.Fatal(err)
+				return err
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "unlink", event.GetType(), "wrong event type")
 			assert.Equal(t, inode, event.Unlink.File.Inode, "wrong inode")
 			assertRights(t, event.Unlink.File.Mode, expectedMode)
-
 			assertNearTime(t, event.Unlink.File.MTime)
 			assertNearTime(t, event.Unlink.File.CTime)
 		})
@@ -109,8 +107,7 @@ func TestUnlinkInvalidate(t *testing.T) {
 		f.Close()
 
 		test.WaitSignal(t, func() error {
-			os.Remove(testFile)
-			return nil
+			return os.Remove(testFile)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "unlink", event.GetType(), "wrong event type")
 			assertFieldEqual(t, event, "unlink.file.path", testFile)

--- a/pkg/security/tests/utimes_test.go
+++ b/pkg/security/tests/utimes_test.go
@@ -48,7 +48,7 @@ func TestUtimes(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			if _, _, errno := syscall.Syscall(syscallNB, uintptr(testFilePtr), uintptr(unsafe.Pointer(utimbuf)), 0); errno != 0 {
-				t.Fatal(errno)
+				return error(errno)
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
@@ -56,9 +56,7 @@ func TestUtimes(t *testing.T) {
 			assert.Equal(t, int64(123), event.Utimes.Atime.Unix())
 			assert.Equal(t, int64(456), event.Utimes.Mtime.Unix())
 			assert.Equal(t, getInode(t, testFile), event.Utimes.File.Inode, "wrong inode")
-
 			assertRights(t, event.Utimes.File.Mode, expectedMode)
-
 			assertNearTime(t, event.Utimes.File.MTime)
 			assertNearTime(t, event.Utimes.File.CTime)
 		})
@@ -86,17 +84,15 @@ func TestUtimes(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			if _, _, errno := syscall.Syscall(syscallNB, uintptr(testFilePtr), uintptr(unsafe.Pointer(&times[0])), 0); errno != 0 {
-				t.Fatal(errno)
+				return err
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "utimes", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(111), event.Utimes.Atime.Unix())
-
 			assert.Equal(t, int64(222), event.Utimes.Atime.UnixNano()%int64(time.Second)/int64(time.Microsecond))
 			assert.Equal(t, getInode(t, testFile), event.Utimes.File.Inode)
 			assertRights(t, event.Utimes.File.Mode, expectedMode)
-
 			assertNearTime(t, event.Utimes.File.MTime)
 			assertNearTime(t, event.Utimes.File.CTime)
 		})
@@ -125,19 +121,17 @@ func TestUtimes(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			if _, _, errno := syscall.Syscall6(syscall.SYS_UTIMENSAT, 0, uintptr(testFilePtr), uintptr(unsafe.Pointer(&ntimes[0])), 0, 0, 0); errno != 0 {
 				if errno == syscall.EINVAL {
-					t.Skip("utimensat not supported")
+					return ErrSkipTest{"utimensat not supported"}
 				}
-				t.Fatal(errno)
+				return error(errno)
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "utimes", event.GetType(), "wrong event type")
 			assert.Equal(t, int64(555), event.Utimes.Mtime.Unix())
-
 			assert.Equal(t, int64(666), event.Utimes.Mtime.UnixNano()%int64(time.Second)/int64(time.Nanosecond))
 			assert.Equal(t, getInode(t, testFile), event.Utimes.File.Inode)
 			assertRights(t, event.Utimes.File.Mode, expectedMode)
-
 			assertNearTime(t, event.Utimes.File.MTime)
 			assertNearTime(t, event.Utimes.File.CTime)
 		})

--- a/pkg/security/tests/xattr_test.go
+++ b/pkg/security/tests/xattr_test.go
@@ -67,7 +67,6 @@ func TestSetXAttr(t *testing.T) {
 			assert.Equal(t, "user", event.SetXAttr.Namespace)
 			assert.Equal(t, getInode(t, testFile), event.SetXAttr.File.Inode, "wrong inode")
 			assertRights(t, event.SetXAttr.File.Mode, expectedMode)
-
 			assertNearTime(t, event.SetXAttr.File.MTime)
 			assertNearTime(t, event.SetXAttr.File.CTime)
 		})
@@ -96,7 +95,7 @@ func TestSetXAttr(t *testing.T) {
 			// to xattr(7), so just test that we get the proper error.
 			// We should get the event though
 			if errno != syscall.EACCES && errno != syscall.EPERM {
-				t.Fatal(error(errno))
+				return error(errno)
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
@@ -105,7 +104,6 @@ func TestSetXAttr(t *testing.T) {
 			assert.Equal(t, "user", event.SetXAttr.Namespace)
 			assert.Equal(t, getInode(t, testFile), event.SetXAttr.File.Inode, "wrong inode")
 			assertRights(t, event.SetXAttr.File.Mode, 0777)
-
 			assertNearTime(t, event.SetXAttr.File.MTime)
 			assertNearTime(t, event.SetXAttr.File.CTime)
 		})
@@ -127,7 +125,7 @@ func TestSetXAttr(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			_, _, errno := syscall.Syscall6(syscall.SYS_FSETXATTR, f.Fd(), uintptr(xattrNamePtr), uintptr(xattrValuePtr), 0, unix.XATTR_CREATE, 0)
 			if errno != 0 {
-				t.Fatal(error(errno))
+				return error(errno)
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
@@ -136,7 +134,6 @@ func TestSetXAttr(t *testing.T) {
 			assert.Equal(t, "user", event.SetXAttr.Namespace)
 			assert.Equal(t, getInode(t, testFile), event.SetXAttr.File.Inode, "wrong inode")
 			assertRights(t, event.SetXAttr.File.Mode, expectedMode)
-
 			assertNearTime(t, event.SetXAttr.File.MTime)
 			assertNearTime(t, event.SetXAttr.File.CTime)
 		})
@@ -194,16 +191,14 @@ func TestRemoveXAttr(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			_, _, errno = syscall.Syscall(syscall.SYS_REMOVEXATTR, uintptr(testFilePtr), uintptr(xattrNamePtr), 0)
 			if errno != 0 {
-				t.Fatal(error(errno))
+				return error(errno)
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "removexattr", event.GetType(), "wrong event type")
 			assert.Equal(t, "user.test_xattr", event.RemoveXAttr.Name)
-
 			assert.Equal(t, getInode(t, testFile), event.RemoveXAttr.File.Inode, "wrong inode")
 			assertRights(t, event.RemoveXAttr.File.Mode, uint16(expectedMode))
-
 			assertNearTime(t, event.RemoveXAttr.File.MTime)
 			assertNearTime(t, event.RemoveXAttr.File.CTime)
 		})
@@ -239,16 +234,14 @@ func TestRemoveXAttr(t *testing.T) {
 			// Linux and Android don't support xattrs on symlinks according
 			// to xattr(7), so just test that we get the proper error.
 			if errno != syscall.EACCES && errno != syscall.EPERM {
-				t.Fatal(error(errno))
+				return error(errno)
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "removexattr", event.GetType(), "wrong event type")
 			assert.Equal(t, "user.test_xattr", event.RemoveXAttr.Name)
-
 			assert.Equal(t, getInode(t, testFile), event.RemoveXAttr.File.Inode, "wrong inode")
 			assertRights(t, event.RemoveXAttr.File.Mode, 0777)
-
 			assertNearTime(t, event.RemoveXAttr.File.MTime)
 			assertNearTime(t, event.RemoveXAttr.File.CTime)
 		})
@@ -276,7 +269,7 @@ func TestRemoveXAttr(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			_, _, errno = syscall.Syscall(syscall.SYS_FREMOVEXATTR, f.Fd(), uintptr(xattrNamePtr), 0)
 			if errno != 0 {
-				t.Fatal(error(errno))
+				return error(errno)
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
@@ -289,7 +282,7 @@ func TestRemoveXAttr(t *testing.T) {
 			}
 
 			if inode := getInode(t, testFile); inode != event.RemoveXAttr.File.Inode {
-				t.Logf("expected inode %d, got %d", event.RemoveXAttr.File.Inode, inode)
+				t.Errorf("expected inode %d, got %d", event.RemoveXAttr.File.Inode, inode)
 			}
 
 			if int(event.RemoveXAttr.File.Mode)&expectedMode != expectedMode {


### PR DESCRIPTION
### What does this PR do?

This PR fixes multiple bugs in the CWS functional tests:
- The first major change is to prevent a race between the test goroutines and the goroutine of the test module (see below for more information). In short, this PR ensures that only test goroutines can call `t.FailNow()` or `t.SkipNow()`.
- The second important change is that policies are unloaded at the end of a test. Policies used to be kept alive in between tests, which produced inconsistencies depending on wether a test is run alone or after other tests (see below for more information).
- The second point introduces a race: on machines with a low core count, the `atomic.LoadInt / atomic.SwapInt` method to switch the rulesets isn't enough when 2 reloads are triggered sequentially. A lock was added in `testModule` to prevent this race from happening. This race can happen in real life if 2 reloads are triggered really close to one another, but it will only impact the few events queued at the time of the reload and shouldn't have any other impact.
- The third change is that this PR adds statistic reports at the beginning and end of each test. The goal is to help understand the load on a machine when a test fails. Successful tests can also have an impact (if they generate a lot of noise), and those metrics will help understand which tests should be better isolated.
- The last change is a tiny modification of `TestDiscarderFilterMask` and `TestNoisyProcess` to reduce the noise generated by those tests.

### Motivation

#### Preventing a race between the test goroutines and the module goroutine

Our functional tests use a handler registration method to prevent races between the events generated by our eBPF programs and the goroutines of the tests. This means that part of the code of the tests are run within the context of the runtime-security module. In other words, parts of the tests are run by the goroutine that retrieves events from kernel space. If this goroutine is killed, the runtime-security module won't be able to read data from kernel space anymore. 

When a `t.Fatal*` method is called, the `runtime.goexit` function will eventually be called to exit the running goroutine and run its deferred functions. However, for reasons explained in the first paragraph, in some cases, the running goroutine is _**not**_ a test goroutine, but a core goroutine of the CWS system-probe module. In other words, when a test fails inside a handler, we'll close the wrong goroutine and call the wrong deferred functions. This leads to a possible race (see below) on the `T` structure, but more importantly, this explains why we sometimes don't get any events at all from kernel space, and why we've seen some tests fail consistently until a new instance of `testModule` is created.

```
       WARNING: DATA RACE
       Write at 0x00c004ebc9a1 by goroutine 85:
         testing.tRunner()
             /root/.gimme/versions/go1.16.7.linux.amd64/src/testing/testing.go:1196 +0x21a
       
       Previous write at 0x00c004ebc9a1 by goroutine 46:
         testing.(*common).FailNow()
             /root/.gimme/versions/go1.16.7.linux.amd64/src/testing/testing.go:740 +0x4f
         testing.(*common).Fatal()
             /root/.gimme/versions/go1.16.7.linux.amd64/src/testing/testing.go:809 +0x89
         github.com/DataDog/datadog-agent/pkg/security/tests.TestSpan.func1.2()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/span_test.go:78 +0x233
         github.com/DataDog/datadog-agent/pkg/security/tests.(*testModule).GetSignal.func1()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester.go:653 +0x79
         github.com/DataDog/datadog-agent/pkg/security/tests.(*testModule).RuleMatch()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester.go:540 +0xad
         github.com/DataDog/datadog-agent/pkg/security/rules.(*RuleSet).NotifyRuleMatch()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/rules/ruleset.go:271 +0xb8
         github.com/DataDog/datadog-agent/pkg/security/rules.(*RuleSet).Evaluate()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/rules/ruleset.go:389 +0x644
         github.com/DataDog/datadog-agent/pkg/security/module.(*Module).HandleEvent()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/module/module.go:393 +0xad
         github.com/DataDog/datadog-agent/pkg/security/tests.(*testProbeHandler).HandleEvent()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester.go:209 +0xd8
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).DispatchEvent()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:237 +0x196
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).handleEvent()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:558 +0x121e
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).handleEvent-fm()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:312 +0x72
         github.com/DataDog/datadog-agent/pkg/security/probe.(*reOrdererHeap).dequeue()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/reorderer.go:144 +0x51a
         github.com/DataDog/datadog-agent/pkg/security/probe.(*ReOrderer).Start()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/reorderer.go:220 +0x6d2
       
       Goroutine 85 (running) created at:
         testing.(*T).Run()
             /root/.gimme/versions/go1.16.7.linux.amd64/src/testing/testing.go:1238 +0x5d7
         github.com/DataDog/datadog-agent/pkg/security/tests.TestSpan()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/span_test.go:65 +0x926
         testing.tRunner()
             /root/.gimme/versions/go1.16.7.linux.amd64/src/testing/testing.go:1193 +0x202
```

#### Unload policies at the end of a test

We've had multiple examples of tests generating events past the end of their execution, and thus polluting the following tests with wrong event types. Depending on the order of the tests, and on what setup is required at the end / beginning of a test, this can introduce a flaky generation of events. From now on, this PR proposes to unload the policy of a test when a `testModule` is closed. Any cleanup that needs to be done by a test and that might generate events should be done after the `testModule.Close()` function is called.

#### Preventing a race when 2 reloads are called in a row

During a reload, we currently use an array of 2 rulesets with an atomic int64 to point to the active ruleset. The goal here was to allow a ruleset to be prepared while the old one is still evaluating events. The problem is that (on machines under heavy load and with a low core count) when 2 reloads are called in a row, one goroutine might be stuck trying to access the first ruleset, while another one will successfully change the second ruleset and then the first one again. This introduces the race that you can see below:

```
WARNING: DATA RACE
       Write at 0x00c008ca43b8 by goroutine 125:
         github.com/DataDog/datadog-agent/pkg/security/module.(*Module).Reload()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/module/module.go:328 +0x564
         github.com/DataDog/datadog-agent/pkg/security/tests.(*testModule).reloadConfiguration()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester.go:526 +0x198
         github.com/DataDog/datadog-agent/pkg/security/tests.newTestModule()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester.go:459 +0xe18
         github.com/DataDog/datadog-agent/pkg/security/tests.TestProcessExec()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/process_test.go:607 +0x200
         testing.tRunner()
             /root/.gimme/versions/go1.16.7.linux.arm64/src/testing/testing.go:1193 +0x170
       
       Previous read at 0x00c008ca43b8 by goroutine 131:
         github.com/DataDog/datadog-agent/pkg/security/module.(*Module).GetRuleSet()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/module/module.go:508 +0x58
         github.com/DataDog/datadog-agent/pkg/security/module.(*Module).HandleEvent()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/module/module.go:392 +0x68
         github.com/DataDog/datadog-agent/pkg/security/tests.(*testProbeHandler).HandleEvent()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester.go:210 +0xa0
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).DispatchEvent()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:237 +0x14c
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).handleEvent()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:558 +0xd60
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).handleEvent-fm()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:312 +0x58
         github.com/DataDog/datadog-agent/pkg/security/probe.(*reOrdererHeap).dequeue()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/reorderer.go:144 +0x3c0
         github.com/DataDog/datadog-agent/pkg/security/probe.(*ReOrderer).Start()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/reorderer.go:220 +0x4e4
       
       Goroutine 125 (running) created at:
         testing.(*T).Run()
             /root/.gimme/versions/go1.16.7.linux.arm64/src/testing/testing.go:1238 +0x438
         testing.runTests.func1()
             /root/.gimme/versions/go1.16.7.linux.arm64/src/testing/testing.go:1511 +0x90
         testing.tRunner()
             /root/.gimme/versions/go1.16.7.linux.arm64/src/testing/testing.go:1193 +0x170
         testing.runTests()
             /root/.gimme/versions/go1.16.7.linux.arm64/src/testing/testing.go:1509 +0x510
         testing.(*M).Run()
             /root/.gimme/versions/go1.16.7.linux.arm64/src/testing/testing.go:1417 +0x2d0
         main.main()
             _testmain.go:143 +0x224
         runtime.main()
             /root/.gimme/versions/go1.16.7.linux.arm64/src/runtime/proc.go:225 +0x270
         github.com/cilium/ebpf.init()
             /go/pkg/mod/github.com/cilium/ebpf@v0.6.3-0.20210917122031-fc2955d2ecee/syscalls.go:448 +0x78c
         github.com/cilium/ebpf.init()
             /go/pkg/mod/github.com/cilium/ebpf@v0.6.3-0.20210917122031-fc2955d2ecee/syscalls.go:422 +0x71c
         github.com/cilium/ebpf.init()
             /go/pkg/mod/github.com/cilium/ebpf@v0.6.3-0.20210917122031-fc2955d2ecee/syscalls.go:400 +0x6ac
         github.com/cilium/ebpf.init()
             /go/pkg/mod/github.com/cilium/ebpf@v0.6.3-0.20210917122031-fc2955d2ecee/syscalls.go:382 +0x63c
         github.com/cilium/ebpf.init()
             /go/pkg/mod/github.com/cilium/ebpf@v0.6.3-0.20210917122031-fc2955d2ecee/syscalls.go:201 +0x5cc
         github.com/cilium/ebpf.init()
             /go/pkg/mod/github.com/cilium/ebpf@v0.6.3-0.20210917122031-fc2955d2ecee/syscalls.go:185 +0x55c
         github.com/cilium/ebpf.init()
             /go/pkg/mod/github.com/cilium/ebpf@v0.6.3-0.20210917122031-fc2955d2ecee/syscalls.go:168 +0x4ec
         github.com/cilium/ebpf.init()
             /go/pkg/mod/github.com/cilium/ebpf@v0.6.3-0.20210917122031-fc2955d2ecee/syscalls.go:150 +0x47c
         runtime.doInit()
             /root/.gimme/versions/go1.16.7.linux.arm64/src/runtime/proc.go:6308 +0xd8
         github.com/cilium/ebpf/internal/btf.init()
             /go/pkg/mod/github.com/cilium/ebpf@v0.6.3-0.20210917122031-fc2955d2ecee/internal/btf/btf.go:728 +0x1d8
         runtime.doInit()
             /root/.gimme/versions/go1.16.7.linux.arm64/src/runtime/proc.go:6308 +0xd8
         github.com/DataDog/ebpf.init()
             /go/pkg/mod/github.com/!data!dog/ebpf@v0.0.0-20210923171847-87e6c3a89de8/prog.go:341 +0x570
         github.com/DataDog/ebpf.init()
             /go/pkg/mod/github.com/!data!dog/ebpf@v0.0.0-20210923171847-87e6c3a89de8/syscalls.go:436 +0x500
         github.com/DataDog/ebpf.init()
             /go/pkg/mod/github.com/!data!dog/ebpf@v0.0.0-20210923171847-87e6c3a89de8/syscalls.go:223 +0x490
         github.com/DataDog/ebpf.init()
             /go/pkg/mod/github.com/!data!dog/ebpf@v0.0.0-20210923171847-87e6c3a89de8/syscalls.go:195 +0x420
         runtime.doInit()
             /root/.gimme/versions/go1.16.7.linux.arm64/src/runtime/proc.go:6308 +0xd8
       
       Goroutine 131 (running) created at:
         github.com/DataDog/datadog-agent/pkg/security/probe.(*Probe).Start()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/probe/probe.go:215 +0x78
         github.com/DataDog/datadog-agent/pkg/security/module.(*Module).Start()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/module/module.go:149 +0x44
         github.com/DataDog/datadog-agent/pkg/security/tests.newTestModule()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/module_tester.go:511 +0x814
         github.com/DataDog/datadog-agent/pkg/security/tests.TestProcess()
             /go/src/github.com/DataDog/datadog-agent/pkg/security/tests/process_test.go:46 +0x2b4
         testing.tRunner()
             /root/.gimme/versions/go1.16.7.linux.arm64/src/testing/testing.go:1193 +0x170
```

### Describe how to test your changes

This change only affects CWS's functional tests.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
