### PR TITLE
Introduce ECS metrics provider

### DIFF
--- a/pkg/autodiscovery/listeners/environment.go
+++ b/pkg/autodiscovery/listeners/environment.go
@@ -73,7 +73,7 @@ func (l *EnvironmentListener) createServices() {
 	// We're limited by the collectors in Metadata server on Linux.
 	// We're limited by the runtimes on Windows.
 	if runtime.GOOS == "linux" {
-		containerFeatures := []config.Feature{config.Docker, config.Containerd, config.Kubernetes}
+		containerFeatures := []config.Feature{config.Docker, config.Containerd, config.Kubernetes, config.ECSFargate}
 		for _, f := range containerFeatures {
 			if config.IsFeaturePresent(f) {
 				log.Infof("Listener created container service from environment")

--- a/pkg/util/containers/v2/metrics/collector_ecs_fargate.go
+++ b/pkg/util/containers/v2/metrics/collector_ecs_fargate.go
@@ -1,0 +1,193 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build docker
+// +build docker
+
+package metrics
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
+	v2 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v2"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	ecsFargateCollectorID = "ecs_fargate"
+	statsCacheKey         = "ecs-stats-%s"
+	statsCacheExpiration  = 2 * time.Minute
+)
+
+func init() {
+	metricsProvider.registerCollector(collectorMetadata{
+		id:       ecsFargateCollectorID,
+		priority: 0,
+		runtimes: allLinuxRuntimes,
+		factory:  func() (Collector, error) { return newEcsFargateCollector() },
+	})
+}
+
+type ecsFargateCollector struct {
+	client         *v2.Client
+	lastScrapeTime time.Time
+}
+
+// ecsStatsFunc allows mocking the ecs api for testing.
+type ecsStatsFunc func(ctx context.Context, id string) (*v2.ContainerStats, error)
+
+// newEcsFargateCollector returns a new *ecsFargateCollector.
+func newEcsFargateCollector() (*ecsFargateCollector, error) {
+	client, err := metadata.V2()
+	if err != nil {
+		return nil, err
+	}
+
+	return &ecsFargateCollector{client: client}, nil
+}
+
+// ID returns the collector ID.
+func (e *ecsFargateCollector) ID() string { return ecsFargateCollectorID }
+
+// GetContainerStats returns stats by container ID.
+func (e *ecsFargateCollector) GetContainerStats(containerID string, cacheValidity time.Duration) (*ContainerStats, error) {
+	stats, err := e.stats(containerID, cacheValidity, e.client.GetContainerStats)
+	if err != nil {
+		return nil, err
+	}
+
+	return convertEcsStats(stats), nil
+}
+
+// GetContainerNetworkStats returns network stats by container ID.
+func (e *ecsFargateCollector) GetContainerNetworkStats(containerID string, cacheValidity time.Duration, networks map[string]string) (*ContainerNetworkStats, error) {
+	stats, err := e.stats(containerID, cacheValidity, e.client.GetContainerStats)
+	if err != nil {
+		return nil, err
+	}
+
+	return convertEcsNetworkStats(stats.Networks, networks), nil
+}
+
+// stats returns stats by container ID, it uses an in-memory cache to reduce the number of api calls.
+// Cache expires every 2 minutes and can also be invalidated using the cacheValidity argument.
+func (e *ecsFargateCollector) stats(containerID string, cacheValidity time.Duration, clientFunc ecsStatsFunc) (*v2.ContainerStats, error) {
+	refreshRequired := e.lastScrapeTime.Add(cacheValidity).Before(time.Now())
+	cacheKey := fmt.Sprintf(statsCacheKey, containerID)
+	if cacheStats, found := cache.Cache.Get(cacheKey); found && !refreshRequired {
+		stats := cacheStats.(*v2.ContainerStats)
+		log.Debugf("Got ecs stats from cache for container %s", containerID)
+		return stats, nil
+	}
+
+	stats, err := clientFunc(context.TODO(), containerID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get container stats for %s: %w", containerID, err)
+	}
+
+	log.Debugf("Got ecs stats from ECS API for container %s", containerID)
+	e.lastScrapeTime = time.Now()
+	cache.Cache.Set(cacheKey, stats, statsCacheExpiration)
+
+	return stats, nil
+}
+
+func convertEcsStats(ecsStats *v2.ContainerStats) *ContainerStats {
+	return &ContainerStats{
+		Timestamp: time.Now(),
+		CPU:       convertCPUStats(&ecsStats.CPU),
+		Memory:    convertMemoryStats(&ecsStats.Memory),
+		IO:        convertIOStats(&ecsStats.IO),
+	}
+}
+
+func convertCPUStats(cpuStats *v2.CPUStats) *ContainerCPUStats {
+	stats := &ContainerCPUStats{}
+	convertField(&cpuStats.Usage.Total, &stats.Total)
+	convertField(&cpuStats.Usage.Kernelmode, &stats.System)
+	convertField(&cpuStats.Usage.Usermode, &stats.User)
+
+	return stats
+}
+
+func convertMemoryStats(memStats *v2.MemStats) *ContainerMemStats {
+	stats := &ContainerMemStats{}
+	convertField(&memStats.Limit, &stats.Limit)
+	convertField(&memStats.Usage, &stats.UsageTotal)
+	convertField(&memStats.Details.RSS, &stats.RSS)
+	convertField(&memStats.Details.Cache, &stats.Cache)
+
+	return stats
+}
+
+func convertIOStats(ioStats *v2.IOStats) *ContainerIOStats {
+	stats := &ContainerIOStats{}
+
+	var readBytes, writeBytes uint64
+	for _, stat := range ioStats.BytesPerDeviceAndKind {
+		switch stat.Kind {
+		case "Read":
+			readBytes += stat.Value
+		case "Write":
+			writeBytes += stat.Value
+		default:
+			continue
+		}
+	}
+
+	convertField(&readBytes, &stats.ReadBytes)
+	convertField(&writeBytes, &stats.WriteBytes)
+
+	var readOp, writeOp uint64
+	for _, stat := range ioStats.OPPerDeviceAndKind {
+		switch stat.Kind {
+		case "Read":
+			readOp += stat.Value
+		case "Write":
+			writeOp += stat.Value
+		default:
+			continue
+		}
+	}
+
+	convertField(&readOp, &stats.ReadOperations)
+	convertField(&writeOp, &stats.WriteOperations)
+
+	return stats
+}
+
+func convertEcsNetworkStats(netStats v2.NetStatsMap, networks map[string]string) *ContainerNetworkStats {
+	stats := &ContainerNetworkStats{}
+	stats.Interfaces = make(map[string]InterfaceNetStats)
+	var totalPacketsRcvd, totalPacketsSent, totalBytesRcvd, totalBytesSent uint64
+	for iface, statsPerInterface := range netStats {
+		if new, found := networks[iface]; found {
+			iface = new
+		}
+
+		iStats := InterfaceNetStats{}
+		convertField(&statsPerInterface.TxBytes, &iStats.BytesSent)
+		convertField(&statsPerInterface.TxPackets, &iStats.PacketsSent)
+		convertField(&statsPerInterface.RxBytes, &iStats.BytesRcvd)
+		convertField(&statsPerInterface.RxPackets, &iStats.PacketsRcvd)
+		stats.Interfaces[iface] = iStats
+
+		totalPacketsRcvd += statsPerInterface.RxPackets
+		totalPacketsSent += statsPerInterface.TxPackets
+		totalBytesRcvd += statsPerInterface.RxBytes
+		totalBytesSent += statsPerInterface.TxBytes
+	}
+
+	convertField(&totalPacketsRcvd, &stats.PacketsRcvd)
+	convertField(&totalPacketsSent, &stats.PacketsSent)
+	convertField(&totalBytesRcvd, &stats.BytesRcvd)
+	convertField(&totalBytesSent, &stats.BytesSent)
+
+	return stats
+}

--- a/pkg/util/containers/v2/metrics/collector_ecs_fargate.go
+++ b/pkg/util/containers/v2/metrics/collector_ecs_fargate.go
@@ -22,7 +22,7 @@ import (
 const (
 	ecsFargateCollectorID = "ecs_fargate"
 	statsCacheKey         = "ecs-stats-%s"
-	statsCacheExpiration  = 2 * time.Minute
+	statsCacheExpiration  = 10 * time.Second
 )
 
 func init() {
@@ -99,6 +99,10 @@ func (e *ecsFargateCollector) stats(containerID string, cacheValidity time.Durat
 }
 
 func convertEcsStats(ecsStats *v2.ContainerStats) *ContainerStats {
+	if ecsStats == nil {
+		return nil
+	}
+
 	return &ContainerStats{
 		Timestamp: time.Now(),
 		CPU:       convertCPUStats(&ecsStats.CPU),
@@ -108,6 +112,10 @@ func convertEcsStats(ecsStats *v2.ContainerStats) *ContainerStats {
 }
 
 func convertCPUStats(cpuStats *v2.CPUStats) *ContainerCPUStats {
+	if cpuStats == nil {
+		return nil
+	}
+
 	stats := &ContainerCPUStats{}
 	convertField(&cpuStats.Usage.Total, &stats.Total)
 	convertField(&cpuStats.Usage.Kernelmode, &stats.System)
@@ -117,6 +125,10 @@ func convertCPUStats(cpuStats *v2.CPUStats) *ContainerCPUStats {
 }
 
 func convertMemoryStats(memStats *v2.MemStats) *ContainerMemStats {
+	if memStats == nil {
+		return nil
+	}
+
 	stats := &ContainerMemStats{}
 	convertField(&memStats.Limit, &stats.Limit)
 	convertField(&memStats.Usage, &stats.UsageTotal)
@@ -127,8 +139,11 @@ func convertMemoryStats(memStats *v2.MemStats) *ContainerMemStats {
 }
 
 func convertIOStats(ioStats *v2.IOStats) *ContainerIOStats {
-	stats := &ContainerIOStats{}
+	if ioStats == nil {
+		return nil
+	}
 
+	stats := &ContainerIOStats{}
 	var readBytes, writeBytes uint64
 	for _, stat := range ioStats.BytesPerDeviceAndKind {
 		switch stat.Kind {

--- a/pkg/util/containers/v2/metrics/collector_ecs_fargate_test.go
+++ b/pkg/util/containers/v2/metrics/collector_ecs_fargate_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	v2 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v2"
 
@@ -135,11 +136,11 @@ func TestConvertEcsNetworkStats(t *testing.T) {
 				networks: map[string]string{},
 			},
 			want: &ContainerNetworkStats{
-				Interfaces:  map[string]InterfaceNetStats{"eth1": {BytesRcvd: floatPtr(2398415937), PacketsRcvd: floatPtr(1898631), BytesSent: floatPtr(1259037719), PacketsSent: floatPtr(428002)}},
-				BytesRcvd:   floatPtr(2398415937),
-				PacketsRcvd: floatPtr(1898631),
-				BytesSent:   floatPtr(1259037719),
-				PacketsSent: floatPtr(428002),
+				Interfaces:  map[string]InterfaceNetStats{"eth1": {BytesRcvd: util.UIntToFloatPtr(2398415937), PacketsRcvd: util.UIntToFloatPtr(1898631), BytesSent: util.UIntToFloatPtr(1259037719), PacketsSent: util.UIntToFloatPtr(428002)}},
+				BytesRcvd:   util.UIntToFloatPtr(2398415937),
+				PacketsRcvd: util.UIntToFloatPtr(1898631),
+				BytesSent:   util.UIntToFloatPtr(1259037719),
+				PacketsSent: util.UIntToFloatPtr(428002),
 			},
 		},
 		{
@@ -149,11 +150,11 @@ func TestConvertEcsNetworkStats(t *testing.T) {
 				networks: map[string]string{"eth1": "custom_iface"},
 			},
 			want: &ContainerNetworkStats{
-				Interfaces:  map[string]InterfaceNetStats{"custom_iface": {BytesRcvd: floatPtr(2398415937), PacketsRcvd: floatPtr(1898631), BytesSent: floatPtr(1259037719), PacketsSent: floatPtr(428002)}},
-				BytesRcvd:   floatPtr(2398415937),
-				PacketsRcvd: floatPtr(1898631),
-				BytesSent:   floatPtr(1259037719),
-				PacketsSent: floatPtr(428002),
+				Interfaces:  map[string]InterfaceNetStats{"custom_iface": {BytesRcvd: util.UIntToFloatPtr(2398415937), PacketsRcvd: util.UIntToFloatPtr(1898631), BytesSent: util.UIntToFloatPtr(1259037719), PacketsSent: util.UIntToFloatPtr(428002)}},
+				BytesRcvd:   util.UIntToFloatPtr(2398415937),
+				PacketsRcvd: util.UIntToFloatPtr(1898631),
+				BytesSent:   util.UIntToFloatPtr(1259037719),
+				PacketsSent: util.UIntToFloatPtr(428002),
 			},
 		},
 		{
@@ -161,19 +162,19 @@ func TestConvertEcsNetworkStats(t *testing.T) {
 			args: args{
 				netStats: v2.NetStatsMap{
 					"eth0": v2.NetStats{RxBytes: 2398415937, RxPackets: 1898631, TxBytes: 1259037719, TxPackets: 428002},
-					"eth1": v2.NetStats{TxBytes: 2398415937, TxPackets: 1898631, RxBytes: 1259037719, RxPackets: 428002},
+					"eth1": v2.NetStats{TxBytes: 2398415936, TxPackets: 1898630, RxBytes: 1259037718, RxPackets: 428001},
 				},
 				networks: map[string]string{},
 			},
 			want: &ContainerNetworkStats{
 				Interfaces: map[string]InterfaceNetStats{
-					"eth0": {BytesRcvd: floatPtr(2398415937), PacketsRcvd: floatPtr(1898631), BytesSent: floatPtr(1259037719), PacketsSent: floatPtr(428002)},
-					"eth1": {BytesSent: floatPtr(2398415937), PacketsSent: floatPtr(1898631), BytesRcvd: floatPtr(1259037719), PacketsRcvd: floatPtr(428002)},
+					"eth0": {BytesRcvd: util.UIntToFloatPtr(2398415937), PacketsRcvd: util.UIntToFloatPtr(1898631), BytesSent: util.UIntToFloatPtr(1259037719), PacketsSent: util.UIntToFloatPtr(428002)},
+					"eth1": {BytesSent: util.UIntToFloatPtr(2398415936), PacketsSent: util.UIntToFloatPtr(1898630), BytesRcvd: util.UIntToFloatPtr(1259037718), PacketsRcvd: util.UIntToFloatPtr(428001)},
 				},
-				BytesRcvd:   floatPtr(3657453656),
-				PacketsRcvd: floatPtr(2326633),
-				BytesSent:   floatPtr(3657453656),
-				PacketsSent: floatPtr(2326633),
+				BytesRcvd:   util.UIntToFloatPtr(3657453655),
+				PacketsRcvd: util.UIntToFloatPtr(2326632),
+				BytesSent:   util.UIntToFloatPtr(3657453655),
+				PacketsSent: util.UIntToFloatPtr(2326632),
 			},
 		},
 	}
@@ -269,23 +270,18 @@ func TestConvertEcsStats(t *testing.T) {
 			},
 			want: &ContainerStats{
 				Timestamp: constTime,
-				CPU:       &ContainerCPUStats{Total: floatPtr(1137691504), System: floatPtr(80000000), User: floatPtr(810000000)},
-				Memory:    &ContainerMemStats{Limit: floatPtr(9223372036854772000), UsageTotal: floatPtr(6504448), RSS: floatPtr(4669440), Cache: floatPtr(651264)},
-				IO:        &ContainerIOStats{ReadBytes: floatPtr(638976), WriteBytes: floatPtr(0), ReadOperations: floatPtr(12), WriteOperations: floatPtr(0)},
+				CPU:       &ContainerCPUStats{Total: util.UIntToFloatPtr(1137691504), System: util.UIntToFloatPtr(80000000), User: util.UIntToFloatPtr(810000000)},
+				Memory:    &ContainerMemStats{Limit: util.UIntToFloatPtr(9223372036854772000), UsageTotal: util.UIntToFloatPtr(6504448), RSS: util.UIntToFloatPtr(4669440), Cache: util.UIntToFloatPtr(651264)},
+				IO:        &ContainerIOStats{ReadBytes: util.UIntToFloatPtr(638976), WriteBytes: util.UIntToFloatPtr(0), ReadOperations: util.UIntToFloatPtr(12), WriteOperations: util.UIntToFloatPtr(0)},
 			},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := convertEcsStats(tt.args.ecsStats)
-			got.Timestamp = constTime
+			got.Timestamp = constTime // avoid comparing the timestamp field as we have no control over it
 
 			assert.EqualValues(t, tt.want, got)
 		})
 	}
-}
-
-func floatPtr(u uint64) *float64 {
-	f := float64(u)
-	return &f
 }

--- a/pkg/util/containers/v2/metrics/collector_ecs_fargate_test.go
+++ b/pkg/util/containers/v2/metrics/collector_ecs_fargate_test.go
@@ -1,0 +1,291 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build docker
+// +build docker
+
+package metrics
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	v2 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v2"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestStats(t *testing.T) {
+	apiStats := v2.ContainerStats{Memory: v2.MemStats{Limit: 512}}
+	cachedStats := v2.ContainerStats{Memory: v2.MemStats{Limit: 256}}
+	type fields struct {
+		lastScrapeTime time.Time
+	}
+	type args struct {
+		containerID   string
+		cacheValidity time.Duration
+		clientFunc    ecsStatsFunc
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		args     args
+		loadFunc func()
+		want     *v2.ContainerStats
+		wantErr  bool
+		wantFunc func() error
+	}{
+		{
+			name: "empty cache, call api, set cache",
+			args: args{
+				containerID:   "container_id",
+				cacheValidity: 5 * time.Second,
+				clientFunc:    func(context.Context, string) (*v2.ContainerStats, error) { return &apiStats, nil },
+			},
+			loadFunc: func() {},
+			want:     &apiStats,
+			wantErr:  false,
+			wantFunc: func() error {
+				if _, found := cache.Cache.Get("ecs-stats-container_id"); !found {
+					return errors.New("container stats not cached")
+				}
+				return nil
+			},
+		},
+		{
+			name: "cache is valid",
+			fields: fields{
+				lastScrapeTime: time.Now(),
+			},
+			args: args{
+				containerID:   "container_id",
+				cacheValidity: 10 * time.Second,
+				clientFunc: func(context.Context, string) (*v2.ContainerStats, error) {
+					return nil, errors.New("should use cache")
+				},
+			},
+			loadFunc: func() { cache.Cache.Set("ecs-stats-container_id", &cachedStats, statsCacheExpiration) },
+			want:     &cachedStats,
+			wantErr:  false,
+			wantFunc: func() error {
+				if _, found := cache.Cache.Get("ecs-stats-container_id"); !found {
+					return errors.New("container stats not cached")
+				}
+				return nil
+			},
+		},
+		{
+			name: "cache is populated, but invalid",
+			fields: fields{
+				lastScrapeTime: time.Now().Add(-30 * time.Second),
+			},
+			args: args{
+				containerID:   "container_id",
+				cacheValidity: 10 * time.Second,
+				clientFunc:    func(context.Context, string) (*v2.ContainerStats, error) { return &apiStats, nil },
+			},
+			loadFunc: func() { cache.Cache.Set("ecs-stats-container_id", &cachedStats, statsCacheExpiration) },
+			want:     &apiStats,
+			wantErr:  false,
+			wantFunc: func() error {
+				if _, found := cache.Cache.Get("ecs-stats-container_id"); !found {
+					return errors.New("container stats not cached")
+				}
+				return nil
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			e := &ecsFargateCollector{
+				lastScrapeTime: tt.fields.lastScrapeTime,
+			}
+
+			tt.loadFunc()
+			got, err := e.stats(tt.args.containerID, tt.args.cacheValidity, tt.args.clientFunc)
+
+			assert.Equal(t, tt.wantErr, err != nil)
+			assert.EqualValues(t, tt.want, got)
+			assert.Nil(t, tt.wantFunc())
+
+			cache.Cache.Flush()
+		})
+	}
+}
+
+func TestConvertEcsNetworkStats(t *testing.T) {
+	type args struct {
+		netStats v2.NetStatsMap
+		networks map[string]string
+	}
+	tests := []struct {
+		name string
+		args args
+		want *ContainerNetworkStats
+	}{
+		{
+			name: "nominal case",
+			args: args{
+				netStats: v2.NetStatsMap{"eth1": v2.NetStats{RxBytes: 2398415937, RxPackets: 1898631, TxBytes: 1259037719, TxPackets: 428002}},
+				networks: map[string]string{},
+			},
+			want: &ContainerNetworkStats{
+				Interfaces:  map[string]InterfaceNetStats{"eth1": {BytesRcvd: floatPtr(2398415937), PacketsRcvd: floatPtr(1898631), BytesSent: floatPtr(1259037719), PacketsSent: floatPtr(428002)}},
+				BytesRcvd:   floatPtr(2398415937),
+				PacketsRcvd: floatPtr(1898631),
+				BytesSent:   floatPtr(1259037719),
+				PacketsSent: floatPtr(428002),
+			},
+		},
+		{
+			name: "custom interface name",
+			args: args{
+				netStats: v2.NetStatsMap{"eth1": v2.NetStats{RxBytes: 2398415937, RxPackets: 1898631, TxBytes: 1259037719, TxPackets: 428002}},
+				networks: map[string]string{"eth1": "custom_iface"},
+			},
+			want: &ContainerNetworkStats{
+				Interfaces:  map[string]InterfaceNetStats{"custom_iface": {BytesRcvd: floatPtr(2398415937), PacketsRcvd: floatPtr(1898631), BytesSent: floatPtr(1259037719), PacketsSent: floatPtr(428002)}},
+				BytesRcvd:   floatPtr(2398415937),
+				PacketsRcvd: floatPtr(1898631),
+				BytesSent:   floatPtr(1259037719),
+				PacketsSent: floatPtr(428002),
+			},
+		},
+		{
+			name: "multiple interfaces",
+			args: args{
+				netStats: v2.NetStatsMap{
+					"eth0": v2.NetStats{RxBytes: 2398415937, RxPackets: 1898631, TxBytes: 1259037719, TxPackets: 428002},
+					"eth1": v2.NetStats{TxBytes: 2398415937, TxPackets: 1898631, RxBytes: 1259037719, RxPackets: 428002},
+				},
+				networks: map[string]string{},
+			},
+			want: &ContainerNetworkStats{
+				Interfaces: map[string]InterfaceNetStats{
+					"eth0": {BytesRcvd: floatPtr(2398415937), PacketsRcvd: floatPtr(1898631), BytesSent: floatPtr(1259037719), PacketsSent: floatPtr(428002)},
+					"eth1": {BytesSent: floatPtr(2398415937), PacketsSent: floatPtr(1898631), BytesRcvd: floatPtr(1259037719), PacketsRcvd: floatPtr(428002)},
+				},
+				BytesRcvd:   floatPtr(3657453656),
+				PacketsRcvd: floatPtr(2326633),
+				BytesSent:   floatPtr(3657453656),
+				PacketsSent: floatPtr(2326633),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.EqualValues(t, tt.want, convertEcsNetworkStats(tt.args.netStats, tt.args.networks))
+		})
+	}
+}
+
+func TestConvertEcsStats(t *testing.T) {
+	constTime := time.Now()
+	type args struct {
+		ecsStats *v2.ContainerStats
+	}
+	tests := []struct {
+		name string
+		args args
+		want *ContainerStats
+	}{
+		{
+			name: "nominal case",
+			args: args{
+				ecsStats: &v2.ContainerStats{
+					CPU:    v2.CPUStats{Usage: v2.CPUUsage{Total: 1137691504, Kernelmode: 80000000, Usermode: 810000000}},
+					Memory: v2.MemStats{Limit: 9223372036854772000, Usage: 6504448, Details: v2.DetailedMem{RSS: 4669440, Cache: 651264}},
+					IO: v2.IOStats{BytesPerDeviceAndKind: []v2.OPStat{
+						{
+							Major: 202,
+							Minor: 26368,
+							Kind:  "Read",
+							Value: 638976,
+						},
+						{
+							Major: 202,
+							Minor: 26368,
+							Kind:  "Write",
+							Value: 0,
+						},
+						{
+							Major: 202,
+							Minor: 26368,
+							Kind:  "Sync",
+							Value: 638976,
+						},
+						{
+							Major: 202,
+							Minor: 26368,
+							Kind:  "Async",
+							Value: 0,
+						},
+						{
+							Major: 202,
+							Minor: 26368,
+							Kind:  "Total",
+							Value: 638976,
+						},
+					},
+						OPPerDeviceAndKind: []v2.OPStat{
+							{
+								Major: 202,
+								Minor: 26368,
+								Kind:  "Read",
+								Value: 12,
+							},
+							{
+								Major: 202,
+								Minor: 26368,
+								Kind:  "Write",
+								Value: 0,
+							},
+							{
+								Major: 202,
+								Minor: 26368,
+								Kind:  "Sync",
+								Value: 12,
+							},
+							{
+								Major: 202,
+								Minor: 26368,
+								Kind:  "Async",
+								Value: 0,
+							},
+							{
+								Major: 202,
+								Minor: 26368,
+								Kind:  "Total",
+								Value: 12,
+							},
+						},
+					},
+				},
+			},
+			want: &ContainerStats{
+				Timestamp: constTime,
+				CPU:       &ContainerCPUStats{Total: floatPtr(1137691504), System: floatPtr(80000000), User: floatPtr(810000000)},
+				Memory:    &ContainerMemStats{Limit: floatPtr(9223372036854772000), UsageTotal: floatPtr(6504448), RSS: floatPtr(4669440), Cache: floatPtr(651264)},
+				IO:        &ContainerIOStats{ReadBytes: floatPtr(638976), WriteBytes: floatPtr(0), ReadOperations: floatPtr(12), WriteOperations: floatPtr(0)},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertEcsStats(tt.args.ecsStats)
+			got.Timestamp = constTime
+
+			assert.EqualValues(t, tt.want, got)
+		})
+	}
+}
+
+func floatPtr(u uint64) *float64 {
+	f := float64(u)
+	return &f
+}

--- a/pkg/util/containers/v2/metrics/collector_system_linux.go
+++ b/pkg/util/containers/v2/metrics/collector_system_linux.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/system"
@@ -200,10 +199,4 @@ func buildPIDStats(cgs *cgroups.PIDStats) *ContainerPIDStats {
 	convertField(cgs.HierarchicalThreadLimit, &cs.ThreadLimit)
 
 	return cs
-}
-
-func convertField(s *uint64, t **float64) {
-	if s != nil {
-		*t = util.Float64Ptr(float64(*s))
-	}
 }

--- a/pkg/util/containers/v2/metrics/util.go
+++ b/pkg/util/containers/v2/metrics/util.go
@@ -1,0 +1,14 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metrics
+
+import "github.com/DataDog/datadog-agent/pkg/util"
+
+func convertField(s *uint64, t **float64) {
+	if s != nil {
+		*t = util.Float64Ptr(float64(*s))
+	}
+}

--- a/pkg/util/pointer.go
+++ b/pkg/util/pointer.go
@@ -14,3 +14,9 @@ func UInt64Ptr(v uint64) *uint64 {
 func Float64Ptr(v float64) *float64 {
 	return &v
 }
+
+// UIntToFloatPtr converts a uint64 value to float64 and returns a pointer.
+func UIntToFloatPtr(u uint64) *float64 {
+	f := float64(u)
+	return &f
+}


### PR DESCRIPTION
### What does this PR do?

Implement ECS Fargate metrics provider.

### Motivation

Make the `container` check support ECS Fargate.

### Describe how to test your changes

Run the generic `container` check on ECS Fargate.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
