### PR TITLE
[gitlab] Record compressed packages size

### DIFF
--- a/.gitlab/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics.yml
@@ -5,8 +5,8 @@
 .add_metric_func:
   script:
     - apt-get install -y jq
-    # we will build up a JSON body in `$post_body`.
-    # Then the script using add_metric needs to use the .send_metrics script to send the metrics
+    # Build up a JSON body in $post_body.
+    # To send metrics accumulated in $post_body by add_metric, use the .send_metrics script
     - 'post_body="{\"series\": []}"'
     - currenttime=$(date +%s)
     - |
@@ -27,6 +27,7 @@
 
 .send_metrics:
   script:
+    # Send the metrics accumulated by add_metric
     - DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key --with-decryption --query "Parameter.Value" --out text)
     - 'curl --fail -X POST -H "Content-type: application/json" -d "$post_body" "https://api.datadoghq.com/api/v1/series?api_key=$DD_API_KEY"'
 
@@ -161,7 +162,7 @@ send_pkg_size-a7:
     - source /root/.bashrc && conda activate ddpy3
     - export failures=0
     - export last_stable=$(inv release.get-release-json-value "last_stable::${MAJOR_VERSION}")
-    # Get stable packages from S3 buckets & compare sizes
+    # Get stable packages from S3 buckets, send new package sizes & compare stable and new package sizes
     # The loop assumes that all flavors start with "da", which is currently the case
     # We want to run all package size comparisons before failing, so we set +e while doing the comparisons
     # to get the error codes without exiting the shell.
@@ -189,7 +190,7 @@ send_pkg_size-a7:
     # Send package size metrics
     - !reference [.send_metrics, script]
 
-    # Make the job fail if at least
+    # Make the job fail if at least one package is above threshold
     - if [ "${failures}" -ne "0" ]; then false; fi
 
 check_pkg_size-a6:

--- a/.gitlab/pkg_metrics.yml
+++ b/.gitlab/pkg_metrics.yml
@@ -2,6 +2,35 @@
 # pkg_metrics stage
 # Contains jobs which send metrics (package size) about the Linus Agent packages to our backend.
 
+.add_metric_func:
+  script:
+    - apt-get install -y jq
+    # we will build up a JSON body in `$post_body`.
+    # Then the script using add_metric needs to use the .send_metrics script to send the metrics
+    - 'post_body="{\"series\": []}"'
+    - currenttime=$(date +%s)
+    - |
+        add_metric() {
+            local metric="${1}"
+            shift
+            local value="${1}"
+            shift
+
+            local tags=[]
+            while [ -n "${1}" ]; do
+                tags=$(echo $tags | jq -c ". += [\"${1}\"]")
+                shift
+            done
+
+            post_body=$(echo $post_body | jq -c ".series += [{\"metric\":\"$metric\", \"points\":[[$currenttime, $value]],\"tags\":$tags}]")
+        }
+
+.send_metrics:
+  script:
+    - DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key --with-decryption --query "Parameter.Value" --out text)
+    - 'curl --fail -X POST -H "Content-type: application/json" -d "$post_body" "https://api.datadoghq.com/api/v1/series?api_key=$DD_API_KEY"'
+
+
 send_pkg_size-a6:
   allow_failure: true
   rules:
@@ -66,38 +95,23 @@ send_pkg_size-a7:
     - iot_agent_suse-x64
   before_script:
     # FIXME: tmp while we uppdate the base image
-    - apt-get install -y wget rpm2cpio cpio jq
+    - apt-get install -y wget rpm2cpio cpio
     - ls -l $OMNIBUS_PACKAGE_DIR
     - ls -l $OMNIBUS_PACKAGE_DIR_SUSE
   script:
+    - !reference [.add_metric_func, script]
+
     - source /root/.bashrc && conda activate ddpy3
     - mkdir -p /tmp/deb/agent /tmp/deb/dogstatsd /tmp/deb/iot-agent
     - mkdir -p /tmp/rpm/agent /tmp/rpm/dogstatsd /tmp/rpm/iot-agent
     - mkdir -p /tmp/suse/agent /tmp/suse/dogstatsd /tmp/suse/iot-agent
 
-    # we will build up a JSON body in `$metrics`, and then post it.
-    - 'post_body="{\"series\": []}"'
-    - |
-        add_metric() {
-            local metric="${1}"
-            shift
-            local value="${1}"
-            shift
-
-            local tags=[]
-            while [ -n "${1}" ]; do
-                tags=$(echo $tags | jq -c ". += [\"${1}\"]")
-                shift
-            done
-
-            post_body=$(echo $post_body | jq -c ".series += [{\"metric\":\"$metric\", \"points\":[[$currenttime, $value]],\"tags\":$tags}]")
-        }
     - |
         add_metrics() {
             local base="${1}"
             local os="${2}"
 
-            # record a the total uncompressed size of each package
+            # record the total uncompressed size of each package
             add_metric datadog.agent.package.size $(du -sB1 ${base}/agent | sed 's/\([0-9]\+\).\+/\1/') os:${os} package:agent agent:7 bucket_branch:$DEB_RPM_BUCKET_BRANCH
             add_metric datadog.agent.package.size $(du -sB1 ${base}/dogstatsd | sed 's/\([0-9]\+\).\+/\1/') os:${os} package:dogstatsd agent:7 bucket_branch:$DEB_RPM_BUCKET_BRANCH
             add_metric datadog.agent.package.size $(du -sB1 ${base}/iot-agent | sed 's/\([0-9]\+\).\+/\1/') os:${os} package:iot-agent agent:7 bucket_branch:$DEB_RPM_BUCKET_BRANCH
@@ -111,7 +125,6 @@ send_pkg_size-a7:
             add_metric datadog.agent.binary.size $(du -sB1 ${base}/dogstatsd/opt/datadog-dogstatsd/bin/dogstatsd | sed 's/\([0-9]\+\).\+/\1/') bin:dogstatsd os:${os} package:dogstatsd agent:7 bucket_branch:$DEB_RPM_BUCKET_BRANCH
             add_metric datadog.agent.binary.size $(du -sB1 ${base}/iot-agent/opt/datadog-agent/bin/agent/agent | sed 's/\([0-9]\+\).\+/\1/') bin:agent os:${os} package:iot-agent agent:7 bucket_branch:$DEB_RPM_BUCKET_BRANCH
         }
-    - currenttime=$(date +%s)
 
     # We silence dpkg and cpio output so we don't exceed gitlab log limit
 
@@ -133,14 +146,16 @@ send_pkg_size-a7:
     - cd /tmp/suse/iot-agent && rpm2cpio $OMNIBUS_PACKAGE_DIR_SUSE/datadog-iot-agent-7.*.x86_64.rpm | cpio -idm > /dev/null
     - add_metrics /tmp/suse suse
 
-    - DD_API_KEY=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.datadog_api_key --with-decryption --query "Parameter.Value" --out text)
-    - 'curl --fail -X POST -H "Content-type: application/json" -d "$post_body" "https://api.datadoghq.com/api/v1/series?api_key=$DD_API_KEY"'
+    # Send package and binary size metrics
+    - !reference [.send_metrics, script]
 
 .check_pkg_size:
   stage: pkg_metrics
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main"]
   script:
+    - !reference [.add_metric_func, script]
+
     - ls -l $OMNIBUS_PACKAGE_DIR
     - ls -l $OMNIBUS_PACKAGE_DIR_SUSE
     - source /root/.bashrc && conda activate ddpy3
@@ -157,6 +172,10 @@ send_pkg_size-a7:
             curl -sSL "https://s3.amazonaws.com/yum.datadoghq.com/stable/${MAJOR_VERSION}/x86_64/${flavor}-${last_stable}-1.x86_64.rpm" -o "/tmp/stable/${flavor}/${flavor}-${last_stable}-1.x86_64.rpm"
             curl -sSL "https://s3.amazonaws.com/yum.datadoghq.com/suse/stable/${MAJOR_VERSION}/x86_64/${flavor}-${last_stable}-1.x86_64.rpm" -o "/tmp/stable/${flavor}/suse/${flavor}-${last_stable}-1.x86_64.rpm"
             
+            add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}_${MAJOR_VERSION}*_amd64.deb | cut -f -1) os:debian package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${DEB_RPM_BUCKET_BRANCH}
+            add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR}/${flavor}-${MAJOR_VERSION}.*.x86_64.rpm | cut -f -1) os:centos package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${DEB_RPM_BUCKET_BRANCH}
+            add_metric datadog.agent.compressed_package.size $(du -sB1 ${OMNIBUS_PACKAGE_DIR_SUSE}/${flavor}-${MAJOR_VERSION}.*.x86_64.rpm | cut -f -1) os:suse package:${flavor} agent:${MAJOR_VERSION} git_ref:${CI_COMMIT_REF_SLUG} bucket_branch:${DEB_RPM_BUCKET_BRANCH}
+
             set +e
             inv package.compare-size --package-type "${flavor} deb" --last-stable "${last_stable}" --threshold "${max_sizes[${flavor}]}" --new-package "$OMNIBUS_PACKAGE_DIR/${flavor}_${MAJOR_VERSION}*_amd64.deb" --stable-package "/tmp/stable/${flavor}/${flavor}_${last_stable}-1_amd64.deb"
             failures=$((${failures}+$?))
@@ -166,6 +185,11 @@ send_pkg_size-a7:
             failures=$((${failures}+$?))
             set -e
         done
+
+    # Send package size metrics
+    - !reference [.send_metrics, script]
+
+    # Make the job fail if at least
     - if [ "${failures}" -ne "0" ]; then false; fi
 
 check_pkg_size-a6:


### PR DESCRIPTION
### What does this PR do?

Updates the `check_pkg_size` jobs to also upload the compressed package size metrics to Datadog (tagged by git ref, os, flavor, target repo branch).

Refactors the `pkg_metrics` jobs to use common scripts & functions.

### Motivation

Get additional metrics on Agent package size evolution.

### Describe how to test your changes

Tried a deploy pipeline to check all `pkg_metrics` jobs: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/5938725

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
