### PR TITLE
[CWS] various optimisations around event serializers

### DIFF
--- a/pkg/security/module/event.go
+++ b/pkg/security/module/event.go
@@ -1,4 +1,4 @@
-//go:generate go run github.com/mailru/easyjson/easyjson $GOFILE
+//go:generate go run github.com/mailru/easyjson/easyjson -no_std_marshalers $GOFILE
 
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
@@ -20,6 +20,6 @@ type AgentContext struct {
 // Signal - Rule event wrapper used to send an event to the backend
 // easyjson:json
 type Signal struct {
-	*AgentContext `json:"agent"`
-	Title         string `json:"title"`
+	AgentContext `json:"agent"`
+	Title        string `json:"title"`
 }

--- a/pkg/security/module/event_easyjson.go
+++ b/pkg/security/module/event_easyjson.go
@@ -26,7 +26,6 @@ func easyjsonF642ad3eDecodeGithubComDataDogDatadogAgentPkgSecurityModule(in *jle
 		in.Skip()
 		return
 	}
-	out.AgentContext = new(AgentContext)
 	in.Delim('{')
 	for !in.IsDelim('}') {
 		key := in.UnsafeFieldName(false)
@@ -38,15 +37,7 @@ func easyjsonF642ad3eDecodeGithubComDataDogDatadogAgentPkgSecurityModule(in *jle
 		}
 		switch key {
 		case "agent":
-			if in.IsNull() {
-				in.Skip()
-				out.AgentContext = nil
-			} else {
-				if out.AgentContext == nil {
-					out.AgentContext = new(AgentContext)
-				}
-				(*out.AgentContext).UnmarshalEasyJSON(in)
-			}
+			(out.AgentContext).UnmarshalEasyJSON(in)
 		case "title":
 			out.Title = string(in.String())
 		default:
@@ -66,11 +57,7 @@ func easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgSecurityModule(out *jw
 	{
 		const prefix string = ",\"agent\":"
 		out.RawString(prefix[1:])
-		if in.AgentContext == nil {
-			out.RawString("null")
-		} else {
-			(*in.AgentContext).MarshalEasyJSON(out)
-		}
+		(in.AgentContext).MarshalEasyJSON(out)
 	}
 	{
 		const prefix string = ",\"title\":"
@@ -80,23 +67,9 @@ func easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgSecurityModule(out *jw
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v Signal) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgSecurityModule(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v Signal) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgSecurityModule(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *Signal) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonF642ad3eDecodeGithubComDataDogDatadogAgentPkgSecurityModule(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -174,23 +147,9 @@ func easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgSecurityModule1(out *j
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v AgentContext) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgSecurityModule1(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v AgentContext) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonF642ad3eEncodeGithubComDataDogDatadogAgentPkgSecurityModule1(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *AgentContext) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonF642ad3eDecodeGithubComDataDogDatadogAgentPkgSecurityModule1(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface

--- a/pkg/security/module/server.go
+++ b/pkg/security/module/server.go
@@ -9,13 +9,14 @@ package module
 
 import (
 	"context"
-	"encoding/json"
+	json "encoding/json"
 	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-go/statsd"
+	easyjson "github.com/mailru/easyjson"
 	"github.com/pkg/errors"
 	"golang.org/x/time/rate"
 
@@ -235,7 +236,7 @@ func (a *APIServer) RunSelfTest(ctx context.Context, params *api.RunSelfTestPara
 
 // SendEvent forwards events sent by the runtime security module to Datadog
 func (a *APIServer) SendEvent(rule *rules.Rule, event Event, extTagsCb func() []string, service string) {
-	agentContext := &AgentContext{
+	agentContext := AgentContext{
 		RuleID:      rule.Definition.ID,
 		RuleVersion: rule.Definition.Version,
 		Version:     version.AgentVersion,
@@ -247,8 +248,8 @@ func (a *APIServer) SendEvent(rule *rules.Rule, event Event, extTagsCb func() []
 	}
 
 	if policy := rule.Definition.Policy; policy != nil {
-		agentContext.PolicyName = policy.Name
-		agentContext.PolicyVersion = policy.Version
+		ruleEvent.AgentContext.PolicyName = policy.Name
+		ruleEvent.AgentContext.PolicyVersion = policy.Version
 	}
 
 	probeJSON, err := json.Marshal(event)
@@ -257,7 +258,7 @@ func (a *APIServer) SendEvent(rule *rules.Rule, event Event, extTagsCb func() []
 		return
 	}
 
-	ruleEventJSON, err := json.Marshal(ruleEvent)
+	ruleEventJSON, err := easyjson.Marshal(ruleEvent)
 	if err != nil {
 		log.Error(errors.Wrap(err, "failed to marshal event context"))
 		return

--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -265,12 +265,12 @@ func NewRuleSetLoadedEvent(rs *rules.RuleSet, err *multierror.Error) (*rules.Rul
 // NoisyProcessEvent is used to report that a noisy process was temporarily discarded
 // easyjson:json
 type NoisyProcessEvent struct {
-	Timestamp      time.Time                 `json:"date"`
-	Count          uint64                    `json:"pid_count"`
-	Threshold      int64                     `json:"threshold"`
-	ControlPeriod  time.Duration             `json:"control_period"`
-	DiscardedUntil time.Time                 `json:"discarded_until"`
-	Process        *ProcessContextSerializer `json:"process"`
+	Timestamp      time.Time                `json:"date"`
+	Count          uint64                   `json:"pid_count"`
+	Threshold      int64                    `json:"threshold"`
+	ControlPeriod  time.Duration            `json:"control_period"`
+	DiscardedUntil time.Time                `json:"discarded_until"`
+	Process        ProcessContextSerializer `json:"process"`
 }
 
 // NewNoisyProcessEvent returns the rule and a populated custom event for a noisy_process event
@@ -291,7 +291,7 @@ func NewNoisyProcessEvent(count uint64,
 			Threshold:      threshold,
 			ControlPeriod:  controlPeriod,
 			DiscardedUntil: discardedUntil,
-			Process:        &processSerializer,
+			Process:        processSerializer,
 		}.MarshalJSON)
 }
 

--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -1,4 +1,4 @@
-//go:generate go run github.com/mailru/easyjson/easyjson -build_tags linux $GOFILE
+//go:generate go run github.com/mailru/easyjson/easyjson -no_std_marshalers -build_tags linux $GOFILE
 
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.

--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -281,6 +281,8 @@ func NewNoisyProcessEvent(count uint64,
 	process *model.ProcessCacheEntry,
 	resolvers *Resolvers,
 	timestamp time.Time) (*rules.Rule, *CustomEvent) {
+
+	processSerializer := newProcessContextSerializer(process, nil, resolvers)
 	return newRule(&rules.RuleDefinition{
 			ID: NoisyProcessRuleID,
 		}), newCustomEvent(model.CustomNoisyProcessEventType, NoisyProcessEvent{
@@ -289,7 +291,7 @@ func NewNoisyProcessEvent(count uint64,
 			Threshold:      threshold,
 			ControlPeriod:  controlPeriod,
 			DiscardedUntil: discardedUntil,
-			Process:        newProcessContextSerializer(process, nil, resolvers),
+			Process:        &processSerializer,
 		}.MarshalJSON)
 }
 

--- a/pkg/security/probe/custom_events_easyjson.go
+++ b/pkg/security/probe/custom_events_easyjson.go
@@ -562,15 +562,7 @@ func easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(in *jle
 				in.AddError((out.DiscardedUntil).UnmarshalJSON(data))
 			}
 		case "process":
-			if in.IsNull() {
-				in.Skip()
-				out.Process = nil
-			} else {
-				if out.Process == nil {
-					out.Process = new(ProcessContextSerializer)
-				}
-				(*out.Process).UnmarshalEasyJSON(in)
-			}
+			(out.Process).UnmarshalEasyJSON(in)
 		default:
 			in.SkipRecursive()
 		}
@@ -613,11 +605,7 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(out *jw
 	{
 		const prefix string = ",\"process\":"
 		out.RawString(prefix)
-		if in.Process == nil {
-			out.RawString("null")
-		} else {
-			(*in.Process).MarshalEasyJSON(out)
-		}
+		(in.Process).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/probe/custom_events_easyjson.go
+++ b/pkg/security/probe/custom_events_easyjson.go
@@ -172,23 +172,9 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(out *jwr
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v RulesetLoadedEvent) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v RulesetLoadedEvent) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *RulesetLoadedEvent) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -252,23 +238,9 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(out *jw
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v RuleLoaded) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v RuleLoaded) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *RuleLoaded) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -339,23 +311,9 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(out *jw
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v RuleIgnored) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v RuleIgnored) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *RuleIgnored) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -505,23 +463,9 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(out *jw
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v PolicyLoaded) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v PolicyLoaded) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *PolicyLoaded) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -610,23 +554,9 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(out *jw
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v NoisyProcessEvent) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v NoisyProcessEvent) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *NoisyProcessEvent) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -722,23 +652,9 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe5(out *jw
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v EventLostWrite) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe5(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v EventLostWrite) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe5(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *EventLostWrite) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe5(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -804,23 +720,9 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe6(out *jw
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v EventLostRead) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe6(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v EventLostRead) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe6(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *EventLostRead) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe6(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -898,23 +800,9 @@ func easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe7(out *jw
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v AbnormalPathEvent) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe7(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v AbnormalPathEvent) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonF8f9ddd1EncodeGithubComDataDogDatadogAgentPkgSecurityProbe7(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *AbnormalPathEvent) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonF8f9ddd1DecodeGithubComDataDogDatadogAgentPkgSecurityProbe7(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -8,7 +8,6 @@
 package probe
 
 import (
-	"encoding/json"
 	"path"
 	"strings"
 	"syscall"
@@ -17,7 +16,7 @@ import (
 	pconfig "github.com/DataDog/datadog-agent/pkg/process/config"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
-	"github.com/mailru/easyjson"
+	"github.com/mailru/easyjson/jwriter"
 )
 
 const (
@@ -391,7 +390,7 @@ func (ev *Event) ResolveSELinuxBoolName(e *model.SELinuxEvent) string {
 }
 
 func (ev *Event) String() string {
-	d, err := json.Marshal(ev)
+	d, err := ev.MarshalJSON()
 	if err != nil {
 		return err.Error()
 	}
@@ -406,7 +405,11 @@ func (ev *Event) SetPathResolutionError(err error) {
 // MarshalJSON returns the JSON encoding of the event
 func (ev *Event) MarshalJSON() ([]byte, error) {
 	s := NewEventSerializer(ev)
-	return easyjson.Marshal(s)
+	w := &jwriter.Writer{
+		Flags: jwriter.NilSliceAsEmpty | jwriter.NilMapAsEmpty,
+	}
+	s.MarshalEasyJSON(w)
+	return w.BuildBytes()
 }
 
 // ExtractEventInfo extracts cpu and timestamp from the raw data event

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -17,6 +17,7 @@ import (
 	pconfig "github.com/DataDog/datadog-agent/pkg/process/config"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
+	"github.com/mailru/easyjson"
 )
 
 const (
@@ -405,7 +406,7 @@ func (ev *Event) SetPathResolutionError(err error) {
 // MarshalJSON returns the JSON encoding of the event
 func (ev *Event) MarshalJSON() ([]byte, error) {
 	s := NewEventSerializer(ev)
-	return json.Marshal(s)
+	return easyjson.Marshal(s)
 }
 
 // ExtractEventInfo extracts cpu and timestamp from the raw data event

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -1,4 +1,4 @@
-//go:generate go run github.com/mailru/easyjson/easyjson -build_tags linux $GOFILE
+//go:generate go run github.com/mailru/easyjson/easyjson -no_std_marshalers -build_tags linux $GOFILE
 //go:generate go run github.com/DataDog/datadog-agent/pkg/security/probe/doc_generator -output ../../../docs/cloud-workload-security/backend.schema.json
 
 // Unless explicitly stated otherwise all files in this repository are licensed

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -11,7 +11,6 @@
 package probe
 
 import (
-	"encoding/json"
 	"syscall"
 	"time"
 
@@ -59,20 +58,20 @@ type UserContextSerializer struct {
 // CredentialsSerializer serializes a set credentials to JSON
 // easyjson:json
 type CredentialsSerializer struct {
-	UID          int          `json:"uid" jsonschema_description:"User ID"`
-	User         string       `json:"user,omitempty" jsonschema_description:"User name"`
-	GID          int          `json:"gid" jsonschema_description:"Group ID"`
-	Group        string       `json:"group,omitempty" jsonschema_description:"Group name"`
-	EUID         int          `json:"euid" jsonschema_description:"Effective User ID"`
-	EUser        string       `json:"euser,omitempty" jsonschema_description:"Effective User name"`
-	EGID         int          `json:"egid" jsonschema_description:"Effective Group ID"`
-	EGroup       string       `json:"egroup,omitempty" jsonschema_description:"Effective Group name"`
-	FSUID        int          `json:"fsuid" jsonschema_description:"Filesystem User ID"`
-	FSUser       string       `json:"fsuser,omitempty" jsonschema_description:"Filesystem User name"`
-	FSGID        int          `json:"fsgid" jsonschema_description:"Filesystem Group ID"`
-	FSGroup      string       `json:"fsgroup,omitempty" jsonschema_description:"Filesystem Group name"`
-	CapEffective JStringArray `json:"cap_effective" jsonschema_description:"Effective Capacity set"`
-	CapPermitted JStringArray `json:"cap_permitted" jsonschema_description:"Permitted Capacity set"`
+	UID          int      `json:"uid" jsonschema_description:"User ID"`
+	User         string   `json:"user,omitempty" jsonschema_description:"User name"`
+	GID          int      `json:"gid" jsonschema_description:"Group ID"`
+	Group        string   `json:"group,omitempty" jsonschema_description:"Group name"`
+	EUID         int      `json:"euid" jsonschema_description:"Effective User ID"`
+	EUser        string   `json:"euser,omitempty" jsonschema_description:"Effective User name"`
+	EGID         int      `json:"egid" jsonschema_description:"Effective Group ID"`
+	EGroup       string   `json:"egroup,omitempty" jsonschema_description:"Effective Group name"`
+	FSUID        int      `json:"fsuid" jsonschema_description:"Filesystem User ID"`
+	FSUser       string   `json:"fsuser,omitempty" jsonschema_description:"Filesystem User name"`
+	FSGID        int      `json:"fsgid" jsonschema_description:"Filesystem Group ID"`
+	FSGroup      string   `json:"fsgroup,omitempty" jsonschema_description:"Filesystem Group name"`
+	CapEffective []string `json:"cap_effective" jsonschema_description:"Effective Capacity set"`
+	CapPermitted []string `json:"cap_permitted" jsonschema_description:"Permitted Capacity set"`
 }
 
 // SetuidSerializer serializes a setuid event
@@ -97,22 +96,11 @@ type SetgidSerializer struct {
 	FSGroup string `json:"fsgroup,omitempty" jsonschema_description:"Filesystem Group name"`
 }
 
-// JStringArray handles empty array properly not generating null output but []
-type JStringArray []string
-
-// MarshalJSON custom marshaller to handle empty array
-func (j *JStringArray) MarshalJSON() ([]byte, error) {
-	if len(*j) == 0 {
-		return []byte("[]"), nil
-	}
-	return json.Marshal([]string(*j))
-}
-
 // CapsetSerializer serializes a capset event
 // easyjson:json
 type CapsetSerializer struct {
-	CapEffective JStringArray `json:"cap_effective" jsonschema_description:"Effective Capacity set"`
-	CapPermitted JStringArray `json:"cap_permitted" jsonschema_description:"Permitted Capacity set"`
+	CapEffective []string `json:"cap_effective" jsonschema_description:"Effective Capacity set"`
+	CapPermitted []string `json:"cap_permitted" jsonschema_description:"Permitted Capacity set"`
 }
 
 // ProcessCredentialsSerializer serializes the process credentials to JSON
@@ -315,8 +303,8 @@ func newCredentialsSerializer(ce *model.Credentials) *CredentialsSerializer {
 		EGroup:       ce.EGroup,
 		FSGID:        int(ce.FSGID),
 		FSGroup:      ce.FSGroup,
-		CapEffective: JStringArray(model.KernelCapability(ce.CapEffective).StringArray()),
-		CapPermitted: JStringArray(model.KernelCapability(ce.CapPermitted).StringArray()),
+		CapEffective: model.KernelCapability(ce.CapEffective).StringArray(),
+		CapPermitted: model.KernelCapability(ce.CapPermitted).StringArray(),
 	}
 }
 
@@ -644,8 +632,8 @@ func NewEventSerializer(event *Event) *EventSerializer {
 		s.Category = ProcessActivity
 	case model.CapsetEventType:
 		s.ProcessContextSerializer.Credentials.Destination = &CapsetSerializer{
-			CapEffective: JStringArray(model.KernelCapability(event.Capset.CapEffective).StringArray()),
-			CapPermitted: JStringArray(model.KernelCapability(event.Capset.CapPermitted).StringArray()),
+			CapEffective: model.KernelCapability(event.Capset.CapEffective).StringArray(),
+			CapPermitted: model.KernelCapability(event.Capset.CapPermitted).StringArray(),
 		}
 		s.EventContextSerializer.Outcome = serializeSyscallRetval(0)
 		s.Category = ProcessActivity

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -204,12 +204,12 @@ type DDContextSerializer struct {
 // EventSerializer serializes an event to JSON
 // easyjson:json
 type EventSerializer struct {
-	*EventContextSerializer    `json:"evt,omitempty"`
+	EventContextSerializer     `json:"evt,omitempty"`
 	*FileEventSerializer       `json:"file,omitempty"`
 	*SELinuxEventSerializer    `json:"selinux,omitempty"`
 	UserContextSerializer      UserContextSerializer       `json:"usr,omitempty"`
-	ProcessContextSerializer   *ProcessContextSerializer   `json:"process,omitempty"`
-	DDContextSerializer        *DDContextSerializer        `json:"dd,omitempty"`
+	ProcessContextSerializer   ProcessContextSerializer    `json:"process,omitempty"`
+	DDContextSerializer        DDContextSerializer         `json:"dd,omitempty"`
 	ContainerContextSerializer *ContainerContextSerializer `json:"container,omitempty"`
 	Date                       time.Time                   `json:"date,omitempty"`
 }
@@ -377,15 +377,15 @@ func newProcessCacheEntrySerializer(pce *model.ProcessCacheEntry, e *Event) *Pro
 	return pceSerializer
 }
 
-func newDDContextSerializer(e *Event) *DDContextSerializer {
-	return &DDContextSerializer{
+func newDDContextSerializer(e *Event) DDContextSerializer {
+	return DDContextSerializer{
 		SpanID:  e.SpanContext.SpanID,
 		TraceID: e.SpanContext.TraceID,
 	}
 }
 
-func newProcessContextSerializer(entry *model.ProcessCacheEntry, e *Event, r *Resolvers) *ProcessContextSerializer {
-	var ps *ProcessContextSerializer
+func newProcessContextSerializer(entry *model.ProcessCacheEntry, e *Event, r *Resolvers) ProcessContextSerializer {
+	var ps ProcessContextSerializer
 
 	if e == nil {
 		// custom events create an empty event
@@ -395,7 +395,7 @@ func newProcessContextSerializer(entry *model.ProcessCacheEntry, e *Event, r *Re
 		}
 	}
 
-	ps = &ProcessContextSerializer{
+	ps = ProcessContextSerializer{
 		ProcessCacheEntrySerializer: newProcessCacheEntrySerializer(entry, e),
 	}
 
@@ -474,7 +474,7 @@ func serializeSyscallRetval(retval int64) string {
 // NewEventSerializer creates a new event serializer based on the event type
 func NewEventSerializer(event *Event) *EventSerializer {
 	s := &EventSerializer{
-		EventContextSerializer: &EventContextSerializer{
+		EventContextSerializer: EventContextSerializer{
 			Name:     model.EventType(event.Type).String(),
 			Category: FIMCategory,
 		},

--- a/pkg/security/probe/serializers_easyjson.go
+++ b/pkg/security/probe/serializers_easyjson.go
@@ -64,23 +64,9 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(out *jwr
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v selinuxEnforceStatusSerializer) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v selinuxEnforceStatusSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *selinuxEnforceStatusSerializer) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -131,23 +117,9 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(out *jw
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v selinuxBoolCommitSerializer) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v selinuxBoolCommitSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe1(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *selinuxBoolCommitSerializer) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe1(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -210,23 +182,9 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(out *jw
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v selinuxBoolChangeSerializer) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v selinuxBoolChangeSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe2(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *selinuxBoolChangeSerializer) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe2(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -289,23 +247,9 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(out *jw
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v UserContextSerializer) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v UserContextSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe3(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *UserContextSerializer) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe3(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -390,23 +334,9 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(out *jw
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v SetuidSerializer) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v SetuidSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe4(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *SetuidSerializer) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe4(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -491,23 +421,9 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe5(out *jw
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v SetgidSerializer) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe5(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v SetgidSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe5(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *SetgidSerializer) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe5(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -606,23 +522,9 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe6(out *jw
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v SELinuxEventSerializer) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe6(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v SELinuxEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe6(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *SELinuxEventSerializer) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe6(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -853,23 +755,9 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe7(out *jw
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v ProcessCredentialsSerializer) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe7(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ProcessCredentialsSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe7(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *ProcessCredentialsSerializer) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe7(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -1257,23 +1145,9 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe8(out *jw
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v ProcessContextSerializer) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe8(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ProcessContextSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe8(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *ProcessContextSerializer) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe8(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -1586,23 +1460,9 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe9(out *jw
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v ProcessCacheEntrySerializer) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe9(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ProcessCacheEntrySerializer) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe9(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *ProcessCacheEntrySerializer) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe9(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -1904,23 +1764,9 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe10(out *j
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v FileSerializer) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe10(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v FileSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe10(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *FileSerializer) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe10(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -2290,23 +2136,9 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe11(out *j
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v FileEventSerializer) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe11(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v FileEventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe11(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *FileEventSerializer) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe11(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -2469,23 +2301,9 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe12(out *j
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v EventSerializer) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe12(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v EventSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe12(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *EventSerializer) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe12(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -2560,23 +2378,9 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe13(out *j
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v EventContextSerializer) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe13(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v EventContextSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe13(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *EventContextSerializer) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe13(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -2639,23 +2443,9 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe14(out *j
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v DDContextSerializer) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe14(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v DDContextSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe14(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *DDContextSerializer) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe14(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -2860,23 +2650,9 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe15(out *j
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v CredentialsSerializer) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe15(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CredentialsSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe15(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *CredentialsSerializer) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe15(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -2927,23 +2703,9 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe16(out *j
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v ContainerContextSerializer) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe16(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v ContainerContextSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe16(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *ContainerContextSerializer) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe16(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface
@@ -3064,23 +2826,9 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe17(out *j
 	out.RawByte('}')
 }
 
-// MarshalJSON supports json.Marshaler interface
-func (v CapsetSerializer) MarshalJSON() ([]byte, error) {
-	w := jwriter.Writer{}
-	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe17(&w, v)
-	return w.Buffer.BuildBytes(), w.Error
-}
-
 // MarshalEasyJSON supports easyjson.Marshaler interface
 func (v CapsetSerializer) MarshalEasyJSON(w *jwriter.Writer) {
 	easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe17(w, v)
-}
-
-// UnmarshalJSON supports json.Unmarshaler interface
-func (v *CapsetSerializer) UnmarshalJSON(data []byte) error {
-	r := jlexer.Lexer{Data: data}
-	easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe17(&r, v)
-	return r.Error()
 }
 
 // UnmarshalEasyJSON supports easyjson.Unmarshaler interface

--- a/pkg/security/probe/serializers_easyjson.go
+++ b/pkg/security/probe/serializers_easyjson.go
@@ -689,9 +689,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe7(in *jle
 				in.Delim('[')
 				if out.CapEffective == nil {
 					if !in.IsDelim(']') {
-						out.CapEffective = make(JStringArray, 0, 4)
+						out.CapEffective = make([]string, 0, 4)
 					} else {
-						out.CapEffective = JStringArray{}
+						out.CapEffective = []string{}
 					}
 				} else {
 					out.CapEffective = (out.CapEffective)[:0]
@@ -712,9 +712,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe7(in *jle
 				in.Delim('[')
 				if out.CapPermitted == nil {
 					if !in.IsDelim(']') {
-						out.CapPermitted = make(JStringArray, 0, 4)
+						out.CapPermitted = make([]string, 0, 4)
 					} else {
-						out.CapPermitted = JStringArray{}
+						out.CapPermitted = []string{}
 					}
 				} else {
 					out.CapPermitted = (out.CapPermitted)[:0]
@@ -821,12 +821,34 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe7(out *jw
 	{
 		const prefix string = ",\"cap_effective\":"
 		out.RawString(prefix)
-		out.Raw((in.CapEffective).MarshalJSON())
+		if in.CapEffective == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v3, v4 := range in.CapEffective {
+				if v3 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v4))
+			}
+			out.RawByte(']')
+		}
 	}
 	{
 		const prefix string = ",\"cap_permitted\":"
 		out.RawString(prefix)
-		out.Raw((in.CapPermitted).MarshalJSON())
+		if in.CapPermitted == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v5, v6 := range in.CapPermitted {
+				if v5 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v6))
+			}
+			out.RawByte(']')
+		}
 	}
 	out.RawByte('}')
 }
@@ -900,17 +922,17 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe8(in *jle
 					out.Ancestors = (out.Ancestors)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v3 *ProcessCacheEntrySerializer
+					var v7 *ProcessCacheEntrySerializer
 					if in.IsNull() {
 						in.Skip()
-						v3 = nil
+						v7 = nil
 					} else {
-						if v3 == nil {
-							v3 = new(ProcessCacheEntrySerializer)
+						if v7 == nil {
+							v7 = new(ProcessCacheEntrySerializer)
 						}
-						(*v3).UnmarshalEasyJSON(in)
+						(*v7).UnmarshalEasyJSON(in)
 					}
-					out.Ancestors = append(out.Ancestors, v3)
+					out.Ancestors = append(out.Ancestors, v7)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1017,9 +1039,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe8(in *jle
 					out.Args = (out.Args)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v4 string
-					v4 = string(in.String())
-					out.Args = append(out.Args, v4)
+					var v8 string
+					v8 = string(in.String())
+					out.Args = append(out.Args, v8)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1042,9 +1064,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe8(in *jle
 					out.Envs = (out.Envs)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v5 string
-					v5 = string(in.String())
-					out.Envs = append(out.Envs, v5)
+					var v9 string
+					v9 = string(in.String())
+					out.Envs = append(out.Envs, v9)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1081,14 +1103,14 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe8(out *jw
 		}
 		{
 			out.RawByte('[')
-			for v6, v7 := range in.Ancestors {
-				if v6 > 0 {
+			for v10, v11 := range in.Ancestors {
+				if v10 > 0 {
 					out.RawByte(',')
 				}
-				if v7 == nil {
+				if v11 == nil {
 					out.RawString("null")
 				} else {
-					(*v7).MarshalEasyJSON(out)
+					(*v11).MarshalEasyJSON(out)
 				}
 			}
 			out.RawByte(']')
@@ -1199,11 +1221,11 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe8(out *jw
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v8, v9 := range in.Args {
-				if v8 > 0 {
+			for v12, v13 := range in.Args {
+				if v12 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v9))
+				out.String(string(v13))
 			}
 			out.RawByte(']')
 		}
@@ -1218,11 +1240,11 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe8(out *jw
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v10, v11 := range in.Envs {
-				if v10 > 0 {
+			for v14, v15 := range in.Envs {
+				if v14 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v11))
+				out.String(string(v15))
 			}
 			out.RawByte(']')
 		}
@@ -1379,9 +1401,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe9(in *jle
 					out.Args = (out.Args)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v12 string
-					v12 = string(in.String())
-					out.Args = append(out.Args, v12)
+					var v16 string
+					v16 = string(in.String())
+					out.Args = append(out.Args, v16)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1404,9 +1426,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe9(in *jle
 					out.Envs = (out.Envs)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v13 string
-					v13 = string(in.String())
-					out.Envs = append(out.Envs, v13)
+					var v17 string
+					v17 = string(in.String())
+					out.Envs = append(out.Envs, v17)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1528,11 +1550,11 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe9(out *jw
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v14, v15 := range in.Args {
-				if v14 > 0 {
+			for v18, v19 := range in.Args {
+				if v18 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v15))
+				out.String(string(v19))
 			}
 			out.RawByte(']')
 		}
@@ -1547,11 +1569,11 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe9(out *jw
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v16, v17 := range in.Envs {
-				if v16 > 0 {
+			for v20, v21 := range in.Envs {
+				if v20 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v17))
+				out.String(string(v21))
 			}
 			out.RawByte(']')
 		}
@@ -1682,9 +1704,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe10(in *jl
 					out.Flags = (out.Flags)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v18 string
-					v18 = string(in.String())
-					out.Flags = append(out.Flags, v18)
+					var v22 string
+					v22 = string(in.String())
+					out.Flags = append(out.Flags, v22)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -1855,11 +1877,11 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe10(out *j
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v19, v20 := range in.Flags {
-				if v19 > 0 {
+			for v23, v24 := range in.Flags {
+				if v23 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v20))
+				out.String(string(v24))
 			}
 			out.RawByte(']')
 		}
@@ -2018,9 +2040,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe11(in *jl
 					out.Flags = (out.Flags)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v21 string
-					v21 = string(in.String())
-					out.Flags = append(out.Flags, v21)
+					var v25 string
+					v25 = string(in.String())
+					out.Flags = append(out.Flags, v25)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2241,11 +2263,11 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe11(out *j
 		out.RawString(prefix)
 		{
 			out.RawByte('[')
-			for v22, v23 := range in.Flags {
-				if v22 > 0 {
+			for v26, v27 := range in.Flags {
+				if v26 > 0 {
 					out.RawByte(',')
 				}
-				out.String(string(v23))
+				out.String(string(v27))
 			}
 			out.RawByte(']')
 		}
@@ -2716,17 +2738,17 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe15(in *jl
 				in.Delim('[')
 				if out.CapEffective == nil {
 					if !in.IsDelim(']') {
-						out.CapEffective = make(JStringArray, 0, 4)
+						out.CapEffective = make([]string, 0, 4)
 					} else {
-						out.CapEffective = JStringArray{}
+						out.CapEffective = []string{}
 					}
 				} else {
 					out.CapEffective = (out.CapEffective)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v24 string
-					v24 = string(in.String())
-					out.CapEffective = append(out.CapEffective, v24)
+					var v28 string
+					v28 = string(in.String())
+					out.CapEffective = append(out.CapEffective, v28)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2739,17 +2761,17 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe15(in *jl
 				in.Delim('[')
 				if out.CapPermitted == nil {
 					if !in.IsDelim(']') {
-						out.CapPermitted = make(JStringArray, 0, 4)
+						out.CapPermitted = make([]string, 0, 4)
 					} else {
-						out.CapPermitted = JStringArray{}
+						out.CapPermitted = []string{}
 					}
 				} else {
 					out.CapPermitted = (out.CapPermitted)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v25 string
-					v25 = string(in.String())
-					out.CapPermitted = append(out.CapPermitted, v25)
+					var v29 string
+					v29 = string(in.String())
+					out.CapPermitted = append(out.CapPermitted, v29)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2831,12 +2853,34 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe15(out *j
 	{
 		const prefix string = ",\"cap_effective\":"
 		out.RawString(prefix)
-		out.Raw((in.CapEffective).MarshalJSON())
+		if in.CapEffective == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v30, v31 := range in.CapEffective {
+				if v30 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v31))
+			}
+			out.RawByte(']')
+		}
 	}
 	{
 		const prefix string = ",\"cap_permitted\":"
 		out.RawString(prefix)
-		out.Raw((in.CapPermitted).MarshalJSON())
+		if in.CapPermitted == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v32, v33 := range in.CapPermitted {
+				if v32 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v33))
+			}
+			out.RawByte(']')
+		}
 	}
 	out.RawByte('}')
 }
@@ -2958,17 +3002,17 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe17(in *jl
 				in.Delim('[')
 				if out.CapEffective == nil {
 					if !in.IsDelim(']') {
-						out.CapEffective = make(JStringArray, 0, 4)
+						out.CapEffective = make([]string, 0, 4)
 					} else {
-						out.CapEffective = JStringArray{}
+						out.CapEffective = []string{}
 					}
 				} else {
 					out.CapEffective = (out.CapEffective)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v26 string
-					v26 = string(in.String())
-					out.CapEffective = append(out.CapEffective, v26)
+					var v34 string
+					v34 = string(in.String())
+					out.CapEffective = append(out.CapEffective, v34)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -2981,17 +3025,17 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe17(in *jl
 				in.Delim('[')
 				if out.CapPermitted == nil {
 					if !in.IsDelim(']') {
-						out.CapPermitted = make(JStringArray, 0, 4)
+						out.CapPermitted = make([]string, 0, 4)
 					} else {
-						out.CapPermitted = JStringArray{}
+						out.CapPermitted = []string{}
 					}
 				} else {
 					out.CapPermitted = (out.CapPermitted)[:0]
 				}
 				for !in.IsDelim(']') {
-					var v27 string
-					v27 = string(in.String())
-					out.CapPermitted = append(out.CapPermitted, v27)
+					var v35 string
+					v35 = string(in.String())
+					out.CapPermitted = append(out.CapPermitted, v35)
 					in.WantComma()
 				}
 				in.Delim(']')
@@ -3013,12 +3057,34 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe17(out *j
 	{
 		const prefix string = ",\"cap_effective\":"
 		out.RawString(prefix[1:])
-		out.Raw((in.CapEffective).MarshalJSON())
+		if in.CapEffective == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v36, v37 := range in.CapEffective {
+				if v36 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v37))
+			}
+			out.RawByte(']')
+		}
 	}
 	{
 		const prefix string = ",\"cap_permitted\":"
 		out.RawString(prefix)
-		out.Raw((in.CapPermitted).MarshalJSON())
+		if in.CapPermitted == nil && (out.Flags&jwriter.NilSliceAsEmpty) == 0 {
+			out.RawString("null")
+		} else {
+			out.RawByte('[')
+			for v38, v39 := range in.CapPermitted {
+				if v38 > 0 {
+					out.RawByte(',')
+				}
+				out.String(string(v39))
+			}
+			out.RawByte(']')
+		}
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/probe/serializers_easyjson.go
+++ b/pkg/security/probe/serializers_easyjson.go
@@ -2322,7 +2322,6 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe12(in *jl
 		in.Skip()
 		return
 	}
-	out.EventContextSerializer = new(EventContextSerializer)
 	out.FileEventSerializer = new(FileEventSerializer)
 	out.SELinuxEventSerializer = new(SELinuxEventSerializer)
 	in.Delim('{')
@@ -2336,15 +2335,7 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe12(in *jl
 		}
 		switch key {
 		case "evt":
-			if in.IsNull() {
-				in.Skip()
-				out.EventContextSerializer = nil
-			} else {
-				if out.EventContextSerializer == nil {
-					out.EventContextSerializer = new(EventContextSerializer)
-				}
-				(*out.EventContextSerializer).UnmarshalEasyJSON(in)
-			}
+			(out.EventContextSerializer).UnmarshalEasyJSON(in)
 		case "file":
 			if in.IsNull() {
 				in.Skip()
@@ -2368,25 +2359,9 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe12(in *jl
 		case "usr":
 			(out.UserContextSerializer).UnmarshalEasyJSON(in)
 		case "process":
-			if in.IsNull() {
-				in.Skip()
-				out.ProcessContextSerializer = nil
-			} else {
-				if out.ProcessContextSerializer == nil {
-					out.ProcessContextSerializer = new(ProcessContextSerializer)
-				}
-				(*out.ProcessContextSerializer).UnmarshalEasyJSON(in)
-			}
+			(out.ProcessContextSerializer).UnmarshalEasyJSON(in)
 		case "dd":
-			if in.IsNull() {
-				in.Skip()
-				out.DDContextSerializer = nil
-			} else {
-				if out.DDContextSerializer == nil {
-					out.DDContextSerializer = new(DDContextSerializer)
-				}
-				(*out.DDContextSerializer).UnmarshalEasyJSON(in)
-			}
+			(out.DDContextSerializer).UnmarshalEasyJSON(in)
 		case "container":
 			if in.IsNull() {
 				in.Skip()
@@ -2415,11 +2390,11 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe12(out *j
 	out.RawByte('{')
 	first := true
 	_ = first
-	if in.EventContextSerializer != nil {
+	if true {
 		const prefix string = ",\"evt\":"
 		first = false
 		out.RawString(prefix[1:])
-		(*in.EventContextSerializer).MarshalEasyJSON(out)
+		(in.EventContextSerializer).MarshalEasyJSON(out)
 	}
 	if in.FileEventSerializer != nil {
 		const prefix string = ",\"file\":"
@@ -2451,7 +2426,7 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe12(out *j
 		}
 		(in.UserContextSerializer).MarshalEasyJSON(out)
 	}
-	if in.ProcessContextSerializer != nil {
+	if true {
 		const prefix string = ",\"process\":"
 		if first {
 			first = false
@@ -2459,9 +2434,9 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe12(out *j
 		} else {
 			out.RawString(prefix)
 		}
-		(*in.ProcessContextSerializer).MarshalEasyJSON(out)
+		(in.ProcessContextSerializer).MarshalEasyJSON(out)
 	}
-	if in.DDContextSerializer != nil {
+	if true {
 		const prefix string = ",\"dd\":"
 		if first {
 			first = false
@@ -2469,7 +2444,7 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe12(out *j
 		} else {
 			out.RawString(prefix)
 		}
-		(*in.DDContextSerializer).MarshalEasyJSON(out)
+		(in.DDContextSerializer).MarshalEasyJSON(out)
 	}
 	if in.ContainerContextSerializer != nil {
 		const prefix string = ",\"container\":"

--- a/pkg/security/tests/serializers_test.go
+++ b/pkg/security/tests/serializers_test.go
@@ -1,0 +1,62 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build functionaltests
+
+package tests
+
+import (
+	"syscall"
+	"testing"
+
+	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"github.com/stretchr/testify/assert"
+)
+
+func BenchmarkSerializers(b *testing.B) {
+	// Let's first fetch a realistic event
+
+	rule := &rules.RuleDefinition{
+		ID:         "test_rule",
+		Expression: `open.file.path == "{{.Root}}/test-open" && open.flags & O_CREAT != 0`,
+	}
+
+	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule}, testOpts{})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer test.Close()
+
+	_, testFilePtr, err := test.Path("test-open")
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	var workingEvent *sprobe.Event
+	err = test.WaitSignal(b, func() error {
+		fd, _, errno := syscall.Syscall6(syscall.SYS_OPENAT, 0, uintptr(testFilePtr), syscall.O_CREAT, 0711, 0, 0)
+		if errno != 0 {
+			b.Fatal(errno)
+		}
+		return syscall.Close(int(fd))
+	}, func(event *sprobe.Event, r *rules.Rule) {
+		assert.Equal(b, "open", event.GetType(), "wrong event type")
+		workingEvent = event
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// then we run the benchmark
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		_, err := workingEvent.MarshalJSON()
+		if err != nil {
+			b.Error(err)
+		}
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This PR tries to:
- remove usage of `encoding/json` especially `json.Marshal` as this uses reflection (only on the first level on the best case)
- remove some pointer indirections that are not justified

### Motivation

Improve event serializers performance

### Describe how to test your changes

This should not change the event JSON result. The schema tests should ensure this.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
