### PR TITLE
[AD] Fix assignment to entry in nil map

### DIFF
--- a/pkg/autodiscovery/providers/kubelet.go
+++ b/pkg/autodiscovery/providers/kubelet.go
@@ -40,6 +40,7 @@ func NewKubeletConfigProvider(config config.ConfigurationProviders) (ConfigProvi
 	return &KubeletConfigProvider{
 		workloadmetaStore: workloadmeta.GetGlobalStore(),
 		configErrors:      make(map[string]ErrorMsgSet),
+		podCache:          make(map[string]*workloadmeta.KubernetesPod),
 	}, nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Fixes the following panic:

```
panic: assignment to entry in nil map

goroutine 403 [running]:
github.com/DataDog/datadog-agent/pkg/autodiscovery/providers.(*KubeletConfigProvider).addPod(0xc0001facd0, 0x5134cc8, 0xc000cabe00)
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/kubelet.go:108 +0xee
github.com/DataDog/datadog-agent/pkg/autodiscovery/providers.(*KubeletConfigProvider).processEvents(0xc0001facd0, 0xc001280000, 0xd, 0x10, 0xc000c18120)
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/kubelet.go:93 +0x1af
github.com/DataDog/datadog-agent/pkg/autodiscovery/providers.(*KubeletConfigProvider).listen(0xc0001facd0)
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/kubelet.go:80 +0x22b
created by github.com/DataDog/datadog-agent/pkg/autodiscovery/providers.(*KubeletConfigProvider).Collect.func1
        /omnibus/src/datadog-agent/src/github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/kubelet.go:54 +0x3e
```

### Describe how to test your changes

The agent does not go into CrashloopBackoff. E2E tests pass.