### PR TITLE
Hide security-agent compliance event command

### DIFF
--- a/cmd/security-agent/app/compliance.go
+++ b/cmd/security-agent/app/compliance.go
@@ -34,9 +34,10 @@ var (
 	}
 
 	eventCmd = &cobra.Command{
-		Use:   "event",
-		Short: "Issue logs to test Security Agent compliance events",
-		RunE:  eventRun,
+		Use:    "event",
+		Short:  "Issue logs to test Security Agent compliance events",
+		RunE:   eventRun,
+		Hidden: true,
 	}
 
 	eventArgs = struct {


### PR DESCRIPTION
### What does this PR do?

Hide test `security-agent compliance event`testing command

### Motivation

This command should only be used for debugging purposes