### PR TITLE
Adding oracle cloud support

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -190,7 +190,7 @@ func InitConfig(config Config) {
 	config.BindEnv("site")
 	config.BindEnv("dd_url")
 	config.BindEnvAndSetDefault("app_key", "")
-	config.BindEnvAndSetDefault("cloud_provider_metadata", []string{"aws", "gcp", "azure", "alibaba"})
+	config.BindEnvAndSetDefault("cloud_provider_metadata", []string{"aws", "gcp", "azure", "alibaba", "oracle"})
 	config.SetDefault("proxy", nil)
 	config.BindEnvAndSetDefault("skip_ssl_validation", false)
 	config.BindEnvAndSetDefault("sslkeylogfile", "")

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -289,8 +289,8 @@ api_key:
 #
 # forwarder_requeue_buffer_size: 100
 
-## @param cloud_provider_metadata - list of strings -  optional - default: ["aws", "gcp", "azure", "alibaba"]
-## @env DD_CLOUD_PROVIDER_METADATA - space separated list of strings - optional - default: aws gcp azure alibaba
+## @param cloud_provider_metadata - list of strings -  optional - default: ["aws", "gcp", "azure", "alibaba", "oracle"]
+## @env DD_CLOUD_PROVIDER_METADATA - space separated list of strings - optional - default: aws gcp azure alibaba oracle
 ## This option restricts which cloud provider endpoint will be used by the
 ## agent to retrieve metadata. By default the agent will try # AWS, GCP, Azure
 ## and alibaba providers. Some cloud provider are not enabled by default to not
@@ -306,12 +306,14 @@ api_key:
 ## "azure"   Azure
 ## "alibaba" Alibaba
 ## "tencent" Tencent
+## "oracle"  Oracle Cloud
 #
 # cloud_provider_metadata:
 #   - "aws"
 #   - "gcp"
 #   - "azure"
 #   - "alibaba"
+#   - "oracle"
 
 ## @param collect_ec2_tags - boolean - optional - default: false
 ## @env DD_COLLECT_EC2_TAGS - boolean - optional - default: false

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -69,7 +69,7 @@ func TestDefaults(t *testing.T) {
 	assert.False(t, config.IsSet("dd_url"))
 	assert.Equal(t, "", config.GetString("site"))
 	assert.Equal(t, "", config.GetString("dd_url"))
-	assert.Equal(t, []string{"aws", "gcp", "azure", "alibaba"}, config.GetStringSlice("cloud_provider_metadata"))
+	assert.Equal(t, []string{"aws", "gcp", "azure", "alibaba", "oracle"}, config.GetStringSlice("cloud_provider_metadata"))
 
 	// Testing process-agent defaults
 	assert.Equal(t, map[string]interface{}{

--- a/pkg/util/cloudproviders/cloudproviders.go
+++ b/pkg/util/cloudproviders/cloudproviders.go
@@ -22,6 +22,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/azure"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/cloudfoundry"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/gce"
+	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/oracle"
 	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders/tencent"
 )
 
@@ -39,6 +40,7 @@ func DetectCloudProvider(ctx context.Context) {
 		{name: azure.CloudProviderName, callback: azure.IsRunningOn},
 		{name: alibaba.CloudProviderName, callback: alibaba.IsRunningOn},
 		{name: tencent.CloudProviderName, callback: tencent.IsRunningOn},
+		{name: oracle.CloudProviderName, callback: oracle.IsRunningOn},
 	}
 
 	for _, cloudDetector := range detectors {
@@ -65,6 +67,7 @@ func GetCloudProviderNTPHosts(ctx context.Context) []string {
 		{name: azure.CloudProviderName, callback: azure.GetNTPHosts},
 		{name: alibaba.CloudProviderName, callback: alibaba.GetNTPHosts},
 		{name: tencent.CloudProviderName, callback: tencent.GetNTPHosts},
+		{name: oracle.CloudProviderName, callback: oracle.GetNTPHosts},
 	}
 
 	for _, cloudNTPDetector := range detectors {
@@ -93,6 +96,7 @@ func GetHostAliases(ctx context.Context) []string {
 		{name: cloudfoundry.CloudProviderName, callback: cloudfoundry.GetHostAliases},
 		{name: "kubelet", callback: kubelet.GetHostAliases},
 		{name: tencent.CloudProviderName, callback: tencent.GetHostAliases},
+		{name: oracle.CloudProviderName, callback: oracle.GetHostAliases},
 	}
 
 	for _, cloudAliasesDetector := range detectors {

--- a/pkg/util/cloudproviders/oracle/diagnosis.go
+++ b/pkg/util/cloudproviders/oracle/diagnosis.go
@@ -1,0 +1,22 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package oracle
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/pkg/diagnose/diagnosis"
+)
+
+func init() {
+	diagnosis.Register("OracleCloud Metadata availability", diagnose)
+}
+
+// diagnose the oraclecloud metadata API availability
+func diagnose() error {
+	_, err := GetHostAliases(context.TODO())
+	return err
+}

--- a/pkg/util/cloudproviders/oracle/oracle.go
+++ b/pkg/util/cloudproviders/oracle/oracle.go
@@ -1,0 +1,73 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package oracle
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/cachedfetch"
+	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
+)
+
+// declare these as vars not const to ease testing
+var (
+	metadataURL = "http://169.254.169.254"
+	timeout     = 300 * time.Millisecond
+
+	// CloudProviderName contains the inventory name of for EC2
+	CloudProviderName = "Oracle"
+)
+
+// IsRunningOn returns true if the agent is running on Oracle
+func IsRunningOn(ctx context.Context) bool {
+	if _, err := GetHostAliases(ctx); err == nil {
+		return true
+	}
+	return false
+}
+
+var instanceIDFetcher = cachedfetch.Fetcher{
+	Name: "Oracle InstanceID",
+	Attempt: func(ctx context.Context) (interface{}, error) {
+		if !config.IsCloudProviderEnabled(CloudProviderName) {
+			return "", fmt.Errorf("Oracle cloud provider is disabled by configuration")
+		}
+
+		endpoint := metadataURL + "/opc/v2/instance/id"
+		res, err := httputils.Get(ctx, endpoint, map[string]string{"Authorization": "Bearer Oracle"}, timeout)
+		if err != nil {
+			return nil, fmt.Errorf("Oracle HostAliases: unable to query metadata endpoint: %s", err)
+		}
+
+		if res == "" {
+			return nil, fmt.Errorf("Oracle '%s' returned empty id", endpoint)
+		}
+
+		maxLength := config.Datadog.GetInt("metadata_endpoints_max_hostname_size")
+		if len(res) > maxLength {
+			return nil, fmt.Errorf("%v gave a response with length > to %v", endpoint, maxLength)
+		}
+		return []string{res}, nil
+	},
+}
+
+// GetHostAliases returns the VM ID from the Oracle Metadata api
+func GetHostAliases(ctx context.Context) ([]string, error) {
+	return instanceIDFetcher.FetchStringSlice(ctx)
+}
+
+// GetNTPHosts returns the NTP hosts for Oracle if it is detected as the cloud provider, otherwise an nil array.
+// Docs: https://docs.oracle.com/en-us/iaas/Content/Compute/Tasks/configuringntpservice.htm
+func GetNTPHosts(ctx context.Context) []string {
+	if IsRunningOn(ctx) {
+		return []string{"169.254.169.254"}
+	}
+
+	return nil
+}

--- a/pkg/util/cloudproviders/oracle/oracle_test.go
+++ b/pkg/util/cloudproviders/oracle/oracle_test.go
@@ -1,0 +1,65 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package oracle
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetHostAliases(t *testing.T) {
+	holdValue := config.Datadog.Get("cloud_provider_metadata")
+	defer config.Datadog.Set("cloud_provider_metadata", holdValue)
+	config.Datadog.Set("cloud_provider_metadata", []string{"oracle"})
+
+	ctx := context.Background()
+	expected := "ocid1.instance.oc1.iad.anuwcljte6cuweqcz7sarpn43hst2kaaaxbbbccbaaa6vpd66tvcyhgiifsq"
+	var lastRequest *http.Request
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		io.WriteString(w, expected)
+		lastRequest = r
+	}))
+	defer ts.Close()
+
+	defer func(url string) { metadataURL = url }(metadataURL)
+	metadataURL = ts.URL
+
+	aliases, err := GetHostAliases(ctx)
+	assert.Nil(t, err)
+	require.Len(t, aliases, 1)
+	assert.Equal(t, expected, aliases[0])
+	assert.Equal(t, lastRequest.URL.Path, "/opc/v2/instance/id")
+	assert.Equal(t, lastRequest.Header.Get("Authorization"), "Bearer Oracle")
+}
+
+func TestGetNTPHosts(t *testing.T) {
+	holdValue := config.Datadog.Get("cloud_provider_metadata")
+	defer config.Datadog.Set("cloud_provider_metadata", holdValue)
+	config.Datadog.Set("cloud_provider_metadata", []string{"oracle"})
+
+	ctx := context.Background()
+	expectedHosts := []string{"169.254.169.254"}
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		io.WriteString(w, "test")
+	}))
+	defer ts.Close()
+
+	defer func(url string) { metadataURL = url }(metadataURL)
+	metadataURL = ts.URL
+
+	actualHosts := GetNTPHosts(ctx)
+	assert.Equal(t, expectedHosts, actualHosts)
+}

--- a/releasenotes/notes/add-oracle-cloud-12445d3962a5d4b0.yaml
+++ b/releasenotes/notes/add-oracle-cloud-12445d3962a5d4b0.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    Cloud provider detection now support Oracle Cloud. This includes cloud provider detection, host aliases and NTP
+    servers.


### PR DESCRIPTION
### What does this PR do?

Cloud provider detection now support Oracle Cloud. This includes cloud provider detection, host aliases and NTP servers.

### Describe how to test your changes

Install the Agent on an Oracle cloud VM and check host aliases.

status page will show, for example:
```
  Hostnames
  =========
    host_aliases: [ocid1.instance.oc1.iad.<instance ID>]
    [...]

  Metadata
  ========
    agent_version: 7.34.0-devel+git.118.aadd980
    cloud_provider: Oracle
```