### PR TITLE
[containers] Add containerd collector (linux and windows)

### DIFF
--- a/pkg/autodiscovery/listeners/environment.go
+++ b/pkg/autodiscovery/listeners/environment.go
@@ -69,17 +69,20 @@ func (l *EnvironmentListener) createServices() {
 	}
 
 	// Handle generic container check auto-activation.
-	// Currently only on Linux.
 	// We're limited by the collectors in Metadata server on Linux.
 	// We're limited by the runtimes on Windows.
+	var containerFeatures []config.Feature
 	if runtime.GOOS == "linux" {
-		containerFeatures := []config.Feature{config.Docker, config.Containerd, config.Kubernetes, config.ECSFargate}
-		for _, f := range containerFeatures {
-			if config.IsFeaturePresent(f) {
-				log.Infof("Listener created container service from environment")
-				l.newService <- &EnvironmentService{adIdentifier: "_container"}
-				break
-			}
+		containerFeatures = []config.Feature{config.Docker, config.Containerd, config.Kubernetes, config.ECSFargate}
+	} else if runtime.GOOS == "windows" {
+		containerFeatures = []config.Feature{config.Containerd}
+	}
+
+	for _, f := range containerFeatures {
+		if config.IsFeaturePresent(f) {
+			log.Infof("Listener created container service from environment")
+			l.newService <- &EnvironmentService{adIdentifier: "_container"}
+			break
 		}
 	}
 }

--- a/pkg/util/containers/v2/metrics/collector_containerd.go
+++ b/pkg/util/containers/v2/metrics/collector_containerd.go
@@ -1,0 +1,406 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build containerd
+
+package metrics
+
+import (
+	"fmt"
+	"time"
+
+	wstats "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
+	v1 "github.com/containerd/cgroups/stats/v1"
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/oci"
+	"github.com/containerd/typeurl"
+	"github.com/opencontainers/runtime-spec/specs-go"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	cutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/providers"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/retry"
+	"github.com/DataDog/datadog-agent/pkg/util/system"
+)
+
+const (
+	containerdCollectorID    = "containerd"
+	containerdCacheKeyPrefix = "containerd-stats-"
+	containerdCacheTTL       = 10 * time.Second
+)
+
+func init() {
+	metricsProvider.registerCollector(collectorMetadata{
+		id:       containerdCollectorID,
+		priority: 1, // Less than the "system" collector, so we can rely on cgroups directly if possible
+		runtimes: []string{RuntimeNameContainerd},
+		factory: func() (Collector, error) {
+			return newContainerdCollector()
+		},
+	})
+}
+
+type containerdCollector struct {
+	client         cutil.ContainerdItf
+	lastScrapeTime time.Time
+}
+
+func newContainerdCollector() (*containerdCollector, error) {
+	if !config.IsFeaturePresent(config.Containerd) {
+		return nil, ErrPermaFail
+	}
+
+	client, err := cutil.GetContainerdUtil()
+	if err != nil {
+		if retry.IsErrPermaFail(err) {
+			return nil, ErrPermaFail
+		}
+
+		return nil, ErrNothingYet
+	}
+
+	return &containerdCollector{client: client}, nil
+}
+
+// ID returns the collector ID.
+func (c *containerdCollector) ID() string {
+	return containerdCollectorID
+}
+
+// GetContainerStats returns stats by container ID.
+func (c *containerdCollector) GetContainerStats(containerID string, cacheValidity time.Duration) (*ContainerStats, error) {
+	metrics, err := c.getContainerdMetrics(containerID, cacheValidity)
+	if err != nil {
+		return nil, err
+	}
+
+	switch metricsVal := metrics.(type) {
+	case *v1.Metrics:
+		container, err := c.client.Container(containerID)
+		if err != nil {
+			return nil, fmt.Errorf("could not get container with ID %s: %s", containerID, err)
+		}
+
+		OCISpec, err := c.client.Spec(container)
+		if err != nil {
+			return nil, fmt.Errorf("could not retrieve OCI Spec from container with ID %s: %s", containerID, err)
+		}
+
+		info, err := c.client.Info(container)
+		if err != nil {
+			return nil, fmt.Errorf("could not retrieve the metadata of the container with ID %s: %s", containerID, err)
+		}
+
+		processes, err := c.client.TaskPids(container)
+		if err != nil {
+			return nil, fmt.Errorf("could not retrieve the processes of the container with ID %s: %s", containerID, err)
+		}
+
+		return getContainerdStatsLinux(metricsVal, info, OCISpec, processes), nil
+	case *wstats.Statistics:
+		windowsMetrics := metricsVal.GetWindows()
+
+		if windowsMetrics == nil {
+			return nil, fmt.Errorf("error getting Windows metrics for container with ID: %s: %s", containerID, err)
+		}
+
+		return getContainerdStatsWindows(windowsMetrics), nil
+	default:
+		return nil, fmt.Errorf("can't convert the metrics data (type %T) from container with ID %s", metricsVal, containerID)
+	}
+}
+
+// GetContainerNetworkStats returns network stats by container ID.
+func (c *containerdCollector) GetContainerNetworkStats(containerID string, cacheValidity time.Duration, networks map[string]string) (*ContainerNetworkStats, error) {
+	metrics, err := c.getContainerdMetrics(containerID, cacheValidity)
+	if err != nil {
+		return nil, err
+	}
+
+	switch metricsVal := metrics.(type) {
+	case *v1.Metrics:
+		return getContainerdNetworkStatsLinux(metricsVal.Network, networks), nil
+	case *wstats.Statistics:
+		// Network stats are not available on Windows
+		return nil, nil
+	default:
+		return nil, fmt.Errorf("can't convert the metrics data (type %T) from container with ID %s", metricsVal, containerID)
+	}
+}
+
+// This method returns interface{} because the metrics could be an instance of
+// v1.Metrics (for Linux) or stats.Statistics (Windows) and they don't share a
+// common interface.
+func (c *containerdCollector) getContainerdMetrics(containerID string, cacheValidity time.Duration) (interface{}, error) {
+	refreshRequired := c.lastScrapeTime.Add(cacheValidity).Before(time.Now())
+	cacheKey := containerdCacheKeyPrefix + containerID
+	if cachedMetrics, found := cache.Cache.Get(cacheKey); found && !refreshRequired {
+		log.Debugf("Got containerd stats from cache for container %s", containerID)
+		return cachedMetrics, nil
+	}
+
+	container, err := c.client.Container(containerID)
+	if err != nil {
+		return nil, fmt.Errorf("could not get container with ID %s: %s", containerID, err)
+	}
+
+	metricTask, errTask := c.client.TaskMetrics(container)
+	if errTask != nil {
+		return nil, fmt.Errorf("could not get metrics for container with ID %s: %s", containerID, err)
+	}
+
+	metrics, err := typeurl.UnmarshalAny(metricTask.Data)
+	if err != nil {
+		return nil, fmt.Errorf("could not convert the metrics data from container with ID %s: %s", containerID, err)
+	}
+
+	c.lastScrapeTime = time.Now()
+	cache.Cache.Set(cacheKey, metrics, containerdCacheTTL)
+
+	return metrics, nil
+}
+
+func getContainerdStatsLinux(metrics *v1.Metrics, container containers.Container, OCISpec *oci.Spec, processes []containerd.ProcessInfo) *ContainerStats {
+	if metrics == nil {
+		return nil
+	}
+
+	currentTime := time.Now()
+
+	return &ContainerStats{
+		Timestamp: currentTime,
+		CPU:       getContainerdCPUStatsLinux(metrics.CPU, currentTime, container.CreatedAt, OCISpec),
+		Memory:    getContainerdMemoryStatsLinux(metrics.Memory),
+		IO:        getContainerdIOStatsLinux(metrics.Blkio, processes),
+	}
+}
+
+func getContainerdCPUStatsLinux(cpuStat *v1.CPUStat, currentTime time.Time, startTime time.Time, OCISpec *oci.Spec) *ContainerCPUStats {
+	if cpuStat == nil {
+		return nil
+	}
+
+	res := ContainerCPUStats{}
+
+	if cpuStat.Usage != nil {
+		res.Total = util.UIntToFloatPtr(cpuStat.Usage.Total)
+		res.System = util.UIntToFloatPtr(cpuStat.Usage.Kernel)
+		res.User = util.UIntToFloatPtr(cpuStat.Usage.User)
+	}
+
+	if cpuStat.Throttling != nil {
+		res.ThrottledPeriods = util.UIntToFloatPtr(cpuStat.Throttling.ThrottledPeriods)
+		res.ThrottledTime = util.UIntToFloatPtr(cpuStat.Throttling.ThrottledTime)
+	}
+
+	res.Limit = getContainerdCPULimit(currentTime, startTime, OCISpec)
+
+	return &res
+}
+
+func getContainerdMemoryStatsLinux(memStat *v1.MemoryStat) *ContainerMemStats {
+	if memStat == nil {
+		return nil
+	}
+
+	res := ContainerMemStats{
+		RSS:   util.UIntToFloatPtr(memStat.RSS),
+		Cache: util.UIntToFloatPtr(memStat.Cache),
+	}
+
+	if memStat.Usage != nil {
+		res.UsageTotal = util.UIntToFloatPtr(memStat.Usage.Usage)
+		res.Limit = util.UIntToFloatPtr(memStat.Usage.Limit)
+	}
+
+	if memStat.Kernel != nil {
+		res.KernelMemory = util.UIntToFloatPtr(memStat.Kernel.Usage)
+	}
+
+	if memStat.Swap != nil {
+		res.Swap = util.UIntToFloatPtr(memStat.Swap.Usage)
+	}
+
+	return &res
+}
+
+func getContainerdIOStatsLinux(blkioStat *v1.BlkIOStat, processes []containerd.ProcessInfo) *ContainerIOStats {
+	if blkioStat == nil {
+		return nil
+	}
+
+	result := ContainerIOStats{
+		ReadBytes:       util.Float64Ptr(0),
+		WriteBytes:      util.Float64Ptr(0),
+		ReadOperations:  util.Float64Ptr(0),
+		WriteOperations: util.Float64Ptr(0),
+		Devices:         make(map[string]DeviceIOStats),
+	}
+
+	for _, blkioStatEntry := range blkioStat.IoServiceBytesRecursive {
+		deviceName := fmt.Sprintf("%d:%d", blkioStatEntry.Major, blkioStatEntry.Minor)
+		device := result.Devices[deviceName]
+		switch blkioStatEntry.Op {
+		case "Read":
+			device.ReadBytes = util.Float64Ptr(float64(blkioStatEntry.Value))
+		case "Write":
+			device.WriteBytes = util.Float64Ptr(float64(blkioStatEntry.Value))
+		}
+		result.Devices[deviceName] = device
+	}
+
+	for _, blkioStatEntry := range blkioStat.IoServicedRecursive {
+		deviceName := fmt.Sprintf("%d:%d", blkioStatEntry.Major, blkioStatEntry.Minor)
+		device := result.Devices[deviceName]
+		switch blkioStatEntry.Op {
+		case "Read":
+			device.ReadOperations = util.Float64Ptr(float64(blkioStatEntry.Value))
+		case "Write":
+			device.WriteOperations = util.Float64Ptr(float64(blkioStatEntry.Value))
+		}
+		result.Devices[deviceName] = device
+	}
+
+	for _, device := range result.Devices {
+		if device.ReadBytes != nil {
+			*result.ReadBytes += *device.ReadBytes
+		}
+		if device.WriteBytes != nil {
+			*result.WriteBytes += *device.WriteBytes
+		}
+		if device.ReadOperations != nil {
+			*result.ReadOperations += *device.ReadOperations
+		}
+		if device.WriteOperations != nil {
+			*result.WriteOperations += *device.WriteOperations
+		}
+	}
+
+	result.OpenFiles = util.Float64Ptr(float64(getOpenFileDescriptors(processes)))
+
+	return &result
+}
+
+func getContainerdNetworkStatsLinux(networkStats []*v1.NetworkStat, networksMapping map[string]string) *ContainerNetworkStats {
+	containerNetworkStats := ContainerNetworkStats{
+		BytesSent:   util.Float64Ptr(0),
+		BytesRcvd:   util.Float64Ptr(0),
+		PacketsSent: util.Float64Ptr(0),
+		PacketsRcvd: util.Float64Ptr(0),
+		Interfaces:  make(map[string]InterfaceNetStats),
+	}
+
+	for _, stats := range networkStats {
+		*containerNetworkStats.BytesSent += float64(stats.TxBytes)
+		*containerNetworkStats.BytesRcvd += float64(stats.RxBytes)
+		*containerNetworkStats.PacketsSent += float64(stats.TxPackets)
+		*containerNetworkStats.PacketsRcvd += float64(stats.RxPackets)
+
+		interfaceName := stats.Name
+		if customName, useCustomName := networksMapping[stats.Name]; useCustomName {
+			interfaceName = customName
+		}
+
+		containerNetworkStats.Interfaces[interfaceName] = InterfaceNetStats{
+			BytesSent:   util.UIntToFloatPtr(stats.TxBytes),
+			BytesRcvd:   util.UIntToFloatPtr(stats.RxBytes),
+			PacketsSent: util.UIntToFloatPtr(stats.TxPackets),
+			PacketsRcvd: util.UIntToFloatPtr(stats.RxPackets),
+		}
+	}
+
+	return &containerNetworkStats
+}
+
+func getContainerdCPULimit(currentTime time.Time, startTime time.Time, OCISpec *oci.Spec) *float64 {
+	timeDiff := float64(currentTime.Sub(startTime).Nanoseconds()) // cpu.total is in nanoseconds
+
+	if timeDiff <= 0 {
+		return nil
+	}
+
+	var cpuLimits *specs.LinuxCPU
+	if OCISpec != nil && OCISpec.Linux != nil && OCISpec.Linux.Resources != nil {
+		cpuLimits = OCISpec.Linux.Resources.CPU
+	}
+
+	cpuLimitPct := float64(system.HostCPUCount())
+	if cpuLimits != nil && cpuLimits.Period != nil && *cpuLimits.Period > 0 && cpuLimits.Quota != nil && *cpuLimits.Quota > 0 {
+		cpuLimitPct = float64(*cpuLimits.Quota) / float64(*cpuLimits.Period)
+	}
+
+	limit := cpuLimitPct * timeDiff
+	return &limit
+}
+
+func getContainerdStatsWindows(windowsStats *wstats.WindowsContainerStatistics) *ContainerStats {
+	if windowsStats == nil {
+		return nil
+	}
+
+	return &ContainerStats{
+		Timestamp: windowsStats.Timestamp,
+		CPU:       getContainerdCPUStatsWindows(windowsStats.Processor),
+		Memory:    getContainerdMemoryStatsWindows(windowsStats.Memory),
+		IO:        getContainerdIOStatsWindows(windowsStats.Storage),
+	}
+}
+
+func getContainerdCPUStatsWindows(procStats *wstats.WindowsContainerProcessorStatistics) *ContainerCPUStats {
+	if procStats == nil {
+		return nil
+	}
+
+	return &ContainerCPUStats{
+		Total:  util.UIntToFloatPtr(procStats.TotalRuntimeNS),
+		System: util.UIntToFloatPtr(procStats.RuntimeKernelNS),
+		User:   util.UIntToFloatPtr(procStats.RuntimeUserNS),
+	}
+}
+
+func getContainerdMemoryStatsWindows(memStats *wstats.WindowsContainerMemoryStatistics) *ContainerMemStats {
+	if memStats == nil {
+		return nil
+	}
+
+	return &ContainerMemStats{
+		PrivateWorkingSet: util.UIntToFloatPtr(memStats.MemoryUsagePrivateWorkingSetBytes),
+		CommitBytes:       util.UIntToFloatPtr(memStats.MemoryUsageCommitBytes),
+		CommitPeakBytes:   util.UIntToFloatPtr(memStats.MemoryUsageCommitPeakBytes),
+	}
+}
+
+func getContainerdIOStatsWindows(ioStats *wstats.WindowsContainerStorageStatistics) *ContainerIOStats {
+	if ioStats == nil {
+		return nil
+	}
+
+	return &ContainerIOStats{
+		ReadBytes:       util.UIntToFloatPtr(ioStats.ReadSizeBytes),
+		WriteBytes:      util.UIntToFloatPtr(ioStats.WriteSizeBytes),
+		ReadOperations:  util.UIntToFloatPtr(ioStats.ReadCountNormalized),
+		WriteOperations: util.UIntToFloatPtr(ioStats.WriteCountNormalized),
+	}
+}
+
+func getOpenFileDescriptors(processes []containerd.ProcessInfo) int {
+	fileDescCount := 0
+
+	for _, p := range processes {
+		pid := p.Pid
+		fdCount, err := providers.ContainerImpl().GetNumFileDescriptors(int(pid))
+		if err != nil {
+			log.Debugf("Failed to get file desc length for pid %d: %s", pid, err)
+			continue
+		}
+		fileDescCount += fdCount
+	}
+
+	return fileDescCount
+}

--- a/pkg/util/containers/v2/metrics/collector_containerd.go
+++ b/pkg/util/containers/v2/metrics/collector_containerd.go
@@ -25,7 +25,6 @@ import (
 	cutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/providers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/datadog-agent/pkg/util/retry"
 	"github.com/DataDog/datadog-agent/pkg/util/system"
 )
 
@@ -58,11 +57,7 @@ func newContainerdCollector() (*containerdCollector, error) {
 
 	client, err := cutil.GetContainerdUtil()
 	if err != nil {
-		if retry.IsErrPermaFail(err) {
-			return nil, ErrPermaFail
-		}
-
-		return nil, ErrNothingYet
+		return nil, convertRetrierErr(err)
 	}
 
 	return &containerdCollector{client: client}, nil

--- a/pkg/util/containers/v2/metrics/collector_containerd_test.go
+++ b/pkg/util/containers/v2/metrics/collector_containerd_test.go
@@ -1,0 +1,404 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build containerd
+
+package metrics
+
+import (
+	"testing"
+	"time"
+
+	wstats "github.com/Microsoft/hcsshim/cmd/containerd-shim-runhcs-v1/stats"
+	v1 "github.com/containerd/cgroups/stats/v1"
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/oci"
+	"github.com/containerd/typeurl"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/util"
+	containerdutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
+)
+
+type mockedContainerdClient struct {
+	containerdutil.ContainerdItf
+	mockContainer   func(id string) (containerd.Container, error)
+	mockInfo        func(ctn containerd.Container) (containers.Container, error)
+	mockSpec        func(ctn containerd.Container) (*oci.Spec, error)
+	mockTaskMetrics func(ctn containerd.Container) (*types.Metric, error)
+	mockTaskPids    func(ctn containerd.Container) ([]containerd.ProcessInfo, error)
+}
+
+func (m *mockedContainerdClient) Container(id string) (containerd.Container, error) {
+	return m.mockContainer(id)
+}
+
+func (m *mockedContainerdClient) Info(ctn containerd.Container) (containers.Container, error) {
+	return m.mockInfo(ctn)
+}
+
+func (m *mockedContainerdClient) Spec(ctn containerd.Container) (*oci.Spec, error) {
+	return m.mockSpec(ctn)
+}
+
+func (m *mockedContainerdClient) TaskMetrics(ctn containerd.Container) (*types.Metric, error) {
+	return m.mockTaskMetrics(ctn)
+}
+
+func (m *mockedContainerdClient) TaskPids(ctn containerd.Container) ([]containerd.ProcessInfo, error) {
+	return m.mockTaskPids(ctn)
+}
+
+type mockedContainer struct {
+	containerd.Container
+}
+
+func TestGetContainerStats_Containerd(t *testing.T) {
+	currentTime := time.Now()
+
+	linuxMetrics := v1.Metrics{
+		CPU: &v1.CPUStat{
+			Usage: &v1.CPUUsage{
+				Total:  1000,
+				Kernel: 600,
+				User:   400,
+			},
+			Throttling: &v1.Throttle{
+				ThrottledPeriods: 1,
+				ThrottledTime:    100,
+			},
+		},
+		Memory: &v1.MemoryStat{
+			Cache: 20,
+			RSS:   100,
+			Usage: &v1.MemoryEntry{
+				Limit: 2000,
+				Usage: 1000,
+			},
+			Swap: &v1.MemoryEntry{
+				Usage: 10,
+			},
+			Kernel: &v1.MemoryEntry{
+				Usage: 500,
+			},
+		},
+		Blkio: &v1.BlkIOStat{
+			IoServiceBytesRecursive: []*v1.BlkIOEntry{
+				{
+					Major: 1,
+					Minor: 1,
+					Op:    "Read",
+					Value: 10,
+				},
+				{
+					Major: 1,
+					Minor: 1,
+					Op:    "Write",
+					Value: 15,
+				},
+				{
+					Major: 1,
+					Minor: 2,
+					Op:    "Read",
+					Value: 50,
+				},
+				{
+					Major: 1,
+					Minor: 2,
+					Op:    "Write",
+					Value: 5,
+				},
+			},
+			IoServicedRecursive: []*v1.BlkIOEntry{
+				{
+					Major: 1,
+					Minor: 1,
+					Op:    "Read",
+					Value: 1,
+				},
+				{
+					Major: 1,
+					Minor: 1,
+					Op:    "Write",
+					Value: 2,
+				},
+				{
+					Major: 1,
+					Minor: 2,
+					Op:    "Read",
+					Value: 5,
+				},
+				{
+					Major: 1,
+					Minor: 2,
+					Op:    "Write",
+					Value: 1,
+				},
+			},
+		},
+	}
+	linuxMetricsAny, err := typeurl.MarshalAny(&linuxMetrics)
+	assert.NoError(t, err)
+
+	windowsMetrics := wstats.Statistics{
+		Container: &wstats.Statistics_Windows{
+			Windows: &wstats.WindowsContainerStatistics{
+				Timestamp: currentTime,
+				Processor: &wstats.WindowsContainerProcessorStatistics{
+					TotalRuntimeNS:  1000,
+					RuntimeUserNS:   400,
+					RuntimeKernelNS: 600,
+				},
+				Memory: &wstats.WindowsContainerMemoryStatistics{
+					MemoryUsageCommitBytes:            1000,
+					MemoryUsageCommitPeakBytes:        1500,
+					MemoryUsagePrivateWorkingSetBytes: 100,
+				},
+				Storage: &wstats.WindowsContainerStorageStatistics{
+					ReadCountNormalized:  2,
+					ReadSizeBytes:        20,
+					WriteCountNormalized: 1,
+					WriteSizeBytes:       10,
+				},
+			},
+		},
+	}
+	windowsMetricsAny, err := typeurl.MarshalAny(&windowsMetrics)
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name                   string
+		containerdMetrics      *types.Metric
+		expectedContainerStats *ContainerStats
+	}{
+		{
+			name: "Linux metrics",
+			containerdMetrics: &types.Metric{
+				Data: linuxMetricsAny,
+			},
+			expectedContainerStats: &ContainerStats{
+				Timestamp: currentTime,
+				CPU: &ContainerCPUStats{
+					Total:            util.Float64Ptr(1000),
+					System:           util.Float64Ptr(600),
+					User:             util.Float64Ptr(400),
+					ThrottledPeriods: util.Float64Ptr(1),
+					ThrottledTime:    util.Float64Ptr(100),
+				},
+				Memory: &ContainerMemStats{
+					UsageTotal:   util.Float64Ptr(1000),
+					KernelMemory: util.Float64Ptr(500),
+					Limit:        util.Float64Ptr(2000),
+					RSS:          util.Float64Ptr(100),
+					Cache:        util.Float64Ptr(20),
+					Swap:         util.Float64Ptr(10),
+				},
+				IO: &ContainerIOStats{
+					ReadBytes:       util.Float64Ptr(60),
+					WriteBytes:      util.Float64Ptr(20),
+					ReadOperations:  util.Float64Ptr(6),
+					WriteOperations: util.Float64Ptr(3),
+					Devices: map[string]DeviceIOStats{
+						"1:1": {
+							ReadBytes:       util.Float64Ptr(10),
+							WriteBytes:      util.Float64Ptr(15),
+							ReadOperations:  util.Float64Ptr(1),
+							WriteOperations: util.Float64Ptr(2),
+						},
+						"1:2": {
+							ReadBytes:       util.Float64Ptr(50),
+							WriteBytes:      util.Float64Ptr(5),
+							ReadOperations:  util.Float64Ptr(5),
+							WriteOperations: util.Float64Ptr(1),
+						},
+					},
+					OpenFiles: util.Float64Ptr(0), // Not checked in this test
+				},
+			},
+		},
+		{
+			name: "Windows metrics",
+			containerdMetrics: &types.Metric{
+				Data: windowsMetricsAny,
+			},
+			expectedContainerStats: &ContainerStats{
+				Timestamp: currentTime,
+				CPU: &ContainerCPUStats{
+					Total:  util.Float64Ptr(1000),
+					System: util.Float64Ptr(600),
+					User:   util.Float64Ptr(400),
+				},
+				Memory: &ContainerMemStats{
+					PrivateWorkingSet: util.Float64Ptr(100),
+					CommitBytes:       util.Float64Ptr(1000),
+					CommitPeakBytes:   util.Float64Ptr(1500),
+				},
+				IO: &ContainerIOStats{
+					ReadBytes:       util.Float64Ptr(20),
+					WriteBytes:      util.Float64Ptr(10),
+					ReadOperations:  util.Float64Ptr(2),
+					WriteOperations: util.Float64Ptr(1),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			collector := containerdCollector{client: containerdClient(test.containerdMetrics)}
+
+			// ID and cache TTL not relevant for these tests
+			result, err := collector.GetContainerStats("1", 10*time.Second)
+			assert.NoError(t, err)
+
+			result.CPU.Limit = nil         // Don't check this field. It's complex to calculate. Needs separate tests.
+			result.Timestamp = currentTime // We have no control over it, so set it to avoid checking it.
+
+			assert.Empty(t, cmp.Diff(test.expectedContainerStats, result))
+		})
+	}
+}
+
+func TestGetContainerNetworkStats_Containerd(t *testing.T) {
+	linuxMetrics := v1.Metrics{
+		Network: []*v1.NetworkStat{
+			{
+				Name:      "interface-1",
+				RxBytes:   10,
+				RxPackets: 1,
+				TxBytes:   20,
+				TxPackets: 2,
+			},
+			{
+				Name:      "interface-2",
+				RxBytes:   100,
+				RxPackets: 10,
+				TxBytes:   200,
+				TxPackets: 20,
+			},
+		},
+	}
+	linuxMetricsAny, err := typeurl.MarshalAny(&linuxMetrics)
+	assert.NoError(t, err)
+
+	windowsMetrics := wstats.Statistics{
+		Container: &wstats.Statistics_Windows{
+			Windows: &wstats.WindowsContainerStatistics{},
+		},
+	}
+	windowsMetricsAny, err := typeurl.MarshalAny(&windowsMetrics)
+	assert.NoError(t, err)
+
+	tests := []struct {
+		name                 string
+		containerdMetrics    *types.Metric
+		interfaceMapping     map[string]string
+		expectedNetworkStats *ContainerNetworkStats
+	}{
+		{
+			name: "Linux with no interface mapping",
+			containerdMetrics: &types.Metric{
+				Data: linuxMetricsAny,
+			},
+			expectedNetworkStats: &ContainerNetworkStats{
+				BytesSent:   util.Float64Ptr(220),
+				BytesRcvd:   util.Float64Ptr(110),
+				PacketsSent: util.Float64Ptr(22),
+				PacketsRcvd: util.Float64Ptr(11),
+				Interfaces: map[string]InterfaceNetStats{
+					"interface-1": {
+						BytesSent:   util.Float64Ptr(20),
+						BytesRcvd:   util.Float64Ptr(10),
+						PacketsSent: util.Float64Ptr(2),
+						PacketsRcvd: util.Float64Ptr(1),
+					},
+					"interface-2": {
+						BytesSent:   util.Float64Ptr(200),
+						BytesRcvd:   util.Float64Ptr(100),
+						PacketsSent: util.Float64Ptr(20),
+						PacketsRcvd: util.Float64Ptr(10),
+					},
+				},
+			},
+		},
+		{
+			name: "Linux with interface mapping",
+			containerdMetrics: &types.Metric{
+				Data: linuxMetricsAny,
+			},
+			interfaceMapping: map[string]string{
+				"interface-1": "custom-1",
+				"interface-2": "custom-2",
+			},
+			expectedNetworkStats: &ContainerNetworkStats{
+				BytesSent:   util.Float64Ptr(220),
+				BytesRcvd:   util.Float64Ptr(110),
+				PacketsSent: util.Float64Ptr(22),
+				PacketsRcvd: util.Float64Ptr(11),
+				Interfaces: map[string]InterfaceNetStats{
+					"custom-1": {
+						BytesSent:   util.Float64Ptr(20),
+						BytesRcvd:   util.Float64Ptr(10),
+						PacketsSent: util.Float64Ptr(2),
+						PacketsRcvd: util.Float64Ptr(1),
+					},
+					"custom-2": {
+						BytesSent:   util.Float64Ptr(200),
+						BytesRcvd:   util.Float64Ptr(100),
+						PacketsSent: util.Float64Ptr(20),
+						PacketsRcvd: util.Float64Ptr(10),
+					},
+				},
+			},
+		},
+		{
+			name: "Windows",
+			containerdMetrics: &types.Metric{
+				Data: windowsMetricsAny,
+			},
+			expectedNetworkStats: nil, // Does not return anything on Windows
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			collector := containerdCollector{client: containerdClient(test.containerdMetrics)}
+
+			// ID and cache TTL not relevant for these tests
+			result, err := collector.GetContainerNetworkStats("1", 10*time.Second, test.interfaceMapping)
+
+			assert.NoError(t, err)
+			assert.Empty(t, cmp.Diff(test.expectedNetworkStats, result))
+		})
+	}
+}
+
+// Returns a fake containerd client for testing.
+// For these tests we need 2 things:
+//   - 1) Being able to control the metrics returned by the TaskMetrics
+//   function.
+//   - 2) Define functions like Info, Spec, etc. so they don't return errors.
+func containerdClient(metrics *types.Metric) *mockedContainerdClient {
+	return &mockedContainerdClient{
+		mockTaskMetrics: func(ctn containerd.Container) (*types.Metric, error) {
+			return metrics, nil
+		},
+		mockContainer: func(id string) (containerd.Container, error) {
+			return mockedContainer{}, nil
+		},
+		mockInfo: func(ctn containerd.Container) (containers.Container, error) {
+			return containers.Container{}, nil
+		},
+		mockSpec: func(ctn containerd.Container) (*oci.Spec, error) {
+			return nil, nil
+		},
+		mockTaskPids: func(ctn containerd.Container) ([]containerd.ProcessInfo, error) {
+			return nil, nil
+		},
+	}
+}

--- a/pkg/util/containers/v2/metrics/util.go
+++ b/pkg/util/containers/v2/metrics/util.go
@@ -5,10 +5,21 @@
 
 package metrics
 
-import "github.com/DataDog/datadog-agent/pkg/util"
+import (
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/retry"
+)
 
 func convertField(s *uint64, t **float64) {
 	if s != nil {
 		*t = util.Float64Ptr(float64(*s))
 	}
+}
+
+func convertRetrierErr(err error) *retry.Error {
+	if retry.IsErrPermaFail(err) {
+		return ErrPermaFail
+	}
+
+	return ErrNothingYet
 }


### PR DESCRIPTION
### What does this PR do?

Adds a containerd collector (Linux and Windows) for the generic metrics provider introduced in #9403 

### Describe how to test your changes

Run the generic `container` check on a Windows host with containerd.

For Linux is a bit more complicated because the `system` collector always takes precedence. To disable it, run the Agent without mounting `/proc` to `/host/proc`, the system provider will be automatically disabled.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
