### PR TITLE
Enable NAT gateway lookup by default

### DIFF
--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -119,7 +119,7 @@ func InitSystemProbeConfig(cfg Config) {
 	// network_config namespace only
 	cfg.BindEnv(join(netNS, "enable_http_monitoring"), "DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTP_MONITORING")
 	cfg.BindEnv(join(netNS, "enable_https_monitoring"), "DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTPS_MONITORING")
-	cfg.BindEnvAndSetDefault(join(netNS, "enable_gateway_lookup"), false, "DD_SYSTEM_PROBE_NETWORK_ENABLE_GATEWAY_LOOKUP")
+	cfg.BindEnvAndSetDefault(join(netNS, "enable_gateway_lookup"), true, "DD_SYSTEM_PROBE_NETWORK_ENABLE_GATEWAY_LOOKUP")
 
 	// list of DNS query types to be recorded
 	cfg.BindEnvAndSetDefault(join(netNS, "dns_recorded_query_types"), []string{})

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -75,7 +75,7 @@ func TestEnableHTTPMonitoring(t *testing.T) {
 	})
 }
 
-func TestEnableGatewayLookup(t *testing.T) {
+func TestDisableGatewayLookup(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
 		newConfig()
 		defer restoreGlobalConfig()
@@ -85,27 +85,27 @@ func TestEnableGatewayLookup(t *testing.T) {
 		require.NoError(t, err)
 		cfg := New()
 
-		assert.False(t, cfg.EnableGatewayLookup)
+		assert.True(t, cfg.EnableGatewayLookup)
 
 		newConfig()
-		_, err = sysconfig.New("./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableGwLookup.yaml")
+		_, err = sysconfig.New("./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-DisableGwLookup.yaml")
 		require.NoError(t, err)
 		cfg = New()
 
-		assert.True(t, cfg.EnableGatewayLookup)
+		assert.False(t, cfg.EnableGatewayLookup)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
 		newConfig()
 		defer restoreGlobalConfig()
 
-		os.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLE_GATEWAY_LOOKUP", "true")
+		os.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLE_GATEWAY_LOOKUP", "false")
 		defer os.Unsetenv("DD_SYSTEM_PROBE_NETWORK_ENABLE_GATEWAY_LOOKUP")
 		_, err := sysconfig.New("")
 		require.NoError(t, err)
 		cfg := New()
 
-		assert.True(t, cfg.EnableGatewayLookup)
+		assert.False(t, cfg.EnableGatewayLookup)
 	})
 }
 

--- a/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-DisableGwLookup.yaml
+++ b/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-DisableGwLookup.yaml
@@ -1,0 +1,2 @@
+network_config:
+  enable_gateway_lookup: false

--- a/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableGwLookup.yaml
+++ b/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableGwLookup.yaml
@@ -1,2 +1,0 @@
-network_config:
-  enable_gateway_lookup: true

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -511,15 +511,6 @@ func TestUnconnectedUDPSendIPv6(t *testing.T) {
 }
 
 func TestGatewayLookupNotEnabled(t *testing.T) {
-	t.Run("gateway lookup not enabled", func(t *testing.T) {
-		cfg := testConfig()
-		tr, err := NewTracer(cfg)
-		require.NoError(t, err)
-		require.NotNil(t, tr)
-		defer tr.Stop()
-		require.Nil(t, tr.gwLookup)
-	})
-
 	t.Run("gateway lookup enabled, not on aws", func(t *testing.T) {
 		cfg := testConfig()
 		cfg.EnableGatewayLookup = true

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1409,6 +1409,8 @@ func TestTCPDirectionWithPreexistingConnection(t *testing.T) {
 
 	// start tracer so it dumps port bindings
 	cfg := testConfig()
+	// delay from gateway lookup timeout can cause test failure
+	cfg.EnableGatewayLookup = false
 	tr, err := NewTracer(cfg)
 	require.NoError(t, err)
 	defer tr.Stop()

--- a/releasenotes/notes/enable-npm-nat-gw-lookup-default-4dd11a75e9b9a582.yaml
+++ b/releasenotes/notes/enable-npm-nat-gw-lookup-default-4dd11a75e9b9a582.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Enable NPM NAT gateway lookup by default.


### PR DESCRIPTION
### What does this PR do?

Enable NAT gateway lookup in NPM by default.

### Motivation

Feature is ready for GA.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
