### PR TITLE
Enable DNS domain collection by default

### DIFF
--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -102,7 +102,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "disable_dns_inspection"), false, "DD_DISABLE_DNS_INSPECTION")
 	cfg.BindEnvAndSetDefault(join(spNS, "collect_dns_stats"), true, "DD_COLLECT_DNS_STATS")
 	cfg.BindEnvAndSetDefault(join(spNS, "collect_local_dns"), false, "DD_COLLECT_LOCAL_DNS")
-	cfg.BindEnvAndSetDefault(join(spNS, "collect_dns_domains"), false, "DD_COLLECT_DNS_DOMAINS")
+	cfg.BindEnvAndSetDefault(join(spNS, "collect_dns_domains"), true, "DD_COLLECT_DNS_DOMAINS")
 	cfg.BindEnvAndSetDefault(join(spNS, "max_dns_stats"), 20000)
 	cfg.BindEnvAndSetDefault(join(spNS, "dns_timeout_in_s"), 15)
 

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -168,16 +168,16 @@ func TestEnablingDNSStatsCollection(t *testing.T) {
 	})
 }
 
-func TestEnablingDNSDomainCollection(t *testing.T) {
+func TestDisablingDNSDomainCollection(t *testing.T) {
 	newConfig()
 	defer restoreGlobalConfig()
 
 	t.Run("via YAML", func(t *testing.T) {
-		_, err := sysconfig.New("./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableDNSDomains.yaml")
+		_, err := sysconfig.New("./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-DisableDNSDomains.yaml")
 		require.NoError(t, err)
 		cfg := New()
 
-		assert.True(t, cfg.CollectDNSDomains)
+		assert.False(t, cfg.CollectDNSDomains)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
@@ -188,7 +188,7 @@ func TestEnablingDNSDomainCollection(t *testing.T) {
 		require.NoError(t, err)
 		cfg := New()
 
-		assert.False(t, cfg.CollectDNSDomains) // default value should be false
+		assert.False(t, cfg.CollectDNSDomains)
 
 		newConfig()
 		os.Setenv("DD_COLLECT_DNS_DOMAINS", "true")
@@ -205,7 +205,7 @@ func TestSettingMaxDNSStats(t *testing.T) {
 	defer restoreGlobalConfig()
 
 	t.Run("via YAML", func(t *testing.T) {
-		_, err := sysconfig.New("./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableDNSDomains.yaml")
+		_, err := sysconfig.New("./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-DisableDNSDomains.yaml")
 		require.NoError(t, err)
 		cfg := New()
 

--- a/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-DisableDNSDomains.yaml
+++ b/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-DisableDNSDomains.yaml
@@ -1,0 +1,3 @@
+system_probe_config:
+  collect_dns_domains: false
+  max_dns_stats: 100

--- a/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableDNSDomains.yaml
+++ b/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableDNSDomains.yaml
@@ -1,3 +1,0 @@
-system_probe_config:
-    collect_dns_domains: true
-    max_dns_stats: 100

--- a/releasenotes/notes/enable-npm-dns-domain-default-b7ed3bce98ee4ade.yaml
+++ b/releasenotes/notes/enable-npm-dns-domain-default-b7ed3bce98ee4ade.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Enable NPM DNS domain collection by default.


### PR DESCRIPTION
### What does this PR do?

Enables DNS domain name collection by default.

### Motivation

Feature is ready for GA.

### Checklist

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
