### PR TITLE
[install_script] Fix SUSE detection of unsupported versions

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -504,7 +504,8 @@ elif [ "$OS" = "SUSE" ]; then
   echo -e "\033[34m\n* Installing Datadog Agent\n\033[0m"
 
   # ".32" is the latest version supported for OpenSUSE < 15 and SLES < 12
-  if [ "$DISTRIBUTION" == "openSUSE" ] && [ "$SUSE_VER" -lt 15 ]; then
+  # we explicitly test for SUSE11 = "yes", as some SUSE11 don't have /etc/os-release, thus SUSE_VER is empty
+  if [ "$DISTRIBUTION" == "openSUSE" ] && { [ "$SUSE11" == "yes" ] || [ "$SUSE_VER" -lt 15 ]; }; then
       if [ -n "$agent_minor_version" ]; then
           if [ "$agent_minor_version" -ge "33" ]; then
               printf "\033[31mopenSUSE < 15 only supports Agent %s up to %s.32.\033[0m\n" "$agent_major_version" "$agent_major_version"
@@ -517,7 +518,7 @@ elif [ "$OS" = "SUSE" ]; then
           fi
       fi
   fi
-  if [ "$DISTRIBUTION" == "SUSE" ] && [ "$SUSE_VER" -lt 12 ]; then
+  if [ "$DISTRIBUTION" == "SUSE" ] && { [ "$SUSE11" == "yes" ] || [ "$SUSE_VER" -lt 12 ]; }; then
       if [ -n "$agent_minor_version" ]; then
           if [ "$agent_minor_version" -ge "33" ]; then
               printf "\033[31mSLES < 12 only supports Agent %s up to %s.32.\033[0m\n" "$agent_major_version" "$agent_major_version"


### PR DESCRIPTION
### What does this PR do?

Fixes detection of SUSE 11 in the part that detects unsupported systems for future agent >= 7.33.0.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Test on suse11, which doesn't have /etc/os-release. Running the script shouldn't print error `[: : integer expression expected`.


### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
