### PR TITLE
[pkg/otlp/model] Backport attributes changes from Datadog exporter

### DIFF
--- a/pkg/otlp/model/attributes/attributes_test.go
+++ b/pkg/otlp/model/attributes/attributes_test.go
@@ -52,3 +52,32 @@ func TestTagsFromAttributesEmpty(t *testing.T) {
 
 	assert.Equal(t, []string{}, TagsFromAttributes(attrs))
 }
+
+func TestContainerTagFromAttributes(t *testing.T) {
+	attributeMap := map[string]string{
+		conventions.AttributeContainerName:         "sample_app",
+		conventions.AttributeContainerImageTag:     "sample_app_image_tag",
+		conventions.AttributeK8SContainerName:      "kube_sample_app",
+		conventions.AttributeK8SReplicaSetName:     "sample_replica_set",
+		conventions.AttributeK8SDaemonSetName:      "sample_daemonset_name",
+		conventions.AttributeK8SPodName:            "sample_pod_name",
+		conventions.AttributeCloudProvider:         "sample_cloud_provider",
+		conventions.AttributeCloudRegion:           "sample_region",
+		conventions.AttributeCloudAvailabilityZone: "sample_zone",
+		conventions.AttributeAWSECSTaskFamily:      "sample_task_family",
+		conventions.AttributeAWSECSClusterARN:      "sample_ecs_cluster_name",
+		conventions.AttributeAWSECSContainerARN:    "sample_ecs_container_name",
+		"custom_tag":                               "example_custom_tag",
+		"":                                         "empty_string_key",
+		"empty_string_val":                         "",
+	}
+
+	assert.Equal(t, "container_name:sample_app,image_tag:sample_app_image_tag,kube_container_name:kube_sample_app,kube_replica_set:sample_replica_set,kube_daemon_set:sample_daemonset_name,pod_name:sample_pod_name,cloud_provider:sample_cloud_provider,region:sample_region,zone:sample_zone,task_family:sample_task_family,ecs_cluster_name:sample_ecs_cluster_name,ecs_container_name:sample_ecs_container_name", ContainerTagFromAttributes(attributeMap))
+}
+
+func TestContainerTagFromAttributesEmpty(t *testing.T) {
+	var empty string
+	attributeMap := map[string]string{}
+
+	assert.Equal(t, empty, ContainerTagFromAttributes(attributeMap))
+}


### PR DESCRIPTION
### What does this PR do?

Backports OpenTelemetry Collector Contrib Datadog exporter `attributes` package changes made in this [PR](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/6086) to `pkg/otlp/model`.

### Motivation

Keep `pkg/otlp/model` updated with latest changes to the `attributes` package in the OpenTelemetry Collector Contrib Datadog exporter. This is part of the effort led in the following [PR](https://github.com/DataDog/datadog-agent/pull/9162).

### Additional Notes

### Describe how to test your changes

The tests in the OpenTelemetry Collector Contrib Datadog exporter `attributes` package have also been backported.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.