### PR TITLE
[kitchen] Add more explicit tags on EC2 kitchen instances

### DIFF
--- a/test/kitchen/drivers/ec2-driver.yml
+++ b/test/kitchen/drivers/ec2-driver.yml
@@ -24,8 +24,11 @@ driver:
   spot_price: <%= ENV['KITCHEN_EC2_SPOT_PRICE'] %>
   block_duration_minutes: <%= ENV['KITCHEN_EC2_SPOT_DURATION'] ||= '60' %>
   tags:
-    created-by: test-kitchen
-    creator: <%= ENV['KITCHEN_EC2_TAG_CREATOR'] || "kitchen-user" %>
+    Name: ci-datadog-agent-kitchen
+    Team: agent-platform
+    PipelineId: <%= ENV['DD_PIPELINE_ID'] %>
+    CreatedBy: datadog-agent-kitchen-tests
+    Creator: <%= ENV['KITCHEN_EC2_TAG_CREATOR'] || "datadog-agent-kitchen-user" %>
 
 platforms:
 # Loop through two lists and output a total matrix of all possible platform + chef versions,


### PR DESCRIPTION
### What does this PR do?

Adds new tags to the EC2 kitchen instances to make them more recognizable.
In particular, adds the `Name` tag, which is used by the console to list running instances.

### Motivation

Make it easier to find kitchen instances in EC2.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
