### PR TITLE
[install_script] Honor $DD_SITE when reporting errors

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -98,7 +98,12 @@ Troubleshooting and basic usage information for the Agent are available at:
       fallback_msg
       exit 1;
     fi
-    
+
+    if [ "$site" == "ddog-gov.com" ]; then
+      fallback_msg
+      exit 1;
+    fi
+
     while true; do
         read -t 60 -p  "Do you want to send a failure report to Datadog (including $logfile)? (y/[n]) " -r yn || on_read_error
         case $yn in
@@ -249,6 +254,9 @@ else
 fi
 
 report_failure_url="https://api.datadoghq.com/agent_stats/report_failure"
+if [ -n "$DD_SITE" ]; then
+    report_failure_url="https://api.${DD_SITE}/agent_stats/report_failure"
+fi
 if [ -n "$TESTING_REPORT_URL" ]; then
   report_failure_url=$TESTING_REPORT_URL
 fi


### PR DESCRIPTION
### What does this PR do?

- Call the `report_failure` endpoint on the site that is being passed to the install script, if any.
- On dd-gov, do not upload logs.

### Motivation

All install errors were being reported to the US1 site.
