### PR TITLE
[install_script] Direct user to support even when reporting the error

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -59,7 +59,6 @@ function report(){
    printf "A notification has been sent to Datadog with the contents of $logfile\n"
   else
     printf "Unable to send the notification (curl v7.18 or newer is required)"
-    fallback_msg
   fi
 }
 
@@ -106,9 +105,8 @@ Troubleshooting and basic usage information for the Agent are available at:
             get_email
             if [[ -n "$isEmailValid" ]]; then
               report
-            else
-              fallback_msg
             fi
+            fallback_msg
             break;;
           [Nn]*|"" )
             fallback_msg


### PR DESCRIPTION
### What does this PR do?

- Tell the user to contact support (`fallback_msg`) even when they chose to report the error logs.

### Motivation

Reporting the error doesn't ping support automatically anymore.
