### PR TITLE
[containers/ecs_fargate] Run only if the feature is enabled

### DIFF
--- a/pkg/util/containers/v2/metrics/collector_ecs_fargate.go
+++ b/pkg/util/containers/v2/metrics/collector_ecs_fargate.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
 	v2 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v2"
@@ -44,6 +45,10 @@ type ecsStatsFunc func(ctx context.Context, id string) (*v2.ContainerStats, erro
 
 // newEcsFargateCollector returns a new *ecsFargateCollector.
 func newEcsFargateCollector() (*ecsFargateCollector, error) {
+	if !config.IsFeaturePresent(config.ECSFargate) {
+		return nil, ErrPermaFail
+	}
+
 	client, err := metadata.V2()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### What does this PR do?

Runs the ECS Fargate collector only if the feature is enabled.

Without this, the collector is instantiated without errors, because it only checks that the AWS provider is enabled, which it is by default. As a result, this collector can be enabled and replace others even when not running on ECS Fargate. This happened to me in a kind cluster when I was trying the containerd collector:

```
2021-11-04 17:57:58 UTC | CORE | INFO | (pkg/util/containers/v2/metrics/provider.go:179 in updateEffectiveCollectors) | Replaced old collector: containerd by new collector: ecs_fargate for runtime: containerd
```

### Describe how to test your changes

Skip this PR and just test the containerd collector when it's merged: #9749 

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
