### PR TITLE
[DCA] Fix webhook and secret controllers hogging cpu

### DIFF
--- a/pkg/clusteragent/admission/controllers/secret/controller.go
+++ b/pkg/clusteragent/admission/controllers/secret/controller.go
@@ -157,10 +157,6 @@ func (c *Controller) run() {
 // of the Secret when new item is added to the work queue.
 // Always returns true unless the work queue was shutdown.
 func (c *Controller) processNextWorkItem() bool {
-	if !c.isLeaderFunc() {
-		return true
-	}
-
 	key, shutdown := c.queue.Get()
 	if shutdown {
 		return false

--- a/pkg/clusteragent/admission/controllers/webhook/controller_base.go
+++ b/pkg/clusteragent/admission/controllers/webhook/controller_base.go
@@ -159,10 +159,6 @@ func (c *controllerBase) requeue(key interface{}) {
 // of the Webhook when new item is added to the work queue.
 // Always returns true unless the work queue was shutdown.
 func (c *controllerBase) processNextWorkItem(reconcile func() error) bool {
-	if !c.isLeaderFunc() {
-		return true
-	}
-
 	key, shutdown := c.queue.Get()
 	if shutdown {
 		return false


### PR DESCRIPTION
### What does this PR do?

Fix a regression introduced by https://github.com/DataDog/datadog-agent/pull/9097 that caused the DCA follower to hog CPU: `processNextWorkItem` should be a blocking function, there is no need to check `isLeaderFunc` in `processNextWorkItem` as the reconciling method and the informer event handlers verify leadership status already.

### Motivation

Bug fix.

### Additional Notes

The bug wasn't released, identified during QA.

Profile from a buggy DCA follower:
![image](https://user-images.githubusercontent.com/38987709/140487208-96edf14a-095f-470c-93f9-e4263490e0a2.png)


### Describe how to test your changes

Same as https://github.com/DataDog/datadog-agent/pull/9097 + the follower should consume CPU less than the leader.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
