### PR TITLE
[ECS Fargate collector] Allow retrying the client connection

### DIFF
--- a/pkg/util/containers/v2/metrics/collector_ecs_fargate.go
+++ b/pkg/util/containers/v2/metrics/collector_ecs_fargate.go
@@ -51,7 +51,7 @@ func newEcsFargateCollector() (*ecsFargateCollector, error) {
 
 	client, err := metadata.V2()
 	if err != nil {
-		return nil, err
+		return nil, convertRetrierErr(err)
 	}
 
 	return &ecsFargateCollector{client: client}, nil

--- a/pkg/util/containers/v2/metrics/util.go
+++ b/pkg/util/containers/v2/metrics/util.go
@@ -16,10 +16,14 @@ func convertField(s *uint64, t **float64) {
 	}
 }
 
-func convertRetrierErr(err error) *retry.Error {
+func convertRetrierErr(err error) error {
 	if retry.IsErrPermaFail(err) {
 		return ErrPermaFail
 	}
 
-	return ErrNothingYet
+	if retry.IsErrWillRetry(err) {
+		return ErrNothingYet
+	}
+
+	return err
 }

--- a/pkg/util/ecs/metadata/clients.go
+++ b/pkg/util/ecs/metadata/clients.go
@@ -23,6 +23,11 @@ import (
 	v3 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3"
 )
 
+const (
+	initialRetryDelay = 1 * time.Second
+	maxRetryDelay     = 5 * time.Minute
+)
+
 var globalUtil util
 
 type util struct {
@@ -51,8 +56,8 @@ func V1() (*v1.Client, error) {
 			Name:              "ecsutil-meta-v1",
 			AttemptMethod:     initV1,
 			Strategy:          retry.Backoff,
-			InitialRetryDelay: 1 * time.Second,
-			MaxRetryDelay:     5 * time.Minute,
+			InitialRetryDelay: initialRetryDelay,
+			MaxRetryDelay:     maxRetryDelay,
 		})
 	})
 	if err := globalUtil.initRetryV1.TriggerRetry(); err != nil {
@@ -74,8 +79,8 @@ func V2() (*v2.Client, error) {
 			Name:              "ecsutil-meta-v2",
 			AttemptMethod:     initV2,
 			Strategy:          retry.Backoff,
-			InitialRetryDelay: 1 * time.Second,
-			MaxRetryDelay:     5 * time.Minute,
+			InitialRetryDelay: initialRetryDelay,
+			MaxRetryDelay:     maxRetryDelay,
 		})
 	})
 	if err := globalUtil.initRetryV2.TriggerRetry(); err != nil {
@@ -99,8 +104,8 @@ func V3FromCurrentTask() (*v3.Client, error) {
 			Name:              "ecsutil-meta-v3",
 			AttemptMethod:     initV3,
 			Strategy:          retry.Backoff,
-			InitialRetryDelay: 1 * time.Second,
-			MaxRetryDelay:     5 * time.Minute,
+			InitialRetryDelay: initialRetryDelay,
+			MaxRetryDelay:     maxRetryDelay,
 		})
 	})
 	if err := globalUtil.initRetryV3.TriggerRetry(); err != nil {


### PR DESCRIPTION
### What does this PR do?

- The ECS Fargate uses `convertRetrierErr` so the main provider logic can decide whether it should retry it or not.
- Implement a retrier in `pkg/util/ecs/metadata/clients.go` for the v2 client.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Follow up on https://github.com/DataDog/datadog-agent/pull/9739

### Describe how to test your changes

Same as https://github.com/DataDog/datadog-agent/pull/9739

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
