### PR TITLE
[AD] Fixes to the kubelet listener and config provider

### DIFF
--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !serverless
 // +build !serverless
 
 package listeners
@@ -72,7 +73,7 @@ func (l *KubeletListener) processPod(
 			continue
 		}
 
-		l.createContainerService(pod, podContainer, container, creationTime)
+		l.createContainerService(pod, &podContainer, container, creationTime)
 
 		containers = append(containers, container)
 	}
@@ -115,7 +116,7 @@ func (l *KubeletListener) createPodService(
 
 func (l *KubeletListener) createContainerService(
 	pod *workloadmeta.KubernetesPod,
-	podContainer workloadmeta.OrchestratorContainer,
+	podContainer *workloadmeta.OrchestratorContainer,
 	container *workloadmeta.Container,
 	creationTime integration.CreationTime,
 ) {

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -72,7 +72,7 @@ func (l *KubeletListener) processPod(
 			continue
 		}
 
-		l.createContainerService(pod, container, creationTime)
+		l.createContainerService(pod, podContainer, container, creationTime)
 
 		containers = append(containers, container)
 	}
@@ -115,17 +115,18 @@ func (l *KubeletListener) createPodService(
 
 func (l *KubeletListener) createContainerService(
 	pod *workloadmeta.KubernetesPod,
+	podContainer workloadmeta.OrchestratorContainer,
 	container *workloadmeta.Container,
 	creationTime integration.CreationTime,
 ) {
-	containerImg := container.Image
+	containerImg := podContainer.Image
 	if l.IsExcluded(
 		containers.GlobalFilter,
 		container.Name,
 		containerImg.RawName,
 		pod.Namespace,
 	) {
-		log.Debugf("container %s filtered out: name %q image %q namespace %q", container.ID, container.Name, container.Image.RawName, pod.Namespace)
+		log.Debugf("container %s filtered out: name %q image %q namespace %q", container.ID, container.Name, containerImg.RawName, pod.Namespace)
 		return
 	}
 

--- a/pkg/autodiscovery/listeners/kubelet_test.go
+++ b/pkg/autodiscovery/listeners/kubelet_test.go
@@ -344,7 +344,12 @@ func TestKubeletCreateContainerService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			listener, wlm := newKubeletListener(t)
 
-			listener.createContainerService(tt.pod, tt.container, integration.After)
+			podContainer := workloadmeta.OrchestratorContainer{
+				ID:    tt.container.ID,
+				Image: tt.container.Image,
+			}
+
+			listener.createContainerService(tt.pod, podContainer, tt.container, integration.After)
 
 			wlm.assertServices(tt.expectedServices)
 		})

--- a/pkg/autodiscovery/listeners/kubelet_test.go
+++ b/pkg/autodiscovery/listeners/kubelet_test.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !serverless
 // +build !serverless
 
 package listeners
@@ -344,7 +345,7 @@ func TestKubeletCreateContainerService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			listener, wlm := newKubeletListener(t)
 
-			podContainer := workloadmeta.OrchestratorContainer{
+			podContainer := &workloadmeta.OrchestratorContainer{
 				ID:    tt.container.ID,
 				Image: tt.container.Image,
 			}

--- a/pkg/autodiscovery/providers/kubelet.go
+++ b/pkg/autodiscovery/providers/kubelet.go
@@ -155,7 +155,7 @@ func (k *KubeletConfigProvider) generateConfigs() ([]integration.Config, error) 
 		for _, podContainer := range pod.Containers {
 			container, err := k.workloadmetaStore.GetContainer(podContainer.ID)
 			if err != nil {
-				log.Debugf("pod %q has reference to non-existing container %q", pod.Name, podContainer.ID)
+				log.Debugf("Pod %q has reference to non-existing container %q", pod.Name, podContainer.ID)
 				continue
 			}
 


### PR DESCRIPTION
### What does this PR do?

This fixes two small issues in kubelet AD:

* The image name used as an AD identifier was coming from the container runtime instead of the pod spec, which can break when running alongside the containerd collector in workloadmeta.

* The kubelet config provider was generating bad AD identifiers from the container ID by omitting the container runtime prefix.

### Describe how to test your changes

These were both identified from end to end tests, so passing tests is enough QA. Besides, this area of code will already be under heavy scrutiny during QA due to a ton of other PRs ;)