### PR TITLE
[CWS] fix selinux tests cleanup

### DIFF
--- a/pkg/security/tests/selinux_test.go
+++ b/pkg/security/tests/selinux_test.go
@@ -55,9 +55,7 @@ func TestSELinux(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to save enforce status")
 	}
-	defer cleanAndWait(test, t, func() error {
-		return setEnforceStatus(currentEnforceStatus)
-	})
+	defer setEnforceStatus(currentEnforceStatus)
 
 	savedBoolValue, err := getBoolValue(TestBoolName)
 	if err != nil {
@@ -180,7 +178,9 @@ func TestSELinuxCommitBools(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to save bool state: %v", err)
 	}
-	defer setBoolValue(TestBoolName, savedBoolValue)
+	defer cleanAndWait(test, t, func() error {
+		return setBoolValue(TestBoolName, savedBoolValue)
+	})
 
 	t.Run("sel_commit_bools", func(t *testing.T) {
 		test.WaitSignal(t, func() error {

--- a/pkg/security/tests/selinux_test.go
+++ b/pkg/security/tests/selinux_test.go
@@ -55,9 +55,7 @@ func TestSELinux(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to save enforce status")
 	}
-	defer cleanAndWait(test, t, func() error {
-		return setEnforceStatus(currentEnforceStatus)
-	})
+	defer restoreEnforcementStatus(test, t, currentEnforceStatus)
 
 	savedBoolValue, err := getBoolValue(TestBoolName)
 	if err != nil {
@@ -287,6 +285,15 @@ func setEnforceStatus(status string) error {
 		return err
 	}
 	return nil
+}
+
+func restoreEnforcementStatus(test *testModule, t *testing.T, savedStatus string) {
+	current, err := getEnforceStatus()
+	if err != nil || current != savedStatus {
+		cleanAndWait(test, t, func() error {
+			return setEnforceStatus(savedStatus)
+		})
+	}
 }
 
 func cleanAndWait(test *testModule, t *testing.T, trigger func() error) {

--- a/pkg/security/tests/selinux_test.go
+++ b/pkg/security/tests/selinux_test.go
@@ -55,7 +55,9 @@ func TestSELinux(t *testing.T) {
 	if err != nil {
 		t.Errorf("failed to save enforce status")
 	}
-	defer setEnforceStatus(currentEnforceStatus)
+	defer cleanAndWait(test, t, func() error {
+		return setEnforceStatus(currentEnforceStatus)
+	})
 
 	savedBoolValue, err := getBoolValue(TestBoolName)
 	if err != nil {

--- a/pkg/security/tests/selinux_test.go
+++ b/pkg/security/tests/selinux_test.go
@@ -288,7 +288,8 @@ func setEnforceStatus(status string) error {
 }
 
 func cleanAndWait(test *testModule, t *testing.T, trigger func() error) {
-	test.WaitSignal(t, func() error {
+	// if there is no signal, then we continue nevertheless
+	_ = test.GetSignal(t, func() error {
 		if err := trigger(); err != nil {
 			t.Errorf("failed to cleanup: %v", err)
 		}


### PR DESCRIPTION
### What does this PR do?

Some of the `defer`s of the SELinux tests are doing some SELinux operations (to restore the state previous to the test runs). Those operations can trigger events matching the provided rules, potentially breaking following tests (especially the `SELinux` -> `Span` transition).

This PR fixes this issue by waiting for signals when doing the cleanup steps.

### Motivation

Fix test errors.

### Describe how to test your changes

This changes are only touching test internals.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
