### PR TITLE
[CWS] add runtime-settings support to security-agent

### DIFF
--- a/cmd/agent/app/config.go
+++ b/cmd/agent/app/config.go
@@ -14,6 +14,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/api/util"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	commonsettings "github.com/DataDog/datadog-agent/pkg/config/settings"
+	"github.com/spf13/cobra"
 
 	"github.com/fatih/color"
 )
@@ -41,7 +42,7 @@ func setupConfig() error {
 	return util.SetAuthToken()
 }
 
-func getSettingsClient() (commonsettings.Client, error) {
+func getSettingsClient(_ *cobra.Command, _ []string) (commonsettings.Client, error) {
 	err := setupConfig()
 	if err != nil {
 		return nil, err

--- a/cmd/agent/common/commands/config/config.go
+++ b/cmd/agent/common/commands/config/config.go
@@ -19,7 +19,7 @@ func Config(getClient settings.ClientBuilder) *cobra.Command {
 		Use:   "config",
 		Short: "Print the runtime configuration of a running agent",
 		Long:  ``,
-		RunE:  func(_ *cobra.Command, _ []string) error { return showRuntimeConfiguration(getClient) },
+		RunE:  func(cmd *cobra.Command, args []string) error { return showRuntimeConfiguration(getClient, cmd, args) },
 	}
 
 	cmd.AddCommand(listRuntime(getClient))
@@ -35,7 +35,9 @@ func listRuntime(getClient settings.ClientBuilder) *cobra.Command {
 		Use:   "list-runtime",
 		Short: "List settings that can be changed at runtime",
 		Long:  ``,
-		RunE:  func(_ *cobra.Command, _ []string) error { return listRuntimeConfigurableValue(getClient) },
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return listRuntimeConfigurableValue(getClient, cmd, args)
+		},
 	}
 }
 
@@ -45,7 +47,7 @@ func set(getClient settings.ClientBuilder) *cobra.Command {
 		Use:   "set [setting] [value]",
 		Short: "Set, for the current runtime, the value of a given configuration setting",
 		Long:  ``,
-		RunE:  func(_ *cobra.Command, args []string) error { return setConfigValue(getClient, args) },
+		RunE:  func(cmd *cobra.Command, args []string) error { return setConfigValue(getClient, cmd, args) },
 	}
 }
 
@@ -55,12 +57,12 @@ func get(getClient settings.ClientBuilder) *cobra.Command {
 		Use:   "get [setting]",
 		Short: "Get, for the current runtime, the value of a given configuration setting",
 		Long:  ``,
-		RunE:  func(_ *cobra.Command, args []string) error { return getConfigValue(getClient, args) },
+		RunE:  func(cmd *cobra.Command, args []string) error { return getConfigValue(getClient, cmd, args) },
 	}
 }
 
-func showRuntimeConfiguration(getClient settings.ClientBuilder) error {
-	c, err := getClient()
+func showRuntimeConfiguration(getClient settings.ClientBuilder, cmd *cobra.Command, args []string) error {
+	c, err := getClient(cmd, args)
 	if err != nil {
 		return err
 	}
@@ -75,8 +77,8 @@ func showRuntimeConfiguration(getClient settings.ClientBuilder) error {
 	return nil
 }
 
-func listRuntimeConfigurableValue(getClient settings.ClientBuilder) error {
-	c, err := getClient()
+func listRuntimeConfigurableValue(getClient settings.ClientBuilder, cmd *cobra.Command, args []string) error {
+	c, err := getClient(cmd, args)
 	if err != nil {
 		return err
 	}
@@ -96,12 +98,12 @@ func listRuntimeConfigurableValue(getClient settings.ClientBuilder) error {
 	return nil
 }
 
-func setConfigValue(getClient settings.ClientBuilder, args []string) error {
+func setConfigValue(getClient settings.ClientBuilder, cmd *cobra.Command, args []string) error {
 	if len(args) != 2 {
 		return fmt.Errorf("exactly two parameters are required: the setting name and its value")
 	}
 
-	c, err := getClient()
+	c, err := getClient(cmd, args)
 	if err != nil {
 		return err
 	}
@@ -120,12 +122,12 @@ func setConfigValue(getClient settings.ClientBuilder, args []string) error {
 	return nil
 }
 
-func getConfigValue(getClient settings.ClientBuilder, args []string) error {
+func getConfigValue(getClient settings.ClientBuilder, cmd *cobra.Command, args []string) error {
 	if len(args) != 1 {
 		return fmt.Errorf("a single setting name must be specified")
 	}
 
-	c, err := getClient()
+	c, err := getClient(cmd, args)
 	if err != nil {
 		return err
 	}

--- a/cmd/cluster-agent/app/config.go
+++ b/cmd/cluster-agent/app/config.go
@@ -18,6 +18,7 @@ import (
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
 
 	"github.com/fatih/color"
+	"github.com/spf13/cobra"
 )
 
 func init() {
@@ -45,7 +46,7 @@ func setupConfig() error {
 	return util.SetAuthToken()
 }
 
-func getSettingsClient() (commonsettings.Client, error) {
+func getSettingsClient(_ *cobra.Command, _ []string) (commonsettings.Client, error) {
 	err := setupConfig()
 	if err != nil {
 		return nil, err

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -71,7 +71,7 @@ var (
 	configCommand = cmdconfig.Config(getSettingsClient)
 )
 
-func getSettingsClient() (settings.Client, error) {
+func getSettingsClient(_ *cobra.Command, _ []string) (settings.Client, error) {
 	// Set up the config so we can get the port later
 	// We set this up differently from the main process-agent because this way is quieter
 	cfg := config.NewDefaultAgentConfig(false)

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -28,6 +28,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/security-agent/common"
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/config/resolver"
+	"github.com/DataDog/datadog-agent/pkg/config/settings"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/logs/client"
 	logshttp "github.com/DataDog/datadog-agent/pkg/logs/client/http"
@@ -280,6 +281,10 @@ func RunAgent(ctx context.Context) (err error) {
 		return err
 	}
 
+	if err = initRuntimeSettings(); err != nil {
+		return err
+	}
+
 	// start runtime security agent
 	runtimeAgent, err := startRuntimeSecurity(hostname, stopper, statsdClient)
 	if err != nil {
@@ -298,6 +303,10 @@ func RunAgent(ctx context.Context) (err error) {
 	log.Infof("Datadog Security Agent is now running.")
 
 	return
+}
+
+func initRuntimeSettings() error {
+	return settings.RegisterRuntimeSetting(settings.LogLevelRuntimeSetting{})
 }
 
 // handleSignals handles OS signals, and sends a message on stopCh when an interrupt

--- a/cmd/system-probe/app/config.go
+++ b/cmd/system-probe/app/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config/settings"
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
 	"github.com/fatih/color"
+	"github.com/spf13/cobra"
 )
 
 func init() {
@@ -40,7 +41,7 @@ func setupConfig() (*config.Config, error) {
 	return cfg, nil
 }
 
-func getSettingsClient() (settings.Client, error) {
+func getSettingsClient(cmd *cobra.Command, _ []string) (settings.Client, error) {
 	cfg, err := setupConfig()
 	if err != nil {
 		return nil, err

--- a/pkg/config/settings/api.go
+++ b/pkg/config/settings/api.go
@@ -1,5 +1,7 @@
 package settings
 
+import "github.com/spf13/cobra"
+
 // Client is the interface for interacting with the runtime settings API
 type Client interface {
 	Get(key string) (interface{}, error)
@@ -9,4 +11,4 @@ type Client interface {
 }
 
 // ClientBuilder represents a function returning a runtime settings API client
-type ClientBuilder func() (Client, error)
+type ClientBuilder func(_ *cobra.Command, _ []string) (Client, error)

--- a/releasenotes/notes/security-agent-runtime-settings-d764cbfaa6f77aca.yaml
+++ b/releasenotes/notes/security-agent-runtime-settings-d764cbfaa6f77aca.yaml
@@ -1,0 +1,4 @@
+features:
+  - |
+    Add runtime settings support to the security-agent. Currenlty only the log-level
+    is supported.


### PR DESCRIPTION
### What does this PR do?

Add runtime settings support. Currently only the log-level is configurable.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
