### PR TITLE
system-probe use common runtime settings helpers

### DIFF
--- a/cmd/system-probe/app/config.go
+++ b/cmd/system-probe/app/config.go
@@ -8,48 +8,18 @@ package app
 import (
 	"fmt"
 
+	cmdconfig "github.com/DataDog/datadog-agent/cmd/agent/common/commands/config"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/config/settings"
 	settingshttp "github.com/DataDog/datadog-agent/pkg/config/settings/http"
 	"github.com/fatih/color"
-	"github.com/spf13/cobra"
 )
 
 func init() {
-	SysprobeCmd.AddCommand(configCommand)
-	configCommand.AddCommand(listRuntimeCommand)
-	configCommand.AddCommand(setCommand)
-	configCommand.AddCommand(getCommand)
+	SysprobeCmd.AddCommand(cmdconfig.Config(getSettingsClient))
 }
-
-var (
-	configCommand = &cobra.Command{
-		Use:   "config",
-		Short: "Print the runtime configuration of a running system-probe",
-		Long:  ``,
-		RunE:  showRuntimeConfiguration,
-	}
-	listRuntimeCommand = &cobra.Command{
-		Use:   "list-runtime",
-		Short: "List settings that can be changed at runtime",
-		Long:  ``,
-		RunE:  listRuntimeConfigurableValue,
-	}
-	setCommand = &cobra.Command{
-		Use:   "set [setting] [value]",
-		Short: "Set, for the current runtime, the value of a given configuration setting",
-		Long:  ``,
-		RunE:  setConfigValue,
-	}
-	getCommand = &cobra.Command{
-		Use:   "get [setting]",
-		Short: "Get, for the current runtime, the value of a given configuration setting",
-		Long:  ``,
-		RunE:  getConfigValue,
-	}
-)
 
 func setupConfig() (*config.Config, error) {
 	if flagNoColor {
@@ -70,40 +40,6 @@ func setupConfig() (*config.Config, error) {
 	return cfg, nil
 }
 
-func showRuntimeConfiguration(_ *cobra.Command, _ []string) error {
-	c, err := getSettingsClient()
-	if err != nil {
-		return err
-	}
-	runtimeConfig, err := c.FullConfig()
-	if err != nil {
-		return err
-	}
-
-	fmt.Println(runtimeConfig)
-	return nil
-}
-
-func listRuntimeConfigurableValue(_ *cobra.Command, _ []string) error {
-	c, err := getSettingsClient()
-	if err != nil {
-		return err
-	}
-
-	settingsList, err := c.List()
-	if err != nil {
-		return err
-	}
-
-	fmt.Println("=== Settings that can be changed at runtime ===")
-	for setting, details := range settingsList {
-		if !details.Hidden {
-			fmt.Printf("%-30s %s\n", setting, details.Description)
-		}
-	}
-	return nil
-}
-
 func getSettingsClient() (settings.Client, error) {
 	cfg, err := setupConfig()
 	if err != nil {
@@ -111,44 +47,6 @@ func getSettingsClient() (settings.Client, error) {
 	}
 	hc := api.GetClient(cfg.SocketAddress)
 	return settingshttp.NewClient(hc, "http://localhost/config", "system-probe"), nil
-}
-
-func setConfigValue(_ *cobra.Command, args []string) error {
-	if len(args) != 2 {
-		return fmt.Errorf("Exactly two parameters are required: the setting name and its value")
-	}
-	c, err := getSettingsClient()
-	if err != nil {
-		return err
-	}
-
-	hidden, err := c.Set(args[0], args[1])
-	if err != nil {
-		return err
-	}
-	if hidden {
-		fmt.Printf("IMPORTANT: you have modified a hidden option, this may incur billing charges or have other unexpected side-effects.\n")
-	}
-	fmt.Printf("Configuration setting %s is now set to: %s\n", args[0], args[1])
-	return nil
-}
-
-func getConfigValue(_ *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return fmt.Errorf("A single setting name must be specified")
-	}
-
-	c, err := getSettingsClient()
-	if err != nil {
-		return err
-	}
-	value, err := c.Get(args[0])
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("%s is set to: %v\n", args[0], value)
-	return nil
 }
 
 // initRuntimeSettings builds the map of runtime settings configurable at runtime.


### PR DESCRIPTION
### What does this PR do?

Make use of common runtime settings helpers.

### Motivation

What inspired you to submit this pull request?

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
