### PR TITLE
[CWS] add check so that event are not propagated if from the wrong ruleset

### DIFF
--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -400,7 +400,7 @@ func (m *Module) HandleCustomEvent(rule *rules.Rule, event *sprobe.CustomEvent) 
 }
 
 // RuleMatch is called by the ruleset when a rule matches
-func (m *Module) RuleMatch(rule *rules.Rule, event eval.Event) {
+func (m *Module) RuleMatch(rule *rules.Rule, ruleSet *rules.RuleSet, event eval.Event) {
 	// prepare the event
 	m.probe.OnRuleMatch(rule, event.(*sprobe.Event))
 

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -63,7 +63,7 @@ type Rule struct {
 // RuleSetListener describes the methods implemented by an object used to be
 // notified of events on a rule set.
 type RuleSetListener interface {
-	RuleMatch(rule *Rule, event eval.Event)
+	RuleMatch(rule *Rule, ruleSet *RuleSet, event eval.Event)
 	EventDiscarderFound(rs *RuleSet, event eval.Event, field eval.Field, eventType eval.EventType)
 }
 
@@ -268,7 +268,7 @@ func (rs *RuleSet) AddRule(ruleDef *RuleDefinition) (*eval.Rule, error) {
 // NotifyRuleMatch notifies all the ruleset listeners that an event matched a rule
 func (rs *RuleSet) NotifyRuleMatch(rule *Rule, event eval.Event) {
 	for _, listener := range rs.listeners {
-		listener.RuleMatch(rule, event)
+		listener.RuleMatch(rule, rs, event)
 	}
 }
 
@@ -458,16 +458,6 @@ func (rs *RuleSet) generatePartials() error {
 // AddPolicyVersion adds the provided policy filename and version to the map of loaded policies
 func (rs *RuleSet) AddPolicyVersion(filename string, version string) {
 	rs.loadedPolicies[strings.ReplaceAll(filename, ".", "_")] = version
-}
-
-// ContainsRule check if the rule is contained in the rule set
-func (rs *RuleSet) ContainsRule(rule *Rule) bool {
-	for _, rsRule := range rs.rules {
-		if rsRule == rule {
-			return true
-		}
-	}
-	return false
 }
 
 // NewRuleSet returns a new ruleset for the specified data model

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -460,6 +460,16 @@ func (rs *RuleSet) AddPolicyVersion(filename string, version string) {
 	rs.loadedPolicies[strings.ReplaceAll(filename, ".", "_")] = version
 }
 
+// ContainsRule check if the rule is contained in the rule set
+func (rs *RuleSet) ContainsRule(rule *Rule) bool {
+	for _, rsRule := range rs.rules {
+		if rsRule == rule {
+			return true
+		}
+	}
+	return false
+}
+
 // NewRuleSet returns a new ruleset for the specified data model
 func NewRuleSet(model eval.Model, eventCtor func() eval.Event, opts *Opts) *RuleSet {
 	return &RuleSet{

--- a/pkg/security/secl/rules/ruleset_test.go
+++ b/pkg/security/secl/rules/ruleset_test.go
@@ -22,7 +22,7 @@ type testHandler struct {
 	filters map[string]testFieldValues
 }
 
-func (f *testHandler) RuleMatch(rule *Rule, event eval.Event) {
+func (f *testHandler) RuleMatch(rule *Rule, ruleSet *RuleSet, event eval.Event) {
 }
 
 func (f *testHandler) EventDiscarderFound(rs *RuleSet, event eval.Event, field string, eventType eval.EventType) {

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -531,8 +531,8 @@ func (tm *testModule) SwapLogLevel(logLevel seelog.LogLevel) (seelog.LogLevel, e
 	return tm.st.swapLogLevel(logLevel)
 }
 
-func (tm *testModule) RuleMatch(rule *rules.Rule, event eval.Event) {
-	if !tm.module.GetRuleSet().ContainsRule(rule) {
+func (tm *testModule) RuleMatch(rule *rules.Rule, ruleSet *rules.RuleSet, event eval.Event) {
+	if tm.module.GetRuleSet() != ruleSet {
 		return
 	}
 

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -532,6 +532,10 @@ func (tm *testModule) SwapLogLevel(logLevel seelog.LogLevel) (seelog.LogLevel, e
 }
 
 func (tm *testModule) RuleMatch(rule *rules.Rule, event eval.Event) {
+	if !tm.module.GetRuleSet().ContainsRule(rule) {
+		return
+	}
+
 	tm.ruleHandler.RLock()
 	callback := tm.ruleHandler.callback
 	tm.ruleHandler.RUnlock()


### PR DESCRIPTION
### What does this PR do?

This PR adds a check (for functional tests only) to ensure that we only send event with rules contained in the current ruleset.

### Motivation

Fix some flakyness in the tests (`TestSELinux` -> `TestSpan` mainly).

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
