### PR TITLE
[install script] Exclude patch version when comparing minor

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -509,11 +509,13 @@ elif [ "$OS" = "SUSE" ]; then
   
   echo -e "\033[34m\n* Installing Datadog Agent\n\033[0m"
 
+  # remove the patch version if the minor version includes it (eg: 33.1 -> 33)
+  agent_minor_version_without_patch="${agent_minor_version%.*}"
   # ".32" is the latest version supported for OpenSUSE < 15 and SLES < 12
   # we explicitly test for SUSE11 = "yes", as some SUSE11 don't have /etc/os-release, thus SUSE_VER is empty
   if [ "$DISTRIBUTION" == "openSUSE" ] && { [ "$SUSE11" == "yes" ] || [ "$SUSE_VER" -lt 15 ]; }; then
-      if [ -n "$agent_minor_version" ]; then
-          if [ "$agent_minor_version" -ge "33" ]; then
+      if [ -n "$agent_minor_version_without_patch" ]; then
+          if [ "$agent_minor_version_without_patch" -ge "33" ]; then
               printf "\033[31mopenSUSE < 15 only supports Agent %s up to %s.32.\033[0m\n" "$agent_major_version" "$agent_major_version"
               exit;
           fi
@@ -525,8 +527,8 @@ elif [ "$OS" = "SUSE" ]; then
       fi
   fi
   if [ "$DISTRIBUTION" == "SUSE" ] && { [ "$SUSE11" == "yes" ] || [ "$SUSE_VER" -lt 12 ]; }; then
-      if [ -n "$agent_minor_version" ]; then
-          if [ "$agent_minor_version" -ge "33" ]; then
+      if [ -n "$agent_minor_version_without_patch" ]; then
+          if [ "$agent_minor_version_without_patch" -ge "33" ]; then
               printf "\033[31mSLES < 12 only supports Agent %s up to %s.32.\033[0m\n" "$agent_major_version" "$agent_major_version"
               exit;
           fi


### PR DESCRIPTION
### What does this PR do?

Compare only the first part of the string before the dot.

### Motivation

The previous code would print an "integer expression expected" error if
DD_AGENT_MINOR_VERSION included the patch version, eg: 33.1
