### PR TITLE
[github] Update the pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,30 @@
 ### What does this PR do?
 
+<!--
 A brief description of the change being made with this pull request.
+-->
 
 ### Motivation
 
+<!--
 What inspired you to submit this pull request?
+-->
 
 ### Additional Notes
 
+<!--
 Anything else we should know when reviewing?
+-->
 
-### Describe how to test your changes
+### Describe how to test/QA your changes
 
-Write here in detail how you have tested your changes
-and instructions on how this should be tested in QA.
+<!--
+Write here in detail how you have tested your changes and instructions on how
+this should be tested in QA.
 
-Describe or link instructions to set up environment 
-for testing, if the process requires more than just
-running the agent on one of the supported platforms.
+Describe or link instructions to set up environment for testing, if the process
+requires more than just running the agent on one of the supported platforms.
+-->
 
 ### Checklist
 <!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -62,6 +62,6 @@ Note: Adding GitHub labels is only possible for contributors with write access.
 - [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
 - [ ] If applicable, docs team has been notified or
   [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
-- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels has been applied.
+- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
 - [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml)
   has been updated.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,7 +21,7 @@
 
 <!--
 * What inspired you to submit this pull request?
-* Link any related GitHub issues here.
+* Link any related GitHub issues or PRs here.
 -->
 
 ### Additional Notes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,57 +1,67 @@
 <!--
-Requirements for contributing to this repository:
-
-* Fill out the template below. Any pull request that does not include enough
-  information to be reviewed in a timely manner may be closed at thei
-  maintainers' discretion.
-* The pull request should only fix one issue, or add one feature, at the time.
-* The pull request must update the test suite to demonstrate the changedi
-  functionality.
-* After you create the pull request, all status checks must be pass before a
-  maintainer reviews your contribution. For more details, please see
-  [CONTRIBUTING](/CONTRIBUTING.md).
+* New contributors are highly encouraged to read our
+  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
+* The pull request:
+  * Should only fix one issue or add one feature at a time.
+  * Must update the test suite for the relevant functionality.
+  * Should pass all status checks before being reviewed or merged.
+* Commit titles should be prefixed with general area of pull request's change.
+* Draft PRs should be prefixed with `[WIP]` in their title.
 
 -->
 ### What does this PR do?
 
 <!--
-A brief description of the change being made with this pull request.
+* A brief description of the change being made with this pull request.
+* If the description here cannot be expressed in a succint form, consider
+  opening multiple pull requests instead of a single one.
 -->
 
 ### Motivation
 
 <!--
-What inspired you to submit this pull request?
+* What inspired you to submit this pull request?
+* Link any related GitHub issues here.
 -->
 
 ### Additional Notes
 
 <!--
-Anything else we should know when reviewing?
+* Anything else we should know when reviewing?
+* Include benchmarking information here whenever possible.
+* Include info about alternatives that were considered and why the proposed
+  version was chosen.
+-->
+
+### Possible Drawbacks
+
+<!--
+* What are the possible side-effects or negative impacts of the code change?
 -->
 
 ### Describe how to test/QA your changes
 
 <!--
-Write here in detail how you have tested your changes and instructions on how
-this should be tested in QA.
-
-Describe or link instructions to set up environment for testing, if the process
-requires more than just running the agent on one of the supported platforms.
+* Write here in detail or link to detailed instructions on how this change can
+  be tested/QAd/validated, including any environment setup.
 -->
 
 ### Reviewer's Checklist
 <!--
-Authors can use this list as a reference to ensure that there are no problems
-during the review but the signing off on the list is to be done by the
-reviewer(s).
+* Authors can use this list as a reference to ensure that there are no problems
+  during the review but the signing off is to be done by the reviewer(s).
 
 Note: Adding GitHub labels is only possible for contributors with write access.
 -->
 
-- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
-- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
-- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
-- [ ] The appropriate `team/..` label has been applied, if known.
 - [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
-- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
+- [ ] The appropriate `team/..` label has been applied, if known.
+- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno)
+  has been added or the `changelog/no-changelog` label has been applied.
+- [ ] Changed code has automated tests for its functionality.
+- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
+- [ ] If applicable, docs team has been notified or
+  [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
+- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels has been applied.
+- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml)
+  has been updated.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -33,7 +33,7 @@
   version was chosen.
 -->
 
-### Possible Drawbacks
+### Possible Drawbacks / Trade-offs
 
 <!--
 * What are the possible side-effects or negative impacts of the code change?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,13 +40,18 @@ Describe or link instructions to set up environment for testing, if the process
 requires more than just running the agent on one of the supported platforms.
 -->
 
-### Checklist
-<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->
+### Reviewer's Checklist
+<!--
+Authors can use this list as a reference to ensure that there are no problems
+during the review but the signing off on the list is to be done by the
+reviewer(s).
+
+Note: Adding GitHub labels is only possible for contributors with write access.
+-->
 
 - [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
 - [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
+- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
 - [ ] The appropriate `team/..` label has been applied, if known.
 - [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
 - [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.
-
-Note: Adding GitHub labels is only possible for contributors with write access.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,17 @@
+<!--
+Requirements for contributing to this repository:
+
+* Fill out the template below. Any pull request that does not include enough
+  information to be reviewed in a timely manner may be closed at thei
+  maintainers' discretion.
+* The pull request should only fix one issue, or add one feature, at the time.
+* The pull request must update the test suite to demonstrate the changedi
+  functionality.
+* After you create the pull request, all status checks must be pass before a
+  maintainer reviews your contribution. For more details, please see
+  [CONTRIBUTING](/CONTRIBUTING.md).
+
+-->
 ### What does this PR do?
 
 <!--


### PR DESCRIPTION
### What does this PR do?

Updates the PR template for GitHub:
- Old template suggestions were moved to invisible comments
- Additional information was added about how to fill each section
- Additional sections were added as needed
- Checklist has ben updated with:
  - The new items and the order of precedence
  - Wording to indicate that its use is primarily for the reviewer

### Motivation

The current PR template has been inadequate as the template
was usually not filled out, leading to problems QAing/verifying
patches along with not having clearer guidelines for the reviewer. 

When no information has been filled in, the new template makes it obvious when content is missing:

<hr />
 
 <img width="715" alt="Screen Shot 2021-11-05 at 2 13 58 PM" src="https://user-images.githubusercontent.com/175811/140566129-568020d9-9808-4c4e-8b2a-bdd3326e691a.png">

<hr />

### Additional Notes

N/A

### Describe how to test your changes

N/A

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
