### PR TITLE
Most of AD is owned by container-integrations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -146,7 +146,7 @@
 /pkg/autodiscovery/listeners/cloudfoundry*.go  @DataDog/integrations-tools-and-libraries
 /pkg/autodiscovery/listeners/snmp*.go   @DataDog/infrastructure-integrations
 /pkg/autodiscovery/providers/           @DataDog/container-integrations
-/pkg/autodiscovery/providers/file*.go   @DataDog/container-integrations @DataDog/agent-core
+/pkg/autodiscovery/providers/file*.go   @DataDog/agent-core
 /pkg/autodiscovery/providers/cloudfoundry*.go  @DataDog/integrations-tools-and-libraries
 /pkg/clusteragent/                      @DataDog/container-integrations
 /pkg/clusteragent/orchestrator/         @DataDog/container-app

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -145,6 +145,8 @@
 /pkg/autodiscovery/listeners/           @DataDog/container-integrations
 /pkg/autodiscovery/listeners/cloudfoundry*.go  @DataDog/integrations-tools-and-libraries
 /pkg/autodiscovery/listeners/snmp*.go   @DataDog/infrastructure-integrations
+/pkg/autodiscovery/providers/           @DataDog/container-integrations
+/pkg/autodiscovery/providers/file*.go   @DataDog/container-integrations @DataDog/agent-core
 /pkg/autodiscovery/providers/cloudfoundry*.go  @DataDog/integrations-tools-and-libraries
 /pkg/clusteragent/                      @DataDog/container-integrations
 /pkg/clusteragent/orchestrator/         @DataDog/container-app


### PR DESCRIPTION
..with the exception of the file provider.

### Motivation

PRs for which agent-core review isn't really required.

