### PR TITLE
Fix deadlock in WeightedQueue

### DIFF
--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -225,6 +225,13 @@ func (l *Collector) run(exit chan struct{}) error {
 	l.rtProcessResults = api.NewWeightedQueue(l.cfg.RTQueueSize, int64(l.cfg.ProcessQueueBytes))
 	l.podResults = api.NewWeightedQueue(l.cfg.QueueSize, int64(l.cfg.Orchestrator.PodQueueBytes))
 
+	go func() {
+		<-exit
+		l.processResults.Stop()
+		l.rtProcessResults.Stop()
+		l.podResults.Stop()
+	}()
+
 	var wg sync.WaitGroup
 
 	wg.Add(1)
@@ -293,19 +300,19 @@ func (l *Collector) run(exit chan struct{}) error {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		l.consumePayloads(l.processResults, processForwarder, exit)
+		l.consumePayloads(l.processResults, processForwarder)
 	}()
 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		l.consumePayloads(l.rtProcessResults, rtProcessForwarder, exit)
+		l.consumePayloads(l.rtProcessResults, rtProcessForwarder)
 	}()
 
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		l.consumePayloads(l.podResults, podForwarder, exit)
+		l.consumePayloads(l.podResults, podForwarder)
 	}()
 
 	for _, c := range l.enabledChecks {
@@ -395,10 +402,10 @@ func (l *Collector) basicRunner(c checks.Check, results *api.WeightedQueue, exit
 	}
 }
 
-func (l *Collector) consumePayloads(results *api.WeightedQueue, fwd forwarder.Forwarder, exit chan struct{}) {
+func (l *Collector) consumePayloads(results *api.WeightedQueue, fwd forwarder.Forwarder) {
 	for {
-		// results.Poll() will block until either `exit` is closed, or an item is available on the queue (a check run occurs and adds data)
-		item, ok := results.Poll(exit)
+		// results.Poll() will return ok=false when stopped
+		item, ok := results.Poll()
 		if !ok {
 			return
 		}

--- a/pkg/process/util/api/weighted_queue.go
+++ b/pkg/process/util/api/weighted_queue.go
@@ -35,10 +35,14 @@ type WeightedQueue struct {
 
 	// Guards the mutable internal state for the queue
 	mu sync.Mutex
+	// Signalled when data is added to queue or when the instance is stopped
+	cv *sync.Cond
 	// guarded by: mu
 	queue *list.List
 	// guarded by: mu
 	currentWeight int64
+	// guarded by: mu
+	stop bool
 
 	maxSize   int
 	maxWeight int64
@@ -46,13 +50,16 @@ type WeightedQueue struct {
 
 // NewWeightedQueue returns a new WeightedQueue with the given maximum size & weight
 func NewWeightedQueue(maxSize int, maxWeight int64) *WeightedQueue {
-	return &WeightedQueue{
-		dataAvailable: make(chan struct{}),
+	q := &WeightedQueue{
+		dataAvailable: make(chan struct{}, 1),
 		queue:         list.New(),
 		maxSize:       maxSize,
 		maxWeight:     maxWeight,
 		currentWeight: 0,
+		stop:          false,
 	}
+	q.cv = sync.NewCond(&q.mu)
+	return q
 }
 
 // Len returns the number of items in the queue
@@ -69,41 +76,29 @@ func (q *WeightedQueue) Weight() int64 {
 	return q.currentWeight
 }
 
-// Poll retrieves the head of the queue or blocks until an item is available.  The provided exit channel can be closed
-// to interrupt the blocking operation.  Returns the head of the queue and true or nil, false if the poll was
-// interrupted by the closing of the exit channel
-func (q *WeightedQueue) Poll(exit chan struct{}) (WeightedItem, bool) {
-	for {
-		select {
-		case <-exit:
-			return nil, false
-		default:
+// Poll retrieves the head of the queue or blocks until an item is available or
+// the WeightedQueue is stopped.  Returns the head of the queue and true or
+// nil, false if the WeightedQueue is stopped.
+func (q *WeightedQueue) Poll() (WeightedItem, bool) {
+	q.mu.Lock()
 
-		}
-
-		q.mu.Lock()
-
-		// If the queue is empty, wait for a signal on the dataAvailable channel
-		if q.queue.Len() == 0 {
-			q.mu.Unlock()
-
-			select {
-			case <-q.dataAvailable:
-				continue
-			case <-exit:
-				return nil, false
-			}
-		}
-
-		e := q.queue.Front()
-		item := e.Value.(WeightedItem)
-		q.queue.Remove(e)
-		q.currentWeight -= item.Weight()
-
-		q.mu.Unlock()
-
-		return item, true
+	// If the queue is empty and we aren't stopped, wait for a signal
+	for q.queue.Len() == 0 && !q.stop {
+		q.cv.Wait()
 	}
+
+	if q.stop {
+		return nil, false
+	}
+
+	e := q.queue.Front()
+	item := e.Value.(WeightedItem)
+	q.queue.Remove(e)
+	q.currentWeight -= item.Weight()
+
+	q.mu.Unlock()
+
+	return item, true
 }
 
 // Add adds the item to the queue.
@@ -168,12 +163,17 @@ func (q *WeightedQueue) Add(item WeightedItem) {
 
 	q.queue.PushBack(item)
 
-	// Send a signal on the dataAvailable channel if needed
-	select {
-	case q.dataAvailable <- struct{}{}:
-	default:
+	// Send a signal that data is available
+	q.cv.Signal()
+}
 
-	}
+// Stop stops the WeightedQueue instance.  Any calls to Poll concurrent with or
+// after the call to Stop will return (nil, false) immediately.
+func (q *WeightedQueue) Stop() {
+	q.mu.Lock()
+	q.stop = true
+	q.cv.Signal()
+	q.mu.Unlock()
 }
 
 func (q *WeightedQueue) iterator() *iterator {

--- a/pkg/process/util/api/weighted_queue.go
+++ b/pkg/process/util/api/weighted_queue.go
@@ -81,6 +81,7 @@ func (q *WeightedQueue) Weight() int64 {
 // nil, false if the WeightedQueue is stopped.
 func (q *WeightedQueue) Poll() (WeightedItem, bool) {
 	q.mu.Lock()
+	defer q.mu.Unlock()
 
 	// If the queue is empty and we aren't stopped, wait for a signal
 	for q.queue.Len() == 0 && !q.stop {
@@ -95,8 +96,6 @@ func (q *WeightedQueue) Poll() (WeightedItem, bool) {
 	item := e.Value.(WeightedItem)
 	q.queue.Remove(e)
 	q.currentWeight -= item.Weight()
-
-	q.mu.Unlock()
 
 	return item, true
 }

--- a/pkg/process/util/api/weighted_queue.go
+++ b/pkg/process/util/api/weighted_queue.go
@@ -171,7 +171,8 @@ func (q *WeightedQueue) Add(item WeightedItem) {
 func (q *WeightedQueue) Stop() {
 	q.mu.Lock()
 	q.stop = true
-	q.cv.Signal()
+	// broadcast to all pending Poll operations
+	q.cv.Broadcast()
 	q.mu.Unlock()
 }
 

--- a/pkg/process/util/api/weighted_queue_test.go
+++ b/pkg/process/util/api/weighted_queue_test.go
@@ -11,7 +11,6 @@ import (
 
 func TestWeightedQueue(t *testing.T) {
 	q := NewWeightedQueue(10, math.MaxInt64)
-	exit := make(chan struct{})
 
 	var wg sync.WaitGroup
 	wg.Add(1)
@@ -19,7 +18,7 @@ func TestWeightedQueue(t *testing.T) {
 		defer wg.Done()
 
 		for i := 0; i < 10; i++ {
-			item, ok := q.Poll(exit)
+			item, ok := q.Poll()
 
 			assert.True(t, ok)
 			assert.Equal(t, "item", item.Type())
@@ -36,28 +35,26 @@ func TestWeightedQueue(t *testing.T) {
 
 func TestWeightedQueuePollInterrupt(t *testing.T) {
 	q := NewWeightedQueue(3, math.MaxInt64)
-	exit := make(chan struct{})
 
 	go func() {
 		time.Sleep(500 * time.Millisecond)
-		close(exit)
+		q.Stop()
 	}()
 
-	item, ok := q.Poll(exit)
+	item, ok := q.Poll()
 	assert.False(t, ok)
 	assert.Nil(t, item)
 }
 
 func TestWeightedQueuePollBlocking(t *testing.T) {
 	q := NewWeightedQueue(3, math.MaxInt64)
-	exit := make(chan struct{})
 
 	go func() {
 		time.Sleep(500 * time.Millisecond)
 		q.Add(newItem("item", 1))
 	}()
 
-	item, ok := q.Poll(exit)
+	item, ok := q.Poll()
 	assert.True(t, ok)
 	assert.Equal(t, "item", item.Type())
 	assert.Equal(t, int64(1), item.Weight())
@@ -65,23 +62,22 @@ func TestWeightedQueuePollBlocking(t *testing.T) {
 
 func TestWeightedQueueItemsEvicted(t *testing.T) {
 	q := NewWeightedQueue(3, math.MaxInt64)
-	exit := make(chan struct{})
 
 	q.Add(newItem("item", 1))
 	q.Add(newItem("item", 2))
 	q.Add(newItem("item", 3))
 	q.Add(newItem("item", 4))
 
-	item, ok := q.Poll(exit)
+	item, ok := q.Poll()
 	assert.True(t, ok)
 	assert.Equal(t, "item", item.Type())
 	assert.Equal(t, int64(2), item.Weight())
 
-	item, ok = q.Poll(exit)
+	item, ok = q.Poll()
 	assert.True(t, ok)
 	assert.Equal(t, int64(3), item.Weight())
 
-	item, ok = q.Poll(exit)
+	item, ok = q.Poll()
 	assert.True(t, ok)
 	assert.Equal(t, int64(4), item.Weight())
 
@@ -91,24 +87,23 @@ func TestWeightedQueueItemsEvicted(t *testing.T) {
 
 func TestWeightedQueueItemsEvictedByType(t *testing.T) {
 	q := NewWeightedQueue(3, math.MaxInt64)
-	exit := make(chan struct{})
 
 	q.Add(newItem("item1", 1))
 	q.Add(newItem("item2", 2))
 	q.Add(newItem("item1", 3))
 	q.Add(newItem("item2", 4))
 
-	item, ok := q.Poll(exit)
+	item, ok := q.Poll()
 	assert.True(t, ok)
 	assert.Equal(t, "item1", item.Type())
 	assert.Equal(t, int64(1), item.Weight())
 
-	item, ok = q.Poll(exit)
+	item, ok = q.Poll()
 	assert.True(t, ok)
 	assert.Equal(t, "item1", item.Type())
 	assert.Equal(t, int64(3), item.Weight())
 
-	item, ok = q.Poll(exit)
+	item, ok = q.Poll()
 	assert.True(t, ok)
 	assert.Equal(t, "item2", item.Type())
 	assert.Equal(t, int64(4), item.Weight())
@@ -118,24 +113,23 @@ func TestWeightedQueueItemsEvictedByType(t *testing.T) {
 
 func TestWeightedQueueItemsEvictedFromHead(t *testing.T) {
 	q := NewWeightedQueue(3, math.MaxInt64)
-	exit := make(chan struct{})
 
 	q.Add(newItem("item", 1))
 	q.Add(newItem("item", 2))
 	q.Add(newItem("item", 3))
 	q.Add(newItem("item-new", 4))
 
-	item, ok := q.Poll(exit)
+	item, ok := q.Poll()
 	assert.True(t, ok)
 	assert.Equal(t, "item", item.Type())
 	assert.Equal(t, int64(2), item.Weight())
 
-	item, ok = q.Poll(exit)
+	item, ok = q.Poll()
 	assert.True(t, ok)
 	assert.Equal(t, "item", item.Type())
 	assert.Equal(t, int64(3), item.Weight())
 
-	item, ok = q.Poll(exit)
+	item, ok = q.Poll()
 	assert.True(t, ok)
 	assert.Equal(t, "item-new", item.Type())
 	assert.Equal(t, int64(4), item.Weight())
@@ -146,24 +140,23 @@ func TestWeightedQueueItemsEvictedFromHead(t *testing.T) {
 
 func TestWeightedQueueItemsEvictedByTypeForWeight(t *testing.T) {
 	q := NewWeightedQueue(100, 10)
-	exit := make(chan struct{})
 
 	q.Add(newItem("item1", 1))
 	q.Add(newItem("item2", 7))
 	q.Add(newItem("item1", 2))
 	q.Add(newItem("item2", 4))
 
-	item, ok := q.Poll(exit)
+	item, ok := q.Poll()
 	assert.True(t, ok)
 	assert.Equal(t, "item1", item.Type())
 	assert.Equal(t, int64(1), item.Weight())
 
-	item, ok = q.Poll(exit)
+	item, ok = q.Poll()
 	assert.True(t, ok)
 	assert.Equal(t, "item1", item.Type())
 	assert.Equal(t, int64(2), item.Weight())
 
-	item, ok = q.Poll(exit)
+	item, ok = q.Poll()
 	assert.True(t, ok)
 	assert.Equal(t, "item2", item.Type())
 	assert.Equal(t, int64(4), item.Weight())
@@ -173,14 +166,13 @@ func TestWeightedQueueItemsEvictedByTypeForWeight(t *testing.T) {
 
 func TestWeightedQueueItemsEvictedForWeight(t *testing.T) {
 	q := NewWeightedQueue(100, 10)
-	exit := make(chan struct{})
 
 	q.Add(newItem("item1", 1))
 	q.Add(newItem("item2", 7))
 	q.Add(newItem("item1", 2))
 	q.Add(newItem("item2", 10))
 
-	item, ok := q.Poll(exit)
+	item, ok := q.Poll()
 	assert.True(t, ok)
 	assert.Equal(t, "item2", item.Type())
 	assert.Equal(t, int64(10), item.Weight())
@@ -191,7 +183,6 @@ func TestWeightedQueueItemsEvictedForWeight(t *testing.T) {
 
 func TestWeightedQueueAvailableWeightCorrectlySetEvictingItemsOfSameType(t *testing.T) {
 	q := NewWeightedQueue(100, 10)
-	exit := make(chan struct{})
 
 	q.Add(newItem("item1", 1))
 	q.Add(newItem("item1", 2))
@@ -199,12 +190,12 @@ func TestWeightedQueueAvailableWeightCorrectlySetEvictingItemsOfSameType(t *test
 	q.Add(newItem("item1", 6))
 	q.Add(newItem("item1", 4))
 
-	item, ok := q.Poll(exit)
+	item, ok := q.Poll()
 	assert.True(t, ok)
 	assert.Equal(t, "item1", item.Type())
 	assert.Equal(t, int64(6), item.Weight())
 
-	item, ok = q.Poll(exit)
+	item, ok = q.Poll()
 	assert.True(t, ok)
 	assert.Equal(t, "item1", item.Type())
 	assert.Equal(t, int64(4), item.Weight())
@@ -214,7 +205,6 @@ func TestWeightedQueueAvailableWeightCorrectlySetEvictingItemsOfSameType(t *test
 
 func TestWeightedQueueAvailableWeightCorrectlySetEvictingItemsOfDifferentType(t *testing.T) {
 	q := NewWeightedQueue(100, 10)
-	exit := make(chan struct{})
 
 	q.Add(newItem("item1", 1))
 	q.Add(newItem("item1", 2))
@@ -222,12 +212,12 @@ func TestWeightedQueueAvailableWeightCorrectlySetEvictingItemsOfDifferentType(t 
 	q.Add(newItem("item2", 6))
 	q.Add(newItem("item3", 4))
 
-	item, ok := q.Poll(exit)
+	item, ok := q.Poll()
 	assert.True(t, ok)
 	assert.Equal(t, "item2", item.Type())
 	assert.Equal(t, int64(6), item.Weight())
 
-	item, ok = q.Poll(exit)
+	item, ok = q.Poll()
 	assert.True(t, ok)
 	assert.Equal(t, "item3", item.Type())
 	assert.Equal(t, int64(4), item.Weight())
@@ -237,30 +227,29 @@ func TestWeightedQueueAvailableWeightCorrectlySetEvictingItemsOfDifferentType(t 
 
 func TestWeightedQueueAvailableWeightDecreasedAfterPoll(t *testing.T) {
 	q := NewWeightedQueue(100, 10)
-	exit := make(chan struct{})
 
 	q.Add(newItem("item", 2))
 	q.Add(newItem("item", 3))
 	q.Add(newItem("item", 5))
 
-	item, ok := q.Poll(exit)
+	item, ok := q.Poll()
 	assert.True(t, ok)
 	assert.Equal(t, "item", item.Type())
 	assert.Equal(t, int64(2), item.Weight())
 
-	item, ok = q.Poll(exit)
+	item, ok = q.Poll()
 	assert.True(t, ok)
 	assert.Equal(t, "item", item.Type())
 	assert.Equal(t, int64(3), item.Weight())
 
 	q.Add(newItem("item", 4))
 
-	item, ok = q.Poll(exit)
+	item, ok = q.Poll()
 	assert.True(t, ok)
 	assert.Equal(t, "item", item.Type())
 	assert.Equal(t, int64(5), item.Weight())
 
-	item, ok = q.Poll(exit)
+	item, ok = q.Poll()
 	assert.True(t, ok)
 	assert.Equal(t, "item", item.Type())
 	assert.Equal(t, int64(4), item.Weight())


### PR DESCRIPTION
The deadlock was due to use of an unbuffered channel as a
condition variable.  It could be reproduced by adding a `time.Sleep`
call before the check of `q.dataAvailable` in `Poll`.  The timeline is:

 * [goroutine 1] calls Poll()
 * [goroutine 1] locks q
 * [goroutine 1] sees q.queue.Len() == 0
 * [goroutine 1] unlocks q
 * [goroutine 2] calls Add
 * [goroutine 2] locks q
 * [goroutine 2] pushes a value into the queue
 * [goroutine 2] tries ->q.dataAvailable, but finds no pair and continues
 * [goroutine 1] executes <-q.dataAvailable and hangs

An easier fix might be to use a buffered channel of size N, where N is
the maximum number of concurrent Poll operations.  Current usage of
WeightedQueue suggests N=1, but that is a difficult API constraint to
place on users of this type.

So the fix applied here is to use a condition variable which is
signalled both when there is data available in the queue and when the
queue is stopped.  This simplifies the Poll operation, but requires a
simple goroutine to "translate" `<-exit` into `wq.Stop()` calls.

### Motivation

We have seen intermittent failures in `cmd/process-agent.TestQueueSpaceReleased`, due to the race condition triggering this deadlock.

### Describe how to test your changes

Normal process-agent QA should identify any undesirable side-effects of this change.  The complexity in this patch is around `exit`, so the most likely side-effect is a failure of the agent to exit appropriately when signalled.
