### PR TITLE
[process-agent] Fix ProcessQueueBytes default value comment

### DIFF
--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -196,7 +196,7 @@ func NewDefaultAgentConfig(canAccessContainers bool) *AgentConfig {
 		LogLevel:     "info",
 		LogToConsole: false,
 
-		// Allow buffering up to 75 megabytes of payload data in total
+		// Allow buffering up to 60 megabytes of payload data in total
 		ProcessQueueBytes: 60 * 1000 * 1000,
 		// This can be fairly high as the input should get throttled by queue bytes first.
 		// Assuming we generate ~8 checks/minute (for process/network), this should allow buffering of ~30 minutes of data assuming it fits within the queue bytes memory budget


### PR DESCRIPTION
### What does this PR do?

This comment referred to `ProcessQueueBytes` and `PodQueueBytes`. The latter has been moved to `OrchestratorConfig` by https://github.com/DataDog/datadog-agent/commit/f439ad8d60b21c43c5f366ec3a29d2870499b476#diff-69c5fcd6c4bca1aedf14eda11845d90134c99e08b99f99bcc07a9e984a8fa144R182-R184 so we need to update it.

### Motivation

Better code documentation.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

No test needed

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
