### PR TITLE
[pkg/otlp/model] Backport translator changes

### DIFF
--- a/pkg/otlp/model/translator/metrics_translator.go
+++ b/pkg/otlp/model/translator/metrics_translator.go
@@ -141,6 +141,7 @@ func (t *Translator) mapNumberMonotonicMetrics(
 	for i := 0; i < slice.Len(); i++ {
 		p := slice.At(i)
 		ts := uint64(p.Timestamp())
+		startTs := uint64(p.StartTimestamp())
 		tags := getTags(p.Attributes())
 		tags = append(tags, additionalTags...)
 
@@ -156,7 +157,7 @@ func (t *Translator) mapNumberMonotonicMetrics(
 			continue
 		}
 
-		if dx, ok := t.prevPts.putAndGetDiff(name, tags, ts, val); ok {
+		if dx, ok := t.prevPts.MonotonicDiff(name, tags, startTs, ts, val); ok {
 			consumer.ConsumeTimeSeries(ctx, name, Count, ts, dx, tags, host)
 		}
 	}
@@ -179,12 +180,13 @@ func (t *Translator) getSketchBuckets(
 	ctx context.Context,
 	consumer SketchConsumer,
 	name string,
-	ts uint64,
 	p pdata.HistogramDataPoint,
 	delta bool,
 	tags []string,
 	host string,
 ) {
+	startTs := uint64(p.StartTimestamp())
+	ts := uint64(p.Timestamp())
 	as := &quantile.Agent{}
 	for j := range p.BucketCounts() {
 		lowerBound, upperBound := getBounds(p, j)
@@ -210,7 +212,7 @@ func (t *Translator) getSketchBuckets(
 		count := p.BucketCounts()[j]
 		if delta {
 			as.InsertInterpolate(lowerBound, upperBound, uint(count))
-		} else if dx, ok := t.prevPts.putAndGetDiff(name, bucketTags, ts, float64(count)); ok {
+		} else if dx, ok := t.prevPts.Diff(name, bucketTags, startTs, ts, float64(count)); ok {
 			as.InsertInterpolate(lowerBound, upperBound, uint(dx))
 		}
 
@@ -231,6 +233,8 @@ func (t *Translator) getLegacyBuckets(
 	tags []string,
 	host string,
 ) {
+	startTs := uint64(p.StartTimestamp())
+	ts := uint64(p.Timestamp())
 	// We have a single metric, 'bucket', which is tagged with the bucket bounds. See:
 	// https://github.com/DataDog/integrations-core/blob/7.30.1/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/transformers/histogram.py
 	fullName := fmt.Sprintf("%s.bucket", name)
@@ -243,10 +247,9 @@ func (t *Translator) getLegacyBuckets(
 		bucketTags = append(bucketTags, tags...)
 
 		count := float64(val)
-		ts := uint64(p.Timestamp())
 		if delta {
 			consumer.ConsumeTimeSeries(ctx, fullName, Count, ts, count, bucketTags, host)
-		} else if dx, ok := t.prevPts.putAndGetDiff(fullName, bucketTags, ts, count); ok {
+		} else if dx, ok := t.prevPts.Diff(fullName, bucketTags, startTs, ts, count); ok {
 			consumer.ConsumeTimeSeries(ctx, fullName, Count, ts, dx, bucketTags, host)
 		}
 	}
@@ -276,6 +279,7 @@ func (t *Translator) mapHistogramMetrics(
 ) {
 	for i := 0; i < slice.Len(); i++ {
 		p := slice.At(i)
+		startTs := uint64(p.StartTimestamp())
 		ts := uint64(p.Timestamp())
 		tags := getTags(p.Attributes())
 		tags = append(tags, additionalTags...)
@@ -285,7 +289,7 @@ func (t *Translator) mapHistogramMetrics(
 			countName := fmt.Sprintf("%s.count", name)
 			if delta {
 				consumer.ConsumeTimeSeries(ctx, countName, Count, ts, count, tags, host)
-			} else if dx, ok := t.prevPts.putAndGetDiff(countName, tags, ts, count); ok {
+			} else if dx, ok := t.prevPts.Diff(countName, tags, startTs, ts, count); ok {
 				consumer.ConsumeTimeSeries(ctx, countName, Count, ts, dx, tags, host)
 			}
 		}
@@ -296,7 +300,7 @@ func (t *Translator) mapHistogramMetrics(
 			if !t.isSkippable(sumName, p.Sum()) {
 				if delta {
 					consumer.ConsumeTimeSeries(ctx, sumName, Count, ts, sum, tags, host)
-				} else if dx, ok := t.prevPts.putAndGetDiff(sumName, tags, ts, sum); ok {
+				} else if dx, ok := t.prevPts.Diff(sumName, tags, startTs, ts, sum); ok {
 					consumer.ConsumeTimeSeries(ctx, sumName, Count, ts, dx, tags, host)
 				}
 			}
@@ -306,7 +310,7 @@ func (t *Translator) mapHistogramMetrics(
 		case HistogramModeCounters:
 			t.getLegacyBuckets(ctx, consumer, name, p, delta, tags, host)
 		case HistogramModeDistributions:
-			t.getSketchBuckets(ctx, consumer, name, ts, p, delta, tags, host)
+			t.getSketchBuckets(ctx, consumer, name, p, delta, tags, host)
 		}
 	}
 }
@@ -350,6 +354,7 @@ func (t *Translator) mapSummaryMetrics(
 
 	for i := 0; i < slice.Len(); i++ {
 		p := slice.At(i)
+		startTs := uint64(p.StartTimestamp())
 		ts := uint64(p.Timestamp())
 		tags := getTags(p.Attributes())
 		tags = append(tags, additionalTags...)
@@ -357,7 +362,7 @@ func (t *Translator) mapSummaryMetrics(
 		// count and sum are increasing; we treat them as cumulative monotonic sums.
 		{
 			countName := fmt.Sprintf("%s.count", name)
-			if dx, ok := t.prevPts.putAndGetDiff(countName, tags, ts, float64(p.Count())); ok && !t.isSkippable(countName, dx) {
+			if dx, ok := t.prevPts.Diff(countName, tags, startTs, ts, float64(p.Count())); ok && !t.isSkippable(countName, dx) {
 				consumer.ConsumeTimeSeries(ctx, countName, Count, ts, dx, tags, host)
 			}
 		}
@@ -365,7 +370,7 @@ func (t *Translator) mapSummaryMetrics(
 		{
 			sumName := fmt.Sprintf("%s.sum", name)
 			if !t.isSkippable(sumName, p.Sum()) {
-				if dx, ok := t.prevPts.putAndGetDiff(sumName, tags, ts, p.Sum()); ok {
+				if dx, ok := t.prevPts.Diff(sumName, tags, startTs, ts, p.Sum()); ok {
 					consumer.ConsumeTimeSeries(ctx, sumName, Count, ts, dx, tags, host)
 				}
 			}
@@ -442,7 +447,7 @@ func (t *Translator) MapMetrics(ctx context.Context, md pdata.Metrics, consumer 
 						}
 					case pdata.MetricAggregationTemporalityDelta:
 						t.mapNumberMetrics(ctx, consumer, md.Name(), Count, md.Sum().DataPoints(), additionalTags, host)
-					default: // pdata.MetricAggregationTemporalityUnspecified or any other not supported type
+					default: // pdata.AggregationTemporalityUnspecified or any other not supported type
 						t.logger.Debug("Unknown or unsupported aggregation temporality",
 							zap.String(metricName, md.Name()),
 							zap.Any("aggregation temporality", md.Sum().AggregationTemporality()),
@@ -454,7 +459,7 @@ func (t *Translator) MapMetrics(ctx context.Context, md pdata.Metrics, consumer 
 					case pdata.MetricAggregationTemporalityCumulative, pdata.MetricAggregationTemporalityDelta:
 						delta := md.Histogram().AggregationTemporality() == pdata.MetricAggregationTemporalityDelta
 						t.mapHistogramMetrics(ctx, consumer, md.Name(), md.Histogram().DataPoints(), delta, additionalTags, host)
-					default: // pdata.MetricAggregationTemporalityUnspecified or any other not supported type
+					default: // pdata.AggregationTemporalityUnspecified or any other not supported type
 						t.logger.Debug("Unknown or unsupported aggregation temporality",
 							zap.String("metric name", md.Name()),
 							zap.Any("aggregation temporality", md.Histogram().AggregationTemporality()),
@@ -470,6 +475,5 @@ func (t *Translator) MapMetrics(ctx context.Context, md pdata.Metrics, consumer 
 			}
 		}
 	}
-
 	return nil
 }

--- a/pkg/otlp/model/translator/metrics_translator_test.go
+++ b/pkg/otlp/model/translator/metrics_translator_test.go
@@ -110,8 +110,7 @@ func newTranslator(t *testing.T, logger *zap.Logger) *Translator {
 	tr, err := New(
 		logger,
 		WithFallbackHostnameProvider(testProvider("fallbackHostname")),
-		WithCountSumMetrics(),
-		WithHistogramMode(HistogramModeNoBuckets),
+		WithHistogramMode(HistogramModeDistributions),
 		WithNumberMode(NumberModeCumulativeToDelta),
 	)
 
@@ -533,31 +532,25 @@ func TestMapDeltaHistogramMetrics(t *testing.T) {
 	point.SetExplicitBounds([]float64{0})
 	point.SetTimestamp(ts)
 
-	noBuckets := []metric{
+	counts := []metric{
 		newCount("doubleHist.test.count", uint64(ts), 20, []string{}),
 		newCount("doubleHist.test.sum", uint64(ts), math.Pi, []string{}),
 	}
 
-	buckets := []metric{
+	countsAttributeTags := []metric{
+		newCount("doubleHist.test.count", uint64(ts), 20, []string{"attribute_tag:attribute_value"}),
+		newCount("doubleHist.test.sum", uint64(ts), math.Pi, []string{"attribute_tag:attribute_value"}),
+	}
+
+	bucketsCounts := []metric{
 		newCount("doubleHist.test.bucket", uint64(ts), 2, []string{"lower_bound:-inf", "upper_bound:0"}),
 		newCount("doubleHist.test.bucket", uint64(ts), 18, []string{"lower_bound:0", "upper_bound:inf"}),
 	}
 
-	ctx := context.Background()
-	tr := newTranslator(t, zap.NewNop())
-	delta := true
-
-	tr.cfg.HistMode = HistogramModeNoBuckets
-	consumer := &mockFullConsumer{}
-	tr.mapHistogramMetrics(ctx, consumer, "doubleHist.test", slice, delta, []string{}, "")
-	assert.ElementsMatch(t, noBuckets, consumer.metrics)
-	assert.Empty(t, consumer.sketches)
-
-	tr.cfg.HistMode = HistogramModeCounters
-	consumer = &mockFullConsumer{}
-	tr.mapHistogramMetrics(ctx, consumer, "doubleHist.test", slice, delta, []string{}, "")
-	assert.ElementsMatch(t, append(noBuckets, buckets...), consumer.metrics)
-	assert.Empty(t, consumer.sketches)
+	bucketsCountsAttributeTags := []metric{
+		newCount("doubleHist.test.bucket", uint64(ts), 2, []string{"lower_bound:-inf", "upper_bound:0", "attribute_tag:attribute_value"}),
+		newCount("doubleHist.test.bucket", uint64(ts), 18, []string{"lower_bound:0", "upper_bound:inf", "attribute_tag:attribute_value"}),
+	}
 
 	sketches := []sketch{
 		newSketch("doubleHist.test", uint64(ts), summary.Summary{
@@ -571,35 +564,6 @@ func TestMapDeltaHistogramMetrics(t *testing.T) {
 		),
 	}
 
-	tr.cfg.HistMode = HistogramModeDistributions
-	consumer = &mockFullConsumer{}
-	tr.mapHistogramMetrics(ctx, consumer, "doubleHist.test", slice, delta, []string{}, "")
-	assert.ElementsMatch(t, noBuckets, consumer.metrics)
-	assert.ElementsMatch(t, sketches, consumer.sketches)
-
-	// With attribute tags
-	noBucketsAttributeTags := []metric{
-		newCount("doubleHist.test.count", uint64(ts), 20, []string{"attribute_tag:attribute_value"}),
-		newCount("doubleHist.test.sum", uint64(ts), math.Pi, []string{"attribute_tag:attribute_value"}),
-	}
-
-	bucketsAttributeTags := []metric{
-		newCount("doubleHist.test.bucket", uint64(ts), 2, []string{"lower_bound:-inf", "upper_bound:0", "attribute_tag:attribute_value"}),
-		newCount("doubleHist.test.bucket", uint64(ts), 18, []string{"lower_bound:0", "upper_bound:inf", "attribute_tag:attribute_value"}),
-	}
-
-	tr.cfg.HistMode = HistogramModeNoBuckets
-	consumer = &mockFullConsumer{}
-	tr.mapHistogramMetrics(ctx, consumer, "doubleHist.test", slice, delta, []string{"attribute_tag:attribute_value"}, "")
-	assert.ElementsMatch(t, noBucketsAttributeTags, consumer.metrics)
-	assert.Empty(t, consumer.sketches)
-
-	tr.cfg.HistMode = HistogramModeCounters
-	consumer = &mockFullConsumer{}
-	tr.mapHistogramMetrics(ctx, consumer, "doubleHist.test", slice, delta, []string{"attribute_tag:attribute_value"}, "")
-	assert.ElementsMatch(t, append(noBucketsAttributeTags, bucketsAttributeTags...), consumer.metrics)
-	assert.Empty(t, consumer.sketches)
-
 	sketchesAttributeTags := []sketch{
 		newSketch("doubleHist.test", uint64(ts), summary.Summary{
 			Min: 0,
@@ -612,11 +576,111 @@ func TestMapDeltaHistogramMetrics(t *testing.T) {
 		),
 	}
 
-	tr.cfg.HistMode = HistogramModeDistributions
-	consumer = &mockFullConsumer{}
-	tr.mapHistogramMetrics(ctx, consumer, "doubleHist.test", slice, delta, []string{"attribute_tag:attribute_value"}, "")
-	assert.ElementsMatch(t, noBucketsAttributeTags, consumer.metrics)
-	assert.ElementsMatch(t, sketchesAttributeTags, consumer.sketches)
+	ctx := context.Background()
+	delta := true
+
+	tests := []struct {
+		name             string
+		histogramMode    HistogramMode
+		sendCountSum     bool
+		tags             []string
+		expectedMetrics  []metric
+		expectedSketches []sketch
+	}{
+		{
+			name:             "No buckets: send count & sum metrics, no attribute tags",
+			histogramMode:    HistogramModeNoBuckets,
+			sendCountSum:     true,
+			tags:             []string{},
+			expectedMetrics:  counts,
+			expectedSketches: []sketch{},
+		},
+		{
+			name:             "No buckets: send count & sum metrics, attribute tags",
+			histogramMode:    HistogramModeNoBuckets,
+			sendCountSum:     true,
+			tags:             []string{"attribute_tag:attribute_value"},
+			expectedMetrics:  countsAttributeTags,
+			expectedSketches: []sketch{},
+		},
+		{
+			name:             "Counters: do not send count & sum metrics, no tags",
+			histogramMode:    HistogramModeCounters,
+			sendCountSum:     false,
+			tags:             []string{},
+			expectedMetrics:  bucketsCounts,
+			expectedSketches: []sketch{},
+		},
+		{
+			name:             "Counters: do not send count & sum metrics, attribute tags",
+			histogramMode:    HistogramModeCounters,
+			sendCountSum:     false,
+			tags:             []string{"attribute_tag:attribute_value"},
+			expectedMetrics:  bucketsCountsAttributeTags,
+			expectedSketches: []sketch{},
+		},
+		{
+			name:             "Counters: send count & sum metrics, no tags",
+			histogramMode:    HistogramModeCounters,
+			sendCountSum:     true,
+			tags:             []string{},
+			expectedMetrics:  append(counts, bucketsCounts...),
+			expectedSketches: []sketch{},
+		},
+		{
+			name:             "Counters: send count & sum metrics, attribute tags",
+			histogramMode:    HistogramModeCounters,
+			sendCountSum:     true,
+			tags:             []string{"attribute_tag:attribute_value"},
+			expectedMetrics:  append(countsAttributeTags, bucketsCountsAttributeTags...),
+			expectedSketches: []sketch{},
+		},
+		{
+			name:             "Distributions: do not send count & sum metrics, no tags",
+			histogramMode:    HistogramModeDistributions,
+			sendCountSum:     false,
+			tags:             []string{},
+			expectedMetrics:  []metric{},
+			expectedSketches: sketches,
+		},
+		{
+			name:             "Distributions: do not send count & sum metrics, attribute tags",
+			histogramMode:    HistogramModeDistributions,
+			sendCountSum:     false,
+			tags:             []string{"attribute_tag:attribute_value"},
+			expectedMetrics:  []metric{},
+			expectedSketches: sketchesAttributeTags,
+		},
+		{
+			name:             "Distributions: send count & sum metrics, no tags",
+			histogramMode:    HistogramModeDistributions,
+			sendCountSum:     true,
+			tags:             []string{},
+			expectedMetrics:  counts,
+			expectedSketches: sketches,
+		},
+		{
+			name:             "Distributions: send count & sum metrics, attribute tags",
+			histogramMode:    HistogramModeDistributions,
+			sendCountSum:     true,
+			tags:             []string{"attribute_tag:attribute_value"},
+			expectedMetrics:  countsAttributeTags,
+			expectedSketches: sketchesAttributeTags,
+		},
+	}
+
+	for _, testInstance := range tests {
+		t.Run(testInstance.name, func(t *testing.T) {
+			tr := newTranslator(t, zap.NewNop())
+			tr.cfg.HistMode = testInstance.histogramMode
+			tr.cfg.SendCountSum = testInstance.sendCountSum
+			consumer := &mockFullConsumer{}
+
+			tr.mapHistogramMetrics(ctx, consumer, "doubleHist.test", slice, delta, testInstance.tags, "")
+			assert.ElementsMatch(t, consumer.metrics, testInstance.expectedMetrics)
+			assert.ElementsMatch(t, consumer.sketches, testInstance.expectedSketches)
+		})
+	}
 }
 
 func TestMapCumulativeHistogramMetrics(t *testing.T) {
@@ -635,30 +699,17 @@ func TestMapCumulativeHistogramMetrics(t *testing.T) {
 	point.SetExplicitBounds([]float64{0})
 	point.SetTimestamp(seconds(2))
 
-	expectedCounts := []metric{
+	counts := []metric{
 		newCount("doubleHist.test.count", uint64(seconds(2)), 30, []string{}),
 		newCount("doubleHist.test.sum", uint64(seconds(2)), 20, []string{}),
 	}
 
-	expectedBuckets := []metric{
+	bucketsCounts := []metric{
 		newCount("doubleHist.test.bucket", uint64(seconds(2)), 11, []string{"lower_bound:-inf", "upper_bound:0"}),
 		newCount("doubleHist.test.bucket", uint64(seconds(2)), 19, []string{"lower_bound:0", "upper_bound:inf"}),
 	}
 
-	ctx := context.Background()
-	tr := newTranslator(t, zap.NewNop())
-	delta := false
-
-	tr.cfg.HistMode = HistogramModeCounters
-	consumer := &mockFullConsumer{}
-	tr.mapHistogramMetrics(ctx, consumer, "doubleHist.test", slice, delta, []string{}, "")
-	assert.Empty(t, consumer.sketches)
-	assert.ElementsMatch(t,
-		consumer.metrics,
-		append(expectedCounts, expectedBuckets...),
-	)
-
-	expectedSketches := []sketch{
+	sketches := []sketch{
 		newSketch("doubleHist.test", uint64(seconds(2)), summary.Summary{
 			Min: 0,
 			Max: 0,
@@ -670,20 +721,65 @@ func TestMapCumulativeHistogramMetrics(t *testing.T) {
 		),
 	}
 
-	tr = newTranslator(t, zap.NewNop())
-	delta = false
+	ctx := context.Background()
+	delta := false
 
-	tr.cfg.HistMode = HistogramModeDistributions
-	consumer = &mockFullConsumer{}
-	tr.mapHistogramMetrics(ctx, consumer, "doubleHist.test", slice, delta, []string{}, "")
-	assert.ElementsMatch(t,
-		consumer.metrics,
-		expectedCounts,
-	)
-	assert.ElementsMatch(t,
-		consumer.sketches,
-		expectedSketches,
-	)
+	tests := []struct {
+		name             string
+		histogramMode    HistogramMode
+		sendCountSum     bool
+		expectedMetrics  []metric
+		expectedSketches []sketch
+	}{
+		{
+			name:             "No buckets: send count & sum metrics",
+			histogramMode:    HistogramModeNoBuckets,
+			sendCountSum:     true,
+			expectedMetrics:  counts,
+			expectedSketches: []sketch{},
+		},
+		{
+			name:             "Counters: do not send count & sum metrics",
+			histogramMode:    HistogramModeCounters,
+			sendCountSum:     false,
+			expectedMetrics:  bucketsCounts,
+			expectedSketches: []sketch{},
+		},
+		{
+			name:             "Counters: send count & sum metrics",
+			histogramMode:    HistogramModeCounters,
+			sendCountSum:     true,
+			expectedMetrics:  append(counts, bucketsCounts...),
+			expectedSketches: []sketch{},
+		},
+		{
+			name:             "Distributions: do not send count & sum metrics",
+			histogramMode:    HistogramModeDistributions,
+			sendCountSum:     false,
+			expectedMetrics:  []metric{},
+			expectedSketches: sketches,
+		},
+		{
+			name:             "Distributions: send count & sum metrics",
+			histogramMode:    HistogramModeDistributions,
+			sendCountSum:     true,
+			expectedMetrics:  counts,
+			expectedSketches: sketches,
+		},
+	}
+
+	for _, testInstance := range tests {
+		t.Run(testInstance.name, func(t *testing.T) {
+			tr := newTranslator(t, zap.NewNop())
+			tr.cfg.HistMode = testInstance.histogramMode
+			tr.cfg.SendCountSum = testInstance.sendCountSum
+			consumer := &mockFullConsumer{}
+
+			tr.mapHistogramMetrics(ctx, consumer, "doubleHist.test", slice, delta, []string{}, "")
+			assert.ElementsMatch(t, consumer.metrics, testInstance.expectedMetrics)
+			assert.ElementsMatch(t, consumer.sketches, testInstance.expectedSketches)
+		})
+	}
 }
 
 func TestLegacyBucketsTags(t *testing.T) {
@@ -769,8 +865,8 @@ func TestMapSummaryMetrics(t *testing.T) {
 
 	newTranslator := func(tags []string, quantiles bool) *Translator {
 		c := newTestCache()
-		c.cache.Set(c.metricDimensionsToMapKey("summary.example.count", tags), numberCounter{0, 1}, gocache.NoExpiration)
-		c.cache.Set(c.metricDimensionsToMapKey("summary.example.sum", tags), numberCounter{0, 1}, gocache.NoExpiration)
+		c.cache.Set(c.metricDimensionsToMapKey("summary.example.count", tags), numberCounter{0, 0, 1}, gocache.NoExpiration)
+		c.cache.Set(c.metricDimensionsToMapKey("summary.example.sum", tags), numberCounter{0, 0, 1}, gocache.NoExpiration)
 		options := []Option{WithFallbackHostnameProvider(testProvider("fallbackHostname"))}
 		if quantiles {
 			options = append(options, WithQuantiles())
@@ -1000,16 +1096,22 @@ func createTestMetrics() pdata.Metrics {
 	return md
 }
 
-func testGauge(name string, val float64) metric {
+func newGaugeWithHostname(name string, val float64) metric {
 	m := newGauge(name, 0, val, []string{})
 	m.host = testHostname
 	return m
 }
 
-func testCount(name string, val float64, seconds uint64) metric {
+func newCountWithHostname(name string, val float64, seconds uint64) metric {
 	m := newCount(name, seconds*1e9, val, []string{})
 	m.host = testHostname
 	return m
+}
+
+func newSketchWithHostname(name string, summary summary.Summary, seconds uint64) sketch {
+	s := newSketch(name, seconds, summary, []string{})
+	s.host = testHostname
+	return s
 }
 
 func TestMapMetrics(t *testing.T) {
@@ -1024,22 +1126,29 @@ func TestMapMetrics(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.ElementsMatch(t, consumer.metrics, []metric{
-		testGauge("int.gauge", 1),
-		testGauge("double.gauge", math.Pi),
-		testCount("int.delta.sum", 2, 0),
-		testCount("double.delta.sum", math.E, 0),
-		testCount("int.delta.monotonic.sum", 2, 0),
-		testCount("double.delta.monotonic.sum", math.E, 0),
-		testCount("double.histogram.sum", math.Phi, 0),
-		testCount("double.histogram.count", 20, 0),
-		testCount("summary.sum", 10_000, 2),
-		testCount("summary.count", 100, 2),
-		testGauge("int.cumulative.sum", 4),
-		testGauge("double.cumulative.sum", 4),
-		testCount("int.cumulative.monotonic.sum", 3, 2),
-		testCount("double.cumulative.monotonic.sum", math.Pi, 2),
+		newGaugeWithHostname("int.gauge", 1),
+		newGaugeWithHostname("double.gauge", math.Pi),
+		newCountWithHostname("int.delta.sum", 2, 0),
+		newCountWithHostname("double.delta.sum", math.E, 0),
+		newCountWithHostname("int.delta.monotonic.sum", 2, 0),
+		newCountWithHostname("double.delta.monotonic.sum", math.E, 0),
+		newCountWithHostname("summary.sum", 10_000, 2),
+		newCountWithHostname("summary.count", 100, 2),
+		newGaugeWithHostname("int.cumulative.sum", 4),
+		newGaugeWithHostname("double.cumulative.sum", 4),
+		newCountWithHostname("int.cumulative.monotonic.sum", 3, 2),
+		newCountWithHostname("double.cumulative.monotonic.sum", math.Pi, 2),
 	})
-	assert.Empty(t, consumer.sketches)
+
+	assert.ElementsMatch(t, consumer.sketches, []sketch{
+		newSketchWithHostname("double.histogram", summary.Summary{
+			Min: 0,
+			Max: 0,
+			Sum: 0,
+			Avg: 0,
+			Cnt: 20,
+		}, 0),
+	})
 
 	// One metric type was unknown or unsupported
 	assert.Equal(t, observed.FilterMessage("Unknown or unsupported metric type").Len(), 1)
@@ -1150,12 +1259,19 @@ func TestNaNMetrics(t *testing.T) {
 	require.NoError(t, err)
 
 	assert.ElementsMatch(t, consumer.metrics, []metric{
-		testCount("nan.histogram.count", 20, 0),
-		testCount("nan.summary.count", 100, 2),
+		newCountWithHostname("nan.summary.count", 100, 2),
 	})
 
-	assert.Empty(t, consumer.sketches)
+	assert.ElementsMatch(t, consumer.sketches, []sketch{
+		newSketchWithHostname("nan.histogram", summary.Summary{
+			Min: 0,
+			Max: 0,
+			Sum: 0,
+			Avg: 0,
+			Cnt: 20,
+		}, 0),
+	})
 
 	// One metric type was unknown or unsupported
-	assert.Equal(t, observed.FilterMessage("Unsupported metric value").Len(), 7)
+	assert.Equal(t, observed.FilterMessage("Unsupported metric value").Len(), 6)
 }

--- a/pkg/otlp/model/translator/sketches_test.go
+++ b/pkg/otlp/model/translator/sketches_test.go
@@ -111,7 +111,7 @@ func TestHistogramSketches(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			p := fromCDF(test.cdf)
 			consumer := &sketchConsumer{}
-			tr.getSketchBuckets(ctx, consumer, "test", 0, p, true, []string{}, "")
+			tr.getSketchBuckets(ctx, consumer, "test", p, true, []string{}, "")
 			sk := consumer.sk
 
 			// Check the minimum is 0.0
@@ -203,7 +203,7 @@ func TestInfiniteBounds(t *testing.T) {
 		t.Run(testInstance.name, func(t *testing.T) {
 			p := testInstance.getHist()
 			consumer := &sketchConsumer{}
-			tr.getSketchBuckets(ctx, consumer, "test", 0, p, true, []string{}, "")
+			tr.getSketchBuckets(ctx, consumer, "test", p, true, []string{}, "")
 			sk := consumer.sk
 			assert.InDelta(t, sk.Basic.Sum, p.Sum(), 1)
 			assert.Equal(t, uint64(sk.Basic.Cnt), p.Count())

--- a/pkg/otlp/model/translator/ttlcache.go
+++ b/pkg/otlp/model/translator/ttlcache.go
@@ -33,8 +33,9 @@ type ttlCache struct {
 // numberCounter keeps the value of a number
 // monotonic counter at a given point in time
 type numberCounter struct {
-	ts    uint64
-	value float64
+	ts      uint64
+	startTs uint64
+	value   float64
 }
 
 func newTTLCache(sweepInterval int64, deltaTTL int64) *ttlCache {
@@ -67,9 +68,27 @@ func (*ttlCache) metricDimensionsToMapKey(name string, tags []string) string {
 	return metricKeyBuilder.String()
 }
 
+// Diff submits a new value for a given non-monotonic metric and returns the difference with the
+// last submitted value (ordered by timestamp). The diff value is only valid if `ok` is true.
+func (t *ttlCache) Diff(name string, tags []string, startTs, ts uint64, val float64) (float64, bool) {
+	return t.putAndGetDiff(name, tags, false, startTs, ts, val)
+}
+
+// MonotonicDiff submits a new value for a given monotonic metric and returns the difference with the
+// last submitted value (ordered by timestamp). The diff value is only valid if `ok` is true.
+func (t *ttlCache) MonotonicDiff(name string, tags []string, startTs, ts uint64, val float64) (float64, bool) {
+	return t.putAndGetDiff(name, tags, true, startTs, ts, val)
+}
+
 // putAndGetDiff submits a new value for a given metric and returns the difference with the
 // last submitted value (ordered by timestamp). The diff value is only valid if `ok` is true.
-func (t *ttlCache) putAndGetDiff(name string, tags []string, ts uint64, val float64) (dx float64, ok bool) {
+func (t *ttlCache) putAndGetDiff(
+	name string,
+	tags []string,
+	monotonic bool,
+	startTs, ts uint64,
+	val float64,
+) (dx float64, ok bool) {
 	key := t.metricDimensionsToMapKey(name, tags)
 	if c, found := t.cache.Get(key); found {
 		cnt := c.(numberCounter)
@@ -78,12 +97,37 @@ func (t *ttlCache) putAndGetDiff(name string, tags []string, ts uint64, val floa
 			// We keep the existing point in memory since it is the most recent
 			return 0, false
 		}
-		// if dx < 0, we assume there was a reset, thus we save the point
-		// but don't export it (it's the first one so we can't do a delta)
 		dx = val - cnt.value
-		ok = dx >= 0
+
+		// Determine if this is the first point on a cumulative series:
+		// https://github.com/open-telemetry/opentelemetry-specification/blob/v1.7.0/specification/metrics/datamodel.md#resets-and-gaps
+		//
+		// This is written down as an 'if' because I feel it is easier to understand than with a boolean expression.
+		if startTs == 0 {
+			// We don't know the start time, assume the sequence has not been restarted.
+			ok = true
+		} else if startTs != ts && startTs == cnt.startTs {
+			// Since startTs != 0 we know the start time, thus we apply the following rules from the spec:
+			//  - "When StartTimeUnixNano equals TimeUnixNano, a new unbroken sequence of observations begins with a reset at an unknown start time."
+			//  - "[for cumulative series] the StartTimeUnixNano of each point matches the StartTimeUnixNano of the initial observation."
+			ok = true
+		}
+
+		// If sequence is monotonic and diff is negative, there has been a reset.
+		// This must never happen if we know the startTs; we also override the value in this case.
+		if monotonic && dx < 0 {
+			ok = false
+		}
 	}
 
-	t.cache.Set(key, numberCounter{ts, val}, gocache.DefaultExpiration)
+	t.cache.Set(
+		key,
+		numberCounter{
+			startTs: startTs,
+			ts:      ts,
+			value:   val,
+		},
+		gocache.DefaultExpiration,
+	)
 	return
 }

--- a/releasenotes/notes/otlp-reset-starts-ed9e79da8acca363.yaml
+++ b/releasenotes/notes/otlp-reset-starts-ed9e79da8acca363.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The experimental OTLP endpoint now uses the StartTimestamp field for reset detection on cumulative metrics transformations.


### PR DESCRIPTION
### What does this PR do?

This PR backports two recent changes on the OpenTelemetry Collector Datadog exporter version of this module:

- open-telemetry/opentelemetry-collector-contrib#6120
- open-telemetry/opentelemetry-collector-contrib#5885

### Motivation

Keep the two versions in sync until we can drop the code from the Datadog exporter side.

### Additional Notes

To do this I copied the code from the main branch on the Collector and replaced the imports. diff between the translator code and the Collector translator code as of commit open-telemetry/opentelemetry-collector-contrib@e066c9cdd3ebc1fd288e1e74479cc3f6fa9caa61:

```diff
diff -u pkg/otlp/model/translator/metrics_translator.go /Users/pablo.baeyens/Source/otel/opentelemetry-collector-contrib/exporter/datadogexporter/internal/translator/metrics_translator.go
--- pkg/otlp/model/translator/metrics_translator.go     2021-11-08 13:18:11.000000000 +0100
+++ opentelemetry-collector-contrib/exporter/datadogexporter/internal/translator/metrics_translator.go 2021-11-08 13:16:32.000000000 +0100
@@ -24,9 +24,9 @@
        "go.opentelemetry.io/collector/model/pdata"
        "go.uber.org/zap"
 
-       "github.com/DataDog/datadog-agent/pkg/otlp/model/attributes"
-       "github.com/DataDog/datadog-agent/pkg/otlp/model/internal/instrumentationlibrary"
-       "github.com/DataDog/datadog-agent/pkg/otlp/model/internal/utils"
+       "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/attributes"
+       "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/instrumentationlibrary"
+       "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/translator/utils"
 )
 
 const metricName string = "metric name"
diff -u pkg/otlp/model/translator/metrics_translator_test.go /Users/pablo.baeyens/Source/otel/opentelemetry-collector-contrib/exporter/datadogexporter/internal/translator/metrics_translator_test.go
--- pkg/otlp/model/translator/metrics_translator_test.go        2021-11-08 13:18:11.000000000 +0100
+++ opentelemetry-collector-contrib/exporter/datadogexporter/internal/translator/metrics_translator_test.go    2021-11-08 13:16:32.000000000 +0100
@@ -30,7 +30,7 @@
        "go.uber.org/zap/zapcore"
        "go.uber.org/zap/zaptest/observer"
 
-       "github.com/DataDog/datadog-agent/pkg/otlp/model/attributes"
+       "github.com/open-telemetry/opentelemetry-collector-contrib/exporter/datadogexporter/internal/attributes"
 )
 
 func TestGetTags(t *testing.T) {
Only in opentelemetry-collector-contrib/exporter/datadogexporter/internal/translator/: utils
```

### Describe how to test your changes

To test open-telemetry/opentelemetry-collector-contrib#6120:
1. Setup an OTLP-producing program that generates a cumulative histogram and a cumulative sum (e.g. with the `Histogram` and `Counter` instruments with default settings).
2. Send a constant amount per collection period (e.g. increase the value by 10 on every collection period).
3. Check that the graph on the Datadog's webapp looks constant
4. Restart the application (but not the Agent); check that there are no spikes on the webapp graph.

One can also add a negative amount with the `counters` histogram mode and check that the sum is non `0`.

open-telemetry/opentelemetry-collector-contrib#5885 doesn't need testing (only adds unit tests on this module)

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
