### PR TITLE
Bump shellcheck version

### DIFF
--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -164,12 +164,12 @@ if grep -E 'api_key:( APIKEY)?$' "$etc_dir/datadog.yaml" > /dev/null 2>&1; then
 
     # Wait for the agent to fully stop
     retry=0
-    until [ $retry -ge 5 ]; do
+    until [ "$retry" -ge 5 ]; do
         curl -m 5 -o /dev/null -s -I http://127.0.0.1:5002 || break
         retry=$[$retry+1]
         sleep 5
     done
-    if [ $retry -ge 5 ]; then
+    if [ "$retry" -ge 5 ]; then
         printf "\n\033[33mCould not restart the agent.
 You may have to restart it manually using the systray app or the
 \"launchctl start com.datadoghq.agent\" command.\n\033[0m\n"

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -541,7 +541,7 @@ def lint_python(ctx):
 
 
 @task
-def install_shellcheck(ctx, version="0.7.0", destination="/usr/local/bin"):
+def install_shellcheck(ctx, version="0.8.0", destination="/usr/local/bin"):
     """
     Installs the requested version of shellcheck in the specified folder (by default /usr/local/bin).
     Required to run the shellcheck pre-commit hook.


### PR DESCRIPTION
### What does this PR do?

Bump shellcheck to the latest version: https://github.com/koalaman/shellcheck/releases/tag/v0.8.0

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
