### PR TITLE
pkg/trace/api: preserve OpenTelemetry TraceID by default

### DIFF
--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/trace/api/apiutil"
 	"github.com/DataDog/datadog-agent/pkg/trace/config"
-	"github.com/DataDog/datadog-agent/pkg/trace/config/features"
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics/timing"
@@ -327,12 +326,7 @@ func convertSpan(rattr map[string]string, lib *otlppb.InstrumentationLibrary, in
 			sampler.KeySamplingPriority: float64(sampler.PriorityAutoKeep),
 		},
 	}
-	if features.Has("otlp_original_ids") {
-		// keep original IDs
-		span.Meta["otlp_ids.trace"] = hex.EncodeToString(in.TraceId)
-		span.Meta["otlp_ids.span"] = hex.EncodeToString(in.SpanId)
-		span.Meta["otlp_ids.parent"] = hex.EncodeToString(in.ParentSpanId)
-	}
+	span.Meta["otlp.trace_id"] = hex.EncodeToString(in.TraceId)
 	if _, ok := span.Meta["version"]; !ok {
 		if ver := rattr[string(semconv.AttributeServiceVersion)]; ver != "" {
 			span.Meta["version"] = ver

--- a/pkg/trace/api/otlp_test.go
+++ b/pkg/trace/api/otlp_test.go
@@ -474,6 +474,7 @@ func TestOTLPConvertSpan(t *testing.T) {
 				Error:    1,
 				Meta: map[string]string{
 					"name":                            "john",
+					"otlp.trace_id":                   "72df520af2bde7a5240031ead750e5f3",
 					"env":                             "staging",
 					"instrumentation_library.name":    "ddtracer",
 					"instrumentation_library.version": "v2",
@@ -564,6 +565,7 @@ func TestOTLPConvertSpan(t *testing.T) {
 					"env":                             "prod",
 					"deployment.environment":          "prod",
 					"instrumentation_library.name":    "ddtracer",
+					"otlp.trace_id":                   "72df520af2bde7a5240031ead750e5f3",
 					"instrumentation_library.version": "v2",
 					"service.version":                 "v1.2.3",
 					"trace_state":                     "state",
@@ -658,6 +660,7 @@ func TestOTLPConvertSpan(t *testing.T) {
 					"service.version":                 "v1.2.3",
 					"trace_state":                     "state",
 					"version":                         "v1.2.3",
+					"otlp.trace_id":                   "72df520af2bde7a5240031ead750e5f3",
 					"events":                          "[{\"time_unix_nano\":123,\"name\":\"boom\",\"attributes\":{\"message\":\"Out of memory\",\"accuracy\":\"2.40\"},\"dropped_attributes_count\":2},{\"time_unix_nano\":456,\"name\":\"exception\",\"attributes\":{\"exception.message\":\"Out of memory\",\"exception.type\":\"mem\",\"exception.stacktrace\":\"1/2/3\"},\"dropped_attributes_count\":2}]",
 					"error.msg":                       "Out of memory",
 					"error.type":                      "mem",


### PR DESCRIPTION
This change ensures that the collector behaviour matches the OTel
Collector datadog exporter. Ref: https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/6158