### PR TITLE
[runtime-security] Check unmarshallString error

### DIFF
--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -395,9 +395,6 @@ type MountEvent struct {
 
 // GetFSType returns the filesystem type of the mountpoint
 func (m *MountEvent) GetFSType() string {
-	if len(m.FSType) == 0 {
-		m.FSType, _ = UnmarshalString(m.FSTypeRaw[:], 16)
-	}
 	return m.FSType
 }
 

--- a/pkg/security/secl/model/unmarshallers.go
+++ b/pkg/security/secl/model/unmarshallers.go
@@ -146,7 +146,10 @@ func (e *Process) UnmarshalBinary(data []byte) (int, error) {
 
 	var ttyRaw [64]byte
 	SliceToArray(data[read:read+64], unsafe.Pointer(&ttyRaw))
-	ttyName, _ := UnmarshalString(ttyRaw[:], 64)
+	ttyName, err := UnmarshalString(ttyRaw[:], 64)
+	if err != nil {
+		return 0, err
+	}
 	if IsPrintableASCII(ttyName) {
 		e.TTYName = ttyName
 	}
@@ -154,7 +157,10 @@ func (e *Process) UnmarshalBinary(data []byte) (int, error) {
 
 	var commRaw [16]byte
 	SliceToArray(data[read:read+16], unsafe.Pointer(&commRaw))
-	e.Comm, _ = UnmarshalString(commRaw[:], 16)
+	e.Comm, err = UnmarshalString(commRaw[:], 16)
+	if err != nil {
+		return 0, err
+	}
 	read += 16
 
 	// Unmarshal pid_cache_t
@@ -293,6 +299,10 @@ func (e *MountEvent) UnmarshalBinary(data []byte) (int, error) {
 	// Notes: bytes 36 to 40 are used to pad the structure
 
 	SliceToArray(data[40:56], unsafe.Pointer(&e.FSTypeRaw))
+	e.FSType, err = UnmarshalString(e.FSTypeRaw[:], 16)
+	if err != nil {
+		return 0, err
+	}
 
 	return 56, nil
 }

--- a/pkg/security/secl/model/utils_test.go
+++ b/pkg/security/secl/model/utils_test.go
@@ -13,7 +13,10 @@ import (
 
 func TestUnmarshalString(t *testing.T) {
 	array := []byte{65, 66, 67, 0, 0, 0, 65, 66}
-	str, _ := UnmarshalString(array, 8)
+	str, err := UnmarshalString(array, 8)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	assert.Equal(t, "ABC", str)
 }


### PR DESCRIPTION
### What does this PR do?

This PR makes sure we check the error returned by `UnmarshalString`.

### Motivation

Currently, when a string is unsuccessfully unmarshalled, the returned error is hidden.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

The unit test was updated.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
