### PR TITLE
Export cluster id for rego checks

### DIFF
--- a/pkg/compliance/checks/builder.go
+++ b/pkg/compliance/checks/builder.go
@@ -157,7 +157,7 @@ func (c *kubeClient) ClusterID() (string, error) {
 }
 
 // WithKubernetesClient allows specific Kubernetes client
-func WithKubernetesClient(cli env.KubeClient, clusterID string) BuilderOption {
+func WithKubernetesClient(cli dynamic.Interface, clusterID string) BuilderOption {
 	return func(b *builder) error {
 		b.kubeClient = &kubeClient{Interface: cli, clusterID: clusterID}
 		return nil

--- a/pkg/compliance/checks/custom/helper_for_test.go
+++ b/pkg/compliance/checks/custom/helper_for_test.go
@@ -25,6 +25,14 @@ type kubeApiserverFixture struct {
 	expectError  error
 }
 
+type fakeKubeClient struct {
+	*fake.FakeDynamicClient
+}
+
+func (f *fakeKubeClient) ClusterID() (string, error) {
+	return "fake-k8s-cluster", nil
+}
+
 func (f *kubeApiserverFixture) run(t *testing.T) {
 	t.Helper()
 
@@ -33,7 +41,9 @@ func (f *kubeApiserverFixture) run(t *testing.T) {
 	env := &mocks.Env{}
 	defer env.AssertExpectations(t)
 
-	kubeClient := fake.NewSimpleDynamicClient(scheme.Scheme, f.objects...)
+	kubeClient := &fakeKubeClient{
+		FakeDynamicClient: fake.NewSimpleDynamicClient(scheme.Scheme, f.objects...),
+	}
 	env.On("KubeClient").Return(kubeClient)
 
 	resource := compliance.Resource{

--- a/pkg/compliance/checks/env/kubernetes.go
+++ b/pkg/compliance/checks/env/kubernetes.go
@@ -10,4 +10,5 @@ import "k8s.io/client-go/dynamic"
 // KubeClient is the Kubernetes (API server) client interface
 type KubeClient interface {
 	dynamic.Interface
+	ClusterID() (string, error)
 }

--- a/pkg/compliance/checks/kubeapiserver_check_test.go
+++ b/pkg/compliance/checks/kubeapiserver_check_test.go
@@ -109,6 +109,14 @@ type kubeApiserverFixture struct {
 	expectReport *compliance.Report
 }
 
+type fakeKubeClient struct {
+	*fake.FakeDynamicClient
+}
+
+func (f *fakeKubeClient) ClusterID() (string, error) {
+	return "fake-k8s-cluster", nil
+}
+
 func newMyObj(namespace, name, uid string) *MyObj {
 	return &MyObj{
 		TypeMeta: metav1.TypeMeta{
@@ -141,7 +149,9 @@ func (f *kubeApiserverFixture) run(t *testing.T) {
 
 	defer env.AssertExpectations(t)
 
-	kubeClient := fake.NewSimpleDynamicClient(scheme, f.objects...)
+	kubeClient := &fakeKubeClient{
+		FakeDynamicClient: fake.NewSimpleDynamicClient(scheme, f.objects...),
+	}
 	env.On("KubeClient").Return(kubeClient)
 
 	kubeCheck, err := newResourceCheck(env, "rule-id", f.resource)

--- a/pkg/compliance/checks/rego_check.go
+++ b/pkg/compliance/checks/rego_check.go
@@ -247,7 +247,9 @@ func (r *regoCheck) appendInstance(input map[string][]interface{}, key string, i
 func (r *regoCheck) buildContextInput(env env.Env) eval.RegoInputMap {
 	context := make(map[string]interface{})
 	context["hostname"] = env.Hostname()
-
+	if r.ruleScope == compliance.KubernetesClusterScope {
+		context["kubernetes_cluster"], _ = env.KubeClient().ClusterID()
+	}
 	if r.ruleScope == compliance.KubernetesNodeScope {
 		context["kubernetes_node_labels"] = env.NodeLabels()
 	}

--- a/pkg/compliance/checks/rego_helpers/datadog.rego
+++ b/pkg/compliance/checks/rego_helpers/datadog.rego
@@ -9,6 +9,10 @@ raw_finding(status, resource_type, resource_id, event_data) = f {
 	}
 }
 
+kubernetes_cluster_resource_id = id {
+	id := sprintf("%s_kubernetes_cluster", [input.context.kubernetes_cluster])
+}
+
 docker_container_resource_id(c) = id {
 	id := sprintf("%s_%s", [input.context.hostname, cast_string(c.id)])
 }

--- a/pkg/compliance/mocks/kube_client.go
+++ b/pkg/compliance/mocks/kube_client.go
@@ -15,6 +15,27 @@ type KubeClient struct {
 	mock.Mock
 }
 
+// ClusterID provides a mock function with given fields:
+func (_m *KubeClient) ClusterID() (string, error) {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Resource provides a mock function with given fields: resource
 func (_m *KubeClient) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
 	ret := _m.Called(resource)


### PR DESCRIPTION
### What does this PR do?

Export `kubernetes_cluster` to be used in Rego checks

### Motivation

Kubernetes checks need to specify the Kubernetes namespace ID as the check resource id.

### Additional Notes

Anything else we should know when reviewing?

### Describe how to test your changes

Write here in detail how you have tested your changes
and instructions on how this should be tested in QA.

Describe or link instructions to set up environment 
for testing, if the process requires more than just
running the agent on one of the supported platforms.

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
