### PR TITLE
[Windows] Sign all binaries in Omnibus recipes

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -122,7 +122,7 @@ package :zip do
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\uninstall-cmd.exe"
       ]
     if with_python_runtime? "2"
-      additional_sign_files << "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\libdatadog-agent-two.dll",
+      additional_sign_files << "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\libdatadog-agent-two.dll"
     end
     if ENV['SIGN_PFX']
       signing_identity_file "#{ENV['SIGN_PFX']}", password: "#{ENV['SIGN_PFX_PW']}", algorithm: "SHA256"

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -117,11 +117,13 @@ package :zip do
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\process-agent.exe",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\trace-agent.exe",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent.exe",
-        "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\libdatadog-agent-two.dll",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\libdatadog-agent-three.dll",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\install-cmd.exe",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\uninstall-cmd.exe"
       ]
+    if with_python_runtime? "2"
+      additional_sign_files << "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\libdatadog-agent-two.dll",
+    end
     if ENV['SIGN_PFX']
       signing_identity_file "#{ENV['SIGN_PFX']}", password: "#{ENV['SIGN_PFX_PW']}", algorithm: "SHA256"
     end

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -117,10 +117,12 @@ package :zip do
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\trace-agent.exe",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent.exe",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\libdatadog-agent-three.dll",
-        "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\libdatadog-agent-two.dll",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\install-cmd.exe",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\uninstall-cmd.exe"
       ]
+      if with_python_runtime? "2"
+        additional_sign_files.append("#{Omnibus::Config.source_dir()}\\cf-root\\bin\\libdatadog-agent-two.dll")
+      end
     if ENV['SIGN_PFX']
       signing_identity_file "#{ENV['SIGN_PFX']}", password: "#{ENV['SIGN_PFX_PW']}", algorithm: "SHA256"
     end
@@ -147,9 +149,11 @@ package :msi do
       "#{Omnibus::Config.source_dir()}\\datadog-agent\\src\\github.com\\DataDog\\datadog-agent\\bin\\agent\\trace-agent.exe",
       "#{Omnibus::Config.source_dir()}\\datadog-agent\\src\\github.com\\DataDog\\datadog-agent\\bin\\agent\\agent.exe",
       "#{Omnibus::Config.source_dir()}\\datadog-agent\\src\\github.com\\DataDog\\datadog-agent\\bin\\agent\\libdatadog-agent-three.dll",
-      "#{Omnibus::Config.source_dir()}\\datadog-agent\\src\\github.com\\DataDog\\datadog-agent\\bin\\agent\\libdatadog-agent-two.dll",
       "#{install_dir}\\bin\\agent\\ddtray.exe"
     ]
+    if with_python_runtime? "2"
+      additional_sign_files.append("#{Omnibus::Config.source_dir()}\\datadog-agent\\src\\github.com\\DataDog\\datadog-agent\\bin\\agent\\libdatadog-agent-two.dll")
+    end
   #if ENV['SIGN_WINDOWS']
   #  signing_identity "ECCDAE36FDCB654D2CBAB3E8975AA55469F96E4C", machine_store: true, algorithm: "SHA256"
   #end

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -101,7 +101,7 @@ compress :dmg do
   pkg_position '10, 10'
 end
 
-# Windows .msi specific flags
+# Windows .zip specific flags
 package :zip do
   if windows_arch_i386?
     skip_packager true
@@ -117,6 +117,7 @@ package :zip do
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\trace-agent.exe",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent.exe",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\libdatadog-agent-three.dll",
+        "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\libdatadog-agent-two.dll",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\install-cmd.exe",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\uninstall-cmd.exe"
       ]
@@ -145,6 +146,8 @@ package :msi do
       "#{Omnibus::Config.source_dir()}\\datadog-agent\\src\\github.com\\DataDog\\datadog-agent\\bin\\agent\\process-agent.exe",
       "#{Omnibus::Config.source_dir()}\\datadog-agent\\src\\github.com\\DataDog\\datadog-agent\\bin\\agent\\trace-agent.exe",
       "#{Omnibus::Config.source_dir()}\\datadog-agent\\src\\github.com\\DataDog\\datadog-agent\\bin\\agent\\agent.exe",
+      "#{Omnibus::Config.source_dir()}\\datadog-agent\\src\\github.com\\DataDog\\datadog-agent\\bin\\agent\\libdatadog-agent-three.dll",
+      "#{Omnibus::Config.source_dir()}\\datadog-agent\\src\\github.com\\DataDog\\datadog-agent\\bin\\agent\\libdatadog-agent-two.dll",
       "#{install_dir}\\bin\\agent\\ddtray.exe"
     ]
   #if ENV['SIGN_WINDOWS']

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -116,7 +116,6 @@ package :zip do
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\security-agent.exe",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\process-agent.exe",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\trace-agent.exe",
-        "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\system-probe.exe",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent.exe",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\libdatadog-agent-two.dll",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\libdatadog-agent-three.dll",
@@ -152,7 +151,7 @@ package :msi do
       "#{install_dir}\\bin\\agent\\ddtray.exe"
     ]
     if with_python_runtime? "2"
-      additional_sign_files << "#{Omnibus::Config.source_dir()}\\datadog-agent\\src\\github.com\\DataDog\\datadog-agent\\bin\\agent\\libdatadog-agent-two.dll"
+      additional_sign_files_list << "#{Omnibus::Config.source_dir()}\\datadog-agent\\src\\github.com\\DataDog\\datadog-agent\\bin\\agent\\libdatadog-agent-two.dll"
     end
   #if ENV['SIGN_WINDOWS']
   #  signing_identity "ECCDAE36FDCB654D2CBAB3E8975AA55469F96E4C", machine_store: true, algorithm: "SHA256"

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -111,18 +111,18 @@ package :zip do
       "#{Omnibus::Config.source_dir()}\\cf-root",
     ]
 
+    # Always sign everything for binaries zip
     additional_sign_files [
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\security-agent.exe",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\process-agent.exe",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\trace-agent.exe",
+        "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\system-probe.exe",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent.exe",
+        "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\libdatadog-agent-two.dll",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\libdatadog-agent-three.dll",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\install-cmd.exe",
         "#{Omnibus::Config.source_dir()}\\cf-root\\bin\\agent\\uninstall-cmd.exe"
       ]
-      if with_python_runtime? "2"
-        additional_sign_files.append("#{Omnibus::Config.source_dir()}\\cf-root\\bin\\libdatadog-agent-two.dll")
-      end
     if ENV['SIGN_PFX']
       signing_identity_file "#{ENV['SIGN_PFX']}", password: "#{ENV['SIGN_PFX_PW']}", algorithm: "SHA256"
     end
@@ -152,7 +152,7 @@ package :msi do
       "#{install_dir}\\bin\\agent\\ddtray.exe"
     ]
     if with_python_runtime? "2"
-      additional_sign_files.append("#{Omnibus::Config.source_dir()}\\datadog-agent\\src\\github.com\\DataDog\\datadog-agent\\bin\\agent\\libdatadog-agent-two.dll")
+      additional_sign_files << "#{Omnibus::Config.source_dir()}\\datadog-agent\\src\\github.com\\DataDog\\datadog-agent\\bin\\agent\\libdatadog-agent-two.dll"
     end
   #if ENV['SIGN_WINDOWS']
   #  signing_identity "ECCDAE36FDCB654D2CBAB3E8975AA55469F96E4C", machine_store: true, algorithm: "SHA256"


### PR DESCRIPTION
### What does this PR do?

This PR ensures that all binaries are signed in Omnibus recipes.

### Motivation

All binaries should be signed.

### Describe how to test your changes

1. Simple way:
Right click on each binaries we ship, and check the tab "Digital signature". For example:
![image](https://user-images.githubusercontent.com/63521/140783683-d6514f63-b628-4aba-ac2e-c62ed54d7eb2.png)

2. Best way:
Download the `signtool.exe` from Microsoft or open a command line session in a build container.
Run the command `signtool.exe verify /pa <path_to_binary>` on each binary. For example:
```
PS C:\Users\julien.lebot> & "C:\Program Files (x86)\Windows Kits\10\App Certification Kit\signtool.exe" verify /pa "C:\Program Files\Datadog\Datadog Agent\bin\agent.exe"
File: C:\Program Files\Datadog\Datadog Agent\bin\agent.exe
Index  Algorithm  Timestamp    
========================================
0      sha256     Authenticode 

Successfully verified: C:\Program Files\Datadog\Datadog Agent\bin\agent.exe


PS C:\Users\julien.lebot> & "C:\Program Files (x86)\Windows Kits\10\App Certification Kit\signtool.exe" verify /pa "C:\Program Files\Datadog\Datadog Agent\embedded\libdatadog-agent-two.dll"
File: C:\Program Files\Datadog\Datadog Agent\embedded\libdatadog-agent-two.dll
Index  Algorithm  Timestamp    
========================================
0      sha256     Authenticode 

Successfully verified: C:\Program Files\Datadog\Datadog Agent\embedded\libdatadog-agent-two.dll


PS C:\Users\julien.lebot> & "C:\Program Files (x86)\Windows Kits\10\App Certification Kit\signtool.exe" verify /pa "C:\Program Files\Datadog\Datadog Agent\embedded\libdatadog-agent-three.dll"
File: C:\Program Files\Datadog\Datadog Agent\embedded\libdatadog-agent-three.dll
Index  Algorithm  Timestamp    
========================================
0      sha256     Authenticode 

Successfully verified: C:\Program Files\Datadog\Datadog Agent\embedded\libdatadog-agent-three.dll


PS C:\Users\julien.lebot> & "C:\Program Files (x86)\Windows Kits\10\App Certification Kit\signtool.exe" verify /pa "C:\Program Files\Datadog\Datadog Agent\embedded\agent\process-agent.exe"
File: C:\Program Files\Datadog\Datadog Agent\embedded\agent\process-agent.exe
Index  Algorithm  Timestamp    
========================================
0      sha256     Authenticode 

Successfully verified: C:\Program Files\Datadog\Datadog Agent\embedded\agent\process-agent.exe


PS C:\Users\julien.lebot> & "C:\Program Files (x86)\Windows Kits\10\App Certification Kit\signtool.exe" verify /pa "C:\Program Files\Datadog\Datadog Agent\embedded\agent\system-probe.exe"
File: C:\Program Files\Datadog\Datadog Agent\embedded\agent\system-probe.exe
Index  Algorithm  Timestamp    
========================================
0      sha256     Authenticode 

Successfully verified: C:\Program Files\Datadog\Datadog Agent\embedded\agent\system-probe.exe


PS C:\Users\julien.lebot> & "C:\Program Files (x86)\Windows Kits\10\App Certification Kit\signtool.exe" verify /pa "C:\Program Files\Datadog\Datadog Agent\embedded\agent\trace-agent.exe"
File: C:\Program Files\Datadog\Datadog Agent\embedded\agent\trace-agent.exe
Index  Algorithm  Timestamp    
========================================
0      sha256     Authenticode 

Successfully verified: C:\Program Files\Datadog\Datadog Agent\embedded\agent\trace-agent.exe


PS C:\Users\julien.lebot> & "C:\Program Files (x86)\Windows Kits\10\App Certification Kit\signtool.exe" verify /pa "C:\Program Files\Datadog\Datadog Agent\embedded\agent\ddtray.exe"
File: C:\Program Files\Datadog\Datadog Agent\embedded\agent\ddtray.exe
Index  Algorithm  Timestamp    
========================================
0      sha256     Authenticode 

Successfully verified: C:\Program Files\Datadog\Datadog Agent\embedded\agent\ddtray.exe
```

### Checklist
<!-- Place an '[x]' (no spaces) in all applicable fields. Please remove unrelated fields. -->

- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] The `need-change/operator` and `need-change/helm` labels has been applied if applicable.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated if applicable.

Note: Adding GitHub labels is only possible for contributors with write access.
