### PR TITLE
[CWS] fix kube client mock issue with `ClusterID`

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1338,6 +1338,7 @@ core,k8s.io/client-go/discovery/fake,Apache-2.0,Cloud Native Computing Foundatio
 core,k8s.io/client-go/dynamic,Apache-2.0,Cloud Native Computing Foundation (CNCF) | The Kubernetes Authors
 core,k8s.io/client-go/dynamic/dynamicinformer,Apache-2.0,Cloud Native Computing Foundation (CNCF) | The Kubernetes Authors
 core,k8s.io/client-go/dynamic/dynamiclister,Apache-2.0,Cloud Native Computing Foundation (CNCF) | The Kubernetes Authors
+core,k8s.io/client-go/dynamic/fake,Apache-2.0,Cloud Native Computing Foundation (CNCF) | The Kubernetes Authors
 core,k8s.io/client-go/informers,Apache-2.0,Cloud Native Computing Foundation (CNCF) | The Kubernetes Authors
 core,k8s.io/client-go/informers/admissionregistration,Apache-2.0,Cloud Native Computing Foundation (CNCF) | The Kubernetes Authors
 core,k8s.io/client-go/informers/admissionregistration/v1,Apache-2.0,Cloud Native Computing Foundation (CNCF) | The Kubernetes Authors

--- a/pkg/compliance/checks/custom/helper_for_test.go
+++ b/pkg/compliance/checks/custom/helper_for_test.go
@@ -33,7 +33,11 @@ func (f *kubeApiserverFixture) run(t *testing.T) {
 	env := &mocks.Env{}
 	defer env.AssertExpectations(t)
 
-	kubeClient := fake.NewSimpleDynamicClient(scheme.Scheme, f.objects...)
+	fakeClient := fake.NewSimpleDynamicClient(scheme.Scheme, f.objects...)
+	kubeClient := &mocks.KubeClientProxy{
+		FakeClient: fakeClient,
+		MockClient: mocks.KubeClient{},
+	}
 	env.On("KubeClient").Return(kubeClient)
 
 	resource := compliance.Resource{

--- a/pkg/compliance/checks/kubeapiserver_check_test.go
+++ b/pkg/compliance/checks/kubeapiserver_check_test.go
@@ -141,7 +141,11 @@ func (f *kubeApiserverFixture) run(t *testing.T) {
 
 	defer env.AssertExpectations(t)
 
-	kubeClient := fake.NewSimpleDynamicClient(scheme, f.objects...)
+	fakeClient := fake.NewSimpleDynamicClient(scheme, f.objects...)
+	kubeClient := &mocks.KubeClientProxy{
+		FakeClient: fakeClient,
+		MockClient: mocks.KubeClient{},
+	}
 	env.On("KubeClient").Return(kubeClient)
 
 	kubeCheck, err := newResourceCheck(env, "rule-id", f.resource)

--- a/pkg/compliance/checks/rego_check.go
+++ b/pkg/compliance/checks/rego_check.go
@@ -239,9 +239,9 @@ func (r *regoCheck) appendInstance(input map[string][]interface{}, key string, i
 func (r *regoCheck) buildContextInput(env env.Env) eval.RegoInputMap {
 	context := make(map[string]interface{})
 	context["hostname"] = env.Hostname()
-	context["kubernetes_cluster"], _ = env.KubeClient().ClusterID()
 	if r.ruleScope == compliance.KubernetesNodeScope {
 		context["kubernetes_node_labels"] = env.NodeLabels()
+		context["kubernetes_cluster"], _ = env.KubeClient().ClusterID()
 	}
 
 	return context

--- a/pkg/compliance/mocks/kube_client_proxy.go
+++ b/pkg/compliance/mocks/kube_client_proxy.go
@@ -1,0 +1,20 @@
+package mocks
+
+import (
+	schema "k8s.io/apimachinery/pkg/runtime/schema"
+	dynamic "k8s.io/client-go/dynamic"
+	"k8s.io/client-go/dynamic/fake"
+)
+
+type KubeClientProxy struct {
+	FakeClient *fake.FakeDynamicClient
+	MockClient KubeClient
+}
+
+func (p *KubeClientProxy) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return p.FakeClient.Resource(resource)
+}
+
+func (p *KubeClientProxy) ClusterID() (string, error) {
+	return p.MockClient.ClusterID()
+}

--- a/pkg/compliance/mocks/kube_client_proxy.go
+++ b/pkg/compliance/mocks/kube_client_proxy.go
@@ -6,15 +6,18 @@ import (
 	"k8s.io/client-go/dynamic/fake"
 )
 
+// KubeClientProxy is a proxy that maps methods to either a mock or a fake client
 type KubeClientProxy struct {
 	FakeClient *fake.FakeDynamicClient
 	MockClient KubeClient
 }
 
+// Resource maps the call to the underlying fake client
 func (p *KubeClientProxy) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
 	return p.FakeClient.Resource(resource)
 }
 
+// ClusterID maps the call to the underlying mock
 func (p *KubeClientProxy) ClusterID() (string, error) {
 	return p.MockClient.ClusterID()
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR fixes the issue with `ClusterID` and the `KubeClient` mock.

### Motivation

Fix tests, and merge rego as soon as possible.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno)
  has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or
  [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml)
  has been updated.
