### PR TITLE
[logs-agent] Use workloadmeta instead of AD to learn about new containers

### DIFF
--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -16,6 +16,7 @@ import (
 	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/client/http"
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -79,8 +80,9 @@ func start(getAC func() *autodiscovery.AutoConfig, serverless bool, logsChan cha
 	sources := config.NewLogSources()
 	services := service.NewServices()
 
-	// setup the config scheduler
-	scheduler.CreateScheduler(sources, services)
+	// setup the config scheduler; this will be added to the AD meta-scheduler
+	// later during agent startup, in common.LoadComponents
+	scheduler.CreateScheduler(sources, services, workloadmeta.GetGlobalStore())
 
 	// setup the server config
 	endpoints, err := buildEndpoints(serverless)

--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -6,6 +6,7 @@
 package scheduler
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
@@ -13,11 +14,18 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	logsConfig "github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
+
+// The logs scheduler is connected to autodiscovery via the agent's
+// common.LoadComponents method, which calls its Schedule and Unschedule
+// methods.  For containers, the scheduler uses workloadmeta, rather than
+// autodiscovery.
 
 var (
 	// scheduler is plugged to autodiscovery to collect integration configs
@@ -33,19 +41,94 @@ var (
 type Scheduler struct {
 	sources  *logsConfig.LogSources
 	services *service.Services
+
+	// context controls the lifetime of this service
+	ctx context.Context
+
+	// cancel cancels the context
+	cancel context.CancelFunc
+
+	// events from the workloadmeta store
+	events chan workloadmeta.EventBundle
+
+	// services we have added, so that we can remove them again, indexed by ID
+	addedServices map[workloadmeta.EntityID]*service.Service
 }
 
-// CreateScheduler creates the scheduler.
-func CreateScheduler(sources *logsConfig.LogSources, services *service.Services) {
-	adScheduler = &Scheduler{
-		sources:  sources,
-		services: services,
+// NewScheduler creates a scheduler that will report to the given LogSources
+// and Services instances.  The scheduler is automatically started.
+func NewScheduler(sources *logsConfig.LogSources, services *service.Services, wlms workloadmeta.Store) *Scheduler {
+	filter := workloadmeta.NewFilter([]workloadmeta.Kind{workloadmeta.KindContainer}, nil)
+	events := wlms.Subscribe("logs", filter)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	sch := &Scheduler{
+		sources:       sources,
+		services:      services,
+		ctx:           ctx,
+		cancel:        cancel,
+		events:        events,
+		addedServices: make(map[workloadmeta.EntityID]*service.Service),
 	}
+	sch.start()
+	return sch
 }
 
-// Stop does nothing.
+// CreateScheduler creates the global scheduler (which will subsequently be
+// returned from GetScheduler)
+func CreateScheduler(sources *logsConfig.LogSources, services *service.Services, wlms workloadmeta.Store) {
+	adScheduler = NewScheduler(sources, services, wlms)
+}
+
+// start begins listening for scheduling events
+func (s *Scheduler) start() {
+	go func() {
+		// logs services have a "creationTime" relative to agent startup: Before or
+		// After.  This is used to determine whether we are logging something that
+		// has already been running (Before) or something new (After), and thus
+		// whether to start at the end (Before) or beginning (After) of the
+		// logfile.  Workloadmeta does not give us this information directly, but
+		// it does produce an EventBundle at subscription time containing all of
+		// the already-detected services.  So, we treat this first bundle as Before
+		// and all subsequent as After.
+		creationTime := service.Before
+
+		for {
+			select {
+			case <-s.ctx.Done():
+				return
+			case evtbundle, open := <-s.events:
+				if !open {
+					return
+				}
+				for _, e := range evtbundle.Events {
+					switch e.Type {
+					case workloadmeta.EventTypeSet:
+						s.handleWorkloadMetaSetEvent(e, creationTime)
+					case workloadmeta.EventTypeUnset:
+						s.handleWorkloadMetaUnsetEvent(e)
+					}
+				}
+				close(evtbundle.Ch)
+				creationTime = service.After
+			}
+		}
+	}()
+}
+
+// Stop stops the scheduler.
 func (s *Scheduler) Stop() {
-	adScheduler = nil
+	// cancel the context, signalling the listening goroutine to stop
+	s.cancel()
+
+	// unsubscribe from workloadmeta events
+	wlms := workloadmeta.GetGlobalStore()
+	wlms.Unsubscribe(s.events)
+
+	// if this was the global scheduler, remove it
+	if s == adScheduler {
+		adScheduler = nil
+	}
 }
 
 // Schedule creates new sources and services from a list of integration configs.
@@ -72,23 +155,6 @@ func (s *Scheduler) Schedule(configs []integration.Config) {
 			for _, source := range sources {
 				s.sources.AddSource(source)
 			}
-		case s.newService(config):
-			entityType, _, err := s.parseEntity(config.TaggerEntity)
-			if err != nil {
-				log.Warnf("Invalid service: %v", err)
-				continue
-			}
-			// logs only consider container services
-			if entityType != containers.ContainerEntityName {
-				continue
-			}
-			log.Infof("Received a new service: %v", config.Entity)
-			service, err := s.toService(config)
-			if err != nil {
-				log.Warnf("Invalid service: %v", err)
-				continue
-			}
-			s.services.AddService(service)
 		default:
 			// invalid integration config
 			continue
@@ -116,24 +182,6 @@ func (s *Scheduler) Unschedule(configs []integration.Config) {
 					s.sources.RemoveSource(source)
 				}
 			}
-		case s.newService(config):
-			// new service to remove
-			entityType, _, err := s.parseEntity(config.TaggerEntity)
-			if err != nil {
-				log.Warnf("Invalid service: %v", err)
-				continue
-			}
-			// logs only consider container services
-			if entityType != containers.ContainerEntityName {
-				continue
-			}
-			log.Infof("New service to remove: entity: %v", config.Entity)
-			service, err := s.toService(config)
-			if err != nil {
-				log.Warnf("Invalid service: %v", err)
-				continue
-			}
-			s.services.RemoveService(service)
 		default:
 			// invalid integration config
 			continue
@@ -141,14 +189,44 @@ func (s *Scheduler) Unschedule(configs []integration.Config) {
 	}
 }
 
+// handleWorkloadMetaSetEvent handles an incoming event from the workload
+// metadata service indicating that an entity has been "set".  The creationTime
+// argument is an estimate of whether this workload started Before or After the
+// agent started.
+func (s *Scheduler) handleWorkloadMetaSetEvent(e workloadmeta.Event, creationTime service.CreationTime) {
+	container := e.Entity.(*workloadmeta.Container)
+
+	var svc *service.Service
+	switch container.Runtime {
+	case workloadmeta.ContainerRuntimeDocker:
+		svc = service.NewService(config.DockerType, container.ID, creationTime)
+	default:
+		// unknown runtime, so no logging
+		return
+	}
+	s.addedServices[e.Entity.GetID()] = svc
+	s.services.AddService(svc)
+}
+
+// handleWorkloadMetaUnsetEvent handles an incoming event from the workload metadata
+// service indicating that an entity has been "unset"
+func (s *Scheduler) handleWorkloadMetaUnsetEvent(e workloadmeta.Event) {
+	// We don't get a workloadmeta.Container in e.Entity, so we do not know the
+	// container runtime for this container and must find the container we have
+	// previously added to s.services.
+	id := e.Entity.GetID()
+	svc, found := s.addedServices[id]
+	if !found {
+		log.Debugf("Container %s was not being logged; nothing to do to stop logging", id)
+		return
+	}
+	s.services.RemoveService(svc)
+	delete(s.addedServices, id)
+}
+
 // newSources returns true if the config can be mapped to sources.
 func (s *Scheduler) newSources(config integration.Config) bool {
 	return config.Provider != ""
-}
-
-// newService returns true if the config can be mapped to a service.
-func (s *Scheduler) newService(config integration.Config) bool {
-	return config.Provider == "" && config.Entity != ""
 }
 
 // configName returns the name of the configuration.

--- a/pkg/serverless/logs/logs_test.go
+++ b/pkg/serverless/logs/logs_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	serverlessMetrics "github.com/DataDog/datadog-agent/pkg/serverless/metrics"
+	workloadmetatesting "github.com/DataDog/datadog-agent/pkg/workloadmeta/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -158,7 +159,7 @@ func TestGetLambdaSourceNilScheduler(t *testing.T) {
 func TestGetLambdaSourceNilSource(t *testing.T) {
 	logSources := config.NewLogSources()
 	services := service.NewServices()
-	scheduler.CreateScheduler(logSources, services)
+	scheduler.CreateScheduler(logSources, services, workloadmetatesting.NewStore())
 	assert.Nil(t, GetLambdaSource())
 }
 
@@ -172,7 +173,7 @@ func TestGetLambdaSourceValidSource(t *testing.T) {
 	})
 	logSources.AddSource(chanSource)
 	services := service.NewServices()
-	scheduler.CreateScheduler(logSources, services)
+	scheduler.CreateScheduler(logSources, services, workloadmetatesting.NewStore())
 	assert.NotNil(t, GetLambdaSource())
 }
 

--- a/pkg/workloadmeta/testing/store.go
+++ b/pkg/workloadmeta/testing/store.go
@@ -8,10 +8,16 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
+type subscriber struct {
+	name string
+	ch   chan workloadmeta.EventBundle
+}
+
 // Store is a testing store that satisfies the workloadmeta.Store interface.
 type Store struct {
-	mu    sync.RWMutex
-	store map[workloadmeta.Kind]map[string]workloadmeta.Entity
+	mu          sync.RWMutex
+	subscribers []subscriber
+	store       map[workloadmeta.Kind]map[string]workloadmeta.Entity
 }
 
 var _ workloadmeta.Store = &Store{}
@@ -121,14 +127,54 @@ func (s *Store) Start(ctx context.Context) {
 	panic("not implemented")
 }
 
-// Subscribe is not implemented in the testing store.
+// Subscribe allows subscriptions, to which events are sent via
+// NotifySubscribers.  The filter is ignored.
 func (s *Store) Subscribe(name string, filter *workloadmeta.Filter) chan workloadmeta.EventBundle {
-	panic("not implemented")
+	// ch needs to be buffered since we'll send it events before the
+	// subscriber has the chance to start receiving from it. if it's
+	// unbuffered, it'll deadlock.
+	sub := subscriber{
+		name: name,
+		ch:   make(chan workloadmeta.EventBundle, 1),
+	}
+
+	s.mu.Lock()
+	s.subscribers = append(s.subscribers, sub)
+	s.mu.Unlock()
+
+	return sub.ch
 }
 
-// Unsubscribe is not implemented in the testing store.
+// Unsubscribe reverses the effect of Subscribe
 func (s *Store) Unsubscribe(ch chan workloadmeta.EventBundle) {
-	panic("not implemented")
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for i, sub := range s.subscribers {
+		if sub.ch == ch {
+			s.subscribers = append(s.subscribers[:i], s.subscribers[i+1:]...)
+			break
+		}
+	}
+
+	close(ch)
+}
+
+// NotifySubscribers sends the given events to all subscrbers as a single
+// bundle, ignoring filters.  It waits for the consumers to acknowledge the
+// bundle by closing Ch.
+func (s *Store) NotifySubscribers(events []workloadmeta.Event) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	for _, sub := range s.subscribers {
+		bundle := workloadmeta.EventBundle{
+			Ch:     make(chan struct{}),
+			Events: events,
+		}
+		sub.ch <- bundle
+		<-bundle.Ch
+	}
 }
 
 // Notify is not implemented in the testing store.


### PR DESCRIPTION
This replaces uses of autodiscovery for detecting new containers with workloadmeta.  

### Motivation

The advantage is that workloadmeta correctly distinguishes container runtimes, so this enables automatically handling docker, containerd, and podman logs correctly (and any other runtimes..)

### Additional Notes

Currently work-in-progress.  See notes in subsequent comments.

### Describe how to test/QA your changes

Configure logging for docker containers and ensure that they still start and stop logging appropriately when the containers are created and destroyed.

Consider other cards from https://trello.com/b/YpG8jaWk/7290-logs-agent-release-qa

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno)
  has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or
  [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml)
  has been updated.
