### PR TITLE
[serverless] Increment errors metric in case of timeout or OOM

### DIFF
--- a/pkg/serverless/logs/logs_test.go
+++ b/pkg/serverless/logs/logs_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/scheduler"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	serverlessMetrics "github.com/DataDog/datadog-agent/pkg/serverless/metrics"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -376,7 +377,7 @@ func TestProcessMessageShouldProcessLogTypeFunction(t *testing.T) {
 	select {
 	case received := <-metricsChan:
 		assert.Equal(t, len(received), 1)
-		assert.Equal(t, "aws.lambda.enhanced.out_of_memory", received[0].Name)
+		assert.Equal(t, serverlessMetrics.OutOfMemoryMetric, received[0].Name)
 	case <-time.After(100 * time.Millisecond):
 		assert.Fail(t, "We should have received metrics")
 	}

--- a/pkg/serverless/metrics/enhanced_metrics.go
+++ b/pkg/serverless/metrics/enhanced_metrics.go
@@ -28,10 +28,11 @@ const (
 	durationMetric        = "aws.lambda.enhanced.duration"
 	estimatedCostMetric   = "aws.lambda.enhanced.estimated_cost"
 	initDurationMetric    = "aws.lambda.enhanced.init_duration"
-	OutOfMemoryMetric     = "aws.lambda.enhanced.out_of_memory"
-	timeoutsMetric        = "aws.lambda.enhanced.timeouts"
-	errorsMetric          = "aws.lambda.enhanced.errors"
-	invocationsMetric     = "aws.lambda.enhanced.invocations"
+	// OutOfMemoryMetric is the name of the out of memory enhanced Lambda metric
+	OutOfMemoryMetric = "aws.lambda.enhanced.out_of_memory"
+	timeoutsMetric    = "aws.lambda.enhanced.timeouts"
+	errorsMetric      = "aws.lambda.enhanced.errors"
+	invocationsMetric = "aws.lambda.enhanced.invocations"
 )
 
 func getOutOfMemorySubstrings() []string {

--- a/pkg/serverless/metrics/enhanced_metrics.go
+++ b/pkg/serverless/metrics/enhanced_metrics.go
@@ -14,11 +14,24 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// Latest Lambda pricing per https://aws.amazon.com/lambda/pricing/
 const (
+	// Latest Lambda pricing per https://aws.amazon.com/lambda/pricing/
 	baseLambdaInvocationPrice = 0.0000002
 	lambdaPricePerGbSecond    = 0.0000166667
 	msToSec                   = 0.001
+
+	// Enhanced metrics
+	maxMemoryUsedMetric   = "aws.lambda.enhanced.max_memory_used"
+	memorySizeMetric      = "aws.lambda.enhanced.memorysize"
+	runtimeDurationMetric = "aws.lambda.enhanced.runtime_duration"
+	billedDurationMetric  = "aws.lambda.enhanced.billed_duration"
+	durationMetric        = "aws.lambda.enhanced.duration"
+	estimatedCostMetric   = "aws.lambda.enhanced.estimated_cost"
+	initDurationMetric    = "aws.lambda.enhanced.init_duration"
+	OutOfMemoryMetric     = "aws.lambda.enhanced.out_of_memory"
+	timeoutsMetric        = "aws.lambda.enhanced.timeouts"
+	errorsMetric          = "aws.lambda.enhanced.errors"
+	invocationsMetric     = "aws.lambda.enhanced.invocations"
 )
 
 func getOutOfMemorySubstrings() []string {
@@ -40,7 +53,7 @@ func GenerateRuntimeDurationMetric(start time.Time, end time.Time, status string
 	} else {
 		duration := end.Sub(start).Milliseconds()
 		metricsChan <- []metrics.MetricSample{{
-			Name:       "aws.lambda.enhanced.runtime_duration",
+			Name:       runtimeDurationMetric,
 			Value:      float64(duration),
 			Mtype:      metrics.DistributionType,
 			Tags:       tags,
@@ -54,14 +67,8 @@ func GenerateRuntimeDurationMetric(start time.Time, end time.Time, status string
 func GenerateEnhancedMetricsFromFunctionLog(logString string, time time.Time, tags []string, metricsChan chan []metrics.MetricSample) {
 	for _, substring := range getOutOfMemorySubstrings() {
 		if strings.Contains(logString, substring) {
-			metricsChan <- []metrics.MetricSample{{
-				Name:       "aws.lambda.enhanced.out_of_memory",
-				Value:      1.0,
-				Mtype:      metrics.DistributionType,
-				Tags:       tags,
-				SampleRate: 1,
-				Timestamp:  float64(time.UnixNano()),
-			}}
+			SendOutOfMemoryEnhancedMetric(tags, time, metricsChan)
+			SendErrorsEnhancedMetric(tags, time, metricsChan)
 			return
 		}
 	}
@@ -73,35 +80,35 @@ func GenerateEnhancedMetricsFromReportLog(initDurationMs float64, durationMs flo
 	billedDuration := float64(billedDurationMs)
 	memorySize := float64(memorySizeMb)
 	enhancedMetrics := []metrics.MetricSample{{
-		Name:       "aws.lambda.enhanced.max_memory_used",
+		Name:       maxMemoryUsedMetric,
 		Value:      float64(maxMemoryUsedMb),
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,
 		SampleRate: 1,
 		Timestamp:  timestamp,
 	}, {
-		Name:       "aws.lambda.enhanced.memorysize",
+		Name:       memorySizeMetric,
 		Value:      memorySize,
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,
 		SampleRate: 1,
 		Timestamp:  timestamp,
 	}, {
-		Name:       "aws.lambda.enhanced.billed_duration",
+		Name:       billedDurationMetric,
 		Value:      billedDuration * msToSec,
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,
 		SampleRate: 1,
 		Timestamp:  timestamp,
 	}, {
-		Name:       "aws.lambda.enhanced.duration",
+		Name:       durationMetric,
 		Value:      durationMs * msToSec,
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,
 		SampleRate: 1,
 		Timestamp:  timestamp,
 	}, {
-		Name:       "aws.lambda.enhanced.estimated_cost",
+		Name:       estimatedCostMetric,
 		Value:      calculateEstimatedCost(billedDuration, memorySize),
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,
@@ -110,7 +117,7 @@ func GenerateEnhancedMetricsFromReportLog(initDurationMs float64, durationMs flo
 	}}
 	if initDurationMs > 0 {
 		initDurationMetric := metrics.MetricSample{
-			Name:       "aws.lambda.enhanced.init_duration",
+			Name:       initDurationMetric,
 			Value:      initDurationMs * msToSec,
 			Mtype:      metrics.DistributionType,
 			Tags:       tags,
@@ -122,27 +129,35 @@ func GenerateEnhancedMetricsFromReportLog(initDurationMs float64, durationMs flo
 	metricsChan <- enhancedMetrics
 }
 
-// SendInvocationEnhancedMetric sends an enhanced metric representing an invocation
-func SendInvocationEnhancedMetric(tags []string, metricsChan chan []metrics.MetricSample) {
-	metricsChan <- []metrics.MetricSample{{
-		Name:       "aws.lambda.enhanced.invocations",
-		Value:      1.0,
-		Mtype:      metrics.DistributionType,
-		Tags:       tags,
-		SampleRate: 1,
-		Timestamp:  float64(time.Now().UnixNano()),
-	}}
+// SendOutOfMemoryEnhancedMetric sends an enhanced metric representing a function running out of memory at a given time
+func SendOutOfMemoryEnhancedMetric(tags []string, time time.Time, metricsChan chan []metrics.MetricSample) {
+	incrementEnhancedMetric(OutOfMemoryMetric, tags, float64(time.UnixNano()), metricsChan)
 }
 
-// SendTimeoutEnhancedMetric sends an enhanced metric representing a timeout
+// SendErrorsEnhancedMetric sends an enhanced metric representing an error at a given time
+func SendErrorsEnhancedMetric(tags []string, time time.Time, metricsChan chan []metrics.MetricSample) {
+	incrementEnhancedMetric(errorsMetric, tags, float64(time.UnixNano()), metricsChan)
+}
+
+// SendTimeoutEnhancedMetric sends an enhanced metric representing a timeout at the current time
 func SendTimeoutEnhancedMetric(tags []string, metricsChan chan []metrics.MetricSample) {
+	incrementEnhancedMetric(timeoutsMetric, tags, float64(time.Now().UnixNano()), metricsChan)
+}
+
+// SendInvocationEnhancedMetric sends an enhanced metric representing an invocation at the current time
+func SendInvocationEnhancedMetric(tags []string, metricsChan chan []metrics.MetricSample) {
+	incrementEnhancedMetric(invocationsMetric, tags, float64(time.Now().UnixNano()), metricsChan)
+}
+
+// incrementEnhancedMetric sends an enhanced metric with a value of 1 to the metrics channel
+func incrementEnhancedMetric(name string, tags []string, timestamp float64, metricsChan chan []metrics.MetricSample) {
 	metricsChan <- []metrics.MetricSample{{
-		Name:       "aws.lambda.enhanced.timeouts",
+		Name:       name,
 		Value:      1.0,
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,
 		SampleRate: 1,
-		Timestamp:  float64(time.Now().UnixNano()),
+		Timestamp:  timestamp,
 	}}
 }
 

--- a/pkg/serverless/metrics/enhanced_metrics_test.go
+++ b/pkg/serverless/metrics/enhanced_metrics_test.go
@@ -20,9 +20,17 @@ func TestGenerateEnhancedMetricsFromFunctionLogOutOfMemory(t *testing.T) {
 	go GenerateEnhancedMetricsFromFunctionLog("JavaScript heap out of memory", reportLogTime, tags, metricsChan)
 
 	generatedMetrics := <-metricsChan
-
 	assert.Equal(t, generatedMetrics, []metrics.MetricSample{{
 		Name:       OutOfMemoryMetric,
+		Value:      1.0,
+		Mtype:      metrics.DistributionType,
+		Tags:       tags,
+		SampleRate: 1,
+		Timestamp:  float64(reportLogTime.UnixNano()),
+	}})
+	generatedMetrics = <-metricsChan
+	assert.Equal(t, generatedMetrics, []metrics.MetricSample{{
+		Name:       errorsMetric,
 		Value:      1.0,
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,

--- a/pkg/serverless/metrics/enhanced_metrics_test.go
+++ b/pkg/serverless/metrics/enhanced_metrics_test.go
@@ -22,7 +22,7 @@ func TestGenerateEnhancedMetricsFromFunctionLogOutOfMemory(t *testing.T) {
 	generatedMetrics := <-metricsChan
 
 	assert.Equal(t, generatedMetrics, []metrics.MetricSample{{
-		Name:       "aws.lambda.enhanced.out_of_memory",
+		Name:       OutOfMemoryMetric,
 		Value:      1.0,
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,
@@ -49,42 +49,42 @@ func TestGenerateEnhancedMetricsFromReportLogColdStart(t *testing.T) {
 	generatedMetrics := <-metricsChan
 
 	assert.Equal(t, generatedMetrics, []metrics.MetricSample{{
-		Name:       "aws.lambda.enhanced.max_memory_used",
+		Name:       maxMemoryUsedMetric,
 		Value:      256.0,
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,
 		SampleRate: 1,
 		Timestamp:  float64(reportLogTime.UnixNano()),
 	}, {
-		Name:       "aws.lambda.enhanced.memorysize",
+		Name:       memorySizeMetric,
 		Value:      1024.0,
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,
 		SampleRate: 1,
 		Timestamp:  float64(reportLogTime.UnixNano()),
 	}, {
-		Name:       "aws.lambda.enhanced.billed_duration",
+		Name:       billedDurationMetric,
 		Value:      0.80,
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,
 		SampleRate: 1,
 		Timestamp:  float64(reportLogTime.UnixNano()),
 	}, {
-		Name:       "aws.lambda.enhanced.duration",
+		Name:       durationMetric,
 		Value:      1.0,
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,
 		SampleRate: 1,
 		Timestamp:  float64(reportLogTime.UnixNano()),
 	}, {
-		Name:       "aws.lambda.enhanced.estimated_cost",
+		Name:       estimatedCostMetric,
 		Value:      calculateEstimatedCost(800.0, 1024.0),
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,
 		SampleRate: 1,
 		Timestamp:  float64(reportLogTime.UnixNano()),
 	}, {
-		Name:       "aws.lambda.enhanced.init_duration",
+		Name:       initDurationMetric,
 		Value:      0.1,
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,
@@ -103,35 +103,35 @@ func TestGenerateEnhancedMetricsFromReportLogNoColdStart(t *testing.T) {
 	generatedMetrics := <-metricsChan
 
 	assert.Equal(t, generatedMetrics, []metrics.MetricSample{{
-		Name:       "aws.lambda.enhanced.max_memory_used",
+		Name:       maxMemoryUsedMetric,
 		Value:      256.0,
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,
 		SampleRate: 1,
 		Timestamp:  float64(reportLogTime.UnixNano()),
 	}, {
-		Name:       "aws.lambda.enhanced.memorysize",
+		Name:       memorySizeMetric,
 		Value:      1024.0,
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,
 		SampleRate: 1,
 		Timestamp:  float64(reportLogTime.UnixNano()),
 	}, {
-		Name:       "aws.lambda.enhanced.billed_duration",
+		Name:       billedDurationMetric,
 		Value:      0.80,
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,
 		SampleRate: 1,
 		Timestamp:  float64(reportLogTime.UnixNano()),
 	}, {
-		Name:       "aws.lambda.enhanced.duration",
+		Name:       durationMetric,
 		Value:      1.0,
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,
 		SampleRate: 1,
 		Timestamp:  float64(reportLogTime.UnixNano()),
 	}, {
-		Name:       "aws.lambda.enhanced.estimated_cost",
+		Name:       estimatedCostMetric,
 		Value:      calculateEstimatedCost(800.0, 1024.0),
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,
@@ -149,7 +149,7 @@ func TestSendTimeoutEnhancedMetric(t *testing.T) {
 	generatedMetrics := <-metricsChan
 
 	assert.Equal(t, generatedMetrics, []metrics.MetricSample{{
-		Name:       "aws.lambda.enhanced.timeouts",
+		Name:       timeoutsMetric,
 		Value:      1.0,
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,
@@ -168,13 +168,49 @@ func TestSendInvocationEnhancedMetric(t *testing.T) {
 	generatedMetrics := <-metricsChan
 
 	assert.Equal(t, generatedMetrics, []metrics.MetricSample{{
-		Name:       "aws.lambda.enhanced.invocations",
+		Name:       invocationsMetric,
 		Value:      1.0,
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,
 		SampleRate: 1,
 		// compare the generated timestamp to itself because we can't know its value
 		Timestamp: generatedMetrics[0].Timestamp,
+	}})
+}
+
+func TestSendOutOfMemoryEnhancedMetric(t *testing.T) {
+	metricsChan := make(chan []metrics.MetricSample)
+	tags := []string{"functionname:test-function"}
+	mockTime := time.Now()
+	go SendOutOfMemoryEnhancedMetric(tags, mockTime, metricsChan)
+
+	generatedMetrics := <-metricsChan
+
+	assert.Equal(t, generatedMetrics, []metrics.MetricSample{{
+		Name:       OutOfMemoryMetric,
+		Value:      1.0,
+		Mtype:      metrics.DistributionType,
+		Tags:       tags,
+		SampleRate: 1,
+		Timestamp:  float64(mockTime.UnixNano()),
+	}})
+}
+
+func TestSendErrorsEnhancedMetric(t *testing.T) {
+	metricsChan := make(chan []metrics.MetricSample)
+	tags := []string{"functionname:test-function"}
+	mockTime := time.Now()
+	go SendErrorsEnhancedMetric(tags, mockTime, metricsChan)
+
+	generatedMetrics := <-metricsChan
+
+	assert.Equal(t, generatedMetrics, []metrics.MetricSample{{
+		Name:       errorsMetric,
+		Value:      1.0,
+		Mtype:      metrics.DistributionType,
+		Tags:       tags,
+		SampleRate: 1,
+		Timestamp:  float64(mockTime.UnixNano()),
 	}})
 }
 
@@ -231,7 +267,7 @@ func TestGenerateRuntimeDurationMetricOK(t *testing.T) {
 	go GenerateRuntimeDurationMetric(startTime, endTime, "myStatus", tags, metricsChan)
 	generatedMetrics := <-metricsChan
 	assert.Equal(t, generatedMetrics, []metrics.MetricSample{{
-		Name:       "aws.lambda.enhanced.runtime_duration",
+		Name:       runtimeDurationMetric,
 		Value:      153,
 		Mtype:      metrics.DistributionType,
 		Tags:       tags,

--- a/pkg/serverless/metrics/metric.go
+++ b/pkg/serverless/metrics/metric.go
@@ -122,5 +122,5 @@ func buildBufferedAggregator(multipleEndpointConfig MultipleEndpointConfig, forw
 }
 
 func buildMetricBlocklist(userProvidedList []string) []string {
-	return append(userProvidedList, "aws.lambda.enhanced.invocations")
+	return append(userProvidedList, invocationsMetric)
 }

--- a/pkg/serverless/metrics/metric_test.go
+++ b/pkg/serverless/metrics/metric_test.go
@@ -116,7 +116,7 @@ func TestBuildMetricBlocklist(t *testing.T) {
 	expected := []string{
 		"user.defined.a",
 		"user.defined.b",
-		"aws.lambda.enhanced.invocations",
+		invocationsMetric,
 	}
 	result := buildMetricBlocklist(userProvidedBlocklist)
 	assert.Equal(t, expected, result)

--- a/pkg/serverless/serverless.go
+++ b/pkg/serverless/serverless.go
@@ -172,6 +172,7 @@ func WaitForNextInvocation(stopCh chan struct{}, daemon *daemon.Daemon, id regis
 			metricTags := tags.AddColdStartTag(daemon.ExtraTags.Tags, daemon.ExecutionContext.Coldstart)
 			metricsChan := daemon.MetricAgent.GetMetricChannel()
 			metrics.SendTimeoutEnhancedMetric(metricTags, metricsChan)
+			metrics.SendErrorsEnhancedMetric(metricTags, time.Now(), metricsChan)
 		}
 		daemon.Stop()
 		stopCh <- struct{}{}


### PR DESCRIPTION
### What does this PR do?

- When the function times out, increment the `aws.lambda.enhanced.errors` metric in addition to the `aws.lambda.enhanced.timeouts` metric.
- When the function runs out of memory, increment the `aws.lambda.enhanced.errors` metric in addition to the `aws.lambda.enhanced.out_of_memory` metric.

### Motivation

Customers should be able to see all types of errors by using the `enhanced.errors` metric. Also, the behavior of the `enhanced.errors` metric should more closely match the behavior of the AWS CloudWatch `errors` metric, which encompasses timeouts and out of memory errors.

### Additional Notes

I also did some minor refactoring of the enhanced metrics code, including creating constants for the enhanced metrics.

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

The new behavior is covered by the Lambda Extension integration tests.

### Reviewer's Checklist
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno)
  has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
