### PR TITLE
[process-agent] Start process agent on Windows when process discovery is enabled

### DIFF
--- a/cmd/agent/app/dependent_services_windows.go
+++ b/cmd/agent/app/dependent_services_windows.go
@@ -35,7 +35,7 @@ var subservices = []Servicedef{
 	},
 	{
 		name:        "process",
-		configKeys:  []string{"process_config.enabled", "network_config.enabled", "system_probe_config.enabled"},
+		configKeys:  []string{"process_config.enabled", "process_config.process_discovery.enabled", "network_config.enabled", "system_probe_config.enabled"},
 		serviceName: "datadog-process-agent",
 		serviceInit: processInit,
 	},

--- a/releasenotes/notes/start-process-agent-service-for-process-discovery-5590b43aa330591c.yaml
+++ b/releasenotes/notes/start-process-agent-service-for-process-discovery-5590b43aa330591c.yaml
@@ -1,0 +1,4 @@
+enhancements:
+  - |
+    Datadog Process Agent Service is started automatically by the core agent on Windows when process discovery is enabled in the config.
+


### PR DESCRIPTION
### What does this PR do?

Starts the process agent service when the `process_config.process_discovery.enabled` flag is enabled.

### Motivation

Support for the process discovery feature in Windows.

### Describe how to test/QA your changes

On Windows, enable the setting in the configuration and make sure that the process agent service starts when the core agent service is started.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno)
  has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or
  [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml)
  has been updated.
