### PR TITLE
Lenaic/improve e2e

### DIFF
--- a/test/e2e/scripts/run-instance/23-argo-get.sh
+++ b/test/e2e/scripts/run-instance/23-argo-get.sh
@@ -28,7 +28,7 @@ done
 
 EXIT_CODE=0
 for workflow in $(./argo list --status Failed -o name | grep -v 'No workflows found'); do
-    ./argo get "$workflow" -o json | jq -r '.status.nodes[] | select(.phase == "Failed") | .displayName + " " + .id' | while read -r displayName podName; do
+    ./argo get "$workflow" -o json | jq -r '.status.nodes | to_entries | map(.value) | sort_by(.phase) | .[] | select(.phase == "Failed" or (.name | contains("onExit[0].diagnose[0]."))) | .displayName + " " + .id' | while read -r displayName podName; do
         printf '\033[1m===> Logs of %s\t%s <===\033[0m\n' "$displayName" "$podName"
         ./argo logs "$workflow" "$podName"
     done

--- a/test/e2e/scripts/setup-instance/03-ssh.sh
+++ b/test/e2e/scripts/setup-instance/03-ssh.sh
@@ -16,7 +16,7 @@ test "${COMMIT_ID}" || {
     COMMIT_ID=$(git rev-parse --verify HEAD)
 }
 
-SSH_OPTS=("-o" "ControlMaster=no" "-o" "ServerAliveInterval=20" "-o" "ConnectTimeout=6" "-o" "StrictHostKeyChecking=no" "-o" "UserKnownHostsFile=/dev/null" "-i" "${PWD}/id_rsa" "-o" "SendEnv=DOCKER_REGISTRY_* DATADOG_AGENT_IMAGE=${DATADOG_AGENT_IMAGE:-datadog/agent-dev:master} DATADOG_CLUSTER_AGENT_IMAGE=${DATADOG_CLUSTER_AGENT_IMAGE:-datadog/cluster-agent-dev:master}")
+SSH_OPTS=("-o" "ServerAliveInterval=20" "-o" "ConnectTimeout=6" "-o" "StrictHostKeyChecking=no" "-o" "UserKnownHostsFile=/dev/null" "-i" "${PWD}/id_rsa" "-o" "SendEnv=DOCKER_REGISTRY_* DATADOG_AGENT_IMAGE=${DATADOG_AGENT_IMAGE:-datadog/agent-dev:master} DATADOG_CLUSTER_AGENT_IMAGE=${DATADOG_CLUSTER_AGENT_IMAGE:-datadog/cluster-agent-dev:master}")
 
 function _ssh() {
     ssh "${SSH_OPTS[@]}" -lcore "${MACHINE}" "$@"
@@ -59,6 +59,8 @@ else
 fi
 
 _ssh_logged /home/core/datadog-agent/test/e2e/scripts/run-instance/10-setup-kind.sh
+# Force reconnection to take into account the addition of the `docker` group to the `core` user
+_ssh -O exit
 _ssh_logged /home/core/datadog-agent/test/e2e/scripts/run-instance/11-setup-kind-cluster.sh
 
 # Use a logged bash

--- a/test/e2e/scripts/setup-instance/03-ssh.sh
+++ b/test/e2e/scripts/setup-instance/03-ssh.sh
@@ -60,7 +60,7 @@ fi
 
 _ssh_logged /home/core/datadog-agent/test/e2e/scripts/run-instance/10-setup-kind.sh
 # Force reconnection to take into account the addition of the `docker` group to the `core` user
-_ssh -O exit
+_ssh -O exit ||:
 _ssh_logged /home/core/datadog-agent/test/e2e/scripts/run-instance/11-setup-kind-cluster.sh
 
 # Use a logged bash


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->
When the e2e tests are failing, in order to help diagnosing what’s wrong,
* the logs of the failed steps is printed
* some additional “diagnostic” steps are run to collect `agent status`, `agent config`, etc.
But as the “diagonstic” steps were successful, the collected data was not printed !

With this change, the CI will print the logs of both:
* the failed steps and
* the “diagostic” steps.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Provide more clues to investigate e2e tests failures.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Look at the GitLab logs of a failed e2e job.
It should now contain the output of all the diagnostic “steps” in addition to the output of the failed steps.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [X] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [X] The appropriate `team/..` label has been applied, if known.
- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno)
  has been added or the `changelog/no-changelog` label has been applied.
- [X] Changed code has automated tests for its functionality.
- [X] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [X] If applicable, docs team has been notified or
  [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [X] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [X] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml)
  has been updated.
