### PR TITLE
[workloadmeta] Extract the org.opencontainers.image.revision docker label

### DIFF
--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -30,9 +30,10 @@ const (
 	podStandardLabelPrefix           = "tags.datadoghq.com/"
 
 	// Standard tag - Tag keys
-	tagKeyEnv     = "env"
-	tagKeyVersion = "version"
-	tagKeyService = "service"
+	tagKeyEnv          = "env"
+	tagKeyVersion      = "version"
+	tagKeyService      = "service"
+	tagKeyGitCommitSha = "git.commit.sha"
 
 	// Standard K8s labels - Tag keys
 	tagKeyKubeAppName      = "kube_app_name"
@@ -48,9 +49,10 @@ const (
 	envVarService = "DD_SERVICE"
 
 	// Docker label keys
-	dockerLabelEnv     = "com.datadoghq.tags.env"
-	dockerLabelVersion = "com.datadoghq.tags.version"
-	dockerLabelService = "com.datadoghq.tags.service"
+	dockerLabelEnv      = "com.datadoghq.tags.env"
+	dockerLabelVersion  = "com.datadoghq.tags.version"
+	dockerLabelService  = "com.datadoghq.tags.service"
+	dockerLabelRevision = "org.opencontainers.image.revision"
 
 	autodiscoveryLabelTagsKey = "com.datadoghq.ad.tags"
 )
@@ -78,9 +80,10 @@ var (
 	}
 
 	standardDockerLabels = map[string]string{
-		dockerLabelEnv:     tagKeyEnv,
-		dockerLabelVersion: tagKeyVersion,
-		dockerLabelService: tagKeyService,
+		dockerLabelEnv:      tagKeyEnv,
+		dockerLabelVersion:  tagKeyVersion,
+		dockerLabelService:  tagKeyService,
+		dockerLabelRevision: tagKeyGitCommitSha,
 	}
 
 	lowCardOrchestratorLabels = map[string]string{

--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -30,10 +30,9 @@ const (
 	podStandardLabelPrefix           = "tags.datadoghq.com/"
 
 	// Standard tag - Tag keys
-	tagKeyEnv          = "env"
-	tagKeyVersion      = "version"
-	tagKeyService      = "service"
-	tagKeyGitCommitSha = "git.commit.sha"
+	tagKeyEnv     = "env"
+	tagKeyVersion = "version"
+	tagKeyService = "service"
 
 	// Standard K8s labels - Tag keys
 	tagKeyKubeAppName      = "kube_app_name"
@@ -49,10 +48,9 @@ const (
 	envVarService = "DD_SERVICE"
 
 	// Docker label keys
-	dockerLabelEnv      = "com.datadoghq.tags.env"
-	dockerLabelVersion  = "com.datadoghq.tags.version"
-	dockerLabelService  = "com.datadoghq.tags.service"
-	dockerLabelRevision = "org.opencontainers.image.revision"
+	dockerLabelEnv     = "com.datadoghq.tags.env"
+	dockerLabelVersion = "com.datadoghq.tags.version"
+	dockerLabelService = "com.datadoghq.tags.service"
 
 	autodiscoveryLabelTagsKey = "com.datadoghq.ad.tags"
 )
@@ -80,10 +78,9 @@ var (
 	}
 
 	standardDockerLabels = map[string]string{
-		dockerLabelEnv:      tagKeyEnv,
-		dockerLabelVersion:  tagKeyVersion,
-		dockerLabelService:  tagKeyService,
-		dockerLabelRevision: tagKeyGitCommitSha,
+		dockerLabelEnv:     tagKeyEnv,
+		dockerLabelVersion: tagKeyVersion,
+		dockerLabelService: tagKeyService,
 	}
 
 	lowCardOrchestratorLabels = map[string]string{
@@ -92,6 +89,9 @@ var (
 
 		"io.rancher.stack.name":         "rancher_stack",
 		"io.rancher.stack_service.name": "rancher_service",
+
+		// Automatically extract git commit sha from image for source code integration
+		"org.opencontainers.image.revision": "git.commit.sha",
 	}
 
 	highCardOrchestratorLabels = map[string]string{

--- a/pkg/tagger/collectors/workloadmeta_test.go
+++ b/pkg/tagger/collectors/workloadmeta_test.go
@@ -836,7 +836,7 @@ func TestHandleContainer(t *testing.T) {
 					},
 					OrchestratorCardTags: []string{},
 					LowCardTags:          []string{"git.commit.sha:758691a28aa920070651d360814c559bc26af907"},
-					StandardTags:         []string{"git.commit.sha:758691a28aa920070651d360814c559bc26af907"},
+					StandardTags:         []string{},
 				},
 			},
 		},

--- a/pkg/tagger/collectors/workloadmeta_test.go
+++ b/pkg/tagger/collectors/workloadmeta_test.go
@@ -815,6 +815,31 @@ func TestHandleContainer(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "opencontainers image revision",
+			container: workloadmeta.Container{
+				EntityID: entityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: containerName,
+					Labels: map[string]string{
+						"org.opencontainers.image.revision": "758691a28aa920070651d360814c559bc26af907",
+					},
+				},
+			},
+			expected: []*TagInfo{
+				{
+					Source: containerSource,
+					Entity: taggerEntityID,
+					HighCardTags: []string{
+						fmt.Sprintf("container_name:%s", containerName),
+						fmt.Sprintf("container_id:%s", entityID.ID),
+					},
+					OrchestratorCardTags: []string{},
+					LowCardTags:          []string{"git.commit.sha:758691a28aa920070651d360814c559bc26af907"},
+					StandardTags:         []string{"git.commit.sha:758691a28aa920070651d360814c559bc26af907"},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/releasenotes/notes/opencontainers-image-revision-as-tag-caa73d54488f0b52.yaml
+++ b/releasenotes/notes/opencontainers-image-revision-as-tag-caa73d54488f0b52.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    Automatically extract the org.opencontainers.image.revision docker label into the git.commit.sha standard tag.
+    Automatically extract the org.opencontainers.image.revision docker label into the git.commit.sha tag.

--- a/releasenotes/notes/opencontainers-image-revision-as-tag-caa73d54488f0b52.yaml
+++ b/releasenotes/notes/opencontainers-image-revision-as-tag-caa73d54488f0b52.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Automatically extract the org.opencontainers.image.revision docker label into the git.commit.sha standard tag.

--- a/releasenotes/notes/opencontainers-image-revision-as-tag-caa73d54488f0b52.yaml
+++ b/releasenotes/notes/opencontainers-image-revision-as-tag-caa73d54488f0b52.yaml
@@ -1,4 +1,4 @@
 ---
 enhancements:
   - |
-    Automatically extract the org.opencontainers.image.revision docker label into the git.commit.sha tag.
+    Automatically extract the ``org.opencontainers.image.revision`` container label into the ``git.commit.sha`` tag.


### PR DESCRIPTION
### What does this PR do?

Automatically extract the `org.opencontainers.image.revision` docker label into the `git.commit.sha` tag.

### Motivation

The `git.commit.sha` tag must be set for Datadog's Source Code Integration setup.
Our public documentation currently suggest using the `org.opencontainers.image.revision` docker label and to configure the agent to extract the tag. See [Configure the Agent](https://docs.datadoghq.com/integrations/guide/source-code-integration/?tab=dockerruntime#configure-the-agent).  
 This PR will make the Source Code Integration setup easier by allowing to skip the `Configure the Agent` part.

### Additional Notes

The label is added inside the `standardDockerLabels` map since we do want this behavior to be enabled by default for all.

I've opened a draft [documentation PR](https://github.com/DataDog/documentation/pull/12237/files).

### Describe how to test/QA your changes

Start the Agent with a traced app running within a container with the label `org.opencontainers.image.revision` set.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno)
  has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or
  [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
