### PR TITLE
[cmd/workload-list] Fix error message

### DIFF
--- a/cmd/agent/app/workload_list.go
+++ b/cmd/agent/app/workload_list.go
@@ -61,7 +61,7 @@ var workloadListCommand = &cobra.Command{
 		r, err := util.DoGet(c, workloadURL(verboseList, ipcAddress, config.Datadog.GetInt("cmd_port")))
 		if err != nil {
 			if r != nil && string(r) != "" {
-				fmt.Fprintf(color.Output, "The agent ran into an error while getting tags list: %s\n", string(r))
+				fmt.Fprintf(color.Output, "The agent ran into an error while getting the workload store information: %s\n", string(r))
 			} else {
 				fmt.Fprintf(color.Output, "Failed to query the agent (running?): %s\n", err)
 			}


### PR DESCRIPTION
### What does this PR do?

Fixes an error message in the `agent workload-list` command. The message was referring to the tagger instead of the workloadmeta store.

### Describe how to test/QA your changes

Skip.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno)
  has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or
  [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml)
  has been updated.
