### PR TITLE
[orchestration] fix output in case CLC is running

### DIFF
--- a/cmd/cluster-agent/commands/clusterchecks.go
+++ b/cmd/cluster-agent/commands/clusterchecks.go
@@ -22,12 +22,15 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	checkName string
+)
+
 func GetClusterChecksCobraCmd(flagNoColor *bool, confPath *string, loggerName config.LoggerName) *cobra.Command {
 	clusterChecksCmd := &cobra.Command{
 		Use:   "clusterchecks",
 		Short: "Prints the active cluster check configurations",
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			if *flagNoColor {
 				color.NoColor = true
 			}
@@ -45,13 +48,14 @@ func GetClusterChecksCobraCmd(flagNoColor *bool, confPath *string, loggerName co
 				return err
 			}
 
-			if err = flare.GetClusterChecks(color.Output); err != nil {
+			if err = flare.GetClusterChecks(color.Output, checkName); err != nil {
 				return err
 			}
 
 			return flare.GetEndpointsChecks(color.Output)
 		},
 	}
+	clusterChecksCmd.PersistentFlags().StringVarP(&checkName, "cluster-check-name", "", "", "the cluster check name to filter for")
 
 	return clusterChecksCmd
 }

--- a/cmd/cluster-agent/commands/clusterchecks.go
+++ b/cmd/cluster-agent/commands/clusterchecks.go
@@ -52,10 +52,10 @@ func GetClusterChecksCobraCmd(flagNoColor *bool, confPath *string, loggerName co
 				return err
 			}
 
-			return flare.GetEndpointsChecks(color.Output)
+			return flare.GetEndpointsChecks(color.Output, checkName)
 		},
 	}
-	clusterChecksCmd.PersistentFlags().StringVarP(&checkName, "cluster-check-name", "", "", "the cluster check name to filter for")
+	clusterChecksCmd.PersistentFlags().StringVarP(&checkName, "check", "", "", "the check name to filter for")
 
 	return clusterChecksCmd
 }

--- a/pkg/clusteragent/clusterchecks/api_nocompile.go
+++ b/pkg/clusteragent/clusterchecks/api_nocompile.go
@@ -43,8 +43,3 @@ func (h *Handler) Run(_ context.Context) error {
 func GetStats() (*types.Stats, error) {
 	return nil, ErrNotCompiled
 }
-
-// GetState not implemented
-func GetState() (*types.StateResponse, error) {
-	return nil, ErrNotCompiled
-}

--- a/pkg/clusteragent/clusterchecks/api_nocompile.go
+++ b/pkg/clusteragent/clusterchecks/api_nocompile.go
@@ -43,3 +43,8 @@ func (h *Handler) Run(_ context.Context) error {
 func GetStats() (*types.Stats, error) {
 	return nil, ErrNotCompiled
 }
+
+// GetState not implemented
+func GetState() (*types.StateResponse, error) {
+	return nil, ErrNotCompiled
+}

--- a/pkg/clusteragent/clusterchecks/stats.go
+++ b/pkg/clusteragent/clusterchecks/stats.go
@@ -33,6 +33,23 @@ func GetStats() (*types.Stats, error) {
 	return handler.getStats(), nil
 }
 
+// GetState retrieves the stats of the latest started handler.
+// It is used for the agent status command.
+func GetState() (*types.StateResponse, error) {
+	key := cache.BuildAgentKey(handlerCacheKey)
+	x, found := cache.Cache.Get(key)
+	if !found {
+		return nil, errors.New("Clusterchecks not running")
+	}
+
+	handler, ok := x.(*Handler)
+	if !ok {
+		return nil, errors.New("Cache entry is not a valid handler")
+	}
+	state, err := handler.GetState()
+	return &state, err
+}
+
 func (h *Handler) getStats() *types.Stats {
 	h.m.RLock()
 	defer h.m.RUnlock()

--- a/pkg/clusteragent/clusterchecks/stats.go
+++ b/pkg/clusteragent/clusterchecks/stats.go
@@ -33,23 +33,6 @@ func GetStats() (*types.Stats, error) {
 	return handler.getStats(), nil
 }
 
-// GetState retrieves the stats of the latest started handler.
-// It is used for the agent status command.
-func GetState() (*types.StateResponse, error) {
-	key := cache.BuildAgentKey(handlerCacheKey)
-	x, found := cache.Cache.Get(key)
-	if !found {
-		return nil, errors.New("Clusterchecks not running")
-	}
-
-	handler, ok := x.(*Handler)
-	if !ok {
-		return nil, errors.New("Cache entry is not a valid handler")
-	}
-	state, err := handler.GetState()
-	return &state, err
-}
-
 func (h *Handler) getStats() *types.Stats {
 	h.m.RLock()
 	defer h.m.RUnlock()

--- a/pkg/clusteragent/clusterchecks/stats.go
+++ b/pkg/clusteragent/clusterchecks/stats.go
@@ -56,12 +56,16 @@ func (h *Handler) getStats() *types.Stats {
 func (d *dispatcher) getStats() *types.Stats {
 	d.store.RLock()
 	defer d.store.RUnlock()
-
+	var checkNames []string
+	for _, m := range d.store.digestToConfig {
+		checkNames = append(checkNames, m.Name)
+	}
 	return &types.Stats{
 		Active:          d.store.active,
 		NodeCount:       len(d.store.nodes),
 		ActiveConfigs:   len(d.store.digestToNode),
 		DanglingConfigs: len(d.store.danglingConfigs),
 		TotalConfigs:    len(d.store.digestToConfig),
+		CheckNames:      checkNames,
 	}
 }

--- a/pkg/clusteragent/clusterchecks/stats.go
+++ b/pkg/clusteragent/clusterchecks/stats.go
@@ -56,9 +56,9 @@ func (h *Handler) getStats() *types.Stats {
 func (d *dispatcher) getStats() *types.Stats {
 	d.store.RLock()
 	defer d.store.RUnlock()
-	var checkNames []string
+	var checkNames map[string]struct{}
 	for _, m := range d.store.digestToConfig {
-		checkNames = append(checkNames, m.Name)
+		checkNames[m.Name] = struct{}{}
 	}
 	return &types.Stats{
 		Active:          d.store.active,

--- a/pkg/clusteragent/clusterchecks/types/types.go
+++ b/pkg/clusteragent/clusterchecks/types/types.go
@@ -64,6 +64,7 @@ type Stats struct {
 	ActiveConfigs   int
 	DanglingConfigs int
 	TotalConfigs    int
+	CheckNames      []string
 }
 
 // LeaderIPCallback describes the leader-election method we

--- a/pkg/clusteragent/clusterchecks/types/types.go
+++ b/pkg/clusteragent/clusterchecks/types/types.go
@@ -64,7 +64,7 @@ type Stats struct {
 	ActiveConfigs   int
 	DanglingConfigs int
 	TotalConfigs    int
-	CheckNames      []string
+	CheckNames      map[string]struct{}
 }
 
 // LeaderIPCallback describes the leader-election method we

--- a/pkg/clusteragent/orchestrator/status.go
+++ b/pkg/clusteragent/orchestrator/status.go
@@ -88,7 +88,7 @@ func GetStatus(ctx context.Context, apiCl kubernetes.Interface) map[string]inter
 		} else {
 			for _, node := range state.Nodes {
 				for _, c := range node.Configs {
-					if c.Name == orchestrator.OrchestratorCheckName { // use name
+					if c.Name == orchestrator.CheckName { // use name
 						if c.NodeName != "" {
 							dispatchedNodes = append(dispatchedNodes, clcNode{
 								Node:   c.NodeName,

--- a/pkg/clusteragent/orchestrator/status.go
+++ b/pkg/clusteragent/orchestrator/status.go
@@ -31,6 +31,11 @@ type stats struct {
 	TotalMiss int64
 }
 
+type clcNode struct {
+	Node   string
+	Source string
+}
+
 // GetStatus returns status info for the orchestrator explorer.
 func GetStatus(ctx context.Context, apiCl kubernetes.Interface) map[string]interface{} {
 	status := make(map[string]interface{})
@@ -74,7 +79,7 @@ func GetStatus(ctx context.Context, apiCl kubernetes.Interface) map[string]inter
 	// rewriting DCA Mode in case we are running in cluster check mode.
 	if config.Datadog.GetBool("cluster_checks.enabled") {
 		status["CLCEnabled"] = true
-		var dispatchedNodes []string
+		var dispatchedNodes []clcNode
 		state, err := clusterchecks.GetState()
 		if err != nil {
 			status["CLCRunnerError"] = err.Error()
@@ -85,7 +90,10 @@ func GetStatus(ctx context.Context, apiCl kubernetes.Interface) map[string]inter
 				for _, c := range node.Configs {
 					if c.Name == orchestrator.OrchestratorCheckName { // use name
 						if c.NodeName != "" {
-							dispatchedNodes = append(dispatchedNodes, c.NodeName)
+							dispatchedNodes = append(dispatchedNodes, clcNode{
+								Node:   c.NodeName,
+								Source: c.Source,
+							})
 						}
 					}
 				}

--- a/pkg/clusteragent/orchestrator/status.go
+++ b/pkg/clusteragent/orchestrator/status.go
@@ -79,12 +79,18 @@ func GetStatus(ctx context.Context, apiCl kubernetes.Interface) map[string]inter
 		if err != nil {
 			status["CLCError"] = err.Error()
 		} else {
-			for _, name := range getStats.CheckNames {
-				if name == orchestrator.CheckName {
-					status["CLCEnabled"] = true
-					status["CacheNumber"] = "No Elements in the cache, since collection is run on CLC Runners"
-					status["CollectionWorking"] = "The collection is not running on the DCA but on the CLC Runners"
-					break
+			// this and the cache section will only be shown on the DCA leader
+			if !getStats.Active {
+				status["CLCEnabled"] = true
+				status["CollectionWorking"] = "Clusterchecks are activated but still warming up, the collection could be running on CLC Runners. To verify that we need the clusterchecks to be warmed up."
+			} else {
+				for _, name := range getStats.CheckNames {
+					if name == orchestrator.CheckName {
+						status["CLCEnabled"] = true
+						status["CacheNumber"] = "No Elements in the cache, since collection is run on CLC Runners"
+						status["CollectionWorking"] = "The collection is not running on the DCA but on the CLC Runners"
+						break
+					}
 				}
 			}
 		}

--- a/pkg/clusteragent/orchestrator/status.go
+++ b/pkg/clusteragent/orchestrator/status.go
@@ -88,13 +88,12 @@ func GetStatus(ctx context.Context, apiCl kubernetes.Interface) map[string]inter
 		} else {
 			for _, node := range state.Nodes {
 				for _, c := range node.Configs {
-					if c.Name == orchestrator.CheckName { // use name
-						if c.NodeName != "" {
-							dispatchedNodes = append(dispatchedNodes, clcNode{
-								Node:   c.NodeName,
-								Source: c.Source,
-							})
-						}
+					if c.Name == orchestrator.CheckName {
+						dispatchedNodes = append(dispatchedNodes, clcNode{
+							// as we rely on a non endpoint check, we can use the node.Name not c.NodeName
+							Node:   node.Name,
+							Source: c.Source,
+						})
 					}
 				}
 			}
@@ -103,6 +102,7 @@ func GetStatus(ctx context.Context, apiCl kubernetes.Interface) map[string]inter
 		status["CacheNumber"] = "No Elements in the cache, since collection is run on CLC Runners"
 		status["CollectionWorking"] = "The collection is not running on the DCA but on the CLC Runners"
 	}
+
 	// get options
 	if config.Datadog.GetBool("orchestrator_explorer.container_scrubbing.enabled") {
 		status["ContainerScrubbing"] = "Container scrubbing: enabled"

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -43,7 +43,6 @@ import (
 )
 
 const (
-	orchestratorCheckName   = "orchestrator"
 	maximumWaitForAPIServer = 10 * time.Second
 	collectionInterval      = 10 * time.Second
 )
@@ -65,7 +64,7 @@ var (
 )
 
 func init() {
-	core.RegisterCheck(orchestratorCheckName, OrchestratorFactory)
+	core.RegisterCheck(orchestrator.CheckName, OrchestratorFactory)
 }
 
 // OrchestratorInstance is the config of the orchestrator check instance.
@@ -125,7 +124,7 @@ func newOrchestratorCheck(base core.CheckBase, instance *OrchestratorInstance) *
 // OrchestratorFactory returns the orchestrator check
 func OrchestratorFactory() check.Check {
 	return newOrchestratorCheck(
-		core.NewCheckBase(orchestratorCheckName),
+		core.NewCheckBase(orchestrator.CheckName),
 		&OrchestratorInstance{},
 	)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -64,7 +64,7 @@ var (
 )
 
 func init() {
-	core.RegisterCheck(orchestrator.OrchestratorCheckName, OrchestratorFactory)
+	core.RegisterCheck(orchestrator.CheckName, OrchestratorFactory)
 }
 
 // OrchestratorInstance is the config of the orchestrator check instance.
@@ -124,7 +124,7 @@ func newOrchestratorCheck(base core.CheckBase, instance *OrchestratorInstance) *
 // OrchestratorFactory returns the orchestrator check
 func OrchestratorFactory() check.Check {
 	return newOrchestratorCheck(
-		core.NewCheckBase(orchestrator.OrchestratorCheckName),
+		core.NewCheckBase(orchestrator.CheckName),
 		&OrchestratorInstance{},
 	)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -43,7 +43,6 @@ import (
 )
 
 const (
-	orchestratorCheckName   = "orchestrator"
 	maximumWaitForAPIServer = 10 * time.Second
 	collectionInterval      = 10 * time.Second
 )
@@ -65,7 +64,7 @@ var (
 )
 
 func init() {
-	core.RegisterCheck(orchestratorCheckName, OrchestratorFactory)
+	core.RegisterCheck(orchestrator.OrchestratorCheckName, OrchestratorFactory)
 }
 
 // OrchestratorInstance is the config of the orchestrator check instance.
@@ -125,7 +124,7 @@ func newOrchestratorCheck(base core.CheckBase, instance *OrchestratorInstance) *
 // OrchestratorFactory returns the orchestrator check
 func OrchestratorFactory() check.Check {
 	return newOrchestratorCheck(
-		core.NewCheckBase(orchestratorCheckName),
+		core.NewCheckBase(orchestrator.OrchestratorCheckName),
 		&OrchestratorInstance{},
 	)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -43,6 +43,7 @@ import (
 )
 
 const (
+	orchestratorCheckName   = "orchestrator"
 	maximumWaitForAPIServer = 10 * time.Second
 	collectionInterval      = 10 * time.Second
 )
@@ -64,7 +65,7 @@ var (
 )
 
 func init() {
-	core.RegisterCheck(orchestrator.CheckName, OrchestratorFactory)
+	core.RegisterCheck(orchestratorCheckName, OrchestratorFactory)
 }
 
 // OrchestratorInstance is the config of the orchestrator check instance.
@@ -124,7 +125,7 @@ func newOrchestratorCheck(base core.CheckBase, instance *OrchestratorInstance) *
 // OrchestratorFactory returns the orchestrator check
 func OrchestratorFactory() check.Check {
 	return newOrchestratorCheck(
-		core.NewCheckBase(orchestrator.CheckName),
+		core.NewCheckBase(orchestratorCheckName),
 		&OrchestratorInstance{},
 	)
 }

--- a/pkg/flare/archive_dca.go
+++ b/pkg/flare/archive_dca.go
@@ -211,7 +211,7 @@ func zipClusterAgentClusterChecks(tempDir, hostname string) error {
 	var b bytes.Buffer
 
 	writer := bufio.NewWriter(&b)
-	GetClusterChecks(writer) //nolint:errcheck
+	GetClusterChecks(writer, "") //nolint:errcheck
 	writer.Flush()
 
 	f := filepath.Join(tempDir, hostname, "clusterchecks.log")

--- a/pkg/flare/cluster_checks.go
+++ b/pkg/flare/cluster_checks.go
@@ -21,7 +21,7 @@ import (
 )
 
 // GetClusterChecks dumps the clustercheck dispatching state to the writer
-func GetClusterChecks(w io.Writer) error {
+func GetClusterChecks(w io.Writer, checkName string) error {
 	urlstr := fmt.Sprintf("https://localhost:%v/api/v1/clusterchecks", config.Datadog.GetInt("cluster_agent.cmd_port"))
 
 	if w != color.Output {
@@ -74,7 +74,7 @@ func GetClusterChecks(w io.Writer) error {
 	if len(cr.Dangling) > 0 {
 		fmt.Fprintln(w, fmt.Sprintf("=== %s configurations ===", color.RedString("Unassigned")))
 		for _, c := range cr.Dangling {
-			PrintConfig(w, c)
+			PrintConfig(w, c, checkName)
 		}
 		fmt.Fprintln(w, "")
 	}
@@ -101,7 +101,7 @@ func GetClusterChecks(w io.Writer) error {
 		}
 		fmt.Fprintln(w, fmt.Sprintf("\n===== Checks on %s =====", color.HiMagentaString(node.Name)))
 		for _, c := range node.Configs {
-			PrintConfig(w, c)
+			PrintConfig(w, c, checkName)
 		}
 	}
 
@@ -146,7 +146,7 @@ func GetEndpointsChecks(w io.Writer) error {
 	// Print summary of pod-backed endpointschecks
 	fmt.Fprintln(w, fmt.Sprintf("\n===== %d Pod-backed Endpoints-Checks scheduled =====", len(cr.Configs)))
 	for _, c := range cr.Configs {
-		PrintConfig(w, c)
+		PrintConfig(w, c, "")
 	}
 
 	return nil

--- a/pkg/flare/cluster_checks.go
+++ b/pkg/flare/cluster_checks.go
@@ -109,7 +109,7 @@ func GetClusterChecks(w io.Writer, checkName string) error {
 }
 
 // GetEndpointsChecks dumps the endpointschecks dispatching state to the writer
-func GetEndpointsChecks(w io.Writer) error {
+func GetEndpointsChecks(w io.Writer, checkName string) error {
 	if !endpointschecksEnabled() {
 		return nil
 	}
@@ -146,7 +146,7 @@ func GetEndpointsChecks(w io.Writer) error {
 	// Print summary of pod-backed endpointschecks
 	fmt.Fprintln(w, fmt.Sprintf("\n===== %d Pod-backed Endpoints-Checks scheduled =====", len(cr.Configs)))
 	for _, c := range cr.Configs {
-		PrintConfig(w, c, "")
+		PrintConfig(w, c, checkName)
 	}
 
 	return nil

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -64,7 +64,7 @@ func GetConfigCheck(w io.Writer, withDebug bool) error {
 	}
 
 	for _, c := range cr.Configs {
-		PrintConfig(w, c)
+		PrintConfig(w, c, "")
 	}
 
 	if withDebug {
@@ -99,7 +99,10 @@ func GetClusterAgentConfigCheck(w io.Writer, withDebug bool) error {
 }
 
 // PrintConfig prints a human-readable representation of a configuration
-func PrintConfig(w io.Writer, c integration.Config) {
+func PrintConfig(w io.Writer, c integration.Config, checkName string) {
+	if checkName != "" && c.Name != checkName {
+		return
+	}
 	if !c.ClusterCheck {
 		fmt.Fprintln(w, fmt.Sprintf("\n=== %s check ===", color.GreenString(c.Name)))
 	} else {

--- a/pkg/flare/config_check_test.go
+++ b/pkg/flare/config_check_test.go
@@ -58,7 +58,7 @@ func TestContainerExclusionRulesInfo(t *testing.T) {
 			config := newConfig(test.configType, test.excluded)
 
 			var result bytes.Buffer
-			PrintConfig(&result, config)
+			PrintConfig(&result, config, "")
 
 			if test.expectMsg {
 				assert.Contains(t, result.String(), outputMsgs[test.configType])

--- a/pkg/orchestrator/util.go
+++ b/pkg/orchestrator/util.go
@@ -11,6 +11,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+const OrchestratorCheckName   = "orchestrator"
+
 // NodeType represents a kind of resource used by a container orchestrator.
 type NodeType int
 

--- a/pkg/orchestrator/util.go
+++ b/pkg/orchestrator/util.go
@@ -11,8 +11,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// OrchestratorCheckName is the orchestrator cluster check name
-const OrchestratorCheckName   = "orchestrator"
+// CheckName is the orchestrator cluster check name
+const CheckName = "orchestrator"
 
 // NodeType represents a kind of resource used by a container orchestrator.
 type NodeType int

--- a/pkg/orchestrator/util.go
+++ b/pkg/orchestrator/util.go
@@ -11,6 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// OrchestratorCheckName is the orchestrator cluster check name
 const OrchestratorCheckName   = "orchestrator"
 
 // NodeType represents a kind of resource used by a container orchestrator.

--- a/pkg/orchestrator/util.go
+++ b/pkg/orchestrator/util.go
@@ -11,9 +11,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// CheckName is the orchestrator cluster check name
-const CheckName = "orchestrator"
-
 // NodeType represents a kind of resource used by a container orchestrator.
 type NodeType int
 

--- a/pkg/orchestrator/util.go
+++ b/pkg/orchestrator/util.go
@@ -14,6 +14,8 @@ import (
 // NodeType represents a kind of resource used by a container orchestrator.
 type NodeType int
 
+var CheckName = "orchestrator"
+
 const (
 	// K8sDeployment represents a Kubernetes Deployment
 	K8sDeployment NodeType = iota

--- a/pkg/orchestrator/util.go
+++ b/pkg/orchestrator/util.go
@@ -14,6 +14,7 @@ import (
 // NodeType represents a kind of resource used by a container orchestrator.
 type NodeType int
 
+// CheckName is the cluster check name of the orchestrator check
 var CheckName = "orchestrator"
 
 const (

--- a/pkg/status/templates/orchestrator.tmpl
+++ b/pkg/status/templates/orchestrator.tmpl
@@ -32,7 +32,7 @@ Orchestrator Explorer
   ======================
   {{- range $key, $values := .OrchestratorEndpoints}}
   {{- if gt (len $values) 1}}
-  {{$key}} - API Keys ending with:
+				  {{$key}} - API Keys ending with:
   {{- range $values }}
       - {{ . }}
   {{- end}}
@@ -54,6 +54,18 @@ Orchestrator Explorer
     {{ $element.NodeType }}
       Last Run: (Hits: {{$element.CacheHits}} Miss: {{$element.CacheMiss}}) | Total: (Hits: {{$element.TotalHits}} Miss: {{$element.TotalMiss}})
 {{end}}
+  {{- if .CLCEnabled }}
+	  ===========
+  Dispatched Configurations on CLCRunners
+	  ===========
+  {{- if .CLCRunnerError }}
+    CLCRunner Error: {{.CLCRunnerError}}
+  {{else}}
+      {{range $index, $element := .CLCRunners}}
+          {{ $element }}
+      {{end}}
+  {{end}}
+  {{end}}
 {{else}}
 {{- if .LeaderName }}
   Status: Follower, cluster agent leader is: {{ .LeaderName }}

--- a/pkg/status/templates/orchestrator.tmpl
+++ b/pkg/status/templates/orchestrator.tmpl
@@ -56,7 +56,7 @@ Orchestrator Explorer
 {{end}}
 {{- if .CLCEnabled }}
   ===========
-  Dispatched Configurations on CLCRunners
+  Dispatched Configurations on Cluster Check Runners
   ===========
     To print orchestrator check details run agent clusterchecks --cluster-check-name orchestrator
 {{end}}

--- a/pkg/status/templates/orchestrator.tmpl
+++ b/pkg/status/templates/orchestrator.tmpl
@@ -32,7 +32,7 @@ Orchestrator Explorer
   ======================
   {{- range $key, $values := .OrchestratorEndpoints}}
   {{- if gt (len $values) 1}}
-				  {{$key}} - API Keys ending with:
+    {{$key}} - API Keys ending with:
   {{- range $values }}
       - {{ . }}
   {{- end}}
@@ -58,14 +58,7 @@ Orchestrator Explorer
   ===========
   Dispatched Configurations on CLCRunners
   ===========
-{{- if .CLCRunnerError }}
-    CLCRunner Error: {{.CLCRunnerError}}
-{{else}}
- {{range $index, $element := .CLCRunners}}
-    Server: {{ $element.Node }}
-    Configuration: {{ $element.Source }}
-  {{end}}
- {{end}}
+    To print orchestrator check details run agent clusterchecks --cluster-check-name orchestrator
 {{end}}
 {{else}}
 {{- if .LeaderName }}

--- a/pkg/status/templates/orchestrator.tmpl
+++ b/pkg/status/templates/orchestrator.tmpl
@@ -58,7 +58,7 @@ Orchestrator Explorer
   ===========
   Dispatched Configurations on Cluster Check Runners
   ===========
-    To print orchestrator check details run agent clusterchecks --cluster-check-name orchestrator
+    To print orchestrator check details run agent clusterchecks --check orchestrator
 {{end}}
 {{else}}
 {{- if .LeaderName }}

--- a/pkg/status/templates/orchestrator.tmpl
+++ b/pkg/status/templates/orchestrator.tmpl
@@ -37,7 +37,7 @@ Orchestrator Explorer
       - {{ . }}
   {{- end}}
   {{- else}}
-  {{$key}} - API Key ending with: {{index $values 0}}
+    {{$key}} - API Key ending with: {{index $values 0}}
   {{- end}}
   {{- end}}
 
@@ -54,18 +54,19 @@ Orchestrator Explorer
     {{ $element.NodeType }}
       Last Run: (Hits: {{$element.CacheHits}} Miss: {{$element.CacheMiss}}) | Total: (Hits: {{$element.TotalHits}} Miss: {{$element.TotalMiss}})
 {{end}}
-  {{- if .CLCEnabled }}
-	  ===========
+{{- if .CLCEnabled }}
+  ===========
   Dispatched Configurations on CLCRunners
-	  ===========
-  {{- if .CLCRunnerError }}
+  ===========
+{{- if .CLCRunnerError }}
     CLCRunner Error: {{.CLCRunnerError}}
-  {{else}}
-      {{range $index, $element := .CLCRunners}}
-          {{ $element }}
-      {{end}}
+{{else}}
+ {{range $index, $element := .CLCRunners}}
+    Server: {{ $element.Node }}
+    Configuration: {{ $element.Source }}
   {{end}}
-  {{end}}
+ {{end}}
+{{end}}
 {{else}}
 {{- if .LeaderName }}
   Status: Follower, cluster agent leader is: {{ .LeaderName }}

--- a/releasenotes-dca/notes/orchestrator-status-new-clc-932678c503c030af.yaml
+++ b/releasenotes-dca/notes/orchestrator-status-new-clc-932678c503c030af.yaml
@@ -9,3 +9,7 @@
 fixes:
   - |
     Add reworked status output for orchestrator section on CLC setups.
+
+features:
+  - |
+    Add the ability to filter for check names in the cluster checks output.

--- a/releasenotes-dca/notes/orchestrator-status-new-clc-932678c503c030af.yaml
+++ b/releasenotes-dca/notes/orchestrator-status-new-clc-932678c503c030af.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Add reworked status output for orchestrator section on CLC setups.


### PR DESCRIPTION
### What does this PR do?

- orchestration section of DCA output will now "know" when it is running in CLC mode and therefore doesn't expect cache information.
- DCA status output redirects to call `agent clusterchecks --chec korchestrator` to get the clusterchecks and to filter only for a specific check name 

When CLC, dispatched across some workers:
```
=====================
Orchestrator Explorer
=====================
  Collection Status: The collection is not running on the DCA but on the CLC Runners
  Cluster Name: nammn
  Cluster ID: 3a053a3f-b334-4f01-b1ad-5b87c4626d7a

  ======================
  Orchestrator Endpoints
  ======================
    https://orchestrator.datadoghq.com - API Key ending with: f975c

  ===========
  Cache Stats
  ===========
    Elements in the cache: No Elements in the cache, since collection is run on CLC Runners

  Dispatched Configurations on Cluster Check Runners
  ===========
    To print orchestrator check details run agent clusterchecks --check orchestrator
```

if warming up:
```
=====================
Orchestrator Explorer
=====================
  Collection Status: Clusterchecks are activated but still warming up, the collection could be running on CLC Runners. To verify that we need the clusterchecks to be warmed up.
  Cluster Name: nammn
  Cluster ID: 3a053a3f-b334-4f01-b1ad-5b87c4626d7a

  ======================
  Orchestrator Endpoints
  ======================
    https://orchestrator.datadoghq.com - API Key ending with: f975c

  ===========
  Cache Stats
  ===========
    Elements in the cache: 0

  ===========
  Dispatched Configurations on Cluster Check Runners
  ===========
    To print orchestrator check details run agent clusterchecks --check orchestrator
```

without filter
```
╰─❯ k exec -it deployment/datadog-cluster-agent -- agent clusterchecks                                                                    ─╯
2021-11-11 11:18:32 UTC | CLUSTER | WARN | (pkg/util/log/log.go:640 in func1) | Agent configuration relax permissions constraint on the secret backend cmd, Group can read and exec
2021-11-11 11:18:32 UTC | CLUSTER | INFO | (pkg/util/log/log.go:620 in func1) | Features detected from environment: kubernetes,orchestratorexplorer
=== 2 agents reporting ===

Name                                     Running checks
datadog-clusterchecks-5747fcc9cb-h485w   1
datadog-clusterchecks-5747fcc9cb-m5mwv   2

===== Checks on datadog-clusterchecks-5747fcc9cb-h485w =====

=== orchestrator check ===
Configuration provider: file
Configuration source: file:/etc/datadog-agent/conf.d/orchestrator.d/1.yaml
Instance ID: orchestrator:e7d7158143ea4497
collectors:
- services
empty_default_hostname: true
skip_leader_election: true
tags:
- cluster_name:nam.cluster.cluster
- kube_cluster_name:nam.cluster.cluster
~
===

===== Checks on datadog-clusterchecks-5747fcc9cb-m5mwv =====

=== kubernetes_state_core check ===
Configuration provider: file
Configuration source: file:/etc/datadog-agent/conf.d/kubernetes_state_core.d/3.yaml
Instance ID: kubernetes_state_core:7b1a9b5e5f806547
collectors:
- nodes
empty_default_hostname: true
min_collection_interval: 30
skip_leader_election: true
tags:
- cluster_name:nam.cluster.cluster
- kube_cluster_name:nam.cluster.cluster
telemetry: true
~
===

=== orchestrator check ===
Configuration provider: file
Configuration source: file:/etc/datadog-agent/conf.d/orchestrator.d/2.yaml
Instance ID: orchestrator:5d36b9a560b382eb
collectors:
- jobs
empty_default_hostname: true
skip_leader_election: true
tags:
- cluster_name:nam.cluster.cluster
- kube_cluster_name:nam.cluster.cluster
~
===

===== 0 Pod-backed Endpoints-Checks scheduled **=====**
```

calling above filtering method for `orchestrator`

```
╭─ ~/dd/k8s-resources nnguyen/add-wf-es-per-team *4                                                  ○ nam-test/datadog-agent 12:18:32 PM ─╮
╰─❯ k exec -it deployment/datadog-cluster-agent -- agent clusterchecks --cluster-check-name orchestrator                                  ─╯
2021-11-11 11:18:50 UTC | CLUSTER | WARN | (pkg/util/log/log.go:640 in func1) | Agent configuration relax permissions constraint on the secret backend cmd, Group can read and exec
2021-11-11 11:18:50 UTC | CLUSTER | INFO | (pkg/util/log/log.go:620 in func1) | Features detected from environment: kubernetes,orchestratorexplorer
=== 2 agents reporting ===

Name                                     Running checks
datadog-clusterchecks-5747fcc9cb-h485w   1
datadog-clusterchecks-5747fcc9cb-m5mwv   2

===== Checks on datadog-clusterchecks-5747fcc9cb-h485w =====

=== orchestrator check ===
Configuration provider: file
Configuration source: file:/etc/datadog-agent/conf.d/orchestrator.d/1.yaml
Instance ID: orchestrator:e7d7158143ea4497
collectors:
- services
empty_default_hostname: true
skip_leader_election: true
tags:
- cluster_name:nam.cluster.cluster
- kube_cluster_name:nam.cluster.cluster
~
===

===== Checks on datadog-clusterchecks-5747fcc9cb-m5mwv =====

=== orchestrator check ===
Configuration provider: file
Configuration source: file:/etc/datadog-agent/conf.d/orchestrator.d/2.yaml
Instance ID: orchestrator:5d36b9a560b382eb
collectors:
- jobs
empty_default_hostname: true
skip_leader_election: true
tags:
- cluster_name:nam.cluster.cluster
- kube_cluster_name:nam.cluster.cluster
~
===

===== 0 Pod-backed Endpoints-Checks scheduled =====
```


**Missing**:
- Cache stats on the runner running the orchestrator check

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno)
  has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or
  [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml)
  has been updated.
