### PR TITLE
[workloadmeta/dump] Scrub sensitive data

### DIFF
--- a/cmd/agent/app/workload_list.go
+++ b/cmd/agent/app/workload_list.go
@@ -73,9 +73,7 @@ var workloadListCommand = &cobra.Command{
 			return err
 		}
 
-		workload.Write(color.Output)
-
-		return nil
+		return workload.Write(color.Output)
 	},
 }
 


### PR DESCRIPTION
### What does this PR do?

Scrubs sensitive data from the output of the `workload-list` command.

### Motivation

The output can contain sensitive information. For example, if the api key is passed as an ENV to the agent container, because envs appear in the output of `workload-list --verbose`.

### Describe how to test/QA your changes

Run the agent with docker/containerd passing the api key as an ENV. Run `agent workload-list --verbose` and check that in the `Env variables` section of the agent container, the api key has been cleaned-up with `*`s.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno)
  has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or
  [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml)
  has been updated.
