### PR TITLE
pkg/trace: add config to disable rare sampler

### DIFF
--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -65,6 +65,7 @@ func setupAPM(config Config) {
 	config.BindEnv("apm_config.max_events_per_second", "DD_APM_MAX_EPS", "DD_MAX_EPS")
 	config.BindEnv("apm_config.max_traces_per_second", "DD_APM_MAX_TPS", "DD_MAX_TPS")
 	config.BindEnv("apm_config.errors_per_second", "DD_APM_ERROR_TPS")
+	config.BindEnv("apm_config.disable_rare_sampler", "DD_APM_DISABLE_RARE_SAMPLER")
 	config.BindEnv("apm_config.max_memory", "DD_APM_MAX_MEMORY")
 	config.BindEnv("apm_config.max_cpu_percent", "DD_APM_MAX_CPU_PERCENT")
 	config.BindEnv("apm_config.env", "DD_APM_ENV")

--- a/pkg/flare/envvars.go
+++ b/pkg/flare/envvars.go
@@ -54,6 +54,7 @@ var allowedEnvvarNames = []string{
 	"DD_APM_TPS", //deprecated
 	"DD_APM_MAX_TPS",
 	"DD_APM_ERROR_TPS",
+	"DD_APM_DISABLE_RARE_SAMPLER",
 	"DD_APM_MAX_MEMORY",
 	"DD_APM_MAX_CPU_PERCENT",
 	"DD_APM_FEATURES",

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -78,7 +78,7 @@ func NewAgent(ctx context.Context, conf *config.AgentConfig) *Agent {
 		Replacer:              filters.NewReplacer(conf.ReplaceTags),
 		PrioritySampler:       sampler.NewPrioritySampler(conf, dynConf),
 		ErrorsSampler:         sampler.NewErrorsSampler(conf),
-		RareSampler:           sampler.NewRareSampler(conf),
+		RareSampler:           sampler.NewRareSampler(),
 		NoPrioritySampler:     sampler.NewNoPrioritySampler(conf),
 		EventProcessor:        newEventProcessor(conf),
 		TraceWriter:           writer.NewTraceWriter(conf),
@@ -403,6 +403,9 @@ func (a *Agent) samplePriorityTrace(pt ProcessedTrace) bool {
 	}
 	if traceContainsError(pt.Trace) {
 		return a.ErrorsSampler.Sample(pt.Trace, pt.Root, pt.Env)
+	}
+	if a.conf.DisableRareSampler {
+		return false
 	}
 	return a.RareSampler.Sample(pt.Trace, pt.Root, pt.Env)
 }

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -78,7 +78,7 @@ func NewAgent(ctx context.Context, conf *config.AgentConfig) *Agent {
 		Replacer:              filters.NewReplacer(conf.ReplaceTags),
 		PrioritySampler:       sampler.NewPrioritySampler(conf, dynConf),
 		ErrorsSampler:         sampler.NewErrorsSampler(conf),
-		RareSampler:           sampler.NewRareSampler(),
+		RareSampler:           sampler.NewRareSampler(conf),
 		NoPrioritySampler:     sampler.NewNoPrioritySampler(conf),
 		EventProcessor:        newEventProcessor(conf),
 		TraceWriter:           writer.NewTraceWriter(conf),

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -628,6 +628,7 @@ func TestSampling(t *testing.T) {
 				NoPrioritySampler: sampler.NewNoPrioritySampler(cfg),
 				ErrorsSampler:     sampler.NewErrorsSampler(cfg),
 				PrioritySampler:   sampler.NewPrioritySampler(cfg, &sampler.DynamicConfig{}),
+				RareSampler:       sampler.NewRareSampler(cfg),
 			}
 			if tt.errorsSampled {
 				a.ErrorsSampler = sampler.NewErrorsSampler(sampledCfg)

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -263,6 +263,9 @@ func (c *AgentConfig) applyDatadogConfig() error {
 	if config.Datadog.IsSet("apm_config.errors_per_second") {
 		c.ErrorTPS = config.Datadog.GetFloat64("apm_config.errors_per_second")
 	}
+	if config.Datadog.IsSet("apm_config.disable_rare_sampler") {
+		c.DisableRareSampler = config.Datadog.GetBool("apm_config.disable_rare_sampler")
+	}
 
 	if k := "apm_config.ignore_resources"; config.Datadog.IsSet(k) {
 		c.Ignore["resource"] = config.Datadog.GetStringSlice(k)

--- a/pkg/trace/config/config.go
+++ b/pkg/trace/config/config.go
@@ -68,10 +68,11 @@ type AgentConfig struct {
 	ExtraAggregators []string
 
 	// Sampler configuration
-	ExtraSampleRate float64
-	TargetTPS       float64
-	ErrorTPS        float64
-	MaxEPS          float64
+	ExtraSampleRate    float64
+	TargetTPS          float64
+	ErrorTPS           float64
+	DisableRareSampler bool
+	MaxEPS             float64
 
 	// Receiver
 	ReceiverHost    string

--- a/pkg/trace/config/config_test.go
+++ b/pkg/trace/config/config_test.go
@@ -329,6 +329,7 @@ func TestUndocumentedYamlConfig(t *testing.T) {
 	assert.Equal(0.33, c.ExtraSampleRate)
 	assert.Equal(100.0, c.TargetTPS)
 	assert.Equal(37.0, c.ErrorTPS)
+	assert.Equal(true, c.DisableRareSampler)
 	assert.Equal(1000.0, c.MaxEPS)
 	assert.Equal(25, c.ReceiverPort)
 	assert.Equal(120*time.Second, c.ConnectionResetInterval)

--- a/pkg/trace/config/env_test.go
+++ b/pkg/trace/config/env_test.go
@@ -325,6 +325,21 @@ func TestLoadEnv(t *testing.T) {
 	}
 
 	for _, envKey := range []string{
+		"DD_APM_DISABLE_RARE_SAMPLER",
+	} {
+		t.Run(envKey, func(t *testing.T) {
+			defer cleanConfig()()
+			assert := assert.New(t)
+			err := os.Setenv(envKey, "true")
+			assert.NoError(err)
+			defer os.Unsetenv(envKey)
+			cfg, err := Load("./testdata/full.yaml")
+			assert.NoError(err)
+			assert.Equal(true, cfg.DisableRareSampler)
+		})
+	}
+
+	for _, envKey := range []string{
 		"DD_MAX_EPS", // deprecated
 		"DD_APM_MAX_EPS",
 	} {

--- a/pkg/trace/config/testdata/undocumented.yaml
+++ b/pkg/trace/config/testdata/undocumented.yaml
@@ -5,6 +5,7 @@ apm_config:
   dd_agent_bin: /path/to/bin
   max_traces_per_second: 100.0
   errors_per_second: 37.0
+  disable_rare_sampler: true
   max_events_per_second: 1000.0
   connection_reset_interval: 120
   receiver_port: 25

--- a/pkg/trace/sampler/rare_sampler_test.go
+++ b/pkg/trace/sampler/rare_sampler_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/trace/config"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/stretchr/testify/assert"
 )
@@ -28,7 +27,7 @@ func TestSpanSeenTTLExpiration(t *testing.T) {
 		{"p0-ttl-expired", true, testTime.Add(priorityTTL + defaultTTL + 2*time.Nanosecond), map[string]float64{"_dd.measured": 1}},
 	}
 
-	e := NewRareSampler(&config.AgentConfig{})
+	e := NewRareSampler()
 	e.Stop()
 
 	for _, tc := range testCases {
@@ -57,7 +56,7 @@ func TestConsideredSpans(t *testing.T) {
 		{"p0-non-top-non-measured-blocked", false, "s4", nil},
 	}
 
-	e := NewRareSampler(&config.AgentConfig{})
+	e := NewRareSampler()
 	e.Stop()
 
 	for _, tc := range testCases {
@@ -72,7 +71,7 @@ func TestConsideredSpans(t *testing.T) {
 }
 
 func TestRareSamplerRace(t *testing.T) {
-	e := NewRareSampler(&config.AgentConfig{})
+	e := NewRareSampler()
 	e.Stop()
 	for i := 0; i < 2; i++ {
 		go func() {
@@ -86,27 +85,9 @@ func TestRareSamplerRace(t *testing.T) {
 	}
 }
 
-func TestDisableRareSampler(t *testing.T) {
-	e := NewRareSampler(&config.AgentConfig{DisableRareSampler: true})
-	e.Stop()
-	tr := pb.Trace{
-		&pb.Span{Resource: "bim", Metrics: map[string]float64{"_top_level": 1}},
-	}
-	assert.False(t, e.Sample(tr, tr[0], "test"))
-}
-
-func TestEnableRareSampler(t *testing.T) {
-	e := NewRareSampler(&config.AgentConfig{DisableRareSampler: false})
-	e.Stop()
-	tr := pb.Trace{
-		&pb.Span{Resource: "bim", Metrics: map[string]float64{"_top_level": 1}},
-	}
-	assert.True(t, e.Sample(tr, tr[0], "test"))
-}
-
 func TestCardinalityLimit(t *testing.T) {
 	assert := assert.New(t)
-	e := NewRareSampler(&config.AgentConfig{})
+	e := NewRareSampler()
 	e.Stop()
 	for j := 1; j <= cardinalityLimit; j++ {
 		tr := pb.Trace{

--- a/releasenotes/notes/apm-disable-rare-sampler-config-f5f3a6efac3d4ba1.yaml
+++ b/releasenotes/notes/apm-disable-rare-sampler-config-f5f3a6efac3d4ba1.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note is combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    APM: The rare sampler can now be disabled using the environment variable DD_APM_DISABLE_RARE_SAMPLER
+    or the `apm_config.disable_rare_sampler` configuration. By default the rare sampler catches 5 extra trace chunks
+    per second on top of the head base sampling.
+    The TPS is spread to catch all combinations of service, name, resource, http.status, error.type missed by 
+    head base sampling.


### PR DESCRIPTION
### What does this PR do?

Add a configuration to disable RareSampler.

The rare sampler can now be disabled using the environment variable DD_APM_DISABLE_RARE_SAMPLER or the `apm_config.disable_rare_sampler` configuration. By default the rare sampler catches 5 extra trace chunks per second on top of the head base sampling.

### Additional Notes

There's no existing knob on the RareSampler.

### Describe how to test/QA your changes

Verify that when the env variable or the config is set that the rare sampler is disabled. Rare sampler can be triggered by sending P0s trace chunks without errors to an agent.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno)
  has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or
  [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml)
  has been updated.
