### PR TITLE
feat: add resource kind in DatadogMetrics.status.references

### DIFF
--- a/pkg/clusteragent/externalmetrics/autoscaler_watcher.go
+++ b/pkg/clusteragent/externalmetrics/autoscaler_watcher.go
@@ -28,8 +28,11 @@ import (
 )
 
 const (
-	autoscalerWatcherStoreID string = "aw"
-	autoscalerReferencesSep  string = ", "
+	autoscalerWatcherStoreID    string = "aw"
+	autoscalerReferencesSep     string = ", "
+	autoscalerReferencesKindSep string = ":"
+	autoscalerWPAKindKey        string = "wpa"
+	autoscalerHPAKindKey        string = "hpa"
 )
 
 type AutoscalerWatcher struct {
@@ -227,7 +230,7 @@ func (w *AutoscalerWatcher) getAutoscalerReferences() (map[string]*externalMetri
 		for _, hpa := range hpaList {
 			for _, metric := range hpa.Spec.Metrics {
 				if metric.Type == autoscaler.ExternalMetricSourceType && metric.External != nil {
-					autoscalerReference := hpa.Namespace + kubernetesNamespaceSep + hpa.Name
+					autoscalerReference := autoscalerHPAKindKey + autoscalerReferencesKindSep + hpa.Namespace + kubernetesNamespaceSep + hpa.Name
 					if datadogMetricID, parsed, hasPrefix := metricNameToDatadogMetricID(metric.External.MetricName); parsed {
 						addAutoscalerReference(datadogMetricID, autoscalerReference, "", nil)
 					} else if !hasPrefix {
@@ -258,7 +261,7 @@ func (w *AutoscalerWatcher) getAutoscalerReferences() (map[string]*externalMetri
 				continue
 			}
 			for _, metric := range wpa.Spec.Metrics {
-				autoscalerReference := wpa.Namespace + kubernetesNamespaceSep + wpa.Name
+				autoscalerReference := autoscalerWPAKindKey + autoscalerReferencesKindSep + wpa.Namespace + kubernetesNamespaceSep + wpa.Name
 				if metric.External != nil {
 					if datadogMetricID, parsed, hasPrefix := metricNameToDatadogMetricID(metric.External.MetricName); parsed {
 						addAutoscalerReference(datadogMetricID, autoscalerReference, "", nil)

--- a/pkg/clusteragent/externalmetrics/autoscaler_watcher_test.go
+++ b/pkg/clusteragent/externalmetrics/autoscaler_watcher_test.go
@@ -181,7 +181,7 @@ func TestUpdateAutoscalerReferences(t *testing.T) {
 		Valid:                true,
 		Value:                12.0,
 		UpdateTime:           updateTime,
-		AutoscalerReferences: "ns1/hpa1",
+		AutoscalerReferences: "hpa:ns1/hpa1",
 		Error:                nil,
 	}
 	ddm.SetQueries("metric query2")
@@ -198,7 +198,7 @@ func TestUpdateAutoscalerReferences(t *testing.T) {
 		Value:                10.0,
 		UpdateTime:           updateTime,
 		Error:                nil,
-		AutoscalerReferences: "ns0/hpa0",
+		AutoscalerReferences: "hpa:ns0/hpa0",
 	}
 	ddm.SetQueries("metric query0")
 	compareDatadogMetricInternal(t, &ddm, f.store.Get("default/dd-metric-0"))
@@ -210,7 +210,7 @@ func TestUpdateAutoscalerReferences(t *testing.T) {
 		Value:                11.0,
 		UpdateTime:           updateTime,
 		Error:                nil,
-		AutoscalerReferences: "ns0/wpa0",
+		AutoscalerReferences: "wpa:ns0/wpa0",
 	}
 	ddm.SetQueries("metric query1")
 	compareDatadogMetricInternal(t, &ddm, f.store.Get("default/dd-metric-1"))
@@ -307,7 +307,7 @@ func TestCreateAutogenDatadogMetrics(t *testing.T) {
 		Value:                0.0,
 		UpdateTime:           updateTime,
 		Error:                nil,
-		AutoscalerReferences: "ns0/hpa0",
+		AutoscalerReferences: "hpa:ns0/hpa0",
 	}
 	ddm.SetQuery("avg:docker.cpu.usage{foo:bar}.rollup(30)")
 	compareDatadogMetricInternal(t, &ddm, f.store.Get("default/dcaautogen-f311ac1e6b29e3723d1445645c43afd4340d22"))
@@ -321,7 +321,7 @@ func TestCreateAutogenDatadogMetrics(t *testing.T) {
 		Value:                0.0,
 		UpdateTime:           updateTime,
 		Error:                nil,
-		AutoscalerReferences: "ns0/wpa0",
+		AutoscalerReferences: "wpa:ns0/wpa0",
 	}
 	ddm.SetQuery("avg:docker.cpu.usage{bar:foo}.rollup(30)")
 	compareDatadogMetricInternal(t, &ddm, f.store.Get("default/dcaautogen-b6ea72b610c00aba6791b5eca1912e68dc7412"))

--- a/releasenotes-dca/notes/improve-resource-reference-in-DatadogMetric-status.yaml
+++ b/releasenotes-dca/notes/improve-resource-reference-in-DatadogMetric-status.yaml
@@ -1,0 +1,3 @@
+---
+enhancements:
+- Add autoscaler resource kind (hpa,wpa) inside the DatadogMetrics status references.


### PR DESCRIPTION
### What does this PR do?

This PR add the autoscaler resource kind (`hpa`,`wpa`) to the autoscaler resources
reference present in the `DatadogMetric` status.
The code change only impact the Datadog Cluster-Agent

Now a reference will look like: `hpa:foo/bar`.

### Motivation

To ease `DatadogMetric` status comprehension.

### Additional Notes

N/A

### Possible Drawbacks / Trade-offs

N/A

The `DatadogMetric.status.references` is a free text area.

### Describe how to test/QA your changes

Deploy the cluster-agent with the Custom Metrics server and DatadogMetrics feature enable.
Create a DatadogMetrics and a HPA that references the DatadogMetrics.

the `references` present in the DatadogMetrics should container the prefix `hpa:`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno)
  has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or
  [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml)
  has been updated.
