### PR TITLE
Improve rtloader cmake usage

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,13 +2,13 @@ name: "Code Scanning - Action"
 
 on:
   push:
-    branches: 
+    branches:
       - main
-      - 7.[0-9][0-9].x 
+      - 7.[0-9][0-9].x
   pull_request:
-    branches: 
+    branches:
       - main
-      - 7.[0-9][0-9].x 
+      - 7.[0-9][0-9].x
 
 jobs:
   CodeQL-Build:
@@ -51,9 +51,9 @@ jobs:
           GOPATH: /home/runner/work/datadog-agent/go
         run: |
           cd go/src/github.com/DataDog/datadog-agent
-          invoke install-tools
-          invoke deps
-          invoke agent.build --build-exclude=systemd
+          invoke -e install-tools
+          invoke -e deps
+          invoke -e agent.build --build-exclude=systemd
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,7 @@ build: off
 
 test_script:
   - inv -e deps
-  - inv -e rtloader.make --install-prefix=%APPVEYOR_BUILD_FOLDER%\dev --cmake-options="-G \"MSYS Makefiles\""
+  - inv -e rtloader.make --install-prefix=%APPVEYOR_BUILD_FOLDER%\dev --cmake-generator="MSYS Makefiles"
   - inv -e rtloader.install
   - inv -e rtloader.format --raise-if-changed
   - inv -e rtloader.test

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -60,7 +60,7 @@ build do
     if not windows_arch_i386? and ENV['WINDOWS_DDNPM_DRIVER'] and not ENV['WINDOWS_DDNPM_DRIVER'].empty?
       do_windows_sysprobe = "--windows-sysprobe"
     end
-    command "inv -e rtloader.make --python-runtimes #{py_runtimes_arg} --install-prefix \"#{windows_safe_path(python_2_embedded)}\" --cmake-options \"-G \\\"Unix Makefiles\\\"\" --arch #{platform}", :env => env
+    command "inv -e rtloader.make --python-runtimes #{py_runtimes_arg} --install-prefix \"#{windows_safe_path(python_2_embedded)}\" --cmake-generator \"Unix Makefiles\" --arch #{platform}", :env => env
     command "mv rtloader/bin/*.dll  #{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent/"
     command "inv -e agent.build --exclude-rtloader --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg} --rebuild --no-development --embedded-path=#{install_dir}/embedded --arch #{platform} #{do_windows_sysprobe}", env: env
     command "inv -e systray.build --major-version #{major_version_arg} --rebuild --arch #{platform}", env: env

--- a/tasks/rtloader.py
+++ b/tasks/rtloader.py
@@ -60,7 +60,7 @@ def make(ctx, install_prefix=None, python_runtimes='3', cmake_generator='Unix Ma
     dev_path = get_dev_path()
 
     if cmake_generator != "":
-        cmake_options += " -G \"{}\"".format(cmake_generator)
+        cmake_options = "-G \"{}\" ".format(cmake_generator) + cmake_options
 
     cmake_args = cmake_options + " -DBUILD_DEMO:BOOL=OFF -DCMAKE_INSTALL_PREFIX:PATH={}".format(
         install_prefix or dev_path

--- a/tasks/rtloader.py
+++ b/tasks/rtloader.py
@@ -53,11 +53,11 @@ def clear_cmake_cache(rtloader_path, settings):
 
 
 @task
-def make(ctx, install_prefix=None, python_runtimes='3', cmake_options='', arch="x64"):
+def make(ctx, install_prefix=None, python_runtimes='3', cmake_generator='Unix Makefiles', cmake_options='', arch="x64"):
     dev_path = get_dev_path()
 
-    if cmake_options.find("-G") == -1:
-        cmake_options += " -G \"Unix Makefiles\""
+    if cmake_generator != "":
+        cmake_options += " -G \"{}\"".format(cmake_generator)
 
     cmake_args = cmake_options + " -DBUILD_DEMO:BOOL=OFF -DCMAKE_INSTALL_PREFIX:PATH={}".format(
         install_prefix or dev_path

--- a/tasks/rtloader.py
+++ b/tasks/rtloader.py
@@ -23,11 +23,8 @@ def get_dev_path():
     return os.path.abspath(os.path.join(here, '..', 'dev'))
 
 
-def run_make_command(ctx, command="", sub_folder=""):
-    build_path = get_rtloader_build_path()
-    if sub_folder != "":
-        build_path = os.path.join(build_path, sub_folder)
-    ctx.run("cmake --build {} --target {}".format(build_path, command))
+def run_make_command(ctx, command=""):
+    ctx.run("cmake --build {} --target {}".format(get_rtloader_build_path(), command))
 
 
 def get_cmake_cache_path(rtloader_path):
@@ -128,7 +125,7 @@ def install(ctx):
 
 @task
 def test(ctx):
-    run_make_command(ctx, "run", sub_folder="test")
+    run_make_command(ctx, "run")
 
 
 @task

--- a/tasks/rtloader.py
+++ b/tasks/rtloader.py
@@ -23,8 +23,11 @@ def get_dev_path():
     return os.path.abspath(os.path.join(here, '..', 'dev'))
 
 
-def run_make_command(ctx, command=""):
-    ctx.run("make -C {} {}".format(get_rtloader_build_path(), command))
+def run_make_command(ctx, command="", sub_folder=""):
+    build_path = get_rtloader_build_path()
+    if sub_folder != "":
+        build_path = os.path.join(build_path, sub_folder)
+    ctx.run("cmake --build {} --target {}".format(build_path, command))
 
 
 def get_cmake_cache_path(rtloader_path):
@@ -94,7 +97,8 @@ def make(ctx, install_prefix=None, python_runtimes='3', cmake_generator='Unix Ma
         else:
             raise
 
-    ctx.run("cd {} && cmake {} {}".format(rtloader_build_path, cmake_args, get_rtloader_path()))
+    with ctx.cd(rtloader_build_path):
+        ctx.run("cmake {} {}".format(cmake_args, get_rtloader_path()))
     run_make_command(ctx)
 
 
@@ -124,7 +128,7 @@ def install(ctx):
 
 @task
 def test(ctx):
-    ctx.run("make -C {}/test run".format(get_rtloader_build_path()))
+    run_make_command(ctx, "run", sub_folder="test")
 
 
 @task

--- a/tasks/rtloader.py
+++ b/tasks/rtloader.py
@@ -24,7 +24,10 @@ def get_dev_path():
 
 
 def run_make_command(ctx, command=""):
-    ctx.run("cmake --build {} --target {}".format(get_rtloader_build_path(), command))
+    target_arg = ""
+    if command != "":
+        target_arg = "--target \"{}\"".format(command)
+    ctx.run("cmake --build {} {}".format(get_rtloader_build_path(), target_arg))
 
 
 def get_cmake_cache_path(rtloader_path):

--- a/tasks/winbuildscripts/unittests.ps1
+++ b/tasks/winbuildscripts/unittests.ps1
@@ -44,7 +44,7 @@ if($err -ne 0){
 
 & inv -e deps
 
-& inv -e rtloader.make --python-runtimes="$Env:PY_RUNTIMES" --install-prefix=$Env:BUILD_ROOT\dev --cmake-options='-G \"Unix Makefiles\"' --arch $archflag
+& inv -e rtloader.make --python-runtimes="$Env:PY_RUNTIMES" --install-prefix=$Env:BUILD_ROOT\dev --cmake-generator="Unix Makefiles" --arch $archflag
 $err = $LASTEXITCODE
 Write-Host Build result is $err
 if($err -ne 0){


### PR DESCRIPTION
### What does this PR do?

This PR teaches rtloader tasks to use CMake to run the underlying build system. This can be useful to use non-make build systems (like nmake or ninja).

### Motivation

TODO

### Possible Drawbacks / Trade-offs

TODO

### Describe how to test/QA your changes

TODO

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
