### PR TITLE
[CSPM] rego print statement and log for resolve fail

### DIFF
--- a/pkg/compliance/checks/rego_check.go
+++ b/pkg/compliance/checks/rego_check.go
@@ -170,6 +170,7 @@ func (r *regoCheck) buildNormalInput(env env.Env) (eval.RegoInputMap, error) {
 
 		resolved, err := resolve(ctx, env, r.ruleID, input.ResourceCommon)
 		if err != nil {
+			log.Warnf("failed to resolve input: %v", err)
 			continue
 		}
 

--- a/releasenotes/notes/cspm-rego-print-9c6e7f6168a29a4d.yaml
+++ b/releasenotes/notes/cspm-rego-print-9c6e7f6168a29a4d.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    CSPM: enable the usage of the print function in Rego rules.


### PR DESCRIPTION
### What does this PR do?

This PR:
- enables the usage of the `print` function in Rego
- add a warn log message when failing to resolve input

### Describe how to test/QA your changes

Test a rule with a print call.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
