### PR TITLE
Kacper murzyn/7.32.0 changelog (#9814)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,181 @@
 Release Notes
 =============
 
+.. _Release Notes_7.32.0:
+
+7.32.0 / 6.32.0
+======
+
+.. _Release Notes_7.32.0_Prelude:
+
+Prelude
+-------
+
+Release on: 2021-11-10
+
+- Please refer to the `7.32.0 tag on integrations-core <https://github.com/DataDog/integrations-core/blob/master/AGENT_CHANGELOG.md#datadog-agent-version-7320>`_ for the list of changes on the Core Checks
+
+
+.. _Release Notes_7.32.0_Upgrade Notes:
+
+Upgrade Notes
+-------------
+
+- APM: Change default profiling intake to use v2 endpoint.
+
+- CSPM the check subcommand is now part of the security-agent compliance.
+
+
+.. _Release Notes_7.32.0_New Features:
+
+New Features
+------------
+
+- On Kubernetes, add a `kube_priority_class` tag on metrics coming from pods with a priority class.
+
+- Priority class name of pods are now collected and sent to the orchestration endpoint
+
+- Autodiscovery can now resolve template variables and environment variables in log configurations.
+
+- The Windows installer now offers US5 as a new site choice.
+
+- APM: New telemetry was added to measure `/v.*/traces` endpoints latency and response size.
+  These metrics are `datadog.trace_agent.receiver.{rate_response_bytes,serve_traces_ms}`.
+
+- APM: Metrics are now available for Windows Pipes and UDS connections via datadog.trace_agent.receiver.{uds_connections,pipe_connections}.
+
+- Introduce a new configuration parameter ``container_env_as_tags``
+  to allow converting containerd containers' environment variables into tags.
+
+- The "containerd" check is now supported on Windows.
+
+- Add experimental support for writing agent-side CSPM compliance checks in Rego.
+
+- Runtime security can now attach span/trace to event.
+
+- Provides alternative implementation for process collection on Windows using performance counters.
+
+- Add multi-line auto-sensing when tailing logs from file.
+  It checks the 1000 first lines (or waits 30 seconds, whichever is first)
+  when tailing for a list of known timestamp formats. If the 
+  number of matched lines is greater than the threshold it 
+  switches to the MultiLineHandler with the pattern matching
+  the timestamp format. The pattern chosen is saved in the log
+  config and is reused if the file rotates.  Use the new global config 
+  parameter ``logs_config.auto_multi_line_detection`` to enable
+  the feature for the whole agent, or the per log integration config parameter ``auto_multi_line_detection``
+  to enable the feature on a case by case basis.
+
+- Added *experimental* support for OTLP metrics via
+  experimental.otlp.{http_port,grpc_port} or their corresponding
+  environment variables (DD_OTLP_{HTTP,GRPC}_PORT).
+
+- Created a new process discovery check. This is a lightweight check that runs every 4 hours by default, and collects
+  process metadata, so that Datadog can suggest potential integrations for the user to enable.
+
+- Added new executable `readsecret_multiple_providers.sh` that allows the
+  agent to read secrets both from files and Kubernetes secrets. Please refer
+  to the `docs <https://docs.datadoghq.com/agent/guide/secrets-management>`_
+  for more details.
+
+
+.. _Release Notes_7.32.0_Enhancement Notes:
+
+Enhancement Notes
+-----------------
+
+- KSM core check has a new `labels_as_tags` parameter to configure which pod labels should be used as datadog tag in an easier way than with the `label_joins` parameter.
+
+- Add `namespace` to snmp listener config
+
+- Remove `network_devices` from `datadog.yaml` configuration
+
+- kubernetes state core check: add `kubernetes_state.job.completion.succeeded` and `kubernetes_state.job.completion.failed` metrics to report job completion as metrics in addition to the already existing service check.
+
+- Add `use_device_id_as_hostname` in snmp check and snmp_listener configuration to use DeviceId as hostname for metrics and service checks
+
+- APM: The maximum allowed tag value length has been increased to 25,000 bytes.
+
+- Reduce memory usage when checks report new metrics every run. Most metrics are removed
+  after two check runs without new samples. Rate, historate and monotonic count will be
+  kept in memory for additional 25 hours after that. Number of check runs and the
+  additional time can be changed with `check_sampler_bucket_commits_count_expiry` and
+  `check_sampler_stateful_metric_expiration_time`. Metric expiration can be disabled
+  entirely by setting `check_sampler_expire_metrics` to `false`.
+
+- CSPM reports the agent version as part of the events
+
+- Agents are now built with Go1.16.  This will have one user-visible change:
+  on Linux, the process-level RSS metric for agent processes will be
+  reduced from earlier versions.  This reflects a change in how memory
+  usage is calculated, not a reduction in used memory, and is an artifact
+  of the Go runtime `switching from MADV_FREE to MADV_DONTNEED
+  <https://golang.org/doc/go1.16#runtime>`_.
+
+- Tag Kubernetes containers with ``image_id`` tag.
+
+- Eliminates the need to synchronize state between regular and RT process collection.
+
+- APM: Added a configuration option to set the API key separately for Live
+  Debugger. It can be set via `apm_config.debugger_api_key` or
+  `DD_APM_DEBUGGER_API_KEY`.
+
+- Update EP forwarder config to use intake v2 for ndm metadata
+
+- Remove the `reason` tag from the `kubernetes_state.job.failed` metric to reduce cardinality
+
+- the runtime security module of system-probe is now powered by DataDog/ebpf-manager instead of DataDog/ebpf.
+
+- Security Agent: use exponential backoff for log warning when the security agent fails to
+  connect to the system probe.
+
+- APM: OTLP traces now supports semantic conventions from version 1.5.0 of the OpenTelemetry specification.
+
+- Show enabled autodiscovery sources in the agent status
+
+- Add namespace to SNMP integration and SNMP Listener to disambiguate
+  devices with same IP.
+
+- Add snmp corecheck autodiscovery
+
+- Enable SNMP device metadata collection by default
+
+- Reduced CPU usage when origin detection is used.
+
+- The Windows installer now prioritizes user name from the command line over stored registry entries
+
+
+.. _Release Notes_7.32.0_Bug Fixes:
+
+Bug Fixes
+---------
+
+- Make sure ``DD_ENABLE_METADATA_COLLECTION="false"`` prevent all host metadata emission, including the initial one.
+
+- Most checks are stripping tags with an empty value. KSM was missing this logic so that KSM specific metrics could have a tag with an empty value.
+  They will now be stripped like for any other check.
+
+- Fixed a regression that was preventing the Agent from retrying kubelet and docker connections in case of failure.
+
+- Fix the cgroup collector to correctly pickup Cloud Foundry containers.
+
+- Fix an issue where the orchestrator check would stop sending
+  updates when run on as a cluster-check.
+
+- Port python-tuf CVE fix on the embedded Python 2
+  see `<https://github.com/theupdateframework/python-tuf/security/advisories/GHSA-wjw6-2cqr-j4qr>`_.
+
+- Fix some string logging in the Windows installer.
+
+- The flare command now correctly copies agent logs located in subdirectories
+  of the agent's root log directory.
+
+- Kubernetes state core check: `job.status.succeeded` and `job.status.failed` gauges were not sent when equal 0. 0 values are now sent.
+
+- Tag Namespace and PV and PVC metrics correctly with ``phase`` instead of ``pod_phase``
+  in the Kube State Metrics Core check.
+
+
 .. _Release Notes_7.31.1:
 
 7.31.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,7 +12,7 @@ Release Notes
 Prelude
 -------
 
-Release on: 2021-11-10
+Release on: 2021-11-09
 
 - Please refer to the `7.32.0 tag on integrations-core <https://github.com/DataDog/integrations-core/blob/master/AGENT_CHANGELOG.md#datadog-agent-version-7320>`_ for the list of changes on the Core Checks
 

--- a/releasenotes/notes/semconv-1.5.0-otlp-8e6dc691398e2bd1.yaml
+++ b/releasenotes/notes/semconv-1.5.0-otlp-8e6dc691398e2bd1.yaml
@@ -7,4 +7,5 @@
 # Each section note must be formatted as reStructuredText.
 ---
 enhancements:
-  - APM: OTLP traces now supports semantic conventions from version 1.5.0 of the OpenTelemetry specification.
+  - |
+    APM: OTLP traces now supports semantic conventions from version 1.5.0 of the OpenTelemetry specification.


### PR DESCRIPTION
Backport of https://github.com/DataDog/datadog-agent/pull/9814 to the main branch.

* Fix yaml parsing error for changelog generation

* Changelog for 7.32.0

* Update CHANGELOG.rst after comments

