### PR TITLE
[CSPM] improve error handling on Rego inputs

### DIFF
--- a/pkg/compliance/checks/audit_check.go
+++ b/pkg/compliance/checks/audit_check.go
@@ -23,7 +23,7 @@ var auditReportedFields = []string{
 	compliance.AuditFieldPermissions,
 }
 
-func resolveAudit(_ context.Context, e env.Env, ruleID string, res compliance.ResourceCommon, optional bool) (resolved, error) {
+func resolveAudit(_ context.Context, e env.Env, ruleID string, res compliance.ResourceCommon, rego bool) (resolved, error) {
 	if res.Audit == nil {
 		return nil, fmt.Errorf("%s: expecting audit resource in audit check", ruleID)
 	}

--- a/pkg/compliance/checks/audit_check.go
+++ b/pkg/compliance/checks/audit_check.go
@@ -23,7 +23,7 @@ var auditReportedFields = []string{
 	compliance.AuditFieldPermissions,
 }
 
-func resolveAudit(_ context.Context, e env.Env, ruleID string, res compliance.ResourceCommon) (resolved, error) {
+func resolveAudit(_ context.Context, e env.Env, ruleID string, res compliance.ResourceCommon, optional bool) (resolved, error) {
 	if res.Audit == nil {
 		return nil, fmt.Errorf("%s: expecting audit resource in audit check", ruleID)
 	}

--- a/pkg/compliance/checks/command_check.go
+++ b/pkg/compliance/checks/command_check.go
@@ -24,7 +24,7 @@ var commandReportedFields = []string{
 	compliance.CommandFieldExitCode,
 }
 
-func resolveCommand(ctx context.Context, _ env.Env, ruleID string, res compliance.ResourceCommon) (resolved, error) {
+func resolveCommand(ctx context.Context, _ env.Env, ruleID string, res compliance.ResourceCommon, optional bool) (resolved, error) {
 	if res.Command == nil {
 		return nil, fmt.Errorf("%s: expecting command resource in command check", ruleID)
 	}

--- a/pkg/compliance/checks/command_check.go
+++ b/pkg/compliance/checks/command_check.go
@@ -24,7 +24,7 @@ var commandReportedFields = []string{
 	compliance.CommandFieldExitCode,
 }
 
-func resolveCommand(ctx context.Context, _ env.Env, ruleID string, res compliance.ResourceCommon, optional bool) (resolved, error) {
+func resolveCommand(ctx context.Context, _ env.Env, ruleID string, res compliance.ResourceCommon, rego bool) (resolved, error) {
 	if res.Command == nil {
 		return nil, fmt.Errorf("%s: expecting command resource in command check", ruleID)
 	}

--- a/pkg/compliance/checks/constants_check.go
+++ b/pkg/compliance/checks/constants_check.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func resolveConstants(_ context.Context, e env.Env, ruleID string, res compliance.ResourceCommon, optional bool) (resolved, error) {
+func resolveConstants(_ context.Context, e env.Env, ruleID string, res compliance.ResourceCommon, rego bool) (resolved, error) {
 	if res.Constants == nil {
 		return nil, fmt.Errorf("expecting constants resource in constants check")
 	}

--- a/pkg/compliance/checks/constants_check.go
+++ b/pkg/compliance/checks/constants_check.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func resolveConstants(_ context.Context, e env.Env, ruleID string, res compliance.ResourceCommon) (resolved, error) {
+func resolveConstants(_ context.Context, e env.Env, ruleID string, res compliance.ResourceCommon, optional bool) (resolved, error) {
 	if res.Constants == nil {
 		return nil, fmt.Errorf("expecting constants resource in constants check")
 	}

--- a/pkg/compliance/checks/docker_check.go
+++ b/pkg/compliance/checks/docker_check.go
@@ -72,7 +72,7 @@ func dockerKindNotSupported(kind string) error {
 	return fmt.Errorf("unsupported docker object kind '%s'", kind)
 }
 
-func resolveDocker(ctx context.Context, e env.Env, ruleID string, res compliance.ResourceCommon, optional bool) (resolved, error) {
+func resolveDocker(ctx context.Context, e env.Env, ruleID string, res compliance.ResourceCommon, rego bool) (resolved, error) {
 	if res.Docker == nil {
 		return nil, fmt.Errorf("expecting docker resource in docker check")
 	}

--- a/pkg/compliance/checks/docker_check.go
+++ b/pkg/compliance/checks/docker_check.go
@@ -72,7 +72,7 @@ func dockerKindNotSupported(kind string) error {
 	return fmt.Errorf("unsupported docker object kind '%s'", kind)
 }
 
-func resolveDocker(ctx context.Context, e env.Env, ruleID string, res compliance.ResourceCommon) (resolved, error) {
+func resolveDocker(ctx context.Context, e env.Env, ruleID string, res compliance.ResourceCommon, optional bool) (resolved, error) {
 	if res.Docker == nil {
 		return nil, fmt.Errorf("expecting docker resource in docker check")
 	}

--- a/pkg/compliance/checks/file_check.go
+++ b/pkg/compliance/checks/file_check.go
@@ -25,7 +25,7 @@ var fileReportedFields = []string{
 	compliance.FileFieldGroup,
 }
 
-func resolveFile(_ context.Context, e env.Env, ruleID string, res compliance.ResourceCommon, optional bool) (resolved, error) {
+func resolveFile(_ context.Context, e env.Env, ruleID string, res compliance.ResourceCommon, rego bool) (resolved, error) {
 	if res.File == nil {
 		return nil, fmt.Errorf("expecting file resource in file check")
 	}
@@ -104,7 +104,7 @@ func resolveFile(_ context.Context, e env.Env, ruleID string, res compliance.Res
 		instances = append(instances, newResolvedInstance(instance, path, "file"))
 	}
 
-	if len(instances) == 0 && !optional {
+	if len(instances) == 0 {
 		return nil, fmt.Errorf("no files found for file check %q", file.Path)
 	}
 

--- a/pkg/compliance/checks/file_check.go
+++ b/pkg/compliance/checks/file_check.go
@@ -25,7 +25,7 @@ var fileReportedFields = []string{
 	compliance.FileFieldGroup,
 }
 
-func resolveFile(_ context.Context, e env.Env, ruleID string, res compliance.ResourceCommon) (resolved, error) {
+func resolveFile(_ context.Context, e env.Env, ruleID string, res compliance.ResourceCommon, optional bool) (resolved, error) {
 	if res.File == nil {
 		return nil, fmt.Errorf("expecting file resource in file check")
 	}
@@ -104,7 +104,7 @@ func resolveFile(_ context.Context, e env.Env, ruleID string, res compliance.Res
 		instances = append(instances, newResolvedInstance(instance, path, "file"))
 	}
 
-	if len(instances) == 0 {
+	if len(instances) == 0 && !optional {
 		return nil, fmt.Errorf("no files found for file check %q", file.Path)
 	}
 

--- a/pkg/compliance/checks/group_check.go
+++ b/pkg/compliance/checks/group_check.go
@@ -31,7 +31,7 @@ var groupReportedFields = []string{
 // ErrGroupNotFound is returned when a group cannot be found
 var ErrGroupNotFound = errors.New("group not found")
 
-func resolveGroup(_ context.Context, e env.Env, id string, res compliance.ResourceCommon) (resolved, error) {
+func resolveGroup(_ context.Context, e env.Env, id string, res compliance.ResourceCommon, optional bool) (resolved, error) {
 	if res.Group == nil {
 		return nil, fmt.Errorf("%s: expecting group resource in group check", id)
 	}

--- a/pkg/compliance/checks/group_check.go
+++ b/pkg/compliance/checks/group_check.go
@@ -31,7 +31,7 @@ var groupReportedFields = []string{
 // ErrGroupNotFound is returned when a group cannot be found
 var ErrGroupNotFound = errors.New("group not found")
 
-func resolveGroup(_ context.Context, e env.Env, id string, res compliance.ResourceCommon, optional bool) (resolved, error) {
+func resolveGroup(_ context.Context, e env.Env, id string, res compliance.ResourceCommon, rego bool) (resolved, error) {
 	if res.Group == nil {
 		return nil, fmt.Errorf("%s: expecting group resource in group check", id)
 	}

--- a/pkg/compliance/checks/kubeapiserver_check.go
+++ b/pkg/compliance/checks/kubeapiserver_check.go
@@ -35,7 +35,7 @@ type kubeUnstructureResolvedResource struct {
 	eval.Instance
 }
 
-func resolveKubeapiserver(ctx context.Context, e env.Env, ruleID string, res compliance.ResourceCommon) (resolved, error) {
+func resolveKubeapiserver(ctx context.Context, e env.Env, ruleID string, res compliance.ResourceCommon, optional bool) (resolved, error) {
 	if res.KubeApiserver == nil {
 		return nil, fmt.Errorf("expecting Kubeapiserver resource in Kubeapiserver check")
 	}

--- a/pkg/compliance/checks/kubeapiserver_check.go
+++ b/pkg/compliance/checks/kubeapiserver_check.go
@@ -35,7 +35,7 @@ type kubeUnstructureResolvedResource struct {
 	eval.Instance
 }
 
-func resolveKubeapiserver(ctx context.Context, e env.Env, ruleID string, res compliance.ResourceCommon, optional bool) (resolved, error) {
+func resolveKubeapiserver(ctx context.Context, e env.Env, ruleID string, res compliance.ResourceCommon, rego bool) (resolved, error) {
 	if res.KubeApiserver == nil {
 		return nil, fmt.Errorf("expecting Kubeapiserver resource in Kubeapiserver check")
 	}

--- a/pkg/compliance/checks/process_check.go
+++ b/pkg/compliance/checks/process_check.go
@@ -69,6 +69,10 @@ func resolveProcess(_ context.Context, e env.Env, id string, res compliance.Reso
 		instances = append(instances, newResolvedInstance(instance, strconv.Itoa(int(mp.Pid)), "process"))
 	}
 
+	if len(instances) == 0 {
+		return nil, fmt.Errorf("no process found for process check %q", process.Name)
+	}
+
 	// NOTE(safchain) workaround to allow fallback on all this resource if there is only one file
 	if len(instances) == 1 {
 		return instances[0].(*_resolvedInstance), nil

--- a/pkg/compliance/checks/process_check.go
+++ b/pkg/compliance/checks/process_check.go
@@ -28,7 +28,7 @@ var processReportedFields = []string{
 	compliance.ProcessFieldCmdLine,
 }
 
-func resolveProcess(_ context.Context, e env.Env, id string, res compliance.ResourceCommon) (resolved, error) {
+func resolveProcess(_ context.Context, e env.Env, id string, res compliance.ResourceCommon, optional bool) (resolved, error) {
 	if res.Process == nil {
 		return nil, fmt.Errorf("%s: expecting process resource in process check", id)
 	}
@@ -67,6 +67,10 @@ func resolveProcess(_ context.Context, e env.Env, id string, res compliance.Reso
 			},
 		)
 		instances = append(instances, newResolvedInstance(instance, strconv.Itoa(int(mp.Pid)), "process"))
+	}
+
+	if len(instances) == 0 && !optional {
+		return nil, fmt.Errorf("no process found for process check %q", process.Name)
 	}
 
 	// NOTE(safchain) workaround to allow fallback on all this resource if there is only one file

--- a/pkg/compliance/checks/process_check.go
+++ b/pkg/compliance/checks/process_check.go
@@ -69,10 +69,6 @@ func resolveProcess(_ context.Context, e env.Env, id string, res compliance.Reso
 		instances = append(instances, newResolvedInstance(instance, strconv.Itoa(int(mp.Pid)), "process"))
 	}
 
-	if len(instances) == 0 {
-		return nil, fmt.Errorf("no process found for process check %q", process.Name)
-	}
-
 	// NOTE(safchain) workaround to allow fallback on all this resource if there is only one file
 	if len(instances) == 1 {
 		return instances[0].(*_resolvedInstance), nil

--- a/pkg/compliance/checks/process_check.go
+++ b/pkg/compliance/checks/process_check.go
@@ -28,7 +28,7 @@ var processReportedFields = []string{
 	compliance.ProcessFieldCmdLine,
 }
 
-func resolveProcess(_ context.Context, e env.Env, id string, res compliance.ResourceCommon, optional bool) (resolved, error) {
+func resolveProcess(_ context.Context, e env.Env, id string, res compliance.ResourceCommon, rego bool) (resolved, error) {
 	if res.Process == nil {
 		return nil, fmt.Errorf("%s: expecting process resource in process check", id)
 	}
@@ -69,7 +69,7 @@ func resolveProcess(_ context.Context, e env.Env, id string, res compliance.Reso
 		instances = append(instances, newResolvedInstance(instance, strconv.Itoa(int(mp.Pid)), "process"))
 	}
 
-	if len(instances) == 0 && !optional {
+	if len(instances) == 0 && rego {
 		return nil, fmt.Errorf("no process found for process check %q", process.Name)
 	}
 

--- a/pkg/compliance/checks/rego_check.go
+++ b/pkg/compliance/checks/rego_check.go
@@ -170,7 +170,7 @@ func (r *regoCheck) buildNormalInput(env env.Env) (eval.RegoInputMap, error) {
 
 		resolved, err := resolve(ctx, env, r.ruleID, input.ResourceCommon)
 		if err != nil {
-			if input.AllowError {
+			if input.Optional {
 				log.Warnf("failed to resolve input: %v", err)
 				continue
 			} else {

--- a/pkg/compliance/checks/rego_check.go
+++ b/pkg/compliance/checks/rego_check.go
@@ -168,7 +168,7 @@ func (r *regoCheck) buildNormalInput(env env.Env) (eval.RegoInputMap, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 		defer cancel()
 
-		resolved, err := resolve(ctx, env, r.ruleID, input.ResourceCommon)
+		resolved, err := resolve(ctx, env, r.ruleID, input.ResourceCommon, input.Optional)
 		if err != nil {
 			if input.Optional {
 				log.Warnf("failed to resolve input: %v", err)

--- a/pkg/compliance/checks/rego_check.go
+++ b/pkg/compliance/checks/rego_check.go
@@ -168,7 +168,7 @@ func (r *regoCheck) buildNormalInput(env env.Env) (eval.RegoInputMap, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 		defer cancel()
 
-		resolved, err := resolve(ctx, env, r.ruleID, input.ResourceCommon, input.Optional)
+		resolved, err := resolve(ctx, env, r.ruleID, input.ResourceCommon, true)
 		if err != nil {
 			if input.Optional {
 				log.Warnf("failed to resolve input: %v", err)

--- a/pkg/compliance/checks/rego_check.go
+++ b/pkg/compliance/checks/rego_check.go
@@ -170,8 +170,12 @@ func (r *regoCheck) buildNormalInput(env env.Env) (eval.RegoInputMap, error) {
 
 		resolved, err := resolve(ctx, env, r.ruleID, input.ResourceCommon)
 		if err != nil {
-			log.Warnf("failed to resolve input: %v", err)
-			continue
+			if input.AllowError {
+				log.Warnf("failed to resolve input: %v", err)
+				continue
+			} else {
+				return nil, err
+			}
 		}
 
 		tagName := input.TagName

--- a/pkg/compliance/checks/resource_check.go
+++ b/pkg/compliance/checks/resource_check.go
@@ -126,7 +126,7 @@ func newResolvedInstances(resolvedInstances []resolvedInstance) *resolvedIterato
 	return newResolvedIterator(newInstanceIterator(instances))
 }
 
-type resolveFunc func(ctx context.Context, e env.Env, ruleID string, resource compliance.ResourceCommon) (resolved, error)
+type resolveFunc func(ctx context.Context, e env.Env, ruleID string, resource compliance.ResourceCommon, optional bool) (resolved, error)
 
 type resourceCheck struct {
 	ruleID   string
@@ -142,7 +142,7 @@ func (c *resourceCheck) check(env env.Env) []*compliance.Report {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 
-	resolved, err := c.resolve(ctx, env, c.ruleID, c.resource.ResourceCommon)
+	resolved, err := c.resolve(ctx, env, c.ruleID, c.resource.ResourceCommon, true)
 	if err != nil {
 		return []*compliance.Report{compliance.BuildReportForError(err)}
 	}

--- a/pkg/compliance/checks/resource_check.go
+++ b/pkg/compliance/checks/resource_check.go
@@ -126,7 +126,7 @@ func newResolvedInstances(resolvedInstances []resolvedInstance) *resolvedIterato
 	return newResolvedIterator(newInstanceIterator(instances))
 }
 
-type resolveFunc func(ctx context.Context, e env.Env, ruleID string, resource compliance.ResourceCommon, optional bool) (resolved, error)
+type resolveFunc func(ctx context.Context, e env.Env, ruleID string, resource compliance.ResourceCommon, rego bool) (resolved, error)
 
 type resourceCheck struct {
 	ruleID   string
@@ -142,7 +142,7 @@ func (c *resourceCheck) check(env env.Env) []*compliance.Report {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 
-	resolved, err := c.resolve(ctx, env, c.ruleID, c.resource.ResourceCommon, true)
+	resolved, err := c.resolve(ctx, env, c.ruleID, c.resource.ResourceCommon, false)
 	if err != nil {
 		return []*compliance.Report{compliance.BuildReportForError(err)}
 	}

--- a/pkg/compliance/checks/resource_check_test.go
+++ b/pkg/compliance/checks/resource_check_test.go
@@ -254,7 +254,7 @@ func TestResourceCheck(t *testing.T) {
 				}
 			}
 
-			resolve := func(_ context.Context, _ env.Env, _ string, _ compliance.ResourceCommon, optional bool) (resolved, error) {
+			resolve := func(_ context.Context, _ env.Env, _ string, _ compliance.ResourceCommon, rego bool) (resolved, error) {
 				return test.resourceResolved, nil
 			}
 

--- a/pkg/compliance/checks/resource_check_test.go
+++ b/pkg/compliance/checks/resource_check_test.go
@@ -254,7 +254,7 @@ func TestResourceCheck(t *testing.T) {
 				}
 			}
 
-			resolve := func(_ context.Context, _ env.Env, _ string, _ compliance.ResourceCommon) (resolved, error) {
+			resolve := func(_ context.Context, _ env.Env, _ string, _ compliance.ResourceCommon, optional bool) (resolved, error) {
 				return test.resourceResolved, nil
 			}
 

--- a/pkg/compliance/resource.go
+++ b/pkg/compliance/resource.go
@@ -59,8 +59,9 @@ type Resource struct {
 // RegoInput describes supported resource types observed by a Rego Rule
 type RegoInput struct {
 	ResourceCommon `yaml:",inline"`
-	TagName        string `yaml:"tag"`
+	TagName        string `yaml:"tag,omitempty"`
 	Type           string `yaml:"type"`
+	AllowError     bool   `yaml:"allowError,omitempty"`
 }
 
 // ValidateInputType returns the validated input type or an error

--- a/pkg/compliance/resource.go
+++ b/pkg/compliance/resource.go
@@ -61,7 +61,7 @@ type RegoInput struct {
 	ResourceCommon `yaml:",inline"`
 	TagName        string `yaml:"tag,omitempty"`
 	Type           string `yaml:"type"`
-	AllowError     bool   `yaml:"allowError,omitempty"`
+	Optional       bool   `yaml:"optional,omitempty"`
 }
 
 // ValidateInputType returns the validated input type or an error


### PR DESCRIPTION
### What does this PR do?

This PR improves the error handling of rego inputs:
- by returning an error instead of ignoring (for example on missing files)
- by adding an option `optional` to opt-in to the ignore behaviour

### Motivation

Improve Rego rules

### Describe how to test/QA your changes

Write a rule using this feature.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
