### PR TITLE
Revert "Add Docker images for Windows ltsc2022 (#9819)"

### DIFF
--- a/.gitlab/image_build/docker_windows_agent7.yml
+++ b/.gitlab/image_build/docker_windows_agent7.yml
@@ -63,25 +63,6 @@ docker_build_agent7_windows20h2:
     TAG_SUFFIX: "-7"
     WITH_JMX: "false"
 
-docker_build_agent7_windows2022_jmx:
-  extends:
-    - .docker_build_agent7_windows_common
-  tags: ["runner:windows-docker", "windowsversion:2022"]
-  needs: ["windows_msi_and_bosh_zip_x64-a7", "build_windows_container_entrypoint"]
-  variables:
-    VARIANT: 2022
-    TAG_SUFFIX: -7-jmx
-    WITH_JMX: "true"
-
-docker_build_agent7_windows2022:
-  extends:
-    - .docker_build_agent7_windows_common
-  tags: ["runner:windows-docker", "windowsversion:2022"]
-  variables:
-    VARIANT: 2022
-    TAG_SUFFIX: "-7"
-    WITH_JMX: "false"
-
 docker_build_agent7_windows20h2_jmx:
   extends:
     - .docker_build_agent7_windows_common
@@ -163,24 +144,5 @@ docker_build_agent7_windows20h2_core_jmx:
   needs: ["windows_msi_and_bosh_zip_x64-a7", "build_windows_container_entrypoint"]
   variables:
     VARIANT: 20h2
-    TAG_SUFFIX: -7-jmx
-    WITH_JMX: "true"
-
-docker_build_agent7_windows2022_core:
-  extends:
-    - .docker_build_agent7_windows_servercore_common
-  tags: ["runner:windows-docker", "windowsversion:2022"]
-  variables:
-    VARIANT: 2022
-    TAG_SUFFIX: "-7"
-    WITH_JMX: "false"
-
-docker_build_agent7_windows2022_core_jmx:
-  extends:
-    - .docker_build_agent7_windows_servercore_common
-  tags: ["runner:windows-docker", "windowsversion:2022"]
-  needs: ["windows_msi_and_bosh_zip_x64-a7", "build_windows_container_entrypoint"]
-  variables:
-    VARIANT: 2022
     TAG_SUFFIX: -7-jmx
     WITH_JMX: "true"

--- a/.gitlab/image_deploy/docker_windows.yml
+++ b/.gitlab/image_deploy/docker_windows.yml
@@ -27,25 +27,21 @@ dev_branch-a7-windows:
     - docker_build_agent7_windows20h2_jmx
     - docker_build_agent7_windows20h2_core
     - docker_build_agent7_windows20h2_core_jmx
-    - docker_build_agent7_windows2022
-    - docker_build_agent7_windows2022_jmx
-    - docker_build_agent7_windows2022_core
-    - docker_build_agent7_windows2022_core_jmx
   variables:
     IMG_REGISTRIES: dev
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-win2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-win2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-win2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-win-servercore
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-win2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py3-jmx-win-servercore
 
 dev_branch-a6-windows:
@@ -58,13 +54,12 @@ dev_branch-a6-windows:
     - docker_build_agent6_windows1909_core
     - docker_build_agent6_windows2004_core
     - docker_build_agent6_windows20h2_core
-    - docker_build_agent6_windows2022_core
   variables:
     IMG_REGISTRIES: dev
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-win2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:${CI_COMMIT_REF_SLUG}-py2-win-servercore
 
 dev_master-a7-windows:
@@ -89,25 +84,21 @@ dev_master-a7-windows:
     - docker_build_agent7_windows20h2_jmx
     - docker_build_agent7_windows20h2_core
     - docker_build_agent7_windows20h2_core_jmx
-    - docker_build_agent7_windows2022
-    - docker_build_agent7_windows2022_jmx
-    - docker_build_agent7_windows2022_core
-    - docker_build_agent7_windows2022_core_jmx
   variables:
     IMG_REGISTRIES: dev
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-win2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64"
         IMG_DESTINATIONS: agent-dev:master-py3-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-win2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64"
         IMG_DESTINATIONS: agent-dev:master-py3-jmx-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-win2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:master-py3-win-servercore
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-win2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:master-py3-jmx-win-servercore
 
 dev_master-a6-windows:
@@ -120,13 +111,12 @@ dev_master-a6-windows:
     - docker_build_agent6_windows1909_core
     - docker_build_agent6_windows2004_core
     - docker_build_agent6_windows20h2_core
-    - docker_build_agent6_windows2022_core
   variables:
     IMG_REGISTRIES: dev
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-win2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:master-py2-win-servercore
 
 dev_nightly-a7-windows:
@@ -151,25 +141,21 @@ dev_nightly-a7-windows:
     - docker_build_agent7_windows20h2_jmx
     - docker_build_agent7_windows20h2_core
     - docker_build_agent7_windows20h2_core_jmx
-    - docker_build_agent7_windows2022
-    - docker_build_agent7_windows2022_jmx
-    - docker_build_agent7_windows2022_core
-    - docker_build_agent7_windows2022_core_jmx
   variables:
     IMG_REGISTRIES: dev
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-win2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64,%BASE%-win2022-amd64"
+        IMG_SOURCES: "%BASE%-win1809-amd64,%BASE%-win1909-amd64,%BASE%-win2004-amd64,%BASE%-win20h2-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-win2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-win-servercore
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-7-jmx"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-win2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py3-jmx-win-servercore
 
 dev_nightly-a6-windows:
@@ -182,11 +168,10 @@ dev_nightly-a6-windows:
     - docker_build_agent6_windows1909_core
     - docker_build_agent6_windows2004_core
     - docker_build_agent6_windows20h2_core
-    - docker_build_agent6_windows2022_core
   variables:
     IMG_REGISTRIES: dev
   parallel:
     matrix:
       - IMG_VARIABLES: "BASE=${SRC_AGENT}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-6"
-        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64,%BASE%-win2022-servercore-amd64"
+        IMG_SOURCES: "%BASE%-win1809-servercore-amd64,%BASE%-win1909-servercore-amd64,%BASE%-win2004-servercore-amd64,%BASE%-win20h2-servercore-amd64"
         IMG_DESTINATIONS: agent-dev:nightly-${CI_COMMIT_SHORT_SHA}-py2-win-servercore

--- a/releasenotes/notes/windows2022-e554d1e56b4946e8.yaml
+++ b/releasenotes/notes/windows2022-e554d1e56b4946e8.yaml
@@ -1,4 +1,0 @@
----
-enhancements:
-  - |
-    Add support for Windows 2022 in published Docker images


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Reverts #9100, which breaks the Gitlab pipelines and cannot be easily fixed.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Fix pipelines.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
