### PR TITLE
Fix debugfs mountpoint detection logic

### DIFF
--- a/pkg/util/kernel/fs.go
+++ b/pkg/util/kernel/fs.go
@@ -39,13 +39,16 @@ func GetMountPoint(path string) (*mountinfo.Info, error) {
 		return nil, err
 	}
 
-	for path != "" {
+	for {
 		for _, m := range mi {
 			if path == m.Mountpoint {
 				return m, nil
 			}
 		}
 
+		if path == "/" {
+			break
+		}
 		path = filepath.Dir(path)
 	}
 

--- a/pkg/util/kernel/fs.go
+++ b/pkg/util/kernel/fs.go
@@ -30,7 +30,11 @@ func ParseMountInfoFile(pid int32) ([]*mountinfo.Info, error) {
 
 // GetMountPoint returns the mount point of the given path
 func GetMountPoint(path string) (*mountinfo.Info, error) {
-	mi, err := ParseMountInfoFile(int32(os.Getpid()))
+	if path == "" {
+		return nil, fmt.Errorf("empty path")
+	}
+
+	mi, err := mountinfo.GetMounts(nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/kernel/fs.go
+++ b/pkg/util/kernel/fs.go
@@ -3,7 +3,6 @@
 package kernel
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -46,14 +45,13 @@ func GetMountPoint(path string) (*mountinfo.Info, error) {
 		path = filepath.Dir(path)
 	}
 
-	return nil, nil
+	return nil, fmt.Errorf("no matching mountpoint found")
 }
 
 // IsDebugFSMounted would test the existence of file /sys/kernel/debug/tracing/kprobe_events to determine if debugfs is mounted or not
 // returns a boolean and a possible error message
 func IsDebugFSMounted() (bool, error) {
 	_, err := os.Stat("/sys/kernel/debug/tracing/kprobe_events")
-
 	if err != nil {
 		if os.IsPermission(err) {
 			return false, fmt.Errorf("eBPF not supported, does not have permission to access debugfs")
@@ -66,7 +64,7 @@ func IsDebugFSMounted() (bool, error) {
 
 	mi, err := GetMountPoint("/sys/kernel/debug/tracing/kprobe_events")
 	if err != nil {
-		return false, errors.New("unable to detect debugfs mount point")
+		return false, fmt.Errorf("unable to detect debugfs mount point: %w", err)
 	}
 
 	if mi.FSType != "tracefs" && mi.FSType != "debugfs" {


### PR DESCRIPTION
### What does this PR do?

- Changes the `mountinfo` retrieval to use `/proc/self` rather than crafting the procfs path manually. Due to PID namespaces, trying to use `/host/proc` while using a namespaced PID would result in the incorrect data.
- Fixes the loop termination clause because `filepath.Dir` will never return `""`.
- Fixes a potential panic if the end of the path matching loop was hit. It would return a `nil` mount info and `nil` error, thus causing it to try to access `.FSType` on the `nil` variable.
- Includes the error message indicating why the debugfs mountpoint could not be found.

### Motivation

Obtuse error message with no underlying reason given.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
