### PR TITLE
Fix intermittent BBSCache/CCCache test failures (and speed up tests)

### DIFF
--- a/pkg/autodiscovery/listeners/cloudfoundry_test.go
+++ b/pkg/autodiscovery/listeners/cloudfoundry_test.go
@@ -37,11 +37,7 @@ func (b *bbsCacheFake) LastUpdated() time.Time {
 	return b.Updated
 }
 
-func (b *bbsCacheFake) GetPollAttempts() int {
-	panic("implement me")
-}
-
-func (b *bbsCacheFake) GetPollSuccesses() int {
+func (b *bbsCacheFake) UpdatedOnce() <-chan struct{} {
 	panic("implement me")
 }
 

--- a/pkg/autodiscovery/providers/cloudfoundry_test.go
+++ b/pkg/autodiscovery/providers/cloudfoundry_test.go
@@ -28,11 +28,7 @@ func (b bbsCacheFake) LastUpdated() time.Time {
 	return b.Updated
 }
 
-func (b bbsCacheFake) GetPollAttempts() int {
-	panic("implement me")
-}
-
-func (b bbsCacheFake) GetPollSuccesses() int {
+func (b bbsCacheFake) UpdatedOnce() <-chan struct{} {
 	panic("implement me")
 }
 

--- a/pkg/util/cloudfoundry/bbscache.go
+++ b/pkg/util/cloudfoundry/bbscache.go
@@ -36,7 +36,7 @@ type BBSCacheI interface {
 	// GetActualLRPsForProcessGUID returns slice of pointers to ActualLRP objects for given App GUID
 	GetActualLRPsForProcessGUID(appGUID string) ([]*ActualLRP, error)
 
-	// GetActualLRPsForCell returns slice of pointers to ActualLRP objects for given App GUID
+	// GetActualLRPsForCell returns slice of pointers to ActualLRP objects for given Cell ID
 	GetActualLRPsForCell(cellID string) ([]*ActualLRP, error)
 
 	// GetDesiredLRPFor returns DesiredLRP for a specific process GUID
@@ -151,7 +151,7 @@ func (bc *BBSCache) GetActualLRPsForProcessGUID(processGUID string) ([]*ActualLR
 	return []*ActualLRP{}, fmt.Errorf("actual LRPs for app %s not found", processGUID)
 }
 
-// GetActualLRPsForCell returns slice of pointers to ActualLRP objects for given App GUID
+// GetActualLRPsForCell returns slice of pointers to ActualLRP objects for given Cell ID
 func (bc *BBSCache) GetActualLRPsForCell(cellID string) ([]*ActualLRP, error) {
 	bc.RLock()
 	defer bc.RUnlock()

--- a/pkg/util/cloudfoundry/bbscache.go
+++ b/pkg/util/cloudfoundry/bbscache.go
@@ -204,8 +204,6 @@ func (bc *BBSCache) start() {
 
 func (bc *BBSCache) readData() {
 	log.Debug("Reading data from BBS API")
-	bc.Lock()
-	bc.Unlock()
 	var wg sync.WaitGroup
 	var actualLRPsByProcessGUID map[string][]*ActualLRP
 	var actualLRPsByCellID map[string][]*ActualLRP

--- a/pkg/util/cloudfoundry/bbscache.go
+++ b/pkg/util/cloudfoundry/bbscache.go
@@ -33,13 +33,13 @@ type BBSCacheI interface {
 	// will never close.
 	UpdatedOnce() <-chan struct{}
 
-	// GetActualLRPsForProcessGUID returns slice of pointers to ActualLRP objects for given App GUID
-	GetActualLRPsForProcessGUID(appGUID string) ([]*ActualLRP, error)
+	// GetActualLRPsForProcessGUID returns slice of pointers to ActualLRP objects for given process GUID
+	GetActualLRPsForProcessGUID(processGUID string) ([]*ActualLRP, error)
 
-	// GetActualLRPsForCell returns slice of pointers to ActualLRP objects for given Cell ID
+	// GetActualLRPsForCell returns slice of pointers to ActualLRP objects for given cell GUID
 	GetActualLRPsForCell(cellID string) ([]*ActualLRP, error)
 
-	// GetDesiredLRPFor returns DesiredLRP for a specific process GUID
+	// GetDesiredLRPFor returns DesiredLRP for a specific app GUID
 	GetDesiredLRPFor(appGUID string) (DesiredLRP, error)
 
 	// GetAllLRPs returns all Actual LRPs (in mapping {appGuid: []ActualLRP}) and all Desired LRPs
@@ -141,7 +141,7 @@ func (bc *BBSCache) UpdatedOnce() <-chan struct{} {
 	return bc.updatedOnce
 }
 
-// GetActualLRPsForProcessGUID returns slice of pointers to ActualLRP objects for given App GUID
+// GetActualLRPsForProcessGUID returns slice of pointers to ActualLRP objects for given process GUID
 func (bc *BBSCache) GetActualLRPsForProcessGUID(processGUID string) ([]*ActualLRP, error) {
 	bc.RLock()
 	defer bc.RUnlock()
@@ -151,7 +151,7 @@ func (bc *BBSCache) GetActualLRPsForProcessGUID(processGUID string) ([]*ActualLR
 	return []*ActualLRP{}, fmt.Errorf("actual LRPs for app %s not found", processGUID)
 }
 
-// GetActualLRPsForCell returns slice of pointers to ActualLRP objects for given Cell ID
+// GetActualLRPsForCell returns slice of pointers to ActualLRP objects for given cell GUID
 func (bc *BBSCache) GetActualLRPsForCell(cellID string) ([]*ActualLRP, error) {
 	bc.RLock()
 	defer bc.RUnlock()
@@ -161,14 +161,14 @@ func (bc *BBSCache) GetActualLRPsForCell(cellID string) ([]*ActualLRP, error) {
 	return []*ActualLRP{}, fmt.Errorf("actual LRPs for cell %s not found", cellID)
 }
 
-// GetDesiredLRPFor returns DesiredLRP for a specific process GUID
-func (bc *BBSCache) GetDesiredLRPFor(processGUID string) (DesiredLRP, error) {
+// GetDesiredLRPFor returns DesiredLRP for a specific app GUID
+func (bc *BBSCache) GetDesiredLRPFor(appGUID string) (DesiredLRP, error) {
 	bc.RLock()
 	defer bc.RUnlock()
-	if val, ok := bc.desiredLRPs[processGUID]; ok {
+	if val, ok := bc.desiredLRPs[appGUID]; ok {
 		return *val, nil
 	}
-	return DesiredLRP{}, fmt.Errorf("desired LRP for app %s not found", processGUID)
+	return DesiredLRP{}, fmt.Errorf("desired LRP for app %s not found", appGUID)
 }
 
 // GetAllLRPs returns all Actual LRPs (in mapping {appGuid: []ActualLRP}) and all Desired LRPs

--- a/pkg/util/cloudfoundry/bbscache_test.go
+++ b/pkg/util/cloudfoundry/bbscache_test.go
@@ -26,8 +26,7 @@ func (t testBBSClient) DesiredLRPs(lager.Logger, models.DesiredLRPFilter) ([]*mo
 }
 
 func TestBBSCachePolling(t *testing.T) {
-	assert.NotZero(t, bc.GetPollAttempts())
-	assert.NotZero(t, bc.GetPollSuccesses())
+	assert.NotZero(t, bc.LastUpdated())
 }
 
 func TestBBSCache_GetDesiredLRPFor(t *testing.T) {

--- a/pkg/util/cloudfoundry/cccache.go
+++ b/pkg/util/cloudfoundry/cccache.go
@@ -174,9 +174,7 @@ func (ccc *CCCache) readData() {
 	go func() {
 		defer wg.Done()
 		query := url.Values{}
-		ccc.RLock()
 		query.Add("per_page", fmt.Sprintf("%d", ccc.appsBatchSize))
-		ccc.RUnlock()
 		apps, err := ccc.ccAPIClient.ListV3AppsByQuery(query)
 		if err != nil {
 			log.Errorf("Failed listing apps from cloud controller: %v", err)

--- a/pkg/util/cloudfoundry/cccache.go
+++ b/pkg/util/cloudfoundry/cccache.go
@@ -174,7 +174,9 @@ func (ccc *CCCache) readData() {
 	go func() {
 		defer wg.Done()
 		query := url.Values{}
+		ccc.RLock()
 		query.Add("per_page", fmt.Sprintf("%d", ccc.appsBatchSize))
+		ccc.RUnlock()
 		apps, err := ccc.ccAPIClient.ListV3AppsByQuery(query)
 		if err != nil {
 			log.Errorf("Failed listing apps from cloud controller: %v", err)

--- a/pkg/util/cloudfoundry/cccache_test.go
+++ b/pkg/util/cloudfoundry/cccache_test.go
@@ -26,8 +26,7 @@ func (t testCCClient) ListV3SpacesByQuery(_ url.Values) ([]cfclient.V3Space, err
 }
 
 func TestCCCachePolling(t *testing.T) {
-	assert.NotZero(t, cc.GetPollAttempts())
-	assert.NotZero(t, cc.GetPollSuccesses())
+	assert.NotZero(t, cc.LastUpdated())
 }
 
 func TestCCCache_GetApp(t *testing.T) {

--- a/pkg/util/cloudfoundry/main_test.go
+++ b/pkg/util/cloudfoundry/main_test.go
@@ -30,9 +30,10 @@ func TestMain(m *testing.M) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	bc, _ = ConfigureGlobalBBSCache(ctx, "url", "", "", "", time.Second, []*regexp.Regexp{}, []*regexp.Regexp{}, &testBBSClient{})
+	<-bc.UpdatedOnce()
 	cc, _ = ConfigureGlobalCCCache(ctx, "url", "", "", false, time.Second, 1, &testCCClient{})
 	for i := 1; i <= 10; i++ {
-		if cc.GetPollSuccesses() == 0 || bc.GetPollSuccesses() == 0 {
+		if cc.GetPollSuccesses() == 0 {
 			time.Sleep(time.Second)
 		}
 	}

--- a/pkg/util/cloudfoundry/main_test.go
+++ b/pkg/util/cloudfoundry/main_test.go
@@ -29,10 +29,15 @@ var (
 func TestMain(m *testing.M) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	bc, _ = ConfigureGlobalBBSCache(ctx, "url", "", "", "", time.Second, []*regexp.Regexp{}, []*regexp.Regexp{}, &testBBSClient{})
-	<-bc.UpdatedOnce()
+
+	// the BBSCache depends on the CCCache, so initialize the CCache first.  In
+	// production code, any discrepancies would work out after a few polls;
+	// this is just needed for tests.
 	cc, _ = ConfigureGlobalCCCache(ctx, "url", "", "", false, time.Second, 1, &testCCClient{})
 	<-cc.UpdatedOnce()
+	bc, _ = ConfigureGlobalBBSCache(ctx, "url", "", "", "", time.Second, []*regexp.Regexp{}, []*regexp.Regexp{}, &testBBSClient{})
+	<-bc.UpdatedOnce()
+
 	code := m.Run()
 	os.Exit(code)
 }

--- a/pkg/util/cloudfoundry/main_test.go
+++ b/pkg/util/cloudfoundry/main_test.go
@@ -32,11 +32,7 @@ func TestMain(m *testing.M) {
 	bc, _ = ConfigureGlobalBBSCache(ctx, "url", "", "", "", time.Second, []*regexp.Regexp{}, []*regexp.Regexp{}, &testBBSClient{})
 	<-bc.UpdatedOnce()
 	cc, _ = ConfigureGlobalCCCache(ctx, "url", "", "", false, time.Second, 1, &testCCClient{})
-	for i := 1; i <= 10; i++ {
-		if cc.GetPollSuccesses() == 0 {
-			time.Sleep(time.Second)
-		}
-	}
+	<-cc.UpdatedOnce()
 	code := m.Run()
 	os.Exit(code)
 }

--- a/pkg/util/cloudfoundry/types_test.go
+++ b/pkg/util/cloudfoundry/types_test.go
@@ -293,7 +293,7 @@ func TestADIdentifier(t *testing.T) {
 			expected: "4321/flask-app/instance-guid",
 		},
 	} {
-		t.Run(fmt.Sprintf(""), func(t *testing.T) {
+		t.Run(fmt.Sprintf("svcName=%s", tc.svcName), func(t *testing.T) {
 			var i ADIdentifier
 			if tc.aLRP == nil {
 				i = NewADNonContainerIdentifier(tc.dLRP, tc.svcName)


### PR DESCRIPTION
### Motivation

Test `pkg/util/cloudfoundry.TestBBSCache_GetDesiredLRPFor` fails intermittently.  Also, the package tests take just over 1s, due to a 1s sleep in test initialization.

### What does this PR do?

* Replace the existing "poll until success != 0" logic for waiting until the caches are warm with a channel.  This is patterned after `context.Context#Done`.  This has the side-effect of removing the 1s sleep from the tests.
* Start the two caches up in a deterministic order so that the tests pass reliably.

### Additional Notes

I'm not sure if the test data contains conflicting information that might have caused this error.  Switching the order of the CCCache and BBSCache startup in main_test.go will reliably reproduce the error, if someone with more knowledge of the data structures would like to take a look.

### Describe how to test/QA your changes

The only production code changed is the cache startup, so any QA that involves such startup is sufficient.  I don't know what circumstances that would include.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
