### PR TITLE
Replace usage of `go-bindata` with `go:embed` in `pkg/status` and `cmd/agent/gui`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -153,10 +153,6 @@ rtloader/doxygen/errors.log
 # integrations-core when checked out for unit tests
 integrations-core/
 
-# file generated for templates
-pkg/status/templates.go
-cmd/agent/gui/templates.go
-
 # netlink message dump test files
 pkg/network/netlink/testdata/message_dump*
 

--- a/cmd/agent/gui/gui.go
+++ b/cmd/agent/gui/gui.go
@@ -1,10 +1,8 @@
-//go:generate go run github.com/shuLhan/go-bindata/cmd/go-bindata -pkg gui -prefix views -o ./templates.go views/...
-//go:generate go fmt ./templates.go
-
 package gui
 
 import (
 	"crypto/rand"
+	"embed"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -14,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -35,6 +34,9 @@ var (
 	// To compute uptime
 	startTimestamp int64
 )
+
+//go:embed views
+var viewsFS embed.FS
 
 // Payload struct is for the JSON messages received from a client POST request
 type Payload struct {
@@ -111,7 +113,7 @@ func createCSRFToken() error {
 }
 
 func generateIndex(w http.ResponseWriter, r *http.Request) {
-	data, err := Asset("/templates/index.tmpl")
+	data, err := viewsFS.ReadFile("views/templates/index.tmpl")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -130,7 +132,7 @@ func generateIndex(w http.ResponseWriter, r *http.Request) {
 }
 
 func generateAuthEndpoint(w http.ResponseWriter, r *http.Request) {
-	data, err := Asset("/templates/auth.tmpl")
+	data, err := viewsFS.ReadFile("views/templates/auth.tmpl")
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -149,8 +151,8 @@ func generateAuthEndpoint(w http.ResponseWriter, r *http.Request) {
 }
 
 func serveAssets(w http.ResponseWriter, req *http.Request) {
-	path := filepath.Join("/private", req.URL.Path)
-	data, err := Asset(path)
+	path := path.Join("views", "private", req.URL.Path)
+	data, err := viewsFS.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			http.Error(w, err.Error(), http.StatusNotFound)

--- a/cmd/agent/gui/render.go
+++ b/cmd/agent/gui/render.go
@@ -95,7 +95,7 @@ func renderError(name string) (string, error) {
 func fillTemplate(w io.Writer, data Data, request string) error {
 	t := template.New(request + ".tmpl")
 	t.Funcs(fmap)
-	tmpl, err := Asset("/templates/" + request + ".tmpl")
+	tmpl, err := viewsFS.ReadFile("views/templates/" + request + ".tmpl")
 	if err != nil {
 		return err
 	}

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -3,16 +3,15 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:generate go run github.com/shuLhan/go-bindata/cmd/go-bindata -pkg status -prefix templates -o ./templates.go templates/...
-//go:generate go fmt ./templates.go
-
 package status
 
 import (
 	"bytes"
+	"embed"
 	"encoding/json"
 	"fmt"
 	"io"
+	"path"
 	"text/template"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
@@ -201,8 +200,11 @@ func renderAutodiscoveryStats(w io.Writer, adEnabledFeatures interface{}, adConf
 	renderStatusTemplate(w, "/autodiscovery.tmpl", autodiscoveryStats)
 }
 
+//go:embed templates
+var templatesFS embed.FS
+
 func renderStatusTemplate(w io.Writer, templateName string, stats interface{}) {
-	tmpl, tmplErr := Asset(templateName)
+	tmpl, tmplErr := templatesFS.ReadFile(path.Join("templates", templateName))
 	if tmplErr != nil {
 		fmt.Println(tmplErr)
 		return

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -38,7 +38,6 @@ from .go import (
     deps,
     deps_vendored,
     fmt,
-    generate,
     generate_licenses,
     generate_protobuf,
     golangci_lint,
@@ -89,7 +88,6 @@ ns.add_task(lint_filenames)
 ns.add_task(lint_python)
 ns.add_task(audit_tag_impact)
 ns.add_task(e2e_tests)
-ns.add_task(generate)
 ns.add_task(install_shellcheck)
 ns.add_task(download_tools)
 ns.add_task(install_tools)

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -19,7 +19,7 @@ from invoke.exceptions import Exit, ParseError
 from .build_tags import filter_incompatible_tags, get_build_tags, get_default_build_tags
 from .docker import pull_base_images
 from .flavor import AgentFlavor
-from .go import deps, generate
+from .go import deps
 from .rtloader import clean as rtloader_clean
 from .rtloader import install as rtloader_install
 from .rtloader import make as rtloader_make
@@ -164,9 +164,6 @@ def build(
         )
         build_exclude = [] if build_exclude is None else build_exclude.split(",")
         build_tags = get_build_tags(build_include, build_exclude)
-
-    # Generating go source from templates by running go generate on ./pkg/status
-    generate(ctx)
 
     cmd = "go build -mod={go_mod} {race_opt} {build_type} -tags \"{go_build_tags}\" "
 

--- a/tasks/android.py
+++ b/tasks/android.py
@@ -11,7 +11,6 @@ import yaml
 from invoke import task
 
 from .build_tags import get_default_build_tags
-from .go import generate
 from .utils import REPO_PATH, bin_name, get_build_flags, get_version
 
 # constants
@@ -47,9 +46,6 @@ def build(ctx, rebuild=False, race=False, major_version='7', python_runtimes='3'
     assetconfigs(ctx)
 
     ldflags, gcflags, env = get_build_flags(ctx, major_version=major_version, python_runtimes=python_runtimes)
-
-    # Generating go source from templates by running go generate on ./pkg/status
-    generate(ctx, mod="vendor")
 
     build_tags = get_default_build_tags(build="android")
 

--- a/tasks/cluster_agent_helpers.py
+++ b/tasks/cluster_agent_helpers.py
@@ -7,7 +7,6 @@ import shutil
 from distutils.dir_util import copy_tree
 
 from .build_tags import filter_incompatible_tags, get_build_tags
-from .go import generate
 from .utils import REPO_PATH, bin_name, get_build_flags, get_version
 
 
@@ -37,9 +36,6 @@ def build_common(
 
     # We rely on the go libs embedded in the debian stretch image to build dynamically
     ldflags, gcflags, env = get_build_flags(ctx, static=False, prefix='dca')
-
-    # Generating go source from templates by running go generate on ./pkg/status
-    generate(ctx)
 
     cmd = "go build -mod={go_mod} {race_opt} {build_type} -tags '{build_tags}' -o {bin_name} "
     cmd += "-gcflags=\"{gcflags}\" -ldflags=\"{ldflags}\" {REPO_PATH}/cmd/cluster-agent{suffix}"

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -50,9 +50,6 @@ MISSPELL_IGNORED_TARGETS = [
     os.path.join("pkg", "network", "event_windows_test.go"),
 ]
 
-# Packages that need go:generate
-GO_GENERATE_TARGETS = ["./pkg/status", "./cmd/agent/gui"]
-
 
 @task
 def fmt(ctx, targets, fail_on_fmt=False):
@@ -457,15 +454,6 @@ def reset(ctx):
     # remove vendor folder
     print("Remove vendor folder")
     ctx.run("rm -rf ./vendor")
-
-
-@task
-def generate(ctx, mod="mod"):
-    """
-    Run go generate required package
-    """
-    ctx.run(f"go generate -mod={mod} " + " ".join(GO_GENERATE_TARGETS))
-    print("go generate ran successfully")
 
 
 @task

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -7,7 +7,7 @@ import tempfile
 from invoke import task
 
 from .build_tags import get_default_build_tags
-from .go import generate, golangci_lint, staticcheck, vet
+from .go import golangci_lint, staticcheck, vet
 from .utils import (
     REPO_PATH,
     bin_name,
@@ -97,9 +97,6 @@ def build(
                 if env_var in line:
                     goenv[env_var] = line[line.find(env_var) + len(env_var) + 1 : -1].strip('\'\"')
         ld_vars["GoVersion"] = go_version
-
-    # Generating go source from templates by running go generate on ./pkg/status
-    generate(ctx)
 
     # extend PATH from gimme with the one from get_build_flags
     if "PATH" in os.environ and "PATH" in goenv:

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -16,7 +16,7 @@ from .agent import integration_tests as agent_integration_tests
 from .build_tags import filter_incompatible_tags, get_build_tags, get_default_build_tags
 from .cluster_agent import integration_tests as dca_integration_tests
 from .dogstatsd import integration_tests as dsd_integration_tests
-from .go import fmt, generate, golangci_lint, ineffassign, lint, misspell, staticcheck, vet
+from .go import fmt, golangci_lint, ineffassign, lint, misspell, staticcheck, vet
 from .libs.copyright import CopyrightLinter
 from .libs.junit_upload import junit_upload_from_tgz, produce_junit_tar
 from .modules import DEFAULT_MODULES, GoModule
@@ -155,11 +155,6 @@ def test(
     build_tags = get_build_tags(build_include, build_exclude)
 
     timeout = int(timeout)
-
-    # explicitly run these tasks instead of using pre-tasks so we can
-    # pass the `target` param (pre-tasks are invoked without parameters)
-    print("--- go generating:")
-    generate(ctx)
 
     if skip_linters:
         print("--- [skipping Go linters]")


### PR DESCRIPTION
### What does this PR do?

This PR replaces usages of `go-bindata` with `go:embed` in `pkg/status` and `cmd/agent/gui`

This PR also removes the `agent.generate` task now useless. If this change is deemed too much I can revert it.

### Motivation

~While exploring why the codeql github action was spending so much time in building the agent, I figured that the `go generate` step was maybe the culprit. Most likely because of poor FS performances. This is an attempt to fix this issue.~

~Logs extract:~
```
2021-11-09T21:31:20.5381363Z make: Leaving directory '/home/runner/work/datadog-agent/datadog-agent/go/src/github.com/DataDog/datadog-agent/rtloader/build'
2021-11-09T21:31:42.2871709Z templates.go
2021-11-09T21:32:02.9308983Z templates.go
2021-11-09T21:55:46.8366380Z go generate ran successfully
2021-11-09T21:55:46.8371129Z Successfully wrote /home/runner/work/datadog-agent/datadog-agent/go/src/github.com/DataDog/datadog-agent/cmd/agent/dist/datadog.yaml
2021-11-09T21:55:47.3178141Z Successfully wrote /home/runner/work/datadog-agent/datadog-agent/go/src/github.com/DataDog/datadog-agent/cmd/agent/dist/system-probe.yaml
2021-11-09T21:55:47.4220966Z ##[group]Run github/codeql-action/analyze@v1
```

Sadly this PR doesn't fix the issue. However replacing go-bindata with more recent/standard ways can be useful.

### Possible Drawbacks / Trade-offs

No drawbacks that I can think of.

### Describe how to test/QA your changes

This should be fully transparent.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
