### PR TITLE
[CSPM] Run commands as nobody by default

### DIFF
--- a/pkg/compliance/checks/command_utils.go
+++ b/pkg/compliance/checks/command_utils.go
@@ -6,11 +6,7 @@
 package checks
 
 import (
-	"bytes"
 	"context"
-	"errors"
-	"fmt"
-	"os/exec"
 	"runtime"
 	"time"
 
@@ -56,39 +52,4 @@ func runBinaryCmd(execCommand *compliance.BinaryCmd, timeout time.Duration) (int
 
 	exitCode, stdout, err := commandRunner(ctx, execCommand.Name, execCommand.Args, true)
 	return exitCode, string(stdout), err
-}
-
-func runCommand(ctx context.Context, name string, args []string, captureStdout bool) (int, []byte, error) {
-	if len(name) == 0 {
-		return 0, nil, errors.New("cannot run empty command")
-	}
-
-	_, err := exec.LookPath(name)
-	if err != nil {
-		return 0, nil, fmt.Errorf("command '%s' not found, err: %v", name, err)
-	}
-
-	cmd := exec.CommandContext(ctx, name, args...)
-	if cmd == nil {
-		return 0, nil, errors.New("unable to create command context")
-	}
-
-	var stdoutBuffer bytes.Buffer
-	if captureStdout {
-		cmd.Stdout = &stdoutBuffer
-	}
-
-	err = cmd.Run()
-
-	// We expect ExitError as commands may have an exitCode != 0
-	// It's not a failure for a compliance command
-	var e *exec.ExitError
-	if errors.As(err, &e) {
-		err = nil
-	}
-
-	if cmd.ProcessState != nil {
-		return cmd.ProcessState.ExitCode(), stdoutBuffer.Bytes(), err
-	}
-	return -1, nil, fmt.Errorf("unable to retrieve exit code, err: %v", err)
 }

--- a/pkg/compliance/checks/command_utils_unix.go
+++ b/pkg/compliance/checks/command_utils_unix.go
@@ -1,0 +1,96 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !windows
+// +build !windows
+
+package checks
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"os/exec"
+	"os/user"
+	"strconv"
+	"syscall"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+func parseID(s string) (uint32, error) {
+	id, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, err
+	}
+
+	if id < 0 || id > math.MaxInt32 {
+		return 0, fmt.Errorf("ID for '%s' must be positive and less that %d", s, math.MaxInt32)
+	}
+
+	return uint32(id), nil
+}
+
+func runCommand(ctx context.Context, name string, args []string, captureStdout bool) (int, []byte, error) {
+	if len(name) == 0 {
+		return 0, nil, errors.New("cannot run empty command")
+	}
+
+	_, err := exec.LookPath(name)
+	if err != nil {
+		return 0, nil, fmt.Errorf("command '%s' not found, err: %v", name, err)
+	}
+
+	cmd := exec.CommandContext(ctx, name, args...)
+	if cmd == nil {
+		return 0, nil, errors.New("unable to create command context")
+	}
+
+	// Fallback to these values when the nobody user can't be found
+	uid := uint32(65534)
+	gid := uint32(65534)
+
+	runAs := config.Datadog.GetString("compliance_config.run_commands_as")
+	if runAs == "" {
+		runAs = "nobody"
+	}
+
+	user, err := user.Lookup(runAs)
+	if err == nil {
+		uid, err = parseID(user.Uid)
+		if err != nil {
+			return 0, nil, fmt.Errorf("failed to get uid for user %s", runAs)
+		}
+
+		gid, err = parseID(user.Gid)
+		if err != nil {
+			return 0, nil, fmt.Errorf("failed to get gid for user %s", runAs)
+		}
+	}
+
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+	cmd.SysProcAttr.Credential = &syscall.Credential{Uid: uid, Gid: gid}
+
+	var stdoutBuffer bytes.Buffer
+	if captureStdout {
+		cmd.Stdout = &stdoutBuffer
+	}
+
+	err = cmd.Run()
+
+	// We expect ExitError as commands may have an exitCode != 0
+	// It's not a failure for a compliance command
+	var e *exec.ExitError
+	if errors.As(err, &e) {
+		err = nil
+	}
+
+	if cmd.ProcessState != nil {
+		return cmd.ProcessState.ExitCode(), stdoutBuffer.Bytes(), err
+	}
+	return -1, nil, fmt.Errorf("unable to retrieve exit code, err: %v", err)
+}

--- a/pkg/compliance/checks/command_utils_windows.go
+++ b/pkg/compliance/checks/command_utils_windows.go
@@ -1,0 +1,52 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+// +build windows
+
+package checks
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+)
+
+func runCommand(ctx context.Context, name string, args []string, captureStdout bool) (int, []byte, error) {
+	if len(name) == 0 {
+		return 0, nil, errors.New("cannot run empty command")
+	}
+
+	_, err := exec.LookPath(name)
+	if err != nil {
+		return 0, nil, fmt.Errorf("command '%s' not found, err: %v", name, err)
+	}
+
+	cmd := exec.CommandContext(ctx, name, args...)
+	if cmd == nil {
+		return 0, nil, errors.New("unable to create command context")
+	}
+
+	var stdoutBuffer bytes.Buffer
+	if captureStdout {
+		cmd.Stdout = &stdoutBuffer
+	}
+
+	err = cmd.Run()
+
+	// We expect ExitError as commands may have an exitCode != 0
+	// It's not a failure for a compliance command
+	var e *exec.ExitError
+	if errors.As(err, &e) {
+		err = nil
+	}
+
+	if cmd.ProcessState != nil {
+		return cmd.ProcessState.ExitCode(), stdoutBuffer.Bytes(), err
+	}
+	return -1, nil, fmt.Errorf("unable to retrieve exit code, err: %v", err)
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -929,6 +929,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("compliance_config.check_max_events_per_run", 100)
 	config.BindEnvAndSetDefault("compliance_config.dir", "/etc/datadog-agent/compliance.d")
 	config.BindEnvAndSetDefault("compliance_config.run_path", defaultRunPath)
+	config.BindEnv("compliance_config.run_commands_as")
 	bindEnvAndSetLogsConfigKeys(config, "compliance_config.endpoints.")
 
 	// Datadog security agent (runtime)

--- a/releasenotes/notes/cspm-command-check-user-145e687beab0af8e.yaml
+++ b/releasenotes/notes/cspm-command-check-user-145e687beab0af8e.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Run CSPM commands as a configurable user.
+    Defaults to 'nobody'.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Currently, the `command` uses the current user to run command.
This PR allows using a different user to run commands and defaults to `nobody`.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
