### PR TITLE
Update the embedded `pip` version to 21.3.1 on Python 3

### DIFF
--- a/omnibus/config/software/datadog-agent-integrations-py3.rb
+++ b/omnibus/config/software/datadog-agent-integrations-py3.rb
@@ -133,7 +133,7 @@ build do
     # install the core integrations.
     #
     command "#{pip} install wheel==0.34.1"
-    command "#{pip} install pip-tools==5.4.0"
+    command "#{pip} install pip-tools==6.4.0"
     uninstall_buildtime_deps = ['rtloader', 'click', 'first', 'pip-tools']
     nix_build_env = {
       # Specify C99 standard explicitly to avoid issues while building some

--- a/omnibus/config/software/pip3.rb
+++ b/omnibus/config/software/pip3.rb
@@ -1,11 +1,11 @@
 name "pip3"
 
-default_version "20.3.3"
+default_version "21.3.1"
 
 dependency "setuptools3"
 
 source :url => "https://github.com/pypa/pip/archive/#{version}.tar.gz",
-       :sha256 => "016f8d509871b72fb05da911db513c11059d8a99f4591dda3050a3cf83a29a79",
+       :sha256 => "cbfb6a0b5bc2d1e4b4647729ee5b944bb313c8ffd9ff83b9d2e0f727f0c79714",
        :extract => :seven_zip
 
 relative_path "pip-#{version}"

--- a/releasenotes/notes/update-pip-version-21.3.1-python3-d9d2ff96ef3c9774.yaml
+++ b/releasenotes/notes/update-pip-version-21.3.1-python3-d9d2ff96ef3c9774.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Update the embedded ``pip`` version to 21.3.1 on Python 3 to
+    allow the use of newer build backends.


### PR DESCRIPTION
### Motivation

Required for integrations getting rid of `setup.py`

https://pip.pypa.io/en/stable/news/#v21-3

> Support editable installs for projects that have a pyproject.toml and use a build backend that supports PEP 660.

### Notes for QA

Test:

1. the `integration` command
2. manually using `pip` to upgrade the base package