### PR TITLE
pkg/trace/test: find a free port to use when running the agent

### DIFF
--- a/pkg/trace/test/agent.go
+++ b/pkg/trace/test/agent.go
@@ -18,6 +18,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/test/testutil"
 	"github.com/DataDog/viper"
 	yaml "gopkg.in/yaml.v2"
 )
@@ -161,9 +162,16 @@ func (s *agentRunner) createConfigFile(conf []byte) (string, error) {
 	if err := v.ReadConfig(bytes.NewReader(conf)); err != nil {
 		return "", err
 	}
-	s.port = 8126
 	if v.IsSet("apm_config.receiver_port") {
 		s.port = v.GetInt("apm_config.receiver_port")
+	} else {
+		if p, err := testutil.FindTCPPort(); err != nil {
+			fmt.Printf("There was an error finding a free port: %v. Trying 8126.\n", err)
+			s.port = 8126
+		} else {
+			s.port = p
+		}
+		v.Set("apm_config.receiver_port", s.port)
 	}
 	v.Set("apm_config.apm_dd_url", "http://"+s.ddAddr)
 	if !v.IsSet("api_key") {

--- a/pkg/trace/test/testutil/testutil.go
+++ b/pkg/trace/test/testutil/testutil.go
@@ -20,16 +20,26 @@ import (
 	"testing"
 )
 
-// FreeTCPPort returns a free TCP port.
-func FreeTCPPort(t *testing.T) int {
+// FindTCPPort finds a free TCP port and returns it. If it fails, error will be non-nil.
+func FindTCPPort() (int, error) {
 	addr, err := net.ResolveTCPAddr("tcp", "localhost:0")
 	if err != nil {
-		t.Fatal(err)
+		return 0, err
 	}
 	l, err := net.ListenTCP("tcp", addr)
 	if err != nil {
-		t.Fatal(err)
+		return 0, err
 	}
 	defer l.Close()
-	return l.Addr().(*net.TCPAddr).Port
+	return l.Addr().(*net.TCPAddr).Port, nil
+}
+
+// FreeTCPPort returns a free TCP port. Upon encountering an error, it uses t to fail
+// the test and report it.
+func FreeTCPPort(t *testing.T) int {
+	p, err := FindTCPPort()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return p
 }


### PR DESCRIPTION
This change ensures that when the integration tests run, a free TCP port
is sought instead of using the default 8126, which on occasion may be
unavailable.