### PR TITLE
[Docker] Improve docker.exit service check

### DIFF
--- a/cmd/agent/common/tests/a6_conf/conf.d/docker.d/conf.yaml
+++ b/cmd/agent/common/tests/a6_conf/conf.d/docker.d/conf.yaml
@@ -2,6 +2,7 @@ instances:
 - collect_container_size: false
   collect_container_size_frequency: 5
   collect_exit_codes: false
+  ok_exit_codes: []
   collect_images_stats: false
   collect_image_size: false
   collect_disk_stats: false

--- a/cmd/agent/dist/conf.d/docker.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/docker.d/conf.yaml.default
@@ -63,9 +63,16 @@ instances:
     # collect_disk_stats: false
 
     ## @param collect_exit_codes - boolean - optional - default: false
-    ## Collect containers exit codes and send service checks critical when exit code is not 0.
+    ## Collect containers exit codes and send service checks critical when exit code is not 0 or 143.
     #
     # collect_exit_codes: false
+
+    ## @param ok_exit_codes - list of integers - optional - default: [0, 143]
+    ## Define the set of exit codes considered OK. It requires the collect_exit_codes parameter to be enabled.
+    #
+    # ok_exit_codes:
+    #   - 0
+    #   - 143
 
     ## @param tags - list of strings following the pattern: "key:value" - optional
     ## List of tags to attach to every metric, event, and service check emitted by this integration.

--- a/cmd/agent/dist/conf.d/docker.d/conf.yaml.default
+++ b/cmd/agent/dist/conf.d/docker.d/conf.yaml.default
@@ -69,6 +69,7 @@ instances:
 
     ## @param ok_exit_codes - list of integers - optional - default: [0, 143]
     ## Define the set of exit codes considered OK. It requires the collect_exit_codes parameter to be enabled.
+    ## Note: 143 is returned when docker sends a SIGTERM to stop a container.
     #
     # ok_exit_codes:
     #   - 0

--- a/pkg/collector/corechecks/containers/docker/docker_config.go
+++ b/pkg/collector/corechecks/containers/docker/docker_config.go
@@ -19,6 +19,7 @@ type DockerConfig struct {
 	CollectContainerSize     bool               `yaml:"collect_container_size"`
 	CollectContainerSizeFreq uint64             `yaml:"collect_container_size_frequency"`
 	CollectExitCodes         bool               `yaml:"collect_exit_codes"`
+	OkExitCodes              []int              `yaml:"ok_exit_codes"`
 	CollectImagesStats       bool               `yaml:"collect_images_stats"`
 	CollectImageSize         bool               `yaml:"collect_image_size"`
 	CollectDiskStats         bool               `yaml:"collect_disk_stats"`

--- a/pkg/collector/corechecks/containers/docker/docker_events.go
+++ b/pkg/collector/corechecks/containers/docker/docker_events.go
@@ -42,7 +42,7 @@ func (d *DockerCheck) retrieveEvents(du *docker.DockerUtil) ([]*docker.Container
 }
 
 // reportExitCodes monitors events for non zero exit codes and sends service checks
-func (d *DockerCheck) reportExitCodes(events []*docker.ContainerEvent, sender aggregator.Sender) error {
+func (d *DockerCheck) reportExitCodes(events []*docker.ContainerEvent, sender aggregator.Sender) {
 	for _, ev := range events {
 		// Filtering
 		if ev.Action != "die" {
@@ -62,17 +62,18 @@ func (d *DockerCheck) reportExitCodes(events []*docker.ContainerEvent, sender ag
 		// Building and sending message
 		message := fmt.Sprintf("Container %s exited with %d", ev.ContainerName, exitCodeInt)
 		status := metrics.ServiceCheckOK
-		if exitCodeInt != 0 {
+		if _, ok := d.okExitCodes[int(exitCodeInt)]; !ok {
 			status = metrics.ServiceCheckCritical
 		}
+
 		tags, err := tagger.Tag(ev.ContainerEntityName(), collectors.HighCardinality)
 		if err != nil {
 			log.Debugf("no tags for %s: %s", ev.ContainerID, err)
 		}
+
+		tags = append(tags, "exit_code:"+exitCodeString)
 		sender.ServiceCheck(DockerExit, status, "", tags, message)
 	}
-
-	return nil
 }
 
 // reportEvents aggregates and sends events to the Datadog event feed

--- a/pkg/collector/corechecks/containers/docker/docker_events.go
+++ b/pkg/collector/corechecks/containers/docker/docker_events.go
@@ -69,6 +69,7 @@ func (d *DockerCheck) reportExitCodes(events []*docker.ContainerEvent, sender ag
 		tags, err := tagger.Tag(ev.ContainerEntityName(), collectors.HighCardinality)
 		if err != nil {
 			log.Debugf("no tags for %s: %s", ev.ContainerID, err)
+			tags = []string{}
 		}
 
 		tags = append(tags, "exit_code:"+exitCodeString)

--- a/pkg/config/legacy/docker_test.go
+++ b/pkg/config/legacy/docker_test.go
@@ -59,6 +59,7 @@ instances:
 - collect_container_size: true
   collect_container_size_frequency: 5
   collect_exit_codes: true
+  ok_exit_codes: []
   collect_images_stats: false
   collect_image_size: true
   collect_disk_stats: true

--- a/releasenotes/notes/docker-exit-c5b8c5ab4885d54c.yaml
+++ b/releasenotes/notes/docker-exit-c5b8c5ab4885d54c.yaml
@@ -2,7 +2,5 @@
 enhancements:
   - |
     The ``docker.exit`` service check has a new tag ``exit_code``.
-  - |
     The ``143`` exit code is considered OK by default, in addition to ``0``.
-  - |
     The Docker check supports a parameter ``ok_exit_codes`` to allow choosing exit codes that are considered OK.

--- a/releasenotes/notes/docker-exit-c5b8c5ab4885d54c.yaml
+++ b/releasenotes/notes/docker-exit-c5b8c5ab4885d54c.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    The ``docker.exit`` service check has a new tag ``exit_code``.
+  - |
+    The ``143`` exit code is considered OK by default, in addition to ``0``.
+  - |
+    The Docker check supports a parameter ``ok_exit_codes`` to allow choosing exit codes that are considered OK.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- The `docker.exit` service check has a new tag `exit_code`.
- The `143` exit code is considered OK by default, in addition to `0`.
- The Docker check supports a parameter `ok_exit_codes` to allow choosing exit codes that are considered OK.

### Motivation

FR: https://github.com/DataDog/datadog-agent/issues/9785

### Additional Notes

fixes: https://github.com/DataDog/datadog-agent/issues/9785

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

#### Senario 1: Default config
1. Enable `collect_exit_codes` in the docker check
2. Force exit 0 and exit 143 in other containers, make sure the corresponding `docker.exit` service checks are OK (green) + the `exit_code` tag is applied.
3. Force other exit codes in other containers, make sure the corresponding `docker.exit` service checks are Critical (red) + the `exit_code` tag is applied.

#### Senario 2: Custom config
1. Enable `collect_exit_codes` in the docker check
2. Configure `ok_exit_codes` with custom exit code values
3. Do exit 'custom val' in other containers, make sure the corresponding `docker.exit` service checks are OK (green) + the `exit_code` tag is applied.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
