### PR TITLE
[tagger] Enable remote tagger by default

### DIFF
--- a/cmd/agent/common/loader.go
+++ b/cmd/agent/common/loader.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/tagger/local"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 
 	// register all workloadmeta collectors
@@ -30,7 +31,10 @@ func LoadComponents(confdPath string) {
 	// start the tagger. must be done before autodiscovery, as it needs to
 	// be the first subscribed to metadata store to avoid race conditions.
 	tagger.SetDefaultTagger(local.NewTagger(collectors.DefaultCatalog))
-	tagger.Init()
+	err := tagger.Init()
+	if err != nil {
+		log.Errorf("failed to start the tagger: %s", err)
+	}
 
 	// create the Collector instance and start all the components
 	// NOTICE: this will also setup the Python environment, if available

--- a/cmd/agent/common/loader.go
+++ b/cmd/agent/common/loader.go
@@ -31,8 +31,7 @@ func LoadComponents(confdPath string) {
 	// start the tagger. must be done before autodiscovery, as it needs to
 	// be the first subscribed to metadata store to avoid race conditions.
 	tagger.SetDefaultTagger(local.NewTagger(collectors.DefaultCatalog))
-	err := tagger.Init()
-	if err != nil {
+	if err := tagger.Init(); err != nil {
 		log.Errorf("failed to start the tagger: %s", err)
 	}
 

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -213,7 +213,10 @@ func runAgent(ctx context.Context) (err error) {
 		workloadmeta.GetGlobalStore().Start(context.Background())
 
 		tagger.SetDefaultTagger(local.NewTagger(collectors.DefaultCatalog))
-		tagger.Init()
+		err := tagger.Init()
+		if err != nil {
+			log.Errorf("failed to start the tagger: %s", err)
+		}
 	}
 
 	aggregatorInstance := aggregator.InitAggregator(s, nil, hname)

--- a/cmd/dogstatsd/main.go
+++ b/cmd/dogstatsd/main.go
@@ -213,8 +213,7 @@ func runAgent(ctx context.Context) (err error) {
 		workloadmeta.GetGlobalStore().Start(context.Background())
 
 		tagger.SetDefaultTagger(local.NewTagger(collectors.DefaultCatalog))
-		err := tagger.Init()
-		if err != nil {
+		if err := tagger.Init(); err != nil {
 			log.Errorf("failed to start the tagger: %s", err)
 		}
 	}

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -206,7 +206,10 @@ func runAgent(exit chan struct{}) {
 		t = local.NewTagger(collectors.DefaultCatalog)
 	}
 	tagger.SetDefaultTagger(t)
-	tagger.Init()
+	err = tagger.Init()
+	if err != nil {
+		log.Errorf("failed to start the tagger: %s", err)
+	}
 	defer tagger.Stop() //nolint:errcheck
 
 	err = initInfo(cfg)

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -273,7 +273,10 @@ func RunAgent(ctx context.Context) (err error) {
 	// Initialize the remote tagger
 	if coreconfig.Datadog.GetBool("security_agent.remote_tagger") {
 		tagger.SetDefaultTagger(remote.NewTagger())
-		tagger.Init()
+		err := tagger.Init()
+		if err != nil {
+			log.Errorf("failed to start the tagger: %s", err)
+		}
 	}
 
 	if err = startCompliance(hostname, stopper, statsdClient); err != nil {

--- a/pkg/config/apm.go
+++ b/pkg/config/apm.go
@@ -56,7 +56,7 @@ func setupAPM(config Config) {
 	config.BindEnvAndSetDefault("apm_config.receiver_port", 8126, "DD_APM_RECEIVER_PORT", "DD_RECEIVER_PORT")
 	config.BindEnvAndSetDefault("apm_config.windows_pipe_buffer_size", 1_000_000, "DD_APM_WINDOWS_PIPE_BUFFER_SIZE")                          //nolint:errcheck
 	config.BindEnvAndSetDefault("apm_config.windows_pipe_security_descriptor", "D:AI(A;;GA;;;WD)", "DD_APM_WINDOWS_PIPE_SECURITY_DESCRIPTOR") //nolint:errcheck
-	config.BindEnvAndSetDefault("apm_config.remote_tagger", false, "DD_APM_REMOTE_TAGGER")                                                    //nolint:errcheck
+	config.BindEnvAndSetDefault("apm_config.remote_tagger", true, "DD_APM_REMOTE_TAGGER")                                                     //nolint:errcheck
 
 	config.BindEnv("apm_config.max_catalog_services", "DD_APM_MAX_CATALOG_SERVICES")
 	config.BindEnv("apm_config.receiver_timeout", "DD_APM_RECEIVER_TIMEOUT")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -902,7 +902,8 @@ func InitConfig(config Config) {
 	config.SetKnown("process_config.expvar_port")
 	config.SetKnown("process_config.log_file")
 	config.SetKnown("process_config.internal_profiling.enabled")
-	config.SetKnown("process_config.remote_tagger")
+
+	config.BindEnvAndSetDefault("process_config.remote_tagger", true)
 
 	// Process Discovery Check
 	config.BindEnvAndSetDefault("process_config.process_discovery.enabled", false)
@@ -920,7 +921,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("security_agent.cmd_port", 5010)
 	config.BindEnvAndSetDefault("security_agent.expvar_port", 5011)
 	config.BindEnvAndSetDefault("security_agent.log_file", defaultSecurityAgentLogFile)
-	config.BindEnvAndSetDefault("security_agent.remote_tagger", false)
+	config.BindEnvAndSetDefault("security_agent.remote_tagger", true)
 
 	// Datadog security agent (compliance)
 	config.BindEnvAndSetDefault("compliance_config.enabled", false)

--- a/pkg/logs/input/journald/docker.go
+++ b/pkg/logs/input/journald/docker.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build systemd
 // +build systemd
 
 package journald
@@ -42,5 +43,8 @@ func (t *Tailer) getContainerTags(containerID string) []string {
 
 // initializeTagger initializes the tag collector.
 func (t *Tailer) initializeTagger() {
-	tagger.Init()
+	err := tagger.Init()
+	if err != nil {
+		log.Errorf("failed to start the tagger: %s", err)
+	}
 }

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -25,6 +25,7 @@ import (
 // defaultTagger is the shared tagger instance backing the global Tag and Init functions
 var defaultTagger Tagger
 var initOnce sync.Once
+var initErr error
 
 // captureTagger is a tagger instance that contains a tagger that will contain the tagger
 // state when replaying a capture scenario
@@ -48,8 +49,6 @@ var tlmUDPOriginDetectionError = telemetry.NewCounter("dogstatsd", "udp_origin_d
 
 // Init must be called once config is available, call it in your cmd
 func Init() error {
-	var initErr error
-
 	initOnce.Do(func() {
 		var err error
 		checkCard := config.Datadog.GetString("checks_tag_cardinality")

--- a/pkg/tagger/global.go
+++ b/pkg/tagger/global.go
@@ -47,7 +47,9 @@ var tlmUDPOriginDetectionError = telemetry.NewCounter("dogstatsd", "udp_origin_d
 	nil, "Dogstatsd UDP origin detection error count")
 
 // Init must be called once config is available, call it in your cmd
-func Init() {
+func Init() error {
+	var initErr error
+
 	initOnce.Do(func() {
 		var err error
 		checkCard := config.Datadog.GetString("checks_tag_cardinality")
@@ -58,6 +60,7 @@ func Init() {
 			log.Warnf("failed to parse check tag cardinality, defaulting to low. Error: %s", err)
 			ChecksCardinality = collectors.LowCardinality
 		}
+
 		DogstatsdCardinality, err = collectors.StringToTagCardinality(dsdCard)
 		if err != nil {
 			log.Warnf("failed to parse dogstatsd tag cardinality, defaulting to low. Error: %s", err)
@@ -69,11 +72,10 @@ func Init() {
 			return
 		}
 
-		err = defaultTagger.Init()
-		if err != nil {
-			log.Errorf("failed to start the tagger: %s", err)
-		}
+		initErr = defaultTagger.Init()
 	})
+
+	return initErr
 }
 
 // GetEntity returns the hash for the provided entity id.

--- a/pkg/trace/agent/run.go
+++ b/pkg/trace/agent/run.go
@@ -147,8 +147,7 @@ func Run(ctx context.Context) {
 	remoteTagger := coreconfig.Datadog.GetBool("apm_config.remote_tagger")
 	if remoteTagger {
 		tagger.SetDefaultTagger(remote.NewTagger())
-		err = tagger.Init()
-		if err != nil {
+		if err := tagger.Init(); err != nil {
 			log.Infof("starting remote tagger failed. falling back to local tagger: %s", err)
 			remoteTagger = false
 		}
@@ -161,8 +160,7 @@ func Run(ctx context.Context) {
 		workloadmeta.GetGlobalStore().Start(context.Background())
 
 		tagger.SetDefaultTagger(local.NewTagger(collectors.DefaultCatalog))
-		err = tagger.Init()
-		if err != nil {
+		if err := tagger.Init(); err != nil {
 			log.Errorf("failed to start the tagger: %s", err)
 		}
 	}

--- a/pkg/trace/test/agent.go
+++ b/pkg/trace/test/agent.go
@@ -173,6 +173,10 @@ func (s *agentRunner) createConfigFile(conf []byte) (string, error) {
 		v.Set("apm_config.trace_writer.flush_period_seconds", 0.1)
 	}
 	v.Set("log_level", "debug")
+
+	// disable remote tagger to avoid running a core agent for testing
+	v.Set("apm_config.remote_tagger", false)
+
 	out, err := yaml.Marshal(v.AllSettings())
 	if err != nil {
 		return "", err

--- a/pkg/trace/test/testsuite/secrets_test.go
+++ b/pkg/trace/test/testsuite/secrets_test.go
@@ -58,6 +58,7 @@ func TestSecrets(t *testing.T) {
 		"DD_SECRET_BACKEND_COMMAND=" + binSecrets,
 		"DD_HOSTNAME=ENC[secret1]",
 		"DD_API_KEY=123",
+		"DD_APM_REMOTE_TAGGER=false",
 	}
 	cmd.Stdout = &buf
 	cmd.Stderr = &buf

--- a/releasenotes/notes/remote-tagger-by-default-6ccbe955041871ec.yaml
+++ b/releasenotes/notes/remote-tagger-by-default-6ccbe955041871ec.yaml
@@ -1,0 +1,10 @@
+---
+enhancements:
+  - |
+    The Process, APM, and Security agent now use the remote tagger introduced
+    in Agent 7.26 by default. To disable it in the respective agent, the following
+    settings need to be set to `false`:
+
+    - apm_config.remote_tagger
+    - process_config.remote_tagger
+    - security_agent.remote_tagger


### PR DESCRIPTION
### What does this PR do?

This re-applies changes from #9313 that were subsequently reverted due to a memory leak (fixed in #9452). It also adds a fallback in the trace-agent for backwards compatibility, in case the remote tagger is not available if running standalone and remote tagger is not disabled.

### Describe how to test/QA your changes

* Test that the remote tagger is actually enabled in process, trace, and security agent.
* Check that tagging still works for those agents. This is especially important for environments in which the remote tagger is new: ECS EC2 and ECS Fargate.
* Test that the trace-agent falls back to the local tagger if it's running standalone.