### PR TITLE
[process-agent] Allow process discovery to run when container check is off

### DIFF
--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -655,9 +655,9 @@ func TestProcessDiscoveryConfig(t *testing.T) {
 			cfg := AgentConfig{EnabledChecks: []string{}, CheckIntervals: map[string]time.Duration{}}
 			cfg.initProcessDiscoveryCheck()
 
-			// Make sure that the process discovery check is only enabled when both the process-agent is set to false,
+			// Make sure that the process discovery check is only enabled when both the process-agent is not set to true,
 			// and procDiscoveryEnabled isn't overridden.
-			if procDiscoveryEnabled == true && procConfigEnabled == "false" {
+			if procDiscoveryEnabled == true && procConfigEnabled != "true" {
 				assert.ElementsMatch([]string{DiscoveryCheckName}, cfg.EnabledChecks)
 
 				// Interval Tests:

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -316,13 +316,13 @@ func (a *AgentConfig) setCheckInterval(ns, check, checkKey string) {
 func (a *AgentConfig) initProcessDiscoveryCheck() {
 	root := key(ns, "process_discovery")
 
-	// Discovery check should be only enabled when process_config.process_discovery.enabled = true and
-	// process_config.enabled is set to "false". This effectively makes sure the check only runs when the process check is
-	// disabled, while also respecting the users wishes when they want to disable either the check or the process agent completely.
+	// Discovery check can only be enabled when regular process collection is not enabled.
+	// (process_config.process_discovery.enabled = true and process_config.enabled is not set to "true")
 	processAgentEnabled := strings.ToLower(config.Datadog.GetString(key(ns, "enabled")))
 	checkEnabled := config.Datadog.GetBool(key(root, "enabled"))
-	if checkEnabled && processAgentEnabled == "false" {
+	if checkEnabled && processAgentEnabled != "true" {
 		a.EnabledChecks = append(a.EnabledChecks, DiscoveryCheckName)
+		a.Enabled = true
 
 		// We don't need to check if the key exists since we already bound it to a default in InitConfig.
 		// We use a minimum of 10 minutes for this value.

--- a/releasenotes/notes/process-discovery-without-container-collection-138d8e4f6c5446c9.yaml
+++ b/releasenotes/notes/process-discovery-without-container-collection-138d8e4f6c5446c9.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Allow configuring process discovery check in the process agent when both regular process and container checks are off.


### PR DESCRIPTION
### What does this PR do?

- Fix a bug where we would only allow process discovery to run when process check was disabled but container check was enabled (`process_config.enabled: "false").

```
  ## @param enabled - string - optional - default: "false"
  ## @env DD_PROCESS_CONFIG_ENABLED - string - optional - default: "false"
  ##  A string indicating the enabled state of the Process Agent:
  ##    * "false"    : The Agent collects only containers information.
  ##    * "true"     : The Agent collects containers and processes information.
  ##    * "disabled" : The Agent process collection is disabled.
  #
  # enabled: "true"
```

### Motivation

Allow configuring process discovery independently of enabled container check.

### Describe how to test/QA your changes

- Test that process agent starts normally with `process_config.enabled = true|false|disabled`, and process and container checks are enabled accordingly.

- Test that process discovery can be enabled with `process_config.enabled = false|disabled` but not `true`.

