### PR TITLE
[CSPM] allow creation of error findings from rego

### DIFF
--- a/pkg/compliance/checks/rego_check.go
+++ b/pkg/compliance/checks/rego_check.go
@@ -271,7 +271,12 @@ func findingsToReports(findings []regoFinding) []*compliance.Report {
 				errMsg = ""
 			}
 			err := fmt.Errorf("%v", errMsg)
-			report = buildReportForError(err)
+			report = &compliance.Report{
+				Resource:  reportResource,
+				Passed:    false,
+				Error:     err,
+				Evaluator: regoEvaluator,
+			}
 		case "passed":
 			report = &compliance.Report{
 				Resource:  reportResource,
@@ -432,14 +437,10 @@ func checkFindingRequiredFields(metadata *mapstructure.Metadata) error {
 	return nil
 }
 
-func buildReportForError(err error) *compliance.Report {
+func buildErrorReports(err error) []*compliance.Report {
 	report := compliance.BuildReportForError(err)
 	report.Evaluator = regoEvaluator
-	return report
-}
-
-func buildErrorReports(err error) []*compliance.Report {
-	return []*compliance.Report{buildReportForError(err)}
+	return []*compliance.Report{report}
 }
 
 type regoPrintHook struct{}

--- a/pkg/compliance/checks/rego_check_test.go
+++ b/pkg/compliance/checks/rego_check_test.go
@@ -5,6 +5,7 @@
 package checks
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/compliance"
@@ -26,7 +27,6 @@ type regoFixture struct {
 	processes     processes
 	useCache      bool
 	expectReports []*compliance.Report
-	expectError   error
 }
 
 func (f *regoFixture) newRegoCheck() (*regoCheck, error) {
@@ -78,10 +78,9 @@ func (f *regoFixture) run(t *testing.T) {
 
 	reports := regoCheck.check(env)
 	assert.Equal(f.expectReports, reports)
-	assert.Equal(f.expectError, reports[0].Error)
 }
 
-func TestRegoProcessCheck(t *testing.T) {
+func TestRegoCheck(t *testing.T) {
 	tests := []regoFixture{
 		{
 			name: "simple case",
@@ -129,6 +128,51 @@ func TestRegoProcessCheck(t *testing.T) {
 						Type: "process",
 					},
 					Evaluator: "rego",
+				},
+			},
+		},
+		{
+			name: "error case",
+			inputs: []compliance.RegoInput{
+				{
+					ResourceCommon: compliance.ResourceCommon{
+						Process: &compliance.Process{
+							Name: "proc1",
+						},
+					},
+					TagName: "processes",
+					Type:    "array",
+				},
+			},
+			module: `
+				package test
+
+				import data.datadog as dd
+
+				default valid = false
+
+				findings[f] {
+					p := input.processes[_]
+					f := dd.error_finding("process", "42", "error message")
+				}
+			`,
+			findings: "data.test.findings",
+			processes: processes{
+				42: {
+					Name:    "proc1",
+					Cmdline: []string{"arg1", "--path=foo"},
+				},
+			},
+			expectReports: []*compliance.Report{
+				{
+					Passed: false,
+					Data:   nil,
+					Resource: compliance.ReportResource{
+						ID:   "42",
+						Type: "process",
+					},
+					Evaluator: "rego",
+					Error:     errors.New("error message"),
 				},
 			},
 		},

--- a/pkg/compliance/checks/rego_helpers/datadog.rego
+++ b/pkg/compliance/checks/rego_helpers/datadog.rego
@@ -27,11 +27,17 @@ docker_network_resource_id(n) = id {
 }
 
 passed_finding(resource_type, resource_id, event_data) = f {
-	f := raw_finding(true, resource_type, resource_id, event_data)
+	f := raw_finding("passed", resource_type, resource_id, event_data)
 }
 
 failing_finding(resource_type, resource_id, event_data) = f {
-	f := raw_finding(false, resource_type, resource_id, event_data)
+	f := raw_finding("failed", resource_type, resource_id, event_data)
+}
+
+error_finding(resource_type, resource_id, error_msg) = f {
+	f := raw_finding("error", resource_type, resource_id, {
+		"error": error_msg
+	})
 }
 
 docker_container_data(c) = d {

--- a/pkg/compliance/checks/rego_helpers/datadog.rego
+++ b/pkg/compliance/checks/rego_helpers/datadog.rego
@@ -31,7 +31,7 @@ passed_finding(resource_type, resource_id, event_data) = f {
 }
 
 failing_finding(resource_type, resource_id, event_data) = f {
-	f := raw_finding("failed", resource_type, resource_id, event_data)
+	f := raw_finding("failing", resource_type, resource_id, event_data)
 }
 
 error_finding(resource_type, resource_id, error_msg) = f {


### PR DESCRIPTION
### What does this PR do?

This PR allows the definition of error findings from rego

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
