### PR TITLE
[CSPM] add helpers for k8s master/worker resource id

### DIFF
--- a/pkg/compliance/checks/rego_helpers/datadog.rego
+++ b/pkg/compliance/checks/rego_helpers/datadog.rego
@@ -22,6 +22,14 @@ docker_daemon_resource_id = id {
 	id := sprintf("%s_daemon", [input.context.hostname])
 }
 
+kubernetes_master_node_resource_id = id {
+	id := sprintf("%s_kubernetes_master_node", [input.context.hostname])
+}
+
+kubernetes_worker_node_resource_id = id {
+	id := sprintf("%s_kubernetes_worker_node", [input.context.hostname])
+}
+
 docker_network_resource_id(n) = id {
 	id := sprintf("%s_%s", [input.context.hostname, cast_string(n.id)])
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds helpers for master/worker k8s resource ids.

### Motivation

Help writing rules.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
