### PR TITLE
Remove spammy debug log

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -677,7 +677,6 @@ func buildDeniedMetricsSet(collectors []string) options.MetricSet {
 // If the owner is a job, it tries to get the kube_cronjob tag in addition to kube_job.
 func ownerTags(kind, name string) []string {
 	if kind == "" || name == "" {
-		log.Debugf("Empty kind: %q or name: %q", kind, name)
 		return nil
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->
Remove a very verbose debug log.
```
2021-11-10 14:00:27 UTC | CLUSTER | DEBUG | (pkg/collector/corechecks/cluster/ksm/kubernetes_state.go:673 in ownerTags) | Empty kind: "" or name: ""
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
This log was printed by the `kubernetes_state_core` check for every single kubernetes object that doesn’t have an owner reference.
Concretely, on my small dev cluster, I could have several pages of that log inside the same second. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Enable the `kubernetes_state_core` check and the `DEBUG` log level.
The above mentioned log shouldn’t appear anymore whereas it was appearing a lot prior to this change.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [X] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [X] The appropriate `team/..` label has been applied, if known.
- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [X] Changed code has automated tests for its functionality.
- [X] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [X] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [X] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [X] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
