### PR TITLE
add Nomad namespace and datacenter tag extraction

### DIFF
--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -71,6 +71,8 @@ var (
 		"NOMAD_TASK_NAME":  "nomad_task",
 		"NOMAD_JOB_NAME":   "nomad_job",
 		"NOMAD_GROUP_NAME": "nomad_group",
+		"NOMAD_NAMESPACE":  "nomad_namespace",
+		"NOMAD_DC":         "nomad_dc",
 	}
 
 	orchCardOrchestratorEnvKeys = map[string]string{

--- a/pkg/tagger/collectors/workloadmeta_test.go
+++ b/pkg/tagger/collectors/workloadmeta_test.go
@@ -685,6 +685,8 @@ func TestHandleContainer(t *testing.T) {
 					"NOMAD_TASK_NAME":  "test-task",
 					"NOMAD_JOB_NAME":   "test-job",
 					"NOMAD_GROUP_NAME": "test-group",
+					"NOMAD_NAMESPACE":  "test-namespace",
+					"NOMAD_DC":         "test-dc",
 				},
 			},
 			expected: []*TagInfo{
@@ -700,6 +702,8 @@ func TestHandleContainer(t *testing.T) {
 						"nomad_task:test-task",
 						"nomad_job:test-job",
 						"nomad_group:test-group",
+						"nomad_namespace:test-namespace",
+						"nomad_dc:test-dc",
 					}),
 					StandardTags: []string{},
 				},

--- a/releasenotes/notes/add-nomad-namespace-and-dc-efe2b0d6bb081efe.yaml
+++ b/releasenotes/notes/add-nomad-namespace-and-dc-efe2b0d6bb081efe.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Adds Nomad namespace and datacenter to list of env vars extracted from Docker containers.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->
Adds Nomad namespace and datacenter tag extraction from Docker container environmental variables.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Asked by external contributor @kung-foo.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->
Superseds #8215.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Make a deployment on Nomad and check the presence of the following now tags: `nomad_namespace` and `nomad_dc`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [X] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [X] The appropriate `team/..` label has been applied, if known.
- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [X] Changed code has automated tests for its functionality.
- [X] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [X] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [X] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [X] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
