### PR TITLE
[CSPM] export rule inputs and ID in the rego input context document

### DIFF
--- a/pkg/compliance/checks/rego_check.go
+++ b/pkg/compliance/checks/rego_check.go
@@ -291,7 +291,7 @@ func roundTrip(inputs interface{}) (interface{}, error) {
 
 func (r *regoCheck) buildContextInput(env env.Env) eval.RegoInputMap {
 	context := make(map[string]interface{})
-	context["id"] = r.ruleID
+	context["ruleID"] = r.ruleID
 	context["hostname"] = env.Hostname()
 
 	if r.ruleScope == compliance.KubernetesClusterScope {

--- a/pkg/compliance/checks/rego_check.go
+++ b/pkg/compliance/checks/rego_check.go
@@ -18,6 +18,7 @@ import (
 	"github.com/open-policy-agent/opa/ast"
 	"github.com/open-policy-agent/opa/rego"
 	"github.com/open-policy-agent/opa/topdown/print"
+	"gopkg.in/yaml.v3"
 
 	"github.com/DataDog/datadog-agent/pkg/compliance"
 	"github.com/DataDog/datadog-agent/pkg/compliance/checks/env"
@@ -174,10 +175,7 @@ func (r *regoCheck) buildNormalInput(env env.Env) (eval.RegoInputMap, error) {
 			continue
 		}
 
-		tagName := input.TagName
-		if tagName == "" {
-			tagName = string(input.Kind())
-		}
+		tagName := extractTagName(&input)
 
 		inputType, err := input.ValidateInputType()
 		if err != nil {
@@ -245,6 +243,14 @@ func (r *regoCheck) buildNormalInput(env env.Env) (eval.RegoInputMap, error) {
 	return input, nil
 }
 
+func extractTagName(input *compliance.RegoInput) string {
+	tagName := input.TagName
+	if tagName == "" {
+		return string(input.Kind())
+	}
+	return tagName
+}
+
 func (r *regoCheck) appendInstance(input map[string][]interface{}, key string, instance eval.Instance) {
 	vars, exists := input[key]
 	if !exists {
@@ -256,14 +262,53 @@ func (r *regoCheck) appendInstance(input map[string][]interface{}, key string, i
 	}
 }
 
+func buildMappedInputs(inputs []compliance.RegoInput) map[string]compliance.RegoInput {
+	res := make(map[string]compliance.RegoInput)
+	for _, input := range inputs {
+		tagName := extractTagName(&input)
+
+		if _, present := res[tagName]; present {
+			log.Warnf("error building mapped input context: duplicated tag")
+			return nil
+		}
+
+		res[tagName] = input
+	}
+	return res
+}
+
+func roundTrip(inputs interface{}) (interface{}, error) {
+	output, err := yaml.Marshal(inputs)
+	if err != nil {
+		return nil, err
+	}
+	var res interface{}
+	if err := yaml.Unmarshal(output, &res); err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
 func (r *regoCheck) buildContextInput(env env.Env) eval.RegoInputMap {
 	context := make(map[string]interface{})
+	context["id"] = r.ruleID
 	context["hostname"] = env.Hostname()
+
 	if r.ruleScope == compliance.KubernetesClusterScope {
 		context["kubernetes_cluster"], _ = env.KubeClient().ClusterID()
 	}
 	if r.ruleScope == compliance.KubernetesNodeScope {
 		context["kubernetes_node_labels"] = env.NodeLabels()
+	}
+
+	mappedInputs := buildMappedInputs(r.inputs)
+	if mappedInputs != nil {
+		preparedInputs, err := roundTrip(mappedInputs)
+		if err != nil {
+			log.Warnf("failed to build mapped inputs in context")
+		} else {
+			context["input"] = preparedInputs
+		}
 	}
 
 	return context

--- a/pkg/compliance/checks/rego_check_input_test.go
+++ b/pkg/compliance/checks/rego_check_input_test.go
@@ -118,7 +118,17 @@ func TestRegoInputCheck(t *testing.T) {
 			expectedInput: `
 				{
 					"context": {
-						"hostname": "hostname_test"
+						"hostname": "hostname_test",
+						"id": "rule-id",
+						"input": {
+							"processes": {
+								"process": {
+									"name": "proc1"
+								},
+								"tag": "processes",
+								"type": "array"
+							}
+						}
 					},
 					"processes": [
 						{

--- a/pkg/compliance/checks/rego_check_input_test.go
+++ b/pkg/compliance/checks/rego_check_input_test.go
@@ -119,7 +119,7 @@ func TestRegoInputCheck(t *testing.T) {
 				{
 					"context": {
 						"hostname": "hostname_test",
-						"id": "rule-id",
+						"ruleID": "rule-id",
 						"input": {
 							"processes": {
 								"process": {


### PR DESCRIPTION
### What does this PR do?

This PR adds a representation of the rego inputs in the context part.
The context part is a map where tags are used as keys.
This is a best-effort feature. If there is a tag collision, the context part will be skipped and a warning logged.

### Motivation

This is useful to provide expressive error message (for example to go back to the user-provided input).

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
