### PR TITLE
Fix debugfs mountpoint detection logic

### DIFF
--- a/releasenotes/notes/debugfs-fix-ecs-97afb26f9d5a8c8b.yaml
+++ b/releasenotes/notes/debugfs-fix-ecs-97afb26f9d5a8c8b.yaml
@@ -1,0 +1,6 @@
+---
+fixes:
+  - |
+    Fix incorrect use of a namespaced PID with the host procfs when parsing mountinfo to ensure debugfs is mounted correctly.
+    This issue was preventing system-probe startup in AWS ECS. This issue could also surface in other containerized environments
+    where PID namespaces are in use and ``/host/proc`` is mounted.


### PR DESCRIPTION
### What does this PR do?

Backport of #9828