### PR TITLE
Remove unused MetadataEndpoint

### DIFF
--- a/pkg/forwarder/endpoints/endpoints.go
+++ b/pkg/forwarder/endpoints/endpoints.go
@@ -31,8 +31,6 @@ var (
 	SketchSeriesEndpoint = transaction.Endpoint{Route: "/api/beta/sketches", Name: "sketches_v2"}
 	// HostMetadataEndpoint is the v2 endpoint used to send host medatada
 	HostMetadataEndpoint = transaction.Endpoint{Route: "/api/v2/host_metadata", Name: "host_metadata_v2"}
-	// MetadataEndpoint is the v2 endpoint used to send other metadata
-	MetadataEndpoint = transaction.Endpoint{Route: "/api/v2/metadata", Name: "metadata_v2"}
 
 	// ProcessesEndpoint is a v1 endpoint used to send processes checks
 	ProcessesEndpoint = transaction.Endpoint{Route: "/api/v1/collector", Name: "process"}

--- a/pkg/forwarder/forwarder_test.go
+++ b/pkg/forwarder/forwarder_test.go
@@ -412,7 +412,7 @@ func TestTransactionEventHandlers(t *testing.T) {
 	headers := http.Header{}
 	headers.Set("key", "value")
 
-	transactions := f.createHTTPTransactions(endpoints.MetadataEndpoint, payload, false, headers)
+	transactions := f.createHTTPTransactions(endpoints.SeriesEndpoint, payload, false, headers)
 	require.Len(t, transactions, 1)
 
 	attempts := int64(0)
@@ -442,7 +442,7 @@ func TestTransactionEventHandlersOnRetry(t *testing.T) {
 	mux.HandleFunc(endpoints.V1ValidateEndpoint.Route, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	mux.HandleFunc(endpoints.MetadataEndpoint.Route, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(endpoints.SeriesEndpoint.Route, func(w http.ResponseWriter, r *http.Request) {
 		if v := atomic.AddInt64(&requests, 1); v == 1 {
 			w.WriteHeader(http.StatusInternalServerError)
 		} else {
@@ -470,7 +470,7 @@ func TestTransactionEventHandlersOnRetry(t *testing.T) {
 	headers := http.Header{}
 	headers.Set("key", "value")
 
-	transactions := f.createHTTPTransactions(endpoints.MetadataEndpoint, payload, false, headers)
+	transactions := f.createHTTPTransactions(endpoints.SeriesEndpoint, payload, false, headers)
 	require.Len(t, transactions, 1)
 
 	attempts := int64(0)
@@ -500,7 +500,7 @@ func TestTransactionEventHandlersNotRetryable(t *testing.T) {
 	mux.HandleFunc(endpoints.V1ValidateEndpoint.Route, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
-	mux.HandleFunc(endpoints.MetadataEndpoint.Route, func(w http.ResponseWriter, r *http.Request) {
+	mux.HandleFunc(endpoints.SeriesEndpoint.Route, func(w http.ResponseWriter, r *http.Request) {
 		atomic.AddInt64(&requests, 1)
 		w.WriteHeader(http.StatusInternalServerError)
 	})
@@ -524,7 +524,7 @@ func TestTransactionEventHandlersNotRetryable(t *testing.T) {
 	headers := http.Header{}
 	headers.Set("key", "value")
 
-	transactions := f.createHTTPTransactions(endpoints.MetadataEndpoint, payload, false, headers)
+	transactions := f.createHTTPTransactions(endpoints.SeriesEndpoint, payload, false, headers)
 	require.Len(t, transactions, 1)
 
 	attempts := int64(0)
@@ -583,10 +583,10 @@ func TestProcessLikePayloadResponseTimeout(t *testing.T) {
 	headers := http.Header{}
 	headers.Set("key", "value")
 
-	transactions := f.createHTTPTransactions(endpoints.MetadataEndpoint, payload, false, headers)
+	transactions := f.createHTTPTransactions(endpoints.SeriesEndpoint, payload, false, headers)
 	require.Len(t, transactions, 1)
 
-	responses, err := f.submitProcessLikePayload(endpoints.MetadataEndpoint, payload, headers, true)
+	responses, err := f.submitProcessLikePayload(endpoints.SeriesEndpoint, payload, headers, true)
 	require.NoError(t, err)
 
 	_, ok := <-responses

--- a/pkg/forwarder/telemetry.go
+++ b/pkg/forwarder/telemetry.go
@@ -54,7 +54,6 @@ func initEndpointExpvars() {
 		endpoints.ContainerEndpoint,
 		endpoints.EventsEndpoint,
 		endpoints.HostMetadataEndpoint,
-		endpoints.MetadataEndpoint,
 		endpoints.OrchestratorEndpoint,
 		endpoints.ProcessesEndpoint,
 		endpoints.RtContainerEndpoint,


### PR DESCRIPTION
This endpoint corresponds to the "old v2", which never materialized.
This commit gets rid of the relic so that it is not confused with "new
v2".

### Motivation

Deleting code means less to think about.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
