### PR TITLE
[networks] Fix eBPF conntracker

### DIFF
--- a/pkg/network/testutil/ping.go
+++ b/pkg/network/testutil/ping.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -18,7 +19,7 @@ func PingTCP(t *testing.T, ip net.IP, port int) net.Conn {
 		addr = fmt.Sprintf("[%s]:%d", ip, port)
 	}
 
-	conn, err := net.Dial(network, addr)
+	conn, err := net.DialTimeout(network, addr, time.Second)
 	require.NoError(t, err)
 
 	_, err = conn.Write([]byte("ping"))

--- a/pkg/network/tracer/ebpf_conntracker.go
+++ b/pkg/network/tracer/ebpf_conntracker.go
@@ -37,6 +37,7 @@ type ebpfConntracker struct {
 	m            *manager.Manager
 	ctMap        *ebpf.Map
 	telemetryMap *ebpf.Map
+	rootNS       uint32
 	// only kept around for stats purposes from initial dump
 	consumer *netlink.Consumer
 	decoder  *netlink.Decoder
@@ -79,10 +80,16 @@ func NewEBPFConntracker(cfg *config.Config) (netlink.Conntracker, error) {
 		return nil, fmt.Errorf("unable to get telemetry map: %w", err)
 	}
 
+	rootNS, err := util.GetNetNsInoFromPid(cfg.ProcRoot, 1)
+	if err != nil {
+		return nil, fmt.Errorf("could not find network root namespace: %w", err)
+	}
+
 	e := &ebpfConntracker{
 		m:            m,
 		ctMap:        ctMap,
 		telemetryMap: telemetryMap,
+		rootNS:       rootNS,
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.ConntrackInitTimeout)
@@ -195,7 +202,6 @@ func formatKey(netns uint32, tuple *ct.IPTuple) *netebpf.ConntrackTuple {
 }
 
 func toConntrackTupleFromStats(src *netebpf.ConntrackTuple, stats *network.ConnectionStats) {
-	src.Netns = stats.NetNS
 	src.Sport = stats.SPort
 	src.Dport = stats.DPort
 	src.Saddr_l, src.Saddr_h = util.ToLowHigh(stats.Source)
@@ -222,9 +228,19 @@ func (e *ebpfConntracker) GetTranslationForConn(stats network.ConnectionStats) *
 
 	toConntrackTupleFromStats(src, &stats)
 	log.Tracef("looking up in conntrack (stats): %s", stats)
-	log.Tracef("looking up in conntrack (tuple): %s", src)
 
+	// Try the lookup in the root namespace first
+	src.Netns = e.rootNS
+	log.Tracef("looking up in conntrack (tuple): %s", src)
 	dst := e.get(src)
+
+	if dst == nil && stats.NetNS != e.rootNS {
+		// Perform another lookup, this time using the connection namespace
+		src.Netns = stats.NetNS
+		log.Tracef("looking up in conntrack (tuple): %s", src)
+		dst = e.get(src)
+	}
+
 	if dst == nil {
 		return nil
 	}


### PR DESCRIPTION
### What does this PR do?

Fix eBPF conntracker by ensuring that both the root namespace and the connection namespaces are queried.
Prior to this change we were only querying the connection namespace, which caused connections to miss `IPTranslations` when NAT rules are triggered in the root namespace. 
This is typical in containerized environments, where network traffic is usually "funneled"  through a veth pair from the container NS to the rootNS where NAT rules are applied. This happens, for example, with clusterIPs on K8S, or more broadly when traffic originated from a container is masqueraded before leaving a host to access the public internet. 


### Motivation

Improve data correctness now that we are about to start using the eBPF-based Conntracker implementation.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
