### PR TITLE
inventories_*_interval configs are in integer seconds

### DIFF
--- a/pkg/metadata/inventories_collector.go
+++ b/pkg/metadata/inventories_collector.go
@@ -48,7 +48,7 @@ func (c inventoriesCollector) Send(ctx context.Context, s *serializer.Serializer
 
 // Init initializes the inventory metadata collection
 func (c inventoriesCollector) Init() error {
-	return inventories.StartMetadataUpdatedGoroutine(c.sc, config.Datadog.GetDuration("inventories_min_interval")*time.Second)
+	return inventories.StartMetadataUpdatedGoroutine(c.sc, time.Duration(config.Datadog.GetInt("inventories_min_interval"))*time.Second)
 }
 
 // SetupInventoriesExpvar init the expvar function for inventories
@@ -73,7 +73,7 @@ func SetupInventories(sc *Scheduler, ac inventories.AutoConfigInterface, coll in
 	}
 	RegisterCollector("inventories", ic)
 
-	if err := sc.AddCollector("inventories", config.Datadog.GetDuration("inventories_max_interval")*time.Second); err != nil {
+	if err := sc.AddCollector("inventories", time.Duration(config.Datadog.GetInt("inventories_max_interval"))*time.Second); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Reading an integer number of seconds with `config.GetDuration(..) *time.Second` will cause unexpected results if the config contains an actual duration.  For example, `30s` will be interpreted as 30000000000s or about 950 years, certainly not what was intended.

### Motivation

Avoiding future confusion.

### Additional Notes

AC-1303 tracks a larger effort to fix this fairly-widespread issue.  This just addresses this one case while it's still relatively new code.

### Describe how to test/QA your changes

Part of testing #9257.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
