### PR TITLE
Minor cleanup for pkg/util/scrubber

### DIFF
--- a/pkg/forwarder/transaction/transaction.go
+++ b/pkg/forwarder/transaction/transaction.go
@@ -242,7 +242,7 @@ func (t *HTTPTransaction) GetCreatedAt() time.Time {
 // GetTarget return the url used by the transaction
 func (t *HTTPTransaction) GetTarget() string {
 	url := t.Domain + t.Endpoint.Route
-	return scrubber.ScrubURL(url) // sanitized url that can be logged
+	return scrubber.ScrubLine(url) // sanitized url that can be logged
 }
 
 // GetPriority returns the priority
@@ -289,7 +289,7 @@ func (t *HTTPTransaction) internalProcess(ctx context.Context, client *http.Clie
 	reader := bytes.NewReader(*t.Payload)
 	url := t.Domain + t.Endpoint.Route
 	transactionEndpointName := t.GetEndpointName()
-	logURL := scrubber.ScrubURL(url) // sanitized url that can be logged
+	logURL := scrubber.ScrubLine(url) // sanitized url that can be logged
 
 	req, err := http.NewRequest("POST", url, reader)
 	if err != nil {
@@ -311,7 +311,7 @@ func (t *HTTPTransaction) internalProcess(ctx context.Context, client *http.Clie
 		t.ErrorCount++
 		transactionsErrors.Add(1)
 		tlmTxErrors.Inc(t.Domain, transactionEndpointName, "cant_send")
-		return 0, nil, fmt.Errorf("error while sending transaction, rescheduling it: %s", scrubber.ScrubURL(err.Error()))
+		return 0, nil, fmt.Errorf("error while sending transaction, rescheduling it: %s", scrubber.ScrubLine(err.Error()))
 	}
 	defer func() { _ = resp.Body.Close() }()
 

--- a/pkg/util/scrubber/default.go
+++ b/pkg/util/scrubber/default.go
@@ -14,7 +14,13 @@ import (
 
 // DefaultScrubber is the scrubber used by the package-level cleaning functions.
 //
-// It includes a set of agent-specific replacers defined in default.go.
+// It includes a set of agent-specific replacers.  It can scrub DataDog App
+// and API keys, passwords from URLs, and multi-line PEM-formatted TLS keys and
+// certificates.  It contains special handling for YAML-like content (with
+// lines of the form "key: value") and can scrub passwords, tokens, and SNMP
+// community strings in such content.
+//
+// See default.go for details of these replacers.
 var DefaultScrubber = &Scrubber{}
 
 func init() {

--- a/pkg/util/scrubber/default.go
+++ b/pkg/util/scrubber/default.go
@@ -123,10 +123,12 @@ func ScrubBytes(file []byte) ([]byte, error) {
 	return DefaultScrubber.ScrubBytes(file)
 }
 
-// ScrubURL sanitizes credentials from a message containing a URL, and returns
-// a string that can be logged safely, using the default scrubber.
-func ScrubURL(url string) string {
-	return DefaultScrubber.ScrubURL(url)
+// ScrubLine scrubs credentials from a single line of text, using the default
+// scrubber.  It can be safely applied to URLs or to strings containing URLs.
+// It does not run multi-line replacers, and should not be used on multi-line
+// inputs.
+func ScrubLine(url string) string {
+	return DefaultScrubber.ScrubLine(url)
 }
 
 // AddStrippedKeys adds to the set of YAML keys that will be recognized and have

--- a/pkg/util/scrubber/scrubber.go
+++ b/pkg/util/scrubber/scrubber.go
@@ -100,10 +100,10 @@ func (c *Scrubber) ScrubBytes(file []byte) ([]byte, error) {
 	return c.scrubReader(r)
 }
 
-// ScrubURL sanitizes credentials from a message containing a URL, and returns
-// a string that can be logged safely.  This method applies only the SingleLine
-// replacers.
-func (c *Scrubber) ScrubURL(message string) string {
+// ScrubLine scrubs credentials from a single line of text.  It can be safely
+// applied to URLs or to strings containing URLs.  It does not run multi-line
+// replacers, and should not be used on multi-line inputs.
+func (c *Scrubber) ScrubLine(message string) string {
 	return string(c.scrub([]byte(message), c.singleLineReplacers))
 }
 

--- a/pkg/util/scrubber/scrubber_test.go
+++ b/pkg/util/scrubber/scrubber_test.go
@@ -69,7 +69,7 @@ func TestCleanFile(t *testing.T) {
 	require.Equal(t, "a line with bar\na line with bar", string(res))
 }
 
-func TestScrubURL(t *testing.T) {
+func TestScrubLine(t *testing.T) {
 	scrubber := New()
 	scrubber.AddReplacer(SingleLine, Replacer{
 		Regex: regexp.MustCompile(`([A-Za-z][A-Za-z0-9+-.]+\:\/\/|\b)([^\:]+)\:([^\s]+)\@`),
@@ -80,6 +80,6 @@ func TestScrubURL(t *testing.T) {
 		Regex: regexp.MustCompile(".*"),
 		Repl:  []byte("UHOH"),
 	})
-	res := scrubber.ScrubURL("https://foo:bar@example.com")
+	res := scrubber.ScrubLine("https://foo:bar@example.com")
 	require.Equal(t, "https://foo:********@example.com", res)
 }


### PR DESCRIPTION
### What does this PR do?

This adds some minor cleanup for pkg/util/scrubber, now that it is fully utilized:
 * clearer documentation about what is scrubbed by default
 * rename ScrubURL, which was used for scrubbing lots more than URLs, to ScrubLine

### Motivation

Clarity of purpose

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
