### PR TITLE
[CSPM] improves rego consistency on `len = 0` cases

### DIFF
--- a/pkg/compliance/checks/audit_check.go
+++ b/pkg/compliance/checks/audit_check.go
@@ -23,7 +23,7 @@ var auditReportedFields = []string{
 	compliance.AuditFieldPermissions,
 }
 
-func resolveAudit(_ context.Context, e env.Env, ruleID string, res compliance.ResourceCommon) (resolved, error) {
+func resolveAudit(_ context.Context, e env.Env, ruleID string, res compliance.ResourceCommon, rego bool) (resolved, error) {
 	if res.Audit == nil {
 		return nil, fmt.Errorf("%s: expecting audit resource in audit check", ruleID)
 	}

--- a/pkg/compliance/checks/command_check.go
+++ b/pkg/compliance/checks/command_check.go
@@ -24,7 +24,7 @@ var commandReportedFields = []string{
 	compliance.CommandFieldExitCode,
 }
 
-func resolveCommand(ctx context.Context, _ env.Env, ruleID string, res compliance.ResourceCommon) (resolved, error) {
+func resolveCommand(ctx context.Context, _ env.Env, ruleID string, res compliance.ResourceCommon, rego bool) (resolved, error) {
 	if res.Command == nil {
 		return nil, fmt.Errorf("%s: expecting command resource in command check", ruleID)
 	}

--- a/pkg/compliance/checks/constants_check.go
+++ b/pkg/compliance/checks/constants_check.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-func resolveConstants(_ context.Context, e env.Env, ruleID string, res compliance.ResourceCommon) (resolved, error) {
+func resolveConstants(_ context.Context, e env.Env, ruleID string, res compliance.ResourceCommon, rego bool) (resolved, error) {
 	if res.Constants == nil {
 		return nil, fmt.Errorf("expecting constants resource in constants check")
 	}

--- a/pkg/compliance/checks/docker_check.go
+++ b/pkg/compliance/checks/docker_check.go
@@ -72,7 +72,7 @@ func dockerKindNotSupported(kind string) error {
 	return fmt.Errorf("unsupported docker object kind '%s'", kind)
 }
 
-func resolveDocker(ctx context.Context, e env.Env, ruleID string, res compliance.ResourceCommon) (resolved, error) {
+func resolveDocker(ctx context.Context, e env.Env, ruleID string, res compliance.ResourceCommon, rego bool) (resolved, error) {
 	if res.Docker == nil {
 		return nil, fmt.Errorf("expecting docker resource in docker check")
 	}

--- a/pkg/compliance/checks/file_check.go
+++ b/pkg/compliance/checks/file_check.go
@@ -105,6 +105,9 @@ func resolveFile(_ context.Context, e env.Env, ruleID string, res compliance.Res
 	}
 
 	if len(instances) == 0 {
+		if rego {
+			return nil, nil
+		}
 		return nil, fmt.Errorf("no files found for file check %q", file.Path)
 	}
 

--- a/pkg/compliance/checks/file_check.go
+++ b/pkg/compliance/checks/file_check.go
@@ -25,7 +25,7 @@ var fileReportedFields = []string{
 	compliance.FileFieldGroup,
 }
 
-func resolveFile(_ context.Context, e env.Env, ruleID string, res compliance.ResourceCommon) (resolved, error) {
+func resolveFile(_ context.Context, e env.Env, ruleID string, res compliance.ResourceCommon, rego bool) (resolved, error) {
 	if res.File == nil {
 		return nil, fmt.Errorf("expecting file resource in file check")
 	}

--- a/pkg/compliance/checks/group_check.go
+++ b/pkg/compliance/checks/group_check.go
@@ -31,7 +31,7 @@ var groupReportedFields = []string{
 // ErrGroupNotFound is returned when a group cannot be found
 var ErrGroupNotFound = errors.New("group not found")
 
-func resolveGroup(_ context.Context, e env.Env, id string, res compliance.ResourceCommon) (resolved, error) {
+func resolveGroup(_ context.Context, e env.Env, id string, res compliance.ResourceCommon, rego bool) (resolved, error) {
 	if res.Group == nil {
 		return nil, fmt.Errorf("%s: expecting group resource in group check", id)
 	}

--- a/pkg/compliance/checks/kubeapiserver_check.go
+++ b/pkg/compliance/checks/kubeapiserver_check.go
@@ -35,7 +35,7 @@ type kubeUnstructureResolvedResource struct {
 	eval.Instance
 }
 
-func resolveKubeapiserver(ctx context.Context, e env.Env, ruleID string, res compliance.ResourceCommon) (resolved, error) {
+func resolveKubeapiserver(ctx context.Context, e env.Env, ruleID string, res compliance.ResourceCommon, rego bool) (resolved, error) {
 	if res.KubeApiserver == nil {
 		return nil, fmt.Errorf("expecting Kubeapiserver resource in Kubeapiserver check")
 	}

--- a/pkg/compliance/checks/process_check.go
+++ b/pkg/compliance/checks/process_check.go
@@ -28,7 +28,7 @@ var processReportedFields = []string{
 	compliance.ProcessFieldCmdLine,
 }
 
-func resolveProcess(_ context.Context, e env.Env, id string, res compliance.ResourceCommon) (resolved, error) {
+func resolveProcess(_ context.Context, e env.Env, id string, res compliance.ResourceCommon, rego bool) (resolved, error) {
 	if res.Process == nil {
 		return nil, fmt.Errorf("%s: expecting process resource in process check", id)
 	}

--- a/pkg/compliance/checks/process_check.go
+++ b/pkg/compliance/checks/process_check.go
@@ -69,6 +69,10 @@ func resolveProcess(_ context.Context, e env.Env, id string, res compliance.Reso
 		instances = append(instances, newResolvedInstance(instance, strconv.Itoa(int(mp.Pid)), "process"))
 	}
 
+	if len(instances) == 0 && rego {
+		return nil, nil
+	}
+
 	// NOTE(safchain) workaround to allow fallback on all this resource if there is only one file
 	if len(instances) == 1 {
 		return instances[0].(*_resolvedInstance), nil

--- a/pkg/compliance/checks/rego_check.go
+++ b/pkg/compliance/checks/rego_check.go
@@ -189,6 +189,15 @@ func (r *regoCheck) buildNormalInput(env env.Env) (eval.RegoInputMap, error) {
 		}
 
 		switch res := resolved.(type) {
+		case nil:
+			switch inputType {
+			case "array":
+				r.appendInstance(arraysPerTags, tagName, nil)
+			case "object":
+				objectsPerTags[tagName] = &struct{}{}
+			default:
+				return nil, fmt.Errorf("internal error, wrong input type `%s`", inputType)
+			}
 		case resolvedInstance:
 			switch inputType {
 			case "array":
@@ -241,7 +250,10 @@ func (r *regoCheck) appendInstance(input map[string][]interface{}, key string, i
 	if !exists {
 		vars = []interface{}{}
 	}
-	input[key] = append(vars, instance.RegoInput())
+
+	if instance != nil {
+		input[key] = append(vars, instance.RegoInput())
+	}
 }
 
 func (r *regoCheck) buildContextInput(env env.Env) eval.RegoInputMap {

--- a/pkg/compliance/checks/rego_check.go
+++ b/pkg/compliance/checks/rego_check.go
@@ -168,7 +168,7 @@ func (r *regoCheck) buildNormalInput(env env.Env) (eval.RegoInputMap, error) {
 		ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 		defer cancel()
 
-		resolved, err := resolve(ctx, env, r.ruleID, input.ResourceCommon)
+		resolved, err := resolve(ctx, env, r.ruleID, input.ResourceCommon, true)
 		if err != nil {
 			log.Warnf("failed to resolve input: %v", err)
 			continue

--- a/pkg/compliance/checks/rego_check.go
+++ b/pkg/compliance/checks/rego_check.go
@@ -367,8 +367,10 @@ func dumpInputToFile(ruleID, path string, input interface{}) error {
 	currentData := make(map[string]interface{})
 	currentContent, err := ioutil.ReadFile(path)
 	if err == nil {
-		if err := json.Unmarshal(currentContent, &currentData); err != nil {
-			return err
+		if len(currentContent) != 0 {
+			if err := json.Unmarshal(currentContent, &currentData); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/pkg/compliance/checks/rego_check_input_test.go
+++ b/pkg/compliance/checks/rego_check_input_test.go
@@ -1,0 +1,147 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+package checks
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/compliance"
+	"github.com/DataDog/datadog-agent/pkg/compliance/mocks"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/stretchr/testify/mock"
+	assert "github.com/stretchr/testify/require"
+)
+
+type regoInputFixture struct {
+	name          string
+	inputs        []compliance.RegoInput
+	processes     processes
+	expectedInput string
+}
+
+const ruleID string = "rule-id"
+
+func (f *regoInputFixture) newRegoCheck() (*regoCheck, error) {
+	rule := &compliance.RegoRule{
+		RuleCommon: compliance.RuleCommon{
+			ID: ruleID,
+		},
+	}
+
+	regoCheck := &regoCheck{
+		ruleID: ruleID,
+		inputs: f.inputs,
+	}
+
+	if err := regoCheck.compileRule(rule, "", &compliance.SuiteMeta{}); err != nil {
+		return nil, err
+	}
+
+	return regoCheck, nil
+}
+
+func (f *regoInputFixture) run(t *testing.T) {
+	t.Helper()
+	assert := assert.New(t)
+
+	cache.Cache.Delete(processCacheKey)
+	processFetcher = func() (processes, error) {
+		for pid, p := range f.processes {
+			p.Pid = pid
+		}
+		return f.processes, nil
+	}
+
+	tf, err := os.CreateTemp("", "rego-input-dump")
+	assert.NoError(err)
+	err = tf.Close()
+	assert.NoError(err)
+	defer os.Remove(tf.Name())
+
+	env := &mocks.Env{}
+	env.On("MaxEventsPerRun").Return(30).Maybe()
+	env.On("ProvidedInput", mock.Anything).Return(nil).Once()
+	env.On("Hostname").Return("hostname_test").Once()
+	env.On("DumpInputPath").Return(tf.Name()).Once()
+
+	defer env.AssertExpectations(t)
+
+	regoCheck, err := f.newRegoCheck()
+	assert.NoError(err)
+	reports := regoCheck.check(env)
+	t.Logf("reports: %+v", reports)
+
+	content, err := os.ReadFile(tf.Name())
+	assert.NoError(err)
+
+	t.Logf("content: %v", string(content))
+
+	var res interface{}
+	err = json.Unmarshal(content, &res)
+	assert.NoError(err)
+
+	var expected interface{}
+	err = json.Unmarshal([]byte(f.expectedInput), &expected)
+	assert.NoError(err)
+	expectedGlobal := map[string]interface{}{
+		ruleID: expected,
+	}
+
+	assert.Equal(res, expectedGlobal)
+}
+
+func TestRegoInputCheck(t *testing.T) {
+	tests := []regoInputFixture{
+		{
+			name: "simple case",
+			inputs: []compliance.RegoInput{
+				{
+					ResourceCommon: compliance.ResourceCommon{
+						Process: &compliance.Process{
+							Name: "proc1",
+						},
+					},
+					TagName: "processes",
+					Type:    "array",
+				},
+			},
+			processes: processes{
+				42: {
+					Name:    "proc1",
+					Cmdline: []string{"arg1", "--path=foo"},
+				},
+			},
+			expectedInput: `
+				{
+					"context": {
+						"hostname": "hostname_test"
+					},
+					"processes": [
+						{
+							"cmdLine": [
+								"arg1",
+								"--path=foo"
+							],
+							"exe": "",
+							"flags": {
+								"--path": "foo",
+								"arg1": ""
+							},
+							"name": "proc1"
+						}
+					]
+				}
+			`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.run(t)
+		})
+	}
+}

--- a/pkg/compliance/checks/rego_check_test.go
+++ b/pkg/compliance/checks/rego_check_test.go
@@ -22,10 +22,8 @@ type regoFixture struct {
 	inputs   []compliance.RegoInput
 	module   string
 	findings string
-	scope    compliance.RuleScope
 
 	processes     processes
-	useCache      bool
 	expectReports []*compliance.Report
 }
 
@@ -44,7 +42,7 @@ func (f *regoFixture) newRegoCheck() (*regoCheck, error) {
 		inputs: f.inputs,
 	}
 
-	if err := regoCheck.compileRule(rule, f.scope, &compliance.SuiteMeta{}); err != nil {
+	if err := regoCheck.compileRule(rule, "", &compliance.SuiteMeta{}); err != nil {
 		return nil, err
 	}
 
@@ -55,9 +53,7 @@ func (f *regoFixture) run(t *testing.T) {
 	t.Helper()
 	assert := assert.New(t)
 
-	if !f.useCache {
-		cache.Cache.Delete(processCacheKey)
-	}
+	cache.Cache.Delete(processCacheKey)
 	processFetcher = func() (processes, error) {
 		for pid, p := range f.processes {
 			p.Pid = pid

--- a/pkg/compliance/checks/rego_check_test.go
+++ b/pkg/compliance/checks/rego_check_test.go
@@ -225,6 +225,40 @@ func TestRegoCheck(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "empty case",
+			inputs: []compliance.RegoInput{
+				{
+					ResourceCommon: compliance.ResourceCommon{
+						Process: &compliance.Process{
+							Name: "proc2",
+						},
+					},
+					TagName: "processes",
+					Type:    "array",
+				},
+			},
+			module: `
+				package test
+
+				import data.datadog as dd
+
+				default valid = false
+
+				findings[f] {
+					p := input.processes[_]
+					f := dd.error_finding("process", "42", "error message")
+				}
+			`,
+			findings: "data.test.findings",
+			processes: processes{
+				42: {
+					Name:    "proc1",
+					Cmdline: []string{"arg1", "--path=foo"},
+				},
+			},
+			expectReports: nil,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/compliance/checks/resource_check.go
+++ b/pkg/compliance/checks/resource_check.go
@@ -126,7 +126,7 @@ func newResolvedInstances(resolvedInstances []resolvedInstance) *resolvedIterato
 	return newResolvedIterator(newInstanceIterator(instances))
 }
 
-type resolveFunc func(ctx context.Context, e env.Env, ruleID string, resource compliance.ResourceCommon) (resolved, error)
+type resolveFunc func(ctx context.Context, e env.Env, ruleID string, resource compliance.ResourceCommon, rego bool) (resolved, error)
 
 type resourceCheck struct {
 	ruleID   string
@@ -142,7 +142,7 @@ func (c *resourceCheck) check(env env.Env) []*compliance.Report {
 	ctx, cancel := context.WithTimeout(context.Background(), defaultTimeout)
 	defer cancel()
 
-	resolved, err := c.resolve(ctx, env, c.ruleID, c.resource.ResourceCommon)
+	resolved, err := c.resolve(ctx, env, c.ruleID, c.resource.ResourceCommon, false)
 	if err != nil {
 		return []*compliance.Report{compliance.BuildReportForError(err)}
 	}

--- a/pkg/compliance/checks/resource_check_test.go
+++ b/pkg/compliance/checks/resource_check_test.go
@@ -254,7 +254,7 @@ func TestResourceCheck(t *testing.T) {
 				}
 			}
 
-			resolve := func(_ context.Context, _ env.Env, _ string, _ compliance.ResourceCommon) (resolved, error) {
+			resolve := func(_ context.Context, _ env.Env, _ string, _ compliance.ResourceCommon, rego bool) (resolved, error) {
 				return test.resourceResolved, nil
 			}
 


### PR DESCRIPTION
### What does this PR do?

This PR improves consistency between process and file check, on the len = 0 case, when called from rego.
What is wanted is that:
- if there is an error, there is no tagged entry in the rego input (and the creation of error finding is done by the rego code)
- if the result is empty, based on the type selected for the input:
  - if `type: array` then we simply don't push anything
  - if `type: object` then we set it to `{}`

### Motivation

Ease the writing of rego rules.

### Describe how to test/QA your changes

Write rules with the specific where the specific cases are triggered

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
