### PR TITLE
[networks] Enable user-defined rules for processing HTTP paths

### DIFF
--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -1,8 +1,11 @@
 package config
 
 import (
+	"encoding/json"
 	"strings"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
@@ -120,6 +123,15 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnv(join(netNS, "enable_http_monitoring"), "DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTP_MONITORING")
 	cfg.BindEnv(join(netNS, "enable_https_monitoring"), "DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTPS_MONITORING")
 	cfg.BindEnvAndSetDefault(join(netNS, "enable_gateway_lookup"), true, "DD_SYSTEM_PROBE_NETWORK_ENABLE_GATEWAY_LOOKUP")
+	httpRules := join(netNS, "http_replace_rules")
+	cfg.BindEnv(httpRules, "DD_SYSTEM_PROBE_NETWORK_HTTP_REPLACE_RULES")
+	cfg.SetEnvKeyTransformer(httpRules, func(in string) interface{} {
+		var out []map[string]string
+		if err := json.Unmarshal([]byte(in), &out); err != nil {
+			log.Warnf(`%q can not be parsed: %v`, httpRules, err)
+		}
+		return out
+	})
 
 	// list of DNS query types to be recorded
 	cfg.BindEnvAndSetDefault(join(netNS, "dns_recorded_query_types"), []string{})

--- a/pkg/network/config/config.go
+++ b/pkg/network/config/config.go
@@ -153,6 +153,9 @@ type Config struct {
 
 	// RecordedQueryTypes enables specific DNS query types to be recorded
 	RecordedQueryTypes []string
+
+	// HTTP replace rules
+	HTTPReplaceRules []*ReplaceRule
 }
 
 func join(pieces ...string) string {
@@ -213,6 +216,14 @@ func New() *Config {
 		DriverBufferSize:     cfg.GetInt(join(spNS, "windows.driver_buffer_size")),
 
 		RecordedQueryTypes: cfg.GetStringSlice(join(netNS, "dns_recorded_query_types")),
+	}
+
+	httpRRKey := join(netNS, "http_replace_rules")
+	rr, err := parseReplaceRules(cfg, httpRRKey)
+	if err != nil {
+		log.Errorf("error parsing %q: %v", httpRRKey, err)
+	} else {
+		c.HTTPReplaceRules = rr
 	}
 
 	if c.OffsetGuessThreshold > maxOffsetThreshold {

--- a/pkg/network/config/replace_rules.go
+++ b/pkg/network/config/replace_rules.go
@@ -1,0 +1,46 @@
+package config
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+)
+
+// ReplaceRule specifies a replace rule.
+type ReplaceRule struct {
+	// Pattern specifies the regexp pattern to be used when replacing. It must compile.
+	Pattern string `mapstructure:"pattern"`
+
+	// Re holds the compiled Pattern and is only used internally.
+	Re *regexp.Regexp `mapstructure:"-"`
+
+	// Repl specifies the replacement string to be used when Pattern matches.
+	Repl string `mapstructure:"repl"`
+}
+
+func parseReplaceRules(cfg ddconfig.Config, key string) ([]*ReplaceRule, error) {
+	if !config.Datadog.IsSet(key) {
+		return nil, nil
+	}
+
+	rules := make([]*ReplaceRule, 0)
+	if err := cfg.UnmarshalKey(key, &rules); err != nil {
+		return nil, fmt.Errorf("rules format should be of the form '[{\"pattern\":\"pattern\",\"repl\":\"replace_str\"}]', error: %w", err)
+	}
+
+	for _, r := range rules {
+		if r.Pattern == "" {
+			return nil, errors.New(`all rules must have a "pattern"`)
+		}
+		re, err := regexp.Compile(r.Pattern)
+		if err != nil {
+			return nil, fmt.Errorf("failed to compile %q: %s", r.Pattern, err)
+		}
+		r.Re = re
+	}
+
+	return rules, nil
+}

--- a/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-HTTPReplaceRules.yaml
+++ b/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-HTTPReplaceRules.yaml
@@ -1,0 +1,7 @@
+network_config:
+  http_replace_rules:
+    - pattern: "/users/(.*)"
+      repl: "/users/?"
+    - pattern: "foo"
+      repl: "bar"
+    - pattern: "payment_id"

--- a/pkg/network/http/http_statkeeper.go
+++ b/pkg/network/http/http_statkeeper.go
@@ -143,9 +143,7 @@ func (h *httpStatKeeper) processHTTPPath(tx httpTX) (pathStr string, rejected bo
 				return "", true
 			}
 
-			// TODO: consider removing the `break` statement here so rules can be "chained"
 			path = r.Re.ReplaceAll(path, []byte(r.Repl))
-			break
 		}
 	}
 

--- a/pkg/network/http/http_statkeeper.go
+++ b/pkg/network/http/http_statkeeper.go
@@ -61,7 +61,7 @@ func (h *httpStatKeeper) GetAndResetAllStats() map[Key]RequestStats {
 func (h *httpStatKeeper) add(tx httpTX) {
 	path, rejected := h.processHTTPPath(tx)
 	if rejected {
-		atomic.AddInt64(&h.telemetry.dropped, 1)
+		atomic.AddInt64(&h.telemetry.rejected, 1)
 		return
 	}
 

--- a/pkg/network/http/http_statkeeper.go
+++ b/pkg/network/http/http_statkeeper.go
@@ -2,13 +2,20 @@
 
 package http
 
-import "sync/atomic"
+import (
+	"sync/atomic"
+
+	"github.com/DataDog/datadog-agent/pkg/network/config"
+)
 
 type httpStatKeeper struct {
 	stats      map[Key]RequestStats
 	incomplete map[Key]httpTX
 	maxEntries int
 	telemetry  *telemetry
+
+	// replace rules for HTTP path
+	replaceRules []*config.ReplaceRule
 
 	// http path buffer
 	buffer []byte
@@ -18,14 +25,15 @@ type httpStatKeeper struct {
 	interned map[string]string
 }
 
-func newHTTPStatkeeper(maxEntries int, telemetry *telemetry) *httpStatKeeper {
+func newHTTPStatkeeper(c *config.Config, telemetry *telemetry) *httpStatKeeper {
 	return &httpStatKeeper{
-		stats:      make(map[Key]RequestStats),
-		incomplete: make(map[Key]httpTX),
-		maxEntries: maxEntries,
-		buffer:     make([]byte, HTTPBufferSize),
-		interned:   make(map[string]string),
-		telemetry:  telemetry,
+		stats:        make(map[Key]RequestStats),
+		incomplete:   make(map[Key]httpTX),
+		maxEntries:   c.MaxHTTPStatsBuffered,
+		replaceRules: c.HTTPReplaceRules,
+		buffer:       make([]byte, HTTPBufferSize),
+		interned:     make(map[string]string),
+		telemetry:    telemetry,
 	}
 }
 
@@ -51,7 +59,13 @@ func (h *httpStatKeeper) GetAndResetAllStats() map[Key]RequestStats {
 }
 
 func (h *httpStatKeeper) add(tx httpTX) {
-	key := h.newKey(tx)
+	path, rejected := h.processHTTPPath(tx)
+	if rejected {
+		atomic.AddInt64(&h.telemetry.dropped, 1)
+		return
+	}
+
+	key := h.newKey(tx, path)
 	stats, ok := h.stats[key]
 	if !ok && len(h.stats) >= h.maxEntries {
 		atomic.AddInt64(&h.telemetry.dropped, 1)
@@ -106,10 +120,7 @@ func (h *httpStatKeeper) handleIncomplete(tx httpTX) {
 	delete(h.incomplete, key)
 }
 
-func (h *httpStatKeeper) newKey(tx httpTX) Key {
-	path := tx.Path(h.buffer)
-	pathString := h.intern(path)
-
+func (h *httpStatKeeper) newKey(tx httpTX, path string) Key {
 	return Key{
 		SrcIPHigh: uint64(tx.tup.saddr_h),
 		SrcIPLow:  uint64(tx.tup.saddr_l),
@@ -117,9 +128,28 @@ func (h *httpStatKeeper) newKey(tx httpTX) Key {
 		DstIPHigh: uint64(tx.tup.daddr_h),
 		DstIPLow:  uint64(tx.tup.daddr_l),
 		DstPort:   uint16(tx.tup.dport),
-		Path:      pathString,
+		Path:      path,
 		Method:    Method(tx.request_method),
 	}
+}
+
+func (h *httpStatKeeper) processHTTPPath(tx httpTX) (pathStr string, rejected bool) {
+	path := tx.Path(h.buffer)
+
+	for _, r := range h.replaceRules {
+		if r.Re.Match(path) {
+			if r.Repl == "" {
+				// this is a "drop" rule
+				return "", true
+			}
+
+			// TODO: consider removing the `break` statement here so rules can be "chained"
+			path = r.Re.ReplaceAll(path, []byte(r.Repl))
+			break
+		}
+	}
+
+	return h.intern(path), false
 }
 
 func (h *httpStatKeeper) intern(b []byte) string {

--- a/pkg/network/http/http_statkeeper_test.go
+++ b/pkg/network/http/http_statkeeper_test.go
@@ -5,16 +5,20 @@ package http
 import (
 	"encoding/binary"
 	"fmt"
+	"regexp"
 	"strconv"
 	"testing"
 	"time"
 
+	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestProcessHTTPTransactions(t *testing.T) {
-	sk := newHTTPStatkeeper(1000, newTelemetry())
+	cfg := &config.Config{MaxHTTPStatsBuffered: 1000}
+	sk := newHTTPStatkeeper(cfg, newTelemetry())
 	txs := make([]httpTX, 100)
 
 	sourceIP := util.AddressFromString("1.1.1.1")
@@ -74,7 +78,8 @@ func generateIPv4HTTPTransaction(source util.Address, dest util.Address, sourceP
 }
 
 func BenchmarkProcessSameConn(b *testing.B) {
-	sk := newHTTPStatkeeper(1000, newTelemetry())
+	cfg := &config.Config{MaxHTTPStatsBuffered: 1000}
+	sk := newHTTPStatkeeper(cfg, newTelemetry())
 	tx := generateIPv4HTTPTransaction(
 		util.AddressFromString("1.1.1.1"),
 		util.AddressFromString("2.2.2.2"),
@@ -91,4 +96,70 @@ func BenchmarkProcessSameConn(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		sk.Process(transactions)
 	}
+}
+
+func TestPathProcessing(t *testing.T) {
+	var (
+		sourceIP   = util.AddressFromString("1.1.1.1")
+		sourcePort = 1234
+		destIP     = util.AddressFromString("2.2.2.2")
+		destPort   = 8080
+		statusCode = 200
+		latency    = time.Second
+	)
+
+	setupStatKeeper := func(rules []*config.ReplaceRule) *httpStatKeeper {
+		c := &config.Config{
+			MaxHTTPStatsBuffered: 1000,
+			HTTPReplaceRules:     rules,
+		}
+
+		return newHTTPStatkeeper(c, newTelemetry())
+	}
+
+	t.Run("reject rule", func(t *testing.T) {
+		rules := []*config.ReplaceRule{
+			{
+				Re: regexp.MustCompile("payment"),
+			},
+		}
+
+		sk := setupStatKeeper(rules)
+		transactions := []httpTX{
+			generateIPv4HTTPTransaction(sourceIP, destIP, sourcePort, destPort, "/foobar", statusCode, latency),
+			generateIPv4HTTPTransaction(sourceIP, destIP, sourcePort, destPort, "/payment/123", statusCode, latency),
+		}
+		sk.Process(transactions)
+		stats := sk.GetAndResetAllStats()
+
+		require.Len(t, stats, 1)
+		for key := range stats {
+			assert.Equal(t, "/foobar", key.Path)
+		}
+	})
+
+	t.Run("replace rule", func(t *testing.T) {
+		rules := []*config.ReplaceRule{
+			{
+				Re:   regexp.MustCompile("/users/.*"),
+				Repl: "/users/?",
+			},
+		}
+
+		sk := setupStatKeeper(rules)
+		transactions := []httpTX{
+			generateIPv4HTTPTransaction(sourceIP, destIP, sourcePort, destPort, "/prefix/users/1", statusCode, latency),
+			generateIPv4HTTPTransaction(sourceIP, destIP, sourcePort, destPort, "/prefix/users/2", statusCode, latency),
+			generateIPv4HTTPTransaction(sourceIP, destIP, sourcePort, destPort, "/prefix/users/3", statusCode, latency),
+		}
+		sk.Process(transactions)
+		stats := sk.GetAndResetAllStats()
+
+		require.Len(t, stats, 1)
+		for key, metrics := range stats {
+			assert.Equal(t, "/prefix/users/?", key.Path)
+			assert.Equal(t, 3, metrics[statusCode/100-1].Count)
+		}
+	})
+
 }

--- a/pkg/network/http/monitor.go
+++ b/pkg/network/http/monitor.go
@@ -72,7 +72,7 @@ func NewMonitor(c *config.Config, offsets []manager.ConstantEditor, sockFD *ebpf
 	numCPUs := int(notificationMap.ABI().MaxEntries)
 
 	telemetry := newTelemetry()
-	statkeeper := newHTTPStatkeeper(c.MaxHTTPStatsBuffered, telemetry)
+	statkeeper := newHTTPStatkeeper(c, telemetry)
 
 	handler := func(transactions []httpTX) {
 		if statkeeper != nil {

--- a/pkg/network/http/telemetry.go
+++ b/pkg/network/http/telemetry.go
@@ -16,6 +16,7 @@ type telemetry struct {
 	hits         [5]int64
 	misses       int64 // this happens when we can't cope with the rate of events
 	dropped      int64 // this happens when httpStatKeeper reaches capacity
+	rejected     int64 // this happens when an user-defined reject-filter matches a request
 	aggregations int64
 }
 
@@ -44,6 +45,7 @@ func (t *telemetry) reset() telemetry {
 	delta := telemetry{
 		misses:       atomic.SwapInt64(&t.misses, 0),
 		dropped:      atomic.SwapInt64(&t.dropped, 0),
+		rejected:     atomic.SwapInt64(&t.rejected, 0),
 		aggregations: atomic.SwapInt64(&t.aggregations, 0),
 		elapsed:      now.Unix() - then,
 	}
@@ -62,12 +64,14 @@ func (t *telemetry) report() {
 	}
 
 	log.Debugf(
-		"http stats summary: requests_processed=%d(%.2f/s) requests_missed=%d(%.2f/s) requests_dropped=%d(%.2f/s) aggregations=%d",
+		"http stats summary: requests_processed=%d(%.2f/s) requests_missed=%d(%.2f/s) requests_dropped=%d(%.2f/s) requests_rejected=%d(%.2f/s) aggregations=%d",
 		totalRequests,
 		float64(totalRequests)/float64(t.elapsed),
 		t.misses,
 		float64(t.misses)/float64(t.elapsed),
 		t.dropped,
+		float64(t.rejected)/float64(t.elapsed),
+		t.rejected,
 		float64(t.dropped)/float64(t.elapsed),
 		t.aggregations,
 	)


### PR DESCRIPTION
### What does this PR do?

Allow HTTP pathnames to be processed using user-defined rules. The rules are defined in a similar fashion as the ones used by APM: https://docs.datadoghq.com/tracing/setup_overview/configure_data_security/#replace-rules-for-tag-filtering

Rules can be either used to drop requests (by omitting the `repl` field) or "replace" path names.

#### YAML Example

```
network_config:
  http_replace_rules:
    - pattern: "/users/.*"
      repl: "/users/?"
    - pattern: "foo"
      repl: "bar"
    - pattern: "payment_id"
```

#### ENV var example

```
DD_SYSTEM_PROBE_NETWORK_HTTP_REPLACE_RULES='[{ "pattern": "/users/(.*)","repl": "/users/?" },{ "pattern": "foo","repl": "bar" },{ "pattern": "payment_id" }]'
```

### Describe how to test/QA your changes

1. Start system-probe with the following configuration:

```
system_probe_config:
  log_level: debug
network_config:
  enabled: true
  enable_http_monitoring: true
  http_replace_rules:
    - pattern: "foo"
      repl: "bar"
    - pattern: "drop-me"
```

2. Do the following request: `curl http://httpbin.org/anything/foo`
3. Verify you see `/anything/bar` in the HTTP debug information:
```
curl -s --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/debug/http_monitoring | jq
```
(please note your unix-socket path may be different)

Now let's test the `drop-me` rule.
1. Issue the following request: `curl http://httpbin.org/anything/drop-me`
2. Retrieve the HTTP debug information via
```
curl -s --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/debug/http_monitoring | jq
```
You should *not* see a request for `/anything/drop-me` and system-probe should log a `rejected` count of 1:
```
DEBUG | (pkg/network/http/telemetry.go:66 in report) | http stats summary: requests_processed=1(0.05/s) requests_missed=0(0.00/s) requests_dropped=0(0.05/s) requests_rejected=1(0.00/s) aggregations=0
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
