### PR TITLE
[CSPM] fix dump rego input feature when the dump file is present but empty

### DIFF
--- a/pkg/compliance/checks/rego_check.go
+++ b/pkg/compliance/checks/rego_check.go
@@ -355,8 +355,10 @@ func dumpInputToFile(ruleID, path string, input interface{}) error {
 	currentData := make(map[string]interface{})
 	currentContent, err := ioutil.ReadFile(path)
 	if err == nil {
-		if err := json.Unmarshal(currentContent, &currentData); err != nil {
-			return err
+		if len(currentContent) != 0 {
+			if err := json.Unmarshal(currentContent, &currentData); err != nil {
+				return err
+			}
 		}
 	}
 


### PR DESCRIPTION
### What does this PR do?

This PR fixes a bug when dumping rego input to a present but empty file.

### Motivation

Fix bugs

### Possible Drawbacks / Trade-offs

No drawbacks.

### Describe how to test/QA your changes

Try the problematic case

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
