### PR TITLE
[serverless] Do not send platform log messages without stringRecord to intake

### DIFF
--- a/pkg/serverless/logs/logs.go
+++ b/pkg/serverless/logs/logs.go
@@ -284,7 +284,7 @@ func processLogMessages(c *CollectionRouteInfo, messages []logMessage) {
 		// However, if logs are not enabled, we do not send them to the intake.
 		if c.LogsEnabled {
 			// Do not send messages without a stringRecord to the intake
-			if message.stringRecord == "" {
+			if message.stringRecord == "" && message.logType != logTypeFunction {
 				continue
 			}
 			logMessage := logConfig.NewChannelMessageFromLambda([]byte(message.stringRecord), message.time, c.ExecutionContext.ARN, c.ExecutionContext.LastRequestID)

--- a/pkg/serverless/logs/logs.go
+++ b/pkg/serverless/logs/logs.go
@@ -283,7 +283,7 @@ func processLogMessages(c *CollectionRouteInfo, messages []logMessage) {
 		// We always collect and process logs for the purpose of extracting enhanced metrics.
 		// However, if logs are not enabled, we do not send them to the intake.
 		if c.LogsEnabled {
-			// Do not send messages without a stringRecord to the intake
+			// Do not send platform log messages without a stringRecord to the intake
 			if message.stringRecord == "" && message.logType != logTypeFunction {
 				continue
 			}

--- a/pkg/serverless/logs/logs.go
+++ b/pkg/serverless/logs/logs.go
@@ -104,7 +104,8 @@ const (
 type logMessage struct {
 	time    time.Time
 	logType string
-	// "extension" / "function" log messages contain a record which is basically a log string
+	// stringRecord is a string representation of the message's contents. It can be either received directly
+	// from the logs API or added by the extension after receiving it.
 	stringRecord string
 	objectRecord platformObjectRecord
 }
@@ -282,6 +283,10 @@ func processLogMessages(c *CollectionRouteInfo, messages []logMessage) {
 		// We always collect and process logs for the purpose of extracting enhanced metrics.
 		// However, if logs are not enabled, we do not send them to the intake.
 		if c.LogsEnabled {
+			// Do not send messages without a stringRecord to the intake
+			if message.stringRecord == "" {
+				continue
+			}
 			logMessage := logConfig.NewChannelMessageFromLambda([]byte(message.stringRecord), message.time, c.ExecutionContext.ARN, c.ExecutionContext.LastRequestID)
 			c.LogChannel <- logMessage
 		}

--- a/pkg/serverless/logs/logs_test.go
+++ b/pkg/serverless/logs/logs_test.go
@@ -350,7 +350,7 @@ func TestProcessLogMessageLogsEnabled(t *testing.T) {
 	}
 }
 
-func TestProcessLogMessageNoStringRecord(t *testing.T) {
+func TestProcessLogMessageNoStringRecordPlatformLog(t *testing.T) {
 
 	logChannel := make(chan *config.ChannelMessage)
 
@@ -378,6 +378,39 @@ func TestProcessLogMessageNoStringRecord(t *testing.T) {
 		assert.Fail(t, "We should not have received logs")
 	case <-time.After(100 * time.Millisecond):
 		// nothing to do here
+	}
+}
+
+func TestProcessLogMessageNoStringRecordFunctionLog(t *testing.T) {
+
+	logChannel := make(chan *config.ChannelMessage)
+
+	logCollection := &CollectionRouteInfo{
+		ExecutionContext: &ExecutionContext{
+			ARN:           "myARN",
+			LastRequestID: "myRequestID",
+		},
+		LogsEnabled: true,
+		LogChannel:  logChannel,
+		ExtraTags: &Tags{
+			Tags: []string{"tag0:value0,tag1:value1"},
+		},
+	}
+
+	logMessages := []logMessage{
+		{
+			logType: logTypeFunction,
+		},
+	}
+	go processLogMessages(logCollection, logMessages)
+
+	select {
+	case received := <-logChannel:
+		assert.NotNil(t, received)
+		assert.Equal(t, "myARN", received.Lambda.ARN)
+		assert.Equal(t, "myRequestID", received.Lambda.RequestID)
+	case <-time.After(100 * time.Millisecond):
+		assert.Fail(t, "We should have received logs")
 	}
 }
 

--- a/pkg/serverless/logs/logs_test.go
+++ b/pkg/serverless/logs/logs_test.go
@@ -350,6 +350,37 @@ func TestProcessLogMessageLogsEnabled(t *testing.T) {
 	}
 }
 
+func TestProcessLogMessageNoStringRecord(t *testing.T) {
+
+	logChannel := make(chan *config.ChannelMessage)
+
+	logCollection := &CollectionRouteInfo{
+		ExecutionContext: &ExecutionContext{
+			ARN:           "myARN",
+			LastRequestID: "myRequestID",
+		},
+		LogsEnabled: true,
+		LogChannel:  logChannel,
+		ExtraTags: &Tags{
+			Tags: []string{"tag0:value0,tag1:value1"},
+		},
+	}
+
+	logMessages := []logMessage{
+		{
+			logType: logTypePlatformRuntimeDone,
+		},
+	}
+	go processLogMessages(logCollection, logMessages)
+
+	select {
+	case <-logChannel:
+		assert.Fail(t, "We should not have received logs")
+	case <-time.After(100 * time.Millisecond):
+		// nothing to do here
+	}
+}
+
 func TestProcessLogMessageLogsNotEnabled(t *testing.T) {
 
 	logChannel := make(chan *config.ChannelMessage)


### PR DESCRIPTION
### What does this PR do?

The Lambda Extension receives platform log messages from the AWS API with types like `platform.start` and `platform.runtimeDone`.

For some of these messages (like `platform.start`), we create a string representation and add it to the log message. This is the message that is sent to the Datadog intake.

For other types of messages (notably `platform.runtimeDone`) we don't create a string representation. However, we currently still do send these messages to the Datadog intake. This results in extraneous empty log messages in Datadog.

This PR drops empty log messages, unless they come from the runtime itself, in which case we assume they are intentional and let them through.

### Describe how to test/QA your changes

I added unit test coverage and will test this in the self-monitoring app as well.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
