### PR TITLE
Make SLES11 deprecation note more explicit

### DIFF
--- a/releasenotes/notes/build-on-opensuse-42-ef3db38a090254d0.yaml
+++ b/releasenotes/notes/build-on-opensuse-42-ef3db38a090254d0.yaml
@@ -8,5 +8,5 @@
 ---
 upgrade:
   - |
-    SUSE RPMs are now built on OpenSUSE 42.1. Newly built SUSE RPMs are supported
-    on OpenSUSE >= 15 (including OpenSUSE >= 42) and SLES >= 12.
+    Starting from this version of the Agent, the Agent does not run on SLES 11. 
+    The new minimum requirement is SLES >= 12 or OpenSUSE >= 15 (including OpenSUSE 42).


### PR DESCRIPTION
### What does this PR do?

Reword release note about  SLES11 deprecation.

### Motivation

We want the first thing in the note to say the Agent won't run on SUSE11.
