### PR TITLE
Add PROCESS_DISCOVERY_ENABLED for msiexec

### DIFF
--- a/omnibus/resources/agent/msi/source.wxs.erb
+++ b/omnibus/resources/agent/msi/source.wxs.erb
@@ -372,7 +372,7 @@
             Source="$(var.EtcFiles)\system-probe.yaml.example"/>
         </Component>
       <?endif ?>
-      
+
 
       <Directory Id="checks.d" Name="checks.d">
         <Component Id="checks.d"
@@ -451,11 +451,11 @@
     </InstallExecuteSequence>
 
     <!-- Set the components defined in our fragment files that will be used for our feature  -->
-    <Feature 
-      Id="MainApplication" 
-      Title="Datadog Agent" 
+    <Feature
+      Id="MainApplication"
+      Title="Datadog Agent"
       Level="1"
-      Absent="disallow" 
+      Absent="disallow"
       ConfigurableDirectory="APPLICATIONROOTDIRECTORY">
         <ComponentRef Id="conffolder" />
         <ComponentGroupRef Id="ProjectDir" />
@@ -485,9 +485,9 @@
       <?if $(var.IncludeSysprobe) = true ?>
         <!-- don't install by default (indicated by level 100)  Only things with level
         <= INSTALLLEVEL (1 by default) will be installed.  Can be changed via gui or command line params to optionally install -->
-        <Feature  Id="NPM" 
-                  Level="100"  
-                  Title="Network Performance Monitoring" 
+        <Feature  Id="NPM"
+                  Level="100"
+                  Title="Network Performance Monitoring"
                   ConfigurableDirectory="APPLICATIONROOTDIRECTORY"
                   Absent="allow"
                   AllowAdvertise="no"
@@ -497,7 +497,7 @@
         </Feature>
       <?endif ?>
     </Feature>
-  
+
     <!-- UI Stuff: 100% Omnibus Generated -->
     <Icon Id="project.ico" SourceFile="Resources\assets\project_16x16.ico"/>
     <Property Id="ARPPRODUCTICON" Value="project.ico" />
@@ -563,7 +563,7 @@
 
            -->
       <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="LicenseAgreementDlg">NOT PREVIOUSFOUND</Publish>
-      
+
 
       <?if $(var.IncludeSysprobe) = true ?>
         <Publish Dialog="WelcomeDlg" Control="Next" Event="NewDialog" Value="CustomizeDlg">PREVIOUSFOUND</Publish>
@@ -597,13 +597,13 @@
       <Publish Dialog="ExitDialog" Control="Finish" Event="EndDialog" Value="Return" Order="3">1</Publish>
       <Publish Dialog="SiteDlg" Control="Back" Event="NewDialog" Value="ApiKeyDlg">NOT PREVIOUSFOUND</Publish>
       <Publish Dialog="VerifyReadyDlg" Control="Back" Event="NewDialog" Value="SiteDlg">NOT PREVIOUSFOUND</Publish>
-      
+
 
       <Publish Dialog="MaintenanceWelcomeDlg" Control="Next" Event="NewDialog" Value="MaintenanceTypeDlg">1</Publish>
 
       <Publish Dialog="MaintenanceTypeDlg" Control="Back" Event="NewDialog" Value="MaintenanceWelcomeDlg">1</Publish>
 
-      
+
 
 
       <Publish Dialog="MaintenanceTypeDlg" Control="RepairButton" Event="NewDialog" Value="ApiKeyDlg">NOT APIKEY</Publish>
@@ -672,6 +672,7 @@
             LOGS_ENABLED=[LOGS_ENABLED]
             APM_ENABLED=[APM_ENABLED]
             PROCESS_ENABLED=[PROCESS_ENABLED]
+            PROCESS_DISCOVERY_ENABLED=[PROCESS_DISCOVERY_ENABLED]
             CMD_PORT=[CMD_PORT]
             SITE=[SITE]
             DD_URL=[DD_URL]
@@ -717,7 +718,7 @@
 
   </Product>
 </Wix>
-<!-- check 
+<!-- check
 HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\ddnpm
 
 -->

--- a/omnibus/resources/iot/msi/source.wxs.erb
+++ b/omnibus/resources/iot/msi/source.wxs.erb
@@ -188,6 +188,10 @@
                          Type="string"
                          Value="[PROCESS_ENABLED]">
                          </RegistryValue>
+          <RegistryValue Name="process_discovery_enabled"
+                         Type="string"
+                         Value="[PROCESS_DISCOVERY_ENABLED]">
+                         </RegistryValue>
           <RegistryValue Name="cmd_port"
                          Type="string"
                          Value="[CMD_PORT]" />
@@ -229,8 +233,8 @@
                 KeyPath="yes"
                 DiskId="1"
                 Source="$(var.BinFiles)/agent.exe"/>
-          
-          
+
+
           <!-- The "Name" field must match the argument to eventlog.Open() -->
           <util:EventSource Log="Application" Name="DatadogAgent"
                 EventMessageFile="[DIST]agent.exe"
@@ -241,8 +245,8 @@
 
 
         </Component>
-        
-        
+
+
         <Directory Id="AGENT" Name="agent">
           <?if $(var.Platform) = x64 ?>
             <!-- Windows service declaration for APM agent -->
@@ -354,12 +358,12 @@
                 <Permission User="[WIX_ACCOUNT_LOCALSYSTEM]" GenericAll="yes" ChangePermission="yes"/>
                 <Permission User="[WIX_ACCOUNT_USERS]" GenericAll="no" ChangePermission="yes"/>
             </CreateFolder>
-     
+
         </Component>
       </Directory>
     </DirectoryRef>
 
-    
+
     <InstallExecuteSequence>
       <Custom Action='WixCloseApplications' Before='RemoveFiles'> </Custom>
 
@@ -369,17 +373,17 @@
       <Custom Action='StopDDServices' After='StopServices'> </Custom>
 
       <!-- only run the FinalizeInstall action on INSTALL (for now) Note this
-           is from the perspective of the installer being run; on upgrade the 
-           installer is called twice; the existing (previously installed) 
-           installer is called with _UPGRADE, and then the new installer  
+           is from the perspective of the installer being run; on upgrade the
+           installer is called twice; the existing (previously installed)
+           installer is called with _UPGRADE, and then the new installer
            is called with _INSTALL -->
       <Custom Action='SetFinalizeProperty' Before='FinalizeInstall'> <![CDATA[Installed="" ]]> </Custom>
       <Custom Action='FinalizeInstall' After='InstallServices'>      <![CDATA[Installed="" ]]> </Custom>
 
       <!-- Same deal here -->
       <Custom Action='StartDDServices' After='FinalizeInstall'>  <![CDATA[REMOVE<>"ALL" ]]></Custom>
-      
-      <!-- only do the uninstall (which removes the user state and file perms) 
+
+      <!-- only do the uninstall (which removes the user state and file perms)
            on a full uninstall -->
       <Custom Action='SetUninstallProperty' Before='DoUninstall'> <![CDATA[REMOVE="ALL" AND UPGRADINGPRODUCTCODE=""]]> </Custom>
       <Custom Action='DoUninstall' Before='RemoveRegistryValues'>      <![CDATA[REMOVE="ALL" AND UPGRADINGPRODUCTCODE=""]]> </Custom>
@@ -516,15 +520,15 @@
     <WixVariable Id="WixUIDialogBmp" Value="Resources\assets\dialog_background.bmp" />
     <WixVariable Id="WixUIBannerBmp" Value="Resources\assets\banner_background.bmp" />
 
-    <CustomAction Id='SetFinalizeProperty' Return='check' Property='FinalizeInstall' 
+    <CustomAction Id='SetFinalizeProperty' Return='check' Property='FinalizeInstall'
         Value='PROJECTLOCATION=[PROJECTLOCATION];APPLICATIONDATADIRECTORY=[APPLICATIONDATADIRECTORY];DDAGENTUSER_NAME=[DDAGENTUSER_NAME];DDAGENTUSER_PASSWORD=[DDAGENTUSER_PASSWORD];' />
     <CustomAction Id='FinalizeInstall' BinaryKey='wixcadll' DllEntry='FinalizeInstall' Execute='deferred' Return='check' Impersonate='no'/>
     <CustomAction Id='StopDDServices' BinaryKey='wixcadll' DllEntry='PreStopServices' Execute='deferred' Return='check' Impersonate='no'/>
     <CustomAction Id='StartDDServices' BinaryKey='wixcadll' DllEntry='PostStartServices' Execute='deferred' Return='check' Impersonate='no'/>
 
-    <CustomAction Id='SetUninstallProperty' Return='check' Property='DoUninstall' 
+    <CustomAction Id='SetUninstallProperty' Return='check' Property='DoUninstall'
         Value='PROJECTLOCATION=[PROJECTLOCATION];DDAGENTUSER_NAME=[DDAGENTUSER_NAME];DDAGENTUSER_PASSWORD=[DDAGENTUSER_PASSWORD];' />
-    
+
     <CustomAction Id='DoUninstall' BinaryKey='wixcadll' DllEntry='DoUninstall' Execute='deferred' Return='check' Impersonate='no'/>
 
     <CustomAction Id='DoRollback' BinaryKey='wixcadll' DllEntry='DoRollback' Execute='rollback' Impersonate='no' />
@@ -537,12 +541,12 @@
     <CustomAction Id='verifyregperms' BinaryKey='wixcadll' DllEntry='VerifyDatadogRegistryPerms' Execute='immediate' Return='check'/>
     <CustomAction Id='InstallationRollback' BinaryKey='wixcadll' DllEntry='RollbackInstallation' Execute='rollback' />
     -->
-    <!-- the following custom action is a testing custom action.  Set WIXFAILWHENDEFERRED=1 on the command line, and it will FirstFailureActionType   
+    <!-- the following custom action is a testing custom action.  Set WIXFAILWHENDEFERRED=1 on the command line, and it will FirstFailureActionType
          the install at the end, to allow for testing of rollback -->
     <CustomActionRef Id="WixFailWhenDeferred" />
-  
+
     <Binary Id='wixcadll' SourceFile='$(var.BinFiles)\customaction.dll'/>
-    
+
     <Binary Id="BannerBmp" SourceFile="Resources\assets\banner_background.bmp" />
     <Binary Id="BackgroundBmp" SourceFile="Resources\assets\dialog_background.bmp" />
     <Binary Id="PrepBackgroundBmp" SourceFile="Resources\assets\dialog_background.bmp" />

--- a/releasenotes/notes/msi-process-discovery-enabled-76ceb047313a7945.yaml
+++ b/releasenotes/notes/msi-process-discovery-enabled-76ceb047313a7945.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    On Windows, allow enabling process discovery in the process agent by providing PROCESS_DISCOVERY_ENABLED=true to the msiexec command.

--- a/tools/windows/install-help/cal/PropertyReplacer.cpp
+++ b/tools/windows/install-help/cal/PropertyReplacer.cpp
@@ -156,6 +156,8 @@ std::wstring replace_yaml_properties(
          {L"LOGS_DD_URL",                       L"^[ #]*logs_dd_url:.*",                                    format_simple_value(L"  logs_dd_url: ")},
          {L"PROCESS_ENABLED",                   L"^[ #]*process_config:.*",                                 simple_replace(L"process_config:")},
          {L"PROCESS_DD_URL",                    L"^[ #]*process_config:.*",                                 format_simple_value(L"process_config:\n  process_dd_url: ")},
+         {L"PROCESS_DISCOVERY_ENABLED",         L"^[ #]*process_config:.*",                                 simple_replace(L"process_config:")},
+         {L"PROCESS_DISCOVERY_ENABLED",         L"^[ #]*process_discovery:.*",                              simple_replace(L"  process_discovery:")},
          {L"APM_ENABLED",                       L"^[ #]*apm_config:.*",                                     simple_replace(L"apm_config:")},
          {L"TRACE_DD_URL",                      L"^[ #]*apm_config:.*",                                     simple_replace(L"apm_config:")},
          {L"CMD_PORT",                          L"^[ #]*cmd_port:.*",                                       format_simple_value(L"cmd_port: ")},
@@ -168,7 +170,7 @@ std::wstring replace_yaml_properties(
     {
         auto propKey = std::get<WxsKey>(prop);
         auto propValue = propertyRetriever(propKey);
-        
+
         if (propValue)
         {
             if (!PropertyReplacer::match(input, std::get<Regex>(prop)).replace_with(std::get<Replacement>(prop)(*propValue, propertyRetriever)))
@@ -192,6 +194,21 @@ std::wstring replace_yaml_properties(
             if (failedToReplace != nullptr)
             {
                 failedToReplace->push_back(L"PROCESS_ENABLED");
+            }
+        }
+    }
+
+    auto processDiscoveryEnabledProp = propertyRetriever(L"PROCESS_DISCOVERY_ENABLED");
+    if (processDiscoveryEnabledProp)
+    {
+        if (!PropertyReplacer::match(input, L"process_config:")
+                 .then(L"^  process_discovery:.*")
+                 .then(L"^[ #]*enabled:.*")
+                 .replace_with(L"    enabled: " + *processDiscoveryEnabledProp))
+        {
+            if (failedToReplace != nullptr)
+            {
+                failedToReplace->push_back(L"PROCESS_DISCOVERY_ENABLED");
             }
         }
     }

--- a/tools/windows/install-help/cal/customaction-tests/ReplaceYamlProperties_ProcessTests.cpp
+++ b/tools/windows/install-help/cal/customaction-tests/ReplaceYamlProperties_ProcessTests.cpp
@@ -1,7 +1,7 @@
 #include "stdafx.h"
 #include "ReplaceYamlProperties.h"
 
-TEST_F(ReplaceYamlPropertiesTests, When_Apm_Enabled_Correctly_Replace)
+TEST_F(ReplaceYamlPropertiesTests, When_Process_Enabled_Correctly_Replace)
 {
     value_map values = {
         {L"PROCESS_ENABLED", L"true"},
@@ -20,7 +20,7 @@ process_config:
 )");
 }
 
-TEST_F(ReplaceYamlPropertiesTests, When_Apm_Disabled_Correctly_Replace)
+TEST_F(ReplaceYamlPropertiesTests, When_Process_Disabled_Correctly_Replace)
 {
     value_map values = {
         {L"PROCESS_ENABLED", L"false"},
@@ -60,7 +60,7 @@ process_config:
 )");
 }
 
-TEST_F(ReplaceYamlPropertiesTests, When_Process_Url_Set_And_Apm_Enabled_Correctly_Replace)
+TEST_F(ReplaceYamlPropertiesTests, When_Process_Url_Set_And_Process_Enabled_Correctly_Replace)
 {
     value_map values = {
         {L"PROCESS_DD_URL", L"https://process.someurl.datadoghq.com"},
@@ -79,5 +79,30 @@ process_config:
   process_dd_url: https://process.someurl.datadoghq.com
 
   enabled: "disabled"
+)");
+}
+
+TEST_F(ReplaceYamlPropertiesTests, When_Process_Discovery_Enabled_Correctly_Replace)
+{
+    value_map values = {
+        {L"PROCESS_DISCOVERY_ENABLED", L"true"},
+    };
+    std::wstring result = replace_yaml_properties(LR"(
+# process_config:
+
+  # enabled: "disabled"
+
+  # process_discovery:
+    # enabled: false
+)",
+                                                  propertyRetriever(values));
+
+    EXPECT_EQ(result, LR"(
+process_config:
+
+  # enabled: "disabled"
+
+  process_discovery:
+    enabled: true
 )");
 }

--- a/tools/windows/install-help/cal/customaction-tests/ReplaceYamlProperties_ProcessTests.cpp
+++ b/tools/windows/install-help/cal/customaction-tests/ReplaceYamlProperties_ProcessTests.cpp
@@ -106,3 +106,27 @@ process_config:
     enabled: true
 )");
 }
+
+TEST_F(ReplaceYamlPropertiesTests, When_Process_Url_Set_And_Process_Discovery_Enabled_Correctly_Replace)
+{
+    value_map values = {
+        {L"PROCESS_DD_URL", L"https://process.someurl.datadoghq.com"},
+        {L"PROCESS_DISCOVERY_ENABLED", L"true"},
+    };
+    std::wstring result = replace_yaml_properties(LR"(
+# process_config:
+
+  # process_discovery:
+    # enabled: false
+)",
+                                                  propertyRetriever(values));
+
+    EXPECT_EQ(result,
+              LR"(
+process_config:
+  process_dd_url: https://process.someurl.datadoghq.com
+
+  process_discovery:
+    enabled: true
+)");
+}


### PR DESCRIPTION
### What does this PR do?

Allows configuring process discovery check via a parameter to msiexec - `PROCESS_DISCOVERY_ENABLED`:
```
Start-Process -Wait msiexec -ArgumentList '/qb /l*v log.txt /i datadog-agent.msi PROCESS_DISCOVERY_ENABLED=true...'
```

### Motivation

Allow scripted configuration of `process_config.process_discovery.enabled` on Windows.

### Describe how to test/QA your changes

- Provide the `PROCESS_DISCOVERY_ENABLED=true` setting on the command line to the `msiexec`.
- Make sure that `process_config.process_discovery.enabled` is configured accordingly and the process agent service starts collecting these payloads.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
