### PR TITLE
[serverless] Add support for out-of-memory metric for .NET runtime

### DIFF
--- a/pkg/serverless/metrics/enhanced_metrics.go
+++ b/pkg/serverless/metrics/enhanced_metrics.go
@@ -43,6 +43,7 @@ func getOutOfMemorySubstrings() []string {
 		"Runtime exited with error: signal: killed", // Node
 		"MemoryError", // Python
 		"failed to allocate memory (NoMemoryError)", // Ruby
+		"OutOfMemoryException",                      // .NET
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

We generate the `aws.lambda.enhanced.out_of_memory` metric by scanning logs for specific strings. This PR adds the string that appears when the .NET runtime runs out of memory to the list of strings that we look for.

### Motivation

We want to be able to generate enhanced metrics for functions using the .NET runtime.

### Reviewer's Checklist
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
