### PR TITLE
Improve status reporting of system-probe

### DIFF
--- a/cmd/system-probe/modules/oom_kill_probe.go
+++ b/cmd/system-probe/modules/oom_kill_probe.go
@@ -5,6 +5,7 @@ package modules
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api/module"
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
@@ -23,7 +24,7 @@ var OOMKillProbe = module.Factory{
 		if err != nil {
 			return nil, fmt.Errorf("unable to start the OOM kill probe: %w", err)
 		}
-		return &oomKillModule{okp}, nil
+		return &oomKillModule{OOMKillProbe: okp}, nil
 	},
 }
 
@@ -31,10 +32,12 @@ var _ module.Module = &oomKillModule{}
 
 type oomKillModule struct {
 	*probe.OOMKillProbe
+	lastCheck time.Time
 }
 
 func (o *oomKillModule) Register(httpMux *module.Router) error {
 	httpMux.HandleFunc("/check/oom_kill", func(w http.ResponseWriter, req *http.Request) {
+		o.lastCheck = time.Now()
 		stats := o.OOMKillProbe.GetAndFlush()
 		utils.WriteAsJSON(w, stats)
 	})
@@ -43,5 +46,7 @@ func (o *oomKillModule) Register(httpMux *module.Router) error {
 }
 
 func (o *oomKillModule) GetStats() map[string]interface{} {
-	return nil
+	return map[string]interface{}{
+		"last_check": o.lastCheck.Unix(),
+	}
 }

--- a/cmd/system-probe/modules/process.go
+++ b/cmd/system-probe/modules/process.go
@@ -39,11 +39,16 @@ var Process = module.Factory{
 
 var _ module.Module = &process{}
 
-type process struct{ probe procutil.Probe }
+type process struct {
+	probe     procutil.Probe
+	lastCheck time.Time
+}
 
 // GetStats returns stats for the module
 func (t *process) GetStats() map[string]interface{} {
-	return nil
+	return map[string]interface{}{
+		"last_check": t.lastCheck.Unix(),
+	}
 }
 
 // Register registers endpoints for the module to expose data
@@ -51,6 +56,7 @@ func (t *process) Register(httpMux *module.Router) error {
 	var runCounter uint64
 	httpMux.HandleFunc("/proc/stats", func(w http.ResponseWriter, req *http.Request) {
 		start := time.Now()
+		t.lastCheck = start
 		pids, err := getPids(req)
 		if err != nil {
 			log.Errorf("Unable to get PIDs from request: %s", err)

--- a/cmd/system-probe/modules/process.go
+++ b/cmd/system-probe/modules/process.go
@@ -41,13 +41,13 @@ var _ module.Module = &process{}
 
 type process struct {
 	probe     procutil.Probe
-	lastCheck time.Time
+	lastCheck int64
 }
 
 // GetStats returns stats for the module
 func (t *process) GetStats() map[string]interface{} {
 	return map[string]interface{}{
-		"last_check": t.lastCheck.Unix(),
+		"last_check": atomic.LoadInt64(&t.lastCheck),
 	}
 }
 
@@ -56,7 +56,7 @@ func (t *process) Register(httpMux *module.Router) error {
 	var runCounter uint64
 	httpMux.HandleFunc("/proc/stats", func(w http.ResponseWriter, req *http.Request) {
 		start := time.Now()
-		t.lastCheck = start
+		atomic.StoreInt64(&t.lastCheck, start.Unix())
 		pids, err := getPids(req)
 		if err != nil {
 			log.Errorf("Unable to get PIDs from request: %s", err)

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -60,7 +60,7 @@ type Tracer struct {
 	expiredTCPConns  int64
 	closedConns      int64
 	connStatsMapSize int64
-	lastCheck        time.Time
+	lastCheck        int64
 
 	activeBuffer *network.ConnectionBuffer
 	bufferLock   sync.Mutex
@@ -320,7 +320,7 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 	names := t.reverseDNS.Resolve(ips)
 	ctm := t.getConnTelemetry(len(active))
 	rctm := t.getRuntimeCompilationTelemetry()
-	t.lastCheck = time.Now()
+	atomic.StoreInt64(&t.lastCheck, time.Now().Unix())
 
 	return &network.Connections{
 		BufferedData:                delta.BufferedData,
@@ -535,7 +535,7 @@ func (t *Tracer) GetStats() (map[string]interface{}, error) {
 		"conn_valid_skipped":  skipped, // Skipped connections (e.g. Local DNS requests)
 		"expired_tcp_conns":   expiredTCP,
 		"conn_stats_map_size": connStatsMapSize,
-		"last_check":          t.lastCheck.Unix(),
+		"last_check":          atomic.LoadInt64(&t.lastCheck),
 	}
 	for k, v := range runtime.Tracer.GetTelemetry() {
 		tracerStats[k] = v

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -60,6 +60,7 @@ type Tracer struct {
 	expiredTCPConns  int64
 	closedConns      int64
 	connStatsMapSize int64
+	lastCheck        time.Time
 
 	activeBuffer *network.ConnectionBuffer
 	bufferLock   sync.Mutex
@@ -319,6 +320,7 @@ func (t *Tracer) GetActiveConnections(clientID string) (*network.Connections, er
 	names := t.reverseDNS.Resolve(ips)
 	ctm := t.getConnTelemetry(len(active))
 	rctm := t.getRuntimeCompilationTelemetry()
+	t.lastCheck = time.Now()
 
 	return &network.Connections{
 		BufferedData:                delta.BufferedData,
@@ -533,6 +535,7 @@ func (t *Tracer) GetStats() (map[string]interface{}, error) {
 		"conn_valid_skipped":  skipped, // Skipped connections (e.g. Local DNS requests)
 		"expired_tcp_conns":   expiredTCP,
 		"conn_stats_map_size": connStatsMapSize,
+		"last_check":          t.lastCheck.Unix(),
 	}
 	for k, v := range runtime.Tracer.GetTelemetry() {
 		tracerStats[k] = v

--- a/pkg/status/templates/systemprobe.tmpl
+++ b/pkg/status/templates/systemprobe.tmpl
@@ -1,27 +1,80 @@
-{{/*
-NOTE: Changes made to this template should be reflected on the following templates, if applicable:
-* cmd/agent/gui/views/templates/generalStatus.tmpl
-*/}}
 ============
 System Probe
 ============
 
 {{- if .Errors }}
-  System Probe is not running:
-
-    Errors
-    {{ printDashes "Errors" "=" }}
-    {{ .Errors }}
-
+  Status: Not running or unreachable
+  Error: {{ .Errors }}
 {{- else }}
-System Probe is running
-
+  Status: Running
+  Uptime: {{ .uptime }}
+  Last Updated: {{ formatUnixTime .updated_at }}
 {{- end }}
+{{- if .network_tracer }}
 
+  NPM
+  ===
+  {{- if .network_tracer.Error }}
+    Status: Not running
+    Error: {{ .network_tracer.Error }}
+  {{- else }}
+    Status: Running
+    {{- if .network_tracer.tracer.last_check }}
+    Last Check: {{ formatUnixTime .network_tracer.tracer.last_check }}
+    {{- end }}
+    {{- if .network_tracer.state.clients }}
+    Client Count: {{ len .network_tracer.state.clients }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- if .oom_kill_probe }}
 
-{{- if .network_tracer.state.clients }}
+  OOM Kill
+  ========
+  {{- if .oom_kill_probe.Error }}
+    Status: Not running
+    Error: {{ .oom_kill_probe.Error }}
+  {{- else }}
+    Status: Running
+    {{- if .oom_kill_probe.last_check }}
+    Last Check: {{ formatUnixTime .oom_kill_probe.last_check }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- if .tcp_queue_length_tracer }}
 
-  Connection Clients: {{ len .network_tracer.state.clients }}
+  TCP Queue Length
+  ================
+  {{- if .tcp_queue_length_tracer.Error }}
+    Status: Not running
+    Error: {{ .tcp_queue_length_tracer.Error }}
+  {{- else }}
+    Status: Running
+    {{- if .tcp_queue_length_tracer.last_check }}
+    Last Check: {{ formatUnixTime .tcp_queue_length_tracer.last_check }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- if .security_runtime }}
 
+  Runtime Security
+  ================
+  {{- if .security_runtime.Error }}
+    Status: Not running
+    Error: {{ .security_runtime.Error }}
+  {{- else }}
+    Status: Running
+  {{- end }}
+{{- end }}
+{{- if .process }}
+
+  Process
+  =======
+  {{- if .process.Error }}
+    Status: Not running
+    Error: {{ .process.Error }}
+  {{- else }}
+    Status: Running
+  {{- end }}
 {{- end }}
 


### PR DESCRIPTION
### What does this PR do?

Improves the output of `agent status` for system-probe:
- Clarifies running/not-running status of system-probe and each individual module
- Reports critical errors that prevented a module from loading
- Outputs system-probe uptime
- Outputs last check time for NPM, OOM, TCP Queue Length, and Process modules

### Motivation

Improve quality of flares and make it easier to debug system-probe problems.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

If no modules loaded successfully, then the errors will not be reported via `agent status` because system-probe will not be running.

### Describe how to test/QA your changes

Run `agent status` when system-probe and 1+ modules are enabled.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
