### PR TITLE
kubelet: HTTPS port should be type uint16

### DIFF
--- a/pkg/util/kubernetes/kubelet/kubelet_client.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_client.go
@@ -14,6 +14,7 @@ import (
 	"expvar"
 	"fmt"
 	"io/ioutil"
+	"math"
 	"net/http"
 	"os"
 	"strconv"
@@ -205,7 +206,7 @@ func getKubeletClient(ctx context.Context) (*kubeletClient, error) {
 
 	// Checking HTTPS first if port available
 	var httpsErr error
-	if kubeletHTTPSPort > 0 && kubletHTTPSPort <= math.MaxUint16 {
+	if kubeletHTTPSPort > 0 && kubeletHTTPSPort <= math.MaxUint16 {
 		httpsErr = checkKubeletConnection(ctx, "https", uint16(kubeletHTTPSPort), kubeletPathPrefix, potentialHosts, &clientConfig)
 		if httpsErr != nil {
 			log.Debug("Impossible to reach Kubelet through HTTPS")
@@ -219,7 +220,7 @@ func getKubeletClient(ctx context.Context) (*kubeletClient, error) {
 
 	// Check HTTP now if port available
 	var httpErr error
-	if kubeletHTTPPort > 0 && kubletHTTPPort <= math.MaxUint16 {
+	if kubeletHTTPPort > 0 && kubeletHTTPPort <= math.MaxUint16 {
 		httpErr = checkKubeletConnection(ctx, "http", uint16(kubeletHTTPPort), kubeletPathPrefix, potentialHosts, &clientConfig)
 		if httpErr != nil {
 			log.Debug("Impossible to reach Kubelet through HTTP")

--- a/pkg/util/kubernetes/kubelet/kubelet_client.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_client.go
@@ -181,11 +181,11 @@ func getKubeletClient(ctx context.Context) (*kubeletClient, error) {
 	if kubeletProxyEnabled {
 		// Explicitly disable HTTP to reach APIServer
 		kubeletHTTPPort = 0
-		httpsPort, err := strconv.ParseInt(os.Getenv("KUBERNETES_SERVICE_PORT"), 10, 64)
+		httpsPort, err := strconv.ParseUint(os.Getenv("KUBERNETES_SERVICE_PORT"), 10, 16)
 		if err != nil {
 			return nil, fmt.Errorf("unable to get APIServer port: %w", err)
 		}
-		kubeletHTTPSPort = int(httpsPort)
+		kubeletHTTPSPort = httpsPort
 
 		if config.Datadog.Get("kubernetes_kubelet_nodename") != "" {
 			kubeletPathPrefix = fmt.Sprintf("/api/v1/nodes/%s/proxy", kubeletNodeName)
@@ -236,7 +236,7 @@ func getKubeletClient(ctx context.Context) (*kubeletClient, error) {
 	return nil, fmt.Errorf("Invalid Kubelet configuration: both HTTPS and HTTP ports are disabled")
 }
 
-func checkKubeletConnection(ctx context.Context, scheme string, port int, prefix string, hosts *connectionInfo, clientConfig *kubeletClientConfig) error {
+func checkKubeletConnection(ctx context.Context, scheme string, port uint16, prefix string, hosts *connectionInfo, clientConfig *kubeletClientConfig) error {
 	var err error
 	var kubeClient *kubeletClient
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

limits the HTTP kublet port to uint16 (vs int)

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Limit port to available system port range

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

If port can be above 65535, then a different datatype is needed

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
