### PR TITLE
Revert "[tagger] Enable pull collection for ECS collector (#9294)"

### DIFF
--- a/pkg/tagger/collectors/ecs_extract_test.go
+++ b/pkg/tagger/collectors/ecs_extract_test.go
@@ -136,7 +136,7 @@ func TestECSParseTasks(t *testing.T) {
 	} {
 		ctx := context.Background()
 		t.Logf("test case %d", nb)
-		infos, err := ecsCollector.parseTasks(ctx, tc.input, tc.handler)
+		infos, err := ecsCollector.parseTasks(ctx, tc.input, "", tc.handler)
 		if len(infos) > 0 {
 			require.Len(t, infos, 2)
 		}
@@ -151,4 +151,53 @@ func TestECSParseTasks(t *testing.T) {
 			assert.Equal(t, tc.err.Error(), err.Error())
 		}
 	}
+}
+
+func TestECSParseTasksTargetting(t *testing.T) {
+	ctx := context.Background()
+
+	ecsExpireFreq := 5 * time.Minute
+	expiretest, err := newExpire(ecsCollectorName, ecsExpireFreq)
+	require.NoError(t, err)
+	ecsCollector := &ECSCollector{
+		expire: expiretest,
+	}
+
+	input := []v1.Task{
+		{
+			Arn:           "arn:aws:ecs:us-east-1:<aws_account_id>:task/example5-58ff-46c9-ae05-543f8example",
+			DesiredStatus: "RUNNING",
+			KnownStatus:   "RUNNING",
+			Family:        "hello_world",
+			Version:       "8",
+			Containers: []v1.Container{
+				{
+					DockerID:   "9581a69a761a557fbfce1d0f6745e4af5b9dbfb86b6b2c5c4df156f1a5932ff1",
+					DockerName: "ecs-hello_world-8-mysql-fcae8ac8f9f1d89d8301",
+					Name:       "mysql",
+				},
+				{
+					DockerID:   "bf25c5c5b2d4dba68846c7236e75b6915e1e778d31611e3c6a06831e39814a15",
+					DockerName: "ecs-hello_world-8-wordpress-e8bfddf9b488dff36c00",
+					Name:       "wordpress",
+				},
+			},
+		},
+	}
+
+	// First run, collect all
+	infos, err := ecsCollector.parseTasks(ctx, input, "")
+	assert.NoError(t, err)
+	assert.Len(t, infos, 2)
+
+	// Second run, collect none (all already seen)
+	infos, err = ecsCollector.parseTasks(ctx, input, "")
+	assert.NoError(t, err)
+	assert.Len(t, infos, 0)
+
+	// Force a target container ID
+	infos, err = ecsCollector.parseTasks(ctx, input, "bf25c5c5b2d4dba68846c7236e75b6915e1e778d31611e3c6a06831e39814a15")
+	assert.NoError(t, err)
+	require.Len(t, infos, 1)
+	assert.Equal(t, "container_id://bf25c5c5b2d4dba68846c7236e75b6915e1e778d31611e3c6a06831e39814a15", infos[0].Entity)
 }

--- a/pkg/tagger/collectors/ecs_main.go
+++ b/pkg/tagger/collectors/ecs_main.go
@@ -68,7 +68,7 @@ func (c *ECSCollector) Detect(ctx context.Context, out chan<- []*TagInfo) (Colle
 
 	c.clusterName = instance.Cluster
 
-	return PullCollection, nil
+	return FetchOnlyCollection, nil
 }
 
 // Fetch fetches ECS tags
@@ -86,15 +86,20 @@ func (c *ECSCollector) Fetch(ctx context.Context, entity string) ([]string, []st
 	var updates []*TagInfo
 
 	if config.Datadog.GetBool("ecs_collect_resource_tags_ec2") && ecsutil.HasEC2ResourceTags() {
-		updates, err = c.parseTasks(ctx, tasks, addTagsForContainer)
+		updates, err = c.parseTasks(ctx, tasks, cID, addTagsForContainer)
 	} else {
-		updates, err = c.parseTasks(ctx, tasks)
+		updates, err = c.parseTasks(ctx, tasks, cID)
 	}
 	if err != nil {
 		return []string{}, []string{}, []string{}, err
 	}
 
 	c.infoOut <- updates
+
+	expires := c.expire.ComputeExpires()
+	if len(expires) > 0 {
+		c.infoOut <- expires
+	}
 
 	for _, info := range updates {
 		if info.Entity == entity {
@@ -115,34 +120,6 @@ func (c *ECSCollector) Fetch(ctx context.Context, entity string) ([]string, []st
 
 	// container not found in updates
 	return []string{}, []string{}, []string{}, errors.NewNotFound(entity)
-}
-
-// Pull fetches ECS tags for all tasks in the current node
-func (c *ECSCollector) Pull(ctx context.Context) error {
-	tasks, err := c.metaV1.GetTasks(ctx)
-	if err != nil {
-		return err
-	}
-
-	var updates []*TagInfo
-
-	if config.Datadog.GetBool("ecs_collect_resource_tags_ec2") && ecsutil.HasEC2ResourceTags() {
-		updates, err = c.parseTasks(ctx, tasks, addTagsForContainer)
-	} else {
-		updates, err = c.parseTasks(ctx, tasks)
-	}
-	if err != nil {
-		return err
-	}
-
-	c.infoOut <- updates
-
-	expires := c.expire.ComputeExpires()
-	if len(expires) > 0 {
-		c.infoOut <- expires
-	}
-
-	return nil
 }
 
 func addTagsForContainer(ctx context.Context, containerID string, tags *utils.TagList) error {

--- a/pkg/tagger/collectors/types.go
+++ b/pkg/tagger/collectors/types.go
@@ -29,9 +29,10 @@ type CollectionMode int
 
 // Return values for Collector.Init to inform the Tagger of the scheduling needed
 const (
-	NoCollection     CollectionMode = iota // Not available
-	PullCollection                         // Call regularly via the Pull method
-	StreamCollection                       // Will continuously feed updates on the channel from Steam() to Stop()
+	NoCollection        CollectionMode = iota // Not available
+	PullCollection                            // Call regularly via the Pull method
+	StreamCollection                          // Will continuously feed updates on the channel from Steam() to Stop()
+	FetchOnlyCollection                       // Only call Fetch() on cache misses
 )
 
 // Collector retrieve entity tags from a given source and feeds

--- a/pkg/tagger/local/tagger.go
+++ b/pkg/tagger/local/tagger.go
@@ -224,6 +224,13 @@ func (t *Tagger) registerCollectors(replies []collectorReply) {
 			} else {
 				log.Errorf("error initializing collector %s: does not implement stream", c.name)
 			}
+		case collectors.FetchOnlyCollection:
+			fetch, ok := c.instance.(collectors.Fetcher)
+			if ok {
+				t.addFetcher(c.name, fetch)
+			} else {
+				log.Errorf("error initializing collector %s: does not implement fetch", c.name)
+			}
 		}
 	}
 	t.Unlock()

--- a/releasenotes/notes/Fix-ECS-throttling-ba2ef03f3fb488a3.yaml
+++ b/releasenotes/notes/Fix-ECS-throttling-ba2ef03f3fb488a3.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On ECS, fix the volume of calls to `ListTagsForResource` which led to ECS API throttling.


### PR DESCRIPTION
This reverts commit 0f6a8fdfaf15c8126e7959d589442724e86030bf.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->
Revert #9294

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Agent `7.32.0` is doing so many more calls to ECS API that the API is throttled.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Load the agent on ECS and monitor the volume of `ListTagsForResource` API calls.
The volume should significantly increase between `7.31.1` and `7.32.0` and with this fix, it should be back to the level of `7.31.1`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [X] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [X] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [X] Changed code has automated tests for its functionality.
- [X] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [X] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [X] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [X] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
