### PR TITLE
Fix go build with docker build tag

### DIFF
--- a/pkg/logs/input/docker/ad_identifier.go
+++ b/pkg/logs/input/docker/ad_identifier.go
@@ -9,6 +9,6 @@ package docker
 
 // ContainsADIdentifier returns true if the container contains an autodiscovery identifier.
 func ContainsADIdentifier(c *Container) bool {
-	_, exists := c.container.Labels[configPath]
+	_, exists := c.container.Config.Labels[configPath]
 	return exists
 }


### PR DESCRIPTION
### What does this PR do?

Fixes go build of the `pkg/logs/input/docker` with the `docker` build tag.

### Motivation

I discovered the issue when I tried to setup the build process described in the [Getting started](https://github.com/DataDog/datadog-agent#getting-started) in a Dockerfile.

Related issue: 
https://github.com/DataDog/datadog-agent/issues/5152

### Additional Notes

The `Labels` map is not inside the [types.ContainerJSON](https://github.com/moby/moby/blob/bd33bbf0497b2327516dc799a5e541b720822a4c/api/types/types.go#L332-L364) type but on [container.Config](https://github.com/moby/moby/blob/bd33bbf0497b2327516dc799a5e541b720822a4c/api/types/container/config.go#L65).

Other calls to `.Labels` were properly change elsewhere in the package in this PR https://github.com/DataDog/datadog-agent/pull/4852.  
Examples:  
[container.go](https://github.com/DataDog/datadog-agent/blob/jb.pinalie/docker-build-fix/pkg/logs/input/docker/container.go#L180:L180)
[ad_identifier_kubelet.go](https://github.com/DataDog/datadog-agent/blob/jb.pinalie/docker-build-fix/pkg/logs/input/docker/ad_identifier_kubelet.go#L28:L28)

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

```
$ cd pkg/logs/input/docker
$ go1.16.10 build -tags docker

# github.com/DataDog/datadog-agent/pkg/logs/input/docker
./ad_identifier.go:12:26: c.container.Labels undefined (type types.ContainerJSON has no field or method Labels)
```

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
