### PR TITLE
[CSPM] do not fail when loading a rule fails, or when the rule does not apply to this system

### DIFF
--- a/pkg/compliance/checks/builder.go
+++ b/pkg/compliance/checks/builder.go
@@ -380,7 +380,10 @@ func (b *builder) ChecksFromFile(file string, onCheck compliance.CheckVisitor) e
 		log.Debugf("%s/%s: loading rule %s", suite.Meta.Name, suite.Meta.Version, r.ID)
 		check, err := b.checkFromRule(&suite.Meta, &r)
 		if err != nil {
-			return err
+			if err != ErrRuleDoesNotApply {
+				log.Warnf("%s/%s: failed to load rule %s: %v", suite.Meta.Name, suite.Meta.Version, r.ID, err)
+			}
+			log.Infof("%s/%s: skipped rule %s - does not apply to this system", suite.Meta.Name, suite.Meta.Version, r.ID)
 		}
 
 		if err := b.addCheckAndRun(suite, r.Common(), check, onCheck, err); err != nil {
@@ -396,7 +399,10 @@ func (b *builder) ChecksFromFile(file string, onCheck compliance.CheckVisitor) e
 		log.Debugf("%s/%s: loading rule %s", suite.Meta.Name, suite.Meta.Version, r.ID)
 		check, err := b.checkFromRegoRule(&suite.Meta, &r)
 		if err != nil {
-			return err
+			if err != ErrRuleDoesNotApply {
+				log.Warnf("%s/%s: failed to load rule %s: %v", suite.Meta.Name, suite.Meta.Version, r.ID, err)
+			}
+			log.Infof("%s/%s: skipped rule %s - does not apply to this system", suite.Meta.Name, suite.Meta.Version, r.ID)
 		}
 
 		if err := b.addCheckAndRun(suite, r.Common(), check, onCheck, err); err != nil {


### PR DESCRIPTION
### What does this PR do?

This PR fixes an issue where failing to load a rule, or loading a rule that doesn't apply to the system would stop the rule loading process.

### Describe how to test/QA your changes

Usual rules should contain mixed rules (between k8s node types) and should exercise the problem.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
