### PR TITLE
[workloadmeta] Add Podman collector

### DIFF
--- a/.copyright-overrides.yml
+++ b/.copyright-overrides.yml
@@ -83,6 +83,7 @@ github.com/xeipuuv/gojsonpointer: xeipuuv ( https://github.com/xeipuuv )
 github.com/xeipuuv/gojsonreference: xeipuuv ( https://github.com/xeipuuv )
 github.com/xeipuuv/gojsonschema: xeipuuv ( https://github.com/xeipuuv )
 github.com/open-policy-agent/opa: The OPA Authors
+github.com/containernetworking/cni: CNI authors
 
 # These have large AUTHORS/CONTRIBUTORS files but attribute copyright as a group
 github.com/aptly-dev/aptly: aptly authors

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -179,7 +179,6 @@ core,github.com/benbjohnson/clock,MIT,Ben Johnson
 core,github.com/benesch/cgosymbolizer,BSD-3-Clause,Cockroach Labs
 core,github.com/beorn7/perks/quantile,MIT,Blake Mizerany
 core,github.com/bhmj/jsonslice,MIT,bhmj
-core,github.com/bits-and-blooms/bitset,BSD-3-Clause,Will Fitzgerald
 core,github.com/blabber/go-freebsd-sysctl/sysctl,0BSD,Tobias Rehbein <tobias.rehbein@web.de>
 core,github.com/blang/semver,MIT,Benedikt Lang <github at benediktlang.de>
 core,github.com/bmizerany/pat,MIT,"Keith Rarick, Blake Mizerany"
@@ -260,6 +259,13 @@ core,github.com/containerd/continuity/sysx,Apache-2.0,The containerd Authors
 core,github.com/containerd/fifo,Apache-2.0,The containerd Authors
 core,github.com/containerd/ttrpc,Apache-2.0,The containerd Authors
 core,github.com/containerd/typeurl,Apache-2.0,The containerd Authors
+core,github.com/containernetworking/cni/libcni,Apache-2.0,CNI authors
+core,github.com/containernetworking/cni/pkg/invoke,Apache-2.0,CNI authors
+core,github.com/containernetworking/cni/pkg/types,Apache-2.0,CNI authors
+core,github.com/containernetworking/cni/pkg/types/020,Apache-2.0,CNI authors
+core,github.com/containernetworking/cni/pkg/types/current,Apache-2.0,CNI authors
+core,github.com/containernetworking/cni/pkg/utils,Apache-2.0,CNI authors
+core,github.com/containernetworking/cni/pkg/version,Apache-2.0,CNI authors
 core,github.com/coreos/go-semver/semver,Apache-2.0,CoreOS Project
 core,github.com/coreos/go-systemd/daemon,Apache-2.0,CoreOS Project
 core,github.com/coreos/go-systemd/dbus,Apache-2.0,CoreOS Project
@@ -268,6 +274,7 @@ core,github.com/coreos/go-systemd/sdjournal,Apache-2.0,CoreOS Project
 core,github.com/coreos/go-systemd/v22/dbus,Apache-2.0,CoreOS Project
 core,github.com/coreos/pkg/capnslog,Apache-2.0,CoreOS Project
 core,github.com/coreos/pkg/dlopen,Apache-2.0,CoreOS Project
+core,github.com/cri-o/ocicni/pkg/ocicni,Apache-2.0,"Red Hat, Inc"
 core,github.com/cyphar/filepath-securejoin,BSD-3-Clause,Docker Inc & Go Authors | SUSE LLC
 core,github.com/davecgh/go-spew/spew,ISC,Dave Collins <dave@davec.name>
 core,github.com/dgraph-io/ristretto,Apache-2.0,"Dgraph Labs, Inc. and Contributors"
@@ -454,14 +461,14 @@ core,github.com/jstemmer/go-junit-report/parser,MIT,Joel Stemmer
 core,github.com/kardianos/osext,BSD-3-Clause,The Go Authors
 core,github.com/karrick/godirwalk,BSD-2-Clause,Karrick McDermott
 core,github.com/kjk/lzma,BSD-3-Clause,Andrei Vieru
-core,github.com/klauspost/compress,BSD-3-Clause,Klaus Post | The Go Authors | The New York Times Company | The Snappy-Go Authors
-core,github.com/klauspost/compress/flate,BSD-3-Clause,Klaus Post | The Go Authors | The New York Times Company | The Snappy-Go Authors
-core,github.com/klauspost/compress/fse,BSD-3-Clause,Klaus Post | The Go Authors | The New York Times Company | The Snappy-Go Authors
-core,github.com/klauspost/compress/gzip,BSD-3-Clause,Klaus Post | The Go Authors | The New York Times Company | The Snappy-Go Authors
-core,github.com/klauspost/compress/huff0,BSD-3-Clause,Klaus Post | The Go Authors | The New York Times Company | The Snappy-Go Authors
-core,github.com/klauspost/compress/internal/snapref,BSD-3-Clause,Klaus Post | The Go Authors | The New York Times Company | The Snappy-Go Authors
-core,github.com/klauspost/compress/zstd,BSD-3-Clause,Caleb Spare | Klaus Post | The Go Authors | The New York Times Company | The Snappy-Go Authors
-core,github.com/klauspost/compress/zstd/internal/xxhash,MIT,Caleb Spare | Klaus Post | The Go Authors | The New York Times Company | The Snappy-Go Authors
+core,github.com/klauspost/compress,BSD-3-Clause,Klaus Post | The Go Authors | The New York Times Company | The Snappy-Go Authors | The filepathx Authors
+core,github.com/klauspost/compress/flate,BSD-3-Clause,Klaus Post | The Go Authors | The New York Times Company | The Snappy-Go Authors | The filepathx Authors
+core,github.com/klauspost/compress/fse,BSD-3-Clause,Klaus Post | The Go Authors | The New York Times Company | The Snappy-Go Authors | The filepathx Authors
+core,github.com/klauspost/compress/gzip,BSD-3-Clause,Klaus Post | The Go Authors | The New York Times Company | The Snappy-Go Authors | The filepathx Authors
+core,github.com/klauspost/compress/huff0,BSD-3-Clause,Klaus Post | The Go Authors | The New York Times Company | The Snappy-Go Authors | The filepathx Authors
+core,github.com/klauspost/compress/internal/snapref,BSD-3-Clause,Klaus Post | The Go Authors | The New York Times Company | The Snappy-Go Authors | The filepathx Authors
+core,github.com/klauspost/compress/zstd,BSD-3-Clause,Caleb Spare | Klaus Post | The Go Authors | The New York Times Company | The Snappy-Go Authors | The filepathx Authors
+core,github.com/klauspost/compress/zstd/internal/xxhash,MIT,Caleb Spare | Klaus Post | The Go Authors | The New York Times Company | The Snappy-Go Authors | The filepathx Authors
 core,github.com/klauspost/pgzip,MIT,Klaus Post
 core,github.com/knadh/koanf,MIT,Kailash Nadh. https://github.com/knadh
 core,github.com/knadh/koanf/maps,MIT,Kailash Nadh. https://github.com/knadh
@@ -584,6 +591,7 @@ core,github.com/opencontainers/runtime-spec/specs-go,Apache-2.0,The Linux Founda
 core,github.com/opencontainers/selinux/go-selinux,Apache-2.0,OpenContainers Authors
 core,github.com/opencontainers/selinux/go-selinux/label,Apache-2.0,OpenContainers Authors
 core,github.com/opencontainers/selinux/pkg/pwalk,Apache-2.0,OpenContainers Authors
+core,github.com/opencontainers/selinux/pkg/pwalkdir,Apache-2.0,OpenContainers Authors
 core,github.com/openshift/api/quota/v1,Apache-2.0,David Eads | Michal Fojtik
 core,github.com/patrickmn/go-cache,MIT,Alex Edwards <ajmedwards@gmail.com> | Dustin Sallings <dustin@spy.net> | Jason Mooberry <jasonmoo@me.com> | Patrick Mylund Nielsen and the go-cache contributors | Sergey Shepelev <temotor@gmail.com>
 core,github.com/pborman/uuid,BSD-3-Clause,Google Inc | Paul Borman <borman@google.com>
@@ -615,6 +623,7 @@ core,github.com/rcrowley/go-metrics,BSD-2-Clause-Views,Richard Crowley
 core,github.com/richardartoul/molecule,MIT,Richard Artoul
 core,github.com/richardartoul/molecule/src/codec,Apache-2.0,Richard Artoul
 core,github.com/richardartoul/molecule/src/protowire,BSD-3-Clause,Richard Artoul | The Go Authors
+core,github.com/rivo/uniseg,MIT,Oliver Kuederle
 core,github.com/robfig/cron/v3,MIT,Rob Figueiredo
 core,github.com/rs/cors,MIT,Olivier Poitrey <rs@dailymotion.com>
 core,github.com/samuel/go-zookeeper/zk,BSD-3-Clause,Samuel Stauffer <samuel@descolada.com>

--- a/go.mod
+++ b/go.mod
@@ -58,6 +58,7 @@ require (
 	code.cloudfoundry.org/rep v0.0.0-20200325195957-1404b978e31e // indirect
 	code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a // indirect
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
+	github.com/BurntSushi/toml v0.4.1 // indirect
 	github.com/DataDog/agent-payload/v5 v5.0.2
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.0.0-00010101000000-000000000000
 	github.com/DataDog/datadog-agent/pkg/otlp/model v0.33.0-rc.4
@@ -106,6 +107,7 @@ require (
 	github.com/containerd/typeurl v1.0.2
 	github.com/coreos/go-semver v0.3.0
 	github.com/coreos/go-systemd v0.0.0-20190620071333-e64a0ec8b42a
+	github.com/cri-o/ocicni v0.2.0
 	github.com/cyphar/filepath-securejoin v0.2.2
 	github.com/davecgh/go-spew v1.1.1
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200916142827-bd33bbf0497b+incompatible
@@ -148,12 +150,14 @@ require (
 	github.com/json-iterator/go v1.1.12
 	github.com/kardianos/osext v0.0.0-20190222173326-2bc1f35cddc0
 	github.com/karrick/godirwalk v1.16.1
+	github.com/klauspost/compress v1.13.6 // indirect
 	github.com/klauspost/pgzip v1.2.5 // indirect
 	github.com/kubernetes-sigs/custom-metrics-apiserver v0.0.0-20210311094424-0ca2b1909cdc
 	github.com/lib/pq v1.10.0 // indirect
 	github.com/lxn/walk v0.0.0-20191128110447-55ccb3a9f5c1
 	github.com/lxn/win v0.0.0-20191128105842-2da648fda5b4
 	github.com/mailru/easyjson v0.7.7
+	github.com/mattn/go-runewidth v0.0.13 // indirect
 	github.com/mdlayher/netlink v1.4.1
 	github.com/mholt/archiver/v3 v3.5.0
 	github.com/miekg/dns v1.1.43
@@ -163,9 +167,13 @@ require (
 	github.com/nu7hatch/gouuid v0.0.0-20131221200532-179d4d0c4d8d // indirect
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/oliveagle/jsonpath v0.0.0-20180606110733-2e52cf6e6852 // indirect
+	github.com/onsi/ginkgo v1.16.5 // indirect
+	github.com/onsi/gomega v1.17.0 // indirect
 	github.com/open-policy-agent/opa v0.34.2
 	github.com/open-telemetry/opentelemetry-collector-contrib/pkg/resourcetotelemetry v0.38.0
+	github.com/opencontainers/image-spec v1.0.2-0.20210819154149-5ad6f50d6283 // indirect
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
+	github.com/opencontainers/selinux v1.9.1 // indirect
 	github.com/openshift/api v0.0.0-20190924102528-32369d4db2ad
 	github.com/patrickmn/go-cache v2.1.0+incompatible
 	github.com/pierrec/lz4/v4 v4.1.3 // indirect
@@ -192,7 +200,7 @@ require (
 	github.com/vishvananda/netns v0.0.0-20210104183010-2eb08e3e575f
 	github.com/vito/go-sse v1.0.0 // indirect
 	github.com/vmihailenco/msgpack/v4 v4.3.12
-	github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f
+	github.com/xeipuuv/gojsonschema v1.2.0
 	go.etcd.io/bbolt v1.3.6
 	go.etcd.io/etcd/client/v2 v2.305.1
 	go.opentelemetry.io/collector v0.38.0

--- a/go.sum
+++ b/go.sum
@@ -100,8 +100,9 @@ github.com/Azure/go-autorest/logger v0.1.0/go.mod h1:oExouG+K6PryycPJfVSxi/koC6L
 github.com/Azure/go-autorest/logger v0.2.0/go.mod h1:T9E3cAhj2VqvPOtCYAvby9aBXkZmbF5NWuPV8+WeEW8=
 github.com/Azure/go-autorest/tracing v0.5.0/go.mod h1:r/s2XiOKccPW3HrqB+W0TQzfbtp2fGCgRFtBroKn4Dk=
 github.com/Azure/go-autorest/tracing v0.6.0/go.mod h1:+vhtPC754Xsa23ID7GlGsrdKBpUA79WCAKPPZVC2DeU=
-github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
+github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw=
+github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/agent-payload/v5 v5.0.2 h1:Uzbl1yI2/Sv8hA8Jc9AU0wJavOxqhbfTE38KhZceScc=
@@ -255,7 +256,6 @@ github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6r
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bhmj/jsonslice v0.0.0-20200323023432-92c3edaad8e2 h1:11xwzvvHBTyUMCD7infJV2SXSaVyp9ZXK9QgfV6Jfss=
 github.com/bhmj/jsonslice v0.0.0-20200323023432-92c3edaad8e2/go.mod h1:blvNODZOz8uOvDJzGiXzoi8QlzcAhA57sMnKx1D18/k=
-github.com/bits-and-blooms/bitset v1.2.0 h1:Kn4yilvwNtMACtf1eYDlG8H77R07mZSPbMjLyS07ChA=
 github.com/bits-and-blooms/bitset v1.2.0/go.mod h1:gIdJ4wp64HaoK2YrL1Q5/N7Y16edYb8uY+O0FJTyyDA=
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
@@ -378,7 +378,9 @@ github.com/containerd/zfs v0.0.0-20210315114300-dde8f0fda960/go.mod h1:m+m51S1Dv
 github.com/containerd/zfs v0.0.0-20210324211415-d5c4544f0433/go.mod h1:m+m51S1DvAP6r3FcmYCp54bQ34pyOwTieQDNRIRHsFY=
 github.com/containerd/zfs v1.0.0/go.mod h1:m+m51S1DvAP6r3FcmYCp54bQ34pyOwTieQDNRIRHsFY=
 github.com/containernetworking/cni v0.7.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
+github.com/containernetworking/cni v0.7.2-0.20190904153231-83439463f784/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/cni v0.8.0/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
+github.com/containernetworking/cni v0.8.1 h1:7zpDnQ3T3s4ucOuJ/ZCLrYBxzkg0AELFfII3Epo9TmI=
 github.com/containernetworking/cni v0.8.1/go.mod h1:LGwApLUm2FpoOfxTDEeq8T9ipbpZ61X79hmU3w8FmsY=
 github.com/containernetworking/plugins v0.8.6/go.mod h1:qnw5mN19D8fIwkqW7oHHYDHVlzhJpcY6TQxn/fUyDDM=
 github.com/containernetworking/plugins v0.9.1/go.mod h1:xP/idU2ldlzN6m4p5LmGiwRDjeJr6FLK6vuiUwoH7P8=
@@ -410,6 +412,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsr
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
+github.com/cri-o/ocicni v0.2.0 h1:p0kO+/fcLTO574CcDwzAosFdP2U+NEL+a4wph3Bt85k=
+github.com/cri-o/ocicni v0.2.0/go.mod h1:ZOuIEOp/3MB1eCBWANnNxM3zUA3NWh76wSRCsnKAg2c=
 github.com/cucumber/gherkin-go/v13 v13.0.0/go.mod h1:pzMEPEIPcPOBDkE8HaWC+Ck6eDBtBmIWVksUkSin/2E=
 github.com/cucumber/messages-go/v12 v12.0.0/go.mod h1:5zuJu21U6rB+BBqyGoQr839a4h4GUElPnSozdHyhCOQ=
 github.com/cyphar/filepath-securejoin v0.2.2 h1:jCwT2GTP+PY5nBz3c/YL5PAIbusElVrPujOBSCj8xRg=
@@ -602,6 +606,7 @@ github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gG
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0 h1:5SgMzNM5HxrEjV0ww2lTmX6E2Izsfxas4+YHWRs3Lsk=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
+github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.2-0.20181118220953-042da051cf31/go.mod h1:wGDj63lr65AM2AQyKZd/NYHGb0R+1RLqB8NKt3aSFNA=
 github.com/go-test/deep v1.0.5 h1:AKODKU3pDH1RzZzm6YZu77YWtEAq6uh1rLIAQlay2qc=
 github.com/go-test/deep v1.0.5/go.mod h1:QV8Hv/iy04NyLBxAdO9njL0iVPN1S4d/A3NVv1V36o8=
@@ -909,8 +914,9 @@ github.com/klauspost/compress v1.11.3/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYs
 github.com/klauspost/compress v1.11.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.11.13/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/klauspost/compress v1.12.3/go.mod h1:8dP1Hq4DHOhN9w426knH3Rhby4rFm6D8eO+e+Dq5Gzg=
-github.com/klauspost/compress v1.13.5 h1:9O69jUPDcsT9fEm74W92rZL9FQY7rCdaXVneq+yyzl4=
 github.com/klauspost/compress v1.13.5/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
+github.com/klauspost/compress v1.13.6 h1:P76CopJELS0TiO2mebmnzgWaajssP/EszplttgQxcgc=
+github.com/klauspost/compress v1.13.6/go.mod h1:/3/Vjq9QcHkK5uEr5lBEmyoZ1iFhe47etQ6QUkpK6sk=
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/klauspost/pgzip v1.2.4/go.mod h1:Ch1tH69qFZu15pkjo5kYi6mth2Zzwzt50oCQKQE9RUs=
 github.com/klauspost/pgzip v1.2.5 h1:qnWYvvKqedOF2ulHpMG72XQol4ILEJ8k2wwRl/Km8oE=
@@ -985,8 +991,9 @@ github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27k
 github.com/mattn/go-runewidth v0.0.2/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.4/go.mod h1:LwmH8dsx7+W8Uxz3IHJYH5QSwggIsqBzpuz5H//U1FU=
 github.com/mattn/go-runewidth v0.0.8/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/mattn/go-runewidth v0.0.9 h1:Lm995f3rfxdpd6TSmuVCHVb/QhupuXlYr8sCI/QdE+0=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
+github.com/mattn/go-runewidth v0.0.13 h1:lTGmDsbAYt5DmK6OnoV7EuIF1wEIFAcxld6ypU4OSgU=
+github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mattn/go-shellwords v1.0.2/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
 github.com/mattn/go-shellwords v1.0.6/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vqg+NOMyg4B2o=
@@ -1103,8 +1110,10 @@ github.com/onsi/ginkgo v1.11.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+
 github.com/onsi/ginkgo v1.12.0/go.mod h1:oUhWkIvk5aDxtKvDDuw8gItl8pKl42LzjC9KZE0HfGg=
 github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108oapk=
 github.com/onsi/ginkgo v1.14.1/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
-github.com/onsi/ginkgo v1.15.0 h1:1V1NfVQR87RtWAgp1lv9JZJ5Jap+XFGKPi00andXGi4=
 github.com/onsi/ginkgo v1.15.0/go.mod h1:hF8qUzuuC8DJGygJH3726JnCZX4MYbRB8yFfISqnKUg=
+github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
+github.com/onsi/ginkgo v1.16.5 h1:8xi0RTUf59SOSfEtZMvwTvXYMzG4gV23XVHOZiXNtnE=
+github.com/onsi/ginkgo v1.16.5/go.mod h1:+E8gABHa3K6zRBolWtd+ROzc/U5bkGt0FwiG042wbpU=
 github.com/onsi/gomega v0.0.0-20151007035656-2152b45fa28a/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v0.0.0-20170829124025-dcabb60a477c/go.mod h1:C1qb7wdrVGGVU+Z6iS04AVkA3Q65CEZX59MT0QO5uiA=
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
@@ -1115,8 +1124,9 @@ github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.2/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
-github.com/onsi/gomega v1.10.5 h1:7n6FEkpFmfCoo2t+YYqXH0evK+a9ICQz0xcAy9dYcaQ=
 github.com/onsi/gomega v1.10.5/go.mod h1:gza4q3jKQJijlu05nKWRCW/GavJumGt8aNRxWg7mt48=
+github.com/onsi/gomega v1.17.0 h1:9Luw4uT5HTjHTN8+aNcSThgH1vdXnmdJ8xIfZ4wyTRE=
+github.com/onsi/gomega v1.17.0/go.mod h1:HnhC7FXeEQY45zxNK3PPoIUhzk/80Xly9PcubAlGdZY=
 github.com/open-policy-agent/opa v0.34.2 h1:asRmfDRUSd8gwPNRrpUsDxwOUkxLgc1x1FYkwjcnag4=
 github.com/open-policy-agent/opa v0.34.2/go.mod h1:buysXn+6zB/b+6JgLkP4WgKZ9+UgUtFAgtemYGrL9Ik=
 github.com/open-telemetry/opentelemetry-collector-contrib/internal/coreinternal v0.38.0 h1:ecNg5pZkncyGE9YfiAIJnIzoN0/enYcwU/Y+R+6tPUo=
@@ -1127,8 +1137,9 @@ github.com/opencontainers/go-digest v0.0.0-20180430190053-c9281466c8b2/go.mod h1
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
 github.com/opencontainers/go-digest v1.0.0/go.mod h1:0JzlMkj0TRzQZfJkVvzbP0HBR3IKzErnv2BNG4W4MAM=
-github.com/opencontainers/image-spec v1.0.1 h1:JMemWkRwHx4Zj+fVxWoMCFm/8sYGGrUVojFA6h/TRcI=
 github.com/opencontainers/image-spec v1.0.1/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
+github.com/opencontainers/image-spec v1.0.2-0.20210819154149-5ad6f50d6283 h1:TVzvdjOalkJBNkbpPVMAr4KV9QRf2IjfxdyxwAK78Gs=
+github.com/opencontainers/image-spec v1.0.2-0.20210819154149-5ad6f50d6283/go.mod h1:BtxoFyWECRxE4U/7sNtV5W15zMzWCbyJoFRP3s7yZA0=
 github.com/opencontainers/runc v0.0.0-20190115041553-12f6a991201f/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v0.1.1/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
@@ -1144,8 +1155,9 @@ github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417/go.m
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
 github.com/opencontainers/selinux v1.6.0/go.mod h1:VVGKuOLlE7v4PJyT6h7mNWvq1rzqiriPsEqVhc+svHE=
 github.com/opencontainers/selinux v1.8.0/go.mod h1:RScLhm78qiWa2gbVCcGkC7tCGdgk3ogry1nUQF8Evvo=
-github.com/opencontainers/selinux v1.8.2 h1:c4ca10UMgRcvZ6h0K4HtS15UaVSBEaE+iln2LVpAuGc=
 github.com/opencontainers/selinux v1.8.2/go.mod h1:MUIHuUEvKB1wtJjQdOyYRgOnLD2xAPP8dBsCoU0KuF8=
+github.com/opencontainers/selinux v1.9.1 h1:b4VPEF3O5JLZgdTDBmGepaaIbAo0GqoF6EBRq5f/g3Y=
+github.com/opencontainers/selinux v1.9.1/go.mod h1:2i0OySw99QjzBBQByd1Gr9gSjvuho1lHsJxIJ3gGbJI=
 github.com/openshift/api v0.0.0-20190924102528-32369d4db2ad h1:MiZEukiPd7ll8BQDwBfc3LKBxbqyeXIx+wl4CzVj5EQ=
 github.com/openshift/api v0.0.0-20190924102528-32369d4db2ad/go.mod h1:dh9o4Fs58gpFXGSYfnVxGR9PnV53I8TW84pQaJDdGiY=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
@@ -1241,6 +1253,8 @@ github.com/richardartoul/molecule v0.0.0-20210914193524-25d8911bb85b h1:mbJ/v+xr
 github.com/richardartoul/molecule v0.0.0-20210914193524-25d8911bb85b/go.mod h1:uvX/8buq8uVeiZiFht+0lqSLBHF+uGV8BrTv8W/SIwk=
 github.com/rivo/tview v0.0.0-20200219210816-cd38d7432498/go.mod h1:6lkG1x+13OShEf0EaOCaTQYyB7d5nSbb181KtjlS+84=
 github.com/rivo/uniseg v0.1.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
+github.com/rivo/uniseg v0.2.0 h1:S1pD9weZBuJdFmowNwbpi7BJ8TNftyUImj/0WQi72jY=
+github.com/rivo/uniseg v0.2.0/go.mod h1:J6wj4VEh+S6ZtnVlnTBMWIodfgj8LQOQFoIToxlJtxc=
 github.com/robfig/cron/v3 v3.0.0/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
 github.com/robfig/cron/v3 v3.0.1 h1:WdRxkvbJztn8LMz/QEvLN5sBU+xKpSqwwUO1Pjr4qDs=
 github.com/robfig/cron/v3 v3.0.1/go.mod h1:eQICP3HwyT7UooqI/z+Ov+PtYAWygg1TEWWzGIFLtro=
@@ -1417,12 +1431,13 @@ github.com/willf/bitset v1.1.11-0.20200630133818-d5bec3311243/go.mod h1:RjeCKbqT
 github.com/willf/bitset v1.1.11/go.mod h1:83CECat5yLh5zVOf4P1ErAgKA5UDvKtgyUABdr3+MjI=
 github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0 h1:3UeQBvD0TFrlVjOeLOBz+CPAI8dnbqNSVwUwRrkp7vQ=
 github.com/wsxiaoys/terminal v0.0.0-20160513160801-0940f3fc43a0/go.mod h1:IXCdmsXIht47RaVFLEdVnh1t+pgYtTAhQGj73kz+2DM=
+github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb h1:zGWFAtiMcyryUHoUjUJX0/lt1H2+i2Ka2n+D3DImSNo=
 github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb/go.mod h1:N2zxlSyiKSe5eX1tZViRH5QA0qijqEDrYZiPEAiq3wU=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 h1:EzJWgHovont7NscjpAxXsDA8S8BMYve8Y5+7cuRE7R0=
 github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415/go.mod h1:GwrjFmJcFw6At/Gs6z4yjiIwzuJ1/+UwLxMQDVQXShQ=
-github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f h1:mvXjJIHRZyhNuGassLTcXTwjiWq7NmjdavZsUnmFybQ=
-github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f/go.mod h1:5yf86TLmAcydyeJq5YvxkGPE2fm/u4myDekKRoLuqhs=
+github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17UxZ74=
+github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8 h1:nIPpBwaJSVYIxUFsDv3M8ofmx9yWTog9BfvIu0q41lo=
 github.com/xi2/xz v0.0.0-20171230120015-48954b6210f8/go.mod h1:HUYIGzjTL3rfEspMxjDjgmT5uz5wzYJKVo23qUhYTos=
 github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2 h1:eY9dn8+vbi4tKz5Qo6v2eYzo7kUS51QINcR5jNpbZS8=
@@ -1658,6 +1673,7 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210421230115-4e50805a0758/go.mod h1:72T/g9IO56b78aLF+1Kcs5dz7/ng1VjMUvfKvpfy+jM=
+golang.org/x/net v0.0.0-20210428140749-89ef3d95e781/go.mod h1:OJAsFXCWl8Ukc7SiCT/9KSuxbyM7479/AVlXFRxuMCk=
 golang.org/x/net v0.0.0-20210525063256-abc453219eb5/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210610132358-84b48f89b13b/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.0.0-20210614182718-04defd469f4e/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=

--- a/pkg/util/podman/container.go
+++ b/pkg/util/podman/container.go
@@ -1,0 +1,420 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build podman
+// +build podman
+
+package podman
+
+import (
+	"net"
+	"time"
+
+	"github.com/cri-o/ocicni/pkg/ocicni"
+	spec "github.com/opencontainers/runtime-spec/specs-go"
+)
+
+// Note: This file includes the types from the Podman package that we need for
+// our Podman DB client. The structs in this file have been copied from
+// https://github.com/containers/podman/blob/v3.4.1/libpod/ with small
+// modifications.
+//
+// More specifically, the types included here are:
+// - ContainerStatus:
+// https://github.com/containers/podman/blob/v3.4.1/libpod/define/containerstate.go
+// - ContainerState:
+// https://github.com/containers/podman/blob/v3.4.1/libpod/container.go
+// - ContainerConfig (and the ones it depends on like ContainerSecurityConfig,
+// ContainerNameSpaceConfig, etc.):
+// https://github.com/containers/podman/blob/v3.4.1/libpod/container_config.go
+//
+// There are some modifications that have been done to avoid bringing
+// unnecessary dependencies:
+// - Deleted the `ContainerRootFSConfig` embedded struct from `ContainerConfig`.
+// - Deleted the `IDMappings` field from `ContainerConfig`.
+// - Deleted the `NetMode` field of the `ContainerNetworkConfig` struct.
+// - Deleted the `HealthCheckConfig` field of the `ContainerMiscConfig` struct.
+// - Deleted the `EnvSecrets` field of the `ContainerMiscConfig` struct.
+// - The `Container` struct only contains the 2 attributes that we need.
+
+type Container struct {
+	Config *ContainerConfig
+	State  *ContainerState
+}
+
+// ContainerStatus represents the current state of a container
+type ContainerStatus int
+
+const (
+	// ContainerStateUnknown indicates that the container is in an error
+	// state where information about it cannot be retrieved
+	ContainerStateUnknown ContainerStatus = iota
+	// ContainerStateConfigured indicates that the container has had its
+	// storage configured but it has not been created in the OCI runtime
+	ContainerStateConfigured ContainerStatus = iota
+	// ContainerStateCreated indicates the container has been created in
+	// the OCI runtime but not started
+	ContainerStateCreated ContainerStatus = iota
+	// ContainerStateRunning indicates the container is currently executing
+	ContainerStateRunning ContainerStatus = iota
+	// ContainerStateStopped indicates that the container was running but has
+	// exited
+	ContainerStateStopped ContainerStatus = iota
+	// ContainerStatePaused indicates that the container has been paused
+	ContainerStatePaused ContainerStatus = iota
+	// ContainerStateExited indicates the the container has stopped and been
+	// cleaned up
+	ContainerStateExited ContainerStatus = iota
+	// ContainerStateRemoving indicates the container is in the process of
+	// being removed.
+	ContainerStateRemoving ContainerStatus = iota
+	// ContainerStateStopping indicates the container is in the process of
+	// being stopped.
+	ContainerStateStopping ContainerStatus = iota
+)
+
+// ContainerStatus returns a string representation for users
+// of a container state
+func (t ContainerStatus) String() string {
+	switch t {
+	case ContainerStateUnknown:
+		return "unknown"
+	case ContainerStateConfigured:
+		return "configured"
+	case ContainerStateCreated:
+		return "created"
+	case ContainerStateRunning:
+		return "running"
+	case ContainerStateStopped:
+		return "stopped"
+	case ContainerStatePaused:
+		return "paused"
+	case ContainerStateExited:
+		return "exited"
+	case ContainerStateRemoving:
+		return "removing"
+	case ContainerStateStopping:
+		return "stopping"
+	}
+	return "bad state"
+}
+
+// ContainerState contains the current state of the container
+// It is stored on disk in a tmpfs and recreated on reboot
+type ContainerState struct {
+	// The current state of the running container
+	State ContainerStatus `json:"state"`
+	// StartedTime is the time the container was started
+	StartedTime time.Time `json:"startedTime,omitempty"`
+	// FinishedTime is the time the container finished executing
+	FinishedTime time.Time `json:"finishedTime,omitempty"`
+	// PID is the PID of a running container
+	PID int `json:"pid,omitempty"`
+}
+
+// ContainerConfig contains all information that was used to create the
+// container. It may not be changed once created.
+// It is stored, read-only, on disk in Libpod's State.
+// Any changes will not be written back to the database, and will cause
+// inconsistencies with other Libpod instances.
+type ContainerConfig struct {
+	// Spec is OCI runtime spec used to create the container. This is passed
+	// in when the container is created, but it is not the final spec used
+	// to run the container - it will be modified by Libpod to add things we
+	// manage (e.g. bind mounts for /etc/resolv.conf, named volumes, a
+	// network namespace prepared by CNI or slirp4netns) in the
+	// generateSpec() function.
+	Spec *spec.Spec `json:"spec"`
+
+	// ID is a hex-encoded 256-bit pseudorandom integer used as a unique
+	// identifier for the container. IDs are globally unique in Libpod -
+	// once an ID is in use, no other container or pod will be created with
+	// the same one until the holder of the ID has been removed.
+	// ID is generated by Libpod, and cannot be chosen or influenced by the
+	// user (except when restoring a checkpointed container).
+	// ID is guaranteed to be 64 characters long.
+	ID string `json:"id"`
+
+	// Name is a human-readable name for the container. All containers must
+	// have a non-empty name. Name may be provided when the container is
+	// created; if no name is chosen, a name will be auto-generated.
+	Name string `json:"name"`
+
+	// Pod is the full ID of the pod the container belongs to. If the
+	// container does not belong to a pod, this will be empty.
+	// If this is not empty, a pod with this ID is guaranteed to exist in
+	// the state for the duration of this container's existence.
+	Pod string `json:"pod,omitempty"`
+
+	// Namespace is the libpod Namespace the container is in.
+	// Namespaces are used to divide containers in the state.
+	Namespace string `json:"namespace,omitempty"`
+
+	// LockID is the ID of this container's lock. Each container, pod, and
+	// volume is assigned a unique Lock (from one of several backends) by
+	// the libpod Runtime. This lock will belong only to this container for
+	// the duration of the container's lifetime.
+	LockID uint32 `json:"lockID"`
+
+	// CreateCommand is the full command plus arguments that were used to
+	// create the container. It is shown in the output of Inspect, and may
+	// be used to recreate an identical container for automatic updates or
+	// portable systemd unit files.
+	CreateCommand []string `json:"CreateCommand,omitempty"`
+
+	// RawImageName is the raw and unprocessed name of the image when creating
+	// the container (as specified by the user).  May or may not be set.  One
+	// use case to store this data are auto-updates where we need the _exact_
+	// name and not some normalized instance of it.
+	RawImageName string `json:"RawImageName,omitempty"`
+
+	// IDMappings are UID/GID mappings used by the container's user
+	// namespace. They are used by the OCI runtime when creating the
+	// container, and by c/storage to ensure that the container's files have
+	// the appropriate owner.
+	//IDMappings storage.IDMappingOptions `json:"idMappingsOptions,omitempty"`
+
+	// Dependencies are the IDs of dependency containers.
+	// These containers must be started before this container is started.
+	Dependencies []string
+
+	// embedded sub-configs
+	//ContainerRootFSConfig
+	ContainerSecurityConfig
+	ContainerNameSpaceConfig
+	ContainerNetworkConfig
+	ContainerImageConfig
+	ContainerMiscConfig
+}
+
+// ContainerSecurityConfig is an embedded sub-config providing security configuration
+// to the container.
+type ContainerSecurityConfig struct {
+	// Privileged is whether the container is privileged. Privileged
+	// containers have lessened security and increased access to the system.
+	// Note that this does NOT directly correspond to Podman's --privileged
+	// flag - most of the work of that flag is done in creating the OCI spec
+	// given to Libpod. This only enables a small subset of the overall
+	// operation, mostly around mounting the container image with reduced
+	// security.
+	Privileged bool `json:"privileged"`
+	// ProcessLabel is the SELinux process label for the container.
+	ProcessLabel string `json:"ProcessLabel,omitempty"`
+	// MountLabel is the SELinux mount label for the container's root
+	// filesystem. Only used if the container was created from an image.
+	// If not explicitly set, an unused random MLS label will be assigned by
+	// containers/storage (but only if SELinux is enabled).
+	MountLabel string `json:"MountLabel,omitempty"`
+	// LabelOpts are options passed in by the user to setup SELinux labels.
+	// These are used by the containers/storage library.
+	LabelOpts []string `json:"labelopts,omitempty"`
+	// User and group to use in the container. Can be specified as only user
+	// (in which case we will attempt to look up the user in the container
+	// to determine the appropriate group) or user and group separated by a
+	// colon.
+	// Can be specified by name or UID/GID.
+	// If unset, this will default to UID and GID 0 (root).
+	User string `json:"user,omitempty"`
+	// Groups are additional groups to add the container's user to. These
+	// are resolved within the container using the container's /etc/passwd.
+	Groups []string `json:"groups,omitempty"`
+	// AddCurrentUserPasswdEntry indicates that Libpod should ensure that
+	// the container's /etc/passwd contains an entry for the user running
+	// Libpod - mostly used in rootless containers where the user running
+	// Libpod wants to retain their UID inside the container.
+	AddCurrentUserPasswdEntry bool `json:"addCurrentUserPasswdEntry,omitempty"`
+}
+
+// ContainerNameSpaceConfig is an embedded sub-config providing
+// namespace configuration to the container.
+type ContainerNameSpaceConfig struct {
+	// IDs of container to share namespaces with
+	// NetNsCtr conflicts with the CreateNetNS bool
+	// These containers are considered dependencies of the given container
+	// They must be started before the given container is started
+	IPCNsCtr    string `json:"ipcNsCtr,omitempty"`
+	MountNsCtr  string `json:"mountNsCtr,omitempty"`
+	NetNsCtr    string `json:"netNsCtr,omitempty"`
+	PIDNsCtr    string `json:"pidNsCtr,omitempty"`
+	UserNsCtr   string `json:"userNsCtr,omitempty"`
+	UTSNsCtr    string `json:"utsNsCtr,omitempty"`
+	CgroupNsCtr string `json:"cgroupNsCtr,omitempty"`
+}
+
+// ContainerNetworkConfig is an embedded sub-config providing network configuration
+// to the container.
+type ContainerNetworkConfig struct {
+	// CreateNetNS indicates that libpod should create and configure a new
+	// network namespace for the container.
+	// This cannot be set if NetNsCtr is also set.
+	CreateNetNS bool `json:"createNetNS"`
+	// StaticIP is a static IP to request for the container.
+	// This cannot be set unless CreateNetNS is set.
+	// If not set, the container will be dynamically assigned an IP by CNI.
+	StaticIP net.IP `json:"staticIP"`
+	// StaticMAC is a static MAC to request for the container.
+	// This cannot be set unless CreateNetNS is set.
+	// If not set, the container will be dynamically assigned a MAC by CNI.
+	StaticMAC net.HardwareAddr `json:"staticMAC"`
+	// PortMappings are the ports forwarded to the container's network
+	// namespace
+	// These are not used unless CreateNetNS is true
+	PortMappings []ocicni.PortMapping `json:"portMappings,omitempty"`
+	// ExposedPorts are the ports which are exposed but not forwarded
+	// into the container.
+	// The map key is the port and the string slice contains the protocols,
+	// e.g. tcp and udp
+	// These are only set when exposed ports are given but not published.
+	ExposedPorts map[uint16][]string `json:"exposedPorts,omitempty"`
+	// UseImageResolvConf indicates that resolv.conf should not be
+	// bind-mounted inside the container.
+	// Conflicts with DNSServer, DNSSearch, DNSOption.
+	UseImageResolvConf bool
+	// DNS servers to use in container resolv.conf
+	// Will override servers in host resolv if set
+	DNSServer []net.IP `json:"dnsServer,omitempty"`
+	// DNS Search domains to use in container resolv.conf
+	// Will override search domains in host resolv if set
+	DNSSearch []string `json:"dnsSearch,omitempty"`
+	// DNS options to be set in container resolv.conf
+	// With override options in host resolv if set
+	DNSOption []string `json:"dnsOption,omitempty"`
+	// UseImageHosts indicates that /etc/hosts should not be
+	// bind-mounted inside the container.
+	// Conflicts with HostAdd.
+	UseImageHosts bool
+	// Hosts to add in container
+	// Will be appended to host's host file
+	HostAdd []string `json:"hostsAdd,omitempty"`
+	// Network names (CNI) to add container to. Empty to use default network.
+	// Please note that these can be altered at runtime. The actual list is
+	// stored in the DB and should be retrieved from there; this is only the
+	// set of networks the container was *created* with.
+	Networks []string `json:"networks,omitempty"`
+	// Network mode specified for the default network.
+	// NetMode namespaces.NetworkMode `json:"networkMode,omitempty"`
+	// NetworkOptions are additional options for each network
+	NetworkOptions map[string][]string `json:"network_options,omitempty"`
+	// NetworkAliases are aliases that will be added to each network.
+	// These are additional names that this container can be accessed as via
+	// DNS when the CNI dnsname plugin is in use.
+	// Please note that these can be altered at runtime. As such, the actual
+	// list is stored in the database and should be retrieved from there;
+	// this is only the set of aliases the container was *created with*.
+	// Formatted as map of network name to aliases. All network names must
+	// be present in the Networks list above.
+	NetworkAliases map[string][]string `json:"network_alises,omitempty"`
+}
+
+// ContainerImageConfig is an embedded sub-config providing image configuration
+// to the container.
+type ContainerImageConfig struct {
+	// UserVolumes contains user-added volume mounts in the container.
+	// These will not be added to the container's spec, as it is assumed
+	// they are already present in the spec given to Libpod. Instead, it is
+	// used when committing containers to generate the VOLUMES field of the
+	// image that is created, and for triggering some OCI hooks which do not
+	// fire unless user-added volume mounts are present.
+	UserVolumes []string `json:"userVolumes,omitempty"`
+	// Entrypoint is the container's entrypoint.
+	// It is not used in spec generation, but will be used when the
+	// container is committed to populate the entrypoint of the new image.
+	Entrypoint []string `json:"entrypoint,omitempty"`
+	// Command is the container's command.
+	// It is not used in spec generation, but will be used when the
+	// container is committed to populate the command of the new image.
+	Command []string `json:"command,omitempty"`
+}
+
+// ContainerMiscConfig is an embedded sub-config providing misc configuration
+// to the container.
+type ContainerMiscConfig struct {
+	// Whether to keep container STDIN open
+	Stdin bool `json:"stdin,omitempty"`
+	// Labels is a set of key-value pairs providing additional information
+	// about a container
+	Labels map[string]string `json:"labels,omitempty"`
+	// StopSignal is the signal that will be used to stop the container
+	StopSignal uint `json:"stopSignal,omitempty"`
+	// StopTimeout is the signal that will be used to stop the container
+	StopTimeout uint `json:"stopTimeout,omitempty"`
+	// Timeout is maximum time a container will run before getting the kill signal
+	Timeout uint `json:"timeout,omitempty"`
+	// Time container was created
+	CreatedTime time.Time `json:"createdTime"`
+	// CgroupManager is the cgroup manager used to create this container.
+	// If empty, the runtime default will be used.
+	CgroupManager string `json:"cgroupManager,omitempty"`
+	// NoCgroups indicates that the container will not create CGroups. It is
+	// incompatible with CgroupParent.  Deprecated in favor of CgroupsMode.
+	NoCgroups bool `json:"noCgroups,omitempty"`
+	// CgroupsMode indicates how the container will create cgroups
+	// (disabled, no-conmon, enabled).  It supersedes NoCgroups.
+	CgroupsMode string `json:"cgroupsMode,omitempty"`
+	// Cgroup parent of the container.
+	CgroupParent string `json:"cgroupParent"`
+	// LogPath log location
+	LogPath string `json:"logPath"`
+	// LogTag is the tag used for logging
+	LogTag string `json:"logTag"`
+	// LogSize is the tag used for logging
+	LogSize int64 `json:"logSize"`
+	// LogDriver driver for logs
+	LogDriver string `json:"logDriver"`
+	// File containing the conmon PID
+	ConmonPidFile string `json:"conmonPidFile,omitempty"`
+	// RestartPolicy indicates what action the container will take upon
+	// exiting naturally.
+	// Allowed options are "no" (take no action), "on-failure" (restart on
+	// non-zero exit code, up an a maximum of RestartRetries times),
+	// and "always" (always restart the container on any exit code).
+	// The empty string is treated as the default ("no")
+	RestartPolicy string `json:"restart_policy,omitempty"`
+	// RestartRetries indicates the number of attempts that will be made to
+	// restart the container. Used only if RestartPolicy is set to
+	// "on-failure".
+	RestartRetries uint `json:"restart_retries,omitempty"`
+	// TODO log options for log drivers
+	// PostConfigureNetNS needed when a user namespace is created by an OCI runtime
+	// if the network namespace is created before the user namespace it will be
+	// owned by the wrong user namespace.
+	PostConfigureNetNS bool `json:"postConfigureNetNS"`
+	// OCIRuntime used to create the container
+	OCIRuntime string `json:"runtime,omitempty"`
+	// ExitCommand is the container's exit command.
+	// This Command will be executed when the container exits by Conmon.
+	// It is usually used to invoke post-run cleanup - for example, in
+	// Podman, it invokes `podman container cleanup`, which in turn calls
+	// Libpod's Cleanup() API to unmount the container and clean up its
+	// network.
+	ExitCommand []string `json:"exitCommand,omitempty"`
+	// IsInfra is a bool indicating whether this container is an infra container used for
+	// sharing kernel namespaces in a pod
+	IsInfra bool `json:"pause"`
+	// SdNotifyMode tells libpod what to do with a NOTIFY_SOCKET if passed
+	SdNotifyMode string `json:"sdnotifyMode,omitempty"`
+	// Systemd tells libpod to setup the container in systemd mode
+	Systemd bool `json:"systemd"`
+	// HealthCheckConfig has the health check command and related timings
+	//HealthCheckConfig *manifest.Schema2HealthConfig `json:"healthcheck"`
+	// PreserveFDs is a number of additional file descriptors (in addition
+	// to 0, 1, 2) that will be passed to the executed process. The total FDs
+	// passed will be 3 + PreserveFDs.
+	PreserveFDs uint `json:"preserveFds,omitempty"`
+	// Timezone is the timezone inside the container.
+	// Local means it has the same timezone as the host machine
+	Timezone string `json:"timezone,omitempty"`
+	// Umask is the umask inside the container.
+	Umask string `json:"umask,omitempty"`
+	// PidFile is the file that saves the pid of the container process
+	PidFile string `json:"pid_file,omitempty"`
+	// CDIDevices contains devices that use the CDI
+	CDIDevices []string `json:"cdiDevices,omitempty"`
+	// EnvSecrets are secrets that are set as environment variables
+	//EnvSecrets map[string]*secrets.Secret `json:"secret_env,omitempty"`
+	// InitContainerType specifies if the container is an initcontainer
+	// and if so, what type: always or once are possible non-nil entries
+	InitContainerType string `json:"init_container_type,omitempty"`
+}

--- a/pkg/util/podman/db_client.go
+++ b/pkg/util/podman/db_client.go
@@ -1,0 +1,190 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build podman
+// +build podman
+
+package podman
+
+// The podman go package brings a lot of dependencies because it includes the
+// server and the client. Some of those dependencies are problematic for us. For
+// example, it depends on a more recent version of `go-systemd` than the one we
+// are using.
+//
+// To avoid bringing unnecessary dependencies, we have decided to write our own
+// simple client that queries the BoltDB used by Podman directly. This is
+// feasible because we just need a very small subset of the features offered by
+// the Podman package. More specifically, we just need to retrieve the exiting
+// containers from the DB.
+//
+// The functions in this file have been copied from
+// https://github.com/containers/podman/blob/v3.4.1/libpod/boltdb_state_internal.go
+// The code has been adapted a bit to our needs. The only functions of that file
+// that we need are AllContainers() and the helpers that it uses.
+//
+// This code could break in future versions of Podman. This has been tried with
+// v3.4.1.
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	bolt "go.etcd.io/bbolt"
+)
+
+const (
+	DefaultDBPath = "/var/lib/containers/storage/libpod/bolt_state.db"
+	ctrName       = "ctr"
+	allCtrsName   = "all-ctrs"
+	configName    = "config"
+	stateName     = "state"
+)
+
+var (
+	ctrBkt     = []byte(ctrName)
+	allCtrsBkt = []byte(allCtrsName)
+	configKey  = []byte(configName)
+	stateKey   = []byte(stateName)
+)
+
+type DBClient struct {
+	DBPath string
+}
+
+// NewDBClient returns a DB client that uses the DB stored in dbPath. If dbPath
+// is empty, it uses the default path.
+func NewDBClient(dbPath string) *DBClient {
+	if dbPath == "" {
+		dbPath = DefaultDBPath
+	}
+
+	return &DBClient{
+		DBPath: dbPath,
+	}
+}
+
+// GetAllContainers returns all the containers present in the DB
+func (client *DBClient) GetAllContainers() ([]Container, error) {
+	var res []Container
+
+	db, err := client.getDBCon()
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		if errClose := db.Close(); errClose != nil {
+			log.Warnf("failed to close libpod db: %q", err)
+		}
+	}()
+
+	err = db.View(func(tx *bolt.Tx) error {
+		allCtrsBucket, err := getAllCtrsBucket(tx)
+		if err != nil {
+			return err
+		}
+
+		ctrBucket, err := getCtrBucket(tx)
+		if err != nil {
+			return err
+		}
+
+		return allCtrsBucket.ForEach(func(id, name []byte) error {
+			// If performance becomes an issue, this check can be
+			// removed. But the error messages that come back will
+			// be much less helpful.
+			ctrExists := ctrBucket.Bucket(id)
+			if ctrExists == nil {
+				return fmt.Errorf("state is inconsistent - container ID %s in all containers, but container not found", string(id))
+			}
+
+			rawContainerConfig, err := getContainerConfigFromDB(id, ctrBucket)
+			if err != nil {
+				return fmt.Errorf("error retrieving container %s from the database: %v", string(id), err)
+			}
+
+			var containerConfig ContainerConfig
+			if err := json.Unmarshal(rawContainerConfig, &containerConfig); err != nil {
+				return fmt.Errorf("error unmarshalling container config: %s", err)
+			}
+
+			rawContainerState, err := getContainerStateFromDB(id, ctrBucket)
+			if err != nil {
+				return fmt.Errorf("error retrieving container %s from the database: %v", string(id), err)
+			}
+
+			var containerState ContainerState
+			if err := json.Unmarshal(rawContainerState, &containerState); err != nil {
+				return fmt.Errorf("error unmarshalling container config: %s", err)
+			}
+
+			res = append(res, Container{
+				Config: &containerConfig,
+				State:  &containerState,
+			})
+
+			return nil
+		})
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}
+
+func (client *DBClient) getDBCon() (*bolt.DB, error) {
+	db, err := bolt.Open(client.DBPath, 0600, nil)
+	if err != nil {
+		return nil, fmt.Errorf("error opening database %s", client.DBPath)
+	}
+
+	return db, nil
+}
+
+func getCtrBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
+	bkt := tx.Bucket(ctrBkt)
+	if bkt == nil {
+		return nil, errors.New("containers bucket not found in DB")
+	}
+	return bkt, nil
+}
+
+func getAllCtrsBucket(tx *bolt.Tx) (*bolt.Bucket, error) {
+	bkt := tx.Bucket(allCtrsBkt)
+	if bkt == nil {
+		return nil, errors.New("all containers bucket not found in DB")
+	}
+	return bkt, nil
+}
+
+func getContainerConfigFromDB(id []byte, ctrsBkt *bolt.Bucket) ([]byte, error) {
+	ctrBkt := ctrsBkt.Bucket(id)
+	if ctrBkt == nil {
+		return nil, fmt.Errorf("container %s not found in DB", string(id))
+	}
+
+	configBytes := ctrBkt.Get(configKey)
+	if configBytes == nil {
+		return nil, fmt.Errorf("container %s missing config key in DB", string(id))
+	}
+
+	return configBytes, nil
+}
+
+func getContainerStateFromDB(id []byte, ctrsBkt *bolt.Bucket) ([]byte, error) {
+	ctrBkt := ctrsBkt.Bucket(id)
+	if ctrBkt == nil {
+		return nil, fmt.Errorf("container %s not found in DB", string(id))
+	}
+
+	stateBytes := ctrBkt.Get(stateKey)
+	if stateBytes == nil {
+		return nil, fmt.Errorf("container %s missing state key in DB", string(id))
+	}
+
+	return stateBytes, nil
+}

--- a/pkg/workloadmeta/collectors/collectors.go
+++ b/pkg/workloadmeta/collectors/collectors.go
@@ -16,4 +16,5 @@ import (
 	_ "github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/ecsfargate"
 	_ "github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/kubelet"
 	_ "github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/kubemetadata"
+	_ "github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/podman"
 )

--- a/pkg/workloadmeta/collectors/podman/podman.go
+++ b/pkg/workloadmeta/collectors/podman/podman.go
@@ -1,0 +1,181 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build podman
+// +build podman
+
+package podman
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	dderrors "github.com/DataDog/datadog-agent/pkg/errors"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/podman"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/util"
+)
+
+const (
+	collectorID   = "podman"
+	componentName = "workloadmeta-podman"
+	expireFreq    = 10 * time.Second
+)
+
+type podmanClient interface {
+	GetAllContainers() ([]podman.Container, error)
+}
+
+type collector struct {
+	client podmanClient
+	store  workloadmeta.Store
+	expire *util.Expire
+}
+
+func init() {
+	workloadmeta.RegisterCollector(collectorID, func() workloadmeta.Collector {
+		return &collector{}
+	})
+}
+
+func (c *collector) Start(_ context.Context, store workloadmeta.Store) error {
+	if !config.IsFeaturePresent(config.Podman) {
+		return dderrors.NewDisabled(componentName, "Podman not detected")
+	}
+
+	c.client = podman.NewDBClient(podman.DefaultDBPath)
+	c.store = store
+	c.expire = util.NewExpire(expireFreq)
+
+	return nil
+}
+
+func (c *collector) Pull(_ context.Context) error {
+	containers, err := c.client.GetAllContainers()
+	if err != nil {
+		return err
+	}
+
+	var events []workloadmeta.CollectorEvent
+
+	for _, container := range containers {
+		event := convertToEvent(&container)
+		c.expire.Update(event.Entity.GetID(), time.Now())
+		events = append(events, event)
+	}
+
+	events = append(events, c.expiredEvents()...)
+
+	c.store.Notify(events)
+
+	return nil
+}
+
+func convertToEvent(container *podman.Container) workloadmeta.CollectorEvent {
+	containerID := container.Config.ID
+
+	var annotations map[string]string
+	if spec := container.Config.Spec; spec != nil {
+		annotations = spec.Annotations
+	}
+
+	envs, err := envVars(container)
+	if err != nil {
+		log.Warnf("Could not get env vars for container %s", containerID)
+	}
+
+	image, err := workloadmeta.NewContainerImage(container.Config.RawImageName)
+	if err != nil {
+		log.Warnf("Could not get image for container %s", containerID)
+	}
+
+	var ports []workloadmeta.ContainerPort
+	for _, portMapping := range container.Config.PortMappings {
+		ports = append(ports, workloadmeta.ContainerPort{
+			Port:     int(portMapping.ContainerPort),
+			Protocol: portMapping.Protocol,
+		})
+	}
+
+	return workloadmeta.CollectorEvent{
+		Type:   workloadmeta.EventTypeSet,
+		Source: workloadmeta.SourcePodman,
+		Entity: &workloadmeta.Container{
+			EntityID: workloadmeta.EntityID{
+				Kind: workloadmeta.KindContainer,
+				ID:   containerID,
+			},
+			EntityMeta: workloadmeta.EntityMeta{
+				Name:        container.Config.Name,
+				Namespace:   container.Config.Namespace,
+				Annotations: annotations,
+				Labels:      container.Config.Labels,
+			},
+			EnvVars:    envs,
+			Hostname:   hostname(container),
+			Image:      image,
+			NetworkIPs: make(map[string]string), // I think there's no way to get this mapping
+			PID:        container.State.PID,
+			Ports:      ports,
+			Runtime:    workloadmeta.ContainerRuntimePodman,
+			State: workloadmeta.ContainerState{
+				Running:    container.State.State == podman.ContainerStateRunning,
+				StartedAt:  container.State.StartedTime,
+				FinishedAt: container.State.FinishedTime,
+			},
+		},
+	}
+}
+
+func (c *collector) expiredEvents() []workloadmeta.CollectorEvent {
+	var res []workloadmeta.CollectorEvent
+
+	for _, expired := range c.expire.ComputeExpires() {
+		res = append(res, workloadmeta.CollectorEvent{
+			Type:   workloadmeta.EventTypeUnset,
+			Source: workloadmeta.SourcePodman,
+			Entity: expired,
+		})
+	}
+
+	return res
+}
+
+func envVars(container *podman.Container) (map[string]string, error) {
+	res := make(map[string]string)
+
+	if container.Config.Spec == nil || container.Config.Spec.Process == nil {
+		return res, nil
+	}
+
+	for _, env := range container.Config.Spec.Process.Env {
+		envSplit := strings.SplitN(env, "=", 2)
+
+		if len(envSplit) < 2 {
+			return nil, errors.New("unexpected environment variable format")
+		}
+
+		res[envSplit[0]] = envSplit[1]
+	}
+
+	return res, nil
+}
+
+// This function has been copied from
+// https://github.com/containers/podman/blob/v3.4.1/libpod/container.go
+func hostname(container *podman.Container) string {
+	if container.Config.Spec.Hostname != "" {
+		return container.Config.Spec.Hostname
+	}
+
+	if len(container.Config.ID) < 11 {
+		return container.Config.ID
+	}
+	return container.Config.ID[:12]
+}

--- a/pkg/workloadmeta/collectors/podman/podman_test.go
+++ b/pkg/workloadmeta/collectors/podman/podman_test.go
@@ -1,0 +1,280 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build podman
+// +build podman
+
+package podman
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cri-o/ocicni/pkg/ocicni"
+	"github.com/opencontainers/runtime-spec/specs-go"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/util/podman"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta/collectors/util"
+)
+
+type fakeWorkloadmetaStore struct {
+	workloadmeta.Store
+	notifiedEvents []workloadmeta.CollectorEvent
+}
+
+func (store *fakeWorkloadmetaStore) Notify(events []workloadmeta.CollectorEvent) {
+	store.notifiedEvents = append(store.notifiedEvents, events...)
+}
+
+type fakePodmanClient struct {
+	mockGetAllContainers func() ([]podman.Container, error)
+}
+
+func (client *fakePodmanClient) GetAllContainers() ([]podman.Container, error) {
+	return client.mockGetAllContainers()
+}
+
+func TestPull(t *testing.T) {
+	startTime := time.Now()
+
+	containers := []podman.Container{
+		{
+			Config: &podman.ContainerConfig{
+				Spec: &specs.Spec{
+					Process: &specs.Process{
+						Env: []string{"TEST_ENV=TEST_VAL"},
+					},
+					Hostname: "agent",
+					Annotations: map[string]string{
+						"some-annotation":  "some-value",
+						"other-annotation": "other-value",
+					},
+				},
+				ID:           "123",
+				Name:         "dd-agent",
+				Namespace:    "default",
+				RawImageName: "docker.io/datadog/agent:latest",
+				ContainerNetworkConfig: podman.ContainerNetworkConfig{
+					PortMappings: []ocicni.PortMapping{
+						{
+							HostPort:      1000,
+							ContainerPort: 2000,
+							Protocol:      "tcp",
+						},
+					},
+				},
+				ContainerMiscConfig: podman.ContainerMiscConfig{
+					Labels: map[string]string{
+						"label-a": "value-a",
+						"label-b": "value-b",
+					},
+				},
+			},
+			State: &podman.ContainerState{
+				State:       podman.ContainerStateRunning,
+				StartedTime: startTime,
+				PID:         10,
+			},
+		},
+		{
+			Config: &podman.ContainerConfig{
+				Spec: &specs.Spec{
+					Process: &specs.Process{
+						Env: []string{"SOME_ENV=SOME_VAL"},
+					},
+					Hostname: "agent-dev",
+					Annotations: map[string]string{
+						"annotation-a": "value-a",
+						"annotation-b": "value-b",
+					},
+				},
+				ID:           "124",
+				Name:         "dd-agent-dev",
+				Namespace:    "dev",
+				RawImageName: "docker.io/datadog/agent-dev:latest",
+				ContainerNetworkConfig: podman.ContainerNetworkConfig{
+					PortMappings: []ocicni.PortMapping{
+						{
+							HostPort:      2000,
+							ContainerPort: 3000,
+							Protocol:      "tcp",
+						},
+					},
+				},
+				ContainerMiscConfig: podman.ContainerMiscConfig{
+					Labels: map[string]string{
+						"label-a-dev": "value-a-dev",
+						"label-b-dev": "value-b-dev",
+					},
+				},
+			},
+			State: &podman.ContainerState{
+				State:       podman.ContainerStateRunning,
+				StartedTime: startTime,
+				PID:         11,
+			},
+		},
+	}
+
+	// Defined based on the containers above
+	expectedEvents := []workloadmeta.CollectorEvent{
+		{
+			Type:   workloadmeta.EventTypeSet,
+			Source: workloadmeta.SourcePodman,
+			Entity: &workloadmeta.Container{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindContainer,
+					ID:   "123",
+				},
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:      "dd-agent",
+					Namespace: "default",
+					Annotations: map[string]string{
+						"some-annotation":  "some-value",
+						"other-annotation": "other-value",
+					},
+					Labels: map[string]string{
+						"label-a": "value-a",
+						"label-b": "value-b",
+					},
+				},
+				EnvVars: map[string]string{
+					"TEST_ENV": "TEST_VAL",
+				},
+				Hostname: "agent",
+				Image: workloadmeta.ContainerImage{
+					RawName:   "docker.io/datadog/agent:latest",
+					Name:      "docker.io/datadog/agent",
+					ShortName: "agent",
+					Tag:       "latest",
+				},
+				NetworkIPs: make(map[string]string),
+				PID:        10,
+				Ports: []workloadmeta.ContainerPort{
+					{
+						Port:     2000,
+						Protocol: "tcp",
+					},
+				},
+				Runtime: workloadmeta.ContainerRuntimePodman,
+				State: workloadmeta.ContainerState{
+					Running:   true,
+					StartedAt: startTime,
+				},
+			},
+		},
+		{
+			Type:   workloadmeta.EventTypeSet,
+			Source: workloadmeta.SourcePodman,
+			Entity: &workloadmeta.Container{
+				EntityID: workloadmeta.EntityID{
+					Kind: workloadmeta.KindContainer,
+					ID:   "124",
+				},
+				EntityMeta: workloadmeta.EntityMeta{
+					Name:      "dd-agent-dev",
+					Namespace: "dev",
+					Annotations: map[string]string{
+						"annotation-a": "value-a",
+						"annotation-b": "value-b",
+					},
+					Labels: map[string]string{
+						"label-a-dev": "value-a-dev",
+						"label-b-dev": "value-b-dev",
+					},
+				},
+				EnvVars: map[string]string{
+					"SOME_ENV": "SOME_VAL",
+				},
+				Hostname: "agent-dev",
+				Image: workloadmeta.ContainerImage{
+					RawName:   "docker.io/datadog/agent-dev:latest",
+					Name:      "docker.io/datadog/agent-dev",
+					ShortName: "agent-dev",
+					Tag:       "latest",
+				},
+				NetworkIPs: make(map[string]string),
+				PID:        11,
+				Ports: []workloadmeta.ContainerPort{
+					{
+						Port:     3000,
+						Protocol: "tcp",
+					},
+				},
+				Runtime: workloadmeta.ContainerRuntimePodman,
+				State: workloadmeta.ContainerState{
+					Running:   true,
+					StartedAt: startTime,
+				},
+			},
+		},
+	}
+
+	client := fakePodmanClient{
+		mockGetAllContainers: func() ([]podman.Container, error) {
+			return containers, nil
+		},
+	}
+
+	cacheWithExpired := util.NewExpire(1 * time.Second)
+	expiredID := "1"
+	cacheWithExpired.Update(workloadmeta.EntityID{
+		Kind: workloadmeta.KindContainer,
+		ID:   expiredID,
+	}, time.Now().Add(-1*time.Hour)) // Expired because 1 hour > 10s defined above
+
+	// The cache is initialized with a "lastExpire" that equals time.Now, and
+	// the caller has no control over it. When calculating the expired entities,
+	// it first checks that the last expire happen at least TTL seconds ago.
+	// That's why here we need to sleep at least for the TTL defined (1 second
+	// in this case).
+	time.Sleep(1 * time.Second)
+
+	tests := []struct {
+		name           string
+		client         podmanClient
+		cache          *util.Expire
+		expectedEvents []workloadmeta.CollectorEvent
+	}{
+		{
+			name:           "without expired entities",
+			client:         &client,
+			cache:          util.NewExpire(10 * time.Second),
+			expectedEvents: expectedEvents,
+		},
+		{
+			name:   "with expired entities",
+			client: &client,
+			cache:  cacheWithExpired,
+			expectedEvents: append(expectedEvents, workloadmeta.CollectorEvent{
+				Type:   workloadmeta.EventTypeUnset,
+				Source: workloadmeta.SourcePodman,
+				Entity: workloadmeta.EntityID{
+					Kind: workloadmeta.KindContainer,
+					ID:   expiredID,
+				},
+			}),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			workloadmetaStore := fakeWorkloadmetaStore{}
+			podmanCollector := collector{
+				client: test.client,
+				store:  &workloadmetaStore,
+				expire: test.cache,
+			}
+
+			err := podmanCollector.Pull(context.TODO())
+
+			assert.NoError(t, err)
+			assert.Equal(t, test.expectedEvents, workloadmetaStore.notifiedEvents)
+		})
+	}
+}

--- a/pkg/workloadmeta/collectors/podman/stub.go
+++ b/pkg/workloadmeta/collectors/podman/stub.go
@@ -1,0 +1,6 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package podman

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -61,9 +61,11 @@ const (
 	SourceECSFargate   Source = "ecs_fargate"
 	SourceKubelet      Source = "kubelet"
 	SourceKubeMetadata Source = "kube_metadata"
+	SourcePodman       Source = "podman"
 
 	ContainerRuntimeDocker     ContainerRuntime = "docker"
 	ContainerRuntimeContainerd ContainerRuntime = "containerd"
+	ContainerRuntimePodman     ContainerRuntime = "podman"
 
 	ECSLaunchTypeEC2     ECSLaunchType = "ec2"
 	ECSLaunchTypeFargate ECSLaunchType = "fargate"

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -27,6 +27,7 @@ ALL_TAGS = {
     "netcgo",  # Force the use of the CGO resolver. This will also have the effect of making the binary non-static
     "npm",
     "orchestrator",
+    "podman",
     "process",
     "python",
     "secrets",
@@ -53,6 +54,7 @@ AGENT_TAGS = {
     "kubelet",
     "netcgo",
     "orchestrator",
+    "podman",
     "process",
     "python",
     "secrets",
@@ -71,7 +73,7 @@ CLUSTER_AGENT_TAGS = {"clusterchecks", "kubeapiserver", "orchestrator", "secrets
 CLUSTER_AGENT_CLOUDFOUNDRY_TAGS = {"clusterchecks", "secrets"}
 
 # DOGSTATSD_TAGS lists the tags needed when building dogstatsd
-DOGSTATSD_TAGS = {"containerd", "docker", "kubelet", "secrets", "zlib"}
+DOGSTATSD_TAGS = {"containerd", "docker", "kubelet", "podman", "secrets", "zlib"}
 
 # IOT_AGENT_TAGS lists the tags needed when building the IoT agent
 IOT_AGENT_TAGS = {"jetson", "systemd", "zlib"}
@@ -80,13 +82,13 @@ IOT_AGENT_TAGS = {"jetson", "systemd", "zlib"}
 PROCESS_AGENT_TAGS = AGENT_TAGS.union({"clusterchecks", "fargateprocess", "orchestrator"})
 
 # SECURITY_AGENT_TAGS lists the tags necessary to build the security agent
-SECURITY_AGENT_TAGS = {"netcgo", "secrets", "docker", "containerd", "kubeapiserver", "kubelet"}
+SECURITY_AGENT_TAGS = {"netcgo", "secrets", "docker", "containerd", "kubeapiserver", "kubelet", "podman"}
 
 # SYSTEM_PROBE_TAGS lists the tags necessary to build system-probe
 SYSTEM_PROBE_TAGS = AGENT_TAGS.union({"clusterchecks", "linux_bpf", "npm"})
 
 # TRACE_AGENT_TAGS lists the tags that have to be added when the trace-agent
-TRACE_AGENT_TAGS = {"docker", "containerd", "kubeapiserver", "kubelet", "netcgo", "secrets"}
+TRACE_AGENT_TAGS = {"docker", "containerd", "kubeapiserver", "kubelet", "netcgo", "podman", "secrets"}
 
 # TEST_TAGS lists the tags that have to be added to run tests
 TEST_TAGS = AGENT_TAGS.union({"clusterchecks"})
@@ -94,7 +96,7 @@ TEST_TAGS = AGENT_TAGS.union({"clusterchecks"})
 ### Tag exclusion lists
 
 # List of tags to always remove when not building on Linux
-LINUX_ONLY_TAGS = {"cri", "netcgo", "systemd", "jetson", "linux_bpf"}
+LINUX_ONLY_TAGS = {"cri", "netcgo", "systemd", "jetson", "linux_bpf", "podman"}
 
 # List of tags to always remove when building on Windows
 WINDOWS_EXCLUDE_TAGS = {"linux_bpf"}


### PR DESCRIPTION
### What does this PR do?

Adds a Podman collector for the workloadmeta store.

### Additional Notes

Please note that this PR does not require Podman as a dependency in `go.mod`. The reason is that the podman package mixes client and server side, and as a result, brings a lot of dependencies that we don't need. Some of those can be problematic, like the go-systemd one (See https://github.com/DataDog/datadog-agent/pull/9865).

We just need to fetch the existing containers from the DB. That's a very small subset of all the features offered by the Podman package. That's why instead of requiring the podman package, I've copied and adapted the relevant bits for our use case in `pkg/util/podman`. That package contains documentation about what has been copied and modified from the podman repository.

Note that this PR only adds a collector for the workloadmeta store. In future PRs we can add:
- Autodiscovery support.
- A collector for the new "generic" container check.
- Support for pods. For now the collector only works with containers.

### Describe how to test/QA your changes

You'll need a host with podman installed. I use `podman machine` for that. See the instructions: https://podman.io/getting-started/installation#podman-installation-instructions

Run the agent with podman as you would with Docker. The only difference is that you'll need to mount the path where Podman stores its DB: `-v /var/lib/containers/:/var/lib/containers/`. Check:
- Run `agent workload-list` and check that the info of the containers that you have deployed appears there and looks correct.
- Run `agent tagger-list` and check that your containers appear there with the correct ID, name, and image information.

You can also check that when `/var/lib/containers` is not mounted, the Podman collector does not run and the commands above should not show information about the containers deployed with Podman.


<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
