### PR TITLE
[logs-agent] Handle multiple EventTypeSet for a single entity

### DIFF
--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -199,6 +199,10 @@ func (s *Scheduler) handleWorkloadMetaSetEvent(e workloadmeta.Event, creationTim
 	var svc *service.Service
 	switch container.Runtime {
 	case workloadmeta.ContainerRuntimeDocker:
+		if _, exists := s.addedServices[e.Entity.GetID()]; exists {
+			// container already has a service
+			return
+		}
 		svc = service.NewService(config.DockerType, container.ID, creationTime)
 	default:
 		// unknown runtime, so no logging

--- a/pkg/workloadmeta/store.go
+++ b/pkg/workloadmeta/store.go
@@ -184,7 +184,7 @@ func (s *store) Start(ctx context.Context) {
 // as they happen. On first subscription, it will also generate an EventTypeSet
 // event for each entity present in the store that matches filter.
 //
-// Any time an entity changes, a new EventTypeSet event will be set, so mulitple
+// Any time an entity changes, a new EventTypeSet event will be set, so multiple
 // events may be received for each entity.
 func (s *store) Subscribe(name string, filter *Filter) chan EventBundle {
 	// ch needs to be buffered since we'll send it events before the

--- a/pkg/workloadmeta/store.go
+++ b/pkg/workloadmeta/store.go
@@ -183,6 +183,9 @@ func (s *store) Start(ctx context.Context) {
 // Subscribe returns a channel where workload metadata events will be streamed
 // as they happen. On first subscription, it will also generate an EventTypeSet
 // event for each entity present in the store that matches filter.
+//
+// Any time an entity changes, a new EventTypeSet event will be set, so mulitple
+// events may be received for each entity.
 func (s *store) Subscribe(name string, filter *Filter) chan EventBundle {
 	// ch needs to be buffered since we'll send it events before the
 	// subscriber has the chance to start receiving from it. if it's


### PR DESCRIPTION
### What does this PR do?

This handles EventTypeSet messages for containers for which there is already a logs service.  It's normal for the workloadmeta store to send multiple such events for a container, as it changes.  That's now documented on the Subscribe method.

### Motivation

The logs agent actually detects this situation later in the process, issuing a warning message:
```
2021-11-15 12:25:36 UTC | CORE | WARN | (pkg/logs/input/docker/launcher.go:376 in startSocketTailer) | Can't tail twice the same container: 57ad380e3812
```

This is a "this should never happen" kind of message, so it's too late to catch the situation.  This PR catches it at the right place.

### Describe how to test/QA your changes

Existing QA for the logs agent in this release is adequate.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
