### PR TITLE
[Serverless] Rewrite service in trace

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -226,6 +226,7 @@ func (a *Agent) Process(p *api.Payload) {
 			for k, v := range a.conf.GlobalTags {
 				traceutil.SetMeta(span, k, v)
 			}
+			a.rewriteServerlessService(span)
 			a.obfuscator.Obfuscate(span)
 			Truncate(span)
 			if p.ClientComputedTopLevel {
@@ -465,4 +466,13 @@ func newEventProcessor(conf *config.AgentConfig) *event.Processor {
 // SetGlobalTagsUnsafe sets global tags to the agent configuration. Unsafe for concurrent use.
 func (a *Agent) SetGlobalTagsUnsafe(tags map[string]string) {
 	a.conf.GlobalTags = tags
+}
+
+func (a *Agent) rewriteServerlessService(span *pb.Span) {
+	if span.Service == "aws.lambda" {
+		service := a.conf.GlobalTags["service"]
+		if len(service) > 0 {
+			span.Service = service
+		}
+	}
 }

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -469,7 +469,7 @@ func (a *Agent) SetGlobalTagsUnsafe(tags map[string]string) {
 }
 
 func (a *Agent) rewriteServerlessService(span *pb.Span) {
-	if span.Service == "aws.lambda" {
+	if span.Service == "aws.lambda" && a.conf.GlobalTags != nil {
 		service := a.conf.GlobalTags["service"]
 		if len(service) > 0 {
 			span.Service = service

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -323,6 +323,41 @@ func TestProcess(t *testing.T) {
 		assert.Equal(t, "something_that_should_be_a_metric", span.Service)
 	})
 
+	t.Run("serverlessServiceRewrite", func(t *testing.T) {
+		cfg := config.New()
+		cfg.GlobalTags = map[string]string{
+			"service": "myTestService",
+		}
+		cfg.Endpoints[0].APIKey = "test"
+		ctx, cancel := context.WithCancel(context.Background())
+		agnt := NewAgent(ctx, cfg)
+		defer cancel()
+
+		traces := pb.Traces{{{
+			Service:  "aws.lambda",
+			TraceID:  1,
+			SpanID:   1,
+			Resource: "my test resource",
+			Start:    time.Now().Add(-time.Second).UnixNano(),
+			Duration: (500 * time.Millisecond).Nanoseconds(),
+			Metrics:  map[string]float64{sampler.KeySamplingPriority: 2},
+		}}}
+
+		go agnt.Process(&api.Payload{
+			Traces: traces,
+			Source: agnt.Receiver.Stats.GetTagStats(info.Tags{}),
+		})
+		timeout := time.After(2 * time.Second)
+		var span *pb.Span
+		select {
+		case ss := <-agnt.TraceWriter.In:
+			span = ss.Traces[0].Spans[0]
+		case <-timeout:
+			t.Fatal("timed out")
+		}
+		assert.Equal(t, "myTestService", span.Service)
+	})
+
 	t.Run("chunking", func(t *testing.T) {
 		cfg := config.New()
 		cfg.Endpoints[0].APIKey = "test"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Rewrite the service name to the correct value if it has been incorrectly set to "aws.lambda" and if a service name has been detected

### Motivation

Bug

### Describe how to test/QA your changes

Here is the resulting change before/after the fix

<img width="557" alt="Screen Shot 2021-11-16 at 10 58 18 AM" src="https://user-images.githubusercontent.com/864493/141964213-c6018e26-c5c3-4957-ac16-f0e2fd48e7b8.png">

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
