### PR TITLE
[pkg/config] Set all OTLP config fields as known

### DIFF
--- a/pkg/config/otlp.go
+++ b/pkg/config/otlp.go
@@ -23,8 +23,13 @@ func SetupOTLP(config Config) {
 	config.BindEnvAndSetDefault(ExperimentalOTLPTracePort, 5003)
 	config.BindEnvAndSetDefault(ExperimentalOTLPMetricsEnabled, true)
 	config.BindEnvAndSetDefault(ExperimentalOTLPTracesEnabled, true)
-	config.SetKnown(ExperimentalOTLPMetrics)
 	config.BindEnv(ExperimentalOTLPHTTPPort, "DD_OTLP_HTTP_PORT")
 	config.BindEnv(ExperimentalOTLPgRPCPort, "DD_OTLP_GRPC_PORT")
+
+	config.SetKnown(ExperimentalOTLPMetrics)
+	// Set all subkeys of experimental.otlp.metrics as known
+	config.SetKnown(ExperimentalOTLPMetrics + ".*")
 	config.SetKnown(ExperimentalOTLPReceiverSection)
+	// Set all subkeys of experimental.otlp.receiver as known
+	config.SetKnown(ExperimentalOTLPReceiverSection + ".*")
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Sets all OTLP config fields in `experimental.otlp.metrics` and `experimental.otlp.receiver` as known.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Discovered during 7.33.0 QA.
Avoid warning logs when setting OTLP configuration.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Check that no warning logs appear in the next RCs when setting OTLP config.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
