### PR TITLE
[gitlab] Fix owner detection for uploaded test results

### DIFF
--- a/tasks/libs/junit_upload.py
+++ b/tasks/libs/junit_upload.py
@@ -24,7 +24,9 @@ def split_junitxml(xml_path, codeowners, output_dir):
     for suite in tree.iter("testsuite"):
         path = suite.attrib["name"].replace(REPO_NAME_PREFIX, "", 1)
 
-        owners = codeowners.of(path)
+        # Dirs in CODEOWNERS might end with "/", but testuite names in JUnit XML
+        # don't, so for determining ownership we append "/" temporarily.
+        owners = codeowners.of(path + "/")
         if not owners:
             raise KeyError("No code owner found for {}".format(path))
 

--- a/tasks/libs/junit_upload.py
+++ b/tasks/libs/junit_upload.py
@@ -24,7 +24,7 @@ def split_junitxml(xml_path, codeowners, output_dir):
     for suite in tree.iter("testsuite"):
         path = suite.attrib["name"].replace(REPO_NAME_PREFIX, "", 1)
 
-        # Dirs in CODEOWNERS might end with "/", but testuite names in JUnit XML
+        # Dirs in CODEOWNERS might end with "/", but testsuite names in JUnit XML
         # don't, so for determining ownership we append "/" temporarily.
         owners = codeowners.of(path + "/")
         if not owners:


### PR DESCRIPTION
### What does this PR do?

Directoriess in `CODEOWNERS` might end with `/`, but testuite names in JUnit XML don't, so for determining ownership we append `/` temporarily to testsuite path.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
