### PR TITLE
[AD, tagger] Refer to containers by the orchestrator name instead of runtime

### DIFF
--- a/pkg/autodiscovery/listeners/kubelet_test.go
+++ b/pkg/autodiscovery/listeners/kubelet_test.go
@@ -18,11 +18,12 @@ import (
 )
 
 const (
-	containerID   = "foobarquux"
-	containerName = "agent"
-	podID         = "foobar"
-	podName       = "datadog-agent-foobar"
-	podNamespace  = "default"
+	containerID          = "foobarquux"
+	containerName        = "agent"
+	runtimeContainerName = "k8s_datadog-agent_agent"
+	podID                = "foobar"
+	podName              = "datadog-agent-foobar"
+	podNamespace         = "default"
 )
 
 func TestKubeletCreatePodService(t *testing.T) {
@@ -137,7 +138,12 @@ func TestKubeletCreateContainerService(t *testing.T) {
 	}
 
 	containerEntityMeta := workloadmeta.EntityMeta{
-		Name: containerName,
+		Name: runtimeContainerName,
+	}
+
+	imageWithShortname := workloadmeta.ContainerImage{
+		RawName:   "gcr.io/foobar:latest",
+		ShortName: "foobar",
 	}
 
 	basicImage := workloadmeta.ContainerImage{
@@ -148,10 +154,7 @@ func TestKubeletCreateContainerService(t *testing.T) {
 	basicContainer := &workloadmeta.Container{
 		EntityID:   containerEntityID,
 		EntityMeta: containerEntityMeta,
-		Image: workloadmeta.ContainerImage{
-			RawName:   "gcr.io/foobar:latest",
-			ShortName: "foobar",
-		},
+		Image:      imageWithShortname,
 		State: workloadmeta.ContainerState{
 			Running: true,
 		},
@@ -201,12 +204,18 @@ func TestKubeletCreateContainerService(t *testing.T) {
 	tests := []struct {
 		name             string
 		pod              *workloadmeta.KubernetesPod
+		podContainer     *workloadmeta.OrchestratorContainer
 		container        *workloadmeta.Container
 		expectedServices map[string]wlmListenerSvc
 	}{
 		{
-			name:      "basic container setup",
-			pod:       pod,
+			name: "basic container setup",
+			pod:  pod,
+			podContainer: &workloadmeta.OrchestratorContainer{
+				ID:    containerID,
+				Name:  containerName,
+				Image: imageWithShortname,
+			},
 			container: basicContainer,
 			expectedServices: map[string]wlmListenerSvc{
 				"container://foobarquux": {
@@ -236,6 +245,11 @@ func TestKubeletCreateContainerService(t *testing.T) {
 			name:      "recently stopped container excludes metrics but not logs",
 			pod:       pod,
 			container: recentlyStoppedContainer,
+			podContainer: &workloadmeta.OrchestratorContainer{
+				ID:    containerID,
+				Name:  containerName,
+				Image: basicImage,
+			},
 			expectedServices: map[string]wlmListenerSvc{
 				"container://foobarquux": {
 					parent: "kubernetes_pod://foobar",
@@ -263,6 +277,11 @@ func TestKubeletCreateContainerService(t *testing.T) {
 		{
 			name: "old stopped container does not get collected",
 			pod:  pod,
+			podContainer: &workloadmeta.OrchestratorContainer{
+				ID:    containerID,
+				Name:  containerName,
+				Image: basicImage,
+			},
 			container: &workloadmeta.Container{
 				EntityID:   containerEntityID,
 				EntityMeta: containerEntityMeta,
@@ -275,8 +294,13 @@ func TestKubeletCreateContainerService(t *testing.T) {
 			expectedServices: map[string]wlmListenerSvc{},
 		},
 		{
-			name:      "container with multiple ports collects them in ascending order",
-			pod:       pod,
+			name: "container with multiple ports collects them in ascending order",
+			pod:  pod,
+			podContainer: &workloadmeta.OrchestratorContainer{
+				ID:    containerID,
+				Name:  containerName,
+				Image: basicImage,
+			},
 			container: multiplePortsContainer,
 			expectedServices: map[string]wlmListenerSvc{
 				"container://foobarquux": {
@@ -311,8 +335,13 @@ func TestKubeletCreateContainerService(t *testing.T) {
 			},
 		},
 		{
-			name:      "pod with custom check names and identifiers",
-			pod:       podWithAnnotations,
+			name: "pod with custom check names and identifiers",
+			pod:  podWithAnnotations,
+			podContainer: &workloadmeta.OrchestratorContainer{
+				ID:    containerID,
+				Name:  containerName,
+				Image: basicImage,
+			},
 			container: customIDsContainer,
 			expectedServices: map[string]wlmListenerSvc{
 				"container://foobarquux": {
@@ -345,12 +374,7 @@ func TestKubeletCreateContainerService(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			listener, wlm := newKubeletListener(t)
 
-			podContainer := &workloadmeta.OrchestratorContainer{
-				ID:    tt.container.ID,
-				Image: tt.container.Image,
-			}
-
-			listener.createContainerService(tt.pod, podContainer, tt.container, integration.After)
+			listener.createContainerService(tt.pod, tt.podContainer, tt.container, integration.After)
 
 			wlm.assertServices(tt.expectedServices)
 		})

--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -435,10 +435,11 @@ func (c *WorkloadMetaCollector) extractTagsFromPodContainer(pod *workloadmeta.Ku
 	tags.AddLow("image_id", image.ID)
 
 	// enrich with standard tags from labels for this container if present
+	containerName := podContainer.Name
 	standardTagKeys := map[string]string{
-		fmt.Sprintf(podStandardLabelPrefix+"%s.%s", container.Name, tagKeyEnv):     tagKeyEnv,
-		fmt.Sprintf(podStandardLabelPrefix+"%s.%s", container.Name, tagKeyVersion): tagKeyVersion,
-		fmt.Sprintf(podStandardLabelPrefix+"%s.%s", container.Name, tagKeyService): tagKeyService,
+		fmt.Sprintf(podStandardLabelPrefix+"%s.%s", containerName, tagKeyEnv):     tagKeyEnv,
+		fmt.Sprintf(podStandardLabelPrefix+"%s.%s", containerName, tagKeyVersion): tagKeyVersion,
+		fmt.Sprintf(podStandardLabelPrefix+"%s.%s", containerName, tagKeyService): tagKeyService,
 	}
 	c.extractFromMapWithFn(pod.Labels, standardTagKeys, tags.AddStandard)
 
@@ -446,7 +447,7 @@ func (c *WorkloadMetaCollector) extractTagsFromPodContainer(pod *workloadmeta.Ku
 	c.extractFromMapWithFn(container.EnvVars, standardEnvKeys, tags.AddStandard)
 
 	// container-specific tags provided through pod annotation
-	annotation := fmt.Sprintf(podContainerTagsAnnotationFormat, container.Name)
+	annotation := fmt.Sprintf(podContainerTagsAnnotationFormat, containerName)
 	c.extractTagsFromJSONInMap(annotation, pod.Annotations, tags)
 
 	low, orch, high, standard := tags.Compute()

--- a/pkg/tagger/collectors/workloadmeta_test.go
+++ b/pkg/tagger/collectors/workloadmeta_test.go
@@ -22,6 +22,7 @@ func TestHandleKubePod(t *testing.T) {
 		fullyFleshedContainerID = "foobarquux"
 		noEnvContainerID        = "foobarbaz"
 		containerName           = "agent"
+		runtimeContainerName    = "k8s_datadog-agent_agent"
 		podName                 = "datadog-agent-foobar"
 		podNamespace            = "default"
 		env                     = "production"
@@ -59,7 +60,7 @@ func TestHandleKubePod(t *testing.T) {
 			ID:   fullyFleshedContainerID,
 		},
 		EntityMeta: workloadmeta.EntityMeta{
-			Name: containerName,
+			Name: runtimeContainerName,
 		},
 		Image: image,
 		EnvVars: map[string]string{
@@ -74,7 +75,7 @@ func TestHandleKubePod(t *testing.T) {
 			ID:   noEnvContainerID,
 		},
 		EntityMeta: workloadmeta.EntityMeta{
-			Name: containerName,
+			Name: runtimeContainerName,
 		},
 	})
 
@@ -228,7 +229,7 @@ func TestHandleKubePod(t *testing.T) {
 					Entity: fullyFleshedContainerTaggerEntityID,
 					HighCardTags: []string{
 						fmt.Sprintf("container_id:%s", fullyFleshedContainerID),
-						fmt.Sprintf("display_container_name:%s_%s", containerName, podName),
+						fmt.Sprintf("display_container_name:%s_%s", runtimeContainerName, podName),
 					},
 					OrchestratorCardTags: []string{
 						fmt.Sprintf("pod_name:%s", podName),
@@ -283,7 +284,7 @@ func TestHandleKubePod(t *testing.T) {
 					Entity: noEnvContainerTaggerEntityID,
 					HighCardTags: []string{
 						fmt.Sprintf("container_id:%s", noEnvContainerID),
-						fmt.Sprintf("display_container_name:%s_%s", containerName, podName),
+						fmt.Sprintf("display_container_name:%s_%s", runtimeContainerName, podName),
 					},
 					OrchestratorCardTags: []string{
 						fmt.Sprintf("pod_name:%s", podName),


### PR DESCRIPTION
### What does this PR do?

Fixes both the kubelet AD and tagger, where they didn't refer to containers by the orchestrator name (ie, the name given to them by the user through the pod spec) and instead used the runtime name, which in docker is a different name because of namespacing issues. More information is available in the individual commits.

### Describe how to test/QA your changes

Get yourself a k8s cluster running on docker, and apply the following manifest:

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: redis
  namespace: default
spec:
  replicas: 1
  selector:
    matchLabels:
      app: redis
  template:
    metadata:
      labels:
        app: redis
      annotations:
        ad.datadoghq.com/redis.check_names: '["redisdb"]'
        ad.datadoghq.com/redis.init_configs: '[{}]'
        ad.datadoghq.com/redis.instances: |
          [
            {
              "host": "%%host%%",
              "port":"6379"
            }
          ]
        ad.datadoghq.com/redis.tags: '{"tag_key1":"tag_val1"}'
    spec:
      containers:
      - image: redis
        imagePullPolicy: Always
        name: redis
```

To test the AD changes, run `agent status`, check that there is in fact a redis check scheduled, and its configuration source is kubelet and not file. Also check that there is just *one* redis check, as previously two would be scheduled (one with file, one with kubelet as the source). This PR also fixes [inclusion/exclusion by container name](https://docs.datadoghq.com/agent/guide/autodiscovery-management/?tab=containerizedagent), so this needs to be tested as well.

To test the tagger changes, run `agent tagger-list`, and check that the redis container has the `tag_key1:tag_val1` tag applied correctly.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
