### PR TITLE
[tasks] fix cgo header line when running through a link

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -661,15 +661,18 @@ def generate_runtime_files(ctx):
         ctx.run("go generate -mod=mod -tags {tags} {file}".format(file=f, tags=BPF_TAG))
 
 
-def replace_cgo_tag_absolute_path(file_path, absolute_path, relative_path):
+def replace_cgo_tag_absolute_path(file_path):
     # read
     f = open(file_path)
     lines = []
     for line in f:
         if line.startswith("// cgo -godefs"):
-            lines.append(line.replace(absolute_path, relative_path))
-        else:
-            lines.append(line)
+            path = line.split()[-1]
+            if path.startswith("/"):
+                _, filename = os.path.split(path)
+                lines.append(line.replace(path, filename))
+                continue
+        lines.append(line)
     f.close()
 
     # write
@@ -695,7 +698,6 @@ def generate_cgo_types(ctx, windows=is_windows, replace_absolutes=True):
 
     for f in def_files:
         fdir, file = os.path.split(f)
-        absolute_input_file = os.path.abspath(f)
         base, _ = os.path.splitext(file)
         with ctx.cd(fdir):
             output_file = "{base}_{platform}.go".format(base=base, platform=platform)
@@ -705,7 +707,7 @@ def generate_cgo_types(ctx, windows=is_windows, replace_absolutes=True):
             ctx.run("gofmt -w -s {output_file}".format(output_file=output_file))
             if replace_absolutes:
                 # replace absolute path with relative ones in generated file
-                replace_cgo_tag_absolute_path(os.path.join(fdir, output_file), absolute_input_file, file)
+                replace_cgo_tag_absolute_path(os.path.join(fdir, output_file))
 
 
 def is_root():


### PR DESCRIPTION
### What does this PR do?

When generating in pwd containing a link, the absolute path generated by Go and by the python task could be different thus rendering the replacement ineffective.

This PR fixes this issue by simply extracting the filename of the path in the header comment.

### Describe how to test/QA your changes

This should be a no-op.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
