### PR TITLE
Add containerd build flags to trace-agent,security-agent and dogstatsd

### DIFF
--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -75,7 +75,7 @@ CLUSTER_AGENT_TAGS = set(["clusterchecks", "kubeapiserver", "orchestrator", "sec
 CLUSTER_AGENT_CLOUDFOUNDRY_TAGS = set(["clusterchecks", "secrets"])
 
 # DOGSTATSD_TAGS lists the tags needed when building dogstatsd
-DOGSTATSD_TAGS = set(["docker", "kubelet", "secrets", "zlib"])
+DOGSTATSD_TAGS = set(["containerd", "docker", "kubelet", "secrets", "zlib"])
 
 # IOT_AGENT_TAGS lists the tags needed when building the IoT agent
 IOT_AGENT_TAGS = set(["jetson", "systemd", "zlib"])
@@ -84,13 +84,13 @@ IOT_AGENT_TAGS = set(["jetson", "systemd", "zlib"])
 PROCESS_AGENT_TAGS = AGENT_TAGS.union(set(["clusterchecks", "fargateprocess", "orchestrator"]))
 
 # SECURITY_AGENT_TAGS lists the tags necessary to build the security agent
-SECURITY_AGENT_TAGS = set(["netcgo", "secrets", "docker", "kubeapiserver", "kubelet"])
+SECURITY_AGENT_TAGS = set(["netcgo", "secrets", "docker", "containerd", "kubeapiserver", "kubelet"])
 
 # SYSTEM_PROBE_TAGS lists the tags necessary to build system-probe
 SYSTEM_PROBE_TAGS = AGENT_TAGS.union(set(["clusterchecks", "linux_bpf", "npm"]))
 
 # TRACE_AGENT_TAGS lists the tags that have to be added when the trace-agent
-TRACE_AGENT_TAGS = set(["docker", "kubeapiserver", "kubelet", "netcgo", "secrets"])
+TRACE_AGENT_TAGS = set(["docker", "containerd", "kubeapiserver", "kubelet", "netcgo", "secrets"])
 
 # TEST_TAGS lists the tags that have to be added to run tests
 TEST_TAGS = AGENT_TAGS.union(set(["clusterchecks"]))

--- a/tasks/dogstatsd.py
+++ b/tasks/dogstatsd.py
@@ -26,7 +26,7 @@ from .utils import (
 # constants
 DOGSTATSD_BIN_PATH = os.path.join(".", "bin", "dogstatsd")
 STATIC_BIN_PATH = os.path.join(".", "bin", "static")
-MAX_BINARY_SIZE = 23 * 1024
+MAX_BINARY_SIZE = 30 * 1024
 DOGSTATSD_TAG = "datadog/dogstatsd:master"
 
 


### PR DESCRIPTION
### What does this PR do?

Add `containerd` build tags to any Agent that may use the Tagger. Currently there might be discrepancies between Agents if remote tagger is not used.

### Motivation

Bugfix. Following the addition of `containerd` tagger collector we did not adjust the build tags.

### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

Run the `trace-agent` on a VM with `containerd` standalone, send traces. The traces should be tagged with high cardinality tags (like `container_id`)

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
