### PR TITLE
[corechecks/snmp] Avoid replacing newlines and tabs for OctetString

### DIFF
--- a/pkg/collector/corechecks/snmp/gosnmplib/gosnmp_value.go
+++ b/pkg/collector/corechecks/snmp/gosnmplib/gosnmp_value.go
@@ -12,7 +12,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/valuestore"
 )
 
-var specialCharsStripper = strings.NewReplacer("\r", "", "\n", "", "\t", "")
 var strippableSpecialChars = map[byte]bool{'\r': true, '\n': true, '\t': true}
 
 // GetValueFromPDU converts gosnmp.SnmpPDU to ResultValue
@@ -38,7 +37,7 @@ func GetValueFromPDU(pduVariable gosnmp.SnmpPDU) (string, valuestore.ResultValue
 			// An alternative solution is to explicitly force the conversion to specific type using profile config.
 			value = fmt.Sprintf("%#x", bytesValue)
 		} else {
-			value = specialCharsStripper.Replace(string(bytesValue))
+			value = string(bytesValue)
 		}
 	case gosnmp.Integer, gosnmp.Counter32, gosnmp.Gauge32, gosnmp.TimeTicks, gosnmp.Counter64, gosnmp.Uinteger32:
 		value = float64(gosnmp.ToBigInt(pduVariable.Value).Int64())

--- a/pkg/collector/corechecks/snmp/gosnmplib/gosnmp_value_test.go
+++ b/pkg/collector/corechecks/snmp/gosnmplib/gosnmp_value_test.go
@@ -70,7 +70,7 @@ func Test_getValueFromPDU(t *testing.T) {
 				Value: []byte("m\ny\rV\ta\n\r\tl"),
 			},
 			"1.2.3",
-			valuestore.ResultValue{Value: "myVal"},
+			valuestore.ResultValue{Value: "m\ny\rV\ta\n\r\tl"},
 			nil,
 		},
 		{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[corechecks/snmp] Avoid replacing newlines and tabs

Bug fix for https://github.com/DataDog/datadog-agent/pull/9575

### Motivation

- we can let backend normalise strings e.g. if the string is used in tags, backend will normalise the tag value
- we likely not want new lines being replace by strings used for snmp metadata e.g. sysDescr. Even if there is a need to normalise, it's more appropriate for backend or UI to do it.


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->


TIP for QA: you can test this card by changing sysDescr to something like this that contains newlines:

```
1.3.6.1.2.1.1.1.0|4x|4c696e75782034316261393438393131623920342e392e38372d6c696e75786b69742d61756673206c696e6531aa6c696e6532
```
e.g. by modifying `public.snmprec` 

then adding this to `_base.yaml` in profiles:

```
metric_tags:
  - OID: 1.3.6.1.2.1.1.5.0
    symbol: sysName
    tag: snmp_host
  - OID: 1.3.6.1.2.1.1.1.0
    symbol: sysDescr
    tag: snmp_descr
```

When running `agent check snmp` you should see:
- unmodified newlines in snmp metadata
- unmodified newlines as tag value for `snmp_descr` 

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- test that newlines and tags are not stripped for snmp metadata e.g. use sysDesc
- test that newlines and tags are not stripped for snmp metric tags e.g. use sysDesc as tag

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
