### PR TITLE
update release.json for dca 1.16.0

### DIFF
--- a/release.json
+++ b/release.json
@@ -52,6 +52,9 @@
         "WINDOWS_DDNPM_VERSION": "1.2.1",
         "WINDOWS_DDNPM_SHASUM": "f91a8875652941ba0f5b174ed77e434d2c7b8ba83f6c2499207cf8a05eb376f5"
     },
+    "dca-1.16.0": {
+        "SECURITY_AGENT_POLICIES_VERSION": "v0.17"
+    },
     "dca-1.15.0": {
         "SECURITY_AGENT_POLICIES_VERSION": "v0.16"
     },


### PR DESCRIPTION
### What does this PR do?

Cherry-pick https://github.com/DataDog/datadog-agent/commit/996168907455bb672f5e8889ba282f4e08e9d58b

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [X] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [X] The appropriate `team/..` label has been applied, if known.
- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [X] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
