### PR TITLE
Revert logs-agent use of workloadmetadata store

### DIFF
--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -17,7 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/client/http"
 	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
-	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
@@ -81,9 +80,8 @@ func start(getAC func() *autodiscovery.AutoConfig, serverless bool, logsChan cha
 	sources := config.NewLogSources()
 	services := service.NewServices()
 
-	// setup the config scheduler; this will be added to the AD meta-scheduler
-	// later during agent startup, in common.LoadComponents
-	scheduler.CreateScheduler(sources, services, workloadmeta.GetGlobalStore())
+	// setup the config scheduler
+	scheduler.CreateScheduler(sources, services)
 
 	// setup the server config
 	endpoints, err := buildEndpoints(serverless)

--- a/pkg/logs/scheduler/scheduler.go
+++ b/pkg/logs/scheduler/scheduler.go
@@ -199,10 +199,6 @@ func (s *Scheduler) handleWorkloadMetaSetEvent(e workloadmeta.Event, creationTim
 	var svc *service.Service
 	switch container.Runtime {
 	case workloadmeta.ContainerRuntimeDocker:
-		if _, exists := s.addedServices[e.Entity.GetID()]; exists {
-			// container already has a service
-			return
-		}
 		svc = service.NewService(config.DockerType, container.ID, creationTime)
 	default:
 		// unknown runtime, so no logging

--- a/pkg/logs/scheduler/scheduler_test.go
+++ b/pkg/logs/scheduler/scheduler_test.go
@@ -13,16 +13,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
-	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
-	workloadmetatesting "github.com/DataDog/datadog-agent/pkg/workloadmeta/testing"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestScheduleConfigCreatesNewSource(t *testing.T) {
 	logSources := config.NewLogSources()
 	services := service.NewServices()
-	s := NewScheduler(logSources, services, workloadmetatesting.NewStore())
-	defer s.Stop()
+	CreateScheduler(logSources, services)
 
 	logSourcesStream := logSources.GetAddedForType(config.DockerType)
 
@@ -36,7 +33,7 @@ func TestScheduleConfigCreatesNewSource(t *testing.T) {
 		CreationTime:  0,
 	}
 
-	go s.Schedule([]integration.Config{configSource})
+	go adScheduler.Schedule([]integration.Config{configSource})
 	logSource := <-logSourcesStream
 	assert.Equal(t, config.DockerType, logSource.Name)
 	// We use the docker socket, not sourceType here
@@ -50,8 +47,7 @@ func TestScheduleConfigCreatesNewSource(t *testing.T) {
 func TestScheduleConfigCreatesNewSourceServiceFallback(t *testing.T) {
 	logSources := config.NewLogSources()
 	services := service.NewServices()
-	s := NewScheduler(logSources, services, workloadmetatesting.NewStore())
-	defer s.Stop()
+	CreateScheduler(logSources, services)
 
 	logSourcesStream := logSources.GetAddedForType(config.DockerType)
 
@@ -66,7 +62,7 @@ func TestScheduleConfigCreatesNewSourceServiceFallback(t *testing.T) {
 		CreationTime:  0,
 	}
 
-	go s.Schedule([]integration.Config{configSource})
+	go adScheduler.Schedule([]integration.Config{configSource})
 	logSource := <-logSourcesStream
 	assert.Equal(t, config.DockerType, logSource.Name)
 	// We use the docker socket, not sourceType here
@@ -80,8 +76,7 @@ func TestScheduleConfigCreatesNewSourceServiceFallback(t *testing.T) {
 func TestScheduleConfigCreatesNewSourceServiceOverride(t *testing.T) {
 	logSources := config.NewLogSources()
 	services := service.NewServices()
-	s := NewScheduler(logSources, services, workloadmetatesting.NewStore())
-	defer s.Stop()
+	CreateScheduler(logSources, services)
 
 	logSourcesStream := logSources.GetAddedForType(config.DockerType)
 
@@ -96,7 +91,7 @@ func TestScheduleConfigCreatesNewSourceServiceOverride(t *testing.T) {
 		CreationTime:  0,
 	}
 
-	go s.Schedule([]integration.Config{configSource})
+	go adScheduler.Schedule([]integration.Config{configSource})
 	logSource := <-logSourcesStream
 	assert.Equal(t, config.DockerType, logSource.Name)
 	// We use the docker socket, not sourceType here
@@ -107,48 +102,46 @@ func TestScheduleConfigCreatesNewSourceServiceOverride(t *testing.T) {
 	assert.Equal(t, "a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b", logSource.Config.Identifier)
 }
 
-func TestSetEventCreatesNewContainerService(t *testing.T) {
+func TestScheduleConfigCreatesNewService(t *testing.T) {
 	logSources := config.NewLogSources()
 	services := service.NewServices()
-	store := workloadmetatesting.NewStore()
-	s := NewScheduler(logSources, services, store)
-	defer s.Stop()
+	CreateScheduler(logSources, services)
 
 	servicesStream := services.GetAddedServicesForType(config.DockerType)
 
-	makeEvent := func(id string) workloadmeta.Event {
-		return workloadmeta.Event{
-			Type: workloadmeta.EventTypeSet,
-			Entity: &workloadmeta.Container{
-				Runtime:  workloadmeta.ContainerRuntimeDocker,
-				EntityID: workloadmeta.EntityID{ID: id},
-			},
-		}
+	configService := integration.Config{
+		LogsConfig:   []byte(""),
+		TaggerEntity: "container_id://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
+		Entity:       "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
+		ClusterCheck: false,
+		CreationTime: 0,
 	}
 
-	go store.NotifySubscribers([]workloadmeta.Event{
-		makeEvent("a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b"),
-	})
-
+	go adScheduler.Schedule([]integration.Config{configService})
 	svc := <-servicesStream
-	assert.Equal(t, "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b", svc.GetEntityID())
-	assert.Equal(t, service.Before, svc.CreationTime)
+	assert.Equal(t, configService.Entity, svc.GetEntityID())
 
-	// next notification should be "After"
-	go store.NotifySubscribers([]workloadmeta.Event{
-		makeEvent("a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b"),
-	})
-
-	svc = <-servicesStream
-	assert.Equal(t, "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b", svc.GetEntityID())
-	assert.Equal(t, service.After, svc.CreationTime)
+	// shouldn't consider pods
+	configService = integration.Config{
+		LogsConfig:   []byte(""),
+		TaggerEntity: "kubernetes_pod://ee9a4083-10fc-11ea-a545-02c6fa0ccfb0",
+		Entity:       "kubernetes_pod://ee9a4083-10fc-11ea-a545-02c6fa0ccfb0",
+		ClusterCheck: false,
+		CreationTime: 0,
+	}
+	go adScheduler.Schedule([]integration.Config{configService})
+	select {
+	case <-servicesStream:
+		assert.Fail(t, "Pod should be ignored")
+	case <-time.After(100 * time.Millisecond):
+		break
+	}
 }
 
 func TestUnscheduleConfigRemovesSource(t *testing.T) {
 	logSources := config.NewLogSources()
 	services := service.NewServices()
-	s := NewScheduler(logSources, services, workloadmetatesting.NewStore())
-	defer s.Stop()
+	CreateScheduler(logSources, services)
 	logSourcesStream := logSources.GetRemovedForType(config.DockerType)
 
 	configSource := integration.Config{
@@ -162,10 +155,10 @@ func TestUnscheduleConfigRemovesSource(t *testing.T) {
 	}
 
 	// We need to have a source to remove
-	sources, _ := s.toSources(configSource)
+	sources, _ := adScheduler.toSources(configSource)
 	logSources.AddSource(sources[0])
 
-	go s.Unschedule([]integration.Config{configSource})
+	go adScheduler.Unschedule([]integration.Config{configSource})
 	logSource := <-logSourcesStream
 	assert.Equal(t, config.DockerType, logSource.Name)
 	// We use the docker socket, not sourceType here
@@ -176,51 +169,46 @@ func TestUnscheduleConfigRemovesSource(t *testing.T) {
 	assert.Equal(t, "a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b", logSource.Config.Identifier)
 }
 
-func TestUnsetEventRemovesService(t *testing.T) {
+func TestUnscheduleConfigRemovesService(t *testing.T) {
 	logSources := config.NewLogSources()
 	services := service.NewServices()
-	store := workloadmetatesting.NewStore()
-	s := NewScheduler(logSources, services, store)
-	defer s.Stop()
+	CreateScheduler(logSources, services)
+	servicesStream := services.GetRemovedServicesForType(config.DockerType)
 
-	addedServicesStream := services.GetAddedServicesForType(config.DockerType)
-	removedServicesStream := services.GetRemovedServicesForType(config.DockerType)
+	configService := integration.Config{
+		LogsConfig:   []byte(""),
+		TaggerEntity: "container_id://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
+		Entity:       "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
+		ClusterCheck: false,
+		CreationTime: 0,
+	}
 
-	// first set the service
-	go store.NotifySubscribers([]workloadmeta.Event{
-		{
-			Type: workloadmeta.EventTypeSet,
-			Entity: &workloadmeta.Container{
-				Runtime: workloadmeta.ContainerRuntimeDocker,
-				EntityID: workloadmeta.EntityID{
-					ID: "a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
-				},
-			},
-		},
-	})
+	go adScheduler.Unschedule([]integration.Config{configService})
+	svc := <-servicesStream
+	assert.Equal(t, configService.Entity, svc.GetEntityID())
 
-	svc := <-addedServicesStream
-	assert.Equal(t, "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b", svc.GetEntityID())
+	// shouldn't consider pods
+	configService = integration.Config{
+		LogsConfig:   []byte(""),
+		TaggerEntity: "kubernetes_pod://ee9a4083-10fc-11ea-a545-02c6fa0ccfb0",
+		Entity:       "kubernetes_pod://ee9a4083-10fc-11ea-a545-02c6fa0ccfb0",
+		ClusterCheck: false,
+		CreationTime: 0,
+	}
 
-	// now unset it
-	go store.NotifySubscribers([]workloadmeta.Event{
-		{
-			Type: workloadmeta.EventTypeUnset,
-			Entity: &workloadmeta.EntityID{
-				ID: "a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
-			},
-		},
-	})
-
-	svc = <-removedServicesStream
-	assert.Equal(t, "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b", svc.GetEntityID())
+	go adScheduler.Unschedule([]integration.Config{configService})
+	select {
+	case <-servicesStream:
+		assert.Fail(t, "Pod should be ignored")
+	case <-time.After(100 * time.Millisecond):
+		break
+	}
 }
 
 func TestIgnoreConfigIfLogsExcluded(t *testing.T) {
 	logSources := config.NewLogSources()
 	services := service.NewServices()
-	s := NewScheduler(logSources, services, workloadmetatesting.NewStore())
-	defer s.Stop()
+	CreateScheduler(logSources, services)
 	servicesStreamIn := services.GetAddedServicesForType(config.DockerType)
 	servicesStreamOut := services.GetRemovedServicesForType(config.DockerType)
 
@@ -233,7 +221,7 @@ func TestIgnoreConfigIfLogsExcluded(t *testing.T) {
 		LogsExcluded: true,
 	}
 
-	go s.Schedule([]integration.Config{configService})
+	go adScheduler.Schedule([]integration.Config{configService})
 	select {
 	case <-servicesStreamIn:
 		assert.Fail(t, "config must be ignored")
@@ -241,7 +229,7 @@ func TestIgnoreConfigIfLogsExcluded(t *testing.T) {
 		break
 	}
 
-	go s.Unschedule([]integration.Config{configService})
+	go adScheduler.Unschedule([]integration.Config{configService})
 	select {
 	case <-servicesStreamOut:
 		assert.Fail(t, "config must be ignored")

--- a/pkg/logs/scheduler/scheduler_test.go
+++ b/pkg/logs/scheduler/scheduler_test.go
@@ -18,9 +18,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var Container1 = "a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b"
-var Container2 = "9bad87700e8dac88d607056119ce80d3f33da461308d3d60367018891be5ee37"
-
 func TestScheduleConfigCreatesNewSource(t *testing.T) {
 	logSources := config.NewLogSources()
 	services := service.NewServices()
@@ -31,10 +28,10 @@ func TestScheduleConfigCreatesNewSource(t *testing.T) {
 
 	configSource := integration.Config{
 		LogsConfig:    []byte(`[{"service":"foo","source":"bar"}]`),
-		ADIdentifiers: []string{"docker://" + Container1},
+		ADIdentifiers: []string{"docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b"},
 		Provider:      names.Kubernetes,
-		TaggerEntity:  "container_id://" + Container1,
-		Entity:        "docker://" + Container1,
+		TaggerEntity:  "container_id://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
+		Entity:        "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
 		ClusterCheck:  false,
 		CreationTime:  0,
 	}
@@ -47,7 +44,7 @@ func TestScheduleConfigCreatesNewSource(t *testing.T) {
 	assert.Equal(t, "foo", logSource.Config.Service)
 	assert.Equal(t, "bar", logSource.Config.Source)
 	assert.Equal(t, config.DockerType, logSource.Config.Type)
-	assert.Equal(t, Container1, logSource.Config.Identifier)
+	assert.Equal(t, "a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b", logSource.Config.Identifier)
 }
 
 func TestScheduleConfigCreatesNewSourceServiceFallback(t *testing.T) {
@@ -61,10 +58,10 @@ func TestScheduleConfigCreatesNewSourceServiceFallback(t *testing.T) {
 	configSource := integration.Config{
 		InitConfig:    []byte(`{"service":"foo"}`),
 		LogsConfig:    []byte(`[{"source":"bar"}]`),
-		ADIdentifiers: []string{"docker://" + Container1},
+		ADIdentifiers: []string{"docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b"},
 		Provider:      names.Kubernetes,
-		TaggerEntity:  "container_id://" + Container1,
-		Entity:        "docker://" + Container1,
+		TaggerEntity:  "container_id://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
+		Entity:        "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
 		ClusterCheck:  false,
 		CreationTime:  0,
 	}
@@ -77,7 +74,7 @@ func TestScheduleConfigCreatesNewSourceServiceFallback(t *testing.T) {
 	assert.Equal(t, "foo", logSource.Config.Service)
 	assert.Equal(t, "bar", logSource.Config.Source)
 	assert.Equal(t, config.DockerType, logSource.Config.Type)
-	assert.Equal(t, Container1, logSource.Config.Identifier)
+	assert.Equal(t, "a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b", logSource.Config.Identifier)
 }
 
 func TestScheduleConfigCreatesNewSourceServiceOverride(t *testing.T) {
@@ -91,10 +88,10 @@ func TestScheduleConfigCreatesNewSourceServiceOverride(t *testing.T) {
 	configSource := integration.Config{
 		InitConfig:    []byte(`{"service":"foo"}`),
 		LogsConfig:    []byte(`[{"source":"bar","service":"baz"}]`),
-		ADIdentifiers: []string{"docker://" + Container1},
+		ADIdentifiers: []string{"docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b"},
 		Provider:      names.Kubernetes,
-		TaggerEntity:  "container_id://" + Container1,
-		Entity:        "docker://" + Container1,
+		TaggerEntity:  "container_id://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
+		Entity:        "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
 		ClusterCheck:  false,
 		CreationTime:  0,
 	}
@@ -107,7 +104,7 @@ func TestScheduleConfigCreatesNewSourceServiceOverride(t *testing.T) {
 	assert.Equal(t, "baz", logSource.Config.Service)
 	assert.Equal(t, "bar", logSource.Config.Source)
 	assert.Equal(t, config.DockerType, logSource.Config.Type)
-	assert.Equal(t, Container1, logSource.Config.Identifier)
+	assert.Equal(t, "a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b", logSource.Config.Identifier)
 }
 
 func TestSetEventCreatesNewContainerService(t *testing.T) {
@@ -130,33 +127,21 @@ func TestSetEventCreatesNewContainerService(t *testing.T) {
 	}
 
 	go store.NotifySubscribers([]workloadmeta.Event{
-		makeEvent(Container1),
+		makeEvent("a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b"),
 	})
 
 	svc := <-servicesStream
-	assert.Equal(t, "docker://"+Container1, svc.GetEntityID())
+	assert.Equal(t, "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b", svc.GetEntityID())
 	assert.Equal(t, service.Before, svc.CreationTime)
 
-	// next notification (for a new container) should be "After"
+	// next notification should be "After"
 	go store.NotifySubscribers([]workloadmeta.Event{
-		makeEvent(Container2),
+		makeEvent("a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b"),
 	})
 
 	svc = <-servicesStream
-	assert.Equal(t, "docker://"+Container2, svc.GetEntityID())
+	assert.Equal(t, "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b", svc.GetEntityID())
 	assert.Equal(t, service.After, svc.CreationTime)
-
-	// notification for same container as the first should not result in a new service
-	go store.NotifySubscribers([]workloadmeta.Event{
-		makeEvent(Container1),
-	})
-
-	select {
-	case svc = <-servicesStream:
-		assert.Fail(t, "should not have produced a service", "got service %#v", svc)
-	case <-time.After(10 * time.Millisecond):
-		// all good!
-	}
 }
 
 func TestUnscheduleConfigRemovesSource(t *testing.T) {
@@ -168,10 +153,10 @@ func TestUnscheduleConfigRemovesSource(t *testing.T) {
 
 	configSource := integration.Config{
 		LogsConfig:    []byte(`[{"service":"foo","source":"bar"}]`),
-		ADIdentifiers: []string{"docker://" + Container1},
+		ADIdentifiers: []string{"docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b"},
 		Provider:      names.Kubernetes,
-		TaggerEntity:  "container_id://" + Container1,
-		Entity:        "docker://" + Container1,
+		TaggerEntity:  "container_id://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
+		Entity:        "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
 		ClusterCheck:  false,
 		CreationTime:  0,
 	}
@@ -188,7 +173,7 @@ func TestUnscheduleConfigRemovesSource(t *testing.T) {
 	assert.Equal(t, "foo", logSource.Config.Service)
 	assert.Equal(t, "bar", logSource.Config.Source)
 	assert.Equal(t, config.DockerType, logSource.Config.Type)
-	assert.Equal(t, Container1, logSource.Config.Identifier)
+	assert.Equal(t, "a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b", logSource.Config.Identifier)
 }
 
 func TestUnsetEventRemovesService(t *testing.T) {
@@ -208,27 +193,27 @@ func TestUnsetEventRemovesService(t *testing.T) {
 			Entity: &workloadmeta.Container{
 				Runtime: workloadmeta.ContainerRuntimeDocker,
 				EntityID: workloadmeta.EntityID{
-					ID: Container1,
+					ID: "a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
 				},
 			},
 		},
 	})
 
 	svc := <-addedServicesStream
-	assert.Equal(t, "docker://"+Container1, svc.GetEntityID())
+	assert.Equal(t, "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b", svc.GetEntityID())
 
 	// now unset it
 	go store.NotifySubscribers([]workloadmeta.Event{
 		{
 			Type: workloadmeta.EventTypeUnset,
 			Entity: &workloadmeta.EntityID{
-				ID: Container1,
+				ID: "a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
 			},
 		},
 	})
 
 	svc = <-removedServicesStream
-	assert.Equal(t, "docker://"+Container1, svc.GetEntityID())
+	assert.Equal(t, "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b", svc.GetEntityID())
 }
 
 func TestIgnoreConfigIfLogsExcluded(t *testing.T) {
@@ -241,8 +226,8 @@ func TestIgnoreConfigIfLogsExcluded(t *testing.T) {
 
 	configService := integration.Config{
 		LogsConfig:   []byte(""),
-		TaggerEntity: "container_id://" + Container1,
-		Entity:       "docker://" + Container1,
+		TaggerEntity: "container_id://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
+		Entity:       "docker://a1887023ed72a2b0d083ef465e8edfe4932a25731d4bda2f39f288f70af3405b",
 		ClusterCheck: false,
 		CreationTime: 0,
 		LogsExcluded: true,

--- a/pkg/serverless/logs/logs_test.go
+++ b/pkg/serverless/logs/logs_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	serverlessMetrics "github.com/DataDog/datadog-agent/pkg/serverless/metrics"
-	workloadmetatesting "github.com/DataDog/datadog-agent/pkg/workloadmeta/testing"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -159,7 +158,7 @@ func TestGetLambdaSourceNilScheduler(t *testing.T) {
 func TestGetLambdaSourceNilSource(t *testing.T) {
 	logSources := config.NewLogSources()
 	services := service.NewServices()
-	scheduler.CreateScheduler(logSources, services, workloadmetatesting.NewStore())
+	scheduler.CreateScheduler(logSources, services)
 	assert.Nil(t, GetLambdaSource())
 }
 
@@ -173,7 +172,7 @@ func TestGetLambdaSourceValidSource(t *testing.T) {
 	})
 	logSources.AddSource(chanSource)
 	services := service.NewServices()
-	scheduler.CreateScheduler(logSources, services, workloadmetatesting.NewStore())
+	scheduler.CreateScheduler(logSources, services)
 	assert.NotNil(t, GetLambdaSource())
 }
 

--- a/pkg/workloadmeta/store.go
+++ b/pkg/workloadmeta/store.go
@@ -183,9 +183,6 @@ func (s *store) Start(ctx context.Context) {
 // Subscribe returns a channel where workload metadata events will be streamed
 // as they happen. On first subscription, it will also generate an EventTypeSet
 // event for each entity present in the store that matches filter.
-//
-// Any time an entity changes, a new EventTypeSet event will be set, so multiple
-// events may be received for each entity.
 func (s *store) Subscribe(name string, filter *Filter) chan EventBundle {
 	// ch needs to be buffered since we'll send it events before the
 	// subscriber has the chance to start receiving from it. if it's

--- a/pkg/workloadmeta/testing/store.go
+++ b/pkg/workloadmeta/testing/store.go
@@ -8,16 +8,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
-type subscriber struct {
-	name string
-	ch   chan workloadmeta.EventBundle
-}
-
 // Store is a testing store that satisfies the workloadmeta.Store interface.
 type Store struct {
-	mu          sync.RWMutex
-	subscribers []subscriber
-	store       map[workloadmeta.Kind]map[string]workloadmeta.Entity
+	mu    sync.RWMutex
+	store map[workloadmeta.Kind]map[string]workloadmeta.Entity
 }
 
 var _ workloadmeta.Store = &Store{}
@@ -127,54 +121,14 @@ func (s *Store) Start(ctx context.Context) {
 	panic("not implemented")
 }
 
-// Subscribe allows subscriptions, to which events are sent via
-// NotifySubscribers.  The filter is ignored.
+// Subscribe is not implemented in the testing store.
 func (s *Store) Subscribe(name string, filter *workloadmeta.Filter) chan workloadmeta.EventBundle {
-	// ch needs to be buffered since we'll send it events before the
-	// subscriber has the chance to start receiving from it. if it's
-	// unbuffered, it'll deadlock.
-	sub := subscriber{
-		name: name,
-		ch:   make(chan workloadmeta.EventBundle, 1),
-	}
-
-	s.mu.Lock()
-	s.subscribers = append(s.subscribers, sub)
-	s.mu.Unlock()
-
-	return sub.ch
+	panic("not implemented")
 }
 
-// Unsubscribe reverses the effect of Subscribe
+// Unsubscribe is not implemented in the testing store.
 func (s *Store) Unsubscribe(ch chan workloadmeta.EventBundle) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	for i, sub := range s.subscribers {
-		if sub.ch == ch {
-			s.subscribers = append(s.subscribers[:i], s.subscribers[i+1:]...)
-			break
-		}
-	}
-
-	close(ch)
-}
-
-// NotifySubscribers sends the given events to all subscrbers as a single
-// bundle, ignoring filters.  It waits for the consumers to acknowledge the
-// bundle by closing Ch.
-func (s *Store) NotifySubscribers(events []workloadmeta.Event) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	for _, sub := range s.subscribers {
-		bundle := workloadmeta.EventBundle{
-			Ch:     make(chan struct{}),
-			Events: events,
-		}
-		sub.ch <- bundle
-		<-bundle.Ch
-	}
+	panic("not implemented")
 }
 
 // Notify is not implemented in the testing store.


### PR DESCRIPTION
### What does this PR do?

Backs out #9909 and #9803.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
