### PR TITLE
[workloadmeta/ecs] Avoid calls to metav3 for known tasks

### DIFF
--- a/pkg/workloadmeta/collectors/util/expire.go
+++ b/pkg/workloadmeta/collectors/util/expire.go
@@ -45,6 +45,14 @@ func (e *Expire) Update(id workloadmeta.EntityID, ts time.Time) bool {
 	return !found
 }
 
+// Remove forgets an ID.
+func (e *Expire) Remove(id workloadmeta.EntityID) {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	delete(e.lastSeen, id)
+}
+
 // ComputeExpires returns a list of IDs that have not been seen in the Expire's
 // duration.
 func (e *Expire) ComputeExpires() []workloadmeta.EntityID {

--- a/pkg/workloadmeta/collectors/util/expire_test.go
+++ b/pkg/workloadmeta/collectors/util/expire_test.go
@@ -14,7 +14,7 @@ import (
 	"gotest.tools/assert"
 )
 
-func TestUpdate(t *testing.T) {
+func TestUpdateAndRemove(t *testing.T) {
 	expiryDuration := 5 * time.Minute
 	expire := NewExpire(expiryDuration)
 
@@ -41,6 +41,9 @@ func TestUpdate(t *testing.T) {
 	require.Len(t, expire.lastSeen, 1)
 	require.Equal(t, expire.lastSeen[testContainerID], now)
 
+	// Remove container, expect store to be empty
+	expire.Remove(testContainerID)
+	require.Len(t, expire.lastSeen, 0)
 }
 
 func TestComputeExpires(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

This is a forward-port of #9902, to prevent the agent from doing too
many calls to the ECS V3 API and getting throttled, and therefore not
being able to track tags for tasks. This PR follows the same strategy as
the old tagger collector, by considering that once a task starts
running, it won't change, and therefore there is no need to continuously
generate Set events for it.


### Describe how to test/QA your changes

Same as #9902.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
