### PR TITLE
[tagger] Configurable remote tagger timeout

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -228,6 +228,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("python_version", DefaultPython)
 	config.BindEnvAndSetDefault("allow_arbitrary_tags", false)
 	config.BindEnvAndSetDefault("use_proxy_for_cloud_metadata", false)
+	config.BindEnvAndSetDefault("remote_tagger_timeout_seconds", 30)
 
 	// Remote config
 	config.BindEnvAndSetDefault("remote_configuration.enabled", false)

--- a/pkg/tagger/remote/tagger.go
+++ b/pkg/tagger/remote/tagger.go
@@ -32,7 +32,6 @@ import (
 )
 
 const (
-	defaultTimeout    = 5 * time.Minute
 	noTimeout         = 0 * time.Minute
 	streamRecvTimeout = 10 * time.Minute
 )
@@ -98,7 +97,8 @@ func (t *Tagger) Init() error {
 
 	t.client = pb.NewAgentSecureClient(t.conn)
 
-	err = t.startTaggerStream(defaultTimeout)
+	timeout := time.Duration(config.Datadog.GetInt("remote_tagger_timeout_seconds")) * time.Second
+	err = t.startTaggerStream(timeout)
 	if err != nil {
 		// tagger stopped before being connected
 		if err == errTaggerStreamNotStarted {

--- a/releasenotes/notes/remote-tagger-timeout-ef3d402186cad2fb.yaml
+++ b/releasenotes/notes/remote-tagger-timeout-ef3d402186cad2fb.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Allows the remote tagger timeout at startup to be configured by setting the
+    `remote_tagger_timeout_seconds` config value. It also now defaults to 30
+    seconds instead of 5 minutes.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This does two things:

* Reduces the default remote tagger timeout from 5 minutes to 30
  seconds. In our own production environments, we see that this is
  enough to accomodate most delays at startup, and actually allows the
  trace agent to fall back to the local tagger more quickly if it's
  running standalone.
* Allows the user to configure how long to wait for the remote tagger at
  startup before giving up by setting the `remote_tagger_timeout_seconds` config
  value. It also adds the option to wait indefinitely if needed by
  setting the timeout to zero.

### Motivation

We found that the old timeout of 5 minutes was too long to wait for when the trace-agent is running standalone.

### Describe how to test/QA your changes

As this is a follow up to #9842: run the trace-agent standalone, with the `DD_REMOTE_TAGGER_TIMEOUT_SECONDS` set to an arbitrary duration. Check that after roughly that duration, the trace-agent falls back to using the local tagger.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
