### PR TITLE
Choco publish job: fail script if command fails

### DIFF
--- a/tasks/winbuildscripts/Publish-Chocolatey-Package.ps1
+++ b/tasks/winbuildscripts/Publish-Chocolatey-Package.ps1
@@ -8,4 +8,5 @@ $nupkgs = Get-ChildItem .\nupkg\datadog-agent*.nupkg
 foreach($nupkg in $nupkgs) {
     Write-Host "Publishing Chocolatey package $($nupkg.Name) for agent version $agentVersion"
     choco push $nupkg.FullName --verbose --key $env:CHOCOLATEY_API_KEY --source https://push.chocolatey.org/
+    If ($lastExitCode -ne "0") { throw "Previous command returned $lastExitCode" }
 }


### PR DESCRIPTION

### What does this PR do?

Check if `choco` failed and fail the script.

### Motivation

Should make the CI red if the `choco` call fails.

