### PR TITLE
[CWS] rework backoff ticker

### DIFF
--- a/pkg/security/agent/agent.go
+++ b/pkg/security/agent/agent.go
@@ -96,8 +96,7 @@ func (rsa *RuntimeSecurityAgent) StartEventListener() {
 	rsa.running.Store(true)
 	for rsa.running.Load() == true {
 		logTicker.StartIfNeeded()
-		stream, _ := apiClient.GetEvents(context.Background(), &api.GetEventParams{})
-		err := errors.New("test backoff")
+		stream, err := apiClient.GetEvents(context.Background(), &api.GetEventParams{})
 		if err != nil {
 			rsa.connected.Store(false)
 

--- a/pkg/security/agent/agent.go
+++ b/pkg/security/agent/agent.go
@@ -165,7 +165,7 @@ type BackoffTicker struct {
 	ticker *backoff.Ticker
 }
 
-// StartIfNeeded starts the backoff ticker, if not already started
+// Start starts the backoff ticker, if not already started
 func (t *BackoffTicker) Start() {
 	if t.ticker == nil {
 		t.ticker = newLogBackoffTicker()

--- a/pkg/security/agent/agent.go
+++ b/pkg/security/agent/agent.go
@@ -161,20 +161,24 @@ func newLogBackoffTicker() *backoff.Ticker {
 	return backoff.NewTicker(expBackoff)
 }
 
+// BackoffTicker represents a ticker based on an exponential backoff, used to trigger connect error logs
 type BackoffTicker struct {
 	ticker *backoff.Ticker
 }
 
+// StartIfNeeded starts the backoff ticker, if not already started
 func (t *BackoffTicker) StartIfNeeded() {
 	if t.ticker == nil {
 		t.ticker = newLogBackoffTicker()
 	}
 }
 
+// C returns the underlying channel
 func (t *BackoffTicker) C() <-chan time.Time {
 	return t.ticker.C
 }
 
+// Stop stops the ticker and sets the ticker in a restartable state
 func (t *BackoffTicker) Stop() {
 	t.ticker.Stop()
 	t.ticker = nil

--- a/pkg/security/agent/agent.go
+++ b/pkg/security/agent/agent.go
@@ -95,7 +95,7 @@ func (rsa *RuntimeSecurityAgent) StartEventListener() {
 
 	rsa.running.Store(true)
 	for rsa.running.Load() == true {
-		logTicker.StartIfNeeded()
+		logTicker.Start()
 		stream, err := apiClient.GetEvents(context.Background(), &api.GetEventParams{})
 		if err != nil {
 			rsa.connected.Store(false)
@@ -166,7 +166,7 @@ type BackoffTicker struct {
 }
 
 // StartIfNeeded starts the backoff ticker, if not already started
-func (t *BackoffTicker) StartIfNeeded() {
+func (t *BackoffTicker) Start() {
 	if t.ticker == nil {
 		t.ticker = newLogBackoffTicker()
 	}


### PR DESCRIPTION
### What does this PR do?

This PR reworks the exponential backoff used in the security agent by:
- ensuring the ticker it is closed
- reseting the ticker when an event is successfully received

### Motivation

The current backoff ticker will never reset to reasonable delay if there is a temporary failure in the connection.
This PR is an attempt to fix this isue.

### Describe how to test/QA your changes

Test the backoff mechanism and ensure that the delay can come back to a reasonable value.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
