### PR TITLE
Deprecate process_config.enabled in favor of process_collection and container_collection

### DIFF
--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -223,7 +223,7 @@ func runAgent(exit chan struct{}) {
 	}
 
 	// Exit if agent is not enabled and we're not debugging a check.
-	if !cfg.Enabled && opts.check == "" {
+	if !checks.Enabled() && opts.check == "" {
 		log.Infof(agent6DisabledMessage)
 
 		// a sleep is necessary to ensure that supervisor registers this process as "STARTED"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -909,7 +909,7 @@ func InitConfig(config Config) {
 	config.SetKnown("process_config.windows.add_new_args")
 	config.SetKnown("process_config.windows.use_perf_counters")
 	config.SetKnown("process_config.additional_endpoints.*")
-	config.BindEnv("process_config.container_source", "DD_PROCESS_AGENT_CONTAINER_SOURCE")
+	config.SetKnown("process_config.container_source")
 	config.SetKnown("process_config.intervals.connections")
 	config.SetKnown("process_config.expvar_port")
 	config.SetKnown("process_config.log_file")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -887,9 +887,8 @@ func InitConfig(config Config) {
 		}
 		if enabled {
 			return "true"
-		} else {
-			return "disabled"
 		}
+		return "disabled"
 	})
 	config.SetKnown("process_config.intervals.process_realtime")
 	config.SetKnown("process_config.queue_size")

--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -1,0 +1,1 @@
+package config

--- a/pkg/process/checks/checks.go
+++ b/pkg/process/checks/checks.go
@@ -36,6 +36,16 @@ type CheckWithRealTime interface {
 	RunWithOptions(cfg *config.AgentConfig, nextGroupID func() int32, options RunOptions) (*RunResult, error)
 }
 
+// Enabled returns true if there is at least one check enabled. This is used to tell if the process agent should be run.
+func Enabled() bool {
+	for _, chk := range All {
+		if chk.Enabled() {
+			return true
+		}
+	}
+	return false
+}
+
 // All is a list of all runnable checks. Putting a check in here does not guarantee it will be run,
 // it just guarantees that the collector will be able to find the check.
 // If you want to add a check you MUST register it here.

--- a/pkg/process/checks/checks.go
+++ b/pkg/process/checks/checks.go
@@ -14,6 +14,7 @@ type Check interface {
 	Name() string
 	RealTime() bool
 	Run(cfg *config.AgentConfig, groupID int32) ([]model.MessageBody, error)
+	Enabled() bool
 }
 
 // RunOptions provides run options for checks

--- a/pkg/process/checks/container.go
+++ b/pkg/process/checks/container.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/config"
 	"github.com/DataDog/datadog-agent/pkg/process/statsd"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
@@ -117,6 +118,10 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	statsd.Client.Gauge("datadog.process.containers.host_count", totalContainers, []string{}, 1) //nolint:errcheck
 	log.Debugf("collected %d containers in %s", int(totalContainers), time.Now().Sub(start))
 	return messages, nil
+}
+
+func (p *ContainerCheck) Enabled() bool {
+	return ddconfig.Datadog.GetBool("process_config.container_collection.enabled")
 }
 
 // fmtContainers loops through container list and converts them to a list of container objects

--- a/pkg/process/checks/container_rt.go
+++ b/pkg/process/checks/container_rt.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
@@ -80,6 +81,10 @@ func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 	r.lastRun = time.Now()
 
 	return messages, nil
+}
+
+func (r *RTContainerCheck) Enabled() bool {
+	return ddconfig.Datadog.GetBool("process_config.container_collection.rt_interval")
 }
 
 // fmtContainerStats formats and chunks the ctrList into a slice of chunks using a specific

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/network/dns"
@@ -99,6 +100,10 @@ func (c *ConnectionsCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 
 	log.Debugf("collected connections in %s", time.Since(start))
 	return batchConnections(cfg, groupID, c.enrichConnections(conns.Conns), conns.Dns, c.networkID, connTel, conns.CompilationTelemetryByAsset, conns.Domains, conns.Routes, conns.AgentConfiguration), nil
+}
+
+func (c *ConnectionsCheck) Enabled() bool {
+	return ddconfig.Datadog.GetBool("network_config.enabled")
 }
 
 func (c *ConnectionsCheck) getConnections() (*model.Connections, error) {

--- a/pkg/process/checks/pod_null.go
+++ b/pkg/process/checks/pod_null.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !kubelet || !orchestrator
 // +build !kubelet !orchestrator
 
 package checks
@@ -18,12 +19,14 @@ var Pod = &PodCheck{}
 
 // PodCheck is a check that returns container metadata and stats.
 type PodCheck struct {
+	enabled bool
 	sysInfo *model.SystemInfo
 }
 
 // Init initializes a PodCheck instance.
 func (c *PodCheck) Init(cfg *config.AgentConfig, info *model.SystemInfo) {
 	c.sysInfo = info
+	c.enabled = cfg.Orchestrator.OrchestrationCollectionEnabled
 }
 
 // Name returns the name of the ProcessCheck.
@@ -35,4 +38,8 @@ func (c *PodCheck) RealTime() bool { return false }
 // Run runs the PodCheck to collect a list of running pods
 func (c *PodCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.MessageBody, error) {
 	return nil, fmt.Errorf("Not implemented")
+}
+
+func (c *PodCheck) Enabled() bool {
+	return c.enabled
 }

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/config"
 	"github.com/DataDog/datadog-agent/pkg/process/net"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
@@ -96,6 +97,10 @@ func (p *ProcessCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Mess
 	}
 
 	return result.Standard, nil
+}
+
+func (p *ProcessCheck) Enabled() bool {
+	return ddconfig.Datadog.GetBool("process_config.process_collection.enabled")
 }
 
 func (p *ProcessCheck) run(cfg *config.AgentConfig, groupID int32, collectRealTime bool) (*RunResult, error) {

--- a/pkg/process/checks/process_discovery_check.go
+++ b/pkg/process/checks/process_discovery_check.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	model "github.com/DataDog/agent-payload/v5/process"
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/config"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
@@ -65,6 +66,10 @@ func (d *ProcessDiscoveryCheck) Run(cfg *config.AgentConfig, groupID int32) ([]m
 	}
 
 	return payload, nil
+}
+
+func (d *ProcessDiscoveryCheck) Enabled() bool {
+	return ddconfig.Datadog.GetBool("process_config.process_discovery.enabled")
 }
 
 func pidMapToProcDiscoveries(pidMap map[int32]*procutil.Process) []*model.ProcessDiscovery {

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -92,7 +92,6 @@ type WindowsConfig struct {
 // AgentConfig is the global config for the process-agent. This information
 // is sourced from config files and the environment variables.
 type AgentConfig struct {
-	Enabled                   bool
 	HostName                  string
 	APIEndpoints              []apicfg.Endpoint
 	LogFile                   string
@@ -190,7 +189,6 @@ func NewDefaultAgentConfig(canAccessContainers bool) *AgentConfig {
 	}
 
 	ac := &AgentConfig{
-		Enabled:      canAccessContainers, // We'll always run inside of a container.
 		APIEndpoints: []apicfg.Endpoint{{Endpoint: processEndpoint}},
 		LogFile:      defaultLogFilePath,
 		LogLevel:     "info",
@@ -329,11 +327,6 @@ func NewAgentConfig(loggerName config.LoggerName, yamlPath, netYamlPath string) 
 			if checks, ok := moduleCheckMap[mod]; ok {
 				cfg.EnabledChecks = append(cfg.EnabledChecks, checks...)
 			}
-		}
-
-		if !cfg.Enabled {
-			log.Info("enabling process-agent for connections check as the system-probe is enabled")
-			cfg.Enabled = true
 		}
 	}
 

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -489,14 +489,6 @@ func IsBlacklisted(cmdline []string, blacklist []*regexp.Regexp) bool {
 	return false
 }
 
-func isAffirmative(value string) (bool, error) {
-	if value == "" {
-		return false, fmt.Errorf("value is empty")
-	}
-	v := strings.ToLower(value)
-	return v == "true" || v == "yes" || v == "1", nil
-}
-
 // getHostname attempts to resolve the hostname in the following order: the main datadog agent via grpc, the main agent
 // via cli and lastly falling back to os.Hostname() if it is unavailable
 func getHostname(ctx context.Context, ddAgentBin string, grpcConnectionTimeout time.Duration) (string, error) {

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -1,3 +1,4 @@
+//go:build linux || windows
 // +build linux windows
 
 package config
@@ -522,27 +523,6 @@ func TestSystemProbeNoNetwork(t *testing.T) {
 	assert.True(t, agentConfig.Enabled)
 	assert.ElementsMatch(t, []string{OOMKillCheckName, ProcessCheckName, RTProcessCheckName}, agentConfig.EnabledChecks)
 
-}
-
-func TestIsAffirmative(t *testing.T) {
-	value, err := isAffirmative("yes")
-	assert.Nil(t, err)
-	assert.True(t, value)
-
-	value, err = isAffirmative("True")
-	assert.Nil(t, err)
-	assert.True(t, value)
-
-	value, err = isAffirmative("1")
-	assert.Nil(t, err)
-	assert.True(t, value)
-
-	_, err = isAffirmative("")
-	assert.NotNil(t, err)
-
-	value, err = isAffirmative("ok")
-	assert.Nil(t, err)
-	assert.False(t, value)
 }
 
 func TestGetHostnameFromGRPC(t *testing.T) {

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -329,7 +329,6 @@ func (a *AgentConfig) initProcessDiscoveryCheck() {
 	checkEnabled := config.Datadog.GetBool(key(root, "enabled"))
 	if checkEnabled && processAgentEnabled != "true" {
 		a.EnabledChecks = append(a.EnabledChecks, DiscoveryCheckName)
-		a.Enabled = true
 
 		// We don't need to check if the key exists since we already bound it to a default in InitConfig.
 		// We use a minimum of 10 minutes for this value.


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
