### PR TITLE
Move CircleCI requirements to a requirements.txt file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
           command: |
             python3 -m pip install wheel
             python3 -m pip install -r requirements.txt
-            python3 -m pip install codecov~=2.1.11 flake8~=3.9.2 flake8-bugbear~=21.4.3 flake8-unused-arguments==0.0.6 black~=21.8b0 isort~=5.9.3
+            python3 -m pip install -r .circleci/requirements.txt
       - run:
           name: grab go deps
           command: |

--- a/.circleci/requirements.txt
+++ b/.circleci/requirements.txt
@@ -1,0 +1,6 @@
+black==21.8b0
+codecov==2.1.11
+flake8-bugbear==21.4.3
+flake8-unused-arguments==0.0.6 
+flake8==3.9.2
+isort==5.9.3

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -128,3 +128,15 @@ updates:
     milestone: 22
     schedule:
       interval: "weekly"
+- package-ecosystem: "pip"
+    directory: "/.circleci"
+    labels:
+      - dependencies
+      - python
+      - team/agent-platform
+      - changelog/no-changelog
+      - qa/skip-qa
+      - dev/tooling
+    milestone: 22
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Move CircleCI requirements into a requirements.txt file.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

- Dependabot automatic updates
- Easier local testing if someone wants to install all versions

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

- We will need to remember to bump the pre-commit dependencies too; I may do some Github Action for this

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
