### PR TITLE
[AD] Add support for Podman containers

### DIFF
--- a/pkg/autodiscovery/listeners/README.md
+++ b/pkg/autodiscovery/listeners/README.md
@@ -9,6 +9,7 @@ This package is providing the `ServiceListener` concept to the agent. A `Service
 Services can be:
 - Docker containers
 - Containerd containers
+- Podman containers
 - Kubelet containers
 - Kubelet pods
 - ECS containers
@@ -59,6 +60,7 @@ TODO
 |---|---|---|---|---|---|---|---|
 | Docker | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | Containerd | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ |
+| Podman | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | ECS | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ❌ |
 | Kubelet | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ |
 | KubeService | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ |

--- a/pkg/autodiscovery/listeners/container.go
+++ b/pkg/autodiscovery/listeners/container.go
@@ -36,7 +36,7 @@ func NewContainerListener() (ServiceListener, error) {
 	l := &ContainerListener{}
 	f := workloadmeta.NewFilter(
 		[]workloadmeta.Kind{workloadmeta.KindContainer},
-		[]workloadmeta.Source{workloadmeta.SourceDocker, workloadmeta.SourceContainerd},
+		[]workloadmeta.Source{workloadmeta.SourceDocker, workloadmeta.SourceContainerd, workloadmeta.SourcePodman},
 	)
 
 	var err error

--- a/pkg/autodiscovery/providers/container.go
+++ b/pkg/autodiscovery/providers/container.go
@@ -84,6 +84,7 @@ func (d *ContainerConfigProvider) listen() {
 			workloadmeta.SourceDocker,
 			workloadmeta.SourceContainerd,
 			workloadmeta.SourceECSFargate,
+			workloadmeta.SourcePodman,
 		},
 	))
 

--- a/pkg/config/autodiscovery/autodiscovery.go
+++ b/pkg/config/autodiscovery/autodiscovery.go
@@ -46,7 +46,7 @@ func DiscoverComponentsFromEnv() ([]config.ConfigurationProviders, []config.List
 		return detectedProviders, detectedListeners
 	}
 
-	if config.IsFeaturePresent(config.Docker) || config.IsFeaturePresent(config.Containerd) || config.IsFeaturePresent(config.ECSFargate) {
+	if config.IsFeaturePresent(config.Docker) || config.IsFeaturePresent(config.Containerd) || config.IsFeaturePresent(config.ECSFargate) || config.IsFeaturePresent(config.Podman) {
 		detectedProviders = append(detectedProviders, config.ConfigurationProviders{Name: names.Container, Polling: true, PollInterval: "1s"})
 		if !config.IsFeaturePresent(config.Kubernetes) {
 			detectedListeners = append(detectedListeners, config.Listeners{Name: names.Container})

--- a/releasenotes/notes/ad-podman-166025a85e86f2e8.yaml
+++ b/releasenotes/notes/ad-podman-166025a85e86f2e8.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Autodiscovery of integrations now works with Podman containers. The minimum
+    Podman version supported is 3.0.0.


### PR DESCRIPTION
### What does this PR do?

Adds autodiscovery support for Podman containers.

### Describe how to test/QA your changes

You'll need a host with podman installed. I use podman machine for that. See the instructions: https://podman.io/getting-started/installation#podman-installation-instructions

1) Try that autodiscovery works for Podman containers the same way it works for Docker containers. For example, create a Dockerfile based on the redis image with the autodiscovery labels:
```
FROM redis

LABEL "com.datadoghq.ad.check_names"="[\"redisdb\"]"
LABEL "com.datadoghq.ad.init_configs"="[{}]"
LABEL "com.datadoghq.ad.instances"="[{\"host\":\"%%host%%\",\"port\":\"6379\"}]"
LABEL "com.datadoghq.ad.logs"="[{\"source\":\"redis\"}]"
```
- Build it: `podman build -t redis_ad .`.
- Run the agent with the Podman storage mounted (`-v /var/lib/containers/:/var/lib/containers/`) and --net=host (to make things easier for testing).
- Run redis: `podman run --net=host redis_ad`.
- Check the output of `agent configcheck`, verify that the redisdb check is there. Also, run `agent check redisdb` and verify that it reports metrics.

2) You can try the same but passing labels to the redis image (not the custom one above): `podman run --label "com.datadoghq.ad.check_names=[\"redisdb\"]" --label "com.datadoghq.ad.init_configs=[{}]" --label "com.datadoghq.ad.instances=[{\"host\":\"%%host%%\",\"port\":6379}]" --label "com.datadoghq.ad.logs=[{\"source\":\"redis\"}]" --name  redis --net=host redis`

3) Autodiscovery template variables should work too: https://docs.datadoghq.com/agent/faq/template_variables/#pagetitle


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
