### PR TITLE
[Serverless] Fix runtime detection

### DIFF
--- a/pkg/serverless/proc/proc.go
+++ b/pkg/serverless/proc/proc.go
@@ -25,9 +25,7 @@ func getPidList(procPath string) []int {
 	for _, file := range files {
 		if file.IsDir() {
 			if processID, err := strconv.Atoi(file.Name()); err == nil {
-				if processID != 1 { // no need to check for the root pid
-					pids = append(pids, processID)
-				}
+				pids = append(pids, processID)
 			}
 		}
 	}
@@ -57,16 +55,16 @@ func getEnvVariablesFromPid(procPath string, pid int) map[string]string {
 	return envVars
 }
 
-// SearchProcsForEnvVariable returns the value of the given env variable name
-// It returns an empty string if not found
-// If an env variable is found more that one time, the first one is returned
-func SearchProcsForEnvVariable(procPath string, envName string) string {
+// SearchProcsForEnvVariable returns values of the given env variable name
+// it returns a slice since a value could be found in more than one process
+func SearchProcsForEnvVariable(procPath string, envName string) []string {
+	result := []string{}
 	pidList := getPidList(procPath)
 	for _, pid := range pidList {
 		envMap := getEnvVariablesFromPid(procPath, pid)
 		if value, ok := envMap[envName]; ok {
-			return value
+			result = append(result, value)
 		}
 	}
-	return ""
+	return result
 }

--- a/pkg/serverless/proc/proc_test.go
+++ b/pkg/serverless/proc/proc_test.go
@@ -43,9 +43,11 @@ func TestSearchProcsForEnvVariableFromPidCorrect(t *testing.T) {
 
 func TestSearchProcsForEnvVariableFound(t *testing.T) {
 	result := SearchProcsForEnvVariable("./testData", "env1")
-	assert.Equal(t, "value1", result)
+	expected := []string{"value1"}
+	assert.Equal(t, 1, len(result))
+	assert.Equal(t, expected[0], result[0])
 }
 func TestSearchProcsForEnvVariableNotFound(t *testing.T) {
 	result := SearchProcsForEnvVariable("./testData", "xxx")
-	assert.Equal(t, "", result)
+	assert.Equal(t, 0, len(result))
 }

--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -165,14 +165,31 @@ func getRuntimeFromOsReleaseFile(osReleasePath string) string {
 }
 
 func getRuntime(procPath string, osReleasePath string, varName string) string {
-	value := proc.SearchProcsForEnvVariable(procPath, varName)
-	value = strings.Replace(value, "AWS_Lambda_", "", 1)
-	if len(value) == 0 {
-		value = getRuntimeFromOsReleaseFile(osReleasePath)
+	foundRuntimes := proc.SearchProcsForEnvVariable(procPath, varName)
+	fmt.Printf("found runtimes = %s\n", foundRuntimes)
+	runtime := cleanRuntimes(foundRuntimes)
+	fmt.Printf("cleaned runtimes = %s\n", runtime)
+	runtime = strings.Replace(runtime, "AWS_Lambda_", "", 1)
+	if len(runtime) == 0 {
+		runtime = getRuntimeFromOsReleaseFile(osReleasePath)
 	}
-	if len(value) == 0 {
+	if len(runtime) == 0 {
 		log.Debug("could not find a valid runtime, defaulting to unknown")
-		value = "unknown"
+		runtime = "unknown"
 	}
-	return value
+	return runtime
+}
+
+func cleanRuntimes(runtimes []string) string {
+	filtered := []string{}
+	for i := range runtimes {
+		if runtimes[i] != "AWS_Lambda_rapid" {
+			filtered = append(filtered, runtimes[i])
+		}
+	}
+	if len(filtered) != 1 {
+		log.Debug("could not find an unique value for runtime")
+		return ""
+	}
+	return filtered[0]
 }

--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -166,9 +166,7 @@ func getRuntimeFromOsReleaseFile(osReleasePath string) string {
 
 func getRuntime(procPath string, osReleasePath string, varName string) string {
 	foundRuntimes := proc.SearchProcsForEnvVariable(procPath, varName)
-	fmt.Printf("found runtimes = %s\n", foundRuntimes)
 	runtime := cleanRuntimes(foundRuntimes)
-	fmt.Printf("cleaned runtimes = %s\n", runtime)
 	runtime = strings.Replace(runtime, "AWS_Lambda_", "", 1)
 	if len(runtime) == 0 {
 		runtime = getRuntimeFromOsReleaseFile(osReleasePath)
@@ -188,7 +186,7 @@ func cleanRuntimes(runtimes []string) string {
 		}
 	}
 	if len(filtered) != 1 {
-		log.Debug("could not find an unique value for runtime")
+		log.Debug("could not find a unique value for runtime")
 		return ""
 	}
 	return filtered[0]

--- a/pkg/serverless/tags/tags_test.go
+++ b/pkg/serverless/tags/tags_test.go
@@ -315,3 +315,20 @@ func TestExtractRuntimeFromOsReleaseFileInvalidPath(t *testing.T) {
 	result := getRuntimeFromOsReleaseFile("/invalid/path")
 	assert.Equal(t, "", result)
 }
+
+func TestCleanRuntimeValid(t *testing.T) {
+	runtimes := []string{
+		"AWS_Lambda_rapid",
+		"AWS_Lambda_nodejs14.x",
+		"AWS_Lambda_rapid",
+	}
+	assert.Equal(t, "AWS_Lambda_nodejs14.x", cleanRuntimes(runtimes))
+}
+
+func TestCleanRuntimeInvalid(t *testing.T) {
+	runtimes := []string{
+		"toto",
+		"AWS_Lambda_nodejs14.x",
+	}
+	assert.Equal(t, "", cleanRuntimes(runtimes))
+}


### PR DESCRIPTION
### What does this PR do?

This PR fixes runtime detection.
Formerly we skipped pid = 1 to avoid detecting AWS_Lambda_rapid as runtime (since this is the internal API runtime name in AWS Lambda ecosystem). .NET integration tests have shown that this is not reliable so this PR fixes this behaviour. 

### Additional Notes

<img width="296" alt="Screen Shot 2021-11-22 at 11 17 26 AM" src="https://user-images.githubusercontent.com/864493/142843819-c1254439-062a-4ed2-afbe-f5c8c1328790.png">

### Describe how to test/QA your changes

Unit test + integration tests

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functi
onality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
