### PR TITLE
Align some metrics name with metadata.csv for container check + remove `cpu.shares`

### DIFF
--- a/pkg/collector/corechecks/containers/generic/processor.go
+++ b/pkg/collector/corechecks/containers/generic/processor.go
@@ -109,9 +109,8 @@ func (p *Processor) processContainer(sender aggregator.Sender, tags []string, co
 		p.sendMetric(sender.Rate, "container.cpu.usage", containerStats.CPU.Total, tags)
 		p.sendMetric(sender.Rate, "container.cpu.user", containerStats.CPU.User, tags)
 		p.sendMetric(sender.Rate, "container.cpu.system", containerStats.CPU.System, tags)
-		p.sendMetric(sender.Rate, "container.cpu.throttled.time", containerStats.CPU.ThrottledTime, tags)
+		p.sendMetric(sender.Rate, "container.cpu.throttled", containerStats.CPU.ThrottledTime, tags)
 		p.sendMetric(sender.Rate, "container.cpu.throttled.periods", containerStats.CPU.ThrottledPeriods, tags)
-		p.sendMetric(sender.Gauge, "container.cpu.shares", containerStats.CPU.Shares, tags)
 		// Convert CPU Limit to nanoseconds to allow easy percentage computation in the App.
 		if containerStats.CPU.Limit != nil {
 			p.sendMetric(sender.Gauge, "container.cpu.limit", util.Float64Ptr(*containerStats.CPU.Limit*float64(time.Second/100)), tags)
@@ -126,7 +125,7 @@ func (p *Processor) processContainer(sender aggregator.Sender, tags []string, co
 		p.sendMetric(sender.Gauge, "container.memory.rss", containerStats.Memory.RSS, tags)
 		p.sendMetric(sender.Gauge, "container.memory.cache", containerStats.Memory.Cache, tags)
 		p.sendMetric(sender.Gauge, "container.memory.swap", containerStats.Memory.Swap, tags)
-		p.sendMetric(sender.Gauge, "container.memory.oomevents", containerStats.Memory.OOMEvents, tags)
+		p.sendMetric(sender.Gauge, "container.memory.oom_events", containerStats.Memory.OOMEvents, tags)
 		p.sendMetric(sender.Gauge, "container.memory.working_set", containerStats.Memory.PrivateWorkingSet, tags)
 		p.sendMetric(sender.Gauge, "container.memory.commit", containerStats.Memory.CommitBytes, tags)
 		p.sendMetric(sender.Gauge, "container.memory.commit.peak", containerStats.Memory.CommitPeakBytes, tags)

--- a/pkg/collector/corechecks/containers/generic/processor_test.go
+++ b/pkg/collector/corechecks/containers/generic/processor_test.go
@@ -149,15 +149,14 @@ func TestProcessorRunFullStatsLinux(t *testing.T) {
 
 	expectedTags := []string{"runtime:docker"}
 	mockSender.AssertNumberOfCalls(t, "Rate", 13)
-	mockSender.AssertNumberOfCalls(t, "Gauge", 13)
+	mockSender.AssertNumberOfCalls(t, "Gauge", 12)
 
 	mockSender.AssertMetricInRange(t, "Gauge", "container.uptime", 0, 600, "", expectedTags)
 	mockSender.AssertMetric(t, "Rate", "container.cpu.usage", 100, "", expectedTags)
 	mockSender.AssertMetric(t, "Rate", "container.cpu.user", 300, "", expectedTags)
 	mockSender.AssertMetric(t, "Rate", "container.cpu.system", 200, "", expectedTags)
-	mockSender.AssertMetric(t, "Rate", "container.cpu.throttled.time", 100, "", expectedTags)
+	mockSender.AssertMetric(t, "Rate", "container.cpu.throttled", 100, "", expectedTags)
 	mockSender.AssertMetric(t, "Rate", "container.cpu.throttled.periods", 0, "", expectedTags)
-	mockSender.AssertMetric(t, "Gauge", "container.cpu.shares", 400, "", expectedTags)
 	mockSender.AssertMetric(t, "Gauge", "container.cpu.limit", 500000000, "", expectedTags)
 
 	mockSender.AssertMetric(t, "Gauge", "container.memory.usage", 100, "", expectedTags)
@@ -167,7 +166,7 @@ func TestProcessorRunFullStatsLinux(t *testing.T) {
 	mockSender.AssertMetric(t, "Gauge", "container.memory.rss", 300, "", expectedTags)
 	mockSender.AssertMetric(t, "Gauge", "container.memory.cache", 200, "", expectedTags)
 	mockSender.AssertMetric(t, "Gauge", "container.memory.swap", 0, "", expectedTags)
-	mockSender.AssertMetric(t, "Gauge", "container.memory.oomevents", 10, "", expectedTags)
+	mockSender.AssertMetric(t, "Gauge", "container.memory.oom_events", 10, "", expectedTags)
 
 	expectedFooTags := extraTags(expectedTags, "device_name:/dev/foo")
 	mockSender.AssertMetric(t, "Rate", "container.io.read", 100, "", expectedFooTags)


### PR DESCRIPTION
### What does this PR do?

Align metrics name with documentation following reviews in https://github.com/DataDog/integrations-core/pull/10577.
Removing reporting of `cpu.shares` as we may want to work more on it to propose something really usable.

### Motivation

Align with https://github.com/DataDog/integrations-core/pull/10577

### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

Run the generic `container` check (OOTB in most situations), verify the metrics name.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
