### PR TITLE
(rc) missing body close in RC's http client

### DIFF
--- a/pkg/config/remote/service/client.go
+++ b/pkg/config/remote/service/client.go
@@ -71,6 +71,7 @@ func (c *HTTPClient) Fetch(ctx context.Context, request *pbgo.ClientLatestConfig
 	if err != nil {
 		return nil, fmt.Errorf("failed to issue request: %w", err)
 	}
+	defer resp.Body.Close()
 
 	body, err = ioutil.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION

### What does this PR do?

Fix a leak in RC's http client.