### PR TITLE
[AD] Track children services before skipping duplicates

### DIFF
--- a/pkg/autodiscovery/listeners/workloadmeta.go
+++ b/pkg/autodiscovery/listeners/workloadmeta.go
@@ -93,6 +93,14 @@ func (l *workloadmetaListenerImpl) Store() workloadmeta.Store {
 }
 
 func (l *workloadmetaListenerImpl) AddService(svcID string, svc Service, parentSvcID string) {
+	if parentSvcID != "" {
+		if _, ok := l.children[parentSvcID]; !ok {
+			l.children[parentSvcID] = make(map[string]struct{})
+		}
+
+		l.children[parentSvcID][svcID] = struct{}{}
+	}
+
 	if old, found := l.services[svcID]; found {
 		if svcEqual(old, svc) {
 			log.Tracef("%s received a duplicated service '%s', ignoring", l.name, svc.GetEntity())
@@ -105,14 +113,6 @@ func (l *workloadmetaListenerImpl) AddService(svcID string, svc Service, parentS
 
 	l.services[svcID] = svc
 	l.newService <- svc
-
-	if parentSvcID != "" {
-		if _, ok := l.children[parentSvcID]; !ok {
-			l.children[parentSvcID] = make(map[string]struct{})
-		}
-
-		l.children[parentSvcID][svcID] = struct{}{}
-	}
 }
 
 func (l *workloadmetaListenerImpl) IsExcluded(ft containers.FilterType, name, image, ns string) bool {


### PR DESCRIPTION
### What does this PR do?

This fixes an issue where a container inside a pod would have its
services removed if any other service related to the pod was added,
changed or removed. This was very apparent whenever a container had a
check, another container in the pod was restarted, and all checks would
become unscheduled.

The issue happened because a change to a pod would cause all containers
to be re-inspected, and if they hadn't changed, they'd just get
unscheduled becase we skipped duplicated services before tracking the
parent-child relationship. We solved it by moving the tracking to before
the point where we do the skipping.

### Describe how to test/QA your changes

* Create a pod with two containers. Add annotations to target one of the containers for a check. Kill the container without annotations (using `docker kill` or `ctr --namespace k8s.io task rm` for example). Run `agent status` and check that the first container still has a check scheduled (it would be de-scheduled before this fix).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
