### PR TITLE
[CSPM] add configuration to disable rego evaluator

### DIFF
--- a/cmd/cluster-agent/app/compliance.go
+++ b/cmd/cluster-agent/app/compliance.go
@@ -90,6 +90,7 @@ func startCompliance(stopper restart.Stopper, apiCl *apiserver.APIClient, isLead
 	checkInterval := coreconfig.Datadog.GetDuration("compliance_config.check_interval")
 	checkMaxEvents := coreconfig.Datadog.GetInt("compliance_config.check_max_events_per_run")
 	configDir := coreconfig.Datadog.GetString("compliance_config.dir")
+	isRegoEvaluatorEnabled := coreconfig.Datadog.GetBool("compliance_config.rego_evaluator_enabled")
 
 	hostname, err := util.GetHostname(context.TODO())
 	if err != nil {
@@ -99,6 +100,7 @@ func startCompliance(stopper restart.Stopper, apiCl *apiserver.APIClient, isLead
 		reporter,
 		scheduler,
 		configDir,
+		isRegoEvaluatorEnabled,
 		checks.WithInterval(checkInterval),
 		checks.WithMaxEvents(checkMaxEvents),
 		checks.WithHostname(hostname),

--- a/cmd/cluster-agent/app/compliance.go
+++ b/cmd/cluster-agent/app/compliance.go
@@ -90,7 +90,7 @@ func startCompliance(stopper restart.Stopper, apiCl *apiserver.APIClient, isLead
 	checkInterval := coreconfig.Datadog.GetDuration("compliance_config.check_interval")
 	checkMaxEvents := coreconfig.Datadog.GetInt("compliance_config.check_max_events_per_run")
 	configDir := coreconfig.Datadog.GetString("compliance_config.dir")
-	isRegoEvaluatorEnabled := coreconfig.Datadog.GetBool("compliance_config.rego_evaluator_enabled")
+	isRegoEvaluatorEnabled := coreconfig.Datadog.GetBool("compliance_config.enable_rego_evaluator")
 
 	hostname, err := util.GetHostname(context.TODO())
 	if err != nil {

--- a/cmd/security-agent/app/compliance.go
+++ b/cmd/security-agent/app/compliance.go
@@ -126,6 +126,7 @@ func startCompliance(hostname string, stopper restart.Stopper, statsdClient *ddg
 	checkInterval := coreconfig.Datadog.GetDuration("compliance_config.check_interval")
 	checkMaxEvents := coreconfig.Datadog.GetInt("compliance_config.check_max_events_per_run")
 	configDir := coreconfig.Datadog.GetString("compliance_config.dir")
+	isRegoEvaluatorEnabled := coreconfig.Datadog.GetBool("compliance_config.rego_evaluator_enabled")
 
 	options := []checks.BuilderOption{
 		checks.WithInterval(checkInterval),
@@ -149,6 +150,7 @@ func startCompliance(hostname string, stopper restart.Stopper, statsdClient *ddg
 		reporter,
 		scheduler,
 		configDir,
+		isRegoEvaluatorEnabled,
 		options...,
 	)
 	if err != nil {

--- a/cmd/security-agent/app/compliance.go
+++ b/cmd/security-agent/app/compliance.go
@@ -126,7 +126,7 @@ func startCompliance(hostname string, stopper restart.Stopper, statsdClient *ddg
 	checkInterval := coreconfig.Datadog.GetDuration("compliance_config.check_interval")
 	checkMaxEvents := coreconfig.Datadog.GetInt("compliance_config.check_max_events_per_run")
 	configDir := coreconfig.Datadog.GetString("compliance_config.dir")
-	isRegoEvaluatorEnabled := coreconfig.Datadog.GetBool("compliance_config.rego_evaluator_enabled")
+	isRegoEvaluatorEnabled := coreconfig.Datadog.GetBool("compliance_config.enable_rego_evaluator")
 
 	options := []checks.BuilderOption{
 		checks.WithInterval(checkInterval),

--- a/pkg/compliance/agent/agent_test.go
+++ b/pkg/compliance/agent/agent_test.go
@@ -160,6 +160,7 @@ func TestRun(t *testing.T) {
 		reporter,
 		scheduler,
 		e.dir,
+		true,
 		checks.WithHostname("the-host"),
 		checks.WithHostRootMount(e.dir),
 		checks.WithDockerClient(dockerClient),

--- a/pkg/compliance/checks/builder.go
+++ b/pkg/compliance/checks/builder.go
@@ -47,7 +47,7 @@ const (
 
 // Builder defines an interface to build checks from rules
 type Builder interface {
-	ChecksFromFile(file string, onCheck compliance.CheckVisitor) error
+	ChecksFromFile(file string, isRegoEvaluatorEnabled bool, onCheck compliance.CheckVisitor) error
 	GetCheckStatus() compliance.CheckStatusList
 	Close() error
 }
@@ -354,8 +354,8 @@ func (b *builder) addCheckAndRun(suite *compliance.Suite, r *compliance.RuleComm
 	return nil
 }
 
-func (b *builder) ChecksFromFile(file string, onCheck compliance.CheckVisitor) error {
-	suite, err := compliance.ParseSuite(file)
+func (b *builder) ChecksFromFile(file string, isRegoEvaluatorEnabled bool, onCheck compliance.CheckVisitor) error {
+	suite, err := compliance.ParseSuite(file, isRegoEvaluatorEnabled)
 	if err != nil {
 		return err
 	}

--- a/pkg/compliance/mocks/builder.go
+++ b/pkg/compliance/mocks/builder.go
@@ -12,13 +12,13 @@ type Builder struct {
 	mock.Mock
 }
 
-// ChecksFromFile provides a mock function with given fields: file, onCheck
-func (_m *Builder) ChecksFromFile(file string, onCheck compliance.CheckVisitor) error {
-	ret := _m.Called(file, onCheck)
+// ChecksFromFile provides a mock function with given fields: file, isRegoEvaluatorEnabled, onCheck
+func (_m *Builder) ChecksFromFile(file string, isRegoEvaluatorEnabled bool, onCheck compliance.CheckVisitor) error {
+	ret := _m.Called(file, isRegoEvaluatorEnabled, onCheck)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, compliance.CheckVisitor) error); ok {
-		r0 = rf(file, onCheck)
+	if rf, ok := ret.Get(0).(func(string, bool, compliance.CheckVisitor) error); ok {
+		r0 = rf(file, isRegoEvaluatorEnabled, onCheck)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/pkg/compliance/suite.go
+++ b/pkg/compliance/suite.go
@@ -45,7 +45,7 @@ type yamlSuite struct {
 	Rules []map[string]interface{} `yaml:"rules,omitempty"`
 }
 
-func (ys *yamlSuite) toSuite() (*Suite, error) {
+func (ys *yamlSuite) toSuite(isRegoEvaluatorEnabled bool) (*Suite, error) {
 	s := &Suite{}
 	s.Meta = ys.Meta
 
@@ -55,7 +55,7 @@ func (ys *yamlSuite) toSuite() (*Suite, error) {
 			return nil, err
 		}
 
-		if _, ok := rule["input"]; ok {
+		if _, ok := rule["input"]; ok && isRegoEvaluatorEnabled {
 			var regoRule RegoRule
 			if err := yaml.Unmarshal(buffer, &regoRule); err != nil {
 				return nil, err
@@ -74,7 +74,7 @@ func (ys *yamlSuite) toSuite() (*Suite, error) {
 }
 
 // ParseSuite loads a single compliance suite
-func ParseSuite(config string) (*Suite, error) {
+func ParseSuite(config string, isRegoEvaluatorEnabled bool) (*Suite, error) {
 	c, err := semver.NewConstraint(versionConstraint)
 	if err != nil {
 		return nil, err
@@ -91,7 +91,7 @@ func ParseSuite(config string) (*Suite, error) {
 		return nil, err
 	}
 
-	s, err := ys.toSuite()
+	s, err := ys.toSuite(isRegoEvaluatorEnabled)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/compliance/suite_test.go
+++ b/pkg/compliance/suite_test.go
@@ -60,7 +60,7 @@ func TestParseSuite(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			actual, err := ParseSuite(test.file)
+			actual, err := ParseSuite(test.file, true)
 			assert.Equal(t, test.expectError, err)
 			assert.Equal(t, test.expectSuite, actual)
 		})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -937,6 +937,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("compliance_config.check_max_events_per_run", 100)
 	config.BindEnvAndSetDefault("compliance_config.dir", "/etc/datadog-agent/compliance.d")
 	config.BindEnvAndSetDefault("compliance_config.run_path", defaultRunPath)
+	config.BindEnvAndSetDefault("compliance_config.rego_evaluator_enabled", true)
 	config.BindEnv("compliance_config.run_commands_as")
 	bindEnvAndSetLogsConfigKeys(config, "compliance_config.endpoints.")
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -937,7 +937,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("compliance_config.check_max_events_per_run", 100)
 	config.BindEnvAndSetDefault("compliance_config.dir", "/etc/datadog-agent/compliance.d")
 	config.BindEnvAndSetDefault("compliance_config.run_path", defaultRunPath)
-	config.BindEnvAndSetDefault("compliance_config.rego_evaluator_enabled", true)
+	config.BindEnvAndSetDefault("compliance_config.enable_rego_evaluator", true)
 	config.BindEnv("compliance_config.run_commands_as")
 	bindEnvAndSetLogsConfigKeys(config, "compliance_config.endpoints.")
 


### PR DESCRIPTION
### What does this PR do?

This PR adds a configuration `compliance_config.rego_evaluator_enabled` that instructs the rego evaluator to be enabled or not. This will allow us to bundle rules with both rego and legacy and to have the possibility to fallback to legacy if something is not working.

### Possible Drawbacks / Trade-offs

TODO

### Describe how to test/QA your changes

TODO

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
