### PR TITLE
[CSPM] Escape regex end-of-line marker for `gen_mocks` to make it work with fish

### DIFF
--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -159,7 +159,7 @@ def gen_mocks(ctx):
         "Scheduler",
     ]
 
-    interface_regex = "|".join(f"^{i}$" for i in interfaces)
+    interface_regex = "|".join(f"^{i}\\$" for i in interfaces)
 
     with ctx.cd("./pkg/compliance"):
         ctx.run("mockery --case snake -r --name=\"{}\"".format(interface_regex))


### PR DESCRIPTION
### What does this PR do?

This PR escapes the "$" sign in the generated regex. This allows it to work with alternative shells, like fish.

To confirm that it is still working with bash/zsh: you can run `echo "^test\$"` and see that the output is still `^test$`.

### Motivation

Use this command with fish.

### Describe how to test/QA your changes

Should be a no-op.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
