### PR TITLE
[process/checks/container] Fix CPU % calculation

### DIFF
--- a/pkg/process/checks/container_test.go
+++ b/pkg/process/checks/container_test.go
@@ -131,9 +131,6 @@ func TestCalculateCtrPct(t *testing.T) {
 	// Time is empty
 	assert.Equal(t, float32(0), calculateCtrPct(3, 1, 0, 0, 1, emptyTime))
 
-	// Elapsed time is less than 1s
-	assert.Equal(t, float32(0), calculateCtrPct(3, 1, 0, 0, 1, time.Now()))
-
 	// Div by zero on sys2/sys1, fallback to normal cpu calculation
 	assert.InEpsilon(t, 50.0, calculateCtrPct(1.5*math.Pow10(9), math.Pow10(9), 1, 1, 1, before), epsilon)
 

--- a/pkg/process/checks/container_test.go
+++ b/pkg/process/checks/container_test.go
@@ -3,6 +3,7 @@
 package checks
 
 import (
+	"math"
 	"net"
 	"testing"
 	"time"
@@ -115,7 +116,7 @@ func TestContainerNils(t *testing.T) {
 }
 
 func TestCalculateCtrPct(t *testing.T) {
-	epsilon := 0.0000001 // Difference less than some epsilon
+	epsilon := 0.1 // Difference less than some epsilon
 
 	before := time.Now().Add(-1 * time.Second)
 
@@ -134,13 +135,13 @@ func TestCalculateCtrPct(t *testing.T) {
 	assert.Equal(t, float32(0), calculateCtrPct(3, 1, 0, 0, 1, time.Now()))
 
 	// Div by zero on sys2/sys1, fallback to normal cpu calculation
-	assert.InEpsilon(t, 2, calculateCtrPct(3, 1, 1, 1, 1, before), epsilon)
+	assert.InEpsilon(t, 50.0, calculateCtrPct(1.5*math.Pow10(9), math.Pow10(9), 1, 1, 1, before), epsilon)
 
 	// use cur=2, prev=0, sys1=0, sys2=2 simulating first check on new container
 	assert.InEpsilon(t, float32(200), calculateCtrPct(2, 0, 1, 0, 1, before), epsilon)
 
 	// Calculate based off cur & prev
-	assert.InEpsilon(t, 2, calculateCtrPct(3, 1, 0, 0, 1, before), epsilon)
+	assert.InEpsilon(t, 50.0, calculateCtrPct(1.5*math.Pow10(9), math.Pow10(9), 0, 0, 1, before), epsilon)
 
 	// Calculate based off all values
 	assert.InEpsilon(t, 66.66667, calculateCtrPct(3, 1, 4, 1, 1, before), epsilon)


### PR DESCRIPTION
### What does this PR do?

Fixes the CPU % calculation in the `container` check used by the process agent.

When deploying in ECS Fargate Windows, the CPU usage % shown in the live containers view is not accurate (percentage in the millions).

I think that the reason why this happens on ECS Fargate Windows is because `calculateCtrPct` receives 2 parameters (`sys2`, `sys1`) that are not exposed by the metadata endpoint on ECS Fargate Windows, so they're always set to 0. When that happens, the formula applied to calculate the % is `float32(cur-prev) / float32(diff)`. But I believe that's no correct because `cur` and `prev` are CPU usages in ns, and diff is in seconds. This PR fixes the issue.


### Describe how to test/QA your changes

- Deploy the agent on ECS Fargate Windows with the process agent enabled.
- Check that the CPU usage % shown in the containers live view looks reasonable.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
