### PR TITLE
Reset cloud-provider caches in net.TestDefaultHostConfig

### DIFF
--- a/pkg/collector/corechecks/net/ntp_test.go
+++ b/pkg/collector/corechecks/net/ntp_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders"
 )
 
 var (
@@ -336,6 +337,11 @@ hosts:
 }
 
 func TestDefaultHostConfig(t *testing.T) {
+	// Reset any cached cloud-provider information.  All clouds default to
+	// disabled, so without any cached data the Configure call below should
+	// fall back to the default configuration.
+	cloudproviders.ResetCaches()
+
 	expectedHosts := []string{"0.datadog.pool.ntp.org", "1.datadog.pool.ntp.org", "2.datadog.pool.ntp.org", "3.datadog.pool.ntp.org"}
 	testedConfig := []byte(``)
 	config.Datadog.Set("cloud_provider_metadata", []string{})

--- a/pkg/util/cloudproviders/alibaba/alibaba.go
+++ b/pkg/util/cloudproviders/alibaba/alibaba.go
@@ -72,3 +72,8 @@ func GetNTPHosts(ctx context.Context) []string {
 
 	return nil
 }
+
+// ResetCaches resets any caches containing alibaba-related data
+func ResetCaches() {
+	instanceIDFetcher.Reset()
+}

--- a/pkg/util/cloudproviders/azure/azure.go
+++ b/pkg/util/cloudproviders/azure/azure.go
@@ -171,3 +171,10 @@ func getHostnameWithConfig(ctx context.Context, config config.Config) (string, e
 
 	return name, nil
 }
+
+// ResetCaches resets any caches containing Azure-related data
+func ResetCaches() {
+	vmIDFetcher.Reset()
+	resourceGroupNameFetcher.Reset()
+	instanceMetaFetcher.Reset()
+}

--- a/pkg/util/cloudproviders/cloudproviders.go
+++ b/pkg/util/cloudproviders/cloudproviders.go
@@ -125,3 +125,13 @@ func GetHostAliases(ctx context.Context) []string {
 
 	return util.SortUniqInPlace(aliases)
 }
+
+// ResetCaches resets any caches containing cloud-provider-related data.
+func ResetCaches() {
+	ecs.ResetCaches()
+	ec2.ResetCaches()
+	gce.ResetCaches()
+	azure.ResetCaches()
+	alibaba.ResetCaches()
+	tencent.ResetCaches()
+}

--- a/pkg/util/cloudproviders/gce/gce.go
+++ b/pkg/util/cloudproviders/gce/gce.go
@@ -232,3 +232,12 @@ func getResponse(ctx context.Context, url string) (string, error) {
 func HostnameProvider(ctx context.Context, options map[string]interface{}) (string, error) {
 	return GetHostname(ctx)
 }
+
+// ResetCaches resets any caches containing EC2-related data
+func ResetCaches() {
+	hostnameFetcher.Reset()
+	nameFetcher.Reset()
+	projectIDFetcher.Reset()
+	clusterNameFetcher.Reset()
+	publicIPv4Fetcher.Reset()
+}

--- a/pkg/util/cloudproviders/tencent/tencent.go
+++ b/pkg/util/cloudproviders/tencent/tencent.go
@@ -92,3 +92,8 @@ func getMetadataItem(ctx context.Context, endpoint string) (string, error) {
 	}
 	return res, nil
 }
+
+// ResetCaches resets any caches containing tencent-related data
+func ResetCaches() {
+	instanceIDFetcher.Reset()
+}

--- a/pkg/util/ec2/ec2.go
+++ b/pkg/util/ec2/ec2.go
@@ -348,3 +348,11 @@ func HostnameProvider(ctx context.Context, options map[string]interface{}) (stri
 	log.Debug("GetHostname trying EC2 metadata...")
 	return GetInstanceID(ctx)
 }
+
+// ResetCaches resets any caches containing EC2-related data
+func ResetCaches() {
+	instanceIDFetcher.Reset()
+	localIPv4Fetcher.Reset()
+	hostnameFetcher.Reset()
+	networkIDFetcher.Reset()
+}

--- a/pkg/util/ecs/detection.go
+++ b/pkg/util/ecs/detection.go
@@ -143,3 +143,10 @@ func newBoolEntry(v bool) (bool, time.Duration) {
 	}
 	return v, cache.NoExpiration
 }
+
+// ResetCaches resets any caches containing ECS detection-related data.
+func ResetCaches() {
+	cache.Cache.Delete(isFargateInstanceCacheKey)
+	cache.Cache.Delete(hasFargateResourceTagsCacheKey)
+	cache.Cache.Delete(hasEC2ResourceTagsCacheKey)
+}


### PR DESCRIPTION
### What does this PR do?

Adds support for resetting the cloud-provider caches, since those can be invalidated by configuration changes during testing.

### Motivation

Intermittent test due to cached data

### Possible Drawbacks / Trade-offs

This isn't a blanket fix for all race conditions based on cached cloud data, since it only actually resets the caches in this one case.  Let's see what other cases come up.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
