### PR TITLE
[AD/listeners] Create container listener when running on ECS Fargate Windows

### DIFF
--- a/pkg/autodiscovery/listeners/environment.go
+++ b/pkg/autodiscovery/listeners/environment.go
@@ -75,7 +75,7 @@ func (l *EnvironmentListener) createServices() {
 	if runtime.GOOS == "linux" {
 		containerFeatures = []config.Feature{config.Docker, config.Containerd, config.Kubernetes, config.ECSFargate}
 	} else if runtime.GOOS == "windows" {
-		containerFeatures = []config.Feature{config.Docker, config.Containerd}
+		containerFeatures = []config.Feature{config.Docker, config.Containerd, config.ECSFargate}
 	}
 
 	for _, f := range containerFeatures {


### PR DESCRIPTION
### What does this PR do?

Enables the `container` listener on Windows when ECS Fargate is enabled.

When the ECS Fargate container collector was added in https://github.com/DataDog/datadog-agent/pull/9739 we didn't enable the container listener on Windows because we were still working on supporting it. Now there's no reason not to enable it.

With this change, the agent will report the `container.*` metrics when deployed on ECS Fargate Windows, although it reports less metrics than when running on Linux.

### Describe how to test/QA your changes

- Deploy the agent on ECS Fargate Windows.
- Check that it reports the `container.*` metrics. You can check the list here: https://github.com/DataDog/integrations-core/blob/master/container/metadata.csv but keep in mind that on Windows some of those are not reported. You should check metrics like `container.uptime`, `container.cpu.user`, `container.cpu.system`, `container.memory.usage`, etc.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
