### PR TITLE
Do not include the same env var multiple times

### DIFF
--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -28,7 +28,10 @@ type safeConfig struct {
 	sync.RWMutex
 	envPrefix      string
 	envKeyReplacer *strings.Replacer
-	configEnvVars  map[string]struct{}
+
+	// configEnvVars is the set of env vars that are consulted for
+	// configuration values.
+	configEnvVars map[string]struct{}
 }
 
 // Set wraps Viper for concurrent access

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -28,7 +28,7 @@ type safeConfig struct {
 	sync.RWMutex
 	envPrefix      string
 	envKeyReplacer *strings.Replacer
-	configEnvVars  []string
+	configEnvVars  map[string]struct{}
 }
 
 // Set wraps Viper for concurrent access
@@ -294,7 +294,7 @@ func (c *safeConfig) BindEnv(input ...string) {
 		if c.envKeyReplacer != nil {
 			key = c.envKeyReplacer.Replace(key)
 		}
-		c.configEnvVars = append(c.configEnvVars, key)
+		c.configEnvVars[key] = struct{}{}
 	}
 
 	_ = c.Viper.BindEnv(input...)
@@ -411,7 +411,11 @@ func (c *safeConfig) BindPFlag(key string, flag *pflag.Flag) error {
 
 // GetEnvVars implements the Config interface
 func (c *safeConfig) GetEnvVars() []string {
-	return c.configEnvVars
+	vars := make([]string, 0, len(c.configEnvVars))
+	for v := range c.configEnvVars {
+		vars = append(vars, v)
+	}
+	return vars
 }
 
 // BindEnvAndSetDefault implements the Config interface
@@ -423,7 +427,8 @@ func (c *safeConfig) BindEnvAndSetDefault(key string, val interface{}, env ...st
 // NewConfig returns a new Config object.
 func NewConfig(name string, envPrefix string, envKeyReplacer *strings.Replacer) Config {
 	config := safeConfig{
-		Viper: viper.New(),
+		Viper:         viper.New(),
+		configEnvVars: map[string]struct{}{},
 	}
 	config.SetConfigName(name)
 	config.SetEnvPrefix(envPrefix)

--- a/pkg/config/viper_test.go
+++ b/pkg/config/viper_test.go
@@ -91,9 +91,16 @@ func TestGetConfigEnvVars(t *testing.T) {
 
 	config.BindEnv("config_option", "DD_CONFIG_OPTION")
 	assert.Contains(t, config.GetEnvVars(), "DD_CONFIG_OPTION")
+}
 
-	// check for de-duplication
-	config.BindEnv("config_option_again", "DD_CONFIG_OPTION")
+// check for de-duplication of environment variables by declaring two
+// config parameters using DD_CONFIG_OPTION, and asserting that
+// GetConfigVars only returns that env var once.
+func TestGetConfigEnvVarsDedupe(t *testing.T) {
+	config := NewConfig("test", "DD", strings.NewReplacer(".", "_"))
+
+	config.BindEnv("config_option_1", "DD_CONFIG_OPTION")
+	config.BindEnv("config_option_2", "DD_CONFIG_OPTION")
 	count := 0
 	for _, v := range config.GetEnvVars() {
 		if v == "DD_CONFIG_OPTION" {

--- a/pkg/config/viper_test.go
+++ b/pkg/config/viper_test.go
@@ -91,6 +91,16 @@ func TestGetConfigEnvVars(t *testing.T) {
 
 	config.BindEnv("config_option", "DD_CONFIG_OPTION")
 	assert.Contains(t, config.GetEnvVars(), "DD_CONFIG_OPTION")
+
+	// check for de-duplication
+	config.BindEnv("config_option_again", "DD_CONFIG_OPTION")
+	count := 0
+	for _, v := range config.GetEnvVars() {
+		if v == "DD_CONFIG_OPTION" {
+			count++
+		}
+	}
+	assert.Equal(t, 1, count)
 }
 
 func TestGetFloat64SliceE(t *testing.T) {


### PR DESCRIPTION
When multiple config parameters use BindEnv for the same env var, the
agent should still only list the env var once.

### Motivation

Duplicate env vars in envvars.log in flares.  This can occur when multiple calls to config.BindEnv specify the same env var (for example, various config values default to DD_SITE).

### Describe how to test/QA your changes

Start an agent, create a flare, and verify that DD_SITE appears only once in envvars.log in the flare.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
