### PR TITLE
[tagger] Delete unseen children entities

### DIFF
--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -110,6 +110,19 @@ func (c *WorkloadMetaCollector) processEvents(evBundle workloadmeta.EventBundle)
 
 		switch ev.Type {
 		case workloadmeta.EventTypeSet:
+			taggerEntityID := buildTaggerEntityID(entityID)
+
+			// keep track of children of this entity from previous
+			// iterations ...
+			unseen := make(map[string]struct{})
+			for childTaggerID := range c.children[taggerEntityID] {
+				unseen[childTaggerID] = struct{}{}
+			}
+
+			// ... and create a new empty map to store the children
+			// seen in this iteration.
+			c.children[taggerEntityID] = make(map[string]struct{})
+
 			switch entityID.Kind {
 			case workloadmeta.KindContainer:
 				tagInfos = append(tagInfos, c.handleContainer(ev)...)
@@ -120,6 +133,17 @@ func (c *WorkloadMetaCollector) processEvents(evBundle workloadmeta.EventBundle)
 			default:
 				log.Errorf("cannot handle event for entity %q with kind %q", entityID.ID, entityID.Kind)
 			}
+
+			// remove the children seen in this iteration from the
+			// unseen list ...
+			for childTaggerID := range c.children[taggerEntityID] {
+				delete(unseen, childTaggerID)
+			}
+
+			// ... and remove entities for everything that has been
+			// left
+			source := buildTaggerSource(entityID)
+			tagInfos = append(tagInfos, c.handleDeleteChildren(source, unseen)...)
 
 		case workloadmeta.EventTypeUnset:
 			tagInfos = append(tagInfos, c.handleDelete(ev)...)
@@ -482,13 +506,20 @@ func (c *WorkloadMetaCollector) handleDelete(ev workloadmeta.Event) []*TagInfo {
 
 	children := c.children[taggerEntityID]
 
-	source := fmt.Sprintf("%s-%s", workloadmetaCollectorName, string(entityID.Kind))
+	source := buildTaggerSource(entityID)
 	tagInfos := make([]*TagInfo, 0, len(children)+1)
 	tagInfos = append(tagInfos, &TagInfo{
 		Source:       source,
 		Entity:       taggerEntityID,
 		DeleteEntity: true,
 	})
+	tagInfos = append(tagInfos, c.handleDeleteChildren(source, children)...)
+
+	return tagInfos
+}
+
+func (c *WorkloadMetaCollector) handleDeleteChildren(source string, children map[string]struct{}) []*TagInfo {
+	tagInfos := make([]*TagInfo, 0, len(children))
 
 	for childEntityID := range children {
 		t := TagInfo{
@@ -542,6 +573,10 @@ func buildTaggerEntityID(entityID workloadmeta.EntityID) string {
 		log.Errorf("can't recognize entity %q with kind %q, but building a a tagger ID anyway", entityID.ID, entityID.Kind)
 		return containers.BuildEntityName(string(entityID.Kind), entityID.ID)
 	}
+}
+
+func buildTaggerSource(entityID workloadmeta.EntityID) string {
+	return fmt.Sprintf("%s-%s", workloadmetaCollectorName, string(entityID.Kind))
 }
 
 func parseJSONValue(value string, tags *utils.TagList) error {


### PR DESCRIPTION
### What does this PR do?

This is the tagger counterpart to
6517d1299c8c0517ee30651e00da8b1a3d7963d5. The tagger would not prune
containers that went away from inside a pod (i.e. a restarted container)
until the pod itself went away. This makes a single pod in eternal
CrashLoopBackoff eat away memory unrestricted. Now we use the exact same
strategy used by the aforementioned commit.

### Describe how to test/QA your changes

Use the following deployment manifest to create a pod in CLB:

```
apiVersion: apps/v1
kind: Deployment
metadata:
  name: crashloop
  namespace: default
spec:
  replicas: 1
  selector:
    matchLabels:
      app: crashloop
  template:
    metadata:
      labels:
        app: crashloop
    spec:
      containers:
      - image: busybox
        name: crashloop
        command: ["/bin/sh"]
        args: ["-c", "sleep 15 && exit 1"]
        ports:
        - containerPort: 80
```

Check how many container entities that creates over time with `agent tagger-list`. It should not grow indefinitely (take into account it takes ~5 minutes for each of them to go away after the container's dead).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
