### PR TITLE
[Serverless] Fix flaky test

### DIFF
--- a/pkg/serverless/trace/trace_test.go
+++ b/pkg/serverless/trace/trace_test.go
@@ -63,22 +63,12 @@ func TestStartEnabledTrueValidConfigValidPath(t *testing.T) {
 	assert.NotNil(t, agent.ta)
 	assert.NotNil(t, agent.Get())
 	assert.NotNil(t, agent.cancel)
-
 }
 
 func TestLoadConfigShouldBeFast(t *testing.T) {
-	timeout := time.After(1 * time.Second)
-	done := make(chan bool)
-	go func() {
-		var agent = &ServerlessTraceAgent{}
-		agent.Start(true, &LoadConfig{Path: "./testdata/valid.yml"})
-		defer agent.Stop()
-		done <- true
-	}()
-
-	select {
-	case <-timeout:
-		t.Fatal("Tracer config load/validation is too long")
-	case <-done:
-	}
+	startTime := time.Now()
+	agent := &ServerlessTraceAgent{}
+	agent.Start(true, &LoadConfig{Path: "./testdata/valid.yml"})
+	defer agent.Stop()
+	assert.True(t, time.Since(startTime) < time.Second)
 }


### PR DESCRIPTION
### What does this PR do?

Fix a flaky test (due to race condition) by removing the useless go routine

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
