### PR TITLE
Add an `sslkeylogfile` parameter to store the TLS master secrets

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -187,6 +187,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("cloud_provider_metadata", []string{"aws", "gcp", "azure", "alibaba"})
 	config.SetDefault("proxy", nil)
 	config.BindEnvAndSetDefault("skip_ssl_validation", false)
+	config.BindEnvAndSetDefault("sslkeylogfile", "")
 	config.BindEnvAndSetDefault("hostname", "")
 	config.BindEnvAndSetDefault("hostname_file", "")
 	config.BindEnvAndSetDefault("tags", []string{})

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -52,10 +52,10 @@ api_key:
 
 ## @param sslkeylogfile - string - optional - default: ""
 ## @env DD_SSLKEYLOGFILE - string - optional - default: ""
-## sslkeylogfile optionally specifies a destination for TLS master secrets
-## in NSS key log format that can be used to allow external programs
+## sslkeylogfile specifies a destination for TLS master secrets
+## in NSS key log format to allow external programs
 ## such as Wireshark to decrypt TLS connections.
-## See https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format.
+## For more details, see https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format.
 ## Use of sslkeylogfile compromises security and should only be
 ## used for debugging.
 # sslkeylogfile: ""

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -50,6 +50,17 @@ api_key:
 #
 # skip_ssl_validation: false
 
+## @param sslkeylogfile - string - optional - default: ""
+## @env DD_SSLKEYLOGFILE - string - optional - default: ""
+## sslkeylogfile optionally specifies a destination for TLS master secrets
+## in NSS key log format that can be used to allow external programs
+## such as Wireshark to decrypt TLS connections.
+## See https://developer.mozilla.org/en-US/docs/Mozilla/Projects/NSS/Key_Log_Format.
+## Use of sslkeylogfile compromises security and should only be
+## used for debugging.
+# sslkeylogfile: ""
+
+
 ## @param force_tls_12 - boolean - optional - default: false
 ## @env DD_FORCE_TLS_12 - boolean - optional - default: false
 ## Setting this option to "true" forces the Agent to only use TLS 1.2 when

--- a/pkg/util/http/transport.go
+++ b/pkg/util/http/transport.go
@@ -11,6 +11,7 @@ import (
 	"net"
 	"net/http"
 	"net/url"
+	"os"
 	"strings"
 	"sync"
 	"time"
@@ -32,6 +33,9 @@ var (
 
 	// NoProxyMapMutex Lock for all no proxy maps
 	NoProxyMapMutex = sync.Mutex{}
+
+	keyLogWriterInit sync.Once
+	keyLogWriter     *os.File
 )
 
 func logSafeURLString(url *url.URL) string {
@@ -52,7 +56,22 @@ func warnOnce(warnMap map[string]bool, key string, format string, params ...inte
 
 // CreateHTTPTransport creates an *http.Transport for use in the agent
 func CreateHTTPTransport() *http.Transport {
+	// It’s OK to reuse the same file for all the http.Transport objects we create
+	// because all the writes to that file are protected by a global mutex.
+	// See https://github.com/golang/go/blob/go1.17.3/src/crypto/tls/common.go#L1316-L1318
+	keyLogWriterInit.Do(func() {
+		sslKeyLogFile := config.Datadog.GetString("sslkeylogfile")
+		if sslKeyLogFile != "" {
+			var err error
+			keyLogWriter, err = os.OpenFile(sslKeyLogFile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
+			if err != nil {
+				log.Warnf("Failed to open %s for writing NSS keys: %v", sslKeyLogFile, err)
+			}
+		}
+	})
+
 	tlsConfig := &tls.Config{
+		KeyLogWriter:       keyLogWriter,
 		InsecureSkipVerify: config.Datadog.GetBool("skip_ssl_validation"),
 	}
 


### PR DESCRIPTION
### What does this PR do?

Add a `sslkeylogfile` config parameter and its corresponding `DD_SSLKEYLOGFILE` environment variable to specify a file to store the TLS secrets used by the agent.
This file can then be used by wireshark to decipher the encrypted traffic.

### Motivation

There are classes of issues that require to inspect the network traffic for troubleshooting.
Typically, when an agent sends a payload to an intake and the intake rejects that payload, we need to have a way to look at what is precisely the rejected query.

### Additional Notes

This option compromises security and should only be used for debugging.

The name of the environment variable has been chosen to be consistent with other software modulo the `DD_` prefix.
Firefox, Chrome and curl are all 3 using `SSLKEYLOGFILE` environment variable to dump the TLS secrets.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Check that the [“Dump the encrypted traffic generated by a datadog agent” howto](https://datadoghq.atlassian.net/l/c/xVLQ9i1C) works as expected.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [X] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [X] The appropriate `team/..` label has been applied, if known.
- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [X] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [X] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [X] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [X] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
