### PR TITLE
Minor improvements to inventories_min/max_interval

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1592,3 +1592,21 @@ func GetVectorURL(datatype DataType) (string, error) {
 	}
 	return "", nil
 }
+
+// GetInventoriesMinInterval gets the inventories_min_interval value, applying the default if it is zero.
+func GetInventoriesMinInterval() time.Duration {
+	minInterval := time.Duration(Datadog.GetInt("inventories_min_interval")) * time.Second
+	if minInterval == 0 {
+		minInterval = DefaultInventoriesMinInterval
+	}
+	return minInterval
+}
+
+// GetInventoriesMaxInterval gets the inventories_max_interval value, applying the default if it is zero.
+func GetInventoriesMaxInterval() time.Duration {
+	maxInterval := time.Duration(Datadog.GetInt("inventories_max_interval")) * time.Second
+	if maxInterval == 0 {
+		maxInterval = DefaultInventoriesMaxInterval
+	}
+	return maxInterval
+}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -83,10 +83,10 @@ const (
 	DefaultLogsSenderBackoffRecoveryInterval = 2
 
 	// DefaultInventoriesMinInterval is the default value for inventories_min_interval, in seconds
-	DefaultInventoriesMinInterval = 300 // 5min
+	DefaultInventoriesMinInterval = 5 * 60
 
 	// DefaultInventoriesMaxInterval is the default value for inventories_max_interval, in seconds
-	DefaultInventoriesMaxInterval = 600 // 10min
+	DefaultInventoriesMaxInterval = 10 * 60
 )
 
 // Datadog is the global configuration object

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -81,6 +81,12 @@ const (
 
 	// DefaultLogsSenderBackoffRecoveryInterval is the default logs sender backoff recovery interval
 	DefaultLogsSenderBackoffRecoveryInterval = 2
+
+	// DefaultInventoriesMinInterval is the default value for inventories_min_interval, in seconds
+	DefaultInventoriesMinInterval = 300 // 5min
+
+	// DefaultInventoriesMaxInterval is the default value for inventories_max_interval, in seconds
+	DefaultInventoriesMaxInterval = 600 // 10min
 )
 
 // Datadog is the global configuration object
@@ -916,8 +922,8 @@ func InitConfig(config Config) {
 
 	// inventories
 	config.BindEnvAndSetDefault("inventories_enabled", true)
-	config.BindEnvAndSetDefault("inventories_max_interval", 600) // 10min
-	config.BindEnvAndSetDefault("inventories_min_interval", 300) // 5min
+	config.BindEnvAndSetDefault("inventories_max_interval", DefaultInventoriesMaxInterval) // integer seconds
+	config.BindEnvAndSetDefault("inventories_min_interval", DefaultInventoriesMinInterval) // integer seconds
 
 	// Datadog security agent (common)
 	config.BindEnvAndSetDefault("security_agent.cmd_port", 5010)

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1026,3 +1026,25 @@ network_devices:
 	config = setupConfFromYAML(datadogYaml)
 	assert.Equal(t, "dev", config.GetString("network_devices.namespace"))
 }
+
+func TestGetInventoriesMinInterval(t *testing.T) {
+	Mock().Set("inventories_min_interval", 6)
+	assert.EqualValues(t, 6*time.Second, GetInventoriesMinInterval())
+}
+
+func TestGetInventoriesMinIntervalInvalid(t *testing.T) {
+	// an invalid integer results in a value of 0 from Viper (with a logged warning)
+	Mock().Set("inventories_min_interval", 0)
+	assert.EqualValues(t, DefaultInventoriesMinInterval, GetInventoriesMinInterval())
+}
+
+func TestGetInventoriesMaxInterval(t *testing.T) {
+	Mock().Set("inventories_max_interval", 6)
+	assert.EqualValues(t, 6*time.Second, GetInventoriesMaxInterval())
+}
+
+func TestGetInventoriesMaxIntervalInvalid(t *testing.T) {
+	// an invalid integer results in a value of 0 from Viper (with a logged warning)
+	Mock().Set("inventories_max_interval", 0)
+	assert.EqualValues(t, DefaultInventoriesMaxInterval, GetInventoriesMaxInterval())
+}

--- a/pkg/metadata/inventories_collector.go
+++ b/pkg/metadata/inventories_collector.go
@@ -50,7 +50,11 @@ func (c inventoriesCollector) Send(ctx context.Context, s *serializer.Serializer
 // all agents that wish to track inventory, after configuration is initialized.
 func (c inventoriesCollector) Init() error {
 	inventories.InitializeData()
-	return inventories.StartMetadataUpdatedGoroutine(c.sc, time.Duration(config.Datadog.GetInt("inventories_min_interval"))*time.Second)
+	minInterval := time.Duration(config.Datadog.GetInt("inventories_min_interval")) * time.Second
+	if minInterval == 0 {
+		minInterval = config.DefaultInventoriesMinInterval
+	}
+	return inventories.StartMetadataUpdatedGoroutine(c.sc, minInterval)
 }
 
 // SetupInventoriesExpvar init the expvar function for inventories
@@ -75,7 +79,11 @@ func SetupInventories(sc *Scheduler, ac inventories.AutoConfigInterface, coll in
 	}
 	RegisterCollector("inventories", ic)
 
-	if err := sc.AddCollector("inventories", time.Duration(config.Datadog.GetInt("inventories_max_interval"))*time.Second); err != nil {
+	maxInterval := time.Duration(config.Datadog.GetInt("inventories_max_interval")) * time.Second
+	if maxInterval == 0 {
+		maxInterval = config.DefaultInventoriesMaxInterval
+	}
+	if err := sc.AddCollector("inventories", maxInterval); err != nil {
 		return err
 	}
 

--- a/pkg/metadata/inventories_collector.go
+++ b/pkg/metadata/inventories_collector.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"expvar"
 	"fmt"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/inventories"
@@ -50,11 +49,7 @@ func (c inventoriesCollector) Send(ctx context.Context, s *serializer.Serializer
 // all agents that wish to track inventory, after configuration is initialized.
 func (c inventoriesCollector) Init() error {
 	inventories.InitializeData()
-	minInterval := time.Duration(config.Datadog.GetInt("inventories_min_interval")) * time.Second
-	if minInterval == 0 {
-		minInterval = config.DefaultInventoriesMinInterval
-	}
-	return inventories.StartMetadataUpdatedGoroutine(c.sc, minInterval)
+	return inventories.StartMetadataUpdatedGoroutine(c.sc, config.GetInventoriesMinInterval())
 }
 
 // SetupInventoriesExpvar init the expvar function for inventories
@@ -79,11 +74,7 @@ func SetupInventories(sc *Scheduler, ac inventories.AutoConfigInterface, coll in
 	}
 	RegisterCollector("inventories", ic)
 
-	maxInterval := time.Duration(config.Datadog.GetInt("inventories_max_interval")) * time.Second
-	if maxInterval == 0 {
-		maxInterval = config.DefaultInventoriesMaxInterval
-	}
-	if err := sc.AddCollector("inventories", maxInterval); err != nil {
+	if err := sc.AddCollector("inventories", config.GetInventoriesMaxInterval()); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
### What does this PR do?

The config values `inventories_min_interval` and `inventories_max_interval` are configured as integers, but if the user uses a non-integer such as "a few minutes" then Viper helpfully reads that as `0` and logs a warning message.

So, this protects interpreting such durations as zero seconds, which would otherwise result in spamming the inventories intake with data.  Instead, it applies the defaults.

### Describe how to test/QA your changes

Enable log_payloads.  Configure each configuration value to a non-integer, and observe that a warning is logged and that the agent is not constantly logging metadata payloads.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
