### PR TITLE
[install_script] Fix repofile creation on OpenSUSE 42

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -488,7 +488,7 @@ elif [ "$OS" = "SUSE" ]; then
   # See https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15/#fate-324409
   SUSE_VER=$(cat /etc/os-release 2>/dev/null | grep VERSION_ID | tr -d '"' | tr . = | cut -d = -f 2 | xargs echo)
   gpgkeys="https://${keys_url}/DATADOG_RPM_KEY_CURRENT.public"
-  if [ -n "$SUSE_VER" ] && { [ "$SUSE_VER" -ge 15 ] && [ "$SUSE_VER" -ne 42 ]; }; then
+  if [ -n "$SUSE_VER" ] && [ "$SUSE_VER" -ge 15 ] && [ "$SUSE_VER" -ne 42 ]; then
     gpgkeys=''
     separator='\n       '
     for key_path in "${RPM_GPG_KEYS[@]}"; do

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -488,7 +488,7 @@ elif [ "$OS" = "SUSE" ]; then
   # See https://www.suse.com/releasenotes/x86_64/SUSE-SLES/15/#fate-324409
   SUSE_VER=$(cat /etc/os-release 2>/dev/null | grep VERSION_ID | tr -d '"' | tr . = | cut -d = -f 2 | xargs echo)
   gpgkeys="https://${keys_url}/DATADOG_RPM_KEY_CURRENT.public"
-  if [ -n "$SUSE_VER" ] && [ "$SUSE_VER" -ge 15 ]; then
+  if [ -n "$SUSE_VER" ] && { [ "$SUSE_VER" -ge 15 ] && [ "$SUSE_VER" -ne 42 ]; }; then
     gpgkeys=''
     separator='\n       '
     for key_path in "${RPM_GPG_KEYS[@]}"; do

--- a/releasenotes-installscript/notes/fix-opensuse-42-repofile-f31695091ec9e3fb.yaml
+++ b/releasenotes-installscript/notes/fix-opensuse-42-repofile-f31695091ec9e3fb.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG-INSTALLSCRIPT.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Zypper repofile is now created correctly with only one gpgkey entry
+    on OpenSUSE 42.


### PR DESCRIPTION
### What does this PR do?

Fixes repofile creation on OpenSUSE 42 - OpenSUSE 42 doesn't tolerate multiple `gpgkey=` entries. We previously had a condition on version being lower than 15, which obviously doesn't work for 42 (while 42 is still a previous version to 15).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Try invoking the install_script.sh on OpenSUSE 42 system - it should not fail.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
