### PR TITLE
[containers/metrics/provider] Log collector ID in debug msg

### DIFF
--- a/pkg/util/containers/v2/metrics/provider/provider.go
+++ b/pkg/util/containers/v2/metrics/provider/provider.go
@@ -155,7 +155,7 @@ func (mp *GenericProvider) retryCollectors(cacheValidity time.Duration) {
 		} else {
 			if errors.Is(err, ErrPermaFail) {
 				delete(mp.collectors, collectorEntry.ID)
-				log.Debugf("Metrics collector: %s went into PermaFail, removed from candidates")
+				log.Debugf("Metrics collector: %s went into PermaFail, removed from candidates", collector.ID())
 			}
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

Adds a missing collector ID in a debug log from the containers metrics provider.

### Motivation

Useful for debugging.

### Describe how to test/QA your changes

Skip.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
