### PR TITLE
fix: Add missing node tag to kubernetes_state.pod.count metric

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
@@ -146,28 +146,28 @@
 : Describes the reason the container is currently in terminated state. Tags:`kube_namespace` `pod_name` `kube_container_name` `reason` (`env` `service` `version` from standard labels).
 
 `kubernetes_state.pod.ready`
-: Describes whether the pod is ready to serve requests. Tags:`kube_namespace` `pod_name` `condition` (`env` `service` `version` from standard labels).
+: Describes whether the pod is ready to serve requests. Tags:`node` `kube_namespace` `pod_name` `condition` (`env` `service` `version` from standard labels).
 
 `kubernetes_state.pod.scheduled`
-: Describes the status of the scheduling process for the pod. Tags:`kube_namespace` `pod_name` `condition` (`env` `service` `version` from standard labels).
+: Describes the status of the scheduling process for the pod. Tags:`node` `kube_namespace` `pod_name` `condition` (`env` `service` `version` from standard labels).
 
 `kubernetes_state.pod.volumes.persistentvolumeclaims_readonly`
-: Describes whether a persistentvolumeclaim is mounted read only. Tags:`kube_namespace` `pod_name` `volume` `persistentvolumeclaim` (`env` `service` `version` from standard labels).
+: Describes whether a persistentvolumeclaim is mounted read only. Tags:`node` `kube_namespace` `pod_name` `volume` `persistentvolumeclaim` (`env` `service` `version` from standard labels).
 
 `kubernetes_state.pod.unschedulable`
 : Describes the unschedulable status for the pod. Tags:`kube_namespace` `pod_name` (`env` `service` `version` from standard labels).
 
 `kubernetes_state.pod.status_phase`
-: The pods current phase. Tags:`kube_namespace` `pod_name` `pod_phase` (`env` `service` `version` from standard labels).
+: The pods current phase. Tags:`node` `kube_namespace` `pod_name` `pod_phase` (`env` `service` `version` from standard labels).
 
 `kubernetes_state.pod.age`
-: The time in seconds since the creation of the pod. Tags:`kube_namespace` `pod_name` `pod_phase` (`env` `service` `version` from standard labels).
+: The time in seconds since the creation of the pod. Tags:`node` `kube_namespace` `pod_name` `pod_phase` (`env` `service` `version` from standard labels).
 
 `kubernetes_state.pod.uptime`
-: The time in seconds since the pod has been scheduled and acknowledged by the Kubelet. Tags:`kube_namespace` `pod_name` `pod_phase` (`env` `service` `version` from standard labels).
+: The time in seconds since the pod has been scheduled and acknowledged by the Kubelet. Tags:`node` `kube_namespace` `pod_name` `pod_phase` (`env` `service` `version` from standard labels).
 
 `kubernetes_state.pod.count`
-: Number of Pods. Tags:`kube_namespace` `kube_<owner kind>`.
+: Number of Pods. Tags:`node` `kube_namespace` `kube_<owner kind>`.
 
 `kubernetes_state.persistentvolumeclaim.status`
 : The phase the persistent volume claim is currently in. Tags:`kube_namespace` `persistentvolumeclaim` `phase` `storageclass`.

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
@@ -194,6 +194,6 @@ var metricAggregators = map[string]metricAggregator{
 	"kube_pod_info": newCountObjectsAggregator(
 		"pod.count",
 		"kube_pod_info",
-		[]string{"namespace", "created_by_kind", "created_by_name"},
+		[]string{"node", "namespace", "created_by_kind", "created_by_name"},
 	),
 }


### PR DESCRIPTION
### What does this PR do?

Add missing `node` label to the `pod.count` aggregator in the `kubernetes_state_core` check.

### Motivation


the `kubernetes_state.pod.count` metric is computed from the `kube_pod_info`
that contains the label `node`. to be able to map the `kube_pod_info`
to the host, the `pod.count` aggregator need to use the `node` label.

### Additional Notes


### Possible Drawbacks / Trade-offs

increase the number of `kubernetes_state.pod.count` by the number of node in a k8s cluster.
But it was already the case with the legacy `kubernetes_state` python check.

### Describe how to test/QA your changes

* Deploy the agent, cluster-agent in a kubernetes environment with the helm chart or the operator.
* Enable the `kubernetes_state_core` check.
the metric `kubernetes_state.pod.count` should have the `node` and `host` tags present.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
