### PR TITLE
Fix usage of `system` collector on ECS Fargate

### DIFF
--- a/pkg/config/environment.go
+++ b/pkg/config/environment.go
@@ -48,3 +48,19 @@ func IsKubernetes() bool {
 func IsECSFargate() bool {
 	return os.Getenv("ECS_FARGATE") != ""
 }
+
+// IsHostProcAvailable returns whether host proc is available or not
+func IsHostProcAvailable() bool {
+	if IsContainerized() {
+		return pathExists("/host/proc")
+	}
+	return true
+}
+
+// IsHostSysAvailable returns whether host proc is available or not
+func IsHostSysAvailable() bool {
+	if IsContainerized() {
+		return pathExists("/host/sys")
+	}
+	return true
+}

--- a/pkg/util/containers/v2/metrics/provider/provider.go
+++ b/pkg/util/containers/v2/metrics/provider/provider.go
@@ -155,7 +155,7 @@ func (mp *GenericProvider) retryCollectors(cacheValidity time.Duration) {
 		} else {
 			if errors.Is(err, ErrPermaFail) {
 				delete(mp.collectors, collectorEntry.ID)
-				log.Debugf("Metrics collector: %s went into PermaFail, removed from candidates")
+				log.Debugf("Metrics collector: %s went into PermaFail, removed from candidates", collectorEntry.ID)
 			}
 		}
 	}

--- a/pkg/util/containers/v2/metrics/system/collector_linux.go
+++ b/pkg/util/containers/v2/metrics/system/collector_linux.go
@@ -44,6 +44,11 @@ func newCgroupCollector() (*cgroupCollector, error) {
 	var err error
 	var hostPrefix string
 
+	if !config.IsHostProcAvailable() || !config.IsHostSysAvailable() {
+		log.Debug("Container metrics system collector not available as host paths not mounted")
+		return nil, provider.ErrPermaFail
+	}
+
 	procPath := config.Datadog.GetString("container_proc_root")
 	if strings.HasPrefix(procPath, "/host") {
 		hostPrefix = "/host"


### PR DESCRIPTION
### What does this PR do?

Fix randomly missing `container.*` metrics on ECS Fargate as the `system` check may be incorrectly used.

### Motivation

Bugfix

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the Agent on ECS Fargate or in Docker without mounting `/proc` and/or `/sys`, the `system` collector must be not selected. Check `Using metrics collector` logs to know which collector was selected.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
