### PR TITLE
[forwarder] emphase the "API Key invalid" in the status output.

### DIFF
--- a/pkg/forwarder/forwarder_health.go
+++ b/pkg/forwarder/forwarder_health.go
@@ -12,6 +12,8 @@ import (
 	"regexp"
 	"time"
 
+	"github.com/fatih/color"
+
 	"github.com/DataDog/datadog-agent/pkg/config/resolver"
 	"github.com/DataDog/datadog-agent/pkg/forwarder/endpoints"
 	"github.com/DataDog/datadog-agent/pkg/forwarder/transaction"
@@ -38,7 +40,7 @@ var (
 
 func init() {
 	apiKeyStatusUnknown.Set("Unable to validate API Key")
-	apiKeyInvalid.Set("API Key invalid")
+	apiKeyInvalid.Set(color.YellowString("API Key invalid"))
 	apiKeyValid.Set("API Key valid")
 	apiKeyFake.Set("Fake API Key that skips validation")
 }

--- a/releasenotes/notes/color-invalid-apikey-68dd99c3f567dab2.yaml
+++ b/releasenotes/notes/color-invalid-apikey-68dd99c3f567dab2.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The ``invalid api key`` message is emphased in the Agent status.


### PR DESCRIPTION
### What does this PR do?

Colors the `API Key invalid` message in the Agent status.

### Motivation

The Agent status contains a lot of information (and growing!), misconfiguring the api key can easily happen during manual tests or a manual configuration of an Agent and I think it is interesting to have the "API Key invalid" message emphased.

### Additional Notes

Not tested on Windows yet, I expect to have the exact same output since the color helpers are already used somewhere else (in the collector section).

### Describe how to test/QA your changes

  * Run an Agent with an invalid api key, validate that the Agent status displays a yellow/orange "API Key invalid" message
  * Run an Agent with a valid api key, validate that the "API Key valid" message isn't yellow/orange.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [n/a] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [n/a] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [n/a] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
