### PR TITLE
[flare] Fix inclusion of registry.json file

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -691,7 +691,7 @@ func zipFile(originalPath, zippedPath string) error {
 }
 
 func zipRegistryJSON(tempDir, hostname string) error {
-	originalPath := filepath.Join(config.Datadog.GetString("logs_config.run_path"))
+	originalPath := filepath.Join(config.Datadog.GetString("logs_config.run_path"), "registry.json")
 	zippedPath := filepath.Join(tempDir, hostname, "registry.json")
 	return zipFile(originalPath, zippedPath)
 }

--- a/releasenotes/notes/fix-flare-registry-json-e7d4d2c3c0943b7b.yaml
+++ b/releasenotes/notes/fix-flare-registry-json-e7d4d2c3c0943b7b.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix inclusion of ``registry.json`` file in flare


### PR DESCRIPTION
### What does this PR do?

This fixes a regression in the flare command that prevented the `registry.json` file from correctly being included in the flare (it would be be present in the flare, but always as an empty file). Also, adds a unit test.

### Motivation

Fix a regression introduced in 7.30.0 with #8407.

### Describe how to test/QA your changes

On an agent with the logs-agent enabled, create a flare and:
1. check that the `registry.json` file is present in the generated zip (and non-empty)
2. check that there are _no_ warnings logged in the agent logs about `registry.json`, such as:
```
CORE | WARN | (pkg/flare/archive.go:226 in createArchive) | Could not zip registry.json: read /opt/datadog-agent/run: is a directory
```

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
