### PR TITLE
[workloadmeta/containerd] Ignore events for "pause" containers

### DIFF
--- a/pkg/workloadmeta/collectors/containerd/containerd.go
+++ b/pkg/workloadmeta/collectors/containerd/containerd.go
@@ -120,7 +120,7 @@ func (c *collector) stream(ctx context.Context) {
 		case <-healthHandle.C:
 
 		case ev := <-c.eventsChan:
-			if err := c.handleEvent(ctx, ev, c.containerdClient); err != nil {
+			if err := c.handleEvent(ctx, ev); err != nil {
 				log.Warnf(err.Error())
 			}
 
@@ -206,7 +206,7 @@ func (c *collector) generateInitialEvents(ctx context.Context) ([]containerdeven
 	return events, nil
 }
 
-func (c *collector) handleEvent(ctx context.Context, containerdEvent *containerdevents.Envelope, containerdClient cutil.ContainerdItf) error {
+func (c *collector) handleEvent(ctx context.Context, containerdEvent *containerdevents.Envelope) error {
 	ignore, err := c.ignoreEvent(ctx, containerdEvent)
 	if err != nil {
 		return err
@@ -216,7 +216,7 @@ func (c *collector) handleEvent(ctx context.Context, containerdEvent *containerd
 		return nil
 	}
 
-	workloadmetaEvent, err := buildCollectorEvent(ctx, containerdEvent, containerdClient)
+	workloadmetaEvent, err := buildCollectorEvent(ctx, containerdEvent, c.containerdClient)
 	if err != nil {
 		return err
 	}

--- a/pkg/workloadmeta/collectors/containerd/containerd.go
+++ b/pkg/workloadmeta/collectors/containerd/containerd.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	cutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
@@ -58,10 +59,11 @@ var containerLifecycleFilters = []string{
 }
 
 type collector struct {
-	store            workloadmeta.Store
-	containerdClient cutil.ContainerdItf
-	eventsChan       <-chan *containerdevents.Envelope
-	errorsChan       <-chan error
+	store                  workloadmeta.Store
+	containerdClient       cutil.ContainerdItf
+	filterPausedContainers *containers.Filter
+	eventsChan             <-chan *containerdevents.Envelope
+	errorsChan             <-chan error
 }
 
 func init() {
@@ -79,6 +81,11 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Store) error {
 
 	var err error
 	c.containerdClient, err = cutil.GetContainerdUtil()
+	if err != nil {
+		return err
+	}
+
+	c.filterPausedContainers, err = containers.GetPauseContainerFilter()
 	if err != nil {
 		return err
 	}
@@ -136,7 +143,7 @@ func (c *collector) stream(ctx context.Context) {
 }
 
 func (c *collector) generateEventsFromContainerList(ctx context.Context) error {
-	containerdEvents, err := c.generateInitialEvents()
+	containerdEvents, err := c.generateInitialEvents(ctx)
 	if err != nil {
 		return err
 	}
@@ -159,15 +166,15 @@ func (c *collector) generateEventsFromContainerList(ctx context.Context) error {
 	return nil
 }
 
-func (c *collector) generateInitialEvents() ([]containerdevents.Envelope, error) {
+func (c *collector) generateInitialEvents(ctx context.Context) ([]containerdevents.Envelope, error) {
 	var events []containerdevents.Envelope
 
-	containers, err := c.containerdClient.Containers()
+	existingContainers, err := c.containerdClient.Containers()
 	if err != nil {
 		return nil, err
 	}
 
-	for _, container := range containers {
+	for _, container := range existingContainers {
 		eventEncoded, err := proto.Marshal(&apievents.ContainerCreate{
 			ID: container.ID(),
 		})
@@ -175,20 +182,40 @@ func (c *collector) generateInitialEvents() ([]containerdevents.Envelope, error)
 			return nil, err
 		}
 
-		events = append(events, containerdevents.Envelope{
+		event := containerdevents.Envelope{
 			Timestamp: time.Now(),
 			Topic:     containerCreationTopic,
 			Event: &types.Any{
 				TypeUrl: "containerd.events.ContainerCreate",
 				Value:   eventEncoded,
 			},
-		})
+		}
+
+		ignore, err := c.ignoreEvent(ctx, &event)
+		if err != nil {
+			return nil, err
+		}
+
+		if ignore {
+			continue
+		}
+
+		events = append(events, event)
 	}
 
 	return events, nil
 }
 
 func (c *collector) handleEvent(ctx context.Context, containerdEvent *containerdevents.Envelope, containerdClient cutil.ContainerdItf) error {
+	ignore, err := c.ignoreEvent(ctx, containerdEvent)
+	if err != nil {
+		return err
+	}
+
+	if ignore {
+		return nil
+	}
+
 	workloadmetaEvent, err := buildCollectorEvent(ctx, containerdEvent, containerdClient)
 	if err != nil {
 		return err
@@ -197,4 +224,37 @@ func (c *collector) handleEvent(ctx context.Context, containerdEvent *containerd
 	c.store.Notify([]workloadmeta.CollectorEvent{workloadmetaEvent})
 
 	return nil
+}
+
+// ignoreEvent returns whether a containerd event should be ignored.
+// The ignored events are the ones that refer to a "pause" container.
+func (c *collector) ignoreEvent(ctx context.Context, containerdEvent *containerdevents.Envelope) (bool, error) {
+	// The container ID can be in the "id" field (in container events) or
+	// "container_id" (in task events)
+	ID, found := containerdEvent.Field([]string{"event", "id"})
+	if !found {
+		ID, found = containerdEvent.Field([]string{"event", "container_id"})
+		if !found {
+			// We don't handle any events that don't have a container ID, so we
+			// can ignore them.
+			return true, nil
+		}
+	}
+
+	container, err := c.containerdClient.ContainerWithContext(ctx, ID)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			// This is a delete event that needs to be handled
+			return false, nil
+		}
+		return false, err
+	}
+
+	img, err := c.containerdClient.Image(container)
+	if err != nil {
+		return false, err
+	}
+
+	// Only the image name is relevant to exclude paused containers
+	return c.filterPausedContainers.IsExcluded("", img.Name(), ""), nil
 }

--- a/pkg/workloadmeta/collectors/containerd/containerd_test.go
+++ b/pkg/workloadmeta/collectors/containerd/containerd_test.go
@@ -1,0 +1,112 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build containerd
+
+package containerd
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/containerd/containerd"
+	apievents "github.com/containerd/containerd/api/events"
+	containerdevents "github.com/containerd/containerd/events"
+	"github.com/gogo/protobuf/proto"
+	"github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/errors"
+	"github.com/DataDog/datadog-agent/pkg/util/containers"
+)
+
+func TestIgnoreEvent(t *testing.T) {
+	pauseFilter, err := containers.GetPauseContainerFilter()
+	assert.NoError(t, err)
+
+	containerID := "123"
+
+	eventEncoded, err := proto.Marshal(&apievents.ContainerCreate{
+		ID: containerID,
+	})
+	assert.NoError(t, err)
+
+	event := containerdevents.Envelope{
+		Timestamp: time.Now(),
+		Topic:     containerCreationTopic,
+		Event: &types.Any{
+			TypeUrl: "containerd.events.ContainerCreate",
+			Value:   eventEncoded,
+		},
+	}
+
+	container := mockedContainer{
+		mockID: func() string {
+			return containerID
+		},
+	}
+
+	tests := []struct {
+		name           string
+		imgName        string
+		getContainerFn func(ctx context.Context, id string) (containerd.Container, error)
+		expectsIgnored bool
+	}{
+		{
+			name:    "pause image",
+			imgName: "k8s.gcr.io/pause",
+			getContainerFn: func(ctx context.Context, id string) (containerd.Container, error) {
+				return &container, nil
+			},
+			expectsIgnored: true,
+		},
+		{
+			name:    "non-pause container that exists",
+			imgName: "datadog/agent",
+			getContainerFn: func(ctx context.Context, id string) (containerd.Container, error) {
+				return &container, nil
+			},
+			expectsIgnored: false,
+		},
+		{
+			name:    "container that does not exist",
+			imgName: "datadog/agent",
+			getContainerFn: func(ctx context.Context, id string) (containerd.Container, error) {
+				return nil, errors.NewNotFound(id)
+			},
+			expectsIgnored: false, // Because it's a delete event that needs to be handled
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			client := mockedContainerdClient{
+				mockContainerWithContext: test.getContainerFn,
+				mockImage: func(ctn containerd.Container) (containerd.Image, error) {
+					return &mockedImage{
+						mockName: func() string {
+							return test.imgName
+						},
+					}, nil
+				},
+			}
+
+			containerdCollector := collector{
+				containerdClient:       &client,
+				filterPausedContainers: pauseFilter,
+			}
+
+			ignored, err := containerdCollector.ignoreEvent(context.TODO(), &event)
+			assert.NoError(t, err)
+
+			if test.expectsIgnored {
+				assert.True(t, ignored)
+			} else {
+				assert.False(t, ignored)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

Ignores events for "pause" containers in the containerd collector for workloadmeta. This is what other collectors, like the docker one, are already doing.


### Describe how to test/QA your changes

- Deploy the agent in an environment with containerd.
- Check with `agent workload-list` that there are no containers with a "pause" image. `agent workload-list | grep pause` should be empty.
- Deploy some container and check that it appears in `agent workload-list` and no "pause" containers are added.
- Delete the deployed container and check that it disappears from `agent workload-list` (takes some seconds).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
