### PR TITLE
[workloadmeta] Add telemetry

### DIFF
--- a/pkg/workloadmeta/store.go
+++ b/pkg/workloadmeta/store.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta/telemetry"
 )
 
 var (
@@ -197,6 +198,8 @@ func (s *store) Subscribe(name string, filter *Filter) chan EventBundle {
 	s.subscribers = append(s.subscribers, sub)
 	s.subscribersMut.Unlock()
 
+	telemetry.Subscribers.Inc()
+
 	var events []Event
 
 	s.storeMut.RLock()
@@ -247,6 +250,7 @@ func (s *store) Unsubscribe(ch chan EventBundle) {
 	for i, sub := range s.subscribers {
 		if sub.ch == ch {
 			s.subscribers = append(s.subscribers[:i], s.subscribers[i+1:]...)
+			telemetry.Subscribers.Dec()
 			break
 		}
 	}
@@ -369,6 +373,7 @@ func (s *store) pull(ctx context.Context) {
 			err := c.Pull(ctx)
 			if err != nil {
 				log.Warnf("error pulling from collector %q: %s", id, err.Error())
+				telemetry.PullErrors.Inc(id)
 			}
 		}(id, c)
 	}
@@ -379,6 +384,8 @@ func (s *store) handleEvents(evs []CollectorEvent) {
 
 	for _, ev := range evs {
 		meta := ev.Entity.GetID()
+
+		telemetry.EventsReceived.Inc(string(meta.Kind), string(ev.Source))
 
 		entitiesOfKind, ok := s.store[meta.Kind]
 		if !ok {
@@ -396,9 +403,17 @@ func (s *store) handleEvents(evs []CollectorEvent) {
 				entityOfSource = entitiesOfKind[meta.ID]
 			}
 
+			if _, found := entityOfSource[ev.Source]; !found {
+				telemetry.StoredEntities.Inc(string(meta.Kind), string(ev.Source))
+			}
+
 			entityOfSource[ev.Source] = ev.Entity
 		case EventTypeUnset:
 			if ok {
+				if _, found := entityOfSource[ev.Source]; found {
+					telemetry.StoredEntities.Dec(string(meta.Kind), string(ev.Source))
+				}
+
 				delete(entityOfSource, ev.Source)
 
 				if len(entityOfSource) == 0 {
@@ -522,8 +537,10 @@ func notifyChannel(name string, ch chan EventBundle, events []Event, wait bool) 
 		select {
 		case <-bundle.Ch:
 			timer.Stop()
+			telemetry.NotificationsSent.Inc(name, telemetry.StatusSuccess)
 		case <-timer.C:
 			log.Warnf("collector %q did not close the event bundle channel in time, continuing with downstream collectors. bundle dump: %+v", name, bundle)
+			telemetry.NotificationsSent.Inc(name, telemetry.StatusError)
 		}
 	}
 }

--- a/pkg/workloadmeta/telemetry/telemetry.go
+++ b/pkg/workloadmeta/telemetry/telemetry.go
@@ -1,0 +1,69 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package telemetry
+
+import "github.com/DataDog/datadog-agent/pkg/telemetry"
+
+const subsystem = "workloadmeta"
+
+var (
+	// StatusSuccess is the value for the "status" tag that represents a successful operation
+	StatusSuccess = "success"
+	// StatusError is the value for the "status" tag that represents an error
+	StatusError = "error"
+
+	commonOpts = telemetry.Options{NoDoubleUnderscoreSep: true}
+)
+
+var (
+	// StoredEntities tracks how many entities are stored in the workloadmeta store.
+	StoredEntities = telemetry.NewGaugeWithOpts(
+		subsystem,
+		"stored_entities",
+		[]string{"kind", "source"},
+		"Number of entities in the store.",
+		commonOpts,
+	)
+
+	// Subscribers tracks the number of subscribers.
+	Subscribers = telemetry.NewGaugeWithOpts(
+		subsystem,
+		"subscribers",
+		[]string{},
+		"Number of subscribers.",
+		commonOpts,
+	)
+
+	// EventsReceived tracks the number of events received.
+	EventsReceived = telemetry.NewCounterWithOpts(
+		subsystem,
+		"events_received",
+		[]string{"kind", "source"},
+		"Number of events received by the workloadmeta store.",
+		commonOpts,
+	)
+
+	// PullErrors tracks the number of errors that the workloadmeta received
+	// when pulling from the collectors.
+	PullErrors = telemetry.NewCounterWithOpts(
+		subsystem,
+		"pull_errors",
+		[]string{"collector_id"},
+		"Pulls by the workloadmeta to the collectors that returned an error",
+		commonOpts,
+	)
+
+	// NotificationsSent tracks the number of notifications sent from the
+	// workloadmeta store to its subscribers. Note that each notification can
+	// include multiple events.
+	NotificationsSent = telemetry.NewCounterWithOpts(
+		subsystem,
+		"notifications_sent",
+		[]string{"subscriber_name", "status"},
+		"Number of notifications sent by workloadmeta to its subscribers",
+		commonOpts,
+	)
+)

--- a/releasenotes/notes/workloadmeta-telemetry-d56dc96eb37dd3e4.yaml
+++ b/releasenotes/notes/workloadmeta-telemetry-d56dc96eb37dd3e4.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Added telemetry for the workloadmeta store.


### PR DESCRIPTION
### What does this PR do?

Adds telemetry for the workloadmeta store.

### Describe how to test/QA your changes

- Run the agent with `DD_TELEMETRY_ENABLED=true`.
- From the agent, check the telemetry endpoint (`curl http://localhost:6000/telemetry`). You should see some new gauges and counters associated with the workloadmeta store (they have the ` workloadmeta_` prefix). For the full list please check the `pkg/workloadmeta/telemetry/telemetry.go` file added in this PR.
- Deploy something and verify that the telemetry counters and gauges have values that look OK. For some of them is not straightforward to know the values they should have, but for example, the number of stored entities can be validated against what `agent workload-list` shows.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
