### PR TITLE
[cws] Add a weight to approvers

### DIFF
--- a/pkg/security/probe/capabilities.go
+++ b/pkg/security/probe/capabilities.go
@@ -23,6 +23,7 @@ type Capability struct {
 	PolicyFlags     PolicyFlag
 	FieldValueTypes eval.FieldValueType
 	ValidateFnc     func(value rules.FilterValue) bool
+	FilterWeight    int
 }
 
 // Capabilities represents the filtering capabilities for a set of fields
@@ -54,9 +55,10 @@ func (caps Capabilities) GetFieldCapabilities() rules.FieldCapabilities {
 
 	for field, cap := range caps {
 		fcs = append(fcs, rules.FieldCapability{
-			Field:       field,
-			Types:       cap.FieldValueTypes,
-			ValidateFnc: cap.ValidateFnc,
+			Field:        field,
+			Types:        cap.FieldValueTypes,
+			ValidateFnc:  cap.ValidateFnc,
+			FilterWeight: cap.FilterWeight,
 		})
 	}
 

--- a/pkg/security/probe/open.go
+++ b/pkg/security/probe/open.go
@@ -20,10 +20,12 @@ var openCapabilities = Capabilities{
 		PolicyFlags:     PolicyFlagBasename,
 		FieldValueTypes: eval.ScalarValueType | eval.PatternValueType,
 		ValidateFnc:     validateBasenameFilter,
+		FilterWeight:    15,
 	},
 	"open.file.name": {
 		PolicyFlags:     PolicyFlagBasename,
 		FieldValueTypes: eval.ScalarValueType,
+		FilterWeight:    10,
 	},
 	"open.flags": {
 		PolicyFlags:     PolicyFlagFlags,

--- a/pkg/security/secl/rules/bucket.go
+++ b/pkg/security/secl/rules/bucket.go
@@ -97,9 +97,23 @@ func (rb *RuleBucket) GetApprovers(event eval.Event, fieldCaps FieldCapabilities
 		if len(ruleApprovers) == 0 || !fieldCaps.Validate(ruleApprovers) {
 			return nil, &ErrNoApprover{Fields: fieldCaps.GetFields()}
 		}
-		for field, values := range ruleApprovers {
-			approvers[field] = approvers[field].Merge(values)
+
+		// keep the best approver field
+		var approverField eval.Field
+		var approverWeight int
+		for field := range ruleApprovers {
+			for _, fc := range fieldCaps {
+				if field != fc.Field {
+					continue
+				}
+				if fc.FilterWeight >= approverWeight {
+					approverField = field
+				}
+			}
 		}
+
+		values := ruleApprovers[approverField]
+		approvers[approverField] = approvers[approverField].Merge(values)
 	}
 
 	return approvers, nil

--- a/pkg/security/secl/rules/capabilities.go
+++ b/pkg/security/secl/rules/capabilities.go
@@ -14,9 +14,10 @@ type FieldCapabilities []FieldCapability
 
 // FieldCapability represents a field and the type of its value (scalar, pattern, bitmask, ...)
 type FieldCapability struct {
-	Field       eval.Field
-	Types       eval.FieldValueType
-	ValidateFnc func(FilterValue) bool
+	Field        eval.Field
+	Types        eval.FieldValueType
+	ValidateFnc  func(FilterValue) bool
+	FilterWeight int
 }
 
 // GetFields returns all the fields of FieldCapabilities

--- a/pkg/security/secl/rules/ruleset_test.go
+++ b/pkg/security/secl/rules/ruleset_test.go
@@ -195,12 +195,14 @@ func TestRuleSetFilters1(t *testing.T) {
 
 	caps := FieldCapabilities{
 		{
-			Field: "process.uid",
-			Types: eval.ScalarValueType,
+			Field:        "process.uid",
+			Types:        eval.ScalarValueType,
+			FilterWeight: 1,
 		},
 		{
-			Field: "process.gid",
-			Types: eval.ScalarValueType,
+			Field:        "process.gid",
+			Types:        eval.ScalarValueType,
+			FilterWeight: 2,
 		},
 	}
 
@@ -209,8 +211,8 @@ func TestRuleSetFilters1(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, exists := approvers["process.uid"]; !exists {
-		t.Fatal("expected approver not found")
+	if _, exists := approvers["process.uid"]; exists {
+		t.Fatal("Shouldn't get an approver for uid")
 	}
 
 	if _, exists := approvers["process.gid"]; !exists {
@@ -278,16 +280,19 @@ func TestRuleSetFilters2(t *testing.T) {
 
 	caps = FieldCapabilities{
 		{
-			Field: "open.filename",
-			Types: eval.ScalarValueType,
+			Field:        "open.filename",
+			Types:        eval.ScalarValueType,
+			FilterWeight: 3,
 		},
 		{
-			Field: "process.uid",
-			Types: eval.ScalarValueType,
+			Field:        "process.uid",
+			Types:        eval.ScalarValueType,
+			FilterWeight: 2,
 		},
 		{
-			Field: "process.gid",
-			Types: eval.ScalarValueType,
+			Field:        "process.gid",
+			Types:        eval.ScalarValueType,
+			FilterWeight: 1,
 		},
 	}
 
@@ -300,8 +305,8 @@ func TestRuleSetFilters2(t *testing.T) {
 		t.Fatal("expected approver not found")
 	}
 
-	if _, exists := approvers["process.uid"]; !exists {
-		t.Fatal("expected approver not found")
+	if _, exists := approvers["process.uid"]; exists {
+		t.Fatal("shouldn't an approver for uid")
 	}
 
 	if _, exists := approvers["process.gid"]; !exists {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
