### PR TITLE
corechecks/snmp: fix intermittent discovery unit test.

### DIFF
--- a/pkg/collector/corechecks/snmp/discovery/discovery_test.go
+++ b/pkg/collector/corechecks/snmp/discovery/discovery_test.go
@@ -2,13 +2,14 @@ package discovery
 
 import (
 	"fmt"
+	"net"
+	"testing"
+	"time"
+
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/checkconfig"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/session"
 	"github.com/gosnmp/gosnmp"
 	"github.com/stretchr/testify/assert"
-	"net"
-	"testing"
-	"time"
 )
 
 func TestDiscovery(t *testing.T) {
@@ -31,13 +32,18 @@ func TestDiscovery(t *testing.T) {
 	checkConfig := &checkconfig.CheckConfig{
 		Network:            "192.168.0.0/29",
 		CommunityString:    "public",
-		DiscoveryInterval:  3600,
+		DiscoveryInterval:  1,
 		DiscoveryWorkers:   1,
 		IgnoredIPAddresses: map[string]bool{"192.168.0.5": true},
 	}
 	discovery := NewDiscovery(checkConfig)
 	discovery.Start()
-	time.Sleep(100 * time.Millisecond)
+	// discover.Start is immediately starting the discovery in a go routine,
+	// let's give it some time to make sure it is being scheduled and that
+	// it has the time to fully run.
+	// 2500ms make sure the discovery has the time to run its main loop
+	// at least 2 times.
+	time.Sleep(2500 * time.Millisecond)
 	discovery.Stop()
 
 	deviceConfigs := discovery.GetDiscoveredDeviceConfigs()


### PR DESCRIPTION
### What does this PR do?

Fix a flake in one of the SNMP discovery unit tests.

### Additional Notes

Unfortunately, I was not able to reproduce it locally even before my change.

### Describe how to test/QA your changes

Validate that the release branch unit tests are all green.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [n/a] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [n/a] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [n/a] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [n/a] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
