### PR TITLE
pkg/obfuscate: make the package go1.12 compatible

### DIFF
--- a/pkg/obfuscate/cache.go
+++ b/pkg/obfuscate/cache.go
@@ -59,14 +59,14 @@ func newMeasuredCache(opts cacheOptions) *measuredCache {
 	cfg := &ristretto.Config{
 		// We know that the maximum allowed resource length is 5K. This means that
 		// in 5MB we can store a minimum of 1000 queries.
-		MaxCost: 5_000_000,
+		MaxCost: 5000000,
 
 		// An appromixated worst-case scenario when the cache is filled with small
 		// queries averaged as being of length 11 ("LOCK TABLES"), we would be able
 		// to fit 476K of them into 5MB of cost.
 		//
 		// We average it to 500K and multiply 10x as the documentation recommends.
-		NumCounters: 500_000 * 10,
+		NumCounters: 500000 * 10,
 
 		BufferItems: 64,   // default recommended value
 		Metrics:     true, // enable hit/miss counters

--- a/pkg/obfuscate/go.mod
+++ b/pkg/obfuscate/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/datadog-agent/pkg/obfuscate
 
-go 1.16
+go 1.12
 
 require (
 	github.com/DataDog/datadog-go v4.8.2+incompatible


### PR DESCRIPTION
Addresses issue in https://github.com/DataDog/dd-trace-go/pull/1069