### PR TITLE
Fix an issue where `close(tc.shutdown)` can be called twice.

### DIFF
--- a/pkg/dogstatsd/replay/writer.go
+++ b/pkg/dogstatsd/replay/writer.go
@@ -220,7 +220,10 @@ func (tc *TrafficCaptureWriter) Capture(l string, d time.Duration, compressed bo
 		tc.writer = bufio.NewWriter(target)
 	}
 
-	tc.shutdown = make(chan struct{})
+	// Do not use `tc.shutdown` directly as `tc.shutdown` can be set to nil
+	shutdown := make(chan struct{})
+	tc.shutdown = shutdown
+
 	tc.ongoing = true
 
 	err = tc.WriteHeader()
@@ -246,8 +249,6 @@ func (tc *TrafficCaptureWriter) Capture(l string, d time.Duration, compressed bo
 		tc.StopCapture()
 	}()
 
-	// copy the instance as `tc.shutdown` can be set at nil
-	shutdown := tc.shutdown
 process:
 	for {
 		select {


### PR DESCRIPTION
### What does this PR do?

Fix an issue where `close(tc.shutdown)` can be called twice.

### Motivation

https://ci.appveyor.com/project/Datadog/datadog-agent/builds/41270865

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
