### PR TITLE
[gitlab] Fix missing IMG_VARIABLES transformation in docker_publish_job_definition

### DIFF
--- a/.gitlab/docker_common/publish_job_templates.yml
+++ b/.gitlab/docker_common/publish_job_templates.yml
@@ -14,5 +14,6 @@
     - export GITLAB_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.gitlab_pipelines_scheduler_token --with-decryption --query "Parameter.Value" --out text)
     - python3 -m pip install -r requirements.txt
     - ECR_RELEASE_SUFFIX="${CI_COMMIT_TAG+-release}"
+    - IMG_VARIABLES="$(sed -E "s#(${SRC_AGENT}|${SRC_DSD}|${SRC_DCA})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_VARIABLES")"
     - IMG_SOURCES="$(sed -E "s#(${SRC_AGENT}|${SRC_DSD}|${SRC_DCA})#\1${ECR_RELEASE_SUFFIX}#g" <<<"$IMG_SOURCES")"
     - inv pipeline.trigger-child-pipeline --project-name "DataDog/public-images" --git-ref "main" --variables "IMG_VARIABLES,IMG_REGISTRIES,IMG_SOURCES,IMG_DESTINATIONS"


### PR DESCRIPTION


<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->


### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->
Use the `ECR_RELEASE_SUFFIX` transformation on `IMG_VARIABLES`,  which also may contain image names.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fixes an issue in Docker release jobs introduced in https://github.com/DataDog/datadog-agent/pull/9439: `IMG_VARIABLES` doesn't get the `agent` -> `agent-release` transformation, so this makes some release jobs fail: the Windows ones that declare the `BASE` variable in `IMG_VARIABLES`. Notably, this makes `deploy_latest_7` fail: https://github.com/DataDog/datadog-agent/blob/620de01815835b442861601a1e7a7228a9e0ec3d/.gitlab/deploy_7/docker.yml#L61-L80

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Discovered while trying to build a nightly image on a tag, which also triggers this behavior, since all tagged images are sent to `agent-release`, and on nightly runs, `dev_nightly-a7-windows` also defines `BASE` in `IMG_VARIABLES`: https://github.com/DataDog/datadog-agent/blob/16dbec556dc0495feb9519dc2d6738c01a3c640e/.gitlab/image_deploy/docker_windows.yml#L122-L159.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
