### PR TITLE
[security-agent] Show the endpoints used for both CSPM and CWS in status and flare

### DIFF
--- a/cmd/cluster-agent/app/compliance.go
+++ b/cmd/cluster-agent/app/compliance.go
@@ -57,6 +57,10 @@ func newLogContext(logsConfig *config.LogsConfigKeys, endpointPrefix string) (*c
 		return nil, nil, log.Errorf("Invalid endpoints: %v", err)
 	}
 
+	for _, status := range endpoints.GetStatus() {
+		log.Info(status)
+	}
+
 	destinationsCtx := client.NewDestinationsContext()
 	destinationsCtx.Start()
 

--- a/cmd/cluster-agent/app/compliance.go
+++ b/cmd/cluster-agent/app/compliance.go
@@ -103,6 +103,7 @@ func startCompliance(stopper restart.Stopper, apiCl *apiserver.APIClient, isLead
 		reporter,
 		scheduler,
 		configDir,
+		endpoints,
 		checks.WithInterval(checkInterval),
 		checks.WithMaxEvents(checkMaxEvents),
 		checks.WithHostname(hostname),

--- a/cmd/security-agent/api/server.go
+++ b/cmd/security-agent/api/server.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/cmd/security-agent/api/agent"
 	"github.com/DataDog/datadog-agent/pkg/api/security"
 	"github.com/DataDog/datadog-agent/pkg/api/util"
+	compagent "github.com/DataDog/datadog-agent/pkg/compliance/agent"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	secagent "github.com/DataDog/datadog-agent/pkg/security/agent"
 	"github.com/gorilla/mux"
@@ -35,14 +36,14 @@ type Server struct {
 }
 
 // NewServer creates a new Server instance
-func NewServer(runtimeAgent *secagent.RuntimeSecurityAgent) (*Server, error) {
+func NewServer(runtimeAgent *secagent.RuntimeSecurityAgent, complianceAgent *compagent.Agent) (*Server, error) {
 	listener, err := newListener()
 	if err != nil {
 		return nil, err
 	}
 	return &Server{
 		listener: listener,
-		agent:    agent.NewAgent(runtimeAgent),
+		agent:    agent.NewAgent(runtimeAgent, complianceAgent),
 	}, nil
 }
 

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -136,6 +136,10 @@ func newLogContext(logsConfig *config.LogsConfigKeys, endpointPrefix string, int
 		return nil, nil, log.Errorf("Invalid endpoints: %v", err)
 	}
 
+	for _, status := range endpoints.GetStatus() {
+		log.Info(status)
+	}
+
 	destinationsCtx := client.NewDestinationsContext()
 	destinationsCtx.Start()
 

--- a/cmd/security-agent/app/app.go
+++ b/cmd/security-agent/app/app.go
@@ -284,7 +284,8 @@ func RunAgent(ctx context.Context) (err error) {
 		}
 	}
 
-	if err = startCompliance(hostname, stopper, statsdClient); err != nil {
+	complianceAgent, err := startCompliance(hostname, stopper, statsdClient)
+	if err != nil {
 		return err
 	}
 
@@ -298,7 +299,7 @@ func RunAgent(ctx context.Context) (err error) {
 		return err
 	}
 
-	srv, err = api.NewServer(runtimeAgent)
+	srv, err = api.NewServer(runtimeAgent, complianceAgent)
 	if err != nil {
 		return log.Errorf("Error while creating api server, exiting: %v", err)
 	}

--- a/cmd/security-agent/app/compliance.go
+++ b/cmd/security-agent/app/compliance.go
@@ -99,10 +99,10 @@ func eventRun(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func startCompliance(hostname string, stopper restart.Stopper, statsdClient *ddgostatsd.Client) error {
+func startCompliance(hostname string, stopper restart.Stopper, statsdClient *ddgostatsd.Client) (*agent.Agent, error) {
 	enabled := coreconfig.Datadog.GetBool("compliance_config.enabled")
 	if !enabled {
-		return nil
+		return nil, nil
 	}
 
 	endpoints, context, err := newLogContextCompliance()
@@ -114,7 +114,7 @@ func startCompliance(hostname string, stopper restart.Stopper, statsdClient *ddg
 	runPath := coreconfig.Datadog.GetString("compliance_config.run_path")
 	reporter, err := event.NewLogReporter(stopper, "compliance-agent", "compliance", runPath, endpoints, context)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	runner := runner.NewRunner()
@@ -149,16 +149,17 @@ func startCompliance(hostname string, stopper restart.Stopper, statsdClient *ddg
 		reporter,
 		scheduler,
 		configDir,
+		endpoints,
 		options...,
 	)
 	if err != nil {
 		log.Errorf("Compliance agent failed to initialize: %v", err)
-		return err
+		return nil, err
 	}
 	err = agent.Run()
 	if err != nil {
 		log.Errorf("Error starting compliance agent, exiting: %v", err)
-		return err
+		return nil, err
 	}
 	stopper.Add(agent)
 
@@ -168,5 +169,5 @@ func startCompliance(hostname string, stopper restart.Stopper, statsdClient *ddg
 	ticker := sendRunningMetrics(statsdClient, "compliance")
 	stopper.Add(ticker)
 
-	return nil
+	return agent, nil
 }

--- a/cmd/security-agent/app/flare.go
+++ b/cmd/security-agent/app/flare.go
@@ -96,7 +96,7 @@ func requestFlare(caseID string) error {
 			fmt.Fprintln(color.Output, color.RedString("The agent was unable to make a full flare: %s.", e.Error()))
 		}
 		fmt.Fprintln(color.Output, color.YellowString("Initiating flare locally, some logs will be missing."))
-		filePath, e = flare.CreateSecurityAgentArchive(true, logFile, nil)
+		filePath, e = flare.CreateSecurityAgentArchive(true, logFile, nil, nil)
 		if e != nil {
 			fmt.Printf("The flare zipfile failed to be created: %s\n", e)
 			return e

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -204,7 +204,7 @@ func startRuntimeSecurity(hostname string, stopper restart.Stopper, statsdClient
 		return nil, err
 	}
 
-	agent, err := secagent.NewRuntimeSecurityAgent(hostname, reporter)
+	agent, err := secagent.NewRuntimeSecurityAgent(hostname, reporter, endpoints)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to create a runtime security agent instance")
 	}

--- a/pkg/compliance/agent/agent.go
+++ b/pkg/compliance/agent/agent.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/compliance"
 	"github.com/DataDog/datadog-agent/pkg/compliance/checks"
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -36,11 +37,12 @@ type Agent struct {
 	scheduler Scheduler
 	telemetry *telemetry
 	configDir string
+	endpoints *config.Endpoints
 	cancel    context.CancelFunc
 }
 
 // New creates a new instance of Agent
-func New(reporter event.Reporter, scheduler Scheduler, configDir string, options ...checks.BuilderOption) (*Agent, error) {
+func New(reporter event.Reporter, scheduler Scheduler, configDir string, endpoints *config.Endpoints, options ...checks.BuilderOption) (*Agent, error) {
 	builder, err := checks.NewBuilder(
 		reporter,
 		options...,
@@ -59,6 +61,7 @@ func New(reporter event.Reporter, scheduler Scheduler, configDir string, options
 		scheduler: scheduler,
 		configDir: configDir,
 		telemetry: telemetry,
+		endpoints: endpoints,
 	}, nil
 }
 
@@ -189,4 +192,11 @@ func (a *Agent) buildChecks(onCheck compliance.CheckVisitor) error {
 		}
 	}
 	return nil
+}
+
+// GetStatus returns the agent status
+func (a *Agent) GetStatus() map[string]interface{} {
+	return map[string]interface{}{
+		"endpoints": a.endpoints.GetStatus(),
+	}
 }

--- a/pkg/compliance/agent/agent_test.go
+++ b/pkg/compliance/agent/agent_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/compliance/checks"
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
 	"github.com/DataDog/datadog-agent/pkg/compliance/mocks"
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/util"
 
 	"github.com/stretchr/testify/assert"
@@ -160,6 +161,7 @@ func TestRun(t *testing.T) {
 		reporter,
 		scheduler,
 		e.dir,
+		&config.Endpoints{},
 		checks.WithHostname("the-host"),
 		checks.WithHostRootMount(e.dir),
 		checks.WithDockerClient(dockerClient),

--- a/pkg/flare/archive_security.go
+++ b/pkg/flare/archive_security.go
@@ -20,7 +20,7 @@ import (
 )
 
 // CreateSecurityAgentArchive packages up the files
-func CreateSecurityAgentArchive(local bool, logFilePath string, runtimeStatus map[string]interface{}) (string, error) {
+func CreateSecurityAgentArchive(local bool, logFilePath string, runtimeStatus, complianceStatus map[string]interface{}) (string, error) {
 	zipFilePath := getArchivePath()
 
 	tempDir, err := createTempDir()
@@ -45,7 +45,7 @@ func CreateSecurityAgentArchive(local bool, logFilePath string, runtimeStatus ma
 	} else {
 		// The Status will be unavailable unless the agent is running.
 		// Only zip it up if the agent is running
-		err = zipSecurityAgentStatusFile(tempDir, hostname, runtimeStatus)
+		err = zipSecurityAgentStatusFile(tempDir, hostname, runtimeStatus, complianceStatus)
 		if err != nil {
 			log.Infof("Error getting the status of the Security Agent, %q", err)
 			return "", err
@@ -123,10 +123,10 @@ func CreateSecurityAgentArchive(local bool, logFilePath string, runtimeStatus ma
 	return zipFilePath, nil
 }
 
-func zipSecurityAgentStatusFile(tempDir, hostname string, runtimeStatus map[string]interface{}) error {
+func zipSecurityAgentStatusFile(tempDir, hostname string, runtimeStatus, complianceStatus map[string]interface{}) error {
 	// Grab the status
 	log.Infof("Zipping the status at %s for %s", tempDir, hostname)
-	s, err := status.GetAndFormatSecurityAgentStatus(runtimeStatus)
+	s, err := status.GetAndFormatSecurityAgentStatus(runtimeStatus, complianceStatus)
 	if err != nil {
 		log.Infof("Error zipping the status: %q", err)
 		return err

--- a/pkg/flare/archive_security_test.go
+++ b/pkg/flare/archive_security_test.go
@@ -52,7 +52,7 @@ func TestCreateSecurityAgentArchive(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			zipFilePath, err := CreateSecurityAgentArchive(test.local, logFilePath, nil)
+			zipFilePath, err := CreateSecurityAgentArchive(test.local, logFilePath, nil, nil)
 			defer os.Remove(zipFilePath)
 
 			assert.NoError(err)

--- a/pkg/logs/config/endpoints.go
+++ b/pkg/logs/config/endpoints.go
@@ -6,6 +6,7 @@
 package config
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -55,6 +56,42 @@ type Endpoint struct {
 	Origin    IntakeOrigin
 }
 
+func (e *Endpoint) GetStatus(prefix string, useHTTP bool) string {
+	compression := "uncompressed"
+	if e.UseCompression {
+		compression = "compressed"
+	}
+
+	host := e.Host
+	port := e.Port
+
+	var protocol string
+	if useHTTP {
+		if e.UseSSL {
+			protocol = "HTTPS"
+			if port == 0 {
+				port = 443 // use default port
+			}
+		} else {
+			protocol = "HTTP"
+			// this case technically can't happens. In order to
+			// disable SSL, user have to use a custom URL and
+			// specify the port manually.
+			if port == 0 {
+				port = 80 // use default port
+			}
+		}
+	} else {
+		if e.UseSSL {
+			protocol = "SSL encrypted TCP"
+		} else {
+			protocol = "TCP"
+		}
+	}
+
+	return fmt.Sprintf("%sSending %s logs in %s to %s on port %d", prefix, compression, protocol, host, port)
+}
+
 // Endpoints holds the main endpoint and additional ones to dualship logs.
 type Endpoints struct {
 	Main                   Endpoint
@@ -65,6 +102,16 @@ type Endpoints struct {
 	BatchMaxConcurrentSend int
 	BatchMaxSize           int
 	BatchMaxContentSize    int
+}
+
+// GetStatus returns the endpoints status, one line per endpoint
+func (e *Endpoints) GetStatus() []string {
+	result := make([]string, 0)
+	result = append(result, e.Main.GetStatus("", e.UseHTTP))
+	for _, additional := range e.Additionals {
+		result = append(result, additional.GetStatus("Additional: ", e.UseHTTP))
+	}
+	return result
 }
 
 // NewEndpoints returns a new endpoints composite with default batching settings

--- a/pkg/logs/config/endpoints.go
+++ b/pkg/logs/config/endpoints.go
@@ -56,6 +56,7 @@ type Endpoint struct {
 	Origin    IntakeOrigin
 }
 
+// GetStatus returns the endpoint status
 func (e *Endpoint) GetStatus(prefix string, useHTTP bool) string {
 	compression := "uncompressed"
 	if e.UseCompression {

--- a/pkg/logs/status/builder.go
+++ b/pkg/logs/status/builder.go
@@ -7,7 +7,6 @@ package status
 
 import (
 	"expvar"
-	"fmt"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -62,47 +61,7 @@ func (b *Builder) getUseHTTP() bool {
 }
 
 func (b *Builder) getEndpoints() []string {
-	result := make([]string, 0)
-	result = append(result, b.formatEndpoint(b.endpoints.Main, ""))
-	for _, additional := range b.endpoints.Additionals {
-		result = append(result, b.formatEndpoint(additional, "Additional: "))
-	}
-	return result
-}
-
-func (b *Builder) formatEndpoint(endpoint config.Endpoint, prefix string) string {
-	compression := "uncompressed"
-	if endpoint.UseCompression {
-		compression = "compressed"
-	}
-
-	host := endpoint.Host
-	port := endpoint.Port
-
-	var protocol string
-	if b.endpoints.UseHTTP {
-		if endpoint.UseSSL {
-			protocol = "HTTPS"
-			if port == 0 {
-				port = 443 // use default port
-			}
-		} else {
-			protocol = "HTTP"
-			// this case technically can't happens. In order to
-			// disable SSL, user have to use a custom URL and
-			// specify the port manually.
-			if port == 0 {
-				port = 80 // use default port
-			}
-		}
-	} else {
-		if endpoint.UseSSL {
-			protocol = "SSL encrypted TCP"
-		} else {
-			protocol = "TCP"
-		}
-	}
-	return fmt.Sprintf("%sSending %s logs in %s to %s on port %d", prefix, compression, protocol, host, port)
+	return b.endpoints.GetStatus()
 }
 
 // getWarnings returns all the warning messages that

--- a/pkg/security/agent/agent.go
+++ b/pkg/security/agent/agent.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/compliance/event"
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/security/api"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -33,11 +34,12 @@ type RuntimeSecurityAgent struct {
 	connected     atomic.Value
 	eventReceived uint64
 	telemetry     *telemetry
+	endpoints     *config.Endpoints
 	cancel        context.CancelFunc
 }
 
 // NewRuntimeSecurityAgent instantiates a new RuntimeSecurityAgent
-func NewRuntimeSecurityAgent(hostname string, reporter event.Reporter) (*RuntimeSecurityAgent, error) {
+func NewRuntimeSecurityAgent(hostname string, reporter event.Reporter, endpoints *config.Endpoints) (*RuntimeSecurityAgent, error) {
 	socketPath := coreconfig.Datadog.GetString("runtime_security_config.socket")
 	if socketPath == "" {
 		return nil, errors.New("runtime_security_config.socket must be set")
@@ -60,6 +62,7 @@ func NewRuntimeSecurityAgent(hostname string, reporter event.Reporter) (*Runtime
 		reporter:  reporter,
 		hostname:  hostname,
 		telemetry: tel,
+		endpoints: endpoints,
 	}, nil
 }
 
@@ -143,6 +146,7 @@ func (rsa *RuntimeSecurityAgent) GetStatus() map[string]interface{} {
 	return map[string]interface{}{
 		"connected":     rsa.connected.Load(),
 		"eventReceived": atomic.LoadUint64(&rsa.eventReceived),
+		"endpoints":     rsa.endpoints.GetStatus(),
 	}
 }
 

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -127,12 +127,13 @@ func FormatSecurityAgentStatus(data []byte) (string, error) {
 	json.Unmarshal(data, &stats) //nolint:errcheck
 	runnerStats := stats["runnerStats"]
 	complianceChecks := stats["complianceChecks"]
+	complianceStatus := stats["complianceStatus"]
 	title := fmt.Sprintf("Datadog Security Agent (v%s)", stats["version"])
 	stats["title"] = title
 	renderStatusTemplate(b, "/header.tmpl", stats)
 
 	renderRuntimeSecurityStats(b, stats["runtimeSecurityStatus"])
-	renderComplianceChecksStats(b, runnerStats, complianceChecks)
+	renderComplianceChecksStats(b, runnerStats, complianceChecks, complianceStatus)
 
 	return b.String(), nil
 }
@@ -178,9 +179,10 @@ func renderCheckStats(data []byte, checkName string) (string, error) {
 	return b.String(), nil
 }
 
-func renderComplianceChecksStats(w io.Writer, runnerStats interface{}, complianceChecks interface{}) {
+func renderComplianceChecksStats(w io.Writer, runnerStats interface{}, complianceChecks, complianceStatus interface{}) {
 	checkStats := make(map[string]interface{})
 	checkStats["RunnerStats"] = runnerStats
+	checkStats["ComplianceStatus"] = complianceStatus
 	checkStats["ComplianceChecks"] = complianceChecks
 	renderStatusTemplate(w, "/compliance.tmpl", checkStats)
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -218,12 +218,13 @@ func GetAndFormatDCAStatus() ([]byte, error) {
 }
 
 // GetAndFormatSecurityAgentStatus gets and formats the security agent status
-func GetAndFormatSecurityAgentStatus(runtimeStatus map[string]interface{}) ([]byte, error) {
+func GetAndFormatSecurityAgentStatus(runtimeStatus, complianceStatus map[string]interface{}) ([]byte, error) {
 	s, err := GetStatus()
 	if err != nil {
 		return nil, err
 	}
 	s["runtimeSecurityStatus"] = runtimeStatus
+	s["complianceStatus"] = complianceStatus
 
 	statusJSON, err := json.Marshal(s)
 	if err != nil {

--- a/pkg/status/templates/compliance.tmpl
+++ b/pkg/status/templates/compliance.tmpl
@@ -1,51 +1,66 @@
-Compliance Checks
-=========================
-{{- $runnerStats := .RunnerStats }}
-{{- range $Check := .ComplianceChecks }}
-  {{ $Check.Name }}
-  {{printDashes $Check.Name "-"}}
-    Framework: {{ $Check.Framework }} ({{ $Check.Version }})
-    Source: {{ $Check.Source }}
-  {{- if $Check.InitError }}
-    Configuration: [{{ yellowText $Check.InitError }}]
-  {{- else }}
-    Configuration: [{{ greenText "OK"}}]
-  {{- if $Check.LastEvent }}
+Compliance
+==========
 
-    Report:
-      Result: {{ complianceResult $Check.LastEvent.result }}
-      Data:
-      {{- range $k, $v := $Check.LastEvent.data }}
-        {{ $k }}: {{ $v }}
-      {{- end }}
+{{- if not .ComplianceStatus}}
+  Not enabled
+{{- else}}
+  {{- with .ComplianceStatus}}
+  {{ if .endpoints }}
+  {{- range $endpoint := .endpoints }}
+  {{ $endpoint }}
   {{- end }}
-  {{- if and $runnerStats.Checks (index $runnerStats.Checks $Check.Name) }}
-    {{ $checkInstances := index $runnerStats.Checks $Check.Name }}
-    {{- range $checkInstances }}
-    Total Runs: {{humanize .TotalRuns}}
-    Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}
-    Last Execution Date : {{formatUnixTime .UpdateTimestamp}}
-    Last Successful Execution Date : {{ if .LastSuccessDate }}{{formatUnixTime .LastSuccessDate}}{{ else }}Never{{ end }}
-      {{- if $.CheckMetadata }}
-      {{- if index $.CheckMetadata .CheckID }}
-      metadata:
-      {{- range $k, $v := index $.CheckMetadata .CheckID }}
-        {{ $k }}: {{ $v }}
-      {{- end }}
-      {{- end }}
-      {{- end }}
-      {{- if .LastError }}
-    Error: {{lastErrorMessage .LastError}}
-      {{lastErrorTraceback .LastError -}}
-      {{- end }}
-      {{- if .LastWarnings }}
-        {{- range .LastWarnings }}
-    Warning: {{.}}
+  {{- end }}
+  {{- end }}
+{{- end }}
+
+  Checks
+  ======
+  {{ $runnerStats := .RunnerStats }}
+  {{- range $Check := .ComplianceChecks }}
+    {{ $Check.Name }}
+    {{printDashes $Check.Name "-"}}
+      Framework: {{ $Check.Framework }} ({{ $Check.Version }})
+      Source: {{ $Check.Source }}
+    {{- if $Check.InitError }}
+      Configuration: [{{ yellowText $Check.InitError }}]
+    {{- else }}
+      Configuration: [{{ greenText "OK"}}]
+    {{- if $Check.LastEvent }}
+
+      Report:
+        Result: {{ complianceResult $Check.LastEvent.result }}
+        Data:
+        {{- range $k, $v := $Check.LastEvent.data }}
+          {{ $k }}: {{ $v }}
+        {{- end }}
+    {{- end }}
+    {{- if and $runnerStats.Checks (index $runnerStats.Checks $Check.Name) }}
+      {{ $checkInstances := index $runnerStats.Checks $Check.Name }}
+      {{- range $checkInstances }}
+      Total Runs: {{humanize .TotalRuns}}
+      Average Execution Time : {{humanizeDuration .AverageExecutionTime "ms"}}
+      Last Execution Date : {{formatUnixTime .UpdateTimestamp}}
+      Last Successful Execution Date : {{ if .LastSuccessDate }}{{formatUnixTime .LastSuccessDate}}{{ else }}Never{{ end }}
+        {{- if $.CheckMetadata }}
+        {{- if index $.CheckMetadata .CheckID }}
+        metadata:
+        {{- range $k, $v := index $.CheckMetadata .CheckID }}
+          {{ $k }}: {{ $v }}
+        {{- end }}
+        {{- end }}
+        {{- end }}
+        {{- if .LastError }}
+      Error: {{lastErrorMessage .LastError}}
+        {{lastErrorTraceback .LastError -}}
+        {{- end }}
+        {{- if .LastWarnings }}
+          {{- range .LastWarnings }}
+      Warning: {{.}}
+          {{- end }}
         {{- end }}
       {{- end }}
+    {{- else }}
+      {{ greenText "Check has not run yet" }}
     {{- end }}
-  {{- else }}
-    {{ greenText "Check has not run yet" }}
-  {{- end }}
-  {{- end }}
-{{ end }}
+    {{- end }}
+  {{ end }}

--- a/pkg/status/templates/runtimesecurity.tmpl
+++ b/pkg/status/templates/runtimesecurity.tmpl
@@ -5,6 +5,11 @@ Runtime Security
   Not enabled
 {{- else}}
   {{- with .RuntimeSecurityStatus}}
+  {{ if .endpoints }}
+  {{- range $endpoint := .endpoints }}
+  {{ $endpoint }}
+  {{- end }}
+  {{- end }}
   Connected: {{.connected}}
   Events received: {{.eventReceived}}
   {{- end }}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Show the endpoints used for both CSPM and CWS in status and flare.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Before this PR, there was no easy way to know what endpoints were
used, making it hard to troubleshoot.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
