### PR TITLE
Reducing the memory used by flushSeries: Refactor serie signature

### DIFF
--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -120,14 +120,12 @@ func (cs *CheckSampler) addBucket(bucket *metrics.HistogramBucket) {
 
 func (cs *CheckSampler) commitSeries(timestamp float64) {
 	series, errors := cs.metrics.Flush(timestamp)
-	for ckey, errs := range errors {
+	for ckey, err := range errors {
 		context, ok := cs.contextResolver.get(ckey)
-		for _, err := range errs {
-			if !ok {
-				log.Errorf("Can't resolve context of error '%s': inconsistent context resolver state: context with key '%v' is not tracked", err, ckey)
-			} else {
-				log.Infof("No value returned for check metric '%s' on host '%s' and tags '%s': %s", context.Name, context.Host, context.Tags, err)
-			}
+		if !ok {
+			log.Errorf("Can't resolve context of error '%s': inconsistent context resolver state: context with key '%v' is not tracked", err, ckey)
+		} else {
+			log.Infof("No value returned for check metric '%s' on host '%s' and tags '%s': %s", context.Name, context.Host, context.Tags, err)
 		}
 	}
 	for _, serie := range series {

--- a/pkg/aggregator/check_sampler.go
+++ b/pkg/aggregator/check_sampler.go
@@ -120,13 +120,15 @@ func (cs *CheckSampler) addBucket(bucket *metrics.HistogramBucket) {
 
 func (cs *CheckSampler) commitSeries(timestamp float64) {
 	series, errors := cs.metrics.Flush(timestamp)
-	for ckey, err := range errors {
+	for ckey, errs := range errors {
 		context, ok := cs.contextResolver.get(ckey)
-		if !ok {
-			log.Errorf("Can't resolve context of error '%s': inconsistent context resolver state: context with key '%v' is not tracked", err, ckey)
-			continue
+		for _, err := range errs {
+			if !ok {
+				log.Errorf("Can't resolve context of error '%s': inconsistent context resolver state: context with key '%v' is not tracked", err, ckey)
+			} else {
+				log.Infof("No value returned for check metric '%s' on host '%s' and tags '%s': %s", context.Name, context.Host, context.Tags, err)
+			}
 		}
-		log.Infof("No value returned for check metric '%s' on host '%s' and tags '%s': %s", context.Name, context.Host, context.Tags, err)
 	}
 	for _, serie := range series {
 		// Resolve context and populate new []Serie

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -125,7 +125,7 @@ func (s *TimeSampler) flushSeries(cutoffTime int64) metrics.Series {
 	var series []*metrics.Serie
 	s.flushContextMetrics(contextMetricsFlusher, func(rawSeries []*metrics.Serie) {
 		// Note: rawSeries is reused at each call
-		series = append(series, s.dedupSerieBySerieSignature(rawSeries)...)
+		series = append(series, s.dedupSeriesBySignature(rawSeries)...)
 	})
 
 	// Delete the contexts associated to an expired counter
@@ -136,7 +136,7 @@ func (s *TimeSampler) flushSeries(cutoffTime int64) metrics.Series {
 	return series
 }
 
-func (s *TimeSampler) dedupSerieBySerieSignature(rawSeries []*metrics.Serie) []*metrics.Serie {
+func (s *TimeSampler) dedupSeriesBySignature(rawSeries []*metrics.Serie) []*metrics.Serie {
 	var series []*metrics.Serie
 	serieBySignature := make(map[SerieSignature]*metrics.Serie)
 

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -13,10 +13,9 @@ import (
 )
 
 // SerieSignature holds the elements that allow to know whether two similar `Serie`s
-// from the same bucket can be merged into one
+// from the same bucket can be merged into one. Series must have the same contextKey.
 type SerieSignature struct {
 	mType      metrics.APIMetricType
-	contextKey ckey.ContextKey
 	nameSuffix string
 }
 
@@ -141,8 +140,9 @@ func (s *TimeSampler) dedupSerieBySerieSignature(rawSeries []*metrics.Serie) []*
 	var series []*metrics.Serie
 	serieBySignature := make(map[SerieSignature]*metrics.Serie)
 
+	// rawSeries have the same context key.
 	for _, serie := range rawSeries {
-		serieSignature := SerieSignature{serie.MType, serie.ContextKey, serie.NameSuffix}
+		serieSignature := SerieSignature{serie.MType, serie.NameSuffix}
 
 		if existingSerie, ok := serieBySignature[serieSignature]; ok {
 			existingSerie.Points = append(existingSerie.Points, serie.Points[0])

--- a/pkg/aggregator/time_sampler.go
+++ b/pkg/aggregator/time_sampler.go
@@ -162,7 +162,7 @@ func (s *TimeSampler) dedupSerieBySerieSignature(rawSeries []*metrics.Serie) []*
 	return series
 }
 
-func (s TimeSampler) flushSketches(cutoffTime int64) metrics.SketchSeriesList {
+func (s *TimeSampler) flushSketches(cutoffTime int64) metrics.SketchSeriesList {
 	pointsByCtx := make(map[ckey.ContextKey][]metrics.SketchPoint)
 	sketches := make(metrics.SketchSeriesList, 0, len(pointsByCtx))
 

--- a/pkg/metrics/check_metrics.go
+++ b/pkg/metrics/check_metrics.go
@@ -105,7 +105,7 @@ func (cm *CheckMetrics) Expire(contextKeys []ckey.ContextKey, timestamp float64)
 }
 
 // Flush flushes every metrics in the CheckMetrics (see ContextMetrics.Flush)
-func (cm *CheckMetrics) Flush(timestamp float64) ([]*Serie, map[ckey.ContextKey][]error) {
+func (cm *CheckMetrics) Flush(timestamp float64) ([]*Serie, map[ckey.ContextKey]error) {
 	return cm.metrics.Flush(timestamp)
 }
 

--- a/pkg/metrics/check_metrics.go
+++ b/pkg/metrics/check_metrics.go
@@ -105,7 +105,7 @@ func (cm *CheckMetrics) Expire(contextKeys []ckey.ContextKey, timestamp float64)
 }
 
 // Flush flushes every metrics in the CheckMetrics (see ContextMetrics.Flush)
-func (cm *CheckMetrics) Flush(timestamp float64) ([]*Serie, map[ckey.ContextKey]error) {
+func (cm *CheckMetrics) Flush(timestamp float64) ([]*Serie, map[ckey.ContextKey][]error) {
 	return cm.metrics.Flush(timestamp)
 }
 

--- a/pkg/metrics/context_metrics.go
+++ b/pkg/metrics/context_metrics.go
@@ -119,7 +119,7 @@ func flushToSeries(
 	return series
 }
 
-// mergeContextMetrics orders all Metric instances by context key,
+// aggregateContextMetricsByContextKey orders all Metric instances by context key,
 // representing the result as calls to the given callbacks.  The `callback` parameter
 // is called with each Metric in term, while `contextKeyChanged` is called after the
 // last Metric with each context key is processed. The last argument of the callback is the index
@@ -134,7 +134,7 @@ func flushToSeries(
 //     callback(key3, metric5, 0)
 //     callback(key3, metric6, 1)
 //     contextKeyChanged()
-func mergeContextMetrics(
+func aggregateContextMetricsByContextKey(
 	contextMetricsCollection []ContextMetrics,
 	callback func(ckey.ContextKey, Metric, int),
 	contextKeyChanged func()) {

--- a/pkg/metrics/context_metrics.go
+++ b/pkg/metrics/context_metrics.go
@@ -84,11 +84,11 @@ func (m ContextMetrics) Flush(timestamp float64) ([]*Serie, map[ckey.ContextKey]
 	errors := make(map[ckey.ContextKey]error)
 
 	for contextKey, metric := range m {
-		flushToSeries(
+		series = flushToSeries(
 			contextKey,
 			metric,
 			timestamp,
-			&series,
+			series,
 			errors)
 	}
 
@@ -99,14 +99,14 @@ func flushToSeries(
 	contextKey ckey.ContextKey,
 	metric Metric,
 	bucketTimestamp float64,
-	series *[]*Serie,
-	errors map[ckey.ContextKey]error) {
+	series []*Serie,
+	errors map[ckey.ContextKey]error) []*Serie {
 	metricSeries, err := metric.flush(bucketTimestamp)
 
 	if err == nil {
 		for _, serie := range metricSeries {
 			serie.ContextKey = contextKey
-			*series = append(*series, serie)
+			series = append(series, serie)
 		}
 	} else {
 		switch err.(type) {
@@ -116,6 +116,7 @@ func flushToSeries(
 			errors[contextKey] = err
 		}
 	}
+	return series
 }
 
 // mergeContextMetrics orders all Metric instances by context key,

--- a/pkg/metrics/context_metrics.go
+++ b/pkg/metrics/context_metrics.go
@@ -79,9 +79,9 @@ func (m ContextMetrics) AddSample(contextKey ckey.ContextKey, sample *MetricSamp
 
 // Flush flushes every metrics in the ContextMetrics.
 // Returns the slice of Series and a map of errors by context key.
-func (m ContextMetrics) Flush(timestamp float64) ([]*Serie, map[ckey.ContextKey][]error) {
+func (m ContextMetrics) Flush(timestamp float64) ([]*Serie, map[ckey.ContextKey]error) {
 	var series []*Serie
-	errors := make(map[ckey.ContextKey][]error)
+	errors := make(map[ckey.ContextKey]error)
 
 	for contextKey, metric := range m {
 		flushToSeries(
@@ -100,7 +100,7 @@ func flushToSeries(
 	metric Metric,
 	bucketTimestamp float64,
 	series *[]*Serie,
-	errors map[ckey.ContextKey][]error) {
+	errors map[ckey.ContextKey]error) {
 	metricSeries, err := metric.flush(bucketTimestamp)
 
 	if err == nil {
@@ -113,7 +113,7 @@ func flushToSeries(
 		case NoSerieError:
 			// this error happens in nominal conditions and shouldn't be returned
 		default:
-			errors[contextKey] = append(errors[contextKey], err)
+			errors[contextKey] = err
 		}
 	}
 }

--- a/pkg/metrics/context_metrics.go
+++ b/pkg/metrics/context_metrics.go
@@ -117,3 +117,39 @@ func flushToSeries(
 		}
 	}
 }
+
+// mergeContextMetrics orders all Metric instances by context key,
+// representing the result as calls to the given callbacks.  The `callback` parameter
+// is called with each Metric in term, while `contextKeyChanged` is called after the
+// last Metric with each context key is processed. The last argument of the callback is the index
+// of the contextMetrics in contextMetricsCollection.
+//  For example:
+//     callback(key1, metric1, 0)
+//     callback(key1, metric2, 1)
+//     callback(key1, metric3, 2)
+//     contextKeyChanged()
+//     callback(key2, metric4, 0)
+//     contextKeyChanged()
+//     callback(key3, metric5, 0)
+//     callback(key3, metric6, 1)
+//     contextKeyChanged()
+func mergeContextMetrics(
+	contextMetricsCollection []ContextMetrics,
+	callback func(ckey.ContextKey, Metric, int),
+	contextKeyChanged func()) {
+	for i := 0; i < len(contextMetricsCollection); i++ {
+		for contextKey, metrics := range contextMetricsCollection[i] {
+			callback(contextKey, metrics, i)
+
+			// Find `contextKey` in the remaining contextMetrics
+			for j := i + 1; j < len(contextMetricsCollection); j++ {
+				contextMetrics := contextMetricsCollection[j]
+				if m, found := contextMetrics[contextKey]; found {
+					callback(contextKey, m, j)
+					delete(contextMetrics, contextKey)
+				}
+			}
+			contextKeyChanged()
+		}
+	}
+}

--- a/pkg/metrics/context_metrics_flusher.go
+++ b/pkg/metrics/context_metrics_flusher.go
@@ -52,7 +52,7 @@ func (f *ContextMetricsFlusher) FlushAndClear(callback func([]*Serie)) map[ckey.
 
 	errorsByContextKey := make(map[ckey.ContextKey]error)
 
-	mergeContextMetrics(
+	aggregateContextMetricsByContextKey(
 		contextMetricsCollection,
 		func(contextKey ckey.ContextKey, m Metric, contextMetricIndex int) {
 			series = flushToSeries(

--- a/pkg/metrics/context_metrics_flusher.go
+++ b/pkg/metrics/context_metrics_flusher.go
@@ -55,11 +55,11 @@ func (f *ContextMetricsFlusher) FlushAndClear(callback func([]*Serie)) map[ckey.
 	mergeContextMetrics(
 		contextMetricsCollection,
 		func(contextKey ckey.ContextKey, m Metric, contextMetricIndex int) {
-			flushToSeries(
+			series = flushToSeries(
 				contextKey,
 				m,
 				f.metrics[contextMetricIndex].bucketTimestamp,
-				&series,
+				series,
 				errorsByContextKey)
 			for k, err := range errorsByContextKey {
 				errors[k] = append(errors[k], err)

--- a/pkg/metrics/context_metrics_flusher.go
+++ b/pkg/metrics/context_metrics_flusher.go
@@ -1,0 +1,78 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package metrics
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
+)
+
+type timestampedContextMetrics struct {
+	bucketTimestamp float64
+	contextMetrics  ContextMetrics
+}
+
+// ContextMetricsFlusher flushes several ContextMetrics
+type ContextMetricsFlusher struct {
+	metrics []timestampedContextMetrics
+}
+
+// NewContextMetricsFlusher creates a new instance of ContextMetricsFlusher
+func NewContextMetricsFlusher() *ContextMetricsFlusher {
+	return &ContextMetricsFlusher{}
+}
+
+// Append appends a new contextMetrics
+func (f *ContextMetricsFlusher) Append(bucketTimestamp float64, contextMetrics ContextMetrics) {
+	f.metrics = append(f.metrics, timestampedContextMetrics{
+		bucketTimestamp: bucketTimestamp,
+		contextMetrics:  contextMetrics,
+	})
+}
+
+// FlushAndClear flushes contextMetrics to series and clear contextMetrics collection.
+// For each contextKey, FlushAndClear flushes every metrics (Same as ContextMetrics.Flush) and call
+// the callback with all series whose key context is the same.
+// If there are 3 context keys, the callback is called 3 times.
+// Note: The slice []*Serie in callback is reused.
+func (f *ContextMetricsFlusher) FlushAndClear(callback func([]*Serie)) map[ckey.ContextKey][]error {
+	errors := make(map[ckey.ContextKey][]error)
+	var series []*Serie
+
+	f.merge(func(contextKey ckey.ContextKey, m Metric, bucketTimestamp float64) {
+		flushToSeries(
+			contextKey,
+			m,
+			bucketTimestamp,
+			&series,
+			errors)
+	}, func() {
+		callback(series)
+		series = series[:0]
+	})
+	return errors
+}
+
+// For each context key, calls several times `callback``.
+// Call `contextKeyChanged` when handling another context key
+func (f *ContextMetricsFlusher) merge(
+	callback func(ckey.ContextKey, Metric, float64),
+	contextKeyChanged func()) {
+	for i := 0; i < len(f.metrics); i++ {
+		for contextKey, metrics := range f.metrics[i].contextMetrics {
+			callback(contextKey, metrics, f.metrics[i].bucketTimestamp)
+
+			// Find `contextKey` in the remaining contextMetrics
+			for j := i + 1; j < len(f.metrics); j++ {
+				contextMetrics := f.metrics[j].contextMetrics
+				if m, found := contextMetrics[contextKey]; found {
+					callback(contextKey, m, f.metrics[j].bucketTimestamp)
+					delete(contextMetrics, contextKey)
+				}
+			}
+			contextKeyChanged()
+		}
+	}
+}

--- a/pkg/metrics/context_metrics_flusher_test.go
+++ b/pkg/metrics/context_metrics_flusher_test.go
@@ -1,0 +1,94 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build test
+
+package metrics
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/aggregator/ckey"
+	"github.com/stretchr/testify/require"
+	"sort"
+	"testing"
+)
+
+func TestFlushAndClearSingleContextMetrics(t *testing.T) {
+	metrics1 := MakeContextMetrics()
+	addMetricSample(metrics1, 100, 1)
+	addMetricSample(metrics1, 200, 2)
+
+	flusher := NewContextMetricsFlusher()
+	flusher.Append(0, metrics1)
+
+	require := require.New(t)
+	seriesCollection := flushAndClear(require, flusher)
+
+	require.Len(seriesCollection, 2)
+	requireSerie(require, seriesCollection[0], 100, 1)
+	requireSerie(require, seriesCollection[1], 200, 2)
+}
+
+func TestFlushAndClear(t *testing.T) {
+	metrics1 := MakeContextMetrics()
+	addMetricSample(metrics1, 100, 1)
+	addMetricSample(metrics1, 200, 2)
+
+	metrics2 := MakeContextMetrics()
+	addMetricSample(metrics2, 300, 3)
+	addMetricSample(metrics2, 200, 4)
+
+	metrics3 := MakeContextMetrics()
+	addMetricSample(metrics3, 300, 5)
+	addMetricSample(metrics3, 200, 6)
+	addMetricSample(metrics3, 400, 7)
+
+	flusher := NewContextMetricsFlusher()
+	flusher.Append(0, metrics1)
+	flusher.Append(0, metrics2)
+	flusher.Append(0, metrics3)
+
+	require := require.New(t)
+	seriesCollection := flushAndClear(require, flusher)
+	require.Len(seriesCollection, 4)
+	requireSerie(require, seriesCollection[0], 100, 1)
+	requireSerie(require, seriesCollection[1], 200, 2, 4, 6)
+	requireSerie(require, seriesCollection[2], 300, 3, 5)
+	requireSerie(require, seriesCollection[3], 400, 7)
+}
+
+func requireSerie(require *require.Assertions, series []*Serie, contextKey ckey.ContextKey, expectedValues ...float64) {
+	require.Len(series, len(expectedValues))
+	for i, serie := range series {
+		require.Equal(contextKey, serie.ContextKey)
+		require.Len(serie.Points, 1)
+		require.Equal(expectedValues[i], serie.Points[0].Value)
+	}
+}
+
+func addMetricSample(contextMetrics ContextMetrics, contextKey int, value float64) {
+	mSample := MetricSample{
+		Value: value,
+		Mtype: GaugeType,
+	}
+	contextMetrics.AddSample(ckey.ContextKey(contextKey), &mSample, 1, 10, nil)
+}
+
+func flushAndClear(require *require.Assertions, flusher *ContextMetricsFlusher) [][]*Serie {
+	var seriesCollection [][]*Serie
+	flusher.FlushAndClear(func(s []*Serie) {
+		// Clone `s` as it is reused at each call
+		series := make([]*Serie, len(s))
+		copy(series, s)
+		seriesCollection = append(seriesCollection, series)
+	})
+
+	// Sort as the order depensd on the map order which is undefined
+	sort.Slice(seriesCollection, func(i, j int) bool {
+		require.Greater(len(seriesCollection[i]), 0)
+		require.Greater(len(seriesCollection[j]), 0)
+		return seriesCollection[i][0].ContextKey < seriesCollection[j][0].ContextKey
+	})
+	return seriesCollection
+}


### PR DESCRIPTION
### What does this PR do?

**This is the first part** of reducing the memory used by `flushSeries`.
When flushing series, the agent creates a slice of all of `Serie` and then serialize them. It means the Agent has to store in memory the full list of series. The goal of the whole development is to serialize the series at the same time as the series are flushed. As less series has to be kept in memory, the maximum memory usage should be reduce.

This PR is a refactoring in order to prepare further developments. The behavior should be the same as before (The memory usage is not yet optimized). To be more precise, this PR is a refactor around `SerieSignature` logic. 
Before `flushSeries` did:
```
sliceOfSeries = []
for each context metrics
     flush all the series for this context metrics and add them into sliceOfSeries
dedups all the series in sliceOfSeries using `SerieSignature`
return sliceOfSeries
```
After 
```
sliceOfSeries = []
for each context key k
     S = flush all the series with context key k 
     dedups S
    Add S to sliceOfSeries (1)
return sliceOfSeries
```

Before this PR, `flushSeries` flushes all series for every `contextMetrics` and then deduplicates the series by `SerieSignature`. This PR introduces the following change. For each context key, get all metrics with this context key, flushes them into a slice of serie and deduplicates by `SerieSignature`. 

The main goal is to  flush few series, serialize them, flush few series, serialize them and so one.
In the previous code, the deduplication by `SerieSignature` required to have all the series to perform the deduplication making the change `flush few series, serialize them` impossible.
With this PR, instead of perform (1), few series can be sent to the serializer.

### Motivation

Reduce memory usage of the Agent.

### Additional Notes

*** **Reviewing commit by commit is strongly recommended.** ***

The target branch is `olivierg/stream-serie-flush` to fully merged or not the whole dev on `main`.

### Describe how to test/QA your changes

Sending metrics with different timestamp works the same as before.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
