### PR TITLE
Remove unused v2 implemenatations for events, service_checks

### DIFF
--- a/cmd/agent/android/app/src/main/assets/datadog.yaml
+++ b/cmd/agent/android/app/src/main/assets/datadog.yaml
@@ -112,6 +112,4 @@ tags:
 use_dogstatsd: true
 use_service_mapper: true
 use_v2_api:
-  events: false
   series: false
-  service_checks: false

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -384,9 +384,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("serializer_max_payload_size", 2*megaByte+megaByte/2)
 	config.BindEnvAndSetDefault("serializer_max_uncompressed_payload_size", 4*megaByte)
 
-	config.BindEnvAndSetDefault("use_v2_api.events", false)
 	config.BindEnvAndSetDefault("use_v2_api.series", false)
-	config.BindEnvAndSetDefault("use_v2_api.service_checks", false)
 	// Serializer: allow user to blacklist any kind of payload to be sent
 	config.BindEnvAndSetDefault("enable_payloads.events", true)
 	config.BindEnvAndSetDefault("enable_payloads.series", true)

--- a/pkg/forwarder/forwarder.go
+++ b/pkg/forwarder/forwarder.go
@@ -61,8 +61,6 @@ type Forwarder interface {
 	SubmitV1Series(payload Payloads, extra http.Header) error
 	SubmitV1Intake(payload Payloads, extra http.Header) error
 	SubmitV1CheckRuns(payload Payloads, extra http.Header) error
-	SubmitEvents(payload Payloads, extra http.Header) error
-	SubmitServiceChecks(payload Payloads, extra http.Header) error
 	SubmitSeries(payload Payloads, extra http.Header) error
 	SubmitSketchSeries(payload Payloads, extra http.Header) error
 	SubmitHostMetadata(payload Payloads, extra http.Header) error
@@ -447,18 +445,6 @@ func (f *DefaultForwarder) sendHTTPTransactions(transactions []*transaction.HTTP
 		f.domainForwarders[t.Domain].sendHTTPTransactions(t)
 	}
 	return nil
-}
-
-// SubmitEvents will send an event type payload to Datadog backend.
-func (f *DefaultForwarder) SubmitEvents(payload Payloads, extra http.Header) error {
-	transactions := f.createHTTPTransactions(endpoints.EventsEndpoint, payload, false, extra)
-	return f.sendHTTPTransactions(transactions)
-}
-
-// SubmitServiceChecks will send a service check type payload to Datadog backend.
-func (f *DefaultForwarder) SubmitServiceChecks(payload Payloads, extra http.Header) error {
-	transactions := f.createHTTPTransactions(endpoints.ServiceChecksEndpoint, payload, false, extra)
-	return f.sendHTTPTransactions(transactions)
 }
 
 // SubmitSketchSeries will send payloads to Datadog backend - PROTOTYPE FOR PERCENTILE

--- a/pkg/forwarder/sync_forwarder.go
+++ b/pkg/forwarder/sync_forwarder.go
@@ -86,18 +86,6 @@ func (f *SyncForwarder) SubmitV1CheckRuns(payload Payloads, extra http.Header) e
 	return f.sendHTTPTransactions(transactions)
 }
 
-// SubmitEvents will send an event type payload to Datadog backend.
-func (f *SyncForwarder) SubmitEvents(payload Payloads, extra http.Header) error {
-	transactions := f.defaultForwarder.createHTTPTransactions(endpoints.EventsEndpoint, payload, false, extra)
-	return f.sendHTTPTransactions(transactions)
-}
-
-// SubmitServiceChecks will send a service check type payload to Datadog backend.
-func (f *SyncForwarder) SubmitServiceChecks(payload Payloads, extra http.Header) error {
-	transactions := f.defaultForwarder.createHTTPTransactions(endpoints.ServiceChecksEndpoint, payload, false, extra)
-	return f.sendHTTPTransactions(transactions)
-}
-
 // SubmitSketchSeries will send payloads to Datadog backend - PROTOTYPE FOR PERCENTILE
 func (f *SyncForwarder) SubmitSketchSeries(payload Payloads, extra http.Header) error {
 	transactions := f.defaultForwarder.createHTTPTransactions(endpoints.SketchSeriesEndpoint, payload, true, extra)

--- a/pkg/forwarder/test_common.go
+++ b/pkg/forwarder/test_common.go
@@ -108,16 +108,6 @@ func (tf *MockedForwarder) SubmitV1CheckRuns(payload Payloads, extra http.Header
 	return tf.Called(payload, extra).Error(0)
 }
 
-// SubmitEvents updates the internal mock struct
-func (tf *MockedForwarder) SubmitEvents(payload Payloads, extra http.Header) error {
-	return tf.Called(payload, extra).Error(0)
-}
-
-// SubmitServiceChecks updates the internal mock struct
-func (tf *MockedForwarder) SubmitServiceChecks(payload Payloads, extra http.Header) error {
-	return tf.Called(payload, extra).Error(0)
-}
-
 // SubmitSketchSeries updates the internal mock struct
 func (tf *MockedForwarder) SubmitSketchSeries(payload Payloads, extra http.Header) error {
 	return tf.Called(payload, extra).Error(0)

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -248,24 +248,20 @@ func (s *Serializer) SendEvents(e EventsStreamJSONMarshaler) error {
 		return nil
 	}
 
-	useV1API := true
 	var eventPayloads forwarder.Payloads
 	var extraHeaders http.Header
 	var err error
 
-	if useV1API && s.enableEventsJSONStream {
-		eventPayloads, extraHeaders, err = s.serializeEventsStreamJSONMarshalerPayload(e, useV1API)
+	if s.enableEventsJSONStream {
+		eventPayloads, extraHeaders, err = s.serializeEventsStreamJSONMarshalerPayload(e, true)
 	} else {
-		eventPayloads, extraHeaders, err = s.serializePayload(e, true, useV1API)
+		eventPayloads, extraHeaders, err = s.serializePayload(e, true, true)
 	}
 	if err != nil {
 		return fmt.Errorf("dropping event payload: %s", err)
 	}
 
-	if useV1API {
-		return s.Forwarder.SubmitV1Intake(eventPayloads, extraHeaders)
-	}
-	return s.Forwarder.SubmitEvents(eventPayloads, extraHeaders)
+	return s.Forwarder.SubmitV1Intake(eventPayloads, extraHeaders)
 }
 
 // SendServiceChecks serializes a list of serviceChecks and sends the payload to the forwarder
@@ -275,13 +271,11 @@ func (s *Serializer) SendServiceChecks(sc marshaler.StreamJSONMarshaler) error {
 		return nil
 	}
 
-	useV1API := true
-
 	var serviceCheckPayloads forwarder.Payloads
 	var extraHeaders http.Header
 	var err error
 
-	if useV1API && s.enableServiceChecksJSONStream {
+	if s.enableServiceChecksJSONStream {
 		serviceCheckPayloads, extraHeaders, err = s.serializeStreamablePayload(sc, stream.DropItemOnErrItemTooBig)
 	} else {
 		serviceCheckPayloads, extraHeaders, err = s.serializePayloadJSON(sc, true)
@@ -290,10 +284,7 @@ func (s *Serializer) SendServiceChecks(sc marshaler.StreamJSONMarshaler) error {
 		return fmt.Errorf("dropping service check payload: %s", err)
 	}
 
-	if useV1API {
-		return s.Forwarder.SubmitV1CheckRuns(serviceCheckPayloads, extraHeaders)
-	}
-	return s.Forwarder.SubmitServiceChecks(serviceCheckPayloads, extraHeaders)
+	return s.Forwarder.SubmitV1CheckRuns(serviceCheckPayloads, extraHeaders)
 }
 
 // SendSeries serializes a list of serviceChecks and sends the payload to the forwarder

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -248,7 +248,7 @@ func (s *Serializer) SendEvents(e EventsStreamJSONMarshaler) error {
 		return nil
 	}
 
-	useV1API := !config.Datadog.GetBool("use_v2_api.events")
+	useV1API := true
 	var eventPayloads forwarder.Payloads
 	var extraHeaders http.Header
 	var err error

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -401,9 +401,7 @@ func TestSendWithDisabledKind(t *testing.T) {
 	s.SendProcessesMetadata("test")
 
 	f.AssertNotCalled(t, "SubmitMetadata")
-	f.AssertNotCalled(t, "SubmitEvents")
 	f.AssertNotCalled(t, "SubmitV1CheckRuns")
-	f.AssertNotCalled(t, "SubmitServiceChecks")
 	f.AssertNotCalled(t, "SubmitV1Series")
 	f.AssertNotCalled(t, "SubmitSketchSeries")
 

--- a/pkg/serializer/serializer_test.go
+++ b/pkg/serializer/serializer_test.go
@@ -257,26 +257,6 @@ func TestSendV1EventsCreateMarshalersBySourceType(t *testing.T) {
 	eventPayload.AssertNumberOfCalls(t, "CreateMarshalersBySourceType", 1)
 }
 
-func TestSendEvents(t *testing.T) {
-	mockConfig := config.Mock()
-
-	f := &forwarder.MockedForwarder{}
-	f.On("SubmitEvents", protobufPayloads, protobufExtraHeadersWithCompression).Return(nil).Times(1)
-	mockConfig.Set("use_v2_api.events", true)
-	defer mockConfig.Set("use_v2_api.events", nil)
-
-	s := NewSerializer(f, nil)
-
-	payload := createTestEventsPayload(&testPayload{})
-	err := s.SendEvents(payload)
-	require.Nil(t, err)
-	f.AssertExpectations(t)
-
-	errPayload := createTestEventsPayload(&testErrorPayload{})
-	err = s.SendEvents(errPayload)
-	require.NotNil(t, err)
-}
-
 func TestSendV1ServiceChecks(t *testing.T) {
 	f := &forwarder.MockedForwarder{}
 	f.On("SubmitV1CheckRuns", jsonPayloads, jsonExtraHeadersWithCompression).Return(nil).Times(1)

--- a/test/benchmarks/aggregator/main.go
+++ b/test/benchmarks/aggregator/main.go
@@ -88,12 +88,6 @@ func (f *forwarderBenchStub) SubmitV1CheckRuns(payloads forwarder.Payloads, extr
 func (f *forwarderBenchStub) SubmitSeries(payload forwarder.Payloads, extraHeaders http.Header) error {
 	return nil
 }
-func (f *forwarderBenchStub) SubmitEvents(payload forwarder.Payloads, extraHeaders http.Header) error {
-	return nil
-}
-func (f *forwarderBenchStub) SubmitServiceChecks(payload forwarder.Payloads, extraHeaders http.Header) error {
-	return nil
-}
 func (f *forwarderBenchStub) SubmitSketchSeries(payload forwarder.Payloads, extraHeaders http.Header) error {
 	return nil
 }

--- a/test/benchmarks/aggregator/memory.go
+++ b/test/benchmarks/aggregator/memory.go
@@ -134,7 +134,7 @@ func benchmarkMemory(agg *aggregator.BufferedAggregator, sender aggregator.Sende
 
 				i := 0
 				for range ticker.C {
-					i += 1
+					i++
 					i = i % p
 					select {
 					case <-quitGenerator:
@@ -144,17 +144,17 @@ func benchmarkMemory(agg *aggregator.BufferedAggregator, sender aggregator.Sende
 						for _, m := range metrics {
 							for _, generated := range m {
 								rawSender.SendRawMetricSample(generated[i])
-								sent += 1
+								sent++
 							}
 						}
 
 						// Submit ServiceCheck
 						rawSender.SendRawServiceCheck(scs[i])
-						sent += 1
+						sent++
 
 						// Submit Event
 						rawSender.Event(*events[i])
-						sent += 1
+						sent++
 					}
 				}
 			}()
@@ -200,7 +200,7 @@ func benchmarkMemory(agg *aggregator.BufferedAggregator, sender aggregator.Sende
 						quitGenerator <- true
 						return
 					}
-					secs += 1
+					secs++
 				}
 			}()
 

--- a/test/benchmarks/dogstatsd/main.go
+++ b/test/benchmarks/dogstatsd/main.go
@@ -91,14 +91,6 @@ func (f *forwarderBenchStub) SubmitSeries(payloads forwarder.Payloads, extraHead
 	f.computeStats(payloads)
 	return nil
 }
-func (f *forwarderBenchStub) SubmitEvents(payloads forwarder.Payloads, extraHeaders http.Header) error {
-	f.computeStats(payloads)
-	return nil
-}
-func (f *forwarderBenchStub) SubmitServiceChecks(payloads forwarder.Payloads, extraHeaders http.Header) error {
-	f.computeStats(payloads)
-	return nil
-}
 func (f *forwarderBenchStub) SubmitSketchSeries(payloads forwarder.Payloads, extraHeaders http.Header) error {
 	f.computeStats(payloads)
 	return nil


### PR DESCRIPTION
Long ago, we began introducing a "v2" API for various intake payloads.  But that project didn't get finished, and now we are in the midst of another, incompatible "v2" project.  To avoid confusion over "v2", this removes the remaining, unused v2 implementations.

### Motivation

Avoiding confusion.

### Possible Drawbacks / Trade-offs

It's possible that I (and the folks reviewing this) have misunderstood what is in-use, and this disables a working implementation.

The `use_v2_api.events` and `use_v2_api.service_checks` config values were only just added to the various k8s resources, by me, this week, while adding `use_v2_api.series` (which _is_ in use).  So prior to this week, we could not set these configuration parameters internally.

The sketches v2 API is enabled permanently now.  And other intake payloads are handled using different config syntax, unaffected by this change.

### Describe how to test/QA your changes

Configure an agent to support dogstatsd, and then inject a check with

```
echo "_e{21,36}:An exception occurred|Cannot parse CSV file from 10.0.0.17|t:warning|#err_type:bad_file" | nc -w0 -u localhost:8125
```

and look for that event in the DD app.

Similarly, inject a service check with
```
echo "_sc|Pamplemousse|2|#env:dev|m:Fruit connection timed out after 10s" | nc -w0 -u localhost 8125
```
and verify that it shows up, eventually, at https://dddev.datadoghq.com/check/summary?id=Pamplemousse

Configure an agent to produce events and service checks, and observe that those are sent to the intake (log_payloads).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
