### PR TITLE
Add notifications for "allowed-to-fail" CI jobs

### DIFF
--- a/.gitlab/notify.yml
+++ b/.gitlab/notify.yml
@@ -26,6 +26,16 @@ notify-on-success:
     # The triggering repo should already have its own notification system
     if [ "$CI_PIPELINE_SOURCE" != "pipeline" ]; then
       postmessage "#datadog-agent-pipelines" "$MESSAGE_TEXT"
+
+      # Check the result of "allow_failure = true" jobs
+      # and notify any failed jobs that are configured to have notifications.
+      # This lets some jobs not fail pipelines,
+      # but still have notifications when they fail.
+      if [ "$DEPLOY_AGENT" = "true" ]; then
+        invoke -e pipeline.notify-failure --during-pipeline-success --notification-type "deploy"
+      else
+        invoke -e pipeline.notify-failure --during-pipeline-success --notification-type "merge"
+      fi
     else
       echo "This pipeline was triggered by another repository, skipping notification."
     fi

--- a/tasks/pipeline.py
+++ b/tasks/pipeline.py
@@ -332,8 +332,7 @@ Please check for typos in the JOBOWNERS file and/or add them to the Github <-> S
 
 # Set of jobs that are allowed to fail (without failing the pipeline)
 # but should send notifications upon failure.
-ALLOW_FAILURE_NOTIFICATION_JOBS = {
-}
+ALLOW_FAILURE_NOTIFICATION_JOBS = {}
 
 
 def generate_failure_messages(base, during_pipeline_success=False):


### PR DESCRIPTION
### What does this PR do?

This PR adds support for sending job failure notifications to job owners after pipeline success when the jobs are "allowed-to-fail" (have `allow_failure: true`) and are part of a pre-configured allow-list (`ALLOW_FAILURE_NOTIFICATION_JOBS`). To do this, it modifies the `pipeline.notify-failure` invoke task to work in both a pipeline failure and success context, and adds a call to the task in the `notify-on-success` job.

### Motivation

https://github.com/DataDog/datadog-agent/pull/10039

When adding some generated code that depends on an external data source (in this case, the versions of the Go compiler toolchain), we want to be able to be notified when the generated code becomes stale without failing unrelated CI jobs. This PR lets us add a job with `allow_failure: true` that checks the staleness of the generated code (similar to `go_mod_tidy_check`) and get notifications when it fails.

### Additional Notes

The approach for changing CI to support "allowed-to-fail" jobs was taken from [this Slack thread](https://dd.slack.com/archives/CNY5XCHAA/p1637693381135100).

### Possible Drawbacks / Trade-offs

I tried to keep the changes to the CI notification code small (since I'm not well-versed in GitLab CI), and I made a few assumptions. One of the most important is that the changes I added won't cause any visible differences in the notifications *unless* jobs are specifically added to the `ALLOW_FAILURE_NOTIFICATION_JOBS` list (otherwise, I wouldn't want to merge this PR as-is).

### Describe how to test/QA your changes

The modifications to the `pipeline.notify-failure` task can be tested by manually obtaining a Gitlab token, storing it in `GITLAB_TOKEN`, and using the same `--print-to-stdout` flag to cause the messages to be printed out locally instead of sent over Slack (a valid `CI_PIPELINE_ID` also needs to be provided).

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
