### PR TITLE
Separate workloadmeta consts into stanzas

### DIFF
--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -37,24 +37,18 @@ type Store interface {
 // Kind is the kind of an entity.
 type Kind string
 
-// Source is the source name of an entity.
-type Source string
-
-// ContainerRuntime is the container runtime used by a container.
-type ContainerRuntime string
-
-// ECSLaunchType is the launch type of an ECS task.
-type ECSLaunchType string
-
-// EventType is the type of an event.
-type EventType int
-
-// List of enumerable constants for the types above.
+// Defined Kinds
 const (
 	KindContainer     Kind = "container"
 	KindKubernetesPod Kind = "kubernetes_pod"
 	KindECSTask       Kind = "ecs_task"
+)
 
+// Source is the source name of an entity.
+type Source string
+
+// Defined Sources
+const (
 	SourceDocker       Source = "docker"
 	SourceContainerd   Source = "containerd"
 	SourceECS          Source = "ecs"
@@ -62,14 +56,32 @@ const (
 	SourceKubelet      Source = "kubelet"
 	SourceKubeMetadata Source = "kube_metadata"
 	SourcePodman       Source = "podman"
+)
 
+// ContainerRuntime is the container runtime used by a container.
+type ContainerRuntime string
+
+// Defined ContainerRuntimes
+const (
 	ContainerRuntimeDocker     ContainerRuntime = "docker"
 	ContainerRuntimeContainerd ContainerRuntime = "containerd"
 	ContainerRuntimePodman     ContainerRuntime = "podman"
+)
 
+// ECSLaunchType is the launch type of an ECS task.
+type ECSLaunchType string
+
+// Defined ECSLaunchTypes
+const (
 	ECSLaunchTypeEC2     ECSLaunchType = "ec2"
 	ECSLaunchTypeFargate ECSLaunchType = "fargate"
+)
 
+// EventType is the type of an event.
+type EventType int
+
+// Defined EventTypes
+const (
 	EventTypeSet EventType = iota
 	EventTypeUnset
 )


### PR DESCRIPTION
Go doc will include a const stanza containing only items of a single
enum type along with the definition of that type.

### Motivation

Compare

https://pkg.go.dev/github.com/DataDog/datadog-agent/pkg/workloadmeta#Kind
https://pkg.go.dev/github.com/DataDog/datadog-agent/pkg/autodiscovery/integration#CreationTime

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
