### PR TITLE
[corechecks/containerd] Log error in computeMetrics()

### DIFF
--- a/pkg/collector/corechecks/containers/containerd/containerd.go
+++ b/pkg/collector/corechecks/containers/containerd/containerd.go
@@ -180,7 +180,7 @@ func computeMetrics(sender aggregator.Sender, cu cutil.ContainerdItf, fil *ddCon
 	for _, ctn := range containers {
 		info, err := cu.Info(ctn)
 		if err != nil {
-			log.Errorf("Could not retrieve the metadata of the container: %s", ctn.ID()[:12])
+			log.Errorf("Could not retrieve the metadata of the container %s: %s", ctn.ID()[:12], err)
 			continue
 		}
 


### PR DESCRIPTION
### What does this PR do?

Logs an error in the `computeMetrics` function of the containerd corecheck.

### Motivation

I've seen this error in our staging clusters and it'd be good to know what caused it.

### Describe how to test/QA your changes

Skip.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
