### PR TITLE
Avoid unnecessary allocations for trace logs in ebpf conntracker

### DIFF
--- a/pkg/network/tracer/ebpf_conntracker.go
+++ b/pkg/network/tracer/ebpf_conntracker.go
@@ -23,6 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/ebpf"
 	"github.com/DataDog/ebpf/manager"
+	"github.com/cihub/seelog"
 	ct "github.com/florianl/go-conntrack"
 	"golang.org/x/sys/unix"
 )
@@ -227,17 +228,23 @@ func (e *ebpfConntracker) GetTranslationForConn(stats network.ConnectionStats) *
 	defer tuplePool.Put(src)
 
 	toConntrackTupleFromStats(src, &stats)
-	log.Tracef("looking up in conntrack (stats): %s", stats)
+	if log.ShouldLog(seelog.TraceLvl) {
+		log.Tracef("looking up in conntrack (stats): %s", stats)
+	}
 
 	// Try the lookup in the root namespace first
 	src.Netns = e.rootNS
-	log.Tracef("looking up in conntrack (tuple): %s", src)
+	if log.ShouldLog(seelog.TraceLvl) {
+		log.Tracef("looking up in conntrack (tuple): %s", src)
+	}
 	dst := e.get(src)
 
 	if dst == nil && stats.NetNS != e.rootNS {
 		// Perform another lookup, this time using the connection namespace
 		src.Netns = stats.NetNS
-		log.Tracef("looking up in conntrack (tuple): %s", src)
+		if log.ShouldLog(seelog.TraceLvl) {
+			log.Tracef("looking up in conntrack (tuple): %s", src)
+		}
 		dst = e.get(src)
 	}
 


### PR DESCRIPTION
### What does this PR do?

Guards `log.Tracef` statements to prevent unnecessary allocations when trace logs are disabled.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
Seeing these `log.Tracef` calls in a memory profile.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
