### PR TITLE
[Serverless] remove otlp from serverless build

### DIFF
--- a/cmd/agent/common/common.go
+++ b/cmd/agent/common/common.go
@@ -23,7 +23,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/metadata"
-	"github.com/DataDog/datadog-agent/pkg/otlp"
+
 	"github.com/DataDog/datadog-agent/pkg/util/executable"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
@@ -37,9 +37,6 @@ var (
 
 	// DSD is the global dogstatsd instance
 	DSD *dogstatsd.Server
-
-	// OTLP is the global OTLP pipeline instance
-	OTLP *otlp.Pipeline
 
 	// MetadataScheduler is responsible to orchestrate metadata collection
 	MetadataScheduler *metadata.Scheduler

--- a/cmd/agent/common/common.go
+++ b/cmd/agent/common/common.go
@@ -23,7 +23,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/dogstatsd"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/metadata"
-
 	"github.com/DataDog/datadog-agent/pkg/util/executable"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )

--- a/cmd/agent/common/common_otlp.go
+++ b/cmd/agent/common/common_otlp.go
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build !serverless
+
+package common
+
+import "github.com/DataDog/datadog-agent/pkg/otlp"
+
+// OTLP is the global OTLP pipeline instance
+var OTLP *otlp.Pipeline

--- a/pkg/otlp/collector.go
+++ b/pkg/otlp/collector.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021-present Datadog, Inc.
 
+// +build !serverless
+
 package otlp
 
 import (

--- a/pkg/otlp/config.go
+++ b/pkg/otlp/config.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021-present Datadog, Inc.
 
+// +build !serverless
+
 package otlp
 
 import (

--- a/pkg/otlp/config_serverless_noop.go
+++ b/pkg/otlp/config_serverless_noop.go
@@ -11,7 +11,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
-// IsEnabled no-op
+// IsEnabled always returns false since OTLP is disabled in the serverless agent flavor
 func IsEnabled(cfg config.Config) bool {
 	return false
 }

--- a/pkg/otlp/config_serverless_noop.go
+++ b/pkg/otlp/config_serverless_noop.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
+// +build serverless
+
+package otlp
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+// IsEnabled no-op
+func IsEnabled(cfg config.Config) bool {
+	return false
+}

--- a/pkg/otlp/map_provider.go
+++ b/pkg/otlp/map_provider.go
@@ -3,6 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021-present Datadog, Inc.
 
+// +build !serverless
+
 package otlp
 
 import (


### PR DESCRIPTION
### What does this PR do?

Remove imports from `pkg/otlp` from the serverless flavor

### Motivation

The extension build size is a lot bigger since `otlp` was added in the hot path.
(v15 : 8.8mo, v16 RC: 9.95mo)

Looking at the table symbols from the build (without -w -s optimizations) we can see 
`0000000017375616 0000000000047690 t go.opentelemetry.io/otel/semconv/v1%2e4%2e0.init`

Since this is heavily used in the `otlp` package, this PR removes all imports from this as it's impacting a lot the binary size (and thus the cold start duration for about 50ms)


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
