### PR TITLE
[pkg/otlp/model] [Backport] Do not pick up localhost-like names from attributes

### DIFF
--- a/pkg/otlp/model/attributes/hostname.go
+++ b/pkg/otlp/model/attributes/hostname.go
@@ -56,6 +56,26 @@ func getClusterName(attrs pdata.AttributeMap) (string, bool) {
 //
 //  It returns a boolean value indicated if any name was found
 func HostnameFromAttributes(attrs pdata.AttributeMap) (string, bool) {
+	// Check if the host is localhost or 0.0.0.0, if so discard it.
+	// We don't do the more strict validation done for metadata,
+	// to avoid breaking users existing invalid-but-accepted hostnames.
+	var invalidHosts = map[string]struct{}{
+		"0.0.0.0":                 {},
+		"127.0.0.1":               {},
+		"localhost":               {},
+		"localhost.localdomain":   {},
+		"localhost6.localdomain6": {},
+		"ip6-localhost":           {},
+	}
+
+	candidateHost, ok := unsanitizedHostnameFromAttributes(attrs)
+	if _, invalid := invalidHosts[candidateHost]; invalid {
+		return "", false
+	}
+	return candidateHost, ok
+}
+
+func unsanitizedHostnameFromAttributes(attrs pdata.AttributeMap) (string, bool) {
 	// Custom hostname: useful for overriding in k8s/cloud envs
 	if customHostname, ok := attrs.Get(AttributeDatadogHostname); ok {
 		return customHostname.StringVal(), true

--- a/pkg/otlp/model/attributes/hostname_test.go
+++ b/pkg/otlp/model/attributes/hostname_test.go
@@ -99,6 +99,13 @@ func TestHostnameFromAttributes(t *testing.T) {
 	hostname, ok = HostnameFromAttributes(attrs)
 	assert.False(t, ok)
 	assert.Empty(t, hostname)
+
+	attrs = testutils.NewAttributeMap(map[string]string{
+		AttributeDatadogHostname: "127.0.0.1",
+	})
+	hostname, ok = HostnameFromAttributes(attrs)
+	assert.False(t, ok)
+	assert.Empty(t, hostname)
 }
 
 func TestGetClusterName(t *testing.T) {

--- a/releasenotes/notes/otlp-0.0.0.0-hostname-1581cd6eb09aba0e.yaml
+++ b/releasenotes/notes/otlp-0.0.0.0-hostname-1581cd6eb09aba0e.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    The experimental OTLP endpoint now ignores hostname attributes with localhost-like names for hostname resolution.


### PR DESCRIPTION
### What does this PR do?

Backports open-telemetry/opentelemetry-collector-contrib#6477

### Motivation

Keep codebases in sync

### Describe how to test/QA your changes

Send a metric with a `host.name` attribute set to `localhost` or `0.0.0.0`; check that it is ignored.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
