### PR TITLE
[Ochestrator] add retry strategy to syncinformer

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -589,6 +589,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("leader_election", false)
 	config.BindEnvAndSetDefault("kube_resources_namespace", "")
 	config.BindEnvAndSetDefault("kube_cache_sync_timeout_seconds", 5)
+	config.BindEnvAndSetDefault("kube_cache_sync_max_retry_delay_seconds", 60)
 
 	// Datadog cluster agent
 	config.BindEnvAndSetDefault("cluster_agent.enabled", false)

--- a/pkg/util/kubernetes/apiserver/util.go
+++ b/pkg/util/kubernetes/apiserver/util.go
@@ -50,12 +50,12 @@ func SyncInformers(informers map[InformerName]cache.SharedInformer) error {
 					nextTry = nextTry + (1<<config.RetryCount)*time.Second
 					config.RetryCount++
 					log.Warnf("increase kube_cache_sync_timeout_seconds to %s", nextTry)
+					if lastTry {
+						return fmt.Errorf("couldn't sync informer %s in %v", name, time.Now().Sub(start))
+					}
 					if nextTry >= config.MaxRetryDelay {
 						nextTry = config.MaxRetryDelay
 						lastTry = true
-					}
-					if lastTry {
-						return fmt.Errorf("couldn't sync informer %s in %v", name, time.Now().Sub(start))
 					}
 				} else {
 					log.Debugf("Sync done for informer %s in %v, last resource version: %s", name, time.Now().Sub(start), informers[name].LastSyncResourceVersion())

--- a/releasenotes-dca/notes/add-exponential-backoff-to-syncinformer-9385d768f8ca21ce.yaml
+++ b/releasenotes-dca/notes/add-exponential-backoff-to-syncinformer-9385d768f8ca21ce.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Add exponential backoff to syncinformer.
+    Add exponential wait for syncing with the kubernetes informers.

--- a/releasenotes-dca/notes/add-exponential-backoff-to-syncinformer-9385d768f8ca21ce.yaml
+++ b/releasenotes-dca/notes/add-exponential-backoff-to-syncinformer-9385d768f8ca21ce.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add exponential backoff to syncinformer.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Implement exponential backoff to syncinformer. The Deadline is 60 seconds and each `n` times try it will augment timeout value to `kube_cache_sync_timeout_seconds`+2^n .
For example , when kube_cache_sync_timeout_seconds = 5s :
First try : 5s
Second retry : 6s
Third retry : 7s
Forth retry : 9s
....
until 60s

Tested locally:
```
2021-12-02 15:05:51 UTC | CLUSTER | WARN | (pkg/util/kubernetes/apiserver/util.go:48 in func1) | couldn't sync informer RoleBinding in 3.246µs
2021-12-02 15:05:51 UTC | CLUSTER | WARN | (pkg/util/kubernetes/apiserver/util.go:51 in func1) | increase kube_cache_sync_timeout_seconds to 1s
2021-12-02 15:05:51 UTC | CLUSTER | WARN | (pkg/util/kubernetes/apiserver/util.go:48 in func1) | couldn't sync informer ClusterRole in 1.91µs
2021-12-02 15:05:51 UTC | CLUSTER | WARN | (pkg/util/kubernetes/apiserver/util.go:51 in func1) | increase kube_cache_sync_timeout_seconds to 1s
2021-12-02 15:05:51 UTC | CLUSTER | DEBUG | (pkg/util/kubernetes/apiserver/util.go:60 in func1) | Sync done for informer Service in 100.87932ms, last resource version: 60711
2021-12-02 15:05:51 UTC | CLUSTER | DEBUG | (pkg/util/kubernetes/apiserver/util.go:60 in func1) | Sync done for informer StatefulSet in 100.394564ms, last resource version: 60711
2021-12-02 15:05:51 UTC | CLUSTER | DEBUG | (pkg/util/kubernetes/apiserver/util.go:60 in func1) | Sync done for informer ClusterRoleBinding in 100.160187ms, last resource version: 60711
2021-12-02 15:05:51 UTC | CLUSTER | DEBUG | (pkg/util/kubernetes/apiserver/util.go:60 in func1) | Sync done for informer ReplicaSet in 100.564022ms, last resource version: 60711
2021-12-02 15:05:51 UTC | CLUSTER | DEBUG | (pkg/util/kubernetes/apiserver/util.go:60 in func1) | Sync done for informer CronJob in 101.657379ms, last resource versi

```

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
