### PR TITLE
[CWS] do not use stress test diff. returns top N for CPU/Mem

### DIFF
--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -66,15 +66,6 @@ tests_ebpf_x64:
     - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --build-flags "-race"
     # Compile runtime security stress tests to be executed in kitchen tests
     - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
-    # Compile main version for comparison, uncomment following lines when merged
-    # - git checkout -f main
-    # - git pull
-    # - inv -e deps
-    # - inv -e system-probe.build --bundle-ebpf --incremental-build
-    # - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite-master
-    # - git reset --hard
-    # - git checkout -
-
 
 tests_ebpf_arm64:
   extends: .tests_linux_ebpf

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -327,19 +327,7 @@ func newCredentialsSerializer(ce *model.Credentials) *CredentialsSerializer {
 }
 
 func scrubArgs(pr *model.Process, e *Event) ([]string, bool) {
-	argv, truncated := e.resolvers.ProcessResolver.GetProcessArgv(pr)
-
-	// scrub args, do not send args if no scrubber instance is passed
-	// can be the case for some custom event
-	if e.scrubber == nil {
-		argv = []string{}
-	} else {
-		if newArgv, changed := e.scrubber.ScrubCommand(argv); changed {
-			argv = newArgv
-		}
-	}
-
-	return argv, truncated
+	return e.resolvers.ProcessResolver.GetScrubbedProcessArgv(pr)
 }
 
 func scrubEnvs(pr *model.Process, e *Event) ([]string, bool) {

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -267,10 +267,14 @@ type Process struct {
 	ArgsID uint32 `field:"-"`
 	EnvsID uint32 `field:"-"`
 
-	ArgsEntry     *ArgsEntry `field:"-"`
-	EnvsEntry     *EnvsEntry `field:"-"`
-	EnvsTruncated bool       `field:"-"`
-	ArgsTruncated bool       `field:"-"`
+	ArgsEntry *ArgsEntry `field:"-"`
+	EnvsEntry *EnvsEntry `field:"-"`
+
+	EnvsTruncated bool `field:"-"`
+	ArgsTruncated bool `field:"-"`
+
+	EnvsCache []string `field:"-"` // used as cache
+	ArgsCache []string `field:"-"` // used as cache
 }
 
 // SpanContext describes a span context

--- a/pkg/security/tests/dentry_test.go
+++ b/pkg/security/tests/dentry_test.go
@@ -1,0 +1,297 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build functionaltests
+
+package tests
+
+import (
+	"os"
+	"path"
+	"syscall"
+	"testing"
+
+	probe "github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+)
+
+func BenchmarkERPCDentryResolutionSegment(b *testing.B) {
+	rule := &rules.RuleDefinition{
+		ID:         "test_rule",
+		Expression: `open.file.path == "{{.Root}}/aa/bb/cc/dd/ee" && open.flags & O_CREAT != 0`,
+	}
+
+	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule}, testOpts{disableMapDentryResolution: true})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer test.Close()
+
+	testFile, _, err := test.Path("aa/bb/cc/dd/ee")
+	if err != nil {
+		b.Fatal(err)
+	}
+	_ = os.MkdirAll(path.Dir(testFile), 0755)
+
+	defer os.Remove(testFile)
+
+	var (
+		mountID uint32
+		inode   uint64
+		pathID  uint32
+	)
+	err = test.GetSignal(b, func() error {
+		fd, err := syscall.Open(testFile, syscall.O_CREAT, 0755)
+		if err != nil {
+			return err
+		}
+		return syscall.Close(fd)
+	}, func(event *probe.Event, _ *rules.Rule) {
+		mountID = event.Open.File.MountID
+		inode = event.Open.File.Inode
+		pathID = event.Open.File.PathID
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// create a new dentry resolver to avoid concurrent map access errors
+	resolver, err := probe.NewDentryResolver(test.probe)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	if err := resolver.Start(test.probe); err != nil {
+		b.Fatal(err)
+	}
+	name, err := resolver.GetNameFromERPC(mountID, inode, pathID)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Log(name)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		name, err = resolver.GetNameFromERPC(mountID, inode, pathID)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(name) == 0 || len(name) > 0 && name[0] == 0 {
+			b.Log("couldn't resolve segment")
+		}
+	}
+
+	test.Close()
+}
+
+func BenchmarkERPCDentryResolutionPath(b *testing.B) {
+	rule := &rules.RuleDefinition{
+		ID:         "test_rule",
+		Expression: `open.file.path == "{{.Root}}/aa/bb/cc/dd/ee" && open.flags & O_CREAT != 0`,
+	}
+
+	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule}, testOpts{disableMapDentryResolution: true})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer test.Close()
+
+	testFile, _, err := test.Path("aa/bb/cc/dd/ee")
+	if err != nil {
+		b.Fatal(err)
+	}
+	_ = os.MkdirAll(path.Dir(testFile), 0755)
+
+	defer os.Remove(testFile)
+
+	var (
+		mountID uint32
+		inode   uint64
+		pathID  uint32
+	)
+	err = test.GetSignal(b, func() error {
+		fd, err := syscall.Open(testFile, syscall.O_CREAT, 0755)
+		if err != nil {
+			return err
+		}
+		return syscall.Close(fd)
+	}, func(event *probe.Event, _ *rules.Rule) {
+		mountID = event.Open.File.MountID
+		inode = event.Open.File.Inode
+		pathID = event.Open.File.PathID
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// create a new dentry resolver to avoid concurrent map access errors
+	resolver, err := probe.NewDentryResolver(test.probe)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	if err := resolver.Start(test.probe); err != nil {
+		b.Fatal(err)
+	}
+	f, err := resolver.ResolveFromERPC(mountID, inode, pathID, true)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Log(f)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		f, err := resolver.ResolveFromERPC(mountID, inode, pathID, true)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(f) == 0 || len(f) > 0 && f[0] == 0 {
+			b.Log("couldn't resolve path")
+		}
+	}
+
+	test.Close()
+}
+
+func BenchmarkMapDentryResolutionSegment(b *testing.B) {
+	rule := &rules.RuleDefinition{
+		ID:         "test_rule",
+		Expression: `open.file.path == "{{.Root}}/aa/bb/cc/dd/ee" && open.flags & O_CREAT != 0`,
+	}
+
+	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule}, testOpts{disableERPCDentryResolution: true})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer test.Close()
+
+	testFile, _, err := test.Path("aa/bb/cc/dd/ee")
+	if err != nil {
+		b.Fatal(err)
+	}
+	_ = os.MkdirAll(path.Dir(testFile), 0755)
+
+	defer os.Remove(testFile)
+
+	var (
+		mountID uint32
+		inode   uint64
+		pathID  uint32
+	)
+	err = test.GetSignal(b, func() error {
+		fd, err := syscall.Open(testFile, syscall.O_CREAT, 0755)
+		if err != nil {
+			return err
+		}
+		if err = syscall.Close(fd); err != nil {
+			return err
+		}
+		return nil
+	}, func(event *probe.Event, _ *rules.Rule) {
+		mountID = event.Open.File.MountID
+		inode = event.Open.File.Inode
+		pathID = event.Open.File.PathID
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// create a new dentry resolver to avoid concurrent map access errors
+	resolver, err := probe.NewDentryResolver(test.probe)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	if err := resolver.Start(test.probe); err != nil {
+		b.Fatal(err)
+	}
+	name, err := resolver.GetNameFromMap(mountID, inode, pathID)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Log(name)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		name, err = resolver.GetNameFromMap(mountID, inode, pathID)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if len(name) == 0 || len(name) > 0 && name[0] == 0 {
+			b.Fatal("couldn't resolve segment")
+		}
+	}
+
+	test.Close()
+}
+
+func BenchmarkMapDentryResolutionPath(b *testing.B) {
+	rule := &rules.RuleDefinition{
+		ID:         "test_rule",
+		Expression: `open.file.path == "{{.Root}}/aa/bb/cc/dd/ee" && open.flags & O_CREAT != 0`,
+	}
+
+	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule}, testOpts{disableERPCDentryResolution: true})
+	if err != nil {
+		b.Fatal(err)
+	}
+	defer test.Close()
+
+	testFile, _, err := test.Path("aa/bb/cc/dd/ee")
+	if err != nil {
+		b.Fatal(err)
+	}
+	_ = os.MkdirAll(path.Dir(testFile), 0755)
+
+	defer os.Remove(testFile)
+
+	var (
+		mountID uint32
+		inode   uint64
+		pathID  uint32
+	)
+	err = test.GetSignal(b, func() error {
+		fd, err := syscall.Open(testFile, syscall.O_CREAT, 0755)
+		if err != nil {
+			return err
+		}
+		return syscall.Close(fd)
+	}, func(event *probe.Event, _ *rules.Rule) {
+		mountID = event.Open.File.MountID
+		inode = event.Open.File.Inode
+		pathID = event.Open.File.PathID
+	})
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	// create a new dentry resolver to avoid concurrent map access errors
+	resolver, err := probe.NewDentryResolver(test.probe)
+	if err != nil {
+		b.Fatal(err)
+	}
+
+	if err := resolver.Start(test.probe); err != nil {
+		b.Fatal(err)
+	}
+	f, err := resolver.ResolveFromMap(mountID, inode, pathID, true)
+	if err != nil {
+		b.Fatal(err)
+	}
+	b.Log(f)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		f, err := resolver.ResolveFromMap(mountID, inode, pathID, true)
+		if err != nil {
+			b.Fatal(err)
+		}
+		if f[0] == 0 {
+			b.Fatal("couldn't resolve file")
+		}
+	}
+
+	test.Close()
+}

--- a/pkg/security/tests/stress_test.go
+++ b/pkg/security/tests/stress_test.go
@@ -13,11 +13,9 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"syscall"
 	"testing"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/security/probe"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
@@ -104,7 +102,7 @@ func stressOpen(t *testing.T, rule *rules.RuleDefinition, pathname string, size 
 	report.AddMetric("events", float64(events), "events")
 	report.AddMetric("events/sec", float64(events)/report.Duration.Seconds(), "event/s")
 
-	report.Print()
+	report.Print(t)
 
 	if report.Delta() < -2.0 {
 		t.Error("unexpected performance degradation")
@@ -241,17 +239,7 @@ func stressExec(t *testing.T, rule *rules.RuleDefinition, pathname string, execu
 	report.AddMetric("events", float64(events), "events")
 	report.AddMetric("events/sec", float64(events)/report.Duration.Seconds(), "event/s")
 
-	report.Print()
-
-	if report.Delta() < -2.0 {
-		t.Error("unexpected performance degradation")
-
-		cmdOutput, _ := exec.Command("pstree").Output()
-		fmt.Println(string(cmdOutput))
-
-		cmdOutput, _ = exec.Command("ps", "aux").Output()
-		fmt.Println(string(cmdOutput))
-	}
+	report.Print(t)
 }
 
 // goal: measure host abality to handle open syscall without any kprobe, act as a reference
@@ -274,285 +262,6 @@ func TestStress_E2EExecEvent(t *testing.T) {
 	}
 
 	stressExec(t, rule, "folder1/folder2/test-ancestors", executable)
-}
-
-func BenchmarkERPCDentryResolutionSegment(b *testing.B) {
-	rule := &rules.RuleDefinition{
-		ID:         "test_rule",
-		Expression: `open.file.path == "{{.Root}}/aa/bb/cc/dd/ee" && open.flags & O_CREAT != 0`,
-	}
-
-	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule}, testOpts{disableMapDentryResolution: true})
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer test.Close()
-
-	testFile, _, err := test.Path("aa/bb/cc/dd/ee")
-	if err != nil {
-		b.Fatal(err)
-	}
-	_ = os.MkdirAll(path.Dir(testFile), 0755)
-
-	defer os.Remove(testFile)
-
-	var (
-		mountID uint32
-		inode   uint64
-		pathID  uint32
-	)
-	err = test.GetSignal(b, func() error {
-		fd, err := syscall.Open(testFile, syscall.O_CREAT, 0755)
-		if err != nil {
-			return err
-		}
-		return syscall.Close(fd)
-	}, func(event *sprobe.Event, _ *rules.Rule) {
-		mountID = event.Open.File.MountID
-		inode = event.Open.File.Inode
-		pathID = event.Open.File.PathID
-	})
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	// create a new dentry resolver to avoid concurrent map access errors
-	resolver, err := probe.NewDentryResolver(test.probe)
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	if err := resolver.Start(test.probe); err != nil {
-		b.Fatal(err)
-	}
-	name, err := resolver.GetNameFromERPC(mountID, inode, pathID)
-	if err != nil {
-		b.Fatal(err)
-	}
-	b.Log(name)
-
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		name, err = resolver.GetNameFromERPC(mountID, inode, pathID)
-		if err != nil {
-			b.Fatal(err)
-		}
-		if len(name) == 0 || len(name) > 0 && name[0] == 0 {
-			b.Log("couldn't resolve segment")
-		}
-	}
-
-	test.Close()
-}
-
-func BenchmarkERPCDentryResolutionPath(b *testing.B) {
-	rule := &rules.RuleDefinition{
-		ID:         "test_rule",
-		Expression: `open.file.path == "{{.Root}}/aa/bb/cc/dd/ee" && open.flags & O_CREAT != 0`,
-	}
-
-	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule}, testOpts{disableMapDentryResolution: true})
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer test.Close()
-
-	testFile, _, err := test.Path("aa/bb/cc/dd/ee")
-	if err != nil {
-		b.Fatal(err)
-	}
-	_ = os.MkdirAll(path.Dir(testFile), 0755)
-
-	defer os.Remove(testFile)
-
-	var (
-		mountID uint32
-		inode   uint64
-		pathID  uint32
-	)
-	err = test.GetSignal(b, func() error {
-		fd, err := syscall.Open(testFile, syscall.O_CREAT, 0755)
-		if err != nil {
-			return err
-		}
-		return syscall.Close(fd)
-	}, func(event *sprobe.Event, _ *rules.Rule) {
-		mountID = event.Open.File.MountID
-		inode = event.Open.File.Inode
-		pathID = event.Open.File.PathID
-	})
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	// create a new dentry resolver to avoid concurrent map access errors
-	resolver, err := probe.NewDentryResolver(test.probe)
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	if err := resolver.Start(test.probe); err != nil {
-		b.Fatal(err)
-	}
-	f, err := resolver.ResolveFromERPC(mountID, inode, pathID, true)
-	if err != nil {
-		b.Fatal(err)
-	}
-	b.Log(f)
-
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		f, err := resolver.ResolveFromERPC(mountID, inode, pathID, true)
-		if err != nil {
-			b.Fatal(err)
-		}
-		if len(f) == 0 || len(f) > 0 && f[0] == 0 {
-			b.Log("couldn't resolve path")
-		}
-	}
-
-	test.Close()
-}
-
-func BenchmarkMapDentryResolutionSegment(b *testing.B) {
-	rule := &rules.RuleDefinition{
-		ID:         "test_rule",
-		Expression: `open.file.path == "{{.Root}}/aa/bb/cc/dd/ee" && open.flags & O_CREAT != 0`,
-	}
-
-	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule}, testOpts{disableERPCDentryResolution: true})
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer test.Close()
-
-	testFile, _, err := test.Path("aa/bb/cc/dd/ee")
-	if err != nil {
-		b.Fatal(err)
-	}
-	_ = os.MkdirAll(path.Dir(testFile), 0755)
-
-	defer os.Remove(testFile)
-
-	var (
-		mountID uint32
-		inode   uint64
-		pathID  uint32
-	)
-	err = test.GetSignal(b, func() error {
-		fd, err := syscall.Open(testFile, syscall.O_CREAT, 0755)
-		if err != nil {
-			return err
-		}
-		if err = syscall.Close(fd); err != nil {
-			return err
-		}
-		return nil
-	}, func(event *sprobe.Event, _ *rules.Rule) {
-		mountID = event.Open.File.MountID
-		inode = event.Open.File.Inode
-		pathID = event.Open.File.PathID
-	})
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	// create a new dentry resolver to avoid concurrent map access errors
-	resolver, err := probe.NewDentryResolver(test.probe)
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	if err := resolver.Start(test.probe); err != nil {
-		b.Fatal(err)
-	}
-	name, err := resolver.GetNameFromMap(mountID, inode, pathID)
-	if err != nil {
-		b.Fatal(err)
-	}
-	b.Log(name)
-
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		name, err = resolver.GetNameFromMap(mountID, inode, pathID)
-		if err != nil {
-			b.Fatal(err)
-		}
-		if len(name) == 0 || len(name) > 0 && name[0] == 0 {
-			b.Fatal("couldn't resolve segment")
-		}
-	}
-
-	test.Close()
-}
-
-func BenchmarkMapDentryResolutionPath(b *testing.B) {
-	rule := &rules.RuleDefinition{
-		ID:         "test_rule",
-		Expression: `open.file.path == "{{.Root}}/aa/bb/cc/dd/ee" && open.flags & O_CREAT != 0`,
-	}
-
-	test, err := newTestModule(b, nil, []*rules.RuleDefinition{rule}, testOpts{disableERPCDentryResolution: true})
-	if err != nil {
-		b.Fatal(err)
-	}
-	defer test.Close()
-
-	testFile, _, err := test.Path("aa/bb/cc/dd/ee")
-	if err != nil {
-		b.Fatal(err)
-	}
-	_ = os.MkdirAll(path.Dir(testFile), 0755)
-
-	defer os.Remove(testFile)
-
-	var (
-		mountID uint32
-		inode   uint64
-		pathID  uint32
-	)
-	err = test.GetSignal(b, func() error {
-		fd, err := syscall.Open(testFile, syscall.O_CREAT, 0755)
-		if err != nil {
-			return err
-		}
-		return syscall.Close(fd)
-	}, func(event *sprobe.Event, _ *rules.Rule) {
-		mountID = event.Open.File.MountID
-		inode = event.Open.File.Inode
-		pathID = event.Open.File.PathID
-	})
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	// create a new dentry resolver to avoid concurrent map access errors
-	resolver, err := probe.NewDentryResolver(test.probe)
-	if err != nil {
-		b.Fatal(err)
-	}
-
-	if err := resolver.Start(test.probe); err != nil {
-		b.Fatal(err)
-	}
-	f, err := resolver.ResolveFromMap(mountID, inode, pathID, true)
-	if err != nil {
-		b.Fatal(err)
-	}
-	b.Log(f)
-
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		f, err := resolver.ResolveFromMap(mountID, inode, pathID, true)
-		if err != nil {
-			b.Fatal(err)
-		}
-		if f[0] == 0 {
-			b.Fatal("couldn't resolve file")
-		}
-	}
-
-	test.Close()
 }
 
 func init() {

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -306,6 +306,7 @@ def stress_tests(
     output='pkg/security/tests/stresssuite',
     bundle_ebpf=True,
     testflags='',
+    skip_linters=False,
 ):
     build_stress_tests(
         ctx,
@@ -314,6 +315,7 @@ def stress_tests(
         major_version=major_version,
         output=output,
         bundle_ebpf=bundle_ebpf,
+        skip_linters=skip_linters,
     )
 
     run_functional_tests(

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/stress-tests.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/stress-tests.rb
@@ -17,11 +17,6 @@ if node['platform_family'] != 'windows'
     mode '755'
   end
 
-  cookbook_file "#{wrk_dir}/stresssuite-master" do
-    source "stresssuite-master"
-    mode '755'
-  end
-
   ['polkit', 'unattended-upgrades', 'snapd', 'cron', 'walinuxagent',
    'multipathd', 'rsyslog', 'atd', 'chronyd', 'hv-kvp-daemon'].each do |s|
     service s do

--- a/test/kitchen/test/integration/security-agent-stress/rspec/security-agent-stress_spec.rb
+++ b/test/kitchen/test/integration/security-agent-stress/rspec/security-agent-stress_spec.rb
@@ -3,13 +3,7 @@ print `uname -a`
 
 describe 'successfully run stress test against master' do
   it 'displays PASS and returns 0' do
-    output = `sudo /tmp/security-agent/stresssuite-master -test.v --report-file /tmp/report.json -duration 120 1>&2`
-    retval = $?
-    expect(retval).to eq(0)
-  end
-
-  it 'displays PASS and returns 0' do
-    output = `sudo /tmp/security-agent/stresssuite -test.v --diff-base /tmp/report.json -duration 120 1>&2`
+    output = `sudo /tmp/security-agent/stresssuite -test.v -duration 120 1>&2`
     retval = $?
     expect(retval).to eq(0)
   end


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Remove the diff feature of stress test as unreliable due to host unpredictable workload. Use top N usage for CPU/Mem instead

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
