### PR TITLE
[workloadmeta/store] Delete redundant assignment

### DIFF
--- a/pkg/workloadmeta/store.go
+++ b/pkg/workloadmeta/store.go
@@ -397,7 +397,6 @@ func (s *store) handleEvents(evs []CollectorEvent) {
 
 		switch ev.Type {
 		case EventTypeSet:
-			entityOfSource, ok := entitiesOfKind[meta.ID]
 			if !ok {
 				entitiesOfKind[meta.ID] = make(sourceToEntity)
 				entityOfSource = entitiesOfKind[meta.ID]


### PR DESCRIPTION
### What does this PR do?

Deletes a redundant assignment in the workloadmeta store.

### Describe how to test/QA your changes

Skip.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
