### PR TITLE
Add container_mode_docker_origin option for journald logs to set source/service like docker logs

### DIFF
--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -40,9 +40,10 @@ type LogsConfig struct {
 	ExcludePaths []string `mapstructure:"exclude_paths" json:"exclude_paths"`   // File
 	TailingMode  string   `mapstructure:"start_position" json:"start_position"` // File
 
-	IncludeUnits  []string `mapstructure:"include_units" json:"include_units"`   // Journald
-	ExcludeUnits  []string `mapstructure:"exclude_units" json:"exclude_units"`   // Journald
-	ContainerMode bool     `mapstructure:"container_mode" json:"container_mode"` // Journald
+	IncludeUnits              []string `mapstructure:"include_units" json:"include_units"`              // Journald
+	ExcludeUnits              []string `mapstructure:"exclude_units" json:"exclude_units"`              // Journald
+	ContainerMode             bool     `mapstructure:"container_mode" json:"container_mode"`            // Journald
+	ContainerModeDockerOrigin bool     `mapstructure:"docker_mode" json:"container_mode_docker_origin"` // Journald
 
 	Image string // Docker
 	Label string // Docker


### PR DESCRIPTION
### What does this PR do?

This change adds a "container_mode_docker_origin" option which makes the journald collection act like the direct docker log collector by setting the source to "docker" and not explicitly setting a service, which allows it to be set via tags.

### Motivation

The existing container_mode option causes journald logs to have an origin source and service set to the Docker image short name. However, this takes precedence over service tags derived from the container env vars and/or labels, which makes it impossible to override the service though the usual mechanisms.

https://github.com/DataDog/datadog-agent/issues/9985

### Additional Notes

Although the name might be a little confusing, removing or changing the
existing container_mode option could be considered a breaking change.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1. Set up the agent as described in https://docs.datadoghq.com/integrations/journald/?tab=host#configuration, but specify `docker_mode: true` instead of `container_mode: true`.
2. Set up docker to send logs to journald: https://docs.docker.com/config/containers/logging/journald/
3. Run a docker container using tags or labels to specify a service, for example: `docker run -it --rm -e DD_SERVICE=foo alpine echo hello`
4. Verify in the Datadog log UI that the logs have the correct service tag. For the previous example, the "hello" log should have service `foo` (_not_ `alpine`).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
