### PR TITLE
[networks] Fix support for NAT with keep-alives

### DIFF
--- a/pkg/network/http/http_statkeeper.go
+++ b/pkg/network/http/http_statkeeper.go
@@ -16,7 +16,7 @@ import (
 
 type httpStatKeeper struct {
 	stats      map[Key]RequestStats
-	incomplete map[Key]httpTX
+	incomplete *incompleteBuffer
 	maxEntries int
 	telemetry  *telemetry
 
@@ -34,7 +34,7 @@ type httpStatKeeper struct {
 func newHTTPStatkeeper(c *config.Config, telemetry *telemetry) *httpStatKeeper {
 	return &httpStatKeeper{
 		stats:        make(map[Key]RequestStats),
-		incomplete:   make(map[Key]httpTX),
+		incomplete:   newIncompleteBuffer(c, telemetry),
 		maxEntries:   c.MaxHTTPStatsBuffered,
 		replaceRules: c.HTTPReplaceRules,
 		buffer:       make([]byte, HTTPBufferSize),
@@ -46,20 +46,22 @@ func newHTTPStatkeeper(c *config.Config, telemetry *telemetry) *httpStatKeeper {
 func (h *httpStatKeeper) Process(transactions []httpTX) {
 	for _, tx := range transactions {
 		if tx.Incomplete() {
-			h.handleIncomplete(tx)
+			h.incomplete.Add(tx)
 			continue
 		}
 
 		h.add(tx)
 	}
-
-	atomic.StoreInt64(&h.telemetry.aggregations, int64(len(h.stats)))
 }
 
 func (h *httpStatKeeper) GetAndResetAllStats() map[Key]RequestStats {
+	for _, tx := range h.incomplete.Flush() {
+		h.add(*tx)
+	}
+
+	atomic.StoreInt64(&h.telemetry.aggregations, int64(len(h.stats)))
 	ret := h.stats // No deep copy needed since `h.stats` gets reset
 	h.stats = make(map[Key]RequestStats)
-	h.incomplete = make(map[Key]httpTX)
 	h.interned = make(map[string]string)
 	return ret
 }
@@ -80,50 +82,6 @@ func (h *httpStatKeeper) add(tx httpTX) {
 
 	stats.AddRequest(tx.StatusClass(), tx.RequestLatency(), tx.Tags())
 	h.stats[key] = stats
-}
-
-// handleIncomplete is responsible for handling incomplete transactions
-// (eg. httpTX objects that have either only the request or response information)
-// this happens only in the context of localhost traffic with NAT and these disjoint
-// parts of the transactions are joined here by src port
-func (h *httpStatKeeper) handleIncomplete(tx httpTX) {
-	key := Key{
-		SrcIPHigh: uint64(tx.tup.saddr_h),
-		SrcIPLow:  uint64(tx.tup.saddr_l),
-		SrcPort:   uint16(tx.tup.sport),
-	}
-
-	otherHalf, ok := h.incomplete[key]
-	if !ok {
-		if len(h.incomplete) >= h.maxEntries {
-			atomic.AddInt64(&h.telemetry.dropped, 1)
-		} else {
-			h.incomplete[key] = tx
-		}
-
-		return
-	}
-
-	request, response := tx, otherHalf
-	if response.StatusClass() == 0 {
-		request, response = response, request
-	}
-
-	if request.request_started == 0 || response.response_status_code == 0 || request.request_started > response.response_last_seen {
-		// This means we can't join these parts as they don't belong to the same transaction.
-		// In this case, as a best-effort we override the incomplete entry with the latest one
-		// we got from eBPF, so it can be joined by it's other half at a later moment.
-		// This can happen because we can get out-of-order half transactions from eBPF
-		atomic.AddInt64(&h.telemetry.dropped, 1)
-		h.incomplete[key] = tx
-		return
-	}
-
-	// Merge response into request
-	request.response_status_code = response.response_status_code
-	request.response_last_seen = response.response_last_seen
-	h.add(request)
-	delete(h.incomplete, key)
 }
 
 func (h *httpStatKeeper) newKey(tx httpTX, path string) Key {

--- a/pkg/network/http/http_statkeeper.go
+++ b/pkg/network/http/http_statkeeper.go
@@ -10,6 +10,7 @@ package http
 
 import (
 	"sync/atomic"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 )
@@ -55,7 +56,7 @@ func (h *httpStatKeeper) Process(transactions []httpTX) {
 }
 
 func (h *httpStatKeeper) GetAndResetAllStats() map[Key]RequestStats {
-	for _, tx := range h.incomplete.Flush() {
+	for _, tx := range h.incomplete.Flush(time.Now()) {
 		h.add(*tx)
 	}
 

--- a/pkg/network/http/incomplete_stats.go
+++ b/pkg/network/http/incomplete_stats.go
@@ -121,7 +121,7 @@ func (b *incompleteBuffer) Flush(now time.Time) []*httpTX {
 			j++
 		}
 
-		// now that we have finishing matching requests and responses
+		// now that we have finished matching requests and responses
 		// we check if we should keep orphan requests a little bit longer
 		for i < len(parts.requests) {
 			if b.shouldKeep(&parts.requests[i], nowUnix) {

--- a/pkg/network/http/incomplete_stats.go
+++ b/pkg/network/http/incomplete_stats.go
@@ -139,11 +139,7 @@ func (b *incompleteBuffer) Flush(now time.Time) []*httpTX {
 }
 
 func (b *incompleteBuffer) shouldKeep(tx *httpTX, now int64) bool {
-	then := int64(tx.response_last_seen)
-	if tx.request_started > 0 {
-		then = int64(tx.request_started)
-	}
-
+	then := int64(tx.request_started)
 	return (now - then) < b.minAgeNano
 }
 

--- a/pkg/network/http/incomplete_stats.go
+++ b/pkg/network/http/incomplete_stats.go
@@ -1,0 +1,123 @@
+// +build linux_bpf
+
+package http
+
+import (
+	"sort"
+	"sync/atomic"
+
+	"github.com/DataDog/datadog-agent/pkg/network/config"
+)
+
+// incompleteBuffer is responsible for buffering incomplete transactions
+// (eg. httpTX objects that have either only the request or response information)
+// this happens only in the context of localhost traffic with NAT.
+// Imagine, for example, that you have two containers in the same host:
+// * Container A: 1.1.1.1
+// * Container B: 3.3.3.3
+// And a NAT rule: 2.2.2.2 -> 3.3.3.3
+// Now let's say Container A issues a HTTP request to 2.2.2.2;
+// The eBPF socket filter program will see two "disjoint" TCP segments:
+// (1.1.1.1:ephemeral-port -> 2.2.2.2:server-port) GET / HTTP/1.1
+// (3.3.3.3 -> 1.1.1.1:ephemeral-port) HTTP/1.1 200 OK
+// Because of that, we join these two parts of the transaction here in userspace using the
+// client address (1.1.1.1:ephemeral-port)
+// There is, however, another variable that can further complicate this: keep-alives
+// You could have, for example, one TCP socket issuing multiple requests:
+// t0: (1.1.1.1:ephemeral-port -> 2.2.2.2:server-port) GET / HTTP/1.1
+// t1: (3.3.3.3 -> 1.1.1.1:ephemeral-port) HTTP/1.1 200 OK
+// t2: (1.1.1.1:ephemeral-port -> 2.2.2.2:server-port) GET / HTTP/1.1
+// t3: (3.3.3.3 -> 1.1.1.1:ephemeral-port) HTTP/1.1 200 OK
+// The problem is, due to the way our eBPF batching works, there is no guarantee that these
+// incomplete events will be read in the order they happened, so if we had a greedy approach
+// that joined events as soon as they're sent from eBPF, we could potentially join
+// request segment at "t0" with response segment "t3". This is why we buffer data here for 30 seconds
+// and then sort all events by their timestamps before joining them.
+type incompleteBuffer struct {
+	data       map[Key]*txParts
+	maxEntries int
+	telemetry  *telemetry
+}
+
+type txParts struct {
+	requests  []httpTX
+	responses []httpTX
+}
+
+func newIncompleteBuffer(c *config.Config, telemetry *telemetry) *incompleteBuffer {
+	return &incompleteBuffer{
+		data:       make(map[Key]*txParts),
+		maxEntries: c.MaxHTTPStatsBuffered,
+		telemetry:  telemetry,
+	}
+}
+
+func (b *incompleteBuffer) Add(tx httpTX) {
+	key := Key{
+		SrcIPHigh: uint64(tx.tup.saddr_h),
+		SrcIPLow:  uint64(tx.tup.saddr_l),
+		SrcPort:   uint16(tx.tup.sport),
+	}
+
+	parts, ok := b.data[key]
+	if !ok {
+		if len(b.data) >= b.maxEntries {
+			atomic.AddInt64(&b.telemetry.dropped, 1)
+			return
+		}
+
+		parts = &txParts{
+			requests:  make([]httpTX, 0, 5),
+			responses: make([]httpTX, 0, 5),
+		}
+
+		b.data[key] = parts
+	}
+
+	if tx.StatusClass() == 0 {
+		parts.requests = append(parts.requests, tx)
+	} else {
+		parts.responses = append(parts.responses, tx)
+	}
+}
+
+func (b *incompleteBuffer) Flush() []*httpTX {
+	var joined []*httpTX
+
+	for _, parts := range b.data {
+		// TODO: in this loop we're sorting all transactions at once, but we could also
+		// consider sorting data during insertion time (using a tree-like structure, for example)
+		sort.Sort(byRequestTime(parts.requests))
+		sort.Sort(byResponseTime(parts.responses))
+
+		for i := 0; i < len(parts.requests) && i < len(parts.responses); i++ {
+			request := &parts.requests[i]
+			response := &parts.responses[i]
+			if request.request_started > response.response_last_seen {
+				break
+			}
+
+			// Merge response into request
+			request.response_status_code = response.response_status_code
+			request.response_last_seen = response.response_last_seen
+			joined = append(joined, request)
+		}
+	}
+
+	b.data = make(map[Key]*txParts)
+	return joined
+}
+
+type byRequestTime []httpTX
+
+func (rt byRequestTime) Len() int           { return len(rt) }
+func (rt byRequestTime) Swap(i, j int)      { rt[i], rt[j] = rt[j], rt[i] }
+func (rt byRequestTime) Less(i, j int) bool { return rt[i].request_started < rt[j].request_started }
+
+type byResponseTime []httpTX
+
+func (rt byResponseTime) Len() int      { return len(rt) }
+func (rt byResponseTime) Swap(i, j int) { rt[i], rt[j] = rt[j], rt[i] }
+func (rt byResponseTime) Less(i, j int) bool {
+	return rt[i].response_last_seen < rt[j].response_last_seen
+}

--- a/pkg/network/http/incomplete_stats.go
+++ b/pkg/network/http/incomplete_stats.go
@@ -90,17 +90,22 @@ func (b *incompleteBuffer) Flush() []*httpTX {
 		sort.Sort(byRequestTime(parts.requests))
 		sort.Sort(byResponseTime(parts.responses))
 
-		for i := 0; i < len(parts.requests) && i < len(parts.responses); i++ {
+		i := 0
+		j := 0
+		for i < len(parts.requests) && j < len(parts.responses) {
 			request := &parts.requests[i]
-			response := &parts.responses[i]
+			response := &parts.responses[j]
 			if request.request_started > response.response_last_seen {
-				break
+				j++
+				continue
 			}
 
 			// Merge response into request
 			request.response_status_code = response.response_status_code
 			request.response_last_seen = response.response_last_seen
 			joined = append(joined, request)
+			i++
+			j++
 		}
 	}
 

--- a/pkg/network/http/incomplete_stats_test.go
+++ b/pkg/network/http/incomplete_stats_test.go
@@ -1,0 +1,59 @@
+// +build linux_bpf
+
+package http
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/network/config"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrphanEntries(t *testing.T) {
+	t.Run("orphan entries can be joined even after flushing", func(t *testing.T) {
+		now := time.Now()
+		buffer := newIncompleteBuffer(config.New(), newTelemetry())
+		request := httpTX{
+			request_fragment: requestFragment([]byte("GET /foo/bar")),
+			request_started:  _Ctype_ulonglong(now.UnixNano()),
+		}
+		request.tup.sport = 60000
+
+		buffer.Add(request)
+		now = now.Add(5 * time.Second)
+		complete := buffer.Flush(now)
+		assert.Len(t, complete, 0)
+
+		response := httpTX{
+			response_status_code: 200,
+			response_last_seen:   _Ctype_ulonglong(now.UnixNano()),
+		}
+		response.tup.sport = 60000
+		buffer.Add(response)
+		complete = buffer.Flush(now)
+		require.Len(t, complete, 1)
+
+		completeTX := complete[0]
+		assert.Equal(t, "/foo/bar", string(completeTX.Path(make([]byte, 256))))
+		assert.Equal(t, 200, completeTX.StatusClass())
+	})
+
+	t.Run("orphan entries are not kept indefinitely", func(t *testing.T) {
+		buffer := newIncompleteBuffer(config.New(), newTelemetry())
+		now := time.Now()
+		buffer.minAgeNano = (30 * time.Second).Nanoseconds()
+		request := httpTX{
+			request_fragment: requestFragment([]byte("GET /foo/bar")),
+			request_started:  _Ctype_ulonglong(now.UnixNano()),
+		}
+		buffer.Add(request)
+		_ = buffer.Flush(now)
+
+		assert.True(t, len(buffer.data) > 0)
+		now = now.Add(35 * time.Second)
+		_ = buffer.Flush(now)
+		assert.True(t, len(buffer.data) == 0)
+	})
+}

--- a/pkg/network/http/monitor.go
+++ b/pkg/network/http/monitor.go
@@ -138,10 +138,12 @@ func (m *Monitor) Start() error {
 				transactions := m.batchManager.GetPendingTransactions()
 				m.process(transactions, nil)
 
+				stats := m.statkeeper.GetAndResetAllStats()
+
 				delta := m.telemetry.reset()
 				delta.report()
 
-				reply <- m.statkeeper.GetAndResetAllStats()
+				reply <- stats
 			case <-report.C:
 				transactions := m.batchManager.GetPendingTransactions()
 				m.process(transactions, nil)

--- a/pkg/network/http/monitor_test.go
+++ b/pkg/network/http/monitor_test.go
@@ -31,7 +31,17 @@ func TestHTTPMonitorIntegration(t *testing.T) {
 
 	targetAddr := "localhost:8080"
 	serverAddr := "localhost:8080"
-	testHTTPMonitor(t, targetAddr, serverAddr, 100)
+
+	t.Run("with keep-alives", func(t *testing.T) {
+		testHTTPMonitor(t, targetAddr, serverAddr, 100, testutil.Options{
+			EnableKeepAlives: true,
+		})
+	})
+	t.Run("without keep-alives", func(t *testing.T) {
+		testHTTPMonitor(t, targetAddr, serverAddr, 100, testutil.Options{
+			EnableKeepAlives: false,
+		})
+	})
 }
 
 func TestHTTPMonitorIntegrationWithNAT(t *testing.T) {
@@ -47,7 +57,16 @@ func TestHTTPMonitorIntegrationWithNAT(t *testing.T) {
 
 	targetAddr := "2.2.2.2:8080"
 	serverAddr := "1.1.1.1:8080"
-	testHTTPMonitor(t, targetAddr, serverAddr, 10)
+	t.Run("with keep-alives", func(t *testing.T) {
+		testHTTPMonitor(t, targetAddr, serverAddr, 100, testutil.Options{
+			EnableKeepAlives: true,
+		})
+	})
+	t.Run("without keep-alives", func(t *testing.T) {
+		testHTTPMonitor(t, targetAddr, serverAddr, 100, testutil.Options{
+			EnableKeepAlives: false,
+		})
+	})
 }
 
 func TestUnknownMethodRegression(t *testing.T) {
@@ -90,12 +109,8 @@ func TestUnknownMethodRegression(t *testing.T) {
 	}
 }
 
-func testHTTPMonitor(t *testing.T, targetAddr, serverAddr string, numReqs int) {
-	srvDoneFn := testutil.HTTPServer(t, serverAddr, testutil.Options{
-		EnableTLS:        false,
-		EnableKeepAlives: false,
-	})
-	defer srvDoneFn()
+func testHTTPMonitor(t *testing.T, targetAddr, serverAddr string, numReqs int, o testutil.Options) {
+	srvDoneFn := testutil.HTTPServer(t, serverAddr, o)
 
 	monitor, err := NewMonitor(config.New(), nil, nil)
 	require.NoError(t, err)
@@ -109,6 +124,7 @@ func testHTTPMonitor(t *testing.T, targetAddr, serverAddr string, numReqs int) {
 	for i := 0; i < numReqs; i++ {
 		requests = append(requests, requestFn())
 	}
+	srvDoneFn()
 
 	// Ensure all captured transactions get sent to user-space
 	time.Sleep(10 * time.Millisecond)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR fixes HTTP monitoring in the context of localhost traffic + NAT + HTTP keep-alives, which goes unreported at the moment.
A real-world scenario that combines the three elements above would be two containers (http client and http server) colocated in the same host where http client maintains a connection pool and http server belongs to a k8s service with a clusterIP (and therefore uses NAT to translate the clusterIP to a pod IP).
While working on this change I had to change the approach we use to join the request/response TCP segments on userspace (see comments on `incomplete_stats.go`).

### Motivation

Extend HTTP monitoring to more network setups.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

Before this PR the _local NATed_ HTTP request would be joined using a "greedy approach", but now we buffering them for 30s before joining them which can result in a bursty CPU workload.
I'm going to deploy these changes to our load-test cluster and see if the overhead is acceptable.

### Describe how to test/QA your changes

Change already covered by unit and integration tests

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
