### PR TITLE
[Serverless] Block list hello and flush routes from traces

### DIFF
--- a/pkg/serverless/trace/trace_test.go
+++ b/pkg/serverless/trace/trace_test.go
@@ -72,3 +72,18 @@ func TestLoadConfigShouldBeFast(t *testing.T) {
 	defer agent.Stop()
 	assert.True(t, time.Since(startTime) < time.Second)
 }
+
+func TestBuildTraceBlocklist(t *testing.T) {
+	userProvidedBlocklist := []string{
+		"GET /toto",
+		"PATCH /tutu",
+	}
+	expected := []string{
+		"GET /toto",
+		"PATCH /tutu",
+		"GET /lambda/hello",
+		"POST /lambda/flush",
+	}
+	result := buildTraceBlocklist(userProvidedBlocklist)
+	assert.Equal(t, expected, result)
+}


### PR DESCRIPTION
### What does this PR do?

We used to block list those spans from the layers
exemple in nodejs : https://github.com/DataDog/datadog-lambda-js/blob/main/src/handler.ts#L24

As we support more and more runtimes, such as Java.
It might be better to do this as the extension level

### Motivation

Feature parity

### Describe how to test/QA your changes

Released a new extension RC + use java runtime and check that /hello and /flush routes are not here anymore

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
