### PR TITLE
[network/ebpf] Avoid TLS http2 packets

### DIFF
--- a/pkg/network/ebpf/c/http-types.h
+++ b/pkg/network/ebpf/c/http-types.h
@@ -94,6 +94,7 @@ typedef struct {
 typedef struct {
     conn_tuple_t tup;
     __u32 fd;
+    __u8 http20;
 } ssl_sock_t;
 
  #define LIB_PATH_MAX_SIZE 120

--- a/pkg/network/ebpf/c/http.h
+++ b/pkg/network/ebpf/c/http.h
@@ -7,6 +7,26 @@
 
 #include <uapi/linux/ptrace.h>
 
+// HTTP2.0 client->server connection preface 'PRI * HTTP/2.0\r\n\r\nSM\r\n\r\n'
+// https://httpwg.org/specs/rfc7540.html#ConnectionHeader
+#define HTTP20_PRI_LEN 24
+#if HTTP_BUFFER_SIZE < HTTP20_PRI_LEN
+#error "HTTP_BUFFER_SIZE can't less than HTTP20_PRI_LEN"
+#endif
+static __always_inline int is_http20(char *p) {
+    if ((p[0] == 'P') && (p[1] == 'R') && (p[2] == 'I') && (p[3] == ' ') && (p[4] == '*') && (p[5] == ' ')
+        && (p[6] == 'H') && (p[7] == 'T') && (p[8] == 'T') && (p[9] == 'P') && (p[10] == '/') && (p[11] == '2') && (p[12] == '.') && (p[13] == '0')
+        && (p[14] == '\r') && (p[15] == '\n')
+        && (p[16] == '\r') && (p[17] == '\n')
+        && (p[18] == 'S') && (p[19] == 'M')
+        && (p[20] == '\r') && (p[21] == '\n')
+        && (p[22] == '\r') && (p[23] == '\n')
+        ) {
+        return 1;
+    }
+    return 0;
+}
+
 static __always_inline void http_prepare_key(u32 cpu, http_batch_key_t *key, http_batch_state_t *batch_state) {
     __builtin_memset(key, 0, sizeof(http_batch_key_t));
     key->cpu = cpu;

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -124,7 +124,6 @@ static __always_inline ssl_sock_t * ssl_sock_from_ssl_ctx(void *ssl_ctx, u64 pid
 static __always_inline void init_ssl_sock(void *ssl_ctx, u32 socket_fd) {
     ssl_sock_t ssl_sock = { 0 };
     ssl_sock.fd = socket_fd;
-    ssl_sock.http20 = 0;
     bpf_map_update_elem(&ssl_sock_by_ctx, &ssl_ctx, &ssl_sock, BPF_ANY);
 }
 

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -124,7 +124,6 @@ static __always_inline ssl_sock_t * ssl_sock_from_ssl_ctx(void *ssl_ctx, u64 pid
 static __always_inline void init_ssl_sock(void *ssl_ctx, u32 socket_fd) {
     ssl_sock_t ssl_sock = { 0 };
     ssl_sock.fd = socket_fd;
-    ssl_sock.http20 = 0;
     bpf_map_update_elem(&ssl_sock_by_ctx, &ssl_ctx, &ssl_sock, BPF_ANY);
 }
 


### PR DESCRIPTION
### What does this PR do?

Avoiding processing HTTP/2.0 packets as we don't parse it.

### Motivation

Improve the ebpf performance by avoiding unclassified trafic.
previously we try to classify HTTP content from SSL_read/write buffer that contain HTTP2

### Describe how to test/QA your changes

`
system_probe_config:
  log_level: debug
  bpf_debug: true
`

Launch system-probe in ebpf debug
`
curl http://httpbin.org/anything/hello
`
You should find in the ebpf trace : `sudo cat  /sys/kernel/debug/tracing/trace_pipe

Messages like
```
"SSL_* HTTP/2.0"
"gnutls_record_* HTTP/2.0"
```

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
