### PR TITLE
[tools] Add copyright lint tooling for Golang files

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -54,6 +54,7 @@ from .test import (
     install_tools,
     integration_tests,
     junit_upload,
+    lint_copyrights,
     lint_filenames,
     lint_milestone,
     lint_python,
@@ -79,6 +80,7 @@ ns.add_task(lint_licenses)
 ns.add_task(generate_licenses)
 ns.add_task(generate_protobuf)
 ns.add_task(reset)
+ns.add_task(lint_copyrights),
 ns.add_task(lint_teamassignment)
 ns.add_task(lint_releasenote)
 ns.add_task(lint_milestone)

--- a/tasks/libs/copyright.py
+++ b/tasks/libs/copyright.py
@@ -79,7 +79,7 @@ class CopyrightLinter:
                 filtered_files.append(filepath)
 
         excluded_files_cnt = all_matching_files_cnt - len(filtered_files)
-        print(f"[WARN] Excluding {excluded_files_cnt} files based on path filters!")
+        print(f"[INFO] Excluding {excluded_files_cnt} files based on path filters!")
 
         return sorted(filtered_files)
 
@@ -108,21 +108,23 @@ class CopyrightLinter:
     def _has_copyright(filepath, debug=False):
         header = CopyrightLinter._get_header(filepath)
         if header is None:
-            print("Mismatch found! Could not find any content in file!")
+            print("[WARN] Mismatch found! Could not find any content in file!")
             return False
 
         if len(header) > 0 and CopyrightLinter._is_excluded_header(header, exclude=COMPILED_HEADER_EXCLUSION_REGEX):
             if debug:
-                print(f"[WARN] Excluding {filepath} based on header '{header[0]}'")
+                print(f"[INFO] Excluding {filepath} based on header '{header[0]}'")
             return True
 
         if len(header) <= 3:
-            print("Mismatch found! File too small for header stanza!")
+            print("[WARN] Mismatch found! File too small for header stanza!")
             return False
 
         for line_idx, matcher in enumerate(COMPILED_COPYRIGHT_REGEX):
             if not re.match(matcher, header[line_idx]):
-                print(f"Mismatch found! Expected '{COPYRIGHT_REGEX[line_idx]}' pattern but got '{header[line_idx]}'")
+                print(
+                    f"[WARN] Mismatch found! Expected '{COPYRIGHT_REGEX[line_idx]}' pattern but got '{header[line_idx]}'"
+                )
                 return False
 
         return True
@@ -160,15 +162,15 @@ class CopyrightLinter:
         git_repo_dir = CopyrightLinter._get_repo_dir()
 
         if debug:
-            print(f"Repo root: {git_repo_dir}")
-            print(f"Finding all files in {git_repo_dir} matching '{GLOB_PATTERN}'...")
+            print(f"[DEBG] Repo root: {git_repo_dir}")
+            print(f"[DEBG] Finding all files in {git_repo_dir} matching '{GLOB_PATTERN}'...")
 
         matching_files = CopyrightLinter._get_matching_files(
             git_repo_dir,
             GLOB_PATTERN,
             exclude=COMPILED_PATH_EXCLUSION_REGEX,
         )
-        print(f"Found {len(matching_files)} files matching '{GLOB_PATTERN}'")
+        print(f"[INFO] Found {len(matching_files)} files matching '{GLOB_PATTERN}'")
 
         failing_files = CopyrightLinter._assert_copyrights(matching_files, debug=debug)
         if len(failing_files) > 0:

--- a/tasks/libs/copyright.py
+++ b/tasks/libs/copyright.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path, PurePosixPath
+
+GLOB_PATTERN = "**/*.go"
+
+COPYRIGHT_REGEX = [
+    r'^// Unless explicitly stated otherwise all files in this repository are licensed$',
+    r'^// under the Apache License Version 2.0\.$',
+    r'^// This product includes software developed at Datadog \(https://www\.[Dd]atadoghq\.com/\)\.$',
+    r'^// Copyright 20[1-3][0-9]-([Pp]resent|20[1-3][0-9]) Datadog, (Inc|Inmetrics)\.$',
+]
+
+# These path patterns are excluded from checks
+PATH_EXCLUSION_REGEX = [
+    '/third_party/golang/',
+    '/third_party/kubernetes/',
+]
+
+# These header matchers skip enforcement of the rules if found in the first
+# line of the file
+HEADER_EXCLUSION_REGEX = [
+    '^// Code generated ',
+    '^//go:generate ',
+    '^// Copyright.* OpenTelemetry Authors',
+    '^// Copyright.* The Go Authors',
+]
+
+
+COMPILED_COPYRIGHT_REGEX = [re.compile(regex, re.UNICODE) for regex in COPYRIGHT_REGEX]
+COMPILED_PATH_EXCLUSION_REGEX = [re.compile(regex, re.UNICODE) for regex in PATH_EXCLUSION_REGEX]
+COMPILED_HEADER_EXCLUSION_REGEX = [re.compile(regex, re.UNICODE) for regex in HEADER_EXCLUSION_REGEX]
+
+
+class CopyrightLinter:
+    """
+    This class is used to enforce copyright headers on specified file patterns
+    """
+
+    @staticmethod
+    def _get_repo_dir():
+        script_dir = PurePosixPath(__file__).parent
+        current_dir = Path.cwd()
+
+        os.chdir(script_dir)
+        repo_dir = subprocess.check_output(['git', 'rev-parse', '--show-toplevel']).decode(sys.stdout.encoding).strip()
+        os.chdir(current_dir)
+
+        return PurePosixPath(repo_dir)
+
+    @staticmethod
+    def _get_matching_files(root_dir, glob_pattern, exclude=None):
+        if exclude is None:
+            exclude = []
+
+        all_matching_files = Path(root_dir).glob(glob_pattern)
+
+        # `all_matching_files` is a generator so we have to do the counting ourselves
+        all_matching_files_cnt = 0
+
+        filtered_files = []
+        for filepath in all_matching_files:
+            all_matching_files_cnt += 1
+
+            excluded = False
+            for matcher in exclude:
+                if re.search(matcher, filepath.as_posix()):
+                    excluded = True
+                    break
+
+            if excluded:
+                continue
+
+            filtered_files.append(filepath)
+
+        excluded_files_cnt = all_matching_files_cnt - len(filtered_files)
+        print(f"[WARN] Excluding {excluded_files_cnt} files based on path filters!")
+
+        return sorted(filtered_files)
+
+    @staticmethod
+    def _get_header(filepath):
+        header = []
+        with open(filepath, "r") as file_obj:
+            # We expect a specific header format which should be 4 lines
+            for _ in range(4):
+                header.append(file_obj.readline().strip())
+
+        return header
+
+    @staticmethod
+    def _is_excluded_header(header, exclude=None):
+        if exclude is None:
+            exclude = []
+
+        for matcher in exclude:
+            if re.search(matcher, header[0]):
+                return True
+
+        return False
+
+    @staticmethod
+    def _has_copyright(filepath, debug=False):
+        header = CopyrightLinter._get_header(filepath)
+        if header is None:
+            print("Mismatch found! Could not find any content in file!")
+            return False
+
+        if len(header) > 0 and CopyrightLinter._is_excluded_header(header, exclude=COMPILED_HEADER_EXCLUSION_REGEX):
+            if debug:
+                print(f"[WARN] Excluding {filepath} based on header '{header[0]}'")
+            return True
+
+        if len(header) <= 3:
+            print("Mismatch found! File too small for header stanza!")
+            return False
+
+        for line_idx, matcher in enumerate(COMPILED_COPYRIGHT_REGEX):
+            if not re.match(matcher, header[line_idx]):
+                print(f"Mismatch found! Expected '{COPYRIGHT_REGEX[line_idx]}' pattern but got '{header[line_idx]}'")
+                return False
+
+        return True
+
+    @staticmethod
+    def _assert_copyrights(files, debug=False):
+        failing_files = []
+        for filepath in files:
+            if CopyrightLinter._has_copyright(filepath, debug=debug):
+                if debug:
+                    print(f"[ OK ] {filepath}")
+
+                continue
+
+            print(f"[FAIL] {filepath}")
+            failing_files.append(filepath)
+
+        total_files = len(files)
+        if failing_files != 0:
+            pct_failing = (len(failing_files) / total_files) * 100
+            print()
+            print(
+                f"FAIL: There are {len(failing_files)} files out of "
+                + f"{total_files} ({pct_failing:.2f}%) that are missing the proper copyright!"
+            )
+
+        return failing_files
+
+    def assert_compliance(self, debug=False):
+        """
+        This method applies the GLOB_PATTERN to the root of the repository and
+        verifies that all files have the expected copyright header.
+        """
+
+        git_repo_dir = CopyrightLinter._get_repo_dir()
+
+        if debug:
+            print(f"Repo root: {git_repo_dir}")
+            print(f"Finding all files in {git_repo_dir} matching '{GLOB_PATTERN}'...")
+
+        matching_files = CopyrightLinter._get_matching_files(
+            git_repo_dir,
+            GLOB_PATTERN,
+            exclude=COMPILED_PATH_EXCLUSION_REGEX,
+        )
+        print(f"Found {len(matching_files)} files matching '{GLOB_PATTERN}'")
+
+        failing_files = CopyrightLinter._assert_copyrights(matching_files, debug=debug)
+        if len(failing_files) > 0:
+            print("CHECK: FAIL")
+            raise Exception(
+                f"Copyright linting found {len(failing_files)} files that did not have the expected header!"
+            )
+
+        print("CHECK: OK")
+
+
+if __name__ == '__main__':
+    CopyrightLinter().assert_compliance(debug=True)

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -552,8 +552,7 @@ def lint_python(ctx):
 @task
 def lint_copyrights(_):
     """
-    Checks that all files matching the search pattern (default: '**/*.go')
-    contain the appropriate copyright header.
+    Checks that all Go files contain the appropriate copyright header.
     """
 
     CopyrightLinter().assert_compliance()

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -17,6 +17,7 @@ from .build_tags import filter_incompatible_tags, get_build_tags, get_default_bu
 from .cluster_agent import integration_tests as dca_integration_tests
 from .dogstatsd import integration_tests as dsd_integration_tests
 from .go import fmt, generate, golangci_lint, ineffassign, lint, misspell, staticcheck, vet
+from .libs.copyright import CopyrightLinter
 from .libs.junit_upload import junit_upload_from_tgz, produce_junit_tar
 from .modules import DEFAULT_MODULES, GoModule
 from .trace_agent import integration_tests as trace_integration_tests
@@ -546,6 +547,16 @@ def lint_python(ctx):
     ctx.run("black --check --diff .")
     ctx.run("isort --check-only --diff .")
     ctx.run("vulture --ignore-decorators @task --ignore-names 'test_*,Test*' tasks")
+
+
+@task
+def lint_copyrights(_):
+    """
+    Checks that all files matching the search pattern (default: '**/*.go')
+    contain the appropriate copyright header.
+    """
+
+    CopyrightLinter().assert_compliance()
 
 
 @task


### PR DESCRIPTION
### What does this PR do?

This tool addition can be used via `inv lint-copyrights` which traverses the repo
tree and fails if it finds any Golang files with an unexpected copyright
header.

For now the tool is intended to be invoked manually but once all the files
get fixed, we can add it to our internal CI/CD pipeline as an automated
check.

### Motivation

Legal compliance needs

### Additional Notes

- Eventually we would like to enable this check in CI/CD but we need all the
  failures cleaned up first.
  
### Possible Drawbacks / Trade-offs

The tool could ideally have the ability to auto-fix problems but that's outside
of the scope of this task right now.

### Describe how to test/QA your changes

N/A but if test is needed, running `inv lint-copyrights` should show the output.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
