### PR TITLE
backport fix encoding extra hosts

### DIFF
--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -304,9 +304,6 @@ func batchConnections(
 		namedb := make([]string, 0)
 
 		for _, c := range batchConns { // We only want to include DNS entries relevant to this batch of connections
-			if c.Raddr.Ip == "10.128.253.64" {
-				fmt.Printf("Found\n")
-			}
 			if entries, ok := dns[c.Raddr.Ip]; ok {
 				if _, present := batchDNS[c.Raddr.Ip]; !present {
 					// first, walks through and converts entries of type DNSEntry to DNSDatabaseEntry,

--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -189,16 +189,16 @@ func convertDNSEntry(dnstable map[string]*model.DNSDatabaseEntry, namemap map[st
 	dbentry := &model.DNSDatabaseEntry{
 		NameOffsets: make([]int32, len(entry.Names)),
 	}
-	for _, name := range entry.Names {
+	for entryidx, name := range entry.Names {
 		// at this point, the NameOffsets slice is actually a slice of indices into
 		// the name slice.  It will be converted prior to encoding.
 		if idx, ok := namemap[name]; ok {
-			dbentry.NameOffsets = append(dbentry.NameOffsets, idx)
+			dbentry.NameOffsets[entryidx] = idx
 		} else {
 			dblen := int32(len(*namedb))
 			*namedb = append(*namedb, name)
 			namemap[name] = dblen
-			dbentry.NameOffsets = append(dbentry.NameOffsets, dblen)
+			dbentry.NameOffsets[entryidx] = dblen
 		}
 
 	}
@@ -304,6 +304,9 @@ func batchConnections(
 		namedb := make([]string, 0)
 
 		for _, c := range batchConns { // We only want to include DNS entries relevant to this batch of connections
+			if c.Raddr.Ip == "10.128.253.64" {
+				fmt.Printf("Found\n")
+			}
 			if entries, ok := dns[c.Raddr.Ip]; ok {
 				if _, present := batchDNS[c.Raddr.Ip]; !present {
 					// first, walks through and converts entries of type DNSEntry to DNSDatabaseEntry,


### PR DESCRIPTION
### What does this PR do?
Backports main PR with same fix


Even though slice was pre-allocated, was using append(), which caused
an extra entry with the zero value, which always added the first host in
the database to the list for each host.

### Motivation

Fixes incorrect data appearing in NPM.


### Describe how to test/QA your changes

Tests included.  Should also include additional verification in staging that problem
is resolved.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.