### PR TITLE
[corechecks/snmp] Fix flaky test TestDiscovery

### DIFF
--- a/pkg/collector/corechecks/snmp/discovery/discovery_test.go
+++ b/pkg/collector/corechecks/snmp/discovery/discovery_test.go
@@ -22,7 +22,7 @@ func waitForDiscoveredDevices(discovery *Discovery, expectedDeviceCount int, tim
 		}
 		time.Sleep(100 * time.Millisecond)
 	}
-	return fmt.Errorf("timeout after waiting for %v, expected at least %d devices but %d has been discovered", duration, expectedDeviceCount, deviceCount)
+	return fmt.Errorf("timeout after waiting for %v, expected at least %d devices but %d has been discovered", timeout, expectedDeviceCount, deviceCount)
 }
 
 func TestDiscovery(t *testing.T) {

--- a/pkg/collector/corechecks/snmp/discovery/discovery_test.go
+++ b/pkg/collector/corechecks/snmp/discovery/discovery_test.go
@@ -13,6 +13,18 @@ import (
 	"time"
 )
 
+func waitForDiscoveredDevices(discovery *Discovery, expectedDeviceCount int, timeout time.Duration) error {
+	var deviceCount int
+	for start := time.Now(); time.Since(start) < timeout; {
+		deviceCount = len(discovery.GetDiscoveredDeviceConfigs())
+		if deviceCount >= expectedDeviceCount {
+			return nil
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return fmt.Errorf("timeout after waiting for %v, expected at least %d devices but %d has been discovered", duration, expectedDeviceCount, deviceCount)
+}
+
 func TestDiscovery(t *testing.T) {
 	path, _ := filepath.Abs(filepath.Join(".", "test", "run_path", "TestDiscovery"))
 	config.Datadog.Set("run_path", path)
@@ -134,18 +146,6 @@ func TestDiscoveryCache(t *testing.T) {
 		actualDiscoveredIpsFromCache = append(actualDiscoveredIpsFromCache, deviceCk.GetIPAddress())
 	}
 	assert.ElementsMatch(t, expectedDiscoveredIps, actualDiscoveredIpsFromCache)
-}
-
-func waitForDiscoveredDevices(discovery *Discovery, expectedDeviceCount int, timeout time.Duration) error {
-	var deviceCount int
-	for start := time.Now(); time.Since(start) < timeout; {
-		deviceCount = len(discovery.GetDiscoveredDeviceConfigs())
-		if deviceCount >= expectedDeviceCount {
-			return nil
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	return fmt.Errorf("timeout after waiting for %v, expected at least %d devices but %d has been discovered", duration, expectedDeviceCount, deviceCount)
 }
 
 func TestDiscoveryTicker(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[corechecks/snmp] Fix flaky test TestDiscovery

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fixes a flaky test

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs


<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
