### PR TITLE
[CWS] upgrade eBPF lib and fix excluded sections feature

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/DataDog/datadog-go v4.8.3+incompatible
 	github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a
 	github.com/DataDog/ebpf v0.0.0-20211116165855-af5870810f0b
-	github.com/DataDog/ebpf-manager v1.0.2
+	github.com/DataDog/ebpf-manager v0.0.0-20220103145404-d938938b1a8e
 	github.com/DataDog/gohai v0.0.0-20211126091652-d183ed971098
 	github.com/DataDog/gopsutil v0.0.0-20211112180027-9aa392ae181a
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect

--- a/go.sum
+++ b/go.sum
@@ -118,8 +118,8 @@ github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a h1
 github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a/go.mod h1:2qOvG41jii2ks6Umn6MbDGlHRgwoFiYXcjgQQ9VlsS0=
 github.com/DataDog/ebpf v0.0.0-20211116165855-af5870810f0b h1:jh2MmUAXxKlWQw48DEuXxIFJtFHKvDcIp1bczg8fVaY=
 github.com/DataDog/ebpf v0.0.0-20211116165855-af5870810f0b/go.mod h1:tSPYMUcskM0OLVEJSoydgYUVuhX8hOSmtaSLNtOQThg=
-github.com/DataDog/ebpf-manager v1.0.2 h1:r7BTpVkDy5hSPEV8buzDHd5g7Km2zk15KAumWZ/Svbs=
-github.com/DataDog/ebpf-manager v1.0.2/go.mod h1:05Y9FhEyILUdCovBthi5y4KPY8AfUg5EbMNC6RMQXDY=
+github.com/DataDog/ebpf-manager v0.0.0-20220103145404-d938938b1a8e h1:FutKp9ucvaoyiaYslgoZ64c/1wlOIgiPs+scZFy1K7s=
+github.com/DataDog/ebpf-manager v0.0.0-20220103145404-d938938b1a8e/go.mod h1:05Y9FhEyILUdCovBthi5y4KPY8AfUg5EbMNC6RMQXDY=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c h1:a9OMhZzrrB4nd2eAsXZIBkQ061Gb/QT4CI2g+OWWevs=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c/go.mod h1:lMIXf2EAzxbIv2zEvWu1bdqlaclUWoCtN13MHuPcY5I=
 github.com/DataDog/gohai v0.0.0-20211126091652-d183ed971098 h1:ANBijoD3xHRs6po7uejTdUHmCnL7Gr0MlE4RSiSBR1E=

--- a/pkg/security/ebpf/probes/all.go
+++ b/pkg/security/ebpf/probes/all.go
@@ -144,12 +144,12 @@ func AllTailRoutes(ERPCDentryResolutionEnabled bool) []manager.TailCallRoute {
 	return routes
 }
 
-// AllBPFProbeWriteUserSections returns the list of program sections that use the bpf_probe_write_user helper
-func AllBPFProbeWriteUserSections() []string {
+// AllBPFProbeWriteUserProgramFunctions returns the list of program functions that use the bpf_probe_write_user helper
+func AllBPFProbeWriteUserProgramFunctions() []string {
 	return []string{
-		"kprobe/dentry_resolver_erpc",
-		"kprobe/dentry_resolver_parent_erpc",
-		"kprobe/dentry_resolver_segment_erpc",
+		"kprobe_dentry_resolver_erpc",
+		"kprobe_dentry_resolver_parent_erpc",
+		"kprobe_dentry_resolver_segment_erpc",
 	}
 }
 

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -978,7 +978,7 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 	p.managerOptions.TailCallRouter = probes.AllTailRoutes(p.config.ERPCDentryResolutionEnabled)
 	if !p.config.ERPCDentryResolutionEnabled {
 		// exclude the programs that use the bpf_probe_write_user helper
-		p.managerOptions.ExcludedSections = probes.AllBPFProbeWriteUserSections()
+		p.managerOptions.ExcludedFunctions = probes.AllBPFProbeWriteUserProgramFunctions()
 	}
 
 	resolvers, err := NewResolvers(config, p)


### PR DESCRIPTION
### What does this PR do ?

This PR updates the ebpf-manager dependancy to fix the excluded sections feature.

### Motivation

With a recent upgrade to the eBPF library, the excluded sections feature got broken. This feature is required to prevent the ebpf manager from loading certain eBPF programs depending on the kernel version. This is important to disable the dentry resolution over eRPC feature on recent Ubuntu versions.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Start CWS and set `erpc_denty_resolution_enabled: false`. Make sure that the programs listed in `AllBPFProbeWriteUserProgramFunctions()` aren't listed.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
