### PR TITLE
[pkg/forwarder/transaction] Error message from a server is missing

### DIFF
--- a/pkg/forwarder/transaction/transaction.go
+++ b/pkg/forwarder/transaction/transaction.go
@@ -387,8 +387,8 @@ func (t *HTTPTransaction) SerializeTo(serializer TransactionsSerializer) error {
 }
 
 // readResponseBody read HTTP response body. If body is more than 1000 bytes
-// truncates it to prevent from logging a huge message. When EOF occurs,
-// "<nil>" will be returned.
+// truncates it to prevent from logging a huge message.  When EOF occurs,
+// empty bytes will be returned.
 // 1000 bytes are enough to tell which tools a response comes.
 func readResponseBody(body io.ReadCloser) ([]byte, error) {
 	if body == nil {

--- a/pkg/forwarder/transaction/transaction.go
+++ b/pkg/forwarder/transaction/transaction.go
@@ -388,6 +388,7 @@ func (t *HTTPTransaction) SerializeTo(serializer TransactionsSerializer) error {
 
 // readResponseBody read HTTP response body. If body is more than 1000 bytes
 // truncates it to  prevent from logging a huge message. When EOF occurs,
+// truncates it to prevent from logging a huge message. When EOF occurs,
 // "<nil>" will be returned.
 // 1000 bytes are enough to tell which tools a response comes.
 func readResponseBody(body io.ReadCloser) ([]byte, error) {

--- a/pkg/forwarder/transaction/transaction.go
+++ b/pkg/forwarder/transaction/transaction.go
@@ -335,6 +335,14 @@ func (t *HTTPTransaction) internalProcess(ctx context.Context, client *http.Clie
 		tlmTxHTTPErrors.Inc(t.Domain, transactionEndpointName, statusCode)
 	}
 
+	limit := 100
+	if limit < len(body) {
+		// Truncate HTTP response body by first 100 bytes
+		// to tell which of those tools a response comes
+		// and prevent from logging a huge message.
+		body = body[:limit]
+	}
+
 	if resp.StatusCode == 400 || resp.StatusCode == 404 || resp.StatusCode == 413 {
 		log.Errorf("Error code %q received while sending transaction to %q: %s, dropping it", resp.Status, logURL, string(body))
 		TransactionsDroppedByEndpoint.Add(transactionEndpointName, 1)

--- a/pkg/forwarder/transaction/transaction.go
+++ b/pkg/forwarder/transaction/transaction.go
@@ -387,7 +387,6 @@ func (t *HTTPTransaction) SerializeTo(serializer TransactionsSerializer) error {
 }
 
 // readResponseBody read HTTP response body. If body is more than 1000 bytes
-// truncates it to  prevent from logging a huge message. When EOF occurs,
 // truncates it to prevent from logging a huge message. When EOF occurs,
 // "<nil>" will be returned.
 // 1000 bytes are enough to tell which tools a response comes.
@@ -396,12 +395,13 @@ func readResponseBody(body io.ReadCloser) ([]byte, error) {
 		return []byte("<nil>"), nil
 	}
 	limit := 1000
-	b := make([]byte, limit)
+	b := make([]byte, limit+1) // For checking if the body will be truncated or not.
 	n, err := io.ReadFull(body, b)
 	if err != nil && !errors.Is(err, io.ErrUnexpectedEOF) && !errors.Is(err, io.EOF) {
 		return nil, err
 	}
 	if limit < n {
+		n = limit
 		log.Warn("truncated http response body to the first 1000 bytes to prevent from logging a huge message")
 	}
 	if n == 0 {

--- a/pkg/forwarder/transaction/transaction.go
+++ b/pkg/forwarder/transaction/transaction.go
@@ -351,7 +351,7 @@ func (t *HTTPTransaction) internalProcess(ctx context.Context, client *http.Clie
 		t.ErrorCount++
 		transactionsErrors.Add(1)
 		tlmTxErrors.Inc(t.Domain, transactionEndpointName, "gt_400")
-		return resp.StatusCode, body, fmt.Errorf("error %q while sending transaction to %q, rescheduling it", resp.Status, logURL)
+		return resp.StatusCode, body, fmt.Errorf("error %q while sending transaction to %q, rescheduling it: %s", resp.Status, logURL, string(body))
 	}
 
 	tlmTxSuccessCount.Inc(t.Domain, transactionEndpointName)

--- a/pkg/forwarder/transaction/transaction.go
+++ b/pkg/forwarder/transaction/transaction.go
@@ -351,7 +351,7 @@ func (t *HTTPTransaction) internalProcess(ctx context.Context, client *http.Clie
 		t.ErrorCount++
 		transactionsErrors.Add(1)
 		tlmTxErrors.Inc(t.Domain, transactionEndpointName, "gt_400")
-		return resp.StatusCode, body, fmt.Errorf("error %q while sending transaction to %q, rescheduling it: %s", resp.Status, logURL, string(body))
+		return resp.StatusCode, body, fmt.Errorf("error %q while sending transaction to %q, rescheduling it: %q", resp.Status, logURL, string(body))
 	}
 
 	tlmTxSuccessCount.Inc(t.Domain, transactionEndpointName)

--- a/pkg/forwarder/transaction/transaction.go
+++ b/pkg/forwarder/transaction/transaction.go
@@ -392,7 +392,7 @@ func (t *HTTPTransaction) SerializeTo(serializer TransactionsSerializer) error {
 // 1000 bytes are enough to tell which tools a response comes.
 func readResponseBody(body io.ReadCloser) ([]byte, error) {
 	if body == nil {
-		return []byte("<nil>"), nil
+		return []byte{}, nil
 	}
 	limit := 1000
 	b := make([]byte, limit+1) // For checking if the body will be truncated or not.
@@ -405,7 +405,7 @@ func readResponseBody(body io.ReadCloser) ([]byte, error) {
 		log.Warn("truncated http response body to the first 1000 bytes to prevent from logging a huge message")
 	}
 	if n == 0 {
-		return []byte("<nil>"), nil
+		return []byte{}, nil
 	}
 	return b[:n], nil
 }

--- a/pkg/forwarder/transaction/transaction.go
+++ b/pkg/forwarder/transaction/transaction.go
@@ -396,5 +396,5 @@ func truncateBodyForLog(body []byte) []byte {
 		return body
 	}
 	log.Warn("truncated http response body to the first 1000 bytes to prevent from logging a huge message")
-	return body[:limit]
+	return append(body[:limit], []byte("...")...)
 }

--- a/pkg/forwarder/transaction/transaction.go
+++ b/pkg/forwarder/transaction/transaction.go
@@ -395,6 +395,5 @@ func truncateBodyForLog(body []byte) []byte {
 	if len(body) < limit {
 		return body
 	}
-	log.Warn("truncated http response body to the first 1000 bytes to prevent from logging a huge message")
 	return append(body[:limit], []byte("...")...)
 }

--- a/pkg/forwarder/transaction/transaction.go
+++ b/pkg/forwarder/transaction/transaction.go
@@ -344,7 +344,7 @@ func (t *HTTPTransaction) internalProcess(ctx context.Context, client *http.Clie
 	}
 
 	if resp.StatusCode == 400 || resp.StatusCode == 404 || resp.StatusCode == 413 {
-		log.Errorf("Error code %q received while sending transaction to %q: %s, dropping it", resp.Status, logURL, string(body))
+		log.Errorf("Error code %q received while sending transaction to %q: %q, dropping it", resp.Status, logURL, body)
 		TransactionsDroppedByEndpoint.Add(transactionEndpointName, 1)
 		TransactionsDropped.Add(1)
 		TlmTxDropped.Inc(t.Domain, transactionEndpointName)
@@ -359,7 +359,7 @@ func (t *HTTPTransaction) internalProcess(ctx context.Context, client *http.Clie
 		t.ErrorCount++
 		transactionsErrors.Add(1)
 		tlmTxErrors.Inc(t.Domain, transactionEndpointName, "gt_400")
-		return resp.StatusCode, body, fmt.Errorf("error %q while sending transaction to %q, rescheduling it: %q", resp.Status, logURL, string(body))
+		return resp.StatusCode, body, fmt.Errorf("error %q while sending transaction to %q, rescheduling it: %q", resp.Status, logURL, body)
 	}
 
 	tlmTxSuccessCount.Inc(t.Domain, transactionEndpointName)
@@ -372,15 +372,15 @@ func (t *HTTPTransaction) internalProcess(ctx context.Context, client *http.Clie
 
 	if transactionsSuccess.Value() == 1 {
 		log.Infof("Successfully posted payload to %q, the agent will only log transaction success every %d transactions", logURL, loggingFrequency)
-		log.Tracef("Url: %q payload: %s", logURL, string(body))
+		log.Tracef("Url: %q payload: %q", logURL, body)
 		return resp.StatusCode, body, nil
 	}
 	if transactionsSuccess.Value()%loggingFrequency == 0 {
 		log.Infof("Successfully posted payload to %q", logURL)
-		log.Tracef("Url: %q payload: %s", logURL, string(body))
+		log.Tracef("Url: %q payload: %q", logURL, body)
 		return resp.StatusCode, body, nil
 	}
-	log.Tracef("Successfully posted payload to %q: %s", logURL, string(body))
+	log.Tracef("Successfully posted payload to %q: %q", logURL, body)
 	return resp.StatusCode, body, nil
 }
 

--- a/pkg/forwarder/transaction/transaction_test.go
+++ b/pkg/forwarder/transaction/transaction_test.go
@@ -164,13 +164,13 @@ func Test_readResponseBody(t *testing.T) {
 			handleFunc: func(w http.ResponseWriter, r *http.Request) {
 				w.Write([]byte(""))
 			},
-			want:    []byte("<nil>"),
+			want:    []byte{},
 			wantErr: nil,
 		},
 		{
 			name:       "no body",
 			handleFunc: func(w http.ResponseWriter, r *http.Request) {},
-			want:       []byte("<nil>"),
+			want:       []byte{},
 			wantErr:    nil,
 		},
 	}

--- a/pkg/forwarder/transaction/transaction_test.go
+++ b/pkg/forwarder/transaction/transaction_test.go
@@ -142,13 +142,13 @@ func Test_truncateBodyForLog(t *testing.T) {
 		},
 		{
 			name: "body is 1000 bytes",
-			body: []byte(strings.Repeat(".", 1000)),
-			want: []byte(strings.Repeat(".", 1000)),
+			body: []byte(strings.Repeat("a", 1000)),
+			want: append([]byte(strings.Repeat("a", 1000)), []byte("...")...),
 		},
 		{
 			name: "body is 1001 bytes",
-			body: []byte(strings.Repeat(".", 1001)),
-			want: []byte(strings.Repeat(".", 1000)),
+			body: []byte(strings.Repeat("a", 1001)),
+			want: append([]byte(strings.Repeat("a", 1000)), []byte("...")...),
 		},
 		{
 			name: "body is empty",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add a message from a server to an error.

### Motivation

It helps us to understand why a server returns an error.

### Additional Notes

When status code is 400, 404 or 413, an error from a server is included.

https://github.com/DataDog/datadog-agent/blob/a668784871033b004b62540e5644658bbbf38895/pkg/forwarder/transaction/transaction.go#L339

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
