### PR TITLE
[kitchen] Get RPM keys from keys.datadoghq.com

### DIFF
--- a/test/kitchen/site-cookbooks/dd-agent-reinstall/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-reinstall/recipes/default.rb
@@ -33,7 +33,11 @@ if node['dd-agent-reinstall']['add_new_repo']
       make_cache true
       # Older versions of yum embed M2Crypto with SSL that doesn't support TLS1.2
       protocol = node['platform_version'].to_i < 6 ? 'http' : 'https'
-      gpgkey "#{protocol}://yum.datadoghq.com/DATADOG_RPM_KEY.public"
+      gpgkey [
+        "#{protocol}://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public",
+        "#{protocol}://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public",
+        "#{protocol}://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public",
+      ]
     end
   when 'suse'
     old_key_local_path = ::File.join(Chef::Config[:file_cache_path], 'DATADOG_RPM_KEY.public')
@@ -59,7 +63,7 @@ if node['dd-agent-reinstall']['add_new_repo']
       gpgcheck false
       # Older versions of yum embed M2Crypto with SSL that doesn't support TLS1.2
       protocol = node['platform_version'].to_i < 6 ? 'http' : 'https'
-      gpgkey "#{protocol}://yum.datadoghq.com/DATADOG_RPM_KEY.public"
+      gpgkey "#{protocol}://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public"
       gpgautoimportkeys false
     end
   end

--- a/test/kitchen/site-cookbooks/dd-agent-step-by-step/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-step-by-step/recipes/default.rb
@@ -39,8 +39,9 @@ when 'rhel'
       enabled=1
       gpgcheck=1
       repo_gpgcheck=0
-      gpgkey=#{protocol}://yum.datadoghq.com/DATADOG_RPM_KEY.public
-             #{protocol}://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+      gpgkey=#{protocol}://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+             #{protocol}://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+             #{protocol}://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
     EOF
   end
 
@@ -60,19 +61,20 @@ when 'suse'
       enabled=1
       gpgcheck=1
       repo_gpgcheck=0
-      gpgkey=https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-             https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+      gpgkey=https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+             https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+             https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
     EOF
   end
 
   execute 'install suse' do
     command <<-EOF
-      sudo curl -o /tmp/DATADOG_RPM_KEY.public https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-      sudo rpm --import /tmp/DATADOG_RPM_KEY.public
-      sudo curl -o /tmp/DATADOG_RPM_KEY_E09422B3.public https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
+      sudo curl -o /tmp/DATADOG_RPM_KEY_CURRENT.public https://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public
+      sudo rpm --import /tmp/DATADOG_RPM_KEY_CURRENT.public
+      sudo curl -o /tmp/DATADOG_RPM_KEY_FD4BF915.public https://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public
+      sudo rpm --import /tmp/DATADOG_RPM_KEY_FD4BF915.public
+      sudo curl -o /tmp/DATADOG_RPM_KEY_E09422B3.public https://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
       sudo rpm --import /tmp/DATADOG_RPM_KEY_E09422B3.public
-      sudo rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY.public
-      sudo rpm --import https://yum.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public
       sudo zypper --non-interactive --no-gpg-checks refresh datadog
       sudo zypper --non-interactive install #{node['dd-agent-step-by-step']['package_name']}
     EOF

--- a/test/kitchen/site-cookbooks/dd-agent-upgrade/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-upgrade/recipes/default.rb
@@ -33,7 +33,11 @@ if node['dd-agent-upgrade']['add_new_repo']
       make_cache true
       # Older versions of yum embed M2Crypto with SSL that doesn't support TLS1.2
       protocol = node['platform_version'].to_i < 6 ? 'http' : 'https'
-      gpgkey "#{protocol}://yum.datadoghq.com/DATADOG_RPM_KEY.public"
+      gpgkey [
+        "#{protocol}://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public",
+        "#{protocol}://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public",
+        "#{protocol}://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public",
+      ]
     end
   when 'suse'
     old_key_local_path = ::File.join(Chef::Config[:file_cache_path], 'DATADOG_RPM_KEY.public')
@@ -59,7 +63,7 @@ if node['dd-agent-upgrade']['add_new_repo']
       gpgcheck false
       # Older versions of yum embed M2Crypto with SSL that doesn't support TLS1.2
       protocol = node['platform_version'].to_i < 6 ? 'http' : 'https'
-      gpgkey "#{protocol}://yum.datadoghq.com/DATADOG_RPM_KEY.public"
+      gpgkey "#{protocol}://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public"
       gpgautoimportkeys false
     end
   end


### PR DESCRIPTION
### What does this PR do?

Implements getting RPM repo keys from keys.datadoghq.com.

I will be sending another PR for `test/kitchen/site-cookbooks/dd-agent-install-script/files/dogstatsd_install_script.sh`, because that will require more involved changes and also changes for APT keys.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
