### PR TITLE
[CWS] use more recent packages loader in `accessors` generator script

### DIFF
--- a/pkg/security/module/event.go
+++ b/pkg/security/module/event.go
@@ -1,4 +1,4 @@
-//go:generate go run github.com/mailru/easyjson/easyjson -no_std_marshalers $GOFILE
+//go:generate go run github.com/mailru/easyjson/easyjson -gen_build_flags=-mod=mod -no_std_marshalers $GOFILE
 
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.

--- a/pkg/security/probe/custom_events.go
+++ b/pkg/security/probe/custom_events.go
@@ -1,4 +1,4 @@
-//go:generate go run github.com/mailru/easyjson/easyjson -no_std_marshalers -build_tags linux $GOFILE
+//go:generate go run github.com/mailru/easyjson/easyjson -gen_build_flags=-mod=mod -no_std_marshalers -build_tags linux $GOFILE
 
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -1,4 +1,4 @@
-//go:generate go run github.com/mailru/easyjson/easyjson -no_std_marshalers -build_tags linux $GOFILE
+//go:generate go run github.com/mailru/easyjson/easyjson -gen_build_flags=-mod=mod -no_std_marshalers -build_tags linux $GOFILE
 //go:generate go run github.com/DataDog/datadog-agent/pkg/security/probe/doc_generator -output ../../../docs/cloud-workload-security/backend.schema.json
 
 // Unless explicitly stated otherwise all files in this repository are licensed

--- a/pkg/security/secl/compiler/generators/accessors/accessors.go
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.go
@@ -60,7 +60,7 @@ func resolveSymbol(pkg, symbol string) (types.Object, error) {
 		return typePackage.Scope().Lookup(symbol), nil
 	}
 
-	return nil, fmt.Errorf("Failed to retrieve package info for %s", pkg)
+	return nil, fmt.Errorf("failed to retrieve package info for %s", pkg)
 }
 
 func origTypeToBasicType(kind string) string {
@@ -336,14 +336,14 @@ func parseFile(filename string, pkgName string) (*common.Module, error) {
 
 	astFile, err := conf.ParseFile(filename, nil)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to parse %s: %s", filename, err)
+		return nil, fmt.Errorf("failed to parse %s: %s", filename, err)
 	}
 
 	conf.Import(pkgName)
 
 	program, err = conf.Load()
 	if err != nil {
-		return nil, fmt.Errorf("Failed to load %s (%s): %s", filename, pkgName, err)
+		return nil, fmt.Errorf("failed to load %s (%s): %s", filename, pkgName, err)
 	}
 
 	packages = make(map[string]*types.Package, len(program.AllPackages))

--- a/pkg/security/secl/compiler/generators/accessors/accessors.go
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.go
@@ -39,7 +39,6 @@ var (
 	filename  string
 	pkgname   string
 	output    string
-	strict    bool
 	verbose   bool
 	mock      bool
 	genDoc    bool
@@ -288,9 +287,6 @@ func handleSpec(astFile *ast.File, spec interface{}, prefix, aliasPrefix, event 
 							delete(dejavu, fieldName)
 						}
 
-						if strict {
-							log.Panicf("Don't know what to do with %s: %s", fieldName, spew.Sdump(field.Type))
-						}
 						if verbose {
 							log.Printf("Don't know what to do with %s: %s", fieldName, spew.Sdump(field.Type))
 						}

--- a/pkg/security/secl/compiler/generators/accessors/accessors.go
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.go
@@ -311,7 +311,8 @@ func handleSpec(astFile *ast.File, spec interface{}, prefix, aliasPrefix, event 
 
 func parseFile(filename string, pkgName string) (*common.Module, error) {
 	cfg := packages.Config{
-		Mode: packages.NeedSyntax | packages.NeedTypes | packages.NeedImports,
+		Mode:       packages.NeedSyntax | packages.NeedTypes | packages.NeedImports,
+		BuildFlags: []string{"-mod=mod"},
 	}
 
 	pkgs, err := packages.Load(&cfg, filename)

--- a/pkg/security/secl/compiler/generators/accessors/accessors.go
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.go
@@ -44,17 +44,11 @@ var (
 	program   *loader.Program
 	packages  map[string]*types.Package
 	buildTags string
-	vendor    string
 )
 
 var module *common.Module
 
 func resolveSymbol(pkg, symbol string) (types.Object, error) {
-	if typePackage, found := packages[pkg]; found {
-		return typePackage.Scope().Lookup(symbol), nil
-	}
-
-	pkg = path.Join(vendor, pkg)
 	if typePackage, found := packages[pkg]; found {
 		return typePackage.Scope().Lookup(symbol), nil
 	}
@@ -767,6 +761,5 @@ func init() {
 	flag.StringVar(&pkgname, "package", pkgPrefix+"/"+os.Getenv("GOPACKAGE"), "Go package name")
 	flag.StringVar(&buildTags, "tags", "", "build tags used for parsing")
 	flag.StringVar(&output, "output", "", "Go generated file")
-	flag.StringVar(&vendor, "vendor", "", "vendor prefix")
 	flag.Parse()
 }

--- a/pkg/security/secl/compiler/generators/accessors/accessors.go
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.go
@@ -312,7 +312,7 @@ func handleSpec(astFile *ast.File, spec interface{}, prefix, aliasPrefix, event 
 func parseFile(filename string, pkgName string) (*common.Module, error) {
 	cfg := packages.Config{
 		Mode:       packages.NeedSyntax | packages.NeedTypes | packages.NeedImports,
-		BuildFlags: []string{"-mod=mod"},
+		BuildFlags: []string{"-mod=mod", fmt.Sprintf("-tags=%s", buildTags)},
 	}
 
 	pkgs, err := packages.Load(&cfg, filename)

--- a/pkg/security/secl/compiler/generators/accessors/accessors.go
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"go/ast"
@@ -316,6 +317,10 @@ func parseFile(filename string, pkgName string) (*common.Module, error) {
 	pkgs, err := packages.Load(&cfg, filename)
 	if err != nil {
 		return nil, err
+	}
+
+	if len(pkgs) == 0 || len(pkgs[0].Syntax) == 0 {
+		return nil, errors.New("failed to get syntax from parse file")
 	}
 
 	pkg := pkgs[0]

--- a/pkg/security/secl/compiler/generators/accessors/accessors.go
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.go
@@ -310,7 +310,7 @@ func handleSpec(astFile *ast.File, spec interface{}, prefix, aliasPrefix, event 
 
 func parseFile(filename string, pkgName string) (*common.Module, error) {
 	cfg := packages.Config{
-		Mode: packages.NeedName | packages.NeedSyntax | packages.NeedTypes | packages.NeedTypesInfo | packages.NeedImports | packages.NeedDeps | packages.NeedModule,
+		Mode: packages.NeedSyntax | packages.NeedTypes | packages.NeedImports,
 	}
 
 	pkgs, err := packages.Load(&cfg, filename)

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -5,9 +5,9 @@
 
 // +build linux
 
-//go:generate go run github.com/DataDog/datadog-agent/pkg/security/secl/compiler/generators/accessors -vendor github.com/DataDog/datadog-agent/vendor/ -mock -tags linux -output accessors.go
-//go:generate go run github.com/DataDog/datadog-agent/pkg/security/secl/compiler/generators/accessors -vendor github.com/DataDog/datadog-agent/vendor/ -tags linux -output ../../probe/accessors.go
-//go:generate go run github.com/DataDog/datadog-agent/pkg/security/secl/compiler/generators/accessors -vendor github.com/DataDog/datadog-agent/vendor/ -tags linux -doc -output ../../../../docs/cloud-workload-security/secl.json
+//go:generate go run github.com/DataDog/datadog-agent/pkg/security/secl/compiler/generators/accessors -mock -tags linux -output accessors.go
+//go:generate go run github.com/DataDog/datadog-agent/pkg/security/secl/compiler/generators/accessors -tags linux -output ../../probe/accessors.go
+//go:generate go run github.com/DataDog/datadog-agent/pkg/security/secl/compiler/generators/accessors -tags linux -doc -output ../../../../docs/cloud-workload-security/secl.json
 
 package model
 


### PR DESCRIPTION
### What does this PR do?

This PR uses a module-aware golang package loader instead of the deprecated `golang.org/x/tools/go/loader`

### Motivation

Fix issues with vendoring

### Describe how to test/QA your changes

Should be a no-op, will be ensured by the security go generate check job.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
