### PR TITLE
Add GitHub Action to run Serverless integration tests on relevant PRs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,9 +30,10 @@
 
 /.circleci/                             @DataDog/agent-platform
 
-/.github/CODEOWNERS                     @DataDog/do-not-notify
-/.github/*_TEMPLATE.md                  @DataDog/agent-all
-/.github/dependabot.yaml                @DataDog/agent-platform
+/.github/CODEOWNERS                                 @DataDog/do-not-notify
+/.github/*_TEMPLATE.md                              @DataDog/agent-all
+/.github/dependabot.yaml                            @DataDog/agent-platform
+/.github/workflows/serverless-integration.yml       @DataDog/serverless
 
 # Gitlab files
 # Files containing job contents are owned by teams in charge of the jobs + agent-platform

--- a/.github/workflows/serverless-integration.yml
+++ b/.github/workflows/serverless-integration.yml
@@ -5,10 +5,12 @@ on:
     paths:
       - 'cmd/serverless/**'
       - 'pkg/serverless/**'
+      - 'test/integration/serverless/**'
   pull_request:
     paths:
       - 'cmd/serverless/**'
       - 'pkg/serverless/**'
+      - 'test/integration/serverless/**'
 
 jobs:
   test:

--- a/.github/workflows/serverless-integration.yml
+++ b/.github/workflows/serverless-integration.yml
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: DataDog/datadog-lambda-extension
+          ref: refs/heads/ngh/fix-agent-path
           path: go/src/github.com/DataDog/datadog-lambda-extension
 
       - name: Run tests

--- a/.github/workflows/serverless-integration.yml
+++ b/.github/workflows/serverless-integration.yml
@@ -1,7 +1,7 @@
 name: "Serverless Integration Tests"
 
 on:
-  pull_request:
+  push:
     paths:
       - 'cmd/serverless/**'
       - 'pkg/serverless/**'

--- a/.github/workflows/serverless-integration.yml
+++ b/.github/workflows/serverless-integration.yml
@@ -1,6 +1,6 @@
 name: "Serverless Integration Tests"
-
 on: push
+
   # push:
     # paths:
     #   - 'cmd/serverless/**'

--- a/.github/workflows/serverless-integration.yml
+++ b/.github/workflows/serverless-integration.yml
@@ -1,11 +1,11 @@
 name: "Serverless Integration Tests"
-on: push
 
-  # push:
-    # paths:
-    #   - 'cmd/serverless/**'
-    #   - 'pkg/serverless/**'
-    #   - 'test/integration/serverless/**'
+on:
+  push:
+    paths:
+      - 'cmd/serverless/**'
+      - 'pkg/serverless/**'
+      - 'test/integration/serverless/**'
 
 jobs:
   test:
@@ -39,4 +39,4 @@ jobs:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }} 
         run: BUILD_EXTENSION=true .test/integration/serverless/run.sh
-        working_directory: go/src/github.com/DataDog/datadog-agent
+        working-directory: go/src/github.com/DataDog/datadog-agent

--- a/.github/workflows/serverless-integration.yml
+++ b/.github/workflows/serverless-integration.yml
@@ -33,7 +33,6 @@ jobs:
           path: go/src/github.com/DataDog/datadog-lambda-extension
 
       - name: Run tests if AWS credentials are available
-        if: ${{ secrets.SERVERLESS_AWS_ACCESS_KEY_ID != null && secrets.SERVERLESS_AWS_SECRET_ACCESS_KEY != null }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.SERVERLESS_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SERVERLESS_AWS_SECRET_ACCESS_KEY }} 

--- a/.github/workflows/serverless-integration.yml
+++ b/.github/workflows/serverless-integration.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout repository
+      - name: Checkout datadog-agent repository
         uses: actions/checkout@v2
         with:
           path: go/src/github.com/DataDog/datadog-agent

--- a/.github/workflows/serverless-integration.yml
+++ b/.github/workflows/serverless-integration.yml
@@ -29,8 +29,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: DataDog/datadog-lambda-extension
-          # TODO: Remove when PR in other repo is merged
-          ref: refs/heads/ngh/fix-agent-path
           path: go/src/github.com/DataDog/datadog-lambda-extension
 
       - name: Run tests

--- a/.github/workflows/serverless-integration.yml
+++ b/.github/workflows/serverless-integration.yml
@@ -1,11 +1,11 @@
 name: "Serverless Integration Tests"
 
-on: push
-  # push:
-  #   paths:
-  #     - 'cmd/serverless/**'
-  #     - 'pkg/serverless/**'
-  #     - 'test/integration/serverless/**'
+on:
+  push:
+    paths:
+      - 'cmd/serverless/**'
+      - 'pkg/serverless/**'
+      - 'test/integration/serverless/**'
 
 jobs:
   test:
@@ -29,6 +29,7 @@ jobs:
         uses: actions/checkout@v2
         with:
           repository: DataDog/datadog-lambda-extension
+          # TODO: Remove when PR in other repo is merged
           ref: refs/heads/ngh/fix-agent-path
           path: go/src/github.com/DataDog/datadog-lambda-extension
 

--- a/.github/workflows/serverless-integration.yml
+++ b/.github/workflows/serverless-integration.yml
@@ -1,11 +1,11 @@
 name: "Serverless Integration Tests"
 
-on:
-  push:
-    paths:
-      - 'cmd/serverless/**'
-      - 'pkg/serverless/**'
-      - 'test/integration/serverless/**'
+on: push
+  # push:
+  #   paths:
+  #     - 'cmd/serverless/**'
+  #     - 'pkg/serverless/**'
+  #     - 'test/integration/serverless/**'
 
 jobs:
   test:

--- a/.github/workflows/serverless-integration.yml
+++ b/.github/workflows/serverless-integration.yml
@@ -32,8 +32,8 @@ jobs:
           repository: DataDog/datadog-lambda-extension
           path: go/src/github.com/DataDog/datadog-lambda-extension
 
-      - name: Run tests
-        if:
+      - name: Run tests if AWS credentials are available
+        if: ${{ secrets.SERVERLESS_AWS_ACCESS_KEY_ID != null && secrets.SERVERLESS_AWS_SECRET_ACCESS_KEY != null }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.SERVERLESS_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.SERVERLESS_AWS_SECRET_ACCESS_KEY }} 

--- a/.github/workflows/serverless-integration.yml
+++ b/.github/workflows/serverless-integration.yml
@@ -1,11 +1,11 @@
 name: "Serverless Integration Tests"
 
-on:
-  push:
-    paths:
-      - 'cmd/serverless/**'
-      - 'pkg/serverless/**'
-      - 'test/integration/serverless/**'
+on: push
+  # push:
+    # paths:
+    #   - 'cmd/serverless/**'
+    #   - 'pkg/serverless/**'
+    #   - 'test/integration/serverless/**'
 
 jobs:
   test:

--- a/.github/workflows/serverless-integration.yml
+++ b/.github/workflows/serverless-integration.yml
@@ -28,20 +28,12 @@ jobs:
       - name: Checkout the datadog-lambda-extension repository
         uses: actions/checkout@v2
         with:
-          repository: DataDog/datadog-agent
+          repository: DataDog/datadog-lambda-extension
           path: go/src/github.com/DataDog/datadog-lambda-extension
 
       - name: Run tests
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }} 
-        run: |
-          pwd
-          cd ..
-          ls
-          cd datadog-lambda-extension
-          ls
-          cd scripts
-          ls
-        # run: BUILD_EXTENSION=true ./test/integration/serverless/run.sh
+        run: BUILD_EXTENSION=true ./test/integration/serverless/run.sh
         working-directory: go/src/github.com/DataDog/datadog-agent

--- a/.github/workflows/serverless-integration.yml
+++ b/.github/workflows/serverless-integration.yml
@@ -1,11 +1,6 @@
 name: "Serverless Integration Tests"
 
 on:
-  push:
-    paths:
-      - 'cmd/serverless/**'
-      - 'pkg/serverless/**'
-      - 'test/integration/serverless/**'
   pull_request:
     paths:
       - 'cmd/serverless/**'

--- a/.github/workflows/serverless-integration.yml
+++ b/.github/workflows/serverless-integration.yml
@@ -35,5 +35,13 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }} 
-        run: BUILD_EXTENSION=true ./test/integration/serverless/run.sh
+        run: |
+          pwd
+          cd ..
+          ls
+          cd datadog-lambda-extension
+          ls
+          cd scripts
+          ls
+        # run: BUILD_EXTENSION=true ./test/integration/serverless/run.sh
         working-directory: go/src/github.com/DataDog/datadog-agent

--- a/.github/workflows/serverless-integration.yml
+++ b/.github/workflows/serverless-integration.yml
@@ -25,9 +25,6 @@ jobs:
       - name: Install Serverless Framework
         run: sudo yarn global add serverless --prefix /usr/local
 
-      - name: Create folder
-        run: pwd && mkdir -p ~/dd
-
       - name: Checkout the datadog-lambda-extension repository
         uses: actions/checkout@v2
         with:

--- a/.github/workflows/serverless-integration.yml
+++ b/.github/workflows/serverless-integration.yml
@@ -38,5 +38,5 @@ jobs:
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }} 
-        run: BUILD_EXTENSION=true .test/integration/serverless/run.sh
+        run: BUILD_EXTENSION=true ./test/integration/serverless/run.sh
         working-directory: go/src/github.com/DataDog/datadog-agent

--- a/.github/workflows/serverless-integration.yml
+++ b/.github/workflows/serverless-integration.yml
@@ -6,6 +6,7 @@ on:
       - 'cmd/serverless/**'
       - 'pkg/serverless/**'
       - 'test/integration/serverless/**'
+      - '.github/workflows/serverless-integration.yml'
 
 jobs:
   test:
@@ -32,8 +33,9 @@ jobs:
           path: go/src/github.com/DataDog/datadog-lambda-extension
 
       - name: Run tests
+        if:
         env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }} 
+          AWS_ACCESS_KEY_ID: ${{ secrets.SERVERLESS_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.SERVERLESS_AWS_SECRET_ACCESS_KEY }} 
         run: BUILD_EXTENSION=true ./test/integration/serverless/run.sh
         working-directory: go/src/github.com/DataDog/datadog-agent

--- a/.github/workflows/serverless-integration.yml
+++ b/.github/workflows/serverless-integration.yml
@@ -30,11 +30,6 @@ jobs:
       - name: Install Serverless Framework
         run: sudo yarn global add serverless --prefix /usr/local
 
-      # - name: Install dependencies
-      #   # if: steps.cache-node-modules.outputs.cache-hit != 'true'
-      #   working-directory: integration_tests
-      #   run: yarn install
-
       - name: Create folder
         run: pwd && mkdir -p ~/dd
 
@@ -45,14 +40,8 @@ jobs:
           path: go/src/github.com/DataDog/datadog-lambda-extension
 
       - name: Run tests
-        # env:
-        #   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        #   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: ls 
-        # run: BUILD_EXTENSION=true .test/integration/serverless/run.sh
-
-      - name: Run tests
-        # env:
-        #   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        #   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        run: cd go/src/github.com/DataDog/ && ls
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }} 
+        run: BUILD_EXTENSION=true .test/integration/serverless/run.sh
+        working_directory: go/src/github.com/DataDog/datadog-agent

--- a/.github/workflows/serverless-integration.yml
+++ b/.github/workflows/serverless-integration.yml
@@ -1,0 +1,56 @@
+name: "Serverless Integration Tests"
+
+on:
+  push:
+    paths:
+      - 'cmd/serverless/**'
+      - 'pkg/serverless/**'
+  pull_request:
+    paths:
+      - 'cmd/serverless/**'
+      - 'pkg/serverless/**'
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          path: go/src/github.com/DataDog/datadog-agent
+
+      - name: Set up Node 14
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+      
+      - name: Install Serverless Framework
+        run: sudo yarn global add serverless --prefix /usr/local
+
+      # - name: Install dependencies
+      #   # if: steps.cache-node-modules.outputs.cache-hit != 'true'
+      #   working-directory: integration_tests
+      #   run: yarn install
+
+      - name: Create folder
+        run: pwd && mkdir -p ~/dd
+
+      - name: Checkout the datadog-lambda-extension repository
+        uses: actions/checkout@v2
+        with:
+          repository: DataDog/datadog-agent
+          path: go/src/github.com/DataDog/datadog-lambda-extension
+
+      - name: Run tests
+        # env:
+        #   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        #   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: ls 
+        # run: BUILD_EXTENSION=true .test/integration/serverless/run.sh
+
+      - name: Run tests
+        # env:
+        #   AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        #   AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: cd go/src/github.com/DataDog/ && ls

--- a/cmd/serverless/api_key.go
+++ b/cmd/serverless/api_key.go
@@ -17,7 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 )
 
-// encryptionContextKey is the key added to the encryption context by the Lambda console UI
+// encryptionContextKey is the key added to the encryption context by the Lambda console
 const encryptionContextKey = "LambdaFunctionName"
 
 // functionNameEnvVar is the environment variable that stores the function name.

--- a/cmd/serverless/api_key.go
+++ b/cmd/serverless/api_key.go
@@ -17,7 +17,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/secretsmanager"
 )
 
-// encryptionContextKey is the key added to the encryption context by the Lambda console
+// encryptionContextKey is the key added to the encryption context by the Lambda console UI
 const encryptionContextKey = "LambdaFunctionName"
 
 // functionNameEnvVar is the environment variable that stores the function name.

--- a/test/integration/serverless/run.sh
+++ b/test/integration/serverless/run.sh
@@ -15,11 +15,11 @@ set -e
 
 script_utc_start_time=$(date -u +"%Y%m%dT%H%M%S")
 
-if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
-    echo "No AWS credentials were found in the environment."
-    echo "Note that only Datadog employees can run these integration tests."
-    exit 1
-fi
+# if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+#     echo "No AWS credentials were found in the environment."
+#     echo "Note that only Datadog employees can run these integration tests."
+#     exit 1
+# fi
 
 # Move into the root directory, so this script can be called from any directory
 SERVERLESS_INTEGRATION_TESTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/test/integration/serverless/run.sh
+++ b/test/integration/serverless/run.sh
@@ -21,7 +21,7 @@ if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
     echo "Exiting without running tests..."
     
     # If credentials are not available, the run is considered a success
-    # so as not to break CI for external users 
+    # so as not to break CI for external users that don't have access to GitHub secrets 
     exit 0
 fi
 

--- a/test/integration/serverless/run.sh
+++ b/test/integration/serverless/run.sh
@@ -18,7 +18,11 @@ script_utc_start_time=$(date -u +"%Y%m%dT%H%M%S")
 if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
     echo "No AWS credentials were found in the environment."
     echo "Note that only Datadog employees can run these integration tests."
-    exit 1
+    echo "Exiting without running tests..."
+    
+    # If credentials are not available, the run is considered a success
+    # so as not to break CI for external users 
+    exit 0
 fi
 
 # Move into the root directory, so this script can be called from any directory

--- a/test/integration/serverless/run.sh
+++ b/test/integration/serverless/run.sh
@@ -15,11 +15,11 @@ set -e
 
 script_utc_start_time=$(date -u +"%Y%m%dT%H%M%S")
 
-# if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
-#     echo "No AWS credentials were found in the environment."
-#     echo "Note that only Datadog employees can run these integration tests."
-#     exit 1
-# fi
+if [ -z "$AWS_SECRET_ACCESS_KEY" ]; then
+    echo "No AWS credentials were found in the environment."
+    echo "Note that only Datadog employees can run these integration tests."
+    exit 1
+fi
 
 # Move into the root directory, so this script can be called from any directory
 SERVERLESS_INTEGRATION_TESTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/test/integration/serverless/run.sh
+++ b/test/integration/serverless/run.sh
@@ -26,6 +26,7 @@ SERVERLESS_INTEGRATION_TESTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev
 cd "$SERVERLESS_INTEGRATION_TESTS_DIR/../../.."
 
 # TODO: Get this working in CI environment
+pwd
 LAMBDA_EXTENSION_REPOSITORY_PATH="../datadog-lambda-extension"
 
 if [ "$BUILD_EXTENSION" == "true" ]; then

--- a/test/integration/serverless/run.sh
+++ b/test/integration/serverless/run.sh
@@ -3,7 +3,7 @@
 # Usage - run commands from repo root:
 # To check if new changes to the extension cause changes to any snapshots:
 #   BUILD_EXTENSION=true aws-vault exec sandbox-account-admin -- ./run.sh
-# To regeenerate snapshots:
+# To regennerate snapshots:
 #   UPDATE_SNAPSHOTS=true aws-vault exec sandbox-account-admin -- ./run.sh
 
 LOGS_WAIT_SECONDS=600

--- a/test/integration/serverless/run.sh
+++ b/test/integration/serverless/run.sh
@@ -25,8 +25,6 @@ script_utc_start_time=$(date -u +"%Y%m%dT%H%M%S")
 SERVERLESS_INTEGRATION_TESTS_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 cd "$SERVERLESS_INTEGRATION_TESTS_DIR/../../.."
 
-# TODO: Get this working in CI environment
-pwd
 LAMBDA_EXTENSION_REPOSITORY_PATH="../datadog-lambda-extension"
 
 if [ "$BUILD_EXTENSION" == "true" ]; then

--- a/test/integration/serverless/run.sh
+++ b/test/integration/serverless/run.sh
@@ -3,7 +3,7 @@
 # Usage - run commands from repo root:
 # To check if new changes to the extension cause changes to any snapshots:
 #   BUILD_EXTENSION=true aws-vault exec sandbox-account-admin -- ./run.sh
-# To regennerate snapshots:
+# To regenerate snapshots:
 #   UPDATE_SNAPSHOTS=true aws-vault exec sandbox-account-admin -- ./run.sh
 
 LOGS_WAIT_SECONDS=600

--- a/test/integration/serverless/run.sh
+++ b/test/integration/serverless/run.sh
@@ -3,7 +3,7 @@
 # Usage - run commands from repo root:
 # To check if new changes to the extension cause changes to any snapshots:
 #   BUILD_EXTENSION=true aws-vault exec sandbox-account-admin -- ./run.sh
-# To regenerate snapshots:
+# To regeenerate snapshots:
 #   UPDATE_SNAPSHOTS=true aws-vault exec sandbox-account-admin -- ./run.sh
 
 LOGS_WAIT_SECONDS=600


### PR DESCRIPTION
### What does this PR do?

We want to run the integration tests for the Datadog Lambda Extension (aka Serverless Agent) as a GitHub Action on pushes that affect the relevant files.

**This action won't be run on pushes that don't touch the serverless-related files.**

Before this PR works:

- [ ] We'll need to add the Serverless team's testing AWS credentials to the agent repository as secrets.
- [x] This PR needs to be merged: https://github.com/DataDog/datadog-lambda-extension/pull/42

The Lambda Extension uses a totally separate build and release process from the main agent, so this action is completely standalone and isn't written as a step in the GitLab CI pipeline.

### Motivation

By running the integration tests whenever we make changes, we can catch issues faster and more reliably. Exercising the test suite regularly will also force us to keep it up-to-date.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
