### PR TITLE
stub out fetching cloud provider NTP servers in tests

### DIFF
--- a/pkg/collector/corechecks/net/ntp.go
+++ b/pkg/collector/corechecks/net/ntp.go
@@ -69,6 +69,9 @@ func (c *NTPCheck) String() string {
 	return "ntp"
 }
 
+// for testing
+var getCloudProviderNTPHosts = cloudproviders.GetCloudProviderNTPHosts
+
 func (c *ntpConfig) parse(data []byte, initData []byte, getLocalServers func() ([]string, error)) error {
 	var instance ntpInstanceConfig
 	var initConf ntpInitConfig
@@ -77,7 +80,7 @@ func (c *ntpConfig) parse(data []byte, initData []byte, getLocalServers func() (
 	defaultPort := 123
 	defaultOffsetThreshold := 60
 
-	defaultHosts := cloudproviders.GetCloudProviderNTPHosts(context.TODO())
+	defaultHosts := getCloudProviderNTPHosts(context.TODO())
 
 	// Default to our domains on pool.ntp.org if no cloud provider detected
 	if defaultHosts == nil {

--- a/pkg/collector/corechecks/net/ntp_test.go
+++ b/pkg/collector/corechecks/net/ntp_test.go
@@ -6,6 +6,7 @@
 package net
 
 import (
+	"context"
 	"fmt"
 	"strconv"
 	"testing"
@@ -18,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/cloudproviders"
 )
 
 var (
@@ -336,6 +338,10 @@ hosts:
 }
 
 func TestDefaultHostConfig(t *testing.T) {
+	// for this test, do not check the cloud providers
+	getCloudProviderNTPHosts = func(_ context.Context) []string { return nil }
+	defer func() { getCloudProviderNTPHosts = cloudproviders.GetCloudProviderNTPHosts }()
+
 	expectedHosts := []string{"0.datadog.pool.ntp.org", "1.datadog.pool.ntp.org", "2.datadog.pool.ntp.org", "3.datadog.pool.ntp.org"}
 	testedConfig := []byte(``)
 	config.Datadog.Set("cloud_provider_metadata", []string{})


### PR DESCRIPTION
### What does this PR do?

Skips determining the current cloud provider's NTP servers when checking for the default NTP servers, avoiding a race condition.

### Motivation

@ogaca-dd suggested it in #9976.

