### PR TITLE
Update fix to previous encoding bug.

### DIFF
--- a/pkg/process/checks/net.go
+++ b/pkg/process/checks/net.go
@@ -187,18 +187,18 @@ func getConnectionsByPID(conns *model.Connections) map[int32][]*model.Connection
 
 func convertDNSEntry(dnstable map[string]*model.DNSDatabaseEntry, namemap map[string]int32, namedb *[]string, ip string, entry *model.DNSEntry) {
 	dbentry := &model.DNSDatabaseEntry{
-		NameOffsets: make([]int32, len(entry.Names)),
+		NameOffsets: make([]int32, 0, len(entry.Names)),
 	}
-	for entryidx, name := range entry.Names {
+	for _, name := range entry.Names {
 		// at this point, the NameOffsets slice is actually a slice of indices into
 		// the name slice.  It will be converted prior to encoding.
 		if idx, ok := namemap[name]; ok {
-			dbentry.NameOffsets[entryidx] = idx
+			dbentry.NameOffsets = append(dbentry.NameOffsets, idx)
 		} else {
 			dblen := int32(len(*namedb))
 			*namedb = append(*namedb, name)
 			namemap[name] = dblen
-			dbentry.NameOffsets[entryidx] = dblen
+			dbentry.NameOffsets = append(dbentry.NameOffsets, dblen)
 		}
 
 	}

--- a/pkg/process/checks/net_test.go
+++ b/pkg/process/checks/net_test.go
@@ -32,17 +32,19 @@ func makeConnections(n int) []*model.Connection {
 }
 
 func TestDNSNameEncoding(t *testing.T) {
-	p := makeConnections(4)
+	p := makeConnections(5)
 	p[0].Raddr.Ip = "1.1.2.1"
 	p[1].Raddr.Ip = "1.1.2.2"
 	p[2].Raddr.Ip = "1.1.2.3"
 	p[3].Raddr.Ip = "1.1.2.4"
+	p[4].Raddr.Ip = "1.1.2.5"
 
 	dns := map[string]*model.DNSEntry{
 		"1.1.2.1": {Names: []string{"host1.domain.com"}},
 		"1.1.2.2": {Names: []string{"host2.domain.com", "host2.domain2.com"}},
 		"1.1.2.3": {Names: []string{"host3.domain.com", "host3.domain2.com", "host3.domain3.com"}},
 		"1.1.2.4": {Names: []string{"host4.domain.com"}},
+		"1.1.2.5": {Names: nil},
 	}
 	cfg := config.NewDefaultAgentConfig(false)
 	chunks := batchConnections(cfg, 0, p, dns, "nid", nil, nil, nil, nil, nil)
@@ -50,15 +52,20 @@ func TestDNSNameEncoding(t *testing.T) {
 
 	chunk := chunks[0]
 	conns := chunk.(*model.CollectorConnections)
-	for ip := range dns {
+	dnsParsed := make(map[string]*model.DNSEntry)
+	for _, conn := range p {
+		ip := conn.Raddr.Ip
+		dnsParsed[ip] = &model.DNSEntry{}
 		model.IterateDNSV2(conns.EncodedDnsLookups, ip,
 			func(i, total int, entry int32) bool {
-				_, e := conns.GetDNSNameByOffset(entry)
+				host, e := conns.GetDNSNameByOffset(entry)
 				assert.Nil(t, e)
 				assert.Equal(t, total, len(dns[ip].Names))
+				dnsParsed[ip].Names = append(dnsParsed[ip].Names, host)
 				return true
 			})
 	}
+	assert.Equal(t, dns, dnsParsed)
 
 }
 


### PR DESCRIPTION
Previous fix _should_ work; however, did leave open the possibility of
walking off the end of the preallocated array.
In this version, if (somehow) the calculation gets off, then adding
additional values to the slice won't panic.

In the original implementation, the slice was preallocated, but then we appended
to the end (leaving the original first n entries as the zero-value).

Previous fix preallocated and then did direct assignment.   I realized, however, that 
if somehow the computation of the slice size was ever wrong (too small) then the previous fix
would assign off the end of the slice and panic.

With this fix, it will fail gracefully and reallocate the slice automatically.


### Motivation

Realized potential bug while investigating unrelated code.

### Additional Notes
### Describe how to test/QA your changes

Should be a no-op.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ x The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
