### PR TITLE
Add support for '/host/etc' folder when running in containerized mode.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -362,7 +362,7 @@ func InitConfig(config Config) {
 				os.Setenv("HOST_ETC", "/host/etc")
 				log.Debug("Setting environment variable HOST_ETC to '/host/etc'")
 			} else {
-				log.Debug("'/host/etc' folder detected but HOST_ETC is already set to '%s', leaving it untouched", val)
+				log.Debugf("'/host/etc' folder detected but HOST_ETC is already set to '%s', leaving it untouched", val)
 			}
 		}
 	} else {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -353,6 +353,18 @@ func InitConfig(config Config) {
 		} else {
 			config.SetDefault("container_cgroup_root", "/sys/fs/cgroup/")
 		}
+
+		if pathExists("/host/etc") {
+			if val, isSet := os.LookupEnv("HOST_ETC"); !isSet {
+				// We want to detect the host disto informations instead of the one from the container.
+				// 'HOST_ETC' is used by some libraries like gopsutil and by the system-probe to
+				// download the right kernel headers.
+				os.Setenv("HOST_ETC", "/host/etc")
+				log.Debug("Setting environment variable HOST_ETC to '/host/etc'")
+			} else {
+				log.Debug("'/host/etc' folder detected but HOST_ETC is already set to '%s', leaving it untouched", val)
+			}
+		}
 	} else {
 		config.SetDefault("container_proc_root", "/proc")
 		// for amazon linux the cgroup directory on host is /cgroup/

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -356,7 +356,7 @@ func InitConfig(config Config) {
 
 		if pathExists("/host/etc") {
 			if val, isSet := os.LookupEnv("HOST_ETC"); !isSet {
-				// We want to detect the host disto informations instead of the one from the container.
+				// We want to detect the host distro informations instead of the one from the container.
 				// 'HOST_ETC' is used by some libraries like gopsutil and by the system-probe to
 				// download the right kernel headers.
 				os.Setenv("HOST_ETC", "/host/etc")

--- a/pkg/flare/envvars.go
+++ b/pkg/flare/envvars.go
@@ -26,6 +26,7 @@ var allowedEnvvarNames = []string{
 	// HOST vars used in containerized agent
 	"HOST_ETC",
 	"HOST_PROC",
+	"HOST_ROOT",
 
 	// Proxy settings
 	"HTTP_PROXY",

--- a/pkg/flare/envvars.go
+++ b/pkg/flare/envvars.go
@@ -23,6 +23,10 @@ var allowedEnvvarNames = []string{
 	"DOCKER_HOST",
 	"DOCKER_TLS_VERIFY",
 
+	// HOST vars used in containerized agent
+	"HOST_ETC",
+	"HOST_PROC",
+
 	// Proxy settings
 	"HTTP_PROXY",
 	"HTTPS_PROXY",

--- a/releasenotes/notes/support-host-etc-folder-a45dc78da37872e1.yaml
+++ b/releasenotes/notes/support-host-etc-folder-a45dc78da37872e1.yaml
@@ -1,0 +1,5 @@
+---
+features:
+  - |
+    When running inside a container with the host `/etc` folder mounted to `/host/etc`, the agent will now report the
+    distro informations of the host instead of the one from the container.


### PR DESCRIPTION
### What does this PR do?

When running inside a container with the host `/etc` folder mounted to
`/host/etc`, the agent will now report the distro informations of the host instead of
the one from the container.

### Describe how to test/QA your changes

- Install the agent in a container and make sure the host reported in the metadata is the one from the host and not the container (when mounting `/etc` to `/host/etc`).

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
