### PR TITLE
[containerd] Watch all namespaces by default when outside Kubernetes

### DIFF
--- a/pkg/collector/corechecks/containers/containerd/containerd.go
+++ b/pkg/collector/corechecks/containers/containerd/containerd.go
@@ -92,7 +92,7 @@ func (c *ContainerdCheck) Configure(config, initConfig integration.Data, source 
 	}
 	c.filters = fil
 
-	c.client, err = cutil.GetContainerdUtil()
+	c.client, err = cutil.NewContainerdUtil()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/containers/containerd/containerd.go
+++ b/pkg/collector/corechecks/containers/containerd/containerd.go
@@ -8,6 +8,7 @@
 package containerd
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -46,6 +47,7 @@ type ContainerdCheck struct {
 	instance *ContainerdConfig
 	sub      *subscriber
 	filters  *ddContainers.Filter
+	client   cutil.ContainerdItf
 }
 
 // ContainerdConfig contains the custom options and configurations set by the user.
@@ -82,13 +84,18 @@ func (c *ContainerdCheck) Configure(config, initConfig integration.Data, source 
 	if err = c.instance.Parse(config); err != nil {
 		return err
 	}
-	c.sub.Filters = c.instance.ContainerdFilters
+	c.sub.Filters = c.subscribeFilters()
 	// GetSharedMetricFilter should not return a nil instance of *Filter if there is an error during its setup.
 	fil, err := ddContainers.GetSharedMetricFilter()
 	if err != nil {
 		return err
 	}
 	c.filters = fil
+
+	c.client, err = cutil.GetContainerdUtil()
+	if err != nil {
+		return err
+	}
 
 	return nil
 }
@@ -102,30 +109,40 @@ func (c *ContainerdCheck) Run() error {
 	defer sender.Commit()
 
 	// As we do not rely on a singleton, we ensure connectivity every check run.
-	cu, errHealth := cutil.GetContainerdUtil()
-	if errHealth != nil {
+	if errHealth := c.client.CheckConnectivity(); errHealth != nil {
 		sender.ServiceCheck("containerd.health", metrics.ServiceCheckCritical, "", nil, fmt.Sprintf("Connectivity error %v", errHealth))
 		log.Infof("Error ensuring connectivity with Containerd daemon %v", errHealth)
 		return errHealth
 	}
 	sender.ServiceCheck("containerd.health", metrics.ServiceCheckOK, "", nil, "")
-	ns := cu.Namespace()
 
 	if c.instance.CollectEvents {
 		if c.sub == nil {
-			c.sub = CreateEventSubscriber("ContainerdCheck", ns, c.instance.ContainerdFilters)
+			c.sub = CreateEventSubscriber("ContainerdCheck", c.subscribeFilters())
 		}
 
 		if !c.sub.IsRunning() {
-			// Keep track of the health of the Containerd socket
-			c.sub.CheckEvents(cu)
+			// Keep track of the health of the Containerd socket.
+			//
+			// Check events does not rely on the "namespace" attribute of the
+			// client, so we can share it.
+			c.sub.CheckEvents(c.client)
 		}
 		events := c.sub.Flush(time.Now().Unix())
 		// Process events
 		computeEvents(events, sender, c.filters)
 	}
 
-	computeMetrics(sender, cu, c.filters)
+	namespaces, err := cutil.NamespacesToWatch(context.TODO(), c.client)
+	if err != nil {
+		return err
+	}
+
+	for _, namespace := range namespaces {
+		c.client.SetCurrentNamespace(namespace)
+		computeMetrics(sender, c.client, c.filters)
+	}
+
 	return nil
 }
 
@@ -448,4 +465,23 @@ func computeStorageWindows(sender aggregator.Sender, storageStats *wstats.Window
 
 	sender.Rate("containerd.storage.read", float64(storageStats.ReadSizeBytes), "", tags)
 	sender.Rate("containerd.storage.write", float64(storageStats.WriteSizeBytes), "", tags)
+}
+
+// subscribeFilters returns the filters that we need to send to the containerd
+// events subscriber. This returns the user-provided filters present in the
+// config modified, if needed, to filter by namespace as well.
+func (c *ContainerdCheck) subscribeFilters() []string {
+	namespace := config.Datadog.GetString("containerd_namespace")
+
+	if namespace == "" {
+		// We don't need to filter by namespace
+		return c.instance.ContainerdFilters
+	}
+
+	var filters []string
+	for _, filter := range c.instance.ContainerdFilters {
+		filters = append(filters, fmt.Sprintf(`%s,namespace==%q`, filter, namespace))
+	}
+
+	return filters
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -521,13 +521,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("cri_query_timeout", int64(5))      // in seconds
 
 	// Containerd
-	if IsKubernetes() {
-		// By default containerd cri uses `k8s.io` https://github.com/containerd/cri/blob/release/1.2/pkg/constants/constants.go#L22-L23
-		config.BindEnvAndSetDefault("containerd_namespace", "k8s.io")
-	} else {
-		// Outside Kubernetes, watch all the namespaces by default
-		config.BindEnvAndSetDefault("containerd_namespace", "")
-	}
+	config.BindEnvAndSetDefault("containerd_namespace", "")
 	config.BindEnvAndSetDefault("container_env_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("container_labels_as_tags", map[string]string{})
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -521,8 +521,13 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("cri_query_timeout", int64(5))      // in seconds
 
 	// Containerd
-	// We only support containerd in Kubernetes. By default containerd cri uses `k8s.io` https://github.com/containerd/cri/blob/release/1.2/pkg/constants/constants.go#L22-L23
-	config.BindEnvAndSetDefault("containerd_namespace", "k8s.io")
+	if IsKubernetes() {
+		// By default containerd cri uses `k8s.io` https://github.com/containerd/cri/blob/release/1.2/pkg/constants/constants.go#L22-L23
+		config.BindEnvAndSetDefault("containerd_namespace", "k8s.io")
+	} else {
+		// Outside Kubernetes, watch all the namespaces by default
+		config.BindEnvAndSetDefault("containerd_namespace", "")
+	}
 	config.BindEnvAndSetDefault("container_env_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("container_labels_as_tags", map[string]string{})
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2322,11 +2322,11 @@ api_key:
 #
 # cri_query_timeout: 5
 
-## @param containerd_namespace - string - optional - default: k8s.io
-## @env DD_CONTAINERD_NAMESPACE - string - optional - default: k8s.io
+## @param containerd_namespace - string - optional - default: ""
+## @env DD_CONTAINERD_NAMESPACE - string - optional - default: ""
 ## Activating the Containerd check also activates the CRI check, as it contains an additional subset of useful metrics.
-## Specify here the namespace that Containerd is using on your system. When using Kubernetes it defaults to "k8s.io".
-## Outside Kubernetes, it defaults to "" which will report metrics and events from all namespaces.
+## Defaults to "" which configures the agent to report metrics and events from all the containerd namespaces.
+## If you would like to limit it to watch just one namespace, specify it here.
 ## https://github.com/containerd/cri/blob/release/1.2/pkg/constants/constants.go#L22-L23
 #
 # containerd_namespace: k8s.io

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2325,8 +2325,8 @@ api_key:
 ## @param containerd_namespace - string - optional - default: k8s.io
 ## @env DD_CONTAINERD_NAMESPACE - string - optional - default: k8s.io
 ## Activating the Containerd check also activates the CRI check, as it contains an additional subset of useful metrics.
-## Specify here the namespace that Containerd is using on your system. As the Containerd check
-## only supports Kubernetes, the default value is `k8s.io`
+## Specify here the namespace that Containerd is using on your system. When using Kubernetes it defaults to "k8s.io".
+## Outside Kubernetes, it defaults to "" which will report metrics and events from all namespaces.
 ## https://github.com/containerd/cri/blob/release/1.2/pkg/constants/constants.go#L22-L23
 #
 # containerd_namespace: k8s.io

--- a/pkg/util/containerd/containerd_util.go
+++ b/pkg/util/containerd/containerd_util.go
@@ -67,9 +67,9 @@ type ContainerdUtil struct {
 	namespace         string
 }
 
-// GetContainerdUtil creates the Containerd util containing the Containerd client and implementing the ContainerdItf
+// NewContainerdUtil creates the Containerd util containing the Containerd client and implementing the ContainerdItf
 // Errors are handled in the retrier.
-func GetContainerdUtil() (ContainerdItf, error) {
+func NewContainerdUtil() (ContainerdItf, error) {
 	// A singleton does not work because different parts of the code
 	// (workloadmeta, checks, etc.) might need to fetch info from different
 	// namespaces at the same time.

--- a/pkg/util/containerd/containerd_util.go
+++ b/pkg/util/containerd/containerd_util.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"errors"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -33,13 +32,10 @@ const (
 	containerdDefaultSocketPath = "/var/run/containerd/containerd.sock"
 )
 
-var (
-	globalContainerdUtil *ContainerdUtil
-	once                 sync.Once
-)
-
 // ContainerdItf is the interface implementing a subset of methods that leverage the Containerd api.
 type ContainerdItf interface {
+	Close() error
+	CheckConnectivity() *retry.Error
 	Container(id string) (containerd.Container, error)
 	ContainerWithContext(ctx context.Context, id string) (containerd.Container, error)
 	Containers() ([]containerd.Container, error)
@@ -53,7 +49,9 @@ type ContainerdItf interface {
 	Spec(ctn containerd.Container) (*oci.Spec, error)
 	SpecWithContext(ctx context.Context, ctn containerd.Container) (*oci.Spec, error)
 	Metadata() (containerd.Version, error)
-	Namespace() string
+	CurrentNamespace() string
+	SetCurrentNamespace(namespace string)
+	Namespaces(ctx context.Context) ([]string, error)
 	TaskMetrics(ctn containerd.Container) (*types.Metric, error)
 	TaskPids(ctn containerd.Container) ([]containerd.ProcessInfo, error)
 	Status(ctn containerd.Container) (containerd.ProcessStatus, error)
@@ -72,35 +70,50 @@ type ContainerdUtil struct {
 // GetContainerdUtil creates the Containerd util containing the Containerd client and implementing the ContainerdItf
 // Errors are handled in the retrier.
 func GetContainerdUtil() (ContainerdItf, error) {
-	once.Do(func() {
-		globalContainerdUtil = &ContainerdUtil{
-			queryTimeout:      config.Datadog.GetDuration("cri_query_timeout") * time.Second,
-			connectionTimeout: config.Datadog.GetDuration("cri_connection_timeout") * time.Second,
-			socketPath:        config.Datadog.GetString("cri_socket_path"),
-			namespace:         config.Datadog.GetString("containerd_namespace"),
-		}
-		if globalContainerdUtil.socketPath == "" {
-			log.Info("No socket path was specified, defaulting to /var/run/containerd/containerd.sock")
-			globalContainerdUtil.socketPath = containerdDefaultSocketPath
-		}
-		// Initialize the client in the connect method
-		globalContainerdUtil.initRetry.SetupRetrier(&retry.Config{ //nolint:errcheck
-			Name:              "containerdutil",
-			AttemptMethod:     globalContainerdUtil.connect,
-			Strategy:          retry.Backoff,
-			InitialRetryDelay: 1 * time.Second,
-			MaxRetryDelay:     5 * time.Minute,
-		})
+	// A singleton does not work because different parts of the code
+	// (workloadmeta, checks, etc.) might need to fetch info from different
+	// namespaces at the same time.
+	containerdUtil := &ContainerdUtil{
+		queryTimeout:      config.Datadog.GetDuration("cri_query_timeout") * time.Second,
+		connectionTimeout: config.Datadog.GetDuration("cri_connection_timeout") * time.Second,
+		socketPath:        config.Datadog.GetString("cri_socket_path"),
+		namespace:         config.Datadog.GetString("containerd_namespace"),
+	}
+	if containerdUtil.socketPath == "" {
+		log.Info("No socket path was specified, defaulting to /var/run/containerd/containerd.sock")
+		containerdUtil.socketPath = containerdDefaultSocketPath
+	}
+	// Initialize the client in the connect method
+	containerdUtil.initRetry.SetupRetrier(&retry.Config{ //nolint:errcheck
+		Name:              "containerdutil",
+		AttemptMethod:     containerdUtil.connect,
+		Strategy:          retry.Backoff,
+		InitialRetryDelay: 1 * time.Second,
+		MaxRetryDelay:     5 * time.Minute,
 	})
-	if err := globalContainerdUtil.initRetry.TriggerRetry(); err != nil {
+
+	if err := containerdUtil.CheckConnectivity(); err != nil {
 		log.Errorf("Containerd init error: %s", err.Error())
 		return nil, err
 	}
-	return globalContainerdUtil, nil
+
+	return containerdUtil, nil
 }
 
-func (c *ContainerdUtil) Namespace() string {
+func (c *ContainerdUtil) CheckConnectivity() *retry.Error {
+	return c.initRetry.TriggerRetry()
+}
+
+func (c *ContainerdUtil) CurrentNamespace() string {
 	return c.namespace
+}
+
+func (c *ContainerdUtil) SetCurrentNamespace(namespace string) {
+	c.namespace = namespace
+}
+
+func (c *ContainerdUtil) Namespaces(ctx context.Context) ([]string, error) {
+	return c.cl.NamespaceService().List(ctx)
 }
 
 // Metadata is used to collect the version and revision of the Containerd API

--- a/pkg/util/containerd/diagnosis.go
+++ b/pkg/util/containerd/diagnosis.go
@@ -17,6 +17,10 @@ func init() {
 
 // diagnose the Containerd socket connectivity
 func diagnose() error {
-	_, err := GetContainerdUtil()
-	return err
+	client, err := GetContainerdUtil()
+	if err != nil {
+		return err
+	}
+
+	return client.Close()
 }

--- a/pkg/util/containerd/diagnosis.go
+++ b/pkg/util/containerd/diagnosis.go
@@ -17,7 +17,7 @@ func init() {
 
 // diagnose the Containerd socket connectivity
 func diagnose() error {
-	client, err := GetContainerdUtil()
+	client, err := NewContainerdUtil()
 	if err != nil {
 		return err
 	}

--- a/pkg/util/containerd/namespaces.go
+++ b/pkg/util/containerd/namespaces.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build containerd
+
+package containerd
+
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+// NamespacesToWatch returns the namespaces to watch. If the
+// "containerd_namespace" option has been set, it returns that namespace.
+// Otherwise, it returns all of them.
+func NamespacesToWatch(ctx context.Context, containerdClient ContainerdItf) ([]string, error) {
+	if namespace := config.Datadog.GetString("containerd_namespace"); namespace != "" {
+		return []string{namespace}, nil
+	}
+
+	return containerdClient.Namespaces(ctx)
+}

--- a/pkg/util/containerd/namespaces_test.go
+++ b/pkg/util/containerd/namespaces_test.go
@@ -1,0 +1,75 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build containerd
+
+package containerd
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+type mockedContainerdClient struct {
+	ContainerdItf
+	mockNamespaces func(ctx context.Context) ([]string, error)
+}
+
+func (m *mockedContainerdClient) Namespaces(ctx context.Context) ([]string, error) {
+	return m.mockNamespaces(ctx)
+}
+
+func TestNamespacesToWatch(t *testing.T) {
+	tests := []struct {
+		name                   string
+		containerdNamespaceVal string
+		client                 mockedContainerdClient
+		expectedNamespaces     []string
+		expectsError           bool
+	}{
+		{
+			name:                   "containerd_namespace set",
+			containerdNamespaceVal: "some_namespace",
+			expectedNamespaces:     []string{"some_namespace"},
+			expectsError:           false,
+		},
+		{
+			name:                   "containerd_namespace not set",
+			containerdNamespaceVal: "",
+			client: mockedContainerdClient{mockNamespaces: func(ctx context.Context) ([]string, error) {
+				return []string{"namespace_1", "namespace_2"}, nil
+			}},
+			expectedNamespaces: []string{"namespace_1", "namespace_2"},
+			expectsError:       false,
+		},
+		{
+			name: "error when getting namespaces",
+			client: mockedContainerdClient{mockNamespaces: func(ctx context.Context) ([]string, error) {
+				return nil, errors.New("some error")
+			}},
+			containerdNamespaceVal: "",
+			expectsError:           true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config.Datadog.Set("containerd_namespace", test.containerdNamespaceVal)
+			namespaces, err := NamespacesToWatch(context.TODO(), &test.client)
+
+			if test.expectsError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expectedNamespaces, namespaces)
+			}
+		})
+	}
+}

--- a/pkg/util/containers/v2/metrics/containerd/collector.go
+++ b/pkg/util/containers/v2/metrics/containerd/collector.go
@@ -58,7 +58,7 @@ func newContainerdCollector() (*containerdCollector, error) {
 		return nil, provider.ErrPermaFail
 	}
 
-	client, err := cutil.GetContainerdUtil()
+	client, err := cutil.NewContainerdUtil()
 	if err != nil {
 		return nil, provider.ConvertRetrierErr(err)
 	}

--- a/pkg/workloadmeta/collectors/containerd/containerd.go
+++ b/pkg/workloadmeta/collectors/containerd/containerd.go
@@ -45,17 +45,17 @@ const (
 	TaskResumedTopic = "/tasks/resumed"
 )
 
-// containerLifecycleFilters allows subscribing to containers lifecycle updates only.
-var containerLifecycleFilters = []string{
-	fmt.Sprintf(`topic==%q`, containerCreationTopic),
-	fmt.Sprintf(`topic==%q`, containerUpdateTopic),
-	fmt.Sprintf(`topic==%q`, containerDeletionTopic),
-	fmt.Sprintf(`topic==%q`, TaskStartTopic),
-	fmt.Sprintf(`topic==%q`, TaskOOMTopic),
-	fmt.Sprintf(`topic==%q`, TaskExitTopic),
-	fmt.Sprintf(`topic==%q`, TaskDeleteTopic),
-	fmt.Sprintf(`topic==%q`, TaskPausedTopic),
-	fmt.Sprintf(`topic==%q`, TaskResumedTopic),
+// containerdTopics includes the containerd topics that we want to subscribe to
+var containerdTopics = []string{
+	containerCreationTopic,
+	containerUpdateTopic,
+	containerDeletionTopic,
+	TaskStartTopic,
+	TaskOOMTopic,
+	TaskExitTopic,
+	TaskDeleteTopic,
+	TaskPausedTopic,
+	TaskResumedTopic,
 }
 
 type collector struct {
@@ -91,7 +91,7 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Store) error {
 	}
 
 	eventsCtx, cancelEvents := context.WithCancel(ctx)
-	c.eventsChan, c.errorsChan = c.containerdClient.GetEvents().Subscribe(eventsCtx, containerLifecycleFilters...)
+	c.eventsChan, c.errorsChan = c.containerdClient.GetEvents().Subscribe(eventsCtx, subscribeFilters()...)
 
 	err = c.generateEventsFromContainerList(ctx)
 	if err != nil {
@@ -100,7 +100,13 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Store) error {
 	}
 
 	go func() {
+		defer func() {
+			if errClose := c.containerdClient.Close(); errClose != nil {
+				log.Warnf("Error when closing containerd connection: %s", errClose)
+			}
+		}()
 		defer cancelEvents()
+
 		c.stream(ctx)
 	}()
 
@@ -143,20 +149,30 @@ func (c *collector) stream(ctx context.Context) {
 }
 
 func (c *collector) generateEventsFromContainerList(ctx context.Context) error {
-	containerdEvents, err := c.generateInitialEvents(ctx)
+	var events []workloadmeta.CollectorEvent
+
+	namespaces, err := cutil.NamespacesToWatch(ctx, c.containerdClient)
 	if err != nil {
 		return err
 	}
 
-	events := make([]workloadmeta.CollectorEvent, 0, len(containerdEvents))
-	for _, containerdEvent := range containerdEvents {
-		ev, err := buildCollectorEvent(ctx, &containerdEvent, c.containerdClient)
+	for _, namespace := range namespaces {
+		c.containerdClient.SetCurrentNamespace(namespace)
+
+		containerdEvents, err := c.generateInitialEvents(ctx, namespace)
 		if err != nil {
-			log.Warnf(err.Error())
-			continue
+			return err
 		}
 
-		events = append(events, ev)
+		for _, containerdEvent := range containerdEvents {
+			ev, err := buildCollectorEvent(ctx, &containerdEvent, c.containerdClient)
+			if err != nil {
+				log.Warnf(err.Error())
+				continue
+			}
+
+			events = append(events, ev)
+		}
 	}
 
 	if len(events) > 0 {
@@ -166,7 +182,7 @@ func (c *collector) generateEventsFromContainerList(ctx context.Context) error {
 	return nil
 }
 
-func (c *collector) generateInitialEvents(ctx context.Context) ([]containerdevents.Envelope, error) {
+func (c *collector) generateInitialEvents(ctx context.Context, namespace string) ([]containerdevents.Envelope, error) {
 	var events []containerdevents.Envelope
 
 	existingContainers, err := c.containerdClient.Containers()
@@ -184,6 +200,7 @@ func (c *collector) generateInitialEvents(ctx context.Context) ([]containerdeven
 
 		event := containerdevents.Envelope{
 			Timestamp: time.Now(),
+			Namespace: namespace,
 			Topic:     containerCreationTopic,
 			Event: &types.Any{
 				TypeUrl: "containerd.events.ContainerCreate",
@@ -207,6 +224,8 @@ func (c *collector) generateInitialEvents(ctx context.Context) ([]containerdeven
 }
 
 func (c *collector) handleEvent(ctx context.Context, containerdEvent *containerdevents.Envelope) error {
+	c.containerdClient.SetCurrentNamespace(containerdEvent.Namespace)
+
 	ignore, err := c.ignoreEvent(ctx, containerdEvent)
 	if err != nil {
 		return err
@@ -257,4 +276,34 @@ func (c *collector) ignoreEvent(ctx context.Context, containerdEvent *containerd
 
 	// Only the image name is relevant to exclude paused containers
 	return c.filterPausedContainers.IsExcluded("", img.Name(), ""), nil
+}
+
+// subscribeFilters returns the containerd filters we need to subscribe to based
+// on the "containerd_namespace" option and the containerdTopics array defined.
+//
+// When "containerd_namespace" is empty, it means that we don't want to filter
+// by namespace. In that case, the filters only include topics.
+//
+// When the namespace is not empty, we need to include it on every filter. If we
+// define a filter with the TaskStartTopic topic and a second filter with a
+// namespace, we will receive an event when it is a TaskStartTopic OR
+// (inclusive) when the namespace is the one that we selected. What we need is
+// to only receive events that match both conditions and that's why they need to
+// be specified in the same filter.
+func subscribeFilters() []string {
+	namespace := config.Datadog.GetString("containerd_namespace")
+
+	var filters []string
+
+	for _, topic := range containerdTopics {
+		var filter string
+		if namespace == "" {
+			filter = fmt.Sprintf(`topic==%q`, topic)
+		} else {
+			filter = fmt.Sprintf(`topic==%q,namespace==%q`, topic, namespace)
+		}
+		filters = append(filters, filter)
+	}
+
+	return filters
 }

--- a/pkg/workloadmeta/collectors/containerd/containerd.go
+++ b/pkg/workloadmeta/collectors/containerd/containerd.go
@@ -80,7 +80,7 @@ func (c *collector) Start(ctx context.Context, store workloadmeta.Store) error {
 	c.store = store
 
 	var err error
-	c.containerdClient, err = cutil.GetContainerdUtil()
+	c.containerdClient, err = cutil.NewContainerdUtil()
 	if err != nil {
 		return err
 	}

--- a/pkg/workloadmeta/collectors/containerd/event_builder_test.go
+++ b/pkg/workloadmeta/collectors/containerd/event_builder_test.go
@@ -26,6 +26,7 @@ import (
 
 func TestBuildCollectorEvent(t *testing.T) {
 	containerID := "10"
+	namespace := "test_namespace"
 
 	container := mockedContainer{
 		mockID: func() string {
@@ -36,6 +37,7 @@ func TestBuildCollectorEvent(t *testing.T) {
 	client := containerdClient(&container)
 
 	workloadMetaContainer, err := buildWorkloadMetaContainer(&container, &client)
+	workloadMetaContainer.Namespace = namespace
 	assert.NoError(t, err)
 
 	containerCreationEvent, err := proto.Marshal(&events.ContainerCreate{
@@ -97,7 +99,8 @@ func TestBuildCollectorEvent(t *testing.T) {
 		{
 			name: "container create event",
 			event: containerdevents.Envelope{
-				Topic: containerCreationTopic,
+				Namespace: namespace,
+				Topic:     containerCreationTopic,
 				Event: &types.Any{
 					TypeUrl: "containerd.events.ContainerCreate", Value: containerCreationEvent,
 				},
@@ -111,7 +114,8 @@ func TestBuildCollectorEvent(t *testing.T) {
 		{
 			name: "container update event",
 			event: containerdevents.Envelope{
-				Topic: containerUpdateTopic,
+				Namespace: namespace,
+				Topic:     containerUpdateTopic,
 				Event: &types.Any{
 					TypeUrl: "containerd.events.ContainerUpdate", Value: containerUpdateEvent,
 				},
@@ -125,7 +129,8 @@ func TestBuildCollectorEvent(t *testing.T) {
 		{
 			name: "container delete event",
 			event: containerdevents.Envelope{
-				Topic: containerDeletionTopic,
+				Namespace: namespace,
+				Topic:     containerDeletionTopic,
 				Event: &types.Any{
 					TypeUrl: "containerd.events.ContainerDelete", Value: containerDeleteEvent,
 				},
@@ -142,7 +147,8 @@ func TestBuildCollectorEvent(t *testing.T) {
 		{
 			name: "unknown event",
 			event: containerdevents.Envelope{
-				Topic: "Unknown Topic", // This causes the error
+				Namespace: namespace,
+				Topic:     "Unknown Topic", // This causes the error
 				Event: &types.Any{
 					// Uses delete, but could be any other event in this test
 					TypeUrl: "containerd.events.ContainerDelete", Value: containerDeleteEvent,
@@ -153,7 +159,8 @@ func TestBuildCollectorEvent(t *testing.T) {
 		{
 			name: "event without ID",
 			event: containerdevents.Envelope{
-				Topic: containerCreationTopic,
+				Namespace: namespace,
+				Topic:     containerCreationTopic,
 				Event: &types.Any{
 					TypeUrl: "containerd.events.ContainerCreate", Value: eventWithoutID,
 				},
@@ -163,7 +170,8 @@ func TestBuildCollectorEvent(t *testing.T) {
 		{
 			name: "task start event",
 			event: containerdevents.Envelope{
-				Topic: TaskStartTopic,
+				Namespace: namespace,
+				Topic:     TaskStartTopic,
 				Event: &types.Any{
 					TypeUrl: "containerd.events.TaskStart", Value: taskStartEvent,
 				},
@@ -177,7 +185,8 @@ func TestBuildCollectorEvent(t *testing.T) {
 		{
 			name: "task OOM event",
 			event: containerdevents.Envelope{
-				Topic: TaskOOMTopic,
+				Namespace: namespace,
+				Topic:     TaskOOMTopic,
 				Event: &types.Any{
 					TypeUrl: "containerd.events.TaskOOM", Value: taskOOMEvent,
 				},
@@ -191,7 +200,8 @@ func TestBuildCollectorEvent(t *testing.T) {
 		{
 			name: "task exit event",
 			event: containerdevents.Envelope{
-				Topic: TaskExitTopic,
+				Namespace: namespace,
+				Topic:     TaskExitTopic,
 				Event: &types.Any{
 					TypeUrl: "containerd.events.TaskExit", Value: taskExitEvent,
 				},
@@ -205,7 +215,8 @@ func TestBuildCollectorEvent(t *testing.T) {
 		{
 			name: "task delete event",
 			event: containerdevents.Envelope{
-				Topic: TaskDeleteTopic,
+				Namespace: namespace,
+				Topic:     TaskDeleteTopic,
 				Event: &types.Any{
 					TypeUrl: "containerd.events.TaskDelete", Value: taskDeleteEvent,
 				},
@@ -219,7 +230,8 @@ func TestBuildCollectorEvent(t *testing.T) {
 		{
 			name: "task paused event",
 			event: containerdevents.Envelope{
-				Topic: TaskStartTopic,
+				Namespace: namespace,
+				Topic:     TaskStartTopic,
 				Event: &types.Any{
 					TypeUrl: "containerd.events.TaskPaused", Value: taskPausedEvent,
 				},
@@ -233,7 +245,8 @@ func TestBuildCollectorEvent(t *testing.T) {
 		{
 			name: "task resumed event",
 			event: containerdevents.Envelope{
-				Topic: TaskStartTopic,
+				Namespace: namespace,
+				Topic:     TaskStartTopic,
 				Event: &types.Any{
 					TypeUrl: "containerd.events.TaskResumed", Value: taskResumedEvent,
 				},

--- a/releasenotes/notes/containerd-all-namespaces-67ca51b407c1e1a1.yaml
+++ b/releasenotes/notes/containerd-all-namespaces-67ca51b407c1e1a1.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Added possibility to watch all the namespaces when running on containerd
+    outside Kubernetes. By default, the agent will report events and metrics
+    from all the namespaces. In order to select a specific one, please set the
+    `containerd_namespace` option.


### PR DESCRIPTION
### What does this PR do?

This PR adds the possibility to report metrics and events from all the namespaces when using containerd outside Kubernetes.

Currently, the `containerd_namespace` option controls the containerd namespace to monitor. It defaults to “k8s.io” because it’s the one used by Kubernetes.

This PR now detects if the agent is running outside Kubernetes, and in that case, it monitor all the containerd namespaces. Users can still set `containerd_namespace` if they only want to monitor one, this PR does not break backwards compatibility.

There are 3 features affected by this change:
- Workloadmeta containerd collector.
- Containerd collector for the generic container check.
- Containerd check (metrics and events).


### Describe how to test/QA your changes

You’ll need to deploy an agent in an environment with containerd (no Kubernetes). When using Mac, Lima is a good option to set the environment: https://github.com/lima-vm/lima

First, run the agent without specifying `DD_CONTAINERD_NAMESPACE` and we’ll verify that it reports data from all the namespaces.

You need to run the agent with `-v /var/run/containerd/containerd.sock:/var/run/containerd/containerd.sock:ro` and `-v /sys/fs/cgroup/:/host/sys/fs/cgroup:ro`. Don’t mount `/proc`, that way we’ll force the agent to use the containerd collector for the generic container check, instead of the `system` collector.

Deploy a couple of containers in different namespaces. For example:
`nerdctl --namespace=default run —rm redis`
`nerdctl --namespace=another run  —rm redis`

1) Run `agent workload-list` and verify that it shows the containers from both namespaces.
2) Check that the agent is reporting `containerd.*` metrics for the containers in both namespaces. Also, you should see events like container created, deleted, etc. from both namespaces.
3) Check that the agent is reporting `container.*` metrics for the containers in both namespaces.

Try the same thing but specifying a namespace with `DD_CONTAINERD_NAMESPACE`. Repeat the 3 steps above and check that the metrics and events come only from the namespace selected.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
