### PR TITLE
pkg/obfuscate: Expose more SQL tokeniser state

### DIFF
--- a/pkg/obfuscate/sql_tokenizer.go
+++ b/pkg/obfuscate/sql_tokenizer.go
@@ -382,6 +382,8 @@ func (tkn *SQLTokenizer) Scan() (TokenKind, []byte) {
 	}
 }
 
+// SkipBlank moves the tokenizer forward until hitting a non-whitespace character
+// The whitespace definition used here is the same as unicode.IsSpace
 func (tkn *SQLTokenizer) SkipBlank() {
 	for unicode.IsSpace(tkn.lastChar) {
 		tkn.advance()
@@ -732,6 +734,7 @@ func (tkn *SQLTokenizer) bytes() []byte {
 	return ret
 }
 
+// Offset exports the tokenizer's current position in the query
 func (tkn *SQLTokenizer) Offset() int {
 	return tkn.off
 }

--- a/pkg/obfuscate/sql_tokenizer.go
+++ b/pkg/obfuscate/sql_tokenizer.go
@@ -205,7 +205,7 @@ func (tkn *SQLTokenizer) Scan() (TokenKind, []byte) {
 	if tkn.lastChar == 0 {
 		tkn.advance()
 	}
-	tkn.skipBlank()
+	tkn.SkipBlank()
 
 	switch ch := tkn.lastChar; {
 	case isLeadingLetter(ch):
@@ -382,7 +382,7 @@ func (tkn *SQLTokenizer) Scan() (TokenKind, []byte) {
 	}
 }
 
-func (tkn *SQLTokenizer) skipBlank() {
+func (tkn *SQLTokenizer) SkipBlank() {
 	for unicode.IsSpace(tkn.lastChar) {
 		tkn.advance()
 	}

--- a/pkg/obfuscate/sql_tokenizer.go
+++ b/pkg/obfuscate/sql_tokenizer.go
@@ -732,6 +732,10 @@ func (tkn *SQLTokenizer) bytes() []byte {
 	return ret
 }
 
+func (tkn *SQLTokenizer) Offset() int {
+	return tkn.off
+}
+
 func isLeadingLetter(ch rune) bool {
 	return unicode.IsLetter(ch) || ch == '_' || ch == '@'
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR exports some state from the SQL tokeniser enabling the repurposing of the tokeniser outside of simple obfuscation.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The new primitives enable a piece of code to work off tokens, then to export the start/end indices of a token sequence in the original query.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
