### PR TITLE
Updating cloudprovider.GetHostAliases to make it generic

### DIFF
--- a/pkg/util/cachedfetch/fetcher.go
+++ b/pkg/util/cachedfetch/fetcher.go
@@ -80,6 +80,15 @@ func (f *Fetcher) FetchString(ctx context.Context) (string, error) {
 	return v.(string), nil
 }
 
+// FetchStringSlice is a convenience wrapper around Fetch that returns a string
+func (f *Fetcher) FetchStringSlice(ctx context.Context) ([]string, error) {
+	v, err := f.Fetch(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return v.([]string), nil
+}
+
 // Reset resets the cached value (used for testing)
 func (f *Fetcher) Reset() {
 	f.Lock()

--- a/pkg/util/cachedfetch/fetcher_test.go
+++ b/pkg/util/cachedfetch/fetcher_test.go
@@ -109,6 +109,26 @@ func TestFetchStringError(t *testing.T) {
 	require.Error(t, err)
 }
 
+// FetchStringSlice casts to a []string
+func TestFetchStringSlice(t *testing.T) {
+	f := Fetcher{
+		Attempt: func(ctx context.Context) (interface{}, error) { return []string{"hello"}, nil },
+	}
+	v, err := f.FetchStringSlice(context.TODO())
+	require.Equal(t, []string{"hello"}, v)
+	require.NoError(t, err)
+}
+
+// FetchStringSlice casts to a []string
+func TestFetchStringSliceError(t *testing.T) {
+	f := Fetcher{
+		Attempt: func(ctx context.Context) (interface{}, error) { return nil, fmt.Errorf("uhoh") },
+	}
+	v, err := f.FetchStringSlice(context.TODO())
+	require.Nil(t, v)
+	require.Error(t, err)
+}
+
 func TestReset(t *testing.T) {
 	succeed := func(ctx context.Context) (interface{}, error) { return "yay", nil }
 	fail := func(ctx context.Context) (interface{}, error) { return nil, fmt.Errorf("uhoh") }

--- a/pkg/util/cloudproviders/alibaba/alibaba_test.go
+++ b/pkg/util/cloudproviders/alibaba/alibaba_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
@@ -29,9 +30,10 @@ func TestGetHostname(t *testing.T) {
 	defer ts.Close()
 	metadataURL = ts.URL
 
-	val, err := GetHostAlias(ctx)
+	aliases, err := GetHostAliases(ctx)
 	assert.Nil(t, err)
-	assert.Equal(t, expected, val)
+	require.Len(t, aliases, 1)
+	assert.Equal(t, expected, aliases[0])
 	assert.Equal(t, lastRequest.URL.Path, "/latest/meta-data/instance-id")
 }
 

--- a/pkg/util/cloudproviders/alibaba/diagnosis.go
+++ b/pkg/util/cloudproviders/alibaba/diagnosis.go
@@ -17,6 +17,6 @@ func init() {
 
 // diagnose the alibaba metadata API availability
 func diagnose() error {
-	_, err := GetHostAlias(context.TODO())
+	_, err := GetHostAliases(context.TODO())
 	return err
 }

--- a/pkg/util/cloudproviders/azure/azure.go
+++ b/pkg/util/cloudproviders/azure/azure.go
@@ -31,7 +31,7 @@ const hostnameStyleSetting = "azure_hostname_style"
 
 // IsRunningOn returns true if the agent is running on Azure
 func IsRunningOn(ctx context.Context) bool {
-	if _, err := GetHostAlias(ctx); err == nil {
+	if _, err := GetHostAliases(ctx); err == nil {
 		return true
 	}
 	return false
@@ -44,15 +44,15 @@ var vmIDFetcher = cachedfetch.Fetcher{
 			metadataURL+"/metadata/instance/compute/vmId?api-version=2017-04-02&format=text",
 			config.Datadog.GetInt("metadata_endpoints_max_hostname_size"))
 		if err != nil {
-			return "", fmt.Errorf("Azure HostAliases: unable to query metadata endpoint: %s", err)
+			return nil, fmt.Errorf("Azure HostAliases: unable to query metadata endpoint: %s", err)
 		}
-		return res, nil
+		return []string{res}, nil
 	},
 }
 
-// GetHostAlias returns the VM ID from the Azure Metadata api
-func GetHostAlias(ctx context.Context) (string, error) {
-	return vmIDFetcher.FetchString(ctx)
+// GetHostAliases returns the VM ID from the Azure Metadata api
+func GetHostAliases(ctx context.Context) ([]string, error) {
+	return vmIDFetcher.FetchStringSlice(ctx)
 }
 
 var resourceGroupNameFetcher = cachedfetch.Fetcher{

--- a/pkg/util/cloudproviders/azure/azure_test.go
+++ b/pkg/util/cloudproviders/azure/azure_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
@@ -30,9 +31,10 @@ func TestGetAlias(t *testing.T) {
 	defer ts.Close()
 	metadataURL = ts.URL
 
-	val, err := GetHostAlias(ctx)
+	aliases, err := GetHostAliases(ctx)
 	assert.Nil(t, err)
-	assert.Equal(t, expected, val)
+	require.Len(t, aliases, 1)
+	assert.Equal(t, expected, aliases[0])
 	assert.Equal(t, lastRequest.URL.Path, "/metadata/instance/compute/vmId")
 	assert.Equal(t, lastRequest.URL.RawQuery, "api-version=2017-04-02&format=text")
 }

--- a/pkg/util/cloudproviders/azure/diagnosis.go
+++ b/pkg/util/cloudproviders/azure/diagnosis.go
@@ -17,6 +17,6 @@ func init() {
 
 // diagnose the azure metadata API availability
 func diagnose() error {
-	_, err := GetHostAlias(context.TODO())
+	_, err := GetHostAliases(context.TODO())
 	return err
 }

--- a/pkg/util/cloudproviders/cloudfoundry/cloudfoundry.go
+++ b/pkg/util/cloudproviders/cloudfoundry/cloudfoundry.go
@@ -15,6 +15,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util"
 )
 
+var (
+	// CloudProviderName is the name for this cloudprovider
+	CloudProviderName = "CloudFoundry"
+)
+
 // Define alias in order to mock in the tests
 var getFqdn = util.Fqdn
 

--- a/pkg/util/cloudproviders/tencent/tencent.go
+++ b/pkg/util/cloudproviders/tencent/tencent.go
@@ -33,9 +33,13 @@ func IsRunningOn(ctx context.Context) bool {
 	return false
 }
 
-// GetHostAlias returns the VM ID from the Tencent Metadata api
-func GetHostAlias(ctx context.Context) (string, error) {
-	return GetInstanceID(ctx)
+// GetHostAliases returns the VM ID from the Tencent Metadata api
+func GetHostAliases(ctx context.Context) ([]string, error) {
+	alias, err := GetInstanceID(ctx)
+	if err == nil {
+		return []string{alias}, nil
+	}
+	return nil, err
 }
 
 var instanceIDFetcher = cachedfetch.Fetcher{

--- a/pkg/util/cloudproviders/tencent/tencent_test.go
+++ b/pkg/util/cloudproviders/tencent/tencent_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGetInstanceID(t *testing.T) {
@@ -38,7 +39,34 @@ func TestGetInstanceID(t *testing.T) {
 	assert.Equal(t, lastRequest.URL.Path, "/meta-data/instance-id")
 }
 
+func TestGetHostAliases(t *testing.T) {
+	ctx := context.Background()
+	holdValue := config.Datadog.Get("cloud_provider_metadata")
+	defer config.Datadog.Set("cloud_provider_metadata", holdValue)
+	config.Datadog.Set("cloud_provider_metadata", []string{"tencent"})
+
+	expected := "ins-nad6bga0"
+	var lastRequest *http.Request
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		io.WriteString(w, expected)
+		lastRequest = r
+	}))
+	defer ts.Close()
+	metadataURL = ts.URL
+
+	aliases, err := GetHostAliases(ctx)
+	assert.NoError(t, err)
+	require.Len(t, aliases, 1)
+	assert.Equal(t, expected, aliases[0])
+	assert.Equal(t, lastRequest.URL.Path, "/meta-data/instance-id")
+}
+
 func TestGetNTPHosts(t *testing.T) {
+	holdValue := config.Datadog.Get("cloud_provider_metadata")
+	defer config.Datadog.Set("cloud_provider_metadata", holdValue)
+	config.Datadog.Set("cloud_provider_metadata", []string{"tencent"})
+
 	ctx := context.Background()
 	expectedHosts := []string{"ntpupdate.tencentyun.com"}
 
@@ -49,7 +77,6 @@ func TestGetNTPHosts(t *testing.T) {
 	defer ts.Close()
 
 	metadataURL = ts.URL
-	config.Datadog.Set("cloud_provider_metadata", []string{"tencent"})
 	actualHosts := GetNTPHosts(ctx)
 
 	assert.Equal(t, expectedHosts, actualHosts)

--- a/pkg/util/hostname/kubelet/host_alias.go
+++ b/pkg/util/hostname/kubelet/host_alias.go
@@ -14,13 +14,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/hostname/validate"
 )
 
-// GetHostAlias uses the "kubelet" hostname provider to fetch the kubernetes alias
-func GetHostAlias(ctx context.Context) (string, error) {
+// GetHostAliases uses the "kubelet" hostname provider to fetch the kubernetes alias
+func GetHostAliases(ctx context.Context) ([]string, error) {
 	name, err := HostnameProvider(ctx, nil)
 	if err == nil && validate.ValidHostname(name) == nil {
-		return name, nil
+		return []string{name}, nil
 	}
-	return "", fmt.Errorf("couldn't extract a host alias from the kubelet: %s", err)
+	return nil, fmt.Errorf("couldn't extract a host alias from the kubelet: %s", err)
 }
 
 // GetMetaClusterNameText returns the clusterName text for the agent status output. Returns "" if the feature kubernetes is not activated

--- a/pkg/util/hostname/kubelet/no_host_alias.go
+++ b/pkg/util/hostname/kubelet/no_host_alias.go
@@ -12,9 +12,9 @@ import (
 	"fmt"
 )
 
-// GetHostAlias uses the "kubelet" hostname provider to fetch the kubernetes alias
-func GetHostAlias(ctx context.Context) (string, error) {
-	return "", fmt.Errorf("Kubernetes support not build: couldn't extract a host alias from the kubelet")
+// GetHostAliases uses the "kubelet" hostname provider to fetch the kubernetes alias
+func GetHostAliases(ctx context.Context) ([]string, error) {
+	return nil, fmt.Errorf("Kubernetes support not build: couldn't extract a host alias from the kubelet")
 }
 
 // GetMetaClusterNameText returns the clusterName text for the agent status output


### PR DESCRIPTION
### What does this PR do?

Now all cloudproviders share the same API to fetch host aliases.

### Motivation

This will make adding new cloudprovider easier.

### Describe how to test/QA your changes

Install the Agent on Alibaba, Tencent, Azure and/or k8s and check that the metadata are still the same.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
