### PR TITLE
[networks] Fix HTTP monitoring for Kernel 4.4

### DIFF
--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -34,7 +34,7 @@ kitchen_test_system_probe_linux_x64:
   parallel:
     matrix:
       - KITCHEN_PLATFORM: "ubuntu"
-        KITCHEN_OSVERS: "ubuntu-16-04,ubuntu-18-04,ubuntu-20-04"
+        KITCHEN_OSVERS: "ubuntu-16-04-4.4,ubuntu-18-04,ubuntu-20-04"
       - KITCHEN_PLATFORM: "debian"
         KITCHEN_OSVERS: "debian-10"
       - KITCHEN_PLATFORM: "centos"
@@ -61,7 +61,7 @@ kitchen_test_system_probe_linux_arm64:
       - KITCHEN_PLATFORM: "debian"
         KITCHEN_OSVERS: "debian-10"
       - KITCHEN_PLATFORM: "centos"
-        KITCHEN_OSVERS: "centos-78,rhel-83"    
+        KITCHEN_OSVERS: "centos-78,rhel-83"
 
 kitchen_test_system_probe_windows_x64:
   extends:

--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Conntrack = NewRuntimeAsset("conntrack.c", "a72a9cf2b321f8825b1733b72e264a5df37c1aa280f0ff65c3900a5df84c993c")
+var Conntrack = NewRuntimeAsset("conntrack.c", "e34de8a231ee69af4215443bc67a52c524be6b093709a80dc03cd05a15dbdc7a")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Http = NewRuntimeAsset("http.c", "651b57aba4f385486acc1e5904cbc416d20c3b14909d0665e258d012b48b9873")
+var Http = NewRuntimeAsset("http.c", "19e36958dbd1971412a180a49bda633e9373319820fa9bfeb2af5a81272b1eee")

--- a/pkg/network/ebpf/c/http-buffer.h
+++ b/pkg/network/ebpf/c/http-buffer.h
@@ -1,0 +1,28 @@
+#ifndef __HTTP_BUFFER_H
+#define __HTTP_BUFFER_H
+
+#include "http-types.h"
+
+// read_into_buffer copies data from an arbitrary memory address into a (statically sized) HTTP buffer.
+// Ideally we would only copy min(data_size, HTTP_BUFFER_SIZE) bytes, but the code below is the only way
+// we found to handle data sizes smaller than HTTP_BUFFER_SIZE in Kernel 4.4.
+// In a nutshell, we read HTTP_BUFFER_SIZE bytes no matter what and then get rid of garbage data.
+// Please note that even though the memset could be removed with no semantic change to the code,
+// it is still necessary to make the eBPF verifier happy.
+static __always_inline void read_into_buffer(char *buffer, char *data, size_t data_size) {
+    __builtin_memset(buffer, 0, HTTP_BUFFER_SIZE);
+    bpf_probe_read(buffer, HTTP_BUFFER_SIZE, data);
+    if (data_size >= HTTP_BUFFER_SIZE) {
+        return;
+    }
+
+    // clean up garbage
+#pragma unroll
+    for (int i = 0; i < HTTP_BUFFER_SIZE; i++) {
+        if (i >= data_size) {
+            buffer[i] = 0;
+        }
+    }
+}
+
+#endif

--- a/pkg/network/ebpf/c/http.h
+++ b/pkg/network/ebpf/c/http.h
@@ -125,9 +125,6 @@ static __always_inline int http_begin_response(http_transaction_t *http, const c
     __u8 space_found = 0;
 #pragma unroll
     for (int i = 0; i < HTTP_BUFFER_SIZE - 1; i++) {
-	    // buffer might contain a null terminator in the middle
-        if (buffer[i] == 0) break;
-
         if (!space_found && buffer[i] == ' ') {
             space_found = 1;
         } else if (space_found && status_code < 100) {

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -3,6 +3,7 @@
 #include "ip.h"
 #include "ipv6.h"
 #include "http.h"
+#include "http-buffer.h"
 #include "sock.h"
 #include "sockfd.h"
 
@@ -197,10 +198,7 @@ int uretprobe__SSL_read(struct pt_regs* ctx) {
 
     u32 len = (u32)PT_REGS_RC(ctx);
     char buffer[HTTP_BUFFER_SIZE];
-    __builtin_memset(buffer, 0, sizeof(buffer));
-    if (len >= HTTP_BUFFER_SIZE) {
-        bpf_probe_read(buffer, sizeof(buffer), args->buf);
-    }
+    read_into_buffer(buffer, args->buf, len);
 
     skb_info_t skb_info = {0};
     __builtin_memcpy(&skb_info.tup, t, sizeof(conn_tuple_t));
@@ -222,10 +220,7 @@ int uprobe__SSL_write(struct pt_regs* ctx) {
     void *ssl_buffer = (void *)PT_REGS_PARM2(ctx);
     size_t len = (size_t)PT_REGS_PARM3(ctx);
     char buffer[HTTP_BUFFER_SIZE];
-    __builtin_memset(buffer, 0, sizeof(buffer));
-    if (len >= HTTP_BUFFER_SIZE) {
-        bpf_probe_read(buffer, sizeof(buffer), ssl_buffer);
-    }
+    read_into_buffer(buffer, ssl_buffer, len);
 
     skb_info_t skb_info = {0};
     __builtin_memcpy(&skb_info.tup, t, sizeof(conn_tuple_t));
@@ -332,10 +327,7 @@ int uretprobe__gnutls_record_recv(struct pt_regs* ctx) {
     }
 
     char buffer[HTTP_BUFFER_SIZE];
-    __builtin_memset(buffer, 0, sizeof(buffer));
-    if (read_len >= HTTP_BUFFER_SIZE) {
-        bpf_probe_read(buffer, sizeof(buffer), args->buf);
-    }
+    read_into_buffer(buffer, args->buf, read_len);
 
     skb_info_t skb_info = {0};
     __builtin_memcpy(&skb_info.tup, t, sizeof(conn_tuple_t));
@@ -359,10 +351,7 @@ int uprobe__gnutls_record_send(struct pt_regs* ctx) {
     }
 
     char buffer[HTTP_BUFFER_SIZE];
-    __builtin_memset(buffer, 0, sizeof(buffer));
-    if (data_size >= HTTP_BUFFER_SIZE) {
-        bpf_probe_read(buffer, sizeof(buffer), data);
-    }
+    read_into_buffer(buffer, data, data_size);
 
     skb_info_t skb_info = {0};
     __builtin_memcpy(&skb_info.tup, t, sizeof(conn_tuple_t));

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -333,9 +333,7 @@ int uretprobe__gnutls_record_recv(struct pt_regs* ctx) {
 
     char buffer[HTTP_BUFFER_SIZE];
     __builtin_memset(buffer, 0, sizeof(buffer));
-    if (read_len < sizeof(buffer)) {
-        bpf_probe_read(buffer, read_len, args->buf);
-    } else {
+    if (read_len >= HTTP_BUFFER_SIZE) {
         bpf_probe_read(buffer, sizeof(buffer), args->buf);
     }
 
@@ -362,9 +360,7 @@ int uprobe__gnutls_record_send(struct pt_regs* ctx) {
 
     char buffer[HTTP_BUFFER_SIZE];
     __builtin_memset(buffer, 0, sizeof(buffer));
-    if (data_size < sizeof(buffer)) {
-        bpf_probe_read(buffer, data_size, data);
-    } else {
+    if (data_size >= HTTP_BUFFER_SIZE) {
         bpf_probe_read(buffer, sizeof(buffer), data);
     }
 

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -3,6 +3,7 @@
 #include "ip.h"
 #include "ipv6.h"
 #include "http.h"
+#include "http-buffer.h"
 #include "sockfd.h"
 #include "conn-tuple.h"
 
@@ -197,10 +198,7 @@ int uretprobe__SSL_read(struct pt_regs* ctx) {
 
     u32 len = (u32)PT_REGS_RC(ctx);
     char buffer[HTTP_BUFFER_SIZE];
-    __builtin_memset(buffer, 0, sizeof(buffer));
-    if (len >= HTTP_BUFFER_SIZE) {
-        bpf_probe_read(buffer, sizeof(buffer), args->buf);
-    }
+    read_into_buffer(buffer, args->buf, len);
 
     skb_info_t skb_info = {0};
     __builtin_memcpy(&skb_info.tup, t, sizeof(conn_tuple_t));
@@ -222,10 +220,7 @@ int uprobe__SSL_write(struct pt_regs* ctx) {
     void *ssl_buffer = (void *)PT_REGS_PARM2(ctx);
     size_t len = (size_t)PT_REGS_PARM3(ctx);
     char buffer[HTTP_BUFFER_SIZE];
-    __builtin_memset(buffer, 0, sizeof(buffer));
-    if (len >= HTTP_BUFFER_SIZE) {
-        bpf_probe_read(buffer, sizeof(buffer), ssl_buffer);
-    }
+    read_into_buffer(buffer, ssl_buffer, len);
 
     skb_info_t skb_info = {0};
     __builtin_memcpy(&skb_info.tup, t, sizeof(conn_tuple_t));
@@ -332,10 +327,7 @@ int uretprobe__gnutls_record_recv(struct pt_regs* ctx) {
     }
 
     char buffer[HTTP_BUFFER_SIZE];
-    __builtin_memset(buffer, 0, sizeof(buffer));
-    if (read_len >= HTTP_BUFFER_SIZE) {
-        bpf_probe_read(buffer, sizeof(buffer), args->buf);
-    }
+    read_into_buffer(buffer, args->buf, read_len);
 
     skb_info_t skb_info = {0};
     __builtin_memcpy(&skb_info.tup, t, sizeof(conn_tuple_t));
@@ -359,10 +351,7 @@ int uprobe__gnutls_record_send(struct pt_regs* ctx) {
     }
 
     char buffer[HTTP_BUFFER_SIZE];
-    __builtin_memset(buffer, 0, sizeof(buffer));
-    if (data_size >= HTTP_BUFFER_SIZE) {
-        bpf_probe_read(buffer, sizeof(buffer), data);
-    }
+    read_into_buffer(buffer, data, data_size);
 
     skb_info_t skb_info = {0};
     __builtin_memcpy(&skb_info.tup, t, sizeof(conn_tuple_t));

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -333,9 +333,7 @@ int uretprobe__gnutls_record_recv(struct pt_regs* ctx) {
 
     char buffer[HTTP_BUFFER_SIZE];
     __builtin_memset(buffer, 0, sizeof(buffer));
-    if (read_len < sizeof(buffer)) {
-        bpf_probe_read(buffer, read_len, args->buf);
-    } else {
+    if (read_len >= HTTP_BUFFER_SIZE) {
         bpf_probe_read(buffer, sizeof(buffer), args->buf);
     }
 
@@ -362,9 +360,7 @@ int uprobe__gnutls_record_send(struct pt_regs* ctx) {
 
     char buffer[HTTP_BUFFER_SIZE];
     __builtin_memset(buffer, 0, sizeof(buffer));
-    if (data_size < sizeof(buffer)) {
-        bpf_probe_read(buffer, data_size, data);
-    } else {
+    if (data_size >= HTTP_BUFFER_SIZE) {
         bpf_probe_read(buffer, sizeof(buffer), data);
     }
 

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -54,7 +54,8 @@
         "azure": {
             "x86_64": {
                 "ubuntu-14-04": "urn,Canonical:UbuntuServer:14.04.5-LTS:14.04.201905140",
-                "ubuntu-16-04": "urn,Canonical:UbuntuServer:16.04.0-LTS:16.04.201608150",
+                "ubuntu-16-04-4.4": "urn,Canonical:UbuntuServer:16.04.0-LTS:16.04.201608150",
+                "ubuntu-16-04": "urn,Canonical:UbuntuServer:16.04.0-LTS:16.04.202106110",
                 "ubuntu-18-04": "urn,Canonical:UbuntuServer:18.04-LTS:18.04.201906040",
                 "ubuntu-18-04-3": "urn,Canonical:UbuntuServer:18.04-LTS:18.04.201912180",
                 "ubuntu-20-04": "urn,Canonical:0001-com-ubuntu-server-focal:20_04-lts:20.04.202004230",

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -54,7 +54,7 @@
         "azure": {
             "x86_64": {
                 "ubuntu-14-04": "urn,Canonical:UbuntuServer:14.04.5-LTS:14.04.201905140",
-                "ubuntu-16-04": "urn,Canonical:UbuntuServer:16.04.0-LTS:16.04.202106110",
+                "ubuntu-16-04": "urn,Canonical:UbuntuServer:16.04.0-LTS:16.04.201608150",
                 "ubuntu-18-04": "urn,Canonical:UbuntuServer:18.04-LTS:18.04.201906040",
                 "ubuntu-18-04-3": "urn,Canonical:UbuntuServer:18.04-LTS:18.04.201912180",
                 "ubuntu-20-04": "urn,Canonical:0001-com-ubuntu-server-focal:20_04-lts:20.04.202004230",


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix HTTP monitoring support for Kernel 4.4. This was caused by a regression introduced in a recent PR but not released to customers.
Additionally we fix our CI image for Ubuntu 16.04, to ensure that Kernel 4.4 testing is covered. The current one (updated 4 months ago) ships with Kernel 4.15.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
