### PR TITLE
Improve error message when logfile cannot be read

### DIFF
--- a/pkg/logs/input/file/file_provider.go
+++ b/pkg/logs/input/file/file_provider.go
@@ -121,9 +121,9 @@ func (p *Provider) FilesToTail(sources []*config.LogSource) []*File {
 // CollectFiles returns all the files matching the source path.
 func (p *Provider) CollectFiles(source *config.LogSource) ([]*File, error) {
 	path := source.Config.Path
-	fileExists := p.exists(path)
+	_, err := os.Stat(path)
 	switch {
-	case fileExists:
+	case err == nil:
 		return []*File{
 			NewFile(path, source, false),
 		}, nil
@@ -131,7 +131,7 @@ func (p *Provider) CollectFiles(source *config.LogSource) ([]*File, error) {
 		pattern := path
 		return p.searchFiles(pattern, source)
 	default:
-		return nil, fmt.Errorf("file %s does not exist or cannot be read by agent", path)
+		return nil, fmt.Errorf("cannot read file %s: %s", path, err)
 	}
 }
 

--- a/pkg/logs/input/file/file_provider.go
+++ b/pkg/logs/input/file/file_provider.go
@@ -131,7 +131,7 @@ func (p *Provider) CollectFiles(source *config.LogSource) ([]*File, error) {
 		pattern := path
 		return p.searchFiles(pattern, source)
 	default:
-		return nil, fmt.Errorf("file %s does not exist", path)
+		return nil, fmt.Errorf("file %s does not exist or cannot be read by agent", path)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

Improves the error message displayed when a log file to be tailed cannot be read

### Motivation

I spent a long time trying to figure out why the agent thought a file did not exist when it clearly did exist.  In fact, the issue was that the file was inaccessible.  This error message suggests this might be the case to the user.

### Describe how to test/QA your changes

Configure an integration with a logfile path that exists, but is inaccessible to the agent user.  Confirm that the error message visible in `agent status` includes this possibility.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
