### PR TITLE
remove unused private function

### DIFF
--- a/pkg/logs/input/file/file_provider.go
+++ b/pkg/logs/input/file/file_provider.go
@@ -185,13 +185,3 @@ func (p *Provider) searchFiles(pattern string, source *config.LogSource) ([]*Fil
 	}
 	return files, nil
 }
-
-// exists returns true if the file at path filePath exists
-// Note: we can't rely on os.IsNotExist for windows, so we check error nullity.
-// As we're tailing with *, the error is related to the path being malformed.
-func (p *Provider) exists(filePath string) bool {
-	if _, err := os.Stat(filePath); err != nil {
-		return false
-	}
-	return true
-}


### PR DESCRIPTION
Use of this function was removed in #10134, where I didn't realize it was the _only_ use.