### PR TITLE
Kacper murzyn/codeowners action

### DIFF
--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -7,8 +7,10 @@ on:
 jobs:
   autolabeler-codeowners:
     runs-on: ubuntu-latest
+    name: PR + CODEOWNERS Workflows
     steps:
     - uses: actions/checkout@v1
+    - name: Add CODEOWNER Label To PR
       uses: pratikmallya/autolabeler-codeowners@releases/v1
       with:
         githubToken: ${{ secrets.githubToken }}

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -1,7 +1,7 @@
 name: codeowner-autolabel
 
 on:
-  push:
+  pull_request:
     branches:
       - 'kacper-murzyn/**'
 jobs:

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -13,4 +13,4 @@ jobs:
     - name: Add CODEOWNER Label To PR
       uses: pratikmallya/autolabeler-codeowners@releases/v1
       with:
-        githubToken: ${{ secrets.githubToken }}
+        githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Add CODEOWNER Label To PR
-      uses: kacper-murzyn/autolabeler-codeowners@dd-0.1
+      uses: kacper-murzyn/autolabeler-codeowners@release/dd-1
       with:
         githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -1,13 +1,14 @@
 name: codeowner-autolabel
 
-on: [push]
-  branches:
-    - 'kacper-murzyn/**'
+on:
+  push:
+    branches:
+      - 'kacper-murzyn/**'
 jobs:
   autolabeler-codeowners:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - uses: pratikmallya/autolabeler-codeowners@releases/v1
+      uses: pratikmallya/autolabeler-codeowners@releases/v1
       with:
         githubToken: ${{ secrets.githubToken }}

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Add CODEOWNER Label To PR
-      uses: pratikmallya/autolabeler-codeowners@releases/v1
+      uses: kacper-murzyn/autolabeler-codeowners
       with:
         githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -3,14 +3,14 @@ name: codeowner-autolabel
 on:
   pull_request:
     branches:
-      - 'kacper-murzyn/**'
+      - main
 jobs:
   autolabeler-codeowners:
     runs-on: ubuntu-latest
-    name: PR + CODEOWNERS Workflows
+    name: Codeowners labeling
     steps:
     - uses: actions/checkout@v1
-    - name: Add CODEOWNER Label To PR
+    - name: Add 'team' label to PR
       uses: kacper-murzyn/autolabeler-codeowners@release/dd-1
       with:
         githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -11,6 +11,6 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Add CODEOWNER Label To PR
-      uses: kacper-murzyn/autolabeler-codeowners
+      uses: kacper-murzyn/autolabeler-codeowners@dd-0.1
       with:
         githubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/codeowners.yml
+++ b/.github/workflows/codeowners.yml
@@ -1,0 +1,13 @@
+name: codeowner-autolabel
+
+on: [push]
+  branches:
+    - 'kacper-murzyn/**'
+jobs:
+  autolabeler-codeowners:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - uses: pratikmallya/autolabeler-codeowners@releases/v1
+      with:
+        githubToken: ${{ secrets.githubToken }}


### PR DESCRIPTION
### What does this PR do?

This PR adds a GH Action that affects all new PRs on main branch - it adds a team label based on the CODEOWNERS file content.

### Motivation

Action item after 7.31.1 post mortem: https://datadoghq.atlassian.net/browse/AGENTR-25

### Additional Notes

This actions uses fork of https://github.com/pratikmallya/autolabeler-codeowners - the only change is related to DD specific labels that we use to mark teams. Original workflow copies blindly entries from CODEOWNERS (so `@DataDog/agent-all` for example), changes in the fork replace `@DataDog` with `team`.

### Possible Drawbacks / Trade-offs

In case there would be changes made by one team to the file, being owned by the other team - this action is going to put owning team label on the PR, therefore requesting this teams QA effort during release creation. It has to be double checked whether it's really what we want to go for, as it requires owning team to remember to remove the label if necessary (additional step that can be forgotten).
The other element to rethink - this PR references workflow that is currently hosted as a public repository in my private space. We should decide whether this approach is acceptable, if so - maybe move the repo to the DD space.

### Describe how to test/QA your changes

Workflow was tested on couple of testing PRs with different files change (having single, multiple and no owners according to CODEOWNERS).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
