### PR TITLE
[Experimental][SNMP][Traps] Make the channel size configurable

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -579,7 +579,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("snmp_traps_config.port", 162)
 	config.BindEnvAndSetDefault("snmp_traps_config.community_strings", []string{})
 	config.BindEnvAndSetDefault("snmp_traps_config.bind_host", "localhost")
-	config.BindEnvAndSetDefault("snmp_traps_config.stop_timeout", 5) // in seconds
+	config.BindEnvAndSetDefault("snmp_traps_config.stop_timeout", 5)        // in seconds
+	config.BindEnvAndSetDefault("snmp_traps_config.packets_chan_size", 100) // in seconds
 
 	// Kube ApiServer
 	config.BindEnvAndSetDefault("kubernetes_kubeconfig_path", "")

--- a/pkg/snmp/traps/config.go
+++ b/pkg/snmp/traps/config.go
@@ -25,6 +25,7 @@ type Config struct {
 	CommunityStrings []string `mapstructure:"community_strings" yaml:"community_strings"`
 	BindHost         string   `mapstructure:"bind_host" yaml:"bind_host"`
 	StopTimeout      int      `mapstructure:"stop_timeout" yaml:"stop_timeout"`
+	PacketsChanSize  int      `mapstructure:"packets_chan_size" yaml:"packets_chan_size"`
 }
 
 // ReadConfig builds and returns configuration from Agent configuration.
@@ -50,6 +51,9 @@ func ReadConfig() (*Config, error) {
 	}
 	if c.StopTimeout == 0 {
 		c.StopTimeout = defaultStopTimeout
+	}
+	if c.PacketsChanSize == 0 {
+		c.PacketsChanSize = defaultPacketsChanSize
 	}
 
 	return &c, nil

--- a/pkg/snmp/traps/constants.go
+++ b/pkg/snmp/traps/constants.go
@@ -6,7 +6,7 @@
 package traps
 
 const (
-	defaultPort        = uint16(162) // Standard UDP port for traps.
-	defaultStopTimeout = 5
-	packetsChanSize    = 100
+	defaultPort            = uint16(162) // Standard UDP port for traps.
+	defaultStopTimeout     = 5
+	defaultPacketsChanSize = 100
 )

--- a/pkg/snmp/traps/server.go
+++ b/pkg/snmp/traps/server.go
@@ -69,7 +69,7 @@ func NewTrapServer() (*TrapServer, error) {
 		return nil, err
 	}
 
-	packets := make(PacketsChannel, packetsChanSize)
+	packets := make(PacketsChannel, config.PacketsChanSize)
 
 	listener, err := startSNMPv2Listener(config, packets)
 	if err != nil {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
