### PR TITLE
[CWS] e2e tests improvements and bugfixes

### DIFF
--- a/test/e2e/cws-tests/tests/lib/app.py
+++ b/test/e2e/cws-tests/tests/lib/app.py
@@ -8,7 +8,6 @@ from datadog_api_client.v2.models import (
     LogsListRequest,
     LogsListRequestPage,
     LogsQueryFilter,
-    LogsQueryOptions,
     LogsSort,
     SecurityMonitoringRuleCaseCreate,
     SecurityMonitoringRuleCreatePayload,

--- a/test/e2e/cws-tests/tests/lib/app.py
+++ b/test/e2e/cws-tests/tests/lib/app.py
@@ -40,10 +40,6 @@ def get_app_log(api_client, query):
             query=query,
             to="now",
         ),
-        options=LogsQueryOptions(
-            time_offset=1,
-            timezone="GMT",
-        ),
         page=LogsListRequestPage(
             limit=25,
         ),
@@ -166,8 +162,8 @@ class App:
 
         return fp.name
 
-    def wait_app_log(self, query, tries=30, delay=5):
+    def wait_app_log(self, query, tries=30, delay=10):
         return retry_call(get_app_log, fargs=[self.api_client, query], tries=tries, delay=delay)
 
-    def wait_app_signal(self, query, tries=30, delay=5):
+    def wait_app_signal(self, query, tries=30, delay=10):
         return retry_call(get_app_signal, fargs=[self.api_client, query], tries=tries, delay=delay)

--- a/test/e2e/cws-tests/tests/lib/stepper.py
+++ b/test/e2e/cws-tests/tests/lib/stepper.py
@@ -11,5 +11,8 @@ class Step:
         print(f"{_emoji} {self.msg}... ", end="", flush=True)
         return self
 
-    def __exit__(self, _exc_type, _exc_val, _exc_tb):
-        print(emoji.emojize(":check_mark:"), flush=True)
+    def __exit__(self, exc_type, _exc_val, _exc_tb):
+        if exc_type is None:
+            print(emoji.emojize(":check_mark:"), flush=True)
+        else:
+            print(emoji.emojize(":cross_mark:"), flush=True)


### PR DESCRIPTION
### What does this PR do?

Small fixes and cleanup to the e2e CWS tests.

### Motivation

Prepare for CSPM e2e tests.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
