### PR TITLE
Support alignment checks when searching for multibyte newlines

### DIFF
--- a/pkg/logs/decoder/decoder_test.go
+++ b/pkg/logs/decoder/decoder_test.go
@@ -124,7 +124,7 @@ func TestDecodeIncomingData(t *testing.T) {
 
 func TestDecodeIncomingDataWithCustomSequence(t *testing.T) {
 	p := NewMockLineParser()
-	d := New(nil, nil, p, contentLenLimit, &BytesSequenceMatcher{[]byte("SEPARATOR")}, nil)
+	d := New(nil, nil, p, contentLenLimit, NewBytesSequenceMatcher([]byte("SEPARATOR"), 1), nil)
 
 	var line *DecodedInput
 
@@ -167,7 +167,7 @@ func TestDecodeIncomingDataWithCustomSequence(t *testing.T) {
 
 func TestDecodeIncomingDataWithSingleByteCustomSequence(t *testing.T) {
 	p := NewMockLineParser()
-	d := New(nil, nil, p, contentLenLimit, &BytesSequenceMatcher{[]byte("&")}, nil)
+	d := New(nil, nil, p, contentLenLimit, NewBytesSequenceMatcher([]byte("&"), 1), nil)
 
 	var line *DecodedInput
 
@@ -471,7 +471,7 @@ func TestDecoderWithDockerJSONSplittedByDocker(t *testing.T) {
 func TestDecoderWithDecodingParser(t *testing.T) {
 	source := config.NewLogSource("config", &config.LogsConfig{})
 
-	d := NewDecoderWithEndLineMatcher(source, parser.NewEncodedText(parser.UTF16LE), NewBytesSequenceMatcher(Utf16leEOL), nil)
+	d := NewDecoderWithEndLineMatcher(source, parser.NewEncodedText(parser.UTF16LE), NewBytesSequenceMatcher(Utf16leEOL, 2), nil)
 	d.Start()
 
 	input := []byte{'h', 0x0, 'e', 0x0, 'l', 0x0, 'l', 0x0, 'o', 0x0, '\n', 0x0}

--- a/pkg/logs/decoder/matcher.go
+++ b/pkg/logs/decoder/matcher.go
@@ -14,8 +14,10 @@ var (
 
 // EndLineMatcher defines the criterion to whether to end a line or not.
 type EndLineMatcher interface {
-	// Match takes the existing bytes and the bytes to be appended, returns
-	// true if the combination matches the end of line condition.
+
+	// Match takes the existing bytes (the entire slice) and the bytes to be
+	// appended (appender[start:end+1]), and returns true if the combination
+	// matches the end of line condition at the end.
 	Match(exists []byte, appender []byte, start int, end int) bool
 	SeparatorLen() int
 }
@@ -47,7 +49,7 @@ func NewBytesSequenceMatcher(sequence []byte) *BytesSequenceMatcher {
 // Match returns true whenever it finds a matching sequence at the end of append(exists, appender[start:end+1])
 func (b *BytesSequenceMatcher) Match(exists []byte, appender []byte, start int, end int) bool {
 	// Total read message is append(exists,appender[start:end]) and the decoder just read appender[end]
-	// Thus the separator sequence is checked against append(exists, appender[start:end+1])
+	// Thus the separator sequence is checked against append(exists, appender[start:end+1]...)
 	l := len(exists) + ((end + 1) - start)
 	if l < len(b.sequence) {
 		return false

--- a/pkg/logs/decoder/matcher.go
+++ b/pkg/logs/decoder/matcher.go
@@ -38,12 +38,14 @@ func (n *NewLineMatcher) SeparatorLen() int {
 
 // BytesSequenceMatcher defines the criterion to whether to end a line based on an arbitrary byte sequence
 type BytesSequenceMatcher struct {
-	sequence []byte
+	sequence  []byte
+	alignment int
 }
 
-// NewBytesSequenceMatcher Returns a new matcher based on custom bytes sequence
-func NewBytesSequenceMatcher(sequence []byte) *BytesSequenceMatcher {
-	return &BytesSequenceMatcher{sequence}
+// NewBytesSequenceMatcher Returns a new matcher based on custom bytes sequence.  Only matches
+// that begin at a multiple of `alignment` are considered.
+func NewBytesSequenceMatcher(sequence []byte, alignment int) *BytesSequenceMatcher {
+	return &BytesSequenceMatcher{sequence, alignment}
 }
 
 // Match returns true whenever it finds a matching sequence at the end of append(exists, appender[start:end+1])
@@ -52,6 +54,9 @@ func (b *BytesSequenceMatcher) Match(exists []byte, appender []byte, start int, 
 	// Thus the separator sequence is checked against append(exists, appender[start:end+1]...)
 	l := len(exists) + ((end + 1) - start)
 	if l < len(b.sequence) {
+		return false
+	}
+	if (l-len(b.sequence))%b.alignment != 0 {
 		return false
 	}
 	seqIdx := len(b.sequence) - 1

--- a/pkg/logs/decoder/matcher_test.go
+++ b/pkg/logs/decoder/matcher_test.go
@@ -1,0 +1,68 @@
+package decoder
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// test that m matches a line ending at offset endLineAt, and nowhere else,
+// with any distribution of bytes between `existing` and `appender`.
+func testMatchAt(t *testing.T, m EndLineMatcher, data []byte, nextLineStartsAt int) {
+	// offset is the location we will look for the next line to begin
+	for offset := 0; offset <= len(data); offset++ {
+		// ex is the number of existing bytes
+		for ex := 0; ex < offset-1; ex++ {
+			existing := data[:ex]
+			// ap is the beginning of the appender slice, which can contain
+			// existing bytes as well, as offset by `start`
+			for ap := 0; ap < ex; ap++ {
+				appender := data[ap:]
+				start := ex - ap
+				end := offset - ap - 1 // account for "end+1" instead of "end"
+
+				require.Equal(t,
+					offset == nextLineStartsAt, m.Match(existing, appender, start, end),
+					"match(%#v, %#v, %d, %d)", existing, appender, start, end)
+			}
+		}
+	}
+}
+
+func TestNewLineMatcher_Match(t *testing.T) {
+	testMatchAt(t, &NewLineMatcher{}, []byte("abcd\n1234"), 5)
+}
+
+func TestNewLineMatcher_SeparatorLen(t *testing.T) {
+	nlm := &NewLineMatcher{}
+	require.Equal(t, 1, nlm.SeparatorLen())
+}
+
+func TestBytesSequenceMatcher_Match(t *testing.T) {
+	input := []byte{
+		0xff, 0xfe, // BOM
+		0x32, 0x00, 0x30, 0x00, 0x32, 0x00, 0x31, 0x00, 0x0a, 0x00, // "2021\n"
+		0x41, 0x00, 0x40, 0x00, 0x44, 0x00, // "BAD" (no newline)
+	}
+	testMatchAt(t, NewBytesSequenceMatcher([]byte{0x0a, 0x00}), input, 12)
+}
+
+func TestBytesSequenceMatcher_Match_Misaligned(t *testing.T) {
+	input := []byte{
+		0x42, 0x00, // B
+		0x41, 0x00, // A
+		0x44, 0x00, // D
+		0x70, 0x0a, // ਇ
+		0x00, 0x01, // Ā
+		0x44, 0x00, // D
+		0x4f, 0x00, // O
+		0x47, 0x00, // G
+		0x0a, 0x00, // \n
+	}
+	testMatchAt(t, NewBytesSequenceMatcher([]byte{0x0a, 0x00}), input, 18)
+}
+
+func TestBytesSequenceMatcher_SeparatorLen(t *testing.T) {
+	nlm := NewBytesSequenceMatcher([]byte{0x0a, 0x00})
+	require.Equal(t, 2, nlm.SeparatorLen())
+}

--- a/pkg/logs/decoder/matcher_test.go
+++ b/pkg/logs/decoder/matcher_test.go
@@ -44,7 +44,11 @@ func TestBytesSequenceMatcher_Match(t *testing.T) {
 		0x32, 0x00, 0x30, 0x00, 0x32, 0x00, 0x31, 0x00, 0x0a, 0x00, // "2021\n"
 		0x41, 0x00, 0x40, 0x00, 0x44, 0x00, // "BAD" (no newline)
 	}
-	testMatchAt(t, NewBytesSequenceMatcher([]byte{0x0a, 0x00}), input, 12)
+	testMatchAt(t, NewBytesSequenceMatcher([]byte{0x0a, 0x00}, 2), input, 12)
+}
+
+func TestBytesSequenceMatcher_Match_OneByte(t *testing.T) {
+	testMatchAt(t, NewBytesSequenceMatcher([]byte("\n"), 1), []byte("abcd\n1234"), 5)
 }
 
 func TestBytesSequenceMatcher_Match_Misaligned(t *testing.T) {
@@ -52,17 +56,17 @@ func TestBytesSequenceMatcher_Match_Misaligned(t *testing.T) {
 		0x42, 0x00, // B
 		0x41, 0x00, // A
 		0x44, 0x00, // D
-		0x70, 0x0a, // ਇ
+		0x70, 0x0a, // ਇ  // {0x0a, 0x00} is here, at an odd offset
 		0x00, 0x01, // Ā
 		0x44, 0x00, // D
 		0x4f, 0x00, // O
 		0x47, 0x00, // G
 		0x0a, 0x00, // \n
 	}
-	testMatchAt(t, NewBytesSequenceMatcher([]byte{0x0a, 0x00}), input, 18)
+	testMatchAt(t, NewBytesSequenceMatcher([]byte{0x0a, 0x00}, 2), input, 18)
 }
 
 func TestBytesSequenceMatcher_SeparatorLen(t *testing.T) {
-	nlm := NewBytesSequenceMatcher([]byte{0x0a, 0x00})
+	nlm := NewBytesSequenceMatcher([]byte{0x0a, 0x00}, 2)
 	require.Equal(t, 2, nlm.SeparatorLen())
 }

--- a/pkg/logs/input/file/tailer.go
+++ b/pkg/logs/input/file/tailer.go
@@ -87,10 +87,10 @@ func NewDecoderFromSourceWithPattern(source *config.LogSource, multiLinePattern 
 		switch source.Config.Encoding {
 		case config.UTF16BE:
 			lineParser = parser.NewEncodedText(parser.UTF16BE)
-			matcher = decoder.NewBytesSequenceMatcher(decoder.Utf16beEOL)
+			matcher = decoder.NewBytesSequenceMatcher(decoder.Utf16beEOL, 2)
 		case config.UTF16LE:
 			lineParser = parser.NewEncodedText(parser.UTF16LE)
-			matcher = decoder.NewBytesSequenceMatcher(decoder.Utf16leEOL)
+			matcher = decoder.NewBytesSequenceMatcher(decoder.Utf16leEOL, 2)
 		default:
 			lineParser = parser.Noop
 			matcher = &decoder.NewLineMatcher{}


### PR DESCRIPTION
### What does this PR do?

Update the BytesSequenceMatcher, which is used to detect newlines in multibyte log encodings, to check alignment of the sequence.

### Motivation

Without this change, the matcher can be "fooled" by byte sequences that contain a newline formed by bytes from adjacent codepoints, such as `ਇĀ` (`70 0a 00 01` in utf-16-le).

### Additional Notes

None.

### Possible Drawbacks / Trade-offs

None

### Describe how to test/QA your changes

Verify existing functionality is not broken: set up a file integration using utf-16-le
```
logs:
  - type: file
    encoding: utf-16-le
    path: "/tmp/somefile"
    source: "src"
    service: "svc"
```

and then write a utf-16-le file at that location, and verify that it is split into lines correctly using `agent stream-logs`.

Verify new functionality: write a line containing `ਇĀ` to that file and verify that the log message is not split at that point.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
