### PR TITLE
[Serverless] disable backoff delay in serverless mode

### DIFF
--- a/pkg/logs/client/http/destination.go
+++ b/pkg/logs/client/http/destination.go
@@ -105,7 +105,8 @@ func errorToTag(err error) string {
 // Send sends a payload over HTTP,
 // the error returned can be retryable and it is the responsibility of the callee to retry.
 func (d *Destination) Send(payload []byte) error {
-	if d.blockedUntil.After(time.Now()) {
+	if d.blockedUntil.After(time.Now()) && d.origin != config.ServerlessIntakeOrigin {
+		// backoff delay is disabled in serverless mode
 		log.Debugf("%s: sleeping until %v before retrying", d.url, d.blockedUntil)
 		d.waitForBackoff()
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Disable backoff delay in serverless mode. 
In case of failure, we don't want to wait for a retry in a serverless environment. Instead we delay the flush to the next invocation

### Motivation

Performance

### Describe how to test/QA your changes

![Screen Shot 2021-12-08 at 4 30 45 PM](https://user-images.githubusercontent.com/864493/145287427-7bc41550-6a17-4179-9e28-197bb9b0a262.png)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
