### PR TITLE
[kitchen] Simplify dd-agent-reinstall cookbook

### DIFF
--- a/test/kitchen/site-cookbooks/dd-agent-reinstall/README.md
+++ b/test/kitchen/site-cookbooks/dd-agent-reinstall/README.md
@@ -1,3 +1,3 @@
 # dd-agent-reinstall cookbook
 
-Reinstalls the same version, using different installer flags
+Reinstalls the same Windows Agent version, using different installer flags

--- a/test/kitchen/site-cookbooks/dd-agent-reinstall/attributes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-reinstall/attributes/default.rb
@@ -1,70 +1,8 @@
-default['dd-agent-reinstall']['api_key'] = nil
-default['dd-agent-reinstall']['agent_major_version'] = nil
-
-default['dd-agent-reinstall']['version'] = nil # => install the latest available version
-default['dd-agent-reinstall']['add_new_repo'] = false # If set to true, be sure to set aptrepo and yumrepo
-default['dd-agent-reinstall']['aptrepo'] =  nil
-default['dd-agent-reinstall']['aptrepo_dist'] =  nil
-default['dd-agent-reinstall']['yumrepo'] = nil
-default['dd-agent-reinstall']['yumrepo_suse'] = nil
-default['dd-agent-reinstall']['package_name'] = 'datadog-agent'
-
-default['dd-agent-reinstall']['windows_version'] = nil # => install the latest available version
-default['dd-agent-reinstall']['windows_agent_checksum'] = nil
-default['dd-agent-reinstall']['windows_agent_url'] = 'https://ddagent-windows-stable.s3.amazonaws.com/'
-
 default['dd-agent-reinstall']['agent_package_retries'] = nil
 default['dd-agent-reinstall']['agent_package_retry_delay'] = nil
 
-# Enable the agent to start at boot
-default['dd-agent-reinstall']['agent_enable'] = true
+default['dd-agent-reinstall']['windows_version'] = nil # => install the latest available version
+default['dd-agent-reinstall']['windows_agent_url'] = 'https://ddagent-windows-stable.s3.amazonaws.com/'
+default['dd-agent-reinstall']['windows_agent_filename'] = nil
 
-# Start agent or not
-default['dd-agent-reinstall']['agent_start'] = true
-default['dd-agent-reinstall']['enable_trace_agent'] = true
-default['dd-agent-reinstall']['enable_process_agent'] = true
-
-# Set the defaults from the chef recipe
-default['dd-agent-reinstall']['extra_endpoints']['prod']['enabled'] = nil
-default['dd-agent-reinstall']['extra_endpoints']['prod']['api_key'] = nil
-default['dd-agent-reinstall']['extra_endpoints']['prod']['application_key'] = nil
-default['dd-agent-reinstall']['extra_endpoints']['prod']['url'] = nil # op
-default['dd-agent-reinstall']['extra_config']['forwarder_timeout'] = nil
-default['dd-agent-reinstall']['web_proxy']['host'] = nil
-default['dd-agent-reinstall']['web_proxy']['port'] = nil
-default['dd-agent-reinstall']['web_proxy']['user'] = nil
-default['dd-agent-reinstall']['web_proxy']['password'] = nil
-default['dd-agent-reinstall']['web_proxy']['skip_ssl_validation'] = nil # accepted values 'yes' or 'no'
-default['dd-agent-reinstall']['dogstreams'] = []
-default['dd-agent-reinstall']['custom_emitters'] = []
-default['dd-agent-reinstall']['syslog']['active'] = false
-default['dd-agent-reinstall']['syslog']['udp'] = false
-default['dd-agent-reinstall']['syslog']['host'] = nil
-default['dd-agent-reinstall']['syslog']['port'] = nil
-default['dd-agent-reinstall']['log_file_directory'] =
-  if node['platform_family'] == 'windows'
-    nil # let the agent use a default log file dir
-  else
-    '/var/log/datadog'
-  end
-default['dd-agent-reinstall']['process_agent']['blacklist'] = nil
-default['dd-agent-reinstall']['process_agent']['container_blacklist'] = nil
-default['dd-agent-reinstall']['process_agent']['container_whitelist'] = nil
-default['dd-agent-reinstall']['process_agent']['log_file'] = nil
-default['dd-agent-reinstall']['process_agent']['process_interval'] = nil
-default['dd-agent-reinstall']['process_agent']['rtprocess_interval'] = nil
-default['dd-agent-reinstall']['process_agent']['container_interval'] = nil
-default['dd-agent-reinstall']['process_agent']['rtcontainer_interval'] = nil
-default['dd-agent-reinstall']['tags'] = ''
-default['dd-agent-reinstall']['histogram_aggregates'] = 'max, median, avg, count'
-default['dd-agent-reinstall']['histogram_percentiles'] = '0.95'
-default['dd-agent-reinstall']['dogstatsd'] = true
-default['dd-agent-reinstall']['dogstatsd_port'] = 8125
-default['dd-agent-reinstall']['dogstatsd_interval'] = 10
-default['dd-agent-reinstall']['dogstatsd_normalize'] = 'yes'
-default['dd-agent-reinstall']['dogstatsd_target'] = 'http://localhost:17123'
-default['dd-agent-reinstall']['statsd_forward_host'] = nil
-default['dd-agent-reinstall']['statsd_forward_port'] = 8125
-default['dd-agent-reinstall']['statsd_metric_namespace'] = nil
-default['dd-agent-reinstall']['log_level'] = 'INFO'
-default['dd-agent-reinstall']['enable_logs_agent'] = false
+default['dd-agent-reinstall']['agent_install_options'] = ''

--- a/test/kitchen/site-cookbooks/dd-agent-reinstall/metadata.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-reinstall/metadata.rb
@@ -1,9 +1,5 @@
 name             "dd-agent-reinstall"
 maintainer       "Datadog"
-description      "Reinstalls the installed Agent"
+description      "Reinstalls the installed Windows Agent"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          "0.2.0"
-
-depends 'apt', '>= 2.1.0'
-depends 'datadog'
-depends 'yum', '< 7.0.0'

--- a/test/kitchen/site-cookbooks/dd-agent-reinstall/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-agent-reinstall/recipes/default.rb
@@ -8,129 +8,50 @@
 #
 require 'uri'
 
-if node['dd-agent-reinstall']['add_new_repo']
-  case node['platform_family']
-  when 'debian'
-    include_recipe 'apt'
-
-    apt_repository 'datadog-update' do
-      keyserver 'keyserver.ubuntu.com'
-      key 'A2923DFF56EDA6E76E55E492D3A80E30382E94DE'
-      uri node['dd-agent-reinstall']['aptrepo']
-      distribution node['dd-agent-reinstall']['aptrepo_dist']
-      components [node['dd-agent-reinstall']['agent_major_version']]
-      action :add
-    end
-
-  when 'rhel'
-    include_recipe 'yum'
-
-    yum_repository 'datadog-update' do
-      name 'datadog-update'
-      description 'datadog-update'
-      url node['dd-agent-reinstall']['yumrepo']
-      action :add
-      make_cache true
-      # Older versions of yum embed M2Crypto with SSL that doesn't support TLS1.2
-      protocol = node['platform_version'].to_i < 6 ? 'http' : 'https'
-      gpgkey [
-        "#{protocol}://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public",
-        "#{protocol}://keys.datadoghq.com/DATADOG_RPM_KEY_FD4BF915.public",
-        "#{protocol}://keys.datadoghq.com/DATADOG_RPM_KEY_E09422B3.public",
-      ]
-    end
-  when 'suse'
-    old_key_local_path = ::File.join(Chef::Config[:file_cache_path], 'DATADOG_RPM_KEY.public')
-    remote_file 'DATADOG_RPM_KEY.public' do
-      path old_key_local_path
-      source node['datadog']['yumrepo_gpgkey']
-      # not_if 'rpm -q gpg-pubkey-4172a230' # (key already imported)
-      notifies :run, 'execute[rpm-import datadog key 4172a230]', :immediately
-    end
-
-    # Import key if fingerprint matches
-    execute 'rpm-import datadog key 4172a230' do
-      command "rpm --import #{old_key_local_path}"
-      only_if "gpg --dry-run --quiet --with-fingerprint #{old_key_local_path} | grep '60A3 89A4 4A0C 32BA E3C0  3F0B 069B 56F5 4172 A230'"
-      action :nothing
-    end
-
-    zypper_repository 'datadog-update' do
-      name 'datadog-update'
-      description 'datadog-update'
-      baseurl node['dd-agent-reinstall']['yumrepo_suse']
-      action :add
-      gpgcheck false
-      # Older versions of yum embed M2Crypto with SSL that doesn't support TLS1.2
-      protocol = node['platform_version'].to_i < 6 ? 'http' : 'https'
-      gpgkey "#{protocol}://keys.datadoghq.com/DATADOG_RPM_KEY_CURRENT.public"
-      gpgautoimportkeys false
-    end
-  end
-end
-
 if node['platform_family'] != 'windows'
-  package node['dd-agent-reinstall']['package_name'] do
-    action :upgrade
-    version node['dd-agent-reinstall']['version']
-  end
-  # the :upgrade method seems broken for sles: https://github.com/chef/chef/issues/4863
-  if node['platform_family'] == 'suse'
-    package node['dd-agent-reinstall']['package_name'] do
-      action :remove
-    end
-    package node['dd-agent-reinstall']['package_name'] do
-      action :install
-      version node['dd-agent-reinstall']['version']
-    end
+  raise "The dd-agent-reinstall cookbook is only usable on Windows."
+end
+
+package_retries = node['dd-agent-reinstall']['agent_package_retries']
+package_retry_delay = node['dd-agent-reinstall']['agent_package_retry_delay']
+dd_agent_version = node['dd-agent-reinstall']['windows_version']
+dd_agent_filename = node['dd-agent-reinstall']['windows_agent_filename']
+
+if dd_agent_filename
+  dd_agent_installer_basename = dd_agent_filename
+else
+  if dd_agent_version
+    dd_agent_installer_basename = "datadog-agent-#{dd_agent_version}-1-x86_64"
+  else
+    dd_agent_installer_basename = "datadog-agent-6.0.0-beta.latest.amd64"
   end
 end
 
-if node['platform_family'] == 'windows'
-  package_retries = node['dd-agent-reinstall']['agent_package_retries']
-  package_retry_delay = node['dd-agent-reinstall']['agent_package_retry_delay']
-  dd_agent_version = node['dd-agent-reinstall']['windows_version']
-  dd_agent_filename = node['dd-agent-reinstall']['windows_agent_filename']
+temp_file_basename = ::File.join(Chef::Config[:file_cache_path], 'ddagent-up').gsub(File::SEPARATOR, File::ALT_SEPARATOR || File::SEPARATOR)
 
-  if dd_agent_filename
-    dd_agent_installer_basename = dd_agent_filename
-  else
-    if dd_agent_version
-      dd_agent_installer_basename = "datadog-agent-#{dd_agent_version}-1-x86_64"
-    else
-      dd_agent_installer_basename = "datadog-agent-6.0.0-beta.latest.amd64"
-    end
-  end
+dd_agent_installer = "#{dd_agent_installer_basename}.msi"
+temp_file = "#{temp_file_basename}.msi"
+installer_type = :msi
+# Agent >= 5.12.0 installs per-machine by default, but specifying ALLUSERS=1 shouldn't affect the install
+agent_install_options = node['dd-agent-reinstall']['agent_install_options']
+install_options = "/norestart ALLUSERS=1  #{agent_install_options}"
 
-  temp_file_basename = ::File.join(Chef::Config[:file_cache_path], 'ddagent-up').gsub(File::SEPARATOR, File::ALT_SEPARATOR || File::SEPARATOR)
+use_windows_package_resource = true
 
-  dd_agent_installer = "#{dd_agent_installer_basename}.msi"
-  temp_file = "#{temp_file_basename}.msi"
-  installer_type = :msi
-  # Agent >= 5.12.0 installs per-machine by default, but specifying ALLUSERS=1 shouldn't affect the install
-  agent_install_options = node['dd-agent-reinstall']['agent_install_options']
-  install_options = "/norestart ALLUSERS=1  #{agent_install_options}"
+source_url = node['dd-agent-reinstall']['windows_agent_url']
+if !source_url.end_with? '/'
+  source_url += '/'
+end
+source_url += dd_agent_installer
 
-  use_windows_package_resource = true
+# Download the installer to a temp location
+remote_file temp_file do
+  source source_url
+  retries package_retries unless package_retries.nil?
+  retry_delay package_retry_delay unless package_retry_delay.nil?
+end
 
-  source_url = node['dd-agent-reinstall']['windows_agent_url']
-  if !source_url.end_with? '/'
-    source_url += '/'
-  end
-  source_url += dd_agent_installer
-
-    # Download the installer to a temp location
-  remote_file temp_file do
-    source source_url
-    checksum node['dd-agent-reinstall']['windows_agent_checksum'] if node['dd-agent-reinstall']['windows_agent_checksum']
-    retries package_retries unless package_retries.nil?
-    retry_delay package_retry_delay unless package_retry_delay.nil?
-  end
-
-  execute "reinstall-agent" do
-    command "start /wait msiexec /log upgrade.log /q /i #{temp_file} #{install_options}"
-    action :run
-    #notifies :restart, 'service[datadog-agent]'
-  end
-
+execute "reinstall-agent" do
+  command "start /wait msiexec /log upgrade.log /q /i #{temp_file} #{install_options}"
+  action :run
 end

--- a/test/kitchen/test-definitions/windows-npm-test.yml
+++ b/test/kitchen/test-definitions/windows-npm-test.yml
@@ -128,8 +128,6 @@ suites:
       <% end %>
       enable_testsigning: <%= ENV['WINDOWS_DDNPM_DRIVER'] == "testsigned" %>
     dd-agent-reinstall:
-      agent6: true
-      agent_major_version: 7
       windows_agent_url: <%= windows_agent_url %>
       <% if ENV['AGENT_VERSION'] %>
       windows_version: "<%= ENV['AGENT_VERSION'] %>"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Removes unused parts and attributes of the `dd-agent-reinstall` cookbook.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Simplify cookbooks.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Check that the `win-npm-reinstall-option` test passes.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
