### PR TITLE
pkg/obfuscate: improve tokenizer state access

### DIFF
--- a/pkg/obfuscate/sql_tokenizer.go
+++ b/pkg/obfuscate/sql_tokenizer.go
@@ -734,9 +734,9 @@ func (tkn *SQLTokenizer) bytes() []byte {
 	return ret
 }
 
-// Offset exports the tokenizer's current position in the query
-func (tkn *SQLTokenizer) Offset() int {
-	return tkn.off
+// Position exports the tokenizer's current position in the query
+func (tkn *SQLTokenizer) Position() int {
+	return tkn.pos
 }
 
 func isLeadingLetter(ch rune) bool {

--- a/pkg/obfuscate/sql_tokenizer_test.go
+++ b/pkg/obfuscate/sql_tokenizer_test.go
@@ -26,7 +26,7 @@ func TestSQLTokenizerPosition(t *testing.T) {
 			assert.Fail("experienced an unexpected lexer error")
 		}
 		assert.Equal(string(buff), query[startPos:tok.Position()])
-		tokenCount += 1
+		tokenCount++
 		tok.SkipBlank()
 	}
 	assert.Equal(10, tokenCount)

--- a/pkg/obfuscate/sql_tokenizer_test.go
+++ b/pkg/obfuscate/sql_tokenizer_test.go
@@ -7,7 +7,7 @@ package obfuscate
 
 import (
 	"testing"
-	
+
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,7 +16,7 @@ func TestSQLTokenizerPosition(t *testing.T) {
 	query := "SELECT username AS         person FROM users WHERE id=4"
 	tok := NewSQLTokenizer(query, false, nil)
 	tokenCount := 0
-	for {
+	for ; ; tokenCount++ {
 		startPos := tok.Position()
 		kind, buff := tok.Scan()
 		if kind == EndChar {
@@ -26,7 +26,6 @@ func TestSQLTokenizerPosition(t *testing.T) {
 			assert.Fail("experienced an unexpected lexer error")
 		}
 		assert.Equal(string(buff), query[startPos:tok.Position()])
-		tokenCount++
 		tok.SkipBlank()
 	}
 	assert.Equal(10, tokenCount)

--- a/pkg/obfuscate/sql_tokenizer_test.go
+++ b/pkg/obfuscate/sql_tokenizer_test.go
@@ -6,8 +6,9 @@
 package obfuscate
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+	
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSQLTokenizerPosition(t *testing.T) {

--- a/pkg/obfuscate/sql_tokenizer_test.go
+++ b/pkg/obfuscate/sql_tokenizer_test.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package obfuscate
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestTokenizerIndex(t *testing.T) {
+	assert := assert.New(t)
+
+	query := "SELECT username AS         person FROM users WHERE id=4"
+	tokenizer := NewSQLTokenizer(query, false, nil)
+	for {
+		startPos := tokenizer.Position()
+		kind, buff := tokenizer.Scan()
+		if kind == EndChar {
+			break
+		}
+		if kind == LexError {
+			assert.Fail("experienced an unexpected lexer error")
+		}
+
+		assert.Equal(string(buff), query[startPos:tokenizer.Position()])
+		tokenizer.SkipBlank()
+	}
+
+}

--- a/pkg/obfuscate/sql_tokenizer_test.go
+++ b/pkg/obfuscate/sql_tokenizer_test.go
@@ -10,23 +10,23 @@ import (
 	"testing"
 )
 
-func TestTokenizerIndex(t *testing.T) {
+func TestSQLTokenizerPosition(t *testing.T) {
 	assert := assert.New(t)
-
 	query := "SELECT username AS         person FROM users WHERE id=4"
-	tokenizer := NewSQLTokenizer(query, false, nil)
+	tok := NewSQLTokenizer(query, false, nil)
+	tokenCount := 0
 	for {
-		startPos := tokenizer.Position()
-		kind, buff := tokenizer.Scan()
+		startPos := tok.Position()
+		kind, buff := tok.Scan()
 		if kind == EndChar {
 			break
 		}
 		if kind == LexError {
 			assert.Fail("experienced an unexpected lexer error")
 		}
-
-		assert.Equal(string(buff), query[startPos:tokenizer.Position()])
-		tokenizer.SkipBlank()
+		assert.Equal(string(buff), query[startPos:tok.Position()])
+		tokenCount += 1
+		tok.SkipBlank()
 	}
-
+	assert.Equal(10, tokenCount)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Replace a method exposing an internal property of the SQL tokeniser.
`off` report the current look ahead relative to the last consumed character, which is useless to external users.
What we meant to return was `pos` which is the position of the last consumed (returned) character.
A test was added to underline the use case (that calling `Position()` before and after `Scan()` result in the exact indices of the parsed token in the original query.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Make use cases similar to the test work.
This is an improvement on https://github.com/DataDog/datadog-agent/pull/10129

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
