### PR TITLE
[CWS] refactor SECL opts

### DIFF
--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -285,24 +285,22 @@ func (m *Module) Reload() error {
 	policiesDir := m.config.PoliciesDir
 	rsa := sprobe.NewRuleSetApplier(m.config, m.probe)
 
-	newRuleSetOpts := func() *rules.Opts {
-		return rules.NewOptsWithParams(
-			model.SECLConstants,
-			sprobe.SECLVariables,
-			sprobe.SupportedDiscarders,
-			m.getEventTypeEnabled(),
-			sprobe.AllCustomRuleIDs(),
-			model.SECLLegacyAttributes,
-			&seclog.PatternLogger{})
-	}
-
-	ruleSet := m.probe.NewRuleSet(newRuleSetOpts())
-
-	loadErr := rules.LoadPolicies(policiesDir, ruleSet)
+	var opts rules.Opts
+	opts.
+		WithConstants(model.SECLConstants).
+		WithVariables(sprobe.SECLVariables).
+		WithSupportedDiscarders(sprobe.SupportedDiscarders).
+		WithEventTypeEnabled(m.getEventTypeEnabled()).
+		WithReservedRuleIDs(sprobe.AllCustomRuleIDs()).
+		WithLegacyFields(model.SECLLegacyFields).
+		WithLogger(&seclog.PatternLogger{})
 
 	model := &model.Model{}
-	approverRuleSet := rules.NewRuleSet(model, model.NewEvent, newRuleSetOpts())
+	approverRuleSet := rules.NewRuleSet(model, model.NewEvent, &opts)
 	loadApproversErr := rules.LoadPolicies(policiesDir, approverRuleSet)
+
+	ruleSet := m.probe.NewRuleSet(&opts)
+	loadErr := rules.LoadPolicies(policiesDir, ruleSet)
 
 	if loadErr.ErrorOrNil() != nil {
 		logMultiErrors("error while loading policies: %+v", loadErr)

--- a/pkg/security/probe/approvers_test.go
+++ b/pkg/security/probe/approvers_test.go
@@ -10,8 +10,7 @@ package probe
 import (
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/security/log"
-
+	seclog "github.com/DataDog/datadog-agent/pkg/security/log"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
@@ -19,8 +18,16 @@ import (
 
 func TestApproverAncestors1(t *testing.T) {
 	enabled := map[eval.EventType]bool{"*": true}
+
+	var opts rules.Opts
+	opts.
+		WithConstants(model.SECLConstants).
+		WithEventTypeEnabled(enabled).
+		WithLegacyFields(model.SECLLegacyFields).
+		WithLogger(&seclog.PatternLogger{})
+
 	m := &model.Model{}
-	rs := rules.NewRuleSet(m, m.NewEvent, rules.NewOptsWithParams(model.SECLConstants, nil, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	rs := rules.NewRuleSet(m, m.NewEvent, &opts)
 	addRuleExpr(t, rs, `open.file.path == "/etc/passwd" && process.ancestors.file.name == "vipw"`, `open.file.path == "/etc/shadow" && process.ancestors.file.name == "vipw"`)
 
 	capabilities, exists := allCapabilities["open"]
@@ -40,8 +47,16 @@ func TestApproverAncestors1(t *testing.T) {
 
 func TestApproverAncestors2(t *testing.T) {
 	enabled := map[eval.EventType]bool{"*": true}
+
+	var opts rules.Opts
+	opts.
+		WithConstants(model.SECLConstants).
+		WithEventTypeEnabled(enabled).
+		WithLegacyFields(model.SECLLegacyFields).
+		WithLogger(&seclog.PatternLogger{})
+
 	m := &model.Model{}
-	rs := rules.NewRuleSet(m, m.NewEvent, rules.NewOptsWithParams(model.SECLConstants, nil, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	rs := rules.NewRuleSet(m, m.NewEvent, &opts)
 	addRuleExpr(t, rs, `(open.file.path == "/etc/shadow" || open.file.path == "/etc/gshadow") && process.ancestors.file.path not in ["/usr/bin/dpkg"]`)
 	capabilities, exists := allCapabilities["open"]
 	if !exists {

--- a/pkg/security/probe/discarders_test.go
+++ b/pkg/security/probe/discarders_test.go
@@ -11,7 +11,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/DataDog/datadog-agent/pkg/security/log"
+	seclog "github.com/DataDog/datadog-agent/pkg/security/log"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
@@ -39,49 +39,56 @@ func TestIsParentDiscarder(t *testing.T) {
 
 	enabled := map[eval.EventType]bool{"*": true}
 
-	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	var opts rules.Opts
+	opts.
+		WithConstants(model.SECLConstants).
+		WithEventTypeEnabled(enabled).
+		WithLegacyFields(model.SECLLegacyFields).
+		WithLogger(&seclog.PatternLogger{})
+
+	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/log/datadog/system-probe.log"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/datadog/system-probe.sock"); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
 	addRuleExpr(t, rs, `unlink.file.path == "/var/log/datadog/system-probe.log"`, `unlink.file.name == "datadog"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/log/datadog/datadog-agent.log"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.name =~ ".*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/var/lib/.runc/1234"); is {
 		t.Error("shouldn't be able to find a parent discarder, due to partial evaluation: true && unlink.file.name =~ '.*'")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
 	addRuleExpr(t, rs, `unlink.file.path == "/etc/conf.d/httpd.conf" || unlink.file.name == "conf.d"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/nginx.conf"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
 	addRuleExpr(t, rs, `unlink.file.path == "/etc/conf.d/httpd.conf" || unlink.file.name == "sys.d"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/sys.d/nginx.conf"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
 	addRuleExpr(t, rs, `unlink.file.name == "conf.d"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/nginx.conf"); is {
@@ -89,77 +96,77 @@ func TestIsParentDiscarder(t *testing.T) {
 	}
 
 	// field that doesn't exists shouldn't return any discarders
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
 	addRuleExpr(t, rs, `rename.file.path == "/etc/conf.d/abc"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileRenameEventType, "rename.file.path", "/etc/conf.d/nginx.conf"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
 	addRuleExpr(t, rs, `rename.file.path == "/etc/conf.d/abc"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileRenameEventType, "rename.file.path", "/etc/nginx/nginx.conf"); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/conf.d/*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/sys.d/nginx.conf"); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/conf.d/ab*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.d/ab*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "*/conf.d"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/conf.d/abc"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
 	addRuleExpr(t, rs, `unlink.file.path =~ "/etc/*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileUnlinkEventType, "unlink.file.path", "/etc/cron.d/log"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
 	addRuleExpr(t, rs, `open.file.path == "/tmp/passwd"`, `open.file.path == "/tmp/secret"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/runc"); is {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
 	addRuleExpr(t, rs, `open.file.path =~ "/run/secrets/kubernetes.io/serviceaccount/*/token"`, `open.file.path == "/etc/secret"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/token"); !is {
 		t.Error("should be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
 	addRuleExpr(t, rs, `open.file.path =~ "*/token"`, `open.file.path == "/etc/secret"`)
 
 	is, err := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/token")
@@ -170,7 +177,7 @@ func TestIsParentDiscarder(t *testing.T) {
 		t.Error("shouldn't be a parent discarder")
 	}
 
-	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	rs = rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
 	addRuleExpr(t, rs, `open.file.path =~ "/tmp/dir/no-approver-*"`)
 
 	if is, _ := id.isParentPathDiscarder(rs, model.FileOpenEventType, "open.file.path", "/tmp/dir/a/test"); !is {
@@ -183,7 +190,14 @@ func BenchmarkParentDiscarder(b *testing.B) {
 
 	enabled := map[eval.EventType]bool{"*": true}
 
-	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, rules.NewOptsWithParams(model.SECLConstants, nil, nil, enabled, nil, model.SECLLegacyAttributes, &log.PatternLogger{}))
+	var opts rules.Opts
+	opts.
+		WithConstants(model.SECLConstants).
+		WithEventTypeEnabled(enabled).
+		WithLegacyFields(model.SECLLegacyFields).
+		WithLogger(&seclog.PatternLogger{})
+
+	rs := rules.NewRuleSet(&Model{}, func() eval.Event { return &Event{} }, &opts)
 	addRuleExpr(b, rs, `unlink.file.path =~ "/var/log/*" && unlink.file.path != "/var/log/datadog/system-probe.log"`)
 
 	b.ResetTimer()

--- a/pkg/security/secl/compiler/eval/eval.go
+++ b/pkg/security/secl/compiler/eval/eval.go
@@ -63,14 +63,6 @@ type VariableValue struct {
 	StringFnc func(ctx *Context) string
 }
 
-// Opts are the options to be passed to the evaluator
-type Opts struct {
-	LegacyAttributes map[Field]Field
-	Constants        map[string]interface{}
-	Macros           map[MacroID]*Macro
-	Variables        map[string]VariableValue
-}
-
 // Evaluator is the interface of an evaluator
 type Evaluator interface {
 	Eval(ctx *Context) interface{}
@@ -322,12 +314,12 @@ func identToEvaluator(obj *ident, opts *Opts, state *state) (interface{}, lexer.
 		return nil, obj.Pos, err
 	}
 
-	// transform extracted field to support legacy SECL attributes
-	if opts.LegacyAttributes != nil {
-		if newField, ok := opts.LegacyAttributes[field]; ok {
+	// transform extracted field to support legacy SECL fields
+	if opts.LegacyFields != nil {
+		if newField, ok := opts.LegacyFields[field]; ok {
 			field = newField
 		}
-		if newField, ok := opts.LegacyAttributes[field]; ok {
+		if newField, ok := opts.LegacyFields[field]; ok {
 			itField = newField
 		}
 	}

--- a/pkg/security/secl/compiler/eval/eval_test.go
+++ b/pkg/security/secl/compiler/eval/eval_test.go
@@ -19,12 +19,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/ast"
 )
 
-// NewOptsWithParams initializes a new Opts instance with Constants parameters
-func NewOptsWithParams(constants map[string]interface{}, legacyAttributes map[Field]Field) *Opts {
+func newOptsWithParams(constants map[string]interface{}, legacyFields map[Field]Field) *Opts {
 	return &Opts{
-		Constants:        constants,
-		Macros:           make(map[MacroID]*Macro),
-		LegacyAttributes: legacyAttributes,
+		Constants:    constants,
+		Macros:       make(map[MacroID]*Macro),
+		LegacyFields: legacyFields,
 		Variables: map[string]VariableValue{
 			"pid": {
 				IntFnc: func(ctx *Context) int {
@@ -62,7 +61,7 @@ func eval(t *testing.T, event *testEvent, expr string) (bool, *ast.Rule, error) 
 
 	ctx := NewContext(unsafe.Pointer(event))
 
-	opts := NewOptsWithParams(testConstants, nil)
+	opts := newOptsWithParams(testConstants, nil)
 	rule, err := parseRule(expr, model, opts)
 	if err != nil {
 		return false, nil, err
@@ -535,7 +534,7 @@ func TestMacroList(t *testing.T) {
 		t.Fatalf("%s\n%s", err, macro.Expression)
 	}
 
-	opts := NewOptsWithParams(make(map[string]interface{}), nil)
+	opts := newOptsWithParams(make(map[string]interface{}), nil)
 	opts.Macros = map[string]*Macro{
 		"list": macro,
 	}
@@ -579,7 +578,7 @@ func TestMacroExpression(t *testing.T) {
 		t.Fatalf("%s\n%s", err, macro.Expression)
 	}
 
-	opts := NewOptsWithParams(make(map[string]interface{}), nil)
+	opts := newOptsWithParams(make(map[string]interface{}), nil)
 	opts.Macros = map[string]*Macro{
 		"is_passwd": macro,
 	}
@@ -622,7 +621,7 @@ func TestMacroPartial(t *testing.T) {
 		t.Fatalf("%s\n%s", err, macro.Expression)
 	}
 
-	opts := NewOptsWithParams(make(map[string]interface{}), nil)
+	opts := newOptsWithParams(make(map[string]interface{}), nil)
 	opts.Macros = map[string]*Macro{
 		"is_passwd": macro,
 	}
@@ -687,7 +686,7 @@ func TestNestedMacros(t *testing.T) {
 
 	model := &testModel{}
 
-	opts := NewOptsWithParams(make(map[string]interface{}), nil)
+	opts := newOptsWithParams(make(map[string]interface{}), nil)
 	opts.Macros = map[string]*Macro{
 		"sensitive_files":     macro1,
 		"is_sensitive_opened": macro2,
@@ -723,7 +722,7 @@ func TestFieldValidator(t *testing.T) {
 
 func TestLegacyField(t *testing.T) {
 	model := &testModel{}
-	opts := NewOptsWithParams(testConstants, legacyAttributes)
+	opts := newOptsWithParams(testConstants, legacyFields)
 
 	tests := []struct {
 		Expr     string
@@ -744,7 +743,7 @@ func TestLegacyField(t *testing.T) {
 
 func TestRegisterSyntaxError(t *testing.T) {
 	model := &testModel{}
-	opts := NewOptsWithParams(testConstants, nil)
+	opts := newOptsWithParams(testConstants, nil)
 
 	tests := []struct {
 		Expr     string

--- a/pkg/security/secl/compiler/eval/model_test.go
+++ b/pkg/security/secl/compiler/eval/model_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/pkg/errors"
 )
 
-var legacyAttributes = map[Field]Field{
+var legacyFields = map[Field]Field{
 	"process.legacy_name": "process.name",
 }
 

--- a/pkg/security/secl/compiler/eval/opts.go
+++ b/pkg/security/secl/compiler/eval/opts.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package eval
+
+// Opts are the options to be passed to the evaluator
+type Opts struct {
+	LegacyFields map[Field]Field
+	Constants    map[string]interface{}
+	Macros       map[MacroID]*Macro
+	Variables    map[string]VariableValue
+}
+
+// WithConstants set constants
+func (o *Opts) WithConstants(constants map[string]interface{}) *Opts {
+	o.Constants = constants
+	return o
+}
+
+// WithVariables set variables
+func (o *Opts) WithVariables(variables map[string]VariableValue) *Opts {
+	o.Variables = variables
+	return o
+}
+
+// WithLegacyFields set legacy fields
+func (o *Opts) WithLegacyFields(fields map[Field]Field) *Opts {
+	o.LegacyFields = fields
+	return o
+}

--- a/pkg/security/secl/model/legacy_secl.go
+++ b/pkg/security/secl/model/legacy_secl.go
@@ -9,8 +9,8 @@ package model
 
 import "github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 
-// SECLLegacyAttributes contains the list of the legacy attributes we need to support
-var SECLLegacyAttributes = map[eval.Field]eval.Field{
+// SECLLegacyFields contains the list of the legacy attributes we need to support
+var SECLLegacyFields = map[eval.Field]eval.Field{
 	// chmod
 	"chmod.filename": "chmod.file.path",
 	"chmod.basename": "chmod.file.name",

--- a/pkg/security/secl/rules/opts.go
+++ b/pkg/security/secl/rules/opts.go
@@ -1,0 +1,61 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package rules
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+)
+
+// Opts defines rules set options
+type Opts struct {
+	eval.Opts
+	SupportedDiscarders map[eval.Field]bool
+	ReservedRuleIDs     []RuleID
+	EventTypeEnabled    map[eval.EventType]bool
+	Logger              Logger
+}
+
+// WithConstants set constants
+func (o *Opts) WithConstants(constants map[string]interface{}) *Opts {
+	o.Opts.WithConstants(constants)
+	return o
+}
+
+// WithVariables set variables
+func (o *Opts) WithVariables(variables map[string]eval.VariableValue) *Opts {
+	o.Opts.WithVariables(variables)
+	return o
+}
+
+// WithLegacyFields set legacy fields
+func (o *Opts) WithLegacyFields(fields map[eval.Field]eval.Field) *Opts {
+	o.Opts.WithLegacyFields(fields)
+	return o
+}
+
+// WithSupportedDiscarders set supported discarders
+func (o *Opts) WithSupportedDiscarders(discarders map[eval.Field]bool) *Opts {
+	o.SupportedDiscarders = discarders
+	return o
+}
+
+// WithEventTypeEnabled set event types enabled
+func (o *Opts) WithEventTypeEnabled(eventTypes map[eval.EventType]bool) *Opts {
+	o.EventTypeEnabled = eventTypes
+	return o
+}
+
+// WithReservedRuleIDs set reserved rule ids
+func (o *Opts) WithReservedRuleIDs(ruleIds []RuleID) *Opts {
+	o.ReservedRuleIDs = ruleIds
+	return o
+}
+
+// WithLogger set logger
+func (o *Opts) WithLogger(logger Logger) *Opts {
+	o.Logger = logger
+	return o
+}

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -67,34 +67,6 @@ type RuleSetListener interface {
 	EventDiscarderFound(rs *RuleSet, event eval.Event, field eval.Field, eventType eval.EventType)
 }
 
-// Opts defines rules set options
-type Opts struct {
-	eval.Opts
-	SupportedDiscarders map[eval.Field]bool
-	ReservedRuleIDs     []RuleID
-	EventTypeEnabled    map[eval.EventType]bool
-	Logger              Logger
-}
-
-// NewOptsWithParams initializes a new Opts instance with Debug and Constants parameters
-func NewOptsWithParams(constants map[string]interface{}, variables map[string]eval.VariableValue, supportedDiscarders map[eval.Field]bool, eventTypeEnabled map[eval.EventType]bool, reservedRuleIDs []RuleID, legacyAttributes map[eval.Field]eval.Field, logger ...Logger) *Opts {
-	if len(logger) == 0 {
-		logger = []Logger{NullLogger{}}
-	}
-	return &Opts{
-		Opts: eval.Opts{
-			Constants:        constants,
-			Variables:        variables,
-			Macros:           make(map[eval.MacroID]*eval.Macro),
-			LegacyAttributes: legacyAttributes,
-		},
-		SupportedDiscarders: supportedDiscarders,
-		ReservedRuleIDs:     reservedRuleIDs,
-		EventTypeEnabled:    eventTypeEnabled,
-		Logger:              logger[0],
-	}
-}
-
 // RuleSet holds a list of rules, grouped in bucket. An event can be evaluated
 // against it. If the rule matches, the listeners for this rule set are notified
 type RuleSet struct {
@@ -475,6 +447,14 @@ func (rs *RuleSet) AddPolicyVersion(filename string, version string) {
 
 // NewRuleSet returns a new ruleset for the specified data model
 func NewRuleSet(model eval.Model, eventCtor func() eval.Event, opts *Opts) *RuleSet {
+	var logger Logger
+
+	if opts.Logger != nil {
+		logger = opts.Logger
+	} else {
+		logger = &NullLogger{}
+	}
+
 	return &RuleSet{
 		model:            model,
 		eventCtor:        eventCtor,
@@ -483,7 +463,7 @@ func NewRuleSet(model eval.Model, eventCtor func() eval.Event, opts *Opts) *Rule
 		rules:            make(map[eval.RuleID]*Rule),
 		macros:           make(map[eval.RuleID]*Macro),
 		loadedPolicies:   make(map[string]string),
-		logger:           opts.Logger,
+		logger:           logger,
 		pool:             eval.NewContextPool(),
 	}
 }

--- a/pkg/security/secl/rules/ruleset_test.go
+++ b/pkg/security/secl/rules/ruleset_test.go
@@ -74,7 +74,14 @@ func addRuleExpr(t *testing.T, rs *RuleSet, exprs ...string) {
 
 func TestRuleBuckets(t *testing.T) {
 	enabled := map[eval.EventType]bool{"*": true}
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, nil, testSupportedDiscarders, enabled, nil, nil))
+
+	var opts Opts
+	opts.
+		WithConstants(testConstants).
+		WithSupportedDiscarders(testSupportedDiscarders).
+		WithEventTypeEnabled(enabled)
+
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts)
 
 	exprs := []string{
 		`(open.filename =~ "/sbin/*" || open.filename =~ "/usr/sbin/*") && process.uid != 0 && open.flags & O_CREAT > 0`,
@@ -107,7 +114,14 @@ func TestRuleSetDiscarders(t *testing.T) {
 	}
 
 	enabled := map[eval.EventType]bool{"*": true}
-	rs := NewRuleSet(m, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, nil, testSupportedDiscarders, enabled, nil, nil))
+
+	var opts Opts
+	opts.
+		WithConstants(testConstants).
+		WithSupportedDiscarders(testSupportedDiscarders).
+		WithEventTypeEnabled(enabled)
+
+	rs := NewRuleSet(m, func() eval.Event { return &testEvent{} }, &opts)
 	rs.AddListener(handler)
 
 	exprs := []string{
@@ -168,7 +182,14 @@ func TestRuleSetDiscarders(t *testing.T) {
 
 func TestRuleSetFilters1(t *testing.T) {
 	enabled := map[eval.EventType]bool{"*": true}
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, nil, testSupportedDiscarders, enabled, nil, nil))
+
+	var opts Opts
+	opts.
+		WithConstants(testConstants).
+		WithSupportedDiscarders(testSupportedDiscarders).
+		WithEventTypeEnabled(enabled)
+
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts)
 
 	addRuleExpr(t, rs, `open.filename in ["/etc/passwd", "/etc/shadow"] && (process.uid == 0 || process.gid == 0)`)
 
@@ -227,7 +248,14 @@ func TestRuleSetFilters1(t *testing.T) {
 
 func TestRuleSetFilters2(t *testing.T) {
 	enabled := map[eval.EventType]bool{"*": true}
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, nil, testSupportedDiscarders, enabled, nil, nil))
+
+	var opts Opts
+	opts.
+		WithConstants(testConstants).
+		WithSupportedDiscarders(testSupportedDiscarders).
+		WithEventTypeEnabled(enabled)
+
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts)
 
 	exprs := []string{
 		`open.filename in ["/etc/passwd", "/etc/shadow"] && process.uid == 0`,
@@ -284,7 +312,14 @@ func TestRuleSetFilters2(t *testing.T) {
 
 func TestRuleSetFilters3(t *testing.T) {
 	enabled := map[eval.EventType]bool{"*": true}
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, nil, testSupportedDiscarders, enabled, nil, nil))
+
+	var opts Opts
+	opts.
+		WithConstants(testConstants).
+		WithSupportedDiscarders(testSupportedDiscarders).
+		WithEventTypeEnabled(enabled)
+
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts)
 
 	addRuleExpr(t, rs, `open.filename in ["/etc/passwd", "/etc/shadow"] && (process.uid == process.gid)`)
 
@@ -311,7 +346,14 @@ func TestRuleSetFilters3(t *testing.T) {
 
 func TestRuleSetFilters4(t *testing.T) {
 	enabled := map[eval.EventType]bool{"*": true}
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, nil, testSupportedDiscarders, enabled, nil, nil))
+
+	var opts Opts
+	opts.
+		WithConstants(testConstants).
+		WithSupportedDiscarders(testSupportedDiscarders).
+		WithEventTypeEnabled(enabled)
+
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts)
 
 	addRuleExpr(t, rs, `open.filename =~ "/etc/passwd" && process.uid == 0`)
 
@@ -340,7 +382,14 @@ func TestRuleSetFilters4(t *testing.T) {
 
 func TestRuleSetFilters5(t *testing.T) {
 	enabled := map[eval.EventType]bool{"*": true}
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, nil, testSupportedDiscarders, enabled, nil, nil))
+
+	var opts Opts
+	opts.
+		WithConstants(testConstants).
+		WithSupportedDiscarders(testSupportedDiscarders).
+		WithEventTypeEnabled(enabled)
+
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts)
 
 	addRuleExpr(t, rs, `(open.flags & O_CREAT > 0 || open.flags & O_EXCL > 0) && open.flags & O_RDWR > 0`)
 
@@ -365,7 +414,14 @@ func TestRuleSetFilters6(t *testing.T) {
 	t.Skip()
 
 	enabled := map[eval.EventType]bool{"*": true}
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, nil, testSupportedDiscarders, enabled, nil, nil))
+
+	var opts Opts
+	opts.
+		WithConstants(testConstants).
+		WithSupportedDiscarders(testSupportedDiscarders).
+		WithEventTypeEnabled(enabled)
+
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts)
 
 	addRuleExpr(t, rs, `(open.flags & O_CREAT > 0 || open.flags & O_EXCL > 0) || process.name == "httpd"`)
 
@@ -383,7 +439,14 @@ func TestRuleSetFilters6(t *testing.T) {
 
 func TestRuleSetFilters7(t *testing.T) {
 	enabled := map[eval.EventType]bool{"*": true}
-	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, NewOptsWithParams(testConstants, nil, testSupportedDiscarders, enabled, nil, nil))
+
+	var opts Opts
+	opts.
+		WithConstants(testConstants).
+		WithSupportedDiscarders(testSupportedDiscarders).
+		WithEventTypeEnabled(enabled)
+
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts)
 
 	addRuleExpr(t, rs, `open.filename == "123456"`)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Refactor the SECL opts constructor.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
