### PR TITLE
[kitchen] Remove usage of obsolete agent6 attribute

### DIFF
--- a/test/kitchen/test-definitions/windows-install-test.yml
+++ b/test/kitchen/test-definitions/windows-install-test.yml
@@ -11,7 +11,6 @@ suites:
         <%= key %>: <%= value %>
         <% end %>
       dd-agent-install:
-        agent6: false
         <% if ENV['AGENT_VERSION'] %>
         windows_version: "<%= ENV['AGENT_VERSION'] %>"
         <% end %>
@@ -67,7 +66,6 @@ suites:
         <%= key %>: <%= value %>
         <% end %>
       dd-agent-install:
-        agent6: true
         <% if ENV['AGENT_VERSION'] %>
         windows_version: "<%= ENV['AGENT_VERSION'] %>"
         <% end %>
@@ -104,7 +102,6 @@ suites:
         <%= key %>: <%= value %>
         <% end %>
       dd-agent-install:
-        agent6: true
         windows_agent_url: <%= windows_agent_url %>
         <% if ENV['AGENT_VERSION'] %>
         windows_version: "<%= ENV['AGENT_VERSION'] %>"
@@ -133,7 +130,6 @@ suites:
         <%= key %>: <%= value %>
         <% end %>
       dd-agent-install:
-        agent6: true
         windows_agent_url: <%= windows_agent_url %>
         <% if ENV['AGENT_VERSION'] %>
         windows_version: "<%= ENV['AGENT_VERSION'] %>"
@@ -162,7 +158,6 @@ suites:
         <%= key %>: <%= value %>
         <% end %>
       dd-agent-install:
-        agent6: true
         <% if ENV['AGENT_VERSION'] %>
         windows_version: "<%= ENV['AGENT_VERSION'] %>"
         <% end %>
@@ -190,7 +185,6 @@ suites:
         <%= key %>: <%= value %>
         <% end %>
       dd-agent-install:
-        agent6: true
         <% if ENV['AGENT_VERSION'] %>
         windows_version: "<%= ENV['AGENT_VERSION'] %>"
         <% end %>
@@ -219,7 +213,6 @@ suites:
         <%= key %>: <%= value %>
         <% end %>
       dd-agent-install:
-        agent6: true
         <% if ENV['AGENT_VERSION'] %>
         windows_version: "<%= ENV['AGENT_VERSION'] %>"
         <% end %>

--- a/test/kitchen/test-definitions/windows-npm-test.yml
+++ b/test/kitchen/test-definitions/windows-npm-test.yml
@@ -91,7 +91,6 @@ suites:
       agent_flavor: 'datadog-iot-agent'
       <% end %>
     dd-agent-install:
-      agent6: true
       agent_major_version: 7
       windows_agent_url: <%= windows_agent_url %>
       <% if ENV['AGENT_VERSION'] %>
@@ -117,7 +116,6 @@ suites:
       agent_flavor: 'datadog-iot-agent'
       <% end %>
     dd-agent-install:
-      agent6: true
       agent_major_version: 7
       windows_agent_url: <%= windows_agent_url %>
       <% if ENV['AGENT_VERSION'] %>


### PR DESCRIPTION
### What does this PR do?

Removes the obsolete and unused `agent6` attribute still present in some kitchen test suites.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
