### PR TITLE
Kernel header downloading improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -74,7 +74,7 @@ require (
 	github.com/DataDog/gohai v0.0.0-20210303102637-6b668acb50dd
 	github.com/DataDog/gopsutil v0.0.0-20211112180027-9aa392ae181a
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect
-	github.com/DataDog/nikos v1.6.2
+	github.com/DataDog/nikos v1.6.3
 	github.com/DataDog/sketches-go v1.2.1
 	github.com/DataDog/viper v1.9.0
 	github.com/DataDog/watermarkpodautoscaler v0.3.1-logs-attributes.2.0.20211014120627-6d6a5c559fc9

--- a/go.sum
+++ b/go.sum
@@ -133,8 +133,8 @@ github.com/DataDog/kube-state-metrics/v2 v2.1.2-0.20211109105526-c17162ee2798/go
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/nikos v1.6.2 h1:AopzCPXKdNlNVmq7lP7Gc5b6m+fcsSYt9GxQvrG5lIU=
-github.com/DataDog/nikos v1.6.2/go.mod h1:r20vNQr3wTDrMZWLjOZBCJNWeuTB/rBO30ST5ywIfqw=
+github.com/DataDog/nikos v1.6.3 h1:dk/K6bszHzhSAzwNXMI4OvefBS68YR8KS+4n6s7Vt0o=
+github.com/DataDog/nikos v1.6.3/go.mod h1:r20vNQr3wTDrMZWLjOZBCJNWeuTB/rBO30ST5ywIfqw=
 github.com/DataDog/sketches-go v1.0.0/go.mod h1:O+XkJHWk9w4hDwY2ZUDU31ZC9sNYlYo8DiFsxjYeo1k=
 github.com/DataDog/sketches-go v1.2.1 h1:qTBzWLnZ3kM2kw39ymh6rMcnN+5VULwFs++lEYUUsro=
 github.com/DataDog/sketches-go v1.2.1/go.mod h1:1xYmPLY1So10AwxV6MJV0J53XVH+WL9Ad1KetxVivVI=

--- a/pkg/util/kernel/download_headers.go
+++ b/pkg/util/kernel/download_headers.go
@@ -64,6 +64,7 @@ func (h *headerDownloader) downloadHeaders(headerDownloadDir string) error {
 	if backend, err = h.getHeaderDownloadBackend(&target); err != nil {
 		return fmt.Errorf("unable to get kernel header download backend: %s", err)
 	}
+	defer backend.Close()
 
 	if err = backend.GetKernelHeaders(outputDir); err != nil {
 		return fmt.Errorf("failed to download kernel headers: %s", err)

--- a/pkg/util/kernel/download_headers.go
+++ b/pkg/util/kernel/download_headers.go
@@ -50,7 +50,7 @@ func (h *headerDownloader) downloadHeaders(headerDownloadDir string) error {
 		return fmt.Errorf("unable create output directory %s: %s", headerDownloadDir, err)
 	}
 
-	if target, err = getHeaderDownloadTarget(); err != nil {
+	if target, err = types.NewTarget(); err != nil {
 		return fmt.Errorf("failed to retrieve target information: %s", err)
 	}
 
@@ -96,21 +96,6 @@ func (h *headerDownloader) getHeaderDownloadBackend(target *types.Target) (backe
 		err = fmt.Errorf("Unsupported distribution '%s'", target.Distro.Display)
 	}
 	return
-}
-
-func getHeaderDownloadTarget() (types.Target, error) {
-	target, err := types.NewTarget()
-	if err != nil {
-		return types.Target{}, err
-	}
-
-	if _, err := os.Stat("/run/WSL"); err == nil {
-		target.Distro.Display = "wsl"
-	} else if id := target.OSRelease["ID"]; target.Distro.Display == "" && id != "" {
-		target.Distro.Display = id
-	}
-
-	return target, nil
 }
 
 func createOutputDir(path string) (string, error) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Updates the nikos dependency to pull in https://github.com/DataDog/nikos/pull/27 & makes sure the backend is properly closed.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
