### PR TITLE
Remove MacOS build from CircleCI, use Github Actions (through Gitlab) instead

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -241,77 +241,11 @@ jobs:
           name: generate doxygen documentation
           command: inv -e rtloader.generate-doc
 
-  macos_tests:
-    macos:
-      xcode: 11.7.0
-    environment:
-      MACOSBUILD_VERSION: "d28fcab12565bc42cc63a07e564ffb8c39b46f81" # datadog-agent-macos-build commit to fetch to get the MacOS scripts
-    working_directory: ~/go/src/github.com/DataDog/datadog-agent
-    steps:
-      - checkout
-      - run:
-          name: Remove existing packages
-          command: |
-            brew remove --force $(brew list --formula)
-      - restore_cache:
-          keys:
-            # If incremental dep fails, increase the cache version number
-            # See https://github.com/DataDog/datadog-agent/pull/2384
-            - v6-macosdeps-{{ .Branch }}-{{ .Revision }}
-            - v6-macosdeps-{{ .Branch }}-
-            - v6-macosdeps-main-
-      - run:
-          name: Setup runner
-          command: |
-            bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent-macos-build/$MACOSBUILD_VERSION/scripts/builder_setup.sh)"
-      - run:
-          name: Install python deps & clang-format
-          command: |
-            brew install clang-format || brew link --overwrite clang-format
-            python3 -m pip install -r requirements.txt
-      - save_cache:
-          key: v6-macosdeps-{{ .Branch }}-{{ .Revision }}
-          paths:
-            - /usr/local/bin
-            - /usr/local/Cellar
-            - /usr/local/lib
-            - /usr/local/Frameworks
-            - /usr/local/opt
-      - run:
-          name: Compile rtloader
-          command: |
-            source ~/.build_setup
-
-            inv rtloader.make --install-prefix=$GOPATH/src/github.com/DataDog/datadog-agent/dev
-            inv rtloader.install
-      - run:
-          name: Lint rtloader
-          command: |
-            source ~/.build_setup
-
-            inv rtloader.format --raise-if-changed
-      - run:
-          name: Test rtloader
-          command: |
-            source ~/.build_setup
-
-            inv rtloader.test
-      - run:
-          name: Run tests
-          command: |
-            source ~/.build_setup
-            inv -e install-tools
-            inv -e deps
-            inv -e test --rerun-fails=2 --python-runtimes 3 --coverage --race --profile --fail-on-fmt --cpus 3
-            python3 -m tasks.release_tests
-            python3 -m tasks.libs.version_tests
-
 workflows:
   version: 2
   test_and_build:
     jobs:
       - checkout_code
-      - macos_tests
       - dependencies:
           requires:
             - checkout_code

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -245,7 +245,7 @@ jobs:
     macos:
       xcode: 11.7.0
     environment:
-      BUILDIMAGES_VERSION: "249dd7120e29cf04436a116834f5a3e7f634b6a7" # datadog-agent-buildimages commit to fetch to get the MacOS scripts
+      MACOSBUILD_VERSION: "d28fcab12565bc42cc63a07e564ffb8c39b46f81" # datadog-agent-macos-build commit to fetch to get the MacOS scripts
     working_directory: ~/go/src/github.com/DataDog/datadog-agent
     steps:
       - checkout
@@ -263,7 +263,7 @@ jobs:
       - run:
           name: Setup runner
           command: |
-            bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/$BUILDIMAGES_VERSION/macos/builder_setup.sh)"
+            bash -c "$(curl -L https://raw.githubusercontent.com/DataDog/datadog-agent-macos-build/$MACOSBUILD_VERSION/scripts/builder_setup.sh)"
       - run:
           name: Install python deps & clang-format
           command: |

--- a/.gitlab/package_build/dmg.yml
+++ b/.gitlab/package_build/dmg.yml
@@ -20,7 +20,7 @@
 agent_dmg-x64-a6:
   extends: .agent_build_common_dmg
   rules:
-    !reference [.on_all_builds_a6]
+    !reference [.on_a6]
   allow_failure: true
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES

--- a/.gitlab/source_test.yml
+++ b/.gitlab/source_test.yml
@@ -7,6 +7,7 @@ include:
   - /.gitlab/source_test/ebpf.yml
   - /.gitlab/source_test/linux.yml
   - /.gitlab/source_test/security_scan.yml
+  - /.gitlab/source_test/macos.yml
   - /.gitlab/source_test/windows.yml
   - /.gitlab/source_test/go_generate_check.yml
   - /.gitlab/source_test/golang_deps_generate.yml

--- a/.gitlab/source_test/macos.yml
+++ b/.gitlab/source_test/macos.yml
@@ -1,0 +1,17 @@
+
+tests_macos:
+  stage: source_test
+  rules:
+    !reference [.on_a6]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["runner:main"]
+  needs: []
+  variables:
+    PYTHON_RUNTIMES: '3'
+  script:
+    - export GITHUB_KEY_B64=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.macos_github_key_b64 --with-decryption --query "Parameter.Value" --out text)
+    - export GITHUB_APP_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.macos_github_app_id --with-decryption --query "Parameter.Value" --out text)
+    - export GITHUB_INSTALLATION_ID=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.macos_github_installation_id --with-decryption --query "Parameter.Value" --out text)
+    - python3 -m pip install -r requirements.txt
+    - python3 -m pip install -r tasks/libs/requirements-github.txt
+    - inv -e github.trigger-macos-test --datadog-agent-ref "$CI_COMMIT_SHA" --python-runtimes "$PYTHON_RUNTIMES"

--- a/tasks/github.py
+++ b/tasks/github.py
@@ -28,3 +28,25 @@ def trigger_macos_build(
     follow_workflow_run(run_id)
 
     download_artifacts(run_id, destination)
+
+
+@task
+def trigger_macos_test(
+    ctx,
+    datadog_agent_ref=DEFAULT_BRANCH,
+    release_version="nightly-a7",
+    python_runtimes="3",
+):
+
+    env = load_release_versions(ctx, release_version)
+    github_action_ref = env["MACOS_BUILD_VERSION"]
+    github_action_ref = "72536387d7e0f6cd1970e4d0f846c2c3a3968567"
+
+    run_id = trigger_macos_workflow(
+        github_action_ref=github_action_ref,
+        datadog_agent_ref=datadog_agent_ref,
+        python_runtimes=python_runtimes,
+        test_only=True,
+    )
+
+    follow_workflow_run(run_id)

--- a/tasks/github.py
+++ b/tasks/github.py
@@ -41,7 +41,6 @@ def trigger_macos_test(
 
     env = load_release_versions(ctx, release_version)
     github_action_ref = env["MACOS_BUILD_VERSION"]
-    github_action_ref = "72536387d7e0f6cd1970e4d0f846c2c3a3968567"
 
     run_id = trigger_macos_workflow(
         workflow="test.yaml",

--- a/tasks/github.py
+++ b/tasks/github.py
@@ -18,6 +18,7 @@ def trigger_macos_build(
     github_action_ref = env["MACOS_BUILD_VERSION"]
 
     run_id = trigger_macos_workflow(
+        workflow="macos.yaml",
         github_action_ref=github_action_ref,
         datadog_agent_ref=datadog_agent_ref,
         release_version=release_version,
@@ -43,10 +44,10 @@ def trigger_macos_test(
     github_action_ref = "72536387d7e0f6cd1970e4d0f846c2c3a3968567"
 
     run_id = trigger_macos_workflow(
+        workflow="test.yaml",
         github_action_ref=github_action_ref,
         datadog_agent_ref=datadog_agent_ref,
         python_runtimes=python_runtimes,
-        test_only=True,
     )
 
     follow_workflow_run(run_id)

--- a/tasks/libs/common/remote_api.py
+++ b/tasks/libs/common/remote_api.py
@@ -66,9 +66,9 @@ class RemoteAPI(object):
                     r = requests.post(url, headers=headers, data=data, stream=stream_output)
             else:
                 r = requests.get(url, headers=headers, stream=stream_output)
-            if r.status_code == 401:
-                print(self.authorization_error_message)
-
+            if r.status_code >= 400:
+                if r.status_code == 401:
+                    print(self.authorization_error_message)
                 print(f"{self.api_name} says: {r.json()}")
                 raise Exit(code=1)
         except requests.exceptions.Timeout:

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -31,6 +31,7 @@ def trigger_macos_workflow(
     release_version="nightly-a7",
     major_version="7",
     python_runtimes="3",
+    test_only=False,
 ):
     """
     Trigger a workflow to build a MacOS Agent.
@@ -48,6 +49,9 @@ def trigger_macos_workflow(
 
     if python_runtimes is not None:
         inputs["python_runtimes"] = python_runtimes
+
+    if test_only is not None:
+        inputs["test_only"] = str(test_only).lower()
 
     print(
         "Creating workflow on datadog-agent-macos-build on commit {} with args:\n{}".format(  # noqa: FS002

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -70,7 +70,7 @@ def trigger_macos_workflow(
     MAX_RETRIES = 10  # Retry up to 10 times
     for i in range(MAX_RETRIES):
         print(f"Fetching triggered workflow (try {i + 1}/{MAX_RETRIES})")
-        run = get_macos_workflow_run_for_ref(github_action_ref)
+        run = get_macos_workflow_run_for_ref(workflow, github_action_ref)
         if run is not None and run.get("created_at", datetime.fromtimestamp(0).strftime("%Y-%m-%dT%H:%M:%SZ")) >= now:
             return run.get("id")
 
@@ -81,11 +81,11 @@ def trigger_macos_workflow(
     raise Exit(code=1)
 
 
-def get_macos_workflow_run_for_ref(github_action_ref="master"):
+def get_macos_workflow_run_for_ref(workflow="macos.yaml", github_action_ref="master"):
     """
     Get the latest workflow for the given ref.
     """
-    return create_or_refresh_macos_build_github_workflows().latest_workflow_run_for_ref("macos.yaml", github_action_ref)
+    return create_or_refresh_macos_build_github_workflows().latest_workflow_run_for_ref(workflow, github_action_ref)
 
 
 def follow_workflow_run(run_id):

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -26,12 +26,12 @@ def create_or_refresh_macos_build_github_workflows(github_workflows=None):
 
 
 def trigger_macos_workflow(
+    workflow="macos.yaml",
     github_action_ref="master",
     datadog_agent_ref=DEFAULT_BRANCH,
     release_version="nightly-a7",
     major_version="7",
     python_runtimes="3",
-    test_only=False,
 ):
     """
     Trigger a workflow to build a MacOS Agent.
@@ -50,9 +50,6 @@ def trigger_macos_workflow(
     if python_runtimes is not None:
         inputs["python_runtimes"] = python_runtimes
 
-    if test_only is not None:
-        inputs["test_only"] = str(test_only).lower()
-
     print(
         "Creating workflow on datadog-agent-macos-build on commit {} with args:\n{}".format(  # noqa: FS002
             github_action_ref, "\n".join([f"  - {k}: {inputs[k]}" for k in inputs])
@@ -64,7 +61,7 @@ def trigger_macos_workflow(
 
     # The workflow trigger endpoint doesn't return anything. You need to fetch the workflow run id
     # by yourself.
-    create_or_refresh_macos_build_github_workflows().trigger_workflow("macos.yaml", github_action_ref, inputs)
+    create_or_refresh_macos_build_github_workflows().trigger_workflow(workflow, github_action_ref, inputs)
 
     # Thus the following hack: query the latest run for ref, wait until we get a non-completed run
     # that started after we triggered the workflow.

--- a/tasks/libs/github_actions_tools.py
+++ b/tasks/libs/github_actions_tools.py
@@ -29,8 +29,8 @@ def trigger_macos_workflow(
     workflow="macos.yaml",
     github_action_ref="master",
     datadog_agent_ref=DEFAULT_BRANCH,
-    release_version="nightly-a7",
-    major_version="7",
+    release_version=None,
+    major_version=None,
     python_runtimes="3",
 ):
     """


### PR DESCRIPTION
### What does this PR do?

CircleCI hits the OpenSSL 1.0.2 & Let's Encrypt issue when using the latest build scripts from [datadog-agent-macos-build](https://github.com/DataDog/datadog-agent-macos-build) before installing Python 3.8.11.

This was working until now because we were still installing Python 3.8.5, which is another reason to remove this from CircleCI: Gitlab just triggers Github actions which should always run up-to-date scripts.

Depends on: https://github.com/DataDog/datadog-agent-macos-build/pull/76

