### PR TITLE
[omnibus] Add missing license info for Python2/3 on Windows

### DIFF
--- a/omnibus/config/software/python2.rb
+++ b/omnibus/config/software/python2.rb
@@ -95,6 +95,8 @@ else
          :extract => :seven_zip
   end
   build do
+    license "Python-2.0"
+
     #
     # expand python zip into the embedded directory
     command "XCOPY /YEHIR *.* \"#{windows_safe_path(python_2_embedded)}\""

--- a/omnibus/config/software/python2.rb
+++ b/omnibus/config/software/python2.rb
@@ -56,6 +56,7 @@ if ohai["platform"] != "windows"
   end
 
   build do
+    # 2.0 is the license version here, not the python version
     license "Python-2.0"
 
     patch :source => "avoid-allocating-thunks-in-ctypes.patch" if linux?
@@ -95,6 +96,7 @@ else
          :extract => :seven_zip
   end
   build do
+    # 2.0 is the license version here, not the python version
     license "Python-2.0"
 
     #

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -36,6 +36,7 @@ if ohai["platform"] != "windows"
   python_configure.push("--with-dbmliborder=")
 
   build do
+    # 2.0 is the license version here, not the python version
     license "Python-2.0"
 
     env = case ohai["platform"]
@@ -80,6 +81,7 @@ else
   end
   vcrt140_root = "#{Omnibus::Config.source_dir()}/vc_redist_140/expanded"
   build do
+    # 2.0 is the license version here, not the python version
     license "Python-2.0"
 
     command "XCOPY /YEHIR *.* \"#{windows_safe_path(python_3_embedded)}\""

--- a/omnibus/config/software/python3.rb
+++ b/omnibus/config/software/python3.rb
@@ -80,6 +80,8 @@ else
   end
   vcrt140_root = "#{Omnibus::Config.source_dir()}/vc_redist_140/expanded"
   build do
+    license "Python-2.0"
+
     command "XCOPY /YEHIR *.* \"#{windows_safe_path(python_3_embedded)}\""
     command "copy /y \"#{windows_safe_path(vcrt140_root)}\\*.dll\" \"#{windows_safe_path(python_3_embedded)}\""
   end

--- a/omnibus/config/software/setuptools2.rb
+++ b/omnibus/config/software/setuptools2.rb
@@ -12,6 +12,7 @@ source :url => "https://github.com/pypa/setuptools/archive/v#{version}.tar.gz",
        :extract => :seven_zip
 
 build do
+  # 2.0 is the license version here, not the python version
   license "Python-2.0"
 
   if ohai["platform"] == "windows"

--- a/omnibus/config/software/setuptools3.rb
+++ b/omnibus/config/software/setuptools3.rb
@@ -12,6 +12,7 @@ source :url => "https://github.com/pypa/setuptools/archive/v#{version}.tar.gz",
        :extract => :seven_zip
 
 build do
+  # 2.0 is the license version here, not the python version
   license "Python-2.0"
 
   if ohai["platform"] == "windows"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Adds `license` DSL use to the Windows branch of the `python2` and `python3` software definitions.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The `python2` and `python3` software definitions have separate branches for Windows, with different `build` sections. The `license` DSL needs to be present in each of them.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Check omnibus build output.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
