### PR TITLE
[containerd] Extract mocked client and reuse it

### DIFF
--- a/pkg/util/containerd/fake/containerd_util.go
+++ b/pkg/util/containerd/fake/containerd_util.go
@@ -1,0 +1,129 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build containerd
+
+package fake
+
+import (
+	"context"
+
+	"github.com/containerd/containerd"
+	"github.com/containerd/containerd/api/types"
+	"github.com/containerd/containerd/containers"
+	"github.com/containerd/containerd/oci"
+
+	"github.com/DataDog/datadog-agent/pkg/util/retry"
+)
+
+// MockedContainerdClient is a fake containerd client that implements the
+// ContainerItf interface. It's only meant to be used in unit tests.
+type MockedContainerdClient struct {
+	MockClose               func() error
+	MockCheckConnectivity   func() *retry.Error
+	MockEvents              func() containerd.EventService
+	MockContainers          func() ([]containerd.Container, error)
+	MockContainer           func(id string) (containerd.Container, error)
+	MockContainerWithCtx    func(ctx context.Context, id string) (containerd.Container, error)
+	MockEnvVars             func(ctn containerd.Container) (map[string]string, error)
+	MockMetadata            func() (containerd.Version, error)
+	MockImage               func(ctn containerd.Container) (containerd.Image, error)
+	MockImageSize           func(ctn containerd.Container) (int64, error)
+	MockTaskMetrics         func(ctn containerd.Container) (*types.Metric, error)
+	MockTaskPids            func(ctn containerd.Container) ([]containerd.ProcessInfo, error)
+	MockInfo                func(ctn containerd.Container) (containers.Container, error)
+	MockLabels              func(ctn containerd.Container) (map[string]string, error)
+	MockLabelsWithContext   func(ctx context.Context, ctn containerd.Container) (map[string]string, error)
+	MockCurrentNamespace    func() string
+	MockSetCurrentNamespace func(namespace string)
+	MockNamespaces          func(ctx context.Context) ([]string, error)
+	MockSpec                func(ctn containerd.Container) (*oci.Spec, error)
+	MockSpecWithContext     func(ctx context.Context, ctn containerd.Container) (*oci.Spec, error)
+	MockStatus              func(ctn containerd.Container) (containerd.ProcessStatus, error)
+}
+
+func (client *MockedContainerdClient) Close() error {
+	return client.MockClose()
+}
+
+func (client *MockedContainerdClient) CheckConnectivity() *retry.Error {
+	return client.MockCheckConnectivity()
+}
+
+func (client *MockedContainerdClient) Image(ctn containerd.Container) (containerd.Image, error) {
+	return client.MockImage(ctn)
+}
+
+func (client *MockedContainerdClient) ImageSize(ctn containerd.Container) (int64, error) {
+	return client.MockImageSize(ctn)
+}
+
+func (client *MockedContainerdClient) Labels(ctn containerd.Container) (map[string]string, error) {
+	return client.MockLabels(ctn)
+}
+
+func (client *MockedContainerdClient) LabelsWithContext(ctx context.Context, ctn containerd.Container) (map[string]string, error) {
+	return client.MockLabelsWithContext(ctx, ctn)
+}
+
+func (client *MockedContainerdClient) Info(ctn containerd.Container) (containers.Container, error) {
+	return client.MockInfo(ctn)
+}
+
+func (client *MockedContainerdClient) TaskMetrics(ctn containerd.Container) (*types.Metric, error) {
+	return client.MockTaskMetrics(ctn)
+}
+
+func (client *MockedContainerdClient) TaskPids(ctn containerd.Container) ([]containerd.ProcessInfo, error) {
+	return client.MockTaskPids(ctn)
+}
+
+func (client *MockedContainerdClient) Metadata() (containerd.Version, error) {
+	return client.MockMetadata()
+}
+
+func (client *MockedContainerdClient) CurrentNamespace() string {
+	return client.MockCurrentNamespace()
+}
+
+func (client *MockedContainerdClient) SetCurrentNamespace(namespace string) {
+	client.MockSetCurrentNamespace(namespace)
+}
+
+func (client *MockedContainerdClient) Namespaces(ctx context.Context) ([]string, error) {
+	return client.MockNamespaces(ctx)
+}
+
+func (client *MockedContainerdClient) Containers() ([]containerd.Container, error) {
+	return client.MockContainers()
+}
+
+func (client *MockedContainerdClient) Container(id string) (containerd.Container, error) {
+	return client.MockContainer(id)
+}
+
+func (client *MockedContainerdClient) ContainerWithContext(ctx context.Context, id string) (containerd.Container, error) {
+	return client.MockContainerWithCtx(ctx, id)
+}
+
+func (client *MockedContainerdClient) GetEvents() containerd.EventService {
+	return client.MockEvents()
+}
+
+func (client *MockedContainerdClient) Spec(ctn containerd.Container) (*oci.Spec, error) {
+	return client.MockSpec(ctn)
+}
+
+func (client *MockedContainerdClient) SpecWithContext(ctx context.Context, ctn containerd.Container) (*oci.Spec, error) {
+	return client.MockSpecWithContext(ctx, ctn)
+}
+
+func (client *MockedContainerdClient) EnvVars(ctn containerd.Container) (map[string]string, error) {
+	return client.MockEnvVars(ctn)
+}
+
+func (client *MockedContainerdClient) Status(ctn containerd.Container) (containerd.ProcessStatus, error) {
+	return client.MockStatus(ctn)
+}

--- a/pkg/util/containers/v2/metrics/containerd/collector_test.go
+++ b/pkg/util/containers/v2/metrics/containerd/collector_test.go
@@ -22,45 +22,11 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/util"
-	containerdutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
+	"github.com/DataDog/datadog-agent/pkg/util/containerd/fake"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics/provider"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 	workloadmetaTesting "github.com/DataDog/datadog-agent/pkg/workloadmeta/testing"
 )
-
-type mockedContainerdClient struct {
-	containerdutil.ContainerdItf
-	mockContainer           func(id string) (containerd.Container, error)
-	mockInfo                func(ctn containerd.Container) (containers.Container, error)
-	mockSpec                func(ctn containerd.Container) (*oci.Spec, error)
-	mockTaskMetrics         func(ctn containerd.Container) (*types.Metric, error)
-	mockTaskPids            func(ctn containerd.Container) ([]containerd.ProcessInfo, error)
-	mockSetCurrentNamespace func(namespace string)
-}
-
-func (m *mockedContainerdClient) Container(id string) (containerd.Container, error) {
-	return m.mockContainer(id)
-}
-
-func (m *mockedContainerdClient) Info(ctn containerd.Container) (containers.Container, error) {
-	return m.mockInfo(ctn)
-}
-
-func (m *mockedContainerdClient) Spec(ctn containerd.Container) (*oci.Spec, error) {
-	return m.mockSpec(ctn)
-}
-
-func (m *mockedContainerdClient) TaskMetrics(ctn containerd.Container) (*types.Metric, error) {
-	return m.mockTaskMetrics(ctn)
-}
-
-func (m *mockedContainerdClient) TaskPids(ctn containerd.Container) ([]containerd.ProcessInfo, error) {
-	return m.mockTaskPids(ctn)
-}
-
-func (m *mockedContainerdClient) SetCurrentNamespace(namespace string) {
-	m.mockSetCurrentNamespace(namespace)
-}
 
 type mockedContainer struct {
 	containerd.Container
@@ -427,23 +393,23 @@ func TestGetContainerNetworkStats_Containerd(t *testing.T) {
 //   - 1) Being able to control the metrics returned by the TaskMetrics
 //   function.
 //   - 2) Define functions like Info, Spec, etc. so they don't return errors.
-func containerdClient(metrics *types.Metric) *mockedContainerdClient {
-	return &mockedContainerdClient{
-		mockTaskMetrics: func(ctn containerd.Container) (*types.Metric, error) {
+func containerdClient(metrics *types.Metric) *fake.MockedContainerdClient {
+	return &fake.MockedContainerdClient{
+		MockTaskMetrics: func(ctn containerd.Container) (*types.Metric, error) {
 			return metrics, nil
 		},
-		mockContainer: func(id string) (containerd.Container, error) {
+		MockContainer: func(id string) (containerd.Container, error) {
 			return mockedContainer{}, nil
 		},
-		mockInfo: func(ctn containerd.Container) (containers.Container, error) {
+		MockInfo: func(ctn containerd.Container) (containers.Container, error) {
 			return containers.Container{}, nil
 		},
-		mockSpec: func(ctn containerd.Container) (*oci.Spec, error) {
+		MockSpec: func(ctn containerd.Container) (*oci.Spec, error) {
 			return nil, nil
 		},
-		mockTaskPids: func(ctn containerd.Container) ([]containerd.ProcessInfo, error) {
+		MockTaskPids: func(ctn containerd.Container) ([]containerd.ProcessInfo, error) {
 			return nil, nil
 		},
-		mockSetCurrentNamespace: func(namespace string) {},
+		MockSetCurrentNamespace: func(namespace string) {},
 	}
 }

--- a/pkg/workloadmeta/collectors/containerd/container_builder_test.go
+++ b/pkg/workloadmeta/collectors/containerd/container_builder_test.go
@@ -8,7 +8,6 @@
 package containerd
 
 import (
-	"context"
 	"testing"
 	"time"
 
@@ -17,7 +16,7 @@ import (
 	"github.com/containerd/containerd/oci"
 	"github.com/stretchr/testify/assert"
 
-	containerdutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
+	"github.com/DataDog/datadog-agent/pkg/util/containerd/fake"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
@@ -39,46 +38,6 @@ func (m *mockedImage) Name() string {
 	return m.mockName()
 }
 
-type mockedContainerdClient struct {
-	containerdutil.ContainerdItf
-	// Not all the funcs are here. Add them as needed.
-	mockContainerWithContext func(ctx context.Context, id string) (containerd.Container, error)
-	mockEnvVars              func(ctn containerd.Container) (map[string]string, error)
-	mockImage                func(ctn containerd.Container) (containerd.Image, error)
-	mockInfo                 func(ctn containerd.Container) (containers.Container, error)
-	mockLabels               func(ctn containerd.Container) (map[string]string, error)
-	mockSpec                 func(ctn containerd.Container) (*oci.Spec, error)
-	mockStatus               func(ctn containerd.Container) (containerd.ProcessStatus, error)
-}
-
-func (m *mockedContainerdClient) ContainerWithContext(ctx context.Context, id string) (containerd.Container, error) {
-	return m.mockContainerWithContext(ctx, id)
-}
-
-func (m *mockedContainerdClient) EnvVars(ctn containerd.Container) (map[string]string, error) {
-	return m.mockEnvVars(ctn)
-}
-
-func (m *mockedContainerdClient) Image(ctn containerd.Container) (containerd.Image, error) {
-	return m.mockImage(ctn)
-}
-
-func (m *mockedContainerdClient) Info(ctn containerd.Container) (containers.Container, error) {
-	return m.mockInfo(ctn)
-}
-
-func (m *mockedContainerdClient) Labels(ctn containerd.Container) (map[string]string, error) {
-	return m.mockLabels(ctn)
-}
-
-func (m *mockedContainerdClient) Spec(ctn containerd.Container) (*oci.Spec, error) {
-	return m.mockSpec(ctn)
-}
-
-func (m *mockedContainerdClient) Status(ctn containerd.Container) (containerd.ProcessStatus, error) {
-	return m.mockStatus(ctn)
-}
-
 func TestBuildWorkloadMetaContainer(t *testing.T) {
 	containerID := "10"
 	labels := map[string]string{
@@ -98,27 +57,27 @@ func TestBuildWorkloadMetaContainer(t *testing.T) {
 		},
 	}
 
-	client := mockedContainerdClient{
-		mockLabels: func(ctn containerd.Container) (map[string]string, error) {
+	client := fake.MockedContainerdClient{
+		MockLabels: func(ctn containerd.Container) (map[string]string, error) {
 			return labels, nil
 		},
-		mockImage: func(ctn containerd.Container) (containerd.Image, error) {
+		MockImage: func(ctn containerd.Container) (containerd.Image, error) {
 			return &mockedImage{
 				mockName: func() string {
 					return imgName
 				},
 			}, nil
 		},
-		mockEnvVars: func(ctn containerd.Container) (map[string]string, error) {
+		MockEnvVars: func(ctn containerd.Container) (map[string]string, error) {
 			return envVars, nil
 		},
-		mockInfo: func(ctn containerd.Container) (containers.Container, error) {
+		MockInfo: func(ctn containerd.Container) (containers.Container, error) {
 			return containers.Container{CreatedAt: createdAt}, nil
 		},
-		mockSpec: func(ctn containerd.Container) (*oci.Spec, error) {
+		MockSpec: func(ctn containerd.Container) (*oci.Spec, error) {
 			return &oci.Spec{Hostname: hostName}, nil
 		},
-		mockStatus: func(ctn containerd.Container) (containerd.ProcessStatus, error) {
+		MockStatus: func(ctn containerd.Container) (containerd.ProcessStatus, error) {
 			return containerd.Running, nil
 		},
 	}

--- a/pkg/workloadmeta/collectors/containerd/containerd_test.go
+++ b/pkg/workloadmeta/collectors/containerd/containerd_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/errors"
+	"github.com/DataDog/datadog-agent/pkg/util/containerd/fake"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 )
 
@@ -83,9 +84,9 @@ func TestIgnoreEvent(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			client := mockedContainerdClient{
-				mockContainerWithContext: test.getContainerFn,
-				mockImage: func(ctn containerd.Container) (containerd.Image, error) {
+			client := fake.MockedContainerdClient{
+				MockContainerWithCtx: test.getContainerFn,
+				MockImage: func(ctn containerd.Container) (containerd.Image, error) {
 					return &mockedImage{
 						mockName: func() string {
 							return test.imgName

--- a/pkg/workloadmeta/collectors/containerd/event_builder_test.go
+++ b/pkg/workloadmeta/collectors/containerd/event_builder_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/gogo/protobuf/types"
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-agent/pkg/util/containerd/fake"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
@@ -273,37 +274,37 @@ func TestBuildCollectorEvent(t *testing.T) {
 }
 
 // containerdClient returns a mockedContainerdClient set up for the tests in this file.
-func containerdClient(container containerd.Container) mockedContainerdClient {
+func containerdClient(container containerd.Container) fake.MockedContainerdClient {
 	labels := map[string]string{"some_label": "some_val"}
 	imgName := "datadog/agent:7"
 	envVars := map[string]string{"test_env": "test_val"}
 	hostName := "test_hostname"
 	createdAt, _ := time.Parse("2006-01-02", "2021-10-11")
 
-	return mockedContainerdClient{
-		mockContainerWithContext: func(ctx context.Context, id string) (containerd.Container, error) {
+	return fake.MockedContainerdClient{
+		MockContainerWithCtx: func(ctx context.Context, id string) (containerd.Container, error) {
 			return container, nil
 		},
-		mockLabels: func(ctn containerd.Container) (map[string]string, error) {
+		MockLabels: func(ctn containerd.Container) (map[string]string, error) {
 			return labels, nil
 		},
-		mockImage: func(ctn containerd.Container) (containerd.Image, error) {
+		MockImage: func(ctn containerd.Container) (containerd.Image, error) {
 			return &mockedImage{
 				mockName: func() string {
 					return imgName
 				},
 			}, nil
 		},
-		mockEnvVars: func(ctn containerd.Container) (map[string]string, error) {
+		MockEnvVars: func(ctn containerd.Container) (map[string]string, error) {
 			return envVars, nil
 		},
-		mockInfo: func(ctn containerd.Container) (containers.Container, error) {
+		MockInfo: func(ctn containerd.Container) (containers.Container, error) {
 			return containers.Container{CreatedAt: createdAt}, nil
 		},
-		mockSpec: func(ctn containerd.Container) (*oci.Spec, error) {
+		MockSpec: func(ctn containerd.Container) (*oci.Spec, error) {
 			return &oci.Spec{Hostname: hostName}, nil
 		},
-		mockStatus: func(ctn containerd.Container) (containerd.ProcessStatus, error) {
+		MockStatus: func(ctn containerd.Container) (containerd.ProcessStatus, error) {
 			return containerd.Running, nil
 		},
 	}


### PR DESCRIPTION
### What does this PR do?

Extracts a mocked containerd client into `pkg/util/containerd/fake/containerd_util.go` so it can be reused from any test that needs to interfact with the containerd API.

Until now several tests where defining their own mocked client. This PR removes some duplicated code.

### Describe how to test/QA your changes

Skip.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
