### PR TITLE
[CWS] handles SECL rules using symlink paths

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -281,7 +281,6 @@ require (
 	github.com/go-openapi/jsonreference v0.19.6 // indirect
 	github.com/go-openapi/swag v0.19.15 // indirect
 	github.com/go-sql-driver/mysql v1.5.0 // indirect
-	github.com/go-test/deep v1.0.5 // indirect
 	github.com/godbus/dbus/v5 v5.0.4 // indirect
 	github.com/gogo/googleapis v1.4.0 // indirect
 	github.com/golang/glog v1.0.0 // indirect

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1002,6 +1002,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_dump_timeout", 30)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_wait_list_size", 10)
 	config.BindEnvAndSetDefault("runtime_security_config.activity_dump.cgroup_output_directory", "")
+	config.BindEnvAndSetDefault("runtime_security_config.symlink_resolver_enabled", true)
 
 	// Serverless Agent
 	config.BindEnvAndSetDefault("serverless.logs_enabled", true)

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "efc6e8bbd0a12393408090e306d84b5f55f7d00a9ff2734fc2857e203e99295b")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "dd005468c8fa8c13af2d30008557b7e36ec338c816756d2464c9ad2802967484")

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -122,6 +122,8 @@ type Config struct {
 	ActivityDumpCgroupOutputDirectory string
 	// RuntimeMonitor defines if the runtime monitor should be enabled
 	RuntimeMonitor bool
+	// SymlinkResolverEnabled defines whether the symlink resolver is enabled
+	SymlinkResolverEnabled bool
 }
 
 // IsEnabled returns true if any feature is enabled. Has to be applied in config package too
@@ -184,6 +186,7 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 		ActivityDumpCgroupWaitListSize:     aconfig.Datadog.GetInt("runtime_security_config.activity_dump.cgroup_wait_list_size"),
 		ActivityDumpCgroupOutputDirectory:  aconfig.Datadog.GetString("runtime_security_config.activity.cgroup_output_directory"),
 		RuntimeMonitor:                     aconfig.Datadog.GetBool("runtime_security_config.runtime_monitor.enabled"),
+		SymlinkResolverEnabled:             aconfig.Datadog.GetBool("runtime_security_config.symlink_resolver_enabled"),
 	}
 
 	// if runtime is enabled then we force fim

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -292,8 +292,8 @@ func (m *Module) Reload() error {
 				}, nil)
 			},
 		}).
-		WithLogger(&seclog.PatternLogger{})
-	WithUserContext(m.probe)
+		WithLogger(&seclog.PatternLogger{}).
+		WithUserContext(m.probe)
 
 	model := &model.Model{}
 	approverRuleSet := rules.NewRuleSet(model, model.NewEvent, &opts)

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -265,6 +265,10 @@ func (m *Module) Reload() error {
 	atomic.StoreUint64(&m.reloading, 1)
 	defer atomic.StoreUint64(&m.reloading, 0)
 
+	if err := m.probe.OnRuleSetReload(); err != nil {
+		log.Errorf("error while reloading ruleset: %+v", err)
+	}
+
 	policiesDir := m.config.PoliciesDir
 	rsa := sprobe.NewRuleSetApplier(m.config, m.probe)
 
@@ -289,6 +293,7 @@ func (m *Module) Reload() error {
 			},
 		}).
 		WithLogger(&seclog.PatternLogger{})
+	WithUserContext(m.probe)
 
 	model := &model.Model{}
 	approverRuleSet := rules.NewRuleSet(model, model.NewEvent, &opts)

--- a/pkg/security/probe/accessors.go
+++ b/pkg/security/probe/accessors.go
@@ -8682,6 +8682,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "splice.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: OverridePathnames,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Splice.File)

--- a/pkg/security/probe/accessors.go
+++ b/pkg/security/probe/accessors.go
@@ -327,6 +327,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "chmod.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: OverridePathnames,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Chmod.File)
@@ -517,6 +518,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "chown.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: OverridePathnames,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Chown.File)
@@ -877,6 +879,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "exec.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: OverridePathnames,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Exec.Process.PathnameStr
@@ -1147,6 +1150,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "link.file.destination.path":
 		return &eval.StringEvaluator{
+			OpOverrides: OverridePathnames,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Link.Target)
@@ -1277,6 +1281,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "link.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: OverridePathnames,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Link.Source)
@@ -1427,6 +1432,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "load_module.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: OverridePathnames,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).LoadModule.File)
@@ -1617,6 +1623,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "mkdir.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: OverridePathnames,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Mkdir.File)
@@ -1767,6 +1774,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "mmap.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: OverridePathnames,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).MMap.File)
@@ -1977,6 +1985,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "open.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: OverridePathnames,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Open.File)
@@ -2936,6 +2945,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "process.ancestors.file.path":
 		return &eval.StringArrayEvaluator{
+			OpOverrides: OverridePathnames,
 			EvalFnc: func(ctx *eval.Context) []string {
 				if ptr := ctx.Cache[field]; ptr != nil {
 					if result := (*[]string)(ptr); result != nil {
@@ -3722,6 +3732,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "process.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: OverridePathnames,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ProcessContext.Process.PathnameStr
@@ -4801,6 +4812,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "ptrace.tracee.ancestors.file.path":
 		return &eval.StringArrayEvaluator{
+			OpOverrides: OverridePathnames,
 			EvalFnc: func(ctx *eval.Context) []string {
 				if ptr := ctx.Cache[field]; ptr != nil {
 					if result := (*[]string)(ptr); result != nil {
@@ -5587,6 +5599,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "ptrace.tracee.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: OverridePathnames,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).PTrace.Tracee.Process.PathnameStr
@@ -5867,6 +5880,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "removexattr.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: OverridePathnames,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).RemoveXAttr.File)
@@ -6027,6 +6041,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "rename.file.destination.path":
 		return &eval.StringEvaluator{
+			OpOverrides: OverridePathnames,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Rename.New)
@@ -6157,6 +6172,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "rename.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: OverridePathnames,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Rename.Old)
@@ -6307,6 +6323,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "rmdir.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: OverridePathnames,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Rmdir.File)
@@ -6637,6 +6654,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "setxattr.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: OverridePathnames,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).SetXAttr.File)
@@ -7606,6 +7624,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "signal.target.ancestors.file.path":
 		return &eval.StringArrayEvaluator{
+			OpOverrides: OverridePathnames,
 			EvalFnc: func(ctx *eval.Context) []string {
 				if ptr := ctx.Cache[field]; ptr != nil {
 					if result := (*[]string)(ptr); result != nil {
@@ -8392,6 +8411,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "signal.target.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: OverridePathnames,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).Signal.Target.Process.PathnameStr
@@ -8832,6 +8852,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "unlink.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: OverridePathnames,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Unlink.File)
@@ -9002,6 +9023,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 	case "utimes.file.path":
 		return &eval.StringEvaluator{
+			OpOverrides: OverridePathnames,
 			EvalFnc: func(ctx *eval.Context) string {
 
 				return (*Event)(ctx.Object).ResolveFilePath(&(*Event)(ctx.Object).Utimes.File)

--- a/pkg/security/probe/applier.go
+++ b/pkg/security/probe/applier.go
@@ -98,8 +98,8 @@ func (rsa *RuleSetApplier) Apply(rs *rules.RuleSet, approvers map[eval.EventType
 			return nil, errors.Wrap(err, "failed to select probes")
 		}
 
-		if err := rsa.probe.FlushDiscarders(); err != nil {
-			return nil, errors.Wrap(err, "failed to flush discarders")
+		if err := rsa.probe.OnRuleSetApplied(); err != nil {
+			return nil, err
 		}
 	}
 

--- a/pkg/security/probe/approvers_test.go
+++ b/pkg/security/probe/approvers_test.go
@@ -28,7 +28,11 @@ func TestApproverAncestors1(t *testing.T) {
 		WithLogger(&seclog.PatternLogger{})
 
 	m := &model.Model{}
+<<<<<<< HEAD
 	rs := rules.NewRuleSet(m, m.NewEvent, &opts)
+=======
+	rs := rules.NewRuleSet(m, m.NewEvent, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, nil, &log.PatternLogger{}))
+>>>>>>> 3d93879a3 (Introduce a cache)
 	addRuleExpr(t, rs, `open.file.path == "/etc/passwd" && process.ancestors.file.name == "vipw"`, `open.file.path == "/etc/shadow" && process.ancestors.file.name == "vipw"`)
 
 	capabilities, exists := allCapabilities["open"]
@@ -57,7 +61,11 @@ func TestApproverAncestors2(t *testing.T) {
 		WithLogger(&seclog.PatternLogger{})
 
 	m := &model.Model{}
+<<<<<<< HEAD
 	rs := rules.NewRuleSet(m, m.NewEvent, &opts)
+=======
+	rs := rules.NewRuleSet(m, m.NewEvent, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, nil, &log.PatternLogger{}))
+>>>>>>> 3d93879a3 (Introduce a cache)
 	addRuleExpr(t, rs, `(open.file.path == "/etc/shadow" || open.file.path == "/etc/gshadow") && process.ancestors.file.path not in ["/usr/bin/dpkg"]`)
 	capabilities, exists := allCapabilities["open"]
 	if !exists {

--- a/pkg/security/probe/approvers_test.go
+++ b/pkg/security/probe/approvers_test.go
@@ -28,11 +28,7 @@ func TestApproverAncestors1(t *testing.T) {
 		WithLogger(&seclog.PatternLogger{})
 
 	m := &model.Model{}
-<<<<<<< HEAD
 	rs := rules.NewRuleSet(m, m.NewEvent, &opts)
-=======
-	rs := rules.NewRuleSet(m, m.NewEvent, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, nil, &log.PatternLogger{}))
->>>>>>> 3d93879a3 (Introduce a cache)
 	addRuleExpr(t, rs, `open.file.path == "/etc/passwd" && process.ancestors.file.name == "vipw"`, `open.file.path == "/etc/shadow" && process.ancestors.file.name == "vipw"`)
 
 	capabilities, exists := allCapabilities["open"]
@@ -61,11 +57,7 @@ func TestApproverAncestors2(t *testing.T) {
 		WithLogger(&seclog.PatternLogger{})
 
 	m := &model.Model{}
-<<<<<<< HEAD
 	rs := rules.NewRuleSet(m, m.NewEvent, &opts)
-=======
-	rs := rules.NewRuleSet(m, m.NewEvent, rules.NewOptsWithParams(model.SECLConstants, nil, enabled, nil, model.SECLLegacyAttributes, nil, &log.PatternLogger{}))
->>>>>>> 3d93879a3 (Introduce a cache)
 	addRuleExpr(t, rs, `(open.file.path == "/etc/shadow" || open.file.path == "/etc/gshadow") && process.ancestors.file.path not in ["/usr/bin/dpkg"]`)
 	capabilities, exists := allCapabilities["open"]
 	if !exists {

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -288,9 +288,9 @@ func (id *inodeDiscarders) getParentDiscarderFnc(rs *rules.RuleSet, eventType mo
 		if values := rule.GetFieldValues(field); len(values) > 0 {
 			for _, value := range values {
 				if value.Type == eval.PatternValueType {
-					glob, ok := value.StringMatcher.(*eval.GlobStringMatcher)
-					if !ok {
-						return nil, errors.New("unexpected string matcher")
+					var glob eval.GlobStringMatcher
+					if err := glob.Compile(value.Value.(string)); err != nil {
+						return nil, err
 					}
 
 					valueFnc = func(dirname string) (bool, bool, error) {
@@ -381,8 +381,7 @@ func (id *inodeDiscarders) isParentPathDiscarder(rs *rules.RuleSet, eventType mo
 		return false, nil
 	}
 
-	found, err := fnc(dirname)
-	if !found || err != nil {
+	if discarder, err := fnc(dirname); !discarder || err != nil {
 		return false, err
 	}
 

--- a/pkg/security/probe/mount_resolver.go
+++ b/pkg/security/probe/mount_resolver.go
@@ -242,6 +242,11 @@ func (mr *MountResolver) insert(e *model.MountEvent) {
 	mr.NotifyNewInsert(e)
 }
 
+// AddListener add a listener
+func (mr *MountResolver) AddListener(listener MountEventListener) {
+	mr.listerners = append(mr.listerners, listener)
+}
+
 // NotifyNewInsert notifies all the listeners
 func (mr *MountResolver) NotifyNewInsert(e *model.MountEvent) {
 	for _, listener := range mr.listerners {
@@ -380,6 +385,15 @@ func (mr *MountResolver) Start(ctx context.Context) {
 	}()
 }
 
+// GetOverlayPath returns the overlay path
+func (mr *MountResolver) GetOverlayPath(e *model.MountEvent) string {
+	if ancestor := mr.getAncestor(e); ancestor != nil {
+		e = ancestor
+	}
+
+	return mr.getOverlayPath(e)
+}
+
 // GetMountPath returns the path of a mount identified by its mount ID. The first path is the container mount path if
 // it exists, the second parameter is the mount point path, and the third parameter is the root path.
 func (mr *MountResolver) GetMountPath(mountID uint32) (string, string, string, error) {
@@ -394,7 +408,7 @@ func (mr *MountResolver) GetMountPath(mountID uint32) (string, string, string, e
 		return "", "", "", nil
 	}
 
-	return mr.getOverlayPath(mount), mr.getParentPath(mountID), mount.RootStr, nil
+	return mr.GetOverlayPath(mount), mr.getParentPath(mountID), mount.RootStr, nil
 }
 
 func getMountIDOffset(probe *Probe) uint64 {

--- a/pkg/security/probe/mount_resolver.go
+++ b/pkg/security/probe/mount_resolver.go
@@ -238,7 +238,7 @@ func (mr *MountResolver) insert(e *model.MountEvent) {
 
 	// update symlinks
 	if e.IsOverlayFS() {
-		mr.probe.resolvers.SymlinkResolver.UpdateSymlinks(e.MountPointStr)
+		mr.probe.resolvers.SymlinkResolver.ScheduleUpdate(e.MountPointStr)
 	}
 }
 

--- a/pkg/security/probe/mount_resolver_test.go
+++ b/pkg/security/probe/mount_resolver_test.go
@@ -316,7 +316,7 @@ func TestMountResolver(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			for _, evt := range tt.args.events {
 				if evt.mount != nil {
-					mr.insert(*evt.mount)
+					mr.insert(evt.mount)
 				}
 				if evt.umount != nil {
 					if err := mr.Delete(evt.umount.MountID); err != nil {

--- a/pkg/security/probe/op_overrides.go
+++ b/pkg/security/probe/op_overrides.go
@@ -32,9 +32,13 @@ var (
 				return nil, errors.New("non scalar overriden is not supported")
 			}
 
+			if fieldEvaluator.Field == "" {
+				return eval.StringEquals(a, b, opts, state)
+			}
+
 			// pre-cache at compile time
 			probe := opts.UserCtx.(*Probe)
-			probe.resolvers.SymlinkResolver.InitStringValues(key, value)
+			probe.resolvers.SymlinkResolver.InitStringValues(key, fieldEvaluator.Field, value)
 
 			evaluator := eval.StringValuesEvaluator{
 				EvalFnc: func(ctx *eval.Context) *eval.StringValues {
@@ -45,6 +49,10 @@ var (
 			return eval.StringValuesContains(fieldEvaluator, &evaluator, opts, state)
 		},
 		StringValuesContains: func(a *eval.StringEvaluator, b *eval.StringValuesEvaluator, opts *eval.Opts, state *eval.State) (*eval.BoolEvaluator, error) {
+			if a.Field == "" {
+				return eval.StringValuesContains(a, b, opts, state)
+			}
+
 			if !b.IsScalar() {
 				return nil, errors.New("non scalar overriden is not supported")
 			}
@@ -53,7 +61,7 @@ var (
 
 			// pre-cache at compile time
 			probe := opts.UserCtx.(*Probe)
-			probe.resolvers.SymlinkResolver.InitStringValues(key, values...)
+			probe.resolvers.SymlinkResolver.InitStringValues(key, a.Field, values...)
 
 			evaluator := eval.StringValuesEvaluator{
 				EvalFnc: func(ctx *eval.Context) *eval.StringValues {
@@ -65,6 +73,10 @@ var (
 		},
 		// ex: process.ancestors.file.path
 		StringArrayContains: func(a *eval.StringEvaluator, b *eval.StringArrayEvaluator, opts *eval.Opts, state *eval.State) (*eval.BoolEvaluator, error) {
+			if b.Field == "" {
+				return eval.StringArrayContains(a, b, opts, state)
+			}
+
 			if !a.IsScalar() {
 				return nil, errors.New("non scalar overriden is not supported")
 			}
@@ -73,7 +85,7 @@ var (
 
 			// pre-cache at compile time
 			probe := opts.UserCtx.(*Probe)
-			probe.resolvers.SymlinkResolver.InitStringValues(key, value)
+			probe.resolvers.SymlinkResolver.InitStringValues(key, b.Field, value)
 
 			evaluator := eval.StringValuesEvaluator{
 				EvalFnc: func(ctx *eval.Context) *eval.StringValues {
@@ -84,6 +96,10 @@ var (
 			return eval.StringValuesContains(a, &evaluator, opts, state)
 		},
 		StringArrayMatches: func(a *eval.StringArrayEvaluator, b *eval.StringValuesEvaluator, opts *eval.Opts, state *eval.State) (*eval.BoolEvaluator, error) {
+			if a.Field == "" {
+				return eval.StringArrayMatches(a, b, opts, state)
+			}
+
 			if !b.IsScalar() {
 				return nil, errors.New("non scalar overriden is not supported")
 			}
@@ -92,7 +108,7 @@ var (
 
 			// pre-cache at compile time
 			probe := opts.UserCtx.(*Probe)
-			probe.resolvers.SymlinkResolver.InitStringValues(key, values...)
+			probe.resolvers.SymlinkResolver.InitStringValues(key, a.Field, values...)
 
 			evaluator := eval.StringValuesEvaluator{
 				EvalFnc: func(ctx *eval.Context) *eval.StringValues {

--- a/pkg/security/probe/op_overrides.go
+++ b/pkg/security/probe/op_overrides.go
@@ -34,11 +34,11 @@ var (
 
 			// pre-cache at compile time
 			probe := opts.UserCtx.(*Probe)
-			probe.resolvers.SymlinkResolver.Resolve(key, value)
+			probe.resolvers.SymlinkResolver.InitStringValues(key, value)
 
 			evaluator := eval.StringValuesEvaluator{
 				EvalFnc: func(ctx *eval.Context) *eval.StringValues {
-					return probe.resolvers.SymlinkResolver.Resolve(key, value)
+					return probe.resolvers.SymlinkResolver.GetStringValues(key)
 				},
 			}
 
@@ -53,11 +53,11 @@ var (
 
 			// pre-cache at compile time
 			probe := opts.UserCtx.(*Probe)
-			probe.resolvers.SymlinkResolver.Resolve(key, values...)
+			probe.resolvers.SymlinkResolver.InitStringValues(key, values...)
 
 			evaluator := eval.StringValuesEvaluator{
 				EvalFnc: func(ctx *eval.Context) *eval.StringValues {
-					return probe.resolvers.SymlinkResolver.Resolve(key, values...)
+					return probe.resolvers.SymlinkResolver.GetStringValues(key)
 				},
 			}
 
@@ -73,11 +73,11 @@ var (
 
 			// pre-cache at compile time
 			probe := opts.UserCtx.(*Probe)
-			probe.resolvers.SymlinkResolver.Resolve(key, value)
+			probe.resolvers.SymlinkResolver.InitStringValues(key, value)
 
 			evaluator := eval.StringValuesEvaluator{
 				EvalFnc: func(ctx *eval.Context) *eval.StringValues {
-					return probe.resolvers.SymlinkResolver.Resolve(key, value)
+					return probe.resolvers.SymlinkResolver.GetStringValues(key)
 				},
 			}
 
@@ -92,11 +92,11 @@ var (
 
 			// pre-cache at compile time
 			probe := opts.UserCtx.(*Probe)
-			probe.resolvers.SymlinkResolver.Resolve(key, values...)
+			probe.resolvers.SymlinkResolver.InitStringValues(key, values...)
 
 			evaluator := eval.StringValuesEvaluator{
 				EvalFnc: func(ctx *eval.Context) *eval.StringValues {
-					return probe.resolvers.SymlinkResolver.Resolve(key, values...)
+					return probe.resolvers.SymlinkResolver.GetStringValues(key)
 				},
 			}
 

--- a/pkg/security/probe/op_overrides.go
+++ b/pkg/security/probe/op_overrides.go
@@ -23,6 +23,11 @@ var (
 			if opts.UserCtx == nil {
 				return eval.StringEquals(a, b, opts, state)
 			}
+			probe := opts.UserCtx.(*Probe)
+
+			if !probe.config.SymlinkResolverEnabled {
+				return eval.StringEquals(a, b, opts, state)
+			}
 
 			var fieldEvaluator *eval.StringEvaluator
 			var key unsafe.Pointer
@@ -33,7 +38,7 @@ var (
 			} else if b.IsScalar() {
 				fieldEvaluator, key, value = a, unsafe.Pointer(a), b.Value
 			} else {
-				return nil, errors.New("non scalar overriden is not supported")
+				return nil, errors.New("non scalar overridden is not supported")
 			}
 
 			if fieldEvaluator.Field == "" {
@@ -41,7 +46,6 @@ var (
 			}
 
 			// pre-cache at compile time
-			probe := opts.UserCtx.(*Probe)
 			probe.resolvers.SymlinkResolver.InitStringValues(key, fieldEvaluator.Field, value)
 
 			evaluator := eval.StringValuesEvaluator{
@@ -56,19 +60,19 @@ var (
 			if opts.UserCtx == nil {
 				return eval.StringValuesContains(a, b, opts, state)
 			}
+			probe := opts.UserCtx.(*Probe)
 
-			if a.Field == "" {
+			if a.Field == "" || !probe.config.SymlinkResolverEnabled {
 				return eval.StringValuesContains(a, b, opts, state)
 			}
 
 			if !b.IsScalar() {
-				return nil, errors.New("non scalar overriden is not supported")
+				return nil, errors.New("non scalar overridden is not supported")
 			}
 
 			key, values := unsafe.Pointer(b), b.Values.GetScalarValues()
 
 			// pre-cache at compile time
-			probe := opts.UserCtx.(*Probe)
 			probe.resolvers.SymlinkResolver.InitStringValues(key, a.Field, values...)
 
 			evaluator := eval.StringValuesEvaluator{
@@ -84,19 +88,19 @@ var (
 			if opts.UserCtx == nil {
 				return eval.StringArrayContains(a, b, opts, state)
 			}
+			probe := opts.UserCtx.(*Probe)
 
-			if b.Field == "" {
+			if b.Field == "" || !probe.config.SymlinkResolverEnabled {
 				return eval.StringArrayContains(a, b, opts, state)
 			}
 
 			if !a.IsScalar() {
-				return nil, errors.New("non scalar overriden is not supported")
+				return nil, errors.New("non scalar overridden is not supported")
 			}
 
 			key, value := unsafe.Pointer(b), a.Value
 
 			// pre-cache at compile time
-			probe := opts.UserCtx.(*Probe)
 			probe.resolvers.SymlinkResolver.InitStringValues(key, b.Field, value)
 
 			evaluator := eval.StringValuesEvaluator{
@@ -111,19 +115,19 @@ var (
 			if opts.UserCtx == nil {
 				return eval.StringArrayMatches(a, b, opts, state)
 			}
+			probe := opts.UserCtx.(*Probe)
 
-			if a.Field == "" {
+			if a.Field == "" || !probe.config.SymlinkResolverEnabled {
 				return eval.StringArrayMatches(a, b, opts, state)
 			}
 
 			if !b.IsScalar() {
-				return nil, errors.New("non scalar overriden is not supported")
+				return nil, errors.New("non scalar overridden is not supported")
 			}
 
 			key, values := unsafe.Pointer(a), b.Values.GetScalarValues()
 
 			// pre-cache at compile time
-			probe := opts.UserCtx.(*Probe)
 			probe.resolvers.SymlinkResolver.InitStringValues(key, a.Field, values...)
 
 			evaluator := eval.StringValuesEvaluator{

--- a/pkg/security/probe/op_overrides.go
+++ b/pkg/security/probe/op_overrides.go
@@ -1,0 +1,106 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package probe
+
+import (
+	"unsafe"
+
+	"github.com/pkg/errors"
+
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+)
+
+var (
+	// OverridePathnames is used to add symlinks to pathnames
+	OverridePathnames = &eval.OpOverrides{
+		StringEquals: func(a *eval.StringEvaluator, b *eval.StringEvaluator, opts *eval.Opts, state *eval.State) (*eval.BoolEvaluator, error) {
+			var fieldEvaluator *eval.StringEvaluator
+			var key unsafe.Pointer
+			var value string
+
+			if a.IsScalar() {
+				fieldEvaluator, key, value = b, unsafe.Pointer(b), a.Value
+			} else if b.IsScalar() {
+				fieldEvaluator, key, value = a, unsafe.Pointer(a), b.Value
+			} else {
+				return nil, errors.New("non scalar overriden is not supported")
+			}
+
+			// pre-cache at compile time
+			probe := opts.UserCtx.(*Probe)
+			probe.resolvers.SymlinkResolver.Resolve(key, value)
+
+			evaluator := eval.StringValuesEvaluator{
+				EvalFnc: func(ctx *eval.Context) *eval.StringValues {
+					return probe.resolvers.SymlinkResolver.Resolve(key, value)
+				},
+			}
+
+			return eval.StringValuesContains(fieldEvaluator, &evaluator, opts, state)
+		},
+		StringValuesContains: func(a *eval.StringEvaluator, b *eval.StringValuesEvaluator, opts *eval.Opts, state *eval.State) (*eval.BoolEvaluator, error) {
+			if !b.IsScalar() {
+				return nil, errors.New("non scalar overriden is not supported")
+			}
+
+			key, values := unsafe.Pointer(b), b.Values.GetScalarValues()
+
+			// pre-cache at compile time
+			probe := opts.UserCtx.(*Probe)
+			probe.resolvers.SymlinkResolver.Resolve(key, values...)
+
+			evaluator := eval.StringValuesEvaluator{
+				EvalFnc: func(ctx *eval.Context) *eval.StringValues {
+					return probe.resolvers.SymlinkResolver.Resolve(key, values...)
+				},
+			}
+
+			return eval.StringValuesContains(a, &evaluator, opts, state)
+		},
+		// ex: process.ancestors.file.path
+		StringArrayContains: func(a *eval.StringEvaluator, b *eval.StringArrayEvaluator, opts *eval.Opts, state *eval.State) (*eval.BoolEvaluator, error) {
+			if !a.IsScalar() {
+				return nil, errors.New("non scalar overriden is not supported")
+			}
+
+			key, value := unsafe.Pointer(b), a.Value
+
+			// pre-cache at compile time
+			probe := opts.UserCtx.(*Probe)
+			probe.resolvers.SymlinkResolver.Resolve(key, value)
+
+			evaluator := eval.StringValuesEvaluator{
+				EvalFnc: func(ctx *eval.Context) *eval.StringValues {
+					return probe.resolvers.SymlinkResolver.Resolve(key, value)
+				},
+			}
+
+			return eval.StringValuesContains(a, &evaluator, opts, state)
+		},
+		StringArrayMatches: func(a *eval.StringArrayEvaluator, b *eval.StringValuesEvaluator, opts *eval.Opts, state *eval.State) (*eval.BoolEvaluator, error) {
+			if !b.IsScalar() {
+				return nil, errors.New("non scalar overriden is not supported")
+			}
+
+			key, values := unsafe.Pointer(a), b.Values.GetScalarValues()
+
+			// pre-cache at compile time
+			probe := opts.UserCtx.(*Probe)
+			probe.resolvers.SymlinkResolver.Resolve(key, values...)
+
+			evaluator := eval.StringValuesEvaluator{
+				EvalFnc: func(ctx *eval.Context) *eval.StringValues {
+					return probe.resolvers.SymlinkResolver.Resolve(key, values...)
+				},
+			}
+
+			return eval.StringArrayMatches(a, &evaluator, opts, state)
+		},
+	}
+)

--- a/pkg/security/probe/op_overrides.go
+++ b/pkg/security/probe/op_overrides.go
@@ -20,6 +20,10 @@ var (
 	// OverridePathnames is used to add symlinks to pathnames
 	OverridePathnames = &eval.OpOverrides{
 		StringEquals: func(a *eval.StringEvaluator, b *eval.StringEvaluator, opts *eval.Opts, state *eval.State) (*eval.BoolEvaluator, error) {
+			if opts.UserCtx == nil {
+				return eval.StringEquals(a, b, opts, state)
+			}
+
 			var fieldEvaluator *eval.StringEvaluator
 			var key unsafe.Pointer
 			var value string
@@ -49,6 +53,10 @@ var (
 			return eval.StringValuesContains(fieldEvaluator, &evaluator, opts, state)
 		},
 		StringValuesContains: func(a *eval.StringEvaluator, b *eval.StringValuesEvaluator, opts *eval.Opts, state *eval.State) (*eval.BoolEvaluator, error) {
+			if opts.UserCtx == nil {
+				return eval.StringValuesContains(a, b, opts, state)
+			}
+
 			if a.Field == "" {
 				return eval.StringValuesContains(a, b, opts, state)
 			}
@@ -73,6 +81,10 @@ var (
 		},
 		// ex: process.ancestors.file.path
 		StringArrayContains: func(a *eval.StringEvaluator, b *eval.StringArrayEvaluator, opts *eval.Opts, state *eval.State) (*eval.BoolEvaluator, error) {
+			if opts.UserCtx == nil {
+				return eval.StringArrayContains(a, b, opts, state)
+			}
+
 			if b.Field == "" {
 				return eval.StringArrayContains(a, b, opts, state)
 			}
@@ -96,6 +108,10 @@ var (
 			return eval.StringValuesContains(a, &evaluator, opts, state)
 		},
 		StringArrayMatches: func(a *eval.StringArrayEvaluator, b *eval.StringValuesEvaluator, opts *eval.Opts, state *eval.State) (*eval.BoolEvaluator, error) {
+			if opts.UserCtx == nil {
+				return eval.StringArrayMatches(a, b, opts, state)
+			}
+
 			if a.Field == "" {
 				return eval.StringArrayMatches(a, b, opts, state)
 			}

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -649,10 +649,49 @@ func (p *Probe) ApplyFilterPolicy(eventType eval.EventType, mode PolicyMode, fla
 }
 
 func (p *Probe) UptadeApprovers(field eval.Field, path string) {
+	if !p.config.EnableApprovers {
+		return
+	}
+
+	eventType, err := p.event.GetFieldEventType(field)
+	if err != nil {
+		return
+	}
+
+	handler, exists := allApproversHandlers[eventType]
+	if !exists {
+		return
+	}
+
+	approvers := rules.Approvers{
+		field: []rules.FilterValue{
+			{
+				Field: field,
+				Value: path,
+				Type:  eval.ScalarValueType,
+			},
+		},
+	}
+
+	newApprovers, err := handler(p, approvers)
+	if err != nil {
+		log.Errorf("Error while adding approver `%s` for `%s`: %s", path, eventType, err)
+		return
+	}
+
+	for _, newApprover := range newApprovers {
+		seclog.Infof("Applying approver %+v", newApprover)
+		if err := newApprover.Apply(p); err != nil {
+			log.Errorf("Error while adding approver `%s` for `%s`: %s", path, eventType, err)
+			return
+		}
+	}
+
 	p.apprroversLock.Lock()
 	defer p.apprroversLock.Unlock()
-
-	fmt.Printf("AAAAAAAAAAAAAAAaa: %s -> %s\n", field, path)
+	for _, newApprover := range newApprovers {
+		p.approvers[eventType].Add(newApprover)
+	}
 }
 
 // SetApprovers applies approvers and removes the unused ones
@@ -664,7 +703,7 @@ func (p *Probe) SetApprovers(eventType eval.EventType, approvers rules.Approvers
 
 	newApprovers, err := handler(p, approvers)
 	if err != nil {
-		log.Errorf("Error while adding approvers fallback in-kernel policy to `%s` for `%s`: %s", PolicyModeAccept, eventType, err)
+		log.Errorf("Error while adding approvers, fallback in-kernel policy to `%s` for `%s`: %s", PolicyModeAccept, eventType, err)
 	}
 
 	for _, newApprover := range newApprovers {
@@ -676,6 +715,7 @@ func (p *Probe) SetApprovers(eventType eval.EventType, approvers rules.Approvers
 
 	p.apprroversLock.Lock()
 	defer p.apprroversLock.Unlock()
+
 	if previousApprovers, exist := p.approvers[eventType]; exist {
 		previousApprovers.Sub(newApprovers)
 		for _, previousApprover := range previousApprovers {

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -66,7 +66,7 @@ func NewResolvers(config *config.Config, probe *Probe) (*Resolvers, error) {
 		ContainerResolver: &ContainerResolver{},
 		UserGroupResolver: userGroupResolver,
 		TagsResolver:      NewTagsResolver(config),
-		SymlinkResolver:   NewSymLinkResolver(),
+		SymlinkResolver:   NewSymLinkResolver(probe.UptadeApprovers),
 	}
 
 	processResolver, err := NewProcessResolver(probe, resolvers, probe.statsdClient, NewProcessResolverOpts(probe.config.CookieCacheSize))
@@ -184,6 +184,8 @@ func (r *Resolvers) Start(ctx context.Context) error {
 	if err := r.ProcessResolver.Start(ctx); err != nil {
 		return err
 	}
+
+	r.SymlinkResolver.Start(ctx)
 	r.MountResolver.Start(ctx)
 
 	if err := r.TagsResolver.Start(ctx); err != nil {

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -205,6 +205,10 @@ func (r *Resolvers) Snapshot() error {
 	if err != nil {
 		return errors.Wrap(err, "unable to snapshot SELinux")
 	}
+
+	// just sync root, overlayfs will be synced by the mount resolver
+	r.SymlinkResolver.UpdateSymlinks("")
+
 	return snapshotSELinux(selinuxStatusMap)
 }
 

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -66,7 +66,7 @@ func NewResolvers(config *config.Config, probe *Probe) (*Resolvers, error) {
 		ContainerResolver: &ContainerResolver{},
 		UserGroupResolver: userGroupResolver,
 		TagsResolver:      NewTagsResolver(config),
-		SymlinkResolver:   NewSymLinkResolver(probe.UptadeApprovers),
+		SymlinkResolver:   NewSymLinkResolver(probe.UpdateApprovers),
 	}
 
 	processResolver, err := NewProcessResolver(probe, resolvers, probe.statsdClient, NewProcessResolverOpts(probe.config.CookieCacheSize))

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -33,6 +33,7 @@ type Resolvers struct {
 	ProcessResolver   *ProcessResolver
 	UserGroupResolver *UserGroupResolver
 	TagsResolver      *TagsResolver
+	SymlinkResolver   *SymlinkResolver
 }
 
 // NewResolvers creates a new instance of Resolvers
@@ -65,6 +66,7 @@ func NewResolvers(config *config.Config, probe *Probe) (*Resolvers, error) {
 		ContainerResolver: &ContainerResolver{},
 		UserGroupResolver: userGroupResolver,
 		TagsResolver:      NewTagsResolver(config),
+		SymlinkResolver:   NewSymLinkResolver(),
 	}
 
 	processResolver, err := NewProcessResolver(probe, resolvers, probe.statsdClient, NewProcessResolverOpts(probe.config.CookieCacheSize))

--- a/pkg/security/probe/symlink_resolver.go
+++ b/pkg/security/probe/symlink_resolver.go
@@ -64,13 +64,16 @@ func (s *SymlinkResolver) UpdateSymlinks(root string) {
 		if err != nil {
 			continue
 		}
-		dest = strings.TrimPrefix(dest, root)
+
+		if root != "/" {
+			dest = strings.TrimPrefix(dest, root)
+		}
 
 		if s.added[dest] {
 			continue
 		}
 
-		seclog.Tracef("symlink resolved %s(%s) => %s\n", path, root, dest)
+		seclog.Tracef("symlink resolved %s(%s) => %s => %+v\n", path, root, dest, targets)
 
 		s.Lock()
 		for _, target := range targets {

--- a/pkg/security/probe/symlink_resolver.go
+++ b/pkg/security/probe/symlink_resolver.go
@@ -1,0 +1,54 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package probe
+
+import (
+	"os"
+	"unsafe"
+
+	seclog "github.com/DataDog/datadog-agent/pkg/security/log"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+)
+
+// SymlinkResolver defines a symlink resolver
+type SymlinkResolver struct {
+	cache map[unsafe.Pointer]*eval.StringValues
+}
+
+// Resolve resolves the given symlinks
+func (s *SymlinkResolver) Resolve(key unsafe.Pointer, path ...string) *eval.StringValues {
+	if values, exists := s.cache[key]; exists {
+		return values
+	}
+
+	values := &eval.StringValues{}
+
+	for _, p := range path {
+		// re-add existing value
+		values.AppendScalarValue(p)
+
+		dest, err := os.Readlink(p)
+		if err != nil {
+			continue
+		}
+		seclog.Tracef("new symlink resolved : src %s dst %s\n", p, dest)
+		values.AppendScalarValue(dest)
+	}
+
+	s.cache[key] = values
+
+	return values
+}
+
+// NewSymLinkResolver returns a new symlink resolver
+func NewSymLinkResolver() *SymlinkResolver {
+	return &SymlinkResolver{
+		cache: make(map[unsafe.Pointer]*eval.StringValues),
+	}
+}

--- a/pkg/security/secl/compiler/eval/eval.go
+++ b/pkg/security/secl/compiler/eval/eval.go
@@ -59,7 +59,7 @@ type ident struct {
 	Ident *string
 }
 
-func identToEvaluator(obj *ident, opts *Opts, state *State) (interface{}, lexer.Position, error) {
+func identToEvaluator(obj *ident, opts *Opts, state *RuleState) (interface{}, lexer.Position, error) {
 	if accessor, ok := opts.Constants[*obj.Ident]; ok {
 		return accessor, obj.Pos, nil
 	}
@@ -147,7 +147,7 @@ func identToEvaluator(obj *ident, opts *Opts, state *State) (interface{}, lexer.
 	return accessor, obj.Pos, nil
 }
 
-func arrayToEvaluator(array *ast.Array, opts *Opts, state *State) (interface{}, lexer.Position, error) {
+func arrayToEvaluator(array *ast.Array, opts *Opts, state *RuleState) (interface{}, lexer.Position, error) {
 	if len(array.Numbers) != 0 {
 		var evaluator IntArrayEvaluator
 		evaluator.AppendValues(array.Numbers...)
@@ -275,7 +275,7 @@ func stringEvaluatorFromVariable(str string, pos lexer.Position, opts *Opts) (in
 }
 
 // StringEqualsWrapper makes use of operator overrides
-func StringEqualsWrapper(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func StringEqualsWrapper(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 	var evaluator *BoolEvaluator
 	var err error
 
@@ -294,7 +294,7 @@ func StringEqualsWrapper(a *StringEvaluator, b *StringEvaluator, opts *Opts, sta
 }
 
 // StringArrayContainsWrapper makes use of operator overrides
-func StringArrayContainsWrapper(a *StringEvaluator, b *StringArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func StringArrayContainsWrapper(a *StringEvaluator, b *StringArrayEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 	var evaluator *BoolEvaluator
 	var err error
 
@@ -313,7 +313,7 @@ func StringArrayContainsWrapper(a *StringEvaluator, b *StringArrayEvaluator, opt
 }
 
 // StringValuesContainsWrapper makes use of operator overrides
-func StringValuesContainsWrapper(a *StringEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func StringValuesContainsWrapper(a *StringEvaluator, b *StringValuesEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 	var evaluator *BoolEvaluator
 	var err error
 
@@ -330,7 +330,7 @@ func StringValuesContainsWrapper(a *StringEvaluator, b *StringValuesEvaluator, o
 }
 
 // StringArrayMatchesWrapper makes use of operator overrides
-func StringArrayMatchesWrapper(a *StringArrayEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func StringArrayMatchesWrapper(a *StringArrayEvaluator, b *StringValuesEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 	var evaluator *BoolEvaluator
 	var err error
 
@@ -346,7 +346,7 @@ func StringArrayMatchesWrapper(a *StringArrayEvaluator, b *StringValuesEvaluator
 	return evaluator, nil
 }
 
-func nodeToEvaluator(obj interface{}, opts *Opts, state *State) (interface{}, lexer.Position, error) {
+func nodeToEvaluator(obj interface{}, opts *Opts, state *RuleState) (interface{}, lexer.Position, error) {
 	var err error
 	var boolEvaluator *BoolEvaluator
 	var pos lexer.Position

--- a/pkg/security/secl/compiler/eval/eval_operators.go
+++ b/pkg/security/secl/compiler/eval/eval_operators.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 )
 
-func Or(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func Or(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 
 	isDc := a.IsDeterministicFor(state.field) || b.IsDeterministicFor(state.field)
 
@@ -14,12 +14,12 @@ func Or(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *State) (*BoolEval
 		ea, eb := a.EvalFnc, b.EvalFnc
 
 		if state.field != "" {
-			if !a.IsDeterministicFor(state.field) && !a.IsScalar() {
+			if !a.IsDeterministicFor(state.field) && !a.IsStatic() {
 				ea = func(ctx *Context) bool {
 					return true
 				}
 			}
-			if !b.IsDeterministicFor(state.field) && !b.IsScalar() {
+			if !b.IsDeterministicFor(state.field) && !b.IsStatic() {
 				eb = func(ctx *Context) bool {
 					return true
 				}
@@ -65,12 +65,12 @@ func Or(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *State) (*BoolEval
 		}
 
 		if state.field != "" {
-			if !a.IsDeterministicFor(state.field) && !a.IsScalar() {
+			if !a.IsDeterministicFor(state.field) && !a.IsStatic() {
 				ea = func(ctx *Context) bool {
 					return true
 				}
 			}
-			if !b.IsDeterministicFor(state.field) && !b.IsScalar() {
+			if !b.IsDeterministicFor(state.field) && !b.IsStatic() {
 				eb = true
 			}
 		}
@@ -96,10 +96,10 @@ func Or(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *State) (*BoolEval
 	}
 
 	if state.field != "" {
-		if !a.IsDeterministicFor(state.field) && !a.IsScalar() {
+		if !a.IsDeterministicFor(state.field) && !a.IsStatic() {
 			ea = true
 		}
-		if !b.IsDeterministicFor(state.field) && !b.IsScalar() {
+		if !b.IsDeterministicFor(state.field) && !b.IsStatic() {
 			eb = func(ctx *Context) bool {
 				return true
 			}
@@ -118,7 +118,7 @@ func Or(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *State) (*BoolEval
 	}, nil
 }
 
-func And(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func And(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 
 	isDc := a.IsDeterministicFor(state.field) || b.IsDeterministicFor(state.field)
 
@@ -126,12 +126,12 @@ func And(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *State) (*BoolEva
 		ea, eb := a.EvalFnc, b.EvalFnc
 
 		if state.field != "" {
-			if !a.IsDeterministicFor(state.field) && !a.IsScalar() {
+			if !a.IsDeterministicFor(state.field) && !a.IsStatic() {
 				ea = func(ctx *Context) bool {
 					return true
 				}
 			}
-			if !b.IsDeterministicFor(state.field) && !b.IsScalar() {
+			if !b.IsDeterministicFor(state.field) && !b.IsStatic() {
 				eb = func(ctx *Context) bool {
 					return true
 				}
@@ -177,12 +177,12 @@ func And(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *State) (*BoolEva
 		}
 
 		if state.field != "" {
-			if !a.IsDeterministicFor(state.field) && !a.IsScalar() {
+			if !a.IsDeterministicFor(state.field) && !a.IsStatic() {
 				ea = func(ctx *Context) bool {
 					return true
 				}
 			}
-			if !b.IsDeterministicFor(state.field) && !b.IsScalar() {
+			if !b.IsDeterministicFor(state.field) && !b.IsStatic() {
 				eb = true
 			}
 		}
@@ -208,10 +208,10 @@ func And(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *State) (*BoolEva
 	}
 
 	if state.field != "" {
-		if !a.IsDeterministicFor(state.field) && !a.IsScalar() {
+		if !a.IsDeterministicFor(state.field) && !a.IsStatic() {
 			ea = true
 		}
-		if !b.IsDeterministicFor(state.field) && !b.IsScalar() {
+		if !b.IsDeterministicFor(state.field) && !b.IsStatic() {
 			eb = func(ctx *Context) bool {
 				return true
 			}
@@ -230,7 +230,7 @@ func And(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *State) (*BoolEva
 	}, nil
 }
 
-func IntEquals(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func IntEquals(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -301,7 +301,7 @@ func IntEquals(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*Boo
 	}, nil
 }
 
-func IntAnd(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*IntEvaluator, error) {
+func IntAnd(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *RuleState) (*IntEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -362,7 +362,7 @@ func IntAnd(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*IntEva
 	}, nil
 }
 
-func IntOr(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*IntEvaluator, error) {
+func IntOr(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *RuleState) (*IntEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -423,7 +423,7 @@ func IntOr(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*IntEval
 	}, nil
 }
 
-func IntXor(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*IntEvaluator, error) {
+func IntXor(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *RuleState) (*IntEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -484,7 +484,7 @@ func IntXor(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*IntEva
 	}, nil
 }
 
-func BoolEquals(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func BoolEquals(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -555,7 +555,7 @@ func BoolEquals(a *BoolEvaluator, b *BoolEvaluator, opts *Opts, state *State) (*
 	}, nil
 }
 
-func GreaterThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func GreaterThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -626,7 +626,7 @@ func GreaterThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*B
 	}, nil
 }
 
-func GreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func GreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -697,7 +697,7 @@ func GreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *Sta
 	}, nil
 }
 
-func LesserThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func LesserThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -768,7 +768,7 @@ func LesserThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*Bo
 	}, nil
 }
 
-func LesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func LesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -839,7 +839,7 @@ func LesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *Stat
 	}, nil
 }
 
-func DurationLesserThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func DurationLesserThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -910,7 +910,7 @@ func DurationLesserThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *Sta
 	}, nil
 }
 
-func DurationLesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func DurationLesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -981,7 +981,7 @@ func DurationLesserOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, sta
 	}, nil
 }
 
-func DurationGreaterThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func DurationGreaterThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1052,7 +1052,7 @@ func DurationGreaterThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *St
 	}, nil
 }
 
-func DurationGreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func DurationGreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1123,7 +1123,7 @@ func DurationGreaterOrEqualThan(a *IntEvaluator, b *IntEvaluator, opts *Opts, st
 	}, nil
 }
 
-func IntArrayEquals(a *IntEvaluator, b *IntArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func IntArrayEquals(a *IntEvaluator, b *IntArrayEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1201,7 +1201,7 @@ func IntArrayEquals(a *IntEvaluator, b *IntArrayEvaluator, opts *Opts, state *St
 	}, nil
 }
 
-func BoolArrayEquals(a *BoolEvaluator, b *BoolArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func BoolArrayEquals(a *BoolEvaluator, b *BoolArrayEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1279,7 +1279,7 @@ func BoolArrayEquals(a *BoolEvaluator, b *BoolArrayEvaluator, opts *Opts, state 
 	}, nil
 }
 
-func IntArrayGreaterThan(a *IntEvaluator, b *IntArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func IntArrayGreaterThan(a *IntEvaluator, b *IntArrayEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1357,7 +1357,7 @@ func IntArrayGreaterThan(a *IntEvaluator, b *IntArrayEvaluator, opts *Opts, stat
 	}, nil
 }
 
-func IntArrayGreaterOrEqualThan(a *IntEvaluator, b *IntArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func IntArrayGreaterOrEqualThan(a *IntEvaluator, b *IntArrayEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1435,7 +1435,7 @@ func IntArrayGreaterOrEqualThan(a *IntEvaluator, b *IntArrayEvaluator, opts *Opt
 	}, nil
 }
 
-func IntArrayLesserThan(a *IntEvaluator, b *IntArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func IntArrayLesserThan(a *IntEvaluator, b *IntArrayEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 
@@ -1513,7 +1513,7 @@ func IntArrayLesserThan(a *IntEvaluator, b *IntArrayEvaluator, opts *Opts, state
 	}, nil
 }
 
-func IntArrayLesserOrEqualThan(a *IntEvaluator, b *IntArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func IntArrayLesserOrEqualThan(a *IntEvaluator, b *IntArrayEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 
 	isDc := isArithmDeterministic(a, b, state)
 

--- a/pkg/security/secl/compiler/eval/evaluators.go
+++ b/pkg/security/secl/compiler/eval/evaluators.go
@@ -16,7 +16,7 @@ type Evaluator interface {
 	Eval(ctx *Context) interface{}
 	IsDeterministicFor(field Field) bool
 	GetField() string
-	IsScalar() bool
+	IsStatic() bool
 }
 
 // BoolEvaluator returns a bool as result of the evaluation
@@ -46,8 +46,8 @@ func (b *BoolEvaluator) GetField() string {
 	return b.Field
 }
 
-// IsScalar returns whether the evaluator is a scalar
-func (b *BoolEvaluator) IsScalar() bool {
+// IsStatic returns whether the evaluator is a scalar
+func (b *BoolEvaluator) IsStatic() bool {
 	return b.EvalFnc == nil
 }
 
@@ -79,8 +79,8 @@ func (i *IntEvaluator) GetField() string {
 	return i.Field
 }
 
-// IsScalar returns whether the evaluator is a scalar
-func (i *IntEvaluator) IsScalar() bool {
+// IsStatic returns whether the evaluator is a scalar
+func (i *IntEvaluator) IsStatic() bool {
 	return i.EvalFnc == nil
 }
 
@@ -114,8 +114,8 @@ func (s *StringEvaluator) GetField() string {
 	return s.Field
 }
 
-// IsScalar returns whether the evaluator is a scalar
-func (s *StringEvaluator) IsScalar() bool {
+// IsStatic returns whether the evaluator is a scalar
+func (s *StringEvaluator) IsStatic() bool {
 	return s.EvalFnc == nil
 }
 
@@ -169,8 +169,8 @@ func (s *StringArrayEvaluator) GetField() string {
 	return s.Field
 }
 
-// IsScalar returns whether the evaluator is a scalar
-func (s *StringArrayEvaluator) IsScalar() bool {
+// IsStatic returns whether the evaluator is a scalar
+func (s *StringArrayEvaluator) IsStatic() bool {
 	return s.EvalFnc == nil
 }
 
@@ -204,8 +204,8 @@ func (s *StringValuesEvaluator) GetField() string {
 	return ""
 }
 
-// IsScalar returns whether the evaluator is a scalar
-func (s *StringValuesEvaluator) IsScalar() bool {
+// IsStatic returns whether the evaluator is a scalar
+func (s *StringValuesEvaluator) IsStatic() bool {
 	return s.EvalFnc == nil
 }
 
@@ -280,8 +280,8 @@ func (i *IntArrayEvaluator) GetField() string {
 	return i.Field
 }
 
-// IsScalar returns whether the evaluator is a scalar
-func (i *IntArrayEvaluator) IsScalar() bool {
+// IsStatic returns whether the evaluator is a scalar
+func (i *IntArrayEvaluator) IsStatic() bool {
 	return i.EvalFnc == nil
 }
 
@@ -317,7 +317,7 @@ func (b *BoolArrayEvaluator) GetField() string {
 	return b.Field
 }
 
-// IsScalar returns whether the evaluator is a scalar
-func (b *BoolArrayEvaluator) IsScalar() bool {
+// IsStatic returns whether the evaluator is a scalar
+func (b *BoolArrayEvaluator) IsStatic() bool {
 	return b.EvalFnc == nil
 }

--- a/pkg/security/secl/compiler/eval/event.go
+++ b/pkg/security/secl/compiler/eval/event.go
@@ -31,7 +31,7 @@ type Event interface {
 	GetTags() []string
 }
 
-func eventTypesFromFields(model Model, state *State) ([]EventType, error) {
+func eventTypesFromFields(model Model, state *RuleState) ([]EventType, error) {
 	events := make(map[EventType]bool)
 	for field := range state.fieldValues {
 		eventType, err := model.NewEvent().GetFieldEventType(field)

--- a/pkg/security/secl/compiler/eval/field.go
+++ b/pkg/security/secl/compiler/eval/field.go
@@ -5,10 +5,6 @@
 
 package eval
 
-import (
-	"fmt"
-)
-
 // Field name
 type Field = string
 
@@ -28,26 +24,4 @@ const (
 type FieldValue struct {
 	Value interface{}
 	Type  FieldValueType
-
-	StringMatcher StringMatcher
-}
-
-// Compile the regular expression or the pattern
-func (f *FieldValue) Compile() error {
-	switch f.Type {
-	case PatternValueType, RegexpValueType:
-		value, ok := f.Value.(string)
-		if !ok {
-			return fmt.Errorf("invalid pattern `%v`", f.Value)
-		}
-
-		matcher, err := NewStringMatcher(f.Type, value)
-		if err != nil {
-			return err
-		}
-
-		f.StringMatcher = matcher
-	}
-
-	return nil
 }

--- a/pkg/security/secl/compiler/eval/macro.go
+++ b/pkg/security/secl/compiler/eval/macro.go
@@ -96,7 +96,7 @@ func macroToEvaluator(macro *ast.Macro, model Model, opts *Opts, field Field) (*
 	for id, macro := range opts.Macros {
 		macros[id] = macro.evaluator
 	}
-	state := newState(model, field, macros)
+	state := newRuleState(model, field, macros)
 
 	var eval interface{}
 	var err error

--- a/pkg/security/secl/compiler/eval/model_test.go
+++ b/pkg/security/secl/compiler/eval/model_test.go
@@ -343,7 +343,7 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, erro
 			},
 			Field: field,
 			OpOverrides: &OpOverrides{
-				StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+				StringValuesContains: func(a *StringEvaluator, b *StringValuesEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 					evaluator := StringValuesEvaluator{
 						EvalFnc: func(ctx *Context) *StringValues {
 							return (*testEvent)(ctx.Object).process.orNameValues()
@@ -352,7 +352,7 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, erro
 
 					return StringValuesContains(a, &evaluator, opts, state)
 				},
-				StringEquals: func(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+				StringEquals: func(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 					evaluator := StringValuesEvaluator{
 						EvalFnc: func(ctx *Context) *StringValues {
 							return (*testEvent)(ctx.Object).process.orNameValues()
@@ -378,7 +378,7 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, erro
 			},
 			Field: field,
 			OpOverrides: &OpOverrides{
-				StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+				StringArrayContains: func(a *StringEvaluator, b *StringArrayEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 					evaluator := StringValuesEvaluator{
 						EvalFnc: func(ctx *Context) *StringValues {
 							return (*testEvent)(ctx.Object).process.orArrayValues()
@@ -387,7 +387,7 @@ func (m *testModel) GetEvaluator(field Field, regID RegisterID) (Evaluator, erro
 
 					return StringArrayMatches(b, &evaluator, opts, state)
 				},
-				StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+				StringArrayMatches: func(a *StringArrayEvaluator, b *StringValuesEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 					evaluator := StringValuesEvaluator{
 						EvalFnc: func(ctx *Context) *StringValues {
 							return (*testEvent)(ctx.Object).process.orArrayValues()

--- a/pkg/security/secl/compiler/eval/operators.go
+++ b/pkg/security/secl/compiler/eval/operators.go
@@ -7,14 +7,14 @@ package eval
 
 // OpOverrides defines operator override functions
 type OpOverrides struct {
-	StringEquals         func(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *State) (*BoolEvaluator, error)
-	StringValuesContains func(a *StringEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error)
-	StringArrayContains  func(a *StringEvaluator, b *StringArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error)
-	StringArrayMatches   func(a *StringArrayEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error)
+	StringEquals         func(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error)
+	StringValuesContains func(a *StringEvaluator, b *StringValuesEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error)
+	StringArrayContains  func(a *StringEvaluator, b *StringArrayEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error)
+	StringArrayMatches   func(a *StringArrayEvaluator, b *StringValuesEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error)
 }
 
 // return whether a arithmetic operation is deterministic
-func isArithmDeterministic(a Evaluator, b Evaluator, state *State) bool {
+func isArithmDeterministic(a Evaluator, b Evaluator, state *RuleState) bool {
 	isDc := a.IsDeterministicFor(state.field) || b.IsDeterministicFor(state.field)
 
 	if aField := a.GetField(); aField != "" && state.field != "" && aField != state.field {
@@ -28,7 +28,7 @@ func isArithmDeterministic(a Evaluator, b Evaluator, state *State) bool {
 }
 
 // IntNot - ^int operator
-func IntNot(a *IntEvaluator, opts *Opts, state *State) *IntEvaluator {
+func IntNot(a *IntEvaluator, opts *Opts, state *RuleState) *IntEvaluator {
 	isDc := a.IsDeterministicFor(state.field)
 
 	if a.EvalFnc != nil {
@@ -53,7 +53,7 @@ func IntNot(a *IntEvaluator, opts *Opts, state *State) *IntEvaluator {
 }
 
 // StringEquals evaluates string
-func StringEquals(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func StringEquals(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	var arrayOp func(a string, b string) bool
@@ -100,7 +100,7 @@ func StringEquals(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *Sta
 		ea, eb := a.EvalFnc, b.Value
 
 		if a.Field != "" {
-			if err := state.UpdateFieldValues(a.Field, FieldValue{Value: eb, Type: b.ValueType, StringMatcher: b.stringMatcher}); err != nil {
+			if err := state.UpdateFieldValues(a.Field, FieldValue{Value: eb, Type: b.ValueType}); err != nil {
 				return nil, err
 			}
 		}
@@ -119,7 +119,7 @@ func StringEquals(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *Sta
 	ea, eb := a.Value, b.EvalFnc
 
 	if b.Field != "" {
-		if err := state.UpdateFieldValues(b.Field, FieldValue{Value: ea, Type: a.ValueType, StringMatcher: a.stringMatcher}); err != nil {
+		if err := state.UpdateFieldValues(b.Field, FieldValue{Value: ea, Type: a.ValueType}); err != nil {
 			return nil, err
 		}
 	}
@@ -136,7 +136,7 @@ func StringEquals(a *StringEvaluator, b *StringEvaluator, opts *Opts, state *Sta
 }
 
 // Not - !true operator
-func Not(a *BoolEvaluator, opts *Opts, state *State) *BoolEvaluator {
+func Not(a *BoolEvaluator, opts *Opts, state *RuleState) *BoolEvaluator {
 	isDc := a.IsDeterministicFor(state.field)
 
 	if a.EvalFnc != nil {
@@ -165,7 +165,7 @@ func Not(a *BoolEvaluator, opts *Opts, state *State) *BoolEvaluator {
 }
 
 // Minus - -int operator
-func Minus(a *IntEvaluator, opts *Opts, state *State) *IntEvaluator {
+func Minus(a *IntEvaluator, opts *Opts, state *RuleState) *IntEvaluator {
 	isDc := a.IsDeterministicFor(state.field)
 
 	if a.EvalFnc != nil {
@@ -190,7 +190,7 @@ func Minus(a *IntEvaluator, opts *Opts, state *State) *IntEvaluator {
 }
 
 // StringArrayContains evaluates array of strings against a value
-func StringArrayContains(a *StringEvaluator, b *StringArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func StringArrayContains(a *StringEvaluator, b *StringArrayEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	arrayOp := func(a string, b []string) bool {
@@ -271,7 +271,7 @@ func StringArrayContains(a *StringEvaluator, b *StringArrayEvaluator, opts *Opts
 	ea, eb := a.Value, b.EvalFnc
 
 	if b.Field != "" {
-		if err := state.UpdateFieldValues(b.Field, FieldValue{Value: ea, Type: a.ValueType, StringMatcher: a.stringMatcher}); err != nil {
+		if err := state.UpdateFieldValues(b.Field, FieldValue{Value: ea, Type: a.ValueType}); err != nil {
 			return nil, err
 		}
 	}
@@ -293,7 +293,7 @@ func StringArrayContains(a *StringEvaluator, b *StringArrayEvaluator, opts *Opts
 }
 
 // StringValuesContains evaluates a string against values
-func StringValuesContains(a *StringEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func StringValuesContains(a *StringEvaluator, b *StringValuesEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	if a.EvalFnc != nil && b.EvalFnc != nil {
@@ -358,7 +358,7 @@ func StringValuesContains(a *StringEvaluator, b *StringValuesEvaluator, opts *Op
 }
 
 // StringArrayMatches weak comparison, a least one element of a should be in b. a can't contain regexp
-func StringArrayMatches(a *StringArrayEvaluator, b *StringValuesEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func StringArrayMatches(a *StringArrayEvaluator, b *StringValuesEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	arrayOp := func(a []string, b *StringValues) bool {
@@ -430,7 +430,7 @@ func StringArrayMatches(a *StringArrayEvaluator, b *StringValuesEvaluator, opts 
 }
 
 // IntArrayMatches weak comparison, a least one element of a should be in b
-func IntArrayMatches(a *IntArrayEvaluator, b *IntArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func IntArrayMatches(a *IntArrayEvaluator, b *IntArrayEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	arrayOp := func(a []int, b []int) bool {
@@ -504,7 +504,7 @@ func IntArrayMatches(a *IntArrayEvaluator, b *IntArrayEvaluator, opts *Opts, sta
 }
 
 // ArrayBoolContains evaluates array of bool against a value
-func ArrayBoolContains(a *BoolEvaluator, b *BoolArrayEvaluator, opts *Opts, state *State) (*BoolEvaluator, error) {
+func ArrayBoolContains(a *BoolEvaluator, b *BoolArrayEvaluator, opts *Opts, state *RuleState) (*BoolEvaluator, error) {
 	isDc := isArithmDeterministic(a, b, state)
 
 	arrayOp := func(a bool, b []bool) bool {

--- a/pkg/security/secl/compiler/eval/opts.go
+++ b/pkg/security/secl/compiler/eval/opts.go
@@ -49,11 +49,6 @@ func (o *Opts) AddMacro(macro *Macro) *Opts {
 		o.Macros = make(map[string]*Macro)
 	}
 	o.Macros[macro.ID] = macro
-}
-
-// WithUserContext set user context
-func (o *Opts) WithUserContext(ctx interface{}) *Opts {
-	o.UserCtx = ctx
 	return o
 }
 

--- a/pkg/security/secl/compiler/eval/opts.go
+++ b/pkg/security/secl/compiler/eval/opts.go
@@ -49,6 +49,11 @@ func (o *Opts) AddMacro(macro *Macro) *Opts {
 		o.Macros = make(map[string]*Macro)
 	}
 	o.Macros[macro.ID] = macro
+}
+
+// WithUserContext set user context
+func (o *Opts) WithUserContext(ctx interface{}) *Opts {
+	o.UserCtx = ctx
 	return o
 }
 

--- a/pkg/security/secl/compiler/eval/state.go
+++ b/pkg/security/secl/compiler/eval/state.go
@@ -11,8 +11,8 @@ type registerInfo struct {
 	subFields map[Field]bool
 }
 
-// State defines the current state of the rule compilation
-type State struct {
+// RuleState defines the current state of the rule compilation
+type RuleState struct {
 	model         Model
 	field         Field
 	events        map[EventType]bool
@@ -22,14 +22,14 @@ type State struct {
 }
 
 // UpdateFields updates the fields used in the rule
-func (s *State) UpdateFields(field Field) {
+func (s *RuleState) UpdateFields(field Field) {
 	if _, ok := s.fieldValues[field]; !ok {
 		s.fieldValues[field] = []FieldValue{}
 	}
 }
 
 // UpdateFieldValues updates the field values
-func (s *State) UpdateFieldValues(field Field, value FieldValue) error {
+func (s *RuleState) UpdateFieldValues(field Field, value FieldValue) error {
 	values, ok := s.fieldValues[field]
 	if !ok {
 		values = []FieldValue{}
@@ -39,11 +39,27 @@ func (s *State) UpdateFieldValues(field Field, value FieldValue) error {
 	return s.model.ValidateField(field, value)
 }
 
-func newState(model Model, field Field, macros map[MacroID]*MacroEvaluator) *State {
+// GetFields returns all the Field that the state handles
+func (s *RuleState) GetFields() []Field {
+	fields := make([]Field, len(s.fieldValues))
+	i := 0
+	for key := range s.fieldValues {
+		fields[i] = key
+		i++
+	}
+	return fields
+}
+
+// GetFieldValues returns the values of the given field
+func (s *RuleState) GetFieldValues(field Field) []FieldValue {
+	return s.fieldValues[field]
+}
+
+func newRuleState(model Model, field Field, macros map[MacroID]*MacroEvaluator) *RuleState {
 	if macros == nil {
 		macros = make(map[MacroID]*MacroEvaluator)
 	}
-	return &State{
+	return &RuleState{
 		field:         field,
 		macros:        macros,
 		model:         model,

--- a/pkg/security/secl/compiler/generators/operators/operators.go
+++ b/pkg/security/secl/compiler/generators/operators/operators.go
@@ -43,7 +43,7 @@ import (
 
 {{ range .Operators }}
 
-func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, opts *Opts, state *State) (*{{ .FuncReturnType }}, error) {
+func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, opts *Opts, state *RuleState) (*{{ .FuncReturnType }}, error) {
 	{{ if or (eq .FuncName "Or") (eq .FuncName "And") }}
 	isDc := a.IsDeterministicFor(state.field) || b.IsDeterministicFor(state.field)
 	{{ else }}
@@ -60,12 +60,12 @@ func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, opts *Opts, state *
 
 		{{ if or (eq .FuncName "Or") (eq .FuncName "And") }}
 			if state.field != "" {
-				if !a.IsDeterministicFor(state.field) && !a.IsScalar() {
+				if !a.IsDeterministicFor(state.field) && !a.IsStatic() {
 					ea = func(ctx *Context) {{ .EvalReturnType }} {
 						return true
 					}
 				}
-				if !b.IsDeterministicFor(state.field) && !b.IsScalar() {
+				if !b.IsDeterministicFor(state.field) && !b.IsStatic() {
 					eb = func(ctx *Context) {{ .EvalReturnType }} {
 						return true
 					}
@@ -117,12 +117,12 @@ func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, opts *Opts, state *
 
 		{{ if or (eq .FuncName "Or") (eq .FuncName "And") }}
 			if state.field != "" {
-				if !a.IsDeterministicFor(state.field) && !a.IsScalar() {
+				if !a.IsDeterministicFor(state.field) && !a.IsStatic() {
 					ea = func(ctx *Context) {{ .EvalReturnType }} {
 						return true
 					}
 				}
-				if !b.IsDeterministicFor(state.field) && !b.IsScalar() {
+				if !b.IsDeterministicFor(state.field) && !b.IsStatic() {
 					eb = true
 				}
 			}
@@ -150,10 +150,10 @@ func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, opts *Opts, state *
 
 	{{ if or (eq .FuncName "Or") (eq .FuncName "And") }}
 		if state.field != "" {
-			if !a.IsDeterministicFor(state.field) && !a.IsScalar() {
+			if !a.IsDeterministicFor(state.field) && !a.IsStatic() {
 				ea = true
 			}
-			if !b.IsDeterministicFor(state.field) && !b.IsScalar() {
+			if !b.IsDeterministicFor(state.field) && !b.IsStatic() {
 				eb = func(ctx *Context) {{ .EvalReturnType }} {
 					return true
 				}
@@ -176,7 +176,7 @@ func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, opts *Opts, state *
 
 {{ range .ArrayOperators }}
 
-func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, opts *Opts, state *State) (*{{ .FuncReturnType }}, error) {
+func {{ .FuncName }}(a *{{ .Arg1Type }}, b *{{ .Arg2Type }}, opts *Opts, state *RuleState) (*{{ .FuncReturnType }}, error) {
 	{{ if or (eq .FuncName "Or") (eq .FuncName "And") }}
 	isDc := a.IsDeterministicFor(state.field) || b.IsDeterministicFor(state.field)
 	{{ else }}

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -263,17 +263,10 @@ type Process struct {
 	Pid uint32 `field:"pid" msg:"pid"` // Process ID of the process (also called thread group ID)
 	Tid uint32 `field:"tid" msg:"tid"` // Thread ID of the thread
 
-<<<<<<< HEAD
-	PathnameStr         string `field:"file.path" msg:"path"`             // Path of the process executable
-	BasenameStr         string `field:"file.name" msg:"name"`             // Basename of the path of the process executable
-	Filesystem          string `field:"file.filesystem" msg:"filesystem"` // FileSystem of the process executable
+	PathnameStr         string `field:"file.path" msg:"path" op_override:"OverridePathnames"` // Path of the process executable
+	BasenameStr         string `field:"file.name" msg:"name"`                                 // Basename of the path of the process executable
+	Filesystem          string `field:"file.filesystem" msg:"filesystem"`                     // FileSystem of the process executable
 	PathResolutionError error  `field:"-" msg:"-"`
-=======
-	PathnameStr         string `field:"file.path" op_override:"OverridePathnames"` // Path of the process executable
-	BasenameStr         string `field:"file.name"`                                 // Basename of the path of the process executable
-	Filesystem          string `field:"file.filesystem"`                           // FileSystem of the process executable
-	PathResolutionError error  `field:"-"`
->>>>>>> baee6862cf (Introduce a cache)
 
 	ContainerID   string   `field:"container.id" msg:"container_id"` // Container ID
 	ContainerTags []string `field:"-" msg:"container_tags"`
@@ -365,15 +358,9 @@ func (f *FileFields) GetInUpperLayer() bool {
 // FileEvent is the common file event type
 type FileEvent struct {
 	FileFields
-<<<<<<< HEAD
-	PathnameStr string `field:"path,ResolveFilePath" msg:"path"`                   // File's path
-	BasenameStr string `field:"name,ResolveFileBasename" msg:"name"`               // File's basename
-	Filesytem   string `field:"filesystem,ResolveFileFilesystem" msg:"filesystem"` // File's filesystem
-=======
-	PathnameStr string `field:"path,ResolveFilePath" op_override:"OverridePathnames"` // File's path
-	BasenameStr string `field:"name,ResolveFileBasename"`                             // File's basename
-	Filesytem   string `field:"filesystem,ResolveFileFilesystem"`                     // File's filesystem
->>>>>>> baee6862cf (Introduce a cache)
+	PathnameStr string `field:"path,ResolveFilePath" msg:"path" op_override:"OverridePathnames"` // File's path
+	BasenameStr string `field:"name,ResolveFileBasename" msg:"name"`                             // File's basename
+	Filesytem   string `field:"filesystem,ResolveFileFilesystem" msg:"filesystem"`               // File's filesystem
 
 	PathResolutionError error `field:"-" msg:"-"`
 }

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -263,10 +263,17 @@ type Process struct {
 	Pid uint32 `field:"pid" msg:"pid"` // Process ID of the process (also called thread group ID)
 	Tid uint32 `field:"tid" msg:"tid"` // Thread ID of the thread
 
+<<<<<<< HEAD
 	PathnameStr         string `field:"file.path" msg:"path"`             // Path of the process executable
 	BasenameStr         string `field:"file.name" msg:"name"`             // Basename of the path of the process executable
 	Filesystem          string `field:"file.filesystem" msg:"filesystem"` // FileSystem of the process executable
 	PathResolutionError error  `field:"-" msg:"-"`
+=======
+	PathnameStr         string `field:"file.path" op_override:"OverridePathnames"` // Path of the process executable
+	BasenameStr         string `field:"file.name"`                                 // Basename of the path of the process executable
+	Filesystem          string `field:"file.filesystem"`                           // FileSystem of the process executable
+	PathResolutionError error  `field:"-"`
+>>>>>>> baee6862cf (Introduce a cache)
 
 	ContainerID   string   `field:"container.id" msg:"container_id"` // Container ID
 	ContainerTags []string `field:"-" msg:"container_tags"`
@@ -358,9 +365,15 @@ func (f *FileFields) GetInUpperLayer() bool {
 // FileEvent is the common file event type
 type FileEvent struct {
 	FileFields
+<<<<<<< HEAD
 	PathnameStr string `field:"path,ResolveFilePath" msg:"path"`                   // File's path
 	BasenameStr string `field:"name,ResolveFileBasename" msg:"name"`               // File's basename
 	Filesytem   string `field:"filesystem,ResolveFileFilesystem" msg:"filesystem"` // File's filesystem
+=======
+	PathnameStr string `field:"path,ResolveFilePath" op_override:"OverridePathnames"` // File's path
+	BasenameStr string `field:"name,ResolveFileBasename"`                             // File's basename
+	Filesytem   string `field:"filesystem,ResolveFileFilesystem"`                     // File's filesystem
+>>>>>>> baee6862cf (Introduce a cache)
 
 	PathResolutionError error `field:"-" msg:"-"`
 }

--- a/pkg/security/secl/rules/opts.go
+++ b/pkg/security/secl/rules/opts.go
@@ -48,11 +48,6 @@ func (o *Opts) WithLegacyFields(fields map[eval.Field]eval.Field) *Opts {
 // AddMacro add a macro
 func (o *Opts) AddMacro(macro *eval.Macro) *Opts {
 	o.Opts.AddMacro(macro)
-}
-
-// WithUserContext set user context
-func (o *Opts) WithUserContext(ctx interface{}) *Opts {
-	o.Opts.WithUserContext(ctx)
 	return o
 }
 

--- a/pkg/security/secl/rules/opts.go
+++ b/pkg/security/secl/rules/opts.go
@@ -48,6 +48,11 @@ func (o *Opts) WithLegacyFields(fields map[eval.Field]eval.Field) *Opts {
 // AddMacro add a macro
 func (o *Opts) AddMacro(macro *eval.Macro) *Opts {
 	o.Opts.AddMacro(macro)
+}
+
+// WithUserContext set user context
+func (o *Opts) WithUserContext(ctx interface{}) *Opts {
+	o.Opts.WithUserContext(ctx)
 	return o
 }
 

--- a/pkg/security/secl/rules/truth_table.go
+++ b/pkg/security/secl/rules/truth_table.go
@@ -107,7 +107,9 @@ func combineBitmasks(bitmasks []int) []int {
 
 func genFilterValues(rule *eval.Rule, event eval.Event) ([]FilterValues, error) {
 	var filterValues []FilterValues
-	for field, fValues := range rule.GetEvaluator().FieldValues {
+	for _, field := range rule.GetFields() {
+		fValues := rule.GetFieldValues(field)
+
 		// case where there is no static value, ex: process.gid == process.uid
 		// so generate fake value in order to be able to get the truth table
 		// note that we want to have the comparison returning true
@@ -235,10 +237,6 @@ func combineFilterValues(filterValues []FilterValues) []FilterValues {
 
 func newTruthTable(rule *eval.Rule, event eval.Event) (*truthTable, error) {
 	ctx := eval.NewContext(event.GetPointer())
-
-	if len(rule.GetEvaluator().FieldValues) == 0 {
-		return nil, nil
-	}
 
 	filterValues, err := genFilterValues(rule, event)
 	if err != nil {

--- a/pkg/security/tests/cmdwrapper.go
+++ b/pkg/security/tests/cmdwrapper.go
@@ -55,6 +55,7 @@ type dockerCmdWrapper struct {
 	executable    string
 	root          string
 	containerName string
+	image         string
 }
 
 func (d *dockerCmdWrapper) Command(bin string, args []string, envs []string) *exec.Cmd {
@@ -73,7 +74,7 @@ func (d *dockerCmdWrapper) Command(bin string, args []string, envs []string) *ex
 
 func (d *dockerCmdWrapper) start() ([]byte, error) {
 	d.containerName = fmt.Sprintf("docker-wrapper-%s", randStringRunes(6))
-	cmd := exec.Command(d.executable, "run", "--rm", "-d", "--name", d.containerName, "-v", d.root+":"+d.root, "ubuntu:focal", "sleep", "600")
+	cmd := exec.Command(d.executable, "run", "--rm", "-d", "--name", d.containerName, "-v", d.root+":"+d.root, d.image, "sleep", "600")
 	return cmd.CombinedOutput()
 }
 
@@ -103,7 +104,7 @@ func (d *dockerCmdWrapper) Type() wrapperType {
 	return dockerWrapperType
 }
 
-func newDockerCmdWrapper(root string) (*dockerCmdWrapper, error) {
+func newDockerCmdWrapper(root string, image ...string) (*dockerCmdWrapper, error) {
 	executable, err := exec.LookPath("docker")
 	if err != nil {
 		return nil, err
@@ -115,10 +116,17 @@ func newDockerCmdWrapper(root string) (*dockerCmdWrapper, error) {
 		return nil, err
 	}
 
-	return &dockerCmdWrapper{
+	dw := &dockerCmdWrapper{
 		executable: executable,
 		root:       root,
-	}, nil
+		image:      "ubuntu:focal",
+	}
+
+	if len(image) > 0 {
+		dw.image = image[0]
+	}
+
+	return dw, nil
 }
 
 type multiCmdWrapper struct {

--- a/pkg/security/tests/cmdwrapper.go
+++ b/pkg/security/tests/cmdwrapper.go
@@ -122,7 +122,7 @@ func newDockerCmdWrapper(root string, image ...string) (*dockerCmdWrapper, error
 		image:      "ubuntu:focal",
 	}
 
-	if len(image) > 0 {
+	if len(image) > 0 && image[0] != "" {
 		dw.image = image[0]
 	}
 

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -146,6 +146,7 @@ type testOpts struct {
 	reuseProbeHandler           bool
 	disableERPCDentryResolution bool
 	disableMapDentryResolution  bool
+	containerImage              string
 }
 
 func (s *stringSlice) String() string {
@@ -468,7 +469,7 @@ func newTestModule(t testing.TB, macroDefs []*rules.MacroDefinition, ruleDefs []
 	if testEnvironment == DockerEnvironment {
 		cmdWrapper = newStdCmdWrapper()
 	} else {
-		wrapper, err := newDockerCmdWrapper(st.Root())
+		wrapper, err := newDockerCmdWrapper(st.Root(), opts.containerImage)
 		if err == nil {
 			cmdWrapper = newMultiCmdWrapper(wrapper, newStdCmdWrapper())
 		} else {

--- a/pkg/security/tests/symlink_test.go
+++ b/pkg/security/tests/symlink_test.go
@@ -1,0 +1,156 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build functionaltests
+// +build functionaltests
+
+package tests
+
+import (
+	"fmt"
+	"os/exec"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+
+	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+)
+
+func TestSymlink(t *testing.T) {
+	if testEnvironment == DockerEnvironment {
+		t.Skip()
+	}
+
+	ruleDefs := []*rules.RuleDefinition{
+		{
+			ID:         "test_symlink_1",
+			Expression: `open.file.path == "{{.Root}}/test1" && process.file.path == "/usr/bin/python3"`,
+		},
+		{
+			ID:         "test_symlink_2",
+			Expression: `open.file.path == "{{.Root}}/test2" && process.file.path in ["/usr/bin/python3"]`,
+		},
+		{
+			ID:         "test_symlink_3",
+			Expression: `open.file.path == "{{.Root}}/test3" && process.ancestors.file.path == "/usr/bin/python3"`,
+		},
+		{
+			ID:         "test_symlink_4",
+			Expression: `open.file.path == "{{.Root}}/test4" && process.ancestors.file.path in ["/usr/bin/python3"]`,
+		},
+	}
+
+	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	time.Sleep(2 * time.Second)
+
+	cmdWrapper, err := newDockerCmdWrapper(test.Root(), "python:3.9")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer cmdWrapper.stop()
+
+	cmdWrapper.Run(t, "symlink_1", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		testFile, _, err := test.Path("test1")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		args := []string{"-c", fmt.Sprintf(`import os; os.open("%s", os.O_CREAT)`, testFile)}
+		envs := []string{}
+
+		test.WaitSignal(t, func() error {
+			cmd := cmdFunc("/usr/bin/python3", args, envs)
+			return cmd.Run()
+		}, func(event *sprobe.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_symlink_1")
+
+			assert.Equal(t, "/usr/bin/python3.9", event.ProcessContext.PathnameStr, "wrong symlink")
+			assert.Equal(t, testFile, event.Open.File.PathnameStr, "wrong symlink")
+
+			if !validateExecSchema(t, event) {
+				t.Error(event.String())
+			}
+		})
+	})
+
+	cmdWrapper.Run(t, "symlink_2", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		testFile, _, err := test.Path("test2")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		args := []string{"-c", fmt.Sprintf(`import os; os.open("%s", os.O_CREAT)`, testFile)}
+		envs := []string{}
+
+		test.WaitSignal(t, func() error {
+			cmd := cmdFunc("/usr/bin/python3", args, envs)
+			return cmd.Run()
+		}, func(event *sprobe.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_symlink_2")
+
+			assert.Equal(t, "/usr/bin/python3.9", event.ProcessContext.PathnameStr, "wrong symlink")
+			assert.Equal(t, testFile, event.Open.File.PathnameStr, "wrong symlink")
+
+			if !validateExecSchema(t, event) {
+				t.Error(event.String())
+			}
+		})
+	})
+
+	cmdWrapper.Run(t, "symlink_3", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		testFile, _, err := test.Path("test3")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		args := []string{"-c", fmt.Sprintf(`import os; os.system("touch %s")`, testFile)}
+		envs := []string{}
+
+		test.WaitSignal(t, func() error {
+			cmd := cmdFunc("/usr/bin/python3", args, envs)
+			return cmd.Run()
+		}, func(event *sprobe.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_symlink_3")
+
+			assert.Equal(t, "/usr/bin/python3.9", event.ProcessContext.Ancestor.Ancestor.Ancestor.PathnameStr, "wrong symlink")
+			assert.Equal(t, testFile, event.Open.File.PathnameStr, "wrong symlink")
+
+			if !validateExecSchema(t, event) {
+				t.Error(event.String())
+			}
+		})
+	})
+
+	cmdWrapper.Run(t, "symlink_4", func(t *testing.T, kind wrapperType, cmdFunc func(cmd string, args []string, envs []string) *exec.Cmd) {
+		testFile, _, err := test.Path("test4")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		args := []string{"-c", fmt.Sprintf(`import os; os.system("touch %s")`, testFile)}
+		envs := []string{}
+
+		test.WaitSignal(t, func() error {
+			cmd := cmdFunc("/usr/bin/python3", args, envs)
+			return cmd.Run()
+		}, func(event *sprobe.Event, rule *rules.Rule) {
+			assertTriggeredRule(t, rule, "test_symlink_4")
+
+			assert.Equal(t, "/usr/bin/python3.9", event.ProcessContext.Ancestor.Ancestor.Ancestor.PathnameStr, "wrong symlink")
+			assert.Equal(t, testFile, event.Open.File.PathnameStr, "wrong symlink")
+
+			if !validateExecSchema(t, event) {
+				t.Error(event.String())
+			}
+		})
+	})
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR introduce a way to handle symlink in SECL rules. It leverages operator override so that symlinks are resolved and target paths are used in SECL expressions. A callback in the mount resolver is used to resolve symlink in container.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
