### PR TITLE
[CWS] Add cache to mount resolver

### DIFF
--- a/pkg/security/probe/mount_resolver.go
+++ b/pkg/security/probe/mount_resolver.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/DataDog/gopsutil/process"
+	"github.com/hashicorp/golang-lru/simplelru"
 	"github.com/moby/sys/mountinfo"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
@@ -79,11 +80,13 @@ type deleteRequest struct {
 
 // MountResolver represents a cache for mountpoints and the corresponding file systems
 type MountResolver struct {
-	probe       *Probe
-	lock        sync.RWMutex
-	mounts      map[uint32]*model.MountEvent
-	devices     map[uint32]map[uint32]*model.MountEvent
-	deleteQueue []deleteRequest
+	probe            *Probe
+	lock             sync.RWMutex
+	mounts           map[uint32]*model.MountEvent
+	devices          map[uint32]map[uint32]*model.MountEvent
+	deleteQueue      []deleteRequest
+	overlayPathCache *simplelru.LRU
+	parentPathCache  *simplelru.LRU
 }
 
 // SyncCache - Snapshots the current mount points of the system by reading through /proc/[pid]/mountinfo.
@@ -264,7 +267,13 @@ func (mr *MountResolver) _getParentPath(mountID uint32, cache map[uint32]bool) s
 }
 
 func (mr *MountResolver) getParentPath(mountID uint32) string {
-	return mr._getParentPath(mountID, map[uint32]bool{})
+	if entry, found := mr.parentPathCache.Get(mountID); found {
+		return entry.(string)
+	}
+
+	path := mr._getParentPath(mountID, map[uint32]bool{})
+	mr.parentPathCache.Add(mountID, path)
+	return path
 }
 
 func (mr *MountResolver) _getAncestor(mount *model.MountEvent, cache map[uint32]bool) *model.MountEvent {
@@ -291,9 +300,18 @@ func (mr *MountResolver) getAncestor(mount *model.MountEvent) *model.MountEvent 
 
 // getOverlayPath uses deviceID to find overlay path
 func (mr *MountResolver) getOverlayPath(mount *model.MountEvent) string {
+	if entry, found := mr.parentPathCache.Get(mount.MountID); found {
+		return entry.(string)
+	}
+
+	if ancestor := mr.getAncestor(mount); ancestor != nil {
+		mount = ancestor
+	}
+
 	for _, deviceMount := range mr.devices[mount.Device] {
 		if mount.MountID != deviceMount.MountID && deviceMount.IsOverlayFS() {
 			if p := mr.getParentPath(deviceMount.MountID); p != "" {
+				mr.parentPathCache.Add(mount.MountID, p)
 				return p
 			}
 		}
@@ -318,6 +336,10 @@ func (mr *MountResolver) dequeue(now time.Time) {
 		if prev := mr.mounts[req.mount.MountID]; prev == req.mount {
 			mr.delete(req.mount)
 		}
+
+		// clear cache anyway
+		mr.parentPathCache.Remove(req.mount.MountID)
+		mr.overlayPathCache.Remove(req.mount)
 
 		i++
 	}
@@ -362,12 +384,7 @@ func (mr *MountResolver) GetMountPath(mountID uint32) (string, string, string, e
 		return "", "", "", nil
 	}
 
-	ref := mount
-	if ancestor := mr.getAncestor(mount); ancestor != nil {
-		ref = ancestor
-	}
-
-	return mr.getOverlayPath(ref), mr.getParentPath(mountID), mount.RootStr, nil
+	return mr.getOverlayPath(mount), mr.getParentPath(mountID), mount.RootStr, nil
 }
 
 func getMountIDOffset(probe *Probe) uint64 {
@@ -479,11 +496,23 @@ func getVFSRenameInputType(probe *Probe) uint64 {
 }
 
 // NewMountResolver instantiates a new mount resolver
-func NewMountResolver(probe *Probe) *MountResolver {
-	return &MountResolver{
-		probe:   probe,
-		lock:    sync.RWMutex{},
-		devices: make(map[uint32]map[uint32]*model.MountEvent),
-		mounts:  make(map[uint32]*model.MountEvent),
+func NewMountResolver(probe *Probe) (*MountResolver, error) {
+	overlayPathCache, err := simplelru.NewLRU(256, nil)
+	if err != nil {
+		return nil, err
 	}
+
+	parentPathCache, err := simplelru.NewLRU(256, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	return &MountResolver{
+		probe:            probe,
+		lock:             sync.RWMutex{},
+		devices:          make(map[uint32]map[uint32]*model.MountEvent),
+		mounts:           make(map[uint32]*model.MountEvent),
+		overlayPathCache: overlayPathCache,
+		parentPathCache:  parentPathCache,
+	}, nil
 }

--- a/pkg/security/probe/mount_resolver_test.go
+++ b/pkg/security/probe/mount_resolver_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/hashicorp/golang-lru/simplelru"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/model"
@@ -309,7 +310,7 @@ func TestMountResolver(t *testing.T) {
 	}
 
 	// Create mount resolver
-	mr := NewMountResolver(nil)
+	mr, _ := NewMountResolver(nil)
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			for _, evt := range tt.args.events {
@@ -342,6 +343,11 @@ func TestMountResolver(t *testing.T) {
 }
 
 func TestGetParentPath(t *testing.T) {
+	parentPathCache, err := simplelru.NewLRU(256, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	mr := &MountResolver{
 		mounts: map[uint32]*model.MountEvent{
 			1: {
@@ -360,6 +366,7 @@ func TestGetParentPath(t *testing.T) {
 				MountPointStr: "/c",
 			},
 		},
+		parentPathCache: parentPathCache,
 	}
 
 	parentPath := mr.getParentPath(3)

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -52,10 +52,15 @@ func NewResolvers(config *config.Config, probe *Probe) (*Resolvers, error) {
 		return nil, err
 	}
 
+	mountResolver, err := NewMountResolver(probe)
+	if err != nil {
+		return nil, err
+	}
+
 	resolvers := &Resolvers{
 		probe:             probe,
 		DentryResolver:    dentryResolver,
-		MountResolver:     NewMountResolver(probe),
+		MountResolver:     mountResolver,
 		TimeResolver:      timeResolver,
 		ContainerResolver: &ContainerResolver{},
 		UserGroupResolver: userGroupResolver,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add two caches to mount resolver, one for parent resolution, another one from overlay path resolution.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
