### PR TITLE
[util/kubernetes] Add handling for empty container id string

### DIFF
--- a/pkg/util/kubernetes/kubelet/kubelet_common.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_common.go
@@ -75,6 +75,9 @@ func TrimRuntimeFromCID(cid string) string {
 // KubeContainerIDToTaggerEntityID builds an entity ID from a container ID coming from
 // the pod status (i.e. including the <runtime>:// prefix).
 func KubeContainerIDToTaggerEntityID(ctrID string) (string, error) {
+	if(ctrID == "") {
+		return "", fmt.Errorf("container ID is empty")
+	}
 	sep := strings.LastIndex(ctrID, containers.EntitySeparator)
 	if sep != -1 && len(ctrID) > sep+len(containers.EntitySeparator) {
 		return containers.ContainerEntityName + ctrID[sep:], nil

--- a/pkg/util/kubernetes/kubelet/kubelet_common_test.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_common_test.go
@@ -69,6 +69,7 @@ func TestKubeContainerIDToTaggerEntityID(t *testing.T) {
 		"deadbeef":                "",
 		"/deadbeef":               "",
 		"runtime://foo/bar":       "container_id://foo/bar",
+		"": 					   "",
 	} {
 		t.Run(fmt.Sprintf("case: %s", in), func(t *testing.T) {
 			res, _ := KubeContainerIDToTaggerEntityID(in)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

The current error message is not always very clear, if the container hasn't been assigned an ID yet. In the current state the initial thought upon reading is that there is something wrong in the agent side, but it seems to happen mainly due things on the Kubernetes side like crash looping, initialisation and during similar events within the pods lifecycle.

From logs it looks like this:
`2021-12-13 15:19:34 UTC | PROCESS | WARN | (pkg/tagger/collectors/kubelet_extract.go:238 in parsePods) | Unable to parse container pName: datadog-fzf6k / cName: trace-agent / cId:  / err: can't extract an entity ID from container ID`

### Motivation

Ended up debugging the issue based on the logs by myself and based on the search, there have been others as well ([issue](https://github.com/DataDog/datadog-agent/issues/5482)), so I thought I'd propose something.

### Additional Notes

I added the explicit handling for an empty container ID string, but other option would be to enhance the existing message to cover both a real parsing error and an ID that's not set yet on the Kubernetes side.

### Describe how to test/QA your changes

Should be covered by the tests. It has the same output as the other parsing error cases, just a different message, so it should be backwards compatible as well.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
