### PR TITLE
Backport fix: agent encoding fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -57,7 +57,7 @@ require (
 	code.cloudfoundry.org/rep v0.0.0-20200325195957-1404b978e31e // indirect
 	code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a // indirect
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
-	github.com/DataDog/agent-payload/v5 v5.0.2
+	github.com/DataDog/agent-payload/v5 v5.0.4
 	github.com/DataDog/datadog-agent/pkg/otlp/model v0.33.0-rc.7
 	github.com/DataDog/datadog-agent/pkg/quantile v0.33.0-rc.7
 	github.com/DataDog/datadog-agent/pkg/security/secl v0.33.0-rc.7

--- a/go.sum
+++ b/go.sum
@@ -104,8 +104,8 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/DataDog/agent-payload/v5 v5.0.2 h1:Uzbl1yI2/Sv8hA8Jc9AU0wJavOxqhbfTE38KhZceScc=
-github.com/DataDog/agent-payload/v5 v5.0.2/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
+github.com/DataDog/agent-payload/v5 v5.0.4 h1:4iFVwqPoBi+FbViN37gPtMUAbiwCtI1NiLleHI+fQ8M=
+github.com/DataDog/agent-payload/v5 v5.0.4/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/DataDog/datadog-api-client-go v1.0.0-beta.18/go.mod h1:Gn0fZwIOBbSidO0OaPEh9nO5EmIPsxJrHfHvfVXEaoU=


### PR DESCRIPTION
### What does this PR do?
Backport of:

Incorporates new version of `agent-payload`, which fixes the following bug:

The offset of the middle entry of the dns database is being encoded,
but not used (was originally left for future optimization).
However, it has a problem of the result changing its own position.
This works, except in a very specific boundary case.

if offsetOfMiddle happens to be 127 (or any other subsequent size
that causes the size of a varint to go up), we have an off-by-one bug.
The offset is 127, so we compute the size (which is 1), and then increment
the buffer size to match. However, since the offsetOfMiddle is now 128, the
size of the varint is now 2, and the whole buffer's whacked. Only when the
middle happens to be on the boundary of when the varint size changes.

**note** this is a remake of a previously approved PR that was redone due to merge problems.

### Motivation

Agent can send invalid payload which causes grief for back end


### Describe how to test/QA your changes

Requires very specific payload; tests included in agent-payload change describe.

### Reviewer's Checklist
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.