### PR TITLE
[serverless] Enable proxy in .NET integration tests

### DIFF
--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -13,7 +13,7 @@ import (
 // ProxyProcessor is a InvocationProcessor implementation
 type ProxyProcessor struct{}
 
-// OnInvokeStart is the hook triggered when an invocation has started
+// OnInvokeStart is the hook triggered when an invocation starts
 func (pp *ProxyProcessor) OnInvokeStart(startDetails *proxy.InvocationStartDetails) {
 	log.Debug("[proxy] onInvokeStart ------")
 	log.Debug("[proxy] Invocation has started at :", startDetails.StartTime)

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -13,7 +13,7 @@ import (
 // ProxyProcessor is a InvocationProcessor implementation
 type ProxyProcessor struct{}
 
-// OnInvokeStart is the hook triggered when an invocation starts
+// OnInvokeStart is the hook triggered when an invocation has started
 func (pp *ProxyProcessor) OnInvokeStart(startDetails *proxy.InvocationStartDetails) {
 	log.Debug("[proxy] onInvokeStart ------")
 	log.Debug("[proxy] Invocation has started at :", startDetails.StartTime)

--- a/test/integration/serverless/serverless.yml
+++ b/test/integration/serverless/serverless.yml
@@ -251,6 +251,8 @@ functions:
       - { Ref: RecorderExtensionLambdaLayer }
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
     environment:
+      AWS_LAMBDA_EXEC_WRAPPER: /opt/boot.sh
+      DD_EXPERIMENTAL_ENABLE_PROXY: true
       DD_TAGS: tagA:valueA tagB:valueB
       DD_EXTRA_TAGS: tagC:valueC tagD:valueD
 
@@ -264,5 +266,7 @@ functions:
       - { Ref: RecorderExtensionLambdaLayer }
       - { Ref: DatadogExtensionIntegrationTestLambdaLayer }
     environment:
+      AWS_LAMBDA_EXEC_WRAPPER: /opt/boot.sh
+      DD_EXPERIMENTAL_ENABLE_PROXY: true
       DD_TAGS: tagA:valueA tagB:valueB
       DD_EXTRA_TAGS: tagC:valueC tagD:valueD


### PR DESCRIPTION
### What does this PR do?

Enable the experimental proxy when we run the .NET integration tests.

### Motivation

Ensure that features that use the proxy are tested as we iterate on them.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
