### PR TITLE
[tasks] Enable tag inclusion/exclusion for process agent builds

### DIFF
--- a/tasks/process_agent.py
+++ b/tasks/process_agent.py
@@ -7,7 +7,7 @@ import tempfile
 from invoke import task
 from invoke.exceptions import Exit
 
-from .build_tags import get_default_build_tags
+from .build_tags import filter_incompatible_tags, get_build_tags, get_default_build_tags
 from .utils import (
     REPO_PATH,
     bin_name,
@@ -28,6 +28,8 @@ GIMME_ENV_VARS = ['GOROOT', 'PATH']
 def build(
     ctx,
     race=False,
+    build_include=None,
+    build_exclude=None,
     go_version=None,
     incremental_build=False,
     major_version='7',
@@ -82,7 +84,14 @@ def build(
     env.update(goenv)
 
     ldflags += ' '.join([f"-X '{main + key}={value}'" for key, value in ld_vars.items()])
-    build_tags = get_default_build_tags(build="process-agent", arch=arch)
+    build_include = (
+        get_default_build_tags(build="process-agent", arch=arch)
+        if build_include is None
+        else filter_incompatible_tags(build_include.split(","), arch=arch)
+    )
+    build_exclude = [] if build_exclude is None else build_exclude.split(",")
+
+    build_tags = get_build_tags(build_include, build_exclude)
 
     ## secrets is not supported on windows because the process agent still runs as
     ## root.  No matter what `get_default_build_tags()` returns, take secrets out.


### PR DESCRIPTION
### What does this PR do?

Implements arguments for tag inclusion/exclusion for process agent builds, much like we have for base agent/trace agent.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
