### PR TITLE
[tests/e2e] Fix script issues with Dependabot name

### DIFF
--- a/test/e2e/scripts/run-instance/22-argo-submit.sh
+++ b/test/e2e/scripts/run-instance/22-argo-submit.sh
@@ -35,7 +35,7 @@ case "$ARGO_WORKFLOW" in
             exit 2
         fi
 
-        kubectl create secret generic dd-keys --from-literal=DD_API_KEY=${DATADOG_AGENT_API_KEY} --from-literal=DD_APP_KEY=${DATADOG_AGENT_APP_KEY}
+        kubectl create secret generic dd-keys --from-literal=DD_API_KEY="${DATADOG_AGENT_API_KEY}" --from-literal=DD_APP_KEY="${DATADOG_AGENT_APP_KEY}"
 
         eval "$oldstate"
 
@@ -61,7 +61,7 @@ case "$ARGO_WORKFLOW" in
         kubectl create secret generic dd-keys --from-literal=DD_API_KEY=123er --from-literal=DD_APP_KEY=123er1
 
         ./argo template create ../../argo-workflows/templates/*.yaml
-        ./argo submit ../../argo-workflows/${ARGO_WORKFLOW}-workflow.yaml --wait \
+        ./argo submit ../../argo-workflows/"${ARGO_WORKFLOW}"-workflow.yaml --wait \
             --parameter datadog-agent-image-repository="${DATADOG_AGENT_IMAGE%:*}" \
             --parameter datadog-agent-image-tag="${DATADOG_AGENT_IMAGE#*:}" \
             --parameter datadog-cluster-agent-image-repository="${DATADOG_CLUSTER_AGENT_IMAGE%:*}" \

--- a/test/e2e/scripts/run-instance/23-argo-get.sh
+++ b/test/e2e/scripts/run-instance/23-argo-get.sh
@@ -41,7 +41,7 @@ done
 # CWS e2e output
 for workflow in $(./argo list -o name); do
     if [ "$ARGO_WORKFLOW" = "cws" ]; then
-        kubectl logs $(./argo get $workflow -o json | jq -r '.status.nodes[] | select(.displayName=="test-cws-e2e").id') -c main
+        kubectl logs $(./argo get "$workflow" -o json | jq -r '.status.nodes[] | select(.displayName=="test-cws-e2e").id') -c main
     fi
 done
 

--- a/test/e2e/scripts/setup-instance/02-ec2.sh
+++ b/test/e2e/scripts/setup-instance/02-ec2.sh
@@ -39,10 +39,10 @@ done
 aws ec2 create-tags --resources "${SPOT_REQUEST_ID}" "${INSTANCE_ID}" \
     --region "${REGION}" \
     --tags \
-    Key=repository,Value=github.com/DataDog/datadog-agent \
-    Key=branch,Value="${BRANCH}" \
-    Key=commit,Value="${COMMIT_ID:0:8}" \
-    Key=user,Value="${COMMIT_USER}"
+    "Key=repository,Value=github.com/DataDog/datadog-agent" \
+    "Key=branch,Value='${BRANCH}'" \
+    "Key=commit,Value='${COMMIT_ID:0:8}'" \
+    "Key=user,Value='${COMMIT_USER}'"
 
 until [[ -n ${INSTANCE_ENDPOINT:+x} ]]; do
     sleep 5

--- a/test/e2e/scripts/setup-instance/03-ssh.sh
+++ b/test/e2e/scripts/setup-instance/03-ssh.sh
@@ -52,7 +52,7 @@ _ssh git -C /home/core/datadog-agent checkout "${COMMIT_ID}"
 
 if [[ -n ${DOCKER_REGISTRY_URL+x} ]] && [[ -n ${DOCKER_REGISTRY_LOGIN+x} ]] && [[ -n ${DOCKER_REGISTRY_PWD+x} ]]; then
     oldstate=$(shopt -po xtrace ||:); set +x  # Do not log credentials
-    _ssh_logged \"sudo docker login --username \\\"${DOCKER_REGISTRY_LOGIN}\\\" --password \\\"${DOCKER_REGISTRY_PWD}\\\" \\\"${DOCKER_REGISTRY_URL}\\\"\"
+    _ssh_logged \"sudo docker login --username \\\""${DOCKER_REGISTRY_LOGIN}"\\\" --password \\\""${DOCKER_REGISTRY_PWD}"\\\" \\\""${DOCKER_REGISTRY_URL}"\\\"\"
     eval "$oldstate"
 else
     _ssh_logged \"sudo mkdir -p /root/.docker \&\& sudo touch /root/.docker/config.json\"


### PR DESCRIPTION
### What does this PR do?

- Escape tags value (which is what was causing issues)
- `find test/e2e -type f -name '*.sh' -print0 | xargs -0 shellcheck -f diff | git apply`

### Motivation

Dependabot has a `[bot]` in the name which causes issues when not escaped.

### Additional notes:

- [k8s-e2e-dev job run](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/103308852)
- [k8s-e2e-otlp-dev job run](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/103308854)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
