### PR TITLE
[containers] Add CRI collector

### DIFF
--- a/pkg/util/containers/cri/crimock/criutil.go
+++ b/pkg/util/containers/cri/crimock/criutil.go
@@ -23,6 +23,12 @@ func (m *MockCRIClient) ListContainerStats() (map[string]*pb.ContainerStats, err
 	return args.Get(0).(map[string]*pb.ContainerStats), args.Error(1)
 }
 
+// GetContainerStats returns the stats for the container with the given ID
+func (m *MockCRIClient) GetContainerStats(containerID string) (*pb.ContainerStats, error) {
+	args := m.Called(containerID)
+	return args.Get(0).(*pb.ContainerStats), args.Error(1)
+}
+
 // GetContainerStatus sends a ContainerStatusRequest to the server, and parses the returned response
 func (m *MockCRIClient) GetContainerStatus(containerID string) (*pb.ContainerStatus, error) {
 	args := m.Called(containerID)

--- a/pkg/util/containers/v2/metrics/cri/collector.go
+++ b/pkg/util/containers/v2/metrics/cri/collector.go
@@ -1,0 +1,104 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build cri
+
+package cri
+
+import (
+	"time"
+
+	"k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/cache"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/cri"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics/provider"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	criCollectorID    = "cri"
+	criCacheKeyPrefix = "cri-stats-"
+	criCacheTTL       = 10 * time.Second
+)
+
+func init() {
+	provider.GetProvider().RegisterCollector(provider.CollectorMetadata{
+		ID:       criCollectorID,
+		Priority: 1, // Less than the "system" collector, so we can rely on cgroups directly if possible
+		Runtimes: []string{provider.RuntimeNameCRIO},
+		Factory: func() (provider.Collector, error) {
+			return newCRICollector()
+		},
+	})
+}
+
+type criCollector struct {
+	client         cri.CRIClient
+	lastScrapeTime time.Time
+}
+
+func newCRICollector() (*criCollector, error) {
+	if !config.IsFeaturePresent(config.Cri) {
+		return nil, provider.ErrPermaFail
+	}
+
+	client, err := cri.GetUtil()
+	if err != nil {
+		return nil, provider.ConvertRetrierErr(err)
+	}
+
+	return &criCollector{client: client}, nil
+}
+
+// ID returns the collector ID.
+func (collector *criCollector) ID() string {
+	return criCollectorID
+}
+
+// GetContainerStats returns stats by container ID.
+func (collector *criCollector) GetContainerStats(containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) {
+	stats, err := collector.getCriContainerStats(containerID, cacheValidity)
+	if err != nil {
+		return nil, err
+	}
+
+	return &provider.ContainerStats{
+		Timestamp: time.Now(),
+		CPU: &provider.ContainerCPUStats{
+			Total: util.UIntToFloatPtr(stats.GetCpu().GetUsageCoreNanoSeconds().GetValue()),
+		},
+		Memory: &provider.ContainerMemStats{
+			RSS: util.UIntToFloatPtr(stats.GetMemory().GetWorkingSetBytes().GetValue()),
+		},
+	}, nil
+}
+
+// GetContainerNetworkStats returns network stats by container ID.
+func (collector *criCollector) GetContainerNetworkStats(containerID string, cacheValidity time.Duration, networks map[string]string) (*provider.ContainerNetworkStats, error) {
+	// Not available
+	return nil, nil
+}
+
+func (collector *criCollector) getCriContainerStats(containerID string, cacheValidity time.Duration) (*v1alpha2.ContainerStats, error) {
+	refreshRequired := collector.lastScrapeTime.Add(cacheValidity).Before(time.Now())
+	cacheKey := criCacheKeyPrefix + containerID
+	if cachedMetrics, found := cache.Cache.Get(cacheKey); found && !refreshRequired {
+		log.Debugf("Got CRI stats from cache for container %s", containerID)
+		return cachedMetrics.(*v1alpha2.ContainerStats), nil
+	}
+
+	stats, err := collector.client.GetContainerStats(containerID)
+	if err != nil {
+		return nil, err
+	}
+
+	collector.lastScrapeTime = time.Now()
+	cache.Cache.Set(cacheKey, stats, criCacheTTL)
+
+	return stats, nil
+}

--- a/pkg/util/containers/v2/metrics/cri/collector_test.go
+++ b/pkg/util/containers/v2/metrics/cri/collector_test.go
@@ -1,0 +1,60 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build cri
+
+package cri
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	pb "k8s.io/cri-api/pkg/apis/runtime/v1alpha2"
+
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/cri/crimock"
+)
+
+func TestGetContainerStats(t *testing.T) {
+	containerID := "123"
+
+	mockedCriClient := new(crimock.MockCRIClient)
+	mockedCriClient.On("GetContainerStats", containerID).Return(
+		&pb.ContainerStats{
+			Attributes: &pb.ContainerAttributes{
+				Id: containerID,
+			},
+			Cpu: &pb.CpuUsage{
+				UsageCoreNanoSeconds: &pb.UInt64Value{
+					Value: 1000,
+				},
+			},
+			Memory: &pb.MemoryUsage{
+				WorkingSetBytes: &pb.UInt64Value{
+					Value: 1024,
+				},
+			},
+		},
+		nil,
+	)
+
+	collector := criCollector{
+		client: mockedCriClient,
+	}
+
+	stats, err := collector.GetContainerStats(containerID, 10*time.Second)
+	assert.NoError(t, err)
+
+	assert.Equal(t, util.UIntToFloatPtr(1000), stats.CPU.Total)
+	assert.Equal(t, util.UIntToFloatPtr(1024), stats.Memory.RSS)
+}
+
+func TestGetContainerNetworkStats(t *testing.T) {
+	collector := criCollector{}
+	stats, err := collector.GetContainerNetworkStats("123", time.Second, nil)
+	assert.NoError(t, err)
+	assert.Nil(t, stats) // The CRI collector does not return any network data
+}

--- a/pkg/util/containers/v2/metrics/cri/doc.go
+++ b/pkg/util/containers/v2/metrics/cri/doc.go
@@ -1,0 +1,6 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
+package cri

--- a/pkg/util/containers/v2/metrics/facade.go
+++ b/pkg/util/containers/v2/metrics/facade.go
@@ -10,6 +10,7 @@ import (
 
 	// Register all the collectors
 	_ "github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics/containerd"
+	_ "github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics/cri"
 	_ "github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics/docker"
 	_ "github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics/ecsfargate"
 	_ "github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics/system"

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -68,6 +68,7 @@ const (
 	ContainerRuntimeDocker     ContainerRuntime = "docker"
 	ContainerRuntimeContainerd ContainerRuntime = "containerd"
 	ContainerRuntimePodman     ContainerRuntime = "podman"
+	ContainerRuntimeCRIO       ContainerRuntime = "cri-o"
 )
 
 // ECSLaunchType is the launch type of an ECS task.

--- a/releasenotes/notes/cri-collector-container-check-95bca028451e4baa.yaml
+++ b/releasenotes/notes/cri-collector-container-check-95bca028451e4baa.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The container check now works for containers managed by runtimes that
+    implement the CRI interface such as CRI-O.


### PR DESCRIPTION
### What does this PR do?

Adds a CRI collector for the generic container check.


### Describe how to test/QA your changes

You'll need a Kubernetes environment that:
- Uses CRI-O as the container runtime. To make sure that this is the case, `agent workload-list` should show `Runtime: cri-o` in the container info and not containerd or docker.
- Mounts the CRI socket path.
- Doesn't use the "system" collector in the container check (/proc is not mounted). You should see an `INFO` log like this one: `Using metrics collector: cri for runtime: cri-o`.

An easy way to achieve all of the above consists of deploying the agent with the helm-chart or the operator on a local kind cluster that uses a custom image with CRI. You can use this: https://github.com/aojea/kind-images#usage

After the agent is running, check that the metrics `container.uptime`, `container.cpu.usage` and `container.memory.rss` are reported. `agent check container` should run without errors.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
