### PR TITLE
[Serverless] Bump log4j versions for integration tests

### DIFF
--- a/test/integration/serverless/serverless.yml
+++ b/test/integration/serverless/serverless.yml
@@ -1,5 +1,5 @@
 # IAM permissions require service name to begin with 'integration-tests'
-# Adding a comment to start integration tests on push
+# Adding a comment to start integration tests
 service: integration-tests-extension
 
 resources:

--- a/test/integration/serverless/serverless.yml
+++ b/test/integration/serverless/serverless.yml
@@ -1,5 +1,4 @@
 # IAM permissions require service name to begin with 'integration-tests'
-# Adding a comment to start integration tests
 service: integration-tests-extension
 
 resources:

--- a/test/integration/serverless/src/java-tests/error/pom.xml
+++ b/test/integration/serverless/src/java-tests/error/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-log4j2</artifactId>
-      <version>1.1.0</version>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
@@ -27,12 +27,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.8.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>2.8.2</version>
+      <version>2.16.0</version>
     </dependency>
     <dependency>
       <groupId>com.datadoghq</groupId>

--- a/test/integration/serverless/src/java-tests/log/pom.xml
+++ b/test/integration/serverless/src/java-tests/log/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-log4j2</artifactId>
-      <version>1.1.0</version>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
@@ -27,12 +27,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.8.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>2.8.2</version>
+      <version>2.16.0</version>
     </dependency>
     <dependency>
       <groupId>com.datadoghq</groupId>

--- a/test/integration/serverless/src/java-tests/timeout/pom.xml
+++ b/test/integration/serverless/src/java-tests/timeout/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-log4j2</artifactId>
-      <version>1.1.0</version>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
@@ -27,12 +27,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.8.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>2.8.2</version>
+      <version>2.16.0</version>
     </dependency>
     <dependency>
       <groupId>com.datadoghq</groupId>

--- a/test/integration/serverless/src/java-tests/trace/pom.xml
+++ b/test/integration/serverless/src/java-tests/trace/pom.xml
@@ -32,7 +32,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.8.2</version>
+      <version>2.16.0</version>
     </dependency>
     <dependency>
       <groupId>com.datadoghq</groupId>

--- a/test/integration/serverless/src/java-tests/trace/pom.xml
+++ b/test/integration/serverless/src/java-tests/trace/pom.xml
@@ -30,9 +30,14 @@
       <version>2.16.0</version>
     </dependency>
     <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
+      <version>2.8.2</version>
+    </dependency>
+    <dependency>
       <groupId>com.datadoghq</groupId>
       <artifactId>datadog-lambda-java</artifactId>
-      <version>1</version>
+      <version>1.4.0</version>
     </dependency>
   </dependencies>
 

--- a/test/integration/serverless/src/java-tests/trace/pom.xml
+++ b/test/integration/serverless/src/java-tests/trace/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-log4j2</artifactId>
-      <version>1.1.0</version>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
@@ -27,17 +27,12 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.8.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>2.8.2</version>
+      <version>2.16.0</version>
     </dependency>
     <dependency>
       <groupId>com.datadoghq</groupId>
       <artifactId>datadog-lambda-java</artifactId>
-      <version>1.4.0</version>
+      <version>1</version>
     </dependency>
   </dependencies>
 

--- a/test/integration/serverless/src/java-tests/trace/pom.xml
+++ b/test/integration/serverless/src/java-tests/trace/pom.xml
@@ -30,11 +30,6 @@
       <version>2.16.0</version>
     </dependency>
     <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>2.16.0</version>
-    </dependency>
-    <dependency>
       <groupId>com.datadoghq</groupId>
       <artifactId>datadog-lambda-java</artifactId>
       <version>1.4.0</version>

--- a/test/integration/serverless/src/java-tests/with-ddlambda/pom.xml
+++ b/test/integration/serverless/src/java-tests/with-ddlambda/pom.xml
@@ -17,7 +17,7 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-lambda-java-log4j2</artifactId>
-      <version>1.1.0</version>
+      <version>1.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.amazonaws</groupId>
@@ -27,12 +27,7 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.8.2</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-      <version>2.8.2</version>
+      <version>2.16.0</version>
     </dependency>
     <dependency>
       <groupId>com.datadoghq</groupId>


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Updates the log4j versions in the Java integration tests

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Recent vulnerabilities discovered for log4j
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
