### PR TITLE
pkg/trace/api: Add proxy endpoint for pipeline stats

### DIFF
--- a/pkg/trace/api/endpoints.go
+++ b/pkg/trace/api/endpoints.go
@@ -101,6 +101,10 @@ var endpoints = []endpoint{
 		Handler: func(r *HTTPReceiver) http.Handler { return http.HandlerFunc(r.handleStats) },
 	},
 	{
+		Pattern: "/v0.1/pipeline_stats",
+		Handler: func(r *HTTPReceiver) http.Handler { return r.pipelineStatsProxyHandler() },
+	},
+	{
 		Pattern: "/appsec/proxy/",
 		Handler: func(r *HTTPReceiver) http.Handler { return http.StripPrefix("/appsec/proxy", r.appsecHandler) },
 	},

--- a/pkg/trace/api/info_test.go
+++ b/pkg/trace/api/info_test.go
@@ -128,6 +128,7 @@ func TestInfoHandler(t *testing.T) {
 		"/profiling/v1/input",
 		"/telemetry/proxy/",
 		"/v0.6/stats",
+		"/v0.1/pipeline_stats",
 		"/appsec/proxy/",
 		"/debugger/v1/input"
 	],
@@ -185,6 +186,7 @@ func TestInfoHandler(t *testing.T) {
 		"/profiling/v1/input",
 		"/telemetry/proxy/",
 		"/v0.6/stats",
+		"/v0.1/pipeline_stats",
 		"/appsec/proxy/",
 		"/debugger/v1/input",
 		"/v0.6/config"

--- a/pkg/trace/api/pipeline_stats.go
+++ b/pkg/trace/api/pipeline_stats.go
@@ -35,7 +35,7 @@ func pipelineStatsEndpoint(cfg *config.AgentConfig) (url *url.URL, apiKey string
 	urlStr := cfg.Endpoints[0].Host + pipelineStatsURLSuffix
 	url, err = url.Parse(urlStr)
 	if err != nil {
-		return nil, "", fmt.Errorf("error parsing pipeline stats intake URL %s: %v", urlStr, err)
+		return nil, "", fmt.Errorf("error parsing pipeline stats intake URL %q: %v", urlStr, err)
 	}
 	return url, cfg.Endpoints[0].APIKey, nil
 }

--- a/pkg/trace/api/pipeline_stats.go
+++ b/pkg/trace/api/pipeline_stats.go
@@ -1,0 +1,102 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
+	"github.com/DataDog/datadog-agent/pkg/trace/info"
+	"github.com/DataDog/datadog-agent/pkg/trace/logutil"
+	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/fargate"
+)
+
+const (
+	pipelineStatsURLSuffix = "/api/v0.1/pipeline_stats"
+)
+
+// pipelineStatsEndpoint returns the pipeline intake url and the corresponding API key.
+func pipelineStatsEndpoint(cfg *config.AgentConfig) (url *url.URL, apiKey string, err error) {
+	if e := cfg.Endpoints; len(e) == 0 || e[0].Host == "" || e[0].APIKey == "" {
+		return nil, "", errors.New("config was not properly validated")
+	}
+	urlStr := cfg.Endpoints[0].Host + pipelineStatsURLSuffix
+	url, err = url.Parse(urlStr)
+	if err != nil {
+		return nil, "", fmt.Errorf("error parsing pipeline stats intake URL %s: %v", urlStr, err)
+	}
+	return url, cfg.Endpoints[0].APIKey, nil
+}
+
+// pipelineStatsProxyHandler returns a new HTTP handler which will proxy requests to the pipeline stats intake.
+func (r *HTTPReceiver) pipelineStatsProxyHandler() http.Handler {
+	target, key, err := pipelineStatsEndpoint(r.conf)
+	if err != nil {
+		return pipelineStatsErrorHandler(err)
+	}
+	tags := fmt.Sprintf("host:%s,default_env:%s,agent_version:%s", r.conf.Hostname, r.conf.DefaultEnv, info.Version)
+	if orch := r.conf.FargateOrchestrator; orch != fargate.Unknown {
+		tag := fmt.Sprintf("orchestrator:fargate_%s", strings.ToLower(string(orch)))
+		tags = tags + "," + tag
+	}
+	return newPipelineStatsProxy(r.conf.NewHTTPTransport(), target, key, tags)
+}
+
+func pipelineStatsErrorHandler(err error) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		msg := fmt.Sprintf("Pipeline stats forwarder is OFF: %v", err)
+		http.Error(w, msg, http.StatusInternalServerError)
+	})
+}
+
+// newPipelineStatsProxy creates an http.ReverseProxy which forwards requests to the pipeline stats intake.
+// The tags will be added as a header to all proxied requests.
+func newPipelineStatsProxy(transport http.RoundTripper, target *url.URL, key string, tags string) *httputil.ReverseProxy {
+	director := func(req *http.Request) {
+		req.Header.Set("Via", fmt.Sprintf("trace-agent %s", info.Version))
+		if _, ok := req.Header["User-Agent"]; !ok {
+			// explicitly disable User-Agent so it's not set to the default value
+			// that net/http gives it: Go-http-client/1.1
+			// See https://codereview.appspot.com/7532043
+			req.Header.Set("User-Agent", "")
+		}
+		containerID := req.Header.Get(headerContainerID)
+		if ctags := getContainerTags(containerID); ctags != "" {
+			req.Header.Set("X-Datadog-Container-Tags", ctags)
+		}
+		req.Header.Set("X-Datadog-Additional-Tags", tags)
+		metrics.Count("datadog.trace_agent.pipelines_stats", 1, nil, 1)
+		// URL, Host and key are set in the transport for each outbound request
+	}
+	logger := logutil.NewThrottled(5, 10*time.Second) // limit to 5 messages every 10 seconds
+	return &httputil.ReverseProxy{
+		Director:  director,
+		ErrorLog:  log.New(logger, "pipeline_stats.Proxy: ", 0),
+		Transport: &pipelineStatsTransport{transport, target, key},
+	}
+}
+
+// pipelineStatsTransport sends HTTP requests to a target using an underlying http.RoundTripper.
+type pipelineStatsTransport struct {
+	rt     http.RoundTripper
+	target *url.URL
+	key    string
+}
+
+func (t *pipelineStatsTransport) RoundTrip(req *http.Request) (rresp *http.Response, rerr error) {
+	req.Host = t.target.Host
+	req.URL = t.target
+	req.Header.Set("DD-API-KEY", t.key)
+	return t.rt.RoundTrip(req)
+}

--- a/pkg/trace/api/pipeline_stats_test.go
+++ b/pkg/trace/api/pipeline_stats_test.go
@@ -1,0 +1,167 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package api
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/config"
+)
+
+func TestPipelineStatsProxy(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		slurp, err := ioutil.ReadAll(req.Body)
+		req.Body.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if body := string(slurp); body != "body" {
+			t.Fatalf("invalid request body: %q", body)
+		}
+		if v := req.Header.Get("DD-API-KEY"); v != "123" {
+			t.Fatalf("got invalid API key: %q", v)
+		}
+		if v := req.Header.Get("X-Datadog-Additional-Tags"); v != "key:val" {
+			t.Fatalf("got invalid X-Datadog-Additional-Tags: %q", v)
+		}
+		_, err = w.Write([]byte("OK"))
+		if err != nil {
+			t.Fatal(err)
+		}
+	}))
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req, err := http.NewRequest("POST", "dummy.com/path", strings.NewReader("body"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	c := &config.AgentConfig{}
+	newPipelineStatsProxy(c.NewHTTPTransport(), u, "123", "key:val").ServeHTTP(rec, req)
+	slurp, err := ioutil.ReadAll(rec.Result().Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(slurp) != "OK" {
+		t.Fatal("did not proxy")
+	}
+}
+
+func TestPipelineStatsEndpoints(t *testing.T) {
+	var cfg config.AgentConfig
+	cfg.Endpoints = []*config.Endpoint{{Host: "https://trace.agent.datadoghq.com", APIKey: "test_api_key"}}
+	url, key, err := pipelineStatsEndpoint(&cfg)
+	assert.NoError(t, err)
+	assert.Equal(t, url.Host, "https://trace.agent.datadoghq.com/api/v0.1/pipeline_stats")
+	assert.Equal(t, key, "test_api_key")
+}
+
+func TestPipelineStatsProxyHandler(t *testing.T) {
+	t.Run("ok", func(t *testing.T) {
+		var called bool
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			v := req.Header.Get("X-Datadog-Additional-Tags")
+			tags := strings.Split(v, ",")
+			m := make(map[string]string)
+			for _, tag := range tags {
+				kv := strings.Split(tag, ":")
+				if strings.Contains(kv[0], "orchestrator") {
+					t.Fatalf("non-fargate environment shouldn't contain '%s' tag : %q", kv[0], v)
+				}
+				m[kv[0]] = kv[1]
+			}
+			for _, tag := range []string{"host", "default_env", "agent_version"} {
+				if _, ok := m[tag]; !ok {
+					t.Fatalf("invalid X-Datadog-Additional-Tags header, should contain '%s': %q", tag, v)
+				}
+			}
+			called = true
+		}))
+		req, err := http.NewRequest("POST", "/some/path", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		conf := newTestReceiverConfig()
+		conf.Endpoints[0].Host = srv.URL
+		fmt.Println("srv url", srv.URL)
+		receiver := newTestReceiverFromConfig(conf)
+		receiver.pipelineStatsProxyHandler().ServeHTTP(httptest.NewRecorder(), req)
+		if !called {
+			t.Fatal("request not proxied")
+		}
+	})
+
+	t.Run("proxy_code", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			w.WriteHeader(http.StatusAccepted)
+		}))
+		conf := newTestReceiverConfig()
+		conf.Endpoints[0].Host = srv.URL
+		req, _ := http.NewRequest("POST", "/some/path", nil)
+		receiver := newTestReceiverFromConfig(conf)
+		rec := httptest.NewRecorder()
+		receiver.pipelineStatsProxyHandler().ServeHTTP(rec, req)
+		resp := rec.Result()
+		assert.Equal(t, http.StatusAccepted, resp.StatusCode)
+	})
+
+	t.Run("ok_fargate", func(t *testing.T) {
+		var called bool
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			v := req.Header.Get("X-Datadog-Additional-Tags")
+			if !strings.Contains(v, "orchestrator:fargate_orchestrator") {
+				t.Fatalf("invalid X-Datadog-Additional-Tags header, fargate env should contain '%s' tag: %q", "orchestrator", v)
+			}
+			called = true
+		}))
+		req, err := http.NewRequest("POST", "/some/path", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		conf := newTestReceiverConfig()
+		conf.Endpoints[0].Host = srv.URL
+		conf.FargateOrchestrator = "orchestrator"
+		receiver := newTestReceiverFromConfig(conf)
+		receiver.pipelineStatsProxyHandler().ServeHTTP(httptest.NewRecorder(), req)
+		if !called {
+			t.Fatal("request not proxied")
+		}
+	})
+
+	t.Run("error", func(t *testing.T) {
+		defer mockConfig("site", "asd:\r\n")()
+		req, err := http.NewRequest("POST", "/some/path", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		rec := httptest.NewRecorder()
+		conf := newTestReceiverConfig()
+		conf.Endpoints[0].Host = ""
+		r := newTestReceiverFromConfig(conf)
+		r.pipelineStatsProxyHandler().ServeHTTP(rec, req)
+		res := rec.Result()
+		if res.StatusCode != http.StatusInternalServerError {
+			t.Fatalf("invalid response: %s", res.Status)
+		}
+		slurp, err := ioutil.ReadAll(res.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(slurp), "Pipeline stats forwarder is OFF") {
+			t.Fatalf("invalid message: %q", slurp)
+		}
+	})
+}

--- a/pkg/trace/api/pipeline_stats_test.go
+++ b/pkg/trace/api/pipeline_stats_test.go
@@ -60,12 +60,12 @@ func TestPipelineStatsProxy(t *testing.T) {
 	}
 }
 
-func TestPipelineStatsEndpoints(t *testing.T) {
+func TestPipelineStatsEndpoint(t *testing.T) {
 	var cfg config.AgentConfig
 	cfg.Endpoints = []*config.Endpoint{{Host: "https://trace.agent.datadoghq.com", APIKey: "test_api_key"}}
 	url, key, err := pipelineStatsEndpoint(&cfg)
 	assert.NoError(t, err)
-	assert.Equal(t, url.Host, "https://trace.agent.datadoghq.com/api/v0.1/pipeline_stats")
+	assert.Equal(t, url.String(), "https://trace.agent.datadoghq.com/api/v0.1/pipeline_stats")
 	assert.Equal(t, key, "test_api_key")
 }
 

--- a/releasenotes/notes/pipeline-stats-ac5fc6d441312541.yaml
+++ b/releasenotes/notes/pipeline-stats-ac5fc6d441312541.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    APM: Add new endpoint to the trace-agent to forward pipeline stats to the Datadog backend.

--- a/releasenotes/notes/pipeline-stats-ac5fc6d441312541.yaml
+++ b/releasenotes/notes/pipeline-stats-ac5fc6d441312541.yaml
@@ -1,3 +1,3 @@
 features:
   - |
-    APM: Add new endpoint to the trace-agent to forward pipeline stats to the Datadog backend.
+    APM: Adds a new endpoint to the Datadog Agent to forward pipeline stats to the Datadog backend.


### PR DESCRIPTION
### What does this PR do?

Add a new proxy endpoint that forwards pipeline stats requests to the datadog agent.

### Motivation

Be able to compute pipeline stats in the tracers and send them to the backend.

### Possible Drawbacks / Trade-offs

If there is an error with the configuration, the endpoint always returns an error.