### PR TITLE
Backport NAT gateway lookup disable

### DIFF
--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -122,7 +122,7 @@ func InitSystemProbeConfig(cfg Config) {
 	// network_config namespace only
 	cfg.BindEnv(join(netNS, "enable_http_monitoring"), "DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTP_MONITORING")
 	cfg.BindEnv(join(netNS, "enable_https_monitoring"), "DD_SYSTEM_PROBE_NETWORK_ENABLE_HTTPS_MONITORING")
-	cfg.BindEnvAndSetDefault(join(netNS, "enable_gateway_lookup"), true, "DD_SYSTEM_PROBE_NETWORK_ENABLE_GATEWAY_LOOKUP")
+	cfg.BindEnvAndSetDefault(join(netNS, "enable_gateway_lookup"), false, "DD_SYSTEM_PROBE_NETWORK_ENABLE_GATEWAY_LOOKUP")
 	httpRules := join(netNS, "http_replace_rules")
 	cfg.BindEnv(httpRules, "DD_SYSTEM_PROBE_NETWORK_HTTP_REPLACE_RULES")
 	cfg.SetEnvKeyTransformer(httpRules, func(in string) interface{} {

--- a/pkg/network/config/config_test.go
+++ b/pkg/network/config/config_test.go
@@ -76,7 +76,7 @@ func TestEnableHTTPMonitoring(t *testing.T) {
 	})
 }
 
-func TestDisableGatewayLookup(t *testing.T) {
+func TestEnableGatewayLookup(t *testing.T) {
 	t.Run("via YAML", func(t *testing.T) {
 		newConfig()
 		defer restoreGlobalConfig()
@@ -86,27 +86,27 @@ func TestDisableGatewayLookup(t *testing.T) {
 		require.NoError(t, err)
 		cfg := New()
 
-		assert.True(t, cfg.EnableGatewayLookup)
+		assert.False(t, cfg.EnableGatewayLookup)
 
 		newConfig()
-		_, err = sysconfig.New("./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-DisableGwLookup.yaml")
+		_, err = sysconfig.New("./testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableGwLookup.yaml")
 		require.NoError(t, err)
 		cfg = New()
 
-		assert.False(t, cfg.EnableGatewayLookup)
+		assert.True(t, cfg.EnableGatewayLookup)
 	})
 
 	t.Run("via ENV variable", func(t *testing.T) {
 		newConfig()
 		defer restoreGlobalConfig()
 
-		os.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLE_GATEWAY_LOOKUP", "false")
+		os.Setenv("DD_SYSTEM_PROBE_NETWORK_ENABLE_GATEWAY_LOOKUP", "true")
 		defer os.Unsetenv("DD_SYSTEM_PROBE_NETWORK_ENABLE_GATEWAY_LOOKUP")
 		_, err := sysconfig.New("")
 		require.NoError(t, err)
 		cfg := New()
 
-		assert.False(t, cfg.EnableGatewayLookup)
+		assert.True(t, cfg.EnableGatewayLookup)
 	})
 }
 

--- a/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-DisableGwLookup.yaml
+++ b/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-DisableGwLookup.yaml
@@ -1,2 +1,0 @@
-network_config:
-  enable_gateway_lookup: false

--- a/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableGwLookup.yaml
+++ b/pkg/network/config/testdata/TestDDAgentConfigYamlAndSystemProbeConfig-EnableGwLookup.yaml
@@ -1,0 +1,2 @@
+network_config:
+  enable_gateway_lookup: true

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -556,6 +556,15 @@ func TestUnconnectedUDPSendIPv6(t *testing.T) {
 }
 
 func TestGatewayLookupNotEnabled(t *testing.T) {
+	t.Run("gateway lookup not enabled", func(t *testing.T) {
+		cfg := testConfig()
+		tr, err := NewTracer(cfg)
+		require.NoError(t, err)
+		require.NotNil(t, tr)
+		defer tr.Stop()
+		require.Nil(t, tr.gwLookup)
+	})
+
 	t.Run("gateway lookup enabled, not on aws", func(t *testing.T) {
 		cfg := testConfig()
 		cfg.EnableGatewayLookup = true

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1409,8 +1409,6 @@ func TestTCPDirectionWithPreexistingConnection(t *testing.T) {
 
 	// start tracer so it dumps port bindings
 	cfg := testConfig()
-	// delay from gateway lookup timeout can cause test failure
-	cfg.EnableGatewayLookup = false
 	tr, err := NewTracer(cfg)
 	require.NoError(t, err)
 	defer tr.Stop()

--- a/releasenotes/notes/enable-npm-nat-gw-lookup-default-4dd11a75e9b9a582.yaml
+++ b/releasenotes/notes/enable-npm-nat-gw-lookup-default-4dd11a75e9b9a582.yaml
@@ -1,4 +1,0 @@
----
-features:
-  - |
-    Enable NPM NAT gateway lookup by default.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Backport of #10222 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
