### PR TITLE
[appveyor/debug]: dump the test environment in a script on the Desktop

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -50,5 +50,8 @@ test_script:
   - codecov -f profile.cov -F windows
 
 # uncomment to debug builds
-# on_finish:
+#on_finish:
+#  - set | perl -pe "s!^!set !g" > C:\Users\appveyor\Desktop\runme.bat
+#  - echo cd %APPVEYOR_BUILD_FOLDER% >> C:\Users\appveyor\Desktop\runme.bat
+#  - echo cmd >> C:\Users\appveyor\Desktop\runme.bat
 #  - ps: $blockRdp = $true; iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))


### PR DESCRIPTION
### What does this PR do?

Simplify the debugging process by saving the environment in a script available on the desktop.

### Motivation

After spending lots of time debugging another PR/issue and waisting time to recover the correct env.

### Describe how to test/QA your changes

* insert for example a call to `false` somewhere in the script
* uncomment lines under `# uncomment to debug builds`
* connect to the testing host via RDP 
* launch runme.bat


- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
