### PR TITLE
[tasks] Refactor working with agent flavors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -227,7 +227,7 @@ jobs:
       - restore_cache: *restore_deps
       - run:
           name: build iot agent
-          command: inv -e agent.build --iot
+          command: inv -e agent.build --flavor iot
       - run:
           name: test iot agent
           command: ./bin/agent/agent -c ./bin/agent/dist check cpu

--- a/.gitlab/binary_build/linux.yml
+++ b/.gitlab/binary_build/linux.yml
@@ -59,7 +59,7 @@ build_iot_agent-deb_x64:
   before_script:
     - !reference [.retrieve_linux_go_deps]
   script:
-    - inv -e agent.build --iot --major-version 7
+    - inv -e agent.build --flavor iot --major-version 7
     - $S3_CP_CMD $SRC_PATH/$AGENT_BINARIES_DIR/agent $S3_ARTIFACTS_URI/iot/agent
 
 build_iot_agent-deb_arm64:
@@ -78,4 +78,4 @@ build_iot_agent-deb_arm64:
     - cp -R $GOPATH/src/github.com/*/*/DataDog/datadog-agent $GOPATH/src/github.com/DataDog
     - cd $SRC_PATH
   script:
-    - inv -e agent.build --iot --major-version 7
+    - inv -e agent.build --flavor iot --major-version 7

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -133,7 +133,7 @@ agent_deb-arm64-a7:
     # Thus, we move the artifacts at the end in a gitlab-friendly dir.
     - *setup_deb_signing_key
     # Use --skip-deps since the deps are installed by `before_script`.
-    - inv -e agent.omnibus-build --iot --log-level debug --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod"
+    - inv -e agent.omnibus-build --flavor iot --log-level debug --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod"
     - ls -la $OMNIBUS_PACKAGE_DIR
     - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-iot-agent*_${PACKAGE_ARCH}.deb $S3_ARTIFACTS_URI/$DESTINATION_DEB
   artifacts:

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -129,7 +129,7 @@ agent_rpm-arm64-a7:
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name $RPM_SIGNING_PASSPHRASE_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
     - set -x
     # Use --skip-deps since the deps are installed by `before_script`.
-    - inv -e agent.omnibus-build --iot --log-level debug --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod"
+    - inv -e agent.omnibus-build --flavor iot --log-level debug --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod"
     - ls -la $OMNIBUS_PACKAGE_DIR
   artifacts:
     expire_in: 2 weeks

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -105,7 +105,7 @@ iot_agent_suse-x64:
     - export RPM_SIGNING_PASSPHRASE=$(aws ssm get-parameter --region us-east-1 --name $RPM_SIGNING_PASSPHRASE_SSM_NAME --with-decryption --query "Parameter.Value" --out text)
     - set -x
     # Use --skip-deps since the deps are installed by `before_script`.
-    - inv -e agent.omnibus-build --iot --log-level debug --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod"
+    - inv -e agent.omnibus-build --flavor iot --log-level debug --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR --skip-deps --go-mod-cache="$GOPATH/pkg/mod"
     - ls -la $OMNIBUS_PACKAGE_DIR
     # Copy to a different directory to avoid collisions if a job downloads both the RPM and SUSE RPM artifacts
     - mkdir -p $OMNIBUS_PACKAGE_DIR_SUSE && cp $OMNIBUS_PACKAGE_DIR/* $OMNIBUS_PACKAGE_DIR_SUSE

--- a/omnibus/config/software/datadog-iot-agent.rb
+++ b/omnibus/config/software/datadog-iot-agent.rb
@@ -40,7 +40,7 @@ build do
   end
 
   if linux?
-    command "invoke agent.build --iot --rebuild --no-development --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg}", env: env
+    command "invoke agent.build --flavor iot --rebuild --no-development --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg}", env: env
     mkdir "#{install_dir}/bin"
     mkdir "#{install_dir}/run/"
 
@@ -91,7 +91,7 @@ build do
     mkdir conf_dir
     mkdir "#{install_dir}/bin/agent"
 
-    command "inv agent.build --iot --rebuild --no-development --arch #{platform} --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg}", env: env
+    command "inv agent.build --flavor iot --rebuild --no-development --arch #{platform} --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg}", env: env
 
       # move around bin and config files
     move 'bin/agent/dist/datadog.yaml', "#{conf_dir}/datadog.yaml.example"

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -5,6 +5,8 @@ import sys
 
 from invoke import task
 
+from .flavor import AgentFlavor
+
 # ALL_TAGS lists all available build tags.
 # Used to remove unknown tags from provided tag lists.
 ALL_TAGS = {
@@ -104,33 +106,37 @@ WINDOWS_EXCLUDE_TAGS = {"linux_bpf"}
 # List of tags to always remove when building on Windows 32-bits
 WINDOWS_32BIT_EXCLUDE_TAGS = {"docker", "kubeapiserver", "kubelet", "orchestrator"}
 
-# Build type: build tags map
+# Build type: maps flavor to build tags map
 build_tags = {
-    # Build setups
-    "agent": AGENT_TAGS,
-    "android": ANDROID_TAGS,
-    "cluster-agent": CLUSTER_AGENT_TAGS,
-    "cluster-agent-cloudfoundry": CLUSTER_AGENT_CLOUDFOUNDRY_TAGS,
-    "dogstatsd": DOGSTATSD_TAGS,
-    "iot": IOT_AGENT_TAGS,
-    "process-agent": PROCESS_AGENT_TAGS,
-    "security-agent": SECURITY_AGENT_TAGS,
-    "system-probe": SYSTEM_PROBE_TAGS,
-    "trace-agent": TRACE_AGENT_TAGS,
-    # Test setups
-    "test": TEST_TAGS,
-    "test-with-process-tags": TEST_TAGS.union(PROCESS_AGENT_TAGS),
+    AgentFlavor.base: {
+        # Build setups
+        "agent": AGENT_TAGS,
+        "android": ANDROID_TAGS,
+        "cluster-agent": CLUSTER_AGENT_TAGS,
+        "cluster-agent-cloudfoundry": CLUSTER_AGENT_CLOUDFOUNDRY_TAGS,
+        "dogstatsd": DOGSTATSD_TAGS,
+        "process-agent": PROCESS_AGENT_TAGS,
+        "security-agent": SECURITY_AGENT_TAGS,
+        "system-probe": SYSTEM_PROBE_TAGS,
+        "trace-agent": TRACE_AGENT_TAGS,
+        # Test setups
+        "test": TEST_TAGS,
+        "test-with-process-tags": TEST_TAGS.union(PROCESS_AGENT_TAGS),
+    },
+    AgentFlavor.iot: {
+        "agent": IOT_AGENT_TAGS,
+    },
 }
 
 
-def get_default_build_tags(build="agent", arch="x64"):
+def get_default_build_tags(build="agent", arch="x64", flavor=AgentFlavor.base):
     """
     Build the default list of tags based on the build type and current platform.
 
     The container integrations are currently only supported on Linux, disabling on
     the Windows and Darwin builds.
     """
-    include = build_tags.get(build)
+    include = build_tags.get(flavor).get(build)
     if include is None:
         print("Warning: unrecognized build type, no build tags included.")
         include = set()
@@ -193,7 +199,7 @@ def audit_tag_impact(ctx, build_exclude=None, csv=False):
     max_size = _compute_build_size(ctx, build_exclude=','.join(build_exclude))
     print(f"size with all tags is {max_size / 1000} kB")
 
-    iot_agent_size = _compute_build_size(ctx, iot=True)
+    iot_agent_size = _compute_build_size(ctx, flavor=AgentFlavor.iot)
     print(f"iot agent size is {iot_agent_size / 1000} kB\n")
 
     report = {"unaccounted": max_size - iot_agent_size, "iot_agent": iot_agent_size}
@@ -212,12 +218,12 @@ def audit_tag_impact(ctx, build_exclude=None, csv=False):
             print(f"{k};{v}")
 
 
-def _compute_build_size(ctx, build_exclude=None, iot=False):
+def _compute_build_size(ctx, build_exclude=None, flavor=AgentFlavor.base):
     import os
 
     from .agent import build as agent_build
 
-    agent_build(ctx, build_exclude=build_exclude, skip_assets=True, iot=iot)
+    agent_build(ctx, build_exclude=build_exclude, skip_assets=True, flavor=flavor)
 
     statinfo = os.stat('bin/agent/agent')
     return statinfo.st_size

--- a/tasks/flavor.py
+++ b/tasks/flavor.py
@@ -6,9 +6,5 @@ class AgentFlavor(enum.Enum):
     base = 1
     iot = 2
 
-    def equals(self, arg):
-        return arg == self.name
-
-    @classmethod
-    def is_iot(cls, arg):
-        return cls.iot.equals(arg)
+    def is_iot(self):
+        return self == type(self).iot

--- a/tasks/flavor.py
+++ b/tasks/flavor.py
@@ -1,0 +1,14 @@
+import enum
+
+
+# TODO: use StrEnum when we move to Python 3.11
+class AgentFlavor(enum.Enum):
+    base = 1
+    iot = 2
+
+    def equals(self, arg):
+        return arg == self.name
+
+    @classmethod
+    def is_iot(cls, arg):
+        return cls.iot.equals(arg)

--- a/tasks/winbuildscripts/dobuild.bat
+++ b/tasks/winbuildscripts/dobuild.bat
@@ -10,7 +10,7 @@ if NOT DEFINED PY_RUNTIMES set PY_RUNTIMES=%~3
 set OMNIBUS_BUILD=agent.omnibus-build
 set OMNIBUS_ARGS=--python-runtimes "%PY_RUNTIMES%"
 
-if "%OMNIBUS_TARGET%" == "iot" set OMNIBUS_ARGS=--iot
+if "%OMNIBUS_TARGET%" == "iot" set OMNIBUS_ARGS=--flavor iot
 if "%OMNIBUS_TARGET%" == "dogstatsd" set OMNIBUS_BUILD=dogstatsd.omnibus-build && set OMNIBUS_ARGS=
 if "%OMNIBUS_TARGET%" == "agent_binaries" set OMNIBUS_ARGS=%OMNIBUS_ARGS% --agent-binaries
 if DEFINED GOMODCACHE set OMNIBUS_ARGS=%OMNIBUS_ARGS% --go-mod-cache %GOMODCACHE%


### PR DESCRIPTION
### What does this PR do?

This PR implements generalization of working with agent flavors. It takes the `--iot` argument and makes it `--flavor iot` in preparation for potentially adding more flavors. It also makes it technically possible to modify builds of other binaries (like process agent/trace agent) for different flavors.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Ensure that all binaries are still built with proper Go tags (checking base agent, process agent, trace agent and iot agent should be enough).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
