### PR TITLE
[pylint] Pin lazy-object-proxy dependency to latest working

### DIFF
--- a/omnibus/config/software/pylint2.rb
+++ b/omnibus/config/software/pylint2.rb
@@ -17,12 +17,14 @@ build do
     python2 = "#{install_dir}/embedded/bin/python2"
   end
 
+  # pin 2 dependencies of pylint:
+  # - configparser: later versions (up to v3.7.1) are broken
+  # - lazy-object-proxy 1.7.0 broken on python 2 https://github.com/ionelmc/python-lazy-object-proxy/issues/61
   if windows?
-    # this pins a dependency of pylint, later versions (up to v3.7.1) are broken.
-    command "#{python2} -m pip install configparser==3.5.0"
+    command "#{python2} -m pip install configparser==3.5.0 lazy-object-proxy==1.6.0"
     command "#{python2} -m pip install pylint==#{version}"
   else
-    command "#{pip2} install configparser==3.5.0"
+    command "#{pip2} install configparser==3.5.0 lazy-object-proxy==1.6.0"
     command "#{pip2} install pylint==#{version}"
   end
 end


### PR DESCRIPTION
### What does this PR do?

Pins lazy-object-proxy dependency to latest working (1.6.0)

### Motivation

1.7.0 broken for python2 (https://github.com/ionelmc/python-lazy-object-proxy/issues/61)

### Describe how to test/QA your changes

No QA needed

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
