### PR TITLE
Reliability fixes for the workloadmeta and tagger

### DIFF
--- a/pkg/tagger/subscriber/subscriber.go
+++ b/pkg/tagger/subscriber/subscriber.go
@@ -6,7 +6,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/tagger/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/tagger/types"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
+
+const bufferSize = 100
 
 // Subscriber allows processes to subscribe to entity events generated from a
 // tagger.
@@ -26,11 +29,6 @@ func NewSubscriber() *Subscriber {
 // entity is added, modified or deleted. It can send an initial burst of events
 // only to the new subscriber, without notifying all of the others.
 func (s *Subscriber) Subscribe(cardinality collectors.TagCardinality, events []types.EntityEvent) chan []types.EntityEvent {
-	// this buffer size is an educated guess, as we know the rate of
-	// updates, but not how fast these can be streamed out yet. it most
-	// likely should be configurable.
-	bufferSize := 100
-
 	// this is a `ch []EntityEvent` instead of a `ch EntityEvent` to
 	// improve throughput, as bursts of events are as likely to occur as
 	// isolated events, especially at startup or with collectors that
@@ -53,6 +51,13 @@ func (s *Subscriber) Subscribe(cardinality collectors.TagCardinality, events []t
 func (s *Subscriber) Unsubscribe(ch chan []types.EntityEvent) {
 	s.Lock()
 	defer s.Unlock()
+
+	s.unsubscribe(ch)
+}
+
+// unsubscribe ends a subscription to entity events and closes its channel. It
+// is not thread-safe, and callers should take care of synchronization.
+func (s *Subscriber) unsubscribe(ch chan []types.EntityEvent) {
 	defer telemetry.Subscribers.Dec()
 
 	delete(s.subscribers, ch)
@@ -66,10 +71,16 @@ func (s *Subscriber) Notify(events []types.EntityEvent) {
 		return
 	}
 
-	s.RLock()
-	defer s.RUnlock()
+	s.Lock()
+	defer s.Unlock()
 
 	for ch, cardinality := range s.subscribers {
+		if len(ch) >= bufferSize {
+			log.Info("channel full, canceling subscription")
+			s.unsubscribe(ch)
+			continue
+		}
+
 		notify(ch, events, cardinality)
 	}
 }

--- a/pkg/workloadmeta/collectors/containerd/containerd.go
+++ b/pkg/workloadmeta/collectors/containerd/containerd.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build containerd
 // +build containerd
 
 package containerd
@@ -191,9 +192,13 @@ func (c *collector) generateInitialEvents(ctx context.Context) ([]containerdeven
 			},
 		}
 
+		// if ignoreEvent returns an error, keep the event regardless.
+		// it might've been because of network errors, so it's better
+		// to keep a container we should've ignored than ignoring a
+		// container we should've kept
 		ignore, err := c.ignoreEvent(ctx, &event)
 		if err != nil {
-			return nil, err
+			log.Debugf("Error while deciding to ignore event, keeping it: %s", err)
 		}
 
 		if ignore {


### PR DESCRIPTION
### What does this PR do?

Includes fixes that prevent the tagger and workloadmeta components from working properly when things go sideways (more information in the individual commit messages):

* Cancel remote tagger subscriptions if channels are full, as that can slow down tagger and therefore workloadmeta processing
* Ignore certain errors when starting up the containerd workloadmeta collector, which could prevent retries and not start it at all.

### Describe how to test/QA your changes

These issues were spotted with production workloads, so to QA them we'll need to deploy them and watch what happens. In particular, lines like the following should be absent:

```
workloadmeta collector "containerd" could not start. error: (some error that looks transient or related to a specific workload, like "failed to get image")
```

The second one requires a telemetry patch applied to 7.33 (see #10013), and it *could* (but not necessarily *would*) reduce `datadog.agent.workloadmeta.notifications_sent` where the status is `error`. It's otherwise hard to QA.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
