### PR TITLE
[workloadmeta] Fix deadlock in Subscribe

### DIFF
--- a/pkg/workloadmeta/store.go
+++ b/pkg/workloadmeta/store.go
@@ -194,12 +194,6 @@ func (s *store) Subscribe(name string, filter *Filter) chan EventBundle {
 		filter: filter,
 	}
 
-	s.subscribersMut.Lock()
-	s.subscribers = append(s.subscribers, sub)
-	s.subscribersMut.Unlock()
-
-	telemetry.Subscribers.Inc()
-
 	var events []Event
 
 	s.storeMut.RLock()
@@ -238,6 +232,15 @@ func (s *store) Subscribe(name string, filter *Filter) chan EventBundle {
 	// notifyChannel should not wait when doing the first subscription, as
 	// the subscriber is not ready to receive events yet
 	notifyChannel(sub.name, sub.ch, events, false)
+
+	// From the moment we add the subscriber to the list, the store can try to
+	// send it events, that's why it's important that we do this after the line
+	// above. Otherwise, it can cause a deadlock.
+	s.subscribersMut.Lock()
+	s.subscribers = append(s.subscribers, sub)
+	s.subscribersMut.Unlock()
+
+	telemetry.Subscribers.Inc()
 
 	return sub.ch
 }


### PR DESCRIPTION
### What does this PR do?

Same as  #10238 but targetting the `main` branch.

### Describe how to test/QA your changes

Skip. Should be tested in 7.33.x

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
