### PR TITLE
[AD] Add telemetry

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -18,6 +18,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/scheduler"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/secrets"
@@ -274,11 +275,19 @@ func (ac *AutoConfig) GetAllConfigs() []integration.Config {
 
 // schedule takes a slice of configs and schedule them
 func (ac *AutoConfig) schedule(configs []integration.Config) {
+	for _, conf := range configs {
+		telemetry.ScheduledConfigs.Inc(conf.Provider, conf.Type())
+	}
+
 	ac.scheduler.Schedule(configs)
 }
 
 // unschedule takes a slice of configs and unschedule them
 func (ac *AutoConfig) unschedule(configs []integration.Config) {
+	for _, conf := range configs {
+		telemetry.ScheduledConfigs.Dec(conf.Provider, conf.Type())
+	}
+
 	ac.scheduler.Unschedule(configs)
 }
 

--- a/pkg/autodiscovery/integration/config.go
+++ b/pkg/autodiscovery/integration/config.go
@@ -139,12 +139,29 @@ func (c *Config) IsTemplate() bool {
 
 // IsCheckConfig returns true if the config is a node-agent check configuration,
 func (c *Config) IsCheckConfig() bool {
-	return c.ClusterCheck == false && len(c.Instances) > 0
+	return !c.ClusterCheck && len(c.Instances) > 0
 }
 
 // IsLogConfig returns true if config contains a logs config.
 func (c *Config) IsLogConfig() bool {
 	return c.LogsConfig != nil
+}
+
+// Type returns a string representing the config type.
+func (c *Config) Type() string {
+	if c.IsLogConfig() {
+		return "logs"
+	}
+
+	if c.IsCheckConfig() {
+		return "check"
+	}
+
+	if c.ClusterCheck {
+		return "clustercheck"
+	}
+
+	return "unknown"
 }
 
 // HasFilter returns true if metrics or logs collection must be disabled for this config.

--- a/pkg/autodiscovery/listeners/kube_endpoints.go
+++ b/pkg/autodiscovery/listeners/kube_endpoints.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/common/types"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -31,6 +32,7 @@ import (
 const (
 	kubeEndpointsAnnotationFormat = "ad.datadoghq.com/endpoints.instances"
 	leaderAnnotation              = "control-plane.alpha.kubernetes.io/leader"
+	kubeEndpointsName             = "kube_endpoints"
 )
 
 // KubeEndpointsListener listens to kubernetes endpoints creation
@@ -59,7 +61,7 @@ type KubeEndpointService struct {
 var _ Service = &KubeEndpointService{}
 
 func init() {
-	Register("kube_endpoints", NewKubeEndpointsListener)
+	Register(kubeEndpointsName, NewKubeEndpointsListener)
 }
 
 func NewKubeEndpointsListener(Config) (ServiceListener, error) {
@@ -284,9 +286,12 @@ func (l *KubeEndpointsListener) createService(kep *v1.Endpoints, alreadyExisting
 	l.endpoints[kep.UID] = eps
 	l.m.Unlock()
 
+	telemetry.WatchedResources.Inc(kubeEndpointsName, telemetry.ResourceKubeService)
+
 	for _, ep := range eps {
 		log.Debugf("Creating a new AD service: %s", ep.entity)
 		l.newService <- ep
+		telemetry.WatchedResources.Inc(kubeEndpointsName, telemetry.ResourceKubeEndpoint)
 	}
 }
 
@@ -335,9 +340,13 @@ func (l *KubeEndpointsListener) removeService(kep *v1.Endpoints) {
 		l.m.Lock()
 		delete(l.endpoints, kep.UID)
 		l.m.Unlock()
+
+		telemetry.WatchedResources.Dec(kubeEndpointsName, telemetry.ResourceKubeService)
+
 		for _, ep := range eps {
 			log.Debugf("Deleting AD service: %s", ep.entity)
 			l.delService <- ep
+			telemetry.WatchedResources.Dec(kubeEndpointsName, telemetry.ResourceKubeEndpoint)
 		}
 	} else {
 		log.Debugf("Entity %s not found, not removing", kep.UID)

--- a/pkg/autodiscovery/listeners/workloadmeta.go
+++ b/pkg/autodiscovery/listeners/workloadmeta.go
@@ -9,8 +9,10 @@ package listeners
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -93,6 +95,7 @@ func (l *workloadmetaListenerImpl) Store() workloadmeta.Store {
 }
 
 func (l *workloadmetaListenerImpl) AddService(svcID string, svc Service, parentSvcID string) {
+	kind := kindFromSvcID(svcID)
 	if parentSvcID != "" {
 		if _, ok := l.children[parentSvcID]; !ok {
 			l.children[parentSvcID] = make(map[string]struct{})
@@ -109,10 +112,12 @@ func (l *workloadmetaListenerImpl) AddService(svcID string, svc Service, parentS
 
 		log.Tracef("%s received an updated service '%s', removing the old one", l.name, svc.GetEntity())
 		l.delService <- old
+		telemetry.WatchedResources.Dec(l.name, kind)
 	}
 
 	l.services[svcID] = svc
 	l.newService <- svc
+	telemetry.WatchedResources.Inc(l.name, kind)
 }
 
 func (l *workloadmetaListenerImpl) IsExcluded(ft containers.FilterType, name, image, ns string) bool {
@@ -226,8 +231,18 @@ func (l *workloadmetaListenerImpl) removeService(svcID string) {
 
 	delete(l.services, svcID)
 	l.delService <- svc
+	telemetry.WatchedResources.Dec(l.name, kindFromSvcID(svcID))
 }
 
 func buildSvcID(entityID workloadmeta.EntityID) string {
 	return fmt.Sprintf("%s://%s", entityID.Kind, entityID.ID)
+}
+
+func kindFromSvcID(svcID string) string {
+	sep := "://"
+	if strings.Contains(svcID, sep) {
+		return strings.Split(svcID, sep)[0]
+	}
+
+	return "unknown"
 }

--- a/pkg/autodiscovery/providers/file.go
+++ b/pkg/autodiscovery/providers/file.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/telemetry"
 )
 
 // FileConfigProvider collect configuration files from disk
@@ -33,6 +34,7 @@ func (c *FileConfigProvider) Collect(ctx context.Context) ([]integration.Config,
 	}
 
 	c.Errors = errors
+	telemetry.Errors.Set(float64(len(errors)), names.File)
 
 	return configs, nil
 }

--- a/pkg/autodiscovery/providers/kubelet.go
+++ b/pkg/autodiscovery/providers/kubelet.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/common/utils"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
@@ -204,6 +205,7 @@ func (k *KubeletConfigProvider) generateConfigs() ([]integration.Config, error) 
 	}
 
 	k.configErrors = adErrors
+	telemetry.Errors.Set(float64(len(adErrors)), names.Kubernetes)
 
 	return configs, nil
 }

--- a/pkg/autodiscovery/telemetry/README.md
+++ b/pkg/autodiscovery/telemetry/README.md
@@ -1,0 +1,3 @@
+## package `telemetry`
+
+This package defines Autodiscovery's telemetry metrics.

--- a/pkg/autodiscovery/telemetry/telemetry.go
+++ b/pkg/autodiscovery/telemetry/telemetry.go
@@ -1,0 +1,50 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package telemetry
+
+import "github.com/DataDog/datadog-agent/pkg/telemetry"
+
+const (
+	subsystem = "autodiscovery"
+
+	// ResourceKubeService represents kubernetes service entities
+	ResourceKubeService = "k8s_service"
+	// ResourceKubeEndpoint represents kubernetes endpoint entities
+	ResourceKubeEndpoint = "k8s_endpoint"
+)
+
+var (
+	commonOpts = telemetry.Options{NoDoubleUnderscoreSep: true}
+)
+
+var (
+	// ScheduledConfigs tracks how many configs are scheduled.
+	ScheduledConfigs = telemetry.NewGaugeWithOpts(
+		subsystem,
+		"scheduled_configs",
+		[]string{"provider", "type"},
+		"Number of configs scheduled in Autodiscovery by provider and type.",
+		commonOpts,
+	)
+
+	// WatchedResources tracks how many resources are watched by AD listeners.
+	WatchedResources = telemetry.NewGaugeWithOpts(
+		subsystem,
+		"watched_resources",
+		[]string{"listener", "kind"},
+		"Number of resources watched in Autodiscovery by listener and kind.",
+		commonOpts,
+	)
+
+	// Errors tracks the number of AD errors found by AD providers.
+	Errors = telemetry.NewGaugeWithOpts(
+		subsystem,
+		"errors",
+		[]string{"provider"},
+		"Number of Autodiscovery errors by provider.",
+		commonOpts,
+	)
+)

--- a/releasenotes-dca/notes/ad-telemetry-be7d6fa1730a9b1f.yaml
+++ b/releasenotes-dca/notes/ad-telemetry-be7d6fa1730a9b1f.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add Autodiscovery telemetry.

--- a/releasenotes/notes/ad-telemetry-be7d6fa1730a9b1f.yaml
+++ b/releasenotes/notes/ad-telemetry-be7d6fa1730a9b1f.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add Autodiscovery telemetry.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add telemetry for Autodiscovery 
- `autodiscovery_errors`
- `autodiscovery_scheduled_configs`
- `autodiscovery_watched_resources`

### Motivation

Ease debugging and catching regressions

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Enable `telemetry.enabled` and query the prom endpoints on the agent and the cluster agents
- Agent: `curl localhost:6000/telemetry`

Example output
```
HELP autodiscovery_errors Number of Autodiscovery errors by provider.
# TYPE autodiscovery_errors gauge
autodiscovery_errors{provider="file"} 0
autodiscovery_errors{provider="kubernetes"} 1
# HELP autodiscovery_scheduled_configs Number of configs scheduled in Autodiscovery by provider and type.
# TYPE autodiscovery_scheduled_configs gauge
autodiscovery_scheduled_configs{provider="",type="logs"} 33
autodiscovery_scheduled_configs{provider="cluster-checks",type="check"} 1
autodiscovery_scheduled_configs{provider="endpoints-checks",type="check"} 1
autodiscovery_scheduled_configs{provider="file",type="check"} 12
autodiscovery_scheduled_configs{provider="kubernetes",type="logs"} 1
# HELP autodiscovery_watched_resources Number of resources watched in Autodiscovery by listener and kind.
# TYPE autodiscovery_watched_resources gauge
autodiscovery_watched_resources{kind="container",listener="ad-kubeletlistener"} 18
autodiscovery_watched_resources{kind="kubernetes_pod",listener="ad-kubeletlistener"} 12
```

- Cluster Agent: `curl localhost:5000/metrics` or `agent telemetry`

Example output
```
HELP autodiscovery_errors Number of Autodiscovery errors by provider.
# TYPE autodiscovery_errors gauge
autodiscovery_errors{provider="file"} 0
# HELP autodiscovery_scheduled_configs Number of configs scheduled in Autodiscovery by provider and type.
# TYPE autodiscovery_scheduled_configs gauge
autodiscovery_scheduled_configs{provider="",type="logs"} 11
autodiscovery_scheduled_configs{provider="file",type="check"} 2
autodiscovery_scheduled_configs{provider="kubernetes-endpoints",type="clustercheck"} 6
autodiscovery_scheduled_configs{provider="kubernetes-services",type="clustercheck"} 2
# HELP autodiscovery_watched_resources Number of resources watched in Autodiscovery by listener and kind.
# TYPE autodiscovery_watched_resources gauge
autodiscovery_watched_resources{kind="k8s_endpoint",listener="kube_endpoints"} 6
autodiscovery_watched_resources{kind="k8s_service",listener="kube_endpoints"} 4
autodiscovery_watched_resources{kind="k8s_service",listener="kube_services"} 2
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
