### PR TITLE
[CWS] fix empty macros map

### DIFF
--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -143,6 +143,9 @@ func (rs *RuleSet) AddMacro(macroDef *MacroDefinition) (*eval.Macro, error) {
 		return nil, &ErrMacroLoad{Definition: macroDef, Err: errors.Wrap(err, "compilation error")}
 	}
 
+	if rs.opts.Macros == nil {
+		rs.opts.Macros = make(map[string]*eval.Macro)
+	}
 	rs.opts.Macros[macro.ID] = macro.Macro
 
 	return macro.Macro, nil


### PR DESCRIPTION
### What does this PR do?

This PR fixes an error where the `Macros` map of a rule set was nil.
Example of a failing job: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/103744341/

### Motivation

Bugfix

### Possible Drawbacks / Trade-offs

None

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
