### PR TITLE
[gitlab] Add build for new heroku agent flavor

### DIFF
--- a/.gitlab/deploy_6/nix.yml
+++ b/.gitlab/deploy_6/nix.yml
@@ -13,7 +13,7 @@ deploy_staging_deb-6:
   resource_group: deb_bucket
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main"]
-  dependencies: ["agent_deb-x64-a6", "agent_deb-arm64-a6"]
+  dependencies: ["agent_deb-x64-a6", "agent_deb-arm64-a6", "agent_heroku_deb-x64-a6"]
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:

--- a/.gitlab/deploy_7/nix.yml
+++ b/.gitlab/deploy_7/nix.yml
@@ -15,6 +15,7 @@ deploy_staging_deb-7:
   dependencies:
     - agent_deb-x64-a7
     - agent_deb-arm64-a7
+    - agent_heroku_deb-x64-a7
     - iot_agent_deb-x64
     - iot_agent_deb-arm64
     - iot_agent_deb-armhf

--- a/.gitlab/kitchen_cleanup.yml
+++ b/.gitlab/kitchen_cleanup.yml
@@ -12,7 +12,7 @@ kitchen_cleanup_s3-a6:
   extends: .kitchen_cleanup_s3_common
   rules:
     !reference [.on_kitchen_tests_a6]
-  dependencies: ["agent_deb-x64-a6"]
+  dependencies: ["agent_deb-x64-a6", "agent_heroku_deb-x64-a6"]
   variables:
     AGENT_MAJOR_VERSION: 6
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
@@ -21,7 +21,7 @@ kitchen_cleanup_s3-a7:
   extends: .kitchen_cleanup_s3_common
   rules:
     !reference [.on_default_kitchen_tests_a7]
-  dependencies: ["agent_deb-x64-a7"]
+  dependencies: ["agent_deb-x64-a7", "agent_heroku_deb-x64-a7"]
   variables:
     AGENT_MAJOR_VERSION: 7
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7

--- a/.gitlab/kitchen_deploy.yml
+++ b/.gitlab/kitchen_deploy.yml
@@ -42,7 +42,7 @@ deploy_deb_testing-a6:
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main"]
-  needs: ["agent_deb-x64-a6", "tests_deb-x64-py2", "tests_deb-x64-py3"]
+  needs: ["agent_deb-x64-a6", "agent_heroku_deb-x64-a6", "tests_deb-x64-py2", "tests_deb-x64-py3"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
   before_script:
@@ -65,7 +65,7 @@ deploy_deb_testing-a7:
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main"]
-  needs: ["agent_deb-x64-a7", "iot_agent_deb-x64", "dogstatsd_deb-x64", "tests_deb-x64-py3"]
+  needs: ["agent_deb-x64-a7", "agent_heroku_deb-x64-a7", "iot_agent_deb-x64", "dogstatsd_deb-x64", "tests_deb-x64-py3"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
   before_script:

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -37,7 +37,7 @@
     - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/nikos-${PACKAGE_ARCH}.tar.gz /tmp/nikos.tar.gz
     - mkdir -p /tmp/nikos
     - tar -xf /tmp/nikos.tar.gz -C /tmp/nikos
-    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --major-version "$AGENT_MAJOR_VERSION" --python-runtimes "$PYTHON_RUNTIMES" --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps --go-mod-cache="$GOPATH/pkg/mod" --system-probe-bin=/tmp/system-probe --nikos-path=/tmp/nikos
+    - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --major-version "$AGENT_MAJOR_VERSION" --python-runtimes "$PYTHON_RUNTIMES" --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps --go-mod-cache="$GOPATH/pkg/mod" --system-probe-bin=/tmp/system-probe --nikos-path=/tmp/nikos ${FLAVOR:+--flavor $FLAVOR}
     - ls -la $OMNIBUS_PACKAGE_DIR
     - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-agent_*_${PACKAGE_ARCH}.deb $S3_ARTIFACTS_URI/$DESTINATION_DEB
     - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-agent-dbg_*_${PACKAGE_ARCH}.deb $S3_ARTIFACTS_URI/$DESTINATION_DBG_DEB
@@ -204,3 +204,13 @@ dogstatsd_deb-x64:
     expire_in: 2 weeks
     paths:
       - $OMNIBUS_PACKAGE_DIR
+
+agent_heroku_deb-x64-a6:
+  extends: .agent_deb_x64-a6
+  variables:
+    FLAVOR: heroku
+
+agent_heroku_deb-x64-a7:
+  extends: .agent_deb_x64-a7
+  variables:
+    FLAVOR: heroku

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -206,11 +206,11 @@ dogstatsd_deb-x64:
       - $OMNIBUS_PACKAGE_DIR
 
 agent_heroku_deb-x64-a6:
-  extends: .agent_deb_x64-a6
+  extends: agent_deb_x64-a6
   variables:
     FLAVOR: heroku
 
 agent_heroku_deb-x64-a7:
-  extends: .agent_deb_x64-a7
+  extends: agent_deb_x64-a7
   variables:
     FLAVOR: heroku

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -39,8 +39,8 @@
     - tar -xf /tmp/nikos.tar.gz -C /tmp/nikos
     - inv -e agent.omnibus-build --release-version "$RELEASE_VERSION" --major-version "$AGENT_MAJOR_VERSION" --python-runtimes "$PYTHON_RUNTIMES" --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps --go-mod-cache="$GOPATH/pkg/mod" --system-probe-bin=/tmp/system-probe --nikos-path=/tmp/nikos ${FLAVOR:+--flavor $FLAVOR}
     - ls -la $OMNIBUS_PACKAGE_DIR
-    - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-agent_*_${PACKAGE_ARCH}.deb $S3_ARTIFACTS_URI/$DESTINATION_DEB
-    - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-agent-dbg_*_${PACKAGE_ARCH}.deb $S3_ARTIFACTS_URI/$DESTINATION_DBG_DEB
+    - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog${FLAVOR:+-$FLAVOR}-agent_*_${PACKAGE_ARCH}.deb $S3_ARTIFACTS_URI/$DESTINATION_DEB
+    - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog${FLAVOR:+-$FLAVOR}-agent-dbg_*_${PACKAGE_ARCH}.deb $S3_ARTIFACTS_URI/$DESTINATION_DBG_DEB
   artifacts:
     expire_in: 2 weeks
     paths:
@@ -208,9 +208,13 @@ dogstatsd_deb-x64:
 agent_heroku_deb-x64-a6:
   extends: agent_deb-x64-a6
   variables:
+    DESTINATION_DEB: 'datadog-heroku-agent_6_amd64.deb'
+    DESTINATION_DBG_DEB: 'datadog-heroku-agent-dbg_6_amd64.deb'
     FLAVOR: heroku
 
 agent_heroku_deb-x64-a7:
   extends: agent_deb-x64-a7
   variables:
+    DESTINATION_DEB: 'datadog-heroku-agent_7_amd64.deb'
+    DESTINATION_DBG_DEB: 'datadog-heroku-agent-dbg_7_amd64.deb'
     FLAVOR: heroku

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -206,11 +206,11 @@ dogstatsd_deb-x64:
       - $OMNIBUS_PACKAGE_DIR
 
 agent_heroku_deb-x64-a6:
-  extends: agent_deb_x64-a6
+  extends: agent_deb-x64-a6
   variables:
     FLAVOR: heroku
 
 agent_heroku_deb-x64-a7:
-  extends: agent_deb_x64-a7
+  extends: agent_deb-x64-a7
   variables:
     FLAVOR: heroku

--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -4,8 +4,15 @@
 # Copyright 2016-present Datadog, Inc.
 require "./lib/ostools.rb"
 
-name 'agent'
-package_name 'datadog-agent'
+flavor = ENV['AGENT_FLAVOR']
+
+if flavor.nil? || flavor == 'base'
+  name 'agent'
+  package_name 'datadog-agent'
+else
+  name "agent-#{flavor}"
+  package_name "datadog-#{flavor}-agent"
+end
 license "Apache-2.0"
 license_file "../LICENSE"
 

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -30,6 +30,7 @@ build do
     }
     major_version_arg = "%MAJOR_VERSION%"
     py_runtimes_arg = "%PY_RUNTIMES%"
+    flavor_arg = "%AGENT_FLAVOR%"
   else
     env = {
         'GOPATH' => gopath.to_path,
@@ -42,6 +43,7 @@ build do
     }
     major_version_arg = "$MAJOR_VERSION"
     py_runtimes_arg = "$PY_RUNTIMES"
+    flavor_arg = "$AGENT_FLAVOR"
   end
 
   unless ENV["OMNIBUS_GOMODCACHE"].nil? || ENV["OMNIBUS_GOMODCACHE"].empty?
@@ -61,12 +63,12 @@ build do
     end
     command "inv -e rtloader.make --python-runtimes #{py_runtimes_arg} --install-prefix \"#{windows_safe_path(python_2_embedded)}\" --cmake-options \"-G \\\"Unix Makefiles\\\"\" --arch #{platform}", :env => env
     command "mv rtloader/bin/*.dll  #{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent/"
-    command "inv -e agent.build --exclude-rtloader --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg} --rebuild --no-development --embedded-path=#{install_dir}/embedded --arch #{platform} #{do_windows_sysprobe}", env: env
+    command "inv -e agent.build --exclude-rtloader --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg} --rebuild --no-development --embedded-path=#{install_dir}/embedded --arch #{platform} #{do_windows_sysprobe} --flavor #{flavor_arg}", env: env
     command "inv -e systray.build --major-version #{major_version_arg} --rebuild --arch #{platform}", env: env
   else
     command "inv -e rtloader.make --python-runtimes #{py_runtimes_arg} --install-prefix \"#{install_dir}/embedded\" --cmake-options '-DCMAKE_CXX_FLAGS:=\"-D_GLIBCXX_USE_CXX11_ABI=0\" -DCMAKE_INSTALL_LIBDIR=lib -DCMAKE_FIND_FRAMEWORK:STRING=NEVER'", :env => env
     command "inv -e rtloader.install"
-    command "inv -e agent.build --exclude-rtloader --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg} --rebuild --no-development --embedded-path=#{install_dir}/embedded --python-home-2=#{install_dir}/embedded --python-home-3=#{install_dir}/embedded", env: env
+    command "inv -e agent.build --exclude-rtloader --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg} --rebuild --no-development --embedded-path=#{install_dir}/embedded --python-home-2=#{install_dir}/embedded --python-home-3=#{install_dir}/embedded --flavor #{flavor_arg}", env: env
   end
 
   if osx?
@@ -116,7 +118,7 @@ build do
     # only once the software that the project takes its version from (i.e. `datadog-agent`) has finished building
     env['TRACE_AGENT_VERSION'] = project.build_version.gsub(/[^0-9\.]/, '') # used by gorake.rb in the trace-agent, only keep digits and dots
     platform = windows_arch_i386? ? "x86" : "x64"
-    command "invoke trace-agent.build --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg} --arch #{platform}", :env => env
+    command "invoke trace-agent.build --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg} --arch #{platform} --flavor #{flavor_arg}", :env => env
 
     if windows?
       copy 'bin/trace-agent/trace-agent.exe', "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent"
@@ -128,7 +130,7 @@ build do
   if windows?
     platform = windows_arch_i386? ? "x86" : "x64"
     # Build the process-agent with the correct go version for windows
-    command "invoke -e process-agent.build --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg} --arch #{platform}", :env => env
+    command "invoke -e process-agent.build --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg} --arch #{platform} --flavor #{flavor_arg}", :env => env
 
     copy 'bin/process-agent/process-agent.exe', "#{Omnibus::Config.source_dir()}/datadog-agent/src/github.com/DataDog/datadog-agent/bin/agent"
 
@@ -140,7 +142,7 @@ build do
       end
     end
   else
-    command "invoke -e process-agent.build --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg}", :env => env
+    command "invoke -e process-agent.build --python-runtimes #{py_runtimes_arg} --major-version #{major_version_arg} --flavor #{flavor_arg}", :env => env
     copy 'bin/process-agent/process-agent', "#{install_dir}/embedded/bin"
   end
 

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -158,7 +158,7 @@ def build(
         build_tags = get_default_build_tags(build="agent", arch=arch, flavor=flavor)
     else:
         build_include = (
-            get_default_build_tags(build="agent", arch=arch)
+            get_default_build_tags(build="agent", arch=arch, flavor=flavor)
             if build_include is None
             else filter_incompatible_tags(build_include.split(","), arch=arch)
         )
@@ -363,6 +363,7 @@ def get_omnibus_env(
     system_probe_bin=None,
     nikos_path=None,
     go_mod_cache=None,
+    flavor=None,
 ):
     env = load_release_versions(ctx, release_version)
 
@@ -403,6 +404,8 @@ def get_omnibus_env(
         env['SYSTEM_PROBE_BIN'] = system_probe_bin
     if nikos_path:
         env['NIKOS_PATH'] = nikos_path
+    if flavor:
+        env['AGENT_FLAVOR'] = flavor.name
 
     return env
 
@@ -509,6 +512,7 @@ def omnibus_build(
         system_probe_bin=system_probe_bin,
         nikos_path=nikos_path,
         go_mod_cache=go_mod_cache,
+        flavor=flavor,
     )
 
     target_project = "agent"
@@ -598,6 +602,7 @@ def omnibus_manifest(
         hardened_runtime=hardened_runtime,
         system_probe_bin=system_probe_bin,
         go_mod_cache=go_mod_cache,
+        flavor=flavor,
     )
 
     target_project = "agent"

--- a/tasks/agent.py
+++ b/tasks/agent.py
@@ -363,7 +363,7 @@ def get_omnibus_env(
     system_probe_bin=None,
     nikos_path=None,
     go_mod_cache=None,
-    flavor=None,
+    flavor=AgentFlavor.base,
 ):
     env = load_release_versions(ctx, release_version)
 
@@ -404,8 +404,7 @@ def get_omnibus_env(
         env['SYSTEM_PROBE_BIN'] = system_probe_bin
     if nikos_path:
         env['NIKOS_PATH'] = nikos_path
-    if flavor:
-        env['AGENT_FLAVOR'] = flavor.name
+    env['AGENT_FLAVOR'] = flavor.name
 
     return env
 

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -67,17 +67,7 @@ AGENT_TAGS = {
 
 # AGENT_HEROKU_TAGS lists the tags for Heroku agent build
 AGENT_HEROKU_TAGS = AGENT_TAGS.difference(
-    {
-        "containerd",
-        "cri",
-        "docker",
-        "ec2",
-        "jetson",
-        "kubeapiserver",
-        "kubelet",
-        "podman",
-        "systemd"
-    }
+    {"containerd", "cri", "docker", "ec2", "jetson", "kubeapiserver", "kubelet", "podman", "systemd"}
 )
 
 # ANDROID_TAGS lists the tags needed when building the android agent
@@ -100,17 +90,7 @@ PROCESS_AGENT_TAGS = AGENT_TAGS.union({"clusterchecks", "fargateprocess", "orche
 
 # PROCESS_AGENT_HEROKU_TAGS lists the tags necessary to build the process-agent for Heroku
 PROCESS_AGENT_HEROKU_TAGS = PROCESS_AGENT_TAGS.difference(
-    {
-        "containerd",
-        "cri",
-        "docker",
-        "ec2",
-        "jetson",
-        "kubeapiserver",
-        "kubelet",
-        "podman",
-        "systemd"
-    }
+    {"containerd", "cri", "docker", "ec2", "jetson", "kubeapiserver", "kubelet", "podman", "systemd"}
 )
 
 # SECURITY_AGENT_TAGS lists the tags necessary to build the security agent

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -65,6 +65,21 @@ AGENT_TAGS = {
     "zlib",
 }
 
+# AGENT_HEROKU_TAGS lists the tags for Heroku agent build
+AGENT_HEROKU_TAGS = AGENT_TAGS.difference(
+    {
+        "containerd",
+        "cri",
+        "docker",
+        "ec2",
+        "jetson",
+        "kubeapiserver",
+        "kubelet",
+        "podman",
+        "systemd"
+    }
+)
+
 # ANDROID_TAGS lists the tags needed when building the android agent
 ANDROID_TAGS = {"android", "zlib"}
 
@@ -83,6 +98,21 @@ IOT_AGENT_TAGS = {"jetson", "systemd", "zlib"}
 # PROCESS_AGENT_TAGS lists the tags necessary to build the process-agent
 PROCESS_AGENT_TAGS = AGENT_TAGS.union({"clusterchecks", "fargateprocess", "orchestrator"})
 
+# PROCESS_AGENT_HEROKU_TAGS lists the tags necessary to build the process-agent for Heroku
+PROCESS_AGENT_HEROKU_TAGS = PROCESS_AGENT_TAGS.difference(
+    {
+        "containerd",
+        "cri",
+        "docker",
+        "ec2",
+        "jetson",
+        "kubeapiserver",
+        "kubelet",
+        "podman",
+        "systemd"
+    }
+)
+
 # SECURITY_AGENT_TAGS lists the tags necessary to build the security agent
 SECURITY_AGENT_TAGS = {"netcgo", "secrets", "docker", "containerd", "kubeapiserver", "kubelet", "podman"}
 
@@ -91,6 +121,17 @@ SYSTEM_PROBE_TAGS = AGENT_TAGS.union({"clusterchecks", "linux_bpf", "npm"})
 
 # TRACE_AGENT_TAGS lists the tags that have to be added when the trace-agent
 TRACE_AGENT_TAGS = {"docker", "containerd", "kubeapiserver", "kubelet", "netcgo", "podman", "secrets"}
+
+# TRACE_AGENT_HEROKU_TAGS lists the tags necessary to build the trace-agent for Heroku
+TRACE_AGENT_HEROKU_TAGS = TRACE_AGENT_TAGS.difference(
+    {
+        "containerd",
+        "docker",
+        "kubeapiserver",
+        "kubelet",
+        "podman",
+    }
+)
 
 # TEST_TAGS lists the tags that have to be added to run tests
 TEST_TAGS = AGENT_TAGS.union({"clusterchecks"})
@@ -122,6 +163,11 @@ build_tags = {
         # Test setups
         "test": TEST_TAGS,
         "test-with-process-tags": TEST_TAGS.union(PROCESS_AGENT_TAGS),
+    },
+    AgentFlavor.heroku: {
+        "agent": AGENT_HEROKU_TAGS,
+        "process-agent": PROCESS_AGENT_HEROKU_TAGS,
+        "trace-agent": TRACE_AGENT_HEROKU_TAGS,
     },
     AgentFlavor.iot: {
         "agent": IOT_AGENT_TAGS,

--- a/tasks/flavor.py
+++ b/tasks/flavor.py
@@ -5,6 +5,7 @@ import enum
 class AgentFlavor(enum.Enum):
     base = 1
     iot = 2
+    heroku = 3
 
     def is_iot(self):
         return self == type(self).iot

--- a/tasks/process_agent.py
+++ b/tasks/process_agent.py
@@ -8,6 +8,7 @@ from invoke import task
 from invoke.exceptions import Exit
 
 from .build_tags import filter_incompatible_tags, get_build_tags, get_default_build_tags
+from .flavor import AgentFlavor
 from .utils import (
     REPO_PATH,
     bin_name,
@@ -30,6 +31,7 @@ def build(
     race=False,
     build_include=None,
     build_exclude=None,
+    flavor=AgentFlavor.base.name,
     go_version=None,
     incremental_build=False,
     major_version='7',
@@ -40,6 +42,7 @@ def build(
     """
     Build the process agent
     """
+    flavor = AgentFlavor[flavor]
     ldflags, gcflags, env = get_build_flags(ctx, major_version=major_version, python_runtimes=python_runtimes)
 
     # generate windows resources
@@ -85,7 +88,7 @@ def build(
 
     ldflags += ' '.join([f"-X '{main + key}={value}'" for key, value in ld_vars.items()])
     build_include = (
-        get_default_build_tags(build="process-agent", arch=arch)
+        get_default_build_tags(build="process-agent", arch=arch, flavor=flavor)
         if build_include is None
         else filter_incompatible_tags(build_include.split(","), arch=arch)
     )

--- a/tasks/trace_agent.py
+++ b/tasks/trace_agent.py
@@ -4,6 +4,7 @@ import sys
 from invoke import task
 
 from .build_tags import filter_incompatible_tags, get_build_tags, get_default_build_tags
+from .flavor import AgentFlavor
 from .go import deps
 from .utils import REPO_PATH, bin_name, get_build_flags, get_version_numeric_only
 
@@ -17,6 +18,7 @@ def build(
     race=False,
     build_include=None,
     build_exclude=None,
+    flavor=AgentFlavor.base.name,
     major_version='7',
     python_runtimes='3',
     arch="x64",
@@ -26,6 +28,7 @@ def build(
     Build the trace agent.
     """
 
+    flavor = AgentFlavor[flavor]
     ldflags, gcflags, env = get_build_flags(ctx, major_version=major_version, python_runtimes=python_runtimes)
 
     # generate windows resources
@@ -47,7 +50,8 @@ def build(
 
     build_include = (
         get_default_build_tags(
-            build="trace-agent"
+            build="trace-agent",
+            flavor=flavor,
         )  # TODO/FIXME: Arch not passed to preserve build tags. Should this be fixed?
         if build_include is None
         else filter_incompatible_tags(build_include.split(","), arch=arch)


### PR DESCRIPTION
### What does this PR do?

Modifies tasks and gitlab config to build the new datadog-heroku-agent DEB package. This is a package designed to be only used in Heroku slugs - it's minimized to conserve slug space by removing a lot of functionality that isn't relevant in Heroku dynos.

### Motivation

Heroku slugs (basically application images) are limited to 500 MB compressed, so current agent takes quite a lot of space in that. From the pipeline running this PR, it looks like the DEB size decreased from ~234 MB to ~191 MB, so ~20 % decrease in size.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Create a Heroku app with Datadog Agent as documented in https://github.com/DataDog/heroku-buildpack-datadog#installation, also enable trace-agent and process-agent. Ensure that following works:

* System metrics are sent
* Choose any Python integration to run and ensure its metrics are sent
* Ensure that process-agent and trace-agent work fine

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
