### PR TITLE
[kubelet] Add query telemetry

### DIFF
--- a/pkg/util/kubernetes/kubelet/kubelet_client.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_client.go
@@ -123,6 +123,17 @@ func (kc *kubeletClient) query(ctx context.Context, path string) ([]byte, int, e
 
 	response, err := kc.client.Do(req)
 	kubeletExpVar.Add(1)
+
+	// telemetry
+	defer func() {
+		code := 0
+		if response != nil {
+			code = response.StatusCode
+		}
+
+		queries.Inc(path, strconv.Itoa(code))
+	}()
+
 	if err != nil {
 		log.Debugf("Cannot request %s: %s", req.URL.String(), err)
 		return nil, 0, err

--- a/pkg/util/kubernetes/kubelet/telemetry.go
+++ b/pkg/util/kubernetes/kubelet/telemetry.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build kubelet
+
+package kubelet
+
+import "github.com/DataDog/datadog-agent/pkg/telemetry"
+
+const (
+	subsystem = "kubelet"
+)
+
+var (
+	// queries tracks kubelet queries done by the Agent.
+	queries = telemetry.NewCounterWithOpts(
+		subsystem,
+		"queries",
+		[]string{"path", "code"},
+		"Count of kubelet queries by path and response code. The response code defaults to 0 for unachieved queries. (The metric doesn't include kubelet check queries).",
+		telemetry.Options{NoDoubleUnderscoreSep: true},
+	)
+)

--- a/releasenotes/notes/kubelet-telem-b45f1eb7201b18d0.yaml
+++ b/releasenotes/notes/kubelet-telem-b45f1eb7201b18d0.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Add Kubelet queries telemetry.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add telemetry for Kubelet queries: `kubelet_queries`

### Motivation

Ease debugging and catching regressions

### Describe how to test/QA your changes

- Enable telemetry.enabled and query the prom endpoint `curl localhost:6000/telemetry`
```
# HELP kubelet_queries Count of kubelet queries by path and response code. (Doesn't include kubelet check queries).
# TYPE kubelet_queries counter
kubelet_queries{code="200",path="/metrics"} 1
kubelet_queries{code="200",path="/pods"} 5
kubelet_queries{code="404",path="/spec"} 1
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
