### PR TITLE
Add 'inv check-forbidden-packages'

### DIFF
--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -33,6 +33,7 @@ from . import (
 )
 from .build_tags import audit_tag_impact
 from .go import (
+    check_forbidden_packages,
     check_mod_tidy,
     cyclo,
     deps,
@@ -76,6 +77,7 @@ ns.add_task(test)
 ns.add_task(integration_tests)
 ns.add_task(deps)
 ns.add_task(deps_vendored)
+ns.add_task(check_forbidden_packages)
 ns.add_task(lint_licenses)
 ns.add_task(generate_licenses)
 ns.add_task(generate_protobuf)


### PR DESCRIPTION
### What does this PR do?

Adds a new check that the `plugin` module is not used.

It is used, so this fails :)

### Motivation

https://github.com/golang/go/issues/38824

github.com/containerd/containerd requires `plugins`.

### Additional Notes

`go mod why` does not respect tags -- it just looks at all imports in any `.go` file.  What we would like is to check that `plugin` is not used on Mac (`go:build +darwin`), and we could accomplish that with go tags: containerd does not run on mac, so this is not necessary.

Depending on how we deal with the plugin issue, this may or may not be the right approach.  If we can stop all use of github.com/containerd/containerd on _any_ platform, then this is the right approach.  Otherwise, we'll need to find some alternative.

### Describe how to test/QA your changes

No need.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
