### PR TITLE
[CWS & CSPM] e2e improvements

### DIFF
--- a/test/e2e/cws-tests/requirements.txt
+++ b/test/e2e/cws-tests/requirements.txt
@@ -4,3 +4,4 @@ pyaml==21.10.1
 docker==5.0.3
 retry==0.9.2
 emoji==1.6.1
+requests==2.26.0


### PR DESCRIPTION
### What does this PR do?

This PR converts CWS e2e tests to requests and adds the dependency to the `requirements.txt` file. This dependency was already used by CSPM tests but was missing from the requirements.

### Motivation

Use the same library, and the easier one, for both CWS and CSPM.

### Possible Drawbacks / Trade-offs

None

### Describe how to test/QA your changes

This PR only touch tests.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
