### PR TITLE
[go.mod] document grpc pin

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ replace (
 	github.com/ugorji/go => github.com/ugorji/go v1.1.7
 )
 
-// pinned to grpc v1.28.0 - this pin is required due to k8s.io/apiserver (and other_ pins being set to v0.21.5
+// pinned to grpc v1.28.0 - this pin is required due to k8s.io/apiserver (and other) pins being set to v0.21.5
 //                          the kubernetes pins are required at this time. We will bump grpc once k8s releases
 //                          v1.24 or v1.25.
 replace (

--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,9 @@ replace (
 	github.com/ugorji/go => github.com/ugorji/go v1.1.7
 )
 
-// pinned to grpc v1.28.0
+// pinned to grpc v1.28.0 - this pin is required due to k8s.io/apiserver (and other_ pins being set to v0.21.5
+//                          the kubernetes pins are required at this time. We will bump grpc once k8s releases
+//                          v1.24 or v1.25.
 replace (
 	github.com/grpc-ecosystem/grpc-gateway => github.com/grpc-ecosystem/grpc-gateway v1.12.2
 	google.golang.org/grpc => github.com/grpc/grpc-go v1.28.0


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->

### What does this PR do?

Simply documents the grpc pin and it's reasons to be pinned.

### Motivation

Better understanding and documentation on why the pins are set.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

None.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Nothing to QA.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
