### PR TITLE
[tasks] Add `bind_at_load` flag to external linker on macOS

### DIFF
--- a/releasenotes/notes/macos-hang-210c8da1aaab9619.yaml
+++ b/releasenotes/notes/macos-hang-210c8da1aaab9619.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    On macOS, fix a bug where the Agent would not gracefully stop when sent a SIGTERM signal.


### PR DESCRIPTION
### What does this PR do?

- Refactor `get_build_flags` to pass multiple external linker arguments.
- On macOS, pass `-Wl,-bind_at_load` flag to external linker.
 
### Motivation

Avoid hitting dyld's `<rdar://problem/8663923> race condition with flat-namespace lazy binding` (see golang/go#38824 for details) by applying [this patch](https://go-review.googlesource.com/c/go/+/372798/) manually.

### Additional Notes

Not sure if this works!

### Possible Drawbacks / Trade-offs

- The patch hasn't been accepted yet on Go (but I think thanks to @djmitche and others' investigation we understand the problem well enough to see that this at least reduces the chances of a deadlock happening a lot).
- If we exclude the `containerd` dependency from the macOS Agent, the problem will be fixed for now, but this seems more bulletproof and avoids the need for #10258, which seems difficult to implement reliably

### Describe how to test/QA your changes

Test that macOS Agent does not enter dyld deadlock when shutting down by stopping the service a few times and checking that the Agent stops instead of restarting.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
