### PR TITLE
[network/ebpf/http] http_parse_data() : using __builtin_memcmp()/__builtin_strlen()

### DIFF
--- a/pkg/network/ebpf/c/http.h
+++ b/pkg/network/ebpf/c/http.h
@@ -141,30 +141,32 @@ static __always_inline int http_begin_response(http_transaction_t *http, const c
 }
 
 static __always_inline void http_parse_data(char *p, http_packet_t *packet_type, http_method_t *method) {
-    if ((p[0] == 'H') && (p[1] == 'T') && (p[2] == 'T') && (p[3] == 'P')) {
+#define __builtin_const_strcmp(buf, constbuf) __builtin_memcmp(buf, constbuf, __builtin_strlen(constbuf))
+    if (!__builtin_const_strcmp(p, "HTTP")) {
         *packet_type = HTTP_RESPONSE;
-    } else if ((p[0] == 'G') && (p[1] == 'E') && (p[2] == 'T')) {
+    } else if (!__builtin_const_strcmp(p, "GET")) {
         *packet_type = HTTP_REQUEST;
         *method = HTTP_GET;
-    } else if ((p[0] == 'P') && (p[1] == 'O') && (p[2] == 'S') && (p[3] == 'T')) {
+    } else if (!__builtin_const_strcmp(p, "POST")) {
         *packet_type = HTTP_REQUEST;
         *method = HTTP_POST;
-    } else if ((p[0] == 'P') && (p[1] == 'U') && (p[2] == 'T')) {
+    } else if (!__builtin_const_strcmp(p, "PUT")) {
         *packet_type = HTTP_REQUEST;
         *method = HTTP_PUT;
-    } else if ((p[0] == 'D') && (p[1] == 'E') && (p[2] == 'L') && (p[3] == 'E') && (p[4] == 'T') && (p[5] == 'E')) {
+    } else if (!__builtin_const_strcmp(p, "DELETE")) {
         *packet_type = HTTP_REQUEST;
         *method = HTTP_DELETE;
-    } else if ((p[0] == 'H') && (p[1] == 'E') && (p[2] == 'A') && (p[3] == 'D')) {
+    } else if (!__builtin_const_strcmp(p, "HEAD")) {
         *packet_type = HTTP_REQUEST;
         *method = HTTP_HEAD;
-    } else if ((p[0] == 'O') && (p[1] == 'P') && (p[2] == 'T') && (p[3] == 'I') && (p[4] == 'O') && (p[5] == 'N') && (p[6] == 'S')) {
+    } else if (!__builtin_const_strcmp(p, "OPTIONS")) {
         *packet_type = HTTP_REQUEST;
         *method = HTTP_OPTIONS;
-    } else if ((p[0] == 'P') && (p[1] == 'A') && (p[2] == 'T') && (p[3] == 'C') && (p[4] == 'H')) {
+    } else if (!__builtin_const_strcmp(p, "PATCH")) {
         *packet_type = HTTP_REQUEST;
         *method = HTTP_PATCH;
     }
+#undef __builtin_const_strcmp
 }
 
 static __always_inline int http_process(char *buffer, skb_info_t *skb_info, u16 src_port, u64 tags) {


### PR DESCRIPTION
Compare tests are in this branch
https://github.com/DataDog/datadog-agent/tree/nplanel/ebpf-fast-compare-less-instructions

The conclusion is the __builtin_strcmp() use less instructions

Results :

-DU64
    1915:	05 00 f4 ff 00 00 00 00	goto -12 <LBB0_155>
-DUX
    1913:	05 00 f4 ff 00 00 00 00	goto -12 <LBB0_155>
-DU64U32
    1926:	05 00 f4 ff 00 00 00 00	goto -12 <LBB0_156>
-DBUILTIN
    1804:	05 00 ef ff 00 00 00 00	goto -17 <LBB0_156>
-DBUILTINSTRLEN
    1804:	05 00 ef ff 00 00 00 00	goto -17 <LBB0_156>
-DBUILTINSTRCMP
    1793:	05 00 f4 ff 00 00 00 00	goto -12 <LBB0_156>
-DORIG
    1884:	05 00 35 ff 00 00 00 00	goto -203 <LBB0_94>

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
