### PR TITLE
Improve dogstatd string interner telemetry

### DIFF
--- a/pkg/dogstatsd/intern.go
+++ b/pkg/dogstatsd/intern.go
@@ -7,35 +7,52 @@ package dogstatsd
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/telemetry"
-	telemetry_utils "github.com/DataDog/datadog-agent/pkg/telemetry/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	telemetry_utils "github.com/DataDog/datadog-agent/pkg/telemetry/utils"
 )
 
 var (
-	// Amount of resets of the string interner used in dogstatsd
-	// Note that it's not ideal because there is many allocated string interner
-	// (one per worker) but it'll still give us an insight (and it's comparable
-	// as long as the amount of worker is stable).
-	tlmSIResets = telemetry.NewCounter("dogstatsd", "string_interner_resets",
-		nil, "Amount of resets of the string interner used in dogstatsd")
+	// There are multiple instances of the interner, one per worker. Counters are normally fine,
+	// gauges require special care to make sense. We don't need to clean up when an instance is
+	// dropped, because it only happens on agent shutdown.
+	tlmSIResets = telemetry.NewSimpleCounter("dogstatsd", "string_interner_resets",
+		"Amount of resets of the string interner used in dogstatsd")
+	tlmSIRSize = telemetry.NewSimpleGauge("dogstatsd", "string_interner_entries",
+		"Number of entries in the string interner")
+	tlmSIRBytes = telemetry.NewSimpleGauge("dogstatsd", "string_interner_bytes",
+		"Number of bytes stored in the string interner")
+	tlmSIRHits = telemetry.NewSimpleCounter("dogstatsd", "string_interner_hits",
+		"Number of times string interner returned an existing string")
+	tlmSIRMiss = telemetry.NewSimpleCounter("dogstatsd", "string_interner_miss",
+		"Number of times string interner created a new string object")
+	tlmSIRNew = telemetry.NewSimpleCounter("dogstatsd", "string_interner_new",
+		"Number of times string interner was created")
+	tlmSIRStrBytes = telemetry.NewSimpleHistogram("dogstatsd", "string_interner_str_bytes",
+		"Number of times string with specific length were added",
+		[]float64{1, 2, 4, 8, 16, 32, 64, 128})
 )
 
 // stringInterner is a string cache providing a longer life for strings,
 // helping to avoid GC runs because they're re-used many times instead of
 // created every time.
 type stringInterner struct {
-	strings map[string]string
-	maxSize int
-	// telemetry
+	strings    map[string]string
+	maxSize    int
+	curBytes   int
 	tlmEnabled bool
 }
 
 func newStringInterner(maxSize int) *stringInterner {
-	return &stringInterner{
+	i := &stringInterner{
 		strings:    make(map[string]string),
 		maxSize:    maxSize,
 		tlmEnabled: telemetry_utils.IsEnabled(),
 	}
+	if i.tlmEnabled {
+		tlmSIRNew.Inc()
+	}
+	return i
 }
 
 // LoadOrStore always returns the string from the cache, adding it into the
@@ -49,16 +66,34 @@ func (i *stringInterner) LoadOrStore(key []byte) string {
 	// for this string.
 	// See https://github.com/golang/go/commit/f5f5a8b6209f84961687d993b93ea0d397f5d5bf
 	if s, found := i.strings[string(key)]; found {
+		if i.tlmEnabled {
+			tlmSIRHits.Inc()
+		}
 		return s
 	}
 	if len(i.strings) >= i.maxSize {
-		i.strings = make(map[string]string)
-		log.Debug("clearing the string interner cache")
 		if i.tlmEnabled {
 			tlmSIResets.Inc()
+			tlmSIRBytes.Sub(float64(i.curBytes))
+			tlmSIRSize.Sub(float64(len(i.strings)))
+			i.curBytes = 0
 		}
+
+		i.strings = make(map[string]string)
+		log.Debug("clearing the string interner cache")
+
 	}
+
 	s := string(key)
 	i.strings[s] = s
+
+	if i.tlmEnabled {
+		tlmSIRMiss.Inc()
+		tlmSIRSize.Inc()
+		tlmSIRBytes.Add(float64(len(s)))
+		tlmSIRStrBytes.Observe(float64(len(s)))
+		i.curBytes += len(s)
+	}
+
 	return s
 }

--- a/pkg/telemetry/simple_gauge.go
+++ b/pkg/telemetry/simple_gauge.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package telemetry
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// SimpleGauge tracks how many times something is happening.
+type SimpleGauge interface {
+	// Inc increments the gaguge.
+	Inc()
+	// Dec decrements the gauge.
+	Dec()
+	// Add increments the gauge by given amount.
+	Add(float64)
+	// Sub decrements the gauge by given amount.
+	Sub(float64)
+	// Set sets the value of the gauge.
+	Set(float64)
+}
+
+// NewSimpleGauge creates a new SimpleGauge with default options.
+func NewSimpleGauge(subsystem, name, help string) SimpleGauge {
+	return NewSimpleGaugeWithOpts(subsystem, name, help, DefaultOptions)
+}
+
+// NewSimpleGaugeWithOpts creates a new SimpleGauge.
+func NewSimpleGaugeWithOpts(subsystem, name, help string, opts Options) SimpleGauge {
+	name = opts.NameWithSeparator(subsystem, name)
+
+	pc := prometheus.NewGauge(prometheus.GaugeOpts{
+		Subsystem: subsystem,
+		Name:      name,
+		Help:      help,
+	})
+
+	telemetryRegistry.MustRegister(pc)
+
+	return pc
+}

--- a/pkg/telemetry/simple_histogram.go
+++ b/pkg/telemetry/simple_histogram.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package telemetry
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+)
+
+// SimpleHistogram tracks how many times something is happening.
+type SimpleHistogram interface {
+	// Observe the value to the Histogram value.
+	Observe(value float64)
+}
+
+// NewSimpleHistogram creates a new SimpleHistogram with default options.
+func NewSimpleHistogram(subsystem, name, help string, buckets []float64) SimpleHistogram {
+	return NewSimpleHistogramWithOpts(subsystem, name, help, buckets, DefaultOptions)
+}
+
+// NewSimpleHistogramWithOpts creates a new SimpleHistogram.
+func NewSimpleHistogramWithOpts(subsystem, name, help string, buckets []float64, opts Options) SimpleHistogram {
+	name = opts.NameWithSeparator(subsystem, name)
+
+	pc := prometheus.NewHistogram(prometheus.HistogramOpts{
+		Subsystem: subsystem,
+		Name:      name,
+		Help:      help,
+		Buckets:   buckets,
+	})
+
+	telemetryRegistry.MustRegister(pc)
+
+	return pc
+}


### PR DESCRIPTION
### What does this PR do?

Add additional metrics to the telemetry collected in the dogstatd string interner: number of bytes and strings stored, hit and miss ratio, distribution of string lengths.

### Motivation

Get better information about the workload handled by the agent.

### Additional Notes

### Possible Drawbacks / Trade-offs

Adds about 1% cpu usage when telemetry is enabled on the stress benchmark.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
