### PR TITLE
Rename profiling.Settings#Site to ProfilingURL

### DIFF
--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -139,14 +139,14 @@ func load(configPath string) (*Config, error) {
 		if traceAgentURL := os.Getenv("TRACE_AGENT_URL"); len(traceAgentURL) > 0 {
 			site = fmt.Sprintf(profiling.ProfilingLocalURLTemplate, traceAgentURL)
 		} else {
-			site = fmt.Sprintf(profiling.ProfileURLTemplate, cfgSite)
+			site = fmt.Sprintf(profiling.ProfilingURLTemplate, cfgSite)
 			if cfgURL != "" {
 				site = cfgURL
 			}
 		}
 
 		profSettings = &profiling.Settings{
-			Site:                 site,
+			ProfilingURL:         site,
 			Env:                  cfg.GetString(key(spNS, "internal_profiling.env")),
 			Service:              "system-probe",
 			Period:               cfg.GetDuration(key(spNS, "internal_profiling.period")),

--- a/pkg/config/settings/runtime_setting_profiling.go
+++ b/pkg/config/settings/runtime_setting_profiling.go
@@ -63,7 +63,7 @@ func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 		}
 
 		// allow full url override for development use
-		site := fmt.Sprintf(profiling.ProfileURLTemplate, s)
+		site := fmt.Sprintf(profiling.ProfilingURLTemplate, s)
 		if config.Datadog.IsSet("internal_profiling.profile_dd_url") {
 			site = config.Datadog.GetString("internal_profiling.profile_dd_url")
 		}
@@ -72,7 +72,7 @@ func (l ProfilingRuntimeSetting) Set(v interface{}) error {
 		// invocation, as many of these settings may have changed at runtime.
 		v, _ := version.Agent()
 		settings := profiling.Settings{
-			Site:                 site,
+			ProfilingURL:         site,
 			Env:                  config.Datadog.GetString("env"),
 			Service:              "datadog-agent",
 			Period:               profiling.DefaultProfilingPeriod,

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -254,12 +254,12 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 			if s == "" {
 				s = config.DefaultSite
 			}
-			site = fmt.Sprintf(profiling.ProfileURLTemplate, s)
+			site = fmt.Sprintf(profiling.ProfilingURLTemplate, s)
 		}
 
 		v, _ := version.Agent()
 		a.ProfilingSettings = &profiling.Settings{
-			Site:                 site,
+			ProfilingURL:         site,
 			Env:                  config.Datadog.GetString("env"),
 			Service:              "process-agent",
 			Period:               config.Datadog.GetDuration("internal_profiling.period"),

--- a/pkg/trace/config/apply.go
+++ b/pkg/trace/config/apply.go
@@ -486,11 +486,11 @@ func (c *AgentConfig) applyDatadogConfig() error {
 			if s == "" {
 				s = config.DefaultSite
 			}
-			endpoint = fmt.Sprintf(profiling.ProfileURLTemplate, s)
+			endpoint = fmt.Sprintf(profiling.ProfilingURLTemplate, s)
 		}
 
 		c.ProfilingSettings = &profiling.Settings{
-			Site: endpoint,
+			ProfilingURL: endpoint,
 
 			// remaining configuration parameters use the top-level `internal_profiling` config
 			Period:               config.Datadog.GetDuration("internal_profiling.period"),

--- a/pkg/util/profiling/profiling.go
+++ b/pkg/util/profiling/profiling.go
@@ -20,8 +20,8 @@ var (
 )
 
 const (
-	// ProfileURLTemplate constant template for expected profiling endpoint URL.
-	ProfileURLTemplate = "https://intake.profile.%s/v1/input"
+	// ProfilingURLTemplate constant template for expected profiling endpoint URL.
+	ProfilingURLTemplate = "https://intake.profile.%s/v1/input"
 	// ProfilingLocalURLTemplate is the constant used to compute the URL of the local trace agent
 	ProfilingLocalURLTemplate = "http://%v/profiling/v1/input"
 	// DefaultProfilingPeriod defines the default profiling period
@@ -47,7 +47,7 @@ func Start(settings Settings) error {
 	options := []profiler.Option{
 		profiler.WithEnv(settings.Env),
 		profiler.WithService(settings.Service),
-		profiler.WithURL(settings.Site),
+		profiler.WithURL(settings.ProfilingURL),
 		profiler.WithPeriod(settings.Period),
 		profiler.WithProfileTypes(types...),
 		profiler.CPUDuration(settings.CPUDuration),
@@ -68,7 +68,7 @@ func Start(settings Settings) error {
 
 	if err == nil {
 		running = true
-		log.Debugf("Profiling started! Submitting to: %s", settings.Site)
+		log.Debugf("Profiling started! Submitting to: %s", settings.ProfilingURL)
 	}
 
 	return err

--- a/pkg/util/profiling/profiling_test.go
+++ b/pkg/util/profiling/profiling_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestProfiling(t *testing.T) {
 	settings := Settings{
-		Site:                 "https://nowhere.testing.dev",
+		ProfilingURL:         "https://nowhere.testing.dev",
 		Env:                  "testing",
 		Service:              "test-agent",
 		Period:               time.Minute,

--- a/pkg/util/profiling/settings.go
+++ b/pkg/util/profiling/settings.go
@@ -14,8 +14,9 @@ import (
 
 // Settings contains the settings for internal profiling, to be passed to Start().
 type Settings struct {
-	// Site specifies the datadog site (datadoghq.com, datadoghq.eu, etc.) which profiles will be sent to.
-	Site string
+	// ProfilingURL specifies the URL to which profiles will be sent.  This can be constructed
+	// from a site value with ProfilingURLTemplate.
+	ProfilingURL string
 	// Env specifies the environment to which profiles should be registered.
 	Env string
 	// Service specifies the service name to attach to a profile.
@@ -38,7 +39,7 @@ type Settings struct {
 
 func (settings *Settings) String() string {
 	return fmt.Sprintf("[Target:%q][Env:%q][Period:%s][CPU:%s][Mutex:%d][Block:%d][Routines:%v]",
-		settings.Site,
+		settings.ProfilingURL,
 		settings.Env,
 		settings.Period,
 		settings.CPUDuration,


### PR DESCRIPTION
..and "Profile" to "Profiling" in ProfilingURLTemplate

### Motivation

"Site" typically means a hostname to the agent, not a URL.  So, just better terminology.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
