### PR TITLE
fix out of date type_windows.go

### DIFF
--- a/pkg/network/driver/types_windows.go
+++ b/pkg/network/driver/types_windows.go
@@ -3,7 +3,7 @@
 
 package driver
 
-const Signature = 0xddfd0000000b
+const Signature = 0xddfd0000000c
 
 const (
 	GetStatsIOCTL      = 0x122004
@@ -60,16 +60,19 @@ type HandleStats struct {
 	Ioctl_calls            int64
 }
 type FlowStats struct {
-	Packets_observed              int64
-	Packets_processed             int64
-	Open_flows                    int64
-	Total_flows                   int64
-	Num_flow_searches             int64
-	Num_flow_search_misses        int64
-	Num_flow_collisions           int64
-	Num_flow_structures           int64
-	Peak_num_flow_structures      int64
-	Num_flows_missed_max_exceeded int64
+	Packets_observed                        int64
+	Packets_processed                       int64
+	Open_flows                              int64
+	Total_flows                             int64
+	Num_flow_searches                       int64
+	Num_flow_search_misses                  int64
+	Num_flow_collisions                     int64
+	Num_flow_structures                     int64
+	Peak_num_flow_structures                int64
+	Num_flows_missed_max_exceeded           int64
+	Num_flows_no_handle                     int64
+	Peak_num_flows_no_handle                int64
+	Num_flows_missed_max_no_handle_exceeded int64
 }
 type TransportStats struct {
 	Packets_processed    int64
@@ -87,7 +90,7 @@ type DriverStats struct {
 	Handle        Stats
 }
 
-const DriverStatsSize = 0x148
+const DriverStatsSize = 0x178
 
 type PerFlowData struct {
 	FlowHandle         uint64


### PR DESCRIPTION
### What does this PR do?

fixes problem in windows_types.go which was causing system probe to not be able
to load driver.



- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
