### PR TITLE
[corechecks/snmp] Fix check name for SNMP corecheck autodiscovery

### DIFF
--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -118,7 +118,7 @@ func (c *Check) Configure(rawInstance integration.Data, rawInitConfig integratio
 		}
 		setNameErr := rawInstance.SetNameForInstance(checkName)
 		if setNameErr != nil {
-			log.Debugf("error setting subnet as name: %s", setNameErr)
+			log.Debugf("error setting check name (checkName=%s): %s", checkName, setNameErr)
 		}
 	}
 

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -110,9 +110,17 @@ func (c *Check) Configure(rawInstance integration.Data, rawInitConfig integratio
 		// Set 'name' field of the instance if not already defined in rawInstance config.
 		// The name/device_id will be used by Check.BuildID for building the check id.
 		// Example of check id: `snmp:<DEVICE_ID>:a3ec59dfb03e4457`
-		setNameErr := rawInstance.SetNameForInstance(c.config.DeviceID)
-		if setNameErr != nil {
-			log.Debugf("error setting device_id as name: %s", setNameErr)
+		if c.config.IsDiscovery() {
+			name := fmt.Sprintf("%s:%s", c.config.Namespace, c.config.Network)
+			setNameErr := rawInstance.SetNameForInstance(name)
+			if setNameErr != nil {
+				log.Debugf("error setting subnet as name: %s", setNameErr)
+			}
+		} else {
+			setNameErr := rawInstance.SetNameForInstance(c.config.DeviceID)
+			if setNameErr != nil {
+				log.Debugf("error setting device_id as name: %s", setNameErr)
+			}
 		}
 	}
 

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -118,7 +118,7 @@ func (c *Check) Configure(rawInstance integration.Data, rawInitConfig integratio
 		}
 		setNameErr := rawInstance.SetNameForInstance(checkName)
 		if setNameErr != nil {
-			log.Debugf("error setting check name (checkName=%s): %s", checkName, setNameErr)
+			log.Warnf("error setting check name (checkName=%s): %s", checkName, setNameErr)
 		}
 	}
 

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -107,20 +107,18 @@ func (c *Check) Configure(rawInstance integration.Data, rawInitConfig integratio
 	log.Debugf("SNMP configuration: %s", c.config.ToString())
 
 	if c.config.Name == "" {
+		var checkName string
 		// Set 'name' field of the instance if not already defined in rawInstance config.
 		// The name/device_id will be used by Check.BuildID for building the check id.
 		// Example of check id: `snmp:<DEVICE_ID>:a3ec59dfb03e4457`
 		if c.config.IsDiscovery() {
-			name := fmt.Sprintf("%s:%s", c.config.Namespace, c.config.Network)
-			setNameErr := rawInstance.SetNameForInstance(name)
-			if setNameErr != nil {
-				log.Debugf("error setting subnet as name: %s", setNameErr)
-			}
+			checkName = fmt.Sprintf("%s:%s", c.config.Namespace, c.config.Network)
 		} else {
-			setNameErr := rawInstance.SetNameForInstance(c.config.DeviceID)
-			if setNameErr != nil {
-				log.Debugf("error setting device_id as name: %s", setNameErr)
-			}
+			checkName = c.config.DeviceID
+		}
+		setNameErr := rawInstance.SetNameForInstance(checkName)
+		if setNameErr != nil {
+			log.Debugf("error setting subnet as name: %s", setNameErr)
 		}
 	}
 

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -698,6 +698,7 @@ func TestCheckID(t *testing.T) {
 	check1 := snmpFactory()
 	check2 := snmpFactory()
 	check3 := snmpFactory()
+	checkSubnet := snmpFactory()
 	// language=yaml
 	rawInstanceConfig1 := []byte(`
 ip_address: 1.1.1.1
@@ -714,6 +715,12 @@ ip_address: 3.3.3.3
 community_string: abc
 namespace: ns3
 `)
+	// language=yaml
+	rawInstanceConfigSubnet := []byte(`
+network_address: 10.10.10.0/24
+community_string: abc
+namespace: nsSubnet
+`)
 
 	err := check1.Configure(rawInstanceConfig1, []byte(``), "test")
 	assert.Nil(t, err)
@@ -721,10 +728,13 @@ namespace: ns3
 	assert.Nil(t, err)
 	err = check3.Configure(rawInstanceConfig3, []byte(``), "test")
 	assert.Nil(t, err)
+	err = checkSubnet.Configure(rawInstanceConfigSubnet, []byte(``), "test")
+	assert.Nil(t, err)
 
 	assert.Equal(t, check.ID("snmp:default:1.1.1.1:a3ec59dfb03e4457"), check1.ID())
 	assert.Equal(t, check.ID("snmp:default:2.2.2.2:3979cd473e4beb3f"), check2.ID())
 	assert.Equal(t, check.ID("snmp:ns3:3.3.3.3:819516f4c3986cc6"), check3.ID())
+	assert.Equal(t, check.ID("snmp:nsSubnet:10.10.10.0/24:be3c32b7c5c1c696"), checkSubnet.ID())
 	assert.NotEqual(t, check1.ID(), check2.ID())
 }
 
@@ -1257,7 +1267,7 @@ func TestReportDeviceMetadataWithFetchError(t *testing.T) {
 	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
-	chk := Check{}
+	chk := snmpFactory()
 	// language=yaml
 	rawInstanceConfig := []byte(`
 ip_address: 1.2.3.5


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[corechecks/snmp] Fix check name for SNMP corecheck autodiscovery

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Currently, for SNMP corecheck autodiscovery, the name is `snmp:default::be3c32b7c5c1c696`

But should be `snmp:default:10.10.10.0/24:be3c32b7c5c1c696`

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Test with a SNMP config like:

```
init_config:
  loader: core

instances:
  - network_address: "127.0.0.0/28"
    community_string: 'public'
    port: 1161
```

And check that `agent status` command is showing the correct check instance name:

```
    snmp
    ----
      Instance ID: snmp:default:127.0.0.0/28:6fe0481ec42f2409 [OK]
      Configuration Source: file:/opt/datadog-agent/etc/conf.d/snmp.d/conf.yaml
      Total Runs: 467
      Metric Samples: Last Run: 939, Total: 438,513
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
