### PR TITLE
[CWS] improve volumes and `HOST*` env vars in docker functional tests

### DIFF
--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -7,6 +7,8 @@ package config
 
 import (
 	"encoding/json"
+	"os"
+	"path"
 	"strings"
 	"time"
 
@@ -29,14 +31,14 @@ const (
 	// defaultKernelHeadersDownloadDir is the default path for downloading kernel headers for runtime compilation
 	defaultKernelHeadersDownloadDir = "/var/tmp/datadog-agent/system-probe/kernel-headers"
 
-	// defaultAptConfigDir is the default path to the apt config directory
-	defaultAptConfigDir = "/etc/apt"
+	// defaultAptConfigDirSuffix is the default path under `/etc` to the apt config directory
+	defaultAptConfigDirSuffix = "/apt"
 
-	// defaultYumReposDir is the default path to the yum repository directory
-	defaultYumReposDir = "/etc/yum.repos.d"
+	// defaultYumReposDirSuffix is the default path `/etc` to the yum repository directory
+	defaultYumReposDirSuffix = "/yum.repos.d"
 
-	// defaultZypperReposDir is the default path to the zypper repository directory
-	defaultZypperReposDir = "/etc/zypp/repos.d"
+	// defaultZypperReposDirSuffix is the default path `/etc` to the zypper repository directory
+	defaultZypperReposDirSuffix = "/zypp/repos.d"
 
 	defaultOffsetThreshold = 400
 )
@@ -90,9 +92,9 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "runtime_compiler_output_dir"), defaultRuntimeCompilerOutputDir, "DD_RUNTIME_COMPILER_OUTPUT_DIR")
 	cfg.BindEnvAndSetDefault(join(spNS, "kernel_header_dirs"), []string{}, "DD_KERNEL_HEADER_DIRS")
 	cfg.BindEnvAndSetDefault(join(spNS, "kernel_header_download_dir"), defaultKernelHeadersDownloadDir, "DD_KERNEL_HEADER_DOWNLOAD_DIR")
-	cfg.BindEnvAndSetDefault(join(spNS, "apt_config_dir"), defaultAptConfigDir, "DD_APT_CONFIG_DIR")
-	cfg.BindEnvAndSetDefault(join(spNS, "yum_repos_dir"), defaultYumReposDir, "DD_YUM_REPOS_DIR")
-	cfg.BindEnvAndSetDefault(join(spNS, "zypper_repos_dir"), defaultZypperReposDir, "DD_ZYPPER_REPOS_DIR")
+	cfg.BindEnvAndSetDefault(join(spNS, "apt_config_dir"), suffixHostEtc(defaultAptConfigDirSuffix), "DD_APT_CONFIG_DIR")
+	cfg.BindEnvAndSetDefault(join(spNS, "yum_repos_dir"), suffixHostEtc(defaultYumReposDirSuffix), "DD_YUM_REPOS_DIR")
+	cfg.BindEnvAndSetDefault(join(spNS, "zypper_repos_dir"), suffixHostEtc(defaultZypperReposDirSuffix), "DD_ZYPPER_REPOS_DIR")
 
 	// network_tracer settings
 	// we cannot use BindEnvAndSetDefault for network_config.enabled because we need to know if it was manually set.
@@ -161,4 +163,12 @@ func InitSystemProbeConfig(cfg Config) {
 
 func join(pieces ...string) string {
 	return strings.Join(pieces, ".")
+}
+
+func suffixHostEtc(suffix string) string {
+	if value, _ := os.LookupEnv("HOST_ETC"); value != "" {
+		return path.Join(value, suffix)
+	} else {
+		return path.Join("/etc", suffix)
+	}
 }

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -34,10 +34,10 @@ const (
 	// defaultAptConfigDirSuffix is the default path under `/etc` to the apt config directory
 	defaultAptConfigDirSuffix = "/apt"
 
-	// defaultYumReposDirSuffix is the default path `/etc` to the yum repository directory
+	// defaultYumReposDirSuffix is the default path under `/etc` to the yum repository directory
 	defaultYumReposDirSuffix = "/yum.repos.d"
 
-	// defaultZypperReposDirSuffix is the default path `/etc` to the zypper repository directory
+	// defaultZypperReposDirSuffix is the default path under `/etc` to the zypper repository directory
 	defaultZypperReposDirSuffix = "/zypp/repos.d"
 
 	defaultOffsetThreshold = 400

--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -168,7 +168,6 @@ func join(pieces ...string) string {
 func suffixHostEtc(suffix string) string {
 	if value, _ := os.LookupEnv("HOST_ETC"); value != "" {
 		return path.Join(value, suffix)
-	} else {
-		return path.Join("/etc", suffix)
 	}
+	return path.Join("/etc", suffix)
 }

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -403,6 +403,7 @@ def docker_functional_tests(
     arch="x64",
     major_version='7',
     testflags='',
+    static=False,
     skip_linters=False,
 ):
     build_functional_tests(
@@ -412,6 +413,7 @@ def docker_functional_tests(
         major_version=major_version,
         output="pkg/security/tests/testsuite",
         bundle_ebpf=True,
+        static=static,
         skip_linters=skip_linters,
     )
 
@@ -442,6 +444,8 @@ RUN apt-get update -y \
     cmd = 'docker run --name {container_name} {caps} --privileged -d --pid=host '
     cmd += '-v /dev:/dev '
     cmd += '-v /proc:/host/proc -e HOST_PROC=/host/proc '
+    cmd += '-v /:/host/root -e HOST_ROOT=/host/root '
+    cmd += '-v /etc:/host/etc -e HOST_ETC=/host/etc '
     cmd += '-v {GOPATH}/src/{REPO_PATH}/pkg/security/tests:/tests {image_tag} sleep 3600'
 
     args = {

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -80,8 +80,19 @@ if node['platform_family'] != 'windows'
       tag '7'
       cap_add ['SYS_ADMIN', 'SYS_RESOURCE', 'SYS_PTRACE', 'NET_ADMIN', 'IPC_LOCK', 'ALL']
       command "sleep 7200"
-      volumes ['/tmp/security-agent:/tmp/security-agent', '/proc:/host/proc', '/etc/os-release:/host/etc/os-release']
-      env ['HOST_PROC=/host/proc', 'DOCKER_DD_AGENT=yes']
+      volumes [
+        '/tmp/security-agent:/tmp/security-agent',
+        '/proc:/host/proc',
+        '/etc/os-release:/host/etc/os-release',
+        '/:/host/root',
+        '/etc:/host/etc'
+      ]
+      env [
+        'HOST_PROC=/host/proc',
+        'HOST_ROOT=/host/root',
+        'HOST_ETC=/host/etc',
+        'DOCKER_DD_AGENT=yes'
+      ]
       privileged true
     end
 


### PR DESCRIPTION
### What does this PR do?

This PR mounts volumes and env vars in a more similar way as suggested to users.
This PR also uses `HOST_ETC` for default package managers paths.

### Motivation

This will allow runtime compilation to work for functional tests running in container.

### Describe how to test/QA your changes

Internal tests improvements

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
