### PR TITLE
[AD] Improve ConfigProviderFactory

### DIFF
--- a/cmd/agent/common/autodiscovery.go
+++ b/cmd/agent/common/autodiscovery.go
@@ -78,7 +78,7 @@ func setupAutoDiscovery(confSearchPaths []string, metaScheduler *scheduler.MetaS
 	for _, cp := range uniqueConfigProviders {
 		factory, found := providers.ProviderCatalog[cp.Name]
 		if found {
-			configProvider, err := factory(cp)
+			configProvider, err := factory(&cp)
 			if err != nil {
 				log.Errorf("Error while adding config provider %v: %v", cp.Name, err)
 				continue

--- a/pkg/autodiscovery/providers/cloudfoundry.go
+++ b/pkg/autodiscovery/providers/cloudfoundry.go
@@ -31,7 +31,7 @@ type CloudFoundryConfigProvider struct {
 }
 
 // NewCloudFoundryConfigProvider instantiates a new CloudFoundryConfigProvider from given config
-func NewCloudFoundryConfigProvider(conf config.ConfigurationProviders) (ConfigProvider, error) {
+func NewCloudFoundryConfigProvider(*config.ConfigurationProviders) (ConfigProvider, error) {
 	cfp := CloudFoundryConfigProvider{
 		lastCollected: time.Now(),
 	}

--- a/pkg/autodiscovery/providers/clusterchecks.go
+++ b/pkg/autodiscovery/providers/clusterchecks.go
@@ -34,7 +34,11 @@ type ClusterChecksConfigProvider struct {
 // NewClusterChecksConfigProvider returns a new ConfigProvider collecting
 // cluster check configurations from the cluster-agent.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
-func NewClusterChecksConfigProvider(cfg config.ConfigurationProviders) (ConfigProvider, error) {
+func NewClusterChecksConfigProvider(providerConfig *config.ConfigurationProviders) (ConfigProvider, error) {
+	if providerConfig == nil {
+		providerConfig = &config.ConfigurationProviders{}
+	}
+
 	c := &ClusterChecksConfigProvider{
 		graceDuration: defaultGraceDuration,
 	}
@@ -52,8 +56,8 @@ func NewClusterChecksConfigProvider(cfg config.ConfigurationProviders) (ConfigPr
 		}
 	}
 
-	if cfg.GraceTimeSeconds > 0 {
-		c.graceDuration = time.Duration(cfg.GraceTimeSeconds) * time.Second
+	if providerConfig.GraceTimeSeconds > 0 {
+		c.graceDuration = time.Duration(providerConfig.GraceTimeSeconds) * time.Second
 	}
 
 	// Register in the cluster agent as soon as possible

--- a/pkg/autodiscovery/providers/consul.go
+++ b/pkg/autodiscovery/providers/consul.go
@@ -51,8 +51,12 @@ type ConsulConfigProvider struct {
 }
 
 // NewConsulConfigProvider creates a client connection to consul and create a new ConsulConfigProvider
-func NewConsulConfigProvider(config config.ConfigurationProviders) (ConfigProvider, error) {
-	consulURL, err := url.Parse(config.TemplateURL)
+func NewConsulConfigProvider(providerConfig *config.ConfigurationProviders) (ConfigProvider, error) {
+	if providerConfig == nil {
+		providerConfig = &config.ConfigurationProviders{}
+	}
+
+	consulURL, err := url.Parse(providerConfig.TemplateURL)
 	if err != nil {
 		return nil, err
 	}
@@ -60,24 +64,24 @@ func NewConsulConfigProvider(config config.ConfigurationProviders) (ConfigProvid
 	clientCfg := consul.DefaultConfig()
 	clientCfg.Address = consulURL.Host
 	clientCfg.Scheme = consulURL.Scheme
-	clientCfg.Token = config.Token
+	clientCfg.Token = providerConfig.Token
 
 	if consulURL.Scheme == "https" {
 		clientCfg.TLSConfig = consul.TLSConfig{
 			Address:            consulURL.Host,
-			CAFile:             config.CAFile,
-			CAPath:             config.CAPath,
-			CertFile:           config.CertFile,
-			KeyFile:            config.KeyFile,
+			CAFile:             providerConfig.CAFile,
+			CAPath:             providerConfig.CAPath,
+			CertFile:           providerConfig.CertFile,
+			KeyFile:            providerConfig.KeyFile,
 			InsecureSkipVerify: false,
 		}
 	}
 
-	if len(config.Username) > 0 && len(config.Password) > 0 {
-		log.Infof("Using provided consul credentials (username): %s", config.Username)
+	if len(providerConfig.Username) > 0 && len(providerConfig.Password) > 0 {
+		log.Infof("Using provided consul credentials (username): %s", providerConfig.Username)
 		auth := &consul.HttpBasicAuth{
-			Username: config.Username,
-			Password: config.Password,
+			Username: providerConfig.Username,
+			Password: providerConfig.Password,
 		}
 		clientCfg.HttpAuth = auth
 	}
@@ -93,7 +97,7 @@ func NewConsulConfigProvider(config config.ConfigurationProviders) (ConfigProvid
 
 	return &ConsulConfigProvider{
 		Client:      c,
-		TemplateDir: config.TemplateDir,
+		TemplateDir: providerConfig.TemplateDir,
 		cache:       cache,
 	}, nil
 

--- a/pkg/autodiscovery/providers/container.go
+++ b/pkg/autodiscovery/providers/container.go
@@ -39,7 +39,7 @@ type ContainerConfigProvider struct {
 }
 
 // NewContainerConfigProvider creates a new ContainerConfigProvider
-func NewContainerConfigProvider(config config.ConfigurationProviders) (ConfigProvider, error) {
+func NewContainerConfigProvider(*config.ConfigurationProviders) (ConfigProvider, error) {
 	containerFilter, err := containers.NewAutodiscoveryFilter(containers.GlobalFilter)
 	if err != nil {
 		log.Warnf("Can't get container include/exclude filter, no filtering will be applied: %w", err)

--- a/pkg/autodiscovery/providers/endpointschecks.go
+++ b/pkg/autodiscovery/providers/endpointschecks.go
@@ -30,7 +30,7 @@ type EndpointsChecksConfigProvider struct {
 // NewEndpointsChecksConfigProvider returns a new ConfigProvider collecting
 // endpoints check configurations from the cluster-agent.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
-func NewEndpointsChecksConfigProvider(cfg config.ConfigurationProviders) (ConfigProvider, error) {
+func NewEndpointsChecksConfigProvider(*config.ConfigurationProviders) (ConfigProvider, error) {
 	c := &EndpointsChecksConfigProvider{}
 	var err error
 	c.nodeName, err = getNodename(context.TODO())

--- a/pkg/autodiscovery/providers/etcd.go
+++ b/pkg/autodiscovery/providers/etcd.go
@@ -35,16 +35,20 @@ type EtcdConfigProvider struct {
 }
 
 // NewEtcdConfigProvider creates a client connection to etcd and create a new EtcdConfigProvider
-func NewEtcdConfigProvider(config config.ConfigurationProviders) (ConfigProvider, error) {
+func NewEtcdConfigProvider(providerConfig *config.ConfigurationProviders) (ConfigProvider, error) {
+	if providerConfig == nil {
+		providerConfig = &config.ConfigurationProviders{}
+	}
+
 	clientCfg := client.Config{
-		Endpoints:               []string{config.TemplateURL},
+		Endpoints:               []string{providerConfig.TemplateURL},
 		Transport:               client.DefaultTransport,
 		HeaderTimeoutPerRequest: time.Second,
 	}
-	if len(config.Username) > 0 && len(config.Password) > 0 {
-		log.Info("Using provided etcd credentials: username ", config.Username)
-		clientCfg.Username = config.Username
-		clientCfg.Password = config.Password
+	if len(providerConfig.Username) > 0 && len(providerConfig.Password) > 0 {
+		log.Info("Using provided etcd credentials: username ", providerConfig.Username)
+		clientCfg.Username = providerConfig.Username
+		clientCfg.Password = providerConfig.Password
 	}
 
 	cl, err := client.New(clientCfg)
@@ -53,7 +57,7 @@ func NewEtcdConfigProvider(config config.ConfigurationProviders) (ConfigProvider
 	}
 	cache := NewCPCache()
 	c := client.NewKeysAPI(cl)
-	return &EtcdConfigProvider{Client: c, templateDir: config.TemplateDir, cache: cache}, nil
+	return &EtcdConfigProvider{Client: c, templateDir: providerConfig.TemplateDir, cache: cache}, nil
 }
 
 // Collect retrieves templates from etcd, builds Config objects and returns them

--- a/pkg/autodiscovery/providers/kube_endpoints.go
+++ b/pkg/autodiscovery/providers/kube_endpoints.go
@@ -56,7 +56,7 @@ type configInfo struct {
 
 // NewKubeEndpointsConfigProvider returns a new ConfigProvider connected to apiserver.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
-func NewKubeEndpointsConfigProvider(config config.ConfigurationProviders) (ConfigProvider, error) {
+func NewKubeEndpointsConfigProvider(*config.ConfigurationProviders) (ConfigProvider, error) {
 	// Using GetAPIClient (no wait) as Client should already be initialized by Cluster Agent main entrypoint before
 	ac, err := apiserver.GetAPIClient()
 	if err != nil {

--- a/pkg/autodiscovery/providers/kube_endpoints_file.go
+++ b/pkg/autodiscovery/providers/kube_endpoints_file.go
@@ -61,7 +61,7 @@ type KubeEndpointsFileConfigProvider struct {
 }
 
 // NewKubeEndpointsFileConfigProvider returns a new KubeEndpointsFileConfigProvider
-func NewKubeEndpointsFileConfigProvider(config.ConfigurationProviders) (ConfigProvider, error) {
+func NewKubeEndpointsFileConfigProvider(*config.ConfigurationProviders) (ConfigProvider, error) {
 	templates, _, err := ReadConfigFiles(WithAdvancedADOnly)
 	if err != nil {
 		return nil, err

--- a/pkg/autodiscovery/providers/kube_services.go
+++ b/pkg/autodiscovery/providers/kube_services.go
@@ -38,7 +38,7 @@ type KubeServiceConfigProvider struct {
 
 // NewKubeServiceConfigProvider returns a new ConfigProvider connected to apiserver.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
-func NewKubeServiceConfigProvider(config config.ConfigurationProviders) (ConfigProvider, error) {
+func NewKubeServiceConfigProvider(*config.ConfigurationProviders) (ConfigProvider, error) {
 	// Using GetAPIClient() (no retry)
 	ac, err := apiserver.GetAPIClient()
 	if err != nil {

--- a/pkg/autodiscovery/providers/kube_services_file.go
+++ b/pkg/autodiscovery/providers/kube_services_file.go
@@ -22,7 +22,7 @@ type KubeServiceFileConfigProvider struct {
 }
 
 // NewKubeServiceFileConfigProvider returns a new KubeServiceFileConfigProvider
-func NewKubeServiceFileConfigProvider(config config.ConfigurationProviders) (ConfigProvider, error) {
+func NewKubeServiceFileConfigProvider(*config.ConfigurationProviders) (ConfigProvider, error) {
 	return &KubeServiceFileConfigProvider{}, nil
 }
 

--- a/pkg/autodiscovery/providers/kubelet.go
+++ b/pkg/autodiscovery/providers/kubelet.go
@@ -38,7 +38,7 @@ type KubeletConfigProvider struct {
 
 // NewKubeletConfigProvider returns a new ConfigProvider connected to kubelet.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
-func NewKubeletConfigProvider(config config.ConfigurationProviders) (ConfigProvider, error) {
+func NewKubeletConfigProvider(*config.ConfigurationProviders) (ConfigProvider, error) {
 	return &KubeletConfigProvider{
 		workloadmetaStore: workloadmeta.GetGlobalStore(),
 		configErrors:      make(map[string]ErrorMsgSet),

--- a/pkg/autodiscovery/providers/prometheus_pods.go
+++ b/pkg/autodiscovery/providers/prometheus_pods.go
@@ -27,7 +27,7 @@ type PrometheusPodsConfigProvider struct {
 
 // NewPrometheusPodsConfigProvider returns a new Prometheus ConfigProvider connected to kubelet.
 // Connectivity is not checked at this stage to allow for retries, Collect will do it.
-func NewPrometheusPodsConfigProvider(config config.ConfigurationProviders) (ConfigProvider, error) {
+func NewPrometheusPodsConfigProvider(*config.ConfigurationProviders) (ConfigProvider, error) {
 	checks, err := getPrometheusConfigs()
 	if err != nil {
 		return nil, err

--- a/pkg/autodiscovery/providers/prometheus_services.go
+++ b/pkg/autodiscovery/providers/prometheus_services.go
@@ -64,7 +64,7 @@ type PrometheusServicesConfigProvider struct {
 }
 
 // NewPrometheusServicesConfigProvider returns a new Prometheus ConfigProvider connected to kube apiserver
-func NewPrometheusServicesConfigProvider(configProviders config.ConfigurationProviders) (ConfigProvider, error) {
+func NewPrometheusServicesConfigProvider(*config.ConfigurationProviders) (ConfigProvider, error) {
 	// Using GetAPIClient (no wait) as Client should already be initialized by Cluster Agent main entrypoint before
 	ac, err := apiserver.GetAPIClient()
 	if err != nil {

--- a/pkg/autodiscovery/providers/providers.go
+++ b/pkg/autodiscovery/providers/providers.go
@@ -21,7 +21,7 @@ func RegisterProvider(name string, factory ConfigProviderFactory) {
 }
 
 // ConfigProviderFactory is any function capable to create a ConfigProvider instance
-type ConfigProviderFactory func(cfg config.ConfigurationProviders) (ConfigProvider, error)
+type ConfigProviderFactory func(providerConfig *config.ConfigurationProviders) (ConfigProvider, error)
 
 // ProviderCache contains the number of AD Templates and the latest Index
 type ProviderCache struct {

--- a/pkg/autodiscovery/providers/zookeeper.go
+++ b/pkg/autodiscovery/providers/zookeeper.go
@@ -39,17 +39,21 @@ type ZookeeperConfigProvider struct {
 }
 
 // NewZookeeperConfigProvider returns a new Client connected to a Zookeeper backend.
-func NewZookeeperConfigProvider(cfg config.ConfigurationProviders) (ConfigProvider, error) {
-	urls := strings.Split(cfg.TemplateURL, ",")
+func NewZookeeperConfigProvider(providerConfig *config.ConfigurationProviders) (ConfigProvider, error) {
+	if providerConfig == nil {
+		providerConfig = &config.ConfigurationProviders{}
+	}
+
+	urls := strings.Split(providerConfig.TemplateURL, ",")
 
 	c, _, err := zk.Connect(urls, sessionTimeout)
 	if err != nil {
-		return nil, fmt.Errorf("ZookeeperConfigProvider: couldn't connect to %q (%s): %s", cfg.TemplateURL, strings.Join(urls, ", "), err)
+		return nil, fmt.Errorf("ZookeeperConfigProvider: couldn't connect to %q (%s): %s", providerConfig.TemplateURL, strings.Join(urls, ", "), err)
 	}
 	cache := NewCPCache()
 	return &ZookeeperConfigProvider{
 		client:      c,
-		templateDir: cfg.TemplateDir,
+		templateDir: providerConfig.TemplateDir,
 		cache:       cache,
 	}, nil
 }

--- a/test/integration/config_providers/etcd/etcd_provider_test.go
+++ b/test/integration/config_providers/etcd/etcd_provider_test.go
@@ -145,7 +145,7 @@ func (suite *EtcdTestSuite) TestWorkingConnectionAnon() {
 		TemplateURL: suite.etcdURL,
 		TemplateDir: "/foo",
 	}
-	p, err := providers.NewEtcdConfigProvider(config)
+	p, err := providers.NewEtcdConfigProvider(&config)
 	if err != nil {
 		panic(err)
 	}
@@ -166,7 +166,7 @@ func (suite *EtcdTestSuite) TestBadConnection() {
 		TemplateURL: "http://127.0.0.1:1337",
 		TemplateDir: "/foo",
 	}
-	p, err := providers.NewEtcdConfigProvider(config)
+	p, err := providers.NewEtcdConfigProvider(&config)
 	assert.Nil(suite.T(), err)
 
 	checks, err := p.Collect(ctx)
@@ -183,7 +183,7 @@ func (suite *EtcdTestSuite) TestWorkingAuth() {
 		Username:    etcdUser,
 		Password:    etcdPass,
 	}
-	p, err := providers.NewEtcdConfigProvider(config)
+	p, err := providers.NewEtcdConfigProvider(&config)
 	assert.Nil(suite.T(), err)
 
 	checks, err := p.Collect(ctx)
@@ -200,7 +200,7 @@ func (suite *EtcdTestSuite) TestBadAuth() {
 		Username:    etcdUser,
 		Password:    "invalid",
 	}
-	p, err := providers.NewEtcdConfigProvider(config)
+	p, err := providers.NewEtcdConfigProvider(&config)
 	assert.Nil(suite.T(), err)
 
 	checks, err := p.Collect(ctx)

--- a/test/integration/config_providers/zookeeper/zookeeper_provider_test.go
+++ b/test/integration/config_providers/zookeeper/zookeeper_provider_test.go
@@ -134,7 +134,7 @@ func (suite *ZkTestSuite) populate() error {
 
 func (suite *ZkTestSuite) TestCollect() {
 	ctx := context.Background()
-	zk, err := providers.NewZookeeperConfigProvider(suite.providerConfig)
+	zk, err := providers.NewZookeeperConfigProvider(&suite.providerConfig)
 	require.Nil(suite.T(), err)
 
 	templates, err := zk.Collect(ctx)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->
- Unify the `New<Provider>` functions, by using the same patterns and config variable name and omitting the arg variable when not needed
- Pass a pointer as an argument in `ConfigProviderFactory`, most providers don't use this argument.

### Motivation

Suggested here https://github.com/DataDog/datadog-agent/pull/10214#discussion_r772229511

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

The different config providers work as expected, especially the ones using the `providerConfig` argument (zk, consul, etc, clusterchecks)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
