### PR TITLE
Expand embedded archives in container

### DIFF
--- a/Dockerfiles/agent/install.ps1
+++ b/Dockerfiles/agent/install.ps1
@@ -32,31 +32,6 @@ if ("$env:WITH_JMX" -ne "false") {
     $Env:Path="$Env:Path;C:/java/bin"
 }
 
-Expand-Archive datadog-agent-latest.amd64.zip
-Remove-Item datadog-agent-latest.amd64.zip
-
-Get-ChildItem -Path datadog-agent-* | Rename-Item -NewName "Datadog Agent"
-
-New-Item -ItemType directory -Path "C:/Program Files/Datadog"
-Move-Item "Datadog Agent" "C:/Program Files/Datadog/"
-
-#   Install 7zip module
-[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-Set-PSRepository -Name 'PSGallery' -SourceLocation "https://www.powershellgallery.com/api/v2" -InstallationPolicy Trusted
-Install-Module -Name 7Zip4PowerShell -Force
-
-#   Extract embbeded3.7z
-Expand-7Zip -ArchiveFileName "C:/Program Files/Datadog/Datadog Agent/embedded3.7z" -TargetPath "C:/Program Files/Datadog/Datadog Agent"
-Remove-Item "C:/Program Files/Datadog/Datadog Agent/embedded3.7z"
-
-If (Test-Path -Path "C:/Program Files/Datadog/Datadog Agent/embedded2.7z") {
-  Expand-7Zip -ArchiveFileName "C:/Program Files/Datadog/Datadog Agent/embedded2.7z" -TargetPath "C:/Program Files/Datadog/Datadog Agent"
-  Remove-Item "C:/Program Files/Datadog/Datadog Agent/embedded2.7z"
-}
-
-New-Item -ItemType directory -Path 'C:/ProgramData/Datadog'
-Move-Item "C:/Program Files/Datadog/Datadog Agent/EXAMPLECONFSLOCATION" "C:/ProgramData/Datadog/conf.d"
-
 $services = [ordered]@{
   "datadogagent" = "C:\Program Files\Datadog\Datadog Agent\bin\agent.exe",@()
   "datadog-process-agent" = "C:\Program Files\Datadog\Datadog Agent\bin\agent\process-agent.exe",@("datadogagent")
@@ -66,7 +41,6 @@ $services = [ordered]@{
 foreach ($s in $services.Keys) {
     Install-Service -SvcName $s -BinPath $services[$s][0] $services[$s][1]
 }
-
 
 # Allow to run agent binaries as `agent`
 setx /m PATH "$Env:Path;C:/Program Files/Datadog/Datadog Agent/bin;C:/Program Files/Datadog/Datadog Agent/bin/agent"

--- a/Dockerfiles/agent/install.ps1
+++ b/Dockerfiles/agent/install.ps1
@@ -40,6 +40,20 @@ Get-ChildItem -Path datadog-agent-* | Rename-Item -NewName "Datadog Agent"
 New-Item -ItemType directory -Path "C:/Program Files/Datadog"
 Move-Item "Datadog Agent" "C:/Program Files/Datadog/"
 
+#   Install 7zip module
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+Set-PSRepository -Name 'PSGallery' -SourceLocation "https://www.powershellgallery.com/api/v2" -InstallationPolicy Trusted
+Install-Module -Name 7Zip4PowerShell -Force
+
+#   Extract embbeded3.7z
+Expand-7Zip -ArchiveFileName "C:/Program Files/Datadog/Datadog Agent/embedded3.7z" -TargetPath "C:/Program Files/Datadog/Datadog Agent"
+Remove-Item "C:/Program Files/Datadog/Datadog Agent/embedded3.7z"
+
+If (Test-Path -Path "C:/Program Files/Datadog/Datadog Agent/embedded2.7z") {
+  Expand-7Zip -ArchiveFileName "C:/Program Files/Datadog/Datadog Agent/embedded2.7z" -TargetPath "C:/Program Files/Datadog/Datadog Agent"
+  Remove-Item "C:/Program Files/Datadog/Datadog Agent/embedded2.7z"
+}
+
 New-Item -ItemType directory -Path 'C:/ProgramData/Datadog'
 Move-Item "C:/Program Files/Datadog/Datadog Agent/EXAMPLECONFSLOCATION" "C:/ProgramData/Datadog/conf.d"
 

--- a/Dockerfiles/agent/uncompress-zip.ps1
+++ b/Dockerfiles/agent/uncompress-zip.ps1
@@ -1,0 +1,27 @@
+$ErrorActionPreference = "Stop"
+Trap { Write-Host "Error in install.ps1: $_" }
+
+Expand-Archive datadog-agent-latest.amd64.zip
+Remove-Item datadog-agent-latest.amd64.zip
+
+Get-ChildItem -Path datadog-agent-* | Rename-Item -NewName "Datadog Agent"
+
+New-Item -ItemType directory -Path "C:/Program Files/Datadog"
+Move-Item "Datadog Agent" "C:/Program Files/Datadog/"
+
+#   Install 7zip module
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+Set-PSRepository -Name 'PSGallery' -SourceLocation "https://www.powershellgallery.com/api/v2" -InstallationPolicy Trusted
+Install-Module -Name 7Zip4PowerShell -Force
+
+#   Extract embbeded3.7z
+Expand-7Zip -ArchiveFileName "C:/Program Files/Datadog/Datadog Agent/embedded3.7z" -TargetPath "C:/Program Files/Datadog/Datadog Agent"
+Remove-Item "C:/Program Files/Datadog/Datadog Agent/embedded3.7z"
+
+If (Test-Path -Path "C:/Program Files/Datadog/Datadog Agent/embedded2.7z") {
+  Expand-7Zip -ArchiveFileName "C:/Program Files/Datadog/Datadog Agent/embedded2.7z" -TargetPath "C:/Program Files/Datadog/Datadog Agent"
+  Remove-Item "C:/Program Files/Datadog/Datadog Agent/embedded2.7z"
+}
+
+New-Item -ItemType directory -Path 'C:/ProgramData/Datadog'
+Move-Item "C:/Program Files/Datadog/Datadog Agent/EXAMPLECONFSLOCATION" "C:/ProgramData/Datadog/conf.d"

--- a/Dockerfiles/agent/uncompress-zip.ps1
+++ b/Dockerfiles/agent/uncompress-zip.ps1
@@ -11,24 +11,15 @@ Move-Item "Datadog Agent" "C:/Program Files/Datadog/"
 
 #   Install 7zip module
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-
-$sevenzip="https://www.7-zip.org/a/7z1900-x64.exe"
-
-Write-Host -ForegroundColor Green "Installing 7zip $sevenzip"
-$out = "$($PSScriptRoot)\7zip.exe"
-(New-Object System.Net.WebClient).DownloadFile($sevenzip, $out)
-Start-Process 7zip.exe -ArgumentList '/S' -Wait
-Remove-Item $out
-setx PATH "$Env:Path;c:\program files\7-zip"
-$Env:Path="$Env:Path;c:\program files\7-zip"
-Write-Host -ForegroundColor Green Done with 7zip
+Set-PSRepository -Name 'PSGallery' -SourceLocation "https://www.powershellgallery.com/api/v2" -InstallationPolicy Trusted
+Install-Module -Name 7Zip4PowerShell -Force
 
 #   Extract embbeded3.7z
-& 7z x "C:/Program Files/Datadog/Datadog Agent/embedded3.7z" -o"C:/Program Files/Datadog/Datadog Agent"
+Expand-7Zip -ArchiveFileName "C:/Program Files/Datadog/Datadog Agent/embedded3.7z" -TargetPath "C:/Program Files/Datadog/Datadog Agent"
 Remove-Item "C:/Program Files/Datadog/Datadog Agent/embedded3.7z"
 
 If (Test-Path -Path "C:/Program Files/Datadog/Datadog Agent/embedded2.7z") {
-  & 7z x "C:/Program Files/Datadog/Datadog Agent/embedded2.7z" -o"C:/Program Files/Datadog/Datadog Agent"
+  Expand-7Zip -ArchiveFileName "C:/Program Files/Datadog/Datadog Agent/embedded2.7z" -TargetPath "C:/Program Files/Datadog/Datadog Agent"
   Remove-Item "C:/Program Files/Datadog/Datadog Agent/embedded2.7z"
 }
 

--- a/Dockerfiles/agent/uncompress-zip.ps1
+++ b/Dockerfiles/agent/uncompress-zip.ps1
@@ -12,18 +12,23 @@ Move-Item "Datadog Agent" "C:/Program Files/Datadog/"
 #   Install 7zip module
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-# See why here https://docs.microsoft.com/en-us/powershell/scripting/gallery/installing-psget?view=powershell-7#get-the-latest-version-from-powershell-gallery
-Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+$sevenzip="https://www.7-zip.org/a/7z1900-x64.exe"
 
-Set-PSRepository -Name 'PSGallery' -SourceLocation "https://www.powershellgallery.com/api/v2" -InstallationPolicy Trusted
-Install-Module -Name 7Zip4PowerShell -Force
+Write-Host -ForegroundColor Green "Installing 7zip $sevenzip"
+$out = "$($PSScriptRoot)\7zip.exe"
+(New-Object System.Net.WebClient).DownloadFile($sevenzip, $out)
+Start-Process 7zip.exe -ArgumentList '/S' -Wait
+Remove-Item $out
+setx PATH "$Env:Path;c:\program files\7-zip"
+$Env:Path="$Env:Path;c:\program files\7-zip"
+Write-Host -ForegroundColor Green Done with 7zip
 
 #   Extract embbeded3.7z
-Expand-7Zip -ArchiveFileName "C:/Program Files/Datadog/Datadog Agent/embedded3.7z" -TargetPath "C:/Program Files/Datadog/Datadog Agent"
+& 7z x "C:/Program Files/Datadog/Datadog Agent/embedded3.7z" -o"C:/Program Files/Datadog/Datadog Agent"
 Remove-Item "C:/Program Files/Datadog/Datadog Agent/embedded3.7z"
 
 If (Test-Path -Path "C:/Program Files/Datadog/Datadog Agent/embedded2.7z") {
-  Expand-7Zip -ArchiveFileName "C:/Program Files/Datadog/Datadog Agent/embedded2.7z" -TargetPath "C:/Program Files/Datadog/Datadog Agent"
+  & 7z x "C:/Program Files/Datadog/Datadog Agent/embedded2.7z" -o"C:/Program Files/Datadog/Datadog Agent"
   Remove-Item "C:/Program Files/Datadog/Datadog Agent/embedded2.7z"
 }
 

--- a/Dockerfiles/agent/uncompress-zip.ps1
+++ b/Dockerfiles/agent/uncompress-zip.ps1
@@ -11,6 +11,10 @@ Move-Item "Datadog Agent" "C:/Program Files/Datadog/"
 
 #   Install 7zip module
 [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+# See why here https://docs.microsoft.com/en-us/powershell/scripting/gallery/installing-psget?view=powershell-7#get-the-latest-version-from-powershell-gallery
+Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+
 Set-PSRepository -Name 'PSGallery' -SourceLocation "https://www.powershellgallery.com/api/v2" -InstallationPolicy Trusted
 Install-Module -Name 7Zip4PowerShell -Force
 

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -1,4 +1,9 @@
 ARG BASE_IMAGE=mcr.microsoft.com/powershell:lts-windowsservercore-1809
+FROM ${BASE_IMAGE} as unzipper
+SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop';"]
+COPY datadog-agent-latest.amd64.zip uncompress-zip.ps1 ./
+RUN . ./uncompress-zip.ps1
+
 FROM ${BASE_IMAGE}
 
 ARG WITH_JMX="false"
@@ -10,7 +15,9 @@ USER ContainerAdministrator
 
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop';"]
 
-COPY datadog-agent-latest.amd64.zip install.ps1 ./
+COPY --from=unzipper ["C:/ProgramData/Datadog", "C:/ProgramData/Datadog"]
+COPY --from=unzipper ["C:/Program Files/Datadog", "C:/Program Files/Datadog"]
+COPY install.ps1 ./
 RUN . ./install.ps1
 
 EXPOSE 8125/udp 8126/tcp

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -1,5 +1,6 @@
 ARG BASE_IMAGE=mcr.microsoft.com/powershell:lts-windowsservercore-1809
 FROM ${BASE_IMAGE} as unzipper
+USER ContainerAdministrator
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop';"]
 COPY datadog-agent-latest.amd64.zip uncompress-zip.ps1 ./
 RUN . ./uncompress-zip.ps1

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -1,5 +1,5 @@
-ARG BASE_IMAGE=mcr.microsoft.com/powershell:lts-windowsservercore-1809
-FROM ${BASE_IMAGE} as unzipper
+ARG BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-20h2
+FROM mcr.microsoft.com/powershell:lts-windowsservercore-1809 as unzipper
 USER ContainerAdministrator
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop';"]
 COPY datadog-agent-latest.amd64.zip uncompress-zip.ps1 ./

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -2,12 +2,14 @@ ARG BASE_IMAGE=mcr.microsoft.com/powershell:lts-windowsservercore-1809
 ARG WITH_JMX="false"
 ARG VARIANT="unknown"
 
+# Extract the embedded3.7z in a separate stage
 FROM mcr.microsoft.com/powershell:lts-windowsservercore-${VARIANT} as unzipper
 USER ContainerAdministrator
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop';"]
 COPY datadog-agent-latest.amd64.zip uncompress-zip.ps1 ./
 RUN . ./uncompress-zip.ps1
 
+# Build the containerized Agent
 FROM ${BASE_IMAGE}
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
@@ -16,9 +18,9 @@ USER ContainerAdministrator
 
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop';"]
 
+COPY install.ps1 ./
 COPY --from=unzipper ["C:/ProgramData/Datadog", "C:/ProgramData/Datadog"]
 COPY --from=unzipper ["C:/Program Files/Datadog", "C:/Program Files/Datadog"]
-COPY install.ps1 ./
 RUN . ./install.ps1
 
 EXPOSE 8125/udp 8126/tcp

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -1,14 +1,14 @@
-ARG BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-20h2
-FROM mcr.microsoft.com/powershell:lts-windowsservercore-1809 as unzipper
+ARG BASE_IMAGE=mcr.microsoft.com/powershell:lts-windowsservercore-1809
+ARG WITH_JMX="false"
+ARG VARIANT="unknown"
+
+FROM mcr.microsoft.com/powershell:lts-windowsservercore-${VARIANT} as unzipper
 USER ContainerAdministrator
 SHELL ["pwsh", "-Command", "$ErrorActionPreference = 'Stop';"]
 COPY datadog-agent-latest.amd64.zip uncompress-zip.ps1 ./
 RUN . ./uncompress-zip.ps1
 
 FROM ${BASE_IMAGE}
-
-ARG WITH_JMX="false"
-ARG VARIANT="unknown"
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR fixes a regression introduced by #9966 which caused the E2E tests to fail in the integrations repo.

### Motivation

Fix Windows Agent container & E2E tests.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
