### PR TITLE
[CRI] Add support on Windows

### DIFF
--- a/pkg/config/environment_containers.go
+++ b/pkg/config/environment_containers.go
@@ -139,9 +139,7 @@ func detectContainerd(features FeatureMap) {
 func isCriSupported() bool {
 	// Containerd support was historically meant for K8S
 	// However, containerd is now used standalone elsewhere.
-	// TODO: Consider having a dedicated setting for containerd standalone
-	// Also, cri is not enabled on Windows (check build_tags.py).
-	return IsKubernetes() && runtime.GOOS != "windows"
+	return IsKubernetes()
 }
 
 func detectFargate(features FeatureMap) {

--- a/pkg/util/containers/cri/util_test.go
+++ b/pkg/util/containers/cri/util_test.go
@@ -4,6 +4,11 @@
 // Copyright 2016-present Datadog, Inc.
 
 // +build cri
+// +build !windows
+
+// Note: CRI is supported on Windows. However, these test don't work on Windows
+// because the `kubernetes/pkg/kubelet/cri/remote/fake` Windows build only works
+// with TCP endpoints, and we don't support them, we just support npipes.
 
 package cri
 

--- a/releasenotes/notes/cri-windows-aadb01d870a627e8.yaml
+++ b/releasenotes/notes/cri-windows-aadb01d870a627e8.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    ``cri.*`` and ``container.*`` metrics can now be collected from the CRI API
+    on Windows.
+

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -98,7 +98,7 @@ TEST_TAGS = AGENT_TAGS.union({"clusterchecks"})
 ### Tag exclusion lists
 
 # List of tags to always remove when not building on Linux
-LINUX_ONLY_TAGS = {"cri", "netcgo", "systemd", "jetson", "linux_bpf", "podman"}
+LINUX_ONLY_TAGS = {"netcgo", "systemd", "jetson", "linux_bpf", "podman"}
 
 # List of tags to always remove when building on Windows
 WINDOWS_EXCLUDE_TAGS = {"linux_bpf"}


### PR DESCRIPTION
### What does this PR do?

Adds support for the CRI collector on Windows.

### Describe how to test/QA your changes

- Deploy on Kubernetes with Windows nodes, specifying `DD_CRI_SOCKET_PATH` (not needed if you are using the helm charts and default paths).
- Check that `cri.*` metrics are reported.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
