### PR TITLE
[CWS] expose process ancestors in SECL

### DIFF
--- a/docs/cloud-workload-security/agent_expressions.md
+++ b/docs/cloud-workload-security/agent_expressions.md
@@ -128,6 +128,11 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | -------- | ---- | ---------- |
 | `container.id` | string | ID of the container |
 | `container.tags` | string | Tags of the container |
+| `process.ancestors.args` | string | Arguments of the process (as a string) |
+| `process.ancestors.args_flags` | string | Arguments of the process (as an array) |
+| `process.ancestors.args_options` | string | Arguments of the process (as an array) |
+| `process.ancestors.args_truncated` | bool | Indicator of arguments truncation |
+| `process.ancestors.argv` | string | Arguments of the process (as an array) |
 | `process.ancestors.cap_effective` | int | Effective capability set of the process |
 | `process.ancestors.cap_permitted` | int | Permitted capability set of the process |
 | `process.ancestors.comm` | string | Comm attribute of the process |
@@ -136,6 +141,8 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | `process.ancestors.created_at` | int | Timestamp of the creation of the process |
 | `process.ancestors.egid` | int | Effective GID of the process |
 | `process.ancestors.egroup` | string | Effective group of the process |
+| `process.ancestors.envs` | string | Environment variables of the process |
+| `process.ancestors.envs_truncated` | bool | Indicator of environment variables truncation |
 | `process.ancestors.euid` | int | Effective UID of the process |
 | `process.ancestors.euser` | string | Effective user of the process |
 | `process.ancestors.file.change_time` | int | Change time of the file |
@@ -164,6 +171,11 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | `process.ancestors.tty_name` | string | Name of the TTY associated with the process |
 | `process.ancestors.uid` | int | UID of the process |
 | `process.ancestors.user` | string | User of the process |
+| `process.args` | string | Arguments of the process (as a string) |
+| `process.args_flags` | string | Arguments of the process (as an array) |
+| `process.args_options` | string | Arguments of the process (as an array) |
+| `process.args_truncated` | bool | Indicator of arguments truncation |
+| `process.argv` | string | Arguments of the process (as an array) |
 | `process.cap_effective` | int | Effective capability set of the process |
 | `process.cap_permitted` | int | Permitted capability set of the process |
 | `process.comm` | string | Comm attribute of the process |
@@ -172,6 +184,8 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 | `process.created_at` | int | Timestamp of the creation of the process |
 | `process.egid` | int | Effective GID of the process |
 | `process.egroup` | string | Effective group of the process |
+| `process.envs` | string | Environment variables of the process |
+| `process.envs_truncated` | bool | Indicator of environment variables truncation |
 | `process.euid` | int | Effective UID of the process |
 | `process.euser` | string | Effective user of the process |
 | `process.file.change_time` | int | Change time of the file |

--- a/docs/cloud-workload-security/secl.json
+++ b/docs/cloud-workload-security/secl.json
@@ -17,6 +17,31 @@
           "definition": "Tags of the container"
         },
         {
+          "name": "process.ancestors.args",
+          "type": "string",
+          "definition": "Arguments of the process (as a string)"
+        },
+        {
+          "name": "process.ancestors.args_flags",
+          "type": "string",
+          "definition": "Arguments of the process (as an array)"
+        },
+        {
+          "name": "process.ancestors.args_options",
+          "type": "string",
+          "definition": "Arguments of the process (as an array)"
+        },
+        {
+          "name": "process.ancestors.args_truncated",
+          "type": "bool",
+          "definition": "Indicator of arguments truncation"
+        },
+        {
+          "name": "process.ancestors.argv",
+          "type": "string",
+          "definition": "Arguments of the process (as an array)"
+        },
+        {
           "name": "process.ancestors.cap_effective",
           "type": "int",
           "definition": "Effective capability set of the process"
@@ -55,6 +80,16 @@
           "name": "process.ancestors.egroup",
           "type": "string",
           "definition": "Effective group of the process"
+        },
+        {
+          "name": "process.ancestors.envs",
+          "type": "string",
+          "definition": "Environment variables of the process"
+        },
+        {
+          "name": "process.ancestors.envs_truncated",
+          "type": "bool",
+          "definition": "Indicator of environment variables truncation"
         },
         {
           "name": "process.ancestors.euid",
@@ -197,6 +232,31 @@
           "definition": "User of the process"
         },
         {
+          "name": "process.args",
+          "type": "string",
+          "definition": "Arguments of the process (as a string)"
+        },
+        {
+          "name": "process.args_flags",
+          "type": "string",
+          "definition": "Arguments of the process (as an array)"
+        },
+        {
+          "name": "process.args_options",
+          "type": "string",
+          "definition": "Arguments of the process (as an array)"
+        },
+        {
+          "name": "process.args_truncated",
+          "type": "bool",
+          "definition": "Indicator of arguments truncation"
+        },
+        {
+          "name": "process.argv",
+          "type": "string",
+          "definition": "Arguments of the process (as an array)"
+        },
+        {
           "name": "process.cap_effective",
           "type": "int",
           "definition": "Effective capability set of the process"
@@ -235,6 +295,16 @@
           "name": "process.egroup",
           "type": "string",
           "definition": "Effective group of the process"
+        },
+        {
+          "name": "process.envs",
+          "type": "string",
+          "definition": "Environment variables of the process"
+        },
+        {
+          "name": "process.envs_truncated",
+          "type": "bool",
+          "definition": "Indicator of environment variables truncation"
         },
         {
           "name": "process.euid",

--- a/pkg/security/probe/accessors.go
+++ b/pkg/security/probe/accessors.go
@@ -518,17 +518,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 				return (*Event)(ctx.Object).ResolveContainerTags(&(*Event)(ctx.Object).ContainerContext)
 			},
 			Field:  field,
-			Weight: 9999,
+			Weight: 9999 * eval.HandlerWeight,
 		}, nil
 
 	case "exec.args":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).ResolveExecArgs(&(*Event)(ctx.Object).Exec)
+				return (*Event)(ctx.Object).ResolveProcessArgs(&(*Event)(ctx.Object).Exec.Process)
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: 100 * eval.HandlerWeight,
 		}, nil
 
 	case "exec.args_flags":
@@ -536,7 +536,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			EvalFnc: func(ctx *eval.Context) []string {
 
-				return (*Event)(ctx.Object).ResolveExecArgsFlags(&(*Event)(ctx.Object).Exec)
+				return (*Event)(ctx.Object).ResolveProcessArgsFlags(&(*Event)(ctx.Object).Exec.Process)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -547,7 +547,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			EvalFnc: func(ctx *eval.Context) []string {
 
-				return (*Event)(ctx.Object).ResolveExecArgsOptions(&(*Event)(ctx.Object).Exec)
+				return (*Event)(ctx.Object).ResolveProcessArgsOptions(&(*Event)(ctx.Object).Exec.Process)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -557,7 +557,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).ResolveExecArgsTruncated(&(*Event)(ctx.Object).Exec)
+				return (*Event)(ctx.Object).ResolveProcessArgsTruncated(&(*Event)(ctx.Object).Exec.Process)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -568,7 +568,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			EvalFnc: func(ctx *eval.Context) []string {
 
-				return (*Event)(ctx.Object).ResolveExecArgv(&(*Event)(ctx.Object).Exec)
+				return (*Event)(ctx.Object).ResolveProcessArgv(&(*Event)(ctx.Object).Exec.Process)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -659,17 +659,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			EvalFnc: func(ctx *eval.Context) []string {
 
-				return (*Event)(ctx.Object).ResolveExecEnvs(&(*Event)(ctx.Object).Exec)
+				return (*Event)(ctx.Object).ResolveProcessEnvs(&(*Event)(ctx.Object).Exec.Process)
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: 100 * eval.HandlerWeight,
 		}, nil
 
 	case "exec.envs_truncated":
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).ResolveExecEnvsTruncated(&(*Event)(ctx.Object).Exec)
+				return (*Event)(ctx.Object).ResolveProcessEnvsTruncated(&(*Event)(ctx.Object).Exec.Process)
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1585,6 +1585,164 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "process.ancestors.args":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				if ptr := ctx.Cache[field]; ptr != nil {
+					if result := (*[]string)(ptr); result != nil {
+						return *result
+					}
+				}
+				var results []string
+
+				iterator := &model.ProcessAncestorsIterator{}
+
+				value := iterator.Front(ctx)
+				for value != nil {
+					var result string
+
+					element := (*model.ProcessCacheEntry)(value)
+
+					result = (*Event)(ctx.Object).ResolveProcessArgs(&element.Process)
+
+					results = append(results, result)
+
+					value = iterator.Next()
+				}
+				ctx.Cache[field] = unsafe.Pointer(&results)
+
+				return results
+			}, Field: field,
+			Weight: 100 * eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.args_flags":
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
+				if ptr := ctx.Cache[field]; ptr != nil {
+					if result := (*[]string)(ptr); result != nil {
+						return *result
+					}
+				}
+				var results []string
+
+				iterator := &model.ProcessAncestorsIterator{}
+
+				value := iterator.Front(ctx)
+				for value != nil {
+					var result []string
+
+					element := (*model.ProcessCacheEntry)(value)
+
+					result = (*Event)(ctx.Object).ResolveProcessArgsFlags(&element.Process)
+
+					results = append(results, result...)
+
+					value = iterator.Next()
+				}
+				ctx.Cache[field] = unsafe.Pointer(&results)
+
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.args_options":
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
+				if ptr := ctx.Cache[field]; ptr != nil {
+					if result := (*[]string)(ptr); result != nil {
+						return *result
+					}
+				}
+				var results []string
+
+				iterator := &model.ProcessAncestorsIterator{}
+
+				value := iterator.Front(ctx)
+				for value != nil {
+					var result []string
+
+					element := (*model.ProcessCacheEntry)(value)
+
+					result = (*Event)(ctx.Object).ResolveProcessArgsOptions(&element.Process)
+
+					results = append(results, result...)
+
+					value = iterator.Next()
+				}
+				ctx.Cache[field] = unsafe.Pointer(&results)
+
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.args_truncated":
+		return &eval.BoolArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []bool {
+				if ptr := ctx.Cache[field]; ptr != nil {
+					if result := (*[]bool)(ptr); result != nil {
+						return *result
+					}
+				}
+				var results []bool
+
+				iterator := &model.ProcessAncestorsIterator{}
+
+				value := iterator.Front(ctx)
+				for value != nil {
+					var result bool
+
+					element := (*model.ProcessCacheEntry)(value)
+
+					result = (*Event)(ctx.Object).ResolveProcessArgsTruncated(&element.Process)
+
+					results = append(results, result)
+
+					value = iterator.Next()
+				}
+				ctx.Cache[field] = unsafe.Pointer(&results)
+
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.argv":
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
+				if ptr := ctx.Cache[field]; ptr != nil {
+					if result := (*[]string)(ptr); result != nil {
+						return *result
+					}
+				}
+				var results []string
+
+				iterator := &model.ProcessAncestorsIterator{}
+
+				value := iterator.Front(ctx)
+				for value != nil {
+					var result []string
+
+					element := (*model.ProcessCacheEntry)(value)
+
+					result = (*Event)(ctx.Object).ResolveProcessArgv(&element.Process)
+
+					results = append(results, result...)
+
+					value = iterator.Next()
+				}
+				ctx.Cache[field] = unsafe.Pointer(&results)
+
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+
 	case "process.ancestors.cap_effective":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
@@ -1821,6 +1979,69 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					element := (*model.ProcessCacheEntry)(value)
 
 					result = element.ProcessContext.Process.Credentials.EGroup
+
+					results = append(results, result)
+
+					value = iterator.Next()
+				}
+				ctx.Cache[field] = unsafe.Pointer(&results)
+
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.envs":
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
+				if ptr := ctx.Cache[field]; ptr != nil {
+					if result := (*[]string)(ptr); result != nil {
+						return *result
+					}
+				}
+				var results []string
+
+				iterator := &model.ProcessAncestorsIterator{}
+
+				value := iterator.Front(ctx)
+				for value != nil {
+					var result []string
+
+					element := (*model.ProcessCacheEntry)(value)
+
+					result = (*Event)(ctx.Object).ResolveProcessEnvs(&element.Process)
+
+					results = append(results, result...)
+
+					value = iterator.Next()
+				}
+				ctx.Cache[field] = unsafe.Pointer(&results)
+
+				return results
+			}, Field: field,
+			Weight: 100 * eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.envs_truncated":
+		return &eval.BoolArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []bool {
+				if ptr := ctx.Cache[field]; ptr != nil {
+					if result := (*[]bool)(ptr); result != nil {
+						return *result
+					}
+				}
+				var results []bool
+
+				iterator := &model.ProcessAncestorsIterator{}
+
+				value := iterator.Front(ctx)
+				for value != nil {
+					var result bool
+
+					element := (*model.ProcessCacheEntry)(value)
+
+					result = (*Event)(ctx.Object).ResolveProcessEnvsTruncated(&element.Process)
 
 					results = append(results, result)
 
@@ -2701,6 +2922,59 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.IteratorWeight,
 		}, nil
 
+	case "process.args":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ResolveProcessArgs(&(*Event)(ctx.Object).ProcessContext.Process)
+			},
+			Field:  field,
+			Weight: 100 * eval.HandlerWeight,
+		}, nil
+
+	case "process.args_flags":
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
+
+				return (*Event)(ctx.Object).ResolveProcessArgsFlags(&(*Event)(ctx.Object).ProcessContext.Process)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "process.args_options":
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
+
+				return (*Event)(ctx.Object).ResolveProcessArgsOptions(&(*Event)(ctx.Object).ProcessContext.Process)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "process.args_truncated":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).ResolveProcessArgsTruncated(&(*Event)(ctx.Object).ProcessContext.Process)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "process.argv":
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
+
+				return (*Event)(ctx.Object).ResolveProcessArgv(&(*Event)(ctx.Object).ProcessContext.Process)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "process.cap_effective":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -2779,6 +3053,27 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "process.envs":
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
+
+				return (*Event)(ctx.Object).ResolveProcessEnvs(&(*Event)(ctx.Object).ProcessContext.Process)
+			},
+			Field:  field,
+			Weight: 100 * eval.HandlerWeight,
+		}, nil
+
+	case "process.envs_truncated":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).ResolveProcessEnvsTruncated(&(*Event)(ctx.Object).ProcessContext.Process)
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "process.euid":
@@ -4611,6 +4906,16 @@ func (e *Event) GetFields() []eval.Field {
 
 		"open.retval",
 
+		"process.ancestors.args",
+
+		"process.ancestors.args_flags",
+
+		"process.ancestors.args_options",
+
+		"process.ancestors.args_truncated",
+
+		"process.ancestors.argv",
+
 		"process.ancestors.cap_effective",
 
 		"process.ancestors.cap_permitted",
@@ -4626,6 +4931,10 @@ func (e *Event) GetFields() []eval.Field {
 		"process.ancestors.egid",
 
 		"process.ancestors.egroup",
+
+		"process.ancestors.envs",
+
+		"process.ancestors.envs_truncated",
 
 		"process.ancestors.euid",
 
@@ -4683,6 +4992,16 @@ func (e *Event) GetFields() []eval.Field {
 
 		"process.ancestors.user",
 
+		"process.args",
+
+		"process.args_flags",
+
+		"process.args_options",
+
+		"process.args_truncated",
+
+		"process.argv",
+
 		"process.cap_effective",
 
 		"process.cap_permitted",
@@ -4698,6 +5017,10 @@ func (e *Event) GetFields() []eval.Field {
 		"process.egid",
 
 		"process.egroup",
+
+		"process.envs",
+
+		"process.envs_truncated",
 
 		"process.euid",
 
@@ -5190,23 +5513,23 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "exec.args":
 
-		return e.ResolveExecArgs(&e.Exec), nil
+		return e.ResolveProcessArgs(&e.Exec.Process), nil
 
 	case "exec.args_flags":
 
-		return e.ResolveExecArgsFlags(&e.Exec), nil
+		return e.ResolveProcessArgsFlags(&e.Exec.Process), nil
 
 	case "exec.args_options":
 
-		return e.ResolveExecArgsOptions(&e.Exec), nil
+		return e.ResolveProcessArgsOptions(&e.Exec.Process), nil
 
 	case "exec.args_truncated":
 
-		return e.ResolveExecArgsTruncated(&e.Exec), nil
+		return e.ResolveProcessArgsTruncated(&e.Exec.Process), nil
 
 	case "exec.argv":
 
-		return e.ResolveExecArgv(&e.Exec), nil
+		return e.ResolveProcessArgv(&e.Exec.Process), nil
 
 	case "exec.cap_effective":
 
@@ -5242,11 +5565,11 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "exec.envs":
 
-		return e.ResolveExecEnvs(&e.Exec), nil
+		return e.ResolveProcessEnvs(&e.Exec.Process), nil
 
 	case "exec.envs_truncated":
 
-		return e.ResolveExecEnvsTruncated(&e.Exec), nil
+		return e.ResolveProcessEnvsTruncated(&e.Exec.Process), nil
 
 	case "exec.euid":
 
@@ -5612,6 +5935,116 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.Open.SyscallEvent.Retval), nil
 
+	case "process.ancestors.args":
+
+		var values []string
+
+		ctx := eval.NewContext(unsafe.Pointer(e))
+
+		iterator := &model.ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*model.ProcessCacheEntry)(ptr)
+
+			result := (*Event)(ctx.Object).ResolveProcessArgs(&element.Process)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.args_flags":
+
+		var values []string
+
+		ctx := eval.NewContext(unsafe.Pointer(e))
+
+		iterator := &model.ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*model.ProcessCacheEntry)(ptr)
+
+			result := (*Event)(ctx.Object).ResolveProcessArgsFlags(&element.Process)
+
+			values = append(values, result...)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.args_options":
+
+		var values []string
+
+		ctx := eval.NewContext(unsafe.Pointer(e))
+
+		iterator := &model.ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*model.ProcessCacheEntry)(ptr)
+
+			result := (*Event)(ctx.Object).ResolveProcessArgsOptions(&element.Process)
+
+			values = append(values, result...)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.args_truncated":
+
+		var values []bool
+
+		ctx := eval.NewContext(unsafe.Pointer(e))
+
+		iterator := &model.ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*model.ProcessCacheEntry)(ptr)
+
+			result := (*Event)(ctx.Object).ResolveProcessArgsTruncated(&element.Process)
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.argv":
+
+		var values []string
+
+		ctx := eval.NewContext(unsafe.Pointer(e))
+
+		iterator := &model.ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*model.ProcessCacheEntry)(ptr)
+
+			result := (*Event)(ctx.Object).ResolveProcessArgv(&element.Process)
+
+			values = append(values, result...)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
 	case "process.ancestors.cap_effective":
 
 		var values []int
@@ -5780,6 +6213,50 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 			element := (*model.ProcessCacheEntry)(ptr)
 
 			result := element.ProcessContext.Process.Credentials.EGroup
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.envs":
+
+		var values []string
+
+		ctx := eval.NewContext(unsafe.Pointer(e))
+
+		iterator := &model.ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*model.ProcessCacheEntry)(ptr)
+
+			result := (*Event)(ctx.Object).ResolveProcessEnvs(&element.Process)
+
+			values = append(values, result...)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.envs_truncated":
+
+		var values []bool
+
+		ctx := eval.NewContext(unsafe.Pointer(e))
+
+		iterator := &model.ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*model.ProcessCacheEntry)(ptr)
+
+			result := (*Event)(ctx.Object).ResolveProcessEnvsTruncated(&element.Process)
 
 			values = append(values, result)
 
@@ -6404,6 +6881,26 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return values, nil
 
+	case "process.args":
+
+		return e.ResolveProcessArgs(&e.ProcessContext.Process), nil
+
+	case "process.args_flags":
+
+		return e.ResolveProcessArgsFlags(&e.ProcessContext.Process), nil
+
+	case "process.args_options":
+
+		return e.ResolveProcessArgsOptions(&e.ProcessContext.Process), nil
+
+	case "process.args_truncated":
+
+		return e.ResolveProcessArgsTruncated(&e.ProcessContext.Process), nil
+
+	case "process.argv":
+
+		return e.ResolveProcessArgv(&e.ProcessContext.Process), nil
+
 	case "process.cap_effective":
 
 		return int(e.ProcessContext.Process.Credentials.CapEffective), nil
@@ -6435,6 +6932,14 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "process.egroup":
 
 		return e.ProcessContext.Process.Credentials.EGroup, nil
+
+	case "process.envs":
+
+		return e.ResolveProcessEnvs(&e.ProcessContext.Process), nil
+
+	case "process.envs_truncated":
+
+		return e.ResolveProcessEnvsTruncated(&e.ProcessContext.Process), nil
 
 	case "process.euid":
 
@@ -7505,6 +8010,21 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "open.retval":
 		return "open", nil
 
+	case "process.ancestors.args":
+		return "*", nil
+
+	case "process.ancestors.args_flags":
+		return "*", nil
+
+	case "process.ancestors.args_options":
+		return "*", nil
+
+	case "process.ancestors.args_truncated":
+		return "*", nil
+
+	case "process.ancestors.argv":
+		return "*", nil
+
 	case "process.ancestors.cap_effective":
 		return "*", nil
 
@@ -7527,6 +8047,12 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 
 	case "process.ancestors.egroup":
+		return "*", nil
+
+	case "process.ancestors.envs":
+		return "*", nil
+
+	case "process.ancestors.envs_truncated":
 		return "*", nil
 
 	case "process.ancestors.euid":
@@ -7613,6 +8139,21 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "process.ancestors.user":
 		return "*", nil
 
+	case "process.args":
+		return "*", nil
+
+	case "process.args_flags":
+		return "*", nil
+
+	case "process.args_options":
+		return "*", nil
+
+	case "process.args_truncated":
+		return "*", nil
+
+	case "process.argv":
+		return "*", nil
+
 	case "process.cap_effective":
 		return "*", nil
 
@@ -7635,6 +8176,12 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 
 	case "process.egroup":
+		return "*", nil
+
+	case "process.envs":
+		return "*", nil
+
+	case "process.envs_truncated":
 		return "*", nil
 
 	case "process.euid":
@@ -8705,6 +9252,26 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "process.ancestors.args":
+
+		return reflect.String, nil
+
+	case "process.ancestors.args_flags":
+
+		return reflect.String, nil
+
+	case "process.ancestors.args_options":
+
+		return reflect.String, nil
+
+	case "process.ancestors.args_truncated":
+
+		return reflect.Bool, nil
+
+	case "process.ancestors.argv":
+
+		return reflect.String, nil
+
 	case "process.ancestors.cap_effective":
 
 		return reflect.Int, nil
@@ -8736,6 +9303,14 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "process.ancestors.egroup":
 
 		return reflect.String, nil
+
+	case "process.ancestors.envs":
+
+		return reflect.String, nil
+
+	case "process.ancestors.envs_truncated":
+
+		return reflect.Bool, nil
 
 	case "process.ancestors.euid":
 
@@ -8849,6 +9424,26 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "process.args":
+
+		return reflect.String, nil
+
+	case "process.args_flags":
+
+		return reflect.String, nil
+
+	case "process.args_options":
+
+		return reflect.String, nil
+
+	case "process.args_truncated":
+
+		return reflect.Bool, nil
+
+	case "process.argv":
+
+		return reflect.String, nil
+
 	case "process.cap_effective":
 
 		return reflect.Int, nil
@@ -8880,6 +9475,14 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "process.egroup":
 
 		return reflect.String, nil
+
+	case "process.envs":
+
+		return reflect.String, nil
+
+	case "process.envs_truncated":
+
+		return reflect.Bool, nil
 
 	case "process.euid":
 
@@ -9991,9 +10594,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Args"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.Args"}
 		}
-		e.Exec.Args = str
+		e.Exec.Process.Args = str
 
 		return nil
 
@@ -10002,9 +10605,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Argv"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.Argv"}
 		}
-		e.Exec.Argv = append(e.Exec.Argv, str)
+		e.Exec.Process.Argv = append(e.Exec.Process.Argv, str)
 
 		return nil
 
@@ -10013,17 +10616,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Argv"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.Argv"}
 		}
-		e.Exec.Argv = append(e.Exec.Argv, str)
+		e.Exec.Process.Argv = append(e.Exec.Process.Argv, str)
 
 		return nil
 
 	case "exec.args_truncated":
 
 		var ok bool
-		if e.Exec.ArgsTruncated, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.ArgsTruncated"}
+		if e.Exec.Process.ArgsTruncated, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.ArgsTruncated"}
 		}
 		return nil
 
@@ -10032,9 +10635,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Argv"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.Argv"}
 		}
-		e.Exec.Argv = append(e.Exec.Argv, str)
+		e.Exec.Process.Argv = append(e.Exec.Process.Argv, str)
 
 		return nil
 
@@ -10131,17 +10734,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Envs"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.Envs"}
 		}
-		e.Exec.Envs = append(e.Exec.Envs, str)
+		e.Exec.Process.Envs = append(e.Exec.Process.Envs, str)
 
 		return nil
 
 	case "exec.envs_truncated":
 
 		var ok bool
-		if e.Exec.EnvsTruncated, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.EnvsTruncated"}
+		if e.Exec.Process.EnvsTruncated, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.EnvsTruncated"}
 		}
 		return nil
 
@@ -11131,6 +11734,78 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "process.ancestors.args":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &model.ProcessCacheEntry{}
+		}
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.Args"}
+		}
+		e.ProcessContext.Ancestor.ProcessContext.Process.Args = str
+
+		return nil
+
+	case "process.ancestors.args_flags":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &model.ProcessCacheEntry{}
+		}
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.Argv"}
+		}
+		e.ProcessContext.Ancestor.ProcessContext.Process.Argv = append(e.ProcessContext.Ancestor.ProcessContext.Process.Argv, str)
+
+		return nil
+
+	case "process.ancestors.args_options":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &model.ProcessCacheEntry{}
+		}
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.Argv"}
+		}
+		e.ProcessContext.Ancestor.ProcessContext.Process.Argv = append(e.ProcessContext.Ancestor.ProcessContext.Process.Argv, str)
+
+		return nil
+
+	case "process.ancestors.args_truncated":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &model.ProcessCacheEntry{}
+		}
+
+		var ok bool
+		if e.ProcessContext.Ancestor.ProcessContext.Process.ArgsTruncated, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.ArgsTruncated"}
+		}
+		return nil
+
+	case "process.ancestors.argv":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &model.ProcessCacheEntry{}
+		}
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.Argv"}
+		}
+		e.ProcessContext.Ancestor.ProcessContext.Process.Argv = append(e.ProcessContext.Ancestor.ProcessContext.Process.Argv, str)
+
+		return nil
+
 	case "process.ancestors.cap_effective":
 
 		if e.ProcessContext.Ancestor == nil {
@@ -11249,6 +11924,33 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.ProcessContext.Ancestor.ProcessContext.Process.Credentials.EGroup = str
 
+		return nil
+
+	case "process.ancestors.envs":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &model.ProcessCacheEntry{}
+		}
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.Envs"}
+		}
+		e.ProcessContext.Ancestor.ProcessContext.Process.Envs = append(e.ProcessContext.Ancestor.ProcessContext.Process.Envs, str)
+
+		return nil
+
+	case "process.ancestors.envs_truncated":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &model.ProcessCacheEntry{}
+		}
+
+		var ok bool
+		if e.ProcessContext.Ancestor.ProcessContext.Process.EnvsTruncated, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.EnvsTruncated"}
+		}
 		return nil
 
 	case "process.ancestors.euid":
@@ -11668,6 +12370,58 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "process.args":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.Args"}
+		}
+		e.ProcessContext.Process.Args = str
+
+		return nil
+
+	case "process.args_flags":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.Argv"}
+		}
+		e.ProcessContext.Process.Argv = append(e.ProcessContext.Process.Argv, str)
+
+		return nil
+
+	case "process.args_options":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.Argv"}
+		}
+		e.ProcessContext.Process.Argv = append(e.ProcessContext.Process.Argv, str)
+
+		return nil
+
+	case "process.args_truncated":
+
+		var ok bool
+		if e.ProcessContext.Process.ArgsTruncated, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.ArgsTruncated"}
+		}
+		return nil
+
+	case "process.argv":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.Argv"}
+		}
+		e.ProcessContext.Process.Argv = append(e.ProcessContext.Process.Argv, str)
+
+		return nil
+
 	case "process.cap_effective":
 
 		var ok bool
@@ -11754,6 +12508,25 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.ProcessContext.Process.Credentials.EGroup = str
 
+		return nil
+
+	case "process.envs":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.Envs"}
+		}
+		e.ProcessContext.Process.Envs = append(e.ProcessContext.Process.Envs, str)
+
+		return nil
+
+	case "process.envs_truncated":
+
+		var ok bool
+		if e.ProcessContext.Process.EnvsTruncated, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.EnvsTruncated"}
+		}
 		return nil
 
 	case "process.euid":

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -234,31 +234,31 @@ func (ev *Event) ResolveProcessCreatedAt(e *model.Process) uint64 {
 	return uint64(e.ExecTime.UnixNano())
 }
 
-// ResolveExecArgs resolves the args of the event
-func (ev *Event) ResolveExecArgs(e *model.ExecEvent) string {
-	if ev.Exec.Args == "" {
-		ev.Exec.Args = strings.Join(ev.ResolveExecArgv(e), " ")
+// ResolveProcessArgs resolves the args of the event
+func (ev *Event) ResolveProcessArgs(process *model.Process) string {
+	if process.Args == "" {
+		process.Args = strings.Join(ev.ResolveProcessArgv(process), " ")
 	}
-	return ev.Exec.Args
+	return process.Args
 }
 
-// ResolveExecArgv resolves the args of the event as an array
-func (ev *Event) ResolveExecArgv(e *model.ExecEvent) []string {
-	if len(ev.Exec.Argv) == 0 {
-		ev.Exec.Argv, ev.Exec.ArgsTruncated = ev.resolvers.ProcessResolver.GetProcessArgv(&e.Process)
+// ResolveProcessArgv resolves the args of the event as an array
+func (ev *Event) ResolveProcessArgv(process *model.Process) []string {
+	if len(process.Argv) == 0 {
+		process.Argv, process.ArgsTruncated = ev.resolvers.ProcessResolver.GetProcessArgv(process)
 	}
-	return ev.Exec.Argv
+	return process.Argv
 }
 
-// ResolveExecArgsTruncated returns whether the args are truncated
-func (ev *Event) ResolveExecArgsTruncated(e *model.ExecEvent) bool {
-	_ = ev.ResolveExecArgs(e)
-	return ev.Exec.ArgsTruncated
+// ResolveProcessArgsTruncated returns whether the args are truncated
+func (ev *Event) ResolveProcessArgsTruncated(process *model.Process) bool {
+	_ = ev.ResolveProcessArgs(process)
+	return process.ArgsTruncated
 }
 
-// ResolveExecArgsFlags resolves the arguments flags of the event
-func (ev *Event) ResolveExecArgsFlags(e *model.ExecEvent) (flags []string) {
-	for _, arg := range ev.ResolveExecArgv(e) {
+// ResolveProcessArgsFlags resolves the arguments flags of the event
+func (ev *Event) ResolveProcessArgsFlags(process *model.Process) (flags []string) {
+	for _, arg := range ev.ResolveProcessArgv(process) {
 		if len(arg) > 1 && arg[0] == '-' {
 			isFlag := true
 			name := arg[1:]
@@ -288,9 +288,9 @@ func (ev *Event) ResolveExecArgsFlags(e *model.ExecEvent) (flags []string) {
 	return
 }
 
-// ResolveExecArgsOptions resolves the arguments options of the event
-func (ev *Event) ResolveExecArgsOptions(e *model.ExecEvent) (options []string) {
-	args := ev.ResolveExecArgv(e)
+// ResolveProcessArgsOptions resolves the arguments options of the event
+func (ev *Event) ResolveProcessArgsOptions(process *model.Process) (options []string) {
+	args := ev.ResolveProcessArgv(process)
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		if len(arg) > 1 && arg[0] == '-' {
@@ -313,25 +313,25 @@ func (ev *Event) ResolveExecArgsOptions(e *model.ExecEvent) (options []string) {
 	return
 }
 
-// ResolveExecEnvsTruncated returns whether the envs are truncated
-func (ev *Event) ResolveExecEnvsTruncated(e *model.ExecEvent) bool {
-	_ = ev.ResolveExecEnvs(e)
-	return ev.Exec.EnvsTruncated
+// ResolveProcessEnvsTruncated returns whether the envs are truncated
+func (ev *Event) ResolveProcessEnvsTruncated(process *model.Process) bool {
+	_ = ev.ResolveProcessEnvs(process)
+	return process.EnvsTruncated
 }
 
-// ResolveExecEnvs resolves the envs of the event
-func (ev *Event) ResolveExecEnvs(e *model.ExecEvent) []string {
-	if len(e.Envs) == 0 {
-		envs, truncated := ev.resolvers.ProcessResolver.GetProcessEnvs(&e.Process)
+// ResolveProcessEnvs resolves the envs of the event
+func (ev *Event) ResolveProcessEnvs(process *model.Process) []string {
+	if len(process.Envs) == 0 {
+		envs, truncated := ev.resolvers.ProcessResolver.GetProcessEnvs(process)
 		if envs != nil {
-			ev.Exec.Envs = make([]string, 0, len(envs))
+			process.Envs = make([]string, 0, len(envs))
 			for key := range envs {
-				ev.Exec.Envs = append(ev.Exec.Envs, key)
+				process.Envs = append(process.Envs, key)
 			}
-			ev.Exec.EnvsTruncated = truncated
+			process.EnvsTruncated = truncated
 		}
 	}
-	return ev.Exec.Envs
+	return process.Envs
 }
 
 // ResolveSetuidUser resolves the user of the Setuid event

--- a/pkg/security/probe/model_test.go
+++ b/pkg/security/probe/model_test.go
@@ -43,7 +43,7 @@ func TestSetFieldValue(t *testing.T) {
 	}
 }
 
-func TestExecArgsFlags(t *testing.T) {
+func TestProcessArgsFlags(t *testing.T) {
 	e := Event{
 		Event: model.Event{
 			Exec: model.ExecEvent{
@@ -65,7 +65,7 @@ func TestExecArgsFlags(t *testing.T) {
 		ProcessResolver: resolver,
 	}
 
-	flags := e.ResolveExecArgsFlags(&e.Exec)
+	flags := e.ResolveProcessArgsFlags(&e.Exec.Process)
 	sort.Strings(flags)
 
 	hasFlag := func(flags []string, flag string) bool {
@@ -102,7 +102,7 @@ func TestExecArgsFlags(t *testing.T) {
 	}
 }
 
-func TestExecArgsOptions(t *testing.T) {
+func TestProcessArgsOptions(t *testing.T) {
 	e := Event{
 		Event: model.Event{
 			Exec: model.ExecEvent{
@@ -124,7 +124,7 @@ func TestExecArgsOptions(t *testing.T) {
 		ProcessResolver: resolver,
 	}
 
-	options := e.ResolveExecArgsOptions(&e.Exec)
+	options := e.ResolveProcessArgsOptions(&e.Exec.Process)
 	sort.Strings(options)
 
 	hasOption := func(options []string, option string) bool {

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -685,8 +685,8 @@ func (p *ProcessResolver) GetScrubbedProcessArgv(pr *model.Process) ([]string, b
 		return nil, false
 	}
 
-	if len(pr.ArgsCache) != 0 {
-		return pr.ArgsCache, pr.ArgsTruncated
+	if len(pr.Args) != 0 {
+		return pr.Argv, pr.ArgsTruncated
 	}
 
 	argv, truncated := pr.ArgsEntry.ToArray()
@@ -695,15 +695,15 @@ func (p *ProcessResolver) GetScrubbedProcessArgv(pr *model.Process) ([]string, b
 
 	if p.probe.scrubber != nil {
 		if newArgv, changed := p.probe.scrubber.ScrubCommand(argv); changed {
-			pr.ArgsCache = newArgv
+			pr.Argv = newArgv
 		} else {
-			pr.ArgsCache = argv
+			pr.Argv = argv
 		}
 	} else {
-		pr.ArgsCache = argv
+		pr.Argv = argv
 	}
 
-	return pr.ArgsCache, pr.ArgsTruncated
+	return pr.Argv, pr.ArgsTruncated
 }
 
 // SetProcessEnvs set envs to cache entry

--- a/pkg/security/secl/model/accessors.go
+++ b/pkg/security/secl/model/accessors.go
@@ -515,17 +515,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 				return (*Event)(ctx.Object).ContainerContext.Tags
 			},
 			Field:  field,
-			Weight: 9999,
+			Weight: 9999 * eval.HandlerWeight,
 		}, nil
 
 	case "exec.args":
 		return &eval.StringEvaluator{
 			EvalFnc: func(ctx *eval.Context) string {
 
-				return (*Event)(ctx.Object).Exec.Args
+				return (*Event)(ctx.Object).Exec.Process.Args
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: 100 * eval.HandlerWeight,
 		}, nil
 
 	case "exec.args_flags":
@@ -533,7 +533,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			EvalFnc: func(ctx *eval.Context) []string {
 
-				return (*Event)(ctx.Object).Exec.Argv
+				return (*Event)(ctx.Object).Exec.Process.Argv
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -544,7 +544,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			EvalFnc: func(ctx *eval.Context) []string {
 
-				return (*Event)(ctx.Object).Exec.Argv
+				return (*Event)(ctx.Object).Exec.Process.Argv
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -554,7 +554,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).Exec.ArgsTruncated
+				return (*Event)(ctx.Object).Exec.Process.ArgsTruncated
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -565,7 +565,7 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			EvalFnc: func(ctx *eval.Context) []string {
 
-				return (*Event)(ctx.Object).Exec.Argv
+				return (*Event)(ctx.Object).Exec.Process.Argv
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -656,17 +656,17 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 
 			EvalFnc: func(ctx *eval.Context) []string {
 
-				return (*Event)(ctx.Object).Exec.Envs
+				return (*Event)(ctx.Object).Exec.Process.Envs
 			},
 			Field:  field,
-			Weight: eval.HandlerWeight,
+			Weight: 100 * eval.HandlerWeight,
 		}, nil
 
 	case "exec.envs_truncated":
 		return &eval.BoolEvaluator{
 			EvalFnc: func(ctx *eval.Context) bool {
 
-				return (*Event)(ctx.Object).Exec.EnvsTruncated
+				return (*Event)(ctx.Object).Exec.Process.EnvsTruncated
 			},
 			Field:  field,
 			Weight: eval.HandlerWeight,
@@ -1582,6 +1582,134 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "process.ancestors.args":
+		return &eval.StringArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []string {
+				var results []string
+
+				iterator := &ProcessAncestorsIterator{}
+
+				value := iterator.Front(ctx)
+				for value != nil {
+					var result string
+
+					element := (*ProcessCacheEntry)(value)
+
+					result = element.ProcessContext.Process.Args
+
+					results = append(results, result)
+
+					value = iterator.Next()
+				}
+
+				return results
+			}, Field: field,
+			Weight: 100 * eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.args_flags":
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
+				var results []string
+
+				iterator := &ProcessAncestorsIterator{}
+
+				value := iterator.Front(ctx)
+				for value != nil {
+					var result []string
+
+					element := (*ProcessCacheEntry)(value)
+
+					result = element.ProcessContext.Process.Argv
+
+					results = append(results, result...)
+
+					value = iterator.Next()
+				}
+
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.args_options":
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
+				var results []string
+
+				iterator := &ProcessAncestorsIterator{}
+
+				value := iterator.Front(ctx)
+				for value != nil {
+					var result []string
+
+					element := (*ProcessCacheEntry)(value)
+
+					result = element.ProcessContext.Process.Argv
+
+					results = append(results, result...)
+
+					value = iterator.Next()
+				}
+
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.args_truncated":
+		return &eval.BoolArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []bool {
+				var results []bool
+
+				iterator := &ProcessAncestorsIterator{}
+
+				value := iterator.Front(ctx)
+				for value != nil {
+					var result bool
+
+					element := (*ProcessCacheEntry)(value)
+
+					result = element.ProcessContext.Process.ArgsTruncated
+
+					results = append(results, result)
+
+					value = iterator.Next()
+				}
+
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.argv":
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
+				var results []string
+
+				iterator := &ProcessAncestorsIterator{}
+
+				value := iterator.Front(ctx)
+				for value != nil {
+					var result []string
+
+					element := (*ProcessCacheEntry)(value)
+
+					result = element.ProcessContext.Process.Argv
+
+					results = append(results, result...)
+
+					value = iterator.Next()
+				}
+
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+
 	case "process.ancestors.cap_effective":
 		return &eval.IntArrayEvaluator{
 			EvalFnc: func(ctx *eval.Context) []int {
@@ -1771,6 +1899,57 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 					element := (*ProcessCacheEntry)(value)
 
 					result = element.ProcessContext.Process.Credentials.EGroup
+
+					results = append(results, result)
+
+					value = iterator.Next()
+				}
+
+				return results
+			}, Field: field,
+			Weight: eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.envs":
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
+				var results []string
+
+				iterator := &ProcessAncestorsIterator{}
+
+				value := iterator.Front(ctx)
+				for value != nil {
+					var result []string
+
+					element := (*ProcessCacheEntry)(value)
+
+					result = element.ProcessContext.Process.Envs
+
+					results = append(results, result...)
+
+					value = iterator.Next()
+				}
+
+				return results
+			}, Field: field,
+			Weight: 100 * eval.IteratorWeight,
+		}, nil
+
+	case "process.ancestors.envs_truncated":
+		return &eval.BoolArrayEvaluator{
+			EvalFnc: func(ctx *eval.Context) []bool {
+				var results []bool
+
+				iterator := &ProcessAncestorsIterator{}
+
+				value := iterator.Front(ctx)
+				for value != nil {
+					var result bool
+
+					element := (*ProcessCacheEntry)(value)
+
+					result = element.ProcessContext.Process.EnvsTruncated
 
 					results = append(results, result)
 
@@ -2482,6 +2661,59 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.IteratorWeight,
 		}, nil
 
+	case "process.args":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).ProcessContext.Process.Args
+			},
+			Field:  field,
+			Weight: 100 * eval.HandlerWeight,
+		}, nil
+
+	case "process.args_flags":
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
+
+				return (*Event)(ctx.Object).ProcessContext.Process.Argv
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "process.args_options":
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
+
+				return (*Event)(ctx.Object).ProcessContext.Process.Argv
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "process.args_truncated":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).ProcessContext.Process.ArgsTruncated
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "process.argv":
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
+
+				return (*Event)(ctx.Object).ProcessContext.Process.Argv
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+
 	case "process.cap_effective":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -2560,6 +2792,27 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "process.envs":
+		return &eval.StringArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []string {
+
+				return (*Event)(ctx.Object).ProcessContext.Process.Envs
+			},
+			Field:  field,
+			Weight: 100 * eval.HandlerWeight,
+		}, nil
+
+	case "process.envs_truncated":
+		return &eval.BoolEvaluator{
+			EvalFnc: func(ctx *eval.Context) bool {
+
+				return (*Event)(ctx.Object).ProcessContext.Process.EnvsTruncated
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
 		}, nil
 
 	case "process.euid":
@@ -4392,6 +4645,16 @@ func (e *Event) GetFields() []eval.Field {
 
 		"open.retval",
 
+		"process.ancestors.args",
+
+		"process.ancestors.args_flags",
+
+		"process.ancestors.args_options",
+
+		"process.ancestors.args_truncated",
+
+		"process.ancestors.argv",
+
 		"process.ancestors.cap_effective",
 
 		"process.ancestors.cap_permitted",
@@ -4407,6 +4670,10 @@ func (e *Event) GetFields() []eval.Field {
 		"process.ancestors.egid",
 
 		"process.ancestors.egroup",
+
+		"process.ancestors.envs",
+
+		"process.ancestors.envs_truncated",
 
 		"process.ancestors.euid",
 
@@ -4464,6 +4731,16 @@ func (e *Event) GetFields() []eval.Field {
 
 		"process.ancestors.user",
 
+		"process.args",
+
+		"process.args_flags",
+
+		"process.args_options",
+
+		"process.args_truncated",
+
+		"process.argv",
+
 		"process.cap_effective",
 
 		"process.cap_permitted",
@@ -4479,6 +4756,10 @@ func (e *Event) GetFields() []eval.Field {
 		"process.egid",
 
 		"process.egroup",
+
+		"process.envs",
+
+		"process.envs_truncated",
 
 		"process.euid",
 
@@ -4971,23 +5252,23 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "exec.args":
 
-		return e.Exec.Args, nil
+		return e.Exec.Process.Args, nil
 
 	case "exec.args_flags":
 
-		return e.Exec.Argv, nil
+		return e.Exec.Process.Argv, nil
 
 	case "exec.args_options":
 
-		return e.Exec.Argv, nil
+		return e.Exec.Process.Argv, nil
 
 	case "exec.args_truncated":
 
-		return e.Exec.ArgsTruncated, nil
+		return e.Exec.Process.ArgsTruncated, nil
 
 	case "exec.argv":
 
-		return e.Exec.Argv, nil
+		return e.Exec.Process.Argv, nil
 
 	case "exec.cap_effective":
 
@@ -5023,11 +5304,11 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 	case "exec.envs":
 
-		return e.Exec.Envs, nil
+		return e.Exec.Process.Envs, nil
 
 	case "exec.envs_truncated":
 
-		return e.Exec.EnvsTruncated, nil
+		return e.Exec.Process.EnvsTruncated, nil
 
 	case "exec.euid":
 
@@ -5393,6 +5674,116 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.Open.SyscallEvent.Retval), nil
 
+	case "process.ancestors.args":
+
+		var values []string
+
+		ctx := eval.NewContext(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := element.ProcessContext.Process.Args
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.args_flags":
+
+		var values []string
+
+		ctx := eval.NewContext(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := element.ProcessContext.Process.Argv
+
+			values = append(values, result...)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.args_options":
+
+		var values []string
+
+		ctx := eval.NewContext(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := element.ProcessContext.Process.Argv
+
+			values = append(values, result...)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.args_truncated":
+
+		var values []bool
+
+		ctx := eval.NewContext(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := element.ProcessContext.Process.ArgsTruncated
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.argv":
+
+		var values []string
+
+		ctx := eval.NewContext(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := element.ProcessContext.Process.Argv
+
+			values = append(values, result...)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
 	case "process.ancestors.cap_effective":
 
 		var values []int
@@ -5561,6 +5952,50 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 			element := (*ProcessCacheEntry)(ptr)
 
 			result := element.ProcessContext.Process.Credentials.EGroup
+
+			values = append(values, result)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.envs":
+
+		var values []string
+
+		ctx := eval.NewContext(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := element.ProcessContext.Process.Envs
+
+			values = append(values, result...)
+
+			ptr = iterator.Next()
+		}
+
+		return values, nil
+
+	case "process.ancestors.envs_truncated":
+
+		var values []bool
+
+		ctx := eval.NewContext(unsafe.Pointer(e))
+
+		iterator := &ProcessAncestorsIterator{}
+		ptr := iterator.Front(ctx)
+
+		for ptr != nil {
+
+			element := (*ProcessCacheEntry)(ptr)
+
+			result := element.ProcessContext.Process.EnvsTruncated
 
 			values = append(values, result)
 
@@ -6185,6 +6620,26 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return values, nil
 
+	case "process.args":
+
+		return e.ProcessContext.Process.Args, nil
+
+	case "process.args_flags":
+
+		return e.ProcessContext.Process.Argv, nil
+
+	case "process.args_options":
+
+		return e.ProcessContext.Process.Argv, nil
+
+	case "process.args_truncated":
+
+		return e.ProcessContext.Process.ArgsTruncated, nil
+
+	case "process.argv":
+
+		return e.ProcessContext.Process.Argv, nil
+
 	case "process.cap_effective":
 
 		return int(e.ProcessContext.Process.Credentials.CapEffective), nil
@@ -6216,6 +6671,14 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "process.egroup":
 
 		return e.ProcessContext.Process.Credentials.EGroup, nil
+
+	case "process.envs":
+
+		return e.ProcessContext.Process.Envs, nil
+
+	case "process.envs_truncated":
+
+		return e.ProcessContext.Process.EnvsTruncated, nil
 
 	case "process.euid":
 
@@ -7286,6 +7749,21 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "open.retval":
 		return "open", nil
 
+	case "process.ancestors.args":
+		return "*", nil
+
+	case "process.ancestors.args_flags":
+		return "*", nil
+
+	case "process.ancestors.args_options":
+		return "*", nil
+
+	case "process.ancestors.args_truncated":
+		return "*", nil
+
+	case "process.ancestors.argv":
+		return "*", nil
+
 	case "process.ancestors.cap_effective":
 		return "*", nil
 
@@ -7308,6 +7786,12 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 
 	case "process.ancestors.egroup":
+		return "*", nil
+
+	case "process.ancestors.envs":
+		return "*", nil
+
+	case "process.ancestors.envs_truncated":
 		return "*", nil
 
 	case "process.ancestors.euid":
@@ -7394,6 +7878,21 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "process.ancestors.user":
 		return "*", nil
 
+	case "process.args":
+		return "*", nil
+
+	case "process.args_flags":
+		return "*", nil
+
+	case "process.args_options":
+		return "*", nil
+
+	case "process.args_truncated":
+		return "*", nil
+
+	case "process.argv":
+		return "*", nil
+
 	case "process.cap_effective":
 		return "*", nil
 
@@ -7416,6 +7915,12 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 		return "*", nil
 
 	case "process.egroup":
+		return "*", nil
+
+	case "process.envs":
+		return "*", nil
+
+	case "process.envs_truncated":
 		return "*", nil
 
 	case "process.euid":
@@ -8486,6 +8991,26 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "process.ancestors.args":
+
+		return reflect.String, nil
+
+	case "process.ancestors.args_flags":
+
+		return reflect.String, nil
+
+	case "process.ancestors.args_options":
+
+		return reflect.String, nil
+
+	case "process.ancestors.args_truncated":
+
+		return reflect.Bool, nil
+
+	case "process.ancestors.argv":
+
+		return reflect.String, nil
+
 	case "process.ancestors.cap_effective":
 
 		return reflect.Int, nil
@@ -8517,6 +9042,14 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "process.ancestors.egroup":
 
 		return reflect.String, nil
+
+	case "process.ancestors.envs":
+
+		return reflect.String, nil
+
+	case "process.ancestors.envs_truncated":
+
+		return reflect.Bool, nil
 
 	case "process.ancestors.euid":
 
@@ -8630,6 +9163,26 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.String, nil
 
+	case "process.args":
+
+		return reflect.String, nil
+
+	case "process.args_flags":
+
+		return reflect.String, nil
+
+	case "process.args_options":
+
+		return reflect.String, nil
+
+	case "process.args_truncated":
+
+		return reflect.Bool, nil
+
+	case "process.argv":
+
+		return reflect.String, nil
+
 	case "process.cap_effective":
 
 		return reflect.Int, nil
@@ -8661,6 +9214,14 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "process.egroup":
 
 		return reflect.String, nil
+
+	case "process.envs":
+
+		return reflect.String, nil
+
+	case "process.envs_truncated":
+
+		return reflect.Bool, nil
 
 	case "process.euid":
 
@@ -9772,9 +10333,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Args"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.Args"}
 		}
-		e.Exec.Args = str
+		e.Exec.Process.Args = str
 
 		return nil
 
@@ -9783,9 +10344,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Argv"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.Argv"}
 		}
-		e.Exec.Argv = append(e.Exec.Argv, str)
+		e.Exec.Process.Argv = append(e.Exec.Process.Argv, str)
 
 		return nil
 
@@ -9794,17 +10355,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Argv"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.Argv"}
 		}
-		e.Exec.Argv = append(e.Exec.Argv, str)
+		e.Exec.Process.Argv = append(e.Exec.Process.Argv, str)
 
 		return nil
 
 	case "exec.args_truncated":
 
 		var ok bool
-		if e.Exec.ArgsTruncated, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.ArgsTruncated"}
+		if e.Exec.Process.ArgsTruncated, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.ArgsTruncated"}
 		}
 		return nil
 
@@ -9813,9 +10374,9 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Argv"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.Argv"}
 		}
-		e.Exec.Argv = append(e.Exec.Argv, str)
+		e.Exec.Process.Argv = append(e.Exec.Process.Argv, str)
 
 		return nil
 
@@ -9912,17 +10473,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		var ok bool
 		str, ok := value.(string)
 		if !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.Envs"}
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.Envs"}
 		}
-		e.Exec.Envs = append(e.Exec.Envs, str)
+		e.Exec.Process.Envs = append(e.Exec.Process.Envs, str)
 
 		return nil
 
 	case "exec.envs_truncated":
 
 		var ok bool
-		if e.Exec.EnvsTruncated, ok = value.(bool); !ok {
-			return &eval.ErrValueTypeMismatch{Field: "Exec.EnvsTruncated"}
+		if e.Exec.Process.EnvsTruncated, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "Exec.Process.EnvsTruncated"}
 		}
 		return nil
 
@@ -10912,6 +11473,78 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "process.ancestors.args":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.Args"}
+		}
+		e.ProcessContext.Ancestor.ProcessContext.Process.Args = str
+
+		return nil
+
+	case "process.ancestors.args_flags":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.Argv"}
+		}
+		e.ProcessContext.Ancestor.ProcessContext.Process.Argv = append(e.ProcessContext.Ancestor.ProcessContext.Process.Argv, str)
+
+		return nil
+
+	case "process.ancestors.args_options":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.Argv"}
+		}
+		e.ProcessContext.Ancestor.ProcessContext.Process.Argv = append(e.ProcessContext.Ancestor.ProcessContext.Process.Argv, str)
+
+		return nil
+
+	case "process.ancestors.args_truncated":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+
+		var ok bool
+		if e.ProcessContext.Ancestor.ProcessContext.Process.ArgsTruncated, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.ArgsTruncated"}
+		}
+		return nil
+
+	case "process.ancestors.argv":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.Argv"}
+		}
+		e.ProcessContext.Ancestor.ProcessContext.Process.Argv = append(e.ProcessContext.Ancestor.ProcessContext.Process.Argv, str)
+
+		return nil
+
 	case "process.ancestors.cap_effective":
 
 		if e.ProcessContext.Ancestor == nil {
@@ -11030,6 +11663,33 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.ProcessContext.Ancestor.ProcessContext.Process.Credentials.EGroup = str
 
+		return nil
+
+	case "process.ancestors.envs":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.Envs"}
+		}
+		e.ProcessContext.Ancestor.ProcessContext.Process.Envs = append(e.ProcessContext.Ancestor.ProcessContext.Process.Envs, str)
+
+		return nil
+
+	case "process.ancestors.envs_truncated":
+
+		if e.ProcessContext.Ancestor == nil {
+			e.ProcessContext.Ancestor = &ProcessCacheEntry{}
+		}
+
+		var ok bool
+		if e.ProcessContext.Ancestor.ProcessContext.Process.EnvsTruncated, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Ancestor.ProcessContext.Process.EnvsTruncated"}
+		}
 		return nil
 
 	case "process.ancestors.euid":
@@ -11449,6 +12109,58 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "process.args":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.Args"}
+		}
+		e.ProcessContext.Process.Args = str
+
+		return nil
+
+	case "process.args_flags":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.Argv"}
+		}
+		e.ProcessContext.Process.Argv = append(e.ProcessContext.Process.Argv, str)
+
+		return nil
+
+	case "process.args_options":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.Argv"}
+		}
+		e.ProcessContext.Process.Argv = append(e.ProcessContext.Process.Argv, str)
+
+		return nil
+
+	case "process.args_truncated":
+
+		var ok bool
+		if e.ProcessContext.Process.ArgsTruncated, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.ArgsTruncated"}
+		}
+		return nil
+
+	case "process.argv":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.Argv"}
+		}
+		e.ProcessContext.Process.Argv = append(e.ProcessContext.Process.Argv, str)
+
+		return nil
+
 	case "process.cap_effective":
 
 		var ok bool
@@ -11535,6 +12247,25 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		}
 		e.ProcessContext.Process.Credentials.EGroup = str
 
+		return nil
+
+	case "process.envs":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.Envs"}
+		}
+		e.ProcessContext.Process.Envs = append(e.ProcessContext.Process.Envs, str)
+
+		return nil
+
+	case "process.envs_truncated":
+
+		var ok bool
+		if e.ProcessContext.Process.EnvsTruncated, ok = value.(bool); !ok {
+			return &eval.ErrValueTypeMismatch{Field: "ProcessContext.Process.EnvsTruncated"}
+		}
 		return nil
 
 	case "process.euid":

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -268,11 +268,12 @@ type Process struct {
 	ArgsEntry *ArgsEntry `field:"-"`
 	EnvsEntry *EnvsEntry `field:"-"`
 
-	EnvsTruncated bool `field:"-"`
-	ArgsTruncated bool `field:"-"`
-
-	EnvsCache []string `field:"-"` // used as cache
-	ArgsCache []string `field:"-"` // used as cache
+	// defined to generate accessors
+	Args          string   `field:"args,ResolveProcessArgs:100"`                                                                                           // Arguments of the process (as a string)
+	Argv          []string `field:"argv,ResolveProcessArgv:100" field:"args_flags,ResolveProcessArgsFlags" field:"args_options,ResolveProcessArgsOptions"` // Arguments of the process (as an array)
+	ArgsTruncated bool     `field:"args_truncated,ResolveProcessArgsTruncated"`                                                                            // Indicator of arguments truncation
+	Envs          []string `field:"envs,ResolveProcessEnvs:100"`                                                                                           // Environment variables of the process
+	EnvsTruncated bool     `field:"envs_truncated,ResolveProcessEnvsTruncated"`                                                                            // Indicator of environment variables truncation
 }
 
 // SpanContext describes a span context
@@ -284,13 +285,6 @@ type SpanContext struct {
 // ExecEvent represents a exec event
 type ExecEvent struct {
 	Process
-
-	// defined to generate accessors
-	Args          string   `field:"args,ResolveExecArgs"`                                                                                     // Arguments of the process (as a string)
-	Argv          []string `field:"argv,ResolveExecArgv" field:"args_flags,ResolveExecArgsFlags" field:"args_options,ResolveExecArgsOptions"` // Arguments of the process (as an array)
-	ArgsTruncated bool     `field:"args_truncated,ResolveExecArgsTruncated"`                                                                  // Indicator of arguments truncation
-	Envs          []string `field:"envs,ResolveExecEnvs"`                                                                                     // Environment variables of the process
-	EnvsTruncated bool     `field:"envs_truncated,ResolveExecEnvsTruncated"`                                                                  // Indicator of environment variables truncation
 }
 
 // FileFields holds the information required to identify a file

--- a/releasenotes/notes/cws-ancestors-args-cdce5842adaa859f.yaml
+++ b/releasenotes/notes/cws-ancestors-args-cdce5842adaa859f.yaml
@@ -1,0 +1,3 @@
+features:
+  - |
+    CWS now allows to write SECL rule based on process ancestor args.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Allow to write rule on ancestors args.
Ex:
```
process.ancestors.args_flags == "f"
```
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
