### PR TITLE
[CWS] do allocate macro opt map in rules package

### DIFF
--- a/pkg/security/secl/compiler/eval/opts.go
+++ b/pkg/security/secl/compiler/eval/opts.go
@@ -30,3 +30,18 @@ func (o *Opts) WithLegacyFields(fields map[Field]Field) *Opts {
 	o.LegacyFields = fields
 	return o
 }
+
+// WithMacros set macros fields
+func (o *Opts) WithMacros(macros map[MacroID]*Macro) *Opts {
+	o.Macros = macros
+	return o
+}
+
+// AddMacro add a macro
+func (o *Opts) AddMacro(macro *Macro) *Opts {
+	if o.Macros == nil {
+		o.Macros = make(map[string]*Macro)
+	}
+	o.Macros[macro.ID] = macro
+	return o
+}

--- a/pkg/security/secl/rules/opts.go
+++ b/pkg/security/secl/rules/opts.go
@@ -36,6 +36,12 @@ func (o *Opts) WithLegacyFields(fields map[eval.Field]eval.Field) *Opts {
 	return o
 }
 
+// AddMacro add a macro
+func (o *Opts) AddMacro(macro *eval.Macro) *Opts {
+	o.Opts.AddMacro(macro)
+	return o
+}
+
 // WithSupportedDiscarders set supported discarders
 func (o *Opts) WithSupportedDiscarders(discarders map[eval.Field]bool) *Opts {
 	o.SupportedDiscarders = discarders

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -143,10 +143,7 @@ func (rs *RuleSet) AddMacro(macroDef *MacroDefinition) (*eval.Macro, error) {
 		return nil, &ErrMacroLoad{Definition: macroDef, Err: errors.Wrap(err, "compilation error")}
 	}
 
-	if rs.opts.Macros == nil {
-		rs.opts.Macros = make(map[string]*eval.Macro)
-	}
-	rs.opts.Macros[macro.ID] = macro.Macro
+	rs.opts.AddMacro(macro.Macro)
 
 	return macro.Macro, nil
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Tiny refactoring to remove the opts macro map allocation from the rules package. Introduce a helper on Opts struct to handle the allocation.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
