### PR TITLE
[CSPM] use yaml v2 parser as a fallback if yaml v3 fails

### DIFF
--- a/pkg/compliance/checks/file_check.go
+++ b/pkg/compliance/checks/file_check.go
@@ -79,6 +79,8 @@ func resolveFile(_ context.Context, e env.Env, ruleID string, res compliance.Res
 		if err == nil {
 			vars[compliance.FileFieldContent] = content
 			regoInput["content"] = content
+		} else {
+			log.Errorf("error reading file: %v", err)
 		}
 
 		user, err := getFileUser(fi)

--- a/pkg/compliance/checks/helpers.go
+++ b/pkg/compliance/checks/helpers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/jsonquery"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/Masterminds/sprig"
+	yamlv2 "gopkg.in/yaml.v2"
 	"gopkg.in/yaml.v3"
 )
 
@@ -42,7 +43,10 @@ func parseYAMLContent(data []byte) (interface{}, error) {
 	var content interface{}
 
 	if err := yaml.Unmarshal(data, &content); err != nil {
-		return nil, err
+		if err := yamlv2.Unmarshal(data, &content); err != nil {
+			return nil, err
+		}
+		content = jsonquery.NormalizeYAMLForGoJQ(content)
 	}
 
 	return content, nil

--- a/pkg/compliance/checks/helpers.go
+++ b/pkg/compliance/checks/helpers.go
@@ -46,9 +46,9 @@ func parseYAMLContent(data []byte) (interface{}, error) {
 		if err := yamlv2.Unmarshal(data, &content); err != nil {
 			return nil, err
 		}
-		content = jsonquery.NormalizeYAMLForGoJQ(content)
 	}
 
+	content = jsonquery.NormalizeYAMLForGoJQ(content)
 	return content, nil
 }
 


### PR DESCRIPTION
### What does this PR do?

Use yaml v2 as a fallback if yaml v3 fails.
Because of duplicated key for example.

### Motivation

Fix policies

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
