### PR TITLE
[CSPM] use yaml v2 parser as a fallback if yaml v3 fails (#10298)

### DIFF
--- a/pkg/compliance/checks/file_check.go
+++ b/pkg/compliance/checks/file_check.go
@@ -79,6 +79,8 @@ func resolveFile(_ context.Context, e env.Env, ruleID string, res compliance.Res
 		if err == nil {
 			vars[compliance.FileFieldContent] = content
 			regoInput["content"] = content
+		} else {
+			log.Errorf("error reading file: %v", err)
 		}
 
 		user, err := getFileUser(fi)

--- a/pkg/compliance/checks/helpers.go
+++ b/pkg/compliance/checks/helpers.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/jsonquery"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/Masterminds/sprig"
+	yamlv2 "gopkg.in/yaml.v2"
 	"gopkg.in/yaml.v3"
 )
 
@@ -42,9 +43,12 @@ func parseYAMLContent(data []byte) (interface{}, error) {
 	var content interface{}
 
 	if err := yaml.Unmarshal(data, &content); err != nil {
-		return nil, err
+		if err := yamlv2.Unmarshal(data, &content); err != nil {
+			return nil, err
+		}
 	}
 
+	content = jsonquery.NormalizeYAMLForGoJQ(content)
 	return content, nil
 }
 


### PR DESCRIPTION
(cherry picked from commit bfbfc54cfdcf9f7f2f1c0b23f63799fbd3623358)

### What does this PR do?

Backport of #10298

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
