### PR TITLE
allow auto_multi_line_detection: false to disable multi-line per integration

### DIFF
--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -8,6 +8,8 @@ package config
 import (
 	"fmt"
 	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 // Logs source types
@@ -147,6 +149,13 @@ func (c *LogsConfig) validateTailingMode() error {
 		return fmt.Errorf("tailing from the beginning is not supported for wildcard path %v", c.Path)
 	}
 	return nil
+}
+
+// AutoMultiLineEnabled determines whether auto multi line detection is enabled for this config,
+// considering both the agent-wide logs_config.auto_multi_line_detection and any config for this
+// particular log source.
+func (c *LogsConfig) AutoMultiLineEnabled() bool {
+	return config.Datadog.GetBool("logs_config.auto_multi_line_detection") || c.AutoMultiLine
 }
 
 // ContainsWildcard returns true if the path contains any wildcard character

--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -66,7 +66,7 @@ type LogsConfig struct {
 	Tags            []string
 	ProcessingRules []*ProcessingRule `mapstructure:"log_processing_rules" json:"log_processing_rules"`
 
-	AutoMultiLine               bool    `mapstructure:"auto_multi_line_detection" json:"auto_multi_line_detection"`
+	AutoMultiLine               *bool   `mapstructure:"auto_multi_line_detection" json:"auto_multi_line_detection"`
 	AutoMultiLineSampleSize     int     `mapstructure:"auto_multi_line_sample_size" json:"auto_multi_line_sample_size"`
 	AutoMultiLineMatchThreshold float64 `mapstructure:"auto_multi_line_match_threshold" json:"auto_multi_line_match_threshold"`
 }
@@ -155,7 +155,10 @@ func (c *LogsConfig) validateTailingMode() error {
 // considering both the agent-wide logs_config.auto_multi_line_detection and any config for this
 // particular log source.
 func (c *LogsConfig) AutoMultiLineEnabled() bool {
-	return config.Datadog.GetBool("logs_config.auto_multi_line_detection") || c.AutoMultiLine
+	if c.AutoMultiLine != nil {
+		return *c.AutoMultiLine
+	}
+	return config.Datadog.GetBool("logs_config.auto_multi_line_detection")
 }
 
 // ContainsWildcard returns true if the path contains any wildcard character

--- a/pkg/logs/config/integration_config_test.go
+++ b/pkg/logs/config/integration_config_test.go
@@ -64,7 +64,7 @@ func TestAutoMultilineEnabled(t *testing.T) {
 	assert.False(t, decode(`{"auto_multi_line_detection":false}`).AutoMultiLineEnabled())
 
 	mockConfig.Set("logs_config.auto_multi_line_detection", true)
-	assert.True(t, decode(`{"auto_multi_line_detection":false}`).AutoMultiLineEnabled())
+	assert.False(t, decode(`{"auto_multi_line_detection":false}`).AutoMultiLineEnabled())
 
 	mockConfig.Set("logs_config.auto_multi_line_detection", true)
 	assert.True(t, decode(`{}`).AutoMultiLineEnabled())

--- a/pkg/logs/config/integration_config_test.go
+++ b/pkg/logs/config/integration_config_test.go
@@ -8,8 +8,10 @@
 package config
 
 import (
+	"encoding/json"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -48,4 +50,32 @@ func TestValidateShouldFailWithInvalidConfigs(t *testing.T) {
 		err := config.Validate()
 		assert.NotNil(t, err)
 	}
+}
+
+func TestAutoMultilineEnabled(t *testing.T) {
+	mockConfig := config.Mock()
+	decode := func(cfg string) *LogsConfig {
+		lc := LogsConfig{}
+		json.Unmarshal([]byte(cfg), &lc)
+		return &lc
+	}
+
+	mockConfig.Set("logs_config.auto_multi_line_detection", false)
+	assert.False(t, decode(`{"auto_multi_line_detection":false}`).AutoMultiLineEnabled())
+
+	mockConfig.Set("logs_config.auto_multi_line_detection", true)
+	assert.True(t, decode(`{"auto_multi_line_detection":false}`).AutoMultiLineEnabled())
+
+	mockConfig.Set("logs_config.auto_multi_line_detection", true)
+	assert.True(t, decode(`{}`).AutoMultiLineEnabled())
+
+	mockConfig.Set("logs_config.auto_multi_line_detection", false)
+	assert.True(t, decode(`{"auto_multi_line_detection":true}`).AutoMultiLineEnabled())
+
+	mockConfig.Set("logs_config.auto_multi_line_detection", true)
+	assert.True(t, decode(`{"auto_multi_line_detection":true}`).AutoMultiLineEnabled())
+
+	mockConfig.Set("logs_config.auto_multi_line_detection", false)
+	assert.False(t, decode(`{}`).AutoMultiLineEnabled())
+
 }

--- a/pkg/logs/decoder/decoder.go
+++ b/pkg/logs/decoder/decoder.go
@@ -121,7 +121,7 @@ func NewDecoderWithEndLineMatcher(source *config.LogSource, parser parser.Parser
 		}
 	}
 	if lineHandler == nil {
-		if dd_conf.Datadog.GetBool("logs_config.auto_multi_line_detection") || source.Config.AutoMultiLine {
+		if source.Config.AutoMultiLineEnabled() {
 			log.Infof("Auto multi line log detection enabled")
 
 			if multiLinePattern != nil {

--- a/pkg/logs/input/file/tailer_test.go
+++ b/pkg/logs/input/file/tailer_test.go
@@ -301,7 +301,8 @@ func (suite *TailerTestSuite) TestMutliLineAutoDetect() {
 
 	var err error
 
-	suite.source.Config.AutoMultiLine = true
+	aml := true
+	suite.source.Config.AutoMultiLine = &aml
 	suite.source.Config.AutoMultiLineSampleSize = 3
 
 	suite.tailer = NewTailer(suite.outputChan, NewFile(suite.testPath, suite.source, true), 10*time.Millisecond, NewDecoderFromSource(suite.source))

--- a/releasenotes/notes/auto-multi-line-per-integ-2fec8b18083f5848.yaml
+++ b/releasenotes/notes/auto-multi-line-per-integ-2fec8b18083f5848.yaml
@@ -1,0 +1,5 @@
+enhancements:
+  - |
+    Specifying ``auto_multi_line_detection: false`` in an integration's
+    ``logs_config`` will now disable detection for that integration, even if
+    detection is enabled globally.


### PR DESCRIPTION
### What does this PR do?

allow auto_multi_line_detection: false to disable multi-line per integration

### Motivation

Previously, multi-line detection was enabled as the logical OR of the global and per-integration config, which meant that if enabled globally, it could not be disabled for specific integrations.  This PR fixes that issue.

### Describe how to test/QA your changes

Configure an agent with multi-line logs enabled globally, but disabled for a single integration.  Send multi-line logs for that integration, and observe that they are not detected.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
