### PR TITLE
add agent version prefix and api.* for ddog-gov.com, too

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1012,7 +1012,7 @@ func InitConfig(config Config) {
 	SetupOTLP(config)
 }
 
-var ddURLRegexp = regexp.MustCompile(`^app(\.(us|eu)\d)?\.datad(oghq|0g)\.(com|eu)$`)
+var ddURLRegexp = regexp.MustCompile(`^app(\.(us|eu)\d)?\.(datad(oghq|0g)\.(com|eu)|ddog-gov\.com)$`)
 
 // GetProxies returns the proxy settings from the configuration
 func GetProxies() *Proxy {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -466,6 +466,15 @@ func TestAddAgentVersionToDomain(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, "https://"+getDomainPrefix("flare")+".datadoghq.eu", newURL)
 
+	// Gov
+	newURL, err = AddAgentVersionToDomain("https://app.ddog-gov.com", "app")
+	require.Nil(t, err)
+	assert.Equal(t, "https://"+getDomainPrefix("app")+".ddog-gov.com", newURL)
+
+	newURL, err = AddAgentVersionToDomain("https://app.ddog-gov.com", "flare")
+	require.Nil(t, err)
+	assert.Equal(t, "https://"+getDomainPrefix("flare")+".ddog-gov.com", newURL)
+
 	// Additional site
 	newURL, err = AddAgentVersionToDomain("https://app.us2.datadoghq.com", "app")
 	require.Nil(t, err)

--- a/pkg/forwarder/forwarder_health.go
+++ b/pkg/forwarder/forwarder_health.go
@@ -134,7 +134,7 @@ func (fh *forwarderHealth) healthCheckLoop() {
 func (fh *forwarderHealth) computeDomainsURL() {
 	for domain, dr := range fh.domainResolvers {
 		apiDomain := ""
-		re := regexp.MustCompile(`((us|eu)\d\.)?datadoghq.[a-z]+$`)
+		re := regexp.MustCompile(`((us|eu)\d\.)?(datadoghq.[a-z]+|ddog-gov.com)$`)
 		if re.MatchString(domain) {
 			apiDomain = "https://api." + re.FindString(domain)
 		} else {

--- a/pkg/forwarder/forwarder_health_test.go
+++ b/pkg/forwarder/forwarder_health_test.go
@@ -51,6 +51,8 @@ func TestComputeDomainsURL(t *testing.T) {
 		// debatable whether the next one should be changed to `api.`, preserve pre-existing behavior for now
 		"https://app.datadoghq.internal": {"api_key7"},
 		"https://app.myproxy.com":        {"api_key8"},
+		"https://app.ddog-gov.com":       {"api_key9"},
+		"https://custom.ddog-gov.com":    {"api_key10"},
 	}
 
 	expectedMap := map[string][]string{
@@ -59,6 +61,7 @@ func TestComputeDomainsURL(t *testing.T) {
 		"https://api.us2.datadoghq.com":  {"api_key5", "api_key6"},
 		"https://api.datadoghq.internal": {"api_key7"},
 		"https://app.myproxy.com":        {"api_key8"},
+		"https://api.ddog-gov.com":       {"api_key9", "api_key10"},
 	}
 
 	// just sort the expected map for easy comparison

--- a/releasenotes/notes/ddog-gov-urls-0b75b2377e30f77d.yaml
+++ b/releasenotes/notes/ddog-gov-urls-0b75b2377e30f77d.yaml
@@ -1,0 +1,5 @@
+enhancements:
+  - |
+    When using ``site: ddog-gov.com``, the agent now uses agent-version-based
+    URLs and ``api.ddog-gov.com`` as it has previously done for other DataDog
+    domains.

--- a/releasenotes/notes/ddog-gov-urls-0b75b2377e30f77d.yaml
+++ b/releasenotes/notes/ddog-gov-urls-0b75b2377e30f77d.yaml
@@ -1,5 +1,5 @@
 enhancements:
   - |
-    When using ``site: ddog-gov.com``, the agent now uses agent-version-based
-    URLs and ``api.ddog-gov.com`` as it has previously done for other DataDog
+    When using ``site: ddog-gov.com``, the agent now uses Agent-version-based
+    URLs and ``api.ddog-gov.com`` as it has previously done for other Datadog
     domains.


### PR DESCRIPTION
### What does this PR do?

Adds support for ddog-gov.com to the domain rewriting that selects `{version}-app.agent.{site}` and `api.{site}` URLs.

### Motivation

Making ddog-gov.com act like other sites.

### Additional Notes

The cluster agent also uses the API to autoscale, but appears to already determine the URL correctly.

### Describe how to test/QA your changes

You'll need to have govcloud access.

Configure an agent with `site: ddog-gov.com` with an invalid API key and start the agent.  See something like
```
2021-12-20 21:30:53 UTC | CORE | WARN | (pkg/forwarder/forwarder_health.go:212 in hasValidAPIKey) | api_key '********************************' for domain https://api.ddog-gov.com is invalid
```
(verifying that forwarder_health.go is using the correct domain)

Use a correct API key, start again, and verify that the forwarder is logging the right URL (including the agent version) in the payloads it is sending.

```
2021-12-20 21:34:33 UTC | CORE | INFO | (pkg/forwarder/transaction/transaction.go:366 in internalProcess) | Successfully posted payload to "https://7-34-0-app.agent.ddog-gov.com/intake/?api_key=********************************", the agent will only log transaction success every 500 transactions
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
