### PR TITLE
[Serverless] Use http-intake.logs for Lambda Extension logs submission

### DIFF
--- a/pkg/logs/config/config.go
+++ b/pkg/logs/config/config.go
@@ -27,7 +27,7 @@ const SnmpTraps = "snmp_traps"
 const (
 	tcpEndpointPrefix            = "agent-intake.logs."
 	httpEndpointPrefix           = "agent-http-intake.logs."
-	serverlessHTTPEndpointPrefix = "lambda-http-intake.logs."
+	serverlessHTTPEndpointPrefix = "http-intake.logs."
 )
 
 // DefaultIntakeProtocol indicates that no special protocol is in use for the endpoint intake track type.

--- a/pkg/logs/config/config_test.go
+++ b/pkg/logs/config/config_test.go
@@ -500,7 +500,7 @@ func (suite *ConfigTestSuite) TestBuildServerlessEndpoints() {
 		BatchWait: 1 * time.Second,
 		Main: Endpoint{
 			APIKey:           "123",
-			Host:             "lambda-http-intake.logs.datadoghq.com",
+			Host:             "http-intake.logs.datadoghq.com",
 			Port:             0,
 			UseSSL:           true,
 			UseCompression:   true,

--- a/pkg/logs/logs_test.go
+++ b/pkg/logs/logs_test.go
@@ -14,7 +14,7 @@ import (
 func TestBuildServerlessEndpoints(t *testing.T) {
 	endpoints, err := buildEndpoints(true)
 	assert.Nil(t, err)
-	assert.Equal(t, "lambda-http-intake.logs.datadoghq.com", endpoints.Main.Host)
+	assert.Equal(t, "http-intake.logs.datadoghq.com", endpoints.Main.Host)
 	assert.Equal(t, "lambda-extension", string(endpoints.Main.Origin))
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Use `http-intake.logs` endpoint for Lambda Extension logs submission.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The `lambda-http-intake.logs` endpoint has been merged into the `http-intake.logs` endpoint on Datadog backend. `http-intake.logs` can be [exposed directly over PrivateLink](https://docs.datadoghq.com/agent/guide/private-link/), which simplifies configurations for Lambda functions deployed in private VPC subnets -- no need to ask users to override the `DD_LOGS_CONFIG_LOGS_DD_URL` any longer.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Will remove https://docs.datadoghq.com/serverless/guide/extension_private_link/#extension-configuration and update https://docs.datadoghq.com/serverless/libraries_integrations/extension/#using-aws-privatelink in a follow-up PR.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

The testing Lambda Extension layer using `http-intake.logs` worked just fine with and without PrivateLink.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
