### PR TITLE
[cmd/loader] Don't start workloadmeta and tagger in the DCA

### DIFF
--- a/cmd/agent/common/loader.go
+++ b/cmd/agent/common/loader.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/tagger"
 	"github.com/DataDog/datadog-agent/pkg/tagger/collectors"
 	"github.com/DataDog/datadog-agent/pkg/tagger/local"
+	"github.com/DataDog/datadog-agent/pkg/util/flavor"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 
@@ -26,13 +27,15 @@ import (
 // LoadComponents configures several common Agent components:
 // tagger, collector, scheduler and autodiscovery
 func LoadComponents(confdPath string) {
-	workloadmeta.GetGlobalStore().Start(context.Background())
+	if flavor.GetFlavor() != flavor.ClusterAgent {
+		workloadmeta.GetGlobalStore().Start(context.Background())
 
-	// start the tagger. must be done before autodiscovery, as it needs to
-	// be the first subscribed to metadata store to avoid race conditions.
-	tagger.SetDefaultTagger(local.NewTagger(collectors.DefaultCatalog))
-	if err := tagger.Init(); err != nil {
-		log.Errorf("failed to start the tagger: %s", err)
+		// start the tagger. must be done before autodiscovery, as it needs to
+		// be the first subscribed to metadata store to avoid race conditions.
+		tagger.SetDefaultTagger(local.NewTagger(collectors.DefaultCatalog))
+		if err := tagger.Init(); err != nil {
+			log.Errorf("failed to start the tagger: %s", err)
+		}
 	}
 
 	// create the Collector instance and start all the components


### PR DESCRIPTION
### What does this PR do?

Does not start the workloadmeta or the tagger in the DCA because they're not needed.


### Describe how to test/QA your changes

Start the DCA and check that these 2 messages don't appear in the logs:
- "workloadmeta store initialized successfully"
- "workloadmeta tag collector successfully started"

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
