### PR TITLE
Cleanup of CodeQL workflow

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,6 +31,7 @@ jobs:
           pip3 install -r requirements.txt
 
       - name: Setup env variables
+        run: |
           echo "CODEQL_PYTHON=$(which python3)" >> $GITHUB_ENV
           echo "$GOPATH/bin" >> $GITHUB_PATH
           echo "CGO_LDFLAGS= -L${GITHUB_WORKSPACE}/rtloader/build/rtloader -ldl " >> $GITHUB_ENV
@@ -51,7 +52,6 @@ jobs:
 
       - name: Build DataDog agent
         run: |
-          cd go/src/github.com/DataDog/datadog-agent
           invoke install-tools
           invoke deps
           invoke agent.build --build-exclude=systemd

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -2,13 +2,13 @@ name: "Code Scanning - Action"
 
 on:
   push:
-    branches: 
+    branches:
       - main
-      - 7.[0-9][0-9].x 
+      - 7.[0-9][0-9].x
   pull_request:
-    branches: 
+    branches:
       - main
-      - 7.[0-9][0-9].x 
+      - 7.[0-9][0-9].x
 
 jobs:
   CodeQL-Build:
@@ -20,38 +20,36 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-          path: go/src/github.com/DataDog/datadog-agent
+
       - name: Setup Python3
         uses: actions/setup-python@v2
         with:
           python-version: '3.x'
-      - working-directory: go/src/github.com/DataDog/datadog-agent
+
+      - name: Install Python requirements
         run: |
           pip3 install -r requirements.txt
+
+      - name: Setup env variables
           echo "CODEQL_PYTHON=$(which python3)" >> $GITHUB_ENV
           echo "$GOPATH/bin" >> $GITHUB_PATH
-          echo "CGO_LDFLAGS= -L${GITHUB_WORKSPACE}/go/src/github.com/DataDog/datadog-agent/rtloader/build/rtloader -ldl " >> $GITHUB_ENV
-          echo "CGO_CFLAGS= -I${GITHUB_WORKSPACE}/go/src/github.com/DataDog/datadog-agent/rtloader/include  -I${GITHUB_WORKSPACE}/go/src/github.com/DataDog/datadog-agent/rtloader/common " >> $GITHUB_ENV
+          echo "CGO_LDFLAGS= -L${GITHUB_WORKSPACE}/rtloader/build/rtloader -ldl " >> $GITHUB_ENV
+          echo "CGO_CFLAGS= -I${GITHUB_WORKSPACE}/rtloader/include  -I${GITHUB_WORKSPACE}/rtloader/common " >> $GITHUB_ENV
 
       - uses: actions/setup-go@v2
         with:
           go-version: 1.16.7
-      # Initializes the CodeQL tools for scanning.
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v1
-        env:
-          GOPATH: /home/runner/work/datadog-agent/go
-        # Override language selection by uncommenting this and choosing your languages
         with:
           languages: go, javascript, python, cpp
           setup-python-dependencies: false
-          config-file: /home/runner/work/datadog-agent/datadog-agent/go/src/github.com/DataDog/datadog-agent/.github/codeql_config.yml
-          source-root: go/src/github.com/DataDog/datadog-agent
+          config-file: .github/codeql_config.yml
           # Define a fixed CodeQL bundle version
           tools: https://github.com/github/codeql-action/releases/download/codeql-bundle-20211115/codeql-bundle-linux64.tar.gz
 
-      - env:
-          GOPATH: /home/runner/work/datadog-agent/go
+      - name: Build DataDog agent
         run: |
           cd go/src/github.com/DataDog/datadog-agent
           invoke install-tools
@@ -60,7 +58,3 @@ jobs:
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v1
-        with:
-          checkout_path: go/src/github.com/DataDog/datadog-agent
-        env:
-          GOPATH: /home/runner/work/datadog-agent/go


### PR DESCRIPTION
### What does this PR do?

The CodeQL jobs are generating a lot of noise especially when you list all commits from the main branch (https://github.com/DataDog/datadog-agent/commits/main).
Here for example we only see failing commits because of the CodeQL results that are failing to understand that `main` is the default branch and tries to compare with `master` which is not evaluated.

Looking at the logs, I saw:

```
fatal: not a git repository (or any of the parent directories): .git
Failed to call git to get current commit. Continuing with data from environment: Error: The process '/bin/git' failed with exit code 128
Error: The process '/bin/git' failed with exit code 128
    at ExecState._setResult (/home/runner/work/_actions/github/codeql-action/v1/node_modules/@actions/exec/lib/toolrunner.js:592:25)
    at ExecState.CheckComplete (/home/runner/work/_actions/github/codeql-action/v1/node_modules/@actions/exec/lib/toolrunner.js:575:18)
    at ChildProcess.<anonymous> (/home/runner/work/_actions/github/codeql-action/v1/node_modules/@actions/exec/lib/toolrunner.js:469:27)
    at ChildProcess.emit (events.js:210:5)
    at maybeClose (internal/child_process.js:1021:16)
    at Socket.<anonymous> (internal/child_process.js:430:11)
    at Socket.emit (events.js:210:5)
    at Pipe.<anonymous> (net.js:659:12)
```

I believe codeql is confused by the complexity of the path used in the workflow and fails to fetch the current/base commit refs.

This PR tries to reduce this complexity by removing references to useless `GOPATH` or `go/src/github.com/...`. This is possible since the agent is go 1.11 module aware and thus doesn't require this setup.

It is of course impossible to guarantee that this will do what it should, in the pure tradition of github actions.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
