### PR TITLE
[docker/containers] Fix "out of range" panic

### DIFF
--- a/pkg/util/docker/containers.go
+++ b/pkg/util/docker/containers.go
@@ -228,7 +228,15 @@ func (d *DockerUtil) dockerContainers(ctx context.Context, cfg *ContainerListCon
 		}
 
 		pauseContainerExcluded := config.Datadog.GetBool("exclude_pause_container") && containers.IsPauseContainer(c.Labels)
-		excluded := pauseContainerExcluded || d.cfg.filter.IsExcluded(c.Names[0], image, c.Labels["io.kubernetes.pod.namespace"])
+
+		// Containers don't have a name when they're stuck in the "Removal in progress" state.
+		// Ref: https://github.com/DataDog/datadog-agent/issues/9516
+		containerName := ""
+		if len(c.Names) > 0 {
+			containerName = c.Names[0]
+		}
+
+		excluded := pauseContainerExcluded || d.cfg.filter.IsExcluded(containerName, image, c.Labels["io.kubernetes.pod.namespace"])
 		if excluded && !cfg.FlagExcluded {
 			continue
 		}
@@ -238,14 +246,14 @@ func (d *DockerUtil) dockerContainers(ctx context.Context, cfg *ContainerListCon
 			Type:        "Docker",
 			ID:          c.ID,
 			EntityID:    entityID,
-			Name:        c.Names[0],
+			Name:        containerName,
 			Image:       image,
 			ImageID:     c.ImageID,
 			Created:     c.Created,
 			State:       c.State,
 			Excluded:    excluded,
 			Health:      parseContainerHealth(c.Status),
-			AddressList: d.parseContainerNetworkAddresses(c.ID, c.Ports, c.NetworkSettings, c.Names[0]),
+			AddressList: d.parseContainerNetworkAddresses(c.ID, c.Ports, c.NetworkSettings, containerName),
 		}
 
 		ret = append(ret, container)

--- a/releasenotes/notes/fix-docker-containers-out-of-range-names-fe288f7b760c7984.yaml
+++ b/releasenotes/notes/fix-docker-containers-out-of-range-names-fe288f7b760c7984.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixed a bug that caused a panic when running the docker check in cases
+    where there are containers stuck in the "Removal in Progress" state.


### PR DESCRIPTION

### What does this PR do?

Fixes https://github.com/DataDog/datadog-agent/issues/9516

### Describe how to test/QA your changes

There doesn't seem to be an easy way to reproduce this. Check https://github.com/DataDog/datadog-agent/issues/9516 for context.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
