### PR TITLE
Revert "[corechecks/snmp] Fix check name for SNMP corecheck autodiscovery"

### DIFF
--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -107,18 +107,12 @@ func (c *Check) Configure(rawInstance integration.Data, rawInitConfig integratio
 	log.Debugf("SNMP configuration: %s", c.config.ToString())
 
 	if c.config.Name == "" {
-		var checkName string
 		// Set 'name' field of the instance if not already defined in rawInstance config.
 		// The name/device_id will be used by Check.BuildID for building the check id.
 		// Example of check id: `snmp:<DEVICE_ID>:a3ec59dfb03e4457`
-		if c.config.IsDiscovery() {
-			checkName = fmt.Sprintf("%s:%s", c.config.Namespace, c.config.Network)
-		} else {
-			checkName = c.config.DeviceID
-		}
-		setNameErr := rawInstance.SetNameForInstance(checkName)
+		setNameErr := rawInstance.SetNameForInstance(c.config.DeviceID)
 		if setNameErr != nil {
-			log.Warnf("error setting check name (checkName=%s): %s", checkName, setNameErr)
+			log.Debugf("error setting device_id as name: %s", setNameErr)
 		}
 	}
 

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -708,7 +708,6 @@ func TestCheckID(t *testing.T) {
 	check1 := snmpFactory()
 	check2 := snmpFactory()
 	check3 := snmpFactory()
-	checkSubnet := snmpFactory()
 	// language=yaml
 	rawInstanceConfig1 := []byte(`
 ip_address: 1.1.1.1
@@ -725,12 +724,6 @@ ip_address: 3.3.3.3
 community_string: abc
 namespace: ns3
 `)
-	// language=yaml
-	rawInstanceConfigSubnet := []byte(`
-network_address: 10.10.10.0/24
-community_string: abc
-namespace: nsSubnet
-`)
 
 	err := check1.Configure(rawInstanceConfig1, []byte(``), "test")
 	assert.Nil(t, err)
@@ -738,13 +731,10 @@ namespace: nsSubnet
 	assert.Nil(t, err)
 	err = check3.Configure(rawInstanceConfig3, []byte(``), "test")
 	assert.Nil(t, err)
-	err = checkSubnet.Configure(rawInstanceConfigSubnet, []byte(``), "test")
-	assert.Nil(t, err)
 
 	assert.Equal(t, check.ID("snmp:default:1.1.1.1:a3ec59dfb03e4457"), check1.ID())
 	assert.Equal(t, check.ID("snmp:default:2.2.2.2:3979cd473e4beb3f"), check2.ID())
 	assert.Equal(t, check.ID("snmp:ns3:3.3.3.3:819516f4c3986cc6"), check3.ID())
-	assert.Equal(t, check.ID("snmp:nsSubnet:10.10.10.0/24:be3c32b7c5c1c696"), checkSubnet.ID())
 	assert.NotEqual(t, check1.ID(), check2.ID())
 }
 
@@ -1280,7 +1270,7 @@ func TestReportDeviceMetadataWithFetchError(t *testing.T) {
 	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
-	chk := snmpFactory()
+	chk := Check{}
 	// language=yaml
 	rawInstanceConfig := []byte(`
 ip_address: 1.2.3.5


### PR DESCRIPTION
Reverts DataDog/datadog-agent#10282

Revert due to TestCheck_Run failing on main branch.