### PR TITLE
[networks] Enforce concurrency limit

### DIFF
--- a/cmd/system-probe/api/server.go
+++ b/cmd/system-probe/api/server.go
@@ -33,7 +33,7 @@ func StartServer(cfg *config.Config) error {
 	}
 
 	// Register stats endpoint
-	mux.HandleFunc("/debug/stats", utils.WithConcurrencyLimit(5, func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("/debug/stats", utils.WithConcurrencyLimit(utils.DefaultMaxConcurrentRequests, func(w http.ResponseWriter, req *http.Request) {
 		stats := module.GetStats()
 		utils.WriteAsJSON(w, stats)
 	}))

--- a/cmd/system-probe/api/server.go
+++ b/cmd/system-probe/api/server.go
@@ -33,10 +33,10 @@ func StartServer(cfg *config.Config) error {
 	}
 
 	// Register stats endpoint
-	mux.HandleFunc("/debug/stats", func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("/debug/stats", utils.WithConcurrencyLimit(5, func(w http.ResponseWriter, req *http.Request) {
 		stats := module.GetStats()
 		utils.WriteAsJSON(w, stats)
-	})
+	}))
 
 	setupConfigHandlers(mux)
 

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -30,6 +30,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// one for process-agent checks and another one for manual troubleshooting
+const maxConcurrentRequests = 2
+
 // ErrSysprobeUnsupported is the unsupported error prefix, for error-class matching from callers
 var ErrSysprobeUnsupported = errors.New("system-probe unsupported")
 
@@ -70,7 +73,7 @@ func (nt *networkTracer) GetStats() map[string]interface{} {
 func (nt *networkTracer) Register(httpMux *module.Router) error {
 	var runCounter uint64
 
-	httpMux.HandleFunc("/connections", utils.WithConcurrencyLimit(5, func(w http.ResponseWriter, req *http.Request) {
+	httpMux.HandleFunc("/connections", utils.WithConcurrencyLimit(maxConcurrentRequests, func(w http.ResponseWriter, req *http.Request) {
 		start := time.Now()
 		id := getClientID(req)
 		cs, err := nt.tracer.GetActiveConnections(id)

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -70,7 +70,7 @@ func (nt *networkTracer) GetStats() map[string]interface{} {
 func (nt *networkTracer) Register(httpMux *module.Router) error {
 	var runCounter uint64
 
-	httpMux.HandleFunc("/connections", func(w http.ResponseWriter, req *http.Request) {
+	httpMux.HandleFunc("/connections", utils.WithConcurrencyLimit(5, func(w http.ResponseWriter, req *http.Request) {
 		start := time.Now()
 		id := getClientID(req)
 		cs, err := nt.tracer.GetActiveConnections(id)
@@ -88,7 +88,7 @@ func (nt *networkTracer) Register(httpMux *module.Router) error {
 		}
 		count := atomic.AddUint64(&runCounter, 1)
 		logRequests(id, count, len(cs.Conns), start)
-	})
+	}))
 
 	httpMux.HandleFunc("/debug/net_maps", func(w http.ResponseWriter, req *http.Request) {
 		cs, err := nt.tracer.DebugNetworkMaps()

--- a/cmd/system-probe/modules/network_tracer.go
+++ b/cmd/system-probe/modules/network_tracer.go
@@ -30,9 +30,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// one for process-agent checks and another one for manual troubleshooting
-const maxConcurrentRequests = 2
-
 // ErrSysprobeUnsupported is the unsupported error prefix, for error-class matching from callers
 var ErrSysprobeUnsupported = errors.New("system-probe unsupported")
 
@@ -73,7 +70,7 @@ func (nt *networkTracer) GetStats() map[string]interface{} {
 func (nt *networkTracer) Register(httpMux *module.Router) error {
 	var runCounter uint64
 
-	httpMux.HandleFunc("/connections", utils.WithConcurrencyLimit(maxConcurrentRequests, func(w http.ResponseWriter, req *http.Request) {
+	httpMux.HandleFunc("/connections", utils.WithConcurrencyLimit(utils.DefaultMaxConcurrentRequests, func(w http.ResponseWriter, req *http.Request) {
 		start := time.Now()
 		id := getClientID(req)
 		cs, err := nt.tracer.GetActiveConnections(id)

--- a/cmd/system-probe/modules/oom_kill_probe.go
+++ b/cmd/system-probe/modules/oom_kill_probe.go
@@ -43,11 +43,11 @@ type oomKillModule struct {
 }
 
 func (o *oomKillModule) Register(httpMux *module.Router) error {
-	httpMux.HandleFunc("/check/oom_kill", func(w http.ResponseWriter, req *http.Request) {
+	httpMux.HandleFunc("/check/oom_kill", utils.WithConcurrencyLimit(maxConcurrentRequests, func(w http.ResponseWriter, req *http.Request) {
 		atomic.StoreInt64(&o.lastCheck, time.Now().Unix())
 		stats := o.OOMKillProbe.GetAndFlush()
 		utils.WriteAsJSON(w, stats)
-	})
+	}))
 
 	return nil
 }

--- a/cmd/system-probe/modules/oom_kill_probe.go
+++ b/cmd/system-probe/modules/oom_kill_probe.go
@@ -43,7 +43,7 @@ type oomKillModule struct {
 }
 
 func (o *oomKillModule) Register(httpMux *module.Router) error {
-	httpMux.HandleFunc("/check/oom_kill", utils.WithConcurrencyLimit(maxConcurrentRequests, func(w http.ResponseWriter, req *http.Request) {
+	httpMux.HandleFunc("/check/oom_kill", utils.WithConcurrencyLimit(utils.DefaultMaxConcurrentRequests, func(w http.ResponseWriter, req *http.Request) {
 		atomic.StoreInt64(&o.lastCheck, time.Now().Unix())
 		stats := o.OOMKillProbe.GetAndFlush()
 		utils.WriteAsJSON(w, stats)

--- a/cmd/system-probe/utils/limiter.go
+++ b/cmd/system-probe/utils/limiter.go
@@ -3,6 +3,8 @@ package utils
 import (
 	"net/http"
 	"sync/atomic"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // WithConcurrencyLimit enforces a maximum number of concurrent requests over
@@ -14,6 +16,7 @@ func WithConcurrencyLimit(limit int, original func(http.ResponseWriter, *http.Re
 		defer atomic.AddInt64(&inFlight, -1)
 
 		if current > int64(limit) {
+			log.Warnf("rejecting request for path=%s concurrency_limit=%d", req.URL.Path, limit)
 			w.WriteHeader(http.StatusTooManyRequests)
 			return
 		}

--- a/cmd/system-probe/utils/limiter.go
+++ b/cmd/system-probe/utils/limiter.go
@@ -7,6 +7,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// DefaultMaxConcurrentRequests determines the maximum number of requests in-flight for a given handler
+// We choose 2 because one is for regular agent checks and another one is for manual troubleshooting
+const DefaultMaxConcurrentRequests = 2
+
 // WithConcurrencyLimit enforces a maximum number of concurrent requests over
 // over a certain HTTP handler function
 func WithConcurrencyLimit(limit int, original func(http.ResponseWriter, *http.Request)) func(http.ResponseWriter, *http.Request) {

--- a/cmd/system-probe/utils/limiter_test.go
+++ b/cmd/system-probe/utils/limiter_test.go
@@ -1,0 +1,65 @@
+package utils
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+)
+
+func TestWithConcurrencyLimit(t *testing.T) {
+	const concurrentRequests = 5
+
+	var (
+		recorders []*httptest.ResponseRecorder
+		wg        sync.WaitGroup
+		wait      = make(chan struct{})
+	)
+
+	handler := WithConcurrencyLimit(concurrentRequests, func(w http.ResponseWriter, r *http.Request) {
+		<-wait
+		w.WriteHeader(http.StatusOK)
+	})
+
+	for i := 0; i < concurrentRequests; i++ {
+		wg.Add(1)
+		request := httptest.NewRequest("GET", "http://example.com", nil)
+		responseRecorder := httptest.NewRecorder()
+		recorders = append(recorders, responseRecorder)
+
+		go func(w http.ResponseWriter, r *http.Request) {
+			handler(w, r)
+			wg.Done()
+		}(responseRecorder, request)
+	}
+
+	// Time to ensure that all requests are busy being processed
+	time.Sleep(100 * time.Millisecond)
+
+	// The requests above should all hang and the next ones should return
+	// immediately with a `StatusTooManyRequests` as they're being limitted
+	for i := 0; i < concurrentRequests; i++ {
+		r := httptest.NewRequest("GET", "http://example.com", nil)
+		w := httptest.NewRecorder()
+		handler(w, r)
+		resp := w.Result()
+		io.Copy(ioutil.Discard, resp.Body)
+		assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
+	}
+
+	// Unlock the in-flight requests
+	close(wait)
+	wg.Wait()
+
+	// Verify that they were processed by the original handler
+	for _, recorder := range recorders {
+		resp := recorder.Result()
+		io.Copy(ioutil.Discard, resp.Body)
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	}
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Enforces a maximum number of concurrent requests for certain system-probe endpoints.

### Motivation

Ensure that in-flight requests won't pile up in the event of a system-probe bug.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Change covered by unit tests.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
