### PR TITLE
[WIP] Revert 10310 revert 10282 alex/fix check name for corecheck autodiscovery session factory

### DIFF
--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
@@ -44,10 +44,10 @@ type DeviceCheck struct {
 }
 
 // NewDeviceCheck returns a new DeviceCheck
-func NewDeviceCheck(config *checkconfig.CheckConfig, ipAddress string) (*DeviceCheck, error) {
+func NewDeviceCheck(config *checkconfig.CheckConfig, ipAddress string, sessionFactory session.Factory) (*DeviceCheck, error) {
 	newConfig := config.CopyWithNewIP(ipAddress)
 
-	sess, err := session.NewSession(newConfig)
+	sess, err := sessionFactory(newConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to configure session: %s", err)
 	}

--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck_test.go
@@ -25,7 +25,7 @@ import (
 func TestProfileWithSysObjectIdDetection(t *testing.T) {
 	checkconfig.SetConfdPathAndCleanProfiles()
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
 
@@ -44,7 +44,7 @@ profiles:
 	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig)
 	assert.Nil(t, err)
 
-	deviceCk, err := NewDeviceCheck(config, "1.2.3.4")
+	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", sessionFactory)
 	assert.Nil(t, err)
 
 	sender := mocksender.NewMockSender("123") // required to initiate aggregator
@@ -305,7 +305,7 @@ community_string: public
 	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig)
 	assert.Nil(t, err)
 
-	deviceCk, err := NewDeviceCheck(config, "1.2.3.4")
+	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", session.NewMockSession)
 	assert.Nil(t, err)
 
 	sender := mocksender.NewMockSender("123") // required to initiate aggregator

--- a/pkg/collector/corechecks/snmp/discovery/discovery_test.go
+++ b/pkg/collector/corechecks/snmp/discovery/discovery_test.go
@@ -35,7 +35,7 @@ func TestDiscovery(t *testing.T) {
 	config.Datadog.Set("run_path", path)
 
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
 
@@ -57,7 +57,7 @@ func TestDiscovery(t *testing.T) {
 		DiscoveryWorkers:   1,
 		IgnoredIPAddresses: map[string]bool{"192.168.0.5": true},
 	}
-	discovery := NewDiscovery(checkConfig)
+	discovery := NewDiscovery(checkConfig, sessionFactory)
 	discovery.Start()
 	assert.NoError(t, waitForDiscoveredDevices(&discovery, 7, 2*time.Second))
 	discovery.Stop()
@@ -86,7 +86,7 @@ func TestDiscoveryCache(t *testing.T) {
 	config.Datadog.Set("run_path", path)
 
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
 
@@ -107,7 +107,7 @@ func TestDiscoveryCache(t *testing.T) {
 		DiscoveryInterval: 3600,
 		DiscoveryWorkers:  1,
 	}
-	discovery := NewDiscovery(checkConfig)
+	discovery := NewDiscovery(checkConfig, sessionFactory)
 	discovery.Start()
 	assert.NoError(t, waitForDiscoveredDevices(&discovery, 4, 2*time.Second))
 	discovery.Stop()
@@ -129,7 +129,7 @@ func TestDiscoveryCache(t *testing.T) {
 	// test cache
 	// session is never used, the devices are loaded from cache
 	sess2 := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	discovery.sessionFactory = func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess2, nil
 	}
 
@@ -139,7 +139,7 @@ func TestDiscoveryCache(t *testing.T) {
 		DiscoveryInterval: 3600,
 		DiscoveryWorkers:  0, // no workers, the devices will be loaded from cache
 	}
-	discovery2 := NewDiscovery(checkConfig)
+	discovery2 := NewDiscovery(checkConfig, sessionFactory)
 	discovery2.Start()
 	assert.NoError(t, waitForDiscoveredDevices(&discovery2, 4, 2*time.Second))
 	discovery2.Stop()
@@ -157,7 +157,7 @@ func TestDiscoveryTicker(t *testing.T) {
 	t.Skip() // TODO: FIX ME, currently this test is leading to data race when ran with other tests
 
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
 
@@ -178,7 +178,7 @@ func TestDiscoveryTicker(t *testing.T) {
 		DiscoveryInterval: 1,
 		DiscoveryWorkers:  1,
 	}
-	discovery := NewDiscovery(checkConfig)
+	discovery := NewDiscovery(checkConfig, sessionFactory)
 	discovery.Start()
 	time.Sleep(1500 * time.Millisecond)
 	discovery.Stop()
@@ -196,7 +196,6 @@ func TestDiscovery_checkDevice(t *testing.T) {
 		DiscoveryInterval: 1,
 		DiscoveryWorkers:  1,
 	}
-	discovery := NewDiscovery(checkConfig)
 	ipAddr, ipNet, err := net.ParseCIDR(checkConfig.Network)
 	assert.Nil(t, err)
 	startingIP := ipAddr.Mask(ipNet.Mask)
@@ -226,12 +225,14 @@ func TestDiscovery_checkDevice(t *testing.T) {
 	}
 
 	var sess *session.MockSession
+	discovery := NewDiscovery(checkConfig, session.NewMockSession)
 
 	checkDeviceOnce := func() {
 		sess = session.CreateMockSession()
-		session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+		sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 			return sess, nil
 		}
+		discovery.sessionFactory = sessionFactory
 		sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&packet, nil)
 		err = discovery.checkDevice(job) // add device
 		assert.Nil(t, err)
@@ -239,9 +240,10 @@ func TestDiscovery_checkDevice(t *testing.T) {
 	}
 
 	// session configuration error
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	discovery.sessionFactory = func(*checkconfig.CheckConfig) (session.Session, error) {
 		return nil, fmt.Errorf("some error")
 	}
+
 	err = discovery.checkDevice(job)
 	assert.EqualError(t, err, "error configure session for ip 192.168.0.0: some error")
 	assert.Equal(t, 0, len(discovery.discoveredDevices))
@@ -257,7 +259,7 @@ func TestDiscovery_checkDevice(t *testing.T) {
 	// Test session.Get() error
 	checkDeviceOnce()
 	sess = session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	discovery.sessionFactory = func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
 	var nilPacket *gosnmp.SnmpPacket
@@ -269,7 +271,7 @@ func TestDiscovery_checkDevice(t *testing.T) {
 	// Test session.Get() packet with no variable
 	checkDeviceOnce()
 	sess = session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	discovery.sessionFactory = func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
 	packetNoVariable := gosnmp.SnmpPacket{
@@ -283,7 +285,7 @@ func TestDiscovery_checkDevice(t *testing.T) {
 	// Test session.Get() packet with nil value
 	checkDeviceOnce()
 	sess = session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	discovery.sessionFactory = func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
 	packetNilValue := gosnmp.SnmpPacket{
@@ -311,7 +313,7 @@ func TestDiscovery_createDevice(t *testing.T) {
 		DiscoveryAllowedFailures: 3,
 		Namespace:                "default",
 	}
-	discovery := NewDiscovery(checkConfig)
+	discovery := NewDiscovery(checkConfig, session.NewMockSession)
 	ipAddr, ipNet, err := net.ParseCIDR(checkConfig.Network)
 	assert.Nil(t, err)
 	startingIP := ipAddr.Mask(ipNet.Mask)

--- a/pkg/collector/corechecks/snmp/profile_test.go
+++ b/pkg/collector/corechecks/snmp/profile_test.go
@@ -30,10 +30,10 @@ func TestProfileMetadata_f5(t *testing.T) {
 	config.Datadog.Set("confd_path", invalidPath)
 
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
-	chk := Check{}
+	chk := Check{sessionFactory: sessionFactory}
 	// language=yaml
 	rawInstanceConfig := []byte(`
 ip_address: 1.2.3.4

--- a/pkg/collector/corechecks/snmp/session/session.go
+++ b/pkg/collector/corechecks/snmp/session/session.go
@@ -21,9 +21,8 @@ import (
 
 const sysObjectIDOid = "1.3.6.1.2.1.1.2.0"
 
-// NewSession returns a new session
-// Can be replaced in tests to use a mock session
-var NewSession = NewGosnmpSession
+// Factory will create new sessions
+type Factory func(config *checkconfig.CheckConfig) (Session, error)
 
 // Session interface for connecting to a snmp device
 type Session interface {

--- a/pkg/collector/corechecks/snmp/session/testing_utils.go
+++ b/pkg/collector/corechecks/snmp/session/testing_utils.go
@@ -66,6 +66,6 @@ func CreateMockSession() *MockSession {
 }
 
 // NewMockSession creates a mock session
-func NewMockSession() Session {
-	return CreateMockSession()
+func NewMockSession(config *checkconfig.CheckConfig) (Session, error) {
+	return CreateMockSession(), nil
 }

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -107,12 +107,18 @@ func (c *Check) Configure(rawInstance integration.Data, rawInitConfig integratio
 	log.Debugf("SNMP configuration: %s", c.config.ToString())
 
 	if c.config.Name == "" {
+		var checkName string
 		// Set 'name' field of the instance if not already defined in rawInstance config.
 		// The name/device_id will be used by Check.BuildID for building the check id.
 		// Example of check id: `snmp:<DEVICE_ID>:a3ec59dfb03e4457`
-		setNameErr := rawInstance.SetNameForInstance(c.config.DeviceID)
+		if c.config.IsDiscovery() {
+			checkName = fmt.Sprintf("%s:%s", c.config.Namespace, c.config.Network)
+		} else {
+			checkName = c.config.DeviceID
+		}
+		setNameErr := rawInstance.SetNameForInstance(checkName)
 		if setNameErr != nil {
-			log.Debugf("error setting device_id as name: %s", setNameErr)
+			log.Warnf("error setting check name (checkName=%s): %s", checkName, setNameErr)
 		}
 	}
 

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -21,6 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/devicecheck"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/discovery"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/report"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/session"
 )
 
 var timeNow = time.Now
@@ -31,6 +32,7 @@ type Check struct {
 	config         *checkconfig.CheckConfig
 	singleDeviceCk *devicecheck.DeviceCheck
 	discovery      discovery.Discovery
+	sessionFactory session.Factory
 }
 
 // Run executes the check
@@ -131,10 +133,10 @@ func (c *Check) Configure(rawInstance integration.Data, rawInitConfig integratio
 	}
 
 	if c.config.IsDiscovery() {
-		c.discovery = discovery.NewDiscovery(c.config)
+		c.discovery = discovery.NewDiscovery(c.config, c.sessionFactory)
 		c.discovery.Start()
 	} else {
-		c.singleDeviceCk, err = devicecheck.NewDeviceCheck(c.config, c.config.IPAddress)
+		c.singleDeviceCk, err = devicecheck.NewDeviceCheck(c.config, c.config.IPAddress, c.sessionFactory)
 		if err != nil {
 			return fmt.Errorf("failed to create device check: %s", err)
 		}
@@ -154,7 +156,8 @@ func (c *Check) Interval() time.Duration {
 
 func snmpFactory() check.Check {
 	return &Check{
-		CheckBase: core.NewCheckBase(common.SnmpIntegrationName),
+		CheckBase:      core.NewCheckBase(common.SnmpIntegrationName),
+		sessionFactory: session.NewGosnmpSession,
 	}
 }
 

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -44,10 +44,10 @@ func demuxOpts() aggregator.DemultiplexerOptions {
 func TestBasicSample(t *testing.T) {
 	checkconfig.SetConfdPathAndCleanProfiles()
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
-	chk := Check{}
+	chk := Check{sessionFactory: sessionFactory}
 
 	aggregator.InitAndStartAgentDemultiplexer(demuxOpts(), "")
 
@@ -290,10 +290,10 @@ tags:
 func TestSupportedMetricTypes(t *testing.T) {
 	checkconfig.SetConfdPathAndCleanProfiles()
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
-	chk := Check{}
+	chk := Check{sessionFactory: sessionFactory}
 	// language=yaml
 	rawInstanceConfig := []byte(`
 collect_device_metadata: false
@@ -368,10 +368,10 @@ func TestProfile(t *testing.T) {
 	checkconfig.SetConfdPathAndCleanProfiles()
 
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
-	chk := Check{}
+	chk := Check{sessionFactory: sessionFactory}
 	// language=yaml
 	rawInstanceConfig := []byte(`
 ip_address: 1.2.3.4
@@ -670,11 +670,11 @@ profiles:
 func TestServiceCheckFailures(t *testing.T) {
 	checkconfig.SetConfdPathAndCleanProfiles()
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
 	sess.ConnectErr = fmt.Errorf("can't connect")
-	chk := Check{}
+	chk := Check{sessionFactory: sessionFactory}
 
 	// language=yaml
 	rawInstanceConfig := []byte(`
@@ -918,11 +918,11 @@ func TestCheck_Run(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			checkconfig.SetConfdPathAndCleanProfiles()
 			sess := session.CreateMockSession()
-			session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+			sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 				return sess, nil
 			}
 			sess.ConnectErr = tt.sessionConnError
-			chk := Check{}
+			chk := Check{sessionFactory: sessionFactory}
 
 			// language=yaml
 			rawInstanceConfig := []byte(`
@@ -979,11 +979,11 @@ func TestCheck_Run_sessionCloseError(t *testing.T) {
 	log.SetupLogger(l, "debug")
 
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
 	sess.CloseErr = fmt.Errorf("close error")
-	chk := Check{}
+	chk := Check{sessionFactory: sessionFactory}
 
 	// language=yaml
 	rawInstanceConfig := []byte(`
@@ -1033,10 +1033,10 @@ func TestReportDeviceMetadataEvenOnProfileError(t *testing.T) {
 	checkconfig.SetConfdPathAndCleanProfiles()
 
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
-	chk := Check{}
+	chk := Check{sessionFactory: sessionFactory}
 	// language=yaml
 	rawInstanceConfig := []byte(`
 ip_address: 1.2.3.4
@@ -1277,10 +1277,10 @@ func TestReportDeviceMetadataWithFetchError(t *testing.T) {
 	checkconfig.SetConfdPathAndCleanProfiles()
 
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
-	chk := snmpFactory()
+	chk := Check{sessionFactory: sessionFactory}
 	// language=yaml
 	rawInstanceConfig := []byte(`
 ip_address: 1.2.3.5
@@ -1362,10 +1362,10 @@ func TestDiscovery(t *testing.T) {
 	timeNow = common.MockTimeNow
 	checkconfig.SetConfdPathAndCleanProfiles()
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
-	chk := Check{}
+	chk := Check{sessionFactory: sessionFactory}
 	aggregator.InitAndStartAgentDemultiplexer(demuxOpts(), "")
 
 	// language=yaml
@@ -1649,10 +1649,10 @@ func TestDiscovery_CheckError(t *testing.T) {
 	log.SetupLogger(l, "debug")
 
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
-	chk := Check{}
+	chk := Check{sessionFactory: sessionFactory}
 	aggregator.InitAndStartAgentDemultiplexer(demuxOpts(), "")
 
 	// language=yaml
@@ -1730,10 +1730,10 @@ func TestDeviceIDAsHostname(t *testing.T) {
 
 	checkconfig.SetConfdPathAndCleanProfiles()
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
-	chk := Check{}
+	chk := Check{sessionFactory: sessionFactory}
 	aggregator.InitAndStartAgentDemultiplexer(demuxOpts(), "")
 
 	// language=yaml
@@ -1893,10 +1893,10 @@ func TestDiscoveryDeviceIDAsHostname(t *testing.T) {
 	timeNow = common.MockTimeNow
 	checkconfig.SetConfdPathAndCleanProfiles()
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
-	chk := Check{}
+	chk := Check{sessionFactory: sessionFactory}
 
 	aggregator.InitAndStartAgentDemultiplexer(demuxOpts(), "")
 

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -708,6 +708,7 @@ func TestCheckID(t *testing.T) {
 	check1 := snmpFactory()
 	check2 := snmpFactory()
 	check3 := snmpFactory()
+	checkSubnet := snmpFactory()
 	// language=yaml
 	rawInstanceConfig1 := []byte(`
 ip_address: 1.1.1.1
@@ -724,6 +725,12 @@ ip_address: 3.3.3.3
 community_string: abc
 namespace: ns3
 `)
+	// language=yaml
+	rawInstanceConfigSubnet := []byte(`
+network_address: 10.10.10.0/24
+community_string: abc
+namespace: nsSubnet
+`)
 
 	err := check1.Configure(rawInstanceConfig1, []byte(``), "test")
 	assert.Nil(t, err)
@@ -731,10 +738,13 @@ namespace: ns3
 	assert.Nil(t, err)
 	err = check3.Configure(rawInstanceConfig3, []byte(``), "test")
 	assert.Nil(t, err)
+	err = checkSubnet.Configure(rawInstanceConfigSubnet, []byte(``), "test")
+	assert.Nil(t, err)
 
 	assert.Equal(t, check.ID("snmp:default:1.1.1.1:a3ec59dfb03e4457"), check1.ID())
 	assert.Equal(t, check.ID("snmp:default:2.2.2.2:3979cd473e4beb3f"), check2.ID())
 	assert.Equal(t, check.ID("snmp:ns3:3.3.3.3:819516f4c3986cc6"), check3.ID())
+	assert.Equal(t, check.ID("snmp:nsSubnet:10.10.10.0/24:be3c32b7c5c1c696"), checkSubnet.ID())
 	assert.NotEqual(t, check1.ID(), check2.ID())
 }
 
@@ -1270,7 +1280,7 @@ func TestReportDeviceMetadataWithFetchError(t *testing.T) {
 	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
-	chk := Check{}
+	chk := snmpFactory()
 	// language=yaml
 	rawInstanceConfig := []byte(`
 ip_address: 1.2.3.5


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
