### PR TITLE
[corechecks/snmp] Avoid using global session that can lead to flaky tests

### DIFF
--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
@@ -44,10 +44,10 @@ type DeviceCheck struct {
 }
 
 // NewDeviceCheck returns a new DeviceCheck
-func NewDeviceCheck(config *checkconfig.CheckConfig, ipAddress string) (*DeviceCheck, error) {
+func NewDeviceCheck(config *checkconfig.CheckConfig, ipAddress string, sessionFactory session.Factory) (*DeviceCheck, error) {
 	newConfig := config.CopyWithNewIP(ipAddress)
 
-	sess, err := session.NewSession(newConfig)
+	sess, err := sessionFactory(newConfig)
 	if err != nil {
 		return nil, fmt.Errorf("failed to configure session: %s", err)
 	}

--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck_test.go
@@ -25,7 +25,7 @@ import (
 func TestProfileWithSysObjectIdDetection(t *testing.T) {
 	checkconfig.SetConfdPathAndCleanProfiles()
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
 
@@ -44,7 +44,7 @@ profiles:
 	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig)
 	assert.Nil(t, err)
 
-	deviceCk, err := NewDeviceCheck(config, "1.2.3.4")
+	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", sessionFactory)
 	assert.Nil(t, err)
 
 	sender := mocksender.NewMockSender("123") // required to initiate aggregator
@@ -305,7 +305,7 @@ community_string: public
 	config, err := checkconfig.NewCheckConfig(rawInstanceConfig, rawInitConfig)
 	assert.Nil(t, err)
 
-	deviceCk, err := NewDeviceCheck(config, "1.2.3.4")
+	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", session.NewMockSession)
 	assert.Nil(t, err)
 
 	sender := mocksender.NewMockSender("123") // required to initiate aggregator

--- a/pkg/collector/corechecks/snmp/discovery/discovery_test.go
+++ b/pkg/collector/corechecks/snmp/discovery/discovery_test.go
@@ -35,7 +35,7 @@ func TestDiscovery(t *testing.T) {
 	config.Datadog.Set("run_path", path)
 
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
 
@@ -57,7 +57,7 @@ func TestDiscovery(t *testing.T) {
 		DiscoveryWorkers:   1,
 		IgnoredIPAddresses: map[string]bool{"192.168.0.5": true},
 	}
-	discovery := NewDiscovery(checkConfig)
+	discovery := NewDiscovery(checkConfig, sessionFactory)
 	discovery.Start()
 	assert.NoError(t, waitForDiscoveredDevices(&discovery, 7, 2*time.Second))
 	discovery.Stop()
@@ -86,7 +86,7 @@ func TestDiscoveryCache(t *testing.T) {
 	config.Datadog.Set("run_path", path)
 
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
 
@@ -107,7 +107,7 @@ func TestDiscoveryCache(t *testing.T) {
 		DiscoveryInterval: 3600,
 		DiscoveryWorkers:  1,
 	}
-	discovery := NewDiscovery(checkConfig)
+	discovery := NewDiscovery(checkConfig, sessionFactory)
 	discovery.Start()
 	assert.NoError(t, waitForDiscoveredDevices(&discovery, 4, 2*time.Second))
 	discovery.Stop()
@@ -129,7 +129,7 @@ func TestDiscoveryCache(t *testing.T) {
 	// test cache
 	// session is never used, the devices are loaded from cache
 	sess2 := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	discovery.sessionFactory = func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess2, nil
 	}
 
@@ -139,7 +139,7 @@ func TestDiscoveryCache(t *testing.T) {
 		DiscoveryInterval: 3600,
 		DiscoveryWorkers:  0, // no workers, the devices will be loaded from cache
 	}
-	discovery2 := NewDiscovery(checkConfig)
+	discovery2 := NewDiscovery(checkConfig, sessionFactory)
 	discovery2.Start()
 	assert.NoError(t, waitForDiscoveredDevices(&discovery2, 4, 2*time.Second))
 	discovery2.Stop()
@@ -157,7 +157,7 @@ func TestDiscoveryTicker(t *testing.T) {
 	t.Skip() // TODO: FIX ME, currently this test is leading to data race when ran with other tests
 
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
 
@@ -178,7 +178,7 @@ func TestDiscoveryTicker(t *testing.T) {
 		DiscoveryInterval: 1,
 		DiscoveryWorkers:  1,
 	}
-	discovery := NewDiscovery(checkConfig)
+	discovery := NewDiscovery(checkConfig, sessionFactory)
 	discovery.Start()
 	time.Sleep(1500 * time.Millisecond)
 	discovery.Stop()
@@ -196,7 +196,6 @@ func TestDiscovery_checkDevice(t *testing.T) {
 		DiscoveryInterval: 1,
 		DiscoveryWorkers:  1,
 	}
-	discovery := NewDiscovery(checkConfig)
 	ipAddr, ipNet, err := net.ParseCIDR(checkConfig.Network)
 	assert.Nil(t, err)
 	startingIP := ipAddr.Mask(ipNet.Mask)
@@ -226,12 +225,14 @@ func TestDiscovery_checkDevice(t *testing.T) {
 	}
 
 	var sess *session.MockSession
+	discovery := NewDiscovery(checkConfig, session.NewMockSession)
 
 	checkDeviceOnce := func() {
 		sess = session.CreateMockSession()
-		session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+		sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 			return sess, nil
 		}
+		discovery.sessionFactory = sessionFactory
 		sess.On("Get", []string{"1.3.6.1.2.1.1.2.0"}).Return(&packet, nil)
 		err = discovery.checkDevice(job) // add device
 		assert.Nil(t, err)
@@ -239,9 +240,10 @@ func TestDiscovery_checkDevice(t *testing.T) {
 	}
 
 	// session configuration error
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	discovery.sessionFactory = func(*checkconfig.CheckConfig) (session.Session, error) {
 		return nil, fmt.Errorf("some error")
 	}
+
 	err = discovery.checkDevice(job)
 	assert.EqualError(t, err, "error configure session for ip 192.168.0.0: some error")
 	assert.Equal(t, 0, len(discovery.discoveredDevices))
@@ -257,7 +259,7 @@ func TestDiscovery_checkDevice(t *testing.T) {
 	// Test session.Get() error
 	checkDeviceOnce()
 	sess = session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	discovery.sessionFactory = func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
 	var nilPacket *gosnmp.SnmpPacket
@@ -269,7 +271,7 @@ func TestDiscovery_checkDevice(t *testing.T) {
 	// Test session.Get() packet with no variable
 	checkDeviceOnce()
 	sess = session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	discovery.sessionFactory = func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
 	packetNoVariable := gosnmp.SnmpPacket{
@@ -283,7 +285,7 @@ func TestDiscovery_checkDevice(t *testing.T) {
 	// Test session.Get() packet with nil value
 	checkDeviceOnce()
 	sess = session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	discovery.sessionFactory = func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
 	packetNilValue := gosnmp.SnmpPacket{
@@ -311,7 +313,7 @@ func TestDiscovery_createDevice(t *testing.T) {
 		DiscoveryAllowedFailures: 3,
 		Namespace:                "default",
 	}
-	discovery := NewDiscovery(checkConfig)
+	discovery := NewDiscovery(checkConfig, session.NewMockSession)
 	ipAddr, ipNet, err := net.ParseCIDR(checkConfig.Network)
 	assert.Nil(t, err)
 	startingIP := ipAddr.Mask(ipNet.Mask)

--- a/pkg/collector/corechecks/snmp/profile_test.go
+++ b/pkg/collector/corechecks/snmp/profile_test.go
@@ -30,10 +30,10 @@ func TestProfileMetadata_f5(t *testing.T) {
 	config.Datadog.Set("confd_path", invalidPath)
 
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
-	chk := Check{}
+	chk := Check{sessionFactory: sessionFactory}
 	// language=yaml
 	rawInstanceConfig := []byte(`
 ip_address: 1.2.3.4

--- a/pkg/collector/corechecks/snmp/session/session.go
+++ b/pkg/collector/corechecks/snmp/session/session.go
@@ -21,9 +21,8 @@ import (
 
 const sysObjectIDOid = "1.3.6.1.2.1.1.2.0"
 
-// NewSession returns a new session
-// Can be replaced in tests to use a mock session
-var NewSession = NewGosnmpSession
+// Factory will create new sessions
+type Factory func(config *checkconfig.CheckConfig) (Session, error)
 
 // Session interface for connecting to a snmp device
 type Session interface {

--- a/pkg/collector/corechecks/snmp/session/session.go
+++ b/pkg/collector/corechecks/snmp/session/session.go
@@ -21,7 +21,7 @@ import (
 
 const sysObjectIDOid = "1.3.6.1.2.1.1.2.0"
 
-// Factory will create new sessions
+// Factory will create a new Session
 type Factory func(config *checkconfig.CheckConfig) (Session, error)
 
 // Session interface for connecting to a snmp device

--- a/pkg/collector/corechecks/snmp/session/testing_utils.go
+++ b/pkg/collector/corechecks/snmp/session/testing_utils.go
@@ -66,6 +66,6 @@ func CreateMockSession() *MockSession {
 }
 
 // NewMockSession creates a mock session
-func NewMockSession() Session {
-	return CreateMockSession()
+func NewMockSession(config *checkconfig.CheckConfig) (Session, error) {
+	return CreateMockSession(), nil
 }

--- a/pkg/collector/corechecks/snmp/snmp_test.go
+++ b/pkg/collector/corechecks/snmp/snmp_test.go
@@ -44,10 +44,10 @@ func demuxOpts() aggregator.DemultiplexerOptions {
 func TestBasicSample(t *testing.T) {
 	checkconfig.SetConfdPathAndCleanProfiles()
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
-	chk := Check{}
+	chk := Check{sessionFactory: sessionFactory}
 
 	aggregator.InitAndStartAgentDemultiplexer(demuxOpts(), "")
 
@@ -290,10 +290,10 @@ tags:
 func TestSupportedMetricTypes(t *testing.T) {
 	checkconfig.SetConfdPathAndCleanProfiles()
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
-	chk := Check{}
+	chk := Check{sessionFactory: sessionFactory}
 	// language=yaml
 	rawInstanceConfig := []byte(`
 collect_device_metadata: false
@@ -368,10 +368,10 @@ func TestProfile(t *testing.T) {
 	checkconfig.SetConfdPathAndCleanProfiles()
 
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
-	chk := Check{}
+	chk := Check{sessionFactory: sessionFactory}
 	// language=yaml
 	rawInstanceConfig := []byte(`
 ip_address: 1.2.3.4
@@ -670,11 +670,11 @@ profiles:
 func TestServiceCheckFailures(t *testing.T) {
 	checkconfig.SetConfdPathAndCleanProfiles()
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
 	sess.ConnectErr = fmt.Errorf("can't connect")
-	chk := Check{}
+	chk := Check{sessionFactory: sessionFactory}
 
 	// language=yaml
 	rawInstanceConfig := []byte(`
@@ -908,11 +908,11 @@ func TestCheck_Run(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			checkconfig.SetConfdPathAndCleanProfiles()
 			sess := session.CreateMockSession()
-			session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+			sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 				return sess, nil
 			}
 			sess.ConnectErr = tt.sessionConnError
-			chk := Check{}
+			chk := Check{sessionFactory: sessionFactory}
 
 			// language=yaml
 			rawInstanceConfig := []byte(`
@@ -969,11 +969,11 @@ func TestCheck_Run_sessionCloseError(t *testing.T) {
 	log.SetupLogger(l, "debug")
 
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
 	sess.CloseErr = fmt.Errorf("close error")
-	chk := Check{}
+	chk := Check{sessionFactory: sessionFactory}
 
 	// language=yaml
 	rawInstanceConfig := []byte(`
@@ -1023,10 +1023,10 @@ func TestReportDeviceMetadataEvenOnProfileError(t *testing.T) {
 	checkconfig.SetConfdPathAndCleanProfiles()
 
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
-	chk := Check{}
+	chk := Check{sessionFactory: sessionFactory}
 	// language=yaml
 	rawInstanceConfig := []byte(`
 ip_address: 1.2.3.4
@@ -1267,10 +1267,10 @@ func TestReportDeviceMetadataWithFetchError(t *testing.T) {
 	checkconfig.SetConfdPathAndCleanProfiles()
 
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
-	chk := Check{}
+	chk := Check{sessionFactory: sessionFactory}
 	// language=yaml
 	rawInstanceConfig := []byte(`
 ip_address: 1.2.3.5
@@ -1352,10 +1352,10 @@ func TestDiscovery(t *testing.T) {
 	timeNow = common.MockTimeNow
 	checkconfig.SetConfdPathAndCleanProfiles()
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
-	chk := Check{}
+	chk := Check{sessionFactory: sessionFactory}
 	aggregator.InitAndStartAgentDemultiplexer(demuxOpts(), "")
 
 	// language=yaml
@@ -1639,10 +1639,10 @@ func TestDiscovery_CheckError(t *testing.T) {
 	log.SetupLogger(l, "debug")
 
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
-	chk := Check{}
+	chk := Check{sessionFactory: sessionFactory}
 	aggregator.InitAndStartAgentDemultiplexer(demuxOpts(), "")
 
 	// language=yaml
@@ -1720,10 +1720,10 @@ func TestDeviceIDAsHostname(t *testing.T) {
 
 	checkconfig.SetConfdPathAndCleanProfiles()
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
-	chk := Check{}
+	chk := Check{sessionFactory: sessionFactory}
 	aggregator.InitAndStartAgentDemultiplexer(demuxOpts(), "")
 
 	// language=yaml
@@ -1883,10 +1883,10 @@ func TestDiscoveryDeviceIDAsHostname(t *testing.T) {
 	timeNow = common.MockTimeNow
 	checkconfig.SetConfdPathAndCleanProfiles()
 	sess := session.CreateMockSession()
-	session.NewSession = func(*checkconfig.CheckConfig) (session.Session, error) {
+	sessionFactory := func(*checkconfig.CheckConfig) (session.Session, error) {
 		return sess, nil
 	}
-	chk := Check{}
+	chk := Check{sessionFactory: sessionFactory}
 
 	aggregator.InitAndStartAgentDemultiplexer(demuxOpts(), "")
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

[corechecks/snmp] Avoid using global session that can lead to flaky tests and race conditions in tests

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

- Avoid global session reference
- Less flaky CI

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
