### PR TITLE
[demultiplexer] adapt unit tests to not use the global aggregator instance

### DIFF
--- a/pkg/aggregator/demultiplexer_test.go
+++ b/pkg/aggregator/demultiplexer_test.go
@@ -147,20 +147,19 @@ func TestDemuxSerializerCreated(t *testing.T) {
 func TestDemuxFlushAggregatorToSerializer(t *testing.T) {
 	require := require.New(t)
 
-	resetDemuxInstance(require)
-
 	// default options should have created all forwarders except for the orchestrator
 	// forwarders since we're not in a cluster-agent environment
 
 	opts := demuxTestOptions()
 	opts.FlushInterval = time.Hour
-	demux := InitAndStartAgentDemultiplexer(opts, "")
+	demux := initAgentDemultiplexer(opts, "")
 	demux.Aggregator().tlmContainerTagsEnabled = false
+	go demux.Run()
 	require.NotNil(demux)
 	require.NotNil(demux.aggregator)
 	require.NotNil(demux.sharedSerializer)
 
-	sender, err := GetDefaultSender()
+	sender, err := demux.GetDefaultSender()
 	require.NoError(err)
 	sender.Count("my.check.metric", 1.0, "", []string{"team:agent-core", "dev:remeh"})
 	sender.Count("my.second.check.metric", 5.0, "", []string{"team:agent-core", "dev:remeh"})


### PR DESCRIPTION
### What does this PR do?

In order to fix race conditions in some `pkg/aggregator` unit tests, this pull-request is adapting several unit tests to use a local instance of the `Demultiplexer` (and thus of the `BufferedAggregator`).

Since it is planned in the future to get rid of the global instance of the aggregator and of the demultiplexer, this would have to be done at some point anyway.

### Additional Notes

The race never occurred on our CI nor CircleCI, it seems to only happen while running in AppVeyor.

### Possible Drawbacks / Trade-offs

None.

### Describe how to test/QA your changes

Unit tests are all green.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
