### PR TITLE
Kacper murzyn/changelog cleanup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,7 +14,6 @@ Prelude
 
 Release on: 2021-12-22
 
-.. _Release Notes_7.32.4_Security Notes:
 
 - JMXFetch: Remove all dependencies on ``log4j`` and use ``java.util.logging`` instead.
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,20 @@
 Release Notes
 =============
 
+.. _Release Notes_7.32.3:
+
+7.32.3
+======
+
+.. _Release Notes_7.32.3_Prelude:
+
+Prelude
+-------
+
+Release on: 2021-12-15
+
+- Please refer to the `7.32.3 tag on integrations-core <https://github.com/DataDog/integrations-core/blob/master/AGENT_CHANGELOG.md#datadog-agent-version-7323>`_ for the list of changes on the Core Checks
+
 .. _Release Notes_7.32.2:
 
 7.32.2 / 6.32.2

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,27 @@
 Release Notes
 =============
 
+.. _Release Notes_7.32.2:
+
+7.32.2 / 6.32.2
+======
+
+.. _Release Notes_7.32.2_Prelude:
+
+Prelude
+-------
+
+Release on: 2021-12-10
+
+
+.. _Release Notes_7.32.2_Security Notes:
+
+Security Notes
+--------------
+
+- Set -Dlog4j2.formatMsgNoLookups=True when starting the JMXfetch process to mitigate vulnerability described in `CVE-2021-44228 <https://nvd.nist.gov/vuln/detail/CVE-2021-44228>`
+
+
 .. _Release Notes_7.32.1:
 
 7.32.1 / 6.32.1

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,22 @@
 Release Notes
 =============
 
+.. _Release Notes_7.32.4:
+
+7.32.4 / 6.32.4
+======
+
+.. _Release Notes_7.32.4_Prelude:
+
+Prelude
+-------
+
+Release on: 2021-12-22
+
+.. _Release Notes_7.32.4_Security Notes:
+
+- JMXFetch: Remove all dependencies on ``log4j`` and use ``java.util.logging`` instead.
+
 .. _Release Notes_7.32.3:
 
 7.32.3 / 6.32.3

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,7 +4,7 @@ Release Notes
 
 .. _Release Notes_7.32.3:
 
-7.32.3
+7.32.3 / 6.32.3
 ======
 
 .. _Release Notes_7.32.3_Prelude:
@@ -14,7 +14,9 @@ Prelude
 
 Release on: 2021-12-15
 
-- Please refer to the `7.32.3 tag on integrations-core <https://github.com/DataDog/integrations-core/blob/master/AGENT_CHANGELOG.md#datadog-agent-version-7323>`_ for the list of changes on the Core Checks
+.. _Release Notes_7.32.3_Security Notes:
+
+- Upgrade the log4j dependency to 2.12.2 in JMXFetch to fully address `CVE-2021-44228 <https://nvd.nist.gov/vuln/detail/CVE-2021-44228>`_ and `CVE-2021-45046 <https://nvd.nist.gov/vuln/detail/CVE-2021-45046>`_
 
 .. _Release Notes_7.32.2:
 


### PR DESCRIPTION
Adding all the missing CHANGELOG entries from couple of past 7.32.x releases (exactly same commits).