### PR TITLE
Handle 404s when downloading Gitlab artifacts

### DIFF
--- a/tasks/libs/common/github_api.py
+++ b/tasks/libs/common/github_api.py
@@ -18,7 +18,7 @@ class GithubAPI(RemoteAPI):
     BASE_URL = "https://api.github.com"
 
     def __init__(self, repository="", api_token=""):
-        self.api_name = "GitHub API"
+        super(GithubAPI, self).__init__("GitHub API")
         self.api_token = api_token
         self.repository = repository
         self.authorization_error_message = (

--- a/tasks/libs/common/github_api.py
+++ b/tasks/libs/common/github_api.py
@@ -18,6 +18,7 @@ class GithubAPI(RemoteAPI):
     BASE_URL = "https://api.github.com"
 
     def __init__(self, repository="", api_token=""):
+        self.api_name = "GitHub API"
         self.api_token = api_token
         self.repository = repository
         self.authorization_error_message = (

--- a/tasks/libs/common/github_workflows.py
+++ b/tasks/libs/common/github_workflows.py
@@ -19,10 +19,10 @@ class GithubWorkflows(RemoteAPI):
     BASE_URL = "https://api.github.com"
 
     def __init__(self, repository="", api_token="", api_token_expiration_date=""):
+        super(GithubWorkflows, self).__init__("GitHub Workflows")
         self.api_token = api_token
         self.api_token_expiration_date = api_token_expiration_date
         self.repository = repository
-        self.api_name = "GitHub Workflows"
         self.authorization_error_message = (
             "HTTP 401: The token is invalid. Is the Github App still allowed to perform this action?"
         )

--- a/tasks/libs/common/gitlab.py
+++ b/tasks/libs/common/gitlab.py
@@ -19,11 +19,9 @@ class Gitlab(RemoteAPI):
     BASE_URL = "https://gitlab.ddbuild.io/api/v4"
 
     def __init__(self, project_name="", api_token=""):
-        super(Gitlab, self).__init__()
-
+        super(Gitlab, self).__init__("Gitlab")
         self.api_token = api_token
         self.project_name = project_name
-        self.api_name = "Gitlab"
         self.authorization_error_message = (
             "HTTP 401: Your GITLAB_TOKEN may have expired. You can "
             "check and refresh it at "

--- a/tasks/libs/common/remote_api.py
+++ b/tasks/libs/common/remote_api.py
@@ -20,8 +20,8 @@ class RemoteAPI(object):
 
     BASE_URL = ""
 
-    def __init__(self):
-        self.api_name = "Unknown API"
+    def __init__(self, api_name):
+        self.api_name = api_name
         self.authorization_error_message = "HTTP 401 Unauthorized"
 
     def request(

--- a/tasks/libs/common/remote_api.py
+++ b/tasks/libs/common/remote_api.py
@@ -6,6 +6,13 @@ from invoke.exceptions import Exit
 errno_regex = re.compile(r".*\[Errno (\d+)\] (.*)")
 
 
+class APIError(Exception):
+    def __init__(self, request, api_name):
+        super(APIError, self).__init__(f"{api_name} says: {request.json()}")
+        self.status_code = request.status_code
+        self.request = request
+
+
 class RemoteAPI(object):
     """
     Helper class to perform calls against a given remote API.
@@ -69,8 +76,7 @@ class RemoteAPI(object):
             if r.status_code >= 400:
                 if r.status_code == 401:
                     print(self.authorization_error_message)
-                print(f"{self.api_name} says: {r.json()}")
-                raise Exit(code=1)
+                raise APIError(r, self.api_name)
         except requests.exceptions.Timeout:
             print(f"Connection to {self.api_name} ({url}) timed out.")
             raise Exit(code=1)

--- a/tasks/libs/pipeline_notifications.py
+++ b/tasks/libs/pipeline_notifications.py
@@ -55,7 +55,7 @@ def read_owners(owners_file):
 def get_failed_tests(project_name, job, owners_file=".github/CODEOWNERS"):
     gitlab = Gitlab(project_name=project_name, api_token=get_gitlab_token())
     owners = read_owners(owners_file)
-    test_output = gitlab.artifact(job["id"], "test_output.json")
+    test_output = gitlab.artifact(job["id"], "test_output.json", ignore_not_found=True)
     failed_tests = {}  # type: dict[tuple[str, str], Test]
     if test_output:
         for line in test_output.iter_lines():

--- a/tasks/release.py
+++ b/tasks/release.py
@@ -16,6 +16,7 @@ from invoke.exceptions import Exit
 from tasks.libs.common.color import color_message
 from tasks.libs.common.github_api import GithubAPI, get_github_token
 from tasks.libs.common.gitlab import Gitlab, get_gitlab_token
+from tasks.libs.common.remote_api import APIError
 from tasks.pipeline import run
 from tasks.utils import DEFAULT_BRANCH, get_version, nightly_entry_for, release_entry_for
 
@@ -976,7 +977,12 @@ def check_upstream_branch(github, branch):
     """
     Checks if the given branch already exists in the upstream repository
     """
-    github_branch = github.get_branch(branch)
+    try:
+        github_branch = github.get_branch(branch)
+    except APIError as e:
+        if e.status_code == 404:
+            return False
+        raise e
 
     # Return True if the branch exists
     return github_branch and github_branch.get('name', False)


### PR DESCRIPTION
### What does this PR do?

- Raise an exception on API failure instead of exiting immediately.
- When trying to download artifacts from Gitlab, ignore exceptions caused by 404s.
- Add missing invocations of the `RemoteAPI` parent class from subclasses.
- Fix `api_name` not being defined for `GithubAPI`.

### Motivation

The `test_output.json` file might not be an artifact for some jobs.
