### PR TITLE
pkg/trace: Clean env samplers

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -72,7 +72,7 @@ type Agent struct {
 // NewAgent returns a new Agent object, ready to be started. It takes a context
 // which may be cancelled in order to gracefully stop the agent.
 func NewAgent(ctx context.Context, conf *config.AgentConfig) *Agent {
-	dynConf := sampler.NewDynamicConfig(conf.DefaultEnv)
+	dynConf := sampler.NewDynamicConfig()
 	in := make(chan *api.Payload, 1000)
 	statsChan := make(chan pb.StatsPayload, 100)
 

--- a/pkg/trace/api/api_test.go
+++ b/pkg/trace/api/api_test.go
@@ -50,7 +50,7 @@ type noopStatsProcessor struct{}
 func (noopStatsProcessor) ProcessStats(_ pb.ClientStatsPayload, _, _ string) {}
 
 func newTestReceiverFromConfig(conf *config.AgentConfig) *HTTPReceiver {
-	dynConf := sampler.NewDynamicConfig("none")
+	dynConf := sampler.NewDynamicConfig()
 
 	rawTraceChan := make(chan *Payload, 5000)
 	receiver := NewHTTPReceiver(conf, dynConf, rawTraceChan, noopStatsProcessor{})

--- a/pkg/trace/sampler/catalog_test.go
+++ b/pkg/trace/sampler/catalog_test.go
@@ -35,7 +35,7 @@ func TestCatalogRegression(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		for i := 0; i < n; i++ {
-			cat.ratesByService(map[Signature]float64{
+			cat.ratesByService("", map[Signature]float64{
 				ServiceSignature{}.Hash():                 0.3,
 				ServiceSignature{"web", "staging"}.Hash(): 0.4,
 			}, nil, 0.2)
@@ -65,14 +65,14 @@ func TestServiceKeyCatalogRegister(t *testing.T) {
 	_, root1 := getTestTraceWithService(t, "service1", s)
 	sig1 := cat.register(ServiceSignature{root1.Service, defaultEnv})
 	catalogContains(t, cat, map[ServiceSignature]Signature{
-		{"service1", "none"}: sig1,
+		{"service1", "testEnv"}: sig1,
 	})
 
 	_, root2 := getTestTraceWithService(t, "service2", s)
 	sig2 := cat.register(ServiceSignature{root2.Service, defaultEnv})
 	catalogContains(t, cat, map[ServiceSignature]Signature{
-		{"service1", "none"}: sig1,
-		{"service2", "none"}: sig2,
+		{"service1", "testEnv"}: sig1,
+		{"service2", "testEnv"}: sig2,
 	})
 }
 
@@ -139,6 +139,40 @@ func catalogContains(t *testing.T, cat *serviceKeyCatalog, has map[ServiceSignat
 	}
 }
 
+func TestCatalogEnvMatchAgent(t *testing.T) {
+	assert := assert.New(t)
+	cat := newServiceLookup()
+
+	sig1 := ServiceSignature{"service1", defaultEnv}
+	cat.register(sig1)
+	sig2 := ServiceSignature{"service2", defaultEnv}
+	cat.register(sig2)
+	sig3 := ServiceSignature{"service3", defaultEnv}
+	cat.register(sig3)
+
+	rates := map[Signature]float64{
+		sig1.Hash(): 0.3,
+		sig2.Hash(): 0.7,
+	}
+	const totalRate = 0.2
+
+	remoteRates := map[Signature]float64{
+		sig2.Hash(): 0.5555,
+		sig3.Hash(): 0.19,
+	}
+
+	rateByService := cat.ratesByService(defaultEnv, rates, remoteRates, totalRate)
+	assert.Equal(map[ServiceSignature]float64{
+		{"service1", defaultEnv}: 0.3,
+		{"service1", ""}:         0.3,
+		{"service2", defaultEnv}: 0.5555,
+		{"service2", ""}:         0.5555,
+		{"service3", defaultEnv}: 0.19,
+		{"service3", ""}:         0.19,
+		{}:                       0.2,
+	}, rateByService)
+}
+
 func TestServiceKeyCatalogRatesByService(t *testing.T) {
 	assert := assert.New(t)
 
@@ -163,25 +197,25 @@ func TestServiceKeyCatalogRatesByService(t *testing.T) {
 		sig3: 0.19,
 	}
 
-	rateByService := cat.ratesByService(rates, remoteRates, totalRate)
+	rateByService := cat.ratesByService("", rates, remoteRates, totalRate)
 	assert.Equal(map[ServiceSignature]float64{
-		{"service1", "none"}: 0.3,
-		{"service2", "none"}: 0.5555,
-		{"service3", "none"}: 0.19,
-		{}:                   0.2,
+		{"service1", "testEnv"}: 0.3,
+		{"service2", "testEnv"}: 0.5555,
+		{"service3", "testEnv"}: 0.19,
+		{}:                      0.2,
 	}, rateByService)
 
 	delete(rates, sig1)
 
-	rateByService = cat.ratesByService(rates, nil, totalRate)
+	rateByService = cat.ratesByService("", rates, nil, totalRate)
 	assert.Equal(map[ServiceSignature]float64{
-		{"service2", "none"}: 0.7,
-		{}:                   0.2,
+		{"service2", "testEnv"}: 0.7,
+		{}:                      0.2,
 	}, rateByService)
 
 	delete(rates, sig2)
 
-	rateByService = cat.ratesByService(rates, nil, totalRate)
+	rateByService = cat.ratesByService("", rates, nil, totalRate)
 	assert.Equal(map[ServiceSignature]float64{
 		{}: 0.2,
 	}, rateByService)

--- a/pkg/trace/sampler/dynamic_config.go
+++ b/pkg/trace/sampler/dynamic_config.go
@@ -20,15 +20,13 @@ type DynamicConfig struct {
 // NewDynamicConfig creates a new dynamic config object which maps service signatures
 // to their corresponding sampling rates. Each service will have a default assigned
 // matching the service rate of the specified env.
-func NewDynamicConfig(env string) *DynamicConfig {
-	return &DynamicConfig{RateByService: RateByService{defaultEnv: env}}
+func NewDynamicConfig() *DynamicConfig {
+	return &DynamicConfig{RateByService: RateByService{}}
 }
 
 // RateByService stores the sampling rate per service. It is thread-safe, so
 // one can read/write on it concurrently, using getters and setters.
 type RateByService struct {
-	defaultEnv string // env. to use for service defaults
-
 	mu    sync.RWMutex // guards rates
 	rates map[string]float64
 }
@@ -53,11 +51,6 @@ func (rbs *RateByService) SetAll(rates map[ServiceSignature]float64) {
 			v = 1
 		}
 		rbs.rates[k.String()] = v
-		if k.Env == rbs.defaultEnv {
-			// if this is the default env, then this is also the
-			// service's default rate unbound to any env.
-			rbs.rates[ServiceSignature{Name: k.Name}.String()] = v
-		}
 	}
 }
 

--- a/pkg/trace/sampler/dynamic_config_test.go
+++ b/pkg/trace/sampler/dynamic_config_test.go
@@ -16,7 +16,7 @@ import (
 func TestNewDynamicConfig(t *testing.T) {
 	assert := assert.New(t)
 
-	dc := NewDynamicConfig("none")
+	dc := NewDynamicConfig()
 	assert.NotNil(dc)
 
 	rates := map[ServiceSignature]float64{
@@ -93,7 +93,7 @@ func TestRateByServiceLimits(t *testing.T) {
 }
 
 func TestRateByServiceDefaults(t *testing.T) {
-	rbc := RateByService{defaultEnv: "test"}
+	rbc := RateByService{}
 	rbc.SetAll(map[ServiceSignature]float64{
 		{"one", "prod"}: 0.5,
 		{"two", "test"}: 0.4,
@@ -101,7 +101,6 @@ func TestRateByServiceDefaults(t *testing.T) {
 	assert.Equal(t, map[string]float64{
 		"service:one,env:prod": 0.5,
 		"service:two,env:test": 0.4,
-		"service:two,env:":     0.4,
 	}, rbc.GetAll())
 }
 
@@ -134,7 +133,7 @@ func TestRateByServiceConcurrency(t *testing.T) {
 
 func benchRBSGetAll(sigs map[ServiceSignature]float64) func(*testing.B) {
 	return func(b *testing.B) {
-		rbs := &RateByService{defaultEnv: "test"}
+		rbs := &RateByService{}
 		rbs.SetAll(sigs)
 
 		b.ResetTimer()
@@ -148,7 +147,7 @@ func benchRBSGetAll(sigs map[ServiceSignature]float64) func(*testing.B) {
 
 func benchRBSSetAll(sigs map[ServiceSignature]float64) func(*testing.B) {
 	return func(b *testing.B) {
-		rbs := &RateByService{defaultEnv: "test"}
+		rbs := &RateByService{}
 
 		b.ResetTimer()
 		b.ReportAllocs()

--- a/pkg/trace/sampler/env.go
+++ b/pkg/trace/sampler/env.go
@@ -1,0 +1,18 @@
+package sampler
+
+// tracers with an env value of "" or agentEnv share
+// the same sampler. This is required as remote is unaware
+// of agentEnv and tracerEnv different values
+func toSamplerEnv(tracerEnv, agentEnv string) string {
+	env := tracerEnv
+	if env == "" {
+		env = agentEnv
+	}
+	return env
+}
+
+// tracers with empty env will have the same rate given
+// as tracers with agentEnv
+func rateWithEmptyEnv(samplerEnv, agentEnv string) bool {
+	return samplerEnv == agentEnv
+}

--- a/pkg/trace/sampler/prioritysampler.go
+++ b/pkg/trace/sampler/prioritysampler.go
@@ -35,16 +35,17 @@ const (
 	priorityLocalRateThresholdTo1 = 0.3
 )
 
-// PrioritySampler computes priority rates per env, service to apply in a feedback loop with trace-agent clients.
+// PrioritySampler computes priority rates per tracerEnv, service to apply in a feedback loop with trace-agent clients.
 // Computed rates are sent in http responses to trace-agent. The rates are continuously adjusted in function
 // of the received traffic to match a targetTPS (target traces per second).
 // In order of priority, the sampler will match a targetTPS set remotely (remoteRates) and then the local targetTPS.
 type PrioritySampler struct {
+	agentEnv string
 	// localRates targetTPS is defined locally on the agent
 	// This sampler tries to get the received number of sampled trace chunks/s to match its targetTPS.
 	localRates *Sampler
 	// remoteRates targetTPS is set remotely and distributed by remote configurations.
-	// One target is defined per combination of env, service and it applies only to root spans.
+	// One target is defined per combination of tracerEnv, service and it applies only to root spans.
 	remoteRates *RemoteRates
 
 	// rateByService contains the sampling rates in % to communicate with trace-agent clients.
@@ -57,6 +58,7 @@ type PrioritySampler struct {
 // NewPrioritySampler returns an initialized Sampler
 func NewPrioritySampler(conf *config.AgentConfig, dynConf *DynamicConfig) *PrioritySampler {
 	s := &PrioritySampler{
+		agentEnv:      conf.DefaultEnv,
 		localRates:    newSampler(conf.ExtraSampleRate, conf.TargetTPS, []string{"sampler:priority"}),
 		remoteRates:   newRemoteRates(),
 		rateByService: &dynConf.RateByService,
@@ -98,7 +100,7 @@ func (s *PrioritySampler) Stop() {
 }
 
 // Sample counts an incoming trace and returns the trace sampling decision and the applied sampling rate
-func (s *PrioritySampler) Sample(trace *pb.TraceChunk, root *pb.Span, env string, clientDroppedP0s bool) bool {
+func (s *PrioritySampler) Sample(trace *pb.TraceChunk, root *pb.Span, tracerEnv string, clientDroppedP0s bool) bool {
 	// Extra safety, just in case one trace is empty
 	if len(trace.Spans) == 0 {
 		return false
@@ -125,7 +127,7 @@ func (s *PrioritySampler) Sample(trace *pb.TraceChunk, root *pb.Span, env string
 		return sampled
 	}
 
-	signature := s.catalog.register(ServiceSignature{Name: root.Service, Env: env})
+	signature := s.catalog.register(ServiceSignature{Name: root.Service, Env: toSamplerEnv(tracerEnv, s.agentEnv)})
 
 	// Update sampler state by counting this trace
 	s.CountSignature(root, signature)
@@ -220,5 +222,5 @@ func (s *PrioritySampler) ratesByService() map[ServiceSignature]float64 {
 		remoteRates = s.remoteRates.GetAllSignatureSampleRates()
 	}
 	localRates := s.localRates.GetAllSignatureSampleRates()
-	return s.catalog.ratesByService(localRates, remoteRates, s.localRates.GetDefaultSampleRate())
+	return s.catalog.ratesByService(s.agentEnv, localRates, remoteRates, s.localRates.GetDefaultSampleRate())
 }

--- a/pkg/trace/sampler/scoresampler_test.go
+++ b/pkg/trace/sampler/scoresampler_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-const defaultEnv = "none"
+const defaultEnv = "testEnv"
 
 func getTestErrorsSampler(tps float64) *ErrorsSampler {
 	// Disable debug logs in these tests


### PR DESCRIPTION
Explicit use of env in priority sampling.
This PR is a follow-up of https://github.com/DataDog/datadog-agent/pull/10283 and aims at removing ambiguity between tracerEnv and agentEnv

Prior to PR 10283 the priority sampler would use the agentEnv if the tracerEnv is empty. This PR keeps the same behavior.