### PR TITLE
[pkg/otlp] Add basic tagger support

### DIFF
--- a/pkg/config/otlp.go
+++ b/pkg/config/otlp.go
@@ -16,6 +16,7 @@ const (
 	ReceiverSubSectionKey           = "receiver"
 	ExperimentalOTLPReceiverSection = ExperimentalOTLPSection + "." + ReceiverSubSectionKey
 	ExperimentalOTLPMetrics         = ExperimentalOTLPSection + ".metrics"
+	tagCardinalityKey               = "otlp_tag_cardinality"
 )
 
 // SetupOTLP related configuration.
@@ -25,6 +26,11 @@ func SetupOTLP(config Config) {
 	config.BindEnvAndSetDefault(ExperimentalOTLPTracesEnabled, true)
 	config.BindEnv(ExperimentalOTLPHTTPPort, "DD_OTLP_HTTP_PORT")
 	config.BindEnv(ExperimentalOTLPgRPCPort, "DD_OTLP_GRPC_PORT")
+
+	// NOTE: This only partially works.
+	// The environment variable is also manually checked
+	// in pkg/otlp/internal/serializerexporter/exporter.go
+	config.BindEnv(tagCardinalityKey, "DD_OTLP_TAG_CARDINALITY")
 
 	config.SetKnown(ExperimentalOTLPMetrics)
 	// Set all subkeys of experimental.otlp.metrics as known

--- a/pkg/config/otlp.go
+++ b/pkg/config/otlp.go
@@ -7,16 +7,16 @@ package config
 
 // Experimental OTLP configuration paths.
 const (
-	ExperimentalOTLPSection         = "experimental.otlp"
-	ExperimentalOTLPHTTPPort        = ExperimentalOTLPSection + ".http_port"
-	ExperimentalOTLPgRPCPort        = ExperimentalOTLPSection + ".grpc_port"
-	ExperimentalOTLPTracePort       = ExperimentalOTLPSection + ".internal_traces_port"
-	ExperimentalOTLPMetricsEnabled  = ExperimentalOTLPSection + ".metrics_enabled"
-	ExperimentalOTLPTracesEnabled   = ExperimentalOTLPSection + ".traces_enabled"
-	ReceiverSubSectionKey           = "receiver"
-	ExperimentalOTLPReceiverSection = ExperimentalOTLPSection + "." + ReceiverSubSectionKey
-	ExperimentalOTLPMetrics         = ExperimentalOTLPSection + ".metrics"
-	tagCardinalityKey               = "otlp_tag_cardinality"
+	ExperimentalOTLPSection           = "experimental.otlp"
+	ExperimentalOTLPHTTPPort          = ExperimentalOTLPSection + ".http_port"
+	ExperimentalOTLPgRPCPort          = ExperimentalOTLPSection + ".grpc_port"
+	ExperimentalOTLPTracePort         = ExperimentalOTLPSection + ".internal_traces_port"
+	ExperimentalOTLPMetricsEnabled    = ExperimentalOTLPSection + ".metrics_enabled"
+	ExperimentalOTLPTracesEnabled     = ExperimentalOTLPSection + ".traces_enabled"
+	ReceiverSubSectionKey             = "receiver"
+	ExperimentalOTLPReceiverSection   = ExperimentalOTLPSection + "." + ReceiverSubSectionKey
+	ExperimentalOTLPMetrics           = ExperimentalOTLPSection + ".metrics"
+	ExperimentalOTLPTagCardinalityKey = ExperimentalOTLPMetrics + ".tag_cardinality"
 )
 
 // SetupOTLP related configuration.
@@ -28,9 +28,8 @@ func SetupOTLP(config Config) {
 	config.BindEnv(ExperimentalOTLPgRPCPort, "DD_OTLP_GRPC_PORT")
 
 	// NOTE: This only partially works.
-	// The environment variable is also manually checked
-	// in pkg/otlp/internal/serializerexporter/exporter.go
-	config.BindEnv(tagCardinalityKey, "DD_OTLP_TAG_CARDINALITY")
+	// The environment variable is also manually checked in pkg/otlp/config.go
+	config.BindEnv(ExperimentalOTLPTagCardinalityKey, "DD_OTLP_TAG_CARDINALITY")
 
 	config.SetKnown(ExperimentalOTLPMetrics)
 	// Set all subkeys of experimental.otlp.metrics as known

--- a/pkg/otlp/config.go
+++ b/pkg/otlp/config.go
@@ -9,6 +9,7 @@ package otlp
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -144,6 +145,13 @@ func fromExperimentalConfig(cfg config.Config) (PipelineConfig, error) {
 	metrics := map[string]interface{}{}
 	if isSetExperimentalMetrics(cfg) {
 		metrics = cfg.GetStringMap(config.ExperimentalOTLPMetrics)
+	}
+
+	// HACK: Because of https://github.com/spf13/viper/issues/1012
+	// we need to manually check the environment variable for any nested setting.
+	// The 'correct' solution would be to fix this in our Viper fork.
+	if env, ok := os.LookupEnv("DD_OTLP_TAG_CARDINALITY"); ok {
+		metrics["tag_cardinality"] = env
 	}
 
 	return PipelineConfig{

--- a/pkg/otlp/config.go
+++ b/pkg/otlp/config.go
@@ -9,7 +9,6 @@ package otlp
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -148,11 +147,9 @@ func fromExperimentalConfig(cfg config.Config) (PipelineConfig, error) {
 	}
 
 	// HACK: Because of https://github.com/spf13/viper/issues/1012
-	// we need to manually check the environment variable for any nested setting.
+	// we need to manually get the nested setting to support the bound environment variable.
 	// The 'correct' solution would be to fix this in our Viper fork.
-	if env, ok := os.LookupEnv("DD_OTLP_TAG_CARDINALITY"); ok {
-		metrics["tag_cardinality"] = env
-	}
+	metrics["tag_cardinality"] = cfg.GetString(config.ExperimentalOTLPTagCardinalityKey)
 
 	return PipelineConfig{
 		OTLPReceiverConfig: otlpConfig.ToStringMap(),

--- a/pkg/otlp/config_test.go
+++ b/pkg/otlp/config_test.go
@@ -194,6 +194,7 @@ func TestFromAgentConfigMetrics(t *testing.T) {
 					"send_monotonic_counter":                   true,
 					"resource_attributes_as_tags":              true,
 					"instrumentation_library_metadata_as_tags": true,
+					"tag_cardinality":                          "orchestrator",
 					"histograms": map[string]interface{}{
 						"mode":                   "counters",
 						"send_count_sum_metrics": true,

--- a/pkg/otlp/config_test.go
+++ b/pkg/otlp/config_test.go
@@ -57,7 +57,9 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				TracePort:          5003,
 				MetricsEnabled:     true,
 				TracesEnabled:      true,
-				Metrics:            map[string]interface{}{},
+				Metrics: map[string]interface{}{
+					"tag_cardinality": "",
+				},
 			},
 		},
 		{
@@ -67,7 +69,9 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				TracePort:          5003,
 				MetricsEnabled:     true,
 				TracesEnabled:      true,
-				Metrics:            map[string]interface{}{},
+				Metrics: map[string]interface{}{
+					"tag_cardinality": "",
+				},
 			},
 		},
 		{
@@ -89,7 +93,9 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				TracePort:          5003,
 				MetricsEnabled:     true,
 				TracesEnabled:      true,
-				Metrics:            map[string]interface{}{},
+				Metrics: map[string]interface{}{
+					"tag_cardinality": "",
+				},
 			},
 		},
 		{
@@ -103,7 +109,9 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				TracePort:          5003,
 				MetricsEnabled:     true,
 				TracesEnabled:      true,
-				Metrics:            map[string]interface{}{},
+				Metrics: map[string]interface{}{
+					"tag_cardinality": "",
+				},
 			},
 		},
 		{
@@ -113,7 +121,9 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				TracePort:          5003,
 				MetricsEnabled:     true,
 				TracesEnabled:      true,
-				Metrics:            map[string]interface{}{},
+				Metrics: map[string]interface{}{
+					"tag_cardinality": "",
+				},
 			},
 		},
 		{
@@ -128,7 +138,9 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				TracePort:      5003,
 				MetricsEnabled: true,
 				TracesEnabled:  true,
-				Metrics:        map[string]interface{}{},
+				Metrics: map[string]interface{}{
+					"tag_cardinality": "",
+				},
 			},
 		},
 		{
@@ -156,7 +168,9 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				TracePort:      5003,
 				MetricsEnabled: true,
 				TracesEnabled:  true,
-				Metrics:        map[string]interface{}{},
+				Metrics: map[string]interface{}{
+					"tag_cardinality": "",
+				},
 			},
 		},
 	}

--- a/pkg/otlp/internal/serializerexporter/config.go
+++ b/pkg/otlp/internal/serializerexporter/config.go
@@ -36,6 +36,9 @@ type metricsConfig struct {
 
 	ExporterConfig metricsExporterConfig `mapstructure:",squash"`
 
+	// TagCardinality is the level of granularity of tags to send for OTLP metrics.
+	TagCardinality string `mapstructure:"tag_cardinality"`
+
 	// HistConfig defines the export of OTLP Histograms.
 	HistConfig histogramConfig `mapstructure:"histograms"`
 }

--- a/pkg/otlp/internal/serializerexporter/consumer.go
+++ b/pkg/otlp/internal/serializerexporter/consumer.go
@@ -14,6 +14,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/otlp/model/translator"
 	"github.com/DataDog/datadog-agent/pkg/quantile"
 	"github.com/DataDog/datadog-agent/pkg/serializer"
+	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/tagset"
 )
 
 var _ translator.Consumer = (*serializerConsumer)(nil)
@@ -69,6 +71,29 @@ func (c *serializerConsumer) addTelemetryMetric(hostname string) {
 		MType:          metrics.APIGaugeType,
 		SourceTypeName: "System",
 	})
+}
+
+// enrichTags of series and sketches.
+// This method should be called once after metrics have been mapped.
+//
+// In the OTLP pipeline, 'contexts' are kept within the translator, and,
+// therefore, this works a little differently than for DogStatsD/check metrics.
+func (c *serializerConsumer) enrichTags(cardinality string) {
+	// TODO (AP-1328): Get origin from semantic conventions.
+	const origin = ""
+	const k8sOriginID = ""
+
+	for i := range c.series {
+		tb := tagset.NewHashlessTagsAccumulatorFromSlice(c.series[i].Tags)
+		tagger.EnrichTags(tb, origin, k8sOriginID, cardinality)
+		c.series[i].Tags = tb.Get()
+	}
+
+	for i := range c.sketches {
+		tb := tagset.NewHashlessTagsAccumulatorFromSlice(c.sketches[i].Tags)
+		tagger.EnrichTags(tb, origin, k8sOriginID, cardinality)
+		c.sketches[i].Tags = tb.Get()
+	}
 }
 
 // flush all metrics and sketches in consumer.

--- a/pkg/otlp/testdata/metrics/allconfig.yaml
+++ b/pkg/otlp/testdata/metrics/allconfig.yaml
@@ -6,6 +6,7 @@ experimental:
       delta_ttl: 2400
       report_quantiles: false
       send_monotonic_counter: true
+      tag_cardinality: orchestrator
       resource_attributes_as_tags: true
       instrumentation_library_metadata_as_tags: true
       histograms:

--- a/releasenotes/notes/otlp-tagger-21e4cb2b87eb5e6c.yaml
+++ b/releasenotes/notes/otlp-tagger-21e4cb2b87eb5e6c.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    OTLP metrics tags are enriched when ```experimental.otlp.metrics.tag_cardinality`` is set to ``orchestrator`` or above.
+    This can also be controlled via the ``DD_OTLP_TAG_CARDINALITY`` environment variable.

--- a/releasenotes/notes/otlp-tagger-21e4cb2b87eb5e6c.yaml
+++ b/releasenotes/notes/otlp-tagger-21e4cb2b87eb5e6c.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    OTLP metrics tags are enriched when ```experimental.otlp.metrics.tag_cardinality`` is set to ``orchestrator``.
+    OTLP metrics tags are enriched when ``experimental.otlp.metrics.tag_cardinality`` is set to ``orchestrator``.
     This can also be controlled via the ``DD_OTLP_TAG_CARDINALITY`` environment variable.

--- a/releasenotes/notes/otlp-tagger-21e4cb2b87eb5e6c.yaml
+++ b/releasenotes/notes/otlp-tagger-21e4cb2b87eb5e6c.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    OTLP metrics tags are enriched when ```experimental.otlp.metrics.tag_cardinality`` is set to ``orchestrator`` or above.
+    OTLP metrics tags are enriched when ```experimental.otlp.metrics.tag_cardinality`` is set to ``orchestrator``.
     This can also be controlled via the ``DD_OTLP_TAG_CARDINALITY`` environment variable.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

This PR adds the bare minimum support for the tagger on the OTLP ingest feature. In certain environments, if the `experimental.otlp.metrics.tag_cardinality` setting is set to `orchestrator` or `high`, metrics will be enriched with tags related to the environment (e.g. `task_arn` on ECS Fargate).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This is the same as the DogStatsD functionality with the `dogstatsd_tag_cardinality` setting, when the metrics have no origin set.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

- Origin detection is not supported yet, but this is a small step in the right direction.
- Telemetry metrics are not enriched (this also happens on the aggregator by default).
- We have to do an ugly hack because of spf13/viper#1012 :(

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->


### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Set the `experimental.otlp.metrics.tag_cardinality` setting to `orchestrator` and the `dogstatsd_tag_cardinality` to `orchestrator`. and check that the metrics are enriched in the same way.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
