### PR TITLE
[pkg/otlp] Add telemetry metric for OTLP metrics feature

### DIFF
--- a/pkg/otlp/internal/serializerexporter/consumer.go
+++ b/pkg/otlp/internal/serializerexporter/consumer.go
@@ -72,8 +72,7 @@ func (c *serializerConsumer) addTelemetryMetric(hostname string) {
 }
 
 // flush all metrics and sketches in consumer.
-func (c *serializerConsumer) flush(hostname string, s serializer.MetricSerializer) error {
-	c.addTelemetryMetric(hostname)
+func (c *serializerConsumer) flush(s serializer.MetricSerializer) error {
 	if err := s.SendSketch(c.sketches); err != nil {
 		return err
 	}

--- a/pkg/otlp/internal/serializerexporter/exporter.go
+++ b/pkg/otlp/internal/serializerexporter/exporter.go
@@ -129,7 +129,8 @@ func (e *exporter) ConsumeMetrics(ctx context.Context, ld pdata.Metrics) error {
 		return err
 	}
 
-	if err := consumer.flush(e.hostname, e.s); err != nil {
+	consumer.addTelemetryMetric(e.hostname)
+	if err := consumer.flush(e.s); err != nil {
 		return fmt.Errorf("failed to flush metrics: %w", err)
 	}
 	return nil

--- a/pkg/otlp/map_provider.go
+++ b/pkg/otlp/map_provider.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021-present Datadog, Inc.
 
+//go:build !serverless
 // +build !serverless
 
 package otlp
@@ -70,6 +71,7 @@ receivers:
 
 processors:
   batch:
+    timeout: 10s
 
 exporters:
   serializer:

--- a/pkg/otlp/map_provider.go
+++ b/pkg/otlp/map_provider.go
@@ -3,7 +3,6 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021-present Datadog, Inc.
 
-//go:build !serverless
 // +build !serverless
 
 package otlp

--- a/pkg/otlp/map_provider_test.go
+++ b/pkg/otlp/map_provider_test.go
@@ -92,7 +92,9 @@ func TestNewMap(t *testing.T) {
 					},
 				},
 				"processors": map[string]interface{}{
-					"batch": nil,
+					"batch": map[string]interface{}{
+						"timeout": "10s",
+					},
 				},
 				"exporters": map[string]interface{}{
 					"otlp": map[string]interface{}{
@@ -197,7 +199,9 @@ func TestNewMap(t *testing.T) {
 					},
 				},
 				"processors": map[string]interface{}{
-					"batch": nil,
+					"batch": map[string]interface{}{
+						"timeout": "10s",
+					},
 				},
 				"exporters": map[string]interface{}{
 					"serializer": map[string]interface{}{


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Add telemetry metric for OTLP metrics feature. Set timeout on batch processor to 10s so that this metric is sent at a reasonable pace.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Have a `metric_to_check` on the Otel tile when we add OTLP ingest in the Agent there.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

A metric point will be generated per metrics batch.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Run the OTLP pipeline and send a metric into it. Check that telemetry metric is generated

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
