### PR TITLE
[serverless] Temporarily skip flaky tests

### DIFF
--- a/pkg/serverless/invocationlifecycle/lifecycle_test.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle_test.go
@@ -74,6 +74,8 @@ func TestStartExecutionSpanNoLambdaLibrary(t *testing.T) {
 }
 
 func TestStartExecutionSpanWithLambdaLibrary(t *testing.T) {
+	t.Skip() // TODO: FIX ME - currentExecutionInfo is shared across tests
+
 	extraTags := &logs.Tags{
 		Tags: []string{"functionname:test-function"},
 	}

--- a/pkg/serverless/metrics/metric_test.go
+++ b/pkg/serverless/metrics/metric_test.go
@@ -70,6 +70,8 @@ func TestStartInvalidDogStatsD(t *testing.T) {
 }
 
 func TestStartWithProxy(t *testing.T) {
+	t.Skip() // TODO: FIX ME - config is shared across tests
+
 	os.Setenv("DD_EXPERIMENTAL_ENABLE_PROXY", "true")
 	defer os.Unsetenv("DD_EXPERIMENTAL_ENABLE_PROXY")
 


### PR DESCRIPTION
### What does this PR do?

Skips two flaky tests.

### Motivation

These tests are flaky. Pending a permanent fix, skip them to avoid disrupting others.

### Reviewer's Checklist
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
