### PR TITLE
pkg/trace/api: update the rates payload format

### DIFF
--- a/pkg/trace/api/responses.go
+++ b/pkg/trace/api/responses.go
@@ -27,7 +27,8 @@ const (
 // should we add another fied.
 type traceResponse struct {
 	// All the sampling rates recommended, by service
-	Rates map[string]float64 `json:"rate_by_service"`
+	Rates      map[string]float64 `json:"rate_by_service"`
+	Mechanisms map[string]uint32  `json:"mechanism,omitempty"`
 }
 
 // httpFormatError is used for payload format errors
@@ -90,18 +91,31 @@ func (wc *writeCounter) N() uint64 { return atomic.LoadUint64(&wc.n) }
 // httpRateByService outputs, as a JSON, the recommended sampling rates for all services.
 // It returns the number of bytes written and a boolean specifying whether the write was
 // successful.
-func httpRateByService(w http.ResponseWriter, dynConf *sampler.DynamicConfig) (n uint64, ok bool) {
-	w.Header().Set("Content-Type", "application/json")
-	response := traceResponse{
-		Rates: dynConf.RateByService.GetAll(), // this is thread-safe
-	}
+func httpRateByService(ratesVersion string, w http.ResponseWriter, dynConf *sampler.DynamicConfig) (n uint64, ok bool) {
 	wc := newWriteCounter(w)
-	ok = true
-	encoder := json.NewEncoder(wc)
-	if err := encoder.Encode(response); err != nil {
-		tags := []string{"error:response-error"}
-		metrics.Count(receiverErrorKey, 1, tags, 1)
-		ok = false
+	var err error
+	defer func() {
+		n, ok = wc.N(), err == nil
+		if err != nil {
+			tags := []string{"error:response-error"}
+			metrics.Count(receiverErrorKey, 1, tags, 1)
+		}
+	}()
+
+	w.Header().Set("Content-Type", "application/json")
+	currentState := dynConf.RateByService.GetNewState(ratesVersion) // this is thread-safe
+	response := traceResponse{
+		Rates: currentState.Rates,
 	}
-	return wc.N(), ok
+	if ratesVersion != "" {
+		w.Header().Set(headerRatesPayloadVersion, currentState.Version)
+		if ratesVersion == currentState.Version {
+			_, err = wc.Write([]byte("{}"))
+			return
+		}
+		response.Mechanisms = currentState.Mechanisms
+	}
+	encoder := json.NewEncoder(wc)
+	err = encoder.Encode(response)
+	return
 }

--- a/pkg/trace/api/responses.go
+++ b/pkg/trace/api/responses.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/trace/api/apiutil"
 	"github.com/DataDog/datadog-agent/pkg/trace/metrics"
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -27,8 +28,8 @@ const (
 // should we add another fied.
 type traceResponse struct {
 	// All the sampling rates recommended, by service
-	Rates      map[string]float64 `json:"rate_by_service"`
-	Mechanisms map[string]uint32  `json:"mechanism,omitempty"`
+	Rates      map[string]float64              `json:"rate_by_service"`
+	Mechanisms map[string]pb.SamplingMechanism `json:"mechanism,omitempty"`
 }
 
 // httpFormatError is used for payload format errors

--- a/pkg/trace/api/responses_test.go
+++ b/pkg/trace/api/responses_test.go
@@ -52,11 +52,6 @@ func (w *testResponseWriter) WriteHeader(statusCode int) {
 	w.statusCode = statusCode
 }
 
-type rm struct {
-	r float64
-	m uint32
-}
-
 func TestHTTPRateByService(t *testing.T) {
 	assert := assert.New(t)
 	dc := sampler.NewDynamicConfig()

--- a/pkg/trace/api/responses_test.go
+++ b/pkg/trace/api/responses_test.go
@@ -7,8 +7,11 @@ package api
 
 import (
 	"bytes"
+	"net/http"
+	"strconv"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,4 +27,63 @@ func TestWriteCounter(t *testing.T) {
 	wc.Write([]byte{3})
 	assert.EqualValues(wc.N(), 3)
 	assert.EqualValues(buf.Bytes(), []byte{1, 2, 3})
+}
+
+type testResponseWriter struct {
+	response   string
+	statusCode int
+	header     http.Header
+}
+
+func (w *testResponseWriter) Header() http.Header {
+	if w.header == nil {
+		w.header = http.Header{}
+	}
+
+	return w.header
+}
+
+func (w *testResponseWriter) Write(b []byte) (int, error) {
+	w.response += string(b)
+	return len(b), nil
+}
+
+func (w *testResponseWriter) WriteHeader(statusCode int) {
+	w.statusCode = statusCode
+}
+
+type rm struct {
+	r float64
+	m uint32
+}
+
+func TestHttpRateByService(t *testing.T) {
+	assert := assert.New(t)
+	dc := sampler.NewDynamicConfig()
+	for i, tt := range []struct {
+		version  string
+		response string
+		header   http.Header
+	}{
+		{
+			version:  "",
+			response: "{\"rate_by_service\":{}}\n",
+			header: http.Header{
+				"Content-Type": []string{"application/json"},
+			},
+		},
+		{
+			version:  "-",
+			response: "{\"rate_by_service\":{}}\n",
+			header: http.Header{
+				"Content-Type":                  []string{"application/json"},
+				"Datadog-Rates-Payload-Version": []string{""},
+			},
+		},
+	} {
+		rw := testResponseWriter{}
+		httpRateByService(tt.version, &rw, dc)
+		assert.Equal(tt.header, rw.Header(), strconv.Itoa(i))
+		assert.Equal(tt.response, rw.response, strconv.Itoa(i))
+	}
 }

--- a/pkg/trace/api/responses_test.go
+++ b/pkg/trace/api/responses_test.go
@@ -57,7 +57,7 @@ type rm struct {
 	m uint32
 }
 
-func TestHttpRateByService(t *testing.T) {
+func TestHTTPRateByService(t *testing.T) {
 	assert := assert.New(t)
 	dc := sampler.NewDynamicConfig()
 	for i, tt := range []struct {

--- a/pkg/trace/pb/remote_rates.go
+++ b/pkg/trace/pb/remote_rates.go
@@ -1,5 +1,14 @@
 package pb
 
+// SamplingMechanism is the source of the sampling rates.
+// Possible values
+//     1: agent rate (Default)
+//     2: dynamically calculated remote rate
+//     6: remote rate defined by user
+//     7: remote rate defined by Datadog
+// This list is not exhaustive.
+type SamplingMechanism uint32
+
 // TargetTPS contains the targeted traces per second the agent should try to sample for a particular service and env
 type TargetTPS struct {
 	Service string `msgpack:"0"`
@@ -10,7 +19,7 @@ type TargetTPS struct {
 	// in favor of the highest rank.
 	Rank uint32 `msgpack:"3"`
 	// Mechanism is the identifier of the mechanism that generated this TargetTPS
-	Mechanism uint32 `msgpack:"4"`
+	Mechanism SamplingMechanism `msgpack:"4"`
 }
 
 // APMSampling is the list of target tps

--- a/pkg/trace/pb/remote_rates_gen.go
+++ b/pkg/trace/pb/remote_rates_gen.go
@@ -153,6 +153,58 @@ func (z *APMSampling) Msgsize() (s int) {
 }
 
 // DecodeMsg implements msgp.Decodable
+func (z *SamplingMechanism) DecodeMsg(dc *msgp.Reader) (err error) {
+	{
+		var zb0001 uint32
+		zb0001, err = dc.ReadUint32()
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		(*z) = SamplingMechanism(zb0001)
+	}
+	return
+}
+
+// EncodeMsg implements msgp.Encodable
+func (z SamplingMechanism) EncodeMsg(en *msgp.Writer) (err error) {
+	err = en.WriteUint32(uint32(z))
+	if err != nil {
+		err = msgp.WrapError(err)
+		return
+	}
+	return
+}
+
+// MarshalMsg implements msgp.Marshaler
+func (z SamplingMechanism) MarshalMsg(b []byte) (o []byte, err error) {
+	o = msgp.Require(b, z.Msgsize())
+	o = msgp.AppendUint32(o, uint32(z))
+	return
+}
+
+// UnmarshalMsg implements msgp.Unmarshaler
+func (z *SamplingMechanism) UnmarshalMsg(bts []byte) (o []byte, err error) {
+	{
+		var zb0001 uint32
+		zb0001, bts, err = msgp.ReadUint32Bytes(bts)
+		if err != nil {
+			err = msgp.WrapError(err)
+			return
+		}
+		(*z) = SamplingMechanism(zb0001)
+	}
+	o = bts
+	return
+}
+
+// Msgsize returns an upper bound estimate of the number of bytes occupied by the serialized message
+func (z SamplingMechanism) Msgsize() (s int) {
+	s = msgp.Uint32Size
+	return
+}
+
+// DecodeMsg implements msgp.Decodable
 func (z *TargetTPS) DecodeMsg(dc *msgp.Reader) (err error) {
 	var field []byte
 	_ = field
@@ -195,10 +247,14 @@ func (z *TargetTPS) DecodeMsg(dc *msgp.Reader) (err error) {
 				return
 			}
 		case "4":
-			z.Mechanism, err = dc.ReadUint32()
-			if err != nil {
-				err = msgp.WrapError(err, "Mechanism")
-				return
+			{
+				var zb0002 uint32
+				zb0002, err = dc.ReadUint32()
+				if err != nil {
+					err = msgp.WrapError(err, "Mechanism")
+					return
+				}
+				z.Mechanism = SamplingMechanism(zb0002)
 			}
 		default:
 			err = dc.Skip()
@@ -259,7 +315,7 @@ func (z *TargetTPS) EncodeMsg(en *msgp.Writer) (err error) {
 	if err != nil {
 		return
 	}
-	err = en.WriteUint32(z.Mechanism)
+	err = en.WriteUint32(uint32(z.Mechanism))
 	if err != nil {
 		err = msgp.WrapError(err, "Mechanism")
 		return
@@ -285,7 +341,7 @@ func (z *TargetTPS) MarshalMsg(b []byte) (o []byte, err error) {
 	o = msgp.AppendUint32(o, z.Rank)
 	// string "4"
 	o = append(o, 0xa1, 0x34)
-	o = msgp.AppendUint32(o, z.Mechanism)
+	o = msgp.AppendUint32(o, uint32(z.Mechanism))
 	return
 }
 
@@ -332,10 +388,14 @@ func (z *TargetTPS) UnmarshalMsg(bts []byte) (o []byte, err error) {
 				return
 			}
 		case "4":
-			z.Mechanism, bts, err = msgp.ReadUint32Bytes(bts)
-			if err != nil {
-				err = msgp.WrapError(err, "Mechanism")
-				return
+			{
+				var zb0002 uint32
+				zb0002, bts, err = msgp.ReadUint32Bytes(bts)
+				if err != nil {
+					err = msgp.WrapError(err, "Mechanism")
+					return
+				}
+				z.Mechanism = SamplingMechanism(zb0002)
 			}
 		default:
 			bts, err = msgp.Skip(bts)

--- a/pkg/trace/sampler/catalog.go
+++ b/pkg/trace/sampler/catalog.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	coreconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -37,7 +38,7 @@ type catalogEntry struct {
 // rm specifies the pair of rate and mechanism.
 type rm struct {
 	r float64
-	m samplingMechanism
+	m pb.SamplingMechanism
 }
 
 // newServiceLookup returns a new serviceKeyCatalog.

--- a/pkg/trace/sampler/catalog.go
+++ b/pkg/trace/sampler/catalog.go
@@ -37,7 +37,7 @@ type catalogEntry struct {
 // rm specifies the pair of rate and mechanism.
 type rm struct {
 	r float64
-	m uint32
+	m samplingMechanism
 }
 
 // newServiceLookup returns a new serviceKeyCatalog.

--- a/pkg/trace/sampler/catalog_test.go
+++ b/pkg/trace/sampler/catalog_test.go
@@ -156,20 +156,20 @@ func TestCatalogEnvMatchAgent(t *testing.T) {
 	}
 	const totalRate = 0.2
 
-	remoteRates := map[Signature]float64{
-		sig2.Hash(): 0.5555,
-		sig3.Hash(): 0.19,
+	remoteRates := map[Signature]rm{
+		sig2.Hash(): {0.5555, 2},
+		sig3.Hash(): {0.19, 2},
 	}
 
 	rateByService := cat.ratesByService(defaultEnv, rates, remoteRates, totalRate)
-	assert.Equal(map[ServiceSignature]float64{
-		{"service1", defaultEnv}: 0.3,
-		{"service1", ""}:         0.3,
-		{"service2", defaultEnv}: 0.5555,
-		{"service2", ""}:         0.5555,
-		{"service3", defaultEnv}: 0.19,
-		{"service3", ""}:         0.19,
-		{}:                       0.2,
+	assert.Equal(map[ServiceSignature]rm{
+		{"service1", defaultEnv}: {0.3, 0},
+		{"service1", ""}:         {0.3, 0},
+		{"service2", defaultEnv}: {0.5555, 2},
+		{"service2", ""}:         {0.5555, 2},
+		{"service3", defaultEnv}: {0.19, 2},
+		{"service3", ""}:         {0.19, 2},
+		{}:                       {0.2, 0},
 	}, rateByService)
 }
 
@@ -192,32 +192,32 @@ func TestServiceKeyCatalogRatesByService(t *testing.T) {
 	}
 	const totalRate = 0.2
 
-	remoteRates := map[Signature]float64{
-		sig2: 0.5555,
-		sig3: 0.19,
+	remoteRates := map[Signature]rm{
+		sig2: {0.5555, 2},
+		sig3: {0.19, 2},
 	}
 
 	rateByService := cat.ratesByService("", rates, remoteRates, totalRate)
-	assert.Equal(map[ServiceSignature]float64{
-		{"service1", "testEnv"}: 0.3,
-		{"service2", "testEnv"}: 0.5555,
-		{"service3", "testEnv"}: 0.19,
-		{}:                      0.2,
+	assert.Equal(map[ServiceSignature]rm{
+		{"service1", "testEnv"}: {0.3, 0},
+		{"service2", "testEnv"}: {0.5555, 2},
+		{"service3", "testEnv"}: {0.19, 2},
+		{}:                      {0.2, 0},
 	}, rateByService)
 
 	delete(rates, sig1)
 
 	rateByService = cat.ratesByService("", rates, nil, totalRate)
-	assert.Equal(map[ServiceSignature]float64{
-		{"service2", "testEnv"}: 0.7,
-		{}:                      0.2,
+	assert.Equal(map[ServiceSignature]rm{
+		{"service2", "testEnv"}: {0.7, 0},
+		{}:                      {0.2, 0},
 	}, rateByService)
 
 	delete(rates, sig2)
 
 	rateByService = cat.ratesByService("", rates, nil, totalRate)
-	assert.Equal(map[ServiceSignature]float64{
-		{}: 0.2,
+	assert.Equal(map[ServiceSignature]rm{
+		{}: {0.2, 0},
 	}, rateByService)
 }
 

--- a/pkg/trace/sampler/dynamic_config.go
+++ b/pkg/trace/sampler/dynamic_config.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 )
 
 // DynamicConfig contains configuration items which may change
@@ -31,7 +33,7 @@ func NewDynamicConfig() *DynamicConfig {
 // State specifies the current state of DynamicConfig
 type State struct {
 	Rates      map[string]float64
-	Mechanisms map[string]uint32
+	Mechanisms map[string]pb.SamplingMechanism
 	Version    string
 }
 
@@ -99,13 +101,13 @@ func (rbs *RateByService) GetNewState(version string) State {
 	}
 	ret := State{
 		Rates:      make(map[string]float64, len(rbs.rates)),
-		Mechanisms: make(map[string]uint32, len(rbs.rates)),
+		Mechanisms: make(map[string]pb.SamplingMechanism, len(rbs.rates)),
 		Version:    rbs.version,
 	}
 	for k, v := range rbs.rates {
 		ret.Rates[k] = v.r
 		if v.m != 0 {
-			ret.Mechanisms[k] = uint32(v.m)
+			ret.Mechanisms[k] = v.m
 		}
 	}
 

--- a/pkg/trace/sampler/dynamic_config.go
+++ b/pkg/trace/sampler/dynamic_config.go
@@ -46,7 +46,9 @@ type rmc struct {
 // one can read/write on it concurrently, using getters and setters.
 type RateByService struct {
 	mu sync.RWMutex // guards rates
-	// currentColor is either 0 or 1.
+	// currentColor is either 0 or 1. And, it changes every time `SetAll()` is called.
+	// When `SetAll()` is called, we paint affected keys with `currentColor`.
+	// If there is a key has a color doesn't match `currentColor`, it means that key no longer exists.
 	currentColor int8
 	rates        map[string]*rmc
 	version      string
@@ -103,7 +105,7 @@ func (rbs *RateByService) GetNewState(version string) State {
 	for k, v := range rbs.rates {
 		ret.Rates[k] = v.r
 		if v.m != 0 {
-			ret.Mechanisms[k] = v.m
+			ret.Mechanisms[k] = uint32(v.m)
 		}
 	}
 

--- a/pkg/trace/sampler/dynamic_config_test.go
+++ b/pkg/trace/sampler/dynamic_config_test.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -28,12 +29,12 @@ func TestNewDynamicConfig(t *testing.T) {
 	dc.RateByService.SetAll(rates)
 	state := dc.RateByService.GetNewState("")
 	assert.Equal(map[string]float64{"service:myservice,env:myenv": 0.5}, state.Rates)
-	assert.Equal(map[string]uint32{"service:myservice,env:myenv": 2}, state.Mechanisms)
+	assert.Equal(map[string]pb.SamplingMechanism{"service:myservice,env:myenv": 2}, state.Mechanisms)
 	assert.NotEqual("", state.Version)
 
 	state = dc.RateByService.GetNewState(state.Version)
 	assert.Equal(map[string]float64(nil), state.Rates)
-	assert.Equal(map[string]uint32(nil), state.Mechanisms)
+	assert.Equal(map[string]pb.SamplingMechanism(nil), state.Mechanisms)
 }
 
 func TestRateByServiceGetSet(t *testing.T) {
@@ -50,7 +51,7 @@ func TestRateByServiceGetSet(t *testing.T) {
 				Rates: map[string]float64{
 					"service:,env:": 0.1,
 				},
-				Mechanisms: map[string]uint32{
+				Mechanisms: map[string]pb.SamplingMechanism{
 					"service:,env:": 2,
 				},
 			},
@@ -67,7 +68,7 @@ func TestRateByServiceGetSet(t *testing.T) {
 					"service:mcnulty,env:dev":  0.2,
 					"service:postgres,env:dev": 0.1,
 				},
-				Mechanisms: map[string]uint32{
+				Mechanisms: map[string]pb.SamplingMechanism{
 					"service:,env:":            2,
 					"service:mcnulty,env:dev":  3,
 					"service:postgres,env:dev": 4,
@@ -82,7 +83,7 @@ func TestRateByServiceGetSet(t *testing.T) {
 				Rates: map[string]float64{
 					"service:,env:": 1,
 				},
-				Mechanisms: map[string]uint32{
+				Mechanisms: map[string]pb.SamplingMechanism{
 					"service:,env:": 2,
 				},
 			},
@@ -90,7 +91,7 @@ func TestRateByServiceGetSet(t *testing.T) {
 		{
 			out: State{
 				Rates:      map[string]float64{},
-				Mechanisms: map[string]uint32{},
+				Mechanisms: map[string]pb.SamplingMechanism{},
 			},
 		},
 		{
@@ -101,7 +102,7 @@ func TestRateByServiceGetSet(t *testing.T) {
 				Rates: map[string]float64{
 					"service:,env:": 0.2,
 				},
-				Mechanisms: map[string]uint32{
+				Mechanisms: map[string]pb.SamplingMechanism{
 					"service:,env:": 2,
 				},
 			},
@@ -145,7 +146,7 @@ func TestMechanism(t *testing.T) {
 		{"three", "test"}: {0.4, 0},
 		{"four", "test"}:  {0.4, 3},
 	})
-	assert.Equal(t, map[string]uint32{
+	assert.Equal(t, map[string]pb.SamplingMechanism{
 		"service:two,env:test":  1,
 		"service:four,env:test": 3,
 	}, rbc.GetNewState("").Mechanisms)

--- a/pkg/trace/sampler/dynamic_config_test.go
+++ b/pkg/trace/sampler/dynamic_config_test.go
@@ -19,65 +19,98 @@ func TestNewDynamicConfig(t *testing.T) {
 	dc := NewDynamicConfig()
 	assert.NotNil(dc)
 
-	rates := map[ServiceSignature]float64{
-		{"myservice", "myenv"}: 0.5,
+	rates := map[ServiceSignature]rm{
+		{"myservice", "myenv"}: {0.5, 2},
 	}
 
 	// Not doing a complete test of the different components of dynamic config,
 	// but still assessing it can do the bare minimum once initialized.
 	dc.RateByService.SetAll(rates)
-	rbs := dc.RateByService.GetAll()
-	assert.Equal(map[string]float64{"service:myservice,env:myenv": 0.5}, rbs)
+	state := dc.RateByService.GetNewState("")
+	assert.Equal(map[string]float64{"service:myservice,env:myenv": 0.5}, state.Rates)
+	assert.Equal(map[string]uint32{"service:myservice,env:myenv": 2}, state.Mechanisms)
+	assert.NotEqual("", state.Version)
+
+	state = dc.RateByService.GetNewState(state.Version)
+	assert.Equal(map[string]float64(nil), state.Rates)
+	assert.Equal(map[string]uint32(nil), state.Mechanisms)
 }
 
 func TestRateByServiceGetSet(t *testing.T) {
 	var rbc RateByService
 	for i, tc := range []struct {
-		in  map[ServiceSignature]float64
-		out map[string]float64
+		in  map[ServiceSignature]rm
+		out State
 	}{
 		{
-			in: map[ServiceSignature]float64{
-				{}: 0.1,
+			in: map[ServiceSignature]rm{
+				{}: {0.1, 2},
 			},
-			out: map[string]float64{
-				"service:,env:": 0.1,
-			},
-		},
-		{
-			in: map[ServiceSignature]float64{
-				{}:                  0.3,
-				{"mcnulty", "dev"}:  0.2,
-				{"postgres", "dev"}: 0.1,
-			},
-			out: map[string]float64{
-				"service:,env:":            0.3,
-				"service:mcnulty,env:dev":  0.2,
-				"service:postgres,env:dev": 0.1,
+			out: State{
+				Rates: map[string]float64{
+					"service:,env:": 0.1,
+				},
+				Mechanisms: map[string]uint32{
+					"service:,env:": 2,
+				},
 			},
 		},
 		{
-			in: map[ServiceSignature]float64{
-				{}: 1,
+			in: map[ServiceSignature]rm{
+				{}:                  {0.3, 2},
+				{"mcnulty", "dev"}:  {0.2, 3},
+				{"postgres", "dev"}: {0.1, 4},
 			},
-			out: map[string]float64{
-				"service:,env:": 1,
+			out: State{
+				Rates: map[string]float64{
+					"service:,env:":            0.3,
+					"service:mcnulty,env:dev":  0.2,
+					"service:postgres,env:dev": 0.1,
+				},
+				Mechanisms: map[string]uint32{
+					"service:,env:":            2,
+					"service:mcnulty,env:dev":  3,
+					"service:postgres,env:dev": 4,
+				},
 			},
 		},
 		{
-			out: map[string]float64{},
+			in: map[ServiceSignature]rm{
+				{}: {1, 2},
+			},
+			out: State{
+				Rates: map[string]float64{
+					"service:,env:": 1,
+				},
+				Mechanisms: map[string]uint32{
+					"service:,env:": 2,
+				},
+			},
 		},
 		{
-			in: map[ServiceSignature]float64{
-				{}: 0.2,
+			out: State{
+				Rates:      map[string]float64{},
+				Mechanisms: map[string]uint32{},
 			},
-			out: map[string]float64{
-				"service:,env:": 0.2,
+		},
+		{
+			in: map[ServiceSignature]rm{
+				{}: {0.2, 2},
+			},
+			out: State{
+				Rates: map[string]float64{
+					"service:,env:": 0.2,
+				},
+				Mechanisms: map[string]uint32{
+					"service:,env:": 2,
+				},
 			},
 		},
 	} {
 		rbc.SetAll(tc.in)
-		assert.Equal(t, tc.out, rbc.GetAll(), strconv.Itoa(i))
+		state := rbc.GetNewState("")
+		tc.out.Version = state.Version
+		assert.Equal(t, tc.out, state, strconv.Itoa(i))
 	}
 }
 
@@ -85,23 +118,83 @@ func TestRateByServiceLimits(t *testing.T) {
 	assert := assert.New(t)
 
 	var rbc RateByService
-	rbc.SetAll(map[ServiceSignature]float64{
-		{"high", ""}: 2,
-		{"low", ""}:  -1,
+	rbc.SetAll(map[ServiceSignature]rm{
+		{"high", ""}: {2, 2},
+		{"low", ""}:  {-1, 2},
 	})
-	assert.Equal(map[string]float64{"service:high,env:": 1, "service:low,env:": 0}, rbc.GetAll())
+	assert.Equal(map[string]float64{"service:high,env:": 1, "service:low,env:": 0}, rbc.GetNewState("").Rates)
 }
 
 func TestRateByServiceDefaults(t *testing.T) {
 	rbc := RateByService{}
-	rbc.SetAll(map[ServiceSignature]float64{
-		{"one", "prod"}: 0.5,
-		{"two", "test"}: 0.4,
+	rbc.SetAll(map[ServiceSignature]rm{
+		{"one", "prod"}: {0.5, 0},
+		{"two", "test"}: {0.4, 1},
 	})
 	assert.Equal(t, map[string]float64{
 		"service:one,env:prod": 0.5,
 		"service:two,env:test": 0.4,
-	}, rbc.GetAll())
+	}, rbc.GetNewState("").Rates)
+}
+
+func TestMechanism(t *testing.T) {
+	rbc := RateByService{}
+	rbc.SetAll(map[ServiceSignature]rm{
+		{"one", "prod"}:   {0.5, 0},
+		{"two", "test"}:   {0.4, 1},
+		{"three", "test"}: {0.4, 0},
+		{"four", "test"}:  {0.4, 3},
+	})
+	assert.Equal(t, map[string]uint32{
+		"service:two,env:test":  1,
+		"service:four,env:test": 3,
+	}, rbc.GetNewState("").Mechanisms)
+}
+
+func TestVersionChanges(t *testing.T) {
+	rbc := RateByService{}
+	rates := map[ServiceSignature]rm{
+		{"one", "prod"}:   {0.5, 0},
+		{"two", "test"}:   {0.4, 1},
+		{"three", "test"}: {0.4, 0},
+		{"four", "test"}:  {0.4, 3},
+	}
+
+	previousVersion := rbc.GetNewState("").Version
+	rbc.SetAll(rates)
+	newVersion := rbc.GetNewState("").Version
+	assert.Equal(t, "", previousVersion)
+
+	// received the same rates
+	previousVersion = newVersion
+	rbc.SetAll(rates)
+	newVersion = rbc.GetNewState("").Version
+	assert.Equal(t, previousVersion, newVersion)
+
+	// received slightly different rates
+	previousVersion = newVersion
+	rates[ServiceSignature{"one", "prod"}] = rm{0.5, 1}
+	rbc.SetAll(rates)
+	newVersion = rbc.GetNewState("").Version
+	assert.NotEqual(t, previousVersion, newVersion)
+
+	// received an extra rate
+	previousVersion = newVersion
+	rates[ServiceSignature{"newService", "prod"}] = rm{0.99, 2}
+	rbc.SetAll(rates)
+	newVersion = rbc.GetNewState("").Version
+	assert.NotEqual(t, previousVersion, newVersion)
+
+	// received fewer rates
+	previousVersion = newVersion
+	delete(rates, ServiceSignature{"newService", "prod"})
+	rbc.SetAll(rates)
+	newVersion = rbc.GetNewState("").Version
+	assert.NotEqual(t, previousVersion, newVersion)
+
+	// the response should be empty, because both tracer and agent have the same version
+	state := rbc.GetNewState(newVersion)
+	assert.Equal(t, State{Version: newVersion}, state)
 }
 
 func TestRateByServiceConcurrency(t *testing.T) {
@@ -113,17 +206,17 @@ func TestRateByServiceConcurrency(t *testing.T) {
 	var wg sync.WaitGroup
 	wg.Add(2)
 
-	rbc.SetAll(map[ServiceSignature]float64{{"mcnulty", "test"}: 1})
+	rbc.SetAll(map[ServiceSignature]rm{{"mcnulty", "test"}: {1, 1}})
 	go func() {
 		for i := 0; i < n; i++ {
 			rate := float64(i) / float64(n)
-			rbc.SetAll(map[ServiceSignature]float64{{"mcnulty", "test"}: rate})
+			rbc.SetAll(map[ServiceSignature]rm{{"mcnulty", "test"}: {rate, 2}})
 		}
 		wg.Done()
 	}()
 	go func() {
 		for i := 0; i < n; i++ {
-			rates := rbc.GetAll()
+			rates := rbc.GetNewState("").Rates
 			_, ok := rates["service:mcnulty,env:test"]
 			assert.True(ok, "key should be here")
 		}
@@ -131,7 +224,7 @@ func TestRateByServiceConcurrency(t *testing.T) {
 	}()
 }
 
-func benchRBSGetAll(sigs map[ServiceSignature]float64) func(*testing.B) {
+func benchRBSGetAll(sigs map[ServiceSignature]rm) func(*testing.B) {
 	return func(b *testing.B) {
 		rbs := &RateByService{}
 		rbs.SetAll(sigs)
@@ -140,12 +233,12 @@ func benchRBSGetAll(sigs map[ServiceSignature]float64) func(*testing.B) {
 		b.ReportAllocs()
 
 		for i := 0; i < b.N; i++ {
-			rbs.GetAll()
+			rbs.GetNewState("")
 		}
 	}
 }
 
-func benchRBSSetAll(sigs map[ServiceSignature]float64) func(*testing.B) {
+func benchRBSSetAll(sigs map[ServiceSignature]rm) func(*testing.B) {
 	return func(b *testing.B) {
 		rbs := &RateByService{}
 
@@ -159,19 +252,19 @@ func benchRBSSetAll(sigs map[ServiceSignature]float64) func(*testing.B) {
 }
 
 func BenchmarkRateByService(b *testing.B) {
-	sigs := map[ServiceSignature]float64{
-		{}:                 0.2,
-		{"two", "test"}:    0.4,
-		{"three", "test"}:  0.33,
-		{"one", "prod"}:    0.12,
-		{"five", "test"}:   0.8,
-		{"six", "staging"}: 0.9,
+	sigs := map[ServiceSignature]rm{
+		{}:                 {0.2, 2},
+		{"two", "test"}:    {0.4, 2},
+		{"three", "test"}:  {0.33, 2},
+		{"one", "prod"}:    {0.12, 2},
+		{"five", "test"}:   {0.8, 2},
+		{"six", "staging"}: {0.9, 2},
 	}
 
 	b.Run("GetAll", func(b *testing.B) {
 		for i := 1; i <= len(sigs); i++ {
 			// take first i elements
-			testSigs := make(map[ServiceSignature]float64, i)
+			testSigs := make(map[ServiceSignature]rm, i)
 			var j int
 			for k, v := range sigs {
 				j++
@@ -187,7 +280,7 @@ func BenchmarkRateByService(b *testing.B) {
 	b.Run("SetAll", func(b *testing.B) {
 		for i := 1; i <= len(sigs); i++ {
 			// take first i elements
-			testSigs := make(map[ServiceSignature]float64, i)
+			testSigs := make(map[ServiceSignature]rm, i)
 			var j int
 			for k, v := range sigs {
 				j++

--- a/pkg/trace/sampler/prioritysampler.go
+++ b/pkg/trace/sampler/prioritysampler.go
@@ -236,11 +236,11 @@ func (s *PrioritySampler) applyRate(sampled bool, root *pb.Span, signature Signa
 
 // ratesByService returns all rates by service, this information is useful for
 // agents to pick the right service rate.
-func (s *PrioritySampler) ratesByService() map[ServiceSignature]float64 {
-	var remoteRates map[Signature]float64
+func (s *PrioritySampler) ratesByService() map[ServiceSignature]rm {
+	var remoteRates map[Signature]rm
 	if s.remoteRates != nil {
-		remoteRates = s.remoteRates.GetAllSignatureSampleRates()
+		remoteRates = s.remoteRates.getAllSignatureSampleRates()
 	}
-	localRates := s.localRates.GetAllSignatureSampleRates()
+	localRates := s.localRates.getAllSignatureSampleRates()
 	return s.catalog.ratesByService(s.agentEnv, localRates, remoteRates, s.localRates.GetDefaultSampleRate())
 }

--- a/pkg/trace/sampler/prioritysampler_test.go
+++ b/pkg/trace/sampler/prioritysampler_test.go
@@ -47,8 +47,8 @@ func getTestTraceWithService(t *testing.T, service string, s *PrioritySampler) (
 	key := ServiceSignature{spans[0].Service, defaultEnv}
 	var rate float64
 	if serviceRate, ok := rates[key]; ok {
-		rate = serviceRate
-		spans[0].Metrics[agentRateKey] = serviceRate
+		rate = serviceRate.r
+		spans[0].Metrics[agentRateKey] = serviceRate.r
 	} else {
 		rate = 1
 	}

--- a/pkg/trace/sampler/remote_rates.go
+++ b/pkg/trace/sampler/remote_rates.go
@@ -229,7 +229,7 @@ func (r *RemoteRates) getAllSignatureSampleRates() map[Signature]rm {
 	for sig, s := range r.samplers {
 		res[sig] = rm{
 			r: s.GetSignatureSampleRate(sig),
-			m: samplingMechanism(s.target.Mechanism),
+			m: s.target.Mechanism,
 		}
 	}
 	return res

--- a/pkg/trace/sampler/remote_rates.go
+++ b/pkg/trace/sampler/remote_rates.go
@@ -221,13 +221,16 @@ func (r *RemoteRates) GetSignatureSampleRate(sig Signature) (float64, bool) {
 	return s.GetSignatureSampleRate(sig), true
 }
 
-// GetAllSignatureSampleRates returns sampling rates to apply for all registered signatures.
-func (r *RemoteRates) GetAllSignatureSampleRates() map[Signature]float64 {
+// getAllSignatureSampleRates returns sampling rates to apply for all registered signatures.
+func (r *RemoteRates) getAllSignatureSampleRates() map[Signature]rm {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	res := make(map[Signature]float64, len(r.samplers))
+	res := make(map[Signature]rm, len(r.samplers))
 	for sig, s := range r.samplers {
-		res[sig] = s.GetSignatureSampleRate(sig)
+		res[sig] = rm{
+			r: s.GetSignatureSampleRate(sig),
+			m: s.target.Mechanism,
+		}
 	}
 	return res
 }

--- a/pkg/trace/sampler/remote_rates.go
+++ b/pkg/trace/sampler/remote_rates.go
@@ -229,7 +229,7 @@ func (r *RemoteRates) getAllSignatureSampleRates() map[Signature]rm {
 	for sig, s := range r.samplers {
 		res[sig] = rm{
 			r: s.GetSignatureSampleRate(sig),
-			m: s.target.Mechanism,
+			m: samplingMechanism(s.target.Mechanism),
 		}
 	}
 	return res

--- a/pkg/trace/sampler/remote_rates_test.go
+++ b/pkg/trace/sampler/remote_rates_test.go
@@ -57,7 +57,7 @@ func TestRemoteTPSUpdate(t *testing.T) {
 		service   string
 		env       string
 		targetTPS float64
-		mechanism uint32
+		mechanism pb.SamplingMechanism
 		rank      uint32
 	}
 

--- a/pkg/trace/sampler/sampler.go
+++ b/pkg/trace/sampler/sampler.go
@@ -53,6 +53,15 @@ const (
 // SamplingPriority is the type encoding a priority sampling decision.
 type SamplingPriority int8
 
+// samplingMechanism is the source of the sampling rates.
+// Possible values
+//     1: agent rate (Default)
+//     2: dynamically calculated remote rate
+//     6: remote rate defined by user
+//     7: remote rate defined by Datadog
+// This list is not exhaustive.
+type samplingMechanism uint32
+
 const (
 	// PriorityNone is the value for SamplingPriority when no priority sampling decision could be found.
 	PriorityNone SamplingPriority = math.MinInt8

--- a/pkg/trace/sampler/sampler.go
+++ b/pkg/trace/sampler/sampler.go
@@ -53,15 +53,6 @@ const (
 // SamplingPriority is the type encoding a priority sampling decision.
 type SamplingPriority int8
 
-// samplingMechanism is the source of the sampling rates.
-// Possible values
-//     1: agent rate (Default)
-//     2: dynamically calculated remote rate
-//     6: remote rate defined by user
-//     7: remote rate defined by Datadog
-// This list is not exhaustive.
-type samplingMechanism uint32
-
 const (
 	// PriorityNone is the value for SamplingPriority when no priority sampling decision could be found.
 	PriorityNone SamplingPriority = math.MinInt8

--- a/pkg/trace/sampler/score.go
+++ b/pkg/trace/sampler/score.go
@@ -32,9 +32,9 @@ func (s *Sampler) GetSignatureSampleRate(signature Signature) float64 {
 	return s.loadRate(s.GetCountScore(signature))
 }
 
-// GetAllSignatureSampleRates gives the sample rate to apply to all signatures.
+// getAllSignatureSampleRates gives the sample rate to apply to all signatures.
 // For now, only based on count score.
-func (s *Sampler) GetAllSignatureSampleRates() map[Signature]float64 {
+func (s *Sampler) getAllSignatureSampleRates() map[Signature]float64 {
 	m := s.GetAllCountScores()
 	for k, v := range m {
 		m[k] = s.loadRate(v)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
- Introduces a new API response format
- Introduces versioning in sampling rates, so tracing libraries don't need to fetch the same rates over and over again

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Until now, the agent used to calculate sampling rates. In the future, the agent can receive rates from the remote. In order to distinguish rate source, we are adding a new field `mechanism` in rates in the api response.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
