### PR TITLE
[logs] Support Shift JIS encoded files

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -935,6 +935,7 @@ core,golang.org/x/text/encoding,BSD-3-Clause,The Go Authors
 core,golang.org/x/text/encoding/internal,BSD-3-Clause,The Go Authors
 core,golang.org/x/text/encoding/internal/identifier,BSD-3-Clause,The Go Authors
 core,golang.org/x/text/encoding/unicode,BSD-3-Clause,The Go Authors
+core,golang.org/x/text/encoding/japanese,BSD-3-Clause,The Go Authors
 core,golang.org/x/text/internal/utf8internal,BSD-3-Clause,The Go Authors
 core,golang.org/x/text/runes,BSD-3-Clause,The Go Authors
 core,golang.org/x/text/secure/bidirule,BSD-3-Clause,The Go Authors

--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -28,7 +28,7 @@ const (
 	// UTF16LE for UTF-16 Little Endian encoding
 	UTF16LE string = "utf-16-le"
 	// SHIFTJIS for Shift JIS (Japanese) encoding
-	SHIFTJIS string = "shiftjis"
+	SHIFTJIS string = "shift-jis"
 )
 
 // LogsConfig represents a log source config, which can be for instance

--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -27,6 +27,8 @@ const (
 	UTF16BE string = "utf-16-be"
 	// UTF16LE for UTF-16 Little Endian encoding
 	UTF16LE string = "utf-16-le"
+	// SHIFTJIS for Shift JIS (Japanese) encoding
+	SHIFTJIS string = "shiftjis"
 )
 
 // LogsConfig represents a log source config, which can be for instance

--- a/pkg/logs/input/file/tailer.go
+++ b/pkg/logs/input/file/tailer.go
@@ -93,6 +93,8 @@ func NewDecoderFromSourceWithPattern(source *config.LogSource, multiLinePattern 
 			matcher = decoder.NewBytesSequenceMatcher(decoder.Utf16leEOL, 2)
 		case config.SHIFTJIS:
 			lineParser = parser.NewEncodedText(parser.SHIFTJIS)
+			// No special handling required for the newline matcher since Shift JIS does not use
+			// newline characters (0x0a) as the second byte of a multibyte sequence.
 			matcher = &decoder.NewLineMatcher{}
 		default:
 			lineParser = parser.Noop

--- a/pkg/logs/input/file/tailer.go
+++ b/pkg/logs/input/file/tailer.go
@@ -91,6 +91,9 @@ func NewDecoderFromSourceWithPattern(source *config.LogSource, multiLinePattern 
 		case config.UTF16LE:
 			lineParser = parser.NewEncodedText(parser.UTF16LE)
 			matcher = decoder.NewBytesSequenceMatcher(decoder.Utf16leEOL, 2)
+		case config.SHIFTJIS:
+			lineParser = parser.NewEncodedText(parser.SHIFTJIS)
+			matcher = &decoder.NewLineMatcher{}
 		default:
 			lineParser = parser.Noop
 			matcher = &decoder.NewLineMatcher{}

--- a/pkg/logs/parser/encodedtext.go
+++ b/pkg/logs/parser/encodedtext.go
@@ -7,8 +7,8 @@ package parser
 
 import (
 	"golang.org/x/text/encoding"
-	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/encoding/japanese"
+	"golang.org/x/text/encoding/unicode"
 	"golang.org/x/text/transform"
 )
 

--- a/pkg/logs/parser/encodedtext.go
+++ b/pkg/logs/parser/encodedtext.go
@@ -8,6 +8,7 @@ package parser
 import (
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/unicode"
+	"golang.org/x/text/encoding/japanese"
 	"golang.org/x/text/transform"
 )
 
@@ -19,6 +20,8 @@ const (
 	UTF16LE Encoding = iota
 	// UTF16BE UTF16 big endian
 	UTF16BE
+	// SHIFTJIS Shift JIS (Japanese)
+	SHIFTJIS
 )
 
 // EncodedText a parser for decoding encoded logfiles.  It treats each input
@@ -48,6 +51,8 @@ func NewEncodedText(e Encoding) *EncodedText {
 		enc = unicode.UTF16(unicode.LittleEndian, unicode.UseBOM)
 	case UTF16BE:
 		enc = unicode.UTF16(unicode.BigEndian, unicode.UseBOM)
+	case SHIFTJIS:
+		enc = japanese.ShiftJIS
 	}
 	p.decoder = enc.NewDecoder()
 	return p

--- a/pkg/logs/parser/encodedtext_test.go
+++ b/pkg/logs/parser/encodedtext_test.go
@@ -58,4 +58,3 @@ func TestSHIFTJISParserHandleMessages(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "日本", string(msg))
 }
-

--- a/pkg/logs/parser/encodedtext_test.go
+++ b/pkg/logs/parser/encodedtext_test.go
@@ -50,3 +50,12 @@ func TestUTF16BEParserHandleMessages(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "Foo", string(msg))
 }
+
+func TestSHIFTJISParserHandleMessages(t *testing.T) {
+	parser := NewEncodedText(SHIFTJIS)
+	testMsg := []byte{0x93, 0xfa, 0x96, 0x7b}
+	msg, _, _, _, err := parser.Parse(testMsg)
+	assert.Nil(t, err)
+	assert.Equal(t, "日本", string(msg))
+}
+

--- a/releasenotes/notes/shiftjis-file-support-4a251788e30778a0.yaml
+++ b/releasenotes/notes/shiftjis-file-support-4a251788e30778a0.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Add support for Shift JIS (Japanese) encoding.
+    It should be manually enabled in a log configuration using
+    ``encoding: shiftjis``.

--- a/releasenotes/notes/shiftjis-file-support-4a251788e30778a0.yaml
+++ b/releasenotes/notes/shiftjis-file-support-4a251788e30778a0.yaml
@@ -10,4 +10,4 @@ features:
   - |
     Add support for Shift JIS (Japanese) encoding.
     It should be manually enabled in a log configuration using
-    ``encoding: shiftjis``.
+    ``encoding: shift-jis``.


### PR DESCRIPTION
### What does this PR do?

Adds Shift JIS (Japanese) encoding support when tailing from file.
It can be enabled by adding `encoding: shiftjis` in a log configuration.
About Shift JIS: [wikipedia](https://en.wikipedia.org/wiki/Shift_JIS)

### Motivation

Japanese versions of Windows uses Shift JIS as a primary encoding for Japanese.
Logs from apps and package softwares in Shift JIS cannot be handled by Datadog directly,
So currently, users need to forward logs to fluentd once, and translate to utf-8 with fluentd plugin, then forward them to Datadog.
With this patch, those users can send Shift JIS logs directly via Datadog agent.

### Additional Notes

Shift JIS is written as `ShiftJIS`, `Shift_JIS` and `Shift-JIS`. The underscore and hyphen might be annoying for users to configure correctly, so I chose no hyphenation `shiftjis` as an option string in the configuration.

### Describe how to test/QA your changes

Tail files encoded in Shift JIS. 
On linux system, generate some log lines with Shift JIS encoded message.
`echo "日本" | iconv -t shift_jis | logger`

```
logs:
        - type: file
          path: "/var/log/syslog"
          service: syslog-test
          source: syslog
          encoding: shift-jis
```
for Windows, I used `tomcat`. Set Java locale in `bin\catalina.bat` as the following
`set "JAVA_OPTS=%JAVA_OPTS% -Duser.language=ja -Duser.region=JP"`

and set log file encoding in the `conf\logging.properties`.
`1catalina.org.apache.juli.AsyncFileHandler.encoding = SJIS`

Then `logs\catalina*.log` will be written in Shift JIS. Encoding can be confirmed with editors.

![image](https://user-images.githubusercontent.com/59518903/147623431-e3a15ab2-d65f-4bb9-a895-5258053a8073.png)

With current released agent, Shift JIS logs are shown with garbled characters like the following

![image](https://user-images.githubusercontent.com/59518903/147624264-c16c1bef-bec3-480b-8855-f805692e550c.png)

With this patch, logs show up as expected.

![image](https://user-images.githubusercontent.com/59518903/147624345-6e6a9169-7cff-4a59-a681-cc45fa895f9b.png)


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
