### PR TITLE
[DCA] [Orchestrator] fix sensitive data scrubbing

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -151,6 +151,9 @@ func (o *OrchestratorCheck) Configure(config, initConfig integration.Data, sourc
 		return errors.New("orchestrator check is configured but the feature is disabled")
 	}
 	o.orchestratorConfig.IsScrubbingEnabled = corecfg.Datadog.GetBool("orchestrator_explorer.container_scrubbing.enabled")
+	if corecfg.Datadog.IsSet("orchestrator_explorer.custom_sensitive_words") {
+		o.orchestratorConfig.Scrubber.AddCustomSensitiveWords(corecfg.Datadog.GetStringSlice("orchestrator_explorer.custom_sensitive_words"))
+	}
 	o.orchestratorConfig.ExtraTags = corecfg.Datadog.GetStringSlice("orchestrator_explorer.extra_tags")
 
 	// check if cluster name is set

--- a/releasenotes-dca/notes/fix-sensitive-data-scrubbing-bf51d3adff7ac18a.yaml
+++ b/releasenotes-dca/notes/fix-sensitive-data-scrubbing-bf51d3adff7ac18a.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    fix sensitive data scrubbing.

--- a/releasenotes-dca/notes/fix-sensitive-data-scrubbing-bf51d3adff7ac18a.yaml
+++ b/releasenotes-dca/notes/fix-sensitive-data-scrubbing-bf51d3adff7ac18a.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    fix sensitive data scrubbing.
+    Fix sensitive data scrubbing.

--- a/releasenotes-dca/notes/fix-sensitive-data-scrubbing-bf51d3adff7ac18a.yaml
+++ b/releasenotes-dca/notes/fix-sensitive-data-scrubbing-bf51d3adff7ac18a.yaml
@@ -1,3 +1,3 @@
 fixes:
   - |
-    Fix sensitive data scrubbing.
+    Fix an issue where scrubbing custom sensitive words would not work as intended for the orchestrator check.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Fix sensitive data scrubbing. We need to load the configuration when we create a new one.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
