### PR TITLE
Fix some prometheus scrape field types

### DIFF
--- a/pkg/autodiscovery/common/types/prometheus.go
+++ b/pkg/autodiscovery/common/types/prometheus.go
@@ -51,7 +51,7 @@ type OpenmetricsInstance struct {
 	Metrics                       []string                    `mapstructure:"metrics" yaml:"metrics,omitempty" json:"metrics,omitempty"`
 	Prefix                        string                      `mapstructure:"prometheus_metrics_prefix" yaml:"prometheus_metrics_prefix,omitempty" json:"prometheus_metrics_prefix,omitempty"`
 	HealthCheck                   *bool                       `mapstructure:"health_service_check" yaml:"health_service_check,omitempty" json:"health_service_check,omitempty"`
-	LabelToHostname               bool                        `mapstructure:"label_to_hostname" yaml:"label_to_hostname,omitempty" json:"label_to_hostname,omitempty"`
+	LabelToHostname               string                      `mapstructure:"label_to_hostname" yaml:"label_to_hostname,omitempty" json:"label_to_hostname,omitempty"`
 	LabelJoins                    map[string]LabelJoinsConfig `mapstructure:"label_joins" yaml:"label_joins,omitempty" json:"label_joins,omitempty"`
 	LabelsMapper                  map[string]string           `mapstructure:"labels_mapper" yaml:"labels_mapper,omitempty" json:"labels_mapper,omitempty"`
 	TypeOverride                  map[string]string           `mapstructure:"type_overrides" yaml:"type_overrides,omitempty" json:"type_overrides,omitempty"`
@@ -71,7 +71,7 @@ type OpenmetricsInstance struct {
 	SkipProxy                     bool                        `mapstructure:"skip_proxy" yaml:"skip_proxy,omitempty" json:"skip_proxy,omitempty"`
 	Username                      string                      `mapstructure:"username" yaml:"username,omitempty" json:"username,omitempty"`
 	Password                      string                      `mapstructure:"password" yaml:"password,omitempty" json:"password,omitempty"`
-	TLSVerify                     bool                        `mapstructure:"tls_verify" yaml:"tls_verify,omitempty" json:"tls_verify,omitempty"`
+	TLSVerify                     *bool                       `mapstructure:"tls_verify" yaml:"tls_verify,omitempty" json:"tls_verify,omitempty"`
 	TLSHostHeader                 bool                        `mapstructure:"tls_use_host_header" yaml:"tls_use_host_header,omitempty" json:"tls_use_host_header,omitempty"`
 	TLSIgnoreWarn                 bool                        `mapstructure:"tls_ignore_warning" yaml:"tls_ignore_warning,omitempty" json:"tls_ignore_warning,omitempty"`
 	TLSCert                       string                      `mapstructure:"tls_cert" yaml:"tls_cert,omitempty" json:"tls_cert,omitempty"`

--- a/releasenotes/notes/fix-prometheus-scrape-types-f94a1419add31187.yaml
+++ b/releasenotes/notes/fix-prometheus-scrape-types-f94a1419add31187.yaml
@@ -1,0 +1,4 @@
+fixes:
+  - |
+    Allow prometheus scrape tls_verify to be set to false and 
+    change label_to_hostname type to string.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Allows `tls_verify` to be set to `false` and changes `label_to_hostname` to take a string value. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Support ticket. `json.Marshal` omits the empty value `false` for booleans so the setting `tls_verify:false` was effectively being ignored. `label_to_hostname` looks like it should be a string based on [this template](https://github.com/DataDog/integrations-core/blob/9cbeb2a15d75ccdbe99a89891d1680f5411fe4b3/datadog_checks_dev/datadog_checks/dev/tooling/templates/configuration/instances/openmetrics_legacy_base.yaml#L42-L46), but attempting to set a string value resulted in an unmarshal error:
```
2021-12-29 17:38:42 UTC | CORE | WARN | (pkg/config/config.go:544 in func2) | "prometheus_scrape.checks" can not be parsed: json: cannot unmarshal string into Go struct field OpenmetricsInstance.configurations.label_to_hostname of type bool
```


<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

* Set up an application pod with prometheus annotations and an agent pod with prometheus scrape enabled following [the docs](https://docs.datadoghq.com/agent/kubernetes/prometheus/#configuration-1)
* Using `agent configcheck`, check that `tls_verify:false` can be set to `false` and that setting `label_to_hostname` to a string is reflected in the check configuration and does not produce the `WARN` log from above.

Example helm configuration for prometheus scrape:
```yaml
(...)
  prometheusScrape:
    enabled: true
    additionalConfigs:
      - configurations:
          - tls_verify: false
            label_to_hostname: shortname
```
agent configcheck:
```
=== openmetrics check ===
Configuration provider: prometheus-pods
Configuration source: prometheus_pods:docker://<container_id>
Instance ID: openmetrics:<check_id>
label_to_hostname: shortname
metrics:
- '*'
namespace: ""
prometheus_url: http://<ip>:<port>/metrics
tags:
(...)
tls_verify: false
(...)
```

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
