### PR TITLE
Make `agent checkconfig` an alias of `agent configcheck`

### DIFF
--- a/cmd/agent/app/config_check.go
+++ b/cmd/agent/app/config_check.go
@@ -27,9 +27,10 @@ func init() {
 }
 
 var configCheckCommand = &cobra.Command{
-	Use:   "configcheck",
-	Short: "Print all configurations loaded & resolved of a running agent",
-	Long:  ``,
+	Use:     "configcheck",
+	Aliases: []string{"checkconfig"},
+	Short:   "Print all configurations loaded & resolved of a running agent",
+	Long:    ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		if flagNoColor {

--- a/cmd/cluster-agent/commands/configcheck.go
+++ b/cmd/cluster-agent/commands/configcheck.go
@@ -21,9 +21,10 @@ import (
 func GetConfigCheckCobraCmd(flagNoColor *bool, confPath *string, loggerName config.LoggerName) *cobra.Command {
 	var withDebug bool
 	configCheckCommand := &cobra.Command{
-		Use:   "configcheck",
-		Short: "Print all configurations loaded & resolved of a running cluster agent",
-		Long:  ``,
+		Use:     "configcheck",
+		Aliases: []string{"checkconfig"},
+		Short:   "Print all configurations loaded & resolved of a running cluster agent",
+		Long:    ``,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if *flagNoColor {

--- a/releasenotes/notes/checkconfig-alias-9172271a07db707b.yaml
+++ b/releasenotes/notes/checkconfig-alias-9172271a07db707b.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Make ``agent checkconfig`` an alias of ``agent configcheck``


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Make the `checkconfig` agent command an alias of `configcheck`.

### Motivation

I’m always typing `agent checkconfig` instead of `agent configcheck`.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Run `agent configcheck` and `agent checkconfig`.
It must do exactly the same thing.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [X] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [X] The appropriate `team/..` label has been applied, if known.
- [X] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [X] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
