### PR TITLE
[systemd] Implement wildcard support on systemd unit_name

### DIFF
--- a/pkg/collector/corechecks/systemd/systemd.go
+++ b/pkg/collector/corechecks/systemd/systemd.go
@@ -3,12 +3,14 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build systemd
 // +build systemd
 
 package systemd
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -501,7 +503,9 @@ func getServiceCheckStatus(state string, mapping map[string]string) metrics.Serv
 // isMonitored verifies if a unit should be monitored.
 func (c *SystemdCheck) isMonitored(unitName string) bool {
 	for _, name := range c.config.instance.UnitNames {
-		if name == unitName {
+		name = strings.Replace(name, ".", "\\.", -1)
+		name = strings.Replace(name, "*", ".*", -1)
+		if matched, _ := regexp.MatchString(name, unitName); matched {
 			return true
 		}
 	}

--- a/pkg/collector/corechecks/systemd/systemd_test.go
+++ b/pkg/collector/corechecks/systemd/systemd_test.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build systemd
 // +build systemd
 
 package systemd
@@ -829,6 +830,9 @@ func TestIsMonitored(t *testing.T) {
 unit_names:
   - unit1.service
   - unit2.service
+	- unit4@1.service
+	- unit4@2.service
+	- unit5@.service
 `)
 
 	check := SystemdCheck{}
@@ -841,6 +845,8 @@ unit_names:
 		{"unit1.service", true},
 		{"unit2.service", true},
 		{"unit3.service", false},
+		{"unit4@*.service", true},
+		{"unit5@.service", true},
 	}
 	for _, d := range data {
 		t.Run(fmt.Sprintf("check.isMonitored('%s') expected to be %v", d.unitName, d.expectedToBeMonitored), func(t *testing.T) {

--- a/pkg/collector/corechecks/systemd/systemd_test.go
+++ b/pkg/collector/corechecks/systemd/systemd_test.go
@@ -830,9 +830,7 @@ func TestIsMonitored(t *testing.T) {
 unit_names:
   - unit1.service
   - unit2.service
-	- unit4@1.service
-	- unit4@2.service
-	- unit5@.service
+  - unit3@*.service
 `)
 
 	check := SystemdCheck{}
@@ -844,9 +842,11 @@ unit_names:
 	}{
 		{"unit1.service", true},
 		{"unit2.service", true},
-		{"unit3.service", false},
-		{"unit4@*.service", true},
-		{"unit5@.service", true},
+		{"unit3@1.service", true},
+		{"unit3@2.service", true},
+		{"unit3@abcd.service", true},
+		{"unit3@.service", true},
+		{"unit4@.service", false},
 	}
 	for _, d := range data {
 		t.Run(fmt.Sprintf("check.isMonitored('%s') expected to be %v", d.unitName, d.expectedToBeMonitored), func(t *testing.T) {

--- a/releasenotes/notes/Implement-wildcard-unit-name-selector-on-systemd-877533359b3fae99.yaml
+++ b/releasenotes/notes/Implement-wildcard-unit-name-selector-on-systemd-877533359b3fae99.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Implement wildcard unit name selection on systemd
+    Implement wildcard unit name selection on systemd.

--- a/releasenotes/notes/Implement-wildcard-unit-name-selector-on-systemd-877533359b3fae99.yaml
+++ b/releasenotes/notes/Implement-wildcard-unit-name-selector-on-systemd-877533359b3fae99.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Implement wildcard unit name selection on systemd


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->
Implement unit_name wildcard selection for systems check 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
https://github.com/DataDog/datadog-agent/issues/9290

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Create a systemd unit
```
$ sudo touch /etc/systemd/system/foo-daemon@.service
$ sudo chmod 664 /etc/systemd/system/foo-daemon@.service
```
Add definition:
```
[Unit]
Description=Foo %I

[Service]
User=%i
ExecStart=/usr/sbin/foo-daemon

[Install]
WantedBy=multi-user.target
```
Start 3 unit: 
```
systemctl enable foo-daemon@Toto.service
systemctl enable foo-daemon@Gerard.service
systemctl enable foo-daemon@Milou.service
```
On the datad-agent systemd conf, specify unitName with a wildcard:
```
init_config:
instances:
  - unit_names:
      - foo-daemon@*.service
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
