### PR TITLE
Add a generic caching layer for metrics provider collector

### DIFF
--- a/pkg/util/containers/v2/metrics/cri/collector.go
+++ b/pkg/util/containers/v2/metrics/cri/collector.go
@@ -15,16 +15,12 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util"
-	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/cri"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics/provider"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
-	criCollectorID    = "cri"
-	criCacheKeyPrefix = "cri-stats-"
-	criCacheTTL       = 10 * time.Second
+	criCollectorID = "cri"
 )
 
 func init() {
@@ -35,12 +31,12 @@ func init() {
 		Factory: func() (provider.Collector, error) {
 			return newCRICollector()
 		},
+		DelegateCache: true,
 	})
 }
 
 type criCollector struct {
-	client         cri.CRIClient
-	lastScrapeTime time.Time
+	client cri.CRIClient
 }
 
 func newCRICollector() (*criCollector, error) {
@@ -63,7 +59,7 @@ func (collector *criCollector) ID() string {
 
 // GetContainerStats returns stats by container ID.
 func (collector *criCollector) GetContainerStats(containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) {
-	stats, err := collector.getCriContainerStats(containerID, cacheValidity)
+	stats, err := collector.getCriContainerStats(containerID)
 	if err != nil {
 		return nil, err
 	}
@@ -85,21 +81,11 @@ func (collector *criCollector) GetContainerNetworkStats(containerID string, cach
 	return nil, nil
 }
 
-func (collector *criCollector) getCriContainerStats(containerID string, cacheValidity time.Duration) (*v1alpha2.ContainerStats, error) {
-	refreshRequired := collector.lastScrapeTime.Add(cacheValidity).Before(time.Now())
-	cacheKey := criCacheKeyPrefix + containerID
-	if cachedMetrics, found := cache.Cache.Get(cacheKey); found && !refreshRequired {
-		log.Debugf("Got CRI stats from cache for container %s", containerID)
-		return cachedMetrics.(*v1alpha2.ContainerStats), nil
-	}
-
+func (collector *criCollector) getCriContainerStats(containerID string) (*v1alpha2.ContainerStats, error) {
 	stats, err := collector.client.GetContainerStats(containerID)
 	if err != nil {
 		return nil, err
 	}
-
-	collector.lastScrapeTime = time.Now()
-	cache.Cache.Set(cacheKey, stats, criCacheTTL)
 
 	return stats, nil
 }

--- a/pkg/util/containers/v2/metrics/ecsfargate/collector.go
+++ b/pkg/util/containers/v2/metrics/ecsfargate/collector.go
@@ -15,35 +15,28 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util"
-	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics/provider"
 	"github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
 	v2 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v2"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 const (
 	ecsFargateCollectorID = "ecs_fargate"
-	statsCacheKey         = "ecs-stats-%s"
-	statsCacheExpiration  = 10 * time.Second
 )
 
 func init() {
 	provider.GetProvider().RegisterCollector(provider.CollectorMetadata{
-		ID:       ecsFargateCollectorID,
-		Priority: 0,
-		Runtimes: provider.AllLinuxRuntimes,
-		Factory:  func() (provider.Collector, error) { return newEcsFargateCollector() },
+		ID:            ecsFargateCollectorID,
+		Priority:      0,
+		Runtimes:      provider.AllLinuxRuntimes,
+		Factory:       func() (provider.Collector, error) { return newEcsFargateCollector() },
+		DelegateCache: true,
 	})
 }
 
 type ecsFargateCollector struct {
-	client         *v2.Client
-	lastScrapeTime time.Time
+	client *v2.Client
 }
-
-// ecsStatsFunc allows mocking the ecs api for testing.
-type ecsStatsFunc func(ctx context.Context, id string) (*v2.ContainerStats, error)
 
 // newEcsFargateCollector returns a new *ecsFargateCollector.
 func newEcsFargateCollector() (*ecsFargateCollector, error) {
@@ -64,7 +57,7 @@ func (e *ecsFargateCollector) ID() string { return ecsFargateCollectorID }
 
 // GetContainerStats returns stats by container ID.
 func (e *ecsFargateCollector) GetContainerStats(containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) {
-	stats, err := e.stats(containerID, cacheValidity, e.client.GetContainerStats)
+	stats, err := e.stats(containerID)
 	if err != nil {
 		return nil, err
 	}
@@ -74,7 +67,7 @@ func (e *ecsFargateCollector) GetContainerStats(containerID string, cacheValidit
 
 // GetContainerNetworkStats returns network stats by container ID.
 func (e *ecsFargateCollector) GetContainerNetworkStats(containerID string, cacheValidity time.Duration) (*provider.ContainerNetworkStats, error) {
-	stats, err := e.stats(containerID, cacheValidity, e.client.GetContainerStats)
+	stats, err := e.stats(containerID)
 	if err != nil {
 		return nil, err
 	}
@@ -84,23 +77,11 @@ func (e *ecsFargateCollector) GetContainerNetworkStats(containerID string, cache
 
 // stats returns stats by container ID, it uses an in-memory cache to reduce the number of api calls.
 // Cache expires every 2 minutes and can also be invalidated using the cacheValidity argument.
-func (e *ecsFargateCollector) stats(containerID string, cacheValidity time.Duration, clientFunc ecsStatsFunc) (*v2.ContainerStats, error) {
-	refreshRequired := e.lastScrapeTime.Add(cacheValidity).Before(time.Now())
-	cacheKey := fmt.Sprintf(statsCacheKey, containerID)
-	if cacheStats, found := cache.Cache.Get(cacheKey); found && !refreshRequired {
-		stats := cacheStats.(*v2.ContainerStats)
-		log.Debugf("Got ecs stats from cache for container %s", containerID)
-		return stats, nil
-	}
-
-	stats, err := clientFunc(context.TODO(), containerID)
+func (e *ecsFargateCollector) stats(containerID string) (*v2.ContainerStats, error) {
+	stats, err := e.client.GetContainerStats(context.TODO(), containerID)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get container stats for %s: %w", containerID, err)
 	}
-
-	log.Debugf("Got ecs stats from ECS API for container %s", containerID)
-	e.lastScrapeTime = time.Now()
-	cache.Cache.Set(cacheKey, stats, statsCacheExpiration)
 
 	return stats, nil
 }

--- a/pkg/util/containers/v2/metrics/provider/collector_cache.go
+++ b/pkg/util/containers/v2/metrics/provider/collector_cache.go
@@ -1,0 +1,135 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
+package provider
+
+import (
+	"sync"
+	"time"
+)
+
+const (
+	contStatsCachePrefix    = "cs-"
+	contNetStatsCachePrefix = "cns-"
+	gcInterval              = 30 * time.Second
+)
+
+type cacheEntry struct {
+	value     interface{}
+	err       error
+	timestamp time.Time
+}
+
+// collectorCache is a wrapper handling cache for collectors.
+// this cache is fully synchronized to minimize locking. If a method is called multiple times in parallel for the same cachey key,
+// it may result in multiple calls to the underlying collector
+type collectorCache struct {
+	collector   Collector
+	cache       map[string]cacheEntry
+	cacheLock   sync.RWMutex
+	gcTimestamp time.Time
+}
+
+// NewCollectorCache returns a new cache dedicated to a collector
+func NewCollectorCache(collector Collector) Collector {
+	return &collectorCache{
+		collector: collector,
+		cache:     make(map[string]cacheEntry),
+	}
+}
+
+// ID returns the actual collector ID, no cache
+func (cc *collectorCache) ID() string {
+	return cc.collector.ID()
+}
+
+// GetContainerStats returns the stats if in cache and within cacheValidity
+// errors are cached as well to avoid hammering underlying collector
+func (cc *collectorCache) GetContainerStats(containerID string, cacheValidity time.Duration) (*ContainerStats, error) {
+	currentTime := time.Now()
+	cacheKey := contStatsCachePrefix + containerID
+
+	if cacheValidity > 0 {
+		entry, found, err := cc.getCacheEntry(currentTime, cacheKey, cacheValidity)
+		if found {
+			if err != nil {
+				return nil, err
+			}
+
+			return entry.(*ContainerStats), nil
+		}
+	}
+
+	// No cache, cacheValidity is 0 or too old value
+	cstats, err := cc.collector.GetContainerStats(containerID, cacheValidity)
+	if err != nil {
+		cc.storeCacheEntry(currentTime, cacheKey, nil, err)
+		return nil, err
+	}
+
+	cc.storeCacheEntry(currentTime, cacheKey, cstats, nil)
+	return cstats, nil
+}
+
+// GetContainerNetworkStats returns the stats if in cache and within cacheValidity
+// errors are cached as well to avoid hammering underlying collector
+func (cc *collectorCache) GetContainerNetworkStats(containerID string, cacheValidity time.Duration) (*ContainerNetworkStats, error) {
+	// Generics could be useful. Meanwhile copy-paste.
+	currentTime := time.Now()
+	cacheKey := contNetStatsCachePrefix + containerID
+
+	if cacheValidity > 0 {
+		entry, found, err := cc.getCacheEntry(currentTime, cacheKey, cacheValidity)
+		if found {
+			if err != nil {
+				return nil, err
+			}
+
+			return entry.(*ContainerNetworkStats), nil
+		}
+	}
+
+	// No cache, cacheValidity is 0 or too old value
+	val, err := cc.collector.GetContainerNetworkStats(containerID, cacheValidity)
+	if err != nil {
+		cc.storeCacheEntry(currentTime, cacheKey, nil, err)
+		return nil, err
+	}
+
+	cc.storeCacheEntry(currentTime, cacheKey, val, nil)
+	return val, nil
+}
+
+func (cc *collectorCache) getCacheEntry(currentTime time.Time, key string, cacheValidity time.Duration) (interface{}, bool, error) {
+	cc.cacheLock.RLock()
+	entry, found := cc.cache[key]
+	cc.cacheLock.RUnlock()
+
+	if !found {
+		return nil, false, nil
+	}
+
+	if currentTime.Sub(entry.timestamp) > cacheValidity {
+		return nil, false, nil
+	}
+
+	if entry.err != nil {
+		return nil, true, entry.err
+	}
+
+	return entry.value, true, nil
+}
+
+func (cc *collectorCache) storeCacheEntry(currentTime time.Time, key string, value interface{}, err error) {
+	cc.cacheLock.Lock()
+	defer cc.cacheLock.Unlock()
+
+	if currentTime.Sub(cc.gcTimestamp) > gcInterval {
+		cc.cache = make(map[string]cacheEntry, len(cc.cache))
+		cc.gcTimestamp = currentTime
+	}
+
+	cc.cache[key] = cacheEntry{value: value, timestamp: currentTime, err: err}
+}

--- a/pkg/util/containers/v2/metrics/provider/collector_cache_test.go
+++ b/pkg/util/containers/v2/metrics/provider/collector_cache_test.go
@@ -1,0 +1,92 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
+package provider
+
+import (
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCollectorCache(t *testing.T) {
+	actualCollector := dummyCollector{
+		id: "foo",
+		cStats: map[string]*ContainerStats{
+			"cID1": {
+				CPU: &ContainerCPUStats{
+					Total: util.Float64Ptr(100),
+				},
+			},
+			"cID2": {
+				CPU: &ContainerCPUStats{
+					Total: util.Float64Ptr(200),
+				},
+			},
+		},
+		cNetStats: map[string]*ContainerNetworkStats{
+			"cID1": {
+				BytesSent: util.Float64Ptr(110),
+			},
+			"cID2": {
+				BytesSent: util.Float64Ptr(210),
+			},
+		},
+	}
+
+	collectorCache := NewCollectorCache(actualCollector)
+	assert.Equal(t, collectorCache.ID(), actualCollector.ID())
+
+	cStats, err := collectorCache.GetContainerStats("cID1", time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, 100.0, *cStats.CPU.Total)
+
+	ncStats, err := collectorCache.GetContainerNetworkStats("cID1", time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, 110.0, *ncStats.BytesSent)
+
+	cStats2, err := collectorCache.GetContainerStats("cID2", time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, 200.0, *cStats2.CPU.Total)
+
+	ncStats2, err := collectorCache.GetContainerNetworkStats("cID2", time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, 210.0, *ncStats2.BytesSent)
+
+	// Changing underlying source
+	actualCollector.cStats["cID1"] = &ContainerStats{
+		CPU: &ContainerCPUStats{
+			Total: util.Float64Ptr(150),
+		},
+	}
+	actualCollector.cStats["cID2"] = &ContainerStats{
+		CPU: &ContainerCPUStats{
+			Total: util.Float64Ptr(250),
+		},
+	}
+	actualCollector.cNetStats["cID2"] = &ContainerNetworkStats{
+		BytesSent: util.Float64Ptr(260),
+	}
+
+	cStats, err = collectorCache.GetContainerStats("cID1", time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, 100.0, *cStats.CPU.Total)
+
+	ncStats, err = collectorCache.GetContainerNetworkStats("cID1", time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, 110.0, *ncStats.BytesSent)
+
+	// Force refresh
+	cStats2, err = collectorCache.GetContainerStats("cID2", 0)
+	assert.NoError(t, err)
+	assert.Equal(t, 250.0, *cStats2.CPU.Total)
+
+	// Verify networkStats was not refreshed
+	ncStats2, err = collectorCache.GetContainerNetworkStats("cID2", time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, 210.0, *ncStats2.BytesSent)
+}

--- a/pkg/util/containers/v2/metrics/provider/mock.go
+++ b/pkg/util/containers/v2/metrics/provider/mock.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package provider
+
+import (
+	"time"
+)
+
+type dummyCollector struct {
+	id        string
+	cStats    map[string]*ContainerStats
+	cNetStats map[string]*ContainerNetworkStats
+	err       error
+}
+
+func (d dummyCollector) ID() string {
+	return d.id
+}
+
+func (d dummyCollector) GetContainerStats(containerID string, cacheValidity time.Duration) (*ContainerStats, error) {
+	return d.cStats[containerID], d.err
+}
+
+func (d dummyCollector) GetContainerNetworkStats(containerID string, cacheValidity time.Duration) (*ContainerNetworkStats, error) {
+	return d.cNetStats[containerID], d.err
+}

--- a/pkg/util/containers/v2/metrics/provider/provider.go
+++ b/pkg/util/containers/v2/metrics/provider/provider.go
@@ -68,10 +68,11 @@ type collectorFactory func() (Collector, error)
 
 // CollectorMetadata contains the characteristics of a collector to be registered with RegisterCollector
 type CollectorMetadata struct {
-	ID       string
-	Priority int // lowest gets higher priority (0 more prioritary than 1)
-	Runtimes []string
-	Factory  collectorFactory
+	ID            string
+	Priority      int // lowest gets higher priority (0 more prioritary than 1)
+	Runtimes      []string
+	Factory       collectorFactory
+	DelegateCache bool
 }
 
 type collectorReference struct {
@@ -150,6 +151,10 @@ func (mp *GenericProvider) retryCollectors(cacheValidity time.Duration) {
 	for _, collectorEntry := range mp.collectors {
 		collector, err := collectorEntry.Factory()
 		if err == nil {
+			if collectorEntry.DelegateCache {
+				collector = NewCollectorCache(collector)
+			}
+
 			mp.updateEffectiveCollectors(collector, collectorEntry)
 			delete(mp.collectors, collectorEntry.ID)
 		} else {

--- a/pkg/util/containers/v2/metrics/provider/provider_test.go
+++ b/pkg/util/containers/v2/metrics/provider/provider_test.go
@@ -13,22 +13,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type dummyCollector struct {
-	id string
-}
-
-func (d dummyCollector) ID() string {
-	return d.id
-}
-
-func (d dummyCollector) GetContainerStats(string, time.Duration) (*ContainerStats, error) {
-	return nil, nil
-}
-
-func (d dummyCollector) GetContainerNetworkStats(containerID string, cacheValidity time.Duration) (*ContainerNetworkStats, error) {
-	return nil, nil
-}
-
 func TestMetricsProvider(t *testing.T) {
 	c := newProvider()
 	assert.Equal(t, nil, c.getCollector("foo"))

--- a/pkg/util/containers/v2/metrics/system/collector_linux.go
+++ b/pkg/util/containers/v2/metrics/system/collector_linux.go
@@ -32,6 +32,7 @@ func init() {
 		Factory: func() (provider.Collector, error) {
 			return newSystemCollector()
 		},
+		DelegateCache: true,
 	})
 }
 


### PR DESCRIPTION
### What does this PR do?

Add a generic caching layer for generic metrics provider.

### Motivation

### Additional Notes

No user facing changes.

### Possible Drawbacks / Trade-offs

Using a too high `cacheValidity` will decrease metrics accuracy, especially with `Rates` due to `time of fetch vs time of data` issue.

### Describe how to test/QA your changes

No QA for this PR. The QA will be done as part of the Docker/Containerd/Cri check PRs.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
