### PR TITLE
[CWS] add option to enable the status metrics logs

### DIFF
--- a/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
@@ -5,7 +5,7 @@ print `uname -a`
 
 describe 'successfully run functional test' do
   it 'displays PASS and returns 0' do
-    output = `sudo /tmp/security-agent/testsuite -test.v 1>&2`
+    output = `sudo /tmp/security-agent/testsuite -test.v -status-metrics 1>&2`
     retval = $?
     expect(retval).to eq(0)
   end
@@ -24,7 +24,7 @@ end
 if File.readlines("/etc/os-release").grep(/SUSE/).size == 0 and ! File.exists?('/etc/rhsm')
   describe 'successfully run functional test inside a container' do
     it 'displays PASS and returns 0' do
-      output = `sudo docker exec -ti docker-testsuite /tmp/security-agent/testsuite -test.v --env docker 1>&2`
+      output = `sudo docker exec -ti docker-testsuite /tmp/security-agent/testsuite -test.v -status-metrics --env docker 1>&2`
       retval = $?
       expect(retval).to eq(0)
     end


### PR DESCRIPTION
### What does this PR do?

This PR adds an option to enable the status metrics logging.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
