### PR TITLE
[CWS] Add support for mutable SECL variables

### DIFF
--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -280,8 +280,8 @@ func (m *Module) Reload() error {
 		WithEventTypeEnabled(m.getEventTypeEnabled()).
 		WithReservedRuleIDs(sprobe.AllCustomRuleIDs()).
 		WithLegacyFields(model.SECLLegacyFields).
-		WithStateScopes(map[rules.Scope]rules.StateScope{
-			"process": m.probe.GetResolvers().ProcessResolver,
+		WithStateScopes(map[rules.Scope]rules.VariableProviderFactory{
+			"process": m.probe.GetResolvers().ProcessResolver.NewProcessVariables,
 		}).
 		WithLogger(&seclog.PatternLogger{})
 

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -267,14 +267,22 @@ func (m *Module) Reload() error {
 	policiesDir := m.config.PoliciesDir
 	rsa := sprobe.NewRuleSetApplier(m.config, m.probe)
 
+	probeVariables := make(map[string]eval.VariableValue, len(model.SECLVariables))
+	for name, value := range model.SECLVariables {
+		probeVariables[name] = value
+	}
+
 	var opts rules.Opts
 	opts.
 		WithConstants(model.SECLConstants).
-		WithVariables(model.SECLVariables).
+		WithVariables(probeVariables).
 		WithSupportedDiscarders(sprobe.SupportedDiscarders).
 		WithEventTypeEnabled(m.getEventTypeEnabled()).
 		WithReservedRuleIDs(sprobe.AllCustomRuleIDs()).
 		WithLegacyFields(model.SECLLegacyFields).
+		WithStateScopes(map[rules.Scope]rules.StateScope{
+			"process": m.probe.GetResolvers().ProcessResolver,
+		}).
 		WithLogger(&seclog.PatternLogger{})
 
 	model := &model.Model{}

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -36,13 +36,7 @@ type Model struct {
 
 // NewEvent returns a new Event
 func (m *Model) NewEvent() eval.Event {
-	return &Event{Event: model.Event{
-		ProcessContext: model.ProcessContext{
-			Process: model.Process{
-				Context: make(map[string]interface{}),
-			},
-		},
-	}}
+	return &Event{}
 }
 
 // Event describes a probe event

--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -36,7 +36,13 @@ type Model struct {
 
 // NewEvent returns a new Event
 func (m *Model) NewEvent() eval.Event {
-	return &Event{Event: model.Event{}}
+	return &Event{Event: model.Event{
+		ProcessContext: model.ProcessContext{
+			Process: model.Process{
+				Context: make(map[string]interface{}),
+			},
+		},
+	}}
 }
 
 // Event describes a probe event

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -880,7 +880,7 @@ func (p *Probe) NewRuleSet(opts *rules.Opts) *rules.RuleSet {
 	eventCtor := func() eval.Event {
 		return NewEvent(p.resolvers, p.scrubber)
 	}
-	opts.Logger = &seclog.PatternLogger{}
+	opts.WithLogger(&seclog.PatternLogger{})
 
 	return rules.NewRuleSet(&Model{}, eventCtor, opts)
 }

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -979,57 +979,30 @@ func (p *ProcessResolver) SetState(state int64) {
 // GetVariable returns a new mutable variable with the type of the specified value
 func (p *ProcessResolver) GetVariable(name string, value interface{}) (eval.VariableValue, error) {
 	setVar := func(ctx *eval.Context, value interface{}) error {
-		process := &(*Event)(ctx.Object).ProcessContext.Process
-		process.Context[name] = value
-		return nil
+		return (*Event)(ctx.Object).ProcessContext.Process.Set(name, value)
 	}
 
 	switch value.(type) {
 	case int:
-		intVar := eval.NewIntVariable(func(ctx *eval.Context) int {
-			process := &(*Event)(ctx.Object).ProcessContext.Process
-			if _, found := process.Context[name]; !found {
-				return 0
-			}
-			return process.Context[name].(int)
-		}, setVar)
-		return intVar, nil
+		return eval.NewIntVariable(func(ctx *eval.Context) int {
+			return (*Event)(ctx.Object).ProcessContext.Process.GetInt()
+		}, setVar), nil
 	case bool:
-		boolVar := eval.NewBoolVariable(func(ctx *eval.Context) bool {
-			process := &(*Event)(ctx.Object).ProcessContext.Process
-			if _, found := process.Context[name]; !found {
-				return false
-			}
-			return process.Context[name].(bool)
-		}, setVar)
-		return boolVar, nil
+		return eval.NewBoolVariable(func(ctx *eval.Context) bool {
+			return (*Event)(ctx.Object).ProcessContext.Process.GetBool()
+		}, setVar), nil
 	case string:
-		strVar := eval.NewStringVariable(func(ctx *eval.Context) string {
-			process := &(*Event)(ctx.Object).ProcessContext.Process
-			if _, found := process.Context[name]; !found {
-				return ""
-			}
-			return process.Context[name].(string)
-		}, setVar)
-		return strVar, nil
+		return eval.NewStringVariable(func(ctx *eval.Context) string {
+			return (*Event)(ctx.Object).ProcessContext.Process.GetString()
+		}, setVar), nil
 	case []string:
-		strArrayVar := eval.NewStringArrayVariable(func(ctx *eval.Context) []string {
-			process := &(*Event)(ctx.Object).ProcessContext.Process
-			if _, found := process.Context[name]; !found {
-				return nil
-			}
-			return process.Context[name].([]string)
-		}, setVar)
-		return strArrayVar, nil
+		return eval.NewStringArrayVariable(func(ctx *eval.Context) []string {
+			return (*Event)(ctx.Object).ProcessContext.Process.GetStringArray()
+		}, setVar), nil
 	case []int:
-		intArrayVar := eval.NewIntArrayVariable(func(ctx *eval.Context) []int {
-			process := &(*Event)(ctx.Object).ProcessContext.Process
-			if _, found := process.Context[name]; !found {
-				return nil
-			}
-			return process.Context[name].([]int)
-		}, setVar)
-		return intArrayVar, nil
+		return eval.NewIntArrayVariable(func(ctx *eval.Context) []int {
+			return (*Event)(ctx.Object).ProcessContext.Process.GetIntArray()
+		}, setVar), nil
 	default:
 		return nil, fmt.Errorf("unsupported variable type %s for '%s'", reflect.TypeOf(value), name)
 	}

--- a/pkg/security/probe/variables.go
+++ b/pkg/security/probe/variables.go
@@ -15,10 +15,8 @@ import (
 var (
 	// SECLVariables set of variables
 	SECLVariables = map[string]eval.VariableValue{
-		"process.pid": {
-			IntFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).ProcessContext.Process.Pid)
-			},
-		},
+		"process.pid": eval.NewIntVariable(func(ctx *eval.Context) int {
+			return int((*Event)(ctx.Object).ProcessContext.Process.Pid)
+		}, nil),
 	}
 )

--- a/pkg/security/secl/compiler/ast/secl.go
+++ b/pkg/security/secl/compiler/ast/secl.go
@@ -18,7 +18,7 @@ import (
 var (
 	seclLexer = lexer.Must(ebnf.New(`
 Comment = ("#" | "//") { "\u0000"…"\uffff"-"\n" } .
-IntVariable = "${" (alpha | "_") { "_" | alpha | digit | "." } "}" .
+Variable = "${" (alpha | "_") { "_" | alpha | digit | "." } "}" .
 Duration = digit { digit } ("ms" | "s" | "m" | "h" | "d") .
 Regexp = "r\"" { "\u0000"…"\uffff"-"\""-"\\" | "\\" any } "\"" .
 Ident = (alpha | "_") { "_" | alpha | digit | "." | "[" | "]" } .
@@ -180,14 +180,14 @@ type Unary struct {
 type Primary struct {
 	Pos lexer.Position
 
-	Ident          *string     `parser:"@Ident"`
-	Number         *int        `parser:"| @Int"`
-	NumberVariable *string     `parser:"| @IntVariable"`
-	String         *string     `parser:"| @String"`
-	Pattern        *string     `parser:"| @Pattern"`
-	Regexp         *string     `parser:"| @Regexp"`
-	Duration       *int        `parser:"| @Duration"`
-	SubExpression  *Expression `parser:"| \"(\" @@ \")\""`
+	Ident         *string     `parser:"@Ident"`
+	Number        *int        `parser:"| @Int"`
+	Variable      *string     `parser:"| @Variable"`
+	String        *string     `parser:"| @String"`
+	Pattern       *string     `parser:"| @Pattern"`
+	Regexp        *string     `parser:"| @Regexp"`
+	Duration      *int        `parser:"| @Duration"`
+	SubExpression *Expression `parser:"| \"(\" @@ \")\""`
 }
 
 // StringMember describes a String based array member
@@ -205,5 +205,6 @@ type Array struct {
 
 	StringMembers []StringMember `parser:"\"[\" @@ { \",\" @@ } \"]\""`
 	Numbers       []int          `parser:"| \"[\" @Int { \",\" @Int } \"]\""`
+	Variable      *string        `parser:"| @Variable"`
 	Ident         *string        `parser:"| @Ident"`
 }

--- a/pkg/security/secl/compiler/eval/eval.go
+++ b/pkg/security/secl/compiler/eval/eval.go
@@ -194,28 +194,6 @@ func evaluatorFromVariable(varname string, pos lexer.Position, opts *Opts) (inte
 	return value.GetEvaluator(), pos, nil
 }
 
-func intEvaluatorFromVariable(varname string, pos lexer.Position, opts *Opts) (interface{}, lexer.Position, error) {
-	value, exists := opts.Variables[varname]
-	if !exists {
-		return nil, pos, NewError(pos, fmt.Sprintf("variable '%s' doesn't exist", varname))
-	}
-
-	evaluator := value.GetEvaluator()
-	switch evaluator := evaluator.(type) {
-	case *IntEvaluator:
-		return evaluator, pos, nil
-	case *StringEvaluator:
-		return &IntEvaluator{
-			EvalFnc: func(ctx *Context) int {
-				i, _ := strconv.Atoi(evaluator.EvalFnc(ctx))
-				return i
-			},
-		}, pos, nil
-	default:
-		return nil, pos, NewError(pos, fmt.Sprintf("variable type not supported '%s'", varname))
-	}
-}
-
 func stringEvaluatorFromVariable(str string, pos lexer.Position, opts *Opts) (interface{}, lexer.Position, error) {
 	var evaluators []*StringEvaluator
 

--- a/pkg/security/secl/compiler/eval/eval.go
+++ b/pkg/security/secl/compiler/eval/eval.go
@@ -206,6 +206,23 @@ func stringEvaluatorFromVariable(str string, pos lexer.Position, opts *Opts) (in
 
 			evaluator := value.GetEvaluator()
 			switch evaluator := evaluator.(type) {
+			case *StringArrayEvaluator:
+				evaluators = append(evaluators, &StringEvaluator{
+					EvalFnc: func(ctx *Context) string {
+						return strings.Join(evaluator.EvalFnc(ctx), ",")
+					}})
+			case *IntArrayEvaluator:
+				evaluators = append(evaluators, &StringEvaluator{
+					EvalFnc: func(ctx *Context) string {
+						var result string
+						for i, number := range evaluator.EvalFnc(ctx) {
+							if i != 0 {
+								result += ","
+							}
+							result += strconv.FormatInt(int64(number), 10)
+						}
+						return result
+					}})
 			case *StringEvaluator:
 				evaluators = append(evaluators, evaluator)
 			case *IntEvaluator:

--- a/pkg/security/secl/compiler/eval/eval_test.go
+++ b/pkg/security/secl/compiler/eval/eval_test.go
@@ -25,16 +25,12 @@ func newOptsWithParams(constants map[string]interface{}, legacyFields map[Field]
 		Macros:       make(map[MacroID]*Macro),
 		LegacyFields: legacyFields,
 		Variables: map[string]VariableValue{
-			"pid": {
-				IntFnc: func(ctx *Context) int {
-					return os.Getpid()
-				},
-			},
-			"str": {
-				StringFnc: func(ctx *Context) string {
-					return "aaa"
-				},
-			},
+			"pid": NewIntVariable(func(ctx *Context) int {
+				return os.Getpid()
+			}, nil),
+			"str": NewStringVariable(func(ctx *Context) string {
+				return "aaa"
+			}, nil),
 		},
 	}
 }

--- a/pkg/security/secl/compiler/eval/opts.go
+++ b/pkg/security/secl/compiler/eval/opts.go
@@ -22,7 +22,12 @@ func (o *Opts) WithConstants(constants map[string]interface{}) *Opts {
 
 // WithVariables set variables
 func (o *Opts) WithVariables(variables map[string]VariableValue) *Opts {
-	o.Variables = variables
+	optsVariables := make(map[string]eval.VariableValue, len(sprobe.SECLVariables))
+	for name, value := range variables {
+		optsVariables[name] = value
+	}
+
+	o.Variables = optsVariables
 	return o
 }
 

--- a/pkg/security/secl/compiler/eval/opts.go
+++ b/pkg/security/secl/compiler/eval/opts.go
@@ -22,7 +22,7 @@ func (o *Opts) WithConstants(constants map[string]interface{}) *Opts {
 
 // WithVariables set variables
 func (o *Opts) WithVariables(variables map[string]VariableValue) *Opts {
-	optsVariables := make(map[string]eval.VariableValue, len(sprobe.SECLVariables))
+	optsVariables := make(map[string]VariableValue, len(variables))
 	for name, value := range variables {
 		optsVariables[name] = value
 	}

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -116,6 +116,52 @@ func NewBoolVariable(boolFnc func(ctx *Context) bool, setFnc func(ctx *Context, 
 	}
 }
 
+// StringArrayVariable describes a string array variable
+type StringArrayVariable struct {
+	Variable
+	strFnc func(ctx *Context) []string
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (s *StringArrayVariable) GetEvaluator() interface{} {
+	return &StringArrayEvaluator{
+		EvalFnc: s.strFnc,
+	}
+}
+
+// NewStringArrayVariable returns a new string array variable
+func NewStringArrayVariable(strFnc func(ctx *Context) []string, setFnc func(ctx *Context, value interface{}) error) *StringArrayVariable {
+	return &StringArrayVariable{
+		strFnc: strFnc,
+		Variable: Variable{
+			setFnc: setFnc,
+		},
+	}
+}
+
+// IntArrayVariable describes an integer array variable
+type IntArrayVariable struct {
+	Variable
+	intFnc func(ctx *Context) []int
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (s *IntArrayVariable) GetEvaluator() interface{} {
+	return &IntArrayEvaluator{
+		EvalFnc: s.intFnc,
+	}
+}
+
+// NewIntArrayVariable returns a new integer array variable
+func NewIntArrayVariable(intFnc func(ctx *Context) []int, setFnc func(ctx *Context, value interface{}) error) *IntArrayVariable {
+	return &IntArrayVariable{
+		intFnc: intFnc,
+		Variable: Variable{
+			setFnc: setFnc,
+		},
+	}
+}
+
 // MutableIntVariable describes a mutable integer variable
 type MutableIntVariable struct {
 	Value int

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -5,14 +5,346 @@
 
 package eval
 
-import "regexp"
+import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+)
 
 var (
 	variableRegex = regexp.MustCompile(`\${[^}]*}`)
 )
 
 // VariableValue describes secl variable
-type VariableValue struct {
-	IntFnc    func(ctx *Context) int
-	StringFnc func(ctx *Context) string
+type VariableValue interface {
+	GetEvaluator() interface{}
+	IntFnc(ctx *Context) int
+	StringFnc(ctx *Context) string
+}
+
+// MutableVariable is the interface implemented by modifiable variables
+type MutableVariable interface {
+	Set(ctx *Context, value interface{}) error
+}
+
+// IntVariable describes an integer variable
+type IntVariable struct {
+	intFnc func(ctx *Context) int
+	setFnc func(ctx *Context, value interface{}) error
+}
+
+// IntFnc returns the variable value as an integer
+func (i *IntVariable) IntFnc(ctx *Context) int {
+	return i.intFnc(ctx)
+}
+
+// StringFnc returns the variable value as a string
+func (i *IntVariable) StringFnc(ctx *Context) string {
+	return strconv.FormatInt(int64(i.intFnc(ctx)), 10)
+}
+
+// Set the variable with the specified value
+func (i *IntVariable) Set(ctx *Context, value interface{}) error {
+	if i.setFnc == nil {
+		return errors.New("variable is not mutable")
+	}
+
+	return i.setFnc(ctx, value)
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (i *IntVariable) GetEvaluator() interface{} {
+	return &IntEvaluator{
+		EvalFnc: func(ctx *Context) int {
+			return i.intFnc(ctx)
+		},
+	}
+}
+
+// NewIntVariable returns a new integer variable
+func NewIntVariable(intFnc func(ctx *Context) int, setFnc func(ctx *Context, value interface{}) error) *IntVariable {
+	return &IntVariable{intFnc: intFnc, setFnc: setFnc}
+}
+
+// StringVariable describes a string variable
+type StringVariable struct {
+	strFnc func(ctx *Context) string
+	setFnc func(ctx *Context, value interface{}) error
+}
+
+// IntFnc returns the variable value as an integer
+func (s *StringVariable) IntFnc(ctx *Context) int {
+	i, _ := strconv.Atoi(s.strFnc(ctx))
+	return i
+}
+
+// StringFnc returns the variable value as a string
+func (s *StringVariable) StringFnc(ctx *Context) string {
+	return s.strFnc(ctx)
+}
+
+// Set the variable with the specified value
+func (s *StringVariable) Set(ctx *Context, value interface{}) error {
+	if s.setFnc == nil {
+		return errors.New("variable is not mutable")
+	}
+
+	return s.setFnc(ctx, value)
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (s *StringVariable) GetEvaluator() interface{} {
+	return &StringEvaluator{
+		EvalFnc: func(ctx *Context) string {
+			return s.strFnc(ctx)
+		},
+	}
+}
+
+// NewStringVariable returns a new string variable
+func NewStringVariable(strFnc func(ctx *Context) string, setFnc func(ctx *Context, value interface{}) error) *StringVariable {
+	return &StringVariable{strFnc: strFnc, setFnc: setFnc}
+}
+
+// BoolVariable describes a boolean variable
+type BoolVariable struct {
+	boolFnc func(ctx *Context) bool
+	setFnc  func(ctx *Context, value interface{}) error
+}
+
+// IntFnc returns the variable value as an integer
+func (b *BoolVariable) IntFnc(ctx *Context) int {
+	if b.boolFnc(ctx) {
+		return 1
+	}
+	return 0
+}
+
+// StringFnc returns the variable value as a string
+func (b *BoolVariable) StringFnc(ctx *Context) string {
+	return strconv.FormatBool(b.boolFnc(ctx))
+}
+
+// Set the variable with the specified value
+func (b *BoolVariable) Set(ctx *Context, value interface{}) error {
+	if b.setFnc == nil {
+		return errors.New("variable is not mutable")
+	}
+
+	return b.setFnc(ctx, value)
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (b *BoolVariable) GetEvaluator() interface{} {
+	return &BoolEvaluator{
+		EvalFnc: func(ctx *Context) bool {
+			return b.boolFnc(ctx)
+		},
+	}
+}
+
+// NewBoolVariable returns a new boolean variable
+func NewBoolVariable(boolFnc func(ctx *Context) bool, setFnc func(ctx *Context, value interface{}) error) *BoolVariable {
+	return &BoolVariable{boolFnc: boolFnc, setFnc: setFnc}
+}
+
+// MutableIntVariable describes a mutable integer variable
+type MutableIntVariable struct {
+	Value int
+}
+
+// IntFnc returns the variable value as an integer
+func (m *MutableIntVariable) IntFnc(ctx *Context) int {
+	return m.Value
+}
+
+// StringFnc returns the variable value as a string
+func (m *MutableIntVariable) StringFnc(ctx *Context) string {
+	return strconv.FormatInt(int64(m.Value), 10)
+}
+
+// Set the variable with the specified value
+func (m *MutableIntVariable) Set(ctx *Context, value interface{}) error {
+	m.Value = value.(int)
+	return nil
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (m *MutableIntVariable) GetEvaluator() interface{} {
+	return &IntEvaluator{
+		EvalFnc: func(ctx *Context) int {
+			return m.Value
+		},
+	}
+}
+
+// NewMutableIntVariable returns a new mutable integer variable
+func NewMutableIntVariable() *MutableIntVariable {
+	return &MutableIntVariable{}
+}
+
+// MutableBoolVariable describes a mutable boolean variable
+type MutableBoolVariable struct {
+	Value bool
+}
+
+// IntFnc returns the variable value as an integer
+func (m *MutableBoolVariable) IntFnc(ctx *Context) int {
+	if m.Value {
+		return 1
+	}
+	return 0
+}
+
+// StringFnc returns the variable value as a string
+func (m *MutableBoolVariable) StringFnc(ctx *Context) string {
+	return strconv.FormatBool(m.Value)
+}
+
+// Set the variable with the specified value
+func (m *MutableBoolVariable) Set(ctx *Context, value interface{}) error {
+	m.Value = value.(bool)
+	return nil
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (m *MutableBoolVariable) GetEvaluator() interface{} {
+	return &BoolEvaluator{
+		EvalFnc: func(ctx *Context) bool {
+			return m.Value
+		},
+	}
+}
+
+// NewMutableBoolVariable returns a new mutable boolean variable
+func NewMutableBoolVariable() *MutableBoolVariable {
+	return &MutableBoolVariable{}
+}
+
+// MutableStringVariable describes a mutable string variable
+type MutableStringVariable struct {
+	Value string
+}
+
+// IntFnc returns the variable value as an integer
+func (m *MutableStringVariable) IntFnc(ctx *Context) int {
+	i, _ := strconv.Atoi(m.Value)
+	return i
+}
+
+// StringFnc returns the variable value as a string
+func (m *MutableStringVariable) StringFnc(ctx *Context) string {
+	return m.Value
+}
+
+// Set the variable with the specified value
+func (m *MutableStringVariable) Set(ctx *Context, value interface{}) error {
+	m.Value = value.(string)
+	return nil
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (m *MutableStringVariable) GetEvaluator() interface{} {
+	return &StringEvaluator{
+		EvalFnc: func(ctx *Context) string {
+			return m.Value
+		},
+	}
+}
+
+// NewMutableStringVariable returns a new mutable string variable
+func NewMutableStringVariable() *MutableStringVariable {
+	return &MutableStringVariable{}
+}
+
+// MutableStringArrayVariable describes a mutable string array variable
+type MutableStringArrayVariable struct {
+	Values []string
+}
+
+// IntFnc returns the variable value as an integer
+func (m *MutableStringArrayVariable) IntFnc(ctx *Context) int {
+	return 0
+}
+
+// StringFnc returns the variable value as a string
+func (m *MutableStringArrayVariable) StringFnc(ctx *Context) string {
+	return strings.Join(m.Values, " ")
+}
+
+// Set the variable with the specified value
+func (m *MutableStringArrayVariable) Set(ctx *Context, values interface{}) error {
+	m.Values = values.([]string)
+	return nil
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (m *MutableStringArrayVariable) GetEvaluator() interface{} {
+	return &StringArrayEvaluator{
+		EvalFnc: func(ctx *Context) []string {
+			return m.Values
+		},
+	}
+}
+
+// NewMutableStringArrayVariable returns a new mutable string array variable
+func NewMutableStringArrayVariable() *MutableStringArrayVariable {
+	return &MutableStringArrayVariable{}
+}
+
+// MutableIntArrayVariable describes a mutable integer array variable
+type MutableIntArrayVariable struct {
+	Values []int
+}
+
+// IntFnc returns the variable value as an integer
+func (m *MutableIntArrayVariable) IntFnc(ctx *Context) int {
+	return 0
+}
+
+// StringFnc returns the variable value as a string
+func (m *MutableIntArrayVariable) StringFnc(ctx *Context) string {
+	return ""
+}
+
+// Set the variable with the specified value
+func (m *MutableIntArrayVariable) Set(ctx *Context, values interface{}) error {
+	m.Values = values.([]int)
+	return nil
+}
+
+// GetEvaluator returns the variable SECL evaluator
+func (m *MutableIntArrayVariable) GetEvaluator() interface{} {
+	return &IntArrayEvaluator{
+		EvalFnc: func(ctx *Context) []int {
+			return m.Values
+		},
+	}
+}
+
+// NewMutableIntArrayVariable returns a new mutable integer array variable
+func NewMutableIntArrayVariable() *MutableIntArrayVariable {
+	return &MutableIntArrayVariable{}
+}
+
+// GetVariable returns new variable of the type of the specified value
+func GetVariable(name string, value interface{}) (VariableValue, error) {
+	switch value := value.(type) {
+	case bool:
+		return NewMutableBoolVariable(), nil
+	case int:
+		return NewMutableIntVariable(), nil
+	case string:
+		return NewMutableStringVariable(), nil
+	case []string:
+		return NewMutableStringArrayVariable(), nil
+	case []int:
+		return NewMutableIntArrayVariable(), nil
+	default:
+		return nil, fmt.Errorf("unsupported value type: %s", reflect.TypeOf(value))
+	}
 }

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -396,3 +396,57 @@ func GetVariable(name string, value interface{}) (VariableValue, error) {
 		return nil, fmt.Errorf("unsupported value type: %s", reflect.TypeOf(value))
 	}
 }
+
+// Variables holds a set of variables
+type Variables struct {
+	vars map[string]interface{}
+}
+
+// GetBool returns the boolean value of the specified variable
+func (v *Variables) GetBool(name string) bool {
+	if _, found := v.vars[name]; !found {
+		return false
+	}
+	return v.vars[name].(bool)
+}
+
+// GetInt returns the integer value of the specified variable
+func (v *Variables) GetInt(name string) int {
+	if _, found := v.vars[name]; !found {
+		return 0
+	}
+	return v.vars[name].(int)
+}
+
+// GetString returns the string value of the specified variable
+func (v *Variables) GetString(name string) string {
+	if _, found := v.vars[name]; !found {
+		return ""
+	}
+	return v.vars[name].(string)
+}
+
+// GetStringArray returns the string array value of the specified variable
+func (v *Variables) GetStringArray(name string) []string {
+	if _, found := v.vars[name]; !found {
+		return nil
+	}
+	return v.vars[name].([]string)
+}
+
+// GetIntArray returns the integer array value of the specified variable
+func (v *Variables) GetIntArray(name string) []int {
+	if _, found := v.vars[name]; !found {
+		return nil
+	}
+	return v.vars[name].([]int)
+}
+
+// Set the value of the specified variable
+func (v *Variables) Set(name string, value interface{}) error {
+	if v.vars == nil {
+		v.vars = make(map[string]interface{})
+	}
+	v.vars[name] = value
+	return nil
+}

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -299,7 +299,7 @@ func NewMutableStringVariable() *MutableStringVariable {
 
 // MutableStringArrayVariable describes a mutable string array variable
 type MutableStringArrayVariable struct {
-	Values []string
+	StringValues
 }
 
 // Set the variable with the specified value
@@ -307,7 +307,11 @@ func (m *MutableStringArrayVariable) Set(ctx *Context, values interface{}) error
 	if s, ok := values.(string); ok {
 		values = []string{s}
 	}
-	m.Values = values.([]string)
+
+	m.StringValues = StringValues{}
+	for _, v := range values.([]string) {
+		m.AppendScalarValue(v)
+	}
 	return nil
 }
 
@@ -315,9 +319,11 @@ func (m *MutableStringArrayVariable) Set(ctx *Context, values interface{}) error
 func (m *MutableStringArrayVariable) Append(ctx *Context, value interface{}) error {
 	switch value := value.(type) {
 	case string:
-		m.Values = append(m.Values, value)
+		m.AppendScalarValue(value)
 	case []string:
-		m.Values = append(m.Values, value...)
+		for _, v := range value {
+			m.AppendScalarValue(v)
+		}
 	default:
 		return errAppendNotSupported
 	}
@@ -328,7 +334,7 @@ func (m *MutableStringArrayVariable) Append(ctx *Context, value interface{}) err
 func (m *MutableStringArrayVariable) GetEvaluator() interface{} {
 	return &StringArrayEvaluator{
 		EvalFnc: func(ctx *Context) []string {
-			return m.Values
+			return m.GetScalarValues()
 		},
 	}
 }

--- a/pkg/security/secl/compiler/eval/variables.go
+++ b/pkg/security/secl/compiler/eval/variables.go
@@ -14,8 +14,8 @@ import (
 )
 
 var (
-	variableRegex      = regexp.MustCompile(`\${[^}]*}`)
-	appendNotSupported = errors.New("append is not supported")
+	variableRegex         = regexp.MustCompile(`\${[^}]*}`)
+	errAppendNotSupported = errors.New("append is not supported")
 )
 
 // VariableValue describes a SECL variable value
@@ -43,9 +43,9 @@ func (v *Variable) Set(ctx *Context, value interface{}) error {
 	return v.setFnc(ctx, value)
 }
 
-// Set the variable with the specified value
+// Append a value to the variable
 func (v *Variable) Append(ctx *Context, value interface{}) error {
-	return appendNotSupported
+	return errAppendNotSupported
 }
 
 // IntVariable describes an integer variable
@@ -207,12 +207,12 @@ func (m *MutableIntVariable) Set(ctx *Context, value interface{}) error {
 }
 
 // Append a value to the integer
-func (s *MutableIntVariable) Append(ctx *Context, value interface{}) error {
+func (m *MutableIntVariable) Append(ctx *Context, value interface{}) error {
 	switch value := value.(type) {
 	case int:
-		s.Value += value
+		m.Value += value
 	default:
-		return appendNotSupported
+		return errAppendNotSupported
 	}
 	return nil
 }
@@ -252,8 +252,8 @@ func (m *MutableBoolVariable) Set(ctx *Context, value interface{}) error {
 }
 
 // Append a value to the boolean
-func (s *MutableBoolVariable) Append(ctx *Context, value interface{}) error {
-	return appendNotSupported
+func (m *MutableBoolVariable) Append(ctx *Context, value interface{}) error {
+	return errAppendNotSupported
 }
 
 // NewMutableBoolVariable returns a new mutable boolean variable
@@ -276,12 +276,12 @@ func (m *MutableStringVariable) GetEvaluator() interface{} {
 }
 
 // Append a value to the string
-func (s *MutableStringVariable) Append(ctx *Context, value interface{}) error {
+func (m *MutableStringVariable) Append(ctx *Context, value interface{}) error {
 	switch value := value.(type) {
 	case string:
-		s.Value += value
+		m.Value += value
 	default:
-		return appendNotSupported
+		return errAppendNotSupported
 	}
 	return nil
 }
@@ -312,14 +312,14 @@ func (m *MutableStringArrayVariable) Set(ctx *Context, values interface{}) error
 }
 
 // Append a value to the array
-func (s *MutableStringArrayVariable) Append(ctx *Context, value interface{}) error {
+func (m *MutableStringArrayVariable) Append(ctx *Context, value interface{}) error {
 	switch value := value.(type) {
 	case string:
-		s.Values = append(s.Values, value)
+		m.Values = append(m.Values, value)
 	case []string:
-		s.Values = append(s.Values, value...)
+		m.Values = append(m.Values, value...)
 	default:
-		return appendNotSupported
+		return errAppendNotSupported
 	}
 	return nil
 }
@@ -353,14 +353,14 @@ func (m *MutableIntArrayVariable) Set(ctx *Context, values interface{}) error {
 }
 
 // Append a value to the array
-func (s *MutableIntArrayVariable) Append(ctx *Context, value interface{}) error {
+func (m *MutableIntArrayVariable) Append(ctx *Context, value interface{}) error {
 	switch value := value.(type) {
 	case int:
-		s.Values = append(s.Values, value)
+		m.Values = append(m.Values, value)
 	case []int:
-		s.Values = append(s.Values, value...)
+		m.Values = append(m.Values, value...)
 	default:
-		return appendNotSupported
+		return errAppendNotSupported
 	}
 	return nil
 }

--- a/pkg/security/secl/go.mod
+++ b/pkg/security/secl/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/fatih/structtag v1.2.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/pkg/errors v0.9.1
+	github.com/spf13/cast v1.4.1
 	github.com/stretchr/testify v1.7.0
 	golang.org/x/sys v0.0.0-20211019181941-9d821ace8654
 	golang.org/x/tools v0.1.9

--- a/pkg/security/secl/go.sum
+++ b/pkg/security/secl/go.sum
@@ -25,7 +25,10 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.6.1 h1:/FiVV8dS/e+YqF2JvO3yXRFbBLTIuSDkuC7aBOAvL+k=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
+github.com/spf13/cast v1.4.1 h1:s0hze+J0196ZfEMTs80N7UlFt0BDuQ7Q+JDnHiMWKdA=
+github.com/spf13/cast v1.4.1/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -282,9 +282,10 @@ type Process struct {
 	EnvsTruncated bool     `field:"envs_truncated,ResolveProcessEnvsTruncated"`                                                                            // Indicator of environment variables truncation
 
 	// cache version
-	ScrubbedArgvResolved  bool     `field:"-"`
-	ScrubbedArgv          []string `field:"-"`
-	ScrubbedArgsTruncated bool     `field:"-"`
+	ScrubbedArgvResolved  bool                   `field:"-"`
+	ScrubbedArgv          []string               `field:"-"`
+	ScrubbedArgsTruncated bool                   `field:"-"`
+	Context               map[string]interface{} `field:"-"`
 }
 
 // SpanContext describes a span context
@@ -470,6 +471,7 @@ type ProcessCacheEntry struct {
 // Reset the entry
 func (e *ProcessCacheEntry) Reset() {
 	e.ProcessContext = zeroProcessContext
+	e.ProcessContext.Process.Context = make(map[string]interface{})
 	e.refCount = 0
 }
 
@@ -493,6 +495,11 @@ func (e *ProcessCacheEntry) Release() {
 // NewProcessCacheEntry returns a new process cache entry
 func NewProcessCacheEntry(onRelease func(_ *ProcessCacheEntry)) *ProcessCacheEntry {
 	return &ProcessCacheEntry{
+		ProcessContext: ProcessContext{
+			Process: Process{
+				Context: make(map[string]interface{}),
+			},
+		},
 		onRelease: onRelease,
 	}
 }

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -282,10 +282,10 @@ type Process struct {
 	EnvsTruncated bool     `field:"envs_truncated,ResolveProcessEnvsTruncated"`                                                                            // Indicator of environment variables truncation
 
 	// cache version
-	ScrubbedArgvResolved  bool                   `field:"-"`
-	ScrubbedArgv          []string               `field:"-"`
-	ScrubbedArgsTruncated bool                   `field:"-"`
-	Context               map[string]interface{} `field:"-"`
+	ScrubbedArgvResolved  bool           `field:"-"`
+	ScrubbedArgv          []string       `field:"-"`
+	ScrubbedArgsTruncated bool           `field:"-"`
+	Variables             eval.Variables `field:"-"`
 }
 
 // SpanContext describes a span context
@@ -471,7 +471,6 @@ type ProcessCacheEntry struct {
 // Reset the entry
 func (e *ProcessCacheEntry) Reset() {
 	e.ProcessContext = zeroProcessContext
-	e.ProcessContext.Process.Context = make(map[string]interface{})
 	e.refCount = 0
 }
 
@@ -494,14 +493,7 @@ func (e *ProcessCacheEntry) Release() {
 
 // NewProcessCacheEntry returns a new process cache entry
 func NewProcessCacheEntry(onRelease func(_ *ProcessCacheEntry)) *ProcessCacheEntry {
-	return &ProcessCacheEntry{
-		ProcessContext: ProcessContext{
-			Process: Process{
-				Context: make(map[string]interface{}),
-			},
-		},
-		onRelease: onRelease,
-	}
+	return &ProcessCacheEntry{onRelease: onRelease}
 }
 
 // ProcessAncestorsIterator defines an iterator of ancestors

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -466,17 +466,24 @@ type ProcessCacheEntry struct {
 
 	refCount  uint64                     `field:"-"`
 	onRelease func(_ *ProcessCacheEntry) `field:"-"`
+	releaseCb func()                     `field:"-"`
 }
 
 // Reset the entry
 func (e *ProcessCacheEntry) Reset() {
 	e.ProcessContext = zeroProcessContext
 	e.refCount = 0
+	e.releaseCb = nil
 }
 
 // Retain increment ref counter
 func (e *ProcessCacheEntry) Retain() {
 	e.refCount++
+}
+
+// SetReleaseCallback set the callback called when the entry is released
+func (e *ProcessCacheEntry) SetReleaseCallback(callback func()) {
+	e.releaseCb = callback
 }
 
 // Release decrement and eventually release the entry
@@ -488,6 +495,10 @@ func (e *ProcessCacheEntry) Release() {
 
 	if e.onRelease != nil {
 		e.onRelease(e)
+	}
+
+	if e.releaseCb != nil {
+		e.releaseCb()
 	}
 }
 

--- a/pkg/security/secl/model/variables.go
+++ b/pkg/security/secl/model/variables.go
@@ -15,10 +15,8 @@ import (
 var (
 	// SECLVariables set of variables
 	SECLVariables = map[string]eval.VariableValue{
-		"process.pid": {
-			IntFnc: func(ctx *eval.Context) int {
-				return int((*Event)(ctx.Object).ProcessContext.Process.Pid)
-			},
-		},
+		"process.pid": eval.NewIntVariable(func(ctx *eval.Context) int {
+			return int((*Event)(ctx.Object).ProcessContext.Process.Pid)
+		}, nil),
 	}
 )

--- a/pkg/security/secl/rules/opts.go
+++ b/pkg/security/secl/rules/opts.go
@@ -9,10 +9,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 )
 
-// StateScope is the interface implemented by SECL variable providers
-type StateScope interface {
+// VariableProvider is the interface implemented by SECL variable providers
+type VariableProvider interface {
 	GetVariable(name string, value interface{}) (eval.VariableValue, error)
 }
+
+// VariableProviderFactory describes a function called to instantiate a variable provider
+type VariableProviderFactory func() VariableProvider
 
 // Opts defines rules set options
 type Opts struct {
@@ -20,7 +23,7 @@ type Opts struct {
 	SupportedDiscarders map[eval.Field]bool
 	ReservedRuleIDs     []RuleID
 	EventTypeEnabled    map[eval.EventType]bool
-	StateScopes         map[Scope]StateScope
+	StateScopes         map[Scope]VariableProviderFactory
 	Logger              Logger
 }
 
@@ -79,7 +82,7 @@ func (o *Opts) WithLogger(logger Logger) *Opts {
 }
 
 // WithStateScopes set state scopes
-func (o *Opts) WithStateScopes(stateScopes map[Scope]StateScope) *Opts {
+func (o *Opts) WithStateScopes(stateScopes map[Scope]VariableProviderFactory) *Opts {
 	o.StateScopes = stateScopes
 	return o
 }

--- a/pkg/security/secl/rules/opts.go
+++ b/pkg/security/secl/rules/opts.go
@@ -9,12 +9,18 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
 )
 
+// StateScope is the interface implemented by SECL variable providers
+type StateScope interface {
+	GetVariable(name string, value interface{}) (eval.VariableValue, error)
+}
+
 // Opts defines rules set options
 type Opts struct {
 	eval.Opts
 	SupportedDiscarders map[eval.Field]bool
 	ReservedRuleIDs     []RuleID
 	EventTypeEnabled    map[eval.EventType]bool
+	StateScopes         map[Scope]StateScope
 	Logger              Logger
 }
 
@@ -69,5 +75,11 @@ func (o *Opts) WithReservedRuleIDs(ruleIds []RuleID) *Opts {
 // WithLogger set logger
 func (o *Opts) WithLogger(logger Logger) *Opts {
 	o.Logger = logger
+	return o
+}
+
+// WithStateScopes set state scopes
+func (o *Opts) WithStateScopes(stateScopes map[Scope]StateScope) *Opts {
+	o.StateScopes = stateScopes
 	return o
 }

--- a/pkg/security/secl/rules/policy.go
+++ b/pkg/security/secl/rules/policy.go
@@ -250,8 +250,17 @@ func LoadPolicies(policiesDir string, ruleSet *RuleSet) *multierror.Error {
 
 					switch kind {
 					case reflect.String:
-						variableValue = ""
+						if action.Set.Append {
+							variableValue = []string{""}
+						} else {
+							variableValue = ""
+						}
 					case reflect.Int:
+						if action.Set.Append {
+							variableValue = []int{0}
+						} else {
+							variableValue = 0
+						}
 						variableValue = 0
 					case reflect.Bool:
 						variableValue = false

--- a/pkg/security/secl/rules/policy.go
+++ b/pkg/security/secl/rules/policy.go
@@ -239,7 +239,7 @@ func LoadPolicies(policiesDir string, ruleSet *RuleSet) *multierror.Error {
 						case string:
 							action.Set.Value = cast.ToStringSlice(value)
 						default:
-							result = multierror.Append(result, fmt.Errorf("unsupported array item type '%s' for array '%s'", reflect.TypeOf(arrayType), action.Set.Name))
+							result = multierror.Append(result, fmt.Errorf("unsupported item type '%s' for array '%s'", reflect.TypeOf(arrayType), action.Set.Name))
 							continue
 						}
 					}
@@ -272,7 +272,7 @@ func LoadPolicies(policiesDir string, ruleSet *RuleSet) *multierror.Error {
 				}
 
 				if existingVariable, found := ruleSet.opts.Variables[varName]; found && reflect.TypeOf(variable) != reflect.TypeOf(existingVariable) {
-					result = multierror.Append(result, fmt.Errorf("variable '%s' conflicts with variable (%s != %s)", varName, reflect.TypeOf(variable), reflect.TypeOf(existingVariable)))
+					result = multierror.Append(result, fmt.Errorf("conflicting types for variable '%s'", varName))
 					continue
 				}
 

--- a/pkg/security/secl/rules/policy.go
+++ b/pkg/security/secl/rules/policy.go
@@ -223,6 +223,10 @@ func LoadPolicies(policiesDir string, ruleSet *RuleSet) *multierror.Error {
 
 				if action.Set.Value != nil {
 					switch value := action.Set.Value.(type) {
+					case int:
+						action.Set.Value = []int{value}
+					case string:
+						action.Set.Value = []string{value}
 					case []interface{}:
 						if len(value) == 0 {
 							result = multierror.Append(result, fmt.Errorf("unable to infer item type for '%s'", action.Set.Name))
@@ -250,18 +254,9 @@ func LoadPolicies(policiesDir string, ruleSet *RuleSet) *multierror.Error {
 
 					switch kind {
 					case reflect.String:
-						if action.Set.Append {
-							variableValue = []string{""}
-						} else {
-							variableValue = ""
-						}
+						variableValue = []string{}
 					case reflect.Int:
-						if action.Set.Append {
-							variableValue = []int{0}
-						} else {
-							variableValue = 0
-						}
-						variableValue = 0
+						variableValue = []int{}
 					case reflect.Bool:
 						variableValue = false
 					default:

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -6,14 +6,17 @@
 package rules
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"syscall"
 	"testing"
 
 	"gopkg.in/yaml.v3"
 
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
+	"github.com/hashicorp/go-multierror"
 )
 
 func savePolicy(filename string, testPolicy *Policy) error {
@@ -154,4 +157,462 @@ func TestRuleMerge(t *testing.T) {
 	if err := LoadPolicies(tmpDir, rs); err == nil {
 		t.Error("expected rule ID conflict")
 	}
+}
+
+type testVariableProvider struct {
+	vars map[string]map[string]interface{}
+}
+
+func (t *testVariableProvider) GetVariable(name string, value interface{}) (eval.VariableValue, error) {
+	switch value.(type) {
+	case []int:
+		intVar := eval.NewIntArrayVariable(func(ctx *eval.Context) []int {
+			processName := (*testEvent)(ctx.Object).process.name
+			processVars, found := t.vars[processName]
+			if !found {
+				return nil
+			}
+
+			v, found := processVars[name]
+			if !found {
+				return nil
+			}
+
+			i, _ := v.([]int)
+			return i
+		}, func(ctx *eval.Context, value interface{}) error {
+			processName := (*testEvent)(ctx.Object).process.name
+			if _, found := t.vars[processName]; !found {
+				t.vars[processName] = map[string]interface{}{}
+			}
+
+			t.vars[processName][name] = value
+			return nil
+		})
+		return intVar, nil
+	default:
+		return nil, fmt.Errorf("unsupported variable '%s'", name)
+	}
+}
+
+func TestActionSetVariable(t *testing.T) {
+	enabled := map[eval.EventType]bool{"*": true}
+	stateScopes := map[Scope]VariableProviderFactory{
+		"process": func() VariableProvider {
+			return &testVariableProvider{
+				vars: map[string]map[string]interface{}{},
+			}
+		},
+	}
+	var opts Opts
+	opts.
+		WithConstants(testConstants).
+		WithSupportedDiscarders(testSupportedDiscarders).
+		WithEventTypeEnabled(enabled).
+		WithVariables(make(map[string]eval.VariableValue)).
+		WithStateScopes(stateScopes).
+		WithMacros(make(map[eval.MacroID]*eval.Macro))
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts)
+
+	testPolicy := &Policy{
+		Name: "test-policy",
+		Rules: []*RuleDefinition{{
+			ID:         "test_rule",
+			Expression: `open.filename == "/tmp/test"`,
+			Actions: []ActionDefinition{{
+				Set: &SetDefinition{
+					Name:  "var1",
+					Value: true,
+				},
+			}, {
+				Set: &SetDefinition{
+					Name:  "var2",
+					Value: "value",
+				},
+			}, {
+				Set: &SetDefinition{
+					Name:  "var3",
+					Value: 123,
+				},
+			}, {
+				Set: &SetDefinition{
+					Name:  "var4",
+					Value: 123,
+					Scope: "process",
+				},
+			}, {
+				Set: &SetDefinition{
+					Name: "var5",
+					Value: []string{
+						"val1",
+					},
+				},
+			}, {
+				Set: &SetDefinition{
+					Name: "var6",
+					Value: []int{
+						123,
+					},
+				},
+			}, {
+				Set: &SetDefinition{
+					Name:   "var7",
+					Append: true,
+					Value: []string{
+						"aaa",
+					},
+				},
+			}, {
+				Set: &SetDefinition{
+					Name:   "var8",
+					Append: true,
+					Value: []int{
+						123,
+					},
+				},
+			}, {
+				Set: &SetDefinition{
+					Name:  "var9",
+					Field: "open.filename",
+				},
+			}, {
+				Set: &SetDefinition{
+					Name:   "var10",
+					Field:  "open.filename",
+					Append: true,
+				},
+			}},
+		}, {
+			ID: "test_rule2",
+			Expression: `open.filename == "/tmp/test2" && ` +
+				`${var1} == true && ` +
+				`"${var2}" == "value" && ` +
+				`${var2} == "value" && ` +
+				`${var3} == 123 && ` +
+				`${process.var4} == 123 && ` +
+				`"val1" in ${var5} && ` +
+				`123 in ${var6} && ` +
+				`"aaa" in ${var7} && ` +
+				`123 in ${var8} && ` +
+				`${var9} == "/tmp/test" && ` +
+				`"/tmp/test" in ${var10}`,
+		}},
+	}
+
+	tmpDir, err := ioutil.TempDir("", "test-policy")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := savePolicy(filepath.Join(tmpDir, "test.policy"), testPolicy); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := LoadPolicies(tmpDir, rs); err != nil {
+		t.Error(err)
+	}
+
+	rule := rs.GetRules()["test_rule"]
+	if rule == nil {
+		t.Fatal("failed to find test_rule in ruleset")
+	}
+
+	event := &testEvent{
+		process: testProcess{
+			uid:  0,
+			name: "myprocess",
+		},
+	}
+
+	ev1 := *event
+	ev1.kind = "open"
+	ev1.open = testOpen{
+		filename: "/tmp/test2",
+		flags:    syscall.O_RDONLY,
+	}
+
+	if rs.Evaluate(event) {
+		t.Errorf("Expected event to match no rule")
+	}
+
+	ev1.open.filename = "/tmp/test"
+
+	if !rs.Evaluate(&ev1) {
+		t.Errorf("Expected event to match rule")
+	}
+
+	ev1.open.filename = "/tmp/test2"
+	if !rs.Evaluate(&ev1) {
+		t.Errorf("Expected event to match rule")
+	}
+}
+
+func TestActionSetVariableConflict(t *testing.T) {
+	enabled := map[eval.EventType]bool{"*": true}
+	var opts Opts
+	opts.
+		WithConstants(testConstants).
+		WithSupportedDiscarders(testSupportedDiscarders).
+		WithEventTypeEnabled(enabled).
+		WithVariables(make(map[string]eval.VariableValue)).
+		WithMacros(make(map[eval.MacroID]*eval.Macro))
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts)
+
+	testPolicy := &Policy{
+		Name: "test-policy",
+		Rules: []*RuleDefinition{{
+			ID:         "test_rule",
+			Expression: `open.filename == "/tmp/test"`,
+			Actions: []ActionDefinition{{
+				Set: &SetDefinition{
+					Name:  "var1",
+					Value: true,
+				},
+			}, {
+				Set: &SetDefinition{
+					Name:  "var1",
+					Value: "value",
+				},
+			}},
+		}, {
+			ID: "test_rule2",
+			Expression: `open.filename == "/tmp/test2" && ` +
+				`${var1} == true`,
+		}},
+	}
+
+	tmpDir, err := ioutil.TempDir("", "test-policy")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := savePolicy(filepath.Join(tmpDir, "test.policy"), testPolicy); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := LoadPolicies(tmpDir, rs); err == nil {
+		t.Error("expected policy to fail to load")
+	} else {
+		t.Log(err)
+	}
+}
+
+func loadPolicy(t *testing.T, testPolicy *Policy) *multierror.Error {
+	enabled := map[eval.EventType]bool{"*": true}
+	var opts Opts
+	opts.
+		WithConstants(testConstants).
+		WithSupportedDiscarders(testSupportedDiscarders).
+		WithEventTypeEnabled(enabled).
+		WithVariables(make(map[string]eval.VariableValue)).
+		WithMacros(make(map[eval.MacroID]*eval.Macro))
+	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts)
+
+	tmpDir, err := ioutil.TempDir("", "test-policy")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := savePolicy(filepath.Join(tmpDir, "test.policy"), testPolicy); err != nil {
+		t.Fatal(err)
+	}
+
+	return LoadPolicies(tmpDir, rs)
+}
+
+func TestActionSetVariableInvalid(t *testing.T) {
+	t.Run("both-field-and-value", func(t *testing.T) {
+		testPolicy := &Policy{
+			Name: "test-policy",
+			Rules: []*RuleDefinition{{
+				ID:         "test_rule",
+				Expression: `open.filename == "/tmp/test"`,
+				Actions: []ActionDefinition{{
+					Set: &SetDefinition{
+						Name:  "var1",
+						Value: []string{"abc"},
+						Field: "open.filename",
+					},
+				}},
+			}},
+		}
+
+		if err := loadPolicy(t, testPolicy); err == nil {
+			t.Error("expected policy to fail to load")
+		} else {
+			t.Log(err)
+		}
+	})
+
+	t.Run("bool-array", func(t *testing.T) {
+		testPolicy := &Policy{
+			Name: "test-policy",
+			Rules: []*RuleDefinition{{
+				ID:         "test_rule",
+				Expression: `open.filename == "/tmp/test"`,
+				Actions: []ActionDefinition{{
+					Set: &SetDefinition{
+						Name:  "var1",
+						Value: []bool{true},
+					},
+				}},
+			}, {
+				ID: "test_rule2",
+				Expression: `open.filename == "/tmp/test2" && ` +
+					`${var1} == true`,
+			}},
+		}
+
+		if err := loadPolicy(t, testPolicy); err == nil {
+			t.Error("expected policy to fail to load")
+		} else {
+			t.Log(err)
+		}
+	})
+
+	t.Run("heterogeneous-array", func(t *testing.T) {
+		testPolicy := &Policy{
+			Name: "test-policy",
+			Rules: []*RuleDefinition{{
+				ID:         "test_rule",
+				Expression: `open.filename == "/tmp/test"`,
+				Actions: []ActionDefinition{{
+					Set: &SetDefinition{
+						Name:  "var1",
+						Value: []interface{}{"string", true},
+					},
+				}},
+			}, {
+				ID: "test_rule2",
+				Expression: `open.filename == "/tmp/test2" && ` +
+					`${var1} == true`,
+			}},
+		}
+
+		if err := loadPolicy(t, testPolicy); err == nil {
+			t.Error("expected policy to fail to load")
+		} else {
+			t.Log(err)
+		}
+	})
+
+	t.Run("nil-values", func(t *testing.T) {
+		testPolicy := &Policy{
+			Name: "test-policy",
+			Rules: []*RuleDefinition{{
+				ID:         "test_rule",
+				Expression: `open.filename == "/tmp/test"`,
+				Actions: []ActionDefinition{{
+					Set: &SetDefinition{
+						Name:  "var1",
+						Value: nil,
+					},
+				}},
+			}},
+		}
+
+		if err := loadPolicy(t, testPolicy); err == nil {
+			t.Error("expected policy to fail to load")
+		} else {
+			t.Log(err)
+		}
+	})
+
+	t.Run("append-array", func(t *testing.T) {
+		testPolicy := &Policy{
+			Name: "test-policy",
+			Rules: []*RuleDefinition{{
+				ID:         "test_rule",
+				Expression: `open.filename == "/tmp/test"`,
+				Actions: []ActionDefinition{{
+					Set: &SetDefinition{
+						Name:   "var1",
+						Value:  []string{"abc"},
+						Append: true,
+					},
+				}, {
+					Set: &SetDefinition{
+						Name:   "var1",
+						Value:  true,
+						Append: true,
+					},
+				}},
+			}, {
+				ID: "test_rule2",
+				Expression: `open.filename == "/tmp/test2" && ` +
+					`${var1} == true`,
+			}},
+		}
+
+		if err := loadPolicy(t, testPolicy); err == nil {
+			t.Error("expected policy to fail to load")
+		} else {
+			t.Log(err)
+		}
+	})
+
+	t.Run("conflicting-field-type", func(t *testing.T) {
+		testPolicy := &Policy{
+			Name: "test-policy",
+			Rules: []*RuleDefinition{{
+				ID:         "test_rule",
+				Expression: `open.filename == "/tmp/test"`,
+				Actions: []ActionDefinition{{
+					Set: &SetDefinition{
+						Name:  "var1",
+						Field: "open.filename",
+					},
+				}, {
+					Set: &SetDefinition{
+						Name:   "var1",
+						Value:  true,
+						Append: true,
+					},
+				}},
+			}, {
+				ID: "test_rule2",
+				Expression: `open.filename == "/tmp/test2" && ` +
+					`${var1} == "true"`,
+			}},
+		}
+
+		if err := loadPolicy(t, testPolicy); err == nil {
+			t.Error("expected policy to fail to load")
+		} else {
+			t.Log(err)
+		}
+	})
+
+	t.Run("conflicting-field-type", func(t *testing.T) {
+		testPolicy := &Policy{
+			Name: "test-policy",
+			Rules: []*RuleDefinition{{
+				ID:         "test_rule",
+				Expression: `open.filename == "/tmp/test"`,
+				Actions: []ActionDefinition{{
+					Set: &SetDefinition{
+						Name:   "var1",
+						Field:  "open.filename",
+						Append: true,
+					},
+				}, {
+					Set: &SetDefinition{
+						Name:   "var1",
+						Field:  "process.is_root",
+						Append: true,
+					},
+				}},
+			}, {
+				ID: "test_rule2",
+				Expression: `open.filename == "/tmp/test2" && ` +
+					`${var1} == "true"`,
+			}},
+		}
+
+		if err := loadPolicy(t, testPolicy); err == nil {
+			t.Error("expected policy to fail to load")
+		} else {
+			t.Log(err)
+		}
+	})
 }

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -130,7 +130,7 @@ type SetDefinition struct {
 	Name   string      `yaml:"name"`
 	Value  interface{} `yaml:"value"`
 	Field  string      `yaml:"field"`
-	Append bool        `yaml:"bool"`
+	Append bool        `yaml:"append"`
 	Scope  Scope       `yaml:"scope"`
 }
 
@@ -159,6 +159,8 @@ type RuleSet struct {
 	model            eval.Model
 	eventCtor        func() eval.Event
 	listeners        []RuleSetListener
+	globalVariables  eval.GlobalVariables
+	scopedVariables  map[Scope]VariableProvider
 	// fields holds the list of event field queries (like "process.uid") used by the entire set of rules
 	fields []string
 	logger Logger
@@ -491,11 +493,6 @@ func (rs *RuleSet) runRuleActions(ctx *eval.Context, rule *Rule) error {
 	return nil
 }
 
-// GetVariable returns a new mutable variable with the type of the specified value
-func (rs *RuleSet) GetVariable(name string, value interface{}) (eval.VariableValue, error) {
-	return eval.GetVariable(name, value)
-}
-
 // Evaluate the specified event against the set of rules
 func (rs *RuleSet) Evaluate(event eval.Event) bool {
 	ctx := rs.pool.Get(event.GetPointer())
@@ -612,5 +609,6 @@ func NewRuleSet(model eval.Model, eventCtor func() eval.Event, opts *Opts) *Rule
 		logger:           logger,
 		pool:             eval.NewContextPool(),
 		fieldEvaluators:  make(map[string]eval.Evaluator),
+		scopedVariables:  make(map[Scope]VariableProvider),
 	}
 }

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -104,6 +104,7 @@ type ActionDefinition struct {
 	Set *SetDefinition `yaml:"set"`
 }
 
+// Check returns an error if the action in invalid
 func (a *ActionDefinition) Check() error {
 	if a.Set == nil {
 		return errors.New("missing 'set' section in action")

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -514,8 +514,17 @@ func (rs *RuleSet) runRuleActions(ctx *eval.Context, rule *Rule) error {
 					default:
 						return fmt.Errorf("append is not supported for %s", reflect.TypeOf(value))
 					}
-				} else if err := mutable.Set(ctx, value); err != nil {
-					return err
+				} else {
+					switch value.(type) {
+					case string:
+						value = []string{value.(string)}
+					case int:
+						value = []int{value.(int)}
+					}
+
+					if err := mutable.Set(ctx, value); err != nil {
+						return err
+					}
 				}
 			}
 		}

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -63,13 +63,14 @@ type RuleID = string
 
 // RuleDefinition holds the definition of a rule
 type RuleDefinition struct {
-	ID          RuleID            `yaml:"id"`
-	Version     string            `yaml:"version"`
-	Expression  string            `yaml:"expression"`
-	Description string            `yaml:"description"`
-	Tags        map[string]string `yaml:"tags"`
-	Disabled    bool              `yaml:"disabled"`
-	Combine     CombinePolicy     `yaml:"combine"`
+	ID          RuleID             `yaml:"id"`
+	Version     string             `yaml:"version"`
+	Expression  string             `yaml:"expression"`
+	Description string             `yaml:"description"`
+	Tags        map[string]string  `yaml:"tags"`
+	Disabled    bool               `yaml:"disabled"`
+	Combine     CombinePolicy      `yaml:"combine"`
+	Actions     []ActionDefinition `yaml:"actions"`
 	Policy      *Policy
 }
 
@@ -96,6 +97,37 @@ func (rd *RuleDefinition) MergeWith(rd2 *RuleDefinition) error {
 	}
 	rd.Disabled = rd2.Disabled
 	return nil
+}
+
+// ActionDefinition describes a rule action section
+type ActionDefinition struct {
+	Set *SetDefinition `yaml:"set"`
+}
+
+func (a *ActionDefinition) Check() error {
+	if a.Set == nil {
+		return errors.New("missing 'set' section in action")
+	}
+
+	if a.Set.Name == "" {
+		return errors.New("action name is empty")
+	}
+
+	if a.Set.Value == nil {
+		return errors.New("empty value not allowed")
+	}
+
+	return nil
+}
+
+// Scope describes the scope variables
+type Scope string
+
+// SetDefinition describes the 'set' section of a rule action
+type SetDefinition struct {
+	Name  string      `yaml:"name"`
+	Value interface{} `yaml:"value"`
+	Scope Scope       `yaml:"scope"`
 }
 
 // Rule describes a rule of a ruleset
@@ -401,6 +433,37 @@ func (rs *RuleSet) IsDiscarder(event eval.Event, field eval.Field) (bool, error)
 	return true, nil
 }
 
+func (rs *RuleSet) runRuleActions(ctx *eval.Context, rule *Rule) error {
+	for _, action := range rule.Definition.Actions {
+		switch {
+		case action.Set != nil:
+			name := string(action.Set.Scope)
+			if name != "" {
+				name += "."
+			}
+			name += action.Set.Name
+
+			variable, found := rs.opts.Variables[name]
+			if !found {
+				return fmt.Errorf("unknown variable: %s", name)
+			}
+
+			if mutable, ok := variable.(eval.MutableVariable); ok {
+				if err := mutable.Set(ctx, action.Set.Value); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// GetVariable returns a new mutable variable with the type of the specified value
+func (rs *RuleSet) GetVariable(name string, value interface{}) (eval.VariableValue, error) {
+	return eval.GetVariable(name, value)
+}
+
 // Evaluate the specified event against the set of rules
 func (rs *RuleSet) Evaluate(event eval.Event) bool {
 	ctx := rs.pool.Get(event.GetPointer())
@@ -421,6 +484,10 @@ func (rs *RuleSet) Evaluate(event eval.Event) bool {
 
 			rs.NotifyRuleMatch(rule, event)
 			result = true
+
+			if err := rs.runRuleActions(ctx, rule); err != nil {
+				rs.logger.Errorf("Error while executing rule actions: %s", err)
+			}
 		}
 	}
 

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -154,7 +154,6 @@ type RuleSet struct {
 	loadedPolicies   map[string]string
 	eventRuleBuckets map[eval.EventType]*RuleBucket
 	rules            map[eval.RuleID]*Rule
-	macros           map[eval.RuleID]*Macro
 	fieldEvaluators  map[string]eval.Evaluator
 	model            eval.Model
 	eventCtor        func() eval.Event

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -473,6 +473,10 @@ func (rs *RuleSet) runRuleActions(ctx *eval.Context, rule *Rule) error {
 							if err := mutable.Set(ctx, evaluator.GetValue(ctx)+value); err != nil {
 								return err
 							}
+						case *eval.StringArrayEvaluator:
+							if err := mutable.Set(ctx, append(evaluator.EvalFnc(ctx), value)); err != nil {
+								return err
+							}
 						default:
 							return fmt.Errorf("cannot append string array to string variable %s", name)
 						}
@@ -491,6 +495,10 @@ func (rs *RuleSet) runRuleActions(ctx *eval.Context, rule *Rule) error {
 							if err := mutable.Set(ctx, evaluator.EvalFnc(ctx)+value); err != nil {
 								return err
 							}
+						case *eval.IntArrayEvaluator:
+							if err := mutable.Set(ctx, append(evaluator.EvalFnc(ctx), value)); err != nil {
+								return err
+							}
 						default:
 							return fmt.Errorf("cannot append '%s' to int variable %s", reflect.TypeOf(evaluator), name)
 						}
@@ -506,8 +514,7 @@ func (rs *RuleSet) runRuleActions(ctx *eval.Context, rule *Rule) error {
 					default:
 						return fmt.Errorf("append is not supported for %s", reflect.TypeOf(value))
 					}
-				}
-				if err := mutable.Set(ctx, value); err != nil {
+				} else if err := mutable.Set(ctx, value); err != nil {
 					return err
 				}
 			}

--- a/pkg/security/secl/rules/ruleset.go
+++ b/pkg/security/secl/rules/ruleset.go
@@ -465,63 +465,10 @@ func (rs *RuleSet) runRuleActions(ctx *eval.Context, rule *Rule) error {
 				}
 
 				if action.Set.Append {
-					// TODO(lebauce): move to variables.go
-					switch value := value.(type) {
-					case string:
-						switch evaluator := variable.GetEvaluator().(type) {
-						case *eval.StringEvaluator:
-							if err := mutable.Set(ctx, evaluator.GetValue(ctx)+value); err != nil {
-								return err
-							}
-						case *eval.StringArrayEvaluator:
-							if err := mutable.Set(ctx, append(evaluator.EvalFnc(ctx), value)); err != nil {
-								return err
-							}
-						default:
-							return fmt.Errorf("cannot append string array to string variable %s", name)
-						}
-					case []string:
-						switch evaluator := variable.GetEvaluator().(type) {
-						case *eval.StringArrayEvaluator:
-							if err := mutable.Set(ctx, append(evaluator.EvalFnc(ctx), value...)); err != nil {
-								return err
-							}
-						default:
-							return fmt.Errorf("cannot append string array to string variable %s", name)
-						}
-					case int:
-						switch evaluator := variable.GetEvaluator().(type) {
-						case *eval.IntEvaluator:
-							if err := mutable.Set(ctx, evaluator.EvalFnc(ctx)+value); err != nil {
-								return err
-							}
-						case *eval.IntArrayEvaluator:
-							if err := mutable.Set(ctx, append(evaluator.EvalFnc(ctx), value)); err != nil {
-								return err
-							}
-						default:
-							return fmt.Errorf("cannot append '%s' to int variable %s", reflect.TypeOf(evaluator), name)
-						}
-					case []int:
-						switch evaluator := variable.GetEvaluator().(type) {
-						case *eval.IntArrayEvaluator:
-							if err := mutable.Set(ctx, append(evaluator.EvalFnc(ctx), value...)); err != nil {
-								return err
-							}
-						default:
-							return fmt.Errorf("cannot append '%s' to int array variable %s", reflect.TypeOf(evaluator), name)
-						}
-					default:
+					if err := mutable.Append(ctx, value); err != nil {
 						return fmt.Errorf("append is not supported for %s", reflect.TypeOf(value))
 					}
 				} else {
-					switch value.(type) {
-					case string:
-						value = []string{value.(string)}
-					case int:
-						value = []int{value.(int)}
-					}
-
 					if err := mutable.Set(ctx, value); err != nil {
 						return err
 					}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -110,7 +110,11 @@ rules:
 {{- if $Action.Set}}
       - set:
           name: {{$Action.Set.Name}}
+		  {{- if $Action.Set.Value}}
           value: {{$Action.Set.Value}}
+          {{- else if $Action.Set.Field}}
+          field: {{$Action.Set.Field}}
+          {{- end}}
           scope: {{$Action.Set.Scope}}
 {{- end}}
 {{- end}}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -116,6 +116,7 @@ rules:
           field: {{$Action.Set.Field}}
           {{- end}}
           scope: {{$Action.Set.Scope}}
+          append: {{$Action.Set.Append}}
 {{- end}}
 {{- end}}
 {{end}}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -105,6 +105,15 @@ rules:
   - id: {{$Rule.ID}}
     expression: >-
       {{$Rule.Expression}}
+    actions:
+{{- range $Action := .Actions}}
+{{- if $Action.Set}}
+      - set:
+          name: {{$Action.Set.Name}}
+          value: {{$Action.Set.Value}}
+          scope: {{$Action.Set.Scope}}
+{{- end}}
+{{- end}}
 {{end}}
 `
 

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -657,6 +657,7 @@ func TestProcessMutableVariable(t *testing.T) {
 		Expression: `open.file.path == "{{.Root}}/test-open-3"` +
 			`&& ${process.var1} == true` +
 			`&& ${process.var2} == "on"` +
+			`&& "aaa" in ${process.var3}` +
 			`&& "bbb" in ${process.var3}` +
 			`&& process.file.name == "${var4}"` +
 			`&& open.file.path == "${var5}-3"`,

--- a/releasenotes/notes/cws-secl-state-variables-8f37e28c65c30d03.yaml
+++ b/releasenotes/notes/cws-secl-state-variables-8f37e28c65c30d03.yaml
@@ -1,0 +1,51 @@
+---
+features:
+  - |
+    Allow setting variables to store states through rule actions.
+    Action rules can now be defined as follows:
+
+    ```
+    - id: my_rule
+      expression: ...
+      actions:
+        - set:
+            name: my_boolean_variable
+            value: true
+        - set:
+            name: my_string_variable
+            value: a string
+        - set:
+            name: my_other_variable
+            field: process.file.name
+    ```
+
+    These actions will be executed when the rule is triggered by an event.
+    Right now, only `set` actions can be defined.
+    `name` is the name of the variable that will be set by the actions.
+    The value for the variable can be specified by using:
+    - `value` for a predefined value
+      (strings, integers, booleans, array of strings and array of integers are currently supported).
+    - `field` for the value of an event field.
+
+    Variable arrays can be modified by specifying `append: true`.
+
+    Variables can be reused in rule expressions like a regular variable:
+
+    ```
+    - id: my_other_rule
+      expression: |-
+        open.file.path == ${my_other_variable}
+    ```
+
+    By default, variables are global. They can be bounded to a specific process by using the `process`
+    scope as follows:
+
+    ```
+    - set:
+        name: my_scoped_variable
+        scope: process
+        value: true
+    ```
+
+    The variable can be referenced in other expressions as `${process.my_scoped_variable}`. When the process dies, the
+    variable with be automatically freed.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Allow setting variables to store states through rule actions.

It is now possible to define actions for rules as follows:

```
- id: my_rule
  expression: ...
  actions:
    - set:
        name: my_boolean_variable
        value: true
    - set:
        name: my_string_variable
        value: true
    - set:
        name: my_other_variable
        field: process.file.name
```

These actions will be executed when the rule is triggered by an event.
Right now, only `set` actions can be defined.
`name` is the name of the variable that will be set by the actions.
The value for the variable can be specified
- using `value` for a predefined value
  (strings, integers, booleans, array of strings and array of integers are currently supported).
- using `field` to use the value of an event field.

Variable arrays can be modified by specifying `append: true`.

Variables can be reused in rule expressions like a regular variable:

```
- id: my_other_rule
  expression: |-
    open.file.path == ${my_other_variable}
```

By default, variables are global. They can be attached to a specific process by using the `process`
scope as follows:

```
- set:
    name: my_scoped_variable
    scope: process
    value: true
```

The variable can be referenced in other expressions as `${process.my_scoped_variable}`. When the process dies, the
variable with be automatically freed.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Variables can be used to store state, allowing features such as rule chaining
or process tagging.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
