### PR TITLE
[networks] Migrate NPM to `ebpf-manager` library

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -28,14 +28,7 @@ core,github.com/DataDog/agent-payload/v5/gogen,BSD-3-Clause,"Datadog, Inc"
 core,github.com/DataDog/agent-payload/v5/process,BSD-3-Clause,"Datadog, Inc"
 core,github.com/DataDog/datadog-go/statsd,MIT,"Datadog, Inc"
 core,github.com/DataDog/datadog-operator/api/v1alpha1,Apache-2.0,"Datadog, Inc"
-core,github.com/DataDog/ebpf,MIT,Authors of Cilium | Authors of Datadog | Cloudflare | Nathan Sweet
 core,github.com/DataDog/ebpf-manager,MIT,Authors of Datadog
-core,github.com/DataDog/ebpf/asm,MIT,Authors of Cilium | Authors of Datadog | Cloudflare | Nathan Sweet
-core,github.com/DataDog/ebpf/internal,MIT,Authors of Cilium | Authors of Datadog | Cloudflare | Nathan Sweet
-core,github.com/DataDog/ebpf/internal/btf,MIT,Authors of Cilium | Authors of Datadog | Cloudflare | Nathan Sweet
-core,github.com/DataDog/ebpf/internal/unix,MIT,Authors of Cilium | Authors of Datadog | Cloudflare | Nathan Sweet
-core,github.com/DataDog/ebpf/manager,MIT,Authors of Cilium | Authors of Datadog | Cloudflare | Nathan Sweet
-core,github.com/DataDog/ebpf/perf,MIT,Authors of Cilium | Authors of Datadog | Cloudflare | Nathan Sweet
 core,github.com/DataDog/extendeddaemonset/api/v1alpha1,Apache-2.0,"Datadog, Inc"
 core,github.com/DataDog/gohai/cpu,MIT,Datadog <info@datadoghq.com> | Kentaro Kuribayashi <kentarok@gmail.com>
 core,github.com/DataDog/gohai/filesystem,MIT,Datadog <info@datadoghq.com> | Kentaro Kuribayashi <kentarok@gmail.com>
@@ -937,8 +930,8 @@ core,golang.org/x/term,BSD-3-Clause,The Go Authors
 core,golang.org/x/text/encoding,BSD-3-Clause,The Go Authors
 core,golang.org/x/text/encoding/internal,BSD-3-Clause,The Go Authors
 core,golang.org/x/text/encoding/internal/identifier,BSD-3-Clause,The Go Authors
-core,golang.org/x/text/encoding/unicode,BSD-3-Clause,The Go Authors
 core,golang.org/x/text/encoding/japanese,BSD-3-Clause,The Go Authors
+core,golang.org/x/text/encoding/unicode,BSD-3-Clause,The Go Authors
 core,golang.org/x/text/internal/utf8internal,BSD-3-Clause,The Go Authors
 core,golang.org/x/text/runes,BSD-3-Clause,The Go Authors
 core,golang.org/x/text/secure/bidirule,BSD-3-Clause,The Go Authors

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -185,6 +185,8 @@ core,github.com/cilium/ebpf,MIT,Authors of Cilium | Cloudflare | Nathan Sweet
 core,github.com/cilium/ebpf/asm,MIT,Authors of Cilium | Cloudflare | Nathan Sweet
 core,github.com/cilium/ebpf/internal,MIT,Authors of Cilium | Cloudflare | Nathan Sweet
 core,github.com/cilium/ebpf/internal/btf,MIT,Authors of Cilium | Cloudflare | Nathan Sweet
+core,github.com/cilium/ebpf/internal/epoll,MIT,Authors of Cilium | Cloudflare | Nathan Sweet
+core,github.com/cilium/ebpf/internal/sys,MIT,Authors of Cilium | Cloudflare | Nathan Sweet
 core,github.com/cilium/ebpf/internal/unix,MIT,Authors of Cilium | Cloudflare | Nathan Sweet
 core,github.com/cilium/ebpf/perf,MIT,Authors of Cilium | Cloudflare | Nathan Sweet
 core,github.com/clbanning/mxj,MIT,Charles Banning <clbanning@gmail.com> | The Go Authors

--- a/go.mod
+++ b/go.mod
@@ -71,8 +71,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.33.0-rc.4
 	github.com/DataDog/datadog-go v4.8.3+incompatible
 	github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a
-	github.com/DataDog/ebpf v0.0.0-20211116165855-af5870810f0b
-	github.com/DataDog/ebpf-manager v0.0.0-20220103145404-d938938b1a8e
+	github.com/DataDog/ebpf-manager v0.0.0-20211203142333-a0c5ade33f8e
 	github.com/DataDog/gohai v0.0.0-20211126091652-d183ed971098
 	github.com/DataDog/gopsutil v0.0.0-20211112180027-9aa392ae181a
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.33.0-rc.4
 	github.com/DataDog/datadog-go v4.8.3+incompatible
 	github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a
-	github.com/DataDog/ebpf-manager v0.0.0-20220106192434-e7d08f7e4e27
+	github.com/DataDog/ebpf-manager v0.0.0-20220106215052-9189b77594bb
 	github.com/DataDog/gohai v0.0.0-20211126091652-d183ed971098
 	github.com/DataDog/gopsutil v0.0.0-20211112180027-9aa392ae181a
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.33.0-rc.4
 	github.com/DataDog/datadog-go v4.8.3+incompatible
 	github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a
-	github.com/DataDog/ebpf-manager v0.0.0-20220103145404-d938938b1a8e
+	github.com/DataDog/ebpf-manager v0.0.0-20220106192434-e7d08f7e4e27
 	github.com/DataDog/gohai v0.0.0-20211126091652-d183ed971098
 	github.com/DataDog/gopsutil v0.0.0-20211112180027-9aa392ae181a
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect
@@ -99,7 +99,7 @@ require (
 	github.com/blabber/go-freebsd-sysctl v0.0.0-20201130114544-503969f39d8f
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cihub/seelog v0.0.0-20170130134532-f561c5e57575
-	github.com/cilium/ebpf v0.6.3-0.20210917122031-fc2955d2ecee
+	github.com/cilium/ebpf v0.7.1-0.20211227144435-70d770f1e5f9
 	github.com/clbanning/mxj v1.8.4
 	github.com/cloudfoundry-community/go-cfclient v0.0.0-20210621174645-7773f7e22665
 	github.com/containerd/cgroups v1.0.2

--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.33.0-rc.4
 	github.com/DataDog/datadog-go v4.8.3+incompatible
 	github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a
-	github.com/DataDog/ebpf-manager v0.0.0-20211203142333-a0c5ade33f8e
+	github.com/DataDog/ebpf-manager v0.0.0-20220103145404-d938938b1a8e
 	github.com/DataDog/gohai v0.0.0-20211126091652-d183ed971098
 	github.com/DataDog/gopsutil v0.0.0-20211112180027-9aa392ae181a
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bp
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a h1:vqz6k806rvz01tIzOA2UHE3j1IEAMcDxw8O+nA3H+Mk=
 github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a/go.mod h1:2qOvG41jii2ks6Umn6MbDGlHRgwoFiYXcjgQQ9VlsS0=
-github.com/DataDog/ebpf-manager v0.0.0-20220106192434-e7d08f7e4e27 h1:k/9SjGSDj5nLwLINoMljBo602en/ZUdutqQKn8/nKtA=
-github.com/DataDog/ebpf-manager v0.0.0-20220106192434-e7d08f7e4e27/go.mod h1:q6FEcnn+mlqeRyd+nNN/xuoHfVKVsZav5k3xEIQxkpI=
+github.com/DataDog/ebpf-manager v0.0.0-20220106215052-9189b77594bb h1:nUsDJ5s9zoxwL1RpsxrcTQOop4oa9FU8IDGYVDEgaIY=
+github.com/DataDog/ebpf-manager v0.0.0-20220106215052-9189b77594bb/go.mod h1:q6FEcnn+mlqeRyd+nNN/xuoHfVKVsZav5k3xEIQxkpI=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c h1:a9OMhZzrrB4nd2eAsXZIBkQ061Gb/QT4CI2g+OWWevs=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c/go.mod h1:lMIXf2EAzxbIv2zEvWu1bdqlaclUWoCtN13MHuPcY5I=
 github.com/DataDog/gohai v0.0.0-20211126091652-d183ed971098 h1:ANBijoD3xHRs6po7uejTdUHmCnL7Gr0MlE4RSiSBR1E=

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bp
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a h1:vqz6k806rvz01tIzOA2UHE3j1IEAMcDxw8O+nA3H+Mk=
 github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a/go.mod h1:2qOvG41jii2ks6Umn6MbDGlHRgwoFiYXcjgQQ9VlsS0=
-github.com/DataDog/ebpf-manager v0.0.0-20220103145404-d938938b1a8e h1:FutKp9ucvaoyiaYslgoZ64c/1wlOIgiPs+scZFy1K7s=
-github.com/DataDog/ebpf-manager v0.0.0-20220103145404-d938938b1a8e/go.mod h1:05Y9FhEyILUdCovBthi5y4KPY8AfUg5EbMNC6RMQXDY=
+github.com/DataDog/ebpf-manager v0.0.0-20220106192434-e7d08f7e4e27 h1:k/9SjGSDj5nLwLINoMljBo602en/ZUdutqQKn8/nKtA=
+github.com/DataDog/ebpf-manager v0.0.0-20220106192434-e7d08f7e4e27/go.mod h1:q6FEcnn+mlqeRyd+nNN/xuoHfVKVsZav5k3xEIQxkpI=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c h1:a9OMhZzrrB4nd2eAsXZIBkQ061Gb/QT4CI2g+OWWevs=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c/go.mod h1:lMIXf2EAzxbIv2zEvWu1bdqlaclUWoCtN13MHuPcY5I=
 github.com/DataDog/gohai v0.0.0-20211126091652-d183ed971098 h1:ANBijoD3xHRs6po7uejTdUHmCnL7Gr0MlE4RSiSBR1E=
@@ -305,8 +305,8 @@ github.com/cilium/ebpf v0.2.0/go.mod h1:To2CFviqOWL/M0gIMsvSMlqe7em/l1ALkX1PyjrX
 github.com/cilium/ebpf v0.4.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.5.0/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
 github.com/cilium/ebpf v0.6.2/go.mod h1:4tRaxcgiL706VnOzHOdBlY8IEAIdxINsQBcU4xJJXRs=
-github.com/cilium/ebpf v0.6.3-0.20210917122031-fc2955d2ecee h1:eg3Xm5uBYJLRDVq750EFFx9CHTOEFIH/MjLNNpyTS3Y=
-github.com/cilium/ebpf v0.6.3-0.20210917122031-fc2955d2ecee/go.mod h1:/oI2+1shJiTGAMgl6/RgJr36Eo1jzrRcAWbcXO2usCA=
+github.com/cilium/ebpf v0.7.1-0.20211227144435-70d770f1e5f9 h1:WJJWEj2ETcJwnTZWHaB2tzWb9nTteHfFg1bX9l4t7j4=
+github.com/cilium/ebpf v0.7.1-0.20211227144435-70d770f1e5f9/go.mod h1:f5zLIM0FSNuAkSyLAN7X+Hy6yznlF1mNiWUMfxMtrgk=
 github.com/clbanning/mxj v1.8.4 h1:HuhwZtbyvyOw+3Z1AowPkU87JkJUSv751ELWaiTpj8I=
 github.com/clbanning/mxj v1.8.4/go.mod h1:BVjHeAH+rl9rs6f+QIpeRl0tfu10SXn1pUSa5PVGJng=
 github.com/cloudfoundry-community/go-cfclient v0.0.0-20210621174645-7773f7e22665 h1:LDCKU3OIIsl7sX1KggC6zIHKk0PCeYbmOGbCHqNCSOQ=

--- a/go.sum
+++ b/go.sum
@@ -116,10 +116,8 @@ github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bp
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a h1:vqz6k806rvz01tIzOA2UHE3j1IEAMcDxw8O+nA3H+Mk=
 github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a/go.mod h1:2qOvG41jii2ks6Umn6MbDGlHRgwoFiYXcjgQQ9VlsS0=
-github.com/DataDog/ebpf-manager v0.0.0-20211116173716-a65628f678af h1:/VrEHsq0gjyIl7IXpiE69B/Mzjd7sjM3QcVfYa3PUss=
-github.com/DataDog/ebpf-manager v0.0.0-20211116173716-a65628f678af/go.mod h1:05Y9FhEyILUdCovBthi5y4KPY8AfUg5EbMNC6RMQXDY=
-github.com/DataDog/ebpf-manager v0.0.0-20211203142333-a0c5ade33f8e h1:Uyiz+4/7hlkj3Z0GLQ6Q5UWeL1eR4eWzkmyfkcn/w7I=
-github.com/DataDog/ebpf-manager v0.0.0-20211203142333-a0c5ade33f8e/go.mod h1:05Y9FhEyILUdCovBthi5y4KPY8AfUg5EbMNC6RMQXDY=
+github.com/DataDog/ebpf-manager v0.0.0-20220103145404-d938938b1a8e h1:FutKp9ucvaoyiaYslgoZ64c/1wlOIgiPs+scZFy1K7s=
+github.com/DataDog/ebpf-manager v0.0.0-20220103145404-d938938b1a8e/go.mod h1:05Y9FhEyILUdCovBthi5y4KPY8AfUg5EbMNC6RMQXDY=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c h1:a9OMhZzrrB4nd2eAsXZIBkQ061Gb/QT4CI2g+OWWevs=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c/go.mod h1:lMIXf2EAzxbIv2zEvWu1bdqlaclUWoCtN13MHuPcY5I=
 github.com/DataDog/gohai v0.0.0-20211126091652-d183ed971098 h1:ANBijoD3xHRs6po7uejTdUHmCnL7Gr0MlE4RSiSBR1E=

--- a/go.sum
+++ b/go.sum
@@ -116,10 +116,10 @@ github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bp
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a h1:vqz6k806rvz01tIzOA2UHE3j1IEAMcDxw8O+nA3H+Mk=
 github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a/go.mod h1:2qOvG41jii2ks6Umn6MbDGlHRgwoFiYXcjgQQ9VlsS0=
-github.com/DataDog/ebpf v0.0.0-20211116165855-af5870810f0b h1:jh2MmUAXxKlWQw48DEuXxIFJtFHKvDcIp1bczg8fVaY=
-github.com/DataDog/ebpf v0.0.0-20211116165855-af5870810f0b/go.mod h1:tSPYMUcskM0OLVEJSoydgYUVuhX8hOSmtaSLNtOQThg=
-github.com/DataDog/ebpf-manager v0.0.0-20220103145404-d938938b1a8e h1:FutKp9ucvaoyiaYslgoZ64c/1wlOIgiPs+scZFy1K7s=
-github.com/DataDog/ebpf-manager v0.0.0-20220103145404-d938938b1a8e/go.mod h1:05Y9FhEyILUdCovBthi5y4KPY8AfUg5EbMNC6RMQXDY=
+github.com/DataDog/ebpf-manager v0.0.0-20211116173716-a65628f678af h1:/VrEHsq0gjyIl7IXpiE69B/Mzjd7sjM3QcVfYa3PUss=
+github.com/DataDog/ebpf-manager v0.0.0-20211116173716-a65628f678af/go.mod h1:05Y9FhEyILUdCovBthi5y4KPY8AfUg5EbMNC6RMQXDY=
+github.com/DataDog/ebpf-manager v0.0.0-20211203142333-a0c5ade33f8e h1:Uyiz+4/7hlkj3Z0GLQ6Q5UWeL1eR4eWzkmyfkcn/w7I=
+github.com/DataDog/ebpf-manager v0.0.0-20211203142333-a0c5ade33f8e/go.mod h1:05Y9FhEyILUdCovBthi5y4KPY8AfUg5EbMNC6RMQXDY=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c h1:a9OMhZzrrB4nd2eAsXZIBkQ061Gb/QT4CI2g+OWWevs=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c/go.mod h1:lMIXf2EAzxbIv2zEvWu1bdqlaclUWoCtN13MHuPcY5I=
 github.com/DataDog/gohai v0.0.0-20211126091652-d183ed971098 h1:ANBijoD3xHRs6po7uejTdUHmCnL7Gr0MlE4RSiSBR1E=
@@ -230,7 +230,6 @@ github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgI
 github.com/asaskevich/govalidator v0.0.0-20180720115003-f9ffefc3facf/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
 github.com/aslakhellesoy/gox v1.0.100/go.mod h1:AJl542QsKKG96COVsv0N74HHzVQgDIQPceVUh1aeU2M=
-github.com/avast/retry-go v2.7.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/avast/retry-go v3.0.0+incompatible h1:4SOWQ7Qs+oroOTQOYnAHqelpCO0biHSxpiH9JdtuBj0=
 github.com/avast/retry-go v3.0.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/awalterschulze/gographviz v0.0.0-20160912181450-761fd5fbb34e/go.mod h1:GEV5wmg4YquNw7v1kkyoX9etIk8yVmXj+AkDHuuETHs=
@@ -499,7 +498,6 @@ github.com/felixge/httpsnoop v1.0.2 h1:+nS9g82KMXccJ/wp0zyRW9ZBHFETmMGtkk+2CTTrW
 github.com/felixge/httpsnoop v1.0.2/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/florianl/go-conntrack v0.2.0 h1:JEB4w895ZX35tvNH5JjNM9pxa+Qn73paiA37VeCZGfc=
 github.com/florianl/go-conntrack v0.2.0/go.mod h1:HRSlXmrl5M//9hiHmkwyLDwlaoba2sVDcBpHFRiVo1Q=
-github.com/florianl/go-tc v0.2.0/go.mod h1:aWdDOHrIpaff8cZp6z7dgJZ1bRsgTS6pXIW0xRdFTK8=
 github.com/florianl/go-tc v0.3.0 h1:qeqQB5kp2lwJP1p/8krLQIuRfkHWpiPPcYr3rhRSaC8=
 github.com/florianl/go-tc v0.3.0/go.mod h1:Ni/GTSK8ymDnsRQfL2meJeGmcXy7RFIvchiVHizU76U=
 github.com/flynn/go-docopt v0.0.0-20140912013429-f6dd2ebbb31e/go.mod h1:HyVoz1Mz5Co8TFO8EupIdlcpwShBmY98dkT2xeHkvEI=
@@ -890,7 +888,6 @@ github.com/josharian/native v0.0.0-20200817173448-b6b71def0850/go.mod h1:7X/rasw
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/jsimonetti/rtnetlink v0.0.0-20190606172950-9527aa82566a/go.mod h1:Oz+70psSo5OFh8DBl0Zv2ACw7Esh6pPUphlvZG9x7uw=
 github.com/jsimonetti/rtnetlink v0.0.0-20200117123717-f846d4f6c1f4/go.mod h1:WGuG/smIU4J/54PblvSbh+xvCZmpJnFgr3ds6Z55XMQ=
-github.com/jsimonetti/rtnetlink v0.0.0-20200319143528-d89fb9e42094/go.mod h1:WGuG/smIU4J/54PblvSbh+xvCZmpJnFgr3ds6Z55XMQ=
 github.com/jsimonetti/rtnetlink v0.0.0-20201009170750-9c6f07d100c1/go.mod h1:hqoO/u39cqLeBLebZ8fWdE96O7FxrAsRYhnVOdgHxok=
 github.com/jsimonetti/rtnetlink v0.0.0-20201216134343-bde56ed16391/go.mod h1:cR77jAZG3Y3bsb8hF6fHJbFoyFukLFOkQ98S0pQz3xw=
 github.com/jsimonetti/rtnetlink v0.0.0-20201220180245-69540ac93943/go.mod h1:z4c53zj6Eex712ROyh8WI0ihysb5j2ROyV42iNogmAs=
@@ -1820,7 +1817,6 @@ golang.org/x/sys v0.0.0-20200212091648-12a6c2dcc1e4/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200217220822-9197077df867/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200223170610-d5e6a3e2c0ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20200320181252-af34d8274f85/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200331124033-c3d80250170d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=

--- a/pkg/collector/corechecks/ebpf/probe/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/probe/oom_kill.go
@@ -18,8 +18,8 @@ import (
 
 	"golang.org/x/sys/unix"
 
-	bpflib "github.com/DataDog/ebpf"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
+	bpflib "github.com/cilium/ebpf"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
@@ -48,7 +48,7 @@ func NewOOMKillProbe(cfg *ebpf.Config) (*OOMKillProbe, error) {
 
 	probes := []*manager.Probe{
 		{
-			Section: "kprobe/oom_kill_process",
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kprobe/oom_kill_process", EBPFFuncName: "kprobe__oom_kill_process"},
 		},
 	}
 

--- a/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
@@ -19,8 +19,8 @@ import (
 	"github.com/iovisor/gobpf/pkg/cpupossible"
 	"golang.org/x/sys/unix"
 
-	bpflib "github.com/DataDog/ebpf"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
+	bpflib "github.com/cilium/ebpf"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/runtime"
@@ -34,8 +34,7 @@ import (
 import "C"
 
 const (
-	TCPQueueLengthUID = "tcp-queue-length"
-	statsMapName      = "tcp_queue_stats"
+	statsMapName = "tcp_queue_stats"
 )
 
 type TCPQueueLengthTracer struct {
@@ -51,10 +50,10 @@ func NewTCPQueueLengthTracer(cfg *ebpf.Config) (*TCPQueueLengthTracer, error) {
 	defer compiledOutput.Close()
 
 	probes := []*manager.Probe{
-		{Section: "kprobe/tcp_recvmsg"},
-		{Section: "kretprobe/tcp_recvmsg"},
-		{Section: "kprobe/tcp_sendmsg"},
-		{Section: "kretprobe/tcp_sendmsg"},
+		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kprobe/tcp_recvmsg", EBPFFuncName: "kprobe__tcp_recvmsg"}},
+		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kretprobe/tcp_recvmsg", EBPFFuncName: "kretprobe__tcp_recvmsg"}},
+		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kprobe/tcp_sendmsg", EBPFFuncName: "kprobe__tcp_sendmsg"}},
+		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kretprobe/tcp_sendmsg", EBPFFuncName: "kretprobe__tcp_sendmsg"}},
 	}
 
 	maps := []*manager.Map{

--- a/pkg/ebpf/perf.go
+++ b/pkg/ebpf/perf.go
@@ -11,7 +11,7 @@ package ebpf
 import (
 	"sync"
 
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
 )
 
 type PerfHandler struct {

--- a/pkg/ebpf/probes.go
+++ b/pkg/ebpf/probes.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
 )
 
 var indirectSyscallPrefixes = map[string]string{

--- a/pkg/ebpf/probes_test.go
+++ b/pkg/ebpf/probes_test.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/network/dns/ebpf.go
+++ b/pkg/network/dns/ebpf.go
@@ -15,9 +15,11 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
 	"golang.org/x/sys/unix"
 )
+
+const funcName = "socket__dns_filter"
 
 type ebpfProgram struct {
 	*manager.Manager
@@ -33,7 +35,10 @@ func newEBPFProgram(c *config.Config) (*ebpfProgram, error) {
 
 	mgr := &manager.Manager{
 		Probes: []*manager.Probe{
-			{Section: string(probes.SocketDnsFilter)},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFSection:  string(probes.SocketDnsFilter),
+				EBPFFuncName: funcName,
+			}},
 		},
 	}
 
@@ -63,7 +68,8 @@ func (e *ebpfProgram) Init() error {
 		ActivatedProbes: []manager.ProbesSelector{
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					Section: string(probes.SocketDnsFilter),
+					EBPFSection:  string(probes.SocketDnsFilter),
+					EBPFFuncName: funcName,
 				},
 			},
 		},

--- a/pkg/network/dns/monitor_linux.go
+++ b/pkg/network/dns/monitor_linux.go
@@ -15,7 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	filterpkg "github.com/DataDog/datadog-agent/pkg/network/filter"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
 )
 
 type dnsMonitor struct {
@@ -34,7 +34,7 @@ func NewReverseDNS(cfg *config.Config) (ReverseDNS, error) {
 		return nil, fmt.Errorf("error initializing ebpf programs: %w", err)
 	}
 
-	filter, _ := p.GetProbe(manager.ProbeIdentificationPair{Section: string(probes.SocketDnsFilter)})
+	filter, _ := p.GetProbe(manager.ProbeIdentificationPair{EBPFSection: string(probes.SocketDnsFilter), EBPFFuncName: funcName})
 	if filter == nil {
 		return nil, fmt.Errorf("error retrieving socket filter")
 	}

--- a/pkg/network/ebpf/probes/probes.go
+++ b/pkg/network/ebpf/probes/probes.go
@@ -92,11 +92,6 @@ const (
 	// SockMapFdReturn maps a file descriptor to a kernel sock
 	SockMapFdReturn ProbeName = "kretprobe/sockfd_lookup_light"
 
-	// IPRouteOutputFlow is the kprobe of an ip_route_output_flow call
-	IPRouteOutputFlow ProbeName = "kprobe/ip_route_output_flow"
-	// IPRouteOutputFlow is the kretprobe of an ip_route_output_flow call
-	IPRouteOutputFlowReturn ProbeName = "kretprobe/ip_route_output_flow"
-
 	// ConntrackHashInsert is the probe for new conntrack entries
 	ConntrackHashInsert ProbeName = "kprobe/__nf_conntrack_hash_insert"
 

--- a/pkg/network/filter/packet_source_linux.go
+++ b/pkg/network/filter/packet_source_linux.go
@@ -16,7 +16,7 @@ import (
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/ebpf/manager"
+	"github.com/DataDog/ebpf-manager"
 	"github.com/google/gopacket"
 	"github.com/google/gopacket/afpacket"
 	"github.com/google/gopacket/layers"

--- a/pkg/network/filter/socket_filter.go
+++ b/pkg/network/filter/socket_filter.go
@@ -10,7 +10,7 @@ package filter
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/process/util"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
 )
 
 // HeadlessSocketFilter creates a raw socket attached to the given socket filter.

--- a/pkg/network/http/batch_manager.go
+++ b/pkg/network/http/batch_manager.go
@@ -14,7 +14,7 @@ import (
 
 	"fmt"
 
-	"github.com/DataDog/ebpf"
+	"github.com/cilium/ebpf"
 )
 
 /*

--- a/pkg/network/http/dump.go
+++ b/pkg/network/http/dump.go
@@ -12,26 +12,20 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/DataDog/datadog-agent/pkg/network/ebpf"
-	"github.com/DataDog/ebpf/manager"
-
+	ddebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
+	manager "github.com/DataDog/ebpf-manager"
+	"github.com/cilium/ebpf"
 	"github.com/davecgh/go-spew/spew"
 )
 
-func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
+func dumpMapsHandler(manager *manager.Manager, mapName string, currentMap *ebpf.Map) string {
 	var output strings.Builder
-
-	mapName := managerMap.Name
-	currentMap, found, err := manager.GetMap(mapName)
-	if err != nil || !found {
-		return ""
-	}
 
 	switch mapName {
 	case httpInFlightMap: // maps/http_in_flight (BPF_MAP_TYPE_HASH), key ConnTuple, value httpTX
 		output.WriteString("Map: '" + mapName + "', key: 'ConnTuple', value: 'httpTX'\n")
 		iter := currentMap.Iterate()
-		var key ebpf.ConnTuple
+		var key ddebpf.ConnTuple
 		var value httpTX
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
@@ -50,7 +44,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 		output.WriteString("Map: '" + mapName + "', key: 'C.__u32', value: 'C.http_batch_state_t'\n")
 		iter := currentMap.Iterate()
 		var key uint32
-		var value ebpf.HTTPBatchState
+		var value ddebpf.HTTPBatchState
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
@@ -59,7 +53,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 		output.WriteString("Map: '" + mapName + "', key: 'uintptr // C.void *', value: 'C.ssl_sock_t'\n")
 		iter := currentMap.Iterate()
 		var key uintptr // C.void *
-		var value ebpf.SSLSock
+		var value ddebpf.SSLSock
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
@@ -68,7 +62,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 		output.WriteString("Map: '" + mapName + "', key: 'C.__u64', value: 'C.ssl_read_args_t'\n")
 		iter := currentMap.Iterate()
 		var key uint64
-		var value ebpf.SSLReadArgs
+		var value ddebpf.SSLReadArgs
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
@@ -92,10 +86,4 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 		}
 	}
 	return output.String()
-}
-
-func setupDumpHandler(manager *manager.Manager) {
-	for _, m := range manager.Maps {
-		m.DumpHandler = dumpMapsHandler
-	}
 }

--- a/pkg/network/http/ebpf_ssl.go
+++ b/pkg/network/http/ebpf_ssl.go
@@ -20,32 +20,32 @@ import (
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
-	"github.com/DataDog/ebpf"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
+	"github.com/cilium/ebpf"
 )
 
-var openSSLProbes = []string{
-	"uprobe/SSL_set_bio",
-	"uprobe/SSL_set_fd",
-	"uprobe/SSL_read",
-	"uretprobe/SSL_read",
-	"uprobe/SSL_write",
-	"uprobe/SSL_shutdown",
+var openSSLProbes = map[string]string{
+	"uprobe/SSL_set_bio":  "uprobe__SSL_set_bio",
+	"uprobe/SSL_set_fd":   "uprobe__SSL_set_fd",
+	"uprobe/SSL_read":     "uprobe__SSL_read",
+	"uretprobe/SSL_read":  "uretprobe__SSL_read",
+	"uprobe/SSL_write":    "uprobe__SSL_write",
+	"uprobe/SSL_shutdown": "uprobe__SSL_shutdown",
 }
 
-var cryptoProbes = []string{
-	"uprobe/BIO_new_socket",
-	"uretprobe/BIO_new_socket",
+var cryptoProbes = map[string]string{
+	"uprobe/BIO_new_socket":    "uprobe__BIO_new_socket",
+	"uretprobe/BIO_new_socket": "uretprobe__BIO_new_socket",
 }
 
-var gnuTLSProbes = []string{
-	"uprobe/gnutls_transport_set_int2",
-	"uprobe/gnutls_transport_set_ptr",
-	"uprobe/gnutls_transport_set_ptr2",
-	"uprobe/gnutls_record_recv",
-	"uretprobe/gnutls_record_recv",
-	"uprobe/gnutls_record_send",
-	"uprobe/gnutls_bye",
+var gnuTLSProbes = map[string]string{
+	"uprobe/gnutls_transport_set_int2": "uprobe__gnutls_transport_set_int2",
+	"uprobe/gnutls_transport_set_ptr":  "uprobe__gnutls_transport_set_ptr",
+	"uprobe/gnutls_transport_set_ptr2": "uprobe__gnutls_transport_set_ptr2",
+	"uprobe/gnutls_record_recv":        "uprobe__gnutls_record_recv",
+	"uretprobe/gnutls_record_recv":     "uretprobe__gnutls_record_recv",
+	"uprobe/gnutls_record_send":        "uprobe__gnutls_record_send",
+	"uprobe/gnutls_bye":                "uprobe__gnutls_bye",
 }
 
 const (
@@ -98,8 +98,14 @@ func (o *sslProgram) ConfigureManager(m *manager.Manager) {
 		})
 
 		m.Probes = append(m.Probes,
-			&manager.Probe{Section: doSysOpen, KProbeMaxActive: maxActive},
-			&manager.Probe{Section: doSysOpenRet, KProbeMaxActive: maxActive},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFSection:  doSysOpen,
+				EBPFFuncName: "kprobe__do_sys_open",
+			}, KProbeMaxActive: maxActive},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFSection:  doSysOpenRet,
+				EBPFFuncName: "kretprobe__do_sys_open",
+			}, KProbeMaxActive: maxActive},
 		)
 	}
 }
@@ -119,12 +125,12 @@ func (o *sslProgram) ConfigureOptions(options *manager.Options) {
 		options.ActivatedProbes = append(options.ActivatedProbes,
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					Section: doSysOpen,
+					EBPFSection: doSysOpen,
 				},
 			},
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					Section: doSysOpenRet,
+					EBPFSection: doSysOpenRet,
 				},
 			},
 		)
@@ -172,11 +178,15 @@ func (o *sslProgram) Stop() {
 	o.perfHandler.Stop()
 }
 
-func addHooks(m *manager.Manager, probes []string) func(string) error {
+func addHooks(m *manager.Manager, probes map[string]string) func(string) error {
 	return func(libPath string) error {
 		uid := getUID(libPath)
 		for _, sec := range probes {
-			p, found := m.GetProbe(manager.ProbeIdentificationPair{uid, sec})
+			p, found := m.GetProbe(manager.ProbeIdentificationPair{
+				EBPFSection:  sec,
+				EBPFFuncName: probes[sec],
+				UID:          uid,
+			})
 			if found {
 				if !p.IsRunning() {
 					err := p.Attach()
@@ -188,10 +198,13 @@ func addHooks(m *manager.Manager, probes []string) func(string) error {
 				continue
 			}
 
-			newProbe := manager.Probe{
-				Section:    sec,
+			newProbe := &manager.Probe{
+				ProbeIdentificationPair: manager.ProbeIdentificationPair{
+					EBPFSection:  sec,
+					EBPFFuncName: probes[sec],
+					UID:          uid,
+				},
 				BinaryPath: libPath,
-				UID:        uid,
 			}
 
 			err := m.AddHook("", newProbe)
@@ -204,17 +217,25 @@ func addHooks(m *manager.Manager, probes []string) func(string) error {
 	}
 }
 
-func removeHooks(m *manager.Manager, probes []string) func(string) error {
+func removeHooks(m *manager.Manager, probes map[string]string) func(string) error {
 	return func(libPath string) error {
 		uid := getUID(libPath)
 		for _, sec := range probes {
-			p, found := m.GetProbe(manager.ProbeIdentificationPair{uid, sec})
+			p, found := m.GetProbe(manager.ProbeIdentificationPair{
+				EBPFSection:  sec,
+				EBPFFuncName: probes[sec],
+				UID:          uid,
+			})
 			if !found {
 				continue
 			}
 
 			program := p.Program()
-			m.DetachHook(sec, uid)
+			m.DetachHook(manager.ProbeIdentificationPair{
+				EBPFSection:  sec,
+				EBPFFuncName: probes[sec],
+				UID:          uid,
+			})
 			if program != nil {
 				program.Close()
 			}

--- a/pkg/network/http/monitor.go
+++ b/pkg/network/http/monitor.go
@@ -17,8 +17,8 @@ import (
 	ddebpf "github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
 	filterpkg "github.com/DataDog/datadog-agent/pkg/network/filter"
-	"github.com/DataDog/ebpf"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
+	"github.com/cilium/ebpf"
 )
 
 // Monitor is responsible for:
@@ -54,7 +54,7 @@ func NewMonitor(c *config.Config, offsets []manager.ConstantEditor, sockFD *ebpf
 		return nil, fmt.Errorf("error initializing http ebpf program: %s", err)
 	}
 
-	filter, _ := mgr.GetProbe(manager.ProbeIdentificationPair{Section: httpSocketFilter})
+	filter, _ := mgr.GetProbe(manager.ProbeIdentificationPair{EBPFSection: httpSocketFilter, EBPFFuncName: "socket__http_filter"})
 	if filter == nil {
 		return nil, fmt.Errorf("error retrieving socket filter")
 	}
@@ -75,7 +75,7 @@ func NewMonitor(c *config.Config, offsets []manager.ConstantEditor, sockFD *ebpf
 	}
 
 	notificationMap, _, _ := mgr.GetMap(httpNotificationsPerfMap)
-	numCPUs := int(notificationMap.ABI().MaxEntries)
+	numCPUs := int(notificationMap.MaxEntries())
 
 	telemetry := newTelemetry()
 	statkeeper := newHTTPStatkeeper(c, telemetry)

--- a/pkg/network/tracer/connection/kprobe/dump.go
+++ b/pkg/network/tracer/connection/kprobe/dump.go
@@ -12,22 +12,16 @@ import (
 	"strings"
 	"unsafe"
 
-	"github.com/DataDog/datadog-agent/pkg/network/ebpf"
+	ddebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/ebpf/manager"
-
+	manager "github.com/DataDog/ebpf-manager"
+	"github.com/cilium/ebpf"
 	"github.com/davecgh/go-spew/spew"
 )
 
-func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
+func dumpMapsHandler(manager *manager.Manager, mapName string, currentMap *ebpf.Map) string {
 	var output strings.Builder
-
-	mapName := managerMap.Name
-	currentMap, found, err := manager.GetMap(mapName)
-	if err != nil || !found {
-		return ""
-	}
 
 	switch mapName {
 
@@ -44,7 +38,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 		output.WriteString("Map: '" + mapName + "', key: 'C.__u64', value: 'tracerStatus'\n")
 		iter := currentMap.Iterate()
 		var key uint64
-		var value ebpf.TracerStatus
+		var value ddebpf.TracerStatus
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
@@ -52,8 +46,8 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 	case string(probes.ConntrackMap): // maps/conntrack (BPF_MAP_TYPE_HASH), key ConnTuple, value ConnTuple
 		output.WriteString("Map: '" + mapName + "', key: 'ConnTuple', value: 'ConnTuple'\n")
 		iter := currentMap.Iterate()
-		var key ebpf.ConnTuple
-		var value ebpf.ConnTuple
+		var key ddebpf.ConnTuple
+		var value ddebpf.ConnTuple
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
@@ -61,7 +55,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 	case string(probes.ConntrackTelemetryMap): // maps/conntrack_telemetry (BPF_MAP_TYPE_ARRAY), key C.u32, value conntrackTelemetry
 		output.WriteString("Map: '" + mapName + "', key: 'C.u32', value: 'conntrackTelemetry'\n")
 		var zero uint64
-		telemetry := &ebpf.ConntrackTelemetry{}
+		telemetry := &ddebpf.ConntrackTelemetry{}
 		if err := currentMap.Lookup(unsafe.Pointer(&zero), unsafe.Pointer(telemetry)); err != nil {
 			log.Tracef("error retrieving the contrack telemetry struct: %s", err)
 		}
@@ -79,7 +73,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 	case string(probes.SockByPidFDMap): // maps/sock_by_pid_fd (BPF_MAP_TYPE_HASH), key C.pid_fd_t, value uintptr // C.struct sock*
 		output.WriteString("Map: '" + mapName + "', key: 'C.pid_fd_t', value: 'uintptr // C.struct sock*'\n")
 		iter := currentMap.Iterate()
-		var key ebpf.PIDFD
+		var key ddebpf.PIDFD
 		var value uintptr // C.struct sock*
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
@@ -89,7 +83,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 		output.WriteString("Map: '" + mapName + "', key: 'uintptr // C.struct sock*', value: 'C.pid_fd_t'\n")
 		iter := currentMap.Iterate()
 		var key uintptr // C.struct sock*
-		var value ebpf.PIDFD
+		var value ddebpf.PIDFD
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
@@ -97,8 +91,8 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 	case string(probes.ConnMap): // maps/conn_stats (BPF_MAP_TYPE_HASH), key ConnTuple, value ConnStatsWithTimestamp
 		output.WriteString("Map: '" + mapName + "', key: 'ConnTuple', value: 'ConnStatsWithTimestamp'\n")
 		iter := currentMap.Iterate()
-		var key ebpf.ConnTuple
-		var value ebpf.ConnStats
+		var key ddebpf.ConnTuple
+		var value ddebpf.ConnStats
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
@@ -106,8 +100,8 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 	case string(probes.TcpStatsMap): // maps/tcp_stats (BPF_MAP_TYPE_HASH), key ConnTuple, value TCPStats
 		output.WriteString("Map: '" + mapName + "', key: 'ConnTuple', value: 'TCPStats'\n")
 		iter := currentMap.Iterate()
-		var key ebpf.ConnTuple
-		var value ebpf.TCPStats
+		var key ddebpf.ConnTuple
+		var value ddebpf.TCPStats
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
@@ -116,7 +110,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 		output.WriteString("Map: '" + mapName + "', key: 'C.__u32', value: 'batch'\n")
 		iter := currentMap.Iterate()
 		var key uint32
-		var value ebpf.Batch
+		var value ddebpf.Batch
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
@@ -125,7 +119,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 		output.WriteString("Map: '" + mapName + "', key: 'C.__u64', value: 'C.udp_recv_sock_t'\n")
 		iter := currentMap.Iterate()
 		var key uint64
-		var value ebpf.UDPRecvSock
+		var value ddebpf.UDPRecvSock
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
@@ -133,7 +127,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 	case string(probes.PortBindingsMap): // maps/port_bindings (BPF_MAP_TYPE_HASH), key portBindingTuple, value C.__u8
 		output.WriteString("Map: '" + mapName + "', key: 'portBindingTuple', value: 'C.__u8'\n")
 		iter := currentMap.Iterate()
-		var key ebpf.PortBinding
+		var key ddebpf.PortBinding
 		var value uint8
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
@@ -142,7 +136,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 	case string(probes.UdpPortBindingsMap): // maps/udp_port_bindings (BPF_MAP_TYPE_HASH), key portBindingTuple, value C.__u8
 		output.WriteString("Map: '" + mapName + "', key: 'portBindingTuple', value: 'C.__u8'\n")
 		iter := currentMap.Iterate()
-		var key ebpf.PortBinding
+		var key ddebpf.PortBinding
 		var value uint8
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
@@ -152,7 +146,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 		output.WriteString("Map: '" + mapName + "', key: 'C.__u64', value: 'C.bind_syscall_args_t'\n")
 		iter := currentMap.Iterate()
 		var key uint64
-		var value ebpf.BindSyscallArgs
+		var value ddebpf.BindSyscallArgs
 		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
 			output.WriteString(spew.Sdump(key, value))
 		}
@@ -160,7 +154,7 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 	case string(probes.TelemetryMap): // maps/telemetry (BPF_MAP_TYPE_ARRAY), key C.u32, value kernelTelemetry
 		output.WriteString("Map: '" + mapName + "', key: 'C.u32', value: 'kernelTelemetry'\n")
 		var zero uint64
-		telemetry := &ebpf.Telemetry{}
+		telemetry := &ddebpf.Telemetry{}
 		if err := currentMap.Lookup(unsafe.Pointer(&zero), unsafe.Pointer(telemetry)); err != nil {
 			// This can happen if we haven't initialized the telemetry object yet
 			// so let's just use a trace log
@@ -180,10 +174,4 @@ func dumpMapsHandler(managerMap *manager.Map, manager *manager.Manager) string {
 	}
 
 	return output.String()
-}
-
-func setupDumpHandler(manager *manager.Manager) {
-	for _, m := range manager.Maps {
-		m.DumpHandler = dumpMapsHandler
-	}
 }

--- a/pkg/network/tracer/connection/kprobe/manager.go
+++ b/pkg/network/tracer/connection/kprobe/manager.go
@@ -10,10 +10,11 @@ package kprobe
 
 import (
 	"os"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
 )
 
 const (
@@ -21,6 +22,38 @@ const (
 	// This value should be enough for typical workloads (e.g. some amount of processes blocked on the `accept` syscall).
 	maxActive = 128
 )
+
+var mainProbes = map[probes.ProbeName]string{
+	probes.TCPSendMsg:           "kprobe__tcp_sendmsg",
+	probes.TCPCleanupRBuf:       "kprobe__tcp_cleanup_rbuf",
+	probes.TCPClose:             "kprobe__tcp_close",
+	probes.TCPCloseReturn:       "kretprobe__tcp_close",
+	probes.TCPSetState:          "kprobe__tcp_set_state",
+	probes.IPMakeSkb:            "kprobe__ip_make_skb",
+	probes.IP6MakeSkb:           "kprobe__ip6_make_skb",
+	probes.UDPRecvMsg:           "kprobe__udp_recvmsg",
+	probes.UDPRecvMsgReturn:     "kretprobe__udp_recvmsg",
+	probes.TCPRetransmit:        "kprobe__tcp_retransmit_skb",
+	probes.InetCskAcceptReturn:  "kretprobe__inet_csk_accept",
+	probes.InetCskListenStop:    "kprobe__inet_csk_listen_stop",
+	probes.UDPDestroySock:       "kprobe__udp_destroy_sock",
+	probes.UDPDestroySockReturn: "kretprobe__udp_destroy_sock",
+	probes.InetBind:             "kprobe__inet_bind",
+	probes.Inet6Bind:            "kprobe__inet6_bind",
+	probes.InetBindRet:          "kretprobe__inet_bind",
+	probes.Inet6BindRet:         "kretprobe__inet6_bind",
+	probes.SockFDLookup:         "kprobe__sockfd_lookup_light",
+	probes.SockFDLookupRet:      "kretprobe__sockfd_lookup_light",
+	probes.DoSendfile:           "kprobe__do_sendfile",
+	probes.DoSendfileRet:        "kretprobe__do_sendfile",
+}
+
+var altProbes = map[probes.ProbeName]string{
+	probes.TCPRetransmitPre470: "kprobe__tcp_retransmit_skb_pre_4_7_0",
+	probes.IP6MakeSkbPre470:    "kprobe__ip6_make_skb__pre_4_7_0",
+	probes.UDPRecvMsgPre410:    "kprobe__udp_recvmsg_pre_4_1_0",
+	probes.TCPSendMsgPre410:    "kprobe__tcp_sendmsg__pre_4_1_0",
+}
 
 func newManager(closedHandler *ebpf.PerfHandler, runtimeTracer bool) *manager.Manager {
 	mgr := &manager.Manager{
@@ -49,32 +82,19 @@ func newManager(closedHandler *ebpf.PerfHandler, runtimeTracer bool) *manager.Ma
 				},
 			},
 		},
-		Probes: []*manager.Probe{
-			{Section: string(probes.TCPSendMsg)},
-			{Section: string(probes.TCPCleanupRBuf)},
-			{Section: string(probes.TCPClose)},
-			{Section: string(probes.TCPCloseReturn), KProbeMaxActive: maxActive},
-			{Section: string(probes.TCPSetState)},
-			{Section: string(probes.IPMakeSkb)},
-			{Section: string(probes.IP6MakeSkb)},
-			{Section: string(probes.UDPRecvMsg)},
-			{Section: string(probes.UDPRecvMsgReturn), KProbeMaxActive: maxActive},
-			{Section: string(probes.TCPRetransmit)},
-			{Section: string(probes.InetCskAcceptReturn), KProbeMaxActive: maxActive},
-			{Section: string(probes.InetCskListenStop)},
-			{Section: string(probes.UDPDestroySock)},
-			{Section: string(probes.UDPDestroySockReturn), KProbeMaxActive: maxActive},
-			{Section: string(probes.InetBind)},
-			{Section: string(probes.Inet6Bind)},
-			{Section: string(probes.InetBindRet), KProbeMaxActive: maxActive},
-			{Section: string(probes.Inet6BindRet), KProbeMaxActive: maxActive},
-			{Section: string(probes.IPRouteOutputFlow)},
-			{Section: string(probes.IPRouteOutputFlowReturn), KProbeMaxActive: maxActive},
-			{Section: string(probes.SockFDLookup)},
-			{Section: string(probes.SockFDLookupRet), KProbeMaxActive: maxActive},
-			{Section: string(probes.DoSendfile)},
-			{Section: string(probes.DoSendfileRet), KProbeMaxActive: maxActive},
-		},
+	}
+
+	for probeName, funcName := range mainProbes {
+		p := &manager.Probe{
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{
+				EBPFSection:  string(probeName),
+				EBPFFuncName: funcName,
+			},
+		}
+		if strings.HasPrefix(funcName, "kretprobe") {
+			p.KProbeMaxActive = maxActive
+		}
+		mgr.Probes = append(mgr.Probes, p)
 	}
 
 	// the runtime compiled tracer has no need for separate probes targeting specific kernel versions, since it can
@@ -82,10 +102,10 @@ func newManager(closedHandler *ebpf.PerfHandler, runtimeTracer bool) *manager.Ma
 	// tracer.
 	if !runtimeTracer {
 		mgr.Probes = append(mgr.Probes,
-			&manager.Probe{Section: string(probes.TCPRetransmitPre470), MatchFuncName: "^tcp_retransmit_skb$"},
-			&manager.Probe{Section: string(probes.IP6MakeSkbPre470), MatchFuncName: "^ip6_make_skb$"},
-			&manager.Probe{Section: string(probes.UDPRecvMsgPre410), MatchFuncName: "^udp_recvmsg$"},
-			&manager.Probe{Section: string(probes.TCPSendMsgPre410), MatchFuncName: "^tcp_sendmsg$"},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.TCPRetransmitPre470), EBPFFuncName: "kprobe__tcp_retransmit_skb_pre_4_7_0"}, MatchFuncName: "^tcp_retransmit_skb$"},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.IP6MakeSkbPre470), EBPFFuncName: "kprobe__ip6_make_skb__pre_4_7_0"}, MatchFuncName: "^ip6_make_skb$"},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.UDPRecvMsgPre410), EBPFFuncName: "kprobe__udp_recvmsg_pre_4_1_0"}, MatchFuncName: "^udp_recvmsg$"},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.TCPSendMsgPre410), EBPFFuncName: "kprobe__tcp_sendmsg__pre_4_1_0"}, MatchFuncName: "^tcp_sendmsg$"},
 		)
 	}
 

--- a/pkg/network/tracer/connection/kprobe/perf_batching.go
+++ b/pkg/network/tracer/connection/kprobe/perf_batching.go
@@ -15,7 +15,7 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/network"
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
-	"github.com/DataDog/ebpf"
+	"github.com/cilium/ebpf"
 )
 
 const defaultExpiredStateInterval = 60 * time.Second

--- a/pkg/network/tracer/connection/kprobe/tcp_close_consumer.go
+++ b/pkg/network/tracer/connection/kprobe/tcp_close_consumer.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network"
 	netebpf "github.com/DataDog/datadog-agent/pkg/network/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
 )
 
 const (
@@ -46,7 +46,7 @@ func newTCPCloseConsumer(m *manager.Manager, perfHandler *ddebpf.PerfHandler) (*
 		return nil, err
 	}
 
-	numCPUs := int(connCloseEventMap.ABI().MaxEntries)
+	numCPUs := int(connCloseEventMap.MaxEntries())
 	batchManager, err := newPerfBatchManager(connCloseMap, numCPUs)
 	if err != nil {
 		return nil, err

--- a/pkg/network/tracer/connection/tracer.go
+++ b/pkg/network/tracer/connection/tracer.go
@@ -7,7 +7,7 @@ package connection
 
 import (
 	"github.com/DataDog/datadog-agent/pkg/network"
-	"github.com/DataDog/ebpf"
+	"github.com/cilium/ebpf"
 )
 
 // Tracer is the common interface implemented by all connection tracers.

--- a/pkg/network/tracer/ebpf_conntracker.go
+++ b/pkg/network/tracer/ebpf_conntracker.go
@@ -27,9 +27,9 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/netlink"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/ebpf"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
 	"github.com/cihub/seelog"
+	"github.com/cilium/ebpf"
 	ct "github.com/florianl/go-conntrack"
 	"golang.org/x/sys/unix"
 )
@@ -361,7 +361,7 @@ func getManager(buf io.ReaderAt, maxStateSize int) (*manager.Manager, error) {
 		},
 		PerfMaps: []*manager.PerfMap{},
 		Probes: []*manager.Probe{
-			{Section: string(probes.ConntrackHashInsert)},
+			{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.ConntrackHashInsert), EBPFFuncName: "kprobe___nf_conntrack_hash_insert"}},
 		},
 	}
 

--- a/pkg/network/tracer/offsetguess.go
+++ b/pkg/network/tracer/offsetguess.go
@@ -29,8 +29,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/network/ebpf/probes"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/ebpf"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
+	"github.com/cilium/ebpf"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
@@ -119,6 +119,23 @@ type fieldValues struct {
 	dportFl6 uint16
 }
 
+var offsetProbes = map[probes.ProbeName]string{
+	probes.TCPGetSockOpt:      "kprobe__tcp_getsockopt",
+	probes.SockGetSockOpt:     "kprobe__sock_common_getsockopt",
+	probes.TCPv6Connect:       "kprobe__tcp_v6_connect",
+	probes.IPMakeSkb:          "kprobe__ip_make_skb",
+	probes.IP6MakeSkb:         "kprobe__ip6_make_skb",
+	probes.IP6MakeSkbPre470:   "kprobe__ip6_make_skb__pre_4_7_0",
+	probes.TCPv6ConnectReturn: "kretprobe__tcp_v6_connect",
+}
+
+func idPair(name probes.ProbeName) manager.ProbeIdentificationPair {
+	return manager.ProbeIdentificationPair{
+		EBPFSection:  string(name),
+		EBPFFuncName: offsetProbes[name],
+	}
+}
+
 func newOffsetManager() *manager.Manager {
 	return &manager.Manager{
 		Maps: []*manager.Map{
@@ -127,13 +144,13 @@ func newOffsetManager() *manager.Manager {
 		},
 		PerfMaps: []*manager.PerfMap{},
 		Probes: []*manager.Probe{
-			{Section: string(probes.TCPGetSockOpt)},
-			{Section: string(probes.SockGetSockOpt)},
-			{Section: string(probes.TCPv6Connect)},
-			{Section: string(probes.IPMakeSkb)},
-			{Section: string(probes.IP6MakeSkb)},
-			{Section: string(probes.IP6MakeSkbPre470), MatchFuncName: "^ip6_make_skb$"},
-			{Section: string(probes.TCPv6ConnectReturn), KProbeMaxActive: 128},
+			{ProbeIdentificationPair: idPair(probes.TCPGetSockOpt)},
+			{ProbeIdentificationPair: idPair(probes.SockGetSockOpt)},
+			{ProbeIdentificationPair: idPair(probes.TCPv6Connect)},
+			{ProbeIdentificationPair: idPair(probes.IPMakeSkb)},
+			{ProbeIdentificationPair: idPair(probes.IP6MakeSkb)},
+			{ProbeIdentificationPair: idPair(probes.IP6MakeSkbPre470), MatchFuncName: "^ip6_make_skb$"},
+			{ProbeIdentificationPair: idPair(probes.TCPv6ConnectReturn), KProbeMaxActive: 128},
 		},
 	}
 }
@@ -234,16 +251,21 @@ func waitUntilStable(conn net.Conn, window time.Duration, attempts int) (*fieldV
 	return nil, errors.New("unstable TCP socket params")
 }
 
-func offsetGuessProbes(c *config.Config) (map[probes.ProbeName]struct{}, error) {
-	p := map[probes.ProbeName]struct{}{
-		probes.TCPGetSockOpt:  {},
-		probes.SockGetSockOpt: {},
-		probes.IPMakeSkb:      {},
+func enableProbe(enabled map[probes.ProbeName]string, name probes.ProbeName) {
+	if fn, ok := offsetProbes[name]; ok {
+		enabled[name] = fn
 	}
+}
+
+func offsetGuessProbes(c *config.Config) (map[probes.ProbeName]string, error) {
+	p := map[probes.ProbeName]string{}
+	enableProbe(p, probes.TCPGetSockOpt)
+	enableProbe(p, probes.SockGetSockOpt)
+	enableProbe(p, probes.IPMakeSkb)
 
 	if c.CollectIPv6Conns {
-		p[probes.TCPv6Connect] = struct{}{}
-		p[probes.TCPv6ConnectReturn] = struct{}{}
+		enableProbe(p, probes.TCPv6Connect)
+		enableProbe(p, probes.TCPv6ConnectReturn)
 
 		kv, err := kernel.HostVersion()
 		if err != nil {
@@ -251,11 +273,10 @@ func offsetGuessProbes(c *config.Config) (map[probes.ProbeName]struct{}, error) 
 		}
 
 		if kv < kernel.VersionCode(4, 7, 0) {
-			p[probes.IP6MakeSkbPre470] = struct{}{}
+			enableProbe(p, probes.IP6MakeSkbPre470)
 		} else {
-			p[probes.IP6MakeSkb] = struct{}{}
+			enableProbe(p, probes.IP6MakeSkb)
 		}
-
 	}
 	return p, nil
 }

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -34,8 +34,8 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/kernel"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/DataDog/ebpf"
-	"github.com/DataDog/ebpf/manager"
+	manager "github.com/DataDog/ebpf-manager"
+	"github.com/cilium/ebpf"
 	"golang.org/x/sys/unix"
 )
 
@@ -237,16 +237,17 @@ func runOffsetGuessing(config *config.Config, buf bytecode.AssetReader) ([]manag
 	}
 
 	for _, p := range offsetMgr.Probes {
-		if _, enabled := enabledProbes[probes.ProbeName(p.Section)]; !enabled {
-			offsetOptions.ExcludedSections = append(offsetOptions.ExcludedSections, p.Section)
+		if _, enabled := enabledProbes[probes.ProbeName(p.EBPFSection)]; !enabled {
+			offsetOptions.ExcludedFunctions = append(offsetOptions.ExcludedFunctions, p.EBPFFuncName)
 		}
 	}
-	for probeName := range enabledProbes {
+	for probeName, funcName := range enabledProbes {
 		offsetOptions.ActivatedProbes = append(
 			offsetOptions.ActivatedProbes,
 			&manager.ProbeSelector{
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
-					Section: string(probeName),
+					EBPFSection:  string(probeName),
+					EBPFFuncName: funcName,
 				},
 			})
 	}

--- a/pkg/util/kernel/version.go
+++ b/pkg/util/kernel/version.go
@@ -10,9 +10,14 @@ package kernel
 
 import (
 	"fmt"
+	"io/ioutil"
+	"regexp"
+	"strconv"
 
-	"github.com/DataDog/ebpf"
+	"golang.org/x/sys/unix"
 )
+
+var versionRegex = regexp.MustCompile(`^(\d+)\.(\d+)(?:.(\d+))?.*$`)
 
 // Version is a numerical representation of a kernel version
 type Version uint32
@@ -30,12 +35,24 @@ func HostVersion() (Version, error) {
 	if hostVersion != 0 {
 		return hostVersion, nil
 	}
-	kv, err := ebpf.CurrentKernelVersion()
-	if err != nil {
-		return 0, err
+
+	if procVersion, err := ioutil.ReadFile("/proc/version_signature"); err == nil {
+		v, err := parseUbuntuVersion(string(procVersion))
+		if err != nil {
+			return 0, fmt.Errorf("error parsing ubuntu kernel version: %s", err)
+		}
+		return v, nil
 	}
-	hostVersion = Version(kv)
-	return hostVersion, nil
+
+	var uname unix.Utsname
+	if err := unix.Uname(&uname); err != nil {
+		return 0, fmt.Errorf("error calling uname: %w", err)
+	}
+
+	if v, err := parseDebianVersion(unix.ByteSliceToString(uname.Version[:])); err == nil {
+		return v, nil
+	}
+	return parseReleaseString(unix.ByteSliceToString(uname.Release[:]))
 }
 
 // ParseVersion parses a string in the format of x.x.x to a Version
@@ -50,4 +67,57 @@ func VersionCode(major, minor, patch byte) Version {
 	// KERNEL_VERSION(a,b,c) = (a << 16) + (b << 8) + (c)
 	// Per https://github.com/torvalds/linux/blob/db7c953555388571a96ed8783ff6c5745ba18ab9/Makefile#L1250
 	return Version((uint32(major) << 16) + (uint32(minor) << 8) + uint32(patch))
+}
+
+// parseReleaseString converts a release string with format
+// 4.4.2[-1] to a kernel version number in LINUX_VERSION_CODE format.
+// That is, for kernel "a.b.c", the version number will be (a<<16 + b<<8 + c)
+func parseReleaseString(releaseString string) (Version, error) {
+	versionParts := versionRegex.FindStringSubmatch(releaseString)
+	if len(versionParts) < 3 {
+		return 0, fmt.Errorf("got invalid release version %q (expected format '4.3.2-1')", releaseString)
+	}
+	var major, minor, patch uint64
+	var err error
+	major, err = strconv.ParseUint(versionParts[1], 10, 8)
+	if err != nil {
+		return 0, err
+	}
+
+	minor, err = strconv.ParseUint(versionParts[2], 10, 8)
+	if err != nil {
+		return 0, err
+	}
+
+	// patch is optional
+	if len(versionParts) >= 4 {
+		patch, _ = strconv.ParseUint(versionParts[3], 10, 8)
+	}
+
+	// clamp patch/sublevel to 255 EARLY in 4.14.252 because they merged this too early:
+	// https://github.com/torvalds/linux/commit/e131e0e880f942f138c4b5e6af944c7ddcd7ec96
+	if major == 4 && minor == 14 && patch >= 252 {
+		patch = 255
+	}
+
+	return VersionCode(byte(major), byte(minor), byte(patch)), nil
+}
+
+func parseUbuntuVersion(procVersion string) (Version, error) {
+	var u1, u2, releaseString string
+	_, err := fmt.Sscanf(procVersion, "%s %s %s", &u1, &u2, &releaseString)
+	if err != nil {
+		return 0, err
+	}
+	return parseReleaseString(releaseString)
+}
+
+var debianVersionRegex = regexp.MustCompile(`.* SMP Debian (\d+\.\d+.\d+-\d+)(?:\+[[:alnum:]]*)?.*`)
+
+func parseDebianVersion(str string) (Version, error) {
+	match := debianVersionRegex.FindStringSubmatch(str)
+	if len(match) != 2 {
+		return 0, fmt.Errorf("failed to parse kernel version from /proc/version: %s", str)
+	}
+	return parseReleaseString(match[1])
 }

--- a/pkg/util/kernel/version_test.go
+++ b/pkg/util/kernel/version_test.go
@@ -28,3 +28,90 @@ func TestLinuxKernelVersionCode(t *testing.T) {
 	assert.Equal(t, Version(197132).String(), "3.2.12")
 	assert.Equal(t, Version(263168).String(), "4.4.0")
 }
+
+var testData = []struct {
+	succeed       bool
+	releaseString string
+	kernelVersion uint32
+}{
+	{true, "4.1.2-3", 262402},
+	{true, "4.8.14-200.fc24.x86_64", 264206},
+	{true, "4.1.2-3foo", 262402},
+	{true, "4.1.2foo-1", 262402},
+	{true, "4.1.2-rkt-v1", 262402},
+	{true, "4.1.2rkt-v1", 262402},
+	{true, "4.1.2-3 foo", 262402},
+	{false, "foo 4.1.2-3", 0},
+	{true, "4.1.2", 262402},
+	{false, ".4.1.2", 0},
+	{false, "4", 0},
+	{false, "4.", 0},
+	{true, "4.1.", 262400},
+	{true, "4.1", 262400},
+	{true, "4.19-ovh", 267008},
+	{true, "4.14.252", 265983},
+}
+
+func TestParseReleaseString(t *testing.T) {
+	for _, test := range testData {
+		version, err := parseReleaseString(test.releaseString)
+		if err != nil && test.succeed {
+			t.Errorf("expected %q to succeed: %s", test.releaseString, err)
+		} else if err == nil && !test.succeed {
+			t.Errorf("expected %q to fail", test.releaseString)
+		}
+		if version != Version(test.kernelVersion) {
+			t.Errorf("expected kernel version %d, got %d", test.kernelVersion, version)
+		}
+	}
+}
+
+func TestParseDebianVersion(t *testing.T) {
+	for _, tc := range []struct {
+		succeed       bool
+		releaseString string
+		kernelVersion uint32
+	}{
+		// 4.9.168
+		{true, "Linux version 4.9.0-9-amd64 (debian-kernel@lists.debian.org) (gcc version 6.3.0 20170516 (Debian 6.3.0-18+deb9u1) ) #1 SMP Debian 4.9.168-1+deb9u3 (2019-06-16)", 264616},
+		// 4.9.88
+		{true, "Linux ip-10-0-75-49 4.9.0-6-amd64 #1 SMP Debian 4.9.88-1+deb9u1 (2018-05-07) x86_64 GNU/Linux", 264536},
+		// 3.0.4
+		{true, "Linux version 3.16.0-9-amd64 (debian-kernel@lists.debian.org) (gcc version 4.9.2 (Debian 4.9.2-10+deb8u2) ) #1 SMP Debian 3.16.68-1 (2019-05-22)", 200772},
+		// Invalid
+		{false, "Linux version 4.9.125-linuxkit (root@659b6d51c354) (gcc version 6.4.0 (Alpine 6.4.0) ) #1 SMP Fri Sep 7 08:20:28 UTC 2018", 0},
+		// 4.9.258-1 overflow of patch version which has max 255
+		{true, "Linux version 4.9.0-15-amd64 (debian-kernel@lists.debian.org) (gcc version 6.3.0 20170516 (Debian 6.3.0-18+deb9u1) ) #1 SMP Debian 4.9.258-1 (2021-03-08)", 264703},
+	} {
+		version, err := parseDebianVersion(tc.releaseString)
+		if err != nil && tc.succeed {
+			t.Errorf("expected %q to succeed: %s", tc.releaseString, err)
+		} else if err == nil && !tc.succeed {
+			t.Errorf("expected %q to fail", tc.releaseString)
+		}
+		if version != Version(tc.kernelVersion) {
+			t.Errorf("expected kernel version %d, got %d", tc.kernelVersion, version)
+		}
+	}
+}
+
+func TestParseUbuntuVersion(t *testing.T) {
+	for _, tc := range []struct {
+		succeed       bool
+		procVersion   string
+		kernelVersion uint32
+	}{
+		// 5.4.0-52.57
+		{true, "Ubuntu 5.4.0-52.57-generic 5.4.65", 328769},
+	} {
+		version, err := parseUbuntuVersion(tc.procVersion)
+		if err != nil && tc.succeed {
+			t.Errorf("expected %q to succeed: %s", tc.procVersion, err)
+		} else if err == nil && !tc.succeed {
+			t.Errorf("expected %q to fail", tc.procVersion)
+		}
+		if version != Version(tc.kernelVersion) {
+			t.Errorf("expected kernel version %d, got %d", tc.kernelVersion, version)
+		}
+	}
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Updates the network tracer to use the https://github.com/DataDog/ebpf-manager library, which utilizes the upstream `cilium/ebpf` repo rather than a fork of it.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
