### PR TITLE
[pipeline] Download go tools once

### DIFF
--- a/.gitlab/deps_fetch.yml
+++ b/.gitlab/deps_fetch.yml
@@ -7,6 +7,10 @@
   - mkdir -p $GOPATH/pkg/mod && tar xzf modcache.tar.gz -C $GOPATH/pkg/mod
   - rm -f modcache.tar.gz
 
+.retrieve_linux_go_tools_deps:
+  - mkdir -p $GOPATH/pkg/mod && tar xzf modcache_tools.tar.gz -C $GOPATH/pkg/mod
+  - rm -f modcache_tools.tar.gz
+
 go_deps:
   stage: deps_fetch
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
@@ -19,4 +23,18 @@ go_deps:
     expire_in: 1 day
     paths:
       - $CI_PROJECT_DIR/modcache.tar.gz
+  retry: 1
+
+go_tools_deps:
+  stage: deps_fetch
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
+  tags: ["runner:main"]
+  needs: []
+  script:
+    - inv -e download-tools
+    - cd $GOPATH/pkg/mod/ && tar czf $CI_PROJECT_DIR/modcache_tools.tar.gz .
+  artifacts:
+    expire_in: 1 day
+    paths:
+      - $CI_PROJECT_DIR/modcache_tools.tar.gz
   retry: 1

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -49,12 +49,13 @@
 tests_ebpf_x64:
   extends: .tests_linux_ebpf
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_x64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
-  tags: [ "runner:main" ]
-  needs: [ "go_deps" ]
+  tags: ["runner:main"]
+  needs: ["go_deps", "go_tools_deps"]
   variables:
     ARCH: amd64
   before_script:
     - !reference [.retrieve_linux_go_deps]
+    - !reference [.retrieve_linux_go_tools_deps]
     - mkdir -p $CI_PROJECT_DIR/.tmp/binary-ebpf
     - cd $SRC_PATH
     - !reference [.retrieve_sysprobe_deps]
@@ -71,11 +72,12 @@ tests_ebpf_arm64:
   extends: .tests_linux_ebpf
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/system-probe_arm64:$DATADOG_AGENT_SYSPROBE_BUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
-  needs: [ "go_deps" ]
+  needs: ["go_deps", "go_tools_deps"]
   variables:
     ARCH: arm64
   before_script:
     - !reference [.retrieve_linux_go_deps]
+    - !reference [.retrieve_linux_go_tools_deps]
     - mkdir -p $CI_PROJECT_DIR/.tmp/binary-ebpf
     # Hack to work around the cloning issue with arm runners
     - mkdir -p $GOPATH/src/github.com/DataDog

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -16,6 +16,7 @@
 .linux_tests:
   stage: source_test
   script:
+    - !reference [.retrieve_linux_go_tools_deps]
     - inv -e install-tools
     - inv -e test --race --profile --rerun-fails=2 --python-runtimes "$PYTHON_RUNTIMES" --cpus 4 $EXTRA_OPTS --save-result-json test_output.json --junit-tar "junit-${CI_JOB_NAME}.tgz"
     - python3 -m tasks.release_tests
@@ -44,7 +45,7 @@ tests_deb-x64-py3:
     - .linux_tests
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main"]
-  needs: ["go_deps"]
+  needs: ["go_deps", "go_tools_deps"]
   variables:
     PYTHON_RUNTIMES: '3'
     CONDA_ENV: ddpy3
@@ -70,7 +71,7 @@ tests_rpm-x64-py3:
     - .linux_tests
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main"]
-  needs: ["go_deps"]
+  needs: ["go_deps", "go_tools_deps"]
   variables:
     PYTHON_RUNTIMES: '3'
     CONDA_ENV: ddpy3
@@ -91,7 +92,7 @@ tests_deb-arm64-py3:
   extends:
     - .rtloader_tests
     - .linux_tests
-  needs: ["go_deps"]
+  needs: ["go_deps", "go_tools_deps"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   variables:
@@ -115,7 +116,7 @@ tests_rpm-arm64-py3:
     - .linux_tests
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_arm64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
-  needs: ["go_deps"]
+  needs: ["go_deps", "go_tools_deps"]
   variables:
     PYTHON_RUNTIMES: '3'
     CONDA_ENV: ddpy3

--- a/.gitlab/source_test/windows.yml
+++ b/.gitlab/source_test/windows.yml
@@ -1,7 +1,7 @@
 ---
 .tests_windows_base:
   stage: source_test
-  needs: ["go_deps"]
+  needs: ["go_deps", "go_tools_deps"]
   tags: ["runner:windows-docker", "windowsversion:1809"]
   script:
     - $ErrorActionPreference = "Stop"

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -49,9 +49,9 @@ from .go import (
     vet,
 )
 from .test import (
+    download_tools,
     e2e_tests,
     install_shellcheck,
-    download_tools,
     install_tools,
     integration_tests,
     junit_upload,

--- a/tasks/__init__.py
+++ b/tasks/__init__.py
@@ -51,6 +51,7 @@ from .go import (
 from .test import (
     e2e_tests,
     install_shellcheck,
+    download_tools,
     install_tools,
     integration_tests,
     junit_upload,
@@ -90,6 +91,7 @@ ns.add_task(audit_tag_impact)
 ns.add_task(e2e_tests)
 ns.add_task(generate)
 ns.add_task(install_shellcheck)
+ns.add_task(download_tools)
 ns.add_task(install_tools)
 ns.add_task(check_mod_tidy)
 ns.add_task(tidy_all)

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -72,6 +72,13 @@ TOOLS = {
     'internal/tools/proto': TOOL_LIST_PROTO,
 }
 
+@task
+def download_tools(ctx):
+    """Download all Go tools for testing."""
+    with environ({'GO111MODULE': 'on'}):
+        for path, _ in TOOLS.items():
+            with ctx.cd(path):
+                ctx.run(f"go mod download")
 
 @task
 def install_tools(ctx):

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -72,6 +72,7 @@ TOOLS = {
     'internal/tools/proto': TOOL_LIST_PROTO,
 }
 
+
 @task
 def download_tools(ctx):
     """Download all Go tools for testing."""
@@ -79,6 +80,7 @@ def download_tools(ctx):
         for path, _ in TOOLS.items():
             with ctx.cd(path):
                 ctx.run("go mod download")
+
 
 @task
 def install_tools(ctx):

--- a/tasks/test.py
+++ b/tasks/test.py
@@ -78,7 +78,7 @@ def download_tools(ctx):
     with environ({'GO111MODULE': 'on'}):
         for path, _ in TOOLS.items():
             with ctx.cd(path):
-                ctx.run(f"go mod download")
+                ctx.run("go mod download")
 
 @task
 def install_tools(ctx):

--- a/tasks/winbuildscripts/extract-tools-modcache.bat
+++ b/tasks/winbuildscripts/extract-tools-modcache.bat
@@ -1,0 +1,14 @@
+if exist c:\mnt\modcache_tools.tar.gz (
+    @echo Extracting modcache_tools
+    Powershell -C "7z x c:\mnt\modcache_tools.tar.gz -oc:\mnt"
+    REM Use -aoa to allow overwriting existing files
+    REM This shouldn't have any negative impact: since modules are
+    REM stored per version and hash, files that get replaced will
+    REM get replaced by the same files
+    Powershell -C "7z x c:\mnt\modcache_tools.tar -oc:\modcache -aoa"
+    del /f c:\mnt\modcache_tools.tar.gz
+    del /f c:\mnt\modcache_tools.tar
+    @echo modcache_tools extracted
+) else (
+    @echo modcache_tools.tar.gz not found, tooling dependencies will be downloaded
+)

--- a/tasks/winbuildscripts/unittests.bat
+++ b/tasks/winbuildscripts/unittests.bat
@@ -8,6 +8,7 @@ if not exist c:\mnt\ goto nomntdir
 if NOT DEFINED PY_RUNTIMES set PY_RUNTIMES=%~1
 
 call %~p0extract-modcache.bat
+call %~p0extract-tools-modcache.bat
 
 mkdir \dev\go\src\github.com\DataDog\datadog-agent
 cd \dev\go\src\github.com\DataDog\datadog-agent


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Creates a new Gitlab job, `go_tools_deps`, which fetches tool dependencies once and caches them, and reuses the cache in any job that calls `inv install-tools`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Reduce the number of external dependencies downloads in the pipeline.

### Additional notes

This implementation assumes that merging two go mod cache directories is fine, which theoretically makes sense (since modules are stored per version & hash), and experimentally is the case.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Run a pipeline, check that all test jobs succeed and don't download tool dependencies anymore.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
