### PR TITLE
[ECS] Add telemetry for the client

### DIFF
--- a/pkg/util/ecs/metadata/v1/client.go
+++ b/pkg/util/ecs/metadata/v1/client.go
@@ -17,6 +17,7 @@ import (
 	"reflect"
 
 	"github.com/DataDog/datadog-agent/pkg/util/ecs/common"
+	"github.com/DataDog/datadog-agent/pkg/util/ecs/telemetry"
 )
 
 const (
@@ -80,6 +81,11 @@ func (c *Client) get(ctx context.Context, path string, v interface{}) error {
 	}
 
 	resp, err := client.Do(req)
+
+	defer func() {
+		telemetry.AddQueryToTelemetry(path, resp)
+	}()
+
 	if err != nil {
 		return err
 	}

--- a/pkg/util/ecs/metadata/v2/client.go
+++ b/pkg/util/ecs/metadata/v2/client.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 
 	"github.com/DataDog/datadog-agent/pkg/util/ecs/common"
+	"github.com/DataDog/datadog-agent/pkg/util/ecs/telemetry"
 )
 
 const (
@@ -85,6 +86,11 @@ func (c *Client) get(ctx context.Context, path string, v interface{}) error {
 		return fmt.Errorf("Failed to create new request: %w", err)
 	}
 	resp, err := client.Do(req)
+
+	defer func() {
+		telemetry.AddQueryToTelemetry(path, resp)
+	}()
+
 	if err != nil {
 		return err
 	}

--- a/pkg/util/ecs/metadata/v3/client.go
+++ b/pkg/util/ecs/metadata/v3/client.go
@@ -17,6 +17,7 @@ import (
 	"reflect"
 
 	"github.com/DataDog/datadog-agent/pkg/util/ecs/common"
+	"github.com/DataDog/datadog-agent/pkg/util/ecs/telemetry"
 )
 
 const (
@@ -71,6 +72,11 @@ func (c *Client) get(ctx context.Context, path string, v interface{}) error {
 		return fmt.Errorf("Failed to create new request: %w", err)
 	}
 	resp, err := client.Do(req)
+
+	defer func() {
+		telemetry.AddQueryToTelemetry(path, resp)
+	}()
+
 	if err != nil {
 		return err
 	}

--- a/pkg/util/ecs/telemetry/telemetry.go
+++ b/pkg/util/ecs/telemetry/telemetry.go
@@ -1,0 +1,37 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build docker
+// +build docker
+
+package telemetry
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
+)
+
+var (
+	// queries tracks ECS requests done by the Agent.
+	queries = telemetry.NewCounterWithOpts(
+		"ecs",
+		"queries",
+		[]string{"path", "code"},
+		"Count of ECS queries by path and response code. The response code defaults to 0 for unachieved queries.",
+		telemetry.Options{NoDoubleUnderscoreSep: true},
+	)
+)
+
+// AddQueryToTelemetry Adds a query to the telemetry
+func AddQueryToTelemetry(path string, response *http.Response) {
+	code := 0
+	if response != nil {
+		code = response.StatusCode
+	}
+
+	queries.Inc(path, strconv.Itoa(code))
+}

--- a/releasenotes/notes/ecs-telemetry-6141c319a7902547.yaml
+++ b/releasenotes/notes/ecs-telemetry-6141c319a7902547.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add telemetry for ECS queries.


### PR DESCRIPTION
### What does this PR do?

Adds telemetry for the ECS client. In particular, it adds a metric that tracks the number of requests made by path and response code.

```
# HELP ecs_queries Count of ECS queries by path and response code. The response code defaults to 0 for unachieved queries.
# TYPE ecs_queries counter
ecs_queries{code="200",path="/metadata"} 68
ecs_queries{code="200",path="/stats"} 22
```

### Motivation

Detect if we're making too many requests to the ECS API because that can cause bugs like the one fixed in https://github.com/DataDog/datadog-agent/pull/9928

### Additional Notes

This is similar to the telemetry added for the Kubelet in https://github.com/DataDog/datadog-agent/pull/10256

### Describe how to test/QA your changes

- Deploy the agent in ECS (I tried Fargate) with `DD_TELEMETRY_ENABLED` set to true.
- ssh into the agent, run `curl localhost:6000/telemetry` and check that the `ecs_queries` metric is there. The output should be similar to the one shown above.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
