### PR TITLE
Raise the DefaultBatchMaxSize to 1000 for logs/events pipelines

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -55,7 +55,7 @@ const (
 	DefaultBatchMaxConcurrentSend = 0
 
 	// DefaultBatchMaxSize is the default HTTP batch max size (maximum number of events in a single batch) for logs
-	DefaultBatchMaxSize = 100
+	DefaultBatchMaxSize = 1000
 
 	// DefaultBatchMaxContentSize is the default HTTP batch max content size (before compression) for logs
 	// It is also the maximum possible size of a single event. Events exceeding this limit are dropped.

--- a/releasenotes/notes/raise_max_batch_size-c8fd6a98468ae675.yaml
+++ b/releasenotes/notes/raise_max_batch_size-c8fd6a98468ae675.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Logs and events match batch size raised from `100` to `1000` elements. Improves
+    performance in high volume scenarios. 

--- a/releasenotes/notes/raise_max_batch_size-c8fd6a98468ae675.yaml
+++ b/releasenotes/notes/raise_max_batch_size-c8fd6a98468ae675.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    Logs and events match batch size raised from `100` to `1000` elements. Improves
+    Logs and events max batch size raised from `100` to `1000` elements. Improves
     performance in high volume scenarios. 

--- a/releasenotes/notes/raise_max_batch_size-c8fd6a98468ae675.yaml
+++ b/releasenotes/notes/raise_max_batch_size-c8fd6a98468ae675.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    Logs and events max batch size raised from `100` to `1000` elements. Improves
+    Raised the max batch size of logs and events from `100` to `1000` elements. Improves
     performance in high volume scenarios. 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Raise the max batch payload size to `1000` elements. This is the maximum size according to [our docs](https://docs.datadoghq.com/api/latest/logs/#send-logs). 

This effectively raises the maximum throughput of logs/events (with an assumed 50ms of HTTP latency) from `~1.7 MB/sec` to `~9 MB/Sec` (tested with 1KB log samples). This has no impact on lower throughput scenarios. 

CPU usage raises proportionally to the extra log throughput, but did not exceed `900` mcores in my benchmarks. 

This will impact any pipeline using the default configs (including `epforwarder`). 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Send a high rate of logs to the intake. Spot check that none are missing. 

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
