### PR TITLE
Added logger to TestMultipleAPIKeys

### DIFF
--- a/cmd/process-agent/collector_api_test.go
+++ b/cmd/process-agent/collector_api_test.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"fmt"
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -337,6 +338,17 @@ func TestQueueSpaceReleased(t *testing.T) {
 }
 
 func TestMultipleAPIKeys(t *testing.T) {
+	err := ddconfig.SetupLogger(
+		"test",
+		"debug",
+		ddconfig.Datadog.GetString("process_config.log_file"),
+		ddconfig.GetSyslogURI(),
+		ddconfig.Datadog.GetBool("syslog_rfc"),
+		ddconfig.Datadog.GetBool("log_to_console"),
+		ddconfig.Datadog.GetBool("log_format_json"),
+	)
+	require.NoError(t, err)
+
 	m := &process.CollectorConnections{
 		HostName: testHostName,
 		GroupId:  1,

--- a/cmd/process-agent/collector_api_test.go
+++ b/cmd/process-agent/collector_api_test.go
@@ -8,6 +8,7 @@ package main
 import (
 	"fmt"
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/cihub/seelog"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -348,6 +349,7 @@ func TestMultipleAPIKeys(t *testing.T) {
 		ddconfig.Datadog.GetBool("log_format_json"),
 	)
 	require.NoError(t, err)
+	defer seelog.ReplaceLogger(seelog.Default)
 
 	m := &process.CollectorConnections{
 		HostName: testHostName,

--- a/cmd/process-agent/collector_api_test.go
+++ b/cmd/process-agent/collector_api_test.go
@@ -8,6 +8,7 @@ package main
 import (
 	"fmt"
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/cihub/seelog"
 	"io/ioutil"
 	"net"
@@ -497,6 +498,7 @@ func (m *mockEndpoint) start() (*url.URL, *url.URL) {
 
 		addrC <- listener.Addr()
 
+		log.Debug("Starting listener for mock collectorServer")
 		_ = m.collectorServer.Serve(listener)
 	}()
 
@@ -511,6 +513,7 @@ func (m *mockEndpoint) start() (*url.URL, *url.URL) {
 
 		addrC <- listener.Addr()
 
+		log.Debug("Starting listener for mock orchestratorServer")
 		_ = m.orchestratorServer.Serve(listener)
 	}()
 

--- a/cmd/process-agent/collector_api_test.go
+++ b/cmd/process-agent/collector_api_test.go
@@ -7,9 +7,6 @@ package main
 
 import (
 	"fmt"
-	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
-	"github.com/cihub/seelog"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -20,10 +17,13 @@ import (
 	"time"
 
 	"github.com/DataDog/agent-payload/v5/process"
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/process/config"
 	apicfg "github.com/DataDog/datadog-agent/pkg/process/util/api/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util/api/headers"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/cihub/seelog"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR adds logging to `TestMultipleAPIKeys` so that we can have a better idea of what's going on once the test flakes again.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
