### PR TITLE
[CWS] doc generator improvements

### DIFF
--- a/docs/cloud-workload-security/agent_expressions.md
+++ b/docs/cloud-workload-security/agent_expressions.md
@@ -403,7 +403,9 @@ A directory was created
 
 ### Event `mmap`
 
-[Experimental] A mmap command was executed
+_This event type is experimental and may change in the future._
+
+A mmap command was executed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
@@ -427,7 +429,9 @@ A directory was created
 
 ### Event `mprotect`
 
-[Experimental] A mprotect command was executed
+_This event type is experimental and may change in the future._
+
+A mprotect command was executed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
@@ -461,7 +465,9 @@ A file was opened
 
 ### Event `ptrace`
 
-[Experimental] A ptrace command was executed
+_This event type is experimental and may change in the future._
+
+A ptrace command was executed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |

--- a/docs/cloud-workload-security/scripts/secl-doc-gen.py
+++ b/docs/cloud-workload-security/scripts/secl-doc-gen.py
@@ -19,13 +19,16 @@ class EventType:
     kind: str
     definition: str
     min_agent_version: str
+    experimental: bool
     properties: List[EventTypeProperty]
 
 
 def build_event_types(json_top_node):
     event_types = []
     for et in json_top_node["secl"]:
-        event_type = EventType(et["name"], et["type"], et["definition"], et["from_agent_version"], [])
+        event_type = EventType(
+            et["name"], et["type"], et["definition"], et["from_agent_version"], et["experimental"], []
+        )
         for p in et["properties"]:
             prop = EventTypeProperty(p["name"], p["type"], p["definition"])
             event_type.properties.append(prop)

--- a/docs/cloud-workload-security/scripts/templates/agent_expressions.md
+++ b/docs/cloud-workload-security/scripts/templates/agent_expressions.md
@@ -38,7 +38,7 @@ Triggers are events that correspond to types of activity seen by the system. The
 | ---------- | ---- | ---------- | ------------- |
 {% for event_type in event_types %}
 {% if event_type.name != "*" %}
-| `{{ event_type.name }}` | {{ event_type.kind }} | {{ event_type.definition }} | {{ event_type.min_agent_version }} |
+| `{{ event_type.name }}` | {{ event_type.kind }} | {{ "[Experimental] " if event_type.experimental else "" }}{{ event_type.definition }} | {{ event_type.min_agent_version }} |
 {% endif %}
 {% endfor %}
 

--- a/docs/cloud-workload-security/scripts/templates/agent_expressions.md
+++ b/docs/cloud-workload-security/scripts/templates/agent_expressions.md
@@ -123,6 +123,10 @@ The *file.rights* attribute can now be used in addition to *file.mode*. *file.mo
 {% else %}
 ### Event `{{ event_type.name }}`
 
+{% if event_type.experimental %}
+_This event type is experimental and may change in the future._
+
+{% endif %}
 {{ event_type.definition }}
 {% endif %}
 

--- a/docs/cloud-workload-security/secl.json
+++ b/docs/cloud-workload-security/secl.json
@@ -1174,9 +1174,10 @@
     },
     {
       "name": "mmap",
-      "definition": "[Experimental] A mmap command was executed",
+      "definition": "A mmap command was executed",
       "type": "Kernel",
       "from_agent_version": "7.34",
+      "experimental": true,
       "properties": [
         {
           "name": "mmap.file.change_time",
@@ -1267,9 +1268,10 @@
     },
     {
       "name": "mprotect",
-      "definition": "[Experimental] A mprotect command was executed",
+      "definition": "A mprotect command was executed",
       "type": "Kernel",
       "from_agent_version": "7.34",
+      "experimental": true,
       "properties": [
         {
           "name": "mprotect.req_protection",
@@ -1384,9 +1386,10 @@
     },
     {
       "name": "ptrace",
-      "definition": "[Experimental] A ptrace command was executed",
+      "definition": "A ptrace command was executed",
       "type": "Kernel",
       "from_agent_version": "7.34",
+      "experimental": true,
       "properties": [
         {
           "name": "ptrace.request",

--- a/docs/cloud-workload-security/secl.json
+++ b/docs/cloud-workload-security/secl.json
@@ -5,6 +5,7 @@
       "definition": "",
       "type": "",
       "from_agent_version": "",
+      "experimental": false,
       "properties": [
         {
           "name": "container.id",
@@ -453,6 +454,7 @@
       "definition": "A BPF command was executed",
       "type": "Kernel",
       "from_agent_version": "7.33",
+      "experimental": false,
       "properties": [
         {
           "name": "bpf.cmd",
@@ -486,6 +488,7 @@
       "definition": "A process changed its capacity set",
       "type": "Process",
       "from_agent_version": "7.27",
+      "experimental": false,
       "properties": [
         {
           "name": "capset.cap_effective",
@@ -504,6 +507,7 @@
       "definition": "A file’s permissions were changed",
       "type": "File",
       "from_agent_version": "7.27",
+      "experimental": false,
       "properties": [
         {
           "name": "chmod.file.change_time",
@@ -597,6 +601,7 @@
       "definition": "A file’s owner was changed",
       "type": "File",
       "from_agent_version": "7.27",
+      "experimental": false,
       "properties": [
         {
           "name": "chown.file.change_time",
@@ -700,6 +705,7 @@
       "definition": "A process was executed or forked",
       "type": "Process",
       "from_agent_version": "7.27",
+      "experimental": false,
       "properties": [
         {
           "name": "exec.args",
@@ -923,6 +929,7 @@
       "definition": "Create a new name/alias for a file",
       "type": "File",
       "from_agent_version": "7.27",
+      "experimental": false,
       "properties": [
         {
           "name": "link.file.change_time",
@@ -1076,6 +1083,7 @@
       "definition": "A directory was created",
       "type": "File",
       "from_agent_version": "7.27",
+      "experimental": false,
       "properties": [
         {
           "name": "mkdir.file.change_time",
@@ -1285,6 +1293,7 @@
       "definition": "A file was opened",
       "type": "File",
       "from_agent_version": "7.27",
+      "experimental": false,
       "properties": [
         {
           "name": "open.file.change_time",
@@ -1826,6 +1835,7 @@
       "definition": "Remove extended attributes",
       "type": "File",
       "from_agent_version": "7.27",
+      "experimental": false,
       "properties": [
         {
           "name": "removexattr.file.change_time",
@@ -1919,6 +1929,7 @@
       "definition": "A file/directory was renamed",
       "type": "File",
       "from_agent_version": "7.27",
+      "experimental": false,
       "properties": [
         {
           "name": "rename.file.change_time",
@@ -2072,6 +2083,7 @@
       "definition": "A directory was removed",
       "type": "File",
       "from_agent_version": "7.27",
+      "experimental": false,
       "properties": [
         {
           "name": "rmdir.file.change_time",
@@ -2155,6 +2167,7 @@
       "definition": "An SELinux operation was run",
       "type": "Kernel",
       "from_agent_version": "7.30",
+      "experimental": false,
       "properties": [
         {
           "name": "selinux.bool.name",
@@ -2183,6 +2196,7 @@
       "definition": "A process changed its effective gid",
       "type": "Process",
       "from_agent_version": "7.27",
+      "experimental": false,
       "properties": [
         {
           "name": "setgid.egid",
@@ -2221,6 +2235,7 @@
       "definition": "A process changed its effective uid",
       "type": "Process",
       "from_agent_version": "7.27",
+      "experimental": false,
       "properties": [
         {
           "name": "setuid.euid",
@@ -2259,6 +2274,7 @@
       "definition": "Set exteneded attributes",
       "type": "File",
       "from_agent_version": "7.27",
+      "experimental": false,
       "properties": [
         {
           "name": "setxattr.file.change_time",
@@ -2352,6 +2368,7 @@
       "definition": "A file was deleted",
       "type": "File",
       "from_agent_version": "7.27",
+      "experimental": false,
       "properties": [
         {
           "name": "unlink.file.change_time",
@@ -2435,6 +2452,7 @@
       "definition": "Change file access/modification times",
       "type": "File",
       "from_agent_version": "7.27",
+      "experimental": false,
       "properties": [
         {
           "name": "utimes.file.change_time",

--- a/pkg/security/secl/compiler/generators/accessors/doc/doc.go
+++ b/pkg/security/secl/compiler/generators/accessors/doc/doc.go
@@ -94,7 +94,7 @@ func GenerateDocJSON(module *common.Module, outputPath string) error {
 }
 
 var (
-	minVersionRE      = regexp.MustCompile(`^\[(?P<version>[0-9.]+)\]\s*\[(?P<type>\w+)\](?P<def>.*)`)
+	minVersionRE      = regexp.MustCompile(`^\[(?P<version>(\w|\.|\s)*)\]\s*\[(?P<type>\w+)\](?P<def>.*)`)
 	minVersionREIndex = minVersionRE.SubexpIndex("version")
 	typeREIndex       = minVersionRE.SubexpIndex("type")
 	definitionREIndex = minVersionRE.SubexpIndex("def")

--- a/pkg/security/secl/compiler/generators/accessors/doc/doc.go
+++ b/pkg/security/secl/compiler/generators/accessors/doc/doc.go
@@ -25,6 +25,7 @@ type eventType struct {
 	Definition       string              `json:"definition"`
 	Type             string              `json:"type"`
 	FromAgentVersion string              `json:"from_agent_version"`
+	Experimental     bool                `json:"experimental"`
 	Properties       []eventTypeProperty `json:"properties"`
 }
 
@@ -72,6 +73,7 @@ func GenerateDocJSON(module *common.Module, outputPath string) error {
 			Definition:       info.Definition,
 			Type:             info.Type,
 			FromAgentVersion: info.FromAgentVersion,
+			Experimental:     info.Experimental,
 			Properties:       properties,
 		})
 	}
@@ -94,15 +96,17 @@ func GenerateDocJSON(module *common.Module, outputPath string) error {
 }
 
 var (
-	minVersionRE      = regexp.MustCompile(`^\[(?P<version>(\w|\.|\s)*)\]\s*\[(?P<type>\w+)\](?P<def>.*)`)
-	minVersionREIndex = minVersionRE.SubexpIndex("version")
-	typeREIndex       = minVersionRE.SubexpIndex("type")
-	definitionREIndex = minVersionRE.SubexpIndex("def")
+	minVersionRE        = regexp.MustCompile(`^\[(?P<version>(\w|\.|\s)*)\]\s*\[(?P<type>\w+)\]\s*(\[(?P<experimental>Experimental)\])?\s*(?P<def>.*)`)
+	minVersionREIndex   = minVersionRE.SubexpIndex("version")
+	typeREIndex         = minVersionRE.SubexpIndex("type")
+	experimentalREIndex = minVersionRE.SubexpIndex("experimental")
+	definitionREIndex   = minVersionRE.SubexpIndex("def")
 )
 
 type eventTypeInfo struct {
 	Definition       string
 	Type             string
+	Experimental     bool
 	FromAgentVersion string
 }
 
@@ -113,6 +117,7 @@ func extractVersionAndDefinition(comment string) eventTypeInfo {
 		return eventTypeInfo{
 			Definition:       strings.TrimSpace(matches[definitionREIndex]),
 			Type:             strings.TrimSpace(matches[typeREIndex]),
+			Experimental:     matches[experimentalREIndex] != "",
 			FromAgentVersion: strings.TrimSpace(matches[minVersionREIndex]),
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

This PR allows the specification of SECL experimental event types and the correct display of the experimental status in the generated JSON and Markdown files.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
