### PR TITLE
Make demultiplexer_test.go succeed on non-orchestrator builds

### DIFF
--- a/pkg/aggregator/demultiplexer_test.go
+++ b/pkg/aggregator/demultiplexer_test.go
@@ -35,6 +35,11 @@ func demuxTestOptions() DemultiplexerOptions {
 	return opts
 }
 
+// Check whether we are built with the +orchestrator build tag
+func orchestratorEnabled() bool {
+	return buildOrchestratorForwarder() != nil
+}
+
 func TestDemuxIsSetAsGlobalInstance(t *testing.T) {
 	require := require.New(t)
 
@@ -109,7 +114,11 @@ func TestDemuxForwardersCreated(t *testing.T) {
 	demux = InitAndStartAgentDemultiplexer(opts, "")
 	require.NotNil(demux)
 	require.NotNil(demux.forwarders.eventPlatform)
-	require.NotNil(demux.forwarders.orchestrator)
+	if orchestratorEnabled() {
+		require.NotNil(demux.forwarders.orchestrator)
+	} else {
+		require.Nil(demux.forwarders.orchestrator)
+	}
 	require.NotNil(demux.forwarders.shared)
 	demux.Stop(false)
 


### PR DESCRIPTION
### What does this PR do?

Fixes a test when `orchestrator` is not in the build tags

### Motivation

Running `go test` on this package would fail

### Additional Notes

It appears that CI does not check the no-`orchestrator` build configuration.  Should this be added?

### Possible Drawbacks / Trade-offs

Since Go [refuses to allow checking build tags in an expression](https://github.com/golang/go/issues/7007#issuecomment-66089605), the only option is to call some code defined in build-tag-protected .go files.  I chose to call "real" code and throw away the result, but the other option would have been to add `demultiplexer_orchestrator_test.go` and `demultiplexer_no_orchestrator_test.go` each containing only a `const orchestratorBuildTag = false` / `= true`.

### Describe how to test/QA your changes

Test-only change.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
