### PR TITLE
Do not define bpf_tail_call to avoid symbol redefinition

### DIFF
--- a/pkg/ebpf/c/bpf_helpers.h
+++ b/pkg/ebpf/c/bpf_helpers.h
@@ -60,13 +60,9 @@ static int (*bpf_l4_csum_replace)(void* ctx, int off, int from, int to, int flag
 /* at some point in kernel < 4.15, a duplicate bpf_tail_call symbol got included in the kernel headers.
    This breaks eBPF builds with a symbol redefinition error.
    It is fixed in 4.15 with commit https://github.com/torvalds/linux/commit/035226b964c820f65e201cdf123705a8f1d7c670
-   Using bpf_tail_call_compat as a symbol name avoids this issue. We are keeping bpf_tail_call in 4.15 to avoid
-   code changes in existing code that already requires 4.15+.
+   Using bpf_tail_call_compat as a symbol name avoids this issue.
  */
 static int (*bpf_tail_call_compat)(void* ctx, void* map, int key) = (void*)BPF_FUNC_tail_call;
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
-static int (*bpf_tail_call)(void* ctx, void* map, int key) = (void*)BPF_FUNC_tail_call;
-#endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0)
 static u64 (*bpf_get_current_task)(void) = (void*)BPF_FUNC_get_current_task;

--- a/pkg/ebpf/c/bpf_helpers.h
+++ b/pkg/ebpf/c/bpf_helpers.h
@@ -56,7 +56,17 @@ static unsigned long long (*bpf_get_prandom_u32)(void) = (void*)BPF_FUNC_get_pra
 static int (*bpf_skb_store_bytes)(void* ctx, int off, void* from, int len, int flags) = (void*)BPF_FUNC_skb_store_bytes;
 static int (*bpf_l3_csum_replace)(void* ctx, int off, int from, int to, int flags) = (void*)BPF_FUNC_l3_csum_replace;
 static int (*bpf_l4_csum_replace)(void* ctx, int off, int from, int to, int flags) = (void*)BPF_FUNC_l4_csum_replace;
+
+/* at some point in kernel < 4.15, a duplicate bpf_tail_call symbol got included in the kernel headers.
+   This breaks eBPF builds with a symbol redefinition error.
+   It is fixed in 4.15 with commit https://github.com/torvalds/linux/commit/035226b964c820f65e201cdf123705a8f1d7c670
+   Using bpf_tail_call_compat as a symbol name avoids this issue. We are keeping bpf_tail_call in 4.15 to avoid
+   code changes in existing code that already requires 4.15+.
+ */
+static int (*bpf_tail_call_compat)(void* ctx, void* map, int key) = (void*)BPF_FUNC_tail_call;
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 15, 0)
 static int (*bpf_tail_call)(void* ctx, void* map, int key) = (void*)BPF_FUNC_tail_call;
+#endif
 
 #if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 8, 0)
 static u64 (*bpf_get_current_task)(void) = (void*)BPF_FUNC_get_current_task;

--- a/pkg/security/ebpf/c/dentry_resolver.h
+++ b/pkg/security/ebpf/c/dentry_resolver.h
@@ -183,14 +183,14 @@ int __attribute__((always_inline)) resolve_dentry_tail_call(struct dentry_resolv
                                                                                                                        \
     if (syscall->resolver.ret > 0) {                                                                                   \
         if (syscall->resolver.iteration < DR_MAX_TAIL_CALL && syscall->resolver.key.ino != 0) {                        \
-            bpf_tail_call(ctx, progs_map, dentry_resolver_kern_key);                                                   \
+            bpf_tail_call_compat(ctx, progs_map, dentry_resolver_kern_key);                                                   \
         }                                                                                                              \
                                                                                                                        \
         syscall->resolver.ret += DR_MAX_ITERATION_DEPTH * (syscall->resolver.iteration - 1);                           \
     }                                                                                                                  \
                                                                                                                        \
     if (syscall->resolver.callback >= 0) {                                                                             \
-        bpf_tail_call(ctx, callbacks_map, syscall->resolver.callback);                                                 \
+        bpf_tail_call_compat(ctx, callbacks_map, syscall->resolver.callback);                                                 \
     }                                                                                                                  \
 
 SEC("kprobe/dentry_resolver_kern")
@@ -365,7 +365,7 @@ int kprobe_dentry_resolver_erpc(struct pt_regs *ctx) {
             goto exit;
     }
     if (state->iteration < DR_MAX_TAIL_CALL) {
-        bpf_tail_call(ctx, &dentry_resolver_kprobe_progs, DR_ERPC_KEY);
+        bpf_tail_call_compat(ctx, &dentry_resolver_kprobe_progs, DR_ERPC_KEY);
         resolution_err = DR_ERPC_TAIL_CALL_ERROR;
     }
 
@@ -470,7 +470,7 @@ int __attribute__((always_inline)) handle_dr_request(struct pt_regs *ctx, void *
         goto exit;
     }
 
-    bpf_tail_call(ctx, &dentry_resolver_kprobe_progs, dr_erpc_key);
+    bpf_tail_call_compat(ctx, &dentry_resolver_kprobe_progs, dr_erpc_key);
 
 exit:
     monitor_resolution_err(resolution_err);
@@ -479,9 +479,9 @@ exit:
 
 int __attribute__((always_inline)) resolve_dentry(void *ctx, int dr_type) {
     if (dr_type == DR_KPROBE) {
-        bpf_tail_call(ctx, &dentry_resolver_kprobe_progs, DR_KPROBE_DENTRY_RESOLVER_KERN_KEY);
+        bpf_tail_call_compat(ctx, &dentry_resolver_kprobe_progs, DR_KPROBE_DENTRY_RESOLVER_KERN_KEY);
     } else if (dr_type == DR_TRACEPOINT) {
-        bpf_tail_call(ctx, &dentry_resolver_tracepoint_progs, DR_TRACEPOINT_DENTRY_RESOLVER_KERN_KEY);
+        bpf_tail_call_compat(ctx, &dentry_resolver_tracepoint_progs, DR_TRACEPOINT_DENTRY_RESOLVER_KERN_KEY);
     }
     return 0;
 }

--- a/pkg/security/ebpf/c/exec.h
+++ b/pkg/security/ebpf/c/exec.h
@@ -171,7 +171,7 @@ int kprobe_parse_args_envs(struct pt_regs *ctx) {
 
     syscall->exec.next_tail++;
 
-    bpf_tail_call(ctx, &args_envs_progs, syscall->exec.next_tail);
+    bpf_tail_call_compat(ctx, &args_envs_progs, syscall->exec.next_tail);
 
     return 0;
 }
@@ -437,7 +437,7 @@ int __attribute__((always_inline)) parse_args_and_env(struct pt_regs *ctx) {
     // call it here before the memory get replaced
     fill_span_context(&syscall->exec.span_context);
 
-    bpf_tail_call(ctx, &args_envs_progs, syscall->exec.next_tail);
+    bpf_tail_call_compat(ctx, &args_envs_progs, syscall->exec.next_tail);
     return 0;
 }
 

--- a/pkg/security/ebpf/c/raw_syscalls.h
+++ b/pkg/security/ebpf/c/raw_syscalls.h
@@ -90,7 +90,7 @@ int __attribute__((always_inline)) handle_sys_exit(struct tracepoint_raw_syscall
     if (!syscall)
         return 0;
 
-    bpf_tail_call(args, &sys_exit_progs, syscall->type);
+    bpf_tail_call_compat(args, &sys_exit_progs, syscall->type);
     return 0;
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Do not define `bpf_tail_call` to avoid symbol redefinition. 
### Motivation

Symbol redefinition errors for runtime compiled checks (OOM and TCP Queue Length) on some kernels < 4.15.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run system-probe on kernel 4.4 with the OOM Kill and/or TCP Queue Length checks enabled. Examine logs to ensure checks compiled and started up correctly.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
