### PR TITLE
Use go:embed rather than go-bindata for ebpf bundled files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,5 +5,3 @@ go.sum -diff -merge linguist-generated=true
 *.pb.gw.go linguist-generated=true
 *_easyjson.go -diff -merge
 *_easyjson.go linguist-generated=true
-pkg/ebpf/bytecode/bindata/* -diff -merge
-pkg/ebpf/bytecode/bindata/* linguist-generated=true

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -195,7 +195,6 @@
 /pkg/network/                           @DataDog/agent-network
 /pkg/ebpf/                              @DataDog/agent-network
 /pkg/ebpf/bytecode/runtime/runtime-security.go  @DataDog/agent-security
-/pkg/ebpf/bytecode/bindata/bindataRuntimesecurity*      @DataDog/agent-security
 /pkg/quantile/                          @DataDog/metrics-aggregation
 /pkg/compliance/                        @DataDog/agent-security
 /pkg/kubestatemetrics                   @DataDog/container-integrations

--- a/.gitignore
+++ b/.gitignore
@@ -127,7 +127,6 @@ tools/windows/install-help/cal/packages/
 
 # ebpf object files
 pkg/ebpf/bytecode/build/
-pkg/ebpf/bytecode/bindata/
 *.bc
 
 # CGo generated object files

--- a/pkg/ebpf/bytecode/asset_bindata.go
+++ b/pkg/ebpf/bytecode/asset_bindata.go
@@ -10,14 +10,19 @@ package bytecode
 
 import (
 	"bytes"
+	"embed"
 	"io"
-
-	bindata "github.com/DataDog/datadog-agent/pkg/ebpf/bytecode/bindata"
+	"path"
 )
+
+//go:embed build/runtime-security.o
+//go:embed build/runtime-security-syscall-wrapper.o
+var bindata embed.FS
 
 // GetReader returns a new AssetReader for the specified bundled asset
 func GetReader(dir, name string) (AssetReader, error) {
-	content, err := bindata.Asset(name)
+	dir = "build"
+	content, err := bindata.ReadFile(path.Join(dir, name))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/ebpf/bytecode/bindata/.gitignore
+++ b/pkg/ebpf/bytecode/bindata/.gitignore
@@ -1,2 +1,0 @@
-bindataRuntimesecurityO.go
-bindataRuntimesecuritysyscallwrapperO.go

--- a/pkg/ebpf/bytecode/bindata/package.go
+++ b/pkg/ebpf/bytecode/bindata/package.go
@@ -1,6 +1,0 @@
-// Unless explicitly stated otherwise all files in this repository are licensed
-// under the Apache License Version 2.0.
-// This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2016-present Datadog, Inc.
-
-package bindata

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -11,7 +11,7 @@ from invoke import task
 from invoke.exceptions import Exit
 
 from .build_tags import get_default_build_tags
-from .utils import REPO_PATH, bin_name, bundle_files, get_build_flags, get_version_numeric_only
+from .utils import REPO_PATH, bin_name, get_build_flags, get_version_numeric_only
 
 BIN_DIR = os.path.join(".", "bin", "system-probe")
 BIN_PATH = os.path.join(BIN_DIR, bin_name("system-probe", android=False))
@@ -595,8 +595,6 @@ def build_security_ebpf_files(ctx, build_dir, parallel_build=True):
         for p in promises:
             p.join()
 
-    return [security_agent_obj_file, security_agent_syscall_wrapper_obj_file]
-
 
 def build_object_files(ctx, parallel_build):
     """build_object_files builds only the eBPF object"""
@@ -612,14 +610,10 @@ def build_object_files(ctx, parallel_build):
     ctx.run(f"mkdir -p {build_dir}")
     ctx.run(f"mkdir -p {build_runtime_dir}")
 
-    bindata_files = []
     build_network_ebpf_files(ctx, build_dir=build_dir, parallel_build=parallel_build)
-    bindata_files.extend(build_security_ebpf_files(ctx, build_dir=build_dir, parallel_build=parallel_build))
+    build_security_ebpf_files(ctx, build_dir=build_dir, parallel_build=parallel_build)
 
     generate_runtime_files(ctx)
-
-    go_dir = os.path.join(bpf_dir, "bytecode", "bindata")
-    bundle_files(ctx, bindata_files, "pkg/.*/", go_dir, "bindata", BUNDLE_TAG)
 
 
 @task


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Use go:embed rather than go-bindata for ebpf bundled files

### Motivation

Utilize simpler method for embedding files added in Go 1.16

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
