### PR TITLE
Fixed duplicate runtime settings warning in tests

### DIFF
--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -188,6 +188,8 @@ func runAgent(exit chan struct{}) {
 		cleanupAndExit(1)
 	}
 
+	config.InitRuntimeSettings()
+
 	// Note: This only considers container sources that are already setup. It's possible that container sources may
 	//       need a few minutes to be ready on newly provisioned hosts.
 	_, err := util.GetContainers()

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -351,13 +351,11 @@ func NewAgentConfig(loggerName config.LoggerName, yamlPath, netYamlPath string, 
 		}
 	}
 
-	initRuntimeSettings()
-
 	return cfg, nil
 }
 
-// initRuntimeSettings registers settings to be added to the runtime config.
-func initRuntimeSettings() {
+// InitRuntimeSettings registers settings to be added to the runtime config.
+func InitRuntimeSettings() {
 	// NOTE: Any settings you want to register should simply be added here
 	var processRuntimeSettings = []settings.RuntimeSetting{
 		settings.LogLevelRuntimeSetting{},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR fixes the `cannot initialize the runtime setting log_level: duplicated settings detected` warning that you get when running tests in CI.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The duplicate settings warning is caused by side effects of `NewAgentConfig`. Side effects in this method are considered to be an anti-pattern and should be moved somewhere else.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
`cd` into `pkg/process/config` and run `go test`. Make sure that `cannot initialize the runtime setting log_level: duplicated settings detected` is never logged.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
