### PR TITLE
[WLM] add SubscriberPriority

### DIFF
--- a/pkg/autodiscovery/listeners/workloadmeta.go
+++ b/pkg/autodiscovery/listeners/workloadmeta.go
@@ -128,7 +128,7 @@ func (l *workloadmetaListenerImpl) Listen(newSvc chan<- Service, delSvc chan<- S
 	l.newService = newSvc
 	l.delService = delSvc
 
-	ch := l.store.Subscribe(l.name, l.workloadFilters)
+	ch := l.store.Subscribe(l.name, workloadmeta.ADPriority, l.workloadFilters)
 	health := health.RegisterLiveness(l.name)
 	creationTime := integration.Before
 

--- a/pkg/autodiscovery/listeners/workloadmeta.go
+++ b/pkg/autodiscovery/listeners/workloadmeta.go
@@ -128,7 +128,7 @@ func (l *workloadmetaListenerImpl) Listen(newSvc chan<- Service, delSvc chan<- S
 	l.newService = newSvc
 	l.delService = delSvc
 
-	ch := l.store.Subscribe(l.name, workloadmeta.ADPriority, l.workloadFilters)
+	ch := l.store.Subscribe(l.name, workloadmeta.NormalPriority, l.workloadFilters)
 	health := health.RegisterLiveness(l.name)
 	creationTime := integration.Before
 

--- a/pkg/autodiscovery/providers/container.go
+++ b/pkg/autodiscovery/providers/container.go
@@ -78,7 +78,7 @@ func (d *ContainerConfigProvider) listen() {
 	health := health.RegisterLiveness("ad-containerprovider")
 	d.Unlock()
 
-	workloadmetaEventsChannel := d.workloadmetaStore.Subscribe("ad-containerprovider", workloadmeta.NewFilter(
+	workloadmetaEventsChannel := d.workloadmetaStore.Subscribe("ad-containerprovider", workloadmeta.ADPriority, workloadmeta.NewFilter(
 		[]workloadmeta.Kind{workloadmeta.KindContainer},
 		[]workloadmeta.Source{
 			workloadmeta.SourceDocker,

--- a/pkg/autodiscovery/providers/container.go
+++ b/pkg/autodiscovery/providers/container.go
@@ -78,7 +78,7 @@ func (d *ContainerConfigProvider) listen() {
 	health := health.RegisterLiveness("ad-containerprovider")
 	d.Unlock()
 
-	workloadmetaEventsChannel := d.workloadmetaStore.Subscribe("ad-containerprovider", workloadmeta.ADPriority, workloadmeta.NewFilter(
+	workloadmetaEventsChannel := d.workloadmetaStore.Subscribe("ad-containerprovider", workloadmeta.NormalPriority, workloadmeta.NewFilter(
 		[]workloadmeta.Kind{workloadmeta.KindContainer},
 		[]workloadmeta.Source{
 			workloadmeta.SourceDocker,

--- a/pkg/autodiscovery/providers/kubelet.go
+++ b/pkg/autodiscovery/providers/kubelet.go
@@ -72,7 +72,7 @@ func (k *KubeletConfigProvider) listen() {
 	health := health.RegisterLiveness(name)
 	k.Unlock()
 
-	ch := k.workloadmetaStore.Subscribe(name, workloadmeta.NewFilter(
+	ch := k.workloadmetaStore.Subscribe(name, workloadmeta.ADPriority, workloadmeta.NewFilter(
 		[]workloadmeta.Kind{workloadmeta.KindKubernetesPod},
 		[]workloadmeta.Source{workloadmeta.SourceKubelet},
 	))

--- a/pkg/autodiscovery/providers/kubelet.go
+++ b/pkg/autodiscovery/providers/kubelet.go
@@ -72,7 +72,7 @@ func (k *KubeletConfigProvider) listen() {
 	health := health.RegisterLiveness(name)
 	k.Unlock()
 
-	ch := k.workloadmetaStore.Subscribe(name, workloadmeta.ADPriority, workloadmeta.NewFilter(
+	ch := k.workloadmetaStore.Subscribe(name, workloadmeta.NormalPriority, workloadmeta.NewFilter(
 		[]workloadmeta.Kind{workloadmeta.KindKubernetesPod},
 		[]workloadmeta.Source{workloadmeta.SourceKubelet},
 	))

--- a/pkg/collector/corechecks/containerlifecycle/check.go
+++ b/pkg/collector/corechecks/containerlifecycle/check.go
@@ -93,6 +93,7 @@ func (c *Check) Run() error {
 
 	contEventsCh := c.workloadmetaStore.Subscribe(
 		checkName+"-cont",
+		workloadmeta.NormalPriority,
 		workloadmeta.NewFilter(
 			[]workloadmeta.Kind{workloadmeta.KindContainer},
 			[]workloadmeta.Source{workloadmeta.SourceDocker, workloadmeta.SourceContainerd},
@@ -101,6 +102,7 @@ func (c *Check) Run() error {
 
 	podEventsCh := c.workloadmetaStore.Subscribe(
 		checkName+"-pod",
+		workloadmeta.NormalPriority,
 		workloadmeta.NewFilter(
 			[]workloadmeta.Kind{workloadmeta.KindKubernetesPod},
 			[]workloadmeta.Source{workloadmeta.SourceKubelet},

--- a/pkg/tagger/collectors/workloadmeta_main.go
+++ b/pkg/tagger/collectors/workloadmeta_main.go
@@ -96,7 +96,7 @@ func (c *WorkloadMetaCollector) Stream() error {
 	const name = "tagger-workloadmeta"
 	health := health.RegisterLiveness(name)
 
-	ch := c.store.Subscribe(name, nil)
+	ch := c.store.Subscribe(name, workloadmeta.TaggerPriority, nil)
 
 	for {
 		select {

--- a/pkg/workloadmeta/store_test.go
+++ b/pkg/workloadmeta/store_test.go
@@ -385,7 +385,7 @@ func TestSubscribe(t *testing.T) {
 
 			s.handleEvents(tt.preEvents)
 
-			ch := s.Subscribe(dummySubscriber, tt.filter)
+			ch := s.Subscribe(dummySubscriber, NormalPriority, tt.filter)
 			doneCh := make(chan struct{})
 
 			var actual []EventBundle

--- a/pkg/workloadmeta/testing/store.go
+++ b/pkg/workloadmeta/testing/store.go
@@ -127,7 +127,7 @@ func (s *Store) Start(ctx context.Context) {
 }
 
 // Subscribe is not implemented in the testing store.
-func (s *Store) Subscribe(name string, filter *workloadmeta.Filter) chan workloadmeta.EventBundle {
+func (s *Store) Subscribe(name string, _ workloadmeta.SubscriberPriority, filter *workloadmeta.Filter) chan workloadmeta.EventBundle {
 	panic("not implemented")
 }
 

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -565,10 +565,6 @@ const (
 	// come first.
 	TaggerPriority SubscriberPriority = iota
 
-	// ADPriority is the priority for autodiscovery.  This must come after
-	// Tagger, but before other components.
-	ADPriority SubscriberPriority = iota
-
 	// NormalPriority should be used by subscribers on which other components
 	// do not depend.
 	NormalPriority SubscriberPriority = iota


### PR DESCRIPTION
### What does this PR do?

Adds a priority to subscriptions to the workloadmeta store, so that components which must be notified before other components can ensure that, without resorting to fragile ordering of initialization code.

### Motivation

Tagger needs to know about stuff before other components do.

### Additional Notes

I also gave AD a priority above "Normal".  I don't know that doing so is necessary, but it doesn't hurt.

### Describe how to test/QA your changes

Run the agent and look for "tag collector successfully started", indicating that the Tagger has subscribed.  The order of notifications is not visible in logs but has been verified locally.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
