### PR TITLE
pkg/obfuscate: fix SQL Server query truncation during obfuscation for queries using temp tables

### DIFF
--- a/pkg/obfuscate/sql_test.go
+++ b/pkg/obfuscate/sql_test.go
@@ -688,6 +688,14 @@ func TestSQLQuantizer(t *testing.T) {
 			"select * from users where id = ?",
 		},
 		{
+			"select * from ##ThisIsAGlobalTempTable where id = 1",
+			"select * from ##ThisIsAGlobalTempTable where id = ?",
+		},
+		{
+			"select * from dbo.#ThisIsATempTable where id = 1",
+			"select * from dbo.#ThisIsATempTable where id = ?",
+		},
+		{
 			"select * from users where id = 214325346     -- This comment continues to the end of line",
 			"select * from users where id = ?",
 		},

--- a/releasenotes/notes/fix-sqlserver-temp-table-obfuscation-3514870d1f4f5596.yaml
+++ b/releasenotes/notes/fix-sqlserver-temp-table-obfuscation-3514870d1f4f5596.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fixes truncated queries using temp tables in SQL Server


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR addresses cases where the pound sign (`#`) has different meaning depending on the DBMS used. In MySQL, this syntax indicates a comment: https://dev.mysql.com/doc/refman/8.0/en/comments.html. In the case of MS SQL Server, a pound sign indicates a temp table or global temp table: https://docs.microsoft.com/en-us/sql/t-sql/statements/create-table-transact-sql?view=sql-server-ver15#temporary-tables. The current behavior ends up dropping a lot of the SQL text anytime a temp table is used in the query due to this.

The comment in the code details the workaround.

### Motivation

This is a short-term fix for SQL Server that aims to preserve current MySQL functionality but admittedly may regress in some cases. A longer-term fix will require the obfuscator to be dialect-aware in order to have the correct behaviors.

This solution is not ideal and I am open to alternatives.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
