### PR TITLE
docker/cgroup: Collect cpuset cpus_allowed info for docker containers

### DIFF
--- a/pkg/collector/corechecks/containers/docker/docker.go
+++ b/pkg/collector/corechecks/containers/docker/docker.go
@@ -377,6 +377,10 @@ func (d *DockerCheck) reportCPUMetrics(cpu *cmetrics.ContainerCPUStats, limits *
 		availableCPUTimeHz := 100 * float64(timeDiff) // Converted to Hz to be consistent with UsageTotal
 		sender.Rate("docker.cpu.limit", limits.CPULimit/100*availableCPUTimeHz, "", tags)
 	}
+
+	if limits.CPUsAllowed > 0 {
+		sender.Rate("docker.cpu.cpus_allowed", float64(limits.CPUsAllowed), "", tags)
+	}
 }
 
 func (d *DockerCheck) reportIOMetrics(io *cmetrics.ContainerIOStats, tags []string, sender aggregator.Sender) {

--- a/pkg/util/containers/metrics/types.go
+++ b/pkg/util/containers/metrics/types.go
@@ -147,6 +147,7 @@ type ContainerLimits struct {
 	CPULimit    float64
 	MemLimit    uint64
 	ThreadLimit uint64
+	CPUsAllowed int
 }
 
 // ContainerMetricsProvider defines the API for any implementation that could provide container metrics

--- a/pkg/util/containers/providers/cgroup/provider.go
+++ b/pkg/util/containers/providers/cgroup/provider.go
@@ -127,6 +127,10 @@ func (mp *provider) GetContainerLimits(containerID string) (*metrics.ContainerLi
 	if err != nil {
 		return nil, fmt.Errorf("thread limit: %s", err)
 	}
+	limits.CPUsAllowed, err = cg.CPUsAllowed()
+	if err != nil {
+		return nil, fmt.Errorf("cpus allowed: %s", err)
+	}
 
 	return &limits, nil
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Collect cpuset cpus_allowed info for docker containers.
<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

There are two main ways of limiting container CPU usage - either with CFS quotas (all containers get all cpus for a short time slice), or with cpuset assignments (where a container gets a dedicated cpu core). While the limit information does show info from both sources, it's impossible to tell which is currently in use. 

This PR adds the information to the existing check since the code is already processing the relevant data but throwing it away, to instead expose it as a metric of # of cpus the container is allowed to run on. Where that number doesn't match the system's core count, that must mean that cpu pinning is being used.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

Only includes an implementation for docker/cgroups, not sure if this is applicable to other container runtimes that Datadog agent supports. It also doesn't do the rate scaling that is present in the CpuLimit reporting, not sure if that's required.
<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
