### PR TITLE
pkg/trace: Fix nil remote sampler

### DIFF
--- a/pkg/trace/sampler/prioritysampler.go
+++ b/pkg/trace/sampler/prioritysampler.go
@@ -46,6 +46,8 @@ type PrioritySampler struct {
 	localRates *Sampler
 	// remoteRates targetTPS is set remotely and distributed by remote configurations.
 	// One target is defined per combination of tracerEnv, service and it applies only to root spans.
+	// remoteRates can be nil if the remote feature is not enabled in the trace-agent with feature flag "remote_rates"
+	// or in the core-agent remote client.
 	remoteRates *RemoteRates
 
 	// rateByService contains the sampling rates in % to communicate with trace-agent clients.

--- a/pkg/trace/sampler/prioritysampler.go
+++ b/pkg/trace/sampler/prioritysampler.go
@@ -84,8 +84,7 @@ func (s *PrioritySampler) Start() {
 			case <-updateRates.C:
 				s.updateRates()
 			case <-statsTicker.C:
-				s.localRates.report()
-				s.remoteRates.report()
+				s.reportStats()
 			case <-s.exit:
 				return
 			}
@@ -93,10 +92,20 @@ func (s *PrioritySampler) Start() {
 	}()
 }
 
+// report sampler stats
+func (s *PrioritySampler) reportStats() {
+	s.localRates.report()
+	if s.remoteRates != nil {
+		s.remoteRates.report()
+	}
+}
+
 // update sampling rates
 func (s *PrioritySampler) updateRates() {
 	s.localRates.update()
-	s.remoteRates.update()
+	if s.remoteRates != nil {
+		s.remoteRates.update()
+	}
 	s.rateByService.SetAll(s.ratesByService())
 }
 

--- a/pkg/trace/sampler/prioritysampler_test.go
+++ b/pkg/trace/sampler/prioritysampler_test.go
@@ -149,6 +149,20 @@ func TestPrioritySampleThresholdTo1(t *testing.T) {
 	}
 }
 
+func TestPrioritySamplerWithNilRemote(t *testing.T) {
+	conf := &config.AgentConfig{
+		ExtraSampleRate: 1.0,
+		TargetTPS:       0.0,
+	}
+	s := NewPrioritySampler(conf, NewDynamicConfig())
+	s.Start()
+	s.updateRates()
+	s.reportStats()
+	chunk, root := getTestTraceWithService(t, "my-service", s)
+	assert.True(t, s.Sample(chunk, root, "", false))
+	s.Stop()
+}
+
 func TestPrioritySamplerTPSFeedbackLoop(t *testing.T) {
 	assert := assert.New(t)
 	rand.Seed(1)


### PR DESCRIPTION
If the feature remote is not enabled, remoteSampler is nil.
Added missing nil checks behind timers and a test