### PR TITLE
[CWS] runtime compilation constants test and fixes

### DIFF
--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -33,6 +33,8 @@ var (
 	Kernel4_15 = kernel.VersionCode(4, 15, 0) //nolint:deadcode,unused
 	// Kernel4_16 is the KernelVersion representation of kernel version 4.16
 	Kernel4_16 = kernel.VersionCode(4, 16, 0) //nolint:deadcode,unused
+	// Kernel4_19 is the KernelVersion representation of kernel version 4.19
+	Kernel4_19 = kernel.VersionCode(4, 19, 0) //nolint:deadcode,unused
 	// Kernel5_0 is the KernelVersion representation of kernel version 5.0
 	Kernel5_0 = kernel.VersionCode(5, 0, 0) //nolint:deadcode,unused
 	// Kernel5_1 is the KernelVersion representation of kernel version 5.1
@@ -41,10 +43,26 @@ var (
 	Kernel5_3 = kernel.VersionCode(5, 3, 0) //nolint:deadcode,unused
 	// Kernel5_4 is the KernelVersion representation of kernel version 5.4
 	Kernel5_4 = kernel.VersionCode(5, 4, 0) //nolint:deadcode,unused
+	// Kernel5_5 is the KernelVersion representation of kernel version 5.5
+	Kernel5_5 = kernel.VersionCode(5, 5, 0) //nolint:deadcode,unused
+	// Kernel5_7 is the KernelVersion representation of kernel version 5.7
+	Kernel5_7 = kernel.VersionCode(5, 7, 0) //nolint:deadcode,unused
+	// Kernel5_8 is the KernelVersion representation of kernel version 5.8
+	Kernel5_8 = kernel.VersionCode(5, 8, 0) //nolint:deadcode,unused
+	// Kernel5_9 is the KernelVersion representation of kernel version 5.9
+	Kernel5_9 = kernel.VersionCode(5, 9, 0) //nolint:deadcode,unused
+	// Kernel5_10 is the KernelVersion representation of kernel version 5.10
+	Kernel5_10 = kernel.VersionCode(5, 10, 0) //nolint:deadcode,unused
+	// Kernel5_11 is the KernelVersion representation of kernel version 5.11
+	Kernel5_11 = kernel.VersionCode(5, 11, 0) //nolint:deadcode,unused
 	// Kernel5_12 is the KernelVersion representation of kernel version 5.12
 	Kernel5_12 = kernel.VersionCode(5, 12, 0) //nolint:deadcode,unused
 	// Kernel5_13 is the KernelVersion representation of kernel version 5.13
 	Kernel5_13 = kernel.VersionCode(5, 13, 0) //nolint:deadcode,unused
+	// Kernel5_14 is the KernelVersion representation of kernel version 5.14
+	Kernel5_14 = kernel.VersionCode(5, 14, 0) //nolint:deadcode,unused
+	// Kernel5_16 is the KernelVersion representation of kernel version 5.16
+	Kernel5_16 = kernel.VersionCode(5, 16, 0) //nolint:deadcode,unused
 )
 
 // Version defines a kernel version helper
@@ -130,4 +148,10 @@ func (k *Version) IsOracleUEKKernel() bool {
 // IsCOSKernel returns whether the kernel is a suse kernel
 func (k *Version) IsCOSKernel() bool {
 	return k.osRelease["ID"] == "cos"
+}
+
+// IsInRangeCloseOpen returns whether the kernel version is between the begin
+// version (included) and the end version (excluded)
+func (k *Version) IsInRangeCloseOpen(begin kernel.Version, end kernel.Version) bool {
+	return k.Code != 0 && begin <= k.Code && k.Code < end
 }

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -9,6 +9,8 @@
 package constantfetch
 
 import (
+	"runtime"
+
 	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 )
 
@@ -73,7 +75,7 @@ func getSizeOfStructInode(kv *kernel.Version) uint64 {
 		sizeOf = 632
 	case kv.Code != 0 && kv.Code < kernel.Kernel4_16:
 		sizeOf = 608
-	case kernel.Kernel5_0 <= kv.Code && kv.Code < kernel.Kernel5_1:
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_0, kernel.Kernel5_1):
 		sizeOf = 584
 	case kv.Code != 0 && kv.Code >= kernel.Kernel5_13:
 		sizeOf = 592
@@ -104,6 +106,26 @@ func getSignalTTYOffset(kv *kernel.Version) uint64 {
 		ttyOffset = 376
 	case kv.IsSLES15Kernel():
 		ttyOffset = 408
+	case kv.IsInRangeCloseOpen(kernel.Kernel4_13, kernel.Kernel4_19):
+		ttyOffset = 376
+	case kv.IsInRangeCloseOpen(kernel.Kernel4_19, kernel.Kernel5_0):
+		ttyOffset = 400
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_0, kernel.Kernel5_1):
+		ttyOffset = 408
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_4, kernel.Kernel5_5):
+		ttyOffset = 408
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_4, kernel.Kernel5_7):
+		if runtime.GOARCH == "arm64" || kv.IsOracleUEKKernel() {
+			ttyOffset = 408
+		} else {
+			ttyOffset = 400
+		}
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_7, kernel.Kernel5_9):
+		if runtime.GOARCH == "arm64" {
+			ttyOffset = 400
+		} else {
+			ttyOffset = 408
+		}
 	case kv.Code != 0 && kv.Code < kernel.Kernel5_3:
 		ttyOffset = 368
 	}
@@ -117,6 +139,12 @@ func getTTYNameOffset(kv *kernel.Version) uint64 {
 	switch {
 	case kv.IsRH7Kernel():
 		nameOffset = 312
+	case kv.IsInRangeCloseOpen(kernel.Kernel4_13, kernel.Kernel5_8):
+		nameOffset = 368
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_8, kernel.Kernel5_9) && runtime.GOARCH == "arm64":
+		nameOffset = 368
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_8, kernel.Kernel5_14):
+		nameOffset = 360
 	}
 
 	return nameOffset

--- a/pkg/security/probe/constantfetch/fetcher.go
+++ b/pkg/security/probe/constantfetch/fetcher.go
@@ -151,6 +151,11 @@ func CreateConstantEditors(constants map[string]uint64) []manager.ConstantEditor
 
 var constantsCache *cachedConstants
 
+// ClearConstantsCache clears the constants cache
+func ClearConstantsCache() {
+	constantsCache = nil
+}
+
 type cachedConstants struct {
 	constants map[string]uint64
 	hash      []byte

--- a/pkg/security/probe/constantfetch/runtime_compiled.go
+++ b/pkg/security/probe/constantfetch/runtime_compiled.go
@@ -72,7 +72,6 @@ func (cf *RuntimeCompilationConstantFetcher) AppendOffsetofRequest(id, typeName,
 }
 
 const runtimeCompilationTemplate = `
-#include <linux/compiler.h>
 #include <linux/kconfig.h>
 {{ range .headers }}
 #include <{{ . }}>

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -107,6 +107,14 @@ func (p *Probe) detectKernelVersion() error {
 	return nil
 }
 
+// GetKernelVersion computes and returns the running kernel version
+func (p *Probe) GetKernelVersion() (*kernel.Version, error) {
+	if err := p.detectKernelVersion(); err != nil {
+		return nil, err
+	}
+	return p.kernelVersion, nil
+}
+
 // VerifyOSVersion returns an error if the current kernel version is not supported
 func (p *Probe) VerifyOSVersion() error {
 	if !p.kernelVersion.IsRH7Kernel() && !p.kernelVersion.IsRH8Kernel() && p.kernelVersion.Code < kernel.Kernel4_15 {

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -923,7 +923,7 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 		p.managerOptions.ActivatedProbes = append(p.managerOptions.ActivatedProbes, probes.SyscallMonitorSelectors...)
 	}
 
-	constants, err := getOffsetConstants(config, p)
+	constants, err := GetOffsetConstants(config, p)
 	if err != nil {
 		log.Warnf("constant fetcher failed: %v", err)
 		return nil, err
@@ -1035,7 +1035,8 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 	return p, nil
 }
 
-func getOffsetConstants(config *config.Config, probe *Probe) (map[string]uint64, error) {
+// GetOffsetConstants returns the offsets and struct sizes constants
+func GetOffsetConstants(config *config.Config, probe *Probe) (map[string]uint64, error) {
 	constantFetcher := constantfetch.ComposeConstantFetchers(constantfetch.GetAvailableConstantFetchers(config, probe.kernelVersion, probe.statsdClient))
 
 	constantFetcher.AppendSizeofRequest("sizeof_inode", "struct inode", "linux/fs.h")

--- a/pkg/security/tests/runtime_compiled_constants_test.go
+++ b/pkg/security/tests/runtime_compiled_constants_test.go
@@ -40,5 +40,12 @@ func TestFallbackConstants(t *testing.T) {
 		t.Error(err)
 	}
 
-	assert.Equal(t, withoutRC, withRC)
+	if !assert.Equal(t, withoutRC, withRC) {
+		kernelVersion, err := test.probe.GetKernelVersion()
+		if err != nil {
+			t.Error("failed to get probe kernel version")
+		} else {
+			t.Logf("kernel version: %v", kernelVersion)
+		}
+	}
 }

--- a/pkg/security/tests/runtime_compiled_constants_test.go
+++ b/pkg/security/tests/runtime_compiled_constants_test.go
@@ -1,0 +1,44 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+// +build functionaltests
+
+package tests
+
+import (
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/security/probe"
+	"github.com/DataDog/datadog-agent/pkg/security/probe/constantfetch"
+	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFallbackConstants(t *testing.T) {
+	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, testOpts{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer test.Close()
+
+	config := test.config
+	config.RuntimeCompiledConstantsIsSet = true
+	config.EnableRuntimeCompiledConstants = false
+
+	withoutRC, err := probe.GetOffsetConstants(config, test.probe)
+	if err != nil {
+		t.Error(err)
+	}
+
+	constantfetch.ClearConstantsCache()
+
+	config.EnableRuntimeCompiledConstants = true
+	withRC, err := probe.GetOffsetConstants(config, test.probe)
+	if err != nil {
+		t.Error(err)
+	}
+
+	assert.Equal(t, withoutRC, withRC)
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds a test to compare fallback and RC-generated constants. It also fixes the fallback constants based on test results.

### Possible Drawbacks / Trade-offs

None

### Describe how to test/QA your changes

This adds tests

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
