### PR TITLE
[CWS] Improve `bpf` event context

### DIFF
--- a/docs/cloud-workload-security/agent_expressions.md
+++ b/docs/cloud-workload-security/agent_expressions.md
@@ -241,8 +241,11 @@ A BPF command was executed
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
 | `bpf.cmd` | int | BPF command name |
+| `bpf.map.name` | string | Name of the eBPF map (added in 7.34) |
 | `bpf.map.type` | int | Type of the eBPF map |
 | `bpf.prog.attach_type` | int | Attach type of the eBPF program |
+| `bpf.prog.helpers` | int | eBPF helpers used by the eBPF program (added in 7.34) |
+| `bpf.prog.name` | string | Name of the eBPF program (added in 7.34) |
 | `bpf.prog.type` | int | Type of the eBPF program |
 | `bpf.retval` | int | Return value of the syscall |
 

--- a/docs/cloud-workload-security/agent_expressions.md
+++ b/docs/cloud-workload-security/agent_expressions.md
@@ -241,11 +241,12 @@ A BPF command was executed
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
 | `bpf.cmd` | int | BPF command name |
-| `bpf.map.name` | string | Name of the eBPF map (added in 7.34) |
+| `bpf.map.name` | string | Name of the eBPF map (added in 7.35) |
 | `bpf.map.type` | int | Type of the eBPF map |
 | `bpf.prog.attach_type` | int | Attach type of the eBPF program |
-| `bpf.prog.helpers` | int | eBPF helpers used by the eBPF program (added in 7.34) |
-| `bpf.prog.name` | string | Name of the eBPF program (added in 7.34) |
+| `bpf.prog.helpers` | int | eBPF helpers used by the eBPF program (added in 7.35) |
+| `bpf.prog.name` | string | Name of the eBPF program (added in 7.35) |
+| `bpf.prog.tag` | string | Hash (sha1) of the eBPF program (added in 7.35) |
 | `bpf.prog.type` | int | Type of the eBPF program |
 | `bpf.retval` | int | Return value of the syscall |
 

--- a/docs/cloud-workload-security/backend.md
+++ b/docs/cloud-workload-security/backend.md
@@ -152,6 +152,10 @@ CWS logs have the following JSON schema:
             "type": "string",
             "description": "Name of the BPF program"
         },
+        "tag": {
+            "type": "string",
+            "description": "Hash (sha1) of the BPF program"
+        },
         "program_type": {
             "type": "string",
             "description": "Type of the BPF program"
@@ -177,6 +181,7 @@ CWS logs have the following JSON schema:
 | Field | Description |
 | ----- | ----------- |
 | `name` | Name of the BPF program |
+| `tag` | Hash (sha1) of the BPF program |
 | `program_type` | Type of the BPF program |
 | `attach_type` | Attach type of the BPF program |
 | `helpers` | List of helpers used by the BPF program |

--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -94,6 +94,10 @@
           "type": "string",
           "description": "Name of the BPF program"
         },
+        "tag": {
+          "type": "string",
+          "description": "Hash (sha1) of the BPF program"
+        },
         "program_type": {
           "type": "string",
           "description": "Type of the BPF program"

--- a/docs/cloud-workload-security/secl.json
+++ b/docs/cloud-workload-security/secl.json
@@ -472,6 +472,11 @@
           "definition": "BPF command name"
         },
         {
+          "name": "bpf.map.name",
+          "type": "string",
+          "definition": "Name of the eBPF map (added in 7.34)"
+        },
+        {
           "name": "bpf.map.type",
           "type": "int",
           "definition": "Type of the eBPF map"
@@ -480,6 +485,16 @@
           "name": "bpf.prog.attach_type",
           "type": "int",
           "definition": "Attach type of the eBPF program"
+        },
+        {
+          "name": "bpf.prog.helpers",
+          "type": "int",
+          "definition": "eBPF helpers used by the eBPF program (added in 7.34)"
+        },
+        {
+          "name": "bpf.prog.name",
+          "type": "string",
+          "definition": "Name of the eBPF program (added in 7.34)"
         },
         {
           "name": "bpf.prog.type",

--- a/docs/cloud-workload-security/secl.json
+++ b/docs/cloud-workload-security/secl.json
@@ -474,7 +474,7 @@
         {
           "name": "bpf.map.name",
           "type": "string",
-          "definition": "Name of the eBPF map (added in 7.34)"
+          "definition": "Name of the eBPF map (added in 7.35)"
         },
         {
           "name": "bpf.map.type",
@@ -489,12 +489,17 @@
         {
           "name": "bpf.prog.helpers",
           "type": "int",
-          "definition": "eBPF helpers used by the eBPF program (added in 7.34)"
+          "definition": "eBPF helpers used by the eBPF program (added in 7.35)"
         },
         {
           "name": "bpf.prog.name",
           "type": "string",
-          "definition": "Name of the eBPF program (added in 7.34)"
+          "definition": "Name of the eBPF program (added in 7.35)"
+        },
+        {
+          "name": "bpf.prog.tag",
+          "type": "string",
+          "definition": "Hash (sha1) of the eBPF program (added in 7.35)"
         },
         {
           "name": "bpf.prog.type",

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "bf87900f9a2eb9142f5811c7da32d46ee1c852895af3e045083ab1cf405ed041")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "411ac02839d2655966879acad8f1b0ae6a4f38069e889f15f31d1c5a722821ed")

--- a/pkg/security/ebpf/c/bpf.h
+++ b/pkg/security/ebpf/c/bpf.h
@@ -10,6 +10,54 @@ u64 __attribute__((always_inline)) get_check_helper_call_input(void) {
     return input;
 }
 
+u64 __attribute__((always_inline)) get_bpf_map_id_offset(void) {
+    u64 bpf_map_id_offset;
+    LOAD_CONSTANT("bpf_map_id_offset", bpf_map_id_offset);
+    return bpf_map_id_offset;
+}
+
+u64 __attribute__((always_inline)) get_bpf_map_name_offset(void) {
+    u64 bpf_map_name_offset;
+    LOAD_CONSTANT("bpf_map_name_offset", bpf_map_name_offset);
+    return bpf_map_name_offset;
+}
+
+u64 __attribute__((always_inline)) get_bpf_map_type_offset(void) {
+    u64 bpf_map_type_offset;
+    LOAD_CONSTANT("bpf_map_type_offset", bpf_map_type_offset);
+    return bpf_map_type_offset;
+}
+
+u64 __attribute__((always_inline)) get_bpf_prog_aux_offset(void) {
+    u64 bpf_prog_aux_offset;
+    LOAD_CONSTANT("bpf_prog_aux_offset", bpf_prog_aux_offset);
+    return bpf_prog_aux_offset;
+}
+
+u64 __attribute__((always_inline)) get_bpf_prog_aux_id_offset(void) {
+    u64 bpf_prog_aux_id_offset;
+    LOAD_CONSTANT("bpf_prog_aux_id_offset", bpf_prog_aux_id_offset);
+    return bpf_prog_aux_id_offset;
+}
+
+u64 __attribute__((always_inline)) get_bpf_prog_type_offset(void) {
+    u64 bpf_prog_type_offset;
+    LOAD_CONSTANT("bpf_prog_type_offset", bpf_prog_type_offset);
+    return bpf_prog_type_offset;
+}
+
+u64 __attribute__((always_inline)) get_bpf_prog_attach_type_offset(void) {
+    u64 bpf_prog_attach_type_offset;
+    LOAD_CONSTANT("bpf_prog_attach_type_offset", bpf_prog_attach_type_offset);
+    return bpf_prog_attach_type_offset;
+}
+
+u64 __attribute__((always_inline)) get_bpf_prog_aux_name_offset(void) {
+    u64 bpf_prog_aux_name_offset;
+    LOAD_CONSTANT("bpf_prog_aux_name_offset", bpf_prog_aux_name_offset);
+    return bpf_prog_aux_name_offset;
+}
+
 struct bpf_map_t {
     u32 id;
     enum bpf_map_type map_type;
@@ -316,9 +364,9 @@ int kprobe_security_bpf_map(struct pt_regs *ctx) {
 
     // collect relevant map metadata
     struct bpf_map_t m = {};
-    bpf_probe_read(&m.id, sizeof(m.id), &map->id);
-    bpf_probe_read(&m.name, sizeof(m.name), &map->name);
-    bpf_probe_read(&m.map_type, sizeof(m.map_type), &map->map_type);
+    bpf_probe_read(&m.id, sizeof(m.id), (void *)map + get_bpf_map_id_offset());
+    bpf_probe_read(&m.name, sizeof(m.name), (void *)map + get_bpf_map_name_offset());
+    bpf_probe_read(&m.map_type, sizeof(m.map_type), (void *)map + get_bpf_map_type_offset());
 
     // save map metadata
     bpf_map_update_elem(&bpf_maps, &m.id, &m, BPF_ANY);
@@ -336,14 +384,14 @@ int kprobe_security_bpf_prog(struct pt_regs *ctx) {
 
     struct bpf_prog *prog = (struct bpf_prog *)PT_REGS_PARM1(ctx);
     struct bpf_prog_aux *prog_aux = 0;
-    bpf_probe_read(&prog_aux, sizeof(prog_aux), &prog->aux);
+    bpf_probe_read(&prog_aux, sizeof(prog_aux), (void *)prog + get_bpf_prog_aux_offset());
 
     // collect relevant prog metadata
     struct bpf_prog_t p = {};
-    bpf_probe_read(&p.id, sizeof(p.id), &prog_aux->id);
-    bpf_probe_read(&p.prog_type, sizeof(p.prog_type), &prog->type);
-    bpf_probe_read(&p.attach_type, sizeof(p.attach_type), &prog->expected_attach_type);
-    bpf_probe_read(&p.name, sizeof(p.name), &prog_aux->name);
+    bpf_probe_read(&p.id, sizeof(p.id), (void *)prog_aux + get_bpf_prog_aux_id_offset());
+    bpf_probe_read(&p.prog_type, sizeof(p.prog_type), (void *)prog + get_bpf_prog_type_offset());
+    bpf_probe_read(&p.attach_type, sizeof(p.attach_type), (void *)prog + get_bpf_prog_attach_type_offset());
+    bpf_probe_read(&p.name, sizeof(p.name), (void *)prog_aux + get_bpf_prog_aux_name_offset());
 
     // update context
     syscall->bpf.prog_id = p.id;

--- a/pkg/security/ebpf/kernel/kernel.go
+++ b/pkg/security/ebpf/kernel/kernel.go
@@ -33,6 +33,8 @@ var (
 	Kernel4_15 = kernel.VersionCode(4, 15, 0) //nolint:deadcode,unused
 	// Kernel4_16 is the KernelVersion representation of kernel version 4.16
 	Kernel4_16 = kernel.VersionCode(4, 16, 0) //nolint:deadcode,unused
+	// Kernel4_18 is the KernelVersion representation of kernel version 4.18
+	Kernel4_18 = kernel.VersionCode(4, 18, 0) //nolint:deadcode,unused
 	// Kernel4_19 is the KernelVersion representation of kernel version 4.19
 	Kernel4_19 = kernel.VersionCode(4, 19, 0) //nolint:deadcode,unused
 	// Kernel4_20 is the KernelVersion representation of kernel version 4.20

--- a/pkg/security/probe/accessors.go
+++ b/pkg/security/probe/accessors.go
@@ -90,6 +90,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "bpf.map.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).BPF.Map.Name
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "bpf.map.type":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -105,6 +115,41 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).BPF.Program.AttachType)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "bpf.prog.helpers":
+		return &eval.IntArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []int {
+
+				result := make([]int, len((*Event)(ctx.Object).ResolveHelpers(&(*Event)(ctx.Object).BPF.Program)))
+				for i, v := range (*Event)(ctx.Object).ResolveHelpers(&(*Event)(ctx.Object).BPF.Program) {
+					result[i] = int(v)
+				}
+				return result
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "bpf.prog.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).BPF.Program.Name
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "bpf.prog.tag":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).BPF.Program.Tag
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -6699,9 +6744,17 @@ func (e *Event) GetFields() []eval.Field {
 
 		"bpf.cmd",
 
+		"bpf.map.name",
+
 		"bpf.map.type",
 
 		"bpf.prog.attach_type",
+
+		"bpf.prog.helpers",
+
+		"bpf.prog.name",
+
+		"bpf.prog.tag",
 
 		"bpf.prog.type",
 
@@ -7654,6 +7707,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.BPF.Cmd), nil
 
+	case "bpf.map.name":
+
+		return e.BPF.Map.Name, nil
+
 	case "bpf.map.type":
 
 		return int(e.BPF.Map.Type), nil
@@ -7661,6 +7718,22 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "bpf.prog.attach_type":
 
 		return int(e.BPF.Program.AttachType), nil
+
+	case "bpf.prog.helpers":
+
+		result := make([]int, len(e.ResolveHelpers(&e.BPF.Program)))
+		for i, v := range e.ResolveHelpers(&e.BPF.Program) {
+			result[i] = int(v)
+		}
+		return result, nil
+
+	case "bpf.prog.name":
+
+		return e.BPF.Program.Name, nil
+
+	case "bpf.prog.tag":
+
+		return e.BPF.Program.Tag, nil
 
 	case "bpf.prog.type":
 
@@ -11141,10 +11214,22 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "bpf.cmd":
 		return "bpf", nil
 
+	case "bpf.map.name":
+		return "bpf", nil
+
 	case "bpf.map.type":
 		return "bpf", nil
 
 	case "bpf.prog.attach_type":
+		return "bpf", nil
+
+	case "bpf.prog.helpers":
+		return "bpf", nil
+
+	case "bpf.prog.name":
+		return "bpf", nil
+
+	case "bpf.prog.tag":
 		return "bpf", nil
 
 	case "bpf.prog.type":
@@ -12572,6 +12657,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "bpf.map.name":
+
+		return reflect.String, nil
+
 	case "bpf.map.type":
 
 		return reflect.Int, nil
@@ -12579,6 +12668,18 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "bpf.prog.attach_type":
 
 		return reflect.Int, nil
+
+	case "bpf.prog.helpers":
+
+		return reflect.Int, nil
+
+	case "bpf.prog.name":
+
+		return reflect.String, nil
+
+	case "bpf.prog.tag":
+
+		return reflect.String, nil
 
 	case "bpf.prog.type":
 
@@ -14483,6 +14584,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "bpf.map.name":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BPF.Map.Name"}
+		}
+		e.BPF.Map.Name = str
+
+		return nil
+
 	case "bpf.map.type":
 
 		var ok bool
@@ -14502,6 +14614,39 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "BPF.Program.AttachType"}
 		}
 		e.BPF.Program.AttachType = uint32(v)
+
+		return nil
+
+	case "bpf.prog.helpers":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BPF.Program.Helpers"}
+		}
+		e.BPF.Program.Helpers = append(e.BPF.Program.Helpers, uint32(v))
+
+		return nil
+
+	case "bpf.prog.name":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BPF.Program.Name"}
+		}
+		e.BPF.Program.Name = str
+
+		return nil
+
+	case "bpf.prog.tag":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BPF.Program.Tag"}
+		}
+		e.BPF.Program.Tag = str
 
 		return nil
 

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -50,6 +50,8 @@ func (f *FallbackConstantFetcher) appendRequest(id string) {
 		value = getBpfMapTypeOffset(f.kernelVersion)
 	case "bpf_prog_aux_offset":
 		value = getBpfProgAuxOffset(f.kernelVersion)
+	case "bpf_prog_tag_offset":
+		value = getBpfProgTagOffset(f.kernelVersion)
 	case "bpf_prog_type_offset":
 		value = getBpfProgTypeOffset(f.kernelVersion)
 	case "bpf_prog_attach_type_offset":
@@ -208,7 +210,16 @@ func getBpfMapIDOffset(kv *kernel.Version) uint64 {
 }
 
 func getBpfMapNameOffset(kv *kernel.Version) uint64 {
-	return uint64(168)
+	nameOffset := uint64(168)
+
+	switch {
+	case kv.IsRH7Kernel():
+		nameOffset = 112
+	case kv.IsRH8Kernel():
+		nameOffset = 80
+	}
+
+	return nameOffset
 }
 
 func getBpfMapTypeOffset(kv *kernel.Version) uint64 {
@@ -217,6 +228,10 @@ func getBpfMapTypeOffset(kv *kernel.Version) uint64 {
 
 func getBpfProgAuxOffset(kv *kernel.Version) uint64 {
 	return uint64(32)
+}
+
+func getBpfProgTagOffset(kv *kernel.Version) uint64 {
+	return uint64(20)
 }
 
 func getBpfProgTypeOffset(kv *kernel.Version) uint64 {
@@ -228,9 +243,27 @@ func getBpfProgAttachTypeOffset(kv *kernel.Version) uint64 {
 }
 
 func getBpfProgAuxIDOffset(kv *kernel.Version) uint64 {
-	return uint64(24)
+	idOffset := uint64(24)
+
+	switch {
+	case kv.IsRH7Kernel():
+		idOffset = 8
+	case kv.IsRH8Kernel():
+		idOffset = 32
+	}
+
+	return idOffset
 }
 
 func getBpfProgAuxNameOffset(kv *kernel.Version) uint64 {
-	return uint64(176)
+	nameOffset := uint64(176)
+
+	switch {
+	case kv.IsRH7Kernel():
+		nameOffset = 144
+	case kv.IsRH8Kernel():
+		nameOffset = 528
+	}
+
+	return nameOffset
 }

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -42,6 +42,22 @@ func (f *FallbackConstantFetcher) appendRequest(id string) {
 		value = getTTYNameOffset(f.kernelVersion)
 	case "creds_uid_offset":
 		value = getCredsUIDOffset(f.kernelVersion)
+	case "bpf_map_id_offset":
+		value = getBpfMapIDOffset(f.kernelVersion)
+	case "bpf_map_name_offset":
+		value = getBpfMapNameOffset(f.kernelVersion)
+	case "bpf_map_type_offset":
+		value = getBpfMapTypeOffset(f.kernelVersion)
+	case "bpf_prog_aux_offset":
+		value = getBpfProgAuxOffset(f.kernelVersion)
+	case "bpf_prog_type_offset":
+		value = getBpfProgTypeOffset(f.kernelVersion)
+	case "bpf_prog_attach_type_offset":
+		value = getBpfProgAttachTypeOffset(f.kernelVersion)
+	case "bpf_prog_aux_id_offset":
+		value = getBpfProgAuxIDOffset(f.kernelVersion)
+	case "bpf_prog_aux_name_offset":
+		value = getBpfProgAuxNameOffset(f.kernelVersion)
 	}
 	f.res[id] = value
 }
@@ -185,4 +201,36 @@ func getCredsUIDOffset(kv *kernel.Version) uint64 {
 	}
 
 	return size
+}
+
+func getBpfMapIDOffset(kv *kernel.Version) uint64 {
+	return uint64(48)
+}
+
+func getBpfMapNameOffset(kv *kernel.Version) uint64 {
+	return uint64(168)
+}
+
+func getBpfMapTypeOffset(kv *kernel.Version) uint64 {
+	return uint64(24)
+}
+
+func getBpfProgAuxOffset(kv *kernel.Version) uint64 {
+	return uint64(32)
+}
+
+func getBpfProgTypeOffset(kv *kernel.Version) uint64 {
+	return uint64(4)
+}
+
+func getBpfProgAttachTypeOffset(kv *kernel.Version) uint64 {
+	return uint64(8)
+}
+
+func getBpfProgAuxIDOffset(kv *kernel.Version) uint64 {
+	return uint64(24)
+}
+
+func getBpfProgAuxNameOffset(kv *kernel.Version) uint64 {
+	return uint64(176)
 }

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -217,6 +217,27 @@ func getBpfMapNameOffset(kv *kernel.Version) uint64 {
 		nameOffset = 112
 	case kv.IsRH8Kernel():
 		nameOffset = 80
+	case kv.IsSLES15Kernel():
+		nameOffset = 88
+	case kv.IsSLES12Kernel():
+		nameOffset = 176
+
+	case kv.IsInRangeCloseOpen(kernel.Kernel4_18, kernel.Kernel5_1):
+		nameOffset = 176
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_1, kernel.Kernel5_3):
+		nameOffset = 200
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_3, kernel.Kernel5_5):
+		if kv.IsOracleUEKKernel() {
+			nameOffset = 200
+		} else {
+			nameOffset = 168
+		}
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_5, kernel.Kernel5_11):
+		nameOffset = 88
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_11, kernel.Kernel5_13):
+		nameOffset = 80
+	case kv.Code != 0 && kv.Code >= kernel.Kernel5_13:
+		nameOffset = 80
 	}
 
 	return nameOffset
@@ -227,7 +248,14 @@ func getBpfMapTypeOffset(kv *kernel.Version) uint64 {
 }
 
 func getBpfProgAuxOffset(kv *kernel.Version) uint64 {
-	return uint64(32)
+	auxOffset := uint64(32)
+
+	switch {
+	case kv.Code != 0 && kv.Code >= kernel.Kernel5_13:
+		auxOffset = 56
+	}
+
+	return auxOffset
 }
 
 func getBpfProgTagOffset(kv *kernel.Version) uint64 {
@@ -250,6 +278,21 @@ func getBpfProgAuxIDOffset(kv *kernel.Version) uint64 {
 		idOffset = 8
 	case kv.IsRH8Kernel():
 		idOffset = 32
+	case kv.IsSLES15Kernel():
+		idOffset = 28
+	case kv.IsSLES12Kernel():
+		idOffset = 16
+
+	case kv.IsInRangeCloseOpen(kernel.Kernel4_18, kernel.Kernel5_0):
+		idOffset = 16
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_0, kernel.Kernel5_4):
+		idOffset = 20
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_4, kernel.Kernel5_8):
+		idOffset = 24
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_8, kernel.Kernel5_13):
+		idOffset = 28
+	case kv.Code != 0 && kv.Code >= kernel.Kernel5_13:
+		idOffset = 32
 	}
 
 	return idOffset
@@ -262,6 +305,25 @@ func getBpfProgAuxNameOffset(kv *kernel.Version) uint64 {
 	case kv.IsRH7Kernel():
 		nameOffset = 144
 	case kv.IsRH8Kernel():
+		nameOffset = 528
+	case kv.IsSLES15Kernel():
+		nameOffset = 256
+	case kv.IsSLES12Kernel():
+		nameOffset = 160
+
+	case kv.IsInRangeCloseOpen(kernel.Kernel4_18, kernel.Kernel4_19):
+		nameOffset = 152
+	case kv.IsInRangeCloseOpen(kernel.Kernel4_19, kernel.Kernel5_0):
+		nameOffset = 160
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_0, kernel.Kernel5_8):
+		nameOffset = 176
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_8, kernel.Kernel5_10):
+		nameOffset = 416
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_10, kernel.Kernel5_11):
+		nameOffset = 496
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_11, kernel.Kernel5_13):
+		nameOffset = 504
+	case kv.Code != 0 && kv.Code >= kernel.Kernel5_13:
 		nameOffset = 528
 	}
 

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1071,5 +1071,14 @@ func GetOffsetConstantsFromFetcher(constantFetcher constantfetch.ConstantFetcher
 	constantFetcher.AppendOffsetofRequest("tty_offset", "struct signal_struct", "tty", "linux/sched/signal.h")
 	constantFetcher.AppendOffsetofRequest("tty_name_offset", "struct tty_struct", "name", "linux/tty.h")
 	constantFetcher.AppendOffsetofRequest("creds_uid_offset", "struct cred", "uid", "linux/cred.h")
+	// bpf offsets
+	constantFetcher.AppendOffsetofRequest("bpf_map_id_offset", "struct bpf_map", "id", "linux/bpf.h")
+	constantFetcher.AppendOffsetofRequest("bpf_map_name_offset", "struct bpf_map", "name", "linux/bpf.h")
+	constantFetcher.AppendOffsetofRequest("bpf_map_type_offset", "struct bpf_map", "map_type", "linux/bpf.h")
+	constantFetcher.AppendOffsetofRequest("bpf_prog_aux_id_offset", "struct bpf_prog_aux", "id", "linux/bpf.h")
+	constantFetcher.AppendOffsetofRequest("bpf_prog_aux_name_offset", "struct bpf_prog_aux", "name", "linux/bpf.h")
+	constantFetcher.AppendOffsetofRequest("bpf_prog_aux_offset", "struct bpf_prog", "aux", "linux/filter.h")
+	constantFetcher.AppendOffsetofRequest("bpf_prog_type_offset", "struct bpf_prog", "type", "linux/filter.h")
+	constantFetcher.AppendOffsetofRequest("bpf_prog_attach_type_offset", "struct bpf_prog", "expected_attach_type", "linux/filter.h")
 	return constantFetcher.FinishAndGetResults()
 }

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1061,11 +1061,11 @@ func (p *Probe) ensureConfigDefaults() {
 // GetOffsetConstants returns the offsets and struct sizes constants
 func GetOffsetConstants(config *config.Config, probe *Probe) (map[string]uint64, error) {
 	constantFetcher := constantfetch.ComposeConstantFetchers(constantfetch.GetAvailableConstantFetchers(config, probe.kernelVersion, probe.statsdClient))
-	return GetOffsetConstantsFromFetcher(constantFetcher)
+	return GetOffsetConstantsFromFetcher(constantFetcher, probe)
 }
 
 // GetOffsetConstantsFromFetcher returns the offsets and struct sizes constants, from a constant fetcher
-func GetOffsetConstantsFromFetcher(constantFetcher constantfetch.ConstantFetcher) (map[string]uint64, error) {
+func GetOffsetConstantsFromFetcher(constantFetcher constantfetch.ConstantFetcher, probe *Probe) (map[string]uint64, error) {
 	constantFetcher.AppendSizeofRequest("sizeof_inode", "struct inode", "linux/fs.h")
 	constantFetcher.AppendOffsetofRequest("sb_magic_offset", "struct super_block", "s_magic", "linux/fs.h")
 	constantFetcher.AppendOffsetofRequest("tty_offset", "struct signal_struct", "tty", "linux/sched/signal.h")
@@ -1077,8 +1077,12 @@ func GetOffsetConstantsFromFetcher(constantFetcher constantfetch.ConstantFetcher
 	constantFetcher.AppendOffsetofRequest("bpf_map_type_offset", "struct bpf_map", "map_type", "linux/bpf.h")
 	constantFetcher.AppendOffsetofRequest("bpf_prog_aux_id_offset", "struct bpf_prog_aux", "id", "linux/bpf.h")
 	constantFetcher.AppendOffsetofRequest("bpf_prog_aux_name_offset", "struct bpf_prog_aux", "name", "linux/bpf.h")
+	constantFetcher.AppendOffsetofRequest("bpf_prog_tag_offset", "struct bpf_prog", "tag", "linux/filter.h")
 	constantFetcher.AppendOffsetofRequest("bpf_prog_aux_offset", "struct bpf_prog", "aux", "linux/filter.h")
 	constantFetcher.AppendOffsetofRequest("bpf_prog_type_offset", "struct bpf_prog", "type", "linux/filter.h")
-	constantFetcher.AppendOffsetofRequest("bpf_prog_attach_type_offset", "struct bpf_prog", "expected_attach_type", "linux/filter.h")
+
+	if probe.kernelVersion.Code != 0 && probe.kernelVersion.Code > kernel.Kernel4_16 {
+		constantFetcher.AppendOffsetofRequest("bpf_prog_attach_type_offset", "struct bpf_prog", "expected_attach_type", "linux/filter.h")
+	}
 	return constantFetcher.FinishAndGetResults()
 }

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1081,7 +1081,7 @@ func GetOffsetConstantsFromFetcher(constantFetcher constantfetch.ConstantFetcher
 	constantFetcher.AppendOffsetofRequest("bpf_prog_aux_offset", "struct bpf_prog", "aux", "linux/filter.h")
 	constantFetcher.AppendOffsetofRequest("bpf_prog_type_offset", "struct bpf_prog", "type", "linux/filter.h")
 
-	if probe.kernelVersion.Code != 0 && probe.kernelVersion.Code > kernel.Kernel4_16 {
+	if probe.kernelVersion.Code != 0 && (probe.kernelVersion.Code > kernel.Kernel4_16 || probe.kernelVersion.IsSLES12Kernel() || probe.kernelVersion.IsSLES15Kernel()) {
 		constantFetcher.AppendOffsetofRequest("bpf_prog_attach_type_offset", "struct bpf_prog", "expected_attach_type", "linux/filter.h")
 	}
 	return constantFetcher.FinishAndGetResults()

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -203,6 +203,7 @@ type BPFMapSerializer struct {
 // easyjson:json
 type BPFProgramSerializer struct {
 	Name        string   `json:"name,omitempty" jsonschema_description:"Name of the BPF program"`
+	Tag         string   `json:"tag,omitempty" jsonschema_description:"Hash (sha1) of the BPF program"`
 	ProgramType string   `json:"program_type,omitempty" jsonschema_description:"Type of the BPF program"`
 	AttachType  string   `json:"attach_type,omitempty" jsonschema_description:"Attach type of the BPF program"`
 	Helpers     []string `json:"helpers,omitempty" jsonschema_description:"List of helpers used by the BPF program"`
@@ -500,6 +501,7 @@ func newBPFProgramSerializer(e *Event) *BPFProgramSerializer {
 
 	return &BPFProgramSerializer{
 		Name:        e.BPF.Program.Name,
+		Tag:         e.BPF.Program.Tag,
 		ProgramType: model.BPFProgramType(e.BPF.Program.Type).String(),
 		AttachType:  model.BPFAttachType(e.BPF.Program.AttachType).String(),
 		Helpers:     model.StringifyHelpersList(e.BPF.Program.Helpers),

--- a/pkg/security/probe/serializers_easyjson.go
+++ b/pkg/security/probe/serializers_easyjson.go
@@ -7,10 +7,11 @@ package probe
 
 import (
 	json "encoding/json"
+	time "time"
+
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	jwriter "github.com/mailru/easyjson/jwriter"
-	time "time"
 )
 
 // suppress unused package warning
@@ -3167,6 +3168,8 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe21(in *jl
 		switch key {
 		case "name":
 			out.Name = string(in.String())
+		case "tag":
+			out.Tag = string(in.String())
 		case "program_type":
 			out.ProgramType = string(in.String())
 		case "attach_type":
@@ -3213,6 +3216,16 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe21(out *j
 		first = false
 		out.RawString(prefix[1:])
 		out.String(string(in.Name))
+	}
+	if in.Tag != "" {
+		const prefix string = ",\"tag\":"
+		if first {
+			first = false
+			out.RawString(prefix[1:])
+		} else {
+			out.RawString(prefix)
+		}
+		out.String(string(in.Tag))
 	}
 	if in.ProgramType != "" {
 		const prefix string = ",\"program_type\":"

--- a/pkg/security/probe/serializers_easyjson.go
+++ b/pkg/security/probe/serializers_easyjson.go
@@ -7,11 +7,10 @@ package probe
 
 import (
 	json "encoding/json"
-	time "time"
-
 	easyjson "github.com/mailru/easyjson"
 	jlexer "github.com/mailru/easyjson/jlexer"
 	jwriter "github.com/mailru/easyjson/jwriter"
+	time "time"
 )
 
 // suppress unused package warning

--- a/pkg/security/secl/model/accessors.go
+++ b/pkg/security/secl/model/accessors.go
@@ -86,6 +86,16 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			Weight: eval.FunctionWeight,
 		}, nil
 
+	case "bpf.map.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).BPF.Map.Name
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
 	case "bpf.map.type":
 		return &eval.IntEvaluator{
 			EvalFnc: func(ctx *eval.Context) int {
@@ -101,6 +111,41 @@ func (m *Model) GetEvaluator(field eval.Field, regID eval.RegisterID) (eval.Eval
 			EvalFnc: func(ctx *eval.Context) int {
 
 				return int((*Event)(ctx.Object).BPF.Program.AttachType)
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "bpf.prog.helpers":
+		return &eval.IntArrayEvaluator{
+
+			EvalFnc: func(ctx *eval.Context) []int {
+
+				result := make([]int, len((*Event)(ctx.Object).BPF.Program.Helpers))
+				for i, v := range (*Event)(ctx.Object).BPF.Program.Helpers {
+					result[i] = int(v)
+				}
+				return result
+			},
+			Field:  field,
+			Weight: eval.HandlerWeight,
+		}, nil
+
+	case "bpf.prog.name":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).BPF.Program.Name
+			},
+			Field:  field,
+			Weight: eval.FunctionWeight,
+		}, nil
+
+	case "bpf.prog.tag":
+		return &eval.StringEvaluator{
+			EvalFnc: func(ctx *eval.Context) string {
+
+				return (*Event)(ctx.Object).BPF.Program.Tag
 			},
 			Field:  field,
 			Weight: eval.FunctionWeight,
@@ -6167,9 +6212,17 @@ func (e *Event) GetFields() []eval.Field {
 
 		"bpf.cmd",
 
+		"bpf.map.name",
+
 		"bpf.map.type",
 
 		"bpf.prog.attach_type",
+
+		"bpf.prog.helpers",
+
+		"bpf.prog.name",
+
+		"bpf.prog.tag",
 
 		"bpf.prog.type",
 
@@ -7122,6 +7175,10 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 
 		return int(e.BPF.Cmd), nil
 
+	case "bpf.map.name":
+
+		return e.BPF.Map.Name, nil
+
 	case "bpf.map.type":
 
 		return int(e.BPF.Map.Type), nil
@@ -7129,6 +7186,22 @@ func (e *Event) GetFieldValue(field eval.Field) (interface{}, error) {
 	case "bpf.prog.attach_type":
 
 		return int(e.BPF.Program.AttachType), nil
+
+	case "bpf.prog.helpers":
+
+		result := make([]int, len(e.BPF.Program.Helpers))
+		for i, v := range e.BPF.Program.Helpers {
+			result[i] = int(v)
+		}
+		return result, nil
+
+	case "bpf.prog.name":
+
+		return e.BPF.Program.Name, nil
+
+	case "bpf.prog.tag":
+
+		return e.BPF.Program.Tag, nil
 
 	case "bpf.prog.type":
 
@@ -10609,10 +10682,22 @@ func (e *Event) GetFieldEventType(field eval.Field) (eval.EventType, error) {
 	case "bpf.cmd":
 		return "bpf", nil
 
+	case "bpf.map.name":
+		return "bpf", nil
+
 	case "bpf.map.type":
 		return "bpf", nil
 
 	case "bpf.prog.attach_type":
+		return "bpf", nil
+
+	case "bpf.prog.helpers":
+		return "bpf", nil
+
+	case "bpf.prog.name":
+		return "bpf", nil
+
+	case "bpf.prog.tag":
 		return "bpf", nil
 
 	case "bpf.prog.type":
@@ -12040,6 +12125,10 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 
 		return reflect.Int, nil
 
+	case "bpf.map.name":
+
+		return reflect.String, nil
+
 	case "bpf.map.type":
 
 		return reflect.Int, nil
@@ -12047,6 +12136,18 @@ func (e *Event) GetFieldType(field eval.Field) (reflect.Kind, error) {
 	case "bpf.prog.attach_type":
 
 		return reflect.Int, nil
+
+	case "bpf.prog.helpers":
+
+		return reflect.Int, nil
+
+	case "bpf.prog.name":
+
+		return reflect.String, nil
+
+	case "bpf.prog.tag":
+
+		return reflect.String, nil
 
 	case "bpf.prog.type":
 
@@ -13951,6 +14052,17 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 
 		return nil
 
+	case "bpf.map.name":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BPF.Map.Name"}
+		}
+		e.BPF.Map.Name = str
+
+		return nil
+
 	case "bpf.map.type":
 
 		var ok bool
@@ -13970,6 +14082,39 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 			return &eval.ErrValueTypeMismatch{Field: "BPF.Program.AttachType"}
 		}
 		e.BPF.Program.AttachType = uint32(v)
+
+		return nil
+
+	case "bpf.prog.helpers":
+
+		var ok bool
+		v, ok := value.(int)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BPF.Program.Helpers"}
+		}
+		e.BPF.Program.Helpers = append(e.BPF.Program.Helpers, uint32(v))
+
+		return nil
+
+	case "bpf.prog.name":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BPF.Program.Name"}
+		}
+		e.BPF.Program.Name = str
+
+		return nil
+
+	case "bpf.prog.tag":
+
+		var ok bool
+		str, ok := value.(string)
+		if !ok {
+			return &eval.ErrValueTypeMismatch{Field: "BPF.Program.Tag"}
+		}
+		e.BPF.Program.Tag = str
 
 		return nil
 

--- a/pkg/security/secl/model/consts_common.go
+++ b/pkg/security/secl/model/consts_common.go
@@ -23,6 +23,9 @@ const (
 	// MaxPathDepth defines the maximum depth of a path
 	MaxPathDepth = 1500
 
+	// MaxBpfObjName defines the maximum length of a Bpf object name
+	MaxBpfObjName = 16
+
 	// PathSuffix defines the suffix used for path fields
 	PathSuffix = ".path"
 

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -85,6 +85,12 @@ func (m *Model) ValidateField(field eval.Field, fieldValue eval.FieldValue) erro
 		if value := fieldValue.Value; value != -int(syscall.EPERM) && value != -int(syscall.EACCES) {
 			return errors.New("return value can only be tested against EPERM or EACCES")
 		}
+	case "bpf.map.name", "bpf.prog.name":
+		if value, ok := fieldValue.Value.(string); ok {
+			if len(value) > MaxBpfObjName {
+				return fmt.Errorf("the name provided in %s must be at most %d characters, len(\"%s\") = %d", field, MaxBpfObjName, value, len(value))
+			}
+		}
 	}
 
 	return nil
@@ -594,7 +600,7 @@ type BPFEvent struct {
 type BPFMap struct {
 	ID   uint32 `field:"-"`    // ID of the eBPF map
 	Type uint32 `field:"type"` // Type of the eBPF map
-	Name string `field:"name"` // Name of the eBPF map (added in 7.34)
+	Name string `field:"name"` // Name of the eBPF map (added in 7.35)
 }
 
 // BPFProgram represents a BPF program
@@ -602,8 +608,9 @@ type BPFProgram struct {
 	ID         uint32   `field:"-"`                      // ID of the eBPF program
 	Type       uint32   `field:"type"`                   // Type of the eBPF program
 	AttachType uint32   `field:"attach_type"`            // Attach type of the eBPF program
-	Helpers    []uint32 `field:"helpers,ResolveHelpers"` // eBPF helpers used by the eBPF program (added in 7.34)
-	Name       string   `field:"name"`                   // Name of the eBPF program (added in 7.34)
+	Helpers    []uint32 `field:"helpers,ResolveHelpers"` // eBPF helpers used by the eBPF program (added in 7.35)
+	Name       string   `field:"name"`                   // Name of the eBPF program (added in 7.35)
+	Tag        string   `field:"tag"`                    // Hash (sha1) of the eBPF program (added in 7.35)
 }
 
 // PTraceEvent represents a ptrace event

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -594,16 +594,16 @@ type BPFEvent struct {
 type BPFMap struct {
 	ID   uint32 `field:"-"`    // ID of the eBPF map
 	Type uint32 `field:"type"` // Type of the eBPF map
-	Name string `field:"-"`    // Name of the eBPF map
+	Name string `field:"name"` // Name of the eBPF map (added in 7.34)
 }
 
 // BPFProgram represents a BPF program
 type BPFProgram struct {
-	ID         uint32   `field:"-"`                // ID of the eBPF program
-	Type       uint32   `field:"type"`             // Type of the eBPF program
-	AttachType uint32   `field:"attach_type"`      // Attach type of the eBPF program
-	Helpers    []uint32 `field:"-,ResolveHelpers"` // eBPF helpers used by the eBPF program
-	Name       string   `field:"-"`                // Name of the eBPF program
+	ID         uint32   `field:"-"`                      // ID of the eBPF program
+	Type       uint32   `field:"type"`                   // Type of the eBPF program
+	AttachType uint32   `field:"attach_type"`            // Attach type of the eBPF program
+	Helpers    []uint32 `field:"helpers,ResolveHelpers"` // eBPF helpers used by the eBPF program (added in 7.34)
+	Name       string   `field:"name"`                   // Name of the eBPF program (added in 7.34)
 }
 
 // PTraceEvent represents a ptrace event

--- a/pkg/security/secl/model/unmarshallers.go
+++ b/pkg/security/secl/model/unmarshallers.go
@@ -6,6 +6,7 @@
 package model
 
 import (
+	"fmt"
 	"time"
 	"unsafe"
 )
@@ -568,9 +569,8 @@ func (p *BPFProgram) UnmarshalBinary(data []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	p.Tag, err = UnmarshalString(data[56:64], 8)
-	if err != nil {
-		return 0, err
+	for _, b := range data[56:64] {
+		p.Tag += fmt.Sprintf("%x", b)
 	}
 	return 64, nil
 }

--- a/pkg/security/secl/model/unmarshallers.go
+++ b/pkg/security/secl/model/unmarshallers.go
@@ -550,7 +550,7 @@ func (m *BPFMap) UnmarshalBinary(data []byte) (int, error) {
 
 // UnmarshalBinary unmarshalls a binary representation of itself
 func (p *BPFProgram) UnmarshalBinary(data []byte) (int, error) {
-	if len(data) < 56 {
+	if len(data) < 64 {
 		return 0, ErrNotEnoughData
 	}
 	p.ID = ByteOrder.Uint32(data[0:4])
@@ -568,7 +568,11 @@ func (p *BPFProgram) UnmarshalBinary(data []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	return 56, nil
+	p.Tag, err = UnmarshalString(data[56:64], 8)
+	if err != nil {
+		return 0, err
+	}
+	return 64, nil
 }
 
 func parseHelpers(helpers []uint64) []uint32 {

--- a/pkg/security/tests/bpf_test.go
+++ b/pkg/security/tests/bpf_test.go
@@ -22,11 +22,11 @@ func TestBPFEventLoad(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_prog_load",
-			Expression: `bpf.cmd == BPF_PROG_LOAD && process.file.name == "syscall_go_tester"`,
+			Expression: `bpf.cmd == BPF_PROG_LOAD && bpf.prog.name == "kprobe_vfs_open" && process.file.name == "syscall_go_tester"`,
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs, testOpts{enableRuntimeCompiledConstants: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -55,11 +55,11 @@ func TestBPFEventMap(t *testing.T) {
 	ruleDefs := []*rules.RuleDefinition{
 		{
 			ID:         "test_map_create",
-			Expression: `bpf.cmd == BPF_MAP_CREATE && process.file.name == "syscall_go_tester"`,
+			Expression: `bpf.cmd == BPF_MAP_CREATE && bpf.map.name == "cache" && process.file.name == "syscall_go_tester"`,
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
+	test, err := newTestModule(t, nil, ruleDefs, testOpts{enableRuntimeCompiledConstants: true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,9 +75,7 @@ func TestBPFEventMap(t *testing.T) {
 			return runSyscallTesterFunc(t, syscallTester, "-load-bpf", "-clone-bpf")
 		}, func(event *sprobe.Event, r *rules.Rule) {
 			assert.Equal(t, "bpf", event.GetType(), "wrong event type")
-
-			// TODO: the manager generate a map call, we need to the name available to select the right event
-			//assert.Equal(t, uint32(model.BpfMapTypeHash), event.BPF.Map.Type, "wrong map type")
+			assert.Equal(t, uint32(model.BpfMapTypeHash), event.BPF.Map.Type, "wrong map type")
 
 			if !validateBPFSchema(t, event) {
 				t.Error(event.String())

--- a/pkg/security/tests/bpf_test.go
+++ b/pkg/security/tests/bpf_test.go
@@ -26,7 +26,7 @@ func TestBPFEventLoad(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{enableRuntimeCompiledConstants: true})
+	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -59,7 +59,7 @@ func TestBPFEventMap(t *testing.T) {
 		},
 	}
 
-	test, err := newTestModule(t, nil, ruleDefs, testOpts{enableRuntimeCompiledConstants: true})
+	test, err := newTestModule(t, nil, ruleDefs, testOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/security/tests/constants_test.go
+++ b/pkg/security/tests/constants_test.go
@@ -33,12 +33,12 @@ func TestFallbackConstants(t *testing.T) {
 	fallbackFetcher := constantfetch.NewFallbackConstantFetcher(kv)
 	rcFetcher := constantfetch.NewRuntimeCompilationConstantFetcher(&config.Config, nil)
 
-	fallbackConstants, err := probe.GetOffsetConstantsFromFetcher(fallbackFetcher)
+	fallbackConstants, err := probe.GetOffsetConstantsFromFetcher(fallbackFetcher, test.probe)
 	if err != nil {
 		t.Error(err)
 	}
 
-	rcConstants, err := probe.GetOffsetConstantsFromFetcher(rcFetcher)
+	rcConstants, err := probe.GetOffsetConstantsFromFetcher(rcFetcher, test.probe)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -83,7 +83,6 @@ runtime_security_config:
 {{end}}
   erpc_dentry_resolution_enabled: {{ .ErpcDentryResolutionEnabled }}
   map_dentry_resolution_enabled: {{ .MapDentryResolutionEnabled }}
-  enable_runtime_compiled_constants: {{ .EnableRuntimeCompiledConstants }}
 
   policies:
     dir: {{.TestPoliciesDir}}
@@ -123,15 +122,14 @@ const (
 )
 
 type testOpts struct {
-	testDir                        string
-	disableFilters                 bool
-	disableApprovers               bool
-	disableDiscarders              bool
-	eventsCountThreshold           int
-	reuseProbeHandler              bool
-	disableERPCDentryResolution    bool
-	disableMapDentryResolution     bool
-	enableRuntimeCompiledConstants bool
+	testDir                     string
+	disableFilters              bool
+	disableApprovers            bool
+	disableDiscarders           bool
+	eventsCountThreshold        int
+	reuseProbeHandler           bool
+	disableERPCDentryResolution bool
+	disableMapDentryResolution  bool
 }
 
 func (s *stringSlice) String() string {
@@ -151,8 +149,7 @@ func (to testOpts) Equal(opts testOpts) bool {
 		to.eventsCountThreshold == opts.eventsCountThreshold &&
 		to.reuseProbeHandler == opts.reuseProbeHandler &&
 		to.disableERPCDentryResolution == opts.disableERPCDentryResolution &&
-		to.disableMapDentryResolution == opts.disableMapDentryResolution &&
-		to.enableRuntimeCompiledConstants == opts.enableRuntimeCompiledConstants
+		to.disableMapDentryResolution == opts.disableMapDentryResolution
 }
 
 type testModule struct {
@@ -366,13 +363,12 @@ func setTestConfig(dir string, opts testOpts) (string, error) {
 
 	buffer := new(bytes.Buffer)
 	if err := tmpl.Execute(buffer, map[string]interface{}{
-		"TestPoliciesDir":                dir,
-		"DisableApprovers":               opts.disableApprovers,
-		"EventsCountThreshold":           opts.eventsCountThreshold,
-		"ErpcDentryResolutionEnabled":    erpcDentryResolutionEnabled,
-		"MapDentryResolutionEnabled":     mapDentryResolutionEnabled,
-		"EnableRuntimeCompiledConstants": opts.enableRuntimeCompiledConstants,
-		"LogPatterns":                    logPatterns,
+		"TestPoliciesDir":             dir,
+		"DisableApprovers":            opts.disableApprovers,
+		"EventsCountThreshold":        opts.eventsCountThreshold,
+		"ErpcDentryResolutionEnabled": erpcDentryResolutionEnabled,
+		"MapDentryResolutionEnabled":  mapDentryResolutionEnabled,
+		"LogPatterns":                 logPatterns,
 	}); err != nil {
 		return "", err
 	}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -83,6 +83,7 @@ runtime_security_config:
 {{end}}
   erpc_dentry_resolution_enabled: {{ .ErpcDentryResolutionEnabled }}
   map_dentry_resolution_enabled: {{ .MapDentryResolutionEnabled }}
+  enable_runtime_compiled_constants: {{ .EnableRuntimeCompiledConstants }}
 
   policies:
     dir: {{.TestPoliciesDir}}
@@ -122,14 +123,15 @@ const (
 )
 
 type testOpts struct {
-	testDir                     string
-	disableFilters              bool
-	disableApprovers            bool
-	disableDiscarders           bool
-	eventsCountThreshold        int
-	reuseProbeHandler           bool
-	disableERPCDentryResolution bool
-	disableMapDentryResolution  bool
+	testDir                        string
+	disableFilters                 bool
+	disableApprovers               bool
+	disableDiscarders              bool
+	eventsCountThreshold           int
+	reuseProbeHandler              bool
+	disableERPCDentryResolution    bool
+	disableMapDentryResolution     bool
+	enableRuntimeCompiledConstants bool
 }
 
 func (s *stringSlice) String() string {
@@ -149,7 +151,8 @@ func (to testOpts) Equal(opts testOpts) bool {
 		to.eventsCountThreshold == opts.eventsCountThreshold &&
 		to.reuseProbeHandler == opts.reuseProbeHandler &&
 		to.disableERPCDentryResolution == opts.disableERPCDentryResolution &&
-		to.disableMapDentryResolution == opts.disableMapDentryResolution
+		to.disableMapDentryResolution == opts.disableMapDentryResolution &&
+		to.enableRuntimeCompiledConstants == opts.enableRuntimeCompiledConstants
 }
 
 type testModule struct {
@@ -363,12 +366,13 @@ func setTestConfig(dir string, opts testOpts) (string, error) {
 
 	buffer := new(bytes.Buffer)
 	if err := tmpl.Execute(buffer, map[string]interface{}{
-		"TestPoliciesDir":             dir,
-		"DisableApprovers":            opts.disableApprovers,
-		"EventsCountThreshold":        opts.eventsCountThreshold,
-		"ErpcDentryResolutionEnabled": erpcDentryResolutionEnabled,
-		"MapDentryResolutionEnabled":  mapDentryResolutionEnabled,
-		"LogPatterns":                 logPatterns,
+		"TestPoliciesDir":                dir,
+		"DisableApprovers":               opts.disableApprovers,
+		"EventsCountThreshold":           opts.eventsCountThreshold,
+		"ErpcDentryResolutionEnabled":    erpcDentryResolutionEnabled,
+		"MapDentryResolutionEnabled":     mapDentryResolutionEnabled,
+		"EnableRuntimeCompiledConstants": opts.enableRuntimeCompiledConstants,
+		"LogPatterns":                    logPatterns,
 	}); err != nil {
 		return "", err
 	}

--- a/pkg/security/tests/schemas/bpf.schema.json
+++ b/pkg/security/tests/schemas/bpf.schema.json
@@ -47,11 +47,15 @@
                             "type": "object",
                             "required": [
                                 "name",
+                                "tag",
                                 "program_type",
                                 "attach_type"
                             ],
                             "properties": {
                                 "name": {
+                                    "type": "string"
+                                },
+                                "tag": {
                                     "type": "string"
                                 },
                                 "program_type": {


### PR DESCRIPTION
### What does this PR do?

This PR introduces `bpf.prog.name`, `bpf.prog.helpers` and `bpf.map.name`. Those fields weren't initially introduced in the SECL syntax because of missing structure offsets. Now that we have runtime compilation, we can compute the offsets within those structures dynamically, or fallback to default values for the kernel versions and Linux distributions supported by CWS.

### Motivation

Improve the context of an existing event type.

### Describe how to test/QA your changes

Functional tests were added to make sure the new fields are correctly resolved for the kernel versions and Linux distribution supported by CWS.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
