### PR TITLE
[serverless] Fix data race in TellDaemonRuntimeDone

### DIFF
--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -75,7 +75,7 @@ type Daemon struct {
 
 	// TellDaemonRuntimeDoneOnce asserts that TellDaemonRuntimeDone will be called at most once per invocation (at the end of the function OR after a timeout)
 	// this should be reset before each invocation
-	TellDaemonRuntimeDoneOnce sync.Once
+	TellDaemonRuntimeDoneOnce *sync.Once
 
 	// metricsFlushMutex ensures that only one metrics flush can be underway at a given time
 	metricsFlushMutex sync.Mutex
@@ -328,7 +328,7 @@ func (d *Daemon) TellDaemonRuntimeStarted() {
 	// Reset the RuntimeWg on every new invocation.
 	// We might receive a new invocation before we learn that the previous invocation has finished.
 	d.RuntimeWg = &sync.WaitGroup{}
-	d.TellDaemonRuntimeDoneOnce = sync.Once{}
+	d.TellDaemonRuntimeDoneOnce = &sync.Once{}
 	d.RuntimeWg.Add(1)
 }
 

--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -73,8 +73,10 @@ type Daemon struct {
 
 	ExecutionContext *serverlessLog.ExecutionContext
 
-	// TellDaemonRuntimeDoneOnce asserts that TellDaemonRuntimeDone will be called at most once per invocation (at the end of the function OR after a timeout)
-	// this should be reset before each invocation
+	// TellDaemonRuntimeDoneOnce asserts that TellDaemonRuntimeDone will be called at most once per invocation (at the end of the function OR after a timeout).
+	// We store a pointer to a sync.Once, which should be reset to a new pointer at the beginning of each invocation.
+	// Note that overwriting the actual underlying sync.Once is not thread safe,
+	// so we must use a pointer here to create a new sync.Once without overwriting the old one when resetting.
 	TellDaemonRuntimeDoneOnce *sync.Once
 
 	// metricsFlushMutex ensures that only one metrics flush can be underway at a given time

--- a/pkg/serverless/daemon/daemon_test.go
+++ b/pkg/serverless/daemon/daemon_test.go
@@ -43,7 +43,7 @@ func TestTellDaemonRuntimeDoneOnceStartOnly(t *testing.T) {
 	defer d.Stop()
 
 	d.TellDaemonRuntimeStarted()
-	assert.Equal(uint64(0), GetValueSyncOnce(&d.TellDaemonRuntimeDoneOnce))
+	assert.Equal(uint64(0), GetValueSyncOnce(d.TellDaemonRuntimeDoneOnce))
 }
 
 func TestTellDaemonRuntimeDoneOnceStartAndEnd(t *testing.T) {
@@ -54,7 +54,7 @@ func TestTellDaemonRuntimeDoneOnceStartAndEnd(t *testing.T) {
 	d.TellDaemonRuntimeStarted()
 	d.TellDaemonRuntimeDone()
 
-	assert.Equal(uint64(1), GetValueSyncOnce(&d.TellDaemonRuntimeDoneOnce))
+	assert.Equal(uint64(1), GetValueSyncOnce(d.TellDaemonRuntimeDoneOnce))
 }
 
 func TestTellDaemonRuntimeDoneOnceStartAndEndAndTimeout(t *testing.T) {
@@ -66,7 +66,7 @@ func TestTellDaemonRuntimeDoneOnceStartAndEndAndTimeout(t *testing.T) {
 	d.TellDaemonRuntimeDone()
 	d.TellDaemonRuntimeDone()
 
-	assert.Equal(uint64(1), GetValueSyncOnce(&d.TellDaemonRuntimeDoneOnce))
+	assert.Equal(uint64(1), GetValueSyncOnce(d.TellDaemonRuntimeDoneOnce))
 }
 
 func TestSetTraceTagNoop(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Fix a data race bug that caused an [issue](https://github.com/DataDog/datadog-agent/issues/10401) with the Lambda Extension.

### Additional Information

We use a `sync.Once` to make sure that the function `TellDaemonRuntimeDone` is called at most once per invocation. We reset this `sync.Once` at the beginning of each invocation to enable this behavior.

The way we did this is incorrect.

[Internally](https://cs.opensource.google/go/go/+/refs/tags/go1.17.5:src/sync/once.go;l=65), `sync.Once` uses a mutex. Unlocking a mutex that is already unlocked causes a panic. When we reset the `Once`, we overwrote the old one. This creates a problem if there is currently a function call in flight using the `Once`. When that function call finishes, the `sync.Once` will unlock the mutex -- which was just overwritten with a new, unlocked mutex. Oops!

Minimal example of the issue: https://go.dev/play/p/5xJ-Pgt0DG5

The solution is to store a **pointer to a sync.Once**. That way, when we reset with a new pointer, the original sync.Once is not overwritten.

Minimal example of the solution: https://go.dev/play/p/Rk-uDsR6dZl

### Reviewer's Checklist
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
