### PR TITLE
[pipeline] Remove superfluous upgrade of pip and setuptools in jobs

### DIFF
--- a/.gitlab/source_test/golang_deps_generate.yml
+++ b/.gitlab/source_test/golang_deps_generate.yml
@@ -10,7 +10,6 @@ golang_deps_generate:
   needs: ["go_deps"]
   before_script:
     - !reference [.retrieve_linux_go_deps]
-    - python3 -m pip install --upgrade --ignore-installed pip setuptools
     - python3 -m pip install -r requirements.txt
   script:
     - inv agent.build-dep-tree

--- a/.gitlab/source_test/linux.yml
+++ b/.gitlab/source_test/linux.yml
@@ -129,7 +129,6 @@ go_mod_tidy_check:
   needs: ["go_deps"]
   before_script:
     - !reference [.retrieve_linux_go_deps]
-    - python3 -m pip install --upgrade --ignore-installed pip setuptools
     - python3 -m pip install -r requirements.txt
   script:
     - inv -e check-mod-tidy


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Removes `python3 -m pip install --upgrade --ignore-installed pip setuptools` lines in two jobs: `golang_deps_generate` and `go_mod_tidy_check`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This line shouldn't be needed, as `pip` and `setuptools` are already present in the build image, and is dangerous, as it installs whatever the latest is (which is currently causing issues).

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Run pipeline, check that `go_mod_tidy_check` succeeds (`golang_deps_generate` only runs on `main`).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
