### PR TITLE
fix: eks_fargate_node tag not added

### DIFF
--- a/pkg/tagger/collectors/workloadmeta_main.go
+++ b/pkg/tagger/collectors/workloadmeta_main.go
@@ -154,11 +154,10 @@ func fargateStaticTags(ctx context.Context) map[string]string {
 	if fargate.IsEKSFargateInstance() {
 		node, err := fargate.GetEKSFargateNodename()
 		if err != nil {
-			tags["eks_fargate_node"] = node
-		} else {
 			log.Infof("Couldn't build the 'eks_fargate_node' tag: %w", err)
+		} else {
+			tags["eks_fargate_node"] = node
 		}
-
 	}
 
 	return tags

--- a/pkg/tagger/collectors/workloadmeta_test.go
+++ b/pkg/tagger/collectors/workloadmeta_test.go
@@ -6,10 +6,12 @@
 package collectors
 
 import (
+	"context"
 	"fmt"
 	"sort"
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
@@ -1144,6 +1146,66 @@ func Test_mergeMaps(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			assert.EqualValues(t, tt.want, mergeMaps(tt.first, tt.second))
+		})
+	}
+}
+
+func TestFargateStaticTags(t *testing.T) {
+	mockConfig := config.Mock()
+	tests := []struct {
+		name        string
+		loadFunc    func()
+		cleanupFunc func()
+		want        map[string]string
+	}{
+		{
+			name: "dd tags",
+			loadFunc: func() {
+				mockConfig.Set("eks_fargate", true)
+				mockConfig.Set("tags", "dd_tag1:dd_val1 dd_tag2:dd_val2")
+			},
+			cleanupFunc: func() { mockConfig.Set("tags", "") },
+			want:        map[string]string{"dd_tag1": "dd_val1", "dd_tag2": "dd_val2"},
+		},
+		{
+			name: "eks fargate node",
+			loadFunc: func() {
+				mockConfig.Set("eks_fargate", true)
+				mockConfig.Set("kubernetes_kubelet_nodename", "fargate_node_name")
+			},
+			cleanupFunc: func() {
+				mockConfig.Set("eks_fargate", false)
+				mockConfig.Set("kubernetes_kubelet_nodename", "")
+			},
+			want: map[string]string{"eks_fargate_node": "fargate_node_name"},
+		},
+		{
+			name: "dd tags and eks fargate node",
+			loadFunc: func() {
+				mockConfig.Set("tags", "dd_tag1:dd_val1 dd_tag2:dd_val2")
+				mockConfig.Set("eks_fargate", true)
+				mockConfig.Set("kubernetes_kubelet_nodename", "fargate_node_name")
+			},
+			cleanupFunc: func() {
+				mockConfig.Set("tags", "")
+				mockConfig.Set("eks_fargate", false)
+				mockConfig.Set("kubernetes_kubelet_nodename", "")
+			},
+			want: map[string]string{"dd_tag1": "dd_val1", "dd_tag2": "dd_val2", "eks_fargate_node": "fargate_node_name"},
+		},
+		{
+			name:        "no tags",
+			loadFunc:    func() {},
+			cleanupFunc: func() {},
+			want:        nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.loadFunc()
+			defer tt.cleanupFunc()
+
+			assert.EqualValues(t, tt.want, fargateStaticTags(context.TODO()))
 		})
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix a regression that prevents adding the `eks_fargate_node` tag.

Context:
- The tag was introduced in 7.31 https://github.com/DataDog/datadog-agent/pull/8933
- Regression in 7.33 when the static collector was moved to workloadmeta collector https://github.com/DataDog/datadog-agent/commit/798d88213db3d89f2015521f478e3b28752459b8#diff-525be2c5c6fcf090a251de752ac8e504643d86acb97ced30546223d34f7e5eddR169-R175

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Deploy the agent on EKS Fargate as a sidecar, agent tagger-list should show the eks_fargate_node

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
