### PR TITLE
[CWS] build functional tests with DNF tag

### DIFF
--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -3,6 +3,10 @@
   - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/clang-$ARCH-11.0.1.tar.xz /tmp/clang.tar.xz
   - mkdir -p $DATADOG_AGENT_EMBEDDED_PATH
   - tar -xvf /tmp/clang.tar.xz -C $DATADOG_AGENT_EMBEDDED_PATH
+  # Retrieve nikos from S3
+  - $S3_CP_CMD $S3_PERMANENT_ARTIFACTS_URI/nikos-$ARCH.tar.gz /tmp/nikos.tar.gz
+  - mkdir -p $NIKOS_EMBEDDED_PATH
+  - tar -xf /tmp/nikos.tar.gz -C $NIKOS_EMBEDDED_PATH
 
 .build_sysprobe_artifacts:
   - inv -e system-probe.object-files

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -64,7 +64,7 @@ tests_ebpf_x64:
     - inv -e install-tools
     - export PATH=$PATH:$GOPATH/bin
     # Compile runtime security functional tests to be executed in kitchen tests
-    - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --build-flags "-race"
+    - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --build-flags "-race" --nikos-embedded-path=$NIKOS_EMBEDDED_PATH
     # Compile runtime security stress tests to be executed in kitchen tests
     - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
 
@@ -89,7 +89,7 @@ tests_ebpf_arm64:
     - inv -e install-tools
     - export PATH=$PATH:$GOPATH/bin
     # Compile runtime security functional tests to be executed in kitchen tests
-    - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --build-flags "-race"
+    - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --build-flags "-race" --nikos-embedded-path=$NIKOS_EMBEDDED_PATH
     # Compile runtime security stress tests to be executed in kitchen tests
     - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
 

--- a/.gitlab/source_test/ebpf.yml
+++ b/.gitlab/source_test/ebpf.yml
@@ -71,6 +71,8 @@ tests_ebpf_x64:
     - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --build-flags "-race" --nikos-embedded-path=$NIKOS_EMBEDDED_PATH
     # Compile runtime security stress tests to be executed in kitchen tests
     - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
+    # Copy nikos archive to be extracted in kitchen tests
+    - cp /tmp/nikos.tar.gz $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/nikos.tar.gz
 
 tests_ebpf_arm64:
   extends: .tests_linux_ebpf
@@ -96,6 +98,8 @@ tests_ebpf_arm64:
     - inv -e security-agent.build-functional-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/testsuite --build-flags "-race" --nikos-embedded-path=$NIKOS_EMBEDDED_PATH
     # Compile runtime security stress tests to be executed in kitchen tests
     - inv -e security-agent.build-stress-tests --output=$DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/stresssuite
+    # Copy nikos archive to be extracted in kitchen tests
+    - cp /tmp/nikos.tar.gz $DD_AGENT_TESTING_DIR/site-cookbooks/dd-security-agent-check/files/nikos.tar.gz
 
 tests_windows_sysprobe_x64:
   extends: .tests_windows_sysprobe

--- a/go.mod
+++ b/go.mod
@@ -75,7 +75,7 @@ require (
 	github.com/DataDog/gohai v0.0.0-20211126091652-d183ed971098
 	github.com/DataDog/gopsutil v0.0.0-20211112180027-9aa392ae181a
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect
-	github.com/DataDog/nikos v1.7.0
+	github.com/DataDog/nikos v1.7.1
 	github.com/DataDog/sketches-go v1.2.1
 	github.com/DataDog/viper v1.9.0
 	github.com/DataDog/watermarkpodautoscaler v0.3.1-logs-attributes.2.0.20211014120627-6d6a5c559fc9

--- a/go.sum
+++ b/go.sum
@@ -132,8 +132,8 @@ github.com/DataDog/kube-state-metrics/v2 v2.1.2-0.20211109105526-c17162ee2798/go
 github.com/DataDog/mmh3 v0.0.0-20200805151601-30884ca2197a/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 h1:EbzDX8HPk5uE2FsJYxD74QmMw0/3CqSKhEr6teh0ncQ=
 github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49/go.mod h1:SvsjzyJlSg0rKsqYgdcFxeEVflx3ZNAyFfkUHP0TxXg=
-github.com/DataDog/nikos v1.7.0 h1:n3i7WdhghFlIrUcLkKcT98YoGitjiBPZTo5S9vFNQIs=
-github.com/DataDog/nikos v1.7.0/go.mod h1:r20vNQr3wTDrMZWLjOZBCJNWeuTB/rBO30ST5ywIfqw=
+github.com/DataDog/nikos v1.7.1 h1:StIoDS9oAM+W0/dRM9l6fHYA4Cd4UamN5vinvaB7ggg=
+github.com/DataDog/nikos v1.7.1/go.mod h1:r20vNQr3wTDrMZWLjOZBCJNWeuTB/rBO30ST5ywIfqw=
 github.com/DataDog/sketches-go v1.0.0/go.mod h1:O+XkJHWk9w4hDwY2ZUDU31ZC9sNYlYo8DiFsxjYeo1k=
 github.com/DataDog/sketches-go v1.2.1 h1:qTBzWLnZ3kM2kw39ymh6rMcnN+5VULwFs++lEYUUsro=
 github.com/DataDog/sketches-go v1.2.1/go.mod h1:1xYmPLY1So10AwxV6MJV0J53XVH+WL9Ad1KetxVivVI=

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -233,6 +233,7 @@ def build_functional_tests(
     major_version='7',
     build_tags='functionaltests',
     build_flags='',
+    nikos_embedded_path=None,
     bundle_ebpf=True,
     static=False,
     skip_linters=False,
@@ -243,7 +244,7 @@ def build_functional_tests(
         golangci_lint(ctx, targets=targets, build_tags=[build_tags], arch=arch)
         staticcheck(ctx, targets=targets, build_tags=[build_tags], arch=arch)
 
-    ldflags, gcflags, env = get_build_flags(ctx, major_version=major_version)
+    ldflags, _, env = get_build_flags(ctx, major_version=major_version, nikos_embedded_path=nikos_embedded_path)
 
     goenv = get_go_env(ctx, go_version)
     env.update(goenv)
@@ -259,6 +260,9 @@ def build_functional_tests(
     if static:
         ldflags += '-extldflags "-static"'
         build_tags += ',osusergo,netgo'
+
+    if nikos_embedded_path:
+        build_tags += ",dnf"
 
     cmd = 'go test -mod=mod -tags {build_tags} -ldflags="{ldflags}" -c -o {output} '
     cmd += '{build_flags} {repo_path}/pkg/security/tests'

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -17,6 +17,16 @@ if node['platform_family'] != 'windows'
     mode '755'
   end
 
+  cookbook_file "#{wrk_dir}/nikos.tar.gz" do
+    source "nikos.tar.gz"
+    mode '755'
+  end
+
+  archive_file "nikos.tar.gz" do
+    path "#{wrk_dir}/nikos.tar.gz"
+    destination "/opt/datadog-agent/embedded/nikos/embedded"
+  end
+
   # `/swapfile` doesn't work on Oracle Linux, so we use `/mnt/swapfile`
   swap_file '/mnt/swapfile' do
     size 2048


### PR DESCRIPTION
### What does this PR do?

This PR adds support for dnf backend in CWS functional tests.

Please note that the SLES tests are not completely working yet, because of repository issues.

### Motivation

Fix SLES tests.

### Possible Drawbacks / Trade-offs

None

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
