### PR TITLE
[commands/check] Add `--discovery-instances` option to `agent check` command

### DIFF
--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -82,7 +82,7 @@ func setupCmd(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&saveFlare, "flare", "", false, "save check results to the log dir so it may be reported in a flare")
 	cmd.Flags().UintVarP(&discoveryTimeout, "discovery-timeout", "", 5, "max retry duration until Autodiscovery resolves the check template (in seconds)")
 	cmd.Flags().UintVarP(&discoveryRetryInterval, "discovery-retry-interval", "", 1, "duration between retries until Autodiscovery resolves the check template (in seconds)")
-	cmd.Flags().UintVarP(&discoveryInstances, "discovery-instances", "", 1, "number of check instances to wait (retry/wait until the specified number of instances is not reached)")
+	cmd.Flags().UintVarP(&discoveryInstances, "discovery-min-instances", "", 1, "minimum number of config instances to be discovered before running the check(s)")
 	config.Datadog.BindPFlag("cmd.check.fullsketches", cmd.Flags().Lookup("full-sketches")) //nolint:errcheck
 
 	// Power user flags - mark as hidden
@@ -723,8 +723,8 @@ func populateMemoryProfileConfig(initConfig map[string]interface{}) error {
 	return nil
 }
 
-// containsCheck returns true if the number of configs found for the check name is ast least the expected instances
-func containsCheck(checkName string, instances uint, configs []integration.Config) bool {
+// checkReady returns true if the number of configs found for the check name is more or equal to min instances
+func checkReady(checkName string, minInstances uint, configs []integration.Config) bool {
 	var matchedConfigsCount uint
 	for _, cfg := range configs {
 		if cfg.Name == checkName {

--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -735,7 +735,7 @@ func checkReady(checkName string, minInstances uint, configs []integration.Confi
 }
 
 // waitForConfigs retries the collection of Autodiscovery configs until a minimum number of config instances
-// are discovered or the timeout is reached.
+// for the check are discovered or the timeout is reached.
 // Autodiscovery listeners run asynchronously, AC.GetAllConfigs() can fail at the beginning to resolve templated configs
 // depending on non-deterministic factors (system load, network latency, active Autodiscovery listeners and their configurations).
 // This function improves the resiliency of the check command.

--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -41,31 +41,31 @@ import (
 )
 
 var (
-	checkRate               bool
-	checkTimes              int
-	checkPause              int
-	checkName               string
-	checkDelay              int
-	logLevel                string
-	formatJSON              bool
-	formatTable             bool
-	breakPoint              string
-	fullSketches            bool
-	saveFlare               bool
-	profileMemory           bool
-	profileMemoryDir        string
-	profileMemoryFrames     string
-	profileMemoryGC         string
-	profileMemoryCombine    string
-	profileMemorySort       string
-	profileMemoryLimit      string
-	profileMemoryDiff       string
-	profileMemoryFilters    string
-	profileMemoryUnit       string
-	profileMemoryVerbose    string
-	discoveryTimeout        uint
-	discoveryRetryInterval  uint
-	discoveryInstancesCount uint
+	checkRate              bool
+	checkTimes             int
+	checkPause             int
+	checkName              string
+	checkDelay             int
+	logLevel               string
+	formatJSON             bool
+	formatTable            bool
+	breakPoint             string
+	fullSketches           bool
+	saveFlare              bool
+	profileMemory          bool
+	profileMemoryDir       string
+	profileMemoryFrames    string
+	profileMemoryGC        string
+	profileMemoryCombine   string
+	profileMemorySort      string
+	profileMemoryLimit     string
+	profileMemoryDiff      string
+	profileMemoryFilters   string
+	profileMemoryUnit      string
+	profileMemoryVerbose   string
+	discoveryTimeout       uint
+	discoveryRetryInterval uint
+	discoveryInstances     uint
 )
 
 func setupCmd(cmd *cobra.Command) {
@@ -82,7 +82,7 @@ func setupCmd(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&saveFlare, "flare", "", false, "save check results to the log dir so it may be reported in a flare")
 	cmd.Flags().UintVarP(&discoveryTimeout, "discovery-timeout", "", 5, "max retry duration until Autodiscovery resolves the check template (in seconds)")
 	cmd.Flags().UintVarP(&discoveryRetryInterval, "discovery-retry-interval", "", 1, "duration between retries until Autodiscovery resolves the check template (in seconds)")
-	cmd.Flags().UintVarP(&discoveryInstancesCount, "discovery-instances-count", "", 1, "number of check instances to wait (retry/wait until the specified number of instances is not reached)")
+	cmd.Flags().UintVarP(&discoveryInstances, "discovery-instances", "", 1, "number of check instances to wait (retry/wait until the specified number of instances is not reached)")
 	config.Datadog.BindPFlag("cmd.check.fullsketches", cmd.Flags().Lookup("full-sketches")) //nolint:errcheck
 
 	// Power user flags - mark as hidden
@@ -154,7 +154,7 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 				discoveryRetryInterval = discoveryTimeout
 			}
 
-			allConfigs := waitForConfigs(checkName, time.Duration(discoveryRetryInterval)*time.Second, time.Duration(discoveryTimeout)*time.Second, discoveryInstancesCount)
+			allConfigs := waitForConfigs(checkName, time.Duration(discoveryRetryInterval)*time.Second, time.Duration(discoveryTimeout)*time.Second, discoveryInstances)
 
 			// make sure the checks in cs are not JMX checks
 			for idx := range allConfigs {
@@ -723,15 +723,15 @@ func populateMemoryProfileConfig(initConfig map[string]interface{}) error {
 	return nil
 }
 
-// containsCheck returns true if the number of configs found for the check name is ast least the expected instances count
-func containsCheck(checkName string, instancesCount uint, configs []integration.Config) bool {
+// containsCheck returns true if the number of configs found for the check name is ast least the expected instances
+func containsCheck(checkName string, instances uint, configs []integration.Config) bool {
 	var matchedConfigsCount uint
 	for _, cfg := range configs {
 		if cfg.Name == checkName {
 			matchedConfigsCount++
 		}
 	}
-	return matchedConfigsCount >= instancesCount
+	return matchedConfigsCount >= instances
 }
 
 // waitForConfigs retries the collection of Autodiscovery configs until the check is found or the timeout is reached.
@@ -739,9 +739,9 @@ func containsCheck(checkName string, instancesCount uint, configs []integration.
 // depending on non-deterministic factors (system load, network latency, active Autodiscovery listeners and their configurations).
 // This function improves the resiliency of the check command.
 // Note: If the check corresponds to a non-template configuration it should be found on the first try and fast-returned.
-func waitForConfigs(checkName string, retryInterval, timeout time.Duration, instancesCount uint) []integration.Config {
+func waitForConfigs(checkName string, retryInterval, timeout time.Duration, instances uint) []integration.Config {
 	allConfigs := common.AC.GetAllConfigs()
-	if containsCheck(checkName, instancesCount, allConfigs) {
+	if containsCheck(checkName, instances, allConfigs) {
 		return allConfigs
 	}
 
@@ -757,7 +757,7 @@ func waitForConfigs(checkName string, retryInterval, timeout time.Duration, inst
 			return allConfigs
 		case <-retryTicker.C:
 			allConfigs = common.AC.GetAllConfigs()
-			if containsCheck(checkName, instancesCount, allConfigs) {
+			if containsCheck(checkName, instances, allConfigs) {
 				return allConfigs
 			}
 		}

--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -65,6 +65,7 @@ var (
 	profileMemoryVerbose   string
 	discoveryTimeout       uint
 	discoveryRetryInterval uint
+	discoveryCheckCount    uint
 )
 
 func setupCmd(cmd *cobra.Command) {
@@ -81,6 +82,7 @@ func setupCmd(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&saveFlare, "flare", "", false, "save check results to the log dir so it may be reported in a flare")
 	cmd.Flags().UintVarP(&discoveryTimeout, "discovery-timeout", "", 5, "max retry duration until Autodiscovery resolves the check template (in seconds)")
 	cmd.Flags().UintVarP(&discoveryRetryInterval, "discovery-retry-interval", "", 1, "duration between retries until Autodiscovery resolves the check template (in seconds)")
+	cmd.Flags().UintVarP(&discoveryCheckCount, "discovery-check-count", "", 1, "number of check instances to wait (retry/wait until the specified number of instances is not reached)")
 	config.Datadog.BindPFlag("cmd.check.fullsketches", cmd.Flags().Lookup("full-sketches")) //nolint:errcheck
 
 	// Power user flags - mark as hidden
@@ -152,7 +154,7 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 				discoveryRetryInterval = discoveryTimeout
 			}
 
-			allConfigs := waitForConfigs(checkName, time.Duration(discoveryRetryInterval)*time.Second, time.Duration(discoveryTimeout)*time.Second)
+			allConfigs := waitForConfigs(checkName, time.Duration(discoveryRetryInterval)*time.Second, time.Duration(discoveryTimeout)*time.Second, discoveryCheckCount)
 
 			// make sure the checks in cs are not JMX checks
 			for idx := range allConfigs {
@@ -721,15 +723,15 @@ func populateMemoryProfileConfig(initConfig map[string]interface{}) error {
 	return nil
 }
 
-// containsCheck returns true if at least one config corresponds to the check name.
-func containsCheck(checkName string, configs []integration.Config) bool {
+// containsCheck returns true if the number of configs found for the check name is ast least the expected check count
+func containsCheck(checkName string, checkCount uint, configs []integration.Config) bool {
+	var matchedConfigsCount uint
 	for _, cfg := range configs {
 		if cfg.Name == checkName {
-			return true
+			matchedConfigsCount++
 		}
 	}
-
-	return false
+	return matchedConfigsCount >= checkCount
 }
 
 // waitForConfigs retries the collection of Autodiscovery configs until the check is found or the timeout is reached.
@@ -737,9 +739,9 @@ func containsCheck(checkName string, configs []integration.Config) bool {
 // depending on non-deterministic factors (system load, network latency, active Autodiscovery listeners and their configurations).
 // This function improves the resiliency of the check command.
 // Note: If the check corresponds to a non-template configuration it should be found on the first try and fast-returned.
-func waitForConfigs(checkName string, retryInterval, timeout time.Duration) []integration.Config {
+func waitForConfigs(checkName string, retryInterval, timeout time.Duration, checkCount uint) []integration.Config {
 	allConfigs := common.AC.GetAllConfigs()
-	if containsCheck(checkName, allConfigs) {
+	if containsCheck(checkName, checkCount, allConfigs) {
 		return allConfigs
 	}
 
@@ -755,7 +757,7 @@ func waitForConfigs(checkName string, retryInterval, timeout time.Duration) []in
 			return allConfigs
 		case <-retryTicker.C:
 			allConfigs = common.AC.GetAllConfigs()
-			if containsCheck(checkName, allConfigs) {
+			if containsCheck(checkName, checkCount, allConfigs) {
 				return allConfigs
 			}
 		}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add `discovery-instances` option to `agent check` command

Currently, the `agent check` command waits for at least 1 check instance.
If `discovery-instances` is used, the `agent check` will wait for at least the specified number of check instances.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Needed for e2e testing listeners (snmp listener) that schedules multiple check instances.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
