### PR TITLE
[Tagger] Support `kube_cluster_name` tag on eks fargate

### DIFF
--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -215,7 +215,7 @@ func (c *WorkloadMetaCollector) handleContainer(ev workloadmeta.Event) []*TagInf
 		utils.AddMetadataAsTags(envName, envValue, c.containerEnvAsTags, c.globContainerEnvLabels, tags)
 	}
 
-	// static tags for ECS Fargate
+	// static tags for ECS and EKS Fargate containers
 	for tag, value := range c.staticTags {
 		tags.AddLow(tag, value)
 	}
@@ -271,6 +271,11 @@ func (c *WorkloadMetaCollector) handleKubePod(ev workloadmeta.Event) []*TagInfo 
 		tags.AddOrchestrator(kubernetes.OwnerRefNameTagName, owner.Name)
 
 		c.extractTagsFromPodOwner(pod, owner, tags)
+	}
+
+	// static tags for EKS Fargate pods
+	for tag, value := range c.staticTags {
+		tags.AddLow(tag, value)
 	}
 
 	low, orch, high, standard := tags.Compute()

--- a/pkg/tagger/collectors/workloadmeta_main.go
+++ b/pkg/tagger/collectors/workloadmeta_main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	"github.com/DataDog/datadog-agent/pkg/tagger/utils"
 	"github.com/DataDog/datadog-agent/pkg/util/fargate"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/clustername"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
@@ -152,11 +153,26 @@ func fargateStaticTags(ctx context.Context) map[string]string {
 
 	// EKS Fargate specific tags
 	if fargate.IsEKSFargateInstance() {
+		// eks_fargate_node
 		node, err := fargate.GetEKSFargateNodename()
 		if err != nil {
 			log.Infof("Couldn't build the 'eks_fargate_node' tag: %w", err)
 		} else {
 			tags["eks_fargate_node"] = node
+		}
+
+		// kube_cluster_name
+		clusterTagName := "kube_cluster_name"
+		tag, found := tags[clusterTagName]
+		if found {
+			log.Infof("'%s:%s' was set manually via DD_TAGS, not changing it", clusterTagName, tag)
+		} else {
+			cluster := clustername.GetClusterName(context.TODO(), "")
+			if cluster == "" {
+				log.Infof("Couldn't build the %q tag, DD_CLUSTER_NAME can be used to set it", clusterTagName)
+			} else {
+				tags[clusterTagName] = cluster
+			}
 		}
 	}
 

--- a/pkg/tagger/collectors/workloadmeta_main.go
+++ b/pkg/tagger/collectors/workloadmeta_main.go
@@ -167,7 +167,7 @@ func fargateStaticTags(ctx context.Context) map[string]string {
 		if found {
 			log.Infof("'%s:%s' was set manually via DD_TAGS, not changing it", clusterTagName, tag)
 		} else {
-			cluster := clustername.GetClusterName(context.TODO(), "")
+			cluster := clustername.GetClusterName(ctx, "")
 			if cluster == "" {
 				log.Infof("Couldn't build the %q tag, DD_CLUSTER_NAME can be used to set it", clusterTagName)
 			} else {

--- a/releasenotes/notes/clustername-eks-fargate-bd6b486162b42db8.yaml
+++ b/releasenotes/notes/clustername-eks-fargate-bd6b486162b42db8.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    ``DD_CLUSTER_NAME`` can be used to define the ``kube_cluster_name`` on EKS Fargate.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Add `kube_cluster_name` to the static tags in the workloadmeta tagger collector, this will allows applying `DD_CLUSTER_NAME` in EKS Fargate (hostless env -> no host tags)
- Apply the static tags to pod entities, in addition to containers.

### Motivation

Support `DD_CLUSTER_NAME` in EKS Fargate the same way we support `DD_TAGS`.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Define `DD_CLUSTER_NAME`, make sure `agent tagger-list` prints `kube_cluster_name:<DD_CLUSTER_NAME>` for all entities 
- If `kube_cluster_name` is defined in `DD_TAGS` and `DD_CLUSTER_NAME` is also defined with different value, the value set in `DD_TAGS` is prioritised

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
