### PR TITLE
[docker] Fix counting of stopped containers

### DIFF
--- a/releasenotes/notes/docker-fix-containers-stopped-b1cc5e744adea525.yaml
+++ b/releasenotes/notes/docker-fix-containers-stopped-b1cc5e744adea525.yaml
@@ -1,0 +1,7 @@
+---
+fixes:
+  - |
+    Fixes an issue where the docker check would undercount the number of
+    stopped containers in the `docker.containers.stopped` and
+    `docker.containers.stopped.total` metrics, accompanied by a "Cannot split
+    the image name" error in the logs.

--- a/releasenotes/notes/docker-fix-containers-stopped-b1cc5e744adea525.yaml
+++ b/releasenotes/notes/docker-fix-containers-stopped-b1cc5e744adea525.yaml
@@ -1,7 +1,7 @@
 ---
 fixes:
   - |
-    Fixes an issue where the docker check would undercount the number of
+    Fixes an issue where the Docker check would undercount the number of
     stopped containers in the `docker.containers.stopped` and
     `docker.containers.stopped.total` metrics, accompanied by a "Cannot split
     the image name" error in the logs.


### PR DESCRIPTION
### What does this PR do?

This fixes an issue where a stopped container that has a SHA256 as its
image name would not be counted in `docker.containers.stopped` and
`docker.containers.stopped.total` metrics. It also lowers the log level
for the `Cannot split the image name` error, since it is not actionable
and would only be useful for debugging.

### Additional Notes

As written in a code comment, this does not completely solve containers only having a SHA256 in their image name, as we;d need to use `dockerUtil.ResolveImageName` as we do in workloadmeta. That's a relatively expensive call, since it needs to talk to the docker daemon, and doing that potentially dozens of times in every check run is not worth the benefit of adding tags to stopped containers. Ideally this information could come from workloadmeta in the future.

### Describe how to test/QA your changes

Trigger the condition that causes the docker check to see a SHA256 instead of an image name (the easiest way seems to be to just run a container, stop it, then force-delete its image). Check the following:

1. The `Cannot split the image name` log only appears if `DD_LOG_LEVEL` is `DEBUG` or higher.
2. `docker.containers.stopped.total` matches the number of stopped containers as seen by the docker daemon.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
