### PR TITLE
Change NPM test log level to warn

### DIFF
--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -54,7 +54,7 @@ var (
 const runtimeCompilationEnvVar = "DD_TESTS_RUNTIME_COMPILED"
 
 func TestMain(m *testing.M) {
-	log.SetupLogger(seelog.Default, "info")
+	log.SetupLogger(seelog.Default, "warn")
 	cfg := testConfig()
 	if cfg.EnableRuntimeCompiler {
 		fmt.Println("RUNTIME COMPILER ENABLED")


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Changes the log level in automated tests to WARN

### Motivation

The repeated INFO logs are not helpful in the test output, and make it hard to identify real problems.
```
=== RUN   TestConntrackDelays
1641492200540632307 [Info] socket struct offset guessing complete (took 290.710117ms)
1641492200671928821 [Info] initialized conntrack with target_rate_limit=500 messages/sec
1641492200673245225 [Info] DNS Stats Collection has been enabled. Maximum number of stats objects: 20000
1641492200673263325 [Info] DNS domain collection has been enabled
1641492200673284125 [Info] Recording dns query types: [A]
1641492200673309125 [Info] dns inspection enabled
1641492201191653959 [Info] exited conntrack netlink receive loop
--- PASS: TestConntrackDelays (1.17s)
=== RUN   TestTranslationBindingRegression
1641492201700632664 [Info] socket struct offset guessing complete (took 263.738732ms)
1641492201862859875 [Info] initialized conntrack with target_rate_limit=500 messages/sec
1641492201864054279 [Info] DNS Stats Collection has been enabled. Maximum number of stats objects: 20000
1641492201864077379 [Info] DNS domain collection has been enabled
1641492201864096579 [Info] Recording dns query types: [A]
1641492201864134179 [Info] dns inspection enabled
1641492202432106370 [Info] exited conntrack netlink receive loop
--- PASS: TestTranslationBindingRegression (1.23s)
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
