### PR TITLE
[networks] Improve tuple normalization

### DIFF
--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Conntrack = NewRuntimeAsset("conntrack.c", "e75b81ba22c7a732b55ac06575cb6414819d19abb5e2d4931c3add8d03d564ea")
+var Conntrack = NewRuntimeAsset("conntrack.c", "82cc427c2c37867ba41182e44ef83ed0d71edd85e51d827e3399c27676153c49")

--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Http = NewRuntimeAsset("http.c", "e287b47be0c94973101f50871255e3aa12c0ba261090d21855be5029779c33c7")
+var Http = NewRuntimeAsset("http.c", "c792b7f43a460d4e3df2757345960b318cf7354426aee1989cea7d32fb6efaf8")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "d507ba429c6f0cebc5ef54669a5ca2e81e419edb956fe3c64419d4733a1bba09")
+var Tracer = NewRuntimeAsset("tracer.c", "0196cb07f7f37a49d747424bb40f25c33b2a650e37bd8738fb098eb545a4d894")

--- a/pkg/network/ebpf/c/ip.h
+++ b/pkg/network/ebpf/c/ip.h
@@ -108,20 +108,6 @@ static __always_inline __u64 read_conn_tuple_skb(struct __sk_buff *skb, skb_info
     return 1;
 }
 
-static __always_inline void flip_tuple(conn_tuple_t *t) {
-    __u16 tmp_port = t->sport;
-    t->sport = t->dport;
-    t->dport = tmp_port;
-
-    __u64 tmp_ip_part = t->saddr_l;
-    t->saddr_l = t->daddr_l;
-    t->daddr_l = tmp_ip_part;
-
-    tmp_ip_part = t->saddr_h;
-    t->saddr_h = t->daddr_h;
-    t->daddr_h = tmp_ip_part;
-}
-
 static __always_inline void print_ip(u64 ip_h, u64 ip_l, u16 port, u32 metadata) {
     if (metadata & CONN_V6) {
         log_debug("v6 %llx%llx:%u\n", bpf_ntohll(ip_h), bpf_ntohll(ip_l), port);

--- a/pkg/network/ebpf/c/port_range.h
+++ b/pkg/network/ebpf/c/port_range.h
@@ -10,4 +10,34 @@ static __always_inline int is_ephemeral_port(u16 port) {
     return port >= EPHEMERAL_RANGE_BEG && port <= EPHEMERAL_RANGE_END;
 }
 
+static __always_inline void flip_tuple(conn_tuple_t *t) {
+    __u16 tmp_port = t->sport;
+    t->sport = t->dport;
+    t->dport = tmp_port;
+
+    __u64 tmp_ip_part = t->saddr_l;
+    t->saddr_l = t->daddr_l;
+    t->daddr_l = tmp_ip_part;
+
+    tmp_ip_part = t->saddr_h;
+    t->saddr_h = t->daddr_h;
+    t->daddr_h = tmp_ip_part;
+}
+
+// ensure that the given tuple is in the (src: client, dst: server) format based
+// on the port range heuristic
+static __always_inline void normalize_tuple(conn_tuple_t *t) {
+    if (is_ephemeral_port(t->sport) && !is_ephemeral_port(t->dport)) {
+        return;
+    }
+
+    if ((!is_ephemeral_port(t->sport) && is_ephemeral_port(t->dport)) || t->sport > t->dport) {
+        // flip the tuple if:
+        // 1) the tuple is currently in the (server, client) format;
+        // 2) unlikely: if both ports are in the same range we ensure that sport < dport to make
+        // this function return a deterministic result for a given pair of ports;
+        flip_tuple(t);
+    }
+}
+
 #endif

--- a/pkg/network/ebpf/c/prebuilt/http.c
+++ b/pkg/network/ebpf/c/prebuilt/http.c
@@ -54,12 +54,7 @@ int socket__http_filter(struct __sk_buff* skb) {
     // src_port represents the source port number *before* normalization
     // for more context please refer to http-types.h comment on `owned_by_src_port` field
     http.owned_by_src_port = http.tup.sport;
-
-    // we normalize the tuple to always be (client, server),
-    // so if sport is not in ephemeral port range we flip it
-    if (!is_ephemeral_port(http.tup.sport)) {
-        flip_tuple(&http.tup);
-    }
+    normalize_tuple(&http.tup);
 
     read_into_buffer_skb((char *)http.request_fragment, skb, &skb_info);
     http_process(&http, &skb_info);

--- a/pkg/network/ebpf/c/runtime/http.c
+++ b/pkg/network/ebpf/c/runtime/http.c
@@ -53,12 +53,7 @@ int socket__http_filter(struct __sk_buff* skb) {
     // src_port represents the source port number *before* normalization
     // for more context please refer to http-types.h comment on `owned_by_src_port` field
     http.owned_by_src_port = http.tup.sport;
-
-    // we normalize the tuple to always be (client, server),
-    // so if sport is not in ephemeral port range we flip it
-    if (!is_ephemeral_port(http.tup.sport)) {
-        flip_tuple(&http.tup);
-    }
+    normalize_tuple(&http.tup);
 
     read_into_buffer_skb((char *)http.request_fragment, skb, &skb_info);
     http_process(&http, &skb_info);

--- a/pkg/network/encoding/format.go
+++ b/pkg/network/encoding/format.go
@@ -186,9 +186,12 @@ func httpKeyFromConn(c network.ConnectionStats) http.Key {
 	laddr, lport := network.GetNATLocalAddress(c)
 	raddr, rport := network.GetNATRemoteAddress(c)
 
-	// HTTP data is always indexed as (client, server), so we flip
-	// the lookup key if necessary using the port range heuristic
-	if network.IsEphemeralPort(int(lport)) {
+	// HTTP data is always indexed as (client, server), so we account for that when generating the
+	// the lookup key using the port range heuristic.
+	// In the rare cases where both ports are within the same range we ensure that sport < dport
+	// to mimic the normalization heuristic done in the eBPF side (see `port_range.h`)
+	if (network.IsEphemeralPort(int(lport)) && !network.IsEphemeralPort(int(rport))) ||
+		(network.IsEphemeralPort(int(lport)) == network.IsEphemeralPort(int(rport)) && lport < rport) {
 		return http.NewKey(laddr, raddr, lport, rport, "", http.MethodUnknown)
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Ensures that the tuple normalization is always deterministic for any given pair of ports, even when both ports are within the ephemeral range.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
