### PR TITLE
[customaction] Build libarchive with only required features

### DIFF
--- a/tools/windows/install-help/cal/vcpkg.json
+++ b/tools/windows/install-help/cal/vcpkg.json
@@ -7,7 +7,8 @@
     "yaml-cpp",
     {
       "name": "libarchive",
-      "features": [ "lzma" ]
+      "features": [ "lzma" ],
+      "default-features": false
     }
   ],
   "builtin-baseline": "5568f110b509a9fd90711978a7cb76bae75bb092",

--- a/tools/windows/install-help/cal/vcpkg.json
+++ b/tools/windows/install-help/cal/vcpkg.json
@@ -5,7 +5,10 @@
   "dependencies": [
     "gtest",
     "yaml-cpp",
-    "libarchive"
+    {
+      "name": "libarchive",
+      "features": [ "lzma" ]
+    }
   ],
   "builtin-baseline": "5568f110b509a9fd90711978a7cb76bae75bb092",
   "overrides": [


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Builds `libarchive` for the custom action only with the `lzma` feature.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

`libarchive` is built with a bunch of default features ([listed here](https://vcpkg.info/port/libarchive)), but we only need `lzma`. This results in a faster build (5mn to build the custom action instead of 20mn).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
