### PR TITLE
[process-agent] Fix kitchen test failing with process_discovery.enabled=true

### DIFF
--- a/test/kitchen/test-definitions/windows-install-test.yml
+++ b/test/kitchen/test-definitions/windows-install-test.yml
@@ -142,6 +142,7 @@ suites:
           APIKEY=<%= api_key %>
           LOGS_ENABLED=false
           PROCESS_ENABLED=false
+          PROCESS_DISCOVERY_ENABLED=false
           APM_ENABLED=false
       dd-agent-rspec:
         skip_windows_signing_test: &skip_windows_signing_test <%= ENV['SKIP_SIGNATURE_TEST'] || false %>

--- a/test/kitchen/test/integration/win-no-subservices/rspec/win-no-subservices_spec.rb
+++ b/test/kitchen/test/integration/win-no-subservices/rspec/win-no-subservices_spec.rb
@@ -30,7 +30,7 @@ shared_examples_for 'an Agent with process disabled' do
     expect(confYaml).to have_key("process_config")
     expect(confYaml["process_config"]).to have_key("enabled")
     expect(confYaml["process_config"]["enabled"]).to eq("disabled")
-    expect(confYaml["process_config"]["process_discovery"]["enabled"]).to eq("false")
+    expect(confYaml["process_config"]["process_discovery"]["enabled"]).to eq(false)
   end
   it 'does not have the process agent running' do
     expect(is_process_running?("process-agent.exe")).to be_falsey

--- a/test/kitchen/test/integration/win-no-subservices/rspec/win-no-subservices_spec.rb
+++ b/test/kitchen/test/integration/win-no-subservices/rspec/win-no-subservices_spec.rb
@@ -30,6 +30,7 @@ shared_examples_for 'an Agent with process disabled' do
     expect(confYaml).to have_key("process_config")
     expect(confYaml["process_config"]).to have_key("enabled")
     expect(confYaml["process_config"]["enabled"]).to eq("disabled")
+    expect(confYaml["process_config"]["process_discovery"]["enabled"].to eq("false"))
   end
   it 'does not have the process agent running' do
     expect(is_process_running?("process-agent.exe")).to be_falsey
@@ -44,4 +45,3 @@ describe 'win-no-subservices' do
   it_behaves_like 'an Agent with logs disabled'
   it_behaves_like 'an Agent with process disabled'
 end
-  

--- a/test/kitchen/test/integration/win-no-subservices/rspec/win-no-subservices_spec.rb
+++ b/test/kitchen/test/integration/win-no-subservices/rspec/win-no-subservices_spec.rb
@@ -30,7 +30,7 @@ shared_examples_for 'an Agent with process disabled' do
     expect(confYaml).to have_key("process_config")
     expect(confYaml["process_config"]).to have_key("enabled")
     expect(confYaml["process_config"]["enabled"]).to eq("disabled")
-    expect(confYaml["process_config"]["process_discovery"]["enabled"].to eq("false"))
+    expect(confYaml["process_config"]["process_discovery"]["enabled"]).to eq("false")
   end
   it 'does not have the process agent running' do
     expect(is_process_running?("process-agent.exe")).to be_falsey


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

This is a regression in kitchen tests caused by https://github.com/DataDog/datadog-agent/pull/10408.

- `process_discovery` relies on the process agent running
- Fixing the test by providing `PROCESS_DISCOVERY_ENABLED=false` switch to disable it.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
