### PR TITLE
Add an extra timeout setting in the orchestrator check

### DIFF
--- a/pkg/clusteragent/admission/start.go
+++ b/pkg/clusteragent/admission/start.go
@@ -93,5 +93,5 @@ func StartControllers(ctx ControllerContext) error {
 		informers[apiserver.WebhooksInformer] = ctx.WebhookInformers.Admissionregistration().V1beta1().MutatingWebhookConfigurations().Informer()
 	}
 
-	return apiserver.SyncInformers(informers)
+	return apiserver.SyncInformers(informers, 0)
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -77,7 +77,8 @@ type OrchestratorInstance struct {
 	// collectors:
 	//   - nodes
 	//   - services
-	Collectors []string `yaml:"collectors"`
+	Collectors              []string `yaml:"collectors"`
+	ExtraSyncTimeoutSeconds int      `yaml:"extra_sync_timeout_seconds"`
 }
 
 func (c *OrchestratorInstance) parse(data []byte) error {
@@ -187,6 +188,14 @@ func (o *OrchestratorCheck) Configure(config, initConfig integration.Data, sourc
 		return err
 	}
 
+	// Get the extra time we can wait for the informer cache sync
+	var extraTimeout time.Duration
+	if o.instance.ExtraSyncTimeoutSeconds == 0 {
+		extraTimeout = 60 * time.Second
+	} else {
+		extraTimeout = time.Duration(o.instance.ExtraSyncTimeoutSeconds) * time.Second
+	}
+
 	// Prepare the collectors for the resources specified in the configuration file.
 	collectors := o.instance.Collectors
 
@@ -275,7 +284,7 @@ func (o *OrchestratorCheck) Configure(config, initConfig integration.Data, sourc
 		go informer.Run(o.stopCh)
 	}
 
-	return apiserver.SyncInformers(informersToSync)
+	return apiserver.SyncInformers(informersToSync, extraTimeout)
 }
 
 // Run runs the orchestrator check

--- a/pkg/util/kubernetes/apiserver/controllers.go
+++ b/pkg/util/kubernetes/apiserver/controllers.go
@@ -105,7 +105,7 @@ func StartControllers(ctx ControllerContext) errors.Aggregate {
 	ctx.InformerFactory.Start(ctx.StopCh)
 
 	// Wait for the cache to sync
-	if err := SyncInformers(ctx.informers); err != nil {
+	if err := SyncInformers(ctx.informers, 0); err != nil {
 		errs = append(errs, err)
 	}
 

--- a/pkg/util/kubernetes/apiserver/util.go
+++ b/pkg/util/kubernetes/apiserver/util.go
@@ -24,11 +24,12 @@ import (
 
 // SyncInformers should be called after the instantiation of new informers.
 // It's blocking until the informers are synced or the timeout exceeded.
-func SyncInformers(informers map[InformerName]cache.SharedInformer) error {
+// An extra timeout duration can be provided depending on the informer
+func SyncInformers(informers map[InformerName]cache.SharedInformer, extraWait time.Duration) error {
 	var g errgroup.Group
 	// syncTimeout can be used to wait for the kubernetes client-go cache to sync.
 	// It cannot be retrieved at the package-level due to the package being imported before configs are loaded.
-	syncTimeout := config.Datadog.GetDuration("kube_cache_sync_timeout_seconds") * time.Second
+	syncTimeout := config.Datadog.GetDuration("kube_cache_sync_timeout_seconds")*time.Second + extraWait
 	for name := range informers {
 		name := name // https://golang.org/doc/faq#closures_and_goroutines
 		g.Go(func() error {

--- a/releasenotes-dca/notes/informer-timeout-e748b2b71cd5ab6e.yaml
+++ b/releasenotes-dca/notes/informer-timeout-e748b2b71cd5ab6e.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - |
+    The orchestrator check can now be configured with
+    an extra timeout to ensure the Kubernetes informers have enough time
+    to synchronize (60s by default).


### PR DESCRIPTION

### What does this PR do?

Add an extra timeout setting in the orchestrator check, alternative to #10072 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
