### PR TITLE
pkg/trace: Fix remote start

### DIFF
--- a/pkg/trace/sampler/prioritysampler.go
+++ b/pkg/trace/sampler/prioritysampler.go
@@ -74,7 +74,7 @@ func NewPrioritySampler(conf *config.AgentConfig, dynConf *DynamicConfig) *Prior
 // Start runs and block on the Sampler main loop
 func (s *PrioritySampler) Start() {
 	if s.remoteRates != nil {
-		s.Start()
+		s.remoteRates.Start()
 	}
 	go func() {
 		updateRates := time.NewTicker(decayPeriod)

--- a/pkg/trace/sampler/prioritysampler_test.go
+++ b/pkg/trace/sampler/prioritysampler_test.go
@@ -163,6 +163,21 @@ func TestPrioritySamplerWithNilRemote(t *testing.T) {
 	s.Stop()
 }
 
+func TestPrioritySamplerWithRemote(t *testing.T) {
+	conf := &config.AgentConfig{
+		ExtraSampleRate: 1.0,
+		TargetTPS:       0.0,
+	}
+	s := NewPrioritySampler(conf, NewDynamicConfig())
+	s.remoteRates = newRemoteRates(10)
+	s.Start()
+	s.updateRates()
+	s.reportStats()
+	chunk, root := getTestTraceWithService(t, "my-service", s)
+	assert.True(t, s.Sample(chunk, root, "", false))
+	s.Stop()
+}
+
 func TestPrioritySamplerTPSFeedbackLoop(t *testing.T) {
 	assert := assert.New(t)
 	rand.Seed(1)


### PR DESCRIPTION
Fixing an infinite loop when entering prioritysampler.Start 