### PR TITLE
Remove useless header include in oomkill probe

### DIFF
--- a/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern.c
@@ -1,6 +1,5 @@
 #include <linux/compiler.h>
 #include <linux/kconfig.h>
-#include <linux/ptrace.h>
 #include <linux/types.h>
 #include <linux/version.h>
 #include <linux/oom.h>

--- a/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/oom-kill-kern.c
@@ -1,4 +1,3 @@
-#include <linux/compiler.h>
 #include <linux/kconfig.h>
 #include <linux/types.h>
 #include <linux/version.h>

--- a/pkg/collector/corechecks/ebpf/c/runtime/tcp-queue-length-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/tcp-queue-length-kern.c
@@ -1,5 +1,3 @@
-#include <linux/compiler.h>
-
 #include <linux/kconfig.h>
 #include <linux/types.h>
 #include <linux/version.h>

--- a/pkg/collector/corechecks/ebpf/c/runtime/tcp-queue-length-kern.c
+++ b/pkg/collector/corechecks/ebpf/c/runtime/tcp-queue-length-kern.c
@@ -1,7 +1,6 @@
 #include <linux/compiler.h>
 
 #include <linux/kconfig.h>
-#include <linux/ptrace.h>
 #include <linux/types.h>
 #include <linux/version.h>
 #include <linux/tcp.h>

--- a/pkg/ebpf/bytecode/runtime/oom-kill.go
+++ b/pkg/ebpf/bytecode/runtime/oom-kill.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var OomKill = NewRuntimeAsset("oom-kill.c", "341e26057950586d0c337f5acd0abb9c8dde7db033ad32b4379489e859c7443f")
+var OomKill = NewRuntimeAsset("oom-kill.c", "b880fcbf4e0da6afe4389e02ad49afe157deb58e33a8fa5cc76c69d850ab34fe")

--- a/pkg/ebpf/bytecode/runtime/oom-kill.go
+++ b/pkg/ebpf/bytecode/runtime/oom-kill.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var OomKill = NewRuntimeAsset("oom-kill.c", "b880fcbf4e0da6afe4389e02ad49afe157deb58e33a8fa5cc76c69d850ab34fe")
+var OomKill = NewRuntimeAsset("oom-kill.c", "8e3754c36a5df5d9e3396f4b239665422cc69c1aff1932d475b6874218931cc7")

--- a/pkg/ebpf/bytecode/runtime/tcp-queue-length.go
+++ b/pkg/ebpf/bytecode/runtime/tcp-queue-length.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var TcpQueueLength = NewRuntimeAsset("tcp-queue-length.c", "309e025815ed5d815a869bbcda91b3bbf05079ba1cc13d24b37b8af8ef7b64ca")
+var TcpQueueLength = NewRuntimeAsset("tcp-queue-length.c", "ce81761a70951275139fcca2d4f69cc9a5dcfd6c4b91892626c903413b988faf")

--- a/pkg/ebpf/bytecode/runtime/tcp-queue-length.go
+++ b/pkg/ebpf/bytecode/runtime/tcp-queue-length.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var TcpQueueLength = NewRuntimeAsset("tcp-queue-length.c", "d00d35edaf9df4c60083234f425c89dee00e3d1ac8769a69c557e7c6dd424330")
+var TcpQueueLength = NewRuntimeAsset("tcp-queue-length.c", "309e025815ed5d815a869bbcda91b3bbf05079ba1cc13d24b37b8af8ef7b64ca")


### PR DESCRIPTION
### What does this PR do?

This PR removes the useless
```
#include <linux/ptrace.h>
#include <linux/compiler.h>
```
in oom-kill and tcp queue length probes.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
