### PR TITLE
[pipeline] Fix APIError init in notification jobs

### DIFF
--- a/tasks/libs/common/remote_api.py
+++ b/tasks/libs/common/remote_api.py
@@ -8,7 +8,7 @@ errno_regex = re.compile(r".*\[Errno (\d+)\] (.*)")
 
 class APIError(Exception):
     def __init__(self, request, api_name):
-        super(APIError, self).__init__(f"{api_name} says: {request.json()}")
+        super(APIError, self).__init__(f"{api_name} says: {request.content}")
         self.status_code = request.status_code
         self.request = request
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Reads the `content` of the API response when generating the API error message, instead of trying to parse it as `json`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fixes issue where `APIError` would try to parse the API response as `json`, even when the response isn't `json`, leading to crashes while generating notification messages:

<details>

<summary>Traceback</summary>

```
Extra data: line 1 column 5 (char 4)
Traceback (most recent call last):
  File "/Users/kylian.serrania/go/src/github.com/DataDog/datadog-agent/tasks/pipeline.py", line 441, in notify_failure
    messages_to_send = generate_failure_messages(base)
  File "/Users/kylian.serrania/go/src/github.com/DataDog/datadog-agent/tasks/pipeline.py", line 347, in generate_failure_messages
    for test in get_failed_tests(project_name, job):
  File "/Users/kylian.serrania/go/src/github.com/DataDog/datadog-agent/tasks/libs/pipeline_notifications.py", line 58, in get_failed_tests
    test_output = gitlab.artifact(job["id"], "test_output.json", ignore_not_found=True)
  File "/Users/kylian.serrania/go/src/github.com/DataDog/datadog-agent/tasks/libs/common/gitlab.py", line 135, in artifact
    response = self.make_request(path, stream_output=True)
  File "/Users/kylian.serrania/go/src/github.com/DataDog/datadog-agent/tasks/libs/common/gitlab.py", line 277, in make_request
    return self.request(
  File "/Users/kylian.serrania/go/src/github.com/DataDog/datadog-agent/tasks/libs/common/remote_api.py", line 79, in request
    raise APIError(r, self.api_name)
  File "/Users/kylian.serrania/go/src/github.com/DataDog/datadog-agent/tasks/libs/common/remote_api.py", line 11, in __init__
    super(APIError, self).__init__(f"{api_name} says: {request.json()}")
  File "/Users/kylian.serrania/Library/Python/3.8/lib/python/site-packages/requests/models.py", line 910, in json
    return complexjson.loads(self.text, **kwargs)
  File "/usr/local/Cellar/python@3.8/3.8.8_1/Frameworks/Python.framework/Versions/3.8/lib/python3.8/json/__init__.py", line 357, in loads
    return _default_decoder.decode(s)
  File "/usr/local/Cellar/python@3.8/3.8.8_1/Frameworks/Python.framework/Versions/3.8/lib/python3.8/json/decoder.py", line 340, in decode
    raise JSONDecodeError("Extra data", s, end)
json.decoder.JSONDecodeError: Extra data: line 1 column 5 (char 4)
```

</details>

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Test against a pipeline that showed this behavior: `CI_PIPELINE_ID=6555740 inv pipeline.notify-failure --print-to-stdout`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
