### PR TITLE
[Serverless] Add extension version to startup debug log

### DIFF
--- a/cmd/serverless/debug.go
+++ b/cmd/serverless/debug.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/serverless/tags"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -23,7 +24,9 @@ func outputDatadogEnvVariablesForDebugging() {
 func buildDebugString() string {
 	var sb strings.Builder
 	envMap := getEnvVariableToObfuscate()
-	sb.WriteString("Datadog environment variables: ")
+	sb.WriteString("Datadog extension version : ")
+	sb.WriteString(tags.GetExtensionVersion())
+	sb.WriteString("|Datadog environment variables: ")
 	allEnv := os.Environ()
 	sort.Strings(allEnv)
 	for _, pair := range allEnv {

--- a/cmd/serverless/debug.go
+++ b/cmd/serverless/debug.go
@@ -26,7 +26,8 @@ func buildDebugString() string {
 	envMap := getEnvVariableToObfuscate()
 	sb.WriteString("Datadog extension version : ")
 	sb.WriteString(tags.GetExtensionVersion())
-	sb.WriteString("|Datadog environment variables: ")
+	sb.WriteString("|")
+	sb.WriteString("Datadog environment variables: ")
 	allEnv := os.Environ()
 	sort.Strings(allEnv)
 	for _, pair := range allEnv {

--- a/cmd/serverless/debug_test.go
+++ b/cmd/serverless/debug_test.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"testing"
 
@@ -26,7 +27,8 @@ func TestBuildDebugString(t *testing.T) {
 
 	res := buildDebugString()
 	// cannot check for strict equality as the CI adds some env variables (ie : DD_REPO_BRANCH_NAME)
-	assert.Regexp(t, "Datadog environment variables: (.*)DD_AAA=aaa|(.*)DD_API_KEY=\\*\\*\\*|(.*)DD_BBB=bbb|(.*)DD_CCC=ccc|(.*)", res)
+	fmt.Println(res)
+	assert.Regexp(t, "Datadog extension version : totossss|Datadog environment variables: (.*)DD_AAA=aaa|(.*)DD_API_KEY=\\*\\*\\*|(.*)DD_BBB=bbb|(.*)DD_CCC=ccc|(.*)", res)
 }
 
 func TestObfuscatePairIfNeededInvalid(t *testing.T) {

--- a/cmd/serverless/debug_test.go
+++ b/cmd/serverless/debug_test.go
@@ -6,7 +6,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"testing"
 
@@ -27,8 +26,7 @@ func TestBuildDebugString(t *testing.T) {
 
 	res := buildDebugString()
 	// cannot check for strict equality as the CI adds some env variables (ie : DD_REPO_BRANCH_NAME)
-	fmt.Println(res)
-	assert.Regexp(t, "Datadog extension version : totossss|Datadog environment variables: (.*)DD_AAA=aaa|(.*)DD_API_KEY=\\*\\*\\*|(.*)DD_BBB=bbb|(.*)DD_CCC=ccc|(.*)", res)
+	assert.Regexp(t, "Datadog extension version : xxx\\|Datadog environment variables: ((DD_)?.*)DD_AAA=aaa\\|((DD_)?.*)DD_API_KEY=\\*\\*\\*\\|((DD_)?.*)DD_BBB=bbb\\|((DD_)?.*)DD_CCC=ccc\\|((DD_)?.*)", res)
 }
 
 func TestObfuscatePairIfNeededInvalid(t *testing.T) {

--- a/pkg/serverless/tags/tags.go
+++ b/pkg/serverless/tags/tags.go
@@ -74,7 +74,7 @@ func BuildTagMap(arn string, configTags []string) map[string]string {
 	tags = setIfNotEmpty(tags, traceOriginMetadataKey, traceOriginMetadataValue)
 	tags = setIfNotEmpty(tags, computeStatsKey, computeStatsValue)
 	tags = setIfNotEmpty(tags, functionARNKey, arn)
-	tags = setIfNotEmpty(tags, extensionVersionKey, currentExtensionVersion)
+	tags = setIfNotEmpty(tags, extensionVersionKey, GetExtensionVersion())
 
 	parts := strings.Split(arn, ":")
 	if len(parts) < 6 {
@@ -132,6 +132,11 @@ func BuildTracerTags(tags map[string]string) map[string]string {
 func AddColdStartTag(tags []string, coldStart bool) []string {
 	tags = append(tags, fmt.Sprintf("cold_start:%v", coldStart))
 	return tags
+}
+
+// GetExtensionVersion returns the extension version which is fed at build time
+func GetExtensionVersion() string {
+	return currentExtensionVersion
 }
 
 func setIfNotEmpty(tagMap map[string]string, key string, value string) map[string]string {


### PR DESCRIPTION
### What does this PR do?

Add the extension version to debug log lines at startup

![Screen Shot 2022-01-10 at 11 13 09 AM](https://user-images.githubusercontent.com/864493/148799277-2486fca4-61a6-491a-b43c-767a4daae961.png)


### Motivation

Make support easier 

### Describe how to test/QA your changes

Covered by unit-testing

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
