### PR TITLE
Add Windows flavor in Docker install info

### DIFF
--- a/.gitlab/image_build/docker_windows.yml
+++ b/.gitlab/image_build/docker_windows.yml
@@ -67,7 +67,7 @@
   needs: ["windows_msi_and_bosh_zip_x64-a7", "build_windows_container_entrypoint"]
   variables:
     AGENT_ZIP: "datadog-agent-7*-x86_64.zip"
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT}"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT} --build-arg INSTALL_INFO=nano-${VARIANT}"
 
 .docker_build_agent6_windows_common:
   extends:
@@ -78,20 +78,20 @@
   needs: ["windows_msi_x64-a6", "build_windows_container_entrypoint"]
   variables:
     AGENT_ZIP: "datadog-agent-6*-x86_64.zip"
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT}"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:nanoserver-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT} --build-arg INSTALL_INFO=nano-${VARIANT}"
 
 .docker_build_agent6_windows_servercore_common:
   extends:
     - .docker_build_agent6_windows_common
   variables:
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT}"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT} --build-arg INSTALL_INFO=core-${VARIANT}"
     SERVERCORE: "-servercore"
 
 .docker_build_agent7_windows_servercore_common:
   extends:
     - .docker_build_agent7_windows_common
   variables:
-    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT}"
+    BUILD_ARG: "--build-arg BASE_IMAGE=mcr.microsoft.com/powershell:windowsservercore-${VARIANT} --build-arg WITH_JMX=${WITH_JMX} --build-arg VARIANT=${VARIANT} --build-arg INSTALL_INFO=core-${VARIANT}"
     SERVERCORE: "-servercore"
 
 include:

--- a/Dockerfiles/agent/install.ps1
+++ b/Dockerfiles/agent/install.ps1
@@ -54,7 +54,7 @@ $Env:DOCKER_DD_AGENT="true"
 Write-Output @"
 ---
 install_method:
-  tool: docker
-  tool_version: docker-win-$env:VARIANT
-  installer_version: docker-win-$env:VARIANT
+  tool: docker-win
+  tool_version: docker-win-$env:INSTALL_INFO
+  installer_version: docker-win-$env:INSTALL_INFO
 "@ > C:/ProgramData/Datadog/install_info

--- a/Dockerfiles/agent/windows/amd64/Dockerfile
+++ b/Dockerfiles/agent/windows/amd64/Dockerfile
@@ -1,6 +1,7 @@
 ARG BASE_IMAGE=mcr.microsoft.com/powershell:lts-windowsservercore-1809
 ARG WITH_JMX="false"
 ARG VARIANT="unknown"
+ARG INSTALL_INFO="unknown"
 
 # Extract the embedded3.7z in a separate stage
 FROM mcr.microsoft.com/powershell:lts-windowsservercore-${VARIANT} as unzipper


### PR DESCRIPTION
### What does this PR do?

- Specify the flavor (nano or core) of the Windows base container image.
- Change `tool` from `docker` to `docker-win`.

### Motivation

- Tell the two flavors apart.
- `docker-win` is its own different thing from `docker`.

