### PR TITLE
WIP: fix(externalmetrics): removing strings.ToLower to be compatible to docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
   rev: 21.11b1
   hooks:
     - id: black
-- repo: https://github.com/timothycrosley/isort/
+- repo: https://github.com/PyCQA/isort
   rev: 5.10.1
   hooks:
     - id: isort

--- a/pkg/clusteragent/externalmetrics/provider.go
+++ b/pkg/clusteragent/externalmetrics/provider.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build kubeapiserver
 // +build kubeapiserver
 
 package externalmetrics
@@ -11,7 +12,6 @@ import (
 	"context"
 	"fmt"
 	"math"
-	"strings"
 
 	"github.com/kubernetes-sigs/custom-metrics-apiserver/pkg/provider"
 	apierr "k8s.io/apimachinery/pkg/api/errors"
@@ -112,9 +112,6 @@ func (p *datadogMetricProvider) GetExternalMetric(namespace string, metricSelect
 
 func (p *datadogMetricProvider) getExternalMetric(namespace string, metricSelector labels.Selector, info provider.ExternalMetricInfo) (*external_metrics.ExternalMetricValueList, error) {
 	log.Debugf("Received external metric query with ns: %s, selector: %s, metricName: %s", namespace, metricSelector.String(), info.Metric)
-
-	// Convert metric name to lower case to allow proper matching (and DD metrics are always lower case)
-	info.Metric = strings.ToLower(info.Metric)
 
 	// If the metric name is already prefixed, we can directly look up metrics in store
 	datadogMetricID, parsed, hasPrefix := metricNameToDatadogMetricID(info.Metric)

--- a/releasenotes/notes/fix-externalmetrics-removing-strings-ToLower-68ce8a437cd681b0.yaml
+++ b/releasenotes/notes/fix-externalmetrics-removing-strings-ToLower-68ce8a437cd681b0.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Removes `strings.ToLower(info.Metric)` to align with the custom metrics documentation.


### PR DESCRIPTION
### What does this PR do?

With this we remove the strings.ToLower(info.Metric) as we need to stay compatible to the DataDog [documentation] for custom metrics.

### Motivation

Without this fix the datadog agent cannot find a custom metric name like `customMetricName`, because it is looking for `custommetricname`.

### Additional Notes

Solves #10330

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.

[documentation]: https://docs.datadoghq.com/metrics/custom_metrics/#naming-custom-metrics