### PR TITLE
Don't use SendIterableSeries when enableJSONStream is disabled

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -302,7 +302,7 @@ func NewBufferedAggregator(s serializer.MetricSerializer, eventPlatformForwarder
 		ServerlessFlush:         make(chan bool),
 		ServerlessFlushDone:     make(chan struct{}),
 		flushAndSerializeInParallel: flushAndSerializeInParallel{
-			enabled:     config.Datadog.GetBool("aggregator_flush_metrics_and_serialize_in_parallel") && s.IsIterableSeriesSupported(),
+			enabled:     config.Datadog.GetBool("aggregator_flush_metrics_and_serialize_in_parallel") && s != nil && s.IsIterableSeriesSupported(),
 			bufferSize:  config.Datadog.GetInt("aggregator_flush_metrics_and_serialize_in_parallel_buffer_size"),
 			channelSize: config.Datadog.GetInt("aggregator_flush_metrics_and_serialize_in_parallel_chan_size"),
 		},

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -302,7 +302,7 @@ func NewBufferedAggregator(s serializer.MetricSerializer, eventPlatformForwarder
 		ServerlessFlush:         make(chan bool),
 		ServerlessFlushDone:     make(chan struct{}),
 		flushAndSerializeInParallel: flushAndSerializeInParallel{
-			enabled:     config.Datadog.GetBool("aggregator_flush_metrics_and_serialize_in_parallel"),
+			enabled:     config.Datadog.GetBool("aggregator_flush_metrics_and_serialize_in_parallel") && s.IsIterableSeriesSupported(),
 			bufferSize:  config.Datadog.GetInt("aggregator_flush_metrics_and_serialize_in_parallel_buffer_size"),
 			channelSize: config.Datadog.GetInt("aggregator_flush_metrics_and_serialize_in_parallel_chan_size"),
 		},

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -521,6 +521,7 @@ func TestAggregatorFlush(t *testing.T) {
 			config.Datadog.Set("aggregator_flush_metrics_and_serialize_in_parallel", tt.enabled)
 			s := &MockSerializerIterableSerie{}
 			s.On("SendServiceChecks", mock.Anything).Return(nil)
+			s.On("IsIterableSeriesSupported", mock.Anything).Return(true).Maybe()
 			agg := NewBufferedAggregator(s, nil, "hostname", DefaultFlushInterval)
 			expectedSeries := flushSomeSamples(agg)
 			assertSeriesEqual(t, s.series, expectedSeries)

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -333,10 +333,7 @@ func (s *Serializer) SendIterableSeries(series marshaler.IterableMarshaler) erro
 // IsIterableSeriesSupported returns whether `SendIterableSeries` is supported.
 // Should be removed when `serializePayloadJSON` (useV1API && !s.enableJSONStream) will be removed
 func (s *Serializer) IsIterableSeriesSupported() bool {
-	useV1API := !config.Datadog.GetBool("use_v2_api.series")
-
-	// Supported except for serializePayloadJSON
-	return !(useV1API && !s.enableJSONStream)
+	return config.Datadog.GetBool("use_v2_api.series") || s.enableJSONStream
 }
 
 // SendSeries serializes a list of serviceChecks and sends the payload to the forwarder

--- a/pkg/serializer/serializer.go
+++ b/pkg/serializer/serializer.go
@@ -97,6 +97,7 @@ type MetricSerializer interface {
 	SendServiceChecks(sc marshaler.StreamJSONMarshaler) error
 	SendSeries(series marshaler.StreamJSONMarshaler) error
 	SendIterableSeries(series marshaler.IterableMarshaler) error
+	IsIterableSeriesSupported() bool
 	SendSketch(sketches marshaler.Marshaler) error
 	SendMetadata(m marshaler.JSONMarshaler) error
 	SendHostMetadata(m marshaler.JSONMarshaler) error
@@ -327,6 +328,15 @@ func (s *Serializer) SendIterableSeries(series marshaler.IterableMarshaler) erro
 		return s.Forwarder.SubmitV1Series(seriesPayloads, extraHeaders)
 	}
 	return s.Forwarder.SubmitSeries(seriesPayloads, extraHeaders)
+}
+
+// IsIterableSeriesSupported returns whether `SendIterableSeries` is supported.
+// Should be removed when `serializePayloadJSON` (useV1API && !s.enableJSONStream) will be removed
+func (s *Serializer) IsIterableSeriesSupported() bool {
+	useV1API := !config.Datadog.GetBool("use_v2_api.series")
+
+	// Supported except for serializePayloadJSON
+	return !(useV1API && !s.enableJSONStream)
 }
 
 // SendSeries serializes a list of serviceChecks and sends the payload to the forwarder

--- a/pkg/serializer/test_common.go
+++ b/pkg/serializer/test_common.go
@@ -33,6 +33,11 @@ func (s *MockSerializer) SendIterableSeries(series marshaler.IterableMarshaler) 
 	return s.Called(series).Error(0)
 }
 
+// IsIterableSeriesSupported returns whether `SendIterableSeries` is supported
+func (s *MockSerializer) IsIterableSeriesSupported() bool {
+	return s.Called().Get(0).(bool)
+}
+
 // SendSeries serializes a list of serviceChecks and sends the payload to the forwarder
 func (s *MockSerializer) SendSeries(series marshaler.StreamJSONMarshaler) error {
 	return s.Called(series).Error(0)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Don't use `SendIterableSeries` when (useV1API && !s.enableJSONStream) is true.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

`SendIterableSeries` does not implement `serializePayloadJSON`.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Disable `enableJSONStream` by setting `enable_stream_payload_serialization: false`.

Before this PR the expvars `splitter` values are zero `"splitter": {"NotTooBig": 0, "PayloadDrops": 0, "TooBig": 0, "TotalLoops": 0}`.
After this PR the some expvars should be not zero

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
