### PR TITLE
Revert autodiscovery_scheduled_configs telemetry

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -18,7 +18,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/listeners"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/scheduler"
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/telemetry"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/secrets"
@@ -275,19 +274,11 @@ func (ac *AutoConfig) GetAllConfigs() []integration.Config {
 
 // schedule takes a slice of configs and schedule them
 func (ac *AutoConfig) schedule(configs []integration.Config) {
-	for _, conf := range configs {
-		telemetry.ScheduledConfigs.Inc(conf.Provider, conf.Type())
-	}
-
 	ac.scheduler.Schedule(configs)
 }
 
 // unschedule takes a slice of configs and unschedule them
 func (ac *AutoConfig) unschedule(configs []integration.Config) {
-	for _, conf := range configs {
-		telemetry.ScheduledConfigs.Dec(conf.Provider, conf.Type())
-	}
-
 	ac.scheduler.Unschedule(configs)
 }
 

--- a/pkg/autodiscovery/telemetry/telemetry.go
+++ b/pkg/autodiscovery/telemetry/telemetry.go
@@ -21,15 +21,6 @@ var (
 )
 
 var (
-	// ScheduledConfigs tracks how many configs are scheduled.
-	ScheduledConfigs = telemetry.NewGaugeWithOpts(
-		subsystem,
-		"scheduled_configs",
-		[]string{"provider", "type"},
-		"Number of configs scheduled in Autodiscovery by provider and type.",
-		commonOpts,
-	)
-
 	// WatchedResources tracks how many resources are watched by AD listeners.
 	WatchedResources = telemetry.NewGaugeWithOpts(
 		subsystem,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Revert telemetry metric `autodiscovery_scheduled_configs`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
The metric uncovered an unexpected behaviour in AD and reported negative values on some nodes in certain circumstances (multiple container restarts on the node). Even though the metric itself is not buggy, we preferred to revert it until the scheduling/unscheduling bug is fixed.

![image](https://user-images.githubusercontent.com/38987709/148953053-339bb6b1-2346-443e-a66d-f5c20fd55246.png)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

The unexpected behaviour in AD will be investigated and fixed, and we'll add this metric back then.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

The metric is not reported anymore

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
