### PR TITLE
Add UIDs to OOM/TCPQ checks to prevent conflicts with NPM

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/probe/oom_kill.go
@@ -48,7 +48,7 @@ func NewOOMKillProbe(cfg *ebpf.Config) (*OOMKillProbe, error) {
 
 	probes := []*manager.Probe{
 		{
-			ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kprobe/oom_kill_process", EBPFFuncName: "kprobe__oom_kill_process"},
+			ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kprobe/oom_kill_process", EBPFFuncName: "kprobe__oom_kill_process", UID: "oom"},
 		},
 	}
 

--- a/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
@@ -50,10 +50,10 @@ func NewTCPQueueLengthTracer(cfg *ebpf.Config) (*TCPQueueLengthTracer, error) {
 	defer compiledOutput.Close()
 
 	probes := []*manager.Probe{
-		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kprobe/tcp_recvmsg", EBPFFuncName: "kprobe__tcp_recvmsg"}},
-		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kretprobe/tcp_recvmsg", EBPFFuncName: "kretprobe__tcp_recvmsg"}},
-		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kprobe/tcp_sendmsg", EBPFFuncName: "kprobe__tcp_sendmsg"}},
-		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kretprobe/tcp_sendmsg", EBPFFuncName: "kretprobe__tcp_sendmsg"}},
+		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kprobe/tcp_recvmsg", EBPFFuncName: "kprobe__tcp_recvmsg", UID: "tcpq"}},
+		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kretprobe/tcp_recvmsg", EBPFFuncName: "kretprobe__tcp_recvmsg", UID: "tcpq"}},
+		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kprobe/tcp_sendmsg", EBPFFuncName: "kprobe__tcp_sendmsg", UID: "tcpq"}},
+		{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: "kretprobe/tcp_sendmsg", EBPFFuncName: "kretprobe__tcp_sendmsg", UID: "tcpq"}},
 	}
 
 	maps := []*manager.Map{

--- a/releasenotes/notes/npm-tcpq-conflict-bdba2237cd903e32.yaml
+++ b/releasenotes/notes/npm-tcpq-conflict-bdba2237cd903e32.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fixes a conflict preventing NPM and the TCP Queue Length check from being enabled at the same time.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add UIDs to OOM/TCPQ checks to prevent conflicts with NPM.

### Motivation

The `ebpf-manager` uses a deterministic probe event naming method. Since the TCP Queue Length Check uses some of the same kprobes as NPM, this can cause a conflict if both are enabled. 
```
new module `tcp_queue_length_tracer` error: unable to start the TCP queue length tracer: failed to start manager: probes activation validation failed: 1 error occurred:
        * {UID: EBPFSection:kprobe/tcp_sendmsg EBPFFuncName:kprobe__tcp_sendmsg}: couldn't enable kprobe {UID: EBPFSection:kprobe/tcp_sendmsg EBPFFuncName:kprobe__tcp_sendmsg}: cannot write "p:p_tcp_sendmsg__30777 tcp_sendmsg\n" to kprobe_events: write /sys/kernel/debug/tracing/kprobe_events: device or resource busy
``` 

### Additional Notes

This was introduced with https://github.com/DataDog/datadog-agent/pull/8779

Preemptively adding UID to all probes in the OOM Kill and TCP Queue Length checks.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
