### PR TITLE
[Serverlerss] add /trace-context endpoint

### DIFF
--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -116,7 +116,7 @@ func StartDaemon(addr string) *Daemon {
 
 	mux.Handle("/lambda/hello", &Hello{daemon})
 	mux.Handle("/lambda/flush", &Flush{daemon})
-	mux.Handle("/lambda/trace-context", &TraceContext{})
+	mux.Handle("/trace-context", &TraceContext{})
 
 	// start the HTTP server used to communicate with the runtime and the Lambda platform
 	go func() {

--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -116,6 +116,7 @@ func StartDaemon(addr string) *Daemon {
 
 	mux.Handle("/lambda/hello", &Hello{daemon})
 	mux.Handle("/lambda/flush", &Flush{daemon})
+	mux.Handle("/lambda/trace-context", &TraceContext{})
 
 	// start the HTTP server used to communicate with the runtime and the Lambda platform
 	go func() {

--- a/pkg/serverless/daemon/tracecontext.go
+++ b/pkg/serverless/daemon/tracecontext.go
@@ -21,11 +21,11 @@ type TraceContext struct {
 func (tc *TraceContext) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	log.Debug("Hit the serverless.TraceContext route.")
 
-	// TODO use traceId and spanId from the generated span
-	traceId := uint64(rand.Uint32())<<32 + uint64(rand.Uint32())
-	spanId := uint64(rand.Uint32())<<32 + uint64(rand.Uint32())
+	// TODO use traceID and spanID from the generated span
+	traceID := uint64(rand.Uint32())<<32 + uint64(rand.Uint32())
+	spanID := uint64(rand.Uint32())<<32 + uint64(rand.Uint32())
 
-	w.Header().Set("x-datadog-trace-id", fmt.Sprintf("%v", traceId))
-	w.Header().Set("x-datadog-span-id", fmt.Sprintf("%v", spanId))
+	w.Header().Set("x-datadog-trace-id", fmt.Sprintf("%v", traceID))
+	w.Header().Set("x-datadog-span-id", fmt.Sprintf("%v", spanID))
 	w.WriteHeader(200)
 }

--- a/pkg/serverless/daemon/tracecontext.go
+++ b/pkg/serverless/daemon/tracecontext.go
@@ -1,0 +1,31 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package daemon
+
+import (
+	"fmt"
+	"math/rand"
+	"net/http"
+
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+// TraceContext is a route called by tracer so they retrieve the tracing context
+type TraceContext struct {
+}
+
+// TraceContext - see type TraceContext comment.
+func (tc *TraceContext) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	log.Debug("Hit the serverless.TraceContext route.")
+
+	// TODO use traceId and spanId from the generated span
+	traceId := uint64(rand.Uint32())<<32 + uint64(rand.Uint32())
+	spanId := uint64(rand.Uint32())<<32 + uint64(rand.Uint32())
+
+	w.Header().Set("x-datadog-trace-id", fmt.Sprintf("%v", traceId))
+	w.Header().Set("x-datadog-span-id", fmt.Sprintf("%v", spanId))
+	w.WriteHeader(200)
+}

--- a/pkg/serverless/daemon/tracecontext.go
+++ b/pkg/serverless/daemon/tracecontext.go
@@ -13,7 +13,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-// TraceContext is a route called by tracer so they retrieve the tracing context
+// TraceContext is a route called by tracer so they can retrieve the tracing context
 type TraceContext struct {
 }
 

--- a/pkg/serverless/daemon/tracecontext_test.go
+++ b/pkg/serverless/daemon/tracecontext_test.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package daemon
+
+import (
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTraceContextEndpoint(t *testing.T) {
+	assert := assert.New(t)
+	d := StartDaemon("127.0.0.1:8124")
+	defer d.Stop()
+	client := &http.Client{Timeout: 1 * time.Second}
+	request, err := http.NewRequest(http.MethodPost, "http://127.0.0.1:8124/lambda/trace-context", nil)
+	assert.Nil(err)
+	response, err := client.Do(request)
+	assert.Nil(err)
+	assert.NotEmpty(response.Header.Get("x-datadog-trace-id"))
+	assert.NotEmpty(response.Header.Get("x-datadog-span-id"))
+}

--- a/pkg/serverless/daemon/tracecontext_test.go
+++ b/pkg/serverless/daemon/tracecontext_test.go
@@ -18,7 +18,7 @@ func TestTraceContextEndpoint(t *testing.T) {
 	d := StartDaemon("127.0.0.1:8124")
 	defer d.Stop()
 	client := &http.Client{Timeout: 1 * time.Second}
-	request, err := http.NewRequest(http.MethodPost, "http://127.0.0.1:8124/lambda/trace-context", nil)
+	request, err := http.NewRequest(http.MethodPost, "http://127.0.0.1:8124/trace-context", nil)
 	assert.Nil(err)
 	response, err := client.Do(request)
 	assert.Nil(err)


### PR DESCRIPTION
### What does this PR do?

Adds /trace-context endpoint

### Motivation

This endpoint will be used by tracers so they can be aware of the trace context

### Describe how to test/QA your changes

Covered by unit-testing 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
