### PR TITLE
Fixup GNUTLS by hooking gnutls_deinit(ctx)

### DIFF
--- a/pkg/network/http/ebpf_ssl.go
+++ b/pkg/network/http/ebpf_ssl.go
@@ -46,6 +46,7 @@ var gnuTLSProbes = map[string]string{
 	"uretprobe/gnutls_record_recv":     "uretprobe__gnutls_record_recv",
 	"uprobe/gnutls_record_send":        "uprobe__gnutls_record_send",
 	"uprobe/gnutls_bye":                "uprobe__gnutls_bye",
+	"uprobe/gnutls_deinit":             "uprobe__gnutls_deinit",
 }
 
 const (


### PR DESCRIPTION
### What does this PR do?

Support more implementation linked with lib gnutls

### Motivation

Some program linked with gnutls lib doesn't call gnutls_bye() but gnutls_deinit()

### Describe how to test/QA your changes

wget/gnutls (debian-10 IIRC) have this behavior

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
