### PR TITLE
[containerd] Allow to watch list of namespaces

### DIFF
--- a/pkg/collector/corechecks/containers/containerd/containerd.go
+++ b/pkg/collector/corechecks/containers/containerd/containerd.go
@@ -84,7 +84,7 @@ func (c *ContainerdCheck) Configure(config, initConfig integration.Data, source 
 	if err = c.instance.Parse(config); err != nil {
 		return err
 	}
-	c.sub.Filters = c.subscribeFilters()
+	c.sub.Filters = cutil.FiltersWithNamespaces(c.instance.ContainerdFilters)
 	// GetSharedMetricFilter should not return a nil instance of *Filter if there is an error during its setup.
 	fil, err := ddContainers.GetSharedMetricFilter()
 	if err != nil {
@@ -118,7 +118,7 @@ func (c *ContainerdCheck) Run() error {
 
 	if c.instance.CollectEvents {
 		if c.sub == nil {
-			c.sub = CreateEventSubscriber("ContainerdCheck", c.subscribeFilters())
+			c.sub = CreateEventSubscriber("ContainerdCheck", cutil.FiltersWithNamespaces(c.instance.ContainerdFilters))
 		}
 
 		if !c.sub.IsRunning() {
@@ -465,23 +465,4 @@ func computeStorageWindows(sender aggregator.Sender, storageStats *wstats.Window
 
 	sender.Rate("containerd.storage.read", float64(storageStats.ReadSizeBytes), "", tags)
 	sender.Rate("containerd.storage.write", float64(storageStats.WriteSizeBytes), "", tags)
-}
-
-// subscribeFilters returns the filters that we need to send to the containerd
-// events subscriber. This returns the user-provided filters present in the
-// config modified, if needed, to filter by namespace as well.
-func (c *ContainerdCheck) subscribeFilters() []string {
-	namespace := config.Datadog.GetString("containerd_namespace")
-
-	if namespace == "" {
-		// We don't need to filter by namespace
-		return c.instance.ContainerdFilters
-	}
-
-	var filters []string
-	for _, filter := range c.instance.ContainerdFilters {
-		filters = append(filters, fmt.Sprintf(`%s,namespace==%q`, filter, namespace))
-	}
-
-	return filters
 }

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2361,14 +2361,15 @@ api_key:
 #
 # cri_query_timeout: 5
 
-## @param containerd_namespace - string - optional - default: ""
-## @env DD_CONTAINERD_NAMESPACE - string - optional - default: ""
+## @param containerd_namespace - list of strings - optional - default: ""
+## @env DD_CONTAINERD_NAMESPACE - space separated list of strings - optional - default: ""
 ## Activating the Containerd check also activates the CRI check, as it contains an additional subset of useful metrics.
 ## Defaults to "" which configures the agent to report metrics and events from all the containerd namespaces.
-## If you would like to limit it to watch just one namespace, specify it here.
+## To watch specific namespaces, list them here.
 ## https://github.com/containerd/cri/blob/release/1.2/pkg/constants/constants.go#L22-L23
 #
-# containerd_namespace: k8s.io
+# containerd_namespace:
+#   - k8s.io
 
 {{ end -}}
 {{- if .Kubelet }}

--- a/pkg/util/containerd/namespaces.go
+++ b/pkg/util/containerd/namespaces.go
@@ -9,17 +9,44 @@ package containerd
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
 // NamespacesToWatch returns the namespaces to watch. If the
-// "containerd_namespace" option has been set, it returns that namespace.
+// "containerd_namespace" option has been set, it returns the namespaces it contains.
 // Otherwise, it returns all of them.
 func NamespacesToWatch(ctx context.Context, containerdClient ContainerdItf) ([]string, error) {
-	if namespace := config.Datadog.GetString("containerd_namespace"); namespace != "" {
-		return []string{namespace}, nil
+	namespaces := config.Datadog.GetStringSlice("containerd_namespace")
+
+	if len(namespaces) == 0 {
+		return containerdClient.Namespaces(ctx)
 	}
 
-	return containerdClient.Namespaces(ctx)
+	return namespaces, nil
+}
+
+// FiltersWithNamespaces returns the given list of filters adapted to take into
+// account the namespaces that we need to watch.
+// For example, if the given filter is `topic=="/container/create"`, and the
+// namespace that we need to watch is "ns1", this function returns
+// `topic=="/container/create",namespace=="ns1"`.
+func FiltersWithNamespaces(filters []string) []string {
+	namespaces := config.Datadog.GetStringSlice("containerd_namespace")
+
+	if len(namespaces) == 0 {
+		// Watch all namespaces. No need to add them to the filters.
+		return filters
+	}
+
+	var res []string
+
+	for _, filter := range filters {
+		for _, namespace := range namespaces {
+			res = append(res, fmt.Sprintf(`%s,namespace==%q`, filter, namespace))
+		}
+	}
+
+	return res
 }

--- a/pkg/util/containerd/namespaces_test.go
+++ b/pkg/util/containerd/namespaces_test.go
@@ -27,9 +27,15 @@ func TestNamespacesToWatch(t *testing.T) {
 		expectsError           bool
 	}{
 		{
-			name:                   "containerd_namespace set",
+			name:                   "containerd_namespace set with one namespace",
 			containerdNamespaceVal: "some_namespace",
 			expectedNamespaces:     []string{"some_namespace"},
+			expectsError:           false,
+		},
+		{
+			name:                   "containerd_namespace set with multiple namespaces",
+			containerdNamespaceVal: "ns1 ns2 ns3",
+			expectedNamespaces:     []string{"ns1", "ns2", "ns3"},
 			expectsError:           false,
 		},
 		{
@@ -51,6 +57,9 @@ func TestNamespacesToWatch(t *testing.T) {
 		},
 	}
 
+	originalContainerdNamespaceOpt := config.Datadog.GetString("containerd_namespace")
+	defer config.Datadog.Set("containerd_namespace", originalContainerdNamespaceOpt)
+
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			config.Datadog.Set("containerd_namespace", test.containerdNamespaceVal)
@@ -62,6 +71,65 @@ func TestNamespacesToWatch(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, test.expectedNamespaces, namespaces)
 			}
+		})
+	}
+}
+
+func TestFiltersWithNamespaces(t *testing.T) {
+	tests := []struct {
+		name                         string
+		containerdNamespaceConfigOpt string
+		inputFilters                 []string
+		expectedFilters              []string
+	}{
+		{
+			name:                         "watch all namespaces",
+			containerdNamespaceConfigOpt: "",
+			inputFilters: []string{
+				`topic==/containers/create`,
+				`topic==/containers/delete`,
+			},
+			expectedFilters: []string{
+				`topic==/containers/create`,
+				`topic==/containers/delete`,
+			},
+		},
+		{
+			name:                         "watch one namespace",
+			containerdNamespaceConfigOpt: "ns1",
+			inputFilters: []string{
+				`topic=="/containers/create"`,
+				`topic=="/containers/delete"`,
+			},
+			expectedFilters: []string{
+				`topic=="/containers/create",namespace=="ns1"`,
+				`topic=="/containers/delete",namespace=="ns1"`,
+			},
+		},
+		{
+			name:                         "watch several namespaces, but not all",
+			containerdNamespaceConfigOpt: "ns1 ns2",
+			inputFilters: []string{
+				`topic=="/containers/create"`,
+				`topic=="/containers/delete"`,
+			},
+			expectedFilters: []string{
+				`topic=="/containers/create",namespace=="ns1"`,
+				`topic=="/containers/delete",namespace=="ns1"`,
+				`topic=="/containers/create",namespace=="ns2"`,
+				`topic=="/containers/delete",namespace=="ns2"`,
+			},
+		},
+	}
+
+	originalContainerdNamespaceOpt := config.Datadog.GetString("containerd_namespace")
+	defer config.Datadog.Set("containerd_namespace", originalContainerdNamespaceOpt)
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config.Datadog.Set("containerd_namespace", test.containerdNamespaceConfigOpt)
+			result := FiltersWithNamespaces(test.inputFilters)
+			assert.ElementsMatch(t, test.expectedFilters, result)
 		})
 	}
 }

--- a/pkg/workloadmeta/collectors/containerd/containerd.go
+++ b/pkg/workloadmeta/collectors/containerd/containerd.go
@@ -294,34 +294,14 @@ func (c *collector) ignoreEvent(ctx context.Context, containerdEvent *containerd
 	return c.filterPausedContainers.IsExcluded("", img.Name(), ""), nil
 }
 
-// subscribeFilters returns the containerd filters we need to subscribe to based
-// on the "containerd_namespace" option and the containerdTopics array defined.
-//
-// When "containerd_namespace" is empty, it means that we don't want to filter
-// by namespace. In that case, the filters only include topics.
-//
-// When the namespace is not empty, we need to include it on every filter. If we
-// define a filter with the TaskStartTopic topic and a second filter with a
-// namespace, we will receive an event when it is a TaskStartTopic OR
-// (inclusive) when the namespace is the one that we selected. What we need is
-// to only receive events that match both conditions and that's why they need to
-// be specified in the same filter.
 func subscribeFilters() []string {
-	namespace := config.Datadog.GetString("containerd_namespace")
-
 	var filters []string
 
 	for _, topic := range containerdTopics {
-		var filter string
-		if namespace == "" {
-			filter = fmt.Sprintf(`topic==%q`, topic)
-		} else {
-			filter = fmt.Sprintf(`topic==%q,namespace==%q`, topic, namespace)
-		}
-		filters = append(filters, filter)
+		filters = append(filters, fmt.Sprintf(`topic==%q`, topic))
 	}
 
-	return filters
+	return cutil.FiltersWithNamespaces(filters)
 }
 
 func (c *collector) getExitInfo(id string) *exitInfo {


### PR DESCRIPTION
### What does this PR do?

Allows to watch a list of containerd namespaces using the `containerd_namespace` option.

It was possible to watch a single namespace or all of them. This PR adds the possibility to watch several namespaces by specifying them separated by spaces in the `containerd_namespace` option.


### Describe how to test/QA your changes

Same as https://github.com/DataDog/datadog-agent/pull/10128 but define a list in `DD_CONTAINERD_NAMESPACE` like `DD_CONTAINERD_NAMESPACE=ns1 ns2`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
