### PR TITLE
[workloadmeta] Fixes EventTypeSet/Unset logic

### DIFF
--- a/pkg/workloadmeta/store_test.go
+++ b/pkg/workloadmeta/store_test.go
@@ -377,6 +377,65 @@ func TestSubscribe(t *testing.T) {
 				},
 			},
 		},
+		{
+			// setting an entity from two different sources, and
+			// unsetting one of them, correctly generates a three
+			// sets and no unsets
+			name:   "sets and unsets an entity from different sources",
+			filter: nil,
+			postEvents: [][]CollectorEvent{
+				{
+					{
+						Type:   EventTypeSet,
+						Source: fooSource,
+						Entity: fooContainer.GetID(),
+					},
+				},
+				{
+					{
+						Type:   EventTypeSet,
+						Source: barSource,
+						Entity: fooContainer.GetID(),
+					},
+				},
+				{
+					{
+						Type:   EventTypeUnset,
+						Source: fooSource,
+						Entity: fooContainer.GetID(),
+					},
+				},
+			},
+			expected: []EventBundle{
+				{
+					Events: []Event{
+						{
+							Type:    EventTypeSet,
+							Sources: []Source{fooSource},
+							Entity:  fooContainer.GetID(),
+						},
+					},
+				},
+				{
+					Events: []Event{
+						{
+							Type:    EventTypeSet,
+							Sources: []Source{barSource, fooSource},
+							Entity:  fooContainer.GetID(),
+						},
+					},
+				},
+				{
+					Events: []Event{
+						{
+							Type:    EventTypeSet,
+							Sources: []Source{barSource},
+							Entity:  fooContainer.GetID(),
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
### What does this PR do?

This fixes an issue where a workloadmeta subscriber would see an
EventTypeUnset when actually updating an entity.

### Describe how to test/QA your changes

This has been observed, and has the easiest repro, in ECS EC2. Deploy the agent, and check that after ~5minutes the `sum:container.uptime{ecs_cluster_name:$your_cluster_name} by {container_name}` metric does not contain `container_name:N/A`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
