### PR TITLE
[CWS] add runtime security agent command to download policy

### DIFF
--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"os"
+	"path"
 	"time"
 
 	"github.com/pkg/errors"
@@ -273,12 +275,15 @@ func downloadPolicy(cmd *cobra.Command, args []string) error {
 	apiKey := coreconfig.Datadog.GetString("api_key")
 	appKey := coreconfig.Datadog.GetString("app_key")
 	site := coreconfig.Datadog.GetString("site")
+	policiesDir := coreconfig.Datadog.GetString("runtime_security_config.policies.dir")
+
 	if site == "" {
 		site = "datadoghq.com"
 	}
 
 	downloadUrl := fmt.Sprintf("https://api.%s/api/v2/security/cloud_workload/policy/download", site)
 	fmt.Printf("Policy download url: %s\n", downloadUrl)
+	fmt.Printf("Policies dir:        %s\n", policiesDir)
 
 	headers := map[string]string{
 		"Content-Type":       "application/json",
@@ -292,7 +297,10 @@ func downloadPolicy(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	fmt.Printf("%s\n", res)
+	outputPath := path.Join(policiesDir, "default.policy")
+	if err := os.WriteFile(outputPath, []byte(res), 0644); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -115,7 +115,8 @@ var (
 	}
 
 	downloadPolicyArgs = struct {
-		check bool
+		check      bool
+		outputPath string
 	}{}
 
 	commonPolicyCmd = &cobra.Command{
@@ -136,6 +137,7 @@ func init() {
 	runtimeCmd.AddCommand(reloadPoliciesCmd)
 
 	downloadPolicyCmd.Flags().BoolVar(&downloadPolicyArgs.check, "check", false, "Check policies after downloading")
+	downloadPolicyCmd.Flags().StringVar(&downloadPolicyArgs.outputPath, "output-path", "", "Output path for downloaded policies")
 	commonPolicyCmd.AddCommand(downloadPolicyCmd)
 
 	commonCheckPoliciesCmd.Flags().StringVar(&checkPoliciesArgs.dir, "policies-dir", coreconfig.DefaultRuntimePoliciesDir, "Path to policies directory")
@@ -327,7 +329,7 @@ func downloadPolicy(cmd *cobra.Command, args []string) error {
 	}
 
 	var outputPath string
-	if len(args) == 0 {
+	if downloadPolicyArgs.outputPath == "" {
 		policiesDir := coreconfig.Datadog.GetString("runtime_security_config.policies.dir")
 		outputPath = path.Join(policiesDir, "default.policy")
 	} else {

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -273,6 +273,14 @@ func startRuntimeSecurity(hostname string, stopper restart.Stopper, statsdClient
 }
 
 func downloadPolicy(cmd *cobra.Command, args []string) error {
+	if !coreconfig.Datadog.IsSet("api_key") {
+		return errors.New("no API key is set")
+	}
+
+	if !coreconfig.Datadog.IsSet("app_key") {
+		return errors.New("no application key is set")
+	}
+
 	apiKey := coreconfig.Datadog.GetString("api_key")
 	appKey := coreconfig.Datadog.GetString("app_key")
 

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -310,16 +310,16 @@ func startRuntimeSecurity(hostname string, stopper restart.Stopper, statsdClient
 }
 
 func downloadPolicy(cmd *cobra.Command, args []string) error {
-	if !coreconfig.Datadog.IsSet("api_key") {
-		return errors.New("no API key is set")
-	}
-
-	if !coreconfig.Datadog.IsSet("app_key") {
-		return errors.New("no application key is set")
-	}
-
 	apiKey := coreconfig.Datadog.GetString("api_key")
 	appKey := coreconfig.Datadog.GetString("app_key")
+
+	if apiKey == "" {
+		return errors.New("API key is empty")
+	}
+
+	if appKey == "" {
+		return errors.New("application key is empty")
+	}
 
 	site := coreconfig.Datadog.GetString("site")
 	if site == "" {

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -42,6 +42,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/status/health"
 	httputils "github.com/DataDog/datadog-agent/pkg/util/http"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/version"
 	ddgostatsd "github.com/DataDog/datadog-go/statsd"
 )
 
@@ -305,6 +306,10 @@ func downloadPolicy(cmd *cobra.Command, args []string) error {
 		"Content-Type":       "application/json",
 		"DD-API-KEY":         apiKey,
 		"DD-APPLICATION-KEY": appKey,
+	}
+
+	if av, err := version.Agent(); err == nil {
+		headers["DD-AGENT-VERSION"] = av.GetNumberAndPre()
 	}
 
 	ctx := context.Background()

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -289,8 +289,8 @@ func downloadPolicy(cmd *cobra.Command, args []string) error {
 		outputPath = args[0]
 	}
 
-	downloadUrl := fmt.Sprintf("https://api.%s/api/v2/security/cloud_workload/policy/download", site)
-	fmt.Printf("Policy download url: %s\n", downloadUrl)
+	downloadURL := fmt.Sprintf("https://api.%s/api/v2/security/cloud_workload/policy/download", site)
+	fmt.Printf("Policy download url: %s\n", downloadURL)
 	fmt.Printf("Output path:         %s\n", outputPath)
 
 	headers := map[string]string{
@@ -300,7 +300,7 @@ func downloadPolicy(cmd *cobra.Command, args []string) error {
 	}
 
 	ctx := context.Background()
-	res, err := httputils.Get(ctx, downloadUrl, headers, 10*time.Second)
+	res, err := httputils.Get(ctx, downloadURL, headers, 10*time.Second)
 	if err != nil {
 		return err
 	}

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -57,9 +57,10 @@ var (
 	}
 
 	checkPoliciesCmd = &cobra.Command{
-		Use:   "check-policies",
-		Short: "Check policies and return a report",
-		RunE:  checkPolicies,
+		Use:        "check-policies",
+		Short:      "Check policies and return a report",
+		RunE:       checkPolicies,
+		Deprecated: "please use `security-agent runtime policy check` instead",
 	}
 
 	checkPoliciesArgs = struct {
@@ -88,14 +89,27 @@ var (
 	}
 
 	reloadPoliciesCmd = &cobra.Command{
+		Use:        "reload",
+		Short:      "Reload policies",
+		RunE:       reloadRuntimePolicies,
+		Deprecated: "please use `security-agent runtime policy reload` instead",
+	}
+
+	commonReloadPoliciesCmd = &cobra.Command{
 		Use:   "reload",
 		Short: "Reload policies",
 		RunE:  reloadRuntimePolicies,
 	}
 
+	commonCheckPoliciesCmd = &cobra.Command{
+		Use:   "check",
+		Short: "Check policies and return a report",
+		RunE:  checkPolicies,
+	}
+
 	downloadPolicyCmd = &cobra.Command{
-		Use:   "download-policy",
-		Short: "Download policy",
+		Use:   "download",
+		Short: "Download policies",
 		Args:  cobra.MaximumNArgs(1),
 		RunE:  downloadPolicy,
 	}
@@ -103,6 +117,11 @@ var (
 	downloadPolicyArgs = struct {
 		check bool
 	}{}
+
+	commonPolicyCmd = &cobra.Command{
+		Use:   "policy",
+		Short: "Policy related commands",
+	}
 )
 
 func init() {
@@ -115,8 +134,16 @@ func init() {
 
 	runtimeCmd.AddCommand(selfTestCmd)
 	runtimeCmd.AddCommand(reloadPoliciesCmd)
-	runtimeCmd.AddCommand(downloadPolicyCmd)
+
 	downloadPolicyCmd.Flags().BoolVar(&downloadPolicyArgs.check, "check", false, "Check policies after downloading")
+	commonPolicyCmd.AddCommand(downloadPolicyCmd)
+
+	commonCheckPoliciesCmd.Flags().StringVar(&checkPoliciesArgs.dir, "policies-dir", coreconfig.DefaultRuntimePoliciesDir, "Path to policies directory")
+	commonPolicyCmd.AddCommand(commonCheckPoliciesCmd)
+
+	commonPolicyCmd.AddCommand(commonReloadPoliciesCmd)
+
+	runtimeCmd.AddCommand(commonPolicyCmd)
 }
 
 func dumpProcessCache(cmd *cobra.Command, args []string) error {

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -341,7 +341,7 @@ func downloadPolicy(cmd *cobra.Command, args []string) error {
 	}
 
 	downloadURL := fmt.Sprintf("https://api.%s/api/v2/security/cloud_workload/policy/download", site)
-	fmt.Printf("Policy download url: %s\n", downloadURL)
+	fmt.Fprintf(os.Stderr, "Policy download url: %s\n", downloadURL)
 
 	headers := map[string]string{
 		"Content-Type":       "application/json",

--- a/cmd/security-agent/app/runtime.go
+++ b/cmd/security-agent/app/runtime.go
@@ -110,7 +110,6 @@ var (
 	downloadPolicyCmd = &cobra.Command{
 		Use:   "download",
 		Short: "Download policies",
-		Args:  cobra.MaximumNArgs(1),
 		RunE:  downloadPolicy,
 	}
 
@@ -333,7 +332,7 @@ func downloadPolicy(cmd *cobra.Command, args []string) error {
 		policiesDir := coreconfig.Datadog.GetString("runtime_security_config.policies.dir")
 		outputPath = path.Join(policiesDir, "default.policy")
 	} else {
-		outputPath = args[0]
+		outputPath = downloadPolicyArgs.outputPath
 	}
 
 	downloadURL := fmt.Sprintf("https://api.%s/api/v2/security/cloud_workload/policy/download", site)

--- a/releasenotes/notes/cws-cmd-download-policy-0b19ce628afd289f.yaml
+++ b/releasenotes/notes/cws-cmd-download-policy-0b19ce628afd289f.yaml
@@ -11,5 +11,5 @@ features:
     The security Agent now offers a command to directly download the policy file from the API.
 deprecations:
   - |
-    The security Agent commands `check-policies` and `reload` are deprecated.
-    Use `runtime policy check` and `runtime policy reload` respectively instead.
+    The security Agent commands ``check-policies`` and ``reload`` are deprecated.
+    Use ``runtime policy check`` and ``runtime policy reload`` respectively instead.

--- a/releasenotes/notes/cws-cmd-download-policy-0b19ce628afd289f.yaml
+++ b/releasenotes/notes/cws-cmd-download-policy-0b19ce628afd289f.yaml
@@ -8,7 +8,7 @@
 ---
 features:
   - |
-    The security agent now offers a command to directly download policy file from the API.
+    The security agent now offers a command to directly download the policy file from the API.
 deprecations:
   - |
     The commands `check-policies` and `reload` of the security agent are deprecated.

--- a/releasenotes/notes/cws-cmd-download-policy-0b19ce628afd289f.yaml
+++ b/releasenotes/notes/cws-cmd-download-policy-0b19ce628afd289f.yaml
@@ -1,0 +1,15 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    The security agent now offers a command to directly download policy file from the API.
+deprecations:
+  - |
+    The commands `check-policies` and `reload` of the security agent are deprecated.
+    Please use `runtime policy check` and `runtime policy reload` respectively instead.

--- a/releasenotes/notes/cws-cmd-download-policy-0b19ce628afd289f.yaml
+++ b/releasenotes/notes/cws-cmd-download-policy-0b19ce628afd289f.yaml
@@ -8,8 +8,8 @@
 ---
 features:
   - |
-    The security agent now offers a command to directly download the policy file from the API.
+    The security Agent now offers a command to directly download the policy file from the API.
 deprecations:
   - |
-    The commands `check-policies` and `reload` of the security agent are deprecated.
-    Please use `runtime policy check` and `runtime policy reload` respectively instead.
+    The security Agent commands `check-policies` and `reload` are deprecated.
+    Use `runtime policy check` and `runtime policy reload` respectively instead.


### PR DESCRIPTION
### What does this PR do?

This PR adds a command to the security agent runtime subcommand to download the CWS policy from the API.
It also reworks policy-related commands:
- `security-agent runtime check-policies -> security-agent runtime policy check`
- `security-agent runtime reload -> security-agent runtime policy reload`
- `security-agent runtime policy download`

Old commands are kept for now, but marked deprecated and will print a message when used

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
