### PR TITLE
Do not schedule checks for stopped podman containers

### DIFF
--- a/pkg/workloadmeta/collectors/podman/podman.go
+++ b/pkg/workloadmeta/collectors/podman/podman.go
@@ -103,8 +103,15 @@ func convertToEvent(container *podman.Container) workloadmeta.CollectorEvent {
 		})
 	}
 
+	var eventType workloadmeta.EventType
+	if container.State.State == podman.ContainerStateRunning {
+		eventType = workloadmeta.EventTypeSet
+	} else {
+		eventType = workloadmeta.EventTypeUnset
+	}
+
 	return workloadmeta.CollectorEvent{
-		Type:   workloadmeta.EventTypeSet,
+		Type:   eventType,
 		Source: workloadmeta.SourcePodman,
 		Entity: &workloadmeta.Container{
 			EntityID: workloadmeta.EntityID{


### PR DESCRIPTION
### What does this PR do?

Ensure stopped podman containers are removed from the workload meta store.

### Motivation

The agent is currently scheduling checks for stopped podman containers.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Start an agent:
```
podman run -v /var/lib/containers/:/var/lib/containers/ --net=host -e DD_API_KEY=$DD_API_KEY gcr.io/datadoghq/agent:7.34.0-rc.1
```

Start a redis container:
```
podman run --net=host --label "com.datadoghq.ad.check_names=[\"redisdb\"]" --label "com.datadoghq.ad.init_configs=[{}]" --label "com.datadoghq.ad.instances=[{\"host\":\"localhost\",\"port\":6379}]" --label "com.datadoghq.ad.logs=[{\"source\":\"redis\"}]" docker.io/redis
```

This should schedule a working `redisdb` check.
To be checked with `agent status` and `agent checkconfig`.

Then, stop the redis container.

Before this change, a new instance of the `redisdb` check was scheduled. As it was targeting a stopped container, it was failing.
With this change, there shouldn’t be any `redisdb` check for this container anymore.
To be checked with `agent status` and `agent checkconfig`.

### Reviewer's Checklist


- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
