### PR TITLE
Support a max point count in serializing series

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -440,6 +440,7 @@ func InitConfig(config Config) {
 	// Warning: do not change the two following values. Your payloads will get dropped by Datadog's intake.
 	config.BindEnvAndSetDefault("serializer_max_payload_size", 2*megaByte+megaByte/2)
 	config.BindEnvAndSetDefault("serializer_max_uncompressed_payload_size", 4*megaByte)
+	config.BindEnvAndSetDefault("serializer_max_series_points_per_payload", 100000)
 
 	config.BindEnvAndSetDefault("use_v2_api.series", false)
 	// Serializer: allow user to blacklist any kind of payload to be sent

--- a/pkg/metrics/series.go
+++ b/pkg/metrics/series.go
@@ -318,7 +318,9 @@ func marshalSplitCompress(iterator serieIterator, bufferContext *marshaler.Buffe
 			return err
 		}
 
-		payloads = append(payloads, &payload)
+		if seriesThisPayload > 0 {
+			payloads = append(payloads, &payload)
+		}
 
 		return nil
 	}
@@ -462,11 +464,9 @@ func marshalSplitCompress(iterator serieIterator, bufferContext *marshaler.Buffe
 	}
 
 	// if the last payload has any data, flush it
-	if seriesThisPayload > 0 {
-		err = finishPayload()
-		if err != nil {
-			return nil, err
-		}
+	err = finishPayload()
+	if err != nil {
+		return nil, err
 	}
 
 	return payloads, nil

--- a/pkg/metrics/series_test.go
+++ b/pkg/metrics/series_test.go
@@ -17,6 +17,7 @@ import (
 
 	jsoniter "github.com/json-iterator/go"
 
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/serializer/marshaler"
 	"github.com/DataDog/datadog-agent/pkg/serializer/stream"
@@ -349,11 +350,8 @@ func TestDescribeItem(t *testing.T) {
 	assert.Equal(t, "out of range", desc2)
 }
 
-func TestMarshalSplitCompress(t *testing.T) {
-	const numItems = 10000
-	const numPoints = 50
-	var series Series
-	series = make([]*Serie, 0, numItems)
+func makeSeries(numItems, numPoints int) Series {
+	series := make([]*Serie, 0, numItems)
 	for i := 0; i < numItems; i++ {
 		series = append(series, &Serie{
 			Points: func() []Point {
@@ -370,6 +368,11 @@ func TestMarshalSplitCompress(t *testing.T) {
 			Tags:     []string{"tag1", "tag2:yes"},
 		})
 	}
+	return series
+}
+
+func TestMarshalSplitCompress(t *testing.T) {
+	series := makeSeries(10000, 50)
 
 	payloads, err := series.MarshalSplitCompress(marshaler.DefaultBufferContext())
 	require.NoError(t, err)
@@ -381,6 +384,20 @@ func TestMarshalSplitCompress(t *testing.T) {
 
 		// TODO: unmarshal these when agent-payload has support
 	}
+}
+
+func TestMarshalSplitCompressPointsLimit(t *testing.T) {
+	mockConfig := config.Mock()
+	oldMax := mockConfig.GetInt("serializer_max_series_points_per_payload")
+	defer mockConfig.Set("serializer_max_series_points_per_payload", oldMax)
+	mockConfig.Set("serializer_max_series_points_per_payload", 100)
+
+	// ten series, each with 50 points, so two should fit in each payload
+	series := makeSeries(10, 50)
+
+	payloads, err := series.MarshalSplitCompress(marshaler.DefaultBufferContext())
+	require.NoError(t, err)
+	require.Equal(t, 5, len(payloads))
 }
 
 // test taken from the spliter

--- a/pkg/metrics/series_test.go
+++ b/pkg/metrics/series_test.go
@@ -400,6 +400,18 @@ func TestMarshalSplitCompressPointsLimit(t *testing.T) {
 	require.Equal(t, 5, len(payloads))
 }
 
+func TestMarshalSplitCompressPointsLimitTooBig(t *testing.T) {
+	mockConfig := config.Mock()
+	oldMax := mockConfig.GetInt("serializer_max_series_points_per_payload")
+	defer mockConfig.Set("serializer_max_series_points_per_payload", oldMax)
+	mockConfig.Set("serializer_max_series_points_per_payload", 1)
+
+	series := makeSeries(1, 2)
+	payloads, err := series.MarshalSplitCompress(marshaler.DefaultBufferContext())
+	require.NoError(t, err)
+	require.Len(t, payloads, 0)
+}
+
 // test taken from the spliter
 func TestPayloadsSeries(t *testing.T) {
 	testSeries := Series{}


### PR DESCRIPTION
### What does this PR do?

This adds a new configuration value, "serializer_max_series_points_per_payload", defining the maximum number of series points to put in a single payload.  It then finishes a payload if the next series would put it over the limit.

### Motivation

Request from intake team

### Possible Drawbacks / Trade-offs

This was a minimal change to accomplish the goal without adding unnecessary risk.

Series serialization now has three limits for a payload: compressed size, uncompressed size, and number of points.  The first two are handled by the compressor, and in this patch the third is handled by the series marshalSplitCompress function.  Note that the compressor is generic to multiple metric types, not all of which have points.

A more invasive approach would involve refactoring all of this to abstract the serialization loop currently duplicated between the different metric types, and adding support for multiple per-payload maxima.  That would constitute a change to multiple metric types, though, and has a high likelihood of introducing bugs.

### Describe how to test/QA your changes

With the previous agent version, observe that the rate at which 
```
curl http://localhost:5000/debug/vars | jq .sketch_series.PayloadFull
```
is increasing.  Alternately, look at datadog.agent.sketch_series.payload_full for the host.

Upgrade the agent, and confirm that this rate is the same.

Configure "serializer_max_series_points_per_payload" to a small value in a situation where lots of series metrics are transmitted (such as the benchmark environment).  Confirm that the rate increases (more full payloads).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
