### PR TITLE
[kitchen] Remove old prefixes from maintenance jobs

### DIFF
--- a/.gitlab/maintenance_jobs/kitchen.yml
+++ b/.gitlab/maintenance_jobs/kitchen.yml
@@ -28,12 +28,6 @@ periodic_kitchen_cleanup_azure:
     - export ARM_CLIENT_SECRET=`aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_client_secret --with-decryption --query "Parameter.Value" --out text`
     - export ARM_TENANT_ID=`aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.azure_tenant_id --with-decryption --query "Parameter.Value" --out text`
     # Remove kitchen resources for all existing test suite prefixes
-    # Legacy resource group prefixes
-    # TODO: remove them once we're not using them at all anymore
-    - RESOURCE_GROUP_PREFIX=kitchen-dd-agent python3.6 /deploy_scripts/cleanup_azure.py
-    - RESOURCE_GROUP_PREFIX=kitchen-dd-security-agent python3.6 /deploy_scripts/cleanup_azure.py
-    - RESOURCE_GROUP_PREFIX=kitchen-dd-system-probe python3.6 /deploy_scripts/cleanup_azure.py
-    # New resource group prefixes
     - RESOURCE_GROUP_PREFIX=kitchen-chef python3.6 /deploy_scripts/cleanup_azure.py
     - RESOURCE_GROUP_PREFIX=kitchen-install-script python3.6 /deploy_scripts/cleanup_azure.py
     - RESOURCE_GROUP_PREFIX=kitchen-upgrade python3.6 /deploy_scripts/cleanup_azure.py


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Removes old prefixes from the list of kitchen prefixes to remove during the cleanup, they're not used anymore.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Clean up maintenance jobs.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
