### PR TITLE
[podman] Set network IPs to fix autodiscovery

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -105,6 +105,7 @@ require (
 	github.com/containerd/cgroups v1.0.2
 	github.com/containerd/containerd v1.5.9
 	github.com/containerd/typeurl v1.0.2
+	github.com/containernetworking/cni v0.8.1
 	github.com/coreos/go-semver v0.3.0
 	github.com/coreos/go-systemd v0.0.0-20190620071333-e64a0ec8b42a
 	github.com/cri-o/ocicni v0.2.0

--- a/pkg/util/podman/container.go
+++ b/pkg/util/podman/container.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"time"
 
+	cnitypes "github.com/containernetworking/cni/pkg/types/current"
 	"github.com/cri-o/ocicni/pkg/ocicni"
 	spec "github.com/opencontainers/runtime-spec/specs-go"
 )
@@ -24,7 +25,7 @@ import (
 // More specifically, the types included here are:
 // - ContainerStatus:
 // https://github.com/containers/podman/blob/v3.4.1/libpod/define/containerstate.go
-// - ContainerState:
+// - ContainerState (with only the attrs that we need):
 // https://github.com/containers/podman/blob/v3.4.1/libpod/container.go
 // - ContainerConfig (and the ones it depends on like ContainerSecurityConfig,
 // ContainerNameSpaceConfig, etc.):
@@ -112,6 +113,11 @@ type ContainerState struct {
 	FinishedTime time.Time `json:"finishedTime,omitempty"`
 	// PID is the PID of a running container
 	PID int `json:"pid,omitempty"`
+	// NetworkStatus contains the configuration results for all networks
+	// the pod is attached to. Only populated if we created a network
+	// namespace for the container, and the network namespace is currently
+	// active
+	NetworkStatus []*cnitypes.Result `json:"networkResults,omitempty"`
 }
 
 // ContainerConfig contains all information that was used to create the

--- a/pkg/workloadmeta/collectors/podman/podman.go
+++ b/pkg/workloadmeta/collectors/podman/podman.go
@@ -127,7 +127,7 @@ func convertToEvent(container *podman.Container) workloadmeta.CollectorEvent {
 			EnvVars:    envs,
 			Hostname:   hostname(container),
 			Image:      image,
-			NetworkIPs: make(map[string]string), // I think there's no way to get this mapping
+			NetworkIPs: networkIPs(container),
 			PID:        container.State.PID,
 			Ports:      ports,
 			Runtime:    workloadmeta.ContainerRuntimePodman,
@@ -149,6 +149,18 @@ func (c *collector) expiredEvents() []workloadmeta.CollectorEvent {
 			Source: workloadmeta.SourcePodman,
 			Entity: expired,
 		})
+	}
+
+	return res
+}
+
+func networkIPs(container *podman.Container) map[string]string {
+	res := make(map[string]string)
+
+	if len(container.State.NetworkStatus) > 0 {
+		if len(container.State.NetworkStatus[0].IPs) > 0 {
+			res["podman"] = container.State.NetworkStatus[0].IPs[0].Address.IP.String()
+		}
 	}
 
 	return res

--- a/pkg/workloadmeta/collectors/podman/podman.go
+++ b/pkg/workloadmeta/collectors/podman/podman.go
@@ -11,6 +11,7 @@ package podman
 import (
 	"context"
 	"errors"
+	"sort"
 	"strings"
 	"time"
 
@@ -154,12 +155,43 @@ func (c *collector) expiredEvents() []workloadmeta.CollectorEvent {
 	return res
 }
 
+func getShortID(container *podman.Container) (containerID string) {
+	if len(container.Config.ID) >= 12 {
+		containerID = container.Config.ID[:12]
+	} else {
+		containerID = container.Config.ID
+	}
+	return
+}
+
 func networkIPs(container *podman.Container) map[string]string {
 	res := make(map[string]string)
 
-	if len(container.State.NetworkStatus) > 0 {
-		if len(container.State.NetworkStatus[0].IPs) > 0 {
-			res["podman"] = container.State.NetworkStatus[0].IPs[0].Address.IP.String()
+	// container.Config.Networks contains only the networks specified at container creation time
+	// and not the ones attached afterwards with `podman network attach`
+	// They appear in the order in which they were specified in the `podman run --net=…` command
+	networkNames := make([]string, len(container.Config.Networks))
+	copy(networkNames, container.Config.Networks)
+	sort.Strings(networkNames)
+
+	// Handle the default case where no `--net` is specified
+	if len(networkNames) == 0 && len(container.State.NetworkStatus) == 1 {
+		networkNames = []string{"podman"}
+	}
+
+	if len(networkNames) != len(container.State.NetworkStatus) {
+		log.Warnf("podman container %s %s has now a number of networks (%d) different from what it was at creation time (%d). This can be due to the use of `podman network attach`/`podman network detach`. This may confuse the agent.", getShortID(container), container.Config.Name, len(container.State.NetworkStatus), len(networkNames))
+		return map[string]string{}
+	}
+
+	// container.State.NetworkStatus contains all the networks but they are not in the same order
+	// as in container.Config.Network. Here, they are sorted by network name.
+	for i := 0; i < len(networkNames); i++ {
+		if len(container.State.NetworkStatus[i].IPs) > 1 {
+			log.Warnf("podman container %s %s has several IPs on network %s. This is most probably because of a dual-stack IPv4/IPv6 setup. The agent will use only the first IP.", getShortID(container), container.Config.Name, networkNames[i])
+		}
+		if len(container.State.NetworkStatus[i].IPs) > 0 {
+			res[networkNames[i]] = container.State.NetworkStatus[i].IPs[0].Address.IP.String()
 		}
 	}
 

--- a/pkg/workloadmeta/collectors/podman/podman_test.go
+++ b/pkg/workloadmeta/collectors/podman/podman_test.go
@@ -10,9 +10,11 @@ package podman
 
 import (
 	"context"
+	"net"
 	"testing"
 	"time"
 
+	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/cri-o/ocicni/pkg/ocicni"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	"github.com/stretchr/testify/assert"
@@ -79,6 +81,17 @@ func TestPull(t *testing.T) {
 				State:       podman.ContainerStateRunning,
 				StartedTime: startTime,
 				PID:         10,
+				NetworkStatus: []*current.Result{
+					{
+						IPs: []*current.IPConfig{
+							{
+								Address: net.IPNet{
+									IP: net.ParseIP("10.88.0.13"),
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 		{
@@ -117,6 +130,17 @@ func TestPull(t *testing.T) {
 				State:       podman.ContainerStateRunning,
 				StartedTime: startTime,
 				PID:         11,
+				NetworkStatus: []*current.Result{
+					{
+						IPs: []*current.IPConfig{
+							{
+								Address: net.IPNet{
+									IP: net.ParseIP("10.88.0.14"),
+								},
+							},
+						},
+					},
+				},
 			},
 		},
 	}
@@ -153,8 +177,10 @@ func TestPull(t *testing.T) {
 					ShortName: "agent",
 					Tag:       "latest",
 				},
-				NetworkIPs: make(map[string]string),
-				PID:        10,
+				NetworkIPs: map[string]string{
+					"podman": "10.88.0.13",
+				},
+				PID: 10,
 				Ports: []workloadmeta.ContainerPort{
 					{
 						Port:     2000,
@@ -198,8 +224,10 @@ func TestPull(t *testing.T) {
 					ShortName: "agent-dev",
 					Tag:       "latest",
 				},
-				NetworkIPs: make(map[string]string),
-				PID:        11,
+				NetworkIPs: map[string]string{
+					"podman": "10.88.0.14",
+				},
+				PID: 11,
 				Ports: []workloadmeta.ContainerPort{
 					{
 						Port:     3000,


### PR DESCRIPTION
### What does this PR do?

Sets the network IPs when creating workloadmeta events from Podman.

Without this, autodiscovery of Podman containers does not work properly, because `%%host%%` does not resolve to an IP accessible by the agent.


### Describe how to test/QA your changes

- Run the agent with the Podman storage mounted (-v /var/lib/containers/:/var/lib/containers/).
- Run a redis container with the AD labels: `podman run --label "com.datadoghq.ad.check_names=[\"redisdb\"]" --label "com.datadoghq.ad.init_configs=[{}]" --label "com.datadoghq.ad.instances=[{\"host\":\"%%host%%\",\"port\":6379}]" --label "com.datadoghq.ad.logs=[{\"source\":\"redis\"}]" docker.io/redis`

This should schedule a working redisdb check.

Check with `agent status` and `agent checkconfig` (the host should correctly be resolved to an IP) that the check is working correctly and reporting metrics.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
