### PR TITLE
[kitchen] Use newer instance types

### DIFF
--- a/test/kitchen/drivers/azure-driver.yml
+++ b/test/kitchen/drivers/azure-driver.yml
@@ -56,7 +56,7 @@ platforms:
     ]
 
     windows_sizes = [
-      "Standard_D2_v2"
+      "Standard_D2_v4"
     ]
 
     windows_platforms = []

--- a/test/kitchen/drivers/hyperv-driver.yml
+++ b/test/kitchen/drivers/hyperv-driver.yml
@@ -39,15 +39,6 @@ platforms:
     # TEST_PLATFORMS syntax is `short_name1,parent vhd folder,parent_vhd_name|...`
     hyperv_test_platforms = ENV['TEST_PLATFORMS'].split('|').map { |p| p.split(',') }
 
-    sizes = [
-      "Standard_D1_v2",
-      "Standard_A1_v2",
-    ]
-
-    windows_sizes = [
-      "Standard_D2_v2"
-    ]
-
     windows_platforms = []
     sles15_platforms = []
 
@@ -64,12 +55,9 @@ platforms:
 
       if windows
         windows_platforms << platform_name
-        size = windows_sizes[idx % windows_sizes.length]
-      else
-        if sles15
-          sles15_platforms << platform_name
-        end
-        size = sizes[idx % sizes.length]
+      end
+      if sles15
+        sles15_platforms << platform_name
       end
 
       vm_username = ENV['VM_USERNAME'] ? ENV['VM_USERNAME'] : "datadog"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Changes the Windows instance types used for Azure kitchen tests from `Standard_D2_v2` to `Standard_D2_v4`.

Removes unused logic from the hyperv kitchen test definitions.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

These instance types are more recent (and therefore should be maintained for a longer time) and [cost less](https://azureprice.net/?filter=standard_d2). `D2_v5` instances do not seem to be available in all regions yet (I get allocation errors when using them in some regions).

The Linux instance types we use are already the latest ones of their series (`Standard_D1_v2` and `Standard_A1_v2`), so they don't need to be changed.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Run pipeline with kitchen tests.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
