### PR TITLE
[network/ebpf/https] fix regression when SSL_shutdown is not called from userspace and tcp fin flush/close it

### DIFF
--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Http = NewRuntimeAsset("http.c", "c792b7f43a460d4e3df2757345960b318cf7354426aee1989cea7d32fb6efaf8")
+var Http = NewRuntimeAsset("http.c", "739e2dd72b8e8d014829670ea8bb74a6e0c49f52a3e22a23a1fd2437bf5e208c")

--- a/pkg/network/ebpf/c/https.h
+++ b/pkg/network/ebpf/c/https.h
@@ -34,7 +34,6 @@ static __always_inline void https_process(conn_tuple_t *t, void *buffer, size_t 
     __builtin_memcpy(&http.tup, t, sizeof(conn_tuple_t));
     read_into_buffer((char *)http.request_fragment, buffer, len);
     http.owned_by_src_port = http.tup.sport;
-    normalize_tuple(&http.tup);
     http.tags |= tags;
     http_process(&http, NULL);
 }
@@ -43,6 +42,7 @@ static __always_inline void https_finish(conn_tuple_t *t) {
     http_transaction_t http;
     __builtin_memset(&http, 0, sizeof(http));
     __builtin_memcpy(&http.tup, t, sizeof(conn_tuple_t));
+    http.owned_by_src_port = http.tup.sport;
 
     skb_info_t skb_info = {0};
     skb_info.tcp_flags |= TCPHDR_FIN;

--- a/pkg/network/ebpf/c/https.h
+++ b/pkg/network/ebpf/c/https.h
@@ -33,6 +33,8 @@ static __always_inline void https_process(conn_tuple_t *t, void *buffer, size_t 
     __builtin_memset(&http, 0, sizeof(http));
     __builtin_memcpy(&http.tup, t, sizeof(conn_tuple_t));
     read_into_buffer((char *)http.request_fragment, buffer, len);
+    http.owned_by_src_port = http.tup.sport;
+    normalize_tuple(&http.tup);
     http.tags |= tags;
     http_process(&http, NULL);
 }

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -112,7 +112,7 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 	// Offset guessing has been flaky for some customers, so if it fails we'll retry it up to 5 times
 	needsOffsets := (!config.EnableRuntimeCompiler ||
 		config.AllowPrecompiledFallback ||
-		// hotfix: always force offset guessing for kernel <= 4.6 when HTTP monitoring is enabled
+		// hotfix: always force offset guessing for kernel < 4.6 when HTTPS monitoring is enabled
 		(config.EnableHTTPSMonitoring && currKernelVersion < kernel.VersionCode(4, 6, 0)))
 
 	var constantEditors []manager.ConstantEditor

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -110,7 +110,11 @@ func NewTracer(config *config.Config) (*Tracer, error) {
 	defer offsetBuf.Close()
 
 	// Offset guessing has been flaky for some customers, so if it fails we'll retry it up to 5 times
-	needsOffsets := !config.EnableRuntimeCompiler || config.AllowPrecompiledFallback
+	needsOffsets := (!config.EnableRuntimeCompiler ||
+		config.AllowPrecompiledFallback ||
+		// hotfix: always force offset guessing for kernel <= 4.6 when HTTP monitoring is enabled
+		(config.EnableHTTPSMonitoring && currKernelVersion < kernel.VersionCode(4, 6, 0)))
+
 	var constantEditors []manager.ConstantEditor
 	if needsOffsets {
 		for i := 0; i < 5; i++ {

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -1564,7 +1564,8 @@ func TestHTTPSViaOpenSSLIntegration(t *testing.T) {
 
 	// Spin-up HTTPS server
 	serverDoneFn := testutil.HTTPServer(t, "127.0.0.1:443", testutil.Options{
-		EnableTLS: true,
+		EnableTLS:        true,
+		EnableKeepAlives: true,
 	})
 	defer serverDoneFn()
 


### PR DESCRIPTION
### What does this PR do?

Fix regression when SSL_shutdown is not called from userspace and tcp fin flush/close it

wget/openssl doesn't call SSL_shutdown() is the server respond with a "Connection: keep-alive" header

The fix set the http.owned_by_src_port when called from SSL_read/write() uprobes
This will fix the context correctly aim to be flushed and closed later when tcp_fin will be seen http_closed() will return true accordingly.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
