### PR TITLE
Fix race in batch strategy when stop is called and there are payloads to be flushed

### DIFF
--- a/pkg/logs/sender/batch_strategy_test.go
+++ b/pkg/logs/sender/batch_strategy_test.go
@@ -77,7 +77,9 @@ func TestBatchStrategySendsPayloadWhenClosingInput(t *testing.T) {
 	message := message.NewMessage([]byte("a"), nil, "", 0)
 	input <- message
 
-	s.Stop()
+	go func() {
+		s.Stop()
+	}()
 
 	// expect payload to be sent before timer, so we never advance the clock; if this
 	// doesn't work, the test will hang
@@ -94,7 +96,10 @@ func TestBatchStrategyShouldNotBlockWhenStoppingGracefully(t *testing.T) {
 	message := message.NewMessage([]byte{}, nil, "", 0)
 
 	input <- message
-	s.Stop()
+
+	go func() {
+		s.Stop()
+	}()
 	assert.Equal(t, message, (<-output).Messages[0])
 }
 
@@ -125,8 +130,10 @@ func TestBatchStrategySynchronousFlush(t *testing.T) {
 	default:
 	}
 
-	// Stop triggers the flush and make sure we can read the messages out now
-	strategy.Stop()
+	go func() {
+		// Stop triggers the flush and make sure we can read the messages out now
+		strategy.Stop()
+	}()
 
 	assert.ElementsMatch(t, messages, (<-output).Messages)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

A bug was found in QA where if the agent is shutdown while there are payloads buffered in the batch strategy that have not flushed yet, there was a race to flush the paylaods before the sender's input channel closed. 

The sender shuts down after the strategy. Because the strategy didnt block until the final flush was finished, there was a race to write to the batch output channel (the senders input) before the sender closed the channel. Making `Stop` wait for the flush fixes this and removes the race. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
