### PR TITLE
Add debug endpoints to dump cached and host conntrack tables

### DIFF
--- a/pkg/network/netlink/conntrack_debug.go
+++ b/pkg/network/netlink/conntrack_debug.go
@@ -1,0 +1,169 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux && !android
+// +build linux,!android
+
+package netlink
+
+import (
+	"context"
+
+	"golang.org/x/sys/unix"
+)
+
+// DebugConntrackEntry is a entry in a conntrack table (host or cached).
+type DebugConntrackEntry struct {
+	Proto  string
+	Family string
+	Origin DebugConntrackTuple
+	Reply  DebugConntrackTuple
+}
+
+// DebugConntrackTuple is one side of a conntrack entry
+type DebugConntrackTuple struct {
+	Src DebugConntrackAddress
+	Dst DebugConntrackAddress
+}
+
+// DebugConntrackAddress is an endpoint for one part of a conntrack tuple
+type DebugConntrackAddress struct {
+	IP   string
+	Port uint16
+}
+
+// DumpCachedTable dumps the cached conntrack NAT entries grouped by network namespace
+func (ctr *realConntracker) DumpCachedTable(ctx context.Context) (map[uint32][]DebugConntrackEntry, error) {
+	table := make(map[uint32][]DebugConntrackEntry)
+	keys := ctr.cache.cache.Keys()
+	if len(keys) == 0 {
+		return table, nil
+	}
+
+	// netlink conntracker does not store netns values
+	ns := uint32(0)
+	table[ns] = []DebugConntrackEntry{}
+
+	for _, k := range keys {
+		if ctx.Err() != nil {
+			return nil, ctx.Err()
+		}
+
+		ck, ok := k.(connKey)
+		if !ok {
+			continue
+		}
+		v, ok := ctr.cache.cache.Peek(ck)
+		if !ok {
+			continue
+		}
+		te, ok := v.(*translationEntry)
+		if !ok {
+			continue
+		}
+
+		table[ns] = append(table[ns], DebugConntrackEntry{
+			Family: ck.transport.String(),
+			Origin: DebugConntrackTuple{
+				Src: DebugConntrackAddress{
+					IP:   ck.src.IP().String(),
+					Port: ck.src.Port(),
+				},
+				Dst: DebugConntrackAddress{
+					IP:   ck.dst.IP().String(),
+					Port: ck.dst.Port(),
+				},
+			},
+			Reply: DebugConntrackTuple{
+				Src: DebugConntrackAddress{
+					IP:   te.ReplSrcIP.String(),
+					Port: te.ReplSrcPort,
+				},
+				Dst: DebugConntrackAddress{
+					IP:   te.ReplDstIP.String(),
+					Port: te.ReplDstPort,
+				},
+			},
+		})
+	}
+	return table, nil
+}
+
+// DumpHostTable dumps the host conntrack NAT entries grouped by network namespace
+func DumpHostTable(ctx context.Context, procRoot string) (map[uint32][]DebugConntrackEntry, error) {
+	consumer := NewConsumer(procRoot, -1, true)
+	decoder := NewDecoder()
+	defer consumer.Stop()
+
+	table := make(map[uint32][]DebugConntrackEntry)
+
+	for _, family := range []uint8{unix.AF_INET, unix.AF_INET6} {
+		events, err := consumer.DumpTable(family)
+		if err != nil {
+			return nil, err
+		}
+
+		fstr := "v4"
+		if family == unix.AF_INET6 {
+			fstr = "v6"
+		}
+
+	dumploop:
+		for {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case ev, ok := <-events:
+				if !ok {
+					break dumploop
+				}
+				conns := decoder.DecodeAndReleaseEvent(ev)
+				for _, c := range conns {
+					if !IsNAT(c) {
+						continue
+					}
+
+					ns := c.NetNS
+					_, ok := table[ns]
+					if !ok {
+						table[ns] = []DebugConntrackEntry{}
+					}
+
+					src, sok := formatKey(&c.Origin)
+					dst, dok := formatKey(&c.Reply)
+					if !sok || !dok {
+						continue
+					}
+
+					table[ns] = append(table[ns], DebugConntrackEntry{
+						Family: fstr,
+						Proto:  src.transport.String(),
+						Origin: DebugConntrackTuple{
+							Src: DebugConntrackAddress{
+								IP:   src.src.IP().String(),
+								Port: src.src.Port(),
+							},
+							Dst: DebugConntrackAddress{
+								IP:   src.dst.IP().String(),
+								Port: src.dst.Port(),
+							},
+						},
+						Reply: DebugConntrackTuple{
+							Src: DebugConntrackAddress{
+								IP:   dst.src.IP().String(),
+								Port: dst.src.Port(),
+							},
+							Dst: DebugConntrackAddress{
+								IP:   dst.dst.IP().String(),
+								Port: dst.dst.Port(),
+							},
+						},
+					})
+				}
+			}
+		}
+	}
+	return table, nil
+}

--- a/pkg/network/netlink/conntracker.go
+++ b/pkg/network/netlink/conntracker.go
@@ -10,6 +10,7 @@ package netlink
 
 import (
 	"container/list"
+	"context"
 	"fmt"
 	"net"
 	"sync"
@@ -36,6 +37,7 @@ type Conntracker interface {
 	DeleteTranslation(network.ConnectionStats)
 	IsSampling() bool
 	GetStats() map[string]int64
+	DumpCachedTable(context.Context) (map[uint32][]DebugConntrackEntry, error)
 	Close()
 }
 

--- a/pkg/network/netlink/noop.go
+++ b/pkg/network/netlink/noop.go
@@ -8,7 +8,11 @@
 
 package netlink
 
-import "github.com/DataDog/datadog-agent/pkg/network"
+import (
+	"context"
+
+	"github.com/DataDog/datadog-agent/pkg/network"
+)
 
 type noOpConntracker struct{}
 
@@ -35,4 +39,8 @@ func (*noOpConntracker) GetStats() map[string]int64 {
 	return map[string]int64{
 		"noop_conntracker": 0,
 	}
+}
+
+func (c *noOpConntracker) DumpCachedTable(ctx context.Context) (map[uint32][]DebugConntrackEntry, error) {
+	return nil, nil
 }

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -739,6 +739,8 @@ func (t *Tracer) DebugCachedConntrack(ctx context.Context) (interface{}, error) 
 	if err != nil {
 		return nil, err
 	}
+	defer rootNSHandle.Close()
+
 	rootNS, err := util.GetInoForNs(rootNSHandle)
 	if err != nil {
 		return nil, err
@@ -763,6 +765,8 @@ func (t *Tracer) DebugHostConntrack(ctx context.Context) (interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer rootNSHandle.Close()
+
 	rootNS, err := util.GetInoForNs(rootNSHandle)
 	if err != nil {
 		return nil, err

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -9,6 +9,7 @@
 package tracer
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math"
@@ -730,6 +731,54 @@ func (t *Tracer) retryConntrack(connections []network.ConnectionStats) {
 			}
 		}
 	}
+}
+
+// DebugCachedConntrack dumps the cached NAT conntrack data
+func (t *Tracer) DebugCachedConntrack(ctx context.Context) (interface{}, error) {
+	rootNSHandle, err := util.GetRootNetNamespace(t.config.ProcRoot)
+	if err != nil {
+		return nil, err
+	}
+	rootNS, err := util.GetInoForNs(rootNSHandle)
+	if err != nil {
+		return nil, err
+	}
+	table, err := t.conntracker.DumpCachedTable(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return struct {
+		RootNS  uint32
+		Entries map[uint32][]netlink.DebugConntrackEntry
+	}{
+		RootNS:  rootNS,
+		Entries: table,
+	}, nil
+}
+
+// DebugHostConntrack dumps the NAT conntrack data obtained from the host via netlink.
+func (t *Tracer) DebugHostConntrack(ctx context.Context) (interface{}, error) {
+	rootNSHandle, err := util.GetRootNetNamespace(t.config.ProcRoot)
+	if err != nil {
+		return nil, err
+	}
+	rootNS, err := util.GetInoForNs(rootNSHandle)
+	if err != nil {
+		return nil, err
+	}
+	table, err := netlink.DumpHostTable(ctx, t.config.ProcRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	return struct {
+		RootNS  uint32
+		Entries map[uint32][]netlink.DebugConntrackEntry
+	}{
+		RootNS:  rootNS,
+		Entries: table,
+	}, nil
 }
 
 func newHTTPMonitor(supported bool, c *config.Config, tracer connection.Tracer, offsets []manager.ConstantEditor) *http.Monitor {

--- a/pkg/network/tracer/tracer_unsupported.go
+++ b/pkg/network/tracer/tracer_unsupported.go
@@ -9,6 +9,8 @@
 package tracer
 
 import (
+	"context"
+
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
 	"github.com/DataDog/datadog-agent/pkg/network"
 	"github.com/DataDog/datadog-agent/pkg/network/config"
@@ -53,4 +55,14 @@ func (t *Tracer) DebugNetworkMaps() (*network.Connections, error) {
 // DebugEBPFMaps is not implemented on this OS for Tracer
 func (t *Tracer) DebugEBPFMaps(maps ...string) (string, error) {
 	return "", ebpf.ErrNotImplemented
+}
+
+// DebugCachedConntrack is not implemented on this OS for Tracer
+func (t *Tracer) DebugCachedConntrack(ctx context.Context) (interface{}, error) {
+	return nil, ebpf.ErrNotImplemented
+}
+
+// DebugHostConntrack is not implemented on this OS for Tracer
+func (t *Tracer) DebugHostConntrack(ctx context.Context) (interface{}, error) {
+	return nil, ebpf.ErrNotImplemented
 }

--- a/pkg/network/tracer/tracer_windows.go
+++ b/pkg/network/tracer/tracer_windows.go
@@ -9,6 +9,7 @@
 package tracer
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"sync"
@@ -205,4 +206,14 @@ func (t *Tracer) DebugNetworkMaps() (*network.Connections, error) {
 // DebugEBPFMaps is not implemented on this OS for Tracer
 func (t *Tracer) DebugEBPFMaps(maps ...string) (string, error) {
 	return "", ebpf.ErrNotImplemented
+}
+
+// DebugCachedConntrack is not implemented on this OS for Tracer
+func (t *Tracer) DebugCachedConntrack(ctx context.Context) (interface{}, error) {
+	return nil, ebpf.ErrNotImplemented
+}
+
+// DebugHostConntrack is not implemented on this OS for Tracer
+func (t *Tracer) DebugHostConntrack(ctx context.Context) (interface{}, error) {
+	return nil, ebpf.ErrNotImplemented
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add debug endpoints to dump cached and host conntrack tables. The output includes the root network namespace number, and breaks down the entries by network namespace number.

### Motivation

Allowing us to see the internal state of conntrack will help with debugging. There will be a follow up PR to include this data in flares.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->
Running `curl --silent --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/debug/conntrack/cached` will give you the cached data of the running conntracker (netlink or eBPF).

Running `curl --silent --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/debug/conntrack/host` will dump the host conntrack table (via netlink), but only output any NAT related entries. This should contain the same entries as `sudo conntrack -L -j` in each network namespace.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
