### PR TITLE
Use netns provided for conntrack dump if none available

### DIFF
--- a/pkg/network/netlink/consumer.go
+++ b/pkg/network/netlink/consumer.go
@@ -102,7 +102,7 @@ type Consumer struct {
 // Event encapsulates the result of a single netlink.Con.Receive() call
 type Event struct {
 	msgs   []netlink.Message
-	netns  int32
+	netns  uint32
 	buffer *[]byte
 	pool   *sync.Pool
 }
@@ -151,7 +151,7 @@ func (c *Consumer) Events() (<-chan Event, error) {
 
 		c.streaming = true
 		_ = c.conn.JoinGroup(netlinkCtNew)
-		c.receive(output)
+		c.receive(output, 0)
 	}()
 
 	return output, nil
@@ -311,8 +311,13 @@ func (c *Consumer) dumpTable(family uint8, output chan Event, ns netns.NsHandle)
 			return fmt.Errorf("netlink dump message validation error: %w", err)
 		}
 
+		nsIno, err := util.GetInoForNs(ns)
+		if err != nil {
+			return fmt.Errorf("netns ino: %w", err)
+		}
+
 		c.socket = sock
-		c.receive(output)
+		c.receive(output, nsIno)
 		return nil
 	})
 }
@@ -396,7 +401,7 @@ func (c *Consumer) initNetlinkSocket(samplingRate float64) error {
 // attribute is true, and only when we detect an EOF we close the output channel.
 // It's also worth noting that in the event of an ENOBUF error, we'll re-create a new netlink socket,
 // and attach a BPF sampler to it, to lower the the read throughput and save CPU.
-func (c *Consumer) receive(output chan Event) {
+func (c *Consumer) receive(output chan Event, ns uint32) {
 	atomic.StoreInt32(&c.recvLoopRunning, 1)
 	defer func() {
 		atomic.StoreInt32(&c.recvLoopRunning, 0)
@@ -439,6 +444,10 @@ ReadLoop:
 			msgs = msgs[:len(msgs)-1]
 		}
 
+		if netns == 0 {
+			netns = ns
+		}
+
 		output <- c.eventFor(msgs, netns, buffer)
 
 		// If we're doing a conntrack dump we terminate after reading the multi-part message
@@ -448,7 +457,7 @@ ReadLoop:
 	}
 }
 
-func (c *Consumer) eventFor(msgs []netlink.Message, netns int32, buffer *[]byte) Event {
+func (c *Consumer) eventFor(msgs []netlink.Message, netns uint32, buffer *[]byte) Event {
 	return Event{
 		msgs:   msgs,
 		netns:  netns,

--- a/pkg/network/netlink/decoding.go
+++ b/pkg/network/netlink/decoding.go
@@ -45,7 +45,7 @@ const (
 // Con represents a conntrack entry, along with any network namespace info (nsid)
 type Con struct {
 	ct.Con
-	NetNS int32
+	NetNS uint32
 }
 
 func (c Con) String() string {

--- a/pkg/network/netlink/socket.go
+++ b/pkg/network/netlink/socket.go
@@ -118,7 +118,7 @@ func (s *Socket) Receive() ([]netlink.Message, error) {
 }
 
 // ReceiveInto reads one or more netlink.Messages off the socket
-func (s *Socket) ReceiveInto(b []byte) ([]netlink.Message, int32, error) {
+func (s *Socket) ReceiveInto(b []byte) ([]netlink.Message, uint32, error) {
 	oob := make([]byte, unix.CmsgSpace(24))
 	n, oobn, err := s.recvmsg(s.recvbuf, oob, 0)
 	if err != nil {
@@ -148,7 +148,7 @@ func (s *Socket) ReceiveInto(b []byte) ([]netlink.Message, int32, error) {
 		msgs = append(msgs, m)
 	}
 
-	var netns int32
+	var netns uint32
 	if oobn > 0 {
 		oob = oob[:oobn]
 		scms, err := unix.ParseSocketControlMessage(oob)
@@ -162,13 +162,13 @@ func (s *Socket) ReceiveInto(b []byte) ([]netlink.Message, int32, error) {
 	return msgs, netns, nil
 }
 
-func parseNetNS(scms []unix.SocketControlMessage) int32 {
+func parseNetNS(scms []unix.SocketControlMessage) uint32 {
 	for _, m := range scms {
 		if m.Header.Level != unix.SOL_NETLINK || m.Header.Type != unix.NETLINK_LISTEN_ALL_NSID {
 			continue
 		}
 
-		return *(*int32)(unsafe.Pointer(&m.Data[0]))
+		return *(*uint32)(unsafe.Pointer(&m.Data[0]))
 	}
 
 	return 0

--- a/pkg/network/tracer/ebpf_conntracker.go
+++ b/pkg/network/tracer/ebpf_conntracker.go
@@ -149,8 +149,8 @@ func (e *ebpfConntracker) processEvent(ev netlink.Event) {
 	for _, c := range conns {
 		if netlink.IsNAT(c) {
 			log.Tracef("initial conntrack %s", c)
-			src := formatKey(uint32(c.NetNS), c.Origin)
-			dst := formatKey(uint32(c.NetNS), c.Reply)
+			src := formatKey(c.NetNS, c.Origin)
+			dst := formatKey(c.NetNS, c.Reply)
 			if src != nil && dst != nil {
 				if err := e.addTranslation(src, dst); err != nil {
 					log.Warnf("error adding initial conntrack entry to ebpf map: %s", err)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Use netns provided for conntrack dump if none available. We know the netns when doing a netlink dump, since we dump each namespace individually.

### Motivation

Improve quality of conntrack data.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Using the debug endpoints from #10539 you can see that the netns numbers will be non-zero for the initial dumped entries.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
