### PR TITLE
[kitchen] vagrant/virtualbox use vbguest plugin if available

### DIFF
--- a/test/kitchen/drivers/vagrant-driver.yml
+++ b/test/kitchen/drivers/vagrant-driver.yml
@@ -22,6 +22,8 @@ platforms:
   - name: <%= platform[0] %>
     driver:
       box: <%= platform[1] %>
+      vagrantfiles:
+        - ./drivers/vagrant-vbguest.rb
       <% if platform[1].include?('opensuse') %>
       customize:
         disk_bus: sata

--- a/test/kitchen/drivers/vagrant-vbguest.rb
+++ b/test/kitchen/drivers/vagrant-vbguest.rb
@@ -1,0 +1,6 @@
+Vagrant.configure("2") do |c|
+    if Vagrant.has_plugin?("vagrant-vbguest") then
+        c.vbguest.auto_update = false
+    end
+end
+


### PR DESCRIPTION
### What does this PR do?

Some image don't have the right packages installed to build/update vbox additions
This PR use vbguest plugging to solve this issue


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
