### PR TITLE
Podman: retrieve the IPs of all the networks

### DIFF
--- a/pkg/workloadmeta/collectors/podman/podman.go
+++ b/pkg/workloadmeta/collectors/podman/podman.go
@@ -11,6 +11,7 @@ package podman
 import (
 	"context"
 	"errors"
+	"sort"
 	"strings"
 	"time"
 
@@ -154,12 +155,43 @@ func (c *collector) expiredEvents() []workloadmeta.CollectorEvent {
 	return res
 }
 
+func getShortID(container *podman.Container) (containerID string) {
+	if len(container.Config.ID) >= 12 {
+		containerID = container.Config.ID[:12]
+	} else {
+		containerID = container.Config.ID
+	}
+	return
+}
+
 func networkIPs(container *podman.Container) map[string]string {
 	res := make(map[string]string)
 
-	if len(container.State.NetworkStatus) > 0 {
-		if len(container.State.NetworkStatus[0].IPs) > 0 {
-			res["podman"] = container.State.NetworkStatus[0].IPs[0].Address.IP.String()
+	// container.Config.Networks contains only the networks specified at container creation time
+	// and not the ones attached afterwards with `podman network attach`
+	// They appear in the order in which they were specified in the `podman run --net=…` command
+	networkNames := make([]string, len(container.Config.Networks))
+	copy(networkNames, container.Config.Networks)
+	sort.Strings(networkNames)
+
+	// Handle the default case where no `--net` is specified
+	if len(networkNames) == 0 && len(container.State.NetworkStatus) == 1 {
+		networkNames = []string{"podman"}
+	}
+
+	if len(networkNames) != len(container.State.NetworkStatus) {
+		log.Warnf("podman container %s %s has now a number of networks (%d) different from what it was at creation time (%d). This can be due to the use of `podman network attach`/`podman network detach`. This may confuse the agent.", getShortID(container), container.Config.Name, len(container.State.NetworkStatus), len(networkNames))
+		return map[string]string{}
+	}
+
+	// container.State.NetworkStatus contains all the networks but they are not in the same order
+	// as in container.Config.Network. Here, they are sorted by network name.
+	for i := 0; i < len(networkNames); i++ {
+		if len(container.State.NetworkStatus[i].IPs) > 1 {
+			log.Warnf("podman container %s %s has several IPs on network %s. This is most probably because of a dual-stack IPv4/IPv6 setup. The agent will use only the first IP.", getShortID(container), container.Config.Name, networkNames[i])
+		}
+		if len(container.State.NetworkStatus[i].IPs) > 0 {
+			res[networkNames[i]] = container.State.NetworkStatus[i].IPs[0].Address.IP.String()
 		}
 	}
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
