### PR TITLE
Add more kernel header downloading telemetry

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a // indirect
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
 	github.com/BurntSushi/toml v0.4.1 // indirect
-	github.com/DataDog/agent-payload/v5 v5.0.8
+	github.com/DataDog/agent-payload/v5 v5.0.9
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.34.0-rc.4
 	github.com/DataDog/datadog-agent/pkg/otlp/model v0.34.0-rc.4
 	github.com/DataDog/datadog-agent/pkg/quantile v0.34.0-rc.4

--- a/go.mod
+++ b/go.mod
@@ -65,7 +65,7 @@ require (
 	code.cloudfoundry.org/rfc5424 v0.0.0-20180905210152-236a6d29298a // indirect
 	code.cloudfoundry.org/tlsconfig v0.0.0-20200131000646-bbe0f8da39b3 // indirect
 	github.com/BurntSushi/toml v0.4.1 // indirect
-	github.com/DataDog/agent-payload/v5 v5.0.9
+	github.com/DataDog/agent-payload/v5 v5.0.10
 	github.com/DataDog/datadog-agent/pkg/obfuscate v0.34.0-rc.4
 	github.com/DataDog/datadog-agent/pkg/otlp/model v0.34.0-rc.4
 	github.com/DataDog/datadog-agent/pkg/quantile v0.34.0-rc.4

--- a/go.sum
+++ b/go.sum
@@ -118,6 +118,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/agent-payload/v5 v5.0.8 h1:zESeMHIQ7zMV/3DES3hZk+zwC5i7HylNe17Ise9AL6I=
 github.com/DataDog/agent-payload/v5 v5.0.8/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
+github.com/DataDog/agent-payload/v5 v5.0.9 h1:cbJB7/Q4vMvJhDUFiaEqXxpV8s5DNJpeDBg0ag1OsP8=
+github.com/DataDog/agent-payload/v5 v5.0.9/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/DataDog/datadog-api-client-go v1.0.0-beta.18/go.mod h1:Gn0fZwIOBbSidO0OaPEh9nO5EmIPsxJrHfHvfVXEaoU=

--- a/go.sum
+++ b/go.sum
@@ -120,6 +120,8 @@ github.com/DataDog/agent-payload/v5 v5.0.8 h1:zESeMHIQ7zMV/3DES3hZk+zwC5i7HylNe1
 github.com/DataDog/agent-payload/v5 v5.0.8/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
 github.com/DataDog/agent-payload/v5 v5.0.9 h1:cbJB7/Q4vMvJhDUFiaEqXxpV8s5DNJpeDBg0ag1OsP8=
 github.com/DataDog/agent-payload/v5 v5.0.9/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
+github.com/DataDog/agent-payload/v5 v5.0.10 h1:ctiEca/xQbD87QAbHQ/AMSmszWRv2FSsEcyVwJ6lrPg=
+github.com/DataDog/agent-payload/v5 v5.0.10/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3/go.mod h1:Qx5cxh0v+4UWYiBimWS+eyWzqEqokIECu5etghLkUJE=
 github.com/DataDog/datadog-api-client-go v1.0.0-beta.18/go.mod h1:Gn0fZwIOBbSidO0OaPEh9nO5EmIPsxJrHfHvfVXEaoU=

--- a/go.sum
+++ b/go.sum
@@ -116,10 +116,6 @@ github.com/BurntSushi/toml v0.4.1 h1:GaI7EiDXDRfa8VshkTj7Fym7ha+y8/XxIgD2okUIjLw
 github.com/BurntSushi/toml v0.4.1/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
-github.com/DataDog/agent-payload/v5 v5.0.8 h1:zESeMHIQ7zMV/3DES3hZk+zwC5i7HylNe17Ise9AL6I=
-github.com/DataDog/agent-payload/v5 v5.0.8/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
-github.com/DataDog/agent-payload/v5 v5.0.9 h1:cbJB7/Q4vMvJhDUFiaEqXxpV8s5DNJpeDBg0ag1OsP8=
-github.com/DataDog/agent-payload/v5 v5.0.9/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
 github.com/DataDog/agent-payload/v5 v5.0.10 h1:ctiEca/xQbD87QAbHQ/AMSmszWRv2FSsEcyVwJ6lrPg=
 github.com/DataDog/agent-payload/v5 v5.0.10/go.mod h1:2gapp8p4Vd548JI+axD8kCExklNvVI6AMF5/+IfN/4g=
 github.com/DataDog/cast v1.3.1-0.20190301154711-1ee8c8bd14a3 h1:SobA9WYm4K/MUtWlbKaomWTmnuYp1KhIm8Wlx3vmpsg=


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Adds a check immediately prior to attempting kernel header downloading to verify that we can access the repository directory for the current distribution. If it isn't accessible, then a specific error is outputted & specific telemetry is reported.

### Motivation

Currently, if kernel header downloading is attempted on a container which has not mounted the correct directories, kernel header downloading will fail with an unspecific "operation not permitted" error, and the telemetry will simply indicate that kernel header downloading failed

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1) Enable runtime compilation, force kernel header downloading to occur, & tell the system-probe to look in the incorrect location for the apt repos directory: 
```
system_probe_config:
  enable_runtime_compiler: true
  kernel_header_dirs: /dev/null
  apt_config_dir: /fake/directory/path
```
2) Check the logs to see if this error is reported:
```
WARN | (pkg/util/kernel/download_headers.go:102 in verifyReposDir) | Unable to read /fake/directory/path, which is necessary for downloading kernel headers. If you are in a containerized environment, please ensure this directory is mounted.
```
3) In a separate window, query to see if this telemetry is reported:
```
sudo curl -s --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/connections?client_id=1 | jq .compilationTelemetryByAsset.tracer.kernelHeaderFetchResult
"ReposDirAccessFailure"
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
