### PR TITLE
Fix missing tags with eBPF checks (oom/tcp) with some container runtimes

### DIFF
--- a/pkg/collector/corechecks/ebpf/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/oom_kill.go
@@ -7,8 +7,8 @@
 // github.com/DataDog/datadog-agent/pkg/process/net depends on `github.com/DataDog/agent-payload/v5/process`,
 // which has a hard dependency on `github.com/DataDog/zstd_0`, which requires CGO.
 // Should be removed once `github.com/DataDog/agent-payload/v5/process` can be imported with CGO disabled.
-// +build cgo
-// +build linux
+//go:build cgo && linux
+// +build cgo,linux
 
 package ebpf
 
@@ -28,6 +28,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/metrics"
 	process_net "github.com/DataDog/datadog-agent/pkg/process/net"
 	"github.com/DataDog/datadog-agent/pkg/tagger"
+	"github.com/DataDog/datadog-agent/pkg/util/cgroups"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -109,18 +110,24 @@ func (m *OOMKillCheck) Run() error {
 		return log.Errorf("Raw data has incorrect type")
 	}
 	for _, line := range oomkillStats {
-		entityID := containers.BuildTaggerEntityName(line.ContainerID)
+		containerID, err := cgroups.ContainerFilter("", line.CgroupName)
+		if err != nil || containerID == "" {
+			log.Warnf("Unable to extract containerID from cgroup name: %s, err: %v", line.CgroupName, err)
+			continue
+		}
+
+		entityID := containers.BuildTaggerEntityName(containerID)
 		var tags []string
 		if entityID != "" {
 			tags, err = tagger.Tag(entityID, tagger.ChecksCardinality)
 			if err != nil {
-				log.Errorf("Error collecting tags for container %s: %s", line.ContainerID, err)
+				log.Errorf("Error collecting tags for container %s: %s", containerID, err)
 			}
 		}
 
 		if line.MemCgOOM == 1 {
 			triggerType = "cgroup"
-			triggerTypeText = fmt.Sprintf("This OOM kill was invoked by a cgroup, containerID: %s.", line.ContainerID)
+			triggerTypeText = fmt.Sprintf("This OOM kill was invoked by a cgroup, containerID: %s.", containerID)
 		} else {
 			triggerType = "system"
 			triggerTypeText = "This OOM kill was invoked by the system."
@@ -138,7 +145,7 @@ func (m *OOMKillCheck) Run() error {
 			Priority:       metrics.EventPriorityNormal,
 			SourceTypeName: oomKillCheckName,
 			EventType:      oomKillCheckName,
-			AggregationKey: line.ContainerID,
+			AggregationKey: containerID,
 			Title:          fmt.Sprintf("Process OOM Killed: oom_kill_process called on %s (pid: %d)", line.TComm, line.TPid),
 			Tags:           tags,
 		}

--- a/pkg/collector/corechecks/ebpf/probe/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/probe/oom_kill.go
@@ -113,7 +113,7 @@ func (k *OOMKillProbe) GetAndFlush() (results []OOMKillStats) {
 }
 
 func convertStats(in C.struct_oom_stats) (out OOMKillStats) {
-	out.ContainerID = C.GoString(&in.cgroup_name[0])
+	out.CgroupName = C.GoString(&in.cgroup_name[0])
 	out.Pid = uint32(in.pid)
 	out.TPid = uint32(in.tpid)
 	out.FComm = C.GoString(&in.fcomm[0])

--- a/pkg/collector/corechecks/ebpf/probe/oom_kill_types.go
+++ b/pkg/collector/corechecks/ebpf/probe/oom_kill_types.go
@@ -7,11 +7,11 @@ package probe
 
 // OOMKillStats contains the statistics of a given socket
 type OOMKillStats struct {
-	ContainerID string `json:"containerid"`
-	Pid         uint32 `json:"pid"`
-	TPid        uint32 `json:"tpid"`
-	FComm       string `json:"fcomm"`
-	TComm       string `json:"tcomm"`
-	Pages       uint64 `json:"pages"`
-	MemCgOOM    uint32 `json:"memcgoom"`
+	CgroupName string `json:"cgroupName"`
+	Pid        uint32 `json:"pid"`
+	TPid       uint32 `json:"tpid"`
+	FComm      string `json:"fcomm"`
+	TComm      string `json:"tcomm"`
+	Pages      uint64 `json:"pages"`
+	MemCgOOM   uint32 `json:"memcgoom"`
 }

--- a/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcp_queue_length.go
@@ -113,9 +113,9 @@ func (t *TCPQueueLengthTracer) GetAndFlush() TCPQueueLengthStats {
 	statsValue := make([]C.struct_stats_value, nbCpus)
 	it := t.statsMap.Iterate()
 	for it.Next(unsafe.Pointer(&statsKey), unsafe.Pointer(&statsValue[0])) {
-		containerID := C.GoString(&statsKey.cgroup_name[0])
+		cgroupName := C.GoString(&statsKey.cgroup_name[0])
 		// This cannot happen because statsKey.cgroup_name is filled by bpf_probe_read_str which ensures a NULL-terminated string
-		if len(containerID) >= C.sizeof_struct_stats_key {
+		if len(cgroupName) >= C.sizeof_struct_stats_key {
 			log.Critical("statsKey.cgroup_name wasn’t properly NULL-terminated")
 			break
 		}
@@ -129,7 +129,7 @@ func (t *TCPQueueLengthTracer) GetAndFlush() TCPQueueLengthStats {
 				max.WriteBufferMaxUsage = uint32(statsValue[cpu].write_buffer_max_usage)
 			}
 		}
-		result[containerID] = max
+		result[cgroupName] = max
 
 		if err := t.statsMap.Delete(unsafe.Pointer(&statsKey)); err != nil {
 			log.Warnf("failed to delete stat: %s", err)

--- a/pkg/collector/corechecks/ebpf/probe/tcp_queue_length_types.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcp_queue_length_types.go
@@ -7,7 +7,7 @@ package probe
 
 // TCPQueueLengthStatsKey is the type of the `TCPQueueLengthStats` map key: the container ID
 type TCPQueueLengthStatsKey struct {
-	ContainerID string `json:"containerid"`
+	CgroupName string `json:"cgroupName"`
 }
 
 // TCPQueueLengthStatsValue is the type of the `TCPQueueLengthStats` map value: the maximum fill rate of busiest read and write buffers

--- a/releasenotes/notes/oom-kill-tags-5cd6b2f601531347.yaml
+++ b/releasenotes/notes/oom-kill-tags-5cd6b2f601531347.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix missing tags with eBPF checks (OOM Kill/TCP Queue Length) with some container runtimes (for instance, containerd 1.5).


### PR DESCRIPTION
### What does this PR do?

Add logic to extract container id from cgroupName retrieved by eBPF checks.

### Motivation

Bugfix.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Run the OOM Kill or TCP Queue Length check on a system running `containerd >= 1.5`. Trigger an OOM Event, make sure the `oom_kill.oom_process.count` metric is tagged properly.
You may want to set `checks_tag_cardinality` to `orchestrator` or `high` to easily identify Tagger tags.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
