### PR TITLE
[workloadmeta] Gracefully stop on agent shutdown

### DIFF
--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -9,6 +9,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -178,7 +179,7 @@ func runJmxCommandConsole(command string) error {
 		return fmt.Errorf("Unable to set up JMX logger: %v", err)
 	}
 
-	common.LoadComponents(config.Datadog.GetString("confd_path"))
+	common.LoadComponents(context.Background(), config.Datadog.GetString("confd_path"))
 
 	if discoveryRetryInterval > discoveryTimeout {
 		fmt.Println("The discovery retry interval", discoveryRetryInterval, "is higher than the discovery timeout", discoveryTimeout)

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -431,7 +431,7 @@ func StartAgent() error {
 	util.LogVersionHistory()
 
 	// create and setup the Autoconfig instance
-	common.LoadComponents(config.Datadog.GetString("confd_path"))
+	common.LoadComponents(common.MainCtx, config.Datadog.GetString("confd_path"))
 	// start the autoconfig, this will immediately run any configured check
 	common.StartAutoConfig()
 

--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -142,7 +142,7 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 			opts.UseOrchestratorForwarder = false
 			demux := aggregator.InitAndStartAgentDemultiplexer(opts, hostname)
 
-			common.LoadComponents(config.Datadog.GetString("confd_path"))
+			common.LoadComponents(context.Background(), config.Datadog.GetString("confd_path"))
 
 			if config.Datadog.GetBool("inventories_enabled") {
 				metadata.SetupInventoriesExpvar(common.AC, common.Coll)

--- a/cmd/agent/common/loader.go
+++ b/cmd/agent/common/loader.go
@@ -26,9 +26,9 @@ import (
 
 // LoadComponents configures several common Agent components:
 // tagger, collector, scheduler and autodiscovery
-func LoadComponents(confdPath string) {
+func LoadComponents(ctx context.Context, confdPath string) {
 	if flavor.GetFlavor() != flavor.ClusterAgent {
-		workloadmeta.GetGlobalStore().Start(context.Background())
+		workloadmeta.GetGlobalStore().Start(ctx)
 
 		// start the tagger. must be done before autodiscovery, as it needs to
 		// be the first subscribed to metadata store to avoid race conditions.

--- a/cmd/cluster-agent-cloudfoundry/app/app.go
+++ b/cmd/cluster-agent-cloudfoundry/app/app.go
@@ -191,7 +191,7 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 
 	// create and setup the Autoconfig instance
-	common.LoadComponents(config.Datadog.GetString("confd_path"))
+	common.LoadComponents(mainCtx, config.Datadog.GetString("confd_path"))
 	// start the autoconfig, this will immediately run any configured check
 	common.StartAutoConfig()
 

--- a/cmd/cluster-agent/app/app.go
+++ b/cmd/cluster-agent/app/app.go
@@ -275,7 +275,7 @@ func start(cmd *cobra.Command, args []string) error {
 	signalCh := make(chan os.Signal, 1)
 	signal.Notify(signalCh, os.Interrupt, syscall.SIGTERM)
 	// create and setup the Autoconfig instance
-	common.LoadComponents(config.Datadog.GetString("confd_path"))
+	common.LoadComponents(mainCtx, config.Datadog.GetString("confd_path"))
 	// start the autoconfig, this will immediately run any configured check
 	common.StartAutoConfig()
 

--- a/pkg/autodiscovery/providers/container.go
+++ b/pkg/autodiscovery/providers/container.go
@@ -76,6 +76,12 @@ func (d *ContainerConfigProvider) listen() {
 	d.Lock()
 	d.streaming = true
 	health := health.RegisterLiveness("ad-containerprovider")
+	defer func() {
+		err := health.Deregister()
+		if err != nil {
+			log.Warnf("error de-registering health check: %s", err)
+		}
+	}()
 	d.Unlock()
 
 	workloadmetaEventsChannel := d.workloadmetaStore.Subscribe("ad-containerprovider", workloadmeta.NormalPriority, workloadmeta.NewFilter(
@@ -90,7 +96,11 @@ func (d *ContainerConfigProvider) listen() {
 
 	for {
 		select {
-		case evBundle := <-workloadmetaEventsChannel:
+		case evBundle, ok := <-workloadmetaEventsChannel:
+			if !ok {
+				return
+			}
+
 			d.processEvents(evBundle)
 
 		case <-health.C:


### PR DESCRIPTION
### What does this PR do?

This passes `common.MainCtx` (where available) to
`common.LoadComponents`, which in turn passes that context to the
workloadmeta, so it can be notified that an agent shutdown has been
requested, and we can do it cleanly. Besides being just common good
practice, we're also introducing this to help debug a panic in the
tagger that's suspected to happen on shutdown, and being able to
actually request one is useful.

Note that this has only been done in the main agent for now.
Workloadmeta is not enabled by default in other agents, so there's lower
priority in doing that.

### Describe how to test/QA your changes

Run the agent in a container, and `kill -s SIGINT` on the `agent run` process (`docker stop` or equivalent might hide hangups, see #10833). Nothing should happen :) (as in, the agent shuts down cleanly, no errors coming from workloadmeta, and definitely no panics).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
