### PR TITLE
[dogstatsd/otlp] Only log that the components started when they do start

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -379,9 +379,10 @@ func StartAgent() error {
 		common.DSD, err = dogstatsd.NewServer(demux, nil)
 		if err != nil {
 			log.Errorf("Could not start dogstatsd: %s", err)
+		} else {
+			log.Debugf("dogstatsd started")
 		}
 	}
-	log.Debugf("statsd started")
 
 	// Start OTLP intake
 	if otlp.IsEnabled(config.Datadog) {
@@ -389,9 +390,10 @@ func StartAgent() error {
 		common.OTLP, err = otlp.BuildAndStart(common.MainCtx, config.Datadog, demux.Serializer())
 		if err != nil {
 			log.Errorf("Could not start OTLP: %s", err)
+		} else {
+			log.Debug("OTLP pipeline started")
 		}
 	}
-	log.Debug("OTLP pipeline started")
 
 	// Start SNMP trap server
 	if traps.IsEnabled() {


### PR DESCRIPTION
### What does this PR do?

Avoids misleading debug logs that seem to indicate dogstatsd/otlp pipelines started when they actually didn't (because they're disabled in config, or because an error occurred when they were started).

### Motivation

Log message correctness.

### Possible Drawbacks / Trade-offs

None.

### Describe how to test/QA your changes

Check these log messages are not logged anymore:
* when OTLP pipeline is disabled (default)
* when dogstatsd pipeline is disabled (`use_dogstatsd: false`)

and that they're still logged when the pipelines are enabled and were started successfully.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
