### PR TITLE
[AD] Collect containers with an old "FinishedAt" if they're running

### DIFF
--- a/pkg/autodiscovery/listeners/container.go
+++ b/pkg/autodiscovery/listeners/container.go
@@ -65,7 +65,11 @@ func (l *ContainerListener) createContainerService(
 		return
 	}
 
-	if !container.State.FinishedAt.IsZero() {
+	// Note: Docker containers can have a "FinishedAt" time set even when
+	// they're running. That happens when they've been stopped and then
+	// restarted. "FinishedAt" corresponds to the last time the container was
+	// stopped.
+	if !container.State.Running && !container.State.FinishedAt.IsZero() {
 		finishedAt := container.State.FinishedAt
 		excludeAge := time.Duration(config.Datadog.GetInt("container_exclude_stopped_age")) * time.Hour
 		if time.Now().Sub(finishedAt) > excludeAge {

--- a/pkg/autodiscovery/listeners/container_test.go
+++ b/pkg/autodiscovery/listeners/container_test.go
@@ -63,6 +63,20 @@ func TestCreateContainerService(t *testing.T) {
 		Runtime: workloadmeta.ContainerRuntimeDocker,
 	}
 
+	runningContainerWithFinishedAtTime := &workloadmeta.Container{
+		EntityID:   containerEntityID,
+		EntityMeta: containerEntityMeta,
+		Image: workloadmeta.ContainerImage{
+			RawName:   "gcr.io/foobar:latest",
+			ShortName: "foobar",
+		},
+		State: workloadmeta.ContainerState{
+			Running:    true,
+			FinishedAt: time.Now().Add(-48 * time.Hour), // Older than default "container_exclude_stopped_age" config
+		},
+		Runtime: workloadmeta.ContainerRuntimeDocker,
+	}
+
 	tests := []struct {
 		name             string
 		container        *workloadmeta.Container
@@ -95,11 +109,35 @@ func TestCreateContainerService(t *testing.T) {
 				EntityMeta: containerEntityMeta,
 				Image:      basicImage,
 				State: workloadmeta.ContainerState{
+					Running:    false,
 					FinishedAt: time.Now().Add(-48 * time.Hour),
 				},
 				Runtime: workloadmeta.ContainerRuntimeDocker,
 			},
 			expectedServices: map[string]wlmListenerSvc{},
+		},
+		{
+			// In docker, running containers can have a "finishedAt" time when
+			// they have been stopped and then restarted. When that's the case,
+			// we want to collect their info.
+			name:      "running container with finishedAt time older than the configured threshold is collected",
+			container: runningContainerWithFinishedAtTime,
+			expectedServices: map[string]wlmListenerSvc{
+				"container://foobarquux": {
+					service: &service{
+						entity: runningContainerWithFinishedAtTime,
+						adIdentifiers: []string{
+							"docker://foobarquux",
+							"gcr.io/foobar",
+							"foobar",
+						},
+						hosts:        map[string]string{},
+						creationTime: integration.After,
+						ports:        []ContainerPort{},
+						ready:        true,
+					},
+				},
+			},
 		},
 		{
 			name:      "container with multiple ports collects them in ascending order",

--- a/pkg/autodiscovery/listeners/kubelet.go
+++ b/pkg/autodiscovery/listeners/kubelet.go
@@ -137,7 +137,11 @@ func (l *KubeletListener) createContainerService(
 		return
 	}
 
-	if !container.State.FinishedAt.IsZero() {
+	// Note: Docker containers can have a "FinishedAt" time set even when
+	// they're running. That happens when they've been stopped and then
+	// restarted. "FinishedAt" corresponds to the last time the container was
+	// stopped.
+	if !container.State.Running && !container.State.FinishedAt.IsZero() {
 		finishedAt := container.State.FinishedAt
 		excludeAge := time.Duration(config.Datadog.GetInt("container_exclude_stopped_age")) * time.Hour
 		if time.Now().Sub(finishedAt) > excludeAge {

--- a/pkg/autodiscovery/listeners/kubelet_test.go
+++ b/pkg/autodiscovery/listeners/kubelet_test.go
@@ -171,6 +171,17 @@ func TestKubeletCreateContainerService(t *testing.T) {
 		Runtime: workloadmeta.ContainerRuntimeDocker,
 	}
 
+	runningContainerWithFinishedAtTime := &workloadmeta.Container{
+		EntityID:   containerEntityID,
+		EntityMeta: containerEntityMeta,
+		Image:      basicImage,
+		State: workloadmeta.ContainerState{
+			Running:    true,
+			FinishedAt: time.Now().Add(-48 * time.Hour), // Older than default "container_exclude_stopped_age" config
+		},
+		Runtime: workloadmeta.ContainerRuntimeDocker,
+	}
+
 	multiplePortsContainer := &workloadmeta.Container{
 		EntityID:   containerEntityID,
 		EntityMeta: containerEntityMeta,
@@ -287,11 +298,47 @@ func TestKubeletCreateContainerService(t *testing.T) {
 				EntityMeta: containerEntityMeta,
 				Image:      basicImage,
 				State: workloadmeta.ContainerState{
+					Running:    false,
 					FinishedAt: time.Now().Add(-48 * time.Hour),
 				},
 				Runtime: workloadmeta.ContainerRuntimeDocker,
 			},
 			expectedServices: map[string]wlmListenerSvc{},
+		},
+		{
+			// In docker, running containers can have a "finishedAt" time when
+			// they have been stopped and then restarted. When that's the case,
+			// we want to collect their info.
+			name: "running container with finishedAt time older than the configured threshold is collected",
+			pod:  pod,
+			podContainer: &workloadmeta.OrchestratorContainer{
+				ID:    containerID,
+				Name:  containerName,
+				Image: basicImage,
+			},
+			container: runningContainerWithFinishedAtTime,
+			expectedServices: map[string]wlmListenerSvc{
+				"container://foobarquux": {
+					parent: "kubernetes_pod://foobar",
+					service: &service{
+						entity: runningContainerWithFinishedAtTime,
+						adIdentifiers: []string{
+							"docker://foobarquux",
+							"foobar",
+						},
+						hosts: map[string]string{
+							"pod": "127.0.0.1",
+						},
+						ports:        []ContainerPort{},
+						creationTime: integration.After,
+						extraConfig: map[string]string{
+							"namespace": podNamespace,
+							"pod_name":  podName,
+							"pod_uid":   podID,
+						},
+					},
+				},
+			},
 		},
 		{
 			name: "container with multiple ports collects them in ascending order",


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in the `container` and `kubelet` AD listeners. They were ignoring Docker containers that were running but had an old `FinishedAt` time set.

The code was assuming that containers with `FinishedAt` set are stopped. However, that's not the case when using Docker. Docker sets `FinishedAt` with last time when it was stopped. So when a container is stopped, and then restarted, it has a `FinishedAt` time, even though it's running.


### Describe how to test/QA your changes

- Run a docker container with AD tags. For example: `docker run --label "com.datadoghq.ad.check_names=[\"redisdb\"]" --label "com.datadoghq.ad.init_configs=[{}]" --label "com.datadoghq.ad.instances=[{\"host\":\"%%host%%\",\"port\":6379}]" --label "com.datadoghq.ad.logs=[{\"source\":\"redis\"}]" --name  redis redis`.
- Stop the container.
- Restart the container.
- Start the agent with `DD_CONTAINER_EXCLUDE_STOPPED_AGE=0` so we don't have to wait (the default is 23 hours).
- Verify that `agent configcheck` shows the `redisdb` check.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
