### PR TITLE
[DCA][Admission] Improve telemetry

### DIFF
--- a/cmd/cluster-agent/admission/server.go
+++ b/cmd/cluster-agent/admission/server.go
@@ -107,6 +107,12 @@ func (s *Server) Run(mainCtx context.Context, client kubernetes.Interface) error
 // It supports both v1 and v1beta1 requests.
 func (s *Server) mutateHandler(w http.ResponseWriter, r *http.Request, mutateFunc admissionFunc, dc dynamic.Interface) {
 	metrics.WebhooksReceived.Inc()
+
+	start := time.Now()
+	defer func() {
+		metrics.WebhooksResponseDuration.Observe(time.Since(start).Seconds())
+	}()
+
 	if r.Method != http.MethodPost {
 		w.WriteHeader(http.StatusMethodNotAllowed)
 		log.Warnf("Invalid method %s, only POST requests are allowed", r.Method)

--- a/pkg/clusteragent/admission/metrics/metrics.go
+++ b/pkg/clusteragent/admission/metrics/metrics.go
@@ -7,7 +7,11 @@
 
 package metrics
 
-import "github.com/DataDog/datadog-agent/pkg/telemetry"
+import (
+	"github.com/DataDog/datadog-agent/pkg/telemetry"
+
+	"github.com/prometheus/client_golang/prometheus"
+)
 
 // Metric names
 const (
@@ -43,4 +47,12 @@ var (
 	GetOwnerCacheMiss = telemetry.NewGaugeWithOpts("admission_webhooks", "owner_cache_miss",
 		[]string{"resource"}, "Number of cache misses while getting pod's owner object.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
+	WebhooksResponseDuration = telemetry.NewHistogramWithOpts(
+		"admission_webhooks",
+		"response_duration",
+		[]string{},
+		"Webhook response duration distribution (in seconds).",
+		prometheus.DefBuckets, // The default prometheus buckets are adapted to measure response time
+		telemetry.Options{NoDoubleUnderscoreSep: true},
+	)
 )

--- a/pkg/clusteragent/admission/metrics/metrics.go
+++ b/pkg/clusteragent/admission/metrics/metrics.go
@@ -34,7 +34,7 @@ var (
 	MutationErrors = telemetry.NewGaugeWithOpts("admission_webhooks", "mutation_errors",
 		[]string{"mutation_type", "reason"}, "Number of mutation failures by mutation type (agent config, standard tags).",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
-	WebhooksReceived = telemetry.NewGaugeWithOpts("admission_webhooks", "webhooks_received",
+	WebhooksReceived = telemetry.NewCounterWithOpts("admission_webhooks", "webhooks_received",
 		[]string{}, "Number of mutation webhook requests received.",
 		telemetry.Options{NoDoubleUnderscoreSep: true})
 	GetOwnerCacheHit = telemetry.NewGaugeWithOpts("admission_webhooks", "owner_cache_hit",

--- a/releasenotes-dca/notes/admission-telem-4157ab8574c9e1a0.yaml
+++ b/releasenotes-dca/notes/admission-telem-4157ab8574c9e1a0.yaml
@@ -1,5 +1,4 @@
 ---
 enhancements:
   - |
-    Added a new metric ``admission_webhooks_response_duration`` (histogram) to monitor the admission-webhook's response time.
-    The existing metric ``admission_webhooks_webhooks_received`` became a counter.
+    Adds a new histogram metric `admission_webhooks_response_duration` to monitor the admission-webhook's response time. The existing metric `admission_webhooks_webhooks_received` is now a counter.

--- a/releasenotes-dca/notes/admission-telem-4157ab8574c9e1a0.yaml
+++ b/releasenotes-dca/notes/admission-telem-4157ab8574c9e1a0.yaml
@@ -1,0 +1,5 @@
+---
+enhancements:
+  - |
+    Added a new metric ``admission_webhooks_response_duration`` (histogram) to monitor the admission-webhook's response time.
+    The existing metric ``admission_webhooks_webhooks_received`` became a counter.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Added a new metric `admission_webhooks_response_duration` (histogram) to monitor the admission-webhook's response time.
- The existing metric `admission_webhooks_webhooks_received` became a counter.

### Motivation

Deeper telemetry around the admission webhook server

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Enable the admission controller and make handle multiple requests by creating other pods in the cluster, these metrics should be shown

```
# agent telemetry
...
# HELP admission_webhooks_response_duration Webhook response duration distribution (in seconds).
# TYPE admission_webhooks_response_duration histogram
admission_webhooks_response_duration_bucket{le="0.005"} 0
admission_webhooks_response_duration_bucket{le="0.01"} 0
admission_webhooks_response_duration_bucket{le="0.025"} 2
admission_webhooks_response_duration_bucket{le="0.05"} 6
admission_webhooks_response_duration_bucket{le="0.1"} 8
admission_webhooks_response_duration_bucket{le="0.25"} 8
admission_webhooks_response_duration_bucket{le="0.5"} 8
admission_webhooks_response_duration_bucket{le="1"} 8
admission_webhooks_response_duration_bucket{le="2.5"} 8
admission_webhooks_response_duration_bucket{le="5"} 8
admission_webhooks_response_duration_bucket{le="10"} 8
admission_webhooks_response_duration_bucket{le="+Inf"} 8
admission_webhooks_response_duration_sum 0.271534101
admission_webhooks_response_duration_count 8
# HELP admission_webhooks_webhooks_received Number of mutation webhook requests received.
# TYPE admission_webhooks_webhooks_received counter
admission_webhooks_webhooks_received 8
...
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
