### PR TITLE
Add dogstatsd arm64 binary, .deb and docker builds

### DIFF
--- a/.gitlab/binary_build/linux.yml
+++ b/.gitlab/binary_build/linux.yml
@@ -1,6 +1,6 @@
 ---
 
-build_dogstatsd_static-deb_x64:
+build_dogstatsd_static-binary_x64:
   stage: binary_build
   rules:
     !reference [.on_a7]
@@ -14,7 +14,27 @@ build_dogstatsd_static-deb_x64:
     - inv -e dogstatsd.build --static --major-version 7
     - $S3_CP_CMD $SRC_PATH/$STATIC_BINARIES_DIR/dogstatsd $S3_ARTIFACTS_URI/static/dogstatsd
 
-build_dogstatsd-deb_x64:
+build_dogstatsd_static-binary_arm64:
+  stage: binary_build
+  rules:
+    !reference [.on_a7]
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
+  tags: ["runner:docker-arm", "platform:arm64"]
+  needs: ["tests_deb-x64-py3", "go_deps"]
+  variables:
+    ARCH: arm64
+  before_script:
+    - !reference [.retrieve_linux_go_deps]
+    - source /root/.bashrc && conda activate ddpy3
+    # Hack to work around the cloning issue with arm runners
+    - mkdir -p $GOPATH/src/github.com/DataDog
+    - cp -R $GOPATH/src/github.com/*/*/DataDog/datadog-agent $GOPATH/src/github.com/DataDog
+    - cd $SRC_PATH
+  script:
+    - inv -e dogstatsd.build --static --major-version 7
+    - $S3_CP_CMD $SRC_PATH/$STATIC_BINARIES_DIR/dogstatsd $S3_ARTIFACTS_URI/static/dogstatsd.$ARCH
+
+build_dogstatsd-binary_x64:
   stage: binary_build
   rules:
     !reference [.on_a7]
@@ -28,7 +48,7 @@ build_dogstatsd-deb_x64:
     - inv -e dogstatsd.build --major-version 7
     - $S3_CP_CMD $SRC_PATH/$DOGSTATSD_BINARIES_DIR/dogstatsd $S3_ARTIFACTS_URI/dogstatsd/dogstatsd
 
-build_dogstatsd-deb_arm64:
+build_dogstatsd-binary_arm64:
   rules:
     !reference [.on_all_builds_a7]
   stage: binary_build
@@ -49,7 +69,7 @@ build_dogstatsd-deb_arm64:
     - $S3_CP_CMD $SRC_PATH/$DOGSTATSD_BINARIES_DIR/dogstatsd $S3_ARTIFACTS_URI/dogstatsd/dogstatsd.$ARCH
 
 # IoT Agent builds to make sure the build is not broken because of build flags
-build_iot_agent-deb_x64:
+build_iot_agent-binary_x64:
   stage: binary_build
   rules:
     !reference [.on_a7]
@@ -62,7 +82,7 @@ build_iot_agent-deb_x64:
     - inv -e agent.build --flavor iot --major-version 7
     - $S3_CP_CMD $SRC_PATH/$AGENT_BINARIES_DIR/agent $S3_ARTIFACTS_URI/iot/agent
 
-build_iot_agent-deb_arm64:
+build_iot_agent-binary_arm64:
   rules:
     !reference [.on_all_builds_a7]
   stage: binary_build

--- a/.gitlab/binary_build/linux.yml
+++ b/.gitlab/binary_build/linux.yml
@@ -17,7 +17,7 @@ build_dogstatsd_static-binary_x64:
 build_dogstatsd_static-binary_arm64:
   stage: binary_build
   rules:
-    !reference [.on_a7]
+    !reference [.on_all_builds_a7]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   needs: ["tests_deb-x64-py3", "go_deps"]

--- a/.gitlab/deploy_7/docker.yml
+++ b/.gitlab/deploy_7/docker.yml
@@ -50,7 +50,7 @@ deploy-dogstatsd:
   dependencies: []
   before_script:
     - export VERSION="$(inv -e agent.version --major-version 7 --url-safe)"
-    - export IMG_SOURCES="${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64"
+    - export IMG_SOURCES="${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64"
     - export IMG_DESTINATIONS="${DSD_REPOSITORY}:${VERSION}"
 
 
@@ -86,5 +86,5 @@ deploy_latest-dogstatsd:
     !reference [.on_deploy_a7_manual_final]
   dependencies: []
   variables:
-    IMG_SOURCES: ${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
+    IMG_SOURCES: ${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
     IMG_DESTINATIONS: ${DSD_REPOSITORY}:7,${DSD_REPOSITORY}:latest

--- a/.gitlab/deploy_7/nix.yml
+++ b/.gitlab/deploy_7/nix.yml
@@ -20,6 +20,7 @@ deploy_staging_deb-7:
     - iot_agent_deb-arm64
     - iot_agent_deb-armhf
     - dogstatsd_deb-x64
+    - dogstatsd_deb-arm64
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
   script:
@@ -97,28 +98,28 @@ deploy_staging_dmg-a7:
   script:
     - $S3_CP_CMD --recursive --exclude "*" --include "datadog-agent-7*.dmg" $OMNIBUS_PACKAGE_DIR s3://$MACOS_S3_BUCKET/$BUCKET_BRANCH/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
-# deploy dsd binary to staging bucket
+# deploy dogstatsd x64, non-static binary to staging bucket
 deploy_staging_dsd:
   rules:
     !reference [.on_deploy_a7]
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main"]
-  dependencies: []
+  dependencies: ["build_dogstatsd-binary_x64"]
   script:
     - python3.6 -m pip install --user -r requirements.txt
     - $S3_CP_CMD $S3_ARTIFACTS_URI/dogstatsd/dogstatsd ./dogstatsd
     - export PACKAGE_VERSION=$(inv agent.version --url-safe --major-version 7)
     - $S3_CP_CMD ./dogstatsd $S3_DSD6_URI/linux/dogstatsd-$PACKAGE_VERSION --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732
 
-# deploy iot-agent binary to staging bucket
+# deploy iot-agent x64 binary to staging bucket
 deploy_staging_iot_agent:
   rules:
     !reference [.on_deploy_a7]
   stage: deploy7
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main"]
-  dependencies: []
+  dependencies: ["build_iot_agent-binary_x64"]
   script:
     - python3.6 -m pip install --user -r requirements.txt
     - $S3_CP_CMD $S3_ARTIFACTS_URI/iot/agent ./agent

--- a/.gitlab/image_build/docker_linux.yml
+++ b/.gitlab/image_build/docker_linux.yml
@@ -199,7 +199,19 @@ docker_build_dogstatsd_amd64:
   rules:
     !reference [.on_a7]
   needs:
-    - job: build_dogstatsd_static-deb_x64
+    - job: build_dogstatsd_static-binary_x64
+      artifacts: false
+  variables:
+    IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/dogstatsd
+    BUILD_CONTEXT: Dockerfiles/dogstatsd/alpine
+
+# build the dogstatsd image
+docker_build_dogstatsd_arm64:
+  extends: .docker_build_job_definition_arm64
+  rules:
+    !reference [.on_a7]
+  needs:
+    - job: build_dogstatsd_static-binary_arm64
       artifacts: false
   variables:
     IMAGE: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/dogstatsd

--- a/.gitlab/image_build/docker_linux.yml
+++ b/.gitlab/image_build/docker_linux.yml
@@ -209,7 +209,7 @@ docker_build_dogstatsd_amd64:
 docker_build_dogstatsd_arm64:
   extends: .docker_build_job_definition_arm64
   rules:
-    !reference [.on_a7]
+    !reference [.on_all_builds_a7]
   needs:
     - job: build_dogstatsd_static-binary_arm64
       artifacts: false

--- a/.gitlab/image_deploy/docker_linux.yml
+++ b/.gitlab/image_deploy/docker_linux.yml
@@ -34,7 +34,7 @@ dev_branch-dogstatsd:
     - docker_build_dogstatsd_amd64
   variables:
     IMG_REGISTRIES: dev
-    IMG_SOURCES: ${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
+    IMG_SOURCES: ${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
     IMG_DESTINATIONS: dogstatsd-dev:${CI_COMMIT_REF_SLUG}
 
 dev_branch-a7:
@@ -104,7 +104,7 @@ dev_branch_multiarch-dogstatsd:
     - docker_build_dogstatsd_amd64
   variables:
     IMG_REGISTRIES: dev
-    IMG_SOURCES: ${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
+    IMG_SOURCES: ${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
     IMG_DESTINATIONS: dogstatsd-dev:${CI_COMMIT_REF_SLUG}
 
 dev_master-a6:
@@ -151,7 +151,7 @@ dev_master-dogstatsd:
     - docker_build_dogstatsd_amd64
   variables:
     IMG_REGISTRIES: dev
-    IMG_SOURCES: ${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
+    IMG_SOURCES: ${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
     IMG_DESTINATIONS: dogstatsd-dev:master
 
 dca_dev_branch:
@@ -238,5 +238,5 @@ dev_nightly-dogstatsd:
     - docker_build_dogstatsd_amd64
   variables:
     IMG_REGISTRIES: dev
-    IMG_SOURCES: ${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64
+    IMG_SOURCES: ${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
     IMG_DESTINATIONS: dogstatsd-dev:nightly-${CI_COMMIT_SHORT_SHA}

--- a/.gitlab/integration_test.yml
+++ b/.gitlab/integration_test.yml
@@ -8,7 +8,7 @@ dogstatsd_x64_size_test:
     !reference [.on_a7]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main"]
-  needs: ["build_dogstatsd_static-deb_x64"]
+  needs: ["build_dogstatsd_static-binary_x64"]
   before_script:
     - source /root/.bashrc && conda activate ddpy3
     - mkdir -p $STATIC_BINARIES_DIR

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -207,7 +207,7 @@ dogstatsd_deb-x64:
 
 dogstatsd_deb-arm64:
   rules:
-    !reference [.on_a7]
+    !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -184,7 +184,7 @@ dogstatsd_deb-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main"]
-  needs: ["go_mod_tidy_check", "build_dogstatsd-deb_x64", "go_deps"]
+  needs: ["go_mod_tidy_check", "build_dogstatsd-binary_x64", "go_deps"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   before_script:
@@ -200,6 +200,33 @@ dogstatsd_deb-x64:
     - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps --go-mod-cache="$GOPATH/pkg/mod"
     - ls -la $OMNIBUS_PACKAGE_DIR
     - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd*_amd64.deb $S3_ARTIFACTS_URI/datadog-dogstatsd_amd64.deb
+  artifacts:
+    expire_in: 2 weeks
+    paths:
+      - $OMNIBUS_PACKAGE_DIR
+
+dogstatsd_deb-arm64:
+  rules:
+    !reference [.on_a7]
+  stage: package_build
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
+  tags: ["runner:docker-arm", "platform:arm64"]
+  needs: ["go_mod_tidy_check", "build_dogstatsd-binary_arm64", "go_deps"]
+  variables:
+    AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
+  before_script:
+    - !reference [.retrieve_linux_go_deps]
+    - source /root/.bashrc && conda activate ddpy3
+  script:
+    # remove artifacts from previous pipelines that may come from the cache
+    - rm -rf $OMNIBUS_PACKAGE_DIR/*
+    # Artifacts and cache must live within project directory but we run omnibus in a neutral directory.
+    # Thus, we move the artifacts at the end in a gitlab-friendly dir.
+    - *setup_deb_signing_key
+    # Use --skip-deps since the deps are installed by `before_script`.
+    - inv -e dogstatsd.omnibus-build --release-version "$RELEASE_VERSION_7" --major-version 7 --base-dir $OMNIBUS_BASE_DIR ${USE_S3_CACHING} --skip-deps --go-mod-cache="$GOPATH/pkg/mod"
+    - ls -la $OMNIBUS_PACKAGE_DIR
+    - $S3_CP_CMD $OMNIBUS_PACKAGE_DIR/datadog-dogstatsd*_arm64.deb $S3_ARTIFACTS_URI/datadog-dogstatsd_arm64.deb
   artifacts:
     expire_in: 2 weeks
     paths:

--- a/.gitlab/package_build/rpm.yml
+++ b/.gitlab/package_build/rpm.yml
@@ -173,7 +173,7 @@ dogstatsd_rpm-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/rpm_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main"]
-  needs: ["go_mod_tidy_check", "build_dogstatsd-deb_x64", "go_deps"]
+  needs: ["go_mod_tidy_check", "build_dogstatsd-binary_x64", "go_deps"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   before_script:

--- a/.gitlab/package_build/suse_rpm.yml
+++ b/.gitlab/package_build/suse_rpm.yml
@@ -120,7 +120,7 @@ dogstatsd_suse-x64:
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/suse_x64:$DATADOG_AGENT_BUILDIMAGES
   tags: ["runner:main"]
-  needs: ["go_mod_tidy_check", "build_dogstatsd-deb_x64", "go_deps"]
+  needs: ["go_mod_tidy_check", "build_dogstatsd-binary_x64", "go_deps"]
   variables:
     AWS_CONTAINER_CREDENTIALS_RELATIVE_URI: /credentials
   before_script:


### PR DESCRIPTION
### What does this PR do?

- Add dogstatsd arm64 binary, .deb and docker builds
- Renames the binary build jobs from *-deb* to *-binary*, even if they run on Debian to avoid confusion with the .deb package build jobs.
- The deploy jobs for dogstatsd and iot-agent binaries now explicitly depend on the respective binary build jobs, so they only fetch those artifacts.

### Motivation

Support for arm64 dogstatsd and doing some cleanup.
Fixes #9784.

### Additional Notes

- dogstatsd .deb packages and docker builds are promoted, binary builds are not.

