### PR TITLE
[AD] Replace Docker listener/provider with Container

### DIFF
--- a/cmd/agent/common/autodiscovery.go
+++ b/cmd/agent/common/autodiscovery.go
@@ -8,6 +8,7 @@ package common
 import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers/names"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/scheduler"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	confad "github.com/DataDog/datadog-agent/pkg/config/autodiscovery"
@@ -19,8 +20,8 @@ import (
 // When this is solved, we can remove this check and simplify code below
 var (
 	incompatibleListeners = map[string]map[string]struct{}{
-		"kubelet": {"docker": struct{}{}},
-		"docker":  {"kubelet": struct{}{}},
+		"kubelet":   {"container": struct{}{}},
+		"container": {"kubelet": struct{}{}},
 	}
 )
 
@@ -56,6 +57,15 @@ func setupAutoDiscovery(confSearchPaths []string, metaScheduler *scheduler.MetaS
 			} else {
 				log.Infof("Duplicate AD provider from extra_config_providers discarded as already present in config_providers: %s", name)
 			}
+		}
+
+		// The "docker" config provider was replaced with the "container" one
+		// that supports Docker, but also other runtimes. We need this
+		// conversion to avoid breaking configs that included "docker".
+		if options, found := uniqueConfigProviders["docker"]; found {
+			delete(uniqueConfigProviders, "docker")
+			options.Name = names.Container
+			uniqueConfigProviders["container"] = options
 		}
 
 		for _, provider := range extraConfigProviders {
@@ -102,6 +112,15 @@ func setupAutoDiscovery(confSearchPaths []string, metaScheduler *scheduler.MetaS
 		// Add extra listeners
 		for _, name := range config.Datadog.GetStringSlice("extra_listeners") {
 			listeners = append(listeners, config.Listeners{Name: name})
+		}
+
+		// The "docker" listener was replaced with the "container" one that
+		// supports Docker, but also other runtimes. We need this conversion to
+		// avoid breaking configs that included "docker".
+		for i := range listeners {
+			if listeners[i].Name == "docker" {
+				listeners[i].Name = "container"
+			}
 		}
 
 		for _, listener := range extraConfigListeners {


### PR DESCRIPTION
### What does this PR do?

Same as https://github.com/DataDog/datadog-agent/pull/10568 (`7.33.x` branch) but targets `main`.


### Describe how to test/QA your changes

Should be tested in 7.33.x.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
