### PR TITLE
[CWS] tests cleanup + ioutil replacements

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -12,6 +12,7 @@
   rules:
     !reference [.manual]
   stage: functional_test
+  retry: 0
   variables:
     AGENT_MAJOR_VERSION: 7
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7

--- a/pkg/security/module/self_tester.go
+++ b/pkg/security/module/self_tester.go
@@ -10,7 +10,6 @@ package module
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -64,14 +63,14 @@ func (t *SelfTester) CreateTargetFileIfNeeded() error {
 	}
 
 	// Create temp directory to put target file in
-	tmpDir, err := ioutil.TempDir("", "datadog_agent_cws_self_test")
+	tmpDir, err := os.MkdirTemp("", "datadog_agent_cws_self_test")
 	if err != nil {
 		return err
 	}
 	t.targetTempDir = tmpDir
 
 	// Create target file
-	targetFile, err := ioutil.TempFile(tmpDir, "datadog_agent_cws_target_file")
+	targetFile, err := os.CreateTemp(tmpDir, "datadog_agent_cws_target_file")
 	if err != nil {
 		return err
 	}

--- a/pkg/security/probe/doc_generator/backend_doc_gen.go
+++ b/pkg/security/probe/doc_generator/backend_doc_gen.go
@@ -12,7 +12,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"flag"
-	"io/ioutil"
+	"os"
 	"reflect"
 	"strings"
 
@@ -37,7 +37,7 @@ func generateBackendJSON(output string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(output, out.Bytes(), 0664)
+	return os.WriteFile(output, out.Bytes(), 0664)
 }
 
 func jsonTypeNamer(ty reflect.Type) string {

--- a/pkg/security/probe/process_resolver.go
+++ b/pkg/security/probe/process_resolver.go
@@ -12,7 +12,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"strings"
@@ -923,7 +922,7 @@ func (p *ProcessResolver) dumpEntry(writer io.Writer, entry *model.ProcessCacheE
 
 // Dump create a temp file and dump the cache
 func (p *ProcessResolver) Dump(withArgs bool) (string, error) {
-	dump, err := ioutil.TempFile("/tmp", "process-cache-dump-")
+	dump, err := os.CreateTemp("/tmp", "process-cache-dump-")
 	if err != nil {
 		return "", err
 	}

--- a/pkg/security/probe/syscall_table_generator/syscall_table_generator.go
+++ b/pkg/security/probe/syscall_table_generator/syscall_table_generator.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"os/exec"
@@ -163,7 +162,7 @@ func snakeToCamelCase(snake string) string {
 }
 
 func writeFileAndFormat(outputPath string, content string) error {
-	tmpfile, err := ioutil.TempFile(path.Dir(outputPath), "syscalls-enum")
+	tmpfile, err := os.CreateTemp(path.Dir(outputPath), "syscalls-enum")
 	if err != nil {
 		return err
 	}

--- a/pkg/security/secl/compiler/generators/accessors/accessors.go
+++ b/pkg/security/secl/compiler/generators/accessors/accessors.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"go/ast"
 	"go/types"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -772,7 +771,7 @@ func (e *Event) SetFieldValue(field eval.Field, value interface{}) error {
 		return
 	}
 
-	tmpfile, err := ioutil.TempFile(path.Dir(output), "accessors")
+	tmpfile, err := os.CreateTemp(path.Dir(output), "accessors")
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/security/secl/compiler/generators/accessors/doc/doc.go
+++ b/pkg/security/secl/compiler/generators/accessors/doc/doc.go
@@ -8,7 +8,7 @@ package doc
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"regexp"
 	"sort"
 	"strings"
@@ -92,7 +92,7 @@ func GenerateDocJSON(module *common.Module, outputPath string) error {
 		return err
 	}
 
-	return ioutil.WriteFile(outputPath, res, 0644)
+	return os.WriteFile(outputPath, res, 0644)
 }
 
 var (

--- a/pkg/security/secl/rules/policy.go
+++ b/pkg/security/secl/rules/policy.go
@@ -8,7 +8,6 @@ package rules
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -99,7 +98,7 @@ func LoadPolicies(policiesDir string, ruleSet *RuleSet) *multierror.Error {
 		allRules []*RuleDefinition
 	)
 
-	policyFiles, err := ioutil.ReadDir(policiesDir)
+	policyFiles, err := os.ReadDir(policiesDir)
 	if err != nil {
 		return multierror.Append(result, ErrPoliciesLoad{Name: policiesDir, Err: err})
 	}

--- a/pkg/security/tests/cmdwrapper.go
+++ b/pkg/security/tests/cmdwrapper.go
@@ -74,10 +74,7 @@ func (d *dockerCmdWrapper) Command(bin string, args []string, envs []string) *ex
 func (d *dockerCmdWrapper) start() ([]byte, error) {
 	d.containerName = fmt.Sprintf("docker-wrapper-%s", randStringRunes(6))
 	cmd := exec.Command(d.executable, "run", "--rm", "-d", "--name", d.containerName, "-v", d.root+":"+d.root, "ubuntu:focal", "sleep", "600")
-	if out, err := cmd.CombinedOutput(); err != nil {
-		return out, err
-	}
-	return nil, nil
+	return cmd.CombinedOutput()
 }
 
 func (d *dockerCmdWrapper) stop() ([]byte, error) {

--- a/pkg/security/tests/dentry_test.go
+++ b/pkg/security/tests/dentry_test.go
@@ -186,10 +186,7 @@ func BenchmarkMapDentryResolutionSegment(b *testing.B) {
 		if err != nil {
 			return err
 		}
-		if err = syscall.Close(fd); err != nil {
-			return err
-		}
-		return nil
+		return syscall.Close(fd)
 	}, func(event *probe.Event, _ *rules.Rule) {
 		mountID = event.Open.File.MountID
 		inode = event.Open.File.Inode

--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -77,10 +77,7 @@ func TestOpenBasenameApproverFilterERPCDentryResolution(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if err = syscall.Close(fd1); err != nil {
-			return err
-		}
-		return nil
+		return syscall.Close(fd1)
 	}, testFile1); err != nil {
 		t.Fatal(err)
 	}
@@ -97,10 +94,7 @@ func TestOpenBasenameApproverFilterERPCDentryResolution(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if err = syscall.Close(fd2); err != nil {
-			return err
-		}
-		return nil
+		return syscall.Close(fd2)
 	}, testFile2); err == nil {
 		t.Fatal("shouldn't get an event")
 	}
@@ -138,10 +132,7 @@ func TestOpenBasenameApproverFilterMapDentryResolution(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if err = syscall.Close(fd1); err != nil {
-			return err
-		}
-		return nil
+		return syscall.Close(fd1)
 	}, testFile1); err != nil {
 		t.Fatal(err)
 	}
@@ -158,10 +149,7 @@ func TestOpenBasenameApproverFilterMapDentryResolution(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if err = syscall.Close(fd2); err != nil {
-			return err
-		}
-		return nil
+		return syscall.Close(fd2)
 	}, testFile2); err == nil {
 		t.Fatal("shouldn't get an event")
 	}
@@ -200,10 +188,7 @@ func TestOpenLeafDiscarderFilter(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if err = syscall.Close(fd); err != nil {
-			return err
-		}
-		return nil
+		return syscall.Close(fd)
 	}, func(d *testDiscarder) bool {
 		e := d.event.(*probe.Event)
 		if e == nil || (e != nil && e.GetEventType() != model.FileOpenEventType) {
@@ -226,10 +211,7 @@ func TestOpenLeafDiscarderFilter(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if err = syscall.Close(fd); err != nil {
-			return err
-		}
-		return nil
+		return syscall.Close(fd)
 	}, testFile); err == nil {
 		t.Fatal("shouldn't get an event")
 	}
@@ -268,10 +250,7 @@ func testOpenParentDiscarderFilter(t *testing.T, parents ...string) {
 		if err != nil {
 			return err
 		}
-		if err = syscall.Close(fd); err != nil {
-			return err
-		}
-		return nil
+		return syscall.Close(fd)
 	}, func(d *testDiscarder) bool {
 		e := d.event.(*probe.Event)
 		if e == nil || (e != nil && e.GetEventType() != model.FileOpenEventType) {
@@ -300,10 +279,7 @@ func testOpenParentDiscarderFilter(t *testing.T, parents ...string) {
 		if err != nil {
 			return err
 		}
-		if err = syscall.Close(fd); err != nil {
-			return err
-		}
-		return nil
+		return syscall.Close(fd)
 	}, testFile); err == nil {
 		t.Fatal("shouldn't get an event")
 	}
@@ -349,10 +325,7 @@ func TestDiscarderFilterMask(t *testing.T) {
 			time.Sleep(probe.DiscardRetention)
 
 			testFile, testFilePtr, err = test.CreateWithOptions("test-mask", 98, 99, 0o447)
-			if err != nil {
-				return err
-			}
-			return nil
+			return err
 		}, func(event *probe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_mask_open_rule")
 		})
@@ -385,10 +358,7 @@ func TestDiscarderFilterMask(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			if err = f.Close(); err != nil {
-				return err
-			}
-			return nil
+			return f.Close()
 		}, func(event *probe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_mask_open_rule")
 		})
@@ -422,10 +392,7 @@ func TestOpenFlagsApproverFilter(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if err = syscall.Close(fd); err != nil {
-			return err
-		}
-		return nil
+		return syscall.Close(fd)
 	}, testFile); err != nil {
 		t.Fatal(err)
 	}
@@ -435,10 +402,7 @@ func TestOpenFlagsApproverFilter(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if err = syscall.Close(fd); err != nil {
-			return err
-		}
-		return nil
+		return syscall.Close(fd)
 	}, testFile); err != nil {
 		t.Fatal(err)
 	}
@@ -448,10 +412,7 @@ func TestOpenFlagsApproverFilter(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if err = syscall.Close(fd); err != nil {
-			return err
-		}
-		return nil
+		return syscall.Close(fd)
 	}, testFile); err == nil {
 		t.Fatal("shouldn't get an event")
 	}
@@ -488,10 +449,7 @@ func TestOpenProcessPidDiscarder(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if err = syscall.Close(fd); err != nil {
-			return err
-		}
-		return nil
+		return syscall.Close(fd)
 	}, func(d *testDiscarder) bool {
 		e := d.event.(*probe.Event)
 		if e == nil || (e != nil && e.GetEventType() != model.FileOpenEventType) {
@@ -514,10 +472,7 @@ func TestOpenProcessPidDiscarder(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if err = syscall.Close(fd); err != nil {
-			return err
-		}
-		return nil
+		return syscall.Close(fd)
 	}, testFile); err == nil {
 		t.Fatalf("shouldn't get an event")
 	}
@@ -562,11 +517,7 @@ func TestDiscarderRetentionFilter(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if err = syscall.Close(fd); err != nil {
-			return err
-		}
-		return nil
-
+		return syscall.Close(fd)
 	}, func(d *testDiscarder) bool {
 		e := d.event.(*probe.Event)
 		if e == nil || (e != nil && e.GetEventType() != model.FileOpenEventType) {
@@ -592,10 +543,7 @@ func TestDiscarderRetentionFilter(t *testing.T) {
 		if err != nil {
 			return err
 		}
-		if err = syscall.Close(fd); err != nil {
-			return err
-		}
-		return nil
+		return syscall.Close(fd)
 	}, testFile); err == nil {
 		t.Fatal("shouldn't get an event")
 	}
@@ -622,10 +570,7 @@ func TestDiscarderRetentionFilter(t *testing.T) {
 			if err != nil {
 				return err
 			}
-			if err = syscall.Close(fd); err != nil {
-				return err
-			}
-			return nil
+			return syscall.Close(fd)
 		}, newFile); err != nil {
 			discarded = true
 			break

--- a/pkg/security/tests/mmap_test.go
+++ b/pkg/security/tests/mmap_test.go
@@ -37,14 +37,13 @@ func TestMMapEvent(t *testing.T) {
 
 	t.Run("mmap", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
-			var data []byte
-			data, err = unix.Mmap(0, 0, os.Getpagesize(), unix.PROT_READ|unix.PROT_WRITE|unix.PROT_EXEC, unix.MAP_SHARED|unix.MAP_ANON)
+			data, err := unix.Mmap(0, 0, os.Getpagesize(), unix.PROT_READ|unix.PROT_WRITE|unix.PROT_EXEC, unix.MAP_SHARED|unix.MAP_ANON)
 			if err != nil {
-				return fmt.Errorf("couldn't memory segment: %v", err)
+				return fmt.Errorf("couldn't memory segment: %w", err)
 			}
 
-			if err = unix.Munmap(data); err != nil {
-				return fmt.Errorf("couldn't unmap memory segment: %v", err)
+			if err := unix.Munmap(data); err != nil {
+				return fmt.Errorf("couldn't unmap memory segment: %w", err)
 			}
 			return nil
 		}, func(event *sprobe.Event, r *rules.Rule) {

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -278,12 +278,7 @@ func copyFile(src string, dst string, mode fs.FileMode) error {
 		return err
 	}
 
-	err = ioutil.WriteFile(dst, input, mode)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return os.WriteFile(dst, input, mode)
 }
 
 //nolint:deadcode,unused

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"os/exec"
@@ -273,7 +272,7 @@ func which(name string) string {
 
 //nolint:deadcode,unused
 func copyFile(src string, dst string, mode fs.FileMode) error {
-	input, err := ioutil.ReadFile(src)
+	input, err := os.ReadFile(src)
 	if err != nil {
 		return err
 	}
@@ -384,7 +383,7 @@ func setTestConfig(dir string, opts testOpts) (string, error) {
 }
 
 func setTestPolicy(dir string, macros []*rules.MacroDefinition, rules []*rules.RuleDefinition) (string, error) {
-	testPolicyFile, err := ioutil.TempFile(dir, "secagent-policy.*.policy")
+	testPolicyFile, err := os.CreateTemp(dir, "secagent-policy.*.policy")
 	if err != nil {
 		return "", err
 	}
@@ -1102,7 +1101,7 @@ func newSimpleTest(macros []*rules.MacroDefinition, rules []*rules.RuleDefinitio
 	}
 
 	if testDir == "" {
-		t.root, err = ioutil.TempDir("", "test-secagent-root")
+		t.root, err = os.MkdirTemp("", "test-secagent-root")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/security/tests/mount_test.go
+++ b/pkg/security/tests/mount_test.go
@@ -66,7 +66,7 @@ func TestMount(t *testing.T) {
 		err = test.GetProbeEvent(func() error {
 			// Test mount
 			if err := syscall.Mount(mntPath, dstMntPath, "bind", syscall.MS_BIND, ""); err != nil {
-				return fmt.Errorf("could not create bind mount: %s", err)
+				return fmt.Errorf("could not create bind mount: %w", err)
 			}
 			return nil
 		}, func(event *sprobe.Event) bool {
@@ -123,7 +123,7 @@ func TestMount(t *testing.T) {
 		err = test.GetProbeEvent(func() error {
 			// Test umount
 			if err = syscall.Unmount(dstMntPath, syscall.MNT_DETACH); err != nil {
-				return fmt.Errorf("could not unmount test-mount: %s", err)
+				return fmt.Errorf("could not unmount test-mount: %w", err)
 			}
 			return nil
 		}, func(event *sprobe.Event) bool {

--- a/pkg/security/tests/mprotect_test.go
+++ b/pkg/security/tests/mprotect_test.go
@@ -40,11 +40,11 @@ func TestMProtectEvent(t *testing.T) {
 			var data []byte
 			data, err = unix.Mmap(0, 0, os.Getpagesize(), unix.PROT_READ|unix.PROT_WRITE, unix.MAP_SHARED|unix.MAP_ANON)
 			if err != nil {
-				return fmt.Errorf("couldn't memory segment: %v", err)
+				return fmt.Errorf("couldn't memory segment: %w", err)
 			}
 
 			if err = unix.Mprotect(data, unix.PROT_READ|unix.PROT_WRITE|unix.PROT_EXEC); err != nil {
-				return fmt.Errorf("couldn't mprotect segment: %v", err)
+				return fmt.Errorf("couldn't mprotect segment: %w", err)
 			}
 			return nil
 		}, func(event *sprobe.Event, r *rules.Rule) {

--- a/pkg/security/tests/open_test.go
+++ b/pkg/security/tests/open_test.go
@@ -190,7 +190,7 @@ func TestOpen(t *testing.T) {
 				if err == unix.EINVAL {
 					return ErrSkipTest{"open_by_handle_at not supported"}
 				}
-				return fmt.Errorf("OpenByHandleAt: %v", err)
+				return fmt.Errorf("OpenByHandleAt: %w", err)
 			}
 			return unix.Close(fdInt)
 		}, func(event *sprobe.Event, r *rules.Rule) {

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -263,10 +263,7 @@ func TestProcessContext(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			cmd := exec.Command(lsExecutable, "-ll")
-			if err = cmd.Run(); err != nil {
-				return err
-			}
-			return nil
+			return cmd.Run()
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_argv")
 		})
@@ -277,10 +274,7 @@ func TestProcessContext(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			cmd := exec.Command(lsExecutable, "-ls", "--escape")
-			if err = cmd.Run(); err != nil {
-				return err
-			}
-			return nil
+			return cmd.Run()
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assertTriggeredRule(t, rule, "test_rule_args_flags")
 		})

--- a/pkg/security/tests/process_test.go
+++ b/pkg/security/tests/process_test.go
@@ -443,7 +443,7 @@ func TestProcessContext(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := cmdFunc("sh", args, nil)
 			if out, err := cmd.CombinedOutput(); err != nil {
-				return fmt.Errorf("%s: %s", out, err)
+				return fmt.Errorf("%s: %w", out, err)
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
@@ -471,7 +471,7 @@ func TestProcessContext(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := cmdFunc(shell, args, nil)
 			if out, err := cmd.CombinedOutput(); err != nil {
-				return fmt.Errorf("%s: %s", out, err)
+				return fmt.Errorf("%s: %w", out, err)
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
@@ -499,7 +499,7 @@ func TestProcessContext(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := cmdFunc(shell, args, envs)
 			if out, err := cmd.CombinedOutput(); err != nil {
-				return fmt.Errorf("%s: %s", out, err)
+				return fmt.Errorf("%s: %w", out, err)
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
@@ -526,7 +526,7 @@ func TestProcessContext(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := cmdFunc(shell, args, nil)
 			if out, err := cmd.CombinedOutput(); err != nil {
-				return fmt.Errorf("%s: %s", out, err)
+				return fmt.Errorf("%s: %w", out, err)
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
@@ -773,7 +773,7 @@ func testProcessEEExit(t *testing.T, pid uint32, test *testModule) {
 		resolvers := test.probe.GetResolvers()
 		entry := resolvers.ProcessResolver.Get(pid)
 		if entry != nil {
-			return fmt.Errorf("the process cache entry was not deleted from the user space cache")
+			return errors.New("the process cache entry was not deleted from the user space cache")
 		}
 
 		return nil

--- a/pkg/security/tests/rmdir_test.go
+++ b/pkg/security/tests/rmdir_test.go
@@ -113,10 +113,7 @@ func TestRmdirInvalidate(t *testing.T) {
 		}
 
 		test.WaitSignal(t, func() error {
-			if err := syscall.Rmdir(testFile); err != nil {
-				return err
-			}
-			return nil
+			return syscall.Rmdir(testFile)
 		}, func(event *sprobe.Event, rule *rules.Rule) {
 			assert.Equal(t, "rmdir", event.GetType(), "wrong event type")
 			assertFieldEqual(t, event, "rmdir.file.path", testFile)

--- a/pkg/security/tests/rmdir_test.go
+++ b/pkg/security/tests/rmdir_test.go
@@ -77,7 +77,7 @@ func TestRmdir(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			if _, _, err := syscall.Syscall(syscall.SYS_UNLINKAT, 0, uintptr(testDirPtr), 512); err != 0 {
-				return err
+				return error(err)
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {

--- a/pkg/security/tests/selinux_test.go
+++ b/pkg/security/tests/selinux_test.go
@@ -68,7 +68,7 @@ func TestSELinux(t *testing.T) {
 	t.Run("setenforce", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			if err := setEnforceStatus("permissive"); err != nil {
-				return fmt.Errorf("failed to run setenforce: %v", err)
+				return fmt.Errorf("failed to run setenforce: %w", err)
 			}
 			return nil
 		}, func(event *probe.Event, rule *rules.Rule) {
@@ -85,7 +85,7 @@ func TestSELinux(t *testing.T) {
 	t.Run("sel_disable", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			if err := rawSudoWrite("/sys/fs/selinux/disable", "0", false); err != nil {
-				return fmt.Errorf("failed to write to selinuxfs: %v", err)
+				return fmt.Errorf("failed to write to selinuxfs: %w", err)
 			}
 			return nil
 		}, func(event *probe.Event, rule *rules.Rule) {
@@ -101,7 +101,7 @@ func TestSELinux(t *testing.T) {
 	t.Run("setsebool_true_value", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			if err := setBoolValue(TestBoolName, true); err != nil {
-				return fmt.Errorf("failed to run setsebool: %v", err)
+				return fmt.Errorf("failed to run setsebool: %w", err)
 			}
 			return nil
 		}, func(event *probe.Event, rule *rules.Rule) {
@@ -119,7 +119,7 @@ func TestSELinux(t *testing.T) {
 	t.Run("setsebool_false_value", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			if err := setBoolValue(TestBoolName, false); err != nil {
-				return fmt.Errorf("failed to run setsebool: %v", err)
+				return fmt.Errorf("failed to run setsebool: %w", err)
 			}
 			return nil
 		}, func(event *probe.Event, rule *rules.Rule) {
@@ -137,7 +137,7 @@ func TestSELinux(t *testing.T) {
 	t.Run("setsebool_error_value", func(t *testing.T) {
 		err = test.GetSignal(t, func() error {
 			if err := rawSudoWrite("/sys/fs/selinux/booleans/httpd_enable_cgi", "test_error", true); err != nil {
-				return fmt.Errorf("failed to write to selinuxfs: %v", err)
+				return fmt.Errorf("failed to write to selinuxfs: %w", err)
 			}
 			return nil
 		}, func(event *probe.Event, rule *rules.Rule) {
@@ -179,7 +179,7 @@ func TestSELinuxCommitBools(t *testing.T) {
 	t.Run("sel_commit_bools", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			if err := setBoolValue(TestBoolName, true); err != nil {
-				return fmt.Errorf("failed to run setsebool: %v", err)
+				return fmt.Errorf("failed to run setsebool: %w", err)
 			}
 			return nil
 		}, func(event *probe.Event, rule *rules.Rule) {

--- a/pkg/security/tests/selinux_test.go
+++ b/pkg/security/tests/selinux_test.go
@@ -274,8 +274,5 @@ func setEnforceStatus(status string) error {
 
 	cmd := exec.Command("sudo", "-n", "setenforce", strconv.Itoa(enforceNumber))
 	_, err := cmd.Output()
-	if err != nil {
-		return err
-	}
-	return nil
+	return err
 }

--- a/pkg/security/tests/span_test.go
+++ b/pkg/security/tests/span_test.go
@@ -57,7 +57,6 @@ func TestSpan(t *testing.T) {
 			out, err := cmd.CombinedOutput()
 
 			if err != nil {
-				//if out, err := cmd.CombinedOutput(); err != nil {
 				return fmt.Errorf("%s: %w", out, err)
 			}
 

--- a/pkg/security/tests/span_test.go
+++ b/pkg/security/tests/span_test.go
@@ -58,7 +58,7 @@ func TestSpan(t *testing.T) {
 
 			if err != nil {
 				//if out, err := cmd.CombinedOutput(); err != nil {
-				return fmt.Errorf("%s: %s", out, err)
+				return fmt.Errorf("%s: %w", out, err)
 			}
 
 			return nil
@@ -87,7 +87,7 @@ func TestSpan(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			cmd := cmdFunc(syscallTester, args, envs)
 			if out, err := cmd.CombinedOutput(); err != nil {
-				return fmt.Errorf("%s: %s", out, err)
+				return fmt.Errorf("%s: %w", out, err)
 			}
 
 			return nil

--- a/pkg/security/tests/stress_test.go
+++ b/pkg/security/tests/stress_test.go
@@ -70,11 +70,7 @@ func stressOpen(t *testing.T, rule *rules.RuleDefinition, pathname string, size 
 			}
 		}
 
-		if err := f.Close(); err != nil {
-			return err
-		}
-
-		return nil
+		return f.Close()
 	}
 
 	opts := StressOpts{
@@ -205,11 +201,8 @@ func stressExec(t *testing.T, rule *rules.RuleDefinition, pathname string, execu
 
 	fnc := func() error {
 		cmd := exec.Command(executable, testFile)
-		if _, err := cmd.CombinedOutput(); err != nil {
-			return err
-		}
-
-		return nil
+		_, err := cmd.CombinedOutput()
+		return err
 	}
 
 	opts := StressOpts{

--- a/pkg/security/tests/stresser_test.go
+++ b/pkg/security/tests/stresser_test.go
@@ -181,8 +181,7 @@ func (s *StressReport) Save(filename string, name string) error {
 	fmt.Printf("Writing reports in %s\n", filename)
 
 	j, _ := json.Marshal(reports)
-	err := os.WriteFile(filename, j, 0644)
-	return err
+	return os.WriteFile(filename, j, 0644)
 }
 
 // Load previous report

--- a/pkg/security/tests/stresser_test.go
+++ b/pkg/security/tests/stresser_test.go
@@ -182,11 +182,7 @@ func (s *StressReport) Save(filename string, name string) error {
 
 	j, _ := json.Marshal(reports)
 	err := ioutil.WriteFile(filename, j, 0644)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return err
 }
 
 // Load previous report
@@ -202,11 +198,7 @@ func (s *StressReports) Load(filename string) error {
 		return err
 	}
 
-	if err := json.Unmarshal(data, s); err != nil {
-		return err
-	}
-
-	return nil
+	return json.Unmarshal(data, s)
 }
 
 func getTopData(filename string, from string, size int) ([]byte, error) {

--- a/pkg/security/tests/stresser_test.go
+++ b/pkg/security/tests/stresser_test.go
@@ -12,7 +12,7 @@ import (
 	"bufio"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"runtime"
 	"runtime/pprof"
@@ -181,7 +181,7 @@ func (s *StressReport) Save(filename string, name string) error {
 	fmt.Printf("Writing reports in %s\n", filename)
 
 	j, _ := json.Marshal(reports)
-	err := ioutil.WriteFile(filename, j, 0644)
+	err := os.WriteFile(filename, j, 0644)
 	return err
 }
 
@@ -193,7 +193,7 @@ func (s *StressReports) Load(filename string) error {
 	}
 	defer jsonFile.Close()
 
-	data, err := ioutil.ReadAll(jsonFile)
+	data, err := io.ReadAll(jsonFile)
 	if err != nil {
 		return err
 	}
@@ -202,7 +202,7 @@ func (s *StressReports) Load(filename string) error {
 }
 
 func getTopData(filename string, from string, size int) ([]byte, error) {
-	topFile, err := ioutil.TempFile("/tmp", "stress-top-")
+	topFile, err := os.CreateTemp("/tmp", "stress-top-")
 	if err != nil {
 		return nil, err
 	}
@@ -238,7 +238,7 @@ func getTopData(filename string, from string, size int) ([]byte, error) {
 func StressIt(t *testing.T, pre, post, fnc func() error, opts StressOpts) (StressReport, error) {
 	var report StressReport
 
-	proCPUFile, err := ioutil.TempFile("/tmp", "stress-cpu-")
+	proCPUFile, err := os.CreateTemp("/tmp", "stress-cpu-")
 	if err != nil {
 		t.Error(err)
 		return report, err
@@ -293,7 +293,7 @@ LOOP:
 	proCPUFile.Close()
 
 	runtime.GC()
-	proMemFile, err := ioutil.TempFile("/tmp", "stress-mem-")
+	proMemFile, err := os.CreateTemp("/tmp", "stress-mem-")
 	if err != nil {
 		t.Error(err)
 		return report, err

--- a/pkg/security/tests/syscall_tester.go
+++ b/pkg/security/tests/syscall_tester.go
@@ -24,7 +24,7 @@ var syscallTesterFS embed.FS
 func loadSyscallTester(t *testing.T, test *testModule, binary string) (string, error) {
 	var uname unix.Utsname
 	if err := unix.Uname(&uname); err != nil {
-		return "", fmt.Errorf("couldn't resolve arch: %s", err)
+		return "", fmt.Errorf("couldn't resolve arch: %w", err)
 	}
 
 	testerBin, err := syscallTesterFS.ReadFile(fmt.Sprintf("syscall_tester/bin/%s", binary))
@@ -57,7 +57,7 @@ func checkSyscallTester(t *testing.T, path string) error {
 	t.Helper()
 	sideTester := exec.Command(path, "check")
 	if _, err := sideTester.CombinedOutput(); err != nil {
-		return fmt.Errorf("cannot run syscall tester check: %s", err)
+		return fmt.Errorf("cannot run syscall tester check: %w", err)
 	}
 	return nil
 }

--- a/pkg/security/tests/syscall_tester/go/syscall_go_tester.go
+++ b/pkg/security/tests/syscall_tester/go/syscall_go_tester.go
@@ -59,9 +59,7 @@ func BPFLoad() error {
 	}
 
 	if bpfClone {
-		if err := BPFClone(m); err != nil {
-			return err
-		}
+		return BPFClone(m)
 	}
 
 	return nil

--- a/pkg/security/tests/syscall_tester/go/syscall_go_tester.go
+++ b/pkg/security/tests/syscall_tester/go/syscall_go_tester.go
@@ -58,8 +58,10 @@ func BPFLoad() error {
 		return fmt.Errorf("failed to initialize manager: %w", err)
 	}
 
-	if err := BPFClone(m); err != nil {
-		return err
+	if bpfClone {
+		if err := BPFClone(m); err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/pkg/security/tests/syscall_tester/go/syscall_go_tester.go
+++ b/pkg/security/tests/syscall_tester/go/syscall_go_tester.go
@@ -28,7 +28,7 @@ var ebpfProbe []byte
 
 func BPFClone(m *manager.Manager) error {
 	if _, err := m.CloneMap("cache", "cache_clone", manager.MapOptions{}); err != nil {
-		return fmt.Errorf("couldn't clone 'cache' map: %v", err)
+		return fmt.Errorf("couldn't clone 'cache' map: %w", err)
 	}
 	return nil
 }
@@ -55,7 +55,7 @@ func BPFLoad() error {
 	}()
 
 	if err := m.Init(bytes.NewReader(ebpfProbe)); err != nil {
-		return fmt.Errorf("failed to initialize manager: %v", err)
+		return fmt.Errorf("failed to initialize manager: %w", err)
 	}
 
 	if err := BPFClone(m); err != nil {

--- a/pkg/security/tests/testdrive.go
+++ b/pkg/security/tests/testdrive.go
@@ -10,7 +10,6 @@ package tests
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -49,7 +48,7 @@ func newTestDrive(fsType string, mountOpts []string) (*testDrive, error) {
 }
 
 func newTestDriveWithMountPoint(fsType string, mountOpts []string, mountPoint string) (*testDrive, error) {
-	backingFile, err := ioutil.TempFile("", "secagent-testdrive-")
+	backingFile, err := os.CreateTemp("", "secagent-testdrive-")
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create testdrive backing file")
 	}
@@ -59,7 +58,7 @@ func newTestDriveWithMountPoint(fsType string, mountOpts []string, mountPoint st
 	}
 
 	if len(mountPoint) == 0 {
-		mountPoint, err = ioutil.TempDir("", "secagent-testdrive-")
+		mountPoint, err = os.MkdirTemp("", "secagent-testdrive-")
 		if err != nil {
 			os.Remove(backingFile.Name())
 			return nil, errors.Wrap(err, "failed to create testdrive mount point")

--- a/pkg/security/tests/unlink_test.go
+++ b/pkg/security/tests/unlink_test.go
@@ -45,7 +45,7 @@ func TestUnlink(t *testing.T) {
 	t.Run("unlink", ifSyscallSupported("SYS_UNLINK", func(t *testing.T, syscallNB uintptr) {
 		test.WaitSignal(t, func() error {
 			if _, _, err := syscall.Syscall(syscallNB, uintptr(testFilePtr), 0, 0); err != 0 {
-				return err
+				return error(err)
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {
@@ -68,7 +68,7 @@ func TestUnlink(t *testing.T) {
 	t.Run("unlinkat", func(t *testing.T) {
 		test.WaitSignal(t, func() error {
 			if _, _, err := syscall.Syscall(syscall.SYS_UNLINKAT, 0, uintptr(testAtFilePtr), 0); err != 0 {
-				return err
+				return error(err)
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {

--- a/pkg/security/tests/utimes_test.go
+++ b/pkg/security/tests/utimes_test.go
@@ -85,7 +85,7 @@ func TestUtimes(t *testing.T) {
 
 		test.WaitSignal(t, func() error {
 			if _, _, errno := syscall.Syscall(syscallNB, uintptr(testFilePtr), uintptr(unsafe.Pointer(&times[0])), 0); errno != 0 {
-				return err
+				return error(errno)
 			}
 			return nil
 		}, func(event *sprobe.Event, rule *rules.Rule) {

--- a/pkg/security/utils/cgroup.go
+++ b/pkg/security/utils/cgroup.go
@@ -12,7 +12,7 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/sha256"
-	"io/ioutil"
+	"os"
 	"strconv"
 	"strings"
 
@@ -54,7 +54,7 @@ func (cg ControlGroup) GetContainerID() ContainerID {
 
 // GetProcControlGroups returns the cgroup membership of the specified task.
 func GetProcControlGroups(tgid, pid uint32) ([]ControlGroup, error) {
-	data, err := ioutil.ReadFile(CgroupTaskPath(tgid, pid))
+	data, err := os.ReadFile(CgroupTaskPath(tgid, pid))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/utils/proc.go
+++ b/pkg/security/utils/proc.go
@@ -11,7 +11,6 @@ package utils
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -52,7 +51,7 @@ func StatusPath(pid int32) string {
 // CapEffCapEprm returns the effective and permitted kernel capabilities of a process
 func CapEffCapEprm(pid int32) (uint64, uint64, error) {
 	var capEff, capPrm uint64
-	contents, err := ioutil.ReadFile(StatusPath(pid))
+	contents, err := os.ReadFile(StatusPath(pid))
 	if err != nil {
 		return 0, 0, err
 	}


### PR DESCRIPTION
### What does this PR do?

- change retry to 0 for CWS functional tests
- simplify cases of
```go
if err != nil {
  return err
}
return nil
```
- replace usages of ioutil since this package is in the process of being deprecated
- fix a few `error(errno)` that were wrong or missing
- improve the BPF syscall go tester
- use `%w` to embed error when appliable (in tests only)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
