### PR TITLE
[networks] Eliminate allocations from `gatewayLookup`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -188,6 +188,8 @@
 /pkg/logs/                              @DataDog/agent-core
 /pkg/logs/input/traps/                  @DataDog/infrastructure-integrations @DataDog/agent-core
 /pkg/process/                           @DataDog/processes
+/pkg/process/address*                   @DataDog/agent-network
+/pkg/process/netns*                     @DataDog/agent-network
 /pkg/process/checks/net*                @DataDog/agent-network
 /pkg/process/checks/pod*.go             @DataDog/container-app
 /pkg/process/net/                       @DataDog/processes @DataDog/agent-network

--- a/pkg/network/network_filter.go
+++ b/pkg/network/network_filter.go
@@ -161,16 +161,16 @@ func IsExcludedConnection(scf []*ConnectionFilter, dcf []*ConnectionFilter, conn
 		return false
 	}
 
-	buf := util.IPBufferPool.Get().([]byte)
+	buf := util.IPBufferPool.Get().(*[]byte)
 	defer util.IPBufferPool.Put(buf)
 
 	if len(scf) > 0 && conn.Source != nil {
-		if findMatchingFilter(scf, util.NetIPFromAddress(conn.Source, buf), conn.SPort, conn.Type) {
+		if findMatchingFilter(scf, util.NetIPFromAddress(conn.Source, *buf), conn.SPort, conn.Type) {
 			return true
 		}
 	}
 	if len(dcf) > 0 && conn.Dest != nil {
-		if findMatchingFilter(dcf, util.NetIPFromAddress(conn.Dest, buf), conn.DPort, conn.Type) {
+		if findMatchingFilter(dcf, util.NetIPFromAddress(conn.Dest, *buf), conn.DPort, conn.Type) {
 			return true
 		}
 	}

--- a/pkg/network/route_cache.go
+++ b/pkg/network/route_cache.go
@@ -103,7 +103,7 @@ func (c *routeCache) Get(source, dest util.Address, netns uint32) (Route, bool) 
 func newRouteKey(source, dest util.Address, netns uint32) routeKey {
 	k := routeKey{netns: netns, source: source, dest: dest}
 
-	switch len(dest.Bytes()) {
+	switch util.IPLen(dest) {
 	case 4:
 		k.connFamily = AFINET
 	case 16:

--- a/pkg/network/route_cache.go
+++ b/pkg/network/route_cache.go
@@ -131,14 +131,14 @@ func NewNetlinkRouter(procRoot string) (Router, error) {
 func (n *netlinkRouter) Route(source, dest util.Address, netns uint32) (Route, bool) {
 	var iifName string
 
-	srcBuf := util.IPBufferPool.Get().([]byte)
-	dstBuf := util.IPBufferPool.Get().([]byte)
+	srcBuf := util.IPBufferPool.Get().(*[]byte)
+	dstBuf := util.IPBufferPool.Get().(*[]byte)
 	defer func() {
 		util.IPBufferPool.Put(srcBuf)
 		util.IPBufferPool.Put(dstBuf)
 	}()
 
-	srcIP := util.NetIPFromAddress(source, srcBuf)
+	srcIP := util.NetIPFromAddress(source, *srcBuf)
 	if n.rootNs != netns {
 		// if its a non-root ns, we're dealing with traffic from
 		// a container most likely, and so need to find out
@@ -161,7 +161,7 @@ func (n *netlinkRouter) Route(source, dest util.Address, netns uint32) (Route, b
 		}
 	}
 
-	dstIP := util.NetIPFromAddress(dest, dstBuf)
+	dstIP := util.NetIPFromAddress(dest, *dstBuf)
 	routes, err := netlink.RouteGetWithOptions(
 		dstIP,
 		&netlink.RouteGetOptions{

--- a/pkg/network/route_cache.go
+++ b/pkg/network/route_cache.go
@@ -103,7 +103,7 @@ func (c *routeCache) Get(source, dest util.Address, netns uint32) (Route, bool) 
 func newRouteKey(source, dest util.Address, netns uint32) routeKey {
 	k := routeKey{netns: netns, source: source, dest: dest}
 
-	switch util.IPLen(dest) {
+	switch dest.Len() {
 	case 4:
 		k.connFamily = AFINET
 	case 16:

--- a/pkg/network/tracer/cached_conntrack.go
+++ b/pkg/network/tracer/cached_conntrack.go
@@ -77,14 +77,14 @@ func (cache *cachedConntrack) exists(c *network.ConnectionStats, netns uint32, p
 		protoNumber = unix.IPPROTO_TCP
 	}
 
-	srcBuf := util.IPBufferPool.Get().([]byte)
-	dstBuf := util.IPBufferPool.Get().([]byte)
+	srcBuf := util.IPBufferPool.Get().(*[]byte)
+	dstBuf := util.IPBufferPool.Get().(*[]byte)
 	defer func() {
 		util.IPBufferPool.Put(srcBuf)
 		util.IPBufferPool.Put(dstBuf)
 	}()
 
-	srcAddr, dstAddr := util.NetIPFromAddress(c.Source, srcBuf), util.NetIPFromAddress(c.Dest, dstBuf)
+	srcAddr, dstAddr := util.NetIPFromAddress(c.Source, *srcBuf), util.NetIPFromAddress(c.Dest, *dstBuf)
 	srcPort, dstPort := c.SPort, c.DPort
 
 	conn := netlink.Con{

--- a/pkg/network/tracer/gateway_lookup.go
+++ b/pkg/network/tracer/gateway_lookup.go
@@ -116,8 +116,9 @@ func (g *gatewayLookup) Lookup(cs *network.ConnectionStats) *network.Via {
 			return nil
 		}
 
-		g.subnetCache.Add(r.IfIndex, s)
-		v = s
+		via := &network.Via{Subnet: s}
+		g.subnetCache.Add(r.IfIndex, via)
+		v = via
 	} else if v == nil {
 		return nil
 	}
@@ -128,8 +129,8 @@ func (g *gatewayLookup) Lookup(cs *network.ConnectionStats) *network.Via {
 			g.subnetCache.Remove(r.IfIndex)
 		}
 		return nil
-	case network.Subnet:
-		return &network.Via{Subnet: cv}
+	case *network.Via:
+		return cv
 	default:
 		return nil
 	}

--- a/pkg/network/tracer/gateway_lookup.go
+++ b/pkg/network/tracer/gateway_lookup.go
@@ -83,11 +83,11 @@ func (g *gatewayLookup) Lookup(cs *network.ConnectionStats) *network.Via {
 		return nil
 	}
 
-	buf := util.IPBufferPool.Get().([]byte)
+	buf := util.IPBufferPool.Get().(*[]byte)
 	defer util.IPBufferPool.Put(buf)
 	// if there is no gateway, we don't need to add subnet info
 	// for gateway resolution in the backend
-	if util.NetIPFromAddress(r.Gateway, buf).IsUnspecified() {
+	if util.NetIPFromAddress(r.Gateway, *buf).IsUnspecified() {
 		return nil
 	}
 

--- a/pkg/process/util/address.go
+++ b/pkg/process/util/address.go
@@ -17,6 +17,7 @@ type Address interface {
 	WriteTo([]byte) int
 	String() string
 	IsLoopback() bool
+	Len() int
 }
 
 // AddressFromNetIP returns an Address from a provided net.IP
@@ -41,7 +42,7 @@ func AddressFromString(ip string) Address {
 // Warning: the returned `net.IP` will share the same underlying
 // memory as the given `buf` argument.
 func NetIPFromAddress(addr Address, buf []byte) net.IP {
-	if addrLen := IPLen(addr); len(buf) < addrLen {
+	if addrLen := addr.Len(); len(buf) < addrLen {
 		// if the function is misused we allocate
 		buf = make([]byte, addrLen)
 	}
@@ -64,18 +65,6 @@ func ToLowHigh(addr Address) (l, h uint64) {
 	}
 
 	return
-}
-
-// IPLen returns the size (in bytes) required to represent the address IP
-func IPLen(a Address) int {
-	switch a.(type) {
-	case v4Address:
-		return 4
-	case v6Address:
-		return 16
-	default:
-		return 0
-	}
 }
 
 type v4Address [4]byte
@@ -117,6 +106,11 @@ func (a v4Address) IsLoopback() bool {
 	return net.IP(a[:]).IsLoopback()
 }
 
+// Len returns the number of bytes required to represent this IP
+func (a v4Address) Len() int {
+	return 4
+}
+
 type v6Address [16]byte
 
 // V6Address creates an Address using the uint128 representation of an v6 IP
@@ -152,6 +146,11 @@ func (a v6Address) String() string {
 // IsLoopback returns true if this address is the loopback address
 func (a v6Address) IsLoopback() bool {
 	return net.IP(a[:]).IsLoopback()
+}
+
+// Len returns the number of bytes required to represent this IP
+func (a v6Address) Len() int {
+	return 16
 }
 
 // IPBufferPool is meant to be used in conjunction with `NetIPFromAddress`

--- a/pkg/process/util/address.go
+++ b/pkg/process/util/address.go
@@ -41,17 +41,7 @@ func AddressFromString(ip string) Address {
 // Warning: the returned `net.IP` will share the same underlying
 // memory as the given `buf` argument.
 func NetIPFromAddress(addr Address, buf []byte) net.IP {
-	var addrLen int
-	switch addr.(type) {
-	case v4Address:
-		addrLen = 4
-	case v6Address:
-		addrLen = 16
-	default:
-		return nil
-	}
-
-	if len(buf) < addrLen {
+	if addrLen := IPLen(addr); len(buf) < addrLen {
 		// if the function is misused we allocate
 		buf = make([]byte, addrLen)
 	}
@@ -74,6 +64,18 @@ func ToLowHigh(addr Address) (l, h uint64) {
 	}
 
 	return
+}
+
+// IPLen returns the size (in bytes) required to represent the address IP
+func IPLen(a Address) int {
+	switch a.(type) {
+	case v4Address:
+		return 4
+	case v6Address:
+		return 16
+	default:
+		return 0
+	}
 }
 
 type v4Address [4]byte

--- a/pkg/process/util/address.go
+++ b/pkg/process/util/address.go
@@ -38,6 +38,8 @@ func AddressFromString(ip string) Address {
 }
 
 // NetIPFromAddress returns a net.IP from an Address
+// Warning: the returned `net.IP` will share the same underlying
+// memory as the given `buf` argument.
 func NetIPFromAddress(addr Address, buf []byte) net.IP {
 	var addrLen int
 	switch addr.(type) {
@@ -153,6 +155,7 @@ func (a v6Address) IsLoopback() bool {
 // IPBufferPool is meant to be used in conjunction with `NetIPFromAddress`
 var IPBufferPool = sync.Pool{
 	New: func() interface{} {
-		return make([]byte, net.IPv6len)
+		b := make([]byte, net.IPv6len)
+		return &b
 	},
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Eliminate the majority of allocations in the `gatewayLookup` codepath. Basically three changes were made:
* Fix `IPBufferPool`;
* Cache `network.Via` objects directly
* Use `util.IPLen` instead of `len(address.Bytes())` which allocates;

In one of the hosts from our load test cluster these changes resulted in a ~30% decrease in the global allocation rate:
<img width="797" alt="Screen Shot 2022-01-18 at 10 06 54 AM" src="https://user-images.githubusercontent.com/692520/149963145-af0da47a-dd66-45f4-b098-e9d62865168d.png">

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
