### PR TITLE
Fix default values of inventories_min/max_interval

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1623,7 +1623,7 @@ func GetVectorURL(datatype DataType) (string, error) {
 func GetInventoriesMinInterval() time.Duration {
 	minInterval := time.Duration(Datadog.GetInt("inventories_min_interval")) * time.Second
 	if minInterval == 0 {
-		minInterval = DefaultInventoriesMinInterval
+		minInterval = DefaultInventoriesMinInterval * time.Second
 	}
 	return minInterval
 }
@@ -1632,7 +1632,7 @@ func GetInventoriesMinInterval() time.Duration {
 func GetInventoriesMaxInterval() time.Duration {
 	maxInterval := time.Duration(Datadog.GetInt("inventories_max_interval")) * time.Second
 	if maxInterval == 0 {
-		maxInterval = DefaultInventoriesMaxInterval
+		maxInterval = DefaultInventoriesMaxInterval * time.Second
 	}
 	return maxInterval
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1026,7 +1026,7 @@ func TestGetInventoriesMinInterval(t *testing.T) {
 func TestGetInventoriesMinIntervalInvalid(t *testing.T) {
 	// an invalid integer results in a value of 0 from Viper (with a logged warning)
 	Mock().Set("inventories_min_interval", 0)
-	assert.EqualValues(t, DefaultInventoriesMinInterval, GetInventoriesMinInterval())
+	assert.EqualValues(t, DefaultInventoriesMinInterval*time.Second, GetInventoriesMinInterval())
 }
 
 func TestGetInventoriesMaxInterval(t *testing.T) {
@@ -1037,5 +1037,5 @@ func TestGetInventoriesMaxInterval(t *testing.T) {
 func TestGetInventoriesMaxIntervalInvalid(t *testing.T) {
 	// an invalid integer results in a value of 0 from Viper (with a logged warning)
 	Mock().Set("inventories_max_interval", 0)
-	assert.EqualValues(t, DefaultInventoriesMaxInterval, GetInventoriesMaxInterval())
+	assert.EqualValues(t, DefaultInventoriesMaxInterval*time.Second, GetInventoriesMaxInterval())
 }


### PR DESCRIPTION
The defaults are in seconds, but were being cast to time.Duration
instead.  The tests did the same thing.

### What does this PR do?

Fixes #9995.

### Describe how to test/QA your changes

Enable log_payloads. Configure each configuration value to a non-integer, and observe that a warning is logged and that the agent is not constantly logging metadata payloads.


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
