### PR TITLE
[tagger/collectors/workloadmeta] Fix "docker_image" tag for images without tag

### DIFF
--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -180,7 +180,11 @@ func (c *WorkloadMetaCollector) handleContainer(ev workloadmeta.Event) []*TagInf
 	tags.AddLow("image_tag", image.Tag)
 
 	if container.Runtime == workloadmeta.ContainerRuntimeDocker {
-		tags.AddLow("docker_image", fmt.Sprintf("%s:%s", image.Name, image.Tag))
+		if image.Tag != "" {
+			tags.AddLow("docker_image", fmt.Sprintf("%s:%s", image.Name, image.Tag))
+		} else {
+			tags.AddLow("docker_image", image.Name)
+		}
 	}
 
 	// standard tags from labels

--- a/pkg/tagger/collectors/workloadmeta_test.go
+++ b/pkg/tagger/collectors/workloadmeta_test.go
@@ -681,6 +681,39 @@ func TestHandleContainer(t *testing.T) {
 			},
 		},
 		{
+			name: "docker container with image that has no tag",
+			container: workloadmeta.Container{
+				EntityID: entityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: containerName,
+				},
+				Runtime: workloadmeta.ContainerRuntimeDocker,
+				Image: workloadmeta.ContainerImage{
+					RawName:   "redis",
+					Name:      "redis",
+					ShortName: "redis",
+					Tag:       "",
+				},
+			},
+			expected: []*TagInfo{
+				{
+					Source: containerSource,
+					Entity: taggerEntityID,
+					HighCardTags: []string{
+						fmt.Sprintf("container_name:%s", containerName),
+						fmt.Sprintf("container_id:%s", entityID.ID),
+					},
+					OrchestratorCardTags: []string{},
+					LowCardTags: append([]string{
+						"docker_image:redis", // Notice that there's no tag
+						"image_name:redis",
+						"short_image:redis",
+					}),
+					StandardTags: []string{},
+				},
+			},
+		},
+		{
 			name: "nomad container",
 			container: workloadmeta.Container{
 				EntityID: entityID,


### PR DESCRIPTION
### What does this PR do?

Fixes the `docker_image` tag for containers that have an image that does not include a tag.

For example, for the "redis" image, "docker_image" was set to "redis:". This PR fixes the issue. Now "docker_image" is set to "redis".

This needs to be backported to 7.33.

### Describe how to test/QA your changes

Should be tested in 7.33.x.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
