### PR TITLE
[CWS] check if probes are up to date when building functional tests

### DIFF
--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -508,8 +508,9 @@ def check_outdated_ebpf_probes():
 
     sysprobe_version_line = check_output(["./bin/system-probe/system-probe", "version"]).decode('utf-8').strip()
     commit_re = re.compile("- Commit: ([a-fA-F0-9]+) -")
-    if m := commit_re.search(sysprobe_version_line):
-        sysprobe_short = m.group(1)
+    captures = commit_re.search(sysprobe_version_line)
+    if captures:
+        sysprobe_short = captures.group(1)
         if sysprobe_short != current_short:
             print(
                 color_message(

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -4,7 +4,7 @@ import re
 import shutil
 import sys
 import tempfile
-from subprocess import check_output
+import subprocess
 
 from invoke import task
 
@@ -506,7 +506,13 @@ def cws_go_generate(ctx):
 def check_outdated_ebpf_probes():
     current_short = get_git_commit()
 
-    sysprobe_version_line = check_output(["./bin/system-probe/system-probe", "version"]).decode('utf-8').strip()
+    try:
+        sysprobe_version_line = (
+            subprocess.check_output(["./bin/system-probe/system-probe", "version"]).decode('utf-8').strip()
+        )
+    except (FileNotFoundError, subprocess.CalledProcessError):
+        sysprobe_version_line = ""
+
     commit_re = re.compile("- Commit: ([a-fA-F0-9]+) -")
     captures = commit_re.search(sysprobe_version_line)
     if captures:


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
