### PR TITLE
[AD] Add container provider AND ecs listener on Fargate

### DIFF
--- a/pkg/config/autodiscovery/autodiscovery.go
+++ b/pkg/config/autodiscovery/autodiscovery.go
@@ -46,13 +46,19 @@ func DiscoverComponentsFromEnv() ([]config.ConfigurationProviders, []config.List
 		return detectedProviders, detectedListeners
 	}
 
-	if config.IsFeaturePresent(config.Docker) || config.IsFeaturePresent(config.Containerd) || config.IsFeaturePresent(config.ECSFargate) {
+	if config.IsFeaturePresent(config.Docker) || config.IsFeaturePresent(config.Containerd) {
 		detectedProviders = append(detectedProviders, config.ConfigurationProviders{Name: names.Container, Polling: true, PollInterval: "1s"})
 		if !config.IsFeaturePresent(config.Kubernetes) {
 			detectedListeners = append(detectedListeners, config.Listeners{Name: names.Container})
 			log.Info("Adding Container listener from environment")
 		}
 		log.Info("Adding Container provider from environment")
+	}
+
+	if config.IsFeaturePresent(config.ECSFargate) {
+		detectedProviders = append(detectedProviders, config.ConfigurationProviders{Name: names.Container, Polling: true, PollInterval: "1s"})
+		detectedListeners = append(detectedListeners, config.Listeners{Name: names.ECS})
+		log.Info("Adding Container provider and ECS listener from environment")
 	}
 
 	if config.IsFeaturePresent(config.Kubernetes) {


### PR DESCRIPTION
### What does this PR do?

This fixes a regression where the Agent was solely relying on the
container listener in ECS Fargate, which doesn't work because that
listener does not receive events coming from ECS Fargate containers
(while the config provider in fact does).

### Describe how to test/QA your changes

Deploy the agent with a `redis` (or your preferred image) sidecar to ECS Fargate. `agent status` should show the `redis` check scheduled correctly.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
