### PR TITLE
[tagger/collectors/workloadmeta] Fix "docker_image" tag when there's no image tag

### DIFF
--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -178,7 +178,11 @@ func (c *WorkloadMetaCollector) handleContainer(ev workloadmeta.Event) []*TagInf
 	tags.AddLow("image_tag", image.Tag)
 
 	if container.Runtime == workloadmeta.ContainerRuntimeDocker {
-		tags.AddLow("docker_image", fmt.Sprintf("%s:%s", image.Name, image.Tag))
+		if image.Tag != "" {
+			tags.AddLow("docker_image", fmt.Sprintf("%s:%s", image.Name, image.Tag))
+		} else {
+			tags.AddLow("docker_image", image.Name)
+		}
 	}
 
 	// standard tags from labels

--- a/pkg/tagger/collectors/workloadmeta_test.go
+++ b/pkg/tagger/collectors/workloadmeta_test.go
@@ -678,6 +678,39 @@ func TestHandleContainer(t *testing.T) {
 			},
 		},
 		{
+			name: "docker container with image that has no tag",
+			container: workloadmeta.Container{
+				EntityID: entityID,
+				EntityMeta: workloadmeta.EntityMeta{
+					Name: containerName,
+				},
+				Runtime: workloadmeta.ContainerRuntimeDocker,
+				Image: workloadmeta.ContainerImage{
+					RawName:   "redis",
+					Name:      "redis",
+					ShortName: "redis",
+					Tag:       "",
+				},
+			},
+			expected: []*TagInfo{
+				{
+					Source: containerSource,
+					Entity: taggerEntityID,
+					HighCardTags: []string{
+						fmt.Sprintf("container_name:%s", containerName),
+						fmt.Sprintf("container_id:%s", entityID.ID),
+					},
+					OrchestratorCardTags: []string{},
+					LowCardTags: append([]string{
+						"docker_image:redis", // Notice that there's no tag
+						"image_name:redis",
+						"short_image:redis",
+					}),
+					StandardTags: []string{},
+				},
+			},
+		},
+		{
 			name: "nomad container",
 			container: workloadmeta.Container{
 				EntityID: entityID,


### PR DESCRIPTION
### What does this PR do?

Backports https://github.com/DataDog/datadog-agent/pull/10582 to `7.33.x`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Deploy Redis using "redis" (without latest tag or any other version) as the image. For example: docker run --name redis redis.
- Run the agent with docker.
- Check that the docker_image tag is set correctly. For example, run agent configcheck and verify that the docker_image tag is set to redis (not `redis:`). You can also run agent check redisdb and check that the metrics are reported with the docker_image tag set to redis.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
