### PR TITLE
[CWS] Use agent rule API in e2e tests

### DIFF
--- a/test/e2e/cws-tests/requirements.txt
+++ b/test/e2e/cws-tests/requirements.txt
@@ -1,5 +1,5 @@
 kubernetes==20.13.0
-datadog-api-client==1.7.0
+datadog-api-client==1.8.0
 pyaml==21.10.1
 docker==5.0.3
 retry==0.9.2

--- a/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
@@ -25,7 +25,8 @@ class TestE2EKubernetes(unittest.TestCase):
         warnings.simplefilter("ignore", category=UserWarning)
         warnings.simplefilter("ignore", category=DeprecationWarning)
 
-        self.rule_id = None
+        self.signal_rule_id = None
+        self.agent_rule_id = None
         self.policies = None
 
         self.App = App()
@@ -33,8 +34,11 @@ class TestE2EKubernetes(unittest.TestCase):
         self.policy_loader = PolicyLoader()
 
     def tearDown(self):
-        if self.rule_id:
-            self.App.delete_rule(self.rule_id)
+        if self.agent_rule_id:
+            self.App.delete_agent_rule(self.agent_rule_id)
+
+        if self.signal_rule_id:
+            self.App.delete_signal_rule(self.signal_rule_id)
 
         if self.policies:
             os.remove(self.policies)
@@ -49,13 +53,20 @@ class TestE2EKubernetes(unittest.TestCase):
         test_id = str(uuid.uuid4())[:4]
         desc = f"e2e test rule {test_id}"
         data = None
+        agent_rule_name = f"e2e_agent_rule_{test_id}"
 
-        with Step(msg=f"check rule({test_id}) creation", emoji=":straight_ruler:"):
-            self.rule_id = self.App.create_cws_rule(
+        with Step(msg=f"check agent rule({test_id}) creation", emoji=":straight_ruler:"):
+            self.agent_rule_id = self.App.create_cws_agent_rule(
+                agent_rule_name,
                 desc,
-                "rule for e2e testing",
-                f"e2e_{test_id}",
                 f'open.file.path == "{filename}"',
+            )
+
+        with Step(msg=f"check signal rule({test_id}) creation", emoji=":straight_ruler:"):
+            self.signal_rule_id = self.App.create_cws_signal_rule(
+                desc,
+                "signal rule for e2e testing",
+                agent_rule_name,
             )
 
         with Step(msg="check policies download", emoji=":file_folder:"):
@@ -66,6 +77,7 @@ class TestE2EKubernetes(unittest.TestCase):
         with Step(msg="check rule presence in policies", emoji=":bullseye:"):
             rule = self.policy_loader.get_rule_by_desc(desc)
             self.assertIsNotNone(rule, msg="unable to find e2e rule")
+            self.assertEqual(rule["id"], agent_rule_name)
 
         with Step(msg="select pod", emoji=":man_running:"):
             self.kubernetes_helper.select_pod_name("app=datadog-agent")
@@ -89,31 +101,27 @@ class TestE2EKubernetes(unittest.TestCase):
         with Step(msg="check agent event", emoji=":check_mark_button:"):
             os.system(f"touch {filename}")
 
-            rule_id = rule["id"]
-
             wait_agent_log(
                 "system-probe",
                 self.kubernetes_helper,
-                f"Sending event message for rule `{rule_id}`",
+                f"Sending event message for rule `{agent_rule_name}`",
             )
 
         with Step(msg="check app event", emoji=":chart_increasing_with_yen:"):
-            rule_id = rule["id"]
-            event = self.App.wait_app_log(f"rule_id:{rule_id}")
+            event = self.App.wait_app_log(f"rule_id:{agent_rule_name}")
             attributes = event["data"][0]["attributes"]
 
             self.assertIn("tag1", attributes["tags"], "unable to find tag")
             self.assertIn("tag2", attributes["tags"], "unable to find tag")
 
         with Step(msg="check app signal", emoji=":1st_place_medal:"):
-            rule_id = rule["id"]
-            tag = f"rule_id:{rule_id}"
+            tag = f"rule_id:{agent_rule_name}"
             signal = self.App.wait_app_signal(tag)
             attributes = signal["data"][0]["attributes"]
 
             self.assertIn(tag, attributes["tags"], "unable to find rule_id tag")
             self.assertEqual(
-                rule["id"],
+                agent_rule_name,
                 attributes["attributes"]["agent"]["rule_id"],
                 "unable to find rule_id tag attribute",
             )


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Create an agent rule and reference it in signal rule.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The previous way of creating agent rules is being deprecated

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
