### PR TITLE
[CWS] fix static build of functional tests

### DIFF
--- a/pkg/ebpf/compiler/wrapper.h
+++ b/pkg/ebpf/compiler/wrapper.h
@@ -27,7 +27,7 @@ $ objdump -p bin/system-probe/system-probe
 $ nm bin/system-probe/system-probe | grep GLIBC_X.XX
 */
 
-#ifdef __GLIBC__
+#if defined(__GLIBC__) && !defined(SKIP_GLIBC_WRAPPER)
 
 #ifdef __x86_64__
 #define GLIBC_VERS "GLIBC_2.2.5"

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -261,7 +261,9 @@ def build_functional_tests(
 
     if static:
         build_tags += ',osusergo,netgo'
-        env["CGO_CPPFLAGS"] = "-DSKIP_GLIBC_WRAPPER"
+        if "CGO_CPPFLAGS" not in env:
+            env["CGO_CPPFLAGS"] = ""
+        env["CGO_CPPFLAGS"] += "-DSKIP_GLIBC_WRAPPER"
 
     if nikos_embedded_path:
         build_tags += ",dnf"

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -244,7 +244,9 @@ def build_functional_tests(
         golangci_lint(ctx, targets=targets, build_tags=[build_tags], arch=arch)
         staticcheck(ctx, targets=targets, build_tags=[build_tags], arch=arch)
 
-    ldflags, _, env = get_build_flags(ctx, major_version=major_version, nikos_embedded_path=nikos_embedded_path)
+    ldflags, _, env = get_build_flags(
+        ctx, major_version=major_version, nikos_embedded_path=nikos_embedded_path, static=static
+    )
 
     goenv = get_go_env(ctx, go_version)
     env.update(goenv)
@@ -258,8 +260,8 @@ def build_functional_tests(
         build_tags = "ebpf_bindata," + build_tags
 
     if static:
-        ldflags += '-extldflags "-static"'
         build_tags += ',osusergo,netgo'
+        env["CGO_CPPFLAGS"] = "-DSKIP_GLIBC_WRAPPER"
 
     if nikos_embedded_path:
         build_tags += ",dnf"


### PR DESCRIPTION
### What does this PR do?

This PR fixes the static compilation of CWS functional tests

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
