### PR TITLE
[gitlab] Run RC container deploy jobs only on RCs

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -313,6 +313,18 @@ variables:
     when: never
   - <<: *if_deploy
 
+.on_deploy_a6_rc:
+  - <<: *if_not_version_6
+    when: never
+  - <<: *if_not_deploy
+    when: never
+  - <<: *if_rc_tag_on_beta_repo_branch
+    when: on_success
+    variables:
+      AGENT_REPOSITORY: agent
+      DSD_REPOSITORY: dogstatsd
+      IMG_REGISTRIES: public
+
 .on_deploy_a6_manual:
   - <<: *if_not_version_6
     when: never
@@ -383,6 +395,18 @@ variables:
   - <<: *if_not_version_7
     when: never
   - <<: *if_deploy
+
+.on_deploy_a7_rc:
+  - <<: *if_not_version_7
+    when: never
+  - <<: *if_not_deploy
+    when: never
+  - <<: *if_rc_tag_on_beta_repo_branch
+    when: on_success
+    variables:
+      AGENT_REPOSITORY: agent
+      DSD_REPOSITORY: dogstatsd
+      IMG_REGISTRIES: public
 
 .on_deploy_a7_manual:
   - <<: *if_not_version_7

--- a/.gitlab/deploy_6/docker.yml
+++ b/.gitlab/deploy_6/docker.yml
@@ -12,8 +12,6 @@
 .deploy-a6-base:
   extends: .docker_publish_job_definition
   stage: deploy6
-  rules:
-    !reference [.on_deploy_a6_manual_auto_on_rc]
   dependencies: []
   before_script:
     - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv -e agent.version --major-version 6 --url-safe)"; fi
@@ -28,10 +26,15 @@
 
 deploy-a6:
   extends: .deploy-a6-base
+  rules:
+    !reference [.on_deploy_a6_manual_auto_on_rc]
+
 
 
 deploy-a6-rc:
   extends: .deploy-a6-base
+  rules:
+    !reference [.on_deploy_a6_rc]
   variables:
     VERSION: 6-rc
 

--- a/.gitlab/deploy_7/docker.yml
+++ b/.gitlab/deploy_7/docker.yml
@@ -12,8 +12,6 @@
 .deploy-a7-base:
   extends: .docker_publish_job_definition
   stage: deploy7
-  rules:
-    !reference [.on_deploy_a7_manual_auto_on_rc]
   dependencies: []
   before_script:
     - if [[ "$VERSION" == "" ]]; then export VERSION="$(inv -e agent.version --major-version 7 --url-safe)"; fi
@@ -34,10 +32,15 @@
 
 deploy-a7:
   extends: .deploy-a7-base
+  rules:
+    !reference [.on_deploy_a7_manual_auto_on_rc]
+
 
 
 deploy-a7-rc:
   extends: .deploy-a7-base
+  rules:
+    !reference [.on_deploy_a7_rc]
   variables:
     VERSION: 7-rc
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Changes the container deploy jobs for RCs so that they only appear in the pipeline on RCs.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Prevent confusion when someone does a non-RC deploy pipeline and doesn't know what these jobs are there for.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Run a deploy pipeline, check that the jobs aren't there. Run an RC deploy pipeline, check that the jobs are there.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
