### PR TITLE
[CWS] fix parent discarder using mount points as discarder

### DIFF
--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -217,6 +217,8 @@ enum event_type
     EVENT_MMAP,
     EVENT_MPROTECT,
     EVENT_MAX, // has to be the last one
+
+    EVENT_ALL = 0xffffffffffffffff // used as a mask for all the events
 };
 
 struct kevent_t {
@@ -525,7 +527,11 @@ static __attribute__((always_inline)) int is_event_enabled(enum event_type event
 }
 
 static __attribute__((always_inline)) void add_event_to_mask(u64 *mask, enum event_type event) {
-    *mask |= 1 << (event - EVENT_FIRST_DISCARDER);
+    if (event == EVENT_ALL) {
+        *mask = event;
+    } else {
+        *mask |= 1 << (event - EVENT_FIRST_DISCARDER);
+    }
 }
 
 #define VFS_ARG_POSITION1 1

--- a/pkg/security/probe/dentry_resolver.go
+++ b/pkg/security/probe/dentry_resolver.go
@@ -737,6 +737,11 @@ func (dr *DentryResolver) GetParent(mountID uint32, inode uint64, pathID uint32)
 	if err != nil && err != errTruncatedParentsERPC && dr.mapEnabled {
 		parentMountID, parentInode, err = dr.resolveParentFromMap(mountID, inode, pathID)
 	}
+
+	if parentInode == 0 {
+		return 0, 0, ErrEntryNotFound
+	}
+
 	return parentMountID, parentInode, err
 }
 

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -39,6 +39,9 @@ const (
 	// maxParentDiscarderDepth defines the maximum parent depth to find parent discarders
 	// the eBPF part need to be adapted accordingly
 	maxParentDiscarderDepth = 3
+
+	// allEventTypes is a mask to match all the events
+	allEventTypes = 0xffffffffffffffff
 )
 
 var (

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -418,7 +418,7 @@ func (id *inodeDiscarders) discardParentInode(rs *rules.RuleSet, eventType model
 
 	for i := 0; i < discarderDepth; i++ {
 		parentMountID, parentInode, err := id.dentryResolver.GetParent(mountID, inode, pathID)
-		if err != nil {
+		if err != nil || IsFakeInode(parentInode) {
 			if i == 0 {
 				return false, 0, 0, err
 			}
@@ -464,11 +464,13 @@ func filenameDiscarderWrapper(eventType model.EventType, handler onDiscarderHand
 			isDiscarded, _, parentInode, err := probe.inodeDiscarders.discardParentInode(rs, eventType, field, filename, mountID, inode, pathID)
 			if !isDiscarded && !isDeleted {
 				if _, ok := err.(*ErrInvalidKeyPath); !ok {
-					seclog.Tracef("Apply `%s.file.path` inode discarder for event `%s`, inode: %d(%s)", eventType, eventType, inode, filename)
+					if !IsFakeInode(inode) {
+						seclog.Tracef("Apply `%s.file.path` inode discarder for event `%s`, inode: %d(%s)", eventType, eventType, inode, filename)
 
-					// not able to discard the parent then only discard the filename
-					if err = probe.inodeDiscarders.discardInode(eventType, mountID, inode, true); err == nil {
-						probe.countNewInodeDiscarder(eventType)
+						// not able to discard the parent then only discard the filename
+						if err = probe.inodeDiscarders.discardInode(eventType, mountID, inode, true); err == nil {
+							probe.countNewInodeDiscarder(eventType)
+						}
 					}
 				}
 			} else if !isDeleted {

--- a/pkg/security/probe/discarders.go
+++ b/pkg/security/probe/discarders.go
@@ -414,10 +414,14 @@ func (id *inodeDiscarders) discardParentInode(rs *rules.RuleSet, eventType model
 	}
 
 	for i := 0; i < discarderDepth; i++ {
-		mountID, inode, err = id.dentryResolver.GetParent(mountID, inode, pathID)
+		parentMountID, parentInode, err := id.dentryResolver.GetParent(mountID, inode, pathID)
 		if err != nil {
-			return false, 0, 0, err
+			if i == 0 {
+				return false, 0, 0, err
+			}
+			break
 		}
+		mountID, inode = parentMountID, parentInode
 	}
 
 	if err := id.discardInode(eventType, mountID, inode, false); err != nil {

--- a/pkg/security/probe/load_controller.go
+++ b/pkg/security/probe/load_controller.go
@@ -131,7 +131,7 @@ func (lc *LoadController) discardNoisiestProcess() {
 
 	// push a temporary discarder on the noisiest process & event type tuple
 	seclog.Tracef("discarding events from pid %d for %s seconds", maxKey.Pid, lc.DiscarderTimeout)
-	if err := lc.probe.pidDiscarders.discardWithTimeout(0xffffffffffffffff, maxKey.Pid, lc.DiscarderTimeout.Nanoseconds()); err != nil {
+	if err := lc.probe.pidDiscarders.discardWithTimeout(allEventTypes, maxKey.Pid, lc.DiscarderTimeout.Nanoseconds()); err != nil {
 		log.Warnf("couldn't insert temporary discarder: %v", err)
 		return
 	}

--- a/pkg/security/probe/resolvers.go
+++ b/pkg/security/probe/resolvers.go
@@ -238,7 +238,9 @@ func (r *Resolvers) snapshot() error {
 		}
 
 		// Sync the process cache
-		cacheModified = r.ProcessResolver.SyncCache(proc)
+		if r.ProcessResolver.SyncCache(proc) {
+			cacheModified = true
+		}
 	}
 
 	// There is a possible race condition when a process starts right after we called process.AllProcesses


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR fixes parent discarder when the parent is actually a mount point. In that case the inode returned was 0 leading in not being able to apply a discarder.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
