### PR TITLE
[jmxfetch] ensure command waits for AD sync

### DIFF
--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -186,7 +186,10 @@ func runJmxCommandConsole(command string) error {
 		discoveryRetryInterval = discoveryTimeout
 	}
 
-	allConfigs := common.WaitForConfigs(time.Duration(discoveryRetryInterval)*time.Second, time.Duration(discoveryTimeout)*time.Second, common.SelectedCheckMatcherBuilder(cliSelectedChecks, discoveryMinInstances))
+	// Note: when no checks are selected, cliSelectedChecks will be the empty slice and thus common.SelectedCheckMatcherBuilder
+	//       will return false, leading WaitForConfigs to timeout before returning all AD configs.
+	allConfigs := common.WaitForConfigs(time.Duration(discoveryRetryInterval)*time.Second, time.Duration(discoveryTimeout)*time.Second,
+		common.SelectedCheckMatcherBuilder(cliSelectedChecks, discoveryMinInstances))
 
 	err = standalone.ExecJMXCommandConsole(command, cliSelectedChecks, logLevel, allConfigs)
 

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/cmd/agent/app/standalone"
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
-	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
@@ -187,7 +186,7 @@ func runJmxCommandConsole(command string) error {
 		discoveryRetryInterval = discoveryTimeout
 	}
 
-	allConfigs := common.WaitForConfigs(time.Duration(discoveryRetryInterval)*time.Second, time.Duration(discoveryTimeout)*time.Second, selectedCheckMatcherBuilder(cliSelectedChecks, discoveryMinInstances))
+	allConfigs := common.WaitForConfigs(time.Duration(discoveryRetryInterval)*time.Second, time.Duration(discoveryTimeout)*time.Second, common.SelectedCheckMatcherBuilder(cliSelectedChecks, discoveryMinInstances))
 
 	err = standalone.ExecJMXCommandConsole(command, cliSelectedChecks, logLevel, allConfigs)
 
@@ -196,20 +195,4 @@ func runJmxCommandConsole(command string) error {
 	}
 
 	return err
-}
-
-// selectedCheckMatcherBuilder returns a function that returns true if the number of configs found for the
-// check name is more or equal to min instances
-func selectedCheckMatcherBuilder(checkNames []string, minInstances uint) func(configs []integration.Config) bool {
-	return func(configs []integration.Config) bool {
-		var matchedConfigsCount uint
-		for _, cfg := range configs {
-			for _, name := range checkNames {
-				if cfg.Name == name {
-					matchedConfigsCount++
-				}
-			}
-		}
-		return matchedConfigsCount >= minInstances
-	}
 }

--- a/cmd/agent/app/standalone/jmx.go
+++ b/cmd/agent/app/standalone/jmx.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build jmx
 // +build jmx
 
 package standalone
@@ -10,10 +11,8 @@ package standalone
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/api"
-	"github.com/DataDog/datadog-agent/cmd/agent/common"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/embed/jmx"
@@ -24,37 +23,37 @@ import (
 // ExecJMXCommandConsole runs the provided JMX command name on the selected checks, and
 // reports with the ConsoleReporter to the agent's `log.Info`.
 // The common utils, including AutoConfig, must have already been initialized.
-func ExecJMXCommandConsole(command string, selectedChecks []string, logLevel string, discoveryRetryInterval time.Duration, discoveryTimeout time.Duration, discoveryMinInstances uint) error {
-	return execJmxCommand(command, selectedChecks, jmxfetch.ReporterConsole, log.JMXInfo, logLevel, discoveryRetryInterval, discoveryTimeout, discoveryMinInstances)
+func ExecJMXCommandConsole(command string, selectedChecks []string, logLevel string, configs []integration.Config) error {
+	return execJmxCommand(command, selectedChecks, jmxfetch.ReporterConsole, log.JMXInfo, logLevel, configs)
 }
 
 // ExecJmxListWithMetricsJSON runs the JMX command with "with-metrics", reporting
 // the data as a JSON on the console. It is used by the `check jmx` cli command
 // of the Agent.
 // The common utils, including AutoConfig, must have already been initialized.
-func ExecJmxListWithMetricsJSON(selectedChecks []string, logLevel string, discoveryRetryInterval time.Duration, discoveryTimeout time.Duration, discoveryMinInstances uint) error {
+func ExecJmxListWithMetricsJSON(selectedChecks []string, logLevel string, configs []integration.Config) error {
 	// don't pollute the JSON with the log pattern.
 	out := func(a ...interface{}) {
 		fmt.Println(a...)
 	}
-	return execJmxCommand("list_with_metrics", selectedChecks, jmxfetch.ReporterJSON, out, logLevel, discoveryRetryInterval, discoveryTimeout, discoveryMinInstances)
+	return execJmxCommand("list_with_metrics", selectedChecks, jmxfetch.ReporterJSON, out, logLevel, configs)
 }
 
 // ExecJmxListWithRateMetricsJSON runs the JMX command with "with-rate-metrics", reporting
 // the data as a JSON on the console. It is used by the `check jmx --rate` cli command
 // of the Agent.
 // The common utils, including AutoConfig, must have already been initialized.
-func ExecJmxListWithRateMetricsJSON(selectedChecks []string, logLevel string, discoveryRetryInterval time.Duration, discoveryTimeout time.Duration, discoveryMinInstances uint) error {
+func ExecJmxListWithRateMetricsJSON(selectedChecks []string, logLevel string, configs []integration.Config) error {
 	// don't pollute the JSON with the log pattern.
 	out := func(a ...interface{}) {
 		fmt.Println(a...)
 	}
-	return execJmxCommand("list_with_rate_metrics", selectedChecks, jmxfetch.ReporterJSON, out, logLevel, discoveryRetryInterval, discoveryTimeout, discoveryMinInstances)
+	return execJmxCommand("list_with_rate_metrics", selectedChecks, jmxfetch.ReporterJSON, out, logLevel, configs)
 }
 
 // execJmxCommand runs the provided JMX command name on the selected checks.
 // The common utils, including AutoConfig, must have already been initialized.
-func execJmxCommand(command string, selectedChecks []string, reporter jmxfetch.JMXReporter, output func(...interface{}), logLevel string, discoveryRetryInterval time.Duration, discoveryTimeout time.Duration, discoveryMinInstances uint) error {
+func execJmxCommand(command string, selectedChecks []string, reporter jmxfetch.JMXReporter, output func(...interface{}), logLevel string, configs []integration.Config) error {
 	// start the cmd HTTP server
 	if err := api.StartServer(nil); err != nil {
 		return fmt.Errorf("Error while starting api server, exiting: %v", err)
@@ -68,7 +67,7 @@ func execJmxCommand(command string, selectedChecks []string, reporter jmxfetch.J
 	runner.Output = output
 	runner.LogLevel = logLevel
 
-	loadJMXConfigs(runner, selectedChecks, discoveryRetryInterval, discoveryTimeout, discoveryMinInstances)
+	loadJMXConfigs(runner, selectedChecks, configs)
 
 	err := runner.Start(false)
 	if err != nil {
@@ -88,12 +87,10 @@ func execJmxCommand(command string, selectedChecks []string, reporter jmxfetch.J
 	return nil
 }
 
-func loadJMXConfigs(runner *jmxfetch.JMXFetch, selectedChecks []string, discoveryRetryInterval time.Duration, discoveryTimeout time.Duration, discoveryMinInstances uint) {
+func loadJMXConfigs(runner *jmxfetch.JMXFetch, selectedChecks []string, configs []integration.Config) {
 	fmt.Println("Loading configs...")
 
 	includeEverything := len(selectedChecks) == 0
-
-	configs := common.WaitForConfigs(discoveryRetryInterval, discoveryTimeout, jmxCheckMatcherBuilder(includeEverything, selectedChecks, discoveryMinInstances))
 
 	for _, c := range configs {
 		if check.IsJMXConfig(c) && (includeEverything || configIncluded(c, selectedChecks)) {
@@ -128,7 +125,7 @@ func configIncluded(config integration.Config, selectedChecks []string) bool {
 }
 
 // jmxCheckMatcherBuilder returns a function that returns true if the number of JMX configs found for the check name is more or equal to min instances
-func jmxCheckMatcherBuilder(includeEverything bool, selectedChecks []string, minInstances uint) func ([]integration.Config) bool {
+func jmxCheckMatcherBuilder(includeEverything bool, selectedChecks []string, minInstances uint) func([]integration.Config) bool {
 	return func(configs []integration.Config) bool {
 		var matchedConfigsCount uint
 		for _, c := range configs {

--- a/cmd/agent/app/standalone/jmx.go
+++ b/cmd/agent/app/standalone/jmx.go
@@ -123,16 +123,3 @@ func configIncluded(config integration.Config, selectedChecks []string) bool {
 	}
 	return false
 }
-
-// jmxCheckMatcherBuilder returns a function that returns true if the number of JMX configs found for the check name is more or equal to min instances
-func jmxCheckMatcherBuilder(includeEverything bool, selectedChecks []string, minInstances uint) func([]integration.Config) bool {
-	return func(configs []integration.Config) bool {
-		var matchedConfigsCount uint
-		for _, c := range configs {
-			if check.IsJMXConfig(c) && (includeEverything || configIncluded(c, selectedChecks)) {
-				matchedConfigsCount++
-			}
-		}
-		return matchedConfigsCount >= minInstances
-	}
-}

--- a/cmd/agent/app/standalone/jmx_nojmx.go
+++ b/cmd/agent/app/standalone/jmx_nojmx.go
@@ -3,23 +3,28 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !jmx
 // +build !jmx
 
 package standalone
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+)
 
 // ExecJMXCommandConsole is not supported when the 'jmx' build tag isn't included
-func ExecJMXCommandConsole(command string, selectedChecks []string, logLevel string) error {
+func ExecJMXCommandConsole(command string, selectedChecks []string, logLevel string, configs []integration.Config) error {
 	return fmt.Errorf("not supported: the Agent is compiled without the 'jmx' build tag")
 }
 
 // ExecJmxListWithMetricsJSON is not supported when the 'jmx' build tag isn't included
-func ExecJmxListWithMetricsJSON(selectedChecks []string, logLevel string) error {
+func ExecJmxListWithMetricsJSON(selectedChecks []string, logLevel string, configs []integration.Config) error {
 	return fmt.Errorf("not supported: the Agent is compiled without the 'jmx' build tag")
 }
 
 // ExecJmxListWithRateMetricsJSON is not supported when the 'jmx' build tag isn't included
-func ExecJmxListWithRateMetricsJSON(selectedChecks []string, logLevel string) error {
+func ExecJmxListWithRateMetricsJSON(selectedChecks []string, logLevel string, configs []integration.Config) error {
 	return fmt.Errorf("not supported: the Agent is compiled without the 'jmx' build tag")
 }

--- a/cmd/agent/common/autodiscovery.go
+++ b/cmd/agent/common/autodiscovery.go
@@ -6,7 +6,11 @@
 package common
 
 import (
+	"context"
+	"time"
+
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/providers"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/scheduler"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -162,4 +166,35 @@ func setupAutoDiscovery(confSearchPaths []string, metaScheduler *scheduler.MetaS
 // StartAutoConfig starts auto discovery
 func StartAutoConfig() {
 	AC.LoadAndRun()
+}
+
+// waitForConfigs retries the collection of Autodiscovery configs until the checkMatcher function (which
+// defines whether the list of integration configs collected is sufficient) returns true or the timeout is reached.
+// Autodiscovery listeners run asynchronously, AC.GetAllConfigs() can fail at the beginning to resolve templated configs
+// depending on non-deterministic factors (system load, network latency, active Autodiscovery listeners and their configurations).
+// This function improves the resiliency of the check command.
+// Note: If the check corresponds to a non-template configuration it should be found on the first try and fast-returned.
+func WaitForConfigs(retryInterval, timeout time.Duration, checkMatcher func([]integration.Config) bool) []integration.Config {
+	allConfigs := AC.GetAllConfigs()
+	if checkMatcher(allConfigs) {
+		return allConfigs
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	retryTicker := time.NewTicker(retryInterval)
+	defer retryTicker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return allConfigs
+		case <-retryTicker.C:
+			allConfigs = AC.GetAllConfigs()
+			if checkMatcher(allConfigs) {
+				return allConfigs
+			}
+		}
+	}
 }

--- a/cmd/agent/common/autodiscovery.go
+++ b/cmd/agent/common/autodiscovery.go
@@ -168,7 +168,7 @@ func StartAutoConfig() {
 	AC.LoadAndRun()
 }
 
-// waitForConfigs retries the collection of Autodiscovery configs until the checkMatcher function (which
+// WaitForConfigs retries the collection of Autodiscovery configs until the checkMatcher function (which
 // defines whether the list of integration configs collected is sufficient) returns true or the timeout is reached.
 // Autodiscovery listeners run asynchronously, AC.GetAllConfigs() can fail at the beginning to resolve templated configs
 // depending on non-deterministic factors (system load, network latency, active Autodiscovery listeners and their configurations).

--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -169,11 +169,13 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 					fmt.Println("Please consider using the 'jmx' command instead of 'check jmx'")
 					selectedChecks := []string{checkName}
 					if checkRate {
-						if err := standalone.ExecJmxListWithRateMetricsJSON(selectedChecks, resolvedLogLevel); err != nil {
+						if err := standalone.ExecJmxListWithRateMetricsJSON(selectedChecks, resolvedLogLevel,
+							time.Duration(discoveryRetryInterval)*time.Second, time.Duration(discoveryTimeout)*time.Second, discoveryMinInstances); err != nil {
 							return fmt.Errorf("while running the jmx check: %v", err)
 						}
 					} else {
-						if err := standalone.ExecJmxListWithMetricsJSON(selectedChecks, resolvedLogLevel); err != nil {
+						if err := standalone.ExecJmxListWithMetricsJSON(selectedChecks, resolvedLogLevel,
+							time.Duration(discoveryRetryInterval)*time.Second, time.Duration(discoveryTimeout)*time.Second, discoveryMinInstances); err != nil {
 							return fmt.Errorf("while running the jmx check: %v", err)
 						}
 					}

--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -154,7 +154,8 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 				discoveryRetryInterval = discoveryTimeout
 			}
 
-			allConfigs := common.WaitForConfigs(time.Duration(discoveryRetryInterval)*time.Second, time.Duration(discoveryTimeout)*time.Second, common.SelectedCheckMatcherBuilder([]string{checkName}, discoveryMinInstances))
+			allConfigs := common.WaitForConfigs(time.Duration(discoveryRetryInterval)*time.Second, time.Duration(discoveryTimeout)*time.Second,
+				common.SelectedCheckMatcherBuilder([]string{checkName}, discoveryMinInstances))
 
 			// make sure the checks in cs are not JMX checks
 			for idx := range allConfigs {

--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -154,7 +154,7 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 				discoveryRetryInterval = discoveryTimeout
 			}
 
-			allConfigs := common.WaitForConfigs(time.Duration(discoveryRetryInterval)*time.Second, time.Duration(discoveryTimeout)*time.Second, checkMatcherBuilder(checkName, discoveryMinInstances))
+			allConfigs := common.WaitForConfigs(time.Duration(discoveryRetryInterval)*time.Second, time.Duration(discoveryTimeout)*time.Second, common.SelectedCheckMatcherBuilder([]string{checkName}, discoveryMinInstances))
 
 			// make sure the checks in cs are not JMX checks
 			for idx := range allConfigs {
@@ -721,18 +721,4 @@ func populateMemoryProfileConfig(initConfig map[string]interface{}) error {
 	}
 
 	return nil
-}
-
-// checkMatcherBuilder returns a function that returns true if the number of configs found for the
-// check name is more or equal to min instances
-func checkMatcherBuilder(checkName string, minInstances uint) func(configs []integration.Config) bool {
-	return func(configs []integration.Config) bool {
-		var matchedConfigsCount uint
-		for _, cfg := range configs {
-			if cfg.Name == checkName {
-				matchedConfigsCount++
-			}
-		}
-		return matchedConfigsCount >= minInstances
-	}
 }

--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -169,13 +169,11 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 					fmt.Println("Please consider using the 'jmx' command instead of 'check jmx'")
 					selectedChecks := []string{checkName}
 					if checkRate {
-						if err := standalone.ExecJmxListWithRateMetricsJSON(selectedChecks, resolvedLogLevel,
-							time.Duration(discoveryRetryInterval)*time.Second, time.Duration(discoveryTimeout)*time.Second, discoveryMinInstances); err != nil {
+						if err := standalone.ExecJmxListWithRateMetricsJSON(selectedChecks, resolvedLogLevel, allConfigs); err != nil {
 							return fmt.Errorf("while running the jmx check: %v", err)
 						}
 					} else {
-						if err := standalone.ExecJmxListWithMetricsJSON(selectedChecks, resolvedLogLevel,
-							time.Duration(discoveryRetryInterval)*time.Second, time.Duration(discoveryTimeout)*time.Second, discoveryMinInstances); err != nil {
+						if err := standalone.ExecJmxListWithMetricsJSON(selectedChecks, resolvedLogLevel, allConfigs); err != nil {
 							return fmt.Errorf("while running the jmx check: %v", err)
 						}
 					}

--- a/cmd/agent/common/helpers.go
+++ b/cmd/agent/common/helpers.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/viper"
 )
@@ -69,4 +70,20 @@ func setupConfig(confFilePath string, configName string, withoutSecrets bool, fa
 		return warnings, fmt.Errorf("unable to load Datadog config file: %w", err)
 	}
 	return warnings, nil
+}
+
+// SelectedCheckMatcherBuilder returns a function that returns true if the number of configs found for the
+// check name is more or equal to min instances
+func SelectedCheckMatcherBuilder(checkNames []string, minInstances uint) func(configs []integration.Config) bool {
+	return func(configs []integration.Config) bool {
+		var matchedConfigsCount uint
+		for _, cfg := range configs {
+			for _, name := range checkNames {
+				if cfg.Name == name {
+					matchedConfigsCount++
+				}
+			}
+		}
+		return matchedConfigsCount >= minInstances
+	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR ensures the `datadog-agent jmx` commands wait for the necessary AD config sync prior to invoking the actual command. 

### Motivation

This is now necessary due to a race condition by which the jmx command would run before the AD configurations were available and thus would result in the commands consistently failing due to the JMXFetch configs discovered being unavailable. This race condition is now worse since the AD changes planned for 7.33.0, because AD now takes slightly longer to initially collect configs from all config providers/listeners (in particular the k8s/container-related ones).

This PR also includes a small refactor such that the resolved configs are only resolved once, and then passed onto the jmx functions where they no longer have to be matched again. 

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

The `agent jmx` commands, when called without a list of check names, now always wait for AD configs until the `discoveryTimeout` (default: 5 seconds) is hit. This makes these commands slower (it slows them down by ~5 seconds), but maximizes the chances that all the AD configs are actually correctly collected before JMXFetch is started by the commands, and therefore maximizes the chances that the commands will actually output the information for all configured JMXFetch checks.

Long-term, to shorten the wait, AD should provide a mechanism to signal that its initial config/service collection is complete.

### Describe how to test/QA your changes

With an agent with JMXFetch checks that are configured in files and in k8s annotations or container labels:
* test that all the `agent jmx` commands work and return the output for all (or the selected) JMXFetch checks:
  * with and without the pre-existing `--checks` parameter (without this parameter, the command is expected to initially wait for `discovery-timeout` seconds when collecting AD configs)
  * with and without the new `--discovery-timeout`, `--discovery-retry-interval`, and `--discovery-min-instances` parameters
* test that the `agent check` command works:
  * with and without the pre-existing `--check-rate` parameter
  * with and without the pre-existing `--discovery-timeout`, `--discovery-retry-interval`, and `--discovery-min-instances` parameters

To test this change find a node with a relatively heavy AD workload. Feel free to reach out to me to point you in the right direction for a suitable cluster in our staging/prod environments. It's then quite straight forward to run the following commands to evaluate the fix (assuming a containerized deployment):
```bash
agent jmx list collected
agent jmx collect
agent jmx list collected --checks <a relevant check list (ie. cassandra)>
agent jmx collect --checks <a relevant check list (ie. cassandra)>
``` 
A working fix will wait for the AD configs to be available before launching the jmx command. 

The first two commands, since there is no check list available will wait for the timeout to be hit (thus making sure all available AD configs are available), while the second option, will launch the `jmx` commands as soon as there is a matching hit.
 
 Additionally, to ensure there are no regressions on the `check` command, you may also run the following and observe the expected behavior with check runs:
 ```
 agent check <check-name>
 ```
 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
