### PR TITLE
Fix CPU rates calculations in process-agent and disable remote tagger

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -905,7 +905,7 @@ func InitConfig(config Config) {
 	config.SetKnown("process_config.log_file")
 	config.SetKnown("process_config.internal_profiling.enabled")
 
-	config.BindEnvAndSetDefault("process_config.remote_tagger", true)
+	config.BindEnvAndSetDefault("process_config.remote_tagger", false)
 
 	// Process Discovery Check
 	config.BindEnvAndSetDefault("process_config.process_discovery.enabled", false)

--- a/pkg/process/checks/container.go
+++ b/pkg/process/checks/container.go
@@ -121,6 +121,7 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 
 // fmtContainers loops through container list and converts them to a list of container objects
 func fmtContainers(ctrList []*containers.Container, lastRates map[string]util.ContainerRateMetrics, lastRun time.Time) []*model.Container {
+	currentTime := time.Now()
 	containersList := make([]*model.Container, 0, len(ctrList))
 	for _, ctr := range ctrList {
 		lastCtr, ok := lastRates[ctr.ID]
@@ -152,13 +153,13 @@ func fmtContainers(ctrList []*containers.Container, lastRates map[string]util.Co
 		cpus := system.HostCPUCount()
 		sys2, sys1 := ctr.CPU.SystemUsage, lastCtr.CPU.SystemUsage
 
-		userPct := calculateCtrPct(ctr.CPU.User, lastCtr.CPU.User, sys2, sys1, cpus, lastRun)
-		systemPct := calculateCtrPct(ctr.CPU.System, lastCtr.CPU.System, sys2, sys1, cpus, lastRun)
+		userPct := calculateCtrPct(ctr.CPU.User, lastCtr.CPU.User, sys2, sys1, cpus, currentTime, lastRun)
+		systemPct := calculateCtrPct(ctr.CPU.System, lastCtr.CPU.System, sys2, sys1, cpus, currentTime, lastRun)
 		var totalPct float32
 		if userPct == -1 || systemPct == -1 {
 			totalPct = -1
 		} else {
-			totalPct = calculateCtrPct(ctr.CPU.User+ctr.CPU.System, lastCtr.CPU.User+lastCtr.CPU.System, sys2, sys1, cpus, lastRun)
+			totalPct = calculateCtrPct(ctr.CPU.User+ctr.CPU.System, lastCtr.CPU.User+lastCtr.CPU.System, sys2, sys1, cpus, currentTime, lastRun)
 		}
 
 		containersList = append(containersList, &model.Container{

--- a/pkg/process/checks/container_common.go
+++ b/pkg/process/checks/container_common.go
@@ -4,15 +4,14 @@ import (
 	"time"
 )
 
-func calculateCtrPct(cur, prev float64, sys2, sys1 uint64, numCPU int, before time.Time) float32 {
+func calculateCtrPct(cur, prev float64, sys2, sys1 uint64, numCPU int, current, before time.Time) float32 {
 	// -1 is returned if a cgroup file is missing or the `ContainerCPUStats` object is nil.
 	// In these situations, return -1 so that the metric is skipped on the backend.
 	if cur == -1 || prev == -1 {
 		return -1
 	}
-	now := time.Now()
-	diff := now.UnixNano() - before.UnixNano()
-	if before.IsZero() || diff <= 0 {
+	diff := current.Sub(before).Seconds()
+	if before.IsZero() || diff < 0 {
 		return 0
 	}
 
@@ -21,15 +20,15 @@ func calculateCtrPct(cur, prev float64, sys2, sys1 uint64, numCPU int, before ti
 		return 0
 	}
 
-	cpuDelta := float32(cur - prev)
+	cpuDelta := cur - prev
 
 	// If we have system usage values then we need to calculate against those.
 	// XXX: Right now this only applies to ECS collection. Note that the inclusion of CPUs is
 	// necessary because the value gets normalized against the CPU limit, which also accounts for CPUs.
 	if sys1 >= 0 && sys2 > 0 && sys2 != sys1 {
-		sysDelta := float32(sys2 - sys1)
-		return (cpuDelta / sysDelta) * float32(numCPU) * 100
+		sysDelta := float64(sys2 - sys1)
+		return float32((cpuDelta / sysDelta) * float64(numCPU) * 100)
 	}
 
-	return (cpuDelta / (float32(diff) * float32(numCPU))) * 100
+	return float32(cpuDelta / diff)
 }

--- a/pkg/process/checks/container_rt.go
+++ b/pkg/process/checks/container_rt.go
@@ -90,6 +90,7 @@ func fmtContainerStats(
 	lastRun time.Time,
 	chunks int,
 ) [][]*model.ContainerStat {
+	currentTime := time.Now()
 	perChunk := (len(ctrList) / chunks) + 1
 	chunked := make([][]*model.ContainerStat, chunks)
 	chunk := make([]*model.ContainerStat, 0, perChunk)
@@ -110,13 +111,13 @@ func fmtContainerStats(
 		cpus := system.HostCPUCount()
 		sys2, sys1 := ctr.CPU.SystemUsage, lastCtr.CPU.SystemUsage
 
-		userPct := calculateCtrPct(ctr.CPU.User, lastCtr.CPU.User, sys2, sys1, cpus, lastRun)
-		systemPct := calculateCtrPct(ctr.CPU.System, lastCtr.CPU.System, sys2, sys1, cpus, lastRun)
+		userPct := calculateCtrPct(ctr.CPU.User, lastCtr.CPU.User, sys2, sys1, cpus, currentTime, lastRun)
+		systemPct := calculateCtrPct(ctr.CPU.System, lastCtr.CPU.System, sys2, sys1, cpus, currentTime, lastRun)
 		var totalPct float32
 		if userPct == -1 || systemPct == -1 {
 			totalPct = -1
 		} else {
-			totalPct = calculateCtrPct(ctr.CPU.User+ctr.CPU.System, lastCtr.CPU.User+lastCtr.CPU.System, sys2, sys1, cpus, lastRun)
+			totalPct = calculateCtrPct(ctr.CPU.User+ctr.CPU.System, lastCtr.CPU.User+lastCtr.CPU.System, sys2, sys1, cpus, currentTime, lastRun)
 		}
 
 		chunk = append(chunk, &model.ContainerStat{

--- a/pkg/process/checks/container_test.go
+++ b/pkg/process/checks/container_test.go
@@ -1,9 +1,9 @@
+//go:build linux
 // +build linux
 
 package checks
 
 import (
-	"math"
 	"net"
 	"testing"
 	"time"
@@ -118,34 +118,35 @@ func TestContainerNils(t *testing.T) {
 func TestCalculateCtrPct(t *testing.T) {
 	epsilon := 0.1 // Difference less than some epsilon
 
-	before := time.Now().Add(-1 * time.Second)
+	currentTime := time.Now()
+	before := currentTime.Add(-1 * time.Second)
 
 	var emptyTime time.Time
 
 	// Underflow on cur-prev
-	assert.Equal(t, float32(0), calculateCtrPct(0, 1, 0, 0, 1, before))
+	assert.Equal(t, float32(0), calculateCtrPct(0, 1, 0, 0, 1, currentTime, before))
 
 	// Underflow on sys2-sys1
-	assert.Equal(t, float32(0), calculateCtrPct(3, 1, 4, 5, 1, before))
+	assert.Equal(t, float32(0), calculateCtrPct(3, 1, 4, 5, 1, currentTime, before))
 
 	// Time is empty
-	assert.Equal(t, float32(0), calculateCtrPct(3, 1, 0, 0, 1, emptyTime))
+	assert.Equal(t, float32(0), calculateCtrPct(3, 1, 0, 0, 1, currentTime, emptyTime))
 
 	// Div by zero on sys2/sys1, fallback to normal cpu calculation
-	assert.InEpsilon(t, 50.0, calculateCtrPct(1.5*math.Pow10(9), math.Pow10(9), 1, 1, 1, before), epsilon)
+	assert.InEpsilon(t, 2, calculateCtrPct(3, 1, 1, 1, 1, currentTime, before), epsilon)
 
 	// use cur=2, prev=0, sys1=0, sys2=2 simulating first check on new container
-	assert.InEpsilon(t, float32(200), calculateCtrPct(2, 0, 1, 0, 1, before), epsilon)
+	assert.InEpsilon(t, float32(200), calculateCtrPct(2, 0, 1, 0, 1, currentTime, before), epsilon)
 
 	// Calculate based off cur & prev
-	assert.InEpsilon(t, 50.0, calculateCtrPct(1.5*math.Pow10(9), math.Pow10(9), 0, 0, 1, before), epsilon)
+	assert.InEpsilon(t, 2, calculateCtrPct(3, 1, 0, 0, 1, currentTime, before), epsilon)
 
 	// Calculate based off all values
-	assert.InEpsilon(t, 66.66667, calculateCtrPct(3, 1, 4, 1, 1, before), epsilon)
+	assert.InEpsilon(t, 66.66667, calculateCtrPct(3, 1, 4, 1, 1, currentTime, before), epsilon)
 
 	// cur=-1 because of missing cgroup file
-	assert.Equal(t, float32(-1), calculateCtrPct(-1, 1, 0, 0, 1, emptyTime))
+	assert.Equal(t, float32(-1), calculateCtrPct(-1, 1, 0, 0, 1, currentTime, emptyTime))
 
 	// prev=-1 because of missing cgroup file in last run
-	assert.Equal(t, float32(-1), calculateCtrPct(3, -1, 0, 0, 1, emptyTime))
+	assert.Equal(t, float32(-1), calculateCtrPct(3, -1, 0, 0, 1, currentTime, emptyTime))
 }

--- a/pkg/util/ecs/common.go
+++ b/pkg/util/ecs/common.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017-present Datadog, Inc.
 
+//go:build docker
 // +build docker
 
 package ecs
@@ -169,9 +170,9 @@ func formatMemoryLimit(val uint64) uint64 {
 func convertMetaV2ContainerStats(s *v2.ContainerStats) (metrics.ContainerMetrics, uint64) {
 	return metrics.ContainerMetrics{
 		CPU: &metrics.ContainerCPUStats{
-			User:        float64(s.CPU.Usage.Usermode),
-			System:      float64(s.CPU.Usage.Kernelmode),
-			SystemUsage: s.CPU.System,
+			User:        float64(s.CPU.Usage.Usermode) / 1e7, // Normalize to UserHz (1/100s)
+			System:      float64(s.CPU.Usage.Kernelmode) / 1e7,
+			SystemUsage: s.CPU.System / 1e7,
 		},
 		Memory: &metrics.ContainerMemStats{
 			Cache:           s.Memory.Details.Cache,

--- a/pkg/util/ecs/common_test.go
+++ b/pkg/util/ecs/common_test.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build docker
 // +build docker
 
 package ecs
@@ -270,9 +271,9 @@ func TestConvertMetaV2ContainerStats(t *testing.T) {
 	}
 
 	expectedCPU := &metrics.ContainerCPUStats{
-		User:        7450000000,
-		System:      2260000000,
-		SystemUsage: 3951680000000,
+		User:        745,
+		System:      226,
+		SystemUsage: 395168,
 	}
 	expectedMem := &metrics.ContainerMemStats{
 		Cache:           65499136,


### PR DESCRIPTION
### What does this PR do?

Fix CPU Rates calculations in `process-agent`. The original fix in #9974 was not working for non-Fargate collectors.

### Motivation

Bugfix.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

To QA this card, it requires to deploy to 3 different environments:
- ECS Fargate Linux
- ECS Fargate Windows
- Any host-based container environment (ECS/Docker/Kubernetes)

You need to deploy an application consuming a known amount of CPU (like `stress-ng`). The CPU rates reported in Live Container View should be correct.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
