### PR TITLE
[serverless] Fix race condition between TellDaemonRuntimeStarted and TellDaemonRuntimeDone

### DIFF
--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -64,7 +64,7 @@ type Daemon struct {
 	// LambdaLibraryDetected represents whether the Datadog Lambda Library was detected in the environment
 	LambdaLibraryDetected bool
 
-	// RuntimeStateMutex is used to ensure that modifying the state of the runtime is thread-safe
+	// runtimeStateMutex is used to ensure that modifying the state of the runtime is thread-safe
 	runtimeStateMutex sync.Mutex
 
 	// RuntimeWg is used to keep track of whether the runtime is currently handling an invocation.
@@ -345,7 +345,6 @@ func (d *Daemon) TellDaemonRuntimeStarted() {
 	d.RuntimeWg = &sync.WaitGroup{}
 	d.TellDaemonRuntimeDoneOnce = &sync.Once{}
 	d.RuntimeWg.Add(1)
-
 }
 
 // TellDaemonRuntimeDone tells the daemon that the runtime finished handling an invocation

--- a/pkg/serverless/daemon/daemon.go
+++ b/pkg/serverless/daemon/daemon.go
@@ -64,6 +64,9 @@ type Daemon struct {
 	// LambdaLibraryDetected represents whether the Datadog Lambda Library was detected in the environment
 	LambdaLibraryDetected bool
 
+	// RuntimeStateMutex is used to ensure that modifying the state of the runtime is thread-safe
+	runtimeStateMutex sync.Mutex
+
 	// RuntimeWg is used to keep track of whether the runtime is currently handling an invocation.
 	// It should be reset when we start a new invocation, as we may start a new invocation before hearing that the last one finished.
 	RuntimeWg *sync.WaitGroup
@@ -337,13 +340,18 @@ func (d *Daemon) Stop() {
 func (d *Daemon) TellDaemonRuntimeStarted() {
 	// Reset the RuntimeWg on every new invocation.
 	// We might receive a new invocation before we learn that the previous invocation has finished.
+	d.runtimeStateMutex.Lock()
+	defer d.runtimeStateMutex.Unlock()
 	d.RuntimeWg = &sync.WaitGroup{}
 	d.TellDaemonRuntimeDoneOnce = &sync.Once{}
 	d.RuntimeWg.Add(1)
+
 }
 
 // TellDaemonRuntimeDone tells the daemon that the runtime finished handling an invocation
 func (d *Daemon) TellDaemonRuntimeDone() {
+	d.runtimeStateMutex.Lock()
+	defer d.runtimeStateMutex.Unlock()
 	d.TellDaemonRuntimeDoneOnce.Do(func() {
 		d.RuntimeWg.Done()
 	})

--- a/pkg/serverless/daemon/daemon_test.go
+++ b/pkg/serverless/daemon/daemon_test.go
@@ -107,6 +107,27 @@ func TestTellDaemonRuntimeDoneOnceStartAndEndAndTimeout(t *testing.T) {
 	assert.Equal(uint64(1), GetValueSyncOnce(d.TellDaemonRuntimeDoneOnce))
 }
 
+func TestRaceTellDaemonRuntimeStartedVersusTellDaemonRuntimeDone(t *testing.T) {
+	d := StartDaemon("127.0.0.1:8124")
+	defer d.Stop()
+
+	d.TellDaemonRuntimeStarted()
+
+	go func() {
+		for i := 0; i < 1000; i++ {
+			go d.TellDaemonRuntimeStarted()
+		}
+	}()
+
+	go func() {
+		for i := 0; i < 1000; i++ {
+			go d.TellDaemonRuntimeDone()
+		}
+	}()
+
+	time.Sleep(2 * time.Second)
+}
+
 func TestSetTraceTagNoop(t *testing.T) {
 	tagsMap := map[string]string{
 		"key0": "value0",


### PR DESCRIPTION
### What does this PR do?

Fixes a race condition between `TellDaemonRuntimeStarted` and `TellDaemonRuntimeDone`.

We are seeing panics occurring (on the order of 1 in 200,000 invocations) due to the `RuntimeWg` being decremented below 0. There are **at least** two ways this could happen:

```
func (d *Daemon) TellDaemonRuntimeStarted() {
	d.RuntimeWg = &sync.WaitGroup{}
	d.TellDaemonRuntimeDoneOnce = &sync.Once{}
	
	// RuntimeWg is decremented here before we add 1 -> panic
	
	d.RuntimeWg.Add(1)
}
```

but also:

```
func (d *Daemon) TellDaemonRuntimeDone() {
	d.TellDaemonRuntimeDoneOnce.Do(func() {
	        
	        // RuntimeWg is reset here
	        
		d.RuntimeWg.Done()  // -> panic
	})
}
```

This PR solves the race condition by adding a `runtimeStateMutex`. We need to be modifying the runtime state (interacting with the `WaitGroup` and the `Once`) atomically. The PR adds a unit test to verify that the race condition has been removed.

### Reviewer's Checklist
- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
