### PR TITLE
Fix CPU rates calculations in process-agent and disable remote tagger

### DIFF
--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -58,7 +58,7 @@ func setupProcesses(config Config) {
 	procBindEnvAndSetDefault(config, "process_config.log_file", DefaultProcessAgentLogFile)
 	config.SetKnown("process_config.internal_profiling.enabled")
 	procBindEnvAndSetDefault(config, "process_config.grpc_connection_timeout_secs", DefaultGRPCConnectionTimeoutSecs)
-	procBindEnvAndSetDefault(config, "process_config.remote_tagger", true)
+	procBindEnvAndSetDefault(config, "process_config.remote_tagger", false)
 	procBindEnvAndSetDefault(config, "process_config.disable_realtime_checks", false)
 
 	// Process Discovery Check

--- a/pkg/config/process_test.go
+++ b/pkg/config/process_test.go
@@ -36,7 +36,7 @@ func TestProcessDefaultConfig(t *testing.T) {
 		},
 		{
 			key:          "process_config.remote_tagger",
-			defaultValue: true,
+			defaultValue: false,
 		},
 		{
 			key:          "process_config.process_discovery.enabled",
@@ -137,8 +137,8 @@ func TestEnvVarOverride(t *testing.T) {
 		{
 			key:      "process_config.remote_tagger",
 			env:      "DD_PROCESS_CONFIG_REMOTE_TAGGER",
-			value:    "false",
-			expected: false,
+			value:    "true",
+			expected: true,
 		},
 		{
 			key:      "process_config.process_discovery.enabled",

--- a/pkg/process/checks/container.go
+++ b/pkg/process/checks/container.go
@@ -126,6 +126,7 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 
 // fmtContainers loops through container list and converts them to a list of container objects
 func fmtContainers(ctrList []*containers.Container, lastRates map[string]util.ContainerRateMetrics, lastRun time.Time) []*model.Container {
+	currentTime := time.Now()
 	containersList := make([]*model.Container, 0, len(ctrList))
 	for _, ctr := range ctrList {
 		lastCtr, ok := lastRates[ctr.ID]
@@ -157,13 +158,13 @@ func fmtContainers(ctrList []*containers.Container, lastRates map[string]util.Co
 		cpus := system.HostCPUCount()
 		sys2, sys1 := ctr.CPU.SystemUsage, lastCtr.CPU.SystemUsage
 
-		userPct := calculateCtrPct(ctr.CPU.User, lastCtr.CPU.User, sys2, sys1, cpus, lastRun)
-		systemPct := calculateCtrPct(ctr.CPU.System, lastCtr.CPU.System, sys2, sys1, cpus, lastRun)
+		userPct := calculateCtrPct(ctr.CPU.User, lastCtr.CPU.User, sys2, sys1, cpus, currentTime, lastRun)
+		systemPct := calculateCtrPct(ctr.CPU.System, lastCtr.CPU.System, sys2, sys1, cpus, currentTime, lastRun)
 		var totalPct float32
 		if userPct == -1 || systemPct == -1 {
 			totalPct = -1
 		} else {
-			totalPct = calculateCtrPct(ctr.CPU.User+ctr.CPU.System, lastCtr.CPU.User+lastCtr.CPU.System, sys2, sys1, cpus, lastRun)
+			totalPct = calculateCtrPct(ctr.CPU.User+ctr.CPU.System, lastCtr.CPU.User+lastCtr.CPU.System, sys2, sys1, cpus, currentTime, lastRun)
 		}
 
 		containersList = append(containersList, &model.Container{

--- a/pkg/process/checks/container_rt.go
+++ b/pkg/process/checks/container_rt.go
@@ -95,6 +95,7 @@ func fmtContainerStats(
 	lastRun time.Time,
 	chunks int,
 ) [][]*model.ContainerStat {
+	currentTime := time.Now()
 	perChunk := (len(ctrList) / chunks) + 1
 	chunked := make([][]*model.ContainerStat, chunks)
 	chunk := make([]*model.ContainerStat, 0, perChunk)
@@ -115,13 +116,13 @@ func fmtContainerStats(
 		cpus := system.HostCPUCount()
 		sys2, sys1 := ctr.CPU.SystemUsage, lastCtr.CPU.SystemUsage
 
-		userPct := calculateCtrPct(ctr.CPU.User, lastCtr.CPU.User, sys2, sys1, cpus, lastRun)
-		systemPct := calculateCtrPct(ctr.CPU.System, lastCtr.CPU.System, sys2, sys1, cpus, lastRun)
+		userPct := calculateCtrPct(ctr.CPU.User, lastCtr.CPU.User, sys2, sys1, cpus, currentTime, lastRun)
+		systemPct := calculateCtrPct(ctr.CPU.System, lastCtr.CPU.System, sys2, sys1, cpus, currentTime, lastRun)
 		var totalPct float32
 		if userPct == -1 || systemPct == -1 {
 			totalPct = -1
 		} else {
-			totalPct = calculateCtrPct(ctr.CPU.User+ctr.CPU.System, lastCtr.CPU.User+lastCtr.CPU.System, sys2, sys1, cpus, lastRun)
+			totalPct = calculateCtrPct(ctr.CPU.User+ctr.CPU.System, lastCtr.CPU.User+lastCtr.CPU.System, sys2, sys1, cpus, currentTime, lastRun)
 		}
 
 		chunk = append(chunk, &model.ContainerStat{

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -192,7 +192,7 @@ process_config:
     log_file: /tmp/test
     dd_agent_bin: /tmp/test
     grpc_connection_timeout_secs: 1
-    remote_tagger: false
+    remote_tagger: true
     process_discovery:
         enabled: true
         interval: 1h
@@ -206,7 +206,7 @@ process_config:
 	assert.Equal(t, "/tmp/test", config.Datadog.GetString("process_config.log_file"))
 	assert.Equal(t, "/tmp/test", config.Datadog.GetString("process_config.dd_agent_bin"))
 	assert.Equal(t, 1, config.Datadog.GetInt("process_config.grpc_connection_timeout_secs"))
-	assert.False(t, config.Datadog.GetBool("process_config.remote_tagger"))
+	assert.True(t, config.Datadog.GetBool("process_config.remote_tagger"))
 	assert.True(t, config.Datadog.GetBool("process_config.process_discovery.enabled"))
 	assert.Equal(t, time.Hour, config.Datadog.GetDuration("process_config.process_discovery.interval"))
 }
@@ -317,10 +317,9 @@ func TestDefaultConfig(t *testing.T) {
 	assert.Equal(config.DefaultProcessAgentLogFile, config.Datadog.GetString("process_config.log_file"))
 	assert.Equal(config.DefaultDDAgentBin, config.Datadog.GetString("process_config.dd_agent_bin"))
 	assert.Equal(config.DefaultGRPCConnectionTimeoutSecs, config.Datadog.GetInt("process_config.grpc_connection_timeout_secs"))
-	assert.True(config.Datadog.GetBool("process_config.remote_tagger"))
+	assert.False(config.Datadog.GetBool("process_config.remote_tagger"))
 	assert.True(config.Datadog.GetBool("process_config.process_discovery.enabled"))
 	assert.Equal(4*time.Hour, config.Datadog.GetDuration("process_config.process_discovery.interval"))
-
 }
 
 func TestAgentConfigYamlAndSystemProbeConfig(t *testing.T) {
@@ -576,7 +575,6 @@ func TestSystemProbeNoNetwork(t *testing.T) {
 	assert.True(t, agentConfig.EnableSystemProbe)
 	assert.True(t, agentConfig.Enabled)
 	assert.ElementsMatch(t, []string{OOMKillCheckName, ProcessCheckName, RTProcessCheckName}, agentConfig.EnabledChecks)
-
 }
 
 func TestIsAffirmative(t *testing.T) {

--- a/pkg/util/ecs/common.go
+++ b/pkg/util/ecs/common.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2017-present Datadog, Inc.
 
+//go:build docker
 // +build docker
 
 package ecs
@@ -169,9 +170,9 @@ func formatMemoryLimit(val uint64) uint64 {
 func convertMetaV2ContainerStats(s *v2.ContainerStats) (metrics.ContainerMetrics, uint64) {
 	return metrics.ContainerMetrics{
 		CPU: &metrics.ContainerCPUStats{
-			User:        float64(s.CPU.Usage.Usermode),
-			System:      float64(s.CPU.Usage.Kernelmode),
-			SystemUsage: s.CPU.System,
+			User:        float64(s.CPU.Usage.Usermode) / 1e7, // Normalize to UserHz (1/100s)
+			System:      float64(s.CPU.Usage.Kernelmode) / 1e7,
+			SystemUsage: s.CPU.System / 1e7,
 		},
 		Memory: &metrics.ContainerMemStats{
 			Cache:           s.Memory.Details.Cache,

--- a/pkg/util/ecs/common_test.go
+++ b/pkg/util/ecs/common_test.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build docker
 // +build docker
 
 package ecs
@@ -270,9 +271,9 @@ func TestConvertMetaV2ContainerStats(t *testing.T) {
 	}
 
 	expectedCPU := &metrics.ContainerCPUStats{
-		User:        7450000000,
-		System:      2260000000,
-		SystemUsage: 3951680000000,
+		User:        745,
+		System:      226,
+		SystemUsage: 395168,
 	}
 	expectedMem := &metrics.ContainerMemStats{
 		Cache:           65499136,


### PR DESCRIPTION
### What does this PR do?

Fix CPU Rates calculations in `process-agent`. The original fix in #9974 was not working for non-Fargate collectors.
Forward port of #10600

### Motivation

Bugfix.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

To QA this card, it requires to deploy to 3 different environments:
- ECS Fargate Linux
- ECS Fargate Windows
- Any host-based container environment (ECS/Docker/Kubernetes)

You need to deploy an application consuming a known amount of CPU (like `stress-ng`). The CPU rates reported in Live Container View should be correct.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
