### PR TITLE
[dsd] Support container-level UDP origin detection

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -496,7 +496,7 @@ func InitConfig(config Config) {
 	// is 10s), otherwise we won't be able to sample unseen counter as
 	// contexts will be deleted (see 'dogstatsd_expiry_seconds').
 	config.BindEnvAndSetDefault("dogstatsd_context_expiry_seconds", 300)
-	config.BindEnvAndSetDefault("dogstatsd_origin_detection", false) // Only supported for socket traffic
+	config.BindEnvAndSetDefault("dogstatsd_origin_detection", false)
 	config.BindEnvAndSetDefault("dogstatsd_so_rcvbuf", 0)
 	config.BindEnvAndSetDefault("dogstatsd_metrics_stats_enable", false)
 	config.BindEnvAndSetDefault("dogstatsd_tags", []string{})

--- a/releasenotes/notes/dsd-container-entity-85b4754dfbb0f285.yaml
+++ b/releasenotes/notes/dsd-container-entity-85b4754dfbb0f285.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Dogstatsd origin detection on UDP supports container entities in addition to Kubernetes Pods.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Extend origin detection on UDP by supporting tagger-ready origin strings in `dd.internal.prefixed_origin`.

### Motivation

- More granular tags (container tags instead of pod tags)
- Not limited to Kubernetes, and can be a good alternative in environments where origin detection on UDS is not an option (e.g Fargate)

### Additional Notes

Client side logic is implemented in https://github.com/DataDog/datadog-go/pull/250

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Deploy the agent with `DD_DOGSTATSD_ORIGIN_DETECTION` enabled

```
echo -n "testing.dsd.container:1|g|#foo:bar,dd.internal.prefixed_origin:container_id://<your container ID>" | nc -u -w1 <Agent IP> 8125
```

You should be able to see container tags attached to the `testing.dsd.container` metric on the app.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
