### PR TITLE
[scrubber] Fix snmp traps community strings scrubber

### DIFF
--- a/pkg/util/scrubber/default.go
+++ b/pkg/util/scrubber/default.go
@@ -116,7 +116,11 @@ func matchCert() *regexp.Regexp {
 	)
 }
 
-// matchYAMLKeyWithListValue matches YAML keys with list values.
+// matchYAMLKeyWithListValue matches YAML keys with array values.
+// caveat: doesn't work if the array contain nested arrays. Example:
+//   key: [
+//    [a, b, c],
+//    def]
 func matchYAMLKeyWithListValue(key string) *regexp.Regexp {
 	/*
 		Example 1:

--- a/pkg/util/scrubber/default.go
+++ b/pkg/util/scrubber/default.go
@@ -136,7 +136,7 @@ func matchYAMLKeyWithListValue(key string) *regexp.Regexp {
 		    'pass2']
 	*/
 	return regexp.MustCompile(
-		fmt.Sprintf(`(\s*%s\s*:)\s*(?:\n(?:\s+-\s+.*)*|\[(?:\n?.*)*\])`, key),
+		fmt.Sprintf(`(\s*%s\s*:)\s*(?:\n(?:\s+-\s+.*)*|\[(?:\n?.*?)*?\])`, key),
 		/*           -----------      ---------------  -------------
 		             match key(s)     |                |
 		                              match multiple   match anything

--- a/pkg/util/scrubber/default.go
+++ b/pkg/util/scrubber/default.go
@@ -116,22 +116,24 @@ func matchCert() *regexp.Regexp {
 	)
 }
 
+// matchYAMLKeyWithListValue matches YAML keys with list values.
 func matchYAMLKeyWithListValue(key string) *regexp.Regexp {
-	/* Match yaml keys with list values.
+	/*
+		Example 1:
+		snmp_traps_config:
+		  community_strings:
+		    - 'pass1'
+		    - 'pass2'
 
-	Example 1:
-	snmp_traps_config:
-	  community_strings:
-	    - 'pass1'
-	    - 'pass2'
-	Example 2:
-	snmp_traps_config:
-	  community_strings: ['pass1', 'pass2']
-	Example 3:
-	snmp_traps_config:
-	  community_strings: [
-	    'pass1',
-	    'pass2']
+		Example 2:
+		snmp_traps_config:
+		  community_strings: ['pass1', 'pass2']
+
+		Example 3:
+		snmp_traps_config:
+		  community_strings: [
+		    'pass1',
+		    'pass2']
 	*/
 	return regexp.MustCompile(
 		fmt.Sprintf(`(\s*%s\s*:)\s*(?:\n(?:\s+-\s+.*)*|\[(?:\n?.*)*\])`, key),

--- a/pkg/util/scrubber/default_test.go
+++ b/pkg/util/scrubber/default_test.go
@@ -312,6 +312,18 @@ other_config_with_list: [abc]
 	assertClean(t,
 		`
 snmp_traps_config:
+  community_strings: []
+other_config: 1
+other_config_with_list: [abc]
+`,
+		`snmp_traps_config:
+  community_strings: ********
+other_config: 1
+other_config_with_list: [abc]
+`)
+	assertClean(t,
+		`
+snmp_traps_config:
   community_strings: [
    'password1',
    'password2']

--- a/pkg/util/scrubber/default_test.go
+++ b/pkg/util/scrubber/default_test.go
@@ -290,20 +290,24 @@ snmp_traps_config:
     - 'password1'
     - 'password2'
 other_config: 1
+other_config_with_list: [abc]
 `,
 		`snmp_traps_config:
   community_strings: ********
 other_config: 1
+other_config_with_list: [abc]
 `)
 	assertClean(t,
 		`
 snmp_traps_config:
   community_strings: ['password1', 'password2']
 other_config: 1
+other_config_with_list: [abc]
 `,
 		`snmp_traps_config:
   community_strings: ********
 other_config: 1
+other_config_with_list: [abc]
 `)
 	assertClean(t,
 		`
@@ -312,10 +316,12 @@ snmp_traps_config:
    'password1',
    'password2']
 other_config: 1
+other_config_with_list: [abc]
 `,
 		`snmp_traps_config:
   community_strings: ********
 other_config: 1
+other_config_with_list: [abc]
 `)
 	assertClean(t,
 		`community: password`,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix snmp traps community strings scrubber

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

Fix for https://github.com/DataDog/datadog-agent/pull/10305

If there are another array after the community string array, we scrubbed too much content. Example:

```
snmp_traps_config:
  community_strings: []
other_config: 1
other_config_with_list: [abc]
another_config: 1
```

will lead to:
```
snmp_traps_config:
  community_strings: *****
another_config: 1
```

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes



<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
