### PR TITLE
[install_script] When installing the IoT Agent, default to version 7

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -206,6 +206,11 @@ if [ -n "$DD_UPGRADE" ]; then
   upgrade=$DD_UPGRADE
 fi
 
+agent_flavor="datadog-agent"
+if [ -n "$DD_AGENT_FLAVOR" ]; then
+    agent_flavor=$DD_AGENT_FLAVOR #Eg: datadog-iot-agent
+fi
+
 agent_major_version=6
 if [ -n "$DD_AGENT_MAJOR_VERSION" ]; then
   if [ "$DD_AGENT_MAJOR_VERSION" != "6" ] && [ "$DD_AGENT_MAJOR_VERSION" != "7" ]; then
@@ -214,7 +219,12 @@ if [ -n "$DD_AGENT_MAJOR_VERSION" ]; then
   fi
   agent_major_version=$DD_AGENT_MAJOR_VERSION
 else
-  echo -e "\033[33mWarning: DD_AGENT_MAJOR_VERSION not set. Installing Agent version 6 by default.\033[0m"
+  if [ "$agent_flavor" != "datadog-iot-agent" ]
+    echo -e "\033[33mWarning: DD_AGENT_MAJOR_VERSION not set. Installing Agent version 6 by default.\033[0m"
+  else
+    echo -e "\033[33mWarning: DD_AGENT_MAJOR_VERSION not set. Installing IoT Agent version 7 by default.\033[0m"
+    agent_major_version=7
+  fi
 fi
 
 if [ -n "$DD_AGENT_MINOR_VERSION" ]; then
@@ -223,11 +233,6 @@ if [ -n "$DD_AGENT_MINOR_VERSION" ]; then
   #  - 20.0 = sets explicit patch version x.20.0
   # Note: Specifying an invalid minor version will terminate the script.
   agent_minor_version=$DD_AGENT_MINOR_VERSION
-fi
-
-agent_flavor="datadog-agent"
-if [ -n "$DD_AGENT_FLAVOR" ]; then
-    agent_flavor=$DD_AGENT_FLAVOR #Eg: datadog-iot-agent
 fi
 
 agent_dist_channel=stable

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -219,7 +219,7 @@ if [ -n "$DD_AGENT_MAJOR_VERSION" ]; then
   fi
   agent_major_version=$DD_AGENT_MAJOR_VERSION
 else
-  if [ "$agent_flavor" != "datadog-iot-agent" ]
+  if [ "$agent_flavor" != "datadog-iot-agent" ]; then
     echo -e "\033[33mWarning: DD_AGENT_MAJOR_VERSION not set. Installing Agent version 6 by default.\033[0m"
   else
     echo -e "\033[33mWarning: DD_AGENT_MAJOR_VERSION not set. Installing IoT Agent version 7 by default.\033[0m"


### PR DESCRIPTION
### What does this PR do?

In the Linux install script, check if installing the IoT Agent and change the default major version to 7.

### Motivation

Version 6 doesn't exist for the Iot Agent, so the installation fails if
`DD_AGENT_MAJOR_VERSION` was not set.

### Additional Notes

Not a breaking change since the previous behavior didn't work.

### Possible Drawbacks / Trade-offs

None I can think of.

### Describe how to test/QA your changes

Pass `DD_AGENT_FLAVOR=datadog-iot-agent` without passing `DD_AGENT_MAJOR_VERSION`. 

Before: script fails. After: Version 7 is installed.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
