### PR TITLE
[networks] Process initial conntrack dump in kernelspace

### DIFF
--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Conntrack = NewRuntimeAsset("conntrack.c", "34852f860c1b290c22ae31abea6d1d212e51c8ddc65cbcc890cc98457b39782f")
+var Conntrack = NewRuntimeAsset("conntrack.c", "b26b80270d71684f79afd57412662e3a0f9321e6cea5174a3d3fb1f2f099a37d")

--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Conntrack = NewRuntimeAsset("conntrack.c", "f706e1be3c691842b517f6e68524dfdbb49456157d6c78ce9532911a71274cad")
+var Conntrack = NewRuntimeAsset("conntrack.c", "2b1e7be9c8223b29e74ac56715491c823290f09f38c314c3c7ecba6a9cc31390")

--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Conntrack = NewRuntimeAsset("conntrack.c", "2b1e7be9c8223b29e74ac56715491c823290f09f38c314c3c7ecba6a9cc31390")
+var Conntrack = NewRuntimeAsset("conntrack.c", "34852f860c1b290c22ae31abea6d1d212e51c8ddc65cbcc890cc98457b39782f")

--- a/pkg/ebpf/bytecode/runtime/conntrack.go
+++ b/pkg/ebpf/bytecode/runtime/conntrack.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var Conntrack = NewRuntimeAsset("conntrack.c", "15bc796ede03c59e76778d68f1d1f9c853beace91f60c310997f0b29673e2234")
+var Conntrack = NewRuntimeAsset("conntrack.c", "f706e1be3c691842b517f6e68524dfdbb49456157d6c78ce9532911a71274cad")

--- a/pkg/network/ebpf/c/conntrack.h
+++ b/pkg/network/ebpf/c/conntrack.h
@@ -3,6 +3,7 @@
 
 #include <net/netfilter/nf_conntrack.h>
 #include <linux/types.h>
+#include <linux/sched.h>
 #include "tracer.h"
 #include "conntrack-types.h"
 #include "conntrack-maps.h"

--- a/pkg/network/ebpf/c/conntrack.h
+++ b/pkg/network/ebpf/c/conntrack.h
@@ -97,20 +97,13 @@ static __always_inline int nf_conntrack_tuple_to_conntrack_tuple(conntrack_tuple
     return 1;
 }
 
-static __always_inline void increment_telemetry_count(enum conntrack_telemetry_counter counter_name) {
+static __always_inline void increment_telemetry_registers_count() {
     u64 key = 0;
     conntrack_telemetry_t *val = bpf_map_lookup_elem(&conntrack_telemetry, &key);
     if (val == NULL) {
         return;
     }
-
-    switch (counter_name) {
-    case registers:
-        __sync_fetch_and_add(&val->registers, 1);
-        break;
-    case registers_dropped:
-        __sync_fetch_and_add(&val->registers_dropped, 1);
-    }
+    __sync_fetch_and_add(&val->registers, 1);
 }
 
 static __always_inline int nf_conn_to_conntrack_tuples(struct nf_conn* ct, conntrack_tuple_t* orig, conntrack_tuple_t* reply) {

--- a/pkg/network/ebpf/c/conntrack.h
+++ b/pkg/network/ebpf/c/conntrack.h
@@ -2,6 +2,7 @@
 #define __CONNTRACK_H
 
 #include <net/netfilter/nf_conntrack.h>
+#include <linux/types.h>
 #include "tracer.h"
 #include "conntrack-types.h"
 #include "conntrack-maps.h"
@@ -11,6 +12,14 @@
 #ifdef FEATURE_IPV6_ENABLED
 #include "ipv6.h"
 #endif
+
+#ifndef TASK_COMM_LEN
+#define TASK_COMM_LEN 16
+#endif
+
+typedef struct {
+    char comm[TASK_COMM_LEN];
+} proc_t;
 
 static __always_inline u32 ct_status(const struct nf_conn *ct) {
     u32 status = 0;
@@ -130,6 +139,19 @@ static __always_inline int nf_conn_to_conntrack_tuples(struct nf_conn* ct, connt
     print_translation(reply);
 
     return 0;
+}
+
+static __always_inline bool proc_t_comm_prefix_equals(char* prefix, int prefix_len, proc_t c) {
+    if (prefix_len > TASK_COMM_LEN) {
+        return false;
+    }
+
+    for (int i = 0; i < prefix_len; i++) {
+        if (c.comm[i] != prefix[i]) {
+            return false;
+        }
+    }
+    return true;
 }
 
 #endif

--- a/pkg/network/ebpf/c/runtime/conntrack-types.h
+++ b/pkg/network/ebpf/c/runtime/conntrack-types.h
@@ -22,12 +22,7 @@ typedef struct {
 
 typedef struct {
     __u64 registers;
-    __u64 registers_dropped;
 } conntrack_telemetry_t;
 
-enum conntrack_telemetry_counter {
-    registers,
-    registers_dropped,
-};
 
 #endif

--- a/pkg/network/ebpf/c/runtime/conntrack.c
+++ b/pkg/network/ebpf/c/runtime/conntrack.c
@@ -34,7 +34,7 @@ int kprobe___nf_conntrack_hash_insert(struct pt_regs* ctx) {
 
     bpf_map_update_elem(&conntrack, &orig, &reply, BPF_ANY);
     bpf_map_update_elem(&conntrack, &reply, &orig, BPF_ANY);
-    increment_telemetry_count(registers);
+    increment_telemetry_registers_count();
 
     return 0;
 }
@@ -66,7 +66,7 @@ int kprobe_ctnetlink_fill_info(struct pt_regs* ctx) {
 
     bpf_map_update_elem(&conntrack, &orig, &reply, BPF_ANY);
     bpf_map_update_elem(&conntrack, &reply, &orig, BPF_ANY);
-    increment_telemetry_count(registers);
+    increment_telemetry_registers_count();
 
     return 0;
 }

--- a/pkg/network/ebpf/c/runtime/conntrack.c
+++ b/pkg/network/ebpf/c/runtime/conntrack.c
@@ -20,6 +20,7 @@
 SEC("kprobe/__nf_conntrack_hash_insert")
 int kprobe___nf_conntrack_hash_insert(struct pt_regs* ctx) {
     struct nf_conn *ct = (struct nf_conn*)PT_REGS_PARM1(ctx);
+
     u32 status = ct_status(ct);
     if (!(status&IPS_CONFIRMED)) {
         return 0;
@@ -28,37 +29,43 @@ int kprobe___nf_conntrack_hash_insert(struct pt_regs* ctx) {
         increment_telemetry_count(registers_dropped);
         return 0;
     }
+    
+    log_debug("kprobe/__nf_conntrack_hash_insert: netns: %u, status: %x\n", get_netns(&ct->ct_net), status);
 
-    struct nf_conntrack_tuple_hash tuplehash[IP_CT_DIR_MAX];
-    __builtin_memset(tuplehash, 0, sizeof(tuplehash));
-    bpf_probe_read_kernel(&tuplehash, sizeof(tuplehash), &ct->tuplehash);
-
-    struct nf_conntrack_tuple orig = tuplehash[IP_CT_DIR_ORIGINAL].tuple;
-    struct nf_conntrack_tuple reply = tuplehash[IP_CT_DIR_REPLY].tuple;
-
-    u32 netns = get_netns(&ct->ct_net);
-    log_debug("kprobe/__nf_conntrack_hash_insert: netns: %u, status: %x\n", netns, status);
-
-    conntrack_tuple_t orig_conn = {};
-    if (!nf_conntrack_tuple_to_conntrack_tuple(&orig_conn, &orig)) {
+    conntrack_tuple_t orig = {}, reply = {};
+    if (nf_conn_to_conntrack_tuples(ct, &orig, &reply) != 0) {
         return 0;
     }
-    orig_conn.netns = netns;
 
-    log_debug("orig\n");
-    print_translation(&orig_conn);
+    bpf_map_update_elem(&conntrack, &orig, &reply, BPF_ANY);
+    bpf_map_update_elem(&conntrack, &reply, &orig, BPF_ANY);
+    increment_telemetry_count(registers);
 
-    conntrack_tuple_t reply_conn = {};
-    if (!nf_conntrack_tuple_to_conntrack_tuple(&reply_conn, &reply)) {
+    return 0;
+}
+
+SEC("kprobe/ctnetlink_fill_info")
+int kprobe_ctnetlink_fill_info(struct pt_regs* ctx) {
+    struct nf_conn *ct = (struct nf_conn*)PT_REGS_PARM5(ctx);
+
+    u32 status = ct_status(ct);
+    if (!(status&IPS_CONFIRMED)) {
         return 0;
     }
-    reply_conn.netns = netns;
+    if (!(status&IPS_NAT_MASK)) {
+        increment_telemetry_count(registers_dropped);
+        return 0;
+    }
+    
+    log_debug("kprobe/ctnetlink_fill_info: netns: %u, status: %x\n", get_netns(&ct->ct_net), status);
 
-    log_debug("reply\n");
-    print_translation(&reply_conn);
+    conntrack_tuple_t orig = {}, reply = {};
+    if (nf_conn_to_conntrack_tuples(ct, &orig, &reply) != 0) {
+        return 0;
+    }
 
-    bpf_map_update_elem(&conntrack, &orig_conn, &reply_conn, BPF_ANY);
-    bpf_map_update_elem(&conntrack, &reply_conn, &orig_conn, BPF_ANY);
+    bpf_map_update_elem(&conntrack, &orig, &reply, BPF_ANY);
+    bpf_map_update_elem(&conntrack, &reply, &orig, BPF_ANY);
     increment_telemetry_count(registers);
 
     return 0;

--- a/pkg/network/ebpf/c/runtime/conntrack.c
+++ b/pkg/network/ebpf/c/runtime/conntrack.c
@@ -21,11 +21,7 @@ int kprobe___nf_conntrack_hash_insert(struct pt_regs* ctx) {
     struct nf_conn *ct = (struct nf_conn*)PT_REGS_PARM1(ctx);
 
     u32 status = ct_status(ct);
-    if (!(status&IPS_CONFIRMED)) {
-        return 0;
-    }
-    if (!(status&IPS_NAT_MASK)) {
-        increment_telemetry_count(registers_dropped);
+    if (!(status&IPS_CONFIRMED) || !(status&IPS_NAT_MASK)) {
         return 0;
     }
     
@@ -57,11 +53,7 @@ int kprobe_ctnetlink_fill_info(struct pt_regs* ctx) {
     struct nf_conn *ct = (struct nf_conn*)PT_REGS_PARM5(ctx);
 
     u32 status = ct_status(ct);
-    if (!(status&IPS_CONFIRMED)) {
-        return 0;
-    }
-    if (!(status&IPS_NAT_MASK)) {
-        increment_telemetry_count(registers_dropped);
+    if (!(status&IPS_CONFIRMED) || !(status&IPS_NAT_MASK)) {
         return 0;
     }
     

--- a/pkg/network/ebpf/conntrack_types_linux.go
+++ b/pkg/network/ebpf/conntrack_types_linux.go
@@ -17,5 +17,4 @@ type ConntrackTuple struct {
 
 type ConntrackTelemetry struct {
 	Registers uint64
-	Dropped   uint64
 }

--- a/pkg/network/ebpf/probes/probes.go
+++ b/pkg/network/ebpf/probes/probes.go
@@ -108,6 +108,9 @@ const (
 	// ConntrackHashInsert is the probe for new conntrack entries
 	ConntrackHashInsert ProbeName = "kprobe/__nf_conntrack_hash_insert"
 
+	// ConntrackFillInfo is the probe for for dumping existing conntrack entries
+	ConntrackFillInfo ProbeName = "kprobe/ctnetlink_fill_info"
+
 	// SockFDLookup is the kprobe used for mapping socket FDs to kernel sock structs
 	SockFDLookup ProbeName = "kprobe/sockfd_lookup_light"
 

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -130,21 +130,20 @@ type ConnTelemetryType string
 
 //revive:disable:exported
 const (
-	MonotonicKprobesTriggered          ConnTelemetryType = "kprobes_triggered"
-	MonotonicKprobesMissed             ConnTelemetryType = "kprobes_missed"
-	MonotonicConnsClosed               ConnTelemetryType = "conns_closed"
-	MonotonicConntrackRegisters        ConnTelemetryType = "conntrack_registers"
-	MonotonicConntrackRegistersDropped ConnTelemetryType = "conntrack_registers_dropped"
-	MonotonicDNSPacketsProcessed       ConnTelemetryType = "dns_packets_processed"
-	MonotonicUDPSendsProcessed         ConnTelemetryType = "udp_sends_processed"
-	MonotonicUDPSendsMissed            ConnTelemetryType = "udp_sends_missed"
-	DNSStatsDropped                    ConnTelemetryType = "dns_stats_dropped"
-	ConnsBpfMapSize                    ConnTelemetryType = "conns_bpf_map_size"
-	ConntrackSamplingPercent           ConnTelemetryType = "conntrack_sampling_percent"
-	NPMDriverFlowsMissedMaxExceeded    ConnTelemetryType = "driver_flows_missed_max_exceeded"
-	MonotonicDNSPacketsDropped         ConnTelemetryType = "dns_packets_dropped"
-	HTTPRequestsDropped                ConnTelemetryType = "http_requests_dropped"
-	HTTPRequestsMissed                 ConnTelemetryType = "http_requests_missed"
+	MonotonicKprobesTriggered       ConnTelemetryType = "kprobes_triggered"
+	MonotonicKprobesMissed          ConnTelemetryType = "kprobes_missed"
+	MonotonicConnsClosed            ConnTelemetryType = "conns_closed"
+	MonotonicConntrackRegisters     ConnTelemetryType = "conntrack_registers"
+	MonotonicDNSPacketsProcessed    ConnTelemetryType = "dns_packets_processed"
+	MonotonicUDPSendsProcessed      ConnTelemetryType = "udp_sends_processed"
+	MonotonicUDPSendsMissed         ConnTelemetryType = "udp_sends_missed"
+	DNSStatsDropped                 ConnTelemetryType = "dns_stats_dropped"
+	ConnsBpfMapSize                 ConnTelemetryType = "conns_bpf_map_size"
+	ConntrackSamplingPercent        ConnTelemetryType = "conntrack_sampling_percent"
+	NPMDriverFlowsMissedMaxExceeded ConnTelemetryType = "driver_flows_missed_max_exceeded"
+	MonotonicDNSPacketsDropped      ConnTelemetryType = "dns_packets_dropped"
+	HTTPRequestsDropped             ConnTelemetryType = "http_requests_dropped"
+	HTTPRequestsMissed              ConnTelemetryType = "http_requests_missed"
 )
 
 //revive:enable
@@ -167,7 +166,6 @@ var (
 		MonotonicKprobesTriggered,
 		MonotonicKprobesMissed,
 		MonotonicConntrackRegisters,
-		MonotonicConntrackRegistersDropped,
 		MonotonicDNSPacketsProcessed,
 		MonotonicConnsClosed,
 		MonotonicUDPSendsProcessed,

--- a/pkg/network/netlink/conntracker.go
+++ b/pkg/network/netlink/conntracker.go
@@ -194,7 +194,6 @@ func (ctr *realConntracker) GetStats() map[string]int64 {
 	if registers != 0 {
 		m["nanoseconds_per_register"] = registersTotalTime / registers
 	}
-	m["registers_dropped"] = ctr.stats.registersDropped.Load()
 
 	unregisters := ctr.stats.unregisters.Load()
 	unregisterTotalTime := ctr.stats.unregistersTotalTime.Load()

--- a/pkg/network/netlink/consumer.go
+++ b/pkg/network/netlink/consumer.go
@@ -575,9 +575,9 @@ func (c *Consumer) receiveAndDiscard() {
 				// EOFs are usually indicative of normal program termination, so we simply exit
 				return
 			case errENOBUF:
-				atomic.AddInt64(&c.enobufs, 1)
+				c.enobufs.Inc()
 			default:
-				atomic.AddInt64(&c.readErrors, 1)
+				c.readErrors.Inc()
 			}
 		}
 		if done {

--- a/pkg/network/tracer/ebpf_conntracker.go
+++ b/pkg/network/tracer/ebpf_conntracker.go
@@ -62,7 +62,8 @@ type ebpfConntracker struct {
 	rootNS       uint32
 	// only kept around for stats purposes from initial dump
 	consumer *netlink.Consumer
-	decoder  *netlink.Decoder
+
+	stop chan struct{}
 
 	stats ebpfConntrackerStats
 }
@@ -115,6 +116,7 @@ func NewEBPFConntracker(cfg *config.Config) (netlink.Conntracker, error) {
 		telemetryMap: telemetryMap,
 		rootNS:       rootNS,
 		stats:        newEbpfConntrackerStats(),
+		stop:         make(chan struct{}),
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.ConntrackInitTimeout)
@@ -133,86 +135,45 @@ func NewEBPFConntracker(cfg *config.Config) (netlink.Conntracker, error) {
 
 func (e *ebpfConntracker) dumpInitialTables(ctx context.Context, cfg *config.Config) error {
 	e.consumer = netlink.NewConsumer(cfg.ProcRoot, cfg.ConntrackRateLimit, true)
-	e.decoder = netlink.NewDecoder()
 	defer e.consumer.Stop()
 
 	for _, family := range []uint8{unix.AF_INET, unix.AF_INET6} {
-		events, err := e.consumer.DumpTable(family)
+		done, err := e.consumer.DumpAndDiscardTable(family)
 		if err != nil {
 			return err
 		}
-		if err := e.loadInitialState(ctx, events); err != nil {
+
+		if err := e.processEvents(ctx, done); err != nil {
 			return err
 		}
 	}
+
+	go func() {
+		// We'll wait a while before detaching the hook in order to give ebpf ample time to finish processing the dump
+		timer := time.NewTimer(1 * time.Minute)
+		for {
+			select {
+			case <-timer.C:
+				break
+			case <-e.stop:
+				break
+			}
+			e.m.DetachHook(manager.ProbeIdentificationPair{EBPFSection: string(probes.ConntrackFillInfo), EBPFFuncName: "kprobe_ctnetlink_fill_info"})
+		}
+	}()
+
 	return nil
 }
 
-func (e *ebpfConntracker) loadInitialState(ctx context.Context, events <-chan netlink.Event) error {
+func (e *ebpfConntracker) processEvents(ctx context.Context, done <-chan bool) error {
 	for {
 		select {
 		case <-ctx.Done():
 			return ctx.Err()
-		case ev, ok := <-events:
-			if !ok {
-				return nil
-			}
-			e.processEvent(ev)
+		case <-done:
+			return nil
 		}
 	}
-}
-
-func (e *ebpfConntracker) processEvent(ev netlink.Event) {
-	conns := e.decoder.DecodeAndReleaseEvent(ev)
-	for _, c := range conns {
-		if netlink.IsNAT(c) {
-			log.Tracef("initial conntrack %s", c)
-			src := formatKey(c.NetNS, &c.Origin)
-			dst := formatKey(c.NetNS, &c.Reply)
-			if src != nil && dst != nil {
-				if err := e.addTranslation(src, dst); err != nil {
-					log.Warnf("error adding initial conntrack entry to ebpf map: %s", err)
-				}
-				if err := e.addTranslation(dst, src); err != nil {
-					log.Warnf("error adding initial conntrack entry to ebpf map: %s", err)
-				}
-			}
-		}
-	}
-}
-
-func (e *ebpfConntracker) addTranslation(src *netebpf.ConntrackTuple, dst *netebpf.ConntrackTuple) error {
-	if err := e.ctMap.Update(unsafe.Pointer(src), unsafe.Pointer(dst), ebpf.UpdateNoExist); err != nil && !errors.Is(err, ebpf.ErrKeyExist) {
-		return err
-	}
-	return nil
-}
-
-func formatKey(netns uint32, tuple *netlink.ConTuple) *netebpf.ConntrackTuple {
-	nct := &netebpf.ConntrackTuple{
-		Netns: netns,
-		Sport: tuple.Src.Port(),
-		Dport: tuple.Dst.Port(),
-	}
-	src := tuple.Src.IP()
-	nct.Saddr_l, nct.Saddr_h = util.ToLowHighIP(src)
-	nct.Daddr_l, nct.Daddr_h = util.ToLowHighIP(tuple.Dst.IP())
-
-	if src.Is4() {
-		nct.Metadata |= uint32(netebpf.IPv4)
-	} else {
-		nct.Metadata |= uint32(netebpf.IPv6)
-	}
-	switch tuple.Proto {
-	case unix.IPPROTO_TCP:
-		nct.Metadata |= uint32(netebpf.TCP)
-	case unix.IPPROTO_UDP:
-		nct.Metadata |= uint32(netebpf.UDP)
-	default:
-		return nil
-	}
-
-	return nct
 }
 
 func toConntrackTupleFromStats(src *netebpf.ConntrackTuple, stats *network.ConnectionStats) {
@@ -354,6 +315,7 @@ func (e *ebpfConntracker) GetStats() map[string]int64 {
 }
 
 func (e *ebpfConntracker) Close() {
+	close(e.stop)
 	err := e.m.Stop(manager.CleanAll)
 	if err != nil {
 		log.Warnf("error cleaning up ebpf conntrack: %s", err)
@@ -422,6 +384,13 @@ func getManager(buf io.ReaderAt, maxStateSize int) (*manager.Manager, error) {
 				ProbeIdentificationPair: manager.ProbeIdentificationPair{
 					EBPFSection:  string(probes.ConntrackHashInsert),
 					EBPFFuncName: "kprobe___nf_conntrack_hash_insert",
+					UID:          "conntracker",
+				},
+			},
+			{
+				ProbeIdentificationPair: manager.ProbeIdentificationPair{
+					EBPFSection:  string(probes.ConntrackFillInfo),
+					EBPFFuncName: "kprobe_ctnetlink_fill_info",
 					UID:          "conntracker",
 				},
 			},

--- a/pkg/network/tracer/ebpf_conntracker.go
+++ b/pkg/network/tracer/ebpf_conntracker.go
@@ -275,7 +275,6 @@ func (e *ebpfConntracker) GetStats() map[string]int64 {
 		log.Tracef("error retrieving the telemetry struct: %s", err)
 	} else {
 		m["registers_total"] = int64(telemetry.Registers)
-		m["registers_dropped"] = int64(telemetry.Dropped)
 	}
 
 	gets := e.stats.gets.Load()

--- a/pkg/network/tracer/ebpf_conntracker.go
+++ b/pkg/network/tracer/ebpf_conntracker.go
@@ -147,21 +147,7 @@ func (e *ebpfConntracker) dumpInitialTables(ctx context.Context, cfg *config.Con
 			return err
 		}
 	}
-
-	go func() {
-		// We'll wait a while before detaching the hook in order to give ebpf ample time to finish processing the dump
-		timer := time.NewTimer(1 * time.Minute)
-		for {
-			select {
-			case <-timer.C:
-				break
-			case <-e.stop:
-				break
-			}
-			e.m.DetachHook(manager.ProbeIdentificationPair{EBPFSection: string(probes.ConntrackFillInfo), EBPFFuncName: "kprobe_ctnetlink_fill_info"})
-		}
-	}()
-
+	e.m.DetachHook(manager.ProbeIdentificationPair{EBPFSection: string(probes.ConntrackFillInfo), EBPFFuncName: "kprobe_ctnetlink_fill_info"})
 	return nil
 }
 
@@ -315,7 +301,6 @@ func (e *ebpfConntracker) GetStats() map[string]int64 {
 }
 
 func (e *ebpfConntracker) Close() {
-	close(e.stop)
 	err := e.m.Stop(manager.CleanAll)
 	if err != nil {
 		log.Warnf("error cleaning up ebpf conntrack: %s", err)

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -386,9 +386,6 @@ func (t *Tracer) getConnTelemetry(mapSize int) map[network.ConnTelemetryType]int
 	if rt, ok := conntrackStats["registers_total"]; ok {
 		tm[network.MonotonicConntrackRegisters] = rt
 	}
-	if rtd, ok := conntrackStats["registers_dropped"]; ok {
-		tm[network.MonotonicConntrackRegistersDropped] = rtd
-	}
 	if sp, ok := conntrackStats["sampling_pct"]; ok {
 		tm[network.ConntrackSamplingPercent] = sp
 	}

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -101,7 +101,6 @@ func TestGetStats(t *testing.T) {
         "msg_errors": 0,
         "orphan_size": 0,
         "read_errors": 0,
-        "registers_dropped": 2,
         "registers_total": 0,
         "sampling_pct": 100,
         "state_size": 0,


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Leverages the `ctnetlink_fill_info` kprobe to add existing conntrack table entries to our ebpf maps directly from kernelspace, rather than reading the table entries in userspace & then sending them to kernelspace.

### Motivation

Performance

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1) Install bpftool
2) Setup NAT locally:
```
sudo ip link add dummy0 type dummy
sudo ip address add  1.1.1.1 broadcast + dev dummy0
sudo ip link set dummy0 up
sudo iptables -t nat -A OUTPUT --dest 2.2.2.2 -j DNAT --to-destination 1.1.1.1
```
3) Configure your `system-probe.yaml` to enable runtime compilation and bpf debug logging:
```
system_probe_config:
  enable_runtime_compiler: true
  bpf_debug: true
network_config:
  enabled: true
```
3) In a separate window, start an HTTP server which listens on `1.1.1.1:8080`:
```
python3 -m http.server --bind 1.1.1.1 8080
```
4) Create a NAT connection in the conntrack table by sending a request to this server at `2.2.2.2:8080`:
```
curl -I http://2.2.2.2:8080
```
5) Close the HTTP server. In the same window (window # 2), watch the `ebpf` debug logs:
```
sudo cat  /sys/kernel/debug/tracing/trace_pipe
```
6)  Run the system-probe. Check the ebpf debug logs for a `ctnetlink_fill_info` kprobe which saw a connection with original destination **2.2.2.2**:8080 and reply source **1.1.1.1**:8080. For example:
```
<...>-47043   [002] ....  1205.549914: 0: kprobe/ctnetlink_fill_info: netns: 4026531992, status: 1ae
<...>-47043   [002] ....  1205.549923: 0: orig
<...>-47043   [002] ....  1205.549923: 0: TCP
<...>-47043   [002] ....  1205.549924: 0: v4 a00020f:54108     # Original source
<...>-47043   [002] ....  1205.549925: 0: v4 2020202:8080      # Original destination
<...>-47043   [002] ....  1205.549925: 0: reply
<...>-47043   [002] ....  1205.549925: 0: TCP
<...>-47043   [002] ....  1205.549926: 0: v4 1010101:8080      # Reply source
<...>-47043   [002] ....  1205.549926: 0: v4 a00020f:54108     # Reply destination
```
7) In a new window (window # 3) dump the conntrack table manually:
```
sudo conntrack -L
```
and then verify that the debug logs indicate we skipped processing that dump:
```
<...>-24784   [002] ....  1762.205425: 0: skipping kprobe/ctnetlink_fill_info invocation from non-system-probe process
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
