### PR TITLE
[kitchen] cleanup Windows kitchen tests

### DIFF
--- a/test/kitchen/test-definitions/windows-install-test.yml
+++ b/test/kitchen/test-definitions/windows-install-test.yml
@@ -58,9 +58,6 @@ suites:
     run_list:
       - "recipe[dd-agent-install::_install_windows_base]"
     attributes:
-      apt:
-        unattended_upgrades:
-          enable: false
       datadog:
         <% dd_agent_config.each do |key, value| %>
         <%= key %>: <%= value %>
@@ -94,9 +91,6 @@ suites:
     run_list:
       - "recipe[dd-agent-install::_install_windows_base]"
     attributes:
-      apt:
-        unattended_upgrades:
-          enable: false
       datadog:
         <% dd_agent_config.each do |key, value| %>
         <%= key %>: <%= value %>
@@ -122,9 +116,6 @@ suites:
     run_list:
       - "recipe[dd-agent-install::_install_windows_base]"
     attributes:
-      apt:
-        unattended_upgrades:
-          enable: false
       datadog:
         <% dd_agent_config.each do |key, value| %>
         <%= key %>: <%= value %>
@@ -151,9 +142,6 @@ suites:
     run_list:
       - "recipe[dd-agent-install::_install_windows_base]"
     attributes:
-      apt:
-        unattended_upgrades:
-          enable: false
       datadog:
         <% dd_agent_config.each do |key, value| %>
         <%= key %>: <%= value %>
@@ -178,9 +166,6 @@ suites:
     run_list:
         - "recipe[dd-agent-install::_install_windows_base]"
     attributes:
-      apt:
-        unattended_upgrades:
-          enable: false
       datadog:
         <% dd_agent_config.each do |key, value| %>
         <%= key %>: <%= value %>
@@ -206,9 +191,6 @@ suites:
     run_list:
         - "recipe[dd-agent-install::_install_windows_base]"
     attributes:
-      apt:
-        unattended_upgrades:
-          enable: false
       datadog:
         <% dd_agent_config.each do |key, value| %>
         <%= key %>: <%= value %>

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -244,6 +244,7 @@ def json_info
 end
 
 def windows_service_status(service)
+  raise "windows_service_status is only for windows" unless os == :windows
   # Language-independent way of getting the service status
   return (`powershell -command "try { (get-service "#{service}" -ErrorAction Stop).Status } catch { write-host "NOTINSTALLED" }"`).upcase.strip
 end

--- a/test/kitchen/test/integration/win-alt-dir/rspec/win-alt-dir_spec.rb
+++ b/test/kitchen/test/integration/win-alt-dir/rspec/win-alt-dir_spec.rb
@@ -12,11 +12,7 @@ shared_examples_for 'a correctly created configuration root' do
   # to set env variables on the target machine or via parameters in Kitchen/Busser
   # See https://github.com/test-kitchen/test-kitchen/issues/662 for reference
   let(:configuration_path) {
-    if os == :windows
-      dna_json_path = "#{ENV['USERPROFILE']}\\AppData\\Local\\Temp\\kitchen\\dna.json"
-    else
-      dna_json_path = "/tmp/kitchen/dna.json"
-    end
+    dna_json_path = "#{ENV['USERPROFILE']}\\AppData\\Local\\Temp\\kitchen\\dna.json"
     JSON.parse(IO.read(dna_json_path)).fetch('dd-agent-rspec').fetch('APPLICATIONDATADIRECTORY')
   }
   it 'has the proper configuration root' do
@@ -30,11 +26,7 @@ shared_examples_for 'a correctly created binary root' do
   # to set env variables on the target machine or via parameters in Kitchen/Busser
   # See https://github.com/test-kitchen/test-kitchen/issues/662 for reference
   let(:binary_path) {
-    if os == :windows
-      dna_json_path = "#{ENV['USERPROFILE']}\\AppData\\Local\\Temp\\kitchen\\dna.json"
-    else
-      dna_json_path = "/tmp/kitchen/dna.json"
-    end
+    dna_json_path = "#{ENV['USERPROFILE']}\\AppData\\Local\\Temp\\kitchen\\dna.json"
     JSON.parse(IO.read(dna_json_path)).fetch('dd-agent-rspec').fetch('PROJECTLOCATION')
   }
   it 'has the proper binary root' do
@@ -45,19 +37,11 @@ end
 
 shared_examples_for 'an Agent with valid permissions' do
   let(:configuration_path) {
-    if os == :windows
-      dna_json_path = "#{ENV['USERPROFILE']}\\AppData\\Local\\Temp\\kitchen\\dna.json"
-    else
-      dna_json_path = "/tmp/kitchen/dna.json"
-    end
+    dna_json_path = "#{ENV['USERPROFILE']}\\AppData\\Local\\Temp\\kitchen\\dna.json"
     JSON.parse(IO.read(dna_json_path)).fetch('dd-agent-rspec').fetch('APPLICATIONDATADIRECTORY')
   }
   let(:binary_path) {
-    if os == :windows
-      dna_json_path = "#{ENV['USERPROFILE']}\\AppData\\Local\\Temp\\kitchen\\dna.json"
-    else
-      dna_json_path = "/tmp/kitchen/dna.json"
-    end
+    dna_json_path = "#{ENV['USERPROFILE']}\\AppData\\Local\\Temp\\kitchen\\dna.json"
     JSON.parse(IO.read(dna_json_path)).fetch('dd-agent-rspec').fetch('PROJECTLOCATION')
   }
   dd_user_sid = get_user_sid('ddagentuser')

--- a/test/kitchen/test/integration/win-installopts/rspec/win-installopts_spec.rb
+++ b/test/kitchen/test/integration/win-installopts/rspec/win-installopts_spec.rb
@@ -1,22 +1,5 @@
 require 'spec_helper'
 
-def read_conf_file
-    conf_path = ""
-    if os == :windows
-      conf_path = "#{ENV['ProgramData']}\\Datadog\\datadog.yaml"
-      ddpath_exists = File.exist?("#{ENV['ProgramData']}\\Datadog")
-      ddfile_exists = File.exist?(conf_path)
-      puts "path exists #{ddpath_exists} file exists #{ddfile_exists}"
-    else
-      conf_path = '/etc/datadog-agent/datadog.yaml'
-    end
-    puts "cp is #{conf_path}"
-    f = File.read(conf_path)
-    confYaml = YAML.load(f)
-    confYaml
-end
-
-
 shared_examples_for 'an Agent with APM disabled' do
   it 'has apm disabled' do
     confYaml = read_conf_file()

--- a/test/kitchen/test/integration/win-user/rspec/win-user_spec.rb
+++ b/test/kitchen/test/integration/win-user/rspec/win-user_spec.rb
@@ -1,19 +1,5 @@
 require 'spec_helper'
 
-def read_conf_file
-    conf_path = ""
-    if os == :windows
-      conf_path = "#{ENV['ProgramData']}\\Datadog\\datadog.yaml"
-    else
-      conf_path = '/etc/datadog-agent/datadog.yaml'
-    end
-    f = File.read(conf_path)
-    confYaml = YAML.load(f)
-    confYaml
-end
-
-
-
 =begin
 Each SDDL is defined as follows (split across multiple lines here for readability, but they're
 all concatenated into one)


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

General cleanup of Kitchen Windows tests. In particular:
- remove unused `apt` blocks.
- remove duplicated get conf function.
- remove `if os == :windows` in Windows specific code.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Remove unused code to simplify it.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Should be a no-op.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
