### PR TITLE
[install_mac_os] Enable systemwide LaunchDaemon installation of agent

### DIFF
--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -46,8 +46,12 @@ if [ -n "$DD_SYSTEMDAEMON_INSTALL" ]; then
         printf "\033[31mDD_SYSTEMDAEMON_INSTALL set without DD_SYSTEDAEMON_USER_GROUP\033[0m\n"
         exit 1;
     fi
-    if ! echo "$systemdaemon_user_group" | grep "^[^:][^:]*:[^:][^:]*$" > /dev/null; then
+    if ! echo "$systemdaemon_user_group" | grep "^[^:]\+:[^:]\+$" > /dev/null; then
         printf "\033[31mDD_SYSTEDAEMON_USER_GROUP must be in format UID:GID or UserName:GroupName\033[0m\n"
+        exit 1;
+    fi
+    if echo "$systemdaemon_user_group" | grep ">\|<" > /dev/null; then
+        printf "\033[31mDD_SYSTEDAEMON_USER_GROUP can't contain '>' or '<', because it will be used in XML file\033[0m\n"
         exit 1;
     fi
 fi

--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -9,6 +9,8 @@ install_script_version=1.0.0
 dmg_file=/tmp/datadog-agent.dmg
 dmg_base_url="https://s3.amazonaws.com/dd-agent"
 etc_dir=/opt/datadog-agent/etc
+log_dir=/opt/datadog-agent/logs
+run_dir=/opt/datadog-agent/run
 service_name="com.datadoghq.agent"
 systemwide_servicefile_name="/Library/LaunchDaemons/${service_name}.plist"
 
@@ -270,9 +272,11 @@ else
     $cmd_launchctl unload "$user_plist_file"
     # move the plist file to the system location
     $sudo_cmd mv "$user_plist_file" /Library/LaunchDaemons/
-    # make sure the daemon launches under proper user/group and then start it
+    # make sure the daemon launches under proper user/group and that it has access
+    # to all files/dirs it needs; then start it
     plist_modify_user_group "$systemwide_servicefile_name" "$systemdaemon_user_group"
     $sudo_cmd chown "$systemdaemon_user_group" "$systemwide_servicefile_name"
+    $sudo_cmd chown -R "$systemdaemon_user_group" "$etc_dir" "$log_dir" "$run_dir"
     $sudo_cmd launchctl load -w "$systemwide_servicefile_name"
     $sudo_cmd launchctl start "$service_name"
 fi

--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -47,11 +47,11 @@ if [ -n "$DD_SYSTEMDAEMON_INSTALL" ]; then
         exit 1;
     fi
     if ! echo "$systemdaemon_user_group" | grep "^[^:]\+:[^:]\+$" > /dev/null; then
-        printf "\033[31mDD_SYSTEDAEMON_USER_GROUP must be in format UID:GID or UserName:GroupName\033[0m\n"
+        printf "\033[31mDD_SYSTEMDAEMON_USER_GROUP must be in format UID:GID or UserName:GroupName\033[0m\n"
         exit 1;
     fi
     if echo "$systemdaemon_user_group" | grep ">\|<" > /dev/null; then
-        printf "\033[31mDD_SYSTEDAEMON_USER_GROUP can't contain '>' or '<', because it will be used in XML file\033[0m\n"
+        printf "\033[31mDD_SYSTEMDAEMON_USER_GROUP can't contain '>' or '<', because it will be used in XML file\033[0m\n"
         exit 1;
     fi
 fi

--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -284,7 +284,7 @@ else
     # make sure the daemon launches under proper user/group and that it has access
     # to all files/dirs it needs; then start it
     plist_modify_user_group "$systemwide_servicefile_name" "$systemdaemon_user_group"
-    $sudo_cmd chown "$systemdaemon_user_group" "$systemwide_servicefile_name"
+    $sudo_cmd chown "0:0" "$systemwide_servicefile_name"
     $sudo_cmd chown -R "$systemdaemon_user_group" "$etc_dir" "$log_dir" "$run_dir"
     $sudo_cmd launchctl load -w "$systemwide_servicefile_name"
     $sudo_cmd launchctl start "$service_name"

--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -82,6 +82,23 @@ if [ ! "$apikey" ]; then
     fi
 fi
 
+if [ "$systemdaemon_install" == false ] && [ -f "$systemwide_servicefile_name" ]; then
+    printf "\033[31m
+$systemwide_servicefile_name exists, suggesting a
+systemwide Agent installation is present. Individual users
+can't install the Agent when systemwide installation exists.
+
+If no systemwide installation is present or you want to remove it, run:
+
+    sudo launchctl unload -w $systemwide_servicefile_name
+    sudo rm $systemwide_servicefile_name
+
+Then rerun this script to install the Agent for your user account.
+\033[0m\n"
+
+    exit 1;
+fi
+
 
 # SUDO_USER is defined in man sudo: https://linux.die.net/man/8/sudo
 # "SUDO_USER Set to the login name of the user who invoked sudo."
@@ -184,8 +201,7 @@ function plist_modify_user_group() {
 # # Install the agent
 printf "\033[34m\n* Downloading datadog-agent\n\033[0m"
 rm -f $dmg_file
-# curl --fail --progress-bar $dmg_url > $dmg_file
-dmg_file=/Users/slavek.kabrda/Downloads/datadog-agent-7.34.0-rc.1-1.dmg
+curl --fail --progress-bar $dmg_url > $dmg_file
 printf "\033[34m\n* Installing datadog-agent, you might be asked for your sudo password...\n\033[0m"
 $sudo_cmd hdiutil detach "/Volumes/datadog_agent" >/dev/null 2>&1 || true
 printf "\033[34m\n    - Mounting the DMG installer...\n\033[0m"
@@ -270,7 +286,16 @@ background and submit metrics to Datadog.
 You can check the agent status using the \"datadog-agent status\" command
 or by opening the webui using the \"datadog-agent launch-gui\" command.
 
+\033[0m"
+
+if [ "$systemdaemon_install" = false ]; then
+    printf "\033[32m
 If you ever want to stop the Agent, please use the Datadog Agent App or
 the launchctl command. It will start automatically at login.
-
 \033[0m"
+else
+    printf "\033[32m
+If you ever want to stop the Agent, please use the the launchctl command.
+The Agent will start automatically at system startup.
+\033[0m"
+fi

--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -254,7 +254,7 @@ if grep -E 'api_key:( APIKEY)?$' "$etc_dir/datadog.yaml" > /dev/null 2>&1; then
     if [ "$retry" -ge 5 ]; then
         printf "\n\033[33mCould not restart the agent.
 You may have to restart it manually using the systray app or the
-\"launchctl start com.datadoghq.agent\" command.\n\033[0m\n"
+\"launchctl start $service_name\" command.\n\033[0m\n"
     fi
 
     $cmd_launchctl start $service_name


### PR DESCRIPTION
### What does this PR do?

Implements functionality to install the agent as systemwide LaunchDaemon instead of a user LaunchAgent. Some notes on the solution:

* The systemwide installation is triggered by specifying `DD_SYSTEMDAEMON_INSTALL=true`.
* It requires specifying the user+group under which the agent will run, e.g. `DD_SYSTEMDAEMON_USER_GROUP=username:groupname`.
* When agent is install as systemwide LaunchDaemon, the script makes it impossible to also install it as user LaunchAgent.
* The system tray app doesn't start when agent is set up as LaunchDaemon, because it wouldn't work with it.

### Motivation

This makes it possible to set up the agent to start on system startup instead when a specific user logs in.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

* With a clean system (no existing agent installation), try installing the agent and verify it's correctly submitting metrics:
  * Without specifying `DD_SYSTEMDAEMON_INSTALL` - should install the agent as LaunchAgent for the user, open a dialog asking for permissions and then launch the systemtray app.
  * Test the following scenario both locally and also through SSH on a user account that's not logged in via GUI:
    * While specifying `DD_SYSTEMDAEMON_INSTALL=true` (and `DD_SYSTEMDAEMON_USER_GROUP`) - should install the agent as LaunchDaemon, *not* open any dialog and *not* launch the systemtray app. (If testing this on a system that previously had agent installed, you need to run `sudo tccutil reset AppleEvents com.datadoghq.agent` before uninstalling the previous agent to ensure the permissions get removed and we actually properly test the agent doesn't ask again when installing systemwide).
* With a system that already has agent installed as user LaunchAgent:
  * Without specifying `DD_SYSTEMDAEMON_INSTALL` - should reinstall the agent.
  * While specifying `DD_SYSTEMDAEMON_INSTALL=true` (and `DD_SYSTEMDAEMON_USER_GROUP`) - should reinstall the agent as systemwide LaunchDaemon.
* With a system that already has agent installed as systemwide LaunchDaemon:
  * Without specifying `DD_SYSTEMDAEMON_INSTALL` - should fail, saying it's not possible to install the agent as user LaunchAgent when systemwide installation is present.
  * While specifying `DD_SYSTEMDAEMON_INSTALL=true` (and `DD_SYSTEMDAEMON_USER_GROUP`) - should reinstall the agent (and keep it running as systemwide LaunchDaemon).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
