### PR TITLE
[Serverless] Update logic for start-invocation and end-invocation endpoints

### DIFF
--- a/pkg/serverless/daemon/routes.go
+++ b/pkg/serverless/daemon/routes.go
@@ -1,7 +1,6 @@
 package daemon
 
 import (
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -55,16 +54,11 @@ func (s *StartInvocation) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Could not read StartInvocation request body", 400)
 		return
 	}
-
-	var startDetails invocationlifecycle.InvocationStartDetails
-	err = json.Unmarshal(reqBody, &startDetails)
-	if err != nil {
-		log.Error("Could not unmarshal StartInvocation payload")
-		http.Error(w, "Could not unmarshal StartInvocation payload", 400)
-		return
+	var startDetails = &invocationlifecycle.InvocationStartDetails{
+		StartTime:             startTime,
+		InvokeEventRawPayload: string(reqBody),
 	}
-	startDetails.StartTime = startTime
-	s.daemon.InvocationProcessor.OnInvokeStart(&startDetails)
+	s.daemon.InvocationProcessor.OnInvokeStart(startDetails)
 }
 
 // EndInvocation is a route that can be called at the end of an invocation to enable

--- a/pkg/serverless/daemon/routes.go
+++ b/pkg/serverless/daemon/routes.go
@@ -54,7 +54,7 @@ func (s *StartInvocation) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "Could not read StartInvocation request body", 400)
 		return
 	}
-	var startDetails = &invocationlifecycle.InvocationStartDetails{
+	startDetails := &invocationlifecycle.InvocationStartDetails{
 		StartTime:             startTime,
 		InvokeEventRawPayload: string(reqBody),
 	}
@@ -73,7 +73,7 @@ func (e *EndInvocation) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	var endDetails = invocationlifecycle.InvocationEndDetails{
 		EndTime:   endTime,
 		IsError:   r.Header.Get(invocationlifecycle.InvocationErrorHeader) == "true",
-		RequestId: e.daemon.ExecutionContext.LastRequestID,
+		RequestID: e.daemon.ExecutionContext.LastRequestID,
 	}
 	e.daemon.InvocationProcessor.OnInvokeEnd(&endDetails)
 }

--- a/pkg/serverless/daemon/routes_test.go
+++ b/pkg/serverless/daemon/routes_test.go
@@ -49,24 +49,6 @@ func TestStartInvocation(t *testing.T) {
 	assert.True(m.OnInvokeStartCalled)
 }
 
-func TestStartInvocationInvalidRequestBody(t *testing.T) {
-	assert := assert.New(t)
-	d := StartDaemon("127.0.0.1:8124")
-	defer d.Stop()
-
-	m := &mockLifecycleProcessor{}
-	d.InvocationProcessor = m
-
-	client := &http.Client{Timeout: 1 * time.Second}
-	body := bytes.NewBuffer([]byte(`INVALID`))
-	request, err := http.NewRequest(http.MethodPost, "http://127.0.0.1:8124/lambda/start-invocation", body)
-	assert.Nil(err)
-	res, err := client.Do(request)
-	assert.Nil(err)
-	assert.Equal(res.StatusCode, 400)
-	assert.False(m.OnInvokeStartCalled)
-}
-
 func TestEndInvocation(t *testing.T) {
 	assert := assert.New(t)
 	d := StartDaemon("127.0.0.1:8124")
@@ -118,7 +100,7 @@ func TestTraceContext(t *testing.T) {
 		DetectLambdaLibrary: func() bool { return false },
 	}
 	client := &http.Client{Timeout: 1 * time.Second}
-	body := bytes.NewBuffer([]byte(`{"start_time": "2019-10-12T07:20:50.52Z","headers": {"x-datadog-trace-id": ["1234"]},"payload": "{\"headers\":{\"x-datadog-parent-id\":\"1111\",\"x-datadog-trace-id\":\"2222\"}}"}`))
+	body := bytes.NewBuffer([]byte(`{"start_time": "2019-10-12T07:20:50.52Z","Headers": {"x-datadog-trace-id": "2222"}}`))
 	request, err := http.NewRequest(http.MethodPost, "http://127.0.0.1:8124/lambda/start-invocation", body)
 	assert.Nil(err)
 	_, err = client.Do(request)

--- a/pkg/serverless/daemon/routes_test.go
+++ b/pkg/serverless/daemon/routes_test.go
@@ -40,7 +40,7 @@ func TestStartInvocation(t *testing.T) {
 	d.InvocationProcessor = m
 
 	client := &http.Client{Timeout: 1 * time.Second}
-	body := bytes.NewBuffer([]byte(`{"start_time": "2019-10-12T07:20:50.52Z", "headers": {"header-1": ["value-1"]}, "payload": "payload-string"}`))
+	body := bytes.NewBuffer([]byte(`{"toto": "titi", "tata":true}`))
 	request, err := http.NewRequest(http.MethodPost, "http://127.0.0.1:8124/lambda/start-invocation", body)
 	assert.Nil(err)
 	res, err := client.Do(request)
@@ -100,7 +100,7 @@ func TestTraceContext(t *testing.T) {
 		DetectLambdaLibrary: func() bool { return false },
 	}
 	client := &http.Client{Timeout: 1 * time.Second}
-	body := bytes.NewBuffer([]byte(`{"start_time": "2019-10-12T07:20:50.52Z","Headers": {"x-datadog-trace-id": "2222"}}`))
+	body := bytes.NewBuffer([]byte(`{"toto": "tutu","Headers": {"x-datadog-trace-id": "2222"}}`))
 	request, err := http.NewRequest(http.MethodPost, "http://127.0.0.1:8124/lambda/start-invocation", body)
 	assert.Nil(err)
 	_, err = client.Do(request)

--- a/pkg/serverless/daemon/routes_test.go
+++ b/pkg/serverless/daemon/routes_test.go
@@ -19,14 +19,16 @@ import (
 type mockLifecycleProcessor struct {
 	OnInvokeStartCalled bool
 	OnInvokeEndCalled   bool
+	isError             bool
 }
 
 func (m *mockLifecycleProcessor) OnInvokeStart(*invocationlifecycle.InvocationStartDetails) {
 	m.OnInvokeStartCalled = true
 }
 
-func (m *mockLifecycleProcessor) OnInvokeEnd(*invocationlifecycle.InvocationEndDetails) {
+func (m *mockLifecycleProcessor) OnInvokeEnd(endDetails *invocationlifecycle.InvocationEndDetails) {
 	m.OnInvokeEndCalled = true
+	m.isError = endDetails.IsError
 }
 
 func TestStartInvocation(t *testing.T) {
@@ -74,13 +76,34 @@ func TestEndInvocation(t *testing.T) {
 	d.InvocationProcessor = m
 
 	client := &http.Client{Timeout: 1 * time.Second}
-	body := bytes.NewBuffer([]byte(`{"end_time": "2019-10-12T07:20:50.52Z", "is_error": false}`))
+	body := bytes.NewBuffer([]byte(`{}`))
 	request, err := http.NewRequest(http.MethodPost, "http://127.0.0.1:8124/lambda/end-invocation", body)
 	assert.Nil(err)
 	res, err := client.Do(request)
 	assert.Nil(err)
 	assert.Equal(res.StatusCode, 200)
+	assert.False(m.isError)
 	assert.True(m.OnInvokeEndCalled)
+}
+
+func TestEndInvocationWithError(t *testing.T) {
+	assert := assert.New(t)
+	d := StartDaemon("127.0.0.1:8124")
+	defer d.Stop()
+
+	m := &mockLifecycleProcessor{}
+	d.InvocationProcessor = m
+
+	client := &http.Client{Timeout: 1 * time.Second}
+	body := bytes.NewBuffer([]byte(`{}`))
+	request, err := http.NewRequest(http.MethodPost, "http://127.0.0.1:8124/lambda/end-invocation", body)
+	request.Header.Set("x-datadog-invocation-error", "true")
+	assert.Nil(err)
+	res, err := client.Do(request)
+	assert.Nil(err)
+	assert.Equal(res.StatusCode, 200)
+	assert.True(m.OnInvokeEndCalled)
+	assert.True(m.isError)
 }
 
 func TestTraceContext(t *testing.T) {
@@ -107,22 +130,4 @@ func TestTraceContext(t *testing.T) {
 	assert.Equal("2222", fmt.Sprintf("%v", invocationlifecycle.TraceID()))
 	assert.Equal(response.Header.Get("x-datadog-trace-id"), fmt.Sprintf("%v", invocationlifecycle.TraceID()))
 	assert.Equal(response.Header.Get("x-datadog-span-id"), fmt.Sprintf("%v", invocationlifecycle.SpanID()))
-}
-
-func TestEndInvocationInvalidRequestBody(t *testing.T) {
-	assert := assert.New(t)
-	d := StartDaemon("127.0.0.1:8124")
-	defer d.Stop()
-
-	m := &mockLifecycleProcessor{}
-	d.InvocationProcessor = m
-
-	client := &http.Client{Timeout: 1 * time.Second}
-	body := bytes.NewBuffer([]byte(`INVALID`))
-	request, err := http.NewRequest(http.MethodPost, "http://127.0.0.1:8124/lambda/end-invocation", body)
-	assert.Nil(err)
-	res, err := client.Do(request)
-	assert.Nil(err)
-	assert.Equal(res.StatusCode, 400)
-	assert.False(m.OnInvokeStartCalled)
 }

--- a/pkg/serverless/invocationlifecycle/constants.go
+++ b/pkg/serverless/invocationlifecycle/constants.go
@@ -7,12 +7,15 @@ package invocationlifecycle
 
 const (
 	// TraceIDHeader is the header containing the traceID
+	// used in /trace-context
 	TraceIDHeader = "x-datadog-trace-id"
 
 	// SpanIDHeader is the header containing the spanID
+	// used in /lambda/start-invocation
 	SpanIDHeader = "x-datadog-span-id"
 
 	// InvocationErrorHeader : if set to "true", the extension will know that the current invocation has failed
+	// used in /lambda/end-invocation
 	InvocationErrorHeader = "x-datadog-invocation-error"
 
 	parentIDHeader = "x-datadog-parent-id"

--- a/pkg/serverless/invocationlifecycle/constants.go
+++ b/pkg/serverless/invocationlifecycle/constants.go
@@ -12,5 +12,8 @@ const (
 	// SpanIDHeader is the header containing the spanID
 	SpanIDHeader = "x-datadog-span-id"
 
+	// InvocationErrorHeader : if set to "true", the extension will know that the current invocation has failed
+	InvocationErrorHeader = "x-datadog-invocation-error"
+
 	parentIDHeader = "x-datadog-parent-id"
 )

--- a/pkg/serverless/invocationlifecycle/invocation_details.go
+++ b/pkg/serverless/invocationlifecycle/invocation_details.go
@@ -12,9 +12,8 @@ import (
 // InvocationStartDetails stores information about the start of an invocation.
 // This structure is passed to the onInvokeStart method of the invocationProcessor interface
 type InvocationStartDetails struct {
-	StartTime          time.Time
-	InvokeHeaders      map[string][]string `json:"headers"`
-	InvokeEventPayload string              `json:"payload"`
+	StartTime             time.Time
+	InvokeEventRawPayload string
 }
 
 // InvocationEndDetails stores information about the end of an invocation.

--- a/pkg/serverless/invocationlifecycle/invocation_details.go
+++ b/pkg/serverless/invocationlifecycle/invocation_details.go
@@ -12,7 +12,7 @@ import (
 // InvocationStartDetails stores information about the start of an invocation.
 // This structure is passed to the onInvokeStart method of the invocationProcessor interface
 type InvocationStartDetails struct {
-	StartTime          time.Time           `json:"start_time"`
+	StartTime          time.Time
 	InvokeHeaders      map[string][]string `json:"headers"`
 	InvokeEventPayload string              `json:"payload"`
 }
@@ -20,6 +20,7 @@ type InvocationStartDetails struct {
 // InvocationEndDetails stores information about the end of an invocation.
 // This structure is passed to the onInvokeEnd method of the invocationProcessor interface
 type InvocationEndDetails struct {
-	EndTime time.Time `json:"end_time"`
-	IsError bool      `json:"is_error"`
+	EndTime   time.Time
+	IsError   bool
+	RequestId string
 }

--- a/pkg/serverless/invocationlifecycle/invocation_details.go
+++ b/pkg/serverless/invocationlifecycle/invocation_details.go
@@ -21,5 +21,5 @@ type InvocationStartDetails struct {
 type InvocationEndDetails struct {
 	EndTime   time.Time
 	IsError   bool
-	RequestId string
+	RequestID string
 }

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -43,7 +43,7 @@ func (lp *LifecycleProcessor) OnInvokeEnd(endDetails *InvocationEndDetails) {
 
 	if !lp.DetectLambdaLibrary() {
 		log.Debug("Creating and sending function execution span for invocation")
-		endExecutionSpan(lp.ProcessTrace, endDetails.RequestId, endDetails.EndTime, endDetails.IsError)
+		endExecutionSpan(lp.ProcessTrace, endDetails.RequestID, endDetails.EndTime, endDetails.IsError)
 	}
 
 	if endDetails.IsError {

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -26,13 +26,11 @@ type LifecycleProcessor struct {
 func (lp *LifecycleProcessor) OnInvokeStart(startDetails *InvocationStartDetails) {
 	log.Debug("[lifecycle] onInvokeStart ------")
 	log.Debug("[lifecycle] Invocation has started at :", startDetails.StartTime)
-	log.Debug("[lifecycle] Invocation invokeHeaders are :", startDetails.InvokeHeaders)
-	log.Debug("[lifecycle] Invocation invokeEvent payload is :", startDetails.InvokeEventPayload)
+	log.Debug("[lifecycle] Invocation invokeEvent payload is :", startDetails.InvokeEventRawPayload)
 	log.Debug("[lifecycle] ---------------------------------------")
 
 	if !lp.DetectLambdaLibrary() {
-		startExecutionSpan(startDetails.StartTime, startDetails.InvokeEventPayload)
-
+		startExecutionSpan(startDetails.StartTime, startDetails.InvokeEventRawPayload)
 	}
 }
 

--- a/pkg/serverless/invocationlifecycle/lifecycle.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle.go
@@ -45,7 +45,7 @@ func (lp *LifecycleProcessor) OnInvokeEnd(endDetails *InvocationEndDetails) {
 
 	if !lp.DetectLambdaLibrary() {
 		log.Debug("Creating and sending function execution span for invocation")
-		endExecutionSpan(lp.ProcessTrace, endDetails.EndTime, endDetails.IsError)
+		endExecutionSpan(lp.ProcessTrace, endDetails.RequestId, endDetails.EndTime, endDetails.IsError)
 	}
 
 	if endDetails.IsError {

--- a/pkg/serverless/invocationlifecycle/lifecycle_test.go
+++ b/pkg/serverless/invocationlifecycle/lifecycle_test.go
@@ -58,7 +58,7 @@ func TestStartExecutionSpanNoLambdaLibrary(t *testing.T) {
 
 	eventPayload := `a5a{"resource":"/users/create","path":"/users/create","httpMethod":"GET","headers":{"Accept":"*/*","Accept-Encoding":"gzip","x-datadog-parent-id":"1480558859903409531","x-datadog-sampling-priority":"1","x-datadog-trace-id":"5736943178450432258"}}0`
 	startInvocationTime := time.Now()
-	startDetails := InvocationStartDetails{StartTime: startInvocationTime, InvokeEventPayload: eventPayload}
+	startDetails := InvocationStartDetails{StartTime: startInvocationTime, InvokeEventRawPayload: eventPayload}
 
 	testProcessor := LifecycleProcessor{
 		ExtraTags:           extraTags,

--- a/pkg/serverless/invocationlifecycle/trace.go
+++ b/pkg/serverless/invocationlifecycle/trace.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/api"
 	"github.com/DataDog/datadog-agent/pkg/trace/info"
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+	"github.com/DataDog/datadog-agent/pkg/trace/sampler"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -62,7 +63,7 @@ func startExecutionSpan(startTime time.Time, rawPayload string) {
 
 // endExecutionSpan builds the function execution span and sends it to the intake.
 // It should be called at the end of the invocation.
-func endExecutionSpan(processTrace func(p *api.Payload), endTime time.Time, isError bool) {
+func endExecutionSpan(processTrace func(p *api.Payload), requestId string, endTime time.Time, isError bool) {
 	duration := endTime.UnixNano() - currentExecutionInfo.startTime.UnixNano()
 
 	executionSpan := &pb.Span{
@@ -75,6 +76,9 @@ func endExecutionSpan(processTrace func(p *api.Payload), endTime time.Time, isEr
 		ParentID: currentExecutionInfo.parentID,
 		Start:    currentExecutionInfo.startTime.UnixNano(),
 		Duration: duration,
+		Meta: map[string]string{
+			"request_id": requestId,
+		},
 	}
 
 	if isError {
@@ -82,7 +86,8 @@ func endExecutionSpan(processTrace func(p *api.Payload), endTime time.Time, isEr
 	}
 
 	traceChunk := &pb.TraceChunk{
-		Spans: []*pb.Span{executionSpan},
+		Priority: int32(sampler.PriorityNone),
+		Spans:    []*pb.Span{executionSpan},
 	}
 
 	tracerPayload := &pb.TracerPayload{

--- a/pkg/serverless/invocationlifecycle/trace.go
+++ b/pkg/serverless/invocationlifecycle/trace.go
@@ -63,7 +63,7 @@ func startExecutionSpan(startTime time.Time, rawPayload string) {
 
 // endExecutionSpan builds the function execution span and sends it to the intake.
 // It should be called at the end of the invocation.
-func endExecutionSpan(processTrace func(p *api.Payload), requestId string, endTime time.Time, isError bool) {
+func endExecutionSpan(processTrace func(p *api.Payload), requestID string, endTime time.Time, isError bool) {
 	duration := endTime.UnixNano() - currentExecutionInfo.startTime.UnixNano()
 
 	executionSpan := &pb.Span{
@@ -77,7 +77,7 @@ func endExecutionSpan(processTrace func(p *api.Payload), requestId string, endTi
 		Start:    currentExecutionInfo.startTime.UnixNano(),
 		Duration: duration,
 		Meta: map[string]string{
-			"request_id": requestId,
+			"request_id": requestID,
 		},
 	}
 

--- a/pkg/serverless/invocationlifecycle/trace_test.go
+++ b/pkg/serverless/invocationlifecycle/trace_test.go
@@ -61,12 +61,13 @@ func TestEndExecutionSpanWithNoError(t *testing.T) {
 		tracePayload = payload
 	}
 
-	endExecutionSpan(mockProcessTrace, endTime, isError)
+	endExecutionSpan(mockProcessTrace, "test-request-id", endTime, isError)
 	executionSpan := tracePayload.TracerPayload.Chunks[0].Spans[0]
 	assert.Equal(t, "aws.lambda", executionSpan.Name)
 	assert.Equal(t, "aws.lambda", executionSpan.Service)
 	assert.Equal(t, "TestFunction", executionSpan.Resource)
 	assert.Equal(t, "serverless", executionSpan.Type)
+	assert.Equal(t, "test-request-id", executionSpan.Meta["request_id"])
 	assert.Equal(t, currentExecutionInfo.traceID, executionSpan.TraceID)
 	assert.Equal(t, currentExecutionInfo.spanID, executionSpan.SpanID)
 	assert.Equal(t, startTime.UnixNano(), executionSpan.Start)
@@ -90,7 +91,7 @@ func TestEndExecutionSpanWithError(t *testing.T) {
 		tracePayload = payload
 	}
 
-	endExecutionSpan(mockProcessTrace, endTime, isError)
+	endExecutionSpan(mockProcessTrace, "test-request-id", endTime, isError)
 	executionSpan := tracePayload.TracerPayload.Chunks[0].Spans[0]
 	assert.Equal(t, executionSpan.Error, int32(1))
 }

--- a/pkg/serverless/proxy/proxy_test.go
+++ b/pkg/serverless/proxy/proxy_test.go
@@ -25,10 +25,7 @@ func (tp *testProcessorResponseValid) OnInvokeStart(startDetails *invocationlife
 	if startDetails.StartTime.IsZero() {
 		panic("isZero")
 	}
-	if len(startDetails.InvokeHeaders) != 3 {
-		panic("headers")
-	}
-	if !strings.HasSuffix(startDetails.InvokeEventPayload, "ok") {
+	if !strings.HasSuffix(startDetails.InvokeEventRawPayload, "ok") {
 		panic("payload")
 	}
 }
@@ -48,10 +45,7 @@ func (tp *testProcessorResponseError) OnInvokeStart(startDetails *invocationlife
 	if startDetails.StartTime.IsZero() {
 		panic("isZero")
 	}
-	if len(startDetails.InvokeHeaders) != 3 {
-		panic("headers")
-	}
-	if !strings.HasSuffix(startDetails.InvokeEventPayload, "ok") {
+	if !strings.HasSuffix(startDetails.InvokeEventRawPayload, "ok") {
 		panic("payload")
 	}
 }

--- a/pkg/serverless/proxy/transport.go
+++ b/pkg/serverless/proxy/transport.go
@@ -47,9 +47,8 @@ func (p *proxyTransport) RoundTrip(request *http.Request) (*http.Response, error
 	// triggers onInvokeStart when /next response is received
 	if request.Method == "GET" && strings.HasSuffix(request.URL.String(), "/next") {
 		details := &invocationlifecycle.InvocationStartDetails{
-			StartTime:          time.Now(),
-			InvokeHeaders:      response.Header,
-			InvokeEventPayload: string(dumpedResponse[indexPayload:]),
+			StartTime:             time.Now(),
+			InvokeEventRawPayload: string(dumpedResponse[indexPayload:]),
 		}
 		p.processor.OnInvokeStart(details)
 	}


### PR DESCRIPTION
### What does this PR do?

This PR contains various little things

- A confusion was made between headers and payload while receiving the event from the tracer (or the proxy)
  - In `InvocationStartDetails` we had originally two fields, `header` and `payload`. But in fact, interesting headers are part of the full `payload` (the event object sent from the tracer / proxy). The remaining header field is useless since it would have referred to headers from the request itself the the proxy `/invocations/requestId/xxx` or `/start-invocation`
  - Due to this, there is no need to unmarshall it in the endpoint. We only need to parse it for getting the trace context so `InvokeEventPayload` has been renamed to `InvokeEventRawPayload`

- While creating the top-level span in the extension, we forgot to specify the `priority`. This has been resulting in sampling out every spans not issued from cold starts (due to inherent logic of the sampling) so `int32(sampler.PriorityNone)` has been set not to interfere with actual sampling

- Detect isError from the `/end-invocation` via a header (no need to umarshall, and payload sent from the tracer is empty as long as we don't support payload captures)

- To totally remove the need of unmarshalling in both endpoints, `startTime` and `endTime` timestamp are now computed when we receive the `POST` requests in `/start-invocation` and `/end-invocation` (since it's happening locally from the tracer, the time difference is extremely extremely low

- Unit testing from new features + fixing the existing ones due to the described changes



### Motivation

.NET tracing

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
