### PR TITLE
[kitchen] fixup invoke kitchen-prepare

### DIFF
--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -184,7 +184,7 @@ def kitchen_prepare(ctx, windows=is_windows):
     for pkg in TEST_PACKAGES_LIST:
         target_packages += (
             check_output(
-                f"go list -f \"{{{{ .Dir }}}}\" -mod=mod -tags \"{','.join(build_tags)}\" {pkg}",
+                f"go list -mod=mod -tags \"{','.join(build_tags)}\" {pkg}",
                 shell=True,
             )
             .decode('utf-8')
@@ -198,8 +198,9 @@ def kitchen_prepare(ctx, windows=is_windows):
     # test/kitchen/site-cookbooks/dd-system-probe-check/files/default/tests/pkg/network/netlink/testsuite
     # test/kitchen/site-cookbooks/dd-system-probe-check/files/default/tests/pkg/ebpf/testsuite
     # test/kitchen/site-cookbooks/dd-system-probe-check/files/default/tests/pkg/ebpf/bytecode/testsuite
+    gopath = check_output("go env GOPATH", shell=True).decode('utf-8').strip("\n")
     for i, pkg in enumerate(target_packages):
-        relative_path = os.path.relpath(pkg)
+        relative_path = os.path.relpath(gopath + "/src/" + pkg)
         target_path = os.path.join(KITCHEN_ARTIFACT_DIR, relative_path)
         target_bin = "testsuite"
         if windows:

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -2,6 +2,7 @@ import contextlib
 import glob
 import json
 import os
+import re
 import shutil
 import sys
 import tempfile
@@ -198,10 +199,8 @@ def kitchen_prepare(ctx, windows=is_windows):
     # test/kitchen/site-cookbooks/dd-system-probe-check/files/default/tests/pkg/network/netlink/testsuite
     # test/kitchen/site-cookbooks/dd-system-probe-check/files/default/tests/pkg/ebpf/testsuite
     # test/kitchen/site-cookbooks/dd-system-probe-check/files/default/tests/pkg/ebpf/bytecode/testsuite
-    gopath = check_output("go env GOPATH", shell=True).decode('utf-8').strip("\n")
     for i, pkg in enumerate(target_packages):
-        relative_path = os.path.relpath(gopath + "/src/" + pkg)
-        target_path = os.path.join(KITCHEN_ARTIFACT_DIR, relative_path)
+        target_path = os.path.join(KITCHEN_ARTIFACT_DIR, re.sub("^.*datadog-agent.", "", pkg))
         target_bin = "testsuite"
         if windows:
             target_bin = "testsuite.exe"


### PR DESCRIPTION
### What does this PR do?

Fixup invoke kitchen-prepare

By using the absolute path GOPATH/src/PKG

happen when you have a symlink in your path like
$HOME/dd/datadog-agent -> $HOME/go/src/github.com/DataDog/datadog-agent
cd dd ; inv system-probe.kitchen-prepare

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
