### PR TITLE
use given creationTime for containers

### DIFF
--- a/pkg/autodiscovery/listeners/container.go
+++ b/pkg/autodiscovery/listeners/container.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !serverless
 // +build !serverless
 
 package listeners
@@ -92,7 +93,7 @@ func (l *ContainerListener) createContainerService(
 
 	svc := &service{
 		entity:       container,
-		creationTime: integration.After,
+		creationTime: creationTime,
 		adIdentifiers: ComputeContainerServiceIDs(
 			containers.BuildEntityName(string(container.Runtime), container.ID),
 			containerImg.RawName,


### PR DESCRIPTION
NOTE: This is more of a question than a PR.

### What does this PR do?

Fixes annotation of containers as from "Before" or "After" the agent started.

### Motivation

`pkg/autodiscovery/listeners/workloadmeta.go` calculates `creationTime` based on the WLM semantics, which are that the first EventBundle a subscriber receives represents everything that happened "Before" the subscription, and all subsequent bundles are "After."  It passes this value to `createContainerService` in `pkg/autodiscovery/listeners/container.go`.  However, before this PR, that value was ignored and all containers were represented as services with `creationTime: After`.

I've verified this experimentally -- I see `CreationTime: 1` (= After) in some debug logging of the `integration.Config` received by the logs agent's scheduler, for a container created before the agent was started.

### Additional Notes

It looks like, before #9196, this [was set to Before in `init`](https://github.com/DataDog/datadog-agent/blob/9dcc9bc925a52d24fad776239b456762616154d7/pkg/autodiscovery/listeners/docker.go#L129-L167) and [to After in createService](https://github.com/DataDog/datadog-agent/blob/9dcc9bc925a52d24fad776239b456762616154d7/pkg/autodiscovery/listeners/docker.go#L129-L248), presumably called after init.  Did this just get missed in the translation?

It appears this is broken in 7.33.0.

### Possible Drawbacks / Trade-offs

All of this code is super-fragile and I do not have a complete understanding of the agent, so this "fix" may in fact be incorrect, or even if correct may have undesirable side effects.

### Describe how to test/QA your changes

Start a container before the agent, and log some output from it.

Start the agent, configured to log that container (do this once each for container_collect_all,  container labels, and an integration config), and observe that it does not log the most recent output from the container.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
