### PR TITLE
Add support for UDPv6 receive to NPM

### DIFF
--- a/pkg/ebpf/bytecode/runtime/http.go
+++ b/pkg/ebpf/bytecode/runtime/http.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Http = NewRuntimeAsset("http.c", "739e2dd72b8e8d014829670ea8bb74a6e0c49f52a3e22a23a1fd2437bf5e208c")
+var Http = NewRuntimeAsset("http.c", "524ac163af4b57db616fc61a62b8c2ee59fb62c64a1f69419f495d7666b0c4e4")

--- a/pkg/ebpf/bytecode/runtime/tracer.go
+++ b/pkg/ebpf/bytecode/runtime/tracer.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var Tracer = NewRuntimeAsset("tracer.c", "0196cb07f7f37a49d747424bb40f25c33b2a650e37bd8738fb098eb545a4d894")
+var Tracer = NewRuntimeAsset("tracer.c", "de9a08f0389f5f73f79e69c8dba13d5bf18cd7171efe2d2d38ba5dd1807118fc")

--- a/pkg/network/ebpf/c/runtime/conn-tuple.h
+++ b/pkg/network/ebpf/c/runtime/conn-tuple.h
@@ -51,8 +51,12 @@ static __always_inline int read_conn_tuple_partial(conn_tuple_t* t, struct sock*
 #ifdef FEATURE_IPV6_ENABLED
     else if (family == AF_INET6) {
         // TODO cleanup? having it split on 64 bits is not nice for kernel reads
-        read_in6_addr(&t->saddr_h, &t->saddr_l, &skp->sk_v6_rcv_saddr);
-        read_in6_addr(&t->daddr_h, &t->daddr_l, &skp->sk_v6_daddr);
+        if (!(t->saddr_h || t->saddr_l)) {
+            read_in6_addr(&t->saddr_h, &t->saddr_l, &skp->sk_v6_rcv_saddr);
+        }
+        if (!(t->daddr_h || t->daddr_l)) {
+            read_in6_addr(&t->daddr_h, &t->daddr_l, &skp->sk_v6_daddr);
+        }
 
         // We can only pass 4 args to bpf_trace_printk
         // so split those 2 statements to be able to log everything

--- a/pkg/network/ebpf/c/sock.h
+++ b/pkg/network/ebpf/c/sock.h
@@ -209,16 +209,12 @@ static __always_inline int read_conn_tuple_partial(conn_tuple_t * t, struct sock
             return 0;
         }
 
-        if (t->saddr_h == 0) {
+        if (!(t->saddr_h || t->saddr_l)) {
             bpf_probe_read(&t->saddr_h, sizeof(t->saddr_h), ((char*)skp) + offset_daddr_ipv6() + 2 * sizeof(u64));
-        }
-        if (t->saddr_l == 0) {
             bpf_probe_read(&t->saddr_l, sizeof(t->saddr_l), ((char*)skp) + offset_daddr_ipv6() + 3 * sizeof(u64));
         }
-        if (t->daddr_h == 0) {
+        if (!(t->daddr_h || t->daddr_l)) {
             bpf_probe_read(&t->daddr_h, sizeof(t->daddr_h), ((char*)skp) + offset_daddr_ipv6());
-        }
-        if (t->daddr_l == 0) {
             bpf_probe_read(&t->daddr_l, sizeof(t->daddr_l), ((char*)skp) + offset_daddr_ipv6() + sizeof(u64));
         }
 

--- a/pkg/network/ebpf/c/tracer-maps.h
+++ b/pkg/network/ebpf/c/tracer-maps.h
@@ -67,6 +67,19 @@ struct bpf_map_def SEC("maps/udp_recv_sock") udp_recv_sock = {
     .namespace = "",
 };
 
+/* This map is used to match the kprobe & kretprobe of udpv6_recvmsg */
+/* This is a key/value store with the keys being a pid
+ * and the values being a udp_recv_sock_t
+ */
+struct bpf_map_def SEC("maps/udpv6_recv_sock") udpv6_recv_sock = {
+    .type = BPF_MAP_TYPE_HASH,
+    .key_size = sizeof(__u64),
+    .value_size = sizeof(udp_recv_sock_t),
+    .max_entries = 1024,
+    .pinning = 0,
+    .namespace = "",
+};
+
 /* This maps tracks listening TCP ports. Entries are added to the map via tracing the inet_csk_accept syscall.  The
  * key in the map is the network namespace inode together with the port and the value is a flag that
  * indicates if the port is listening or not. When the socket is destroyed (via tcp_v4_destroy_sock), we set the

--- a/pkg/network/ebpf/c/tracer-telemetry.h
+++ b/pkg/network/ebpf/c/tracer-telemetry.h
@@ -44,7 +44,7 @@ static __always_inline void increment_telemetry_count(enum telemetry_counter cou
     }
 }
 
-static __always_inline void sockaddr_to_addr(struct sockaddr *sa, u64 *addr_h, u64 *addr_l, u16 *port) {
+static __always_inline void sockaddr_to_addr(struct sockaddr *sa, u64 *addr_h, u64 *addr_l, u16 *port, u32 *metadata) {
     if (!sa) {
         return;
     }
@@ -56,6 +56,7 @@ static __always_inline void sockaddr_to_addr(struct sockaddr *sa, u64 *addr_h, u
     struct sockaddr_in6 *sin6;
     switch (family) {
     case AF_INET:
+        *metadata |= CONN_V4;
         sin = (struct sockaddr_in *)sa;
         if (addr_l) {
             bpf_probe_read(addr_l, sizeof(__be32), &(sin->sin_addr.s_addr));
@@ -66,6 +67,7 @@ static __always_inline void sockaddr_to_addr(struct sockaddr *sa, u64 *addr_h, u
         }
         break;
     case AF_INET6:
+        *metadata |= CONN_V6;
         sin6 = (struct sockaddr_in6 *)sa;
         if (addr_l && addr_h) {
             bpf_probe_read(addr_h, sizeof(u64), sin6->sin6_addr.s6_addr);
@@ -76,6 +78,8 @@ static __always_inline void sockaddr_to_addr(struct sockaddr *sa, u64 *addr_h, u
             *port = bpf_ntohs(*port);
         }
         break;
+    default:
+        log_debug("ERR(sockaddr_to_addr): invalid family: %u\n", family);
     }
 }
 

--- a/pkg/network/ebpf/probes/probes.go
+++ b/pkg/network/ebpf/probes/probes.go
@@ -64,6 +64,13 @@ const (
 	// UDPRecvMsgReturn traces the return value for the udp_recvmsg() system call
 	UDPRecvMsgReturn ProbeName = "kretprobe/udp_recvmsg"
 
+	// UDPv6RecvMsg traces the udpv6_recvmsg() system call
+	UDPv6RecvMsg ProbeName = "kprobe/udpv6_recvmsg"
+	// UDPv6RecvMsgPre410 traces the udpv6_recvmsg() system call on kernels prior to 4.1.0
+	UDPv6RecvMsgPre410 ProbeName = "kprobe/udpv6_recvmsg/pre_4_1_0"
+	// UDPv6RecvMsgReturn traces the return value for the udpv6_recvmsg() system call
+	UDPv6RecvMsgReturn ProbeName = "kretprobe/udpv6_recvmsg"
+
 	// UDPDestroySock traces the udp_destroy_sock() function
 	UDPDestroySock ProbeName = "kprobe/udp_destroy_sock"
 	// UDPDestroySockrReturn traces the return of the udp_destroy_sock() system call

--- a/pkg/network/tracer/connection/kprobe/config.go
+++ b/pkg/network/tracer/connection/kprobe/config.go
@@ -32,30 +32,22 @@ func enableProbe(enabled map[probes.ProbeName]string, name probes.ProbeName) {
 func enabledProbes(c *config.Config, runtimeTracer bool) (map[probes.ProbeName]string, error) {
 	enabled := make(map[probes.ProbeName]string, 0)
 
+	kv410 := kernel.VersionCode(4, 1, 0)
+	kv470 := kernel.VersionCode(4, 7, 0)
 	kv, err := kernel.HostVersion()
 	if err != nil {
 		return nil, err
 	}
-	pre410Kernel := kv < kernel.VersionCode(4, 1, 0)
 
 	if c.CollectTCPConns {
-		if !runtimeTracer && pre410Kernel {
-			enableProbe(enabled, probes.TCPSendMsgPre410)
-		} else {
-			enableProbe(enabled, probes.TCPSendMsg)
-		}
+		enableProbe(enabled, selectVersionBasedProbe(runtimeTracer, kv, probes.TCPSendMsg, probes.TCPSendMsgPre410, kv410))
 		enableProbe(enabled, probes.TCPCleanupRBuf)
 		enableProbe(enabled, probes.TCPClose)
 		enableProbe(enabled, probes.TCPCloseReturn)
 		enableProbe(enabled, probes.InetCskAcceptReturn)
 		enableProbe(enabled, probes.InetCskListenStop)
 		enableProbe(enabled, probes.TCPSetState)
-
-		if !runtimeTracer && kv < kernel.VersionCode(4, 7, 0) {
-			enableProbe(enabled, probes.TCPRetransmitPre470)
-		} else {
-			enableProbe(enabled, probes.TCPRetransmit)
-		}
+		enableProbe(enabled, selectVersionBasedProbe(runtimeTracer, kv, probes.TCPRetransmit, probes.TCPRetransmitPre470, kv470))
 
 		missing, err := ebpf.VerifyKernelFuncs(filepath.Join(c.ProcRoot, "kallsyms"), []string{"sockfd_lookup_light"})
 		if err == nil && len(missing) == 0 {
@@ -67,30 +59,32 @@ func enabledProbes(c *config.Config, runtimeTracer bool) (map[probes.ProbeName]s
 	}
 
 	if c.CollectUDPConns {
-		enableProbe(enabled, probes.UDPRecvMsgReturn)
 		enableProbe(enabled, probes.UDPDestroySock)
 		enableProbe(enabled, probes.UDPDestroySockReturn)
 		enableProbe(enabled, probes.IPMakeSkb)
 		enableProbe(enabled, probes.InetBind)
 		enableProbe(enabled, probes.InetBindRet)
+		enableProbe(enabled, selectVersionBasedProbe(runtimeTracer, kv, probes.UDPRecvMsg, probes.UDPv6RecvMsgPre410, kv410))
+		enableProbe(enabled, probes.UDPRecvMsgReturn)
 
 		if c.CollectIPv6Conns {
-			if !runtimeTracer && kv < kernel.VersionCode(4, 7, 0) {
-				enableProbe(enabled, probes.IP6MakeSkbPre470)
-			} else {
-				enableProbe(enabled, probes.IP6MakeSkb)
-			}
-
+			enableProbe(enabled, selectVersionBasedProbe(runtimeTracer, kv, probes.IP6MakeSkb, probes.IP6MakeSkbPre470, kv470))
 			enableProbe(enabled, probes.Inet6Bind)
 			enableProbe(enabled, probes.Inet6BindRet)
-		}
-
-		if !runtimeTracer && pre410Kernel {
-			enableProbe(enabled, probes.UDPRecvMsgPre410)
-		} else {
-			enableProbe(enabled, probes.UDPRecvMsg)
+			enableProbe(enabled, selectVersionBasedProbe(runtimeTracer, kv, probes.UDPv6RecvMsg, probes.UDPv6RecvMsgPre410, kv410))
+			enableProbe(enabled, probes.UDPv6RecvMsgReturn)
 		}
 	}
 
 	return enabled, nil
+}
+
+func selectVersionBasedProbe(runtimeTracer bool, kv kernel.Version, dfault probes.ProbeName, versioned probes.ProbeName, reqVer kernel.Version) probes.ProbeName {
+	if runtimeTracer {
+		return dfault
+	}
+	if kv < reqVer {
+		return versioned
+	}
+	return dfault
 }

--- a/pkg/network/tracer/connection/kprobe/dump.go
+++ b/pkg/network/tracer/connection/kprobe/dump.go
@@ -124,6 +124,15 @@ func dumpMapsHandler(manager *manager.Manager, mapName string, currentMap *ebpf.
 			output.WriteString(spew.Sdump(key, value))
 		}
 
+	case "udpv6_recv_sock": // maps/udpv6_recv_sock (BPF_MAP_TYPE_HASH), key C.__u64, value C.udp_recv_sock_t
+		output.WriteString("Map: '" + mapName + "', key: 'C.__u64', value: 'C.udp_recv_sock_t'\n")
+		iter := currentMap.Iterate()
+		var key uint64
+		var value ddebpf.UDPRecvSock
+		for iter.Next(unsafe.Pointer(&key), unsafe.Pointer(&value)) {
+			output.WriteString(spew.Sdump(key, value))
+		}
+
 	case string(probes.PortBindingsMap): // maps/port_bindings (BPF_MAP_TYPE_HASH), key portBindingTuple, value C.__u8
 		output.WriteString("Map: '" + mapName + "', key: 'portBindingTuple', value: 'C.__u8'\n")
 		iter := currentMap.Iterate()

--- a/pkg/network/tracer/connection/kprobe/manager.go
+++ b/pkg/network/tracer/connection/kprobe/manager.go
@@ -33,6 +33,8 @@ var mainProbes = map[probes.ProbeName]string{
 	probes.IP6MakeSkb:           "kprobe__ip6_make_skb",
 	probes.UDPRecvMsg:           "kprobe__udp_recvmsg",
 	probes.UDPRecvMsgReturn:     "kretprobe__udp_recvmsg",
+	probes.UDPv6RecvMsg:         "kprobe__udpv6_recvmsg",
+	probes.UDPv6RecvMsgReturn:   "kretprobe__udpv6_recvmsg",
 	probes.TCPRetransmit:        "kprobe__tcp_retransmit_skb",
 	probes.InetCskAcceptReturn:  "kretprobe__inet_csk_accept",
 	probes.InetCskListenStop:    "kprobe__inet_csk_listen_stop",
@@ -52,6 +54,7 @@ var altProbes = map[probes.ProbeName]string{
 	probes.TCPRetransmitPre470: "kprobe__tcp_retransmit_skb_pre_4_7_0",
 	probes.IP6MakeSkbPre470:    "kprobe__ip6_make_skb__pre_4_7_0",
 	probes.UDPRecvMsgPre410:    "kprobe__udp_recvmsg_pre_4_1_0",
+	probes.UDPv6RecvMsgPre410:  "kprobe__udpv6_recvmsg_pre_4_1_0",
 	probes.TCPSendMsgPre410:    "kprobe__tcp_sendmsg__pre_4_1_0",
 }
 
@@ -62,6 +65,7 @@ func newManager(closedHandler *ebpf.PerfHandler, runtimeTracer bool) *manager.Ma
 			{Name: string(probes.TcpStatsMap)},
 			{Name: string(probes.ConnCloseBatchMap)},
 			{Name: "udp_recv_sock"},
+			{Name: "udpv6_recv_sock"},
 			{Name: string(probes.PortBindingsMap)},
 			{Name: string(probes.UdpPortBindingsMap)},
 			{Name: "pending_bind"},
@@ -105,6 +109,7 @@ func newManager(closedHandler *ebpf.PerfHandler, runtimeTracer bool) *manager.Ma
 			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.TCPRetransmitPre470), EBPFFuncName: "kprobe__tcp_retransmit_skb_pre_4_7_0"}, MatchFuncName: "^tcp_retransmit_skb$"},
 			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.IP6MakeSkbPre470), EBPFFuncName: "kprobe__ip6_make_skb__pre_4_7_0"}, MatchFuncName: "^ip6_make_skb$"},
 			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.UDPRecvMsgPre410), EBPFFuncName: "kprobe__udp_recvmsg_pre_4_1_0"}, MatchFuncName: "^udp_recvmsg$"},
+			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.UDPv6RecvMsgPre410), EBPFFuncName: "kprobe__udpv6_recvmsg_pre_4_1_0"}, MatchFuncName: "^udpv6_recvmsg$"},
 			&manager.Probe{ProbeIdentificationPair: manager.ProbeIdentificationPair{EBPFSection: string(probes.TCPSendMsgPre410), EBPFFuncName: "kprobe__tcp_sendmsg__pre_4_1_0"}, MatchFuncName: "^tcp_sendmsg$"},
 		)
 	}

--- a/pkg/network/tracer/tracer_linux_test.go
+++ b/pkg/network/tracer/tracer_linux_test.go
@@ -882,9 +882,11 @@ func TestConnectionAssured(t *testing.T) {
 	// register test as client
 	getConnections(t, tr)
 
-	server := NewUDPServer(func(b []byte, n int) []byte {
-		return genPayload(serverMessageSize)
-	})
+	server := &UDPServer{
+		onMessage: func(b []byte, n int) []byte {
+			return genPayload(serverMessageSize)
+		},
+	}
 
 	done := make(chan struct{})
 	err = server.Run(done, clientMessageSize)
@@ -927,9 +929,11 @@ func TestConnectionNotAssured(t *testing.T) {
 	// register test as client
 	getConnections(t, tr)
 
-	server := NewUDPServer(func(b []byte, n int) []byte {
-		return nil
-	})
+	server := &UDPServer{
+		onMessage: func(b []byte, n int) []byte {
+			return nil
+		},
+	}
 
 	done := make(chan struct{})
 	err = server.Run(done, clientMessageSize)

--- a/pkg/network/tracer/tracer_test.go
+++ b/pkg/network/tracer/tracer_test.go
@@ -432,22 +432,31 @@ func TestTCPCollectionDisabled(t *testing.T) {
 }
 
 func TestUDPSendAndReceive(t *testing.T) {
-	// incoming.MonotonicSentBytes is 0, when it should be 512
+	t.Run("v4", func(t *testing.T) {
+		testUDPSendAndReceive(t, "127.0.0.1:8001")
+	})
+	t.Run("v6", func(t *testing.T) {
+		testUDPSendAndReceive(t, "[::1]:8001")
+	})
+}
 
-	// Enable BPF-based system probe
+func testUDPSendAndReceive(t *testing.T, addr string) {
 	cfg := testConfig()
 	tr, err := NewTracer(cfg)
 	require.NoError(t, err)
-	defer tr.Stop()
+	t.Cleanup(tr.Stop)
 
-	server := NewUDPServerOnAddress("127.0.0.1:8001", func(buf []byte, n int) []byte {
-		return genPayload(serverMessageSize)
-	})
+	server := &UDPServer{
+		address: addr,
+		onMessage: func(buf []byte, n int) []byte {
+			return genPayload(serverMessageSize)
+		},
+	}
 
 	doneChan := make(chan struct{})
 	err = server.Run(doneChan, clientMessageSize)
 	require.NoError(t, err)
-	defer close(doneChan)
+	t.Cleanup(func() { close(doneChan) })
 
 	// Connect to server
 	c, err := net.DialTimeout("udp", server.address, 50*time.Millisecond)
@@ -465,21 +474,23 @@ func TestUDPSendAndReceive(t *testing.T) {
 	connections := getConnections(t, tr)
 
 	incoming, ok := findConnection(c.RemoteAddr(), c.LocalAddr(), connections)
-	require.True(t, ok)
-	require.Equal(t, network.INCOMING, incoming.Direction)
+	if assert.True(t, ok, "unable to find incoming connection") {
+		assert.Equal(t, network.INCOMING, incoming.Direction)
+
+		// make sure the inverse values are seen for the other message
+		assert.Equal(t, serverMessageSize, int(incoming.MonotonicSentBytes), "incoming sent")
+		assert.Equal(t, clientMessageSize, int(incoming.MonotonicRecvBytes), "incoming recv")
+		assert.True(t, incoming.IntraHost, "incoming intrahost")
+	}
 
 	outgoing, ok := findConnection(c.LocalAddr(), c.RemoteAddr(), connections)
-	require.True(t, ok)
-	require.Equal(t, network.OUTGOING, outgoing.Direction)
+	if assert.True(t, ok, "unable to find outgoing connection") {
+		assert.Equal(t, network.OUTGOING, outgoing.Direction)
 
-	require.Equal(t, clientMessageSize, int(outgoing.MonotonicSentBytes))
-	require.Equal(t, serverMessageSize, int(outgoing.MonotonicRecvBytes))
-	require.True(t, outgoing.IntraHost)
-
-	// make sure the inverse values are seen for the other message
-	require.Equal(t, serverMessageSize, int(incoming.MonotonicSentBytes))
-	require.Equal(t, clientMessageSize, int(incoming.MonotonicRecvBytes))
-	require.True(t, incoming.IntraHost)
+		assert.Equal(t, clientMessageSize, int(outgoing.MonotonicSentBytes), "outgoing sent")
+		assert.Equal(t, serverMessageSize, int(outgoing.MonotonicRecvBytes), "outgoing recv")
+		assert.True(t, outgoing.IntraHost, "outgoing intrahost")
+	}
 }
 
 func TestUDPDisabled(t *testing.T) {
@@ -494,9 +505,11 @@ func TestUDPDisabled(t *testing.T) {
 	defer tr.Stop()
 
 	// Create UDP Server which sends back serverMessageSize bytes
-	server := NewUDPServer(func(b []byte, n int) []byte {
-		return genPayload(serverMessageSize)
-	})
+	server := &UDPServer{
+		onMessage: func(b []byte, n int) []byte {
+			return genPayload(serverMessageSize)
+		},
+	}
 
 	doneChan := make(chan struct{})
 	err = server.Run(doneChan, clientMessageSize)
@@ -748,7 +761,7 @@ func benchEchoUDP(size int) func(b *testing.B) {
 
 	return func(b *testing.B) {
 		end := make(chan struct{})
-		server := NewUDPServer(echoOnMessage)
+		server := &UDPServer{onMessage: echoOnMessage}
 		err := server.Run(end, size)
 		require.NoError(b, err)
 		defer close(end)
@@ -920,23 +933,18 @@ func (s *TCPServer) Run(done chan struct{}) error {
 }
 
 type UDPServer struct {
+	network   string
 	address   string
 	onMessage func(b []byte, n int) []byte
 }
 
-func NewUDPServer(onMessage func(b []byte, n int) []byte) *UDPServer {
-	return NewUDPServerOnAddress("127.0.0.1:0", onMessage)
-}
-
-func NewUDPServerOnAddress(addr string, onMessage func(b []byte, n int) []byte) *UDPServer {
-	return &UDPServer{
-		address:   addr,
-		onMessage: onMessage,
-	}
-}
-
 func (s *UDPServer) Run(done chan struct{}, payloadSize int) error {
-	ln, err := net.ListenPacket("udp", s.address)
+	network := "udp"
+	if s.network != "" {
+		network = s.network
+	}
+
+	ln, err := net.ListenPacket(network, s.address)
 	if err != nil {
 		return err
 	}

--- a/releasenotes/notes/npm-udpv6-receive-1a62cf8b6080b7c6.yaml
+++ b/releasenotes/notes/npm-udpv6-receive-1a62cf8b6080b7c6.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Add missing support for UDPv6 receive path to NPM


### PR DESCRIPTION
### What does this PR do?

Add support for UDPv6 receives

### Motivation

We will completely missing the receive path for UDPv6 before.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
