### PR TITLE
[Process Agent] Remove `AgentConfig.Enabled`

### DIFF
--- a/cmd/process-agent/collector_api_test.go
+++ b/cmd/process-agent/collector_api_test.go
@@ -38,7 +38,7 @@ func TestSendConnectionsMessage(t *testing.T) {
 		data: [][]process.MessageBody{{m}},
 	}
 
-	runCollectorTest(t, check, config.NewDefaultAgentConfig(false), &endpointConfig{}, func(cfg *config.AgentConfig, ep *mockEndpoint) {
+	runCollectorTest(t, check, config.NewDefaultAgentConfig(), &endpointConfig{}, func(cfg *config.AgentConfig, ep *mockEndpoint) {
 		req := <-ep.Requests
 
 		assert.Equal(t, "/api/v1/collector", req.uri)
@@ -71,7 +71,7 @@ func TestSendContainerMessage(t *testing.T) {
 		data: [][]process.MessageBody{{m}},
 	}
 
-	runCollectorTest(t, check, config.NewDefaultAgentConfig(false), &endpointConfig{}, func(cfg *config.AgentConfig, ep *mockEndpoint) {
+	runCollectorTest(t, check, config.NewDefaultAgentConfig(), &endpointConfig{}, func(cfg *config.AgentConfig, ep *mockEndpoint) {
 		req := <-ep.Requests
 
 		assert.Equal(t, "/api/v1/container", req.uri)
@@ -102,7 +102,7 @@ func TestSendProcMessage(t *testing.T) {
 		data: [][]process.MessageBody{{m}},
 	}
 
-	runCollectorTest(t, check, config.NewDefaultAgentConfig(false), &endpointConfig{}, func(cfg *config.AgentConfig, ep *mockEndpoint) {
+	runCollectorTest(t, check, config.NewDefaultAgentConfig(), &endpointConfig{}, func(cfg *config.AgentConfig, ep *mockEndpoint) {
 		req := <-ep.Requests
 
 		assert.Equal(t, "/api/v1/collector", req.uri)
@@ -136,7 +136,7 @@ func TestSendProcessDiscoveryMessage(t *testing.T) {
 		data: [][]process.MessageBody{{m}},
 	}
 
-	runCollectorTest(t, check, config.NewDefaultAgentConfig(false), &endpointConfig{}, func(cfg *config.AgentConfig, ep *mockEndpoint) {
+	runCollectorTest(t, check, config.NewDefaultAgentConfig(), &endpointConfig{}, func(cfg *config.AgentConfig, ep *mockEndpoint) {
 		req := <-ep.Requests
 
 		assert.Equal(t, "/api/v1/discovery", req.uri)
@@ -170,7 +170,7 @@ func TestSendProcMessageWithRetry(t *testing.T) {
 		data: [][]process.MessageBody{{m}},
 	}
 
-	runCollectorTest(t, check, config.NewDefaultAgentConfig(false), &endpointConfig{ErrorCount: 1}, func(cfg *config.AgentConfig, ep *mockEndpoint) {
+	runCollectorTest(t, check, config.NewDefaultAgentConfig(), &endpointConfig{ErrorCount: 1}, func(cfg *config.AgentConfig, ep *mockEndpoint) {
 		requests := []request{
 			<-ep.Requests,
 			<-ep.Requests,
@@ -207,7 +207,7 @@ func TestRTProcMessageNotRetried(t *testing.T) {
 		data: [][]process.MessageBody{{m}},
 	}
 
-	runCollectorTest(t, check, config.NewDefaultAgentConfig(false), &endpointConfig{ErrorCount: 1}, func(cfg *config.AgentConfig, ep *mockEndpoint) {
+	runCollectorTest(t, check, config.NewDefaultAgentConfig(), &endpointConfig{ErrorCount: 1}, func(cfg *config.AgentConfig, ep *mockEndpoint) {
 		req := <-ep.Requests
 
 		reqBody, err := process.DecodeMessage(req.body)
@@ -230,7 +230,7 @@ func TestRTProcMessageNotRetried(t *testing.T) {
 func TestSendPodMessage(t *testing.T) {
 	clusterID := "d801b2b1-4811-11ea-8618-121d4d0938a3"
 
-	cfg := config.NewDefaultAgentConfig(false)
+	cfg := config.NewDefaultAgentConfig()
 	cfg.Orchestrator.OrchestrationCollectionEnabled = true
 
 	orig := os.Getenv("DD_ORCHESTRATOR_CLUSTER_ID")
@@ -280,7 +280,7 @@ func TestQueueSpaceNotAvailable(t *testing.T) {
 		data: [][]process.MessageBody{{m}},
 	}
 
-	cfg := config.NewDefaultAgentConfig(false)
+	cfg := config.NewDefaultAgentConfig()
 	cfg.ProcessQueueBytes = 1
 
 	runCollectorTest(t, check, cfg, &endpointConfig{ErrorCount: 1}, func(cfg *config.AgentConfig, ep *mockEndpoint) {
@@ -310,7 +310,7 @@ func TestQueueSpaceReleased(t *testing.T) {
 		data: [][]process.MessageBody{{m1}, {m2}},
 	}
 
-	cfg := config.NewDefaultAgentConfig(false)
+	cfg := config.NewDefaultAgentConfig()
 	cfg.ProcessQueueBytes = 50 // This should be enough for one message, but not both if the space isn't released
 
 	runCollectorTest(t, check, cfg, &endpointConfig{ErrorCount: 1}, func(cfg *config.AgentConfig, ep *mockEndpoint) {
@@ -347,7 +347,7 @@ func TestMultipleAPIKeys(t *testing.T) {
 		data: [][]process.MessageBody{{m}},
 	}
 
-	cfg := config.NewDefaultAgentConfig(false)
+	cfg := config.NewDefaultAgentConfig()
 	apiKeys := []string{"apiKeyI", "apiKeyII", "apiKeyIII"}
 	orchKeys := []string{"orchKey"}
 

--- a/cmd/process-agent/collector_test.go
+++ b/cmd/process-agent/collector_test.go
@@ -19,7 +19,7 @@ import (
 
 func TestUpdateRTStatus(t *testing.T) {
 	assert := assert.New(t)
-	cfg := config.NewDefaultAgentConfig(false)
+	cfg := config.NewDefaultAgentConfig()
 	c, err := NewCollector(cfg)
 	assert.NoError(err)
 	// XXX: Give the collector a big channel so it never blocks.
@@ -55,7 +55,7 @@ func TestUpdateRTStatus(t *testing.T) {
 
 func TestUpdateRTInterval(t *testing.T) {
 	assert := assert.New(t)
-	cfg := config.NewDefaultAgentConfig(false)
+	cfg := config.NewDefaultAgentConfig()
 	c, err := NewCollector(cfg)
 	assert.NoError(err)
 	// XXX: Give the collector a big channel so it never blocks.
@@ -121,7 +121,7 @@ func TestDisableRealTime(t *testing.T) {
 	}
 
 	assert := assert.New(t)
-	cfg := config.NewDefaultAgentConfig(false)
+	cfg := config.NewDefaultAgentConfig()
 	cfg.EnabledChecks = []string{
 		config.ProcessCheckName,
 		config.RTProcessCheckName,

--- a/cmd/process-agent/info_test.go
+++ b/cmd/process-agent/info_test.go
@@ -88,7 +88,7 @@ func testServer(t *testing.T) *httptest.Server {
 
 func TestInfo(t *testing.T) {
 	assert := assert.New(t)
-	conf := config.NewDefaultAgentConfig(false)
+	conf := config.NewDefaultAgentConfig()
 	server := testServer(t)
 	assert.NotNil(server)
 	defer server.Close()
@@ -105,7 +105,7 @@ func TestInfo(t *testing.T) {
 
 func TestNotRunning(t *testing.T) {
 	assert := assert.New(t)
-	conf := config.NewDefaultAgentConfig(false)
+	conf := config.NewDefaultAgentConfig()
 	server := testServer(t)
 	assert.NotNil(server)
 	defer server.Close()
@@ -132,7 +132,7 @@ func TestNotRunning(t *testing.T) {
 
 func TestError(t *testing.T) {
 	assert := assert.New(t)
-	conf := config.NewDefaultAgentConfig(false)
+	conf := config.NewDefaultAgentConfig()
 	server := testServer(t)
 	assert.NotNil(server)
 	defer server.Close()

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -254,7 +254,7 @@ func runAgent(exit chan struct{}) {
 	}
 
 	// Exit if agent is not enabled and we're not debugging a check.
-	if !cfg.Enabled && opts.check == "" {
+	if len(cfg.EnabledChecks) == 0 && opts.check == "" {
 		log.Infof(agent6DisabledMessage)
 
 		// a sleep is necessary to ensure that supervisor registers this process as "STARTED"

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -80,13 +80,13 @@ var (
 func getSettingsClient(_ *cobra.Command, _ []string) (settings.Client, error) {
 	// Set up the config so we can get the port later
 	// We set this up differently from the main process-agent because this way is quieter
-	cfg := config.NewDefaultAgentConfig(false)
+	cfg := config.NewDefaultAgentConfig()
 	if opts.configPath != "" {
 		if err := config.LoadConfigIfExists(opts.configPath); err != nil {
 			return nil, err
 		}
 	}
-	err := cfg.LoadProcessYamlConfig(opts.configPath)
+	err := cfg.LoadProcessYamlConfig(opts.configPath, false)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/process/checks/net_test.go
+++ b/pkg/process/checks/net_test.go
@@ -51,7 +51,7 @@ func TestDNSNameEncoding(t *testing.T) {
 		"1.1.2.4": {Names: []string{"host4.domain.com"}},
 		"1.1.2.5": {Names: nil},
 	}
-	cfg := config.NewDefaultAgentConfig(false)
+	cfg := config.NewDefaultAgentConfig()
 	chunks := batchConnections(cfg, 0, p, dns, "nid", nil, nil, nil, nil, nil, nil)
 	assert.Equal(t, len(chunks), 1)
 
@@ -75,7 +75,7 @@ func TestDNSNameEncoding(t *testing.T) {
 }
 
 func TestNetworkConnectionBatching(t *testing.T) {
-	cfg := config.NewDefaultAgentConfig(false)
+	cfg := config.NewDefaultAgentConfig()
 
 	for i, tc := range []struct {
 		cur, last      []*model.Connection
@@ -155,7 +155,7 @@ func TestNetworkConnectionBatchingWithDNS(t *testing.T) {
 		"1.1.2.3": {Names: []string{"datacat.edu"}},
 	}
 
-	cfg := config.NewDefaultAgentConfig(false)
+	cfg := config.NewDefaultAgentConfig()
 	cfg.MaxConnsPerMessage = 1
 
 	chunks := batchConnections(cfg, 0, p, dns, "nid", nil, nil, nil, nil, nil, nil)
@@ -196,7 +196,7 @@ func TestBatchSimilarConnectionsTogether(t *testing.T) {
 	p[4].Raddr.Ip = "1.2.3.4"
 	p[5].Raddr.Ip = "1.3.4.5"
 
-	cfg := config.NewDefaultAgentConfig(false)
+	cfg := config.NewDefaultAgentConfig()
 	cfg.MaxConnsPerMessage = 2
 
 	chunks := batchConnections(cfg, 0, p, map[string]*model.DNSEntry{}, "nid", nil, nil, nil, nil, nil, nil)
@@ -281,7 +281,7 @@ func TestNetworkConnectionBatchingWithDomainsByQueryType(t *testing.T) {
 	}
 	dnsmap := map[string]*model.DNSEntry{}
 
-	cfg := config.NewDefaultAgentConfig(false)
+	cfg := config.NewDefaultAgentConfig()
 	cfg.MaxConnsPerMessage = 1
 
 	chunks := batchConnections(cfg, 0, conns, dnsmap, "nid", nil, nil, domains, nil, nil, nil)
@@ -400,7 +400,7 @@ func TestNetworkConnectionBatchingWithDomains(t *testing.T) {
 	}
 	dnsmap := map[string]*model.DNSEntry{}
 
-	cfg := config.NewDefaultAgentConfig(false)
+	cfg := config.NewDefaultAgentConfig()
 	cfg.MaxConnsPerMessage = 1
 
 	chunks := batchConnections(cfg, 0, conns, dnsmap, "nid", nil, nil, domains, nil, nil, nil)
@@ -510,7 +510,7 @@ func TestNetworkConnectionBatchingWithRoutes(t *testing.T) {
 	conns[6].RouteIdx = 3
 	conns[7].RouteIdx = 2
 
-	cfg := config.NewDefaultAgentConfig(false)
+	cfg := config.NewDefaultAgentConfig()
 	cfg.MaxConnsPerMessage = 4
 
 	chunks := batchConnections(cfg, 0, conns, nil, "nid", nil, nil, nil, routes, nil, nil)
@@ -579,7 +579,7 @@ func TestNetworkConnectionTags(t *testing.T) {
 	}
 	foundTags := []fakeConn{}
 
-	cfg := config.NewDefaultAgentConfig(false)
+	cfg := config.NewDefaultAgentConfig()
 	cfg.MaxConnsPerMessage = 4
 
 	chunks := batchConnections(cfg, 0, conns, nil, "nid", nil, nil, nil, nil, tags, nil)

--- a/pkg/process/checks/process_common_test.go
+++ b/pkg/process/checks/process_common_test.go
@@ -142,7 +142,7 @@ func TestProcessChunking(t *testing.T) {
 	containers := []*containers.Container{}
 	lastRun := time.Now().Add(-5 * time.Second)
 	syst1, syst2 := cpu.TimesStat{}, cpu.TimesStat{}
-	cfg := config.NewDefaultAgentConfig(false)
+	cfg := config.NewDefaultAgentConfig()
 
 	for i, tc := range []struct {
 		cur, last          []*procutil.Process

--- a/pkg/process/checks/process_nix_test.go
+++ b/pkg/process/checks/process_nix_test.go
@@ -43,7 +43,7 @@ func TestBasicProcessMessages(t *testing.T) {
 	c[1].Pids = []int32{3}
 	lastRun := time.Now().Add(-5 * time.Second)
 	syst1, syst2 := cpu.TimesStat{}, cpu.TimesStat{}
-	cfg := config.NewDefaultAgentConfig(false)
+	cfg := config.NewDefaultAgentConfig()
 	sysInfo := &model.SystemInfo{}
 	lastCtrRates := util.ExtractContainerRateMetric(c)
 
@@ -325,7 +325,7 @@ func TestContainerProcessChunking(t *testing.T) {
 
 			lastRun := time.Now().Add(-5 * time.Second)
 			syst1, syst2 := cpu.TimesStat{}, cpu.TimesStat{}
-			cfg := config.NewDefaultAgentConfig(false)
+			cfg := config.NewDefaultAgentConfig()
 			sysInfo := &model.SystemInfo{}
 			lastCtrRates := util.ExtractContainerRateMetric(ctrs)
 			cfg.MaxPerMessage = tc.maxSize

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -170,16 +170,11 @@ func NewDefaultTransport() *http.Transport {
 }
 
 // NewDefaultAgentConfig returns an AgentConfig with defaults initialized
-func NewDefaultAgentConfig(canAccessContainers bool) *AgentConfig {
+func NewDefaultAgentConfig() *AgentConfig {
 	processEndpoint, err := url.Parse(defaultProcessEndpoint)
 	if err != nil {
 		// This is a hardcoded URL so parsing it should not fail
 		panic(err)
-	}
-
-	var enabledChecks []string
-	if canAccessContainers {
-		enabledChecks = containerChecks
 	}
 
 	ac := &AgentConfig{
@@ -208,7 +203,7 @@ func NewDefaultAgentConfig(canAccessContainers bool) *AgentConfig {
 		Orchestrator: oconfig.NewDefaultOrchestratorConfig(),
 
 		// Check config
-		EnabledChecks: enabledChecks,
+		EnabledChecks: nil,
 		CheckIntervals: map[string]time.Duration{
 			ProcessCheckName:     ProcessCheckDefaultInterval,
 			RTProcessCheckName:   RTProcessCheckDefaultInterval,
@@ -270,9 +265,9 @@ func LoadConfigIfExists(path string) error {
 func NewAgentConfig(loggerName config.LoggerName, yamlPath string, syscfg *sysconfig.Config, canAccessContainers bool) (*AgentConfig, error) {
 	var err error
 
-	cfg := NewDefaultAgentConfig(canAccessContainers)
+	cfg := NewDefaultAgentConfig()
 
-	if err := cfg.LoadProcessYamlConfig(yamlPath); err != nil {
+	if err := cfg.LoadProcessYamlConfig(yamlPath, canAccessContainers); err != nil {
 		return nil, err
 	}
 

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -95,7 +95,6 @@ type WindowsConfig struct {
 //
 // Deprecated. Use `pkg/config` directly.
 type AgentConfig struct {
-	Enabled                   bool
 	HostName                  string
 	APIEndpoints              []apicfg.Endpoint
 	QueueSize                 int // The number of items allowed in each delivery queue.
@@ -184,7 +183,6 @@ func NewDefaultAgentConfig(canAccessContainers bool) *AgentConfig {
 	}
 
 	ac := &AgentConfig{
-		Enabled:      canAccessContainers, // We'll always run inside of a container.
 		APIEndpoints: []apicfg.Endpoint{{Endpoint: processEndpoint}},
 
 		// Allow buffering up to 60 megabytes of payload data in total
@@ -299,11 +297,6 @@ func NewAgentConfig(loggerName config.LoggerName, yamlPath string, syscfg *sysco
 			if checks, ok := moduleCheckMap[mod]; ok {
 				cfg.EnabledChecks = append(cfg.EnabledChecks, checks...)
 			}
-		}
-
-		if !cfg.Enabled {
-			log.Info("enabling process-agent for connections check as the system-probe is enabled")
-			cfg.Enabled = true
 		}
 	}
 

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -128,23 +128,9 @@ func TestOnlyEnvConfig(t *testing.T) {
 	// setting an API Key should be enough to generate valid config
 	os.Setenv("DD_API_KEY", "apikey_from_env")
 	defer os.Unsetenv("DD_API_KEY")
-	os.Setenv("DD_PROCESS_AGENT_ENABLED", "true")
-	defer os.Unsetenv("DD_PROCESS_AGENT_ENABLED")
 
 	agentConfig, _ := NewAgentConfig("test", "", syscfg, true)
 	assert.Equal(t, "apikey_from_env", agentConfig.APIEndpoints[0].APIKey)
-
-	os.Setenv("DD_PROCESS_AGENT_ENABLED", "false")
-	os.Setenv("DD_PROCESS_AGENT_PROCESS_DISCOVERY_ENABLED", "false")
-	_, _ = config.Load() // Deprecated environment variables won't have their transforms applied until the config is reloaded
-	agentConfig, _ = NewAgentConfig("test", "", syscfg, true)
-	assert.Equal(t, "apikey_from_env", agentConfig.APIEndpoints[0].APIKey)
-
-	os.Setenv("DD_PROCESS_AGENT_ENABLED", "false")
-	os.Setenv("DD_PROCESS_AGENT_PROCESS_DISCOVERY_ENABLED", "true")
-	agentConfig, _ = NewAgentConfig("test", "", syscfg, true)
-	assert.Equal(t, "apikey_from_env", agentConfig.APIEndpoints[0].APIKey)
-	// Process discovery enabled by default enables the process agent
 
 	os.Setenv("DD_PROCESS_AGENT_MAX_PER_MESSAGE", "99")
 	agentConfig, _ = NewAgentConfig("test", "", syscfg, true)

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -133,21 +133,18 @@ func TestOnlyEnvConfig(t *testing.T) {
 
 	agentConfig, _ := NewAgentConfig("test", "", syscfg, true)
 	assert.Equal(t, "apikey_from_env", agentConfig.APIEndpoints[0].APIKey)
-	assert.True(t, agentConfig.Enabled)
 
 	os.Setenv("DD_PROCESS_AGENT_ENABLED", "false")
 	os.Setenv("DD_PROCESS_AGENT_PROCESS_DISCOVERY_ENABLED", "false")
 	_, _ = config.Load() // Deprecated environment variables won't have their transforms applied until the config is reloaded
 	agentConfig, _ = NewAgentConfig("test", "", syscfg, true)
 	assert.Equal(t, "apikey_from_env", agentConfig.APIEndpoints[0].APIKey)
-	assert.False(t, agentConfig.Enabled)
 
 	os.Setenv("DD_PROCESS_AGENT_ENABLED", "false")
 	os.Setenv("DD_PROCESS_AGENT_PROCESS_DISCOVERY_ENABLED", "true")
 	agentConfig, _ = NewAgentConfig("test", "", syscfg, true)
 	assert.Equal(t, "apikey_from_env", agentConfig.APIEndpoints[0].APIKey)
 	// Process discovery enabled by default enables the process agent
-	assert.True(t, agentConfig.Enabled)
 
 	os.Setenv("DD_PROCESS_AGENT_MAX_PER_MESSAGE", "99")
 	agentConfig, _ = NewAgentConfig("test", "", syscfg, true)
@@ -335,7 +332,6 @@ func TestAgentConfigYamlAndSystemProbeConfig(t *testing.T) {
 	assert.Equal("apikey_20", ep.APIKey)
 	assert.Equal("my-process-app.datadoghq.com", ep.Endpoint.Hostname())
 	assert.Equal(10, agentConfig.QueueSize)
-	assert.Equal(true, agentConfig.Enabled)
 	assert.Equal(append(processChecks), agentConfig.EnabledChecks)
 	assert.Equal(8*time.Second, agentConfig.CheckIntervals[ContainerCheckName])
 	assert.Equal(30*time.Second, agentConfig.CheckIntervals[ProcessCheckName])
@@ -351,7 +347,6 @@ func TestAgentConfigYamlAndSystemProbeConfig(t *testing.T) {
 	assert.Equal("my-process-app.datadoghq.com", ep.Endpoint.Hostname())
 	assert.Equal("server-01", agentConfig.HostName)
 	assert.Equal(10, agentConfig.QueueSize)
-	assert.Equal(true, agentConfig.Enabled)
 	assert.Equal(8*time.Second, agentConfig.CheckIntervals[ContainerCheckName])
 	assert.Equal(30*time.Second, agentConfig.CheckIntervals[ProcessCheckName])
 	assert.Equal(100, agentConfig.Windows.ArgsRefreshInterval)
@@ -368,7 +363,6 @@ func TestAgentConfigYamlAndSystemProbeConfig(t *testing.T) {
 	assert.Equal("apikey_20", ep.APIKey)
 	assert.Equal("my-process-app.datadoghq.com", ep.Endpoint.Hostname())
 	assert.Equal(10, agentConfig.QueueSize)
-	assert.Equal(true, agentConfig.Enabled)
 	assert.Equal(8*time.Second, agentConfig.CheckIntervals[ContainerCheckName])
 	assert.Equal(30*time.Second, agentConfig.CheckIntervals[ProcessCheckName])
 	assert.Equal(100, agentConfig.Windows.ArgsRefreshInterval)
@@ -545,7 +539,6 @@ func TestNetworkConfig(t *testing.T) {
 		agentConfig := loadAgentConfigForTest(t, "./testdata/TestDDAgentConfigYamlOnly.yaml", "./testdata/TestDDAgentConfig-NetConfig.yaml")
 
 		assert.True(t, agentConfig.EnableSystemProbe)
-		assert.True(t, agentConfig.Enabled)
 		assert.ElementsMatch(t, []string{ConnectionsCheckName, NetworkCheckName, ProcessCheckName, RTProcessCheckName}, agentConfig.EnabledChecks)
 	})
 
@@ -562,7 +555,6 @@ func TestNetworkConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.True(t, agentConfig.EnableSystemProbe)
-		assert.True(t, agentConfig.Enabled)
 		assert.ElementsMatch(t, []string{ConnectionsCheckName, NetworkCheckName, ContainerCheckName, RTContainerCheckName, DiscoveryCheckName}, agentConfig.EnabledChecks)
 	})
 }
@@ -574,7 +566,6 @@ func TestSystemProbeNoNetwork(t *testing.T) {
 	agentConfig := loadAgentConfigForTest(t, "./testdata/TestDDAgentConfigYamlOnly.yaml", "./testdata/TestDDAgentConfig-OOMKillOnly.yaml")
 
 	assert.True(t, agentConfig.EnableSystemProbe)
-	assert.True(t, agentConfig.Enabled)
 	assert.ElementsMatch(t, []string{OOMKillCheckName, ProcessCheckName, RTProcessCheckName}, agentConfig.EnabledChecks)
 }
 

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -271,7 +271,7 @@ func TestOnlyEnvConfigLogLevelOverride(t *testing.T) {
 
 func TestGetHostname(t *testing.T) {
 	ctx := context.Background()
-	_ = NewDefaultAgentConfig(false)
+	_ = NewDefaultAgentConfig()
 	h, err := getHostname(ctx, config.Datadog.GetString("process_config.dd_agent_bin"), 0)
 	assert.Nil(t, err)
 	// verify we fall back to getting os hostname
@@ -281,14 +281,14 @@ func TestGetHostname(t *testing.T) {
 
 func TestDefaultConfig(t *testing.T) {
 	assert := assert.New(t)
-	agentConfig := NewDefaultAgentConfig(false)
+	agentConfig := NewDefaultAgentConfig()
 
 	// assert that some sane defaults are set
 	assert.Equal("info", config.Datadog.GetString("log_level"))
 	assert.Equal(true, agentConfig.Scrubber.Enabled)
 
 	os.Setenv("DOCKER_DD_AGENT", "yes")
-	agentConfig = NewDefaultAgentConfig(false)
+	agentConfig = NewDefaultAgentConfig()
 	assert.Equal(os.Getenv("HOST_PROC"), "")
 	assert.Equal(os.Getenv("HOST_SYS"), "")
 	os.Setenv("DOCKER_DD_AGENT", "no")

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -57,10 +57,10 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 	}
 
 	if config.Datadog.GetBool("process_config.process_collection.enabled") {
-		a.EnabledChecks = processChecks
+		a.EnabledChecks = append(a.EnabledChecks, processChecks...)
 	} else if config.Datadog.GetBool("process_config.container_collection.enabled") {
 		// Container checks are enabled only when process checks are not (since they automatically collect container data).
-		a.EnabledChecks = containerChecks
+		a.EnabledChecks = append(a.EnabledChecks, containerChecks...)
 	}
 	// The interval, in seconds, at which we will run each check. If you want consistent
 	// behavior between real-time you may set the Container/ProcessRT intervals to 10.

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -56,12 +56,11 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 		a.HostName = config.Datadog.GetString("hostname")
 	}
 
-	a.Enabled = false
 	if config.Datadog.GetBool("process_config.process_collection.enabled") {
-		a.Enabled, a.EnabledChecks = true, processChecks
+		a.EnabledChecks = processChecks
 	} else if config.Datadog.GetBool("process_config.container_collection.enabled") {
 		// Container checks are enabled only when process checks are not (since they automatically collect container data).
-		a.Enabled, a.EnabledChecks = true, containerChecks
+		a.EnabledChecks = containerChecks
 	}
 	// The interval, in seconds, at which we will run each check. If you want consistent
 	// behavior between real-time you may set the Container/ProcessRT intervals to 10.
@@ -270,7 +269,6 @@ func (a *AgentConfig) initProcessDiscoveryCheck() {
 	discoveryCheckEnabled := config.Datadog.GetBool(key(root, "enabled"))
 	if discoveryCheckEnabled && !processCheckEnabled {
 		a.EnabledChecks = append(a.EnabledChecks, DiscoveryCheckName)
-		a.Enabled = true
 
 		// We don't need to check if the key exists since we already bound it to a default in InitConfig.
 		// We use a minimum of 10 minutes for this value.

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -34,7 +34,7 @@ func key(pieces ...string) string {
 }
 
 // LoadProcessYamlConfig load Process-specific configuration
-func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
+func (a *AgentConfig) LoadProcessYamlConfig(path string, canAccessContainers bool) error {
 	loadEnvVariables()
 
 	// Resolve any secrets
@@ -58,7 +58,7 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 
 	if config.Datadog.GetBool("process_config.process_collection.enabled") {
 		a.EnabledChecks = append(a.EnabledChecks, processChecks...)
-	} else if config.Datadog.GetBool("process_config.container_collection.enabled") {
+	} else if config.Datadog.GetBool("process_config.container_collection.enabled") && canAccessContainers {
 		// Container checks are enabled only when process checks are not (since they automatically collect container data).
 		a.EnabledChecks = append(a.EnabledChecks, containerChecks...)
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Removes `AgentConfig.Enabled`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
This PR is part of deprecating `AgentConfig` as part of the config refactor RFC

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This PR includes a fix for the container check being disabled if containers are unreachable.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Using this config file:
```yaml
process_config:
  process_collection:
    enabled: false
  container_collection:
    enabled: false
  process_discovery:
    enabled: false
```
Make sure that the process agent starts up and then exits with this message:
```
Set env var DD_PROCESS_CONFIG_PROCESS_COLLECTION_ENABLED=true or add
process_config:
  process_collection:
    enabled: true
to your datadog.yaml file.
```

Also, make sure that `process_config.enabled` still works as expected.

Additionally, make sure that container checks are disabled if containers are not available. Keep in mind to test this you will have to either use `inv process-agent.build` or build the process agent with `-tags "docker"`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
