### PR TITLE
[pkg/config] Set default value for `experimental.otlp.metrics.tag_cardinality`

### DIFF
--- a/pkg/config/otlp.go
+++ b/pkg/config/otlp.go
@@ -29,7 +29,7 @@ func SetupOTLP(config Config) {
 
 	// NOTE: This only partially works.
 	// The environment variable is also manually checked in pkg/otlp/config.go
-	config.BindEnv(ExperimentalOTLPTagCardinalityKey, "low", "DD_OTLP_TAG_CARDINALITY")
+	config.BindEnvAndSetDefault(ExperimentalOTLPTagCardinalityKey, "low", "DD_OTLP_TAG_CARDINALITY")
 
 	config.SetKnown(ExperimentalOTLPMetrics)
 	// Set all subkeys of experimental.otlp.metrics as known

--- a/pkg/config/otlp.go
+++ b/pkg/config/otlp.go
@@ -29,7 +29,7 @@ func SetupOTLP(config Config) {
 
 	// NOTE: This only partially works.
 	// The environment variable is also manually checked in pkg/otlp/config.go
-	config.BindEnv(ExperimentalOTLPTagCardinalityKey, "DD_OTLP_TAG_CARDINALITY")
+	config.BindEnv(ExperimentalOTLPTagCardinalityKey, "low", "DD_OTLP_TAG_CARDINALITY")
 
 	config.SetKnown(ExperimentalOTLPMetrics)
 	// Set all subkeys of experimental.otlp.metrics as known

--- a/pkg/otlp/config_test.go
+++ b/pkg/otlp/config_test.go
@@ -58,7 +58,7 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				MetricsEnabled:     true,
 				TracesEnabled:      true,
 				Metrics: map[string]interface{}{
-					"tag_cardinality": "",
+					"tag_cardinality": "low",
 				},
 			},
 		},
@@ -70,7 +70,7 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				MetricsEnabled:     true,
 				TracesEnabled:      true,
 				Metrics: map[string]interface{}{
-					"tag_cardinality": "",
+					"tag_cardinality": "low",
 				},
 			},
 		},
@@ -94,7 +94,7 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				MetricsEnabled:     true,
 				TracesEnabled:      true,
 				Metrics: map[string]interface{}{
-					"tag_cardinality": "",
+					"tag_cardinality": "low",
 				},
 			},
 		},
@@ -110,7 +110,7 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				MetricsEnabled:     true,
 				TracesEnabled:      true,
 				Metrics: map[string]interface{}{
-					"tag_cardinality": "",
+					"tag_cardinality": "low",
 				},
 			},
 		},
@@ -122,7 +122,7 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				MetricsEnabled:     true,
 				TracesEnabled:      true,
 				Metrics: map[string]interface{}{
-					"tag_cardinality": "",
+					"tag_cardinality": "low",
 				},
 			},
 		},
@@ -139,7 +139,7 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				MetricsEnabled: true,
 				TracesEnabled:  true,
 				Metrics: map[string]interface{}{
-					"tag_cardinality": "",
+					"tag_cardinality": "low",
 				},
 			},
 		},
@@ -171,7 +171,7 @@ func TestFromAgentConfigReceiver(t *testing.T) {
 				MetricsEnabled: true,
 				TracesEnabled:  true,
 				Metrics: map[string]interface{}{
-					"tag_cardinality": "",
+					"tag_cardinality": "low",
 				},
 			},
 		},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Set default value for `experimental.otlp.metrics.tag_cardinality` option to `low`. Before this PR, the default value is taken from the equivalent DogStatsD option.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

https://github.com/DataDog/datadog-agent/pull/10347#discussion_r788750181

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Set `dogstatsd_tag_cardinality` to `orchestrator` and check that `experimental.otlp.metrics.tag_cardinality` is set to `low`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
