### PR TITLE
pkg/trace: Fix missed priorities

### DIFF
--- a/pkg/trace/agent/normalizer.go
+++ b/pkg/trace/agent/normalizer.go
@@ -147,15 +147,17 @@ func normalize(ts *info.TagStats, s *pb.Span) error {
 // * populates Origin field if it wasn't populated
 // * populates Priority field if it wasn't populated
 func normalizeChunk(chunk *pb.TraceChunk, root *pb.Span) {
-	if chunk.Priority == int32(sampler.PriorityNone) && root.Metrics != nil {
+	// check if priority is already populated
+	if chunk.Priority == int32(sampler.PriorityNone) {
 		// Older tracers set sampling priority in the root span.
 		if p, ok := root.Metrics[tagSamplingPriority]; ok {
 			chunk.Priority = int32(p)
-		}
-		for _, s := range chunk.Spans {
-			if p, ok := s.Metrics[tagSamplingPriority]; ok {
-				chunk.Priority = int32(p)
-				break
+		} else {
+			for _, s := range chunk.Spans {
+				if p, ok := s.Metrics[tagSamplingPriority]; ok {
+					chunk.Priority = int32(p)
+					break
+				}
 			}
 		}
 	}

--- a/pkg/trace/agent/normalizer.go
+++ b/pkg/trace/agent/normalizer.go
@@ -152,6 +152,12 @@ func normalizeChunk(chunk *pb.TraceChunk, root *pb.Span) {
 		if p, ok := root.Metrics[tagSamplingPriority]; ok {
 			chunk.Priority = int32(p)
 		}
+		for _, s := range chunk.Spans {
+			if p, ok := s.Metrics[tagSamplingPriority]; ok {
+				chunk.Priority = int32(p)
+				break
+			}
+		}
 	}
 	if chunk.Origin == "" && root.Meta != nil {
 		// Older tracers set origin in the root span.

--- a/pkg/trace/agent/normalizer_test.go
+++ b/pkg/trace/agent/normalizer_test.go
@@ -493,6 +493,17 @@ func TestNormalizeChunkNotPopulatingSamplingPriority(t *testing.T) {
 	assert.EqualValues(sampler.PriorityAutoDrop, chunk.Priority)
 }
 
+func TestNormalizePopulatePriorityFromAnySpan(t *testing.T) {
+	assert := assert.New(t)
+	root := newTestSpan()
+	chunk := testutil.TraceChunkWithSpan(root)
+	chunk.Priority = int32(sampler.PriorityNone)
+	chunk.Spans = []*pb.Span{newTestSpan(), newTestSpan(), newTestSpan()}
+	traceutil.SetMetric(chunk.Spans[1], "_sampling_priority_v1", float64(sampler.PriorityAutoKeep))
+	normalizeChunk(chunk, root)
+	assert.EqualValues(sampler.PriorityAutoKeep, chunk.Priority)
+}
+
 func BenchmarkNormalization(b *testing.B) {
 	b.ReportAllocs()
 

--- a/pkg/trace/agent/normalizer_test.go
+++ b/pkg/trace/agent/normalizer_test.go
@@ -499,6 +499,8 @@ func TestNormalizePopulatePriorityFromAnySpan(t *testing.T) {
 	chunk := testutil.TraceChunkWithSpan(root)
 	chunk.Priority = int32(sampler.PriorityNone)
 	chunk.Spans = []*pb.Span{newTestSpan(), newTestSpan(), newTestSpan()}
+	chunk.Spans[0].Metrics = nil
+	chunk.Spans[2].Metrics = nil
 	traceutil.SetMetric(chunk.Spans[1], "_sampling_priority_v1", float64(sampler.PriorityAutoKeep))
 	normalizeChunk(chunk, root)
 	assert.EqualValues(sampler.PriorityAutoKeep, chunk.Priority)


### PR DESCRIPTION
Priority is picked from root span by default. In distributed pieces the root span might be missing and the GetRoot algorithm can pick a span for which no priority was set.
Some priority 0s with spans caught by the no_priority sampler are caught by the backend.

This PR ensures that if at least a span has a priority set, it's respected.