### PR TITLE
pkg/logs README update

### DIFF
--- a/pkg/logs/README.md
+++ b/pkg/logs/README.md
@@ -1,34 +1,157 @@
 # logs-agent
 
-logs-agent collects logs and submits them to datadog's infrastructure.
+The logs-agent collects logs and submits them to DataDog's infrastructure.
 
-## Structure
+## Agent Structure
 
-`logs` reads the config files, and instantiates what's needed.
-Each log line comes from a source (such as file, network, docker), and then enters one of the available _pipeline - tailer|listener|container -> decoder -> processor -> strategy -> sender -> destination -> auditor_
+There are two major "parts" of the logs agent: what to log, and the mechanics of logging.
 
-`Tailer` tails a file and submits data to the processors
+### What to Log (Schedulers and Launchers)
 
-`Listener` listens on local network (TCP, UDP, Unix) and submits data to the processors
-
-`Container` scans docker logs from stdout/stderr and submits data to the processors
-
-`Decoder` converts bytes arrays into messages
-
-`Processor` updates the messages, filtering, redacting, or adding metadata, and submits to the strategy.
-
-`Strategy` converts a stream of messages into a stream of encoded payloads, batching if needed.
-
-`Sender` submits the payloads to the destination(s).
-
-`Destination` sends the actual encoded content to the intake, retries if needed, and sends successful payloads to the auditor.
-
-`Auditor` notes that messages were properly submitted, and stores offsets for Agent restarts.
-
-## Tests
+The first part has an architecture like this:
 
 ```
-# Run the unit tests
-inv test --targets=./pkg/logs --timeout=10
+                          Autodiscovery
+                                │
+                                │integration.Config
+                                │
+                                ▼
+                          ┌────────────┐
+                          │ Scheduler  │
+                          └──┬──────┬──┘
+             config.LogSource│      │service.Service
+                             │      │
+                             ▼      ▼
+                     ┌─────────┐  ┌──────────┐
+            ┌────────┤ Sources │  │ Services │
+            ▼        └┬──┬─────┘  └─┬──────┬─┘
+      ┌───────────┐   │  │   ▲ ▲    │      │
+   ┌──┤ Launchers │   │  │   │ │    │      │
+   │  └───────────┘   │  │ ┌────────┘      │
+   │                  ▼  │ │ │ │           │
+   │  ┌────────────────┐ │ │ │ │           │
+   ├──┤ file.Scanner   │ │ │ │ │           │
+   │  └────────────────┘ │ │ │ │           │
+   │                     ▼ ▼ │ │           ▼
+   │  ┌─────────────────────┐│ │   ┌─────────────────────┐
+   ├──┤ docker.Launcher     ├┘ └───┤ kubernetes.Launcher │
+   │  └─────────────────────┘      └─────────────────────┘
+   │    ▲                            ▲
+   ▼    └──container labels          └──pod annotations
+tailers
+```
+
+#### Scheduling
+
+The Autodiscovery component (`pkg/autodiscovery`) provides a sequence of configs (`integration.Config`) to the logs *Scheduler*.
+The scheduler categorizes each config as either
+
+ * *Source* - an integration with LogsConfig that immediately provides a source of log messages to be handled.
+ * *Service* - a container
+
+These go into two separate stores of active sources and active services.
+The remaining components of the logs agent subscribe to these stores.
+
+#### Launchers
+
+Launchers are implemented in sub-packages of `pkg/input`.
+They are responsible for creating tailers, which contain pipelines -- see below.
+Each filters the sources, usually based on `source.Config.Type`, which comes from the `type` key in `logs_config` sections.
+
+Several Launchers are quite simple, translating sources into a tailers.
+For example:
+
+* The listener launcher creates a new tailer for each configured UDP port, or for each incoming connection on a configured TCP port.
+* The "traps" launcher (`pkg/input/traps`) creates a tailer that produces logs messages for each SNMP trap from the configured SNMP device(s).
+
+The launchers depicted separately in the diagram above have some additional behaviors.
+
+##### file.Scanner
+
+The file scanner acts as a launcher, but handles wild-card filenames and logfile rotation by creating multiple tailers for each source.
+
+##### docker.Launcher
+
+The Docker launcher consumes both sources and services from the scheduler.
+It reconciles these two streams to find matching sources and services, and only when both have arrived does it start a new tailer.
+
+When `logs_config.container_collect_all` is enabled, the launcher also starts a tailer for any docker container that does not have a corresponding source and which does not have autodiscovery-related labels.
+This functionality has some inherent race conditions.
+The logs-agent delays startup of the `container_collect_all` support until after autodiscovery has scanned its configuration sources once, so that all file-based source definitions are already in place when it begins handling services.
+
+The agent can use two mechanisms to capture log messages from a Docker container (configured with `logs_config.docker_container_use_file` and `logs_config.docker_container_force_use_file`):
+ * Docker API - the launcher creates a tailer which reads from the Docker API socket and sends messages into the logging pipeline.
+ * File - the launcher determines the on-disk filename of the container's logfile and creates a "child" `config.LogSource`  with `source.Config.Type = "file"`.
+   The file launcher receives this source from the sources store and tails the logfile.
+
+##### kubernetes.Launcher
+
+The Kubernetes launcher never produces tailers, and only subscribes to services.
+For each service (container) it finds, it determines which pod the container represents, and consults the annotations on that pod.
+It then generates a `"file"` source, similar to that produced by the Docker launcher, and adds it to the sources store.
+
+### Logging Messages (Tailers and Pipelines)
+
+The second portion of the logs agent looks like this:
 
 ```
+  ┌───────────────────┐
+┌►│      Tailer       │  ─┐
+│ └─────────┬─────────┘   │
+│           │             │ input
+│           ▼             │ (many)
+│ ┌───────────────────┐   │
+│ │      Decoder      │  ─┘
+│ └─────────┬─────────┘
+│           │
+│           ▼
+│ ┌───────────────────┐
+│ │     Processor     │  ─┐
+│ └─────────┬─────────┘   │
+│           │             │
+│           ▼             │
+│ ┌───────────────────┐   │
+│ │     Strategy      │   │
+│ └─────────┬─────────┘   │
+│           │             │ pipeline
+│           ▼             │ (few)
+│ ┌───────────────────┐   │
+│ │      Sender       │   │
+│ └─────────┬─────────┘   │
+│           │             │
+│           ▼             │
+│ ┌───────────────────┐   │
+│ │    Destination    │  ─┘
+│ └─────────┬──────┬──┘
+│           │      └────►DataDog
+│           ▼            Intake
+│ ┌───────────────────┐
+│ │      Auditor      │
+│ └─────────┬─────────┘
+└───────────┘
+```
+
+### Inputs
+
+Each input is composed of a tailer and (sometimes) a decoder, as created by the portion described above.
+One such input exists for each source of logs -- potentially many in a single agent.
+
+In many cases, an input consists only of a tailer, so inputs are sometimes referred to as tailers.
+
+### Pipelines
+
+Each input writes to a pipeline, consisting of a processor, strategy, sender, and destinations.
+There are a limited number of pipelines for an agent, to take advantage of CPU parallelism, and inputs are distributed evenly among those pipelines.
+Each pipeline handles messages in-order, so assigning each input to a single pipeline ensures that input's messages will be delivered to the intake in-order.
+
+The components of a pipeline are:
+
+* `Processor` updates the messages, filtering, redacting, or adding metadata, and submits to the strategy.
+* `Strategy` converts a stream of messages into a stream of encoded payloads, batching if needed.
+* `Sender` submits the payloads to the destination(s).
+* `Destination` sends the actual encoded content to the intake, retries if needed, and sends successful payloads to the auditor.
+
+### Auditor
+
+Finally, pipelines report successful message transmission to the auditor, which informs tailers.
+Some inputs use this information to track messages that have been delivered successfully, allowing them to continue re-transmitting unsuccessful messages after agent restart.


### PR DESCRIPTION
This updates the pkg/log README to better represent the structure of the logs agent, and in particular the "what to log" portion.

### Additional Notes

Please have a careful look and let me know if I've gotten anything wrong, or omitted important details.  The idea is that this is enough for a reader to begin navigating the code.  Later PRs will apply some renames and file moves to better represent this structure, and other PRs will undo some of the more puzzling bits, such as that the k8s launcher doesn't actually launch anything.

### Possible Drawbacks / Trade-offs

None :)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
