### PR TITLE
[network/ebpf] get sock fd from new syscall connect/accept (kernel >= 5.5.0)

### DIFF
--- a/pkg/network/ebpf/c/prebuilt/offset-guess.c
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.c
@@ -306,10 +306,10 @@ int kprobe__stream_open(struct pt_regs* ctx) {
         bpf_probe_read(&socket, sizeof(socket), file + status->offset_file_private);
         status->socket = socket;
 
-        log_debug("stream  %x %x %d\n", socket, SOCKET_I((struct inode*)inode), status->offset_socket_i);
+//        log_debug("stream  %x %x %d\n", socket, SOCKET_I((struct inode*)inode), status->offset_socket_i);
         u64 r;
         bpf_probe_read(&r, sizeof(r), ((char*)inode) - status->offset_socket_i);
-        log_debug("stream  %x %c\n", r);
+//        log_debug("stream  %x %c\n", r);
 
         guess_offsets(status, (char*)inode);
         return 0;

--- a/pkg/network/ebpf/c/prebuilt/offset-guess.c
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.c
@@ -265,7 +265,6 @@ int kprobe__sock_alloc_file(struct pt_regs* ctx) {
     if (status == NULL || status->what != GUESS_FILE_INODE) {
         return 0;
     }
-//    log_debug("sock_alloc_file\n");
     return 0;
 }
 SEC("kretprobe/sock_alloc_file")
@@ -280,7 +279,6 @@ int kretprobe__sock_alloc_file(struct pt_regs* ctx) {
     if (status == NULL || status->what != GUESS_FILE_INODE) {
         return 0;
     }
-    log_debug("sock_alloc_file ret\n");
     return 0;
 }
     
@@ -305,12 +303,6 @@ int kprobe__stream_open(struct pt_regs* ctx) {
         u64 socket;
         bpf_probe_read(&socket, sizeof(socket), file + status->offset_file_private);
         status->socket = socket;
-
-//        log_debug("stream  %x %x %d\n", socket, SOCKET_I((struct inode*)inode), status->offset_socket_i);
-        u64 r;
-        bpf_probe_read(&r, sizeof(r), ((char*)inode) - status->offset_socket_i);
-//        log_debug("stream  %x %c\n", r);
-
         guess_offsets(status, (char*)inode);
         return 0;
     }

--- a/pkg/network/ebpf/c/prebuilt/offset-guess.h
+++ b/pkg/network/ebpf/c/prebuilt/offset-guess.h
@@ -28,6 +28,9 @@ static const __u8 GUESS_DADDR_FL6 = 13;
 static const __u8 GUESS_SPORT_FL6 = 14;
 static const __u8 GUESS_DPORT_FL6 = 15;
 static const __u8 GUESS_SOCKET_SK = 16;
+static const __u8 GUESS_FILE_PRIVATE_SOCKET = 17;
+static const __u8 GUESS_FILE_INODE = 18;
+static const __u8 GUESS_SOCKET_I = 19;
 
 static const __u8 TRACER_STATE_UNINITIALIZED = 0;
 static const __u8 TRACER_STATE_CHECKING = 1;
@@ -62,6 +65,9 @@ typedef struct {
     __u64 offset_sport_fl6;
     __u64 offset_dport_fl6;
     __u64 offset_socket_sk;
+    __u64 offset_file_private;
+    __u64 offset_file_inode;
+    __u64 offset_socket_i;
 
     __u64 err;
 
@@ -84,6 +90,11 @@ typedef struct {
     __u32 daddr_fl6[4];
     __u16 sport_fl6;
     __u16 dport_fl6;
+    __u64 file_private;
+    __u64 file_inode;
+    __u64 socket_i;
+    __u64 socket;
+    __u64 inode;
 
     __u8 ipv6_enabled;
     __u8 fl4_offsets;

--- a/pkg/network/ebpf/c/prebuilt/tracer.c
+++ b/pkg/network/ebpf/c/prebuilt/tracer.c
@@ -641,10 +641,10 @@ int kprobe__fd_install(struct pt_regs* ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
 
     void *private_data;
-    bpf_probe_read(&private_data, sizeof(private_data), file + offsetof(struct file, private_data));
+    bpf_probe_read(&private_data, sizeof(private_data), file + offset_file_private());
     struct inode *inode;
-    bpf_probe_read(&inode, sizeof(inode), file + offsetof(struct file, f_inode));
-    struct socket *socket = SOCKET_I(inode);
+    bpf_probe_read(&inode, sizeof(inode), file + offset_file_inode());
+    struct socket *socket = (struct socket *)((char*)inode - offset_socket_i()); //SOCKET_I(inode)
     if (!private_data || (private_data != socket)) {
         return 0;
     }

--- a/pkg/network/ebpf/c/prebuilt/tracer.c
+++ b/pkg/network/ebpf/c/prebuilt/tracer.c
@@ -656,7 +656,6 @@ int kprobe__fd_install(struct pt_regs* ctx) {
         .pid = pid_tgid >> 32,
         .fd = sockfd,
     };
-    log_debug("=fd_install pid fd %d %d \n", pid_fd.pid, pid_fd.fd);
 
     // These entries are cleaned up by tcp_close
     bpf_map_update_elem(&pid_fd_by_sock, &sock, &pid_fd, BPF_ANY);

--- a/pkg/network/ebpf/c/runtime/tracer.c
+++ b/pkg/network/ebpf/c/runtime/tracer.c
@@ -47,6 +47,27 @@ static __always_inline void get_tcp_segment_counts(struct sock* skp, __u32* pack
     bpf_probe_read(packets_in, sizeof(*packets_in), &tcp_sk(skp)->segs_in);
 }
 
+static __always_inline int socket2sock(struct socket *socket, struct sock **sock) {
+    enum sock_type sock_type = 0;
+    bpf_probe_read(&sock_type, sizeof(short), &socket->type);
+
+    struct proto_ops *proto_ops = NULL;
+    bpf_probe_read(&proto_ops, sizeof(proto_ops), &socket->ops);
+    if (!proto_ops) {
+        return 1;
+    }
+
+    int family = 0;
+    bpf_probe_read(&family, sizeof(family), &proto_ops->family);
+    if (sock_type != SOCK_STREAM || !(family == AF_INET || family == AF_INET6)) {
+        return 1;
+    }
+
+    // Retrieve struct sock* pointer from struct socket*
+    bpf_probe_read(sock, sizeof(*sock), &socket->sk);
+    return 0;
+}
+
 SEC("kprobe/tcp_sendmsg")
 int kprobe__tcp_sendmsg(struct pt_regs* ctx) {
     u64 pid_tgid = bpf_get_current_pid_tgid();
@@ -569,6 +590,37 @@ int kretprobe__inet6_bind(struct pt_regs* ctx) {
     return sys_exit_bind(ret);
 }
 
+SEC("kprobe/fd_install")
+int kprobe__fd_install(struct pt_regs* ctx) {
+// void fd_install(unsigned int fd, struct file *file)
+    int sockfd = (int)PT_REGS_PARM1(ctx);
+    struct file *file = (struct file *)PT_REGS_PARM2(ctx);
+    u64 pid_tgid = bpf_get_current_pid_tgid();
+
+    void *private_data;
+    bpf_probe_read(&private_data, sizeof(private_data), &file->private_data);
+    struct inode *inode;
+    bpf_probe_read(&inode, sizeof(inode), &file->f_inode);
+    struct socket *socket = SOCKET_I(inode);
+    if (!private_data || (private_data != socket)) {
+        return 0;
+    }
+    struct sock *sock = NULL;
+    if (socket2sock(socket, &sock)) {
+        return 0;
+    }
+    pid_fd_t pid_fd = {
+        .pid = pid_tgid >> 32,
+        .fd = sockfd,
+    };
+    log_debug("=fd_install pid fd %d %d \n", pid_fd.pid, pid_fd.fd);
+
+    // These entries are cleaned up by tcp_close
+    bpf_map_update_elem(&pid_fd_by_sock, &sock, &pid_fd, BPF_ANY);
+    bpf_map_update_elem(&sock_by_pid_fd, &pid_fd, &sock, BPF_ANY);
+    return 0;
+}
+
 SEC("kprobe/sockfd_lookup_light")
 int kprobe__sockfd_lookup_light(struct pt_regs* ctx) {
     int sockfd = (int)PT_REGS_PARM1(ctx);
@@ -604,24 +656,10 @@ int kretprobe__sockfd_lookup_light(struct pt_regs* ctx) {
 
     // For now let's only store information for TCP sockets
     struct socket* socket = (struct socket*)PT_REGS_RC(ctx);
-    enum sock_type sock_type = 0;
-    bpf_probe_read(&sock_type, sizeof(short), &socket->type);
-
-    struct proto_ops *proto_ops = NULL;
-    bpf_probe_read(&proto_ops, sizeof(proto_ops), &socket->ops);
-    if (!proto_ops) {
+    struct sock* sock = NULL;
+    if (socket2sock(socket, &sock)) {
         goto cleanup;
     }
-
-    int family = 0;
-    bpf_probe_read(&family, sizeof(family), &proto_ops->family);
-    if (sock_type != SOCK_STREAM || !(family == AF_INET || family == AF_INET6)) {
-        goto cleanup;
-    }
-
-    // Retrieve struct sock* pointer from struct socket*
-    struct sock *sock = NULL;
-    bpf_probe_read(&sock, sizeof(sock), &socket->sk);
 
     pid_fd_t pid_fd = {
         .pid = pid_tgid >> 32,

--- a/pkg/network/ebpf/c/sock.h
+++ b/pkg/network/ebpf/c/sock.h
@@ -155,6 +155,24 @@ static __always_inline __u64 offset_socket_sk() {
      return val;
 }
 
+static __always_inline __u64 offset_file_private() {
+     __u64 val = 0;
+     LOAD_CONSTANT("offset_file_private", val);
+     return val;
+}
+
+static __always_inline __u64 offset_file_inode() {
+     __u64 val = 0;
+     LOAD_CONSTANT("offset_file_inode", val);
+     return val;
+}
+
+static __always_inline __u64 offset_socket_i() {
+     __u64 val = 0;
+     LOAD_CONSTANT("offset_socket_i", val);
+     return val;
+}
+
 static __always_inline __u32 get_netns_from_sock(struct sock* sk) {
     void* skc_net = NULL;
     __u32 net_ns_inum = 0;

--- a/pkg/network/ebpf/offsetguess_types.go
+++ b/pkg/network/ebpf/offsetguess_types.go
@@ -47,11 +47,14 @@ const (
 	GuessDPortFl4 GuessWhat = C.GUESS_DPORT_FL4
 	// Following values are associated with an UDPv6 connection, used for guessing offsets
 	// in the flowi6 data structure
-	GuessSAddrFl6 GuessWhat = C.GUESS_SADDR_FL6
-	GuessDAddrFl6 GuessWhat = C.GUESS_DADDR_FL6
-	GuessSPortFl6 GuessWhat = C.GUESS_SPORT_FL6
-	GuessDPortFl6 GuessWhat = C.GUESS_DPORT_FL6
-	GuessSocketSK GuessWhat = C.GUESS_SOCKET_SK
+	GuessSAddrFl6          GuessWhat = C.GUESS_SADDR_FL6
+	GuessDAddrFl6          GuessWhat = C.GUESS_DADDR_FL6
+	GuessSPortFl6          GuessWhat = C.GUESS_SPORT_FL6
+	GuessDPortFl6          GuessWhat = C.GUESS_DPORT_FL6
+	GuessSocketSK          GuessWhat = C.GUESS_SOCKET_SK
+	GuessFilePrivateSocket GuessWhat = C.GUESS_FILE_PRIVATE_SOCKET
+	GuessFileInode         GuessWhat = C.GUESS_FILE_INODE
+	GuessSocketI           GuessWhat = C.GUESS_SOCKET_I
 
 	GuessNotApplicable GuessWhat = 99999
 )

--- a/pkg/network/ebpf/offsetguess_types_linux.go
+++ b/pkg/network/ebpf/offsetguess_types_linux.go
@@ -33,6 +33,9 @@ type TracerStatus struct {
 	Offset_sport_fl6       uint64
 	Offset_dport_fl6       uint64
 	Offset_socket_sk       uint64
+	Offset_file_private    uint64
+	Offset_file_inode      uint64
+	Offset_socket_i        uint64
 	Err                    uint64
 	Daddr_ipv6             [4]uint32
 	Netns                  uint32
@@ -53,6 +56,11 @@ type TracerStatus struct {
 	Daddr_fl6              [4]uint32
 	Sport_fl6              uint16
 	Dport_fl6              uint16
+	File_private           uint64
+	File_inode             uint64
+	Socket_i               uint64
+	Socket                 uint64
+	Inode                  uint64
 	Ipv6_enabled           uint8
 	Fl4_offsets            uint8
 	Fl6_offsets            uint8
@@ -85,11 +93,14 @@ const (
 	GuessSPortFl4 GuessWhat = 10.000000
 	GuessDPortFl4 GuessWhat = 11.000000
 
-	GuessSAddrFl6 GuessWhat = 12.000000
-	GuessDAddrFl6 GuessWhat = 13.000000
-	GuessSPortFl6 GuessWhat = 14.000000
-	GuessDPortFl6 GuessWhat = 15.000000
-	GuessSocketSK GuessWhat = 16.000000
+	GuessSAddrFl6          GuessWhat = 12.000000
+	GuessDAddrFl6          GuessWhat = 13.000000
+	GuessSPortFl6          GuessWhat = 14.000000
+	GuessDPortFl6          GuessWhat = 15.000000
+	GuessSocketSK          GuessWhat = 16.000000
+	GuessFilePrivateSocket GuessWhat = 17.000000
+	GuessFileInode         GuessWhat = 18.000000
+	GuessSocketI           GuessWhat = 19.000000
 
 	GuessNotApplicable GuessWhat = 99999
 )

--- a/pkg/network/ebpf/probes/probes.go
+++ b/pkg/network/ebpf/probes/probes.go
@@ -116,6 +116,11 @@ const (
 
 	// DoSendfileRet is the kretprobe used to trace traffic via SENDFILE(2) syscall
 	DoSendfileRet ProbeName = "kretprobe/do_sendfile"
+
+	SockCreate       ProbeName = "kprobe/__sock_create"
+	SockCreateReturn ProbeName = "kretprobe/__sock_create"
+
+	StreamOpen ProbeName = "kprobe/stream_open"
 )
 
 // BPFMapName stores the name of the BPF maps storing statistics and other info

--- a/pkg/network/ebpf/probes/probes.go
+++ b/pkg/network/ebpf/probes/probes.go
@@ -102,6 +102,9 @@ const (
 	// ConntrackHashInsert is the probe for new conntrack entries
 	ConntrackHashInsert ProbeName = "kprobe/__nf_conntrack_hash_insert"
 
+	// SockFDInstall is the kprobe used for mapping socket FDs to kernel sock structs (kernel >= 5.5) for sys_connect() sys_accept()
+	SockFDInstall ProbeName = "kprobe/fd_install"
+
 	// SockFDLookup is the kprobe used for mapping socket FDs to kernel sock structs
 	SockFDLookup ProbeName = "kprobe/sockfd_lookup_light"
 

--- a/pkg/network/tracer/connection/kprobe/config.go
+++ b/pkg/network/tracer/connection/kprobe/config.go
@@ -57,6 +57,10 @@ func enabledProbes(c *config.Config, runtimeTracer bool) (map[probes.ProbeName]s
 			enableProbe(enabled, probes.DoSendfile)
 			enableProbe(enabled, probes.DoSendfileRet)
 		}
+
+		if kv >= kernel.VersionCode(5, 5, 0) {
+			enableProbe(enabled, probes.SockFDInstall)
+		}
 	}
 
 	if c.CollectUDPConns {

--- a/pkg/network/tracer/connection/kprobe/manager.go
+++ b/pkg/network/tracer/connection/kprobe/manager.go
@@ -45,6 +45,7 @@ var mainProbes = map[probes.ProbeName]string{
 	probes.Inet6Bind:            "kprobe__inet6_bind",
 	probes.InetBindRet:          "kretprobe__inet_bind",
 	probes.Inet6BindRet:         "kretprobe__inet6_bind",
+	probes.SockFDInstall:        "kprobe__fd_install",
 	probes.SockFDLookup:         "kprobe__sockfd_lookup_light",
 	probes.SockFDLookupRet:      "kretprobe__sockfd_lookup_light",
 	probes.DoSendfile:           "kprobe__do_sendfile",


### PR DESCRIPTION
### What does this PR do?

This fixing the behavior where on kernel 5.5.0 if (wget/openssl or other client) call only socket/connect/read/write our tracer will not see the call to sockfd_lookup_light as it's not been called by connect or accept syscall anymore

### Describe how to test/QA your changes

```
system_probe_config:
  log_level: debug
  enable_runtime_compiler: false
network_config:
  enable_http_monitoring: true
  enable_https_monitoring: true
```
 * run system-probe on ubuntu 21.10
 * wget https://httpbin.org/anything/foo/200
 * `sudo curl -s --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/connections | tee cnx | jq '.conns[].tags , .tags'`
You should see openssl tags : `tls.library:openssl`
 * `sudo curl -s --unix-socket /opt/datadog-agent/run/sysprobe.sock http://unix/debug/http_monitoring`

run the test with enable_runtime_compiler: true as well
note: double check with strace that wget will call only socket() connect() read/write() ; and not calling set/getsockopt()

### Reviewer's Checklist
- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
