### PR TITLE
[pkg/otlp] Disable OTLP internal metrics port

### DIFF
--- a/pkg/otlp/map_provider.go
+++ b/pkg/otlp/map_provider.go
@@ -26,7 +26,6 @@ func buildKey(keys ...string) string {
 // defaultTracesConfig is the base traces OTLP pipeline configuration.
 // This pipeline is extended through the datadog.yaml configuration values.
 // It is written in YAML because it is easier to read and write than a map.
-// TODO (AP-1254): Set service-level configuration when available.
 const defaultTracesConfig string = `
 receivers:
   otlp:
@@ -37,6 +36,9 @@ exporters:
       insecure: true
 
 service:
+  telemetry:
+    metrics:
+      level: none
   pipelines:
     traces:
       receivers: [otlp]
@@ -57,7 +59,6 @@ func buildTracesMap(tracePort uint) (*config.Map, error) {
 }
 
 // defaultMetricsConfig is the metrics OTLP pipeline configuration.
-// TODO (AP-1254): Set service-level configuration when available.
 const defaultMetricsConfig string = `
 receivers:
   otlp:
@@ -70,6 +71,9 @@ exporters:
   serializer:
 
 service:
+  telemetry:
+    metrics:
+      level: none
   pipelines:
     metrics:
       receivers: [otlp]

--- a/pkg/otlp/map_provider_test.go
+++ b/pkg/otlp/map_provider_test.go
@@ -52,6 +52,7 @@ func TestNewMap(t *testing.T) {
 					},
 				},
 				"service": map[string]interface{}{
+					"telemetry": map[string]interface{}{"metrics": map[string]interface{}{"level": "none"}},
 					"pipelines": map[string]interface{}{
 						"traces": map[string]interface{}{
 							"receivers": []interface{}{"otlp"},
@@ -117,6 +118,7 @@ func TestNewMap(t *testing.T) {
 					},
 				},
 				"service": map[string]interface{}{
+					"telemetry": map[string]interface{}{"metrics": map[string]interface{}{"level": "none"}},
 					"pipelines": map[string]interface{}{
 						"traces": map[string]interface{}{
 							"receivers": []interface{}{"otlp"},
@@ -160,6 +162,7 @@ func TestNewMap(t *testing.T) {
 					},
 				},
 				"service": map[string]interface{}{
+					"telemetry": map[string]interface{}{"metrics": map[string]interface{}{"level": "none"}},
 					"pipelines": map[string]interface{}{
 						"traces": map[string]interface{}{
 							"receivers": []interface{}{"otlp"},
@@ -218,6 +221,7 @@ func TestNewMap(t *testing.T) {
 					},
 				},
 				"service": map[string]interface{}{
+					"telemetry": map[string]interface{}{"metrics": map[string]interface{}{"level": "none"}},
 					"pipelines": map[string]interface{}{
 						"metrics": map[string]interface{}{
 							"receivers":  []interface{}{"otlp"},


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Disable OTLP Prometheus port on `0.0.0.0:8888`, which exposed internal observability metrics of the OTLP pipeline.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

- Avoid reserving an additional port in all interfaces
- Avoid reserving an additional port that clashes with a running OpenTelemetry Collector
- Avoid exposing a feature that is experimental and will change. We can re-enable this once the Collector switches to using opentelemetry-go for internal metrics, and create a shim exporter that unifies these metrics with other Agent internal metrics.


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This depends on #10652 and #10638.

This is technically a breaking change, but we have never publicly advertised the existance of this port, so I think a release note is more confusing than helpful.


### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Run the Datadog Agent with the OTLP ingest feature enabled. Check that the port 8888 is not reserved.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
