### PR TITLE
[CWS] Use cache entry to cache args instead of process context

### DIFF
--- a/pkg/security/probe/model.go
+++ b/pkg/security/probe/model.go
@@ -245,24 +245,19 @@ func (ev *Event) ResolveProcessCreatedAt(e *model.Process) uint64 {
 
 // ResolveProcessArgs resolves the args of the event
 func (ev *Event) ResolveProcessArgs(process *model.Process) string {
-	if process.Args == "" {
-		process.Args = strings.Join(ev.ResolveProcessArgv(process), " ")
-	}
-	return process.Args
+	return strings.Join(ev.ResolveProcessArgv(process), " ")
 }
 
 // ResolveProcessArgv resolves the args of the event as an array
 func (ev *Event) ResolveProcessArgv(process *model.Process) []string {
-	if len(process.Argv) == 0 {
-		process.Argv, process.ArgsTruncated = ev.resolvers.ProcessResolver.GetProcessArgv(process)
-	}
-	return process.Argv
+	argv, _ := ev.resolvers.ProcessResolver.GetProcessArgv(process)
+	return argv
 }
 
 // ResolveProcessArgsTruncated returns whether the args are truncated
 func (ev *Event) ResolveProcessArgsTruncated(process *model.Process) bool {
-	_ = ev.ResolveProcessArgs(process)
-	return process.ArgsTruncated
+	_, truncated := ev.resolvers.ProcessResolver.GetProcessArgv(process)
+	return truncated
 }
 
 // ResolveProcessArgsFlags resolves the arguments flags of the event
@@ -324,23 +319,14 @@ func (ev *Event) ResolveProcessArgsOptions(process *model.Process) (options []st
 
 // ResolveProcessEnvsTruncated returns whether the envs are truncated
 func (ev *Event) ResolveProcessEnvsTruncated(process *model.Process) bool {
-	_ = ev.ResolveProcessEnvs(process)
-	return process.EnvsTruncated
+	_, truncated := ev.resolvers.ProcessResolver.GetProcessEnvs(process)
+	return truncated
 }
 
 // ResolveProcessEnvs resolves the envs of the event
 func (ev *Event) ResolveProcessEnvs(process *model.Process) []string {
-	if len(process.Envs) == 0 {
-		envs, truncated := ev.resolvers.ProcessResolver.GetProcessEnvs(process)
-		if envs != nil {
-			process.Envs = make([]string, 0, len(envs))
-			for key := range envs {
-				process.Envs = append(process.Envs, key)
-			}
-			process.EnvsTruncated = truncated
-		}
-	}
-	return process.Envs
+	envs, _ := ev.resolvers.ProcessResolver.GetProcessEnvs(process)
+	return envs
 }
 
 // ResolveSetuidUser resolves the user of the Setuid event

--- a/pkg/security/probe/model_test.go
+++ b/pkg/security/probe/model_test.go
@@ -60,7 +60,7 @@ func TestProcessArgsFlags(t *testing.T) {
 		},
 	}
 
-	resolver, _ := NewProcessResolver(nil, nil, nil, NewProcessResolverOpts(10000))
+	resolver, _ := NewProcessResolver(&Probe{}, nil, nil, NewProcessResolverOpts(10000))
 	e.resolvers = &Resolvers{
 		ProcessResolver: resolver,
 	}
@@ -119,7 +119,7 @@ func TestProcessArgsOptions(t *testing.T) {
 		},
 	}
 
-	resolver, _ := NewProcessResolver(nil, nil, nil, NewProcessResolverOpts(10000))
+	resolver, _ := NewProcessResolver(&Probe{}, nil, nil, NewProcessResolverOpts(10000))
 	e.resolvers = &Resolvers{
 		ProcessResolver: resolver,
 	}

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -357,27 +357,9 @@ func newCredentialsSerializer(ce *model.Credentials) *CredentialsSerializer {
 	}
 }
 
-func scrubArgs(pr *model.Process, e *Event) ([]string, bool) {
-	return e.resolvers.ProcessResolver.GetScrubbedProcessArgv(pr)
-}
-
-func scrubEnvs(pr *model.Process, e *Event) ([]string, bool) {
-	envs, truncated := e.resolvers.ProcessResolver.GetProcessEnvs(pr)
-	if envs == nil {
-		return nil, false
-	}
-
-	result := make([]string, 0, len(envs))
-	for key := range envs {
-		result = append(result, key)
-	}
-
-	return result, truncated
-}
-
 func newProcessCacheEntrySerializer(pce *model.ProcessCacheEntry, e *Event) *ProcessCacheEntrySerializer {
-	argv, argvTruncated := scrubArgs(&pce.Process, e)
-	envs, EnvsTruncated := scrubEnvs(&pce.Process, e)
+	argv, argvTruncated := e.resolvers.ProcessResolver.GetProcessArgv(&pce.Process)
+	envs, EnvsTruncated := e.resolvers.ProcessResolver.GetProcessEnvs(&pce.Process)
 
 	pceSerializer := &ProcessCacheEntrySerializer{
 		ForkTime: getTimeIfNotZero(pce.ForkTime),

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -273,7 +273,7 @@ type Process struct {
 	ArgsEntry *ArgsEntry `field:"-"`
 	EnvsEntry *EnvsEntry `field:"-"`
 
-	// defined to generate accessors
+	// defined to generate accessors, ArgsTruncated and EnvsTruncated
 	Args          string   `field:"args,ResolveProcessArgs:100"`                                                                                           // Arguments of the process (as a string)
 	Argv          []string `field:"argv,ResolveProcessArgv:100" field:"args_flags,ResolveProcessArgsFlags" field:"args_options,ResolveProcessArgsOptions"` // Arguments of the process (as an array)
 	ArgsTruncated bool     `field:"args_truncated,ResolveProcessArgsTruncated"`                                                                            // Indicator of arguments truncation


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

The goal is to keep only one version of the envs and args in the cache entries instead of the process context. This should reduce the amount of memory used once a event is serialized. This PR also remove from the cache unused envs values.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
