### PR TITLE
Improve the `Custom Metrics Server` section of `agent status`

### DIFF
--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -177,7 +177,11 @@ func GetDCAStatus() (map[string]interface{}, error) {
 		stats["admissionWebhook"] = admission.GetStatus(apiCl.Cl)
 	}
 
-	stats["externalmetrics"] = externalmetrics.GetStatus()
+	if config.Datadog.GetBool("external_metrics_provider.use_datadogmetric_crd") {
+		stats["externalmetrics"] = externalmetrics.GetStatus()
+	} else {
+		stats["externalmetrics"] = apiserver.GetStatus()
+	}
 
 	if config.Datadog.GetBool("cluster_checks.enabled") {
 		cchecks, err := clusterchecks.GetStats()

--- a/pkg/status/templates/header.tmpl
+++ b/pkg/status/templates/header.tmpl
@@ -146,7 +146,7 @@ Custom Metrics Server
   URL: {{ .externalmetrics.client.url }}
   {{- else if .externalmetrics.clients }}
   {{- range $client := .externalmetrics.clients }}
-  - URL: {{ $client.url }}  {{ if $client.lastQuerySucceeded -}} [OK] {{- else -}} [Failed] {{- end }}
+  - URL: {{ $client.url }}  [{{ $client.status }}]
     Last failure: {{ $client.lastFailure }}
     Last Success: {{ $client.lastSuccess }}
   {{- end }}

--- a/pkg/util/kubernetes/apiserver/controllers.go
+++ b/pkg/util/kubernetes/apiserver/controllers.go
@@ -127,7 +127,8 @@ func startMetadataController(ctx ControllerContext, c chan error) {
 // startAutoscalersController starts the informers needed for autoscaling.
 // The synchronization of the informers is handled by the controller.
 func startAutoscalersController(ctx ControllerContext, c chan error) {
-	dogCl, err := autoscalers.NewDatadogClient()
+	var err error
+	dogCl, err = autoscalers.NewDatadogClient()
 	if err != nil {
 		c <- err
 		return

--- a/pkg/util/kubernetes/apiserver/status.go
+++ b/pkg/util/kubernetes/apiserver/status.go
@@ -1,0 +1,18 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
+// +build kubeapiserver
+
+package apiserver
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/autoscalers"
+)
+
+var dogCl autoscalers.DatadogClient
+
+func GetStatus() map[string]interface{} {
+	return autoscalers.GetStatus(dogCl)
+}

--- a/pkg/util/kubernetes/apiserver/status_stub.go
+++ b/pkg/util/kubernetes/apiserver/status_stub.go
@@ -1,0 +1,13 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
+// +build !kubeapiserver
+
+package apiserver
+
+// GetStatus returns various information about the datadog client(s)
+func GetStatus() map[string]interface{} {
+	return map[string]interface{}{}
+}

--- a/pkg/util/kubernetes/autoscalers/datadogclient.go
+++ b/pkg/util/kubernetes/autoscalers/datadogclient.go
@@ -184,8 +184,8 @@ func (cl *datadogFallbackClient) QueryMetrics(from, to int64, query string) ([]d
 			return series, nil
 		}
 
-		log.Infof("Failed to query metrics on %s: %#v", c.client.GetBaseUrl(), err)
-		errs = fmt.Errorf("%w, Failed to query metrics on %s: %v", errs, c.client.GetBaseUrl(), err)
+		log.Infof("Failed to query metrics on %s: %s", c.client.GetBaseUrl(), err.Error())
+		errs = fmt.Errorf("%w, Failed to query metrics on %s: %s", errs, c.client.GetBaseUrl(), err.Error())
 	}
 
 	for _, c := range skippedClients {
@@ -225,8 +225,24 @@ func GetStatus(datadogClient DatadogClient) map[string]interface{} {
 			clientsStatus[i] = make(map[string]interface{})
 			clientsStatus[i]["url"] = individualClient.client.GetBaseUrl()
 			clientsStatus[i]["lastQuerySucceeded"] = individualClient.lastQuerySucceeded
-			clientsStatus[i]["lastFailure"] = individualClient.lastFailure
-			clientsStatus[i]["lastSuccess"] = individualClient.lastSuccess
+			if individualClient.lastFailure.IsZero() {
+				clientsStatus[i]["lastFailure"] = "Never"
+			} else {
+				clientsStatus[i]["lastFailure"] = individualClient.lastFailure
+			}
+			if individualClient.lastSuccess.IsZero() {
+				clientsStatus[i]["lastSuccess"] = "Never"
+			} else {
+				clientsStatus[i]["lastSuccess"] = individualClient.lastSuccess
+			}
+			if individualClient.lastFailure.IsZero() &&
+				individualClient.lastSuccess.IsZero() {
+				clientsStatus[i]["status"] = "Unknown"
+			} else if individualClient.lastQuerySucceeded {
+				clientsStatus[i]["status"] = "OK"
+			} else {
+				clientsStatus[i]["status"] = "Failed"
+			}
 			clientsStatus[i]["retryInterval"] = individualClient.retryInterval
 		}
 		status["clients"] = clientsStatus


### PR DESCRIPTION
### What does this PR do?

Improve the `Data sources` part of the `Custom Metrics Server` section of the DCA `agent status` that has been introduced by #9908.

Before:
```
Custom Metrics Server
=====================

  Data sources
  ------------
  - URL: https://api.datadoghq.com [OK]
    Last failure: 0001-01-01T00:00:00Z
    Last Success: 2021-12-13T14:31:36.66842282Z
  - URL: https://anriuets.nrsat.rs [OK]
    Last failure: 0001-01-01T00:00:00Z
    Last Success: 0001-01-01T00:00:00Z
  - URL: https://app.datadoghq.com [OK]
    Last failure: 0001-01-01T00:00:00Z
    Last Success: 0001-01-01T00:00:00Z
```

After:
```
Custom Metrics Server
=====================

  Data sources
  ------------
  - URL: https://api.datadoghq.com  [OK]
    Last failure: Never
    Last Success: 2022-01-26T13:41:34.409364411Z
  - URL: https://anriuets.nrsat.rs  [Unknown]
    Last failure: Never
    Last Success: Never
  - URL: https://app.datadoghq.com  [Unknown]
    Last failure: Never
    Last Success: Never
```

Improve the log emitted by the agent when it fails getting the metrics from datadog:

Before:
```
2022-01-24 16:01:54 UTC | CLUSTER | INFO | (pkg/util/kubernetes/autoscalers/datadogclient.go:187 in QueryMetrics) | Failed to query metrics on https://foo.bar.com: &url.Error{Op:"Get", URL:"https://foo.bar.com/api/v1/query?from=1643039801&query=avg%3Akubernetes.pods.running%7Bkube_cluster_name%3Aeks-appmesh%7D.rollup%2830%29&to=1643040101", Err:(*net.OpError)(0xc000c66190)}
```

After:
```
2022-01-26 12:51:05 UTC | CLUSTER | INFO | (pkg/util/kubernetes/autoscalers/datadogclient.go:187 in QueryMetrics) | Failed to query metrics on https://api.datadoghq.com: "Get \"https://api.datadoghq.com/api/v1/query?from=1643201122&query=avg%3Anginx.net.request_per_s%7Bkube_cluster_name%3Agke-lenaic-huard%7D.rollup%2860%29&to=1643201422\": dial tcp 3.233.147.128:443: connect: connection refused"
2022-01-26 12:51:10 UTC | CLUSTER | INFO | (pkg/util/kubernetes/autoscalers/datadogclient.go:187 in QueryMetrics) | Failed to query metrics on https://anriuets.nrsat.rs: "Get \"https://anriuets.nrsat.rs/api/v1/query?from=1643201122&query=avg%3Anginx.net.request_per_s%7Bkube_cluster_name%3Agke-lenaic-huard%7D.rollup%2860%29&to=1643201422\": dial tcp: lookup anriuets.nrsat.rs on 10.252.0.10:53: no such host"
```

### Motivation

The previous output of `agent status` could be confusing.
The fixed error message was helpless (the address of the error object instead of its string)

### Additional Notes

### Possible Drawbacks / Trade-offs

None

### Describe how to test/QA your changes

Configure the DCA with several endpoints. Ex to put in `/etc/datadog-agent/datadog-cluster.yaml`:

```yaml
external_metrics_provider:
  use_datadogmetric_crd: true
  endpoints:
  - api_key: 123456
    app_key: 456789
    url: https://anriuets.nrsat.rs
  - api_key: REDACTED
    app_key: REDACTED
    url: https://app.datadoghq.com
```

Check the output of `agent status`.
`0001-01-01T00:00:00Z` should now be replaced by `Never` and endpoints never used should now be displayed with the `Unknown` state as described above.

Simulate failures for ex. by blocking the network with iptables rules.

```
iptables -I FORWARD 1 -d 3.233.147.128/26 -j REJECT
```

Check that the DCA switches to another endpoint in the output of agent status.

Check in the logs that the message is now helpful and doesn’t display the error address anymore.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
