### PR TITLE
[process-agent] Migrate check queue settings to global config

### DIFF
--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -107,13 +107,13 @@ func isRealTimeCheck(checkName string) bool {
 // NewCollectorWithChecks creates a new Collector
 func NewCollectorWithChecks(cfg *config.AgentConfig, checks []checks.Check, runRealTime bool) Collector {
 	queueSize := ddconfig.Datadog.GetInt("process_config.queue_size")
-	if queueSize < 0 {
+	if queueSize <= 0 {
 		log.Warnf("Invalid check queue size: %d. Using default value: %d", queueSize, ddconfig.DefaultCheckQueueSize)
 		queueSize = ddconfig.DefaultCheckQueueSize
 	}
 
 	rtQueueSize := ddconfig.Datadog.GetInt("process_config.rt_queue_size")
-	if rtQueueSize < 0 {
+	if rtQueueSize <= 0 {
 		log.Warnf("Invalid rt check queue size: %d. Using default value: %d", rtQueueSize, ddconfig.DefaultRTCheckQueueSize)
 		rtQueueSize = ddconfig.DefaultRTCheckQueueSize
 	}

--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -110,14 +110,14 @@ func isRealTimeCheck(checkName string) bool {
 func NewCollectorWithChecks(cfg *config.AgentConfig, checks []checks.Check, runRealTime bool) Collector {
 	queueSize := ddconfig.Datadog.GetInt("process_config.queue_size")
 	if queueSize <= 0 {
-		log.Warnf("Invalid check queue size: %d. Using default value: %d", queueSize, ddconfig.DefaultCheckQueueSize)
-		queueSize = ddconfig.DefaultCheckQueueSize
+		log.Warnf("Invalid check queue size: %d. Using default value: %d", queueSize, ddconfig.DefaultProcessQueueSize)
+		queueSize = ddconfig.DefaultProcessQueueSize
 	}
 
 	rtQueueSize := ddconfig.Datadog.GetInt("process_config.rt_queue_size")
 	if rtQueueSize <= 0 {
-		log.Warnf("Invalid rt check queue size: %d. Using default value: %d", rtQueueSize, ddconfig.DefaultRTCheckQueueSize)
-		rtQueueSize = ddconfig.DefaultRTCheckQueueSize
+		log.Warnf("Invalid rt check queue size: %d. Using default value: %d", rtQueueSize, ddconfig.DefaultProcessRTQueueSize)
+		rtQueueSize = ddconfig.DefaultProcessRTQueueSize
 	}
 
 	queueBytes := ddconfig.Datadog.GetInt("process_config.process_queue_bytes")

--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -73,6 +73,8 @@ type Collector struct {
 	rtProcessResults *api.WeightedQueue
 	podResults       *api.WeightedQueue
 
+	forwarderRetryQueueMaxBytes int
+
 	// Enables running realtime checks
 	runRealTime bool
 }
@@ -118,15 +120,21 @@ func NewCollectorWithChecks(cfg *config.AgentConfig, checks []checks.Check, runR
 		rtQueueSize = ddconfig.DefaultRTCheckQueueSize
 	}
 
-	processResults := api.NewWeightedQueue(queueSize, int64(cfg.ProcessQueueBytes))
-	log.Debugf("Creating process check queue with max_size=%d and max_weight=%d", queueSize, cfg.ProcessQueueBytes)
+	queueBytes := ddconfig.Datadog.GetInt("process_config.process_queue_bytes")
+	if queueBytes <= 0 {
+		log.Warnf("Invalid queue bytes size: %d. Using default value: %d", queueBytes, ddconfig.DefaultProcessQueueBytes)
+		queueBytes = ddconfig.DefaultProcessQueueBytes
+	}
+
+	processResults := api.NewWeightedQueue(queueSize, int64(queueBytes))
+	log.Debugf("Creating process check queue with max_size=%d and max_weight=%d", processResults.MaxSize(), processResults.MaxWeight())
 
 	// reuse main queue's ProcessQueueBytes because it's unlikely that it'll reach to that size in bytes, so we don't need a separate config for it
-	rtProcessResults := api.NewWeightedQueue(rtQueueSize, int64(cfg.ProcessQueueBytes))
-	log.Debugf("Creating rt process check queue with max_size=%d and max_weight=%d", rtQueueSize, cfg.ProcessQueueBytes)
+	rtProcessResults := api.NewWeightedQueue(rtQueueSize, int64(queueBytes))
+	log.Debugf("Creating rt process check queue with max_size=%d and max_weight=%d", rtProcessResults.MaxSize(), rtProcessResults.MaxWeight())
 
 	podResults := api.NewWeightedQueue(queueSize, int64(cfg.Orchestrator.PodQueueBytes))
-	log.Debugf("Creating pod check queue with max_size=%d and max_weight=%d", queueSize, cfg.Orchestrator.PodQueueBytes)
+	log.Debugf("Creating pod check queue with max_size=%d and max_weight=%d", podResults.MaxSize(), podResults.MaxWeight())
 
 	return Collector{
 		rtIntervalCh:  make(chan time.Duration),
@@ -141,6 +149,8 @@ func NewCollectorWithChecks(cfg *config.AgentConfig, checks []checks.Check, runR
 		processResults:   processResults,
 		rtProcessResults: rtProcessResults,
 		podResults:       podResults,
+
+		forwarderRetryQueueMaxBytes: queueBytes,
 
 		runRealTime: runRealTime,
 	}
@@ -315,7 +325,7 @@ func (l *Collector) run(exit chan struct{}) error {
 
 	processForwarderOpts := forwarder.NewOptionsWithResolvers(resolver.NewSingleDomainResolvers(apicfg.KeysPerDomains(l.cfg.APIEndpoints)))
 	processForwarderOpts.DisableAPIKeyChecking = true
-	processForwarderOpts.RetryQueuePayloadsTotalMaxSize = l.cfg.ProcessQueueBytes // Allow more in-flight requests than the default
+	processForwarderOpts.RetryQueuePayloadsTotalMaxSize = l.forwarderRetryQueueMaxBytes // Allow more in-flight requests than the default
 	processForwarder := forwarder.NewDefaultForwarder(processForwarderOpts)
 
 	// rt forwarder can reuse processForwarder's config
@@ -323,7 +333,7 @@ func (l *Collector) run(exit chan struct{}) error {
 
 	podForwarderOpts := forwarder.NewOptionsWithResolvers(resolver.NewSingleDomainResolvers(apicfg.KeysPerDomains(l.cfg.Orchestrator.OrchestratorEndpoints)))
 	podForwarderOpts.DisableAPIKeyChecking = true
-	podForwarderOpts.RetryQueuePayloadsTotalMaxSize = l.cfg.ProcessQueueBytes // Allow more in-flight requests than the default
+	podForwarderOpts.RetryQueuePayloadsTotalMaxSize = l.forwarderRetryQueueMaxBytes // Allow more in-flight requests than the default
 	podForwarder := forwarder.NewDefaultForwarder(podForwarderOpts)
 
 	if err := processForwarder.Start(); err != nil {

--- a/cmd/process-agent/collector_api_test.go
+++ b/cmd/process-agent/collector_api_test.go
@@ -7,7 +7,6 @@ package main
 
 import (
 	"fmt"
-	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -18,6 +17,7 @@ import (
 	"time"
 
 	"github.com/DataDog/agent-payload/v5/process"
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/checks"
 	"github.com/DataDog/datadog-agent/pkg/process/config"
 	apicfg "github.com/DataDog/datadog-agent/pkg/process/util/api/config"

--- a/cmd/process-agent/collector_api_test.go
+++ b/cmd/process-agent/collector_api_test.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"fmt"
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"io/ioutil"
 	"net"
 	"net/http"
@@ -280,8 +281,9 @@ func TestQueueSpaceNotAvailable(t *testing.T) {
 		data: [][]process.MessageBody{{m}},
 	}
 
+	mockConfig := ddconfig.Mock()
+	mockConfig.Set("process_config.process_queue_bytes", 1)
 	cfg := config.NewDefaultAgentConfig(false)
-	cfg.ProcessQueueBytes = 1
 
 	runCollectorTest(t, check, cfg, &endpointConfig{ErrorCount: 1}, func(cfg *config.AgentConfig, ep *mockEndpoint) {
 		select {
@@ -310,8 +312,9 @@ func TestQueueSpaceReleased(t *testing.T) {
 		data: [][]process.MessageBody{{m1}, {m2}},
 	}
 
+	mockConfig := ddconfig.Mock()
+	mockConfig.Set("process_config.process_queue_bytes", 50) // This should be enough for one message, but not both if the space isn't released
 	cfg := config.NewDefaultAgentConfig(false)
-	cfg.ProcessQueueBytes = 50 // This should be enough for one message, but not both if the space isn't released
 
 	runCollectorTest(t, check, cfg, &endpointConfig{ErrorCount: 1}, func(cfg *config.AgentConfig, ep *mockEndpoint) {
 		req := <-ep.Requests

--- a/cmd/process-agent/collector_test.go
+++ b/cmd/process-agent/collector_test.go
@@ -151,7 +151,7 @@ func TestNewCollectorQueueSize(t *testing.T) {
 		{
 			name:              "default queue size",
 			override:          false,
-			queueSize:         ddconfig.DefaultCheckQueueSize,
+			queueSize:         42,
 			expectedQueueSize: ddconfig.DefaultCheckQueueSize,
 		},
 		{

--- a/cmd/process-agent/collector_test.go
+++ b/cmd/process-agent/collector_test.go
@@ -161,9 +161,15 @@ func TestNewCollectorQueueSize(t *testing.T) {
 			expectedQueueSize: 42,
 		},
 		{
-			name:              "invalid queue size override",
+			name:              "invalid negative queue size override",
 			override:          true,
 			queueSize:         -10,
+			expectedQueueSize: ddconfig.DefaultProcessQueueSize,
+		},
+		{
+			name:              "invalid 0 queue size override",
+			override:          true,
+			queueSize:         0,
 			expectedQueueSize: ddconfig.DefaultProcessQueueSize,
 		},
 	}
@@ -206,9 +212,15 @@ func TestNewCollectorRTQueueSize(t *testing.T) {
 			expectedQueueSize: 2,
 		},
 		{
-			name:              "invalid queue size override",
+			name:              "invalid negative size override",
 			override:          true,
 			queueSize:         -2,
+			expectedQueueSize: ddconfig.DefaultProcessRTQueueSize,
+		},
+		{
+			name:              "invalid 0 queue size override",
+			override:          true,
+			queueSize:         0,
 			expectedQueueSize: ddconfig.DefaultProcessRTQueueSize,
 		},
 	}
@@ -250,9 +262,15 @@ func TestNewCollectorProcessQueueBytes(t *testing.T) {
 			expectedQueueSize: 42000,
 		},
 		{
-			name:              "invalid queue size override",
+			name:              "invalid negative queue size override",
 			override:          true,
 			queueBytes:        -2,
+			expectedQueueSize: ddconfig.DefaultProcessQueueBytes,
+		},
+		{
+			name:              "invalid 0 queue size override",
+			override:          true,
+			queueBytes:        0,
 			expectedQueueSize: ddconfig.DefaultProcessQueueBytes,
 		},
 	}

--- a/cmd/process-agent/collector_test.go
+++ b/cmd/process-agent/collector_test.go
@@ -152,7 +152,7 @@ func TestNewCollectorQueueSize(t *testing.T) {
 			name:              "default queue size",
 			override:          false,
 			queueSize:         42,
-			expectedQueueSize: ddconfig.DefaultCheckQueueSize,
+			expectedQueueSize: ddconfig.DefaultProcessQueueSize,
 		},
 		{
 			name:              "valid queue size override",
@@ -164,7 +164,7 @@ func TestNewCollectorQueueSize(t *testing.T) {
 			name:              "invalid queue size override",
 			override:          true,
 			queueSize:         -10,
-			expectedQueueSize: ddconfig.DefaultCheckQueueSize,
+			expectedQueueSize: ddconfig.DefaultProcessQueueSize,
 		},
 	}
 
@@ -197,7 +197,7 @@ func TestNewCollectorRTQueueSize(t *testing.T) {
 			name:              "default queue size",
 			override:          false,
 			queueSize:         2,
-			expectedQueueSize: ddconfig.DefaultRTCheckQueueSize,
+			expectedQueueSize: ddconfig.DefaultProcessRTQueueSize,
 		},
 		{
 			name:              "valid queue size override",
@@ -209,7 +209,7 @@ func TestNewCollectorRTQueueSize(t *testing.T) {
 			name:              "invalid queue size override",
 			override:          true,
 			queueSize:         -2,
-			expectedQueueSize: ddconfig.DefaultRTCheckQueueSize,
+			expectedQueueSize: ddconfig.DefaultProcessRTQueueSize,
 		},
 	}
 

--- a/cmd/process-agent/collector_test.go
+++ b/cmd/process-agent/collector_test.go
@@ -185,3 +185,47 @@ func TestNewCollectorQueueSize(t *testing.T) {
 		})
 	}
 }
+
+func TestNewCollectorRTQueueSize(t *testing.T) {
+	tests := []struct {
+		name              string
+		override          bool
+		queueSize         int
+		expectedQueueSize int
+	}{
+		{
+			name:              "default queue size",
+			override:          false,
+			queueSize:         2,
+			expectedQueueSize: ddconfig.DefaultRTCheckQueueSize,
+		},
+		{
+			name:              "valid queue size override",
+			override:          true,
+			queueSize:         2,
+			expectedQueueSize: 2,
+		},
+		{
+			name:              "invalid queue size override",
+			override:          true,
+			queueSize:         -2,
+			expectedQueueSize: ddconfig.DefaultRTCheckQueueSize,
+		},
+	}
+
+	assert := assert.New(t)
+	cfg := config.NewDefaultAgentConfig(false)
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockConfig := ddconfig.Mock()
+			if tc.override {
+				mockConfig.Set("process_config.rt_queue_size", tc.queueSize)
+			}
+
+			c, err := NewCollector(cfg)
+			assert.NoError(err)
+			assert.Equal(tc.expectedQueueSize, c.rtProcessResults.MaxSize())
+		})
+	}
+}

--- a/cmd/process-agent/collector_test.go
+++ b/cmd/process-agent/collector_test.go
@@ -175,7 +175,7 @@ func TestNewCollectorQueueSize(t *testing.T) {
 	}
 
 	assert := assert.New(t)
-	cfg := config.NewDefaultAgentConfig(false)
+	cfg := config.NewDefaultAgentConfig()
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -226,7 +226,7 @@ func TestNewCollectorRTQueueSize(t *testing.T) {
 	}
 
 	assert := assert.New(t)
-	cfg := config.NewDefaultAgentConfig(false)
+	cfg := config.NewDefaultAgentConfig()
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -276,7 +276,7 @@ func TestNewCollectorProcessQueueBytes(t *testing.T) {
 	}
 
 	assert := assert.New(t)
-	cfg := config.NewDefaultAgentConfig(false)
+	cfg := config.NewDefaultAgentConfig()
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/cmd/process-agent/collector_test.go
+++ b/cmd/process-agent/collector_test.go
@@ -234,8 +234,8 @@ func TestNewCollectorProcessQueueBytes(t *testing.T) {
 	tests := []struct {
 		name              string
 		override          bool
-		queueBytes        int64
-		expectedQueueSize int64
+		queueBytes        int
+		expectedQueueSize int
 	}{
 		{
 			name:              "default queue size",
@@ -269,9 +269,9 @@ func TestNewCollectorProcessQueueBytes(t *testing.T) {
 
 			c, err := NewCollector(cfg)
 			assert.NoError(err)
-			assert.Equal(tc.expectedQueueSize, c.processResults.MaxWeight())
-			assert.Equal(tc.expectedQueueSize, c.rtProcessResults.MaxWeight())
-			assert.Equal(tc.expectedQueueSize, c.forwarderMaxQueueBytes)
+			assert.Equal(int64(tc.expectedQueueSize), c.processResults.MaxWeight())
+			assert.Equal(int64(tc.expectedQueueSize), c.rtProcessResults.MaxWeight())
+			assert.Equal(tc.expectedQueueSize, c.forwarderRetryQueueMaxBytes)
 		})
 	}
 }

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1258,19 +1258,19 @@ api_key:
 
   ## @param queue_size - integer - optional - default: 256
   ## @env DD_PROCESS_CONFIG_QUEUE_SIZE - integer - optional - default: 256
-  ## How many check results to buffer in memory when POST fails.
+  ## The number of check results to buffer in memory when a POST fails.
   #
   # queue_size: 256
 
   ## @param process_queue_bytes - integer - optional - default: 60000000
   ## @env DD_PROCESS_CONFIG_PROCESS_QUEUE_BYTES - integer - optional - default: 60000000
-  ## How much check data (in bytes) to buffer in memory when POST fails.
+  ## The amount of data (in bytes) to buffer in memory when a POST fails.
   #
   # process_queue_bytes: 60000000
 
   ## @param rt_queue_size - integer - optional - default: 5
   ## @env DD_PROCESS_CONFIG_RT_QUEUE_SIZE - integer - optional - default: 5
-  ## How many realtime check results to buffer in memory when POST fails.
+  ## The number of realtime check results to buffer in memory when a POST fails.
   #
   # rt_queue_size: 5
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1256,11 +1256,23 @@ api_key:
   # blacklist_patterns:
   #   - <REGEX>
 
-  ## @param queue_size - integer - optional - default: 20
-  ## @env DD_PROCESS_CONFIG_QUEUE_SIZE - integer - optional - default: 20
+  ## @param queue_size - integer - optional - default: 256
+  ## @env DD_PROCESS_CONFIG_QUEUE_SIZE - integer - optional - default: 256
   ## How many check results to buffer in memory when POST fails.
   #
-  # queue_size: 20
+  # queue_size: 256
+
+  ## @param process_queue_bytes - integer - optional - default: 60000000
+  ## @env DD_PROCESS_CONFIG_PROCESS_QUEUE_BYTES - integer - optional - default: 60000000
+  ## How much check data (in bytes) to buffer in memory when POST fails.
+  #
+  # process_queue_bytes: 60000000
+
+  ## @param rt_queue_size - integer - optional - default: 5
+  ## @env DD_PROCESS_CONFIG_RT_QUEUE_SIZE - integer - optional - default: 5
+  ## How many realtime check results to buffer in memory when POST fails.
+  #
+  # rt_queue_size: 5
 
   ## @param max_per_message - integer - optional - default: 100
   ## @env DD_PROCESS_CONFIG_MAX_PER_MESSAGE - integer - optional - default: 100

--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -22,6 +22,10 @@ const (
 	// This can be fairly high as the input should get throttled by queue bytes first.
 	// Assuming we generate ~8 checks/minute (for process/network), this should allow buffering of ~30 minutes of data assuming it fits within the queue bytes memory budget
 	DefaultCheckQueueSize = 256
+
+	// DefaultRTCheckQueueSize is the max amount of realtime checks that can be buffered in memory
+	// We set a small queue size for real-time message because they get staled very quickly, thus we only keep the latest several payloads
+	DefaultRTCheckQueueSize = 5
 )
 
 // setupProcesses is meant to be called multiple times for different configs, but overrides apply to all configs, so
@@ -70,7 +74,7 @@ func setupProcesses(config Config) {
 	config.SetKnown("process_config.enabled")
 	config.SetKnown("process_config.intervals.process_realtime")
 	procBindEnvAndSetDefault(config, "process_config.queue_size", DefaultCheckQueueSize)
-	config.SetKnown("process_config.rt_queue_size")
+	procBindEnvAndSetDefault(config, "process_config.rt_queue_size", DefaultRTCheckQueueSize)
 	config.SetKnown("process_config.max_per_message")
 	config.SetKnown("process_config.max_ctr_procs_per_message")
 	config.SetKnown("process_config.cmd_port")

--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -18,14 +18,18 @@ const (
 	// DefaultGRPCConnectionTimeoutSecs sets the default value for timeout when connecting to the agent
 	DefaultGRPCConnectionTimeoutSecs = 60
 
-	// DefaultCheckQueueSize is the max amount of checks that can be buffered in memory if the forwarder can't consume them fast enough (e.g. due to network disruption).
+	// DefaultCheckQueueSize is the defatul max amount of checks that can be buffered in memory if the forwarder can't consume them fast enough (e.g. due to network disruption)
 	// This can be fairly high as the input should get throttled by queue bytes first.
 	// Assuming we generate ~8 checks/minute (for process/network), this should allow buffering of ~30 minutes of data assuming it fits within the queue bytes memory budget
 	DefaultCheckQueueSize = 256
 
-	// DefaultRTCheckQueueSize is the max amount of realtime checks that can be buffered in memory
+	// DefaultRTCheckQueueSize is the default max amount of realtime checks that can be buffered in memory
 	// We set a small queue size for real-time message because they get staled very quickly, thus we only keep the latest several payloads
 	DefaultRTCheckQueueSize = 5
+
+	// DefaultProcessQueueBytes is the default amount of check data (in bytes) that can be buffered in memory
+	// Allow buffering up to 60 megabytes of payload data in total
+	DefaultProcessQueueBytes = 60 * 1000 * 1000
 )
 
 // setupProcesses is meant to be called multiple times for different configs, but overrides apply to all configs, so
@@ -74,6 +78,7 @@ func setupProcesses(config Config) {
 	config.SetKnown("process_config.enabled")
 	config.SetKnown("process_config.intervals.process_realtime")
 	procBindEnvAndSetDefault(config, "process_config.queue_size", DefaultCheckQueueSize)
+	procBindEnvAndSetDefault(config, "process_config.process_queue_bytes", DefaultProcessQueueBytes)
 	procBindEnvAndSetDefault(config, "process_config.rt_queue_size", DefaultRTCheckQueueSize)
 	config.SetKnown("process_config.max_per_message")
 	config.SetKnown("process_config.max_ctr_procs_per_message")

--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -17,6 +17,11 @@ import (
 const (
 	// DefaultGRPCConnectionTimeoutSecs sets the default value for timeout when connecting to the agent
 	DefaultGRPCConnectionTimeoutSecs = 60
+
+	// DefaultCheckQueueSize is the max amount of checks that can be buffered in memory if the forwarder can't consume them fast enough (e.g. due to network disruption).
+	// This can be fairly high as the input should get throttled by queue bytes first.
+	// Assuming we generate ~8 checks/minute (for process/network), this should allow buffering of ~30 minutes of data assuming it fits within the queue bytes memory budget
+	DefaultCheckQueueSize = 256
 )
 
 // setupProcesses is meant to be called multiple times for different configs, but overrides apply to all configs, so
@@ -64,7 +69,7 @@ func setupProcesses(config Config) {
 	config.SetKnown("process_config.dd_agent_env")
 	config.SetKnown("process_config.enabled")
 	config.SetKnown("process_config.intervals.process_realtime")
-	config.SetKnown("process_config.queue_size")
+	procBindEnvAndSetDefault(config, "process_config.queue_size", DefaultCheckQueueSize)
 	config.SetKnown("process_config.rt_queue_size")
 	config.SetKnown("process_config.max_per_message")
 	config.SetKnown("process_config.max_ctr_procs_per_message")

--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -18,16 +18,16 @@ const (
 	// DefaultGRPCConnectionTimeoutSecs sets the default value for timeout when connecting to the agent
 	DefaultGRPCConnectionTimeoutSecs = 60
 
-	// DefaultCheckQueueSize is the defatul max amount of checks that can be buffered in memory if the forwarder can't consume them fast enough (e.g. due to network disruption)
+	// DefaultProcessQueueSize is the default max amount of process-agent checks that can be buffered in memory if the forwarder can't consume them fast enough (e.g. due to network disruption)
 	// This can be fairly high as the input should get throttled by queue bytes first.
 	// Assuming we generate ~8 checks/minute (for process/network), this should allow buffering of ~30 minutes of data assuming it fits within the queue bytes memory budget
-	DefaultCheckQueueSize = 256
+	DefaultProcessQueueSize = 256
 
-	// DefaultRTCheckQueueSize is the default max amount of realtime checks that can be buffered in memory
+	// DefaultProcessRTQueueSize is the default max amount of process-agent realtime checks that can be buffered in memory
 	// We set a small queue size for real-time message because they get staled very quickly, thus we only keep the latest several payloads
-	DefaultRTCheckQueueSize = 5
+	DefaultProcessRTQueueSize = 5
 
-	// DefaultProcessQueueBytes is the default amount of check data (in bytes) that can be buffered in memory
+	// DefaultProcessQueueBytes is the default amount of process-agent check data (in bytes) that can be buffered in memory
 	// Allow buffering up to 60 megabytes of payload data in total
 	DefaultProcessQueueBytes = 60 * 1000 * 1000
 )
@@ -77,9 +77,9 @@ func setupProcesses(config Config) {
 	config.SetKnown("process_config.dd_agent_env")
 	config.SetKnown("process_config.enabled")
 	config.SetKnown("process_config.intervals.process_realtime")
-	procBindEnvAndSetDefault(config, "process_config.queue_size", DefaultCheckQueueSize)
+	procBindEnvAndSetDefault(config, "process_config.queue_size", DefaultProcessQueueSize)
 	procBindEnvAndSetDefault(config, "process_config.process_queue_bytes", DefaultProcessQueueBytes)
-	procBindEnvAndSetDefault(config, "process_config.rt_queue_size", DefaultRTCheckQueueSize)
+	procBindEnvAndSetDefault(config, "process_config.rt_queue_size", DefaultProcessRTQueueSize)
 	config.SetKnown("process_config.max_per_message")
 	config.SetKnown("process_config.max_ctr_procs_per_message")
 	config.SetKnown("process_config.cmd_port")

--- a/pkg/config/process_test.go
+++ b/pkg/config/process_test.go
@@ -56,11 +56,11 @@ func TestProcessDefaultConfig(t *testing.T) {
 		},
 		{
 			key:          "process_config.queue_size",
-			defaultValue: DefaultCheckQueueSize,
+			defaultValue: DefaultProcessQueueSize,
 		},
 		{
 			key:          "process_config.rt_queue_size",
-			defaultValue: DefaultRTCheckQueueSize,
+			defaultValue: DefaultProcessRTQueueSize,
 		},
 		{
 			key:          "process_config.process_queue_bytes",

--- a/pkg/config/process_test.go
+++ b/pkg/config/process_test.go
@@ -62,6 +62,10 @@ func TestProcessDefaultConfig(t *testing.T) {
 			key:          "process_config.rt_queue_size",
 			defaultValue: DefaultRTCheckQueueSize,
 		},
+		{
+			key:          "process_config.process_queue_bytes",
+			defaultValue: DefaultProcessQueueBytes,
+		},
 	} {
 		t.Run(tc.key+" default", func(t *testing.T) {
 			assert.Equal(t, tc.defaultValue, cfg.Get(tc.key))
@@ -209,6 +213,12 @@ func TestEnvVarOverride(t *testing.T) {
 			env:      "DD_PROCESS_CONFIG_RT_QUEUE_SIZE",
 			value:    "10",
 			expected: 10,
+		},
+		{
+			key:      "process_config.process_queue_bytes",
+			env:      "DD_PROCESS_CONFIG_PROCESS_QUEUE_BYTES",
+			value:    "20000",
+			expected: 20000,
 		},
 	} {
 		t.Run(tc.env, func(t *testing.T) {

--- a/pkg/config/process_test.go
+++ b/pkg/config/process_test.go
@@ -54,6 +54,10 @@ func TestProcessDefaultConfig(t *testing.T) {
 			key:          "process_config.container_collection.enabled",
 			defaultValue: true,
 		},
+		{
+			key:          "process_config.queue_size",
+			defaultValue: DefaultCheckQueueSize,
+		},
 	} {
 		t.Run(tc.key+" default", func(t *testing.T) {
 			assert.Equal(t, tc.defaultValue, cfg.Get(tc.key))
@@ -189,6 +193,12 @@ func TestEnvVarOverride(t *testing.T) {
 			env:      "DD_PROCESS_CONFIG_ENABLED",
 			value:    "false",
 			expected: "disabled",
+		},
+		{
+			key:      "process_config.queue_size",
+			env:      "DD_PROCESS_CONFIG_QUEUE_SIZE",
+			value:    "42",
+			expected: 42,
 		},
 	} {
 		t.Run(tc.env, func(t *testing.T) {

--- a/pkg/config/process_test.go
+++ b/pkg/config/process_test.go
@@ -58,6 +58,10 @@ func TestProcessDefaultConfig(t *testing.T) {
 			key:          "process_config.queue_size",
 			defaultValue: DefaultCheckQueueSize,
 		},
+		{
+			key:          "process_config.rt_queue_size",
+			defaultValue: DefaultCheckQueueSize,
+		},
 	} {
 		t.Run(tc.key+" default", func(t *testing.T) {
 			assert.Equal(t, tc.defaultValue, cfg.Get(tc.key))
@@ -199,6 +203,12 @@ func TestEnvVarOverride(t *testing.T) {
 			env:      "DD_PROCESS_CONFIG_QUEUE_SIZE",
 			value:    "42",
 			expected: 42,
+		},
+		{
+			key:      "process_config.rt_queue_size",
+			env:      "DD_PROCESS_CONFIG_RT_QUEUE_SIZE",
+			value:    "10",
+			expected: 10,
 		},
 	} {
 		t.Run(tc.env, func(t *testing.T) {

--- a/pkg/config/process_test.go
+++ b/pkg/config/process_test.go
@@ -60,7 +60,7 @@ func TestProcessDefaultConfig(t *testing.T) {
 		},
 		{
 			key:          "process_config.rt_queue_size",
-			defaultValue: DefaultCheckQueueSize,
+			defaultValue: DefaultRTCheckQueueSize,
 		},
 	} {
 		t.Run(tc.key+" default", func(t *testing.T) {

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -98,7 +98,6 @@ type AgentConfig struct {
 	Enabled                   bool
 	HostName                  string
 	APIEndpoints              []apicfg.Endpoint
-	QueueSize                 int // The number of items allowed in each delivery queue.
 	RTQueueSize               int // the number of items allowed in real-time delivery queue
 	ProcessQueueBytes         int // The total number of bytes that can be enqueued for delivery to the process intake endpoint
 	Blacklist                 []*regexp.Regexp
@@ -189,10 +188,7 @@ func NewDefaultAgentConfig(canAccessContainers bool) *AgentConfig {
 
 		// Allow buffering up to 60 megabytes of payload data in total
 		ProcessQueueBytes: 60 * 1000 * 1000,
-		// This can be fairly high as the input should get throttled by queue bytes first.
-		// Assuming we generate ~8 checks/minute (for process/network), this should allow buffering of ~30 minutes of data assuming it fits within the queue bytes memory budget
-		QueueSize:   256,
-		RTQueueSize: 5, // We set a small queue size for real-time message queue because they get staled very quickly, thus we only keep the latest several payloads
+		RTQueueSize:       5, // We set a small queue size for real-time message queue because they get staled very quickly, thus we only keep the latest several payloads
 
 		MaxPerMessage:             maxMessageBatch,
 		MaxCtrProcessesPerMessage: defaultMaxCtrProcsMessageBatch,

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -98,7 +98,6 @@ type AgentConfig struct {
 	Enabled                   bool
 	HostName                  string
 	APIEndpoints              []apicfg.Endpoint
-	RTQueueSize               int // the number of items allowed in real-time delivery queue
 	ProcessQueueBytes         int // The total number of bytes that can be enqueued for delivery to the process intake endpoint
 	Blacklist                 []*regexp.Regexp
 	Scrubber                  *DataScrubber
@@ -188,7 +187,6 @@ func NewDefaultAgentConfig(canAccessContainers bool) *AgentConfig {
 
 		// Allow buffering up to 60 megabytes of payload data in total
 		ProcessQueueBytes: 60 * 1000 * 1000,
-		RTQueueSize:       5, // We set a small queue size for real-time message queue because they get staled very quickly, thus we only keep the latest several payloads
 
 		MaxPerMessage:             maxMessageBatch,
 		MaxCtrProcessesPerMessage: defaultMaxCtrProcsMessageBatch,

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -98,7 +98,6 @@ type AgentConfig struct {
 	Enabled                   bool
 	HostName                  string
 	APIEndpoints              []apicfg.Endpoint
-	ProcessQueueBytes         int // The total number of bytes that can be enqueued for delivery to the process intake endpoint
 	Blacklist                 []*regexp.Regexp
 	Scrubber                  *DataScrubber
 	MaxPerMessage             int
@@ -184,9 +183,6 @@ func NewDefaultAgentConfig(canAccessContainers bool) *AgentConfig {
 	ac := &AgentConfig{
 		Enabled:      canAccessContainers, // We'll always run inside of a container.
 		APIEndpoints: []apicfg.Endpoint{{Endpoint: processEndpoint}},
-
-		// Allow buffering up to 60 megabytes of payload data in total
-		ProcessQueueBytes: 60 * 1000 * 1000,
 
 		MaxPerMessage:             maxMessageBatch,
 		MaxCtrProcessesPerMessage: defaultMaxCtrProcsMessageBatch,

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -334,7 +334,7 @@ func TestAgentConfigYamlAndSystemProbeConfig(t *testing.T) {
 	ep := agentConfig.APIEndpoints[0]
 	assert.Equal("apikey_20", ep.APIKey)
 	assert.Equal("my-process-app.datadoghq.com", ep.Endpoint.Hostname())
-	assert.Equal(10, agentConfig.QueueSize)
+	assert.Equal(10, config.Datadog.GetInt("process_config.queue_size"))
 	assert.Equal(true, agentConfig.Enabled)
 	assert.Equal(append(processChecks), agentConfig.EnabledChecks)
 	assert.Equal(8*time.Second, agentConfig.CheckIntervals[ContainerCheckName])
@@ -350,7 +350,7 @@ func TestAgentConfigYamlAndSystemProbeConfig(t *testing.T) {
 	assert.Equal("apikey_20", ep.APIKey)
 	assert.Equal("my-process-app.datadoghq.com", ep.Endpoint.Hostname())
 	assert.Equal("server-01", agentConfig.HostName)
-	assert.Equal(10, agentConfig.QueueSize)
+	assert.Equal(10, config.Datadog.GetInt("process_config.queue_size"))
 	assert.Equal(true, agentConfig.Enabled)
 	assert.Equal(8*time.Second, agentConfig.CheckIntervals[ContainerCheckName])
 	assert.Equal(30*time.Second, agentConfig.CheckIntervals[ProcessCheckName])
@@ -367,7 +367,7 @@ func TestAgentConfigYamlAndSystemProbeConfig(t *testing.T) {
 
 	assert.Equal("apikey_20", ep.APIKey)
 	assert.Equal("my-process-app.datadoghq.com", ep.Endpoint.Hostname())
-	assert.Equal(10, agentConfig.QueueSize)
+	assert.Equal(10, config.Datadog.GetInt("process_config.queue_size"))
 	assert.Equal(true, agentConfig.Enabled)
 	assert.Equal(8*time.Second, agentConfig.CheckIntervals[ContainerCheckName])
 	assert.Equal(30*time.Second, agentConfig.CheckIntervals[ProcessCheckName])

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -125,12 +125,6 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 		a.Scrubber.StripAllArguments = true
 	}
 
-	if k := key(ns, "process_queue_bytes"); config.Datadog.IsSet(k) {
-		if queueBytes := config.Datadog.GetInt(k); queueBytes > 0 {
-			a.ProcessQueueBytes = queueBytes
-		}
-	}
-
 	// The maximum number of processes, or containers per message. Note: Only change if the defaults are causing issues.
 	if k := key(ns, "max_per_message"); config.Datadog.IsSet(k) {
 		if maxPerMessage := config.Datadog.GetInt(k); maxPerMessage <= 0 {

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -125,13 +125,6 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 		a.Scrubber.StripAllArguments = true
 	}
 
-	// How many check results to buffer in memory when POST fails. The default is usually fine.
-	if k := key(ns, "queue_size"); config.Datadog.IsSet(k) {
-		if queueSize := config.Datadog.GetInt(k); queueSize > 0 {
-			a.QueueSize = queueSize
-		}
-	}
-
 	if k := key(ns, "process_queue_bytes"); config.Datadog.IsSet(k) {
 		if queueBytes := config.Datadog.GetInt(k); queueBytes > 0 {
 			a.ProcessQueueBytes = queueBytes

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -131,13 +131,6 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 		}
 	}
 
-	// How many check results to buffer in memory when POST fails. The default is usually fine.
-	if k := key(ns, "rt_queue_size"); config.Datadog.IsSet(k) {
-		if rtqueueSize := config.Datadog.GetInt(k); rtqueueSize > 0 {
-			a.RTQueueSize = rtqueueSize
-		}
-	}
-
 	// The maximum number of processes, or containers per message. Note: Only change if the defaults are causing issues.
 	if k := key(ns, "max_per_message"); config.Datadog.IsSet(k) {
 		if maxPerMessage := config.Datadog.GetInt(k); maxPerMessage <= 0 {

--- a/pkg/process/util/api/weighted_queue.go
+++ b/pkg/process/util/api/weighted_queue.go
@@ -76,6 +76,16 @@ func (q *WeightedQueue) Weight() int64 {
 	return q.currentWeight
 }
 
+// MaxSize returns the maxSize of the queue
+func (q *WeightedQueue) MaxSize() int {
+	return q.maxSize
+}
+
+// MaxWeight returns the maxWeight of the queue
+func (q *WeightedQueue) MaxWeight() int64 {
+	return q.maxWeight
+}
+
 // Poll retrieves the head of the queue or blocks until an item is available or
 // the WeightedQueue is stopped.  Returns the head of the queue and true or
 // nil, false if the WeightedQueue is stopped.

--- a/releasenotes/notes/process-agent-check-queue-size-fix-6e69705ec71896a4.yaml
+++ b/releasenotes/notes/process-agent-check-queue-size-fix-6e69705ec71896a4.yaml
@@ -1,0 +1,3 @@
+fixes:
+  - |
+    Add DD_PROCESS_CONFIG_PROCESS_QUEUE_BYTES and DD_PROCESS_AGENT_PROCESS_QUEUE_BYTES env variables to set process_config.process_queue_bytes

--- a/releasenotes/notes/process-agent-check-queue-size-fix-6e69705ec71896a4.yaml
+++ b/releasenotes/notes/process-agent-check-queue-size-fix-6e69705ec71896a4.yaml
@@ -1,3 +1,0 @@
-fixes:
-  - |
-    Add DD_PROCESS_CONFIG_PROCESS_QUEUE_BYTES and DD_PROCESS_AGENT_PROCESS_QUEUE_BYTES env variables to set process_config.process_queue_bytes

--- a/releasenotes/notes/process-agent-queue-size-env-vars-753849e87d61c876.yaml
+++ b/releasenotes/notes/process-agent-queue-size-env-vars-753849e87d61c876.yaml
@@ -1,0 +1,5 @@
+enhancements:
+  - |
+    Add DD_PROCESS_CONFIG_QUEUE_SIZE and DD_PROCESS_AGENT_QUEUE_SIZE env variables to set process_config.queue_size
+    Add DD_PROCESS_CONFIG_RT_QUEUE_SIZE and DD_PROCESS_AGENT_RT_QUEUE_SIZE env variables to set process_config.rt_queue_size
+    Add DD_PROCESS_CONFIG_PROCESS_QUEUE_BYTES and DD_PROCESS_AGENT_PROCESS_QUEUE_BYTES env variables to set process_config.process_queue_bytes

--- a/releasenotes/notes/process-agent-queue-size-env-vars-753849e87d61c876.yaml
+++ b/releasenotes/notes/process-agent-queue-size-env-vars-753849e87d61c876.yaml
@@ -1,5 +1,5 @@
 enhancements:
   - |
-    Add DD_PROCESS_CONFIG_QUEUE_SIZE and DD_PROCESS_AGENT_QUEUE_SIZE env variables to set process_config.queue_size
-    Add DD_PROCESS_CONFIG_RT_QUEUE_SIZE and DD_PROCESS_AGENT_RT_QUEUE_SIZE env variables to set process_config.rt_queue_size
-    Add DD_PROCESS_CONFIG_PROCESS_QUEUE_BYTES and DD_PROCESS_AGENT_PROCESS_QUEUE_BYTES env variables to set process_config.process_queue_bytes
+    Add the ``DD_PROCESS_CONFIG_QUEUE_SIZE`` and ``DD_PROCESS_AGENT_QUEUE_SIZE`` env variables to set the ``process_config.queue_size``.
+    Add the ``DD_PROCESS_CONFIG_RT_QUEUE_SIZE`` and ``DD_PROCESS_AGENT_RT_QUEUE_SIZE`` env variables to set the ``process_config.rt_queue_size``.
+    Add the ``DD_PROCESS_CONFIG_PROCESS_QUEUE_BYTES`` and ``DD_PROCESS_AGENT_PROCESS_QUEUE_BYTES`` env variables to set the ``process_config.process_queue_bytes``.


### PR DESCRIPTION
### What does this PR do?

This PR removes the `QueueSize`, `RTQueueSize ` and `ProcessQueueBytes` fields from the deprecated `AgentConfig` struct and instead relies on the equivalent settings from the global Config object.

Default values for these settings have been created in the `pkg/config/process.go` file. The validation once done in `LoadProcessYamlConfig()` is now performed when these settings are read and used in the `Collector` constructor.

### Motivation

Refactor and improve `process-agent` config logic.

### Additional Notes

`process_config.queue_size`, `process_config.rt_queue_size` and `process_config.process_queue_bytes` currently can't be overriden by env vars. This PR also creates `DD_PROCESS_CONFIG_` and `PROCESS_AGENT_` env vars for these settings.

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

Set the following settings in the `datadog.yaml` file:

```yaml
log_level: 'debug'

process_config:
  enabled: "true"
  queue_size: 100
  rt_queue_size: 50
  process_queue_bytes: 20000
```

Start the `process-agent` and make sure that the following log lines are printed
```
Creating process check queue with max_size=100 and max_weight=20000
Creating rt process check queue with max_size=50 and max_weight=20000
Creating pod check queue with max_size=100 and max_weight=15000000
```

Update `queue_size`, `rt_queue_size` and `process_queue_bytes` to non-positive values and make sure that a `Warn` message is printed showing that `process-agent` falls back to the default values.

Repeat the tests with positives and non-positives values for
```
DD_PROCESS_CONFIG_QUEUE_SIZE
DD_PROCESS_AGENT_QUEUE_SIZE
DD_PROCESS_CONFIG_RT_QUEUE_SIZE
DD_PROCESS_AGENT_RT_QUEUE_SIZE
DD_PROCESS_CONFIG_PROCESS_QUEUE_BYTES
DD_PROCESS_AGENT_PROCESS_QUEUE_BYTES
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
