### PR TITLE
Adding changelog for release of the Cluster Agent 1.17

### DIFF
--- a/CHANGELOG-DCA.rst
+++ b/CHANGELOG-DCA.rst
@@ -2,6 +2,49 @@
 Release Notes
 =============
 
+.. _Release Notes_dca-1.17.0_dca-1.17.X:
+
+dca-1.17.0
+==========
+
+.. _Release Notes_dca-1.17.0_dca-1.17.X_Prelude:
+
+Prelude
+-------
+
+Released on: 2022-01-26
+Pinned to datadog-agent v7.33.0: `CHANGELOG <https://github.com/DataDog/datadog-agent/blob/master/CHANGELOG.rst#7330>`_.
+
+.. _Release Notes_dca-1.17.0_dca-1.17.X_New Features:
+
+New Features
+------------
+
+- Collect PVC tag on pending pods
+- Add the ability to filter for check names in the cluster checks output.
+
+
+.. _Release Notes_dca-1.17.0_dca-1.17.X_Bug Fixes:
+
+Bug Fixes
+---------
+
+- Add reworked status output for orchestrator section on CLC setups.
+
+.. _Release Notes_dca-1.17.0_dca-1.17.X_Security:
+
+Security
+--------
+
+- Fix the removal of the "kubectl.kubernetes.io/last-applied-configuration" annotation on new collected resources
+
+.. _Release Notes_dca-1.17.0_dca-1.17.X_Enhancement Notes:
+
+Enhancement Notes
+-----------------
+
+- Add autoscaler resource kind (hpa,wpa) inside the DatadogMetrics status references.
+
 .. _Release Notes_dca-1.16.0_dca-1.16.X:
 
 dca-1.16.0


### PR DESCRIPTION
### What does this PR do?

Add changelog for the Cluster Agent 1.17.

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.