### PR TITLE
Add ARM kitchen tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -213,7 +213,7 @@ variables:
 # - on main and deploy pipelines, kitchen tests are run
 # - on branch pipelines, kitchen tests are not run
 # RUN_KITCHEN_TESTS can be set to true to force kitchen tests to be run on a branch pipeline.
-# RUN_KITCHEN_TESTS can be set to false to force kithcen tests to not run on main/deploy pipelines.
+# RUN_KITCHEN_TESTS can be set to false to force kitchen tests to not run on main/deploy pipelines.
 .if_kitchen: &if_kitchen
   if: ($CI_COMMIT_BRANCH == "main"  || $DEPLOY_AGENT == "true" || $RUN_KITCHEN_TESTS == "true") && $RUN_KITCHEN_TESTS != "false"
 
@@ -222,6 +222,12 @@ variables:
 # by setting RUN_KITCHEN_TESTS to false.
 .if_default_kitchen: &if_default_kitchen
   if: $RUN_KITCHEN_TESTS != "false"
+
+# Runs on all builds where RUN_KITCHEN_TESTS is also true.
+.all_kitchen_builds: &all_kitchen_builds
+  - <<: *if_not_run_all_builds
+    when: never
+  - <<: *if_kitchen
 
 .if_testing_cleanup: &if_testing_cleanup
   if: $TESTING_CLEANUP == "true"
@@ -653,6 +659,11 @@ variables:
   - <<: *if_kitchen
     when: always
 
+.on_all_kitchen_builds_a6:
+  - <<: *if_not_version_6
+    when: never
+  - <<: *all_kitchen_builds
+
 .on_kitchen_tests_a7:
   - <<: *if_not_version_7
     when: never
@@ -663,6 +674,11 @@ variables:
     when: never
   - <<: *if_kitchen
     when: always
+
+.on_all_kitchen_builds_a7:
+  - <<: *if_not_version_7
+    when: never
+  - <<: *all_kitchen_builds
 
 # Default kitchen tests are also run on dev branches
 # In that case, the target OS versions is a subset of the

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -662,7 +662,9 @@ variables:
 .on_all_kitchen_builds_a6:
   - <<: *if_not_version_6
     when: never
-  - <<: *all_kitchen_builds
+  - <<: *if_not_run_all_builds
+    when: never
+  - <<: *if_kitchen
 
 .on_kitchen_tests_a7:
   - <<: *if_not_version_7
@@ -678,7 +680,9 @@ variables:
 .on_all_kitchen_builds_a7:
   - <<: *if_not_version_7
     when: never
-  - <<: *all_kitchen_builds
+  - <<: *if_not_run_all_builds
+    when: never
+  - <<: *if_kitchen
 
 # Default kitchen tests are also run on dev branches
 # In that case, the target OS versions is a subset of the

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -223,12 +223,6 @@ variables:
 .if_default_kitchen: &if_default_kitchen
   if: $RUN_KITCHEN_TESTS != "false"
 
-# Runs on all builds where RUN_KITCHEN_TESTS is also true.
-.all_kitchen_builds: &all_kitchen_builds
-  - <<: *if_not_run_all_builds
-    when: never
-  - <<: *if_kitchen
-
 .if_testing_cleanup: &if_testing_cleanup
   if: $TESTING_CLEANUP == "true"
 

--- a/.gitlab/deploy_7/install_script.yml
+++ b/.gitlab/deploy_7/install_script.yml
@@ -9,14 +9,14 @@ promote_install_script:
     - kitchen_centos_install_script_agent-a6
     - kitchen_centos_install_script_agent-a7
     - kitchen_centos_install_script_iot_agent-a7
-    - kitchen_debian_install_script_agent-a6
-    - kitchen_debian_install_script_agent-a7
+    - kitchen_debian_install_script_agent-a6_x64
+    - kitchen_debian_install_script_agent-a7_x64
     - kitchen_debian_install_script_iot_agent-a7
     - kitchen_suse_install_script_agent-a6
     - kitchen_suse_install_script_agent-a7
     - kitchen_suse_install_script_iot_agent-a7
-    - kitchen_ubuntu_install_script_agent-a6
-    - kitchen_ubuntu_install_script_agent-a7
+    - kitchen_ubuntu_install_script_agent-a6_x64
+    - kitchen_ubuntu_install_script_agent-a7_x64
     - kitchen_ubuntu_install_script_iot_agent-a7
   script:
     - $S3_CP_CMD ./cmd/agent/install_script.sh s3://dd-agent/scripts/install_script.sh --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=id=3a6e02b08553fd157ae3fb918945dd1eaae5a1aa818940381ef07a430cf25732

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -24,6 +24,7 @@
 kitchen_test_security_agent_x64:
   extends:
     - .kitchen_test_security_agent
+    - .kitchen_azure_x64
     - .kitchen_azure_location_north_central_us
   needs: ["tests_ebpf_x64"]
   variables:
@@ -69,6 +70,7 @@ kitchen_stress_security_agent:
   extends:
     - .kitchen_common
     - .kitchen_datadog_agent_flavor
+    - .kitchen_azure_x64
     - .kitchen_azure_location_north_central_us
   rules:
     !reference [.manual]

--- a/.gitlab/functional_test/system_probe.yml
+++ b/.gitlab/functional_test/system_probe.yml
@@ -23,6 +23,7 @@
 kitchen_test_system_probe_linux_x64:
   extends:
     - .kitchen_test_system_probe
+    - .kitchen_azure_x64
     - .kitchen_azure_location_north_central_us
   needs: [ "tests_ebpf_x64" ]
   variables:
@@ -68,6 +69,7 @@ kitchen_test_system_probe_windows_x64:
     - .kitchen_agent_a7
     - .kitchen_os_windows
     - .kitchen_test_system_probe
+    - .kitchen_azure_x64
     - .kitchen_azure_location_north_central_us
   needs: [ "tests_windows_sysprobe_x64" ]
   variables:

--- a/.gitlab/kitchen_common/testing.yml
+++ b/.gitlab/kitchen_common/testing.yml
@@ -149,7 +149,7 @@
     KITCHEN_EC2_SUBNET: subnet-c18341ed
     KITCHEN_EC2_SG_IDS: sg-0f5617ceb3e5a6c39
 
-# Kitchen: Test types (test suite * agent flavor * location?)
+# Kitchen: Test types (test suite * agent flavor + location in each cloud provider)
 # -------------------------------
 
 .kitchen_test_chef_agent:

--- a/.gitlab/kitchen_common/testing.yml
+++ b/.gitlab/kitchen_common/testing.yml
@@ -131,66 +131,65 @@
     KITCHEN_EC2_SUBNET: subnet-c18341ed
     KITCHEN_EC2_SG_IDS: sg-0f5617ceb3e5a6c39
 
+.kitchen_ec2_arm64:
+  variables:
+    KITCHEN_ARCH: arm64
+    KITCHEN_EC2_INSTANCE_TYPE: "t4g.xlarge"
+  extends:
+    - .kitchen_ec2_location_us_east_1
+    - .kitchen_ec2_spot_instances
 
-# Kitchen: Test types (test suite * agent flavor + azure location)
+# Kitchen: Test types (test suite * agent flavor)
+# Don't specify location for the jobs as they can be ran either
+# in Azure or EC2, e.g. for ARM tests.
 # -------------------------------
 
 .kitchen_test_chef_agent:
   extends:
     - .kitchen_test_chef
     - .kitchen_datadog_agent_flavor
-    - .kitchen_azure_location_north_central_us
 
 .kitchen_test_step_by_step_agent:
   extends:
     - .kitchen_test_step_by_step
     - .kitchen_datadog_agent_flavor
-    - .kitchen_azure_location_central_us
 
 .kitchen_test_install_script_agent:
   extends:
     - .kitchen_test_install_script
     - .kitchen_datadog_agent_flavor
-    - .kitchen_azure_location_south_central_us
 
 .kitchen_test_install_script_iot_agent:
   extends:
     - .kitchen_test_install_script
     - .kitchen_datadog_iot_agent_flavor
-    - .kitchen_azure_location_west_central_us
 
 .kitchen_test_install_script_heroku_agent:
   extends:
     - .kitchen_test_install_script
     - .kitchen_datadog_heroku_agent_flavor
-    - .kitchen_azure_location_west_central_us
 
 .kitchen_test_install_script_dogstatsd:
   extends:
     - .kitchen_test_install_script
     - .kitchen_datadog_dogstatsd_flavor
-    - .kitchen_azure_location_west_central_us
 
 .kitchen_test_upgrade5_agent:
   extends:
     - .kitchen_test_upgrade5
     - .kitchen_datadog_agent_flavor
-    - .kitchen_azure_location_central_us
 
 .kitchen_test_upgrade6_agent:
   extends:
     - .kitchen_test_upgrade6
     - .kitchen_datadog_agent_flavor
-    - .kitchen_azure_location_south_central_us
 
 .kitchen_test_upgrade7_agent:
   extends:
     - .kitchen_test_upgrade7
     - .kitchen_datadog_agent_flavor
-    - .kitchen_azure_location_west_central_us
 
 .kitchen_test_upgrade7_iot_agent:
   extends:
     - .kitchen_test_upgrade7
     - .kitchen_datadog_iot_agent_flavor
-    - .kitchen_azure_location_south_central_us

--- a/.gitlab/kitchen_common/testing.yml
+++ b/.gitlab/kitchen_common/testing.yml
@@ -135,6 +135,8 @@
   variables:
     KITCHEN_ARCH: arm64
     KITCHEN_EC2_INSTANCE_TYPE: "t4g.xlarge"
+    # we need chef >= 15 for arm64 and for the arm? helper
+    CHEF_VERSION: 15.16.4
   extends:
     - .kitchen_ec2_location_us_east_1
     - .kitchen_ec2_spot_instances

--- a/.gitlab/kitchen_common/testing.yml
+++ b/.gitlab/kitchen_common/testing.yml
@@ -13,14 +13,38 @@
 # Kitchen: providers
 # ---------------
 
+# Azure
+# ---------------
+.kitchen_azure:
+  variables:
+    KITCHEN_PROVIDER: azure
+
+.kitchen_azure_x64:
+  variables:
+    KITCHEN_ARCH: x86_64
+  extends:
+    - .kitchen_azure
+
+# EC2
+# ---------------
 .kitchen_ec2:
   variables:
     KITCHEN_PROVIDER: ec2
     KITCHEN_EC2_IAM_PROFILE_NAME: ci-datadog-agent-e2e-runner
 
 .kitchen_ec2_spot_instances:
+  extends: .kitchen_ec2
   variables:
     KITCHEN_EC2_SPOT_PRICE: on-demand
+
+.kitchen_ec2_arm64:
+  variables:
+    KITCHEN_ARCH: arm64
+    KITCHEN_EC2_INSTANCE_TYPE: "t4g.xlarge"
+    # we need chef >= 15 for arm64 and for the arm? helper
+    CHEF_VERSION: 15.16.4
+  extends:
+    - .kitchen_ec2_spot_instances
 
 # Kitchen: agents
 # ---------------
@@ -101,22 +125,18 @@
 
 .kitchen_azure_location_north_central_us:
   variables:
-    KITCHEN_PROVIDER: azure
     AZURE_LOCATION: "North Central US"
 
 .kitchen_azure_location_west_central_us:
   variables:
-    KITCHEN_PROVIDER: azure
     AZURE_LOCATION: "West Central US"
 
 .kitchen_azure_location_central_us:
   variables:
-    KITCHEN_PROVIDER: azure
     AZURE_LOCATION: "Central US"
 
 .kitchen_azure_location_south_central_us:
   variables:
-    KITCHEN_PROVIDER: azure
     AZURE_LOCATION: "South Central US"
 
 
@@ -124,74 +144,80 @@
 # -------------------------------
 
 .kitchen_ec2_location_us_east_1:
-  extends:
-    - .kitchen_ec2
   variables:
     KITCHEN_EC2_REGION: us-east-1
     KITCHEN_EC2_SUBNET: subnet-c18341ed
     KITCHEN_EC2_SG_IDS: sg-0f5617ceb3e5a6c39
 
-.kitchen_ec2_arm64:
-  variables:
-    KITCHEN_ARCH: arm64
-    KITCHEN_EC2_INSTANCE_TYPE: "t4g.xlarge"
-    # we need chef >= 15 for arm64 and for the arm? helper
-    CHEF_VERSION: 15.16.4
-  extends:
-    - .kitchen_ec2_location_us_east_1
-    - .kitchen_ec2_spot_instances
-
-# Kitchen: Test types (test suite * agent flavor)
-# Don't specify location for the jobs as they can be ran either
-# in Azure or EC2, e.g. for ARM tests.
+# Kitchen: Test types (test suite * agent flavor * location?)
 # -------------------------------
 
 .kitchen_test_chef_agent:
   extends:
     - .kitchen_test_chef
     - .kitchen_datadog_agent_flavor
+    - .kitchen_azure_location_north_central_us
+    - .kitchen_ec2_location_us_east_1
 
 .kitchen_test_step_by_step_agent:
   extends:
     - .kitchen_test_step_by_step
     - .kitchen_datadog_agent_flavor
+    - .kitchen_azure_location_central_us
+    - .kitchen_ec2_location_us_east_1
 
 .kitchen_test_install_script_agent:
   extends:
     - .kitchen_test_install_script
     - .kitchen_datadog_agent_flavor
+    - .kitchen_azure_location_south_central_us
+    - .kitchen_ec2_location_us_east_1
 
 .kitchen_test_install_script_iot_agent:
   extends:
     - .kitchen_test_install_script
     - .kitchen_datadog_iot_agent_flavor
+    - .kitchen_azure_location_west_central_us
+    - .kitchen_ec2_location_us_east_1
 
 .kitchen_test_install_script_heroku_agent:
   extends:
     - .kitchen_test_install_script
     - .kitchen_datadog_heroku_agent_flavor
+    - .kitchen_azure_location_west_central_us
+    - .kitchen_ec2_location_us_east_1
 
 .kitchen_test_install_script_dogstatsd:
   extends:
     - .kitchen_test_install_script
     - .kitchen_datadog_dogstatsd_flavor
+    - .kitchen_azure_location_west_central_us
+    - .kitchen_ec2_location_us_east_1
 
 .kitchen_test_upgrade5_agent:
   extends:
     - .kitchen_test_upgrade5
     - .kitchen_datadog_agent_flavor
+    - .kitchen_azure_location_central_us
+    - .kitchen_ec2_location_us_east_1
 
 .kitchen_test_upgrade6_agent:
   extends:
     - .kitchen_test_upgrade6
     - .kitchen_datadog_agent_flavor
+    - .kitchen_azure_location_south_central_us
+    - .kitchen_ec2_location_us_east_1
 
 .kitchen_test_upgrade7_agent:
   extends:
     - .kitchen_test_upgrade7
     - .kitchen_datadog_agent_flavor
+    - .kitchen_azure_location_west_central_us
+    - .kitchen_ec2_location_us_east_1
 
 .kitchen_test_upgrade7_iot_agent:
   extends:
     - .kitchen_test_upgrade7
     - .kitchen_datadog_iot_agent_flavor
+    - .kitchen_azure_location_south_central_us
+    - .kitchen_ec2_location_us_east_1

--- a/.gitlab/kitchen_deploy.yml
+++ b/.gitlab/kitchen_deploy.yml
@@ -37,8 +37,6 @@
   - popd
 
 .deploy_deb_testing-a6:
-  rules:
-    !reference [.on_kitchen_tests_a6]
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main"]
@@ -48,6 +46,8 @@
     - ls $OMNIBUS_PACKAGE_DIR
 
 deploy_deb_testing-a6_x64:
+  rules:
+    !reference [.on_kitchen_tests_a6]
   extends:
     - .deploy_deb_testing-a6
   needs: ["agent_deb-x64-a6", "agent_heroku_deb-x64-a6", "tests_deb-x64-py2", "tests_deb-x64-py3"]
@@ -63,6 +63,8 @@ deploy_deb_testing-a6_x64:
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID" -m 6 -b $DEB_TESTING_S3_BUCKET -a x86_64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-signing-keys_${DD_PIPELINE_ID}.deb
 
 deploy_deb_testing-a6_arm64:
+  rules:
+    !reference [.on_all_builds_a6]
   extends:
     - .deploy_deb_testing-a6
   needs: ["agent_deb-arm64-a6", "tests_deb-arm64-py2", "tests_deb-arm64-py3"]
@@ -76,8 +78,6 @@ deploy_deb_testing-a6_arm64:
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID" -m 6 -b $DEB_TESTING_S3_BUCKET -a arm64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-signing-keys_${DD_PIPELINE_ID}.deb
 
 .deploy_deb_testing-a7:
-  rules:
-    !reference [.on_default_kitchen_tests_a7]
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main"]
@@ -87,6 +87,8 @@ deploy_deb_testing-a6_arm64:
     - ls $OMNIBUS_PACKAGE_DIR
 
 deploy_deb_testing-a7_x64:
+  rules:
+    !reference [.on_default_kitchen_tests_a7]
   extends:
     - .deploy_deb_testing-a7
   needs: ["agent_deb-x64-a7", "agent_heroku_deb-x64-a7", "iot_agent_deb-x64", "dogstatsd_deb-x64", "tests_deb-x64-py3"]
@@ -102,6 +104,8 @@ deploy_deb_testing-a7_x64:
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID" -m 7 -b $DEB_TESTING_S3_BUCKET -a x86_64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-signing-keys_${DD_PIPELINE_ID}.deb
 
 deploy_deb_testing-a7_arm64:
+  rules:
+    !reference [.on_all_builds_a7]
   extends:
     - .deploy_deb_testing-a7
   needs: ["agent_deb-arm64-a7", "tests_deb-arm64-py2", "tests_deb-arm64-py3"]

--- a/.gitlab/kitchen_deploy.yml
+++ b/.gitlab/kitchen_deploy.yml
@@ -64,7 +64,7 @@ deploy_deb_testing-a6_x64:
 
 deploy_deb_testing-a6_arm64:
   rules:
-    !reference [.on_all_builds_a6]
+    !reference [.on_all_kitchen_builds_a6]
   extends:
     - .deploy_deb_testing-a6
   needs: ["agent_deb-arm64-a6", "tests_deb-arm64-py2", "tests_deb-arm64-py3"]
@@ -105,7 +105,7 @@ deploy_deb_testing-a7_x64:
 
 deploy_deb_testing-a7_arm64:
   rules:
-    !reference [.on_all_builds_a7]
+    !reference [.on_all_kitchen_builds_a7]
   extends:
     - .deploy_deb_testing-a7
   needs: ["agent_deb-arm64-a7", "tests_deb-arm64-py2", "tests_deb-arm64-py3"]

--- a/.gitlab/kitchen_deploy.yml
+++ b/.gitlab/kitchen_deploy.yml
@@ -36,17 +36,21 @@
   - filename=$(ls datadog-signing-keys*.deb); mv $filename datadog-signing-keys_${DD_PIPELINE_ID}.deb
   - popd
 
-deploy_deb_testing-a6:
+.deploy_deb_testing-a6:
   rules:
     !reference [.on_kitchen_tests_a6]
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main"]
-  needs: ["agent_deb-x64-a6", "agent_heroku_deb-x64-a6", "tests_deb-x64-py2", "tests_deb-x64-py3"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a6
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
+
+deploy_deb_testing-a6_x64:
+  extends:
+    - .deploy_deb_testing-a6
+  needs: ["agent_deb-x64-a6", "agent_heroku_deb-x64-a6", "tests_deb-x64-py2", "tests_deb-x64-py3"]
   script:
     - *setup_apt_signing_key
     - set +x  # make sure we don't output the creds to the build log
@@ -58,18 +62,34 @@ deploy_deb_testing-a6:
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID" -m 6 -b $DEB_TESTING_S3_BUCKET -a amd64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-signing-keys_${DD_PIPELINE_ID}.deb
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID" -m 6 -b $DEB_TESTING_S3_BUCKET -a x86_64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-signing-keys_${DD_PIPELINE_ID}.deb
 
+deploy_deb_testing-a6_arm64:
+  extends:
+    - .deploy_deb_testing-a6
+  needs: ["agent_deb-arm64-a6", "tests_deb-arm64-py2", "tests_deb-arm64-py3"]
+  script:
+    - *setup_apt_signing_key
+    - set +x  # make sure we don't output the creds to the build log
 
-deploy_deb_testing-a7:
+    - *setup_signing_keys_package
+
+    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID" -m 6 -b $DEB_TESTING_S3_BUCKET -a arm64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-*_6*arm64.deb
+    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID" -m 6 -b $DEB_TESTING_S3_BUCKET -a arm64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-signing-keys_${DD_PIPELINE_ID}.deb
+
+.deploy_deb_testing-a7:
   rules:
     !reference [.on_default_kitchen_tests_a7]
   stage: kitchen_deploy
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-builders/gitlab_agent_deploy:$DATADOG_AGENT_BUILDERS
   tags: ["runner:main"]
-  needs: ["agent_deb-x64-a7", "agent_heroku_deb-x64-a7", "iot_agent_deb-x64", "dogstatsd_deb-x64", "tests_deb-x64-py3"]
   variables:
     DD_PIPELINE_ID: $CI_PIPELINE_ID-a7
   before_script:
     - ls $OMNIBUS_PACKAGE_DIR
+
+deploy_deb_testing-a7_x64:
+  extends:
+    - .deploy_deb_testing-a7
+  needs: ["agent_deb-x64-a7", "agent_heroku_deb-x64-a7", "iot_agent_deb-x64", "dogstatsd_deb-x64", "tests_deb-x64-py3"]
   script:
     - *setup_apt_signing_key
     - set +x  # make sure we don't output the creds to the build log
@@ -80,6 +100,19 @@ deploy_deb_testing-a7:
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID" -m 7 -b $DEB_TESTING_S3_BUCKET -a x86_64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-*_7*amd64.deb
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID" -m 7 -b $DEB_TESTING_S3_BUCKET -a amd64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-signing-keys_${DD_PIPELINE_ID}.deb
     - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID" -m 7 -b $DEB_TESTING_S3_BUCKET -a x86_64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-signing-keys_${DD_PIPELINE_ID}.deb
+
+deploy_deb_testing-a7_arm64:
+  extends:
+    - .deploy_deb_testing-a7
+  needs: ["agent_deb-arm64-a7", "tests_deb-arm64-py2", "tests_deb-arm64-py3"]
+  script:
+    - *setup_apt_signing_key
+    - set +x  # make sure we don't output the creds to the build log
+
+    - *setup_signing_keys_package
+
+    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID" -m 7 -b $DEB_TESTING_S3_BUCKET -a arm64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-*_7*arm64.deb
+    - echo "$APT_SIGNING_KEY_PASSPHRASE" | deb-s3 upload -c "pipeline-$DD_PIPELINE_ID" -m 7 -b $DEB_TESTING_S3_BUCKET -a arm64 --sign=$DEB_GPG_KEY_ID --gpg_options="--passphrase-fd 0 --batch --digest-algo SHA512" --preserve_versions --visibility public $OMNIBUS_PACKAGE_DIR/datadog-signing-keys_${DD_PIPELINE_ID}.deb
 
 deploy_rpm_testing-a6:
   rules:

--- a/.gitlab/kitchen_testing/centos.yml
+++ b/.gitlab/kitchen_testing/centos.yml
@@ -49,36 +49,42 @@
   extends:
     - .kitchen_agent_a6
     - .kitchen_os_centos_all_non_fips
+    - .kitchen_azure_location_central_us
   needs: ["deploy_rpm_testing-a6"]
 
 .kitchen_scenario_centos_all_non_fips_a7:
   extends:
     - .kitchen_agent_a7
     - .kitchen_os_centos_all_non_fips
+    - .kitchen_azure_location_central_us
   needs: ["deploy_rpm_testing-a7"]
 
 .kitchen_scenario_centos_6_7_non_fips_a6:
   extends:
     - .kitchen_os_centos_6_7_non_fips
     - .kitchen_agent_a6
+    - .kitchen_azure_location_central_us
   needs: ["deploy_rpm_testing-a6"]
 
 .kitchen_scenario_centos_6_7_non_fips_a7:
   extends:
     - .kitchen_agent_a7
     - .kitchen_os_centos_6_7_non_fips
+    - .kitchen_azure_location_south_central_us
   needs: ["deploy_rpm_testing-a7"]
 
 .kitchen_scenario_centos_8_fips_a6:
   extends:
     - .kitchen_agent_a6
     - .kitchen_os_centos_8_fips
+    - .kitchen_azure_location_south_central_us
   needs: ["deploy_rpm_testing-a6"]
 
 .kitchen_scenario_centos_8_fips_a7:
   extends:
     - .kitchen_agent_a7
     - .kitchen_os_centos_8_fips
+    - .kitchen_azure_location_south_central_us
   needs: ["deploy_rpm_testing-a7"]
 
 # Kitchen: final test matrix (tests * scenarios)

--- a/.gitlab/kitchen_testing/centos.yml
+++ b/.gitlab/kitchen_testing/centos.yml
@@ -42,49 +42,49 @@
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 
-# Kitchen: scenarios (os * agent)
+# Kitchen: scenarios (os * agent * (cloud + arch))
 # -------------------------------
 
 .kitchen_scenario_centos_all_non_fips_a6:
   extends:
     - .kitchen_agent_a6
     - .kitchen_os_centos_all_non_fips
-    - .kitchen_azure_location_central_us
+    - .kitchen_azure_x64
   needs: ["deploy_rpm_testing-a6"]
 
 .kitchen_scenario_centos_all_non_fips_a7:
   extends:
     - .kitchen_agent_a7
     - .kitchen_os_centos_all_non_fips
-    - .kitchen_azure_location_central_us
+    - .kitchen_azure_x64
   needs: ["deploy_rpm_testing-a7"]
 
 .kitchen_scenario_centos_6_7_non_fips_a6:
   extends:
     - .kitchen_os_centos_6_7_non_fips
     - .kitchen_agent_a6
-    - .kitchen_azure_location_central_us
+    - .kitchen_azure_x64
   needs: ["deploy_rpm_testing-a6"]
 
 .kitchen_scenario_centos_6_7_non_fips_a7:
   extends:
     - .kitchen_agent_a7
     - .kitchen_os_centos_6_7_non_fips
-    - .kitchen_azure_location_south_central_us
+    - .kitchen_azure_x64
   needs: ["deploy_rpm_testing-a7"]
 
 .kitchen_scenario_centos_8_fips_a6:
   extends:
     - .kitchen_agent_a6
     - .kitchen_os_centos_8_fips
-    - .kitchen_azure_location_south_central_us
+    - .kitchen_azure_x64
   needs: ["deploy_rpm_testing-a6"]
 
 .kitchen_scenario_centos_8_fips_a7:
   extends:
     - .kitchen_agent_a7
     - .kitchen_os_centos_8_fips
-    - .kitchen_azure_location_south_central_us
+        - .kitchen_azure_x64
   needs: ["deploy_rpm_testing-a7"]
 
 # Kitchen: final test matrix (tests * scenarios)

--- a/.gitlab/kitchen_testing/centos.yml
+++ b/.gitlab/kitchen_testing/centos.yml
@@ -84,7 +84,7 @@
   extends:
     - .kitchen_agent_a7
     - .kitchen_os_centos_8_fips
-        - .kitchen_azure_x64
+    - .kitchen_azure_x64
   needs: ["deploy_rpm_testing-a7"]
 
 # Kitchen: final test matrix (tests * scenarios)

--- a/.gitlab/kitchen_testing/debian.yml
+++ b/.gitlab/kitchen_testing/debian.yml
@@ -17,7 +17,7 @@
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 
-# Kitchen: scenarios (os * agent * arch)
+# Kitchen: scenarios (os * agent * (cloud + arch))
 # -------------------------------
 
 .kitchen_scenario_debian_a6_x64:
@@ -27,7 +27,7 @@
   extends:
     - .kitchen_agent_a6
     - .kitchen_os_debian
-    - .kitchen_azure_location_south_central_us
+    - .kitchen_azure_x64
   needs: ["deploy_deb_testing-a6_x64"]
 
 .kitchen_scenario_debian_a7_x64:
@@ -37,7 +37,7 @@
   extends:
     - .kitchen_agent_a7
     - .kitchen_os_debian
-    - .kitchen_azure_location_south_central_us
+    - .kitchen_azure_x64
   needs: ["deploy_deb_testing-a7_x64"]
 
 .kitchen_scenario_debian_a6_arm64:
@@ -82,9 +82,8 @@ kitchen_debian_install_script_agent-a7_x64:
     - .kitchen_test_install_script_agent
 
 kitchen_debian_install_script_agent-a7_arm64:
-  # Run install script test on branches, on a reduced number of platforms
   rules:
-    !reference [.on_all_builds_a7]
+    !reference [.on_all_kitchen_builds_a7]
   extends:
     - .kitchen_scenario_debian_a7_arm64
     - .kitchen_test_install_script_agent

--- a/.gitlab/kitchen_testing/debian.yml
+++ b/.gitlab/kitchen_testing/debian.yml
@@ -19,20 +19,36 @@
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 
-# Kitchen: scenarios (os * agent)
+# Kitchen: scenarios (os * agent * arch)
 # -------------------------------
 
-.kitchen_scenario_debian_a6:
+.kitchen_scenario_debian_a6_x64:
   extends:
     - .kitchen_agent_a6
     - .kitchen_os_debian
-  needs: ["deploy_deb_testing-a6"]
+    - .kitchen_azure_location_south_central_us
+  needs: ["deploy_deb_testing-a6_x64"]
 
-.kitchen_scenario_debian_a7:
+.kitchen_scenario_debian_a7_x64:
   extends:
     - .kitchen_agent_a7
     - .kitchen_os_debian
-  needs: ["deploy_deb_testing-a7"]
+    - .kitchen_azure_location_south_central_us
+  needs: ["deploy_deb_testing-a7_x64"]
+
+.kitchen_scenario_debian_a6_arm64:
+  extends:
+    - .kitchen_agent_a6
+    - .kitchen_os_debian
+    - .kitchen_ec2_arm64
+  needs: ["deploy_deb_testing-a6_arm64"]
+
+.kitchen_scenario_debian_a7_arm64:
+  extends:
+    - .kitchen_agent_a7
+    - .kitchen_os_debian
+    - .kitchen_ec2_arm64
+  needs: ["deploy_deb_testing-a7_arm64"]
 
 # Kitchen: final test matrix (tests * scenarios)
 # ----------------------------------------------

--- a/.gitlab/kitchen_testing/debian.yml
+++ b/.gitlab/kitchen_testing/debian.yml
@@ -60,20 +60,33 @@
     - .kitchen_ec2_arm64
   needs: ["deploy_deb_testing-a7_arm64"]
 
-# Kitchen: final test matrix (tests * scenarios)
+# Kitchen: final test matrix (tests * scenarios * arch)
 # ----------------------------------------------
 
-kitchen_debian_install_script_agent-a6:
+kitchen_debian_install_script_agent-a6_x64:
   extends:
     - .kitchen_scenario_debian_a6_x64
     - .kitchen_test_install_script_agent
 
-kitchen_debian_install_script_agent-a7:
+kitchen_debian_install_script_agent-a6_arm64:
+  extends:
+    - .kitchen_scenario_debian_a6_arm64
+    - .kitchen_test_install_script_agent
+
+kitchen_debian_install_script_agent-a7_x64:
   # Run install script test on branches, on a reduced number of platforms
   rules:
     !reference [.on_default_kitchen_tests_a7]
   extends:
     - .kitchen_scenario_debian_a7_x64
+    - .kitchen_test_install_script_agent
+
+kitchen_debian_install_script_agent-a7_arm64:
+  # Run install script test on branches, on a reduced number of platforms
+  rules:
+    !reference [.on_default_kitchen_tests_a7]
+  extends:
+    - .kitchen_scenario_debian_a7_arm64
     - .kitchen_test_install_script_agent
 
 kitchen_debian_install_script_iot_agent-a7:

--- a/.gitlab/kitchen_testing/debian.yml
+++ b/.gitlab/kitchen_testing/debian.yml
@@ -60,7 +60,7 @@
     - .kitchen_ec2_arm64
   needs: ["deploy_deb_testing-a7_arm64"]
 
-# Kitchen: final test matrix (tests * scenarios * arch)
+# Kitchen: final test matrix (tests * scenarios)
 # ----------------------------------------------
 
 kitchen_debian_install_script_agent-a6_x64:

--- a/.gitlab/kitchen_testing/debian.yml
+++ b/.gitlab/kitchen_testing/debian.yml
@@ -84,7 +84,7 @@ kitchen_debian_install_script_agent-a7_x64:
 kitchen_debian_install_script_agent-a7_arm64:
   # Run install script test on branches, on a reduced number of platforms
   rules:
-    !reference [.on_default_kitchen_tests_a7]
+    !reference [.on_all_builds_a7]
   extends:
     - .kitchen_scenario_debian_a7_arm64
     - .kitchen_test_install_script_agent

--- a/.gitlab/kitchen_testing/debian.yml
+++ b/.gitlab/kitchen_testing/debian.yml
@@ -12,8 +12,6 @@
 .kitchen_os_debian:
   variables:
     KITCHEN_PLATFORM: "debian"
-    KITCHEN_OSVERS: "debian-8,debian-9,debian-10,debian-11"
-    DEFAULT_KITCHEN_OSVERS: "debian-11"
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - cd $DD_AGENT_TESTING_DIR
@@ -23,6 +21,9 @@
 # -------------------------------
 
 .kitchen_scenario_debian_a6_x64:
+  variables:
+    KITCHEN_OSVERS: "debian-8,debian-9,debian-10,debian-11"
+    DEFAULT_KITCHEN_OSVERS: "debian-11"
   extends:
     - .kitchen_agent_a6
     - .kitchen_os_debian
@@ -30,6 +31,9 @@
   needs: ["deploy_deb_testing-a6_x64"]
 
 .kitchen_scenario_debian_a7_x64:
+  variables:
+    KITCHEN_OSVERS: "debian-8,debian-9,debian-10,debian-11"
+    DEFAULT_KITCHEN_OSVERS: "debian-11"
   extends:
     - .kitchen_agent_a7
     - .kitchen_os_debian
@@ -37,6 +41,9 @@
   needs: ["deploy_deb_testing-a7_x64"]
 
 .kitchen_scenario_debian_a6_arm64:
+  variables:
+    KITCHEN_OSVERS: "debian-10"
+    DEFAULT_KITCHEN_OSVERS: "debian-10"
   extends:
     - .kitchen_agent_a6
     - .kitchen_os_debian
@@ -44,6 +51,9 @@
   needs: ["deploy_deb_testing-a6_arm64"]
 
 .kitchen_scenario_debian_a7_arm64:
+  variables:
+    KITCHEN_OSVERS: "debian-10"
+    DEFAULT_KITCHEN_OSVERS: "debian-10"
   extends:
     - .kitchen_agent_a7
     - .kitchen_os_debian
@@ -55,7 +65,7 @@
 
 kitchen_debian_install_script_agent-a6:
   extends:
-    - .kitchen_scenario_debian_a6
+    - .kitchen_scenario_debian_a6_x64
     - .kitchen_test_install_script_agent
 
 kitchen_debian_install_script_agent-a7:
@@ -63,27 +73,27 @@ kitchen_debian_install_script_agent-a7:
   rules:
     !reference [.on_default_kitchen_tests_a7]
   extends:
-    - .kitchen_scenario_debian_a7
+    - .kitchen_scenario_debian_a7_x64
     - .kitchen_test_install_script_agent
 
 kitchen_debian_install_script_iot_agent-a7:
   extends:
-    - .kitchen_scenario_debian_a7
+    - .kitchen_scenario_debian_a7_x64
     - .kitchen_test_install_script_iot_agent
 
 kitchen_debian_install_script_heroku_agent-a6:
   extends:
-    - .kitchen_scenario_debian_a6
+    - .kitchen_scenario_debian_a6_x64
     - .kitchen_test_install_script_heroku_agent
 
 kitchen_debian_install_script_heroku_agent-a7:
   extends:
-    - .kitchen_scenario_debian_a7
+    - .kitchen_scenario_debian_a7_x64
     - .kitchen_test_install_script_heroku_agent
 
 kitchen_debian_install_script_dogstatsd-a7:
   extends:
-    - .kitchen_scenario_debian_a7
+    - .kitchen_scenario_debian_a7_x64
     - .kitchen_test_install_script_dogstatsd
 
 # We only want to run step-by-step tests on deploy pipelines,
@@ -91,44 +101,44 @@ kitchen_debian_install_script_dogstatsd-a7:
 
 kitchen_debian_step_by_step_agent-a6:
   extends:
-    - .kitchen_scenario_debian_a6
+    - .kitchen_scenario_debian_a6_x64
     - .kitchen_test_step_by_step_agent
   rules:
     !reference [.on_deploy_a6]
 
 kitchen_debian_step_by_step_agent-a7:
   extends:
-    - .kitchen_scenario_debian_a7
+    - .kitchen_scenario_debian_a7_x64
     - .kitchen_test_step_by_step_agent
   rules:
     !reference [.on_deploy_a7]
 
 kitchen_debian_upgrade5_agent-a6:
   extends:
-    - .kitchen_scenario_debian_a6
+    - .kitchen_scenario_debian_a6_x64
     - .kitchen_test_upgrade5_agent
 
 kitchen_debian_upgrade5_agent-a7:
   extends:
-    - .kitchen_scenario_debian_a7
+    - .kitchen_scenario_debian_a7_x64
     - .kitchen_test_upgrade5_agent
 
 kitchen_debian_upgrade6_agent-a6:
   extends:
-    - .kitchen_scenario_debian_a6
+    - .kitchen_scenario_debian_a6_x64
     - .kitchen_test_upgrade6_agent
 
 kitchen_debian_upgrade6_agent-a7:
   extends:
-    - .kitchen_scenario_debian_a7
+    - .kitchen_scenario_debian_a7_x64
     - .kitchen_test_upgrade6_agent
 
 kitchen_debian_upgrade7_agent-a7:
   extends:
-    - .kitchen_scenario_debian_a7
+    - .kitchen_scenario_debian_a7_x64
     - .kitchen_test_upgrade7_agent
 
 kitchen_debian_upgrade7_iot_agent-a7:
   extends:
-    - .kitchen_scenario_debian_a7
+    - .kitchen_scenario_debian_a7_x64
     - .kitchen_test_upgrade7_iot_agent

--- a/.gitlab/kitchen_testing/suse.yml
+++ b/.gitlab/kitchen_testing/suse.yml
@@ -19,21 +19,21 @@
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 
-# Kitchen: scenarios (os * agent)
+# Kitchen: scenarios (os * agent * (cloud + arch))
 # -------------------------------
 
 .kitchen_scenario_suse_a6:
   extends:
     - .kitchen_agent_a6
     - .kitchen_os_suse
-    - .kitchen_azure_location_west_central_us
+    - .kitchen_azure_x64
   needs: ["deploy_suse_rpm_testing-a6"]
 
 .kitchen_scenario_suse_a7:
   extends:
     - .kitchen_agent_a7
     - .kitchen_os_suse
-    - .kitchen_azure_location_west_central_us
+    - .kitchen_azure_x64
   needs: ["deploy_suse_rpm_testing-a7"]
 
 # Kitchen: final test matrix (tests * scenarios)

--- a/.gitlab/kitchen_testing/suse.yml
+++ b/.gitlab/kitchen_testing/suse.yml
@@ -26,12 +26,14 @@
   extends:
     - .kitchen_agent_a6
     - .kitchen_os_suse
+    - .kitchen_azure_location_west_central_us
   needs: ["deploy_suse_rpm_testing-a6"]
 
 .kitchen_scenario_suse_a7:
   extends:
     - .kitchen_agent_a7
     - .kitchen_os_suse
+    - .kitchen_azure_location_west_central_us
   needs: ["deploy_suse_rpm_testing-a7"]
 
 # Kitchen: final test matrix (tests * scenarios)

--- a/.gitlab/kitchen_testing/ubuntu.yml
+++ b/.gitlab/kitchen_testing/ubuntu.yml
@@ -18,90 +18,133 @@
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 
-# Kitchen: scenarios (os * agent)
+# Kitchen: scenarios (os * agent * arch)
 # -------------------------------
 
-.kitchen_scenario_ubuntu_a6:
+.kitchen_scenario_ubuntu_a6_x64:
   extends:
     - .kitchen_agent_a6
     - .kitchen_os_ubuntu
-  needs: ["deploy_deb_testing-a6"]
+    - .kitchen_azure_location_central_us
+  needs: ["deploy_deb_testing-a6_x64"]
 
-.kitchen_scenario_ubuntu_a7:
+.kitchen_scenario_ubuntu_a7_x64:
   extends:
     - .kitchen_agent_a7
     - .kitchen_os_ubuntu
-  needs: ["deploy_deb_testing-a7"]
+    - .kitchen_azure_location_north_central_us
+  needs: ["deploy_deb_testing-a7_x64"]
+
+.kitchen_scenario_ubuntu_a6_arm64:
+  extends:
+    - .kitchen_agent_a6
+    - .kitchen_os_ubuntu
+    - .kitchen_ec2_arm64
+  needs: ["deploy_deb_testing-a6_arm64"]
+
+.kitchen_scenario_ubuntu_a7_arm64:
+  extends:
+    - .kitchen_agent_a7
+    - .kitchen_os_ubuntu
+    - .kitchen_ec2_arm64
+  needs: ["deploy_deb_testing-a7_arm64"]
 
 # Kitchen: final test matrix (tests * scenarios)
 # ----------------------------------------------
 
-kitchen_ubuntu_install_script_agent-a6:
+kitchen_ubuntu_install_script_agent-a6_x64:
   extends:
-    - .kitchen_scenario_ubuntu_a6
+    - .kitchen_scenario_ubuntu_a6_x64
     - .kitchen_test_install_script_agent
 
-kitchen_ubuntu_install_script_agent-a7:
+kitchen_ubuntu_install_script_agent-a6_arm64:
+  extends:
+    - .kitchen_scenario_ubuntu_a6_arm64
+    - .kitchen_test_install_script_agent
+
+kitchen_ubuntu_install_script_agent-a7_x64:
   # Run install script test on branches, on a reduced number of platforms
   rules:
     !reference [.on_default_kitchen_tests_a7]
   extends:
-    - .kitchen_scenario_ubuntu_a7
+    - .kitchen_scenario_ubuntu_a7_x64
+    - .kitchen_test_install_script_agent
+
+kitchen_ubuntu_install_script_agent-a7_arm64:
+  # Run install script test on branches, on a reduced number of platforms
+  rules:
+    !reference [.on_default_kitchen_tests_a7]
+  extends:
+    - .kitchen_scenario_ubuntu_a7_arm64
     - .kitchen_test_install_script_agent
 
 kitchen_ubuntu_install_script_iot_agent-a7:
   extends:
-    - .kitchen_scenario_ubuntu_a7
+    - .kitchen_scenario_ubuntu_a7_x64
     - .kitchen_test_install_script_iot_agent
 
 kitchen_ubuntu_install_script_dogstatsd-a7:
   extends:
-    - .kitchen_scenario_ubuntu_a7
+    - .kitchen_scenario_ubuntu_a7_x64
     - .kitchen_test_install_script_dogstatsd
 
 # We only want to run step-by-step tests on deploy pipelines,
 # which is why they have a different rule (if_deploy_6/7)
 
-kitchen_ubuntu_step_by_step_agent-a6:
+kitchen_ubuntu_step_by_step_agent-a6_x64:
   extends:
-    - .kitchen_scenario_ubuntu_a6
+    - .kitchen_scenario_ubuntu_a6_x64
     - .kitchen_test_step_by_step_agent
   rules:
     !reference [.on_deploy_a6]
 
-kitchen_ubuntu_step_by_step_agent-a7:
+kitchen_ubuntu_step_by_step_agent-a6_arm64:
   extends:
-    - .kitchen_scenario_ubuntu_a7
+    - .kitchen_scenario_ubuntu_a6_arm64
+    - .kitchen_test_step_by_step_agent
+  rules:
+    !reference [.on_deploy_a6]
+
+kitchen_ubuntu_step_by_step_agent-a7_x64:
+  extends:
+    - .kitchen_scenario_ubuntu_a7_x64
+    - .kitchen_test_step_by_step_agent
+  rules:
+    !reference [.on_deploy_a7]
+
+kitchen_ubuntu_step_by_step_agent-a7_arm64:
+  extends:
+    - .kitchen_scenario_ubuntu_a7_arm64
     - .kitchen_test_step_by_step_agent
   rules:
     !reference [.on_deploy_a7]
 
 kitchen_ubuntu_upgrade5_agent-a6:
   extends:
-    - .kitchen_scenario_ubuntu_a6
+    - .kitchen_scenario_ubuntu_a6_x64
     - .kitchen_test_upgrade5_agent
 
 kitchen_ubuntu_upgrade5_agent-a7:
   extends:
-    - .kitchen_scenario_ubuntu_a7
+    - .kitchen_scenario_ubuntu_a7_x64
     - .kitchen_test_upgrade5_agent
 
 kitchen_ubuntu_upgrade6_agent-a6:
   extends:
-    - .kitchen_scenario_ubuntu_a6
+    - .kitchen_scenario_ubuntu_a6_x64
     - .kitchen_test_upgrade6_agent
 
 kitchen_ubuntu_upgrade6_agent-a7:
   extends:
-    - .kitchen_scenario_ubuntu_a7
+    - .kitchen_scenario_ubuntu_a7_x64
     - .kitchen_test_upgrade6_agent
 
 kitchen_ubuntu_upgrade7_agent-a7:
   extends:
-    - .kitchen_scenario_ubuntu_a7
+    - .kitchen_scenario_ubuntu_a7_x64
     - .kitchen_test_upgrade7_agent
 
 kitchen_ubuntu_upgrade7_iot_agent-a7:
   extends:
-    - .kitchen_scenario_ubuntu_a7
+    - .kitchen_scenario_ubuntu_a7_x64
     - .kitchen_test_upgrade7_iot_agent

--- a/.gitlab/kitchen_testing/ubuntu.yml
+++ b/.gitlab/kitchen_testing/ubuntu.yml
@@ -11,8 +11,6 @@
 .kitchen_os_ubuntu:
   variables:
     KITCHEN_PLATFORM: "ubuntu"
-    KITCHEN_OSVERS: "ubuntu-14-04,ubuntu-16-04,ubuntu-18-04,ubuntu-20-04"
-    DEFAULT_KITCHEN_OSVERS: "ubuntu-20-04"
   before_script:
     - rsync -azr --delete ./ $SRC_PATH
     - cd $DD_AGENT_TESTING_DIR
@@ -22,6 +20,9 @@
 # -------------------------------
 
 .kitchen_scenario_ubuntu_a6_x64:
+  variables:
+    KITCHEN_OSVERS: "ubuntu-14-04,ubuntu-16-04,ubuntu-18-04,ubuntu-20-04"
+    DEFAULT_KITCHEN_OSVERS: "ubuntu-20-04"
   extends:
     - .kitchen_agent_a6
     - .kitchen_os_ubuntu
@@ -29,6 +30,9 @@
   needs: ["deploy_deb_testing-a6_x64"]
 
 .kitchen_scenario_ubuntu_a7_x64:
+  variables:
+    KITCHEN_OSVERS: "ubuntu-14-04,ubuntu-16-04,ubuntu-18-04,ubuntu-20-04"
+    DEFAULT_KITCHEN_OSVERS: "ubuntu-20-04"
   extends:
     - .kitchen_agent_a7
     - .kitchen_os_ubuntu
@@ -36,6 +40,9 @@
   needs: ["deploy_deb_testing-a7_x64"]
 
 .kitchen_scenario_ubuntu_a6_arm64:
+  variables:
+    KITCHEN_OSVERS: "ubuntu-18-04,ubuntu-20-04"
+    DEFAULT_KITCHEN_OSVERS: "ubuntu-20-04"
   extends:
     - .kitchen_agent_a6
     - .kitchen_os_ubuntu
@@ -43,6 +50,9 @@
   needs: ["deploy_deb_testing-a6_arm64"]
 
 .kitchen_scenario_ubuntu_a7_arm64:
+  variables:
+    KITCHEN_OSVERS: "ubuntu-18-04,ubuntu-20-04"
+    DEFAULT_KITCHEN_OSVERS: "ubuntu-20-04"
   extends:
     - .kitchen_agent_a7
     - .kitchen_os_ubuntu

--- a/.gitlab/kitchen_testing/ubuntu.yml
+++ b/.gitlab/kitchen_testing/ubuntu.yml
@@ -16,7 +16,7 @@
     - cd $DD_AGENT_TESTING_DIR
     - bash -l tasks/kitchen_setup.sh
 
-# Kitchen: scenarios (os * agent * arch)
+# Kitchen: scenarios (os * agent * (cloud + arch))
 # -------------------------------
 
 .kitchen_scenario_ubuntu_a6_x64:
@@ -26,7 +26,7 @@
   extends:
     - .kitchen_agent_a6
     - .kitchen_os_ubuntu
-    - .kitchen_azure_location_central_us
+    - .kitchen_azure_x64
   needs: ["deploy_deb_testing-a6_x64"]
 
 .kitchen_scenario_ubuntu_a7_x64:
@@ -36,7 +36,7 @@
   extends:
     - .kitchen_agent_a7
     - .kitchen_os_ubuntu
-    - .kitchen_azure_location_north_central_us
+    - .kitchen_azure_x64
   needs: ["deploy_deb_testing-a7_x64"]
 
 .kitchen_scenario_ubuntu_a6_arm64:
@@ -81,9 +81,8 @@ kitchen_ubuntu_install_script_agent-a7_x64:
     - .kitchen_test_install_script_agent
 
 kitchen_ubuntu_install_script_agent-a7_arm64:
-  # Run install script test on branches, on a reduced number of platforms
   rules:
-    !reference [.on_all_builds_a7]
+    !reference [.on_all_kitchen_builds_a7]
   extends:
     - .kitchen_scenario_ubuntu_a7_arm64
     - .kitchen_test_install_script_agent

--- a/.gitlab/kitchen_testing/ubuntu.yml
+++ b/.gitlab/kitchen_testing/ubuntu.yml
@@ -83,7 +83,7 @@ kitchen_ubuntu_install_script_agent-a7_x64:
 kitchen_ubuntu_install_script_agent-a7_arm64:
   # Run install script test on branches, on a reduced number of platforms
   rules:
-    !reference [.on_default_kitchen_tests_a7]
+    !reference [.on_all_builds_a7]
   extends:
     - .kitchen_scenario_ubuntu_a7_arm64
     - .kitchen_test_install_script_agent

--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -9,6 +9,8 @@
 # -------------
 
 .kitchen_os_windows:
+  extends:
+    - .kitchen_azure_x64
   variables:
     KITCHEN_PLATFORM: "windows"
     KITCHEN_OSVERS: "win2008r2,win2012,win2012r2,win2016,win2019,win2019cn,win2022"
@@ -82,16 +84,19 @@
   extends:
     - .kitchen_test_windows_installer
     - .kitchen_datadog_agent_flavor
+    - .kitchen_azure_location_north_central_us
 
 .kitchen_test_windows_installer_driver:
   extends:
     - .kitchen_test_windows_npm_driver
     - .kitchen_datadog_agent_flavor
+    - .kitchen_azure_location_north_central_us
 
 .kitchen_test_windows_installer_npm:
   extends:
     - .kitchen_test_windows_npm_installer
     - .kitchen_datadog_agent_flavor
+    - .kitchen_azure_location_north_central_us
 
 # Kitchen: scenarios (os * agent)
 # -------------------------------

--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -77,7 +77,7 @@
     - export LAST_STABLE_VERSION=$(cd ../.. && invoke release.get-release-json-value "last_stable::$AGENT_MAJOR_VERSION")
     - bash -l tasks/run-test-kitchen.sh windows-npm-test $AGENT_MAJOR_VERSION
 
-# Kitchen: Test types (test suite * agent flavor)
+# Kitchen: Test types (test suite * agent flavor + azure location)
 # -------------------------------
 
 .kitchen_test_windows_installer_agent:

--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -27,6 +27,8 @@
 # --------------
 
 .kitchen_test_windows_installer:
+  extends:
+    - .kitchen_azure_x64
   variables:
     KITCHEN_PLATFORM: "windows"
     KITCHEN_OSVERS: "win2012r2"
@@ -40,6 +42,8 @@
     - bash -l tasks/run-test-kitchen.sh windows-install-test $AGENT_MAJOR_VERSION
 
 .kitchen_test_windows_npm_driver:
+  extends:
+    - .kitchen_azure_x64
   variables:
     KITCHEN_PLATFORM: "windows"
     KITCHEN_OSVERS: "win2012r2,win2016,win2019,win2019cn,win1903,win1909,win2004,win20h2,win2022"
@@ -55,6 +59,8 @@
     - bash -l tasks/run-test-kitchen.sh windows-npmdriver $AGENT_MAJOR_VERSION
 
 .kitchen_test_windows_npm_installer:
+  extends:
+    - .kitchen_azure_x64
   variables:
     KITCHEN_PLATFORM: "windows"
     KITCHEN_OSVERS: "win2016"
@@ -69,26 +75,23 @@
     - export LAST_STABLE_VERSION=$(cd ../.. && invoke release.get-release-json-value "last_stable::$AGENT_MAJOR_VERSION")
     - bash -l tasks/run-test-kitchen.sh windows-npm-test $AGENT_MAJOR_VERSION
 
-# Kitchen: Test types (test suite * agent flavor + azure location)
+# Kitchen: Test types (test suite * agent flavor)
 # -------------------------------
 
 .kitchen_test_windows_installer_agent:
   extends:
     - .kitchen_test_windows_installer
     - .kitchen_datadog_agent_flavor
-    - .kitchen_azure_location_north_central_us
 
 .kitchen_test_windows_installer_driver:
   extends:
     - .kitchen_test_windows_npm_driver
     - .kitchen_datadog_agent_flavor
-    - .kitchen_azure_location_north_central_us
 
 .kitchen_test_windows_installer_npm:
   extends:
     - .kitchen_test_windows_npm_installer
     - .kitchen_datadog_agent_flavor
-    - .kitchen_azure_location_north_central_us
 
 # Kitchen: scenarios (os * agent)
 # -------------------------------
@@ -135,7 +138,6 @@ kitchen_windows_chef_agent-a6:
   extends:
     - .kitchen_scenario_windows_a6
     - .kitchen_test_chef_agent
-    - .kitchen_azure_location_north_central_us
 
 kitchen_windows_chef_agent-a7:
   # Run chef test on branches, on a reduced number of platforms
@@ -144,34 +146,28 @@ kitchen_windows_chef_agent-a7:
   extends:
     - .kitchen_scenario_windows_a7
     - .kitchen_test_chef_agent
-    - .kitchen_azure_location_north_central_us
 
 kitchen_windows_upgrade5_agent-a6:
   extends:
     - .kitchen_scenario_windows_a6
     - .kitchen_test_upgrade5_agent
-    - .kitchen_azure_location_south_central_us
 
 kitchen_windows_upgrade5_agent-a7:
   extends:
     - .kitchen_scenario_windows_a7
     - .kitchen_test_upgrade5_agent
-    - .kitchen_azure_location_south_central_us
 
 kitchen_windows_upgrade6_agent-a6:
   extends:
     - .kitchen_scenario_windows_a6
     - .kitchen_test_upgrade6_agent
-    - .kitchen_azure_location_west_central_us
 
 kitchen_windows_upgrade6_agent-a7:
   extends:
     - .kitchen_scenario_windows_a7
     - .kitchen_test_upgrade6_agent
-    - .kitchen_azure_location_west_central_us
 
 kitchen_windows_upgrade7_agent-a7:
   extends:
     - .kitchen_scenario_windows_a7
     - .kitchen_test_upgrade7_agent
-    - .kitchen_azure_location_west_central_us

--- a/.gitlab/kitchen_testing/windows.yml
+++ b/.gitlab/kitchen_testing/windows.yml
@@ -135,6 +135,7 @@ kitchen_windows_chef_agent-a6:
   extends:
     - .kitchen_scenario_windows_a6
     - .kitchen_test_chef_agent
+    - .kitchen_azure_location_north_central_us
 
 kitchen_windows_chef_agent-a7:
   # Run chef test on branches, on a reduced number of platforms
@@ -143,28 +144,34 @@ kitchen_windows_chef_agent-a7:
   extends:
     - .kitchen_scenario_windows_a7
     - .kitchen_test_chef_agent
+    - .kitchen_azure_location_north_central_us
 
 kitchen_windows_upgrade5_agent-a6:
   extends:
     - .kitchen_scenario_windows_a6
     - .kitchen_test_upgrade5_agent
+    - .kitchen_azure_location_south_central_us
 
 kitchen_windows_upgrade5_agent-a7:
   extends:
     - .kitchen_scenario_windows_a7
     - .kitchen_test_upgrade5_agent
+    - .kitchen_azure_location_south_central_us
 
 kitchen_windows_upgrade6_agent-a6:
   extends:
     - .kitchen_scenario_windows_a6
     - .kitchen_test_upgrade6_agent
+    - .kitchen_azure_location_west_central_us
 
 kitchen_windows_upgrade6_agent-a7:
   extends:
     - .kitchen_scenario_windows_a7
     - .kitchen_test_upgrade6_agent
+    - .kitchen_azure_location_west_central_us
 
 kitchen_windows_upgrade7_agent-a7:
   extends:
     - .kitchen_scenario_windows_a7
     - .kitchen_test_upgrade7_agent
+    - .kitchen_azure_location_west_central_us

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -87,7 +87,7 @@ agent_deb-x64-a7:
 agent_deb-arm64-a6:
   extends: .agent_build_common_deb
   rules:
-    !reference [.on_a6]
+    !reference [.on_all_builds_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
@@ -105,7 +105,7 @@ agent_deb-arm64-a6:
 agent_deb-arm64-a7:
   extends: .agent_build_common_deb
   rules:
-    !reference [.on_a7]
+    !reference [.on_all_builds_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]

--- a/.gitlab/package_build/deb.yml
+++ b/.gitlab/package_build/deb.yml
@@ -87,7 +87,7 @@ agent_deb-x64-a7:
 agent_deb-arm64-a6:
   extends: .agent_build_common_deb
   rules:
-    !reference [.on_all_builds_a6]
+    !reference [.on_a6]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
@@ -105,7 +105,7 @@ agent_deb-arm64-a6:
 agent_deb-arm64-a7:
   extends: .agent_build_common_deb
   rules:
-    !reference [.on_all_builds_a7]
+    !reference [.on_a7]
   stage: package_build
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR adds several ARM kitchen tests running in EC2 for Ubuntu and Debian.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
Better tests coverage.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes
Since the Agent install kitchen tests were initially only run on Azure, they were spread over various Azure locations (due to the Azure resource limits). In order to run those tests in EC2 as well, the location parameter was moved closer to the actual test definition, and that resulted in shuffling the location of the tests a little bit.
I tried to maintain a rough balance to ensure the tests are evenly spread out in Azure.

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes
Running a full pipeline should the following tests for ARM:
- kitchen_ubuntu_install_script_agent-a6_arm64
- kitchen_ubuntu_install_script_agent-a7_arm64
- kitchen_ubuntu_step_by_step_agent-a6_arm64
- kitchen_ubuntu_step_by_step_agent-a7_arm64
- kitchen_debian_install_script_agent-a6_arm64
- kitchen_debian_install_script_agent-a7_arm64

In a normal (PR) pipeline, there should be no changes.

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
