### PR TITLE
[inv deps] Also fetch dependencies for nested modules

### DIFF
--- a/.gitlab/deps_fetch.yml
+++ b/.gitlab/deps_fetch.yml
@@ -17,7 +17,7 @@ go_deps:
   tags: ["runner:main"]
   needs: []
   script:
-    - inv -e deps
+    - inv -e deps --verbose
     - cd $GOPATH/pkg/mod/ && tar czf $CI_PROJECT_DIR/modcache.tar.gz .
   artifacts:
     expire_in: 1 day

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -291,7 +291,10 @@ def deps(ctx, verbose=False):
     print("downloading dependencies")
     start = datetime.datetime.now()
     verbosity = ' -x' if verbose else ''
-    ctx.run(f"go mod download{verbosity}")
+    cmd = f"go mod download{verbosity}"
+    for mod in DEFAULT_MODULES.values():
+        with ctx.cd(mod.full_path()):
+            ctx.run(cmd)
     dep_done = datetime.datetime.now()
     print(f"go mod download, elapsed: {dep_done - start}")
 

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -291,10 +291,9 @@ def deps(ctx, verbose=False):
     print("downloading dependencies")
     start = datetime.datetime.now()
     verbosity = ' -x' if verbose else ''
-    cmd = f"go mod download{verbosity}"
     for mod in DEFAULT_MODULES.values():
         with ctx.cd(mod.full_path()):
-            ctx.run(cmd)
+            ctx.run(f"go mod download{verbosity}")
     dep_done = datetime.datetime.now()
     print(f"go mod download, elapsed: {dep_done - start}")
 


### PR DESCRIPTION
### Motivation

Some nested modules in the repo use specify versions of dependencies that differ from one module to another.

Although at build time only one version will be used, when running commands on a specific module (which we do when linting, for example) the version specified locally on the module will be used.

This change ensures those dependencies are pre-fetched.

### Additional Notes

I also made `inv deps` run in verbose mode in gitlab, so we can more easily catch cases where we really don't need to use different versions of a dependency and we could just update `go.mod` on a module.

