### PR TITLE
[Process Agent] Remove `EnabledChecks` from `AgentConfig`

### DIFF
--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -78,46 +78,28 @@ type Collector struct {
 }
 
 // NewCollector creates a new Collector
-func NewCollector(cfg *config.AgentConfig) (Collector, error) {
+func NewCollector(cfg *config.AgentConfig, enabledChecks []checks.Check) (Collector, error) {
 	sysInfo, err := checks.CollectSystemInfo(cfg)
 	if err != nil {
 		return Collector{}, err
 	}
 
-	enabledChecks := make([]checks.Check, 0)
-	runRealTime := !ddconfig.Datadog.GetBool("process_config.disable_realtime_checks")
-	for _, c := range checks.All {
-		if !runRealTime && isRealTimeCheck(c.Name()) {
-			log.Infof("Skip enabling check '%s': realtime disabled", c.Name())
-			continue
-		}
-		if cfg.CheckIsEnabled(c.Name()) {
-			c.Init(cfg, sysInfo)
-			enabledChecks = append(enabledChecks, c)
-		}
+	for _, c := range enabledChecks {
+		c.Init(cfg, sysInfo)
 	}
 
-	return NewCollectorWithChecks(cfg, enabledChecks, runRealTime), nil
-}
-
-func isRealTimeCheck(checkName string) bool {
-	return checkName == config.RTProcessCheckName || checkName == config.RTContainerCheckName
-}
-
-// NewCollectorWithChecks creates a new Collector
-func NewCollectorWithChecks(cfg *config.AgentConfig, checks []checks.Check, runRealTime bool) Collector {
 	return Collector{
 		rtIntervalCh:  make(chan time.Duration),
 		cfg:           cfg,
 		groupID:       rand.Int31(),
-		enabledChecks: checks,
+		enabledChecks: enabledChecks,
 
 		// Defaults for real-time on start
 		realTimeInterval: 2 * time.Second,
 		realTimeEnabled:  0,
 
-		runRealTime: runRealTime,
-	}
+		runRealTime: !ddconfig.Datadog.GetBool("process_config.disable_realtime_checks"),
+	}, nil
 }
 
 func (l *Collector) runCheck(c checks.Check, results *api.WeightedQueue) {
@@ -236,7 +218,18 @@ func (l *Collector) run(exit chan struct{}) error {
 	for _, e := range l.cfg.Orchestrator.OrchestratorEndpoints {
 		orchestratorEps = append(orchestratorEps, e.Endpoint.String())
 	}
-	log.Infof("Starting process-agent for host=%s, endpoints=%s, orchestrator endpoints=%s, enabled checks=%v", l.cfg.HostName, eps, orchestratorEps, l.cfg.EnabledChecks)
+
+	var checkNames []string
+	for _, check := range l.enabledChecks {
+		checkNames = append(checkNames, check.Name())
+
+		// Append `process_rt` if process check is enabled, and rt is enabled, so the customer doesn't get confused if
+		// process_rt doesn't show up in the enabled checks
+		if check.Name() == checks.Process.Name() && !ddconfig.Datadog.GetBool("process_config.disable_realtime_checks") {
+			checkNames = append(checkNames, checks.Process.RealTimeName())
+		}
+	}
+	log.Infof("Starting process-agent for host=%s, endpoints=%s, orchestrator endpoints=%s, enabled checks=%v", l.cfg.HostName, eps, orchestratorEps, checkNames)
 
 	go util.HandleSignals(exit)
 

--- a/cmd/process-agent/collector_test.go
+++ b/cmd/process-agent/collector_test.go
@@ -122,7 +122,7 @@ func TestDisableRealTime(t *testing.T) {
 
 	assert := assert.New(t)
 	cfg := config.NewDefaultAgentConfig(false)
-	cfg.EnabledChecks = []string{
+	enabledChecks := []string{
 		config.ProcessCheckName,
 		config.RTProcessCheckName,
 		config.ContainerCheckName,
@@ -134,7 +134,7 @@ func TestDisableRealTime(t *testing.T) {
 			mockConfig := ddconfig.Mock()
 			mockConfig.Set("process_config.disable_realtime_checks", tc.disableRealtime)
 
-			c, err := NewCollector(cfg)
+			c, err := NewCollector(cfg, enabledChecks)
 			assert.NoError(err)
 			assert.ElementsMatch(tc.expectedChecks, c.enabledChecks)
 			assert.Equal(!tc.disableRealtime, c.runRealTime)

--- a/cmd/process-agent/config.go
+++ b/cmd/process-agent/config.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	oconfig "github.com/DataDog/datadog-agent/pkg/orchestrator/config"
+	"github.com/DataDog/datadog-agent/pkg/process/checks"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+func getChecks(sysCfg *sysconfig.Config, oCfg *oconfig.OrchestratorConfig) (checkCfg []checks.Check) {
+	rtChecksEnabled := !ddconfig.Datadog.GetBool("process_config.disable_realtime_checks")
+	if ddconfig.Datadog.GetBool("process_config.process_collection.enabled") {
+		checkCfg = append(checkCfg, checks.Process)
+	} else {
+		if ddconfig.Datadog.GetBool("process_config.container_collection.enabled") {
+			checkCfg = append(checkCfg, checks.Container)
+			if rtChecksEnabled {
+				checkCfg = append(checkCfg, checks.RTContainer)
+			}
+		}
+		if ddconfig.Datadog.GetBool("process_config.process_discovery.enabled") {
+			checkCfg = append(checkCfg, checks.ProcessDiscovery)
+		}
+	}
+
+	// activate the pod collection if enabled and we have the cluster name set
+	if oCfg.OrchestrationCollectionEnabled {
+		if oCfg.KubeClusterName != "" {
+			checkCfg = append(checkCfg, checks.Pod)
+		} else {
+			_ = log.Warnf("Failed to auto-detect a Kubernetes cluster name. Pod collection will not start. To fix this, set it manually via the cluster_name config option")
+		}
+	}
+
+	if sysCfg.Enabled {
+		if _, ok := sysCfg.EnabledModules[sysconfig.ProcessModule]; ok {
+			checks.Process.NotifySysprobeProcessModuleEnabled()
+		}
+		if _, ok := sysCfg.EnabledModules[sysconfig.NetworkTracerModule]; ok {
+			checkCfg = append(checkCfg, checks.Connections)
+		}
+	}
+
+	return
+}

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -253,8 +253,10 @@ func runAgent(exit chan struct{}) {
 		cleanupAndExit(1)
 	}
 
+	enabledChecks := getChecks(syscfg, cfg.Orchestrator)
+
 	// Exit if agent is not enabled and we're not debugging a check.
-	if !cfg.Enabled && opts.check == "" {
+	if len(enabledChecks) == 0 && opts.check == "" {
 		log.Infof(agent6DisabledMessage)
 
 		// a sleep is necessary to ensure that supervisor registers this process as "STARTED"
@@ -320,7 +322,7 @@ func runAgent(exit chan struct{}) {
 		_ = log.Error(err)
 	}
 
-	cl, err := NewCollector(cfg)
+	cl, err := NewCollector(cfg, enabledChecks)
 	if err != nil {
 		log.Criticalf("Error creating collector: %s", err)
 		cleanupAndExit(1)

--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -17,6 +17,8 @@ import (
 const (
 	// DefaultGRPCConnectionTimeoutSecs sets the default value for timeout when connecting to the agent
 	DefaultGRPCConnectionTimeoutSecs = 60
+
+	procDiscoveryMinInterval = 10 * time.Minute
 )
 
 // setupProcesses is meant to be called multiple times for different configs, but overrides apply to all configs, so
@@ -120,6 +122,15 @@ func loadProcessTransforms(config Config) {
 		} else { // "false"
 			config.Set("process_config.process_collection.enabled", false)
 			config.Set("process_config.container_collection.enabled", true)
+		}
+	}
+
+	if config.GetBool("process_config.process_discovery.enabled") {
+		procDiscoveryInterval := config.GetDuration("process_config.process_discovery.interval")
+		if procDiscoveryInterval < procDiscoveryMinInterval {
+			_ = log.Warnf("Invalid interval for process discovery (<= %s) using default value of %[1]s",
+				procDiscoveryMinInterval.String())
+			config.Set("process_config.process_discovery.interval", procDiscoveryMinInterval)
 		}
 	}
 }

--- a/pkg/config/process_test.go
+++ b/pkg/config/process_test.go
@@ -285,3 +285,10 @@ func TestProcConfigEnabledTransform(t *testing.T) {
 	}
 
 }
+
+func TestProcessDiscoveryTransform(t *testing.T) {
+	cfg := setupConf()
+	cfg.Set("process_config.process_discovery.interval", procDiscoveryMinInterval-1)
+	loadProcessTransforms(cfg)
+	assert.Equal(t, procDiscoveryMinInterval, cfg.GetDuration("process_config.process_discovery.interval"))
+}

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -62,6 +62,15 @@ type ProcessCheck struct {
 
 	// Create times by PID used in the network check
 	createTimes atomic.Value
+
+	// sysprobeProcessModuleEnabled tells the process check wheither to use the RemoteSystemProbeUtil to gather privileged proces stats
+	sysprobeProcessModuleEnabled bool
+}
+
+// NotifySysprobeProcessModuleEnabled tells the process check that the sysprobe process module is enabled.
+// This means that the process check should ask the system probe for privileged process stats.
+func (p *ProcessCheck) NotifySysprobeProcessModuleEnabled() {
+	p.sysprobeProcessModuleEnabled = true
 }
 
 // Init initializes the singleton ProcessCheck.
@@ -117,7 +126,7 @@ func (p *ProcessCheck) run(cfg *config.AgentConfig, groupID int32, collectRealTi
 	var sysProbeUtil *net.RemoteSysProbeUtil
 	// if the Process module is disabled, we allow Probe to collect
 	// fields that require elevated permission to collect with best effort
-	if !cfg.CheckIsEnabled(config.ProcessModuleCheckName) {
+	if !p.sysprobeProcessModuleEnabled {
 		procutil.WithPermission(true)(p.probe)
 	} else {
 		procutil.WithPermission(false)(p.probe)

--- a/pkg/process/checks/process_rt.go
+++ b/pkg/process/checks/process_rt.go
@@ -37,7 +37,7 @@ func (p *ProcessCheck) runRealtime(cfg *config.AgentConfig, groupID int32) (*Run
 	var sysProbeUtil *net.RemoteSysProbeUtil
 	// if the Process module is disabled, we allow Probe to collect
 	// fields that require elevated permission to collect with best effort
-	if !cfg.CheckIsEnabled(config.ProcessModuleCheckName) {
+	if !p.sysprobeProcessModuleEnabled {
 		procutil.WithPermission(true)(p.probe)
 	} else {
 		procutil.WithPermission(false)(p.probe)

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -555,6 +555,10 @@ func TestNetworkConfig(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.True(t, agentConfig.EnableSystemProbe)
+	})
+}
+
+func TestSystemProbeNoNetwork(t *testing.T) {
 	defer restoreGlobalConfig()
 
 	agentConfig := loadAgentConfigForTest(t, "./testdata/TestDDAgentConfigYamlOnly.yaml", "./testdata/TestDDAgentConfig-OOMKillOnly.yaml")

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -25,8 +25,7 @@ import (
 )
 
 const (
-	ns                   = "process_config"
-	discoveryMinInterval = 10 * time.Minute
+	ns = "process_config"
 )
 
 func key(pieces ...string) string {
@@ -56,13 +55,6 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 		a.HostName = config.Datadog.GetString("hostname")
 	}
 
-	a.Enabled = false
-	if config.Datadog.GetBool("process_config.process_collection.enabled") {
-		a.Enabled, a.EnabledChecks = true, processChecks
-	} else if config.Datadog.GetBool("process_config.container_collection.enabled") {
-		// Container checks are enabled only when process checks are not (since they automatically collect container data).
-		a.Enabled, a.EnabledChecks = true, containerChecks
-	}
 	// The interval, in seconds, at which we will run each check. If you want consistent
 	// behavior between real-time you may set the Container/ProcessRT intervals to 10.
 	// Defaults to 10s for normal checks and 2s for others.
@@ -71,10 +63,6 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string) error {
 	a.setCheckInterval(ns, "process", ProcessCheckName)
 	a.setCheckInterval(ns, "process_realtime", RTProcessCheckName)
 	a.setCheckInterval(ns, "connections", ConnectionsCheckName)
-
-	// We need another method to read in process discovery check configs because it is in its own object,
-	// and uses a different unit of time
-	a.initProcessDiscoveryCheck()
 
 	if a.CheckIntervals[ProcessCheckName] < a.CheckIntervals[RTProcessCheckName] || a.CheckIntervals[ProcessCheckName]%a.CheckIntervals[RTProcessCheckName] != 0 {
 		// Process check interval must be greater or equal to RTProcess check interval and the intervals must be divisible
@@ -258,6 +246,7 @@ func (a *AgentConfig) setCheckInterval(ns, check, checkKey string) {
 		a.CheckIntervals[checkKey] = time.Duration(interval) * time.Second
 	}
 }
+<<<<<<< HEAD
 
 // Separate handler for initializing the process discovery check.
 // Since it has its own unique object, we need to handle loading in the check config differently separately
@@ -274,11 +263,8 @@ func (a *AgentConfig) initProcessDiscoveryCheck() {
 
 		// We don't need to check if the key exists since we already bound it to a default in InitConfig.
 		// We use a minimum of 10 minutes for this value.
-		discoveryInterval := config.Datadog.GetDuration(key(root, "interval"))
-		if discoveryInterval < discoveryMinInterval {
-			discoveryInterval = discoveryMinInterval
-			_ = log.Warnf("Invalid interval for process discovery (<= %s) using default value of %[1]s", discoveryMinInterval.String())
-		}
-		a.CheckIntervals[DiscoveryCheckName] = discoveryInterval
+		a.CheckIntervals[DiscoveryCheckName] = config.Datadog.GetDuration(key(root, "interval"))
 	}
 }
+=======
+>>>>>>> b8f34e7a6 (Removed check initialization code from AgentConfig)

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -246,25 +246,3 @@ func (a *AgentConfig) setCheckInterval(ns, check, checkKey string) {
 		a.CheckIntervals[checkKey] = time.Duration(interval) * time.Second
 	}
 }
-<<<<<<< HEAD
-
-// Separate handler for initializing the process discovery check.
-// Since it has its own unique object, we need to handle loading in the check config differently separately
-// from the other checks.
-func (a *AgentConfig) initProcessDiscoveryCheck() {
-	root := key(ns, "process_discovery")
-
-	// Discovery check can only be enabled when regular process collection is not enabled.
-	processCheckEnabled := config.Datadog.GetBool("process_config.process_collection.enabled")
-	discoveryCheckEnabled := config.Datadog.GetBool(key(root, "enabled"))
-	if discoveryCheckEnabled && !processCheckEnabled {
-		a.EnabledChecks = append(a.EnabledChecks, DiscoveryCheckName)
-		a.Enabled = true
-
-		// We don't need to check if the key exists since we already bound it to a default in InitConfig.
-		// We use a minimum of 10 minutes for this value.
-		a.CheckIntervals[DiscoveryCheckName] = config.Datadog.GetDuration(key(root, "interval"))
-	}
-}
-=======
->>>>>>> b8f34e7a6 (Removed check initialization code from AgentConfig)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
This PR removes `EnabledChecks` from `AgentConfig`. 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
