### PR TITLE
dogstatsd-arm64 docker image: Add missing job dependency in publish jobs

### DIFF
--- a/.gitlab/binary_build/linux.yml
+++ b/.gitlab/binary_build/linux.yml
@@ -17,7 +17,7 @@ build_dogstatsd_static-binary_x64:
 build_dogstatsd_static-binary_arm64:
   stage: binary_build
   rules:
-    !reference [.on_all_builds_a7]
+    !reference [.on_a7]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_arm64:$DATADOG_AGENT_ARMBUILDIMAGES
   tags: ["runner:docker-arm", "platform:arm64"]
   needs: ["tests_deb-x64-py3", "go_deps"]

--- a/.gitlab/image_build/docker_linux.yml
+++ b/.gitlab/image_build/docker_linux.yml
@@ -209,7 +209,7 @@ docker_build_dogstatsd_amd64:
 docker_build_dogstatsd_arm64:
   extends: .docker_build_job_definition_arm64
   rules:
-    !reference [.on_all_builds_a7]
+    !reference [.on_a7]
   needs:
     - job: build_dogstatsd_static-binary_arm64
       artifacts: false

--- a/.gitlab/image_deploy/docker_linux.yml
+++ b/.gitlab/image_deploy/docker_linux.yml
@@ -32,6 +32,7 @@ dev_branch-dogstatsd:
     !reference [.on_a7_manual]
   needs:
     - docker_build_dogstatsd_amd64
+    - docker_build_dogstatsd_arm64
   variables:
     IMG_REGISTRIES: dev
     IMG_SOURCES: ${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
@@ -102,6 +103,7 @@ dev_branch_multiarch-dogstatsd:
     !reference [.on_a7_manual]
   needs:
     - docker_build_dogstatsd_amd64
+    - docker_build_dogstatsd_arm64
   variables:
     IMG_REGISTRIES: dev
     IMG_SOURCES: ${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
@@ -149,6 +151,7 @@ dev_master-dogstatsd:
     !reference [.on_main_a7]
   needs:
     - docker_build_dogstatsd_amd64
+    - docker_build_dogstatsd_arm64
   variables:
     IMG_REGISTRIES: dev
     IMG_SOURCES: ${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64
@@ -236,6 +239,7 @@ dev_nightly-dogstatsd:
     !reference [.on_deploy_nightly_repo_branch_a7]
   needs:
     - docker_build_dogstatsd_amd64
+    - docker_build_dogstatsd_arm64
   variables:
     IMG_REGISTRIES: dev
     IMG_SOURCES: ${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-amd64,${SRC_DSD}:v${CI_PIPELINE_ID}-${CI_COMMIT_SHORT_SHA}-arm64


### PR DESCRIPTION
### What does this PR do?

Make the trigger jobs that consume the arm64 image depend on the build jobs

### Motivation

The publish job could run before the build job succeeded.
