### PR TITLE
Fix the `Webhook info` section of the DCA `agent status` output on k8s 1.22+

### DIFF
--- a/pkg/clusteragent/admission/start.go
+++ b/pkg/clusteragent/admission/start.go
@@ -89,8 +89,10 @@ func StartControllers(ctx ControllerContext) error {
 
 	if v1Enabled {
 		informers[apiserver.WebhooksInformer] = ctx.WebhookInformers.Admissionregistration().V1().MutatingWebhookConfigurations().Informer()
+		getWebhookStatus = getWebhookStatusV1
 	} else {
 		informers[apiserver.WebhooksInformer] = ctx.WebhookInformers.Admissionregistration().V1beta1().MutatingWebhookConfigurations().Informer()
+		getWebhookStatus = getWebhookStatusV1beta1
 	}
 
 	return apiserver.SyncInformers(informers, 0)

--- a/pkg/clusteragent/admission/status.go
+++ b/pkg/clusteragent/admission/status.go
@@ -53,9 +53,50 @@ func GetStatus(apiCl kubernetes.Interface) map[string]interface{} {
 	return status
 }
 
-func getWebhookStatus(name string, apiCl kubernetes.Interface) (map[string]interface{}, error) {
+var getWebhookStatus = func(string, kubernetes.Interface) (map[string]interface{}, error) {
+	return nil, fmt.Errorf("admission controller not started")
+}
+
+func getWebhookStatusV1beta1(name string, apiCl kubernetes.Interface) (map[string]interface{}, error) {
 	webhookStatus := make(map[string]interface{})
 	webhook, err := apiCl.AdmissionregistrationV1beta1().MutatingWebhookConfigurations().Get(context.TODO(), name, metav1.GetOptions{})
+	if err != nil {
+		return webhookStatus, err
+	}
+
+	webhookStatus["Name"] = webhook.GetName()
+	webhookStatus["CreatedAt"] = webhook.GetCreationTimestamp()
+
+	webhooksConfig := make(map[string]map[string]interface{})
+	webhookStatus["Webhooks"] = webhooksConfig
+	for _, w := range webhook.Webhooks {
+		webhooksConfig[w.Name] = make(map[string]interface{})
+		svc := w.ClientConfig.Service
+		if svc != nil {
+			port := "Port: None (default 443)"
+			path := "Path: None"
+			if svc.Port != nil {
+				port = fmt.Sprintf("Port: %d", *svc.Port)
+			}
+			if svc.Path != nil {
+				path = fmt.Sprintf("Path: %s", *svc.Path)
+			}
+			webhooksConfig[w.Name]["Service"] = fmt.Sprintf("%s/%s - %s - %s", svc.Namespace, svc.Name, port, path)
+		}
+		if w.ObjectSelector != nil {
+			webhooksConfig[w.Name]["Object selector"] = w.ObjectSelector.String()
+		}
+		for i, r := range w.Rules {
+			webhooksConfig[w.Name][fmt.Sprintf("Rule %d", i+1)] = fmt.Sprintf("Operations: %v - APIGroups: %v - APIVersions: %v - Resources: %v", r.Operations, r.Rule.APIGroups, r.Rule.APIVersions, r.Rule.Resources)
+		}
+		webhooksConfig[w.Name]["CA bundle digest"] = getDigest(w.ClientConfig.CABundle)
+	}
+	return webhookStatus, nil
+}
+
+func getWebhookStatusV1(name string, apiCl kubernetes.Interface) (map[string]interface{}, error) {
+	webhookStatus := make(map[string]interface{})
+	webhook, err := apiCl.AdmissionregistrationV1().MutatingWebhookConfigurations().Get(context.TODO(), name, metav1.GetOptions{})
 	if err != nil {
 		return webhookStatus, err
 	}

--- a/releasenotes-dca/notes/webhook_status-c6cb6fddc7d7df7c.yaml
+++ b/releasenotes-dca/notes/webhook_status-c6cb6fddc7d7df7c.yaml
@@ -1,0 +1,12 @@
+# Each section from every releasenote are combined when the
+# CHANGELOG-DCA.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Fix the ``Admission Controller``/``Webhooks info`` section of the cluster agent ``agent status`` output on Kubernetes 1.22+.
+    Although the cluster agent was able to register its webhook with both the ``v1beta1`` and the ``v1`` version of the Administrationregistration API, the ``agent status`` command was always using the ``v1beta1``, which has been removed in Kubernetes 1.22.


### PR DESCRIPTION
### What does this PR do?

Fix the output of the cluster agent `agent status` on Kubernetes 1.22 and above.

### Motivation

It was showing:
```
Admission Controller
====================

  MutatingWebhookConfigurations name: datadog-webhook
  Error: the server could not find the requested resource
```
although it worked correctly.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the cluster agent with the admission controller enabled on a Kubernetes version 1.22 or more recent.

Check the output of `agent status`.

Before this fix, it was showing an error like:
```
Admission Controller
====================

  MutatingWebhookConfigurations name: datadog-webhook
  Error: the server could not find the requested resource
```

With this fix, it should show information like:
```
Admission Controller
====================

    Webhooks info
    -------------
      MutatingWebhookConfigurations name: datadog-webhook
      Created at: 2022-01-28T10:56:18Z
      ---------
        Name: datadog.webhook.config
        CA bundle digest: e2146442e9a1335d
        Object selector: &LabelSelector{MatchLabels:map[string]string{admission.datadoghq.com/enabled: true,},MatchExpressions:[]LabelSelectorRequirement{},}
        Rule 1: Operations: [CREATE] - APIGroups: [] - APIVersions: [v1] - Resources: [pods]
        Service: datadog-agent-helm/datadog-agent-linux-cluster-agent-admission-controller - Port: 443 - Path: /injectconfig
      ---------
        Name: datadog.webhook.tags
        CA bundle digest: e2146442e9a1335d
        Object selector: &LabelSelector{MatchLabels:map[string]string{admission.datadoghq.com/enabled: true,},MatchExpressions:[]LabelSelectorRequirement{},}
        Rule 1: Operations: [CREATE] - APIGroups: [] - APIVersions: [v1] - Resources: [pods]
        Service: datadog-agent-helm/datadog-agent-linux-cluster-agent-admission-controller - Port: 443 - Path: /injecttags
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
