### PR TITLE
[snmp] normalize hostname

### DIFF
--- a/pkg/collector/corechecks/snmp/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config.go
@@ -413,7 +413,11 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 		c.Namespace = coreconfig.Datadog.GetString("network_devices.namespace")
 	}
 
-	err = common.ValidateNamespace(c.Namespace)
+	c.Namespace, err = common.NormalizeNamespace(c.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/collector/corechecks/snmp/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config.go
@@ -418,10 +418,6 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 		return nil, err
 	}
 
-	if err != nil {
-		return nil, err
-	}
-
 	// profile configs
 	profile := instance.Profile
 	if profile != "" || len(c.Metrics) > 0 {

--- a/pkg/collector/corechecks/snmp/checkconfig/config.go
+++ b/pkg/collector/corechecks/snmp/checkconfig/config.go
@@ -413,9 +413,9 @@ func NewCheckConfig(rawInstance integration.Data, rawInitConfig integration.Data
 		c.Namespace = coreconfig.Datadog.GetString("network_devices.namespace")
 	}
 
-	if c.Namespace == "" {
-		// Can only happen if snmp_listener.namespace config is set to empty string in `datadog.yaml`
-		return nil, fmt.Errorf("namespace cannot be empty")
+	err = common.ValidateNamespace(c.Namespace)
+	if err != nil {
+		return nil, err
 	}
 
 	// profile configs

--- a/pkg/collector/corechecks/snmp/common/utils.go
+++ b/pkg/collector/corechecks/snmp/common/utils.go
@@ -50,7 +50,7 @@ func NormalizeNamespace(namespace string) (string, error) {
 
 	// namespace longer than 100 characters are illegal
 	if len(namespace) > 100 {
-		return "", fmt.Errorf("namespace is too long, should contain less than 253 characters")
+		return "", fmt.Errorf("namespace is too long, should contain less than 100 characters")
 	}
 
 	for _, r := range namespace {

--- a/pkg/collector/corechecks/snmp/common/utils.go
+++ b/pkg/collector/corechecks/snmp/common/utils.go
@@ -6,7 +6,6 @@
 package common
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -42,32 +41,4 @@ func CopyStrings(tags []string) []string {
 // GetAgentVersionTag returns agent version tag
 func GetAgentVersionTag() string {
 	return "agent_version:" + version.AgentVersion
-}
-
-// NormalizeHost applies a liberal policy on host names.
-func NormalizeHost(host string) string {
-	var buf bytes.Buffer
-
-	// hosts longer than 253 characters are illegal
-	if len(host) > 253 {
-		return ""
-	}
-
-	for _, r := range host {
-		switch r {
-		// has null rune just toss the whole thing
-		case '\x00':
-			return ""
-		// drop these characters entirely
-		case '\n', '\r', '\t':
-			continue
-		// replace characters that are generally used for xss with '-'
-		case '>', '<':
-			buf.WriteByte('-')
-		default:
-			buf.WriteRune(r)
-		}
-	}
-
-	return buf.String()
 }

--- a/pkg/collector/corechecks/snmp/common/utils.go
+++ b/pkg/collector/corechecks/snmp/common/utils.go
@@ -6,6 +6,7 @@
 package common
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/DataDog/datadog-agent/pkg/version"
@@ -41,4 +42,32 @@ func CopyStrings(tags []string) []string {
 // GetAgentVersionTag returns agent version tag
 func GetAgentVersionTag() string {
 	return "agent_version:" + version.AgentVersion
+}
+
+// NormalizeHost applies a liberal policy on host names.
+func NormalizeHost(host string) string {
+	var buf bytes.Buffer
+
+	// hosts longer than 253 characters are illegal
+	if len(host) > 253 {
+		return ""
+	}
+
+	for _, r := range host {
+		switch r {
+		// has null rune just toss the whole thing
+		case '\x00':
+			return ""
+		// drop these characters entirely
+		case '\n', '\r', '\t':
+			continue
+		// replace characters that are generally used for xss with '-'
+		case '>', '<':
+			buf.WriteByte('-')
+		default:
+			buf.WriteRune(r)
+		}
+	}
+
+	return buf.String()
 }

--- a/pkg/collector/corechecks/snmp/common/utils.go
+++ b/pkg/collector/corechecks/snmp/common/utils.go
@@ -42,3 +42,27 @@ func CopyStrings(tags []string) []string {
 func GetAgentVersionTag() string {
 	return "agent_version:" + version.AgentVersion
 }
+
+// ValidateNamespace applies
+func ValidateNamespace(namespace string) error {
+	if namespace == "" {
+		// Can only happen if snmp_listener.namespace config is set to empty string in `datadog.yaml`
+		return fmt.Errorf("namespace cannot be empty")
+	}
+
+	// namespace longer than 100 characters are illegal
+	if len(namespace) > 100 {
+		return fmt.Errorf("namespace too long (> 100)")
+	}
+
+	// using NormalizeHost rune policy
+	for _, r := range namespace {
+		switch r {
+		// has null rune just toss the whole thing
+		case '\x00', '\n', '\r', '\t', '>', '<':
+			return fmt.Errorf("namespace cannot contain [%v], only alphanumeric characters allowed", r)
+		}
+	}
+
+	return nil
+}

--- a/pkg/collector/corechecks/snmp/common/utils_test.go
+++ b/pkg/collector/corechecks/snmp/common/utils_test.go
@@ -111,9 +111,16 @@ func Test_CopyStrings(t *testing.T) {
 func TestValidateNamespace(t *testing.T) {
 	assert := assert.New(t)
 	long := strings.Repeat("a", 105)
-	assert.NotNil(ValidateNamespace(long), "namespace should not be too long")
-	assert.NotNil(ValidateNamespace("a<b"), "namespace should not contain symbols")
-	assert.NotNil(ValidateNamespace("a\nb"), "namespace should not contain symbols")
+	_, err := NormalizeNamespace(long)
+	assert.NotNil(err, "namespace should not be too long")
+
+	namespace, err := NormalizeNamespace("a<b")
+	assert.Nil(err, "namespace with symbols should be normalized")
+	assert.Equal("a-b", namespace, "namespace should not contain symbols")
+
+	namespace, err = NormalizeNamespace("a\nb")
+	assert.Nil(err, "namespace with symbols should be normalized")
+	assert.Equal("ab", namespace, "namespace should not contain symbols")
 
 	// Invalid namespace as bytes that would look like this: 9cbef2d1-8c20-4bf2-97a5-7d70��
 	b := []byte{
@@ -121,5 +128,6 @@ func TestValidateNamespace(t *testing.T) {
 		52, 98, 102, 50, 45, 57, 55, 97, 53, 45, 55, 100, 55, 48,
 		0, 0, 0, 0, 239, 191, 189, 239, 191, 189, 1, // these are bad bytes
 	}
-	assert.NotNil(ValidateNamespace(string(b)), "namespace should not contain bad bytes")
+	_, err = NormalizeNamespace(string(b))
+	assert.NotNil(err, "namespace should not contain bad bytes")
 }

--- a/pkg/collector/corechecks/snmp/common/utils_test.go
+++ b/pkg/collector/corechecks/snmp/common/utils_test.go
@@ -7,7 +7,6 @@ package common
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -106,21 +105,4 @@ func Test_CopyStrings(t *testing.T) {
 	assert.Equal(t, tags, newTags)
 	assert.NotEqual(t, fmt.Sprintf("%p", tags), fmt.Sprintf("%p", newTags))
 	assert.NotEqual(t, fmt.Sprintf("%p", &tags[0]), fmt.Sprintf("%p", &newTags[0]))
-}
-
-func TestNormalizeHost(t *testing.T) {
-	assert := assert.New(t)
-	long := strings.Repeat("a", 256)
-	assert.Len(NormalizeHost(long), 0, "long host should be dropped")
-	assert.Equal("a-b", NormalizeHost("a<b"), "< defanged")
-	assert.Equal("a-b", NormalizeHost("a>b"), "> defanged")
-	assert.Equal("example.com", NormalizeHost("example.com\r\n"), "NL/CR dropped")
-
-	// Invalid host name as bytes that would look like this: 9cbef2d1-8c20-4bf2-97a5-7d70��
-	b := []byte{
-		57, 99, 98, 101, 102, 50, 100, 49, 45, 56, 99, 50, 48, 45,
-		52, 98, 102, 50, 45, 57, 55, 97, 53, 45, 55, 100, 55, 48,
-		0, 0, 0, 0, 239, 191, 189, 239, 191, 189, 1, // these are bad bytes
-	}
-	assert.Equal("", NormalizeHost(string(b)))
 }

--- a/pkg/collector/corechecks/snmp/common/utils_test.go
+++ b/pkg/collector/corechecks/snmp/common/utils_test.go
@@ -7,6 +7,7 @@ package common
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -105,4 +106,21 @@ func Test_CopyStrings(t *testing.T) {
 	assert.Equal(t, tags, newTags)
 	assert.NotEqual(t, fmt.Sprintf("%p", tags), fmt.Sprintf("%p", newTags))
 	assert.NotEqual(t, fmt.Sprintf("%p", &tags[0]), fmt.Sprintf("%p", &newTags[0]))
+}
+
+func TestNormalizeHost(t *testing.T) {
+	assert := assert.New(t)
+	long := strings.Repeat("a", 256)
+	assert.Len(NormalizeHost(long), 0, "long host should be dropped")
+	assert.Equal("a-b", NormalizeHost("a<b"), "< defanged")
+	assert.Equal("a-b", NormalizeHost("a>b"), "> defanged")
+	assert.Equal("example.com", NormalizeHost("example.com\r\n"), "NL/CR dropped")
+
+	// Invalid host name as bytes that would look like this: 9cbef2d1-8c20-4bf2-97a5-7d70��
+	b := []byte{
+		57, 99, 98, 101, 102, 50, 100, 49, 45, 56, 99, 50, 48, 45,
+		52, 98, 102, 50, 45, 57, 55, 97, 53, 45, 55, 100, 55, 48,
+		0, 0, 0, 0, 239, 191, 189, 239, 191, 189, 1, // these are bad bytes
+	}
+	assert.Equal("", NormalizeHost(string(b)))
 }

--- a/pkg/collector/corechecks/snmp/common/utils_test.go
+++ b/pkg/collector/corechecks/snmp/common/utils_test.go
@@ -7,6 +7,7 @@ package common
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -105,4 +106,20 @@ func Test_CopyStrings(t *testing.T) {
 	assert.Equal(t, tags, newTags)
 	assert.NotEqual(t, fmt.Sprintf("%p", tags), fmt.Sprintf("%p", newTags))
 	assert.NotEqual(t, fmt.Sprintf("%p", &tags[0]), fmt.Sprintf("%p", &newTags[0]))
+}
+
+func TestValidateNamespace(t *testing.T) {
+	assert := assert.New(t)
+	long := strings.Repeat("a", 105)
+	assert.NotNil(ValidateNamespace(long), "namespace should not be too long")
+	assert.NotNil(ValidateNamespace("a<b"), "namespace should not contain symbols")
+	assert.NotNil(ValidateNamespace("a\nb"), "namespace should not contain symbols")
+
+	// Invalid namespace as bytes that would look like this: 9cbef2d1-8c20-4bf2-97a5-7d70��
+	b := []byte{
+		57, 99, 98, 101, 102, 50, 100, 49, 45, 56, 99, 50, 48, 45,
+		52, 98, 102, 50, 45, 57, 55, 97, 53, 45, 55, 100, 55, 48,
+		0, 0, 0, 0, 239, 191, 189, 239, 191, 189, 1, // these are bad bytes
+	}
+	assert.NotNil(ValidateNamespace(string(b)), "namespace should not contain bad bytes")
 }

--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
@@ -78,12 +78,9 @@ func (d *DeviceCheck) GetIDTags() []string {
 func (d *DeviceCheck) GetDeviceHostname() (string, error) {
 	if d.config.UseDeviceIDAsHostname {
 		hostname := deviceHostnamePrefix + d.config.DeviceID
-		normalizedHostname := util.NormalizeHost(hostname)
-		if normalizedHostname == "" {
-			return "", fmt.Errorf("invalid hostname: %s", hostname)
-		}
-		if hostname != normalizedHostname {
-			log.Warnf("Invalid hostname %s, normalized to: %s", hostname, normalizedHostname)
+		normalizedHostname, err := util.NormalizeHost(hostname)
+		if err != nil {
+			return "", err
 		}
 		return normalizedHostname, nil
 	}

--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
@@ -76,7 +76,12 @@ func (d *DeviceCheck) GetIDTags() []string {
 // GetDeviceHostname returns DeviceID as hostname if UseDeviceIDAsHostname is true
 func (d *DeviceCheck) GetDeviceHostname() string {
 	if d.config.UseDeviceIDAsHostname {
-		return deviceHostnamePrefix + d.config.DeviceID
+		hostname := deviceHostnamePrefix + d.config.DeviceID
+		normalizedHostname := common.NormalizeHost(hostname)
+		if hostname != normalizedHostname {
+			log.Warnf("Invalid namespace, device hostname %s normalized to: %s", hostname, normalizedHostname)
+		}
+		return normalizedHostname
 	}
 	return ""
 }

--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck.go
@@ -16,6 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/externalhost"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/snmp/checkconfig"
@@ -77,7 +78,7 @@ func (d *DeviceCheck) GetIDTags() []string {
 func (d *DeviceCheck) GetDeviceHostname() string {
 	if d.config.UseDeviceIDAsHostname {
 		hostname := deviceHostnamePrefix + d.config.DeviceID
-		normalizedHostname := common.NormalizeHost(hostname)
+		normalizedHostname := util.NormalizeHost(hostname)
 		if hostname != normalizedHostname {
 			log.Warnf("Invalid namespace, device hostname %s normalized to: %s", hostname, normalizedHostname)
 		}

--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck_test.go
@@ -346,28 +346,42 @@ community_string: public
 	deviceCk, err := NewDeviceCheck(config, "1.2.3.4", session.NewMockSession)
 	assert.Nil(t, err)
 
-	assert.Equal(t, "", deviceCk.GetDeviceHostname())
+	hostname, err := deviceCk.GetDeviceHostname()
+	assert.Nil(t, err)
+	assert.Equal(t, "", hostname)
 
 	deviceCk.config.UseDeviceIDAsHostname = true
-	assert.Equal(t, "device:default:1.2.3.4", deviceCk.GetDeviceHostname())
+	hostname, err = deviceCk.GetDeviceHostname()
+	assert.Nil(t, err)
+	assert.Equal(t, "device:default:1.2.3.4", hostname)
 
 	deviceCk.config.UseDeviceIDAsHostname = false
-	assert.Equal(t, "", deviceCk.GetDeviceHostname())
+	hostname, err = deviceCk.GetDeviceHostname()
+	assert.Nil(t, err)
+	assert.Equal(t, "", hostname)
 
 	deviceCk.config.UseDeviceIDAsHostname = true
 	deviceCk.config.Namespace = "a>b"
 	deviceCk.config.UpdateDeviceIDAndTags()
-	assert.Equal(t, "device:a-b:1.2.3.4", deviceCk.GetDeviceHostname())
+	hostname, err = deviceCk.GetDeviceHostname()
+	assert.Nil(t, err)
+	assert.Equal(t, "device:a-b:1.2.3.4", hostname)
 
 	deviceCk.config.Namespace = "a<b"
 	deviceCk.config.UpdateDeviceIDAndTags()
-	assert.Equal(t, "device:a-b:1.2.3.4", deviceCk.GetDeviceHostname())
+	hostname, err = deviceCk.GetDeviceHostname()
+	assert.Nil(t, err)
+	assert.Equal(t, "device:a-b:1.2.3.4", hostname)
 
 	deviceCk.config.Namespace = "a\n\r\tb"
 	deviceCk.config.UpdateDeviceIDAndTags()
-	assert.Equal(t, "device:ab:1.2.3.4", deviceCk.GetDeviceHostname())
+	hostname, err = deviceCk.GetDeviceHostname()
+	assert.Nil(t, err)
+	assert.Equal(t, "device:ab:1.2.3.4", hostname)
 
 	deviceCk.config.Namespace = strings.Repeat("a", 256)
 	deviceCk.config.UpdateDeviceIDAndTags()
-	assert.Equal(t, "", deviceCk.GetDeviceHostname())
+	hostname, err = deviceCk.GetDeviceHostname()
+	assert.NotNil(t, err)
+	assert.Equal(t, "", hostname)
 }

--- a/pkg/collector/corechecks/snmp/devicecheck/devicecheck_test.go
+++ b/pkg/collector/corechecks/snmp/devicecheck/devicecheck_test.go
@@ -297,7 +297,7 @@ profiles:
 	assert.Len(t, deviceCk.config.MetricTags, len(firstRunMetricsTags))
 }
 
-func TestDeviceCheck_GetHostname(t *testing.T) {
+func TestDeviceCheck_Hostname(t *testing.T) {
 	checkconfig.SetConfdPathAndCleanProfiles()
 	// language=yaml
 	rawInstanceConfig := []byte(`
@@ -323,7 +323,6 @@ community_string: public
 	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "", []string{"snmp_device:1.2.3.4"})
 
 	// with hostname
-	deviceCk.config.UseDeviceIDAsHostname = true
 	deviceCk.SetSender(report.NewMetricSender(sender, "device:123"))
 	deviceCk.sender.Gauge("snmp.devices_monitored", float64(1), []string{"snmp_device:1.2.3.4"})
 	sender.AssertMetric(t, "Gauge", "snmp.devices_monitored", float64(1), "device:123", []string{"snmp_device:1.2.3.4"})

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -60,7 +60,8 @@ func (c *Check) Run() error {
 			deviceCk := discoveredDevices[i]
 			hostname, err := deviceCk.GetDeviceHostname()
 			if err != nil {
-				return err
+				log.Warnf("error getting hostname for device %s: %s", deviceCk.GetIPAddress(), err)
+				continue
 			}
 			deviceCk.SetSender(report.NewMetricSender(sender, hostname))
 			jobs <- deviceCk

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -58,7 +58,11 @@ func (c *Check) Run() error {
 
 		for i := range discoveredDevices {
 			deviceCk := discoveredDevices[i]
-			deviceCk.SetSender(report.NewMetricSender(sender, deviceCk.GetDeviceHostname()))
+			hostname, err := deviceCk.GetDeviceHostname()
+			if err != nil {
+				return err
+			}
+			deviceCk.SetSender(report.NewMetricSender(sender, hostname))
 			jobs <- deviceCk
 		}
 		close(jobs)
@@ -68,7 +72,11 @@ func (c *Check) Run() error {
 		tags = append(tags, c.config.GetNetworkTags()...)
 		sender.Gauge("snmp.discovered_devices_count", float64(len(discoveredDevices)), "", tags)
 	} else {
-		c.singleDeviceCk.SetSender(report.NewMetricSender(sender, c.singleDeviceCk.GetDeviceHostname()))
+		hostname, err := c.singleDeviceCk.GetDeviceHostname()
+		if err != nil {
+			return err
+		}
+		c.singleDeviceCk.SetSender(report.NewMetricSender(sender, hostname))
 		checkErr = c.runCheckDevice(c.singleDeviceCk)
 	}
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -697,6 +697,8 @@ api_key:
   ## @param namespace - string - optional - default: default
   ## Namespace can be used to disambiguate devices with same IPs.
   ## Changing namespace will cause devices being recreated in NDM app.
+  ## It should contain less than 100 characters and should not contain any of
+  ## `<`, `>`, `\n`, `\t`, `\r` characters
   ## Only available using corecheck SNMP integration with `loader: core` config.
   #
   # namespace: default

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build !serverless
 // +build !serverless
 
 package util
@@ -378,19 +379,19 @@ func getValidEC2Hostname(ctx context.Context, ec2Provider hostname.Provider) (st
 }
 
 // NormalizeHost applies a liberal policy on host names.
-func NormalizeHost(host string) string {
+func NormalizeHost(host string) (string, error) {
 	var buf bytes.Buffer
 
 	// hosts longer than 253 characters are illegal
 	if len(host) > 253 {
-		return ""
+		return "", fmt.Errorf("hostname is too long, should contain less than 253 characters")
 	}
 
 	for _, r := range host {
 		switch r {
 		// has null rune just toss the whole thing
 		case '\x00':
-			return ""
+			return "", fmt.Errorf("hostname cannot contain null character")
 		// drop these characters entirely
 		case '\n', '\r', '\t':
 			continue
@@ -402,5 +403,5 @@ func NormalizeHost(host string) string {
 		}
 	}
 
-	return buf.String()
+	return buf.String(), nil
 }

--- a/pkg/util/hostname_test.go
+++ b/pkg/util/hostname_test.go
@@ -11,6 +11,7 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -70,6 +71,23 @@ func TestGetHostnameFromHostnameFileConfig(t *testing.T) {
 	}
 
 	assert.Equal(t, "expectedfilehostname", hostname)
+}
+
+func TestNormalizeHost(t *testing.T) {
+	assert := assert.New(t)
+	long := strings.Repeat("a", 256)
+	assert.Len(NormalizeHost(long), 0, "long host should be dropped")
+	assert.Equal("a-b", NormalizeHost("a<b"), "< defanged")
+	assert.Equal("a-b", NormalizeHost("a>b"), "> defanged")
+	assert.Equal("example.com", NormalizeHost("example.com\r\n"), "NL/CR dropped")
+
+	// Invalid host name as bytes that would look like this: 9cbef2d1-8c20-4bf2-97a5-7d70��
+	b := []byte{
+		57, 99, 98, 101, 102, 50, 100, 49, 45, 56, 99, 50, 48, 45,
+		52, 98, 102, 50, 45, 57, 55, 97, 53, 45, 55, 100, 55, 48,
+		0, 0, 0, 0, 239, 191, 189, 239, 191, 189, 1, // these are bad bytes
+	}
+	assert.Equal("", NormalizeHost(string(b)))
 }
 
 func writeTempHostnameFile(content string) (string, error) {

--- a/releasenotes/notes/snmp-normalize-namespace-9b6e4de441a4f2cd.yaml
+++ b/releasenotes/notes/snmp-normalize-namespace-9b6e4de441a4f2cd.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Validate snmp namespace to ensure it does respect length and illegal characters rules

--- a/releasenotes/notes/snmp-normalize-namespace-9b6e4de441a4f2cd.yaml
+++ b/releasenotes/notes/snmp-normalize-namespace-9b6e4de441a4f2cd.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Validate snmp namespace to ensure it does respect length and illegal characters rules
+    Validate SNMP namespace to ensure it respects length and illegal character rules.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

* Add hostname normalization function
* Normalize hostname when using user entered input

### Motivation

When `use_device_id_as_hostname` is enabled we allow user input to be used as hostname, to be used to create an entry in host database.  As host backend has some validation policies, we need to normalize and prompt user if the `namespace` is illegal. 

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Tests in `TestDeviceCheck_GetHostname` can be used for local testing:

* enable `use_device_id_as_hostname`
* verify illegal chars `[\n\r\t]` in `namespace` are dropped in`hostname`
* verify illegal chars `[<>]` in namespace are replaced by `-`
* verify long namespace (> 100 chars) makes the check fail

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
