### PR TITLE
Do not log warnings about proxy-related env vars

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1113,7 +1113,7 @@ func findUnknownKeys(config Config) []string {
 	return unknownKeys
 }
 
-func findUnknownEnvVars(config Config) []string {
+func findUnknownEnvVars(config Config, environ []string) []string {
 	var unknownVars []string
 
 	knownVars := map[string]struct{}{
@@ -1127,7 +1127,7 @@ func findUnknownEnvVars(config Config) []string {
 		knownVars[key] = struct{}{}
 	}
 
-	for _, equality := range os.Environ() {
+	for _, equality := range environ {
 		key := strings.SplitN(equality, "=", 2)[0]
 		if !strings.HasPrefix(key, "DD_") {
 			continue
@@ -1182,7 +1182,7 @@ func load(config Config, origin string, loadSecret bool) (*Warnings, error) {
 		log.Warnf("Unknown key in config file: %v", key)
 	}
 
-	for _, v := range findUnknownEnvVars(config) {
+	for _, v := range findUnknownEnvVars(config, os.Environ()) {
 		log.Warnf("Unknown environment variable: %v", v)
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1116,7 +1116,13 @@ func findUnknownKeys(config Config) []string {
 func findUnknownEnvVars(config Config) []string {
 	var unknownVars []string
 
-	knownVars := map[string]struct{}{}
+	knownVars := map[string]struct{}{
+		// these variables are used by the agent, but not via the Config struct,
+		// so must be listed separately.
+		"DD_PROXY_NO_PROXY": {},
+		"DD_PROXY_HTTP":     {},
+		"DD_PROXY_HTTPS":    {},
+	}
 	for _, key := range config.GetEnvVars() {
 		knownVars[key] = struct{}{}
 	}

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -151,7 +151,7 @@ func TestUnknownVarsWarning(t *testing.T) {
 	}
 	t.Run("DD_API_KEY", test("DD_API_KEY", false))
 	t.Run("DD_SITE", test("DD_SITE", false))
-	t.Run("DD_UNKOWN", test("DD_UNKOWN", true))
+	t.Run("DD_UNKNOWN", test("DD_UNKNOWN", true))
 	t.Run("UNKOWN", test("UNKOWN", false)) // no DD_ prefix
 	t.Run("DD_PROXY_NO_PROXY", test("DD_PROXY_NO_PROXY", false))
 	t.Run("DD_PROXY_HTTP", test("DD_PROXY_HTTP", false))

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -152,7 +152,7 @@ func TestUnknownVarsWarning(t *testing.T) {
 	t.Run("DD_API_KEY", test("DD_API_KEY", false))
 	t.Run("DD_SITE", test("DD_SITE", false))
 	t.Run("DD_UNKNOWN", test("DD_UNKNOWN", true))
-	t.Run("UNKOWN", test("UNKOWN", false)) // no DD_ prefix
+	t.Run("UNKNOWN", test("UNKNOWN", false)) // no DD_ prefix
 	t.Run("DD_PROXY_NO_PROXY", test("DD_PROXY_NO_PROXY", false))
 	t.Run("DD_PROXY_HTTP", test("DD_PROXY_HTTP", false))
 	t.Run("DD_PROXY_HTTPS", test("DD_PROXY_HTTPS", false))

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -135,6 +135,29 @@ unknown_key.unknown_subkey: true
 	assert.Len(t, findUnknownKeys(confWithUnknownKeys), 0)
 }
 
+func TestUnknownVarsWarning(t *testing.T) {
+	test := func(v string, unknown bool) func(*testing.T) {
+		return func(t *testing.T) {
+			os.Setenv(v, "foo")
+			defer func() {
+				os.Unsetenv(v)
+			}()
+			var exp []string
+			if unknown {
+				exp = append(exp, v)
+			}
+			assert.Equal(t, exp, findUnknownEnvVars(Mock()))
+		}
+	}
+	t.Run("DD_API_KEY", test("DD_API_KEY", false))
+	t.Run("DD_SITE", test("DD_SITE", false))
+	t.Run("DD_UNKOWN", test("DD_UNKOWN", true))
+	t.Run("UNKOWN", test("UNKOWN", false)) // no DD_ prefix
+	t.Run("DD_PROXY_NO_PROXY", test("DD_PROXY_NO_PROXY", false))
+	t.Run("DD_PROXY_HTTP", test("DD_PROXY_HTTP", false))
+	t.Run("DD_PROXY_HTTPS", test("DD_PROXY_HTTPS", false))
+}
+
 func TestSiteEnvVar(t *testing.T) {
 	resetAPIKey := setEnvForTest("DD_API_KEY", "fakeapikey")
 	resetSite := setEnvForTest("DD_SITE", "datadoghq.eu")

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -7,6 +7,7 @@ package config
 
 import (
 	"bytes"
+	"fmt"
 	"log"
 	"os"
 	"strings"
@@ -138,15 +139,12 @@ unknown_key.unknown_subkey: true
 func TestUnknownVarsWarning(t *testing.T) {
 	test := func(v string, unknown bool) func(*testing.T) {
 		return func(t *testing.T) {
-			os.Setenv(v, "foo")
-			defer func() {
-				os.Unsetenv(v)
-			}()
+			env := []string{fmt.Sprintf("%s=foo", v)}
 			var exp []string
 			if unknown {
 				exp = append(exp, v)
 			}
-			assert.Equal(t, exp, findUnknownEnvVars(Mock()))
+			assert.Equal(t, exp, findUnknownEnvVars(Mock(), env))
 		}
 	}
 	t.Run("DD_API_KEY", test("DD_API_KEY", false))

--- a/releasenotes/notes/silence-env-var-warning-363dca8f70c17f92.yaml
+++ b/releasenotes/notes/silence-env-var-warning-363dca8f70c17f92.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    The Agent no longer logs purious warnings regarding environment variables
+    The Agent no longer logs spurious warnings regarding proxy-related environment variables
     ``DD_PROXY_NO_PROXY``, ``DD_PROXY_HTTP``, and ``DD_PROXY_HTTPS``.

--- a/releasenotes/notes/silence-env-var-warning-363dca8f70c17f92.yaml
+++ b/releasenotes/notes/silence-env-var-warning-363dca8f70c17f92.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The Agent no longer logs purious warnings regarding environment variables
+    ``DD_PROXY_NO_PROXY``, ``DD_PROXY_HTTP``, and ``DD_PROXY_HTTPS``.


### PR DESCRIPTION
### What does this PR do?

Silences warnings about DD_PROXY_NO_PROXY, DD_PROXY_HTTP and DD_PROXY_HTTPS env vars

### Motivation

#10693 

### Additional Notes

I'd like to backport this to 7.34.

### Possible Drawbacks / Trade-offs

None

### Describe how to test/QA your changes

Set DD_PROXY_HTTP and start the agent; you should see no log messages.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
