### PR TITLE
Send logs agent metrics via DogStatsd

### DIFF
--- a/omnibus/releasenotes/notes/send-logs-agent-metrics-via-dogstatsd-6b3fb68d32e0c331.yaml
+++ b/omnibus/releasenotes/notes/send-logs-agent-metrics-via-dogstatsd-6b3fb68d32e0c331.yaml
@@ -1,0 +1,25 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Send logs agent metrics via DogStatsd.
+    - datadog.logs_agent.http.bytes_sent
+    - datadog.logs_agent.http.encoded_bytes_sent
+    - datadog.logs_agent.http.dropped
+    - datadog.logs_agent.http.network_errors
+    - datadog.logs_agent.http.retries
+    - datadog.logs_agent.http.sent
+    - datadog.logs_agent.http.sender_latency
+    - datadog.logs_agent.tcp.bytes_sent
+    - datadog.logs_agent.tcp.encoded_bytes_sent
+    - datadog.logs_agent.tcp.dropped
+    - datadog.logs_agent.tcp.network_errors
+    - datadog.logs_agent.tcp.sent
+    - datadog.logs_agent.processor.decoded
+    - datadog.logs_agent.processor.processed

--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -27,6 +27,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/logs/input/listener"
 	"github.com/DataDog/datadog-agent/pkg/logs/input/traps"
 	"github.com/DataDog/datadog-agent/pkg/logs/input/windowsevent"
+	"github.com/DataDog/datadog-agent/pkg/logs/metrics"
 	"github.com/DataDog/datadog-agent/pkg/logs/pipeline"
 	"github.com/DataDog/datadog-agent/pkg/logs/restart"
 	"github.com/DataDog/datadog-agent/pkg/logs/service"
@@ -105,6 +106,10 @@ func NewAgent(sources *config.LogSources, services *service.Services, processing
 	// Only try to start the container launchers if Docker or Kubernetes is available
 	if coreConfig.IsFeaturePresent(coreConfig.Docker) || coreConfig.IsFeaturePresent(coreConfig.Kubernetes) {
 		inputs = append(inputs, container.NewLauncher(containerLaunchables))
+	}
+
+	if err := metrics.InitDogStatsdClient(coreConfig.Datadog); err != nil {
+		log.Warnf("initialize DogStatsd client for logs agent: %v", err)
 	}
 
 	return &Agent{

--- a/pkg/logs/message/message.go
+++ b/pkg/logs/message/message.go
@@ -25,6 +25,15 @@ type Payload struct {
 	UnencodedSize int
 }
 
+// Size gets the total size of message contents.
+func (p *Payload) Size() int {
+	size := 0
+	for _, m := range p.Messages {
+		size += len(m.Content)
+	}
+	return size
+}
+
 // Message represents a log line sent to datadog, with its metadata
 type Message struct {
 	Content            []byte

--- a/pkg/logs/metrics/client.go
+++ b/pkg/logs/metrics/client.go
@@ -1,0 +1,49 @@
+package metrics
+
+import (
+	"fmt"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-go/statsd"
+)
+
+var dogstatsdClient = (*statsd.Client)(nil)
+
+// InitDogStatsdClient initializes the grobal DogStatsd client.
+func InitDogStatsdClient(conf config.Config) error {
+	var err error
+	dogstatsdClient, err = statsd.New(findAddr(conf))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func findAddr(conf config.Config) string {
+	host := "localhost"
+	if conf.IsSet("bind_host") {
+		host = conf.GetString("bind_host")
+	}
+
+	port := 8125
+	if conf.IsSet("dogstatsd_port") {
+		port = conf.GetInt("dogstatsd_port")
+	}
+	return fmt.Sprintf("%s:%d", host, port)
+}
+
+// Count calls Count on the global Client, if set.
+func Count(name string, value int64, tags []string, rate float64) error {
+	if dogstatsdClient == nil {
+		return nil // no-op
+	}
+	return dogstatsdClient.Count(name, value, tags, rate)
+}
+
+// Histogram calls Histogram on the global Client, if set.
+func Histogram(name string, value float64, tags []string, rate float64) error {
+	if dogstatsdClient == nil {
+		return nil // no-op
+	}
+	return dogstatsdClient.Histogram(name, value, tags, rate)
+}

--- a/pkg/logs/metrics/client_test.go
+++ b/pkg/logs/metrics/client_test.go
@@ -1,0 +1,51 @@
+package metrics
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_findAddr(t *testing.T) {
+	tests := []struct {
+		name          string
+		binddHost     string
+		dogstatsdPort int
+	}{
+		{
+			name:          "both set",
+			binddHost:     "somehost",
+			dogstatsdPort: 1234,
+		},
+		{
+			name:      "bind_host only",
+			binddHost: "somehost",
+		},
+		{
+			name:          "dogstatsd_port only",
+			dogstatsdPort: 1234,
+		},
+		{
+			name: "both empty",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config.Datadog = config.NewConfig("datadog", "DD", strings.NewReplacer(".", "_"))
+			if tt.binddHost == "" {
+				tt.binddHost = "localhost"
+			} else {
+				config.Datadog.Set("bind_host", tt.binddHost)
+			}
+			if tt.dogstatsdPort == 0 {
+				tt.dogstatsdPort = 8125
+			} else {
+				config.Datadog.Set("dogstatsd_port", tt.dogstatsdPort)
+			}
+			assert.Equal(t, findAddr(config.Datadog), fmt.Sprintf("%s:%d", tt.binddHost, tt.dogstatsdPort))
+		})
+	}
+}

--- a/pkg/logs/processor/processor.go
+++ b/pkg/logs/processor/processor.go
@@ -86,9 +86,11 @@ func (p *Processor) run() {
 func (p *Processor) processMessage(msg *message.Message) {
 	metrics.LogsDecoded.Add(1)
 	metrics.TlmLogsDecoded.Inc()
+	metrics.Count("datadog.logs_agent.processor.decoded", 1, nil, 1)
 	if shouldProcess, redactedMsg := p.applyRedactingRules(msg); shouldProcess {
 		metrics.LogsProcessed.Add(1)
 		metrics.TlmLogsProcessed.Inc()
+		metrics.Count("datadog.logs_agent.processor.processed", 1, nil, 1)
 
 		p.diagnosticMessageReceiver.HandleMessage(*msg, redactedMsg)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Send logs agent metrics via DogStatsd.

- datadog.logs_agent.http.bytes_sent
- datadog.logs_agent.http.encoded_bytes_sent
- datadog.logs_agent.http.dropped
- datadog.logs_agent.http.network_errors
- datadog.logs_agent.http.retries
- datadog.logs_agent.http.sent
- datadog.logs_agent.http.sender_latency
- datadog.logs_agent.tcp.bytes_sent
- datadog.logs_agent.tcp.encoded_bytes_sent
- datadog.logs_agent.tcp.dropped
- datadog.logs_agent.tcp.network_errors
- datadog.logs_agent.tcp.sent
- datadog.logs_agent.processor.decoded
- datadog.logs_agent.processor.processed

### Motivation

[Logs agent metrics](https://github.com/DataDog/datadog-agent/blob/fc37bdd247d9147ad1d7953df4004c9a5963c912/pkg/logs/metrics/metrics.go#L14-L76) can still be obtained by using  [expvars check](https://docs.datadoghq.com/integrations/go_expvar/?tab=host). Besides, we can use [Generate Metrics from Ingested Logs](https://docs.datadoghq.com/logs/log_configuration/logs_to_metrics/), but they need to be implemented. I want a metric that can be obtained just by installing Datadog Agent like [APM metrics](https://docs.datadoghq.com/tracing/troubleshooting/agent_apm_metrics/#pagetitle). It helps troubleshooting.
For example, when customers want supports for lost logs, the metrics we use this time make it easier to isolate whether the problem was logs agent or backend. 

### Additional Notes

- https://github.com/DataDog/datadog-agent/issues/10685
- If this PR is acceptable, I should add the explanation of metrics in https://github.com/DataDog/documentation like 
[APM metrics sent by the Datadog Agent](https://docs.datadoghq.com/tracing/troubleshooting/agent_apm_metrics/#pagetitle).

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Confirm new metrics intakes when running logs agent.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
