### PR TITLE
[kitchen] Update last stable version + fix stable Windows msi location

### DIFF
--- a/release.json
+++ b/release.json
@@ -1,8 +1,8 @@
 {
     "base_branch": "main",
     "last_stable": {
-        "6": "6.32.0",
-        "7": "7.32.0"
+        "6": "6.33.0",
+        "7": "7.33.0"
     },
     "nightly": {
         "INTEGRATIONS_CORE_VERSION": "master",

--- a/test/kitchen/test-definitions/windows-install-test.yml
+++ b/test/kitchen/test-definitions/windows-install-test.yml
@@ -31,7 +31,7 @@ suites:
         <%= key %>: <%= value %>
         <% end %>
       dd-agent-install:
-        windows_agent_url: https://s3.amazonaws.com/dd-agent-mstesting/builds/tagged/
+        windows_agent_url: https://s3.amazonaws.com/dd-agent-mstesting/builds/stable/
         windows_version: "<%= ENV['LAST_STABLE_VERSION'] %>"
         agent_install_options: >
           APIKEY=<%= api_key %>


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Updates last stable version on main + changes the path to stable msi in kitchen tests.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Since 7.33.0, the Windows stable builds are in `builds/stable`, not `builds/master`, which is why we need to update kitchen tests.

The last stable Agent version was updated on `7.34.x` without this kitchen change, so that part of the PR (the first commit) will have to be backported to 7.34.x.

### Additional notes

To be merged once the pipeline with kitchen tests passes.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Run kitchen tests.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
