### PR TITLE
pkg/trace/api: prevent proxied connection from being reused for profiles

### DIFF
--- a/pkg/trace/api/profiles.go
+++ b/pkg/trace/api/profiles.go
@@ -146,6 +146,7 @@ func (m *multiTransport) RoundTrip(req *http.Request) (rresp *http.Response, rer
 		r.Host = u.Host
 		r.URL = u
 		r.Header.Set("DD-API-KEY", apiKey)
+		r.Close = true
 	}
 	defer func() {
 		// Hack for backwards-compatibility

--- a/pkg/trace/api/profiles_test.go
+++ b/pkg/trace/api/profiles_test.go
@@ -63,6 +63,9 @@ func TestProfileProxy(t *testing.T) {
 		if v := req.Header.Get("X-Datadog-Additional-Tags"); v != "key:val" {
 			t.Fatalf("got invalid X-Datadog-Additional-Tags: %q", v)
 		}
+		if v := req.Close; v != true {
+			t.Fatalf("proxied connection was not closed after request: %t", v)
+		}
 		_, err = w.Write([]byte("OK"))
 		if err != nil {
 			t.Fatal(err)

--- a/releasenotes/notes/apm-profiling-do-not-reuse-connection-d5690bbe567a92f8.yaml
+++ b/releasenotes/notes/apm-profiling-do-not-reuse-connection-d5690bbe567a92f8.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    APM: Connections to upload profiles to the Datadog intake are no longer
+    reused. Tracers are generally configured to send one profile per minute,
+    which would occasionally coincide with the intake's connection timeout and
+    lead to errors.


### PR DESCRIPTION

### What does this PR do?

The proxied connection used to upload profiles to the Datadog intake is now closed after the request.

### Motivation

Some tracer libraries have been observing 502 error codes returned by the agent . This has for example been observed in dd-trace-js (see https://github.com/DataDog/dd-trace-js/pull/1461) and ddprof.

Performing a packet capture between the agent and the intake shows that this happens when a new profile request on a kept-alive connection coincides with the intake closing said connection. The reverse proxy we use for profile uploads throws an EOF error, which is translated to a 502 response code back to the tracer.

I've not looked into the intricacies of Go's reverse proxy behaviour, but there does seem to be some debate about this error handling (for example https://github.com/golang/go/issues/34413).

In the meantime, preventing the connection from being reused prevents 502 errors from happening.

### Possible Drawbacks / Trade-offs

Tracers are generally configured to perform one profile upload roughly every minute, reopening a new connection to do so will have a negligible impact on performance. For some tracers, such as dd-trace-js which has a 65 second upload interval by default, this prevents the connection from unnecessarily lingering around for 60 seconds before being closed by the intake.

### Describe how to test/QA your changes

You can use the setup from [here](https://gist.github.com/Qard/8ec88b8f2fe9884a1183e4162513db75), or use the latest version of dd-trace-js and override the default upload interval to be 60 seconds.

* when using the latest version of the agent, you'll observe occasional 502 errors.
* when using the agent version corresponding to this patch, 502 errors will no longer occur.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
