### PR TITLE
[serverless] Fix flakiness in routes tests

### DIFF
--- a/pkg/serverless/daemon/routes_test.go
+++ b/pkg/serverless/daemon/routes_test.go
@@ -45,7 +45,9 @@ func TestStartInvocation(t *testing.T) {
 	assert.Nil(err)
 	res, err := client.Do(request)
 	assert.Nil(err)
-	assert.Equal(res.StatusCode, 200)
+	if res != nil {
+		assert.Equal(res.StatusCode, 200)
+	}
 	assert.True(m.OnInvokeStartCalled)
 }
 
@@ -63,7 +65,9 @@ func TestEndInvocation(t *testing.T) {
 	assert.Nil(err)
 	res, err := client.Do(request)
 	assert.Nil(err)
-	assert.Equal(res.StatusCode, 200)
+	if res != nil {
+		assert.Equal(res.StatusCode, 200)
+	}
 	assert.False(m.isError)
 	assert.True(m.OnInvokeEndCalled)
 }
@@ -83,7 +87,9 @@ func TestEndInvocationWithError(t *testing.T) {
 	assert.Nil(err)
 	res, err := client.Do(request)
 	assert.Nil(err)
-	assert.Equal(res.StatusCode, 200)
+	if res != nil {
+		assert.Equal(res.StatusCode, 200)
+	}
 	assert.True(m.OnInvokeEndCalled)
 	assert.True(m.isError)
 }
@@ -107,9 +113,11 @@ func TestTraceContext(t *testing.T) {
 	assert.Nil(err)
 	request, err = http.NewRequest(http.MethodPost, "http://127.0.0.1:8124/trace-context", nil)
 	assert.Nil(err)
-	response, err := client.Do(request)
+	res, err := client.Do(request)
 	assert.Nil(err)
 	assert.Equal("2222", fmt.Sprintf("%v", invocationlifecycle.TraceID()))
-	assert.Equal(response.Header.Get("x-datadog-trace-id"), fmt.Sprintf("%v", invocationlifecycle.TraceID()))
-	assert.Equal(response.Header.Get("x-datadog-span-id"), fmt.Sprintf("%v", invocationlifecycle.SpanID()))
+	if res != nil {
+		assert.Equal(res.Header.Get("x-datadog-trace-id"), fmt.Sprintf("%v", invocationlifecycle.TraceID()))
+		assert.Equal(res.Header.Get("x-datadog-span-id"), fmt.Sprintf("%v", invocationlifecycle.SpanID()))
+	}
 }


### PR DESCRIPTION
### What does this PR do?

Attempts to fix flakiness in the `routes_test.go` file.

The failure mode this fixes:
- HTTP client returns an `err`, but `res` is nil
- Test execution continues, we check `res.StatusCode`, which causes a panic because `res` is nil
- Test is NOT retried because of panic

### Motivation

We have been seeing some sporadic failures in these tests in CI.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
