### PR TITLE
[process-agent] Disable process_discovery check on ECS Fargate (#10715)

### DIFF
--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -284,6 +284,11 @@ func (a *AgentConfig) setCheckInterval(ns, check, checkKey string) {
 // Since it has its own unique object, we need to handle loading in the check config differently separately
 // from the other checks.
 func (a *AgentConfig) initProcessDiscoveryCheck() {
+	if config.IsECSFargate() {
+		log.Debug("Process discovery is not supported on ECS Fargate")
+		return
+	}
+
 	root := key(ns, "process_discovery")
 
 	// Discovery check can only be enabled when regular process collection is not enabled.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Port of https://github.com/DataDog/datadog-agent/pull/10715.
Disables process_discovery check on ECS Fargate (no procfs visibility in this environment). 

### Motivation

process_discovery check is enabled by default, however in this environment it will not be producing meaningful data, while the feature existed in prior releases, now it's running by default which qualifies this as a potential regression.

Note that this functionality is still supported on EKS Fargate - can collect processes with `shareProcessNamespace`.

### Possible Drawbacks / Trade-offs

This needs to be revisited in the future when process collection is supported on ECS Fargate.

### Describe how to test/QA your changes

Run Datadog Agent on ECS Fargate in the default configuration and confirm that the process_discovery check is not running (based on observed logs).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
