### PR TITLE
Implement ECS metadata v4

### DIFF
--- a/pkg/util/docker/containers.go
+++ b/pkg/util/docker/containers.go
@@ -358,7 +358,9 @@ func (d *DockerUtil) getECSMetadataURL(ctx context.Context, cID string) (string,
 		return "", err
 	}
 	for _, e := range i.Config.Env {
-		if strings.HasPrefix(e, "ECS_CONTAINER_METADATA_URI=") {
+		if strings.HasPrefix(e, "ECS_CONTAINER_METADATA_URI_V4=") {
+			return strings.Split(e, "=")[1], nil
+		} else if strings.HasPrefix(e, "ECS_CONTAINER_METADATA_URI=") {
 			return strings.Split(e, "=")[1], nil
 		}
 	}

--- a/pkg/util/docker/containers.go
+++ b/pkg/util/docker/containers.go
@@ -86,13 +86,13 @@ func (d *DockerUtil) ListContainers(ctx context.Context, cfg *ContainerListConfi
 			// in awsvpc networking mode so we try getting IP address from the
 			// ECS container metadata endpoint and port from inspect.Config.ExposedPorts
 			if networkMode == containers.AwsvpcNetworkMode {
-				ecsContainerMetadataURL, err := d.getECSMetadataURL(ctx, container.ID)
+				ecsContainerMetadataURL, ecsMetadataVersion, err := d.getECSMetadataURL(ctx, container.ID)
 				if err != nil {
 					log.Debugf("Failed to get the ECS container metadata URI for container %s. Network info will be missing. Error: %s", container.ID, err)
 					continue
 				}
 
-				addresses, err := GetContainerNetworkAddresses(ecsContainerMetadataURL)
+				addresses, err := GetContainerNetworkAddresses(ecsContainerMetadataURL, ecsMetadataVersion)
 				if err != nil {
 					log.Errorf("Failed to get network addresses for container: %s. Network info will be missing. Error: %s", container.ID, err)
 					continue
@@ -352,19 +352,19 @@ func isExposed(port types.Port) bool {
 
 // getECSMetadataURL inspects a given container ID and returns its ECS container metadata URI
 // if found in its environment. It returns an empty string and an error on failure.
-func (d *DockerUtil) getECSMetadataURL(ctx context.Context, cID string) (string, error) {
+func (d *DockerUtil) getECSMetadataURL(ctx context.Context, cID string) (string, string, error) {
 	i, err := d.Inspect(ctx, cID, false)
 	if err != nil {
-		return "", err
+		return "", "", err
 	}
 	for _, e := range i.Config.Env {
 		if strings.HasPrefix(e, "ECS_CONTAINER_METADATA_URI_V4=") {
-			return strings.Split(e, "=")[1], nil
+			return strings.Split(e, "=")[1], "v4", nil
 		} else if strings.HasPrefix(e, "ECS_CONTAINER_METADATA_URI=") {
-			return strings.Split(e, "=")[1], nil
+			return strings.Split(e, "=")[1], "v3", nil
 		}
 	}
-	return "", errors.New("ecs container metadata uri not found")
+	return "", "", errors.New("ecs container metadata uri not found")
 }
 
 // cleanupCaches removes cache entries for unknown containers and images

--- a/pkg/util/docker/network.go
+++ b/pkg/util/docker/network.go
@@ -24,7 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/containers/providers"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
-	v3 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3"
+	v3or4 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3or4"
 )
 
 type dockerNetwork struct {
@@ -153,9 +153,9 @@ func GetAgentContainerNetworkMode(ctx context.Context) (string, error) {
 // GetContainerNetworkAddresses returns internal container network address
 // representations from the container metadata retrieved at the given URL.
 func GetContainerNetworkAddresses(agentURL string) ([]containers.NetworkAddress, error) {
-	container, err := v3.NewClient(agentURL).GetContainer(context.TODO())
+	container, err := v3or4.NewClient(agentURL).GetContainer(context.TODO())
 	if err != nil {
-		return nil, fmt.Errorf("failed to get task from metadata v3 API: %s", err)
+		return nil, fmt.Errorf("failed to get task from metadata v3 or v4 API: %s", err)
 	}
 	return parseContainerNetworkAddresses(container.Ports, container.Networks, container.DockerName), nil
 }
@@ -193,7 +193,7 @@ func GetContainerNetworkMode(ctx context.Context, cid string) (string, error) {
 
 // parseContainerNetworkAddresses converts ECS container ports
 // and networks into a list of NetworkAddress
-func parseContainerNetworkAddresses(ports []v3.Port, networks []v3.Network, container string) []containers.NetworkAddress {
+func parseContainerNetworkAddresses(ports []v3or4.Port, networks []v3or4.Network, container string) []containers.NetworkAddress {
 	addrList := []containers.NetworkAddress{}
 	if networks == nil {
 		log.Debugf("No network settings available in ECS metadata")

--- a/pkg/util/docker/network.go
+++ b/pkg/util/docker/network.go
@@ -152,10 +152,10 @@ func GetAgentContainerNetworkMode(ctx context.Context) (string, error) {
 
 // GetContainerNetworkAddresses returns internal container network address
 // representations from the container metadata retrieved at the given URL.
-func GetContainerNetworkAddresses(agentURL string) ([]containers.NetworkAddress, error) {
-	container, err := v3or4.NewClient(agentURL).GetContainer(context.TODO())
+func GetContainerNetworkAddresses(agentURL, apiVersion string) ([]containers.NetworkAddress, error) {
+	container, err := v3or4.NewClient(agentURL, apiVersion).GetContainer(context.TODO())
 	if err != nil {
-		return nil, fmt.Errorf("failed to get task from metadata v3 or v4 API: %s", err)
+		return nil, fmt.Errorf("failed to get task from metadata %s API: %s", apiVersion, err)
 	}
 	return parseContainerNetworkAddresses(container.Ports, container.Networks, container.DockerName), nil
 }

--- a/pkg/util/ecs/detection.go
+++ b/pkg/util/ecs/detection.go
@@ -83,9 +83,9 @@ func HasEC2ResourceTags() bool {
 		return false
 	}
 	return queryCacheBool(hasEC2ResourceTagsCacheKey, func() (bool, time.Duration) {
-		client, err := ecsmeta.V3FromCurrentTask()
+		client, err := ecsmeta.V3orV4FromCurrentTask()
 		if err != nil {
-			log.Debugf("failed to detect V3 metadata endpoint: %s", err)
+			log.Debugf("failed to detect V3 and V4 metadata endpoint: %s", err)
 			return false, hasEC2ResourceTagsCacheExpiry
 		}
 		_, err = client.GetTaskWithTags(context.TODO())

--- a/pkg/util/ecs/diagnosis.go
+++ b/pkg/util/ecs/diagnosis.go
@@ -42,7 +42,7 @@ func diagnoseECS() error {
 
 // diagnose the ECS metadata with tags API availability
 func diagnoseECSTags() error {
-	client, err := ecsmeta.V3FromCurrentTask()
+	client, err := ecsmeta.V3orV4FromCurrentTask()
 	if err != nil {
 		return err
 	}

--- a/pkg/util/ecs/metadata/clients.go
+++ b/pkg/util/ecs/metadata/clients.go
@@ -21,7 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/ecs/common"
 	v1 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v1"
 	v2 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v2"
-	v3 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3"
+	v3or4 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3or4"
 )
 
 const (
@@ -33,15 +33,15 @@ var globalUtil util
 
 type util struct {
 	// used to setup the ECSUtil
-	initRetryV1 retry.Retrier
-	initRetryV2 retry.Retrier
-	initRetryV3 retry.Retrier
-	initV1      sync.Once
-	initV2      sync.Once
-	initV3      sync.Once
-	v1          *v1.Client
-	v2          *v2.Client
-	v3          *v3.Client
+	initRetryV1     retry.Retrier
+	initRetryV2     retry.Retrier
+	initRetryV3orV4 retry.Retrier
+	initV1          sync.Once
+	initV2          sync.Once
+	initV3orV4      sync.Once
+	v1              *v1.Client
+	v2              *v2.Client
+	v3or4           *v3or4.Client
 }
 
 // V1 returns a client for the ECS metadata API v1, also called introspection
@@ -92,28 +92,28 @@ func V2() (*v2.Client, error) {
 	return globalUtil.v2, nil
 }
 
-// V3FromCurrentTask returns a client for the ECS metadata API v3 by detecting
+// V3orV4FromCurrentTask returns a client for the ECS metadata API v3 or v4 by detecting
 // the endpoint address from the task the executable is running in. Returns an
 // error if it was not possible to detect the endpoint address.
-func V3FromCurrentTask() (*v3.Client, error) {
+func V3orV4FromCurrentTask() (*v3or4.Client, error) {
 	if !config.IsCloudProviderEnabled(common.CloudProviderName) {
 		return nil, fmt.Errorf("Cloud Provider %s is disabled by configuration", common.CloudProviderName)
 	}
 
-	globalUtil.initV3.Do(func() {
-		globalUtil.initRetryV3.SetupRetrier(&retry.Config{ //nolint:errcheck
-			Name:              "ecsutil-meta-v3",
-			AttemptMethod:     initV3,
+	globalUtil.initV3orV4.Do(func() {
+		globalUtil.initRetryV3orV4.SetupRetrier(&retry.Config{ //nolint:errcheck
+			Name:              "ecsutil-meta-v3-or-v4",
+			AttemptMethod:     initV3orV4,
 			Strategy:          retry.Backoff,
 			InitialRetryDelay: initialRetryDelay,
 			MaxRetryDelay:     maxRetryDelay,
 		})
 	})
-	if err := globalUtil.initRetryV3.TriggerRetry(); err != nil {
-		log.Debugf("ECS metadata v3 client init error: %s", err)
+	if err := globalUtil.initRetryV3orV4.TriggerRetry(); err != nil {
+		log.Debugf("ECS metadata v3 or v4 client init error: %s", err)
 		return nil, err
 	}
-	return globalUtil.v3, nil
+	return globalUtil.v3or4, nil
 }
 
 // newAutodetectedClientV1 detects the metadata v1 API endpoint and creates a new
@@ -128,12 +128,22 @@ func newAutodetectedClientV1() (*v1.Client, error) {
 
 // newClientV3ForCurrentTask detects the metadata API v3 endpoint from the current
 // task and creates a new client for it.
-func newClientV3ForCurrentTask() (*v3.Client, error) {
+func newClientV3ForCurrentTask() (*v3or4.Client, error) {
 	agentURL, err := getAgentV3URLFromEnv()
 	if err != nil {
 		return nil, err
 	}
-	return v3.NewClient(agentURL), nil
+	return v3or4.NewClient(agentURL), nil
+}
+
+// newClientV4ForCurrentTask detects the metadata API v4 endpoint from the current
+// task and creates a new client for it.
+func newClientV4ForCurrentTask() (*v3or4.Client, error) {
+	agentURL, err := getAgentV4URLFromEnv()
+	if err != nil {
+		return nil, err
+	}
+	return v3or4.NewClient(agentURL), nil
 }
 
 func initV1() error {
@@ -155,11 +165,17 @@ func initV2() error {
 	return nil
 }
 
-func initV3() error {
-	client, err := newClientV3ForCurrentTask()
+func initV3orV4() error {
+	client, err := newClientV4ForCurrentTask()
+	if err == nil {
+		globalUtil.v3or4 = client
+		return nil
+	}
+
+	client, err = newClientV3ForCurrentTask()
 	if err != nil {
 		return err
 	}
-	globalUtil.v3 = client
+	globalUtil.v3or4 = client
 	return nil
 }

--- a/pkg/util/ecs/metadata/clients.go
+++ b/pkg/util/ecs/metadata/clients.go
@@ -95,6 +95,7 @@ func V2() (*v2.Client, error) {
 // V3orV4FromCurrentTask returns a client for the ECS metadata API v3 or v4 by detecting
 // the endpoint address from the task the executable is running in. Returns an
 // error if it was not possible to detect the endpoint address.
+// v4 metadata API is preferred over v3 if both are available.
 func V3orV4FromCurrentTask() (*v3or4.Client, error) {
 	if !config.IsCloudProviderEnabled(common.CloudProviderName) {
 		return nil, fmt.Errorf("Cloud Provider %s is disabled by configuration", common.CloudProviderName)
@@ -133,7 +134,7 @@ func newClientV3ForCurrentTask() (*v3or4.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return v3or4.NewClient(agentURL), nil
+	return v3or4.NewClient(agentURL, "v3"), nil
 }
 
 // newClientV4ForCurrentTask detects the metadata API v4 endpoint from the current
@@ -143,7 +144,7 @@ func newClientV4ForCurrentTask() (*v3or4.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	return v3or4.NewClient(agentURL), nil
+	return v3or4.NewClient(agentURL, "v4"), nil
 }
 
 func initV1() error {

--- a/pkg/util/ecs/metadata/clients_nodocker.go
+++ b/pkg/util/ecs/metadata/clients_nodocker.go
@@ -17,7 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/ecs/common"
 	v1 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v1"
 	v2 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v2"
-	v3 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3"
+	v3or4 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3or4"
 )
 
 // V1 returns a client for the ECS metadata API v1, also called introspection
@@ -31,15 +31,15 @@ func V1() (*v1.Client, error) {
 // endpoint address.
 func V2() (*v2.Client, error) {
 	if !config.IsCloudProviderEnabled(common.CloudProviderName) {
-		return nil, fmt.Errorf("Cloud Provider %s is disabled by configuration", common.CloudProviderName)
+		return nil, fmt.Errorf("cloud Provider %s is disabled by configuration", common.CloudProviderName)
 	}
 
 	return v2.NewDefaultClient(), nil
 }
 
-// V3FromCurrentTask returns a client for the ECS metadata API v3 by detedting
+// V3orV4FromCurrentTask returns a client for the ECS metadata API v3 or v4 by detedting
 // the endpoint address from the task the executable is running in. Returns an
 // error if it was not possible to detect the endpoint address.
-func V3FromCurrentTask() (*v3.Client, error) {
+func V3orV4FromCurrentTask() (*v3or4.Client, error) {
 	return nil, docker.ErrDockerNotCompiled
 }

--- a/pkg/util/ecs/metadata/detection.go
+++ b/pkg/util/ecs/metadata/detection.go
@@ -24,7 +24,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	v1 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v1"
-	v3 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3"
+	v3or4 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v3or4"
 )
 
 func detectAgentV1URL() (string, error) {
@@ -123,9 +123,17 @@ func testURLs(urls []string, timeout time.Duration) string {
 }
 
 func getAgentV3URLFromEnv() (string, error) {
-	agentURL, found := os.LookupEnv(v3.DefaultMetadataURIEnvVariable)
+	agentURL, found := os.LookupEnv(v3or4.DefaultMetadataURIv3EnvVariable)
 	if !found {
 		return "", fmt.Errorf("Could not initialize client: missing metadata v3 URL")
+	}
+	return agentURL, nil
+}
+
+func getAgentV4URLFromEnv() (string, error) {
+	agentURL, found := os.LookupEnv(v3or4.DefaultMetadataURIv4EnvVariable)
+	if !found {
+		return "", fmt.Errorf("Could not initialize client: missing metadata v4 URL")
 	}
 	return agentURL, nil
 }

--- a/pkg/util/ecs/metadata/v3or4/client.go
+++ b/pkg/util/ecs/metadata/v3or4/client.go
@@ -1,12 +1,12 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2020-present Datadog, Inc.
+// Copyright 2022-present Datadog, Inc.
 
 //go:build docker
 // +build docker
 
-package v3
+package v3or4
 
 import (
 	"context"
@@ -22,20 +22,22 @@ import (
 )
 
 const (
-	// DefaultMetadataURIEnvVariable is the default environment variable used to hold the metadata endpoint URI.
-	DefaultMetadataURIEnvVariable = "ECS_CONTAINER_METADATA_URI"
+	// DefaultMetadataURIv3EnvVariable is the default environment variable used to hold the metadata endpoint URI v3.
+	DefaultMetadataURIv3EnvVariable = "ECS_CONTAINER_METADATA_URI"
+	// DefaultMetadataURIv4EnvVariable is the default environment variable used to hold the metadata endpoint URI v4.
+	DefaultMetadataURIv4EnvVariable = "ECS_CONTAINER_METADATA_URI_V4"
 
-	// Metadata v3 API paths
+	// Metadata v3 and v4 API paths. They're the same.
 	taskMetadataPath         = "/task"
 	taskMetadataWithTagsPath = "/taskWithTags"
 )
 
-// Client represents a client for a metadata v3 API endpoint.
+// Client represents a client for a metadata v3 or v4 API endpoint.
 type Client struct {
 	agentURL string
 }
 
-// NewClient creates a new client for the specified metadata v3 API endpoint.
+// NewClient creates a new client for the specified metadata v3 or v4 API endpoint.
 func NewClient(agentURL string) *Client {
 	return &Client{
 		agentURL: agentURL,
@@ -85,11 +87,11 @@ func (c *Client) get(ctx context.Context, path string, v interface{}) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("Unexpected HTTP status code in metadata v3 reply: %d", resp.StatusCode)
+		return fmt.Errorf("Unexpected HTTP status code in metadata v3 or v4 reply: %d", resp.StatusCode)
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(v); err != nil {
-		return fmt.Errorf("Failed to decode metadata v3 JSON payload to type %s: %s", reflect.TypeOf(v), err)
+		return fmt.Errorf("Failed to decode metadata v3 or v4 JSON payload to type %s: %s", reflect.TypeOf(v), err)
 	}
 
 	return nil

--- a/pkg/util/ecs/metadata/v3or4/client.go
+++ b/pkg/util/ecs/metadata/v3or4/client.go
@@ -34,13 +34,15 @@ const (
 
 // Client represents a client for a metadata v3 or v4 API endpoint.
 type Client struct {
-	agentURL string
+	agentURL   string
+	apiVersion string
 }
 
 // NewClient creates a new client for the specified metadata v3 or v4 API endpoint.
-func NewClient(agentURL string) *Client {
+func NewClient(agentURL, apiVersion string) *Client {
 	return &Client{
-		agentURL: agentURL,
+		agentURL:   agentURL,
+		apiVersion: apiVersion,
 	}
 }
 
@@ -87,11 +89,11 @@ func (c *Client) get(ctx context.Context, path string, v interface{}) error {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("Unexpected HTTP status code in metadata v3 or v4 reply: %d", resp.StatusCode)
+		return fmt.Errorf("Unexpected HTTP status code in metadata %s reply: %d", c.apiVersion, resp.StatusCode)
 	}
 
 	if err := json.NewDecoder(resp.Body).Decode(v); err != nil {
-		return fmt.Errorf("Failed to decode metadata v3 or v4 JSON payload to type %s: %s", reflect.TypeOf(v), err)
+		return fmt.Errorf("Failed to decode metadata %s JSON payload to type %s: %s", c.apiVersion, reflect.TypeOf(v), err)
 	}
 
 	return nil

--- a/pkg/util/ecs/metadata/v3or4/client_nodocker.go
+++ b/pkg/util/ecs/metadata/v3or4/client_nodocker.go
@@ -1,12 +1,12 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2020-present Datadog, Inc.
+// Copyright 2022-present Datadog, Inc.
 
 //go:build !docker
 // +build !docker
 
-package v3
+package v3or4
 
-// Client represents a client for a metadata v3 API endpoint.
+// Client represents a client for a metadata v3 or v4 API endpoint.
 type Client struct{}

--- a/pkg/util/ecs/metadata/v3or4/types.go
+++ b/pkg/util/ecs/metadata/v3or4/types.go
@@ -1,11 +1,11 @@
 // Unless explicitly stated otherwise all files in this repository are licensed
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
-// Copyright 2020-present Datadog, Inc.
+// Copyright 2022-present Datadog, Inc.
 
-package v3
+package v3or4
 
-// Task represents a task as returned by the ECS metadata API v3.
+// Task represents a task as returned by the ECS metadata API v3 or v4.
 type Task struct {
 	ClusterName           string             `json:"Cluster"`
 	Containers            []Container        `json:"Containers"`
@@ -13,33 +13,37 @@ type Task struct {
 	TaskARN               string             `json:"TaskARN"`
 	Family                string             `json:"Family"`
 	Version               string             `json:"Revision"`
-	Limits                map[string]float64 `json:"Limits"`
+	Limits                map[string]float64 `json:"Limits,omitempty"`
 	DesiredStatus         string             `json:"DesiredStatus"`
-	ContainerInstanceTags map[string]string  `json:"ContainerInstanceTags,omitempty"` // undocumented
-	TaskTags              map[string]string  `json:"TaskTags,omitempty"`              // undocumented
+	LaunchType            string             `json:"LaunchType,omitempty"` // present only in v4
+	ContainerInstanceTags map[string]string  `json:"ContainerInstanceTags,omitempty"`
+	TaskTags              map[string]string  `json:"TaskTags,omitempty"`
 }
 
 // Container represents a container within a task.
 type Container struct {
 	Name          string            `json:"Name"`
-	Limits        map[string]uint64 `json:"Limits"`
+	Limits        map[string]uint64 `json:"Limits,omitempty"`
 	ImageID       string            `json:"ImageID,omitempty"`
-	StartedAt     string            `json:"StartedAt"` // 2017-11-17T17:14:07.781711848Z
+	StartedAt     string            `json:"StartedAt,omitempty"` // 2017-11-17T17:14:07.781711848Z
 	DockerName    string            `json:"DockerName"`
 	Type          string            `json:"Type"`
 	Image         string            `json:"Image"`
-	Labels        map[string]string `json:"Labels"`
+	Labels        map[string]string `json:"Labels,omitempty"`
 	KnownStatus   string            `json:"KnownStatus"`
 	DesiredStatus string            `json:"DesiredStatus"`
 	DockerID      string            `json:"DockerID"`
-	CreatedAt     string            `json:"CreatedAt"`
-	Networks      []Network         `json:"Networks"`
-	Ports         []Port            `json:"Ports"`
+	CreatedAt     string            `json:"CreatedAt,omitempty"`
+	Networks      []Network         `json:"Networks,omitempty"`
+	Ports         []Port            `json:"Ports,omitempty"`
+	LogDriver     string            `json:"LogDriver,omitemty"`     // present only in v4
+	LogOptions    map[string]string `json:"LogOptions,omitempty"`   // present only in v4
+	ContainerARN  string            `json:"ContainerARN,omitempty"` // present only in v4
 }
 
 // Network represents the network of a container
 type Network struct {
-	NetworkMode   string   `json:"NetworkMode"`   // as of today the only supported mode is awsvpc
+	NetworkMode   string   `json:"NetworkMode"`   // supports awsvpc and bridge
 	IPv4Addresses []string `json:"IPv4Addresses"` // one-element list
 }
 

--- a/pkg/workloadmeta/collectors/ecs/ecs.go
+++ b/pkg/workloadmeta/collectors/ecs/ecs.go
@@ -237,7 +237,7 @@ func (c *collector) getResourceTags(ctx context.Context, entity *workloadmeta.EC
 		return rt
 	}
 
-	metaV3orV4 := v3or4.NewClient(metaURI)
+	metaV3orV4 := v3or4.NewClient(metaURI, metaVersion)
 	taskWithTags, err := metaV3orV4.GetTaskWithTags(ctx)
 	if err != nil {
 		log.Errorf("failed to get task with tags from metadata %s API: %s", metaVersion, err)

--- a/releasenotes/notes/ecs_metadata_v4-cd98dd2d10039f41.yaml
+++ b/releasenotes/notes/ecs_metadata_v4-cd98dd2d10039f41.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    Add support of ECS metadata v4 API
+    Add support for ECS metadata v4 API
     https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html

--- a/releasenotes/notes/ecs_metadata_v4-cd98dd2d10039f41.yaml
+++ b/releasenotes/notes/ecs_metadata_v4-cd98dd2d10039f41.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add support of ECS metadata v4 API
+    https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Implement the support of the [ECS metadata v4 API](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v4.html).
It turns out it’s not very different from the [ECS metadata v3 API](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-metadata-endpoint-v3.html) already supported.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

* Create an ECS cluster ([script](https://github.com/DataDog/container-agent-envs-doc/tree/main/create_test_env/1_cluster_management/ecs))
* Patch the ECS IAM role to add the `ecs:ListTagsForResource` permission (see point 2 [here](https://docs.datadoghq.com/agent/amazon_ecs/tags/#resource-tag-collection))
* Deploy the agent on it ([script](https://github.com/DataDog/container-agent-envs-doc/tree/main/create_test_env/2_agent_management/ecs-ec2))
* Deploy some testing workload ([script](https://github.com/DataDog/container-agent-envs-doc/tree/main/create_test_env/3_dummy_app_management/ecs-ec2))
* Check that the `redisdb` metrics reported by [this task](https://github.com/DataDog/container-agent-envs-doc/blob/main/create_test_env/3_dummy_app_management/ecs-ec2/tasks/redis.json) are properly tagged with [this tag](https://github.com/DataDog/container-agent-envs-doc/blob/main/create_test_env/3_dummy_app_management/ecs-ec2/tasks/redis.json#L12-L15).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
