### PR TITLE
[Process Agent] Move Windows Settings to Global Config

### DIFF
--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -91,7 +91,8 @@ func setupProcesses(config Config) {
 	config.SetKnown("process_config.custom_sensitive_words")
 	config.SetKnown("process_config.scrub_args")
 	config.SetKnown("process_config.strip_proc_arguments")
-	config.SetKnown("process_config.windows.use_perf_counters")
+	// Use PDH API to collect performance counter data for process check on Windows
+	procBindEnvAndSetDefault(config, "process_config.windows.use_perf_counters", false)
 	config.SetKnown("process_config.additional_endpoints.*")
 	config.SetKnown("process_config.container_source")
 	config.SetKnown("process_config.intervals.connections")

--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -91,7 +91,6 @@ func setupProcesses(config Config) {
 	config.SetKnown("process_config.custom_sensitive_words")
 	config.SetKnown("process_config.scrub_args")
 	config.SetKnown("process_config.strip_proc_arguments")
-	config.SetKnown("process_config.windows.args_refresh_interval")
 	config.SetKnown("process_config.windows.use_perf_counters")
 	config.SetKnown("process_config.additional_endpoints.*")
 	config.SetKnown("process_config.container_source")

--- a/pkg/config/process.go
+++ b/pkg/config/process.go
@@ -92,7 +92,6 @@ func setupProcesses(config Config) {
 	config.SetKnown("process_config.scrub_args")
 	config.SetKnown("process_config.strip_proc_arguments")
 	config.SetKnown("process_config.windows.args_refresh_interval")
-	config.SetKnown("process_config.windows.add_new_args")
 	config.SetKnown("process_config.windows.use_perf_counters")
 	config.SetKnown("process_config.additional_endpoints.*")
 	config.SetKnown("process_config.container_source")

--- a/pkg/config/process_test.go
+++ b/pkg/config/process_test.go
@@ -66,6 +66,10 @@ func TestProcessDefaultConfig(t *testing.T) {
 			key:          "process_config.process_queue_bytes",
 			defaultValue: DefaultProcessQueueBytes,
 		},
+		{
+			key:          "process_config.windows.use_perf_counters",
+			defaultValue: false,
+		},
 	} {
 		t.Run(tc.key+" default", func(t *testing.T) {
 			assert.Equal(t, tc.defaultValue, cfg.Get(tc.key))
@@ -219,6 +223,12 @@ func TestEnvVarOverride(t *testing.T) {
 			env:      "DD_PROCESS_CONFIG_PROCESS_QUEUE_BYTES",
 			value:    "20000",
 			expected: 20000,
+		},
+		{
+			key:      "process_config.windows.use_perf_counters",
+			env:      "DD_PROCESS_CONFIG_WINDOWS_USE_PERF_COUNTERS",
+			value:    "true",
+			expected: true,
 		},
 	} {
 		t.Run(tc.env, func(t *testing.T) {

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -65,9 +65,9 @@ type ProcessCheck struct {
 }
 
 // Init initializes the singleton ProcessCheck.
-func (p *ProcessCheck) Init(cfg *config.AgentConfig, info *model.SystemInfo) {
+func (p *ProcessCheck) Init(_ *config.AgentConfig, info *model.SystemInfo) {
 	p.sysInfo = info
-	p.probe = getProcessProbe(cfg)
+	p.probe = getProcessProbe()
 
 	p.notInitializedLogLimit = util.NewLogLimit(1, time.Minute*10)
 

--- a/pkg/process/checks/process_discovery_check.go
+++ b/pkg/process/checks/process_discovery_check.go
@@ -27,10 +27,10 @@ type ProcessDiscoveryCheck struct {
 }
 
 // Init initializes the ProcessDiscoveryCheck. It is a runtime error to call Run without first having called Init.
-func (d *ProcessDiscoveryCheck) Init(cfg *config.AgentConfig, info *model.SystemInfo) {
+func (d *ProcessDiscoveryCheck) Init(_ *config.AgentConfig, info *model.SystemInfo) {
 	d.info = info
 	d.initCalled = true
-	d.probe = getProcessProbe(cfg)
+	d.probe = getProcessProbe()
 }
 
 // Name returns the name of the ProcessDiscoveryCheck.

--- a/pkg/process/checks/process_probe.go
+++ b/pkg/process/checks/process_probe.go
@@ -9,8 +9,7 @@ import (
 	"runtime"
 	"sync"
 
-	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/process/config"
+	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
@@ -21,10 +20,10 @@ var (
 	defaultWindowsProbe procutil.Probe
 )
 
-func getProcessProbe(cfg *config.AgentConfig) procutil.Probe {
+func getProcessProbe() procutil.Probe {
 	processProbeOnce.Do(func() {
 		if runtime.GOOS == "windows" {
-			if !ddconfig.Datadog.GetBool("process_config.windows.use_perf_counters") {
+			if !config.Datadog.GetBool("process_config.windows.use_perf_counters") {
 				log.Info("Using toolhelp API probe for process data collection")
 				processProbe = defaultWindowsProbe
 				return

--- a/pkg/process/checks/process_probe.go
+++ b/pkg/process/checks/process_probe.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"sync"
 
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/process/config"
 	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -23,7 +24,7 @@ var (
 func getProcessProbe(cfg *config.AgentConfig) procutil.Probe {
 	processProbeOnce.Do(func() {
 		if runtime.GOOS == "windows" {
-			if !cfg.Windows.UsePerfCounters {
+			if !ddconfig.Datadog.GetBool("process_config.windows.use_perf_counters") {
 				log.Info("Using toolhelp API probe for process data collection")
 				processProbe = defaultWindowsProbe
 				return

--- a/pkg/process/checks/process_windows_test.go
+++ b/pkg/process/checks/process_windows_test.go
@@ -1,0 +1,24 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build windows
+// +build windows
+
+package checks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+)
+
+func TestPerfCountersConfigSetting(t *testing.T) {
+	cfg := config.Mock()
+	cfg.Set("process_config.windows.use_perf_counters", true)
+	probe := getProcessProbe()
+	assert.Equal(t, probe, defaultWindowsProbe)
+}

--- a/pkg/process/checks/process_windows_test.go
+++ b/pkg/process/checks/process_windows_test.go
@@ -9,6 +9,7 @@
 package checks
 
 import (
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,8 +18,27 @@ import (
 )
 
 func TestPerfCountersConfigSetting(t *testing.T) {
-	cfg := config.Mock()
-	cfg.Set("process_config.windows.use_perf_counters", true)
-	probe := getProcessProbe()
-	assert.Equal(t, probe, defaultWindowsProbe)
+	resetOnce := func() {
+		processProbeOnce = sync.Once{}
+	}
+
+	t.Run("enabled", func(t *testing.T) {
+		resetOnce()
+		defer resetOnce()
+
+		cfg := config.Mock()
+		cfg.Set("process_config.windows.use_perf_counters", true)
+		probe := getProcessProbe()
+		assert.Equal(t, probe, defaultWindowsProbe)
+	})
+
+	t.Run("disabled", func(t *testing.T) {
+		resetOnce()
+		defer resetOnce()
+
+		cfg := config.Mock()
+		cfg.Set("process_config.windows.use_perf_counters", false)
+		probe := getProcessProbe()
+		assert.NotEqual(t, probe, defaultWindowsProbe)
+	})
 }

--- a/pkg/process/checks/process_windows_test.go
+++ b/pkg/process/checks/process_windows_test.go
@@ -22,22 +22,22 @@ func TestPerfCountersConfigSetting(t *testing.T) {
 		processProbeOnce = sync.Once{}
 	}
 
-	t.Run("enabled", func(t *testing.T) {
-		resetOnce()
-		defer resetOnce()
-
-		cfg := config.Mock()
-		cfg.Set("process_config.windows.use_perf_counters", true)
-		probe := getProcessProbe()
-		assert.Equal(t, probe, defaultWindowsProbe)
-	})
-
-	t.Run("disabled", func(t *testing.T) {
+	t.Run("use toolhelp API", func(t *testing.T) {
 		resetOnce()
 		defer resetOnce()
 
 		cfg := config.Mock()
 		cfg.Set("process_config.windows.use_perf_counters", false)
+		probe := getProcessProbe()
+		assert.Equal(t, probe, defaultWindowsProbe)
+	})
+
+	t.Run("use PDH api", func(t *testing.T) {
+		resetOnce()
+		defer resetOnce()
+
+		cfg := config.Mock()
+		cfg.Set("process_config.windows.use_perf_counters", true)
 		probe := getProcessProbe()
 		assert.NotEqual(t, probe, defaultWindowsProbe)
 	})

--- a/pkg/process/checks/process_windows_test.go
+++ b/pkg/process/checks/process_windows_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/process/procutil"
 )
 
 func TestPerfCountersConfigSetting(t *testing.T) {
@@ -29,7 +30,7 @@ func TestPerfCountersConfigSetting(t *testing.T) {
 		cfg := config.Mock()
 		cfg.Set("process_config.windows.use_perf_counters", false)
 		probe := getProcessProbe()
-		assert.Equal(t, probe, defaultWindowsProbe)
+		assert.IsType(t, procutil.NewWindowsToolhelpProbe(), probe)
 	})
 
 	t.Run("use PDH api", func(t *testing.T) {
@@ -39,6 +40,6 @@ func TestPerfCountersConfigSetting(t *testing.T) {
 		cfg := config.Mock()
 		cfg.Set("process_config.windows.use_perf_counters", true)
 		probe := getProcessProbe()
-		assert.NotEqual(t, probe, defaultWindowsProbe)
+		assert.IsType(t, procutil.NewProcessProbe(), probe)
 	})
 }

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -340,7 +340,6 @@ func loadEnvVariables() {
 		{"DD_PROCESS_AGENT_MAX_PER_MESSAGE", "process_config.max_per_message"},
 		{"DD_PROCESS_AGENT_MAX_CTR_PROCS_PER_MESSAGE", "process_config.max_ctr_procs_per_message"},
 		{"DD_PROCESS_AGENT_CMD_PORT", "process_config.cmd_port"},
-		{"DD_PROCESS_AGENT_WINDOWS_USE_PERF_COUNTERS", "process_config.windows.use_perf_counters"},
 		{"DD_ORCHESTRATOR_URL", "orchestrator_explorer.orchestrator_dd_url"},
 		{"DD_HOSTNAME", "hostname"},
 		{"DD_BIND_HOST", "bind_host"},

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -205,11 +205,6 @@ func NewDefaultAgentConfig() *AgentConfig {
 		// DataScrubber to hide command line sensitive words
 		Scrubber:  NewDefaultDataScrubber(),
 		Blacklist: make([]*regexp.Regexp, 0),
-
-		// Windows process config
-		Windows: WindowsConfig{
-			ArgsRefreshInterval: 15, // with default 20s check interval we refresh every 5m
-		},
 	}
 
 	// Set default values for proc/sys paths if unset.
@@ -303,13 +298,6 @@ func NewAgentConfig(loggerName config.LoggerName, yamlPath string, syscfg *sysco
 
 	if cfg.proxy != nil {
 		cfg.Transport.Proxy = cfg.proxy
-	}
-
-	// sanity check. This element is used with the modulo operator (%), so it can't be zero.
-	// if it is, log the error, and assume the config was attempting to disable
-	if cfg.Windows.ArgsRefreshInterval == 0 {
-		log.Warnf("invalid configuration: windows_collect_skip_new_args was set to 0.  Disabling argument collection")
-		cfg.Windows.ArgsRefreshInterval = -1
 	}
 
 	// activate the pod collection if enabled and we have the cluster name set

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -80,12 +80,6 @@ type proxyFunc func(*http.Request) (*url.URL, error)
 
 type cmdFunc = func(name string, arg ...string) *exec.Cmd
 
-// WindowsConfig stores all windows-specific configuration for the process-agent and system-probe.
-type WindowsConfig struct {
-	// UsePerfCounters enables new process check using performance counters for process collection
-	UsePerfCounters bool
-}
-
 // AgentConfig is the global config for the process-agent. This information
 // is sourced from config files and the environment variables.
 //
@@ -120,9 +114,6 @@ type AgentConfig struct {
 
 	// Internal store of a proxy used for generating the Transport
 	proxy proxyFunc
-
-	// Windows-specific config
-	Windows WindowsConfig
 }
 
 // CheckIsEnabled returns a bool indicating if the given check name is enabled.

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -82,8 +82,6 @@ type cmdFunc = func(name string, arg ...string) *exec.Cmd
 
 // WindowsConfig stores all windows-specific configuration for the process-agent and system-probe.
 type WindowsConfig struct {
-	// Number of checks runs between refreshes of command-line arguments
-	ArgsRefreshInterval int
 	// UsePerfCounters enables new process check using performance counters for process collection
 	UsePerfCounters bool
 }

--- a/pkg/process/config/config.go
+++ b/pkg/process/config/config.go
@@ -84,8 +84,6 @@ type cmdFunc = func(name string, arg ...string) *exec.Cmd
 type WindowsConfig struct {
 	// Number of checks runs between refreshes of command-line arguments
 	ArgsRefreshInterval int
-	// Controls getting process arguments immediately when a new process is discovered
-	AddNewArgs bool
 	// UsePerfCounters enables new process check using performance counters for process collection
 	UsePerfCounters bool
 }
@@ -211,7 +209,6 @@ func NewDefaultAgentConfig() *AgentConfig {
 		// Windows process config
 		Windows: WindowsConfig{
 			ArgsRefreshInterval: 15, // with default 20s check interval we refresh every 5m
-			AddNewArgs:          true,
 		},
 	}
 

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -322,7 +322,6 @@ func TestAgentConfigYamlAndSystemProbeConfig(t *testing.T) {
 	assert.Equal(8*time.Second, agentConfig.CheckIntervals[ContainerCheckName])
 	assert.Equal(30*time.Second, agentConfig.CheckIntervals[ProcessCheckName])
 	assert.Equal(100, agentConfig.Windows.ArgsRefreshInterval)
-	assert.Equal(false, agentConfig.Windows.AddNewArgs)
 	assert.Equal(false, agentConfig.Scrubber.Enabled)
 	assert.Equal(5065, agentConfig.ProcessExpVarPort)
 
@@ -336,7 +335,6 @@ func TestAgentConfigYamlAndSystemProbeConfig(t *testing.T) {
 	assert.Equal(8*time.Second, agentConfig.CheckIntervals[ContainerCheckName])
 	assert.Equal(30*time.Second, agentConfig.CheckIntervals[ProcessCheckName])
 	assert.Equal(100, agentConfig.Windows.ArgsRefreshInterval)
-	assert.Equal(false, agentConfig.Windows.AddNewArgs)
 	assert.Equal(false, agentConfig.Scrubber.Enabled)
 	if runtime.GOOS != "windows" {
 		assert.Equal("/var/my-location/system-probe.log", agentConfig.SystemProbeAddress)
@@ -352,7 +350,6 @@ func TestAgentConfigYamlAndSystemProbeConfig(t *testing.T) {
 	assert.Equal(8*time.Second, agentConfig.CheckIntervals[ContainerCheckName])
 	assert.Equal(30*time.Second, agentConfig.CheckIntervals[ProcessCheckName])
 	assert.Equal(100, agentConfig.Windows.ArgsRefreshInterval)
-	assert.Equal(false, agentConfig.Windows.AddNewArgs)
 	assert.Equal(false, agentConfig.Scrubber.Enabled)
 	if runtime.GOOS != "windows" {
 		assert.Equal("/var/my-location/system-probe.log", agentConfig.SystemProbeAddress)

--- a/pkg/process/config/config_test.go
+++ b/pkg/process/config/config_test.go
@@ -321,7 +321,6 @@ func TestAgentConfigYamlAndSystemProbeConfig(t *testing.T) {
 	assert.Equal(append(processChecks), agentConfig.EnabledChecks)
 	assert.Equal(8*time.Second, agentConfig.CheckIntervals[ContainerCheckName])
 	assert.Equal(30*time.Second, agentConfig.CheckIntervals[ProcessCheckName])
-	assert.Equal(100, agentConfig.Windows.ArgsRefreshInterval)
 	assert.Equal(false, agentConfig.Scrubber.Enabled)
 	assert.Equal(5065, agentConfig.ProcessExpVarPort)
 
@@ -334,7 +333,6 @@ func TestAgentConfigYamlAndSystemProbeConfig(t *testing.T) {
 	assert.Equal(10, config.Datadog.GetInt("process_config.queue_size"))
 	assert.Equal(8*time.Second, agentConfig.CheckIntervals[ContainerCheckName])
 	assert.Equal(30*time.Second, agentConfig.CheckIntervals[ProcessCheckName])
-	assert.Equal(100, agentConfig.Windows.ArgsRefreshInterval)
 	assert.Equal(false, agentConfig.Scrubber.Enabled)
 	if runtime.GOOS != "windows" {
 		assert.Equal("/var/my-location/system-probe.log", agentConfig.SystemProbeAddress)
@@ -349,7 +347,6 @@ func TestAgentConfigYamlAndSystemProbeConfig(t *testing.T) {
 	assert.Equal(10, config.Datadog.GetInt("process_config.queue_size"))
 	assert.Equal(8*time.Second, agentConfig.CheckIntervals[ContainerCheckName])
 	assert.Equal(30*time.Second, agentConfig.CheckIntervals[ProcessCheckName])
-	assert.Equal(100, agentConfig.Windows.ArgsRefreshInterval)
 	assert.Equal(false, agentConfig.Scrubber.Enabled)
 	if runtime.GOOS != "windows" {
 		assert.Equal("/var/my-location/system-probe.log", agentConfig.SystemProbeAddress)

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -146,11 +146,6 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string, canAccessContainers boo
 		}
 	}
 
-	// Windows: Controls using the new check based on performance counters PDH APIs
-	if usePerfCountersKey := key(ns, "windows", "use_perf_counters"); config.Datadog.IsSet(usePerfCountersKey) {
-		a.Windows.UsePerfCounters = config.Datadog.GetBool(usePerfCountersKey)
-	}
-
 	// Optional additional pairs of endpoint_url => []apiKeys to submit to other locations.
 	if k := key(ns, "additional_endpoints"); config.Datadog.IsSet(k) {
 		for endpointURL, apiKeys := range config.Datadog.GetStringMapStringSlice(k) {

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -146,11 +146,6 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string, canAccessContainers boo
 		}
 	}
 
-	// Windows: Sets windows process table refresh rate (in number of check runs)
-	if argRefresh := config.Datadog.GetInt(key(ns, "windows", "args_refresh_interval")); argRefresh != 0 {
-		a.Windows.ArgsRefreshInterval = argRefresh
-	}
-
 	// Windows: Controls using the new check based on performance counters PDH APIs
 	if usePerfCountersKey := key(ns, "windows", "use_perf_counters"); config.Datadog.IsSet(usePerfCountersKey) {
 		a.Windows.UsePerfCounters = config.Datadog.GetBool(usePerfCountersKey)

--- a/pkg/process/config/yaml_config.go
+++ b/pkg/process/config/yaml_config.go
@@ -151,11 +151,6 @@ func (a *AgentConfig) LoadProcessYamlConfig(path string, canAccessContainers boo
 		a.Windows.ArgsRefreshInterval = argRefresh
 	}
 
-	// Windows: Controls getting process arguments immediately when a new process is discovered
-	if addArgsKey := key(ns, "windows", "add_new_args"); config.Datadog.IsSet(addArgsKey) {
-		a.Windows.AddNewArgs = config.Datadog.GetBool(addArgsKey)
-	}
-
 	// Windows: Controls using the new check based on performance counters PDH APIs
 	if usePerfCountersKey := key(ns, "windows", "use_perf_counters"); config.Datadog.IsSet(usePerfCountersKey) {
 		a.Windows.UsePerfCounters = config.Datadog.GetBool(usePerfCountersKey)

--- a/releasenotes/notes/process-agent-move-windows-settings-7c903ac4ba9fd393.yaml
+++ b/releasenotes/notes/process-agent-move-windows-settings-7c903ac4ba9fd393.yaml
@@ -1,0 +1,6 @@
+---
+enhancements:
+  - Added `DD_PROCESS_CONFIG_WINDOWS_USE_PERF_COUNTERS` and `DD_PROCESS_AGENT_WINDOWS_USE_PERF_COUNTERS` environment variables
+deprecations:
+  - Removed `process_config.windows.args_refresh_interval` config setting
+  - Removed `process_config.windows.add_new_args` config setting

--- a/releasenotes/notes/process-agent-move-windows-settings-7c903ac4ba9fd393.yaml
+++ b/releasenotes/notes/process-agent-move-windows-settings-7c903ac4ba9fd393.yaml
@@ -2,5 +2,5 @@
 enhancements:
   - Added `DD_PROCESS_CONFIG_WINDOWS_USE_PERF_COUNTERS` and `DD_PROCESS_AGENT_WINDOWS_USE_PERF_COUNTERS` environment variables
 deprecations:
-  - Removed `process_config.windows.args_refresh_interval` config setting
-  - Removed `process_config.windows.add_new_args` config setting
+  - Removed unused `process_config.windows.args_refresh_interval` config setting
+  - Removed unused `process_config.windows.add_new_args` config setting


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

This PR removes unused settings from `WindowsConfig`. The remaining setting, `UsePerfCounters` is moved to the global config.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This PR is part of the process agent config refactor.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

On Windows, set `process_config.windows.use_perf_counters` to `true`, as well as `log_level` to `info`. When you run the process check make sure you get the message "Using toolhelp API probe for process data collection".

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
