### PR TITLE
Remove requirements.txt contents and point to datadog-agent-buildimages

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -131,18 +131,6 @@ updates:
     schedule:
       interval: monthly
   - package-ecosystem: "pip"
-    directory: "/"
-    labels:
-      - dependencies
-      - python
-      - team/agent-platform
-      - changelog/no-changelog
-      - qa/skip-qa
-      - dev/tooling
-    milestone: 22
-    schedule:
-      interval: "weekly"
-  - package-ecosystem: "pip"
     directory: "/.circleci"
     labels:
       - dependencies

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,2 @@
-# python development requirements for the Datadog Agent
-invoke==1.6.0
-reno==3.5.0
-docker==5.0.3
-docker-squash==1.0.9
-requests==2.27.1
-PyYAML==6.0
-toml==0.10.2
+# To edit the requirements file, open a PR on github.com/DataDog/datadog-agent-buildimages
+-r https://raw.githubusercontent.com/DataDog/datadog-agent-buildimages/main/requirements.txt


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Replace current `requirements.txt` file with the latest version of the `datadog-agent-buildimages` requirements.txt file.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

We want to install dependencies on the images at build time to reduce the amount of network errors, while still keeping existing contributing instructions simple.


### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This should be a no-op.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
