### PR TITLE
[windows] add 1.3.1 driver for 7.34

### DIFF
--- a/release.json
+++ b/release.json
@@ -12,8 +12,8 @@
         "JMXFETCH_HASH": "dbd31f982328a3cf6b44c65b06812a14daf24172a82ab6266be1d208e0f420e9",
         "MACOS_BUILD_VERSION": "master",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "1.3.0",
-        "WINDOWS_DDNPM_SHASUM": "c135e8f8d1060235dcc52a3e5c3b421d1d37be2b4124ec3269308949a254c540",
+        "WINDOWS_DDNPM_VERSION": "1.3.1",
+        "WINDOWS_DDNPM_SHASUM": "a14514beb952f3aaa09de4df43c5e439044a90aaddf05b1ade459778c1d255d3",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
@@ -24,8 +24,8 @@
         "JMXFETCH_HASH": "dbd31f982328a3cf6b44c65b06812a14daf24172a82ab6266be1d208e0f420e9",
         "MACOS_BUILD_VERSION": "master",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "1.3.0",
-        "WINDOWS_DDNPM_SHASUM": "c135e8f8d1060235dcc52a3e5c3b421d1d37be2b4124ec3269308949a254c540",
+        "WINDOWS_DDNPM_VERSION": "1.3.1",
+        "WINDOWS_DDNPM_SHASUM": "a14514beb952f3aaa09de4df43c5e439044a90aaddf05b1ade459778c1d255d3",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "release-a6": {

--- a/releasenotes/notes/bsod131-fceaf6319e3e1b5c.yaml
+++ b/releasenotes/notes/bsod131-fceaf6319e3e1b5c.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Adds Windows NPM driver 1.3.1, which contains a fix for the system crash on system-probe shutdown under heavy load.


### PR DESCRIPTION
### What does this PR do?

Upgrades release with new NPM driver version 1.3.1

### Motivation

Customer reported crash in previous version.

### Describe how to test/QA your changes

Enable windows NPM.

#### ensure that you can reproduce the problem
Install previous version (7.33 or previous RC).
generate very high DNS load.
start a loop of starting/stopping the system probe

(in powershell)
`while ($true) { stop-service datadog-system-probe; start-service datadog-system-probe }`

within a short period of time, the machine should blue screen

#### test fix
Upgrade to this RC 
repeat conditions; ensure no blue screen.


### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
