### PR TITLE
backport 1.3.1 npm version to main

### DIFF
--- a/release.json
+++ b/release.json
@@ -12,8 +12,8 @@
         "JMXFETCH_HASH": "dbd31f982328a3cf6b44c65b06812a14daf24172a82ab6266be1d208e0f420e9",
         "MACOS_BUILD_VERSION": "master",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "1.3.0",
-        "WINDOWS_DDNPM_SHASUM": "c135e8f8d1060235dcc52a3e5c3b421d1d37be2b4124ec3269308949a254c540",
+        "WINDOWS_DDNPM_VERSION": "1.3.1",
+        "WINDOWS_DDNPM_SHASUM": "a14514beb952f3aaa09de4df43c5e439044a90aaddf05b1ade459778c1d255d3",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "nightly-a7": {
@@ -24,8 +24,8 @@
         "JMXFETCH_HASH": "dbd31f982328a3cf6b44c65b06812a14daf24172a82ab6266be1d208e0f420e9",
         "MACOS_BUILD_VERSION": "master",
         "WINDOWS_DDNPM_DRIVER": "release-signed",
-        "WINDOWS_DDNPM_VERSION": "1.3.0",
-        "WINDOWS_DDNPM_SHASUM": "c135e8f8d1060235dcc52a3e5c3b421d1d37be2b4124ec3269308949a254c540",
+        "WINDOWS_DDNPM_VERSION": "1.3.1",
+        "WINDOWS_DDNPM_SHASUM": "a14514beb952f3aaa09de4df43c5e439044a90aaddf05b1ade459778c1d255d3",
         "SECURITY_AGENT_POLICIES_VERSION": "master"
     },
     "release-a6": {


### PR DESCRIPTION
### What does this PR do?

backports the upgrade from NPM 1.3.0 to 1.3.1 to main (#10746)

### Motivation

make sure main has latest/greatest driver with bugfix.

### Describe how to test/QA your changes

see #10746 for more details

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
