### PR TITLE
Add the possibility to specify multiple config files to the Agent.

### DIFF
--- a/cmd/agent/app/app.go
+++ b/cmd/agent/app/app.go
@@ -28,21 +28,23 @@ to Datadog on your behalf so that you can do something useful with your
 monitoring and performance data.`,
 		SilenceUsage: true,
 	}
-	// confFilePath holds the path to the folder containing the configuration
+	// confFilePaths holds the path to the folder containing the configuration
 	// file, to allow overrides from the command line
-	confFilePath string
-	flagNoColor  bool
+	confFilePaths []string
+	flagNoColor   bool
 	// sysProbeConfFilePath holds the path to the folder containing the system-probe
 	// configuration file, to allow overrides from the command line
 	sysProbeConfFilePath string
 )
 
 // loggerName is the name of the core agent logger
-const loggerName config.LoggerName = "CORE"
-const jmxLoggerName config.LoggerName = "JMXFETCH"
+const (
+	loggerName    config.LoggerName = "CORE"
+	jmxLoggerName config.LoggerName = "JMXFETCH"
+)
 
 func init() {
-	AgentCmd.PersistentFlags().StringVarP(&confFilePath, "cfgpath", "c", "", "path to directory containing datadog.yaml")
+	AgentCmd.PersistentFlags().StringSliceVarP(&confFilePaths, "cfgpath", "c", nil, "path to directory containing datadog.yaml")
 	AgentCmd.PersistentFlags().BoolVarP(&flagNoColor, "no-color", "n", false, "disable color output")
 	AgentCmd.PersistentFlags().StringVarP(&sysProbeConfFilePath, "sysprobecfgpath", "", "", "path to directory containing system-probe.yaml")
 }

--- a/cmd/agent/app/check.go
+++ b/cmd/agent/app/check.go
@@ -10,5 +10,5 @@ import (
 )
 
 func init() {
-	AgentCmd.AddCommand(commands.Check(loggerName, &confFilePath, &flagNoColor))
+	AgentCmd.AddCommand(commands.Check(loggerName, confFilePaths, &flagNoColor))
 }

--- a/cmd/agent/app/config.go
+++ b/cmd/agent/app/config.go
@@ -28,7 +28,7 @@ func setupConfig() error {
 		color.NoColor = true
 	}
 
-	err := common.SetupConfigWithoutSecrets(confFilePath, "")
+	err := common.SetupConfigWithoutSecrets(confFilePaths, "")
 	if err != nil {
 		return fmt.Errorf("unable to set up global agent configuration: %v", err)
 	}

--- a/cmd/agent/app/config_check.go
+++ b/cmd/agent/app/config_check.go
@@ -32,12 +32,11 @@ var configCheckCommand = &cobra.Command{
 	Short:   "Print all configurations loaded & resolved of a running agent",
 	Long:    ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		if flagNoColor {
 			color.NoColor = true
 		}
 
-		err := common.SetupConfig(confFilePath)
+		err := common.SetupConfig(confFilePaths)
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}

--- a/cmd/agent/app/diagnose.go
+++ b/cmd/agent/app/diagnose.go
@@ -29,7 +29,7 @@ var diagnoseCommand = &cobra.Command{
 
 func doDiagnose(cmd *cobra.Command, args []string) error {
 	// Global config setup
-	err := common.SetupConfig(confFilePath)
+	err := common.SetupConfig(confFilePaths)
 	if err != nil {
 		return fmt.Errorf("unable to set up global agent configuration: %v", err)
 	}

--- a/cmd/agent/app/dogstatsd_capture.go
+++ b/cmd/agent/app/dogstatsd_capture.go
@@ -52,12 +52,11 @@ var dogstatsdCaptureCmd = &cobra.Command{
 	Short: "Start a dogstatsd UDS traffic capture",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		if flagNoColor {
 			color.NoColor = true
 		}
 
-		err := common.SetupConfigWithoutSecrets(confFilePath, "")
+		err := common.SetupConfigWithoutSecrets(confFilePaths, "")
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}

--- a/cmd/agent/app/dogstatsd_replay.go
+++ b/cmd/agent/app/dogstatsd_replay.go
@@ -51,12 +51,11 @@ var dogstatsdReplayCmd = &cobra.Command{
 	Short: "Replay dogstatsd traffic",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		if flagNoColor {
 			color.NoColor = true
 		}
 
-		err := common.SetupConfigWithoutSecrets(confFilePath, "")
+		err := common.SetupConfigWithoutSecrets(confFilePaths, "")
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}
@@ -72,7 +71,6 @@ var dogstatsdReplayCmd = &cobra.Command{
 }
 
 func dogstatsdReplay() error {
-
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 

--- a/cmd/agent/app/dogstatsd_stats.go
+++ b/cmd/agent/app/dogstatsd_stats.go
@@ -22,9 +22,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	dsdStatsFilePath string
-)
+var dsdStatsFilePath string
 
 func init() {
 	AgentCmd.AddCommand(dogstatsdStatsCmd)
@@ -38,12 +36,11 @@ var dogstatsdStatsCmd = &cobra.Command{
 	Short: "Print basic statistics on the metrics processed by dogstatsd",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		if flagNoColor {
 			color.NoColor = true
 		}
 
-		err := common.SetupConfigWithoutSecrets(confFilePath, "")
+		err := common.SetupConfigWithoutSecrets(confFilePaths, "")
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}
@@ -77,7 +74,7 @@ func requestDogstatsdStats() error {
 
 	r, e := util.DoGet(c, urlstr)
 	if e != nil {
-		var errMap = make(map[string]string)
+		errMap := make(map[string]string)
 		json.Unmarshal(r, &errMap) //nolint:errcheck
 		// If the error has been marshalled into a json object, check it and return it properly
 		if err, found := errMap["error"]; found {

--- a/cmd/agent/app/flare.go
+++ b/cmd/agent/app/flare.go
@@ -51,12 +51,11 @@ var flareCmd = &cobra.Command{
 	Short: "Collect a flare and send it to Datadog",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		if flagNoColor {
 			color.NoColor = true
 		}
 
-		err := common.SetupConfig(confFilePath)
+		err := common.SetupConfig(confFilePaths)
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}

--- a/cmd/agent/app/health.go
+++ b/cmd/agent/app/health.go
@@ -10,5 +10,5 @@ import (
 )
 
 func init() {
-	AgentCmd.AddCommand(commands.Health(loggerName, &confFilePath, &flagNoColor))
+	AgentCmd.AddCommand(commands.Health(loggerName, confFilePaths, &flagNoColor))
 }

--- a/cmd/agent/app/hostname.go
+++ b/cmd/agent/app/hostname.go
@@ -28,8 +28,7 @@ var getHostnameCommand = &cobra.Command{
 
 // query for the version
 func doGetHostname(cmd *cobra.Command, args []string) error {
-
-	err := common.SetupConfigWithoutSecrets(confFilePath, "")
+	err := common.SetupConfigWithoutSecrets(confFilePaths, "")
 	if err != nil {
 		return fmt.Errorf("unable to set up global agent configuration: %v", err)
 	}

--- a/cmd/agent/app/import.go
+++ b/cmd/agent/app/import.go
@@ -40,7 +40,7 @@ func doImport(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("please provide all the required arguments")
 	}
 
-	if confFilePath != "" {
+	if len(confFilePaths) == 0 {
 		fmt.Fprintf(os.Stderr, "Please note configdir option has no effect\n")
 	}
 	oldConfigDir := args[0]

--- a/cmd/agent/app/integrations.go
+++ b/cmd/agent/app/integrations.go
@@ -145,7 +145,7 @@ func loadPythonInfo() error {
 		rootDir = parentDir
 	}
 
-	if err := common.SetupConfigIfExist(confFilePath); err != nil {
+	if err := common.SetupConfigIfExist(confFilePaths); err != nil {
 		fmt.Printf("Cannot setup config, exiting: %v\n", err)
 		return err
 	}
@@ -712,7 +712,6 @@ func installedVersion(integration string) (*semver.Version, bool, error) {
 
 	pythonCmd := exec.Command(pythonPath, "-c", fmt.Sprintf(integrationVersionScript, integration))
 	output, err := pythonCmd.Output()
-
 	if err != nil {
 		errMsg := ""
 		if exitErr, ok := err.(*exec.ExitError); ok {

--- a/cmd/agent/app/jmx.go
+++ b/cmd/agent/app/jmx.go
@@ -112,7 +112,7 @@ func init() {
 	jmxCmd.AddCommand(jmxListCmd)
 	jmxCmd.AddCommand(jmxCollectCmd)
 
-	//attach list commands to list root
+	// attach list commands to list root
 	jmxListCmd.AddCommand(jmxListEverythingCmd, jmxListMatchingCmd, jmxListLimitedCmd, jmxListCollectedCmd, jmxListNotMatchingCmd, jmxListWithMetricsCmd, jmxListWithRateMetricsCmd)
 
 	jmxListCmd.PersistentFlags().StringSliceVar(&cliSelectedChecks, "checks", []string{}, "JMX checks (ex: jmx,tomcat)")
@@ -167,7 +167,7 @@ func runJmxCommandConsole(command string) error {
 		jmxLogLevel = "debug"
 	}
 
-	logLevel, _, err := standalone.SetupCLI(loggerName, confFilePath, "", logFile, jmxLogLevel, "debug")
+	logLevel, _, err := standalone.SetupCLI(loggerName, confFilePaths, "", logFile, jmxLogLevel, "debug")
 	if err != nil {
 		fmt.Printf("Cannot initialize command: %v\n", err)
 		return err

--- a/cmd/agent/app/launchgui.go
+++ b/cmd/agent/app/launchgui.go
@@ -16,24 +16,21 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	launchCmd = &cobra.Command{
-		Use:          "launch-gui",
-		Short:        "starts the Datadog Agent GUI",
-		Long:         ``,
-		RunE:         launchGui,
-		SilenceUsage: true,
-	}
-)
+var launchCmd = &cobra.Command{
+	Use:          "launch-gui",
+	Short:        "starts the Datadog Agent GUI",
+	Long:         ``,
+	RunE:         launchGui,
+	SilenceUsage: true,
+}
 
 func init() {
 	// attach the command to the root
 	AgentCmd.AddCommand(launchCmd)
-
 }
 
 func launchGui(cmd *cobra.Command, args []string) error {
-	err := common.SetupConfigWithoutSecrets(confFilePath, "")
+	err := common.SetupConfigWithoutSecrets(confFilePaths, "")
 	if err != nil {
 		return fmt.Errorf("unable to set up global agent configuration: %v", err)
 	}
@@ -63,7 +60,7 @@ func launchGui(cmd *cobra.Command, args []string) error {
 
 	csrfToken, err := util.DoGet(c, urlstr)
 	if err != nil {
-		var errMap = make(map[string]string)
+		errMap := make(map[string]string)
 		json.Unmarshal(csrfToken, &errMap) //nolint:errcheck
 		if e, found := errMap["error"]; found {
 			err = fmt.Errorf(e)

--- a/cmd/agent/app/listchecks.go
+++ b/cmd/agent/app/listchecks.go
@@ -25,12 +25,11 @@ var listCheckCommand = &cobra.Command{
 	Short: "Query the agent for the list of checks running",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		if flagNoColor {
 			color.NoColor = true
 		}
 
-		err := common.SetupConfigWithoutSecrets(confFilePath, "")
+		err := common.SetupConfigWithoutSecrets(confFilePaths, "")
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}

--- a/cmd/agent/app/reloadcheck.go
+++ b/cmd/agent/app/reloadcheck.go
@@ -7,7 +7,6 @@ package app
 
 import (
 	"fmt"
-
 	"strings"
 
 	"github.com/DataDog/datadog-agent/cmd/agent/common"
@@ -27,12 +26,11 @@ var reloadCheckCommand = &cobra.Command{
 	Short: "Reload a running check",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		if flagNoColor {
 			color.NoColor = true
 		}
 
-		err := common.SetupConfigWithoutSecrets(confFilePath, "")
+		err := common.SetupConfigWithoutSecrets(confFilePaths, "")
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -169,7 +169,7 @@ func StartAgent() error {
 	common.MainCtx, common.MainCtxCancel = context.WithCancel(context.Background())
 
 	// Global Agent configuration
-	configSetupErr = common.SetupConfig(confFilePath)
+	configSetupErr = common.SetupConfig(confFilePaths)
 
 	// Setup logger
 	if runtime.GOOS != "android" {

--- a/cmd/agent/app/secret.go
+++ b/cmd/agent/app/secret.go
@@ -28,12 +28,11 @@ var secretInfoCommand = &cobra.Command{
 	Short: "Print information about decrypted secrets in configuration.",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		if flagNoColor {
 			color.NoColor = true
 		}
 
-		err := common.SetupConfigWithoutSecrets(confFilePath, "")
+		err := common.SetupConfigWithoutSecrets(confFilePaths, "")
 		if err != nil {
 			fmt.Printf("unable to set up global agent configuration: %v\n", err)
 			return nil
@@ -68,7 +67,7 @@ func showSecretInfo() error {
 
 	r, err := util.DoGet(c, apiConfigURL)
 	if err != nil {
-		var errMap = make(map[string]string)
+		errMap := make(map[string]string)
 		json.Unmarshal(r, &errMap) //nolint:errcheck
 		// If the error has been marshalled into a json object, check it and return it properly
 		if e, found := errMap["error"]; found {

--- a/cmd/agent/app/standalone/setup.go
+++ b/cmd/agent/app/standalone/setup.go
@@ -16,7 +16,7 @@ import (
 // - config, with defaults to avoid conflicting with an agent process running in parallel
 // - logger
 // and returns the log level resolved from cliLogLevel and defaultLogLevel
-func SetupCLI(loggerName config.LoggerName, confFilePath, configName string, cliLogFile string, cliLogLevel string, defaultLogLevel string) (string, *config.Warnings, error) {
+func SetupCLI(loggerName config.LoggerName, confFilePath []string, configName string, cliLogFile string, cliLogLevel string, defaultLogLevel string) (string, *config.Warnings, error) {
 	var resolvedLogLevel string
 
 	if cliLogLevel != "" {

--- a/cmd/agent/app/status.go
+++ b/cmd/agent/app/status.go
@@ -44,7 +44,6 @@ var statusCmd = &cobra.Command{
 	Short: "Print the current status",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		if flagNoColor {
 			color.NoColor = true
 		}
@@ -52,7 +51,7 @@ var statusCmd = &cobra.Command{
 		// Prevent autoconfig to run when running status as it logs before logger is setup
 		// Cannot rely on config.Override as env detection is run before overrides are set
 		os.Setenv("DD_AUTOCONFIG_FROM_ENVIRONMENT", "false")
-		err := common.SetupConfigWithoutSecrets(confFilePath, "")
+		err := common.SetupConfigWithoutSecrets(confFilePaths, "")
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}
@@ -74,7 +73,7 @@ var componentCmd = &cobra.Command{
 	Short: "Print the component status",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		err := common.SetupConfigWithoutSecrets(confFilePath, "")
+		err := common.SetupConfigWithoutSecrets(confFilePaths, "")
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}
@@ -204,7 +203,7 @@ func makeRequest(url string) ([]byte, error) {
 
 	r, e := util.DoGet(c, url)
 	if e != nil {
-		var errMap = make(map[string]string)
+		errMap := make(map[string]string)
 		json.Unmarshal(r, &errMap) //nolint:errcheck
 		// If the error has been marshalled into a json object, check it and return it properly
 		if err, found := errMap["error"]; found {
@@ -216,5 +215,4 @@ func makeRequest(url string) ([]byte, error) {
 	}
 
 	return r, nil
-
 }

--- a/cmd/agent/app/stop.go
+++ b/cmd/agent/app/stop.go
@@ -18,14 +18,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	stopCmd = &cobra.Command{
-		Use:   "stop",
-		Short: "Stops a running Agent",
-		Long:  ``,
-		RunE:  stop,
-	}
-)
+var stopCmd = &cobra.Command{
+	Use:   "stop",
+	Short: "Stops a running Agent",
+	Long:  ``,
+	RunE:  stop,
+}
 
 func init() {
 	// attach the command to the root
@@ -34,7 +32,7 @@ func init() {
 
 func stop(*cobra.Command, []string) error {
 	// Global Agent configuration
-	err := common.SetupConfigWithoutSecrets(confFilePath, "")
+	err := common.SetupConfigWithoutSecrets(confFilePaths, "")
 	if err != nil {
 		return fmt.Errorf("unable to set up global agent configuration: %v", err)
 	}

--- a/cmd/agent/app/stream_logs.go
+++ b/cmd/agent/app/stream_logs.go
@@ -20,9 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	filters diagnostic.Filters
-)
+var filters diagnostic.Filters
 
 func init() {
 	AgentCmd.AddCommand(troubleshootLogsCmd)
@@ -36,12 +34,11 @@ var troubleshootLogsCmd = &cobra.Command{
 	Short: "Stream the logs being processed by a running agent",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		if flagNoColor {
 			color.NoColor = true
 		}
 
-		err := common.SetupConfigWithoutSecrets(confFilePath, "")
+		err := common.SetupConfigWithoutSecrets(confFilePaths, "")
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}
@@ -63,7 +60,6 @@ func connectAndStream() error {
 	}
 
 	body, err := json.Marshal(&filters)
-
 	if err != nil {
 		return err
 	}

--- a/cmd/agent/app/tagger_list.go
+++ b/cmd/agent/app/tagger_list.go
@@ -30,12 +30,11 @@ var taggerListCommand = &cobra.Command{
 	Short: "Print the tagger content of a running agent",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		if flagNoColor {
 			color.NoColor = true
 		}
 
-		err := common.SetupConfigWithoutSecrets(confFilePath, "")
+		err := common.SetupConfigWithoutSecrets(confFilePaths, "")
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}

--- a/cmd/agent/app/workload_list.go
+++ b/cmd/agent/app/workload_list.go
@@ -30,12 +30,11 @@ var workloadListCommand = &cobra.Command{
 	Short: "Print the workload content of a running agent",
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
-
 		if flagNoColor {
 			color.NoColor = true
 		}
 
-		err := common.SetupConfigWithoutSecrets(confFilePath, "")
+		err := common.SetupConfigWithoutSecrets(confFilePaths, "")
 		if err != nil {
 			return fmt.Errorf("unable to set up global agent configuration: %v", err)
 		}

--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -101,7 +101,7 @@ func setupCmd(cmd *cobra.Command) {
 }
 
 // Check returns a cobra command to run checks
-func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool) *cobra.Command {
+func Check(loggerName config.LoggerName, confFilePaths []string, flagNoColor *bool) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "check <check_name>",
 		Short: "Run the specified check",
@@ -112,7 +112,7 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 				// we'll search for a config file named `datadog-cluster.yaml`
 				configName = "datadog-cluster"
 			}
-			resolvedLogLevel, warnings, err := standalone.SetupCLI(loggerName, *confFilePath, configName, "", logLevel, "off")
+			resolvedLogLevel, warnings, err := standalone.SetupCLI(loggerName, confFilePaths, configName, "", logLevel, "off")
 			if err != nil {
 				fmt.Printf("Cannot initialize command: %v\n", err)
 				return err

--- a/cmd/agent/common/commands/health.go
+++ b/cmd/agent/common/commands/health.go
@@ -22,14 +22,13 @@ import (
 )
 
 // Health returns a cobra command to report on the agent's health
-func Health(loggerName config.LoggerName, confPath *string, flagNoColor *bool) *cobra.Command {
+func Health(loggerName config.LoggerName, confPaths []string, flagNoColor *bool) *cobra.Command {
 	return &cobra.Command{
 		Use:          "health",
 		Short:        "Print the current agent health",
 		Long:         ``,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			if *flagNoColor {
 				color.NoColor = true
 			}
@@ -40,7 +39,7 @@ func Health(loggerName config.LoggerName, confPath *string, flagNoColor *bool) *
 
 			// Set up config without secrets so that running the health command (e.g. from container
 			// liveness probe script) does not trigger a secret backend command call.
-			err := common.SetupConfigWithoutSecrets(*confPath, "")
+			err := common.SetupConfigWithoutSecrets(confPaths, "")
 			if err != nil {
 				return fmt.Errorf("unable to set up global agent configuration: %v", err)
 			}
@@ -55,6 +54,7 @@ func Health(loggerName config.LoggerName, confPath *string, flagNoColor *bool) *
 		},
 	}
 }
+
 func requestHealth() error {
 	c := util.GetClient(false) // FIX: get certificates right then make this true
 
@@ -78,7 +78,7 @@ func requestHealth() error {
 
 	r, err := util.DoGet(c, urlstr)
 	if err != nil {
-		var errMap = make(map[string]string)
+		errMap := make(map[string]string)
 		json.Unmarshal(r, &errMap) //nolint:errcheck
 		// If the error has been marshalled into a json object, check it and return it properly
 		if e, found := errMap["error"]; found {

--- a/cmd/agent/common/import.go
+++ b/cmd/agent/common/import.go
@@ -53,8 +53,7 @@ func ImportConfig(oldConfigDir string, newConfigDir string, force bool) error {
 	}
 
 	// setup the configuration system
-	config.Datadog.AddConfigPath(newConfigDir)
-	_, err = config.Load()
+	_, err = config.Load("datadog", []string{newConfigDir}, true)
 	if err != nil {
 		return fmt.Errorf("unable to load Datadog config file: %s", err)
 	}

--- a/cmd/system-probe/config/config.go
+++ b/cmd/system-probe/config/config.go
@@ -85,7 +85,7 @@ func New(configPath string) (*Config, error) {
 	}
 	aconfig.Datadog.AddConfigPath(defaultConfigDir)
 
-	_, err := aconfig.LoadWithoutSecret()
+	_, err := aconfig.LoadWithoutSecret("system-probe", []string{configPath}, true)
 	var e viper.ConfigFileNotFoundError
 	if err != nil {
 		if errors.As(err, &e) || errors.Is(err, os.ErrNotExist) {

--- a/pkg/config/tests/datadog_first.yaml
+++ b/pkg/config/tests/datadog_first.yaml
@@ -1,0 +1,7 @@
+api_key: apikey1
+auto_exit:
+  noprocess:
+    enabled: true
+    excluded_processes: ["foo", "bar", "baz"]
+health_port: 1
+check_runners: 5

--- a/pkg/config/tests/datadog_second.yaml
+++ b/pkg/config/tests/datadog_second.yaml
@@ -1,0 +1,5 @@
+api_key: apikey2
+auto_exit:
+  noprocess:
+    enabled: false
+    excluded_processes: ["1", "2"]

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -56,6 +56,7 @@ type Config interface {
 	UnmarshalExact(rawVal interface{}) error
 
 	ReadInConfig() error
+	MergeInConfig() error
 	ReadConfig(in io.Reader) error
 	MergeConfig(in io.Reader) error
 	MergeConfigOverride(in io.Reader) error

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -333,6 +333,13 @@ func (c *safeConfig) UnmarshalExact(rawVal interface{}) error {
 }
 
 // ReadInConfig wraps Viper for concurrent access
+func (c *safeConfig) MergeInConfig() error {
+	c.Lock()
+	defer c.Unlock()
+	return c.Viper.MergeInConfig()
+}
+
+// ReadInConfig wraps Viper for concurrent access
 func (c *safeConfig) ReadInConfig() error {
 	c.Lock()
 	defer c.Unlock()


### PR DESCRIPTION
### What does this PR do?

The command line is modified to accept multiple --cfgpath parameters.
The configurations are merged, in order, from left to right (ritghmost file has highest priority).
All files still have less priority than environment variables.

### Motivation

Allow proper override between default/generated configuration and user provided configuration.

### Additional Notes

### Possible Drawbacks / Trade-offs

Loosing the ability to use any other file format than YAML (a PR to our fork could enable it again).

### Describe how to test/QA your changes

Nothing should change when using a single configuration file (default setup).
When multiple files are given on the command line, the resulting `agent config` should show the rightmost values for overridden fields.
Setting a value through ENV Var should always override any value from file.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
