### PR TITLE
[CWS] fix runtime compiled constants config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -971,7 +971,7 @@ func InitConfig(config Config) {
 	bindEnvAndSetLogsConfigKeys(config, "runtime_security_config.endpoints.")
 	config.BindEnvAndSetDefault("runtime_security_config.self_test.enabled", true)
 	config.BindEnvAndSetDefault("runtime_security_config.enable_remote_configuration", false)
-	config.BindEnvAndSetDefault("runtime_security_config.enable_runtime_compiled_constants", false)
+	config.BindEnv("runtime_security_config.enable_runtime_compiled_constants")
 
 	// Serverless Agent
 	config.BindEnvAndSetDefault("serverless.logs_enabled", true)

--- a/pkg/security/module/module.go
+++ b/pkg/security/module/module.go
@@ -96,11 +96,6 @@ func (m *Module) sanityChecks() error {
 		m.config.ERPCDentryResolutionEnabled = false
 	}
 
-	// enable runtime compiled constants on COS by default
-	if !m.config.RuntimeCompiledConstantsIsSet && version.IsCOSKernel() {
-		m.config.EnableRuntimeCompiledConstants = true
-	}
-
 	return nil
 }
 

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -907,6 +907,8 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 		log.Warnf("the current kernel isn't officially supported, some features might not work properly: %v", err)
 	}
 
+	p.sanityChecks()
+
 	numCPU, err := utils.NumCPU()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to parse CPU count")
@@ -1041,6 +1043,13 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 	eventZero.scrubber = p.scrubber
 
 	return p, nil
+}
+
+func (p *Probe) sanityChecks() {
+	// enable runtime compiled constants on COS by default
+	if !p.config.RuntimeCompiledConstantsIsSet && p.kernelVersion.IsCOSKernel() {
+		p.config.EnableRuntimeCompiledConstants = true
+	}
 }
 
 // GetOffsetConstants returns the offsets and struct sizes constants

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -907,7 +907,7 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 		log.Warnf("the current kernel isn't officially supported, some features might not work properly: %v", err)
 	}
 
-	p.sanityChecks()
+	p.ensureConfigDefaults()
 
 	numCPU, err := utils.NumCPU()
 	if err != nil {
@@ -1045,7 +1045,7 @@ func NewProbe(config *config.Config, client *statsd.Client) (*Probe, error) {
 	return p, nil
 }
 
-func (p *Probe) sanityChecks() {
+func (p *Probe) ensureConfigDefaults() {
 	// enable runtime compiled constants on COS by default
 	if !p.config.RuntimeCompiledConstantsIsSet && p.kernelVersion.IsCOSKernel() {
 		p.config.EnableRuntimeCompiledConstants = true


### PR DESCRIPTION
### What does this PR do?

For the following reasons, the runtime compilation based constant fetcher was not used on COS, where it should be the default.
- When using `SetDefault`, `IsSet` is always true. This "feature" was misunderstood.
- The COS default check was done after the constants were fetched.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
