### PR TITLE
[pkg/flare] Improve `zipFile` signature

### DIFF
--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -607,8 +607,10 @@ func zipDiagnose(tempDir, hostname string) error {
 	return writeScrubbedFile(f, b.Bytes())
 }
 
-func zipFile(originalPath, zippedPath string) error {
-	original, err := os.Open(originalPath)
+func zipFile(sourceDir, targetDir, fileBasename string) error {
+	original, err := os.Open(filepath.Join(sourceDir, fileBasename))
+	zippedPath := filepath.Join(targetDir, fileBasename)
+
 	if err != nil {
 		return err
 	}
@@ -645,15 +647,15 @@ func zipFile(originalPath, zippedPath string) error {
 }
 
 func zipRegistryJSON(tempDir, hostname string) error {
-	originalPath := filepath.Join(config.Datadog.GetString("logs_config.run_path"), "registry.json")
-	zippedPath := filepath.Join(tempDir, hostname, "registry.json")
-	return zipFile(originalPath, zippedPath)
+	originalPath := filepath.Join(config.Datadog.GetString("logs_config.run_path"))
+	zippedPath := filepath.Join(tempDir, hostname)
+	return zipFile(originalPath, zippedPath, "registry.json")
 }
 
 func zipVersionHistory(tempDir, hostname string) error {
-	originalPath := filepath.Join(config.Datadog.GetString("run_path"), "version-history.json")
-	zippedPath := filepath.Join(tempDir, hostname, "version-history.json")
-	return zipFile(originalPath, zippedPath)
+	originalPath := filepath.Join(config.Datadog.GetString("run_path"))
+	zippedPath := filepath.Join(tempDir, hostname)
+	return zipFile(originalPath, zippedPath, "version-history.json")
 }
 
 func zipConfigCheck(tempDir, hostname string) error {
@@ -697,6 +699,7 @@ func zipTaggerList(tempDir, hostname string) error {
 	}
 
 	f := filepath.Join(tempDir, hostname, "tagger-list.json")
+
 	err = ensureParentDirsExist(f)
 	if err != nil {
 		return err
@@ -774,9 +777,9 @@ func zipHealth(tempDir, hostname string) error {
 }
 
 func zipInstallInfo(tempDir, hostname string) error {
-	originalPath := filepath.Join(config.FileUsedDir(), "install_info")
-	zippedPath := filepath.Join(tempDir, hostname, "install_info")
-	return zipFile(originalPath, zippedPath)
+	originalPath := filepath.Join(config.FileUsedDir())
+	zippedPath := filepath.Join(tempDir, hostname)
+	return zipFile(originalPath, zippedPath, "install_info")
 }
 
 func zipTelemetry(tempDir, hostname string) error {

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -647,13 +647,13 @@ func zipFile(sourceDir, targetDir, filename string) error {
 }
 
 func zipRegistryJSON(tempDir, hostname string) error {
-	originalPath := filepath.Join(config.Datadog.GetString("logs_config.run_path"))
+	originalPath := config.Datadog.GetString("logs_config.run_path")
 	targetPath := filepath.Join(tempDir, hostname)
 	return zipFile(originalPath, targetPath, "registry.json")
 }
 
 func zipVersionHistory(tempDir, hostname string) error {
-	originalPath := filepath.Join(config.Datadog.GetString("run_path"))
+	originalPath := config.Datadog.GetString("run_path")
 	targetPath := filepath.Join(tempDir, hostname)
 	return zipFile(originalPath, targetPath, "version-history.json")
 }
@@ -777,9 +777,8 @@ func zipHealth(tempDir, hostname string) error {
 }
 
 func zipInstallInfo(tempDir, hostname string) error {
-	originalPath := filepath.Join(config.FileUsedDir())
 	targetPath := filepath.Join(tempDir, hostname)
-	return zipFile(originalPath, targetPath, "install_info")
+	return zipFile(config.FileUsedDir(), targetPath, "install_info")
 }
 
 func zipTelemetry(tempDir, hostname string) error {

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -607,21 +607,21 @@ func zipDiagnose(tempDir, hostname string) error {
 	return writeScrubbedFile(f, b.Bytes())
 }
 
-func zipFile(sourceDir, targetDir, fileBasename string) error {
-	original, err := os.Open(filepath.Join(sourceDir, fileBasename))
-	zippedPath := filepath.Join(targetDir, fileBasename)
+func zipFile(sourceDir, targetDir, filename string) error {
+	original, err := os.Open(filepath.Join(sourceDir, filename))
+	targetPath := filepath.Join(targetDir, filename)
 
 	if err != nil {
 		return err
 	}
 	defer original.Close()
 
-	err = ensureParentDirsExist(zippedPath)
+	err = ensureParentDirsExist(targetPath)
 	if err != nil {
 		return err
 	}
 
-	zipped, err := os.OpenFile(zippedPath, os.O_RDWR|os.O_CREATE, os.ModePerm)
+	zipped, err := os.OpenFile(targetPath, os.O_RDWR|os.O_CREATE, os.ModePerm)
 	if err != nil {
 		return err
 	}
@@ -648,14 +648,14 @@ func zipFile(sourceDir, targetDir, fileBasename string) error {
 
 func zipRegistryJSON(tempDir, hostname string) error {
 	originalPath := filepath.Join(config.Datadog.GetString("logs_config.run_path"))
-	zippedPath := filepath.Join(tempDir, hostname)
-	return zipFile(originalPath, zippedPath, "registry.json")
+	targetPath := filepath.Join(tempDir, hostname)
+	return zipFile(originalPath, targetPath, "registry.json")
 }
 
 func zipVersionHistory(tempDir, hostname string) error {
 	originalPath := filepath.Join(config.Datadog.GetString("run_path"))
-	zippedPath := filepath.Join(tempDir, hostname)
-	return zipFile(originalPath, zippedPath, "version-history.json")
+	targetPath := filepath.Join(tempDir, hostname)
+	return zipFile(originalPath, targetPath, "version-history.json")
 }
 
 func zipConfigCheck(tempDir, hostname string) error {
@@ -778,8 +778,8 @@ func zipHealth(tempDir, hostname string) error {
 
 func zipInstallInfo(tempDir, hostname string) error {
 	originalPath := filepath.Join(config.FileUsedDir())
-	zippedPath := filepath.Join(tempDir, hostname)
-	return zipFile(originalPath, zippedPath, "install_info")
+	targetPath := filepath.Join(tempDir, hostname)
+	return zipFile(originalPath, targetPath, "install_info")
 }
 
 func zipTelemetry(tempDir, hostname string) error {

--- a/pkg/flare/archive_linux.go
+++ b/pkg/flare/archive_linux.go
@@ -12,26 +12,26 @@ import (
 	"path/filepath"
 )
 
-func zipLinuxFunctions(source, tempDir, hostname, filename string) error {
+func zipLinuxFile(source, tempDir, hostname, filename string) error {
 	return zipFile(source, filepath.Join(tempDir, hostname), filename)
 }
 
 func zipLinuxKernelSymbols(tempDir, hostname string) error {
-	return zipLinuxFunctions("/proc", filepath.Join(tempDir, hostname), "kallsyms")
+	return zipLinuxFile("/proc", tempDir, hostname, "kallsyms")
 }
 
 func zipLinuxKrobeEvents(tempDir, hostname string) error {
-	return zipLinuxFunctions("/sys/kernel/debug/tracing", filepath.Join(tempDir, hostname), "kprobe_events")
+	return zipLinuxFile("/sys/kernel/debug/tracing", tempDir, hostname, "kprobe_events")
 }
 
 func zipLinuxPid1MountInfo(tempDir, hostname string) error {
-	return zipLinuxFunctions("/proc/1", filepath.Join(tempDir, hostname), "mountinfo")
+	return zipLinuxFile("/proc/1", tempDir, hostname, "mountinfo")
 }
 
 func zipLinuxTracingAvailableEvents(tempDir, hostname string) error {
-	return zipLinuxFunctions("/sys/kernel/debug/tracing", filepath.Join(tempDir, hostname), "available_events")
+	return zipLinuxFile("/sys/kernel/debug/tracing", tempDir, hostname, "available_events")
 }
 
 func zipLinuxTracingAvailableFilterFunctions(tempDir, hostname string) error {
-	return zipLinuxFunctions("/sys/kernel/debug/tracing", filepath.Join(tempDir, hostname), "available_filter_functions")
+	return zipLinuxFile("/sys/kernel/debug/tracing", tempDir, hostname, "available_filter_functions")
 }

--- a/pkg/flare/archive_linux.go
+++ b/pkg/flare/archive_linux.go
@@ -12,22 +12,26 @@ import (
 	"path/filepath"
 )
 
+func zipLinuxFunctions(source, tempDir, hostname, filename string) error {
+	return zipFile(source, filepath.Join(tempDir, hostname), filename)
+}
+
 func zipLinuxKernelSymbols(tempDir, hostname string) error {
-	return zipFile("/proc/kallsyms", filepath.Join(tempDir, hostname, "kallsyms"))
+	return zipLinuxFunctions("/proc", filepath.Join(tempDir, hostname), "kallsyms")
 }
 
 func zipLinuxKrobeEvents(tempDir, hostname string) error {
-	return zipFile("/sys/kernel/debug/tracing/kprobe_events", filepath.Join(tempDir, hostname, "kprobe_events"))
+	return zipLinuxFunctions("/sys/kernel/debug/tracing", filepath.Join(tempDir, hostname), "kprobe_events")
 }
 
 func zipLinuxPid1MountInfo(tempDir, hostname string) error {
-	return zipFile("/proc/1/mountinfo", filepath.Join(tempDir, hostname, "mountinfo"))
+	return zipLinuxFunctions("/proc/1", filepath.Join(tempDir, hostname), "mountinfo")
 }
 
 func zipLinuxTracingAvailableEvents(tempDir, hostname string) error {
-	return zipFile("/sys/kernel/debug/tracing/available_events", filepath.Join(tempDir, hostname, "available_events"))
+	return zipLinuxFunctions("/sys/kernel/debug/tracing", filepath.Join(tempDir, hostname), "available_events")
 }
 
 func zipLinuxTracingAvailableFilterFunctions(tempDir, hostname string) error {
-	return zipFile("/sys/kernel/debug/tracing/available_filter_functions", filepath.Join(tempDir, hostname, "available_filter_functions"))
+	return zipLinuxFunctions("/sys/kernel/debug/tracing", filepath.Join(tempDir, hostname), "available_filter_functions")
 }

--- a/pkg/flare/archive_linux_test.go
+++ b/pkg/flare/archive_linux_test.go
@@ -17,186 +17,30 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestZipLinuxKernelSymbols(t *testing.T) {
-	srcDir, err := ioutil.TempDir("", "run")
+func TestZipLinuxFileWrapper(t *testing.T) {
+	srcDir, err := ioutil.TempDir("", "ZipLinuxFileSource")
 	require.NoError(t, err)
 	defer os.RemoveAll(srcDir)
-	dstDir, err := ioutil.TempDir("", "TestZipLinuxKernelSymbols")
+
+	dstDir, err := ioutil.TempDir("", "ZipLinuxFileTarget")
 	require.NoError(t, err)
 	defer os.RemoveAll(dstDir)
 
-	// create non-empty kallsyms file
-	file, err := os.Create(filepath.Join(srcDir, "kallsyms"))
+	file, err := os.Create(filepath.Join(srcDir, "testfile.txt"))
 	require.NoError(t, err)
-	_, err = file.WriteString("0000000000000000 A irq_stack_union")
+
+	expectedContent := "expected content"
+	_, err = file.WriteString(expectedContent)
 	require.NoError(t, err)
+
 	err = file.Close()
 	require.NoError(t, err)
 
-	err = zipLinuxKernelSymbols(dstDir, "test")
+	err = zipLinuxFile(srcDir, dstDir, "hostname", "testfile.txt")
 	require.NoError(t, err)
 
-	// Check all the log files are in the destination path, at the right subdirectories
-	stat, err := os.Stat(filepath.Join(dstDir, "test", "kallsyms"))
+	targetPath := filepath.Join(dstDir, "hostname", "testfile.txt")
+	actualContent, err := ioutil.ReadFile(targetPath)
 	require.NoError(t, err)
-	require.Greater(t, stat.Size(), int64(0))
+	require.Equal(t, expectedContent, string(actualContent))
 }
-
-func TestZipLinuxKrobeEvents(t *testing.T) {
-	srcDir, err := ioutil.TempDir("", "run")
-	require.NoError(t, err)
-	defer os.RemoveAll(srcDir)
-	dstDir, err := ioutil.TempDir("", "TestZipLinuxKrobeEvents")
-	require.NoError(t, err)
-	defer os.RemoveAll(dstDir)
-
-	// create non-empty kprobe_events file
-	file, err := os.Create(filepath.Join(srcDir, "kprobe_events"))
-	require.NoError(t, err)
-	_, err = file.WriteString("0000000000000000 A irq_stack_union")
-	require.NoError(t, err)
-	err = file.Close()
-	require.NoError(t, err)
-
-	err = zipLinuxKrobeEvents(dstDir, "test")
-	require.NoError(t, err)
-
-	// Check all the log files are in the destination path, at the right subdirectories
-	stat, err := os.Stat(filepath.Join(dstDir, "test", "kprobe_events"))
-	require.NoError(t, err)
-	require.Greater(t, stat.Size(), int64(0))
-}
-
-func TestZipLinuxPid1MountInfo(t *testing.T) {
-	srcDir, err := ioutil.TempDir("", "run")
-	require.NoError(t, err)
-	defer os.RemoveAll(srcDir)
-	dstDir, err := ioutil.TempDir("", "TestZipLinuxPid1MountInfo")
-	require.NoError(t, err)
-	defer os.RemoveAll(dstDir)
-
-	// create non-empty mountinfo file
-	file, err := os.Create(filepath.Join(srcDir, "mountinfo"))
-	require.NoError(t, err)
-	_, err = file.WriteString("1910 1286 0:322")
-	require.NoError(t, err)
-	err = file.Close()
-	require.NoError(t, err)
-
-	err = zipLinuxPid1MountInfo(dstDir, "test")
-	require.NoError(t, err)
-
-	// Check all the log files are in the destination path, at the right subdirectories
-	stat, err := os.Stat(filepath.Join(dstDir, "test", "mountinfo"))
-	require.NoError(t, err)
-	require.Greater(t, stat.Size(), int64(0))
-}
-
-func TestZipLinuxTracingAvailableEvents(t *testing.T) {
-	srcDir, err := ioutil.TempDir("", "run")
-	require.NoError(t, err)
-	defer os.RemoveAll(srcDir)
-	dstDir, err := ioutil.TempDir("", "TestZipLinuxTracingAvailableEvents")
-	require.NoError(t, err)
-	defer os.RemoveAll(dstDir)
-
-	// create non-empty available_events file
-	file, err := os.Create(filepath.Join(srcDir, "available_events"))
-	require.NoError(t, err)
-	_, err = file.WriteString("0000000000000000 A irq_stack_union")
-	require.NoError(t, err)
-	err = file.Close()
-	require.NoError(t, err)
-
-	err = zipLinuxTracingAvailableEvents(dstDir, "test")
-	require.NoError(t, err)
-
-	// Check all the log files are in the destination path, at the right subdirectories
-	stat, err := os.Stat(filepath.Join(dstDir, "test", "available_events"))
-	require.NoError(t, err)
-	require.Greater(t, stat.Size(), int64(0))
-}
-
-func TestZipLinuxTracingAvailableFilterFunctions(t *testing.T) {
-	srcDir, err := ioutil.TempDir("", "run")
-	require.NoError(t, err)
-	defer os.RemoveAll(srcDir)
-	dstDir, err := ioutil.TempDir("", "TestZipLinuxTracingAvailableFilterFunctions")
-	require.NoError(t, err)
-	defer os.RemoveAll(dstDir)
-
-	// create non-empty available_filter_functions file
-	file, err := os.Create(filepath.Join(srcDir, "available_filter_functions"))
-	require.NoError(t, err)
-	_, err = file.WriteString("0000000000000000 A irq_stack_union")
-	require.NoError(t, err)
-	err = file.Close()
-	require.NoError(t, err)
-
-	err = zipLinuxTracingAvailableFilterFunctions(dstDir, "test")
-	require.NoError(t, err)
-
-	// Check all the log files are in the destination path, at the right subdirectories
-	stat, err := os.Stat(filepath.Join(dstDir, "test", "available_filter_functions"))
-	require.NoError(t, err)
-	require.Greater(t, stat.Size(), int64(0))
-}
-
-// func TestZipLinuxFiles(t *testing.T) {
-// 	assert := assert.New(t)
-
-// 	tests := []struct {
-// 		name string
-// 		file string
-// 		test func
-// 	}{
-// 		{
-// 			name: "TestZipLinuxKernelSymbols",
-// 			file: "kallsyms",
-// 			test:
-// 		},
-// 		{
-// 			name: "TestZipLinuxKrobeEvents",
-// 			file: "kprobe_events",
-// 		},
-// 		{
-// 			name: "TestZipLinuxPid1MountInfo",
-// 			file: "mountinfo",
-// 		},
-// 		{
-// 			name: "TestZipLinuxTracingAvailableEvents",
-// 			file: "available_events",
-// 		},
-// 		{
-// 			name: "TestZipLinuxTracingAvailableFilterFunctions",
-// 			file: "available_filter_functions",
-// 		},
-// 	}
-
-// 	for _, test := range tests {
-// 		t.Run(test.name, func(t *testing.T) {
-// 			srcDir, err := ioutil.TempDir("", "run")
-// 			require.NoError(t, err)
-// 			defer os.RemoveAll(srcDir)
-// 			dstDir, err := ioutil.TempDir("", name)
-// 			require.NoError(t, err)
-// 			defer os.RemoveAll(dstDir)
-
-// 			// create non-empty test file
-// 			file, err := os.Create(filepath.Join(srcDir, file))
-// 			require.NoError(t, err)
-// 			_, err = file.WriteString("0000000000000000 A irq_stack_union")
-// 			require.NoError(t, err)
-// 			err = file.Close()
-// 			require.NoError(t, err)
-
-// 			err = zipLinuxTracingAvailableFilterFunctions(srcDir, dstDir, "test", file)
-// 			require.NoError(t, err)
-
-// 			// Check all the log files are in the destination path, at the right subdirectories
-// 			stat, err := os.Stat(filepath.Join(dstDir, "test", file))
-// 			require.NoError(t, err)
-// 			require.Greater(t, stat.Size(), int64(0))
-// 		})
-// 	}
-// }

--- a/pkg/flare/archive_linux_test.go
+++ b/pkg/flare/archive_linux_test.go
@@ -1,0 +1,202 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package flare
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestZipLinuxKernelSymbols(t *testing.T) {
+	srcDir, err := ioutil.TempDir("", "run")
+	require.NoError(t, err)
+	defer os.RemoveAll(srcDir)
+	dstDir, err := ioutil.TempDir("", "TestZipLinuxKernelSymbols")
+	require.NoError(t, err)
+	defer os.RemoveAll(dstDir)
+
+	// create non-empty kallsyms file
+	file, err := os.Create(filepath.Join(srcDir, "kallsyms"))
+	require.NoError(t, err)
+	_, err = file.WriteString("0000000000000000 A irq_stack_union")
+	require.NoError(t, err)
+	err = file.Close()
+	require.NoError(t, err)
+
+	err = zipLinuxKernelSymbols(dstDir, "test")
+	require.NoError(t, err)
+
+	// Check all the log files are in the destination path, at the right subdirectories
+	stat, err := os.Stat(filepath.Join(dstDir, "test", "kallsyms"))
+	require.NoError(t, err)
+	require.Greater(t, stat.Size(), int64(0))
+}
+
+func TestZipLinuxKrobeEvents(t *testing.T) {
+	srcDir, err := ioutil.TempDir("", "run")
+	require.NoError(t, err)
+	defer os.RemoveAll(srcDir)
+	dstDir, err := ioutil.TempDir("", "TestZipLinuxKrobeEvents")
+	require.NoError(t, err)
+	defer os.RemoveAll(dstDir)
+
+	// create non-empty kprobe_events file
+	file, err := os.Create(filepath.Join(srcDir, "kprobe_events"))
+	require.NoError(t, err)
+	_, err = file.WriteString("0000000000000000 A irq_stack_union")
+	require.NoError(t, err)
+	err = file.Close()
+	require.NoError(t, err)
+
+	err = zipLinuxKrobeEvents(dstDir, "test")
+	require.NoError(t, err)
+
+	// Check all the log files are in the destination path, at the right subdirectories
+	stat, err := os.Stat(filepath.Join(dstDir, "test", "kprobe_events"))
+	require.NoError(t, err)
+	require.Greater(t, stat.Size(), int64(0))
+}
+
+func TestZipLinuxPid1MountInfo(t *testing.T) {
+	srcDir, err := ioutil.TempDir("", "run")
+	require.NoError(t, err)
+	defer os.RemoveAll(srcDir)
+	dstDir, err := ioutil.TempDir("", "TestZipLinuxPid1MountInfo")
+	require.NoError(t, err)
+	defer os.RemoveAll(dstDir)
+
+	// create non-empty mountinfo file
+	file, err := os.Create(filepath.Join(srcDir, "mountinfo"))
+	require.NoError(t, err)
+	_, err = file.WriteString("1910 1286 0:322")
+	require.NoError(t, err)
+	err = file.Close()
+	require.NoError(t, err)
+
+	err = zipLinuxPid1MountInfo(dstDir, "test")
+	require.NoError(t, err)
+
+	// Check all the log files are in the destination path, at the right subdirectories
+	stat, err := os.Stat(filepath.Join(dstDir, "test", "mountinfo"))
+	require.NoError(t, err)
+	require.Greater(t, stat.Size(), int64(0))
+}
+
+func TestZipLinuxTracingAvailableEvents(t *testing.T) {
+	srcDir, err := ioutil.TempDir("", "run")
+	require.NoError(t, err)
+	defer os.RemoveAll(srcDir)
+	dstDir, err := ioutil.TempDir("", "TestZipLinuxTracingAvailableEvents")
+	require.NoError(t, err)
+	defer os.RemoveAll(dstDir)
+
+	// create non-empty available_events file
+	file, err := os.Create(filepath.Join(srcDir, "available_events"))
+	require.NoError(t, err)
+	_, err = file.WriteString("0000000000000000 A irq_stack_union")
+	require.NoError(t, err)
+	err = file.Close()
+	require.NoError(t, err)
+
+	err = zipLinuxTracingAvailableEvents(dstDir, "test")
+	require.NoError(t, err)
+
+	// Check all the log files are in the destination path, at the right subdirectories
+	stat, err := os.Stat(filepath.Join(dstDir, "test", "available_events"))
+	require.NoError(t, err)
+	require.Greater(t, stat.Size(), int64(0))
+}
+
+func TestZipLinuxTracingAvailableFilterFunctions(t *testing.T) {
+	srcDir, err := ioutil.TempDir("", "run")
+	require.NoError(t, err)
+	defer os.RemoveAll(srcDir)
+	dstDir, err := ioutil.TempDir("", "TestZipLinuxTracingAvailableFilterFunctions")
+	require.NoError(t, err)
+	defer os.RemoveAll(dstDir)
+
+	// create non-empty available_filter_functions file
+	file, err := os.Create(filepath.Join(srcDir, "available_filter_functions"))
+	require.NoError(t, err)
+	_, err = file.WriteString("0000000000000000 A irq_stack_union")
+	require.NoError(t, err)
+	err = file.Close()
+	require.NoError(t, err)
+
+	err = zipLinuxTracingAvailableFilterFunctions(dstDir, "test")
+	require.NoError(t, err)
+
+	// Check all the log files are in the destination path, at the right subdirectories
+	stat, err := os.Stat(filepath.Join(dstDir, "test", "available_filter_functions"))
+	require.NoError(t, err)
+	require.Greater(t, stat.Size(), int64(0))
+}
+
+// func TestZipLinuxFiles(t *testing.T) {
+// 	assert := assert.New(t)
+
+// 	tests := []struct {
+// 		name string
+// 		file string
+// 		test func
+// 	}{
+// 		{
+// 			name: "TestZipLinuxKernelSymbols",
+// 			file: "kallsyms",
+// 			test:
+// 		},
+// 		{
+// 			name: "TestZipLinuxKrobeEvents",
+// 			file: "kprobe_events",
+// 		},
+// 		{
+// 			name: "TestZipLinuxPid1MountInfo",
+// 			file: "mountinfo",
+// 		},
+// 		{
+// 			name: "TestZipLinuxTracingAvailableEvents",
+// 			file: "available_events",
+// 		},
+// 		{
+// 			name: "TestZipLinuxTracingAvailableFilterFunctions",
+// 			file: "available_filter_functions",
+// 		},
+// 	}
+
+// 	for _, test := range tests {
+// 		t.Run(test.name, func(t *testing.T) {
+// 			srcDir, err := ioutil.TempDir("", "run")
+// 			require.NoError(t, err)
+// 			defer os.RemoveAll(srcDir)
+// 			dstDir, err := ioutil.TempDir("", name)
+// 			require.NoError(t, err)
+// 			defer os.RemoveAll(dstDir)
+
+// 			// create non-empty test file
+// 			file, err := os.Create(filepath.Join(srcDir, file))
+// 			require.NoError(t, err)
+// 			_, err = file.WriteString("0000000000000000 A irq_stack_union")
+// 			require.NoError(t, err)
+// 			err = file.Close()
+// 			require.NoError(t, err)
+
+// 			err = zipLinuxTracingAvailableFilterFunctions(srcDir, dstDir, "test", file)
+// 			require.NoError(t, err)
+
+// 			// Check all the log files are in the destination path, at the right subdirectories
+// 			stat, err := os.Stat(filepath.Join(dstDir, "test", file))
+// 			require.NoError(t, err)
+// 			require.Greater(t, stat.Size(), int64(0))
+// 		})
+// 	}
+// }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

- Change zipFile signature to not require basename duplication
- Add tests for changed functions

### Motivation

- By ensuring that the source and destination files have the same basename we will reduce the chance that the programmer calling this function will make errors

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

none

### Describe how to test/QA your changes

- On linux generate a flare with the agent and ensure that `registry.json` and `version-history.json` have content
- On linux generate a flare with the security-agent and ensure that `kallsyms`, `kprobe_events`, `mountinfo`, `available_events`, & `available_filter_functions` files have content (note that `kprobe_events` may be empty)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
