### PR TITLE
Fix snyk

### DIFF
--- a/.gitlab/source_test/security_scan.yml
+++ b/.gitlab/source_test/security_scan.yml
@@ -17,6 +17,4 @@ security_scan_test:
     - set +x     # don't print the api key to the logs
     # send the list of the dependencies to snyk
     - SNYK_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.snyk_token --with-decryption --query "Parameter.Value" --out text)
-      snyk monitor --command=python3 --project-name=datadog-agent-requirements.txt --file=requirements.txt --package-manager=pip
-    - SNYK_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.snyk_token --with-decryption --query "Parameter.Value" --out text)
       snyk monitor --project-name=datadog-agent-go.sum --file=go.mod

--- a/.gitlab/source_test/security_scan.yml
+++ b/.gitlab/source_test/security_scan.yml
@@ -14,7 +14,7 @@ security_scan_test:
     - cd $GOPATH/src/github.com/DataDog/datadog-agent
     - python3 -m pip install -r requirements.txt
   script:
-    - set +x     # don't print the api key to the logs
-    # send the list of the dependencies to snyk
-    - SNYK_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.snyk_token --with-decryption --query "Parameter.Value" --out text)
-      snyk monitor --project-name=datadog-agent-go.sum --file=go.mod
+    - set +x # don't print the api key to the logs
+    - export SNYK_TOKEN=$(aws ssm get-parameter --region us-east-1 --name ci.datadog-agent.snyk_token --with-decryption --query "Parameter.Value" --out text)
+    - set -x
+    - find . -name go.mod -not -path './test/*' -not -path './internal/tools/modparser/testdata/*' -exec snyk test --severity-threshold=medium --file={} \;


### PR DESCRIPTION
### What does this PR do?

- Change from `snyk monitor` to `snyk test`. According to the [docs](https://support.snyk.io/hc/en-us/articles/360000920818-What-is-the-difference-between-snyk-test-protect-and-monitor-) `monitor` only needs to be called once since it "registers" a project with snyk so they check for vulnerabilities automatically on their backend.
- Call `snyk` also for go.mod from submodules
- Do not check requirements.txt with snyk, since it seems it doesn't like the indirection we added in #10732

### Motivation

Fix snyk failing.

### Additional Notes

Because of how we call snyk now (using `find -exec`) it won't fail the build if vulnerabilities are found (because `find` returns 0 even when the executed command fails). This is not a regression since `snyk monitor` didn't fail if there were vulnerabilities, but it kind of defeats the point of running a vulnerability scanner.

### Describe how to test/QA your changes

Tested calling `snyk` manually from the command line (token is in the password manager).
