### PR TITLE
[pkg/otlp] Always map conventional attributes to tags

### DIFF
--- a/pkg/otlp/model/translator/metrics_translator.go
+++ b/pkg/otlp/model/translator/metrics_translator.go
@@ -369,13 +369,8 @@ func (t *Translator) MapMetrics(ctx context.Context, md pdata.Metrics, consumer 
 	for i := 0; i < rms.Len(); i++ {
 		rm := rms.At(i)
 
-		var attributeTags []string
-
-		// Only fetch attribute tags if they're not already converted into labels.
-		// Otherwise some tags would be present twice in a metric's tag list.
-		if !t.cfg.ResourceAttributesAsTags {
-			attributeTags = attributes.TagsFromAttributes(rm.Resource().Attributes())
-		}
+		// Fetch tags from attributes.
+		attributeTags := attributes.TagsFromAttributes(rm.Resource().Attributes())
 
 		host, ok := attributes.HostnameFromAttributes(rm.Resource().Attributes())
 		if !ok {

--- a/releasenotes/notes/otlp-map-attributes-to-tags-c7372bc01730ef1e.yaml
+++ b/releasenotes/notes/otlp-map-attributes-to-tags-c7372bc01730ef1e.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The OTLP ingest endpoint now always maps conventional metric resource-level attributes to metric tags.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Backport of https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/7185.
Makes the Datadog exporter add conventional attributes as tags (as defined in [internal/attributes](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/9c593ae0e52217fa031c896718c10a3a5385c7ba/exporter/datadogexporter/internal/attributes/attributes.go#L28-L67), eg. `development.environment` -> `env`) in all cases, instead of only when the `ResourceAttributesAsTags` option is set to `false`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

These default mappings are useful in all cases (and makes filtering by these default tags in the backend work regardless of the value of `ResourceAttributesAsTags` set in the collector).

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Run the Agent with experimental OTLP support enabled, and send metrics with both `resource_attributes_as_tags` set to `true` and `false`, and check the tags on metrics.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
