### PR TITLE
Add `containerd_namespaces` parameter

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -570,6 +570,7 @@ func InitConfig(config Config) {
 
 	// Containerd
 	config.BindEnvAndSetDefault("containerd_namespace", "")
+	config.BindEnvAndSetDefault("containerd_namespaces", []string{}) // alias for containerd_namespace
 	config.BindEnvAndSetDefault("container_env_as_tags", map[string]string{})
 	config.BindEnvAndSetDefault("container_labels_as_tags", map[string]string{})
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2452,7 +2452,7 @@ api_key:
 ## Activating the Containerd check also activates the CRI check, as it contains an additional subset of useful metrics.
 ## Defaults to [] which configures the agent to report metrics and events from all the containerd namespaces.
 ## containerd_namespaces acts as an alias for containerd_namespace. When both containerd_namespaces and containerd_namespace
-## are configured, the Agents merges the two lists.
+## are configured, the Agent merges the two lists.
 #
 # containerd_namespaces:
 #   - k8s.io

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2436,6 +2436,7 @@ api_key:
 #
 # cri_query_timeout: 5
 
+## Deprecated - use `containerd_namespaces` instead
 ## @param containerd_namespace - list of strings - optional - default: ""
 ## @env DD_CONTAINERD_NAMESPACE - space separated list of strings - optional - default: ""
 ## Activating the Containerd check also activates the CRI check, as it contains an additional subset of useful metrics.

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2446,6 +2446,16 @@ api_key:
 # containerd_namespace:
 #   - k8s.io
 
+## @param containerd_namespaces - list of strings - optional - default: []
+## @env DD_CONTAINERD_NAMESPACES - space separated list of strings - optional - default: []
+## Activating the Containerd check also activates the CRI check, as it contains an additional subset of useful metrics.
+## Defaults to [] which configures the agent to report metrics and events from all the containerd namespaces.
+## containerd_namespaces acts as an alias for containerd_namespace. When both containerd_namespaces and containerd_namespace
+## are configured, the Agents merges the two lists.
+#
+# containerd_namespaces:
+#   - k8s.io
+
 {{ end -}}
 {{- if .Kubelet }}
 

--- a/pkg/config/environment_containers.go
+++ b/pkg/config/environment_containers.go
@@ -134,6 +134,11 @@ func detectContainerd(features FeatureMap) {
 			features[Containerd] = struct{}{}
 		}
 	}
+
+	// Merge containerd_namespace with containerd_namespaces
+	namespaces := merge(Datadog.GetStringSlice("containerd_namespaces"), Datadog.GetStringSlice("containerd_namespace"))
+	AddOverride("containerd_namespace", namespaces)
+	AddOverride("containerd_namespaces", namespaces)
 }
 
 func isCriSupported() bool {
@@ -214,4 +219,20 @@ func getDefaultPodmanPaths() []string {
 		paths = append(paths, path.Join(prefix, defaultPodmanContainersStoragePath))
 	}
 	return paths
+}
+
+// merge merges and dedupes 2 slices without changing order
+func merge(s1, s2 []string) []string {
+	dedupe := map[string]struct{}{}
+	merged := []string{}
+
+	for _, elem := range append(s1, s2...) {
+		if _, seen := dedupe[elem]; !seen {
+			merged = append(merged, elem)
+		}
+
+		dedupe[elem] = struct{}{}
+	}
+
+	return merged
 }

--- a/pkg/config/environment_containers_test.go
+++ b/pkg/config/environment_containers_test.go
@@ -1,0 +1,63 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_merge(t *testing.T) {
+	tests := []struct {
+		name string
+		s1   []string
+		s2   []string
+		want []string
+	}{
+		{
+			name: "nominal case",
+			s1:   []string{"foo", "bar"},
+			s2:   []string{"baz", "tar"},
+			want: []string{"foo", "bar", "baz", "tar"},
+		},
+		{
+			name: "empty s1",
+			s1:   []string{},
+			s2:   []string{"baz", "tar"},
+			want: []string{"baz", "tar"},
+		},
+		{
+			name: "empty s2",
+			s1:   []string{"foo", "bar"},
+			s2:   []string{},
+			want: []string{"foo", "bar"},
+		},
+		{
+			name: "dedupe 1",
+			s1:   []string{"foo", "bar"},
+			s2:   []string{"baz", "foo"},
+			want: []string{"foo", "bar", "baz"},
+		},
+		{
+			name: "dedupe 2",
+			s1:   []string{"foo", "foo"},
+			s2:   []string{"foo", "foo"},
+			want: []string{"foo"},
+		},
+		{
+			name: "dedupe 3",
+			s1:   []string{"foo", "foo"},
+			s2:   []string{"baz", "tar"},
+			want: []string{"foo", "baz", "tar"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.EqualValues(t, tt.want, merge(tt.s1, tt.s2))
+		})
+	}
+}

--- a/pkg/util/containerd/containerd_util.go
+++ b/pkg/util/containerd/containerd_util.go
@@ -78,7 +78,6 @@ func NewContainerdUtil() (ContainerdItf, error) {
 		queryTimeout:      config.Datadog.GetDuration("cri_query_timeout") * time.Second,
 		connectionTimeout: config.Datadog.GetDuration("cri_connection_timeout") * time.Second,
 		socketPath:        config.Datadog.GetString("cri_socket_path"),
-		namespace:         config.Datadog.GetString("containerd_namespace"),
 	}
 	if containerdUtil.socketPath == "" {
 		log.Info("No socket path was specified, defaulting to /var/run/containerd/containerd.sock")

--- a/pkg/util/containerd/namespaces.go
+++ b/pkg/util/containerd/namespaces.go
@@ -15,10 +15,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/config"
 )
 
-func init() {
-	mergeNamespaceConfigs()
-}
-
 // NamespacesToWatch returns the namespaces to watch. If the
 // "containerd_namespace" option has been set, it returns the namespaces it contains.
 // Otherwise, it returns all of them.
@@ -54,27 +50,4 @@ func FiltersWithNamespaces(filters []string) []string {
 	}
 
 	return res
-}
-
-// mergeNamespaceConfig merges and dedupes containerd_namespaces and containerd_namespace
-func mergeNamespaceConfigs() {
-	namespaces := merge(config.Datadog.GetStringSlice("containerd_namespaces"), config.Datadog.GetStringSlice("containerd_namespace"))
-	config.Datadog.Set("containerd_namespaces", namespaces)
-	config.Datadog.Set("containerd_namespace", namespaces)
-}
-
-// merge merges and dedupes 2 slices without changing order
-func merge(s1, s2 []string) []string {
-	dedupe := map[string]struct{}{}
-	merged := []string{}
-
-	for _, elem := range append(s1, s2...) {
-		if _, seen := dedupe[elem]; !seen {
-			merged = append(merged, elem)
-		}
-
-		dedupe[elem] = struct{}{}
-	}
-
-	return merged
 }

--- a/pkg/util/containerd/namespaces_test.go
+++ b/pkg/util/containerd/namespaces_test.go
@@ -58,17 +58,12 @@ func TestNamespacesToWatch(t *testing.T) {
 		},
 	}
 
-	originalContainerdNamespaceOpt := config.Datadog.GetString("containerd_namespace")
 	originalContainerdNamespacesOpt := config.Datadog.GetStringSlice("containerd_namespaces")
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			config.Datadog.Set("containerd_namespaces", test.containerdNamespaceVal)
-
-			defer config.Datadog.Set("containerd_namespace", originalContainerdNamespaceOpt)
 			defer config.Datadog.Set("containerd_namespaces", originalContainerdNamespacesOpt)
-
-			mergeNamespaceConfigs()
 
 			namespaces, err := NamespacesToWatch(context.TODO(), test.client)
 
@@ -129,70 +124,15 @@ func TestFiltersWithNamespaces(t *testing.T) {
 		},
 	}
 
-	originalContainerdNamespaceOpt := config.Datadog.GetString("containerd_namespace")
 	originalContainerdNamespacesOpt := config.Datadog.GetStringSlice("containerd_namespaces")
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			config.Datadog.Set("containerd_namespaces", test.containerdNamespaceConfigOpt)
-
-			defer config.Datadog.Set("containerd_namespace", originalContainerdNamespaceOpt)
 			defer config.Datadog.Set("containerd_namespaces", originalContainerdNamespacesOpt)
 
-			mergeNamespaceConfigs()
 			result := FiltersWithNamespaces(test.inputFilters)
 			assert.ElementsMatch(t, test.expectedFilters, result)
-		})
-	}
-}
-
-func Test_merge(t *testing.T) {
-	tests := []struct {
-		name string
-		s1   []string
-		s2   []string
-		want []string
-	}{
-		{
-			name: "nominal case",
-			s1:   []string{"foo", "bar"},
-			s2:   []string{"baz", "tar"},
-			want: []string{"foo", "bar", "baz", "tar"},
-		},
-		{
-			name: "empty s1",
-			s1:   []string{},
-			s2:   []string{"baz", "tar"},
-			want: []string{"baz", "tar"},
-		},
-		{
-			name: "empty s2",
-			s1:   []string{"foo", "bar"},
-			s2:   []string{},
-			want: []string{"foo", "bar"},
-		},
-		{
-			name: "dedupe 1",
-			s1:   []string{"foo", "bar"},
-			s2:   []string{"baz", "foo"},
-			want: []string{"foo", "bar", "baz"},
-		},
-		{
-			name: "dedupe 2",
-			s1:   []string{"foo", "foo"},
-			s2:   []string{"foo", "foo"},
-			want: []string{"foo"},
-		},
-		{
-			name: "dedupe 3",
-			s1:   []string{"foo", "foo"},
-			s2:   []string{"baz", "tar"},
-			want: []string{"foo", "baz", "tar"},
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			assert.EqualValues(t, tt.want, merge(tt.s1, tt.s2))
 		})
 	}
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Introduce `containerd_namespaces` param, alias for `containerd_namespace`.

### Motivation

Follow-up on https://github.com/DataDog/datadog-agent/pull/10509 where `containerd_namespace` became a list, now `containerd_namespaces` would make more sense.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Same as https://github.com/DataDog/datadog-agent/pull/10509 and https://github.com/DataDog/datadog-agent/pull/10128 but with `DD_CONTAINERD_NAMESPACES` instead of `DD_CONTAINERD_NAMESPACE`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
