### PR TITLE
Add environment variables for OTLP ingest

### DIFF
--- a/pkg/config/otlp.go
+++ b/pkg/config/otlp.go
@@ -42,7 +42,7 @@ func SetupOTLP(config Config) {
 	// Set all subkeys of otlp.receiver as known
 	config.SetKnown(OTLPReceiverSection + ".*")
 	// set environment variables for selected fields
-	setupEnvironmentVariables(config)
+	setupOTLPEnvironmentVariables(config)
 }
 
 // promoteExperimentalOTLP checks if "experimental.otlp" is set and promotes it to the top level
@@ -90,14 +90,14 @@ func promoteExperimentalOTLP(cfg Config) {
 	}
 }
 
-// setupEnvironmentVariables sets up the environment variables associated with different OTLP ingest settings:
+// setupOTLPEnvironmentVariables sets up the environment variables associated with different OTLP ingest settings:
 // If there are changes in the OTLP receiver configuration, they should be reflected here.
 //
 // We don't need to set the default value: it is dealt with at the unmarshaling level
 // since we get the configuration through GetStringMap
 //
 // We are missing TLS settings: since some of them need more work to work right they are not included here.
-func setupEnvironmentVariables(config Config) {
+func setupOTLPEnvironmentVariables(config Config) {
 	// gRPC settings
 	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.endpoint")
 	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.transport")

--- a/pkg/config/otlp.go
+++ b/pkg/config/otlp.go
@@ -41,6 +41,8 @@ func SetupOTLP(config Config) {
 	config.SetKnown(OTLPReceiverSection)
 	// Set all subkeys of otlp.receiver as known
 	config.SetKnown(OTLPReceiverSection + ".*")
+	// set environment variables for selected fields
+	setupEnvironmentVariables(config)
 }
 
 // promoteExperimentalOTLP checks if "experimental.otlp" is set and promotes it to the top level
@@ -86,4 +88,37 @@ func promoteExperimentalOTLP(cfg Config) {
 	if v := cfg.GetString("experimental.otlp.grpc_port"); v != "" {
 		cfg.Set(OTLPReceiverSection+".protocols.grpc.endpoint", net.JoinHostPort(getBindHost(cfg), v))
 	}
+}
+
+// setupEnvironmentVariables sets up the environment variables associated with different OTLP ingest settings:
+// If there are changes in the OTLP receiver configuration, they should be reflected here.
+//
+// We don't need to set the default value: it is dealt with at the unmarshaling level
+// since we get the configuration through GetStringMap
+//
+// We are missing TLS settings: since some of them need more work to work right they are not included here.
+func setupEnvironmentVariables(config Config) {
+	// gRPC settings
+	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.endpoint")
+	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.transport")
+	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.max_recv_msg_size_mib")
+	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.max_concurrent_streams")
+	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.read_buffer_size")
+	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.write_buffer_size")
+	config.BindEnv(OTLPSection + ".receiver.protocols.grpc.include_metadata")
+
+	// HTTP settings
+	config.BindEnv(OTLPSection + ".receiver.protocols.http.endpoint")
+	config.BindEnv(OTLPSection + ".receiver.protocols.http.max_request_body_size")
+	config.BindEnv(OTLPSection + ".receiver.protocols.http.include_metadata")
+
+	// Metrics settings
+	config.BindEnv(OTLPSection + ".metrics.report_quantiles")
+	config.BindEnv(OTLPSection + ".metrics.send_monotonic_counter")
+	config.BindEnv(OTLPSection + ".metrics.delta_ttl")
+	config.BindEnv(OTLPSection + ".metrics.resource_attributes_as_tags")
+	config.BindEnv(OTLPSection + ".metrics.instrumentation_library_metadata_as_tags")
+	config.BindEnv(OTLPSection + ".metrics.tag_cardinality")
+	config.BindEnv(OTLPSection + ".metrics.histograms.mode")
+	config.BindEnv(OTLPSection + ".metrics.histograms.send_count_sum_metrics")
 }

--- a/pkg/otlp/config.go
+++ b/pkg/otlp/config.go
@@ -10,6 +10,7 @@ package otlp
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	colConfig "go.opentelemetry.io/collector/config"
@@ -29,16 +30,34 @@ func portToUint(v int) (port uint, err error) {
 	return
 }
 
-func fromReceiverSectionConfig(cfg config.Config) *colConfig.Map {
-	return colConfig.NewMapFromStringMap(
-		cfg.GetStringMap(config.OTLPReceiverSection),
-	)
+// readConfigSection from a config.Config object.
+func readConfigSection(cfg config.Config, section string) *colConfig.Map {
+	// Viper doesn't work well when getting subsections, since it
+	// ignores environment variables and nil-but-present sections.
+	// To work around this, we do the following two steps:
+
+	// Step one works around https://github.com/spf13/viper/issues/819
+	// If we only had the stuff below, the nil sections would be ignored.
+	// We want to take into account nil-but-present sections.
+	cfgMap := colConfig.NewMapFromStringMap(cfg.GetStringMap(section))
+
+	// Step two works around https://github.com/spf13/viper/issues/1012
+	// we check every key manually, and if it belongs to the OTLP receiver section,
+	// we set it. We need to do this to account for environment variable values.
+	prefix := section + "."
+	for _, key := range cfg.AllKeys() {
+		if strings.HasPrefix(key, prefix) && cfg.IsSet(key) {
+			mapKey := strings.ReplaceAll(key[len(prefix):], ".", colConfig.KeyDelimiter)
+			cfgMap.Set(mapKey, cfg.Get(key))
+		}
+	}
+	return cfgMap
 }
 
 // fromConfig builds a PipelineConfig from the configuration.
 func fromConfig(cfg config.Config) (PipelineConfig, error) {
 	var errs []error
-	otlpConfig := fromReceiverSectionConfig(cfg)
+	otlpConfig := readConfigSection(cfg, config.OTLPReceiverSection)
 
 	tracePort, err := portToUint(cfg.GetInt(config.OTLPTracePort))
 	if err != nil {
@@ -51,17 +70,14 @@ func fromConfig(cfg config.Config) (PipelineConfig, error) {
 		errs = append(errs, fmt.Errorf("at least one OTLP signal needs to be enabled"))
 	}
 
-	metrics := map[string]interface{}{}
-	if isSetMetrics(cfg) {
-		metrics = cfg.GetStringMap(config.OTLPMetrics)
-	}
+	metricsConfig := readConfigSection(cfg, config.OTLPMetrics)
 
 	return PipelineConfig{
 		OTLPReceiverConfig: otlpConfig.ToStringMap(),
 		TracePort:          tracePort,
 		MetricsEnabled:     metricsEnabled,
 		TracesEnabled:      tracesEnabled,
-		Metrics:            metrics,
+		Metrics:            metricsConfig.ToStringMap(),
 	}, multierr.Combine(errs...)
 }
 
@@ -72,7 +88,7 @@ func IsEnabled(cfg config.Config) bool {
 	//
 	// IsSet won't work here: it will return false if the section is present but empty.
 	// To work around this, we check if the receiver key is present in the string map, which does the 'correct' thing.
-	_, ok := cfg.GetStringMap(config.OTLPSection)[config.OTLPReceiverSubSectionKey]
+	_, ok := readConfigSection(cfg, config.OTLPSection).ToStringMap()[config.OTLPReceiverSubSectionKey]
 	return ok
 }
 

--- a/pkg/otlp/config.go
+++ b/pkg/otlp/config.go
@@ -17,11 +17,6 @@ import (
 	"go.uber.org/multierr"
 )
 
-// isSetMetrics checks if the metrics config is set.
-func isSetMetrics(cfg config.Config) bool {
-	return cfg.IsSet(config.OTLPMetrics)
-}
-
 func portToUint(v int) (port uint, err error) {
 	if v < 0 || v > 65535 {
 		err = fmt.Errorf("%d is out of [0, 65535] range", v)

--- a/releasenotes/notes/otlp-env-variables-4d6e37cddb13cd2c.yaml
+++ b/releasenotes/notes/otlp-env-variables-4d6e37cddb13cd2c.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    The OTLP ingest endpoint can now be configured through environment variables.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Add environment variables for most commonly used OTLP ingest features.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Provide a way to configure OTLP features through environment variables.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

<details>
<summary>Script used to generate the code</summary>

```go
package main

import (
	"fmt"
	"reflect"
	"strings"

	"go.opentelemetry.io/collector/receiver/otlpreceiver"
)

// metricsConfig defines the metrics exporter specific configuration options
type MetricsConfig struct {
	// Quantiles states whether to report quantiles from summary metrics.
	// By default, the minimum, maximum and average are reported.
	Quantiles bool `mapstructure:"report_quantiles"`

	// SendMonotonic states whether to report cumulative monotonic metrics as counters
	// or gauges
	SendMonotonic bool `mapstructure:"send_monotonic_counter"`

	// DeltaTTL defines the time that previous points of a cumulative monotonic
	// metric are kept in memory to calculate deltas
	DeltaTTL int64 `mapstructure:"delta_ttl"`

	ExporterConfig metricsExporterConfig `mapstructure:",squash"`

	// TagCardinality is the level of granularity of tags to send for OTLP metrics.
	TagCardinality string `mapstructure:"tag_cardinality"`

	// HistConfig defines the export of OTLP Histograms.
	HistConfig histogramConfig `mapstructure:"histograms"`
}

// histogramConfig customizes export of OTLP Histograms.
type histogramConfig struct {
	// Mode for exporting histograms. Valid values are 'distributions', 'counters' or 'nobuckets'.
	//  - 'distributions' sends histograms as Datadog distributions (recommended).
	//  - 'counters' sends histograms as Datadog counts, one metric per bucket.
	//  - 'nobuckets' sends no bucket histogram metrics. .sum and .count metrics will still be sent
	//    if `send_count_sum_metrics` is enabled.
	//
	// The current default is 'distributions'.
	Mode string `mapstructure:"mode"`

	// SendCountSum states if the export should send .sum and .count metrics for histograms.
	// The current default is false.
	SendCountSum bool `mapstructure:"send_count_sum_metrics"`
}

// metricsExporterConfig provides options for a user to customize the behavior of the
// metrics exporter
type metricsExporterConfig struct {
	// ResourceAttributesAsTags, if set to true, will use the exporterhelper feature to transform all
	// resource attributes into metric labels, which are then converted into tags
	ResourceAttributesAsTags bool `mapstructure:"resource_attributes_as_tags"`

	// InstrumentationLibraryMetadataAsTags, if set to true, adds the name and version of the
	// instrumentation library that created a metric to the metric tags
	InstrumentationLibraryMetadataAsTags bool `mapstructure:"instrumentation_library_metadata_as_tags"`
}

type Config struct {
	Receiver otlpreceiver.Config `mapstructure:"receiver"`
	Metrics  MetricsConfig       `mapstructure:"metrics"`
}

func forEachField(prefix string, config interface{}, f func(yamlKey string, value interface{})) {
	v := reflect.ValueOf(config)
	t := reflect.TypeOf(config)

	visibleFields := reflect.VisibleFields(t)
	for _, field := range visibleFields {
		if !field.IsExported() {
			continue
		}

		key := strings.SplitN(field.Tag.Get("mapstructure"), ",", 2)[0]
		fieldVal := v.FieldByIndex(field.Index)
		yamlKey := prefix
		if key != "" {
			yamlKey = prefix + "." + key
		}

		if strings.HasPrefix(yamlKey, ".receiver.grpc") || strings.HasPrefix(yamlKey, ".receiver.http") {
			// HACK: Skip embedded fields, we only want the promoted fields which have 'protocols' in the path
			continue
		}

		if fieldVal.Kind() == reflect.Ptr {
			if fieldVal.Elem().Kind() == reflect.Struct {
				fieldVal = fieldVal.Elem()
			} else {
				continue
			}
		}

		if fieldVal.Kind() == reflect.Struct {
			forEachField(yamlKey, fieldVal.Interface(), f)
		} else {
			f(yamlKey, fieldVal.Interface())
		}
	}
}

func printConfig(yamlKey string, _ interface{}) {
	fmt.Printf("\tconfig.BindEnv(OTLPSection + %q)\n", yamlKey)
}

func main() {
	receiver := otlpreceiver.NewFactory()
	otlpconfig := *(receiver.CreateDefaultConfig().(*otlpreceiver.Config))
	config := Config{
		Receiver: otlpconfig,
		Metrics: MetricsConfig{
			SendMonotonic: true,
			DeltaTTL:      3600,
			Quantiles:     true,
			ExporterConfig: metricsExporterConfig{
				ResourceAttributesAsTags:             false,
				InstrumentationLibraryMetadataAsTags: false,
			},
			TagCardinality: "low",
			HistConfig: histogramConfig{
				Mode:         "distributions",
				SendCountSum: false,
			},
		},
	}

	forEachField("", config, printConfig)
}
```

</details>

Some fields related to TLS are not exposed as environment variables. Their support on the Agent needs to be considered more closely because of the inter-Agent communication, so I think it's okay if they are not added for now.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

- The Viper setup is fragile, so care needs to be taken that the default values are not overridden with the zero value.
- Environment variable names are a bit too long (e.g. `DD_OTLP_CONFIG_METRICS_INSTRUMENTATION_LIBRARY_METADATA_AS_TAGS`), but they are predictable. We can add shorter names for commonly used features if needed in the future. 
- You can't set an empty section as in
   ```yaml
   otlp_config:
     receiver:
        protocols:
          grpc:
   ```
    through environment variables. This is still an open problem.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Set the OTLP ingest feature through environment variables (e.g. set `DD_OTLP_CONFIG_RECEIVER_PROTOCOL_GRPC_ENDPOINT` to `0.0.0.0:4317`)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
