### PR TITLE
Allow the docker build CI jobs to be retried

### DIFF
--- a/.gitlab/image_build/docker_linux.yml
+++ b/.gitlab/image_build/docker_linux.yml
@@ -20,6 +20,8 @@
     - docker build --build-arg CIBUILD=true $BUILD_ARG --file $BUILD_CONTEXT/$ARCH/Dockerfile --pull --tag ${TARGET_TAG}-unsquashed $BUILD_CONTEXT
     - docker-squash ${TARGET_TAG}-unsquashed -t ${TARGET_TAG}
     - docker push $TARGET_TAG
+  # Workaround for temporary network failures
+  retry: 2
 
 .docker_build_job_definition_amd64:
   extends: .docker_build_job_definition

--- a/.gitlab/image_build/docker_windows.yml
+++ b/.gitlab/image_build/docker_windows.yml
@@ -20,6 +20,8 @@
       docker login --username "`${DOCKER_REGISTRY_LOGIN}" --password "`${DOCKER_REGISTRY_PWD}" "${DOCKER_REGISTRY_URL}"
       If (`$lastExitCode -ne "0") { throw "Previous command returned `$lastExitCode" }
       "@ | out-file ci-scripts/docker-login.ps1
+  # Workaround for temporary network failures
+  retry: 2
 
 .docker_build_agent_windows_common:
   extends:


### PR DESCRIPTION
### What does this PR do?

Allow the docker build CI jobs to be retried to workaround temporary network failures.

### Motivation

We regularly receive notifications of GitLab job failures, including on the `main` branch and, when we look at them, it’s quite common that it’s because of temporary network failures like:

```
Step 11/19 : FROM ubuntu:21.10
Get https://registry-1.docker.io/v2/: dial tcp: lookup registry-1.docker.io: Temporary failure in name resolution
ERROR: Job failed: exit code 1
```

or

```
$ docker push $TARGET_TAG
The push refers to repository [486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent/agent]
Get https://486234852809.dkr.ecr.us-east-1.amazonaws.com/v2/: dial tcp: lookup 486234852809.dkr.ecr.us-east-1.amazonaws.com: Temporary failure in name resolution
ERROR: Job failed: exit code 1
```

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
