### PR TITLE
SNMP Traps: Support v1 and v3

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -399,7 +399,7 @@ func StartAgent() error {
 	// Start SNMP trap server
 	if traps.IsEnabled() {
 		if config.Datadog.GetBool("logs_enabled") {
-			err = traps.StartServer()
+			err = traps.StartServer(hostname)
 			if err != nil {
 				log.Errorf("Failed to start snmp-traps server: %s", err)
 			}

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2815,7 +2815,7 @@ api_key:
 ## @param snmp_traps_config - custom object - optional
 ## This section configures SNMP traps collection. Traps are forwarded as logs to Datadog.
 ## NOTE: This feature is currently **EXPERIMENTAL**. Both behavior and configuration options may
-## change in the future. Only SNMPv2 is supported.
+## change in the future.
 #
 # snmp_traps_config:
 
@@ -2825,7 +2825,7 @@ api_key:
   # port: 162
 
   ## @param community_strings - list of strings - required
-  ## A list of known SNMPv2 community strings that devices can use to send traps to the Agent.
+  ## A list of known SNMP community strings that devices can use to send traps to the Agent.
   ## Traps with an unknown community string are ignored.
   ## Enclose the community string with single quote like below (to avoid special characters being interpreted).
   ## Must be non-empty.
@@ -2833,6 +2833,28 @@ api_key:
   # community_strings:
   #   - '<COMMUNITY_1>'
   #   - '<COMMUNITY_2>'
+
+  ## @param users - list of custom objects - optional
+  ## List of SNMPv3 users that can be used to listen for traps.
+  ## NOTE: Currently the Datadog Agent only supports having a
+  ## single user in this list.
+  ## Each user can contain:
+  ##  * username     - string - The username used by devices when sending Traps to the Agent.
+  ##  * authKey      - string - (Optional) The passphrase to use with the given user and authProtocol
+  ##  * authProtocol - string - (Optional) The authentication protocol to use when listening for traps from this user.
+  ##                            Available options are: MD5, SHA, SHA224, SHA256, SHA384, SHA512.
+  ##                            Defaults to MD5 when authKey is set.
+  ##  * privKey      - string - (Optional) The passphrase to use with the given user privacy protocol.
+  ##  * privProtocol - string - (Optional) The privacy protocol to use when listening for traps from this user.
+  ##                            Available options are: DES, AES (128 bits), AES192, AES192C, AES256, AES256C.
+  ##                            Defaults to DES when privKey is set.
+  #
+  # users:
+  # - username: <USERNAME>
+  #   authKey: <AUTHENTICATION_KEY>
+  #   authProtocol: <AUTHENTICATION_PROTOCOL>
+  #   privKey: <PRIVACY_KEY>
+  #   privProtocol: <PRIVACY_PROTOCOL>
 
   ## @param bind_host - string - optional
   ## The hostname to listen on for incoming trap packets.

--- a/pkg/logs/internal/tailers/traps/tailer_test.go
+++ b/pkg/logs/internal/tailers/traps/tailer_test.go
@@ -30,7 +30,7 @@ func TestTrapsShouldReceiveMessages(t *testing.T) {
 		Content: &gosnmp.SnmpPacket{
 			Version:   gosnmp.Version2c,
 			Community: "public",
-			Variables: traps.NetSNMPExampleHeartbeatNotificationVariables,
+			Variables: traps.NetSNMPExampleHeartbeatNotification.Variables,
 		},
 		Addr: &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 1620},
 	}

--- a/pkg/snmp/traps/config.go
+++ b/pkg/snmp/traps/config.go
@@ -8,6 +8,8 @@ package traps
 import (
 	"errors"
 	"fmt"
+	"hash/fnv"
+	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/gosnmp/gosnmp"
@@ -18,26 +20,38 @@ func IsEnabled() bool {
 	return config.Datadog.GetBool("snmp_traps_enabled")
 }
 
+// UserV3 contains the definition of one SNMPv3 user with its username and its auth
+// parameters.
+type UserV3 struct {
+	Username     string `mapstructure:"user" yaml:"user"`
+	AuthKey      string `mapstructure:"authKey" yaml:"authKey"`
+	AuthProtocol string `mapstructure:"authProtocol" yaml:"authProtocol"`
+	PrivKey      string `mapstructure:"privKey" yaml:"privKey"`
+	PrivProtocol string `mapstructure:"privProtocol" yaml:"privProtocol"`
+}
+
 // Config contains configuration for SNMP trap listeners.
 // YAML field tags provided for test marshalling purposes.
 type Config struct {
-	Port             uint16   `mapstructure:"port" yaml:"port"`
-	CommunityStrings []string `mapstructure:"community_strings" yaml:"community_strings"`
-	BindHost         string   `mapstructure:"bind_host" yaml:"bind_host"`
-	StopTimeout      int      `mapstructure:"stop_timeout" yaml:"stop_timeout"`
+	Port                  uint16   `mapstructure:"port" yaml:"port"`
+	Users                 []UserV3 `mapstructure:"users" yaml:"users"`
+	CommunityStrings      []string `mapstructure:"community_strings" yaml:"community_strings"`
+	BindHost              string   `mapstructure:"bind_host" yaml:"bind_host"`
+	StopTimeout           int      `mapstructure:"stop_timeout" yaml:"stop_timeout"`
+	authoritativeEngineID string   `mapstructure:"-" yaml:"-"`
 }
 
 // ReadConfig builds and returns configuration from Agent configuration.
-func ReadConfig() (*Config, error) {
+func ReadConfig(agentHostname string) (*Config, error) {
 	var c Config
 	err := config.Datadog.UnmarshalKey("snmp_traps_config", &c)
 	if err != nil {
 		return nil, err
 	}
 
-	// Validate required fields.
-	if c.CommunityStrings == nil || len(c.CommunityStrings) == 0 {
-		return nil, errors.New("`community_strings` is required and must be non-empty")
+	// gosnmp only supports one v3 user at the moment.
+	if len(c.Users) > 1 {
+		return nil, errors.New("only one user is currently supported in snmp_traps_config")
 	}
 
 	// Set defaults.
@@ -52,6 +66,19 @@ func ReadConfig() (*Config, error) {
 		c.StopTimeout = defaultStopTimeout
 	}
 
+	if agentHostname == "" {
+		// Make sure to have at least some unique bytes for the authoritative engineID.
+		// Unlikely to happen since the agent cannot start without a hostname
+		agentHostname = "unknown-datadog-agent"
+	}
+	h := fnv.New128()
+	h.Write([]byte(agentHostname))
+	// First byte is always 0x80
+	// Next four bytes are the Private Enterprise Number (set to an invalid value here)
+	// The next 16 bytes are the hash of the agent hostname
+	engineID := h.Sum([]byte{0x80, 0xff, 0xff, 0xff, 0xff})
+	c.authoritativeEngineID = string(engineID)
+
 	return &c, nil
 }
 
@@ -60,12 +87,70 @@ func (c *Config) Addr() string {
 	return fmt.Sprintf("%s:%d", c.BindHost, c.Port)
 }
 
-// BuildV2Params returns a valid GoSNMP SNMPv2 params structure from configuration.
-func (c *Config) BuildV2Params() *gosnmp.GoSNMP {
-	return &gosnmp.GoSNMP{
-		Port:      c.Port,
-		Transport: "udp",
-		Version:   gosnmp.Version2c,
-		Logger:    gosnmp.NewLogger(&trapLogger{}),
+// BuildSNMPParams returns a valid GoSNMP params structure from configuration.
+func (c *Config) BuildSNMPParams() (*gosnmp.GoSNMP, error) {
+	if len(c.Users) == 0 {
+		return &gosnmp.GoSNMP{
+			Port:      c.Port,
+			Transport: "udp",
+			Version:   gosnmp.Version2c, // No user configured, let's use Version2 which is enough and doesn't require setting up fake security data.
+			Logger:    gosnmp.NewLogger(&trapLogger{}),
+		}, nil
 	}
+	user := c.Users[0]
+	var authProtocol gosnmp.SnmpV3AuthProtocol
+	switch lowerAuthProtocol := strings.ToLower(user.AuthProtocol); lowerAuthProtocol {
+	case "":
+		authProtocol = gosnmp.NoAuth
+	case "md5":
+		authProtocol = gosnmp.MD5
+	case "sha":
+		authProtocol = gosnmp.SHA
+	default:
+		return nil, fmt.Errorf("unsupported authentication protocol: %s", user.AuthProtocol)
+	}
+
+	var privProtocol gosnmp.SnmpV3PrivProtocol
+	switch lowerPrivProtocol := strings.ToLower(user.PrivProtocol); lowerPrivProtocol {
+	case "":
+		privProtocol = gosnmp.NoPriv
+	case "des":
+		privProtocol = gosnmp.DES
+	case "aes":
+		privProtocol = gosnmp.AES
+	case "aes192":
+		privProtocol = gosnmp.AES192
+	case "aes192c":
+		privProtocol = gosnmp.AES192C
+	case "aes256":
+		privProtocol = gosnmp.AES256
+	case "aes256c":
+		privProtocol = gosnmp.AES256C
+	default:
+		return nil, fmt.Errorf("unsupported privacy protocol: %s", user.PrivProtocol)
+	}
+
+	msgFlags := gosnmp.NoAuthNoPriv
+	if user.PrivKey != "" {
+		msgFlags = gosnmp.AuthPriv
+	} else if user.AuthKey != "" {
+		msgFlags = gosnmp.AuthNoPriv
+	}
+
+	return &gosnmp.GoSNMP{
+		Port:          c.Port,
+		Transport:     "udp",
+		Version:       gosnmp.Version3, // Always using version3 for traps, only option that works with all SNMP versions simultaneously
+		SecurityModel: gosnmp.UserSecurityModel,
+		MsgFlags:      msgFlags,
+		SecurityParameters: &gosnmp.UsmSecurityParameters{
+			UserName:                 user.Username,
+			AuthoritativeEngineID:    c.authoritativeEngineID,
+			AuthenticationProtocol:   authProtocol,
+			AuthenticationPassphrase: user.AuthKey,
+			PrivacyProtocol:          privProtocol,
+			PrivacyPassphrase:        user.PrivKey,
+		},
+		Logger: gosnmp.NewLogger(&trapLogger{}),
+	}, nil
 }

--- a/pkg/snmp/traps/config_test.go
+++ b/pkg/snmp/traps/config_test.go
@@ -16,6 +16,11 @@ const mockedHostname = "VeryLongHostnameThatDoesNotFitIntoTheByteArray"
 
 var expectedEngineID = "\x80\xff\xff\xff\xff\x67\xb2\x0f\xe4\xdf\x73\x7a\xce\x28\x47\x03\x8f\x57\xe6\x5c\x98"
 
+var expectedEngineIDs = map[string]string{
+	"VeryLongHostnameThatDoesNotFitIntoTheByteArray": "\x80\xff\xff\xff\xff\x67\xb2\x0f\xe4\xdf\x73\x7a\xce\x28\x47\x03\x8f\x57\xe6\x5c\x98",
+	"VeryLongHostnameThatIsDifferent":                "\x80\xff\xff\xff\xff\xe7\x21\xcc\xd7\x0b\xe1\x60\xc5\x18\xd7\xde\x17\x86\xb0\x7d\x36",
+}
+
 func TestFullConfig(t *testing.T) {
 	Configure(t, Config{
 		Port: 1234,
@@ -97,7 +102,9 @@ func TestDefaultUsers(t *testing.T) {
 
 func TestBuildAuthoritativeEngineID(t *testing.T) {
 	Configure(t, Config{})
-	config, err := ReadConfig(mockedHostname)
-	assert.NoError(t, err)
-	assert.Equal(t, expectedEngineID, config.authoritativeEngineID)
+	for hostname, engineID := range expectedEngineIDs {
+		config, err := ReadConfig(hostname)
+		assert.NoError(t, err)
+		assert.Equal(t, engineID, config.authoritativeEngineID)
+	}
 }

--- a/pkg/snmp/traps/config_test.go
+++ b/pkg/snmp/traps/config_test.go
@@ -6,68 +6,98 @@
 package traps
 
 import (
+	"testing"
+
 	"github.com/gosnmp/gosnmp"
 	"github.com/stretchr/testify/assert"
-	"testing"
 )
 
-func TestConfig(t *testing.T) {
+const mockedHostname = "VeryLongHostnameThatDoesNotFitIntoTheByteArray"
+
+var expectedEngineID = "\x80\xff\xff\xff\xff\x67\xb2\x0f\xe4\xdf\x73\x7a\xce\x28\x47\x03\x8f\x57\xe6\x5c\x98"
+
+func TestFullConfig(t *testing.T) {
 	Configure(t, Config{
-		Port:             1234,
+		Port: 1234,
+		Users: []UserV3{
+			{
+				Username:     "user",
+				AuthKey:      "password",
+				AuthProtocol: "MD5",
+				PrivKey:      "password",
+				PrivProtocol: "AES",
+			},
+		},
+		BindHost:         "127.0.0.1",
 		CommunityStrings: []string{"public"},
+		StopTimeout:      12,
 	})
-	config, err := ReadConfig()
+	config, err := ReadConfig(mockedHostname)
 	assert.NoError(t, err)
 	assert.Equal(t, uint16(1234), config.Port)
-	assert.Equal(t, defaultStopTimeout, config.StopTimeout)
+	assert.Equal(t, 12, config.StopTimeout)
+	assert.Equal(t, []string{"public"}, config.CommunityStrings)
+	assert.Equal(t, "127.0.0.1", config.BindHost)
+	assert.Equal(t, []UserV3{
+		{
+			Username:     "user",
+			AuthKey:      "password",
+			AuthProtocol: "MD5",
+			PrivKey:      "password",
+			PrivProtocol: "AES",
+		},
+	}, config.Users)
 
-	params := config.BuildV2Params()
+	params, err := config.BuildSNMPParams()
+	assert.NoError(t, err)
 	assert.Equal(t, uint16(1234), params.Port)
+	assert.Equal(t, gosnmp.Version3, params.Version)
+	assert.Equal(t, "udp", params.Transport)
+	assert.NotNil(t, params.Logger)
+	assert.Equal(t, gosnmp.UserSecurityModel, params.SecurityModel)
+	assert.Equal(t, &gosnmp.UsmSecurityParameters{
+		UserName:                 "user",
+		AuthoritativeEngineID:    expectedEngineID,
+		AuthenticationProtocol:   gosnmp.MD5,
+		AuthenticationPassphrase: "password",
+		PrivacyProtocol:          gosnmp.AES,
+		PrivacyPassphrase:        "password",
+	}, params.SecurityParameters)
+}
+
+func TestMinimalConfig(t *testing.T) {
+	Configure(t, Config{})
+	config, err := ReadConfig("")
+	assert.NoError(t, err)
+	assert.Equal(t, uint16(162), config.Port)
+	assert.Equal(t, 5, config.StopTimeout)
+	assert.Equal(t, []string{}, config.CommunityStrings)
+	assert.Equal(t, "localhost", config.BindHost)
+	assert.Equal(t, []UserV3{}, config.Users)
+
+	params, err := config.BuildSNMPParams()
+	assert.NoError(t, err)
+	assert.Equal(t, uint16(162), params.Port)
 	assert.Equal(t, gosnmp.Version2c, params.Version)
 	assert.Equal(t, "udp", params.Transport)
 	assert.NotNil(t, params.Logger)
+	assert.Equal(t, nil, params.SecurityParameters)
 }
 
-func TestDefaultPort(t *testing.T) {
-	Configure(t, Config{
-		CommunityStrings: []string{"public"},
-	})
-	config, err := ReadConfig()
-	assert.NoError(t, err)
-	assert.Equal(t, defaultPort, config.Port)
-}
-
-func TestCommunityStringsEmpty(t *testing.T) {
-	Configure(t, Config{
-		CommunityStrings: []string{},
-	})
-	_, err := ReadConfig()
-	assert.Error(t, err)
-}
-
-func TestCommunityStringsMissing(t *testing.T) {
-	Configure(t, Config{})
-	_, err := ReadConfig()
-	assert.Error(t, err)
-}
-
-func TestDefaultStopTimeout(t *testing.T) {
-	Configure(t, Config{
-		CommunityStrings: []string{"public"},
-	})
-	config, err := ReadConfig()
-	assert.NoError(t, err)
-
-	assert.Equal(t, 5, config.StopTimeout)
-}
-
-func TestStopTimeout(t *testing.T) {
+func TestDefaultUsers(t *testing.T) {
 	Configure(t, Config{
 		CommunityStrings: []string{"public"},
 		StopTimeout:      11,
 	})
-	config, err := ReadConfig()
+	config, err := ReadConfig("")
 	assert.NoError(t, err)
 
 	assert.Equal(t, 11, config.StopTimeout)
+}
+
+func TestBuildAuthoritativeEngineID(t *testing.T) {
+	Configure(t, Config{})
+	config, err := ReadConfig(mockedHostname)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedEngineID, config.authoritativeEngineID)
 }

--- a/pkg/snmp/traps/constants.go
+++ b/pkg/snmp/traps/constants.go
@@ -9,4 +9,5 @@ const (
 	defaultPort        = uint16(162) // Standard UDP port for traps.
 	defaultStopTimeout = 5
 	packetsChanSize    = 100
+	genericTrapOid     = "1.3.6.1.6.3.1.1.5"
 )

--- a/pkg/snmp/traps/format.go
+++ b/pkg/snmp/traps/format.go
@@ -19,7 +19,10 @@ const (
 
 // FormatPacketToJSON converts an SNMP trap packet to a JSON-serializable object.
 func FormatPacketToJSON(packet *SnmpPacket) (map[string]interface{}, error) {
-	return formatTrapPDUs(packet.Content.Variables)
+	if packet.Content.Version == gosnmp.Version1 {
+		return formatV1Trap(packet), nil
+	}
+	return formatTrap(packet)
 }
 
 // GetTags returns a list of tags associated to an SNMP trap packet.
@@ -32,19 +35,47 @@ func GetTags(packet *SnmpPacket) []string {
 
 func formatVersion(packet *SnmpPacket) string {
 	switch packet.Content.Version {
+	case gosnmp.Version3:
+		return "3"
 	case gosnmp.Version2c:
 		return "2"
+	case gosnmp.Version1:
+		return "1"
 	default:
 		return "unknown"
 	}
 }
 
-func formatTrapPDUs(variables []gosnmp.SnmpPDU) (map[string]interface{}, error) {
+func formatV1Trap(packet *SnmpPacket) map[string]interface{} {
+	data := make(map[string]interface{})
+	data["uptime"] = uint32(packet.Content.Timestamp)
+	enterpriseOid := normalizeOID(packet.Content.Enterprise)
+	genericTrap := packet.Content.GenericTrap
+	specificTrap := packet.Content.SpecificTrap
+	var trapOID string
+	if genericTrap == 6 {
+		// Vendor-specific trap
+		trapOID = fmt.Sprintf("%s.0.%d", enterpriseOid, specificTrap)
+	} else {
+		// Generic trap
+		trapOID = fmt.Sprintf("%s.%d", genericTrapOid, genericTrap+1)
+	}
+	data["oid"] = trapOID
+	data["enterprise_oid"] = enterpriseOid
+	data["generic_trap"] = genericTrap
+	data["specific_trap"] = specificTrap
+	data["variables"] = parseVariables(packet.Content.Variables)
+
+	return data
+}
+
+func formatTrap(packet *SnmpPacket) (map[string]interface{}, error) {
 	/*
-		An SNMPv2 trap packet consists in the following variables (PDUs):
+		An SNMP v2 or v3 trap packet consists in the following variables (PDUs):
 		{sysUpTime.0, snmpTrapOID.0, additionalDataVariables...}
 		See: https://tools.ietf.org/html/rfc3416#section-4.2.6
 	*/
+	variables := packet.Content.Variables
 	if len(variables) < 2 {
 		return nil, fmt.Errorf("expected at least 2 variables, got %d", len(variables))
 	}

--- a/pkg/snmp/traps/format_test.go
+++ b/pkg/snmp/traps/format_test.go
@@ -14,15 +14,100 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func createTestPacket() *SnmpPacket {
+func createTestV1GenericPacket() *SnmpPacket {
+	examplePacket := &gosnmp.SnmpPacket{Version: gosnmp.Version1, SnmpTrap: LinkDownv1GenericTrap}
+	examplePacket.Variables = examplePacket.SnmpTrap.Variables
 	return &SnmpPacket{
-		Content: &gosnmp.SnmpPacket{
-			Version:   gosnmp.Version2c,
-			Community: "public",
-			Variables: NetSNMPExampleHeartbeatNotificationVariables,
-		},
-		Addr: &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 13156},
+		Content: examplePacket,
+		Addr:    &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 13156},
 	}
+}
+
+func createTestV1SpecificPacket() *SnmpPacket {
+	examplePacket := &gosnmp.SnmpPacket{Version: gosnmp.Version1, SnmpTrap: AlarmActiveStatev1SpecificTrap}
+	examplePacket.Variables = examplePacket.SnmpTrap.Variables
+	return &SnmpPacket{
+		Content: examplePacket,
+		Addr:    &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 13156},
+	}
+}
+
+func createTestPacket() *SnmpPacket {
+	examplePacket := &gosnmp.SnmpPacket{
+		Version:   gosnmp.Version2c,
+		Community: "public",
+		Variables: NetSNMPExampleHeartbeatNotification.Variables,
+	}
+	return &SnmpPacket{
+		Content: examplePacket,
+		Addr:    &net.UDPAddr{IP: net.ParseIP("127.0.0.1"), Port: 13156},
+	}
+}
+
+func TestFormatPacketV1Generic(t *testing.T) {
+	packet := createTestV1GenericPacket()
+	data, err := FormatPacketToJSON(packet)
+	require.NoError(t, err)
+
+	assert.Equal(t, "1.3.6.1.6.3.1.1.5.3", data["oid"])
+	assert.NotNil(t, data["uptime"])
+	assert.NotNil(t, data["enterprise_oid"])
+	assert.NotNil(t, data["generic_trap"])
+	assert.NotNil(t, data["specific_trap"])
+
+	variables, ok := data["variables"].([]map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, len(variables), 3)
+
+	assert.Equal(t, "1.3.6.1.6.3.1.1.5", data["enterprise_oid"])
+	assert.Equal(t, 2, data["generic_trap"])
+	assert.Equal(t, 0, data["specific_trap"])
+
+	ifIndex := variables[0]
+	assert.Equal(t, ifIndex["oid"], "1.3.6.1.2.1.2.2.1.1")
+	assert.Equal(t, ifIndex["type"], "integer")
+	assert.Equal(t, ifIndex["value"], 2)
+
+	ifAdminStatus := variables[1]
+	assert.Equal(t, ifAdminStatus["oid"], "1.3.6.1.2.1.2.2.1.7")
+	assert.Equal(t, ifAdminStatus["type"], "integer")
+	assert.Equal(t, ifAdminStatus["value"], 1)
+
+	ifOperStatus := variables[2]
+	assert.Equal(t, ifOperStatus["oid"], "1.3.6.1.2.1.2.2.1.8")
+	assert.Equal(t, ifOperStatus["type"], "integer")
+	assert.Equal(t, ifOperStatus["value"], 2)
+}
+
+func TestFormatPacketV1Specific(t *testing.T) {
+	packet := createTestV1SpecificPacket()
+	data, err := FormatPacketToJSON(packet)
+	require.NoError(t, err)
+
+	assert.Equal(t, "1.3.6.1.2.1.118.0.2", data["oid"])
+	assert.NotNil(t, data["uptime"])
+	assert.NotNil(t, data["enterprise_oid"])
+	assert.NotNil(t, data["generic_trap"])
+	assert.NotNil(t, data["specific_trap"])
+
+	variables, ok := data["variables"].([]map[string]interface{})
+	assert.True(t, ok)
+	assert.Equal(t, len(variables), 2)
+
+	assert.Equal(t, "1.3.6.1.2.1.118", data["enterprise_oid"])
+	assert.Equal(t, 6, data["generic_trap"])
+	assert.Equal(t, 2, data["specific_trap"])
+
+	alarmActiveModelPointer := variables[0]
+	assert.Equal(t, alarmActiveModelPointer["oid"], "1.3.6.1.2.1.118.1.2.2.1.13")
+	assert.Equal(t, alarmActiveModelPointer["type"], "string")
+	assert.Equal(t, alarmActiveModelPointer["value"], "foo")
+
+	alarmActiveResourceID := variables[1]
+	assert.Equal(t, alarmActiveResourceID["oid"], "1.3.6.1.2.1.118.1.2.2.1.10")
+	assert.Equal(t, alarmActiveResourceID["type"], "string")
+	assert.Equal(t, alarmActiveResourceID["value"], "bar")
+
 }
 
 func TestFormatPacketToJSON(t *testing.T) {
@@ -88,8 +173,7 @@ func TestGetTags(t *testing.T) {
 
 func TestGetTagsForUnsupportedVersionShouldStillSucceed(t *testing.T) {
 	packet := createTestPacket()
-	packet.Content.Version = gosnmp.Version3
-	packet.Content.Community = ""
+	packet.Content.Version = 12
 	tags := GetTags(packet)
 	assert.Equal(t, tags, []string{
 		"snmp_version:unknown",

--- a/pkg/snmp/traps/server.go
+++ b/pkg/snmp/traps/server.go
@@ -22,7 +22,7 @@ type SnmpPacket struct {
 // PacketsChannel is the type of channels of trap packets.
 type PacketsChannel = chan *SnmpPacket
 
-// TrapServer manages an SNMPv2 trap listener.
+// TrapServer manages an SNMP trap listener.
 type TrapServer struct {
 	Addr     string
 	config   *Config
@@ -36,8 +36,8 @@ var (
 )
 
 // StartServer starts the global trap server.
-func StartServer() error {
-	server, err := NewTrapServer()
+func StartServer(agentHostname string) error {
+	server, err := NewTrapServer(agentHostname)
 	serverInstance = server
 	startError = err
 	return err
@@ -63,15 +63,15 @@ func GetPacketsChannel() PacketsChannel {
 }
 
 // NewTrapServer configures and returns a running SNMP traps server.
-func NewTrapServer() (*TrapServer, error) {
-	config, err := ReadConfig()
+func NewTrapServer(agentHostname string) (*TrapServer, error) {
+	config, err := ReadConfig(agentHostname)
 	if err != nil {
 		return nil, err
 	}
 
 	packets := make(PacketsChannel, packetsChanSize)
 
-	listener, err := startSNMPv2Listener(config, packets)
+	listener, err := startSNMPTrapListener(config, packets)
 	if err != nil {
 		return nil, err
 	}
@@ -85,12 +85,16 @@ func NewTrapServer() (*TrapServer, error) {
 	return server, nil
 }
 
-func startSNMPv2Listener(c *Config, packets PacketsChannel) (*gosnmp.TrapListener, error) {
+func startSNMPTrapListener(c *Config, packets PacketsChannel) (*gosnmp.TrapListener, error) {
+	var err error
 	listener := gosnmp.NewTrapListener()
-	listener.Params = c.BuildV2Params()
+	listener.Params, err = c.BuildSNMPParams()
+	if err != nil {
+		return nil, err
+	}
 
 	listener.OnNewTrap = func(p *gosnmp.SnmpPacket, u *net.UDPAddr) {
-		if err := validateCredentials(p, c); err != nil {
+		if err := validatePacket(p, c); err != nil {
 			log.Warnf("Invalid credentials from %s on listener %s, dropping packet", u.String(), c.Addr())
 			trapsPacketsAuthErrors.Add(1)
 			return

--- a/pkg/snmp/traps/server_test.go
+++ b/pkg/snmp/traps/server_test.go
@@ -8,14 +8,47 @@ package traps
 import (
 	"testing"
 
+	"github.com/gosnmp/gosnmp"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestServerV1GenericTrap(t *testing.T) {
+	config := Config{Port: GetPort(t), CommunityStrings: []string{"public"}}
+	Configure(t, config)
+
+	err := StartServer("dummy_hostname")
+	require.NoError(t, err)
+	defer StopServer()
+
+	sendTestV1GenericTrap(t, config, "public")
+	packet := receivePacket(t)
+	require.NotNil(t, packet)
+	packet.Content.SnmpTrap.Variables = packet.Content.Variables
+	assert.Equal(t, LinkDownv1GenericTrap, packet.Content.SnmpTrap)
+
+}
+
+func TestServerV1SpecificTrap(t *testing.T) {
+	config := Config{Port: GetPort(t), CommunityStrings: []string{"public"}}
+	Configure(t, config)
+
+	err := StartServer("dummy_hostname")
+	require.NoError(t, err)
+	defer StopServer()
+
+	sendTestV1SpecificTrap(t, config, "public")
+	packet := receivePacket(t)
+	require.NotNil(t, packet)
+	packet.Content.SnmpTrap.Variables = packet.Content.Variables
+	assert.Equal(t, AlarmActiveStatev1SpecificTrap, packet.Content.SnmpTrap)
+}
 
 func TestServerV2(t *testing.T) {
 	config := Config{Port: GetPort(t), CommunityStrings: []string{"public"}}
 	Configure(t, config)
 
-	err := StartServer()
+	err := StartServer("dummy_hostname")
 	require.NoError(t, err)
 	defer StopServer()
 
@@ -23,18 +56,60 @@ func TestServerV2(t *testing.T) {
 	packet := receivePacket(t)
 	require.NotNil(t, packet)
 	assertIsValidV2Packet(t, packet, config)
-	assertV2Variables(t, packet)
+	assertVariables(t, packet)
 }
 
 func TestServerV2BadCredentials(t *testing.T) {
 	config := Config{Port: GetPort(t), CommunityStrings: []string{"public"}}
 	Configure(t, config)
 
-	err := StartServer()
+	err := StartServer("dummy_hostname")
 	require.NoError(t, err)
 	defer StopServer()
 
 	sendTestV2Trap(t, config, "wrong-community")
+	assertNoPacketReceived(t)
+}
+
+func TestServerV3(t *testing.T) {
+	userV3 := UserV3{Username: "user", AuthKey: "password", AuthProtocol: "sha", PrivKey: "password", PrivProtocol: "aes"}
+	config := Config{Port: GetPort(t), Users: []UserV3{userV3}}
+	Configure(t, config)
+
+	err := StartServer("dummy_hostname")
+	require.NoError(t, err)
+	defer StopServer()
+
+	sendTestV3Trap(t, config, &gosnmp.UsmSecurityParameters{
+		UserName:                 "user",
+		AuthoritativeEngineID:    "foo",
+		AuthenticationPassphrase: "password",
+		AuthenticationProtocol:   gosnmp.SHA,
+		PrivacyPassphrase:        "password",
+		PrivacyProtocol:          gosnmp.AES,
+	})
+	packet := receivePacket(t)
+	require.NotNil(t, packet)
+	assertVariables(t, packet)
+}
+
+func TestServerV3BadCredentials(t *testing.T) {
+	userV3 := UserV3{Username: "user", AuthKey: "password", AuthProtocol: "sha", PrivKey: "password", PrivProtocol: "aes"}
+	config := Config{Port: GetPort(t), Users: []UserV3{userV3}}
+	Configure(t, config)
+
+	err := StartServer("dummy_hostname")
+	require.NoError(t, err)
+	defer StopServer()
+
+	sendTestV3Trap(t, config, &gosnmp.UsmSecurityParameters{
+		UserName:                 "user",
+		AuthoritativeEngineID:    "foo",
+		AuthenticationPassphrase: "password",
+		AuthenticationProtocol:   gosnmp.SHA,
+		PrivacyPassphrase:        "wrong_password",
+		PrivacyProtocol:          gosnmp.AES,
+	})
 	assertNoPacketReceived(t)
 }
 
@@ -47,12 +122,12 @@ func TestStartFailure(t *testing.T) {
 	config := Config{Port: port, CommunityStrings: []string{"public"}}
 	Configure(t, config)
 
-	sucessServer, err := NewTrapServer()
+	sucessServer, err := NewTrapServer("dummy_hostname")
 	require.NoError(t, err)
 	require.NotNil(t, sucessServer)
 	defer sucessServer.Stop()
 
-	failedServer, err := NewTrapServer()
+	failedServer, err := NewTrapServer("dummy_hostname")
 	require.Nil(t, failedServer)
 	require.Error(t, err)
 }

--- a/pkg/snmp/traps/testing.go
+++ b/pkg/snmp/traps/testing.go
@@ -25,15 +25,45 @@ import (
 // List of variables for a NetSNMP::ExampleHeartBeatNotification trap message.
 // See: http://www.circitor.fr/Mibs/Html/N/NET-SNMP-EXAMPLES-MIB.php#netSnmpExampleHeartbeatNotification
 var (
-	NetSNMPExampleHeartbeatNotificationVariables = []gosnmp.SnmpPDU{
-		// sysUpTimeInstance
-		{Name: "1.3.6.1.2.1.1.3.0", Type: gosnmp.TimeTicks, Value: uint32(1000)},
-		// snmpTrapOID
-		{Name: "1.3.6.1.6.3.1.1.4.1.0", Type: gosnmp.OctetString, Value: "1.3.6.1.4.1.8072.2.3.0.1"},
-		// heartBeatRate
-		{Name: "1.3.6.1.4.1.8072.2.3.2.1", Type: gosnmp.Integer, Value: 1024},
-		// heartBeatName
-		{Name: "1.3.6.1.4.1.8072.2.3.2.2", Type: gosnmp.OctetString, Value: "test"},
+	NetSNMPExampleHeartbeatNotification = gosnmp.SnmpTrap{
+		Variables: []gosnmp.SnmpPDU{
+			// sysUpTimeInstance
+			{Name: "1.3.6.1.2.1.1.3.0", Type: gosnmp.TimeTicks, Value: uint32(1000)},
+			// snmpTrapOID
+			{Name: "1.3.6.1.6.3.1.1.4.1.0", Type: gosnmp.OctetString, Value: "1.3.6.1.4.1.8072.2.3.0.1"},
+			// heartBeatRate
+			{Name: "1.3.6.1.4.1.8072.2.3.2.1", Type: gosnmp.Integer, Value: 1024},
+			// heartBeatName
+			{Name: "1.3.6.1.4.1.8072.2.3.2.2", Type: gosnmp.OctetString, Value: "test"},
+		},
+	}
+	LinkDownv1GenericTrap = gosnmp.SnmpTrap{
+		AgentAddress: "127.0.0.1",
+		Enterprise:   ".1.3.6.1.6.3.1.1.5",
+		GenericTrap:  2,
+		SpecificTrap: 0,
+		Timestamp:    1000,
+		Variables: []gosnmp.SnmpPDU{
+			// ifIndex
+			{Name: ".1.3.6.1.2.1.2.2.1.1", Type: gosnmp.Integer, Value: 2},
+			// ifAdminStatus
+			{Name: ".1.3.6.1.2.1.2.2.1.7", Type: gosnmp.Integer, Value: 1},
+			// ifOperStatusjq
+			{Name: ".1.3.6.1.2.1.2.2.1.8", Type: gosnmp.Integer, Value: 2},
+		},
+	}
+	AlarmActiveStatev1SpecificTrap = gosnmp.SnmpTrap{
+		AgentAddress: "127.0.0.1",
+		Enterprise:   ".1.3.6.1.2.1.118",
+		GenericTrap:  6,
+		SpecificTrap: 2,
+		Timestamp:    1000,
+		Variables: []gosnmp.SnmpPDU{
+			// alarmActiveModelPointer
+			{Name: ".1.3.6.1.2.1.118.1.2.2.1.13", Type: gosnmp.OctetString, Value: []uint8{0x66, 0x6f, 0x6f}},
+			// alarmActiveResourceId
+			{Name: ".1.3.6.1.2.1.118.1.2.2.1.10", Type: gosnmp.OctetString, Value: []uint8{0x62, 0x61, 0x72}},
+		},
 	}
 )
 
@@ -70,17 +100,73 @@ func Configure(t *testing.T, trapConfig Config) {
 	require.NoError(t, err)
 }
 
+func sendTestV1GenericTrap(t *testing.T, trapConfig Config, community string) *gosnmp.GoSNMP {
+	params, err := trapConfig.BuildSNMPParams()
+	require.NoError(t, err)
+	params.Community = community
+	params.Timeout = 1 * time.Second // Must be non-zero when sending traps.
+	params.Retries = 1               // Must be non-zero when sending traps.
+	params.Version = gosnmp.Version1
+
+	err = params.Connect()
+	require.NoError(t, err)
+	defer params.Conn.Close()
+
+	_, err = params.SendTrap(LinkDownv1GenericTrap)
+	require.NoError(t, err)
+
+	return params
+}
+
+func sendTestV1SpecificTrap(t *testing.T, trapConfig Config, community string) *gosnmp.GoSNMP {
+	params, err := trapConfig.BuildSNMPParams()
+	require.NoError(t, err)
+	params.Community = community
+	params.Timeout = 1 * time.Second // Must be non-zero when sending traps.
+	params.Retries = 1               // Must be non-zero when sending traps.
+	params.Version = gosnmp.Version1
+
+	err = params.Connect()
+	require.NoError(t, err)
+	defer params.Conn.Close()
+
+	_, err = params.SendTrap(AlarmActiveStatev1SpecificTrap)
+	require.NoError(t, err)
+
+	return params
+}
+
 func sendTestV2Trap(t *testing.T, trapConfig Config, community string) *gosnmp.GoSNMP {
-	params := trapConfig.BuildV2Params()
+	params, err := trapConfig.BuildSNMPParams()
+	require.NoError(t, err)
 	params.Community = community
 	params.Timeout = 1 * time.Second // Must be non-zero when sending traps.
 	params.Retries = 1               // Must be non-zero when sending traps.
 
-	err := params.Connect()
+	err = params.Connect()
 	require.NoError(t, err)
 	defer params.Conn.Close()
 
-	trap := gosnmp.SnmpTrap{Variables: NetSNMPExampleHeartbeatNotificationVariables}
+	trap := NetSNMPExampleHeartbeatNotification
+	_, err = params.SendTrap(trap)
+	require.NoError(t, err)
+
+	return params
+}
+
+func sendTestV3Trap(t *testing.T, trapConfig Config, securityParams *gosnmp.UsmSecurityParameters) *gosnmp.GoSNMP {
+	params, err := trapConfig.BuildSNMPParams()
+	require.NoError(t, err)
+	params.MsgFlags = gosnmp.AuthPriv
+	params.SecurityParameters = securityParams
+	params.Timeout = 1 * time.Second // Must be non-zero when sending traps.
+	params.Retries = 1               // Must be non-zero when sending traps.
+
+	err = params.Connect()
+	require.NoError(t, err)
+	defer params.Conn.Close()
+
+	trap := NetSNMPExampleHeartbeatNotification
 	_, err = params.SendTrap(trap)
 	require.NoError(t, err)
 
@@ -109,7 +195,7 @@ func assertIsValidV2Packet(t *testing.T, packet *SnmpPacket, trapConfig Config) 
 	require.True(t, communityValid)
 }
 
-func assertV2Variables(t *testing.T, packet *SnmpPacket) {
+func assertVariables(t *testing.T, packet *SnmpPacket) {
 	variables := packet.Content.Variables
 	assert.Equal(t, 4, len(variables))
 

--- a/pkg/snmp/traps/validation.go
+++ b/pkg/snmp/traps/validation.go
@@ -7,14 +7,14 @@ package traps
 
 import (
 	"errors"
-	"fmt"
 
 	"github.com/gosnmp/gosnmp"
 )
 
-func validateCredentials(p *gosnmp.SnmpPacket, c *Config) error {
-	if p.Version != gosnmp.Version2c {
-		return fmt.Errorf("Unsupported version: %s", p.Version)
+func validatePacket(p *gosnmp.SnmpPacket, c *Config) error {
+	if p.Version == gosnmp.Version3 {
+		// v3 Packets are already decrypted and validated by gosnmp
+		return nil
 	}
 
 	// At least one of the known community strings must match.
@@ -24,5 +24,5 @@ func validateCredentials(p *gosnmp.SnmpPacket, c *Config) error {
 		}
 	}
 
-	return errors.New("Unknown community string")
+	return errors.New("unknown community string")
 }

--- a/releasenotes/notes/SNMP-Traps-Support-v1-and-v3-7ea83c24e9c37dff.yaml
+++ b/releasenotes/notes/SNMP-Traps-Support-v1-and-v3-7ea83c24e9c37dff.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    SNMP Trap Listener now also supports protocol versions 1 and 3 on top of the existing v2 support.


### PR DESCRIPTION
### What does this PR do?

Add support for v1 and v3 traps in the SNMP TrapsListener.

### Motivation

Better support for traps.

### Additional Notes

We currently only support a single v3 user because of a gosnmp limitation.
We currently are not able to listen for v3 informs because of a gosnmp limitation (being worked on upstream already) 

### Describe how to test/QA your changes

Run the trap listener with 
```yaml
api_key: ***************************
logs_enabled: true
snmp_traps_enabled: true
snmp_traps_config:
  port: 9162
  community_strings: ********
  users:
    - user: "user"
      authKey: ********
      authProtocol: "SHA"
      privKey: ********
      privProtocol: "AES"
```

Then send traps with snmptrapd like so:


```
snmptrap -v 1 -c public localhost:9162 1.3.6.1.4.1.8072.2.3.0.1 127.0.0.1 6 0 123456789 netSnmpExampleHeartbeatRate i 123456
snmptrap -v 2c -c public localhost:9162 '' NET-SNMP-EXAMPLES-MIB::netSnmpExampleHeartbeatNotification netSnmpExampleHeartbeatRate.3 i 1 netSnmpExampleHeartbeatRate i 4
snmptrap -v 3 -e 0x090807060504030201 -u userx -a SHA -A password -x AES -X password -l authPriv localhost:9162 '' netSnmpExampleHeartbeatNotification netSnmpExampleHeartbeatRate i 123456
```

You can also send an INFORM with 
```
snmptrap -v 3 -Ci -u user -a SHA -A password -x AES -X password -l authPriv localhost:9162 '' netSnmpExampleHeartbeatNotification netSnmpExampleHeartbeatRate i 123456
```
But as of this PR this does not work just yet (waiting on an gosnmp update)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
