### PR TITLE
Turn an error into a warning because the cause is not an agent malfunction

### DIFF
--- a/pkg/util/kubernetes/autoscalers/datadogexternal.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal.go
@@ -148,7 +148,7 @@ func (p *Processor) queryDatadogExternal(ddQueries []string, bucketSize int64) (
 
 	// If we add no series at all, return an error on top of invalid metrics
 	if len(seriesSlice) == 0 {
-		return processedMetrics, log.Errorf("Returned series slice empty")
+		return processedMetrics, log.Warnf("none of the queries %s returned any point, there might be an issue with them", query)
 	}
 
 	return processedMetrics, nil

--- a/pkg/util/kubernetes/autoscalers/datadogexternal_test.go
+++ b/pkg/util/kubernetes/autoscalers/datadogexternal_test.go
@@ -42,7 +42,7 @@ func TestDatadogExternalQuery(t *testing.T) {
 			},
 			[]string{"mymetric{foo:bar}"},
 			map[string]Point{"mymetric{foo:bar}": {Value: 0, Valid: false}},
-			fmt.Errorf("Returned series slice empty"),
+			fmt.Errorf("none of the queries mymetric{foo:bar} returned any point, there might be an issue with them"),
 		},
 		{
 			"metricName yields rate limiting error response from Datadog",


### PR DESCRIPTION
### What does this PR do?

Turn an error into a warning because its cause is external to the agent and the agent is properly handling this case. As nothing was wrong with the agent itself, logging an error was a little bit too stressful.

### Motivation

People were worried by this log:

```
2021-01-28 15:43:26 UTC | CLUSTER | ERROR | (pkg/util/kubernetes/autoscalers/datadogexternal.go:154 in queryDatadogExternal) | Returned series slice empty
```

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Try to trigger this condition by enabling the DCA external metrics server and define only HPA with queries returning nothing (by specifying wrong tags for ex.)

The error `Returned series slice empty` should be replaced by a warning `None of the queries … returned any point. There might be an issue with them.`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
