### PR TITLE
[install script] Set correct owner on datadog.yaml even if not created by us

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -617,10 +617,11 @@ else
       formatted_host_tags="['""$( echo "$host_tags" | sed "s/,/','/g" )""']"  # format `env:prod,foo:bar` to yaml-compliant `['env:prod','foo:bar']`
       $sudo_cmd sh -c "sed -i \"s/# tags:.*/tags: ""$formatted_host_tags""/\" $CONF"
   fi
-  $sudo_cmd chown dd-agent:dd-agent $CONF
-  $sudo_cmd chmod 640 $CONF
 fi
 
+$sudo_cmd chown dd-agent:dd-agent $CONF
+$sudo_cmd chmod 640 $CONF
+  
 # Creating or overriding the install information
 install_info_content="---
 install_method:

--- a/releasenotes-installscript/notes/install-script-always-set-conf-owner-2428685f03a2b982.yaml
+++ b/releasenotes-installscript/notes/install-script-always-set-conf-owner-2428685f03a2b982.yaml
@@ -8,4 +8,4 @@
 ---
 other:
   - |
-    The install script will set the owner and permissions of datadog.yaml even if the file exists beforehand.
+    The install script sets the owner and permissions of ``datadog.yaml`` even if the file exists beforehand.

--- a/releasenotes-installscript/notes/install-script-always-set-conf-owner-2428685f03a2b982.yaml
+++ b/releasenotes-installscript/notes/install-script-always-set-conf-owner-2428685f03a2b982.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    The install script will set the owner and permissions of datadog.yaml even if the file exists beforehand.


### PR DESCRIPTION
### What does this PR do?

Before we would only change the owner and permissions to the `datadog.yaml` file if we created it, but would not do anything if the file was already there. This sets the owner and permissions in both cases.

### Motivation

This allows creating the file before installing the Agent (so, before the `dd-agent` user exists), and still have the correct owner at the end of the installation.

This is useful for EBS, so we can use EBS' facilities to create the config before running the install script. Note: We could also create it later, but then we would need to restart the Agent, and the command to do that changes depending on the init system.

### Possible Drawbacks / Trade-offs

Could break someone's setup if they rely on some specific (more open) permissions set on the file after they run `install_script.sh`.
