### PR TITLE
[Serverless] Override all non-inferred span's service names

### DIFF
--- a/pkg/serverless/trace/span_modifier.go
+++ b/pkg/serverless/trace/span_modifier.go
@@ -17,10 +17,6 @@ type spanModifier struct {
 
 // Process applies extra logic to the given span
 func (s *spanModifier) ModifySpan(span *pb.Span) {
-	if span.Service == "aws.lambda" && s.tags["service"] != "" {
-		// service name could be incorrectly set to 'aws.lambda' in datadog lambda libraries
-		span.Service = s.tags["service"]
-	}
 	if inferredspan.CheckIsInferredSpan(span) {
 		log.Debug("Detected a managed service span, filtering out function tags")
 
@@ -29,6 +25,11 @@ func (s *spanModifier) ModifySpan(span *pb.Span) {
 		if spanMetadataTags != nil {
 			spanMetadataTags = inferredspan.FilterFunctionTags(spanMetadataTags)
 			span.Meta = spanMetadataTags
+		}
+	} else {
+		if s.tags["service"] != "" {
+			// service name could be incorrectly set to 'aws.lambda' in datadog lambda libraries
+			span.Service = s.tags["service"]
 		}
 	}
 }


### PR DESCRIPTION
### What does this PR do?

In nodejs.x runtime, we can have multiple service names in a trace.
For instance in the following screenshot, we can see the correct service name for the top level span, but an incorrect service name for the second span (where `http-client` has been appended) 

![nodejs-service](https://user-images.githubusercontent.com/864493/152599383-4a306395-d9fa-4480-aba1-ea075f89f155.png)

This PR fixes that by overriding all service in received spans (except the inferred ones)

![Screen Shot 2022-02-04 at 1 20 13 PM](https://user-images.githubusercontent.com/864493/152599584-a9fc22ef-4991-444f-a7ab-363a63b011c4.png)


### Motivation

feature parity between nodejs and python runtimes

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
