### PR TITLE
retry fetching EC2 tags

### DIFF
--- a/pkg/metadata/host/host_tags.go
+++ b/pkg/metadata/host/host_tags.go
@@ -108,7 +108,7 @@ func GetHostTags(ctx context.Context, cached bool) *Tags {
 	providers := make(map[string]*providerDef)
 
 	if config.Datadog.GetBool("collect_ec2_tags") {
-		providers["ec2"] = &providerDef{1, ec2.GetTags, false}
+		providers["ec2"] = &providerDef{10, ec2.GetTags, false}
 	}
 
 	if config.Datadog.GetBool("collect_gce_tags") {

--- a/releasenotes/notes/retry-ec2-collect-tags-b634a9fa2d49010c.yaml
+++ b/releasenotes/notes/retry-ec2-collect-tags-b634a9fa2d49010c.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    When ``ec2_collect_tags`` is configured, the agent will retry the API calls to gather those tags before giving up.
+    When ``ec2_collect_tags`` is configured, the Agent retries API calls to gather EC2 tags before giving up.

--- a/releasenotes/notes/retry-ec2-collect-tags-b634a9fa2d49010c.yaml
+++ b/releasenotes/notes/retry-ec2-collect-tags-b634a9fa2d49010c.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    When ``ec2_collect_tags`` is configured, the agent will retry the API calls to gather those tags before giving up.


### PR DESCRIPTION
### What does this PR do?

What it says on the tin

### Motivation

We've seen a few situations that might be caused by host metadata being sent without the tags, which might happen when EC2 returns an error from this API call.  EC2 APIs should always be retried anyway.

### Possible Drawbacks / Trade-offs

None

### Describe how to test/QA your changes

Enable `collect_ec2_tags` and set some tags on your ec2 instance, and then observe them in the app.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
