### PR TITLE
SNMP Traps: Add support for namespace

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -621,6 +621,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("snmp_traps_enabled", false)
 	config.BindEnvAndSetDefault("snmp_traps_config.port", 162)
 	config.BindEnvAndSetDefault("snmp_traps_config.community_strings", []string{})
+	// No default as the agent falls back to `network_devices.namespace` if empty.
+	config.BindEnv("snmp_traps_config.namespace")
 	config.BindEnvAndSetDefault("snmp_traps_config.bind_host", "localhost")
 	config.BindEnvAndSetDefault("snmp_traps_config.stop_timeout", 5) // in seconds
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -2807,6 +2807,18 @@ api_key:
 ## Network Devices Configuration ##
 ###################################
 
+## @param network_devices - custom object - optional
+## Configuration related to Network Devices Monitoring
+#
+# network_devices:
+
+  ## @param namespace - string - optional - default: default
+  ## Namespace can be used to disambiguate devices with the same IP.
+  ## Changing namespace will cause devices being recreated in NDM app.
+  ## This field is used by both the SNMP check and by the traps listener.
+  #
+  # namespace: default
+
 ## @param snmp_traps_enabled - boolean - optional - default: false
 ## Set to true to enable collection of traps.
 #

--- a/pkg/snmp/traps/constants.go
+++ b/pkg/snmp/traps/constants.go
@@ -8,6 +8,7 @@ package traps
 const (
 	defaultPort        = uint16(162) // Standard UDP port for traps.
 	defaultStopTimeout = 5
+	defaultNamespace   = "default"
 	packetsChanSize    = 100
 	genericTrapOid     = "1.3.6.1.6.3.1.1.5"
 )

--- a/pkg/snmp/traps/format.go
+++ b/pkg/snmp/traps/format.go
@@ -29,6 +29,7 @@ func FormatPacketToJSON(packet *SnmpPacket) (map[string]interface{}, error) {
 func GetTags(packet *SnmpPacket) []string {
 	return []string{
 		fmt.Sprintf("snmp_version:%s", formatVersion(packet)),
+		fmt.Sprintf("device_namespace:%s", GetNamespace()),
 		fmt.Sprintf("snmp_device:%s", packet.Addr.IP.String()),
 	}
 }

--- a/pkg/snmp/traps/format_test.go
+++ b/pkg/snmp/traps/format_test.go
@@ -167,6 +167,7 @@ func TestGetTags(t *testing.T) {
 	tags := GetTags(packet)
 	assert.Equal(t, tags, []string{
 		"snmp_version:2",
+		"device_namespace:default",
 		"snmp_device:127.0.0.1",
 	})
 }
@@ -177,6 +178,7 @@ func TestGetTagsForUnsupportedVersionShouldStillSucceed(t *testing.T) {
 	tags := GetTags(packet)
 	assert.Equal(t, tags, []string{
 		"snmp_version:unknown",
+		"device_namespace:default",
 		"snmp_device:127.0.0.1",
 	})
 }

--- a/pkg/snmp/traps/server.go
+++ b/pkg/snmp/traps/server.go
@@ -62,6 +62,14 @@ func GetPacketsChannel() PacketsChannel {
 	return serverInstance.packets
 }
 
+// GetNamespace returns the device namespace for the traps listener.
+func GetNamespace() string {
+	if serverInstance != nil {
+		return serverInstance.config.Namespace
+	}
+	return defaultNamespace
+}
+
 // NewTrapServer configures and returns a running SNMP traps server.
 func NewTrapServer(agentHostname string) (*TrapServer, error) {
 	config, err := ReadConfig(agentHostname)

--- a/pkg/snmp/traps/testing.go
+++ b/pkg/snmp/traps/testing.go
@@ -87,9 +87,19 @@ func GetPort(t *testing.T) uint16 {
 
 // Configure sets Datadog Agent configuration from a config object.
 func Configure(t *testing.T, trapConfig Config) {
+	ConfigureWithGlobalNamespace(t, trapConfig, "")
+}
+
+// ConfigureWithGlobalNamespace sets Datadog Agent configuration from a config object and a namespace
+func ConfigureWithGlobalNamespace(t *testing.T, trapConfig Config, globalNamespace string) {
 	datadogYaml := map[string]interface{}{
 		"snmp_traps_enabled": true,
 		"snmp_traps_config":  trapConfig,
+	}
+	if globalNamespace != "" {
+		datadogYaml["network_devices"] = map[string]interface{}{
+			"namespace": globalNamespace,
+		}
 	}
 
 	config.Datadog.SetConfigType("yaml")

--- a/releasenotes/notes/SNMP-Traps---support-namespace-f69befc242f23b0a.yaml
+++ b/releasenotes/notes/SNMP-Traps---support-namespace-f69befc242f23b0a.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Add support for the device_namespace tag in SNMP Traps.


### PR DESCRIPTION
Add support for the `device_namespace` tag in the traps listener