### PR TITLE
[workloadmeta] Don't generate events with nil entities

### DIFF
--- a/pkg/workloadmeta/store.go
+++ b/pkg/workloadmeta/store.go
@@ -460,16 +460,21 @@ func (s *store) handleEvents(evs []CollectorEvent) {
 				continue
 			}
 
-			entityOfSource := s.store[entityID.Kind][entityID.ID]
+			entityOfSource, ok := s.store[entityID.Kind][entityID.ID]
 			filteredSources, _ := filter.SelectSources(entityOfSource.sources())
 
-			if ev.Type == EventTypeSet || len(filteredSources) > 0 {
+			var entity Entity
+			if ok && len(filteredSources) > 0 {
+				entity = entityOfSource.merge(filteredSources)
+			}
+
+			if ev.Type == EventTypeSet || entity != nil {
 				// setting an entity (EventTypeSet) or entity
 				// had one source removed, but others remain
 				filteredEvents = append(filteredEvents, Event{
 					Type:    EventTypeSet,
 					Sources: filteredSources,
-					Entity:  entityOfSource.merge(filteredSources),
+					Entity:  entity,
 				})
 
 			} else {


### PR DESCRIPTION
### What does this PR do?

It's possible that `merge` returns a `nil` entity if the sources present
in `filteredSources` have also been deleted. This prevents the
generation of a `EventTypeSet` with a `nil` entity, and sends an
`EventTypeUnset` instead.

This same issue is addressed by #10331 here: https://github.com/DataDog/datadog-agent/pull/10331/files#diff-6ed7857f2afad2e0b2b69a81ac6dcda1e94a5a489dab1b7b6932501d91de2c83R429-R436

### Describe how to test/QA your changes

This has already been QA'ed in staging. It's difficult to reproduce, as it requires two collectors deleting the same entity in a specific order, but it the effect of the bug itself can be observed whenever the tagger panics with a `nil` entity.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
