### PR TITLE
[codeowners] config_template.yaml: change from agent-all to agent-core

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -164,7 +164,7 @@
 /pkg/collector/corechecks/system/       @DataDog/agent-platform
 /pkg/collector/corechecks/systemd/      @DataDog/agent-integrations
 /pkg/collector/corechecks/nvidia/       @DataDog/agent-platform
-/pkg/config/config_template.yaml        @DataDog/agent-all @DataDog/documentation
+/pkg/config/config_template.yaml        @DataDog/agent-core @DataDog/documentation
 /pkg/config/apm.go                      @DataDog/agent-apm
 /pkg/config/autodiscovery/              @Datadog/container-integrations
 /pkg/config/environment*.go             @DataDog/container-integrations @DataDog/container-app


### PR DESCRIPTION
### What does this PR do?

Change codeowners file so not every single team receives a notification when the `datadog.yaml` template changes.

### Motivation

Notifications when that file changes are not relevant to most teams. Some people from Agent Core expressed interest in continue receiving those, so I've left Agent Core in.
