### PR TITLE
[CWS] Fix security module startup on 4.14 and 4.15 kernels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -71,7 +71,7 @@ require (
 	github.com/DataDog/datadog-agent/pkg/util/winutil v0.34.0-rc.7
 	github.com/DataDog/datadog-go v4.8.3+incompatible
 	github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a
-	github.com/DataDog/ebpf-manager v0.0.0-20220106215052-9189b77594bb
+	github.com/DataDog/ebpf-manager v0.0.0-20220125102432-266fda150ee4
 	github.com/DataDog/gohai v0.0.0-20220112164844-3f118982b8ef
 	github.com/DataDog/gopsutil v0.0.0-20211112180027-9aa392ae181a
 	github.com/DataDog/mmh3 v0.0.0-20210722141835-012dc69a9e49 // indirect

--- a/go.sum
+++ b/go.sum
@@ -116,8 +116,8 @@ github.com/DataDog/datadog-go v4.8.3+incompatible h1:fNGaYSuObuQb5nzeTQqowRAd9bp
 github.com/DataDog/datadog-go v4.8.3+incompatible/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a h1:vqz6k806rvz01tIzOA2UHE3j1IEAMcDxw8O+nA3H+Mk=
 github.com/DataDog/datadog-operator v0.5.0-rc.2.0.20210402083916-25ba9a22e67a/go.mod h1:2qOvG41jii2ks6Umn6MbDGlHRgwoFiYXcjgQQ9VlsS0=
-github.com/DataDog/ebpf-manager v0.0.0-20220106215052-9189b77594bb h1:nUsDJ5s9zoxwL1RpsxrcTQOop4oa9FU8IDGYVDEgaIY=
-github.com/DataDog/ebpf-manager v0.0.0-20220106215052-9189b77594bb/go.mod h1:q6FEcnn+mlqeRyd+nNN/xuoHfVKVsZav5k3xEIQxkpI=
+github.com/DataDog/ebpf-manager v0.0.0-20220125102432-266fda150ee4 h1:zSuIvvR1UXERGq7df54+yzT7764KYNwcckprZ/fM7Zc=
+github.com/DataDog/ebpf-manager v0.0.0-20220125102432-266fda150ee4/go.mod h1:q6FEcnn+mlqeRyd+nNN/xuoHfVKVsZav5k3xEIQxkpI=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c h1:a9OMhZzrrB4nd2eAsXZIBkQ061Gb/QT4CI2g+OWWevs=
 github.com/DataDog/extendeddaemonset v0.5.1-0.20210315105301-41547d4ff09c/go.mod h1:lMIXf2EAzxbIv2zEvWu1bdqlaclUWoCtN13MHuPcY5I=
 github.com/DataDog/gohai v0.0.0-20220112164844-3f118982b8ef h1:6iRmwthm4+IxdzST08yD3MjJCPughK5afDsTSy+84iw=

--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -3,4 +3,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "74721ac79df4d9e855d4d0e324fa89f93f2d782908fb0cf90d37983a6a285198")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "41dc5962f7791499a212cf2193c06e9e1795f046c6144fa287750858c49fc8d8")

--- a/pkg/security/ebpf/c/bpf.h
+++ b/pkg/security/ebpf/c/bpf.h
@@ -85,14 +85,18 @@ __attribute__((always_inline)) void save_obj_fd(struct syscall_cache_t *syscall)
         .fd = syscall->bpf.retval,
     };
 
+    u32 id = 0;
+
     switch (syscall->bpf.cmd) {
     case BPF_MAP_CREATE:
     case BPF_MAP_GET_FD_BY_ID:
-        bpf_map_update_elem(&tgid_fd_map_id, &key, &syscall->bpf.map_id, BPF_ANY);
+        id = syscall->bpf.map_id;
+        bpf_map_update_elem(&tgid_fd_map_id, &key, &id, BPF_ANY);
         break;
     case BPF_PROG_LOAD:
     case BPF_PROG_GET_FD_BY_ID:
-        bpf_map_update_elem(&tgid_fd_prog_id, &key, &syscall->bpf.prog_id, BPF_ANY);
+        id = syscall->bpf.prog_id;
+        bpf_map_update_elem(&tgid_fd_prog_id, &key, &id, BPF_ANY);
         break;
     }
 }
@@ -224,9 +228,12 @@ __attribute__((always_inline)) void send_bpf_event(void *ctx, struct syscall_cac
     fill_container_context(entry, &event.container);
     fill_span_context(&event.span);
 
+    u32 id = 0;
+
     // select map if applicable
     if (syscall->bpf.map_id != 0) {
-        struct bpf_map_t *map = bpf_map_lookup_elem(&bpf_maps, &syscall->bpf.map_id);
+        id = syscall->bpf.map_id;
+        struct bpf_map_t *map = bpf_map_lookup_elem(&bpf_maps, &id);
         if (map != NULL) {
             event.map = *map;
         }
@@ -234,7 +241,8 @@ __attribute__((always_inline)) void send_bpf_event(void *ctx, struct syscall_cac
 
     // select prog if applicable
     if (syscall->bpf.prog_id != 0) {
-        struct bpf_prog_t *prog = bpf_map_lookup_elem(&bpf_progs, &syscall->bpf.prog_id);
+        id = syscall->bpf.prog_id;
+        struct bpf_prog_t *prog = bpf_map_lookup_elem(&bpf_progs, &id);
         if (prog != NULL) {
             event.prog = *prog;
         }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix security module startup on 4.14 and 4.15 kernels

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

The eBPF verifier complains and refuses to load the eBPF CWS programs on
4.14 and 4.15 kernels.

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
