### PR TITLE
Try fetching EC2 tags from IMDS

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -656,6 +656,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("ec2_metadata_token_lifetime", 21600) // value in seconds
 	config.BindEnvAndSetDefault("ec2_prefer_imdsv2", false)
 	config.BindEnvAndSetDefault("collect_ec2_tags", false)
+	config.BindEnvAndSetDefault("collect_ec2_tags_use_imds", false)
 
 	// ECS
 	config.BindEnvAndSetDefault("ecs_agent_url", "") // Will be autodetected

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -332,11 +332,11 @@ api_key:
 ## @param collect_ec2_tags - boolean - optional - default: false
 ## @env DD_COLLECT_EC2_TAGS - boolean - optional - default: false
 ## Collect AWS EC2 custom tags as host tags.
-## Requires either:
-##  - the EC2 instance to have an IAM role with the `EC2:DescribeTags`
-##    permission; or
-##  - the EC2 instance to allow tags in instance metadata and
-##    `collect_ec2_tags_use_imds`
+## Requires one of:
+##  - `collect_ec2_tags_use_imds: true` and configuration of the
+##    EC2 instance to allow tags in instance metadata; or
+##  - configuration of the EC2 instance to have an IAM role with
+##    the `EC2:DescribeTags` permission.
 ## See docs for further details:
 ## https://docs.datadoghq.com/integrations/faq/how-do-i-pull-my-ec2-tags-without-using-the-aws-integration/
 #

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -332,11 +332,22 @@ api_key:
 ## @param collect_ec2_tags - boolean - optional - default: false
 ## @env DD_COLLECT_EC2_TAGS - boolean - optional - default: false
 ## Collect AWS EC2 custom tags as host tags.
-## Requires the EC2 instance to have an IAM role with the `EC2:DescribeTags`
-## permission. See docs for further details:
+## Requires either:
+##  - the EC2 instance to have an IAM role with the `EC2:DescribeTags`
+##    permission; or
+##  - the EC2 instance to allow tags in instance metadata and
+##    `collect_ec2_tags_use_imds`
+## See docs for further details:
 ## https://docs.datadoghq.com/integrations/faq/how-do-i-pull-my-ec2-tags-without-using-the-aws-integration/
 #
 # collect_ec2_tags: false
+
+## @param collect_ec2_tags_use_imds - boolean - optional - default: false
+## @env DD_COLLECT_EC2_TAGS_USE_IMDS - boolean - optional - default: false
+## Use instance metadata service (IMDS) instead of EC2 API to collect AWS EC2 custom tags.
+## Requires `collect_ec2_tags`.
+#
+# collect_ec2_tags_use_imds: false
 
 ## @param ec2_metadata_timeout - integer - optional - default: 300
 ## @env DD_EC2_METADATA_TIMEOUT - integer - optional - default: 300

--- a/pkg/util/ec2/ec2_tags.go
+++ b/pkg/util/ec2/ec2_tags.go
@@ -59,6 +59,13 @@ func fetchEc2TagsFromIMDS(ctx context.Context) ([]string, error) {
 
 	tags := []string{}
 	for _, key := range keys {
+		// The key is a valid URL component and need not be escaped:
+		//
+		// https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#tag-restrictions
+		// > If you enable instance tags in instance metadata, instance tag
+		// > keys can only use letters (a-z, A-Z), numbers (0-9), and the
+		// > following characters: -_+=,.@:. Instance tag keys can't use spaces,
+		// > /, or the reserved names ., .., or _index.
 		val, err := getMetadataItem(ctx, "/tags/instance/"+key)
 		if err != nil {
 			return nil, err

--- a/pkg/util/ec2/ec2_tags.go
+++ b/pkg/util/ec2/ec2_tags.go
@@ -37,7 +37,7 @@ func fetchEc2Tags(ctx context.Context) ([]string, error) {
 			return tags, nil
 		}
 
-		log.Debugf("Could not fetech tags from instance metadata (trying EC2 API instead): %s", err)
+		log.Debugf("Could not fetch tags from instance metadata (trying EC2 API instead): %s", err)
 	}
 
 	tags, err := fetchEc2TagsFromAPI(ctx)

--- a/pkg/util/ec2/ec2_tags.go
+++ b/pkg/util/ec2/ec2_tags.go
@@ -40,12 +40,7 @@ func fetchEc2Tags(ctx context.Context) ([]string, error) {
 		log.Debugf("Could not fetch tags from instance metadata (trying EC2 API instead): %s", err)
 	}
 
-	tags, err := fetchEc2TagsFromAPI(ctx)
-	if err == nil {
-		return tags, err
-	}
-
-	return nil, err
+	return fetchEc2TagsFromAPI(ctx)
 }
 
 func fetchEc2TagsFromIMDS(ctx context.Context) ([]string, error) {

--- a/pkg/util/ec2/ec2_tags.go
+++ b/pkg/util/ec2/ec2_tags.go
@@ -57,7 +57,7 @@ func fetchEc2TagsFromIMDS(ctx context.Context) ([]string, error) {
 	// keysStr is a newline-separated list of strings containing tag keys
 	keys := strings.Split(keysStr, "\n")
 
-	tags := []string{}
+	tags := make([]string, 0, len(keys))
 	for _, key := range keys {
 		// The key is a valid URL component and need not be escaped:
 		//

--- a/releasenotes/notes/ec2-collect-tags-imds-31d8488b7337a24a.yaml
+++ b/releasenotes/notes/ec2-collect-tags-imds-31d8488b7337a24a.yaml
@@ -1,0 +1,8 @@
+---
+enhancements:
+  - |
+    When ``ec2_collect_tags`` is enabled, the Agent now attempts to fetch data
+    from the instance metadata service, falling back to the existing
+    EC2-API-based method of fetching tags.  Support for tags in the instance
+    metadata service is an opt-in EC2 feature, so this functionality will
+    not work automatically.


### PR DESCRIPTION
### What does this PR do?

EC2 now has opt-in availability of tags in an instance's metadata.

With this change, when `ec2_collect_tags` is enabled, the Agent attempts
to fetch data from this service, falling back to the existing
EC2-API-based method of fetching tags.

### Motivation

Easier setup for customers, avoiding the need for an instance role.

### Additional Notes

This will need a docs update.

### Possible Drawbacks / Trade-offs

If the IMDS is firewalled off, this may slow down fetching tags, as it waits for the connection to timeout.

### Describe how to test/QA your changes

Existing functionality: Run the agent on an EC2 instance that does not allow access to tags via IMDS, but which has tags.  Set `log_level` to debug and `ec2_collect_tags` to true.  Observe "Could not fetch tags from instance metadata" in the logs, and note that the tags appear in the app nonetheless (after some minutes to propagate).

New functionality: Run the agent on a _different_ EC2 instance, configured to allow access to tags via IMDS, with the same settings.  Observe that the debug log message does not appear, and that the tags appear in the app.

https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html#work-with-tags-in-IMDS

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
