### PR TITLE
[CWS] fix `TestFallbackConstants`

### DIFF
--- a/pkg/security/probe/constantfetch/runtime_compiled.go
+++ b/pkg/security/probe/constantfetch/runtime_compiled.go
@@ -107,9 +107,11 @@ func (cf *RuntimeCompilationConstantFetcher) compileConstantFetcher(config *ebpf
 	runtimeCompiler := runtime.NewRuntimeCompiler()
 	reader, err := runtimeCompiler.CompileObjectFile(config, additionalFlags, "constant_fetcher.c", provider)
 
-	telemetry := runtimeCompiler.GetRCTelemetry()
-	if err := telemetry.SendMetrics(cf.statsdClient); err != nil {
-		log.Errorf("failed to send telemetry for runtime compilation of constants: %v", err)
+	if cf.statsdClient != nil {
+		telemetry := runtimeCompiler.GetRCTelemetry()
+		if err := telemetry.SendMetrics(cf.statsdClient); err != nil {
+			log.Errorf("failed to send telemetry for runtime compilation of constants: %v", err)
+		}
 	}
 
 	return reader, err

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1055,7 +1055,11 @@ func (p *Probe) ensureConfigDefaults() {
 // GetOffsetConstants returns the offsets and struct sizes constants
 func GetOffsetConstants(config *config.Config, probe *Probe) (map[string]uint64, error) {
 	constantFetcher := constantfetch.ComposeConstantFetchers(constantfetch.GetAvailableConstantFetchers(config, probe.kernelVersion, probe.statsdClient))
+	return GetOffsetConstantsFromFetcher(constantFetcher)
+}
 
+// GetOffsetConstantsFromFetcher returns the offsets and struct sizes constants, from a constant fetcher
+func GetOffsetConstantsFromFetcher(constantFetcher constantfetch.ConstantFetcher) (map[string]uint64, error) {
 	constantFetcher.AppendSizeofRequest("sizeof_inode", "struct inode", "linux/fs.h")
 	constantFetcher.AppendOffsetofRequest("sb_magic_offset", "struct super_block", "s_magic", "linux/fs.h")
 	constantFetcher.AppendOffsetofRequest("tty_offset", "struct signal_struct", "tty", "linux/sched/signal.h")

--- a/pkg/security/tests/runtime_compiled_constants_test.go
+++ b/pkg/security/tests/runtime_compiled_constants_test.go
@@ -25,8 +25,9 @@ func TestFallbackConstants(t *testing.T) {
 	defer test.Close()
 
 	config := test.config
-	config.RuntimeCompiledConstantsIsSet = true
 	config.EnableRuntimeCompiledConstants = false
+
+	constantfetch.ClearConstantsCache()
 
 	withoutRC, err := probe.GetOffsetConstants(config, test.probe)
 	if err != nil {

--- a/pkg/security/tests/runtime_compiled_constants_test.go
+++ b/pkg/security/tests/runtime_compiled_constants_test.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
-// +build functionaltests
+//go:build functionaltests && linux_bpf
+// +build functionaltests,linux_bpf
 
 package tests
 
@@ -24,25 +24,26 @@ func TestFallbackConstants(t *testing.T) {
 	}
 	defer test.Close()
 
+	kv, err := test.probe.GetKernelVersion()
+	if err != nil {
+		t.Fatal(err)
+	}
 	config := test.config
-	config.EnableRuntimeCompiledConstants = false
 
-	constantfetch.ClearConstantsCache()
+	fallbackFetcher := constantfetch.NewFallbackConstantFetcher(kv)
+	rcFetcher := constantfetch.NewRuntimeCompilationConstantFetcher(&config.Config, nil)
 
-	withoutRC, err := probe.GetOffsetConstants(config, test.probe)
+	fallbackConstants, err := probe.GetOffsetConstantsFromFetcher(fallbackFetcher)
 	if err != nil {
 		t.Error(err)
 	}
 
-	constantfetch.ClearConstantsCache()
-
-	config.EnableRuntimeCompiledConstants = true
-	withRC, err := probe.GetOffsetConstants(config, test.probe)
+	rcConstants, err := probe.GetOffsetConstantsFromFetcher(rcFetcher)
 	if err != nil {
 		t.Error(err)
 	}
 
-	if !assert.Equal(t, withoutRC, withRC) {
+	if !assert.Equal(t, fallbackConstants, rcConstants) {
 		kernelVersion, err := test.probe.GetKernelVersion()
 		if err != nil {
 			t.Error("failed to get probe kernel version")


### PR DESCRIPTION
### What does this PR do?

This PR fixes and improve the `TestFallbackConstants`, ensuring that it actually tests what it is supposed to test 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
