### PR TITLE
Use net.ErrClosed, new in go1.16

### DIFF
--- a/pkg/logs/client/tcp/connection_manager.go
+++ b/pkg/logs/client/tcp/connection_manager.go
@@ -8,12 +8,12 @@ package tcp
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io"
 	"math/rand"
 	"net"
 	"strconv"
-	"strings"
 	"sync"
 	"time"
 
@@ -166,8 +166,7 @@ func (cm *ConnectionManager) handleServerClose(conn net.Conn) {
 		_, err := conn.Read(buff)
 		switch {
 		case err == nil:
-		case strings.Contains(err.Error(), "use of closed network connection"):
-			// TODO: in go1.16+, match the newly-exported `net.ErrClosed` error instead.
+		case errors.Is(err, net.ErrClosed):
 			// Connection already closed, expected
 			return
 		case err == io.EOF:


### PR DESCRIPTION
### What does this PR do?

Use a new, defined error to detect when `net.Conn#Read` is called on a `net.Conn` that has been closed locally, instead of matching the string form of the error.

### Motivation

Hygeiene

### Describe how to test/QA your changes

Set up an agent to submit logs via TCP, with `logs_config.connection_reset_interval` set to `5` (seconds), and `log_level` debug.  Set up some logging and observe "Connection closed" every five seconds, and no WARN-level logging about connection failures.

```yaml
logs_enabled: true
logs_config:
  use_http: false
  use_tcp: true
  container_collect_all: true
  connection_reset_interval: 5
log_level: DEBUG
```

...and start a container

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
