### PR TITLE
[MacOS install script] Change install_tool from install_script to install_script_mac

### DIFF
--- a/cmd/agent/install_mac_os.sh
+++ b/cmd/agent/install_mac_os.sh
@@ -144,7 +144,7 @@ $sudo_cmd hdiutil detach "/Volumes/datadog_agent" >/dev/null
 # Creating or overriding the install information
 install_info_content="---
 install_method:
-  tool: install_script
+  tool: install_script_mac
   tool_version: install_script_mac
   installer_version: install_script_mac-$install_script_version
 "


### PR DESCRIPTION
### What does this PR do?
Change `install_tool` from `install_script` to `install_script_mac` on the MacOS install script

### Motivation
To not mix it with the Linux install script.


