### PR TITLE
[AD] Prevent workloadmeta listeners from hanging at shutdown

### DIFF
--- a/pkg/autodiscovery/listeners/workloadmeta.go
+++ b/pkg/autodiscovery/listeners/workloadmeta.go
@@ -165,7 +165,7 @@ func (l *workloadmetaListenerImpl) Listen(newSvc chan<- Service, delSvc chan<- S
 }
 
 func (l *workloadmetaListenerImpl) Stop() {
-	l.stop <- struct{}{}
+	close(l.stop)
 }
 
 func (l *workloadmetaListenerImpl) processEvents(evBundle workloadmeta.EventBundle, creationTime integration.CreationTime) {


### PR DESCRIPTION
### What does this PR do?

When the agent shuts down, one of the first things it does is to cancel
the `MainCtx`, that since recently is propagated to the workloadmeta
store, so that it can shutdown as well. As workloadmeta shuts down, it
cancels all of its subscriptions, and in AutoDiscovery that means that
listeners shut down with it.

While all of this is happening, the agent also tells AD to stop itself,
and part of that is to tell each listener to stop with it. Since the
workloadmeta listeners may have already shut down, a send on the
unbuffered `l.stop` hangs, as the receive loop has stopped. This makes
the entire agent shutdown process to hang as well.

Since there's exactly one call to `Stop`, it's safe to just close the
channel. As it's actually *not* expected to be called more than once,
the possible panic that a second call can cause is actually desired so
the bug is apparent.

### Describe how to test/QA your changes

The agent hanging on shutdown was a race condition, so test this several times to be sure. Killing the container won't trigger it, so you need to `kill -s SIGINT` the `agent run` process (or Ctrl-C if you're running the agent on foreground).

Adding the QA skip label since i amended the [original PR's](https://github.com/DataDog/datadog-agent/pull/10567) QA instructions.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
