### PR TITLE
[CWS] runtime compiled constants: convert file hash to base32 when building the path

### DIFF
--- a/pkg/security/probe/constantfetch/runtime_compiled.go
+++ b/pkg/security/probe/constantfetch/runtime_compiled.go
@@ -188,7 +188,7 @@ func (a *constantFetcherRCProvider) GetOutputFilePath(config *ebpf.Config, kerne
 	}
 	cCodeHash := hasher.Sum(nil)
 	// base32 is only [A-V0-9]+
-	cCodeHashB32 := base32.StdEncoding.EncodeToString(cCodeHash)
+	cCodeHashB32 := base32.StdEncoding.WithPadding(base32.NoPadding).EncodeToString(cCodeHash)
 
 	return filepath.Join(config.RuntimeCompilerOutputDir, fmt.Sprintf("constant_fetcher-%d-%s-%s.o", kernelVersion, cCodeHashB32, flagHash)), nil
 }

--- a/pkg/security/probe/constantfetch/runtime_compiled.go
+++ b/pkg/security/probe/constantfetch/runtime_compiled.go
@@ -12,6 +12,7 @@ import (
 	"bytes"
 	"crypto/sha256"
 	"debug/elf"
+	"encoding/base32"
 	"fmt"
 	"io"
 	"path/filepath"
@@ -186,8 +187,10 @@ func (a *constantFetcherRCProvider) GetOutputFilePath(config *ebpf.Config, kerne
 		return "", err
 	}
 	cCodeHash := hasher.Sum(nil)
+	// base32 is only [A-V0-9]+
+	cCodeHashB32 := base32.StdEncoding.EncodeToString(cCodeHash)
 
-	return filepath.Join(config.RuntimeCompilerOutputDir, fmt.Sprintf("constant_fetcher-%d-%s-%s.o", kernelVersion, cCodeHash, flagHash)), nil
+	return filepath.Join(config.RuntimeCompilerOutputDir, fmt.Sprintf("constant_fetcher-%d-%s-%s.o", kernelVersion, cCodeHashB32, flagHash)), nil
 }
 
 func sortAndDedup(in []string) []string {


### PR DESCRIPTION
### What does this PR do?

The hash of the C code was currently used directly to build a filepath, thus resulting in edge cases where `/` would be in the hash and thus would break the expected location. This PR fixes this by incorporating the hash, but converted into base 32.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
