### PR TITLE
[CWS] fix agent rules documentation README and docker workflow

### DIFF
--- a/docs/cloud-workload-security/README.md
+++ b/docs/cloud-workload-security/README.md
@@ -118,6 +118,7 @@ Make an edit to any of the files mentioned above and then, from the root of the 
 - Golang (see `go.mod` for the minimal version supported)
 - Python
 	- `pip install -r requirements.txt` to install dependencies
+	- `pip install -r docs/cloud-workload-security/scripts/requirements-docs.txt` to install dependencies
 
 
 #### Steps

--- a/docs/cloud-workload-security/README.md
+++ b/docs/cloud-workload-security/README.md
@@ -25,7 +25,7 @@ docs/cloud-workload-security/
 
 The Agent expressions documentation is based on the following files:
 
-- `pkg/security/model/model.go` - the source code of the SECL model containing the event types and fields documentation
+- `pkg/security/secl/model/model.go` - the source code of the SECL model containing the event types and fields documentation
 - `docs/cloud-workload-security/secl.json` - the JSON representing the SECL model extracted from the source code
 - `docs/cloud-workload-security/scripts/templates/agent_expressions.md` - the template used for the final generation
 
@@ -125,7 +125,7 @@ Make an edit to any of the files mentioned above and then, from the root of the 
 If a `*.go` file in `pkg/security` has been edited you will first need to generate the `*.json` files.
 Please run:
 ```sh
-go generate ./pkg/security/...
+inv -e security-agent.cws-go-generate
 # or only the specific file
 go generate ./path/to/the/touched/file
 ```

--- a/docs/cloud-workload-security/README.md
+++ b/docs/cloud-workload-security/README.md
@@ -116,9 +116,9 @@ Make an edit to any of the files mentioned above and then, from the root of the 
 #### Requirements
 
 - Golang (see `go.mod` for the minimal version supported)
-- Python
-	- `pip install -r requirements.txt` to install dependencies
-	- `pip install -r docs/cloud-workload-security/scripts/requirements-docs.txt` to install dependencies
+- Python, install dependencies with:
+	- `pip install -r requirements.txt`
+	- `pip install -r docs/cloud-workload-security/scripts/requirements-docs.txt`
 
 
 #### Steps
@@ -131,7 +131,7 @@ inv -e security-agent.cws-go-generate
 go generate ./path/to/the/touched/file
 ```
 
-To generate the final markdown files (at the root of `docs/cloud-workload-security`) please run:
+To generate the final markdown files please run:
 ```sh
 inv -e security-agent.generate-cws-documentation
 ```

--- a/docs/cloud-workload-security/scripts/Dockerfile
+++ b/docs/cloud-workload-security/scripts/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.16-buster
+FROM golang:1.17-buster
 
 ENV DEBIAN_FRONTEND noninteractive
 ENV GOPATH /go
@@ -22,5 +22,6 @@ WORKDIR $GOPATH/src/github.com/DataDog/datadog-agent
 
 COPY requirements.txt requirements.txt
 COPY docs/cloud-workload-security/scripts/requirements-docs.txt requirements-docs.txt
+RUN python3 -m pip install wheel
 RUN python3 -m pip install -r requirements.txt
 RUN python3 -m pip install -r requirements-docs.txt


### PR DESCRIPTION
### What does this PR do?

This PR fixes the readme and the docker workflow used to generate CWS agent rules documentation

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
