### PR TITLE
[install_script] Dogstatsd can be installed on aarch64 since 7.35

### DIFF
--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -308,9 +308,15 @@ if [[ `uname -m` == "armv7l" ]] && [[ $agent_flavor == "datadog-agent" ]]; then
     exit 1;
 fi
 
-if [[ `uname -m` != "x86_64" ]] && [[ $agent_flavor == "datadog-dogstatsd" ]]; then
-    printf "\033[31mThe $nice_flavor is only available for x86_64 architecture.\033[0m\n"
-    exit 1;
+if [[ "$agent_flavor" == "datadog-dogstatsd" ]]; then
+    if [[ `uname -m` == "armv7l" ]]; then
+        printf "\033[31mThe $nice_flavor isn't available for your architecture (armv7l).\033[0m\n"
+        exit 1;
+    fi
+    if  [[ `uname -m` == "aarch64" ]] && { [[ -n "$agent_minor_version" ]] && [[ "$agent_minor_version" -lt 35 ]]; }; then
+        printf "\033[31mThe $nice_flavor is only available since version 7.35.0 for your architecture (aarch64).\033[0m\n"
+        exit 1;
+    fi
 fi
 
 # OS/Distro Detection

--- a/cmd/agent/install_script.sh
+++ b/cmd/agent/install_script.sh
@@ -308,17 +308,6 @@ if [[ `uname -m` == "armv7l" ]] && [[ $agent_flavor == "datadog-agent" ]]; then
     exit 1;
 fi
 
-if [[ "$agent_flavor" == "datadog-dogstatsd" ]]; then
-    if [[ `uname -m` == "armv7l" ]]; then
-        printf "\033[31mThe $nice_flavor isn't available for your architecture (armv7l).\033[0m\n"
-        exit 1;
-    fi
-    if  [[ `uname -m` == "aarch64" ]] && { [[ -n "$agent_minor_version" ]] && [[ "$agent_minor_version" -lt 35 ]]; }; then
-        printf "\033[31mThe $nice_flavor is only available since version 7.35.0 for your architecture (aarch64).\033[0m\n"
-        exit 1;
-    fi
-fi
-
 # OS/Distro Detection
 # Try lsb_release, fallback with /etc/issue then uname command
 KNOWN_DISTRIBUTION="(Debian|Ubuntu|RedHat|CentOS|openSUSE|Amazon|Arista|SUSE|Rocky|AlmaLinux)"
@@ -343,6 +332,17 @@ elif [ -f /etc/Eos-release ] || [ "$DISTRIBUTION" == "Arista" ]; then
 # openSUSE and SUSE use /etc/SuSE-release or /etc/os-release
 elif [ -f /etc/SuSE-release ] || [ "$DISTRIBUTION" == "SUSE" ] || [ "$DISTRIBUTION" == "openSUSE" ]; then
     OS="SUSE"
+fi
+
+if [[ "$agent_flavor" == "datadog-dogstatsd" ]]; then
+    if [[ `uname -m` == "armv7l" ]] || { [[ `uname -m` != "x86_64" ]] && [[ "$OS" != "Debian" ]]; }; then
+        printf "\033[31mThe $nice_flavor isn't available for your architecture.\033[0m\n"
+        exit 1;
+    fi
+    if  [[ "$OS" == "Debian" ]] && [[ `uname -m` == "aarch64" ]] && { [[ -n "$agent_minor_version" ]] && [[ "$agent_minor_version" -lt 35 ]]; }; then
+        printf "\033[31mThe $nice_flavor is only available since version 7.35.0 for your architecture.\033[0m\n"
+        exit 1;
+    fi
 fi
 
 # Root user detection


### PR DESCRIPTION
### What does this PR do?

Allows installing dogstatsd on aarch64 since 7.35.

### Motivation

Being able to install dogstatsd on aarch64 Debian (builds added in https://github.com/DataDog/datadog-agent/pull/10574)

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

* Ensure dogstatsd can be installed on aarch64 Debian machine through install script
* Ensure that specifying `DD_AGENT_MINOR_VERSION` < 35 on aarch64 Debian fails with a meaningful error message
* Ensure there's a failure with proper error message on aarch64 on RedHat or SUSE

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
