### PR TITLE
[tagger] Prevent panic on double closed channel

### DIFF
--- a/pkg/tagger/subscriber/subscriber.go
+++ b/pkg/tagger/subscriber/subscriber.go
@@ -63,10 +63,11 @@ func (s *Subscriber) Unsubscribe(ch chan []types.EntityEvent) {
 // unsubscribe ends a subscription to entity events and closes its channel. It
 // is not thread-safe, and callers should take care of synchronization.
 func (s *Subscriber) unsubscribe(ch chan []types.EntityEvent) {
-	defer telemetry.Subscribers.Dec()
-
-	delete(s.subscribers, ch)
-	close(ch)
+	if _, ok := s.subscribers[ch]; ok {
+		telemetry.Subscribers.Dec()
+		delete(s.subscribers, ch)
+		close(ch)
+	}
 }
 
 // Notify sends a slice of EntityEvents to all registered subscribers at their


### PR DESCRIPTION
### What does this PR do?

When a remote tagger is unable to receive updates from the core agent,
its channel fills up and gets closed automatically by the upstream. When
that happens, the subscription in the gRPC server also unsubscribes,
resulting in a double close. To prevent that, we check that we still
have the channel in the list of subscriptions instead of blindly closing
the passed in `ch`.

### Describe how to test/QA your changes

This is a very rare condition on an agent that's running properly. This is best QA'd by observing that the panics are gone in staging (especially large or malfunctioning clusters).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
