### PR TITLE
feat(dogstatsd): add dd_tags to dogstatsd metrics on Fargate envs

### DIFF
--- a/pkg/config/environment_containers.go
+++ b/pkg/config/environment_containers.go
@@ -167,8 +167,8 @@ func detectFargate(features FeatureMap) {
 		// traces, events...
 		// To ease customer configuration, the agent should inject dd_tags to the dogstatsd_tags configuration option
 		// to have the same behaviour with dogstatsd metrics than with other metrics.
-		dsd_tags := merge(Datadog.GetStringSlice("dogstatsd_tags"), Datadog.GetStringSlice("dd_tags"))
-		AddOverride("dogstatsd_tags", dsd_tags)
+		dsdTags := merge(Datadog.GetStringSlice("dogstatsd_tags"), Datadog.GetStringSlice("dd_tags"))
+		AddOverride("dogstatsd_tags", dsdTags)
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

in AWS Fargate environments, dd_tags can't be attached to host.

The agent already add all tags present to dd_tags to the tagger entities to have them on metrics checks, traces, events...
To ease customer configuration, the agent should inject `dd_tags` to the `dogstatsd_tags` configuration option to have the same behaviour with dogstatsd metrics than with other metrics.

### Motivation

Ease Agent configuration for customers on AWS Fargate environment.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Deploy the agent on ECS Fargate following our official documentation. Add to the Fargate task a dummy application that generate dogstatsd metrics. add in the agent configuration some tags thanks to the `dd_tags` parameter. 

The tags should be present on the dsd metrics generated by the dummy app.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
