### PR TITLE
[workloadmeta/containerd] Don't error out on ignoreEvent

### DIFF
--- a/pkg/workloadmeta/collectors/containerd/containerd.go
+++ b/pkg/workloadmeta/collectors/containerd/containerd.go
@@ -244,7 +244,11 @@ func (c *collector) handleEvent(ctx context.Context, containerdEvent *containerd
 
 	ignore, err := c.ignoreEvent(ctx, containerdEvent)
 	if err != nil {
-		return err
+		// if ignoreEvent returns an error, keep the event regardless.
+		// it might've been because of network errors, so it's better
+		// to keep a container we should've ignored than ignoring a
+		// container we should've kept
+		log.Debugf("Error while deciding to ignore event, keeping it: %s", err)
 	}
 
 	if ignore {


### PR DESCRIPTION
### What does this PR do?

This applies the same fix as eb306aadd25c0e33b21e2f997a884403ec872052,
but after the agent has started. This fixes a small entity leak where
containers that were kept at startup would not be removed afterwards
because `ignoreEvent` fails with the same error (usually `failed to get
image`).

### Describe how to test/QA your changes

This is a bit difficult to QA in a local environment because we still don't know what causes the `failed to get image` error. If you have an event where that does happen at startup (staging is a good place), stopping that container should make it go away from the workloadmeta store (you can check it with `agent workload-list`).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
