### PR TITLE
[7.34][Backport] Fix container check scheduling and liveness/readiness on EKS Fargate

### DIFF
--- a/pkg/autodiscovery/listeners/environment.go
+++ b/pkg/autodiscovery/listeners/environment.go
@@ -7,7 +7,6 @@ package listeners
 
 import (
 	"context"
-	"runtime"
 
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
@@ -69,13 +68,9 @@ func (l *EnvironmentListener) createServices() {
 	}
 
 	// Handle generic container check auto-activation.
-	// We're limited by the collectors in Metadata server on Linux.
-	// We're limited by the runtimes on Windows.
-	var containerFeatures []config.Feature
-	if runtime.GOOS == "linux" {
-		containerFeatures = []config.Feature{config.Docker, config.Containerd, config.Kubernetes, config.ECSFargate}
-	} else if runtime.GOOS == "windows" {
-		containerFeatures = []config.Feature{config.Docker, config.Containerd, config.ECSFargate}
+	containerFeatures := []config.Feature{config.Docker, config.Containerd, config.Cri, config.ECSFargate}
+	if !config.IsFeaturePresent(config.EKSFargate) {
+		containerFeatures = append(containerFeatures, config.Kubernetes)
 	}
 
 	for _, f := range containerFeatures {

--- a/pkg/util/kubernetes/hostinfo/apiserver.go
+++ b/pkg/util/kubernetes/hostinfo/apiserver.go
@@ -9,19 +9,11 @@ package hostinfo
 
 import (
 	"context"
-	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
 )
 
-const (
-	apiserverTimeout = 10 * time.Second
-)
-
-func apiserverNodeLabels(nodeName string) (map[string]string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), apiserverTimeout)
-	defer cancel()
-
+func apiserverNodeLabels(ctx context.Context, nodeName string) (map[string]string, error) {
 	client, err := apiserver.WaitForAPIClient(ctx)
 	if err != nil {
 		return nil, err
@@ -29,10 +21,7 @@ func apiserverNodeLabels(nodeName string) (map[string]string, error) {
 	return client.NodeLabels(nodeName)
 }
 
-func apiserverNodeAnnotations(nodeName string) (map[string]string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), apiserverTimeout)
-	defer cancel()
-
+func apiserverNodeAnnotations(ctx context.Context, nodeName string) (map[string]string, error) {
 	client, err := apiserver.WaitForAPIClient(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/util/kubernetes/hostinfo/no_apiserver.go
+++ b/pkg/util/kubernetes/hostinfo/no_apiserver.go
@@ -7,10 +7,12 @@
 
 package hostinfo
 
-func apiserverNodeLabels(nodeName string) (map[string]string, error) {
+import "context"
+
+func apiserverNodeLabels(ctx context.Context, nodeName string) (map[string]string, error) {
 	return nil, nil
 }
 
-func apiserverNodeAnnotations(nodeName string) (map[string]string, error) {
+func apiserverNodeAnnotations(ctx context.Context, nodeName string) (map[string]string, error) {
 	return nil, nil
 }

--- a/pkg/util/kubernetes/hostinfo/node_annotations.go
+++ b/pkg/util/kubernetes/hostinfo/node_annotations.go
@@ -34,5 +34,5 @@ func GetNodeAnnotations(ctx context.Context) (map[string]string, error) {
 		}
 		return cl.GetNodeAnnotations(nodeName)
 	}
-	return apiserverNodeAnnotations(nodeName)
+	return apiserverNodeAnnotations(ctx, nodeName)
 }

--- a/pkg/util/kubernetes/hostinfo/node_labels.go
+++ b/pkg/util/kubernetes/hostinfo/node_labels.go
@@ -34,7 +34,7 @@ func GetNodeLabels(ctx context.Context) (map[string]string, error) {
 		}
 		return cl.GetNodeLabels(nodeName)
 	}
-	return apiserverNodeLabels(nodeName)
+	return apiserverNodeLabels(ctx, nodeName)
 }
 
 // GetNodeClusterNameLabel returns clustername by fetching a node label

--- a/releasenotes/notes/fix-eks-fargate-bugs-88518beb7b09d6a3.yaml
+++ b/releasenotes/notes/fix-eks-fargate-bugs-88518beb7b09d6a3.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    On EKS Fargate, the `container` check is scheduled while no suitable metrics collector is available, leading to excessive logging. Also fixes an issue with Liveness/Readiness probes failing regularly.


### PR DESCRIPTION
### What does this PR do?

Backport PR#10853

Fixes two issues on EKS Fargate:
- Scheduling of the `container` check while, in fact, we do not have any valid collector.
- Random failure of Liveness/Readiness probes.

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Run the Agent in EKS Fargate with Liveness probe activated:
```
      - name: DD_HEALTH_PORT
        value: "5555"
...
      livenessProbe:
        failureThreshold: 3
        httpGet:
          path: /health
          port: 5555
          scheme: HTTP
        initialDelaySeconds: 15
        periodSeconds: 15
        successThreshold: 1
        timeoutSeconds: 5
```

The `container` check should not run.
Let the Agent run for at least 1 hour, you should not encounter any liveness probe failure in `kubectl describe po`:
```
  Warning  Unhealthy  5m41s (x20 over 170m)  kubelet  Liveness probe failed: HTTP probe failed with statuscode: 500
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
