### PR TITLE
[CWS] Export Go runtime metrics to debug memory regressions

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -970,7 +970,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.enable_kernel_filters", true)
 	config.BindEnvAndSetDefault("runtime_security_config.flush_discarder_window", 3)
 	config.BindEnvAndSetDefault("runtime_security_config.syscall_monitor.enabled", false)
-	config.BindEnvAndSetDefault("runtime_security_config.runtime_monitor.enabled", true)
+	config.BindEnvAndSetDefault("runtime_security_config.runtime_monitor.enabled", false)
 	config.BindEnvAndSetDefault("runtime_security_config.events_stats.polling_interval", 20)
 	config.BindEnvAndSetDefault("runtime_security_config.events_stats.tags_cardinality", "high")
 	config.BindEnvAndSetDefault("runtime_security_config.run_path", defaultRunPath)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -970,6 +970,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("runtime_security_config.enable_kernel_filters", true)
 	config.BindEnvAndSetDefault("runtime_security_config.flush_discarder_window", 3)
 	config.BindEnvAndSetDefault("runtime_security_config.syscall_monitor.enabled", false)
+	config.BindEnvAndSetDefault("runtime_security_config.runtime_monitor.enabled", true)
 	config.BindEnvAndSetDefault("runtime_security_config.events_stats.polling_interval", 20)
 	config.BindEnvAndSetDefault("runtime_security_config.events_stats.tags_cardinality", "high")
 	config.BindEnvAndSetDefault("runtime_security_config.run_path", defaultRunPath)

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -7,11 +7,13 @@ package config
 
 import (
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	aconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/security/utils"
 )
 
@@ -106,6 +108,17 @@ func (c *Config) IsEnabled() bool {
 	return c.RuntimeEnabled || c.FIMEnabled
 }
 
+func setEnv() {
+	if aconfig.IsContainerized() && util.PathExists("/host") {
+		if v := os.Getenv("HOST_PROC"); v == "" {
+			os.Setenv("HOST_PROC", "/host/proc")
+		}
+		if v := os.Getenv("HOST_SYS"); v == "" {
+			os.Setenv("HOST_SYS", "/host/sys")
+		}
+	}
+}
+
 // NewConfig returns a new Config object
 func NewConfig(cfg *config.Config) (*Config, error) {
 	c := &Config{
@@ -180,5 +193,6 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 		c.HostServiceName = fmt.Sprintf("service:%s", serviceName)
 	}
 
+	setEnv()
 	return c, nil
 }

--- a/pkg/security/config/config.go
+++ b/pkg/security/config/config.go
@@ -97,6 +97,8 @@ type Config struct {
 	// ActivityDumpCleanupPeriod defines the period at which the activity dump manager should perform its cleanup
 	// operation.
 	ActivityDumpCleanupPeriod time.Duration
+	// RuntimeMonitor defines if the runtime monitor should be enabled
+	RuntimeMonitor bool
 }
 
 // IsEnabled returns true if any feature is enabled. Has to be applied in config package too
@@ -141,6 +143,7 @@ func NewConfig(cfg *config.Config) (*Config, error) {
 		RuntimeCompiledConstantsIsSet:      aconfig.Datadog.IsSet("runtime_security_config.enable_runtime_compiled_constants"),
 		ActivityDumpEnabled:                aconfig.Datadog.GetBool("runtime_security_config.activity_dump_manager.enabled"),
 		ActivityDumpCleanupPeriod:          time.Duration(aconfig.Datadog.GetInt("runtime_security_config.activity_dump_manager.cleanup_period")) * time.Second,
+		RuntimeMonitor:                     aconfig.Datadog.GetBool("runtime_security_config.runtime_monitor.enabled"),
 	}
 
 	// if runtime is enabled then we force fim

--- a/pkg/security/metrics/metrics.go
+++ b/pkg/security/metrics/metrics.go
@@ -157,7 +157,7 @@ var (
 	// `FIM` feature is enabled
 	MetricSecurityAgentFIMContainersRunning = newAgentMetric(".fim.containers_running")
 
-	// Runtime Compilaed Constants metrics
+	// Runtime Compiled Constants metrics
 
 	// MetricRuntimeCompiledConstantsEnabled is used to report if the runtime compilation has succeeded
 	MetricRuntimeCompiledConstantsEnabled = newRuntimeCompiledConstantsMetric(".enabled")
@@ -167,6 +167,142 @@ var (
 	MetricRuntimeCompiledConstantsCompilationDuration = newRuntimeCompiledConstantsMetric(".compilation_duration")
 	// MetricRuntimeCompiledConstantsHeaderFetchResult is used to report the result of the header fetching
 	MetricRuntimeCompiledConstantsHeaderFetchResult = newRuntimeCompiledConstantsMetric(".header_fetch_result")
+
+	// RuntimeMonitor metrics
+
+	// MetricRuntimeMonitorGoAlloc is the name of the metric used to report the size in bytes of allocated heap objects
+	// Tags: -
+	MetricRuntimeMonitorGoAlloc = newRuntimeMetric(".runtime_monitor.go.alloc")
+	// MetricRuntimeMonitorGoTotalAlloc is the name of the metric used to report the cumulative size of bytes allocated
+	// for heap objects
+	// Tags: -
+	MetricRuntimeMonitorGoTotalAlloc = newRuntimeMetric(".runtime_monitor.go.total_alloc")
+	// MetricRuntimeMonitorGoSys is the name of the metric used to report the total size in bytes of memory obtained from
+	// the OS
+	// Tags: -
+	MetricRuntimeMonitorGoSys = newRuntimeMetric(".runtime_monitor.go.sys")
+	// MetricRuntimeMonitorGoLookups is the name of the metric used to report the number of pointer lookups performed by
+	// the runtime
+	// Tags: -
+	MetricRuntimeMonitorGoLookups = newRuntimeMetric(".runtime_monitor.go.lookups")
+	// MetricRuntimeMonitorGoMallocs is the name of the metric used to report the cumulative count of allocated heap
+	// objects
+	// Tags: -
+	MetricRuntimeMonitorGoMallocs = newRuntimeMetric(".runtime_monitor.go.mallocs")
+	// MetricRuntimeMonitorGoFrees is the name of the metric used to report the cumulative count of freed heap objects
+	// Tags: -
+	MetricRuntimeMonitorGoFrees = newRuntimeMetric(".runtime_monitor.go.frees")
+	// MetricRuntimeMonitorGoHeapAlloc is the name of the metric used to report the size in bytes of allocated heap
+	// objects (including reachable and unreachable objects that the garbage collector has not yet freed)
+	// Tags: -
+	MetricRuntimeMonitorGoHeapAlloc = newRuntimeMetric(".runtime_monitor.go.heap_alloc")
+	// MetricRuntimeMonitorGoHeapSys is the name of the metric used to report the size in bytes of heap memory obtained
+	// from the OS. This includes virtual address space that has been reserved but not yet used, as well as virtual
+	// address space for which the physical memory has been returned to the OS after it became unused
+	// Tags: -
+	MetricRuntimeMonitorGoHeapSys = newRuntimeMetric(".runtime_monitor.go.heap_sys")
+	// MetricRuntimeMonitorGoHeapIdle is the name of the metric used to report the size in bytes in idle (unused) spans
+	// Tags: -
+	MetricRuntimeMonitorGoHeapIdle = newRuntimeMetric(".runtime_monitor.go.heap_idle")
+	// MetricRuntimeMonitorGoHeapInuse is the name of the metric used to report the size in bytes in in-use spans
+	// Tags: -
+	MetricRuntimeMonitorGoHeapInuse = newRuntimeMetric(".runtime_monitor.go.heap_inuse")
+	// MetricRuntimeMonitorGoHeapReleased is the name of the metric used to report the size in bytes of physical memory
+	// returned to the OS
+	// Tags: -
+	MetricRuntimeMonitorGoHeapReleased = newRuntimeMetric(".runtime_monitor.go.heap_released")
+	// MetricRuntimeMonitorGoHeapObjects is the name of the metric used to report the number of allocated heap objects
+	// Tags: -
+	MetricRuntimeMonitorGoHeapObjects = newRuntimeMetric(".runtime_monitor.go.heap_objects")
+	// MetricRuntimeMonitorGoStackInuse is the name of the metric used to report the size in bytes of stack spans
+	// Tags: -
+	MetricRuntimeMonitorGoStackInuse = newRuntimeMetric(".runtime_monitor.go.stack_inuse")
+	// MetricRuntimeMonitorGoStackSys is the name of the metric used to report the size in bytes of stack memory obtained
+	// from the OS
+	// Tags: -
+	MetricRuntimeMonitorGoStackSys = newRuntimeMetric(".runtime_monitor.go.stack_sys")
+	// MetricRuntimeMonitorGoMSpanInuse is the name of the metric used to report the size in bytes of allocated mspan
+	// structures
+	// Tags: -
+	MetricRuntimeMonitorGoMSpanInuse = newRuntimeMetric(".runtime_monitor.go.mspan_inuse")
+	// MetricRuntimeMonitorGoMSpanSys is the name of the metric used to report the size in bytes of memory obtained from
+	// the OS for mspan structures
+	// Tags: -
+	MetricRuntimeMonitorGoMSpanSys = newRuntimeMetric(".runtime_monitor.go.mspan_sys")
+	// MetricRuntimeMonitorGoMCacheInuse is the name of the metric used to report the size in bytes of allocated mcache
+	// structures
+	// Tags: -
+	MetricRuntimeMonitorGoMCacheInuse = newRuntimeMetric(".runtime_monitor.go.mcache_inuse")
+	// MetricRuntimeMonitorGoMCacheSys is the name of the metric used to report the size in bytes of memory obtained from
+	// the OS for mcache structures
+	// Tags: -
+	MetricRuntimeMonitorGoMCacheSys = newRuntimeMetric(".runtime_monitor.go.mcache_sys")
+	// MetricRuntimeMonitorGoBuckHashSys is the name of the metric used to report the size in bytes of memory in profiling
+	// bucket hash tables
+	// Tags: -
+	MetricRuntimeMonitorGoBuckHashSys = newRuntimeMetric(".runtime_monitor.go.buck_hash_sys")
+	// MetricRuntimeMonitorGoGCSys is the name of the metric used to report the size in bytes of memory in garbage
+	// collection metadata
+	// Tags: -
+	MetricRuntimeMonitorGoGCSys = newRuntimeMetric(".runtime_monitor.go.gc_sys")
+	// MetricRuntimeMonitorGoOtherSys is the name of the metric used to report the size in bytes of memory in miscellaneous
+	// off-heap runtime allocations
+	// Tags: -
+	MetricRuntimeMonitorGoOtherSys = newRuntimeMetric(".runtime_monitor.go.other_sys")
+	// MetricRuntimeMonitorGoNextGC is the name of the metric used to report the target heap size of the next GC cycle
+	// Tags: -
+	MetricRuntimeMonitorGoNextGC = newRuntimeMetric(".runtime_monitor.go.next_gc")
+	// MetricRuntimeMonitorGoNumGC is the name of the metric used to report the number of completed GC cycles
+	// Tags: -
+	MetricRuntimeMonitorGoNumGC = newRuntimeMetric(".runtime_monitor.go.num_gc")
+	// MetricRuntimeMonitorGoNumForcedGC is the name of the metric used to report the number of GC cycles that were forced
+	// by the application calling the GC function
+	// Tags: -
+	MetricRuntimeMonitorGoNumForcedGC = newRuntimeMetric(".runtime_monitor.go.num_forced_gc")
+
+	// MetricRuntimeMonitorProcRSS is the name of the metric used to report the RSS in bytes retrieved from Procfs
+	// Tags: -
+	MetricRuntimeMonitorProcRSS = newRuntimeMetric(".runtime_monitor.proc.rss")
+	// MetricRuntimeMonitorProcVMS is the name of the metric used to report the VMS in bytes retrieved from Procfs
+	// Tags: -
+	MetricRuntimeMonitorProcVMS = newRuntimeMetric(".runtime_monitor.proc.vms")
+	// MetricRuntimeMonitorProcShared is the name of the metric used to report the shared memory in bytes retrieved from Procfs
+	// Tags: -
+	MetricRuntimeMonitorProcShared = newRuntimeMetric(".runtime_monitor.proc.shared")
+	// MetricRuntimeMonitorProcText is the name of the metric used to report the text memory in bytes retrieved from Procfs
+	// Tags: -
+	MetricRuntimeMonitorProcText = newRuntimeMetric(".runtime_monitor.proc.text")
+	// MetricRuntimeMonitorProcLib is the name of the metric used to report the lib memory in bytes retrieved from Procfs
+	// Tags: -
+	MetricRuntimeMonitorProcLib = newRuntimeMetric(".runtime_monitor.proc.lib")
+	// MetricRuntimeMonitorProcData is the name of the metric used to report the data memory in bytes retrieved from Procfs
+	// Tags: -
+	MetricRuntimeMonitorProcData = newRuntimeMetric(".runtime_monitor.proc.data")
+	// MetricRuntimeMonitorProcDirty is the name of the metric used to report the dirty memory in bytes retrieved from Procfs
+	// Tags: -
+	MetricRuntimeMonitorProcDirty = newRuntimeMetric(".runtime_monitor.proc.dirty")
+
+	// MetricRuntimeCgroupMemoryStatPrefix is the prefix for the metrics collected in the memory.stat cgroup file
+	// Tags: -
+	MetricRuntimeCgroupMemoryStatPrefix = newRuntimeMetric(".runtime_monitor.cgroup.memory_stat.")
+	// MetricRuntimeCgroupMemoryUsageInBytes is the name of the metric used to report memory.usage_in_bytes
+	// Tags: -
+	MetricRuntimeCgroupMemoryUsageInBytes = newRuntimeMetric(".runtime_monitor.cgroup.memory.usage_in_bytes")
+	// MetricRuntimeCgroupMemoryLimitInBytes is the name of the metric used to report memory.limit_in_bytes
+	// Tags: -
+	MetricRuntimeCgroupMemoryLimitInBytes = newRuntimeMetric(".runtime_monitor.cgroup.memory.limit_in_bytes")
+	// MetricRuntimeCgroupMemoryMemSWUsageInBytes is the name of the metric used to report memory.memsw.usage_in_bytes
+	// Tags: -
+	MetricRuntimeCgroupMemoryMemSWUsageInBytes = newRuntimeMetric(".runtime_monitor.cgroup.memory.memsw_usage_in_bytes")
+	// MetricRuntimeCgroupMemoryMemSWLimitInBytes is the name of the metric used to report memory.memsw.limit_in_bytes
+	// Tags: -
+	MetricRuntimeCgroupMemoryMemSWLimitInBytes = newRuntimeMetric(".runtime_monitor.cgroup.memory.memsw_limit_in_bytes")
+	// MetricRuntimeCgroupMemoryKmemUsageInBytes is the name of the metric used to report memory.kmem.usage_in_bytes
+	// Tags: -
+	MetricRuntimeCgroupMemoryKmemUsageInBytes = newRuntimeMetric(".runtime_monitor.cgroup.memory.kmem_usage_in_bytes")
+	// MetricRuntimeCgroupMemoryKmemLimitInBytes is the name of the metric used to report memory.kmem.limit_in_bytes
+	// Tags: -
+	MetricRuntimeCgroupMemoryKmemLimitInBytes = newRuntimeMetric(".runtime_monitor.cgroup.memory.kmem_limit_in_bytes")
 )
 
 // SetTagsWithCardinality returns the array of tags and set the requested cardinality

--- a/pkg/security/probe/probe_monitor.go
+++ b/pkg/security/probe/probe_monitor.go
@@ -35,6 +35,7 @@ type Monitor struct {
 	syscallMonitor      *SyscallMonitor
 	reordererMonitor    *ReordererMonitor
 	activityDumpManager *ActivityDumpManager
+	runtimeMonitor      *RuntimeMonitor
 }
 
 // NewMonitor returns a new instance of a ProbeMonitor
@@ -75,6 +76,10 @@ func NewMonitor(p *Probe, client *statsd.Client) (*Monitor, error) {
 		if err != nil {
 			return nil, err
 		}
+	}
+
+	if p.config.RuntimeMonitor {
+		m.runtimeMonitor = NewRuntimeMonitor(client)
 	}
 	return m, nil
 }
@@ -136,6 +141,12 @@ func (m *Monitor) SendStats() error {
 	if m.activityDumpManager != nil {
 		if err := m.activityDumpManager.SendStats(); err != nil {
 			return errors.Wrap(err, "failed to send activity dump maanger stats")
+		}
+	}
+
+	if m.probe.config.RuntimeMonitor {
+		if err := m.runtimeMonitor.SendStats(); err != nil {
+			return errors.Wrap(err, "failed to send runtime monitor stats")
 		}
 	}
 

--- a/pkg/security/probe/runtime_monitor.go
+++ b/pkg/security/probe/runtime_monitor.go
@@ -1,0 +1,248 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-2020 Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package probe
+
+import (
+	"runtime"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/gopsutil/process"
+	"github.com/pkg/errors"
+
+	"github.com/DataDog/datadog-agent/pkg/security/metrics"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
+	"github.com/DataDog/datadog-go/statsd"
+)
+
+// RuntimeMonitor is used to export runtime.MemStats metrics for debugging purposes
+type RuntimeMonitor struct {
+	client *statsd.Client
+}
+
+// SendStats sends the metric of the runtime monitor
+func (m *RuntimeMonitor) SendStats() error {
+	if err := m.sendGoRuntimeMetrics(); err != nil {
+		return err
+	}
+	if err := m.sendProcMetrics(); err != nil {
+		return err
+	}
+	return m.sendCgroupMetrics()
+}
+
+func (m *RuntimeMonitor) sendCgroupMetrics() error {
+	pid := uint32(utils.Getpid())
+
+	// get cgroups
+	cgroups, err := utils.GetProcControlGroups(pid, pid)
+	if err != nil {
+		return err
+	}
+
+	// find memory controller
+	var memoryCgroup utils.ControlGroup
+	for _, cgroup := range cgroups {
+		for _, controller := range cgroup.Controllers {
+			if controller == "memory" {
+				memoryCgroup = cgroup
+				break
+			}
+		}
+	}
+	if len(memoryCgroup.Path) == 0 {
+		return errors.Wrapf(err, "couldn't find memory controller in: %v", cgroups)
+	}
+
+	usageInBytes, err := utils.ParseCgroupFileValue("memory", memoryCgroup.Path, "memory.usage_in_bytes")
+	if err == nil {
+		if err = m.client.Gauge(metrics.MetricRuntimeCgroupMemoryUsageInBytes, float64(usageInBytes), []string{}, 1.0); err != nil {
+			return errors.Wrap(err, "failed to send MetricRuntimeCgroupMemoryUsageInBytes metric")
+		}
+	}
+
+	limitInBytes, err := utils.ParseCgroupFileValue("memory", memoryCgroup.Path, "memory.limit_in_bytes")
+	if err == nil {
+		if err = m.client.Gauge(metrics.MetricRuntimeCgroupMemoryLimitInBytes, float64(limitInBytes), []string{}, 1.0); err != nil {
+			return errors.Wrap(err, "failed to send MetricRuntimeCgroupMemoryLimitInBytes metric")
+		}
+	}
+
+	memswUsageInBytes, err := utils.ParseCgroupFileValue("memory", memoryCgroup.Path, "memory.memsw.usage_in_bytes")
+	if err == nil {
+		if err = m.client.Gauge(metrics.MetricRuntimeCgroupMemoryMemSWUsageInBytes, float64(memswUsageInBytes), []string{}, 1.0); err != nil {
+			return errors.Wrap(err, "failed to send MetricRuntimeCgroupMemoryMemSWUsageInBytes metric")
+		}
+	}
+
+	memswLimitInBytes, err := utils.ParseCgroupFileValue("memory", memoryCgroup.Path, "memory.memsw.limit_in_bytes")
+	if err == nil {
+		if err = m.client.Gauge(metrics.MetricRuntimeCgroupMemoryMemSWLimitInBytes, float64(memswLimitInBytes), []string{}, 1.0); err != nil {
+			return errors.Wrap(err, "failed to send MetricRuntimeCgroupMemoryMemSWLimitInBytes metric")
+		}
+	}
+
+	kmemUsageInBytes, err := utils.ParseCgroupFileValue("memory", memoryCgroup.Path, "memory.kmem.usage_in_bytes")
+	if err == nil {
+		if err = m.client.Gauge(metrics.MetricRuntimeCgroupMemoryKmemUsageInBytes, float64(kmemUsageInBytes), []string{}, 1.0); err != nil {
+			return errors.Wrap(err, "failed to send MetricRuntimeCgroupMemoryKmemUsageInBytes metric")
+		}
+	}
+
+	kmemLimitInBytes, err := utils.ParseCgroupFileValue("memory", memoryCgroup.Path, "memory.kmem.limit_in_bytes")
+	if err == nil {
+		if err = m.client.Gauge(metrics.MetricRuntimeCgroupMemoryKmemLimitInBytes, float64(kmemLimitInBytes), []string{}, 1.0); err != nil {
+			return errors.Wrap(err, "failed to send MetricRuntimeCgroupMemoryKmemLimitInBytes metric")
+		}
+	}
+
+	data, _, err := utils.ReadCgroupFile("memory", memoryCgroup.Path, "memory.stat")
+	if err != nil {
+		return err
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		lineSplit := strings.Split(line, " ")
+		if len(lineSplit) < 2 {
+			continue
+		}
+
+		value, err := strconv.Atoi(lineSplit[1])
+		if err != nil {
+			continue
+		}
+
+		if err = m.client.Gauge(metrics.MetricRuntimeCgroupMemoryStatPrefix+lineSplit[0], float64(value), []string{}, 1.0); err != nil {
+			return errors.Wrapf(err, "failed to send %s metric", metrics.MetricRuntimeCgroupMemoryStatPrefix+lineSplit[0])
+		}
+	}
+
+	return nil
+}
+
+func (m *RuntimeMonitor) sendProcMetrics() error {
+	p, err := process.NewProcess(utils.Getpid())
+	if err != nil {
+		return err
+	}
+
+	memoryExt, err := p.MemoryInfoEx()
+	if err != nil {
+		return err
+	}
+
+	if err = m.client.Gauge(metrics.MetricRuntimeMonitorProcRSS, float64(memoryExt.RSS), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorProcRSS metric")
+	}
+	if err = m.client.Gauge(metrics.MetricRuntimeMonitorProcVMS, float64(memoryExt.VMS), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorProcVMS metric")
+	}
+	if err = m.client.Gauge(metrics.MetricRuntimeMonitorProcShared, float64(memoryExt.Shared), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorProcShared metric")
+	}
+	if err = m.client.Gauge(metrics.MetricRuntimeMonitorProcText, float64(memoryExt.Text), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorProcText metric")
+	}
+	if err = m.client.Gauge(metrics.MetricRuntimeMonitorProcLib, float64(memoryExt.Lib), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorProcLib metric")
+	}
+	if err = m.client.Gauge(metrics.MetricRuntimeMonitorProcData, float64(memoryExt.Data), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorProcData metric")
+	}
+	if err = m.client.Gauge(metrics.MetricRuntimeMonitorProcDirty, float64(memoryExt.Dirty), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorProcDirty metric")
+	}
+
+	return nil
+}
+
+func (m *RuntimeMonitor) sendGoRuntimeMetrics() error {
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoAlloc, float64(stats.Alloc), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoAlloc metric")
+	}
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoTotalAlloc, float64(stats.TotalAlloc), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoTotalAlloc metric")
+	}
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoSys, float64(stats.Sys), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoSys metric")
+	}
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoLookups, float64(stats.Lookups), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoLookups metric")
+	}
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoMallocs, float64(stats.Mallocs), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoMallocs metric")
+	}
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoFrees, float64(stats.Frees), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoFrees metric")
+	}
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoHeapAlloc, float64(stats.HeapAlloc), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoHeapAlloc metric")
+	}
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoHeapSys, float64(stats.HeapSys), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoHeapSys metric")
+	}
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoHeapIdle, float64(stats.HeapIdle), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoHeapIdle metric")
+	}
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoHeapInuse, float64(stats.HeapInuse), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoHeapInuse metric")
+	}
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoHeapReleased, float64(stats.HeapReleased), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoHeapReleased metric")
+	}
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoHeapObjects, float64(stats.HeapObjects), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoHeapObjects metric")
+	}
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoStackInuse, float64(stats.StackInuse), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoStackInuse metric")
+	}
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoStackSys, float64(stats.StackSys), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoStackSys metric")
+	}
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoMSpanInuse, float64(stats.MSpanInuse), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoMSpanInuse metric")
+	}
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoMSpanSys, float64(stats.MSpanSys), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoMSpanSys metric")
+	}
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoMCacheInuse, float64(stats.MCacheInuse), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoMCacheInuse metric")
+	}
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoMCacheSys, float64(stats.MCacheSys), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoMCacheSys metric")
+	}
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoBuckHashSys, float64(stats.BuckHashSys), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoBuckHashSys metric")
+	}
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoGCSys, float64(stats.GCSys), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoGCSys metric")
+	}
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoOtherSys, float64(stats.OtherSys), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoOtherSys metric")
+	}
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoNextGC, float64(stats.NextGC), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoNextGC metric")
+	}
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoNumGC, float64(stats.NumGC), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoNumGC metric")
+	}
+	if err := m.client.Gauge(metrics.MetricRuntimeMonitorGoNumForcedGC, float64(stats.NumForcedGC), []string{}, 1.0); err != nil {
+		return errors.Wrap(err, "failed to send MetricRuntimeMonitorGoNumForcedGC metric")
+	}
+	return nil
+}
+
+// NewRuntimeMonitor returns a new instance of RuntimeMonitor
+func NewRuntimeMonitor(client *statsd.Client) *RuntimeMonitor {
+	return &RuntimeMonitor{
+		client: client,
+	}
+}

--- a/pkg/security/utils/sys.go
+++ b/pkg/security/utils/sys.go
@@ -1,0 +1,49 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build linux
+// +build linux
+
+package utils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+)
+
+// CgroupSysPath returns the path to the provided file within the provided cgroup
+func CgroupSysPath(controller string, path string, file string) string {
+	return filepath.Join(util.HostSys("fs/cgroup/", controller, path, file))
+}
+
+// ReadCgroupFile reads the content of a cgroup file
+func ReadCgroupFile(controller string, path string, file string) ([]byte, string, error) {
+	p := CgroupSysPath(controller, path, file)
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return nil, "", fmt.Errorf("couldn't read %s: %w", p, err)
+	}
+	return data, p, nil
+}
+
+// ParseCgroupFileValue parses the content of a cgroup file into an int
+func ParseCgroupFileValue(controller string, path string, file string) (int, error) {
+	data, cgroupPath, err := ReadCgroupFile(controller, path, file)
+	if err != nil {
+		return 0, err
+	}
+
+	value, err := strconv.Atoi(strings.Trim(string(data), "\n"))
+	if err != nil {
+		return 0, fmt.Errorf("couldn't parse %s: %w", cgroupPath, err)
+	}
+
+	return value, nil
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

This PR exports a ton of metrics from the Go runtime (all memory related metrics from `runtime.MemStats`), along with the metrics in `/proc/[pid]/statm` and the current memory cgroup of system-probe. This `RuntimeMonitor` sits behind a configuration parameter which will be disabled by default.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The goal is to expose more metrics to debug and better understand memory regressions. We often observe discrepancies between the memory reported by the Go runtime, and the actual memory usage of the system-probe process. Exporting these metrics will help us understand where the missing memory is.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
