### PR TITLE
Update otlp/serilizerexporter to use composite tags

### DIFF
--- a/pkg/otlp/internal/serializerexporter/consumer.go
+++ b/pkg/otlp/internal/serializerexporter/consumer.go
@@ -83,16 +83,17 @@ func (c *serializerConsumer) enrichTags(cardinality string) {
 	const origin = ""
 	const k8sOriginID = ""
 
+	tb := tagset.NewHashlessTagsAccumulator()
 	for i := range c.series {
-		tb := tagset.NewHashlessTagsAccumulatorFromSlice(c.series[i].Tags)
+		tb.Reset()
 		tagger.EnrichTags(tb, origin, k8sOriginID, cardinality)
-		c.series[i].Tags = tb.Get()
+		c.series[i].Tags.CombineWithSlice(tb.Copy())
 	}
 
 	for i := range c.sketches {
-		tb := tagset.NewHashlessTagsAccumulatorFromSlice(c.sketches[i].Tags)
+		tb.Reset()
 		tagger.EnrichTags(tb, origin, k8sOriginID, cardinality)
-		c.sketches[i].Tags = tb.Get()
+		c.sketches[i].Tags.CombineWithSlice(tb.Copy())
 	}
 }
 

--- a/pkg/tagset/composite_tags.go
+++ b/pkg/tagset/composite_tags.go
@@ -43,6 +43,11 @@ func CombineCompositeTagsAndSlice(compositeTags CompositeTags, tags []string) Co
 	return NewCompositeTags(compositeTags.tags1, newTags)
 }
 
+// CombineWithSlice adds tags to the composite tags. Consumes the slice.
+func (t *CompositeTags) CombineWithSlice(tags []string) {
+	*t = CombineCompositeTagsAndSlice(*t, tags)
+}
+
 // ForEach applies `callback` to each tag
 func (t CompositeTags) ForEach(callback func(tag string)) {
 	for _, t := range t.tags1 {

--- a/pkg/tagset/hashless_tags_accumulator.go
+++ b/pkg/tagset/hashless_tags_accumulator.go
@@ -47,6 +47,11 @@ func (h *HashlessTagsAccumulator) Get() []string {
 	return h.data
 }
 
+// Copy returns a new slice with the copy of the tags
+func (h *HashlessTagsAccumulator) Copy() []string {
+	return append(make([]string, 0, len(h.data)), h.data...)
+}
+
 // SortUniq sorts and remove duplicate in place
 func (h *HashlessTagsAccumulator) SortUniq() {
 	h.data = util.SortUniqInPlace(h.data)


### PR DESCRIPTION
(NB this is a PR to a feature branch)

Tags enrichment was added on main and it needs to be updated to use
CompositeTags.

This patch adds CombineWithSlice to modify CompositeTags inplace, to
avoid mistakes like the one I did today:

    c.sketches[i].Tags = CombineCompositeTagsWithSlice(c.series[i].Tags, ..)

