### PR TITLE
[process-agent] Refactor status build and add it to core agent

### DIFF
--- a/cmd/process-agent/api/status.go
+++ b/cmd/process-agent/api/status.go
@@ -9,18 +9,14 @@ import (
 	"encoding/json"
 	"net/http"
 
-	"github.com/DataDog/datadog-agent/pkg/status"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 func statusHandler(w http.ResponseWriter, _ *http.Request) {
-	log.Trace("Received status request from process-agent")
+	log.Info("Got a request for the status. Making status.")
 
-	agentStatus, err := status.GetStatus()
-	if err != nil {
-		_ = log.Warn("failed to get status from agent:", agentStatus)
-	}
-
+	agentStatus := util.GetStatus()
 	b, err := json.Marshal(agentStatus)
 	if err != nil {
 		_ = log.Warn("failed to serialize status response from agent:", err)

--- a/cmd/process-agent/api/status.go
+++ b/cmd/process-agent/api/status.go
@@ -23,6 +23,7 @@ func writeError(err error, code int, w http.ResponseWriter) {
 func statusHandler(w http.ResponseWriter, _ *http.Request) {
 	log.Info("Got a request for the status. Making status.")
 
+	// Get expVar server address
 	ipcAddr, err := ddconfig.GetIPCAddress()
 	if err != nil {
 		writeError(err, http.StatusInternalServerError, w)
@@ -38,10 +39,8 @@ func statusHandler(w http.ResponseWriter, _ *http.Request) {
 
 	agentStatus, err := util.GetStatus(expvarEndpoint)
 	if err != nil {
-		if err != nil {
-			_ = log.Warn("failed to get status from agent:", err)
-			writeError(err, http.StatusInternalServerError, w)
-		}
+		_ = log.Warn("failed to get status from agent:", err)
+		writeError(err, http.StatusInternalServerError, w)
 	}
 
 	b, err := json.Marshal(agentStatus)

--- a/cmd/process-agent/api/status.go
+++ b/cmd/process-agent/api/status.go
@@ -16,10 +16,20 @@ import (
 func statusHandler(w http.ResponseWriter, _ *http.Request) {
 	log.Info("Got a request for the status. Making status.")
 
-	agentStatus := util.GetStatus()
+	agentStatus, err := util.GetStatus()
+	if err != nil {
+		if err != nil {
+			_ = log.Warn("failed to get status from agent:", agentStatus)
+			body, _ := json.Marshal(map[string]string{"error": err.Error()})
+			http.Error(w, string(body), http.StatusInternalServerError)
+		}
+	}
+
 	b, err := json.Marshal(agentStatus)
 	if err != nil {
 		_ = log.Warn("failed to serialize status response from agent:", err)
+		body, _ := json.Marshal(map[string]string{"error": err.Error()})
+		http.Error(w, string(body), http.StatusInternalServerError)
 	}
 
 	_, err = w.Write(b)

--- a/cmd/process-agent/api/status.go
+++ b/cmd/process-agent/api/status.go
@@ -28,6 +28,7 @@ func statusHandler(w http.ResponseWriter, _ *http.Request) {
 	if err != nil {
 		writeError(err, http.StatusInternalServerError, w)
 		_ = log.Warn("config error:", err)
+		return
 	}
 
 	port := ddconfig.Datadog.GetInt("process_config.expvar_port")
@@ -41,12 +42,14 @@ func statusHandler(w http.ResponseWriter, _ *http.Request) {
 	if err != nil {
 		_ = log.Warn("failed to get status from agent:", err)
 		writeError(err, http.StatusInternalServerError, w)
+		return
 	}
 
 	b, err := json.Marshal(agentStatus)
 	if err != nil {
 		_ = log.Warn("failed to serialize status response from agent:", err)
 		writeError(err, http.StatusInternalServerError, w)
+		return
 	}
 
 	_, err = w.Write(b)

--- a/cmd/process-agent/api/status.go
+++ b/cmd/process-agent/api/status.go
@@ -13,23 +13,26 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+func writeError(err error, code int, w http.ResponseWriter) {
+	body, _ := json.Marshal(map[string]string{"error": err.Error()})
+	http.Error(w, string(body), code)
+}
+
 func statusHandler(w http.ResponseWriter, _ *http.Request) {
 	log.Info("Got a request for the status. Making status.")
 
 	agentStatus, err := util.GetStatus()
 	if err != nil {
 		if err != nil {
-			_ = log.Warn("failed to get status from agent:", agentStatus)
-			body, _ := json.Marshal(map[string]string{"error": err.Error()})
-			http.Error(w, string(body), http.StatusInternalServerError)
+			_ = log.Warn("failed to get status from agent:", err)
+			writeError(err, http.StatusInternalServerError, w)
 		}
 	}
 
 	b, err := json.Marshal(agentStatus)
 	if err != nil {
 		_ = log.Warn("failed to serialize status response from agent:", err)
-		body, _ := json.Marshal(map[string]string{"error": err.Error()})
-		http.Error(w, string(body), http.StatusInternalServerError)
+		writeError(err, http.StatusInternalServerError, w)
 	}
 
 	_, err = w.Write(b)

--- a/cmd/process-agent/app/status.go
+++ b/cmd/process-agent/app/status.go
@@ -112,6 +112,11 @@ func getAndWriteStatus(w io.Writer, options ...util.StatusOption) {
 	}
 
 	stats, err := ddstatus.FormatProcessAgentStatus(body)
+	if err != nil {
+		writeError(w, err)
+		return
+	}
+
 	w.Write([]byte(stats))
 }
 

--- a/cmd/process-agent/app/status.go
+++ b/cmd/process-agent/app/status.go
@@ -117,7 +117,10 @@ func getAndWriteStatus(w io.Writer, options ...util.StatusOption) {
 		return
 	}
 
-	w.Write([]byte(stats))
+	_, err = w.Write([]byte(stats))
+	if err != nil {
+		_ = log.Error(err)
+	}
 }
 
 // StatusCmd returns a cobra command that prints the current status

--- a/cmd/process-agent/app/status.go
+++ b/cmd/process-agent/app/status.go
@@ -95,6 +95,10 @@ func getAndWriteStatus(w io.Writer, options ...util.StatusOption) {
 	if len(options) > 0 {
 		var s util.Status
 		err = json.Unmarshal(body, &s)
+		if err != nil {
+			writeError(w, err)
+			return
+		}
 
 		for _, option := range options {
 			option(&s)
@@ -103,6 +107,7 @@ func getAndWriteStatus(w io.Writer, options ...util.StatusOption) {
 		body, err = json.Marshal(s)
 		if err != nil {
 			writeError(w, err)
+			return
 		}
 	}
 

--- a/cmd/process-agent/app/status.go
+++ b/cmd/process-agent/app/status.go
@@ -66,7 +66,7 @@ func writeError(w io.Writer, e error) {
 func fetchStatus() ([]byte, error) {
 	addressPort, err := api.GetAPIAddressPort()
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("config error: %s", err.Error())
 	}
 
 	statusEndpoint := fmt.Sprintf("http://%s/agent/status", addressPort)

--- a/cmd/process-agent/app/status_test.go
+++ b/cmd/process-agent/app/status_test.go
@@ -1,147 +1,129 @@
 package app
 
-import (
-	"context"
-	"encoding/json"
-	"fmt"
-	"net"
-	"net/http"
-	"strings"
-	"sync"
-	"testing"
-	"text/template"
-	"time"
+// TODO: mock status server here to test status cmd. Move expvar server logic to pkg/process/util
 
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
-	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/metadata/host"
-	ddstatus "github.com/DataDog/datadog-agent/pkg/status"
-)
-
-type statusServer struct {
-	shutdownWg                      *sync.WaitGroup
-	coreStatusServer, expvarsServer *http.Server
-}
-
-func (s *statusServer) stop() error {
-	err := s.coreStatusServer.Shutdown(context.Background())
-	if err != nil {
-		return err
-	}
-
-	err = s.expvarsServer.Shutdown(context.Background())
-	if err != nil {
-		return err
-	}
-
-	s.shutdownWg.Wait()
-	return nil
-}
-
-func startTestServer(t *testing.T, cfg config.Config, expectedStatus status) statusServer {
-	var serverWg sync.WaitGroup
-	serverWg.Add(2)
-
-	statusMux := http.NewServeMux()
-	statusMux.HandleFunc("/agent/status", func(w http.ResponseWriter, _ *http.Request) {
-		b, err := json.Marshal(expectedStatus.Core)
-		require.NoError(t, err)
-
-		_, err = w.Write(b)
-		require.NoError(t, err)
-	})
-	statusEndpoint := fmt.Sprintf("localhost:%d", cfg.GetInt("process_config.cmd_port"))
-	coreStatusServer := http.Server{Addr: statusEndpoint, Handler: statusMux}
-	statusListener, err := net.Listen("tcp", statusEndpoint)
-	require.NoError(t, err)
-	go func() {
-		_ = coreStatusServer.Serve(statusListener)
-		serverWg.Done()
-	}()
-
-	expvarMux := http.NewServeMux()
-	expvarMux.HandleFunc("/debug/vars", func(w http.ResponseWriter, _ *http.Request) {
-		b, err := json.Marshal(expectedStatus.Expvars)
-		require.NoError(t, err)
-
-		_, err = w.Write(b)
-		require.NoError(t, err)
-	})
-	expvarEndpoint := fmt.Sprintf("localhost:%d", cfg.GetInt("process_config.expvar_port"))
-	expvarsServer := http.Server{Addr: expvarEndpoint, Handler: expvarMux}
-	expvarsListener, err := net.Listen("tcp", expvarEndpoint)
-	require.NoError(t, err)
-	go func() {
-		_ = expvarsServer.Serve(expvarsListener)
-		serverWg.Done()
-	}()
-
-	return statusServer{coreStatusServer: &coreStatusServer, expvarsServer: &expvarsServer, shutdownWg: &serverWg}
-}
-
-func TestStatus(t *testing.T) {
-	testTime := time.Now()
-	expectedStatus := status{
-		Date: float64(testTime.UnixNano()),
-		Core: coreStatus{
-			Metadata: host.Payload{
-				Meta: &host.Meta{},
-			},
-		},
-		Expvars: processExpvars{},
-	}
-
-	// Use different ports in case the host is running a real agent
-	cfg := config.Mock()
-	cfg.Set("process_config.expvar_port", 8081)
-	cfg.Set("process_config.cmd_port", 8082)
-	server := startTestServer(t, cfg, expectedStatus)
-
-	var statusBuilder, expectedStatusBuilder strings.Builder
-
-	// Build what the expected status should be
-	tpl, err := template.New("").Funcs(ddstatus.Textfmap()).Parse(statusTemplate)
-	require.NoError(t, err)
-	err = tpl.Execute(&expectedStatusBuilder, expectedStatus)
-	require.NoError(t, err)
-
-	// Build the actual status
-	getAndWriteStatus(&statusBuilder, overrideTime(testTime))
-
-	assert.Equal(t, expectedStatusBuilder.String(), statusBuilder.String())
-
-	err = server.stop()
-	require.NoError(t, err)
-}
-
-func TestNotRunning(t *testing.T) {
-	// Use different ports in case the host is running a real agent
-	cfg := config.Mock()
-	cfg.Set("process_config.expvar_port", 8081)
-	cfg.Set("process_config.cmd_port", 8082)
-
-	var b strings.Builder
-	getAndWriteStatus(&b)
-
-	assert.Equal(t, notRunning, b.String())
-}
-
-// TestError tests an example error to make sure that the error template prints properly if we get something other than
-// a connection error
-func TestError(t *testing.T) {
-	cfg := config.Mock()
-	cfg.Set("ipc_address", "8.8.8.8") // Non-local ip address will cause error in `GetIPCAddress`
-	_, ipcError := config.GetIPCAddress()
-
-	var errText, expectedErrText strings.Builder
-	getAndWriteStatus(&errText)
-
-	tpl, err := template.New("").Parse(errorMessage)
-	require.NoError(t, err)
-	err = tpl.Execute(&expectedErrText, fmt.Errorf("config error: %s", ipcError))
-	require.NoError(t, err)
-
-	assert.Equal(t, expectedErrText.String(), errText.String())
-}
+//type statusServer struct {
+//	shutdownWg                  *sync.WaitGroup
+//	statusServer, expvarsServer *http.Server
+//}
+//
+//func (s *statusServer) stop() error {
+//	err := s.statusServer.Shutdown(context.Background())
+//	if err != nil {
+//		return err
+//	}
+//
+//	err = s.expvarsServer.Shutdown(context.Background())
+//	if err != nil {
+//		return err
+//	}
+//
+//	s.shutdownWg.Wait()
+//	return nil
+//}
+//
+//func startTestServer(t *testing.T, cfg config.Config, expectedStatus util.Status) statusServer {
+//	var serverWg sync.WaitGroup
+//	serverWg.Add(2)
+//
+//	statusMux := http.NewServeMux()
+//	statusMux.HandleFunc("/agent/status", func(w http.ResponseWriter, _ *http.Request) {
+//		b, err := json.Marshal(expectedStatus)
+//		require.NoError(t, err)
+//
+//		_, err = w.Write(b)
+//		require.NoError(t, err)
+//	})
+//	statusEndpoint := fmt.Sprintf("localhost:%d", cfg.GetInt("process_config.cmd_port"))
+//	statusServer := http.Server{Addr: statusEndpoint, Handler: statusMux}
+//	statusListener, err := net.Listen("tcp", statusEndpoint)
+//	require.NoError(t, err)
+//	go func() {
+//		_ = statusServer.Serve(statusListener)
+//		serverWg.Done()
+//	}()
+//
+//	expvarMux := http.NewServeMux()
+//	expvarMux.HandleFunc("/debug/vars", func(w http.ResponseWriter, _ *http.Request) {
+//		b, err := json.Marshal(expectedStatus.Expvars)
+//		require.NoError(t, err)
+//
+//		_, err = w.Write(b)
+//		require.NoError(t, err)
+//	})
+//	expvarEndpoint := fmt.Sprintf("localhost:%d", cfg.GetInt("process_config.expvar_port"))
+//	expvarsServer := http.Server{Addr: expvarEndpoint, Handler: expvarMux}
+//	expvarsListener, err := net.Listen("tcp", expvarEndpoint)
+//	require.NoError(t, err)
+//	go func() {
+//		_ = expvarsServer.Serve(expvarsListener)
+//		serverWg.Done()
+//	}()
+//
+//	return statusServer{coreStatusServer: &coreStatusServer, expvarsServer: &expvarsServer, shutdownWg: &serverWg}
+//}
+//
+//func TestStatus(t *testing.T) {
+//	testTime := time.Now()
+//	expectedStatus := util.Status{
+//		Date: float64(testTime.UnixNano()),
+//		Core: util.CoreStatus{
+//			Metadata: host.Payload{
+//				Meta: &host.Meta{},
+//			},
+//		},
+//		Expvars: util.ProcessExpvars{},
+//	}
+//
+//	// Use different ports in case the host is running a real agent
+//	cfg := config.Mock()
+//	cfg.Set("process_config.expvar_port", 8081)
+//	cfg.Set("process_config.cmd_port", 8082)
+//	server := startTestServer(t, cfg, expectedStatus)
+//
+//	var statusBuilder, expectedStatusBuilder strings.Builder
+//
+//	// Build what the expected status should be
+//	tpl, err := template.New("").Funcs(ddstatus.Textfmap()).Parse(statusTemplate)
+//	require.NoError(t, err)
+//	err = tpl.Execute(&expectedStatusBuilder, expectedStatus)
+//	require.NoError(t, err)
+//
+//	// Build the actual status
+//	getAndWriteStatus(&statusBuilder, util.OverrideTime(testTime))
+//
+//	assert.Equal(t, expectedStatusBuilder.String(), statusBuilder.String())
+//
+//	err = server.stop()
+//	require.NoError(t, err)
+//}
+//
+//func TestNotRunning(t *testing.T) {
+//	// Use different ports in case the host is running a real agent
+//	cfg := config.Mock()
+//	cfg.Set("process_config.expvar_port", 8081)
+//	cfg.Set("process_config.cmd_port", 8082)
+//
+//	var b strings.Builder
+//	getAndWriteStatus(&b)
+//
+//	assert.Equal(t, notRunning, b.String())
+//}
+//
+//// TestError tests an example error to make sure that the error template prints properly if we get something other than
+//// a connection error
+//func TestError(t *testing.T) {
+//	cfg := config.Mock()
+//	cfg.Set("ipc_address", "8.8.8.8") // Non-local ip address will cause error in `GetIPCAddress`
+//	_, ipcError := config.GetIPCAddress()
+//
+//	var errText, expectedErrText strings.Builder
+//	getAndWriteStatus(&errText)
+//
+//	tpl, err := template.New("").Parse(errorMessage)
+//	require.NoError(t, err)
+//	err = tpl.Execute(&expectedErrText, fmt.Errorf("config error: %s", ipcError))
+//	require.NoError(t, err)
+//
+//	assert.Equal(t, expectedErrText.String(), errText.String())
+//}

--- a/cmd/process-agent/app/status_test.go
+++ b/cmd/process-agent/app/status_test.go
@@ -107,7 +107,6 @@ func TestNotRunning(t *testing.T) {
 	assert.Equal(t, notRunning, b.String())
 }
 
-//
 // TestError tests an example error to make sure that the error template prints properly if we get something other than
 // a connection error
 func TestError(t *testing.T) {

--- a/cmd/process-agent/app/status_test.go
+++ b/cmd/process-agent/app/status_test.go
@@ -1,129 +1,127 @@
 package app
 
-// TODO: mock status server here to test status cmd. Move expvar server logic to pkg/process/util
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"text/template"
+	"time"
 
-//type statusServer struct {
-//	shutdownWg                  *sync.WaitGroup
-//	statusServer, expvarsServer *http.Server
-//}
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/metadata/host"
+	ddstatus "github.com/DataDog/datadog-agent/pkg/status"
+)
+
+type statusServer struct {
+	shutdownWg *sync.WaitGroup
+	server     *http.Server
+}
+
+func (s *statusServer) stop() error {
+	err := s.server.Shutdown(context.Background())
+	if err != nil {
+		return err
+	}
+
+	s.shutdownWg.Wait()
+	return nil
+}
+
+func startTestServer(t *testing.T, cfg config.Config, expectedStatus util.Status) statusServer {
+	var serverWg sync.WaitGroup
+	serverWg.Add(1)
+
+	statusMux := http.NewServeMux()
+	statusMux.HandleFunc("/agent/status", func(w http.ResponseWriter, _ *http.Request) {
+		b, err := json.Marshal(expectedStatus)
+		require.NoError(t, err)
+
+		_, err = w.Write(b)
+		require.NoError(t, err)
+	})
+
+	statusEndpoint := fmt.Sprintf("localhost:%d", cfg.GetInt("process_config.cmd_port"))
+	server := http.Server{Addr: statusEndpoint, Handler: statusMux}
+	statusListener, err := net.Listen("tcp", statusEndpoint)
+	require.NoError(t, err)
+	go func() {
+		_ = server.Serve(statusListener)
+		serverWg.Done()
+	}()
+
+	return statusServer{server: &server, shutdownWg: &serverWg}
+}
+
+func TestStatus(t *testing.T) {
+	testTime := time.Now()
+	expectedStatus := util.Status{
+		Date: float64(testTime.UnixNano()),
+		Core: util.CoreStatus{
+			Metadata: host.Payload{
+				Meta: &host.Meta{},
+			},
+		},
+		Expvars: util.ProcessExpvars{},
+	}
+
+	// Use different ports in case the host is running a real agent
+	cfg := config.Mock()
+	cfg.Set("process_config.cmd_port", 8082)
+	server := startTestServer(t, cfg, expectedStatus)
+
+	var statusBuilder strings.Builder
+
+	j, err := json.Marshal(expectedStatus)
+	require.NoError(t, err)
+
+	// Build what the expected status should be
+	expectedOutput, err := ddstatus.FormatProcessAgentStatus(j)
+	require.NoError(t, err)
+
+	// Build the actual status
+	getAndWriteStatus(&statusBuilder, util.OverrideTime(testTime))
+
+	assert.Equal(t, expectedOutput, statusBuilder.String())
+
+	err = server.stop()
+	require.NoError(t, err)
+}
+
+func TestNotRunning(t *testing.T) {
+	// Use different ports in case the host is running a real agent
+	cfg := config.Mock()
+	cfg.Set("process_config.cmd_port", 8082)
+
+	var b strings.Builder
+	getAndWriteStatus(&b)
+
+	assert.Equal(t, notRunning, b.String())
+}
+
 //
-//func (s *statusServer) stop() error {
-//	err := s.statusServer.Shutdown(context.Background())
-//	if err != nil {
-//		return err
-//	}
-//
-//	err = s.expvarsServer.Shutdown(context.Background())
-//	if err != nil {
-//		return err
-//	}
-//
-//	s.shutdownWg.Wait()
-//	return nil
-//}
-//
-//func startTestServer(t *testing.T, cfg config.Config, expectedStatus util.Status) statusServer {
-//	var serverWg sync.WaitGroup
-//	serverWg.Add(2)
-//
-//	statusMux := http.NewServeMux()
-//	statusMux.HandleFunc("/agent/status", func(w http.ResponseWriter, _ *http.Request) {
-//		b, err := json.Marshal(expectedStatus)
-//		require.NoError(t, err)
-//
-//		_, err = w.Write(b)
-//		require.NoError(t, err)
-//	})
-//	statusEndpoint := fmt.Sprintf("localhost:%d", cfg.GetInt("process_config.cmd_port"))
-//	statusServer := http.Server{Addr: statusEndpoint, Handler: statusMux}
-//	statusListener, err := net.Listen("tcp", statusEndpoint)
-//	require.NoError(t, err)
-//	go func() {
-//		_ = statusServer.Serve(statusListener)
-//		serverWg.Done()
-//	}()
-//
-//	expvarMux := http.NewServeMux()
-//	expvarMux.HandleFunc("/debug/vars", func(w http.ResponseWriter, _ *http.Request) {
-//		b, err := json.Marshal(expectedStatus.Expvars)
-//		require.NoError(t, err)
-//
-//		_, err = w.Write(b)
-//		require.NoError(t, err)
-//	})
-//	expvarEndpoint := fmt.Sprintf("localhost:%d", cfg.GetInt("process_config.expvar_port"))
-//	expvarsServer := http.Server{Addr: expvarEndpoint, Handler: expvarMux}
-//	expvarsListener, err := net.Listen("tcp", expvarEndpoint)
-//	require.NoError(t, err)
-//	go func() {
-//		_ = expvarsServer.Serve(expvarsListener)
-//		serverWg.Done()
-//	}()
-//
-//	return statusServer{coreStatusServer: &coreStatusServer, expvarsServer: &expvarsServer, shutdownWg: &serverWg}
-//}
-//
-//func TestStatus(t *testing.T) {
-//	testTime := time.Now()
-//	expectedStatus := util.Status{
-//		Date: float64(testTime.UnixNano()),
-//		Core: util.CoreStatus{
-//			Metadata: host.Payload{
-//				Meta: &host.Meta{},
-//			},
-//		},
-//		Expvars: util.ProcessExpvars{},
-//	}
-//
-//	// Use different ports in case the host is running a real agent
-//	cfg := config.Mock()
-//	cfg.Set("process_config.expvar_port", 8081)
-//	cfg.Set("process_config.cmd_port", 8082)
-//	server := startTestServer(t, cfg, expectedStatus)
-//
-//	var statusBuilder, expectedStatusBuilder strings.Builder
-//
-//	// Build what the expected status should be
-//	tpl, err := template.New("").Funcs(ddstatus.Textfmap()).Parse(statusTemplate)
-//	require.NoError(t, err)
-//	err = tpl.Execute(&expectedStatusBuilder, expectedStatus)
-//	require.NoError(t, err)
-//
-//	// Build the actual status
-//	getAndWriteStatus(&statusBuilder, util.OverrideTime(testTime))
-//
-//	assert.Equal(t, expectedStatusBuilder.String(), statusBuilder.String())
-//
-//	err = server.stop()
-//	require.NoError(t, err)
-//}
-//
-//func TestNotRunning(t *testing.T) {
-//	// Use different ports in case the host is running a real agent
-//	cfg := config.Mock()
-//	cfg.Set("process_config.expvar_port", 8081)
-//	cfg.Set("process_config.cmd_port", 8082)
-//
-//	var b strings.Builder
-//	getAndWriteStatus(&b)
-//
-//	assert.Equal(t, notRunning, b.String())
-//}
-//
-//// TestError tests an example error to make sure that the error template prints properly if we get something other than
-//// a connection error
-//func TestError(t *testing.T) {
-//	cfg := config.Mock()
-//	cfg.Set("ipc_address", "8.8.8.8") // Non-local ip address will cause error in `GetIPCAddress`
-//	_, ipcError := config.GetIPCAddress()
-//
-//	var errText, expectedErrText strings.Builder
-//	getAndWriteStatus(&errText)
-//
-//	tpl, err := template.New("").Parse(errorMessage)
-//	require.NoError(t, err)
-//	err = tpl.Execute(&expectedErrText, fmt.Errorf("config error: %s", ipcError))
-//	require.NoError(t, err)
-//
-//	assert.Equal(t, expectedErrText.String(), errText.String())
-//}
+// TestError tests an example error to make sure that the error template prints properly if we get something other than
+// a connection error
+func TestError(t *testing.T) {
+	cfg := config.Mock()
+	cfg.Set("ipc_address", "8.8.8.8") // Non-local ip address will cause error in `GetIPCAddress`
+	_, ipcError := config.GetIPCAddress()
+
+	var errText, expectedErrText strings.Builder
+	getAndWriteStatus(&errText)
+
+	tpl, err := template.New("").Parse(errorMessage)
+	require.NoError(t, err)
+	err = tpl.Execute(&expectedErrText, fmt.Errorf("config error: %s", ipcError))
+	require.NoError(t, err)
+
+	assert.Equal(t, expectedErrText.String(), errText.String())
+}

--- a/pkg/process/util/status.go
+++ b/pkg/process/util/status.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"runtime"
 	"time"
 
@@ -12,10 +11,9 @@ import (
 	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metadata/host"
 	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
-
-var httpClient = apiutil.GetClient(false)
 
 // CoreStatus holds core info about the process-agent
 type CoreStatus struct {
@@ -72,7 +70,7 @@ type ProcessExpvars struct {
 // Status holds runtime information from process-agent
 type Status struct {
 	Date    float64        `json:"date"`
-	Core    CoreStatus     `json:"core"`    // Contains the status from the core agent
+	Core    CoreStatus     `json:"core"`    // Contains fields that are collected similarly to the core agent in pkg/status
 	Expvars ProcessExpvars `json:"expvars"` // Contains the expvars retrieved from the process agent
 }
 
@@ -129,6 +127,8 @@ func getExpvars() (s ProcessExpvars, err error) {
 		port = ddconfig.DefaultProcessExpVarPort
 	}
 	expvarEndpoint := fmt.Sprintf("http://%s:%d/debug/vars", ipcAddr, port)
+
+	httpClient := apiutil.GetClient(false)
 	b, err := apiutil.DoGet(httpClient, expvarEndpoint)
 	if err != nil {
 		return s, ConnectionError{err}

--- a/pkg/process/util/status.go
+++ b/pkg/process/util/status.go
@@ -40,14 +40,17 @@ type InfoVersion struct {
 	GoVersion string
 }
 
+// MemInfo holds information about memory usage from process-agent
+type MemInfo struct {
+	Alloc uint64 `json:"alloc"`
+}
+
 // ProcessExpvars holds values fetched from the exp var server
 type ProcessExpvars struct {
-	Pid        int     `json:"pid"`
-	Uptime     int     `json:"uptime"`
-	UptimeNano float64 `json:"uptime_nano"`
-	MemStats   struct {
-		Alloc uint64 `json:"alloc"`
-	} `json:"memstats"`
+	Pid                 int                 `json:"pid"`
+	Uptime              int                 `json:"uptime"`
+	UptimeNano          float64             `json:"uptime_nano"`
+	MemStats            MemInfo             `json:"memstats"`
 	Version             InfoVersion         `json:"version"`
 	DockerSocket        string              `json:"docker_socket"`
 	LastCollectTime     string              `json:"last_collect_time"`
@@ -66,7 +69,7 @@ type ProcessExpvars struct {
 	Endpoints           map[string][]string `json:"endpoints"`
 }
 
-// Status holds status info from process-agent
+// Status holds runtime information from process-agent
 type Status struct {
 	Date    float64        `json:"date"`
 	Core    CoreStatus     `json:"core"`    // Contains the status from the core agent
@@ -76,7 +79,7 @@ type Status struct {
 // StatusOption is a function that acts on a Status object
 type StatusOption func(s *Status)
 
-// ConnectionError represents an error to connect to a HTTP server
+// ConnectionError represents an error to connect to an HTTP server
 type ConnectionError struct {
 	error
 }

--- a/pkg/process/util/status.go
+++ b/pkg/process/util/status.go
@@ -95,13 +95,13 @@ func OverrideTime(t time.Time) StatusOption {
 }
 
 func getCoreStatus() (s CoreStatus) {
-	hostnameData, err := util.GetHostnameData(context.TODO())
+	hostnameData, err := util.GetHostnameData(context.Background())
 	var metadata *host.Payload
 	if err != nil {
 		log.Errorf("Error grabbing hostname for status: %v", err)
-		metadata = host.GetPayloadFromCache(context.TODO(), util.HostnameData{Hostname: "unknown", Provider: "unknown"})
+		metadata = host.GetPayloadFromCache(context.Background(), util.HostnameData{Hostname: "unknown", Provider: "unknown"})
 	} else {
-		metadata = host.GetPayloadFromCache(context.TODO(), hostnameData)
+		metadata = host.GetPayloadFromCache(context.Background(), hostnameData)
 	}
 
 	return CoreStatus{

--- a/pkg/process/util/status.go
+++ b/pkg/process/util/status.go
@@ -1,0 +1,146 @@
+package util
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"runtime"
+	"time"
+
+	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
+	ddconfig "github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/metadata/host"
+	"github.com/DataDog/datadog-agent/pkg/util"
+	"github.com/DataDog/datadog-agent/pkg/version"
+)
+
+var httpClient = apiutil.GetClient(false)
+
+type CoreStatus struct {
+	AgentVersion  string       `json:"version"`
+	GoVersion     string       `json:"go_version"`
+	PythonVersion string       `json:"python_version"`
+	Arch          string       `json:"build_arch"`
+	Config        ConfigStatus `json:"config"`
+	Metadata      host.Payload `json:"metadata"`
+}
+
+type ConfigStatus struct {
+	LogLevel string `json:"log_level"`
+}
+type InfoVersion struct {
+	Version   string
+	GitCommit string
+	GitBranch string
+	BuildDate string
+	GoVersion string
+}
+
+type ProcessExpvars struct {
+	Pid        int     `json:"pid"`
+	Uptime     int     `json:"uptime"`
+	UptimeNano float64 `json:"uptime_nano"`
+	MemStats   struct {
+		Alloc uint64 `json:"alloc"`
+	} `json:"memstats"`
+	Version             InfoVersion         `json:"version"`
+	DockerSocket        string              `json:"docker_socket"`
+	LastCollectTime     string              `json:"last_collect_time"`
+	ProcessCount        int                 `json:"process_count"`
+	ContainerCount      int                 `json:"container_count"`
+	ProcessQueueSize    int                 `json:"process_queue_size"`
+	RTProcessQueueSize  int                 `json:"rtprocess_queue_size"`
+	PodQueueSize        int                 `json:"pod_queue_size"`
+	ProcessQueueBytes   int                 `json:"process_queue_bytes"`
+	RTProcessQueueBytes int                 `json:"rtprocess_queue_bytes"`
+	PodQueueBytes       int                 `json:"pod_queue_bytes"`
+	ContainerID         string              `json:"container_id"`
+	ProxyURL            string              `json:"proxy_url"`
+	LogFile             string              `json:"log_file"`
+	EnabledChecks       []string            `json:"enabled_checks"`
+	Endpoints           map[string][]string `json:"endpoints"`
+}
+
+type Status struct {
+	Date    float64
+	Core    CoreStatus     // Contains the status from the core agent
+	Expvars ProcessExpvars // Contains the expvars retrieved from the process agent
+}
+
+type StatusOption func(s *Status)
+
+type ConnectionError struct {
+	error
+}
+
+func NewConnectionError(err error) ConnectionError {
+	return ConnectionError{err}
+}
+
+func OverrideTime(t time.Time) StatusOption {
+	return func(s *Status) {
+		s.Date = float64(t.UnixNano())
+	}
+}
+
+func getCoreStatus() (s CoreStatus) {
+	hostnameData, err := util.GetHostnameData(context.TODO())
+	var metadata *host.Payload
+	if err != nil {
+		log.Errorf("Error grabbing hostname for status: %v", err)
+		metadata = host.GetPayloadFromCache(context.TODO(), util.HostnameData{Hostname: "unknown", Provider: "unknown"})
+	} else {
+		metadata = host.GetPayloadFromCache(context.TODO(), hostnameData)
+	}
+
+	return CoreStatus{
+		AgentVersion:  version.AgentVersion,
+		GoVersion:     runtime.Version(),
+		PythonVersion: host.GetPythonVersion(),
+		Arch:          runtime.GOARCH,
+		Config: ConfigStatus{
+			LogLevel: ddconfig.Datadog.GetString("log_level"),
+		},
+		Metadata: *metadata,
+	}
+}
+
+func getExpvars() (s ProcessExpvars, err error) {
+	ipcAddr, err := ddconfig.GetIPCAddress()
+	if err != nil {
+		return ProcessExpvars{}, fmt.Errorf("config error: %s", err.Error())
+	}
+
+	port := ddconfig.Datadog.GetInt("process_config.expvar_port")
+	if port <= 0 {
+		_ = log.Warnf("Invalid process_config.expvar_port -- %d, using default port %d\n", port, ddconfig.DefaultProcessExpVarPort)
+		port = ddconfig.DefaultProcessExpVarPort
+	}
+	expvarEndpoint := fmt.Sprintf("http://%s:%d/debug/vars", ipcAddr, port)
+	b, err := apiutil.DoGet(httpClient, expvarEndpoint)
+	if err != nil {
+		return s, ConnectionError{err}
+	}
+
+	err = json.Unmarshal(b, &s)
+	return
+}
+
+func GetStatus() map[string]interface{} {
+	stats := make(map[string]interface{})
+
+	coreStatus := getCoreStatus()
+
+	processStatus, err := getExpvars()
+	if err != nil {
+		stats["error"] = fmt.Sprintf("%v", err.Error())
+		return stats
+	}
+
+	stats["date"] = float64(time.Now().UnixNano())
+	stats["core"] = coreStatus
+	stats["expvars"] = processStatus
+
+	return stats
+}

--- a/pkg/process/util/status_test.go
+++ b/pkg/process/util/status_test.go
@@ -92,12 +92,12 @@ func TestGetStatus(t *testing.T) {
 	cfg := ddconfig.Mock()
 	ddconfig.DetectFeatures()
 
-	hostnameData, err := util.GetHostnameData(context.TODO())
+	hostnameData, err := util.GetHostnameData(context.Background())
 	var metadata *host.Payload
 	if err != nil {
-		metadata = host.GetPayloadFromCache(context.TODO(), util.HostnameData{Hostname: "unknown", Provider: "unknown"})
+		metadata = host.GetPayloadFromCache(context.Background(), util.HostnameData{Hostname: "unknown", Provider: "unknown"})
 	} else {
-		metadata = host.GetPayloadFromCache(context.TODO(), hostnameData)
+		metadata = host.GetPayloadFromCache(context.Background(), hostnameData)
 	}
 
 	expectedStatus := &Status{

--- a/pkg/process/util/status_test.go
+++ b/pkg/process/util/status_test.go
@@ -21,13 +21,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
-type statusServer struct {
-	shutdownWg   *sync.WaitGroup
-	expVarServer *http.Server
+type expVarServer struct {
+	shutdownWg *sync.WaitGroup
+	server     *http.Server
 }
 
-func (s *statusServer) stop() error {
-	err := s.expVarServer.Shutdown(context.Background())
+func (s *expVarServer) stop() error {
+	err := s.server.Shutdown(context.Background())
 	if err != nil {
 		return err
 	}
@@ -36,7 +36,7 @@ func (s *statusServer) stop() error {
 	return nil
 }
 
-func startTestServer(t *testing.T, cfg config.Config, expectedExpVars ProcessExpvars) statusServer {
+func startTestServer(t *testing.T, cfg config.Config, expectedExpVars ProcessExpvars) expVarServer {
 	var serverWg sync.WaitGroup
 	serverWg.Add(1)
 
@@ -57,7 +57,7 @@ func startTestServer(t *testing.T, cfg config.Config, expectedExpVars ProcessExp
 		serverWg.Done()
 	}()
 
-	return statusServer{expVarServer: &expVarsServer, shutdownWg: &serverWg}
+	return expVarServer{server: &expVarsServer, shutdownWg: &serverWg}
 }
 
 func TestGetStatus(t *testing.T) {

--- a/pkg/process/util/status_test.go
+++ b/pkg/process/util/status_test.go
@@ -1,0 +1,57 @@
+package util
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"net"
+	"net/http"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+type statusServer struct {
+	shutdownWg   *sync.WaitGroup
+	expVarServer *http.Server
+}
+
+func (s *statusServer) stop() error {
+	err := s.expVarServer.Shutdown(context.Background())
+	if err != nil {
+		return err
+	}
+
+	s.shutdownWg.Wait()
+	return nil
+}
+
+func startTestServer(t *testing.T, cfg config.Config, expectedExpVars ProcessExpvars) statusServer {
+	var serverWg sync.WaitGroup
+	serverWg.Add(1)
+
+	expVarMux := http.NewServeMux()
+	expVarMux.HandleFunc("/debug/vars", func(w http.ResponseWriter, _ *http.Request) {
+		b, err := json.Marshal(expectedExpVars)
+		require.NoError(t, err)
+
+		_, err = w.Write(b)
+		require.NoError(t, err)
+	})
+	expVarEndpoint := fmt.Sprintf("localhost:%d", cfg.GetInt("process_config.expvar_port"))
+	expVarsServer := http.Server{Addr: expCarEndpoint, Handler: expVarMux}
+	expVarsListener, err := net.Listen("tcp", expVarEndpoint)
+	require.NoError(t, err)
+	go func() {
+		_ = expVarsServer.Serve(expVarsListener)
+		serverWg.Done()
+	}()
+
+	return statusServer{expVarServer: &expVarsServer, shutdownWg: &serverWg}
+}
+
+func TestGetStatus(t *testing.T) {
+
+}

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -52,6 +52,7 @@ func FormatStatus(data []byte) (string, error) {
 	endpointsInfos := stats["endpointsInfos"]
 	inventoriesStats := stats["inventories"]
 	systemProbeStats := stats["systemProbeStats"]
+	processAgentStatus := stats["processAgentStatus"]
 	snmpTrapsStats := stats["snmpTrapsStats"]
 	title := fmt.Sprintf("Agent (v%s)", stats["version"])
 	stats["title"] = title
@@ -64,6 +65,7 @@ func FormatStatus(data []byte) (string, error) {
 	if config.Datadog.GetBool("system_probe_config.enabled") {
 		renderStatusTemplate(b, "/systemprobe.tmpl", systemProbeStats)
 	}
+	renderStatusTemplate(b, "/process-agent.tmpl", processAgentStatus)
 	renderStatusTemplate(b, "/trace-agent.tmpl", stats["apmStats"])
 	renderStatusTemplate(b, "/aggregator.tmpl", aggregatorStats)
 	renderStatusTemplate(b, "/dogstatsd.tmpl", dogstatsdStats)

--- a/pkg/status/render.go
+++ b/pkg/status/render.go
@@ -139,6 +139,17 @@ func FormatSecurityAgentStatus(data []byte) (string, error) {
 	return b.String(), nil
 }
 
+// FormatProcessAgentStatus takes a json bytestring and prints out the formatted status for process-agent
+func FormatProcessAgentStatus(data []byte) (string, error) {
+	var b = new(bytes.Buffer)
+
+	stats := make(map[string]interface{})
+	json.Unmarshal(data, &stats) //nolint:errcheck
+	renderStatusTemplate(b, "/process-agent.tmpl", stats)
+
+	return b.String(), nil
+}
+
 // FormatMetadataMapCLI builds the rendering in the metadataMapper template.
 func FormatMetadataMapCLI(data []byte) (string, error) {
 	var b = new(bytes.Buffer)

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -76,6 +76,8 @@ func GetStatus() (map[string]interface{}, error) {
 		stats["systemProbeStats"] = GetSystemProbeStats(config.Datadog.GetString("system_probe_config.sysprobe_socket"))
 	}
 
+	stats["processAgentStatus"] = GetProcessAgentStatus()
+
 	if !config.Datadog.GetBool("no_proxy_nonexact_match") {
 		httputils.NoProxyMapMutex.Lock()
 		stats["TransportWarnings"] = len(httputils.NoProxyIgnoredWarningMap)+len(httputils.NoProxyUsedInFuture)+len(httputils.NoProxyChanged) > 0

--- a/pkg/status/status_process_agent.go
+++ b/pkg/status/status_process_agent.go
@@ -13,11 +13,10 @@ import (
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
 )
 
-//TODO: do not use a global var for this
-var httpClient = apiutil.GetClient(false)
-
 // GetProcessAgentStatus returns the status command of the process-agent
 func GetProcessAgentStatus() map[string]interface{} {
+	httpClient := apiutil.GetClient(false)
+
 	s := make(map[string]interface{})
 	addressPort, err := api.GetAPIAddressPort()
 	if err != nil {

--- a/pkg/status/status_process_agent.go
+++ b/pkg/status/status_process_agent.go
@@ -1,0 +1,35 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package status
+
+import (
+	"fmt"
+)
+
+// GetProcessAgentStats returns the status command of the process-agent
+func GetProcessAgentStatus() map[string]interface{} {
+	//net.SetSystemProbePath(socketPath)
+	//probeUtil, err := net.GetRemoteSystemProbeUtil()
+
+	//if err != nil {
+	//	return map[string]interface{}{
+	//		"Errors": fmt.Sprintf("%v", err),
+	//	}
+	//}
+
+	processAgentStatus := map[string]interface{}{
+		"Errors": fmt.Sprintf("Testing process-agent status"),
+	}
+
+	//systemProbeDetails, err := probeUtil.GetStats()
+	//if err != nil {
+	//	return map[string]interface{}{
+	//		"Errors": fmt.Sprintf("issue querying stats from system probe: %v", err),
+	//	}
+	//}
+
+	return processAgentStatus
+}

--- a/pkg/status/status_process_agent.go
+++ b/pkg/status/status_process_agent.go
@@ -13,7 +13,7 @@ import (
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
 )
 
-// GetProcessAgentStatus returns the status command of the process-agent
+// GetProcessAgentStatus fetches the process-agent status from the process-agent API server
 func GetProcessAgentStatus() map[string]interface{} {
 	httpClient := apiutil.GetClient(false)
 

--- a/pkg/status/templates/process-agent.tmpl
+++ b/pkg/status/templates/process-agent.tmpl
@@ -2,79 +2,47 @@
 Process Agent
 =============
 
-{{- if .Errors }}
-  Status: Testing Process Agent Status on main agent
-  Error: {{ .Errors }}
+{{- if .error }}
+  Status: Not running or unreachable
 {{- else }}
-  Status: Running
-  Uptime: {{ .uptime }}
-  Last Updated: {{ formatUnixTime .updated_at }}
-{{- end }}
-{{- if .network_tracer }}
+  Version: {{ .core.version }}
+  Status date: {{ formatUnixTime .date }}
+  Process Agent Start: {{ formatUnixTime .expvars.uptime_nano }}
+  Pid: {{ .expvars.pid }}
+  Go Version: {{ .core.go_version }}
+  Build arch: {{ .core.build_arch }}
+  Log Level: {{ .core.config.log_level }}
+  Enabled Checks: {{ .expvars.enabled_checks }}
+  Allocated Memory: {{ .expvars.memstats.alloc }} bytes
+  Hostname: {{ .core.metadata.meta.hostname }}
 
-  NPM
-  ===
-  {{- if .network_tracer.Error }}
-    Status: Not running
-    Error: {{ .network_tracer.Error }}
+  =================
+  Process Endpoints
+  =================
+  {{- with .expvars.endpoints}}
+    {{- range $key, $value := .}}
+    {{$key}} - API Key{{ if gt (len $value) 1}}s{{end}} ending with:
+      {{- range $idx, $apikey := $value }}
+        - {{$apikey}}
+      {{- end}}
+    {{- end}}
   {{- else }}
-    Status: Running
-    {{- if .network_tracer.tracer.last_check }}
-    Last Check: {{ formatUnixTime .network_tracer.tracer.last_check }}
-    {{- end }}
-    {{- if .network_tracer.state.clients }}
-    Client Count: {{ len .network_tracer.state.clients }}
-    {{- end }}
-  {{- end }}
-{{- end }}
-{{- if .oom_kill_probe }}
 
-  OOM Kill
-  ========
-  {{- if .oom_kill_probe.Error }}
-    Status: Not running
-    Error: {{ .oom_kill_probe.Error }}
-  {{- else }}
-    Status: Running
-    {{- if .oom_kill_probe.last_check }}
-    Last Check: {{ formatUnixTime .oom_kill_probe.last_check }}
-    {{- end }}
+    No endpoints information. The agent may be misconfigured.
   {{- end }}
-{{- end }}
-{{- if .tcp_queue_length_tracer }}
 
-  TCP Queue Length
-  ================
-  {{- if .tcp_queue_length_tracer.Error }}
-    Status: Not running
-    Error: {{ .tcp_queue_length_tracer.Error }}
-  {{- else }}
-    Status: Running
-    {{- if .tcp_queue_length_tracer.last_check }}
-    Last Check: {{ formatUnixTime .tcp_queue_length_tracer.last_check }}
-    {{- end }}
-  {{- end }}
-{{- end }}
-{{- if .security_runtime }}
+  =========
+  Collector
+  =========
 
-  Runtime Security
-  ================
-  {{- if .security_runtime.Error }}
-    Status: Not running
-    Error: {{ .security_runtime.Error }}
-  {{- else }}
-    Status: Running
-  {{- end }}
-{{- end }}
-{{- if .process }}
-
-  Process
-  =======
-  {{- if .process.Error }}
-    Status: Not running
-    Error: {{ .process.Error }}
-  {{- else }}
-    Status: Running
-  {{- end }}
-{{- end }}
-
+    Last collection time: {{.expvars.last_collect_time}}
+    Docker socket: {{.expvars.docker_socket}}
+    Number of processes: {{.expvars.process_count}}
+    Number of containers: {{.expvars.container_count}}
+    Process Queue length: {{.expvars.process_queue_size}}
+    RTProcess Queue length: {{.expvars.rtprocess_queue_size}}
+    Pod Queue length: {{.expvars.pod_queue_size}}
+    Process Bytes enqueued: {{.expvars.process_queue_bytes}}
+    RTProcess Bytes enqueued: {{.expvars.rtprocess_queue_bytes}}
+    Pod Bytes enqueued: {{.expvars.pod_queue_bytes}}
+{{ end }}

--- a/pkg/status/templates/process-agent.tmpl
+++ b/pkg/status/templates/process-agent.tmpl
@@ -1,0 +1,80 @@
+=============
+Process Agent
+=============
+
+{{- if .Errors }}
+  Status: Testing Process Agent Status on main agent
+  Error: {{ .Errors }}
+{{- else }}
+  Status: Running
+  Uptime: {{ .uptime }}
+  Last Updated: {{ formatUnixTime .updated_at }}
+{{- end }}
+{{- if .network_tracer }}
+
+  NPM
+  ===
+  {{- if .network_tracer.Error }}
+    Status: Not running
+    Error: {{ .network_tracer.Error }}
+  {{- else }}
+    Status: Running
+    {{- if .network_tracer.tracer.last_check }}
+    Last Check: {{ formatUnixTime .network_tracer.tracer.last_check }}
+    {{- end }}
+    {{- if .network_tracer.state.clients }}
+    Client Count: {{ len .network_tracer.state.clients }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- if .oom_kill_probe }}
+
+  OOM Kill
+  ========
+  {{- if .oom_kill_probe.Error }}
+    Status: Not running
+    Error: {{ .oom_kill_probe.Error }}
+  {{- else }}
+    Status: Running
+    {{- if .oom_kill_probe.last_check }}
+    Last Check: {{ formatUnixTime .oom_kill_probe.last_check }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- if .tcp_queue_length_tracer }}
+
+  TCP Queue Length
+  ================
+  {{- if .tcp_queue_length_tracer.Error }}
+    Status: Not running
+    Error: {{ .tcp_queue_length_tracer.Error }}
+  {{- else }}
+    Status: Running
+    {{- if .tcp_queue_length_tracer.last_check }}
+    Last Check: {{ formatUnixTime .tcp_queue_length_tracer.last_check }}
+    {{- end }}
+  {{- end }}
+{{- end }}
+{{- if .security_runtime }}
+
+  Runtime Security
+  ================
+  {{- if .security_runtime.Error }}
+    Status: Not running
+    Error: {{ .security_runtime.Error }}
+  {{- else }}
+    Status: Running
+  {{- end }}
+{{- end }}
+{{- if .process }}
+
+  Process
+  =======
+  {{- if .process.Error }}
+    Status: Not running
+    Error: {{ .process.Error }}
+  {{- else }}
+    Status: Running
+  {{- end }}
+{{- end }}
+

--- a/pkg/status/templates/process-agent.tmpl
+++ b/pkg/status/templates/process-agent.tmpl
@@ -1,10 +1,11 @@
 =============
 Process Agent
 =============
-
 {{- if .error }}
+
   Status: Not running or unreachable
 {{- else }}
+
   Version: {{ .core.version }}
   Status date: {{ formatUnixTime .date }}
   Process Agent Start: {{ formatUnixTime .expvars.uptime_nano }}
@@ -34,7 +35,6 @@ Process Agent
   =========
   Collector
   =========
-
     Last collection time: {{.expvars.last_collect_time}}
     Docker socket: {{.expvars.docker_socket}}
     Number of processes: {{.expvars.process_count}}
@@ -45,4 +45,5 @@ Process Agent
     Process Bytes enqueued: {{.expvars.process_queue_bytes}}
     RTProcess Bytes enqueued: {{.expvars.rtprocess_queue_bytes}}
     Pod Bytes enqueued: {{.expvars.pod_queue_bytes}}
-{{ end }}
+{{- end }}
+

--- a/releasenotes/notes/process-agent-add-status-to-core-agent-38d1cd109ab5bb0e.yaml
+++ b/releasenotes/notes/process-agent-add-status-to-core-agent-38d1cd109ab5bb0e.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add `process-agent status` output to the core Agent status command.


### PR DESCRIPTION
### What does this PR do?

Currently process-agent exposes an `agent/status` endpoint that is used only to fetch the core status from the main `pkg/status` library. It's up to the `./process-agent status` process to fetch the core status, fetch the expvars, build the final status and render the status template.


![old_architecture](https://user-images.githubusercontent.com/45740044/153475126-efb384a0-5975-4e39-aa32-1ebf8e2acf96.png)

This PR refactors this architecture to encapsulate the status build inside `/agent/status`. By doing so, `./process-agent status` needs only to call the endpoint and render the status template. It also makes it easier to reuse the same endpoint in the core agent to include process-agent in its status output.

![new_architecture](https://user-images.githubusercontent.com/45740044/153493274-f4cada47-8f84-441a-8482-33b270ade9ef.png)


This PR introduces the following main changes:
* Move status build logic to a dedicated `pkg/process/util/status.go` file
* `cmd/process-agent/api` uses the GetStatus build function from  `pkg/process/util`
* `cmd/process-agent/app` fetches the status from the process-agent API server
* `core agent` fetches the process-agent status from the process-agent API server
* Move process-agent status template to `pkg/status` so it can be used by both core and process agents.


### Motivation

Add status command to process-agent and improve agent flare.

### Additional Notes

### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

The following tests need to be performed on a **linux host**, **docker**, **k8s cluster**, **windows** and **macOS**.

Set the following settings on the `datadog.yaml` file
```yaml
process_config:
  enabled: "disabled"
  process_discovery:
    enabled: false
```

Run
```
./agent status
```

and 
``` 
./process-agent status
```

Make sure that the output contains a message saying that the process-agent is not running or is unreachable.


Update datadog.yaml to enable the process-agent
```yaml
process_config:
  enabled: "true"
#  process_discovery:
#    enabled: false
```

Re-run
```
./agent status
```

and 
``` 
./process-agent status
```

Make sure that we're showing relevant and correct runtime information for process-agent.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
