### PR TITLE
Store metric and tagger tags separately

### DIFF
--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -587,7 +587,8 @@ func flushSomeSamples(agg *BufferedAggregator) map[string]*metrics.Serie {
 					Name:     name,
 					MType:    metrics.APICountType,
 					Interval: int64(timeSamplerBucketSize),
-					Tags:     tagset.CompositeTagsFromSlice(make([]string, 0))}
+					Tags:     tagset.NewCompositeTags([]string{}, []string{}),
+				}
 			}
 			expectedSeries[name].Points = append(expectedSeries[name].Points, metrics.Point{Ts: timestamp, Value: value})
 		}

--- a/pkg/aggregator/check_sampler_test.go
+++ b/pkg/aggregator/check_sampler_test.go
@@ -29,7 +29,7 @@ import (
 func generateContextKey(sample metrics.MetricSampleContext) ckey.ContextKey {
 	k := ckey.NewKeyGenerator()
 	tb := tagset.NewHashingTagsAccumulator()
-	sample.GetTags(tb)
+	sample.GetTags(tb, tb)
 	return k.Generate(sample.GetName(), sample.GetHost(), tb)
 }
 

--- a/pkg/aggregator/ckey/key.go
+++ b/pkg/aggregator/ckey/key.go
@@ -61,6 +61,16 @@ func (g *KeyGenerator) GenerateWithTags(name, hostname string, tagsBuf *tagset.H
 	return ContextKey(hash), TagsKey(tags)
 }
 
+// GenerateWithTags2 returns the ContextKey and TagsKey hashes for the given parameters.
+//
+// Tags from l, r are combined to produce the key and deduplicated, but most of the time left in
+// their respective buffers.
+func (g *KeyGenerator) GenerateWithTags2(name, hostname string, l, r *tagset.HashingTagsAccumulator) (ContextKey, TagsKey, TagsKey) {
+	lHash, rHash := g.hg.Hash2(l, r)
+	hash := murmur3.StringSum64(name) ^ murmur3.StringSum64(hostname) ^ lHash ^ rHash
+	return ContextKey(hash), TagsKey(lHash), TagsKey(rHash)
+}
+
 // Equals returns whether the two context keys are equal or not.
 func Equals(a, b ContextKey) bool {
 	return a == b

--- a/pkg/aggregator/ckey/key.go
+++ b/pkg/aggregator/ckey/key.go
@@ -66,7 +66,9 @@ func (g *KeyGenerator) GenerateWithTags(name, hostname string, tagsBuf *tagset.H
 // Tags from l, r are combined to produce the key and deduplicated, but most of the time left in
 // their respective buffers.
 func (g *KeyGenerator) GenerateWithTags2(name, hostname string, l, r *tagset.HashingTagsAccumulator) (ContextKey, TagsKey, TagsKey) {
-	lHash, rHash := g.hg.Hash2(l, r)
+	g.hg.Dedup2(l, r)
+	lHash := l.Hash()
+	rHash := r.Hash()
 	hash := murmur3.StringSum64(name) ^ murmur3.StringSum64(hostname) ^ lHash ^ rHash
 	return ContextKey(hash), TagsKey(lHash), TagsKey(rHash)
 }

--- a/pkg/aggregator/context_resolver.go
+++ b/pkg/aggregator/context_resolver.go
@@ -16,22 +16,15 @@ import (
 
 // Context holds the elements that form a context, and can be serialized into a context key
 type Context struct {
-	Name string
-	Host string
-	tags *tags.Entry
-}
-
-func newContext(name string, host string, tags *tags.Entry) *Context {
-	return &Context{
-		Name: name,
-		Host: host,
-		tags: tags,
-	}
+	Name       string
+	Host       string
+	taggerTags *tags.Entry
+	metricTags *tags.Entry
 }
 
 // Tags returns tags for the context.
 func (c *Context) Tags() tagset.CompositeTags {
-	return tagset.NewCompositeTags(c.tags.Tags(), nil)
+	return tagset.NewCompositeTags(c.taggerTags.Tags(), c.metricTags.Tags())
 }
 
 // contextResolver allows tracking and expiring contexts
@@ -39,14 +32,13 @@ type contextResolver struct {
 	contextsByKey map[ckey.ContextKey]*Context
 	tagsCache     *tags.Store
 	keyGenerator  *ckey.KeyGenerator
-	// buffer slice allocated once per contextResolver to combine and sort
-	// tags, origin detection tags and k8s tags.
-	tagsBuffer *tagset.HashingTagsAccumulator
+	taggerBuffer  *tagset.HashingTagsAccumulator
+	metricBuffer  *tagset.HashingTagsAccumulator
 }
 
 // generateContextKey generates the contextKey associated with the context of the metricSample
-func (cr *contextResolver) generateContextKey(metricSampleContext metrics.MetricSampleContext) (ckey.ContextKey, ckey.TagsKey) {
-	return cr.keyGenerator.GenerateWithTags(metricSampleContext.GetName(), metricSampleContext.GetHost(), cr.tagsBuffer)
+func (cr *contextResolver) generateContextKey(metricSampleContext metrics.MetricSampleContext) (ckey.ContextKey, ckey.TagsKey, ckey.TagsKey) {
+	return cr.keyGenerator.GenerateWithTags2(metricSampleContext.GetName(), metricSampleContext.GetHost(), cr.taggerBuffer, cr.metricBuffer)
 }
 
 func newContextResolver(cache *tags.Store) *contextResolver {
@@ -54,22 +46,28 @@ func newContextResolver(cache *tags.Store) *contextResolver {
 		contextsByKey: make(map[ckey.ContextKey]*Context),
 		tagsCache:     cache,
 		keyGenerator:  ckey.NewKeyGenerator(),
-		tagsBuffer:    tagset.NewHashingTagsAccumulator(),
+		taggerBuffer:  tagset.NewHashingTagsAccumulator(),
+		metricBuffer:  tagset.NewHashingTagsAccumulator(),
 	}
 }
 
 // trackContext returns the contextKey associated with the context of the metricSample and tracks that context
 func (cr *contextResolver) trackContext(metricSampleContext metrics.MetricSampleContext) ckey.ContextKey {
-	metricSampleContext.GetTags(cr.tagsBuffer)                        // tags here are not sorted and can contain duplicates
-	contextKey, tagsKey := cr.generateContextKey(metricSampleContext) // the generator will remove duplicates from cr.tagsBuffer (and doesn't mind the order)
+	metricSampleContext.GetTags(cr.taggerBuffer, cr.metricBuffer)                  // tags here are not sorted and can contain duplicates
+	contextKey, taggerKey, metricKey := cr.generateContextKey(metricSampleContext) // the generator will remove duplicates (and doesn't mind the order)
 
 	if _, ok := cr.contextsByKey[contextKey]; !ok {
-
-		cr.contextsByKey[contextKey] =
-			newContext(metricSampleContext.GetName(), metricSampleContext.GetHost(), cr.tagsCache.Insert(tagsKey, cr.tagsBuffer))
+		cr.contextsByKey[contextKey] = &Context{
+			Name:       metricSampleContext.GetName(),
+			taggerTags: cr.tagsCache.Insert(taggerKey, cr.taggerBuffer),
+			metricTags: cr.tagsCache.Insert(metricKey, cr.metricBuffer),
+			Host:       metricSampleContext.GetHost(),
+		}
 	}
 
-	cr.tagsBuffer.Reset()
+	cr.taggerBuffer.Reset()
+	cr.metricBuffer.Reset()
+
 	return contextKey
 }
 
@@ -88,7 +86,8 @@ func (cr *contextResolver) removeKeys(expiredContextKeys []ckey.ContextKey) {
 		delete(cr.contextsByKey, expiredContextKey)
 
 		if context != nil {
-			context.tags.Release()
+			context.taggerTags.Release()
+			context.metricTags.Release()
 		}
 	}
 }

--- a/pkg/metrics/histogram_bucket.go
+++ b/pkg/metrics/histogram_bucket.go
@@ -33,9 +33,9 @@ func (m *HistogramBucket) GetHost() string {
 }
 
 // GetTags returns the bucket tags.
-func (m *HistogramBucket) GetTags(tb *tagset.HashingTagsAccumulator) {
+func (m *HistogramBucket) GetTags(taggerBuffer, metricBuffer *tagset.HashingTagsAccumulator) {
 	// Other 'GetTags' methods for metrics support origin detections. Since
 	// HistogramBucket only come, for now, from checks we can simply return
 	// tags.
-	tb.Append(m.Tags...)
+	metricBuffer.Append(m.Tags...)
 }

--- a/pkg/metrics/metric_sample.go
+++ b/pkg/metrics/metric_sample.go
@@ -63,7 +63,7 @@ func (m MetricType) String() string {
 type MetricSampleContext interface {
 	GetName() string
 	GetHost() string
-	GetTags(*tagset.HashingTagsAccumulator)
+	GetTags(*tagset.HashingTagsAccumulator, *tagset.HashingTagsAccumulator)
 }
 
 // MetricSample represents a raw metric sample
@@ -95,9 +95,9 @@ func (m *MetricSample) GetHost() string {
 }
 
 // GetTags returns the metric sample tags
-func (m *MetricSample) GetTags(tb *tagset.HashingTagsAccumulator) {
-	tb.Append(m.Tags...)
-	tagger.EnrichTags(tb, m.OriginFromUDS, m.OriginFromClient, m.Cardinality)
+func (m *MetricSample) GetTags(taggerBuffer, metricBuffer *tagset.HashingTagsAccumulator) {
+	metricBuffer.Append(m.Tags...)
+	tagger.EnrichTags(taggerBuffer, m.OriginFromUDS, m.OriginFromClient, m.Cardinality)
 }
 
 // Copy returns a deep copy of the m MetricSample

--- a/pkg/otlp/internal/serializerexporter/consumer.go
+++ b/pkg/otlp/internal/serializerexporter/consumer.go
@@ -83,16 +83,17 @@ func (c *serializerConsumer) enrichTags(cardinality string) {
 	const origin = ""
 	const k8sOriginID = ""
 
+	tb := tagset.NewHashlessTagsAccumulator()
 	for i := range c.series {
-		tb := tagset.NewHashlessTagsAccumulatorFromSlice(c.series[i].Tags)
+		tb.Reset()
 		tagger.EnrichTags(tb, origin, k8sOriginID, cardinality)
-		c.series[i].Tags = tb.Get()
+		c.series[i].Tags.CombineWithSlice(tb.Copy())
 	}
 
 	for i := range c.sketches {
-		tb := tagset.NewHashlessTagsAccumulatorFromSlice(c.sketches[i].Tags)
+		tb.Reset()
 		tagger.EnrichTags(tb, origin, k8sOriginID, cardinality)
-		c.sketches[i].Tags = tb.Get()
+		c.sketches[i].Tags.CombineWithSlice(tb.Copy())
 	}
 }
 

--- a/pkg/tagset/composite_tags.go
+++ b/pkg/tagset/composite_tags.go
@@ -43,6 +43,11 @@ func CombineCompositeTagsAndSlice(compositeTags CompositeTags, tags []string) Co
 	return NewCompositeTags(compositeTags.tags1, newTags)
 }
 
+// CombineWithSlice adds tags to the composite tags. Consumes the slice.
+func (t *CompositeTags) CombineWithSlice(tags []string) {
+	*t = CombineCompositeTagsAndSlice(*t, tags)
+}
+
 // ForEach applies `callback` to each tag
 func (t CompositeTags) ForEach(callback func(tag string)) {
 	for _, t := range t.tags1 {

--- a/pkg/tagset/composite_tags_test.go
+++ b/pkg/tagset/composite_tags_test.go
@@ -3,6 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build test
 // +build test
 
 package tagset

--- a/pkg/tagset/hash_generator_test.go
+++ b/pkg/tagset/hash_generator_test.go
@@ -8,6 +8,8 @@ package tagset
 import (
 	"fmt"
 	"math/rand"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -112,4 +114,87 @@ func genTags(count int, div int) ([]string, []string) {
 	}
 
 	return tags, uniq
+}
+
+func TestHash2Small(t *testing.T) {
+	g := NewHashGenerator()
+
+	cases := []struct {
+		name             string
+		l, r, expL, expR string
+	}{
+		{"empty", "", "", "", ""},
+		{"empty l small", "", "foo", "", "foo"},
+		{"empty r small", "foo", "", "foo", ""},
+		{"small-1", "foo,foo,bar", "ook", "foo,bar", "ook"},
+		{"small-2", "foo,bar", "foo,ook", "foo,bar", "ook"},
+		{"small-3", "foo", "ook,foo,eek", "foo", "ook,eek"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			l := NewHashingTagsAccumulatorWithTags(strings.Split(tc.l, ","))
+			r := NewHashingTagsAccumulatorWithTags(strings.Split(tc.r, ","))
+
+			b := NewHashingTagsAccumulator()
+			b.Append(l.Get()...)
+			b.Append(r.Get()...)
+
+			hl, hr := g.Hash2(l, r)
+			got := hl ^ hr
+			exp := g.Hash(b)
+
+			assert.EqualValues(t, exp, got)
+			assert.EqualValues(t, tc.expL, strings.Join(l.Get(), ","))
+			assert.EqualValues(t, tc.expR, strings.Join(r.Get(), ","))
+		})
+	}
+}
+
+func TestHash2Rand(t *testing.T) {
+	g := NewHashGenerator()
+
+	for i := 1; i <= 1024; i *= 4 {
+		for j := 1; j < 4; j++ {
+			for k := 0; k < 20; k++ {
+				tags, _ := genTags(i, j)
+				rand.Shuffle(len(tags), func(i, j int) { tags[i], tags[j] = tags[j], tags[i] })
+				for n := 0; n <= len(tags); n += len(tags)/5 + 1 {
+					b := NewHashingTagsAccumulatorWithTags(tags)
+					l := NewHashingTagsAccumulatorWithTags(tags[:n])
+					r := NewHashingTagsAccumulatorWithTags(tags[n:])
+
+					h1 := g.Hash(b)
+					hl, hr := g.Hash2(l, r)
+					h2 := hl ^ hr
+
+					assert.EqualValues(t, h1, h2)
+					l.AppendHashingAccumulator(r)
+
+					sort.Sort(b)
+					sort.Sort(l)
+
+					assert.EqualValues(t, b.Get(), l.Get())
+				}
+			}
+		}
+	}
+}
+
+func BenchmarkHash2(b *testing.B) {
+	tags, _ := genTags(2048, 1)
+	for i := 1; i < 4096; i *= 2 {
+		l := NewHashingTagsAccumulatorWithTags(tags[:i/2])
+		r := NewHashingTagsAccumulatorWithTags(tags[i/2 : i])
+		b.Run(fmt.Sprintf("%d-tags", i), func(b *testing.B) {
+			hg := NewHashGenerator()
+			l, r := l.Dup(), r.Dup()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for n := 0; n < b.N; n++ {
+				hl, hr := hg.Hash2(l, r)
+				Hash = hl ^ hr
+			}
+		})
+	}
 }

--- a/pkg/tagset/hash_generator_test.go
+++ b/pkg/tagset/hash_generator_test.go
@@ -116,7 +116,7 @@ func genTags(count int, div int) ([]string, []string) {
 	return tags, uniq
 }
 
-func TestHash2Small(t *testing.T) {
+func TestDedup2Small(t *testing.T) {
 	g := NewHashGenerator()
 
 	cases := []struct {
@@ -140,8 +140,8 @@ func TestHash2Small(t *testing.T) {
 			b.Append(l.Get()...)
 			b.Append(r.Get()...)
 
-			hl, hr := g.Hash2(l, r)
-			got := hl ^ hr
+			g.Dedup2(l, r)
+			got := l.Hash() ^ r.Hash()
 			exp := g.Hash(b)
 
 			assert.EqualValues(t, exp, got)
@@ -151,7 +151,7 @@ func TestHash2Small(t *testing.T) {
 	}
 }
 
-func TestHash2Rand(t *testing.T) {
+func TestDedup2Rand(t *testing.T) {
 	g := NewHashGenerator()
 
 	for i := 1; i <= 1024; i *= 4 {
@@ -165,8 +165,8 @@ func TestHash2Rand(t *testing.T) {
 					r := NewHashingTagsAccumulatorWithTags(tags[n:])
 
 					h1 := g.Hash(b)
-					hl, hr := g.Hash2(l, r)
-					h2 := hl ^ hr
+					g.Dedup2(l, r)
+					h2 := l.Hash() ^ r.Hash()
 
 					assert.EqualValues(t, h1, h2)
 					l.AppendHashingAccumulator(r)
@@ -181,7 +181,7 @@ func TestHash2Rand(t *testing.T) {
 	}
 }
 
-func BenchmarkHash2(b *testing.B) {
+func BenchmarkDedup2(b *testing.B) {
 	tags, _ := genTags(2048, 1)
 	for i := 1; i < 4096; i *= 2 {
 		l := NewHashingTagsAccumulatorWithTags(tags[:i/2])
@@ -192,8 +192,7 @@ func BenchmarkHash2(b *testing.B) {
 			b.ReportAllocs()
 			b.ResetTimer()
 			for n := 0; n < b.N; n++ {
-				hl, hr := hg.Hash2(l, r)
-				Hash = hl ^ hr
+				hg.Dedup2(l, r)
 			}
 		})
 	}

--- a/pkg/tagset/hashing_tags_accumulator.go
+++ b/pkg/tagset/hashing_tags_accumulator.go
@@ -114,3 +114,15 @@ func (h *HashingTagsAccumulator) Swap(i, j int) {
 func (h *HashingTagsAccumulator) Dup() *HashingTagsAccumulator {
 	return &HashingTagsAccumulator{h.dup()}
 }
+
+// Hash returns combined hashes of all tags in the accumulator.
+//
+// Does not account for possibility of duplicates. Must be called after a call to Dedup2 or SortUniq
+// first.
+func (h *HashingTagsAccumulator) Hash() uint64 {
+	var hash uint64
+	for _, h := range h.hash {
+		hash ^= h
+	}
+	return hash
+}

--- a/pkg/tagset/hashing_tags_accumulator.go
+++ b/pkg/tagset/hashing_tags_accumulator.go
@@ -47,6 +47,12 @@ func (h *HashingTagsAccumulator) AppendHashed(src HashedTags) {
 	h.hash = append(h.hash, src.hash...)
 }
 
+// AppendHashingAccumulator appends tags and corresponding hashes to the accumulator
+func (h *HashingTagsAccumulator) AppendHashingAccumulator(src *HashingTagsAccumulator) {
+	h.data = append(h.data, src.data...)
+	h.hash = append(h.hash, src.hash...)
+}
+
 // SortUniq sorts and remove duplicate in place
 func (h *HashingTagsAccumulator) SortUniq() {
 	if h.Len() < 2 {

--- a/pkg/tagset/hashless_tags_accumulator.go
+++ b/pkg/tagset/hashless_tags_accumulator.go
@@ -47,6 +47,11 @@ func (h *HashlessTagsAccumulator) Get() []string {
 	return h.data
 }
 
+// Copy returns a new slice with the copy of the tags
+func (h *HashlessTagsAccumulator) Copy() []string {
+	return append(make([]string, 0, len(h.data)), h.data...)
+}
+
 // SortUniq sorts and remove duplicate in place
 func (h *HashlessTagsAccumulator) SortUniq() {
 	h.data = util.SortUniqInPlace(h.data)


### PR DESCRIPTION
(Depends on #10884)

This patch is based on observation that tagger tags usually have lower cardinality than metric tags. If stored separately, tagger tags can be shared between higher number of contexts, reducing number of tags in the per-context slice (which can also be shared better, if the same tagset happens to come from different origins).

- Use separate accumulators for tags that came with the metric sample and for tags from the tagger (origin detection). 
- Use Dedup2 to deduplicate them together and use hashes to store them separately in the store.
- Leverage CompositeTags to pass the two tags slices separately all the way to the serializer without having to allocate unified slice most of the time.

A round of cleanups and refactoring to follow after this lands.