### PR TITLE
Fix linting failure

### DIFF
--- a/pkg/collector/corechecks/system/winkmem/winkmem_test.go
+++ b/pkg/collector/corechecks/system/winkmem/winkmem_test.go
@@ -2,6 +2,7 @@
 // under the Apache License Version 2.0.
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2021-present Datadog, Inc.
+//go:build windows
 // +build windows
 
 package winkmem


### PR DESCRIPTION
### What does this PR do?

Fixes linting failure.  PR was built on older version of go, linting rules have changed.

### Motivation


### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
