### PR TITLE
[demultiplexer] the `Demultiplexer` is responsible of flushing all samplers/service checks/events to the serializer

### DIFF
--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -684,8 +684,6 @@ func (agg *BufferedAggregator) run() {
 			// - we don't need to Shrink() on stop
 			agg.tagsStore.Shrink()
 
-			addFlushTime("MainFlushTime", int64(time.Since(trigger.time)))
-			aggregatorNumberOfFlush.Add(1)
 			aggregatorEventPlatformErrorLogged = false
 		case <-agg.health.C:
 		case checkMetric := <-agg.checkMetricIn:

--- a/pkg/aggregator/aggregator.go
+++ b/pkg/aggregator/aggregator.go
@@ -652,13 +652,13 @@ func (agg *BufferedAggregator) Flush(trigger flushTrigger) {
 	agg.flushMutex.Lock()
 	defer agg.flushMutex.Unlock()
 	agg.flushSeriesAndSketches(trigger)
-	agg.flushServiceChecks(trigger.time, trigger.waitForSerializer)
-	agg.flushEvents(trigger.time, trigger.waitForSerializer)
-	agg.updateChecksTelemetry()
-	// notify the triggerer that we're done
+	// notify the triggerer that we're done flushing the series and sketches
 	if trigger.blockChan != nil {
 		trigger.blockChan <- struct{}{}
 	}
+	agg.flushServiceChecks(trigger.time, trigger.waitForSerializer)
+	agg.flushEvents(trigger.time, trigger.waitForSerializer)
+	agg.updateChecksTelemetry()
 }
 
 // Stop stops the aggregator.

--- a/pkg/aggregator/aggregator_test.go
+++ b/pkg/aggregator/aggregator_test.go
@@ -63,12 +63,14 @@ func testNewFlushTrigger(start time.Time, waitForSerializer bool) flushTrigger {
 	flushedSketches := make([]metrics.SketchSeriesList, 0)
 
 	return flushTrigger{
-		time:              start,
-		blockChan:         nil,
-		waitForSerializer: waitForSerializer,
-		flushedSeries:     &flushedSeries,
-		flushedSketches:   &flushedSketches,
-		seriesSink:        seriesSink,
+		trigger: trigger{
+			time:              start,
+			blockChan:         nil,
+			waitForSerializer: waitForSerializer,
+		},
+		flushedSeries:   &flushedSeries,
+		flushedSketches: &flushedSketches,
+		seriesSink:      seriesSink,
 	}
 }
 

--- a/pkg/aggregator/demultiplexer.go
+++ b/pkg/aggregator/demultiplexer.go
@@ -378,9 +378,9 @@ func (d *AgentDemultiplexer) Run() {
 }
 
 func (d *AgentDemultiplexer) flushLoop() {
-	var flushTicker *time.Ticker
+	var flushTicker <-chan time.Time
 	if d.options.FlushInterval > 0 {
-		flushTicker = time.NewTicker(d.options.FlushInterval)
+		flushTicker = time.NewTicker(d.options.FlushInterval).C
 	} else {
 		log.Debugf("flushInterval set to 0: will never flush automatically")
 	}
@@ -397,7 +397,7 @@ func (d *AgentDemultiplexer) flushLoop() {
 				trigger.blockChan <- struct{}{}
 			}
 		// automatic flush sequence
-		case t := <-flushTicker.C:
+		case t := <-flushTicker:
 			d.flushToSerializer(t, false)
 		}
 	}

--- a/pkg/aggregator/demultiplexer.go
+++ b/pkg/aggregator/demultiplexer.go
@@ -52,7 +52,7 @@ type Demultiplexer interface {
 	AddTimeSampleBatch(shard TimeSamplerID, samples metrics.MetricSampleBatch)
 	// AddCheckSample adds check sample sent by a check from one of the collectors into a check sampler pipeline.
 	AddCheckSample(sample metrics.MetricSample)
-	// ForceFlushToSerializer flushes all the aggregated data from the samplers to
+	// ForceFlushToSerializer flushes all the aggregated data from the different samplers to
 	// the serialization/forwarding parts.
 	ForceFlushToSerializer(start time.Time, waitForSerializer bool)
 	// GetMetricSamplePool returns a shared resource used in the whole DogStatsD
@@ -92,6 +92,14 @@ type Demultiplexer interface {
 // AgentDemultiplexer is the demultiplexer implementation for the main Agent
 type AgentDemultiplexer struct {
 	m sync.Mutex
+
+	// stopChan completely stops the flushLoop of the Demultiplexer when receiving
+	// a message, not doing anything else.
+	stopChan chan struct{}
+	// flushChan receives a flushTrigger to trigger an internal flush of all
+	// samplers (TimeSampler, BufferedAggregator (CheckSampler, Events, ServiceChecks))
+	// to the shared serializer.
+	flushChan chan flushTrigger
 
 	// options are the options with which the demultiplexer has been created
 	options    DemultiplexerOptions
@@ -136,6 +144,22 @@ type forwarders struct {
 type dataOutputs struct {
 	forwarders       forwarders
 	sharedSerializer serializer.MetricSerializer
+}
+
+// flushTrigger must be used to trigger a flush of the TimeSampler.
+// If `BlockChan` is not nil, a message is sent when the flush is complete.
+type flushTrigger struct {
+	time      time.Time
+	blockChan chan struct{}
+
+	// used by the BufferedAggregator to know if serialization of events,
+	// service checks and such have to be waited for before returning
+	// from Flush()
+	waitForSerializer bool
+
+	flushedSeries   *[]metrics.Series
+	flushedSketches *[]metrics.SketchSeriesList
+	seriesSink      metrics.SerieSink
 }
 
 // DefaultDemultiplexerOptions returns the default options to initialize a Demultiplexer.
@@ -229,19 +253,16 @@ func initAgentDemultiplexer(options DemultiplexerOptions, hostname string) *Agen
 
 		// its worker (process loop + flush/serialization mechanism)
 
-		// NOTE(remy): we can consider that the orchestrator forwarder and the
-		// container lifecycle fwder aren't useful here and having them nil
-		// could probably be considered
-		serializer := serializer.NewSerializer(sharedForwarder, orchestratorForwarder,
-			containerLifecycleForwarder)
 		statsdWorkers[i] = newTimeSamplerWorker(statsdSampler, options.FlushInterval,
-			bufferSize, metricSamplePool, serializer, agg.flushAndSerializeInParallel)
+			bufferSize, metricSamplePool, agg.flushAndSerializeInParallel)
 	}
 
 	// --
 
 	demux := &AgentDemultiplexer{
-		options: options,
+		options:   options,
+		stopChan:  make(chan struct{}),
+		flushChan: make(chan flushTrigger),
 
 		// Input
 		aggregator: agg,
@@ -342,26 +363,71 @@ func (d *AgentDemultiplexer) Run() {
 	for _, w := range d.statsd.workers {
 		go w.run()
 	}
-	d.aggregator.run() // this is the blocking call
+
+	go d.aggregator.run()
+	d.flushLoop() // this is the blocking call
+}
+
+func (d *AgentDemultiplexer) flushLoop() {
+	var flushTicker *time.Ticker
+	if d.options.FlushInterval > 0 {
+		flushTicker = time.NewTicker(d.options.FlushInterval)
+	} else {
+		log.Debugf("flushInterval set to 0: will never flush automatically")
+	}
+
+	for {
+		select {
+		// stop sequence
+		case <-d.stopChan:
+			return
+		// manual flush sequence
+		case trigger := <-d.flushChan:
+			d.flushToSerializer(trigger.time, trigger.waitForSerializer)
+			if trigger.blockChan != nil {
+				trigger.blockChan <- struct{}{}
+			}
+		// automatic flush sequence
+		case t := <-flushTicker.C:
+			d.flushToSerializer(t, false)
+		}
+	}
 }
 
 // Stop stops the demultiplexer.
 // Resources are released, the instance should not be used after a call to `Stop()`.
 func (d *AgentDemultiplexer) Stop(flush bool) {
+	timeout := config.Datadog.GetDuration("aggregator_stop_timeout") * time.Second
+
+	// do a manual complete flush then stop
+	// stop all automatic flush & the mainloop,
+	if flush {
+		trigger := flushTrigger{
+			time:              time.Now(),
+			blockChan:         make(chan struct{}),
+			waitForSerializer: flush,
+		}
+
+		d.flushChan <- trigger
+		select {
+		case <-trigger.blockChan:
+		case <-time.After(timeout):
+			log.Errorf("flushing data on Stop() timed out")
+		}
+	}
+
+	// stops the flushloop and makes sure no automatic flushes will happen anymore
+	d.stopChan <- struct{}{}
+
 	d.m.Lock()
 	defer d.m.Unlock()
 
-	if flush {
-		d.forceFlushToSerializer(time.Now(), true)
-	}
-
 	// aggregated data
-
 	for _, worker := range d.statsd.workers {
 		worker.stop()
 	}
 	if d.aggregator != nil {
-		d.aggregator.Stop(false)
+		d.aggregator.Stop()
 	}
 	d.aggregator = nil
 
@@ -393,50 +459,141 @@ func (d *AgentDemultiplexer) Stop(flush bool) {
 	demultiplexerInstance = nil
 }
 
-// ForceFlushToSerializer flushes all data from the aggregator and time samplers
-// to the serializer.
+// ForceFlushToSerializer triggers the execution of a flush from all data of samplers
+// and the BufferedAggregator to the serializer.
 // Safe to call from multiple threads.
 func (d *AgentDemultiplexer) ForceFlushToSerializer(start time.Time, waitForSerializer bool) {
-	d.m.Lock()
-	defer d.m.Unlock()
-	d.forceFlushToSerializer(start, waitForSerializer)
+	trigger := flushTrigger{
+		time:              start,
+		waitForSerializer: waitForSerializer,
+		blockChan:         make(chan struct{}),
+	}
+	d.flushChan <- trigger
+	<-trigger.blockChan
 }
 
-// ForceFlushToSerializer flushes all data from the aggregator and time samplers
+// flushToSerializer flushes all data from the aggregator and time samplers
 // to the serializer.
-// Not safe to call from multiple threads, consider using ForceFlushToSerializer instead.
-func (d *AgentDemultiplexer) forceFlushToSerializer(start time.Time, waitForSerializer bool) {
+//
+// Best practice is that this method is *only* called by the flushLoop routine.
+// It technically works if called from outside of this routine, but beware of
+// deadlocks with the parallel stream series implementation.
+//
+// This implementation is not flushing the TimeSampler and the BufferedAggregator
+// concurrently because the IterableSeries is not thread safe / supporting concurrent usage.
+// If one day a better (faster?) solution is needed, we could either consider:
+// - to have an implementation of SendIterableSeries listening on multiple sinks in parallel, or,
+// - to have a thread-safe implementation of the underlying `util.BufferedChan`.
+func (d *AgentDemultiplexer) flushToSerializer(start time.Time, waitForSerializer bool) {
+	d.m.Lock()
+	defer d.m.Unlock()
 
-	// flush the time samplers
-	// ----------------------
+	if d.aggregator == nil {
+		// NOTE(remy): we could consider flushing only the time samplers
+		return
+	}
 
-	if waitForSerializer {
-		wg := sync.WaitGroup{}
-		for _, tsWorker := range d.statsd.workers {
-			wg.Add(1)
-			// order the flush to the time sampler, and wait, in a different routine
-			go func(worker *timeSamplerWorker, wg *sync.WaitGroup) {
-				worker.flush(start, true)
-				wg.Done()
-			}(tsWorker, &wg)
+	flushedSeries := make([]metrics.Series, 0)
+	flushedSketches := make([]metrics.SketchSeriesList, 0)
+
+	// only used when we're using flush/serialize in parallel feature
+	var seriesSink *metrics.IterableSeries
+	var done chan struct{}
+
+	if d.aggregator.flushAndSerializeInParallel.enabled {
+		seriesSink = metrics.NewIterableSeries(func(se *metrics.Serie) {
+			tagsetTlm.updateHugeSerieTelemetry(se)
+		}, d.aggregator.flushAndSerializeInParallel.bufferSize, d.aggregator.flushAndSerializeInParallel.channelSize)
+		done = make(chan struct{})
+		go d.sendIterableSeries(start, seriesSink, done)
+	}
+
+	// flush DogStatsD pipelines (statsd/time samplers)
+	// ------------------------------------------------
+
+	for _, worker := range d.statsd.workers {
+		// order the flush to the time sampler, and wait, in a different routine
+		trigger := flushTrigger{
+			time:            start,
+			blockChan:       make(chan struct{}),
+			flushedSeries:   &flushedSeries,
+			flushedSketches: &flushedSketches,
+			seriesSink:      seriesSink,
 		}
-		// wait for all samplers to have finished their flush
-		wg.Wait()
-	} else {
-		for _, tsWorker := range d.statsd.workers {
-			tsWorker.flush(start, false)
-		}
+
+		worker.flushChan <- trigger
+		<-trigger.blockChan
 	}
 
 	// flush the aggregator (check samplers)
 	// -------------------------------------
 
 	if d.aggregator != nil {
-		d.aggregator.Flush(start, waitForSerializer)
+		trigger := flushTrigger{
+			time:              start,
+			blockChan:         make(chan struct{}),
+			waitForSerializer: waitForSerializer,
+			flushedSeries:     &flushedSeries,
+			flushedSketches:   &flushedSketches,
+			seriesSink:        seriesSink,
+		}
+
+		d.aggregator.flushChan <- trigger
+		<-trigger.blockChan
+	}
+
+	// collect the series and sketches that the multiple samplers may have reported
+	// ------------------------------------------------------
+
+	var series metrics.Series
+	var sketches metrics.SketchSeriesList
+
+	for _, s := range flushedSeries {
+		series = append(series, s...)
+	}
+	for _, s := range flushedSketches {
+		sketches = append(sketches, s...)
+	}
+
+	// send these to the serializer
+	// ----------------------------
+
+	addFlushCount("Series", int64(len(series)))
+	if len(series) > 0 {
+		err := d.sharedSerializer.SendSeries(series)
+		updateSerieTelemetry(start, uint64(len(series)), err)
+		tagsetTlm.updateHugeSeriesTelemetry(&series)
+	}
+
+	addFlushCount("Sketches", int64(len(sketches)))
+	if len(sketches) > 0 {
+		err := d.sharedSerializer.SendSketch(sketches)
+		updateSketchTelemetry(start, uint64(len(sketches)), err)
+		tagsetTlm.updateHugeSketchesTelemetry(&sketches)
+	}
+
+	if d.aggregator.flushAndSerializeInParallel.enabled {
+		seriesSink.SenderStopped()
+		<-done
 	}
 
 	addFlushTime("MainFlushTime", int64(time.Since(start)))
 	aggregatorNumberOfFlush.Add(1)
+}
+
+// sendIterableSeries is continuously sending series to the serializer, until another routine calls SenderStopped on the
+// series sink.
+// Mainly meant to be executed in its own routine, sendIterableSeries is closing the `done` channel once it has returned
+// from SendIterableSeries (because the SenderStopped methods has been called on the sink).
+func (d *AgentDemultiplexer) sendIterableSeries(start time.Time, series *metrics.IterableSeries, done chan<- struct{}) {
+	log.Debug("Demultiplexer: sendIterableSeries: start sending iterable series to the serializer")
+	err := d.sharedSerializer.SendIterableSeries(series)
+	// if err == nil, SenderStopped was called and it is safe to read the number of series.
+	count := series.SeriesCount()
+	addFlushCount("Series", int64(count))
+	updateSerieTelemetry(start, count, err)
+	close(done)
+	log.Debug("Demultiplexer: sendIterableSeries: stop routine")
 }
 
 // AddTimeSampleBatch adds a batch of MetricSample into the given time sampler shard.
@@ -523,14 +680,14 @@ func InitAndStartServerlessDemultiplexer(domainResolvers map[string]resolver.Dom
 	tagsStore := tags.NewStore(config.Datadog.GetBool("aggregator_use_tags_store"), "timesampler")
 
 	statsdSampler := NewTimeSampler(TimeSamplerID(0), bucketSize, tagsStore)
-	statsdWorker := newTimeSamplerWorker(statsdSampler, DefaultFlushInterval, bufferSize, metricSamplePool, serializer, flushAndSerializeInParallel{enabled: false})
+	statsdWorker := newTimeSamplerWorker(statsdSampler, DefaultFlushInterval, bufferSize, metricSamplePool, flushAndSerializeInParallel{enabled: false})
 
 	demux := &ServerlessDemultiplexer{
 		aggregator:       aggregator,
-		serializer:       serializer,
 		forwarder:        forwarder,
 		statsdSampler:    statsdSampler,
 		statsdWorker:     statsdWorker,
+		serializer:       serializer,
 		metricSamplePool: metricSamplePool,
 		senders:          newSenders(aggregator),
 		flushLock:        &sync.Mutex{},
@@ -562,11 +719,15 @@ func (d *ServerlessDemultiplexer) Run() {
 
 // Stop stops the wrapped aggregator and the forwarder.
 func (d *ServerlessDemultiplexer) Stop(flush bool) {
-	d.statsdWorker.flush(time.Now(), flush)
+	if flush {
+		d.ForceFlushToSerializer(time.Now(), true)
+	}
+
+	d.statsdWorker.stop()
 
 	// no need to flush the aggregator, it doesn't contain any data
 	// for the serverless agent
-	d.aggregator.Stop(false)
+	d.aggregator.Stop()
 
 	if d.forwarder != nil {
 		d.forwarder.Stop()
@@ -577,7 +738,34 @@ func (d *ServerlessDemultiplexer) Stop(flush bool) {
 func (d *ServerlessDemultiplexer) ForceFlushToSerializer(start time.Time, waitForSerializer bool) {
 	d.flushLock.Lock()
 	defer d.flushLock.Unlock()
-	d.statsdWorker.flush(start, waitForSerializer)
+
+	flushedSeries := make([]metrics.Series, 0)
+	flushedSketches := make([]metrics.SketchSeriesList, 0)
+
+	trigger := flushTrigger{
+		time:              start,
+		blockChan:         make(chan struct{}),
+		waitForSerializer: waitForSerializer,
+		flushedSeries:     &flushedSeries,
+		flushedSketches:   &flushedSketches,
+	}
+
+	d.statsdWorker.flushChan <- trigger
+	<-trigger.blockChan
+
+	var series metrics.Series
+	for _, s := range flushedSeries {
+		series = append(series, s...)
+	}
+	var sketches metrics.SketchSeriesList
+	for _, s := range flushedSketches {
+		sketches = append(sketches, s...)
+	}
+
+	d.serializer.SendSeries(series) //nolint:errcheck
+	if len(sketches) > 0 {
+		d.serializer.SendSketch(sketches) //nolint:errcheck
+	}
 }
 
 // AddTimeSample send a MetricSample to the TimeSampler.

--- a/pkg/aggregator/sender_test.go
+++ b/pkg/aggregator/sender_test.go
@@ -176,7 +176,7 @@ func TestGetSenderDefaultHostname(t *testing.T) {
 	assert.Equal(t, altDefaultHostname, checksender.defaultHostname)
 	assert.Equal(t, false, checksender.defaultHostnameDisabled)
 
-	aggregatorInstance.Stop(false)
+	aggregatorInstance.Stop()
 }
 
 func TestGetSenderServiceTagMetrics(t *testing.T) {

--- a/pkg/aggregator/time_sampler_worker.go
+++ b/pkg/aggregator/time_sampler_worker.go
@@ -8,10 +8,7 @@ package aggregator
 import (
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
-	"github.com/DataDog/datadog-agent/pkg/serializer"
-	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // The timeSamplerWorker runs the process loop for a TimeSampler:
@@ -24,9 +21,6 @@ type timeSamplerWorker struct {
 
 	// pointer to the shared MetricSamplePool stored in the Demultiplexer.
 	metricSamplePool *metrics.MetricSamplePool
-
-	// serializer to send the series on
-	serializer serializer.MetricSerializer
 
 	// flushInterval is the automatic flush interval
 	flushInterval time.Duration
@@ -43,20 +37,12 @@ type timeSamplerWorker struct {
 	stopChan chan struct{}
 }
 
-// flushTrigger must be used to trigger a flush of the TimeSampler.
-// If `BlockChan` is not nil, a message is sent when the flush is complete.
-type flushTrigger struct {
-	time      time.Time
-	blockChan chan struct{}
-}
-
 func newTimeSamplerWorker(sampler *TimeSampler, flushInterval time.Duration, bufferSize int,
-	metricSamplePool *metrics.MetricSamplePool, serializer serializer.MetricSerializer,
+	metricSamplePool *metrics.MetricSamplePool,
 	parallelSerialization flushAndSerializeInParallel) *timeSamplerWorker {
 	return &timeSamplerWorker{
 		sampler: sampler,
 
-		serializer:            serializer,
 		metricSamplePool:      metricSamplePool,
 		parallelSerialization: parallelSerialization,
 
@@ -68,20 +54,6 @@ func newTimeSamplerWorker(sampler *TimeSampler, flushInterval time.Duration, buf
 	}
 }
 
-// flush flushes the TimeSampler data into the serializer.
-func (w *timeSamplerWorker) flush(start time.Time, waitForSerializer bool) {
-	trigger := flushTrigger{time: start}
-	if waitForSerializer {
-		trigger.blockChan = make(chan struct{})
-	}
-
-	w.flushChan <- trigger
-
-	if waitForSerializer {
-		<-trigger.blockChan
-	}
-}
-
 // We process all receivend samples in the `select`, but we also process a flush action,
 // meaning that the time sampler does not process any sample while flushing.
 // Note that it was the same design in the BufferedAggregator (but at the aggregator level,
@@ -89,13 +61,6 @@ func (w *timeSamplerWorker) flush(start time.Time, waitForSerializer bool) {
 // If we want to move to a design where we can flush while we are processing samples,
 // we could consider implementing double-buffering or locking for every sample reception.
 func (w *timeSamplerWorker) run() {
-	var tickerChan <-chan time.Time
-	if w.flushInterval > 0 {
-		tickerChan = time.NewTicker(w.flushInterval).C
-	} else {
-		log.Debugf("Time Sampler #%d - flushInterval set to 0: it won't automatically flush", w.sampler.id)
-	}
-
 	for {
 		select {
 		case <-w.stopChan:
@@ -109,12 +74,7 @@ func (w *timeSamplerWorker) run() {
 			}
 			w.metricSamplePool.PutBatch(ms)
 		case trigger := <-w.flushChan:
-			w.triggerFlush(trigger.time, trigger.blockChan != nil)
-			if trigger.blockChan != nil {
-				trigger.blockChan <- struct{}{}
-			}
-		case t := <-tickerChan:
-			w.triggerFlush(t, false)
+			w.triggerFlush(trigger)
 		}
 	}
 }
@@ -123,72 +83,21 @@ func (w *timeSamplerWorker) stop() {
 	w.stopChan <- struct{}{}
 }
 
-func (w *timeSamplerWorker) triggerFlush(t time.Time, waitForSerializer bool) {
+func (w *timeSamplerWorker) triggerFlush(trigger flushTrigger) {
 	if w.parallelSerialization.enabled {
-		w.triggerFlushWithParallelSerialize(t, waitForSerializer)
+		sketches := w.sampler.flush(float64(trigger.time.Unix()), trigger.seriesSink)
+		if len(sketches) > 0 {
+			*trigger.flushedSketches = append(*trigger.flushedSketches, sketches)
+		}
 	} else {
-		log.Debugf("Time Sampler #%d - Flushing series to the forwarder", w.sampler.id)
-
 		var series metrics.Series
-		sketches := w.sampler.flush(float64(t.Unix()), &series)
-		if w.serializer != nil {
-			err := w.serializer.SendSeries(series)
-			updateSerieTelemetry(t, uint64(len(series)), "timeSamplerWorker", err)
-			tagsetTlm.updateHugeSeriesTelemetry(&series)
-
-			if len(sketches) > 0 {
-				err = w.serializer.SendSketch(sketches)
-				updateSketchTelemetry(t, uint64(len(sketches)), "timeSamplerWorker", err)
-				tagsetTlm.updateHugeSketchesTelemetry(&sketches)
-			}
+		sketches := w.sampler.flush(float64(trigger.time.Unix()), &series)
+		if len(series) > 0 {
+			*trigger.flushedSeries = append(*trigger.flushedSeries, series)
+		}
+		if len(sketches) > 0 {
+			*trigger.flushedSketches = append(*trigger.flushedSketches, sketches)
 		}
 	}
-}
-
-// NOTE(remy): this has been stolen from the Aggregator implementation, we will have
-// to factor it at some point.
-func (w *timeSamplerWorker) sendIterableSeries(
-	start time.Time,
-	series *metrics.IterableSeries,
-	done chan<- struct{}) {
-	go func() {
-		log.Debugf("Time Sampler #%d - Flushing series to the forwarder in parallel", w.sampler.id)
-
-		err := w.serializer.SendIterableSeries(series)
-		// if err == nil, SenderStopped was called and it is safe to read the number of series.
-		count := series.SeriesCount()
-		addFlushCount("Series", int64(count))
-		updateSerieTelemetry(start, count, "timeSamplerWorker", err)
-		close(done)
-	}()
-}
-
-// NOTE(remy): this has been stolen from the Aggregator implementation, we will have
-// to factor it at some point.
-func (w *timeSamplerWorker) triggerFlushWithParallelSerialize(start time.Time, waitForSerializer bool) {
-	logPayloads := config.Datadog.GetBool("log_payloads")
-	series := metrics.NewIterableSeries(func(se *metrics.Serie) {
-		if logPayloads {
-			log.Debugf("Time Sampler #%d - Flushing the following metrics: %s", w.sampler.id, se)
-		}
-		tagsetTlm.updateHugeSerieTelemetry(se)
-	}, w.parallelSerialization.channelSize, w.parallelSerialization.bufferSize)
-	done := make(chan struct{})
-
-	// start the serialization routine
-	w.sendIterableSeries(start, series, done)
-
-	sketches := w.sampler.flush(float64(start.Unix()), series)
-	series.SenderStopped()
-
-	if waitForSerializer {
-		<-done
-	}
-
-	if len(sketches) > 0 {
-		tagsetTlm.updateHugeSketchesTelemetry(&sketches)
-		if err := w.serializer.SendSketch(sketches); err != nil {
-			log.Errorf("flushLoop: %+v", err)
-		}
-	}
+	trigger.blockChan <- struct{}{}
 }

--- a/pkg/dogstatsd/server_test.go
+++ b/pkg/dogstatsd/server_test.go
@@ -51,13 +51,14 @@ func TestNewServer(t *testing.T) {
 	require.NoError(t, err)
 	config.Datadog.SetDefault("dogstatsd_port", port)
 
-	demux := mockDemultiplexer()
+	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(10 * time.Millisecond)
 	defer demux.Stop(false)
 	s, err := NewServer(demux, nil)
 	require.NoError(t, err, "cannot start DSD")
-	defer s.Stop()
 	assert.NotNil(t, s)
 	assert.True(t, s.Started)
+
+	s.Stop()
 }
 
 func TestStopServer(t *testing.T) {
@@ -65,7 +66,7 @@ func TestStopServer(t *testing.T) {
 	require.NoError(t, err)
 	config.Datadog.SetDefault("dogstatsd_port", port)
 
-	demux := mockDemultiplexer()
+	demux := aggregator.InitTestAgentDemultiplexerWithFlushInterval(10 * time.Millisecond)
 	defer demux.Stop(false)
 	s, err := NewServer(demux, nil)
 	require.NoError(t, err, "cannot start DSD")

--- a/pkg/serverless/metrics/metric_test.go
+++ b/pkg/serverless/metrics/metric_test.go
@@ -190,7 +190,7 @@ func TestRaceFlushVersusParsePacket(t *testing.T) {
 	opts := aggregator.DefaultDemultiplexerOptions(nil)
 	opts.FlushInterval = 10 * time.Millisecond
 	opts.DontStartForwarders = true
-	demux := aggregator.InitAndStartAgentDemultiplexer(opts, "hostname")
+	demux := aggregator.InitAndStartServerlessDemultiplexer(nil, "serverless", time.Second*1000)
 
 	s, err := dogstatsd.NewServer(demux, nil)
 	require.NoError(t, err, "cannot start DSD")


### PR DESCRIPTION
### What does this PR do?

This PR intends to synchronize the flush of all samplers (check, time), service checks and events to the serializer.

Either on a ticker or on a manual call to the `ForceFlushToSerializer`, the `Demultiplexer` sends a `flushTrigger` to all concerned part flush loops, and they report in struct available in the trigger. Once they've all reported, the `Demultiplexer` forward this data to the serializer.
There is an exception when we have `aggregator_flush_metrics_and_serialize_in_parallel` enabled (which is `true` by default in 7.35.0) where the data is forwarded to the serializer while it is being collected, and not after the samples have finished to report them.

The important change lies in `AgentDemultiplexer.flushToSerializer` which contains all the aforementioned logic.

A benefit of this change is that the flush logic (of series, etc.) is now centralized within the Demultiplexer, but keeping the benefit of running multiple samplers concurrently.

### Motivation

The purpose of this change is to use only one shared serializer instead of one per samplers, in order to create only one (serie) payload per transaction.

### Additional Notes

The flush of every sampler is happening one after the another: the current series sink API doesn't support concurrent usage, we could consider having a sink implementation but, flushing the samplers and buffered aggregator in sequence also has the benefit that it look less like a "stop the world" for the DogStatsD workers and collector senders. 

This pull-request targets `remeh/sharded-aggregator-sharding`.

### Possible Drawbacks / Trade-offs

The sketches especially, during a flush, I expect the heap usage to be slightly higher than my original implementation using multiple serializers, but not worse than 7.34.0 (should be identical to 7.34.0). 

### Describe how to test/QA your changes

* Listen to what's the Agent is sending to the intake
* Send multiple DogStatsD count / let the Agent collect check metrics
* Validate that the flush happening every 15 seconds is only sending on POST request to /series (and one to /sketches depending on what you've sent/collected)

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
