### PR TITLE
Add config option to turn off kernel header downloading

### DIFF
--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -94,6 +94,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "enable_tracepoints"), false)
 	cfg.BindEnvAndSetDefault(join(spNS, "enable_runtime_compiler"), false, "DD_ENABLE_RUNTIME_COMPILER")
 	cfg.BindEnvAndSetDefault(join(spNS, "runtime_compiler_output_dir"), defaultRuntimeCompilerOutputDir, "DD_RUNTIME_COMPILER_OUTPUT_DIR")
+	cfg.BindEnvAndSetDefault(join(spNS, "enable_kernel_header_download"), false, "DD_ENABLE_KERNEL_HEADER_DOWNLOAD")
 	cfg.BindEnvAndSetDefault(join(spNS, "kernel_header_dirs"), []string{}, "DD_KERNEL_HEADER_DIRS")
 	cfg.BindEnvAndSetDefault(join(spNS, "kernel_header_download_dir"), defaultKernelHeadersDownloadDir, "DD_KERNEL_HEADER_DOWNLOAD_DIR")
 	cfg.BindEnvAndSetDefault(join(spNS, "apt_config_dir"), suffixHostEtc(defaultAptConfigDirSuffix), "DD_APT_CONFIG_DIR")

--- a/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
+++ b/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
@@ -156,7 +156,7 @@ func (rc *RuntimeCompiler) CompileObjectFile(config *ebpf.Config, cflags []strin
 			rc.telemetry.compilationResult = outputFileErr
 			return nil, fmt.Errorf("error stat-ing output file %s: %w", outputFile, err)
 		}
-		dirs, res, err := kernel.GetKernelHeaders(config.KernelHeadersDirs, config.KernelHeadersDownloadDir, config.AptConfigDir, config.YumReposDir, config.ZypperReposDir)
+		dirs, res, err := kernel.GetKernelHeaders(config.EnableKernelHeaderDownload, config.KernelHeadersDirs, config.KernelHeadersDownloadDir, config.AptConfigDir, config.YumReposDir, config.ZypperReposDir)
 		rc.telemetry.headerFetchResult = res
 		if err != nil {
 			rc.telemetry.compilationResult = headerFetchErr

--- a/pkg/ebpf/config.go
+++ b/pkg/ebpf/config.go
@@ -36,6 +36,9 @@ type Config struct {
 	// EnableRuntimeCompiler enables the use of the embedded compiler to build eBPF programs on-host
 	EnableRuntimeCompiler bool
 
+	// EnableKernelHeaderDownload enables the use of the automatic kernel header downloading
+	EnableKernelHeaderDownload bool
+
 	// KernelHeadersDir is the directories of the kernel headers to use for runtime compilation
 	KernelHeadersDirs []string
 
@@ -74,13 +77,14 @@ func NewConfig() *Config {
 		EnableTracepoints:        cfg.GetBool(key(spNS, "enable_tracepoints")),
 		ProcRoot:                 util.GetProcRoot(),
 
-		EnableRuntimeCompiler:    cfg.GetBool(key(spNS, "enable_runtime_compiler")),
-		RuntimeCompilerOutputDir: cfg.GetString(key(spNS, "runtime_compiler_output_dir")),
-		KernelHeadersDirs:        cfg.GetStringSlice(key(spNS, "kernel_header_dirs")),
-		KernelHeadersDownloadDir: cfg.GetString(key(spNS, "kernel_header_download_dir")),
-		AptConfigDir:             cfg.GetString(key(spNS, "apt_config_dir")),
-		YumReposDir:              cfg.GetString(key(spNS, "yum_repos_dir")),
-		ZypperReposDir:           cfg.GetString(key(spNS, "zypper_repos_dir")),
-		AllowPrecompiledFallback: true,
+		EnableRuntimeCompiler:      cfg.GetBool(key(spNS, "enable_runtime_compiler")),
+		RuntimeCompilerOutputDir:   cfg.GetString(key(spNS, "runtime_compiler_output_dir")),
+		EnableKernelHeaderDownload: cfg.GetBool(key(spNS, "enable_kernel_header_download")),
+		KernelHeadersDirs:          cfg.GetStringSlice(key(spNS, "kernel_header_dirs")),
+		KernelHeadersDownloadDir:   cfg.GetString(key(spNS, "kernel_header_download_dir")),
+		AptConfigDir:               cfg.GetString(key(spNS, "apt_config_dir")),
+		YumReposDir:                cfg.GetString(key(spNS, "yum_repos_dir")),
+		ZypperReposDir:             cfg.GetString(key(spNS, "zypper_repos_dir")),
+		AllowPrecompiledFallback:   true,
 	}
 }

--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -51,6 +51,7 @@ const (
 	downloadFailure
 	validationFailure
 	reposDirAccessFailure
+	headersNotFound
 )
 
 var errLinuxTypesHMissing = errors.New("correctly versioned kernel headers found, but linux/types.h missing")
@@ -58,7 +59,7 @@ var errReposDirInaccessible = errors.New("unable to access repos directory")
 
 // GetKernelHeaders attempts to find kernel headers on the host, and if they cannot be found it will attempt
 // to  download them to headerDownloadDir
-func GetKernelHeaders(headerDirs []string, headerDownloadDir, aptConfigDir, yumReposDir, zypperReposDir string) ([]string, HeaderFetchResult, error) {
+func GetKernelHeaders(downloadEnabled bool, headerDirs []string, headerDownloadDir, aptConfigDir, yumReposDir, zypperReposDir string) ([]string, HeaderFetchResult, error) {
 	hv, hvErr := HostVersion()
 	if hvErr != nil {
 		return nil, hostVersionErr, fmt.Errorf("unable to determine host kernel version: %w", hvErr)
@@ -110,19 +111,22 @@ func GetKernelHeaders(headerDirs []string, headerDownloadDir, aptConfigDir, yumR
 		}
 	}
 
-	d := headerDownloader{aptConfigDir, yumReposDir, zypperReposDir}
-	if err = d.downloadHeaders(headerDownloadDir); err != nil {
-		if errors.Is(err, errReposDirInaccessible) {
-			return nil, reposDirAccessFailure, fmt.Errorf("unable to download kernel headers: %w", err)
+	if downloadEnabled {
+		d := headerDownloader{aptConfigDir, yumReposDir, zypperReposDir}
+		if err = d.downloadHeaders(headerDownloadDir); err != nil {
+			if errors.Is(err, errReposDirInaccessible) {
+				return nil, reposDirAccessFailure, fmt.Errorf("unable to download kernel headers: %w", err)
+			}
+			return nil, downloadFailure, fmt.Errorf("unable to download kernel headers: %w", err)
 		}
-		return nil, downloadFailure, fmt.Errorf("unable to download kernel headers: %w", err)
-	}
 
-	log.Infof("successfully downloaded kernel headers to %s", headerDownloadDir)
-	if err = validateHeaderDirs(hv, dirs); err == nil {
-		return dirs, downloadSuccess, nil
+		log.Infof("successfully downloaded kernel headers to %s", headerDownloadDir)
+		if err = validateHeaderDirs(hv, dirs); err == nil {
+			return dirs, downloadSuccess, nil
+		}
+		return nil, validationFailure, fmt.Errorf("downloaded headers are not valid: %w", err)
 	}
-	return nil, validationFailure, fmt.Errorf("downloaded headers are not valid: %w", err)
+	return nil, headersNotFound, fmt.Errorf("kernel header downloading is disabled")
 }
 
 // validateHeaderDirs verifies that the kernel headers in at least 1 directory matches the kernel version of the running host

--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -126,7 +126,7 @@ func GetKernelHeaders(downloadEnabled bool, headerDirs []string, headerDownloadD
 		}
 		return nil, validationFailure, fmt.Errorf("downloaded headers are not valid: %w", err)
 	}
-	return nil, headersNotFound, fmt.Errorf("kernel header downloading is disabled")
+	return nil, headersNotFound, fmt.Errorf("no valid matching kernel header directories found")
 }
 
 // validateHeaderDirs verifies that the kernel headers in at least 1 directory matches the kernel version of the running host

--- a/pkg/util/kernel/find_headers_test.go
+++ b/pkg/util/kernel/find_headers_test.go
@@ -21,7 +21,7 @@ func TestGetKernelHeaders(t *testing.T) {
 	if _, ok := os.LookupEnv("INTEGRATION"); !ok {
 		t.Skip("set INTEGRATION environment variable to run")
 	}
-	dirs, _, err := GetKernelHeaders(nil, "", "", "", "")
+	dirs, _, err := GetKernelHeaders(false, nil, "", "", "", "")
 	require.NoError(t, err)
 	assert.NotZero(t, len(dirs), "expected to find header directories")
 	t.Log(dirs)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add config option to turn off kernel header downloading, defaulting to false.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

We need to disable this feature while it is being debugged for memory issues.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
