### PR TITLE
Remove APIServer auth resources check

### DIFF
--- a/pkg/util/kubernetes/apiserver/diagnosis.go
+++ b/pkg/util/kubernetes/apiserver/diagnosis.go
@@ -9,8 +9,14 @@
 package apiserver
 
 import (
+	"context"
+
 	"github.com/DataDog/datadog-agent/pkg/diagnose/diagnosis"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver/common"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
+
+	authorizationv1 "k8s.io/api/authorization/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func init() {
@@ -19,12 +25,44 @@ func init() {
 
 // diagnose the API server availability
 func diagnose() error {
-	isConnectVerbose = true
 	c, err := GetAPIClient()
-	isConnectVerbose = false
 	if err != nil {
 		return err
 	}
 	log.Infof("Detecting OpenShift APIs: %s available", c.DetectOpenShiftAPILevel())
+
+	resourcesNamespace := common.GetResourcesNamespace()
+	printRBAC(c, resourcesNamespace)
+
+	myNamespace := common.GetMyNamespace()
+	if myNamespace != resourcesNamespace {
+		printRBAC(c, myNamespace)
+	}
+
 	return nil
+}
+
+func printRBAC(client *APIClient, namespace string) {
+	rulesReview, err := listRBAC(client, namespace)
+	if err != nil {
+		log.Errorf("Unable to get RBACs for namespace: %s", namespace)
+	}
+
+	log.Infof("RulesReview result for namespace %s:", namespace)
+	log.Info(rulesReview.String())
+}
+
+func listRBAC(client *APIClient, namespace string) (*authorizationv1.SubjectRulesReviewStatus, error) {
+	sar := &authorizationv1.SelfSubjectRulesReview{
+		Spec: authorizationv1.SelfSubjectRulesReviewSpec{
+			Namespace: namespace,
+		},
+	}
+
+	response, err := client.Cl.AuthorizationV1().SelfSubjectRulesReviews().Create(context.TODO(), sar, metav1.CreateOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return &response.Status, nil
 }


### PR DESCRIPTION
### What does this PR do?

Remove auth check when trying to get Kubernetes APIServer, reasoning is that the number of use cases covered by the Agent are now too wide and it does not make sense to enforce some un-necessary RBACs (for instance in EKS Fargate).

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

The initial idea was to make failure more visible, but currently the failure is not very visible due to how the Retrier handles errors and is not easy to debug because failure does not happen where the feature is used.

### Describe how to test/QA your changes

Deploy the Agent on EKS Fargate with our default RBACs. Check logs, no failure should come from `pkg/util/kubernetes/apiserver`

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
