### PR TITLE
[process-agent] Add process-agent runtime config to the core agent flare

### DIFF
--- a/cmd/process-agent/api/server.go
+++ b/cmd/process-agent/api/server.go
@@ -18,7 +18,8 @@ import (
 )
 
 func setupHandlers(r *mux.Router) {
-	r.HandleFunc("/config", settingshttp.Server.GetFull("process_config")).Methods("GET")
+	r.HandleFunc("/config", settingshttp.Server.GetFull("process_config")).Methods("GET") // Get only settings in the process_config namespace
+	r.HandleFunc("/config/all", settingshttp.Server.GetFull("")).Methods("GET")           // Get all fields from process-agent Config object
 	r.HandleFunc("/config/list-runtime", settingshttp.Server.ListConfigurable).Methods("GET")
 	r.HandleFunc("/config/{setting}", settingshttp.Server.GetValue).Methods("GET")
 	r.HandleFunc("/config/{setting}", settingshttp.Server.SetValue).Methods("POST")

--- a/cmd/process-agent/app/status.go
+++ b/cmd/process-agent/app/status.go
@@ -63,6 +63,7 @@ func writeError(w io.Writer, e error) {
 		_ = log.Error(err)
 	}
 }
+
 func fetchStatus(statusURL string) ([]byte, error) {
 	body, err := apiutil.DoGet(httpClient, statusURL)
 	if err != nil {

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -525,6 +525,14 @@ func zipSystemProbeStats(tempDir, hostname string) error {
 	return writeScrubbedFile(sysProbeFile, sysProbeBuf)
 }
 
+// zipProcessAgentCfgDump fetches process-agent runtime config as YAML and writes it to process_agent_runtime_config_dump.yaml
+func zipProcessAgentCfgDump(tempDir, hostname string) error {
+	cfgB := status.GetProcessAgentRuntimeConfig()
+	f := filepath.Join(tempDir, hostname, "process_agent_runtime_config_dump.yaml")
+
+	return writeScrubbedFile(f, cfgB)
+}
+
 func zipConfigFiles(tempDir, hostname string, confSearchPaths SearchPaths, permsInfos permissionsInfos) error {
 	c, err := yaml.Marshal(config.Datadog.AllSettings())
 	if err != nil {
@@ -540,6 +548,12 @@ func zipConfigFiles(tempDir, hostname string, confSearchPaths SearchPaths, perms
 	err = writeScrubbedFile(f, c)
 	if err != nil {
 		return err
+	}
+
+	// Use best effort to write process-agent runtime configs
+	err = zipProcessAgentCfgDump(tempDir, hostname)
+	if err != nil {
+		log.Warnf("could not zip process_agent_runtime_config_dump.yaml: %s", err)
 	}
 
 	err = walkConfigFilePaths(tempDir, hostname, confSearchPaths, permsInfos)

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -525,8 +525,8 @@ func zipSystemProbeStats(tempDir, hostname string) error {
 	return writeScrubbedFile(sysProbeFile, sysProbeBuf)
 }
 
-// zipProcessAgentCfgDump fetches process-agent runtime config as YAML and writes it to process_agent_runtime_config_dump.yaml
-func zipProcessAgentCfgDump(tempDir, hostname string) error {
+// zipProcessAgentFullConfig fetches process-agent runtime config as YAML and writes it to process_agent_runtime_config_dump.yaml
+func zipProcessAgentFullConfig(tempDir, hostname string) error {
 	cfgB := status.GetProcessAgentRuntimeConfig()
 	f := filepath.Join(tempDir, hostname, "process_agent_runtime_config_dump.yaml")
 
@@ -551,7 +551,7 @@ func zipConfigFiles(tempDir, hostname string, confSearchPaths SearchPaths, perms
 	}
 
 	// Use best effort to write process-agent runtime configs
-	err = zipProcessAgentCfgDump(tempDir, hostname)
+	err = zipProcessAgentFullConfig(tempDir, hostname)
 	if err != nil {
 		log.Warnf("could not zip process_agent_runtime_config_dump.yaml: %s", err)
 	}

--- a/pkg/flare/archive_test.go
+++ b/pkg/flare/archive_test.go
@@ -530,10 +530,6 @@ dd_url: https://my-url.com
 process_config:
   enabled: "true"`
 
-	cfg := config.Mock()
-	// Use different port in case the host is running a real agent
-	cfg.Set("process_config.cmd_port", 8182)
-
 	t.Run("without process-agent running", func(t *testing.T) {
 		dir, err := ioutil.TempDir("", "TestZipProcessAgentFullConfig")
 		require.NoError(t, err)

--- a/pkg/status/status_process_agent.go
+++ b/pkg/status/status_process_agent.go
@@ -61,16 +61,10 @@ func marshalError(err error) []byte {
 // The API server in process-agent already scrubs and marshals the runtime settings as YAML.
 // Since the api_key has been obfuscated with *, we're not able to unmarshal the response as YAML because *
 // is not a valid YAML character
-func GetProcessAgentRuntimeConfig() []byte {
+func GetProcessAgentRuntimeConfig(statusURL string) []byte {
 	httpClient := apiutil.GetClient(false)
 
-	addressPort, err := api.GetAPIAddressPort()
-	if err != nil {
-		return marshalError(fmt.Errorf("wrong configuration to connect to process-agent"))
-	}
-
-	statusEndpoint := fmt.Sprintf("http://%s/config/all", addressPort)
-	b, err := apiutil.DoGet(httpClient, statusEndpoint)
+	b, err := apiutil.DoGet(httpClient, statusURL)
 	if err != nil {
 		return marshalError(fmt.Errorf("process-agent is not running or is unreachable"))
 	}

--- a/pkg/status/status_process_agent.go
+++ b/pkg/status/status_process_agent.go
@@ -19,6 +19,7 @@ import (
 // GetProcessAgentStatus fetches the process-agent status from the process-agent API server
 func GetProcessAgentStatus() map[string]interface{} {
 	httpClient := apiutil.GetClient(false)
+
 	s := make(map[string]interface{})
 	addressPort, err := api.GetAPIAddressPort()
 	if err != nil {

--- a/pkg/status/status_process_agent.go
+++ b/pkg/status/status_process_agent.go
@@ -9,8 +9,11 @@ import (
 	"encoding/json"
 	"fmt"
 
+	"gopkg.in/yaml.v2"
+
 	"github.com/DataDog/datadog-agent/cmd/process-agent/api"
 	apiutil "github.com/DataDog/datadog-agent/pkg/api/util"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
 // GetProcessAgentStatus fetches the process-agent status from the process-agent API server
@@ -37,4 +40,39 @@ func GetProcessAgentStatus() map[string]interface{} {
 	}
 
 	return s
+}
+
+// marshalError marshals an error as YAML
+func marshalError(err error) []byte {
+	errYaml := make(map[string]interface{})
+
+	errYaml["error"] = fmt.Sprintf("%v", err.Error())
+	b, err := yaml.Marshal(errYaml)
+	if err != nil {
+		log.Warn("Unable to marshal error as yaml")
+		return nil
+	}
+
+	return b
+}
+
+// GetProcessAgentRuntimeConfig fetches the process-agent runtime configs
+// The API server in process-agent already scrubs and marshals the runtime configs as YAML.
+// Since the api_key has been obfuscated with *, we're not able to unmarshal the response as YAML because *
+// is not a valid YAML character
+func GetProcessAgentRuntimeConfig() []byte {
+	httpClient := apiutil.GetClient(false)
+
+	addressPort, err := api.GetAPIAddressPort()
+	if err != nil {
+		return marshalError(err)
+	}
+
+	statusEndpoint := fmt.Sprintf("http://%s/config/all", addressPort)
+	b, err := apiutil.DoGet(httpClient, statusEndpoint)
+	if err != nil {
+		return marshalError(err)
+	}
+
+	return b
 }

--- a/pkg/status/status_process_agent.go
+++ b/pkg/status/status_process_agent.go
@@ -74,5 +74,10 @@ func GetProcessAgentRuntimeConfig() []byte {
 		return marshalError(err)
 	}
 
+	fmt.Println("GOT RESPONSE FROM SERVER: ", string(b))
+	y := make(map[string]interface{})
+	err = yaml.Unmarshal(b, &y)
+	fmt.Println("ERROR UNMARSHALING? ", err)
+	fmt.Println("UNMARSHALLED YAML", y)
 	return b
 }

--- a/pkg/status/status_process_agent.go
+++ b/pkg/status/status_process_agent.go
@@ -44,9 +44,10 @@ func GetProcessAgentStatus() map[string]interface{} {
 
 // marshalError marshals an error as YAML
 func marshalError(err error) []byte {
-	errYaml := make(map[string]interface{})
+	errYaml := map[string]string{
+		"error": err.Error(),
+	}
 
-	errYaml["error"] = fmt.Sprintf("%v", err.Error())
 	b, err := yaml.Marshal(errYaml)
 	if err != nil {
 		log.Warn("Unable to marshal error as yaml")
@@ -65,19 +66,14 @@ func GetProcessAgentRuntimeConfig() []byte {
 
 	addressPort, err := api.GetAPIAddressPort()
 	if err != nil {
-		return marshalError(err)
+		return marshalError(fmt.Errorf("wrong configuration to connect to process-agent"))
 	}
 
 	statusEndpoint := fmt.Sprintf("http://%s/config/all", addressPort)
 	b, err := apiutil.DoGet(httpClient, statusEndpoint)
 	if err != nil {
-		return marshalError(err)
+		return marshalError(fmt.Errorf("process-agent is not running or is unreachable"))
 	}
 
-	fmt.Println("GOT RESPONSE FROM SERVER: ", string(b))
-	y := make(map[string]interface{})
-	err = yaml.Unmarshal(b, &y)
-	fmt.Println("ERROR UNMARSHALING? ", err)
-	fmt.Println("UNMARSHALLED YAML", y)
 	return b
 }

--- a/pkg/status/status_process_agent.go
+++ b/pkg/status/status_process_agent.go
@@ -16,7 +16,6 @@ import (
 // GetProcessAgentStatus fetches the process-agent status from the process-agent API server
 func GetProcessAgentStatus() map[string]interface{} {
 	httpClient := apiutil.GetClient(false)
-
 	s := make(map[string]interface{})
 	addressPort, err := api.GetAPIAddressPort()
 	if err != nil {

--- a/pkg/status/status_process_agent.go
+++ b/pkg/status/status_process_agent.go
@@ -57,8 +57,8 @@ func marshalError(err error) []byte {
 	return b
 }
 
-// GetProcessAgentRuntimeConfig fetches the process-agent runtime configs
-// The API server in process-agent already scrubs and marshals the runtime configs as YAML.
+// GetProcessAgentRuntimeConfig fetches the process-agent runtime settings.
+// The API server in process-agent already scrubs and marshals the runtime settings as YAML.
 // Since the api_key has been obfuscated with *, we're not able to unmarshal the response as YAML because *
 // is not a valid YAML character
 func GetProcessAgentRuntimeConfig() []byte {

--- a/pkg/status/templates/process-agent.tmpl
+++ b/pkg/status/templates/process-agent.tmpl
@@ -5,7 +5,6 @@ Process Agent
 
   Status: Not running or unreachable
 {{- else }}
-
   Version: {{ .core.version }}
   Status date: {{ formatUnixTime .date }}
   Process Agent Start: {{ formatUnixTime .expvars.uptime_nano }}

--- a/pkg/status/templates/process-agent.tmpl
+++ b/pkg/status/templates/process-agent.tmpl
@@ -5,6 +5,7 @@ Process Agent
 
   Status: Not running or unreachable
 {{- else }}
+
   Version: {{ .core.version }}
   Status date: {{ formatUnixTime .date }}
   Process Agent Start: {{ formatUnixTime .expvars.uptime_nano }}

--- a/releasenotes/notes/process-agent-add-runtime-cfg-to-core-flare-ed7231c140ad2c1b.yaml
+++ b/releasenotes/notes/process-agent-add-runtime-cfg-to-core-flare-ed7231c140ad2c1b.yaml
@@ -1,0 +1,4 @@
+---
+features:
+  - |
+    Add the `process_agent_runtime_config_dump.yaml` file to the core Agent flare with `process-agent` runtime settings.


### PR DESCRIPTION
### What does this PR do?

This PR adds a new `process_agent_runtime_config_dump.yaml` file to the core agent flare in order to send `process-agent` runtime settings. 

A new `/config/all` endpoint has been added to the `process-agent` API server. This endpoint is used by the core agent to fetch `process-agent` settings.

### Motivation

Improve process-agent info in the core agent flare.

### Additional Notes


### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

The following tests need to be performed on a **linux host**, **docker**, **k8s cluster**, **windows** and **macOS**.

Set the following settings on the `datadog.yaml` file to disable `process-agent`.
```yaml
process_config:
  enabled: "disabled"
  process_discovery:
    enabled: false
```

Collect a flare with 
```
./agent flare
```

Unzip it and check the content of the `process_agent_runtime_config_dump.yaml` file. A message should be present saying that `process-agent` it not running or is unreachable.

Reenable the `process-agent` and recollect a flare from the main agent. Make sure that `process_agent_runtime_config_dump.yaml` shows `process-agent` settings. **Check that all sensitive settings including api_keys have been scrubbed.**


### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
