### PR TITLE
Add config option to turn off kernel header downloading

### DIFF
--- a/pkg/config/system_probe.go
+++ b/pkg/config/system_probe.go
@@ -90,6 +90,7 @@ func InitSystemProbeConfig(cfg Config) {
 	cfg.BindEnvAndSetDefault(join(spNS, "enable_tracepoints"), false)
 	cfg.BindEnvAndSetDefault(join(spNS, "enable_runtime_compiler"), false, "DD_ENABLE_RUNTIME_COMPILER")
 	cfg.BindEnvAndSetDefault(join(spNS, "runtime_compiler_output_dir"), defaultRuntimeCompilerOutputDir, "DD_RUNTIME_COMPILER_OUTPUT_DIR")
+	cfg.BindEnvAndSetDefault(join(spNS, "enable_kernel_header_download"), false, "DD_ENABLE_KERNEL_HEADER_DOWNLOAD")
 	cfg.BindEnvAndSetDefault(join(spNS, "kernel_header_dirs"), []string{}, "DD_KERNEL_HEADER_DIRS")
 	cfg.BindEnvAndSetDefault(join(spNS, "kernel_header_download_dir"), defaultKernelHeadersDownloadDir, "DD_KERNEL_HEADER_DOWNLOAD_DIR")
 	cfg.BindEnvAndSetDefault(join(spNS, "apt_config_dir"), suffixHostEtc(defaultAptConfigDirSuffix), "DD_APT_CONFIG_DIR")

--- a/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
+++ b/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
@@ -155,7 +155,7 @@ func (rc *RuntimeCompiler) CompileObjectFile(config *ebpf.Config, cflags []strin
 			rc.telemetry.compilationResult = outputFileErr
 			return nil, fmt.Errorf("error stat-ing output file %s: %w", outputFile, err)
 		}
-		dirs, res, err := kernel.GetKernelHeaders(config.KernelHeadersDirs, config.KernelHeadersDownloadDir, config.AptConfigDir, config.YumReposDir, config.ZypperReposDir)
+		dirs, res, err := kernel.GetKernelHeaders(config.EnableKernelHeaderDownload, config.KernelHeadersDirs, config.KernelHeadersDownloadDir, config.AptConfigDir, config.YumReposDir, config.ZypperReposDir)
 		rc.telemetry.headerFetchResult = res
 		if err != nil {
 			rc.telemetry.compilationResult = headerFetchErr

--- a/pkg/ebpf/config.go
+++ b/pkg/ebpf/config.go
@@ -36,6 +36,9 @@ type Config struct {
 	// EnableRuntimeCompiler enables the use of the embedded compiler to build eBPF programs on-host
 	EnableRuntimeCompiler bool
 
+	// EnableKernelHeaderDownload enables the use of the automatic kernel header downloading
+	EnableKernelHeaderDownload bool
+
 	// KernelHeadersDir is the directories of the kernel headers to use for runtime compilation
 	KernelHeadersDirs []string
 
@@ -74,13 +77,14 @@ func NewConfig() *Config {
 		EnableTracepoints:        cfg.GetBool(key(spNS, "enable_tracepoints")),
 		ProcRoot:                 util.GetProcRoot(),
 
-		EnableRuntimeCompiler:    cfg.GetBool(key(spNS, "enable_runtime_compiler")),
-		RuntimeCompilerOutputDir: cfg.GetString(key(spNS, "runtime_compiler_output_dir")),
-		KernelHeadersDirs:        cfg.GetStringSlice(key(spNS, "kernel_header_dirs")),
-		KernelHeadersDownloadDir: cfg.GetString(key(spNS, "kernel_header_download_dir")),
-		AptConfigDir:             cfg.GetString(key(spNS, "apt_config_dir")),
-		YumReposDir:              cfg.GetString(key(spNS, "yum_repos_dir")),
-		ZypperReposDir:           cfg.GetString(key(spNS, "zypper_repos_dir")),
-		AllowPrecompiledFallback: true,
+		EnableRuntimeCompiler:      cfg.GetBool(key(spNS, "enable_runtime_compiler")),
+		RuntimeCompilerOutputDir:   cfg.GetString(key(spNS, "runtime_compiler_output_dir")),
+		EnableKernelHeaderDownload: cfg.GetBool(key(spNS, "enable_kernel_header_download")),
+		KernelHeadersDirs:          cfg.GetStringSlice(key(spNS, "kernel_header_dirs")),
+		KernelHeadersDownloadDir:   cfg.GetString(key(spNS, "kernel_header_download_dir")),
+		AptConfigDir:               cfg.GetString(key(spNS, "apt_config_dir")),
+		YumReposDir:                cfg.GetString(key(spNS, "yum_repos_dir")),
+		ZypperReposDir:             cfg.GetString(key(spNS, "zypper_repos_dir")),
+		AllowPrecompiledFallback:   true,
 	}
 }

--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -52,7 +52,6 @@ const (
 	headersNotFound
 )
 
-var errLinuxTypesHMissing = errors.New("correctly versioned kernel headers found, but linux/types.h missing")
 
 // GetKernelHeaders attempts to find kernel headers on the host, and if they cannot be found it will attempt
 // to  download them to headerDownloadDir
@@ -62,101 +61,97 @@ func GetKernelHeaders(downloadEnabled bool, headerDirs []string, headerDownloadD
 		return nil, hostVersionErr, fmt.Errorf("unable to determine host kernel version: %w", hvErr)
 	}
 
-	var err error
-	var dirs []string
 	if len(headerDirs) > 0 {
-		if err = validateHeaderDirs(hv, headerDirs); err == nil {
+		if dirs := validateHeaderDirs(hv, headerDirs); len(dirs) > 0 {
 			return headerDirs, customHeadersFound, nil
 		}
-		log.Debugf("unable to find configured kernel headers: %s", err)
+		log.Debugf("unable to find configured kernel headers: no valid headers found")
 	} else {
-		dirs = getDefaultHeaderDirs()
-		if err = validateHeaderDirs(hv, dirs); err == nil {
+		if dirs := validateHeaderDirs(hv, getDefaultHeaderDirs()); len(dirs) > 0 {
 			return dirs, defaultHeadersFound, nil
 		}
-		log.Debugf("unable to find default kernel headers: %s", err)
+		log.Debugf("unable to find default kernel headers: no valid headers found")
 
 		// If no valid directories are found, attempt a fallback to extracting from `/sys/kernel/kheaders.tar.xz`
 		// which is enabled via the `kheaders` kernel module and the `CONFIG_KHEADERS` kernel config option.
 		// The `kheaders` module will be automatically added and removed if present and needed.
+		var err error
+		var dirs []string
 		if dirs, err = getSysfsHeaderDirs(hv); err == nil {
 			return dirs, sysfsHeadersFound, nil
 		}
-		log.Debugf("unable to find system kernel headers: %s", err)
+		log.Debugf("unable to find system kernel headers: %w", err)
 	}
 
-	dirs = getDownloadedHeaderDirs(headerDownloadDir)
-	if err = validateHeaderDirs(hv, dirs); err == nil {
-		return dirs, downloadedHeadersFound, nil
+	downloadedDirs := validateHeaderDirs(hv, getDownloadedHeaderDirs(headerDownloadDir))
+	linuxTypeHFound := false
+	for _, d := range downloadedDirs {
+		if containsLinuxTypesHFile(d) {
+			linuxTypeHFound = true
+			break
+		}
 	}
-	log.Debugf("unable to find downloaded kernel headers: %s", err)
-
-	if errors.Is(err, errLinuxTypesHMissing) {
+	if !linuxTypeHFound {
 		// If this happens, it means we've previously downloaded kernel headers containing broken
 		// symlinks. We'll delete these to prevent them from affecting the next download
 		log.Infof("deleting previously downloaded kernel headers")
-		files, err := ioutil.ReadDir(headerDownloadDir)
-		if err != nil {
-			log.Warnf("error deleting kernel headers: %v", err)
+		for _, d := range downloadedDirs {
+			deleteKernelHeaderDirectory(d)
 		}
-		for _, fi := range files {
-			path := filepath.Join(headerDownloadDir, fi.Name())
-			err = os.RemoveAll(path)
-			if err != nil {
-				log.Warnf("error deleting %s: %s", path, err)
-			}
-		}
+		downloadedDirs = nil
+	}
+	if len(downloadedDirs) > 0 {
+		return downloadedDirs, downloadedHeadersFound, nil
+	}
+	log.Debugf("unable to find downloaded kernel headers: no valid headers found")
+
+	if !downloadEnabled {
+		return nil, headersNotFound, fmt.Errorf("no valid matching kernel header directories found")
 	}
 
-	if downloadEnabled {
-		d := headerDownloader{aptConfigDir, yumReposDir, zypperReposDir}
-		if err = d.downloadHeaders(headerDownloadDir); err == nil {
-			log.Infof("successfully downloaded kernel headers to %s", headerDownloadDir)
-			if err = validateHeaderDirs(hv, dirs); err == nil {
-				return dirs, downloadSuccess, nil
-			}
-			return nil, downloadFailure, fmt.Errorf("downloaded headers are not valid: %w", err)
+	d := headerDownloader{aptConfigDir, yumReposDir, zypperReposDir}
+	if err := d.downloadHeaders(headerDownloadDir); err != nil {
+		if errors.Is(err, errReposDirInaccessible) {
+			return nil, reposDirAccessFailure, fmt.Errorf("unable to download kernel headers: %w", err)
 		}
 		return nil, downloadFailure, fmt.Errorf("unable to download kernel headers: %w", err)
 	}
-	return nil, headersNotFound, fmt.Errorf("no valid matching kernel header directories found")
+	log.Infof("successfully downloaded kernel headers to %s", headerDownloadDir)
+	if dirs := validateHeaderDirs(hv, getDownloadedHeaderDirs(headerDownloadDir)); len(dirs) > 0 {
+		return dirs, downloadSuccess, nil
+	}
+	return nil, validationFailure, fmt.Errorf("downloaded headers are not valid")
 }
 
-// validateHeaderDirs verifies that the kernel headers in at least 1 directory matches the kernel version of the running host
-// and contains the linux/types.h file
-func validateHeaderDirs(hv Version, dirs []string) error {
-	versionMatches, linuxTypesHFound := false, false
+// validateHeaderDirs checks all the given directories and returns the directories containing kernel
+// headers matching the kernel version of the running host
+func validateHeaderDirs(hv Version, dirs []string) []string {
+	var valid []string
 	for _, d := range dirs {
-		if containsLinuxTypesHFile(d) {
-			linuxTypesHFound = true
+		if _, err := os.Stat(d); errors.Is(err, fs.ErrNotExist) {
+			continue
 		}
 
 		dirv, err := getHeaderVersion(d)
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
-				// if version.h is not found in this directory, keep going
+				// version.h is not found in this directory; we'll consider it valid, in case
+				// it contains necessary files
+				log.Debugf("found non-versioned kernel headers at %s", d)
+				valid = append(valid, d)
 				continue
 			}
-			return fmt.Errorf("error validating headers version: %w", err)
+			log.Debugf("error validating %s: error validating headers version: %w", d, err)
+			continue
 		}
 		if dirv != hv {
-			return fmt.Errorf("header version %s does not match host version %s", dirv, hv)
+			log.Debugf("error validating %s: header version %s does not match host version %s", d, dirv, hv)
+			continue
 		}
-
-		// as long as one directory passes, validate the entire set
-		versionMatches = true
+		log.Debugf("found valid kernel headers at %s", d)
+		valid = append(valid, d)
 	}
-
-	if !versionMatches {
-		return fmt.Errorf("no valid kernel headers found")
-	}
-
-	if !linuxTypesHFound {
-		return errLinuxTypesHMissing
-	}
-
-	log.Debugf("valid kernel headers found in %v", dirs)
-	return nil
+	return valid
 }
 
 func containsLinuxTypesHFile(dir string) bool {
@@ -169,6 +164,20 @@ func containsLinuxTypesHFile(dir string) bool {
 		defer f.Close()
 	}
 	return true
+}
+
+func deleteKernelHeaderDirectory(dir string) {
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		log.Warnf("error deleting kernel headers: %v", err)
+	}
+	for _, fi := range files {
+		path := filepath.Join(dir, fi.Name())
+		err = os.RemoveAll(path)
+		if err != nil {
+			log.Warnf("error deleting %s: %s", path, err)
+		}
+	}
 }
 
 func getHeaderVersion(path string) (Version, error) {

--- a/pkg/util/kernel/find_headers_test.go
+++ b/pkg/util/kernel/find_headers_test.go
@@ -21,7 +21,7 @@ func TestGetKernelHeaders(t *testing.T) {
 	if _, ok := os.LookupEnv("INTEGRATION"); !ok {
 		t.Skip("set INTEGRATION environment variable to run")
 	}
-	dirs, _, err := GetKernelHeaders(nil, "", "", "", "")
+	dirs, _, err := GetKernelHeaders(false, nil, "", "", "", "")
 	require.NoError(t, err)
 	assert.NotZero(t, len(dirs), "expected to find header directories")
 	t.Log(dirs)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Backport of #10899 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
