### PR TITLE
do not panic on ctr.Add(<negative>)

### DIFF
--- a/pkg/telemetry/prom_counter.go
+++ b/pkg/telemetry/prom_counter.go
@@ -25,15 +25,26 @@ func (c *promCounter) Initialize(tagsValue ...string) {
 }
 
 // Add adds the given value to the counter with the given tags value.
+//
+// If the value is < 0, no add takes place, as the counter is monotonic.
+// The prometheus client would panic in such a case.
 func (c *promCounter) Add(value float64, tagsValue ...string) {
-	c.pc.WithLabelValues(tagsValue...).Add(value)
+	if value > 0 {
+		c.pc.WithLabelValues(tagsValue...).Add(value)
+	}
 }
 
 // AddWithTags adds the given value to the counter with the given tags.
 // Even if less convenient, this signature could be used in hot path
 // instead of Add(float64, ...string) to avoid escaping the parameters on the heap.
+//
+//
+// If the value is < 0, no add takes place, as the counter is monotonic.
+// The prometheus client would panic in such a case.
 func (c *promCounter) AddWithTags(value float64, tags map[string]string) {
-	c.pc.With(tags).Add(value)
+	if value > 0 {
+		c.pc.With(tags).Add(value)
+	}
 }
 
 // Inc increments the counter with the given tags value.


### PR DESCRIPTION
### What does this PR do?

Converts what had been [a panic](https://github.com/DataDog/datadog-agent/issues/10730) into a no-op.

### Motivation

Avoiding panics.  The panic in this case came from the underlying source of Go's [monotonic clock](https://pkg.go.dev/time#Since) [running backward](https://doc.rust-lang.org/stable/src/std/time.rs.html#247), causing a small duration (the time to lock and unlocked mutex) to be negative.

### Possible Drawbacks / Trade-offs

Prometheus counters are defined to be monotonic, so Add'ing a negative value _is_ an error, and this PR silences that error.

I argue that this is acceptable -- the wrapper is only used for telemetry, so this would not mask errors in customer metrics, but only in the Agent telemetry implementation.

### Describe how to test/QA your changes

Enable agent telemetry, observe no panics.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
