### PR TITLE
Simple statsd telemetry provider + multi-line log metrics

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -384,6 +384,11 @@ func StartAgent() error {
 		}
 	}
 
+	// Setup stats telemetry handler
+	if sender, err := demux.GetDefaultSender(); err == nil {
+		telemetry.RegisterStatsHandler(sender)
+	}
+
 	// Start OTLP intake
 	otlpEnabled := otlp.IsEnabled(config.Datadog)
 	inventories.SetAgentMetadata(inventories.AgentOTLPEnabled, otlpEnabled)

--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -386,7 +386,7 @@ func StartAgent() error {
 
 	// Setup stats telemetry handler
 	if sender, err := demux.GetDefaultSender(); err == nil {
-		telemetry.RegisterStatsHandler(sender)
+		telemetry.RegisterStatsSender(sender)
 	}
 
 	// Start OTLP intake

--- a/pkg/logs/decoder/auto_multiline_handler.go
+++ b/pkg/logs/decoder/auto_multiline_handler.go
@@ -170,12 +170,12 @@ func (h *AutoMultilineHandler) processAndTry(message *Message) {
 
 		if matchRatio >= h.matchThreshold {
 			log.Debugf("Pattern %v matched %d lines with a ratio of %f", topMatch.regexp.String(), topMatch.score, matchRatio)
-			telemetry.StatsTelemetryProvider().Count(autoMultiLineTelemetryMetricName, 1, []string{"success:true"})
+			telemetry.GetStatsTelemetryProvider().Count(autoMultiLineTelemetryMetricName, 1, []string{"success:true"})
 			h.detectedPattern.Set(topMatch.regexp)
 			h.switchToMultilineHandler(topMatch.regexp)
 		} else {
 			log.Debug("No pattern met the line match threshold during multiline autosensing - using single line handler")
-			telemetry.StatsTelemetryProvider().Count(autoMultiLineTelemetryMetricName, 1, []string{"success:false"})
+			telemetry.GetStatsTelemetryProvider().Count(autoMultiLineTelemetryMetricName, 1, []string{"success:false"})
 			// Stay with the single line handler and no longer attempt to detect multiline matches.
 			h.processsingFunc = h.singleLineHandler.process
 		}

--- a/pkg/logs/decoder/auto_multiline_handler.go
+++ b/pkg/logs/decoder/auto_multiline_handler.go
@@ -16,7 +16,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
-var autoMultiLineTelemetryMetricName = "datadog.logs_agent.auto_multi_line"
+const autoMultiLineTelemetryMetricName = "datadog.logs_agent.auto_multi_line"
 
 type scoredPattern struct {
 	score  int

--- a/pkg/metadata/host/host.go
+++ b/pkg/metadata/host/host.go
@@ -218,7 +218,10 @@ func getContainerMeta(timeout time.Duration) map[string]string {
 }
 
 func getLogsMeta() *LogsMeta {
-	return &LogsMeta{Transport: string(status.CurrentTransport)}
+	return &LogsMeta{
+		Transport:            string(status.CurrentTransport),
+		AutoMultilineEnabled: config.Datadog.GetBool("logs_config.auto_multi_line_detection"),
+	}
 }
 
 // Expose the value of no_proxy_nonexact_match as well as any warnings of proxy behavior change in the metadata payload.

--- a/pkg/metadata/host/host_test.go
+++ b/pkg/metadata/host/host_test.go
@@ -114,15 +114,22 @@ func TestGetLogsMeta(t *testing.T) {
 	// No transport
 	status.CurrentTransport = ""
 	meta := getLogsMeta()
-	assert.Equal(t, &LogsMeta{Transport: ""}, meta)
+	assert.Equal(t, &LogsMeta{Transport: "", AutoMultilineEnabled: false}, meta)
 	// TCP transport
 	status.CurrentTransport = status.TransportTCP
 	meta = getLogsMeta()
-	assert.Equal(t, &LogsMeta{Transport: "TCP"}, meta)
+	assert.Equal(t, &LogsMeta{Transport: "TCP", AutoMultilineEnabled: false}, meta)
 	// HTTP transport
 	status.CurrentTransport = status.TransportHTTP
 	meta = getLogsMeta()
-	assert.Equal(t, &LogsMeta{Transport: "HTTP"}, meta)
+	assert.Equal(t, &LogsMeta{Transport: "HTTP", AutoMultilineEnabled: false}, meta)
+
+	// auto multiline enabled
+	config.Datadog.Set("logs_config.auto_multi_line_detection", true)
+	meta = getLogsMeta()
+	assert.Equal(t, &LogsMeta{Transport: "HTTP", AutoMultilineEnabled: true}, meta)
+
+	config.Datadog.Set("logs_config.auto_multi_line_detection", false)
 }
 
 func TestGetInstallMethod(t *testing.T) {

--- a/pkg/metadata/host/payload.go
+++ b/pkg/metadata/host/payload.go
@@ -38,7 +38,8 @@ type NetworkMeta struct {
 
 // LogsMeta is metadata about the host's logs agent
 type LogsMeta struct {
-	Transport string `json:"transport"`
+	Transport            string `json:"transport"`
+	AutoMultilineEnabled bool   `json:"auto_multi_line_detection_enabled"`
 }
 
 // Tags contains the detected host tags

--- a/pkg/telemetry/stats_telemetry.go
+++ b/pkg/telemetry/stats_telemetry.go
@@ -7,31 +7,32 @@ type StatsTelemetryHandler interface {
 	Count(metric string, value float64, hostname string, tags []string)
 }
 
-type statsTelemetryProvider struct {
-	sync.RWMutex
+// StatsTelemetryProvider handles stats telemetry and passes it on to a handler
+type StatsTelemetryProvider struct {
 	handler StatsTelemetryHandler
+	m       sync.RWMutex
 }
 
 var (
-	statsProvider = &statsTelemetryProvider{}
+	statsProvider = &StatsTelemetryProvider{}
 )
 
 // RegisterStatsHandler regsiters a handler to send the stats metrics
 func RegisterStatsHandler(handler StatsTelemetryHandler) {
-	statsProvider.Lock()
-	defer statsProvider.Unlock()
+	statsProvider.m.Lock()
+	defer statsProvider.m.Unlock()
 	statsProvider.handler = handler
 }
 
-// StatsTelemetryProvider gets an instance of the current stats telemetry provider
-func StatsTelemetryProvider() *statsTelemetryProvider {
+// GetStatsTelemetryProvider gets an instance of the current stats telemetry provider
+func GetStatsTelemetryProvider() *StatsTelemetryProvider {
 	return statsProvider
 }
 
 // Count reports a count metric to the handler
-func (s *statsTelemetryProvider) Count(metric string, value float64, tags []string) {
-	s.RLock()
-	defer s.RUnlock()
+func (s *StatsTelemetryProvider) Count(metric string, value float64, tags []string) {
+	s.m.RLock()
+	defer s.m.RUnlock()
 	if s.handler == nil {
 		return
 	}

--- a/pkg/telemetry/stats_telemetry.go
+++ b/pkg/telemetry/stats_telemetry.go
@@ -2,26 +2,26 @@ package telemetry
 
 import "sync"
 
-// StatsTelemetryHandler contains methods needed for sending stats metrics
-type StatsTelemetryHandler interface {
+// StatsTelemetrySender contains methods needed for sending stats metrics
+type StatsTelemetrySender interface {
 	Count(metric string, value float64, hostname string, tags []string)
 }
 
-// StatsTelemetryProvider handles stats telemetry and passes it on to a handler
+// StatsTelemetryProvider handles stats telemetry and passes it on to a sender
 type StatsTelemetryProvider struct {
-	handler StatsTelemetryHandler
-	m       sync.RWMutex
+	sender StatsTelemetrySender
+	m      sync.RWMutex
 }
 
 var (
 	statsProvider = &StatsTelemetryProvider{}
 )
 
-// RegisterStatsHandler regsiters a handler to send the stats metrics
-func RegisterStatsHandler(handler StatsTelemetryHandler) {
+// RegisterStatsSender regsiters a sender to send the stats metrics
+func RegisterStatsSender(sender StatsTelemetrySender) {
 	statsProvider.m.Lock()
 	defer statsProvider.m.Unlock()
-	statsProvider.handler = handler
+	statsProvider.sender = sender
 }
 
 // GetStatsTelemetryProvider gets an instance of the current stats telemetry provider
@@ -29,13 +29,13 @@ func GetStatsTelemetryProvider() *StatsTelemetryProvider {
 	return statsProvider
 }
 
-// Count reports a count metric to the handler
+// Count reports a count metric to the sender
 func (s *StatsTelemetryProvider) Count(metric string, value float64, tags []string) {
 	s.m.RLock()
 	defer s.m.RUnlock()
-	if s.handler == nil {
+	if s.sender == nil {
 		return
 	}
 
-	s.handler.Count(metric, value, "", tags)
+	s.sender.Count(metric, value, "", tags)
 }

--- a/pkg/telemetry/stats_telemetry.go
+++ b/pkg/telemetry/stats_telemetry.go
@@ -1,3 +1,8 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
 package telemetry
 
 import "sync"

--- a/pkg/telemetry/stats_telemetry.go
+++ b/pkg/telemetry/stats_telemetry.go
@@ -1,0 +1,40 @@
+package telemetry
+
+import "sync"
+
+// StatsTelemetryHandler contains methods needed for sending stats metrics
+type StatsTelemetryHandler interface {
+	Count(metric string, value float64, hostname string, tags []string)
+}
+
+type statsTelemetryProvider struct {
+	sync.RWMutex
+	handler StatsTelemetryHandler
+}
+
+var (
+	statsProvider = &statsTelemetryProvider{}
+)
+
+// RegisterStatsHandler regsiters a handler to send the stats metrics
+func RegisterStatsHandler(handler StatsTelemetryHandler) {
+	statsProvider.Lock()
+	defer statsProvider.Unlock()
+	statsProvider.handler = handler
+}
+
+// StatsTelemetryProvider gets an instance of the current stats telemetry provider
+func StatsTelemetryProvider() *statsTelemetryProvider {
+	return statsProvider
+}
+
+// Count reports a count metric to the handler
+func (s *statsTelemetryProvider) Count(metric string, value float64, tags []string) {
+	s.RLock()
+	defer s.RUnlock()
+	if s.handler == nil {
+		return
+	}
+
+	s.handler.Count(metric, value, "", tags)
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add a simple "direct to aggregator" telemetry provider. 
This is a minimal first pass to expose the ability to report metrics via the telemetry package. Like the Prometheus based telemetry implementation, this requires a handler to register on agent startup. In the case of the logs agent, the aggregator can register  the default sender directly. Other backends/handlers could be implemented for other use cases. 

We plan to expand on this in the future to support more types of metric based telemetry in the agent. This PR also exposes metrics from within the logs agent on auto multi-line usage success. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

- Agent startup and shutdown succeeds 
- auto multi-line metrics show up in app

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
