### PR TITLE
Validate kernel headers individually

### DIFF
--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -54,7 +54,6 @@ const (
 	headersNotFound
 )
 
-var errLinuxTypesHMissing = errors.New("correctly versioned kernel headers found, but linux/types.h missing")
 var errReposDirInaccessible = errors.New("unable to access repos directory")
 
 // GetKernelHeaders attempts to find kernel headers on the host, and if they cannot be found it will attempt
@@ -65,105 +64,86 @@ func GetKernelHeaders(downloadEnabled bool, headerDirs []string, headerDownloadD
 		return nil, hostVersionErr, fmt.Errorf("unable to determine host kernel version: %w", hvErr)
 	}
 
-	var err error
-	var dirs []string
 	if len(headerDirs) > 0 {
-		if err = validateHeaderDirs(hv, headerDirs); err == nil {
+		if dirs := validateHeaderDirs(hv, headerDirs); len(dirs) > 0 {
 			return headerDirs, customHeadersFound, nil
 		}
-		log.Debugf("unable to find configured kernel headers: %s", err)
+		log.Debugf("unable to find configured kernel headers: no valid headers found")
 	} else {
-		dirs = getDefaultHeaderDirs()
-		if err = validateHeaderDirs(hv, dirs); err == nil {
+		if dirs := validateHeaderDirs(hv, getDefaultHeaderDirs()); len(dirs) > 0 {
 			return dirs, defaultHeadersFound, nil
 		}
-		log.Debugf("unable to find default kernel headers: %s", err)
+		log.Debugf("unable to find default kernel headers: no valid headers found")
 
 		// If no valid directories are found, attempt a fallback to extracting from `/sys/kernel/kheaders.tar.xz`
 		// which is enabled via the `kheaders` kernel module and the `CONFIG_KHEADERS` kernel config option.
 		// The `kheaders` module will be automatically added and removed if present and needed.
+		var err error
+		var dirs []string
 		if dirs, err = getSysfsHeaderDirs(hv); err == nil {
 			return dirs, sysfsHeadersFound, nil
 		}
 		log.Debugf("unable to find system kernel headers: %s", err)
 	}
 
-	dirs = getDownloadedHeaderDirs(headerDownloadDir)
-	if err = validateHeaderDirs(hv, dirs); err == nil {
-		return dirs, downloadedHeadersFound, nil
-	}
-	log.Debugf("unable to find downloaded kernel headers: %s", err)
+	downloadedDirs := validateHeaderDirs(hv, getDownloadedHeaderDirs(headerDownloadDir))
+	for i := len(downloadedDirs) - 1; i >= 0; i-- {
+		d := downloadedDirs[i]
+		if !containsLinuxTypesHFile(d) {
+			log.Debugf("error validating %s: include/linux/types.h file missing", d)
 
-	if errors.Is(err, errLinuxTypesHMissing) {
-		// If this happens, it means we've previously downloaded kernel headers containing broken
-		// symlinks. We'll delete these to prevent them from affecting the next download
-		log.Infof("deleting previously downloaded kernel headers")
-		files, err := ioutil.ReadDir(headerDownloadDir)
-		if err != nil {
-			log.Warnf("error deleting kernel headers: %v", err)
-		}
-		for _, fi := range files {
-			path := filepath.Join(headerDownloadDir, fi.Name())
-			err = os.RemoveAll(path)
-			if err != nil {
-				log.Warnf("error deleting %s: %s", path, err)
-			}
+			// If this happens, it means we've previously downloaded kernel headers containing broken
+			// symlinks. We'll delete these to prevent them from affecting the next download
+			log.Infof("deleting previously downloaded kernel headers")
+			deleteKernelHeaderDirectory(d)
+			downloadedDirs = append(downloadedDirs[:i], downloadedDirs[i+1:]...)
 		}
 	}
-
-	if downloadEnabled {
-		d := headerDownloader{aptConfigDir, yumReposDir, zypperReposDir}
-		if err = d.downloadHeaders(headerDownloadDir); err != nil {
-			if errors.Is(err, errReposDirInaccessible) {
-				return nil, reposDirAccessFailure, fmt.Errorf("unable to download kernel headers: %w", err)
-			}
-			return nil, downloadFailure, fmt.Errorf("unable to download kernel headers: %w", err)
-		}
-
-		log.Infof("successfully downloaded kernel headers to %s", headerDownloadDir)
-		if err = validateHeaderDirs(hv, dirs); err == nil {
-			return dirs, downloadSuccess, nil
-		}
-		return nil, validationFailure, fmt.Errorf("downloaded headers are not valid: %w", err)
+	if len(downloadedDirs) > 0 {
+		return downloadedDirs, downloadedHeadersFound, nil
 	}
-	return nil, headersNotFound, fmt.Errorf("no valid matching kernel header directories found")
+	log.Debugf("unable to find downloaded kernel headers: no valid headers found")
+
+	if !downloadEnabled {
+		return nil, headersNotFound, fmt.Errorf("no valid matching kernel header directories found")
+	}
+
+	d := headerDownloader{aptConfigDir, yumReposDir, zypperReposDir}
+	if err := d.downloadHeaders(headerDownloadDir); err != nil {
+		if errors.Is(err, errReposDirInaccessible) {
+			return nil, reposDirAccessFailure, fmt.Errorf("unable to download kernel headers: %w", err)
+		}
+		return nil, downloadFailure, fmt.Errorf("unable to download kernel headers: %w", err)
+	}
+
+	log.Infof("successfully downloaded kernel headers to %s", headerDownloadDir)
+	if dirs := validateHeaderDirs(hv, getDownloadedHeaderDirs(headerDownloadDir)); len(dirs) > 0 {
+		return dirs, downloadSuccess, nil
+	}
+	return nil, validationFailure, fmt.Errorf("downloaded headers are not valid")
 }
 
-// validateHeaderDirs verifies that the kernel headers in at least 1 directory matches the kernel version of the running host
-// and contains the linux/types.h file
-func validateHeaderDirs(hv Version, dirs []string) error {
-	versionMatches, linuxTypesHFound := false, false
+// validateHeaderDirs checks all the given directories and returns the directories containing kernel
+// headers matching the kernel version of the running host
+func validateHeaderDirs(hv Version, dirs []string) []string {
+	var valid []string
 	for _, d := range dirs {
-		if containsLinuxTypesHFile(d) {
-			linuxTypesHFound = true
-		}
-
 		dirv, err := getHeaderVersion(d)
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
-				// if version.h is not found in this directory, keep going
+				// version.h is not found in this directory
 				continue
 			}
-			return fmt.Errorf("error validating headers version: %w", err)
+			log.Debugf("error validating %s: error validating headers version: %w", d, err)
+			continue
 		}
 		if dirv != hv {
-			return fmt.Errorf("header version %s does not match host version %s", dirv, hv)
+			log.Debugf("error validating %s: header version %s does not match host version %s", d, dirv, hv)
+			continue
 		}
-
-		// as long as one directory passes, validate the entire set
-		versionMatches = true
+		valid = append(valid, d)
 	}
-
-	if !versionMatches {
-		return fmt.Errorf("no valid kernel headers found")
-	}
-
-	if !linuxTypesHFound {
-		return errLinuxTypesHMissing
-	}
-
-	log.Debugf("valid kernel headers found in %v", dirs)
-	return nil
+	return valid
 }
 
 func containsLinuxTypesHFile(dir string) bool {
@@ -176,6 +156,20 @@ func containsLinuxTypesHFile(dir string) bool {
 		defer f.Close()
 	}
 	return true
+}
+
+func deleteKernelHeaderDirectory(dir string) {
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		log.Warnf("error deleting kernel headers: %v", err)
+	}
+	for _, fi := range files {
+		path := filepath.Join(dir, fi.Name())
+		err = os.RemoveAll(path)
+		if err != nil {
+			log.Warnf("error deleting %s: %s", path, err)
+		}
+	}
 }
 
 func getHeaderVersion(path string) (Version, error) {

--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -83,7 +83,7 @@ func GetKernelHeaders(downloadEnabled bool, headerDirs []string, headerDownloadD
 		if dirs, err = getSysfsHeaderDirs(hv); err == nil {
 			return dirs, sysfsHeadersFound, nil
 		}
-		log.Debugf("unable to find system kernel headers: %s", err)
+		log.Debugf("unable to find system kernel headers: %w", err)
 	}
 
 	downloadedDirs := validateHeaderDirs(hv, getDownloadedHeaderDirs(headerDownloadDir))

--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -131,7 +131,9 @@ func validateHeaderDirs(hv Version, dirs []string) []string {
 		dirv, err := getHeaderVersion(d)
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
-				// version.h is not found in this directory
+				// version.h is not found in this directory; we'll consider it valid, in case
+				// it contains necessary files
+				log.Debugf("found non-versioned kernel headers at %s", d)
 				valid = append(valid, d)
 				continue
 			}
@@ -142,6 +144,7 @@ func validateHeaderDirs(hv Version, dirs []string) []string {
 			log.Debugf("error validating %s: header version %s does not match host version %s", d, dirv, hv)
 			continue
 		}
+		log.Debugf("found valid kernel headers at %s", d)
 		valid = append(valid, d)
 	}
 	return valid

--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -132,6 +132,7 @@ func validateHeaderDirs(hv Version, dirs []string) []string {
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {
 				// version.h is not found in this directory
+				valid = append(valid, d)
 				continue
 			}
 			log.Debugf("error validating %s: error validating headers version: %w", d, err)

--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -128,6 +128,10 @@ func GetKernelHeaders(downloadEnabled bool, headerDirs []string, headerDownloadD
 func validateHeaderDirs(hv Version, dirs []string) []string {
 	var valid []string
 	for _, d := range dirs {
+		if _, err := os.Stat(d); errors.Is(err, fs.ErrNotExist) {
+			continue
+		}
+
 		dirv, err := getHeaderVersion(d)
 		if err != nil {
 			if errors.Is(err, fs.ErrNotExist) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Previously, we validated kernel headers as an entire set; this meant that if a single set of kernel headers was found whose version didn't match the host version, we considered the whole set invalid.
This change makes it so that we simply leave out kernel header directories containing invalid versions, and include all other kernel header directories.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

1) Enable runtime compilation:
```
system_probe_config:
  enabled: true
  enable_runtime_compiler: true
```
2) Find the location of your system's kernel headers `version.h` file (ie on my dev VM, they are at `/lib/modules/5.4.0-77-generic/build/include/generated/uapi/linux/version.h`)
3) Copy the file found in step 2 to `/usr/include/linux/version.h`. Edit the copied file & change the value of `LINUX_VERSION_CODE` to something random.
4) Run the system-probe, and check that you see the following log lines:
```
 found valid kernel headers at <whatever path your valid kernel headers were at>
 error validating /usr: header version <some random version> does not match host version 5.4.119
 ```
 Verify that you do **not** see a log line containing the following error: `unable to find kernel headers:`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
