### PR TITLE
[CWS] Track namespaced pids on fork

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime-security.go
+++ b/pkg/ebpf/bytecode/runtime/runtime-security.go
@@ -4,4 +4,4 @@
 
 package runtime
 
-var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "411ac02839d2655966879acad8f1b0ae6a4f38069e889f15f31d1c5a722821ed")
+var RuntimeSecurity = NewRuntimeAsset("runtime-security.c", "d1a37086d868e9ea436b7d37e7326ee9373706508a1605b6757260cf2f6fbc6e")

--- a/pkg/security/ebpf/c/process.h
+++ b/pkg/security/ebpf/c/process.h
@@ -51,15 +51,6 @@ struct bpf_map_def SEC("maps/proc_cache") proc_cache = {
     .namespace = "",
 };
 
-struct bpf_map_def SEC("maps/pid_ns") pid_ns = {
-    .type = BPF_MAP_TYPE_LRU_HASH,
-    .key_size = sizeof(u64),
-    .value_size = sizeof(u64),
-    .max_entries = 32768,
-    .pinning = 0,
-    .namespace = "",
-};
-
 static void __attribute__((always_inline)) fill_container_context(struct proc_cache_t *entry, struct container_context_t *context) {
     if (entry) {
         copy_container_id(entry->container.container_id, context->container_id);
@@ -132,13 +123,96 @@ static struct proc_cache_t * __attribute__((always_inline)) fill_process_context
     return get_proc_cache(tgid);
 }
 
-void __attribute__((always_inline)) register_pid_ns(u64 pid_tgid, u64 pid_tgid_ns) {
-   bpf_map_update_elem(&pid_ns, &pid_tgid, &pid_tgid_ns, BPF_NOEXIST);
+struct bpf_map_def SEC("maps/root_nr_namespace_nr") root_nr_namespace_nr = {
+    .type = BPF_MAP_TYPE_LRU_HASH,
+    .key_size = sizeof(u32),
+    .value_size = sizeof(u32),
+    .max_entries = 32768,
+    .pinning = 0,
+    .namespace = "",
+};
+
+struct bpf_map_def SEC("maps/namespace_nr_root_nr") namespace_nr_root_nr = {
+    .type = BPF_MAP_TYPE_LRU_HASH,
+    .key_size = sizeof(u32),
+    .value_size = sizeof(u32),
+    .max_entries = 32768,
+    .pinning = 0,
+    .namespace = "",
+};
+
+void __attribute__((always_inline)) register_nr(u32 root_nr, u64 namespace_nr) {
+    // no namespace
+    if (root_nr == 0 || namespace_nr == 0) {
+        return;
+    }
+
+    // TODO(will): this can conflict between containers, add cgroup ID or namespace to the lookup key
+    bpf_map_update_elem(&root_nr_namespace_nr, &root_nr, &namespace_nr, BPF_ANY);
+    bpf_map_update_elem(&namespace_nr_root_nr, &namespace_nr, &root_nr, BPF_ANY);
 }
 
-u64 __attribute__((always_inline)) lookup_pid_ns(u64 pid_tgid) {
-    u64 *pid = bpf_map_lookup_elem(&pid_ns, &pid_tgid);
+u32 __attribute__((always_inline)) get_root_nr(u32 namespace_nr) {
+    // TODO(will): this can conflict between containers, add cgroup ID or namespace to the lookup key
+    u32 *pid = bpf_map_lookup_elem(&namespace_nr_root_nr, &namespace_nr);
     return pid ? *pid : 0;
+}
+
+u32 __attribute__((always_inline)) get_namespace_nr(u32 root_nr) {
+    // TODO(will): this can conflict between containers, add cgroup ID or namespace to the lookup key
+    u32 *pid = bpf_map_lookup_elem(&root_nr_namespace_nr, &root_nr);
+    return pid ? *pid : 0;
+}
+
+void __attribute__((always_inline)) remove_nr(u32 root_nr) {
+    // TODO(will): this can conflict between containers, add cgroup ID or namespace to the lookup key
+    u32 namespace_nr = get_namespace_nr(root_nr);
+    if (root_nr == 0 || namespace_nr == 0) {
+        return;
+    }
+
+    bpf_map_delete_elem(&root_nr_namespace_nr, &root_nr);
+    bpf_map_delete_elem(&namespace_nr_root_nr, &namespace_nr);
+}
+
+u64 __attribute__((always_inline)) get_pid_level_offset() {
+    u64 pid_level_offset;
+    LOAD_CONSTANT("pid_level_offset", pid_level_offset);
+    return pid_level_offset;
+}
+
+u64 __attribute__((always_inline)) get_pid_numbers_offset() {
+    u64 pid_numbers_offset;
+    LOAD_CONSTANT("pid_numbers_offset", pid_numbers_offset);
+    return pid_numbers_offset;
+}
+
+u64 __attribute__((always_inline)) get_sizeof_upid() {
+    u64 sizeof_upid;
+    LOAD_CONSTANT("sizeof_upid", sizeof_upid);
+    return sizeof_upid;
+}
+
+void __attribute__((always_inline)) cache_nr_translations(struct pid *pid) {
+    if (pid == NULL) {
+        return;
+    }
+
+    // read the root namespace nr from &pid->numbers[0].nr
+    u32 root_nr = 0;
+    bpf_probe_read(&root_nr, sizeof(root_nr), (void *)pid + get_pid_numbers_offset());
+
+    // TODO(will): iterate over the list to insert the nr of each namespace, for now get only the deepest one
+    u32 pid_level = 0;
+    bpf_probe_read(&pid_level, sizeof(pid_level), (void *)pid + get_pid_level_offset());
+
+    // read the namespace nr from &pid->numbers[pid_level].nr
+    u32 namespace_nr = 0;
+    u64 namespace_numbers_offset = pid_level * get_sizeof_upid();
+    bpf_probe_read(&namespace_nr, sizeof(namespace_nr), (void *)pid + get_pid_numbers_offset() + namespace_numbers_offset);
+
+    register_nr(root_nr, namespace_nr);
+    return;
 }
 
 #endif

--- a/pkg/security/ebpf/c/ptrace.h
+++ b/pkg/security/ebpf/c/ptrace.h
@@ -37,10 +37,16 @@ int __attribute__((always_inline)) sys_ptrace_ret(void *ctx, int retval) {
     if (!syscall)
         return 0;
 
+    // try to resolve namespaced nr
+    u32 namespace_nr = get_root_nr(syscall->ptrace.pid);
+    if (namespace_nr == 0) {
+        namespace_nr = syscall->ptrace.pid;
+    }
+
     struct ptrace_event_t event = {
         .syscall.retval = retval,
         .request = syscall->ptrace.request,
-        .pid = syscall->ptrace.pid,
+        .pid = namespace_nr,
         .addr = syscall->ptrace.addr,
     };
 

--- a/pkg/security/ebpf/c/span.h
+++ b/pkg/security/ebpf/c/span.h
@@ -23,7 +23,7 @@ struct bpf_map_def SEC("maps/span_tls") span_tls = {
 };
 
 // defined in process.h
-u64 lookup_pid_ns(u64 pid_tgid);
+u32 get_namespace_nr(u32 root_nr);
 
 int __attribute__((always_inline)) handle_register_span_memory(void *data) {
    struct span_tls_t tls = {};
@@ -49,12 +49,12 @@ int __attribute__((always_inline)) unregister_span_memory() {
 void __attribute__((always_inline)) fill_span_context(struct span_context_t *span) {
    u64 pid_tgid = bpf_get_current_pid_tgid();
    u32 tgid = pid_tgid >> 32;
-  
+
    struct span_tls_t *tls = bpf_map_lookup_elem(&span_tls, &tgid);
    if (tls) {
       u32 tid = pid_tgid;
 
-      u64 pid = lookup_pid_ns(pid_tgid);
+      u32 pid = get_namespace_nr(tid);
       if (pid) {
          tid = pid;
       }

--- a/pkg/security/ebpf/c/syscalls.h
+++ b/pkg/security/ebpf/c/syscalls.h
@@ -128,6 +128,11 @@ struct syscall_cache_t {
         } exec;
 
         struct {
+            u32 is_thread;
+            struct pid *pid;
+        } fork;
+
+        struct {
             struct dentry *dentry;
             struct file_t file;
             u32 event_kind;

--- a/pkg/security/ebpf/probes/event_types.go
+++ b/pkg/security/ebpf/probes/event_types.go
@@ -41,6 +41,7 @@ var SelectorsPerEventType = map[eval.EventType][]manager.ProbesSelector{
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/do_dentry_open", EBPFFuncName: "kprobe_do_dentry_open"}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/commit_creds", EBPFFuncName: "kprobe_commit_creds"}},
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/__task_pid_nr_ns", EBPFFuncName: "kretprobe__task_pid_nr_ns"}},
+			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kretprobe/alloc_pid", EBPFFuncName: "kretprobe_alloc_pid"}},
 		}},
 		&manager.OneOf{Selectors: []manager.ProbesSelector{
 			&manager.ProbeSelector{ProbeIdentificationPair: manager.ProbeIdentificationPair{UID: SecurityAgentUID, EBPFSection: "kprobe/cgroup_procs_write", EBPFFuncName: "kprobe_cgroup_procs_write"}},

--- a/pkg/security/ebpf/probes/exec.go
+++ b/pkg/security/ebpf/probes/exec.go
@@ -124,6 +124,13 @@ var execProbes = []*manager.Probe{
 			EBPFFuncName: "kretprobe__task_pid_nr_ns",
 		},
 	},
+	{
+		ProbeIdentificationPair: manager.ProbeIdentificationPair{
+			UID:          SecurityAgentUID,
+			EBPFSection:  "kretprobe/alloc_pid",
+			EBPFFuncName: "kretprobe_alloc_pid",
+		},
+	},
 }
 
 func getExecProbes() []*manager.Probe {

--- a/pkg/security/probe/constantfetch/fallback.go
+++ b/pkg/security/probe/constantfetch/fallback.go
@@ -60,6 +60,12 @@ func (f *FallbackConstantFetcher) appendRequest(id string) {
 		value = getBpfProgAuxIDOffset(f.kernelVersion)
 	case "bpf_prog_aux_name_offset":
 		value = getBpfProgAuxNameOffset(f.kernelVersion)
+	case "pid_level_offset":
+		value = getPIDLevelOffset(f.kernelVersion)
+	case "pid_numbers_offset":
+		value = getPIDNumbersOffset(f.kernelVersion)
+	case "sizeof_upid":
+		value = getSizeOfUpid(f.kernelVersion)
 	}
 	f.res[id] = value
 }
@@ -330,4 +336,47 @@ func getBpfProgAuxNameOffset(kv *kernel.Version) uint64 {
 	}
 
 	return nameOffset
+}
+
+func getPIDLevelOffset(kv *kernel.Version) uint64 {
+	return uint64(4)
+}
+
+func getPIDNumbersOffset(kv *kernel.Version) uint64 {
+	pidNumbersOffset := uint64(48)
+
+	switch {
+	case kv.IsRH7Kernel():
+		pidNumbersOffset = 48
+	case kv.IsRH8Kernel():
+		pidNumbersOffset = 56
+	case kv.IsSLES12Kernel():
+		pidNumbersOffset = 48
+	case kv.IsSLES15Kernel():
+		pidNumbersOffset = 80
+
+	case kv.IsInRangeCloseOpen(kernel.Kernel4_15, kernel.Kernel5_3):
+		pidNumbersOffset = 48
+	case kv.IsInRangeCloseOpen(kernel.Kernel5_3, kernel.Kernel5_7):
+		pidNumbersOffset = 80
+	case kv.Code != 0 && kv.Code >= kernel.Kernel5_7:
+		pidNumbersOffset = 96
+	}
+	return pidNumbersOffset
+}
+
+func getSizeOfUpid(kv *kernel.Version) uint64 {
+	sizeOfUpid := uint64(16)
+
+	switch {
+	case kv.IsRH7Kernel():
+		sizeOfUpid = 32
+	case kv.IsRH8Kernel():
+		sizeOfUpid = 16
+	case kv.IsSLES12Kernel():
+		sizeOfUpid = 16
+	case kv.IsSLES15Kernel():
+		sizeOfUpid = 32
+	}
+	return sizeOfUpid
 }

--- a/pkg/security/probe/probe.go
+++ b/pkg/security/probe/probe.go
@@ -1084,5 +1084,9 @@ func GetOffsetConstantsFromFetcher(constantFetcher constantfetch.ConstantFetcher
 	if probe.kernelVersion.Code != 0 && (probe.kernelVersion.Code > kernel.Kernel4_16 || probe.kernelVersion.IsSLES12Kernel() || probe.kernelVersion.IsSLES15Kernel()) {
 		constantFetcher.AppendOffsetofRequest("bpf_prog_attach_type_offset", "struct bpf_prog", "expected_attach_type", "linux/filter.h")
 	}
+	// namespace nr offsets
+	constantFetcher.AppendOffsetofRequest("pid_level_offset", "struct pid", "level", "linux/pid.h")
+	constantFetcher.AppendOffsetofRequest("pid_numbers_offset", "struct pid", "numbers", "linux/pid.h")
+	constantFetcher.AppendSizeofRequest("sizeof_upid", "struct upid", "linux/pid.h")
 	return constantFetcher.FinishAndGetResults()
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

This PR improves the way we track namespaced pids.

Currently we rely on a kretprobe on `__task_pid_nr_ns`, hoping that the current thread matches the thread that is being resolved. That's the case when this function is called from `exec_binprm` but in most cases, this is a wrong assumption, and we populate our caches with wrong values. A filter for the exec syscall was added.

This PR introduces a new kretprobe (unfortunately I wasn't able to find a kprobe) on `alloc_pid` so that we get the newly created `struct pid` for the child task of a fork. Since pid namespaces are inherited on fork, this kernel function will allocate a new nr for each namespace, which means that we can populate our caches with the correct namespaced pids when the fork syscall returns.

TIL: `setns` won't change the active pid namespace of a task, but will only change the `pid_ns_for_children` namespace. In a few words, a task can't ever change its pid namespace, it can only change where its children will live. This is why the `nsenter` utility issues a `setns` and `clone` syscall before executing the requested command (instead of `setns` and `exec` directly).

Future work:
- index the `root_nr_namespace_nr` and `namespace_nr_root_nr` maps with the cgroup ID of each container
- add a snapshot to definitely get rid of `__task_pid_nr_ns`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fix the `ptrace` functional tests and improve the span tracking feature support for containers.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
