### PR TITLE
use_local_defined_servers: include /etc/chrony.conf

### DIFF
--- a/pkg/collector/corechecks/net/ntp_local_defined_server_nowindows.go
+++ b/pkg/collector/corechecks/net/ntp_local_defined_server_nowindows.go
@@ -15,7 +15,7 @@ import (
 )
 
 func getLocalDefinedNTPServers() ([]string, error) {
-	return getNTPServersFromFiles([]string{"/etc/ntp.conf", "etc/xntp.conf"})
+	return getNTPServersFromFiles([]string{"/etc/ntp.conf", "/etc/xntp.conf", "/etc/chrony.conf"})
 }
 
 func getNTPServersFromFiles(files []string) ([]string, error) {

--- a/releasenotes/notes/use_local_defined_servers-include-chronyd-support-a5dd58318f5294ef.yaml
+++ b/releasenotes/notes/use_local_defined_servers-include-chronyd-support-a5dd58318f5294ef.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Include `/etc/chrony.conf` for `use_local_defined_servers`.


### PR DESCRIPTION
### What does this PR do?

Includes NTP servers in `/etc/chrony.conf` for use with `use_local_defined_servers`

### Motivation

- FRAGENT-1625
- FRAGENT-1346

### Additional Notes

- No additional tests are needed since `/etc/chrony.conf` share the same format with `/etc/ntp.conf`. In fact, the current workaround is to symlink `/etc/chrony.conf` to `/etc/ntp.conf`.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Test in RHEL/Centos 8 where `/etc/chrony.conf` exists by default.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
