### PR TITLE
[CWS] add more test on SECL list

### DIFF
--- a/pkg/security/secl/compiler/eval/eval_test.go
+++ b/pkg/security/secl/compiler/eval/eval_test.go
@@ -853,10 +853,16 @@ func TestRegister(t *testing.T) {
 		{Expr: `process.list[_].value !~ "AA*"`, Expected: false},
 		{Expr: `process.list[_].value !~ "ZZ*"`, Expected: true},
 
-		{Expr: `process.list[_].value in [~"AA*", "nnnnn"]`, Expected: true},
+		{Expr: `process.list[_].value in ["~zzzz", ~"AA*", "nnnnn"]`, Expected: true},
+		{Expr: `process.list[_].value in ["~zzzz", ~"AA*", "nnnnn"]`, Expected: true},
+		{Expr: `process.list[_].value in ["~zzzz", "AAA", "nnnnn"]`, Expected: true},
+		{Expr: `process.list[_].value in ["~zzzz", "AA*", "nnnnn"]`, Expected: false},
+
 		{Expr: `process.list[_].value in [~"ZZ*", "nnnnn"]`, Expected: false},
 		{Expr: `process.list[_].value not in [~"AA*", "nnnnn"]`, Expected: false},
 		{Expr: `process.list[_].value not in [~"ZZ*", "nnnnn"]`, Expected: true},
+		{Expr: `process.list[_].value not in [~"ZZ*", "AAA", "nnnnn"]`, Expected: false},
+		{Expr: `process.list[_].value not in [~"ZZ*", ~"AA*", "nnnnn"]`, Expected: false},
 
 		{Expr: `process.list[_].key == 10 && process.list[_].value == "AAA"`, Expected: true},
 		{Expr: `process.list[_].key == 9999 && process.list[_].value == "AAA"`, Expected: false},
@@ -867,12 +873,6 @@ func TestRegister(t *testing.T) {
 
 		{Expr: `process.array[_].key == 1000 && process.array[_].value == "EEEE"`, Expected: true},
 		{Expr: `process.array[_].key == 1002 && process.array[_].value == "EEEE"`, Expected: true},
-
-		//{Expr: `process.list[A].key == 200 && process.list[A].value == "CCC"`, Expected: true},
-		//{Expr: `process.list[A].key == 200 && process.list[B].value == "BBB"`, Expected: true},
-		//{Expr: `process.list[A].key == 200 || process.list[B].value == "AA"`, Expected: true},
-		//{Expr: `process.array[A].key == 1002 && process.array[B].value == "DDDD"`, Expected: true},
-		//{Expr: `process.list[_].key == 10 && process.list[_].value == "AA" && process.array[A].key == 1002 && process.array[A].value == "DDDD"`, Expected: true},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Add test to ensure non-regression on SECL list mixing scalar values en patterns. This to track a bug present in 7.32, fixed in 7.34 after a refactoring.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
