### PR TITLE
[CWS & CSPM] e2e tests fix and improvements

### DIFF
--- a/.gitlab/e2e.yml
+++ b/.gitlab/e2e.yml
@@ -84,7 +84,9 @@ k8s-e2e-cws-main:
   extends: .k8s_e2e_template
   rules:
     !reference [.on_main]
-  needs: []
+  # needs:
+  #   - dev_master-a6
+  #   - dev_master-a7
   retry: 1
   script:
     - !reference [.k8s-e2e-cws-cspm-init]
@@ -103,7 +105,9 @@ k8s-e2e-cspm-main:
   extends: .k8s_e2e_template
   rules:
     !reference [.on_main]
-  needs: []
+  # needs:
+  #   - dev_master-a6
+  #   - dev_master-a7
   retry: 1
   script:
     - !reference [.k8s-e2e-cws-cspm-init]

--- a/test/e2e/cws-tests/README.md
+++ b/test/e2e/cws-tests/README.md
@@ -1,0 +1,25 @@
+# CWS & CSPM e2e tests
+
+## Docker flavors
+
+To run docker flavoured tests, local only, please run:
+
+For CWS:
+```sh
+DD_API_KEY=<API_KEY> \
+DD_APP_KEY=<APP_KEY> \
+DD_SITE=datadoghq.com \
+DD_AGENT_IMAGE=datadog/agent-dev:master \
+python3 tests/test_e2e_cws_docker.py
+```
+
+For CSPM:
+```sh
+DD_API_KEY=<API_KEY> \
+DD_APP_KEY=<APP_KEY> \
+DD_SITE=datadoghq.com \
+DD_AGENT_IMAGE=datadog/agent-dev:master \
+python3 tests/test_e2e_cspm_docker.py
+```
+
+Please change `DD_AGENT_IMAGE` to a branch specific tag if you need to test a specific branch.

--- a/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
@@ -108,6 +108,8 @@ class TestE2EDocker(unittest.TestCase):
                 f"Sending event message for rule `{agent_rule_name}`",
             )
 
+            wait_agent_log("security-agent", self.docker_helper, "Successfully posted payload to")
+
         with Step(msg="check app event", emoji=":chart_increasing_with_yen:"):
             event = self.App.wait_app_log(f"rule_id:{agent_rule_name}")
             attributes = event["data"][0]["attributes"]

--- a/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_docker.py
@@ -96,7 +96,7 @@ class TestE2EDocker(unittest.TestCase):
             wait_agent_log("security-agent", self.docker_helper, SECURITY_START_LOG)
             wait_agent_log("system-probe", self.docker_helper, SYS_PROBE_START_LOG)
 
-        with Step(msg="wait for host tags(~2m)", emoji=":alarm_clock:"):
+        with Step(msg="wait for host tags (3m)", emoji=":alarm_clock:"):
             time.sleep(3 * 60)
 
         with Step(msg="check agent event", emoji=":check_mark_button:"):

--- a/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
@@ -107,6 +107,12 @@ class TestE2EKubernetes(unittest.TestCase):
                 f"Sending event message for rule `{agent_rule_name}`",
             )
 
+            wait_agent_log(
+                "security-agent",
+                self.kubernetes_helper,
+                "Successfully posted payload to",
+            )
+
         with Step(msg="check app event", emoji=":chart_increasing_with_yen:"):
             event = self.App.wait_app_log(f"rule_id:{agent_rule_name}")
             attributes = event["data"][0]["attributes"]

--- a/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
+++ b/test/e2e/cws-tests/tests/test_e2e_cws_kubernetes.py
@@ -88,7 +88,7 @@ class TestE2EKubernetes(unittest.TestCase):
         with Step(msg="check system-probe start", emoji=":customs:"):
             wait_agent_log("system-probe", self.kubernetes_helper, SYS_PROBE_START_LOG)
 
-        with Step(msg="wait for host tags(~2m)", emoji=":alarm_clock:"):
+        with Step(msg="wait for host tags (3m)", emoji=":alarm_clock:"):
             time.sleep(3 * 60)
 
         with Step(msg="upload policies", emoji=":down_arrow:"):


### PR DESCRIPTION
### What does this PR do?

This PR represents improvements to CWS e2e tests resulting from the investigation of failing tests. The root cause was actually a daily quota that was reached daily in about an hour, meaning that logs were ignored the rest of the day.

This PR:
- adds a README to ease the usage of docker e2e tests
- adds a step checking some security-agent log
- fixes some inconsistencies between user message and time actually slept
- fixes some gitlab job dependency inconsistency with other e2e jobs

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
