### PR TITLE
[pkg/otlp] Export `Dimensions` struct and use it in Consumer interfaces

### DIFF
--- a/pkg/otlp/internal/serializerexporter/consumer.go
+++ b/pkg/otlp/internal/serializerexporter/consumer.go
@@ -25,11 +25,11 @@ type serializerConsumer struct {
 	sketches metrics.SketchSeriesList
 }
 
-func (c *serializerConsumer) ConsumeSketch(_ context.Context, name string, ts uint64, qsketch *quantile.Sketch, tags []string, host string) {
+func (c *serializerConsumer) ConsumeSketch(_ context.Context, dimensions *translator.Dimensions, ts uint64, qsketch *quantile.Sketch) {
 	c.sketches = append(c.sketches, metrics.SketchSeries{
-		Name:     name,
-		Tags:     tags,
-		Host:     host,
+		Name:     dimensions.Name(),
+		Tags:     dimensions.Tags(),
+		Host:     dimensions.Host(),
 		Interval: 1,
 		Points: []metrics.SketchPoint{{
 			Ts:     int64(ts / 1e9),
@@ -48,13 +48,13 @@ func apiTypeFromTranslatorType(typ translator.MetricDataType) metrics.APIMetricT
 	panic(fmt.Sprintf("unreachable: received non-count non-gauge type: %d", typ))
 }
 
-func (c *serializerConsumer) ConsumeTimeSeries(ctx context.Context, name string, typ translator.MetricDataType, ts uint64, value float64, tags []string, host string) {
+func (c *serializerConsumer) ConsumeTimeSeries(ctx context.Context, dimensions *translator.Dimensions, typ translator.MetricDataType, ts uint64, value float64) {
 	c.series = append(c.series,
 		&metrics.Serie{
-			Name:     name,
+			Name:     dimensions.Name(),
 			Points:   []metrics.Point{{Ts: float64(ts / 1e9), Value: value}},
-			Tags:     tags,
-			Host:     host,
+			Tags:     dimensions.Tags(),
+			Host:     dimensions.Host(),
 			MType:    apiTypeFromTranslatorType(typ),
 			Interval: 1,
 		},

--- a/pkg/otlp/model/translator/consumer.go
+++ b/pkg/otlp/model/translator/consumer.go
@@ -35,12 +35,10 @@ type TimeSeriesConsumer interface {
 	// ConsumeTimeSeries consumes a timeseries-style metric.
 	ConsumeTimeSeries(
 		ctx context.Context,
-		name string,
+		dimensions *Dimensions,
 		typ MetricDataType,
 		timestamp uint64,
 		value float64,
-		tags []string,
-		host string,
 	)
 }
 
@@ -49,11 +47,9 @@ type SketchConsumer interface {
 	// ConsumeSketch consumes a pkg/quantile-style sketch.
 	ConsumeSketch(
 		ctx context.Context,
-		name string,
+		dimensions *Dimensions,
 		timestamp uint64,
 		sketch *quantile.Sketch,
-		tags []string,
-		host string,
 	)
 }
 

--- a/pkg/otlp/model/translator/dimensions.go
+++ b/pkg/otlp/model/translator/dimensions.go
@@ -28,10 +28,27 @@ const (
 	dimensionSeparator = string(byte(0))
 )
 
-type metricsDimensions struct {
+// Dimensions of a metric that identify a timeseries uniquely.
+// This is similar to the concept of 'context' in DogStatsD/check metrics.
+type Dimensions struct {
 	name string
 	tags []string
 	host string
+}
+
+// Name of the metric.
+func (d *Dimensions) Name() string {
+	return d.name
+}
+
+// Tags of the metric (read-only).
+func (d *Dimensions) Tags() []string {
+	return d.tags
+}
+
+// Host of the metric (may be empty).
+func (d *Dimensions) Host() string {
+	return d.host
 }
 
 // getTags maps an attributeMap into a slice of Datadog tags
@@ -46,29 +63,29 @@ func getTags(labels pdata.AttributeMap) []string {
 }
 
 // AddTags to metrics dimensions.
-func (m *metricsDimensions) AddTags(tags ...string) metricsDimensions {
+func (d *Dimensions) AddTags(tags ...string) *Dimensions {
 	// defensively copy the tags
-	newTags := make([]string, 0, len(tags)+len(m.tags))
+	newTags := make([]string, 0, len(tags)+len(d.tags))
 	newTags = append(newTags, tags...)
-	newTags = append(newTags, m.tags...)
-	return metricsDimensions{
-		name: m.name,
+	newTags = append(newTags, d.tags...)
+	return &Dimensions{
+		name: d.name,
 		tags: newTags,
-		host: m.host,
+		host: d.host,
 	}
 }
 
 // WithAttributeMap creates a new metricDimensions struct with additional tags from attributes.
-func (m *metricsDimensions) WithAttributeMap(labels pdata.AttributeMap) metricsDimensions {
-	return m.AddTags(getTags(labels)...)
+func (d *Dimensions) WithAttributeMap(labels pdata.AttributeMap) *Dimensions {
+	return d.AddTags(getTags(labels)...)
 }
 
 // WithSuffix creates a new dimensions struct with an extra name suffix.
-func (m *metricsDimensions) WithSuffix(suffix string) metricsDimensions {
-	return metricsDimensions{
-		name: fmt.Sprintf("%s.%s", m.name, suffix),
-		host: m.host,
-		tags: m.tags,
+func (d *Dimensions) WithSuffix(suffix string) *Dimensions {
+	return &Dimensions{
+		name: fmt.Sprintf("%s.%s", d.name, suffix),
+		host: d.host,
+		tags: d.tags,
 	}
 }
 
@@ -82,14 +99,14 @@ func concatDimensionValue(metricKeyBuilder *strings.Builder, value string) {
 
 // String maps dimensions to a string to use as an identifier.
 // The tags order does not matter.
-func (m *metricsDimensions) String() string {
+func (d *Dimensions) String() string {
 	var metricKeyBuilder strings.Builder
 
-	dimensions := make([]string, len(m.tags))
-	copy(dimensions, m.tags)
+	dimensions := make([]string, len(d.tags))
+	copy(dimensions, d.tags)
 
-	dimensions = append(dimensions, fmt.Sprintf("name:%s", m.name))
-	dimensions = append(dimensions, fmt.Sprintf("host:%s", m.host))
+	dimensions = append(dimensions, fmt.Sprintf("name:%s", d.name))
+	dimensions = append(dimensions, fmt.Sprintf("host:%s", d.host))
 	sort.Strings(dimensions)
 
 	for _, dim := range dimensions {

--- a/pkg/otlp/model/translator/dimensions_test.go
+++ b/pkg/otlp/model/translator/dimensions_test.go
@@ -28,7 +28,7 @@ func TestWithAttributeMap(t *testing.T) {
 		"key3": pdata.NewAttributeValueString(""),
 	})
 
-	dims := metricsDimensions{}
+	dims := Dimensions{}
 	assert.ElementsMatch(t,
 		dims.WithAttributeMap(attributes).tags,
 		[...]string{"key1:val1", "key2:val2", "key3:n/a"},
@@ -37,7 +37,7 @@ func TestWithAttributeMap(t *testing.T) {
 
 func TestMetricDimensionsString(t *testing.T) {
 	getKey := func(name string, tags []string, host string) string {
-		dims := metricsDimensions{name: name, tags: tags, host: host}
+		dims := Dimensions{name: name, tags: tags, host: host}
 		return dims.String()
 	}
 	metricName := "metric.name"
@@ -68,7 +68,7 @@ func TestMetricDimensionsStringNoTagsChange(t *testing.T) {
 	originalTags[0] = "key1:val1"
 	originalTags[1] = "key2:val2"
 
-	dims := metricsDimensions{
+	dims := Dimensions{
 		name: "a.metric.name",
 		tags: originalTags,
 	}
@@ -78,7 +78,7 @@ func TestMetricDimensionsStringNoTagsChange(t *testing.T) {
 
 }
 
-var testDims = metricsDimensions{
+var testDims = Dimensions{
 	name: "test.metric",
 	tags: []string{"key:val"},
 	host: "host",

--- a/pkg/otlp/model/translator/metrics_translator.go
+++ b/pkg/otlp/model/translator/metrics_translator.go
@@ -90,7 +90,7 @@ func (t *Translator) isSkippable(name string, v float64) bool {
 func (t *Translator) mapNumberMetrics(
 	ctx context.Context,
 	consumer TimeSeriesConsumer,
-	dims metricsDimensions,
+	dims *Dimensions,
 	dt MetricDataType,
 	slice pdata.NumberDataPointSlice,
 ) {
@@ -110,7 +110,7 @@ func (t *Translator) mapNumberMetrics(
 			continue
 		}
 
-		consumer.ConsumeTimeSeries(ctx, pointDims.name, dt, uint64(p.Timestamp()), val, pointDims.tags, pointDims.host)
+		consumer.ConsumeTimeSeries(ctx, pointDims, dt, uint64(p.Timestamp()), val)
 	}
 }
 
@@ -118,7 +118,7 @@ func (t *Translator) mapNumberMetrics(
 func (t *Translator) mapNumberMonotonicMetrics(
 	ctx context.Context,
 	consumer TimeSeriesConsumer,
-	dims metricsDimensions,
+	dims *Dimensions,
 	slice pdata.NumberDataPointSlice,
 ) {
 	for i := 0; i < slice.Len(); i++ {
@@ -140,7 +140,7 @@ func (t *Translator) mapNumberMonotonicMetrics(
 		}
 
 		if dx, ok := t.prevPts.MonotonicDiff(pointDims, startTs, ts, val); ok {
-			consumer.ConsumeTimeSeries(ctx, pointDims.name, Count, ts, dx, pointDims.tags, pointDims.host)
+			consumer.ConsumeTimeSeries(ctx, pointDims, Count, ts, dx)
 		}
 	}
 }
@@ -161,7 +161,7 @@ func getBounds(p pdata.HistogramDataPoint, idx int) (lowerBound float64, upperBo
 func (t *Translator) getSketchBuckets(
 	ctx context.Context,
 	consumer SketchConsumer,
-	pointDims metricsDimensions,
+	pointDims *Dimensions,
 	p pdata.HistogramDataPoint,
 	delta bool,
 ) {
@@ -199,14 +199,14 @@ func (t *Translator) getSketchBuckets(
 
 	sketch := as.Finish()
 	if sketch != nil {
-		consumer.ConsumeSketch(ctx, pointDims.name, ts, sketch, pointDims.tags, pointDims.host)
+		consumer.ConsumeSketch(ctx, pointDims, ts, sketch)
 	}
 }
 
 func (t *Translator) getLegacyBuckets(
 	ctx context.Context,
 	consumer TimeSeriesConsumer,
-	pointDims metricsDimensions,
+	pointDims *Dimensions,
 	p pdata.HistogramDataPoint,
 	delta bool,
 ) {
@@ -224,9 +224,9 @@ func (t *Translator) getLegacyBuckets(
 
 		count := float64(val)
 		if delta {
-			consumer.ConsumeTimeSeries(ctx, bucketDims.name, Count, ts, count, bucketDims.tags, bucketDims.host)
+			consumer.ConsumeTimeSeries(ctx, bucketDims, Count, ts, count)
 		} else if dx, ok := t.prevPts.Diff(bucketDims, startTs, ts, count); ok {
-			consumer.ConsumeTimeSeries(ctx, bucketDims.name, Count, ts, dx, bucketDims.tags, bucketDims.host)
+			consumer.ConsumeTimeSeries(ctx, bucketDims, Count, ts, dx)
 		}
 	}
 }
@@ -247,7 +247,7 @@ func (t *Translator) getLegacyBuckets(
 func (t *Translator) mapHistogramMetrics(
 	ctx context.Context,
 	consumer Consumer,
-	dims metricsDimensions,
+	dims *Dimensions,
 	slice pdata.HistogramDataPointSlice,
 	delta bool,
 ) {
@@ -261,9 +261,9 @@ func (t *Translator) mapHistogramMetrics(
 			count := float64(p.Count())
 			countDims := pointDims.WithSuffix("count")
 			if delta {
-				consumer.ConsumeTimeSeries(ctx, countDims.name, Count, ts, count, countDims.tags, countDims.host)
+				consumer.ConsumeTimeSeries(ctx, countDims, Count, ts, count)
 			} else if dx, ok := t.prevPts.Diff(countDims, startTs, ts, count); ok {
-				consumer.ConsumeTimeSeries(ctx, countDims.name, Count, ts, dx, countDims.tags, countDims.host)
+				consumer.ConsumeTimeSeries(ctx, countDims, Count, ts, dx)
 			}
 		}
 
@@ -272,9 +272,9 @@ func (t *Translator) mapHistogramMetrics(
 			sumDims := pointDims.WithSuffix("sum")
 			if !t.isSkippable(sumDims.name, p.Sum()) {
 				if delta {
-					consumer.ConsumeTimeSeries(ctx, sumDims.name, Count, ts, sum, sumDims.tags, sumDims.host)
+					consumer.ConsumeTimeSeries(ctx, sumDims, Count, ts, sum)
 				} else if dx, ok := t.prevPts.Diff(sumDims, startTs, ts, sum); ok {
-					consumer.ConsumeTimeSeries(ctx, sumDims.name, Count, ts, dx, sumDims.tags, sumDims.host)
+					consumer.ConsumeTimeSeries(ctx, sumDims, Count, ts, dx)
 				}
 			}
 		}
@@ -319,7 +319,7 @@ func getQuantileTag(quantile float64) string {
 func (t *Translator) mapSummaryMetrics(
 	ctx context.Context,
 	consumer TimeSeriesConsumer,
-	dims metricsDimensions,
+	dims *Dimensions,
 	slice pdata.SummaryDataPointSlice,
 ) {
 
@@ -333,7 +333,7 @@ func (t *Translator) mapSummaryMetrics(
 		{
 			countDims := pointDims.WithSuffix("count")
 			if dx, ok := t.prevPts.Diff(countDims, startTs, ts, float64(p.Count())); ok && !t.isSkippable(countDims.name, dx) {
-				consumer.ConsumeTimeSeries(ctx, countDims.name, Count, ts, dx, countDims.tags, countDims.host)
+				consumer.ConsumeTimeSeries(ctx, countDims, Count, ts, dx)
 			}
 		}
 
@@ -341,7 +341,7 @@ func (t *Translator) mapSummaryMetrics(
 			sumDims := pointDims.WithSuffix("sum")
 			if !t.isSkippable(sumDims.name, p.Sum()) {
 				if dx, ok := t.prevPts.Diff(sumDims, startTs, ts, p.Sum()); ok {
-					consumer.ConsumeTimeSeries(ctx, sumDims.name, Count, ts, dx, sumDims.tags, sumDims.host)
+					consumer.ConsumeTimeSeries(ctx, sumDims, Count, ts, dx)
 				}
 			}
 		}
@@ -357,7 +357,7 @@ func (t *Translator) mapSummaryMetrics(
 				}
 
 				quantileDims := baseQuantileDims.AddTags(getQuantileTag(q.Quantile()))
-				consumer.ConsumeTimeSeries(ctx, quantileDims.name, Gauge, ts, q.Value(), quantileDims.tags, quantileDims.host)
+				consumer.ConsumeTimeSeries(ctx, quantileDims, Gauge, ts, q.Value())
 			}
 		}
 	}
@@ -400,7 +400,7 @@ func (t *Translator) MapMetrics(ctx context.Context, md pdata.Metrics, consumer 
 
 			for k := 0; k < metricsArray.Len(); k++ {
 				md := metricsArray.At(k)
-				baseDims := metricsDimensions{
+				baseDims := &Dimensions{
 					name: md.Name(),
 					tags: additionalTags,
 					host: host,

--- a/pkg/otlp/model/translator/metrics_translator_test.go
+++ b/pkg/otlp/model/translator/metrics_translator_test.go
@@ -136,38 +136,36 @@ type mockTimeSeriesConsumer struct {
 
 func (m *mockTimeSeriesConsumer) ConsumeTimeSeries(
 	_ context.Context,
-	name string,
+	dimensions *Dimensions,
 	typ MetricDataType,
 	ts uint64,
 	val float64,
-	tags []string,
-	host string,
 ) {
 	m.metrics = append(m.metrics,
 		metric{
-			name:      name,
+			name:      dimensions.Name(),
 			typ:       typ,
 			timestamp: ts,
 			value:     val,
-			tags:      tags,
-			host:      host,
+			tags:      dimensions.Tags(),
+			host:      dimensions.Host(),
 		},
 	)
 }
 
-func newDims(name string) metricsDimensions {
-	return metricsDimensions{name: name, tags: []string{}}
+func newDims(name string) *Dimensions {
+	return &Dimensions{name: name, tags: []string{}}
 }
 
-func newGauge(dims metricsDimensions, ts uint64, val float64) metric {
+func newGauge(dims *Dimensions, ts uint64, val float64) metric {
 	return metric{name: dims.name, typ: Gauge, timestamp: ts, value: val, tags: dims.tags}
 }
 
-func newCount(dims metricsDimensions, ts uint64, val float64) metric {
+func newCount(dims *Dimensions, ts uint64, val float64) metric {
 	return metric{name: dims.name, typ: Count, timestamp: ts, value: val, tags: dims.tags}
 }
 
-func newSketch(dims metricsDimensions, ts uint64, s summary.Summary) sketch {
+func newSketch(dims *Dimensions, ts uint64, s summary.Summary) sketch {
 	return sketch{name: dims.name, basic: s, timestamp: ts, tags: dims.tags}
 }
 
@@ -198,7 +196,7 @@ func TestMapIntMetrics(t *testing.T) {
 
 	// With attribute tags
 	consumer = &mockTimeSeriesConsumer{}
-	dims = metricsDimensions{name: "int64.test", tags: []string{"attribute_tag:attribute_value"}}
+	dims = &Dimensions{name: "int64.test", tags: []string{"attribute_tag:attribute_value"}}
 	tr.mapNumberMetrics(ctx, consumer, dims, Gauge, slice)
 	assert.ElementsMatch(t,
 		consumer.metrics,
@@ -233,7 +231,7 @@ func TestMapDoubleMetrics(t *testing.T) {
 
 	// With attribute tags
 	consumer = &mockTimeSeriesConsumer{}
-	dims = metricsDimensions{name: "float64.test", tags: []string{"attribute_tag:attribute_value"}}
+	dims = &Dimensions{name: "float64.test", tags: []string{"attribute_tag:attribute_value"}}
 	tr.mapNumberMetrics(ctx, consumer, dims, Gauge, slice)
 	assert.ElementsMatch(t,
 		consumer.metrics,
@@ -502,24 +500,26 @@ func TestMapDoubleMonotonicOutOfOrder(t *testing.T) {
 	)
 }
 
+var _ SketchConsumer = (*mockFullConsumer)(nil)
+
 type mockFullConsumer struct {
 	mockTimeSeriesConsumer
 	sketches []sketch
 }
 
-func (c *mockFullConsumer) ConsumeSketch(_ context.Context, name string, ts uint64, sk *quantile.Sketch, tags []string, host string) {
+func (c *mockFullConsumer) ConsumeSketch(_ context.Context, dimensions *Dimensions, ts uint64, sk *quantile.Sketch) {
 	c.sketches = append(c.sketches,
 		sketch{
-			name:      name,
+			name:      dimensions.Name(),
 			basic:     sk.Basic,
 			timestamp: ts,
-			tags:      tags,
-			host:      host,
+			tags:      dimensions.Tags(),
+			host:      dimensions.Host(),
 		},
 	)
 }
 
-func dimsWithBucket(dims metricsDimensions, lowerBound string, upperBound string) metricsDimensions {
+func dimsWithBucket(dims *Dimensions, lowerBound string, upperBound string) *Dimensions {
 	dims = dims.WithSuffix("bucket")
 	return dims.AddTags(
 		fmt.Sprintf("lower_bound:%s", lowerBound),
@@ -677,7 +677,7 @@ func TestMapDeltaHistogramMetrics(t *testing.T) {
 			tr.cfg.HistMode = testInstance.histogramMode
 			tr.cfg.SendCountSum = testInstance.sendCountSum
 			consumer := &mockFullConsumer{}
-			dims := metricsDimensions{name: "doubleHist.test", tags: testInstance.tags}
+			dims := &Dimensions{name: "doubleHist.test", tags: testInstance.tags}
 			tr.mapHistogramMetrics(ctx, consumer, dims, slice, delta)
 			assert.ElementsMatch(t, consumer.metrics, testInstance.expectedMetrics)
 			assert.ElementsMatch(t, consumer.sketches, testInstance.expectedSketches)
@@ -795,7 +795,7 @@ func TestLegacyBucketsTags(t *testing.T) {
 	pointOne.SetExplicitBounds([]float64{0})
 	pointOne.SetTimestamp(seconds(0))
 	consumer := &mockTimeSeriesConsumer{}
-	dims := metricsDimensions{name: "test.histogram.one", tags: tags}
+	dims := &Dimensions{name: "test.histogram.one", tags: tags}
 	tr.getLegacyBuckets(ctx, consumer, dims, pointOne, true)
 	seriesOne := consumer.metrics
 
@@ -804,7 +804,7 @@ func TestLegacyBucketsTags(t *testing.T) {
 	pointTwo.SetExplicitBounds([]float64{1})
 	pointTwo.SetTimestamp(seconds(0))
 	consumer = &mockTimeSeriesConsumer{}
-	dims = metricsDimensions{name: "test.histogram.two", tags: tags}
+	dims = &Dimensions{name: "test.histogram.two", tags: tags}
 	tr.getLegacyBuckets(ctx, consumer, dims, pointTwo, true)
 	seriesTwo := consumer.metrics
 
@@ -868,8 +868,8 @@ func TestMapSummaryMetrics(t *testing.T) {
 
 	newTranslator := func(tags []string, quantiles bool) *Translator {
 		c := newTestCache()
-		c.cache.Set((&metricsDimensions{name: "summary.example.count", tags: tags}).String(), numberCounter{0, 0, 1}, gocache.NoExpiration)
-		c.cache.Set((&metricsDimensions{name: "summary.example.sum", tags: tags}).String(), numberCounter{0, 0, 1}, gocache.NoExpiration)
+		c.cache.Set((&Dimensions{name: "summary.example.count", tags: tags}).String(), numberCounter{0, 0, 1}, gocache.NoExpiration)
+		c.cache.Set((&Dimensions{name: "summary.example.sum", tags: tags}).String(), numberCounter{0, 0, 1}, gocache.NoExpiration)
 		options := []Option{WithFallbackHostnameProvider(testProvider("fallbackHostname"))}
 		if quantiles {
 			options = append(options, WithQuantiles())

--- a/pkg/otlp/model/translator/sketches_test.go
+++ b/pkg/otlp/model/translator/sketches_test.go
@@ -35,11 +35,9 @@ type sketchConsumer struct {
 // ConsumeSketch implements the translator.Consumer interface.
 func (c *sketchConsumer) ConsumeSketch(
 	_ context.Context,
-	_ string,
+	_ *Dimensions,
 	_ uint64,
 	sketch *quantile.Sketch,
-	_ []string,
-	_ string,
 ) {
 	c.sk = sketch
 }
@@ -106,7 +104,7 @@ func TestHistogramSketches(t *testing.T) {
 	cfg := quantile.Default()
 	ctx := context.Background()
 	tr := newTranslator(t, zap.NewNop())
-	dims := metricsDimensions{name: "test"}
+	dims := &Dimensions{name: "test"}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			p := fromCDF(test.cdf)
@@ -199,7 +197,7 @@ func TestInfiniteBounds(t *testing.T) {
 
 	ctx := context.Background()
 	tr := newTranslator(t, zap.NewNop())
-	dims := metricsDimensions{name: "test"}
+	dims := &Dimensions{name: "test"}
 	for _, testInstance := range tests {
 		t.Run(testInstance.name, func(t *testing.T) {
 			p := testInstance.getHist()

--- a/pkg/otlp/model/translator/ttlcache.go
+++ b/pkg/otlp/model/translator/ttlcache.go
@@ -39,20 +39,20 @@ func newTTLCache(sweepInterval int64, deltaTTL int64) *ttlCache {
 
 // Diff submits a new value for a given non-monotonic metric and returns the difference with the
 // last submitted value (ordered by timestamp). The diff value is only valid if `ok` is true.
-func (t *ttlCache) Diff(dimensions metricsDimensions, startTs, ts uint64, val float64) (float64, bool) {
+func (t *ttlCache) Diff(dimensions *Dimensions, startTs, ts uint64, val float64) (float64, bool) {
 	return t.putAndGetDiff(dimensions, false, startTs, ts, val)
 }
 
 // MonotonicDiff submits a new value for a given monotonic metric and returns the difference with the
 // last submitted value (ordered by timestamp). The diff value is only valid if `ok` is true.
-func (t *ttlCache) MonotonicDiff(dimensions metricsDimensions, startTs, ts uint64, val float64) (float64, bool) {
+func (t *ttlCache) MonotonicDiff(dimensions *Dimensions, startTs, ts uint64, val float64) (float64, bool) {
 	return t.putAndGetDiff(dimensions, true, startTs, ts, val)
 }
 
 // putAndGetDiff submits a new value for a given metric and returns the difference with the
 // last submitted value (ordered by timestamp). The diff value is only valid if `ok` is true.
 func (t *ttlCache) putAndGetDiff(
-	dimensions metricsDimensions,
+	dimensions *Dimensions,
 	monotonic bool,
 	startTs, ts uint64,
 	val float64,

--- a/pkg/otlp/model/translator/ttlcache_test.go
+++ b/pkg/otlp/model/translator/ttlcache_test.go
@@ -25,7 +25,7 @@ func newTestCache() *ttlCache {
 	return cache
 }
 
-var dims = metricsDimensions{name: "test"}
+var dims = &Dimensions{name: "test"}
 
 func TestMonotonicDiffUnknownStart(t *testing.T) {
 	startTs := uint64(0) // equivalent to start being unset


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

- Export `metricsDimensions` as `Dimensions`.
- Be consistent with usage of pointer vs struct.
- Changes `*Consumer` interfaces to take `Dimensions` instead of separate name/host/tags fields.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

- Preparation for adding `k8sOriginId` as a dimension.
- Future-proof `*Consumer` interfaces to be able to add new dimensions without breaking things.


### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

This doesn't need any specific QA, it only needs testing that the OTLP ingest for metrics works correctly.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
