### PR TITLE
[windows][containers] update cpu limit calculation

### DIFF
--- a/releasenotes/notes/fix-windows-container-cpu-limit-5e1e7489c63bd115.yaml
+++ b/releasenotes/notes/fix-windows-container-cpu-limit-5e1e7489c63bd115.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Fix CPU limit calculation for Windows containers.


### PR DESCRIPTION
### What does this PR do?

Fix CPU Limit calculation for Windows containers.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

This change is for v1; changes for v2 to come in a subsequent PR.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

- Start the agent on a Windows Docker container with `--cpus` set (e.g. ` docker run -d --name dd-agent-cpu-count-2 -e DD_API_KEY=<api_key> -e DD_PROCESS_AGENT_ENABLED=true -v \\.\pipe\docker_engine:\\.\pipe\docker_engine --cpus="1" <image_name>`)
- Try increasing CPU usage with a script such as described [here](https://www.robvit.com/windows_server/generate-cpu-load-with-powershell/)
- Check the CPU values reported on the Live Containers page
- Try running containers with different values for `--cpus` as well as `--cpu-percent` and `--cpu-count`

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
