### PR TITLE
[pkg/forwarder] Improve error messages for http errors in API key validity check

### DIFF
--- a/pkg/forwarder/forwarder_health.go
+++ b/pkg/forwarder/forwarder_health.go
@@ -203,7 +203,12 @@ func (fh *forwarderHealth) hasValidAPIKey() bool {
 		for _, apiKey := range apiKeys {
 			v, err := fh.validateAPIKey(apiKey, domain)
 			if err != nil {
-				log.Debug(err)
+				log.Debugf(
+					"api_key '%s' for domain %s could not be validated: %s",
+					apiKey,
+					domain,
+					err.Error(),
+				)
 				apiError = true
 			} else if v {
 				log.Debugf("api_key '%s' for domain %s is valid", apiKey, domain)


### PR DESCRIPTION
### What does this PR do?

Adds domain/key info to client errors in forwarder health check (API key validation)

### Motivation

When using the `dd_url` option and going through a misconfigured proxy, then
hitting a redirect endpoint may make the agent connect directly to the redirect
target. When this occurs, debugging may be difficult as the target
redirect domain is shown in the error messages instead of the original
`dd_url` domain. By adding this info to the error message, exact
pinpointing of the problem can be made quicker.

### Additional Notes

New errors will have the following format:
```
2022-02-14 16:23:31 CST | CORE | DEBUG | (pkg/forwarder/forwarder_health.go:206 in hasValidAPIKey) | api_key 'asdasfdsfds' for domain https://123.123.123.123:3834 could not be validated: Get "https://123.123.123.123:3834/api/v1/validate?api_key=***************************dsfds": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
```


### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Run the agent in debug log mode with a non-working `dd_url` endpoint. Ensure that the
error message shows both the `dd_url` endpoint and key as well as the client error.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
