### PR TITLE
Ship SNMP Traps database

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -254,6 +254,9 @@ if linux?
   dependency 'datadog-security-agent-policies'
 end
 
+# Include traps db file in snmp.d/traps_db/
+dependency 'snmp-traps'
+
 # External agents
 dependency 'jmxfetch'
 

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -14,6 +14,9 @@ dependency "python3" if with_python_runtime? "3"
 dependency "libarchive" if windows?
 dependency "yaml-cpp" if windows?
 
+# Include traps db file in snmp.d/traps_db/
+dependency 'snmp-traps'
+
 source path: '..'
 relative_path 'src/github.com/DataDog/datadog-agent'
 

--- a/omnibus/config/software/datadog-agent.rb
+++ b/omnibus/config/software/datadog-agent.rb
@@ -14,9 +14,6 @@ dependency "python3" if with_python_runtime? "3"
 dependency "libarchive" if windows?
 dependency "yaml-cpp" if windows?
 
-# Include traps db file in snmp.d/traps_db/
-dependency 'snmp-traps'
-
 source path: '..'
 relative_path 'src/github.com/DataDog/datadog-agent'
 

--- a/omnibus/config/software/snmp-traps.rb
+++ b/omnibus/config/software/snmp-traps.rb
@@ -1,0 +1,18 @@
+name "snmp-traps"
+default_version "0.2.0"
+
+source :url => "https://s3.amazonaws.com/dd-agent-omnibus/snmp_traps_db/dd_traps_db-#{version}.json.gz",
+       :sha256 => "dd308ba8ec1453ed73d60e9b8d4c38050371fdceaab4404448e1084d628d3298",
+       :target_filename => "dd_traps_db.json.gz"
+
+
+build do
+  # The dir for confs
+  if osx?
+    traps_db_dir = "#{install_dir}/etc/conf.d/snmp.d/traps_db"
+  else
+    traps_db_dir = "#{install_dir}/etc/datadog-agent/conf.d/snmp.d/traps_db"
+  end
+  mkdir traps_db_dir
+  copy "dd_traps_db.json.gz", "#{traps_db_dir}/dd_traps_db.json.gz"
+end

--- a/releasenotes/notes/SNMP---include-traps-db-7c44bd129daf7667.yaml
+++ b/releasenotes/notes/SNMP---include-traps-db-7c44bd129daf7667.yaml
@@ -8,4 +8,4 @@
 ---
 other:
   - |
-    Include pre-generated trap db file in the `conf.d/snmp.d/traps_db/` folder.
+    Include pre-generated trap db file in the ``conf.d/snmp.d/traps_db/`` folder.

--- a/releasenotes/notes/SNMP---include-traps-db-7c44bd129daf7667.yaml
+++ b/releasenotes/notes/SNMP---include-traps-db-7c44bd129daf7667.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+other:
+  - |
+    Include pre-generated trap db file in the `conf.d/snmp.d/traps_db/` folder.


### PR DESCRIPTION
Start shipping the `conf.d/snmp.d/traps_db/dd_traps_db.json.gz` file with the agent (as of today `1014KiB`).
This file will be used by https://github.com/DataDog/datadog-agent/pull/10934 when ready