### PR TITLE
[CWS] functional tests cleanup

### DIFF
--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -36,7 +36,7 @@ kitchen_test_security_agent_x64:
   parallel:
     matrix:
       - KITCHEN_PLATFORM: "centos"
-        KITCHEN_OSVERS: "centos-77,rhel-81"
+        KITCHEN_OSVERS: "centos-77,rhel-81,rhel-85"
       - KITCHEN_PLATFORM: "ubuntu"
         KITCHEN_OSVERS: "ubuntu-18-04,ubuntu-18-04-3"
       - KITCHEN_PLATFORM: "ubuntu"

--- a/.gitlab/functional_test/security_agent.yml
+++ b/.gitlab/functional_test/security_agent.yml
@@ -36,7 +36,7 @@ kitchen_test_security_agent_x64:
   parallel:
     matrix:
       - KITCHEN_PLATFORM: "centos"
-        KITCHEN_OSVERS: "centos-77,rhel-81,rhel-85"
+        KITCHEN_OSVERS: "centos-77,rhel-85"
       - KITCHEN_PLATFORM: "ubuntu"
         KITCHEN_OSVERS: "ubuntu-18-04,ubuntu-18-04-3"
       - KITCHEN_PLATFORM: "ubuntu"

--- a/pkg/security/tests/chown32_test.go
+++ b/pkg/security/tests/chown32_test.go
@@ -14,14 +14,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
 
 func TestChown32(t *testing.T) {
-	if isSuseKernel() {
-		t.Skip("SUSE kernel: skipping chown32 tests")
-	}
+	checkKernelCompatibility(t, "SUSE kernel", func(kv *kernel.Version) bool {
+		return kv.IsSuseKernel()
+	})
 
 	ruleDef := &rules.RuleDefinition{
 		ID:         "test_rule",

--- a/pkg/security/tests/chown32_test.go
+++ b/pkg/security/tests/chown32_test.go
@@ -14,21 +14,12 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
-	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
 )
 
 func TestChown32(t *testing.T) {
-	isSuseKernel := func() bool {
-		kv, err := kernel.NewKernelVersion()
-		if err != nil {
-			return false
-		}
-		return kv.IsSuseKernel()
-	}()
-
-	if isSuseKernel {
+	if isSuseKernel() {
 		t.Skip("SUSE kernel: skipping chown32 tests")
 	}
 

--- a/pkg/security/tests/constants_test.go
+++ b/pkg/security/tests/constants_test.go
@@ -18,6 +18,10 @@ import (
 )
 
 func TestFallbackConstants(t *testing.T) {
+	if isSuseKernel() {
+		t.Skip("SUSE kernel: skipping chown32 tests")
+	}
+
 	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, testOpts{})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/security/tests/constants_test.go
+++ b/pkg/security/tests/constants_test.go
@@ -11,6 +11,7 @@ package tests
 import (
 	"testing"
 
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/probe/constantfetch"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/rules"
@@ -18,13 +19,9 @@ import (
 )
 
 func TestFallbackConstants(t *testing.T) {
-	if isSuseKernel() {
-		t.Skip("SUSE kernel: skipping chown32 tests")
-	}
-
-	if isOracleKernel() {
-		t.Skip("SUSE kernel: skipping chown32 tests")
-	}
+	checkKernelCompatibility(t, "SLES and Oracle kernels", func(kv *kernel.Version) bool {
+		return kv.IsSLES12Kernel() || kv.IsSLES15Kernel() || kv.IsOracleUEKKernel()
+	})
 
 	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, testOpts{})
 	if err != nil {

--- a/pkg/security/tests/constants_test.go
+++ b/pkg/security/tests/constants_test.go
@@ -22,6 +22,10 @@ func TestFallbackConstants(t *testing.T) {
 		t.Skip("SUSE kernel: skipping chown32 tests")
 	}
 
+	if isOracleKernel() {
+		t.Skip("SUSE kernel: skipping chown32 tests")
+	}
+
 	test, err := newTestModule(t, nil, []*rules.RuleDefinition{}, testOpts{})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -1212,3 +1212,11 @@ func isSuseKernel() bool {
 	}
 	return kv.IsSuseKernel()
 }
+
+func isOracleKernel() bool {
+	kv, err := kernel.NewKernelVersion()
+	if err != nil {
+		return false
+	}
+	return kv.IsOracleUEKKernel()
+}

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -37,6 +37,7 @@ import (
 	sysconfig "github.com/DataDog/datadog-agent/cmd/system-probe/config"
 	"github.com/DataDog/datadog-agent/pkg/process/util"
 	"github.com/DataDog/datadog-agent/pkg/security/config"
+	"github.com/DataDog/datadog-agent/pkg/security/ebpf/kernel"
 	"github.com/DataDog/datadog-agent/pkg/security/module"
 	sprobe "github.com/DataDog/datadog-agent/pkg/security/probe"
 	"github.com/DataDog/datadog-agent/pkg/security/secl/compiler/eval"
@@ -1202,4 +1203,12 @@ func randStringRunes(n int) string {
 		b[i] = letterRunes[rand.Intn(len(letterRunes))]
 	}
 	return string(b)
+}
+
+func isSuseKernel() bool {
+	kv, err := kernel.NewKernelVersion()
+	if err != nil {
+		return false
+	}
+	return kv.IsSuseKernel()
 }

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -1205,18 +1205,14 @@ func randStringRunes(n int) string {
 	return string(b)
 }
 
-func isSuseKernel() bool {
+func checkKernelCompatibility(t *testing.T, why string, skipCheck func(kv *kernel.Version) bool) {
 	kv, err := kernel.NewKernelVersion()
 	if err != nil {
-		return false
+		t.Errorf("failed to get kernel version: %w", err)
+		return
 	}
-	return kv.IsSuseKernel()
-}
 
-func isOracleKernel() bool {
-	kv, err := kernel.NewKernelVersion()
-	if err != nil {
-		return false
+	if skipCheck(kv) {
+		t.Skipf("kernel version not supported: %s", why)
 	}
-	return kv.IsOracleUEKKernel()
 }

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -1205,6 +1205,7 @@ func randStringRunes(n int) string {
 	return string(b)
 }
 
+//nolint:deadcode,unused
 func checkKernelCompatibility(t *testing.T, why string, skipCheck func(kv *kernel.Version) bool) {
 	kv, err := kernel.NewKernelVersion()
 	if err != nil {

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -69,7 +69,7 @@
                 "ubuntu-18-04": "ami-02ed82f3a38303e6f",
                 "ubuntu-20-04": "ami-0b75998a97c952252",
                 "ubuntu-20-04-2": "ami-0a82127206c2824a1",
-                "ubuntu-21-04": "ami-074fb75106523f6ff"
+                "ubuntu-21-04": "ami-044f0ceee8e885e87"
             }
         },
         "vagrant": {

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -61,7 +61,7 @@
                 "ubuntu-18-04-3": "urn,Canonical:UbuntuServer:18.04-LTS:18.04.201912180",
                 "ubuntu-20-04": "urn,Canonical:0001-com-ubuntu-server-focal:20_04-lts:20.04.202004230",
                 "ubuntu-20-04-2": "urn,Canonical:0001-com-ubuntu-server-focal:20_04-lts:20.04.202107200",
-                "ubuntu-21-10": "urn,Canonical:0001-com-ubuntu-server-impish-daily:21_10-daily:21.10.202110040"
+                "ubuntu-21-10": "urn,Canonical:0001-com-ubuntu-server-impish-daily:21_10-daily:21.10.202202040"
             }
         },
         "ec2": {

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -5,7 +5,8 @@
                 "centos-610": "urn,OpenLogic:CentOS:6.10:6.10.2020042900",
                 "centos-76": "urn,OpenLogic:CentOS:7.6:7.6.201909120",
                 "centos-77": "urn,OpenLogic:CentOS:7.7:7.7.201912090",
-                "rhel-81": "urn,RedHat:RHEL:8.1:8.1.2021040910"
+                "rhel-81": "urn,RedHat:RHEL:8.1:8.1.2021040910",
+                "rhel-85": "urn,RedHat:RHEL:8_5:8.5.2021121501"
             }
         },
         "ec2": {

--- a/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
@@ -2,9 +2,6 @@ require 'spec_helper'
 
 print `cat /etc/os-release`
 print `uname -a`
-print `cat /etc/yum.repos.d/* || true`
-print `ls /etc/pki/rpm-gpg/ || true`
-print `rpm -qa || true`
 
 describe 'successfully run functional test' do
   it 'displays PASS and returns 0' do

--- a/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
+++ b/test/kitchen/test/integration/security-agent-test/rspec/security-agent-test_spec.rb
@@ -2,6 +2,9 @@ require 'spec_helper'
 
 print `cat /etc/os-release`
 print `uname -a`
+print `cat /etc/yum.repos.d/* || true`
+print `ls /etc/pki/rpm-gpg/ || true`
+print `rpm -qa || true`
 
 describe 'successfully run functional test' do
   it 'displays PASS and returns 0' do


### PR DESCRIPTION
### What does this PR do?

This PR:
- updates the version used of RHEL8, Ubuntu 21.04 and Ubuntu 21.10 to use versions where package managers are still working and kernel headers available
- skip `TestFallbackConstants` on SLES (because of registration issues) and Oracle (because not yet supported by Nikos)

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
