### PR TITLE
[CWS] mmap & mprotect taxonomy update

### DIFF
--- a/docs/cloud-workload-security/agent_expressions.md
+++ b/docs/cloud-workload-security/agent_expressions.md
@@ -39,10 +39,10 @@ Triggers are events that correspond to types of activity seen by the system. The
 | `exec` | Process | A process was executed or forked | 7.27 |
 | `link` | File | Create a new name/alias for a file | 7.27 |
 | `mkdir` | File | A directory was created | 7.27 |
-| `mmap` | Kernel | [Experimental] A mmap command was executed | 7.34 |
-| `mprotect` | Kernel | [Experimental] A mprotect command was executed | 7.34 |
+| `mmap` | Kernel | A mmap command was executed | 7.35 |
+| `mprotect` | Kernel | A mprotect command was executed | 7.35 |
 | `open` | File | A file was opened | 7.27 |
-| `ptrace` | Kernel | [Experimental] A ptrace command was executed | 7.34 |
+| `ptrace` | Kernel | A ptrace command was executed | 7.35 |
 | `removexattr` | File | Remove extended attributes | 7.27 |
 | `rename` | File | A file/directory was renamed | 7.27 |
 | `rmdir` | File | A directory was removed | 7.27 |
@@ -418,8 +418,6 @@ A directory was created
 
 ### Event `mmap`
 
-_This event type is experimental and may change in the future._
-
 A mmap command was executed
 
 | Property | Type | Definition |
@@ -438,21 +436,19 @@ A mmap command was executed
 | `mmap.file.rights` | int | Mode/rights of the file |
 | `mmap.file.uid` | int | UID of the file's owner |
 | `mmap.file.user` | string | User of the file's owner |
-| `mmap.flags` | int |  |
-| `mmap.protection` | int |  |
+| `mmap.flags` | int | memory segment flags |
+| `mmap.protection` | int | memory segment protection |
 | `mmap.retval` | int | Return value of the syscall |
 
 ### Event `mprotect`
-
-_This event type is experimental and may change in the future._
 
 A mprotect command was executed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `mprotect.req_protection` | int |  |
+| `mprotect.req_protection` | int | new memory segment protection |
 | `mprotect.retval` | int | Return value of the syscall |
-| `mprotect.vm_protection` | int |  |
+| `mprotect.vm_protection` | int | initial memory segment protection |
 
 ### Event `open`
 
@@ -480,13 +476,11 @@ A file was opened
 
 ### Event `ptrace`
 
-_This event type is experimental and may change in the future._
-
 A ptrace command was executed
 
 | Property | Type | Definition |
 | -------- | ---- | ---------- |
-| `ptrace.request` | int |  |
+| `ptrace.request` | int | ptrace request |
 | `ptrace.retval` | int | Return value of the syscall |
 | `ptrace.tracee.ancestors.args` | string | Arguments of the process (as a string) |
 | `ptrace.tracee.ancestors.args_flags` | string | Arguments of the process (as an array) |

--- a/docs/cloud-workload-security/backend.md
+++ b/docs/cloud-workload-security/backend.md
@@ -553,10 +553,6 @@ CWS logs have the following JSON schema:
         "flags": {
             "type": "string",
             "description": "memory segment flags"
-        },
-        "file": {
-            "$ref": "#/definitions/File",
-            "description": "mmaped file"
         }
     },
     "additionalProperties": false,
@@ -572,11 +568,7 @@ CWS logs have the following JSON schema:
 | `length` | memory segment length |
 | `protection` | memory segment protection |
 | `flags` | memory segment flags |
-| `file` | mmaped file |
 
-| References |
-| ---------- |
-| [File](#file) |
 
 ## `MProtectEvent`
 
@@ -587,7 +579,7 @@ CWS logs have the following JSON schema:
         "vm_start",
         "vm_end",
         "vm_protection",
-        "new_protection"
+        "req_protection"
     ],
     "properties": {
         "vm_start": {
@@ -600,9 +592,9 @@ CWS logs have the following JSON schema:
         },
         "vm_protection": {
             "type": "string",
-            "description": "memory segment protection"
+            "description": "initial memory segment protection"
         },
-        "new_protection": {
+        "req_protection": {
             "type": "string",
             "description": "new memory segment protection"
         }
@@ -617,8 +609,8 @@ CWS logs have the following JSON schema:
 | ----- | ----------- |
 | `vm_start` | memory segment start address |
 | `vm_end` | memory segment end address |
-| `vm_protection` | memory segment protection |
-| `new_protection` | new memory segment protection |
+| `vm_protection` | initial memory segment protection |
+| `req_protection` | new memory segment protection |
 
 
 ## `PTraceEvent`

--- a/docs/cloud-workload-security/backend.schema.json
+++ b/docs/cloud-workload-security/backend.schema.json
@@ -378,10 +378,6 @@
         "flags": {
           "type": "string",
           "description": "memory segment flags"
-        },
-        "file": {
-          "$ref": "#/definitions/File",
-          "description": "mmaped file"
         }
       },
       "additionalProperties": false,
@@ -392,7 +388,7 @@
         "vm_start",
         "vm_end",
         "vm_protection",
-        "new_protection"
+        "req_protection"
       ],
       "properties": {
         "vm_start": {
@@ -405,9 +401,9 @@
         },
         "vm_protection": {
           "type": "string",
-          "description": "memory segment protection"
+          "description": "initial memory segment protection"
         },
-        "new_protection": {
+        "req_protection": {
           "type": "string",
           "description": "new memory segment protection"
         }

--- a/docs/cloud-workload-security/secl.json
+++ b/docs/cloud-workload-security/secl.json
@@ -1191,8 +1191,8 @@
       "name": "mmap",
       "definition": "A mmap command was executed",
       "type": "Kernel",
-      "from_agent_version": "7.34",
-      "experimental": true,
+      "from_agent_version": "7.35",
+      "experimental": false,
       "properties": [
         {
           "name": "mmap.file.change_time",
@@ -1267,12 +1267,12 @@
         {
           "name": "mmap.flags",
           "type": "int",
-          "definition": ""
+          "definition": "memory segment flags"
         },
         {
           "name": "mmap.protection",
           "type": "int",
-          "definition": ""
+          "definition": "memory segment protection"
         },
         {
           "name": "mmap.retval",
@@ -1285,13 +1285,13 @@
       "name": "mprotect",
       "definition": "A mprotect command was executed",
       "type": "Kernel",
-      "from_agent_version": "7.34",
-      "experimental": true,
+      "from_agent_version": "7.35",
+      "experimental": false,
       "properties": [
         {
           "name": "mprotect.req_protection",
           "type": "int",
-          "definition": ""
+          "definition": "new memory segment protection"
         },
         {
           "name": "mprotect.retval",
@@ -1301,7 +1301,7 @@
         {
           "name": "mprotect.vm_protection",
           "type": "int",
-          "definition": ""
+          "definition": "initial memory segment protection"
         }
       ]
     },
@@ -1403,13 +1403,13 @@
       "name": "ptrace",
       "definition": "A ptrace command was executed",
       "type": "Kernel",
-      "from_agent_version": "7.34",
-      "experimental": true,
+      "from_agent_version": "7.35",
+      "experimental": false,
       "properties": [
         {
           "name": "ptrace.request",
           "type": "int",
-          "definition": ""
+          "definition": "ptrace request"
         },
         {
           "name": "ptrace.retval",

--- a/pkg/security/probe/serializers_easyjson.go
+++ b/pkg/security/probe/serializers_easyjson.go
@@ -2498,7 +2498,7 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe14(in *jl
 			out.VMEnd = string(in.String())
 		case "vm_protection":
 			out.VMProtection = string(in.String())
-		case "new_protection":
+		case "req_protection":
 			out.ReqProtection = string(in.String())
 		default:
 			in.SkipRecursive()
@@ -2530,7 +2530,7 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe14(out *j
 		out.String(string(in.VMProtection))
 	}
 	{
-		const prefix string = ",\"new_protection\":"
+		const prefix string = ",\"req_protection\":"
 		out.RawString(prefix)
 		out.String(string(in.ReqProtection))
 	}
@@ -2565,16 +2565,6 @@ func easyjsonA970e379DecodeGithubComDataDogDatadogAgentPkgSecurityProbe13(in *jl
 			out.Protection = string(in.String())
 		case "flags":
 			out.Flags = string(in.String())
-		case "file":
-			if in.IsNull() {
-				in.Skip()
-				out.File = nil
-			} else {
-				if out.File == nil {
-					out.File = new(FileSerializer)
-				}
-				(*out.File).UnmarshalEasyJSON(in)
-			}
 		default:
 			in.SkipRecursive()
 		}
@@ -2613,11 +2603,6 @@ func easyjsonA970e379EncodeGithubComDataDogDatadogAgentPkgSecurityProbe13(out *j
 		const prefix string = ",\"flags\":"
 		out.RawString(prefix)
 		out.String(string(in.Flags))
-	}
-	if in.File != nil {
-		const prefix string = ",\"file\":"
-		out.RawString(prefix)
-		(*in.File).MarshalEasyJSON(out)
 	}
 	out.RawByte('}')
 }

--- a/pkg/security/secl/model/model.go
+++ b/pkg/security/secl/model/model.go
@@ -144,9 +144,9 @@ type Event struct {
 
 	SELinux  SELinuxEvent  `field:"selinux" event:"selinux"`   // [7.30] [Kernel] An SELinux operation was run
 	BPF      BPFEvent      `field:"bpf" event:"bpf"`           // [7.33] [Kernel] A BPF command was executed
-	PTrace   PTraceEvent   `field:"ptrace" event:"ptrace"`     // [7.34] [Kernel] [Experimental] A ptrace command was executed
-	MMap     MMapEvent     `field:"mmap" event:"mmap"`         // [7.34] [Kernel] [Experimental] A mmap command was executed
-	MProtect MProtectEvent `field:"mprotect" event:"mprotect"` // [7.34] [Kernel] [Experimental] A mprotect command was executed
+	PTrace   PTraceEvent   `field:"ptrace" event:"ptrace"`     // [7.35] [Kernel] A ptrace command was executed
+	MMap     MMapEvent     `field:"mmap" event:"mmap"`         // [7.35] [Kernel] A mmap command was executed
+	MProtect MProtectEvent `field:"mprotect" event:"mprotect"` // [7.35] [Kernel] A mprotect command was executed
 
 	Mount            MountEvent            `field:"-"`
 	Umount           UmountEvent           `field:"-"`
@@ -610,10 +610,10 @@ type BPFProgram struct {
 type PTraceEvent struct {
 	SyscallEvent
 
-	Request                 uint32             `field:"request"`
+	Request                 uint32             `field:"request"` //  ptrace request
 	PID                     uint32             `field:"-"`
 	Address                 uint64             `field:"-"`
-	Tracee                  ProcessContext     `field:"tracee"`
+	Tracee                  ProcessContext     `field:"tracee"` // process context of the tracee
 	TraceeProcessCacheEntry *ProcessCacheEntry `field:"-"`
 }
 
@@ -625,8 +625,8 @@ type MMapEvent struct {
 	Addr       uint64    `field:"-"`
 	Offset     uint64    `field:"-"`
 	Len        uint32    `field:"-"`
-	Protection int       `field:"protection"`
-	Flags      int       `field:"flags"`
+	Protection int       `field:"protection"` // memory segment protection
+	Flags      int       `field:"flags"`      // memory segment flags
 }
 
 // MProtectEvent represents a mprotect event
@@ -635,6 +635,6 @@ type MProtectEvent struct {
 
 	VMStart       uint64 `field:"-"`
 	VMEnd         uint64 `field:"-"`
-	VMProtection  int    `field:"vm_protection"`
-	ReqProtection int    `field:"req_protection"`
+	VMProtection  int    `field:"vm_protection"`  // initial memory segment protection
+	ReqProtection int    `field:"req_protection"` // new memory segment protection
 }

--- a/pkg/security/tests/schemas/mprotect.schema.json
+++ b/pkg/security/tests/schemas/mprotect.schema.json
@@ -25,7 +25,7 @@
                         "vm_start",
                         "vm_end",
                         "vm_protection",
-                        "new_protection"
+                        "req_protection"
                     ],
                     "properties": {
                         "vm_start": {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Changes `mprotect.new_protection` to `mprotect.req_protection` and move the `file` section to the top level for `mmap`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Unify the taxonomy to make easier to use.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
