### PR TITLE
[corechecks] Add Helm cluster check

### DIFF
--- a/cmd/agent/app/run.go
+++ b/cmd/agent/app/run.go
@@ -55,6 +55,7 @@ import (
 	ddruntime "github.com/DataDog/datadog-agent/pkg/runtime"
 
 	// register core checks
+	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/helm"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/kubernetesapiserver"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator"

--- a/cmd/cluster-agent/main.go
+++ b/cmd/cluster-agent/main.go
@@ -16,6 +16,7 @@ import (
 	_ "expvar"         // Blank import used because this isn't directly used in this file
 	_ "net/http/pprof" // Blank import used because this isn't directly used in this file
 
+	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/helm"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/ksm"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/kubernetesapiserver"
 	_ "github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster/orchestrator"

--- a/pkg/collector/corechecks/cluster/helm/helm.go
+++ b/pkg/collector/corechecks/cluster/helm/helm.go
@@ -1,0 +1,148 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package helm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
+	"github.com/DataDog/datadog-agent/pkg/collector/check"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/collector/corechecks/cluster"
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+const (
+	checkName               = "helm"
+	maximumWaitForAPIServer = 10 * time.Second
+	informerSyncTimeout     = 60 * time.Second
+)
+
+func init() {
+	core.RegisterCheck(checkName, factory)
+}
+
+// HelmCheck collects information about the Helm releases deployed in the
+// cluster. The check only works for Helm installations configured to use
+// Kubernetes secrets as the storage. K8s secrets are the default in Helm v3.
+// Helm v2 used config maps by default. Ref:
+// https://helm.sh/docs/faq/changes_since_helm2/#secrets-as-the-default-storage-driver
+type HelmCheck struct {
+	core.CheckBase
+	secretLister      v1.SecretLister
+	runLeaderElection bool
+}
+
+var helmSecretsSelector = labels.Set{"owner": "helm"}.AsSelector()
+
+func factory() check.Check {
+	return &HelmCheck{
+		CheckBase:         core.NewCheckBase(checkName),
+		runLeaderElection: !config.IsCLCRunner(),
+	}
+}
+
+// Configure configures the Helm check
+func (hc *HelmCheck) Configure(config, initConfig integration.Data, source string) error {
+	apiCtx, apiCancel := context.WithTimeout(context.Background(), maximumWaitForAPIServer)
+	defer apiCancel()
+
+	apiClient, err := apiserver.WaitForAPIClient(apiCtx)
+	if err != nil {
+		return err
+	}
+
+	stopCh := make(chan struct{})
+	apiClient.InformerFactory.Start(stopCh)
+
+	informer := apiClient.InformerFactory.Core().V1().Secrets()
+	hc.secretLister = informer.Lister()
+	go informer.Informer().Run(stopCh)
+
+	return apiserver.SyncInformers(
+		map[apiserver.InformerName]cache.SharedInformer{"helm": informer.Informer()},
+		informerSyncTimeout,
+	)
+}
+
+// Run executes the check
+func (hc *HelmCheck) Run() error {
+	sender, err := aggregator.GetSender(hc.ID())
+	if err != nil {
+		return err
+	}
+	defer sender.Commit()
+
+	if hc.runLeaderElection {
+		isCurrentLeader, errLeader := isLeader()
+		if errLeader != nil {
+			return errLeader
+		}
+
+		if !isCurrentLeader {
+			log.Debugf("Not leader. Skipping the Helm check")
+			return nil
+		}
+	}
+
+	secrets, err := hc.secretLister.List(helmSecretsSelector)
+	if err != nil {
+		return fmt.Errorf("error while listing secrets: %s", err)
+	}
+
+	for _, secret := range secrets {
+		deployedRelease, err := decodeRelease(string(secret.Data["release"]))
+		if err != nil {
+			return fmt.Errorf("error while decoding Helm release: %s", err)
+		}
+
+		sender.Gauge("helm.release", 1, "", helmTags(deployedRelease))
+	}
+
+	return nil
+}
+
+func helmTags(release *release) []string {
+	return []string{
+		fmt.Sprintf("helm_release:%s", release.Name),
+		fmt.Sprintf("helm_chart_name:%s", release.Chart.Metadata.Name),
+		fmt.Sprintf("helm_namespace:%s", release.Namespace),
+		fmt.Sprintf("helm_revision:%d", release.Version),
+		fmt.Sprintf("helm_status:%s", release.Info.Status),
+		fmt.Sprintf("helm_chart_version:%s", release.Chart.Metadata.Version),
+		fmt.Sprintf("helm_app_version:%s", release.Chart.Metadata.AppVersion),
+	}
+}
+
+func isLeader() (bool, error) {
+	if !config.Datadog.GetBool("leader_election") {
+		return false, errors.New("leader election not enabled. The check will not run")
+	}
+
+	_, errLeader := cluster.RunLeaderElection()
+	if errLeader != nil {
+		if errLeader == apiserver.ErrNotLeader {
+			return false, nil
+		}
+
+		return false, errLeader
+	}
+
+	return true, nil
+}

--- a/pkg/collector/corechecks/cluster/helm/helm.go
+++ b/pkg/collector/corechecks/cluster/helm/helm.go
@@ -68,6 +68,18 @@ func factory() check.Check {
 
 // Configure configures the Helm check
 func (hc *HelmCheck) Configure(config, initConfig integration.Data, source string) error {
+	hc.BuildID(config, initConfig)
+
+	err := hc.CommonConfigure(config, source)
+	if err != nil {
+		return err
+	}
+
+	err = hc.CommonConfigure(initConfig, source)
+	if err != nil {
+		return err
+	}
+
 	apiCtx, apiCancel := context.WithTimeout(context.Background(), maximumWaitForAPIServer)
 	defer apiCancel()
 

--- a/pkg/collector/corechecks/cluster/helm/helm_test.go
+++ b/pkg/collector/corechecks/cluster/helm/helm_test.go
@@ -1,0 +1,166 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package helm
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
+	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/tools/cache"
+
+	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
+	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/apiserver"
+)
+
+func TestRun(t *testing.T) {
+	releases := []release{
+		{
+			Name: "my_datadog",
+			Info: &info{
+				Status: "deployed",
+			},
+			Chart: &chart{
+				Metadata: &metadata{
+					Name:       "datadog",
+					Version:    "2.30.5",
+					AppVersion: "7",
+				},
+			},
+			Version:   1,
+			Namespace: "default",
+		},
+		{
+			Name: "my_app",
+			Info: &info{
+				Status: "deployed",
+			},
+			Chart: &chart{
+				Metadata: &metadata{
+					Name:       "some_app",
+					Version:    "1.1.0",
+					AppVersion: "1",
+				},
+			},
+			Version:   2,
+			Namespace: "app",
+		},
+	}
+
+	var secrets []runtime.Object
+	for _, rel := range releases {
+		secret, err := secretForRelease(&rel)
+		assert.NoError(t, err)
+		secrets = append(secrets, secret)
+	}
+
+	// Add a secret not managed by Helm to verify that it doesn't cause issues.
+	secrets = append(secrets, &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:   "some_secret",
+			Labels: map[string]string{"owner": "not-helm"},
+		},
+	})
+
+	// Set up mocked k8s client and informer
+	k8sClient := fake.NewSimpleClientset(secrets...)
+	sharedK8sInformerFactory := informers.NewSharedInformerFactory(k8sClient, time.Minute)
+	secretsInformer := sharedK8sInformerFactory.Core().V1().Secrets().Informer()
+	go secretsInformer.Run(make(chan struct{}))
+	err := apiserver.SyncInformers(
+		map[apiserver.InformerName]cache.SharedInformer{"helm": secretsInformer},
+		10*time.Second,
+	)
+	assert.NoError(t, err)
+
+	check := &HelmCheck{
+		CheckBase:         core.NewCheckBase(checkName),
+		runLeaderElection: false,
+		secretLister:      sharedK8sInformerFactory.Core().V1().Secrets().Lister(),
+	}
+
+	mockedSender := mocksender.NewMockSender(checkName)
+	mockedSender.SetupAcceptAll()
+
+	err = check.Run()
+	assert.NoError(t, err)
+
+	mockedSender.AssertMetric(t, "Gauge", "helm.release", 1, "", []string{
+		"helm_release:my_datadog",
+		"helm_chart_name:datadog",
+		"helm_namespace:default",
+		"helm_revision:1",
+		"helm_status:deployed",
+		"helm_chart_version:2.30.5",
+		"helm_app_version:7",
+	})
+
+	mockedSender.AssertMetric(t, "Gauge", "helm.release", 1, "", []string{
+		"helm_release:my_app",
+		"helm_chart_name:some_app",
+		"helm_namespace:app",
+		"helm_revision:2",
+		"helm_status:deployed",
+		"helm_chart_version:1.1.0",
+		"helm_app_version:1",
+	})
+}
+
+// secretForRelease returns a Kubernetes secret that contains the info of the
+// given Helm release.
+func secretForRelease(rls *release) (*v1.Secret, error) {
+	encodedRel, err := encodeRelease(rls)
+	if err != nil {
+		return nil, err
+	}
+
+	return &v1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			// The name is not important for this test. We only need to make
+			// sure that there are no collisions.
+			Name:   fmt.Sprintf("%s.%d", rls.Name, rls.Version),
+			Labels: map[string]string{"owner": "helm"},
+		},
+		Data: map[string][]byte{"release": []byte(encodedRel)},
+	}, nil
+}
+
+// Note: the encodeRelease function has been copied from the Helm library.
+// It's private, so we can't reuse it.
+// Ref: https://github.com/helm/helm/blob/v3.8.0/pkg/storage/driver/util.go#L35
+
+// encodeRelease encodes a release returning a base64 encoded
+// gzipped string representation, or error.
+func encodeRelease(rls *release) (string, error) {
+	b, err := json.Marshal(rls)
+	if err != nil {
+		return "", err
+	}
+	var buf bytes.Buffer
+	w, err := gzip.NewWriterLevel(&buf, gzip.BestCompression)
+	if err != nil {
+		return "", err
+	}
+	if _, err = w.Write(b); err != nil {
+		return "", err
+	}
+	w.Close()
+
+	return b64.EncodeToString(buf.Bytes()), nil
+}

--- a/pkg/collector/corechecks/cluster/helm/release.go
+++ b/pkg/collector/corechecks/cluster/helm/release.go
@@ -1,0 +1,89 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package helm
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"encoding/json"
+	"io/ioutil"
+)
+
+// The "release" struct and the related ones, are a simplified version of the
+// ones found in the Helm lib. Ref:
+// https://github.com/helm/helm/blob/v3.8.0/pkg/release/release.go#L22
+//
+// Defining the structs here allows us to avoid importing Helm as a dependency.
+// If in the future we need to support other storage backends or more advanced
+// functionality, we'll need to rethink if the trade-off of not importing the
+// Helm lib is still worth it.
+
+type release struct {
+	Name      string `json:"name,omitempty"`
+	Info      *info  `json:"info,omitempty"`
+	Chart     *chart `json:"chart,omitempty"`
+	Version   int    `json:"version,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
+type info struct {
+	Status string `json:"status,omitempty"`
+}
+
+type chart struct {
+	Metadata *metadata `json:"metadata"`
+}
+
+type metadata struct {
+	Name       string `json:"name,omitempty"`
+	Version    string `json:"version,omitempty"`
+	AppVersion string `json:"appVersion,omitempty"`
+}
+
+// Note: the decodeRelease function has been copied from the helm library.
+// It's private, so we can't reuse it.
+// Ref: https://github.com/helm/helm/blob/v3.8.0/pkg/storage/driver/util.go#L56
+
+var b64 = base64.StdEncoding
+var magicGzip = []byte{0x1f, 0x8b, 0x08}
+
+// decodeRelease decodes the bytes of data into a release
+// type. Data must contain a base64 encoded gzipped string of a
+// valid release, otherwise an error is returned.
+func decodeRelease(data string) (*release, error) {
+	// base64 decode string
+	b, err := b64.DecodeString(data)
+	if err != nil {
+		return nil, err
+	}
+
+	// For backwards compatibility with releases that were stored before
+	// compression was introduced we skip decompression if the
+	// gzip magic header is not found
+	if bytes.Equal(b[0:3], magicGzip) {
+		r, err := gzip.NewReader(bytes.NewReader(b))
+		if err != nil {
+			return nil, err
+		}
+		defer r.Close()
+		b2, err := ioutil.ReadAll(r)
+		if err != nil {
+			return nil, err
+		}
+		b = b2
+	}
+
+	var rls release
+	// unmarshal release object bytes
+	if err := json.Unmarshal(b, &rls); err != nil {
+		return nil, err
+	}
+	return &rls, nil
+}

--- a/pkg/collector/corechecks/cluster/helm/stub.go
+++ b/pkg/collector/corechecks/cluster/helm/stub.go
@@ -1,0 +1,6 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package helm

--- a/releasenotes/notes/helm-cluster-check-0cff16a55a0fba87.yaml
+++ b/releasenotes/notes/helm-cluster-check-0cff16a55a0fba87.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+features:
+  - |
+    Added new "Helm" cluster check that collects information about the Helm releases deployed in the cluster.


### PR DESCRIPTION
### What does this PR do?

This PR adds a new cluster check that collects information about the Helm releases deployed in the cluster.

For each Helm release deployed, the check reports the `helm.release` gauge set to 1 with the following tags:
- helm_release
- helm_chart_name
- helm_namespace
- helm_revision
- helm_status
- helm_chart_version
- helm_app_version
- helm_storage

### Additional Notes

- Not in this PR, but may be implemented in the future: add events to the check (helm release deployed, deleted, etc.). Also, add extra tags to the metrics from Pods managed by Helm.
- Helm supports multiple storage backends. The default in v3 is Kubernetes secrets, in v2 it is configmaps. Both are supported by this check. We might add support for SQL in the future.
- This PR needs changes in our Helm chart and the Operator. The reason is that this check needs permissions to read Kubernetes secrets and configmaps. At the moment, in order to use this check, the user needs to set those permissions manually.
- The check is not enabled by default.

### Describe how to test/QA your changes

- Deploy the agent in Kubernetes. The check is not enabled by default. When deploying with the Helm chart, it can be enabled with the `datadog.helmCheck.enabled` option.
- Deploy some Helm chart in your cluster. The datadog one also counts if that's what you used.
- For each Helm release deployed in your cluster, check that the metric `helm.release` is reported and that it's tagged with all the tags listed above.

The check should run properly on the DCA and the cluster check runners (this can be controlled with the `clusterChecksRunner.enabled` option of the Helm chart). When configured to run on the DCA, try 2 replicas and make sure that the check only runs in the leader.

The above needs to be tested both when Helm uses secrets to store releases (default in Helm v3) and when it uses configmaps (default in v2). To select the storage you can use the `HELM_DRIVER` env. For example, `HELM_DRIVER=configmap helm install ...`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
