### PR TITLE
[CWS] improve kernel headers download error feedback

### DIFF
--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -158,7 +158,7 @@ func validateHeaderDirs(hv Version, dirs []string, checkForCriticalHeaders bool)
 
 	if checkForCriticalHeaders && len(valid) != 0 {
 		if err := containsCriticalHeaders(valid); err != nil {
-			log.Debugf("error validating %s: missing critical headers: %w", valid, err)
+			log.Debugf("error validating %s: missing critical headers: %v", valid, err)
 			return nil, err
 		}
 	}

--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -148,7 +148,7 @@ func validateHeaderDirs(hv Version, dirs []string, checkForCriticalHeaders bool)
 			continue
 		}
 
-		if dirv != hv {
+		if dirv != hv && dirv.WithZeroPatch() != hv {
 			log.Debugf("error validating %s: header version %s does not match host version %s", d, dirv, hv)
 			continue
 		}

--- a/pkg/util/kernel/version.go
+++ b/pkg/util/kernel/version.go
@@ -44,6 +44,10 @@ func (v Version) Patch() uint8 {
 	return (uint8)(v & 0xff)
 }
 
+func (v Version) WithZeroPatch() Version {
+	return VersionCode(v.Major(), v.Minor(), 0)
+}
+
 // HostVersion returns the running kernel version of the host
 func HostVersion() (Version, error) {
 	if hostVersion != 0 {

--- a/pkg/util/kernel/version.go
+++ b/pkg/util/kernel/version.go
@@ -44,6 +44,8 @@ func (v Version) Patch() uint8 {
 	return (uint8)(v & 0xff)
 }
 
+// WithZeroPatch returns the same kernel version,
+// but with the patch version set to 0
 func (v Version) WithZeroPatch() Version {
 	return VersionCode(v.Major(), v.Minor(), 0)
 }


### PR DESCRIPTION
### What does this PR do?

This PR:
- improves the error reporting from the kernel headers find module
- add kernel header comparison fallback to "with patch=0 version", this is useful because debian is starting to distribute kernels with headers versioned with the full version (5.16.8 for example) when it only provided versions like 5.16.0 before... 

I'm obviously open to find a better way of checking the downloaded kernel version. Maybe we could simply skip the check if we look at downloaded headers, since they should be downloaded based on the kernel version.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
