### PR TITLE
SetKnown snmp_traps_config.users

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -628,6 +628,7 @@ func InitConfig(config Config) {
 	config.BindEnv("snmp_traps_config.namespace")
 	config.BindEnvAndSetDefault("snmp_traps_config.bind_host", "localhost")
 	config.BindEnvAndSetDefault("snmp_traps_config.stop_timeout", 5) // in seconds
+	config.SetKnown("snmp_traps_config.users")
 
 	// Kube ApiServer
 	config.BindEnvAndSetDefault("kubernetes_kubeconfig_path", "")


### PR DESCRIPTION
The `snmp_traps_config.users` was not declared in config.go