### PR TITLE
[pkg/otlp/model] Use exact sum and count for Datadog distributions

### DIFF
--- a/pkg/otlp/model/translator/metrics_translator.go
+++ b/pkg/otlp/model/translator/metrics_translator.go
@@ -158,11 +158,21 @@ func getBounds(p pdata.HistogramDataPoint, idx int) (lowerBound float64, upperBo
 	return
 }
 
+type histogramInfo struct {
+	// sum of histogram (exact)
+	sum float64
+	// count of histogram (exact)
+	count uint64
+	// ok to use
+	ok bool
+}
+
 func (t *Translator) getSketchBuckets(
 	ctx context.Context,
 	consumer SketchConsumer,
 	pointDims *Dimensions,
 	p pdata.HistogramDataPoint,
+	histInfo histogramInfo,
 	delta bool,
 ) {
 	startTs := uint64(p.StartTimestamp())
@@ -199,6 +209,12 @@ func (t *Translator) getSketchBuckets(
 
 	sketch := as.Finish()
 	if sketch != nil {
+		if histInfo.ok {
+			// override approximate sum, count and average in sketch with exact values if available.
+			sketch.Basic.Cnt = int64(histInfo.count)
+			sketch.Basic.Sum = histInfo.sum
+			sketch.Basic.Avg = sketch.Basic.Sum / float64(sketch.Basic.Cnt)
+		}
 		consumer.ConsumeSketch(ctx, pointDims, ts, sketch)
 	}
 }
@@ -257,33 +273,41 @@ func (t *Translator) mapHistogramMetrics(
 		ts := uint64(p.Timestamp())
 		pointDims := dims.WithAttributeMap(p.Attributes())
 
-		if t.cfg.SendCountSum {
-			count := float64(p.Count())
-			countDims := pointDims.WithSuffix("count")
-			if delta {
-				consumer.ConsumeTimeSeries(ctx, countDims, Count, ts, count)
-			} else if dx, ok := t.prevPts.Diff(countDims, startTs, ts, count); ok {
-				consumer.ConsumeTimeSeries(ctx, countDims, Count, ts, dx)
-			}
+		histInfo := histogramInfo{ok: true}
+
+		countDims := pointDims.WithSuffix("count")
+		if delta {
+			histInfo.count = p.Count()
+		} else if dx, ok := t.prevPts.Diff(countDims, startTs, ts, float64(p.Count())); ok {
+			histInfo.count = uint64(dx)
+		} else { // not ok
+			histInfo.ok = false
 		}
 
-		if t.cfg.SendCountSum {
-			sum := p.Sum()
-			sumDims := pointDims.WithSuffix("sum")
-			if !t.isSkippable(sumDims.name, p.Sum()) {
-				if delta {
-					consumer.ConsumeTimeSeries(ctx, sumDims, Count, ts, sum)
-				} else if dx, ok := t.prevPts.Diff(sumDims, startTs, ts, sum); ok {
-					consumer.ConsumeTimeSeries(ctx, sumDims, Count, ts, dx)
-				}
+		sumDims := pointDims.WithSuffix("sum")
+		if !t.isSkippable(sumDims.name, p.Sum()) {
+			if delta {
+				histInfo.sum = p.Sum()
+			} else if dx, ok := t.prevPts.Diff(sumDims, startTs, ts, p.Sum()); ok {
+				histInfo.sum = dx
+			} else { // not ok
+				histInfo.ok = false
 			}
+		} else { // skippable
+			histInfo.ok = false
+		}
+
+		if t.cfg.SendCountSum && histInfo.ok {
+			// We only send the sum and count if both values were ok.
+			consumer.ConsumeTimeSeries(ctx, countDims, Count, ts, float64(histInfo.count))
+			consumer.ConsumeTimeSeries(ctx, sumDims, Count, ts, histInfo.sum)
 		}
 
 		switch t.cfg.HistMode {
 		case HistogramModeCounters:
 			t.getLegacyBuckets(ctx, consumer, pointDims, p, delta)
 		case HistogramModeDistributions:
-			t.getSketchBuckets(ctx, consumer, pointDims, p, delta)
+			t.getSketchBuckets(ctx, consumer, pointDims, p, histInfo, delta)
 		}
 	}
 }

--- a/pkg/otlp/model/translator/metrics_translator_test.go
+++ b/pkg/otlp/model/translator/metrics_translator_test.go
@@ -563,9 +563,9 @@ func TestMapDeltaHistogramMetrics(t *testing.T) {
 		newSketch(dims, uint64(ts), summary.Summary{
 			Min: 0,
 			Max: 0,
-			Sum: 0,
-			Avg: 0,
-			Cnt: 20,
+			Sum: point.Sum(),
+			Avg: point.Sum() / float64(point.Count()),
+			Cnt: int64(point.Count()),
 		}),
 	}
 
@@ -573,8 +573,8 @@ func TestMapDeltaHistogramMetrics(t *testing.T) {
 		newSketch(dimsTags, uint64(ts), summary.Summary{
 			Min: 0,
 			Max: 0,
-			Sum: 0,
-			Avg: 0,
+			Sum: point.Sum(),
+			Avg: point.Sum() / float64(point.Count()),
 			Cnt: 20,
 		}),
 	}
@@ -716,8 +716,8 @@ func TestMapCumulativeHistogramMetrics(t *testing.T) {
 		newSketch(dims, uint64(seconds(2)), summary.Summary{
 			Min: 0,
 			Max: 0,
-			Sum: 0,
-			Avg: 0,
+			Sum: 20,
+			Avg: 20.0 / 30.0,
 			Cnt: 30,
 		}),
 	}
@@ -1183,8 +1183,8 @@ func TestMapMetrics(t *testing.T) {
 				newSketchWithHostname("double.histogram", summary.Summary{
 					Min: 0,
 					Max: 0,
-					Sum: 0,
-					Avg: 0,
+					Sum: math.Phi,
+					Avg: math.Phi / 20,
 					Cnt: 20,
 				}, attrTags),
 			},
@@ -1213,8 +1213,8 @@ func TestMapMetrics(t *testing.T) {
 				newSketchWithHostname("double.histogram", summary.Summary{
 					Min: 0,
 					Max: 0,
-					Sum: 0,
-					Avg: 0,
+					Sum: math.Phi,
+					Avg: math.Phi / 20.0,
 					Cnt: 20,
 				}, attrTags),
 			},
@@ -1243,8 +1243,8 @@ func TestMapMetrics(t *testing.T) {
 				newSketchWithHostname("double.histogram", summary.Summary{
 					Min: 0,
 					Max: 0,
-					Sum: 0,
-					Avg: 0,
+					Sum: math.Phi,
+					Avg: math.Phi / 20,
 					Cnt: 20,
 				}, append(attrTags, ilTags...)),
 			},
@@ -1273,8 +1273,8 @@ func TestMapMetrics(t *testing.T) {
 				newSketchWithHostname("double.histogram", summary.Summary{
 					Min: 0,
 					Max: 0,
-					Sum: 0,
-					Avg: 0,
+					Sum: math.Phi,
+					Avg: math.Phi / 20,
 					Cnt: 20,
 				}, append(attrTags, ilTags...)),
 			},
@@ -1428,5 +1428,5 @@ func TestNaNMetrics(t *testing.T) {
 	})
 
 	// One metric type was unknown or unsupported
-	assert.Equal(t, observed.FilterMessage("Unsupported metric value").Len(), 6)
+	assert.Equal(t, observed.FilterMessage("Unsupported metric value").Len(), 7)
 }

--- a/pkg/otlp/model/translator/sketches_test.go
+++ b/pkg/otlp/model/translator/sketches_test.go
@@ -29,6 +29,7 @@ import (
 var _ SketchConsumer = (*sketchConsumer)(nil)
 
 type sketchConsumer struct {
+	mockTimeSeriesConsumer
 	sk *quantile.Sketch
 }
 
@@ -42,6 +43,30 @@ func (c *sketchConsumer) ConsumeSketch(
 	c.sk = sketch
 }
 
+func newHistogramMetric(p pdata.HistogramDataPoint) pdata.Metrics {
+	md := pdata.NewMetrics()
+	rms := md.ResourceMetrics()
+	rm := rms.AppendEmpty()
+	ilms := rm.InstrumentationLibraryMetrics()
+	ilm := ilms.AppendEmpty()
+	metricsArray := ilm.Metrics()
+	m := metricsArray.AppendEmpty()
+	m.SetDataType(pdata.MetricDataTypeHistogram)
+	m.SetName("test")
+
+	// Copy Histogram point
+	m.Histogram().SetAggregationTemporality(pdata.MetricAggregationTemporalityDelta)
+	dps := m.Histogram().DataPoints()
+	np := dps.AppendEmpty()
+	np.SetCount(p.Count())
+	np.SetSum(p.Sum())
+	np.SetBucketCounts(p.BucketCounts())
+	np.SetExplicitBounds(p.ExplicitBounds())
+	np.SetTimestamp(p.Timestamp())
+
+	return md
+}
+
 func TestHistogramSketches(t *testing.T) {
 	N := 1_000
 	M := 50_000.0
@@ -50,7 +75,7 @@ func TestHistogramSketches(t *testing.T) {
 	// with support [0, N], generate an OTLP Histogram data point with N buckets,
 	// (-inf, 0], (0, 1], ..., (N-1, N], (N, inf)
 	// which contains N*M uniform samples of the distribution.
-	fromCDF := func(cdf func(x float64) float64) pdata.HistogramDataPoint {
+	fromCDF := func(cdf func(x float64) float64) pdata.Metrics {
 		p := pdata.NewHistogramDataPoint()
 		bounds := make([]float64, N+1)
 		buckets := make([]uint64, N+2)
@@ -68,7 +93,7 @@ func TestHistogramSketches(t *testing.T) {
 		p.SetExplicitBounds(bounds)
 		p.SetBucketCounts(buckets)
 		p.SetCount(count)
-		return p
+		return newHistogramMetric(p)
 	}
 
 	tests := []struct {
@@ -104,12 +129,11 @@ func TestHistogramSketches(t *testing.T) {
 	cfg := quantile.Default()
 	ctx := context.Background()
 	tr := newTranslator(t, zap.NewNop())
-	dims := &Dimensions{name: "test"}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			p := fromCDF(test.cdf)
+			md := fromCDF(test.cdf)
 			consumer := &sketchConsumer{}
-			tr.getSketchBuckets(ctx, consumer, dims, p, true)
+			tr.MapMetrics(ctx, md, consumer)
 			sk := consumer.sk
 
 			// Check the minimum is 0.0
@@ -127,6 +151,7 @@ func TestHistogramSketches(t *testing.T) {
 			}
 
 			cumulSum := uint64(0)
+			p := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).Histogram().DataPoints().At(0)
 			for i := 0; i < len(p.BucketCounts())-3; i++ {
 				{
 					q := float64(cumulSum) / float64(p.Count()) * (1 - tol)
@@ -154,56 +179,193 @@ func TestHistogramSketches(t *testing.T) {
 	}
 }
 
+func TestExactSumCount(t *testing.T) {
+	tests := []struct {
+		name    string
+		getHist func() pdata.Metrics
+		sum     float64
+		count   uint64
+	}{}
+
+	// Add tests for issue 6129: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/6129
+	tests = append(tests,
+		struct {
+			name    string
+			getHist func() pdata.Metrics
+			sum     float64
+			count   uint64
+		}{
+			name: "Uniform distribution (delta)",
+			getHist: func() pdata.Metrics {
+				md := pdata.NewMetrics()
+				rms := md.ResourceMetrics()
+				rm := rms.AppendEmpty()
+				ilms := rm.InstrumentationLibraryMetrics()
+				ilm := ilms.AppendEmpty()
+				metricsArray := ilm.Metrics()
+				m := metricsArray.AppendEmpty()
+				m.SetDataType(pdata.MetricDataTypeHistogram)
+				m.SetName("test")
+				m.Histogram().SetAggregationTemporality(pdata.MetricAggregationTemporalityDelta)
+				dp := m.Histogram().DataPoints()
+				p := dp.AppendEmpty()
+				p.SetExplicitBounds([]float64{0, 5_000, 10_000, 15_000, 20_000})
+				// Points from contrib issue 6129: 0, 5_000, 10_000, 15_000, 20_000
+				p.SetBucketCounts([]uint64{0, 1, 1, 1, 1, 1})
+				p.SetCount(5)
+				p.SetSum(50_000)
+				return md
+			},
+			sum:   50_000,
+			count: 5,
+		},
+
+		struct {
+			name    string
+			getHist func() pdata.Metrics
+			sum     float64
+			count   uint64
+		}{
+			name: "Uniform distribution (cumulative)",
+			getHist: func() pdata.Metrics {
+				md := pdata.NewMetrics()
+				rms := md.ResourceMetrics()
+				rm := rms.AppendEmpty()
+				ilms := rm.InstrumentationLibraryMetrics()
+				ilm := ilms.AppendEmpty()
+				metricsArray := ilm.Metrics()
+				m := metricsArray.AppendEmpty()
+				m.SetDataType(pdata.MetricDataTypeHistogram)
+				m.SetName("test")
+				m.Histogram().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
+				dp := m.Histogram().DataPoints()
+				// Points from contrib issue 6129: 0, 5_000, 10_000, 15_000, 20_000 repeated.
+				bounds := []float64{0, 5_000, 10_000, 15_000, 20_000}
+				for i := 1; i <= 2; i++ {
+					p := dp.AppendEmpty()
+					p.SetExplicitBounds(bounds)
+					cnt := uint64(i)
+					p.SetBucketCounts([]uint64{0, cnt, cnt, cnt, cnt, cnt})
+					p.SetCount(uint64(5 * i))
+					p.SetSum(float64(50_000 * i))
+				}
+				return md
+			},
+			sum:   50_000,
+			count: 5,
+		})
+
+	// Add tests for issue 7065: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/7065
+	for pos, val := range []float64{500, 5_000, 50_000} {
+		pos := pos
+		val := val
+		tests = append(tests, struct {
+			name    string
+			getHist func() pdata.Metrics
+			sum     float64
+			count   uint64
+		}{
+			name: fmt.Sprintf("Issue 7065 (%d, %f)", pos, val),
+			getHist: func() pdata.Metrics {
+				md := pdata.NewMetrics()
+				rms := md.ResourceMetrics()
+				rm := rms.AppendEmpty()
+				ilms := rm.InstrumentationLibraryMetrics()
+				ilm := ilms.AppendEmpty()
+				metricsArray := ilm.Metrics()
+				m := metricsArray.AppendEmpty()
+				m.SetDataType(pdata.MetricDataTypeHistogram)
+				m.SetName("test")
+
+				m.Histogram().SetAggregationTemporality(pdata.MetricAggregationTemporalityCumulative)
+				bounds := []float64{1_000, 10_000, 100_000}
+
+				dp := m.Histogram().DataPoints()
+				for i := 0; i < 2; i++ {
+					p := dp.AppendEmpty()
+					p.SetExplicitBounds(bounds)
+					counts := []uint64{0, 0, 0, 0}
+					counts[pos] = uint64(i)
+					t.Logf("pos: %d, val: %f, counts: %v", pos, val, counts)
+					p.SetBucketCounts(counts)
+					p.SetCount(uint64(i))
+					p.SetSum(val * float64(i))
+				}
+				return md
+			},
+			sum:   val,
+			count: 1,
+		})
+	}
+
+	ctx := context.Background()
+	tr := newTranslator(t, zap.NewNop())
+	for _, testInstance := range tests {
+		t.Run(testInstance.name, func(t *testing.T) {
+			md := testInstance.getHist()
+			consumer := &sketchConsumer{}
+			tr.MapMetrics(ctx, md, consumer)
+			sk := consumer.sk
+
+			assert.Equal(t, testInstance.count, uint64(sk.Basic.Cnt), "counts differ")
+			assert.Equal(t, testInstance.sum, sk.Basic.Sum, "sums differ")
+			avg := testInstance.sum / float64(testInstance.count)
+			assert.Equal(t, avg, sk.Basic.Avg, "averages differ")
+		})
+	}
+}
+
 func TestInfiniteBounds(t *testing.T) {
 
 	tests := []struct {
 		name    string
-		getHist func() pdata.HistogramDataPoint
+		getHist func() pdata.Metrics
 	}{
 		{
 			name: "(-inf, inf): 100",
-			getHist: func() pdata.HistogramDataPoint {
+			getHist: func() pdata.Metrics {
 				p := pdata.NewHistogramDataPoint()
 				p.SetExplicitBounds([]float64{})
 				p.SetBucketCounts([]uint64{100})
 				p.SetCount(100)
 				p.SetSum(0)
-				return p
+				return newHistogramMetric(p)
 			},
 		},
 		{
 			name: "(-inf, 0]: 100, (0, +inf]: 100",
-			getHist: func() pdata.HistogramDataPoint {
+			getHist: func() pdata.Metrics {
 				p := pdata.NewHistogramDataPoint()
 				p.SetExplicitBounds([]float64{0})
 				p.SetBucketCounts([]uint64{100, 100})
 				p.SetCount(200)
 				p.SetSum(0)
-				return p
+				return newHistogramMetric(p)
 			},
 		},
 		{
 			name: "(-inf, -1]: 100, (-1, 1]: 10,  (1, +inf]: 100",
-			getHist: func() pdata.HistogramDataPoint {
+			getHist: func() pdata.Metrics {
 				p := pdata.NewHistogramDataPoint()
 				p.SetExplicitBounds([]float64{-1, 1})
 				p.SetBucketCounts([]uint64{100, 10, 100})
 				p.SetCount(210)
 				p.SetSum(0)
-				return p
+				return newHistogramMetric(p)
 			},
 		},
 	}
 
 	ctx := context.Background()
 	tr := newTranslator(t, zap.NewNop())
-	dims := &Dimensions{name: "test"}
 	for _, testInstance := range tests {
 		t.Run(testInstance.name, func(t *testing.T) {
-			p := testInstance.getHist()
+			md := testInstance.getHist()
 			consumer := &sketchConsumer{}
-			tr.getSketchBuckets(ctx, consumer, dims, p, true)
+			tr.MapMetrics(ctx, md, consumer)
 			sk := consumer.sk
+
+			p := md.ResourceMetrics().At(0).InstrumentationLibraryMetrics().At(0).Metrics().At(0).Histogram().DataPoints().At(0)
 			assert.InDelta(t, sk.Basic.Sum, p.Sum(), 1)
 			assert.Equal(t, uint64(sk.Basic.Cnt), p.Count())
 		})

--- a/releasenotes/notes/otlp-exact-sum-count-ebab5aef6c5229d7.yaml
+++ b/releasenotes/notes/otlp-exact-sum-count-ebab5aef6c5229d7.yaml
@@ -9,4 +9,4 @@
 
 fixes:
   - |
-   OTLP ingest now uses the exact sum and count values from OTLP Histograms when generating Datadog distributions
+   OTLP ingest now uses the exact sum and count values from OTLP Histograms when generating Datadog distributions.

--- a/releasenotes/notes/otlp-exact-sum-count-ebab5aef6c5229d7.yaml
+++ b/releasenotes/notes/otlp-exact-sum-count-ebab5aef6c5229d7.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+
+fixes:
+  - |
+   OTLP ingest now uses the exact sum and count values from OTLP Histograms when generating Datadog distributions


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Backport of open-telemetry/opentelemetry-collector-contrib#7830.
Uses the exact values for sum, count and average on Datadog distributions whenever possible.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Exact is better than approximate. It's a common complaint about our exporter.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

The code on open-telemetry/opentelemetry-collector-contrib#7065 can be used for QA.
Send OTLP Histograms using this code to the Datadog Agent OTLP ingest endpoint.
Check that the generated histograms have the correct sum, count and average.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
