### PR TITLE
Use repository mirrorlists when building Docker images in CI

### DIFF
--- a/Dockerfiles/agent/amd64/Dockerfile
+++ b/Dockerfiles/agent/amd64/Dockerfile
@@ -1,7 +1,15 @@
 FROM ubuntu:21.10 AS baseimage
 ARG CIBUILD
+# NOTE about APT mirrorlists:
+# It seems that this feature could use some improvement. If you just get mirrorlist
+# from mirrors.ubuntu.com/mirrors.txt, it might contain faulty mirrors that either
+# cause `apt update` to fail with exit code 100 or make it hang on `0% [Working]`
+# indefinitely. Therefore we create a mirrorlist with the 2 mirrors that we know
+# should be reliable enough in combination and also well maintained.
 RUN if [ "$CIBUILD" = "true" ]; then \
-  sed -i 's#http://archive.ubuntu.com#http://us-east-1.ec2.archive.ubuntu.com#g' /etc/apt/sources.list; \
+  echo "http://us-east-1.ec2.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://archive.ubuntu.com/ubuntu" > /etc/apt/mirrorlist && \
+  sed -i -e 's#http://archive.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist#g' \
+         -e 's#http://security.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist#g' /etc/apt/sources.list; \
   fi
 
 FROM baseimage AS faccessat

--- a/Dockerfiles/agent/arm64/Dockerfile
+++ b/Dockerfiles/agent/arm64/Dockerfile
@@ -1,8 +1,15 @@
 FROM ubuntu:21.10 AS baseimage
 ARG CIBUILD
-RUN if [ "$CIBUILD" = "true" ]; then \
-  sed -i 's#http://archive.ubuntu.com#http://us-east-1.ec2.archive.ubuntu.com#g' /etc/apt/sources.list; \
-  fi
+# NOTE about APT mirrorlists:
+# It seems that this feature could use some improvement. If you just get mirrorlist
+# from mirrors.ubuntu.com/mirrors.txt, it might contain faulty mirrors that either
+# cause `apt update` to fail with exit code 100 or make it hang on `0% [Working]`
+# indefinitely. Therefore we create a mirrorlist with the 2 mirrors that we know
+# should be reliable enough in combination and also well maintained.
+ RUN if [ "$CIBUILD" = "true" ]; then \
+  echo "http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports\tpriority:1\nhttp://ports.ubuntu.com/ubuntu-ports" > /etc/apt/mirrorlist && \
+  sed -i -e 's#http://ports.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist#g' /etc/apt/sources.list; \
+   fi
 
 FROM baseimage AS faccessat
 COPY faccessat/faccessat.c   /tmp/faccessat.c

--- a/Dockerfiles/cluster-agent/amd64/Dockerfile
+++ b/Dockerfiles/cluster-agent/amd64/Dockerfile
@@ -29,6 +29,19 @@ FROM ubuntu:21.10
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 
+ ARG CIBUILD
+# NOTE about APT mirrorlists:
+# It seems that this feature could use some improvement. If you just get mirrorlist
+# from mirrors.ubuntu.com/mirrors.txt, it might contain faulty mirrors that either
+# cause `apt update` to fail with exit code 100 or make it hang on `0% [Working]`
+# indefinitely. Therefore we create a mirrorlist with the 2 mirrors that we know
+# should be reliable enough in combination and also well maintained.
+ RUN if [ "$CIBUILD" = "true" ]; then \
+  echo "http://us-east-1.ec2.archive.ubuntu.com/ubuntu\tpriority:1\nhttp://archive.ubuntu.com/ubuntu" > /etc/apt/mirrorlist && \
+  sed -i -e 's#http://archive.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist#g' \
+         -e 's#http://security.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist#g' /etc/apt/sources.list; \
+   fi
+
 ENV PATH="/opt/datadog-agent/bin/:$PATH" \
     DOCKER_DD_AGENT="true" \
     # Allow User Group to exec the secret backend script.

--- a/Dockerfiles/cluster-agent/arm64/Dockerfile
+++ b/Dockerfiles/cluster-agent/arm64/Dockerfile
@@ -28,6 +28,18 @@ FROM ubuntu:21.10
 
 LABEL maintainer "Datadog <package@datadoghq.com>"
 
+ARG CIBUILD
+# NOTE about APT mirrorlists:
+# It seems that this feature could use some improvement. If you just get mirrorlist
+# from mirrors.ubuntu.com/mirrors.txt, it might contain faulty mirrors that either
+# cause `apt update` to fail with exit code 100 or make it hang on `0% [Working]`
+# indefinitely. Therefore we create a mirrorlist with the 2 mirrors that we know
+# should be reliable enough in combination and also well maintained.
+ RUN if [ "$CIBUILD" = "true" ]; then \
+  echo "http://us-east-1.ec2.ports.ubuntu.com/ubuntu-ports\tpriority:1\nhttp://ports.ubuntu.com/ubuntu-ports" > /etc/apt/mirrorlist && \
+  sed -i -e 's#http://ports.ubuntu.com\S*#mirror+file:/etc/apt/mirrorlist#g' /etc/apt/sources.list; \
+   fi
+
 ENV PATH="/opt/datadog-agent/bin/:$PATH" \
     DOCKER_DD_AGENT="true" \
     # Allow User Group to exec the secret backend script.

--- a/Dockerfiles/dogstatsd/alpine/amd64/Dockerfile
+++ b/Dockerfiles/dogstatsd/alpine/amd64/Dockerfile
@@ -4,6 +4,12 @@ LABEL maintainer "Datadog <package@datadoghq.com>"
 
 ENV DOCKER_DD_AGENT=true
 
+# We add mirror.clarkson.edu as a secondary mirror, as it's closest to us-east-1
+# where we build the agent
+
+RUN ALPINE_RELEASE=$(cat /etc/alpine-release | sed "s/^\(\d\+\.\d\+\).\+$/\1/") && \
+  echo -e "http://mirror.clarkson.edu/alpine/v${ALPINE_RELEASE}/main\nhttp://mirror.clarkson.edu/alpine/v${ALPINE_RELEASE}/community" >> /etc/apk/repositories
+
 RUN apk add --no-cache ca-certificates
 
 COPY entrypoint.sh probe.sh /

--- a/Dockerfiles/dogstatsd/alpine/arm64/Dockerfile
+++ b/Dockerfiles/dogstatsd/alpine/arm64/Dockerfile
@@ -4,6 +4,12 @@ LABEL maintainer "Datadog <package@datadoghq.com>"
 
 ENV DOCKER_DD_AGENT=true
 
+# We add mirror.clarkson.edu as a secondary mirror, as it's closest to us-east-1
+# where we build the agent
+
+RUN ALPINE_RELEASE=$(cat /etc/alpine-release | sed "s/^\(\d\+\.\d\+\).\+$/\1/") && \
+  echo -e "http://mirror.clarkson.edu/alpine/v${ALPINE_RELEASE}/main\nhttp://mirror.clarkson.edu/alpine/v${ALPINE_RELEASE}/community" >> /etc/apk/repositories
+
 RUN apk add --no-cache ca-certificates
 
 COPY entrypoint.sh probe.sh /


### PR DESCRIPTION
### What does this PR do?

* Implements usage of APT mirrorlist for images based on Debian
  * The mirrorlist only contains 2 repositories that are well maintained and there's a very high likelihood of at least one being up.
  * We don't just fetch mirrorlist from `mirrors.ubuntu.com/mirrors.txt`, because that wouldn't contain `us-east-1.ec2.archive.ubuntu.com/ubuntu` and also certain faulty mirrors can cause `apt update` to fail/hang indefinitely (for example if one of the repositories has an out-of-sync `Release` and `Release.gpg` files, it makes `apt update` fail).
* Adds a second repository for images based on Alpine
  * There are no "mirrorlists" for `apk`, but adding more repositories makes `apk` fall back to the second one if the first one is offline.

### Motivation

Increase reliability of distro package installation in images built in pipeline.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
