### PR TITLE
[workloadmeta/containerd] Reduce probability of getting errors when handling container events

### DIFF
--- a/pkg/workloadmeta/collectors/containerd/container_builder.go
+++ b/pkg/workloadmeta/collectors/containerd/container_builder.go
@@ -21,11 +21,6 @@ import (
 
 // buildWorkloadMetaContainer generates a workloadmeta.Container from a containerd.Container
 func buildWorkloadMetaContainer(container containerd.Container, containerdClient cutil.ContainerdItf) (workloadmeta.Container, error) {
-	labels, err := containerdClient.Labels(container)
-	if err != nil {
-		return workloadmeta.Container{}, err
-	}
-
 	info, err := containerdClient.Info(container)
 	if err != nil {
 		return workloadmeta.Container{}, err
@@ -41,15 +36,9 @@ func buildWorkloadMetaContainer(container containerd.Container, containerdClient
 		return workloadmeta.Container{}, err
 	}
 
-	containerdImage, err := containerdClient.Image(container)
+	image, err := workloadmeta.NewContainerImage(info.Image)
 	if err != nil {
-		return workloadmeta.Container{}, err
-	}
-
-	imageName := containerdImage.Name()
-	image, err := workloadmeta.NewContainerImage(imageName)
-	if err != nil {
-		log.Debugf("cannot split image name %q: %s", imageName, err)
+		log.Debugf("cannot split image name %q: %s", info.Image, err)
 	}
 
 	status, err := containerdClient.Status(container)
@@ -73,7 +62,7 @@ func buildWorkloadMetaContainer(container containerd.Container, containerdClient
 		},
 		EntityMeta: workloadmeta.EntityMeta{
 			Name:   "", // Not available
-			Labels: labels,
+			Labels: info.Labels,
 		},
 		Image:   image,
 		EnvVars: envs,

--- a/pkg/workloadmeta/collectors/containerd/container_builder_test.go
+++ b/pkg/workloadmeta/collectors/containerd/container_builder_test.go
@@ -59,21 +59,15 @@ func TestBuildWorkloadMetaContainer(t *testing.T) {
 	}
 
 	client := fake.MockedContainerdClient{
-		MockLabels: func(ctn containerd.Container) (map[string]string, error) {
-			return labels, nil
-		},
-		MockImage: func(ctn containerd.Container) (containerd.Image, error) {
-			return &mockedImage{
-				mockName: func() string {
-					return imgName
-				},
-			}, nil
-		},
 		MockEnvVars: func(ctn containerd.Container) (map[string]string, error) {
 			return envVars, nil
 		},
 		MockInfo: func(ctn containerd.Container) (containers.Container, error) {
-			return containers.Container{CreatedAt: createdAt}, nil
+			return containers.Container{
+				Labels:    labels,
+				CreatedAt: createdAt,
+				Image:     imgName,
+			}, nil
 		},
 		MockSpec: func(ctn containerd.Container) (*oci.Spec, error) {
 			return &oci.Spec{Hostname: hostName}, nil

--- a/pkg/workloadmeta/collectors/containerd/containerd.go
+++ b/pkg/workloadmeta/collectors/containerd/containerd.go
@@ -13,10 +13,8 @@ import (
 	"fmt"
 	"time"
 
-	apievents "github.com/containerd/containerd/api/events"
+	"github.com/containerd/containerd"
 	containerdevents "github.com/containerd/containerd/events"
-	"github.com/gogo/protobuf/proto"
-	"github.com/gogo/protobuf/types"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/errors"
@@ -171,20 +169,12 @@ func (c *collector) generateEventsFromContainerList(ctx context.Context) error {
 	for _, namespace := range namespaces {
 		c.containerdClient.SetCurrentNamespace(namespace)
 
-		containerdEvents, err := c.generateInitialEvents(ctx, namespace)
+		nsEvents, err := c.generateInitialEvents(ctx, namespace)
 		if err != nil {
 			return err
 		}
 
-		for _, containerdEvent := range containerdEvents {
-			ev, err := c.buildCollectorEvent(ctx, &containerdEvent)
-			if err != nil {
-				log.Warnf(err.Error())
-				continue
-			}
-
-			events = append(events, ev)
-		}
+		events = append(events, nsEvents...)
 	}
 
 	if len(events) > 0 {
@@ -194,8 +184,8 @@ func (c *collector) generateEventsFromContainerList(ctx context.Context) error {
 	return nil
 }
 
-func (c *collector) generateInitialEvents(ctx context.Context, namespace string) ([]containerdevents.Envelope, error) {
-	var events []containerdevents.Envelope
+func (c *collector) generateInitialEvents(ctx context.Context, namespace string) ([]workloadmeta.CollectorEvent, error) {
+	var events []workloadmeta.CollectorEvent
 
 	existingContainers, err := c.containerdClient.Containers()
 	if err != nil {
@@ -203,37 +193,24 @@ func (c *collector) generateInitialEvents(ctx context.Context, namespace string)
 	}
 
 	for _, container := range existingContainers {
-		eventEncoded, err := proto.Marshal(&apievents.ContainerCreate{
-			ID: container.ID(),
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		event := containerdevents.Envelope{
-			Timestamp: time.Now(),
-			Namespace: namespace,
-			Topic:     containerCreationTopic,
-			Event: &types.Any{
-				TypeUrl: "containerd.events.ContainerCreate",
-				Value:   eventEncoded,
-			},
-		}
-
 		// if ignoreEvent returns an error, keep the event regardless.
 		// it might've been because of network errors, so it's better
 		// to keep a container we should've ignored than ignoring a
 		// container we should've kept
-		ignore, err := c.ignoreEvent(ctx, &event)
+		ignore, err := c.ignoreEvent(ctx, container)
 		if err != nil {
 			log.Debugf("Error while deciding to ignore event, keeping it: %s", err)
-		}
-
-		if ignore {
+		} else if ignore {
 			continue
 		}
 
-		events = append(events, event)
+		ev, err := createSetEvent(ctx, container, namespace, c.containerdClient)
+		if err != nil {
+			log.Warnf(err.Error())
+			continue
+		}
+
+		events = append(events, ev)
 	}
 
 	return events, nil
@@ -242,22 +219,23 @@ func (c *collector) generateInitialEvents(ctx context.Context, namespace string)
 func (c *collector) handleEvent(ctx context.Context, containerdEvent *containerdevents.Envelope) error {
 	c.containerdClient.SetCurrentNamespace(containerdEvent.Namespace)
 
-	ignore, err := c.ignoreEvent(ctx, containerdEvent)
+	containerID, container, err := c.extractContainerFromEvent(ctx, containerdEvent)
 	if err != nil {
-		// if ignoreEvent returns an error, keep the event regardless.
-		// it might've been because of network errors, so it's better
-		// to keep a container we should've ignored than ignoring a
-		// container we should've kept
-		log.Debugf("Error while deciding to ignore event, keeping it: %s", err)
+		return fmt.Errorf("cannot extract container from event: %w", err)
 	}
 
-	if ignore {
-		return nil
+	if container != nil {
+		ignore, err := c.ignoreEvent(ctx, container)
+		if err != nil {
+			log.Debugf("Error while deciding to ignore event, keeping it: %s", err)
+		} else if ignore {
+			return nil
+		}
 	}
 
-	workloadmetaEvent, err := c.buildCollectorEvent(ctx, containerdEvent)
+	workloadmetaEvent, err := c.buildCollectorEvent(ctx, containerdEvent, containerID, container)
 	if err != nil {
-		return err
+		return fmt.Errorf("cannot build collector event: %w", err)
 	}
 
 	c.store.Notify([]workloadmeta.CollectorEvent{workloadmetaEvent})
@@ -265,30 +243,42 @@ func (c *collector) handleEvent(ctx context.Context, containerdEvent *containerd
 	return nil
 }
 
+func (c *collector) extractContainerFromEvent(ctx context.Context, containerdEvent *containerdevents.Envelope) (string, containerd.Container, error) {
+	var (
+		containerID string
+		hasID       bool
+	)
+
+	switch containerdEvent.Topic {
+	case containerCreationTopic, containerUpdateTopic, containerDeletionTopic:
+		containerID, hasID = containerdEvent.Field([]string{"event", "id"})
+		if !hasID {
+			return "", nil, fmt.Errorf("missing ID in containerd event")
+		}
+
+	case TaskStartTopic, TaskOOMTopic, TaskPausedTopic, TaskResumedTopic, TaskExitTopic, TaskDeleteTopic:
+		containerID, hasID = containerdEvent.Field([]string{"event", "container_id"})
+		if !hasID {
+			return "", nil, fmt.Errorf("missing ID in containerd event")
+		}
+
+	default:
+		return "", nil, fmt.Errorf("unknown action type %s, ignoring", containerdEvent.Topic)
+	}
+
+	// ignore NotFound errors, since they happen for every deleted
+	// container, but these events still need to be handled
+	container, err := c.containerdClient.ContainerWithContext(ctx, containerID)
+	if err != nil && !errors.IsNotFound(err) {
+		return "", nil, err
+	}
+
+	return containerID, container, nil
+}
+
 // ignoreEvent returns whether a containerd event should be ignored.
 // The ignored events are the ones that refer to a "pause" container.
-func (c *collector) ignoreEvent(ctx context.Context, containerdEvent *containerdevents.Envelope) (bool, error) {
-	// The container ID can be in the "id" field (in container events) or
-	// "container_id" (in task events)
-	ID, found := containerdEvent.Field([]string{"event", "id"})
-	if !found {
-		ID, found = containerdEvent.Field([]string{"event", "container_id"})
-		if !found {
-			// We don't handle any events that don't have a container ID, so we
-			// can ignore them.
-			return true, nil
-		}
-	}
-
-	container, err := c.containerdClient.ContainerWithContext(ctx, ID)
-	if err != nil {
-		if errors.IsNotFound(err) {
-			// This is a delete event that needs to be handled
-			return false, nil
-		}
-		return false, err
-	}
-
+func (c *collector) ignoreEvent(ctx context.Context, container containerd.Container) (bool, error) {
 	info, err := c.containerdClient.Info(container)
 	if err != nil {
 		return false, err

--- a/pkg/workloadmeta/collectors/containerd/containerd.go
+++ b/pkg/workloadmeta/collectors/containerd/containerd.go
@@ -289,13 +289,13 @@ func (c *collector) ignoreEvent(ctx context.Context, containerdEvent *containerd
 		return false, err
 	}
 
-	img, err := c.containerdClient.Image(container)
+	info, err := c.containerdClient.Info(container)
 	if err != nil {
 		return false, err
 	}
 
 	// Only the image name is relevant to exclude paused containers
-	return c.filterPausedContainers.IsExcluded("", img.Name(), ""), nil
+	return c.filterPausedContainers.IsExcluded("", info.Image, ""), nil
 }
 
 func subscribeFilters() []string {

--- a/pkg/workloadmeta/collectors/containerd/containerd_test.go
+++ b/pkg/workloadmeta/collectors/containerd/containerd_test.go
@@ -9,7 +9,6 @@
 package containerd
 
 import (
-	"context"
 	"testing"
 
 	"github.com/containerd/containerd"
@@ -20,7 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
 )
 
-func TestIgnoreEvent(t *testing.T) {
+func TestIgnoreContainer(t *testing.T) {
 	pauseFilter, err := containers.GetPauseContainerFilter()
 	assert.NoError(t, err)
 
@@ -67,7 +66,7 @@ func TestIgnoreEvent(t *testing.T) {
 				filterPausedContainers: pauseFilter,
 			}
 
-			ignored, err := containerdCollector.ignoreEvent(context.TODO(), test.container)
+			ignored, err := containerdCollector.ignoreContainer(test.container)
 			assert.NoError(t, err)
 
 			if test.expectsIgnored {

--- a/pkg/workloadmeta/collectors/containerd/containerd_test.go
+++ b/pkg/workloadmeta/collectors/containerd/containerd_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/containerd/containerd"
 	apievents "github.com/containerd/containerd/api/events"
+	containerdcontainers "github.com/containerd/containerd/containers"
 	containerdevents "github.com/containerd/containerd/events"
 	"github.com/gogo/protobuf/proto"
 	"github.com/gogo/protobuf/types"
@@ -87,11 +88,9 @@ func TestIgnoreEvent(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			client := fake.MockedContainerdClient{
 				MockContainerWithCtx: test.getContainerFn,
-				MockImage: func(ctn containerd.Container) (containerd.Image, error) {
-					return &mockedImage{
-						mockName: func() string {
-							return test.imgName
-						},
+				MockInfo: func(containerd.Container) (containerdcontainers.Container, error) {
+					return containerdcontainers.Container{
+						Image: test.imgName,
 					}, nil
 				},
 			}

--- a/pkg/workloadmeta/collectors/containerd/event_builder.go
+++ b/pkg/workloadmeta/collectors/containerd/event_builder.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/containerd/containerd"
 	"github.com/containerd/containerd/api/events"
 	containerdevents "github.com/containerd/containerd/events"
 	"github.com/gogo/protobuf/proto"
@@ -21,67 +22,52 @@ import (
 )
 
 // buildCollectorEvent generates a CollectorEvent from a containerdevents.Envelope
-func (c *collector) buildCollectorEvent(ctx context.Context, containerdEvent *containerdevents.Envelope) (workloadmeta.CollectorEvent, error) {
+func (c *collector) buildCollectorEvent(
+	ctx context.Context,
+	containerdEvent *containerdevents.Envelope,
+	containerID string,
+	container containerd.Container,
+) (workloadmeta.CollectorEvent, error) {
 	switch containerdEvent.Topic {
 	case containerCreationTopic, containerUpdateTopic:
-		ID, hasID := containerdEvent.Field([]string{"event", "id"})
-		if !hasID {
-			return workloadmeta.CollectorEvent{}, fmt.Errorf("missing ID in containerd event")
-		}
+		return createSetEvent(ctx, container, containerdEvent.Namespace, c.containerdClient)
 
-		return createSetEvent(ctx, ID, containerdEvent.Namespace, c.containerdClient)
 	case containerDeletionTopic:
-		ID, hasID := containerdEvent.Field([]string{"event", "id"})
-		if !hasID {
-			return workloadmeta.CollectorEvent{}, fmt.Errorf("missing ID in containerd event")
-		}
+		exitInfo := c.getExitInfo(containerID)
+		defer c.deleteExitInfo(containerID)
 
-		exitInfo := c.getExitInfo(ID)
-		defer c.deleteExitInfo(ID)
+		return createDeletionEvent(containerID, exitInfo), nil
 
-		return createDeletionEvent(ID, exitInfo), nil
 	case TaskExitTopic:
 		exited := &events.TaskExit{}
 		if err := proto.Unmarshal(containerdEvent.Event.Value, exited); err != nil {
 			return workloadmeta.CollectorEvent{}, err
 		}
 
-		c.cacheExitInfo(exited.ContainerID, &exited.ExitStatus, exited.ExitedAt)
-		return createSetEventFromTask(ctx, containerdEvent.Namespace, containerdEvent, c.containerdClient)
+		c.cacheExitInfo(containerID, &exited.ExitStatus, exited.ExitedAt)
+		return createSetEvent(ctx, container, containerdEvent.Namespace, c.containerdClient)
+
 	case TaskDeleteTopic:
 		deleted := &events.TaskDelete{}
 		if err := proto.Unmarshal(containerdEvent.Event.Value, deleted); err != nil {
 			return workloadmeta.CollectorEvent{}, err
 		}
 
-		c.cacheExitInfo(deleted.ContainerID, &deleted.ExitStatus, deleted.ExitedAt)
-		return createSetEventFromTask(ctx, containerdEvent.Namespace, containerdEvent, c.containerdClient)
+		c.cacheExitInfo(containerID, &deleted.ExitStatus, deleted.ExitedAt)
+		return createSetEvent(ctx, container, containerdEvent.Namespace, c.containerdClient)
+
 	case TaskStartTopic, TaskOOMTopic, TaskPausedTopic, TaskResumedTopic:
-		return createSetEventFromTask(ctx, containerdEvent.Namespace, containerdEvent, c.containerdClient)
+		return createSetEvent(ctx, container, containerdEvent.Namespace, c.containerdClient)
+
 	default:
 		return workloadmeta.CollectorEvent{}, fmt.Errorf("unknown action type %s, ignoring", containerdEvent.Topic)
 	}
 }
 
-func createSetEventFromTask(ctx context.Context, namespace string, containerdEvent *containerdevents.Envelope, containerdClient cutil.ContainerdItf) (workloadmeta.CollectorEvent, error) {
-	// Notice that the ID field in this case is stored in "ContainerID".
-	ID, hasID := containerdEvent.Field([]string{"event", "container_id"})
-	if !hasID {
-		return workloadmeta.CollectorEvent{}, fmt.Errorf("missing ID in containerd event")
-	}
-
-	return createSetEvent(ctx, ID, namespace, containerdClient)
-}
-
-func createSetEvent(ctx context.Context, containerID string, namespace string, containerdClient cutil.ContainerdItf) (workloadmeta.CollectorEvent, error) {
-	container, err := containerdClient.ContainerWithContext(ctx, containerID)
-	if err != nil {
-		return workloadmeta.CollectorEvent{}, fmt.Errorf("could not fetch container %s: %s", containerID, err)
-	}
-
+func createSetEvent(ctx context.Context, container containerd.Container, namespace string, containerdClient cutil.ContainerdItf) (workloadmeta.CollectorEvent, error) {
 	entity, err := buildWorkloadMetaContainer(container, containerdClient)
 	if err != nil {
-		return workloadmeta.CollectorEvent{}, fmt.Errorf("could not fetch info for container %s: %s", containerID, err)
+		return workloadmeta.CollectorEvent{}, fmt.Errorf("could not fetch info for container %s: %s", container.ID(), err)
 	}
 
 	// The namespace cannot be obtained from a container instance. That's why we

--- a/pkg/workloadmeta/collectors/containerd/event_builder_test.go
+++ b/pkg/workloadmeta/collectors/containerd/event_builder_test.go
@@ -264,7 +264,7 @@ func TestBuildCollectorEvent(t *testing.T) {
 				c.contToExitInfo[containerID] = test.exitInfo
 			}
 
-			workloadMetaEvent, err := c.buildCollectorEvent(context.TODO(), &test.event, container.ID(), &container)
+			workloadMetaEvent, err := c.buildCollectorEvent(&test.event, container.ID(), &container)
 
 			if test.expectsError {
 				assert.Error(t, err)

--- a/pkg/workloadmeta/collectors/containerd/event_builder_test.go
+++ b/pkg/workloadmeta/collectors/containerd/event_builder_test.go
@@ -91,11 +91,6 @@ func TestBuildCollectorEvent(t *testing.T) {
 	})
 	assert.NoError(t, err)
 
-	eventWithoutID, err := proto.Marshal(&events.ContainerCreate{
-		ID: "",
-	})
-	assert.NoError(t, err)
-
 	tests := []struct {
 		name          string
 		event         containerdevents.Envelope
@@ -166,17 +161,6 @@ func TestBuildCollectorEvent(t *testing.T) {
 				Event: &types.Any{
 					// Uses delete, but could be any other event in this test
 					TypeUrl: "containerd.events.ContainerDelete", Value: containerDeleteEvent,
-				},
-			},
-			expectsError: true,
-		},
-		{
-			name: "event without ID",
-			event: containerdevents.Envelope{
-				Namespace: namespace,
-				Topic:     containerCreationTopic,
-				Event: &types.Any{
-					TypeUrl: "containerd.events.ContainerCreate", Value: eventWithoutID,
 				},
 			},
 			expectsError: true,
@@ -280,7 +264,7 @@ func TestBuildCollectorEvent(t *testing.T) {
 				c.contToExitInfo[containerID] = test.exitInfo
 			}
 
-			workloadMetaEvent, err := c.buildCollectorEvent(context.TODO(), &test.event)
+			workloadMetaEvent, err := c.buildCollectorEvent(context.TODO(), &test.event, container.ID(), &container)
 
 			if test.expectsError {
 				assert.Error(t, err)


### PR DESCRIPTION
### What does this PR do?

This PR reduces the amount of requests we make to the containerd daemon to reduce the chance of errors happening, and therefore polluting logs and potentially missing events that should be handled by workloadmeta. We do that by using as much information that we already have in memory as possible.

### Describe how to test/QA your changes

* Check that container information is still collected properly. This can be checked with `agent workload-list --verbose`, and seeing that entities with `source:containerd` (not the merged ones!) have the expected info.
* Check that there are much fewer errors coming from this collector. Specifically, `could not fetch info for container: failed to get image $IMAGE for container: image "$IMAGE": not found` should be gone entirely. This is best done by looking at the logs from a large staging cluster.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
