### PR TITLE
[workloadmeta] Extract the org.opencontainers.image.source docker label

### DIFF
--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -94,6 +94,9 @@ var (
 
 		// Automatically extract git commit sha from image for source code integration
 		"org.opencontainers.image.revision": "git.commit.sha",
+
+		// Automatically extract repository url from image for source code integration
+		"org.opencontainers.image.source": "git.repository_url",
 	}
 
 	highCardOrchestratorLabels = map[string]string{

--- a/pkg/tagger/collectors/workloadmeta_test.go
+++ b/pkg/tagger/collectors/workloadmeta_test.go
@@ -860,13 +860,14 @@ func TestHandleContainer(t *testing.T) {
 			},
 		},
 		{
-			name: "opencontainers image revision",
+			name: "opencontainers image revision and source",
 			container: workloadmeta.Container{
 				EntityID: entityID,
 				EntityMeta: workloadmeta.EntityMeta{
 					Name: containerName,
 					Labels: map[string]string{
 						"org.opencontainers.image.revision": "758691a28aa920070651d360814c559bc26af907",
+						"org.opencontainers.image.source":   "https://github.com/my-company/repo",
 					},
 				},
 			},
@@ -879,8 +880,11 @@ func TestHandleContainer(t *testing.T) {
 						fmt.Sprintf("container_id:%s", entityID.ID),
 					},
 					OrchestratorCardTags: []string{},
-					LowCardTags:          []string{"git.commit.sha:758691a28aa920070651d360814c559bc26af907"},
-					StandardTags:         []string{},
+					LowCardTags: []string{
+						"git.commit.sha:758691a28aa920070651d360814c559bc26af907",
+						"git.repository_url:https://github.com/my-company/repo",
+					},
+					StandardTags: []string{},
 				},
 			},
 		},

--- a/releasenotes/notes/opencontainers-image-source-as-tag-aa5abe3c11345850.yaml
+++ b/releasenotes/notes/opencontainers-image-source-as-tag-aa5abe3c11345850.yaml
@@ -1,0 +1,4 @@
+---
+enhancements:
+  - |
+    Automatically extract the ``org.opencontainers.image.source`` container label into the ``git.repository_url`` tag.


### PR DESCRIPTION
### What does this PR do?

Automatically extract the org.opencontainers.image.source docker label into the git.repository_url.

### Motivation

The `git.repository_url` tag recommended be set for Datadog's Source Code Integration setup.
Our public documentation currently suggest using the `org.opencontainers.image.source` docker label and to configure the agent to extract the repository url. See [Configure the Agent](https://docs.datadoghq.com/integrations/guide/source-code-integration/?tab=dockerruntime#configure-the-agent).  

### Additional Notes

The label is added inside the `standardDockerLabels` map since we do want this behaviour to be enabled by default for all.

### Describe how to test/QA your changes

Start the Agent with a traced app running within a container with the label `org.opencontainers.image.source` set.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
