### PR TITLE
Add Kubelet collector to generic metrics provider

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -1616,6 +1616,7 @@ core,k8s.io/kube-state-metrics/v2/pkg/metrics_store,Apache-2.0,Cloud Native Comp
 core,k8s.io/kube-state-metrics/v2/pkg/options,Apache-2.0,Cloud Native Computing Foundation (CNCF) | The Kubernetes Authors
 core,k8s.io/kube-state-metrics/v2/pkg/sharding,Apache-2.0,Cloud Native Computing Foundation (CNCF) | The Kubernetes Authors
 core,k8s.io/kube-state-metrics/v2/pkg/watch,Apache-2.0,Cloud Native Computing Foundation (CNCF) | The Kubernetes Authors
+core,k8s.io/kubelet/pkg/apis/stats/v1alpha1,Apache-2.0,Cloud Native Computing Foundation (CNCF) | The Kubernetes Authors
 core,k8s.io/metrics/pkg/apis/custom_metrics,Apache-2.0,Cloud Native Computing Foundation (CNCF) | The Kubernetes Authors
 core,k8s.io/metrics/pkg/apis/custom_metrics/install,Apache-2.0,Cloud Native Computing Foundation (CNCF) | The Kubernetes Authors
 core,k8s.io/metrics/pkg/apis/custom_metrics/v1beta1,Apache-2.0,Cloud Native Computing Foundation (CNCF) | The Kubernetes Authors

--- a/go.mod
+++ b/go.mod
@@ -208,6 +208,7 @@ require (
 	k8s.io/klog/v2 v2.9.0
 	k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7
 	k8s.io/kube-state-metrics/v2 v2.1.1
+	k8s.io/kubelet v0.21.5
 	k8s.io/metrics v0.21.5
 	k8s.io/utils v0.0.0-20201110183641-67b214c5f920
 )

--- a/go.sum
+++ b/go.sum
@@ -2332,6 +2332,8 @@ k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAG
 k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7 h1:vEx13qjvaZ4yfObSSXW7BrMc/KQBBT/Jyee8XtLf4x0=
 k8s.io/kube-openapi v0.0.0-20210305001622-591a79e4bda7/go.mod h1:wXW5VT87nVfh/iLV8FpR2uDvrFyomxbtb1KivDbvPTE=
 k8s.io/kube-state-metrics v1.9.7/go.mod h1:VmWbsdvz/+sCXfxG1RDdlMageJNST9Uo8vBwavSYBu0=
+k8s.io/kubelet v0.21.5 h1:XPc6L3qcw/XM8HE2P6zBGyffghblWEbw5dj9XboeHhA=
+k8s.io/kubelet v0.21.5/go.mod h1:yVKsH4usaXy40Z3cZ8jknE70obOF/4aFNB7bittEEZ0=
 k8s.io/metrics v0.0.0-20191109111301-80b462294217/go.mod h1:GSVMuBbi34fc7MSnJ1Q//5ijIPF5ykXeEVQ49V5l2SM=
 k8s.io/metrics v0.18.3/go.mod h1:TkuJE3ezDZ1ym8pYkZoEzJB7HDiFE7qxl+EmExEBoPA=
 k8s.io/metrics v0.20.0/go.mod h1:9yiRhfr8K8sjdj2EthQQE9WvpYDvsXIV3CjN4Ruq4Jw=

--- a/pkg/autodiscovery/listeners/environment.go
+++ b/pkg/autodiscovery/listeners/environment.go
@@ -67,11 +67,7 @@ func (l *EnvironmentListener) createServices() {
 	}
 
 	// Handle generic container check auto-activation.
-	containerFeatures := []config.Feature{config.Docker, config.Containerd, config.Cri, config.ECSFargate, config.Podman}
-	if !config.IsFeaturePresent(config.EKSFargate) {
-		containerFeatures = append(containerFeatures, config.Kubernetes)
-	}
-
+	containerFeatures := []config.Feature{config.Docker, config.Containerd, config.Cri, config.ECSFargate, config.Podman, config.Kubernetes}
 	for _, f := range containerFeatures {
 		if config.IsFeaturePresent(f) {
 			log.Infof("Listener created container service from environment")

--- a/pkg/util/containers/v2/metrics/kubelet/collector.go
+++ b/pkg/util/containers/v2/metrics/kubelet/collector.go
@@ -1,0 +1,287 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubelet
+// +build kubelet
+
+package kubelet
+
+import (
+	"context"
+	"hash/fnv"
+	"sync"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics/provider"
+	kutil "github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+	"k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+)
+
+const (
+	contStatsCachePrefix    = "cs-"
+	contNetStatsCachePrefix = "cns-"
+	refreshCacheKey         = "refresh"
+
+	kubeletCollectorID     = "kubelet"
+	kubeletCallTimeout     = 10 * time.Second
+	kubeletCacheGCInterval = 30 * time.Second
+)
+
+func init() {
+	provider.GetProvider().RegisterCollector(provider.CollectorMetadata{
+		ID: kubeletCollectorID,
+		// Lowest priority as Kubelet stats are less detailed as we don't rely on cAdvisor
+		Priority: 2,
+		// Only runtimes implementing the CRI interface
+		Runtimes: []string{provider.RuntimeNameCRIO, provider.RuntimeNameContainerd, provider.RuntimeNameDocker},
+		Factory: func() (provider.Collector, error) {
+			return newKubeletCollector()
+		},
+		DelegateCache: false,
+	})
+}
+
+type kubeletCollector struct {
+	kubeletClient kutil.KubeUtilInterface
+	metadataStore workloadmeta.Store
+	statsCache    provider.Cache
+	refreshLock   sync.Mutex
+}
+
+func newKubeletCollector() (*kubeletCollector, error) {
+	if !config.IsFeaturePresent(config.Kubernetes) {
+		return nil, provider.ErrPermaFail
+	}
+
+	client, err := kutil.GetKubeUtil()
+	if err != nil {
+		return nil, provider.ConvertRetrierErr(err)
+	}
+
+	return &kubeletCollector{
+		kubeletClient: client,
+		statsCache:    *provider.NewCache(kubeletCacheGCInterval),
+		metadataStore: workloadmeta.GetGlobalStore(),
+	}, nil
+}
+
+// ID returns the collector ID.
+func (kc *kubeletCollector) ID() string {
+	return kubeletCollectorID
+}
+
+// GetContainerIDForPID returns a container ID for given PID.
+// ("", nil) will be returned if no error but the containerd ID was not found.
+func (kc *kubeletCollector) GetContainerIDForPID(pid int, cacheValidity time.Duration) (string, error) {
+	// Not implemented
+	return "", nil
+}
+
+// GetSelfContainerID returns the container ID for current container.
+// ("", nil) will be returned if not possible to get ID for current container.
+func (kc *kubeletCollector) GetSelfContainerID() (string, error) {
+	return "", nil
+}
+
+// GetContainerStats returns stats by container ID.
+func (kc *kubeletCollector) GetContainerStats(containerID string, cacheValidity time.Duration) (*provider.ContainerStats, error) {
+	currentTime := time.Now()
+
+	containerStats, found, err := kc.statsCache.Get(currentTime, contStatsCachePrefix+containerID, cacheValidity)
+	if found {
+		if containerStats != nil {
+			return containerStats.(*provider.ContainerStats), err
+		}
+		return nil, err
+	}
+
+	// Item missing from cache
+	if err := kc.refreshContainerCache(currentTime, cacheValidity); err != nil {
+		return nil, err
+	}
+
+	containerStats, found, err = kc.statsCache.Get(currentTime, contStatsCachePrefix+containerID, cacheValidity)
+	if found {
+		if containerStats != nil {
+			return containerStats.(*provider.ContainerStats), err
+		}
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+// GetContainerNetworkStats returns network stats by container ID.
+func (kc *kubeletCollector) GetContainerNetworkStats(containerID string, cacheValidity time.Duration) (*provider.ContainerNetworkStats, error) {
+	currentTime := time.Now()
+
+	containerNetworkStats, found, err := kc.statsCache.Get(currentTime, contNetStatsCachePrefix+containerID, cacheValidity)
+	if found {
+		if containerNetworkStats != nil {
+			return containerNetworkStats.(*provider.ContainerNetworkStats), err
+		}
+		return nil, err
+	}
+
+	// Item missing from cache
+	if err := kc.refreshContainerCache(currentTime, cacheValidity); err != nil {
+		return nil, err
+	}
+
+	containerNetworkStats, found, err = kc.statsCache.Get(currentTime, contNetStatsCachePrefix+containerID, cacheValidity)
+	if found {
+		if containerNetworkStats != nil {
+			return containerNetworkStats.(*provider.ContainerNetworkStats), err
+		}
+		return nil, err
+	}
+
+	return nil, nil
+}
+
+func (kc *kubeletCollector) refreshContainerCache(currentTime time.Time, cacheValidity time.Duration) error {
+	kc.refreshLock.Lock()
+	defer kc.refreshLock.Unlock()
+
+	// Not refreshing if last refresh is within cacheValidity
+	_, found, err := kc.statsCache.Get(currentTime, refreshCacheKey, cacheValidity)
+	if found {
+		return err
+	}
+
+	statsSummary, err := kc.getStatsSummary()
+	if err == nil {
+		kc.processStatsSummary(currentTime, statsSummary)
+	} else {
+		log.Debugf("Unable to get stats from Kubelet, err: %v", err)
+	}
+
+	kc.statsCache.Store(currentTime, refreshCacheKey, nil, err)
+	return err
+}
+
+func (kc *kubeletCollector) getStatsSummary() (*v1alpha1.Summary, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), kubeletCallTimeout)
+	statsSummary, err := kc.kubeletClient.GetLocalStatsSummary(ctx)
+	cancel()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return statsSummary, err
+}
+
+func (kc *kubeletCollector) processStatsSummary(currentTime time.Time, statsSummary *v1alpha1.Summary) {
+	if statsSummary == nil {
+		return
+	}
+
+	for _, pod := range statsSummary.Pods {
+		if len(pod.Containers) == 0 {
+			continue
+		}
+
+		// Parsing network stats, need to store them by container anyway as it's the way it works currently
+		// We use POD UID to generate an isolation group. It won't be network namespace FD, but it will still work
+		// as all containers will get the same.
+		// We could know if we're hostNetwork or not if we retrieve local POD list instead of relying on Workload meta,
+		// albeit, with extra work. As this collector is designed to run in environment where we don't have access to
+		// underlying host, it should not be an issue.
+		podNetworkStats := &provider.ContainerNetworkStats{}
+		convertNetworkStats(pod.Network, podNetworkStats)
+		podNetworkStats.NetworkIsolationGroupID = pointer.UInt64Ptr(networkIDFromPODUID(pod.PodRef.UID))
+
+		// As Metadata collector is running through polling, it can happen that we have newer PODs, containers
+		metaPod, err := kc.metadataStore.GetKubernetesPod(pod.PodRef.UID)
+		if err != nil || metaPod == nil {
+			log.Debugf("Missing metadata for POD %s/%s - skipping, err: %v", pod.PodRef.Name, pod.PodRef.Namespace, err)
+			continue
+		}
+
+		// In stats/summary we only have container name, need to remap to CID
+		nameToCID := make(map[string]string, len(metaPod.Containers))
+		for _, metaContainer := range metaPod.Containers {
+			nameToCID[metaContainer.Name] = metaContainer.ID
+		}
+
+		// Parsing stats per container
+		for _, container := range pod.Containers {
+			cID := nameToCID[container.Name]
+			if cID == "" {
+				log.Debugf("Missing container ID for POD: %s/%s, container: %s - skipping, err: %v", pod.PodRef.Name, pod.PodRef.Namespace, container.Name, err)
+				continue
+			}
+
+			containerStats := &provider.ContainerStats{}
+			convertContainerStats(&container, containerStats)
+			kc.statsCache.Store(currentTime, contStatsCachePrefix+cID, containerStats, nil)
+			kc.statsCache.Store(currentTime, contNetStatsCachePrefix+cID, podNetworkStats, nil)
+		}
+	}
+}
+
+func convertContainerStats(kubeContainerStats *v1alpha1.ContainerStats, outContainerStats *provider.ContainerStats) {
+	outContainerStats.Timestamp = kubeContainerStats.CPU.Time.Time
+
+	if kubeContainerStats.CPU != nil {
+		outContainerStats.CPU = &provider.ContainerCPUStats{
+			Total: pointer.UIntPtrToFloatPtr(kubeContainerStats.CPU.UsageCoreNanoSeconds),
+		}
+	}
+
+	if kubeContainerStats.Memory != nil {
+		outContainerStats.Memory = &provider.ContainerMemStats{
+			UsageTotal: pointer.UIntPtrToFloatPtr(kubeContainerStats.Memory.UsageBytes),
+			RSS:        pointer.UIntPtrToFloatPtr(kubeContainerStats.Memory.RSSBytes),
+		}
+
+		// On Linux `UsageBytes` is set. On Windows only `WorkingSetBytes` is set
+		if outContainerStats.Memory.UsageTotal == nil && kubeContainerStats.Memory.WorkingSetBytes != nil {
+			outContainerStats.Memory.UsageTotal = pointer.UIntPtrToFloatPtr(kubeContainerStats.Memory.WorkingSetBytes)
+			outContainerStats.Memory.PrivateWorkingSet = pointer.UIntPtrToFloatPtr(kubeContainerStats.Memory.WorkingSetBytes)
+		}
+	}
+}
+
+func convertNetworkStats(podNetworkStats *v1alpha1.NetworkStats, outNetworkStats *provider.ContainerNetworkStats) {
+	var sumBytesSent, sumBytesRcvd float64
+	outNetworkStats.Interfaces = make(map[string]provider.InterfaceNetStats, len(podNetworkStats.Interfaces))
+
+	for _, interfaceStats := range podNetworkStats.Interfaces {
+		fieldSet := false
+		outInterfaceStats := provider.InterfaceNetStats{}
+
+		if interfaceStats.TxBytes != nil {
+			fieldSet = true
+			sumBytesSent += float64(*interfaceStats.TxBytes)
+			outInterfaceStats.BytesSent = pointer.UIntPtrToFloatPtr(interfaceStats.TxBytes)
+		}
+		if interfaceStats.RxBytes != nil {
+			fieldSet = true
+			sumBytesRcvd += float64(*interfaceStats.RxBytes)
+			outInterfaceStats.BytesRcvd = pointer.UIntPtrToFloatPtr(interfaceStats.RxBytes)
+		}
+
+		if fieldSet {
+			outNetworkStats.Interfaces[interfaceStats.Name] = outInterfaceStats
+		}
+	}
+
+	if len(outNetworkStats.Interfaces) > 0 {
+		outNetworkStats.BytesSent = &sumBytesSent
+		outNetworkStats.BytesRcvd = &sumBytesRcvd
+	}
+}
+
+func networkIDFromPODUID(s string) uint64 {
+	h := fnv.New64a()
+	h.Write([]byte(s))
+	return h.Sum64()
+}

--- a/pkg/util/containers/v2/metrics/kubelet/collector_test.go
+++ b/pkg/util/containers/v2/metrics/kubelet/collector_test.go
@@ -1,0 +1,208 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubelet
+// +build kubelet
+
+package kubelet
+
+import (
+	"io/ioutil"
+	"testing"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics/provider"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet/mock"
+	"github.com/DataDog/datadog-agent/pkg/util/pointer"
+	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestKubeletCollectorLinux(t *testing.T) {
+	metadataStore := workloadmeta.NewMockStore()
+	kubeletMock := mock.NewKubeletMock()
+
+	// POD UID is c84eb7fb-09f2-11ea-abb1-42010a84017a
+	// Has containers kubedns, prometheus-to-sd, sidecar, dnsmasq
+	setStatsSummaryFromFile(t, "./testdata/statsSummaryLinux.json", kubeletMock)
+	metadataStore.SetEntity(&workloadmeta.KubernetesPod{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesPod,
+			ID:   "c84eb7fb-09f2-11ea-abb1-42010a84017a",
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name:      "kube-dns-5877696fb4-m6cvp",
+			Namespace: "kube-system",
+		},
+		Containers: []workloadmeta.OrchestratorContainer{
+			{
+				ID:   "cID1",
+				Name: "kubedns",
+			},
+			{
+				ID:   "cID2",
+				Name: "prometheus-to-sd",
+			},
+			{
+				ID:   "cID3",
+				Name: "sidecar",
+			},
+		},
+	})
+
+	kubeletCollector := &kubeletCollector{
+		kubeletClient: kubeletMock,
+		metadataStore: metadataStore,
+	}
+
+	// On first `GetContainerStats`, the full data is read and cache is filled
+	expectedTime, _ := time.Parse(time.RFC3339, "2019-11-20T13:13:13Z")
+	expectedTime = expectedTime.Local()
+	cID1Stats, err := kubeletCollector.GetContainerStats("cID1", time.Minute)
+	// Removing content from kubeletMock to make sure anything we hit is from cache
+	clearFakeStatsSummary(kubeletMock)
+
+	assert.NoError(t, err)
+	assert.Equal(t, &provider.ContainerStats{
+		Timestamp: expectedTime,
+		CPU: &provider.ContainerCPUStats{
+			Total: pointer.Float64Ptr(194414788585),
+		},
+		Memory: &provider.ContainerMemStats{
+			UsageTotal: pointer.Float64Ptr(12713984),
+			RSS:        pointer.Float64Ptr(12238848),
+		},
+	}, cID1Stats)
+
+	expectedTime, _ = time.Parse(time.RFC3339, "2019-11-20T13:13:09Z")
+	expectedTime = expectedTime.Local()
+	cID2Stats, err := kubeletCollector.GetContainerStats("cID2", time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, &provider.ContainerStats{
+		Timestamp: expectedTime,
+		CPU: &provider.ContainerCPUStats{
+			Total: pointer.Float64Ptr(12460233103),
+		},
+		Memory: &provider.ContainerMemStats{
+			UsageTotal: pointer.Float64Ptr(6705152),
+			RSS:        pointer.Float64Ptr(6119424),
+		},
+	}, cID2Stats)
+
+	expectedTime, _ = time.Parse(time.RFC3339, "2019-11-20T13:13:16Z")
+	expectedTime = expectedTime.Local()
+	cID3Stats, err := kubeletCollector.GetContainerStats("cID3", time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, &provider.ContainerStats{
+		Timestamp: expectedTime,
+		CPU: &provider.ContainerCPUStats{
+			Total: pointer.Float64Ptr(139979939975),
+		},
+		Memory: &provider.ContainerMemStats{
+			UsageTotal: pointer.Float64Ptr(11325440),
+			RSS:        pointer.Float64Ptr(10797056),
+		},
+	}, cID3Stats)
+
+	// Test network stats
+	expectedPodNetworkStats := &provider.ContainerNetworkStats{
+		BytesRcvd: pointer.Float64Ptr(254942755),
+		BytesSent: pointer.Float64Ptr(137422821),
+		Interfaces: map[string]provider.InterfaceNetStats{
+			"eth0": {
+				BytesRcvd: pointer.Float64Ptr(254942755),
+				BytesSent: pointer.Float64Ptr(137422821),
+			},
+		},
+		NetworkIsolationGroupID: pointer.UInt64Ptr(17659160645723176180),
+	}
+
+	cID3NetworkStats, err := kubeletCollector.GetContainerNetworkStats("cID3", time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedPodNetworkStats, cID3NetworkStats)
+
+	cID2NetworkStats, err := kubeletCollector.GetContainerNetworkStats("cID2", time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, expectedPodNetworkStats, cID2NetworkStats)
+
+	// Test getting stats for an unknown container, should answer without data but without error (no API call triggered)
+	cID4Stats, err := kubeletCollector.GetContainerStats("cID4", time.Minute)
+	assert.NoError(t, err)
+	assert.Nil(t, cID4Stats)
+
+	// Forcing a refresh, will trigger a Kubelet call (which will answer with 404 Not found)
+	cID1Stats, err = kubeletCollector.GetContainerStats("cID1", 0)
+	assert.Equal(t, err.Error(), "Unable to fetch stats summary from Kubelet, rc: 404")
+	assert.Nil(t, cID1Stats)
+}
+
+func TestKubeletCollectorWindows(t *testing.T) {
+	metadataStore := workloadmeta.NewMockStore()
+	kubeletMock := mock.NewKubeletMock()
+
+	// POD UID is 8ddf0e3f-ac6c-4d44-87d7-0bc41f6729ec
+	// Has containers trace-agent, agent, process-agent
+	setStatsSummaryFromFile(t, "./testdata/statsSummaryWindows.json", kubeletMock)
+	metadataStore.SetEntity(&workloadmeta.KubernetesPod{
+		EntityID: workloadmeta.EntityID{
+			Kind: workloadmeta.KindKubernetesPod,
+			ID:   "8ddf0e3f-ac6c-4d44-87d7-0bc41f6729ec",
+		},
+		EntityMeta: workloadmeta.EntityMeta{
+			Name:      "dd-datadog-lbvkl",
+			Namespace: "default",
+		},
+		Containers: []workloadmeta.OrchestratorContainer{
+			{
+				ID:   "cID1",
+				Name: "process-agent",
+			},
+		},
+	})
+
+	kubeletCollector := &kubeletCollector{
+		kubeletClient: kubeletMock,
+		metadataStore: metadataStore,
+	}
+
+	// On first `GetContainerStats`, the full data is read and cache is filled
+	expectedTime, _ := time.Parse(time.RFC3339, "2020-04-24T15:54:14Z")
+	expectedTime = expectedTime.Local()
+	cID1Stats, err := kubeletCollector.GetContainerStats("cID1", time.Minute)
+	assert.NoError(t, err)
+	assert.Equal(t, &provider.ContainerStats{
+		Timestamp: expectedTime,
+		CPU: &provider.ContainerCPUStats{
+			Total: pointer.Float64Ptr(9359375000),
+		},
+		Memory: &provider.ContainerMemStats{
+			UsageTotal:        pointer.Float64Ptr(65474560),
+			PrivateWorkingSet: pointer.Float64Ptr(65474560),
+		},
+	}, cID1Stats)
+}
+
+func setStatsSummaryFromFile(t *testing.T, filePath string, kubeletMock *mock.KubeletMock) {
+	t.Helper()
+
+	content, err := ioutil.ReadFile(filePath)
+	if err != nil {
+		t.Errorf("unable to read test file at: %s, err: %v", filePath, err)
+	}
+
+	setFakeStatsSummary(kubeletMock, content, 200, nil)
+}
+
+func setFakeStatsSummary(kubeletMock *mock.KubeletMock, content []byte, rc int, err error) {
+	kubeletMock.MockReplies["/stats/summary"] = &mock.HTTPReplyMock{
+		Data:         content,
+		ResponseCode: rc,
+		Error:        err,
+	}
+}
+
+func clearFakeStatsSummary(kubeletMock *mock.KubeletMock) {
+	delete(kubeletMock.MockReplies, "/stats/summary")
+}

--- a/pkg/util/containers/v2/metrics/kubelet/doc.go
+++ b/pkg/util/containers/v2/metrics/kubelet/doc.go
@@ -1,0 +1,6 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2021-present Datadog, Inc.
+
+package kubelet

--- a/pkg/util/containers/v2/metrics/kubelet/testdata/statsSummaryLinux.json
+++ b/pkg/util/containers/v2/metrics/kubelet/testdata/statsSummaryLinux.json
@@ -1,0 +1,344 @@
+{
+    "node": {
+        "nodeName": "gke-lenaic-pool-1-1c8b424c-wnkn",
+        "systemContainers": [
+            {
+                "name": "kubelet",
+                "startTime": "2019-11-15T14:40:15Z",
+                "cpu": {
+                    "time": "2019-11-20T13:13:13Z",
+                    "usageNanoCores": 36755862,
+                    "usageCoreNanoSeconds": 14274249717788
+                },
+                "memory": {
+                    "time": "2019-11-20T13:13:13Z",
+                    "usageBytes": 127561728,
+                    "workingSetBytes": 77357056,
+                    "rssBytes": 88477696,
+                    "pageFaults": 11231616,
+                    "majorPageFaults": 231
+                },
+                "userDefinedMetrics": null
+            },
+            {
+                "name": "runtime",
+                "startTime": "2019-11-15T14:40:16Z",
+                "cpu": {
+                    "time": "2019-11-20T13:13:16Z",
+                    "usageNanoCores": 19442853,
+                    "usageCoreNanoSeconds": 6216352123769
+                },
+                "memory": {
+                    "time": "2019-11-20T13:13:16Z",
+                    "usageBytes": 2077380608,
+                    "workingSetBytes": 650326016,
+                    "rssBytes": 101273600,
+                    "pageFaults": 790383,
+                    "majorPageFaults": 0
+                },
+                "userDefinedMetrics": null
+            },
+            {
+                "name": "pods",
+                "startTime": "2019-11-15T14:40:16Z",
+                "cpu": {
+                    "time": "2019-11-20T13:13:10Z",
+                    "usageNanoCores": 50110616,
+                    "usageCoreNanoSeconds": 23207698646433
+                },
+                "memory": {
+                    "time": "2019-11-20T13:13:10Z",
+                    "availableBytes": 2406899712,
+                    "usageBytes": 599695360,
+                    "workingSetBytes": 464281600,
+                    "rssBytes": 419045376,
+                    "pageFaults": 0,
+                    "majorPageFaults": 0
+                },
+                "userDefinedMetrics": null
+            }
+        ],
+        "startTime": "2019-11-15T14:39:52Z",
+        "cpu": {
+            "time": "2019-11-20T13:13:10Z",
+            "usageNanoCores": 112148031,
+            "usageCoreNanoSeconds": 49365244626551
+        },
+        "memory": {
+            "time": "2019-11-20T13:13:10Z",
+            "availableBytes": 2429980672,
+            "usageBytes": 3229667328,
+            "workingSetBytes": 1447833600,
+            "rssBytes": 742707200,
+            "pageFaults": 76329,
+            "majorPageFaults": 66
+        },
+        "network": {
+            "time": "2019-11-20T13:13:10Z",
+            "name": "eth0",
+            "rxBytes": 6368322541,
+            "rxErrors": 0,
+            "txBytes": 5864590736,
+            "txErrors": 0,
+            "interfaces": [
+                {
+                    "name": "cbr0",
+                    "rxBytes": 1721361279,
+                    "rxErrors": 0,
+                    "txBytes": 12179135997,
+                    "txErrors": 0
+                },
+                {
+                    "name": "eth0",
+                    "rxBytes": 6368322541,
+                    "rxErrors": 0,
+                    "txBytes": 5864590736,
+                    "txErrors": 0
+                }
+            ]
+        },
+        "fs": {
+            "time": "2019-11-20T13:13:10Z",
+            "availableBytes": 96644841472,
+            "capacityBytes": 101241290752,
+            "usedBytes": 4579672064,
+            "inodesFree": 6131709,
+            "inodes": 6258720,
+            "inodesUsed": 127011
+        },
+        "runtime": {
+            "imageFs": {
+                "time": "2019-11-20T13:13:10Z",
+                "availableBytes": 96644841472,
+                "capacityBytes": 101241290752,
+                "usedBytes": 4808304320,
+                "inodesFree": 6131709,
+                "inodes": 6258720,
+                "inodesUsed": 127011
+            }
+        },
+        "rlimit": {
+            "time": "2019-11-20T13:13:16Z",
+            "maxpid": 4194304,
+            "curproc": 623
+        }
+    },
+    "pods": [
+        {
+            "podRef": {
+                "name": "kube-dns-5877696fb4-m6cvp",
+                "namespace": "kube-system",
+                "uid": "c84eb7fb-09f2-11ea-abb1-42010a84017a"
+            },
+            "startTime": "2019-11-18T11:01:33Z",
+            "containers": [
+                {
+                    "name": "kubedns",
+                    "startTime": "2019-11-18T11:01:42Z",
+                    "cpu": {
+                        "time": "2019-11-20T13:13:13Z",
+                        "usageNanoCores": 973655,
+                        "usageCoreNanoSeconds": 194414788585
+                    },
+                    "memory": {
+                        "time": "2019-11-20T13:13:13Z",
+                        "availableBytes": 165543936,
+                        "usageBytes": 12713984,
+                        "workingSetBytes": 12713984,
+                        "rssBytes": 12238848,
+                        "pageFaults": 13101,
+                        "majorPageFaults": 0
+                    },
+                    "rootfs": {
+                        "time": "2019-11-20T13:13:13Z",
+                        "availableBytes": 96644841472,
+                        "capacityBytes": 101241290752,
+                        "usedBytes": 24576,
+                        "inodesFree": 6131709,
+                        "inodes": 6258720,
+                        "inodesUsed": 6
+                    },
+                    "logs": {
+                        "time": "2019-11-20T13:13:13Z",
+                        "availableBytes": 96644841472,
+                        "capacityBytes": 101241290752,
+                        "usedBytes": 45056,
+                        "inodesFree": 6131709,
+                        "inodes": 6258720,
+                        "inodesUsed": 127011
+                    },
+                    "userDefinedMetrics": null
+                },
+                {
+                    "name": "prometheus-to-sd",
+                    "startTime": "2019-11-18T11:01:56Z",
+                    "cpu": {
+                        "time": "2019-11-20T13:13:09Z",
+                        "usageNanoCores": 109829,
+                        "usageCoreNanoSeconds": 12460233103
+                    },
+                    "memory": {
+                        "time": "2019-11-20T13:13:09Z",
+                        "usageBytes": 6705152,
+                        "workingSetBytes": 6705152,
+                        "rssBytes": 6119424,
+                        "pageFaults": 9603,
+                        "majorPageFaults": 0
+                    },
+                    "rootfs": {
+                        "time": "2019-11-20T13:13:09Z",
+                        "availableBytes": 96644841472,
+                        "capacityBytes": 101241290752,
+                        "usedBytes": 28672,
+                        "inodesFree": 6131709,
+                        "inodes": 6258720,
+                        "inodesUsed": 6
+                    },
+                    "logs": {
+                        "time": "2019-11-20T13:13:09Z",
+                        "availableBytes": 96644841472,
+                        "capacityBytes": 101241290752,
+                        "usedBytes": 1277952,
+                        "inodesFree": 6131709,
+                        "inodes": 6258720,
+                        "inodesUsed": 127011
+                    },
+                    "userDefinedMetrics": null
+                },
+                {
+                    "name": "sidecar",
+                    "startTime": "2019-11-18T11:01:54Z",
+                    "cpu": {
+                        "time": "2019-11-20T13:13:16Z",
+                        "usageNanoCores": 639834,
+                        "usageCoreNanoSeconds": 139979939975
+                    },
+                    "memory": {
+                        "time": "2019-11-20T13:13:16Z",
+                        "usageBytes": 11325440,
+                        "workingSetBytes": 11325440,
+                        "rssBytes": 10797056,
+                        "pageFaults": 7722,
+                        "majorPageFaults": 0
+                    },
+                    "rootfs": {
+                        "time": "2019-11-20T13:13:16Z",
+                        "availableBytes": 96644841472,
+                        "capacityBytes": 101241290752,
+                        "usedBytes": 20480,
+                        "inodesFree": 6131709,
+                        "inodes": 6258720,
+                        "inodesUsed": 5
+                    },
+                    "logs": {
+                        "time": "2019-11-20T13:13:16Z",
+                        "availableBytes": 96644841472,
+                        "capacityBytes": 101241290752,
+                        "usedBytes": 28672,
+                        "inodesFree": 6131709,
+                        "inodes": 6258720,
+                        "inodesUsed": 127011
+                    },
+                    "userDefinedMetrics": null
+                },
+                {
+                    "name": "dnsmasq",
+                    "startTime": "2019-11-18T11:01:51Z",
+                    "cpu": {
+                        "time": "2019-11-20T13:13:10Z",
+                        "usageNanoCores": 155155,
+                        "usageCoreNanoSeconds": 25799788032
+                    },
+                    "memory": {
+                        "time": "2019-11-20T13:13:10Z",
+                        "usageBytes": 6283264,
+                        "workingSetBytes": 6279168,
+                        "rssBytes": 5586944,
+                        "pageFaults": 4950,
+                        "majorPageFaults": 0
+                    },
+                    "rootfs": {
+                        "time": "2019-11-20T13:13:10Z",
+                        "availableBytes": 96644841472,
+                        "capacityBytes": 101241290752,
+                        "usedBytes": 24576,
+                        "inodesFree": 6131709,
+                        "inodes": 6258720,
+                        "inodesUsed": 6
+                    },
+                    "logs": {
+                        "time": "2019-11-20T13:13:10Z",
+                        "availableBytes": 96644841472,
+                        "capacityBytes": 101241290752,
+                        "usedBytes": 28672,
+                        "inodesFree": 6131709,
+                        "inodes": 6258720,
+                        "inodesUsed": 127011
+                    },
+                    "userDefinedMetrics": null
+                }
+            ],
+            "cpu": {
+                "time": "2019-11-20T13:13:04Z",
+                "usageNanoCores": 2423692,
+                "usageCoreNanoSeconds": 372679572873
+            },
+            "memory": {
+                "time": "2019-11-20T13:13:04Z",
+                "usageBytes": 37384192,
+                "workingSetBytes": 37380096,
+                "rssBytes": 34746368,
+                "pageFaults": 0,
+                "majorPageFaults": 0
+            },
+            "network": {
+                "time": "2019-11-20T13:13:16Z",
+                "name": "eth0",
+                "rxBytes": 254942755,
+                "rxErrors": 0,
+                "txBytes": 137422821,
+                "txErrors": 0,
+                "interfaces": [
+                    {
+                        "name": "eth0",
+                        "rxBytes": 254942755,
+                        "rxErrors": 0,
+                        "txBytes": 137422821,
+                        "txErrors": 0
+                    }
+                ]
+            },
+            "volume": [
+                {
+                    "time": "2019-11-18T11:02:17Z",
+                    "availableBytes": 97543753728,
+                    "capacityBytes": 101241290752,
+                    "usedBytes": 8192,
+                    "inodesFree": 6154488,
+                    "inodes": 6258720,
+                    "inodesUsed": 3,
+                    "name": "kube-dns-config"
+                },
+                {
+                    "time": "2019-11-18T11:02:17Z",
+                    "availableBytes": 1938894848,
+                    "capacityBytes": 1938907136,
+                    "usedBytes": 12288,
+                    "inodesFree": 473357,
+                    "inodes": 473366,
+                    "inodesUsed": 9,
+                    "name": "kube-dns-token-8gwlt"
+                }
+            ],
+            "ephemeral-storage": {
+                "time": "2019-11-20T13:13:16Z",
+                "availableBytes": 96644841472,
+                "capacityBytes": 101241290752,
+                "usedBytes": 1486848,
+                "inodesFree": 6131709,
+                "inodes": 6258720,
+                "inodesUsed": 26
+            }
+        }
+    ]
+}

--- a/pkg/util/containers/v2/metrics/kubelet/testdata/statsSummaryWindows.json
+++ b/pkg/util/containers/v2/metrics/kubelet/testdata/statsSummaryWindows.json
@@ -1,0 +1,328 @@
+{
+    "node": {
+        "nodeName": "ip-172-29-160-189.ec2.internal",
+        "systemContainers": [
+            {
+                "name": "pods",
+                "startTime": "2020-04-24T15:54:20Z",
+                "cpu": {
+                    "time": "2020-04-24T15:54:20Z",
+                    "usageNanoCores": 760136190,
+                    "usageCoreNanoSeconds": 103250000000
+                },
+                "memory": {
+                    "time": "2020-04-24T15:54:20Z",
+                    "workingSetBytes": 401727488
+                },
+                "userDefinedMetrics": null
+            }
+        ],
+        "startTime": "2020-04-24T15:44:31Z",
+        "cpu": {
+            "time": "2020-04-24T15:54:11Z",
+            "usageNanoCores": 500000000,
+            "usageCoreNanoSeconds": 452800000000
+        },
+        "memory": {
+            "time": "2020-04-24T15:54:11Z",
+            "availableBytes": 15852421120,
+            "usageBytes": 2893811712,
+            "workingSetBytes": 924364800,
+            "rssBytes": 0,
+            "pageFaults": 0,
+            "majorPageFaults": 0
+        },
+        "network": {
+            "time": "2020-04-24T15:54:11Z",
+            "name": "",
+            "interfaces": [
+                {
+                    "name": "6to4 Adapter",
+                    "rxBytes": 0,
+                    "rxErrors": 0,
+                    "txBytes": 0,
+                    "txErrors": 0
+                },
+                {
+                    "name": "Hyper-V Virtual Ethernet Adapter _2",
+                    "rxBytes": 1149346892,
+                    "rxErrors": 0,
+                    "txBytes": 4186701,
+                    "txErrors": 0
+                },
+                {
+                    "name": "Hyper-V Virtual Switch Extension Adapter _2",
+                    "rxBytes": 0,
+                    "rxErrors": 0,
+                    "txBytes": 0,
+                    "txErrors": 0
+                },
+                {
+                    "name": "AWS PV Network Device",
+                    "rxBytes": 0,
+                    "rxErrors": 0,
+                    "txBytes": 0,
+                    "txErrors": 0
+                },
+                {
+                    "name": "Hyper-V Virtual Switch Extension Adapter",
+                    "rxBytes": 0,
+                    "rxErrors": 0,
+                    "txBytes": 0,
+                    "txErrors": 0
+                },
+                {
+                    "name": "Teredo Tunneling Pseudo-Interface",
+                    "rxBytes": 0,
+                    "rxErrors": 0,
+                    "txBytes": 0,
+                    "txErrors": 0
+                },
+                {
+                    "name": "Amazon Elastic Network Adapter",
+                    "rxBytes": 1150147728,
+                    "rxErrors": 0,
+                    "txBytes": 4278314,
+                    "txErrors": 0
+                },
+                {
+                    "name": "Microsoft IP-HTTPS Platform Interface",
+                    "rxBytes": 0,
+                    "rxErrors": 0,
+                    "txBytes": 0,
+                    "txErrors": 0
+                },
+                {
+                    "name": "Hyper-V Virtual Ethernet Adapter",
+                    "rxBytes": 0,
+                    "rxErrors": 0,
+                    "txBytes": 272,
+                    "txErrors": 0
+                },
+                {
+                    "name": "Microsoft Kernel Debug Network Adapter",
+                    "rxBytes": 0,
+                    "rxErrors": 0,
+                    "txBytes": 0,
+                    "txErrors": 0
+                }
+            ]
+        },
+        "fs": {
+            "time": "2020-04-24T15:54:11Z",
+            "availableBytes": 80788066304,
+            "capacityBytes": 107372081152,
+            "usedBytes": 26584014848
+        },
+        "runtime": {
+            "imageFs": {
+                "time": "2020-04-24T15:54:12Z",
+                "availableBytes": 80788066304,
+                "capacityBytes": 107372081152,
+                "usedBytes": 26584014848
+            }
+        }
+    },
+    "pods": [
+        {
+            "podRef": {
+                "name": "dd-datadog-lbvkl",
+                "namespace": "default",
+                "uid": "8ddf0e3f-ac6c-4d44-87d7-0bc41f6729ec"
+            },
+            "startTime": "2020-04-24T15:48:04Z",
+            "containers": [
+                {
+                    "name": "process-agent",
+                    "startTime": "2020-04-24T15:53:40Z",
+                    "cpu": {
+                        "time": "2020-04-24T15:54:14Z",
+                        "usageCoreNanoSeconds": 9359375000
+                    },
+                    "memory": {
+                        "time": "2020-04-24T15:54:14Z",
+                        "workingSetBytes": 65474560
+                    },
+                    "rootfs": {
+                        "time": "2020-04-24T15:54:14Z",
+                        "availableBytes": 80754503680,
+                        "capacityBytes": 107372081152,
+                        "usedBytes": 0
+                    },
+                    "logs": {
+                        "time": "2020-04-24T15:54:20Z",
+                        "availableBytes": 80788066304,
+                        "capacityBytes": 107372081152,
+                        "usedBytes": 0,
+                        "inodesUsed": 0
+                    },
+                    "userDefinedMetrics": null
+                },
+                {
+                    "name": "trace-agent",
+                    "startTime": "2020-04-24T15:53:38Z",
+                    "cpu": {
+                        "time": "2020-04-24T15:54:16Z",
+                        "usageNanoCores": 343426740,
+                        "usageCoreNanoSeconds": 9953125000
+                    },
+                    "memory": {
+                        "time": "2020-04-24T15:54:16Z",
+                        "workingSetBytes": 63348736
+                    },
+                    "rootfs": {
+                        "time": "2020-04-24T15:54:16Z",
+                        "availableBytes": 80754503680,
+                        "capacityBytes": 107372081152,
+                        "usedBytes": 0
+                    },
+                    "logs": {
+                        "time": "2020-04-24T15:54:20Z",
+                        "availableBytes": 80788066304,
+                        "capacityBytes": 107372081152,
+                        "usedBytes": 0,
+                        "inodesUsed": 0
+                    },
+                    "userDefinedMetrics": null
+                },
+                {
+                    "name": "agent",
+                    "startTime": "2020-04-24T15:53:37Z",
+                    "cpu": {
+                        "time": "2020-04-24T15:54:18Z",
+                        "usageNanoCores": 415804288,
+                        "usageCoreNanoSeconds": 13796875000
+                    },
+                    "memory": {
+                        "time": "2020-04-24T15:54:18Z",
+                        "workingSetBytes": 136089600
+                    },
+                    "rootfs": {
+                        "time": "2020-04-24T15:54:18Z",
+                        "availableBytes": 80754503680,
+                        "capacityBytes": 107372081152,
+                        "usedBytes": 0
+                    },
+                    "logs": {
+                        "time": "2020-04-24T15:54:20Z",
+                        "availableBytes": 80788066304,
+                        "capacityBytes": 107372081152,
+                        "usedBytes": 0,
+                        "inodesUsed": 0
+                    },
+                    "userDefinedMetrics": null
+                },
+                {
+                    "name": "init-config",
+                    "startTime": "2020-04-24T15:53:20Z",
+                    "cpu": {
+                        "time": "2020-04-24T15:54:18Z",
+                        "usageNanoCores": 0,
+                        "usageCoreNanoSeconds": 0
+                    },
+                    "memory": {
+                        "time": "2020-04-24T15:54:18Z",
+                        "workingSetBytes": 0
+                    },
+                    "rootfs": {
+                        "time": "2020-04-24T15:54:18Z",
+                        "availableBytes": 80754503680,
+                        "capacityBytes": 107372081152,
+                        "usedBytes": 0
+                    },
+                    "logs": {
+                        "time": "2020-04-24T15:54:20Z",
+                        "availableBytes": 80788066304,
+                        "capacityBytes": 107372081152,
+                        "usedBytes": 0,
+                        "inodesUsed": 0
+                    },
+                    "userDefinedMetrics": null
+                },
+                {
+                    "name": "init-volume",
+                    "startTime": "2020-04-24T15:53:01Z",
+                    "cpu": {
+                        "time": "2020-04-24T15:54:18Z",
+                        "usageNanoCores": 0,
+                        "usageCoreNanoSeconds": 0
+                    },
+                    "memory": {
+                        "time": "2020-04-24T15:54:18Z",
+                        "workingSetBytes": 0
+                    },
+                    "rootfs": {
+                        "time": "2020-04-24T15:54:18Z",
+                        "availableBytes": 80754503680,
+                        "capacityBytes": 107372081152,
+                        "usedBytes": 0
+                    },
+                    "logs": {
+                        "time": "2020-04-24T15:54:20Z",
+                        "availableBytes": 80788066304,
+                        "capacityBytes": 107372081152,
+                        "usedBytes": 0,
+                        "inodesUsed": 0
+                    },
+                    "userDefinedMetrics": null
+                }
+            ],
+            "cpu": {
+                "time": "2020-04-24T15:53:01Z",
+                "usageNanoCores": 759231028,
+                "usageCoreNanoSeconds": 33109375000
+            },
+            "memory": {
+                "time": "2020-04-24T15:54:18Z",
+                "availableBytes": 0,
+                "usageBytes": 0,
+                "workingSetBytes": 264912896,
+                "rssBytes": 0,
+                "pageFaults": 0,
+                "majorPageFaults": 0
+            },
+            "network": {
+                "time": "2020-04-24T15:54:20Z",
+                "name": "cid-41dfe66c6f1f5597dbdf6ab1029b4cf72baa10b530e85685adcd6105ad70d70a",
+                "rxBytes": 694636,
+                "txBytes": 163670,
+                "interfaces": [
+                    {
+                        "name": "cid-41dfe66c6f1f5597dbdf6ab1029b4cf72baa10b530e85685adcd6105ad70d70a",
+                        "rxBytes": 694636,
+                        "txBytes": 163670
+                    }
+                ]
+            },
+            "volume": [
+                {
+                    "time": "2020-04-24T15:53:27Z",
+                    "availableBytes": 81055125504,
+                    "capacityBytes": 107372081152,
+                    "usedBytes": 919980,
+                    "inodesFree": 0,
+                    "inodes": 0,
+                    "inodesUsed": 0,
+                    "name": "config"
+                },
+                {
+                    "time": "2020-04-24T15:48:50Z",
+                    "availableBytes": 82672992256,
+                    "capacityBytes": 107372081152,
+                    "usedBytes": 5982,
+                    "inodesFree": 0,
+                    "inodes": 0,
+                    "inodesUsed": 0,
+                    "name": "dd-datadog-token-8lqzd"
+                }
+            ],
+            "ephemeral-storage": {
+                "time": "2020-04-24T15:54:20Z",
+                "availableBytes": 80788066304,
+                "capacityBytes": 107372081152,
+                "usedBytes": 919980,
+                "inodesUsed": 0
+            }
+        }
+    ]
+}

--- a/pkg/util/containers/v2/metrics/provider/provider.go
+++ b/pkg/util/containers/v2/metrics/provider/provider.go
@@ -22,6 +22,7 @@ const (
 	RuntimeNameContainerd string = "containerd"
 	RuntimeNameCRIO       string = "cri-o"
 	RuntimeNameGarden     string = "garden"
+	RuntimeNamePodman     string = "podman"
 )
 
 const (
@@ -51,7 +52,9 @@ var (
 		RuntimeNameContainerd,
 		RuntimeNameCRIO,
 		RuntimeNameGarden,
+		RuntimeNamePodman,
 	}
+
 	// AllWindowsRuntimes lists all runtimes available on Windows
 	// nolint: deadcode, unused
 	AllWindowsRuntimes = []string{

--- a/pkg/util/kubernetes/kubelet/kubelet_interface.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_interface.go
@@ -12,6 +12,8 @@ import (
 	"context"
 
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
+
+	kubeletv1alpha1 "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 )
 
 // KubeUtilInterface defines the interface for kubelet api
@@ -33,4 +35,5 @@ type KubeUtilInterface interface {
 	IsAgentHostNetwork(ctx context.Context) (bool, error)
 	ListContainers(ctx context.Context) ([]*containers.Container, error)
 	UpdateContainerMetrics(ctrList []*containers.Container) error
+	GetLocalStatsSummary(ctx context.Context) (*kubeletv1alpha1.Summary, error)
 }

--- a/pkg/util/kubernetes/kubelet/kubelet_orchestrator.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_orchestrator.go
@@ -17,6 +17,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	clientsetscheme "k8s.io/client-go/kubernetes/scheme"
+	kubeletv1alpha1 "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 )
 
 // KubeUtilInterface defines the interface for kubelet api
@@ -39,12 +40,12 @@ type KubeUtilInterface interface {
 	IsAgentHostNetwork(ctx context.Context) (bool, error)
 	UpdateContainerMetrics(ctrList []*containers.Container) error
 	GetRawLocalPodList(ctx context.Context) ([]*v1.Pod, error)
+	GetLocalStatsSummary(ctx context.Context) (*kubeletv1alpha1.Summary, error)
 }
 
 // GetRawLocalPodList returns the unfiltered pod list from the kubelet
 func (ku *KubeUtil) GetRawLocalPodList(ctx context.Context) ([]*v1.Pod, error) {
 	data, code, err := ku.QueryKubelet(ctx, kubeletPodPath)
-
 	if err != nil {
 		return nil, fmt.Errorf("error performing kubelet query %s%s: %s", ku.kubeletClient.kubeletURL, kubeletPodPath, err)
 	}

--- a/pkg/util/kubernetes/kubelet/mock/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/mock/kubelet.go
@@ -1,0 +1,68 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubelet
+// +build kubelet
+
+package mock
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
+
+	kubeletv1alpha1 "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
+)
+
+// HTTPReplyMock represents a fake HTTP reply
+type HTTPReplyMock struct {
+	Data         []byte
+	ResponseCode int
+	Error        error
+}
+
+// KubeletMock is a fake Kubelet implementation
+type KubeletMock struct {
+	kubelet.KubeUtil
+	MockReplies map[string]*HTTPReplyMock
+}
+
+// NewKubeletMock returns a mock instance
+func NewKubeletMock() *KubeletMock {
+	return &KubeletMock{
+		MockReplies: make(map[string]*HTTPReplyMock),
+	}
+}
+
+// QueryKubelet overrides base implementation using HTTPReplyMock
+func (km *KubeletMock) QueryKubelet(ctx context.Context, path string) ([]byte, int, error) {
+	reply := km.MockReplies[path]
+	if reply != nil {
+		return reply.Data, reply.ResponseCode, reply.Error
+	}
+
+	return nil, http.StatusNotFound, nil
+}
+
+func (km *KubeletMock) GetLocalStatsSummary(ctx context.Context) (*kubeletv1alpha1.Summary, error) {
+	data, rc, err := km.QueryKubelet(ctx, "/stats/summary")
+	if err != nil {
+		return nil, err
+	}
+
+	if rc != http.StatusOK {
+		return nil, fmt.Errorf("Unable to fetch stats summary from Kubelet, rc: %d", rc)
+	}
+
+	statsSummary := &kubeletv1alpha1.Summary{}
+	if err := json.Unmarshal(data, statsSummary); err != nil {
+		return nil, err
+	}
+
+	return statsSummary, nil
+}

--- a/pkg/util/pointer/pointer.go
+++ b/pkg/util/pointer/pointer.go
@@ -27,6 +27,16 @@ func UIntToFloatPtr(u uint64) *float64 {
 	return &f
 }
 
+// UIntPtrToFloatPtr converts a uint64 value to float64 and returns a pointer.
+func UIntPtrToFloatPtr(u *uint64) *float64 {
+	if u == nil {
+		return nil
+	}
+
+	f := float64(*u)
+	return &f
+}
+
 // BoolPtr returns a pointer from a value. It will allocate a new heap object for it.
 func BoolPtr(b bool) *bool {
 	return &b


### PR DESCRIPTION
### What does this PR do?

Add a Kubelet collector in generic metrics provider to provide minimal metrics when running in environment without any access to underlying host or container runtime socket.

### Motivation

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

The new `kubelet` provider has priority 2, which means it will never be used except if running in Kubernetes and no other provider are available.
This can be tested on EKS Fargate through the generic `container` check and through the Live Container View

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
