### PR TITLE
Minor fixes to "Include static tags in dogstatsd metrics in hostless situations"

### DIFF
--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -291,7 +291,6 @@ func NewServer(demultiplexer aggregator.Demultiplexer, extraTags []string) (*Ser
 	// if the server is running in a context where static tags are required, add those
 	// to extraTags.
 	if staticTags := util.GetStaticTagsSlice(context.TODO()); staticTags != nil {
-		extraTags = append([]string{}, extraTags...)
 		extraTags = append(extraTags, staticTags...)
 	}
 	util.SortUniqInPlace(extraTags)

--- a/releasenotes/notes/dd-tags-fargate-f421600265ef18a4.yaml
+++ b/releasenotes/notes/dd-tags-fargate-f421600265ef18a4.yaml
@@ -8,4 +8,4 @@
 ---
 enhancements:
   - |
-    Tags configured with `DD_TAGS` or `DD_EXTRA_TAGS` in an EKS Fargate environment are now attached to Dogstatsd metrics.
+    Tags configured with `DD_TAGS` or `DD_EXTRA_TAGS` in an ECS Fargate or EKS Fargate environment are now attached to Dogstatsd metrics.


### PR DESCRIPTION
Minor fixes from review in #10952.
