### PR TITLE
Minor updates to logs-agent tailers and launchers

### DIFF
--- a/pkg/logs/agent.go
+++ b/pkg/logs/agent.go
@@ -33,12 +33,8 @@ import (
 )
 
 // Agent represents the data pipeline that collects, decodes,
-// processes and sends logs to the backend
-// + --------------------------------------------------------------------------------- +
-// |                                                                                   |
-// | Collector -> Decoder -> Processor -> Strategy -> Sender -> Destination -> Auditor |
-// |                                                                                   |
-// + --------------------------------------------------------------------------------- +
+// processes and sends logs to the backend.  See the package README for
+// a description of its operation.
 type Agent struct {
 	auditor                   auditor.Auditor
 	destinationsCtx           *client.DestinationsContext

--- a/pkg/logs/internal/launchers/file/launcher.go
+++ b/pkg/logs/internal/launchers/file/launcher.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
-	"sync/atomic"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -139,7 +138,7 @@ func (s *Launcher) scan() {
 		// tailer is tailing the file for the new container).
 		tailerKey := file.GetScanKey()
 		tailer, isTailed := s.tailers[tailerKey]
-		if isTailed && atomic.LoadInt32(&tailer.ShouldStop) != 0 {
+		if isTailed && tailer.IsFinished() {
 			// skip this tailer as it must be stopped
 			continue
 		}

--- a/pkg/logs/internal/tailers/docker/reader.go
+++ b/pkg/logs/internal/tailers/docker/reader.go
@@ -15,6 +15,10 @@ import (
 
 var errReaderNotInitialized = errors.New("reader not initialized")
 
+// safeReader wraps an io.ReadCloser in such a way that a nil reader is
+// treated as a recoverable error and does not cause a panic.  This is a
+// belt-and-suspenders way to avoid such nil-pointer panics; see
+// https://github.com/DataDog/datadog-agent/pull/2817
 type safeReader struct {
 	reader io.ReadCloser
 }

--- a/pkg/logs/internal/tailers/docker/tailer.go
+++ b/pkg/logs/internal/tailers/docker/tailer.go
@@ -54,7 +54,7 @@ type Tailer struct {
 	readTimeout   time.Duration
 	sleepDuration time.Duration
 
-	/// stop: writing a value to this channel will cause the readForever component to stop
+	// stop: writing a value to this channel will cause the readForever component to stop
 	stop chan struct{}
 
 	// done: a value is written to this channel when the message-forwarder

--- a/pkg/logs/internal/tailers/docker/tailer.go
+++ b/pkg/logs/internal/tailers/docker/tailer.go
@@ -34,25 +34,43 @@ type dockerContainerLogInterface interface {
 }
 
 // Tailer tails logs coming from stdout and stderr of a docker container
-// Logs from stdout and stderr are multiplexed into a single channel and needs to be demultiplexed later one.
+// Logs from stdout and stderr are multiplexed into a single channel and needs to be demultiplexed later on.
 // To multiplex logs, docker adds a header to all logs with format '[SEV][TS] [MSG]'.
+//
+// This tailer contains three components, communicating with channels:
+//  - readForever
+//  - decoder
+//  - message forwarder
 type Tailer struct {
 	ContainerID string
 	outputChan  chan *message.Message
 	decoder     *decoder.Decoder
-	reader      *safeReader
 	dockerutil  dockerContainerLogInterface
 	Source      *config.LogSource
 	tagProvider tag.Provider
 
-	readTimeout        time.Duration
-	sleepDuration      time.Duration
-	stop               chan struct{}
-	done               chan struct{}
+	readTimeout   time.Duration
+	sleepDuration time.Duration
+
+	/// stop: writing a value to this channel will cause the readForever component to stop
+	stop chan struct{}
+
+	// done: a value is written to this channel when the message-forwarder
+	// component is finished.
+	done chan struct{}
+
 	erroredContainerID chan string
-	cancelFunc         context.CancelFunc
-	lastSince          string
-	mutex              sync.Mutex
+
+	// reader is the io.Reader reading chunks of log data from the Docker API.
+	reader *safeReader
+
+	// readerCancelFunc is the context cancellation function for the ongoing
+	// docker-API reader.  Calling this function will cancel any pending Read
+	// calls, which will return context.Canceled
+	readerCancelFunc context.CancelFunc
+
+	lastSince string
+	mutex     sync.Mutex
 }
 
 // NewTailer returns a new Tailer
@@ -82,13 +100,22 @@ func (t *Tailer) Identifier() string {
 // this call blocks until the decoder is completely flushed
 func (t *Tailer) Stop() {
 	log.Infof("Stop tailing container: %v", dockerutil.ShortContainerID(t.ContainerID))
+
+	// signal the readForever component to stop
 	t.stop <- struct{}{}
 
+	// signal the reader itself to close.
 	t.reader.Close()
-	// no-op if already closed because of a timeout
-	t.cancelFunc()
+
+	// signal the reader to stop a third way, by cancelling its context.  no-op
+	// if already closed because of a timeout
+	t.readerCancelFunc()
+
 	t.Source.RemoveInput(t.ContainerID)
-	// wait for the decoder to be flushed
+
+	// the closed readForever component will eventually close its channel to the decoder,
+	// which will eventually close its channel to the message-forwarder component,
+	// which will indicate it's done with this channel.
 	<-t.done
 }
 
@@ -135,7 +162,7 @@ func (t *Tailer) setupReader() error {
 	ctx, cancelFunc := context.WithCancel(context.Background())
 	reader, err := t.dockerutil.ContainerLogs(ctx, t.ContainerID, options)
 	t.reader.setUnsafeReader(reader)
-	t.cancelFunc = cancelFunc
+	t.readerCancelFunc = cancelFunc
 
 	return err
 }
@@ -163,6 +190,11 @@ func (t *Tailer) tail(since string) error {
 	t.Source.Status.Success()
 	t.Source.AddInput(t.ContainerID)
 
+	// Start (in reverse order) the three actor components of this tailer, each
+	// in dedicated goroutines:
+	// - readForever, which reads data from the docker API and passes it to..
+	// - the decoder, which runs in its own goroutine(s) and passes messages to..
+	// - forwardMessage, which writes messages to t.outputChan.
 	go t.forwardMessages()
 	t.decoder.Start()
 	go t.readForever()
@@ -173,6 +205,8 @@ func (t *Tailer) tail(since string) error {
 // readForever reads from the reader as fast as it can,
 // and sleeps when there is nothing to read
 func (t *Tailer) readForever() {
+	// close the decoder's input channel when this function returns, causing it to
+	// flush and close its output channel
 	defer t.decoder.Stop()
 	for {
 		select {
@@ -242,7 +276,7 @@ func (t *Tailer) readForever() {
 }
 
 // read implement a timeout on t.reader.Read() because it can be blocking (it's a
-// wrapper over an HTTP call). If read timeouts, the tailer will be restarted.
+// wrapper over an HTTP call). If read timeouts, this function returns context.Canceled.
 func (t *Tailer) read(buffer []byte, timeout time.Duration) (int, error) {
 	var n int
 	var err error
@@ -256,7 +290,9 @@ func (t *Tailer) read(buffer []byte, timeout time.Duration) (int, error) {
 	case <-doneReading:
 	case <-time.After(timeout):
 		// Cancel the docker socket reader context
-		t.cancelFunc()
+		t.readerCancelFunc()
+		// wait for the Read call to return, likely with
+		// context.Canceled
 		<-doneReading
 	}
 

--- a/pkg/logs/internal/tailers/docker/tailer.go
+++ b/pkg/logs/internal/tailers/docker/tailer.go
@@ -47,7 +47,6 @@ type Tailer struct {
 
 	readTimeout        time.Duration
 	sleepDuration      time.Duration
-	shouldStop         bool
 	stop               chan struct{}
 	done               chan struct{}
 	erroredContainerID chan string
@@ -273,7 +272,6 @@ func (t *Tailer) read(buffer []byte, timeout time.Duration) (int, error) {
 func (t *Tailer) forwardMessages() {
 	defer func() {
 		// the decoder has successfully been flushed
-		t.shouldStop = true
 		t.done <- struct{}{}
 	}()
 	for output := range t.decoder.OutputChan {

--- a/pkg/logs/internal/tailers/docker/tailer.go
+++ b/pkg/logs/internal/tailers/docker/tailer.go
@@ -42,7 +42,9 @@ type dockerContainerLogInterface interface {
 //  - decoder
 //  - message forwarder
 type Tailer struct {
+	// ContainerID is the ID of the container this tailer is tailing.
 	ContainerID string
+
 	outputChan  chan *message.Message
 	decoder     *decoder.Decoder
 	dockerutil  dockerContainerLogInterface

--- a/pkg/logs/internal/tailers/docker/tailer_test.go
+++ b/pkg/logs/internal/tailers/docker/tailer_test.go
@@ -96,7 +96,7 @@ func NewTestTailer(reader io.ReadCloser, dockerClient *fakeDockerClient, cancelF
 		done:               make(chan struct{}, 1),
 		erroredContainerID: make(chan string, 1),
 		reader:             newSafeReader(),
-		cancelFunc:         cancelFunc,
+		readerCancelFunc:   cancelFunc,
 	}
 	tailer.reader.setUnsafeReader(reader)
 

--- a/pkg/logs/internal/tailers/file/tailer.go
+++ b/pkg/logs/internal/tailers/file/tailer.go
@@ -259,7 +259,7 @@ func (t *Tailer) GetDetectedPattern() *regexp.Regexp {
 	return t.decoder.GetDetectedPattern()
 }
 
-// fileHasRotated indicates causes subsequent calls to hasFileRotated to return true.
+// fileHasRotated causes subsequent calls to hasFileRotated to return true.
 func (t *Tailer) fileHasRotated() {
 	atomic.StoreInt32(&t.didFileRotate, 1)
 }


### PR DESCRIPTION
### What does this PR do?

A per-commit collection of relatively minor updates to logs-agent tailers and launchers.

### Motivation

Part of larger work to untangle the logs agent in preparation for supporting more container runtimes.

### Additional Notes

This used to include a [much bigger refactor](https://github.com/DataDog/datadog-agent/commit/af3d5ffa4c5fb26574b9d8b3fc6707787d8d932f), but this turned out to be too difficult, especially for the file tailer/launcher, which are _very_ intimately tied together and both fully of mystery and wonder.  It's also probably not necessary for the project at hand, so I've deferred it as out-of-scope.

So, this is sort of a house-cleaning PR containing the small cleanups I did while working on that.

### Possible Drawbacks / Trade-offs

None

### Describe how to test/QA your changes

```
logs: 
  - type: file
    path: /var/log/hello-world.log
    service: test-file-tailing
    source: hello-world
```

To test:

- Stop the agent, generate new logs, start the agent and make sure those are sent
- Generate a log rotate and make sure the new logs are sent

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
