### PR TITLE
Bump semantic conventions used to v1.6.1

### DIFF
--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -805,6 +805,7 @@ core,go.opentelemetry.io/collector/model/otlp,Apache-2.0,Open Telemetry Maintain
 core,go.opentelemetry.io/collector/model/otlpgrpc,Apache-2.0,Open Telemetry Maintainers
 core,go.opentelemetry.io/collector/model/pdata,Apache-2.0,Open Telemetry Maintainers
 core,go.opentelemetry.io/collector/model/semconv/v1.5.0,Apache-2.0,Open Telemetry Maintainers
+core,go.opentelemetry.io/collector/model/semconv/v1.6.1,Apache-2.0,Open Telemetry Maintainers
 core,go.opentelemetry.io/collector/obsreport,Apache-2.0,Open Telemetry Maintainers
 core,go.opentelemetry.io/collector/processor/batchprocessor,Apache-2.0,Open Telemetry Maintainers
 core,go.opentelemetry.io/collector/processor/processorhelper,Apache-2.0,Open Telemetry Maintainers

--- a/pkg/otlp/model/attributes/attributes.go
+++ b/pkg/otlp/model/attributes/attributes.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/collector/model/pdata"
-	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 )
 
 var (

--- a/pkg/otlp/model/attributes/attributes_test.go
+++ b/pkg/otlp/model/attributes/attributes_test.go
@@ -20,7 +20,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/model/pdata"
-	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 )
 
 func TestTagsFromAttributes(t *testing.T) {

--- a/pkg/otlp/model/attributes/azure/azure.go
+++ b/pkg/otlp/model/attributes/azure/azure.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/collector/model/pdata"
-	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 )
 
 const (

--- a/pkg/otlp/model/attributes/azure/azure_test.go
+++ b/pkg/otlp/model/attributes/azure/azure_test.go
@@ -18,7 +18,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 
 	"github.com/DataDog/datadog-agent/pkg/otlp/model/internal/testutils"
 )

--- a/pkg/otlp/model/attributes/ec2/ec2.go
+++ b/pkg/otlp/model/attributes/ec2/ec2.go
@@ -19,7 +19,7 @@ import (
 	"strings"
 
 	"go.opentelemetry.io/collector/model/pdata"
-	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 )
 
 var (

--- a/pkg/otlp/model/attributes/ec2/ec2_test.go
+++ b/pkg/otlp/model/attributes/ec2/ec2_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 
 	"github.com/DataDog/datadog-agent/pkg/otlp/model/internal/testutils"
 )

--- a/pkg/otlp/model/attributes/gcp/gcp.go
+++ b/pkg/otlp/model/attributes/gcp/gcp.go
@@ -18,7 +18,7 @@ import (
 	"fmt"
 
 	"go.opentelemetry.io/collector/model/pdata"
-	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 )
 
 // HostInfo holds the GCP host information.

--- a/pkg/otlp/model/attributes/gcp/gcp_test.go
+++ b/pkg/otlp/model/attributes/gcp/gcp_test.go
@@ -17,7 +17,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 
 	"github.com/DataDog/datadog-agent/pkg/otlp/model/internal/testutils"
 )

--- a/pkg/otlp/model/attributes/hostname.go
+++ b/pkg/otlp/model/attributes/hostname.go
@@ -16,7 +16,7 @@ package attributes
 
 import (
 	"go.opentelemetry.io/collector/model/pdata"
-	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 
 	"github.com/DataDog/datadog-agent/pkg/otlp/model/attributes/azure"
 	"github.com/DataDog/datadog-agent/pkg/otlp/model/attributes/ec2"

--- a/pkg/otlp/model/attributes/hostname_test.go
+++ b/pkg/otlp/model/attributes/hostname_test.go
@@ -18,7 +18,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 
 	"github.com/DataDog/datadog-agent/pkg/otlp/model/attributes/azure"
 	"github.com/DataDog/datadog-agent/pkg/otlp/model/internal/testutils"

--- a/pkg/otlp/model/attributes/process.go
+++ b/pkg/otlp/model/attributes/process.go
@@ -17,7 +17,7 @@ package attributes
 import (
 	"fmt"
 
-	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 )
 
 type processAttributes struct {

--- a/pkg/otlp/model/attributes/process_test.go
+++ b/pkg/otlp/model/attributes/process_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 )
 
 func TestProcessExtractTags(t *testing.T) {

--- a/pkg/otlp/model/attributes/system.go
+++ b/pkg/otlp/model/attributes/system.go
@@ -17,7 +17,7 @@ package attributes
 import (
 	"fmt"
 
-	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 )
 
 type systemAttributes struct {

--- a/pkg/otlp/model/attributes/system_test.go
+++ b/pkg/otlp/model/attributes/system_test.go
@@ -19,7 +19,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 )
 
 func TestSystemExtractTags(t *testing.T) {

--- a/pkg/otlp/model/translator/metrics_translator_test.go
+++ b/pkg/otlp/model/translator/metrics_translator_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.opentelemetry.io/collector/model/pdata"
-	conventions "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+	conventions "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest/observer"

--- a/pkg/trace/api/otlp.go
+++ b/pkg/trace/api/otlp.go
@@ -31,7 +31,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	"github.com/gogo/protobuf/proto"
-	semconv "go.opentelemetry.io/collector/model/semconv/v1.5.0"
+	semconv "go.opentelemetry.io/collector/model/semconv/v1.6.1"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
 )


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Bump semantic conventions used to v1.6.1.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Be on par with OpenTelemetry Collector version until the telemetry schema processor is available (see open-telemetry/opentelemetry-collector-contrib#5036).

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Should not be merged until open-telemetry/opentelemetry-collector-contrib#7926 has landed.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

As mentioned in the contrib PR, no breaking changes happened between these two versions, therefore this is a no-op.

This was done by running `fd -e go -X sd model/semconv/v1.5.0 model/semconv/v1.6.1`.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
