### PR TITLE
[fargate] Add DD_TAGS/DD_EXTRA_TAGS to integration tags

### DIFF
--- a/pkg/autodiscovery/providers/config_reader.go
+++ b/pkg/autodiscovery/providers/config_reader.go
@@ -371,7 +371,7 @@ func GetIntegrationConfigFromFile(name, fpath string) (integration.Config, error
 				log.Debugf("Could not add agent-level tags to instance of %v: %v", fpath, err)
 			}
 		}
-		conf.Instances = append(conf.Instances, rawConf)
+		conf.Instances = append(conf.Instances, dataConf)
 	}
 
 	// If JMX metrics were found, add them to the config

--- a/pkg/autodiscovery/providers/config_reader.go
+++ b/pkg/autodiscovery/providers/config_reader.go
@@ -6,6 +6,7 @@
 package providers
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io/ioutil"
@@ -18,6 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/configresolver"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/util/fargate"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
 	cache "github.com/patrickmn/go-cache"
@@ -325,20 +327,20 @@ func collectDir(parentPath string, folder os.FileInfo, integrationErrors map[str
 // GetIntegrationConfigFromFile returns an instance of integration.Config if `fpath` points to a valid config file
 func GetIntegrationConfigFromFile(name, fpath string) (integration.Config, error) {
 	cf := configFormat{}
-	config := integration.Config{Name: name}
+	conf := integration.Config{Name: name}
 
 	// Read file contents
 	// FIXME: ReadFile reads the entire file, possible security implications
 	yamlFile, err := readFilePtr(fpath)
 	if err != nil {
-		return config, err
+		return conf, err
 	}
 
 	// Parse configuration
 	// Try UnmarshalStrict first, so we can warn about duplicated keys
 	if strictErr := yaml.UnmarshalStrict(yamlFile, &cf); strictErr != nil {
 		if err := yaml.Unmarshal(yamlFile, &cf); err != nil {
-			return config, err
+			return conf, err
 		}
 		log.Warnf("reading config file %v: %v\n", fpath, strictErr)
 	}
@@ -346,56 +348,66 @@ func GetIntegrationConfigFromFile(name, fpath string) (integration.Config, error
 	// If no valid instances were found & this is neither a metrics file, nor a logs file
 	// this is not a valid configuration file
 	if cf.MetricConfig == nil && cf.LogsConfig == nil && len(cf.Instances) < 1 {
-		return config, errors.New("Configuration file contains no valid instances")
+		return conf, errors.New("Configuration file contains no valid instances")
 	}
 
 	// at this point the Yaml was already parsed, no need to check the error
 	if cf.InitConfig != nil {
 		rawInitConfig, _ := yaml.Marshal(cf.InitConfig)
-		config.InitConfig = rawInitConfig
+		conf.InitConfig = rawInitConfig
 	}
 
 	// Go through instances and return corresponding []byte
 	for _, instance := range cf.Instances {
 		// at this point the Yaml was already parsed, no need to check the error
 		rawConf, _ := yaml.Marshal(instance)
-		config.Instances = append(config.Instances, rawConf)
+		dataConf := (integration.Data)(rawConf)
+		if fargate.IsFargateInstance(context.TODO()) {
+			// In Fargate, since no host tags are applied in the backend,
+			// add the configured DD_TAGS/DD_EXTRA_TAGS to the instance tags.
+			tags := config.GetConfiguredTags(false)
+			err := dataConf.MergeAdditionalTags(tags)
+			if err != nil {
+				log.Debugf("Could not add agent-level tags to instance of %v: %v", fpath, err)
+			}
+		}
+		conf.Instances = append(conf.Instances, rawConf)
 	}
 
 	// If JMX metrics were found, add them to the config
 	if cf.MetricConfig != nil {
 		rawMetricConfig, _ := yaml.Marshal(cf.MetricConfig)
-		config.MetricConfig = rawMetricConfig
+		conf.MetricConfig = rawMetricConfig
 	}
 
 	// If logs was found, add it to the config
 	if cf.LogsConfig != nil {
 		logsConfig := make(map[string]interface{})
 		logsConfig["logs"] = cf.LogsConfig
-		config.LogsConfig, _ = yaml.Marshal(logsConfig)
+		conf.LogsConfig, _ = yaml.Marshal(logsConfig)
 	}
 
 	// Copy auto discovery identifiers
-	config.ADIdentifiers = cf.ADIdentifiers
-	config.AdvancedADIdentifiers = cf.AdvancedADIdentifiers
+	conf.ADIdentifiers = cf.ADIdentifiers
+	conf.AdvancedADIdentifiers = cf.AdvancedADIdentifiers
 
 	// Copy cluster_check status
-	config.ClusterCheck = cf.ClusterCheck
+	conf.ClusterCheck = cf.ClusterCheck
 
 	// Copy ignore_autodiscovery_tags parameter
-	config.IgnoreAutodiscoveryTags = cf.IgnoreAutodiscoveryTags
+	conf.IgnoreAutodiscoveryTags = cf.IgnoreAutodiscoveryTags
 
 	// DockerImages entry was found: we ignore it if no ADIdentifiers has been found
 	if len(cf.DockerImages) > 0 && len(cf.ADIdentifiers) == 0 {
-		return config, errors.New("the 'docker_images' section is deprecated, please use 'ad_identifiers' instead")
+		return conf, errors.New("the 'docker_images' section is deprecated, please use 'ad_identifiers' instead")
 	}
 
 	// Interpolate env vars. Returns an error a variable wasn't subsituted, ignore it.
-	_ = configresolver.SubstituteTemplateEnvVars(&config)
+	_ = configresolver.SubstituteTemplateEnvVars(&conf)
 
-	config.Source = "file:" + fpath
+	conf.Source = "file:" + fpath
 
-	return config, err
+	return conf, err
 }
 
 func containsString(slice []string, str string) bool {

--- a/releasenotes/notes/host-tags-integration-fargate-2e8ea237e6959b0c.yaml
+++ b/releasenotes/notes/host-tags-integration-fargate-2e8ea237e6959b0c.yaml
@@ -8,5 +8,5 @@
 ---
 enhancements:
   - |
-    On ECS Fargate and EKS Fargate, agent-configured tags (``DD_TAGS``/``DD_EXTRA_TAGS``)
+    On ECS Fargate and EKS Fargate, Agent-configured tags (``DD_TAGS``/``DD_EXTRA_TAGS``)
     are now applied to all integration-collected metrics.

--- a/releasenotes/notes/host-tags-integration-fargate-2e8ea237e6959b0c.yaml
+++ b/releasenotes/notes/host-tags-integration-fargate-2e8ea237e6959b0c.yaml
@@ -1,0 +1,12 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    On ECS Fargate and EKS Fargate, agent-configured tags (``DD_TAGS``/``DD_EXTRA_TAGS``)
+    are now applied to all integration-collected metrics.


### PR DESCRIPTION
### What does this PR do?

On Fargate, since the Agent doesn't report a hostname, DD_TAGS/DD_EXTRA_TAGS
are not added to integration metrics, unless the integration config is dynamically
pulled from AD logic.

To address this, this PR makes the file provider add these tags to each
integration instance's tags.

### Motivation

* Apply agent-configured tags to integration metrics on ECS Fargate/EKS Fargate, to make metrics reported from these envs more consistent with other envs.
* this is relatively similar to what was done for dogstatsd metrics in https://github.com/DataDog/datadog-agent/pull/10952, except that Fargate-collected tags are not added by default

### Possible Drawbacks / Trade-offs

* This is a quick implementation. Ideally this should be moved to the main AD logic instead of just the file provider, so that it 100% covers all integration configuration methods. Will create a follow up card.
* This doesn't add any test (a little tricky to add one since `IsFargateInstance` doesn't have a mock).
* It's unclear at this point whether we want Fargate collected tags to be included, and calling `util.GetStaticTagSlice` may take some time/make API calls to return tags so may not be suitable to call from this code path that's called repeatedly, hence the decision to not include EKS Fargate tags (unlike in https://github.com/DataDog/datadog-agent/pull/10952)

### Describe how to test/QA your changes

1. Set up an agent in ECS Fargate, with an integration configured in a file, and `DD_TAGS` configured
2. Verify that the tags defined in `DD_TAGS` are present in integration config in `agent configcheck`, and are present in Datadog on the metrics collected by the integration.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
