### PR TITLE
[CWS & CSPM] remove ioutil usage

### DIFF
--- a/cmd/security-agent/app/status.go
+++ b/cmd/security-agent/app/status.go
@@ -9,7 +9,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
@@ -107,7 +107,7 @@ func requestStatus() error {
 	}
 
 	if statusArgs.file != "" {
-		ioutil.WriteFile(statusArgs.file, []byte(s), 0644) //nolint:errcheck
+		os.WriteFile(statusArgs.file, []byte(s), 0644) //nolint:errcheck
 	} else {
 		fmt.Println(s)
 	}

--- a/cmd/system-probe/app/restart.go
+++ b/cmd/system-probe/app/restart.go
@@ -7,7 +7,7 @@ package app
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/DataDog/datadog-agent/cmd/system-probe/api"
 	"github.com/spf13/cobra"
@@ -39,7 +39,7 @@ func moduleRestart(_ *cobra.Command, args []string) error {
 
 	defer resp.Body.Close()
 	if resp.StatusCode >= 400 {
-		body, _ := ioutil.ReadAll(resp.Body)
+		body, _ := io.ReadAll(resp.Body)
 		err := fmt.Errorf("error restarting module: %s", body)
 		return err
 	}

--- a/cmd/system-probe/modules/process.go
+++ b/cmd/system-probe/modules/process.go
@@ -10,7 +10,7 @@ package modules
 
 import (
 	"errors"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -115,7 +115,7 @@ func writeStats(w http.ResponseWriter, marshaler encoding.Marshaler, stats map[i
 
 func getPids(r *http.Request) ([]int32, error) {
 	contentType := r.Header.Get("Content-Type")
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/system-probe/utils/limiter_test.go
+++ b/cmd/system-probe/utils/limiter_test.go
@@ -2,7 +2,6 @@ package utils
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -48,7 +47,7 @@ func TestWithConcurrencyLimit(t *testing.T) {
 		w := httptest.NewRecorder()
 		handler(w, r)
 		resp := w.Result()
-		io.Copy(ioutil.Discard, resp.Body)
+		io.Copy(io.Discard, resp.Body)
 		assert.Equal(t, http.StatusTooManyRequests, resp.StatusCode)
 	}
 
@@ -59,7 +58,7 @@ func TestWithConcurrencyLimit(t *testing.T) {
 	// Verify that they were processed by the original handler
 	for _, recorder := range recorders {
 		resp := recorder.Result()
-		io.Copy(ioutil.Discard, resp.Body)
+		io.Copy(io.Discard, resp.Body)
 		assert.Equal(t, http.StatusOK, resp.StatusCode)
 	}
 }

--- a/cmd/system-probe/utils/memory_monitor_linux.go
+++ b/cmd/system-probe/utils/memory_monitor_linux.go
@@ -10,7 +10,6 @@ package utils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -39,7 +38,7 @@ func getActionCallback(action string) (func(), string, error) {
 	case "profile":
 		return func() {
 			tmpDir := os.TempDir()
-			tmpFiles, err := ioutil.ReadDir(tmpDir)
+			tmpFiles, err := os.ReadDir(tmpDir)
 			if err != nil {
 				log.Errorf("Failed to list old memory profiles: %s", err)
 			} else {
@@ -60,7 +59,7 @@ func getActionCallback(action string) (func(), string, error) {
 				}
 			}
 
-			memProfile, err := ioutil.TempFile(tmpDir, "memcg-pprof-heap")
+			memProfile, err := os.CreateTemp(tmpDir, "memcg-pprof-heap")
 			if err != nil {
 				log.Errorf("Failed to generate memory profile: %s", err)
 				return

--- a/cmd/system-probe/utils/memory_monitor_linux.go
+++ b/cmd/system-probe/utils/memory_monitor_linux.go
@@ -45,7 +45,12 @@ func getActionCallback(action string) (func(), string, error) {
 				var oldProfiles []os.FileInfo
 				for _, tmpFile := range tmpFiles {
 					if strings.HasPrefix(tmpFile.Name(), "memcg-pprof-heap") {
-						oldProfiles = append(oldProfiles, tmpFile)
+						tmpFileInfo, err := tmpFile.Info()
+						if err != nil {
+							log.Errorf("Failed to get file info for: %s", tmpFile.Name())
+							continue
+						}
+						oldProfiles = append(oldProfiles, tmpFileInfo)
 					}
 				}
 

--- a/pkg/compliance/agent/agent_test.go
+++ b/pkg/compliance/agent/agent_test.go
@@ -10,7 +10,6 @@ package agent
 
 import (
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -39,7 +38,7 @@ func (e *tempEnv) leave() {
 func enterTempEnv(t *testing.T) *tempEnv {
 	t.Helper()
 	assert := assert.New(t)
-	tempDir, err := ioutil.TempDir("", "compliance-agent-")
+	tempDir, err := os.MkdirTemp("", "compliance-agent-")
 	assert.NoError(err)
 
 	err = util.CopyDir("./testdata/configs", tempDir)

--- a/pkg/compliance/checks/builder.go
+++ b/pkg/compliance/checks/builder.go
@@ -11,7 +11,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"strings"
 	"time"
 
@@ -220,7 +220,7 @@ func WithNodeLabels(nodeLabels map[string]string) BuilderOption {
 // of a file instead of the current environment
 func WithRegoInput(regoInputPath string) BuilderOption {
 	return func(b *builder) error {
-		content, err := ioutil.ReadFile(regoInputPath)
+		content, err := os.ReadFile(regoInputPath)
 		if err != nil {
 			return err
 		}

--- a/pkg/compliance/checks/docker_check_test.go
+++ b/pkg/compliance/checks/docker_check_test.go
@@ -7,7 +7,7 @@ package checks
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"testing"
 
@@ -28,7 +28,7 @@ func loadTestJSON(path string, obj interface{}) error {
 	if err != nil {
 		return err
 	}
-	b, err := ioutil.ReadAll(jsonFile)
+	b, err := io.ReadAll(jsonFile)
 	if err != nil {
 		return err
 	}

--- a/pkg/compliance/checks/file_check_test.go
+++ b/pkg/compliance/checks/file_check_test.go
@@ -11,7 +11,6 @@ package checks
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -40,7 +39,7 @@ func TestFileCheck(t *testing.T) {
 	cleanUpDirs := make([]string, 0)
 	createTempFiles := func(t *testing.T, numFiles int) (string, []string) {
 		paths := make([]string, 0, numFiles)
-		dir, err := ioutil.TempDir("", "cmplFileTest")
+		dir, err := os.MkdirTemp("", "cmplFileTest")
 		assert.NoError(err)
 		cleanUpDirs = append(cleanUpDirs, dir)
 

--- a/pkg/compliance/checks/helpers.go
+++ b/pkg/compliance/checks/helpers.go
@@ -8,7 +8,7 @@ package checks
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"regexp"
 	"strings"
@@ -78,7 +78,7 @@ func readContent(filePath, parser string) (interface{}, error) {
 	}
 	defer f.Close()
 
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return "", err
 	}
@@ -135,7 +135,7 @@ func queryValueFromFile(filePath string, query string, get getter) (string, erro
 	}
 	defer f.Close()
 
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/compliance/checks/rego_check.go
+++ b/pkg/compliance/checks/rego_check.go
@@ -10,7 +10,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -410,7 +409,7 @@ func (r *regoCheck) check(env env.Env) []*compliance.Report {
 
 func dumpInputToFile(ruleID, path string, input interface{}) error {
 	currentData := make(map[string]interface{})
-	currentContent, err := ioutil.ReadFile(path)
+	currentContent, err := os.ReadFile(path)
 	if err == nil {
 		if len(currentContent) != 0 {
 			if err := json.Unmarshal(currentContent, &currentData); err != nil {
@@ -426,7 +425,7 @@ func dumpInputToFile(ruleID, path string, input interface{}) error {
 		return err
 	}
 
-	return ioutil.WriteFile(path, jsonData, 0644)
+	return os.WriteFile(path, jsonData, 0644)
 }
 
 type regoFinding struct {

--- a/pkg/compliance/suite.go
+++ b/pkg/compliance/suite.go
@@ -7,7 +7,7 @@ package compliance
 
 import (
 	"errors"
-	"io/ioutil"
+	"os"
 
 	"github.com/Masterminds/semver"
 	"gopkg.in/yaml.v2"
@@ -80,7 +80,7 @@ func ParseSuite(config string) (*Suite, error) {
 		return nil, err
 	}
 
-	f, err := ioutil.ReadFile(config)
+	f, err := os.ReadFile(config)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/security/probe/activity_dump.go
+++ b/pkg/security/probe/activity_dump.go
@@ -11,7 +11,6 @@ package probe
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -99,7 +98,7 @@ func NewActivityDump(params *api.DumpActivityParams, tracedPIDs *ebpf.Map, resol
 	}
 
 	// generate random output file
-	ad.outputFile, err = ioutil.TempFile("/tmp", "activity-dump-")
+	ad.outputFile, err = os.CreateTemp("/tmp", "activity-dump-")
 	if err != nil {
 		return nil, err
 	}
@@ -111,7 +110,7 @@ func NewActivityDump(params *api.DumpActivityParams, tracedPIDs *ebpf.Map, resol
 
 	// generate random graph file
 	if params.WithGraph {
-		ad.graphFile, err = ioutil.TempFile("/tmp", "graph-dump-")
+		ad.graphFile, err = os.CreateTemp("/tmp", "graph-dump-")
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/security/probe/activity_dump_manager.go
+++ b/pkg/security/probe/activity_dump_manager.go
@@ -11,7 +11,7 @@ package probe
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"os"
 	"strings"
 	"sync"
@@ -233,7 +233,7 @@ func (adm *ActivityDumpManager) GenerateProfile(params *api.GenerateProfileParam
 		return "", errors.Wrap(err, "couldn't open activity dump file")
 	}
 
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		return "", errors.Wrap(err, "couldn't read activity dump file")
 	}
@@ -246,7 +246,7 @@ func (adm *ActivityDumpManager) GenerateProfile(params *api.GenerateProfileParam
 
 	// create profile output file
 	var profile *os.File
-	profile, err = ioutil.TempFile("/tmp", "profile-")
+	profile, err = os.CreateTemp("/tmp", "profile-")
 	if err != nil {
 		return "", errors.Wrap(err, "couldn't create profile file")
 	}

--- a/pkg/security/secl/rules/policy_test.go
+++ b/pkg/security/secl/rules/policy_test.go
@@ -7,7 +7,6 @@ package rules
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -25,7 +24,7 @@ func savePolicy(filename string, testPolicy *Policy) error {
 		return err
 	}
 
-	return ioutil.WriteFile(filename, yamlBytes, 0700)
+	return os.WriteFile(filename, yamlBytes, 0700)
 }
 
 func TestMacroMerge(t *testing.T) {
@@ -57,7 +56,7 @@ func TestMacroMerge(t *testing.T) {
 		}},
 	}
 
-	tmpDir, err := ioutil.TempDir("", "test-policy")
+	tmpDir, err := os.MkdirTemp("", "test-policy")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +124,7 @@ func TestRuleMerge(t *testing.T) {
 		}},
 	}
 
-	tmpDir, err := ioutil.TempDir("", "test-policy")
+	tmpDir, err := os.MkdirTemp("", "test-policy")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -299,7 +298,7 @@ func TestActionSetVariable(t *testing.T) {
 		}},
 	}
 
-	tmpDir, err := ioutil.TempDir("", "test-policy")
+	tmpDir, err := os.MkdirTemp("", "test-policy")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -381,7 +380,7 @@ func TestActionSetVariableConflict(t *testing.T) {
 		}},
 	}
 
-	tmpDir, err := ioutil.TempDir("", "test-policy")
+	tmpDir, err := os.MkdirTemp("", "test-policy")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -408,7 +407,7 @@ func loadPolicy(t *testing.T, testPolicy *Policy) *multierror.Error {
 		WithMacros(make(map[eval.MacroID]*eval.Macro))
 	rs := NewRuleSet(&testModel{}, func() eval.Event { return &testEvent{} }, &opts)
 
-	tmpDir, err := ioutil.TempDir("", "test-policy")
+	tmpDir, err := os.MkdirTemp("", "test-policy")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

The [ioutil](https://pkg.go.dev/io/ioutil) package is in a near-deprecated state, this PR uses functions from `io`/`os` to replace ioutil usages.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
