### PR TITLE
Fix missing registration of Kubelet collector, fix containerRT panic

### DIFF
--- a/pkg/process/checks/container_rt.go
+++ b/pkg/process/checks/container_rt.go
@@ -33,9 +33,9 @@ type RTContainerCheck struct {
 
 // Init initializes a RTContainerCheck instance.
 func (r *RTContainerCheck) Init(_ *config.AgentConfig, sysInfo *model.SystemInfo) {
-	r.sysInfo = sysInfo
-
 	r.maxBatchSize = getMaxBatchSize()
+	r.sysInfo = sysInfo
+	r.containerProvider = util.GetSharedContainerProvider()
 }
 
 // Name returns the name of the RTContainerCheck.
@@ -51,7 +51,7 @@ func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.
 	var err error
 	var containers []*model.Container
 	var lastRates map[string]*util.ContainerRateMetrics
-	containers, lastRates, _, err = r.containerProvider.GetContainers(cacheValidityNoRT, r.lastRates, r.lastRun, startTime)
+	containers, lastRates, _, err = r.containerProvider.GetContainers(cacheValidityRT, r.lastRates, r.lastRun, startTime)
 	if err == nil {
 		r.lastRun = startTime
 		r.lastRates = lastRates

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -152,8 +152,12 @@ func (p *ProcessCheck) run(cfg *config.AgentConfig, groupID int32, collectRealTi
 	var containers []*model.Container
 	var pidToCid map[int]string
 	var lastContainerRates map[string]*util.ContainerRateMetrics
+	cacheValidity := cacheValidityNoRT
+	if collectRealTime {
+		cacheValidity = cacheValidityRT
+	}
 	containerTime := time.Now()
-	containers, lastContainerRates, pidToCid, err = p.containerProvider.GetContainers(cacheValidityNoRT, p.lastContainerRates, p.lastContainerRun, containerTime)
+	containers, lastContainerRates, pidToCid, err = p.containerProvider.GetContainers(cacheValidity, p.lastContainerRates, p.lastContainerRun, containerTime)
 	if err == nil {
 		p.lastContainerRun = containerTime
 		p.lastContainerRates = lastContainerRates

--- a/pkg/util/containers/v2/metrics/facade.go
+++ b/pkg/util/containers/v2/metrics/facade.go
@@ -13,6 +13,7 @@ import (
 	_ "github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics/cri"
 	_ "github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics/docker"
 	_ "github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics/ecsfargate"
+	_ "github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics/kubelet"
 	_ "github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics/system"
 )
 

--- a/pkg/util/containers/v2/metrics/kubelet/collector.go
+++ b/pkg/util/containers/v2/metrics/kubelet/collector.go
@@ -20,6 +20,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+
 	"k8s.io/kubelet/pkg/apis/stats/v1alpha1"
 )
 

--- a/pkg/util/containers/v2/metrics/kubelet/collector_test.go
+++ b/pkg/util/containers/v2/metrics/kubelet/collector_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet/mock"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
+
 	"github.com/stretchr/testify/assert"
 )
 

--- a/pkg/util/containers/v2/metrics/provider/cache.go
+++ b/pkg/util/containers/v2/metrics/provider/cache.go
@@ -42,11 +42,7 @@ func (c *Cache) Get(currentTime time.Time, key string, cacheValidity time.Durati
 	entry, found := c.cache[key]
 	c.cacheLock.RUnlock()
 
-	if !found {
-		return nil, false, nil
-	}
-
-	if currentTime.Sub(entry.timestamp) > cacheValidity {
+	if !found || currentTime.Sub(entry.timestamp) > cacheValidity {
 		return nil, false, nil
 	}
 

--- a/pkg/util/kube_hostnetwork.go
+++ b/pkg/util/kube_hostnetwork.go
@@ -11,6 +11,7 @@ package util
 import (
 	"context"
 
+	"github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/kubernetes/kubelet"
 )
 
@@ -20,5 +21,10 @@ func isAgentKubeHostNetwork() (bool, error) {
 		return true, err
 	}
 
-	return ku.IsAgentHostNetwork(context.TODO())
+	cid, err := metrics.GetProvider().GetMetaCollector().GetSelfContainerID()
+	if err != nil {
+		return false, err
+	}
+
+	return ku.IsAgentHostNetwork(context.TODO(), cid)
 }

--- a/pkg/util/kubernetes/kubelet/kubelet.go
+++ b/pkg/util/kubernetes/kubelet/kubelet.go
@@ -21,7 +21,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/errors"
 	"github.com/DataDog/datadog-agent/pkg/util/cache"
 	"github.com/DataDog/datadog-agent/pkg/util/containers"
-	"github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/retry"
 	kubeletv1alpha1 "k8s.io/kubelet/pkg/apis/stats/v1alpha1"
@@ -424,17 +423,12 @@ func (ku *KubeUtil) GetRawMetrics(ctx context.Context) ([]byte, error) {
 }
 
 // IsAgentHostNetwork returns whether the agent is running inside a container with `hostNetwork` or not
-func (ku *KubeUtil) IsAgentHostNetwork(ctx context.Context) (bool, error) {
-	cid, err := metrics.GetProvider().GetMetaCollector().GetSelfContainerID()
-	if err != nil {
-		return false, err
-	}
-
-	if cid == "" {
+func (ku *KubeUtil) IsAgentHostNetwork(ctx context.Context, agentContainerID string) (bool, error) {
+	if agentContainerID == "" {
 		return false, fmt.Errorf("unable to determine self container id")
 	}
 
-	pod, err := ku.GetPodForContainerID(ctx, cid)
+	pod, err := ku.GetPodForContainerID(ctx, agentContainerID)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/util/kubernetes/kubelet/kubelet_interface.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_interface.go
@@ -32,7 +32,7 @@ type KubeUtilInterface interface {
 	GetKubeletAPIEndpoint() string
 	GetRawConnectionInfo() map[string]string
 	GetRawMetrics(ctx context.Context) ([]byte, error)
-	IsAgentHostNetwork(ctx context.Context) (bool, error)
+	IsAgentHostNetwork(ctx context.Context, agentContainerID string) (bool, error)
 	ListContainers(ctx context.Context) ([]*containers.Container, error)
 	UpdateContainerMetrics(ctrList []*containers.Container) error
 	GetLocalStatsSummary(ctx context.Context) (*kubeletv1alpha1.Summary, error)

--- a/pkg/util/kubernetes/kubelet/kubelet_orchestrator.go
+++ b/pkg/util/kubernetes/kubelet/kubelet_orchestrator.go
@@ -37,7 +37,7 @@ type KubeUtilInterface interface {
 	GetRawConnectionInfo() map[string]string
 	GetRawMetrics(ctx context.Context) ([]byte, error)
 	ListContainers(ctx context.Context) ([]*containers.Container, error)
-	IsAgentHostNetwork(ctx context.Context) (bool, error)
+	IsAgentHostNetwork(ctx context.Context, agentContainerID string) (bool, error)
 	UpdateContainerMetrics(ctrList []*containers.Container) error
 	GetRawLocalPodList(ctx context.Context) ([]*v1.Pod, error)
 	GetLocalStatsSummary(ctx context.Context) (*kubeletv1alpha1.Summary, error)


### PR DESCRIPTION
### What does this PR do?

Fix missing registration of the `kubelet` metrics collector.
Fix missing init of `metricsProvider` in `containerRT`

### Motivation

Fixes

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

No dedicated QA, QA will be done as part of original PRs: #10967 and #10605

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
