### PR TITLE
[otlp] Fix DD_OTLP_GRPC_PORT and DD_OTLP_HTTP_PORT env var support

### DIFF
--- a/pkg/config/otlp.go
+++ b/pkg/config/otlp.go
@@ -31,6 +31,12 @@ func SetupOTLP(config Config) {
 	config.BindEnvAndSetDefault(OTLPMetricsEnabled, true)
 	config.BindEnvAndSetDefault(OTLPTracesEnabled, true)
 
+	// Make sure the old DD_OTLP_GRPC_PORT and DD_OTLP_HTTP_PORT env variables keep working
+	// for one release.
+	// TODO: To be removed once 7.35.0 is out.
+	config.BindEnv("experimental.otlp.grpc_port", "DD_OTLP_GRPC_PORT")
+	config.BindEnv("experimental.otlp.http_port", "DD_OTLP_HTTP_PORT")
+
 	// NOTE: This only partially works.
 	// The environment variable is also manually checked in pkg/otlp/config.go
 	config.BindEnvAndSetDefault(OTLPTagCardinalityKey, "low", "DD_OTLP_TAG_CARDINALITY")

--- a/pkg/config/otlp.go
+++ b/pkg/config/otlp.go
@@ -57,12 +57,14 @@ func SetupOTLP(config Config) {
 // TODO(gbbr): This is to keep backwards compatibility and should
 // be completely removed once 7.35.0 is out.
 func promoteExperimentalOTLP(cfg Config) {
-	if !cfg.IsSet("experimental.otlp") {
+	if !cfg.IsSectionSet("experimental.otlp") {
 		return
 	}
+
 	log.Warn(`OTLP ingest configuration is now stable and has been moved out of the "experimental" section. ` +
 		`This section will be deprecated in the 7.37 Datadog Agent release. Please use the "otlp_config" section instead.`)
-	if k := "experimental.otlp.metrics"; cfg.IsSet(k) {
+
+	if k := "experimental.otlp.metrics"; cfg.IsSectionSet(k) {
 		for key, val := range cfg.GetStringMap(k) {
 			cfg.Set(OTLPMetrics+"."+key, val)
 		}

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -89,4 +89,8 @@ type Config interface {
 	// GetEnvVars returns a list of the env vars that the config supports.
 	// These have had the EnvPrefix applied, as well as the EnvKeyReplacer.
 	GetEnvVars() []string
+
+	// IsSectionSet checks if a given section is set by checking if any of
+	// its subkeys is set.
+	IsSectionSet(section string) bool
 }

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -88,6 +88,24 @@ func (c *safeConfig) IsSet(key string) bool {
 	return c.Viper.IsSet(key)
 }
 
+// IsSectionSet checks if a section is set by checking if either it
+// or any of its subkeys is set.
+func (c *safeConfig) IsSectionSet(section string) bool {
+	// The section is considered set if any of the keys
+	// inside it is set.
+	// This is needed when keys within the section
+	// are set through env variables.
+	for _, key := range c.AllKeys() {
+		if strings.HasPrefix(key, section) && c.IsSet(key) {
+			return true
+		}
+	}
+
+	// Is none of the keys are set, the section is still considered as set
+	// if it has been explicitly set in the config.
+	return c.IsSet(section)
+}
+
 // Get wraps Viper for concurrent access
 func (c *safeConfig) Get(key string) interface{} {
 	c.RLock()

--- a/pkg/config/viper_test.go
+++ b/pkg/config/viper_test.go
@@ -161,3 +161,29 @@ float_list:
 	assert.Nil(t, err)
 	assert.Equal(t, []float64{1.1, 2.2, 3.3}, list)
 }
+
+func TestIsSectionSet(t *testing.T) {
+	config := NewConfig("test", "DD", strings.NewReplacer(".", "_"))
+
+	config.BindEnv("test.key")
+	config.BindEnv("othertest.key")
+	config.SetConfigType("yaml")
+
+	yamlExample := []byte(`
+test:
+  key:
+`)
+
+	config.ReadConfig(bytes.NewBuffer(yamlExample))
+
+	res := config.IsSectionSet("test")
+	assert.Equal(t, true, res)
+
+	res = config.IsSectionSet("othertest")
+	assert.Equal(t, false, res)
+
+	t.Setenv("DD_OTHERTEST_KEY", "value")
+
+	res = config.IsSectionSet("othertest")
+	assert.Equal(t, true, res)
+}

--- a/releasenotes/notes/otlp-not-experimental-56d7130909082cf1.yaml
+++ b/releasenotes/notes/otlp-not-experimental-56d7130909082cf1.yaml
@@ -11,6 +11,5 @@ upgrade:
     The OTLP ingest endpoint is now considered stable for traces.
     The configuration for it needs no longer be part of the "experimental" config section.
 
-    Please note that previously setting "experimental.otlp.grpc_port" together with "apm_config.apm_non_local_traffic"
-    would result in the listener being bound to "0.0.0.0" whereas now it will be bound to "localhost" or the value set
-    by "bind_host".
+    Support for the "experimental.otlp" section and the DD_OTLP_GRPC_PORT and DD_OTLP_HTTP_PORT
+    environment variables will be removed in Agent 7.37.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Adds back support for the `DD_OTLP_GRPC_PORT` and `DD_OTLP_HTTP_PORT` environment variables to set up the endpoint port of the OTLP ingest in the Agent.
Introduces `IsSectionSet` to `pkg/config/viper` as an alternative to `IsSet` that works for sections where only a subsection is set, through an environment variable.
Reintroduces code (in `getOTLPReceiverHost`) to make sure the receiver host is correctly set when the above legacy variables are used.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Make sure 7.35.0 doesn't break any experimental functionality.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

E2E tests, try to run the OTLP ingest in the Agent using the `DD_OTLP_GRPC_PORT` / `DD_OTLP_HTTP_PORT` variables.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
