### PR TITLE
[CWS] Fixing serialization when an EACCESS or EPERM error occurs

### DIFF
--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -570,9 +570,10 @@ func newUnloadModuleEventSerializer(e *Event) *ModuleEventSerializer {
 
 func serializeSyscallRetval(retval int64) string {
 	switch {
-	case int(syscall.Errno(retval)) == -int(syscall.EACCES) || int(syscall.Errno(retval)) == -int(syscall.EPERM):
-		return "Refused"
 	case retval < 0:
+		if syscall.Errno(-retval) == syscall.EACCES || syscall.Errno(-retval) == syscall.EPERM {
+			return "Refused"
+		}
 		return "Error"
 	default:
 		return "Success"

--- a/pkg/security/probe/serializers.go
+++ b/pkg/security/probe/serializers.go
@@ -570,7 +570,7 @@ func newUnloadModuleEventSerializer(e *Event) *ModuleEventSerializer {
 
 func serializeSyscallRetval(retval int64) string {
 	switch {
-	case syscall.Errno(retval) == syscall.EACCES || syscall.Errno(retval) == syscall.EPERM:
+	case int(syscall.Errno(retval)) == -int(syscall.EACCES) || int(syscall.Errno(retval)) == -int(syscall.EPERM):
 		return "Refused"
 	case retval < 0:
 		return "Error"


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Fix the serialisation of EACCESS and EPERM error retvals.
Should now be serialised as "Refused" instead of "Error".

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
