### PR TITLE
Add reporting of container CPU limit on Docker collector

### DIFF
--- a/pkg/util/cgroups/cgroup_shared.go
+++ b/pkg/util/cgroups/cgroup_shared.go
@@ -18,11 +18,11 @@ const (
 	procCgroupFile  = "cgroup"
 )
 
-// parseCPUSetFormat counts CPUs in CPUSet specs like "0,1,5-8". These are comma-separated lists
+// ParseCPUSetFormat counts CPUs in CPUSet specs like "0,1,5-8". These are comma-separated lists
 // of processor IDs, with hyphenated ranges representing closed sets.
 // So "0,1,5-8" represents processors 0, 1, 5, 6, 7, 8.
 // The function returns the count of CPUs, in this case 6.
-func parseCPUSetFormat(line string) uint64 {
+func ParseCPUSetFormat(line string) uint64 {
 	var numCPUs uint64
 
 	lineSlice := strings.Split(line, ",")

--- a/pkg/util/cgroups/cgroup_shared_test.go
+++ b/pkg/util/cgroups/cgroup_shared_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestCPUSetParsing(t *testing.T) {
-	assert.EqualValues(t, parseCPUSetFormat("0,1,5-8"), 6)
-	assert.EqualValues(t, parseCPUSetFormat("1"), 1)
-	assert.EqualValues(t, parseCPUSetFormat("2-3"), 2)
+	assert.EqualValues(t, ParseCPUSetFormat("0,1,5-8"), 6)
+	assert.EqualValues(t, ParseCPUSetFormat("1"), 1)
+	assert.EqualValues(t, ParseCPUSetFormat("2-3"), 2)
 }

--- a/pkg/util/cgroups/cgroupv1_cpu.go
+++ b/pkg/util/cgroups/cgroupv1_cpu.go
@@ -79,7 +79,7 @@ func (c *cgroupV1) parseCPUSetController(stats *CPUStats) {
 	// Normally there's only one line, but as the parser works line by line anyway, we do support multiple lines
 	var cpuCount uint64
 	err := parseFile(c.fr, c.pathFor("cpuset", "cpuset.cpus"), func(line string) error {
-		cpuCount += parseCPUSetFormat(line)
+		cpuCount += ParseCPUSetFormat(line)
 		return nil
 	})
 

--- a/pkg/util/cgroups/cgroupv2_cpu.go
+++ b/pkg/util/cgroups/cgroupv2_cpu.go
@@ -54,7 +54,7 @@ func (c *cgroupV2) parseCPUSetController(stats *CPUStats) {
 	// Normally there's only one line, but as the parser works line by line anyway, we do support multiple lines
 	var cpuCount uint64
 	err := parseFile(c.fr, c.pathFor("cpuset.cpus.effective"), func(line string) error {
-		cpuCount += parseCPUSetFormat(line)
+		cpuCount += ParseCPUSetFormat(line)
 		return nil
 	})
 

--- a/pkg/util/containers/v2/metrics/docker/collector_test.go
+++ b/pkg/util/containers/v2/metrics/docker/collector_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
 
-func Test_convertNetworkStats(t *testing.T) {
+func TestConvertNetworkStats(t *testing.T) {
 	tests := []struct {
 		name           string
 		input          map[string]types.NetworkStats

--- a/pkg/util/containers/v2/metrics/docker/collector_windows_test.go
+++ b/pkg/util/containers/v2/metrics/docker/collector_windows_test.go
@@ -12,10 +12,12 @@ import (
 	"testing"
 
 	"github.com/docker/docker/api/types"
+	"github.com/docker/docker/api/types/container"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics/provider"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
+	"github.com/DataDog/datadog-agent/pkg/util/system"
 )
 
 func Test_convertCPUStats(t *testing.T) {
@@ -128,6 +130,70 @@ func Test_convetrPIDStats(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			assert.Equal(t, &test.expectedOutput, convertPIDStats(test.input))
+		})
+	}
+}
+
+func Test_computeCPULimit(t *testing.T) {
+	tests := []struct {
+		name          string
+		spec          *types.ContainerJSON
+		expectedLimit float64
+	}{
+		{
+			name: "No CPU Limit",
+			spec: &types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					HostConfig: &container.HostConfig{},
+				},
+			},
+			expectedLimit: 100 * float64(system.HostCPUCount()),
+		},
+		{
+			name: "Nano CPUs",
+			spec: &types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					HostConfig: &container.HostConfig{
+						Resources: container.Resources{
+							NanoCPUs: 5000000000,
+						},
+					},
+				},
+			},
+			expectedLimit: 500,
+		},
+		{
+			name: "CPU Percent",
+			spec: &types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					HostConfig: &container.HostConfig{
+						Resources: container.Resources{
+							CPUPercent: 50,
+						},
+					},
+				},
+			},
+			expectedLimit: 50 * float64(system.HostCPUCount()),
+		},
+		{
+			name: "CPU Count",
+			spec: &types.ContainerJSON{
+				ContainerJSONBase: &types.ContainerJSONBase{
+					HostConfig: &container.HostConfig{
+						Resources: container.Resources{
+							CPUCount: 2,
+						},
+					},
+				},
+			},
+			expectedLimit: 200,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			containerStats := &provider.ContainerStats{CPU: &provider.ContainerCPUStats{}}
+			computeCPULimit(containerStats, tt.spec)
+			assert.Equal(t, tt.expectedLimit, *containerStats.CPU.Limit)
 		})
 	}
 }


### PR DESCRIPTION
### What does this PR do?

Add reporting of CPU limit in the Docker metrics collector.

### Motivation

Is currently provided by legacy container monitoring (used only on Windows)

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the Agent on Windows+Docker or Linux+Docker, the metric `docker.cpu.limit` should be generated correctly based on the limit set at runtime (CPUCount, CPUs, CFS Quotas, etc.)

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
