### PR TITLE
[pkg/config] Exclude DD_INSIDE_CI from being flagged as unknown env var

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1140,6 +1140,7 @@ func findUnknownEnvVars(config Config, environ []string) []string {
 	knownVars := map[string]struct{}{
 		// these variables are used by the agent, but not via the Config struct,
 		// so must be listed separately.
+		"DD_INSIDE_CI":      {},
 		"DD_PROXY_NO_PROXY": {},
 		"DD_PROXY_HTTP":     {},
 		"DD_PROXY_HTTPS":    {},

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -154,6 +154,7 @@ func TestUnknownVarsWarning(t *testing.T) {
 	t.Run("DD_PROXY_NO_PROXY", test("DD_PROXY_NO_PROXY", false))
 	t.Run("DD_PROXY_HTTP", test("DD_PROXY_HTTP", false))
 	t.Run("DD_PROXY_HTTPS", test("DD_PROXY_HTTPS", false))
+	t.Run("DD_INSIDE_CI", test("DD_INSIDE_CI", false))
 }
 
 func TestSiteEnvVar(t *testing.T) {

--- a/pkg/flare/envvars.go
+++ b/pkg/flare/envvars.go
@@ -87,6 +87,9 @@ var allowedEnvvarNames = []string{
 	"DD_PROCESS_AGENT_CONTAINER_SOURCE",
 	"DD_SYSTEM_PROBE_ENABLED",
 	"DD_SYSTEM_PROBE_NETWORK_ENABLED",
+
+	// CI
+	"DD_INSIDE_CI",
 }
 
 func getAllowedEnvvars() []string {


### PR DESCRIPTION
### What does this PR do?

Removes `DD_INSIDE_CI` from unknown env var warnings emitted by the agent.

### Motivation

This env var is externally tracked in the container startup scripts so
it can be safely ignored in the config checking for unknown variables.

### Additional Notes

Fixes: #10969 

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

- Run the agent with `DD_INSIDE_CI` variable set
- Ensure there are no warnings about this variable being unknown

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
