### PR TITLE
Do not rely on payload serialization for `agent check --json`

### DIFF
--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -614,13 +614,14 @@ func getMetricsData(demux aggregator.Demultiplexer) map[string]interface{} {
 
 	series, sketches := agg.GetSeriesAndSketches(time.Now())
 	if len(series) != 0 {
-		// Workaround to get the raw sequence of metrics, see:
-		// https://github.com/DataDog/datadog-agent/blob/b2d9527ec0ec0eba1a7ae64585df443c5b761610/pkg/metrics/series.go#L109-L122
-		var data map[string]interface{}
-		sj, _ := json.Marshal(series)
-		json.Unmarshal(sj, &data) //nolint:errcheck
+		metrics := make([]interface{}, len(series))
+		// Workaround to get the sequence of metrics as plain interface{}
+		for i, serie := range series {
+			sj, _ := json.Marshal(serie)
+			json.Unmarshal(sj, &metrics[i]) //nolint:errcheck
+		}
 
-		aggData["metrics"] = data["series"]
+		aggData["metrics"] = metrics
 	}
 	if len(sketches) != 0 {
 		aggData["sketches"] = sketches


### PR DESCRIPTION
### What does this PR do?

`agent check --json` used to rely on the v1 JSON serialization being available as the
default JSON serialization for a series, but that undocumented
arrangement is no longer the case.  This now serializes the list of
serie's directly, which uses the default JSON serialization.

### Motivation

Fix broken integration tests for integrations-core.

### Describe how to test/QA your changes

Run `agent check load --json` and verify that the `metrics` field is non-null.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
