### PR TITLE
pkg/trace: Fix trace-agent heap regression

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -323,7 +323,7 @@ func (a *Agent) Process(p *api.Payload) {
 			// payload size is getting big; split and flush what we have so far
 			ss.TracerPayload = p.TracerPayload.Cut(i)
 			i = 0
-			ss.TracerPayload.Chunks = newChunksArray(p.TracerPayload.Chunks)
+			ss.TracerPayload.Chunks = newChunksArray(ss.TracerPayload.Chunks)
 			a.TraceWriter.In <- ss
 			ss = new(writer.SampledChunks)
 		}

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -323,11 +323,17 @@ func (a *Agent) Process(p *api.Payload) {
 			// payload size is getting big; split and flush what we have so far
 			ss.TracerPayload = p.TracerPayload.Cut(i)
 			i = 0
+			toFlush := make([]*pb.TraceChunk, len(p.TracerPayload.Chunks))
+			copy(toFlush, p.TracerPayload.Chunks)
+			ss.TracerPayload.Chunks = toFlush
 			a.TraceWriter.In <- ss
 			ss = new(writer.SampledChunks)
 		}
 	}
 	ss.TracerPayload = p.TracerPayload
+	toFlush := make([]*pb.TraceChunk, len(p.TracerPayload.Chunks))
+	copy(toFlush, p.TracerPayload.Chunks)
+	ss.TracerPayload.Chunks = toFlush
 	if ss.Size > 0 {
 		a.TraceWriter.In <- ss
 	}

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -323,23 +323,29 @@ func (a *Agent) Process(p *api.Payload) {
 			// payload size is getting big; split and flush what we have so far
 			ss.TracerPayload = p.TracerPayload.Cut(i)
 			i = 0
-			toFlush := make([]*pb.TraceChunk, len(p.TracerPayload.Chunks))
-			copy(toFlush, p.TracerPayload.Chunks)
-			ss.TracerPayload.Chunks = toFlush
+			ss.TracerPayload.Chunks = newChunksArray(p.TracerPayload.Chunks)
 			a.TraceWriter.In <- ss
 			ss = new(writer.SampledChunks)
 		}
 	}
 	ss.TracerPayload = p.TracerPayload
-	toFlush := make([]*pb.TraceChunk, len(p.TracerPayload.Chunks))
-	copy(toFlush, p.TracerPayload.Chunks)
-	ss.TracerPayload.Chunks = toFlush
+	ss.TracerPayload.Chunks = newChunksArray(p.TracerPayload.Chunks)
 	if ss.Size > 0 {
 		a.TraceWriter.In <- ss
 	}
 	if len(statsInput.Traces) > 0 {
 		a.Concentrator.In <- statsInput
 	}
+}
+
+// newChunksArray creates a new array which will point only to sampled chunks.
+
+// The underlying array behind TracePayload.Chunks points to unsampled chunks
+// preventing them from being collected by the GC.
+func newChunksArray(chunks []*pb.TraceChunk) []*pb.TraceChunk {
+	new := make([]*pb.TraceChunk, len(chunks))
+	copy(new, chunks)
+	return new
 }
 
 var _ api.StatsProcessor = (*Agent)(nil)

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -15,6 +15,8 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -880,6 +882,84 @@ func TestSampling(t *testing.T) {
 			assert.EqualValues(t, tt.wantSampled, sampled)
 		})
 	}
+}
+
+func TestPartialSamplingFree(t *testing.T) {
+	cfg := &config.AgentConfig{DisableRareSampler: true, BucketInterval: 10 * time.Second}
+	statsChan := make(chan pb.StatsPayload, 100)
+	writerChan := make(chan *writer.SampledChunks, 100)
+	dynConf := sampler.NewDynamicConfig()
+	in := make(chan *api.Payload, 1000)
+	agnt := &Agent{
+		Concentrator:      stats.NewConcentrator(cfg, statsChan, time.Now()),
+		Blacklister:       filters.NewBlacklister(cfg.Ignore["resource"]),
+		Replacer:          filters.NewReplacer(cfg.ReplaceTags),
+		NoPrioritySampler: sampler.NewNoPrioritySampler(cfg),
+		ErrorsSampler:     sampler.NewErrorsSampler(cfg),
+		PrioritySampler:   sampler.NewPrioritySampler(cfg, &sampler.DynamicConfig{}),
+		EventProcessor:    newEventProcessor(cfg),
+		RareSampler:       sampler.NewRareSampler(),
+		TraceWriter:       &writer.TraceWriter{In: writerChan},
+		conf:              cfg,
+	}
+	agnt.Receiver = api.NewHTTPReceiver(cfg, dynConf, in, agnt)
+	now := time.Now()
+	smallKeptSpan := &pb.Span{
+		TraceID:  1,
+		SpanID:   1,
+		Service:  "s",
+		Name:     "n",
+		Resource: "aaaa",
+		Type:     "web",
+		Start:    now.Add(-time.Second).UnixNano(),
+		Duration: (500 * time.Millisecond).Nanoseconds(),
+		Metrics:  map[string]float64{"_sampling_priority_v1": 1.0},
+	}
+
+	tracerPayload := testutil.TracerPayloadWithChunk(testutil.TraceChunkWithSpan(smallKeptSpan))
+
+	runtime.GC()
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	assert.Less(t, m.HeapInuse, uint64(50*1e6))
+
+	droppedSpan := &pb.Span{
+		TraceID:  1,
+		SpanID:   1,
+		Service:  "s",
+		Name:     "n",
+		Resource: "bbb",
+		Type:     "web",
+		Start:    now.Add(-time.Second).UnixNano(),
+		Duration: (500 * time.Millisecond).Nanoseconds(),
+		Metrics:  map[string]float64{"_sampling_priority_v1": 0.0},
+		Meta:     map[string]string{},
+	}
+	for i := 0; i < 5*1e3; i++ {
+		droppedSpan.Meta[strconv.Itoa(i)] = strings.Repeat("0123456789", 1e3)
+	}
+	bigChunk := testutil.TraceChunkWithSpan(droppedSpan)
+	bigChunk.Origin = strings.Repeat("0123456789", 50*1e6)
+	tracerPayload.Chunks = append(tracerPayload.Chunks, bigChunk)
+	runtime.GC()
+	runtime.ReadMemStats(&m)
+	assert.Greater(t, m.HeapInuse, uint64(50*1e6))
+	agnt.Process(&api.Payload{
+		TracerPayload: tracerPayload,
+		Source:        info.NewReceiverStats().GetTagStats(info.Tags{}),
+	})
+	runtime.GC()
+	runtime.ReadMemStats(&m)
+	assert.Greater(t, m.HeapInuse, uint64(50*1e6))
+
+	<-agnt.Concentrator.In
+	// big chunk should be cleaned as unsampled and passed through stats
+	runtime.GC()
+	runtime.ReadMemStats(&m)
+	assert.Less(t, m.HeapInuse, uint64(50*1e6))
+
+	p := <-agnt.TraceWriter.In
+	assert.Len(t, p.TracerPayload.Chunks, 1)
 }
 
 func TestEventProcessorFromConf(t *testing.T) {

--- a/pkg/trace/writer/stats.go
+++ b/pkg/trace/writer/stats.go
@@ -155,7 +155,11 @@ func (w *StatsWriter) sendPayloads() {
 	for _, p := range w.payloads {
 		w.SendPayload(p)
 	}
-	w.payloads = w.payloads[:0]
+	w.resetBuffer()
+}
+
+func (w *StatsWriter) resetBuffer() {
+	w.payloads = make([]pb.StatsPayload, 0, len(w.payloads))
 }
 
 // encodePayload encodes the payload as Gzipped msgPack into w.

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -212,7 +212,7 @@ outer:
 
 func (w *TraceWriter) resetBuffer() {
 	w.bufferedSize = 0
-	w.tracerPayloads = w.tracerPayloads[:0]
+	w.tracerPayloads = make([]*pb.TracerPayload, 0, len(w.tracerPayloads))
 }
 
 const headerLanguages = "X-Datadog-Reported-Languages"
@@ -235,7 +235,6 @@ func (w *TraceWriter) flush() {
 		ErrorTPS:       w.errorTPS,
 		TracerPayloads: w.tracerPayloads,
 	}
-	log.DebugfServerless("Sending trace payload : %+v", p)
 	b, err := proto.Marshal(&p)
 	if err != nil {
 		log.Errorf("Failed to serialize payload, data dropped: %v", err)

--- a/pkg/trace/writer/trace_test.go
+++ b/pkg/trace/writer/trace_test.go
@@ -9,6 +9,7 @@ import (
 	"compress/gzip"
 	"io/ioutil"
 	"reflect"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -187,6 +188,42 @@ func TestTraceWriterFlushSync(t *testing.T) {
 		assert.Equal(t, 1, srv.Accepted())
 		payloadsContain(t, srv.Payloads(), testSpans)
 	})
+}
+
+func TestResetBuffer(t *testing.T) {
+	srv := newTestServer()
+	cfg := &config.AgentConfig{
+		Hostname:   testHostname,
+		DefaultEnv: testEnv,
+		Endpoints: []*config.Endpoint{{
+			APIKey: "123",
+			Host:   srv.URL,
+		}},
+		TraceWriter:         &config.WriterConfig{ConnectionLimit: 200, QueueSize: 40},
+		SynchronousFlushing: true,
+	}
+
+	w := NewTraceWriter(cfg)
+
+	runtime.GC()
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	assert.Less(t, m.HeapInuse, uint64(50*1e6))
+
+	bigPayload := &pb.TracerPayload{
+		ContainerID: string(make([]byte, 50*1e6)),
+	}
+
+	w.tracerPayloads = append(w.tracerPayloads, bigPayload)
+
+	runtime.GC()
+	runtime.ReadMemStats(&m)
+	assert.Greater(t, m.HeapInuse, uint64(50*1e6))
+
+	w.resetBuffer()
+	runtime.GC()
+	runtime.ReadMemStats(&m)
+	assert.Less(t, m.HeapInuse, uint64(50*1e6))
 }
 
 func TestTraceWriterSyncStop(t *testing.T) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

The underlying array containing all traces is not collected by the GC. The slice sent to the writer points to it. 

[This fix has the same effect as applying this revert PR](https://github.com/DataDog/datadog-agent/pull/11003) on multiple benchmark setup we did. We return to the nominal heap usage.

Before and after <img width="1242" alt="image" src="https://user-images.githubusercontent.com/22001182/154779637-c15a09b1-c585-4225-a400-22180936df83.png">


The fix is significant in volume as we buffer for couple seconds spans to flush to the backend. Samplers keep about 10 "chunks" per second, while the setup sends 40K/s. Meaning that the backing array of slice of traces in the array would hold alive 4k x more data then contained in the slice

Added some tests to enforce the fix.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
