### PR TITLE
[release]  Fix trace-agent ram regression on rc 7.34

### DIFF
--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -15,6 +15,8 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -880,6 +882,84 @@ func TestSampling(t *testing.T) {
 			assert.EqualValues(t, tt.wantSampled, sampled)
 		})
 	}
+}
+
+func TestPartialSamplingFree(t *testing.T) {
+	cfg := &config.AgentConfig{DisableRareSampler: true, BucketInterval: 10 * time.Second}
+	statsChan := make(chan pb.StatsPayload, 100)
+	writerChan := make(chan *writer.SampledChunks, 100)
+	dynConf := sampler.NewDynamicConfig()
+	in := make(chan *api.Payload, 1000)
+	agnt := &Agent{
+		Concentrator:      stats.NewConcentrator(cfg, statsChan, time.Now()),
+		Blacklister:       filters.NewBlacklister(cfg.Ignore["resource"]),
+		Replacer:          filters.NewReplacer(cfg.ReplaceTags),
+		NoPrioritySampler: sampler.NewNoPrioritySampler(cfg),
+		ErrorsSampler:     sampler.NewErrorsSampler(cfg),
+		PrioritySampler:   sampler.NewPrioritySampler(cfg, &sampler.DynamicConfig{}),
+		EventProcessor:    newEventProcessor(cfg),
+		RareSampler:       sampler.NewRareSampler(),
+		TraceWriter:       &writer.TraceWriter{In: writerChan},
+		conf:              cfg,
+	}
+	agnt.Receiver = api.NewHTTPReceiver(cfg, dynConf, in, agnt)
+	now := time.Now()
+	smallKeptSpan := &pb.Span{
+		TraceID:  1,
+		SpanID:   1,
+		Service:  "s",
+		Name:     "n",
+		Resource: "aaaa",
+		Type:     "web",
+		Start:    now.Add(-time.Second).UnixNano(),
+		Duration: (500 * time.Millisecond).Nanoseconds(),
+		Metrics:  map[string]float64{"_sampling_priority_v1": 1.0},
+	}
+
+	tracerPayload := testutil.TracerPayloadWithChunk(testutil.TraceChunkWithSpan(smallKeptSpan))
+
+	runtime.GC()
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	assert.Less(t, m.HeapInuse, uint64(50*1e6))
+
+	droppedSpan := &pb.Span{
+		TraceID:  1,
+		SpanID:   1,
+		Service:  "s",
+		Name:     "n",
+		Resource: "bbb",
+		Type:     "web",
+		Start:    now.Add(-time.Second).UnixNano(),
+		Duration: (500 * time.Millisecond).Nanoseconds(),
+		Metrics:  map[string]float64{"_sampling_priority_v1": 0.0},
+		Meta:     map[string]string{},
+	}
+	for i := 0; i < 5*1e3; i++ {
+		droppedSpan.Meta[strconv.Itoa(i)] = strings.Repeat("0123456789", 1e3)
+	}
+	bigChunk := testutil.TraceChunkWithSpan(droppedSpan)
+	bigChunk.Origin = strings.Repeat("0123456789", 50*1e6)
+	tracerPayload.Chunks = append(tracerPayload.Chunks, bigChunk)
+	runtime.GC()
+	runtime.ReadMemStats(&m)
+	assert.Greater(t, m.HeapInuse, uint64(50*1e6))
+	agnt.Process(&api.Payload{
+		TracerPayload: tracerPayload,
+		Source:        info.NewReceiverStats().GetTagStats(info.Tags{}),
+	})
+	runtime.GC()
+	runtime.ReadMemStats(&m)
+	assert.Greater(t, m.HeapInuse, uint64(50*1e6))
+
+	<-agnt.Concentrator.In
+	// big chunk should be cleaned as unsampled and passed through stats
+	runtime.GC()
+	runtime.ReadMemStats(&m)
+	assert.Less(t, m.HeapInuse, uint64(50*1e6))
+
+	p := <-agnt.TraceWriter.In
+	assert.Len(t, p.TracerPayload.Chunks, 1)
 }
 
 func TestEventProcessorFromConf(t *testing.T) {

--- a/pkg/trace/writer/stats.go
+++ b/pkg/trace/writer/stats.go
@@ -155,7 +155,11 @@ func (w *StatsWriter) sendPayloads() {
 	for _, p := range w.payloads {
 		w.SendPayload(p)
 	}
-	w.payloads = w.payloads[:0]
+	w.resetBuffer()
+}
+
+func (w *StatsWriter) resetBuffer() {
+	w.payloads = make([]pb.StatsPayload, 0, len(w.payloads))
 }
 
 // encodePayload encodes the payload as Gzipped msgPack into w.

--- a/pkg/trace/writer/trace.go
+++ b/pkg/trace/writer/trace.go
@@ -212,7 +212,7 @@ outer:
 
 func (w *TraceWriter) resetBuffer() {
 	w.bufferedSize = 0
-	w.tracerPayloads = w.tracerPayloads[:0]
+	w.tracerPayloads = make([]*pb.TracerPayload, 0, len(w.tracerPayloads))
 }
 
 const headerLanguages = "X-Datadog-Reported-Languages"

--- a/pkg/trace/writer/trace_test.go
+++ b/pkg/trace/writer/trace_test.go
@@ -9,6 +9,7 @@ import (
 	"compress/gzip"
 	"io/ioutil"
 	"reflect"
+	"runtime"
 	"sync"
 	"testing"
 
@@ -187,6 +188,42 @@ func TestTraceWriterFlushSync(t *testing.T) {
 		assert.Equal(t, 1, srv.Accepted())
 		payloadsContain(t, srv.Payloads(), testSpans)
 	})
+}
+
+func TestResetBuffer(t *testing.T) {
+	srv := newTestServer()
+	cfg := &config.AgentConfig{
+		Hostname:   testHostname,
+		DefaultEnv: testEnv,
+		Endpoints: []*config.Endpoint{{
+			APIKey: "123",
+			Host:   srv.URL,
+		}},
+		TraceWriter:         &config.WriterConfig{ConnectionLimit: 200, QueueSize: 40},
+		SynchronousFlushing: true,
+	}
+
+	w := NewTraceWriter(cfg)
+
+	runtime.GC()
+	var m runtime.MemStats
+	runtime.ReadMemStats(&m)
+	assert.Less(t, m.HeapInuse, uint64(50*1e6))
+
+	bigPayload := &pb.TracerPayload{
+		ContainerID: string(make([]byte, 50*1e6)),
+	}
+
+	w.tracerPayloads = append(w.tracerPayloads, bigPayload)
+
+	runtime.GC()
+	runtime.ReadMemStats(&m)
+	assert.Greater(t, m.HeapInuse, uint64(50*1e6))
+
+	w.resetBuffer()
+	runtime.GC()
+	runtime.ReadMemStats(&m)
+	assert.Less(t, m.HeapInuse, uint64(50*1e6))
 }
 
 func TestTraceWriterSyncStop(t *testing.T) {


### PR DESCRIPTION
Port https://github.com/DataDog/datadog-agent/pull/11005#pullrequestreview-888073767 to agent 7.34 rc

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
