### PR TITLE
[CWS] fix CentOS 7 kernel headers download

### DIFF
--- a/pkg/util/kernel/find_headers.go
+++ b/pkg/util/kernel/find_headers.go
@@ -31,6 +31,7 @@ const sysfsHeadersPath = "/sys/kernel/kheaders.tar.xz"
 const kernelModulesPath = "/lib/modules/%s/build"
 const debKernelModulesPath = "/lib/modules/%s/source"
 const cosKernelModulesPath = "/usr/src/linux-headers-%s"
+const centosKernelModulesPath = "/usr/src/kernels/%s"
 const fedoraKernelModulesPath = "/usr"
 
 var versionCodeRegexp = regexp.MustCompile(`^#define[\t ]+LINUX_VERSION_CODE[\t ]+(\d+)$`)
@@ -245,6 +246,7 @@ func getDefaultHeaderDirs() []string {
 		fmt.Sprintf(kernelModulesPath, hi.KernelVersion),
 		fmt.Sprintf(debKernelModulesPath, hi.KernelVersion),
 		fmt.Sprintf(cosKernelModulesPath, hi.KernelVersion),
+		fmt.Sprintf(centosKernelModulesPath, hi.KernelVersion),
 		fedoraKernelModulesPath,
 	}
 	return dirs

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -78,7 +78,7 @@ if node['platform_family'] != 'windows'
       content <<-EOF
       FROM centos:7
       ADD nikos.tar.gz /opt/datadog-agent/embedded/nikos/embedded/
-      RUN yum -y install xfsprogs e2fsprogs glibc.i686'
+      RUN yum -y install xfsprogs e2fsprogs
       CMD sleep 7200
       EOF
       action :create
@@ -113,11 +113,6 @@ if node['platform_family'] != 'windows'
     docker_exec 'debug_fs' do
       container 'docker-testsuite'
       command ['mount', '-t', 'debugfs', 'none', '/sys/kernel/debug']
-    end
-
-    docker_exec 'install_xfs' do
-      container 'docker-testsuite'
-      command ['yum', '-y', 'install', 'xfsprogs', 'e2fsprogs']
     end
 
     for i in 0..7 do

--- a/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
+++ b/test/kitchen/site-cookbooks/dd-security-agent-check/recipes/default.rb
@@ -74,16 +74,26 @@ if node['platform_family'] != 'windows'
       end
     end
 
-    docker_image 'centos' do
-      tag '7'
-      action :pull
+    file "#{wrk_dir}/Dockerfile" do
+      content <<-EOF
+      FROM centos:7
+      ADD nikos.tar.gz /opt/datadog-agent/embedded/nikos/embedded/
+      RUN yum -y install xfsprogs e2fsprogs glibc.i686'
+      CMD sleep 7200
+      EOF
+      action :create
+    end
+
+    docker_image 'testsuite-img' do
+      tag 'latest'
+      source wrk_dir
+      action :build
     end
 
     docker_container 'docker-testsuite' do
-      repo 'centos'
-      tag '7'
+      repo 'testsuite-img'
+      tag 'latest'
       cap_add ['SYS_ADMIN', 'SYS_RESOURCE', 'SYS_PTRACE', 'NET_ADMIN', 'IPC_LOCK', 'ALL']
-      command "sleep 7200"
       volumes [
         '/tmp/security-agent:/tmp/security-agent',
         '/proc:/host/proc',


### PR DESCRIPTION
### What does this PR do?

This PR:
- adds CentOS 7 kernel headers location to search algorithm
- fixes functional tests to extract Nikos into the docker container

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
