### PR TITLE
[CWS] fix cws functional tests lints

### DIFF
--- a/pkg/security/tests/filters_test.go
+++ b/pkg/security/tests/filters_test.go
@@ -140,10 +140,7 @@ func TestOpenLeafDiscarderFilter(t *testing.T) {
 			return false
 		}
 		v, _ := e.GetFieldValue("open.file.path")
-		if v == testFile {
-			return true
-		}
-		return false
+		return v == testFile
 	}); err != nil {
 		inode := getInode(t, testFile)
 		parentInode := getInode(t, path.Dir(testFile))
@@ -202,10 +199,7 @@ func testOpenParentDiscarderFilter(t *testing.T, parents ...string) {
 			return false
 		}
 		v, _ := e.GetFieldValue("open.file.path")
-		if v == testFile {
-			return true
-		}
-		return false
+		return v == testFile
 	}); err != nil {
 		inode := getInode(t, testFile)
 		parentInode := getInode(t, path.Dir(testFile))
@@ -401,10 +395,7 @@ func TestOpenProcessPidDiscarder(t *testing.T) {
 			return false
 		}
 		v, _ := e.GetFieldValue("open.file.path")
-		if v == testFile {
-			return true
-		}
-		return false
+		return v == testFile
 	}); err != nil {
 		inode := getInode(t, testFile)
 		parentInode := getInode(t, path.Dir(testFile))
@@ -470,12 +461,7 @@ func TestDiscarderRetentionFilter(t *testing.T) {
 		}
 
 		v, _ := e.GetFieldValue("open.file.path")
-		if v == testFile {
-			return true
-		}
-
-		return false
-
+		return v == testFile
 	}); err != nil {
 		inode := getInode(t, testFile)
 		parentInode := getInode(t, path.Dir(testFile))

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -6,6 +6,8 @@
 //go:build functionaltests || stresstests
 // +build functionaltests stresstests
 
+//lint:file-ignore U1000 Trace Pipe Logger is useful for debugging
+
 package tests
 
 import (

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -1251,7 +1251,7 @@ func randStringRunes(n int) string {
 func checkKernelCompatibility(t *testing.T, why string, skipCheck func(kv *kernel.Version) bool) {
 	kv, err := kernel.NewKernelVersion()
 	if err != nil {
-		t.Errorf("failed to get kernel version: %s", err)
+		t.Errorf("failed to get kernel version: %v", err)
 		return
 	}
 

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -6,8 +6,6 @@
 //go:build functionaltests || stresstests
 // +build functionaltests stresstests
 
-//lint:file-ignore U1000 Trace Pipe Logger is useful for debugging
-
 package tests
 
 import (
@@ -21,6 +19,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"

--- a/pkg/security/tests/module_tester.go
+++ b/pkg/security/tests/module_tester.go
@@ -6,6 +6,8 @@
 //go:build functionaltests || stresstests
 // +build functionaltests stresstests
 
+//lint:file-ignore U1000 Module tester contains debug utilities and functions that are used only for tests or stresstests
+
 package tests
 
 import (

--- a/pkg/security/tests/network_device_test.go
+++ b/pkg/security/tests/network_device_test.go
@@ -71,7 +71,7 @@ func TestNetDevice(t *testing.T) {
 			}
 
 			// retrieve new netnsid
-			fi, err := os.Stat(fmt.Sprintf("/var/run/netns/test_netns"))
+			fi, err := os.Stat("/var/run/netns/test_netns")
 			if err != nil {
 				return err
 			}

--- a/pkg/security/tests/stress_test.go
+++ b/pkg/security/tests/stress_test.go
@@ -64,7 +64,7 @@ func stressOpen(t *testing.T, rule *rules.RuleDefinition, pathname string, size 
 		}
 
 		if size > 0 {
-			data := make([]byte, size, size)
+			data := make([]byte, size)
 			if n, err := f.Write(data); err != nil || n != 1024 {
 				return err
 			}

--- a/pkg/security/tests/stresser_test.go
+++ b/pkg/security/tests/stresser_test.go
@@ -286,7 +286,7 @@ LOOP:
 		}
 	}
 
-	duration := time.Now().Sub(start)
+	duration := time.Since(start)
 
 	pprof.StopCPUProfile()
 	proCPUFile.Close()

--- a/pkg/security/tests/trace_pipe_logger.go
+++ b/pkg/security/tests/trace_pipe_logger.go
@@ -1,0 +1,94 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build functionaltests
+// +build functionaltests
+
+//lint:file-ignore U1000 Trace Pipe Logger is useful for debugging
+
+package tests
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+
+	"github.com/DataDog/datadog-agent/pkg/process/util"
+	"github.com/DataDog/datadog-agent/pkg/security/utils"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
+)
+
+//nolint:unused
+func (tm *testModule) startTracing() (*tracePipeLogger, error) {
+	tracePipe, err := NewTracePipe()
+	if err != nil {
+		return nil, err
+	}
+
+	executable, err := os.Executable()
+	if err != nil {
+		return nil, err
+	}
+
+	logger := &tracePipeLogger{
+		TracePipe:  tracePipe,
+		stop:       make(chan struct{}),
+		executable: filepath.Base(executable),
+	}
+	logger.Start()
+
+	time.Sleep(time.Millisecond * 200)
+
+	return logger, nil
+}
+
+//nolint:unused
+type tracePipeLogger struct {
+	*TracePipe
+	stop       chan struct{}
+	executable string
+}
+
+//nolint:unused
+func (l *tracePipeLogger) handleEvent(event *TraceEvent) {
+	// for some reason, the event task is resolved to "<...>"
+	// so we check that event.PID is the ID of a task of the running process
+	taskPath := filepath.Join(util.HostProc(), strconv.Itoa(int(utils.Getpid())), "task", event.PID)
+	_, err := os.Stat(taskPath)
+
+	if event.Task == l.executable || (event.Task == "<...>" && err == nil) {
+		log.Debug(event.Raw)
+	}
+}
+
+//nolint:unused
+func (l *tracePipeLogger) Start() {
+	channelEvents, channelErrors := l.Channel()
+
+	go func() {
+		for {
+			select {
+			case <-l.stop:
+				for len(channelEvents) > 0 {
+					l.handleEvent(<-channelEvents)
+				}
+				return
+			case event := <-channelEvents:
+				l.handleEvent(event)
+			case err := <-channelErrors:
+				log.Error(err)
+			}
+		}
+	}()
+}
+
+//nolint:unused
+func (l *tracePipeLogger) Stop() {
+	time.Sleep(time.Millisecond * 200)
+
+	l.stop <- struct{}{}
+	l.Close()
+}

--- a/pkg/security/tests/trace_pipe_logger.go
+++ b/pkg/security/tests/trace_pipe_logger.go
@@ -3,8 +3,8 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-//go:build functionaltests
-// +build functionaltests
+//go:build functionaltests || stresstests
+// +build functionaltests stresstests
 
 //lint:file-ignore U1000 Trace Pipe Logger is useful for debugging
 

--- a/tasks/go.py
+++ b/tasks/go.py
@@ -227,7 +227,7 @@ def ineffassign(ctx, targets):
 
 
 @task
-def staticcheck(ctx, targets, build_tags=None, arch="x64"):
+def staticcheck(ctx, targets, build_tags=None, checks="SA1027", arch="x64"):
     """
     Run staticcheck on targets.
 
@@ -249,7 +249,14 @@ def staticcheck(ctx, targets, build_tags=None, arch="x64"):
     if "jmx" in tags:
         tags.remove("jmx")
 
-    ctx.run("staticcheck -checks=SA1027 -tags=" + ",".join(tags) + " " + " ".join(pkgs))
+    checks = checks.strip()
+    if checks != "":
+        checks = f"-checks {checks}"
+
+    tags_arg = ",".join(tags)
+    pkgs_arg = " ".join(pkgs)
+
+    ctx.run(f"staticcheck {checks} -tags={tags_arg} {pkgs_arg}")
     # staticcheck exits with status 1 when it finds an issue, if we're here
     # everything went smooth
     print("staticcheck found no issues")

--- a/tasks/security_agent.py
+++ b/tasks/security_agent.py
@@ -293,7 +293,7 @@ def build_functional_tests(
         targets = ['./pkg/security/tests']
         vet(ctx, targets=targets, build_tags=build_tags, arch=arch)
         golangci_lint(ctx, targets=targets, build_tags=build_tags, arch=arch)
-        staticcheck(ctx, targets=targets, build_tags=build_tags, arch=arch)
+        staticcheck(ctx, targets=targets, build_tags=build_tags, checks="", arch=arch)
 
     # linters have a hard time with dnf, so we add the build tag after running them
     if nikos_embedded_path:


### PR DESCRIPTION
### What does this PR do?

This PR enables all checks when running linters on functional tests code. It also adds a small argument to the `staticcheck` function allowing caller to pass the list of enabled checks

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
