### PR TITLE
Revert "Use netns provided for conntrack dump if none available (#10540)

### DIFF
--- a/pkg/network/netlink/decoding.go
+++ b/pkg/network/netlink/decoding.go
@@ -45,7 +45,7 @@ const (
 // Con represents a conntrack entry, along with any network namespace info (nsid)
 type Con struct {
 	ct.Con
-	NetNS uint32
+	NetNS int32
 }
 
 func (c Con) String() string {

--- a/pkg/network/netlink/socket.go
+++ b/pkg/network/netlink/socket.go
@@ -118,7 +118,7 @@ func (s *Socket) Receive() ([]netlink.Message, error) {
 }
 
 // ReceiveInto reads one or more netlink.Messages off the socket
-func (s *Socket) ReceiveInto(b []byte) ([]netlink.Message, uint32, error) {
+func (s *Socket) ReceiveInto(b []byte) ([]netlink.Message, int32, error) {
 	oob := make([]byte, unix.CmsgSpace(24))
 	n, oobn, err := s.recvmsg(s.recvbuf, oob, 0)
 	if err != nil {
@@ -148,7 +148,7 @@ func (s *Socket) ReceiveInto(b []byte) ([]netlink.Message, uint32, error) {
 		msgs = append(msgs, m)
 	}
 
-	var netns uint32
+	var netns int32
 	if oobn > 0 {
 		oob = oob[:oobn]
 		scms, err := unix.ParseSocketControlMessage(oob)
@@ -162,13 +162,13 @@ func (s *Socket) ReceiveInto(b []byte) ([]netlink.Message, uint32, error) {
 	return msgs, netns, nil
 }
 
-func parseNetNS(scms []unix.SocketControlMessage) uint32 {
+func parseNetNS(scms []unix.SocketControlMessage) int32 {
 	for _, m := range scms {
 		if m.Header.Level != unix.SOL_NETLINK || m.Header.Type != unix.NETLINK_LISTEN_ALL_NSID {
 			continue
 		}
 
-		return *(*uint32)(unsafe.Pointer(&m.Data[0]))
+		return *(*int32)(unsafe.Pointer(&m.Data[0]))
 	}
 
 	return 0

--- a/pkg/network/tracer/ebpf_conntracker.go
+++ b/pkg/network/tracer/ebpf_conntracker.go
@@ -149,8 +149,8 @@ func (e *ebpfConntracker) processEvent(ev netlink.Event) {
 	for _, c := range conns {
 		if netlink.IsNAT(c) {
 			log.Tracef("initial conntrack %s", c)
-			src := formatKey(c.NetNS, c.Origin)
-			dst := formatKey(c.NetNS, c.Reply)
+			src := formatKey(uint32(c.NetNS), c.Origin)
+			dst := formatKey(uint32(c.NetNS), c.Reply)
 			if src != nil && dst != nil {
 				if err := e.addTranslation(src, dst); err != nil {
 					log.Warnf("error adding initial conntrack entry to ebpf map: %s", err)


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Reverts #10540

### Motivation

We do not want to introduce memory usage changing behavior in 7.35 relative to 7.33

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
