### PR TITLE
[cmd/check] Silence 'forwarder unhealthy' error in check command

### DIFF
--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -32,6 +32,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
+	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/metadata"
 	"github.com/DataDog/datadog-agent/pkg/status"
@@ -136,7 +137,9 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 			}
 
 			// Initializing the aggregator with a flush interval of 0 (to disable the flush goroutines)
-			opts := aggregator.DefaultDemultiplexerOptions(nil)
+			forwarderOpts := forwarder.NewOptions(nil)
+			forwarderOpts.DisableAPIKeyChecking = true
+			opts := aggregator.DefaultDemultiplexerOptions(forwarderOpts)
 			opts.FlushInterval = 0
 			opts.UseNoopEventPlatformForwarder = true
 			opts.UseOrchestratorForwarder = false

--- a/releasenotes/notes/check-cmd-forwarder-health-err-f7fd46cca9ef38fc.yaml
+++ b/releasenotes/notes/check-cmd-forwarder-health-err-f7fd46cca9ef38fc.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Silence the misleading error message
+    ``No valid api key found, reporting the forwarder as unhealthy``
+    from the output of the ``agent check`` command.


### PR DESCRIPTION
### What does this PR do?

Disable the API key check validation logic from the forwarder that's instantiated by the `check` command.

### Motivation

Silences the following misleading error in the `check` command:

```
error: No valid api key found, reporting the forwarder as unhealthy.
```

which was introduced by https://github.com/DataDog/datadog-agent/pull/9657 (7.34) because since this PR the check command instantiates a forwarder (with no api key or domains).

### Additional Notes

This is a small, safe way to fix this misleading error.

Long-term, the code paths that don't need the forwarder should have a way to instantiate a demultiplexer without a forwarder, for example by allowing the demultiplexer to be configured with a `NoopForwarder`. This would also more reliably avoid the other side effects of instantiating a real forwarder (which may start establishing connections, writing/removing transaction files on disk, etc). Follow up card: AC-1581.

### Possible Drawbacks / Trade-offs

None that I can think of.

### Describe how to test/QA your changes

Run the `agent check` command with any check. The error message:

```
error: No valid api key found, reporting the forwarder as unhealthy.
```

should not be printed out.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
