### PR TITLE
Fix arm64 build of NPM http

### DIFF
--- a/pkg/network/ebpf/c/http.h
+++ b/pkg/network/ebpf/c/http.h
@@ -5,6 +5,7 @@
 #include "http-types.h"
 #include "http-maps.h"
 
+#include <linux/kconfig.h>
 #include <uapi/linux/ptrace.h>
 
 static __always_inline void http_prepare_key(u32 cpu, http_batch_key_t *key, http_batch_state_t *batch_state) {


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Adds an include for `linux/kconfig.h` to fix the build of `http.c` for `arm64`.

### Motivation

The build was broken in my dev VM on a M1 laptop. It resulted in the following errors:
```
In file included from /usr/src/linux-headers-5.4.0-92-generic/arch/arm64/include/asm/lse.h:5:
/usr/src/linux-headers-5.4.0-92-generic/arch/arm64/include/asm/atomic_ll_sc.h:15:5: error: function-like macro 'IS_ENABLED' is not defined
#if IS_ENABLED(CONFIG_ARM64_LSE_ATOMICS) && IS_ENABLED(CONFIG_AS_LSE)

In file included from /usr/src/linux-headers-5.4.0-92-generic/arch/arm64/include/asm/ptrace.h:11:
/usr/src/linux-headers-5.4.0-92-generic/arch/arm64/include/asm/cpufeature.h:576:20: error: use of undeclared identifier 'CONFIG_ARM64_SW_TTBR0_PAN'
        return IS_ENABLED(CONFIG_ARM64_SW_TTBR0_PAN) &&
                          ^
/usr/src/linux-headers-5.4.0-92-generic/arch/arm64/include/asm/cpufeature.h:582:20: error: use of undeclared identifier 'CONFIG_ARM64_SVE'
        return IS_ENABLED(CONFIG_ARM64_SVE) &&
                          ^
/usr/src/linux-headers-5.4.0-92-generic/arch/arm64/include/asm/cpufeature.h:588:20: error: use of undeclared identifier 'CONFIG_ARM64_CNP'
        return IS_ENABLED(CONFIG_ARM64_CNP) &&
                          ^
/usr/src/linux-headers-5.4.0-92-generic/arch/arm64/include/asm/cpufeature.h:594:20: error: use of undeclared identifier 'CONFIG_ARM64_PTR_AUTH'
        return IS_ENABLED(CONFIG_ARM64_PTR_AUTH) &&
                          ^
/usr/src/linux-headers-5.4.0-92-generic/arch/arm64/include/asm/cpufeature.h:601:20: error: use of undeclared identifier 'CONFIG_ARM64_PTR_AUTH'
        return IS_ENABLED(CONFIG_ARM64_PTR_AUTH) &&
                          ^
/usr/src/linux-headers-5.4.0-92-generic/arch/arm64/include/asm/cpufeature.h:608:20: error: use of undeclared identifier 'CONFIG_ARM64_PSEUDO_NMI'
        return IS_ENABLED(CONFIG_ARM64_PSEUDO_NMI) &&
                          ^
/usr/src/linux-headers-5.4.0-92-generic/arch/arm64/include/asm/cpufeature.h:614:20: error: use of undeclared identifier 'CONFIG_ARM64_DEBUG_PRIORITY_MASKING'
        return IS_ENABLED(CONFIG_ARM64_DEBUG_PRIORITY_MASKING) &&
                          ^
/usr/src/linux-headers-5.4.0-92-generic/arch/arm64/include/asm/cpufeature.h:661:18: error: use of undeclared identifier 'CONFIG_ARM64_PA_BITS'
        default: return CONFIG_ARM64_PA_BITS;
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
