### PR TITLE
Fix missing `cri.mem.rss` on Windows and cross-processors extensions

### DIFF
--- a/pkg/collector/corechecks/containers/cri/adapter.go
+++ b/pkg/collector/corechecks/containers/cri/adapter.go
@@ -13,11 +13,11 @@ import (
 )
 
 var metricsNameMapping = map[string]string{
-	"container.uptime":     "cri.uptime",
-	"container.cpu.usage":  "cri.cpu.usage",
-	"container.memory.rss": "cri.mem.rss",
-	"cri.disk.used":        "cri.disk.used",   // Passthrough for custom metrics extension
-	"cri.disk.inodes":      "cri.disk.inodes", // Passthrough for custom metrics extension
+	"container.uptime":       "cri.uptime",
+	"container.cpu.usage":    "cri.cpu.usage",
+	"container.memory.usage": "cri.mem.rss",
+	"cri.disk.used":          "cri.disk.used",   // Passthrough for custom metrics extension
+	"cri.disk.inodes":        "cri.disk.inodes", // Passthrough for custom metrics extension
 }
 
 // metricsAdapter implements the generic.MetricsAdapter interface

--- a/pkg/collector/corechecks/containers/cri/check_test.go
+++ b/pkg/collector/corechecks/containers/cri/check_test.go
@@ -83,7 +83,7 @@ func TestCriCheck(t *testing.T) {
 
 	mockSender.AssertMetricInRange(t, "Gauge", "cri.uptime", 0, 600, "", expectedTags)
 	mockSender.AssertMetric(t, "Rate", "cri.cpu.usage", 100, "", expectedTags)
-	mockSender.AssertMetric(t, "Gauge", "cri.mem.rss", 300, "", expectedTags)
+	mockSender.AssertMetric(t, "Gauge", "cri.mem.rss", 42000, "", expectedTags)
 	mockSender.AssertMetric(t, "Gauge", "cri.disk.used", 10, "", expectedTags)
 	mockSender.AssertMetric(t, "Gauge", "cri.disk.inodes", 20, "", expectedTags)
 }

--- a/pkg/collector/corechecks/containers/generic/processor.go
+++ b/pkg/collector/corechecks/containers/generic/processor.go
@@ -25,10 +25,6 @@ const (
 	NetworkExtensionID = "network"
 )
 
-var defaultExtensions = map[string]ProcessorExtension{
-	NetworkExtensionID: NewProcessorNetwork(),
-}
-
 // Processor contains the core logic of the generic check, allowing reusability
 type Processor struct {
 	metricsProvider metrics.Provider
@@ -45,7 +41,9 @@ func NewProcessor(provider metrics.Provider, lister ContainerAccessor, adapter M
 		ctrLister:       lister,
 		metricsAdapter:  adapter,
 		ctrFilter:       filter,
-		extensions:      defaultExtensions,
+		extensions: map[string]ProcessorExtension{
+			NetworkExtensionID: NewProcessorNetwork(),
+		},
 	}
 }
 

--- a/pkg/util/containers/v2/metrics/cri/collector.go
+++ b/pkg/util/containers/v2/metrics/cri/collector.go
@@ -70,7 +70,7 @@ func (collector *criCollector) GetContainerStats(containerID string, cacheValidi
 			Total: pointer.UIntToFloatPtr(stats.GetCpu().GetUsageCoreNanoSeconds().GetValue()),
 		},
 		Memory: &provider.ContainerMemStats{
-			RSS: pointer.UIntToFloatPtr(stats.GetMemory().GetWorkingSetBytes().GetValue()),
+			UsageTotal: pointer.UIntToFloatPtr(stats.GetMemory().GetWorkingSetBytes().GetValue()),
 		},
 	}, nil
 }

--- a/pkg/util/containers/v2/metrics/cri/collector_test.go
+++ b/pkg/util/containers/v2/metrics/cri/collector_test.go
@@ -50,7 +50,7 @@ func TestGetContainerStats(t *testing.T) {
 	assert.NoError(t, err)
 
 	assert.Equal(t, pointer.UIntToFloatPtr(1000), stats.CPU.Total)
-	assert.Equal(t, pointer.UIntToFloatPtr(1024), stats.Memory.RSS)
+	assert.Equal(t, pointer.UIntToFloatPtr(1024), stats.Memory.UsageTotal)
 }
 
 func TestGetContainerNetworkStats(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Fix a bug where `cri.mem.rss` is not reported on Windows, and panic could happen because extensions belonging to another check could be run in a given check.

### Motivation

Bugfix

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Run the Agent on Kubernetes Windows using our Helm chart. The `cri` check should be scheduled and should report the `cri.mem.rss` metric.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
