### PR TITLE
[pkg/config] Fix IsSectionSet prefix confusion edge case

### DIFF
--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -99,7 +99,7 @@ func (c *safeConfig) IsSectionSet(section string) bool {
 		// Add trailing . to make sure we don't take into account unrelated
 		// settings, eg. IsSectionSet("section") shouldn't return true
 		// if "section_key" is set.
-		if strings.HasPrefix(key, section + ".") && c.IsSet(key) {
+		if strings.HasPrefix(key, section+".") && c.IsSet(key) {
 			return true
 		}
 	}

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -95,11 +95,14 @@ func (c *safeConfig) IsSectionSet(section string) bool {
 	// inside it is set.
 	// This is needed when keys within the section
 	// are set through env variables.
+
+	// Add trailing . to make sure we don't take into account unrelated
+	// settings, eg. IsSectionSet("section") shouldn't return true
+	// if "section_key" is set.
+	sectionPrefix := section + "."
+
 	for _, key := range c.AllKeys() {
-		// Add trailing . to make sure we don't take into account unrelated
-		// settings, eg. IsSectionSet("section") shouldn't return true
-		// if "section_key" is set.
-		if strings.HasPrefix(key, section+".") && c.IsSet(key) {
+		if strings.HasPrefix(key, sectionPrefix) && c.IsSet(key) {
 			return true
 		}
 	}

--- a/pkg/config/viper.go
+++ b/pkg/config/viper.go
@@ -96,7 +96,10 @@ func (c *safeConfig) IsSectionSet(section string) bool {
 	// This is needed when keys within the section
 	// are set through env variables.
 	for _, key := range c.AllKeys() {
-		if strings.HasPrefix(key, section) && c.IsSet(key) {
+		// Add trailing . to make sure we don't take into account unrelated
+		// settings, eg. IsSectionSet("section") shouldn't return true
+		// if "section_key" is set.
+		if strings.HasPrefix(key, section + ".") && c.IsSet(key) {
 			return true
 		}
 	}

--- a/pkg/config/viper_test.go
+++ b/pkg/config/viper_test.go
@@ -167,6 +167,7 @@ func TestIsSectionSet(t *testing.T) {
 
 	config.BindEnv("test.key")
 	config.BindEnv("othertest.key")
+	config.SetKnown("yetanothertest_key")
 	config.SetConfigType("yaml")
 
 	yamlExample := []byte(`
@@ -186,4 +187,8 @@ test:
 
 	res = config.IsSectionSet("othertest")
 	assert.Equal(t, true, res)
+
+	config.Set("yetanothertest_key", "value")
+	res = config.IsSectionSet("yetanothertest")
+	assert.Equal(t, false, res)
 }


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->
Fixes `IsSectionSet` to not take into account config options that share a prefix with the section, but aren't part of it.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Avoid cases where `IsSectionSet` would return true for wrong reasons (eg. `IsSectionSet("experimental.otlp.metrics")` returning true when `experimental.otlp.metrics_enabled` is set).

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Check that setting `experimental.otlp.metrics_enabled` doesn't make the Agent log: `failed to get configuration value for key "experimental.otlp.metrics": unable to cast <nil> of type <nil> to map[string]interface{}` (OTLP config is the only place where `IsSectionSet` is used).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
