### PR TITLE
Fix container features being built on macOS

### DIFF
--- a/pkg/config/environment_container_features.go
+++ b/pkg/config/environment_container_features.go
@@ -1,0 +1,28 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package config
+
+// Remember to also register feature in init()
+const (
+	// Docker socket present
+	Docker Feature = "docker"
+	// Containerd socket present
+	Containerd Feature = "containerd"
+	// Cri is any cri socket present
+	Cri Feature = "cri"
+	// Kubernetes environment
+	Kubernetes Feature = "kubernetes"
+	// ECSFargate environment
+	ECSFargate Feature = "ecsfargate"
+	// EKSFargate environment
+	EKSFargate Feature = "eksfargate"
+	// KubeOrchestratorExplorer can be enabled
+	KubeOrchestratorExplorer Feature = "orchestratorexplorer"
+	// CloudFoundry socket present
+	CloudFoundry Feature = "cloudfoundry"
+	// Podman containers storage path accessible
+	Podman Feature = "podman"
+)

--- a/pkg/config/environment_containers.go
+++ b/pkg/config/environment_containers.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build linux || windows
+// +build linux windows
+
 package config
 
 import (
@@ -16,27 +19,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/system"
 )
 
-// Remember to also register feature in init()
 const (
-	// Docker socket present
-	Docker Feature = "docker"
-	// Containerd socket present
-	Containerd Feature = "containerd"
-	// Cri is any cri socket present
-	Cri Feature = "cri"
-	// Kubernetes environment
-	Kubernetes Feature = "kubernetes"
-	// ECSFargate environment
-	ECSFargate Feature = "ecsfargate"
-	// EKSFargate environment
-	EKSFargate Feature = "eksfargate"
-	// KubeOrchestratorExplorer can be enabled
-	KubeOrchestratorExplorer Feature = "orchestratorexplorer"
-	// CloudFoundry socket present
-	CloudFoundry Feature = "cloudfoundry"
-	// Podman containers storage path accessible
-	Podman Feature = "podman"
-
 	defaultLinuxDockerSocket           = "/var/run/docker.sock"
 	defaultWindowsDockerSocketPath     = "//./pipe/docker_engine"
 	defaultLinuxContainerdSocket       = "/var/run/containerd/containerd.sock"

--- a/pkg/config/environment_containers_test.go
+++ b/pkg/config/environment_containers_test.go
@@ -3,6 +3,9 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
+//go:build linux || windows
+// +build linux windows
+
 package config
 
 import (

--- a/pkg/config/environment_detection.go
+++ b/pkg/config/environment_detection.go
@@ -145,6 +145,7 @@ func excludeFeatures(detectedFeatures FeatureMap, excludedFeatures []string) {
 	}
 }
 
+//nolint:deadcode,unused
 func registerFeature(f Feature) {
 	knownFeatures[f] = struct{}{}
 }

--- a/pkg/config/environment_nocontainers.go
+++ b/pkg/config/environment_nocontainers.go
@@ -1,0 +1,17 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build !(linux || windows)
+// +build !linux,!windows
+
+package config
+
+// IsAnyContainerFeaturePresent checks if any of known container features is present
+func IsAnyContainerFeaturePresent() bool {
+	return false
+}
+
+func detectContainerFeatures(features FeatureMap) {
+}

--- a/tasks/build_tags.py
+++ b/tasks/build_tags.py
@@ -134,6 +134,9 @@ LINUX_ONLY_TAGS = {"netcgo", "systemd", "jetson", "linux_bpf", "podman"}
 # List of tags to always remove when building on Windows
 WINDOWS_EXCLUDE_TAGS = {"linux_bpf"}
 
+# List of tags to always remove when building on Darwin/macOS
+DARWIN_EXCLUDED_TAGS = {"docker", "containerd", "cri"}
+
 # List of tags to always remove when building on Windows 32-bits
 WINDOWS_32BIT_EXCLUDE_TAGS = {"docker", "kubeapiserver", "kubelet", "orchestrator"}
 
@@ -221,6 +224,9 @@ def filter_incompatible_tags(include, arch="x64"):
 
     if sys.platform == "win32":
         exclude = exclude.union(WINDOWS_EXCLUDE_TAGS)
+
+    if sys.platform == "darwin":
+        exclude = exclude.union(DARWIN_EXCLUDED_TAGS)
 
     if sys.platform == "win32" and arch == "x86":
         exclude = exclude.union(WINDOWS_32BIT_EXCLUDE_TAGS)


### PR DESCRIPTION
### What does this PR do?

Properly exclude containers build tags on `macOS` to avoid features being pulled in.

### Motivation

Fix some logs seen in `agent` and `process-agent` when running on macOS with Docker Desktop running.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Run the Agent and Process Agent on macOS with Docker Desktop running. No features should be detected.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
