### PR TITLE
Correctly set the `Device` for a serie when running `agent check disk`

### DIFF
--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -617,6 +617,7 @@ func getMetricsData(demux aggregator.Demultiplexer) map[string]interface{} {
 		metrics := make([]interface{}, len(series))
 		// Workaround to get the sequence of metrics as plain interface{}
 		for i, serie := range series {
+			serie.PopulateDeviceField()
 			sj, _ := json.Marshal(serie)
 			json.Unmarshal(sj, &metrics[i]) //nolint:errcheck
 		}

--- a/pkg/serializer/internal/metrics/series_benchmark_test.go
+++ b/pkg/serializer/internal/metrics/series_benchmark_test.go
@@ -27,7 +27,7 @@ func benchmarkPopulateDeviceField(numberOfTags int, b *testing.B) {
 	for n := 0; n < b.N; n++ {
 		serie.Tags = t
 		for _, serie := range series {
-			populateDeviceField(serie)
+			serie.PopulateDeviceField()
 		}
 	}
 }

--- a/pkg/serializer/internal/metrics/series_test.go
+++ b/pkg/serializer/internal/metrics/series_test.go
@@ -56,7 +56,7 @@ func TestPopulateDeviceField(t *testing.T) {
 
 			// Run a few times to ensure stability
 			for i := 0; i < 4; i++ {
-				populateDeviceField(s)
+				s.PopulateDeviceField()
 				assert.Equal(t, strings.Join(tc.ExpectedTags, ","), s.Tags.Join(","))
 				assert.Equal(t, tc.ExpectedDevice, s.Device)
 			}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR fixes an issue introduced by #11004. Behind the scene `json.Marshal(series)` mutates `series` and calls `populateDeviceField` which correctly sets the `Device` field for a serie.
This PR calls `populateDeviceField` for each serie in order to have the same behavior as before #11004.

Side note: `MarshalJSON()` should not mutate the serie by calling `serie.PopulateDeviceField()` as it is misleading.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run `agent check disk --json`. The metric `system.fs.inodes.free` must have the `device` field set and `tags` should not contain a tag starting with `device:`.

```
 {
          "device": "/dev/disk1s6",
          "host": "COMP-C02YP1AAJHD4",
          "interval": 0,
          "metric": "system.fs.inodes.free",
          "points": [
            [
              1645628203,
              4882452861
            ]
          ],
          "source_type_name": "System",
          "tags": [
            "device_name:disk1s6"
          ],
          "type": "gauge"
        }
```
<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
