### PR TITLE
[containers/filter] Don't apply filters to empty names, images or namespaces

### DIFF
--- a/pkg/util/containers/filter.go
+++ b/pkg/util/containers/filter.go
@@ -293,6 +293,8 @@ func NewAutodiscoveryFilter(filter FilterType) (*Filter, error) {
 
 // IsExcluded returns a bool indicating if the container should be excluded
 // based on the filters in the containerFilter instance.
+// Note: exclude filters are not applied to empty container names, empty
+// images and empty namespaces.
 func (cf Filter) IsExcluded(containerName, containerImage, podNamespace string) bool {
 	if !cf.Enabled {
 		return false
@@ -316,19 +318,27 @@ func (cf Filter) IsExcluded(containerName, containerImage, podNamespace string) 
 	}
 
 	// Check if excludeListed
-	for _, r := range cf.ImageExcludeList {
-		if r.MatchString(containerImage) {
-			return true
+	if containerImage != "" {
+		for _, r := range cf.ImageExcludeList {
+			if r.MatchString(containerImage) {
+				return true
+			}
 		}
 	}
-	for _, r := range cf.NameExcludeList {
-		if r.MatchString(containerName) {
-			return true
+
+	if containerName != "" {
+		for _, r := range cf.NameExcludeList {
+			if r.MatchString(containerName) {
+				return true
+			}
 		}
 	}
-	for _, r := range cf.NamespaceExcludeList {
-		if r.MatchString(podNamespace) {
-			return true
+
+	if podNamespace != "" {
+		for _, r := range cf.NamespaceExcludeList {
+			if r.MatchString(podNamespace) {
+				return true
+			}
 		}
 	}
 

--- a/pkg/util/containers/filter_test.go
+++ b/pkg/util/containers/filter_test.go
@@ -236,6 +236,30 @@ func TestFilter(t *testing.T) {
 			},
 			ns: "default",
 		},
+		{
+			c: ctnDef{ // Empty name
+				ID:    "29",
+				Name:  "",
+				Image: "redis",
+			},
+			ns: "default",
+		},
+		{
+			c: ctnDef{ // Empty image
+				ID:    "30",
+				Name:  "empty_image",
+				Image: "",
+			},
+			ns: "default",
+		},
+		{
+			c: ctnDef{ // Empty namespace
+				ID:    "31",
+				Name:  "empty_namespace",
+				Image: "redis",
+			},
+			ns: "",
+		},
 	}
 
 	for i, tc := range []struct {
@@ -244,34 +268,44 @@ func TestFilter(t *testing.T) {
 		expectedIDs []string
 	}{
 		{
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27", "28"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27", "28", "29", "30", "31"},
 		},
 		{
 			excludeList: []string{"name:secret"},
-			expectedIDs: []string{"2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27", "28"},
+			expectedIDs: []string{"2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27", "28", "29", "30", "31"},
 		},
 		{
 			excludeList: []string{"image:secret"},
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27", "28"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27", "28", "29", "30", "31"},
 		},
 		{
 			includeList: []string{},
 			excludeList: []string{"image:apache", "image:alpine"},
-			expectedIDs: []string{"1", "3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27", "28"},
+			expectedIDs: []string{"1", "3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27", "28", "29", "30", "31"},
 		},
 		{
 			includeList: []string{"name:mysql"},
 			excludeList: []string{"name:dd"},
-			expectedIDs: []string{"3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27", "28"},
+			expectedIDs: []string{"3", "5", "6", "7", "8", "9", "10", "11", "12", "13", "16", "17", "18", "19", "20", "23", "24", "25", "26", "27", "28", "29", "30", "31"},
 		},
 		{
 			excludeList: []string{"kube_namespace:.*"},
 			includeList: []string{"kube_namespace:foo"},
-			expectedIDs: []string{"14"},
+			expectedIDs: []string{"14", "31"},
 		},
 		{
 			excludeList: []string{"kube_namespace:bar"},
-			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "19", "20", "23", "24", "25", "26", "27", "28"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "19", "20", "23", "24", "25", "26", "27", "28", "29", "30", "31"},
+		},
+		{
+			excludeList: []string{"name:.*"},
+			includeList: []string{"name:mysql-dd"},
+			expectedIDs: []string{"3", "29"},
+		},
+		{
+			excludeList: []string{"image:.*"},
+			includeList: []string{"image:docker-dd-agent"},
+			expectedIDs: []string{"1", "30"},
 		},
 		// Test kubernetes defaults
 		{
@@ -292,7 +326,7 @@ func TestFilter(t *testing.T) {
 				pauseContainerUpstream,
 				pauseContainerCDK,
 			},
-			expectedIDs: []string{"1", "2", "3", "4", "5", "14", "15"},
+			expectedIDs: []string{"1", "2", "3", "4", "5", "14", "15", "29", "30", "31"},
 		},
 	} {
 		t.Run("", func(t *testing.T) {

--- a/releasenotes/notes/fix-container-is-excluded-empty-params-66890ade669b6105.yaml
+++ b/releasenotes/notes/fix-container-is-excluded-empty-params-66890ade669b6105.yaml
@@ -1,0 +1,11 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    Exclude filters no longer apply to empty container names, images, or namespaces.


### PR DESCRIPTION
### What does this PR do?

Changes the `IsExcluded` function in the `containers` package so it doesn't apply exclude filter to empty names, images or namespaces.

The main use case for this is dealing with pod-level metrics like the ones reported by the Kubelet check. In that case, both the container name and the image are empty. Only the namespace has a non-empty value.

In that case, when the user defines an exclude-all rule (`.*`) for the name or the image, `IsExcluded` is going to return `true` no matter what the namespace is. This PR changes the behavior to be more intuitive, if the value for a param is not provided, the exclude filter for that param is not applied.


### Describe how to test/QA your changes

The Kubelet use case mentioned above is an easy way to test this.

Deploy the agent in Kubernetes with a config like this one:
```
  env:
    - name: "DD_CONTAINER_EXCLUDE"
      value: "image:.*"
    - name: "DD_CONTAINER_INCLUDE"
      value: "image:redis" (any image here works)
```

Check that pod-level metrics (like `kubernetes.network.*`)  are reported (because they can only be excluded with a namespace and there isn't one in the config above).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
