### PR TITLE
Update kitchen tests to use new Process Agent config format

### DIFF
--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -842,7 +842,7 @@ shared_examples_for 'an Agent with process enabled' do
     confYaml = read_conf_file()
     expect(confYaml).to have_key("process_config")
     expect(confYaml["process_config"]).to have_key("process_collection")
-    expect(confYaml["process_collection"]).to have_key("enabled")
+    expect(confYaml["process_config"]["process_collection"]).to have_key("enabled")
     expect(confYaml["process_config"]["process_collection"]["enabled"]).to be_truthy
   end
   it 'has the process agent running' do

--- a/test/kitchen/test/integration/common/rspec/spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/spec_helper.rb
@@ -269,7 +269,7 @@ def is_windows_service_installed(service)
   raise "is_windows_service_installed is only for windows" unless os == :windows
   return windows_service_status(service) != "NOTINSTALLED"
 end
-  
+
 def is_flavor_running?(flavor)
   is_service_running?(get_service_name(flavor))
 end
@@ -841,8 +841,9 @@ shared_examples_for 'an Agent with process enabled' do
   it 'has process enabled' do
     confYaml = read_conf_file()
     expect(confYaml).to have_key("process_config")
-    expect(confYaml["process_config"]).to have_key("enabled")
-    expect(confYaml["process_config"]["enabled"]).to be_truthy
+    expect(confYaml["process_config"]).to have_key("process_collection")
+    expect(confYaml["process_collection"]).to have_key("enabled")
+    expect(confYaml["process_config"]["process_collection"]["enabled"]).to be_truthy
   end
   it 'has the process agent running' do
     expect(is_process_running?("process-agent.exe")).to be_truthy
@@ -878,7 +879,7 @@ shared_examples_for 'an upgraded Agent with the expected version' do
     # Match the first line of the manifest file
     expect(File.open(version_manifest_file) {|f| f.readline.strip}).to match "agent #{agent_expected_version}"
   end
-end 
+end
 
 def get_user_sid(uname)
   output = `powershell -command "(New-Object System.Security.Principal.NTAccount('#{uname}')).Translate([System.Security.Principal.SecurityIdentifier]).value"`.strip

--- a/test/kitchen/test/integration/common/rspec/windows_npm_spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/windows_npm_spec_helper.rb
@@ -67,7 +67,7 @@ shared_examples_for 'a Windows Agent with NPM running' do
     if !confYaml.key("process_config")
       confYaml["process_config"] = {}
     end
-    confYaml["process_config"]["process_collection"]["enabled"] = true
+    confYaml["process_config"]["process_collection"] = { "enabled": true }
     File.write(conf_path, confYaml.to_yaml)
 
     if os != :windows

--- a/test/kitchen/test/integration/common/rspec/windows_npm_spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/windows_npm_spec_helper.rb
@@ -19,7 +19,7 @@ shared_examples_for 'a Windows Agent with NPM driver that can start' do
 
 
   it 'can successfully start the driver' do
-    ## start the service 
+    ## start the service
     result = system "net start ddnpm 2>&1"
 
     ## now expect it to be running
@@ -67,7 +67,7 @@ shared_examples_for 'a Windows Agent with NPM running' do
     if !confYaml.key("process_config")
       confYaml["process_config"] = {}
     end
-    confYaml["process_config"]["enabled"] = "true"
+    confYaml["process_config"]["process_collection"]["enabled"] = "true"
     File.write(conf_path, confYaml.to_yaml)
 
     if os != :windows
@@ -77,7 +77,7 @@ shared_examples_for 'a Windows Agent with NPM running' do
     end
     spf = File.read(spconf_path)
     spconfYaml = YAML.load(spf)
-    if !spconfYaml 
+    if !spconfYaml
       spconfYaml = {}
     end
     if !spconfYaml.key("network_config")

--- a/test/kitchen/test/integration/common/rspec/windows_npm_spec_helper.rb
+++ b/test/kitchen/test/integration/common/rspec/windows_npm_spec_helper.rb
@@ -67,7 +67,7 @@ shared_examples_for 'a Windows Agent with NPM running' do
     if !confYaml.key("process_config")
       confYaml["process_config"] = {}
     end
-    confYaml["process_config"]["process_collection"]["enabled"] = "true"
+    confYaml["process_config"]["process_collection"]["enabled"] = true
     File.write(conf_path, confYaml.to_yaml)
 
     if os != :windows

--- a/test/kitchen/test/integration/win-no-subservices/rspec/win-no-subservices_spec.rb
+++ b/test/kitchen/test/integration/win-no-subservices/rspec/win-no-subservices_spec.rb
@@ -28,8 +28,9 @@ shared_examples_for 'an Agent with process disabled' do
   it 'has process disabled' do
     confYaml = read_conf_file()
     expect(confYaml).to have_key("process_config")
-    expect(confYaml["process_config"]).to have_key("enabled")
-    expect(confYaml["process_config"]["enabled"]).to eq("disabled")
+    expect(confYaml["process_config"]).to have_key("process_collection")
+    expect(confYaml["process_collection"]).to have_key("enabled")
+    expect(confYaml["process_config"]["process_collection"]["enabled"]).to eq("disabled")
     expect(confYaml["process_config"]["process_discovery"]["enabled"]).to eq(false)
   end
   it 'does not have the process agent running' do

--- a/test/kitchen/test/integration/win-no-subservices/rspec/win-no-subservices_spec.rb
+++ b/test/kitchen/test/integration/win-no-subservices/rspec/win-no-subservices_spec.rb
@@ -29,8 +29,8 @@ shared_examples_for 'an Agent with process disabled' do
     confYaml = read_conf_file()
     expect(confYaml).to have_key("process_config")
     expect(confYaml["process_config"]).to have_key("process_collection")
-    expect(confYaml["process_collection"]).to have_key("enabled")
-    expect(confYaml["process_config"]["process_collection"]["enabled"]).to eq("disabled")
+    expect(confYaml["process_config"]["process_collection"]).to have_key("enabled")
+    expect(confYaml["process_config"]["process_collection"]["enabled"]).to eq(false)
     expect(confYaml["process_config"]["process_discovery"]["enabled"]).to eq(false)
   end
   it 'does not have the process agent running' do


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
This PR updates the kitchen tests to use the new Process Agent config format.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation
The PR https://github.com/DataDog/datadog-agent/pull/11057 broke those kitchen tests because the Windows installer now writes the configuration for the Agent Process with the new format, and those tests have not been updated to support it.
<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
