### PR TITLE
[process-agent] Fix reporting of containers without processes

### DIFF
--- a/pkg/process/checks/chunking_test.go
+++ b/pkg/process/checks/chunking_test.go
@@ -605,6 +605,51 @@ func TestChunkProcessesBySizeAndWeight(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "containers with no processes",
+			containers: []*model.Container{
+				ctr("foo"),
+				ctr("bar"),
+				ctr("baz"),
+				ctr("qux"),
+			},
+			procsByCtr: map[string][]*model.Process{
+				"": {
+					proc(100, "top"),
+				},
+				"foo": {
+					proc(2, "foo", strings.Repeat("-", 970)),
+				},
+				"bar": {
+					proc(3, "bar"),
+					proc(4, "bar2"),
+				},
+			},
+			maxChunkSize:   3,
+			maxChunkWeight: 1000,
+			expectedChunks: []*model.CollectorProc{
+				{
+					Containers: []*model.Container{
+						ctr("foo"),
+					},
+					Processes: []*model.Process{
+						proc(100, "top"),
+						proc(2, "foo", strings.Repeat("-", 970)),
+					},
+				},
+				{
+					Containers: []*model.Container{
+						ctr("bar"),
+						ctr("baz"),
+						ctr("qux"),
+					},
+					Processes: []*model.Process{
+						proc(3, "bar"),
+						proc(4, "bar2"),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -299,15 +299,11 @@ func chunkProcessesAndContainers(
 
 	chunkProcessesBySizeAndWeight(procsByCtr[emptyCtrID], nil, maxChunkSize, maxChunkWeight, chunker)
 
-	totalContainers := 0
+	totalContainers := len(containers)
 	for _, ctr := range containers {
 		procs := procsByCtr[ctr.Id]
-		if len(procs) == 0 {
-			// can happen if a process is skipped (e.g. disallowlisted)
-			continue
-		}
 		totalProcs += len(procs)
-		totalContainers++
+
 		chunkProcessesBySizeAndWeight(procs, ctr, maxChunkSize, maxChunkWeight, chunker)
 	}
 	return chunker.collectorProcs, totalProcs, totalContainers

--- a/pkg/process/checks/process_nix_test.go
+++ b/pkg/process/checks/process_nix_test.go
@@ -103,7 +103,7 @@ func TestBasicProcessMessages(t *testing.T) {
 			blacklist:          []string{"foo"},
 			expectedChunks:     1,
 			expectedProcs:      2,
-			expectedContainers: 0,
+			expectedContainers: 1,
 		},
 	} {
 		t.Run(tc.testName, func(t *testing.T) {


### PR DESCRIPTION

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
- Ensure we report containers when they don't have associated processes
(happens if they are disallow-listed or in envs that don't support container ID <-> PID resolution - Docker on Windows).

### Motivation
- Addresses problem with container reporting in Docker on Windows.

### Possible Drawbacks / Trade-offs

Note that we are currently not chunking container payloads in this logic, assuming that majority of payload size contribution is due to the CLIs in the processes

### Describe how to test/QA your changes

- Run process-agent with process collection on Windows with Docker (process check collects containers in this configuration), example command:
```
docker run --rm --name datadog-agent -e DD_API_KEY=$DD_API_KEY -e DD_PROCESS_AGENT_ENABLED=true -v \\.\pipe\docker_engine:\\.\pipe\docker_engine datadog/agent:<tag>
```
- Ensure that containers and processes are reported correctly and container metrics are showing correct  data

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
