### PR TITLE
pkg/trace: Fix default rate + upstream client drop on new sampler

### DIFF
--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -7,7 +7,6 @@ package agent
 
 import (
 	"context"
-	"fmt"
 	"runtime"
 	"sync/atomic"
 	"time"
@@ -197,7 +196,6 @@ func (a *Agent) Process(p *api.Payload) {
 		log.Debugf("Skipping received empty payload")
 		return
 	}
-	fmt.Println(p.Chunks())
 	now := time.Now()
 	defer timing.Since("datadog.trace_agent.internal.process_payload_ms", now)
 	ts := p.Source

--- a/pkg/trace/agent/agent.go
+++ b/pkg/trace/agent/agent.go
@@ -7,6 +7,7 @@ package agent
 
 import (
 	"context"
+	"fmt"
 	"runtime"
 	"sync/atomic"
 	"time"
@@ -196,6 +197,7 @@ func (a *Agent) Process(p *api.Payload) {
 		log.Debugf("Skipping received empty payload")
 		return
 	}
+	fmt.Println(p.Chunks())
 	now := time.Now()
 	defer timing.Since("datadog.trace_agent.internal.process_payload_ms", now)
 	ts := p.Source

--- a/pkg/trace/agent/agent_test.go
+++ b/pkg/trace/agent/agent_test.go
@@ -843,7 +843,7 @@ func TestSampling(t *testing.T) {
 	} {
 		t.Run(name, func(t *testing.T) {
 			cfg := &config.AgentConfig{DisableRareSampler: tt.disableRareSampler}
-			sampledCfg := &config.AgentConfig{ExtraSampleRate: 1, ErrorTPS: 10, DisableRareSampler: tt.disableRareSampler}
+			sampledCfg := &config.AgentConfig{ExtraSampleRate: 1, TargetTPS: 5, ErrorTPS: 10, DisableRareSampler: tt.disableRareSampler}
 
 			a := &Agent{
 				NoPrioritySampler: sampler.NewNoPrioritySampler(cfg),

--- a/pkg/trace/sampler/coresampler.go
+++ b/pkg/trace/sampler/coresampler.go
@@ -38,8 +38,8 @@ type Sampler struct {
 	lastBucketID int64
 	// rates maps sampling rate in %
 	rates map[Signature]float64
-	// minRate is the lowest rate of all signatures
-	minRate float64
+	// lowestRate is the lowest rate of all signatures
+	lowestRate float64
 
 	// muSeen is a lock protecting seen map and totalSeen count
 	muSeen sync.RWMutex
@@ -166,7 +166,7 @@ func (s *Sampler) updateRates(previousBucket, newBucket int64) {
 
 	s.muRates.Lock()
 	defer s.muRates.Unlock()
-	s.minRate = 1
+	s.lowestRate = 1
 	for i, sig := range sigs {
 		seenTPS := seenTPSs[i]
 		rate := 1.0
@@ -187,8 +187,8 @@ func (s *Sampler) updateRates(previousBucket, newBucket int64) {
 			delete(s.seen, sig)
 			continue
 		}
-		if rate < s.minRate {
-			s.minRate = rate
+		if rate < s.lowestRate {
+			s.lowestRate = rate
 		}
 		rates[sig] = rate
 	}
@@ -293,8 +293,8 @@ func (s *Sampler) defaultRate() float64 {
 		rate = targetTPS / seenTPS
 	}
 	s.muSeen.RUnlock()
-	if s.minRate < rate && s.minRate != 0 {
-		return s.minRate
+	if s.lowestRate < rate && s.lowestRate != 0 {
+		return s.lowestRate
 	}
 	return rate
 }

--- a/pkg/trace/sampler/coresampler.go
+++ b/pkg/trace/sampler/coresampler.go
@@ -29,10 +29,10 @@ const (
 // a targetTPS. The bucket with the maximum counts over the period
 // of the buffer is used to compute the sampling rates.
 type Sampler struct {
-	// seen counts seen signatures. In the case of the PrioritySampler, chunks dropped
-	// in the Client are also taken in account.
+	// seen counts seen signatures by Signature in a circular buffer of numBuckets of bucketDuration.
+	// In the case of the PrioritySampler, chunks dropped in the Client are also taken in account.
 	seen map[Signature][numBuckets]float32
-	// allSigsSeen counts all signatures
+	// allSigsSeen counts all signatures in a circular buffer of numBuckets of bucketDuration
 	allSigsSeen [numBuckets]float32
 	// lastBucketID is the index of the last bucket on which traces were counted
 	lastBucketID int64

--- a/pkg/trace/sampler/coresampler.go
+++ b/pkg/trace/sampler/coresampler.go
@@ -208,7 +208,7 @@ func computeTPSPerSig(targetTPS float64, seen []float64) float64 {
 
 	for i, c := range sorted {
 		if c >= sigTarget || i == len(sorted)-1 {
-			return sigTarget
+			break
 		}
 		targetTPS -= c
 		sigTarget = targetTPS / float64((len(sorted) - i - 1))

--- a/pkg/trace/sampler/coresampler_test.go
+++ b/pkg/trace/sampler/coresampler_test.go
@@ -272,6 +272,16 @@ func TestComputeTPSPerSig(t *testing.T) {
 	}
 }
 
+func TestDefaultRate(t *testing.T) {
+	targetTPS := 10.0
+	s := newSampler(1, targetTPS, nil)
+	s.countWeightedSig(time.Now(), Signature(0), 1000)
+
+	_, defaultRate := s.getAllSignatureSampleRates()
+	assert.Equal(t, 1.0/20, defaultRate)
+	assert.Equal(t, 1.0/20, s.getSignatureSampleRate(Signature(100)))
+}
+
 func TestTargetTPSPerSigUpdate(t *testing.T) {
 	targetTPS := 10.0
 	s := newSampler(1, targetTPS, nil)

--- a/pkg/trace/sampler/prioritysampler.go
+++ b/pkg/trace/sampler/prioritysampler.go
@@ -144,14 +144,15 @@ func (s *PrioritySampler) Sample(now time.Time, trace *pb.TraceChunk, root *pb.S
 
 // countSignature counts all chunks received with local chunk root signature.
 func (s *PrioritySampler) countSignature(now time.Time, root *pb.Span, signature Signature, clientDroppedP0Weight float64) {
-	newRates := s.localRates.countWeightedSig(now, signature, 1+float32(clientDroppedP0Weight))
+	rootWeight := weightRoot(root)
+	newRates := s.localRates.countWeightedSig(now, signature, rootWeight+float32(clientDroppedP0Weight))
 	if newRates {
 		s.updateRates()
 	}
 
 	// remoteRates only considers root spans
 	if s.remoteRates != nil && root.ParentID == 0 {
-		s.remoteRates.countWeightedSig(now, signature, 1+float32(clientDroppedP0Weight))
+		s.remoteRates.countWeightedSig(now, signature, rootWeight+float32(clientDroppedP0Weight))
 	}
 }
 

--- a/pkg/trace/sampler/prioritysampler.go
+++ b/pkg/trace/sampler/prioritysampler.go
@@ -146,13 +146,14 @@ func (s *PrioritySampler) Sample(now time.Time, trace *pb.TraceChunk, root *pb.S
 func (s *PrioritySampler) countSignature(now time.Time, root *pb.Span, signature Signature, clientDroppedP0Weight float64) {
 	rootWeight := weightRoot(root)
 	newRates := s.localRates.countWeightedSig(now, signature, rootWeight+float32(clientDroppedP0Weight))
-	if newRates {
-		s.updateRates()
-	}
 
 	// remoteRates only considers root spans
 	if s.remoteRates != nil && root.ParentID == 0 {
 		s.remoteRates.countWeightedSig(now, signature, rootWeight+float32(clientDroppedP0Weight))
+	}
+
+	if newRates {
+		s.updateRates()
 	}
 }
 

--- a/pkg/trace/sampler/prioritysampler_test.go
+++ b/pkg/trace/sampler/prioritysampler_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/cihub/seelog"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -45,20 +46,23 @@ func getTestTraceWithService(t *testing.T, service string, s *PrioritySampler) (
 		{TraceID: tID, SpanID: 1, ParentID: 0, Start: 42, Duration: 1000000, Service: service, Type: "web", Meta: map[string]string{"env": defaultEnv}, Metrics: map[string]float64{}},
 		{TraceID: tID, SpanID: 2, ParentID: 1, Start: 100, Duration: 200000, Service: service, Type: "sql"},
 	}
-	r := rand.Float64()
 	priority := PriorityAutoDrop
-	rates := s.ratesByService()
+	r := rand.Float64()
+	rates := s.rateByService.rates
 	key := ServiceSignature{spans[0].Service, defaultEnv}
-	var rate float64
-	if serviceRate, ok := rates[key]; ok {
+
+	serviceRate, ok := rates[key.String()]
+	if !ok {
+		serviceRate, ok = rates[ServiceSignature{}.String()]
+	}
+	rate := float64(1)
+	if serviceRate != nil {
 		rate = serviceRate.r
-		spans[0].Metrics[agentRateKey] = serviceRate.r
-	} else {
-		rate = 1
 	}
 	if r <= rate {
 		priority = PriorityAutoKeep
 	}
+	spans[0].Metrics[agentRateKey] = rate
 	return &pb.TraceChunk{
 		Priority: int32(priority),
 		Spans:    spans,
@@ -210,9 +214,7 @@ func TestPrioritySamplerTPSFeedbackLoop(t *testing.T) {
 		s.remoteRates.onUpdate(configGenerator(generatedConfigVersion, testCasesRates))
 
 		t.Logf("testing targetTPS=%0.1f generatedTPS=%0.1f localRate=%v clientDrop=%v", tc.targetTPS, tc.generatedTPS, tc.localRate, tc.clientDrop)
-		if tc.localRate {
-			s.localRates.targetTPS = atomic.NewFloat(tc.targetTPS)
-		}
+		s.localRates.targetTPS = atomic.NewFloat(tc.targetTPS)
 
 		var sampledCount, handledCount int
 		const warmUpDuration, testDuration = 2, 10
@@ -238,6 +240,19 @@ func TestPrioritySamplerTPSFeedbackLoop(t *testing.T) {
 
 				tpsTag, okTPS := root.Metrics[tagRemoteTPS]
 				versionTag, okVersion := root.Metrics[tagRemoteVersion]
+				if !tc.localRate && timeElapsed > 1 {
+					localRates, _ := s.localRates.getAllSignatureSampleRates()
+					remoteRates := s.remoteRates.getAllSignatureSampleRates()
+					require.Equal(t, len(localRates), len(remoteRates))
+
+					for sig, rate := range localRates {
+						remoteRate, ok := remoteRates[sig]
+						assert.True(ok)
+						require.Equal(t, rate, remoteRate.r)
+					}
+
+				}
+
 				if !tc.localRate && sampled {
 					assert.True(okTPS)
 					assert.Equal(tc.targetTPS, tpsTag)

--- a/pkg/trace/sampler/prioritysampler_test.go
+++ b/pkg/trace/sampler/prioritysampler_test.go
@@ -53,7 +53,7 @@ func getTestTraceWithService(t *testing.T, service string, s *PrioritySampler) (
 
 	serviceRate, ok := rates[key.String()]
 	if !ok {
-		serviceRate, ok = rates[ServiceSignature{}.String()]
+		serviceRate, _ = rates[ServiceSignature{}.String()]
 	}
 	rate := float64(1)
 	if serviceRate != nil {

--- a/pkg/trace/sampler/prioritysampler_test.go
+++ b/pkg/trace/sampler/prioritysampler_test.go
@@ -133,7 +133,7 @@ func TestPrioritySample(t *testing.T) {
 func TestPrioritySamplerWithNilRemote(t *testing.T) {
 	conf := &config.AgentConfig{
 		ExtraSampleRate: 1.0,
-		TargetTPS:       0.0,
+		TargetTPS:       1.0,
 	}
 	s := NewPrioritySampler(conf, NewDynamicConfig())
 	s.Start()
@@ -147,7 +147,7 @@ func TestPrioritySamplerWithNilRemote(t *testing.T) {
 func TestPrioritySamplerWithRemote(t *testing.T) {
 	conf := &config.AgentConfig{
 		ExtraSampleRate: 1.0,
-		TargetTPS:       0.0,
+		TargetTPS:       1.0,
 	}
 	s := NewPrioritySampler(conf, NewDynamicConfig())
 	s.remoteRates = newRemoteRates(10)

--- a/pkg/trace/sampler/prioritysampler_test.go
+++ b/pkg/trace/sampler/prioritysampler_test.go
@@ -250,7 +250,6 @@ func TestPrioritySamplerTPSFeedbackLoop(t *testing.T) {
 						assert.True(ok)
 						require.Equal(t, rate, remoteRate.r)
 					}
-
 				}
 
 				if !tc.localRate && sampled {

--- a/pkg/trace/sampler/sampler.go
+++ b/pkg/trace/sampler/sampler.go
@@ -173,9 +173,7 @@ func weightRoot(s *pb.Span) float32 {
 	if !ok || preSamplerRate <= 0.0 || preSamplerRate > 1.0 {
 		preSamplerRate = 1
 	}
-
 	return float32(1.0 / (preSamplerRate * clientRate))
-
 }
 
 func getMetric(s *pb.Span, k string) (float64, bool) {

--- a/pkg/trace/sampler/sampler.go
+++ b/pkg/trace/sampler/sampler.go
@@ -161,6 +161,23 @@ func IsAnalyzedSpan(s *pb.Span) bool {
 	return v == 1
 }
 
+func weightRoot(s *pb.Span) float32 {
+	if s == nil {
+		return 1
+	}
+	clientRate, ok := s.Metrics[KeySamplingRateGlobal]
+	if !ok || clientRate <= 0.0 || clientRate > 1.0 {
+		clientRate = 1
+	}
+	preSamplerRate, ok := s.Metrics[KeySamplingRatePreSampler]
+	if !ok || preSamplerRate <= 0.0 || preSamplerRate > 1.0 {
+		preSamplerRate = 1
+	}
+
+	return float32(1.0 / (preSamplerRate * clientRate))
+
+}
+
 func getMetric(s *pb.Span, k string) (float64, bool) {
 	if s.Metrics == nil {
 		return 0, false

--- a/pkg/trace/sampler/scoresampler.go
+++ b/pkg/trace/sampler/scoresampler.go
@@ -66,7 +66,7 @@ func (s *ScoreSampler) Sample(now time.Time, trace pb.Trace, root *pb.Span, env 
 	signature := computeSignatureWithRootAndEnv(trace, root, env)
 	signature = s.shrink(signature)
 	// Update sampler state by counting this trace
-	s.countWeightedSig(now, signature, 1)
+	s.countWeightedSig(now, signature, weightRoot(root))
 
 	rate := s.getSignatureSampleRate(signature)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This PR fixes two regressions introduced in 7.35 sampler https://github.com/DataDog/datadog-agent/pull/10958
- Signature and Error samplers are slower to kick in, introducing higher volume of sent spans du coup non
- Traces dropped by tracers deprecated client sampler are not taken in account in the algorithm. It might converge to keep 10% while seeing only 1% of the traffic. Given that the same hash is used to compute the rates in the tracer, 100% of the 1% will be kept.

Fix 1: Compute default rate based on all the traffic seen by the sampler:
-> signature/error samplers new signatures will stop default at 1

Fix 2: Take in account in seen spans two new upstream sources of dropped spans:
- client dropped traces (deprecated tracer samplers). As we use the same hash on PrioritySampling and Client samplers in tracers, we need to make sure the full traffic is taken in account. The weight is like the stats concentrator component from the _sample_rate tag
- trace-agent rate limited trace


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
