### PR TITLE
Fix cgroups metrics collection on PCF

### DIFF
--- a/pkg/autodiscovery/listeners/environment.go
+++ b/pkg/autodiscovery/listeners/environment.go
@@ -67,13 +67,9 @@ func (l *EnvironmentListener) createServices() {
 	}
 
 	// Handle generic container check auto-activation.
-	containerFeatures := []config.Feature{config.Docker, config.Containerd, config.Cri, config.ECSFargate, config.Podman, config.Kubernetes}
-	for _, f := range containerFeatures {
-		if config.IsFeaturePresent(f) {
-			log.Infof("Listener created container service from environment")
-			l.newService <- &EnvironmentService{adIdentifier: "_container"}
-			break
-		}
+	if config.IsAnyContainerFeaturePresent() {
+		log.Infof("Listener created container service from environment")
+		l.newService <- &EnvironmentService{adIdentifier: "_container"}
 	}
 }
 

--- a/pkg/util/cgroups/reader.go
+++ b/pkg/util/cgroups/reader.go
@@ -55,7 +55,7 @@ func ContainerFilter(path, name string) (string, error) {
 	// With systemd cgroup driver, there may be a `.mount` cgroup on top of the normal one
 	// While existing, no process is attached to it and thus holds no stats
 	if match != "" {
-		if strings.HasSuffix(name, ".mount") {
+		if strings.HasSuffix(name, ".mount") || strings.HasPrefix(name, "crio-conmon-") {
 			return "", nil
 		}
 

--- a/pkg/util/containers/v2/metrics/system/collector_linux.go
+++ b/pkg/util/containers/v2/metrics/system/collector_linux.go
@@ -57,7 +57,7 @@ func newSystemCollector() (*systemCollector, error) {
 	}
 
 	reader, err := cgroups.NewReader(
-		cgroups.WithCgroupV1BaseController("freezer"),
+		cgroups.WithCgroupV1BaseController("memory"),
 		cgroups.WithProcPath(procPath),
 		cgroups.WithHostPrefix(hostPrefix),
 		cgroups.WithReaderFilter(cgroups.ContainerFilter),


### PR DESCRIPTION
### What does this PR do?

Cgroups on PCF have non consistent cgroup paths, like:
```
12:pids:/system.slice/garden.service/garden/fa48c261-19f0-4445-7b4b-87bf
11:rdma:/
10:net_cls,net_prio:/garden/fa48c261-19f0-4445-7b4b-87bf
9:hugetlb:/garden/fa48c261-19f0-4445-7b4b-87bf
8:blkio:/system.slice/garden.service/garden/fa48c261-19f0-4445-7b4b-87bf
7:perf_event:/garden/fa48c261-19f0-4445-7b4b-87bf
6:memory:/system.slice/garden.service/garden/fa48c261-19f0-4445-7b4b-87bf
5:devices:/system.slice/garden.service/garden/fa48c261-19f0-4445-7b4b-87bf
4:cpuset:/garden/fa48c261-19f0-4445-7b4b-87bf
3:cpu,cpuacct:/system.slice/garden.service/garden/fa48c261-19f0-4445-7b4b-87bf
2:freezer:/garden/fa48c261-19f0-4445-7b4b-87bf
1:name=systemd:/system.slice/garden.service/garden/fa48c261-19f0-4445-7b4b-87bf
```

Namely, the `freezer` path does not match the of main controllers (cpu, memory, pids, blkio).
The `cgroup` parsing lib assumes consistent paths, leading to nearly all metrics missing.

The `freezer` was chosen as it's normally present when a cgroup is used for a container and avoid matching some cgroups created for container-launcher process (like `crio-common` cgroups), which we now need to exclude explicitly.

### Motivation

Bugfix.

### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

Deploy the Agent on PCF, the `container` check should report the `container.cpu.usage` metric. The `process-agent` should report metrics in the container live view.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
