### PR TITLE
Ignore response body for the pod check

### DIFF
--- a/cmd/process-agent/collector.go
+++ b/cmd/process-agent/collector.go
@@ -591,6 +591,11 @@ func readResponseStatuses(checkName string, responses <-chan forwarder.Response)
 			continue
 		}
 
+		// we don't need to decode the body in case of the pod check
+		if checkName == checks.Pod.Name() {
+			continue
+		}
+
 		r, err := model.DecodeMessage(response.Body)
 		if err != nil {
 			log.Errorf("[%s] Could not decode response body: %s", checkName, err)


### PR DESCRIPTION
### What does this PR do?

Ignore response body for the pod check of the process agent

### Motivation

Avoid a noisy error log because the process-agent cannot decode the new intake response

```
2022-02-25 15:44:32 UTC | PROCESS | ERROR | (collector.go:596 in readResponseStatuses) | [pod] Could not decode response body: invalid message length: 2
```

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
