### PR TITLE
close MultiLineParser output channel

### DIFF
--- a/pkg/logs/decoder/line_parser.go
+++ b/pkg/logs/decoder/line_parser.go
@@ -110,6 +110,8 @@ func (p *MultiLineParser) run() {
 		// make sure the content stored in the buffer gets sent,
 		// this can happen when the stop is called in between two timer ticks.
 		p.sendLine()
+		// and close the outputChan, signalling to downstream that this component is finished
+		close(p.outputChan)
 	}()
 	for {
 		select {

--- a/pkg/logs/decoder/line_parser_test.go
+++ b/pkg/logs/decoder/line_parser_test.go
@@ -118,6 +118,10 @@ func TestMultilineParser(t *testing.T) {
 	assert.Equal(t, message.RawDataLen, 11+12+14)
 
 	close(inputChan)
+
+	// once the input channel closes, the output channel closes as well
+	_, ok := <-outputChan
+	require.Equal(t, false, ok)
 }
 
 func TestMultilineParserTimeout(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

Closes the output channel from the decoder's MultiLineParser component.

### Motivation

Without this, all of the downstream components do not stop, leading to a goroutine leak.

### Describe how to test/QA your changes

In a context where docker containers are logged by file (agent running in a docker container), enable `logs_config.container_collect_all` and start and stop a container repeatedly, leaving it running long enough for the agent to see it. Use

```shell
curl -s http://localhost:5000/debug/pprof/goroutine?debug=2 | grep ^goroutin | wc -l
```

to verify that goroutines do not leak (the total number of goroutines should not increase, although it may fluctuate).

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
