### PR TITLE
[process-agent][core-agent] Fix leaky HTTP connections

### DIFF
--- a/cmd/agent/app/dogstatsd_stats.go
+++ b/cmd/agent/app/dogstatsd_stats.go
@@ -75,7 +75,7 @@ func requestDogstatsdStats() error {
 		return e
 	}
 
-	r, e := util.DoGet(c, urlstr)
+	r, e := util.DoGet(c, urlstr, util.LeaveConnectionOpen)
 	if e != nil {
 		var errMap = make(map[string]string)
 		json.Unmarshal(r, &errMap) //nolint:errcheck

--- a/cmd/agent/app/launchgui.go
+++ b/cmd/agent/app/launchgui.go
@@ -61,7 +61,7 @@ func launchGui(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	csrfToken, err := util.DoGet(c, urlstr)
+	csrfToken, err := util.DoGet(c, urlstr, util.LeaveConnectionOpen)
 	if err != nil {
 		var errMap = make(map[string]string)
 		json.Unmarshal(csrfToken, &errMap) //nolint:errcheck

--- a/cmd/agent/app/listchecks.go
+++ b/cmd/agent/app/listchecks.go
@@ -54,7 +54,7 @@ func doListChecks() error {
 	}
 	urlstr := fmt.Sprintf("https://%v:%v/check/", ipcAddress, config.Datadog.GetInt("cmd_port"))
 
-	body, e := util.DoGet(c, urlstr)
+	body, e := util.DoGet(c, urlstr, util.LeaveConnectionOpen)
 	if e != nil {
 		fmt.Printf("Error getting version string: %s\n", e)
 		return e

--- a/cmd/agent/app/secret.go
+++ b/cmd/agent/app/secret.go
@@ -66,7 +66,7 @@ func showSecretInfo() error {
 	}
 	apiConfigURL := fmt.Sprintf("https://%v:%v/agent/secrets", ipcAddress, config.Datadog.GetInt("cmd_port"))
 
-	r, err := util.DoGet(c, apiConfigURL)
+	r, err := util.DoGet(c, apiConfigURL, util.LeaveConnectionOpen)
 	if err != nil {
 		var errMap = make(map[string]string)
 		json.Unmarshal(r, &errMap) //nolint:errcheck

--- a/cmd/agent/app/status.go
+++ b/cmd/agent/app/status.go
@@ -202,7 +202,7 @@ func makeRequest(url string) ([]byte, error) {
 		return nil, e
 	}
 
-	r, e := util.DoGet(c, url)
+	r, e := util.DoGet(c, url, util.LeaveConnectionOpen)
 	if e != nil {
 		var errMap = make(map[string]string)
 		json.Unmarshal(r, &errMap) //nolint:errcheck

--- a/cmd/agent/app/tagger_list.go
+++ b/cmd/agent/app/tagger_list.go
@@ -57,7 +57,7 @@ var taggerListCommand = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		r, err := util.DoGet(c, fmt.Sprintf("https://%v:%v/agent/tagger-list", ipcAddress, config.Datadog.GetInt("cmd_port")))
+		r, err := util.DoGet(c, fmt.Sprintf("https://%v:%v/agent/tagger-list", ipcAddress, config.Datadog.GetInt("cmd_port")), util.LeaveConnectionOpen)
 		if err != nil {
 			if r != nil && string(r) != "" {
 				fmt.Fprintln(color.Output, fmt.Sprintf("The agent ran into an error while getting tags list: %s", string(r)))

--- a/cmd/agent/app/workload_list.go
+++ b/cmd/agent/app/workload_list.go
@@ -58,7 +58,7 @@ var workloadListCommand = &cobra.Command{
 			return err
 		}
 
-		r, err := util.DoGet(c, workloadURL(verboseList, ipcAddress, config.Datadog.GetInt("cmd_port")))
+		r, err := util.DoGet(c, workloadURL(verboseList, ipcAddress, config.Datadog.GetInt("cmd_port")), util.LeaveConnectionOpen)
 		if err != nil {
 			if r != nil && string(r) != "" {
 				fmt.Fprintf(color.Output, "The agent ran into an error while getting the workload store information: %s\n", string(r))

--- a/cmd/agent/common/commands/health.go
+++ b/cmd/agent/common/commands/health.go
@@ -76,7 +76,7 @@ func requestHealth() error {
 		return err
 	}
 
-	r, err := util.DoGet(c, urlstr)
+	r, err := util.DoGet(c, urlstr, util.LeaveConnectionOpen)
 	if err != nil {
 		var errMap = make(map[string]string)
 		json.Unmarshal(r, &errMap) //nolint:errcheck

--- a/cmd/cluster-agent/app/metadata_mapper_digest.go
+++ b/cmd/cluster-agent/app/metadata_mapper_digest.go
@@ -78,7 +78,7 @@ func getMetadataMap(nodeName string) error {
 		return e
 	}
 
-	r, e := util.DoGet(c, urlstr)
+	r, e := util.DoGet(c, urlstr, util.LeaveConnectionOpen)
 	if e != nil {
 		fmt.Printf(`
 		Could not reach agent: %v

--- a/cmd/cluster-agent/app/status.go
+++ b/cmd/cluster-agent/app/status.go
@@ -81,7 +81,7 @@ func requestStatus() error {
 		return e
 	}
 
-	r, e := util.DoGet(c, urlstr)
+	r, e := util.DoGet(c, urlstr, util.LeaveConnectionOpen)
 	if e != nil {
 		var errMap = make(map[string]string)
 		json.Unmarshal(r, &errMap) //nolint:errcheck

--- a/cmd/process-agent/app/status.go
+++ b/cmd/process-agent/app/status.go
@@ -65,7 +65,7 @@ func writeError(w io.Writer, e error) {
 }
 
 func fetchStatus(statusURL string) ([]byte, error) {
-	body, err := apiutil.DoGet(httpClient, statusURL)
+	body, err := apiutil.DoGet(httpClient, statusURL, apiutil.LeaveConnectionOpen)
 	if err != nil {
 		return nil, util.NewConnectionError(err)
 	}

--- a/cmd/security-agent/app/status.go
+++ b/cmd/security-agent/app/status.go
@@ -75,7 +75,7 @@ func requestStatus() error {
 		return e
 	}
 
-	r, e := util.DoGet(c, urlstr)
+	r, e := util.DoGet(c, urlstr, util.LeaveConnectionOpen)
 	if e != nil {
 		var errMap = make(map[string]string)
 		json.Unmarshal(r, &errMap) //nolint:errcheck

--- a/cmd/system-probe/app/debug.go
+++ b/cmd/system-probe/app/debug.go
@@ -39,7 +39,7 @@ func debugRuntime(_ *cobra.Command, args []string) error {
 	}
 
 	// TODO rather than allowing arbitrary query params, use cobra flags
-	r, err := util.DoGet(c, "http://localhost/debug/"+args[0])
+	r, err := util.DoGet(c, "http://localhost/debug/"+args[0], util.LeaveConnectionOpen)
 	if err != nil {
 		var errMap = make(map[string]string)
 		_ = json.Unmarshal(r, &errMap)

--- a/cmd/system-probe/app/debug.go
+++ b/cmd/system-probe/app/debug.go
@@ -39,7 +39,7 @@ func debugRuntime(_ *cobra.Command, args []string) error {
 	}
 
 	// TODO rather than allowing arbitrary query params, use cobra flags
-	r, err := util.DoGet(c, "http://localhost/debug/"+args[0], util.LeaveConnectionOpen)
+	r, err := util.DoGet(c, "http://localhost/debug/"+args[0], util.CloseConnection)
 	if err != nil {
 		var errMap = make(map[string]string)
 		_ = json.Unmarshal(r, &errMap)

--- a/cmd/systray/doconfigure.go
+++ b/cmd/systray/doconfigure.go
@@ -58,7 +58,7 @@ func doConfigure() error {
 		return err
 	}
 
-	csrfToken, err := util.DoGet(c, urlstr)
+	csrfToken, err := util.DoGet(c, urlstr, util.LeaveConnectionOpen)
 	if err != nil {
 		var errMap = make(map[string]string)
 		json.Unmarshal(csrfToken, &errMap)

--- a/pkg/api/util/doget.go
+++ b/pkg/api/util/doget.go
@@ -13,6 +13,13 @@ import (
 	"net/http"
 )
 
+type ShouldCloseConnection int
+
+const (
+	LeaveConnectionOpen ShouldCloseConnection = iota
+	CloseConnection
+)
+
 // GetClient is a convenience function returning an http client
 // `GetClient(false)` must be used only for HTTP requests whose destination is
 // localhost (ie, for Agent commands).
@@ -29,20 +36,14 @@ func GetClient(verify bool) *http.Client {
 }
 
 // DoGet is a wrapper around performing HTTP GET requests
-// By default, the underlying connection is kept open after reading the response
-func DoGet(c *http.Client, url string) (body []byte, e error) {
-	return DoGetWithOptions(c, url, false)
-}
-
-// DoGetWithOptions is a wrapper around performing HTTP GET requests with additional options
-func DoGetWithOptions(c *http.Client, url string, close bool) (body []byte, e error) {
+func DoGet(c *http.Client, url string, conn ShouldCloseConnection) (body []byte, e error) {
 	req, e := http.NewRequest("GET", url, nil)
 	if e != nil {
 		return body, e
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+GetAuthToken())
-	if close {
+	if conn == CloseConnection {
 		req.Close = true
 	}
 

--- a/pkg/api/util/doget.go
+++ b/pkg/api/util/doget.go
@@ -13,10 +13,14 @@ import (
 	"net/http"
 )
 
+// ShouldCloseConnection is an option to DoGet to indicate whether to close the underlying
+// connection after reading the response
 type ShouldCloseConnection int
 
 const (
+	// LeaveConnectionOpen keeps the underlying connection open after reading the request response
 	LeaveConnectionOpen ShouldCloseConnection = iota
+	// CloseConnection closes the underlying connection after reading the request response
 	CloseConnection
 )
 

--- a/pkg/api/util/doget.go
+++ b/pkg/api/util/doget.go
@@ -29,13 +29,22 @@ func GetClient(verify bool) *http.Client {
 }
 
 // DoGet is a wrapper around performing HTTP GET requests
+// By default, the underlying connection is kept open after reading the response
 func DoGet(c *http.Client, url string) (body []byte, e error) {
+	return DoGetWithOptions(c, url, false)
+}
+
+// DoGetWithOptions is a wrapper around performing HTTP GET requests with additional options
+func DoGetWithOptions(c *http.Client, url string, close bool) (body []byte, e error) {
 	req, e := http.NewRequest("GET", url, nil)
 	if e != nil {
 		return body, e
 	}
 	req.Header.Set("Content-Type", "application/json")
 	req.Header.Set("Authorization", "Bearer "+GetAuthToken())
+	if close {
+		req.Close = true
+	}
 
 	r, e := c.Do(req)
 	if e != nil {

--- a/pkg/config/settings/http/client.go
+++ b/pkg/config/settings/http/client.go
@@ -28,7 +28,7 @@ func NewClient(c *http.Client, baseURL string, targetProcessName string) setting
 }
 
 func (rc *runtimeSettingsHTTPClient) FullConfig() (string, error) {
-	r, err := util.DoGet(rc.c, rc.baseURL)
+	r, err := util.DoGet(rc.c, rc.baseURL, util.LeaveConnectionOpen)
 	if err != nil {
 		var errMap = make(map[string]string)
 		_ = json.Unmarshal(r, &errMap)
@@ -44,7 +44,7 @@ func (rc *runtimeSettingsHTTPClient) FullConfig() (string, error) {
 }
 
 func (rc *runtimeSettingsHTTPClient) List() (map[string]settings.RuntimeSettingResponse, error) {
-	r, err := util.DoGet(rc.c, fmt.Sprintf("%s/%s", rc.baseURL, "list-runtime"))
+	r, err := util.DoGet(rc.c, fmt.Sprintf("%s/%s", rc.baseURL, "list-runtime"), util.LeaveConnectionOpen)
 	if err != nil {
 		var errMap = make(map[string]string)
 		_ = json.Unmarshal(r, &errMap)
@@ -64,7 +64,7 @@ func (rc *runtimeSettingsHTTPClient) List() (map[string]settings.RuntimeSettingR
 }
 
 func (rc *runtimeSettingsHTTPClient) Get(key string) (interface{}, error) {
-	r, err := util.DoGet(rc.c, fmt.Sprintf("%s/%s", rc.baseURL, key))
+	r, err := util.DoGet(rc.c, fmt.Sprintf("%s/%s", rc.baseURL, key), util.LeaveConnectionOpen)
 	if err != nil {
 		var errMap = make(map[string]string)
 		_ = json.Unmarshal(r, &errMap)

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -139,7 +139,7 @@ func CreatePerformanceProfile(prefix, debugURL string, cpusec int, target *Profi
 			URL:  debugURL + "/block",
 		},
 	} {
-		b, err := apiutil.DoGet(c, prof.URL)
+		b, err := apiutil.DoGet(c, prof.URL, util.LeaveConnectionOpen)
 		if err != nil {
 			return err
 		}
@@ -719,7 +719,7 @@ func zipTaggerList(tempDir, hostname string) error {
 
 	c := apiutil.GetClient(false) // FIX: get certificates right then make this true
 
-	r, err := apiutil.DoGet(c, taggerListURL)
+	r, err := apiutil.DoGet(c, taggerListURL, apiutil.LeaveConnectionOpen)
 	if err != nil {
 		return err
 	}
@@ -758,7 +758,7 @@ func zipWorkloadList(tempDir, hostname string) error {
 
 	c := apiutil.GetClient(false) // FIX: get certificates right then make this true
 
-	r, err := apiutil.DoGet(c, workloadListURL)
+	r, err := apiutil.DoGet(c, workloadListURL, apiutil.LeaveConnectionOpen)
 	if err != nil {
 		return err
 	}

--- a/pkg/flare/archive.go
+++ b/pkg/flare/archive.go
@@ -139,7 +139,7 @@ func CreatePerformanceProfile(prefix, debugURL string, cpusec int, target *Profi
 			URL:  debugURL + "/block",
 		},
 	} {
-		b, err := apiutil.DoGet(c, prof.URL, util.LeaveConnectionOpen)
+		b, err := apiutil.DoGet(c, prof.URL, apiutil.LeaveConnectionOpen)
 		if err != nil {
 			return err
 		}

--- a/pkg/flare/cluster_checks.go
+++ b/pkg/flare/cluster_checks.go
@@ -41,7 +41,7 @@ func GetClusterChecks(w io.Writer, checkName string) error {
 		return err
 	}
 
-	r, err := util.DoGet(c, urlstr)
+	r, err := util.DoGet(c, urlstr, util.LeaveConnectionOpen)
 	if err != nil {
 		if r != nil && string(r) != "" {
 			fmt.Fprintln(w, fmt.Sprintf("The agent ran into an error while checking config: %s", string(r)))
@@ -128,7 +128,7 @@ func GetEndpointsChecks(w io.Writer, checkName string) error {
 	}
 
 	// Query the cluster agent API
-	r, err := util.DoGet(c, urlstr)
+	r, err := util.DoGet(c, urlstr, util.LeaveConnectionOpen)
 	if err != nil {
 		if r != nil && string(r) != "" {
 			fmt.Fprintln(w, fmt.Sprintf("The agent ran into an error while checking config: %s", string(r)))

--- a/pkg/flare/config_check.go
+++ b/pkg/flare/config_check.go
@@ -42,7 +42,7 @@ func GetConfigCheck(w io.Writer, withDebug bool) error {
 	if configCheckURL == "" {
 		configCheckURL = fmt.Sprintf("https://%v:%v/agent/config-check", ipcAddress, config.Datadog.GetInt("cmd_port"))
 	}
-	r, err := util.DoGet(c, configCheckURL)
+	r, err := util.DoGet(c, configCheckURL, util.LeaveConnectionOpen)
 	if err != nil {
 		if r != nil && string(r) != "" {
 			return fmt.Errorf("the agent ran into an error while checking config: %s", string(r))

--- a/pkg/process/util/status.go
+++ b/pkg/process/util/status.go
@@ -119,7 +119,7 @@ func getCoreStatus() (s CoreStatus) {
 }
 
 func getExpvars(expVarURL string) (s ProcessExpvars, err error) {
-	b, err := apiutil.DoGetWithOptions(httpClient, expVarURL, true)
+	b, err := apiutil.DoGet(httpClient, expVarURL, apiutil.CloseConnection)
 	if err != nil {
 		return s, ConnectionError{err}
 	}

--- a/pkg/process/util/status.go
+++ b/pkg/process/util/status.go
@@ -14,6 +14,10 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/version"
 )
 
+// httpClients should be reused instead of created as needed. They keep cached TCP connections
+// that may leak otherwise
+var httpClient = apiutil.GetClient(false)
+
 // CoreStatus holds core info about the process-agent
 type CoreStatus struct {
 	AgentVersion string       `json:"version"`
@@ -115,7 +119,6 @@ func getCoreStatus() (s CoreStatus) {
 }
 
 func getExpvars(expVarURL string) (s ProcessExpvars, err error) {
-	httpClient := apiutil.GetClient(false)
 	b, err := apiutil.DoGet(httpClient, expVarURL)
 	if err != nil {
 		return s, ConnectionError{err}

--- a/pkg/process/util/status.go
+++ b/pkg/process/util/status.go
@@ -23,10 +23,12 @@ var (
 	clientInitOnce sync.Once
 )
 
-func initHTTPClient() {
+func getHTTPClient() *http.Client {
 	clientInitOnce.Do(func() {
 		httpClient = apiutil.GetClient(false)
 	})
+
+	return httpClient
 }
 
 // CoreStatus holds core info about the process-agent
@@ -130,8 +132,8 @@ func getCoreStatus() (s CoreStatus) {
 }
 
 func getExpvars(expVarURL string) (s ProcessExpvars, err error) {
-	initHTTPClient()
-	b, err := apiutil.DoGet(httpClient, expVarURL, apiutil.CloseConnection)
+	client := getHTTPClient()
+	b, err := apiutil.DoGet(client, expVarURL, apiutil.CloseConnection)
 	if err != nil {
 		return s, ConnectionError{err}
 	}

--- a/pkg/process/util/status.go
+++ b/pkg/process/util/status.go
@@ -119,7 +119,7 @@ func getCoreStatus() (s CoreStatus) {
 }
 
 func getExpvars(expVarURL string) (s ProcessExpvars, err error) {
-	b, err := apiutil.DoGet(httpClient, expVarURL)
+	b, err := apiutil.DoGetWithOptions(httpClient, expVarURL, true)
 	if err != nil {
 		return s, ConnectionError{err}
 	}

--- a/pkg/status/status_process_agent.go
+++ b/pkg/status/status_process_agent.go
@@ -25,10 +25,12 @@ var (
 	clientInitOnce sync.Once
 )
 
-func initHTTPClient() {
+func getHTTPClient() *http.Client {
 	clientInitOnce.Do(func() {
 		httpClient = apiutil.GetClient(false)
 	})
+
+	return httpClient
 }
 
 // GetProcessAgentStatus fetches the process-agent status from the process-agent API server
@@ -40,9 +42,9 @@ func GetProcessAgentStatus() map[string]interface{} {
 		return s
 	}
 
-	initHTTPClient()
+	client := getHTTPClient()
 	statusEndpoint := fmt.Sprintf("http://%s/agent/status", addressPort)
-	b, err := apiutil.DoGet(httpClient, statusEndpoint, apiutil.CloseConnection)
+	b, err := apiutil.DoGet(client, statusEndpoint, apiutil.CloseConnection)
 	if err != nil {
 		s["error"] = fmt.Sprintf("%v", err.Error())
 		return s
@@ -77,8 +79,8 @@ func marshalError(err error) []byte {
 // Since the api_key has been obfuscated with *, we're not able to unmarshal the response as YAML because *
 // is not a valid YAML character
 func GetProcessAgentRuntimeConfig(statusURL string) []byte {
-	initHTTPClient()
-	b, err := apiutil.DoGet(httpClient, statusURL, apiutil.CloseConnection)
+	client := getHTTPClient()
+	b, err := apiutil.DoGet(client, statusURL, apiutil.CloseConnection)
 	if err != nil {
 		return marshalError(fmt.Errorf("process-agent is not running or is unreachable"))
 	}

--- a/pkg/status/status_process_agent.go
+++ b/pkg/status/status_process_agent.go
@@ -30,7 +30,7 @@ func GetProcessAgentStatus() map[string]interface{} {
 	}
 
 	statusEndpoint := fmt.Sprintf("http://%s/agent/status", addressPort)
-	b, err := apiutil.DoGet(httpClient, statusEndpoint)
+	b, err := apiutil.DoGetWithOptions(httpClient, statusEndpoint, true)
 	if err != nil {
 		s["error"] = fmt.Sprintf("%v", err.Error())
 		return s
@@ -65,7 +65,7 @@ func marshalError(err error) []byte {
 // Since the api_key has been obfuscated with *, we're not able to unmarshal the response as YAML because *
 // is not a valid YAML character
 func GetProcessAgentRuntimeConfig(statusURL string) []byte {
-	b, err := apiutil.DoGet(httpClient, statusURL)
+	b, err := apiutil.DoGetWithOptions(httpClient, statusURL, true)
 	if err != nil {
 		return marshalError(fmt.Errorf("process-agent is not running or is unreachable"))
 	}

--- a/pkg/status/status_process_agent.go
+++ b/pkg/status/status_process_agent.go
@@ -16,10 +16,12 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
+// httpClients should be reused instead of created as needed. They keep cached TCP connections
+// that may leak otherwise
+var httpClient = apiutil.GetClient(false)
+
 // GetProcessAgentStatus fetches the process-agent status from the process-agent API server
 func GetProcessAgentStatus() map[string]interface{} {
-	httpClient := apiutil.GetClient(false)
-
 	s := make(map[string]interface{})
 	addressPort, err := api.GetAPIAddressPort()
 	if err != nil {
@@ -63,8 +65,6 @@ func marshalError(err error) []byte {
 // Since the api_key has been obfuscated with *, we're not able to unmarshal the response as YAML because *
 // is not a valid YAML character
 func GetProcessAgentRuntimeConfig(statusURL string) []byte {
-	httpClient := apiutil.GetClient(false)
-
 	b, err := apiutil.DoGet(httpClient, statusURL)
 	if err != nil {
 		return marshalError(fmt.Errorf("process-agent is not running or is unreachable"))

--- a/pkg/status/status_process_agent.go
+++ b/pkg/status/status_process_agent.go
@@ -8,6 +8,8 @@ package status
 import (
 	"encoding/json"
 	"fmt"
+	"net/http"
+	"sync"
 
 	"gopkg.in/yaml.v2"
 
@@ -18,7 +20,16 @@ import (
 
 // httpClients should be reused instead of created as needed. They keep cached TCP connections
 // that may leak otherwise
-var httpClient = apiutil.GetClient(false)
+var (
+	httpClient     *http.Client
+	clientInitOnce sync.Once
+)
+
+func initHTTPClient() {
+	clientInitOnce.Do(func() {
+		httpClient = apiutil.GetClient(false)
+	})
+}
 
 // GetProcessAgentStatus fetches the process-agent status from the process-agent API server
 func GetProcessAgentStatus() map[string]interface{} {
@@ -29,6 +40,7 @@ func GetProcessAgentStatus() map[string]interface{} {
 		return s
 	}
 
+	initHTTPClient()
 	statusEndpoint := fmt.Sprintf("http://%s/agent/status", addressPort)
 	b, err := apiutil.DoGet(httpClient, statusEndpoint, apiutil.CloseConnection)
 	if err != nil {
@@ -65,6 +77,7 @@ func marshalError(err error) []byte {
 // Since the api_key has been obfuscated with *, we're not able to unmarshal the response as YAML because *
 // is not a valid YAML character
 func GetProcessAgentRuntimeConfig(statusURL string) []byte {
+	initHTTPClient()
 	b, err := apiutil.DoGet(httpClient, statusURL, apiutil.CloseConnection)
 	if err != nil {
 		return marshalError(fmt.Errorf("process-agent is not running or is unreachable"))

--- a/pkg/status/status_process_agent.go
+++ b/pkg/status/status_process_agent.go
@@ -30,7 +30,7 @@ func GetProcessAgentStatus() map[string]interface{} {
 	}
 
 	statusEndpoint := fmt.Sprintf("http://%s/agent/status", addressPort)
-	b, err := apiutil.DoGetWithOptions(httpClient, statusEndpoint, true)
+	b, err := apiutil.DoGet(httpClient, statusEndpoint, apiutil.CloseConnection)
 	if err != nil {
 		s["error"] = fmt.Sprintf("%v", err.Error())
 		return s
@@ -65,7 +65,7 @@ func marshalError(err error) []byte {
 // Since the api_key has been obfuscated with *, we're not able to unmarshal the response as YAML because *
 // is not a valid YAML character
 func GetProcessAgentRuntimeConfig(statusURL string) []byte {
-	b, err := apiutil.DoGetWithOptions(httpClient, statusURL, true)
+	b, err := apiutil.DoGet(httpClient, statusURL, apiutil.CloseConnection)
 	if err != nil {
 		return marshalError(fmt.Errorf("process-agent is not running or is unreachable"))
 	}


### PR DESCRIPTION
### What does this PR do?

`process-agent` is currently leaking HTTP connections whenever the `agent/status` endpoint is reached or when we run the `./process-agent status` command.

In order to build the status output, `process-agent` connects to its expVar server using a httpClient. This client is currently being recreated whenever `getExpVars` is called but according to the [golang HTTP Client documentation](https://pkg.go.dev/net/http#Client):

> The Client's Transport typically has internal state (cached TCP connections), so Clients should be reused instead of created as needed. Clients are safe for concurrent use by multiple goroutines.

This PR creates a global httpClient that can be reused across multiple calls to the `/agent/status` endpoint.

The `core-agent` is also recreating a new HTTP Client when 
* `./agent status` is triggered in order to fetch process-agent status
*  a new flare is built with `./agent flare` to fetch process-agent runtime configs

The PR also updates the `DoGet` method from the `api` package in order take a `ShouldCloseConnection` argument. This parameter controls whether or not the underlying connection should be kept open after the request response is completely read.

### Motivation

Fix HTTP connections leak in `process-agent` and `core-agent`.


### Additional Notes


### Possible Drawbacks / Trade-offs


### Describe how to test/QA your changes

With the process-agent and the core-agent running
1. Reach to process-agent `/agent/status` endpoint using `curl localhost:6162/agent/status`. Verify that new HTTP connections are created only once even if curl is executed multiple times. You can use `sudo lsoft -i -P -n | grep "6162\6062"` to verify it.

2. Collect the process-agent status with `./process-agent status` multiple times and make sure that HTTP connections are not recreated

3. Collect the core-agent status with `./agent status` multiple times and make sure that HTTP connections are not recreated

4. Collect the core-agent flare with `./agent flare` multiple times and make sure that HTTP connections are not recreated

### Reviewer's Checklist


- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
