### PR TITLE
[CWS] clang tidy fixes and improvements

### DIFF
--- a/pkg/security/ebpf/c/bpf.h
+++ b/pkg/security/ebpf/c/bpf.h
@@ -310,7 +310,6 @@ __attribute__((always_inline)) void send_bpf_event(void *ctx, struct syscall_cac
 
     // send event
     send_event(ctx, EVENT_BPF, event);
-    return;
 }
 
 SYSCALL_KPROBE3(bpf, int, cmd, union bpf_attr __user *, uattr, unsigned int, size) {
@@ -334,8 +333,9 @@ SYSCALL_KPROBE3(bpf, int, cmd, union bpf_attr __user *, uattr, unsigned int, siz
 
 __attribute__((always_inline)) int sys_bpf_ret(void *ctx, int retval) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_BPF);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     syscall->bpf.retval = retval;
 
@@ -364,8 +364,9 @@ int tracepoint_syscalls_sys_exit_bpf(struct tracepoint_syscalls_sys_exit_t *args
 SEC("kprobe/security_bpf_map")
 int kprobe_security_bpf_map(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_BPF);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     struct bpf_map *map = (struct bpf_map *)PT_REGS_PARM1(ctx);
 
@@ -386,8 +387,9 @@ int kprobe_security_bpf_map(struct pt_regs *ctx) {
 SEC("kprobe/security_bpf_prog")
 int kprobe_security_bpf_prog(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_BPF);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     struct bpf_prog *prog = (struct bpf_prog *)PT_REGS_PARM1(ctx);
     struct bpf_prog_aux *prog_aux = 0;
@@ -420,8 +422,9 @@ SEC("kprobe/check_helper_call")
 int kprobe_check_helper_call(struct pt_regs *ctx) {
     int func_id = 0;
     struct syscall_cache_t *syscall = peek_syscall(EVENT_BPF);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     u64 input = get_check_helper_call_input();
     if (input == CHECK_HELPER_CALL_FUNC_ID) {

--- a/pkg/security/ebpf/c/buffer_selector.h
+++ b/pkg/security/ebpf/c/buffer_selector.h
@@ -18,8 +18,9 @@ struct bpf_map_def *select_buffer(struct bpf_map_def *front_buffer,
                                   struct bpf_map_def *back_buffer,
                                   u32 selector_key) {
     u32 *buffer_id = bpf_map_lookup_elem(&buffer_selector, &selector_key);
-    if (buffer_id == NULL)
+    if (buffer_id == NULL) {
         return NULL;
+    }
 
     return *buffer_id ? back_buffer : front_buffer;
 }
@@ -31,12 +32,14 @@ void *bpf_map_lookup_or_try_init(struct bpf_map_def *map, void *key, void *zero)
     }
 
     void *value = bpf_map_lookup_elem(map, key);
-    if (value != NULL)
+    if (value != NULL) {
         return value;
+    }
 
     // Use BPF_NOEXIST to prevent race condition
-    if (bpf_map_update_elem(map, key, zero, BPF_NOEXIST) < 0)
+    if (bpf_map_update_elem(map, key, zero, BPF_NOEXIST) < 0) {
         return NULL;
+    }
 
     return bpf_map_lookup_elem(map, key);
 }

--- a/pkg/security/ebpf/c/chmod.h
+++ b/pkg/security/ebpf/c/chmod.h
@@ -51,11 +51,13 @@ SYSCALL_KPROBE3(fchmodat, int, dirfd, const char*, filename, umode_t, mode) {
 
 int __attribute__((always_inline)) sys_chmod_ret(void *ctx, int retval) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_CHMOD);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
-    if (IS_UNHANDLED_ERROR(retval))
+    if (IS_UNHANDLED_ERROR(retval)) {
         return 0;
+    }
 
     struct chmod_event_t event = {
         .syscall.retval = retval,

--- a/pkg/security/ebpf/c/chown.h
+++ b/pkg/security/ebpf/c/chown.h
@@ -68,11 +68,13 @@ SYSCALL_KPROBE4(fchownat, int, dirfd, const char*, filename, uid_t, user, gid_t,
 
 int __attribute__((always_inline)) sys_chown_ret(void *ctx, int retval) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_CHOWN);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
-    if (IS_UNHANDLED_ERROR(retval))
+    if (IS_UNHANDLED_ERROR(retval)) {
         return 0;
+    }
 
     struct chown_event_t event = {
         .syscall.retval = retval,

--- a/pkg/security/ebpf/c/commit_creds.h
+++ b/pkg/security/ebpf/c/commit_creds.h
@@ -45,11 +45,13 @@ int __attribute__((always_inline)) credentials_predicate(u64 type) {
 
 int __attribute__((always_inline)) credentials_update_ret(void *ctx, int retval) {
     struct syscall_cache_t *syscall = pop_syscall_with(credentials_predicate);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
-    if (retval < 0)
+    if (retval < 0) {
         return 0;
+    }
 
     u32 pid = bpf_get_current_pid_tgid() >> 32;
     struct pid_cache_t *pid_entry = (struct pid_cache_t *)bpf_map_lookup_elem(&pid_cache, &pid);

--- a/pkg/security/ebpf/c/container.h
+++ b/pkg/security/ebpf/c/container.h
@@ -1,7 +1,7 @@
 #ifndef _CONTAINER_H_
 #define _CONTAINER_H_
 
-static __attribute__((always_inline)) u32 copy_container_id(char src[CONTAINER_ID_LEN], char dst[CONTAINER_ID_LEN]) {
+static __attribute__((always_inline)) u32 copy_container_id(const char src[CONTAINER_ID_LEN], char dst[CONTAINER_ID_LEN]) {
     if (src[0] == 0) {
         return 0;
     }
@@ -9,8 +9,9 @@ static __attribute__((always_inline)) u32 copy_container_id(char src[CONTAINER_I
 #pragma unroll
     for (int i = 0; i < CONTAINER_ID_LEN; i++)
     {
-        if (src[i] == 0)
+        if (src[i] == 0) {
             break;
+        }
 
         dst[i] = src[i];
     }

--- a/pkg/security/ebpf/c/defs.h
+++ b/pkg/security/ebpf/c/defs.h
@@ -519,8 +519,9 @@ struct bpf_map_def SEC("maps/enabled_events") enabled_events = {
 static __attribute__((always_inline)) u64 get_enabled_events(void) {
     u32 key = 0;
     u64 *mask = bpf_map_lookup_elem(&enabled_events, &key);
-    if (mask)
+    if (mask) {
         return *mask;
+    }
     return 0;
 }
 

--- a/pkg/security/ebpf/c/dentry_resolver.h
+++ b/pkg/security/ebpf/c/dentry_resolver.h
@@ -376,8 +376,9 @@ int kprobe_dentry_resolver_erpc(struct pt_regs *ctx) {
         state->key.ino = map_value->parent.ino;
         state->key.path_id = map_value->parent.path_id;
         state->key.mount_id = map_value->parent.mount_id;
-        if (state->key.ino == 0)
+        if (state->key.ino == 0) {
             goto exit;
+        }
     }
     if (state->iteration < DR_MAX_TAIL_CALL) {
         bpf_tail_call_compat(ctx, &dentry_resolver_kprobe_progs, DR_ERPC_KEY);

--- a/pkg/security/ebpf/c/discarders.h
+++ b/pkg/security/ebpf/c/discarders.h
@@ -77,8 +77,9 @@ u64* __attribute__((always_inline)) get_discarder_timestamp(struct discarder_par
 
 void * __attribute__((always_inline)) is_discarded(struct bpf_map_def *discarder_map, void *key, u64 event_type, u64 now) {
     void *entry = bpf_map_lookup_elem(discarder_map, key);
-    if (entry == NULL)
+    if (entry == NULL) {
         return NULL;
+    }
 
     struct discarder_params_t *params = (struct discarder_params_t *)entry;
 
@@ -368,8 +369,9 @@ int __attribute__((always_inline)) is_discarded_by_process(const char mode, u64 
 
     if (mode != NO_FILTER) {
         // try with pid first
-        if (is_discarded_by_pid(event_type, tgid))
+        if (is_discarded_by_pid(event_type, tgid)) {
             return 1;
+        }
 
         struct proc_cache_t *entry = get_proc_cache(tgid);
         if (entry != NULL) {

--- a/pkg/security/ebpf/c/exec.h
+++ b/pkg/security/ebpf/c/exec.h
@@ -145,9 +145,12 @@ void __attribute__((always_inline)) parse_str_array(struct pt_regs *ctx, struct 
         .id = array_ref->id,
     };
 
-    int i = 0, n = 0, buff_offset = 0, perf_offset = 0;
+    int i = 0;
+    int n = 0;
+    int buff_offset = 0;
+    int perf_offset = 0;
 
-    #pragma unroll
+#pragma unroll
     for (i = 0; i < MAX_ARRAY_ELEMENT_PER_TAIL; i++) {
         void *ptr = &(buff->value[(buff_offset + sizeof(n)) & (MAX_STR_BUFF_LEN - MAX_ARRAY_ELEMENT_SIZE - 1)]);
 
@@ -404,8 +407,9 @@ int sched_process_exec(struct _tracepoint_sched_process_exec *args) {
     bpf_probe_read_str(&key.filename, MAX_PATH_LEN, filename);
 
     struct bpf_map_def *exec_count = select_buffer(&exec_count_fb, &exec_count_bb, SYSCALL_MONITOR_KEY);
-    if (exec_count == NULL)
+    if (exec_count == NULL) {
         return 0;
+    }
 
     u64 zero = 0;
     u64 *count = bpf_map_lookup_or_try_init(exec_count, &key, &zero);

--- a/pkg/security/ebpf/c/filename.h
+++ b/pkg/security/ebpf/c/filename.h
@@ -6,8 +6,9 @@
 SEC("kprobe/filename_create")
 int kprobe_filename_create(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_ANY);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     switch (syscall->type) {
         case EVENT_MKDIR:

--- a/pkg/security/ebpf/c/link.h
+++ b/pkg/security/ebpf/c/link.h
@@ -45,8 +45,9 @@ SYSCALL_KPROBE0(linkat) {
 SEC("kprobe/vfs_link")
 int kprobe_vfs_link(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_LINK);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     if (syscall->link.target_dentry) {
         return 0;
@@ -78,8 +79,9 @@ int kprobe_vfs_link(struct pt_regs *ctx) {
     // we generate a fake target key as the inode is the same
     syscall->link.target_file.path_key.ino = FAKE_INODE_MSW<<32 | bpf_get_prandom_u32();
     syscall->link.target_file.path_key.mount_id = syscall->link.src_file.path_key.mount_id;
-    if (is_overlayfs(src_dentry))
+    if (is_overlayfs(src_dentry)) {
         syscall->link.target_file.flags |= UPPER_LAYER;
+    }
 
     syscall->resolver.dentry = src_dentry;
     syscall->resolver.key = syscall->link.src_file.path_key;
@@ -95,8 +97,9 @@ int kprobe_vfs_link(struct pt_regs *ctx) {
 SEC("kprobe/dr_link_src_callback")
 int __attribute__((always_inline)) kprobe_dr_link_src_callback(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_LINK);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     if (syscall->resolver.ret == DENTRY_DISCARDED) {
         return mark_as_discarded(syscall);
@@ -106,12 +109,14 @@ int __attribute__((always_inline)) kprobe_dr_link_src_callback(struct pt_regs *c
 }
 
 int __attribute__((always_inline)) sys_link_ret(void *ctx, int retval, int dr_type) {
-    if (IS_UNHANDLED_ERROR(retval))
+    if (IS_UNHANDLED_ERROR(retval)) {
         return 0;
+    }
 
     struct syscall_cache_t *syscall = peek_syscall(EVENT_LINK);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     int pass_to_userspace = !syscall->discarded && is_event_enabled(EVENT_LINK);
 
@@ -167,11 +172,13 @@ int tracepoint_handle_sys_link_exit(struct tracepoint_raw_syscalls_sys_exit_t *a
 
 int __attribute__((always_inline)) dr_link_dst_callback(void *ctx, int retval) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_LINK);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
-    if (IS_UNHANDLED_ERROR(retval))
+    if (IS_UNHANDLED_ERROR(retval)) {
         return 0;
+    }
 
     struct link_event_t event = {
         .event.type = EVENT_LINK,

--- a/pkg/security/ebpf/c/mkdir.h
+++ b/pkg/security/ebpf/c/mkdir.h
@@ -50,8 +50,9 @@ SYSCALL_KPROBE3(mkdirat, int, dirfd, const char*, filename, umode_t, mode)
 SEC("kprobe/vfs_mkdir")
 int kprobe_vfs_mkdir(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_MKDIR);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     if (syscall->mkdir.dentry) {
         return 0;
@@ -75,12 +76,14 @@ int kprobe_vfs_mkdir(struct pt_regs *ctx) {
 }
 
 int __attribute__((always_inline)) sys_mkdir_ret(void *ctx, int retval, int dr_type) {
-    if (IS_UNHANDLED_ERROR(retval))
+    if (IS_UNHANDLED_ERROR(retval)) {
         return 0;
+    }
 
     struct syscall_cache_t *syscall = peek_syscall(EVENT_MKDIR);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     // the inode of the dentry was not properly set when kprobe/security_path_mkdir was called, make sure we grab it now
     set_file_inode(syscall->mkdir.dentry, &syscall->mkdir.file, 0);
@@ -130,11 +133,13 @@ int tracepoint_handle_sys_mkdir_exit(struct tracepoint_raw_syscalls_sys_exit_t *
 
 int __attribute__((always_inline)) dr_mkdir_callback(void *ctx, int retval) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_MKDIR);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
-    if (IS_UNHANDLED_ERROR(retval))
+    if (IS_UNHANDLED_ERROR(retval)) {
         return 0;
+    }
 
     if (syscall->resolver.ret == DENTRY_DISCARDED) {
        return 0;

--- a/pkg/security/ebpf/c/mmap.h
+++ b/pkg/security/ebpf/c/mmap.h
@@ -108,8 +108,9 @@ int tracepoint_syscalls_sys_enter_mmap(struct tracepoint_syscalls_sys_enter_mmap
 
 int __attribute__((always_inline)) sys_mmap_ret(void *ctx, int retval, u64 addr) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_MMAP);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     if (syscall->resolver.ret == DENTRY_DISCARDED) {
        return 0;
@@ -156,8 +157,9 @@ int tracepoint_syscalls_sys_exit_mmap(struct tracepoint_syscalls_sys_exit_t *arg
 SEC("kretprobe/fget")
 int kretprobe_fget(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_MMAP);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     struct file *f = (struct file*) PT_REGS_RC(ctx);
     syscall->mmap.dentry = get_file_dentry(f);

--- a/pkg/security/ebpf/c/mnt.h
+++ b/pkg/security/ebpf/c/mnt.h
@@ -11,51 +11,60 @@ int __attribute__((always_inline)) mnt_want_write_predicate(u64 type) {
 SEC("kprobe/mnt_want_write")
 int kprobe_mnt_want_write(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall_with(mnt_want_write_predicate);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     struct vfsmount *mnt = (struct vfsmount *)PT_REGS_PARM1(ctx);
 
     switch (syscall->type) {
     case EVENT_UTIME:
-        if (syscall->setattr.file.path_key.mount_id > 0)
+        if (syscall->setattr.file.path_key.mount_id > 0) {
             return 0;
+        }
         syscall->setattr.file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         break;
     case EVENT_CHMOD:
-        if (syscall->setattr.file.path_key.mount_id > 0)
+        if (syscall->setattr.file.path_key.mount_id > 0) {
             return 0;
+        }
         syscall->setattr.file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         break;
     case EVENT_CHOWN:
-        if (syscall->setattr.file.path_key.mount_id > 0)
+        if (syscall->setattr.file.path_key.mount_id > 0) {
             return 0;
+        }
         syscall->setattr.file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         break;
     case EVENT_RENAME:
-        if (syscall->rename.src_file.path_key.mount_id > 0)
+        if (syscall->rename.src_file.path_key.mount_id > 0) {
             return 0;
+        }
         syscall->rename.src_file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         syscall->rename.target_file.path_key.mount_id = syscall->rename.src_file.path_key.mount_id;
         break;
     case EVENT_RMDIR:
-        if (syscall->rmdir.file.path_key.mount_id > 0)
+        if (syscall->rmdir.file.path_key.mount_id > 0) {
             return 0;
+        }
         syscall->rmdir.file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         break;
     case EVENT_UNLINK:
-        if (syscall->unlink.file.path_key.mount_id > 0)
+        if (syscall->unlink.file.path_key.mount_id > 0) {
             return 0;
+        }
         syscall->unlink.file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         break;
     case EVENT_SETXATTR:
-        if (syscall->xattr.file.path_key.mount_id > 0)
+        if (syscall->xattr.file.path_key.mount_id > 0) {
             return 0;
+        }
         syscall->xattr.file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         break;
     case EVENT_REMOVEXATTR:
-        if (syscall->xattr.file.path_key.mount_id > 0)
+        if (syscall->xattr.file.path_key.mount_id > 0) {
             return 0;
+        }
         syscall->xattr.file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         break;
     }
@@ -68,8 +77,9 @@ int __attribute__((always_inline)) mnt_want_write_file_predicate(u64 type) {
 
 int __attribute__((always_inline)) trace__mnt_want_write_file(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall_with(mnt_want_write_file_predicate);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     struct file *file = (struct file *)PT_REGS_PARM1(ctx);
     struct vfsmount *mnt;
@@ -77,18 +87,21 @@ int __attribute__((always_inline)) trace__mnt_want_write_file(struct pt_regs *ct
 
     switch (syscall->type) {
     case EVENT_CHOWN:
-        if (syscall->setattr.file.path_key.mount_id > 0)
+        if (syscall->setattr.file.path_key.mount_id > 0) {
             return 0;
+        }
         syscall->setattr.file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         break;
     case EVENT_SETXATTR:
-        if (syscall->xattr.file.path_key.mount_id > 0)
+        if (syscall->xattr.file.path_key.mount_id > 0) {
             return 0;
+        }
         syscall->xattr.file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         break;
     case EVENT_REMOVEXATTR:
-        if (syscall->xattr.file.path_key.mount_id > 0)
+        if (syscall->xattr.file.path_key.mount_id > 0) {
             return 0;
+        }
         syscall->xattr.file.path_key.mount_id = get_vfsmount_mount_id(mnt);
         break;
     }

--- a/pkg/security/ebpf/c/module.h
+++ b/pkg/security/ebpf/c/module.h
@@ -146,7 +146,7 @@ struct delete_module_event_t {
     char name[MODULE_NAME_LEN];
 };
 
-SYSCALL_KPROBE1(delete_module, char *, name_user) {
+SYSCALL_KPROBE1(delete_module, const const const char *, name_user) {
     struct policy_t policy = fetch_policy(EVENT_DELETE_MODULE);
     if (is_discarded_by_process(policy.mode, EVENT_DELETE_MODULE)) {
         return 0;

--- a/pkg/security/ebpf/c/module.h
+++ b/pkg/security/ebpf/c/module.h
@@ -172,7 +172,7 @@ int __attribute__((always_inline)) trace_delete_module_ret(void *ctx, int retval
     struct delete_module_event_t event = {
         .syscall.retval = retval,
     };
-    bpf_probe_read_str(&event.name, sizeof(event.name), syscall->delete_module.name);
+    bpf_probe_read_str(&event.name, sizeof(event.name), (void *)syscall->delete_module.name);
 
     struct proc_cache_t *entry = fill_process_context(&event.process);
     fill_container_context(entry, &event.container);

--- a/pkg/security/ebpf/c/module.h
+++ b/pkg/security/ebpf/c/module.h
@@ -61,13 +61,13 @@ int __attribute__((always_inline)) trace_kernel_file(struct pt_regs *ctx, struct
 
 SEC("kprobe/security_kernel_module_from_file")
 int kprobe_security_kernel_module_from_file(struct pt_regs *ctx) {
-    struct file *f = (struct file*) PT_REGS_PARM1(ctx);
+    struct file *f = (struct file *)PT_REGS_PARM1(ctx);
     return trace_kernel_file(ctx, f);
 }
 
 SEC("kprobe/security_kernel_read_file")
 int kprobe_security_kernel_read_file(struct pt_regs *ctx) {
-    struct file *f = (struct file*) PT_REGS_PARM1(ctx);
+    struct file *f = (struct file *)PT_REGS_PARM1(ctx);
     return trace_kernel_file(ctx, f);
 }
 
@@ -146,7 +146,7 @@ struct delete_module_event_t {
     char name[MODULE_NAME_LEN];
 };
 
-SYSCALL_KPROBE1(delete_module, const const const char *, name_user) {
+SYSCALL_KPROBE1(delete_module, const char *, name_user) {
     struct policy_t policy = fetch_policy(EVENT_DELETE_MODULE);
     if (is_discarded_by_process(policy.mode, EVENT_DELETE_MODULE)) {
         return 0;

--- a/pkg/security/ebpf/c/mount.h
+++ b/pkg/security/ebpf/c/mount.h
@@ -34,8 +34,9 @@ SYSCALL_COMPAT_KPROBE3(mount, const char*, source, const char*, target, const ch
 SEC("kprobe/attach_recursive_mnt")
 int kprobe_attach_recursive_mnt(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_MOUNT);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     syscall->mount.src_mnt = (struct mount *)PT_REGS_PARM1(ctx);
     syscall->mount.dest_mnt = (struct mount *)PT_REGS_PARM2(ctx);
@@ -64,8 +65,9 @@ int kprobe_attach_recursive_mnt(struct pt_regs *ctx) {
 SEC("kprobe/propagate_mnt")
 int kprobe_propagate_mnt(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_MOUNT);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     syscall->mount.dest_mnt = (struct mount *)PT_REGS_PARM1(ctx);
     syscall->mount.dest_mountpoint = (struct mountpoint *)PT_REGS_PARM2(ctx);
@@ -92,12 +94,14 @@ int kprobe_propagate_mnt(struct pt_regs *ctx) {
 }
 
 int __attribute__((always_inline)) sys_mount_ret(void *ctx, int retval, int dr_type) {
-    if (retval)
+    if (retval) {
         return 0;
+    }
 
     struct syscall_cache_t *syscall = peek_syscall(EVENT_MOUNT);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     struct dentry *dentry = get_mountpoint_dentry(syscall->mount.dest_mountpoint);
     struct path_key_t path_key = {
@@ -137,8 +141,9 @@ int tracepoint_handle_sys_mount_exit(struct tracepoint_raw_syscalls_sys_exit_t *
 
 int __attribute__((always_inline)) dr_mount_callback(void *ctx, int retval) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_MOUNT);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     struct mount_event_t event = {
         .syscall.retval = retval,

--- a/pkg/security/ebpf/c/mprotect.h
+++ b/pkg/security/ebpf/c/mprotect.h
@@ -79,8 +79,9 @@ SYSCALL_KPROBE0(mprotect) {
 SEC("kprobe/security_file_mprotect")
 int kprobe_security_file_mprotect(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_MPROTECT);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     // Retrieve vma information
     struct vm_area_struct *vma = (struct vm_area_struct *)PT_REGS_PARM1(ctx);
@@ -93,8 +94,9 @@ int kprobe_security_file_mprotect(struct pt_regs *ctx) {
 
 int __attribute__((always_inline)) sys_mprotect_ret(void *ctx, int retval) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_MPROTECT);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     if (filter_syscall(syscall, mprotect_approvers)) {
         return discard_syscall(syscall);

--- a/pkg/security/ebpf/c/open.h
+++ b/pkg/security/ebpf/c/open.h
@@ -130,8 +130,9 @@ int __attribute__((always_inline)) handle_open_event(struct syscall_cache_t *sys
 SEC("kprobe/vfs_truncate")
 int kprobe_vfs_truncate(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_OPEN);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     if (syscall->open.dentry) {
         return 0;
@@ -155,8 +156,9 @@ int kprobe_vfs_truncate(struct pt_regs *ctx) {
 SEC("kprobe/vfs_open")
 int kprobe_vfs_open(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_OPEN);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     struct path *path = (struct path *)PT_REGS_PARM1(ctx);
     struct file *file = (struct file *)PT_REGS_PARM2(ctx);
@@ -169,8 +171,9 @@ int kprobe_vfs_open(struct pt_regs *ctx) {
 SEC("kprobe/do_dentry_open")
 int kprobe_do_dentry_open(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_EXEC);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     struct file *file = (struct file *)PT_REGS_PARM1(ctx);
     struct inode *inode = (struct inode *)PT_REGS_PARM2(ctx);
@@ -208,17 +211,20 @@ int kprobe_io_openat2(struct pt_regs *ctx) {
 }
 
 int __attribute__((always_inline)) sys_open_ret(void *ctx, int retval, int dr_type) {
-    if (IS_UNHANDLED_ERROR(retval))
+    if (IS_UNHANDLED_ERROR(retval)) {
         return 0;
+    }
 
     struct syscall_cache_t *syscall = peek_syscall(EVENT_OPEN);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     // increase mount ref
     inc_mount_ref(syscall->open.file.path_key.mount_id);
-    if (syscall->discarded)
+    if (syscall->discarded) {
         return 0;
+    }
 
     syscall->resolver.key = syscall->open.file.path_key;
     syscall->resolver.dentry = syscall->open.dentry;
@@ -302,8 +308,9 @@ int tracepoint_handle_sys_open_exit(struct tracepoint_raw_syscalls_sys_exit_t *a
 SEC("kretprobe/io_openat2")
 int kretprobe_io_openat2(struct pt_regs *ctx) {
     struct file *f = (struct file *) PT_REGS_RC(ctx);
-    if (IS_ERR(f))
+    if (IS_ERR(f)) {
         return 0;
+    }
 
     return sys_open_ret(ctx, 0, DR_KPROBE);
 }
@@ -321,11 +328,13 @@ int kprobe_filp_close(struct pt_regs *ctx) {
 
 int __attribute__((always_inline)) dr_open_callback(void *ctx, int retval) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_OPEN);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
-    if (IS_UNHANDLED_ERROR(retval))
+    if (IS_UNHANDLED_ERROR(retval)) {
         return 0;
+    }
 
     if (syscall->resolver.ret == DENTRY_DISCARDED || syscall->resolver.ret == DENTRY_INVALID) {
        return 0;

--- a/pkg/security/ebpf/c/overlayfs.h
+++ b/pkg/security/ebpf/c/overlayfs.h
@@ -62,10 +62,11 @@ void __always_inline set_overlayfs_ino(struct dentry *dentry, u64 *ino, u32 *fla
     bpf_printk("get_overlayfs_ino lower: %d upper: %d\n", lower_inode, upper_inode);
 #endif
 
-    if (upper_inode)
+    if (upper_inode) {
         *flags |= UPPER_LAYER;
-    else if (lower_inode)
+    } else if (lower_inode) {
         *flags |= LOWER_LAYER;
+    }
 
     if (lower_inode) {
         *ino = lower_inode;

--- a/pkg/security/ebpf/c/prebuilt/probe.c
+++ b/pkg/security/ebpf/c/prebuilt/probe.c
@@ -59,8 +59,9 @@ struct invalidate_dentry_event_t {
 };
 
 void __attribute__((always_inline)) invalidate_inode(struct pt_regs *ctx, u32 mount_id, u64 inode, int send_invalidate_event) {
-    if (!inode || !mount_id)
+    if (!inode || !mount_id) {
         return;
+    }
 
     if (!is_flushing_discarders()) {
         // remove both regular and parent discarders

--- a/pkg/security/ebpf/c/process.h
+++ b/pkg/security/ebpf/c/process.h
@@ -16,7 +16,7 @@ struct proc_cache_t {
     char comm[TASK_COMM_LEN];
 };
 
-static __attribute__((always_inline)) u32 copy_tty_name(char src[TTY_NAME_LEN], char dst[TTY_NAME_LEN]) {
+static __attribute__((always_inline)) u32 copy_tty_name(const char src[TTY_NAME_LEN], char dst[TTY_NAME_LEN]) {
     if (src[0] == 0) {
         return 0;
     }
@@ -39,7 +39,6 @@ void __attribute__((always_inline)) copy_proc_cache_except_comm(struct proc_cach
 void __attribute__((always_inline)) copy_proc_cache(struct proc_cache_t *src, struct proc_cache_t *dst) {
     copy_proc_cache_except_comm(src, dst);
     bpf_probe_read(dst->comm, TASK_COMM_LEN, src->comm);
-    return;
 }
 
 struct bpf_map_def SEC("maps/proc_cache") proc_cache = {
@@ -212,7 +211,6 @@ void __attribute__((always_inline)) cache_nr_translations(struct pid *pid) {
     bpf_probe_read(&namespace_nr, sizeof(namespace_nr), (void *)pid + get_pid_numbers_offset() + namespace_numbers_offset);
 
     register_nr(root_nr, namespace_nr);
-    return;
 }
 
 #endif

--- a/pkg/security/ebpf/c/ptrace.h
+++ b/pkg/security/ebpf/c/ptrace.h
@@ -34,8 +34,9 @@ SYSCALL_KPROBE3(ptrace, u32, request, pid_t, pid, void *, addr) {
 
 int __attribute__((always_inline)) sys_ptrace_ret(void *ctx, int retval) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_PTRACE);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     // try to resolve namespaced nr
     u32 namespace_nr = get_root_nr(syscall->ptrace.pid);

--- a/pkg/security/ebpf/c/rename.h
+++ b/pkg/security/ebpf/c/rename.h
@@ -44,8 +44,9 @@ SYSCALL_KPROBE0(renameat2) {
 SEC("kprobe/vfs_rename")
 int kprobe_vfs_rename(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_RENAME);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     // if second pass, ex: overlayfs, just cache the inode that will be used in ret
     if (syscall->rename.target_file.path_key.ino) {
@@ -115,8 +116,9 @@ int __attribute__((always_inline)) sys_rename_ret(void *ctx, int retval, int dr_
     }
 
     struct syscall_cache_t *syscall = peek_syscall(EVENT_RENAME);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     u64 inode = get_dentry_ino(syscall->rename.src_dentry);
 
@@ -188,11 +190,13 @@ int tracepoint_handle_sys_rename_exit(struct tracepoint_raw_syscalls_sys_exit_t 
 
 int __attribute__((always_inline)) dr_rename_callback(void *ctx, int retval) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_RENAME);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
-    if (IS_UNHANDLED_ERROR(retval))
+    if (IS_UNHANDLED_ERROR(retval)) {
         return 0;
+    }
 
     struct rename_event_t event = {
         .syscall.retval = retval,

--- a/pkg/security/ebpf/c/rmdir.h
+++ b/pkg/security/ebpf/c/rmdir.h
@@ -36,8 +36,9 @@ int __attribute__((always_inline)) rmdir_predicate(u64 type) {
 SEC("kprobe/security_inode_rmdir")
 int kprobe_security_inode_rmdir(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall_with(rmdir_predicate);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     struct path_key_t key = {};
     struct dentry *dentry = NULL;
@@ -106,8 +107,9 @@ int kprobe_security_inode_rmdir(struct pt_regs *ctx) {
 SEC("kprobe/dr_security_inode_rmdir_callback")
 int __attribute__((always_inline)) kprobe_dr_security_inode_rmdir_callback(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall_with(rmdir_predicate);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     if (syscall->resolver.ret == DENTRY_DISCARDED) {
         return mark_as_discarded(syscall);
@@ -117,8 +119,9 @@ int __attribute__((always_inline)) kprobe_dr_security_inode_rmdir_callback(struc
 
 int __attribute__((always_inline)) sys_rmdir_ret(void *ctx, int retval) {
     struct syscall_cache_t *syscall = pop_syscall_with(rmdir_predicate);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     if (IS_UNHANDLED_ERROR(retval)) {
         return 0;

--- a/pkg/security/ebpf/c/selinux.h
+++ b/pkg/security/ebpf/c/selinux.h
@@ -74,7 +74,8 @@ int __attribute__((always_inline)) parse_buf_to_bool(const char *buf) {
         char curr = copy->buffer[i];
         if (curr == 0) {
             return 0;
-        } else if ('0' < curr && curr <= '9') {
+        }
+        if ('0' < curr && curr <= '9') {
             return 1;
         } else if (curr != '0') {
             return 0;
@@ -171,11 +172,13 @@ int __attribute__((always_inline)) handle_selinux_event(void *ctx, struct file *
 
 int __attribute__((always_inline)) dr_selinux_callback(void *ctx, int retval) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_SELINUX);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
-    if (syscall->resolver.ret == DENTRY_DISCARDED || syscall->resolver.ret == DENTRY_INVALID)
+    if (syscall->resolver.ret == DENTRY_DISCARDED || syscall->resolver.ret == DENTRY_INVALID) {
         return 0;
+    }
 
     struct selinux_event_t event = {};
     event.event_kind = syscall->selinux.event_kind;

--- a/pkg/security/ebpf/c/selinux.h
+++ b/pkg/security/ebpf/c/selinux.h
@@ -77,7 +77,8 @@ int __attribute__((always_inline)) parse_buf_to_bool(const char *buf) {
         }
         if ('0' < curr && curr <= '9') {
             return 1;
-        } else if (curr != '0') {
+        }
+        if (curr != '0') {
             return 0;
         }
     }

--- a/pkg/security/ebpf/c/setattr.h
+++ b/pkg/security/ebpf/c/setattr.h
@@ -14,8 +14,9 @@ int __attribute__((always_inline)) security_inode_predicate(u64 type) {
 SEC("kprobe/security_inode_setattr")
 int kprobe_security_inode_setattr(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall_with(security_inode_predicate);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     struct dentry *dentry = (struct dentry *)PT_REGS_PARM1(ctx);
     fill_file_metadata(dentry, &syscall->setattr.file.metadata);
@@ -82,8 +83,9 @@ int kprobe_security_inode_setattr(struct pt_regs *ctx) {
 SEC("kprobe/dr_setattr_callback")
 int __attribute__((always_inline)) kprobe_dr_setattr_callback(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall_with(security_inode_predicate);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     if (syscall->resolver.ret == DENTRY_DISCARDED) {
         return discard_syscall(syscall);

--- a/pkg/security/ebpf/c/setxattr.h
+++ b/pkg/security/ebpf/c/setxattr.h
@@ -77,8 +77,9 @@ SYSCALL_KPROBE2(fremovexattr, int, fd, const char *, name) {
 
 int __attribute__((always_inline)) trace__vfs_setxattr(struct pt_regs *ctx, u64 event_type) {
     struct syscall_cache_t *syscall = peek_syscall(event_type);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     if (syscall->xattr.file.path_key.ino) {
         return 0;
@@ -114,8 +115,9 @@ int __attribute__((always_inline)) xattr_predicate(u64 type) {
 SEC("kprobe/dr_setxattr_callback")
 int __attribute__((always_inline)) kprobe_dr_setxattr_callback(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall_with(xattr_predicate);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     if (syscall->resolver.ret == DENTRY_DISCARDED) {
         return discard_syscall(syscall);
@@ -136,11 +138,13 @@ int kprobe_vfs_removexattr(struct pt_regs *ctx) {
 
 int __attribute__((always_inline)) sys_xattr_ret(void *ctx, int retval, u64 event_type) {
     struct syscall_cache_t *syscall = pop_syscall(event_type);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
-    if (IS_UNHANDLED_ERROR(retval))
+    if (IS_UNHANDLED_ERROR(retval)) {
         return 0;
+    }
 
     struct setxattr_event_t event = {
         .syscall.retval = retval,

--- a/pkg/security/ebpf/c/signal.h
+++ b/pkg/security/ebpf/c/signal.h
@@ -19,14 +19,16 @@ SYSCALL_KPROBE2(kill, int, pid, int, type) {
     }
 
     /* TODO: implement the event for pid equal to 0 or -1. */
-    if (pid < 1)
+    if (pid < 1) {
         return 0;
+    }
 
     /* make a lookup for the target PID in case we are namespaced */
     /* TODO: make a lookup with the key addition of ns or cgroup id */
     u32 root_nr = get_root_nr((u32)pid);
-    if (!root_nr)
+    if (!root_nr) {
         root_nr = pid;
+    }
 
     /* cache the signal and wait to grab the retval to send it */
     struct syscall_cache_t syscall = {
@@ -51,8 +53,9 @@ int kretprobe_check_kill_permission(struct pt_regs* ctx) {
     }
 
     /* do not send event for signals with EINVAL error code */
-    if (IS_UNHANDLED_ERROR(retval))
+    if (IS_UNHANDLED_ERROR(retval)) {
         return 0;
+    }
 
     /* constuct and send the event */
     struct signal_event_t event = {

--- a/pkg/security/ebpf/c/syscalls.h
+++ b/pkg/security/ebpf/c/syscalls.h
@@ -178,7 +178,7 @@ struct syscall_cache_t {
         } init_module;
 
         struct {
-            char *name;
+            const char *name;
         } delete_module;
 
         struct {
@@ -211,7 +211,7 @@ struct policy_t __attribute__((always_inline)) fetch_policy(u64 event_type) {
     if (policy) {
         return *policy;
     }
-    struct policy_t empty_policy = { };
+    struct policy_t empty_policy = {};
     return empty_policy;
 }
 
@@ -221,9 +221,9 @@ void __attribute__((always_inline)) cache_syscall(struct syscall_cache_t *syscal
     bpf_map_update_elem(&syscalls, &key, syscall, BPF_ANY);
 }
 
-struct syscall_cache_t * __attribute__((always_inline)) peek_syscall(u64 type) {
+struct syscall_cache_t *__attribute__((always_inline)) peek_syscall(u64 type) {
     u64 key = bpf_get_current_pid_tgid();
-    struct syscall_cache_t *syscall = (struct syscall_cache_t *) bpf_map_lookup_elem(&syscalls, &key);
+    struct syscall_cache_t *syscall = (struct syscall_cache_t *)bpf_map_lookup_elem(&syscalls, &key);
     if (!syscall) {
         return NULL;
     }
@@ -233,9 +233,9 @@ struct syscall_cache_t * __attribute__((always_inline)) peek_syscall(u64 type) {
     return NULL;
 }
 
-struct syscall_cache_t * __attribute__((always_inline)) peek_syscall_with(int (*predicate)(u64 type)) {
+struct syscall_cache_t *__attribute__((always_inline)) peek_syscall_with(int (*predicate)(u64 type)) {
     u64 key = bpf_get_current_pid_tgid();
-    struct syscall_cache_t *syscall = (struct syscall_cache_t *) bpf_map_lookup_elem(&syscalls, &key);
+    struct syscall_cache_t *syscall = (struct syscall_cache_t *)bpf_map_lookup_elem(&syscalls, &key);
     if (!syscall) {
         return NULL;
     }
@@ -245,9 +245,9 @@ struct syscall_cache_t * __attribute__((always_inline)) peek_syscall_with(int (*
     return NULL;
 }
 
-struct syscall_cache_t * __attribute__((always_inline)) pop_syscall_with(int (*predicate)(u64 type)) {
+struct syscall_cache_t *__attribute__((always_inline)) pop_syscall_with(int (*predicate)(u64 type)) {
     u64 key = bpf_get_current_pid_tgid();
-    struct syscall_cache_t *syscall = (struct syscall_cache_t *) bpf_map_lookup_elem(&syscalls, &key);
+    struct syscall_cache_t *syscall = (struct syscall_cache_t *)bpf_map_lookup_elem(&syscalls, &key);
     if (!syscall) {
         return NULL;
     }
@@ -258,9 +258,9 @@ struct syscall_cache_t * __attribute__((always_inline)) pop_syscall_with(int (*p
     return NULL;
 }
 
-struct syscall_cache_t * __attribute__((always_inline)) pop_syscall(u64 type) {
+struct syscall_cache_t *__attribute__((always_inline)) pop_syscall(u64 type) {
     u64 key = bpf_get_current_pid_tgid();
-    struct syscall_cache_t *syscall = (struct syscall_cache_t *) bpf_map_lookup_elem(&syscalls, &key);
+    struct syscall_cache_t *syscall = (struct syscall_cache_t *)bpf_map_lookup_elem(&syscalls, &key);
     if (!syscall) {
         return NULL;
     }

--- a/pkg/security/ebpf/c/syscalls.h
+++ b/pkg/security/ebpf/c/syscalls.h
@@ -283,8 +283,9 @@ int __attribute__((always_inline)) mark_as_discarded(struct syscall_cache_t *sys
 }
 
 int __attribute__((always_inline)) filter_syscall(struct syscall_cache_t *syscall, int (*check_approvers)(struct syscall_cache_t *syscall)) {
-    if (syscall->policy.mode == NO_FILTER)
+    if (syscall->policy.mode == NO_FILTER) {
         return 0;
+    }
 
     u32 tgid = bpf_get_current_pid_tgid() >> 32;
     u64 *tgid_exec_ts = bpf_map_lookup_elem(&traced_pids, &tgid);

--- a/pkg/security/ebpf/c/umount.h
+++ b/pkg/security/ebpf/c/umount.h
@@ -31,11 +31,13 @@ int kprobe_security_sb_umount(struct pt_regs *ctx) {
 
 int __attribute__((always_inline)) sys_umount_ret(void *ctx, int retval) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_UMOUNT);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
-    if (retval)
+    if (retval) {
         return 0;
+    }
 
     int mount_id = get_vfsmount_mount_id(syscall->umount.vfs);
 

--- a/pkg/security/ebpf/c/unlink.h
+++ b/pkg/security/ebpf/c/unlink.h
@@ -44,8 +44,9 @@ SYSCALL_KPROBE3(unlinkat, int, dirfd, const char*, filename, int, flags) {
 SEC("kprobe/vfs_unlink")
 int kprobe_vfs_unlink(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_UNLINK);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     if (syscall->unlink.file.path_key.ino) {
         return 0;
@@ -87,8 +88,9 @@ int kprobe_vfs_unlink(struct pt_regs *ctx) {
 SEC("kprobe/dr_unlink_callback")
 int __attribute__((always_inline)) kprobe_dr_unlink_callback(struct pt_regs *ctx) {
     struct syscall_cache_t *syscall = peek_syscall(EVENT_UNLINK);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     if (syscall->resolver.ret < 0) {
         return mark_as_discarded(syscall);
@@ -99,8 +101,9 @@ int __attribute__((always_inline)) kprobe_dr_unlink_callback(struct pt_regs *ctx
 
 int __attribute__((always_inline)) sys_unlink_ret(void *ctx, int retval) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_UNLINK);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
     if (IS_UNHANDLED_ERROR(retval)) {
         return 0;

--- a/pkg/security/ebpf/c/utimes.h
+++ b/pkg/security/ebpf/c/utimes.h
@@ -63,11 +63,13 @@ SYSCALL_COMPAT_TIME_KPROBE0(futimesat) {
 
 int __attribute__((always_inline)) sys_utimes_ret(void *ctx, int retval) {
     struct syscall_cache_t *syscall = pop_syscall(EVENT_UTIME);
-    if (!syscall)
+    if (!syscall) {
         return 0;
+    }
 
-    if (IS_UNHANDLED_ERROR(retval))
+    if (IS_UNHANDLED_ERROR(retval)) {
         return 0;
+    }
 
     struct utimes_event_t event = {
         .syscall.retval = retval,

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -338,17 +338,21 @@ def clang_tidy(ctx, fix=False, fail_on_issue=False):
     security_flags = list(build_flags)
     security_flags.append(f"-I{security_agent_c_dir}")
     security_flags.append("-DUSE_SYSCALL_WRAPPER=0")
-    run_tidy(ctx, files=security_files, build_flags=security_flags, fix=fix, fail_on_issue=fail_on_issue)
+    security_checks = ["-readability-function-cognitive-complexity"]
+    run_tidy(ctx, files=security_files, build_flags=security_flags, fix=fix, fail_on_issue=fail_on_issue, checks=security_checks)
 
 
-def run_tidy(ctx, files, build_flags, fix=False, fail_on_issue=False):
+def run_tidy(ctx, files, build_flags, fix=False, fail_on_issue=False, checks=None):
     flags = ["--quiet"]
     if fix:
         flags.append("--fix")
     if fail_on_issue:
         flags.append("--warnings-as-errors='*'")
 
-    ctx.run(f"clang-tidy {' '.join(flags)} {' '.join(files)} -- {' '.join(build_flags)}")
+    if checks is not None:
+        flags.append(f"--checks={','.join(checks)}")
+
+    ctx.run(f"clang-tidy {' '.join(flags)} {' '.join(files)} -- {' '.join(build_flags)}", warn=True)
 
 
 @task

--- a/tasks/system_probe.py
+++ b/tasks/system_probe.py
@@ -339,7 +339,14 @@ def clang_tidy(ctx, fix=False, fail_on_issue=False):
     security_flags.append(f"-I{security_agent_c_dir}")
     security_flags.append("-DUSE_SYSCALL_WRAPPER=0")
     security_checks = ["-readability-function-cognitive-complexity"]
-    run_tidy(ctx, files=security_files, build_flags=security_flags, fix=fix, fail_on_issue=fail_on_issue, checks=security_checks)
+    run_tidy(
+        ctx,
+        files=security_files,
+        build_flags=security_flags,
+        fix=fix,
+        fail_on_issue=fail_on_issue,
+        checks=security_checks,
+    )
 
 
 def run_tidy(ctx, files, build_flags, fix=False, fail_on_issue=False, checks=None):


### PR DESCRIPTION
### What does this PR do?

This PR:
- fixes the `clang-tidy` job for the CWS part
- run `clang-tidy` with warn option so that one part failing does not mean that the other part is not run (currently the network checks fail and thus the CWS part is not run)
- skips the `readability-function-cognitive-complexity` check which is basically untenable with eBPF
- fixes issues reported by `clang-tidy`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
