### PR TITLE
Shutdown expvarserver gracefully

### DIFF
--- a/cmd/dogstatsd/main_nix.go
+++ b/cmd/dogstatsd/main_nix.go
@@ -9,6 +9,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
@@ -25,16 +26,28 @@ func main() {
 	flavor.SetFlavor(flavor.Dogstatsd)
 
 	// go_expvar server
+	port := config.Datadog.GetInt("dogstatsd_stats_port")
+	s := &http.Server{
+		Addr:    fmt.Sprintf("127.0.0.1:%d", port),
+		Handler: http.DefaultServeMux,
+	}
+	defer func() {
+		if err := s.Shutdown(context.Background()); err != nil {
+			log.Errorf("Error shutting down dogstatsd stats server on port %d: %s", port, err)
+		}
+	}()
 	go func() {
-		port := config.Datadog.GetInt("dogstatsd_stats_port")
-		err := http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", port), http.DefaultServeMux)
+		err := s.ListenAndServe()
 		if err != nil && err != http.ErrServerClosed {
-			log.Errorf("Error creating expvar server on port %v: %v", port, err)
+			log.Errorf("Error creating dogstatsd stats server on port %v: %v", port, err)
 		}
 	}()
 
 	if err := dogstatsdCmd.Execute(); err != nil {
 		log.Error(err)
-		os.Exit(-1)
+		// os.Exit() must be called last because it terminates immediately;
+		// deferred functions are not run. Deferred function calls are executed
+		// in Last In First Out order after the surrounding function returns.
+		defer os.Exit(-1)
 	}
 }

--- a/cmd/dogstatsd/main_windows.go
+++ b/cmd/dogstatsd/main_windows.go
@@ -61,9 +61,18 @@ func main() {
 	config.Datadog.AddConfigPath(DefaultConfPath)
 
 	// go_expvar server
+	port := config.Datadog.GetInt("dogstatsd_stats_port")
+	s := &http.Server{
+		Addr:    fmt.Sprintf("127.0.0.1:%d", port),
+		Handler: http.DefaultServeMux,
+	}
+	defer func() {
+		if err := s.Shutdown(context.Background()); err != nil {
+			log.Errorf("Error shutting down dogstatsd stats server on port %d: %s", port, err)
+		}
+	}()
 	go func() {
-		port := config.Datadog.GetInt("dogstatsd_stats_port")
-		err := http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", port), http.DefaultServeMux)
+		err := s.ListenAndServe()
 		if err != nil && err != http.ErrServerClosed {
 			log.Errorf("Error creating expvar server on port %v: %v", port, err)
 		}
@@ -82,7 +91,10 @@ func main() {
 
 	if err = dogstatsdCmd.Execute(); err != nil {
 		log.Error(err)
-		os.Exit(-1)
+		// os.Exit() must be called last because it terminates immediately;
+		// deferred functions are not run. Deferred function calls are executed
+		// in Last In First Out order after the surrounding function returns.
+		defer os.Exit(-1)
 	}
 }
 

--- a/cmd/process-agent/main_common.go
+++ b/cmd/process-agent/main_common.go
@@ -341,12 +341,12 @@ func runAgent(exit chan struct{}) {
 	}
 
 	// Run a profile & telemetry server.
+	if ddconfig.Datadog.GetBool("telemetry.enabled") {
+		http.Handle("/telemetry", telemetry.Handler())
+	}
+	srv := &http.Server{Addr: fmt.Sprintf("localhost:%d", expVarPort), Handler: http.DefaultServeMux}
 	go func() {
-		if ddconfig.Datadog.GetBool("telemetry.enabled") {
-			http.Handle("/telemetry", telemetry.Handler())
-		}
-		err := http.ListenAndServe(fmt.Sprintf("localhost:%d", expVarPort), nil)
-		if err != nil && err != http.ErrServerClosed {
+		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Errorf("Error creating expvar server on port %v: %v", expVarPort, err)
 		}
 	}()
@@ -370,6 +370,10 @@ func runAgent(exit chan struct{}) {
 	}
 
 	for range exit {
+	}
+
+	if err := srv.Shutdown(context.Background()); err != nil {
+		log.Errorf("Error shutdowning expvar server on port %v: %v", expVarPort, err)
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Shutdown expvar servers gracefully.

### Motivation

Same as https://github.com/DataDog/datadog-agent/pull/11023

### Additional Notes

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
