### PR TITLE
Run decoder in a single goroutine

### DIFF
--- a/pkg/logs/decoder/breaker/matcher.go
+++ b/pkg/logs/decoder/breaker/matcher.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package decoder
+package breaker
 
 var (
 	// Utf16leEOL is the bytes sequence for UTF-16 Little-Endian end-of-line char

--- a/pkg/logs/decoder/breaker/matcher_test.go
+++ b/pkg/logs/decoder/breaker/matcher_test.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2016-present Datadog, Inc.
 
-package decoder
+package breaker
 
 import (
 	"testing"

--- a/pkg/logs/decoder/decoder.go
+++ b/pkg/logs/decoder/decoder.go
@@ -87,7 +87,7 @@ func InitializeDecoder(source *config.LogSource, parser parsers.Parser) *Decoder
 // NewDecoderWithEndLineMatcher initialize a decoder with given endline strategy.
 func NewDecoderWithEndLineMatcher(source *config.LogSource, parser parsers.Parser, matcher breaker.EndLineMatcher, multiLinePattern *regexp.Regexp) *Decoder {
 	inputChan := make(chan *Input)
-	outputChan := make(chan *Message, 10)
+	outputChan := make(chan *Message)
 	lineLimit := defaultContentLenLimit
 	detectedPattern := &DetectedPattern{}
 

--- a/pkg/logs/decoder/decoder_test.go
+++ b/pkg/logs/decoder/decoder_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/decoder/breaker"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/dockerfile"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/dockerstream"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/encodedtext"
@@ -238,7 +239,7 @@ func TestDecoderWithDockerJSONSplittedByDocker(t *testing.T) {
 func TestDecoderWithDecodingParser(t *testing.T) {
 	source := config.NewLogSource("config", &config.LogsConfig{})
 
-	d := NewDecoderWithEndLineMatcher(source, encodedtext.New(encodedtext.UTF16LE), NewBytesSequenceMatcher(Utf16leEOL, 2), nil)
+	d := NewDecoderWithEndLineMatcher(source, encodedtext.New(encodedtext.UTF16LE), breaker.NewBytesSequenceMatcher(breaker.Utf16leEOL, 2), nil)
 	d.Start()
 
 	input := []byte{'h', 0x0, 'e', 0x0, 'l', 0x0, 'l', 0x0, 'o', 0x0, '\n', 0x0}

--- a/pkg/logs/decoder/file_decoder.go
+++ b/pkg/logs/decoder/file_decoder.go
@@ -10,6 +10,7 @@ import (
 
 	coreConfig "github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
+	"github.com/DataDog/datadog-agent/pkg/logs/decoder/breaker"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/dockerfile"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/encodedtext"
@@ -27,11 +28,11 @@ func NewDecoderFromSourceWithPattern(source *config.LogSource, multiLinePattern 
 
 	// TODO: remove those checks and add to source a reference to a tagProvider and a lineParser.
 	var lineParser parsers.Parser
-	var matcher EndLineMatcher
+	var matcher breaker.EndLineMatcher
 	switch source.GetSourceType() {
 	case config.KubernetesSourceType:
 		lineParser = kubernetes.New()
-		matcher = &NewLineMatcher{}
+		matcher = &breaker.NewLineMatcher{}
 	case config.DockerSourceType:
 		if coreConfig.Datadog.GetBool("logs_config.use_podman_logs") {
 			// podman's on-disk logs are in kubernetes format
@@ -39,23 +40,23 @@ func NewDecoderFromSourceWithPattern(source *config.LogSource, multiLinePattern 
 		} else {
 			lineParser = dockerfile.New()
 		}
-		matcher = &NewLineMatcher{}
+		matcher = &breaker.NewLineMatcher{}
 	default:
 		switch source.Config.Encoding {
 		case config.UTF16BE:
 			lineParser = encodedtext.New(encodedtext.UTF16BE)
-			matcher = NewBytesSequenceMatcher(Utf16beEOL, 2)
+			matcher = breaker.NewBytesSequenceMatcher(breaker.Utf16beEOL, 2)
 		case config.UTF16LE:
 			lineParser = encodedtext.New(encodedtext.UTF16LE)
-			matcher = NewBytesSequenceMatcher(Utf16leEOL, 2)
+			matcher = breaker.NewBytesSequenceMatcher(breaker.Utf16leEOL, 2)
 		case config.SHIFTJIS:
 			lineParser = encodedtext.New(encodedtext.SHIFTJIS)
 			// No special handling required for the newline matcher since Shift JIS does not use
 			// newline characters (0x0a) as the second byte of a multibyte sequence.
-			matcher = &NewLineMatcher{}
+			matcher = &breaker.NewLineMatcher{}
 		default:
 			lineParser = noop.New()
-			matcher = &NewLineMatcher{}
+			matcher = &breaker.NewLineMatcher{}
 		}
 	}
 

--- a/pkg/logs/decoder/line_breaker.go
+++ b/pkg/logs/decoder/line_breaker.go
@@ -5,19 +5,17 @@ import (
 	"sync/atomic"
 )
 
-// LineBreaker implements an actor which reads chunks of bytes from an input
-// channel and uses and EndLineMatcher to break those into lines, passing the
-// results to a LineParser.
-//
-// After Start(), the actor runs until its input channel is closed.
-// After all inputs are processed, the actor closes its output channel.
+// LineBreaker gets chunks of bytes (via process(..)) and uses an
+// EndLineMatcher to break those into lines, passing the results to its
+// outputFn.
 type LineBreaker struct {
 	// The number of raw lines decoded from the input before they are processed.
 	// Needs to be first to ensure 64 bit alignment
 	linesDecoded int64
 
-	inputChan       chan *Input
-	outputChan      chan *DecodedInput
+	// outputFn is called with each complete "line"
+	outputFn func(*DecodedInput)
+
 	matcher         EndLineMatcher
 	lineBuffer      *bytes.Buffer
 	contentLenLimit int
@@ -25,11 +23,10 @@ type LineBreaker struct {
 }
 
 // NewLineBreaker initializes a LineBreaker
-func NewLineBreaker(inputChan chan *Input, outputChan chan *DecodedInput, matcher EndLineMatcher, contentLenLimit int) *LineBreaker {
+func NewLineBreaker(outputFn func(*DecodedInput), matcher EndLineMatcher, contentLenLimit int) *LineBreaker {
 	return &LineBreaker{
 		linesDecoded:    0,
-		inputChan:       inputChan,
-		outputChan:      outputChan,
+		outputFn:        outputFn,
 		matcher:         matcher,
 		lineBuffer:      &bytes.Buffer{},
 		contentLenLimit: contentLenLimit,
@@ -37,21 +34,8 @@ func NewLineBreaker(inputChan chan *Input, outputChan chan *DecodedInput, matche
 	}
 }
 
-// Start starts the LineBreaker
-func (lb *LineBreaker) Start() {
-	go lb.run()
-}
-
-// run lets the LineBreaker handle data coming from InputChan
-func (lb *LineBreaker) run() {
-	for data := range lb.inputChan {
-		lb.breakIncomingData(data.content)
-	}
-	close(lb.outputChan)
-}
-
-// breakIncomingData splits raw data based on '\n', creates and processes new lines
-func (lb *LineBreaker) breakIncomingData(inBuf []byte) {
+// process splits raw data based on '\n', creates and processes new lines
+func (lb *LineBreaker) process(inBuf []byte) {
 	i, j := 0, 0
 	n := len(inBuf)
 	maxj := lb.contentLenLimit - lb.lineBuffer.Len()
@@ -83,7 +67,7 @@ func (lb *LineBreaker) sendLine() {
 	content := make([]byte, lb.lineBuffer.Len()-(lb.matcher.SeparatorLen()-1))
 	copy(content, lb.lineBuffer.Bytes())
 	lb.lineBuffer.Reset()
-	lb.outputChan <- NewDecodedInput(content, lb.rawDataLen)
+	lb.outputFn(NewDecodedInput(content, lb.rawDataLen))
 	lb.rawDataLen = 0
 	atomic.AddInt64(&lb.linesDecoded, 1)
 }

--- a/pkg/logs/decoder/line_breaker_test.go
+++ b/pkg/logs/decoder/line_breaker_test.go
@@ -10,31 +10,23 @@ import (
 
 const contentLenLimit = 100
 
-func lineBreakerChans() (chan *Input, chan *DecodedInput) {
-	return make(chan *Input, 10), make(chan *DecodedInput, 10)
+func lineBreakerChans() (func(*DecodedInput), chan *DecodedInput) {
+	ch := make(chan *DecodedInput, 10)
+	return func(di *DecodedInput) { ch <- di }, ch
 }
 
-func TestLineBreakActor(t *testing.T) {
+func TestLineBreaking(t *testing.T) {
 	test := func(chunks [][]byte) func(*testing.T) {
 		return func(t *testing.T) {
-			inputChan, outputChan := lineBreakerChans()
-			go func() {
-				for _, chunk := range chunks {
-					inputChan <- &Input{content: chunk}
-				}
-			}()
-			lb := NewLineBreaker(inputChan, outputChan, &NewLineMatcher{}, contentLenLimit)
-			lb.Start()
+			outputFn, outputChan := lineBreakerChans()
+			lb := NewLineBreaker(outputFn, &NewLineMatcher{}, contentLenLimit)
+			for _, chunk := range chunks {
+				lb.process(chunk)
+			}
 			require.Equal(t, "line1", string((<-outputChan).content))
 			require.Equal(t, "line2", string((<-outputChan).content))
 			require.Equal(t, "line3", string((<-outputChan).content))
 			require.Equal(t, "line4", string((<-outputChan).content))
-
-			close(inputChan)
-
-			// once the input channel closes, the output channel closes as well
-			_, ok := <-outputChan
-			require.Equal(t, false, ok)
 		}
 	}
 
@@ -57,20 +49,20 @@ func TestLineBreakActor(t *testing.T) {
 }
 
 func TestLineBreakIncomingData(t *testing.T) {
-	inputChan, outputChan := lineBreakerChans()
-	lb := NewLineBreaker(inputChan, outputChan, &NewLineMatcher{}, contentLenLimit)
+	outputFn, outputChan := lineBreakerChans()
+	lb := NewLineBreaker(outputFn, &NewLineMatcher{}, contentLenLimit)
 
 	var line *DecodedInput
 
 	// one line in one raw should be sent
-	lb.breakIncomingData([]byte("helloworld\n"))
+	lb.process([]byte("helloworld\n"))
 	line = <-outputChan
 	assert.Equal(t, "helloworld", string(line.content))
 	assert.Equal(t, len("helloworld\n"), line.rawDataLen)
 	assert.Equal(t, "", lb.lineBuffer.String())
 
 	// multiple lines in one raw should be sent
-	lb.breakIncomingData([]byte("helloworld\nhowayou\ngoodandyou"))
+	lb.process([]byte("helloworld\nhowayou\ngoodandyou"))
 	l := 0
 	line = <-outputChan
 	l += line.rawDataLen
@@ -84,12 +76,12 @@ func TestLineBreakIncomingData(t *testing.T) {
 	lb.rawDataLen, l = 0, 0
 
 	// multiple lines in multiple rows should be sent
-	lb.breakIncomingData([]byte("helloworld\nthisisa"))
+	lb.process([]byte("helloworld\nthisisa"))
 	line = <-outputChan
 	l += line.rawDataLen
 	assert.Equal(t, "helloworld", string(line.content))
 	assert.Equal(t, "thisisa", lb.lineBuffer.String())
-	lb.breakIncomingData([]byte("longinput\nindeed"))
+	lb.process([]byte("longinput\nindeed"))
 	line = <-outputChan
 	l += line.rawDataLen
 	assert.Equal(t, "thisisalonginput", string(line.content))
@@ -99,14 +91,14 @@ func TestLineBreakIncomingData(t *testing.T) {
 	lb.rawDataLen = 0
 
 	// one line in multiple rows should be sent
-	lb.breakIncomingData([]byte("hello world"))
-	lb.breakIncomingData([]byte("!\n"))
+	lb.process([]byte("hello world"))
+	lb.process([]byte("!\n"))
 	line = <-outputChan
 	assert.Equal(t, "hello world!", string(line.content))
 	assert.Equal(t, len("hello world!\n"), line.rawDataLen)
 
 	// excessively long line in one row should be sent by chunks
-	lb.breakIncomingData([]byte(strings.Repeat("a", contentLenLimit+10) + "\n"))
+	lb.process([]byte(strings.Repeat("a", contentLenLimit+10) + "\n"))
 	line = <-outputChan
 	assert.Equal(t, contentLenLimit, len(line.content))
 	assert.Equal(t, contentLenLimit, line.rawDataLen)
@@ -115,8 +107,8 @@ func TestLineBreakIncomingData(t *testing.T) {
 	assert.Equal(t, 11, line.rawDataLen)
 
 	// excessively long line in multiple rows should be sent by chunks
-	lb.breakIncomingData([]byte(strings.Repeat("a", contentLenLimit-5)))
-	lb.breakIncomingData([]byte(strings.Repeat("a", 15) + "\n"))
+	lb.process([]byte(strings.Repeat("a", contentLenLimit-5)))
+	lb.process([]byte(strings.Repeat("a", 15) + "\n"))
 	line = <-outputChan
 	assert.Equal(t, contentLenLimit, len(line.content))
 	assert.Equal(t, contentLenLimit, line.rawDataLen)
@@ -125,32 +117,32 @@ func TestLineBreakIncomingData(t *testing.T) {
 	assert.Equal(t, 11, line.rawDataLen)
 
 	// empty lines should be sent
-	lb.breakIncomingData([]byte("\n"))
+	lb.process([]byte("\n"))
 	line = <-outputChan
 	assert.Equal(t, "", string(line.content))
 	assert.Equal(t, "", lb.lineBuffer.String())
 	assert.Equal(t, 1, line.rawDataLen)
 
 	// empty message should not change anything
-	lb.breakIncomingData([]byte(""))
+	lb.process([]byte(""))
 	assert.Equal(t, "", lb.lineBuffer.String())
 	assert.Equal(t, 0, lb.rawDataLen)
 }
 
 func TestLineBreakIncomingDataWithCustomSequence(t *testing.T) {
-	inputChan, outputChan := lineBreakerChans()
-	lb := NewLineBreaker(inputChan, outputChan, NewBytesSequenceMatcher([]byte("SEPARATOR"), 1), contentLenLimit)
+	outputFn, outputChan := lineBreakerChans()
+	lb := NewLineBreaker(outputFn, NewBytesSequenceMatcher([]byte("SEPARATOR"), 1), contentLenLimit)
 
 	var line *DecodedInput
 
 	// one line in one raw should be sent
-	lb.breakIncomingData([]byte("helloworldSEPARATOR"))
+	lb.process([]byte("helloworldSEPARATOR"))
 	line = <-outputChan
 	assert.Equal(t, "helloworld", string(line.content))
 	assert.Equal(t, "", lb.lineBuffer.String())
 
 	// multiple lines in one raw should be sent
-	lb.breakIncomingData([]byte("helloworldSEPARATORhowayouSEPARATORgoodandyou"))
+	lb.process([]byte("helloworldSEPARATORhowayouSEPARATORgoodandyou"))
 	line = <-outputChan
 	assert.Equal(t, "helloworld", string(line.content))
 	line = <-outputChan
@@ -159,9 +151,9 @@ func TestLineBreakIncomingDataWithCustomSequence(t *testing.T) {
 	lb.lineBuffer.Reset()
 
 	// Line separartor may be cut by sending party
-	lb.breakIncomingData([]byte("helloworldSEPAR"))
-	lb.breakIncomingData([]byte("ATORhowayouSEPARATO"))
-	lb.breakIncomingData([]byte("Rgoodandyou"))
+	lb.process([]byte("helloworldSEPAR"))
+	lb.process([]byte("ATORhowayouSEPARATO"))
+	lb.process([]byte("Rgoodandyou"))
 	line = <-outputChan
 	assert.Equal(t, "helloworld", string(line.content))
 	line = <-outputChan
@@ -170,30 +162,30 @@ func TestLineBreakIncomingDataWithCustomSequence(t *testing.T) {
 	lb.lineBuffer.Reset()
 
 	// empty lines should be sent
-	lb.breakIncomingData([]byte("SEPARATOR"))
+	lb.process([]byte("SEPARATOR"))
 	line = <-outputChan
 	assert.Equal(t, "", string(line.content))
 	assert.Equal(t, "", lb.lineBuffer.String())
 
 	// empty message should not change anything
-	lb.breakIncomingData([]byte(""))
+	lb.process([]byte(""))
 	assert.Equal(t, "", lb.lineBuffer.String())
 }
 
 func TestLineBreakIncomingDataWithSingleByteCustomSequence(t *testing.T) {
-	inputChan, outputChan := lineBreakerChans()
-	lb := NewLineBreaker(inputChan, outputChan, NewBytesSequenceMatcher([]byte("&"), 1), contentLenLimit)
+	outputFn, outputChan := lineBreakerChans()
+	lb := NewLineBreaker(outputFn, NewBytesSequenceMatcher([]byte("&"), 1), contentLenLimit)
 	var line *DecodedInput
 
 	// one line in one raw should be sent
-	lb.breakIncomingData([]byte("helloworld&"))
+	lb.process([]byte("helloworld&"))
 	line = <-outputChan
 	assert.Equal(t, "helloworld", string(line.content))
 	assert.Equal(t, "", lb.lineBuffer.String())
 
 	// multiple blank lines
 	n := 10
-	lb.breakIncomingData([]byte(strings.Repeat("&", n)))
+	lb.process([]byte(strings.Repeat("&", n)))
 	for i := 0; i < n; i++ {
 		line = <-outputChan
 		assert.Equal(t, "", string(line.content))
@@ -202,8 +194,8 @@ func TestLineBreakIncomingDataWithSingleByteCustomSequence(t *testing.T) {
 	lb.lineBuffer.Reset()
 
 	// Mix empty & non-empty lines
-	lb.breakIncomingData([]byte("helloworld&&"))
-	lb.breakIncomingData([]byte("&howayou&"))
+	lb.process([]byte("helloworld&&"))
+	lb.process([]byte("&howayou&"))
 	line = <-outputChan
 	assert.Equal(t, "helloworld", string(line.content))
 	line = <-outputChan
@@ -216,20 +208,18 @@ func TestLineBreakIncomingDataWithSingleByteCustomSequence(t *testing.T) {
 	lb.lineBuffer.Reset()
 
 	// empty message should not change anything
-	lb.breakIncomingData([]byte(""))
+	lb.process([]byte(""))
 	assert.Equal(t, "", lb.lineBuffer.String())
 }
 
 func TestLinBreakerInputNotDockerHeader(t *testing.T) {
-	inputChan, outputChan := lineBreakerChans()
-	lb := NewLineBreaker(inputChan, outputChan, &NewLineMatcher{}, 100)
-	lb.Start()
-	defer close(inputChan)
+	outputFn, outputChan := lineBreakerChans()
+	lb := NewLineBreaker(outputFn, &NewLineMatcher{}, 100)
 
 	input := []byte("hello")
 	input = append(input, []byte{1, 0, 0, 0, 0, 10, 0, 0}...) // docker header
 	input = append(input, []byte("2018-06-14T18:27:03.246999277Z app logs\n")...)
-	inputChan <- NewInput(input)
+	lb.process(input)
 
 	var output *DecodedInput
 	output = <-outputChan

--- a/pkg/logs/decoder/line_handler.go
+++ b/pkg/logs/decoder/line_handler.go
@@ -5,6 +5,8 @@
 
 package decoder
 
+import "time"
+
 // truncatedFlag is the flag that is added at the beginning
 // or/and at the end of every trucated lines.
 var truncatedFlag = []byte("...TRUNCATED...")
@@ -16,10 +18,14 @@ var truncatedFlag = []byte("...TRUNCATED...")
 var escapedLineFeed = []byte(`\n`)
 
 // LineHandler handles raw lines to form structured lines.
-//
-// Input and output channels are given to the constructor for the concrete
-// type.  After Start(), the actor runs until its input channel is closed.
-// After all inputs are processed, the actor closes its output channel.
 type LineHandler interface {
-	Start()
+	// process handles a new line (message)
+	process(*Message)
+
+	// flushChan returns a channel which will deliver a message when `flush` should be called.
+	flushChan() <-chan time.Time
+
+	// flush flushes partially-processed data.  It should be called either when flushChan has
+	// a message, or when the decoder is stopped.
+	flush()
 }

--- a/pkg/logs/decoder/line_handler_test.go
+++ b/pkg/logs/decoder/line_handler_test.go
@@ -13,11 +13,11 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 // All valid whitespace characters
 const whitespace = "\t\n\v\f\r\u0085\u00a0 "
+const contentLenLimit = 100
 
 func getDummyMessage(content string) *Message {
 	return NewMessage([]byte(content), "info", len(content), "2018-06-14T18:27:03.246999277Z")
@@ -27,63 +27,63 @@ func getDummyMessageWithLF(content string) *Message {
 	return NewMessage([]byte(content), "info", len(content)+1, "2018-06-14T18:27:03.246999277Z")
 }
 
-func lineHandlerChans() (chan *Message, chan *Message) {
-	return make(chan *Message, 5), make(chan *Message, 5)
+func lineHandlerChans() (func(*Message), chan *Message) {
+	ch := make(chan *Message, 20)
+	return func(m *Message) { ch <- m }, ch
+}
+
+func assertNothingInChannel(t *testing.T, ch chan *Message) {
+	select {
+	case <-ch:
+		assert.Fail(t, "unexpected message")
+	default:
+	}
 }
 
 func TestSingleLineHandler(t *testing.T) {
-	inputChan, outputChan := lineHandlerChans()
-	h := NewSingleLineHandler(inputChan, outputChan, 100)
-	h.Start()
+	outputFn, outputChan := lineHandlerChans()
+	h := NewSingleLineHandler(outputFn, 100)
 
 	var output *Message
 	var line string
 
 	// valid line should be sent
 	line = "hello world"
-	inputChan <- getDummyMessageWithLF(line)
+	h.process(getDummyMessageWithLF(line))
 	output = <-outputChan
 	assert.Equal(t, line, string(output.Content))
 	assert.Equal(t, len(line)+1, output.RawDataLen)
 
 	// too long line should be truncated
 	line = strings.Repeat("a", contentLenLimit+10)
-	inputChan <- getDummyMessage(line)
+	h.process(getDummyMessage(line))
 	output = <-outputChan
 	assert.Equal(t, len(line)+len(truncatedFlag), len(output.Content))
 	assert.Equal(t, len(line), output.RawDataLen)
 
 	line = strings.Repeat("a", contentLenLimit+10)
-	inputChan <- getDummyMessage(line)
+	h.process(getDummyMessage(line))
 	output = <-outputChan
 	assert.Equal(t, len(truncatedFlag)+len(line)+len(truncatedFlag), len(output.Content))
 	assert.Equal(t, len(line), output.RawDataLen)
 
 	line = strings.Repeat("a", 10)
-	inputChan <- getDummyMessageWithLF(line)
+	h.process(getDummyMessageWithLF(line))
 	output = <-outputChan
 	assert.Equal(t, string(truncatedFlag)+line, string(output.Content))
 	assert.Equal(t, len(line)+1, output.RawDataLen)
-
-	close(inputChan)
-
-	// once the input channel closes, the output channel closes as well
-	_, ok := <-outputChan
-	require.Equal(t, false, ok)
 }
 
 func TestTrimSingleLine(t *testing.T) {
-	inputChan, outputChan := lineHandlerChans()
-	h := NewSingleLineHandler(inputChan, outputChan, 100)
-	h.Start()
-	defer close(inputChan)
+	outputFn, outputChan := lineHandlerChans()
+	h := NewSingleLineHandler(outputFn, 100)
 
 	var output *Message
 	var line string
 
 	// All leading and trailing whitespace characters should be trimmed
 	line = whitespace + "foo" + whitespace + "bar" + whitespace
-	inputChan <- getDummyMessageWithLF(line)
+	h.process(getDummyMessageWithLF(line))
 	output = <-outputChan
 	assert.Equal(t, "foo"+whitespace+"bar", string(output.Content))
 	assert.Equal(t, len(line)+1, output.RawDataLen)
@@ -91,43 +91,51 @@ func TestTrimSingleLine(t *testing.T) {
 
 func TestMultiLineHandler(t *testing.T) {
 	re := regexp.MustCompile("[0-9]+\\.")
-	inputChan, outputChan := lineHandlerChans()
-	h := NewMultiLineHandler(inputChan, outputChan, re, 10*time.Millisecond, 20)
-	h.Start()
+	outputFn, outputChan := lineHandlerChans()
+	h := NewMultiLineHandler(outputFn, re, 10*time.Millisecond, 20)
 
 	var output *Message
 
 	// two lines long message should be sent
-	inputChan <- getDummyMessageWithLF("1.first")
-	inputChan <- getDummyMessageWithLF("second")
+	h.process(getDummyMessageWithLF("1.first"))
+	h.process(getDummyMessageWithLF("second"))
 
 	// one line long message should be sent
-	inputChan <- getDummyMessageWithLF("2. first line")
+	h.process(getDummyMessageWithLF("2. first line"))
 
 	output = <-outputChan
 	var expectedContent = "1.first\\nsecond"
 	assert.Equal(t, expectedContent, string(output.Content))
 	assert.Equal(t, len(expectedContent), output.RawDataLen)
 
+	assertNothingInChannel(t, outputChan)
+	h.flush()
+
 	output = <-outputChan
 	assert.Equal(t, "2. first line", string(output.Content))
 	assert.Equal(t, len("2. first line")+1, output.RawDataLen)
 
+	assertNothingInChannel(t, outputChan)
+	h.flush()
+
 	// too long line should be truncated
-	inputChan <- getDummyMessage("3. stringssssssize20")
-	inputChan <- getDummyMessageWithLF("con")
+	h.process(getDummyMessage("3. stringssssssize20"))
+	h.process(getDummyMessageWithLF("con"))
 
 	output = <-outputChan
 	assert.Equal(t, "3. stringssssssize20...TRUNCATED...", string(output.Content))
 	assert.Equal(t, len("3. stringssssssize20"), output.RawDataLen)
+
+	assertNothingInChannel(t, outputChan)
+	h.flush()
 
 	output = <-outputChan
 	assert.Equal(t, "...TRUNCATED...con", string(output.Content))
 	assert.Equal(t, 4, output.RawDataLen)
 
 	// second line + TRUNCATED too long
-	inputChan <- getDummyMessage("4. stringssssssize20")
-	inputChan <- getDummyMessageWithLF("continue")
+	h.process(getDummyMessage("4. stringssssssize20"))
+	h.process(getDummyMessageWithLF("continue"))
 
 	output = <-outputChan
 	assert.Equal(t, "4. stringssssssize20...TRUNCATED...", string(output.Content))
@@ -138,12 +146,12 @@ func TestMultiLineHandler(t *testing.T) {
 	assert.Equal(t, 9, output.RawDataLen)
 
 	// continuous too long lines
-	inputChan <- getDummyMessage("5. stringssssssize20")
+	h.process(getDummyMessage("5. stringssssssize20"))
 	longLineTracingSpaces := "continu             "
-	inputChan <- getDummyMessage(longLineTracingSpaces)
-	inputChan <- getDummyMessageWithLF("end")
+	h.process(getDummyMessage(longLineTracingSpaces))
+	h.process(getDummyMessageWithLF("end"))
 	shortLineTracingSpaces := "6. next line      "
-	inputChan <- getDummyMessageWithLF(shortLineTracingSpaces)
+	h.process(getDummyMessageWithLF(shortLineTracingSpaces))
 
 	output = <-outputChan
 	assert.Equal(t, "5. stringssssssize20...TRUNCATED...", string(output.Content))
@@ -157,35 +165,38 @@ func TestMultiLineHandler(t *testing.T) {
 	assert.Equal(t, "...TRUNCATED...end", string(output.Content))
 	assert.Equal(t, len("end\n"), output.RawDataLen)
 
+	assertNothingInChannel(t, outputChan)
+	h.flush()
+
 	output = <-outputChan
 	assert.Equal(t, "6. next line", string(output.Content))
 	assert.Equal(t, len(shortLineTracingSpaces)+1, output.RawDataLen)
-
-	close(inputChan)
-
-	// once the input channel closes, the output channel closes as well
-	_, ok := <-outputChan
-	require.Equal(t, false, ok)
 }
 
 func TestTrimMultiLine(t *testing.T) {
 	re := regexp.MustCompile("[0-9]+\\.")
-	inputChan, outputChan := lineHandlerChans()
-	h := NewMultiLineHandler(inputChan, outputChan, re, 10*time.Millisecond, 100)
-	h.Start()
-	defer close(inputChan)
+	outputFn, outputChan := lineHandlerChans()
+	h := NewMultiLineHandler(outputFn, re, 10*time.Millisecond, 100)
 
 	var output *Message
 
 	// All leading and trailing whitespace characters should be trimmed
-	inputChan <- getDummyMessageWithLF(whitespace + "foo" + whitespace + "bar" + whitespace)
+	h.process(getDummyMessageWithLF(whitespace + "foo" + whitespace + "bar" + whitespace))
+
+	assertNothingInChannel(t, outputChan)
+	h.flush()
+
 	output = <-outputChan
 	assert.Equal(t, "foo"+whitespace+"bar", string(output.Content))
 	assert.Equal(t, len(whitespace+"foo"+whitespace+"bar"+whitespace)+1, output.RawDataLen)
 
 	// With line break
-	inputChan <- getDummyMessageWithLF(whitespace + "foo" + whitespace)
-	inputChan <- getDummyMessageWithLF("bar" + whitespace)
+	h.process(getDummyMessageWithLF(whitespace + "foo" + whitespace))
+	h.process(getDummyMessageWithLF("bar" + whitespace))
+
+	assertNothingInChannel(t, outputChan)
+	h.flush()
+
 	output = <-outputChan
 	assert.Equal(t, "foo"+whitespace+"\\n"+"bar", string(output.Content))
 	assert.Equal(t, len(whitespace+"foo"+whitespace)+1+len("bar"+whitespace)+1, output.RawDataLen)
@@ -193,29 +204,28 @@ func TestTrimMultiLine(t *testing.T) {
 
 func TestMultiLineHandlerDropsEmptyMessages(t *testing.T) {
 	re := regexp.MustCompile("[0-9]+\\.")
-	inputChan, outputChan := lineHandlerChans()
-	h := NewMultiLineHandler(inputChan, outputChan, re, 10*time.Millisecond, 100)
-	h.Start()
-	defer close(inputChan)
+	outputFn, outputChan := lineHandlerChans()
+	h := NewMultiLineHandler(outputFn, re, 10*time.Millisecond, 100)
 
-	inputChan <- getDummyMessage("")
+	h.process(getDummyMessage(""))
 
-	inputChan <- getDummyMessage("1.third line")
-	inputChan <- getDummyMessage("fourth line")
+	h.process(getDummyMessage("1.third line"))
+	h.process(getDummyMessage("fourth line"))
 
 	var output *Message
+
+	assertNothingInChannel(t, outputChan)
+	h.flush()
 
 	output = <-outputChan
 	assert.Equal(t, "1.third line\\nfourth line", string(output.Content))
 }
 
 func TestSingleLineHandlerSendsRawInvalidMessages(t *testing.T) {
-	inputChan, outputChan := lineHandlerChans()
-	h := NewSingleLineHandler(inputChan, outputChan, 100)
-	h.Start()
-	defer close(inputChan)
+	outputFn, outputChan := lineHandlerChans()
+	h := NewSingleLineHandler(outputFn, 100)
 
-	inputChan <- getDummyMessage("one message")
+	h.process(getDummyMessage("one message"))
 
 	var output *Message
 
@@ -225,15 +235,16 @@ func TestSingleLineHandlerSendsRawInvalidMessages(t *testing.T) {
 
 func TestMultiLineHandlerSendsRawInvalidMessages(t *testing.T) {
 	re := regexp.MustCompile("[0-9]+\\.")
-	inputChan, outputChan := lineHandlerChans()
-	h := NewMultiLineHandler(inputChan, outputChan, re, 10*time.Millisecond, 100)
-	h.Start()
-	defer close(inputChan)
+	outputFn, outputChan := lineHandlerChans()
+	h := NewMultiLineHandler(outputFn, re, 10*time.Millisecond, 100)
 
-	inputChan <- getDummyMessage("1.third line")
-	inputChan <- getDummyMessage("fourth line")
+	h.process(getDummyMessage("1.third line"))
+	h.process(getDummyMessage("fourth line"))
 
 	var output *Message
+
+	assertNothingInChannel(t, outputChan)
+	h.flush()
 
 	output = <-outputChan
 	assert.Equal(t, "1.third line\\nfourth line", string(output.Content))
@@ -241,15 +252,13 @@ func TestMultiLineHandlerSendsRawInvalidMessages(t *testing.T) {
 
 func TestAutoMultiLineHandlerStaysSingleLineMode(t *testing.T) {
 
-	inputChan, outputChan := lineHandlerChans()
+	outputFn, outputChan := lineHandlerChans()
 	source := config.NewLogSource("config", &config.LogsConfig{})
 	detectedPattern := &DetectedPattern{}
-	h := NewAutoMultilineHandler(inputChan, outputChan, 100, 5, 1.0, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, detectedPattern)
-	h.Start()
-	defer close(inputChan)
+	h := NewAutoMultilineHandler(outputFn, 100, 5, 1.0, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, detectedPattern)
 
 	for i := 0; i < 6; i++ {
-		inputChan <- getDummyMessageWithLF("blah")
+		h.process(getDummyMessageWithLF("blah"))
 		<-outputChan
 	}
 	assert.NotNil(t, h.singleLineHandler)
@@ -258,15 +267,14 @@ func TestAutoMultiLineHandlerStaysSingleLineMode(t *testing.T) {
 }
 
 func TestAutoMultiLineHandlerSwitchesToMultiLineMode(t *testing.T) {
-	inputChan, outputChan := lineHandlerChans()
+	outputFn, outputChan := lineHandlerChans()
 	source := config.NewLogSource("config", &config.LogsConfig{})
 	detectedPattern := &DetectedPattern{}
-	h := NewAutoMultilineHandler(inputChan, outputChan, 100, 5, 1.0, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, detectedPattern)
-	h.Start()
-	defer close(inputChan)
+	h := NewAutoMultilineHandler(outputFn, 100, 5, 1.0, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, detectedPattern)
 
 	for i := 0; i < 6; i++ {
-		inputChan <- getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message")
+		h.process(getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message"))
+		h.flush() // multiline handler needs to be flushed on 6th iteration
 		<-outputChan
 	}
 	assert.Nil(t, h.singleLineHandler)
@@ -275,69 +283,63 @@ func TestAutoMultiLineHandlerSwitchesToMultiLineMode(t *testing.T) {
 }
 
 func TestAutoMultiLineHandlerHandelsMessage(t *testing.T) {
-	inputChan, outputChan := lineHandlerChans()
+	outputFn, outputChan := lineHandlerChans()
 	source := config.NewLogSource("config", &config.LogsConfig{})
-	h := NewAutoMultilineHandler(inputChan, outputChan, 500, 1, 1.0, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, &DetectedPattern{})
-	h.Start()
-	defer close(inputChan)
+	h := NewAutoMultilineHandler(outputFn, 500, 1, 1.0, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, &DetectedPattern{})
 
-	inputChan <- getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message 1")
+	h.process(getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message 1"))
 	<-outputChan
-	inputChan <- getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message 2")
-	inputChan <- getDummyMessageWithLF("java.lang.Exception: boom")
-	inputChan <- getDummyMessageWithLF("at Main.funcd(Main.java:62)")
-	inputChan <- getDummyMessageWithLF("at Main.funcc(Main.java:60)")
-	inputChan <- getDummyMessageWithLF("at Main.funcb(Main.java:58)")
-	inputChan <- getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM another test message")
+	h.process(getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message 2"))
+	h.process(getDummyMessageWithLF("java.lang.Exception: boom"))
+	h.process(getDummyMessageWithLF("at Main.funcd(Main.java:62)"))
+	h.process(getDummyMessageWithLF("at Main.funcc(Main.java:60)"))
+	h.process(getDummyMessageWithLF("at Main.funcb(Main.java:58)"))
+	h.process(getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM another test message"))
 	output := <-outputChan
 
 	assert.Equal(t, "Jul 12, 2021 12:55:15 PM test message 2\\njava.lang.Exception: boom\\nat Main.funcd(Main.java:62)\\nat Main.funcc(Main.java:60)\\nat Main.funcb(Main.java:58)", string(output.Content))
 }
 
 func TestAutoMultiLineHandlerHandelsMessageConflictingPatterns(t *testing.T) {
-	inputChan, outputChan := lineHandlerChans()
+	outputFn, outputChan := lineHandlerChans()
 	source := config.NewLogSource("config", &config.LogsConfig{})
-	h := NewAutoMultilineHandler(inputChan, outputChan, 500, 4, 0.75, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, &DetectedPattern{})
-	h.Start()
-	defer close(inputChan)
+	h := NewAutoMultilineHandler(outputFn, 500, 4, 0.75, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, &DetectedPattern{})
 
 	// we will match both patterns, but one will win with a threshold of 0.75
-	inputChan <- getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message 1")
-	inputChan <- getDummyMessageWithLF("Jul, 1-sep-12 10:20:30 pm test message 2")
-	inputChan <- getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message 3")
-	inputChan <- getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message 4")
+	h.process(getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message 1"))
+	h.process(getDummyMessageWithLF("Jul, 1-sep-12 10:20:30 pm test message 2"))
+	h.process(getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message 3"))
+	h.process(getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message 4"))
 
 	for i := 0; i < 4; i++ {
 		<-outputChan
 	}
-	inputChan <- getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message 2")
-	inputChan <- getDummyMessageWithLF("java.lang.Exception: boom")
-	inputChan <- getDummyMessageWithLF("at Main.funcd(Main.java:62)")
-	inputChan <- getDummyMessageWithLF("at Main.funcc(Main.java:60)")
-	inputChan <- getDummyMessageWithLF("at Main.funcb(Main.java:58)")
-	inputChan <- getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM another test message")
+	h.process(getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message 2"))
+	h.process(getDummyMessageWithLF("java.lang.Exception: boom"))
+	h.process(getDummyMessageWithLF("at Main.funcd(Main.java:62)"))
+	h.process(getDummyMessageWithLF("at Main.funcc(Main.java:60)"))
+	h.process(getDummyMessageWithLF("at Main.funcb(Main.java:58)"))
+	h.process(getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM another test message"))
 	output := <-outputChan
 
 	assert.Equal(t, "Jul 12, 2021 12:55:15 PM test message 2\\njava.lang.Exception: boom\\nat Main.funcd(Main.java:62)\\nat Main.funcc(Main.java:60)\\nat Main.funcb(Main.java:58)", string(output.Content))
 }
 
 func TestAutoMultiLineHandlerHandelsMessageConflictingPatternsNoWinner(t *testing.T) {
-	inputChan, outputChan := lineHandlerChans()
+	outputFn, outputChan := lineHandlerChans()
 	source := config.NewLogSource("config", &config.LogsConfig{})
-	h := NewAutoMultilineHandler(inputChan, outputChan, 500, 4, 0.75, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, &DetectedPattern{})
-	h.Start()
-	defer close(inputChan)
+	h := NewAutoMultilineHandler(outputFn, 500, 4, 0.75, 10*time.Millisecond, 10*time.Millisecond, source, []*regexp.Regexp{}, &DetectedPattern{})
 
 	// we will match both patterns, but neither will win because it doesn't meet the threshold
-	inputChan <- getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message 1")
-	inputChan <- getDummyMessageWithLF("Jul, 1-sep-12 10:20:30 pm test message 2")
-	inputChan <- getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message 3")
-	inputChan <- getDummyMessageWithLF("Jul, 1-sep-12 10:20:30 pm test message 4")
+	h.process(getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message 1"))
+	h.process(getDummyMessageWithLF("Jul, 1-sep-12 10:20:30 pm test message 2"))
+	h.process(getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message 3"))
+	h.process(getDummyMessageWithLF("Jul, 1-sep-12 10:20:30 pm test message 4"))
 
 	for i := 0; i < 4; i++ {
 		<-outputChan
 	}
-	inputChan <- getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message 2")
+	h.process(getDummyMessageWithLF("Jul 12, 2021 12:55:15 PM test message 2"))
 	output := <-outputChan
 
 	assert.NotNil(t, h.singleLineHandler)

--- a/pkg/logs/decoder/line_parser.go
+++ b/pkg/logs/decoder/line_parser.go
@@ -15,45 +15,41 @@ import (
 
 // LineParser handles decoded lines, parsing them into decoder.Message's using
 // an embedded parsers.Parser.
-//
-// Input and output channels are given to the constructor for the concrete
-// type.  After Start(), the actor runs until its input channel is closed.
-// After all inputs are processed, the actor closes its output channel.
 type LineParser interface {
-	Start()
+	// process handles a new line (message)
+	process(*DecodedInput)
+
+	// flushChan returns a channel which will deliver a message when `flush` should be called.
+	flushChan() <-chan time.Time
+
+	// flush flushes partially-processed data.  It should be called either when flushChan has
+	// a message, or when the decoder is stopped.
+	flush()
 }
 
 // SingleLineParser makes sure that multiple lines from a same content
 // are properly put together.
 type SingleLineParser struct {
-	parser     parsers.Parser
-	inputChan  chan *DecodedInput
-	outputChan chan *Message
+	outputFn func(*Message)
+	parser   parsers.Parser
 }
 
 // NewSingleLineParser returns a new SingleLineParser.
 func NewSingleLineParser(
-	inputChan chan *DecodedInput,
-	outputChan chan *Message,
+	outputFn func(*Message),
 	parser parsers.Parser) *SingleLineParser {
 	return &SingleLineParser{
-		parser:     parser,
-		inputChan:  inputChan,
-		outputChan: outputChan,
+		outputFn: outputFn,
+		parser:   parser,
 	}
 }
 
-// Start starts the parser.
-func (p *SingleLineParser) Start() {
-	go p.run()
+func (p *SingleLineParser) flushChan() <-chan time.Time {
+	return nil
 }
 
-// run consumes new lines and processes them.
-func (p *SingleLineParser) run() {
-	for input := range p.inputChan {
-		p.process(input)
-	}
-	close(p.outputChan)
+func (p *SingleLineParser) flush() {
+	// do nothing
 }
 
 func (p *SingleLineParser) process(input *DecodedInput) {
@@ -62,15 +58,15 @@ func (p *SingleLineParser) process(input *DecodedInput) {
 	if err != nil {
 		log.Debug(err)
 	}
-	p.outputChan <- NewMessage(msg.Content, msg.Status, input.rawDataLen, msg.Timestamp)
+	p.outputFn(NewMessage(msg.Content, msg.Status, input.rawDataLen, msg.Timestamp))
 }
 
 // MultiLineParser makes sure that chunked lines are properly put together.
 type MultiLineParser struct {
+	outputFn     func(*Message)
 	buffer       *bytes.Buffer
 	flushTimeout time.Duration
-	inputChan    chan *DecodedInput
-	outputChan   chan *Message
+	flushTimer   *time.Timer
 	parser       parsers.Parser
 	rawDataLen   int
 	lineLimit    int
@@ -80,68 +76,40 @@ type MultiLineParser struct {
 
 // NewMultiLineParser returns a new MultiLineParser.
 func NewMultiLineParser(
-	inputChan chan *DecodedInput,
-	outputChan chan *Message,
+	outputFn func(*Message),
 	flushTimeout time.Duration,
 	parser parsers.Parser,
 	lineLimit int,
 ) *MultiLineParser {
 	return &MultiLineParser{
-		inputChan:    inputChan,
-		outputChan:   outputChan,
+		outputFn:     outputFn,
 		buffer:       bytes.NewBuffer(nil),
 		flushTimeout: flushTimeout,
+		flushTimer:   nil,
 		lineLimit:    lineLimit,
 		parser:       parser,
 	}
 }
 
-// Start starts the handler.
-func (p *MultiLineParser) Start() {
-	go p.run()
+func (p *MultiLineParser) flushChan() <-chan time.Time {
+	if p.flushTimer != nil && p.buffer.Len() > 0 {
+		return p.flushTimer.C
+	}
+	return nil
 }
 
-// run processes new lines from the channel and makes sur the content is properly sent when
-// it stayed for too long in the buffer.
-func (p *MultiLineParser) run() {
-	flushTimer := time.NewTimer(p.flushTimeout)
-	defer func() {
-		flushTimer.Stop()
-		// make sure the content stored in the buffer gets sent,
-		// this can happen when the stop is called in between two timer ticks.
-		p.sendLine()
-		// and close the outputChan, signalling to downstream that this component is finished
-		close(p.outputChan)
-	}()
-	for {
-		select {
-		case message, isOpen := <-p.inputChan:
-			if !isOpen {
-				// inputChan has been closed, no more lines are expected
-				return
-			}
-			// process the new line and restart the timeout
-			if !flushTimer.Stop() {
-				// flushTimer.stop() doesn't prevent the timer to tick,
-				// makes sure the event is consumed to avoid sending
-				// just one piece of the content.
-				select {
-				case <-flushTimer.C:
-				default:
-				}
-			}
-			p.process(message)
-			flushTimer.Reset(p.flushTimeout)
-		case <-flushTimer.C:
-			// no chunk has been collected since a while,
-			// the content is supposed to be complete.
-			p.sendLine()
-		}
-	}
+func (p *MultiLineParser) flush() {
+	p.sendLine()
 }
 
 // process buffers and aggregates partial lines
 func (p *MultiLineParser) process(input *DecodedInput) {
+	if p.flushTimer != nil && p.buffer.Len() > 0 {
+		// stop the flush timer, as we now have data
+		if !p.flushTimer.Stop() {
+			<-p.flushTimer.C
+		}
+	}
 	msg, err := p.parser.Parse(input.content)
 	if err != nil {
 		log.Debug(err)
@@ -157,10 +125,17 @@ func (p *MultiLineParser) process(input *DecodedInput) {
 		// the current chunk marks the end of an aggregated line
 		p.sendLine()
 	}
+	if p.buffer.Len() > 0 {
+		// since there's buffered data, start the flush timer to flush it
+		if p.flushTimer == nil {
+			p.flushTimer = time.NewTimer(p.flushTimeout)
+		} else {
+			p.flushTimer.Reset(p.flushTimeout)
+		}
+	}
 }
 
 // sendBuffer forwards the content stored in the buffer
-// to the output channel.
 func (p *MultiLineParser) sendLine() {
 	defer func() {
 		p.buffer.Reset()
@@ -170,6 +145,6 @@ func (p *MultiLineParser) sendLine() {
 	content := make([]byte, p.buffer.Len())
 	copy(content, p.buffer.Bytes())
 	if len(content) > 0 || p.rawDataLen > 0 {
-		p.outputChan <- NewMessage(content, p.status, p.rawDataLen, p.timestamp)
+		p.outputFn(NewMessage(content, p.status, p.rawDataLen, p.timestamp))
 	}
 }

--- a/pkg/logs/decoder/line_parser_test.go
+++ b/pkg/logs/decoder/line_parser_test.go
@@ -62,13 +62,13 @@ func TestSingleLineParser(t *testing.T) {
 	line := header
 
 	inputLen := len(line) + 1
-	lineParser.process(&DecodedInput{[]byte(line), inputLen})
+	lineParser.process([]byte(line), inputLen)
 	message = <-outputChan
 	assert.Equal(t, "", string(message.Content))
 	assert.Equal(t, inputLen, message.RawDataLen)
 
 	inputLen = len(line+"one message") + 1
-	lineParser.process(&DecodedInput{[]byte(line + "one message"), inputLen})
+	lineParser.process([]byte(line+"one message"), inputLen)
 	message = <-outputChan
 	assert.Equal(t, "one message", string(message.Content))
 	assert.Equal(t, inputLen, message.RawDataLen)
@@ -80,7 +80,7 @@ func TestSingleLineParserSendsRawInvalidMessages(t *testing.T) {
 	outputFn, outputChan := lineParserChans()
 	lineParser := NewSingleLineParser(outputFn, p)
 
-	lineParser.process(&DecodedInput{[]byte("one message"), 12})
+	lineParser.process([]byte("one message"), 12)
 	message := <-outputChan
 	assert.Equal(t, "one message", string(message.Content))
 }
@@ -93,9 +93,9 @@ func TestMultilineParser(t *testing.T) {
 	outputFn, outputChan := lineParserChans()
 	lineParser := NewMultiLineParser(outputFn, timeout, p, contentLenLimit)
 
-	lineParser.process(&DecodedInput{[]byte(header + "one "), 11})
-	lineParser.process(&DecodedInput{[]byte(header + "long "), 12})
-	lineParser.process(&DecodedInput{[]byte(header + "line\\n"), 14})
+	lineParser.process([]byte(header+"one "), 11)
+	lineParser.process([]byte(header+"long "), 12)
+	lineParser.process([]byte(header+"line\\n"), 14)
 
 	message := <-outputChan
 
@@ -111,7 +111,7 @@ func TestMultilineParserTimeout(t *testing.T) {
 	outputFn, outputChan := lineParserChans()
 	lineParser := NewMultiLineParser(outputFn, timeout, p, contentLenLimit)
 
-	lineParser.process(&DecodedInput{[]byte(header + "message"), 14})
+	lineParser.process([]byte(header+"message"), 14)
 
 	// shouldn't be anything here yet
 	select {
@@ -140,9 +140,9 @@ func TestMultilineParserLimit(t *testing.T) {
 	lineParser := NewMultiLineParser(outputFn, timeout, p, contentLenLimit)
 
 	for i := 0; i < 10; i++ {
-		lineParser.process(&DecodedInput{[]byte(header + line), 7 + len(line)})
+		lineParser.process([]byte(header+line), 7+len(line))
 	}
-	lineParser.process(&DecodedInput{[]byte(header + "aaaa\\n"), 13})
+	lineParser.process([]byte(header+"aaaa\\n"), 13)
 
 	for i := 0; i < 10; i++ {
 		message = <-outputChan

--- a/pkg/logs/decoder/line_parser_test.go
+++ b/pkg/logs/decoder/line_parser_test.go
@@ -14,13 +14,13 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 const header = "HEADER"
 
-func lineParserChans() (chan *DecodedInput, chan *Message) {
-	return make(chan *DecodedInput, 5), make(chan *Message, 5)
+func lineParserChans() (func(*Message), chan *Message) {
+	ch := make(chan *Message, 20)
+	return func(m *Message) { ch <- m }, ch
 }
 
 type MockFailingParser struct {
@@ -56,47 +56,33 @@ func TestSingleLineParser(t *testing.T) {
 	var message *Message
 	p := NewMockFailingParser(header)
 
-	inputChan, outputChan := lineParserChans()
-	lineParser := NewSingleLineParser(inputChan, outputChan, p)
-	lineParser.Start()
+	outputFn, outputChan := lineParserChans()
+	lineParser := NewSingleLineParser(outputFn, p)
 
 	line := header
 
 	inputLen := len(line) + 1
-	inputChan <- &DecodedInput{[]byte(line), inputLen}
+	lineParser.process(&DecodedInput{[]byte(line), inputLen})
 	message = <-outputChan
 	assert.Equal(t, "", string(message.Content))
 	assert.Equal(t, inputLen, message.RawDataLen)
 
 	inputLen = len(line+"one message") + 1
-	inputChan <- &DecodedInput{[]byte(line + "one message"), inputLen}
+	lineParser.process(&DecodedInput{[]byte(line + "one message"), inputLen})
 	message = <-outputChan
 	assert.Equal(t, "one message", string(message.Content))
 	assert.Equal(t, inputLen, message.RawDataLen)
-
-	close(inputChan)
-
-	// once the input channel closes, the output channel closes as well
-	_, ok := <-outputChan
-	require.Equal(t, false, ok)
 }
 
 func TestSingleLineParserSendsRawInvalidMessages(t *testing.T) {
 	p := NewMockFailingParser(header)
 
-	inputChan, outputChan := lineParserChans()
-	lineParser := NewSingleLineParser(inputChan, outputChan, p)
-	lineParser.Start()
+	outputFn, outputChan := lineParserChans()
+	lineParser := NewSingleLineParser(outputFn, p)
 
-	inputChan <- &DecodedInput{[]byte("one message"), 12}
+	lineParser.process(&DecodedInput{[]byte("one message"), 12})
 	message := <-outputChan
 	assert.Equal(t, "one message", string(message.Content))
-
-	close(inputChan)
-
-	// once the input channel closes, the output channel closes as well
-	_, ok := <-outputChan
-	require.Equal(t, false, ok)
 }
 
 func TestMultilineParser(t *testing.T) {
@@ -104,24 +90,17 @@ func TestMultilineParser(t *testing.T) {
 	timeout := 1000 * time.Millisecond
 	contentLenLimit := 256 * 100
 
-	inputChan, outputChan := lineParserChans()
-	lineParser := NewMultiLineParser(inputChan, outputChan, timeout, p, contentLenLimit)
-	lineParser.Start()
+	outputFn, outputChan := lineParserChans()
+	lineParser := NewMultiLineParser(outputFn, timeout, p, contentLenLimit)
 
-	inputChan <- &DecodedInput{[]byte(header + "one "), 11}
-	inputChan <- &DecodedInput{[]byte(header + "long "), 12}
-	inputChan <- &DecodedInput{[]byte(header + "line\\n"), 14}
+	lineParser.process(&DecodedInput{[]byte(header + "one "), 11})
+	lineParser.process(&DecodedInput{[]byte(header + "long "), 12})
+	lineParser.process(&DecodedInput{[]byte(header + "line\\n"), 14})
 
 	message := <-outputChan
 
 	assert.Equal(t, "one long line", string(message.Content))
 	assert.Equal(t, message.RawDataLen, 11+12+14)
-
-	close(inputChan)
-
-	// once the input channel closes, the output channel closes as well
-	_, ok := <-outputChan
-	require.Equal(t, false, ok)
 }
 
 func TestMultilineParserTimeout(t *testing.T) {
@@ -129,12 +108,19 @@ func TestMultilineParserTimeout(t *testing.T) {
 	timeout := 100 * time.Millisecond
 	contentLenLimit := 256 * 100
 
-	inputChan, outputChan := lineParserChans()
-	lineParser := NewMultiLineParser(inputChan, outputChan, timeout, p, contentLenLimit)
-	lineParser.Start()
-	defer close(inputChan)
+	outputFn, outputChan := lineParserChans()
+	lineParser := NewMultiLineParser(outputFn, timeout, p, contentLenLimit)
 
-	inputChan <- &DecodedInput{[]byte(header + "message"), 14}
+	lineParser.process(&DecodedInput{[]byte(header + "message"), 14})
+
+	// shouldn't be anything here yet
+	select {
+	case <-outputChan:
+		panic("shouldn't be a message")
+	default:
+	}
+
+	lineParser.flush()
 
 	message := <-outputChan
 
@@ -150,15 +136,13 @@ func TestMultilineParserLimit(t *testing.T) {
 	var message *Message
 	line := strings.Repeat("a", contentLenLimit)
 
-	inputChan, outputChan := lineParserChans()
-	lineParser := NewMultiLineParser(inputChan, outputChan, timeout, p, contentLenLimit)
-	lineParser.Start()
-	defer close(inputChan)
+	outputFn, outputChan := lineParserChans()
+	lineParser := NewMultiLineParser(outputFn, timeout, p, contentLenLimit)
 
 	for i := 0; i < 10; i++ {
-		inputChan <- &DecodedInput{[]byte(header + line), 7 + len(line)}
+		lineParser.process(&DecodedInput{[]byte(header + line), 7 + len(line)})
 	}
-	inputChan <- &DecodedInput{[]byte(header + "aaaa\\n"), 13}
+	lineParser.process(&DecodedInput{[]byte(header + "aaaa\\n"), 13})
 
 	for i := 0; i < 10; i++ {
 		message = <-outputChan

--- a/pkg/logs/decoder/multiline_handler.go
+++ b/pkg/logs/decoder/multiline_handler.go
@@ -16,11 +16,11 @@ import (
 // MultiLineHandler makes sure that multiple lines from a same content
 // are properly put together.
 type MultiLineHandler struct {
-	inputChan      chan *Message
-	outputChan     chan *Message
+	outputFn       func(*Message)
 	newContentRe   *regexp.Regexp
 	buffer         *bytes.Buffer
 	flushTimeout   time.Duration
+	flushTimer     *time.Timer
 	lineLimit      int
 	shouldTruncate bool
 	linesLen       int
@@ -30,10 +30,9 @@ type MultiLineHandler struct {
 }
 
 // NewMultiLineHandler returns a new MultiLineHandler.
-func NewMultiLineHandler(inputChan chan *Message, outputChan chan *Message, newContentRe *regexp.Regexp, flushTimeout time.Duration, lineLimit int) *MultiLineHandler {
+func NewMultiLineHandler(outputFn func(*Message), newContentRe *regexp.Regexp, flushTimeout time.Duration, lineLimit int) *MultiLineHandler {
 	return &MultiLineHandler{
-		inputChan:    inputChan,
-		outputChan:   outputChan,
+		outputFn:     outputFn,
 		newContentRe: newContentRe,
 		buffer:       bytes.NewBuffer(nil),
 		flushTimeout: flushTimeout,
@@ -42,47 +41,15 @@ func NewMultiLineHandler(inputChan chan *Message, outputChan chan *Message, newC
 	}
 }
 
-// Start starts the handler.
-func (h *MultiLineHandler) Start() {
-	go h.run()
+func (h *MultiLineHandler) flushChan() <-chan time.Time {
+	if h.flushTimer != nil && h.buffer.Len() > 0 {
+		return h.flushTimer.C
+	}
+	return nil
 }
 
-// run processes new lines from the channel and makes sur the content is properly sent when
-// it stayed for too long in the buffer.
-func (h *MultiLineHandler) run() {
-	flushTimer := time.NewTimer(h.flushTimeout)
-	defer func() {
-		flushTimer.Stop()
-		// make sure the content stored in the buffer gets sent,
-		// this can happen when the stop is called in between two timer ticks.
-		h.sendBuffer()
-		close(h.outputChan)
-	}()
-	for {
-		select {
-		case message, isOpen := <-h.inputChan:
-			if !isOpen {
-				// lineChan has been closed, no more lines are expected
-				return
-			}
-			// process the new line and restart the timeout
-			if !flushTimer.Stop() {
-				// timer stop doesn't not prevent the timer to tick,
-				// makes sure the event is consumed to avoid sending
-				// just one piece of the content.
-				select {
-				case <-flushTimer.C:
-				default:
-				}
-			}
-			h.process(message)
-			flushTimer.Reset(h.flushTimeout)
-		case <-flushTimer.C:
-			// no line has been collected since a while,
-			// the content is supposed to be complete.
-			h.sendBuffer()
-		}
-	}
+func (h *MultiLineHandler) flush() {
+	h.sendBuffer()
 }
 
 // process aggregates multiple lines to form a full multiline message,
@@ -91,6 +58,12 @@ func (h *MultiLineHandler) run() {
 // and that the length of the lines is properly tracked
 // so that the agent restarts tailing from the right place.
 func (h *MultiLineHandler) process(message *Message) {
+	if h.flushTimer != nil && h.buffer.Len() > 0 {
+		// stop the flush timer, as we now have data
+		if !h.flushTimer.Stop() {
+			<-h.flushTimer.C
+		}
+	}
 
 	if h.newContentRe.Match(message.Content) {
 		h.countInfo.Add(1)
@@ -130,10 +103,19 @@ func (h *MultiLineHandler) process(message *Message) {
 		h.sendBuffer()
 		h.shouldTruncate = true
 	}
+
+	if h.buffer.Len() > 0 {
+		// since there's buffered data, start the flush timer to flush it
+		if h.flushTimer == nil {
+			h.flushTimer = time.NewTimer(h.flushTimeout)
+		} else {
+			h.flushTimer.Reset(h.flushTimeout)
+		}
+	}
 }
 
 // sendBuffer forwards the content stored in the buffer
-// to the output channel.
+// to the output function.
 func (h *MultiLineHandler) sendBuffer() {
 	defer func() {
 		h.buffer.Reset()
@@ -146,6 +128,6 @@ func (h *MultiLineHandler) sendBuffer() {
 	copy(content, data)
 
 	if len(content) > 0 || h.linesLen > 0 {
-		h.outputChan <- NewMessage(content, h.status, h.linesLen, h.timestamp)
+		h.outputFn(NewMessage(content, h.status, h.linesLen, h.timestamp))
 	}
 }

--- a/pkg/logs/internal/tailers/docker/matcher.go
+++ b/pkg/logs/internal/tailers/docker/matcher.go
@@ -10,6 +10,7 @@ package docker
 import (
 	"github.com/DataDog/datadog-agent/pkg/logs/config"
 	"github.com/DataDog/datadog-agent/pkg/logs/decoder"
+	"github.com/DataDog/datadog-agent/pkg/logs/decoder/breaker"
 	"github.com/DataDog/datadog-agent/pkg/logs/internal/parsers/dockerstream"
 )
 
@@ -23,7 +24,7 @@ const (
 )
 
 type headerMatcher struct {
-	decoder.EndLineMatcher
+	breaker.EndLineMatcher
 }
 
 // SeparatorLen returns the number of byte to skip at the end of each line


### PR DESCRIPTION
### What does this PR do?

Previously, the logs-agent 'decoder' actor ran as three actors connected by channels.  However, these channels were unbuffered, meaning that the actors could not operate concurrently. They merely introduced more complexity in juggling concurrency of four goroutines (main + 3 actors).

This PR refactors the decoder into a single actor goroutine that uses function calls to coordinate the three components (line breaker, line parser, line handler).

### Motivation

Simplify, simplify, simplify.

This leads to some later improvements, and also makes it much simpler and lower-risk to introduce new decoder components.

### Possible Drawbacks / Trade-offs

This should have no functional impact.  No algorithmic complexity or memory consumption changes are expected.

### Describe how to test/QA your changes

Set up logs-agent to test the three conditions under which the decoder is used:

 * tailing from the docker API (run the agent in a docker container, with access to the docker socket, set `logs_config.docker_container_use_file: false` and `logs_config.container_collect_all: true`)
 * tailing from a file (`logs_config.docker_container_use_file: true`)
 * tailing from TCP (set up an integration with type: tcp, and use `nc` or `telnet` to send data to it)

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
