### PR TITLE
Fix metric confusion when the metric name is contained in the tags

### DIFF
--- a/pkg/aggregator/ckey/key.go
+++ b/pkg/aggregator/ckey/key.go
@@ -57,7 +57,8 @@ func (g *KeyGenerator) Generate(name, hostname string, tagsBuf *tagset.HashingTa
 // tagsBuf is re-arranged in place and truncated to only contain unique tags.
 func (g *KeyGenerator) GenerateWithTags(name, hostname string, tagsBuf *tagset.HashingTagsAccumulator) (ContextKey, TagsKey) {
 	tags := g.hg.Hash(tagsBuf)
-	hash := murmur3.StringSum64(name) ^ murmur3.StringSum64(hostname) ^ tags
+	hash := g.combineHash(name, hostname, tags)
+
 	return ContextKey(hash), TagsKey(tags)
 }
 
@@ -69,8 +70,19 @@ func (g *KeyGenerator) GenerateWithTags2(name, hostname string, l, r *tagset.Has
 	g.hg.Dedup2(l, r)
 	lHash := l.Hash()
 	rHash := r.Hash()
-	hash := murmur3.StringSum64(name) ^ murmur3.StringSum64(hostname) ^ lHash ^ rHash
+	hash := g.combineHash(name, hostname, lHash^rHash)
+
 	return ContextKey(hash), TagsKey(lHash), TagsKey(rHash)
+}
+
+func (g *KeyGenerator) combineHash(name, hostname string, tagsHash uint64) uint64 {
+	// Don't just xor with tags hashes, because metric and hostname are allowed to be the same
+	// as a tag, and we don't want them to cancel out.
+	i, j := tagsHash, tagsHash
+	i, j = murmur3.SeedStringSum128(i, j, name)
+	i, _ = murmur3.SeedStringSum128(i, j, hostname)
+
+	return i // Same as murmur3.StringSum64, return upper 64 bits of the result.
 }
 
 // Equals returns whether the two context keys are equal or not.

--- a/pkg/aggregator/ckey/key_test.go
+++ b/pkg/aggregator/ckey/key_test.go
@@ -27,7 +27,7 @@ func TestGenerateReproductible(t *testing.T) {
 	generator := NewKeyGenerator()
 
 	firstKey := generator.Generate(name, hostname, tags)
-	assert.Equal(t, ContextKey(0x932f9848b0fb0802), firstKey)
+	assert.Equal(t, ContextKey(0x1e923504c1aad3ad), firstKey)
 
 	for n := 0; n < 10; n++ {
 		t.Run(fmt.Sprintf("iteration %d:", n), func(t *testing.T) {
@@ -38,7 +38,7 @@ func TestGenerateReproductible(t *testing.T) {
 
 	otherKey := generator.Generate("othername", hostname, tags)
 	assert.NotEqual(t, firstKey, otherKey)
-	assert.Equal(t, ContextKey(0xb059e8f73b4b7ae0), otherKey)
+	assert.Equal(t, ContextKey(0xd298ae9740130f30), otherKey)
 }
 
 func TestGenerateReproductible2(t *testing.T) {
@@ -50,7 +50,7 @@ func TestGenerateReproductible2(t *testing.T) {
 	generator := NewKeyGenerator()
 
 	firstKey, tagsKey1, tagsKey2 := generator.GenerateWithTags2(name, hostname, tags1, tags2)
-	assert.Equal(t, ContextKey(0x932f9848b0fb0802), firstKey)
+	assert.Equal(t, ContextKey(0x1e923504c1aad3ad), firstKey)
 	assert.Equal(t, TagsKey(0x437b13a371a1c7d3), tagsKey1)
 	assert.Equal(t, TagsKey(0), tagsKey2)
 
@@ -65,9 +65,30 @@ func TestGenerateReproductible2(t *testing.T) {
 
 	otherKey, otherTagsKey1, otherTagsKey2 := generator.GenerateWithTags2("othername", hostname, tags1, tags2)
 	assert.NotEqual(t, firstKey, otherKey)
-	assert.Equal(t, ContextKey(0xb059e8f73b4b7ae0), otherKey)
+	assert.Equal(t, ContextKey(0xd298ae9740130f30), otherKey)
 	assert.Equal(t, tagsKey1, otherTagsKey1)
 	assert.Equal(t, tagsKey2, otherTagsKey2)
+}
+
+func TestMetricTagOverlap(t *testing.T) {
+	g := NewKeyGenerator()
+
+	empty := tagset.NewHashingTagsAccumulator()
+	h1, _, _ := g.GenerateWithTags2("metric1", "hostname",
+		tagset.NewHashingTagsAccumulatorWithTags([]string{"metric1", "t1", "t2"}), empty)
+	h2, _, _ := g.GenerateWithTags2("metric2", "hostname",
+		tagset.NewHashingTagsAccumulatorWithTags([]string{"metric2", "t1", "t2"}), empty)
+
+	assert.NotEqual(t, h1, h2)
+}
+
+func TestMetricHostnameSplit(t *testing.T) {
+	g := NewKeyGenerator()
+	empty := tagset.NewHashingTagsAccumulator()
+	h1, _, _ := g.GenerateWithTags2("metric", "hostname", empty, empty)
+	h2, _, _ := g.GenerateWithTags2("metrichost", "name", empty, empty)
+
+	assert.NotEqual(t, h1, h2)
 }
 
 func TestCompare(t *testing.T) {

--- a/pkg/aggregator/context_resolver_test.go
+++ b/pkg/aggregator/context_resolver_test.go
@@ -51,7 +51,7 @@ func TestGenerateContextKey(t *testing.T) {
 	}
 
 	contextKey := generateContextKey(&mSample)
-	assert.Equal(t, ckey.ContextKey(0x14298ff49d0c6bb9), contextKey)
+	assert.Equal(t, ckey.ContextKey(0x8cdd8c0c59c767db), contextKey)
 }
 
 func testTrackContext(t *testing.T, store *tags.Store) {


### PR DESCRIPTION
### What does this PR do?

Previously, when the metric name occurred in the tags list, the two
hashes would cancel out when we combine them with XOR, causing the
same context key to be returned for different metrics.

This patch replaces XOR hash combination with a murmur3 hash of metric
name, hostname and the bytes of the tags hash.


### Motivation

Avoid metric confusion when metric name is present in the tags.

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

```
docker run --rm --name qa \
-e DD_LOG_LEVEL=debug -e DD_LOG_PAYLOADS=true -e DD_DOGSTATSD_SOCKET=/tmp/dsd.sock \
-e DD_API_KEY=none -v /tmp:/tmp \
datadog/agent:7.36.0-rc.1
```

Send two or more metrics that both have the metric name in the tags:
```
echo -e 'metric.1:11111|g|#metric.1\nmetric.2:22222|g|#metric.2' | nc -uU /tmp/dsd.sock
```

Verify that both metrics are present in the outgoing payload:

```
docker logs qa | grep metric\\\.
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
