### PR TITLE
Determine the container runtime from the environment.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -809,11 +809,6 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_default_match_timeout", 30) // Seconds
 	config.BindEnvAndSetDefault("logs_config.auto_multi_line_default_match_threshold", 0.48)
 
-	// If true, the agent looks for container logs in the location used by podman, rather
-	// than docker.  This is a temporary configuration parameter to support podman logs until
-	// a more substantial refactor of autodiscovery is made to determine this automatically.
-	config.BindEnvAndSetDefault("logs_config.use_podman_logs", false)
-
 	config.BindEnvAndSetDefault("logs_config.auditor_ttl", DefaultAuditorTTL) // in hours
 	// Timeout in milliseonds used when performing agreggation operations,
 	// including multi-line log processing rules and chunked line reaggregation.

--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -71,6 +71,10 @@ type LogsConfig struct {
 	AutoMultiLine               *bool   `mapstructure:"auto_multi_line_detection" json:"auto_multi_line_detection"`
 	AutoMultiLineSampleSize     int     `mapstructure:"auto_multi_line_sample_size" json:"auto_multi_line_sample_size"`
 	AutoMultiLineMatchThreshold float64 `mapstructure:"auto_multi_line_match_threshold" json:"auto_multi_line_match_threshold"`
+
+	// For Type="file" when used for logging containers, this gives the container runtime, allowing
+	// the file launcher to determine how to decode the on-disk content.
+	ContainerRuntime config.Feature
 }
 
 // TailingMode type

--- a/pkg/logs/config/integration_config.go
+++ b/pkg/logs/config/integration_config.go
@@ -72,8 +72,9 @@ type LogsConfig struct {
 	AutoMultiLineSampleSize     int     `mapstructure:"auto_multi_line_sample_size" json:"auto_multi_line_sample_size"`
 	AutoMultiLineMatchThreshold float64 `mapstructure:"auto_multi_line_match_threshold" json:"auto_multi_line_match_threshold"`
 
-	// For Type="file" when used for logging containers, this gives the container runtime, allowing
-	// the file launcher to determine how to decode the on-disk content.
+	// When logging containers with Type="file", this is set to the current
+	// container runtime, allowing the file launcher to determine how to decode
+	// the on-disk content.
 	ContainerRuntime config.Feature
 }
 

--- a/pkg/logs/decoder/file_decoder.go
+++ b/pkg/logs/decoder/file_decoder.go
@@ -33,10 +33,11 @@ func NewDecoderFromSourceWithPattern(source *config.LogSource, multiLinePattern 
 		lineParser = kubernetes.New()
 		matcher = &NewLineMatcher{}
 	case config.DockerSourceType:
-		if coreConfig.Datadog.GetBool("logs_config.use_podman_logs") {
+		switch source.Config.ContainerRuntime {
+		case coreConfig.Podman:
 			// podman's on-disk logs are in kubernetes format
 			lineParser = kubernetes.New()
-		} else {
+		default: // default to Docker
 			lineParser = dockerfile.New()
 		}
 		matcher = &NewLineMatcher{}

--- a/pkg/logs/internal/launchers/docker/launcher.go
+++ b/pkg/logs/internal/launchers/docker/launcher.go
@@ -37,7 +37,11 @@ type sourceInfoPair struct {
 	info   *config.MappedInfo
 }
 
-// A Launcher starts and stops new tailers for every new containers discovered by autodiscovery.
+// A Launcher starts and stops new tailers for every new containers discovered
+// by autodiscovery.
+//
+// Note that despite being named "Docker", this is a generic container-related
+// launcher.
 type Launcher struct {
 	pipelineProvider   pipeline.Provider
 	addedSources       chan *config.LogSource
@@ -48,6 +52,7 @@ type Launcher struct {
 	pendingContainers  map[string]*Container
 	tailers            map[string]*tailer.Tailer
 	registry           auditor.Registry
+	runtime            coreConfig.Feature
 	stop               chan struct{}
 	erroredContainerID chan string
 	lock               *sync.Mutex
@@ -84,11 +89,25 @@ func NewLauncher(readTimeout time.Duration, sources *config.LogSources, services
 		return nil
 	}
 
+	var runtime coreConfig.Feature
+	for _, rt := range []coreConfig.Feature{
+		coreConfig.Docker,
+		coreConfig.Containerd,
+		coreConfig.Cri,
+		coreConfig.Podman,
+	} {
+		if coreConfig.IsFeaturePresent(rt) {
+			runtime = rt
+			break
+		}
+	}
+
 	launcher := &Launcher{
 		pipelineProvider:       pipelineProvider,
 		tailers:                make(map[string]*tailer.Tailer),
 		pendingContainers:      make(map[string]*Container),
 		registry:               registry,
+		runtime:                runtime,
 		stop:                   make(chan struct{}),
 		erroredContainerID:     make(chan string),
 		lock:                   &sync.Mutex{},
@@ -102,7 +121,7 @@ func NewLauncher(readTimeout time.Duration, sources *config.LogSources, services
 	}
 
 	if tailFromFile {
-		if err := checkReadAccess(); err != nil {
+		if err := launcher.checkContainerLogfileAccess(); err != nil {
 			log.Errorf("Could not access container log files: %v; falling back on tailing from container runtime socket", err)
 			launcher.tailFromFile = false
 		}
@@ -263,7 +282,7 @@ func (l *Launcher) getFileSource(container *Container, source *config.LogSource)
 	}
 
 	// Update parent source with additional information
-	sourceInfo.SetMessage(containerID, fmt.Sprintf("Container ID: %s, Image: %s, Created: %s, Tailing from file: %s", dockerutilpkg.ShortContainerID(containerID), shortName, container.container.Created, getPath(containerID)))
+	sourceInfo.SetMessage(containerID, fmt.Sprintf("Container ID: %s, Image: %s, Created: %s, Tailing from file: %s", dockerutilpkg.ShortContainerID(containerID), shortName, container.container.Created, l.getContainerLogfilePath(containerID)))
 
 	// When ContainerCollectAll is not enabled, we try to derive the service and source names from container labels
 	// provided by AD (in this case, the parent source config). Otherwise we use the standard service or short image
@@ -284,13 +303,14 @@ func (l *Launcher) getFileSource(container *Container, source *config.LogSource)
 
 	// New file source that inherit most of its parent properties
 	fileSource := config.NewLogSource(source.Name, &config.LogsConfig{
-		Type:            config.FileType,
-		Identifier:      containerID,
-		Path:            getPath(containerID),
-		Service:         serviceName,
-		Source:          sourceName,
-		Tags:            source.Config.Tags,
-		ProcessingRules: source.Config.ProcessingRules,
+		Type:             config.FileType,
+		Identifier:       containerID,
+		Path:             l.getContainerLogfilePath(containerID),
+		Service:          serviceName,
+		Source:           sourceName,
+		Tags:             source.Config.Tags,
+		ProcessingRules:  source.Config.ProcessingRules,
+		ContainerRuntime: l.runtime,
 	})
 	fileSource.SetSourceType(config.DockerSourceType)
 	fileSource.Status = source.Status

--- a/pkg/logs/internal/launchers/docker/launcher_nix_test.go
+++ b/pkg/logs/internal/launchers/docker/launcher_nix_test.go
@@ -17,20 +17,16 @@ import (
 )
 
 func TestGetPath(t *testing.T) {
-	t.Run("use_podman_logs=false", func(t *testing.T) {
-		mockConfig := config.Mock()
-		mockConfig.Set("logs_config.use_podman_logs", false)
-
+	t.Run("runtime=Docker", func(t *testing.T) {
+		l := &Launcher{runtime: config.Docker}
 		require.Equal(t,
 			filepath.Join(basePath, "123abc/123abc-json.log"),
-			getPath("123abc"))
+			l.getContainerLogfilePath("123abc"))
 	})
-	t.Run("use_podman_logs=true", func(t *testing.T) {
-		mockConfig := config.Mock()
-		mockConfig.Set("logs_config.use_podman_logs", true)
-
+	t.Run("runtime=Podman", func(t *testing.T) {
+		l := &Launcher{runtime: config.Podman}
 		require.Equal(t,
 			"/var/lib/containers/storage/overlay-containers/123abc/userdata/ctr.log",
-			getPath("123abc"))
+			l.getContainerLogfilePath("123abc"))
 	})
 }

--- a/pkg/logs/internal/launchers/docker/launcher_windows.go
+++ b/pkg/logs/internal/launchers/docker/launcher_windows.go
@@ -18,13 +18,13 @@ const (
 	basePath = "c:\\programdata\\docker\\containers"
 )
 
-func checkReadAccess() error {
+func (l *Launcher) checkContainerLogfileAccess() error {
 	// We need read access to the docker folder
 	_, err := ioutil.ReadDir(basePath)
 	return err
 }
 
-// getPath returns the file path of the container log to tail.
-func getPath(id string) string {
+// checkContainerLogfileAccess returns the file path of the container log to tail.
+func (l *Launcher) getContainerLogfilePath(id string) string {
 	return filepath.Join(basePath, id, fmt.Sprintf("%s-json.log", id))
 }

--- a/pkg/logs/internal/launchers/docker/launcher_windows_test.go
+++ b/pkg/logs/internal/launchers/docker/launcher_windows_test.go
@@ -76,7 +76,8 @@ func TestGetFileSourceOnWindows(t *testing.T) {
 }
 
 func TestGetPath(t *testing.T) {
+	l := &Launcher{}
 	require.Equal(t,
 		filepath.Join(basePath, "123abc/123abc-json.log"),
-		getPath("123abc"))
+		l.getContainerLogfilePath("123abc"))
 }


### PR DESCRIPTION
### What does this PR do?

This eliminates the need for the temporary `logs_config.use_podman_logs`
configuration value, based on the assumption that the agent is running
in the context of only one container runtime.

### Motivation

Remove unnecessary configuration.

### Describe how to test/QA your changes

Tail a container in
 * a docker environment
 * a (daemonful) podman environment

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
