### PR TITLE
[RC] ttl_seconds should just be an integer

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -289,7 +289,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("remote_configuration.director_root", "")
 	config.BindEnvAndSetDefault("remote_configuration.refresh_interval", 1*time.Minute)
 	config.BindEnvAndSetDefault("remote_configuration.max_backoff_interval", 5*time.Minute)
-	config.BindEnvAndSetDefault("remote_configuration.clients.ttl_seconds", 30)
+	config.BindEnvAndSetDefault("remote_configuration.clients.ttl_seconds", 30*time.Second)
 	// Remote config unstable features
 	config.BindEnvAndSetDefault("remote_configuration.unstable.self_signed", false)
 	config.BindEnvAndSetDefault("remote_configuration.unstable.self_signed_root", "")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -289,7 +289,7 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("remote_configuration.director_root", "")
 	config.BindEnvAndSetDefault("remote_configuration.refresh_interval", 1*time.Minute)
 	config.BindEnvAndSetDefault("remote_configuration.max_backoff_interval", 5*time.Minute)
-	config.BindEnvAndSetDefault("remote_configuration.clients.ttl_seconds", 30*time.Second)
+	config.BindEnvAndSetDefault("remote_configuration.clients.ttl_seconds", 30)
 	// Remote config unstable features
 	config.BindEnvAndSetDefault("remote_configuration.unstable.self_signed", false)
 	config.BindEnvAndSetDefault("remote_configuration.unstable.self_signed_root", "")

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -138,9 +138,9 @@ func NewService() (*Service, error) {
 		return nil, err
 	}
 
-	clientsTTL := time.Second * config.Datadog.GetDuration("remote_configuration.clients.ttl_seconds")
+	clientsTTL := config.Datadog.GetDuration("remote_configuration.clients.ttl_seconds")
 	if clientsTTL <= minimalRefreshInterval || clientsTTL >= maxClientsTTL {
-		log.Warnf("Configured clients ttl is not within accepted range (%ds - %ds): %s. Defaulting to %s", minimalRefreshInterval, maxClientsTTL, clientsTTL, defaultClientsTTL)
+		log.Warnf("Configured clients ttl is not within accepted range (%s - %s): %s. Defaulting to %s", minimalRefreshInterval, maxClientsTTL, clientsTTL, defaultClientsTTL)
 		clientsTTL = defaultClientsTTL
 	}
 	clock := clock.New()

--- a/pkg/config/remote/service/service.go
+++ b/pkg/config/remote/service/service.go
@@ -28,8 +28,9 @@ import (
 )
 
 const (
-	minimalRefreshInterval = time.Second * 5
-	defaultClientsTTL      = 10 * time.Second
+	minimalRefreshInterval = 5 * time.Second
+	defaultClientsTTL      = 30 * time.Second
+	maxClientsTTL          = 60 * time.Second
 )
 
 // Constraints on the maximum backoff time when errors occur
@@ -138,8 +139,8 @@ func NewService() (*Service, error) {
 	}
 
 	clientsTTL := time.Second * config.Datadog.GetDuration("remote_configuration.clients.ttl_seconds")
-	if clientsTTL <= 5*time.Second || clientsTTL >= 60*time.Second {
-		log.Warnf("Configured clients ttl is not within accepted range (%ds - %ds): %s. Defaulting to %s", 5, 10, clientsTTL, defaultClientsTTL)
+	if clientsTTL <= minimalRefreshInterval || clientsTTL >= maxClientsTTL {
+		log.Warnf("Configured clients ttl is not within accepted range (%ds - %ds): %s. Defaulting to %s", minimalRefreshInterval, maxClientsTTL, clientsTTL, defaultClientsTTL)
 		clientsTTL = defaultClientsTTL
 	}
 	clock := clock.New()


### PR DESCRIPTION

### What does this PR do?

As the name contains seconds it's clear it's in seconds.
We have to avoid multiplying it by time.Second twice and use a constant set of types to handle times.

### Motivation

High number of warnings due to the value being out of bounds.

### Describe how to test/QA your changes

- run the agent and verify it doesn't generate this warning when the configuration is not set.
- try to configure the values in various ways

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
