### PR TITLE
[demultiplexer] add a NoopForwarder and its support in the AgentDemultiplexer, use it for `check` command.

### DIFF
--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -141,6 +141,7 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 			forwarderOpts.DisableAPIKeyChecking = true
 			opts := aggregator.DefaultDemultiplexerOptions(forwarderOpts)
 			opts.FlushInterval = 0
+			opts.UseNoopForwarder = true
 			opts.UseNoopEventPlatformForwarder = true
 			opts.UseOrchestratorForwarder = false
 			demux := aggregator.InitAndStartAgentDemultiplexer(opts, hostname)

--- a/cmd/agent/common/commands/check.go
+++ b/cmd/agent/common/commands/check.go
@@ -32,7 +32,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/collector"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	"github.com/DataDog/datadog-agent/pkg/config"
-	"github.com/DataDog/datadog-agent/pkg/forwarder"
 	"github.com/DataDog/datadog-agent/pkg/logs/message"
 	"github.com/DataDog/datadog-agent/pkg/metadata"
 	"github.com/DataDog/datadog-agent/pkg/status"
@@ -137,9 +136,7 @@ func Check(loggerName config.LoggerName, confFilePath *string, flagNoColor *bool
 			}
 
 			// Initializing the aggregator with a flush interval of 0 (to disable the flush goroutines)
-			forwarderOpts := forwarder.NewOptions(nil)
-			forwarderOpts.DisableAPIKeyChecking = true
-			opts := aggregator.DefaultDemultiplexerOptions(forwarderOpts)
+			opts := aggregator.DefaultDemultiplexerOptions(nil)
 			opts.FlushInterval = 0
 			opts.UseNoopForwarder = true
 			opts.UseNoopEventPlatformForwarder = true

--- a/pkg/aggregator/demultiplexer.go
+++ b/pkg/aggregator/demultiplexer.go
@@ -112,6 +112,7 @@ type AgentDemultiplexer struct {
 // DemultiplexerOptions are the options used to initialize a Demultiplexer.
 type DemultiplexerOptions struct {
 	SharedForwarderOptions         *forwarder.Options
+	UseNoopForwarder               bool
 	UseNoopEventPlatformForwarder  bool
 	UseEventPlatformForwarder      bool
 	UseOrchestratorForwarder       bool
@@ -133,7 +134,7 @@ type statsd struct {
 }
 
 type forwarders struct {
-	shared             *forwarder.DefaultForwarder
+	shared             forwarder.Forwarder
 	orchestrator       *forwarder.DefaultForwarder
 	eventPlatform      epforwarder.EventPlatformForwarder
 	containerLifecycle *forwarder.DefaultForwarder
@@ -228,7 +229,12 @@ func initAgentDemultiplexer(options DemultiplexerOptions, hostname string) *Agen
 		containerLifecycleForwarder = containerlifecycle.NewForwarder()
 	}
 
-	sharedForwarder := forwarder.NewDefaultForwarder(options.SharedForwarderOptions)
+	var sharedForwarder forwarder.Forwarder
+	if options.UseNoopForwarder {
+		sharedForwarder = forwarder.NoopForwarder{}
+	} else {
+		sharedForwarder = forwarder.NewDefaultForwarder(options.SharedForwarderOptions)
+	}
 
 	// prepare the serializer
 	// ----------------------

--- a/pkg/forwarder/noop_forwarder.go
+++ b/pkg/forwarder/noop_forwarder.go
@@ -1,0 +1,83 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package forwarder
+
+import "net/http"
+
+// NoopForwarder is a Forwarder doing nothing and not returning any responses.
+type NoopForwarder struct{}
+
+// Start does nothing.
+func (f NoopForwarder) Start() error { return nil }
+
+// Stop does nothing.
+func (f NoopForwarder) Stop() {}
+
+// SubmitV1Series does nothing.
+func (f NoopForwarder) SubmitV1Series(payload Payloads, extra http.Header) error { return nil }
+
+// SubmitV1Intake does nothing.
+func (f NoopForwarder) SubmitV1Intake(payload Payloads, extra http.Header) error { return nil }
+
+// SubmitV1CheckRuns does nothing.
+func (f NoopForwarder) SubmitV1CheckRuns(payload Payloads, extra http.Header) error { return nil }
+
+// SubmitSeries does nothing.
+func (f NoopForwarder) SubmitSeries(payload Payloads, extra http.Header) error { return nil }
+
+// SubmitSketchSeries does nothing.
+func (f NoopForwarder) SubmitSketchSeries(payload Payloads, extra http.Header) error { return nil }
+
+// SubmitHostMetadata does nothing.
+func (f NoopForwarder) SubmitHostMetadata(payload Payloads, extra http.Header) error { return nil }
+
+// SubmitAgentChecksMetadata does nothing.
+func (f NoopForwarder) SubmitAgentChecksMetadata(payload Payloads, extra http.Header) error {
+	return nil
+}
+
+// SubmitMetadata does nothing.
+func (f NoopForwarder) SubmitMetadata(payload Payloads, extra http.Header) error { return nil }
+
+// SubmitProcessChecks does nothing.
+func (f NoopForwarder) SubmitProcessChecks(payload Payloads, extra http.Header) (chan Response, error) {
+	return nil, nil
+}
+
+// SubmitProcessDiscoveryChecks does nothing.
+func (f NoopForwarder) SubmitProcessDiscoveryChecks(payload Payloads, extra http.Header) (chan Response, error) {
+	return nil, nil
+}
+
+// SubmitRTProcessChecks does nothing.
+func (f NoopForwarder) SubmitRTProcessChecks(payload Payloads, extra http.Header) (chan Response, error) {
+	return nil, nil
+}
+
+// SubmitContainerChecks does nothing.
+func (f NoopForwarder) SubmitContainerChecks(payload Payloads, extra http.Header) (chan Response, error) {
+	return nil, nil
+}
+
+// SubmitRTContainerChecks does nothing.
+func (f NoopForwarder) SubmitRTContainerChecks(payload Payloads, extra http.Header) (chan Response, error) {
+	return nil, nil
+}
+
+// SubmitConnectionChecks does nothing.
+func (f NoopForwarder) SubmitConnectionChecks(payload Payloads, extra http.Header) (chan Response, error) {
+	return nil, nil
+}
+
+// SubmitOrchestratorChecks does nothing.
+func (f NoopForwarder) SubmitOrchestratorChecks(payload Payloads, extra http.Header, payloadType int) (chan Response, error) {
+	return nil, nil
+}
+
+// SubmitContainerLifecycleEvents does nothing.
+func (f NoopForwarder) SubmitContainerLifecycleEvents(payload Payloads, extra http.Header) error {
+	return nil
+}


### PR DESCRIPTION
### What does this PR do?

Implements a `NoopForwarder`, supports it in the `AgentDemultiplexer` implementation
and use it while running Agent `check` command.

### Motivation

We need to support a no-op Forwarder to be able to run Agent commands (i.e. the
`check` command) without creating any forwarder which may be doing some extra stuff
(e.g. establishing connection, cleaning transactions on disks, ...)

### Additional Notes

This change is deprecating he fix done in #11037 so I've removed it.

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

Run the agent `check` command with different flags combination (e.g. `agent check cpu --check-rate`, `agent check cpu --json`) and validate its producing an output with series.

Run a normal Agent for a couple minutes and validate your metrics are reaching the intake / a dashboard.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
