### PR TITLE
[orchestrator] Fix missing scrubbing

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/cronjob.go
@@ -98,11 +98,6 @@ func (h *CronJobHandlers) ScrubBeforeExtraction(ctx *processors.ProcessorContext
 func (h *CronJobHandlers) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {
 	r := resource.(*batchv1beta1.CronJob)
 	if ctx.Cfg.IsScrubbingEnabled {
-		for c := 0; c < len(r.Spec.JobTemplate.Spec.Template.Spec.InitContainers); c++ {
-			redact.ScrubContainer(&r.Spec.JobTemplate.Spec.Template.Spec.InitContainers[c], ctx.Cfg.Scrubber)
-		}
-		for c := 0; c < len(r.Spec.JobTemplate.Spec.Template.Spec.Containers); c++ {
-			redact.ScrubContainer(&r.Spec.JobTemplate.Spec.Template.Spec.Containers[c], ctx.Cfg.Scrubber)
-		}
+		redact.ScrubPodTemplateSpec(&r.Spec.JobTemplate.Spec.Template, ctx.Cfg.Scrubber)
 	}
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/daemonset.go
@@ -96,4 +96,8 @@ func (h *DaemonSetHandlers) ScrubBeforeExtraction(ctx *processors.ProcessorConte
 // ScrubBeforeMarshalling is a handler called to redact the raw resource before
 // it is marshalled to generate a manifest.
 func (h *DaemonSetHandlers) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {
+	r := resource.(*appsv1.DaemonSet)
+	if ctx.Cfg.IsScrubbingEnabled {
+		redact.ScrubPodTemplateSpec(&r.Spec.Template, ctx.Cfg.Scrubber)
+	}
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/deployment.go
@@ -98,11 +98,6 @@ func (h *DeploymentHandlers) ScrubBeforeExtraction(ctx *processors.ProcessorCont
 func (h *DeploymentHandlers) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {
 	r := resource.(*appsv1.Deployment)
 	if ctx.Cfg.IsScrubbingEnabled {
-		for c := 0; c < len(r.Spec.Template.Spec.InitContainers); c++ {
-			redact.ScrubContainer(&r.Spec.Template.Spec.InitContainers[c], ctx.Cfg.Scrubber)
-		}
-		for c := 0; c < len(r.Spec.Template.Spec.Containers); c++ {
-			redact.ScrubContainer(&r.Spec.Template.Spec.Containers[c], ctx.Cfg.Scrubber)
-		}
+		redact.ScrubPodTemplateSpec(&r.Spec.Template, ctx.Cfg.Scrubber)
 	}
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/job.go
@@ -98,11 +98,6 @@ func (h *JobHandlers) ScrubBeforeExtraction(ctx *processors.ProcessorContext, re
 func (h *JobHandlers) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {
 	r := resource.(*batchv1.Job)
 	if ctx.Cfg.IsScrubbingEnabled {
-		for c := 0; c < len(r.Spec.Template.Spec.InitContainers); c++ {
-			redact.ScrubContainer(&r.Spec.Template.Spec.InitContainers[c], ctx.Cfg.Scrubber)
-		}
-		for c := 0; c < len(r.Spec.Template.Spec.Containers); c++ {
-			redact.ScrubContainer(&r.Spec.Template.Spec.Containers[c], ctx.Cfg.Scrubber)
-		}
+		redact.ScrubPodTemplateSpec(&r.Spec.Template, ctx.Cfg.Scrubber)
 	}
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/pod.go
@@ -148,12 +148,6 @@ func (h *PodHandlers) ScrubBeforeExtraction(ctx *processors.ProcessorContext, re
 func (h *PodHandlers) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {
 	r := resource.(*corev1.Pod)
 	if ctx.Cfg.IsScrubbingEnabled {
-		for c := 0; c < len(r.Spec.Containers); c++ {
-			redact.ScrubContainer(&r.Spec.Containers[c], ctx.Cfg.Scrubber)
-		}
-		for c := 0; c < len(r.Spec.InitContainers); c++ {
-			redact.ScrubContainer(&r.Spec.InitContainers[c], ctx.Cfg.Scrubber)
-		}
+		redact.ScrubPodSpec(&r.Spec, ctx.Cfg.Scrubber)
 	}
-
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/replicaset.go
@@ -98,11 +98,6 @@ func (h *ReplicaSetHandlers) ScrubBeforeExtraction(ctx *processors.ProcessorCont
 func (h *ReplicaSetHandlers) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {
 	r := resource.(*appsv1.ReplicaSet)
 	if ctx.Cfg.IsScrubbingEnabled {
-		for c := 0; c < len(r.Spec.Template.Spec.InitContainers); c++ {
-			redact.ScrubContainer(&r.Spec.Template.Spec.InitContainers[c], ctx.Cfg.Scrubber)
-		}
-		for c := 0; c < len(r.Spec.Template.Spec.Containers); c++ {
-			redact.ScrubContainer(&r.Spec.Template.Spec.Containers[c], ctx.Cfg.Scrubber)
-		}
+		redact.ScrubPodTemplateSpec(&r.Spec.Template, ctx.Cfg.Scrubber)
 	}
 }

--- a/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/statefulset.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/processors/k8s/statefulset.go
@@ -96,4 +96,8 @@ func (h *StatefulSetHandlers) ScrubBeforeExtraction(ctx *processors.ProcessorCon
 // ScrubBeforeMarshalling is a handler called to redact the raw resource before
 // it is marshalled to generate a manifest.
 func (h *StatefulSetHandlers) ScrubBeforeMarshalling(ctx *processors.ProcessorContext, resource interface{}) {
+	r := resource.(*appsv1.StatefulSet)
+	if ctx.Cfg.IsScrubbingEnabled {
+		redact.ScrubPodTemplateSpec(&r.Spec.Template, ctx.Cfg.Scrubber)
+	}
 }

--- a/pkg/orchestrator/redact/pod.go
+++ b/pkg/orchestrator/redact/pod.go
@@ -18,6 +18,27 @@ const (
 	replacedValue = "-"
 )
 
+// ScrubPodTemplateSpec calls ScrubContainer for every container within a pod
+// template spec.
+func ScrubPodTemplateSpec(template *v1.PodTemplateSpec, scrubber *DataScrubber) {
+	for c := 0; c < len(template.Spec.InitContainers); c++ {
+		ScrubContainer(&template.Spec.InitContainers[c], scrubber)
+	}
+	for c := 0; c < len(template.Spec.Containers); c++ {
+		ScrubContainer(&template.Spec.Containers[c], scrubber)
+	}
+}
+
+// ScrubPodSpec calls ScrubContainer for every container within a pod spec.
+func ScrubPodSpec(spec *v1.PodSpec, scrubber *DataScrubber) {
+	for c := 0; c < len(spec.InitContainers); c++ {
+		ScrubContainer(&spec.InitContainers[c], scrubber)
+	}
+	for c := 0; c < len(spec.Containers); c++ {
+		ScrubContainer(&spec.Containers[c], scrubber)
+	}
+}
+
 // ScrubContainer scrubs sensitive information in the command line & env vars
 func ScrubContainer(c *v1.Container, scrubber *DataScrubber) {
 	// scrub env vars

--- a/pkg/status/templates/orchestrator.tmpl
+++ b/pkg/status/templates/orchestrator.tmpl
@@ -55,9 +55,9 @@ Orchestrator Explorer
       Last Run: (Hits: {{$element.CacheHits}} Miss: {{$element.CacheMiss}}) | Total: (Hits: {{$element.TotalHits}} Miss: {{$element.TotalMiss}})
 {{end}}
 {{- if .CLCEnabled }}
-  ===========
+  ==================================================
   Dispatched Configurations on Cluster Check Runners
-  ===========
+  ==================================================
     To print orchestrator check details run agent clusterchecks --check orchestrator
 {{end}}
 {{else}}

--- a/releasenotes-dca/notes/ds-sts-scrubbing-fix-555771b856b34eac.yaml
+++ b/releasenotes-dca/notes/ds-sts-scrubbing-fix-555771b856b34eac.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+    - Fix a bug that prevents scrubbing sensitive content on the DaemonSet resource.
+    - Fix a bug that prevents scrubbing sensitive content on the StatefulSet resource.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Fix missing scrubbing on DaemonSet and StatefulSet resources.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
