### PR TITLE
pkg/obfuscate: fix SQL tokenizer number parsing

### DIFF
--- a/pkg/obfuscate/sql_test.go
+++ b/pkg/obfuscate/sql_test.go
@@ -1176,6 +1176,10 @@ LIMIT 1
 			query:    "USING $09 SELECT",
 			expected: `USING ? SELECT`,
 		},
+		{
+			query:    "USING - SELECT",
+			expected: `USING - SELECT`,
+		},
 	}
 	o := NewObfuscator(Config{})
 	for _, c := range cases {

--- a/pkg/obfuscate/sql_test.go
+++ b/pkg/obfuscate/sql_test.go
@@ -1172,6 +1172,10 @@ LIMIT 1
 			query:    `SELECT * FROM Items WHERE id = -1 OR id = -01 OR id = -108 OR id = -.018 OR id = -.08 OR id = -908129`,
 			expected: `SELECT * FROM Items WHERE id = ? OR id = ? OR id = ? OR id = ? OR id = ? OR id = ?`,
 		},
+		{
+			query:    "USING $09 SELECT",
+			expected: `USING ? SELECT`,
+		},
 	}
 	o := NewObfuscator(Config{})
 	for _, c := range cases {

--- a/pkg/obfuscate/sql_test.go
+++ b/pkg/obfuscate/sql_test.go
@@ -1943,35 +1943,26 @@ func TestUnicodeDigit(t *testing.T) {
 }
 
 func TestParseNumber(t *testing.T) {
-	var testCases = []struct {
-		in       string
-		expected string
-		error    string
-	}{
-		{"1234", "?", ""},
-		{"-1234", "?", ""},
-		{"1234e12", "?", ""},
-		{"0xfa", "?", ""},
-		{"01234567", "?", ""},
-		{"09", "?", ""},
+	var testCases = []string{
+		"1234",
+		"-1234",
+		"1234e12",
+		"0xfa",
+		"01234567",
+		"09",
 		// Negatives are always parsed as decimals (not octal).
-		{"-01234567", "?", ""},
-		{"-012345678", "?", ""},
+		"-01234567",
+		"-012345678",
 	}
 
 	o := NewObfuscator(Config{})
 	for _, testCase := range testCases {
-		t.Run(testCase.in, func(t *testing.T) {
+		t.Run(testCase, func(t *testing.T) {
 			assert := assert.New(t)
-			oq, err := o.ObfuscateSQLString(testCase.in)
-			if testCase.error != "" {
-				require.NotNil(t, err)
-				assert.Equal(testCase.error, err.Error())
-			} else {
-				assert.NoError(err)
-				if assert.NotNil(oq) {
-					assert.Equal(testCase.expected, oq.Query)
-				}
+			oq, err := o.ObfuscateSQLString(testCase)
+			require.NoError(t, err)
+			if assert.NotNil(oq) {
+				assert.Equal("?", oq.Query)
 			}
 		})
 	}

--- a/pkg/obfuscate/sql_tokenizer.go
+++ b/pkg/obfuscate/sql_tokenizer.go
@@ -723,20 +723,12 @@ func (tkn *SQLTokenizer) scanNumber(seenDecimalPoint bool) (TokenKind, []byte) {
 			tkn.scanMantissa(16)
 		} else {
 			// octal int or float
-			seenDecimalDigit := false
 			tkn.scanMantissa(8)
 			if tkn.lastChar == '8' || tkn.lastChar == '9' {
-				// illegal octal int or float
-				seenDecimalDigit = true
 				tkn.scanMantissa(10)
 			}
 			if tkn.lastChar == '.' || tkn.lastChar == 'e' || tkn.lastChar == 'E' {
 				goto fraction
-			}
-			// octal int
-			if seenDecimalDigit {
-				// tkn.setErr called in caller
-				return LexError, tkn.bytes()
 			}
 		}
 		goto exit
@@ -763,6 +755,7 @@ exponent:
 exit:
 	t := tkn.bytes()
 	if len(t) == 0 {
+		tkn.setErr("Parse error: ended up with zero-length number.")
 		return LexError, nil
 	}
 	return Number, t

--- a/releasenotes/notes/fix-sql-a4adfd27d024af39.yaml
+++ b/releasenotes/notes/fix-sql-a4adfd27d024af39.yaml
@@ -1,0 +1,16 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+fixes:
+  - |
+    APM: Fix SQL parsing of negative numbers and improve error message.
+other:
+  - |
+    Add here every other information you want in the CHANGELOG that
+    don't fit in any other section. This section should rarely be
+    used.

--- a/releasenotes/notes/fix-sql-a4adfd27d024af39.yaml
+++ b/releasenotes/notes/fix-sql-a4adfd27d024af39.yaml
@@ -9,8 +9,4 @@
 fixes:
   - |
     APM: Fix SQL parsing of negative numbers and improve error message.
-other:
-  - |
-    Add here every other information you want in the CHANGELOG that
-    don't fit in any other section. This section should rarely be
-    used.
+


### PR DESCRIPTION
scanNumber failed to parse certain negative numbers and also failed to
set an error in the tokenizer when it returned LexError, resulting in
`nil` error messages. This commit causes scanNumber to correctly parse
those numbers and also set a more meaningful error message when it
encounters an error.

This also adds some tests specifically for the number parser.