### PR TITLE
[docs] Update logs agent TCP/HTTP option descriptions

### DIFF
--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -958,15 +958,17 @@ api_key:
 
   ## @param use_http - boolean - optional - default: false
   ## @env DD_LOGS_CONFIG_USE_HTTP - boolean - optional - default: false
-  ## By default, logs are sent through TCP, use this parameter
-  ## to send logs in HTTPS batches to port 443
+  ## By default, the Agent sends logs in HTTPS batches to port 443 if HTTPS connectivity can
+  ## be established at Agent startup, and falls back to TCP otherwise. Set this parameter to true to
+  ## always send logs with HTTPS (recommended).
   #
   # use_http: true
 
   ## @param use_tcp - boolean - optional - default: false
   ## @env DD_USE_TCP - boolean - optional - default: false
-  ## By default, logs are sent through HTTP if possible, use this parameter
-  ## to send logs in TCP
+  ## By default, logs are sent through HTTPS if possible, set this parameter
+  ## to true to send always logs in TCP. If `use_http` is set to `true`, this parameter
+  ## is ignored.
   #
   # use_tcp: true
 
@@ -980,7 +982,8 @@ api_key:
   ## @param compression_level - integer - optional - default: 6
   ## @env DD_LOGS_CONFIG_COMPRESSION_LEVEL - boolean - optional - default: false
   ## The compression_level parameter accepts values from 0 (no compression)
-  ## to 9 (maximum compression but higher resource usage).
+  ## to 9 (maximum compression but higher resource usage). Only takes effect if
+  ## `use_compression` is set to `true`.
   #
   # compression_level: 6
 

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -959,7 +959,7 @@ api_key:
   ## @param use_http - boolean - optional - default: false
   ## @env DD_LOGS_CONFIG_USE_HTTP - boolean - optional - default: false
   ## By default, the Agent sends logs in HTTPS batches to port 443 if HTTPS connectivity can
-  ## be established at Agent startup, and falls back to TCP otherwise. Set this parameter to true to
+  ## be established at Agent startup, and falls back to TCP otherwise. Set this parameter to `true` to
   ## always send logs with HTTPS (recommended).
   #
   # use_http: true
@@ -967,7 +967,7 @@ api_key:
   ## @param use_tcp - boolean - optional - default: false
   ## @env DD_USE_TCP - boolean - optional - default: false
   ## By default, logs are sent through HTTPS if possible, set this parameter
-  ## to true to send always logs in TCP. If `use_http` is set to `true`, this parameter
+  ## to `true` to always send logs via TCP. If `use_http` is set to `true`, this parameter
   ## is ignored.
   #
   # use_tcp: true


### PR DESCRIPTION
### What does this PR do?

Docs update: add details on the `use_http`/`use_tcp` options, what our recommendation is, and correct a mention of TCP being the default.

### Motivation

Fix docs.

### Describe how to test/QA your changes

Docs update, no QA.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
