### PR TITLE
[system-probe] Use sync.Pool for http aggregation objects

### DIFF
--- a/pkg/network/encoding/encoding.go
+++ b/pkg/network/encoding/encoding.go
@@ -107,8 +107,7 @@ func modelConnections(conns *network.Connections) *model.Connections {
 
 	// return HTTPAggregation objects to pool
 	for _, aggr := range httpIndex {
-		resetHTTPAggregations(aggr)
-		httpAggregationsPool.Put(aggr)
+		releaseHTTPAggregations(aggr)
 	}
 
 	if orphans := len(httpIndex) - len(httpMatches); orphans > 0 {
@@ -133,6 +132,11 @@ func modelConnections(conns *network.Connections) *model.Connections {
 	payload.Routes = routes
 
 	return payload
+}
+
+func releaseHTTPAggregations(aggr *model.HTTPAggregations) {
+	resetHTTPAggregations(aggr)
+	httpAggregationsPool.Put(aggr)
 }
 
 func resetHTTPAggregations(aggr *model.HTTPAggregations) {

--- a/pkg/network/encoding/format_test.go
+++ b/pkg/network/encoding/format_test.go
@@ -183,7 +183,10 @@ func BenchmarkFormatHTTPStats(b *testing.B) {
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		FormatHTTPStats(in)
+		result := FormatHTTPStats(in)
+		for _, a := range result {
+			releaseHTTPAggregations(a)
+		}
 	}
 }
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?
Uses `sync.Pool` for `model.HTTPAggregation` objects to reduce memory usage.

Before:

```
vagrant@agent-dev-hasan:/git/datadog-agent/pkg/network/encoding$ go test -bench=BenchmarkFormatHTTPStats
goos: linux
goarch: amd64
pkg: github.com/DataDog/datadog-agent/pkg/network/encoding
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkFormatHTTPStats-4   	    3285	    334027 ns/op	  495505 B/op	    1014 allocs/op
PASS
ok  	github.com/DataDog/datadog-agent/pkg/network/encoding	1.186s
```

After:
```
vagrant@agent-dev-hasan:/git/datadog-agent/pkg/network/encoding$ go test -bench=BenchmarkFormatHTTPStats
goos: linux
goarch: amd64
pkg: github.com/DataDog/datadog-agent/pkg/network/encoding
cpu: Intel(R) Core(TM) i7-1068NG7 CPU @ 2.30GHz
BenchmarkFormatHTTPStats-4   	    4722	    226413 ns/op	  183330 B/op	       4 allocs/op
PASS
ok  	github.com/DataDog/datadog-agent/pkg/network/encoding	1.163s
```

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
