### PR TITLE
[hostname] tentative fix of the case where no hostname has been found.

### DIFF
--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -346,6 +346,8 @@ func GetHostnameData(ctx context.Context) (HostnameData, error) {
 		return HostnameData{}, err
 	}
 
+	// we have a hostname, cache it and return it
+
 	hostnameData := saveHostnameData(cacheHostnameKey, hostName, provider)
 	return hostnameData, nil
 }

--- a/pkg/util/hostname.go
+++ b/pkg/util/hostname.go
@@ -340,18 +340,14 @@ func GetHostnameData(ctx context.Context) (HostnameData, error) {
 	// If at this point we don't have a name, bail out
 	if hostName == "" {
 		err = fmt.Errorf("unable to reliably determine the host name. You can define one in the agent config file or in your hosts file")
-		return HostnameData{}, err
-	}
-	// we got a hostname, residual errors are irrelevant now
-	err = nil
-
-	hostnameData := saveHostnameData(cacheHostnameKey, hostName, provider)
-	if err != nil {
 		expErr := new(expvar.String)
 		expErr.Set(fmt.Sprintf(err.Error()))
 		hostnameErrors.Set("all", expErr)
+		return HostnameData{}, err
 	}
-	return hostnameData, err
+
+	hostnameData := saveHostnameData(cacheHostnameKey, hostName, provider)
+	return hostnameData, nil
 }
 
 // isHostnameCanonicalForIntake returns true if the intake will use the hostname as canonical hostname.


### PR DESCRIPTION
Tentative fix of #4546, the error reporting in the expvar was wrong.

### Additional notes

This whole function would benefit from a refactoring with early returns.

### Describe how to test/QA your changes

Have an Agent not resolve to any hostname and validate the expvar is reporting it.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
