### PR TITLE
[demultiplexer] remove the `BufferedAggregator` in the Serverless Agent Demultiplexer

### DIFF
--- a/pkg/aggregator/demultiplexer.go
+++ b/pkg/aggregator/demultiplexer.go
@@ -887,7 +887,7 @@ func (d *ServerlessDemultiplexer) Serializer() serializer.MetricSerializer {
 	return d.serializer
 }
 
-// Aggregator returns the main buffered aggregator
+// Aggregator returns nil since the Serverless Agent doesn't run an Aggregator.
 func (d *ServerlessDemultiplexer) Aggregator() *BufferedAggregator {
 	return nil
 }

--- a/pkg/dogstatsd/batch.go
+++ b/pkg/dogstatsd/batch.go
@@ -58,8 +58,8 @@ func newBatcher(demux aggregator.Demultiplexer) *batcher {
 	var e chan []*metrics.Event
 	var sc chan []*metrics.ServiceCheck
 
-	// the Serverless Agent is not running an Aggregator, it does not
-	// have to support service checks nor events.
+	// the Serverless Agent doesn't have to support service checks nor events so
+	// it doesn't run an Aggregator.
 	if agg != nil {
 		e, sc = agg.GetBufferedChannels()
 	}
@@ -132,7 +132,7 @@ func (b *batcher) flush() {
 		b.flushSamples(uint32(i))
 	}
 
-	if len(b.events) > 0 && b.choutEvents != nil {
+	if len(b.events) > 0 {
 		t1 := time.Now()
 		b.choutEvents <- b.events
 		t2 := time.Now()
@@ -141,7 +141,7 @@ func (b *batcher) flush() {
 		b.events = []*metrics.Event{}
 	}
 
-	if len(b.serviceChecks) > 0 && b.choutServiceChecks != nil {
+	if len(b.serviceChecks) > 0 {
 		t1 := time.Now()
 		b.choutServiceChecks <- b.serviceChecks
 		t2 := time.Now()

--- a/pkg/dogstatsd/server.go
+++ b/pkg/dogstatsd/server.go
@@ -455,7 +455,7 @@ func (s *Server) forwarder(fcon net.Conn, packetsChannel chan packets.Packets) {
 func (s *Server) ServerlessFlush() {
 	log.Debug("Received a Flush trigger")
 
-	// make all workers flush their aggregated data (in the batchers) to the aggregator.
+	// make all workers flush their aggregated data (in the batchers) into the time samplers
 	s.serverlessFlushChan <- true
 
 	start := time.Now()

--- a/pkg/serverless/serverless.go
+++ b/pkg/serverless/serverless.go
@@ -163,8 +163,7 @@ func WaitForNextInvocation(stopCh chan struct{}, daemon *daemon.Daemon, id regis
 	if payload.EventType == Invoke {
 		functionArn := removeQualifierFromArn(payload.InvokedFunctionArn)
 		callInvocationHandler(daemon, functionArn, payload.DeadlineMs, safetyBufferTimeout, payload.RequestID, handleInvocation)
-	}
-	if payload.EventType == Shutdown {
+	} else if payload.EventType == Shutdown {
 		log.Debug("Received shutdown event. Reason: " + payload.ShutdownReason)
 		isTimeout := strings.ToLower(payload.ShutdownReason.String()) == Timeout.String()
 		if isTimeout {


### PR DESCRIPTION
### What does this PR do?

Removes the running `BufferedAggregator` from the `ServerlessDemultiplexer` implementation: it only needs to collect series and sketches, running a `TimeSamplerWorker` is enough now.

### Motivation

The Serverless Agent does not need to support Service Checks nor the old Events.

### Additional Notes

N/A

### Possible Drawbacks / Trade-offs

N/A

### Describe how to test/QA your changes

Run a regular Agent and send service checks and events through DogStatsD messages, check that they are correctly processed and available in the webapp.

Run a Serverless Agent, validate it is collecting metrics and logs and runs as usual. 

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
