### PR TITLE
[corechecks/helm] Handle releases with incomplete info

### DIFF
--- a/pkg/collector/corechecks/cluster/helm/helm_test.go
+++ b/pkg/collector/corechecks/cluster/helm/helm_test.go
@@ -61,6 +61,28 @@ func TestRun(t *testing.T) {
 			Version:   2,
 			Namespace: "app",
 		},
+		{ // Release with a nil chart reference
+			Name: "release_without_chart",
+			Info: &info{
+				Status: "deployed",
+			},
+			Chart:     nil,
+			Version:   1,
+			Namespace: "default",
+		},
+		{ // Release with a nil info reference
+			Name: "release_without_info",
+			Info: nil,
+			Chart: &chart{
+				Metadata: &metadata{
+					Name:       "example_app",
+					Version:    "2.0.0",
+					AppVersion: "1",
+				},
+			},
+			Version:   1,
+			Namespace: "default",
+		},
 	}
 
 	// Same order as "releases" array
@@ -99,6 +121,20 @@ func TestRun(t *testing.T) {
 			"helm_chart_version:1.1.0",
 			"helm_app_version:1",
 		},
+		{
+			"helm_release:release_without_chart",
+			"helm_namespace:default",
+			"helm_revision:1",
+			"helm_status:deployed",
+		},
+		{
+			"helm_release:release_without_info",
+			"helm_chart_name:example_app",
+			"helm_namespace:default",
+			"helm_revision:1",
+			"helm_chart_version:2.0.0",
+			"helm_app_version:1",
+		},
 	}
 
 	tests := []struct {
@@ -120,7 +156,7 @@ func TestRun(t *testing.T) {
 		{
 			name:         "using secrets and configmaps",
 			secrets:      []*v1.Secret{secretsForReleases[0]},
-			configmaps:   []*v1.ConfigMap{configmapsForReleases[1]},
+			configmaps:   configmapsForReleases[1:],
 			expectedTags: expectedTagsForReleases,
 		},
 		{


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in the Helm check.

The check panicked when handling releases with incomplete information. It's a bit counter-intuitive, but I've found releases that don't have a chart reference. I'm not sure if this is caused by failed deployments, possible bugs in Helm, etc.

### Describe how to test/QA your changes

Run the check in the same environment where the problem was found and check that it doesn't panic.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
