### PR TITLE
[CWS] use raw uname release instead of kernel version to compute rc file path

### DIFF
--- a/pkg/ebpf/bytecode/runtime/runtime_asset.go
+++ b/pkg/ebpf/bytecode/runtime/runtime_asset.go
@@ -104,12 +104,12 @@ func (a *RuntimeAsset) GetOutputFilePath(config *ebpf.Config, uname *unix.Utsnam
 	// this ensures we re-compile when either of the input changes
 	baseName := strings.TrimSuffix(a.filename, filepath.Ext(a.filename))
 
-	unameReleaseHash, err := Sha256hex(uname.Release[:])
+	unameHash, err := UnameHash(uname)
 	if err != nil {
 		return "", err
 	}
 
-	outputFile := filepath.Join(config.RuntimeCompilerOutputDir, fmt.Sprintf("%s-%s-%s-%s.o", baseName, unameReleaseHash, a.hash, flagHash))
+	outputFile := filepath.Join(config.RuntimeCompilerOutputDir, fmt.Sprintf("%s-%s-%s-%s.o", baseName, unameHash, a.hash, flagHash))
 	return outputFile, nil
 }
 

--- a/pkg/ebpf/bytecode/runtime/runtime_asset.go
+++ b/pkg/ebpf/bytecode/runtime/runtime_asset.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 
 	"github.com/DataDog/datadog-agent/pkg/ebpf"
-	"github.com/DataDog/datadog-agent/pkg/util/kernel"
+	"golang.org/x/sys/unix"
 )
 
 // CompilationResult enumerates runtime compilation success & failure modes
@@ -99,11 +99,17 @@ func (a *RuntimeAsset) GetInputReader(config *ebpf.Config, tm *RuntimeCompilatio
 	return inputReader, nil
 }
 
-func (a *RuntimeAsset) GetOutputFilePath(config *ebpf.Config, kernelVersion kernel.Version, flagHash string, tm *RuntimeCompilationTelemetry) (string, error) {
+func (a *RuntimeAsset) GetOutputFilePath(config *ebpf.Config, uname *unix.Utsname, flagHash string, tm *RuntimeCompilationTelemetry) (string, error) {
 	// filename includes kernel version, input file hash, and cflags hash
 	// this ensures we re-compile when either of the input changes
 	baseName := strings.TrimSuffix(a.filename, filepath.Ext(a.filename))
-	outputFile := filepath.Join(config.RuntimeCompilerOutputDir, fmt.Sprintf("%s-%d-%s-%s.o", baseName, kernelVersion, a.hash, flagHash))
+
+	unameReleaseHash, err := Sha256hex(uname.Release[:])
+	if err != nil {
+		return "", err
+	}
+
+	outputFile := filepath.Join(config.RuntimeCompilerOutputDir, fmt.Sprintf("%s-%s-%s-%s.o", baseName, unameReleaseHash, a.hash, flagHash))
 	return outputFile, nil
 }
 

--- a/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
+++ b/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
@@ -201,8 +201,8 @@ func Sha256hex(buf []byte) (string, error) {
 
 // UnameHash returns a sha256 hash of the uname release and version
 func UnameHash(uname *unix.Utsname) (string, error) {
-	bytes := make([]byte, 0, len(uname.Release)+len(uname.Version))
-	bytes = append(bytes, uname.Release[:]...)
-	bytes = append(bytes, uname.Version[:]...)
-	return Sha256hex(bytes)
+	var rv string
+	rv += unix.ByteSliceToString(uname.Release[:])
+	rv += unix.ByteSliceToString(uname.Version[:])
+	return Sha256hex([]byte(rv))
 }

--- a/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
+++ b/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
@@ -199,6 +199,7 @@ func Sha256hex(buf []byte) (string, error) {
 	return hex.EncodeToString(cCodeHash), nil
 }
 
+// UnameHash returns a sha256 hash of the uname release and version
 func UnameHash(uname *unix.Utsname) (string, error) {
 	bytes := make([]byte, 0, len(uname.Release)+len(uname.Version))
 	bytes = append(bytes, uname.Release[:]...)

--- a/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
+++ b/pkg/ebpf/bytecode/runtime/runtime_compilation_helpers.go
@@ -198,3 +198,10 @@ func Sha256hex(buf []byte) (string, error) {
 	cCodeHash := hasher.Sum(nil)
 	return hex.EncodeToString(cCodeHash), nil
 }
+
+func UnameHash(uname *unix.Utsname) (string, error) {
+	bytes := make([]byte, 0, len(uname.Release)+len(uname.Version))
+	bytes = append(bytes, uname.Release[:]...)
+	bytes = append(bytes, uname.Version[:]...)
+	return Sha256hex(bytes)
+}

--- a/pkg/security/probe/constantfetch/runtime_compiled.go
+++ b/pkg/security/probe/constantfetch/runtime_compiled.go
@@ -185,12 +185,12 @@ func (a *constantFetcherRCProvider) GetOutputFilePath(config *ebpf.Config, uname
 		return "", err
 	}
 
-	unameRHash, err := runtime.Sha256hex(uname.Release[:])
+	unameHash, err := runtime.UnameHash(uname)
 	if err != nil {
 		return "", err
 	}
 
-	return filepath.Join(config.RuntimeCompilerOutputDir, fmt.Sprintf("constant_fetcher-%s-%s-%s.o", unameRHash, cCodeHash, flagHash)), nil
+	return filepath.Join(config.RuntimeCompilerOutputDir, fmt.Sprintf("constant_fetcher-%s-%s-%s.o", unameHash, cCodeHash, flagHash)), nil
 }
 
 func sortAndDedup(in []string) []string {


### PR DESCRIPTION
### What does this PR do?

https://github.com/DataDog/datadog-agent/blob/08198a1f4ef7662f0d132fe1d776edb7eb6996b9/pkg/util/kernel/version.go#L113..L115 means that we cannot trust the `kernel.Version` to be unique across kernel versions, and thus be useful in providing a unique file name.

This PR fixes this issue by using the output of uname. Which should be unique enough.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
