### PR TITLE
[DCA] Remove noisy klog warnings

### DIFF
--- a/pkg/util/kubernetes/apiserver/warning_handler.go
+++ b/pkg/util/kubernetes/apiserver/warning_handler.go
@@ -8,16 +8,20 @@
 
 package apiserver
 
-import klog "k8s.io/klog"
+import (
+	"regexp"
 
-var supressedWarning = "v1 ComponentStatus is deprecated in v1.19+"
+	klog "k8s.io/klog"
+)
+
+var supressedWarning = regexp.MustCompile(`.*is deprecated in v.*`)
 
 type CustomWarningLogger struct{}
 
 // HandleWarningHeader suppresses some warning logs
 // TODO: Remove custom warning logger when we remove usage of ComponentStatus
 func (CustomWarningLogger) HandleWarningHeader(code int, agent string, message string) {
-	if code != 299 || len(message) == 0 || message == supressedWarning {
+	if code != 299 || len(message) == 0 || supressedWarning.MatchString(message) {
 		return
 	}
 

--- a/pkg/util/kubernetes/apiserver/warning_handler_test.go
+++ b/pkg/util/kubernetes/apiserver/warning_handler_test.go
@@ -1,0 +1,29 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+//go:build kubeapiserver
+// +build kubeapiserver
+
+package apiserver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSupressedWarningRegex(t *testing.T) {
+	fixtures := map[string]bool{
+		"v1 ComponentStatus is deprecated in v1.19+":                                                                                                  true,
+		"batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob":                                                  true,
+		"autoscaling/v2beta1 HorizontalPodAutoscaler is deprecated in v1.22+, unavailable in v1.25+; use autoscaling/v2beta2 HorizontalPodAutoscaler": true,
+		"keep me":    false,
+		"deprecated": false,
+	}
+
+	for tc, expected := range fixtures {
+		require.Equal(t, expected, supressedWarning.MatchString(tc))
+	}
+}

--- a/releasenotes-dca/notes/remove-noisy-warm-3b86fbd193cb83b4.yaml
+++ b/releasenotes-dca/notes/remove-noisy-warm-3b86fbd193cb83b4.yaml
@@ -1,0 +1,4 @@
+---
+fixes:
+  - |
+    Remove noisy Kubernetes API deprecation warnings in the Cluster Agent logs.


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Exclude the following klog warnings in the cluster agent logs

```
batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
autoscaling/v2beta1 HorizontalPodAutoscaler is deprecated in v1.22+, unavailable in v1.25+; use autoscaling/v2beta2 HorizontalPodAutoscaler
```

### Motivation

These logs are noisy and keep being logged continuously

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Related to support tickets

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Enable the KSM core check in a recent kubernetes cluster (e.g v1.21), make sure the logs mentioned above are not logged anymore by the cluster agent.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
