### PR TITLE
pkg/obfuscate: fix parsing negative numbers being mistakenly interpreted as octal

### DIFF
--- a/pkg/obfuscate/sql_test.go
+++ b/pkg/obfuscate/sql_test.go
@@ -1148,6 +1148,10 @@ LIMIT 1
 			query:    `SELECT * FROM dbo.Items WHERE id = 1 or /*!obfuscation*/ 1 = 1`,
 			expected: `SELECT * FROM dbo.Items WHERE id = ? or ? = ?`,
 		},
+		{
+			query:    `SELECT * FROM Items WHERE id = -1 OR id = -01 OR id = -108 OR id = -.018 OR id = -.08 OR id = -908129`,
+			expected: `SELECT * FROM Items WHERE id = ? OR id = ? OR id = ? OR id = ? OR id = ? OR id = ?`,
+		},
 	}
 	o := NewObfuscator(Config{})
 	for _, c := range cases {

--- a/pkg/obfuscate/sql_tokenizer.go
+++ b/pkg/obfuscate/sql_tokenizer.go
@@ -304,9 +304,17 @@ func (tkn *SQLTokenizer) Scan() (TokenKind, []byte) {
 				tkn.advance()
 				return tkn.scanCommentType1("--")
 			case isDigit(tkn.lastChar):
-				tkn.advance()
 				kind, tokenBytes := tkn.scanNumber(false)
 				return kind, append([]byte{'-'}, tokenBytes...)
+			case tkn.lastChar == '.':
+				tkn.advance()
+				if isDigit(tkn.lastChar) {
+					kind, tokenBytes := tkn.scanNumber(true)
+					return kind, append([]byte{'-', '.'}, tokenBytes...)
+				}
+				tkn.lastChar = '.'
+				tkn.pos--
+				fallthrough
 			default:
 				return TokenKind(ch), tkn.bytes()
 			}


### PR DESCRIPTION
Any number matching `-\d0\d*[89]\d*` format was misrecognized as an octal number due to the parser ignoring the first digit.

Additionally Any number `-.\d+` was not interpreted as a single number, but as distinct tokens '-' and a number. Added an additional case to handle this scenario to ensure proper normalization.

### Describe how to test/QA your changes

Added a test case covering such numbers.