### PR TITLE
[CWS] pass the kernel version directly when fetching constants

### DIFF
--- a/pkg/security/tests/constants_test.go
+++ b/pkg/security/tests/constants_test.go
@@ -38,22 +38,17 @@ func TestFallbackConstants(t *testing.T) {
 	fallbackFetcher := constantfetch.NewFallbackConstantFetcher(kv)
 	rcFetcher := constantfetch.NewRuntimeCompilationConstantFetcher(&config.Config, nil)
 
-	fallbackConstants, err := probe.GetOffsetConstantsFromFetcher(fallbackFetcher, test.probe)
+	fallbackConstants, err := probe.GetOffsetConstantsFromFetcher(fallbackFetcher, kv)
 	if err != nil {
 		t.Error(err)
 	}
 
-	rcConstants, err := probe.GetOffsetConstantsFromFetcher(rcFetcher, test.probe)
+	rcConstants, err := probe.GetOffsetConstantsFromFetcher(rcFetcher, kv)
 	if err != nil {
 		t.Error(err)
 	}
 
 	if !assert.Equal(t, fallbackConstants, rcConstants) {
-		kernelVersion, err := test.probe.GetKernelVersion()
-		if err != nil {
-			t.Error("failed to get probe kernel version")
-		} else {
-			t.Logf("kernel version: %v", kernelVersion)
-		}
+		t.Logf("kernel version: %v", kv)
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR allows to run the compilation fetching process without the need to create a probe, just providing a kernel version. This is useful to test only the llvm part for example.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
