### PR TITLE
Fix cgroups/pidMapper selection on cgroupV2

### DIFF
--- a/pkg/util/containers/v2/metrics/system/collector_network_linux.go
+++ b/pkg/util/containers/v2/metrics/system/collector_network_linux.go
@@ -103,7 +103,7 @@ func collectNetworkStats(procPath string, pid int) (*provider.ContainerNetworkSt
 	convertField(&totalPktSent, &netStats.PacketsSent)
 
 	// This requires to run as ~root, that's why it's fine to silently fail
-	if inode, err := systemutils.GetProcessNamespaceInode(procPath, pid, "net"); err == nil {
+	if inode, err := systemutils.GetProcessNamespaceInode(procPath, strconv.Itoa(pid), "net"); err == nil {
 		netStats.NetworkIsolationGroupID = &inode
 		netStats.UsingHostNetwork = systemutils.IsProcessHostNetwork(procPath, inode)
 	}

--- a/pkg/util/system/namespace_linux_test.go
+++ b/pkg/util/system/namespace_linux_test.go
@@ -28,14 +28,14 @@ func TestNamespacesInodes(t *testing.T) {
 	assert.NoError(t, os.Link(filepath.Join(fakeProc, "1", "ns", "net"), filepath.Join(fakeProc, "2", "ns", "net")))
 	assert.NoError(t, ioutil.WriteFile(filepath.Join(fakeProc, "3", "ns", "net"), []byte{}, 0o644))
 
-	pid2inode, err := GetProcessNamespaceInode(fakeProc, 2, "net")
+	pid2inode, err := GetProcessNamespaceInode(fakeProc, "2", "net")
 	assert.NoError(t, err)
 
 	pid2HostNet := IsProcessHostNetwork(fakeProc, pid2inode)
 	assert.NotNil(t, pid2HostNet)
 	assert.True(t, *pid2HostNet)
 
-	pid3inode, err := GetProcessNamespaceInode(fakeProc, 3, "net")
+	pid3inode, err := GetProcessNamespaceInode(fakeProc, "3", "net")
 	assert.NoError(t, err)
 
 	pid3HostNet := IsProcessHostNetwork(fakeProc, pid3inode)


### PR DESCRIPTION
### What does this PR do?

Fix selection of pidMapper with cgroupv2, avoid missing PIDs in reported cgroup stats (used by `process-agent` for instance).

### Motivation

Bugfix.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the Agent in Docker with `--cgroupns=host` but without host PID. Enable process collection in `process-agent`. Make sure processes are reported in containers in the live container view.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
