### PR TITLE
Handle windows log file rotation using DidRotate

### DIFF
--- a/pkg/logs/internal/tailers/file/rotate_nix.go
+++ b/pkg/logs/internal/tailers/file/rotate_nix.go
@@ -13,12 +13,13 @@ import (
 )
 
 // DidRotate returns true if the file has been log-rotated.
-// When a log rotation occurs, the file can be either:
+//
+// On *nix, when a log rotation occurs, the file can be either:
 // - renamed and recreated
 // - removed and recreated
 // - truncated
-func DidRotate(file *os.File, lastReadOffset int64) (bool, error) {
-	f, err := openFile(file.Name())
+func (t *Tailer) DidRotate() (bool, error) {
+	f, err := openFile(t.osFile.Name())
 	defer f.Close()
 	if err != nil {
 		return false, err
@@ -29,13 +30,13 @@ func DidRotate(file *os.File, lastReadOffset int64) (bool, error) {
 		return false, err
 	}
 
-	fi2, err := file.Stat()
+	fi2, err := t.osFile.Stat()
 	if err != nil {
 		return true, nil
 	}
 
 	recreated := !os.SameFile(fi1, fi2)
-	truncated := fi1.Size() < lastReadOffset
+	truncated := fi1.Size() < t.GetReadOffset()
 
 	return recreated || truncated, nil
 }

--- a/pkg/logs/internal/tailers/file/rotate_windows.go
+++ b/pkg/logs/internal/tailers/file/rotate_windows.go
@@ -8,12 +8,36 @@
 
 package file
 
-import (
-	"os"
-)
+import "github.com/DataDog/datadog-agent/pkg/util/log"
 
-// DidRotate is not implemented on windows, log rotations are handled by the
-// tailer for now.
-func DidRotate(file *os.File, lastReadOffset int64) (bool, error) {
+// DidRotate returns true if the file has been log-rotated.
+//
+// On Windows, log rotation is identified by the file size being smaller
+// than the last offset read.
+func (t *Tailer) DidRotate() (bool, error) {
+	f, err := openFile(t.fullpath)
+	if err != nil {
+		return false, err
+	}
+	defer f.Close()
+
+	st, err := f.Stat()
+	if err != nil {
+		log.Debugf("Error stat()ing file %v", err)
+		return false, err
+	}
+
+	// It is important to gather these values in this order, as both the file
+	// size and read offset may be changing concurrently.  However, the offset
+	// increases monotonically, and increments occur _after_ the file size has
+	// increased, so the check that size < offset is valid as long as size is
+	// polled before the offset.
+	sz := st.Size()
+	offset := t.GetReadOffset()
+
+	if sz < offset {
+		return true, nil
+	}
+
 	return false, nil
 }

--- a/pkg/logs/internal/tailers/file/rotate_windows.go
+++ b/pkg/logs/internal/tailers/file/rotate_windows.go
@@ -23,7 +23,7 @@ func (t *Tailer) DidRotate() (bool, error) {
 
 	st, err := f.Stat()
 	if err != nil {
-		log.Debugf("Error stat()ing file %v", err)
+		log.Debugf("Error calling stat() on file %v", err)
 		return false, err
 	}
 

--- a/pkg/logs/internal/tailers/file/tailer.go
+++ b/pkg/logs/internal/tailers/file/tailer.go
@@ -116,17 +116,6 @@ func (t *Tailer) Start(offset int64, whence int) error {
 	return nil
 }
 
-// DidRotate returns true if the tailer's file has been log-rotated.
-// When a log rotation occurs, the file can be either:
-// - renamed and recreated
-// - removed and recreated
-// - truncated
-// readForever lets the tailer tail the content of a file
-// until it is closed or the tailer is stopped.
-func (t *Tailer) DidRotate() (bool, error) {
-	return DidRotate(t.osFile, t.GetReadOffset())
-}
-
 func (t *Tailer) readForever() {
 	defer func() {
 		t.osFile.Close()

--- a/pkg/logs/internal/tailers/file/tailer_windows.go
+++ b/pkg/logs/internal/tailers/file/tailer_windows.go
@@ -43,6 +43,12 @@ func (t *Tailer) setup(offset int64, whence int) error {
 }
 
 func (t *Tailer) readAvailable() (int, error) {
+	// If the file has already rotated, there is nothing to be done. Unlike on *nix,
+	// there is no open file handle from which remaining data might be read.
+	if t.hasFileRotated() {
+		return 0, io.EOF
+	}
+
 	f, err := openFile(t.fullpath)
 	if err != nil {
 		return 0, err

--- a/pkg/logs/internal/tailers/file/tailer_windows.go
+++ b/pkg/logs/internal/tailers/file/tailer_windows.go
@@ -57,16 +57,12 @@ func (t *Tailer) readAvailable() (int, error) {
 
 	sz := st.Size()
 	offset := t.GetReadOffset()
-	if sz == 0 {
-		log.Debug("File size now zero, resetting offset")
-		t.SetReadOffset(0)
-		t.SetDecodedOffset(0)
-	} else if sz < offset {
-		log.Debug("Offset off end of file, resetting")
-		t.SetReadOffset(0)
-		t.SetDecodedOffset(0)
+	if sz < offset {
+		log.Debugf("File size of %s is shorter than last read offset; returning EOF", t.fullpath)
+		return 0, io.EOF
 	}
-	f.Seek(t.GetReadOffset(), io.SeekStart)
+
+	f.Seek(offset, io.SeekStart)
 	bytes := 0
 
 	for {


### PR DESCRIPTION
### What does this PR do?

Handle logfile rotation on Windows using the same DidRotate functionality as on UNIX.

### Motivation

Currently, logfile rotation on Windows is handled by noticing that the file has shrunk, and resetting back to the beginning of the file.  This is problematic:

 * It differs notably from how this is handled on *nix, where the launcher detects rotation and creates a new tailer.
 * It uses unsafe access to the decoded offset, in a way that could lead to corruption, lost logs, or incorrect registry entries.
 * It may lose log entries written moments before a rotation.

This PR addresses the first two points by using the same technique as used on *nix.  It adds an additional short-circuit (second commit) to skip some useless work and avoid possibly duplicated messages.

The last point is difficult or impossible to fix, without knowing where the process creating the logfile has stuck the previous data.  This PR won't try to address that.

### Describe how to test/QA your changes

Run an agent on a Windows system that is generating logs to a file (such as SQL server), and configure the agent to gather logs from it.  Cause a log rotation, and verify that the agent correctly logs messages from the new file.

Note that SQL server doesn't log to its errorlog much, but will helpfully rotate its logs on restart.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
