### PR TITLE
Use a "safe" Sender for core checks

### DIFF
--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -79,7 +79,7 @@ func (c *CheckBase) Configure(data integration.Data, initConfig integration.Data
 
 	// Set service for this check
 	if len(commonGlobalOptions.Service) > 0 {
-		s, err := aggregator.GetSender(c.checkID)
+		s, err := c.GetSender()
 		if err != nil {
 			log.Errorf("failed to retrieve a sender for check %s: %s", string(c.ID()), err)
 			return err
@@ -93,7 +93,7 @@ func (c *CheckBase) Configure(data integration.Data, initConfig integration.Data
 	}
 
 	// Add the possibly configured service as a tag for this check
-	s, err := aggregator.GetSender(c.checkID)
+	s, err := c.GetSender()
 	if err != nil {
 		log.Errorf("failed to retrieve a sender for check %s: %s", string(c.ID()), err)
 		return err
@@ -120,7 +120,7 @@ func (c *CheckBase) CommonConfigure(instance integration.Data, source string) er
 
 	// Disable default hostname if specified
 	if commonOptions.EmptyDefaultHostname {
-		s, err := aggregator.GetSender(c.checkID)
+		s, err := c.GetSender()
 		if err != nil {
 			log.Errorf("failed to retrieve a sender for check %s: %s", string(c.ID()), err)
 			return err
@@ -130,7 +130,7 @@ func (c *CheckBase) CommonConfigure(instance integration.Data, source string) er
 
 	// Set custom tags configured for this check
 	if len(commonOptions.Tags) > 0 {
-		s, err := aggregator.GetSender(c.checkID)
+		s, err := c.GetSender()
 		if err != nil {
 			log.Errorf("failed to retrieve a sender for check %s: %s", string(c.ID()), err)
 			return err
@@ -140,7 +140,7 @@ func (c *CheckBase) CommonConfigure(instance integration.Data, source string) er
 
 	// Set configured service for this check, overriding the one possibly defined globally
 	if len(commonOptions.Service) > 0 {
-		s, err := aggregator.GetSender(c.checkID)
+		s, err := c.GetSender()
 		if err != nil {
 			log.Errorf("failed to retrieve a sender for check %s: %s", string(c.ID()), err)
 			return err
@@ -233,9 +233,14 @@ func (c *CheckBase) GetWarnings() []error {
 	return w
 }
 
+// GetSender gets the object to which metrics for this check should be sent.
+func (c *CheckBase) GetSender() (aggregator.Sender, error) {
+	return aggregator.GetSender(c.ID())
+}
+
 // GetSenderStats returns the stats from the last run of the check.
 func (c *CheckBase) GetSenderStats() (check.SenderStats, error) {
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return check.SenderStats{}, fmt.Errorf("failed to retrieve a sender: %v", err)
 	}

--- a/pkg/collector/corechecks/checkbase.go
+++ b/pkg/collector/corechecks/checkbase.go
@@ -234,7 +234,22 @@ func (c *CheckBase) GetWarnings() []error {
 }
 
 // GetSender gets the object to which metrics for this check should be sent.
+//
+// This is a "safe" sender, specialized to avoid some common errors, at a very
+// small cost to performance.  Performance-sensitive checks can use GetRawSender()
+// to avoid this performance cost, as long as they are careful to avoid errors.
+//
+// See `safesender.go` for details on the managed errors.
 func (c *CheckBase) GetSender() (aggregator.Sender, error) {
+	sender, err := c.GetRawSender()
+	if err != nil {
+		return nil, err
+	}
+	return newSafeSender(sender), err
+}
+
+// GetRawSender is similar to GetSender, but does not provide the safety wrapper.
+func (c *CheckBase) GetRawSender() (aggregator.Sender, error) {
 	return aggregator.GetSender(c.ID())
 }
 

--- a/pkg/collector/corechecks/cluster/helm/helm.go
+++ b/pkg/collector/corechecks/cluster/helm/helm.go
@@ -20,7 +20,6 @@ import (
 	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -100,7 +99,7 @@ func (hc *HelmCheck) Configure(config, initConfig integration.Data, source strin
 
 // Run executes the check
 func (hc *HelmCheck) Run() error {
-	sender, err := aggregator.GetSender(hc.ID())
+	sender, err := hc.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -277,7 +277,7 @@ func (c *KSMConfig) parse(data []byte) error {
 
 // Run runs the KSM check
 func (k *KSMCheck) Run() error {
-	sender, err := aggregator.GetSender(k.ID())
+	sender, err := k.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -277,7 +277,11 @@ func (c *KSMConfig) parse(data []byte) error {
 
 // Run runs the KSM check
 func (k *KSMCheck) Run() error {
-	sender, err := k.GetSender()
+	// this check uses a "raw" sender, for better performance.  That requires
+	// careful consideration of uses of this sender.  In particular, the `tags
+	// []string` arguments must not be used after they are passed to the sender
+	// methods, as they may be mutated in-place.
+	sender, err := k.GetRawSender()
 	if err != nil {
 		return err
 	}
@@ -384,11 +388,15 @@ func (k *KSMCheck) processMetrics(sender aggregator.Sender, metrics map[string][
 	}
 }
 
-// hostnameAndTags returns the tags and the hostname for a metric based on the metric labels and the check configuration
+// hostnameAndTags returns the tags and the hostname for a metric based on the metric labels and the check configuration.
+//
+// This function must always return a "fresh" slice of tags, that will not be accessed after return.
 func (k *KSMCheck) hostnameAndTags(labels map[string]string, labelJoiner *labelJoiner, lMapperOverride map[string]string) (string, []string) {
 	hostname := ""
 
 	labelsToAdd := labelJoiner.getLabelsToAdd(labels)
+
+	// generate a dedicated tags slice
 	tags := make([]string, 0, len(labels)+len(labelsToAdd))
 
 	ownerKind, ownerName := "", ""

--- a/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
+++ b/pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@@ -137,7 +137,7 @@ func convertFilter(conf []string) string {
 
 // Run executes the check.
 func (k *KubeASCheck) Run() error {
-	sender, err := aggregator.GetSender(k.ID())
+	sender, err := k.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@@ -14,7 +14,6 @@ import (
 	"math/rand"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -146,7 +145,7 @@ func (o *OrchestratorCheck) Configure(config, initConfig integration.Data, sourc
 // Run runs the orchestrator check
 func (o *OrchestratorCheck) Run() error {
 	// access serializer
-	sender, err := aggregator.GetSender(o.ID())
+	sender, err := o.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/containerlifecycle/check.go
+++ b/pkg/collector/corechecks/containerlifecycle/check.go
@@ -11,7 +11,6 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -68,7 +67,7 @@ func (c *Check) Configure(config, initConfig integration.Data, source string) er
 		return err
 	}
 
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/containers/containerd/check.go
+++ b/pkg/collector/corechecks/containers/containerd/check.go
@@ -95,7 +95,7 @@ func (c *ContainerdCheck) Configure(config, initConfig integration.Data, source 
 
 // Run executes the check
 func (c *ContainerdCheck) Run() error {
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/containers/cri/check.go
+++ b/pkg/collector/corechecks/containers/cri/check.go
@@ -90,7 +90,7 @@ func (c *CRICheck) Configure(config, initConfig integration.Data, source string)
 
 // Run executes the check
 func (c *CRICheck) Run() error {
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/containers/docker/check.go
+++ b/pkg/collector/corechecks/containers/docker/check.go
@@ -95,7 +95,7 @@ func (d *DockerCheck) Configure(config, initConfig integration.Data, source stri
 }
 
 func (d *DockerCheck) getSender() (aggregator.Sender, error) {
-	sender, err := aggregator.GetSender(d.ID())
+	sender, err := d.GetSender()
 	if err != nil {
 		return sender, err
 	}

--- a/pkg/collector/corechecks/containers/generic/check.go
+++ b/pkg/collector/corechecks/containers/generic/check.go
@@ -10,7 +10,6 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -68,7 +67,7 @@ func (c *ContainerCheck) Configure(config, initConfig integration.Data, source s
 
 // Run executes the check
 func (c *ContainerCheck) Run() error {
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/ebpf/oom_kill.go
+++ b/pkg/collector/corechecks/ebpf/oom_kill.go
@@ -20,7 +20,6 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -98,7 +97,7 @@ func (m *OOMKillCheck) Run() error {
 	}
 
 	// sender is just what is used to submit the data
-	sender, err := aggregator.GetSender(m.ID())
+	sender, err := m.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/ebpf/tcp_queue_length.go
+++ b/pkg/collector/corechecks/ebpf/tcp_queue_length.go
@@ -15,7 +15,6 @@ package ebpf
 import (
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -93,7 +92,7 @@ func (t *TCPQueueLengthCheck) Run() error {
 		return err
 	}
 
-	sender, err := aggregator.GetSender(t.ID())
+	sender, err := t.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/net/network.go
+++ b/pkg/collector/corechecks/net/network.go
@@ -118,7 +118,7 @@ func (n defaultNetworkStats) NetstatTCPExtCounters() (map[string]int64, error) {
 
 // Run executes the check
 func (c *NetworkCheck) Run() error {
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/net/ntp.go
+++ b/pkg/collector/corechecks/net/ntp.go
@@ -16,7 +16,6 @@ import (
 	"github.com/beevik/ntp"
 	"gopkg.in/yaml.v2"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -161,7 +160,7 @@ func (c *NTPCheck) Configure(data integration.Data, initConfig integration.Data,
 
 // Run runs the check
 func (c *NTPCheck) Run() error {
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/nvidia/jetson/jetson.go
+++ b/pkg/collector/corechecks/nvidia/jetson/jetson.go
@@ -16,7 +16,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -104,7 +103,7 @@ func getSizeMultiplier(unit string) float64 {
 
 // Parses the output of tegrastats
 func (c *JetsonCheck) processTegraStatsOutput(tegraStatsOuptut string) error {
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/safesender.go
+++ b/pkg/collector/corechecks/safesender.go
@@ -1,0 +1,95 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package corechecks
+
+import (
+	"github.com/DataDog/datadog-agent/pkg/aggregator"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
+)
+
+// SafeSender implements aggregator.Sender, wrapping the methods to provide
+// some additional safety checks.
+//
+// In particular, the methods taking `tags []string` are wrapped to copy the
+// slice, as the aggregator may modify it in-place.
+type safeSender struct {
+	aggregator.Sender
+}
+
+var _ aggregator.Sender = &safeSender{}
+
+func newSafeSender(sender aggregator.Sender) aggregator.Sender {
+	return &safeSender{Sender: sender}
+}
+
+// cloneTags clones a []string of tags.
+//
+// The underlying sender methods take ownership of the []string, and might
+// modify it in-place.  If the caller is still using that tags slice, this can
+// cause corruption of tags.
+func cloneTags(tags []string) []string {
+	if tags == nil {
+		return nil
+	}
+	tagsCopy := make([]string, len(tags))
+	copy(tagsCopy, tags)
+	return tagsCopy
+}
+
+// Gauge implememnts aggregator.Sender#Gauge.
+func (ss *safeSender) Gauge(metric string, value float64, hostname string, tags []string) {
+	ss.Sender.Gauge(metric, value, hostname, cloneTags(tags))
+}
+
+// Rate implememnts aggregator.Sender#Rate.
+func (ss *safeSender) Rate(metric string, value float64, hostname string, tags []string) {
+	ss.Sender.Rate(metric, value, hostname, cloneTags(tags))
+}
+
+// Count implememnts aggregator.Sender#Count.
+func (ss *safeSender) Count(metric string, value float64, hostname string, tags []string) {
+	ss.Sender.Count(metric, value, hostname, cloneTags(tags))
+}
+
+// MonotonicCount implememnts aggregator.Sender#MonotonicCount.
+func (ss *safeSender) MonotonicCount(metric string, value float64, hostname string, tags []string) {
+	ss.Sender.MonotonicCount(metric, value, hostname, cloneTags(tags))
+}
+
+// MonotonicCountWithFlushFirstValue implememnts aggregator.Sender#MonotonicCountWithFlushFirstValue.
+func (ss *safeSender) MonotonicCountWithFlushFirstValue(metric string, value float64, hostname string, tags []string, flushFirstValue bool) {
+	ss.Sender.MonotonicCountWithFlushFirstValue(metric, value, hostname, cloneTags(tags), flushFirstValue)
+}
+
+// Counter implememnts aggregator.Sender#Counter.
+func (ss *safeSender) Counter(metric string, value float64, hostname string, tags []string) {
+	ss.Sender.Counter(metric, value, hostname, cloneTags(tags))
+}
+
+// Histogram implememnts aggregator.Sender#Histogram.
+func (ss *safeSender) Histogram(metric string, value float64, hostname string, tags []string) {
+	ss.Sender.Histogram(metric, value, hostname, cloneTags(tags))
+}
+
+// Historate implememnts aggregator.Sender#Historate.
+func (ss *safeSender) Historate(metric string, value float64, hostname string, tags []string) {
+	ss.Sender.Historate(metric, value, hostname, cloneTags(tags))
+}
+
+// ServiceCheck implememnts aggregator.Sender#ServiceCheck.
+func (ss *safeSender) ServiceCheck(checkName string, status metrics.ServiceCheckStatus, hostname string, tags []string, message string) {
+	ss.Sender.ServiceCheck(checkName, status, hostname, cloneTags(tags), message)
+}
+
+// HistogramBucket implememnts aggregator.Sender#HistogramBucket.
+func (ss *safeSender) HistogramBucket(metric string, value int64, lowerBound, upperBound float64, monotonic bool, hostname string, tags []string, flushFirstValue bool) {
+	ss.Sender.HistogramBucket(metric, value, lowerBound, upperBound, monotonic, hostname, cloneTags(tags), flushFirstValue)
+}
+
+// SetCheckCustomTags implememnts aggregator.Sender#SetCheckCustomTags.
+func (ss *safeSender) SetCheckCustomTags(tags []string) {
+	ss.Sender.SetCheckCustomTags(cloneTags(tags))
+}

--- a/pkg/collector/corechecks/safesender_test.go
+++ b/pkg/collector/corechecks/safesender_test.go
@@ -1,0 +1,27 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package corechecks
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCloneTags(t *testing.T) {
+	t.Run("tags", func(t *testing.T) {
+		tags := []string{"tag1", "tag2"}
+		cloned := cloneTags(tags)
+		tags[0] = "uh-oh"
+		tags[1] = "oh no"
+		require.Equal(t, []string{"tag1", "tag2"}, cloned)
+	})
+
+	t.Run("nil", func(t *testing.T) {
+		cloned := cloneTags(nil)
+		require.Nil(t, cloned)
+	})
+}

--- a/pkg/collector/corechecks/snmp/snmp.go
+++ b/pkg/collector/corechecks/snmp/snmp.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -38,7 +37,7 @@ type Check struct {
 // Run executes the check
 func (c *Check) Run() error {
 	var checkErr error
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/cpu/cpu.go
+++ b/pkg/collector/corechecks/system/cpu/cpu.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/shirou/gopsutil/cpu"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -35,7 +34,7 @@ type Check struct {
 
 // Run executes the check
 func (c *Check) Run() error {
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/cpu/cpu_windows.go
+++ b/pkg/collector/corechecks/system/cpu/cpu_windows.go
@@ -23,8 +23,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
 	"github.com/DataDog/gohai/cpu"
 	"golang.org/x/sys/windows"
-
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 )
 
 var (
@@ -50,7 +48,7 @@ type Check struct {
 
 // Run executes the check
 func (c *Check) Run() error {
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/cpu/load.go
+++ b/pkg/collector/corechecks/system/cpu/load.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/shirou/gopsutil/load"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -32,7 +31,7 @@ type LoadCheck struct {
 
 // Run executes the check
 func (c *LoadCheck) Run() error {
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/disk/disk_nix.go
+++ b/pkg/collector/corechecks/system/disk/disk_nix.go
@@ -34,7 +34,7 @@ type Check struct {
 
 // Run executes the check
 func (c *Check) Run() error {
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/disk/iostats_nix.go
+++ b/pkg/collector/corechecks/system/disk/iostats_nix.go
@@ -14,7 +14,6 @@ import (
 	"regexp"
 	"time"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -71,7 +70,7 @@ func incrementWithOverflow(currentValue, lastValue uint64) int64 {
 }
 
 func (c *IOCheck) nixIO() error {
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}
@@ -192,7 +191,7 @@ func (c *IOCheck) nixIO() error {
 
 // Run executes the check
 func (c *IOCheck) Run() error {
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/disk/iostats_pdh_windows.go
+++ b/pkg/collector/corechecks/system/disk/iostats_pdh_windows.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
@@ -102,7 +101,7 @@ func (c *IOCheck) Configure(data integration.Data, initConfig integration.Data, 
 
 // Run executes the check
 func (c *IOCheck) Run() error {
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/filehandles/file_handles.go
+++ b/pkg/collector/corechecks/system/filehandles/file_handles.go
@@ -13,7 +13,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -53,7 +52,7 @@ func (c *fhCheck) Run() error {
 		return err
 	}
 
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/filehandles/file_handles_freebsd.go
+++ b/pkg/collector/corechecks/system/filehandles/file_handles_freebsd.go
@@ -8,7 +8,6 @@
 package filehandles
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -28,7 +27,7 @@ type fhCheck struct {
 // Run executes the check
 func (c *fhCheck) Run() error {
 
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/filehandles/file_handles_windows.go
+++ b/pkg/collector/corechecks/system/filehandles/file_handles_windows.go
@@ -13,8 +13,6 @@ import (
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
-
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 )
 
 const fileHandlesCheckName = "file_handle"
@@ -27,7 +25,7 @@ type fhCheck struct {
 // Run executes the check
 func (c *fhCheck) Run() error {
 
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/memory/memory_nix.go
+++ b/pkg/collector/corechecks/system/memory/memory_nix.go
@@ -15,7 +15,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/shirou/gopsutil/mem"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 )
 
@@ -33,7 +32,7 @@ const mbSize float64 = 1024 * 1024
 
 // Run executes the check
 func (c *Check) Run() error {
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}
@@ -83,7 +82,7 @@ func (c *Check) Run() error {
 }
 
 func (c *Check) linuxSpecificVirtualMemoryCheck(v *mem.VirtualMemoryStat) error {
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}
@@ -101,7 +100,7 @@ func (c *Check) linuxSpecificVirtualMemoryCheck(v *mem.VirtualMemoryStat) error 
 }
 
 func (c *Check) freebsdSpecificVirtualMemoryCheck(v *mem.VirtualMemoryStat) error {
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/memory/memory_windows.go
+++ b/pkg/collector/corechecks/system/memory/memory_windows.go
@@ -17,8 +17,6 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil"
 	"github.com/DataDog/datadog-agent/pkg/util/winutil/pdhutil"
-
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 )
 
 // For testing purpose
@@ -59,7 +57,7 @@ func (c *Check) Configure(data integration.Data, initConfig integration.Data, so
 
 // Run executes the check
 func (c *Check) Run() error {
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/uptime/uptime.go
+++ b/pkg/collector/corechecks/system/uptime/uptime.go
@@ -6,7 +6,6 @@
 package uptime
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
@@ -21,7 +20,7 @@ type Check struct {
 
 // Run executes the check
 func (c *Check) Run() error {
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/winkmem/winkmem.go
+++ b/pkg/collector/corechecks/system/winkmem/winkmem.go
@@ -15,7 +15,6 @@ import (
 
 	yaml "gopkg.in/yaml.v2"
 
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -112,7 +111,7 @@ func (w *KMemCheck) Configure(data integration.Data, initConfig integration.Data
 
 // Run executes the check
 func (w *KMemCheck) Run() error {
-	sender, err := aggregator.GetSender(w.ID())
+	sender, err := w.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/system/winproc/winproc_windows.go
+++ b/pkg/collector/corechecks/system/winproc/winproc_windows.go
@@ -8,7 +8,6 @@
 package winproc
 
 import (
-	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	"github.com/DataDog/datadog-agent/pkg/autodiscovery/integration"
 	"github.com/DataDog/datadog-agent/pkg/collector/check"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
@@ -25,7 +24,7 @@ type processChk struct {
 
 // Run executes the check
 func (c *processChk) Run() error {
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}

--- a/pkg/collector/corechecks/systemd/systemd.go
+++ b/pkg/collector/corechecks/systemd/systemd.go
@@ -208,7 +208,7 @@ func (s *defaultSystemdStats) UnixNow() int64 {
 
 // Run executes the check
 func (c *SystemdCheck) Run() error {
-	sender, err := aggregator.GetSender(c.ID())
+	sender, err := c.GetSender()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
### What does this PR do?

Replaces the `aggregator.Sender` used in corechecks with one that automatically clones all tags slices before passing them to the aggreator.

### Motivation

The aggregator takes ownership of the tags slices passed to it, and may modify them in-place.  This has caused issues in the past (e.g., #7159).  It's hard to spot, too.  For example, a trivial-looking modification to a check may result in re-use of a tags slice, e.g.,

```patch
-    s.Gauge("some_metric", metric.Val, hostname, tags)
+    s.Gauge("some_metric.v1", metric.Val, hostname, tags)
+    s.Gauge("some_metric.v2", metric.ValV2, hostname, tags)
```

### Possible Drawbacks / Trade-offs

Copying tags is, naturally, slower.  And it is unnecessary in cases where tags were already handled safely (a new slice created and handed to the sender).  However, to my knowledge none of these checks are so performance-sensitive as to be harmed by that slowness.  And, as shown above, it's easy for a "safe" use of tags to become "unsafe" without being obvious in review.  So I think the cost is worth it for safety.

However, if there are specific high-volume checks that need to skip this clone operation, that's easy -- just call `c.GetRawSender()` instead of `c.GetSender()`.  Please let me know if that applies to any core checks.

### Describe how to test/QA your changes

This PR is written such that it should be easy to verify in review that there are no behavioral changes.  So, please give that a second thought now :)

After that, it's wise to verify that each core check is still producing correct-looking data after this change.  I believe that falls to a number of teams, which I've listed in the team/* labels.  Codeowners suggests:
```
@DataDog/agent-core: pkg/collector/corechecks/checkbase.go
@DataDog/agent-core: pkg/collector/corechecks/containerlifecycle/check.go
@DataDog/agent-integrations: pkg/collector/corechecks/systemd/systemd.go
@DataDog/agent-platform: pkg/collector/corechecks/net/network.go
@DataDog/agent-platform: pkg/collector/corechecks/net/ntp.go
@DataDog/agent-platform: pkg/collector/corechecks/nvidia/jetson/jetson.go
@DataDog/agent-platform: pkg/collector/corechecks/system/cpu/cpu.go
@DataDog/agent-platform: pkg/collector/corechecks/system/cpu/cpu_windows.go
@DataDog/agent-platform: pkg/collector/corechecks/system/cpu/load.go
@DataDog/agent-platform: pkg/collector/corechecks/system/disk/disk_nix.go
@DataDog/agent-platform: pkg/collector/corechecks/system/disk/iostats_nix.go
@DataDog/agent-platform: pkg/collector/corechecks/system/disk/iostats_pdh_windows.go
@DataDog/agent-platform: pkg/collector/corechecks/system/filehandles/file_handles_freebsd.go
@DataDog/agent-platform: pkg/collector/corechecks/system/filehandles/file_handles.go
@DataDog/agent-platform: pkg/collector/corechecks/system/filehandles/file_handles_windows.go
@DataDog/agent-platform: pkg/collector/corechecks/system/memory/memory_nix.go
@DataDog/agent-platform: pkg/collector/corechecks/system/memory/memory_windows.go
@DataDog/agent-platform: pkg/collector/corechecks/system/uptime/uptime.go
@DataDog/agent-platform: pkg/collector/corechecks/system/winkmem/winkmem.go
@DataDog/agent-platform: pkg/collector/corechecks/system/winproc/winproc_windows.go
@DataDog/container-integrations: pkg/collector/corechecks/cluster/helm/helm.go
@DataDog/container-integrations: pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@DataDog/container-integrations: pkg/collector/corechecks/cluster/kubernetesapiserver/kubernetes_apiserver.go
@DataDog/container-integrations: pkg/collector/corechecks/cluster/orchestrator/orchestrator.go
@DataDog/container-integrations: pkg/collector/corechecks/containers/containerd/check.go
@DataDog/container-integrations: pkg/collector/corechecks/containers/cri/check.go
@DataDog/container-integrations: pkg/collector/corechecks/containers/docker/check.go
@DataDog/container-integrations: pkg/collector/corechecks/containers/generic/check.go
@DataDog/container-integrations: pkg/collector/corechecks/ebpf/oom_kill.go
@DataDog/container-integrations: pkg/collector/corechecks/ebpf/tcp_queue_length.go
@DataDog/infrastructure-integrations: pkg/collector/corechecks/snmp/snmp.go
```

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.

Fixes #7159.