### PR TITLE
KSM core: add a `kubernetes_state.cronjob.complete` service check

### DIFF
--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.go
@@ -691,7 +691,7 @@ func ownerTags(kind, name string) []string {
 	tags := []string{fmt.Sprintf(tagFormat, tagKey, name)}
 	switch kind {
 	case kubernetes.JobKind:
-		if cronjob := kubernetes.ParseCronJobForJob(name); cronjob != "" {
+		if cronjob, _ := kubernetes.ParseCronJobForJob(name); cronjob != "" {
 			return append(tags, fmt.Sprintf(tagFormat, kubernetes.CronJobTagName, cronjob))
 		}
 	case kubernetes.ReplicaSetKind:

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state.md
@@ -364,6 +364,9 @@ The Kubernetes State Metrics Core check does not include any events.
 
 ### Service Checks
 
+`kubernetes_state.cronjob.complete`
+: Whether the last job of the cronjob is failed or not. Tags:`kube_cronjob` `kube_namespace` (`env` `service` `version` from standard labels).
+
 `kubernetes_state.cronjob.on_schedule_check`
 : Alert if the cronjob's next schedule is in the past. Tags:`kube_cronjob` `kube_namespace` (`env` `service` `version` from standard labels).
 

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
@@ -9,12 +9,10 @@
 package ksm
 
 import (
-	"strconv"
-	"strings"
-
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
 	ksmstore "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/store"
 	"github.com/DataDog/datadog-agent/pkg/metrics"
+	"github.com/DataDog/datadog-agent/pkg/util/kubernetes"
 	"github.com/DataDog/datadog-agent/pkg/util/log"
 )
 
@@ -164,15 +162,9 @@ func (a *lastCronJobAggregator) accumulate(metric ksmstore.DDMetric, state metri
 		return
 	}
 
-	dashPosition := strings.LastIndexByte(jobName, '-')
-	if dashPosition == -1 {
-		return
-	}
-
-	cronjobName := jobName[:dashPosition]
-	cronjobID := jobName[dashPosition+1:]
-	id, err := strconv.Atoi(cronjobID)
-	if err != nil {
+	cronjobName, id := kubernetes.ParseCronJobForJob(jobName)
+	if cronjobName == "" {
+		log.Debug("%s isn't a valid CronJbo name", jobName)
 		return
 	}
 

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators.go
@@ -164,7 +164,7 @@ func (a *lastCronJobAggregator) accumulate(metric ksmstore.DDMetric, state metri
 
 	cronjobName, id := kubernetes.ParseCronJobForJob(jobName)
 	if cronjobName == "" {
-		log.Debug("%s isn't a valid CronJbo name", jobName)
+		log.Debugf("%q isn't a valid CronJob name", jobName)
 		return
 	}
 

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators_test.go
@@ -14,10 +14,13 @@ import (
 	"github.com/DataDog/datadog-agent/pkg/aggregator/mocksender"
 	core "github.com/DataDog/datadog-agent/pkg/collector/corechecks"
 	ksmstore "github.com/DataDog/datadog-agent/pkg/kubestatemetrics/store"
+	"github.com/DataDog/datadog-agent/pkg/metrics"
 )
 
 var _ metricAggregator = &sumValuesAggregator{}
 var _ metricAggregator = &countObjectsAggregator{}
+var _ metricAggregator = &lastCronJobCompleteAggregator{}
+var _ metricAggregator = &lastCronJobFailedAggregator{}
 
 func Test_counterAggregator(t *testing.T) {
 	tests := []struct {
@@ -187,6 +190,128 @@ func Test_counterAggregator(t *testing.T) {
 			for _, expected := range tt.expected {
 				s.AssertMetric(t, "Gauge", expected.name, expected.val, expected.hostname, expected.tags)
 			}
+		})
+	}
+}
+
+func Test_lastCronJobAggregator(t *testing.T) {
+	tests := []struct {
+		name            string
+		metricsComplete []ksmstore.DDMetric
+		metricsFailed   []ksmstore.DDMetric
+		expected        *serviceCheck
+	}{
+		{
+			name: "Last job succeeded",
+			metricsComplete: []ksmstore.DDMetric{
+				{
+					Labels: map[string]string{
+						"namespace": "foo",
+						"job_name":  "bar-12",
+						"condition": "true",
+					},
+					Val: 1,
+				},
+				{
+					Labels: map[string]string{
+						"namespace": "foo",
+						"job_name":  "bar-14",
+						"condition": "true",
+					},
+					Val: 1,
+				},
+			},
+			metricsFailed: []ksmstore.DDMetric{
+				{
+					Labels: map[string]string{
+						"namespace": "foo",
+						"job_name":  "bar-13",
+						"condition": "true",
+					},
+					Val: 1,
+				},
+			},
+			expected: &serviceCheck{
+				name:    "kubernetes_state.cronjob.complete",
+				status:  metrics.ServiceCheckOK,
+				tags:    []string{"namespace:foo", "kube_cronjob:bar"},
+				message: "",
+			},
+		},
+		{
+			name: "Last job failed",
+			metricsFailed: []ksmstore.DDMetric{
+				{
+					Labels: map[string]string{
+						"namespace": "foo",
+						"job_name":  "bar-12",
+						"condition": "true",
+					},
+					Val: 1,
+				},
+				{
+					Labels: map[string]string{
+						"namespace": "foo",
+						"job_name":  "bar-14",
+						"condition": "true",
+					},
+					Val: 1,
+				},
+			},
+			metricsComplete: []ksmstore.DDMetric{
+				{
+					Labels: map[string]string{
+						"namespace": "foo",
+						"job_name":  "bar-13",
+						"condition": "true",
+					},
+					Val: 1,
+				},
+			},
+			expected: &serviceCheck{
+				name:    "kubernetes_state.cronjob.complete",
+				status:  metrics.ServiceCheckCritical,
+				tags:    []string{"namespace:foo", "kube_cronjob:bar"},
+				message: "",
+			},
+		},
+	}
+
+	ksmCheck := newKSMCheck(core.NewCheckBase(kubeStateMetricsCheckName), &KSMConfig{})
+
+	for _, tt := range tests {
+		s := mocksender.NewMockSender("ksm")
+		s.SetupAcceptAll()
+
+		t.Run(tt.name, func(t *testing.T) {
+			agg := newLastCronJobAggregator()
+			aggComplete := &lastCronJobCompleteAggregator{aggregator: agg}
+			aggFailed := &lastCronJobFailedAggregator{aggregator: agg}
+
+			for _, metric := range tt.metricsComplete {
+				aggComplete.accumulate(metric)
+			}
+			for _, metric := range tt.metricsFailed {
+				aggFailed.accumulate(metric)
+			}
+
+			agg.flush(s, ksmCheck, newLabelJoiner(ksmCheck.instance.LabelJoins))
+
+			s.AssertServiceCheck(t, tt.expected.name, tt.expected.status, "", tt.expected.tags, tt.expected.message)
+			s.AssertNumberOfCalls(t, "ServiceCheck", 1)
+
+			// Ingest the metrics in the other order
+			for _, metric := range tt.metricsFailed {
+				aggFailed.accumulate(metric)
+			}
+			for _, metric := range tt.metricsComplete {
+				aggComplete.accumulate(metric)
+			}
+
+			agg.flush(s, ksmCheck, newLabelJoiner(ksmCheck.instance.LabelJoins))
+
+			s.AssertServiceCheck(t, tt.expected.name, tt.expected.status, "", tt.expected.tags, tt.expected.message)
+			s.AssertNumberOfCalls(t, "ServiceCheck", 2)
 		})
 	}
 }

--- a/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators_test.go
+++ b/pkg/collector/corechecks/cluster/ksm/kubernetes_state_aggregators_test.go
@@ -207,7 +207,7 @@ func Test_lastCronJobAggregator(t *testing.T) {
 				{
 					Labels: map[string]string{
 						"namespace": "foo",
-						"job_name":  "bar-12",
+						"job_name":  "bar-112",
 						"condition": "true",
 					},
 					Val: 1,
@@ -215,7 +215,7 @@ func Test_lastCronJobAggregator(t *testing.T) {
 				{
 					Labels: map[string]string{
 						"namespace": "foo",
-						"job_name":  "bar-14",
+						"job_name":  "bar-114",
 						"condition": "true",
 					},
 					Val: 1,
@@ -225,7 +225,7 @@ func Test_lastCronJobAggregator(t *testing.T) {
 				{
 					Labels: map[string]string{
 						"namespace": "foo",
-						"job_name":  "bar-13",
+						"job_name":  "bar-113",
 						"condition": "true",
 					},
 					Val: 1,
@@ -244,7 +244,7 @@ func Test_lastCronJobAggregator(t *testing.T) {
 				{
 					Labels: map[string]string{
 						"namespace": "foo",
-						"job_name":  "bar-12",
+						"job_name":  "bar-112",
 						"condition": "true",
 					},
 					Val: 1,
@@ -252,7 +252,7 @@ func Test_lastCronJobAggregator(t *testing.T) {
 				{
 					Labels: map[string]string{
 						"namespace": "foo",
-						"job_name":  "bar-14",
+						"job_name":  "bar-114",
 						"condition": "true",
 					},
 					Val: 1,
@@ -262,7 +262,7 @@ func Test_lastCronJobAggregator(t *testing.T) {
 				{
 					Labels: map[string]string{
 						"namespace": "foo",
-						"job_name":  "bar-13",
+						"job_name":  "bar-113",
 						"condition": "true",
 					},
 					Val: 1,

--- a/pkg/tagger/collectors/workloadmeta_extract.go
+++ b/pkg/tagger/collectors/workloadmeta_extract.go
@@ -443,7 +443,7 @@ func (c *WorkloadMetaCollector) extractTagsFromPodOwner(pod *workloadmeta.Kubern
 		}
 
 	case kubernetes.JobKind:
-		cronjob := kubernetes.ParseCronJobForJob(owner.Name)
+		cronjob, _ := kubernetes.ParseCronJobForJob(owner.Name)
 		if cronjob != "" {
 			tags.AddOrchestrator(kubernetes.JobTagName, owner.Name)
 			tags.AddLow(kubernetes.CronJobTagName, cronjob)

--- a/pkg/util/kubernetes/helpers_test.go
+++ b/pkg/util/kubernetes/helpers_test.go
@@ -41,19 +41,26 @@ func TestParseDeploymentForReplicaSet(t *testing.T) {
 }
 
 func TestParseCronJobForJob(t *testing.T) {
-	for in, out := range map[string]string{
-		"hello-1562319360": "hello",
-		"hello-600":        "hello",
-		"hello-world":      "",
-		"hello":            "",
-		"-hello1562319360": "",
-		"hello1562319360":  "",
-		"hello60":          "",
-		"hello-60":         "",
-		"hello-1562319a60": "",
+	for in, out := range map[string]struct {
+		string
+		int
+	}{
+		"hello-1562319360": {"hello", 1562319360},
+		"hello-600":        {"hello", 600},
+		"hello-world":      {"", 0},
+		"hello":            {"", 0},
+		"-hello1562319360": {"", 0},
+		"hello1562319360":  {"", 0},
+		"hello60":          {"", 0},
+		"hello-60":         {"", 0},
+		"hello-1562319a60": {"", 0},
 	} {
 		t.Run(fmt.Sprintf("case: %s", in), func(t *testing.T) {
-			assert.Equal(t, out, ParseCronJobForJob(in))
+			cronjobName, id := ParseCronJobForJob(in)
+			assert.Equal(t, out, struct {
+				string
+				int
+			}{cronjobName, id})
 		})
 	}
 }

--- a/releasenotes-dca/notes/ksm_cronjob_complete-dc5ca0eb0a047e1b.yaml
+++ b/releasenotes-dca/notes/ksm_cronjob_complete-dc5ca0eb0a047e1b.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    KSM core check: add a new ``kubernetes_state.cronjob.complete``
+    service check that returns the status of the most recent job for
+    a cronjob.

--- a/releasenotes/notes/ksm_cronjob_complete-dc5ca0eb0a047e1b.yaml
+++ b/releasenotes/notes/ksm_cronjob_complete-dc5ca0eb0a047e1b.yaml
@@ -1,0 +1,13 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    KSM core check: add a new ``kubernetes_state.cronjob.complete``
+    service check that returns the status of the most recent job for
+    a cronjob.


### PR DESCRIPTION
### What does this PR do?

Add a new service check in the KSM core check: `kubernetes_state.cronjob.complete` which returns the status of the latest job created by a cronjob.

### Motivation

The KSM core check already exposes a `kubernetes_state.job.complete` service check per job and there is a `kube_cronjob` tag attached to it to know which cronjob this job is belonging to.
But jobs are not immediately deleted after their completion so that for a given cronjob, there are multiple failed and completed jobs that are kept for a while.
Although the current `kubernetes_state.job.complete` service check can be used to know the state of every individual job, it can be valuable to know what is the status of the lastest job of a cronjob.
This wasn’t easy to get with the current service check.
See https://github.com/DataDog/integrations-core/pull/9226#issuecomment-878299670 for another description of this issue.

### Additional Notes

* Supersedes DataDog/integrations-core#9226
* Corresponding doc update: DataDog/documentation#13484
* Corresponding `integration-core` update: DataDog/integrations-core#11728

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Create a cronjob on a kubernetes cluster.
Validate that `kubernetes_state.cronjob.complete` reflects the state of the latest job of the cronjob.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
