### PR TITLE
Fix regexp used to perform matching of containerID in cgroup paths

### DIFF
--- a/pkg/util/cgroups/reader.go
+++ b/pkg/util/cgroups/reader.go
@@ -46,7 +46,9 @@ func DefaultFilter(path, name string) (string, error) {
 }
 
 // ContainerRegexp defines the regexp used to match container ids
-var ContainerRegexp = regexp.MustCompile("([0-9a-f]{64}|[0-9a-f]{8}(-[0-9a-f]{4}){4})")
+// First part is usual containerid (opencontainers standard)
+// Second part is PCF/Garden regexp. We currently assume no suffix ($) to avoid matching pod UIDs
+var ContainerRegexp = regexp.MustCompile("([0-9a-f]{64})|([0-9a-f]{8}(-[0-9a-f]{4}){4}$)")
 
 // ContainerFilter returns a filter that will match cgroup folders containing a container id
 func ContainerFilter(path, name string) (string, error) {

--- a/pkg/util/cgroups/readerv1_test.go
+++ b/pkg/util/cgroups/readerv1_test.go
@@ -26,6 +26,10 @@ func TestReaderV1(t *testing.T) {
 		"kubepods.slice/kubepods-burstable.slice/kubepods-burstable-podc704ef4c297ab11032b83ce52cbfc87b.slice/cri-containerd-2327a2aec169e25cf05f2a901486b7463fdb513ae097fc0ae6a3ca94381ddc42.scope",
 		"libpod_parent/libpod-6dc3fdffbf66b1239d55e98da9aaa759ea51ed35d04eb09d19ebd78963aa26c2/system.slice/var-lib-docker-containers-1575e8b4a92a9c340a657f3df4ddc0f6a6305c200879f3898b26368ad019b503-mounts-shm.mount",
 		"libpod_parent/libpod-6dc3fdffbf66b1239d55e98da9aaa759ea51ed35d04eb09d19ebd78963aa26c2/kubepods.slice/kubepods-burstable.slice/kubepods-burstable-poda2acd1bccd50fd7790183537181f658e.slice/docker-1575e8b4a92a9c340a657f3df4ddc0f6a6305c200879f3898b26368ad019b503.scope",
+		"kubepods/pod821ad831-6a9a-4970-b623-8cb43cd3462d/f246d96ff6bd76f65c4a687ce17812a8189b735fd6ed643165db2c61e19bc31e",
+		// PCF/Garden
+		"system.slice/garden.service/garden/016b5740-120b-42b7-562f-3c62",
+		"system.slice/garden.service/garden/c034152c-80b0-4a44-70df-5c61-liveness-healthcheck-0",
 	}
 
 	for _, p := range paths {
@@ -50,5 +54,7 @@ func TestReaderV1(t *testing.T) {
 		"2327a2aec169e25cf05f2a901486b7463fdb513ae097fc0ae6a3ca94381ddc42": newCgroupV1("2327a2aec169e25cf05f2a901486b7463fdb513ae097fc0ae6a3ca94381ddc42", paths[3], fakeMountPoints, r.pidMapper),
 		"1575e8b4a92a9c340a657f3df4ddc0f6a6305c200879f3898b26368ad019b503": newCgroupV1("1575e8b4a92a9c340a657f3df4ddc0f6a6305c200879f3898b26368ad019b503", paths[5], fakeMountPoints, r.pidMapper),
 		"6dc3fdffbf66b1239d55e98da9aaa759ea51ed35d04eb09d19ebd78963aa26c2": newCgroupV1("6dc3fdffbf66b1239d55e98da9aaa759ea51ed35d04eb09d19ebd78963aa26c2", "libpod_parent/libpod-6dc3fdffbf66b1239d55e98da9aaa759ea51ed35d04eb09d19ebd78963aa26c2", fakeMountPoints, r.pidMapper),
+		"f246d96ff6bd76f65c4a687ce17812a8189b735fd6ed643165db2c61e19bc31e": newCgroupV1("f246d96ff6bd76f65c4a687ce17812a8189b735fd6ed643165db2c61e19bc31e", paths[6], fakeMountPoints, r.pidMapper),
+		"016b5740-120b-42b7-562f-3c62":                                     newCgroupV1("016b5740-120b-42b7-562f-3c62", paths[7], fakeMountPoints, r.pidMapper),
 	}, cgroups, cmp.AllowUnexported(cgroupV1{})))
 }


### PR DESCRIPTION
### What does this PR do?

In certain circumstances, a POD UID in a cgroup path could be matched by the PCF/Garden part of the container id regexp.

### Motivation

Bugfix.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the Agent on `kind` with internal manifest `dogstatsd-entityid`. Verify that UDS origin detection works. Orchestrator tags must be present in produced metrics.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] The appropriate `team/..` label has been applied, if known.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
