### PR TITLE
Make the DEB package datadog-signing-keys a hard dependency

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -53,7 +53,7 @@ else
   end
 
   if debian?
-    runtime_recommended_dependency 'datadog-signing-keys'
+    runtime_dependency 'datadog-signing-keys'
   end
 
   if osx?

--- a/omnibus/config/projects/dogstatsd.rb
+++ b/omnibus/config/projects/dogstatsd.rb
@@ -44,7 +44,7 @@ else
   end
 
   if debian?
-    runtime_recommended_dependency 'datadog-signing-keys'
+    runtime_dependency 'datadog-signing-keys'
   end
 end
 

--- a/omnibus/config/projects/iot-agent.rb
+++ b/omnibus/config/projects/iot-agent.rb
@@ -46,7 +46,7 @@ else
   end
 
   if debian?
-    runtime_recommended_dependency 'datadog-signing-keys'
+    runtime_dependency 'datadog-signing-keys'
   end
 end
 

--- a/releasenotes/notes/signing-keys-deb-strong-dep-fd8d8e605d88d9d9.yaml
+++ b/releasenotes/notes/signing-keys-deb-strong-dep-fd8d8e605d88d9d9.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    The DEB package now depends on the datadog-signing-keys package. This package contains the latest signing keys used to sign the packages and repo metadata.


### PR DESCRIPTION
### What does this PR do?

We added this package as a "soft" (recommended) dependency, but on some
setups this might not be enough to make sure the package is installed. For
example: if the `datadog-agent` package is not installed from our repos, the
missing `datadog-signing-keys` package won't make the installation fail.

This makes the `datadog-signing-keys` package a regular (hard) dependency,
so it has to be installed when the `datadog-agent` package is.

### Motivation

Since 7.35 will be the last agent package we release before the key
rotation, we should include this change in 7.35 to make sure more people
install the `datadog-signing-keys` package.
