### PR TITLE
[corechecks/helm] Keep deployed releases in memory

### DIFF
--- a/pkg/collector/corechecks/cluster/helm/helm.go
+++ b/pkg/collector/corechecks/cluster/helm/helm.go
@@ -12,10 +12,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
-	"k8s.io/apimachinery/pkg/labels"
-	"k8s.io/client-go/listers/core/v1"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/tools/cache"
 
 	"github.com/DataDog/datadog-agent/pkg/aggregator"
@@ -52,18 +54,23 @@ const (
 // https://helm.sh/docs/faq/changes_since_helm2/#secrets-as-the-default-storage-driver
 type HelmCheck struct {
 	core.CheckBase
-	secretLister      v1.SecretLister
-	configmapLister   v1.ConfigMapLister
+	releases          map[helmStorage]map[string]*release
+	releasesMut       sync.Mutex
 	runLeaderElection bool
 }
 
-var helmSelector = labels.Set{"owner": "helm"}.AsSelector()
-
 func factory() check.Check {
-	return &HelmCheck{
+	helmCheck := &HelmCheck{
 		CheckBase:         core.NewCheckBase(checkName),
+		releases:          make(map[helmStorage]map[string]*release),
 		runLeaderElection: !config.IsCLCRunner(),
 	}
+
+	for _, storageDriver := range []helmStorage{k8sConfigmaps, k8sSecrets} {
+		helmCheck.releases[storageDriver] = make(map[string]*release)
+	}
+
+	return helmCheck
 }
 
 // Configure configures the Helm check
@@ -88,24 +95,7 @@ func (hc *HelmCheck) Configure(config, initConfig integration.Data, source strin
 		return err
 	}
 
-	stopCh := make(chan struct{})
-	apiClient.InformerFactory.Start(stopCh)
-
-	secretInformer := apiClient.InformerFactory.Core().V1().Secrets()
-	hc.secretLister = secretInformer.Lister()
-	go secretInformer.Informer().Run(stopCh)
-
-	configmapInformer := apiClient.InformerFactory.Core().V1().ConfigMaps()
-	hc.configmapLister = configmapInformer.Lister()
-	go configmapInformer.Informer().Run(stopCh)
-
-	return apiserver.SyncInformers(
-		map[apiserver.InformerName]cache.SharedInformer{
-			"helm-secrets":    secretInformer.Informer(),
-			"helm-configmaps": configmapInformer.Informer(),
-		},
-		informerSyncTimeout,
-	)
+	return hc.setupInformers(apiClient.InformerFactory)
 }
 
 // Run executes the check
@@ -128,25 +118,44 @@ func (hc *HelmCheck) Run() error {
 		}
 	}
 
-	releasesInSecrets, err := hc.releasesFromSecrets()
-	if err != nil {
-		return fmt.Errorf("error while getting Helm releases from secrets: %s", err)
-	}
+	hc.releasesMut.Lock()
+	defer hc.releasesMut.Unlock()
 
-	for _, releaseInSecret := range releasesInSecrets {
-		sender.Gauge("helm.release", 1, "", helmTags(releaseInSecret, k8sSecrets))
-	}
-
-	releasesInConfigMaps, err := hc.releasesFromConfigMaps()
-	if err != nil {
-		return fmt.Errorf("error while getting Helm releases from configmaps: %s", err)
-	}
-
-	for _, releaseInConfigMap := range releasesInConfigMaps {
-		sender.Gauge("helm.release", 1, "", helmTags(releaseInConfigMap, k8sConfigmaps))
+	for _, storageDriver := range []helmStorage{k8sConfigmaps, k8sSecrets} {
+		for _, rel := range hc.releases[storageDriver] {
+			sender.Gauge("helm.release", 1, "", helmTags(rel, storageDriver))
+		}
 	}
 
 	return nil
+}
+
+func (hc *HelmCheck) setupInformers(sharedInformerFactory informers.SharedInformerFactory) error {
+	stopCh := make(chan struct{})
+
+	secretInformer := sharedInformerFactory.Core().V1().Secrets()
+	secretInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    hc.addSecret,
+		DeleteFunc: hc.deleteSecret,
+		UpdateFunc: hc.updateSecret,
+	})
+	go secretInformer.Informer().Run(stopCh)
+
+	configmapInformer := sharedInformerFactory.Core().V1().ConfigMaps()
+	configmapInformer.Informer().AddEventHandler(cache.ResourceEventHandlerFuncs{
+		AddFunc:    hc.addConfigmap,
+		DeleteFunc: hc.deleteConfigmap,
+		UpdateFunc: hc.updateConfigmap,
+	})
+	go configmapInformer.Informer().Run(stopCh)
+
+	return apiserver.SyncInformers(
+		map[apiserver.InformerName]cache.SharedInformer{
+			"helm-secrets":    secretInformer.Informer(),
+			"helm-configmaps": configmapInformer.Informer(),
+		},
+		informerSyncTimeout,
+	)
 }
 
 func helmTags(release *release, storageDriver helmStorage) []string {
@@ -175,42 +184,104 @@ func helmTags(release *release, storageDriver helmStorage) []string {
 	return tags
 }
 
-func (hc *HelmCheck) releasesFromSecrets() ([]*release, error) {
-	secrets, err := hc.secretLister.List(helmSelector)
+func (hc *HelmCheck) addSecret(obj interface{}) {
+	secret, ok := obj.(*v1.Secret)
+	if !ok {
+		log.Warnf("Expected secret, got: %v", obj)
+		return
+	}
+
+	if !isManagedByHelm(secret) {
+		return
+	}
+
+	decodedRelease, err := decodeRelease(string(secret.Data["release"]))
 	if err != nil {
-		return nil, err
+		log.Warnf("error while decoding Helm release: %s", err)
+		return
 	}
 
-	var releases []*release
-
-	for _, secret := range secrets {
-		deployedRelease, err := decodeRelease(string(secret.Data["release"]))
-		if err != nil {
-			return nil, fmt.Errorf("error while decoding Helm release: %s", err)
-		}
-		releases = append(releases, deployedRelease)
-	}
-
-	return releases, nil
+	hc.releasesMut.Lock()
+	defer hc.releasesMut.Unlock()
+	hc.releases[k8sSecrets][decodedRelease.ID()] = decodedRelease
 }
 
-func (hc *HelmCheck) releasesFromConfigMaps() ([]*release, error) {
-	configMaps, err := hc.configmapLister.List(helmSelector)
+func (hc *HelmCheck) deleteSecret(obj interface{}) {
+	secret, ok := obj.(*v1.Secret)
+	if !ok {
+		log.Warnf("Expected secret, got: %v", obj)
+		return
+	}
+
+	if !isManagedByHelm(secret) {
+		return
+	}
+
+	decodedRelease, err := decodeRelease(string(secret.Data["release"]))
 	if err != nil {
-		return nil, err
+		log.Warnf("error while decoding Helm release: %s", err)
+		return
 	}
 
-	var releases []*release
+	hc.releasesMut.Lock()
+	defer hc.releasesMut.Unlock()
+	delete(hc.releases[k8sSecrets], decodedRelease.ID())
+}
 
-	for _, configMap := range configMaps {
-		deployedRelease, err := decodeRelease(configMap.Data["release"])
-		if err != nil {
-			return nil, fmt.Errorf("error while decoding Helm release: %s", err)
-		}
-		releases = append(releases, deployedRelease)
+func (hc *HelmCheck) updateSecret(_, obj interface{}) {
+	hc.addSecret(obj)
+}
+
+func (hc *HelmCheck) addConfigmap(obj interface{}) {
+	configmap, ok := obj.(*v1.ConfigMap)
+	if !ok {
+		log.Warnf("Expected configmap, got: %v", obj)
+		return
 	}
 
-	return releases, nil
+	if !isManagedByHelm(configmap) {
+		return
+	}
+
+	decodedRelease, err := decodeRelease(configmap.Data["release"])
+	if err != nil {
+		log.Warnf("error while decoding Helm release: %s", err)
+		return
+	}
+
+	hc.releasesMut.Lock()
+	defer hc.releasesMut.Unlock()
+	hc.releases[k8sConfigmaps][decodedRelease.ID()] = decodedRelease
+}
+
+func (hc *HelmCheck) deleteConfigmap(obj interface{}) {
+	configmap, ok := obj.(*v1.ConfigMap)
+	if !ok {
+		log.Warnf("Expected configmap, got: %v", obj)
+		return
+	}
+
+	if !isManagedByHelm(configmap) {
+		return
+	}
+
+	decodedRelease, err := decodeRelease(configmap.Data["release"])
+	if err != nil {
+		log.Warnf("error while decoding Helm release: %s", err)
+		return
+	}
+
+	hc.releasesMut.Lock()
+	defer hc.releasesMut.Unlock()
+	delete(hc.releases[k8sConfigmaps], decodedRelease.ID())
+}
+
+func (hc *HelmCheck) updateConfigmap(_, obj interface{}) {
+	hc.addConfigmap(obj)
+}
+
+func isManagedByHelm(object metav1.Object) bool {
+	return object.GetLabels()["owner"] == "helm"
 }
 
 func isLeader() (bool, error) {

--- a/pkg/collector/corechecks/cluster/helm/release.go
+++ b/pkg/collector/corechecks/cluster/helm/release.go
@@ -13,6 +13,7 @@ import (
 	"compress/gzip"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 )
 
@@ -31,6 +32,10 @@ type release struct {
 	Chart     *chart `json:"chart,omitempty"`
 	Version   int    `json:"version,omitempty"`
 	Namespace string `json:"namespace,omitempty"`
+}
+
+func (rel *release) ID() string {
+	return fmt.Sprintf("%s/%s/%d", rel.Namespace, rel.Name, rel.Version)
 }
 
 type info struct {


### PR DESCRIPTION
### What does this PR do?

Introduces an optimization for the Helm check.
Now the check stores in memory the Helm releases present in the cluster. This way we don't need to decode the releases on every check run.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Same as https://github.com/DataDog/datadog-agent/pull/10949 but now the runners where the check is executed should consume less CPU.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
