### PR TITLE
[internal/patch/logr] Add `funcr` package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -429,9 +429,9 @@ replace github.com/golang/glog v1.0.0 => github.com/paulcacheux/glog v1.0.1-0.20
 // k8s.io/component-base is incompatible with logr v1.x,
 // remove once k8s.io/* is upgrade to v0.23.x or above (https://github.com/kubernetes/kubernetes/commit/cb6a6537)
 replace (
-	github.com/go-logr/logr => github.com/go-logr/logr v0.4.0
-	github.com/go-logr/stdr => github.com/go-logr/stdr v0.4.0
 	// HACK: Add `funcr` package from v1.0.0 to support packages using it (notably go.opentelemetry/otel)
 	// See internal/patch/logr/funcr/README.md for more details.
-	github.com/go-logr/funcr =>  ./internal/patch/logr/funcr
+	github.com/go-logr/funcr => ./internal/patch/logr/funcr
+	github.com/go-logr/logr => github.com/go-logr/logr v0.4.0
+	github.com/go-logr/stdr => github.com/go-logr/stdr v0.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -429,9 +429,9 @@ replace github.com/golang/glog v1.0.0 => github.com/paulcacheux/glog v1.0.1-0.20
 // k8s.io/component-base is incompatible with logr v1.x,
 // remove once k8s.io/* is upgrade to v0.23.x or above (https://github.com/kubernetes/kubernetes/commit/cb6a6537)
 replace (
+	github.com/go-logr/logr => github.com/go-logr/logr v0.4.0
 	// HACK: Add `funcr` package from v1.0.0 to support packages using it (notably go.opentelemetry/otel)
 	// See internal/patch/logr/funcr/README.md for more details.
-	github.com/go-logr/funcr => ./internal/patch/logr/funcr
-	github.com/go-logr/logr => github.com/go-logr/logr v0.4.0
+	github.com/go-logr/logr/funcr => ./internal/patch/logr/funcr
 	github.com/go-logr/stdr => github.com/go-logr/stdr v0.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -431,4 +431,7 @@ replace github.com/golang/glog v1.0.0 => github.com/paulcacheux/glog v1.0.1-0.20
 replace (
 	github.com/go-logr/logr => github.com/go-logr/logr v0.4.0
 	github.com/go-logr/stdr => github.com/go-logr/stdr v0.4.0
+	// HACK: Add `funcr` package from v1.0.0 to support packages using it (notably go.opentelemetry/otel)
+	// See internal/patch/logr/funcr/README.md for more details.
+	github.com/go-logr/funcr =>  ./internal/patch/logr/funcr
 )

--- a/internal/patch/logr/funcr/README.md
+++ b/internal/patch/logr/funcr/README.md
@@ -12,7 +12,7 @@ We need this because of a 'dependency hell' situation:
 
 1. `k8s.io/component-base` depends on v0.4.0 of `github.com/go-logr/logr`
 2. `go.opentelemetry.io/otel` depends on v1.2.2 of `github.com/go-logr/logr`.
-3. Go considers v0.x and v1.x to be the same major version, pressumably for backwards compatibility with the era pre-modules.
+3. Go considers v0.x and v1.x to be the same major version, presumably for backwards compatibility with the era pre-modules.
 
 This situation would be solved by bumping Kubernetes to v0.23.0 or above, see [relevant commit](https://github.com/kubernetes/kubernetes/commit/cb6a6537).
 However, Kubernetes can't be upgraded above v0.21.x, because of another 'dependency hell': [it depends on v0.20 of `go.opentelemetry.io/otel`](https://github.com/kubernetes/kubernetes/issues/106536). Preserving backwards-compatibility with older Kubernetes API objects also makes the update difficult.

--- a/internal/patch/logr/funcr/README.md
+++ b/internal/patch/logr/funcr/README.md
@@ -1,0 +1,34 @@
+# `github.com/go-logr/logr/funcr` patch
+
+## What is this?
+
+This is an implementation of the `github.com/go-logr/logr/funcr` package from `github.com/go-logr/logr@v1.2.2` which is compatible with v0.4.0. 
+
+It is exposed as a module and declares its path to be `github.com/go-logr/logr/funcr`.
+
+## What is the motivation behind this?
+
+We need this because of a 'dependency hell' situation:
+
+1. `k8s.io/component-base` depends on v0.4.0 of `github.com/go-logr/logr`
+2. `go.opentelemetry.io/otel` depends on v1.2.2 of `github.com/go-logr/logr`.
+3. Go considers v0.x and v1.x to be the same major version, pressumably for backwards compatibility with the era pre-modules.
+
+This situation would be solved by bumping Kubernetes to v0.23.0 or above, see [relevant commit](https://github.com/kubernetes/kubernetes/commit/cb6a6537).
+However, Kubernetes can't be upgraded above v0.21.x, because of another 'dependency hell': [it depends on v0.20 of `go.opentelemetry.io/otel`](https://github.com/kubernetes/kubernetes/issues/106536). Preserving backwards-compatibility with older Kubernetes API objects also makes the update difficult.
+
+This module is used to solve this dependency hell, by adding the `github.com/go-logr/logr/funcr` package into version v0.4.0 of the logr dependency.
+
+It is the smallest patch that can be applied to solve this particular 'dependency hell' issue with logr. It will not fix other issues when packages depend on other, newer packages, or when packages depend on functions/structs not present on logr v0.4.0 (e.g. LogSink).
+
+## When can it be removed?
+
+This must be removed when logr is bumped to v1.0.0 or above.
+
+## How does it work?
+
+It bundles a copy of `github.com/go-logr/logr@v1.2.2` on the `internal/logr` folder, and uses a wrapper (see `internal/wrapper`) to make a v1.2.2 logger into a v0.4.0 logger (which, luckily, is an interface). Furthermore:
+
+1. Non-public references to logr are replaced with references to the `internal/logr` copy. 
+2. Public references are kept referencing v0.4.0 logr.
+3. The `New` and `NewJSON` functions are rewritten using the wrapper.

--- a/internal/patch/logr/funcr/funcr.go
+++ b/internal/patch/logr/funcr/funcr.go
@@ -1,0 +1,789 @@
+/*
+Copyright 2021 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package funcr implements formatting of structured log messages and
+// optionally captures the call site and timestamp.
+//
+// The simplest way to use it is via its implementation of a
+// github.com/go-logr/logr.LogSink with output through an arbitrary
+// "write" function.  See New and NewJSON for details.
+//
+// Custom LogSinks
+//
+// For users who need more control, a funcr.Formatter can be embedded inside
+// your own custom LogSink implementation. This is useful when the LogSink
+// needs to implement additional methods, for example.
+//
+// Formatting
+//
+// This will respect logr.Marshaler, fmt.Stringer, and error interfaces for
+// values which are being logged.  When rendering a struct, funcr will use Go's
+// standard JSON tags (all except "string").
+package funcr
+
+import (
+	"bytes"
+	"encoding"
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/go-logr/logr"
+	v122Logr "github.com/go-logr/logr/funcr/internal/logr"
+	"github.com/go-logr/logr/funcr/internal/wrapper"
+)
+
+// New returns a logr.Logger which is implemented by an arbitrary function.
+func New(fn func(prefix, args string), opts Options) logr.Logger {
+	return wrapper.Fromv122Logger(v122Logr.New(newSink(fn, NewFormatter(opts))))
+}
+
+// NewJSON returns a logr.Logger which is implemented by an arbitrary function
+// and produces JSON output.
+func NewJSON(fn func(obj string), opts Options) logr.Logger {
+	fnWrapper := func(_, obj string) {
+		fn(obj)
+	}
+	return wrapper.Fromv122Logger(v122Logr.New(newSink(fnWrapper, NewFormatterJSON(opts))))
+}
+
+// Underlier exposes access to the underlying logging function. Since
+// callers only have a logr.Logger, they have to know which
+// implementation is in use, so this interface is less of an
+// abstraction and more of a way to test type conversion.
+type Underlier interface {
+	GetUnderlying() func(prefix, args string)
+}
+
+func newSink(fn func(prefix, args string), formatter Formatter) v122Logr.LogSink {
+	l := &fnlogger{
+		Formatter: formatter,
+		write:     fn,
+	}
+	// For skipping fnlogger.Info and fnlogger.Error.
+	l.Formatter.AddCallDepth(1)
+	return l
+}
+
+// Options carries parameters which influence the way logs are generated.
+type Options struct {
+	// LogCaller tells funcr to add a "caller" key to some or all log lines.
+	// This has some overhead, so some users might not want it.
+	LogCaller MessageClass
+
+	// LogCallerFunc tells funcr to also log the calling function name.  This
+	// has no effect if caller logging is not enabled (see Options.LogCaller).
+	LogCallerFunc bool
+
+	// LogTimestamp tells funcr to add a "ts" key to log lines.  This has some
+	// overhead, so some users might not want it.
+	LogTimestamp bool
+
+	// TimestampFormat tells funcr how to render timestamps when LogTimestamp
+	// is enabled.  If not specified, a default format will be used.  For more
+	// details, see docs for Go's time.Layout.
+	TimestampFormat string
+
+	// Verbosity tells funcr which V logs to produce.  Higher values enable
+	// more logs.  Info logs at or below this level will be written, while logs
+	// above this level will be discarded.
+	Verbosity int
+
+	// RenderBuiltinsHook allows users to mutate the list of key-value pairs
+	// while a log line is being rendered.  The kvList argument follows logr
+	// conventions - each pair of slice elements is comprised of a string key
+	// and an arbitrary value (verified and sanitized before calling this
+	// hook).  The value returned must follow the same conventions.  This hook
+	// can be used to audit or modify logged data.  For example, you might want
+	// to prefix all of funcr's built-in keys with some string.  This hook is
+	// only called for built-in (provided by funcr itself) key-value pairs.
+	// Equivalent hooks are offered for key-value pairs saved via
+	// logr.Logger.WithValues or Formatter.AddValues (see RenderValuesHook) and
+	// for user-provided pairs (see RenderArgsHook).
+	RenderBuiltinsHook func(kvList []interface{}) []interface{}
+
+	// RenderValuesHook is the same as RenderBuiltinsHook, except that it is
+	// only called for key-value pairs saved via logr.Logger.WithValues.  See
+	// RenderBuiltinsHook for more details.
+	RenderValuesHook func(kvList []interface{}) []interface{}
+
+	// RenderArgsHook is the same as RenderBuiltinsHook, except that it is only
+	// called for key-value pairs passed directly to Info and Error.  See
+	// RenderBuiltinsHook for more details.
+	RenderArgsHook func(kvList []interface{}) []interface{}
+
+	// MaxLogDepth tells funcr how many levels of nested fields (e.g. a struct
+	// that contains a struct, etc.) it may log.  Every time it finds a struct,
+	// slice, array, or map the depth is increased by one.  When the maximum is
+	// reached, the value will be converted to a string indicating that the max
+	// depth has been exceeded.  If this field is not specified, a default
+	// value will be used.
+	MaxLogDepth int
+}
+
+// MessageClass indicates which category or categories of messages to consider.
+type MessageClass int
+
+const (
+	// None ignores all message classes.
+	None MessageClass = iota
+	// All considers all message classes.
+	All
+	// Info only considers info messages.
+	Info
+	// Error only considers error messages.
+	Error
+)
+
+// fnlogger inherits some of its LogSink implementation from Formatter
+// and just needs to add some glue code.
+type fnlogger struct {
+	Formatter
+	write func(prefix, args string)
+}
+
+func (l fnlogger) WithName(name string) v122Logr.LogSink {
+	l.Formatter.AddName(name)
+	return &l
+}
+
+func (l fnlogger) WithValues(kvList ...interface{}) v122Logr.LogSink {
+	l.Formatter.AddValues(kvList)
+	return &l
+}
+
+func (l fnlogger) WithCallDepth(depth int) v122Logr.LogSink {
+	l.Formatter.AddCallDepth(depth)
+	return &l
+}
+
+func (l fnlogger) Info(level int, msg string, kvList ...interface{}) {
+	prefix, args := l.FormatInfo(level, msg, kvList)
+	l.write(prefix, args)
+}
+
+func (l fnlogger) Error(err error, msg string, kvList ...interface{}) {
+	prefix, args := l.FormatError(err, msg, kvList)
+	l.write(prefix, args)
+}
+
+func (l fnlogger) GetUnderlying() func(prefix, args string) {
+	return l.write
+}
+
+// Assert conformance to the interfaces.
+var _ v122Logr.LogSink = &fnlogger{}
+var _ v122Logr.CallDepthLogSink = &fnlogger{}
+var _ Underlier = &fnlogger{}
+
+// NewFormatter constructs a Formatter which emits a JSON-like key=value format.
+func NewFormatter(opts Options) Formatter {
+	return newFormatter(opts, outputKeyValue)
+}
+
+// NewFormatterJSON constructs a Formatter which emits strict JSON.
+func NewFormatterJSON(opts Options) Formatter {
+	return newFormatter(opts, outputJSON)
+}
+
+// Defaults for Options.
+const defaultTimestampFormat = "2006-01-02 15:04:05.000000"
+const defaultMaxLogDepth = 16
+
+func newFormatter(opts Options, outfmt outputFormat) Formatter {
+	if opts.TimestampFormat == "" {
+		opts.TimestampFormat = defaultTimestampFormat
+	}
+	if opts.MaxLogDepth == 0 {
+		opts.MaxLogDepth = defaultMaxLogDepth
+	}
+	f := Formatter{
+		outputFormat: outfmt,
+		prefix:       "",
+		values:       nil,
+		depth:        0,
+		opts:         opts,
+	}
+	return f
+}
+
+// Formatter is an opaque struct which can be embedded in a LogSink
+// implementation. It should be constructed with NewFormatter. Some of
+// its methods directly implement v122Logr.LogSink.
+type Formatter struct {
+	outputFormat outputFormat
+	prefix       string
+	values       []interface{}
+	valuesStr    string
+	depth        int
+	opts         Options
+}
+
+// outputFormat indicates which outputFormat to use.
+type outputFormat int
+
+const (
+	// outputKeyValue emits a JSON-like key=value format, but not strict JSON.
+	outputKeyValue outputFormat = iota
+	// outputJSON emits strict JSON.
+	outputJSON
+)
+
+// PseudoStruct is a list of key-value pairs that gets logged as a struct.
+type PseudoStruct []interface{}
+
+// render produces a log line, ready to use.
+func (f Formatter) render(builtins, args []interface{}) string {
+	// Empirically bytes.Buffer is faster than strings.Builder for this.
+	buf := bytes.NewBuffer(make([]byte, 0, 1024))
+	if f.outputFormat == outputJSON {
+		buf.WriteByte('{')
+	}
+	vals := builtins
+	if hook := f.opts.RenderBuiltinsHook; hook != nil {
+		vals = hook(f.sanitize(vals))
+	}
+	f.flatten(buf, vals, false, false) // keys are ours, no need to escape
+	continuing := len(builtins) > 0
+	if len(f.valuesStr) > 0 {
+		if continuing {
+			if f.outputFormat == outputJSON {
+				buf.WriteByte(',')
+			} else {
+				buf.WriteByte(' ')
+			}
+		}
+		continuing = true
+		buf.WriteString(f.valuesStr)
+	}
+	vals = args
+	if hook := f.opts.RenderArgsHook; hook != nil {
+		vals = hook(f.sanitize(vals))
+	}
+	f.flatten(buf, vals, continuing, true) // escape user-provided keys
+	if f.outputFormat == outputJSON {
+		buf.WriteByte('}')
+	}
+	return buf.String()
+}
+
+// flatten renders a list of key-value pairs into a buffer.  If continuing is
+// true, it assumes that the buffer has previous values and will emit a
+// separator (which depends on the output format) before the first pair it
+// writes.  If escapeKeys is true, the keys are assumed to have
+// non-JSON-compatible characters in them and must be evaluated for escapes.
+//
+// This function returns a potentially modified version of kvList, which
+// ensures that there is a value for every key (adding a value if needed) and
+// that each key is a string (substituting a key if needed).
+func (f Formatter) flatten(buf *bytes.Buffer, kvList []interface{}, continuing bool, escapeKeys bool) []interface{} {
+	// This logic overlaps with sanitize() but saves one type-cast per key,
+	// which can be measurable.
+	if len(kvList)%2 != 0 {
+		kvList = append(kvList, noValue)
+	}
+	for i := 0; i < len(kvList); i += 2 {
+		k, ok := kvList[i].(string)
+		if !ok {
+			k = f.nonStringKey(kvList[i])
+			kvList[i] = k
+		}
+		v := kvList[i+1]
+
+		if i > 0 || continuing {
+			if f.outputFormat == outputJSON {
+				buf.WriteByte(',')
+			} else {
+				// In theory the format could be something we don't understand.  In
+				// practice, we control it, so it won't be.
+				buf.WriteByte(' ')
+			}
+		}
+
+		if escapeKeys {
+			buf.WriteString(prettyString(k))
+		} else {
+			// this is faster
+			buf.WriteByte('"')
+			buf.WriteString(k)
+			buf.WriteByte('"')
+		}
+		if f.outputFormat == outputJSON {
+			buf.WriteByte(':')
+		} else {
+			buf.WriteByte('=')
+		}
+		buf.WriteString(f.pretty(v))
+	}
+	return kvList
+}
+
+func (f Formatter) pretty(value interface{}) string {
+	return f.prettyWithFlags(value, 0, 0)
+}
+
+const (
+	flagRawStruct = 0x1 // do not print braces on structs
+)
+
+// TODO: This is not fast. Most of the overhead goes here.
+func (f Formatter) prettyWithFlags(value interface{}, flags uint32, depth int) string {
+	if depth > f.opts.MaxLogDepth {
+		return `"<max-log-depth-exceeded>"`
+	}
+
+	// Handle types that take full control of logging.
+	if v, ok := value.(v122Logr.Marshaler); ok {
+		// Replace the value with what the type wants to get logged.
+		// That then gets handled below via reflection.
+		value = invokeMarshaler(v)
+	}
+
+	// Handle types that want to format themselves.
+	switch v := value.(type) {
+	case fmt.Stringer:
+		value = invokeStringer(v)
+	case error:
+		value = invokeError(v)
+	}
+
+	// Handling the most common types without reflect is a small perf win.
+	switch v := value.(type) {
+	case bool:
+		return strconv.FormatBool(v)
+	case string:
+		return prettyString(v)
+	case int:
+		return strconv.FormatInt(int64(v), 10)
+	case int8:
+		return strconv.FormatInt(int64(v), 10)
+	case int16:
+		return strconv.FormatInt(int64(v), 10)
+	case int32:
+		return strconv.FormatInt(int64(v), 10)
+	case int64:
+		return strconv.FormatInt(int64(v), 10)
+	case uint:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint8:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint16:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint32:
+		return strconv.FormatUint(uint64(v), 10)
+	case uint64:
+		return strconv.FormatUint(v, 10)
+	case uintptr:
+		return strconv.FormatUint(uint64(v), 10)
+	case float32:
+		return strconv.FormatFloat(float64(v), 'f', -1, 32)
+	case float64:
+		return strconv.FormatFloat(v, 'f', -1, 64)
+	case complex64:
+		return `"` + strconv.FormatComplex(complex128(v), 'f', -1, 64) + `"`
+	case complex128:
+		return `"` + strconv.FormatComplex(v, 'f', -1, 128) + `"`
+	case PseudoStruct:
+		buf := bytes.NewBuffer(make([]byte, 0, 1024))
+		v = f.sanitize(v)
+		if flags&flagRawStruct == 0 {
+			buf.WriteByte('{')
+		}
+		for i := 0; i < len(v); i += 2 {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			k, _ := v[i].(string) // sanitize() above means no need to check success
+			// arbitrary keys might need escaping
+			buf.WriteString(prettyString(k))
+			buf.WriteByte(':')
+			buf.WriteString(f.prettyWithFlags(v[i+1], 0, depth+1))
+		}
+		if flags&flagRawStruct == 0 {
+			buf.WriteByte('}')
+		}
+		return buf.String()
+	}
+
+	buf := bytes.NewBuffer(make([]byte, 0, 256))
+	t := reflect.TypeOf(value)
+	if t == nil {
+		return "null"
+	}
+	v := reflect.ValueOf(value)
+	switch t.Kind() {
+	case reflect.Bool:
+		return strconv.FormatBool(v.Bool())
+	case reflect.String:
+		return prettyString(v.String())
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return strconv.FormatInt(int64(v.Int()), 10)
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return strconv.FormatUint(uint64(v.Uint()), 10)
+	case reflect.Float32:
+		return strconv.FormatFloat(float64(v.Float()), 'f', -1, 32)
+	case reflect.Float64:
+		return strconv.FormatFloat(v.Float(), 'f', -1, 64)
+	case reflect.Complex64:
+		return `"` + strconv.FormatComplex(complex128(v.Complex()), 'f', -1, 64) + `"`
+	case reflect.Complex128:
+		return `"` + strconv.FormatComplex(v.Complex(), 'f', -1, 128) + `"`
+	case reflect.Struct:
+		if flags&flagRawStruct == 0 {
+			buf.WriteByte('{')
+		}
+		for i := 0; i < t.NumField(); i++ {
+			fld := t.Field(i)
+			if fld.PkgPath != "" {
+				// reflect says this field is only defined for non-exported fields.
+				continue
+			}
+			if !v.Field(i).CanInterface() {
+				// reflect isn't clear exactly what this means, but we can't use it.
+				continue
+			}
+			name := ""
+			omitempty := false
+			if tag, found := fld.Tag.Lookup("json"); found {
+				if tag == "-" {
+					continue
+				}
+				if comma := strings.Index(tag, ","); comma != -1 {
+					if n := tag[:comma]; n != "" {
+						name = n
+					}
+					rest := tag[comma:]
+					if strings.Contains(rest, ",omitempty,") || strings.HasSuffix(rest, ",omitempty") {
+						omitempty = true
+					}
+				} else {
+					name = tag
+				}
+			}
+			if omitempty && isEmpty(v.Field(i)) {
+				continue
+			}
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			if fld.Anonymous && fld.Type.Kind() == reflect.Struct && name == "" {
+				buf.WriteString(f.prettyWithFlags(v.Field(i).Interface(), flags|flagRawStruct, depth+1))
+				continue
+			}
+			if name == "" {
+				name = fld.Name
+			}
+			// field names can't contain characters which need escaping
+			buf.WriteByte('"')
+			buf.WriteString(name)
+			buf.WriteByte('"')
+			buf.WriteByte(':')
+			buf.WriteString(f.prettyWithFlags(v.Field(i).Interface(), 0, depth+1))
+		}
+		if flags&flagRawStruct == 0 {
+			buf.WriteByte('}')
+		}
+		return buf.String()
+	case reflect.Slice, reflect.Array:
+		buf.WriteByte('[')
+		for i := 0; i < v.Len(); i++ {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			e := v.Index(i)
+			buf.WriteString(f.prettyWithFlags(e.Interface(), 0, depth+1))
+		}
+		buf.WriteByte(']')
+		return buf.String()
+	case reflect.Map:
+		buf.WriteByte('{')
+		// This does not sort the map keys, for best perf.
+		it := v.MapRange()
+		i := 0
+		for it.Next() {
+			if i > 0 {
+				buf.WriteByte(',')
+			}
+			// If a map key supports TextMarshaler, use it.
+			keystr := ""
+			if m, ok := it.Key().Interface().(encoding.TextMarshaler); ok {
+				txt, err := m.MarshalText()
+				if err != nil {
+					keystr = fmt.Sprintf("<error-MarshalText: %s>", err.Error())
+				} else {
+					keystr = string(txt)
+				}
+				keystr = prettyString(keystr)
+			} else {
+				// prettyWithFlags will produce already-escaped values
+				keystr = f.prettyWithFlags(it.Key().Interface(), 0, depth+1)
+				if t.Key().Kind() != reflect.String {
+					// JSON only does string keys.  Unlike Go's standard JSON, we'll
+					// convert just about anything to a string.
+					keystr = prettyString(keystr)
+				}
+			}
+			buf.WriteString(keystr)
+			buf.WriteByte(':')
+			buf.WriteString(f.prettyWithFlags(it.Value().Interface(), 0, depth+1))
+			i++
+		}
+		buf.WriteByte('}')
+		return buf.String()
+	case reflect.Ptr, reflect.Interface:
+		if v.IsNil() {
+			return "null"
+		}
+		return f.prettyWithFlags(v.Elem().Interface(), 0, depth)
+	}
+	return fmt.Sprintf(`"<unhandled-%s>"`, t.Kind().String())
+}
+
+func prettyString(s string) string {
+	// Avoid escaping (which does allocations) if we can.
+	if needsEscape(s) {
+		return strconv.Quote(s)
+	}
+	b := bytes.NewBuffer(make([]byte, 0, 1024))
+	b.WriteByte('"')
+	b.WriteString(s)
+	b.WriteByte('"')
+	return b.String()
+}
+
+// needsEscape determines whether the input string needs to be escaped or not,
+// without doing any allocations.
+func needsEscape(s string) bool {
+	for _, r := range s {
+		if !strconv.IsPrint(r) || r == '\\' || r == '"' {
+			return true
+		}
+	}
+	return false
+}
+
+func isEmpty(v reflect.Value) bool {
+	switch v.Kind() {
+	case reflect.Array, reflect.Map, reflect.Slice, reflect.String:
+		return v.Len() == 0
+	case reflect.Bool:
+		return !v.Bool()
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return v.Int() == 0
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64, reflect.Uintptr:
+		return v.Uint() == 0
+	case reflect.Float32, reflect.Float64:
+		return v.Float() == 0
+	case reflect.Complex64, reflect.Complex128:
+		return v.Complex() == 0
+	case reflect.Interface, reflect.Ptr:
+		return v.IsNil()
+	}
+	return false
+}
+
+func invokeMarshaler(m v122Logr.Marshaler) (ret interface{}) {
+	defer func() {
+		if r := recover(); r != nil {
+			ret = fmt.Sprintf("<panic: %s>", r)
+		}
+	}()
+	return m.MarshalLog()
+}
+
+func invokeStringer(s fmt.Stringer) (ret string) {
+	defer func() {
+		if r := recover(); r != nil {
+			ret = fmt.Sprintf("<panic: %s>", r)
+		}
+	}()
+	return s.String()
+}
+
+func invokeError(e error) (ret string) {
+	defer func() {
+		if r := recover(); r != nil {
+			ret = fmt.Sprintf("<panic: %s>", r)
+		}
+	}()
+	return e.Error()
+}
+
+// Caller represents the original call site for a log line, after considering
+// logr.Logger.WithCallDepth and logr.Logger.WithCallStackHelper.  The File and
+// Line fields will always be provided, while the Func field is optional.
+// Users can set the render hook fields in Options to examine logged key-value
+// pairs, one of which will be {"caller", Caller} if the Options.LogCaller
+// field is enabled for the given MessageClass.
+type Caller struct {
+	// File is the basename of the file for this call site.
+	File string `json:"file"`
+	// Line is the line number in the file for this call site.
+	Line int `json:"line"`
+	// Func is the function name for this call site, or empty if
+	// Options.LogCallerFunc is not enabled.
+	Func string `json:"function,omitempty"`
+}
+
+func (f Formatter) caller() Caller {
+	// +1 for this frame, +1 for Info/Error.
+	pc, file, line, ok := runtime.Caller(f.depth + 2)
+	if !ok {
+		return Caller{"<unknown>", 0, ""}
+	}
+	fn := ""
+	if f.opts.LogCallerFunc {
+		if fp := runtime.FuncForPC(pc); fp != nil {
+			fn = fp.Name()
+		}
+	}
+
+	return Caller{filepath.Base(file), line, fn}
+}
+
+const noValue = "<no-value>"
+
+func (f Formatter) nonStringKey(v interface{}) string {
+	return fmt.Sprintf("<non-string-key: %s>", f.snippet(v))
+}
+
+// snippet produces a short snippet string of an arbitrary value.
+func (f Formatter) snippet(v interface{}) string {
+	const snipLen = 16
+
+	snip := f.pretty(v)
+	if len(snip) > snipLen {
+		snip = snip[:snipLen]
+	}
+	return snip
+}
+
+// sanitize ensures that a list of key-value pairs has a value for every key
+// (adding a value if needed) and that each key is a string (substituting a key
+// if needed).
+func (f Formatter) sanitize(kvList []interface{}) []interface{} {
+	if len(kvList)%2 != 0 {
+		kvList = append(kvList, noValue)
+	}
+	for i := 0; i < len(kvList); i += 2 {
+		_, ok := kvList[i].(string)
+		if !ok {
+			kvList[i] = f.nonStringKey(kvList[i])
+		}
+	}
+	return kvList
+}
+
+// Init configures this Formatter from runtime info, such as the call depth
+// imposed by logr itself.
+// Note that this receiver is a pointer, so depth can be saved.
+func (f *Formatter) Init(info v122Logr.RuntimeInfo) {
+	f.depth += info.CallDepth
+}
+
+// Enabled checks whether an info message at the given level should be logged.
+func (f Formatter) Enabled(level int) bool {
+	return level <= f.opts.Verbosity
+}
+
+// GetDepth returns the current depth of this Formatter.  This is useful for
+// implementations which do their own caller attribution.
+func (f Formatter) GetDepth() int {
+	return f.depth
+}
+
+// FormatInfo renders an Info log message into strings.  The prefix will be
+// empty when no names were set (via AddNames), or when the output is
+// configured for JSON.
+func (f Formatter) FormatInfo(level int, msg string, kvList []interface{}) (prefix, argsStr string) {
+	args := make([]interface{}, 0, 64) // using a constant here impacts perf
+	prefix = f.prefix
+	if f.outputFormat == outputJSON {
+		args = append(args, "logger", prefix)
+		prefix = ""
+	}
+	if f.opts.LogTimestamp {
+		args = append(args, "ts", time.Now().Format(f.opts.TimestampFormat))
+	}
+	if policy := f.opts.LogCaller; policy == All || policy == Info {
+		args = append(args, "caller", f.caller())
+	}
+	args = append(args, "level", level, "msg", msg)
+	return prefix, f.render(args, kvList)
+}
+
+// FormatError renders an Error log message into strings.  The prefix will be
+// empty when no names were set (via AddNames),  or when the output is
+// configured for JSON.
+func (f Formatter) FormatError(err error, msg string, kvList []interface{}) (prefix, argsStr string) {
+	args := make([]interface{}, 0, 64) // using a constant here impacts perf
+	prefix = f.prefix
+	if f.outputFormat == outputJSON {
+		args = append(args, "logger", prefix)
+		prefix = ""
+	}
+	if f.opts.LogTimestamp {
+		args = append(args, "ts", time.Now().Format(f.opts.TimestampFormat))
+	}
+	if policy := f.opts.LogCaller; policy == All || policy == Error {
+		args = append(args, "caller", f.caller())
+	}
+	args = append(args, "msg", msg)
+	var loggableErr interface{}
+	if err != nil {
+		loggableErr = err.Error()
+	}
+	args = append(args, "error", loggableErr)
+	return f.prefix, f.render(args, kvList)
+}
+
+// AddName appends the specified name.  funcr uses '/' characters to separate
+// name elements.  Callers should not pass '/' in the provided name string, but
+// this library does not actually enforce that.
+func (f *Formatter) AddName(name string) {
+	if len(f.prefix) > 0 {
+		f.prefix += "/"
+	}
+	f.prefix += name
+}
+
+// AddValues adds key-value pairs to the set of saved values to be logged with
+// each log line.
+func (f *Formatter) AddValues(kvList []interface{}) {
+	// Three slice args forces a copy.
+	n := len(f.values)
+	f.values = append(f.values[:n:n], kvList...)
+
+	vals := f.values
+	if hook := f.opts.RenderValuesHook; hook != nil {
+		vals = hook(f.sanitize(vals))
+	}
+
+	// Pre-render values, so we don't have to do it on each Info/Error call.
+	buf := bytes.NewBuffer(make([]byte, 0, 1024))
+	f.flatten(buf, vals, false, true) // escape user-provided keys
+	f.valuesStr = buf.String()
+}
+
+// AddCallDepth increases the number of stack-frames to skip when attributing
+// the log line to a file and line.
+func (f *Formatter) AddCallDepth(depth int) {
+	f.depth += depth
+}

--- a/internal/patch/logr/funcr/funcr_test.go
+++ b/internal/patch/logr/funcr/funcr_test.go
@@ -1,0 +1,1131 @@
+/*
+Copyright 2021 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package funcr
+
+import (
+	"encoding/json"
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"testing"
+
+	v122Logr "github.com/go-logr/logr/funcr/internal/logr"
+)
+
+// Will be handled via reflection instead of type assertions.
+type substr string
+
+func ptrint(i int) *int {
+	return &i
+}
+func ptrstr(s string) *string {
+	return &s
+}
+
+// point implements encoding.TextMarshaler and can be used as a map key.
+type point struct{ x, y int }
+
+func (p point) MarshalText() ([]byte, error) {
+	return []byte(fmt.Sprintf("(%d, %d)", p.x, p.y)), nil
+}
+
+// pointErr implements encoding.TextMarshaler but returns an error.
+type pointErr struct{ x, y int }
+
+func (p pointErr) MarshalText() ([]byte, error) {
+	return nil, fmt.Errorf("uh oh: %d, %d", p.x, p.y)
+}
+
+// Logging this should result in the MarshalLog() value.
+type Tmarshaler struct{ val string }
+
+func (t Tmarshaler) MarshalLog() interface{} {
+	return struct{ Inner string }{"I am a logr.Marshaler"}
+}
+
+func (t Tmarshaler) String() string {
+	return "String(): you should not see this"
+}
+
+func (t Tmarshaler) Error() string {
+	return "Error(): you should not see this"
+}
+
+// Logging this should result in a panic.
+type Tmarshalerpanic struct{ val string }
+
+func (t Tmarshalerpanic) MarshalLog() interface{} {
+	panic("Tmarshalerpanic")
+}
+
+// Logging this should result in the String() value.
+type Tstringer struct{ val string }
+
+func (t Tstringer) String() string {
+	return "I am a fmt.Stringer"
+}
+
+func (t Tstringer) Error() string {
+	return "Error(): you should not see this"
+}
+
+// Logging this should result in a panic.
+type Tstringerpanic struct{ val string }
+
+func (t Tstringerpanic) String() string {
+	panic("Tstringerpanic")
+}
+
+// Logging this should result in the Error() value.
+type Terror struct{ val string }
+
+func (t Terror) Error() string {
+	return "I am an error"
+}
+
+// Logging this should result in a panic.
+type Terrorpanic struct{ val string }
+
+func (t Terrorpanic) Error() string {
+	panic("Terrorpanic")
+}
+
+type TjsontagsString struct {
+	String1 string `json:"string1"`           // renamed
+	String2 string `json:"-"`                 // ignored
+	String3 string `json:"-,"`                // named "-"
+	String4 string `json:"string4,omitempty"` // renamed, ignore if empty
+	String5 string `json:","`                 // no-op
+	String6 string `json:",omitempty"`        // ignore if empty
+}
+
+type TjsontagsBool struct {
+	Bool1 bool `json:"bool1"`           // renamed
+	Bool2 bool `json:"-"`               // ignored
+	Bool3 bool `json:"-,"`              // named "-"
+	Bool4 bool `json:"bool4,omitempty"` // renamed, ignore if empty
+	Bool5 bool `json:","`               // no-op
+	Bool6 bool `json:",omitempty"`      // ignore if empty
+}
+
+type TjsontagsInt struct {
+	Int1 int `json:"int1"`           // renamed
+	Int2 int `json:"-"`              // ignored
+	Int3 int `json:"-,"`             // named "-"
+	Int4 int `json:"int4,omitempty"` // renamed, ignore if empty
+	Int5 int `json:","`              // no-op
+	Int6 int `json:",omitempty"`     // ignore if empty
+}
+
+type TjsontagsUint struct {
+	Uint1 uint `json:"uint1"`           // renamed
+	Uint2 uint `json:"-"`               // ignored
+	Uint3 uint `json:"-,"`              // named "-"
+	Uint4 uint `json:"uint4,omitempty"` // renamed, ignore if empty
+	Uint5 uint `json:","`               // no-op
+	Uint6 uint `json:",omitempty"`      // ignore if empty
+}
+
+type TjsontagsFloat struct {
+	Float1 float64 `json:"float1"`           // renamed
+	Float2 float64 `json:"-"`                // ignored
+	Float3 float64 `json:"-,"`               // named "-"
+	Float4 float64 `json:"float4,omitempty"` // renamed, ignore if empty
+	Float5 float64 `json:","`                // no-op
+	Float6 float64 `json:",omitempty"`       // ignore if empty
+}
+
+type TjsontagsComplex struct {
+	Complex1 complex128 `json:"complex1"`           // renamed
+	Complex2 complex128 `json:"-"`                  // ignored
+	Complex3 complex128 `json:"-,"`                 // named "-"
+	Complex4 complex128 `json:"complex4,omitempty"` // renamed, ignore if empty
+	Complex5 complex128 `json:","`                  // no-op
+	Complex6 complex128 `json:",omitempty"`         // ignore if empty
+}
+
+type TjsontagsPtr struct {
+	Ptr1 *string `json:"ptr1"`           // renamed
+	Ptr2 *string `json:"-"`              // ignored
+	Ptr3 *string `json:"-,"`             // named "-"
+	Ptr4 *string `json:"ptr4,omitempty"` // renamed, ignore if empty
+	Ptr5 *string `json:","`              // no-op
+	Ptr6 *string `json:",omitempty"`     // ignore if empty
+}
+
+type TjsontagsArray struct {
+	Array1 [2]string `json:"array1"`           // renamed
+	Array2 [2]string `json:"-"`                // ignored
+	Array3 [2]string `json:"-,"`               // named "-"
+	Array4 [2]string `json:"array4,omitempty"` // renamed, ignore if empty
+	Array5 [2]string `json:","`                // no-op
+	Array6 [2]string `json:",omitempty"`       // ignore if empty
+}
+
+type TjsontagsSlice struct {
+	Slice1 []string `json:"slice1"`           // renamed
+	Slice2 []string `json:"-"`                // ignored
+	Slice3 []string `json:"-,"`               // named "-"
+	Slice4 []string `json:"slice4,omitempty"` // renamed, ignore if empty
+	Slice5 []string `json:","`                // no-op
+	Slice6 []string `json:",omitempty"`       // ignore if empty
+}
+
+type TjsontagsMap struct {
+	Map1 map[string]string `json:"map1"`           // renamed
+	Map2 map[string]string `json:"-"`              // ignored
+	Map3 map[string]string `json:"-,"`             // named "-"
+	Map4 map[string]string `json:"map4,omitempty"` // renamed, ignore if empty
+	Map5 map[string]string `json:","`              // no-op
+	Map6 map[string]string `json:",omitempty"`     // ignore if empty
+}
+
+type Tinnerstruct struct {
+	Inner string
+}
+type Tinnerint int
+type Tinnermap map[string]string
+type Tinnerslice []string
+
+type Tembedstruct struct {
+	Tinnerstruct
+	Outer string
+}
+
+type Tembednonstruct struct {
+	Tinnerint
+	Tinnermap
+	Tinnerslice
+}
+
+type Tinner1 Tinnerstruct
+type Tinner2 Tinnerstruct
+type Tinner3 Tinnerstruct
+type Tinner4 Tinnerstruct
+type Tinner5 Tinnerstruct
+type Tinner6 Tinnerstruct
+
+type Tembedjsontags struct {
+	Outer   string
+	Tinner1 `json:"inner1"`
+	Tinner2 `json:"-"`
+	Tinner3 `json:"-,"`
+	Tinner4 `json:"inner4,omitempty"`
+	Tinner5 `json:","`
+	Tinner6 `json:"inner6,omitempty"`
+}
+
+func TestPretty(t *testing.T) {
+	// used below
+	newStr := func(s string) *string {
+		return &s
+	}
+
+	cases := []struct {
+		val interface{}
+		exp string // used in cases where JSON can't handle it
+	}{
+		{val: "strval"},
+		{val: "strval\nwith\t\"escapes\""},
+		{val: substr("substrval")},
+		{val: substr("substrval\nwith\t\"escapes\"")},
+		{val: true},
+		{val: false},
+		{val: int(93)},
+		{val: int8(93)},
+		{val: int16(93)},
+		{val: int32(93)},
+		{val: int64(93)},
+		{val: int(-93)},
+		{val: int8(-93)},
+		{val: int16(-93)},
+		{val: int32(-93)},
+		{val: int64(-93)},
+		{val: uint(93)},
+		{val: uint8(93)},
+		{val: uint16(93)},
+		{val: uint32(93)},
+		{val: uint64(93)},
+		{val: uintptr(93)},
+		{val: float32(93.76)},
+		{val: float64(93.76)},
+		{
+			val: complex64(93i),
+			exp: `"(0+93i)"`,
+		},
+		{
+			val: complex128(93i),
+			exp: `"(0+93i)"`,
+		},
+		{val: ptrint(93)},
+		{val: ptrstr("pstrval")},
+		{val: []int{}},
+		{
+			val: []int(nil),
+			exp: `[]`,
+		},
+		{val: []int{9, 3, 7, 6}},
+		{val: []string{"str", "with\tescape"}},
+		{val: []substr{"substr", "with\tescape"}},
+		{val: [4]int{9, 3, 7, 6}},
+		{val: [2]string{"str", "with\tescape"}},
+		{val: [2]substr{"substr", "with\tescape"}},
+		{
+			val: struct {
+				Int         int
+				notExported string
+				String      string
+			}{
+				93, "you should not see this", "seventy-six",
+			},
+		},
+		{val: map[string]int{}},
+		{
+			val: map[string]int(nil),
+			exp: `{}`,
+		},
+		{
+			val: map[string]int{
+				"nine": 3,
+			},
+		},
+		{
+			val: map[string]int{
+				"with\tescape": 76,
+			},
+		},
+		{
+			val: map[substr]int{
+				"nine": 3,
+			},
+		},
+		{
+			val: map[substr]int{
+				"with\tescape": 76,
+			},
+		},
+		{
+			val: map[int]int{
+				9: 3,
+			},
+		},
+		{
+			val: map[float64]int{
+				9.5: 3,
+			},
+			exp: `{"9.5":3}`,
+		},
+		{
+			val: map[point]int{
+				{x: 1, y: 2}: 3,
+			},
+		},
+		{
+			val: map[pointErr]int{
+				{x: 1, y: 2}: 3,
+			},
+			exp: `{"<error-MarshalText: uh oh: 1, 2>":3}`,
+		},
+		{
+			val: struct {
+				X int `json:"x"`
+				Y int `json:"y"`
+			}{
+				93, 76,
+			},
+		},
+		{
+			val: struct {
+				X []int
+				Y map[int]int
+				Z struct{ P, Q int }
+			}{
+				[]int{9, 3, 7, 6},
+				map[int]int{9: 3},
+				struct{ P, Q int }{9, 3},
+			},
+		},
+		{
+			val: []struct{ X, Y string }{
+				{"nine", "three"},
+				{"seven", "six"},
+				{"with\t", "\tescapes"},
+			},
+		},
+		{
+			val: struct {
+				A *int
+				B *int
+				C interface{}
+				D interface{}
+			}{
+				B: ptrint(1),
+				D: interface{}(2),
+			},
+		},
+		{
+			val: Tmarshaler{"foobar"},
+			exp: `{"Inner":"I am a logr.Marshaler"}`,
+		},
+		{
+			val: &Tmarshaler{"foobar"},
+			exp: `{"Inner":"I am a logr.Marshaler"}`,
+		},
+		{
+			val: (*Tmarshaler)(nil),
+			exp: `"<panic: value method github.com/go-logr/logr/funcr.Tmarshaler.MarshalLog called using nil *Tmarshaler pointer>"`,
+		},
+		{
+			val: Tmarshalerpanic{"foobar"},
+			exp: `"<panic: Tmarshalerpanic>"`,
+		},
+		{
+			val: Tstringer{"foobar"},
+			exp: `"I am a fmt.Stringer"`,
+		},
+		{
+			val: &Tstringer{"foobar"},
+			exp: `"I am a fmt.Stringer"`,
+		},
+		{
+			val: (*Tstringer)(nil),
+			exp: `"<panic: value method github.com/go-logr/logr/funcr.Tstringer.String called using nil *Tstringer pointer>"`,
+		},
+		{
+			val: Tstringerpanic{"foobar"},
+			exp: `"<panic: Tstringerpanic>"`,
+		},
+		{
+			val: Terror{"foobar"},
+			exp: `"I am an error"`,
+		},
+		{
+			val: &Terror{"foobar"},
+			exp: `"I am an error"`,
+		},
+		{
+			val: (*Terror)(nil),
+			exp: `"<panic: value method github.com/go-logr/logr/funcr.Terror.Error called using nil *Terror pointer>"`,
+		},
+		{
+			val: Terrorpanic{"foobar"},
+			exp: `"<panic: Terrorpanic>"`,
+		},
+		{
+			val: TjsontagsString{
+				String1: "v1",
+				String2: "v2",
+				String3: "v3",
+				String4: "v4",
+				String5: "v5",
+				String6: "v6",
+			},
+		},
+		{val: TjsontagsString{}},
+		{
+			val: TjsontagsBool{
+				Bool1: true,
+				Bool2: true,
+				Bool3: true,
+				Bool4: true,
+				Bool5: true,
+				Bool6: true,
+			},
+		},
+		{val: TjsontagsBool{}},
+		{
+			val: TjsontagsInt{
+				Int1: 1,
+				Int2: 2,
+				Int3: 3,
+				Int4: 4,
+				Int5: 5,
+				Int6: 6,
+			},
+		},
+		{val: TjsontagsInt{}},
+		{
+			val: TjsontagsUint{
+				Uint1: 1,
+				Uint2: 2,
+				Uint3: 3,
+				Uint4: 4,
+				Uint5: 5,
+				Uint6: 6,
+			},
+		},
+		{val: TjsontagsUint{}},
+		{
+			val: TjsontagsFloat{
+				Float1: 1.1,
+				Float2: 2.2,
+				Float3: 3.3,
+				Float4: 4.4,
+				Float5: 5.5,
+				Float6: 6.6,
+			},
+		},
+		{val: TjsontagsFloat{}},
+		{
+			val: TjsontagsComplex{
+				Complex1: 1i,
+				Complex2: 2i,
+				Complex3: 3i,
+				Complex4: 4i,
+				Complex5: 5i,
+				Complex6: 6i,
+			},
+			exp: `{"complex1":"(0+1i)","-":"(0+3i)","complex4":"(0+4i)","Complex5":"(0+5i)","Complex6":"(0+6i)"}`,
+		},
+		{
+			val: TjsontagsComplex{},
+			exp: `{"complex1":"(0+0i)","-":"(0+0i)","Complex5":"(0+0i)"}`,
+		},
+		{
+			val: TjsontagsPtr{
+				Ptr1: newStr("1"),
+				Ptr2: newStr("2"),
+				Ptr3: newStr("3"),
+				Ptr4: newStr("4"),
+				Ptr5: newStr("5"),
+				Ptr6: newStr("6"),
+			},
+		},
+		{val: TjsontagsPtr{}},
+		{
+			val: TjsontagsArray{
+				Array1: [2]string{"v1", "v1"},
+				Array2: [2]string{"v2", "v2"},
+				Array3: [2]string{"v3", "v3"},
+				Array4: [2]string{"v4", "v4"},
+				Array5: [2]string{"v5", "v5"},
+				Array6: [2]string{"v6", "v6"},
+			},
+		},
+		{val: TjsontagsArray{}},
+		{
+			val: TjsontagsSlice{
+				Slice1: []string{"v1", "v1"},
+				Slice2: []string{"v2", "v2"},
+				Slice3: []string{"v3", "v3"},
+				Slice4: []string{"v4", "v4"},
+				Slice5: []string{"v5", "v5"},
+				Slice6: []string{"v6", "v6"},
+			},
+		},
+		{
+			val: TjsontagsSlice{},
+			exp: `{"slice1":[],"-":[],"Slice5":[]}`,
+		},
+		{
+			val: TjsontagsMap{
+				Map1: map[string]string{"k1": "v1"},
+				Map2: map[string]string{"k2": "v2"},
+				Map3: map[string]string{"k3": "v3"},
+				Map4: map[string]string{"k4": "v4"},
+				Map5: map[string]string{"k5": "v5"},
+				Map6: map[string]string{"k6": "v6"},
+			},
+		},
+		{
+			val: TjsontagsMap{},
+			exp: `{"map1":{},"-":{},"Map5":{}}`,
+		},
+		{val: Tembedstruct{}},
+		{
+			val: Tembednonstruct{},
+			exp: `{"Tinnerint":0,"Tinnermap":{},"Tinnerslice":[]}`,
+		},
+		{val: Tembedjsontags{}},
+		{
+			val: PseudoStruct(makeKV("f1", 1, "f2", true, "f3", []int{})),
+			exp: `{"f1":1,"f2":true,"f3":[]}`,
+		},
+		{
+			val: map[TjsontagsString]int{
+				{String1: `"quoted"`, String4: `unquoted`}: 1,
+			},
+			exp: `{"{\"string1\":\"\\\"quoted\\\"\",\"-\":\"\",\"string4\":\"unquoted\",\"String5\":\"\"}":1}`,
+		},
+		{
+			val: map[TjsontagsInt]int{
+				{Int1: 1, Int2: 2}: 3,
+			},
+			exp: `{"{\"int1\":1,\"-\":0,\"Int5\":0}":3}`,
+		},
+		{
+			val: map[[2]struct{ S string }]int{
+				{{S: `"quoted"`}, {S: "unquoted"}}: 1,
+			},
+			exp: `{"[{\"S\":\"\\\"quoted\\\"\"},{\"S\":\"unquoted\"}]":1}`,
+		},
+	}
+
+	f := NewFormatter(Options{})
+	for i, tc := range cases {
+		ours := f.pretty(tc.val)
+		want := ""
+		if tc.exp != "" {
+			want = tc.exp
+		} else {
+			jb, err := json.Marshal(tc.val)
+			if err != nil {
+				t.Fatalf("[%d]: unexpected error: %v\ngot: %q", i, err, ours)
+			}
+			want = string(jb)
+		}
+		if ours != want {
+			t.Errorf("[%d]:\n\texpected %q\n\tgot      %q", i, want, ours)
+		}
+	}
+}
+
+func makeKV(args ...interface{}) []interface{} {
+	return args
+}
+
+func TestRender(t *testing.T) {
+	testCases := []struct {
+		name       string
+		builtins   []interface{}
+		values     []interface{}
+		args       []interface{}
+		expectKV   string
+		expectJSON string
+	}{{
+		name:       "nil",
+		expectKV:   "",
+		expectJSON: "{}",
+	}, {
+		name:       "empty",
+		builtins:   []interface{}{},
+		values:     []interface{}{},
+		args:       []interface{}{},
+		expectKV:   "",
+		expectJSON: "{}",
+	}, {
+		name:       "primitives",
+		builtins:   makeKV("int1", 1, "int2", 2),
+		values:     makeKV("str1", "ABC", "str2", "DEF"),
+		args:       makeKV("bool1", true, "bool2", false),
+		expectKV:   `"int1"=1 "int2"=2 "str1"="ABC" "str2"="DEF" "bool1"=true "bool2"=false`,
+		expectJSON: `{"int1":1,"int2":2,"str1":"ABC","str2":"DEF","bool1":true,"bool2":false}`,
+	}, {
+		name:       "pseudo structs",
+		builtins:   makeKV("int", PseudoStruct(makeKV("intsub", 1))),
+		values:     makeKV("str", PseudoStruct(makeKV("strsub", "2"))),
+		args:       makeKV("bool", PseudoStruct(makeKV("boolsub", true))),
+		expectKV:   `"int"={"intsub":1} "str"={"strsub":"2"} "bool"={"boolsub":true}`,
+		expectJSON: `{"int":{"intsub":1},"str":{"strsub":"2"},"bool":{"boolsub":true}}`,
+	}, {
+		name:       "escapes",
+		builtins:   makeKV("\"1\"", 1),     // will not be escaped, but should never happen
+		values:     makeKV("\tstr", "ABC"), // escaped
+		args:       makeKV("bool\n", true), // escaped
+		expectKV:   `""1""=1 "\tstr"="ABC" "bool\n"=true`,
+		expectJSON: `{""1"":1,"\tstr":"ABC","bool\n":true}`,
+	}, {
+		name:       "missing value",
+		builtins:   makeKV("builtin"),
+		values:     makeKV("value"),
+		args:       makeKV("arg"),
+		expectKV:   `"builtin"="<no-value>" "value"="<no-value>" "arg"="<no-value>"`,
+		expectJSON: `{"builtin":"<no-value>","value":"<no-value>","arg":"<no-value>"}`,
+	}, {
+		name:       "non-string key int",
+		builtins:   makeKV(123, "val"), // should never happen
+		values:     makeKV(456, "val"),
+		args:       makeKV(789, "val"),
+		expectKV:   `"<non-string-key: 123>"="val" "<non-string-key: 456>"="val" "<non-string-key: 789>"="val"`,
+		expectJSON: `{"<non-string-key: 123>":"val","<non-string-key: 456>":"val","<non-string-key: 789>":"val"}`,
+	}, {
+		name: "non-string key struct",
+		builtins: makeKV(struct { // will not be escaped, but should never happen
+			F1 string
+			F2 int
+		}{"builtin", 123}, "val"),
+		values: makeKV(struct {
+			F1 string
+			F2 int
+		}{"value", 456}, "val"),
+		args: makeKV(struct {
+			F1 string
+			F2 int
+		}{"arg", 789}, "val"),
+		expectKV:   `"<non-string-key: {"F1":"builtin",>"="val" "<non-string-key: {\"F1\":\"value\",\"F>"="val" "<non-string-key: {\"F1\":\"arg\",\"F2\">"="val"`,
+		expectJSON: `{"<non-string-key: {"F1":"builtin",>":"val","<non-string-key: {\"F1\":\"value\",\"F>":"val","<non-string-key: {\"F1\":\"arg\",\"F2\">":"val"}`,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			test := func(t *testing.T, formatter Formatter, expect string) {
+				formatter.AddValues(tc.values)
+				r := formatter.render(tc.builtins, tc.args)
+				if r != expect {
+					t.Errorf("wrong output:\nexpected %v\n     got %v", expect, r)
+				}
+			}
+			t.Run("KV", func(t *testing.T) {
+				test(t, NewFormatter(Options{}), tc.expectKV)
+			})
+			t.Run("JSON", func(t *testing.T) {
+				test(t, NewFormatterJSON(Options{}), tc.expectJSON)
+			})
+		})
+	}
+}
+
+func TestSanitize(t *testing.T) {
+	testCases := []struct {
+		name   string
+		kv     []interface{}
+		expect []interface{}
+	}{{
+		name:   "empty",
+		kv:     []interface{}{},
+		expect: []interface{}{},
+	}, {
+		name:   "already sane",
+		kv:     makeKV("int", 1, "str", "ABC", "bool", true),
+		expect: makeKV("int", 1, "str", "ABC", "bool", true),
+	}, {
+		name:   "missing value",
+		kv:     makeKV("key"),
+		expect: makeKV("key", "<no-value>"),
+	}, {
+		name:   "non-string key int",
+		kv:     makeKV(123, "val"),
+		expect: makeKV("<non-string-key: 123>", "val"),
+	}, {
+		name: "non-string key struct",
+		kv: makeKV(struct {
+			F1 string
+			F2 int
+		}{"f1", 8675309}, "val"),
+		expect: makeKV(`<non-string-key: {"F1":"f1","F2":>`, "val"),
+	}}
+
+	f := NewFormatterJSON(Options{})
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := f.sanitize(tc.kv)
+			if !reflect.DeepEqual(r, tc.expect) {
+				t.Errorf("wrong output:\nexpected %q\n     got %q", tc.expect, r)
+			}
+		})
+	}
+}
+
+func TestEnabled(t *testing.T) {
+	t.Run("default V", func(t *testing.T) {
+		log := newSink(func(prefix, args string) {}, NewFormatter(Options{}))
+		if !log.Enabled(0) {
+			t.Errorf("expected true")
+		}
+		if log.Enabled(1) {
+			t.Errorf("expected false")
+		}
+	})
+	t.Run("V=9", func(t *testing.T) {
+		log := newSink(func(prefix, args string) {}, NewFormatter(Options{Verbosity: 9}))
+		if !log.Enabled(8) {
+			t.Errorf("expected true")
+		}
+		if !log.Enabled(9) {
+			t.Errorf("expected true")
+		}
+		if log.Enabled(10) {
+			t.Errorf("expected false")
+		}
+	})
+}
+
+type capture struct {
+	log string
+}
+
+func (c *capture) Func(prefix, args string) {
+	c.log = prefix + " " + args
+}
+
+func TestInfo(t *testing.T) {
+	testCases := []struct {
+		name   string
+		args   []interface{}
+		expect string
+	}{{
+		name:   "just msg",
+		args:   makeKV(),
+		expect: ` "level"=0 "msg"="msg"`,
+	}, {
+		name:   "primitives",
+		args:   makeKV("int", 1, "str", "ABC", "bool", true),
+		expect: ` "level"=0 "msg"="msg" "int"=1 "str"="ABC" "bool"=true`,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := &capture{}
+			sink := newSink(cap.Func, NewFormatter(Options{}))
+			sink.Info(0, "msg", tc.args...)
+			if cap.log != tc.expect {
+				t.Errorf("\nexpected %q\n     got %q", tc.expect, cap.log)
+			}
+		})
+	}
+}
+
+func TestInfoWithCaller(t *testing.T) {
+	t.Run("LogCaller=All", func(t *testing.T) {
+		cap := &capture{}
+		sink := newSink(cap.Func, NewFormatter(Options{LogCaller: All}))
+		sink.Info(0, "msg")
+		_, file, line, _ := runtime.Caller(0)
+		expect := fmt.Sprintf(` "caller"={"file":%q,"line":%d} "level"=0 "msg"="msg"`, filepath.Base(file), line-1)
+		if cap.log != expect {
+			t.Errorf("\nexpected %q\n     got %q", expect, cap.log)
+		}
+		sink.Error(fmt.Errorf("error"), "msg")
+		_, file, line, _ = runtime.Caller(0)
+		expect = fmt.Sprintf(` "caller"={"file":%q,"line":%d} "msg"="msg" "error"="error"`, filepath.Base(file), line-1)
+		if cap.log != expect {
+			t.Errorf("\nexpected %q\n     got %q", expect, cap.log)
+		}
+	})
+	t.Run("LogCaller=All, LogCallerFunc=true", func(t *testing.T) {
+		thisFunc := "github.com/go-logr/logr/funcr.TestInfoWithCaller.func2"
+		cap := &capture{}
+		sink := newSink(cap.Func, NewFormatter(Options{LogCaller: All, LogCallerFunc: true}))
+		sink.Info(0, "msg")
+		_, file, line, _ := runtime.Caller(0)
+		expect := fmt.Sprintf(` "caller"={"file":%q,"line":%d,"function":%q} "level"=0 "msg"="msg"`, filepath.Base(file), line-1, thisFunc)
+		if cap.log != expect {
+			t.Errorf("\nexpected %q\n     got %q", expect, cap.log)
+		}
+		sink.Error(fmt.Errorf("error"), "msg")
+		_, file, line, _ = runtime.Caller(0)
+		expect = fmt.Sprintf(` "caller"={"file":%q,"line":%d,"function":%q} "msg"="msg" "error"="error"`, filepath.Base(file), line-1, thisFunc)
+		if cap.log != expect {
+			t.Errorf("\nexpected %q\n     got %q", expect, cap.log)
+		}
+	})
+	t.Run("LogCaller=Info", func(t *testing.T) {
+		cap := &capture{}
+		sink := newSink(cap.Func, NewFormatter(Options{LogCaller: Info}))
+		sink.Info(0, "msg")
+		_, file, line, _ := runtime.Caller(0)
+		expect := fmt.Sprintf(` "caller"={"file":%q,"line":%d} "level"=0 "msg"="msg"`, filepath.Base(file), line-1)
+		if cap.log != expect {
+			t.Errorf("\nexpected %q\n     got %q", expect, cap.log)
+		}
+		sink.Error(fmt.Errorf("error"), "msg")
+		expect = ` "msg"="msg" "error"="error"`
+		if cap.log != expect {
+			t.Errorf("\nexpected %q\n     got %q", expect, cap.log)
+		}
+	})
+	t.Run("LogCaller=Error", func(t *testing.T) {
+		cap := &capture{}
+		sink := newSink(cap.Func, NewFormatter(Options{LogCaller: Error}))
+		sink.Info(0, "msg")
+		expect := ` "level"=0 "msg"="msg"`
+		if cap.log != expect {
+			t.Errorf("\nexpected %q\n     got %q", expect, cap.log)
+		}
+		sink.Error(fmt.Errorf("error"), "msg")
+		_, file, line, _ := runtime.Caller(0)
+		expect = fmt.Sprintf(` "caller"={"file":%q,"line":%d} "msg"="msg" "error"="error"`, filepath.Base(file), line-1)
+		if cap.log != expect {
+			t.Errorf("\nexpected %q\n     got %q", expect, cap.log)
+		}
+	})
+	t.Run("LogCaller=None", func(t *testing.T) {
+		cap := &capture{}
+		sink := newSink(cap.Func, NewFormatter(Options{LogCaller: None}))
+		sink.Info(0, "msg")
+		expect := ` "level"=0 "msg"="msg"`
+		if cap.log != expect {
+			t.Errorf("\nexpected %q\n     got %q", expect, cap.log)
+		}
+		sink.Error(fmt.Errorf("error"), "msg")
+		expect = ` "msg"="msg" "error"="error"`
+		if cap.log != expect {
+			t.Errorf("\nexpected %q\n     got %q", expect, cap.log)
+		}
+	})
+}
+
+func TestError(t *testing.T) {
+	testCases := []struct {
+		name   string
+		args   []interface{}
+		expect string
+	}{{
+		name:   "just msg",
+		args:   makeKV(),
+		expect: ` "msg"="msg" "error"="err"`,
+	}, {
+		name:   "primitives",
+		args:   makeKV("int", 1, "str", "ABC", "bool", true),
+		expect: ` "msg"="msg" "error"="err" "int"=1 "str"="ABC" "bool"=true`,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := &capture{}
+			sink := newSink(cap.Func, NewFormatter(Options{}))
+			sink.Error(fmt.Errorf("err"), "msg", tc.args...)
+			if cap.log != tc.expect {
+				t.Errorf("\nexpected %q\n     got %q", tc.expect, cap.log)
+			}
+		})
+	}
+}
+
+func TestErrorWithCaller(t *testing.T) {
+	t.Run("LogCaller=All", func(t *testing.T) {
+		cap := &capture{}
+		sink := newSink(cap.Func, NewFormatter(Options{LogCaller: All}))
+		sink.Error(fmt.Errorf("err"), "msg")
+		_, file, line, _ := runtime.Caller(0)
+		expect := fmt.Sprintf(` "caller"={"file":%q,"line":%d} "msg"="msg" "error"="err"`, filepath.Base(file), line-1)
+		if cap.log != expect {
+			t.Errorf("\nexpected %q\n     got %q", expect, cap.log)
+		}
+	})
+	t.Run("LogCaller=Error", func(t *testing.T) {
+		cap := &capture{}
+		sink := newSink(cap.Func, NewFormatter(Options{LogCaller: Error}))
+		sink.Error(fmt.Errorf("err"), "msg")
+		_, file, line, _ := runtime.Caller(0)
+		expect := fmt.Sprintf(` "caller"={"file":%q,"line":%d} "msg"="msg" "error"="err"`, filepath.Base(file), line-1)
+		if cap.log != expect {
+			t.Errorf("\nexpected %q\n     got %q", expect, cap.log)
+		}
+	})
+	t.Run("LogCaller=Info", func(t *testing.T) {
+		cap := &capture{}
+		sink := newSink(cap.Func, NewFormatter(Options{LogCaller: Info}))
+		sink.Error(fmt.Errorf("err"), "msg")
+		expect := ` "msg"="msg" "error"="err"`
+		if cap.log != expect {
+			t.Errorf("\nexpected %q\n     got %q", expect, cap.log)
+		}
+	})
+	t.Run("LogCaller=None", func(t *testing.T) {
+		cap := &capture{}
+		sink := newSink(cap.Func, NewFormatter(Options{LogCaller: None}))
+		sink.Error(fmt.Errorf("err"), "msg")
+		expect := ` "msg"="msg" "error"="err"`
+		if cap.log != expect {
+			t.Errorf("\nexpected %q\n     got %q", expect, cap.log)
+		}
+	})
+}
+
+func TestInfoWithName(t *testing.T) {
+	testCases := []struct {
+		name   string
+		names  []string
+		args   []interface{}
+		expect string
+	}{{
+		name:   "one",
+		names:  []string{"pfx1"},
+		args:   makeKV("k", "v"),
+		expect: `pfx1 "level"=0 "msg"="msg" "k"="v"`,
+	}, {
+		name:   "two",
+		names:  []string{"pfx1", "pfx2"},
+		args:   makeKV("k", "v"),
+		expect: `pfx1/pfx2 "level"=0 "msg"="msg" "k"="v"`,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := &capture{}
+			sink := newSink(cap.Func, NewFormatter(Options{}))
+			for _, n := range tc.names {
+				sink = sink.WithName(n)
+			}
+			sink.Info(0, "msg", tc.args...)
+			if cap.log != tc.expect {
+				t.Errorf("\nexpected %q\n     got %q", tc.expect, cap.log)
+			}
+		})
+	}
+}
+
+func TestErrorWithName(t *testing.T) {
+	testCases := []struct {
+		name   string
+		names  []string
+		args   []interface{}
+		expect string
+	}{{
+		name:   "one",
+		names:  []string{"pfx1"},
+		args:   makeKV("k", "v"),
+		expect: `pfx1 "msg"="msg" "error"="err" "k"="v"`,
+	}, {
+		name:   "two",
+		names:  []string{"pfx1", "pfx2"},
+		args:   makeKV("k", "v"),
+		expect: `pfx1/pfx2 "msg"="msg" "error"="err" "k"="v"`,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := &capture{}
+			sink := newSink(cap.Func, NewFormatter(Options{}))
+			for _, n := range tc.names {
+				sink = sink.WithName(n)
+			}
+			sink.Error(fmt.Errorf("err"), "msg", tc.args...)
+			if cap.log != tc.expect {
+				t.Errorf("\nexpected %q\n     got %q", tc.expect, cap.log)
+			}
+		})
+	}
+}
+
+func TestInfoWithValues(t *testing.T) {
+	testCases := []struct {
+		name   string
+		values []interface{}
+		args   []interface{}
+		expect string
+	}{{
+		name:   "zero",
+		values: makeKV(),
+		args:   makeKV("k", "v"),
+		expect: ` "level"=0 "msg"="msg" "k"="v"`,
+	}, {
+		name:   "one",
+		values: makeKV("one", 1),
+		args:   makeKV("k", "v"),
+		expect: ` "level"=0 "msg"="msg" "one"=1 "k"="v"`,
+	}, {
+		name:   "two",
+		values: makeKV("one", 1, "two", 2),
+		args:   makeKV("k", "v"),
+		expect: ` "level"=0 "msg"="msg" "one"=1 "two"=2 "k"="v"`,
+	}, {
+		name:   "dangling",
+		values: makeKV("dangling"),
+		args:   makeKV("k", "v"),
+		expect: ` "level"=0 "msg"="msg" "dangling"="<no-value>" "k"="v"`,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := &capture{}
+			sink := newSink(cap.Func, NewFormatter(Options{}))
+			sink = sink.WithValues(tc.values...)
+			sink.Info(0, "msg", tc.args...)
+			if cap.log != tc.expect {
+				t.Errorf("\nexpected %q\n     got %q", tc.expect, cap.log)
+			}
+		})
+	}
+}
+
+func TestErrorWithValues(t *testing.T) {
+	testCases := []struct {
+		name   string
+		values []interface{}
+		args   []interface{}
+		expect string
+	}{{
+		name:   "zero",
+		values: makeKV(),
+		args:   makeKV("k", "v"),
+		expect: ` "msg"="msg" "error"="err" "k"="v"`,
+	}, {
+		name:   "one",
+		values: makeKV("one", 1),
+		args:   makeKV("k", "v"),
+		expect: ` "msg"="msg" "error"="err" "one"=1 "k"="v"`,
+	}, {
+		name:   "two",
+		values: makeKV("one", 1, "two", 2),
+		args:   makeKV("k", "v"),
+		expect: ` "msg"="msg" "error"="err" "one"=1 "two"=2 "k"="v"`,
+	}, {
+		name:   "dangling",
+		values: makeKV("dangling"),
+		args:   makeKV("k", "v"),
+		expect: ` "msg"="msg" "error"="err" "dangling"="<no-value>" "k"="v"`,
+	}}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cap := &capture{}
+			sink := newSink(cap.Func, NewFormatter(Options{}))
+			sink = sink.WithValues(tc.values...)
+			sink.Error(fmt.Errorf("err"), "msg", tc.args...)
+			if cap.log != tc.expect {
+				t.Errorf("\nexpected %q\n     got %q", tc.expect, cap.log)
+			}
+		})
+	}
+}
+
+func TestInfoWithCallDepth(t *testing.T) {
+	t.Run("one", func(t *testing.T) {
+		cap := &capture{}
+		sink := newSink(cap.Func, NewFormatter(Options{LogCaller: All}))
+		dSink, _ := sink.(v122Logr.CallDepthLogSink)
+		sink = dSink.WithCallDepth(1)
+		sink.Info(0, "msg")
+		_, file, line, _ := runtime.Caller(1)
+		expect := fmt.Sprintf(` "caller"={"file":%q,"line":%d} "level"=0 "msg"="msg"`, filepath.Base(file), line)
+		if cap.log != expect {
+			t.Errorf("\nexpected %q\n     got %q", expect, cap.log)
+		}
+	})
+}
+
+func TestErrorWithCallDepth(t *testing.T) {
+	t.Run("one", func(t *testing.T) {
+		cap := &capture{}
+		sink := newSink(cap.Func, NewFormatter(Options{LogCaller: All}))
+		dSink, _ := sink.(v122Logr.CallDepthLogSink)
+		sink = dSink.WithCallDepth(1)
+		sink.Error(fmt.Errorf("err"), "msg")
+		_, file, line, _ := runtime.Caller(1)
+		expect := fmt.Sprintf(` "caller"={"file":%q,"line":%d} "msg"="msg" "error"="err"`, filepath.Base(file), line)
+		if cap.log != expect {
+			t.Errorf("\nexpected %q\n     got %q", expect, cap.log)
+		}
+	})
+}
+
+func TestOptionsTimestampFormat(t *testing.T) {
+	cap := &capture{}
+	//  This timestamp format contains none of the characters that are
+	//  considered placeholders, so will produce a constant result.
+	sink := newSink(cap.Func, NewFormatter(Options{LogTimestamp: true, TimestampFormat: "TIMESTAMP"}))
+	dSink, _ := sink.(v122Logr.CallDepthLogSink)
+	sink = dSink.WithCallDepth(1)
+	sink.Info(0, "msg")
+	expect := ` "ts"="TIMESTAMP" "level"=0 "msg"="msg"`
+	if cap.log != expect {
+		t.Errorf("\nexpected %q\n     got %q", expect, cap.log)
+	}
+}

--- a/internal/patch/logr/funcr/go.mod
+++ b/internal/patch/logr/funcr/go.mod
@@ -1,0 +1,5 @@
+module github.com/go-logr/logr/funcr
+
+go 1.17
+
+require github.com/go-logr/logr v0.4.0

--- a/internal/patch/logr/funcr/go.sum
+++ b/internal/patch/logr/funcr/go.sum
@@ -1,0 +1,2 @@
+github.com/go-logr/logr v0.4.0 h1:K7/B1jt6fIBQVd4Owv2MqGQClcgf0R266+7C/QjRcLc=
+github.com/go-logr/logr v0.4.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=

--- a/internal/patch/logr/funcr/internal/logr/README.md
+++ b/internal/patch/logr/funcr/internal/logr/README.md
@@ -1,0 +1,8 @@
+### What is this?
+
+This is a copy of the `github.com/go-logr/logr` package from v1.2.2.
+It only includes the files that define the actual code (no examples, testing or benchmark).
+
+### Why is this here?
+
+See the README file on `internal/patch/logr/funcr`.

--- a/internal/patch/logr/funcr/internal/logr/discard.go
+++ b/internal/patch/logr/funcr/internal/logr/discard.go
@@ -1,0 +1,54 @@
+/*
+Copyright 2020 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logr
+
+// Discard returns a Logger that discards all messages logged to it.  It can be
+// used whenever the caller is not interested in the logs.  Logger instances
+// produced by this function always compare as equal.
+func Discard() Logger {
+	return Logger{
+		level: 0,
+		sink:  discardLogSink{},
+	}
+}
+
+// discardLogSink is a LogSink that discards all messages.
+type discardLogSink struct{}
+
+// Verify that it actually implements the interface
+var _ LogSink = discardLogSink{}
+
+func (l discardLogSink) Init(RuntimeInfo) {
+}
+
+func (l discardLogSink) Enabled(int) bool {
+	return false
+}
+
+func (l discardLogSink) Info(int, string, ...interface{}) {
+}
+
+func (l discardLogSink) Error(error, string, ...interface{}) {
+}
+
+func (l discardLogSink) WithValues(...interface{}) LogSink {
+	return l
+}
+
+func (l discardLogSink) WithName(string) LogSink {
+	return l
+}

--- a/internal/patch/logr/funcr/internal/logr/discard_test.go
+++ b/internal/patch/logr/funcr/internal/logr/discard_test.go
@@ -1,0 +1,49 @@
+/*
+Copyright 2020 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logr
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestDiscard(t *testing.T) {
+	l := Discard()
+	if _, ok := l.GetSink().(discardLogSink); !ok {
+		t.Error("did not return the expected underlying type")
+	}
+	// Verify that none of the methods panic, there is not more we can test.
+	l.WithName("discard").WithValues("z", 5).Info("Hello world")
+	l.Info("Hello world", "x", 1, "y", 2)
+	l.V(1).Error(errors.New("foo"), "a", 123)
+	if l.Enabled() {
+		t.Error("discardLogSink must always say it is disabled")
+	}
+}
+
+func TestComparable(t *testing.T) {
+	a := Discard()
+	if !reflect.TypeOf(a).Comparable() {
+		t.Fatal("discardLogSink must be comparable")
+	}
+
+	b := Discard()
+	if a != b {
+		t.Fatal("any two discardLogSink must be equal")
+	}
+}

--- a/internal/patch/logr/funcr/internal/logr/logr.go
+++ b/internal/patch/logr/funcr/internal/logr/logr.go
@@ -1,0 +1,510 @@
+/*
+Copyright 2019 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// This design derives from Dave Cheney's blog:
+//     http://dave.cheney.net/2015/11/05/lets-talk-about-logging
+
+// Package logr defines a general-purpose logging API and abstract interfaces
+// to back that API.  Packages in the Go ecosystem can depend on this package,
+// while callers can implement logging with whatever backend is appropriate.
+//
+// Usage
+//
+// Logging is done using a Logger instance.  Logger is a concrete type with
+// methods, which defers the actual logging to a LogSink interface.  The main
+// methods of Logger are Info() and Error().  Arguments to Info() and Error()
+// are key/value pairs rather than printf-style formatted strings, emphasizing
+// "structured logging".
+//
+// With Go's standard log package, we might write:
+//   log.Printf("setting target value %s", targetValue)
+//
+// With logr's structured logging, we'd write:
+//   logger.Info("setting target", "value", targetValue)
+//
+// Errors are much the same.  Instead of:
+//   log.Printf("failed to open the pod bay door for user %s: %v", user, err)
+//
+// We'd write:
+//   logger.Error(err, "failed to open the pod bay door", "user", user)
+//
+// Info() and Error() are very similar, but they are separate methods so that
+// LogSink implementations can choose to do things like attach additional
+// information (such as stack traces) on calls to Error(). Error() messages are
+// always logged, regardless of the current verbosity.  If there is no error
+// instance available, passing nil is valid.
+//
+// Verbosity
+//
+// Often we want to log information only when the application in "verbose
+// mode".  To write log lines that are more verbose, Logger has a V() method.
+// The higher the V-level of a log line, the less critical it is considered.
+// Log-lines with V-levels that are not enabled (as per the LogSink) will not
+// be written.  Level V(0) is the default, and logger.V(0).Info() has the same
+// meaning as logger.Info().  Negative V-levels have the same meaning as V(0).
+// Error messages do not have a verbosity level and are always logged.
+//
+// Where we might have written:
+//   if flVerbose >= 2 {
+//       log.Printf("an unusual thing happened")
+//   }
+//
+// We can write:
+//   logger.V(2).Info("an unusual thing happened")
+//
+// Logger Names
+//
+// Logger instances can have name strings so that all messages logged through
+// that instance have additional context.  For example, you might want to add
+// a subsystem name:
+//
+//   logger.WithName("compactor").Info("started", "time", time.Now())
+//
+// The WithName() method returns a new Logger, which can be passed to
+// constructors or other functions for further use.  Repeated use of WithName()
+// will accumulate name "segments".  These name segments will be joined in some
+// way by the LogSink implementation.  It is strongly recommended that name
+// segments contain simple identifiers (letters, digits, and hyphen), and do
+// not contain characters that could muddle the log output or confuse the
+// joining operation (e.g. whitespace, commas, periods, slashes, brackets,
+// quotes, etc).
+//
+// Saved Values
+//
+// Logger instances can store any number of key/value pairs, which will be
+// logged alongside all messages logged through that instance.  For example,
+// you might want to create a Logger instance per managed object:
+//
+// With the standard log package, we might write:
+//   log.Printf("decided to set field foo to value %q for object %s/%s",
+//       targetValue, object.Namespace, object.Name)
+//
+// With logr we'd write:
+//   // Elsewhere: set up the logger to log the object name.
+//   obj.logger = mainLogger.WithValues(
+//       "name", obj.name, "namespace", obj.namespace)
+//
+//   // later on...
+//   obj.logger.Info("setting foo", "value", targetValue)
+//
+// Best Practices
+//
+// Logger has very few hard rules, with the goal that LogSink implementations
+// might have a lot of freedom to differentiate.  There are, however, some
+// things to consider.
+//
+// The log message consists of a constant message attached to the log line.
+// This should generally be a simple description of what's occurring, and should
+// never be a format string.  Variable information can then be attached using
+// named values.
+//
+// Keys are arbitrary strings, but should generally be constant values.  Values
+// may be any Go value, but how the value is formatted is determined by the
+// LogSink implementation.
+//
+// Logger instances are meant to be passed around by value. Code that receives
+// such a value can call its methods without having to check whether the
+// instance is ready for use.
+//
+// Calling methods with the null logger (Logger{}) as instance will crash
+// because it has no LogSink. Therefore this null logger should never be passed
+// around. For cases where passing a logger is optional, a pointer to Logger
+// should be used.
+//
+// Key Naming Conventions
+//
+// Keys are not strictly required to conform to any specification or regex, but
+// it is recommended that they:
+//   * be human-readable and meaningful (not auto-generated or simple ordinals)
+//   * be constant (not dependent on input data)
+//   * contain only printable characters
+//   * not contain whitespace or punctuation
+//   * use lower case for simple keys and lowerCamelCase for more complex ones
+//
+// These guidelines help ensure that log data is processed properly regardless
+// of the log implementation.  For example, log implementations will try to
+// output JSON data or will store data for later database (e.g. SQL) queries.
+//
+// While users are generally free to use key names of their choice, it's
+// generally best to avoid using the following keys, as they're frequently used
+// by implementations:
+//   * "caller": the calling information (file/line) of a particular log line
+//   * "error": the underlying error value in the `Error` method
+//   * "level": the log level
+//   * "logger": the name of the associated logger
+//   * "msg": the log message
+//   * "stacktrace": the stack trace associated with a particular log line or
+//                   error (often from the `Error` message)
+//   * "ts": the timestamp for a log line
+//
+// Implementations are encouraged to make use of these keys to represent the
+// above concepts, when necessary (for example, in a pure-JSON output form, it
+// would be necessary to represent at least message and timestamp as ordinary
+// named values).
+//
+// Break Glass
+//
+// Implementations may choose to give callers access to the underlying
+// logging implementation.  The recommended pattern for this is:
+//   // Underlier exposes access to the underlying logging implementation.
+//   // Since callers only have a logr.Logger, they have to know which
+//   // implementation is in use, so this interface is less of an abstraction
+//   // and more of way to test type conversion.
+//   type Underlier interface {
+//       GetUnderlying() <underlying-type>
+//   }
+//
+// Logger grants access to the sink to enable type assertions like this:
+//   func DoSomethingWithImpl(log logr.Logger) {
+//       if underlier, ok := log.GetSink()(impl.Underlier) {
+//          implLogger := underlier.GetUnderlying()
+//          ...
+//       }
+//   }
+//
+// Custom `With*` functions can be implemented by copying the complete
+// Logger struct and replacing the sink in the copy:
+//   // WithFooBar changes the foobar parameter in the log sink and returns a
+//   // new logger with that modified sink.  It does nothing for loggers where
+//   // the sink doesn't support that parameter.
+//   func WithFoobar(log logr.Logger, foobar int) logr.Logger {
+//      if foobarLogSink, ok := log.GetSink()(FoobarSink); ok {
+//         log = log.WithSink(foobarLogSink.WithFooBar(foobar))
+//      }
+//      return log
+//   }
+//
+// Don't use New to construct a new Logger with a LogSink retrieved from an
+// existing Logger. Source code attribution might not work correctly and
+// unexported fields in Logger get lost.
+//
+// Beware that the same LogSink instance may be shared by different logger
+// instances. Calling functions that modify the LogSink will affect all of
+// those.
+package logr
+
+import (
+	"context"
+)
+
+// New returns a new Logger instance.  This is primarily used by libraries
+// implementing LogSink, rather than end users.
+func New(sink LogSink) Logger {
+	logger := Logger{}
+	logger.setSink(sink)
+	sink.Init(runtimeInfo)
+	return logger
+}
+
+// setSink stores the sink and updates any related fields. It mutates the
+// logger and thus is only safe to use for loggers that are not currently being
+// used concurrently.
+func (l *Logger) setSink(sink LogSink) {
+	l.sink = sink
+}
+
+// GetSink returns the stored sink.
+func (l Logger) GetSink() LogSink {
+	return l.sink
+}
+
+// WithSink returns a copy of the logger with the new sink.
+func (l Logger) WithSink(sink LogSink) Logger {
+	l.setSink(sink)
+	return l
+}
+
+// Logger is an interface to an abstract logging implementation.  This is a
+// concrete type for performance reasons, but all the real work is passed on to
+// a LogSink.  Implementations of LogSink should provide their own constructors
+// that return Logger, not LogSink.
+//
+// The underlying sink can be accessed through GetSink and be modified through
+// WithSink. This enables the implementation of custom extensions (see "Break
+// Glass" in the package documentation). Normally the sink should be used only
+// indirectly.
+type Logger struct {
+	sink  LogSink
+	level int
+}
+
+// Enabled tests whether this Logger is enabled.  For example, commandline
+// flags might be used to set the logging verbosity and disable some info logs.
+func (l Logger) Enabled() bool {
+	return l.sink.Enabled(l.level)
+}
+
+// Info logs a non-error message with the given key/value pairs as context.
+//
+// The msg argument should be used to add some constant description to the log
+// line.  The key/value pairs can then be used to add additional variable
+// information.  The key/value pairs must alternate string keys and arbitrary
+// values.
+func (l Logger) Info(msg string, keysAndValues ...interface{}) {
+	if l.Enabled() {
+		if withHelper, ok := l.sink.(CallStackHelperLogSink); ok {
+			withHelper.GetCallStackHelper()()
+		}
+		l.sink.Info(l.level, msg, keysAndValues...)
+	}
+}
+
+// Error logs an error, with the given message and key/value pairs as context.
+// It functions similarly to Info, but may have unique behavior, and should be
+// preferred for logging errors (see the package documentations for more
+// information). The log message will always be emitted, regardless of
+// verbosity level.
+//
+// The msg argument should be used to add context to any underlying error,
+// while the err argument should be used to attach the actual error that
+// triggered this log line, if present. The err parameter is optional
+// and nil may be passed instead of an error instance.
+func (l Logger) Error(err error, msg string, keysAndValues ...interface{}) {
+	if withHelper, ok := l.sink.(CallStackHelperLogSink); ok {
+		withHelper.GetCallStackHelper()()
+	}
+	l.sink.Error(err, msg, keysAndValues...)
+}
+
+// V returns a new Logger instance for a specific verbosity level, relative to
+// this Logger.  In other words, V-levels are additive.  A higher verbosity
+// level means a log message is less important.  Negative V-levels are treated
+// as 0.
+func (l Logger) V(level int) Logger {
+	if level < 0 {
+		level = 0
+	}
+	l.level += level
+	return l
+}
+
+// WithValues returns a new Logger instance with additional key/value pairs.
+// See Info for documentation on how key/value pairs work.
+func (l Logger) WithValues(keysAndValues ...interface{}) Logger {
+	l.setSink(l.sink.WithValues(keysAndValues...))
+	return l
+}
+
+// WithName returns a new Logger instance with the specified name element added
+// to the Logger's name.  Successive calls with WithName append additional
+// suffixes to the Logger's name.  It's strongly recommended that name segments
+// contain only letters, digits, and hyphens (see the package documentation for
+// more information).
+func (l Logger) WithName(name string) Logger {
+	l.setSink(l.sink.WithName(name))
+	return l
+}
+
+// WithCallDepth returns a Logger instance that offsets the call stack by the
+// specified number of frames when logging call site information, if possible.
+// This is useful for users who have helper functions between the "real" call
+// site and the actual calls to Logger methods.  If depth is 0 the attribution
+// should be to the direct caller of this function.  If depth is 1 the
+// attribution should skip 1 call frame, and so on.  Successive calls to this
+// are additive.
+//
+// If the underlying log implementation supports a WithCallDepth(int) method,
+// it will be called and the result returned.  If the implementation does not
+// support CallDepthLogSink, the original Logger will be returned.
+//
+// To skip one level, WithCallStackHelper() should be used instead of
+// WithCallDepth(1) because it works with implementions that support the
+// CallDepthLogSink and/or CallStackHelperLogSink interfaces.
+func (l Logger) WithCallDepth(depth int) Logger {
+	if withCallDepth, ok := l.sink.(CallDepthLogSink); ok {
+		l.setSink(withCallDepth.WithCallDepth(depth))
+	}
+	return l
+}
+
+// WithCallStackHelper returns a new Logger instance that skips the direct
+// caller when logging call site information, if possible.  This is useful for
+// users who have helper functions between the "real" call site and the actual
+// calls to Logger methods and want to support loggers which depend on marking
+// each individual helper function, like loggers based on testing.T.
+//
+// In addition to using that new logger instance, callers also must call the
+// returned function.
+//
+// If the underlying log implementation supports a WithCallDepth(int) method,
+// WithCallDepth(1) will be called to produce a new logger. If it supports a
+// WithCallStackHelper() method, that will be also called. If the
+// implementation does not support either of these, the original Logger will be
+// returned.
+func (l Logger) WithCallStackHelper() (func(), Logger) {
+	var helper func()
+	if withCallDepth, ok := l.sink.(CallDepthLogSink); ok {
+		l.setSink(withCallDepth.WithCallDepth(1))
+	}
+	if withHelper, ok := l.sink.(CallStackHelperLogSink); ok {
+		helper = withHelper.GetCallStackHelper()
+	} else {
+		helper = func() {}
+	}
+	return helper, l
+}
+
+// contextKey is how we find Loggers in a context.Context.
+type contextKey struct{}
+
+// FromContext returns a Logger from ctx or an error if no Logger is found.
+func FromContext(ctx context.Context) (Logger, error) {
+	if v, ok := ctx.Value(contextKey{}).(Logger); ok {
+		return v, nil
+	}
+
+	return Logger{}, notFoundError{}
+}
+
+// notFoundError exists to carry an IsNotFound method.
+type notFoundError struct{}
+
+func (notFoundError) Error() string {
+	return "no logr.Logger was present"
+}
+
+func (notFoundError) IsNotFound() bool {
+	return true
+}
+
+// FromContextOrDiscard returns a Logger from ctx.  If no Logger is found, this
+// returns a Logger that discards all log messages.
+func FromContextOrDiscard(ctx context.Context) Logger {
+	if v, ok := ctx.Value(contextKey{}).(Logger); ok {
+		return v
+	}
+
+	return Discard()
+}
+
+// NewContext returns a new Context, derived from ctx, which carries the
+// provided Logger.
+func NewContext(ctx context.Context, logger Logger) context.Context {
+	return context.WithValue(ctx, contextKey{}, logger)
+}
+
+// RuntimeInfo holds information that the logr "core" library knows which
+// LogSinks might want to know.
+type RuntimeInfo struct {
+	// CallDepth is the number of call frames the logr library adds between the
+	// end-user and the LogSink.  LogSink implementations which choose to print
+	// the original logging site (e.g. file & line) should climb this many
+	// additional frames to find it.
+	CallDepth int
+}
+
+// runtimeInfo is a static global.  It must not be changed at run time.
+var runtimeInfo = RuntimeInfo{
+	CallDepth: 1,
+}
+
+// LogSink represents a logging implementation.  End-users will generally not
+// interact with this type.
+type LogSink interface {
+	// Init receives optional information about the logr library for LogSink
+	// implementations that need it.
+	Init(info RuntimeInfo)
+
+	// Enabled tests whether this LogSink is enabled at the specified V-level.
+	// For example, commandline flags might be used to set the logging
+	// verbosity and disable some info logs.
+	Enabled(level int) bool
+
+	// Info logs a non-error message with the given key/value pairs as context.
+	// The level argument is provided for optional logging.  This method will
+	// only be called when Enabled(level) is true. See Logger.Info for more
+	// details.
+	Info(level int, msg string, keysAndValues ...interface{})
+
+	// Error logs an error, with the given message and key/value pairs as
+	// context.  See Logger.Error for more details.
+	Error(err error, msg string, keysAndValues ...interface{})
+
+	// WithValues returns a new LogSink with additional key/value pairs.  See
+	// Logger.WithValues for more details.
+	WithValues(keysAndValues ...interface{}) LogSink
+
+	// WithName returns a new LogSink with the specified name appended.  See
+	// Logger.WithName for more details.
+	WithName(name string) LogSink
+}
+
+// CallDepthLogSink represents a Logger that knows how to climb the call stack
+// to identify the original call site and can offset the depth by a specified
+// number of frames.  This is useful for users who have helper functions
+// between the "real" call site and the actual calls to Logger methods.
+// Implementations that log information about the call site (such as file,
+// function, or line) would otherwise log information about the intermediate
+// helper functions.
+//
+// This is an optional interface and implementations are not required to
+// support it.
+type CallDepthLogSink interface {
+	// WithCallDepth returns a LogSink that will offset the call
+	// stack by the specified number of frames when logging call
+	// site information.
+	//
+	// If depth is 0, the LogSink should skip exactly the number
+	// of call frames defined in RuntimeInfo.CallDepth when Info
+	// or Error are called, i.e. the attribution should be to the
+	// direct caller of Logger.Info or Logger.Error.
+	//
+	// If depth is 1 the attribution should skip 1 call frame, and so on.
+	// Successive calls to this are additive.
+	WithCallDepth(depth int) LogSink
+}
+
+// CallStackHelperLogSink represents a Logger that knows how to climb
+// the call stack to identify the original call site and can skip
+// intermediate helper functions if they mark themselves as
+// helper. Go's testing package uses that approach.
+//
+// This is useful for users who have helper functions between the
+// "real" call site and the actual calls to Logger methods.
+// Implementations that log information about the call site (such as
+// file, function, or line) would otherwise log information about the
+// intermediate helper functions.
+//
+// This is an optional interface and implementations are not required
+// to support it. Implementations that choose to support this must not
+// simply implement it as WithCallDepth(1), because
+// Logger.WithCallStackHelper will call both methods if they are
+// present. This should only be implemented for LogSinks that actually
+// need it, as with testing.T.
+type CallStackHelperLogSink interface {
+	// GetCallStackHelper returns a function that must be called
+	// to mark the direct caller as helper function when logging
+	// call site information.
+	GetCallStackHelper() func()
+}
+
+// Marshaler is an optional interface that logged values may choose to
+// implement. Loggers with structured output, such as JSON, should
+// log the object return by the MarshalLog method instead of the
+// original value.
+type Marshaler interface {
+	// MarshalLog can be used to:
+	//   - ensure that structs are not logged as strings when the original
+	//     value has a String method: return a different type without a
+	//     String method
+	//   - select which fields of a complex type should get logged:
+	//     return a simpler struct with fewer fields
+	//   - log unexported fields: return a different struct
+	//     with exported fields
+	//
+	// It may return any value of any type.
+	MarshalLog() interface{}
+}

--- a/internal/patch/logr/funcr/internal/logr/logr_test.go
+++ b/internal/patch/logr/funcr/internal/logr/logr_test.go
@@ -1,0 +1,402 @@
+/*
+Copyright 2021 The logr Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package logr
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+// testLogSink is a Logger just for testing that calls optional hooks on each method.
+type testLogSink struct {
+	fnInit       func(ri RuntimeInfo)
+	fnEnabled    func(lvl int) bool
+	fnInfo       func(lvl int, msg string, kv ...interface{})
+	fnError      func(err error, msg string, kv ...interface{})
+	fnWithValues func(kv ...interface{})
+	fnWithName   func(name string)
+}
+
+var _ LogSink = &testLogSink{}
+
+func (l *testLogSink) Init(ri RuntimeInfo) {
+	if l.fnInit != nil {
+		l.fnInit(ri)
+	}
+}
+
+func (l *testLogSink) Enabled(lvl int) bool {
+	if l.fnEnabled != nil {
+		return l.fnEnabled(lvl)
+	}
+	return false
+}
+
+func (l *testLogSink) Info(lvl int, msg string, kv ...interface{}) {
+	if l.fnInfo != nil {
+		l.fnInfo(lvl, msg, kv...)
+	}
+}
+
+func (l *testLogSink) Error(err error, msg string, kv ...interface{}) {
+	if l.fnError != nil {
+		l.fnError(err, msg, kv...)
+	}
+}
+
+func (l *testLogSink) WithValues(kv ...interface{}) LogSink {
+	if l.fnWithValues != nil {
+		l.fnWithValues(kv...)
+	}
+	out := *l
+	return &out
+}
+
+func (l *testLogSink) WithName(name string) LogSink {
+	if l.fnWithName != nil {
+		l.fnWithName(name)
+	}
+	out := *l
+	return &out
+}
+
+type testCallDepthLogSink struct {
+	testLogSink
+	callDepth       int
+	fnWithCallDepth func(depth int)
+}
+
+var _ CallDepthLogSink = &testCallDepthLogSink{}
+
+func (l *testCallDepthLogSink) WithCallDepth(depth int) LogSink {
+	if l.fnWithCallDepth != nil {
+		l.fnWithCallDepth(depth)
+	}
+	out := *l
+	out.callDepth += depth
+	return &out
+}
+
+func TestNew(t *testing.T) {
+	calledInit := 0
+
+	sink := &testLogSink{}
+	sink.fnInit = func(ri RuntimeInfo) {
+		if ri.CallDepth != 1 {
+			t.Errorf("expected runtimeInfo.CallDepth = 1, got %d", ri.CallDepth)
+		}
+		calledInit++
+	}
+	logger := New(sink)
+
+	if logger.sink == nil {
+		t.Errorf("expected sink to be set, got %v", logger.sink)
+	}
+	if calledInit != 1 {
+		t.Errorf("expected sink.Init() to be called once, got %d", calledInit)
+	}
+	if _, ok := logger.sink.(CallDepthLogSink); ok {
+		t.Errorf("expected conversion to CallDepthLogSink to fail")
+	}
+}
+
+func TestNewCachesCallDepthInterface(t *testing.T) {
+	sink := &testCallDepthLogSink{}
+	logger := New(sink)
+
+	if _, ok := logger.sink.(CallDepthLogSink); !ok {
+		t.Errorf("expected conversion to CallDepthLogSink to succeed")
+	}
+}
+
+func TestEnabled(t *testing.T) {
+	calledEnabled := 0
+
+	sink := &testLogSink{}
+	sink.fnEnabled = func(lvl int) bool {
+		calledEnabled++
+		return true
+	}
+	logger := New(sink)
+
+	if en := logger.Enabled(); en != true {
+		t.Errorf("expected true")
+	}
+	if calledEnabled != 1 {
+		t.Errorf("expected sink.Enabled() to be called once, got %d", calledEnabled)
+	}
+}
+
+func TestError(t *testing.T) {
+	calledError := 0
+	errInput := fmt.Errorf("error")
+	msgInput := "msg"
+	kvInput := []interface{}{0, 1, 2}
+
+	sink := &testLogSink{}
+	sink.fnError = func(err error, msg string, kv ...interface{}) {
+		calledError++
+		if err != errInput {
+			t.Errorf("unexpected err input, got %v", err)
+		}
+		if msg != msgInput {
+			t.Errorf("unexpected msg input, got %q", msg)
+		}
+		if !reflect.DeepEqual(kv, kvInput) {
+			t.Errorf("unexpected kv input, got %v", kv)
+		}
+	}
+	logger := New(sink)
+
+	logger.Error(errInput, msgInput, kvInput...)
+	if calledError != 1 {
+		t.Errorf("expected sink.Error() to be called once, got %d", calledError)
+	}
+}
+
+func TestV(t *testing.T) {
+	sink := &testLogSink{}
+	logger := New(sink)
+
+	if l := logger.V(0); l.level != 0 {
+		t.Errorf("expected level 0, got %d", l.level)
+	}
+	if l := logger.V(93); l.level != 93 {
+		t.Errorf("expected level 93, got %d", l.level)
+	}
+	if l := logger.V(70).V(6); l.level != 76 {
+		t.Errorf("expected level 76, got %d", l.level)
+	}
+	if l := logger.V(-1); l.level != 0 {
+		t.Errorf("expected level 0, got %d", l.level)
+	}
+	if l := logger.V(1).V(-1); l.level != 1 {
+		t.Errorf("expected level 1, got %d", l.level)
+	}
+}
+
+func TestInfo(t *testing.T) {
+	calledEnabled := 0
+	calledInfo := 0
+	lvlInput := 0
+	msgInput := "msg"
+	kvInput := []interface{}{0, 1, 2}
+
+	sink := &testLogSink{}
+	sink.fnEnabled = func(lvl int) bool {
+		calledEnabled++
+		return lvl < 100
+	}
+	sink.fnInfo = func(lvl int, msg string, kv ...interface{}) {
+		calledInfo++
+		if lvl != lvlInput {
+			t.Errorf("unexpected lvl input, got %v", lvl)
+		}
+		if msg != msgInput {
+			t.Errorf("unexpected msg input, got %q", msg)
+		}
+		if !reflect.DeepEqual(kv, kvInput) {
+			t.Errorf("unexpected kv input, got %v", kv)
+		}
+	}
+	logger := New(sink)
+
+	calledEnabled = 0
+	calledInfo = 0
+	lvlInput = 0
+	logger.Info(msgInput, kvInput...)
+	if calledEnabled != 1 {
+		t.Errorf("expected sink.Enabled() to be called once, got %d", calledEnabled)
+	}
+	if calledInfo != 1 {
+		t.Errorf("expected sink.Info() to be called once, got %d", calledInfo)
+	}
+
+	calledEnabled = 0
+	calledInfo = 0
+	lvlInput = 0
+	logger.V(0).Info(msgInput, kvInput...)
+	if calledEnabled != 1 {
+		t.Errorf("expected sink.Enabled() to be called once, got %d", calledEnabled)
+	}
+	if calledInfo != 1 {
+		t.Errorf("expected sink.Info() to be called once, got %d", calledInfo)
+	}
+
+	calledEnabled = 0
+	calledInfo = 0
+	lvlInput = 93
+	logger.V(93).Info(msgInput, kvInput...)
+	if calledEnabled != 1 {
+		t.Errorf("expected sink.Enabled() to be called once, got %d", calledEnabled)
+	}
+	if calledInfo != 1 {
+		t.Errorf("expected sink.Info() to be called once, got %d", calledInfo)
+	}
+
+	calledEnabled = 0
+	calledInfo = 0
+	lvlInput = 100
+	logger.V(100).Info(msgInput, kvInput...)
+	if calledEnabled != 1 {
+		t.Errorf("expected sink.Enabled() to be called once, got %d", calledEnabled)
+	}
+	if calledInfo != 0 {
+		t.Errorf("expected sink.Info() to not be called, got %d", calledInfo)
+	}
+}
+
+func TestWithValues(t *testing.T) {
+	calledWithValues := 0
+	kvInput := []interface{}{"zero", 0, "one", 1, "two", 2}
+
+	sink := &testLogSink{}
+	sink.fnWithValues = func(kv ...interface{}) {
+		calledWithValues++
+		if !reflect.DeepEqual(kv, kvInput) {
+			t.Errorf("unexpected kv input, got %v", kv)
+		}
+	}
+	logger := New(sink)
+
+	out := logger.WithValues(kvInput...)
+	if calledWithValues != 1 {
+		t.Errorf("expected sink.WithValues() to be called once, got %d", calledWithValues)
+	}
+	if p, _ := out.sink.(*testLogSink); p == sink {
+		t.Errorf("expected output to be different from input, got in=%p, out=%p", sink, p)
+	}
+}
+
+func TestWithName(t *testing.T) {
+	calledWithName := 0
+	nameInput := "name"
+
+	sink := &testLogSink{}
+	sink.fnWithName = func(name string) {
+		calledWithName++
+		if name != nameInput {
+			t.Errorf("unexpected name input, got %q", name)
+		}
+	}
+	logger := New(sink)
+
+	out := logger.WithName(nameInput)
+	if calledWithName != 1 {
+		t.Errorf("expected sink.WithName() to be called once, got %d", calledWithName)
+	}
+	if p, _ := out.sink.(*testLogSink); p == sink {
+		t.Errorf("expected output to be different from input, got in=%p, out=%p", sink, p)
+	}
+}
+
+func TestWithCallDepthNotImplemented(t *testing.T) {
+	depthInput := 7
+
+	sink := &testLogSink{}
+	logger := New(sink)
+
+	out := logger.WithCallDepth(depthInput)
+	if p, _ := out.sink.(*testLogSink); p != sink {
+		t.Errorf("expected output to be the same as input, got in=%p, out=%p", sink, p)
+	}
+}
+
+func TestWithCallDepthImplemented(t *testing.T) {
+	calledWithCallDepth := 0
+	depthInput := 7
+
+	sink := &testCallDepthLogSink{}
+	sink.fnWithCallDepth = func(depth int) {
+		calledWithCallDepth++
+		if depth != depthInput {
+			t.Errorf("unexpected depth input, got %d", depth)
+		}
+	}
+	logger := New(sink)
+
+	out := logger.WithCallDepth(depthInput)
+	if calledWithCallDepth != 1 {
+		t.Errorf("expected sink.WithCallDepth() to be called once, got %d", calledWithCallDepth)
+	}
+	p, _ := out.sink.(*testCallDepthLogSink)
+	if p == sink {
+		t.Errorf("expected output to be different from input, got in=%p, out=%p", sink, p)
+	}
+	if p.callDepth != depthInput {
+		t.Errorf("expected sink to have call depth %d, got %d", depthInput, p.callDepth)
+	}
+}
+
+func TestWithCallDepthIncremental(t *testing.T) {
+	calledWithCallDepth := 0
+	depthInput := 7
+
+	sink := &testCallDepthLogSink{}
+	sink.fnWithCallDepth = func(depth int) {
+		calledWithCallDepth++
+		if depth != 1 {
+			t.Errorf("unexpected depth input, got %d", depth)
+		}
+	}
+	logger := New(sink)
+
+	out := logger
+	for i := 0; i < depthInput; i++ {
+		out = out.WithCallDepth(1)
+	}
+	if calledWithCallDepth != depthInput {
+		t.Errorf("expected sink.WithCallDepth() to be called %d times, got %d", depthInput, calledWithCallDepth)
+	}
+	p, _ := out.sink.(*testCallDepthLogSink)
+	if p == sink {
+		t.Errorf("expected output to be different from input, got in=%p, out=%p", sink, p)
+	}
+	if p.callDepth != depthInput {
+		t.Errorf("expected sink to have call depth %d, got %d", depthInput, p.callDepth)
+	}
+}
+
+func TestContext(t *testing.T) {
+	ctx := context.TODO()
+
+	if out, err := FromContext(ctx); err == nil {
+		t.Errorf("expected error, got %#v", out)
+	} else if _, ok := err.(notFoundError); !ok {
+		t.Errorf("expected a notFoundError, got %#v", err)
+	}
+
+	out := FromContextOrDiscard(ctx)
+	if _, ok := out.sink.(discardLogSink); !ok {
+		t.Errorf("expected a discardLogSink, got %#v", out)
+	}
+
+	sink := &testLogSink{}
+	logger := New(sink)
+	lctx := NewContext(ctx, logger)
+	if out, err := FromContext(lctx); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	} else if p, _ := out.sink.(*testLogSink); p != sink {
+		t.Errorf("expected output to be the same as input, got in=%p, out=%p", sink, p)
+	}
+	out = FromContextOrDiscard(lctx)
+	if p, _ := out.sink.(*testLogSink); p != sink {
+		t.Errorf("expected output to be the same as input, got in=%p, out=%p", sink, p)
+	}
+}

--- a/internal/patch/logr/funcr/internal/wrapper/wrapper.go
+++ b/internal/patch/logr/funcr/internal/wrapper/wrapper.go
@@ -1,0 +1,44 @@
+package wrapper
+
+import (
+	"github.com/go-logr/logr"
+	v122Logr "github.com/go-logr/logr/funcr/internal/logr"
+)
+
+var _ logr.Logger = (*loggerImpl)(nil)
+
+// loggerImpl wraps a v1.2.2 logr.Logger struct into a struct
+// that implements the v0.4.0 logr.Logr interface.
+type loggerImpl struct {
+	l v122Logr.Logger
+}
+
+func (l *loggerImpl) Enabled() bool {
+	return l.l.Enabled()
+}
+
+func (l *loggerImpl) Info(msg string, keysAndValues ...interface{}) {
+	l.l.Info(msg, keysAndValues...)
+}
+
+func (l *loggerImpl) Error(err error, msg string, keysAndValues ...interface{}) {
+	l.l.Error(err, msg, keysAndValues...)
+}
+
+func (l *loggerImpl) V(level int) logr.Logger {
+	return &loggerImpl{l.l.V(level)}
+}
+
+func (l *loggerImpl) WithValues(keysAndValues ...interface{}) logr.Logger {
+	return &loggerImpl{l.l.WithValues(keysAndValues...)}
+}
+
+func (l *loggerImpl) WithName(name string) logr.Logger {
+	return &loggerImpl{l.l.WithName(name)}
+}
+
+// Fromv122Logger wraps a v1.2.2 logr.Logger into a struct that implements
+// the v0.4.0 logr.Logger interface.
+func Fromv122Logger(logger v122Logr.Logger) logr.Logger {
+	return &loggerImpl{logger}
+}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Add `funcr` patch module to use the `funcr` package in logr v0.4.0. See https://github.com/DataDog/datadog-agent/blob/main/internal/patch/logr/funcr/README.md for further details.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Be able to bump the OpenTelemetry Collector.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

This is terribly hacky and it only works because a `logr.Logger` was an interface on v0.4.0 but.. it works:
- The behavior should be the same as with logger v1.2.2 because we are just using the v1.2.2 logger under the hood
- If something fails it will fail to compile, not fail at runtime
- Whenever we don't need this we will get an 'ambiguous import' error which can be fixed.

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

Maybe there is some difference in behavior that I am not aware of that makes this package malfunction. I think this is unlikely, but the possibility is there.

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

To be tested as part of the Collector bump.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] The appropriate `team/..` label has been applied, if known.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
