### PR TITLE
Backport: Make the DEB package datadog-signing-keys a hard dependency (#11141)

### DIFF
--- a/omnibus/config/projects/agent.rb
+++ b/omnibus/config/projects/agent.rb
@@ -53,7 +53,7 @@ else
   end
 
   if debian?
-    runtime_recommended_dependency 'datadog-signing-keys'
+    runtime_dependency 'datadog-signing-keys'
   end
 
   if osx?

--- a/omnibus/config/projects/dogstatsd.rb
+++ b/omnibus/config/projects/dogstatsd.rb
@@ -44,7 +44,7 @@ else
   end
 
   if debian?
-    runtime_recommended_dependency 'datadog-signing-keys'
+    runtime_dependency 'datadog-signing-keys'
   end
 end
 

--- a/omnibus/config/projects/iot-agent.rb
+++ b/omnibus/config/projects/iot-agent.rb
@@ -46,7 +46,7 @@ else
   end
 
   if debian?
-    runtime_recommended_dependency 'datadog-signing-keys'
+    runtime_dependency 'datadog-signing-keys'
   end
 end
 

--- a/releasenotes/notes/signing-keys-deb-strong-dep-fd8d8e605d88d9d9.yaml
+++ b/releasenotes/notes/signing-keys-deb-strong-dep-fd8d8e605d88d9d9.yaml
@@ -1,0 +1,4 @@
+---
+upgrade:
+  - |
+    The DEB package now depends on the datadog-signing-keys package. This package contains the latest signing keys used to sign the packages and repo metadata.


### PR DESCRIPTION
### What does this PR do?

Backports #11141, which I forgot to merge before the unfreeze even though it was approved because I'm stupid.
