### PR TITLE
Poll agent integration configuration files for changes

### DIFF
--- a/cmd/agent/common/autodiscovery.go
+++ b/cmd/agent/common/autodiscovery.go
@@ -32,7 +32,11 @@ var (
 func setupAutoDiscovery(confSearchPaths []string, metaScheduler *scheduler.MetaScheduler) *autodiscovery.AutoConfig {
 	ad := autodiscovery.NewAutoConfig(metaScheduler)
 	providers.InitConfigFilesReader(confSearchPaths)
-	ad.AddConfigProvider(providers.NewFileConfigProvider(), false, 0)
+	ad.AddConfigProvider(
+		providers.NewFileConfigProvider(),
+		config.Datadog.GetBool("autoconf_config_files_poll"),
+		config.Datadog.GetDuration("autoconf_config_files_poll_interval")*time.Second,
+	)
 
 	// Autodiscovery cannot easily use config.RegisterOverrideFunc() due to Unmarshalling
 	extraConfigProviders, extraConfigListeners := confad.DiscoverComponentsFromConfig()

--- a/pkg/autodiscovery/providers/README.md
+++ b/pkg/autodiscovery/providers/README.md
@@ -18,7 +18,8 @@ for _, provider := range configProviders {
 
 ### `FileConfigProvider`
 
-The `FileConfigProvider` is a static config provider, it scans the check configs directory once at startup.
+The `FileConfigProvider` is a static config provider, it scans the check configs directory at startup. The files are cached
+in memory for five minutes.
 
 ### `KubeletConfigProvider`
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -541,6 +541,8 @@ func InitConfig(config Config) {
 	config.BindEnvAndSetDefault("statsd_metric_blocklist", []string{})
 	// Autoconfig
 	config.BindEnvAndSetDefault("autoconf_template_dir", "/datadog/check_configs")
+	config.BindEnvAndSetDefault("autoconf_config_files_poll", false)
+	config.BindEnvAndSetDefault("autoconf_config_files_poll_interval", 60)
 	config.BindEnvAndSetDefault("exclude_pause_container", true)
 	config.BindEnvAndSetDefault("ac_include", []string{})
 	config.BindEnvAndSetDefault("ac_exclude", []string{})

--- a/pkg/config/config_template.yaml
+++ b/pkg/config/config_template.yaml
@@ -1991,6 +1991,19 @@ api_key:
 #
 # autoconf_template_dir: /datadog/check_configs
 
+## @param autoconf_config_files_poll - boolean - optional - default: false
+## @env DD_AUTOCONF_CONFIG_FILES_POLL - boolean - optional - default: false
+## Should the we check for new/updated integration configuration files on disk.
+#
+# autoconf_config_files_poll: false
+
+## @param autoconf_config_files_poll_interval - integer - optional - default: 60
+## @env DD_AUTOCONF_CONFIG_FILES_POLL_INTERVAL - integer - optional - default: 60
+## How frequently should the Agent check for new/updated integration configuration files. WARNING: the configuration
+## provider caches reads from disk for 5 minutes.
+#
+# autoconf_config_files_poll_interval: 60
+
 ## @param config_providers - List of custom object - optional
 ## @env DD_CONFIG_PROVIDERS - List of custom object - optional
 ## The providers the Agent should call to collect checks configurations. Available providers are:

--- a/releasenotes/notes/agent-integration-config-polling-9e642c167a7e6033.yaml
+++ b/releasenotes/notes/agent-integration-config-polling-9e642c167a7e6033.yaml
@@ -1,0 +1,14 @@
+# Each section from every release note are combined when the
+# CHANGELOG.rst is rendered. So the text needs to be worded so that
+# it does not depend on any information only available in another
+# section. This may mean repeating some details, but each section
+# must be readable independently of the other.
+#
+# Each section note must be formatted as reStructuredText.
+---
+enhancements:
+  - |
+    Optionally poll Agent integration configuration files for changes after startup. This allows the Agent to pick up new
+    integration configuration without a restart. This is enabled/disabled with the `autoconf_config_files_poll` boolean
+    configuration variable, and the polling interval is configured with the `autoconf_config_files_poll_interval`.
+    Warning- The ConfigFilesReader implementation will cache the files in memory regardless of any changes.


### PR DESCRIPTION
### What does this PR do?

This removes the restart requirement for the agent to pick up new integration configurations. The agent will poll on the same interval as other autodiscovery checks.

### Motivation

* It closes #11160.
* It allows generating integration configuration from a sidecar and doesn't require restarting the DataDog Agent to pick up the new changes.

### Possible Drawbacks / Trade-offs

* The Agent will have more read IO operations due to polling the filesystem for changes. This impact is slightly mitigated by the 5 minute TTL on the configuration cache.

### Describe how to test/QA your changes

* Change integration configuration, wait 5 minutes for the cache entry to expire and get picked up.
* Beyond that, would appreciate some guidance on unit tests for this, unless DataDog employees are of the opinion this doesn't warrant it.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
