### PR TITLE
Fix diagnosis error message

### DIFF
--- a/pkg/diagnose/runner.go
+++ b/pkg/diagnose/runner.go
@@ -43,7 +43,7 @@ func RunAll(w io.Writer) error {
 		statusString := color.GreenString("PASS")
 		if err != nil {
 			statusString = color.RedString("FAIL")
-			log.Infof("diagnosis error for %s: %w", name, err)
+			log.Infof("diagnosis error for %s: %s", name, err)
 		}
 		fmt.Fprintln(w, fmt.Sprintf("===> %s\n", statusString))
 	}


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

Use `%s` to show `err` instead of `%w`

### Motivation

Hard to read INFO logs like below.

- `%!w(*retry.Error=&{0xc0012021e0 0xc0012021e0 containerdutil 3})`
- `%!w(*fmt.wrapError=&{error connecting to docker: temporary failure in dockerutil, will retry later: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running? 0xc00265cc80})`

```
2022-03-04 08:12:53 UTC | CORE | INFO | (pkg/diagnose/runner.go:46 in RunAll) | diagnosis error for Containerd availability: %!w(*retry.Error=&{0xc0012021e0 0xc0012021e0 containerdutil 3})
2022-03-04 08:12:53 UTC | CORE | INFO | (pkg/diagnose/runner.go:46 in RunAll) | diagnosis error for Docker availability: %!w(*fmt.wrapError=&{error connecting to docker: temporary failure in dockerutil, will retry later: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running? 0xc00265cc80})
2022-03-04 08:12:53 UTC | CORE | INFO | (pkg/diagnose/runner.go:46 in RunAll) | diagnosis error for EC2 Metadata availability: %!w(*errors.errorString=&{unable to fetch EC2 API, Get "http://169.254.169.254/latest/meta-data/hostname": dial tcp 169.254.169.254:80: i/o timeout (Client.Timeout exceeded while awaiting headers)})
2022-03-04 08:12:53 UTC | CORE | INFO | (pkg/diagnose/runner.go:46 in RunAll) | diagnosis error for ECS Fargate Metadata availability: %!w(*url.Error=&{Get http://169.254.170.2/v2/metadata 0xc0001139f8})
2022-03-04 08:12:54 UTC | CORE | INFO | (pkg/collector/worker/check_logger.go:56 in CheckFinished) | check:uptime | Done running check
2022-03-04 08:12:54 UTC | CORE | INFO | (pkg/diagnose/runner.go:46 in RunAll) | diagnosis error for ECS Metadata availability: %!w(*retry.Error=&{0xc001f27270 0xc001f27270 ecsutil-meta-v1 3})
2022-03-04 08:12:54 UTC | CORE | INFO | (pkg/diagnose/runner.go:46 in RunAll) | diagnosis error for ECS Metadata with tags availability: %!w(*retry.Error=&{0xc001f27420 0xc001f27420 ecsutil-meta-v3 3})
2022-03-04 08:12:55 UTC | CORE | INFO | (pkg/collector/worker/check_logger.go:56 in CheckFinished) | check:memory | Done running check
2022-03-04 08:12:55 UTC | CORE | INFO | (pkg/diagnose/runner.go:46 in RunAll) | diagnosis error for GCE Metadata availability: %!w(*errors.errorString=&{unable to retrieve hostname from GCE: Get "http://169.254.169.254/computeMetadata/v1/instance/hostname": context deadline exceeded (Client.Timeout exceeded while awaiting headers)})
2022-03-04 08:12:55 UTC | CORE | INFO | (pkg/util/kubernetes/apiserver/diagnosis.go:27 in diagnose) | Detecting OpenShift APIs: new apiGroups available
2022-03-04 08:12:55 UTC | CORE | INFO | (pkg/diagnose/runner.go:46 in RunAll) | diagnosis error for Tencent Metadata availability: %!w(*errors.errorString=&{cloud provider is disabled by configuration})
```

### Additional Notes


### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
