### PR TITLE
Fix several issues with new ECS Fargate collection, move live container stats to use timestamps from collectors as a side effect

### DIFF
--- a/pkg/process/checks/container.go
+++ b/pkg/process/checks/container.go
@@ -32,7 +32,6 @@ type ContainerCheck struct {
 	sysInfo           *model.SystemInfo
 	containerProvider util.ContainerProvider
 	lastRates         map[string]*util.ContainerRateMetrics
-	lastRun           time.Time
 	networkID         string
 
 	containerFailedLogLimit *util.LogLimit
@@ -72,9 +71,8 @@ func (c *ContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.Me
 	var containers []*model.Container
 	var pidToCid map[int]string
 	var lastRates map[string]*util.ContainerRateMetrics
-	containers, lastRates, pidToCid, err = c.containerProvider.GetContainers(cacheValidityNoRT, c.lastRates, c.lastRun, startTime)
+	containers, lastRates, pidToCid, err = c.containerProvider.GetContainers(cacheValidityNoRT, c.lastRates)
 	if err == nil {
-		c.lastRun = startTime
 		c.lastRates = lastRates
 	} else {
 		log.Debugf("Unable to gather stats for containers, err: %v", err)

--- a/pkg/process/checks/container_rt.go
+++ b/pkg/process/checks/container_rt.go
@@ -28,7 +28,6 @@ type RTContainerCheck struct {
 	sysInfo           *model.SystemInfo
 	containerProvider util.ContainerProvider
 	lastRates         map[string]*util.ContainerRateMetrics
-	lastRun           time.Time
 }
 
 // Init initializes a RTContainerCheck instance.
@@ -46,14 +45,11 @@ func (r *RTContainerCheck) RealTime() bool { return true }
 
 // Run runs the real-time container check getting container-level stats from the Cgroups and Docker APIs.
 func (r *RTContainerCheck) Run(cfg *config.AgentConfig, groupID int32) ([]model.MessageBody, error) {
-	startTime := time.Now()
-
 	var err error
 	var containers []*model.Container
 	var lastRates map[string]*util.ContainerRateMetrics
-	containers, lastRates, _, err = r.containerProvider.GetContainers(cacheValidityRT, r.lastRates, r.lastRun, startTime)
+	containers, lastRates, _, err = r.containerProvider.GetContainers(cacheValidityRT, r.lastRates)
 	if err == nil {
-		r.lastRun = startTime
 		r.lastRates = lastRates
 	} else {
 		log.Debugf("Unable to gather stats for containers, err: %v", err)

--- a/pkg/process/checks/process.go
+++ b/pkg/process/checks/process.go
@@ -43,7 +43,6 @@ type ProcessCheck struct {
 	lastRun            time.Time
 	containerProvider  util.ContainerProvider
 	lastContainerRates map[string]*util.ContainerRateMetrics
-	lastContainerRun   time.Time
 	networkID          string
 
 	realtimeLastCPUTime cpu.TimesStat
@@ -156,10 +155,9 @@ func (p *ProcessCheck) run(cfg *config.AgentConfig, groupID int32, collectRealTi
 	if collectRealTime {
 		cacheValidity = cacheValidityRT
 	}
-	containerTime := time.Now()
-	containers, lastContainerRates, pidToCid, err = p.containerProvider.GetContainers(cacheValidity, p.lastContainerRates, p.lastContainerRun, containerTime)
+
+	containers, lastContainerRates, pidToCid, err = p.containerProvider.GetContainers(cacheValidity, p.lastContainerRates)
 	if err == nil {
-		p.lastContainerRun = containerTime
 		p.lastContainerRates = lastContainerRates
 	} else {
 		log.Debugf("Unable to gather stats for containers, err: %v", err)

--- a/pkg/process/checks/process_rt.go
+++ b/pkg/process/checks/process_rt.go
@@ -59,10 +59,8 @@ func (p *ProcessCheck) runRealtime(cfg *config.AgentConfig, groupID int32) (*Run
 	var containers []*model.Container
 	var pidToCid map[int]string
 	var lastContainerRates map[string]*util.ContainerRateMetrics
-	containerTime := time.Now()
-	containers, lastContainerRates, pidToCid, err = p.containerProvider.GetContainers(cacheValidityRT, p.lastContainerRates, p.lastContainerRun, containerTime)
+	containers, lastContainerRates, pidToCid, err = p.containerProvider.GetContainers(cacheValidityRT, p.lastContainerRates)
 	if err == nil {
-		p.lastContainerRun = containerTime
 		p.lastContainerRates = lastContainerRates
 	} else {
 		log.Debugf("Unable to gather stats for containers, err: %v", err)

--- a/pkg/util/containers/v2/metrics/containerd/collector_cgroupv1.go
+++ b/pkg/util/containers/v2/metrics/containerd/collector_cgroupv1.go
@@ -137,6 +137,7 @@ func getIOStatsCgroupV1(blkioStat *v1.BlkIOStat) *provider.ContainerIOStats {
 
 func getNetworkStatsCgroupV1(networkStats []*v1.NetworkStat) *provider.ContainerNetworkStats {
 	containerNetworkStats := provider.ContainerNetworkStats{
+		Timestamp:   time.Now(),
 		BytesSent:   pointer.Float64Ptr(0),
 		BytesRcvd:   pointer.Float64Ptr(0),
 		PacketsSent: pointer.Float64Ptr(0),

--- a/pkg/util/containers/v2/metrics/containerd/collector_linux_test.go
+++ b/pkg/util/containers/v2/metrics/containerd/collector_linux_test.go
@@ -364,6 +364,7 @@ func TestGetContainerNetworkStats_Containerd(t *testing.T) {
 
 			// ID and cache TTL not relevant for these tests
 			result, err := collector.GetContainerNetworkStats(containerID, 10*time.Second)
+			result.Timestamp = time.Time{} // We have no control over it, so set it to avoid checking it.
 
 			assert.NoError(t, err)
 			assert.Empty(t, cmp.Diff(test.expectedNetworkStats, result))

--- a/pkg/util/containers/v2/metrics/docker/collector.go
+++ b/pkg/util/containers/v2/metrics/docker/collector.go
@@ -98,7 +98,7 @@ func (d *dockerCollector) GetContainerNetworkStats(containerID string, cacheVali
 		return nil, err
 	}
 
-	return convertNetworkStats(stats.Networks), nil
+	return convertNetworkStats(stats), nil
 }
 
 // GetContainerIDForPID returns the container ID for given PID
@@ -200,8 +200,9 @@ func fillStatsFromSpec(containerStats *provider.ContainerStats, spec *types.Cont
 	computeCPULimit(containerStats, spec)
 }
 
-func convertNetworkStats(networkStats map[string]types.NetworkStats) *provider.ContainerNetworkStats {
+func convertNetworkStats(stats *types.StatsJSON) *provider.ContainerNetworkStats {
 	containerNetworkStats := &provider.ContainerNetworkStats{
+		Timestamp:   stats.Read,
 		BytesSent:   pointer.Float64Ptr(0),
 		BytesRcvd:   pointer.Float64Ptr(0),
 		PacketsSent: pointer.Float64Ptr(0),
@@ -209,7 +210,7 @@ func convertNetworkStats(networkStats map[string]types.NetworkStats) *provider.C
 		Interfaces:  make(map[string]provider.InterfaceNetStats),
 	}
 
-	for ifname, netStats := range networkStats {
+	for ifname, netStats := range stats.Networks {
 		*containerNetworkStats.BytesSent += float64(netStats.TxBytes)
 		*containerNetworkStats.BytesRcvd += float64(netStats.RxBytes)
 		*containerNetworkStats.PacketsSent += float64(netStats.TxPackets)

--- a/pkg/util/containers/v2/metrics/docker/collector_linux.go
+++ b/pkg/util/containers/v2/metrics/docker/collector_linux.go
@@ -10,7 +10,6 @@ package docker
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/docker/docker/api/types"
 
@@ -25,7 +24,7 @@ import (
 
 func convertContainerStats(stats *types.Stats) *provider.ContainerStats {
 	return &provider.ContainerStats{
-		Timestamp: time.Now(),
+		Timestamp: stats.Read,
 		CPU:       convertCPUStats(&stats.CPUStats),
 		Memory:    convertMemoryStats(&stats.MemoryStats),
 		IO:        convertIOStats(&stats.BlkioStats),

--- a/pkg/util/containers/v2/metrics/docker/collector_test.go
+++ b/pkg/util/containers/v2/metrics/docker/collector_test.go
@@ -24,24 +24,26 @@ import (
 func TestConvertNetworkStats(t *testing.T) {
 	tests := []struct {
 		name           string
-		input          map[string]types.NetworkStats
+		input          *types.StatsJSON
 		networks       map[string]string
 		expectedOutput provider.ContainerNetworkStats
 	}{
 		{
 			name: "basic",
-			input: map[string]types.NetworkStats{
-				"eth0": {
-					RxBytes:   42,
-					RxPackets: 43,
-					TxBytes:   44,
-					TxPackets: 45,
-				},
-				"eth1": {
-					RxBytes:   46,
-					RxPackets: 47,
-					TxBytes:   48,
-					TxPackets: 49,
+			input: &types.StatsJSON{
+				Networks: map[string]types.NetworkStats{
+					"eth0": {
+						RxBytes:   42,
+						RxPackets: 43,
+						TxBytes:   44,
+						TxPackets: 45,
+					},
+					"eth1": {
+						RxBytes:   46,
+						RxPackets: 47,
+						TxBytes:   48,
+						TxPackets: 49,
+					},
 				},
 			},
 			expectedOutput: provider.ContainerNetworkStats{

--- a/pkg/util/containers/v2/metrics/docker/collector_windows.go
+++ b/pkg/util/containers/v2/metrics/docker/collector_windows.go
@@ -9,8 +9,6 @@
 package docker
 
 import (
-	"time"
-
 	"github.com/docker/docker/api/types"
 
 	"github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics/provider"
@@ -20,7 +18,7 @@ import (
 
 func convertContainerStats(stats *types.Stats) *provider.ContainerStats {
 	return &provider.ContainerStats{
-		Timestamp: time.Now(),
+		Timestamp: stats.Read,
 		CPU:       convertCPUStats(&stats.CPUStats),
 		Memory:    convertMemoryStats(&stats.MemoryStats),
 		IO:        convertIOStats(&stats.StorageStats),

--- a/pkg/util/containers/v2/metrics/ecsfargate/collector.go
+++ b/pkg/util/containers/v2/metrics/ecsfargate/collector.go
@@ -11,24 +11,34 @@ package ecsfargate
 import (
 	"context"
 	"fmt"
+	"math"
+	"sync"
 	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/config"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics/provider"
 	"github.com/DataDog/datadog-agent/pkg/util/ecs/metadata"
 	v2 "github.com/DataDog/datadog-agent/pkg/util/ecs/metadata/v2"
+	"github.com/DataDog/datadog-agent/pkg/util/log"
 	"github.com/DataDog/datadog-agent/pkg/util/pointer"
 )
 
 const (
 	ecsFargateCollectorID = "ecs_fargate"
+	ecsTaskTimeout        = 2 * time.Second
+	// cpuKey represents the cpu key used in the resource limits map returned by the ECS API
+	cpuKey = "CPU"
+	// memoryKey represents the memory key used in the resource limits map returned by the ECS API
+	memoryKey = "Memory"
 )
+
+var ecsUnsetMemoryLimit = uint64(math.Pow(2, 62))
 
 func init() {
 	provider.GetProvider().RegisterCollector(provider.CollectorMetadata{
 		ID:            ecsFargateCollectorID,
 		Priority:      0,
-		Runtimes:      provider.AllLinuxRuntimes,
+		Runtimes:      []string{provider.RuntimeNameECSFargate},
 		Factory:       func() (provider.Collector, error) { return newEcsFargateCollector() },
 		DelegateCache: true,
 	})
@@ -36,6 +46,9 @@ func init() {
 
 type ecsFargateCollector struct {
 	client *v2.Client
+
+	taskSpec *v2.Task
+	taskLock sync.Mutex
 }
 
 // newEcsFargateCollector returns a new *ecsFargateCollector.
@@ -61,8 +74,16 @@ func (e *ecsFargateCollector) GetContainerStats(containerID string, cacheValidit
 	if err != nil {
 		return nil, err
 	}
+	containerStats := convertEcsStats(stats)
 
-	return convertEcsStats(stats), nil
+	// Data from Task spec are not mandatory, do not return an error
+	if err := e.getTask(); err == nil {
+		fillFromSpec(containerStats, e.taskSpec)
+	} else {
+		log.Warnf("Unable to get ECS Fargate task metadata, err: %v", err)
+	}
+
+	return containerStats, nil
 }
 
 // GetContainerNetworkStats returns network stats by container ID.
@@ -72,7 +93,7 @@ func (e *ecsFargateCollector) GetContainerNetworkStats(containerID string, cache
 		return nil, err
 	}
 
-	return convertNetworkStats(stats.Networks), nil
+	return convertNetworkStats(stats), nil
 }
 
 // GetContainerIDForPID returns the container ID for given PID
@@ -103,12 +124,79 @@ func convertEcsStats(ecsStats *v2.ContainerStats) *provider.ContainerStats {
 		return nil
 	}
 
+	dataTimestamp, err := time.Parse(time.RFC3339Nano, ecsStats.Timestamp)
+	if err != nil {
+		dataTimestamp = time.Now()
+	}
+
 	return &provider.ContainerStats{
-		Timestamp: time.Now(),
+		Timestamp: dataTimestamp,
 		CPU:       convertCPUStats(&ecsStats.CPU),
 		Memory:    convertMemoryStats(&ecsStats.Memory),
 		IO:        convertIOStats(&ecsStats.IO),
 	}
+}
+
+func (e *ecsFargateCollector) getTask() error {
+	if e.taskSpec != nil {
+		return nil
+	}
+
+	// We can observe a nil task and refresh multiple times, which is not optimal
+	// but better than paying the lock cost forever.
+	e.taskLock.Lock()
+	defer e.taskLock.Unlock()
+
+	ctx, cancel := context.WithTimeout(context.Background(), ecsTaskTimeout)
+	defer cancel()
+
+	task, err := e.client.GetTask(ctx)
+	if err != nil {
+		return err
+	}
+
+	e.taskSpec = task
+	return nil
+}
+
+func convertNetworkStats(ecsStats *v2.ContainerStats) *provider.ContainerNetworkStats {
+	if ecsStats == nil {
+		return nil
+	}
+
+	dataTimestamp, err := time.Parse(time.RFC3339Nano, ecsStats.Timestamp)
+	if err != nil {
+		dataTimestamp = time.Now()
+	}
+
+	// networks is not useful for ECS Fargate as the Fargate endpoint
+	// already reports a name (like `eth0`)
+	stats := &provider.ContainerNetworkStats{
+		Timestamp: dataTimestamp,
+	}
+	stats.Interfaces = make(map[string]provider.InterfaceNetStats)
+	var totalPacketsRcvd, totalPacketsSent, totalBytesRcvd, totalBytesSent uint64
+	for iface, statsPerInterface := range ecsStats.Networks {
+		iStats := provider.InterfaceNetStats{
+			BytesSent:   pointer.UIntToFloatPtr(statsPerInterface.TxBytes),
+			PacketsSent: pointer.UIntToFloatPtr(statsPerInterface.TxPackets),
+			BytesRcvd:   pointer.UIntToFloatPtr(statsPerInterface.RxBytes),
+			PacketsRcvd: pointer.UIntToFloatPtr(statsPerInterface.RxPackets),
+		}
+		stats.Interfaces[iface] = iStats
+
+		totalPacketsRcvd += statsPerInterface.RxPackets
+		totalPacketsSent += statsPerInterface.TxPackets
+		totalBytesRcvd += statsPerInterface.RxBytes
+		totalBytesSent += statsPerInterface.TxBytes
+	}
+
+	stats.PacketsRcvd = pointer.UIntToFloatPtr(totalPacketsRcvd)
+	stats.PacketsSent = pointer.UIntToFloatPtr(totalPacketsSent)
+	stats.BytesRcvd = pointer.UIntToFloatPtr(totalBytesRcvd)
+	stats.BytesSent = pointer.UIntToFloatPtr(totalBytesSent)
+
+	return stats
 }
 
 func convertCPUStats(cpuStats *v2.CPUStats) *provider.ContainerCPUStats {
@@ -128,12 +216,17 @@ func convertMemoryStats(memStats *v2.MemStats) *provider.ContainerMemStats {
 		return nil
 	}
 
-	return &provider.ContainerMemStats{
-		Limit:      pointer.UIntToFloatPtr(memStats.Limit),
+	cMemStats := &provider.ContainerMemStats{
 		UsageTotal: pointer.UIntToFloatPtr(memStats.Usage),
 		RSS:        pointer.UIntToFloatPtr(memStats.Details.RSS),
 		Cache:      pointer.UIntToFloatPtr(memStats.Details.Cache),
 	}
+
+	if memStats.Limit > 0 && memStats.Limit < ecsUnsetMemoryLimit {
+		cMemStats.Limit = pointer.UIntToFloatPtr(memStats.Limit)
+	}
+
+	return cMemStats
 }
 
 func convertIOStats(ioStats *v2.IOStats) *provider.ContainerIOStats {
@@ -173,31 +266,15 @@ func convertIOStats(ioStats *v2.IOStats) *provider.ContainerIOStats {
 	}
 }
 
-func convertNetworkStats(netStats v2.NetStatsMap) *provider.ContainerNetworkStats {
-	// networks is not useful for ECS Fargate as the Fargate endpoint
-	// already reports a name (like `eth0`)
-	stats := &provider.ContainerNetworkStats{}
-	stats.Interfaces = make(map[string]provider.InterfaceNetStats)
-	var totalPacketsRcvd, totalPacketsSent, totalBytesRcvd, totalBytesSent uint64
-	for iface, statsPerInterface := range netStats {
-		iStats := provider.InterfaceNetStats{
-			BytesSent:   pointer.UIntToFloatPtr(statsPerInterface.TxBytes),
-			PacketsSent: pointer.UIntToFloatPtr(statsPerInterface.TxPackets),
-			BytesRcvd:   pointer.UIntToFloatPtr(statsPerInterface.RxBytes),
-			PacketsRcvd: pointer.UIntToFloatPtr(statsPerInterface.RxPackets),
-		}
-		stats.Interfaces[iface] = iStats
-
-		totalPacketsRcvd += statsPerInterface.RxPackets
-		totalPacketsSent += statsPerInterface.TxPackets
-		totalBytesRcvd += statsPerInterface.RxBytes
-		totalBytesSent += statsPerInterface.TxBytes
+func fillFromSpec(containerStats *provider.ContainerStats, taskSpec *v2.Task) {
+	// Handling Task CPU/Memory Limit (cannot be empty, mandatory on ECS Fargate)
+	taskCPULimit := taskSpec.Limits[cpuKey]
+	if taskCPULimit != 0 && containerStats.CPU != nil {
+		containerStats.CPU.Limit = pointer.Float64Ptr(taskCPULimit * 100) // vCPU to percentage (0-N00%)
 	}
 
-	stats.PacketsRcvd = pointer.UIntToFloatPtr(totalPacketsRcvd)
-	stats.PacketsSent = pointer.UIntToFloatPtr(totalPacketsSent)
-	stats.BytesRcvd = pointer.UIntToFloatPtr(totalBytesRcvd)
-	stats.BytesSent = pointer.UIntToFloatPtr(totalBytesSent)
-
-	return stats
+	taskMemoryLimit := taskSpec.Limits[memoryKey]
+	if taskMemoryLimit != 0 && containerStats.Memory != nil && containerStats.Memory.Limit == nil {
+		containerStats.Memory.Limit = pointer.Float64Ptr(taskMemoryLimit * 1024 * 1024) // Megabytes to bytes
+	}
 }

--- a/pkg/util/containers/v2/metrics/kubelet/collector.go
+++ b/pkg/util/containers/v2/metrics/kubelet/collector.go
@@ -253,6 +253,7 @@ func convertContainerStats(kubeContainerStats *v1alpha1.ContainerStats, outConta
 
 func convertNetworkStats(podNetworkStats *v1alpha1.NetworkStats, outNetworkStats *provider.ContainerNetworkStats) {
 	var sumBytesSent, sumBytesRcvd float64
+	outNetworkStats.Timestamp = podNetworkStats.Time.Time
 	outNetworkStats.Interfaces = make(map[string]provider.InterfaceNetStats, len(podNetworkStats.Interfaces))
 
 	for _, interfaceStats := range podNetworkStats.Interfaces {

--- a/pkg/util/containers/v2/metrics/kubelet/collector_test.go
+++ b/pkg/util/containers/v2/metrics/kubelet/collector_test.go
@@ -109,6 +109,7 @@ func TestKubeletCollectorLinux(t *testing.T) {
 
 	// Test network stats
 	expectedPodNetworkStats := &provider.ContainerNetworkStats{
+		Timestamp: expectedTime,
 		BytesRcvd: pointer.Float64Ptr(254942755),
 		BytesSent: pointer.Float64Ptr(137422821),
 		Interfaces: map[string]provider.InterfaceNetStats{

--- a/pkg/util/containers/v2/metrics/provider/provider.go
+++ b/pkg/util/containers/v2/metrics/provider/provider.go
@@ -23,6 +23,7 @@ const (
 	RuntimeNameCRIO       string = "cri-o"
 	RuntimeNameGarden     string = "garden"
 	RuntimeNamePodman     string = "podman"
+	RuntimeNameECSFargate string = "ecsfargate"
 )
 
 const (

--- a/pkg/util/containers/v2/metrics/provider/types.go
+++ b/pkg/util/containers/v2/metrics/provider/types.go
@@ -86,6 +86,7 @@ type InterfaceNetStats struct {
 
 // ContainerNetworkStats stores network statistics about a container per interface
 type ContainerNetworkStats struct {
+	Timestamp               time.Time
 	BytesSent               *float64
 	BytesRcvd               *float64
 	PacketsSent             *float64

--- a/pkg/util/containers/v2/metrics/system/collector_network_linux.go
+++ b/pkg/util/containers/v2/metrics/system/collector_network_linux.go
@@ -15,6 +15,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/DataDog/datadog-agent/pkg/security/log"
 	"github.com/DataDog/datadog-agent/pkg/util/containers/v2/metrics/provider"
@@ -96,7 +97,10 @@ func collectNetworkStats(procPath string, pid int) (*provider.ContainerNetworkSt
 		return nil, nil
 	}
 
-	netStats := provider.ContainerNetworkStats{Interfaces: ifaceStats}
+	netStats := provider.ContainerNetworkStats{
+		Timestamp:  time.Now(),
+		Interfaces: ifaceStats,
+	}
 	convertField(&totalRcvd, &netStats.BytesRcvd)
 	convertField(&totalSent, &netStats.BytesSent)
 	convertField(&totalPktRcvd, &netStats.PacketsRcvd)

--- a/pkg/util/containers/v2/metrics/system/collector_network_linux_test.go
+++ b/pkg/util/containers/v2/metrics/system/collector_network_linux_test.go
@@ -93,6 +93,7 @@ func TestCollectNetworkStats(t *testing.T) {
 			assert.NoError(t, err)
 
 			stat, err := collectNetworkStats(dummyProcDir.RootPath, tc.pid)
+			stat.Timestamp = tc.stat.Timestamp
 			assert.NoError(t, err)
 			assert.Equal(t, &tc.stat, stat)
 		})

--- a/pkg/util/ecs/metadata/v2/client_test.go
+++ b/pkg/util/ecs/metadata/v2/client_test.go
@@ -243,6 +243,7 @@ func TestGetContainerStats(t *testing.T) {
 			fixture:     "./testdata/container_stats.json",
 			containerID: "470f831ceac0479b8c6614a7232e707fb24760c350b13ee589dd1d6424315d98",
 			expectedStats: &ContainerStats{
+				Timestamp: "2019-10-25T10:07:01.006590487Z",
 				CPU: CPUStats{
 					System: 3951680000000,
 					Usage: CPUUsage{
@@ -344,6 +345,7 @@ func TestGetContainerStats(t *testing.T) {
 			fixture:     "./testdata/container_stats_empty_net_stats.json",
 			containerID: "470f831ceac0479b8c6614a7232e707fb24760c350b13ee589dd1d6424315d98",
 			expectedStats: &ContainerStats{
+				Timestamp: "2019-10-25T10:07:01.006590487Z",
 				CPU: CPUStats{
 					System: 3951680000000,
 					Usage: CPUUsage{
@@ -466,5 +468,4 @@ func TestGetContainerStats(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/pkg/util/ecs/metadata/v2/types.go
+++ b/pkg/util/ecs/metadata/v2/types.go
@@ -54,10 +54,11 @@ type Port struct {
 // ContainerStats represents the statistics of a container as returned by the
 // ECS metadata API v2.
 type ContainerStats struct {
-	CPU      CPUStats    `json:"cpu_stats"`
-	Memory   MemStats    `json:"memory_stats"`
-	IO       IOStats     `json:"blkio_stats"`
-	Networks NetStatsMap `json:"networks"`
+	Timestamp string      `json:"read"`
+	CPU       CPUStats    `json:"cpu_stats"`
+	Memory    MemStats    `json:"memory_stats"`
+	IO        IOStats     `json:"blkio_stats"`
+	Networks  NetStatsMap `json:"networks"`
 	// Pids    []int32  `json:"pids_stats"` // seems to be always empty
 }
 

--- a/pkg/workloadmeta/collectors/internal/ecsfargate/ecsfargate.go
+++ b/pkg/workloadmeta/collectors/internal/ecsfargate/ecsfargate.go
@@ -189,7 +189,7 @@ func (c *collector) parseTaskContainers(task *v2.Task) ([]workloadmeta.Orchestra
 					Labels: container.Labels,
 				},
 				Image:      image,
-				Runtime:    workloadmeta.ContainerRuntimeDocker,
+				Runtime:    workloadmeta.ContainerRuntimeECSFargate,
 				NetworkIPs: ips,
 				State: workloadmeta.ContainerState{
 					StartedAt: startedAt,

--- a/pkg/workloadmeta/types.go
+++ b/pkg/workloadmeta/types.go
@@ -124,6 +124,9 @@ const (
 	ContainerRuntimePodman     ContainerRuntime = "podman"
 	ContainerRuntimeCRIO       ContainerRuntime = "cri-o"
 	ContainerRuntimeGarden     ContainerRuntime = "garden"
+	// ECS Fargate can be considered as a runtime in the sense that we don't
+	// know the actual runtime but we need to identify it's Fargate
+	ContainerRuntimeECSFargate ContainerRuntime = "ecsfargate"
 )
 
 // ContainerStatus is the status of the container


### PR DESCRIPTION
### What does this PR do?

Fix multiple issues spotted with the new ECS Fargate collector. To properly fix it, the live container metrics are now computed using timestamped data.

### Motivation

Bugfix.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

Deploy the Agent as a sidecar in ECS Fargate alongside a container that uses a fixed amount of CPU (like `stress`). Make sure:
- The reported icon shows ECS Fargate.
- The number of vCPU reported as limit is correct.
- When running in RT mode, the stats updates only every 10s with correct values.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
