### PR TITLE
Fix tcp queue length collector test on recent kernels

### DIFF
--- a/pkg/collector/corechecks/ebpf/probe/tcp_queue_length_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcp_queue_length_test.go
@@ -57,12 +57,14 @@ func extractGlobalStats(t *testing.T, tracer *TCPQueueLengthTracer) TCPQueueLeng
 		t.Error("failed to get and flush stats")
 	}
 
-	globalStats, ok := stats[""]
-	if !ok {
-		return TCPQueueLengthStatsValue{}
+	cgroupNamesOfInterest := []string{"", "user.slice"}
+	for _, cgroupName := range cgroupNamesOfInterest {
+		if globalStats, ok := stats[cgroupName]; ok {
+			return globalStats
+		}
 	}
 
-	return globalStats
+	return TCPQueueLengthStatsValue{}
 }
 
 // TCP test infrastructure

--- a/pkg/collector/corechecks/ebpf/probe/tcp_queue_length_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcp_queue_length_test.go
@@ -57,14 +57,19 @@ func extractGlobalStats(t *testing.T, tracer *TCPQueueLengthTracer) TCPQueueLeng
 		t.Error("failed to get and flush stats")
 	}
 
-	cgroupNamesOfInterest := []string{"", "user.slice"}
-	for _, cgroupName := range cgroupNamesOfInterest {
-		if globalStats, ok := stats[cgroupName]; ok {
-			return globalStats
+	global := TCPQueueLengthStatsValue{}
+
+	for _, cgroupStats := range stats {
+		if cgroupStats.ReadBufferMaxUsage > global.ReadBufferMaxUsage {
+			global.ReadBufferMaxUsage = cgroupStats.ReadBufferMaxUsage
+		}
+
+		if cgroupStats.WriteBufferMaxUsage > global.WriteBufferMaxUsage {
+			global.WriteBufferMaxUsage = cgroupStats.WriteBufferMaxUsage
 		}
 	}
 
-	return TCPQueueLengthStatsValue{}
+	return global
 }
 
 // TCP test infrastructure

--- a/pkg/collector/corechecks/ebpf/probe/tcp_queue_length_test.go
+++ b/pkg/collector/corechecks/ebpf/probe/tcp_queue_length_test.go
@@ -57,19 +57,19 @@ func extractGlobalStats(t *testing.T, tracer *TCPQueueLengthTracer) TCPQueueLeng
 		t.Error("failed to get and flush stats")
 	}
 
-	global := TCPQueueLengthStatsValue{}
+	globalStats := TCPQueueLengthStatsValue{}
 
 	for _, cgroupStats := range stats {
-		if cgroupStats.ReadBufferMaxUsage > global.ReadBufferMaxUsage {
-			global.ReadBufferMaxUsage = cgroupStats.ReadBufferMaxUsage
+		if cgroupStats.ReadBufferMaxUsage > globalStats.ReadBufferMaxUsage {
+			globalStats.ReadBufferMaxUsage = cgroupStats.ReadBufferMaxUsage
 		}
 
-		if cgroupStats.WriteBufferMaxUsage > global.WriteBufferMaxUsage {
-			global.WriteBufferMaxUsage = cgroupStats.WriteBufferMaxUsage
+		if cgroupStats.WriteBufferMaxUsage > globalStats.WriteBufferMaxUsage {
+			globalStats.WriteBufferMaxUsage = cgroupStats.WriteBufferMaxUsage
 		}
 	}
 
-	return global
+	return globalStats
 }
 
 // TCP test infrastructure


### PR DESCRIPTION
### What does this PR do?

This PR fixes the tcp queue length collector test. On recent kernels, the default cgroup name is not "" anymore but `user.slice` or `systemd.slice` etc. To fix this issue, we compute the global max from all cgroups.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
