### PR TITLE
Revert "[orchestration] properly collect 0 values"

### DIFF
--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod.go
@@ -225,12 +225,27 @@ func convertResourceRequirements(rq corev1.ResourceRequirements, containerName s
 	setLimits := false
 	limits := map[string]int64{}
 
-	for t, v := range rq.Limits {
-		limits[t.String()] = v.Value()
+	cpuLimit := rq.Limits.Cpu()
+	if !cpuLimit.IsZero() {
+		limits[corev1.ResourceCPU.String()] = cpuLimit.MilliValue()
 		setLimits = true
 	}
-	for t, v := range rq.Requests {
-		requests[t.String()] = v.Value()
+
+	memLimit := rq.Limits.Memory()
+	if !memLimit.IsZero() {
+		limits[corev1.ResourceMemory.String()] = memLimit.Value()
+		setLimits = true
+	}
+
+	cpuRequest := rq.Requests.Cpu()
+	if !cpuRequest.IsZero() {
+		requests[corev1.ResourceCPU.String()] = cpuRequest.MilliValue()
+		setRequests = true
+	}
+
+	memRequest := rq.Requests.Memory()
+	if !memRequest.IsZero() {
+		requests[corev1.ResourceMemory.String()] = memRequest.Value()
 		setRequests = true
 	}
 

--- a/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod_test.go
+++ b/pkg/collector/corechecks/cluster/orchestrator/transformers/k8s/pod_test.go
@@ -462,22 +462,6 @@ func TestConvertResourceRequirements(t *testing.T) {
 			},
 			expected: nil,
 		},
-		"0 ResourceRequirements set": {
-			input: v1.Container{
-				Name: "test",
-				Resources: v1.ResourceRequirements{
-					// 1024 = 1Ki
-					Limits:   map[v1.ResourceName]resource.Quantity{v1.ResourceMemory: resource.MustParse("0"), v1.ResourceCPU: resource.MustParse("550Mi")},
-					Requests: map[v1.ResourceName]resource.Quantity{v1.ResourceMemory: resource.MustParse("0")}, // explicitly set the "0" value, that means if not set, it will not be in the map
-				},
-			},
-			expected: &model.ResourceRequirements{
-				Limits:   map[string]int64{v1.ResourceCPU.String(): 576716800, v1.ResourceMemory.String(): 0},
-				Requests: map[string]int64{v1.ResourceMemory.String(): 0},
-				Name:     "test",
-				Type:     model.ResourceRequirementsType_container,
-			},
-		},
 		"only mem set": {
 			input: v1.Container{
 				Name: "test",


### PR DESCRIPTION
This reverts commit c25dcc495b423d85642d8566a9e5a922343ec496.

<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
