### PR TITLE
Fix panics in containerd collector when container cannot be retrieved

### DIFF
--- a/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/container_builder.go
@@ -9,6 +9,7 @@
 package containerd
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/containerd/containerd"
@@ -21,6 +22,10 @@ import (
 
 // buildWorkloadMetaContainer generates a workloadmeta.Container from a containerd.Container
 func buildWorkloadMetaContainer(container containerd.Container, containerdClient cutil.ContainerdItf) (workloadmeta.Container, error) {
+	if container == nil {
+		return workloadmeta.Container{}, fmt.Errorf("cannot build workloadmeta container from nil containerd container")
+	}
+
 	info, err := containerdClient.Info(container)
 	if err != nil {
 		return workloadmeta.Container{}, err

--- a/pkg/workloadmeta/collectors/internal/containerd/event_builder.go
+++ b/pkg/workloadmeta/collectors/internal/containerd/event_builder.go
@@ -9,6 +9,7 @@
 package containerd
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/containerd/containerd"
@@ -19,6 +20,8 @@ import (
 	cutil "github.com/DataDog/datadog-agent/pkg/util/containerd"
 	"github.com/DataDog/datadog-agent/pkg/workloadmeta"
 )
+
+var errNoContainer = errors.New("no container")
 
 // buildCollectorEvent generates a CollectorEvent from a containerdevents.Envelope
 func (c *collector) buildCollectorEvent(
@@ -63,6 +66,10 @@ func (c *collector) buildCollectorEvent(
 }
 
 func createSetEvent(container containerd.Container, namespace string, containerdClient cutil.ContainerdItf) (workloadmeta.CollectorEvent, error) {
+	if container == nil {
+		return workloadmeta.CollectorEvent{}, errNoContainer
+	}
+
 	entity, err := buildWorkloadMetaContainer(container, containerdClient)
 	if err != nil {
 		return workloadmeta.CollectorEvent{}, fmt.Errorf("could not fetch info for container %s: %s", container.ID(), err)


### PR DESCRIPTION
### What does this PR do?

Skip events (normally, task events) when we cannot retrieve a container from containerd API.

### Motivation

Bugfix.

### Additional Notes

### Possible Drawbacks / Trade-offs

### Describe how to test/QA your changes

No scenario to reproduce. Check internally that panics in `pkg/util/containerd/containerd_util.go` are gone.

### Reviewer's Checklist

- [x] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [x] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [x] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [x] Changed code has automated tests for its functionality.
- [x] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [x] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [x] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [x] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [x] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
