### PR TITLE
[workloadmeta] Fix race condition when reading from the store

### DIFF
--- a/pkg/workloadmeta/store.go
+++ b/pkg/workloadmeta/store.go
@@ -402,20 +402,12 @@ func (s *store) handleEvents(evs []CollectorEvent) {
 		}
 	}
 
-	// unlock the store before notifying subscribers, as they might need to
-	// read it for related entities (such as a pod's containers) while they
-	// process an event.
-	s.storeMut.Unlock()
+	filteredEvents := make(map[subscriber][]Event)
 
-	// copy the list of subscribers to hold locks for as little as
-	// possible, since notifyChannel is a blocking operation.
 	s.subscribersMut.RLock()
-	subscribers := append([]subscriber{}, s.subscribers...)
-	s.subscribersMut.RUnlock()
-
-	for _, sub := range subscribers {
+	for _, sub := range s.subscribers {
 		filter := sub.filter
-		filteredEvents := make([]Event, 0, len(evs))
+		filteredEvents[sub] = make([]Event, 0, len(evs))
 
 		for _, ev := range evs {
 			entityID := ev.Entity.GetID()
@@ -435,7 +427,7 @@ func (s *store) handleEvents(evs []CollectorEvent) {
 			if entity != nil {
 				// setting an entity (EventTypeSet) or entity
 				// had one source removed, but others remain
-				filteredEvents = append(filteredEvents, Event{
+				filteredEvents[sub] = append(filteredEvents[sub], Event{
 					Type:   EventTypeSet,
 					Entity: entity,
 				})
@@ -443,14 +435,22 @@ func (s *store) handleEvents(evs []CollectorEvent) {
 			} else {
 				// entity has been removed entirely, unsetting
 				// is straight forward too
-				filteredEvents = append(filteredEvents, Event{
+				filteredEvents[sub] = append(filteredEvents[sub], Event{
 					Type:   EventTypeUnset,
 					Entity: ev.Entity,
 				})
 			}
 		}
+	}
+	s.subscribersMut.RUnlock()
 
-		notifyChannel(sub.name, sub.ch, filteredEvents, true)
+	// unlock the store before notifying subscribers, as they might need to
+	// read it for related entities (such as a pod's containers) while they
+	// process an event.
+	s.storeMut.Unlock()
+
+	for sub, evs := range filteredEvents {
+		notifyChannel(sub.name, sub.ch, evs, true)
 	}
 }
 


### PR DESCRIPTION
### What does this PR do?

When notifying subscribers after handling an event, we read from the store without having a lock on `s.storeMut`. This may result in inconsistent data being fed to subscribers, but more importantly, it may generate `nil` entities that can cause panics downstream (such as in #10716, which we expect to be fixed in #10804, but the actual root cause is the unsafe read) when handling deletes in succession from different collectors.

### Describe how to test/QA your changes

Same as #10804, but since that fix reduced the incidence of this, you'll need a bigger cluster and probably a lot of waiting time.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
