### PR TITLE
Fix batch strategy shutdown race

### DIFF
--- a/pkg/logs/sender/batch_strategy.go
+++ b/pkg/logs/sender/batch_strategy.go
@@ -29,7 +29,7 @@ type batchStrategy struct {
 	serializer      Serializer
 	batchWait       time.Duration
 	contentEncoding ContentEncoding
-	stopChan        chan struct{} // wait for a synchronous flush to finish
+	stopChan        chan struct{} // closed when the goroutine has finished
 	clock           clock.Clock
 }
 
@@ -84,7 +84,7 @@ func (s *batchStrategy) Start() {
 		defer func() {
 			s.flushBuffer(s.outputChan)
 			flushTicker.Stop()
-			s.stopChan <- struct{}{}
+			close(s.stopChan)
 		}()
 		for {
 			select {

--- a/pkg/logs/sender/batch_strategy.go
+++ b/pkg/logs/sender/batch_strategy.go
@@ -25,13 +25,12 @@ type batchStrategy struct {
 	outputChan chan *message.Payload
 	buffer     *MessageBuffer
 	// pipelineName provides a name for the strategy to differentiate it from other instances in other internal pipelines
-	pipelineName     string
-	serializer       Serializer
-	batchWait        time.Duration
-	contentEncoding  ContentEncoding
-	syncFlushTrigger chan struct{} // trigger a synchronous flush
-	syncFlushDone    chan struct{} // wait for a synchronous flush to finish
-	clock            clock.Clock
+	pipelineName    string
+	serializer      Serializer
+	batchWait       time.Duration
+	contentEncoding ContentEncoding
+	stopChan        chan struct{} // wait for a synchronous flush to finish
+	clock           clock.Clock
 }
 
 // NewBatchStrategy returns a new batch concurrent strategy with the specified batch & content size limits
@@ -57,24 +56,22 @@ func newBatchStrategyWithClock(inputChan chan *message.Message,
 	contentEncoding ContentEncoding) Strategy {
 
 	return &batchStrategy{
-		inputChan:        inputChan,
-		outputChan:       outputChan,
-		buffer:           NewMessageBuffer(maxBatchSize, maxContentSize),
-		serializer:       serializer,
-		batchWait:        batchWait,
-		contentEncoding:  contentEncoding,
-		syncFlushTrigger: make(chan struct{}),
-		syncFlushDone:    make(chan struct{}),
-		pipelineName:     pipelineName,
-		clock:            clock,
+		inputChan:       inputChan,
+		outputChan:      outputChan,
+		buffer:          NewMessageBuffer(maxBatchSize, maxContentSize),
+		serializer:      serializer,
+		batchWait:       batchWait,
+		contentEncoding: contentEncoding,
+		stopChan:        make(chan struct{}),
+		pipelineName:    pipelineName,
+		clock:           clock,
 	}
 }
 
 // Stop flushes the buffer and stops the strategy
 func (s *batchStrategy) Stop() {
-	s.syncFlushTrigger <- struct{}{}
-	<-s.syncFlushDone
 	close(s.inputChan)
+	<-s.stopChan
 }
 
 // Start reads the incoming messages and accumulates them to a buffer. The buffer is
@@ -87,6 +84,7 @@ func (s *batchStrategy) Start() {
 		defer func() {
 			s.flushBuffer(s.outputChan)
 			flushTicker.Stop()
+			s.stopChan <- struct{}{}
 		}()
 		for {
 			select {
@@ -100,9 +98,6 @@ func (s *batchStrategy) Start() {
 			case <-flushTicker.C:
 				// flush the payloads at a regular interval so pending messages don't wait here for too long.
 				s.flushBuffer(s.outputChan)
-			case <-s.syncFlushTrigger:
-				s.flushBuffer(s.outputChan)
-				s.syncFlushDone <- struct{}{}
 			}
 		}
 	}()

--- a/pkg/logs/sender/batch_strategy_test.go
+++ b/pkg/logs/sender/batch_strategy_test.go
@@ -95,7 +95,6 @@ func TestBatchStrategySendsPayloadWhenClosingInput(t *testing.T) {
 	// expect payload to be sent before timer, so we never advance the clock; if this
 	// doesn't work, the test will hang
 	payload := <-output
-
 	assert.Equal(t, message, payload.Messages[0])
 }
 

--- a/pkg/logs/sender/batch_strategy_test.go
+++ b/pkg/logs/sender/batch_strategy_test.go
@@ -38,6 +38,10 @@ func TestBatchStrategySendsPayloadWhenBufferIsFull(t *testing.T) {
 	// expect payload to be sent because buffer is full
 	assert.Equal(t, expectedPayload, <-output)
 	s.Stop()
+
+	if _, isOpen := <-input; isOpen {
+		assert.Fail(t, "input should be closed")
+	}
 }
 
 func TestBatchStrategySendsPayloadWhenBufferIsOutdated(t *testing.T) {
@@ -64,6 +68,9 @@ func TestBatchStrategySendsPayloadWhenBufferIsOutdated(t *testing.T) {
 		}
 	}
 	s.Stop()
+	if _, isOpen := <-input; isOpen {
+		assert.Fail(t, "input should be closed")
+	}
 }
 
 func TestBatchStrategySendsPayloadWhenClosingInput(t *testing.T) {
@@ -81,9 +88,14 @@ func TestBatchStrategySendsPayloadWhenClosingInput(t *testing.T) {
 		s.Stop()
 	}()
 
+	if _, isOpen := <-input; isOpen {
+		assert.Fail(t, "input should be closed")
+	}
+
 	// expect payload to be sent before timer, so we never advance the clock; if this
 	// doesn't work, the test will hang
 	payload := <-output
+
 	assert.Equal(t, message, payload.Messages[0])
 }
 
@@ -100,6 +112,10 @@ func TestBatchStrategyShouldNotBlockWhenStoppingGracefully(t *testing.T) {
 	go func() {
 		s.Stop()
 	}()
+	if _, isOpen := <-input; isOpen {
+		assert.Fail(t, "input should be closed")
+	}
+
 	assert.Equal(t, message, (<-output).Messages[0])
 }
 
@@ -134,6 +150,10 @@ func TestBatchStrategySynchronousFlush(t *testing.T) {
 		// Stop triggers the flush and make sure we can read the messages out now
 		strategy.Stop()
 	}()
+
+	if _, isOpen := <-input; isOpen {
+		assert.Fail(t, "input should be closed")
+	}
 
 	assert.ElementsMatch(t, messages, (<-output).Messages)
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

This fixes a shutdown race where `flushBuffer` can be called twice when `Stop` is triggered and will panic on a write to a closed channel. Also slightly simplifies the code. 

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

This is a race so it's difficult to reproduce. The unit tests should cover this. 

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
