### PR TITLE
Do not warn about missing proxy.no_proxy config

### DIFF
--- a/pkg/metadata/inventories/inventories.go
+++ b/pkg/metadata/inventories/inventories.go
@@ -266,12 +266,16 @@ func initializeConfig(cfg config.Config) {
 		return string(cleanBytes)
 	}
 
-	cleanSlice := func(ss []string) []string {
-		rv := make([]string, len(ss))
-		for i, s := range ss {
-			rv[i] = clean(s)
+	cfgSlice := func(name string) []string {
+		if cfg.IsSet(name) {
+			ss := cfg.GetStringSlice(name)
+			rv := make([]string, len(ss))
+			for i, s := range ss {
+				rv[i] = clean(s)
+			}
+			return rv
 		}
-		return rv
+		return []string{}
 	}
 
 	SetAgentMetadata(AgentConfigAPMDDURL, clean(cfg.GetString("apm_config.apm_dd_url")))
@@ -279,7 +283,7 @@ func initializeConfig(cfg config.Config) {
 	SetAgentMetadata(AgentConfigSite, clean(cfg.GetString("dd_site")))
 	SetAgentMetadata(AgentConfigLogsDDURL, clean(cfg.GetString("logs_config.logs_dd_url")))
 	SetAgentMetadata(AgentConfigLogsSocks5ProxyAddress, clean(cfg.GetString("logs_config.socks5_proxy_address")))
-	SetAgentMetadata(AgentConfigNoProxy, cleanSlice(cfg.GetStringSlice("proxy.no_proxy")))
+	SetAgentMetadata(AgentConfigNoProxy, cfgSlice("proxy.no_proxy"))
 	SetAgentMetadata(AgentConfigProcessDDURL, clean(cfg.GetString("process_config.process_dd_url")))
 	SetAgentMetadata(AgentConfigProxyHTTP, clean(cfg.GetString("proxy.http")))
 	SetAgentMetadata(AgentConfigProxyHTTPS, clean(cfg.GetString("proxy.https")))

--- a/pkg/metadata/inventories/inventories_test.go
+++ b/pkg/metadata/inventories/inventories_test.go
@@ -286,9 +286,9 @@ func Test_createCheckInstanceMetadata_returnsNewMetadata(t *testing.T) {
 
 // Test the `initializeConfig` function and especially its scrubbing of secret values.
 func TestInitializeConfig(t *testing.T) {
-	cfg := config.NewConfig("test", "DD", strings.NewReplacer(".", "_"))
 
 	testString := func(cfgName, invName, input, output string) func(*testing.T) {
+		cfg := config.NewConfig("test", "DD", strings.NewReplacer(".", "_"))
 		return func(t *testing.T) {
 			cfg.Set(cfgName, input)
 			initializeConfig(cfg)
@@ -297,8 +297,11 @@ func TestInitializeConfig(t *testing.T) {
 	}
 
 	testStringSlice := func(cfgName, invName string, input, output []string) func(*testing.T) {
+		cfg := config.NewConfig("test", "DD", strings.NewReplacer(".", "_"))
 		return func(t *testing.T) {
-			cfg.Set(cfgName, input)
+			if input != nil {
+				cfg.Set(cfgName, input)
+			}
 			initializeConfig(cfg)
 			require.Equal(t, output, agentMetadata[invName].([]string))
 		}
@@ -337,6 +340,13 @@ func TestInitializeConfig(t *testing.T) {
 		"config_no_proxy",
 		[]string{"http://noprox.example.com", "http://name:sekrit@proxy.example.com/"},
 		[]string{"http://noprox.example.com", "http://name:********@proxy.example.com/"},
+	))
+
+	t.Run("config_no_proxy-nil", testStringSlice(
+		"proxy.no_proxy",
+		"config_no_proxy",
+		nil,
+		[]string{},
 	))
 
 	t.Run("config_process_dd_url", testString(


### PR DESCRIPTION
Due to a quirk of Viper, string-slice configuration parameters such as
`proxy.no_proxy` must be read only if they exist, otherwise generating
a warning when the parameter is not set.

### Motivation

Fixes #11175.

### Additional Notes

The warning itself is harmless, so this is not an urgent fix.

### Describe how to test/QA your changes

Run the agent without `proxy.no_proxy` set, and see that no warning occurs.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
