### PR TITLE
Add Workflow that runs on Dependabot PRs to fix go.sum

### DIFF
--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -15,15 +15,19 @@ jobs:
       uses: actions/setup-go@v2
       with:
         go-version: '1.17.6'
-    - uses: evantorrie/mott-the-tidier@v1-beta
-      id: modtidy
+    - name: Install python
+      uses: actions/setup-python@v2
       with:
-        gomods: '**/go.mod'
-        gomodsum_only: true
+        python-version: '3.8.10'
+    - name: Go mod tidy
+      run: |
+        python3 -m pip install -r requirements.txt
+        inv -e tidy-all
+        inv -e generate-licenses
     - uses: stefanzweifel/git-auto-commit-action@v4
       id: autocommit
       with:
-        commit_message: Auto-fix go.sum changes in dependent modules
+        commit_message: Auto-generate go.sum and LICENSE-3rdparty.csv changes
     - name: changes
       run: |
         echo "Changes detected: ${{ steps.autocommit.outputs.changes_detected }}"

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -22,6 +22,7 @@ jobs:
     - name: Go mod tidy
       run: |
         python3 -m pip install -r requirements.txt
+        inv -e install-tools
         inv -e tidy-all
         inv -e generate-licenses
     - uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/dependabot-pr.yml
+++ b/.github/workflows/dependabot-pr.yml
@@ -1,0 +1,29 @@
+name: Dependabot-Tidier
+on:
+  pull_request:
+    types: [ labeled ]
+
+jobs:
+  mod_tidier:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'dependencies') }}
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.head_ref }}
+    - name: Install go
+      uses: actions/setup-go@v2
+      with:
+        go-version: '1.17.6'
+    - uses: evantorrie/mott-the-tidier@v1-beta
+      id: modtidy
+      with:
+        gomods: '**/go.mod'
+        gomodsum_only: true
+    - uses: stefanzweifel/git-auto-commit-action@v4
+      id: autocommit
+      with:
+        commit_message: Auto-fix go.sum changes in dependent modules
+    - name: changes
+      run: |
+        echo "Changes detected: ${{ steps.autocommit.outputs.changes_detected }}"


### PR DESCRIPTION
### What does this PR do?

Auto-fixes dependabot PRs which contain a `go.sum` generated w/o `-compat=1.17`.

### Motivation

When we run `mod tidy` we pass `-compat=1.17` which makes the CI detect a difference for Dependabot PRs and fail.

### Additional Notes

An alternative would be to just stop passing `-compat=1.17` but I think it's better to live the present (ie: adopt the changes that go 1.17 brings to go.mod) and do this. Happy to discuss, though.

### Describe how to test/QA your changes

I think we need to merge this to be able to test it for real with dependabot.
