### PR TITLE
[pkg/otlp] Skip TestStartPipelineFromConfig on Windows

### DIFF
--- a/pkg/otlp/collector_test.go
+++ b/pkg/otlp/collector_test.go
@@ -72,6 +72,11 @@ func TestStartPipeline(t *testing.T) {
 }
 
 func TestStartPipelineFromConfig(t *testing.T) {
+	// TODO (AP-1550): Fix this once we can disable changing the gRPC logger
+	if runtime.GOOS == "windows" {
+		t.Skip("Skip on Windows, see AP-1550 for details")
+	}
+
 	tests := []struct {
 		path string
 		err  string

--- a/pkg/otlp/collector_test.go
+++ b/pkg/otlp/collector_test.go
@@ -10,6 +10,7 @@ package otlp
 
 import (
 	"context"
+	"runtime"
 	"testing"
 	"time"
 


### PR DESCRIPTION
<!--
* New contributors are highly encouraged to read our
  [CONTRIBUTING](/CONTRIBUTING.md) documentation.
* The pull request:
  * Should only fix one issue or add one feature at a time.
  * Must update the test suite for the relevant functionality.
  * Should pass all status checks before being reviewed or merged.
* Commit titles should be prefixed with general area of pull request's change.
* Draft PRs should be prefixed with `[WIP]` in their title.

-->
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succint form, consider
  opening multiple pull requests instead of a single one.
-->

Skip `TestStartPipelineFromConfig` on Windows.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

The test can have a data race with previous tests. This seems to be a combination of the global state modification described in open-telemetry/opentelemetry-collector#4971, together with the fact that we use a somewhat old grpc-go version that spawns a goroutine on a previous test.

As to why this is only detected on Windows and only sometimes, I have no idea.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

Test will still run on macOS and Linux. `TestStartPipeline` will still run on Windows, so we are still testing that the OTLP pipeline can start successfully on Windows.


### Describe how to test/QA your changes

<!--
* Write here in detail or link to detailed instructions on how this change can
  be tested/QAd/validated, including any environment setup.
-->

Test-only change, no need for QA.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
