### PR TITLE
[system-probe] add telemetry for dropped HTTP statistics

### DIFF
--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -143,8 +143,8 @@ const (
 	ConntrackSamplingPercent                             = "conntrack_sampling_percent"
 	NPMDriverFlowsMissedMaxExceeded                      = "driver_flows_missed_max_exceeded"
 	MonotonicDNSPacketsDropped                           = "dns_packets_dropped"
-	HTTPStatsDropped                                     = "http_stats_dropped"
-	HTTPStatsMisses                                      = "http_stats_misses"
+	HTTPRequestsDropped                                  = "http_requests_dropped"
+	HTTPRequestsMissed                                   = "http_requests_missed"
 )
 
 //revive:enable
@@ -157,8 +157,8 @@ var (
 		ConntrackSamplingPercent,
 		DNSStatsDropped,
 		NPMDriverFlowsMissedMaxExceeded,
-		HTTPStatsDropped,
-		HTTPStatsMisses,
+		HTTPRequestsDropped,
+		HTTPRequestsMissed,
 	}
 
 	// MonotonicConnTelemetryTypes lists all the possible monotonic telemetry which can be bundled

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -143,6 +143,7 @@ const (
 	ConntrackSamplingPercent                             = "conntrack_sampling_percent"
 	NPMDriverFlowsMissedMaxExceeded                      = "driver_flows_missed_max_exceeded"
 	MonotonicDNSPacketsDropped                           = "dns_packets_dropped"
+	HTTPStatsDropped                                     = "http_stats_dropped"
 )
 
 //revive:enable
@@ -155,6 +156,7 @@ var (
 		ConntrackSamplingPercent,
 		DNSStatsDropped,
 		NPMDriverFlowsMissedMaxExceeded,
+		HTTPStatsDropped,
 	}
 
 	// MonotonicConnTelemetryTypes lists all the possible monotonic telemetry which can be bundled

--- a/pkg/network/event_common.go
+++ b/pkg/network/event_common.go
@@ -144,6 +144,7 @@ const (
 	NPMDriverFlowsMissedMaxExceeded                      = "driver_flows_missed_max_exceeded"
 	MonotonicDNSPacketsDropped                           = "dns_packets_dropped"
 	HTTPStatsDropped                                     = "http_stats_dropped"
+	HTTPStatsMisses                                      = "http_stats_misses"
 )
 
 //revive:enable
@@ -157,6 +158,7 @@ var (
 		DNSStatsDropped,
 		NPMDriverFlowsMissedMaxExceeded,
 		HTTPStatsDropped,
+		HTTPStatsMisses,
 	}
 
 	// MonotonicConnTelemetryTypes lists all the possible monotonic telemetry which can be bundled

--- a/pkg/network/http/monitor.go
+++ b/pkg/network/http/monitor.go
@@ -206,6 +206,7 @@ func (m *Monitor) GetStats() map[string]int64 {
 
 	return map[string]int64{
 		"dropped_stats": m.telemetrySnapshot.dropped,
+		"misses_stats":  m.telemetrySnapshot.misses,
 	}
 }
 

--- a/pkg/network/http/monitor.go
+++ b/pkg/network/http/monitor.go
@@ -191,22 +191,22 @@ func (m *Monitor) GetHTTPStats() map[Key]RequestStats {
 
 func (m *Monitor) GetStats() map[string]int64 {
 	if m == nil {
-		return map[string]int64{}
+		return nil
 	}
 
 	m.mux.Lock()
 	defer m.mux.Unlock()
 	if m.stopped {
-		return map[string]int64{}
+		return nil
 	}
 
 	if m.telemetrySnapshot == nil {
-		return map[string]int64{}
+		return nil
 	}
 
 	return map[string]int64{
-		"dropped_stats": m.telemetrySnapshot.dropped,
-		"misses_stats":  m.telemetrySnapshot.misses,
+		"http_requests_dropped": m.telemetrySnapshot.dropped,
+		"http_requests_missed":  m.telemetrySnapshot.misses,
 	}
 }
 

--- a/pkg/network/http/monitor_test.go
+++ b/pkg/network/http/monitor_test.go
@@ -88,6 +88,11 @@ func TestUnknownMethodRegression(t *testing.T) {
 			t.Error("detected HTTP request with method unknown")
 		}
 	}
+
+	telemetry, err := monitor.GetStats()
+	require.NoError(t, err)
+	_, ok := telemetry["dropped_stats"]
+	require.True(t, ok)
 }
 
 func testHTTPMonitor(t *testing.T, targetAddr, serverAddr string, numReqs int) {

--- a/pkg/network/http/monitor_test.go
+++ b/pkg/network/http/monitor_test.go
@@ -89,8 +89,8 @@ func TestUnknownMethodRegression(t *testing.T) {
 		}
 	}
 
-	telemetry, err := monitor.GetStats()
-	require.NoError(t, err)
+	telemetry := monitor.GetStats()
+	require.NotEmpty(t, telemetry)
 	_, ok := telemetry["dropped_stats"]
 	require.True(t, ok)
 }

--- a/pkg/network/http/monitor_test.go
+++ b/pkg/network/http/monitor_test.go
@@ -91,9 +91,9 @@ func TestUnknownMethodRegression(t *testing.T) {
 
 	telemetry := monitor.GetStats()
 	require.NotEmpty(t, telemetry)
-	_, ok := telemetry["dropped_stats"]
+	_, ok := telemetry["http_requests_dropped"]
 	require.True(t, ok)
-	_, ok = telemetry["misses_stats"]
+	_, ok = telemetry["http_requests_missed"]
 	require.True(t, ok)
 
 }

--- a/pkg/network/http/monitor_test.go
+++ b/pkg/network/http/monitor_test.go
@@ -93,6 +93,9 @@ func TestUnknownMethodRegression(t *testing.T) {
 	require.NotEmpty(t, telemetry)
 	_, ok := telemetry["dropped_stats"]
 	require.True(t, ok)
+	_, ok = telemetry["misses_stats"]
+	require.True(t, ok)
+
 }
 
 func testHTTPMonitor(t *testing.T, targetAddr, serverAddr string, numReqs int) {

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -365,10 +365,9 @@ func (t *Tracer) getConnTelemetry(mapSize int) map[network.ConnTelemetryType]int
 		tm[network.DNSStatsDropped] = ds
 	}
 
-	if httpStats, err := t.httpMonitor.GetStats(); err == nil {
-		if ds, ok := httpStats["dropped_stats"]; ok {
-			tm[network.HTTPStatsDropped] = ds
-		}
+	httpStats := t.httpMonitor.GetStats()
+	if ds, ok := httpStats["dropped_stats"]; ok {
+		tm[network.HTTPStatsDropped] = ds
 	}
 
 	ebpfStats := t.ebpfTracer.GetTelemetry()

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -365,6 +365,12 @@ func (t *Tracer) getConnTelemetry(mapSize int) map[network.ConnTelemetryType]int
 		tm[network.DNSStatsDropped] = ds
 	}
 
+	if httpStats, err := t.httpMonitor.GetStats(); err == nil {
+		if ds, ok := httpStats["dropped_stats"]; ok {
+			tm[network.HTTPStatsDropped] = ds
+		}
+	}
+
 	ebpfStats := t.ebpfTracer.GetTelemetry()
 	if usp, ok := ebpfStats["udp_sends_processed"]; ok {
 		tm[network.MonotonicUDPSendsProcessed] = usp

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -370,6 +370,10 @@ func (t *Tracer) getConnTelemetry(mapSize int) map[network.ConnTelemetryType]int
 		tm[network.HTTPStatsDropped] = ds
 	}
 
+	if ms, ok := httpStats["misses_stats"]; ok {
+		tm[network.HTTPStatsMisses] = ms
+	}
+
 	ebpfStats := t.ebpfTracer.GetTelemetry()
 	if usp, ok := ebpfStats["udp_sends_processed"]; ok {
 		tm[network.MonotonicUDPSendsProcessed] = usp
@@ -559,6 +563,7 @@ func (t *Tracer) GetStats() (map[string]interface{}, error) {
 		"ebpf":      t.ebpfTracer.GetTelemetry(),
 		"kprobes":   ddebpf.GetProbeStats(),
 		"dns":       t.reverseDNS.GetStats(),
+		"http":      t.httpMonitor.GetStats(),
 	}
 
 	return ret, nil

--- a/pkg/network/tracer/tracer.go
+++ b/pkg/network/tracer/tracer.go
@@ -366,12 +366,12 @@ func (t *Tracer) getConnTelemetry(mapSize int) map[network.ConnTelemetryType]int
 	}
 
 	httpStats := t.httpMonitor.GetStats()
-	if ds, ok := httpStats["dropped_stats"]; ok {
-		tm[network.HTTPStatsDropped] = ds
+	if ds, ok := httpStats["http_requests_dropped"]; ok {
+		tm[network.HTTPRequestsDropped] = ds
 	}
 
-	if ms, ok := httpStats["misses_stats"]; ok {
-		tm[network.HTTPStatsMisses] = ms
+	if ms, ok := httpStats["http_requests_missed"]; ok {
+		tm[network.HTTPRequestsMissed] = ms
 	}
 
 	ebpfStats := t.ebpfTracer.GetTelemetry()

--- a/test/kitchen/platforms.json
+++ b/test/kitchen/platforms.json
@@ -75,6 +75,9 @@
         "vagrant": {
             "x86_64": {
                 "ubuntu-16-04": "bento/ubuntu-16.04"
+            },
+            "arm64": {
+                "ubuntu-20-04": "bytesguy/ubuntu-server-20.04-arm64"
             }
         }
     },


### PR DESCRIPTION
### What does this PR do?

This add dropped HTTP statistics to telemetry. The other HTTP telemetry statistics are still reported via logs for debugging purpose, as it provides more information than what's actually exported via telemetry.
This also ease local kitchen testing on arm64 platforms.

### Motivation

We were missing some interesting telemetry for the HTTP submodule. This can be useful to understand what's going on on the agent side.

### Describe how to test/QA your changes

A test has been added to the kitchen test suite. It only test that `getStats` actually exports `dropped_stats`. Checking for actual numbers might be too painful here.

### Reviewer's Checklist

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
