### PR TITLE
Fix CCA logs scheduler startup

### DIFF
--- a/pkg/autodiscovery/autoconfig.go
+++ b/pkg/autodiscovery/autoconfig.go
@@ -203,6 +203,12 @@ func (ac *AutoConfig) LoadAndRun() {
 	log.Debug("LoadAndRun done.")
 }
 
+// ForceRanOnceFlag sets the ranOnce flag.  This is used for testing other
+// components that depend on this value.
+func (ac *AutoConfig) ForceRanOnceFlag() {
+	atomic.StoreUint32(&ac.ranOnce, 1)
+}
+
 // HasRunOnce returns true if the AutoConfig has ran once.
 func (ac *AutoConfig) HasRunOnce() bool {
 	if ac == nil {

--- a/pkg/logs/logs.go
+++ b/pkg/logs/logs.go
@@ -130,7 +130,7 @@ func start(getAC func() *autodiscovery.AutoConfig, serverless bool) (*Agent, err
 	log.Info("logs-agent started")
 
 	agent.AddScheduler(adScheduler.New())
-	agent.AddScheduler(ccaScheduler.New(getAC()))
+	agent.AddScheduler(ccaScheduler.New(getAC))
 	agent.AddScheduler(trapsScheduler.New())
 
 	return agent, nil


### PR DESCRIPTION
### What does this PR do?

Fixes a bug in #10987 where the hack to wait for AC to start didn't work right -- it called getAC once (returning nil) and then polled that value for non-nil-ness forever.  The result was that container_collect_all did not work.

### Motivation

Fix bug.

### Additional Notes

<!--
* Anything else we should know when reviewing?
* Include benchmarking information here whenever possible.
* Include info about alternatives that were considered and why the proposed
  version was chosen.
-->

### Possible Drawbacks / Trade-offs

<!--
* What are the possible side-effects or negative impacts of the code change?
-->

### Describe how to test/QA your changes

Run the logs agent with `container_collect_all` enabled and verify it collects all containers.

### Reviewer's Checklist
<!--
* Authors can use this list as a reference to ensure that there are no problems
  during the review but the signing off is to be done by the reviewer(s).

Note: Adding GitHub labels is only possible for contributors with write access.
-->

- [ ] If known, an appropriate milestone has been selected; otherwise the `Triage` milestone is set.
- [ ] Use the `major_change` label if your change either has a major impact on the code base, is impacting multiple teams or is changing important well-established internals of the Agent. This label will be use during QA to make sure each team pay extra attention to the changed behavior. For any customer facing change use a releasenote.
- [ ] A [release note](https://github.com/DataDog/datadog-agent/blob/main/docs/dev/contributing.md#reno) has been added or the `changelog/no-changelog` label has been applied.
- [ ] Changed code has automated tests for its functionality.
- [ ] Adequate QA/testing plan information is provided if the `qa/skip-qa` label is not applied.
- [ ] At least one `team/..` label has been applied, indicating the team(s) that should QA this change.
- [ ] If applicable, docs team has been notified or [an issue has been opened on the documentation repo](https://github.com/DataDog/documentation/issues/new).
- [ ] If applicable, the `need-change/operator` and `need-change/helm` labels have been applied.
- [ ] If applicable, the [config template](https://github.com/DataDog/datadog-agent/blob/main/pkg/config/config_template.yaml) has been updated.
